### PR TITLE
fix(claude): sanitize output_config.effort so xhigh no longer 400s Sonnet 4.6 (#7044)

### DIFF
--- a/open-sse/executors/base/reasoningEffort.ts
+++ b/open-sse/executors/base/reasoningEffort.ts
@@ -69,7 +69,18 @@ export function sanitizeReasoningEffortForProvider(
       ? (b.reasoning as Record<string, unknown>)
       : null;
   const hasTopLevelReasoningEffort = Object.prototype.hasOwnProperty.call(b, "reasoning_effort");
-  const effort = b.reasoning_effort ?? reasoning?.effort;
+  // #7044: native Claude requests carry effort in `output_config.effort`, not the
+  // OpenAI-style reasoning_effort/reasoning.effort. Treat it as an additional carrier
+  // so the provider-aware sanitizer can normalize/downgrade it too (e.g. xhigh → high
+  // for Sonnet 4.6, which opts out of xhigh). Only falls back to it when neither
+  // OpenAI-style carrier is present.
+  const outputConfig =
+    b.output_config && typeof b.output_config === "object" && !Array.isArray(b.output_config)
+      ? (b.output_config as Record<string, unknown>)
+      : null;
+  const hasOutputConfigEffort =
+    !!outputConfig && Object.prototype.hasOwnProperty.call(outputConfig, "effort");
+  const effort = b.reasoning_effort ?? reasoning?.effort ?? outputConfig?.effort;
   if (effort === undefined) return body;
   const effortStr = typeof effort === "string" ? effort.toLowerCase() : "";
   const modelStr = model || "";
@@ -114,6 +125,7 @@ export function sanitizeReasoningEffortForProvider(
       const next: Record<string, unknown> = { ...b };
       if (hasTopLevelReasoningEffort) next.reasoning_effort = mapped;
       if (reasoning) next.reasoning = { ...reasoning, effort: mapped };
+      if (hasOutputConfigEffort) next.output_config = { ...outputConfig, effort: mapped };
       return next;
     }
     return body;
@@ -138,6 +150,9 @@ export function sanitizeReasoningEffortForProvider(
     if (reasoning) {
       next.reasoning = { ...reasoning, effort: "xhigh" };
     }
+    if (hasOutputConfigEffort) {
+      next.output_config = { ...outputConfig, effort: "xhigh" };
+    }
     return next;
   }
 
@@ -152,6 +167,9 @@ export function sanitizeReasoningEffortForProvider(
     }
     if (reasoning) {
       next.reasoning = { ...reasoning, effort: "high" };
+    }
+    if (hasOutputConfigEffort) {
+      next.output_config = { ...outputConfig, effort: "high" };
     }
     return next;
   }

--- a/tests/unit/output-config-effort-sanitize-7044.test.ts
+++ b/tests/unit/output-config-effort-sanitize-7044.test.ts
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #7044: Native Claude requests carry effort in `output_config.effort` (not
+// reasoning_effort / reasoning.effort). The provider-aware effort sanitizer only
+// inspected the two OpenAI-style carriers, so `output_config.effort: "xhigh"`
+// bypassed it entirely and reached Anthropic unchanged → 400 "This model does not
+// support effort level 'xhigh'." for models that opt out of xhigh (Sonnet 4.6).
+const { sanitizeReasoningEffortForProvider } = await import("../../open-sse/executors/base.ts");
+
+type EffortBody = {
+  model?: string;
+  reasoning_effort?: string;
+  reasoning?: Record<string, unknown>;
+  output_config?: Record<string, unknown>;
+  messages?: unknown;
+};
+
+function asBody(value: unknown): EffortBody {
+  return value as EffortBody;
+}
+
+function makeLog() {
+  const messages: Array<[string, string]> = [];
+  return {
+    info: (tag: string, msg: string) => messages.push([tag, msg]),
+    messages,
+  };
+}
+
+test("#7044: claude output_config.effort=xhigh downgrades to high for Sonnet 4.6", () => {
+  const log = makeLog();
+  const body = {
+    model: "claude-sonnet-4-6",
+    output_config: { effort: "xhigh" },
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "claude", "claude-sonnet-4-6", log);
+  assert.notEqual(result, body, "must return a new object when mutating");
+  assert.equal(
+    asBody(result).output_config?.effort,
+    "high",
+    "xhigh must be downgraded on Claude's native output_config carrier"
+  );
+  assert.ok(
+    log.messages.some(([tag, m]) => tag === "REASONING_SANITIZE" && /xhigh → high/.test(m)),
+    "logs the downgrade"
+  );
+});
+
+test("#7044: claude output_config.effort=max is preserved for Sonnet 4.6 (supports max)", () => {
+  const body = {
+    model: "claude-sonnet-4-6",
+    output_config: { effort: "max" },
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "claude", "claude-sonnet-4-6", null);
+  assert.equal(result, body, "max is a supported Claude level — passes through unchanged");
+  assert.equal(asBody(result).output_config?.effort, "max");
+});
+
+test("#7044: output_config.effort preserves sibling fields when rewritten", () => {
+  const body = {
+    model: "claude-opus-4-6",
+    output_config: { effort: "xhigh", format: "text" },
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "claude", "claude-opus-4-6", null);
+  assert.equal(asBody(result).output_config?.effort, "high");
+  assert.equal(
+    asBody(result).output_config?.format,
+    "text",
+    "other output_config fields must be preserved"
+  );
+});
+
+test("#7044: reasoning_effort still wins when both carriers present (no regression)", () => {
+  // reasoning_effort / reasoning.effort remain the primary carriers; output_config
+  // is only the fallback. A supported xhigh model passes through untouched.
+  const body = {
+    model: "mimo-v2.5-pro",
+    reasoning_effort: "xhigh",
+    output_config: { effort: "xhigh" },
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "xiaomi-mimo", "mimo-v2.5-pro", null);
+  assert.equal(result, body, "supported xhigh passes through unchanged");
+  assert.equal(asBody(result).reasoning_effort, "xhigh");
+  assert.equal(asBody(result).output_config?.effort, "xhigh");
+});
+
+test("#7044: no output_config.effort key → unchanged", () => {
+  const body = {
+    model: "claude-sonnet-4-6",
+    output_config: { format: "text" },
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "claude", "claude-sonnet-4-6", null);
+  assert.equal(result, body, "no effort carrier present → returns original body unchanged");
+});


### PR DESCRIPTION
## Problem

Native Claude requests carrying `output_config.effort: "xhigh"` bypass OmniRoute's
provider-aware effort sanitizer. When a combo/alias resolves to
`claude/claude-sonnet-4-6` (which is marked `supportsXHighEffort: false`), OmniRoute
forwards `xhigh` unchanged and Anthropic returns:

```text
[400]: This model does not support effort level 'xhigh'.
Supported levels: high, low, max, medium.
```

Using `max` on the same combo/target succeeds, so this is not missing capability
metadata — the sanitizer simply never inspects Claude's native effort carrier.

## Root cause

`sanitizeReasoningEffortForProvider` (`open-sse/executors/base/reasoningEffort.ts`)
reads effort only from the two OpenAI-style carriers:

```ts
const effort = b.reasoning_effort ?? reasoning?.effort;
if (effort === undefined) return body;
```

Native Claude requests (Anthropic Messages format, Claude → Claude, no OpenAI-shape
translation) carry effort in `output_config.effort`, never in `reasoning_effort` /
`reasoning.effort`. So `effort` resolves to `undefined`, the sanitizer early-returns,
and `xhigh` survives to the upstream. The interception point itself is correct — it
runs after `transformRequest`, right before `fetch` (`open-sse/executors/base.ts`) —
it just wasn't looking at the field Claude actually uses.

## Fix

Treat `output_config.effort` as an additional effort carrier — a fallback that only
applies when neither OpenAI-style carrier is present — and rewrite it in the same
normalize/downgrade branches that already rewrite `reasoning_effort` /
`reasoning.effort`:

- `xhigh` on an xhigh-opt-out model (Sonnet 4.6, Opus 4.6/4.5, older Sonnet) → `high`.
- `max` → `xhigh` where the model supports xhigh but not literal max.
- native-DeepSeek mapping (`xhigh → max`, `low|medium → high`).

`max` on models that support it (Claude Opus/Sonnet with `supportsClaudeMaxEffort`)
still passes through untouched, so the `output_config.effort: "max"` success path is
preserved. Sibling `output_config` fields (e.g. `format`) are carried over unchanged.
The change is additive and does not alter behavior for any request that lacks
`output_config.effort`.

## Verification

New regression test (fails on the unfixed sanitizer, passes after the fix):

```bash
node --import tsx/esm --test tests/unit/output-config-effort-sanitize-7044.test.ts
# 1..5 — # pass 5 # fail 0
```

Before the fix, the `xhigh → high` downgrade and sibling-field cases failed
(`output_config.effort` stayed `"xhigh"`); after the fix all 5 pass.

Neighbouring effort suites — full pass, no regressions:

```bash
node --import tsx/esm --test \
  tests/unit/base-executor-sanitize-effort.test.ts \
  tests/unit/github-claude-reasoning-effort-granular.test.ts \
  tests/unit/base-reasoning-effort-split.test.ts
# 1..45 — # pass 45 # fail 0
```

Lint + typecheck clean:

```bash
npx eslint --suppressions-location config/quality/eslint-suppressions.json \
  open-sse/executors/base/reasoningEffort.ts \
  tests/unit/output-config-effort-sanitize-7044.test.ts   # 0 problems
npm run typecheck:core                                     # clean
```

## Diff summary

- `open-sse/executors/base/reasoningEffort.ts` — read `output_config.effort` as a
  fallback effort carrier; rewrite it in the max→xhigh, downgrade→high, and
  native-DeepSeek branches.
- `tests/unit/output-config-effort-sanitize-7044.test.ts` — new regression test
  (downgrade, max pass-through, sibling-field preservation, carrier precedence,
  no-effort no-op).

Closes #7044.

Thanks to the reporter for the precise four-stage pipeline trace pinpointing the
carrier gap.
