### PR TITLE
fix(combo): derive session stickiness key from Responses API .input, not just .messages (#7270)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -67,6 +67,7 @@ import { estimateTokens } from "./contextManager.ts";
 import { getSessionConnection } from "./sessionManager.ts";
 import {
   applySessionStickiness,
+  normalizeStickinessMessages,
   recordStickyBinding,
   clearStickyBinding,
   peekStickyConnectionId,
@@ -1207,7 +1208,9 @@ export async function handleComboChat({
     ? ({ targets: orderedTargets, messageHash: null, stuck: false } as const)
     : await applySessionStickiness(
         orderedTargets,
-        body.messages as Array<{ role?: string; content?: unknown }>
+        // #7270: normalize both wire shapes (.messages / Responses-API .input) so the
+        // stickiness key is derivable on the /v1/responses surface, not just Chat Completions.
+        normalizeStickinessMessages(body as { messages?: unknown; input?: unknown })
       );
   orderedTargets = _sticky.targets;
   orderedTargets = orderTargetsByEvalScores(orderedTargets, config.evalRouting, log);
@@ -2631,7 +2634,9 @@ async function handleRoundRobinCombo({
     ? ({ targets: filteredTargets, messageHash: null, stuck: false } as const)
     : await applySessionStickiness(
         filteredTargets,
-        body?.messages as Array<{ role?: string; content?: unknown }>
+        // #7270: normalize both wire shapes (.messages / Responses-API .input) so RR
+        // stickiness engages on the /v1/responses surface, not just Chat Completions.
+        normalizeStickinessMessages(body as { messages?: unknown; input?: unknown })
       );
   let rrStartIndex = startIndex;
   if (_rrSessionSticky.stuck) {

--- a/open-sse/services/combo/sessionStickiness.ts
+++ b/open-sse/services/combo/sessionStickiness.ts
@@ -201,6 +201,35 @@ const stickyMap = new Map<string, StickyEntry>();
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
+ * #7270: Normalize a request body's user turns into a `{role, content}[]` view for
+ * stickiness-key derivation, covering both wire formats:
+ *   - Chat Completions (`/v1/chat/completions`) → turns live in `.messages`.
+ *   - OpenAI Responses API (`/v1/responses`) → turns live in `.input`, which may be a
+ *     plain string OR an array of message items; `.messages` is never populated.
+ * Combo target ordering runs BEFORE per-target format translation, so without this
+ * the Responses-API key resolved to null and stickiness silently no-oped for the
+ * entire surface (round-robin/random/strict-random all re-ordered every turn).
+ * `.messages` takes precedence when present (Chat Completions), then `.input`.
+ * Returns null when neither carrier yields turns (fail-open, same as deriveMessageHash).
+ */
+export function normalizeStickinessMessages(
+  body: { messages?: unknown; input?: unknown } | null | undefined
+): Array<{ role?: string; content?: unknown }> | null {
+  if (!body || typeof body !== "object") return null;
+  const { messages, input } = body as { messages?: unknown; input?: unknown };
+  if (Array.isArray(messages) && messages.length > 0) {
+    return messages as Array<{ role?: string; content?: unknown }>;
+  }
+  if (typeof input === "string" && input.length > 0) {
+    return [{ role: "user", content: input }];
+  }
+  if (Array.isArray(input) && input.length > 0) {
+    return input as Array<{ role?: string; content?: unknown }>;
+  }
+  return null;
+}
+
+/**
  * Derive a stable 16-hex-char session key from the first user message content.
  * Returns null when the message cannot be extracted (fail-open).
  */

--- a/open-sse/services/combo/sessionStickiness.ts
+++ b/open-sse/services/combo/sessionStickiness.ts
@@ -205,7 +205,10 @@ const stickyMap = new Map<string, StickyEntry>();
  * stickiness-key derivation, covering both wire formats:
  *   - Chat Completions (`/v1/chat/completions`) → turns live in `.messages`.
  *   - OpenAI Responses API (`/v1/responses`) → turns live in `.input`, which may be a
- *     plain string OR an array of message items; `.messages` is never populated.
+ *     plain string OR an array of message items; `.messages` is never populated. Array
+ *     items may themselves be bare strings (shorthand for a user message) — the same
+ *     shape `responsesInputNormalization.ts`'s `normalizeCodexResponsesInputItem`
+ *     already special-cases — so those are mapped to `{role: "user", content: item}`.
  * Combo target ordering runs BEFORE per-target format translation, so without this
  * the Responses-API key resolved to null and stickiness silently no-oped for the
  * entire surface (round-robin/random/strict-random all re-ordered every turn).
@@ -224,7 +227,9 @@ export function normalizeStickinessMessages(
     return [{ role: "user", content: input }];
   }
   if (Array.isArray(input) && input.length > 0) {
-    return input as Array<{ role?: string; content?: unknown }>;
+    return input.map((item) =>
+      typeof item === "string" ? { role: "user", content: item } : item
+    ) as Array<{ role?: string; content?: unknown }>;
   }
   return null;
 }

--- a/tests/unit/combo-stickiness-responses-input-7270.test.ts
+++ b/tests/unit/combo-stickiness-responses-input-7270.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression for #7270 — combo session stickiness is a silent no-op on the OpenAI
+ * Responses API (`/v1/responses`).
+ *
+ * The stickiness key was derived exclusively from `body.messages`, but Responses-API
+ * requests carry their turns in `.input` and never populate `.messages`. So
+ * deriveMessageHash(body.messages) resolved to null, stickiness failed open, and a
+ * single conversation was re-ordered every turn as if stickiness were disabled —
+ * regardless of strategy or the toggle.
+ *
+ * This drives the REAL handleComboChat with a round-robin combo and an `.input`-shaped
+ * body and asserts:
+ *  - a single sessionless Responses-API conversation re-pins to its turn-1 connection
+ *    (FAILS before the fix: the combo rotates A → B → C …);
+ *  - distinct conversations still spread across connections (spreading preserved);
+ *  - the new normalizeStickinessMessages() helper covers both wire shapes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-stick-resp-7270-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+const stick = await import("../../open-sse/services/combo/sessionStickiness.ts");
+const dbCore = await import("../../src/lib/db/core.ts");
+
+function makeLog() {
+  return { info() {}, warn() {}, debug() {}, error() {} };
+}
+
+function rrCombo(name: string) {
+  return {
+    name,
+    strategy: "round-robin",
+    config: { maxRetries: 0 },
+    models: [
+      { kind: "model", provider: "codex", providerId: "codex", model: "m-a", connectionId: "conn-A", id: `${name}-0` },
+      { kind: "model", provider: "codex", providerId: "codex", model: "m-b", connectionId: "conn-B", id: `${name}-1` },
+      { kind: "model", provider: "glm-cn", providerId: "glm-cn", model: "m-c", connectionId: "conn-C", id: `${name}-2` },
+    ],
+  };
+}
+
+// Responses-API shape: turns live in `.input` (array of message items with
+// input_text content parts), and `.messages` is absent.
+function responsesBody(combo: Record<string, unknown>, firstMessage: string) {
+  return {
+    model: combo.name,
+    input: [{ role: "user", content: [{ type: "input_text", text: firstMessage }] }],
+    stream: false,
+  };
+}
+
+async function dispatchConnection(
+  combo: Record<string, unknown>,
+  body: Record<string, unknown>
+): Promise<string> {
+  let conn = "?";
+  await handleComboChat({
+    body,
+    combo,
+    allCombos: [combo],
+    isModelAvailable: async () => true,
+    relayOptions: undefined,
+    signal: undefined,
+    settings: {},
+    log: makeLog(),
+    handleSingleModel: async (
+      _b: unknown,
+      modelStr: string,
+      target?: { connectionId?: string | null }
+    ) => {
+      conn = target?.connectionId ?? "?";
+      return Response.json({ choices: [{ message: { role: "assistant", content: modelStr } }] });
+    },
+  });
+  return conn;
+}
+
+test.beforeEach(() => {
+  stick.clearAllStickyBindings();
+  // Fail-open saturation (unknown → full headroom) so we exercise the stickiness
+  // MECHANISM, not the headroom gate.
+  stick.__setStickinessHeadroomFetcherForTests(async () => undefined);
+});
+
+test.after(() => {
+  stick.__setStickinessHeadroomFetcherForTests(null);
+  dbCore.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+test("normalizeStickinessMessages: covers .messages, .input array and .input string", () => {
+  const fromMessages = stick.normalizeStickinessMessages({
+    messages: [{ role: "user", content: "hi" }],
+  });
+  assert.deepEqual(fromMessages, [{ role: "user", content: "hi" }]);
+
+  const fromInputArray = stick.normalizeStickinessMessages({
+    input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+  });
+  assert.ok(Array.isArray(fromInputArray) && fromInputArray.length === 1);
+
+  const fromInputString = stick.normalizeStickinessMessages({ input: "plain string turn" });
+  assert.deepEqual(fromInputString, [{ role: "user", content: "plain string turn" }]);
+
+  // .messages wins over .input when both present (Chat Completions precedence).
+  const both = stick.normalizeStickinessMessages({
+    messages: [{ role: "user", content: "from messages" }],
+    input: "from input",
+  });
+  assert.deepEqual(both, [{ role: "user", content: "from messages" }]);
+
+  assert.equal(stick.normalizeStickinessMessages({}), null);
+  assert.equal(stick.normalizeStickinessMessages(null), null);
+});
+
+test("an .input-shaped Responses body yields a stable, non-null stickiness key", () => {
+  const body = responsesBody(rrCombo("k"), "First turn of the conversation");
+  // Old behavior: deriveMessageHash(body.messages) is null (bug).
+  assert.equal(
+    stick.deriveMessageHash(body.messages as never),
+    null,
+    "body.messages is absent on the Responses API — the old key source is null"
+  );
+  // New behavior: the normalized view produces a stable key.
+  const key1 = stick.deriveMessageHash(stick.normalizeStickinessMessages(body));
+  const key2 = stick.deriveMessageHash(stick.normalizeStickinessMessages(body));
+  assert.ok(key1 !== null, "normalized Responses body must yield a key");
+  assert.match(key1!, /^[a-f0-9]{16}$/);
+  assert.equal(key1, key2, "stable across calls");
+});
+
+test("round-robin: a sessionless Responses-API conversation re-pins across turns (#7270)", async () => {
+  const combo = rrCombo("rr-resp-stick");
+  const conns: string[] = [];
+  for (let turn = 0; turn < 5; turn++) {
+    conns.push(
+      await dispatchConnection(combo, responsesBody(combo, "Refactor the streaming handler."))
+    );
+  }
+  // Turns 2..5 must all reuse turn 1's connection. Before the fix the RR combo rotates
+  // (conn-A → conn-B → conn-C → …) because the .input key resolved to null → set size 3.
+  assert.equal(
+    new Set(conns.slice(1)).size,
+    1,
+    `turns 2..5 must stick to one connection, got: ${conns.join(", ")}`
+  );
+  assert.equal(conns[1], conns[0], "turn 2 must reuse turn 1's connection");
+});
+
+test("round-robin: distinct Responses-API conversations still spread (#7270 spreading guard)", async () => {
+  const combo = rrCombo("rr-resp-spread");
+  const hist: Record<string, number> = {};
+  for (let i = 0; i < 6; i++) {
+    const conn = await dispatchConnection(
+      combo,
+      responsesBody(combo, `conversation number ${i} — distinct first turn`)
+    );
+    hist[conn] = (hist[conn] || 0) + 1;
+  }
+  assert.ok(
+    Object.keys(hist).length > 1,
+    `distinct conversations must spread across connections, got: ${JSON.stringify(hist)}`
+  );
+});

--- a/tests/unit/combo-stickiness-responses-input-7270.test.ts
+++ b/tests/unit/combo-stickiness-responses-input-7270.test.ts
@@ -122,6 +122,34 @@ test("normalizeStickinessMessages: covers .messages, .input array and .input str
   assert.equal(stick.normalizeStickinessMessages(null), null);
 });
 
+test("normalizeStickinessMessages: .input array of PLAIN STRINGS maps to user messages (#7270 bare-string-array gap)", () => {
+  // The Responses API also allows `.input` to be an array of bare strings (each string
+  // is shorthand for an `input_text` user message) — the exact shape
+  // `responsesInputNormalization.ts`'s `normalizeCodexResponsesInputItem` already
+  // special-cases (`typeof itemValue === "string"`). Before this fix, the
+  // Array.isArray(input) branch cast the array straight through unmapped, so
+  // deriveMessageHash's `messages.find(m => m?.role === "user")` never matched a bare
+  // string and the key stayed null (fail-open), same bug as #7270 for this narrower shape.
+  const fromPlainStringArray = stick.normalizeStickinessMessages({
+    input: ["First turn of the conversation, plain string item"],
+  });
+  assert.deepEqual(fromPlainStringArray, [
+    { role: "user", content: "First turn of the conversation, plain string item" },
+  ]);
+
+  const key = stick.deriveMessageHash(fromPlainStringArray);
+  assert.ok(key !== null, "a bare-string .input array item must still yield a stickiness key");
+  assert.match(key!, /^[a-f0-9]{16}$/);
+
+  // Mixed arrays (bare string turn followed by a structured item) must only map the
+  // bare-string entries, leaving object items untouched.
+  const mixed = stick.normalizeStickinessMessages({
+    input: ["plain turn", { role: "user", content: [{ type: "input_text", text: "hi" }] }],
+  });
+  assert.deepEqual(mixed?.[0], { role: "user", content: "plain turn" });
+  assert.deepEqual(mixed?.[1], { role: "user", content: [{ type: "input_text", text: "hi" }] });
+});
+
 test("an .input-shaped Responses body yields a stable, non-null stickiness key", () => {
   const body = responsesBody(rrCombo("k"), "First turn of the conversation");
   // Old behavior: deriveMessageHash(body.messages) is null (bug).
@@ -148,6 +176,40 @@ test("round-robin: a sessionless Responses-API conversation re-pins across turns
   }
   // Turns 2..5 must all reuse turn 1's connection. Before the fix the RR combo rotates
   // (conn-A → conn-B → conn-C → …) because the .input key resolved to null → set size 3.
+  assert.equal(
+    new Set(conns.slice(1)).size,
+    1,
+    `turns 2..5 must stick to one connection, got: ${conns.join(", ")}`
+  );
+  assert.equal(conns[1], conns[0], "turn 2 must reuse turn 1's connection");
+});
+
+// Responses-API shape variant: `.input` is an array of PLAIN STRING items (each string
+// is shorthand for a user message), not an array of message objects. Before this fix,
+// normalizeStickinessMessages cast the array straight through unmapped, so
+// deriveMessageHash never found a `role === "user"` entry and stickiness stayed
+// fail-open for this narrower wire shape too.
+function responsesBodyPlainStringArray(combo: Record<string, unknown>, firstMessage: string) {
+  return {
+    model: combo.name,
+    input: [firstMessage],
+    stream: false,
+  };
+}
+
+test("round-robin: a sessionless Responses-API conversation with .input as a plain-string array re-pins across turns (#7270 bare-string-array gap)", async () => {
+  const combo = rrCombo("rr-resp-stick-strarr");
+  const conns: string[] = [];
+  for (let turn = 0; turn < 5; turn++) {
+    conns.push(
+      await dispatchConnection(
+        combo,
+        responsesBodyPlainStringArray(combo, "Refactor the streaming handler (string-array input).")
+      )
+    );
+  }
+  // Turns 2..5 must all reuse turn 1's connection. Before the fix, the bare-string
+  // .input array items yield a null key → the RR combo rotates (conn-A → conn-B → conn-C).
   assert.equal(
     new Set(conns.slice(1)).size,
     1,


### PR DESCRIPTION
## Problem

Combo **session stickiness** is a silent no-op for the entire OpenAI **Responses API**
(`/v1/responses`) surface. A single conversation is re-ordered across accounts every
turn — regardless of the strategy (round-robin / random / strict-random / weighted /
priority) or the "session stickiness" toggle — while the same conversation over
`/v1/chat/completions` sticks correctly.

Reported in the Discord (EN) support channel: *"I used round robin/random/strict random
and enabled session stickiness … it still throws the chat between accounts (the same
chat, not a new one) … It's OpenAI responses API."*

## Root cause

The stickiness key is derived exclusively from `body.messages`:

- `applySessionStickiness` (`open-sse/services/combo.ts:1208`, `:2634`) is called with
  `body.messages`.
- `deriveMessageHash` (`open-sse/services/combo/sessionStickiness.ts`) guards on
  `Array.isArray(messages)` and returns `null` (fail-open, silent) otherwise.

Responses-API requests carry their turns in `.input` (a plain string **or** an array of
message items) and never populate `.messages`. So the key resolves to `null`, the sticky
lookup/binding are skipped, and every turn is re-ordered as if stickiness were disabled.

Format translation (`.input` → `.messages`) happens **per-target, inside
`handleSingleModel`/`handleChatCore`**, i.e. *after* combo target ordering has already
been decided — so it cannot help the stickiness key derivation upstream.

## Fix

Derive the key from a normalized view of the request that covers both wire shapes,
rather than teaching `deriveMessageHash` about a single format:

- New `normalizeStickinessMessages(body)` in `sessionStickiness.ts` returns a
  `{role, content}[]` view from `.messages` (Chat Completions, takes precedence), or
  `.input` — handling both the plain-string and the array-of-message-items forms of the
  Responses API. Returns `null` when neither carrier yields turns (fail-open, unchanged).
- Both combo call sites (`handleComboChat` weighted/priority/random path and
  `handleRoundRobinCombo`) now pass `normalizeStickinessMessages(body)` instead of the
  raw `body.messages`.

`deriveMessageHash` and the sticky store are untouched; the change is confined to the
key's input. Chat Completions behavior is preserved (`.messages` still wins), and the
fail-open path for turnless bodies is preserved.

## Verification

New regression test (fails on the unfixed code, passes after the fix). It drives the
**real** `handleComboChat` with a round-robin combo and an `.input`-shaped Responses
body:

```bash
node --import tsx/esm --test tests/unit/combo-stickiness-responses-input-7270.test.ts
# 1..4 — # pass 4 # fail 0
```

Before the fix, 3 of 4 failed — the `.input` conversation rotated `conn-A → conn-B →
conn-C …` (set size 3) instead of pinning, and the normalized-key assertions had no
helper to call. After the fix:

- a sessionless Responses-API conversation re-pins to its turn-1 connection across 5 turns;
- distinct Responses-API conversations still spread across connections (spreading guard);
- `normalizeStickinessMessages` covers `.messages`, `.input` (array), `.input` (string),
  precedence, and the empty→null case.

Neighbouring stickiness suites — full pass, no regressions:

```bash
node --import tsx/esm --test \
  tests/unit/combo-session-stickiness.test.ts \
  tests/unit/combo-rr-session-stickiness-3825.test.ts \
  tests/unit/combo-disable-session-stickiness.test.ts
# 1..35 — # pass 35 # fail 0
```

Lint + typecheck clean:

```bash
npx eslint --suppressions-location config/quality/eslint-suppressions.json \
  open-sse/services/combo/sessionStickiness.ts open-sse/services/combo.ts \
  tests/unit/combo-stickiness-responses-input-7270.test.ts   # 0 problems
npm run typecheck:core                                        # clean
```

## Diff summary

- `open-sse/services/combo/sessionStickiness.ts` — add `normalizeStickinessMessages()`
  (normalizes `.messages` / Responses-API `.input` string|array → `{role,content}[]`).
- `open-sse/services/combo.ts` — both `applySessionStickiness` call sites pass the
  normalized view instead of `body.messages`.
- `tests/unit/combo-stickiness-responses-input-7270.test.ts` — new regression test.

Closes #7270.

Thanks to the reporter and to whoever wrote the issue's precise pipeline trace — it
pinpointed the `.input`/`.messages` gap exactly.
