### PR TITLE
fix(logs): show saved provider names in request/provider log views

### DIFF
--- a/src/app/api/usage/call-logs/route.ts
+++ b/src/app/api/usage/call-logs/route.ts
@@ -3,11 +3,13 @@ import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { getCallLogs } from "@/lib/usageDb";
 import { getCompletedDetails, getPendingById } from "@/lib/usage/usageHistory";
 import { getProviderConnections } from "@/lib/localDb";
+import { getProviderNodes } from "@/models";
 import { matchesSearch } from "@/shared/utils/turkishText";
 
 type CallLogListRowsInput = {
   logs: any[];
   connections: any[];
+  providerDisplayNames?: Map<string, string>;
   pendingDetails: Iterable<any>;
   completedDetails: Iterable<any>;
   now?: number;
@@ -27,6 +29,7 @@ function rowPriority(row: any): number {
 export function buildCallLogListRows({
   logs,
   connections,
+  providerDisplayNames = new Map<string, string>(),
   pendingDetails,
   completedDetails,
   now = Date.now(),
@@ -37,6 +40,10 @@ export function buildCallLogListRows({
       connection.displayName || connection.name || connection.email || connection.id,
     ])
   );
+  const getProviderDisplay = (providerId: unknown): string | null => {
+    if (typeof providerId !== "string" || providerId.length === 0) return null;
+    return providerDisplayNames.get(providerId) || null;
+  };
 
   // Include active (in-flight) requests from the pending-by-id map
   // so they appear in the logs grid alongside persisted entries.
@@ -53,6 +60,7 @@ export function buildCallLogListRows({
       model: detail.model,
       requestedModel: null,
       provider: detail.provider,
+      providerDisplay: getProviderDisplay(detail.provider),
       account: connectionNames.get(detail.connectionId || "") || detail.connectionId || "unknown",
       connectionId: detail.connectionId,
       duration: Math.max(0, now - detail.startedAt),
@@ -87,6 +95,7 @@ export function buildCallLogListRows({
       model: detail.model,
       requestedModel: null,
       provider: detail.provider,
+      providerDisplay: getProviderDisplay(detail.provider),
       account: connectionNames.get(detail.connectionId || "") || detail.connectionId || "unknown",
       connectionId: detail.connectionId,
       duration,
@@ -135,11 +144,28 @@ export async function GET(request: Request) {
     if (searchParams.get("limit")) filter.limit = parseInt(searchParams.get("limit"));
     if (searchParams.get("offset")) filter.offset = parseInt(searchParams.get("offset"));
 
-    const [logs, connections] = await Promise.all([getCallLogs(filter), getProviderConnections()]);
+    const [logs, connections, providerNodes] = await Promise.all([
+      getCallLogs(filter),
+      getProviderConnections(),
+      getProviderNodes(),
+    ]);
+    const providerDisplayNames = new Map<string, string>(
+      (Array.isArray(providerNodes) ? providerNodes : []).flatMap((node: any) => {
+        if (typeof node?.id !== "string" || node.id.length === 0) return [];
+        const label =
+          (typeof node?.name === "string" && node.name.trim().length > 0
+            ? node.name.trim()
+            : typeof node?.prefix === "string" && node.prefix.trim().length > 0
+              ? node.prefix.trim()
+              : "") || null;
+        return label ? [[node.id, label] as const] : [];
+      })
+    );
 
     const rows = buildCallLogListRows({
       logs,
       connections,
+      providerDisplayNames,
       pendingDetails: getPendingById().values(),
       completedDetails: getCompletedDetails().values(),
     });

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -761,8 +761,7 @@ export async function getCallLogs(filter: any = {}) {
   const db = getDbInstance();
   let sql = `
     SELECT cl.*,
-      pn.name AS provider_node_name,
-      pn.prefix AS provider_node_prefix,
+      pn.name AS provider_node_name, pn.prefix AS provider_node_prefix,
       ${RESOLVED_ACCOUNT_SQL} AS resolved_account
     FROM call_logs cl
     LEFT JOIN provider_nodes pn ON pn.id = cl.provider

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -88,6 +88,7 @@ type CallLogSummaryRow = {
   has_response_body: number | null;
   has_pipeline_details: number | null;
   request_summary: string | null;
+  provider_node_name?: string | null;
   provider_node_prefix?: string | null;
   resolved_account?: string | null;
   correlation_id?: string | null;
@@ -471,9 +472,27 @@ export function trimCallLogsToMaxRows(maxRows = getCallLogsTableMaxRows()) {
   return { deletedRows, deletedArtifacts };
 }
 
+function resolveProviderDisplay(
+  provider: string | null,
+  nodeName: string | null,
+  nodePrefix: string | null
+): string | null {
+  const rawProvider = toStringOrNull(provider);
+  if (!rawProvider) return null;
+
+  const name = toStringOrNull(nodeName)?.trim();
+  if (name) return name;
+
+  const prefix = toStringOrNull(nodePrefix)?.trim();
+  if (prefix) return prefix;
+
+  return null;
+}
+
 function mapSummaryRow(row: CallLogSummaryRow) {
   const detailState = normalizeDetailState(row.detail_state);
   const provider = row.provider;
+  const nodeName = row.provider_node_name ?? null;
   const nodePrefix = row.provider_node_prefix ?? null;
   return {
     id: row.id,
@@ -484,6 +503,7 @@ function mapSummaryRow(row: CallLogSummaryRow) {
     model: row.model,
     requestedModel: applyNodePrefix(row.requested_model, provider, nodePrefix),
     provider,
+    providerDisplay: resolveProviderDisplay(provider, nodeName, nodePrefix),
     account: row.resolved_account || row.account,
     connectionId: row.connection_id,
     duration: toNumber(row.duration),
@@ -741,6 +761,7 @@ export async function getCallLogs(filter: any = {}) {
   const db = getDbInstance();
   let sql = `
     SELECT cl.*,
+      pn.name AS provider_node_name,
       pn.prefix AS provider_node_prefix,
       ${RESOLVED_ACCOUNT_SQL} AS resolved_account
     FROM call_logs cl
@@ -828,6 +849,7 @@ export async function getCallLogById(id: string) {
   const row = db
     .prepare(
       `SELECT cl.*,
+        pn.name AS provider_node_name,
         pn.prefix AS provider_node_prefix,
         ${RESOLVED_ACCOUNT_SQL} AS resolved_account
        FROM call_logs cl

--- a/src/shared/components/ProviderTestSlideOver.tsx
+++ b/src/shared/components/ProviderTestSlideOver.tsx
@@ -314,6 +314,7 @@ interface LogEntry {
   model?: string;
   requestedModel?: string;
   provider?: string;
+  providerDisplay?: string | null;
   status?: number;
   duration?: number;
   tokens?: { in?: number; out?: number };
@@ -518,7 +519,7 @@ function LogDetail({ log }: { log: LogEntry }) {
     { label: "Duration", value: formatDurationMs(log.duration) },
     { label: "Model", value: log.model || "—", mono: true },
     { label: "Requested model", value: log.requestedModel || "—", mono: true },
-    { label: "Provider", value: log.provider || "—", mono: true },
+    { label: "Provider", value: log.providerDisplay || log.provider || "—", mono: true },
     { label: "Requester", value: requester.title, mono: true },
     {
       label: "Tokens",

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -196,6 +196,7 @@ export default function RequestLoggerDetail({
     text: "#fff",
     label: (log.provider || "-").toUpperCase(),
   };
+  const providerLabel = log.providerDisplay || providerColor.label;
 
   const providerStatus = detail?.pipelinePayloads?.providerResponse?.status;
   const hasStatusDiscrepancy = providerStatus && providerStatus !== log.status;
@@ -400,7 +401,7 @@ export default function RequestLoggerDetail({
                   className="inline-block px-2.5 py-1 rounded text-[10px] font-bold uppercase"
                   style={{ backgroundColor: providerColor.bg, color: providerColor.text }}
                 >
-                  {providerColor.label}
+                  {providerLabel}
                 </span>
               </div>
               <div className="min-w-[120px] flex-1">
@@ -523,7 +524,7 @@ export default function RequestLoggerDetail({
                   className="inline-block px-2.5 py-1 rounded text-[10px] font-bold uppercase"
                   style={{ backgroundColor: providerColor.bg, color: providerColor.text }}
                 >
-                  {providerColor.label}
+                  {providerLabel}
                 </span>
               </div>
               <div>

--- a/src/shared/components/RequestLoggerV2.tsx
+++ b/src/shared/components/RequestLoggerV2.tsx
@@ -1256,7 +1256,7 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
                       text: "#fff",
                       label: compatLabel || (log.provider || "-").toUpperCase(),
                     };
-                    const providerLabel = compatLabel || providerColor.label;
+                    const providerLabel = log.providerDisplay || compatLabel || providerColor.label;
                     const isError = !isActive && log.status >= 400;
                     const cacheSourceMeta = getCacheSourceMeta(log.cacheSource);
                     const isSemanticCache = cacheSourceMeta?.key === "semantic";

--- a/tests/unit/call-log-provider-display.test.ts
+++ b/tests/unit/call-log-provider-display.test.ts
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-call-log-provider-display-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const callLogs = await import("../../src/lib/usage/callLogs.ts");
+const callLogsRoute = await import("../../src/app/api/usage/call-logs/route.ts");
+
+function resetTables() {
+  const db = core.getDbInstance();
+  db.prepare("DELETE FROM call_logs").run();
+  db.prepare("DELETE FROM provider_nodes").run();
+  db.prepare("DELETE FROM provider_connections").run();
+}
+
+function seedProviderNode(id: string, name: string, prefix: string) {
+  const db = core.getDbInstance();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR REPLACE INTO provider_nodes (id, type, name, prefix, api_type, base_url, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(id, "provider", name, prefix, "chat", "https://example.com/v1", now, now);
+}
+
+test.beforeEach(() => {
+  resetTables();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("getCallLogs and getCallLogById expose providerDisplay from provider node name", async () => {
+  const providerId = "openai-compatible-chat-bc66d849-c440-4087-96f7-056bc000b2b9";
+  seedProviderNode(providerId, "Bynara", "bynara");
+
+  const db = core.getDbInstance();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO call_logs (id, timestamp, method, path, status, model, requested_model, provider, account, connection_id, duration, tokens_in, tokens_out)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    "log-provider-display-1",
+    now,
+    "POST",
+    "/v1/chat/completions",
+    200,
+    "gpt-4.1",
+    `${providerId}/gpt-4.1`,
+    providerId,
+    "acc1",
+    null,
+    123,
+    10,
+    20
+  );
+
+  const rows = await callLogs.getCallLogs({ limit: 10 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].provider, providerId);
+  assert.equal(rows[0].providerDisplay, "Bynara");
+  assert.equal(rows[0].requestedModel, "bynara/gpt-4.1");
+
+  const detail = await callLogs.getCallLogById("log-provider-display-1");
+  assert.ok(detail);
+  assert.equal(detail?.providerDisplay, "Bynara");
+  assert.equal(detail?.requestedModel, "bynara/gpt-4.1");
+});
+
+test("buildCallLogListRows adds providerDisplay to active and completed in-memory rows", () => {
+  const providerId = "openai-compatible-chat-bc66d849-c440-4087-96f7-056bc000b2b9";
+  const rows = callLogsRoute.buildCallLogListRows({
+    logs: [],
+    connections: [],
+    providerDisplayNames: new Map([[providerId, "Bynara"]]),
+    pendingDetails: [
+      {
+        id: "pending-1",
+        startedAt: Date.now() - 1000,
+        clientEndpoint: "/v1/chat/completions",
+        model: "gpt-4.1",
+        provider: providerId,
+        connectionId: null,
+        correlationId: "cid-pending",
+      },
+    ],
+    completedDetails: [
+      {
+        id: "completed-1",
+        startedAt: Date.now() - 2000,
+        completedAt: Date.now() - 500,
+        durationMs: 1500,
+        clientEndpoint: "/v1/chat/completions",
+        model: "gpt-4.1",
+        provider: providerId,
+        connectionId: null,
+        correlationId: "cid-completed",
+        status: 200,
+        error: null,
+      },
+    ],
+  });
+
+  const pending = rows.find((row: any) => row.id === "pending-1");
+  const completed = rows.find((row: any) => row.id === "completed-1");
+
+  assert.equal(pending?.providerDisplay, "Bynara");
+  assert.equal(completed?.providerDisplay, "Bynara");
+});


### PR DESCRIPTION
## Summary
- show saved provider names in request log list/detail views and provider test log detail
- add `providerDisplay` for persisted and in-memory call-log rows
- cover the behavior with focused regression tests

## What changed
- `src/lib/usage/callLogs.ts`
  - include `provider_nodes.name`/`prefix` when shaping persisted call-log rows
  - expose `providerDisplay` alongside existing raw `provider`
  - return `null` when no friendly server-side label exists so client fallbacks can still resolve compatible providers
  - keep requested-model prefix rewriting intact
- `src/app/api/usage/call-logs/route.ts`
  - build a provider-id -> saved-name map from `getProviderNodes()`
  - attach `providerDisplay` to active/completed in-memory rows too
  - keep `providerDisplayNames` optional in `buildCallLogListRows()` for backward compatibility
- `src/shared/components/RequestLoggerV2.tsx`
  - prefer `log.providerDisplay` when available
- `src/shared/components/RequestLoggerDetail.tsx`
  - use friendly provider label in both active and completed detail panels
- `src/shared/components/ProviderTestSlideOver.tsx`
  - use friendly provider label in log detail rows
- `tests/unit/call-log-provider-display.test.ts`
  - verifies persisted and in-memory rows expose `providerDisplay`

## Verification
- `node --test tests/unit/call-log-provider-display.test.ts` ✅
- `git diff --check` ✅
- touched-file `tsc` grep ✅
- Semgrep ✅

## Scope
- This PR is intentionally limited to request/provider log views.
- Usage analytics is handled separately in #7264.
- This is not claiming a whole-app provider-name audit.
