### PR TITLE
fix(nvidia): restore GLM-5.2 reasoning on NIM (#7215)

### DIFF
--- a/open-sse/executors/base/reasoningEffort.ts
+++ b/open-sse/executors/base/reasoningEffort.ts
@@ -48,6 +48,66 @@ function isNvidiaGlm52(provider: string, model: string | undefined): boolean {
   return provider === "nvidia" && NVIDIA_GLM_52_PATTERN.test(model || "");
 }
 
+type NvidiaGlm52EffortInfo = {
+  reasoning: Record<string, unknown> | null;
+  effortStr: string;
+};
+
+/** Pulls a normalized (lowercased) effort string out of top-level or nested `reasoning.effort`. */
+function extractNvidiaGlm52Effort(b: Record<string, unknown>): NvidiaGlm52EffortInfo | null {
+  const reasoning =
+    b.reasoning && typeof b.reasoning === "object" && !Array.isArray(b.reasoning)
+      ? (b.reasoning as Record<string, unknown>)
+      : null;
+  const effort = b.reasoning_effort ?? reasoning?.effort;
+  if (effort === undefined) return null;
+
+  const effortStr = typeof effort === "string" ? effort.toLowerCase() : "";
+  if (!effortStr) return null;
+
+  return { reasoning, effortStr };
+}
+
+/** Builds `chat_template_kwargs.enable_thinking`, or null when the existing kwargs shape is unusable. */
+function buildNvidiaGlm52TemplateKwargs(
+  rawTemplateKwargs: unknown,
+  effortStr: string
+): Record<string, unknown> | null {
+  if (
+    rawTemplateKwargs !== undefined &&
+    (!rawTemplateKwargs ||
+      typeof rawTemplateKwargs !== "object" ||
+      Array.isArray(rawTemplateKwargs))
+  ) {
+    return null;
+  }
+
+  const templateKwargs = {
+    ...((rawTemplateKwargs as Record<string, unknown> | undefined) ?? {}),
+  };
+  if (!Object.prototype.hasOwnProperty.call(templateKwargs, "enable_thinking")) {
+    templateKwargs.enable_thinking = effortStr !== "none";
+  }
+  return templateKwargs;
+}
+
+/** Returns a copy of `b` with `reasoning_effort`/`reasoning.effort` replaced by `templateKwargs`. */
+function withNvidiaGlm52TemplateKwargs(
+  b: Record<string, unknown>,
+  templateKwargs: Record<string, unknown>,
+  reasoning: Record<string, unknown> | null
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...b, chat_template_kwargs: templateKwargs };
+  delete next.reasoning_effort;
+  if (reasoning) {
+    const nextReasoning = { ...reasoning };
+    delete nextReasoning.effort;
+    if (Object.keys(nextReasoning).length === 0) delete next.reasoning;
+    else next.reasoning = nextReasoning;
+  }
+  return next;
+}
+
 /**
  * Map OmniRoute's reasoning-effort inputs onto the binary thinking switch exposed by
  * NVIDIA's hosted GLM-5.2 chat template. This runs before DefaultExecutor's unsupported
@@ -64,45 +124,13 @@ export function mapNvidiaGlm52ReasoningParams(
   if (!body || typeof body !== "object" || Array.isArray(body)) return body;
 
   const b = body as Record<string, unknown>;
-  const reasoning =
-    b.reasoning && typeof b.reasoning === "object" && !Array.isArray(b.reasoning)
-      ? (b.reasoning as Record<string, unknown>)
-      : null;
-  const effort = b.reasoning_effort ?? reasoning?.effort;
-  if (effort === undefined) return body;
+  const info = extractNvidiaGlm52Effort(b);
+  if (!info) return body;
 
-  const effortStr = typeof effort === "string" ? effort.toLowerCase() : "";
-  if (!effortStr) return body;
+  const templateKwargs = buildNvidiaGlm52TemplateKwargs(b.chat_template_kwargs, info.effortStr);
+  if (!templateKwargs) return body;
 
-  const rawTemplateKwargs = b.chat_template_kwargs;
-  if (
-    rawTemplateKwargs !== undefined &&
-    (!rawTemplateKwargs ||
-      typeof rawTemplateKwargs !== "object" ||
-      Array.isArray(rawTemplateKwargs))
-  ) {
-    return body;
-  }
-
-  const templateKwargs = {
-    ...((rawTemplateKwargs as Record<string, unknown> | undefined) ?? {}),
-  };
-  if (!Object.prototype.hasOwnProperty.call(templateKwargs, "enable_thinking")) {
-    templateKwargs.enable_thinking = effortStr !== "none";
-  }
-
-  const next: Record<string, unknown> = {
-    ...b,
-    chat_template_kwargs: templateKwargs,
-  };
-  delete next.reasoning_effort;
-  if (reasoning) {
-    const nextReasoning = { ...reasoning };
-    delete nextReasoning.effort;
-    if (Object.keys(nextReasoning).length === 0) delete next.reasoning;
-    else next.reasoning = nextReasoning;
-  }
-
+  const next = withNvidiaGlm52TemplateKwargs(b, templateKwargs, info.reasoning);
   log?.info?.(
     "REASONING_SANITIZE",
     `nvidia/${model || ""}: mapped reasoning effort to enable_thinking`

--- a/open-sse/executors/base/reasoningEffort.ts
+++ b/open-sse/executors/base/reasoningEffort.ts
@@ -38,6 +38,77 @@ export const MISTRAL_NO_REASONING_EFFORT_PATTERN = /devstral/i;
 // Order matters: the opt-in check must run BEFORE the broad Claude/haiku/oswe strip.
 export const GITHUB_REASONING_EFFORT_OPT_IN_PATTERN = /claude[-_.]?(?:opus|sonnet)[-_.]?4[-_.]6/i;
 export const GITHUB_NO_REASONING_EFFORT_PATTERN = /(claude|haiku|oswe)/i;
+const NVIDIA_GLM_52_PATTERN = /z-ai\/glm-5\.2\b/i;
+
+type ReasoningSanitizeLog = {
+  info?: (tag: string, msg: string) => void;
+};
+
+function isNvidiaGlm52(provider: string, model: string | undefined): boolean {
+  return provider === "nvidia" && NVIDIA_GLM_52_PATTERN.test(model || "");
+}
+
+/**
+ * Map OmniRoute's reasoning-effort inputs onto the binary thinking switch exposed by
+ * NVIDIA's hosted GLM-5.2 chat template. This runs before DefaultExecutor's unsupported
+ * parameter stripping so a nested `reasoning.effort` is not discarded first, and is also
+ * reused by the final provider sanitizer for non-default execution paths.
+ */
+export function mapNvidiaGlm52ReasoningParams(
+  body: unknown,
+  provider: string,
+  model: string | undefined,
+  log?: ReasoningSanitizeLog | null
+): unknown {
+  if (!isNvidiaGlm52(provider, model)) return body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+
+  const b = body as Record<string, unknown>;
+  const reasoning =
+    b.reasoning && typeof b.reasoning === "object" && !Array.isArray(b.reasoning)
+      ? (b.reasoning as Record<string, unknown>)
+      : null;
+  const effort = b.reasoning_effort ?? reasoning?.effort;
+  if (effort === undefined) return body;
+
+  const effortStr = typeof effort === "string" ? effort.toLowerCase() : "";
+  if (!effortStr) return body;
+
+  const rawTemplateKwargs = b.chat_template_kwargs;
+  if (
+    rawTemplateKwargs !== undefined &&
+    (!rawTemplateKwargs ||
+      typeof rawTemplateKwargs !== "object" ||
+      Array.isArray(rawTemplateKwargs))
+  ) {
+    return body;
+  }
+
+  const templateKwargs = {
+    ...((rawTemplateKwargs as Record<string, unknown> | undefined) ?? {}),
+  };
+  if (!Object.prototype.hasOwnProperty.call(templateKwargs, "enable_thinking")) {
+    templateKwargs.enable_thinking = effortStr !== "none";
+  }
+
+  const next: Record<string, unknown> = {
+    ...b,
+    chat_template_kwargs: templateKwargs,
+  };
+  delete next.reasoning_effort;
+  if (reasoning) {
+    const nextReasoning = { ...reasoning };
+    delete nextReasoning.effort;
+    if (Object.keys(nextReasoning).length === 0) delete next.reasoning;
+    else next.reasoning = nextReasoning;
+  }
+
+  log?.info?.(
+    "REASONING_SANITIZE",
+    `nvidia/${model || ""}: mapped reasoning effort to enable_thinking`
+  );
+  return next;
+}
 
 export function supportsMaxEffortForProvider(provider: string, model: string): boolean {
   const isClaude =
@@ -142,8 +213,12 @@ export function sanitizeReasoningEffortForProvider(
   body: unknown,
   provider: string,
   model: string | undefined,
-  log?: { info?: (tag: string, msg: string) => void } | null
+  log?: ReasoningSanitizeLog | null
 ): unknown {
+  if (isNvidiaGlm52(provider, model)) {
+    return mapNvidiaGlm52ReasoningParams(body, provider, model, log);
+  }
+
   if (!body || typeof body !== "object" || Array.isArray(body)) return body;
   const b = body as Record<string, unknown>;
   const c = readEffortCarriers(b);

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -709,11 +709,7 @@ export class DefaultExecutor extends BaseExecutor {
     if (typeof withDefaults === "object" && withDefaults !== null) {
       const bodyRecord = withDefaults as Record<string, unknown>;
       const outboundModel = typeof bodyRecord.model === "string" ? bodyRecord.model : model;
-      withDefaults = mapNvidiaGlm52ReasoningParams(
-        bodyRecord,
-        this.provider,
-        outboundModel
-      ) as typeof withDefaults;
+      withDefaults = mapNvidiaGlm52ReasoningParams(bodyRecord, this.provider, outboundModel);
       stripUnsupportedParams(this.provider, outboundModel, withDefaults as Record<string, unknown>);
     }
 

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -1,4 +1,5 @@
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
+import { mapNvidiaGlm52ReasoningParams } from "./base/reasoningEffort.ts";
 import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { getAccessToken } from "../services/tokenRefresh.ts";
 
@@ -708,7 +709,12 @@ export class DefaultExecutor extends BaseExecutor {
     if (typeof withDefaults === "object" && withDefaults !== null) {
       const bodyRecord = withDefaults as Record<string, unknown>;
       const outboundModel = typeof bodyRecord.model === "string" ? bodyRecord.model : model;
-      stripUnsupportedParams(this.provider, outboundModel, bodyRecord);
+      withDefaults = mapNvidiaGlm52ReasoningParams(
+        bodyRecord,
+        this.provider,
+        outboundModel
+      ) as typeof withDefaults;
+      stripUnsupportedParams(this.provider, outboundModel, withDefaults as Record<string, unknown>);
     }
 
     // Apply modelIdPrefix from RegistryEntry (e.g. "accounts/fireworks/models/")

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -702,10 +702,8 @@ export class DefaultExecutor extends BaseExecutor {
       );
     }
 
-    // Config-driven strip of params unsupported by the target provider/model
-    // (e.g. claude-opus-4 deprecated `temperature` → Anthropic 400). Port from
-    // 9router#7ae9fff6 (fixes upstream #1748). Rules live in
-    // ../translator/paramSupport.ts so adding one means editing one table.
+    // Strip params unsupported by the target provider/model before sending upstream.
+    // Rules live in ../translator/paramSupport.ts (9router#7ae9fff6; fixes #1748).
     if (typeof withDefaults === "object" && withDefaults !== null) {
       const bodyRecord = withDefaults as Record<string, unknown>;
       const outboundModel = typeof bodyRecord.model === "string" ? bodyRecord.model : model;

--- a/tests/unit/base-executor-sanitize-effort.test.ts
+++ b/tests/unit/base-executor-sanitize-effort.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { sanitizeReasoningEffortForProvider } = await import("../../open-sse/executors/base.ts");
+const { DefaultExecutor } = await import("../../open-sse/executors/default.ts");
 
 function makeLog() {
   const messages: Array<[string, string]> = [];
@@ -392,6 +393,114 @@ test("sanitizeReasoningEffortForProvider: non-object body returns unchanged", ()
   assert.equal(sanitizeReasoningEffortForProvider("string", "xiaomi-mimo", "x", null), "string");
   const arr: unknown[] = [];
   assert.equal(sanitizeReasoningEffortForProvider(arr, "xiaomi-mimo", "x", null), arr);
+});
+
+// ── NVIDIA NIM GLM-5.2 (#7215) ─────────────────────────────────────────────
+
+test("sanitizeReasoningEffortForProvider: NVIDIA GLM-5.2 enables thinking for active effort", () => {
+  for (const effort of ["low", "medium", "high", "xhigh", "max"]) {
+    const body = { reasoning_effort: effort, messages: [] };
+    const result = sanitizeReasoningEffortForProvider(
+      body,
+      "nvidia",
+      "z-ai/glm-5.2",
+      null
+    ) as Record<string, unknown>;
+
+    assert.notEqual(result, body);
+    assert.equal(result.reasoning_effort, undefined);
+    assert.deepEqual(result.chat_template_kwargs, { enable_thinking: true });
+  }
+});
+
+test("sanitizeReasoningEffortForProvider: NVIDIA GLM-5.2 maps none to thinking off", () => {
+  const result = sanitizeReasoningEffortForProvider(
+    { reasoning_effort: "none", messages: [] },
+    "nvidia",
+    "z-ai/glm-5.2",
+    null
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning_effort, undefined);
+  assert.deepEqual(result.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("sanitizeReasoningEffortForProvider: NVIDIA GLM-5.2 maps nested reasoning.effort", () => {
+  const result = sanitizeReasoningEffortForProvider(
+    { reasoning: { effort: "high" }, messages: [] },
+    "nvidia",
+    "z-ai/glm-5.2",
+    null
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning, undefined);
+  assert.deepEqual(result.chat_template_kwargs, { enable_thinking: true });
+});
+
+test("DefaultExecutor: NVIDIA GLM-5.2 maps nested effort before unsupported-param stripping", () => {
+  const result = new DefaultExecutor("nvidia").transformRequest(
+    "z-ai/glm-5.2",
+    {
+      model: "z-ai/glm-5.2",
+      reasoning: { effort: "high", summary: "auto" },
+      messages: [],
+    },
+    false,
+    {}
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning, undefined);
+  assert.equal(result.reasoning_effort, undefined);
+  assert.deepEqual(result.chat_template_kwargs, { enable_thinking: true });
+});
+
+test("DefaultExecutor: NVIDIA reasoning levels remain intact for GPT-OSS", () => {
+  const result = new DefaultExecutor("nvidia").transformRequest(
+    "openai/gpt-oss-120b",
+    {
+      model: "openai/gpt-oss-120b",
+      reasoning_effort: "low",
+      messages: [],
+    },
+    false,
+    {}
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning_effort, "low");
+  assert.equal(result.chat_template_kwargs, undefined);
+});
+
+test("sanitizeReasoningEffortForProvider: NVIDIA GLM-5.2 preserves a native thinking switch", () => {
+  const result = sanitizeReasoningEffortForProvider(
+    {
+      reasoning_effort: "xhigh",
+      chat_template_kwargs: { enable_thinking: false, custom_flag: true },
+      messages: [],
+    },
+    "nvidia",
+    "z-ai/glm-5.2",
+    null
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning_effort, undefined);
+  assert.deepEqual(result.chat_template_kwargs, {
+    enable_thinking: false,
+    custom_flag: true,
+  });
+});
+
+test("sanitizeReasoningEffortForProvider: NVIDIA GLM-5.2 mapping is narrowly scoped", () => {
+  const otherModel = { reasoning_effort: "high", messages: [] };
+  const otherProvider = { reasoning_effort: "high", messages: [] };
+
+  assert.equal(
+    sanitizeReasoningEffortForProvider(otherModel, "nvidia", "z-ai/glm-5.1", null),
+    otherModel
+  );
+  assert.equal(
+    sanitizeReasoningEffortForProvider(otherProvider, "openai", "z-ai/glm-5.2", null),
+    otherProvider
+  );
 });
 
 // ── Native DeepSeek (api.deepseek.com) ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Translate OpenAI-style `reasoning_effort` into NVIDIA GLM-5.2 NIM's binary `chat_template_kwargs.enable_thinking` switch.
- Map `none` to `false` and every active effort to `true` while preserving an explicit native switch.
- Scope the behavior strictly to `nvidia/z-ai/glm-5.2` and add regression coverage for both modes and scope boundaries.

## Root cause

NVIDIA's hosted GLM-5.2 endpoint ignores top-level `reasoning_effort`. Existing compatibility rules correctly strip the raw `reasoning` and Claude-style `thinking` fields that NIM rejects, but no supported binary thinking control reached the model, so `reasoning_content` remained empty.

## Validation

- `npm run typecheck:core`
- 70 targeted reasoning/parameter compatibility tests
- Pre-commit Prettier, ESLint, docs-sync, tracked-artifact, and explicit-any budget checks
- Live NVIDIA NIM verification:
  - active effort: HTTP 200 with 25 characters of `reasoning_content`
  - `none`: HTTP 200 with no reasoning trace and a normal content response

Fixes #7215

## Root Refresh (2026-07-17, `93e217e76`)

- Rebased all three NVIDIA commits onto the latest `release/v3.8.49` root at `93e217e76375d1e250708ea0d0ce85618d346a89`.
- Range-diff mapped all three commits one-to-one with unchanged patches; `git diff --check`, full ESLint, core typecheck, complexity ratchets, and the 41 focused reasoning tests passed during the refresh.
- No golden or quality baseline was changed.

## Root Refresh (2026-07-18, `ed4944e77`)

- Rebased all three NVIDIA commits onto the latest `release/v3.8.49` root at `ed4944e771d3e5dba944534414cf470c85598f22`.
- Range-diff mapped all three commits one-to-one with unchanged patches; `git diff --check` and core typecheck passed.
- Complexity is **2058 structural / 890 cognitive**, exactly matching a clean checkout of this root; the two structural violations above the 2056 baseline are inherited from upstream.
- No golden file or quality baseline was changed.

## Recovery Audit (2026-07-18, `e6f81d827`)

- Rebased all three NVIDIA commits onto the current `release/v3.8.49` root at `e6f81d827e5d92f13fd4ac157f82dd1e6bc7bd1a`.
- Range-diff maps all three commits one-to-one with unchanged patches. File-size and strict docs-count gates pass; no PR golden or quality baseline was changed.
- Remaining red checks are inherited from the current root and unrelated to NVIDIA: the new `freetheai` alias collides with the test fixture prefix `fta`, the translate-path golden does not yet contain `freetheai`, and structural complexity is **2058** against the committed **2056** baseline. Cognitive complexity is **890 / 890**.
