### PR TITLE
chore(ci): stop dependabot proposing typescript majors — peer-blocked by typescript-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-config-next"
         update-types: ["version-update:semver-major"]
+      # typescript majors are peer-blocked by typescript-eslint, which pins a hard
+      # upper bound (8.64.0 → peerDependencies.typescript ">=4.8.4 <6.1.0"). A TS 7
+      # bump therefore violates the peer and takes down the whole toolchain at once —
+      # #7068 grouped it with 6 harmless bumps and turned Build + Lint + Quality Ratchet
+      # + Unit (6/8, 8/8) + Integration (1/2, 2/2) + dast-smoke red in one shot, blocking
+      # the innocuous updates riding along with it. Un-ignore once typescript-eslint
+      # widens the peer, and migrate TS majors intentionally (own PR, own CI run).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
       # jscpd v5 is a Rust rewrite (native binary, no Node.js programmatic API).
       # scripts/check/check-duplication.mjs is deliberately pinned to jscpd@4 (it
       # parses jscpd-report.json against a frozen baseline). A v5 major would break

--- a/changelog.d/maintenance/7068-dependabot-ignore-typescript-major.md
+++ b/changelog.d/maintenance/7068-dependabot-ignore-typescript-major.md
@@ -1,0 +1,1 @@
+- **chore(ci):** stop dependabot from proposing `typescript` majors — `typescript-eslint` pins a hard peer upper bound (`>=4.8.4 <6.1.0`), so a TS 7 bump violates the peer and takes the whole toolchain red at once. #7068 grouped it with 6 harmless dev bumps and blocked all of them. TS majors now migrate intentionally, in their own PR.


### PR DESCRIPTION
## Why

`typescript-eslint` pins a hard upper bound on its `typescript` peer:

```
typescript-eslint@8.64.0 → peerDependencies.typescript: ">=4.8.4 <6.1.0"
```

A major TS bump violates that peer, so the failure is never one check — it is the whole toolchain at once.

**#7068 is the demonstration.** Dependabot grouped `typescript` ^6→^7 with six harmless dev bumps (`@types/node` 26.1.0→26.1.1, `eslint` 9.39.4→9.39.5, `fast-check`, `knip`, `prettier`, `typescript-eslint` 8.63→8.64) and turned **Build, Lint, Quality Ratchet, Unit (6/8, 8/8), Integration (1/2, 2/2) and dast-smoke** red in a single PR. The six innocuous updates were held hostage by the one that could not pass.

This is also worth stating plainly because the received wisdom says otherwise: a dependabot bump *can* break lint/build, and "it's just a version bump" is false for semver-major toolchain packages (typescript, eslint, tsx, esbuild, better-sqlite3).

## What changed

One `ignore` entry, following the file's existing convention (justification comment + reference), alongside the ones already there for `react`, `next`, `eslint`, `jscpd` and `@huggingface/transformers`:

```yaml
- dependency-name: "typescript"
  update-types: ["version-update:semver-major"]
```

Minors and patches keep flowing normally. Only majors are held.

## Consequences

- The remaining bumps in a `development` group are no longer blocked by a TS major that cannot merge.
- TS majors become an intentional migration: own PR, own CI run, own review — not a weekly automated attempt that is guaranteed red until `typescript-eslint` widens the peer.
- **Un-ignore once that peer widens.** The comment in `dependabot.yml` records the condition so the entry doesn't quietly outlive its reason.

## About #7068 itself

It stays red and cannot be greened as-is — the peer conflict is real, not a stale verdict. Recommend closing it; dependabot will reopen the `development` group without the TS major on its next run.

Refs #7068