### PR TITLE
test(ci): make #6634 selfref guard hermetic — no git ref, no skip

### DIFF
--- a/tests/unit/check-test-masking-selfref-6634.test.ts
+++ b/tests/unit/check-test-masking-selfref-6634.test.ts
@@ -14,12 +14,14 @@
  * (`if (file.endsWith("check-test-masking.test.ts")) continue;` in
  * scripts/check/check-test-masking.mjs) for precisely this reason — this test
  * asserts evaluateMasking() now applies the same exclusion for its diff-based
- * tautology counters, using the real base(origin/main)/head(HEAD) diff of
+ * tautology counters, against the REAL current source of
  * tests/unit/check-test-masking.test.ts.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   countTautologies,
@@ -28,29 +30,17 @@ import {
 } from "../../scripts/check/check-test-masking.mjs";
 
 const FILE = "tests/unit/check-test-masking.test.ts";
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-function git(args: string[]): string {
-  return execFileSync("git", args, { encoding: "utf8" });
-}
-
-test("#6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening", (t) => {
-  // origin/main predates the #6404 fixtures (countBareTautologies/scanBareTautologies
-  // tests) that legitimately embed tautology-pattern literals as string fixtures.
-  // Shallow/single-ref checkouts (GitHub-hosted runners) have no origin/main —
-  // fetch it on demand; skip (never fail) when the ref is unreachable offline.
-  let baseSrc: string;
-  try {
-    baseSrc = git(["show", "origin/main:" + FILE]);
-  } catch {
-    try {
-      git(["fetch", "--depth=1", "origin", "main"]);
-      baseSrc = git(["show", "origin/main:" + FILE]);
-    } catch {
-      t.skip("origin/main unavailable (shallow checkout, offline) — nothing to compare against");
-      return;
-    }
-  }
-  const headSrc = git(["show", "HEAD:" + FILE]);
+test("#6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening", () => {
+  // Read the REAL current source from disk rather than a git ref: the Unit Tests
+  // job checks out a shallow/single-ref tree with no origin/main, so `git show
+  // origin/main:<file>` failed the shard before it ever exercised the masking
+  // behavior under test. An empty base models the file's pre-#6404 state (no
+  // fixtures), which maximizes headTaut - baseTaut — the strictest input for the
+  // exclusion this test asserts.
+  const baseSrc = "";
+  const headSrc = fs.readFileSync(path.join(REPO_ROOT, FILE), "utf8");
 
   const perFile = [
     {


### PR DESCRIPTION
## Summary
- `tests/unit/check-test-masking-selfref-6634.test.ts` did git I/O (`git show origin/main:<file>`) inside a unit test. This is the #1 red cause across today's babysit sweep — GitHub-hosted runners use shallow/single-ref checkouts with no `origin/main`, so the `show` fails with `fatal: invalid object name`.
- The prior hotfix (`2e42b8efc`, #7174) wrapped it in try/catch + on-demand `git fetch --depth=1 origin main` + `t.skip()` on failure. That introduces two new problems: `t.skip()` itself trips the PR Test Policy weakened-assert gate (confirmed today when an agent copied the same pattern into #7300 and the gate caught it), and `origin/main` is the wrong ref anyway — PRs in this repo target `release/v3.8.49`, not `main`.
- This PR ports the hermetic fix already proven on #7300 (author: @growab): read the real current source of `tests/unit/check-test-masking.test.ts` from disk instead of diffing against any git ref, using an empty-string base (`baseTaut`/`baseExtTaut = 0`) — this maximizes `headTaut - baseTaut`, the strictest possible input for the `SELF_TEST_FIXTURE_RE` exclusion under test, so the guard is exercised at least as hard as the old git-diff-based version. No git ref, no skip, no CI-checkout-shape dependency.

## Test plan
- [x] `node --import tsx/esm --test tests/unit/check-test-masking-selfref-6634.test.ts` — 2/2 pass
- [x] Neutralized `SELF_TEST_FIXTURE_RE` in `scripts/check/check-test-masking.mjs` (temporarily, reverted before commit) → test **fails** with `10 new bare tautologies + 28 new extended tautologies` reported, proving the guard is not vacuous
- [x] Restored `SELF_TEST_FIXTURE_RE` → test **passes** again
- [x] Full `tests/unit/check-test-masking.test.ts` suite (55 tests) still green, confirming the underlying #6634 self-referential-fixture regression stays covered

Co-authored-by: growab <nekron@icloud.com>