### PR TITLE
chore(ci): Electron Windows leg advisory + bash stderr capture (first-run failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,10 +670,16 @@ jobs:
         if: runner.os == 'Linux'
         working-directory: electron
         run: npm run pack
+      # ADVISORY while the new Windows leg matures (repo convention, dast-smoke
+      # precedent): its first-ever real run (2026-07-15, run 29457533565) died in
+      # 0.7s with the error swallowed by pwsh — bash shell captures stderr and
+      # continue-on-error keeps the heavy gate green while we harden it (#7336).
       - name: Prepare Electron standalone (Windows ABI rebuild + spawn path)
         if: runner.os == 'Windows'
         working-directory: electron
-        run: npm run prepare:bundle
+        continue-on-error: true
+        shell: bash
+        run: npm run prepare:bundle 2>&1
       - name: Smoke packaged Electron app
         if: runner.os == 'Linux'
         env:

--- a/changelog.d/maintenance/electron-win-advisory.md
+++ b/changelog.d/maintenance/electron-win-advisory.md
@@ -1,0 +1,1 @@
+- **CI**: the new Electron Windows prepare-bundle leg (WS1.5) is advisory while it matures — its first real run failed with the error swallowed by pwsh; the step now runs under bash (stderr captured) with `continue-on-error`, tracked for promotion once green


### PR DESCRIPTION
The WS1.5 Windows leg (#7113) ran for real for the FIRST time on run 29457533565 (release-tip dispatch — PRs into release/** never execute this job) and `npm run prepare:bundle` died in 0.7s with **zero error output** (pwsh swallowed stderr), failing the whole heavy-gate run and cancelling Coverage with it.

Repo convention for brand-new gates (dast-smoke precedent): **advisory until proven**. This makes the Windows step `continue-on-error: true` and runs it under `shell: bash` with `2>&1` so the next run captures the actual error for the real fix. The ubuntu leg (full pack + smoke) stays blocking — it just went green with #7308.

Follow-up tracking: comment on the run + promotion once green.