### PR TITLE
test(ci): make the #6634 selfref guard hermetic — main's copy hard-fails every PR into main

### DIFF
--- a/tests/unit/check-test-masking-selfref-6634.test.ts
+++ b/tests/unit/check-test-masking-selfref-6634.test.ts
@@ -14,12 +14,14 @@
  * (`if (file.endsWith("check-test-masking.test.ts")) continue;` in
  * scripts/check/check-test-masking.mjs) for precisely this reason — this test
  * asserts evaluateMasking() now applies the same exclusion for its diff-based
- * tautology counters, using the real base(origin/main)/head(HEAD) diff of
+ * tautology counters, against the REAL current source of
  * tests/unit/check-test-masking.test.ts.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   countTautologies,
@@ -28,16 +30,17 @@ import {
 } from "../../scripts/check/check-test-masking.mjs";
 
 const FILE = "tests/unit/check-test-masking.test.ts";
-
-function git(args: string[]): string {
-  return execFileSync("git", args, { encoding: "utf8" });
-}
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 test("#6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening", () => {
-  // origin/main predates the #6404 fixtures (countBareTautologies/scanBareTautologies
-  // tests) that legitimately embed tautology-pattern literals as string fixtures.
-  const baseSrc = git(["show", "origin/main:" + FILE]);
-  const headSrc = git(["show", "HEAD:" + FILE]);
+  // Read the REAL current source from disk rather than a git ref: the Unit Tests
+  // job checks out a shallow/single-ref tree with no origin/main, so `git show
+  // origin/main:<file>` failed the shard before it ever exercised the masking
+  // behavior under test. An empty base models the file's pre-#6404 state (no
+  // fixtures), which maximizes headTaut - baseTaut — the strictest input for the
+  // exclusion this test asserts.
+  const baseSrc = "";
+  const headSrc = fs.readFileSync(path.join(REPO_ROOT, FILE), "utf8");
 
   const perFile = [
     {


### PR DESCRIPTION
## The problem

`main`'s copy of `tests/unit/check-test-masking-selfref-6634.test.ts` does git I/O **inside a unit test**:

```js
const baseSrc = git(["show", "origin/main:" + FILE]);
```

Runners check out a shallow single ref, so `origin/main` doesn't resolve:

```
fatal: invalid object name 'origin/main'.
✖ #6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening
```

**Every PR into `main` fails `Unit Tests (7/8)` on it.** Right now that's six — #7313, #7315, #7316, #7334, #7336, #7337 — all red on a defect none of them introduced. **#7313 has no other red at all**: it is 100% this.

## Why the existing fix doesn't help

`release/v3.8.49` already carries one (`2e42b8efc`, #7174 — try/catch, fetch `origin/main` on demand, `t.skip()` when unreachable). But it only reaches `main` **at release time**, so `main` stays broken for the whole cycle while every contributor PR lands red on it.

Cherry-picking it would also import a new problem: **`PR Test Policy` classifies `t.skip()` as a silenced assertion** — we watched it correctly catch exactly that on #7300 today. So the cherry-pick would trade one red for another.

## What this does instead

The hermetic version (ported from #7327, which does the same for the release branch): read the file **straight off disk**, compare against an **empty base** so `baseTaut`/`baseExtTaut` are `0` — the strictest possible comparison point — and call `evaluateMasking()` directly.

**No git ref, no fetch, no skip.** Nothing the runner's checkout depth can break.

## The #6634 regression stays covered — proven both ways on main

The guard's logic lives in `SELF_TEST_FIXTURE_RE` (`check-test-masking.mjs:337`), not in the test. The test verifies that mechanism works, so making the test hermetic doesn't weaken it. Verified before committing:

**Neutralise `SELF_TEST_FIXTURE_RE` to `/$^/` → the test FAILS:**
```
✖ #6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening
```

**Restore it → passes 2/2**, and `check-test-masking.mjs` is left byte-identical (`git status` shows only the test file). The sibling suite `check-test-masking.test.ts` stays green.

## Scope

One file, 13 insertions / 10 deletions. No production code, no baseline, no workflow, no suppressions.

Surfaced while auditing the 13 red PRs into `main` — six shared this one cause. Related: #7327 (same fix for `release/v3.8.49`), #7307 (the fast-path vs full-CI gap that made this invisible).

Co-authored with @growab, whose PR #7300 is where the hermetic approach was first worked out.