### PR TITLE
fix(ci): Coverage job timeout 10→20min (lcov reporter pushed it past the cap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,7 +783,10 @@ jobs:
   test-coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 10min was sized before #7114 added the lcov reporter (Codecov/Sonar need it);
+    # merging 8 shard JSONs + text+json+lcov now takes ~10-12min — three consecutive
+    # release-tip runs died at exactly 10m as job-timeout "cancelled" (2026-07-15/16).
+    timeout-minutes: 20
     needs: test-unit
     if: ${{ !cancelled() && needs.test-unit.result == 'success' && !contains(github.event.pull_request.labels.*.name, 'hotfix') }}
     env:

--- a/changelog.d/maintenance/coverage-job-timeout.md
+++ b/changelog.d/maintenance/coverage-job-timeout.md
@@ -1,0 +1,1 @@
+- **CI**: raise the Coverage job timeout 10→20min — the lcov reporter added for Codecov/Sonar (#7114) pushed the 8-shard report merge past the old cap, and three release-tip runs died at exactly 10min as job-timeout "cancelled"


### PR DESCRIPTION
Three consecutive release-tip dispatches (29399184340, 29457533565, 29461066672) had the **Coverage job "cancelled" at exactly 10m0s-10m15s** — that's the job-level `timeout-minutes: 10`, not a real cancellation. The cap was sized before #7114 added the `lcov` reporter to the c8 report step (required by Codecov and the Sonar coverage fix); text+json+lcov over the merged 8-shard data now takes ~10-12min. 10→20min with an explanatory comment. Workflow-config-only.