### PR TITLE
chore(quality): tighten main's coverage baseline to the CI's real numbers

### DIFF
--- a/config/quality/quality-baseline.json
+++ b/config/quality/quality-baseline.json
@@ -27,22 +27,22 @@
       "eps": 0
     },
     "coverage.statements": {
-      "value": 76.5,
+      "value": 80.8,
       "direction": "up",
       "tightenSlack": 5
     },
     "coverage.lines": {
-      "value": 76.5,
+      "value": 80.8,
       "direction": "up",
       "tightenSlack": 5
     },
     "coverage.functions": {
-      "value": 82,
+      "value": 86.44,
       "direction": "up",
       "tightenSlack": 5
     },
     "coverage.branches": {
-      "value": 73,
+      "value": 78.1,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 5
@@ -54,43 +54,43 @@
       "tightenSlack": 10
     },
     "coverage.combo.lines": {
-      "value": 80,
+      "value": 85.42,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10
     },
     "coverage.accountFallback.lines": {
-      "value": 88,
+      "value": 96.78,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10
     },
     "coverage.auth.lines": {
-      "value": 90,
+      "value": 92.55,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10
     },
     "coverage.routeGuard.lines": {
-      "value": 94,
+      "value": 98.73,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10
     },
     "coverage.error.lines": {
-      "value": 88,
+      "value": 92.13,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10
     },
     "coverage.publicCreds.lines": {
-      "value": 92,
+      "value": 99.07,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10
     },
     "coverage.circuitBreaker.lines": {
-      "value": 92,
+      "value": 95.09,
       "direction": "up",
       "eps": 1.5,
       "tightenSlack": 10


### PR DESCRIPTION
## Why

`main`'s `Quality Ratchet` fails on **every** PR into it:

```
[quality-ratchet] OK (57 métricas, 11 melhoraram)
[quality-ratchet] FALHOU (--require-tighten): métrica(s) melhoraram mas o baseline não foi apertado
```

The gate is right — it has been asking for this in plain text. Nobody tightened `main`'s baseline, so the red is permanent and unrelated to whatever the PR changed. It currently accounts for the **only** red on #7341 and #7300.

This is the same class as #7341 (the #6634 selfref guard): **an infra fix that lands only on the release branch leaves `main` broken for the whole cycle**, and every PR into `main` pays. #7326 does this for `release/v3.8.49`; this is its `main` counterpart.

## What

Only the **11 coverage values** move — structure, `direction`, `eps` and `tightenSlack` are untouched, and `gitleaks`/`semgrepFindings` keep `main`'s own state (they differ from the release branch on purpose).

| Metric | Before | After |
|---|---|---|
| `coverage.statements` / `.lines` | 76.5 | **80.8** |
| `coverage.functions` | 82 | **86.44** |
| `coverage.branches` | 73 | **78.1** |
| `coverage.combo.lines` | 80 | **85.42** |
| `coverage.accountFallback.lines` | 88 | **96.78** |
| `coverage.auth.lines` | 90 | **92.55** |
| `coverage.routeGuard.lines` | 94 | **98.73** |
| `coverage.error.lines` | 88 | **92.13** |
| `coverage.publicCreds.lines` | 92 | **99.07** |
| `coverage.circuitBreaker.lines` | 92 | **95.09** |

Values come from a **merged-coverage run on `main`**, not a local one — a local run measures ~68% against CI's ~80%, and the baseline's own note warns about exactly that gap.

## Notes

- **No `changelog.d` fragment on purpose.** #7326 carries it on `release/v3.8.49`; a second one here would double the entry at release time.
- Config-only change, no production code — so no test is owed under the PR rule.
- Unblocks #7341 and #7300, whose sole failing check is this gate.