### PR TITLE
fix(electron): normalize hashed standalone externals

### DIFF
--- a/changelog.d/fixes/7353-electron-hashed-externals.md
+++ b/changelog.d/fixes/7353-electron-hashed-externals.md
@@ -1,0 +1,1 @@
+- **fix(electron):** Normalize hashed Turbopack external imports in packaged desktop builds, preventing instrumentation startup failures ([#7353](https://github.com/diegosouzapw/OmniRoute/pull/7353)) — thanks @tianrking

--- a/scripts/build/prepare-electron-standalone.mjs
+++ b/scripts/build/prepare-electron-standalone.mjs
@@ -177,6 +177,10 @@ assembleStandalone({
   outDir: ELECTRON_STANDALONE_DIR,
   projectRoot: ROOT,
   sanitizePaths: true,
+  // Next can emit hashed external package names in instrumentation chunks.
+  // The standalone dependency tree contains the canonical package names, so
+  // normalize those imports before electron-builder copies the bundle.
+  patchTurbopackChunks: true,
   copyNatives: true,
 });
 

--- a/tests/unit/build/assemble-standalone.test.ts
+++ b/tests/unit/build/assemble-standalone.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   assembleStandalone,
+  patchTurbopackChunks,
   syncStandaloneNativeAssets,
   syncStandaloneExtraModules,
 } from "../../../scripts/build/assembleStandalone.mjs";
@@ -91,6 +92,26 @@ test("assembleStandalone copies standalone + static + public + sidecars into out
     "static is NOT placed under a literal .next (would 404 against distDir server)"
   );
   assert.ok(fs.existsSync(path.join(outDir, "public/logo.svg")), "public copied");
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test("patchTurbopackChunks restores canonical external package names in a custom distDir", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "assemble-hash-strip-"));
+  const chunkDir = path.join(tmp, ".build", "next", "server", "chunks");
+  const chunkPath = path.join(chunkDir, "instrumentation.js");
+  fs.mkdirSync(chunkDir, { recursive: true });
+  fs.writeFileSync(
+    chunkPath,
+    'require("ws-a972e7ffa40ff725"); require("@ngrok/ngrok-0f98e1294a0b09d5");'
+  );
+
+  const result = patchTurbopackChunks(tmp, ".build/next");
+  const patched = fs.readFileSync(chunkPath, "utf8");
+
+  assert.deepEqual(result, { patchedFiles: 1, patchedMatches: 2 });
+  assert.match(patched, /require\("ws"\)/);
+  assert.match(patched, /require\("@ngrok\/ngrok"\)/);
+  assert.doesNotMatch(patched, /-[0-9a-f]{16}/);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 

--- a/tests/unit/electron-packaging.test.ts
+++ b/tests/unit/electron-packaging.test.ts
@@ -24,3 +24,16 @@ test("electron build copies standalone runtime dependencies into resources/app/n
     }
   );
 });
+
+test("electron standalone assembly normalizes Turbopack hashed external imports", () => {
+  const prepareScript = readFileSync(
+    join(ROOT, "scripts", "build", "prepare-electron-standalone.mjs"),
+    "utf8"
+  );
+
+  assert.match(
+    prepareScript,
+    /assembleStandalone\(\{[\s\S]*?patchTurbopackChunks:\s*true,[\s\S]*?\}\);/,
+    "Electron packages must strip Turbopack's hashed external package names before bundling"
+  );
+});


### PR DESCRIPTION
## Summary

Fixes the Electron packaging path that left Turbopack-hashed external imports such as `ws-a972e7ffa40ff725` in server instrumentation chunks.

`assembleStandalone` already has `patchTurbopackChunks` for this exact normalization and the npm prepublish flow enables it. The Electron staging flow did not, so the packaged app copied canonical `node_modules/ws` but attempted to import the non-existent hashed name at startup.

This enables the existing normalization step for Electron builds and adds regression coverage for both the package-name rewrite and the Electron assembly wiring.

## Validation

- `node --import tsx/esm --test --test-name-pattern "patchTurbopackChunks restores canonical external package names|electron standalone assembly normalizes Turbopack hashed external imports" tests/unit/build/assemble-standalone.test.ts tests/unit/electron-packaging.test.ts`
- `npx prettier --check scripts/build/prepare-electron-standalone.mjs tests/unit/build/assemble-standalone.test.ts tests/unit/electron-packaging.test.ts`
- `npx eslint tests/unit/build/assemble-standalone.test.ts tests/unit/electron-packaging.test.ts --no-error-on-unmatched-pattern --suppressions-location config/quality/eslint-suppressions.json`
- `git diff --check`

The complete `assemble-standalone.test.ts` suite has an existing Windows-only path failure in its unrelated `standalone-server-ws.mjs` test: it derives a `file:` URL with `.pathname`, producing `F:\\F:\\...`. The selected new regression and Electron packaging test both pass.

## Scope

No provider behavior, route handling, or bundled dependency list changes. The staging step now rewrites only the erroneous hash suffixes before `electron-builder` copies the standalone bundle.
