### PR TITLE
test(ci): mock route bridge surfaces error message, not raw stack (unblocks all PRs)

### DIFF
--- a/tests/integration/codex-chat-reasoning-http-e2e.test.ts
+++ b/tests/integration/codex-chat-reasoning-http-e2e.test.ts
@@ -179,8 +179,9 @@ async function startRouteServer() {
       });
       await bridgeRouteResponse(await chatRoute.POST(request), outgoing);
     } catch (error) {
+      // Mock route bridge: surface the message, never the raw stack (js/stack-trace-exposure).
       outgoing.writeHead(500, { "content-type": "text/plain" });
-      outgoing.end(error instanceof Error ? error.stack : String(error));
+      outgoing.end(error instanceof Error ? error.message : String(error));
     }
   });
 


### PR DESCRIPTION
## Why this is urgent

The repo-wide **CodeQL ratchet** (`check:codeql-ratchet`, part of the blocking `Quality Ratchet` job) counts open CodeQL alerts **across all branches**. A single new alert (`js/stack-trace-exposure`, medium, #736) pushed the count from baseline `0 → 1`, which turns the `Quality Ratchet` **red on every open PR** — into both `main` and `release/v3.8.49` — regardless of what each PR changes.

It had been **masked** until now: while the coverage `--require-tighten` step was failing (fixed by #7326/#7347), the ratchet aborted on that first failure and never reached the CodeQL step. Fixing the coverage step unmasked this one.

## The alert

`tests/integration/codex-chat-reasoning-http-e2e.test.ts:183` — the E2E test's **mock HTTP server** sent `error.stack` straight to the 500 response body:

```ts
outgoing.end(error instanceof Error ? error.stack : String(error));
```

Test-only, localhost (`127.0.0.1`) — but CodeQL matches the sink mechanically, and the ratchet is repo-wide, so it blocks everyone. Introduced by the #7304 integration test added this cycle.

## The fix

Surface `error.message` instead of `.stack`. This:
- clears the alert (`js/stack-trace-exposure` tracks `.stack` specifically),
- keeps a useful signal when a mock route throws,
- does **not** add `console.error` (the `node:test` native runner corrupts its report stream on console output — a known flake class in this repo).

The test only asserts `status === 200`; the 500 body is never checked, so behavior is unchanged. Verified: `node --import tsx/esm --test …codex-chat-reasoning-http-e2e.test.ts` → **1 pass, 0 fail**.

Test-only change — no production code touched, so no additional test is owed under the PR rule. Once this merges to `release/v3.8.49`, CodeQL re-scans on push and the alert clears repo-wide, unblocking the `Quality Ratchet` on all open PRs.