### PR TITLE
ci(release-green): add a main-green arm to detect when main goes red

### DIFF
--- a/.github/workflows/nightly-release-green.yml
+++ b/.github/workflows/nightly-release-green.yml
@@ -22,7 +22,7 @@ name: Release-Green (continuous)
 
 on:
   push:
-    branches: ["release/v*"]
+    branches: ["release/v*", "main"]
     paths:
       - "src/**"
       - "open-sse/**"
@@ -61,6 +61,9 @@ env:
 jobs:
   release-green:
     name: Validate active release branch
+    # On a push, only run for release/* pushes — a push to main is handled by the
+    # main-green job below. Schedule/dispatch always run (they validate the highest release).
+    if: ${{ github.event_name != 'push' || startsWith(github.ref_name, 'release/') }}
     # Dynamic runner: with USE_VPS_RUNNER=true (release window / on-demand pre-flight)
     # this runs on the dedicated VPS runner — clean env (no operator OMNIROUTE_API_KEY,
     # no local noauth CLIs => zero machine-specific false positives) and no contention.
@@ -200,4 +203,101 @@ jobs:
           path: |
             release-green.json
             release-green.log
+          if-no-files-found: ignore
+
+  # Companion arm for `main`. Under the parallel-cycle model, main only receives merged
+  # work at the release squash — so a gate/infra fix that lands only on release leaves
+  # main red the whole cycle, and repo-wide gates (CodeQL alert count, ratchet baselines)
+  # turn EVERY PR into main red on a check unrelated to its diff. This detects that and
+  # opens a "🔴 main not green" tracking issue. The PREVENTION is the companion-PR reflex
+  # (Hard Rule #21 area / _shared/merge-gates.md §8); this is the automated backstop.
+  main-green:
+    name: Validate main branch
+    # On a push, only run for a push to main — a push to release/* is handled by
+    # release-green above. Schedule/dispatch always run (they also sweep main).
+    if: ${{ github.event_name != 'push' || github.ref_name == 'main' }}
+    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && fromJSON('["self-hosted","omni-release"]')) || 'ubuntu-latest' }}
+    env:
+      JWT_SECRET: ci-nightly-secret-with-sufficient-length-for-validation
+      API_KEY_SECRET: ci-nightly-api-key-secret-long
+      DISABLE_SQLITE_AUTO_BACKUP: "true"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main # literal — no injection surface; scheduled runs default to the repo default branch (a release/v*), so pin main explicitly
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - uses: ./.github/actions/npm-ci-retry
+
+      - name: Main-green validation
+        id: validate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set +e
+          # push (a merge into main) → --quick fast HARD gates; schedule/dispatch → full sweep.
+          if [ "$EVENT_NAME" = "push" ]; then
+            MODE="--quick"
+          else
+            MODE="--with-build --full-ci"
+          fi
+          echo "[main-green] mode: $MODE (event: $EVENT_NAME)"
+          # shellcheck disable=SC2086 — MODE is an intentional flag list
+          node scripts/quality/validate-release-green.mjs --json --hermetic $MODE \
+            1> main-green.json 2> main-green.log
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          echo "------- report -------"
+          cat main-green.log
+
+      - name: Open / update tracking issue on HARD failure
+        if: steps.validate.outputs.exit != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          TITLE="🔴 main branch not green"
+          {
+            echo "The **main-green** validation found HARD failures on \`main\`."
+            echo ""
+            echo "Because \`main\` only receives merged work at the release squash, a gate/infra"
+            echo "fix that landed only on the release branch leaves \`main\` broken for the whole"
+            echo "cycle — and repo-wide gates (CodeQL alert count, ratchet baselines) then turn"
+            echo "**every open PR into main** red on a check unrelated to its diff. The fix is a"
+            echo "companion PR \`--base main\` carrying the release-side fix (see"
+            echo "\`_shared/merge-gates.md\` §8), NOT chasing each contributor PR."
+            echo ""
+            echo "**Run:** ${RUN_URL} (mode: ${EVENT_NAME})"
+            echo ""
+            echo '```'
+            sed -n '/──────── verdict ────────/,$p' main-green.log || tail -40 main-green.log
+            echo '```'
+            echo ""
+            echo "_Ratchet drift (eslint warnings / cognitive-complexity / file-size) is expected mid-cycle and did NOT, on its own, open this issue._"
+          } > issue-body.md
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title $TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file issue-body.md
+            echo "Updated existing issue #$EXISTING"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file issue-body.md
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-green-report
+          path: |
+            main-green.json
+            main-green.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Why

The `nightly-release-green.yml` workflow already watches the **release branch** — it reproduces the release-equivalent gate on every push + 3×/day and opens a tracking issue on HARD failures. But `main` had **no equivalent watch**.

Under the parallel-cycle model, `main` only receives merged work at the release squash. So a gate/infra fix that lands only on `release/vX.Y.Z` leaves `main` broken the whole cycle — and because several gates are **repo-wide** (CodeQL open-alert count, ratchet baselines), a single unfixed item on the release turns **every open PR into `main`** red on a check unrelated to its diff.

**v3.8.49 hit this exact pattern three times in one night** — #7341 (selfref), #7347 (coverage ratchet), #7354 (CodeQL stack-exposure) — each caught reactively by a human noticing. This arm makes the detection automatic.

## What

Adds a dedicated **`main-green`** job to the existing workflow:
- **Triggers:** push to `main` (added to `push.branches`) + the same 3 crons + `workflow_dispatch`.
- **Checkout:** `ref: main` — a **literal**, no injection surface. Explicit because scheduled runs otherwise default to the repo's default branch (now a `release/v*`).
- **Validation:** the same branch-agnostic `validate-release-green.mjs` the release arm uses (push → `--quick`; schedule/dispatch → `--with-build --full-ci`).
- **On HARD failure:** opens/updates a single **`🔴 main branch not green`** issue that points at the companion-PR fix, not at chasing each contributor PR.

The existing `release-green` job gets an `if:` gate so a push to `main` doesn't re-validate the release (and vice-versa); **schedule/dispatch sweep both branches**.

### Trigger matrix

| Event | `release-green` | `main-green` |
|---|---|---|
| push `release/v*` | ✅ | ⛔ |
| push `main` | ⛔ | ✅ |
| schedule / dispatch | ✅ (highest release) | ✅ (main) |

## Notes

- **Non-blocking** — like the release arm, it is not a required status check and never touches a contributor PR; it only reports.
- **Detection, not prevention.** The *prevention* is the companion-PR reflex codified in `_shared/merge-gates.md §8` (skills repo) — a gate/infra fix merged to release opens a `--base main` companion in the same session. This workflow is the backstop for when that's forgotten.
- CI-config only; no production code — no test owed under the PR rule. YAML validated (`yaml.safe_load`) + trigger `if:` logic checked.