### PR TITLE
fix(db): stop a 'latest' path segment from disabling backups and migrations

### DIFF
--- a/src/lib/config/runtimeSettings.ts
+++ b/src/lib/config/runtimeSettings.ts
@@ -1,5 +1,6 @@
 import { clearHealthCheckLogCache } from "@/lib/tokenHealthCheck";
 import { setCustomBannedSignals } from "@omniroute/open-sse/services/accountFallback.ts";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -86,14 +87,6 @@ function isTruthyEnvFlag(value: string | undefined): boolean {
   return new Set(["1", "true", "yes", "on"]).has(value.trim().toLowerCase());
 }
 
-function isAutomatedTestProcess(): boolean {
-  return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((arg) => arg.includes("test")))
-  );
-}
 
 function toRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};

--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -24,6 +24,7 @@ import {
   initCredentialCache,
 } from "@/lib/credentialHealth/cache";
 import { emit } from "@/lib/events/eventBus";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 // ── Config ────────────────────────────────────────────────────────────────
 
@@ -66,14 +67,6 @@ function isBuildProcess(): boolean {
   return typeof process !== "undefined" && process.env.NEXT_PHASE === "phase-production-build";
 }
 
-function isAutomatedTestProcess(): boolean {
-  return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((arg) => arg.includes("test")))
-  );
-}
 
 function isCredentialHealthCheckDisabled(): boolean {
   if (isBuildProcess() || isAutomatedTestProcess()) return true;

--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -14,6 +14,7 @@ import {
   DATA_DIR,
 } from "./core";
 import { resetAllDbModuleState } from "./stateReset";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 type CountRow = { cnt?: number };
 
@@ -308,12 +309,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 function isSqliteAutoBackupDisabled() {
-  const isTest =
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((a) => a.includes("test")));
-  if (isTest) return true;
+  if (isAutomatedTestProcess()) return true;
 
   const value = process.env.DISABLE_SQLITE_AUTO_BACKUP;
   if (!value) return false;

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -35,6 +35,7 @@ import {
 import { migrateLegacyEncryptedString } from "./encryption";
 import { invalidateDbCache } from "./readCache";
 import { rowToCamel } from "./caseMapping";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 // Re-exported so existing call sites that pull these helpers off the core module keep working.
 export { toSnakeCase, toCamelCase, objToSnake, rowToCamel, cleanNulls } from "./caseMapping";
 import {
@@ -795,14 +796,6 @@ function offloadLegacyCallLogDetails(db: SqliteDatabase) {
   }
 }
 
-function isAutomatedTestProcess(): boolean {
-  return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((arg) => arg.includes("test")))
-  );
-}
 
 function shouldRunStartupDbHealthCheck(): boolean {
   if (process.env.OMNIROUTE_FORCE_DB_HEALTHCHECK === "1") return true;

--- a/src/lib/db/migrationRunner.ts
+++ b/src/lib/db/migrationRunner.ts
@@ -19,6 +19,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import type { SqliteAdapter } from "./adapters/types";
 import { DEFAULT_DATABASE_SETTINGS } from "@/types/databaseSettings";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 import {
   RENAMED_MIGRATION_COMPATIBILITY,
   LEGACY_VERSION_SLOT_MIGRATIONS,
@@ -883,10 +884,7 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
 
   // ── Safety Check 2: Mass-migration detection (abort if existing DB + many migrations) ──
   // Skip in test environments where fresh DBs legitimately have many pending migrations.
-  const isTestEnvironment =
-    process.env.NODE_ENV === "test" ||
-    process.env.VITEST !== undefined ||
-    (typeof process.argv !== "undefined" && process.argv.some((arg) => arg.includes("test")));
+  const isTestEnvironment = isAutomatedTestProcess();
 
   // #3416: resolve the threshold at call time so OMNIROUTE_MAX_PENDING_MIGRATIONS
   // can override the default (0 disables the check). The abort message below

--- a/src/lib/initCloudSync.ts
+++ b/src/lib/initCloudSync.ts
@@ -1,18 +1,11 @@
 import initializeCloudSync from "@/shared/services/initializeCloudSync";
 import { startBudgetResetJob } from "@/lib/jobs/budgetResetJob";
 import { startModelSyncScheduler } from "@/shared/services/modelSyncScheduler";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 // Initialize runtime background sync services once per server process.
 let initialized = false;
 
-function isAutomatedTestProcess(
-  env: NodeJS.ProcessEnv = process.env,
-  argv: string[] = process.argv
-): boolean {
-  return (
-    env.NODE_ENV === "test" || env.VITEST !== undefined || argv.some((arg) => arg.includes("test"))
-  );
-}
 
 export function shouldSkipCloudSyncInitialization(
   env: NodeJS.ProcessEnv = process.env,

--- a/src/lib/localHealthCheck.ts
+++ b/src/lib/localHealthCheck.ts
@@ -12,6 +12,7 @@
  */
 
 import { getProviderNodes } from "@/lib/localDb";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -37,14 +38,6 @@ function isBuildProcess(): boolean {
   return typeof process !== "undefined" && process.env.NEXT_PHASE === "phase-production-build";
 }
 
-function isAutomatedTestProcess(): boolean {
-  return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((arg) => arg.includes("test")))
-  );
-}
 
 // ── State (globalThis survives HMR re-evaluation) ───────────────────────
 

--- a/src/lib/quota/connectionRecovery.ts
+++ b/src/lib/quota/connectionRecovery.ts
@@ -22,6 +22,7 @@
  */
 
 import { cooldownUntilMs } from "@omniroute/open-sse/services/accountFallback.ts";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 /**
  * The transient-cooldown status written by `markAccountUnavailable()` for a
@@ -223,14 +224,6 @@ function isBuildProcess(): boolean {
   return typeof process !== "undefined" && process.env.NEXT_PHASE === "phase-production-build";
 }
 
-function isAutomatedTestProcess(): boolean {
-  return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((arg) => arg.includes("test")))
-  );
-}
 
 function isRecoverySchedulerDisabled(): boolean {
   return (

--- a/src/lib/resilience/modelLockoutSettings.ts
+++ b/src/lib/resilience/modelLockoutSettings.ts
@@ -1,3 +1,5 @@
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
+
 export interface ModelLockoutSettings {
   enabled: boolean;
   errorCodes: number[];
@@ -56,10 +58,7 @@ export function resolveModelLockoutSettings(
 ): ModelLockoutSettings {
   const record = asRecord(settings);
   const raw = asRecord(record.modelLockout);
-  const isTest =
-    process.env.NODE_ENV === "test" ||
-    process.execArgv.includes("--test") ||
-    process.argv.some((arg) => typeof arg === "string" && arg.includes("test"));
+  const isTest = isAutomatedTestProcess();
 
   const baseCooldownMs = toInteger(
     raw.baseCooldownMs,

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -25,6 +25,7 @@ import {
   refreshCopilotToken,
 } from "@omniroute/open-sse/services/tokenRefresh.ts";
 import { pickMaskedDisplayValue } from "@/shared/utils/maskEmail";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 const TICK_MS = 60 * 1000; // sweep interval: every 60 seconds
@@ -38,14 +39,6 @@ function isBuildProcess(): boolean {
   return typeof process !== "undefined" && process.env.NEXT_PHASE === "phase-production-build";
 }
 
-function isAutomatedTestProcess(): boolean {
-  return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.VITEST !== undefined ||
-      process.argv.some((arg) => arg.includes("test")))
-  );
-}
 
 function getConnectionLogLabel(conn: { name?: string; email?: string; id?: string }): string {
   return pickMaskedDisplayValue([conn.name, conn.email], conn.id || "-");

--- a/src/server/ws/liveServer.ts
+++ b/src/server/ws/liveServer.ts
@@ -27,6 +27,7 @@ import { emit, on, onAny, getEventHistory, type HistoryEntry } from "@/lib/event
 import type { DashboardEventName, DashboardEventMap, DashboardChannel } from "@/lib/events/types";
 
 import { CHANNEL_EVENTS, getChannelForEvent } from "@/lib/events/types";
+import { isAutomatedTestProcess, isBuildProcess } from "@/shared/utils/testProcess";
 
 import {
   buildAllowedOrigins,
@@ -608,10 +609,7 @@ export async function startLiveDashboardServer(
 
 function isBuildOrTest(): boolean {
   return (
-    process.env.NEXT_PHASE === "phase-production-build" ||
-    process.env.NODE_ENV === "test" ||
-    process.env.VITEST !== undefined ||
-    process.argv.some((arg) => arg.includes("test"))
+    isBuildProcess() || isAutomatedTestProcess()
   );
 }
 

--- a/src/shared/utils/testProcess.ts
+++ b/src/shared/utils/testProcess.ts
@@ -1,0 +1,44 @@
+/**
+ * "Am I running under an automated test runner?" — one answer, one place.
+ *
+ * Eleven subsystems each carried their own copy of this check, and every copy decided it with
+ * `process.argv.some((arg) => arg.includes("test"))`. That substring test is wrong in a way that is
+ * easy to miss and expensive to hit: `'latest'.includes('test') === true`. Any argv carrying a
+ * `latest` segment — a release symlink (`/opt/app/latest/server.js`), an npm/npx cache path, a
+ * `--model=latest` flag — silently flipped the process into "test mode", and the subsystems gated on
+ * it turned themselves off without a word. The worst of them is `src/lib/db/backup.ts`:
+ * `isSqliteAutoBackupDisabled()` returns true, so SQLite auto-backup simply never runs. Same class of
+ * silent disable for migrations, cloud sync, the health checks and quota recovery.
+ *
+ * Matching rules:
+ *  - env first (`NODE_ENV=test`, `VITEST`) — unchanged behaviour.
+ *  - argv: `test`/`tests` only as a WHOLE token delimited by a path separator, dot or dash — so
+ *    `--test`, `tests/unit/x.test.ts` and `src/x.test.ts` match, while `latest`, `protest`,
+ *    `contest` and `attestation` do not.
+ *  - argv: known runner binaries (vitest/jest/mocha/ava/tap), which have no delimiter before "test".
+ *
+ * argv and env are parameters rather than globals so the behaviour is testable: under a test runner
+ * the globals always say "test", which is exactly why the substring bug could never be caught.
+ */
+
+/** `test`/`tests` as a whole token: `--test`, `/tests/`, `.test.ts` — but never `latest`/`protest`. */
+const TEST_TOKEN_RE = /(^|[\\/.-])tests?([\\/.-]|$)/i;
+
+/** Runner binaries: no delimiter precedes "test" in "vitest", so they need their own rule. */
+const TEST_RUNNER_RE = /(^|[\\/])(vitest|jest|mocha|ava|tap)(\.[cm]?js)?$/i;
+
+export function isAutomatedTestProcess(
+  // execArgv too: `node --test x.js` puts `--test` in execArgv, not argv (modelLockoutSettings was the
+  // only copy that remembered to look there — now every caller gets it).
+  argv: readonly string[] = typeof process !== "undefined" ? [...process.argv, ...process.execArgv] : [],
+  env: NodeJS.ProcessEnv = typeof process !== "undefined" ? process.env : ({} as NodeJS.ProcessEnv)
+): boolean {
+  if (env.NODE_ENV === "test") return true;
+  if (env.VITEST !== undefined) return true;
+  return argv.some((arg) => typeof arg === "string" && (TEST_TOKEN_RE.test(arg) || TEST_RUNNER_RE.test(arg)));
+}
+
+/** Next.js production build phase — several call sites pair this with the test check. */
+export function isBuildProcess(env: NodeJS.ProcessEnv = process.env): boolean {
+  return typeof process !== "undefined" && env.NEXT_PHASE === "phase-production-build";
+}

--- a/tests/unit/test-process-detection.test.ts
+++ b/tests/unit/test-process-detection.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
+
+// Regression guard for the substring bug: eleven subsystems decided "am I under a test runner?" with
+// `process.argv.some((a) => a.includes("test"))`. JavaScript agrees that 'latest'.includes('test') is
+// true, so ANY argv carrying a `latest` path segment — a release symlink like /opt/app/latest/server.js,
+// an npm cache path, a `--model=latest` flag — silently put the process into "test mode". For
+// src/lib/db/backup.ts that means isSqliteAutoBackupDisabled() returns true: no SQLite auto-backup, no
+// warning. Same class for migrationRunner, cloud sync, health checks and quota recovery.
+//
+// argv/env are parameters (not read off the global) precisely so this file can assert the negative
+// cases — under the test runner the globals always say "test", which is what made the bug invisible.
+
+const NO_ENV = {} as NodeJS.ProcessEnv;
+
+test("a 'latest' path segment is NOT a test run (the bug that disabled backups)", () => {
+  assert.equal(isAutomatedTestProcess(["node", "/opt/omniroute/latest/server.js"], NO_ENV), false);
+  assert.equal(isAutomatedTestProcess(["node", "C:\\apps\\latest\\bin\\omniroute.mjs", "serve"], NO_ENV), false);
+});
+
+test("other words merely containing 'test' are not test runs either", () => {
+  for (const argv of [
+    ["node", "/srv/protest/app.js"],
+    ["node", "/home/u/contest-bot/index.js"],
+    ["node", "server.js", "--model=latest"],
+    ["node", "/opt/attestation/run.js"],
+  ]) {
+    assert.equal(isAutomatedTestProcess(argv, NO_ENV), false, `argv should not read as a test run: ${argv.join(" ")}`);
+  }
+});
+
+test("the real runners are still detected", () => {
+  assert.equal(isAutomatedTestProcess(["node", "--test", "tests/unit/foo.test.ts"], NO_ENV), true, "node --test");
+  assert.equal(isAutomatedTestProcess(["node", "/repo/tests/unit/foo.test.ts"], NO_ENV), true, "a tests/ path");
+  assert.equal(isAutomatedTestProcess(["node", "/repo/src/foo.test.ts"], NO_ENV), true, "a *.test.ts file");
+  assert.equal(isAutomatedTestProcess(["node", "/repo/node_modules/.bin/vitest", "run"], NO_ENV), true, "vitest binary");
+  assert.equal(isAutomatedTestProcess(["node", "/repo/node_modules/.bin/jest"], NO_ENV), true, "jest binary");
+});
+
+test("env still wins, as before", () => {
+  assert.equal(isAutomatedTestProcess(["node", "server.js"], { NODE_ENV: "test" } as NodeJS.ProcessEnv), true);
+  assert.equal(isAutomatedTestProcess(["node", "server.js"], { VITEST: "1" } as NodeJS.ProcessEnv), true);
+  assert.equal(isAutomatedTestProcess(["node", "server.js"], { NODE_ENV: "production" } as NodeJS.ProcessEnv), false);
+});
+
+test("a production serve is never a test run", () => {
+  assert.equal(
+    isAutomatedTestProcess(["C:\\Program Files\\nodejs\\node.exe", "bin/omniroute.mjs", "serve"], { NODE_ENV: "production" } as NodeJS.ProcessEnv),
+    false
+  );
+});


### PR DESCRIPTION
## The bug

Eleven subsystems decide *"am I running under a test runner?"* with:

```js
process.argv.some((arg) => arg.includes("test"))
```

`'latest'.includes('test') === true`. So **any** argv carrying a `latest` segment silently puts the process into test mode:

- a release symlink — `/opt/omniroute/latest/server.js`
- an npm/npx cache path containing `latest`
- a flag like `--model=latest`

Also matched: `protest`, `contest`, `attestation`, `/srv/latest-build/…`.

## Why it matters

The worst consequence is `src/lib/db/backup.ts`:

```js
function isSqliteAutoBackupDisabled() {
  const isTest = … || process.argv.some((a) => a.includes("test"));
  if (isTest) return true;   // ← SQLite auto-backup never runs
```

No warning, no log — backups just don't happen. The same substring also gates:

| File | What silently turns off |
|---|---|
| `src/lib/db/backup.ts` | SQLite auto-backup |
| `src/lib/db/migrationRunner.ts` | pending-migration check |
| `src/lib/db/core.ts` | managed DB backup |
| `src/lib/initCloudSync.ts` | cloud sync init |
| `src/lib/localHealthCheck.ts`, `src/lib/tokenHealthCheck.ts` | health checks |
| `src/lib/quota/connectionRecovery.ts` | quota recovery |
| `src/lib/credentialHealth/scheduler.ts` | credential health scheduler |
| `src/lib/config/runtimeSettings.ts`, `src/lib/resilience/modelLockoutSettings.ts` | runtime/lockout settings |
| `src/server/ws/liveServer.ts` | WS live server |

All of them fail **silent**.

## The fix

One helper — `src/shared/utils/testProcess.ts` — replaces all eleven copies:

- **env first** (`NODE_ENV=test`, `VITEST`) — unchanged behaviour.
- **argv**: `test`/`tests` only as a *whole token* delimited by a path separator, dot or dash — `--test`, `tests/unit/x.test.ts`, `src/x.test.ts` still match; `latest`, `protest`, `contest`, `attestation` no longer do.
- **argv**: runner binaries (`vitest`/`jest`/`mocha`/`ava`/`tap`), which have no delimiter before `test`.
- **execArgv as well as argv** — `node --test x.js` puts `--test` in `execArgv`. `modelLockoutSettings` was the only copy that looked there; now every caller does.

`argv`/`env` are parameters rather than globals **so the negatives are testable** — under a test runner the globals always say "test", which is exactly why this could never be caught before.

## Tests

`tests/unit/test-process-detection.test.ts` — 5 tests: the regression (`latest` path is not a test run), other `test`-containing words, the runners that must keep matching, env precedence, and a production `serve` invocation.

```
ℹ pass 5
ℹ fail 0
```

## Verification

- `npm run typecheck:core` → exit 0
- `eslint` on every touched file → exit 0
- `tests/unit/check-migration-numbering.test.ts` → 15/15
- `tests/unit/cli-backup-command.test.ts` → 5/5
- `tests/unit/cloud-sync.test.ts` → 5/5

13 files changed, +112 −74.