### PR TITLE
Preserve model test timeout diagnostics

### DIFF
--- a/src/lib/api/modelTestRunner.ts
+++ b/src/lib/api/modelTestRunner.ts
@@ -210,6 +210,27 @@ export interface SingleModelTestResult {
   retryAfter?: number;
 }
 
+export function createModelTestTimeoutError(timeoutMs: number): Error {
+  const error = new Error(`Model test timed out after ${timeoutMs}ms`);
+  error.name = "TimeoutError";
+  return error;
+}
+
+function buildModelTestTimeoutResult(
+  modelId: string,
+  latencyMs: number,
+  timeoutMs: number
+): SingleModelTestResult {
+  return {
+    modelId,
+    status: "error",
+    latencyMs,
+    httpStatus: 504,
+    error: `Timeout (${Math.round(timeoutMs / 1000)}s)`,
+    isTimeout: true,
+  };
+}
+
 /**
  * Run a single model test. When `connectionId` is provided, wraps the
  * upstream call with `withRateLimit` (Bottleneck). Returns a plain
@@ -251,7 +272,7 @@ export async function runSingleModelTest(
   let timedOut = false;
   const timeoutHandle = setTimeout(() => {
     timedOut = true;
-    controller.abort();
+    controller.abort(createModelTestTimeoutError(effectiveTimeoutMs));
   }, effectiveTimeoutMs);
 
   const runInner = async (signal: AbortSignal): Promise<Response> => {
@@ -283,17 +304,10 @@ export async function runSingleModelTest(
     clearTimeout(timeoutHandle);
     const latencyMs = Date.now() - startTime;
     const errorName = getErrorName(error);
+    if (timedOut) {
+      return buildModelTestTimeoutResult(fullModelStr, latencyMs, effectiveTimeoutMs);
+    }
     if (errorName === "AbortError") {
-      if (timedOut) {
-        return {
-          modelId: fullModelStr,
-          status: "error",
-          latencyMs,
-          httpStatus: 500,
-          error: `Timeout (${Math.round(effectiveTimeoutMs / 1000)}s)`,
-          isTimeout: true,
-        };
-      }
       // AbortError without timeout = withRateLimit queue rejection / abort.
       // Surface as rate_limited so the batch endpoint can stop the loop.
       return {
@@ -316,6 +330,13 @@ export async function runSingleModelTest(
   clearTimeout(timeoutHandle);
 
   const latencyMs = Date.now() - startTime;
+
+  // chatCore converts upstream failures into a Response. Preserve the local
+  // controller's more precise timeout diagnosis instead of surfacing the
+  // converted 499/504 response as a generic provider failure.
+  if (timedOut) {
+    return buildModelTestTimeoutResult(fullModelStr, latencyMs, effectiveTimeoutMs);
+  }
 
   if (res.status === 429) {
     const retryAfter = parseRetryAfterHeader(res.headers.get("retry-after"));

--- a/tests/unit/model-test-runner.test.ts
+++ b/tests/unit/model-test-runner.test.ts
@@ -4,6 +4,7 @@ import {
   parseRetryAfterHeader,
   detectTestKind,
   extractProviderErrorMessage,
+  createModelTestTimeoutError,
   resolveModelTestTimeoutMs,
 } from "@/lib/api/modelTestRunner.ts";
 
@@ -116,4 +117,10 @@ test("resolveModelTestTimeoutMs extends Dola Pro model checks", () => {
 test("resolveModelTestTimeoutMs leaves ordinary models unchanged", () => {
   assert.equal(resolveModelTestTimeoutMs("doubao-web", "dola-speed", 10_000), 10_000);
   assert.equal(resolveModelTestTimeoutMs("openai", "dola-pro", 10_000), 10_000);
+});
+
+test("createModelTestTimeoutError preserves a distinct timeout reason", () => {
+  const error = createModelTestTimeoutError(20_000);
+  assert.equal(error.name, "TimeoutError");
+  assert.equal(error.message, "Model test timed out after 20000ms");
 });


### PR DESCRIPTION
## Summary

- Keep local timeout failures distinguishable from generic provider errors.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- Updated model test runner unit tests to verify distinct timeout errors.

## Coverage Notes

- Unit coverage verifies the timeout error identity and diagnostic message.

## Reviewer Notes

- Timeout failures now take precedence over converted upstream responses, preserving accurate timeout diagnostics.

