### PR TITLE
Reject invalid output token budgets

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -14,6 +14,7 @@ import { buildPostCallGuardrailContext } from "./chatCore/postCallGuardrailConte
 import { storeSemanticCacheResponse } from "./chatCore/semanticCacheStore.ts";
 import { buildNonStreamingResponseHeaders } from "./chatCore/nonStreamingResponseHeaders.ts";
 import { buildNonStreamingJsonResponse } from "./chatCore/nonStreamingJsonResponse.ts";
+import { enforceOutputTokenBudget } from "./chatCore/outputTokenBudget.ts";
 import { maybeConvertJsonBodyToSse } from "./chatCore/jsonBodyToSse.ts";
 import { assembleStreamingResponseHeaders } from "./chatCore/streamingResponseHeaders.ts";
 import { storeStreamingSemanticCacheResponse } from "./chatCore/streamingSemanticCacheStore.ts";
@@ -1612,6 +1613,45 @@ export async function handleChatCore({
       `Skipping compression check: body=${!!body}, hasMessages=${Array.isArray(allMessages)}`
     );
   }
+
+  // Re-check the concrete target after all compression passes. Combo compatibility
+  // filtering is advisory and may preserve an all-incompatible pool; this is the
+  // hard boundary that prevents a too-large prompt (or a negative token budget)
+  // from reaching an OpenAI-compatible upstream such as NVIDIA NIM.
+  const finalCompressionBody = adaptBodyForCompression(body as Record<string, unknown>).body;
+  const finalMessages =
+    finalCompressionBody?.messages || body?.contents || body?.request?.contents || [];
+  const finalEstimatedInputTokens =
+    estimateTokens(finalMessages) + (Array.isArray(body?.tools) ? estimateTokens(body.tools) : 0);
+  const finalContextLimit = getTokenLimit(provider, effectiveModel);
+  const outputBudget = enforceOutputTokenBudget(
+    body as Record<string, unknown>,
+    finalEstimatedInputTokens,
+    finalContextLimit
+  );
+  if (!outputBudget.ok) {
+    const message =
+      `Input exceeds the context window for ${provider}/${effectiveModel}: ` +
+      `estimated ${outputBudget.estimatedInputTokens} input tokens, limit ${outputBudget.contextLimit}. ` +
+      "Reduce the prompt or route to a model with a larger context window.";
+    log?.warn?.("CONTEXT", message);
+    trackPendingRequest(model, provider, connectionId, false);
+    return createErrorResult(
+      HTTP_STATUS.BAD_REQUEST,
+      message,
+      null,
+      "context_length_exceeded",
+      "invalid_request_error"
+    );
+  }
+  if (outputBudget.adjustedFields.length > 0) {
+    log?.info?.(
+      "CONTEXT",
+      `Adjusted invalid or oversized output token fields (${outputBudget.adjustedFields.join(", ")}); ` +
+        `${outputBudget.availableOutputTokens} tokens remain for output`
+    );
+  }
+  body = outputBudget.body;
 
   let translatedBody = body;
   const isClaudePassthrough = sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.CLAUDE;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1618,11 +1618,16 @@ export async function handleChatCore({
   // filtering is advisory and may preserve an all-incompatible pool; this is the
   // hard boundary that prevents a too-large prompt (or a negative token budget)
   // from reaching an OpenAI-compatible upstream such as NVIDIA NIM.
-  const finalCompressionBody = adaptBodyForCompression(body as Record<string, unknown>).body;
+  const finalCompressionBody = body
+    ? adaptBodyForCompression(body as Record<string, unknown>).body
+    : null;
   const finalMessages =
     finalCompressionBody?.messages || body?.contents || body?.request?.contents || [];
   const finalEstimatedInputTokens =
-    estimateTokens(finalMessages) + (Array.isArray(body?.tools) ? estimateTokens(body.tools) : 0);
+    estimateTokens(finalMessages) +
+    (Array.isArray(body?.tools) ? estimateTokens(body.tools) : 0) +
+    estimateTokens(body?.system) +
+    estimateTokens(body?.instructions);
   const finalContextLimit = getTokenLimit(provider, effectiveModel);
   const outputBudget = enforceOutputTokenBudget(
     body as Record<string, unknown>,

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -138,6 +138,7 @@ import {
   STREAM_READINESS_TIMEOUT_MS,
   ANTIGRAVITY_PRE_RESPONSE_TIMEOUT_CODE,
   STREAM_RECOVERY,
+  DEFAULT_MAX_TOKENS,
 } from "../config/constants.ts";
 import { createRecoverableStream, makeContinuationBody } from "../services/streamRecovery.ts";
 import {
@@ -1632,7 +1633,8 @@ export async function handleChatCore({
   const outputBudget = enforceOutputTokenBudget(
     body as Record<string, unknown>,
     finalEstimatedInputTokens,
-    finalContextLimit
+    finalContextLimit,
+    targetFormat === FORMATS.CLAUDE && sourceFormat !== FORMATS.CLAUDE ? DEFAULT_MAX_TOKENS : 0
   );
   if (!outputBudget.ok) {
     const message =

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1623,7 +1623,12 @@ export async function handleChatCore({
     ? adaptBodyForCompression(body as Record<string, unknown>).body
     : null;
   const finalMessages =
-    finalCompressionBody?.messages || body?.contents || body?.request?.contents || [];
+    finalCompressionBody?.messages ||
+    body?.contents ||
+    body?.request?.contents ||
+    (body?.input && typeof body.input === "object" && !Array.isArray(body.input)
+      ? body.input
+      : []);
   const finalEstimatedInputTokens =
     estimateTokens(finalMessages) +
     (Array.isArray(body?.tools) ? estimateTokens(body.tools) : 0) +

--- a/open-sse/handlers/chatCore/outputTokenBudget.ts
+++ b/open-sse/handlers/chatCore/outputTokenBudget.ts
@@ -1,0 +1,66 @@
+export const OUTPUT_TOKEN_FIELDS = ["max_tokens", "max_completion_tokens"] as const;
+
+export type OutputTokenBudgetResult =
+  | {
+      ok: true;
+      body: Record<string, unknown>;
+      availableOutputTokens: number;
+      adjustedFields: string[];
+    }
+  | {
+      ok: false;
+      estimatedInputTokens: number;
+      contextLimit: number;
+    };
+
+/**
+ * Enforce the target model's context budget immediately before translation.
+ *
+ * Compression and combo selection are best-effort: a request may still be too
+ * large for a concrete target, and some OpenAI-compatible gateways derive an
+ * internal max_tokens value by subtracting the prompt from the context window.
+ * Reject that target locally instead of allowing the derived value to become
+ * negative upstream. Positive client limits are capped to the remaining room;
+ * invalid numeric limits are removed.
+ */
+export function enforceOutputTokenBudget(
+  body: Record<string, unknown>,
+  estimatedInputTokens: number,
+  contextLimit: number
+): OutputTokenBudgetResult {
+  const normalizedInputTokens = Math.max(0, Math.ceil(estimatedInputTokens));
+  const normalizedContextLimit = Math.max(1, Math.floor(contextLimit));
+  const availableOutputTokens = normalizedContextLimit - normalizedInputTokens;
+
+  if (availableOutputTokens < 1) {
+    return {
+      ok: false,
+      estimatedInputTokens: normalizedInputTokens,
+      contextLimit: normalizedContextLimit,
+    };
+  }
+
+  let nextBody = body;
+  const adjustedFields: string[] = [];
+  for (const field of OUTPUT_TOKEN_FIELDS) {
+    const value = nextBody[field];
+    if (typeof value !== "number") continue;
+
+    const normalized = Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
+    if (normalized === null) {
+      if (nextBody === body) nextBody = { ...body };
+      delete nextBody[field];
+      adjustedFields.push(field);
+      continue;
+    }
+
+    const capped = Math.min(normalized, availableOutputTokens);
+    if (capped !== value) {
+      if (nextBody === body) nextBody = { ...body };
+      nextBody[field] = capped;
+      adjustedFields.push(field);
+    }
+  }
+
+  return { ok: true, body: nextBody, availableOutputTokens, adjustedFields };
+}

--- a/open-sse/handlers/chatCore/outputTokenBudget.ts
+++ b/open-sse/handlers/chatCore/outputTokenBudget.ts
@@ -1,4 +1,8 @@
-export const OUTPUT_TOKEN_FIELDS = ["max_tokens", "max_completion_tokens"] as const;
+export const OUTPUT_TOKEN_FIELDS = [
+  "max_tokens",
+  "max_completion_tokens",
+  "max_output_tokens",
+] as const;
 
 export type OutputTokenBudgetResult =
   | {
@@ -13,6 +17,38 @@ export type OutputTokenBudgetResult =
       contextLimit: number;
     };
 
+type OutputTokenAdjustment = { field: string; value?: number; remove?: boolean };
+
+function getOutputTokenAdjustment(
+  field: string,
+  value: unknown,
+  availableOutputTokens: number
+): OutputTokenAdjustment | null {
+  if (typeof value !== "number") return null;
+  if (!Number.isFinite(value) || value <= 0) return { field, remove: true };
+
+  const capped = Math.min(Math.floor(value), availableOutputTokens);
+  return capped === value ? null : { field, value: capped };
+}
+
+function adjustOutputTokenFields(
+  body: Record<string, unknown>,
+  availableOutputTokens: number
+): Pick<Extract<OutputTokenBudgetResult, { ok: true }>, "body" | "adjustedFields"> {
+  const adjustments = OUTPUT_TOKEN_FIELDS.map((field) =>
+    getOutputTokenAdjustment(field, body[field], availableOutputTokens)
+  ).filter((adjustment): adjustment is OutputTokenAdjustment => adjustment !== null);
+  if (adjustments.length === 0) return { body, adjustedFields: [] };
+
+  const nextBody = { ...body };
+  for (const adjustment of adjustments) {
+    if (adjustment.remove) delete nextBody[adjustment.field];
+    else nextBody[adjustment.field] = adjustment.value;
+  }
+
+  return { body: nextBody, adjustedFields: adjustments.map(({ field }) => field) };
+}
+
 /**
  * Enforce the target model's context budget immediately before translation.
  *
@@ -24,7 +60,7 @@ export type OutputTokenBudgetResult =
  * invalid numeric limits are removed.
  */
 export function enforceOutputTokenBudget(
-  body: Record<string, unknown>,
+  body: Record<string, unknown> | null | undefined,
   estimatedInputTokens: number,
   contextLimit: number
 ): OutputTokenBudgetResult {
@@ -40,27 +76,15 @@ export function enforceOutputTokenBudget(
     };
   }
 
-  let nextBody = body;
-  const adjustedFields: string[] = [];
-  for (const field of OUTPUT_TOKEN_FIELDS) {
-    const value = nextBody[field];
-    if (typeof value !== "number") continue;
-
-    const normalized = Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
-    if (normalized === null) {
-      if (nextBody === body) nextBody = { ...body };
-      delete nextBody[field];
-      adjustedFields.push(field);
-      continue;
-    }
-
-    const capped = Math.min(normalized, availableOutputTokens);
-    if (capped !== value) {
-      if (nextBody === body) nextBody = { ...body };
-      nextBody[field] = capped;
-      adjustedFields.push(field);
-    }
+  if (!body) {
+    return {
+      ok: true,
+      body: {},
+      availableOutputTokens,
+      adjustedFields: [],
+    };
   }
 
-  return { ok: true, body: nextBody, availableOutputTokens, adjustedFields };
+  const adjusted = adjustOutputTokenFields(body, availableOutputTokens);
+  return { ok: true, ...adjusted, availableOutputTokens };
 }

--- a/open-sse/handlers/chatCore/outputTokenBudget.ts
+++ b/open-sse/handlers/chatCore/outputTokenBudget.ts
@@ -31,6 +31,13 @@ function getOutputTokenAdjustment(
   return capped === value ? null : { field, value: capped };
 }
 
+function hasTranslatorOutputTokenLimit(body: Record<string, unknown>): boolean {
+  return ["max_tokens", "max_completion_tokens"].some((field) => {
+    const value = body[field];
+    return typeof value === "number" && Number.isFinite(value) && value > 0;
+  });
+}
+
 function adjustOutputTokenFields(
   body: Record<string, unknown>,
   availableOutputTokens: number
@@ -62,10 +69,12 @@ function adjustOutputTokenFields(
 export function enforceOutputTokenBudget(
   body: Record<string, unknown> | null | undefined,
   estimatedInputTokens: number,
-  contextLimit: number
+  contextLimit: number,
+  defaultOutputTokens = 0
 ): OutputTokenBudgetResult {
   const normalizedInputTokens = Math.max(0, Math.ceil(estimatedInputTokens));
   const normalizedContextLimit = Math.max(1, Math.floor(contextLimit));
+  const normalizedDefaultOutputTokens = Math.max(0, Math.floor(defaultOutputTokens));
   const availableOutputTokens = normalizedContextLimit - normalizedInputTokens;
 
   if (availableOutputTokens < 1) {
@@ -77,11 +86,29 @@ export function enforceOutputTokenBudget(
   }
 
   if (!body) {
+    if (normalizedDefaultOutputTokens > availableOutputTokens) {
+      return {
+        ok: false,
+        estimatedInputTokens: normalizedInputTokens,
+        contextLimit: normalizedContextLimit,
+      };
+    }
     return {
       ok: true,
       body: {},
       availableOutputTokens,
       adjustedFields: [],
+    };
+  }
+
+  if (
+    normalizedDefaultOutputTokens > availableOutputTokens &&
+    !hasTranslatorOutputTokenLimit(body)
+  ) {
+    return {
+      ok: false,
+      estimatedInputTokens: normalizedInputTokens,
+      contextLimit: normalizedContextLimit,
     };
   }
 

--- a/tests/unit/chatcore-sanitization.test.ts
+++ b/tests/unit/chatcore-sanitization.test.ts
@@ -178,7 +178,7 @@ test("chatCore sanitization normalizes max_output_tokens into max_tokens", async
     },
   });
 
-  assert.equal(copied.call.body.max_tokens, 0);
+  assert.equal(copied.call.body.max_tokens, undefined);
   assert.equal("max_output_tokens" in copied.call.body, false);
   assert.equal(preserved.call.body.max_tokens, 7);
   assert.equal("max_output_tokens" in preserved.call.body, false);

--- a/tests/unit/output-token-budget.test.ts
+++ b/tests/unit/output-token-budget.test.ts
@@ -54,3 +54,13 @@ test("accepts a missing request body when output budget remains", () => {
     adjustedFields: [],
   });
 });
+
+test("rejects when a Claude target's default output budget does not fit", () => {
+  const result = enforceOutputTokenBudget({}, 70_000, 128_000, 64_000);
+
+  assert.deepEqual(result, {
+    ok: false,
+    estimatedInputTokens: 70_000,
+    contextLimit: 128_000,
+  });
+});

--- a/tests/unit/output-token-budget.test.ts
+++ b/tests/unit/output-token-budget.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { enforceOutputTokenBudget } from "../../open-sse/handlers/chatCore/outputTokenBudget.ts";
+
+test("rejects a prompt that cannot leave one output token", () => {
+  const result = enforceOutputTokenBudget({ max_tokens: 8192 }, 527_058, 128_000);
+
+  assert.deepEqual(result, {
+    ok: false,
+    estimatedInputTokens: 527_058,
+    contextLimit: 128_000,
+  });
+});
+
+test("caps a positive output budget to the target's remaining context", () => {
+  const input = { messages: [], max_tokens: 12_000 };
+  const result = enforceOutputTokenBudget(input, 127_000, 128_000);
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.body.max_tokens, 1_000);
+  assert.equal(input.max_tokens, 12_000, "must not mutate the shared combo request body");
+});
+
+test("removes non-positive numeric output limits before upstream dispatch", () => {
+  const result = enforceOutputTokenBudget(
+    { max_tokens: -398_464, max_completion_tokens: 0 },
+    1_000,
+    128_000
+  );
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal("max_tokens" in result.body, false);
+  assert.equal("max_completion_tokens" in result.body, false);
+});

--- a/tests/unit/output-token-budget.test.ts
+++ b/tests/unit/output-token-budget.test.ts
@@ -35,3 +35,22 @@ test("removes non-positive numeric output limits before upstream dispatch", () =
   assert.equal("max_tokens" in result.body, false);
   assert.equal("max_completion_tokens" in result.body, false);
 });
+
+test("caps max_output_tokens to the target's remaining context", () => {
+  const result = enforceOutputTokenBudget({ max_output_tokens: 12_000 }, 127_000, 128_000);
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.body.max_output_tokens, 1_000);
+});
+
+test("accepts a missing request body when output budget remains", () => {
+  const result = enforceOutputTokenBudget(null, 1_000, 128_000);
+
+  assert.deepEqual(result, {
+    ok: true,
+    body: {},
+    availableOutputTokens: 127_000,
+    adjustedFields: [],
+  });
+});


### PR DESCRIPTION
## Summary

- Prevent requests from exceeding the target model’s context window by rejecting oversized prompts and capping or removing invalid output token limits before upstream dispatch.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- Added unit tests for output token budget enforcement.

## Coverage Notes

- Unit tests cover context overflow rejection, output budget capping, and removal of invalid numeric limits in `open-sse/`.

## Reviewer Notes

- The final target context check runs immediately before request translation and may adjust the shared request body for upstream dispatch.