### PR TITLE
fix(server): wire credential health scheduler into serve boot

### DIFF
--- a/src/server-init.ts
+++ b/src/server-init.ts
@@ -116,6 +116,19 @@ async function startServer() {
     startBudgetResetJob();
     startReasoningCacheCleanupJob();
     startCleanupScheduler();
+    // Credential health scheduler: periodically re-probe provider connections so a
+    // recovered web-session/key flips test_status back to active without a manual
+    // re-test (fixes providers going red on startup). The module was never wired into
+    // the serve runtime, so its boot sweep never ran. Non-fatal + dynamic import — it
+    // statically pulls the provider test route, and self-guards (disabled under
+    // test/build and via OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK).
+    try {
+      const { initCredentialHealthCheck } = await import("./lib/credentialHealth/scheduler");
+      initCredentialHealthCheck();
+      startupLog.info("Credential health scheduler started");
+    } catch (err) {
+      startupLog.warn({ err }, "Credential health scheduler could not start (non-fatal)");
+    }
     startRuntimeConfigHotReload();
     startupLog.info("Server started with cloud sync initialized");
 

--- a/tests/unit/credential-health-wiring.test.ts
+++ b/tests/unit/credential-health-wiring.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Regression guard for "provider connections go red on startup and require a manual
+// re-test". Root cause: src/lib/credentialHealth/scheduler.ts was never imported by the
+// serve runtime, so initCredentialHealthCheck()'s boot sweep never ran and a recovered
+// web-session/key never flipped test_status back to active on its own.
+//
+// The scheduler self-disables under the test runner (isAutomatedTestProcess), so its
+// boot behavior can't be observed here — this asserts the wiring itself, which is the
+// exact line whose absence was the bug.
+const here = dirname(fileURLToPath(import.meta.url));
+const serverInit = readFileSync(resolve(here, "../../src/server-init.ts"), "utf8");
+
+test("server-init wires the credential health scheduler", () => {
+  assert.match(
+    serverInit,
+    /credentialHealth\/scheduler/,
+    "server-init must import the credential health scheduler module"
+  );
+  assert.match(
+    serverInit,
+    /initCredentialHealthCheck\s*\(\s*\)/,
+    "server-init must call initCredentialHealthCheck() so provider health self-heals on boot"
+  );
+});


### PR DESCRIPTION
## Problem
`src/lib/credentialHealth/scheduler.ts` was never imported by the serve runtime — zero real imports, so its top-level auto-init never fired and `initCredentialHealthCheck()`'s boot sweep never ran. Provider connections whose web-session/key had recovered stayed red (`test_status=error`) until a manual re-test — the recurring *providers go red on startup* symptom.

## Fix
Wire `initCredentialHealthCheck()` into `src/server-init.ts` after the other schedulers, via a non-fatal dynamic import (matches the plugins/pricing/arena pattern in the same file; the scheduler statically pulls the provider test route and self-guards — disabled under test/build and via `OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK`).

Safe by construction: on a successful probe `testSingleConnection` sets `test_status=active` and clears `rateLimitedUntil` (heals the badge); a failed probe only preserves the existing cooldown, so the sweep never amplifies red.

## Tests
- `tests/unit/credential-health-wiring.test.ts` — regression guard on the wiring (fails on the pre-fix file, passes after).
- `typecheck:core` ok · `check:cycles` ok · eslint clean.