### PR TITLE
feat(usage): isolate cache per key and emit billing identities

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -92,6 +92,7 @@ export {
   stripStainlessHeadersForOpenAICompat,
 } from "./base/headers.ts";
 import { sanitizeReasoningEffortForProvider } from "./base/reasoningEffort.ts";
+import { stripProviderCacheControls } from "../utils/providerCacheIsolation.ts";
 // Reasoning-effort sanitation extracted to a pure leaf; re-exported for external
 // importers (mimoThinking service + tests) that import it from "./base.ts".
 export { sanitizeReasoningEffortForProvider } from "./base/reasoningEffort.ts";
@@ -174,6 +175,8 @@ export type ExecuteInput = {
    * `context_management.clear_tool_uses` strategy so the provider clears stale
    * tool-use blocks server-side. Honored only on the genuine `claude` path. */
   contextEditing?: { enabled: boolean } | null;
+  /** Strip provider-side prompt-cache hints from the final upstream payload. */
+  disableProviderCache?: boolean;
 };
 
 export type CountTokensInput = {
@@ -580,6 +583,7 @@ export class BaseExecutor {
       skipUpstreamRetry = false,
       onCredentialsRefreshed,
       contextEditing,
+      disableProviderCache = false,
     } = input;
     const fallbackCount = this.getFallbackCount();
     let lastError: unknown = null;
@@ -1157,6 +1161,10 @@ export class BaseExecutor {
             "CONTEXT_EDITING",
             "Delegated context editing on — attached clear_tool_uses to the Claude request"
           );
+        }
+
+        if (disableProviderCache) {
+          transformedBody = stripProviderCacheControls(transformedBody);
         }
 
         let bodyString = JSON.stringify(transformedBody);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -307,6 +307,7 @@ import { generateRequestId } from "@/shared/utils/requestId";
 import { extractFacts } from "@/lib/memory/extraction";
 import { handleToolCallExecution } from "@/lib/skills/interception";
 import { OMNIROUTE_RESPONSE_HEADERS } from "@/shared/constants/headers";
+import { hasIsolatedCacheScope } from "@/shared/constants/selfServiceScopes";
 import { getClaudeCodeCompatibleRequestDefaults } from "@/lib/providers/requestDefaults";
 import {
   buildClaudeCodeCompatibleRequest,
@@ -755,6 +756,8 @@ export async function handleChatCore({
   const noLogEnabled = apiKeyInfo?.noLog === true;
   // Consolidate settings reads — fetch once, reuse throughout the request
   const settings = cachedSettings ?? (await getCachedSettings());
+  const disableProviderCache =
+    settings.promptCacheEnabled === false || hasIsolatedCacheScope(apiKeyInfo?.scopes);
   // Opt-in tool-source diagnostics (#1825): summarize the request's tool definitions
   // (count + MCP/hosted/client source breakdown + first names) as a single debug line.
   if (settings.logToolSources === true) {
@@ -841,6 +844,18 @@ export async function handleChatCore({
     typeof credentials.providerSpecificData.customUserAgent === "string"
       ? credentials.providerSpecificData.customUserAgent.trim()
       : "";
+  const providerBaseUrl =
+    credentials?.providerSpecificData &&
+    typeof credentials.providerSpecificData === "object" &&
+    typeof credentials.providerSpecificData.baseUrl === "string"
+      ? credentials.providerSpecificData.baseUrl.trim()
+      : "";
+  const providerCacheDisableStrategy =
+    credentials?.providerSpecificData &&
+    typeof credentials.providerSpecificData === "object" &&
+    typeof credentials.providerSpecificData.providerCacheDisableStrategy === "string"
+      ? credentials.providerSpecificData.providerCacheDisableStrategy.trim()
+      : "";
 
   // Upstream extra-header building extracted to chatCore/upstreamExecuteHeaders.ts (#3501); bind the
   // per-request inputs once and delegate so the existing call sites stay byte-identical.
@@ -854,6 +869,9 @@ export async function handleChatCore({
       sourceFormat,
       connectionCustomUserAgent,
       settings,
+      disableProviderCache,
+      providerBaseUrl,
+      providerCacheDisableStrategy,
     });
 
   // Default to false unless client explicitly sets stream: true (OpenAI spec compliant)
@@ -1650,14 +1668,16 @@ export async function handleChatCore({
   // Determine if we should preserve client-side cache_control headers
   // Fetch settings from DB to get user preference
   const cacheControlMode = await getCacheControlSettings().catch(() => "auto" as const);
-  const preserveCacheControl = shouldPreserveCacheControl({
-    userAgent,
-    isCombo,
-    comboStrategy,
-    targetProvider: provider,
-    targetFormat,
-    settings: { alwaysPreserveClientCache: cacheControlMode },
-  });
+  const preserveCacheControl =
+    !disableProviderCache &&
+    shouldPreserveCacheControl({
+      userAgent,
+      isCombo,
+      comboStrategy,
+      targetProvider: provider,
+      targetFormat,
+      settings: { alwaysPreserveClientCache: cacheControlMode },
+    });
 
   if (preserveCacheControl) {
     log?.debug?.(
@@ -2284,6 +2304,7 @@ export async function handleChatCore({
         credentials,
         log,
         bypassDefaultToolLimit: isOpencodeClient,
+        disableProviderCache,
       });
 
       updatePendingScope(pendingScope, {
@@ -2384,6 +2405,7 @@ export async function handleChatCore({
                           onCredentialsRefreshed,
                           skipUpstreamRetry,
                           contextEditing: { enabled: contextEditingEnabled },
+                          disableProviderCache,
                         })
                       ),
                   });
@@ -2630,6 +2652,7 @@ export async function handleChatCore({
                               onCredentialsRefreshed,
                               skipUpstreamRetry,
                               contextEditing: { enabled: contextEditingEnabled },
+                              disableProviderCache,
                             })
                           ),
                       });
@@ -3125,6 +3148,7 @@ export async function handleChatCore({
             onCredentialsRefreshed,
             skipUpstreamRetry: isCombo,
             contextEditing: { enabled: contextEditingEnabled },
+            disableProviderCache,
           })
         );
 
@@ -3339,7 +3363,13 @@ export async function handleChatCore({
           // otherwise degenerate into a 429 rate-limit storm). Connection stays
           // active since only the specific model is unavailable. (#6827)
           const notFoundCooldownMs = COOLDOWN_MS.notFound;
-          lockModel(provider, errorConnectionId, currentModel, "model_not_found", notFoundCooldownMs);
+          lockModel(
+            provider,
+            errorConnectionId,
+            currentModel,
+            "model_not_found",
+            notFoundCooldownMs
+          );
           console.warn(
             `[provider] Node ${errorConnectionId} model not found (${statusCode}) for ${currentModel} - locking model for ${Math.ceil(notFoundCooldownMs / 1000)}s (connection stays active)`
           );

--- a/open-sse/handlers/chatCore/attemptLogging.ts
+++ b/open-sse/handlers/chatCore/attemptLogging.ts
@@ -13,6 +13,7 @@
 import { extractProviderWarnings } from "@/lib/compliance/providerAudit";
 import { logAuditEvent } from "@/lib/compliance";
 import { saveCallLog } from "@/lib/usageDb";
+import { hasIsolatedCacheScope } from "@/shared/constants/selfServiceScopes";
 import { cloneBoundedChatLogPayload, truncateForLog } from "./logTruncation.ts";
 import { attachLogMeta } from "./cacheUsageMeta.ts";
 
@@ -26,7 +27,18 @@ export type PersistAttemptLogsArgs = {
   clientResponse?: unknown;
   claudeCacheMeta?: Record<string, unknown>;
   claudeCacheUsageMeta?: Record<string, unknown>;
+  semanticCacheUsageMeta?: Record<string, unknown>;
   cacheSource?: "upstream" | "semantic";
+  cacheResult?: {
+    source: string;
+    status: string;
+    scope: string;
+    scopeId: string | null;
+    avoidedInputTokens: number;
+    avoidedOutputTokens: number;
+  };
+  routedModelId?: string | null;
+  billingModelId?: string | null;
 };
 
 export type PersistAttemptLogsContext = {
@@ -48,7 +60,14 @@ export type PersistAttemptLogsContext = {
   comboStepId: unknown;
   comboExecutionKey: unknown;
   tokensCompressed: unknown;
-  apiKeyInfo: { id?: string | null; name?: string | null } | null | undefined;
+  apiKeyInfo:
+    | {
+        id?: string | null;
+        name?: string | null;
+        scopes?: string[] | null;
+      }
+    | null
+    | undefined;
   noLogEnabled: unknown;
   correlationId?: string | null;
   modelPinned?: boolean;
@@ -56,6 +75,39 @@ export type PersistAttemptLogsContext = {
 
 function toConnectionId(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function extractObservedProviderModelId(...values: unknown[]): string | null {
+  const seen = new WeakSet<object>();
+  const visit = (value: unknown, depth: number): string | null => {
+    if (!value || typeof value !== "object" || depth > 5) return null;
+    if (seen.has(value as object)) return null;
+    seen.add(value as object);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = visit(item, depth + 1);
+        if (found) return found;
+      }
+      return null;
+    }
+    const record = value as Record<string, unknown>;
+    const direct = toNonEmptyString(record.model);
+    if (direct) return direct;
+    for (const key of ["response", "data", "summary", "message", "providerResponse"]) {
+      const found = visit(record[key], depth + 1);
+      if (found) return found;
+    }
+    return null;
+  };
+  for (const value of values) {
+    const found = visit(value, 0);
+    if (found) return found;
+  }
+  return null;
 }
 
 function buildAccountRotationMeta(
@@ -85,7 +137,11 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
     clientResponse,
     claudeCacheMeta,
     claudeCacheUsageMeta,
+    semanticCacheUsageMeta,
     cacheSource,
+    cacheResult,
+    routedModelId,
+    billingModelId,
   } = args;
   const {
     provider,
@@ -190,6 +246,7 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
             }
           : null,
         claudePromptCacheUsage: claudeCacheUsageMeta,
+        semanticCache: semanticCacheUsageMeta,
       })
     ),
     error: error || null,
@@ -200,6 +257,11 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
     comboExecutionKey,
     tokensCompressed,
     cacheSource: cacheSource === "semantic" ? "semantic" : "upstream",
+    cacheResult,
+    billingContractVersion: hasIsolatedCacheScope(apiKeyInfo?.scopes) ? 2 : 1,
+    routedModelId: routedModelId ?? null,
+    providerModelId: extractObservedProviderModelId(providerResponse, responseBody),
+    billingModelId: billingModelId ?? null,
     apiKeyId: apiKeyInfo?.id || null,
     apiKeyName: apiKeyInfo?.name || null,
     noLog: noLogEnabled,

--- a/open-sse/handlers/chatCore/semanticCache.ts
+++ b/open-sse/handlers/chatCore/semanticCache.ts
@@ -1,14 +1,21 @@
-import {
-  generateSignature,
-  getCachedResponse,
-  isCacheableForRead,
-} from "@/lib/semanticCache";
+import { generateSignature, getCachedResponse, isCacheableForRead } from "@/lib/semanticCache";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { trackPendingRequest } from "@/lib/usageDb";
 import { synthesizeOpenAiSseFromJson } from "../../utils/jsonToSse.ts";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { extractUsageFromResponse } from "../usageExtractor.ts";
 import { OMNIROUTE_RESPONSE_HEADERS } from "@/shared/constants/headers";
+
+function usageTokenCount(usage: Record<string, unknown> | undefined, candidates: string[]): number {
+  if (!usage) return 0;
+  for (const candidate of candidates) {
+    const value = usage[candidate];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return 0;
+}
 
 export async function checkSemanticCache({
   semanticCacheEnabled,
@@ -51,22 +58,59 @@ export async function checkSemanticCache({
     if (cached) {
       log?.debug?.("CACHE", `Semantic cache HIT for ${model} (stream=${stream})`);
       reqLogger.logConvertedResponse(cached as Record<string, unknown>);
+      const rawCachedUsage = (cached as Record<string, unknown>)?.usage as
+        Record<string, unknown> | undefined;
       const cachedUsage =
-        extractUsageFromResponse(cached as Record<string, unknown>, provider) ||
-        ((cached as Record<string, unknown>)?.usage as Record<string, unknown> | undefined);
+        extractUsageFromResponse(cached as Record<string, unknown>, provider) || rawCachedUsage;
       const cachedCost = cachedUsage
         ? await calculateCost(provider, model, cachedUsage as Record<string, number>, {
             serviceTier: effectiveServiceTier,
           })
         : 0;
+      const avoidedInputTokens = usageTokenCount(cachedUsage, [
+        "prompt_tokens",
+        "input_tokens",
+        "inputTokens",
+      ]);
+      const avoidedOutputTokens = usageTokenCount(cachedUsage, [
+        "completion_tokens",
+        "output_tokens",
+        "outputTokens",
+      ]);
       persistAttemptLogs({
         status: 200,
-        tokens: (cached as Record<string, unknown>)?.usage,
+        // A semantic HIT does not call upstream. Keep the original cached
+        // usage only as analytics metadata and persist zero billable counters
+        // so downstream billing cannot charge the original tokens again.
+        tokens: {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          reasoning_tokens: 0,
+        },
         responseBody: cached,
         providerRequest: null,
         providerResponse: null,
         clientResponse: cached,
+        semanticCacheUsageMeta: {
+          status: "hit",
+          isolationScope: apiKeyId ? "api_key" : "local",
+          scopeId: apiKeyId ?? null,
+          avoidedUsage: rawCachedUsage ?? null,
+        },
         cacheSource: "semantic",
+        cacheResult: {
+          source: "semantic",
+          status: "hit",
+          scope: apiKeyId ? "api_key" : "local",
+          scopeId: apiKeyId ?? null,
+          avoidedInputTokens,
+          avoidedOutputTokens,
+        },
       });
       trackPendingRequest(model, provider, connectionId, false);
       const cachedSse = stream ? synthesizeOpenAiSseFromJson(JSON.stringify(cached)) : "";

--- a/open-sse/handlers/chatCore/upstreamBody.ts
+++ b/open-sse/handlers/chatCore/upstreamBody.ts
@@ -100,9 +100,11 @@ function backfillQwenOAuthUser(
 async function injectPromptCacheKey(
   bodyToSend: Body,
   provider: string | null | undefined,
-  targetFormat: string
+  targetFormat: string,
+  disableProviderCache: boolean
 ): Promise<Body> {
   if (
+    !disableProviderCache &&
     targetFormat === FORMATS.OPENAI &&
     providerSupportsCaching(provider) &&
     !bodyToSend.prompt_cache_key &&
@@ -125,6 +127,7 @@ export async function prepareUpstreamBody(opts: {
   targetFormat: string;
   credentials: CredentialsLike;
   bypassDefaultToolLimit?: boolean;
+  disableProviderCache?: boolean;
   log?: LoggerLike;
 }): Promise<Body> {
   const {
@@ -134,6 +137,7 @@ export async function prepareUpstreamBody(opts: {
     targetFormat,
     credentials,
     bypassDefaultToolLimit = false,
+    disableProviderCache = false,
     log,
   } = opts;
 
@@ -162,7 +166,7 @@ export async function prepareUpstreamBody(opts: {
 
   bodyToSend = truncateToolList(bodyToSend, provider, bypassDefaultToolLimit ?? false, log);
   bodyToSend = backfillQwenOAuthUser(bodyToSend, provider, credentials, log);
-  bodyToSend = await injectPromptCacheKey(bodyToSend, provider, targetFormat);
+  bodyToSend = await injectPromptCacheKey(bodyToSend, provider, targetFormat, disableProviderCache);
 
   return bodyToSend;
 }

--- a/open-sse/handlers/chatCore/upstreamExecuteHeaders.ts
+++ b/open-sse/handlers/chatCore/upstreamExecuteHeaders.ts
@@ -11,7 +11,10 @@
 
 import { getModelUpstreamExtraHeaders } from "@/lib/db/models";
 import { resolveModelAlias } from "../../services/modelDeprecation.ts";
-import { CPA_FORCE_FAST_MODE_HEADER, shouldRequestClaudeFastMode } from "@/lib/providers/claudeFastMode";
+import {
+  CPA_FORCE_FAST_MODE_HEADER,
+  shouldRequestClaudeFastMode,
+} from "@/lib/providers/claudeFastMode";
 
 export function buildUpstreamHeadersForExecute(opts: {
   modelToCall: string;
@@ -22,6 +25,9 @@ export function buildUpstreamHeadersForExecute(opts: {
   sourceFormat: string;
   connectionCustomUserAgent: string;
   settings: unknown;
+  disableProviderCache?: boolean;
+  providerBaseUrl?: string;
+  providerCacheDisableStrategy?: string;
 }): Record<string, string> {
   const {
     modelToCall,
@@ -32,6 +38,9 @@ export function buildUpstreamHeadersForExecute(opts: {
     sourceFormat,
     connectionCustomUserAgent,
     settings,
+    disableProviderCache = false,
+    providerBaseUrl = "",
+    providerCacheDisableStrategy = "",
   } = opts;
 
   const upstreamHeaders: Record<string, string> =
@@ -53,6 +62,27 @@ export function buildUpstreamHeadersForExecute(opts: {
     if ("user-agent" in upstreamHeaders) {
       upstreamHeaders["user-agent"] = connectionCustomUserAgent;
     }
+  }
+
+  const isOpenRouterBacked =
+    provider === "openrouter" ||
+    providerCacheDisableStrategy === "openrouter_header" ||
+    (() => {
+      try {
+        const hostname = new URL(providerBaseUrl).hostname.toLowerCase();
+        return hostname === "openrouter.ai" || hostname.endsWith(".openrouter.ai");
+      } catch {
+        return false;
+      }
+    })();
+
+  if (disableProviderCache && isOpenRouterBacked) {
+    for (const headerName of Object.keys(upstreamHeaders)) {
+      if (headerName.toLowerCase() === "x-openrouter-cache") {
+        delete upstreamHeaders[headerName];
+      }
+    }
+    upstreamHeaders["X-OpenRouter-Cache"] = "false";
   }
 
   // Claude Fast Mode opt-in. When enabled in Settings > AI AND the target provider is the canonical

--- a/open-sse/utils/providerCacheIsolation.ts
+++ b/open-sse/utils/providerCacheIsolation.ts
@@ -1,0 +1,50 @@
+/**
+ * Provider-cache isolation helpers.
+ *
+ * OmniRoute's semantic response cache is already namespaced by the downstream
+ * API-key id. Provider-side prompt/response caches are different: shared
+ * upstream credentials can make their cache namespace wider than one
+ * downstream key. Strict keys therefore strip every known prompt-cache hint
+ * immediately before the executor serializes the upstream request.
+ */
+
+const PROVIDER_CACHE_FIELDS = new Set([
+  "cache_control",
+  "prompt_cache_key",
+  "promptCacheKey",
+  "prompt_cache_retention",
+  "promptCacheRetention",
+]);
+
+function stripValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (!value || typeof value !== "object") return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      value[index] = stripValue(value[index], seen);
+    }
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (PROVIDER_CACHE_FIELDS.has(key)) {
+      delete record[key];
+      continue;
+    }
+    record[key] = stripValue(record[key], seen);
+  }
+  return record;
+}
+
+/**
+ * Remove provider-side cache controls from an already request-local payload.
+ *
+ * Mutating the request-local object is intentional: this runs on the final
+ * executor payload and avoids a second full deep clone for large contexts.
+ */
+export function stripProviderCacheControls<T>(payload: T): T {
+  return stripValue(payload, new WeakSet()) as T;
+}

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -325,6 +325,15 @@ const SCHEMA_SQL = `
     tokens_reasoning INTEGER DEFAULT NULL,
     tokens_compressed INTEGER DEFAULT NULL,
     cache_source TEXT DEFAULT "upstream",
+    cache_status TEXT DEFAULT NULL,
+    cache_scope TEXT DEFAULT NULL,
+    cache_scope_id TEXT DEFAULT NULL,
+    cache_avoided_input_tokens INTEGER DEFAULT NULL,
+    cache_avoided_output_tokens INTEGER DEFAULT NULL,
+    billing_contract_version INTEGER NOT NULL DEFAULT 1,
+    routed_model_id TEXT DEFAULT NULL,
+    provider_model_id TEXT DEFAULT NULL,
+    billing_model_id TEXT DEFAULT NULL,
     request_type TEXT,
     source_format TEXT,
     target_format TEXT,
@@ -1028,8 +1037,7 @@ export function getDbInstance(): SqliteDatabase {
         let hasData = false;
         try {
           const count = probe.prepare("SELECT COUNT(*) as c FROM provider_connections").get() as
-            | { c: number }
-            | undefined;
+            { c: number } | undefined;
           hasData = Boolean(count && count.c > 0);
         } catch {
           // Table might not exist at all — truly incompatible
@@ -1083,7 +1091,11 @@ export function getDbInstance(): SqliteDatabase {
       // V8 heap (sql.js loads the whole file into WASM memory). Throwing
       // immediately gives the user a clear "increase --max-old-space-size"
       // signal instead of silently renaming a perfectly good DB.
-      if (/out of memory|allocation failure|Array buffer allocation failed|allocation failed/i.test(message)) {
+      if (
+        /out of memory|allocation failure|Array buffer allocation failed|allocation failed/i.test(
+          message
+        )
+      ) {
         // Cycle-breaker (#6835): the OOM path never renames the file away,
         // so it never trips the generic probe-failed/restore cap above. Cap
         // it independently after 3 consecutive OOM failures (same threshold

--- a/src/lib/db/migrations/123_call_logs_cache_result.sql
+++ b/src/lib/db/migrations/123_call_logs_cache_result.sql
@@ -1,0 +1,13 @@
+-- Persist an explicit cache outcome in call logs so downstream billing can
+-- distinguish a zero-rated semantic cache hit from an ordinary zero-token
+-- request. The scope fields make the per-downstream-key isolation auditable;
+-- avoided tokens are analytics only and must not enter billable token totals.
+ALTER TABLE call_logs ADD COLUMN cache_status TEXT DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN cache_scope TEXT DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN cache_scope_id TEXT DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN cache_avoided_input_tokens INTEGER DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN cache_avoided_output_tokens INTEGER DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN billing_contract_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE call_logs ADD COLUMN routed_model_id TEXT DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN provider_model_id TEXT DEFAULT NULL;
+ALTER TABLE call_logs ADD COLUMN billing_model_id TEXT DEFAULT NULL;

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -71,6 +71,15 @@ type CallLogSummaryRow = {
   tokens_reasoning: number | null;
   tokens_compressed: number | null;
   cache_source: string | null;
+  cache_status: string | null;
+  cache_scope: string | null;
+  cache_scope_id: string | null;
+  cache_avoided_input_tokens: number | null;
+  cache_avoided_output_tokens: number | null;
+  billing_contract_version: number | null;
+  routed_model_id: string | null;
+  provider_model_id: string | null;
+  billing_model_id: string | null;
   request_type: string | null;
   source_format: string | null;
   target_format: string | null;
@@ -170,6 +179,21 @@ function applyNodePrefix(
     return nodePrefix + "/" + requestedModel.slice(provider.length + 1);
   }
   return requestedModel;
+}
+
+function billingComponents(row: CallLogSummaryRow) {
+  const cacheRead = Math.max(0, toNumber(row.tokens_cache_read));
+  const cacheWrite = Math.max(0, toNumber(row.tokens_cache_creation));
+  const reasoning = Math.max(0, toNumber(row.tokens_reasoning));
+  const inputUncached = Math.max(0, toNumber(row.tokens_in) - cacheRead - cacheWrite);
+  const output = Math.max(0, toNumber(row.tokens_out) - reasoning);
+  return [
+    { type: "input_uncached", quantity: inputUncached, cacheTtlSeconds: null },
+    { type: "output", quantity: output, cacheTtlSeconds: null },
+    { type: "reasoning", quantity: reasoning, cacheTtlSeconds: null },
+    { type: "cache_read", quantity: cacheRead, cacheTtlSeconds: null },
+    { type: "cache_write", quantity: cacheWrite, cacheTtlSeconds: 300 },
+  ].filter((component) => component.quantity > 0);
 }
 function buildArtifact(
   logEntry: {
@@ -475,14 +499,54 @@ function mapSummaryRow(row: CallLogSummaryRow) {
   const detailState = normalizeDetailState(row.detail_state);
   const provider = row.provider;
   const nodePrefix = row.provider_node_prefix ?? null;
+  const requestedModel = applyNodePrefix(row.requested_model, provider, nodePrefix);
+  const contractVersion = row.billing_contract_version === 2 ? 2 : 1;
+  const cacheRead = Math.max(0, toNumber(row.tokens_cache_read));
+  const cacheWrite = Math.max(0, toNumber(row.tokens_cache_creation));
+  const hasCacheResult = Boolean(row.cache_status) || row.cache_source === "semantic";
+  const cacheResult = hasCacheResult
+    ? {
+        source: row.cache_source === "semantic" ? "semantic" : "provider_prompt",
+        status: row.cache_status || "hit",
+        scope: row.cache_scope || (row.api_key_id ? "api_key" : "none"),
+        scopeId: row.cache_scope_id || row.api_key_id || null,
+        avoidedInputTokens: toNumber(row.cache_avoided_input_tokens),
+        avoidedOutputTokens: toNumber(row.cache_avoided_output_tokens),
+      }
+    : contractVersion === 2
+      ? cacheRead > 0 || cacheWrite > 0
+        ? {
+            source: "provider_prompt",
+            status: cacheRead > 0 ? "hit" : "write",
+            // An unexpected implicit provider cache is shared by the upstream
+            // credential until the provider proves a downstream-key namespace.
+            // ai-service must quarantine this scope instead of charging it.
+            scope: "upstream_credential",
+            scopeId: row.connection_id,
+            avoidedInputTokens: 0,
+            avoidedOutputTokens: 0,
+          }
+        : {
+            source: "none",
+            status: "miss",
+            scope: "api_key",
+            scopeId: row.api_key_id,
+            avoidedInputTokens: 0,
+            avoidedOutputTokens: 0,
+          }
+      : null;
   return {
+    contractVersion,
     id: row.id,
     timestamp: row.timestamp,
     method: row.method,
     path: row.path,
     status: toNumber(row.status),
     model: row.model,
-    requestedModel: applyNodePrefix(row.requested_model, provider, nodePrefix),
+    requestedModel,
+    routedModelId: row.routed_model_id || requestedModel,
+    providerModelId: row.provider_model_id,
+    billingModelId: row.billing_model_id,
     provider,
     account: row.resolved_account || row.account,
     connectionId: row.connection_id,
@@ -496,6 +560,8 @@ function mapSummaryRow(row: CallLogSummaryRow) {
       compressed: row.tokens_compressed != null ? toNumber(row.tokens_compressed) : null,
     },
     cacheSource: row.cache_source || "upstream",
+    cacheResult,
+    billingComponents: contractVersion === 2 ? billingComponents(row) : null,
     requestType: row.request_type,
     sourceFormat: row.source_format,
     targetFormat: row.target_format,
@@ -593,6 +659,22 @@ export async function saveCallLog(entry: any) {
       reasoningChars: reasoningObservation.chars,
       tokensCompressed: entry.tokensCompressed != null ? toNumber(entry.tokensCompressed) : null,
       cacheSource: entry.cacheSource === "semantic" ? "semantic" : "upstream",
+      cacheStatus: toStringOrNull(entry.cacheResult?.status),
+      cacheScope: toStringOrNull(entry.cacheResult?.scope),
+      cacheScopeId: toStringOrNull(entry.cacheResult?.scopeId),
+      cacheAvoidedInputTokens: entry.cacheResult
+        ? toNumber(entry.cacheResult.avoidedInputTokens)
+        : null,
+      cacheAvoidedOutputTokens: entry.cacheResult
+        ? toNumber(entry.cacheResult.avoidedOutputTokens)
+        : null,
+      billingContractVersion: entry.billingContractVersion === 2 ? 2 : 1,
+      routedModelId:
+        toStringOrNull(entry.routedModelId) ||
+        resolvedRequestedModel ||
+        toStringOrNull(entry.model),
+      providerModelId: toStringOrNull(entry.providerModelId),
+      billingModelId: toStringOrNull(entry.billingModelId),
       requestType: entry.requestType || null,
       sourceFormat: entry.sourceFormat || null,
       targetFormat: entry.targetFormat || null,
@@ -648,7 +730,10 @@ export async function saveCallLog(entry: any) {
         account, connection_id, duration, tokens_in, tokens_out,
         tokens_cache_read, tokens_cache_creation, tokens_reasoning, tokens_compressed,
         reasoning_source, reasoning_chars,
-        cache_source, request_type, source_format, target_format, api_key_id, api_key_name,
+        cache_source, cache_status, cache_scope, cache_scope_id,
+        cache_avoided_input_tokens, cache_avoided_output_tokens,
+        billing_contract_version, routed_model_id, provider_model_id, billing_model_id,
+        request_type, source_format, target_format, api_key_id, api_key_name,
         combo_name, combo_step_id, combo_execution_key, error_summary, detail_state,
         artifact_relpath, artifact_size_bytes, artifact_sha256,
         has_request_body, has_response_body, has_pipeline_details, request_summary,
@@ -659,12 +744,69 @@ export async function saveCallLog(entry: any) {
         @account, @connectionId, @duration, @tokensIn, @tokensOut,
         @tokensCacheRead, @tokensCacheCreation, @tokensReasoning, @tokensCompressed,
         @reasoningSource, @reasoningChars,
-        @cacheSource, @requestType, @sourceFormat, @targetFormat, @apiKeyId, @apiKeyName,
+        @cacheSource, @cacheStatus, @cacheScope, @cacheScopeId,
+        @cacheAvoidedInputTokens, @cacheAvoidedOutputTokens,
+        @billingContractVersion, @routedModelId, @providerModelId, @billingModelId,
+        @requestType, @sourceFormat, @targetFormat, @apiKeyId, @apiKeyName,
         @comboName, @comboStepId, @comboExecutionKey, @errorSummary, @detailState,
         @artifactRelPath, @artifactSizeBytes, @artifactSha256,
         @hasRequestBody, @hasResponseBody, @hasPipelineDetails, @requestSummary,
         @correlationId, @modelPinned
       )
+      ON CONFLICT(id) DO UPDATE SET
+        method = excluded.method,
+        path = excluded.path,
+        status = excluded.status,
+        model = excluded.model,
+        requested_model = excluded.requested_model,
+        provider = excluded.provider,
+        account = excluded.account,
+        connection_id = excluded.connection_id,
+        duration = excluded.duration,
+        tokens_in = excluded.tokens_in,
+        tokens_out = excluded.tokens_out,
+        tokens_cache_read = excluded.tokens_cache_read,
+        tokens_cache_creation = excluded.tokens_cache_creation,
+        tokens_reasoning = excluded.tokens_reasoning,
+        tokens_compressed = excluded.tokens_compressed,
+        reasoning_source = excluded.reasoning_source,
+        reasoning_chars = excluded.reasoning_chars,
+        cache_source = excluded.cache_source,
+        cache_status = excluded.cache_status,
+        cache_scope = excluded.cache_scope,
+        cache_scope_id = excluded.cache_scope_id,
+        cache_avoided_input_tokens = excluded.cache_avoided_input_tokens,
+        cache_avoided_output_tokens = excluded.cache_avoided_output_tokens,
+        billing_contract_version = excluded.billing_contract_version,
+        routed_model_id = excluded.routed_model_id,
+        provider_model_id = excluded.provider_model_id,
+        billing_model_id = excluded.billing_model_id,
+        request_type = excluded.request_type,
+        source_format = excluded.source_format,
+        target_format = excluded.target_format,
+        api_key_id = excluded.api_key_id,
+        api_key_name = excluded.api_key_name,
+        combo_name = excluded.combo_name,
+        combo_step_id = excluded.combo_step_id,
+        combo_execution_key = excluded.combo_execution_key,
+        error_summary = excluded.error_summary,
+        detail_state = excluded.detail_state,
+        artifact_relpath = excluded.artifact_relpath,
+        artifact_size_bytes = excluded.artifact_size_bytes,
+        artifact_sha256 = excluded.artifact_sha256,
+        has_request_body = excluded.has_request_body,
+        has_response_body = excluded.has_response_body,
+        has_pipeline_details = excluded.has_pipeline_details,
+        request_summary = excluded.request_summary,
+        correlation_id = excluded.correlation_id,
+        model_pinned = excluded.model_pinned
+      WHERE excluded.duration > call_logs.duration
+         OR (
+           excluded.duration = call_logs.duration
+           AND excluded.status >= 200
+           AND excluded.status < 400
+           AND (call_logs.status < 200 OR call_logs.status >= 400)
+         )
     `
     ).run({
       ...logEntry,

--- a/src/shared/constants/selfServiceScopes.ts
+++ b/src/shared/constants/selfServiceScopes.ts
@@ -1,5 +1,6 @@
 export const SELF_USAGE_SCOPE = "self:usage";
 export const SELF_ACCOUNT_QUOTA_SCOPE = "self:account-quota";
+export const ISOLATED_CACHE_SCOPE = "cache:isolated";
 
 export const DEFAULT_SELF_SERVICE_SCOPES = [SELF_USAGE_SCOPE] as const;
 
@@ -9,6 +10,10 @@ export function hasSelfUsageScope(scopes: readonly string[] | null | undefined):
 
 export function hasSelfAccountQuotaScope(scopes: readonly string[] | null | undefined): boolean {
   return Array.isArray(scopes) && scopes.includes(SELF_ACCOUNT_QUOTA_SCOPE);
+}
+
+export function hasIsolatedCacheScope(scopes: readonly string[] | null | undefined): boolean {
+  return Array.isArray(scopes) && scopes.includes(ISOLATED_CACHE_SCOPE);
 }
 
 export function normalizeSelfServiceScopesForCreate(

--- a/tests/unit/chatcore-attempt-logging.test.ts
+++ b/tests/unit/chatcore-attempt-logging.test.ts
@@ -61,6 +61,15 @@ async function pollForCallLog(id: string, tries = 120) {
   return null;
 }
 
+async function pollForCallLogStatus(id: string, status: number, tries = 120) {
+  for (let i = 0; i < tries; i++) {
+    const row = (await getCallLogById(id)) as Record<string, unknown> | null;
+    if (row?.status === status) return row;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return null;
+}
+
 function getCodexAccountRotation(value: unknown) {
   if (!value || typeof value !== "object") return undefined;
   return (value as CodexRotationEnvelope)._omniroute?.codexAccountRotation;
@@ -89,6 +98,7 @@ test("persists a call log row with the mapped fields (default cacheSource=upstre
   assert.equal(row.requestedModel, "gpt-x-requested");
   assert.equal(row.connectionId, "conn-1");
   assert.equal(row.cacheSource, "upstream");
+  assert.equal(row.contractVersion, 1);
 });
 
 test("uses final credentials connectionId when Codex failover rotates the account", async () => {
@@ -118,10 +128,69 @@ test("uses final credentials connectionId when Codex failover rotates the accoun
 
 test("cacheSource 'semantic' is preserved", async () => {
   const id = "attempt-semantic-1";
-  persistAttemptLogs({ status: 200, cacheSource: "semantic" }, baseCtx({ pendingRequestId: id }));
+  persistAttemptLogs(
+    {
+      status: 200,
+      cacheSource: "semantic",
+      cacheResult: {
+        source: "semantic",
+        status: "hit",
+        scope: "api_key",
+        scopeId: "key-1",
+        avoidedInputTokens: 21,
+        avoidedOutputTokens: 8,
+      },
+    },
+    baseCtx({
+      pendingRequestId: id,
+      apiKeyInfo: {
+        id: "key-1",
+        name: "Key One",
+        scopes: ["cache:isolated"],
+      },
+    })
+  );
   const row = await pollForCallLog(id);
   assert.ok(row);
   assert.equal(row.cacheSource, "semantic");
+  assert.equal(row.contractVersion, 2);
+  assert.equal(row.routedModelId, "gpt-x-requested");
+  assert.equal(row.billingModelId, null);
+  assert.deepEqual(row.billingComponents, []);
+  assert.deepEqual(row.cacheResult, {
+    source: "semantic",
+    status: "hit",
+    scope: "api_key",
+    scopeId: "key-1",
+    avoidedInputTokens: 21,
+    avoidedOutputTokens: 8,
+  });
+});
+
+test("persists the provider model observed in the upstream response", async () => {
+  const id = "attempt-provider-model-1";
+  persistAttemptLogs(
+    {
+      status: 200,
+      providerResponse: { model: "anthropic/claude-sonnet-4.6" },
+      responseBody: { model: "client-echo-must-not-win" },
+      routedModelId: "or/anthropic/claude-sonnet-4.6",
+      billingModelId: "claude-sonnet-4.6",
+    },
+    baseCtx({
+      pendingRequestId: id,
+      apiKeyInfo: {
+        id: "key-1",
+        name: "Key One",
+        scopes: ["cache:isolated"],
+      },
+    })
+  );
+  const row = await pollForCallLog(id);
+  assert.ok(row);
+  assert.equal(row.routedModelId, "or/anthropic/claude-sonnet-4.6");
+  assert.equal(row.providerModelId, "anthropic/claude-sonnet-4.6");
+  assert.equal(row.billingModelId, "claude-sonnet-4.6");
 });
 
 test("connectionId falls back to credentials.connectionId when null, and error is persisted", async () => {
@@ -135,4 +204,51 @@ test("connectionId falls back to credentials.connectionId when null, and error i
   assert.equal(row.connectionId, "cred-conn");
   assert.equal(row.status, 502);
   assert.match(String(row.error ?? ""), /upstream boom/);
+});
+
+test("one request id keeps one row and the final attempt replaces the failed attempt", async () => {
+  const id = "attempt-final-wins-1";
+  persistAttemptLogs(
+    { status: 502, error: "first attempt failed", tokens: { input: 3, output: 0 } },
+    baseCtx({
+      pendingRequestId: id,
+      connectionId: "failed-conn",
+      startTime: Date.now() - 10,
+    })
+  );
+  const failed = await pollForCallLogStatus(id, 502);
+  assert.ok(failed);
+
+  persistAttemptLogs(
+    {
+      status: 200,
+      tokens: { input: 11, output: 7 },
+      responseBody: { id: "final-response" },
+    },
+    baseCtx({
+      pendingRequestId: id,
+      connectionId: "final-conn",
+      credentials: { connectionId: "final-conn" },
+      startTime: Date.now() - 100,
+    })
+  );
+
+  const final = await pollForCallLogStatus(id, 200);
+  assert.ok(final);
+  assert.equal(final.connectionId, "final-conn");
+  assert.deepEqual(final.tokens, {
+    in: 11,
+    out: 7,
+    cacheRead: null,
+    cacheWrite: null,
+    reasoning: null,
+    compressed: 0,
+  });
+  assert.equal(final.error, null);
+
+  const count = coreDb
+    .getDbInstance()
+    .prepare("SELECT COUNT(*) AS count FROM call_logs WHERE id = ?")
+    .get(id) as { count: number };
+  assert.equal(count.count, 1);
 });

--- a/tests/unit/chatcore-semantic-cache.test.ts
+++ b/tests/unit/chatcore-semantic-cache.test.ts
@@ -14,9 +14,8 @@ const core = await import("../../src/lib/db/core.ts");
 // Seeding the real cache (no mock.module under the Stryker tap-runner) lets us drive the
 // HIT branch deterministically: setCachedResponse populates the in-memory cache that
 // getCachedResponse checks first, so the signature checkSemanticCache rebuilds resolves.
-const { generateSignature, setCachedResponse, clearCache } = await import(
-  "../../src/lib/semanticCache.ts"
-);
+const { generateSignature, setCachedResponse, clearCache } =
+  await import("../../src/lib/semanticCache.ts");
 const { OMNIROUTE_RESPONSE_HEADERS } = await import("../../src/shared/constants/headers.ts");
 const { calculateCost } = await import("../../src/lib/usage/costCalculator.ts");
 const { formatOmniRouteCost } = await import("../../src/domain/omnirouteResponseMeta.ts");
@@ -148,7 +147,11 @@ function makeHitArgs(overrides: Record<string, unknown> = {}) {
   const debugCalls: unknown[][] = [];
   const args = {
     semanticCacheEnabled: true,
-    body: { model: "gpt-4o", messages: [{ role: "user", content: "cached query" }], temperature: 0 },
+    body: {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "cached query" }],
+      temperature: 0,
+    },
     clientRawRequest: { headers: {} },
     model: "gpt-4o",
     provider: "openai",
@@ -198,7 +201,11 @@ test("checkSemanticCache returns a non-streaming JSON HIT with cache headers + l
     usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
   };
   const { args, persistCalls, convertedCalls, debugCalls } = makeHitArgs({
-    body: { model: "gpt-4o", messages: [{ role: "user", content: "hit query one" }], temperature: 0 },
+    body: {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hit query one" }],
+      temperature: 0,
+    },
     stream: false,
   });
   seedHit(args, cached);
@@ -228,7 +235,34 @@ test("checkSemanticCache returns a non-streaming JSON HIT with cache headers + l
   assert.equal(logged.cacheSource, "semantic", "persisted cacheSource is 'semantic'");
   assert.deepEqual(logged.responseBody, cached, "persisted responseBody is the cached object");
   assert.deepEqual(logged.clientResponse, cached, "persisted clientResponse is the cached object");
-  assert.deepEqual(logged.tokens, cached.usage, "persisted tokens come from cached.usage");
+  assert.deepEqual(
+    logged.tokens,
+    {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      reasoning_tokens: 0,
+    },
+    "semantic HIT persists zero billable tokens"
+  );
+  assert.deepEqual(logged.semanticCacheUsageMeta, {
+    status: "hit",
+    isolationScope: "local",
+    scopeId: null,
+    avoidedUsage: cached.usage,
+  });
+  assert.deepEqual(logged.cacheResult, {
+    source: "semantic",
+    status: "hit",
+    scope: "local",
+    scopeId: null,
+    avoidedInputTokens: 10,
+    avoidedOutputTokens: 5,
+  });
   assert.equal(logged.providerRequest, null);
   assert.equal(logged.providerResponse, null);
 
@@ -251,7 +285,11 @@ test("checkSemanticCache returns a streaming SSE HIT (text/event-stream) when st
     usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
   };
   const { args, persistCalls } = makeHitArgs({
-    body: { model: "gpt-4o", messages: [{ role: "user", content: "hit query stream" }], temperature: 0 },
+    body: {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hit query stream" }],
+      temperature: 0,
+    },
     stream: true,
   });
   seedHit(args, cached);
@@ -279,7 +317,11 @@ test("checkSemanticCache HITs even when the cached body has no usage (cost falls
   const cached = {
     id: "chatcmpl-cached-no-usage",
     choices: [
-      { index: 0, message: { role: "assistant", content: "no-usage answer" }, finish_reason: "stop" },
+      {
+        index: 0,
+        message: { role: "assistant", content: "no-usage answer" },
+        finish_reason: "stop",
+      },
     ],
   };
   const { args, persistCalls } = makeHitArgs({
@@ -305,7 +347,16 @@ test("checkSemanticCache HITs even when the cached body has no usage (cost falls
     "no usage -> zero responseCost header"
   );
   assert.equal(persistCalls.length, 1);
-  assert.equal(persistCalls[0].tokens, undefined, "no usage -> persisted tokens is undefined");
+  assert.deepEqual(persistCalls[0].tokens, {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_tokens: 0,
+  });
 });
 
 // ─── Cache-HIT cost reporting (PRD-2026-06-19-cache-hit-cost-reporting) ───────
@@ -388,7 +439,18 @@ test("checkSemanticCache isolates HITs per apiKeyId (no cross-key cache sharing)
   assert.equal(missB, null, "keyB must NOT resolve keyA's cached entry (per-key isolation)");
 
   // keyA itself still gets a HIT.
-  const { args: argsA2 } = makeHitArgs({ body: sharedBody(), apiKeyId: "keyA" });
+  const { args: argsA2, persistCalls: persistCallsA } = makeHitArgs({
+    body: sharedBody(),
+    apiKeyId: "keyA",
+  });
   const hitA = await checkSemanticCache(argsA2 as Parameters<typeof checkSemanticCache>[0]);
   assert.ok(hitA, "keyA must resolve its own cached entry");
+  assert.deepEqual(persistCallsA[0].cacheResult, {
+    source: "semantic",
+    status: "hit",
+    scope: "api_key",
+    scopeId: "keyA",
+    avoidedInputTokens: 5,
+    avoidedOutputTokens: 5,
+  });
 });

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -1214,6 +1214,43 @@ test("chatCore logs chat completions endpoint as OpenAI protocol", async () => {
   assert.equal(logEntry.sourceFormat, FORMATS.OPENAI);
 });
 
+test("cache:isolated API keys strip provider cache hints and disable OpenRouter response cache", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openrouter",
+    model: "openai/gpt-4o-mini",
+    endpoint: "/v1/chat/completions",
+    apiKeyInfo: {
+      id: "smartpack-key-1",
+      name: "Smartpack key",
+      scopes: ["self:usage", "cache:isolated"],
+    },
+    body: {
+      model: "openrouter/openai/gpt-4o-mini",
+      stream: false,
+      temperature: 0.7,
+      prompt_cache_key: "client-controlled-shared-namespace",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "strict cache isolation",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+      ],
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.headers["X-OpenRouter-Cache"], "false");
+  assert.equal(JSON.stringify(call.body).includes("prompt_cache_key"), false);
+  assert.equal(JSON.stringify(call.body).includes("cache_control"), false);
+});
+
 test("chatCore surfaces translation errors with explicit status codes", async () => {
   register(
     FORMATS.OPENAI_RESPONSES,
@@ -1604,6 +1641,21 @@ test("chatCore returns a semantic cache HIT for repeated deterministic requests"
   });
   assert.ok(semanticLog, "expected semantic cache HIT to be persisted in call logs");
   assert.equal(semanticLog.cacheSource, "semantic");
+  assert.equal(semanticLog.contractVersion, 1);
+  assert.deepEqual(semanticLog.tokens, {
+    in: 0,
+    out: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    reasoning: 0,
+    compressed: null,
+  });
+  assert.equal(semanticLog.cacheResult.source, "semantic");
+  assert.equal(semanticLog.cacheResult.status, "hit");
+  assert.equal(semanticLog.cacheResult.scope, "local");
+  assert.equal(semanticLog.cacheResult.scopeId, null);
+  assert.ok(semanticLog.cacheResult.avoidedInputTokens >= 4);
+  assert.equal(semanticLog.cacheResult.avoidedOutputTokens, 2);
   assert.equal(semanticLog.path, "/v1/chat/completions");
   assert.equal(semanticLog.status, 200);
 });

--- a/tests/unit/chatcore-upstream-body.test.ts
+++ b/tests/unit/chatcore-upstream-body.test.ts
@@ -135,3 +135,15 @@ test("never injects prompt_cache_key when the target format is not OpenAI", asyn
   });
   assert.equal(out.prompt_cache_key, undefined);
 });
+
+test("strict per-key cache mode does not inject prompt_cache_key", async () => {
+  const out = await prepareUpstreamBody({
+    translatedBody: { model: "gpt-4o", messages: [{ role: "user", content: "hi" }] },
+    modelToCall: "gpt-4o",
+    provider: "openai",
+    targetFormat: "openai",
+    credentials: null,
+    disableProviderCache: true,
+  });
+  assert.equal(out.prompt_cache_key, undefined);
+});

--- a/tests/unit/chatcore-upstream-execute-headers.test.ts
+++ b/tests/unit/chatcore-upstream-execute-headers.test.ts
@@ -64,7 +64,40 @@ test("fast-mode header is NOT set for non-claude providers even with fast settin
 });
 
 test("returns a plain object (no per-model extra headers configured for unknown models)", () => {
-  const h = buildUpstreamHeadersForExecute({ ...base, modelToCall: "totally-unknown", effectiveModel: "x" });
+  const h = buildUpstreamHeadersForExecute({
+    ...base,
+    modelToCall: "totally-unknown",
+    effectiveModel: "x",
+  });
   assert.equal(typeof h, "object");
   assert.equal(h[CPA_FORCE_FAST_MODE_HEADER], undefined);
+});
+
+test("strict per-key cache mode disables OpenRouter response cache", () => {
+  const h = buildUpstreamHeadersForExecute({
+    ...base,
+    provider: "openrouter",
+    disableProviderCache: true,
+  });
+  assert.equal(h["X-OpenRouter-Cache"], "false");
+});
+
+test("strict per-key cache mode disables cache for an OpenRouter-backed dynamic node", () => {
+  const h = buildUpstreamHeadersForExecute({
+    ...base,
+    provider: "anthropic-compatible-node-id",
+    providerBaseUrl: "https://openrouter.ai/api/v1",
+    disableProviderCache: true,
+  });
+  assert.equal(h["X-OpenRouter-Cache"], "false");
+});
+
+test("explicit node cache strategy disables OpenRouter cache without relying on provider id", () => {
+  const h = buildUpstreamHeadersForExecute({
+    ...base,
+    provider: "custom-compatible-node",
+    providerCacheDisableStrategy: "openrouter_header",
+    disableProviderCache: true,
+  });
+  assert.equal(h["X-OpenRouter-Cache"], "false");
 });

--- a/tests/unit/provider-cache-isolation.test.ts
+++ b/tests/unit/provider-cache-isolation.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stripProviderCacheControls } from "../../open-sse/utils/providerCacheIsolation.ts";
+
+test("stripProviderCacheControls removes prompt-cache hints at every nesting level", () => {
+  const payload = {
+    prompt_cache_key: "shared-key",
+    prompt_cache_retention: "24h",
+    system: [
+      {
+        type: "text",
+        text: "system",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ],
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "hello",
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        name: "tool",
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+  };
+
+  const result = stripProviderCacheControls(payload);
+
+  assert.equal("prompt_cache_key" in result, false);
+  assert.equal("prompt_cache_retention" in result, false);
+  assert.equal("cache_control" in result.system[0], false);
+  assert.equal("cache_control" in result.messages[0].content[0], false);
+  assert.equal("cache_control" in result.tools[0], false);
+  assert.equal(result.messages[0].content[0].text, "hello");
+});

--- a/tests/unit/save-call-log-persistence.test.ts
+++ b/tests/unit/save-call-log-persistence.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { getDbInstance } from "../../src/lib/db/core.ts";
 import { saveCallLog, getCallLogs } from "../../src/lib/usage/callLogs.ts";
 
@@ -100,6 +102,174 @@ test("call_logs table has model_pinned column", () => {
   const columns = db.prepare("PRAGMA table_info(call_logs)").all() as { name: string }[];
   const colNames = columns.map((c) => c.name);
   assert.ok(colNames.includes("model_pinned"), "call_logs should have model_pinned column");
+});
+
+test("call_logs table has persisted cache result columns", () => {
+  const db = getDbInstance();
+  const columns = db.prepare("PRAGMA table_info(call_logs)").all() as { name: string }[];
+  const colNames = columns.map((column) => column.name);
+  for (const column of [
+    "cache_status",
+    "cache_scope",
+    "cache_scope_id",
+    "cache_avoided_input_tokens",
+    "cache_avoided_output_tokens",
+    "billing_contract_version",
+    "routed_model_id",
+    "provider_model_id",
+    "billing_model_id",
+  ]) {
+    assert.ok(colNames.includes(column), `call_logs should have ${column} column`);
+  }
+});
+
+test("saveCallLog returns a root cacheResult for semantic hits", async () => {
+  const db = getDbInstance();
+  const testId = `test-cache-result-${Date.now()}`;
+
+  await saveCallLog({
+    id: testId,
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "cached-model",
+    provider: "test-provider",
+    tokens: { in: 0, out: 0 },
+    cacheSource: "semantic",
+    billingContractVersion: 2,
+    apiKeyId: "downstream-key-1",
+    cacheResult: {
+      source: "semantic",
+      status: "hit",
+      scope: "api_key",
+      scopeId: "downstream-key-1",
+      avoidedInputTokens: 100,
+      avoidedOutputTokens: 25,
+    },
+  });
+
+  const logs = await getCallLogs({ limit: 100 });
+  const found = logs.find((log: { id: string }) => log.id === testId);
+  assert.ok(found, "semantic cache result should be returned by getCallLogs");
+  assert.equal(found.contractVersion, 2);
+  assert.equal(found.routedModelId, "cached-model");
+  assert.equal(found.billingModelId, null);
+  assert.deepEqual(found.billingComponents, []);
+  assert.deepEqual(found.cacheResult, {
+    source: "semantic",
+    status: "hit",
+    scope: "api_key",
+    scopeId: "downstream-key-1",
+    avoidedInputTokens: 100,
+    avoidedOutputTokens: 25,
+  });
+
+  db.prepare("DELETE FROM call_logs WHERE id = ?").run(testId);
+});
+
+test("migration 123 upgrades an existing call_logs table", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec("CREATE TABLE call_logs (id TEXT PRIMARY KEY)");
+    db.exec(fs.readFileSync("src/lib/db/migrations/123_call_logs_cache_result.sql", "utf8"));
+    const columns = db.prepare("PRAGMA table_info(call_logs)").all() as { name: string }[];
+    const columnNames = columns.map((column) => column.name);
+    for (const column of [
+      "cache_status",
+      "cache_scope",
+      "cache_scope_id",
+      "cache_avoided_input_tokens",
+      "cache_avoided_output_tokens",
+      "billing_contract_version",
+      "routed_model_id",
+      "provider_model_id",
+      "billing_model_id",
+    ]) {
+      assert.ok(columnNames.includes(column), `migration should add ${column}`);
+    }
+  } finally {
+    db.close();
+  }
+});
+
+test("contract v2 exposes canonical model, per-key miss scope, and billing components", async () => {
+  const db = getDbInstance();
+  const testId = `test-contract-v2-${Date.now()}`;
+
+  await saveCallLog({
+    id: testId,
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "upstream-model",
+    requestedModel: "main/gpt-5.5",
+    provider: "provider-node-1",
+    connectionId: "connection-1",
+    tokens: {
+      input: 120,
+      output: 45,
+      reasoning: 5,
+    },
+    apiKeyId: "downstream-key-1",
+    billingContractVersion: 2,
+    routedModelId: "main/gpt-5.5",
+    providerModelId: "gpt-5.5",
+    billingModelId: "gpt-5.5",
+  });
+
+  const logs = await getCallLogs({ apiKey: "downstream-key-1", limit: 100 });
+  const found = logs.find((log: { id: string }) => log.id === testId);
+  assert.ok(found);
+  assert.equal(found.contractVersion, 2);
+  assert.equal(found.routedModelId, "main/gpt-5.5");
+  assert.equal(found.providerModelId, "gpt-5.5");
+  assert.equal(found.billingModelId, "gpt-5.5");
+  assert.deepEqual(found.cacheResult, {
+    source: "none",
+    status: "miss",
+    scope: "api_key",
+    scopeId: "downstream-key-1",
+    avoidedInputTokens: 0,
+    avoidedOutputTokens: 0,
+  });
+  assert.deepEqual(found.billingComponents, [
+    { type: "input_uncached", quantity: 120, cacheTtlSeconds: null },
+    { type: "output", quantity: 40, cacheTtlSeconds: null },
+    { type: "reasoning", quantity: 5, cacheTtlSeconds: null },
+  ]);
+
+  db.prepare("DELETE FROM call_logs WHERE id = ?").run(testId);
+});
+
+test("contract v2 keeps routed and billing identities separate", async () => {
+  const db = getDbInstance();
+  const testId = `test-contract-v2-alias-${Date.now()}`;
+
+  await saveCallLog({
+    id: testId,
+    method: "POST",
+    path: "/v1/messages",
+    status: 200,
+    model: "upstream-model",
+    requestedModel: "or/~anthropic/claude-sonnet-latest",
+    provider: "provider-node-1",
+    connectionId: "connection-1",
+    tokens: { input: 10, output: 5 },
+    apiKeyId: "downstream-key-1",
+    billingContractVersion: 2,
+    routedModelId: "or/~anthropic/claude-sonnet-latest",
+    providerModelId: "anthropic/claude-sonnet-4.6",
+    billingModelId: "claude-sonnet-latest",
+  });
+
+  const logs = await getCallLogs({ apiKey: "downstream-key-1", limit: 100 });
+  const found = logs.find((log: { id: string }) => log.id === testId);
+  assert.ok(found);
+  assert.equal(found.routedModelId, "or/~anthropic/claude-sonnet-latest");
+  assert.equal(found.providerModelId, "anthropic/claude-sonnet-4.6");
+  assert.equal(found.billingModelId, "claude-sonnet-latest");
+
+  db.prepare("DELETE FROM call_logs WHERE id = ?").run(testId);
 });
 
 test("saveCallLog persists modelPinned=true as 1", async () => {


### PR DESCRIPTION
## Summary
- namespace semantic response cache by immutable downstream API key id
- strip provider prompt-cache controls and disable OpenRouter response cache for isolated keys
- persist routed model separately from the provider model observed in the provider response
- emit Usage Contract v2 components and per-key cache scope without rewriting requested routing prefixes
- keep one final call-log row per request id across retries

## Safety
- existing keys without `cache:isolated` keep legacy behavior until ai-service backfills the scope
- requested model and route prefix are not normalized or changed
- shared upstream cache is disabled rather than attributed to the wrong downstream key

## Checks
- 7 targeted Node test files, 115 tests passed
- targeted ESLint with repository suppressions passed
- `git diff --check` passed