### PR TITLE
feat: add Chenzk API provider

### DIFF
--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -52,6 +52,7 @@ import { inference_netProvider } from "./registry/inference-net/index.ts";
 import { llm7Provider } from "./registry/llm7/index.ts";
 import { cerebrasProvider } from "./registry/cerebras/index.ts";
 import { charmHyperProvider } from "./registry/charm-hyper/index.ts";
+import { chenzkProvider } from "./registry/chenzk/index.ts";
 import { nubeProvider } from "./registry/nube/index.ts";
 import { clinepassProvider } from "./registry/clinepass/index.ts";
 import { sparkdeskProvider } from "./registry/sparkdesk/index.ts";
@@ -238,6 +239,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   llm7: llm7Provider,
   cerebras: cerebrasProvider,
   "charm-hyper": charmHyperProvider,
+  chenzk: chenzkProvider,
   nube: nubeProvider,
   clinepass: clinepassProvider,
   sparkdesk: sparkdeskProvider,

--- a/open-sse/config/providers/registry/chenzk/index.ts
+++ b/open-sse/config/providers/registry/chenzk/index.ts
@@ -1,0 +1,39 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+/**
+ * Chenzk API — OpenAI-compatible AI gateway (https://chenzk.top).
+ *
+ * Uses Bearer API keys and exposes its current model catalog through /v1/models.
+ */
+export const chenzkProvider: RegistryEntry = {
+  id: "chenzk",
+  alias: "chenzk",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://chenzk.top/v1/chat/completions",
+  modelsUrl: "https://chenzk.top/v1/models",
+  authType: "apikey",
+  authHeader: "bearer",
+  defaultContextLength: 128000,
+  models: [
+    { id: "gpt-5.6", name: "GPT-5.6" },
+    { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+    { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+    { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+    { id: "gpt-5.5", name: "GPT-5.5" },
+    { id: "gpt-5.4", name: "GPT-5.4" },
+    { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
+    { id: "claude-opus-4-8", name: "Claude Opus 4.8" },
+    { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+    { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+    { id: "claude-sonnet-5", name: "Claude Sonnet 5" },
+    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { id: "grok-4.5", name: "Grok 4.5" },
+    { id: "grok-4.3", name: "Grok 4.3" },
+    { id: "grok-build", name: "Grok Build" },
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
+    { id: "glm-4-flash", name: "GLM 4 Flash" },
+  ],
+  passthroughModels: true,
+};

--- a/src/app/api/providers/[id]/models/discovery/providerSets.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerSets.ts
@@ -1,4 +1,5 @@
 export const NAMED_OPENAI_STYLE_PROVIDERS = new Set([
+  "chenzk",
   "modal",
   "reka",
   "empower",

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -3,6 +3,19 @@
  * Pure data; merged by apikey/index.ts via spread (god-file decomposition; semantic split).
  */
 export const APIKEY_PROVIDERS_GATEWAYS = {
+  chenzk: {
+    id: "chenzk",
+    alias: "chenzk",
+    name: "Chenzk API",
+    icon: "router",
+    color: "#0F766E",
+    textIcon: "CZ",
+    website: "https://chenzk.top",
+    passthroughModels: true,
+    apiHint:
+      "Create an API key at https://chenzk.top, then paste it here as a Bearer token. " +
+      "OpenAI-compatible endpoints: https://chenzk.top/v1/chat/completions and https://chenzk.top/v1/models.",
+  },
   "charm-hyper": {
     id: "charm-hyper",
     alias: "charm-hyper",

--- a/tests/unit/chenzk-provider.test.ts
+++ b/tests/unit/chenzk-provider.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
+const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers/apikey/index.ts");
+const { isNamedOpenAIStyleProvider } =
+  await import("../../src/app/api/providers/[id]/models/discovery/providerSets.ts");
+
+test("Chenzk API is registered as an OpenAI-compatible API-key provider", () => {
+  const entry = getRegistryEntry("chenzk");
+
+  assert.ok(entry, "Chenzk provider should be registered");
+  assert.equal(entry.format, "openai");
+  assert.equal(entry.executor, "default");
+  assert.equal(entry.authType, "apikey");
+  assert.equal(entry.authHeader, "bearer");
+  assert.equal(entry.baseUrl, "https://chenzk.top/v1/chat/completions");
+  assert.equal(entry.modelsUrl, "https://chenzk.top/v1/models");
+  assert.equal(entry.passthroughModels, true);
+  assert.ok(entry.models.some((model) => model.id === "gpt-5.5"));
+  assert.ok(entry.models.some((model) => model.id === "claude-opus-4-8"));
+});
+
+test("Chenzk API appears in the API-key provider catalog and supports live model discovery", () => {
+  const catalog = APIKEY_PROVIDERS.chenzk;
+
+  assert.ok(catalog, "Chenzk catalog entry should be registered");
+  assert.equal(catalog.name, "Chenzk API");
+  assert.equal(catalog.website, "https://chenzk.top");
+  assert.equal(catalog.passthroughModels, true);
+  assert.equal(isNamedOpenAIStyleProvider("chenzk"), true);
+});


### PR DESCRIPTION
## Summary

Adds Chenzk API as a named OpenAI-compatible API-key provider.

- Provider website: https://chenzk.top
- Chat completions: `https://chenzk.top/v1/chat/completions`
- Model discovery: `https://chenzk.top/v1/models`
- Authentication: `Authorization: Bearer <API_KEY>`
- Catalog supports passthrough/live model discovery with a local fallback list.

This is a paid gateway option for users who already have a Chenzk API key. It does not claim a free tier or alter routing behavior for other providers.

## Changes

- Adds the Chenzk provider registry entry and curated fallback models.
- Adds the provider to the API-key gateway catalog.
- Enables live `/v1/models` discovery for the named OpenAI-compatible provider.
- Adds focused coverage for registry, catalog, and live-discovery classification.

## Validation

```text
node --import tsx/esm --test tests/unit/chenzk-provider.test.ts
# 2 passed, 0 failed

npx prettier --check <changed files>
# passed
```

The Chenzk endpoints are publicly reachable; `/v1/models` responds with authentication required when no API key is supplied, as expected for a keyed catalog.