### PR TITLE
fix(api): await params in Agent Bridge DNS route (Next.js 16) (#7271)

### DIFF
--- a/src/app/api/tools/agent-bridge/agents/[id]/dns/route.ts
+++ b/src/app/api/tools/agent-bridge/agents/[id]/dns/route.ts
@@ -13,10 +13,10 @@ import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { ALL_TARGETS } from "@/mitm/targets/index";
 
-type Params = { params: { id: string } };
+type Params = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, { params }: Params): Promise<Response> {
-  const { id } = params;
+  const { id } = await params;
 
   let body: unknown;
   try {

--- a/tests/unit/agent-bridge-dns-params-7271.test.ts
+++ b/tests/unit/agent-bridge-dns-params-7271.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { POST } from "../../src/app/api/tools/agent-bridge/agents/[id]/dns/route.ts";
+
+/**
+ * Regression for #7271: Agent Bridge "Start DNS" returned HTTP 404.
+ *
+ * Next.js 16 makes a dynamic route's `params` a Promise. The handler destructured
+ * `id` directly from the (un-awaited) Promise, so `id` was `undefined` and the
+ * agent lookup always missed — producing `404 Unknown agent: undefined` for every
+ * request, including valid agents.
+ *
+ * This test drives the handler with the Next.js 16 params shape (a Promise) and an
+ * unknown agent id. It never reaches the DNS side-effects (the 404 fires before
+ * `addDNSEntry`), so it is a pure, side-effect-free reproduction: the 404 message
+ * must echo the *resolved* id — proving `params` was awaited — not `undefined`.
+ */
+test("POST /agents/[id]/dns awaits params — 404 echoes the real id, not 'undefined'", async () => {
+  const agentId = "definitely-not-a-real-agent-7271";
+  const request = new Request("http://localhost/api/tools/agent-bridge/agents/x/dns", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled: false }),
+  });
+
+  const res = await POST(request, { params: Promise.resolve({ id: agentId }) });
+  const body = await res.json();
+
+  assert.equal(res.status, 404);
+  // Before the fix, `id` was `undefined`, so the message read "Unknown agent: undefined".
+  assert.equal(body.error.message, `Unknown agent: ${agentId}`);
+  assert.ok(
+    !body.error.message.includes("undefined"),
+    "params must be awaited — message should not contain 'undefined'"
+  );
+});


### PR DESCRIPTION
## Problem

In **Dashboard → Tools → Agent Bridge**, clicking **Start DNS** for an agent (e.g. Antigravity) returns **HTTP 404** instead of enabling the DNS entry. Reported on Windows 11 / Node v24.18.0, OmniRoute 3.8.49.

## Root cause

`POST /api/tools/agent-bridge/agents/[id]/dns` read the dynamic route param synchronously:

```ts
type Params = { params: { id: string } };
export async function POST(request: Request, { params }: Params) {
  const { id } = params; // ← params is a Promise in Next.js 16
```

Next.js 16 makes a dynamic route's `params` a **`Promise`**. Destructuring `id` from the un-awaited Promise yields `undefined`, so the agent lookup

```ts
const target = ALL_TARGETS.find((t) => t.id === id); // id === undefined → no match
if (!target) return createErrorResponse({ status: 404, message: `Unknown agent: ${id}` });
```

always misses and returns `404 Unknown agent: undefined` for **every** agent, including valid ones — exactly the 404 in the screenshot.

The rest of the codebase already migrated: 80 route handlers use `params: Promise<…>` + `await params`. This route (and its siblings) simply missed the migration.

## Fix

Await `params`, matching the established Next.js 16 pattern:

```ts
type Params = { params: Promise<{ id: string }> };
export async function POST(request: Request, { params }: Params) {
  const { id } = await params;
```

One-line change, fully backward-compatible (`await` on the already-resolved object the test-time/legacy caller passes is a no-op).

> **Scope note (for the maintainer):** the sibling Agent Bridge `[id]` routes —
> `detect/route.ts`, `mappings/route.ts`, and `agents/[id]/route.ts` — share the same
> un-awaited-`params` pattern and will 404/misbehave the same way. This PR is scoped to the
> **DNS route reported in #7271**; happy to follow up on the siblings (or fold them in here)
> if you'd prefer a single sweep.

## Verification

New regression test drives the handler with the Next.js 16 params shape (a `Promise`) and an unknown agent id — it fires the 404 **before** any DNS side-effect, so it's a pure, side-effect-free reproduction and asserts the 404 echoes the *resolved* id (proving `params` was awaited), not `undefined`.

```
$ node --import tsx/esm --test tests/unit/agent-bridge-dns-params-7271.test.ts
# BEFORE the fix:
not ok 1 - POST /agents/[id]/dns awaits params — 404 echoes the real id, not 'undefined'
  expected: 'Unknown agent: definitely-not-a-real-agent-7271'
  actual:   'Unknown agent: undefined'
# fail 1

# AFTER the fix:
ok 1 - POST /agents/[id]/dns awaits params — 404 echoes the real id, not 'undefined'
# pass 1

# neighbour DNS suites stay green (await on a plain object is a no-op):
$ node --import tsx/esm --test \
    tests/unit/agent-bridge-dns-route-validation.test.ts \
    tests/unit/agent-bridge-dns-toggle-method-7157.test.ts \
    tests/unit/agent-bridge-dns-params-7271.test.ts
# tests 6 / pass 6 / fail 0

$ npx eslint --suppressions-location config/quality/eslint-suppressions.json \
    "src/app/api/tools/agent-bridge/agents/[id]/dns/route.ts" \
    tests/unit/agent-bridge-dns-params-7271.test.ts
# clean (exit 0)

$ npm run typecheck:core
# clean (exit 0)
```

## Diff summary

- `src/app/api/tools/agent-bridge/agents/[id]/dns/route.ts` — `params` typed as `Promise<…>` and awaited.
- `tests/unit/agent-bridge-dns-params-7271.test.ts` — new regression guard.

Closes #7271.

Thanks @diegosouzapw for the clear repro and the screenshot pinpointing the 404 on Start DNS.
