### PR TITLE
fix(ci): fetch full base history in pr-test-policy (shallow graft breaks merge-base)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
         with:
           node-version: ${{ env.CI_NODE_VERSION }}
       - name: Fetch base branch
-        run: git fetch --no-tags origin "${GITHUB_BASE_REF}" --depth=1
+        run: git fetch --no-tags origin "${GITHUB_BASE_REF}"
       - name: Validate source changes include tests
         run: node scripts/check/check-pr-test-policy.mjs --summary-file .artifacts/pr-test-policy.md
       # Anti test-masking: flag net assert removal / new assert.ok(true) in changed tests.

--- a/changelog.d/maintenance/ci-pr-test-policy-shallow-base.md
+++ b/changelog.d/maintenance/ci-pr-test-policy-shallow-base.md
@@ -1,0 +1,1 @@
+- CI: `pr-test-policy` fetches the base branch with full history instead of `--depth=1` — the shallow graft made `merge-base` resolve wrong for PR branches that recently merged the release, so the three-dot diff blamed the PR for OTHER merged PRs' changes (false "deleted test"/"weakened asserts" reds; observed on #7329 being blamed for #7106's files).


### PR DESCRIPTION
## Problem

The `pr-test-policy` job fetches the base branch with `--depth=1`. The shallow graft makes `git merge-base` resolve incorrectly for PR branches that recently merged the release branch — the three-dot diff (`base...HEAD`) then attributes changes from **already-merged sibling PRs** to the PR under test.

## Observed live (2026-07-16, #7329)

The job flagged #7329 for:
- deleting `tests/unit/ui/provider-plan-config.test.tsx` — a file that exists in **no ref reachable from that PR** (deleted by an unrelated merged PR),
- "weakened asserts" in 3 test files whose content is byte-identical to the release tip,
- and listed #7106's antigravity files as the PR's changed files.

Local reproduction of the same head with full history returns **PASS**.

## Fix

Drop `--depth=1` from the base fetch. The job's checkout is already `fetch-depth: 0`, so the full-history base fetch only updates the ref — negligible cost.

## Validation

Mechanical 1-line workflow change; the failure mode is CI-topology-dependent (shallow graft), not reproducible as a unit test. Live evidence documented above per Hard Rule #18's real-environment path.