### PR TITLE
fix(sse): preserve chat quota across mixed windows

### DIFF
--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -315,7 +315,6 @@ function hydrateQuotaCacheFromSnapshots(connectionId: string): QuotaCacheEntry |
   const quotas: Record<string, QuotaInfo> = {};
   let provider = "";
   let fetchedAt = 0;
-  let exhausted = false;
   let windowDurationMs: number | null = null;
 
   for (const snapshot of snapshots) {
@@ -336,7 +335,6 @@ function hydrateQuotaCacheFromSnapshots(connectionId: string): QuotaCacheEntry |
       ),
       resetAt: camelSnapshot.nextResetAt ?? snapshot.next_reset_at ?? null,
     };
-    exhausted = exhausted || (camelSnapshot.isExhausted ?? snapshot.is_exhausted) === 1;
     const snapshotWindowDurationMs =
       camelSnapshot.windowDurationMs ?? snapshot.window_duration_ms ?? null;
     if (snapshotWindowDurationMs && snapshotWindowDurationMs > 0) {
@@ -348,6 +346,7 @@ function hydrateQuotaCacheFromSnapshots(connectionId: string): QuotaCacheEntry |
   }
 
   if (Object.keys(quotas).length === 0) return null;
+  const exhausted = isExhausted(quotas);
 
   const entry: QuotaCacheEntry = {
     connectionId,

--- a/tests/unit/quota-cache-hydrate-5015.test.ts
+++ b/tests/unit/quota-cache-hydrate-5015.test.ts
@@ -60,3 +60,34 @@ test("#5015 a connection with no snapshot is not reported exhausted", () => {
     "no snapshot → no hydration → not exhausted"
   );
 });
+
+test("mixed persisted Z.AI quota windows keep chat requests eligible", () => {
+  const connectionId = "conn-zai-mixed-windows";
+
+  quotaSnapshotsDb.saveQuotaSnapshot({
+    provider: "zai",
+    connection_id: connectionId,
+    window_key: "session",
+    remaining_percentage: 93,
+    is_exhausted: 0,
+    next_reset_at: "2099-01-01T00:00:00.000Z",
+    window_duration_ms: null,
+    raw_data: null,
+  });
+  quotaSnapshotsDb.saveQuotaSnapshot({
+    provider: "zai",
+    connection_id: connectionId,
+    window_key: "mcp_monthly",
+    remaining_percentage: 0,
+    is_exhausted: 1,
+    next_reset_at: "2099-02-01T00:00:00.000Z",
+    window_duration_ms: null,
+    raw_data: null,
+  });
+
+  assert.equal(
+    quotaCache.isQuotaExhaustedForRequest(connectionId, "zai", "glm-5.2"),
+    false,
+    "an exhausted tools window must not block chat while the session window has quota"
+  );
+});


### PR DESCRIPTION
## Summary
- Hydrate persisted quota exhaustion using the same all-windows rule (`isExhausted()`) that the live-fetch path uses, instead of an OR-across-windows flag. Previously, rebuilding the in-memory quota cache from `quota_snapshots` marked a whole connection exhausted if **any** single window was at 0%.
- Fixes a false `429 · All zai accounts have exhausted their quota` where an exhausted **tools** quota window (`mcp_monthly`, Web Search / Reader / Zread) blocked GLM **chat** traffic even though the 5-hour token window had ~93% remaining. API-key connections are especially affected because the background refresh only refreshes OAuth connections and deletes API-key cache entries each tick, so every request re-hydrates from snapshots and re-triggers the bug.
- Adds a regression test covering mixed persisted Z.AI quota windows (healthy `session` + exhausted `mcp_monthly`) asserting a chat request stays eligible.

## Root cause
`hydrateQuotaCacheFromSnapshots` set `exhausted = exhausted || row.is_exhausted === 1` (OR across windows), diverging from `setQuotaCache`/`isExhausted()` which require **every** window to be at 0%. `isQuotaExhaustedForRequest` only scopes per-window for the `codex` provider, so for all other providers a single exhausted window blocked all models.

## Test plan
- [x] Reproduced the failure with the new regression test before the fix (red), confirmed green after
- [x] `node --import tsx/esm --test tests/unit/quota-cache-hydrate-5015.test.ts tests/unit/quota-cache-is-exhausted-per-window-5923.test.ts tests/unit/quota-cache-snapshot-dedup-4438.test.ts`
- [x] `npx eslint src/domain/quotaCache.ts tests/unit/quota-cache-hydrate-5015.test.ts`
- [x] `npm run typecheck:core`
- [x] Live `zai/glm-5.2` request through a local OmniRoute returned HTTP 200 after clearing the stale snapshot

Made with [Cursor](https://cursor.com)