### PR TITLE
fix(oauth): surface sanitized device-code error instead of a generic 500

### DIFF
--- a/src/app/api/oauth/[provider]/[action]/route.ts
+++ b/src/app/api/oauth/[provider]/[action]/route.ts
@@ -259,7 +259,12 @@ export async function GET(
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   } catch (error) {
     console.error("OAuth GET error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    // Surface the SANITIZED upstream reason instead of a generic 500 that hides WHY the flow failed.
+    // device-code providers (qwen → qwen.ai, codebuddy-cn → copilot.tencent.com) throw a descriptive
+    // message ("Device code request failed: …", "CodeBuddy state request failed (403)") that was being
+    // swallowed, so a geo-block / upstream outage looked identical to a real server bug in the UI.
+    const detail = sanitizeErrorMessage(error instanceof Error ? error.message : String(error));
+    return NextResponse.json({ error: detail || "Internal server error" }, { status: 500 });
   }
 }
 

--- a/tests/unit/oauth-device-code-error-transparency.test.ts
+++ b/tests/unit/oauth-device-code-error-transparency.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Regression guard for "qwen / codebuddy-cn device-code show 'ошибка сервера OmniRoute'".
+// The dynamic OAuth GET handler used to swallow EVERY thrown error into a generic
+// `{ error: "Internal server error" }` 500, so a device-code upstream failure (qwen.ai /
+// copilot.tencent.com — geo-block, outage, bad client) was indistinguishable from a real
+// server bug. The fix surfaces the SANITIZED upstream message via sanitizeErrorMessage.
+//
+// Source-level guard: the route runs inside the Next server (auth + module graph), so a
+// behavioural test would need a full request/auth/upstream mock; this pins the exact change.
+const here = dirname(fileURLToPath(import.meta.url));
+const route = readFileSync(
+  resolve(here, "../../src/app/api/oauth/[provider]/[action]/route.ts"),
+  "utf8"
+);
+
+test("OAuth GET catch surfaces the sanitized upstream reason, not a bare generic 500", () => {
+  assert.match(
+    route,
+    /const detail = sanitizeErrorMessage\(/,
+    "the GET catch must sanitize and surface the real error"
+  );
+  assert.match(
+    route,
+    /error:\s*detail\s*\|\|\s*"Internal server error"/,
+    "the GET catch must return the sanitized detail (falling back to the generic only when empty)"
+  );
+});


### PR DESCRIPTION
## Problem
The dynamic OAuth `GET /api/oauth/[provider]/[action]` handler swallowed every thrown error into a generic `{ error: "Internal server error" }` 500. So a **device-code upstream failure** — qwen (`qwen.ai`), codebuddy-cn (`copilot.tencent.com`) — surfaced in the companion extension as an indistinguishable *'ошибка сервера OmniRoute'*, hiding **why** it failed (geo-block, upstream outage, bad client). `requestDeviceCode` already throws a descriptive message (`Device code request failed: …`, `CodeBuddy state request failed (403)`) — it was just discarded.

## Fix
Route the caught error through `sanitizeErrorMessage()` (already imported in the file; hard rule #12) and return it, falling back to the generic string only when the sanitizer yields nothing.

## Tests
`tests/unit/oauth-device-code-error-transparency.test.ts` — regression guard (fails on the pre-fix base, passes after). Source-level: the route needs the full Next request/auth/upstream graph, so behavioural validation (a real device-code failure) belongs on a build/VPS per hard rule #18.