### PR TITLE
test(ci): static body in codex e2e mock route bridge (CodeQL #737)

### DIFF
--- a/tests/integration/codex-chat-reasoning-http-e2e.test.ts
+++ b/tests/integration/codex-chat-reasoning-http-e2e.test.ts
@@ -178,10 +178,12 @@ async function startRouteServer() {
         body,
       });
       await bridgeRouteResponse(await chatRoute.POST(request), outgoing);
-    } catch (error) {
-      // Mock route bridge: surface the message, never the raw stack (js/stack-trace-exposure).
+    } catch {
+      // Mock route bridge: static body only — CodeQL flags ANY error-derived value here,
+      // including error.message / String(error) (js/stack-trace-exposure #736/#737). The test
+      // only asserts status===200, so the 500 body is never inspected.
       outgoing.writeHead(500, { "content-type": "text/plain" });
-      outgoing.end(error instanceof Error ? error.message : String(error));
+      outgoing.end("internal test route error");
     }
   });
 


### PR DESCRIPTION
## What

Replaces the error-derived 500 body in the codex Responses e2e mock route bridge (`tests/integration/codex-chat-reasoning-http-e2e.test.ts`, line 184) with a **static string**.

## Why

CodeQL `js/stack-trace-exposure` flags **any** error-derived value returned from that catch, not only `error.stack`:

- #7354 swapped `error.stack` → `error.message` and cleared alert **#736** ✅
- but sibling alert **#737** (same file, same line) stayed **open** — CodeQL treats `error.message` / `String(error)` as stack-exposure too.

**#737 is currently the only open CodeQL alert in the whole repo**, and `check:codeql-ratchet` counts alerts repo-wide → it keeps `Quality Ratchet` red on **every** open PR. This closes it at the source.

## Fix

```ts
} catch {
  // static body only — CodeQL flags any error-derived value here
  outgoing.writeHead(500, { "content-type": "text/plain" });
  outgoing.end("internal test route error");
}
```

The test only asserts `status === 200`, so the 500 body is never inspected — no assertion weakened.

## Validation (Hard Rule #18)

`node --import tsx/esm --test tests/integration/codex-chat-reasoning-http-e2e.test.ts` → **1 pass, 0 fail**.

Companion PR opens against `main` (the file exists on both branches) per merge-gates §8.