### PR TITLE
test(ci): static body in codex e2e mock route bridge (CodeQL #737) — main companion

### DIFF
--- a/tests/integration/codex-chat-reasoning-http-e2e.test.ts
+++ b/tests/integration/codex-chat-reasoning-http-e2e.test.ts
@@ -178,10 +178,12 @@ async function startRouteServer() {
         body,
       });
       await bridgeRouteResponse(await chatRoute.POST(request), outgoing);
-    } catch (error) {
-      // Mock route bridge: surface the message, never the raw stack (js/stack-trace-exposure).
+    } catch {
+      // Mock route bridge: static body only — CodeQL flags ANY error-derived value here,
+      // including error.message / String(error) (js/stack-trace-exposure #736/#737). The test
+      // only asserts status===200, so the 500 body is never inspected.
       outgoing.writeHead(500, { "content-type": "text/plain" });
-      outgoing.end(error instanceof Error ? error.message : String(error));
+      outgoing.end("internal test route error");
     }
   });
 


### PR DESCRIPTION
## What

Companion to the release/v3.8.49 PR (#7558) — the same file exists on `main`, carrying the same open CodeQL alert. Per merge-gates §8, a gate/CI-touching fix lands on `main` in the same session so `main` doesn't bleed the whole cycle.

## Why

CodeQL `js/stack-trace-exposure` flags **any** error-derived value returned from the mock route bridge's 500 path, not only `error.stack`. Alert **#737** (same file/line as the already-fixed #736) stays open and is the **only** open CodeQL alert repo-wide → `check:codeql-ratchet` keeps `Quality Ratchet` red on every open PR.

## Fix

```ts
} catch {
  outgoing.writeHead(500, { "content-type": "text/plain" });
  outgoing.end("internal test route error");
}
```

Static body, no error content. The test only asserts `status === 200`, so the 500 body is never inspected — no assertion weakened.

## Validation (Hard Rule #18)

`node --import tsx/esm --test tests/integration/codex-chat-reasoning-http-e2e.test.ts` → **1 pass, 0 fail** (verified on the release worktree; identical diff).