### PR TITLE
fix(sse): feed compression pipeline the authoritative vision capability (#7237)

### DIFF
--- a/changelog.d/fixes/7237-vision-compression-authoritative-capability.md
+++ b/changelog.d/fixes/7237-vision-compression-authoritative-capability.md
@@ -1,0 +1,1 @@
+- fix(sse): feed the compression pipeline the authoritative vision capability instead of the conservative model-id heuristic, so vision models absent from the fragment list (e.g. gpt-5.5) no longer have their image_url blocks silently stripped (#7237)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -112,9 +112,8 @@ import { normalizeClaudeHaikuConstraints } from "../services/claudeHaikuConstrai
 import { echoModelInObject } from "../services/responseModelEcho.ts";
 import { stripGpt5SamplingWhenReasoning } from "../services/gpt5SamplingGuard.ts";
 import { getUnsupportedParams, REGISTRY } from "../config/providerRegistry.ts";
-import { supportsMaxTokens } from "@/lib/modelCapabilities.ts";
+import { supportsMaxTokens, getResolvedModelCapabilities } from "@/lib/modelCapabilities.ts";
 import { normalizeThinkingForModel } from "@/shared/constants/modelSpecs.ts";
-import { isVisionModelId } from "@/shared/constants/visionModels.ts";
 import {
   buildErrorBody,
   createErrorResult,
@@ -1327,7 +1326,16 @@ export async function handleChatCore({
         const compressionConfig = resolveCacheAwareConfig(config, compressionInputBody, cacheCtx);
         const result = await applyCompressionAsync(compressionInputBody, mode, {
           model: effectiveModel,
-          supportsVision: isVisionModelId(effectiveModel),
+          // #7237: feed the AUTHORITATIVE capability (model spec / models.dev sync / DB
+          // override, with the conservative model-id fragment heuristic only as its
+          // last-resort fallback) instead of calling the heuristic directly here. The
+          // heuristic alone wrongly returned false for e.g. gpt-5.5 (registered
+          // supportsVision:true in modelSpecs but absent from the deliberately-conservative
+          // fragment list), and lite.ts's gate (`supportsVision !== false`) treated that
+          // false as "strip every image_url block". Resolves to `null` for genuinely unknown
+          // models, which is intentionally NOT `false` so the gate still preserves images.
+          supportsVision: getResolvedModelCapabilities({ provider, model: effectiveModel })
+            .supportsVision,
           // Rota direta oficial ('anthropic') vs agregadores: o engine omniglyph
           // exige 'direct' — agregadores redimensionam imagens (medido 2026-07-06).
           providerTransport: provider === "anthropic" ? "direct" : "aggregator",

--- a/tests/unit/vision-compression-authoritative-capability-7237.test.ts
+++ b/tests/unit/vision-compression-authoritative-capability-7237.test.ts
@@ -1,0 +1,85 @@
+/**
+ * #7237 — vision-capable models lose image_url blocks under compression.
+ *
+ * `open-sse/handlers/chatCore.ts` fed `applyCompressionAsync`'s `supportsVision` option
+ * from `isVisionModelId(effectiveModel)` — the deliberately-conservative model-id
+ * fragment heuristic in `src/shared/constants/visionModels.ts` — instead of the
+ * authoritative `getResolvedModelCapabilities().supportsVision` that every other
+ * vision-aware code path (e.g. the vision-bridge guardrail) uses.
+ *
+ * `gpt-5.5` is registered with `supportsVision: true` in `src/shared/constants/modelSpecs.ts`
+ * but has no gpt-5.x entry in the fragment list, so the heuristic wrongly returned `false`.
+ * `open-sse/services/compression/lite.ts::replaceImageUrls()` gates on
+ * `supportsVision !== false`, so that spurious `false` made it silently strip every
+ * `image_url` block from the request before it ever reached the executor.
+ *
+ * This test asserts the CORRECT, authoritative-capability-driven behavior: gpt-5.5
+ * keeps its images through the lite-compression path.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { isVisionModelId } from "../../src/shared/constants/visionModels.ts";
+import { getResolvedModelCapabilities } from "../../src/lib/modelCapabilities.ts";
+import { replaceImageUrls } from "../../open-sse/services/compression/lite.ts";
+import { applyCompressionAsync } from "../../open-sse/services/compression/strategySelector.ts";
+
+function imageBody() {
+  return {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,iVBOR" } }],
+      },
+    ],
+  };
+}
+
+describe("#7237 vision-capable models keep their images through compression", () => {
+  it("documents the drift: the conservative id-fragment heuristic disagrees with the authoritative spec for gpt-5.5", () => {
+    assert.equal(
+      isVisionModelId("gpt-5.5"),
+      false,
+      "the fragment-list heuristic has no gpt-5.x entry — it is a deliberately conservative fallback, not the source of truth"
+    );
+    assert.equal(
+      getResolvedModelCapabilities({ model: "gpt-5.5" }).supportsVision,
+      true,
+      "modelSpecs.ts registers gpt-5.5 with supportsVision:true — this is the authoritative source chatCore must use"
+    );
+  });
+
+  it("replaceImageUrls preserves the image when fed the authoritative capability (the fixed chatCore.ts:1330 behavior)", () => {
+    const authoritativeSupportsVision = getResolvedModelCapabilities({
+      model: "gpt-5.5",
+    }).supportsVision;
+    const result = replaceImageUrls(imageBody(), { supportsVision: authoritativeSupportsVision });
+    assert.equal(result.applied, false, "the image must be KEPT, not stripped to a placeholder");
+    const content = result.body.messages?.[0]?.content as Array<Record<string, unknown>>;
+    assert.equal(content[0].type, "image_url", "the block must remain a real image_url block");
+  });
+
+  it("regresses the pre-fix bug: feeding the raw heuristic value strips the image for gpt-5.5", () => {
+    const buggyValue = isVisionModelId("gpt-5.5"); // false — the pre-fix chatCore.ts:1330 input
+    const result = replaceImageUrls(imageBody(), { supportsVision: buggyValue });
+    assert.equal(
+      result.applied,
+      true,
+      "sanity check: this reproduces the bug shape when fed the wrong (heuristic) value"
+    );
+  });
+
+  it("applyCompressionAsync end-to-end (lite mode) keeps image_url blocks for gpt-5.5 when fed the authoritative capability", async () => {
+    const model = "gpt-5.5";
+    const supportsVision = getResolvedModelCapabilities({ model }).supportsVision;
+    const result = await applyCompressionAsync(imageBody(), "lite", { model, supportsVision });
+    const content = (result.body as { messages: Array<{ content: unknown }> }).messages[0]
+      .content as Array<Record<string, unknown>>;
+    assert.equal(content[0].type, "image_url", "gpt-5.5 must keep its image_url block intact");
+    assert.equal(
+      (content[0].image_url as Record<string, unknown>)?.url,
+      "data:image/png;base64,iVBOR",
+      "the original data URL must survive unchanged"
+    );
+  });
+});


### PR DESCRIPTION
Closes #7237

## Root cause

`open-sse/handlers/chatCore.ts:1330` fed the `supportsVision` flag into
`applyCompressionAsync` from `isVisionModelId(effectiveModel)` — the
deliberately-conservative model-id fragment heuristic in
`src/shared/constants/visionModels.ts` (its own docstring says to keep it
conservative: newly-released vision models get zero-touch support via the
models.dev sync, not this fallback) — instead of the authoritative
`getResolvedModelCapabilities().supportsVision` that every other
vision-aware path (notably the vision-bridge guardrail) uses.

`gpt-5.5` is registered with `supportsVision: true` in
`src/shared/constants/modelSpecs.ts`, but the fragment list has no
gpt-5.x entry, so the heuristic wrongly returned `false`. That spurious
`false` reached `open-sse/services/compression/lite.ts::replaceImageUrls()`,
whose gate is `supportsVision !== false` — it only strips images when told
explicitly `false` — so every `image_url` block was silently replaced with
a `[image: png]` text placeholder before the request ever reached
AgentRouter/Freemodel.dev (or any other openai-compat passthrough
provider).

This also explains the three symptoms in the report: it reproduces even
though the model is marked `vision: true`; disabling Vision Bridge changes
nothing (separate code path — lite compression runs earlier); and
"updating model capabilities" in the UI never helped because
`modelCapabilityOverrides.ts` only supports a `max_token` override, there
is no vision override to set.

## Fix

Swap the heuristic for the authoritative capability at the single call
site:

```ts
supportsVision: getResolvedModelCapabilities({ provider, model: effectiveModel })
  .supportsVision,
```

`getResolvedModelCapabilities().supportsVision` is `boolean | null` and
falls back to the same conservative heuristic internally only when no
spec/registry/sync data exists — so genuinely unknown models resolve to
`null`, which `lite.ts`'s `!== false` gate already treats as
preserve-by-default. This avoids re-introducing the #4071/#4012 class of
bug (blinding a model that can actually see).

## Regression test

`tests/unit/vision-compression-authoritative-capability-7237.test.ts` —
4 assertions:
1. documents the drift: `isVisionModelId('gpt-5.5') === false` while the
   authoritative spec says `supportsVision: true`
2. `replaceImageUrls` preserves the image when fed the authoritative
   capability (the fixed behavior)
3. sanity-checks the pre-fix bug shape (feeding the raw heuristic value
   strips the image)
4. end-to-end through `applyCompressionAsync(..., 'lite', ...)` with
   `model: 'gpt-5.5'` — the image_url block and its original data URL
   survive intact

RED→GREEN: reproduced the pre-fix behavior standalone (feeding
`isVisionModelId('gpt-5.5')` — `false` — into `applyCompressionAsync`)
and confirmed the placeholder strip:

```json
[{ "type": "text", "text": "[image: png]" }]
```

Post-fix, the same flow (feeding `getResolvedModelCapabilities(...).supportsVision`)
preserves the image_url block unchanged — verified both via the
standalone repro and the 4/4 passing regression test.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK (no frozen file grew)
- `node scripts/check/check-complexity.mjs` — OK (2054 ≤ baseline 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 ≤ baseline 890)
- `npm run typecheck:core` — clean (chatCore.ts is outside the typecheck:core
  allowlist, so also sanity-compiled it against the full `tsconfig.json`;
  the pre-existing strict-mode errors it reports are all in unrelated
  regions of the file, none touching the changed import or the compression
  call site)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/handlers/chatCore.ts tests/unit/vision-compression-authoritative-capability-7237.test.ts` — clean
- Full related test sweep, 106/106 pass: `tests/unit/compression/lite.test.ts`,
  `tests/unit/vision-detection-consistency.test.ts`,
  `tests/unit/guardrails/visionBridge.test.ts`,
  `tests/unit/combo-vision-aware-routing.test.ts`,
  `tests/unit/model-capabilities-mimo-vision-override.test.ts`,
  `tests/unit/model-capabilities-mistral-vision-sync-4073.test.ts`,
  `tests/unit/llm-selector-custom-vision-models.test.ts`,
  `tests/unit/command-code-vision.test.ts`,
  `tests/unit/vision-compression-authoritative-capability-7237.test.ts`
- chatCore compression-integration sweep, 85/85 pass:
  `tests/unit/chatcore-compression-usage-receipt.test.ts`,
  `tests/unit/chatcore-translation-paths.test.ts`,
  `tests/unit/chatcore-compression-settings.test.ts`,
  `tests/unit/chatcore-compression-combo-predicates.test.ts`,
  `tests/unit/chatcore-compression-integration.test.ts`,
  `tests/unit/chatcore-compression-analytics-write.test.ts`,
  `tests/unit/chatcore-caveman-output-analytics.test.ts`,
  `tests/unit/chatcore-compression-cache-stats.test.ts`

## Not confirmed by this mechanism

Per the analysis plan-file, `claude-opus-4-6/4-7/4-8` ids match the
existing `claude-opus-4` fragment, so this specific mechanism should not
affect them. If the reporter's Claude cases are also broken, that would
be a second, separate cause worth tracking in a follow-up.