### PR TITLE
fix(dashboard): providers model-name filter matches live/synced catalog (#7250)

### DIFF
--- a/changelog.d/fixes/7250-provider-model-filter-live-catalog.md
+++ b/changelog.d/fixes/7250-provider-model-filter-live-catalog.md
@@ -1,0 +1,1 @@
+- fix(dashboard): providers model-name filter now matches an aggregator's live/synced catalog, not just the static curated registry (#7250)

--- a/src/app/(dashboard)/dashboard/providers/hooks/useSyncedModelsByProvider.ts
+++ b/src/app/(dashboard)/dashboard/providers/hooks/useSyncedModelsByProvider.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { LiveModelsByProviderId } from "../providerPageUtils";
+
+/**
+ * useSyncedModelsByProvider — fetch the live/synced model catalog for every
+ * provider connection via GET /api/synced-available-models, so the Providers
+ * page model-name filter can match against real upstream models (not just
+ * the static curated registry). See #7250: aggregator providers (openrouter,
+ * kilocode, theoldllm...) declare a single-entry static placeholder, so a
+ * search for a real model name never matched and silently hid the provider.
+ *
+ * Fails soft — a fetch error leaves the map empty, and callers fall back to
+ * the static registry only.
+ */
+export function useSyncedModelsByProvider(): LiveModelsByProviderId {
+  const [models, setModels] = useState<LiveModelsByProviderId>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/synced-available-models")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data && typeof data === "object") {
+          setModels(data as LiveModelsByProviderId);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return models;
+}

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -17,6 +17,7 @@ import { pickDisplayValue } from "@/shared/utils/maskEmail";
 import useEmailPrivacyStore from "@/store/emailPrivacyStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { useTranslations } from "next-intl";
+import { useSyncedModelsByProvider } from "./hooks/useSyncedModelsByProvider";
 import {
   buildStaticProviderEntries,
   buildCompatibleProviderGroups,
@@ -191,6 +192,7 @@ export default function ProvidersPage() {
   const [repairingEnv, setRepairingEnv] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [modelSearchQuery, setModelSearchQuery] = useState("");
+  const liveModelsByProviderId = useSyncedModelsByProvider();
   const [showFreeOnly, setShowFreeOnly] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   // #4240: media-category (serviceKind) filter — composes with activeCategory,
@@ -497,7 +499,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const rawNoAuthEntriesAll = buildStaticProviderEntries("no-auth", getProviderStats);
@@ -514,7 +517,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const apiKeyProviderEntriesAll = buildStaticProviderEntries("apikey", getProviderStats);
@@ -532,7 +536,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
   const aggregatorProviderEntriesAll = apiKeyProviderEntriesAll.filter((entry) =>
     AGGREGATOR_PROVIDER_IDS.has(entry.providerId)
@@ -543,7 +548,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
   const imageProviderEntriesAll = apiKeyProviderEntriesAll.filter((entry) =>
     IMAGE_ONLY_PROVIDER_IDS.has(entry.providerId)
@@ -554,7 +560,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
   const enterpriseProviderEntriesAll = apiKeyProviderEntriesAll.filter((entry) =>
     ENTERPRISE_CLOUD_PROVIDER_IDS.has(entry.providerId)
@@ -565,7 +572,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
   const videoProviderEntriesAll = apiKeyProviderEntriesAll.filter((entry) =>
     VIDEO_PROVIDER_IDS.has(entry.providerId)
@@ -576,7 +584,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
   const embeddingRerankProviderEntriesAll = apiKeyProviderEntriesAll.filter((entry) =>
     EMBEDDING_RERANK_PROVIDER_IDS.has(entry.providerId)
@@ -587,7 +596,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const webCookieProviderEntriesAll = buildStaticProviderEntries("web-cookie", getProviderStats);
@@ -597,7 +607,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const localProviderEntriesAll = buildStaticProviderEntries("local", getProviderStats);
@@ -607,7 +618,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const searchProviderEntriesAll = buildStaticProviderEntries("search", getProviderStats);
@@ -617,7 +629,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const audioProviderEntriesAll = buildStaticProviderEntries("audio", getProviderStats);
@@ -627,7 +640,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const cloudAgentProviderEntriesAll = buildStaticProviderEntries("cloud-agent", getProviderStats);
@@ -637,7 +651,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const upstreamProxyEntriesAll = buildStaticProviderEntries("upstream-proxy", getProviderStats);
@@ -647,7 +662,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const compatibleProviderEntriesAll = [
@@ -679,7 +695,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const staticProviderEntriesAll = dedupeProviderEntries([
@@ -704,7 +721,8 @@ export default function ProvidersPage() {
     searchQuery,
     undefined,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   // IDE providers: subset of oauth/apikey providers that are editors/IDEs with
@@ -719,7 +737,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const oauthOnlyEntriesAll = oauthProviderEntriesAll
@@ -739,7 +758,8 @@ export default function ProvidersPage() {
     searchQuery,
     showFreeOnly,
     modelSearchQuery,
-    activeServiceKind
+    activeServiceKind,
+    liveModelsByProviderId
   );
 
   const compactProviderEntries = buildCompactProviderEntriesForPage({

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -212,13 +212,35 @@ export function buildCompatibleProviderGroups(
   return { openai, anthropic, claudeCode };
 }
 
+export type LiveModelsByProviderId = Record<string, Array<{ id: string; name?: string }>>;
+
+/**
+ * Models to match against for the model-name filter: the static curated
+ * registry PLUS any live/synced catalog for that provider connection (#7250).
+ * Aggregator providers (openrouter, kilocode, theoldllm...) declare a
+ * single-entry static placeholder — matching only that entry means a search
+ * for any real upstream model name can never match, silently hiding the
+ * provider. When the live catalog is empty/unavailable we fall back to the
+ * static-only list so already-correct static providers are unaffected.
+ */
+function getFilterableModelsForEntry(
+  providerId: string,
+  liveModelsByProviderId?: LiveModelsByProviderId
+): Array<{ id: string; name?: string }> {
+  const staticModels = getModelsByProviderId(providerId);
+  const liveModels = liveModelsByProviderId?.[providerId];
+  if (!liveModels || liveModels.length === 0) return staticModels;
+  return [...staticModels, ...liveModels];
+}
+
 export function filterConfiguredProviderEntries<TProvider>(
   entries: ProviderEntry<TProvider>[],
   showConfiguredOnly: boolean,
   searchQuery?: string,
   showFreeOnly?: boolean,
   modelSearchQuery?: string,
-  serviceKindFilter?: string | null
+  serviceKindFilter?: string | null,
+  liveModelsByProviderId?: LiveModelsByProviderId
 ): ProviderEntry<TProvider>[] {
   let filtered = entries;
 
@@ -261,8 +283,8 @@ export function filterConfiguredProviderEntries<TProvider>(
   if (modelSearchQuery && modelSearchQuery.trim()) {
     const q = modelSearchQuery.trim();
     filtered = filtered.filter((entry) => {
-      const models = getModelsByProviderId(entry.providerId);
-      return models.some((m) => matchesSearch(m.id, q) || matchesSearch(m.name, q));
+      const models = getFilterableModelsForEntry(entry.providerId, liveModelsByProviderId);
+      return models.some((m) => matchesSearch(m.id, q) || matchesSearch(m.name || "", q));
     });
   }
 

--- a/tests/unit/provider-model-filter-live-catalog-7250.test.ts
+++ b/tests/unit/provider-model-filter-live-catalog-7250.test.ts
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const providerPageUtils =
+  await import("../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts");
+
+// #7250: the Providers page model-name filter only matched against the static
+// curated model registry (getModelsByProviderId), never against a provider's
+// live/synced catalog. Aggregator providers (openrouter, kilocode,
+// theoldllm...) declare a single-entry static placeholder
+// (`{ id: "auto", name: "Auto (Best Available)" }` for openrouter), so a
+// search for any real upstream model name — e.g. "laguna" — could never
+// match, and the whole provider silently disappeared from the list.
+
+function makeOpenRouterEntry() {
+  return {
+    providerId: "openrouter",
+    provider: { name: "OpenRouter" },
+    stats: { total: 1 },
+    displayAuthType: "apikey" as const,
+    toggleAuthType: "apikey" as const,
+  };
+}
+
+test("#7250: model filter still finds openrouter by its static 'auto' model id (non-regression)", () => {
+  const entries = [makeOpenRouterEntry()];
+
+  const filtered = providerPageUtils.filterConfiguredProviderEntries(
+    entries,
+    false,
+    undefined,
+    undefined,
+    "auto"
+  );
+
+  assert.equal(
+    filtered.length,
+    1,
+    "static registry match must keep working when no live catalog is supplied"
+  );
+});
+
+test("#7250: model filter hides openrouter for a real upstream model name when only the static catalog is available (documents the bug's shape)", () => {
+  const entries = [makeOpenRouterEntry()];
+
+  const filtered = providerPageUtils.filterConfiguredProviderEntries(
+    entries,
+    false,
+    undefined,
+    undefined,
+    "laguna"
+  );
+
+  assert.equal(
+    filtered.length,
+    0,
+    "with no live catalog supplied, a real model name cannot match the single-entry static registry"
+  );
+});
+
+test("#7250: model filter matches a real upstream model name when the live/synced catalog is supplied", () => {
+  const entries = [makeOpenRouterEntry()];
+  const liveModelsByProviderId = {
+    openrouter: [
+      { id: "meta-llama/llama-3.1-laguna", name: "Llama 3.1 Laguna" },
+      { id: "anthropic/claude-3.5-sonnet", name: "Claude 3.5 Sonnet" },
+    ],
+  };
+
+  const filtered = providerPageUtils.filterConfiguredProviderEntries(
+    entries,
+    false,
+    undefined,
+    undefined,
+    "laguna",
+    undefined,
+    liveModelsByProviderId
+  );
+
+  assert.equal(
+    filtered.length,
+    1,
+    "openrouter must be found once its live catalog is consulted, not just the static placeholder"
+  );
+  assert.equal(filtered[0].providerId, "openrouter");
+});
+
+test("#7250: an empty live catalog entry falls back to the static registry instead of excluding the provider", () => {
+  const entries = [makeOpenRouterEntry()];
+  const liveModelsByProviderId = { openrouter: [] };
+
+  const filtered = providerPageUtils.filterConfiguredProviderEntries(
+    entries,
+    false,
+    undefined,
+    undefined,
+    "auto",
+    undefined,
+    liveModelsByProviderId
+  );
+
+  assert.equal(
+    filtered.length,
+    1,
+    "an empty/never-synced live catalog must not regress the static-only match"
+  );
+});
+
+test("#7250: providers with a fully static catalog are unaffected by an unrelated live catalog map", () => {
+  const entries = [
+    {
+      providerId: "minimax",
+      provider: { name: "MiniMax" },
+      stats: { total: 1 },
+      displayAuthType: "apikey" as const,
+      toggleAuthType: "apikey" as const,
+    },
+  ];
+  const liveModelsByProviderId = {
+    openrouter: [{ id: "meta-llama/llama-3.1-laguna", name: "Llama 3.1 Laguna" }],
+  };
+
+  const filtered = providerPageUtils.filterConfiguredProviderEntries(
+    entries,
+    false,
+    undefined,
+    undefined,
+    "minimax-m3",
+    undefined,
+    liveModelsByProviderId
+  );
+
+  assert.equal(
+    filtered.length,
+    1,
+    "minimax's own static-catalog match must be unaffected by an unrelated provider's live catalog"
+  );
+});


### PR DESCRIPTION
Closes #7250

## Root cause

The Providers page model-name filter (`filterConfiguredProviderEntries`,
`src/app/(dashboard)/dashboard/providers/providerPageUtils.ts`) matched only
against `getModelsByProviderId(...)`, the static curated model registry —
never the live/synced catalog actually available through the connection.

Aggregator providers with dynamic catalogs (OpenRouter, kilocode,
[provider removed at its operator's request]...) declare a single-entry static placeholder in the registry —
OpenRouter's is exactly `{ id: "auto", name: "Auto (Best Available)" }`. So
searching for any real upstream model name (e.g. the reporter's "laguna")
could never match that one-entry array, and the whole provider silently
disappeared from the list.

## Fix

- Added `useSyncedModelsByProvider` (new hook,
  `src/app/(dashboard)/dashboard/providers/hooks/useSyncedModelsByProvider.ts`)
  that reads the already-existing `GET /api/synced-available-models` — the
  same per-connection synced-model store the combo builder's live model
  picker already relies on.
- `filterConfiguredProviderEntries` now unions the static registry with this
  live catalog (when present) via a new `getFilterableModelsForEntry`
  helper, instead of only ever reading the static registry.
- An empty/never-synced live catalog for a provider falls back to the
  static-only match, so providers that were already correctly filtered
  (fully static catalogs) are unaffected — no regression for the common
  case.

## Regression test (TDD, Hard Rule #18)

`tests/unit/provider-model-filter-live-catalog-7250.test.ts` — 5 cases:

1. Static-registry match still works with no live catalog supplied
   (non-regression).
2. Documents the original bug's shape: a real model name returns 0 results
   when only the static catalog is available.
3. Proves the fix: the same real model name returns 1 result once the live
   catalog is supplied.
4. An empty live-catalog entry falls back to the static match instead of
   excluding the provider.
5. A fully-static provider (`minimax`) is unaffected by an unrelated
   provider's live catalog map.

RED→GREEN, reproduced by reverting only `providerPageUtils.ts` to the
unfixed `HEAD` content and re-running the suite: test 3 fails
(`0 !== 1`, "openrouter must be found once its live catalog is consulted,
not just the static placeholder") on the unfixed code, and all 5 pass with
the fix applied.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK (no new frozen violations)
- `node scripts/check/check-complexity.mjs` — OK (2054 vs baseline 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 vs baseline 890)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- New regression test: 5/5 pass
- Existing tests of the touched module/file — all green:
  `tests/unit/provider-node-dedup-4746.test.ts`,
  `tests/unit/providers-page-data-timeout.test.ts`,
  `tests/unit/provider-service-kind-filter-4240.test.ts`,
  `tests/unit/providers-page-utils.test.ts` (37/37)

## Scope

Diff limited to the model-name filter path: `providerPageUtils.ts` (new
`LiveModelsByProviderId` type + `getFilterableModelsForEntry` helper),
`page.tsx` (wires the new hook into every `filterConfiguredProviderEntries`
call site), the new hook file, and the regression test. No drive-by
refactors.