### PR TITLE
fix(dashboard): surface rate-limit warning on 429 chat-probe (#7284)

### DIFF
--- a/changelog.d/fixes/7284-conn-test-429.md
+++ b/changelog.d/fixes/7284-conn-test-429.md
@@ -1,0 +1,1 @@
+- fix(dashboard): connection Test surfaces a rate-limit warning on 429 chat-probe responses instead of an unqualified pass (#7284)

--- a/src/lib/providers/validation/openaiFormat.ts
+++ b/src/lib/providers/validation/openaiFormat.ts
@@ -170,6 +170,19 @@ export async function validateOpenAILikeProvider({
       return { valid: false, error: `Provider unavailable (${chatRes.status})` };
     }
 
+    // #7284: A 429 on the chat probe means the key is accepted but this connection
+    // is rate/concurrency limited (e.g. always-throttled free tiers like opencode-zen).
+    // Keep valid:true (the key works) but surface a warning so the connection Test
+    // does not read as an unqualified green when real traffic will hit 429s.
+    // Mirrors validateBedrockProvider's existing 429 precedent above.
+    if (chatRes.status === 429) {
+      return {
+        valid: true,
+        error: null,
+        warning: "Provider accepted the key but is rate limited (429)",
+      };
+    }
+
     return { valid: true, error: null };
   } catch (error: any) {
     return toValidationErrorResult(error);

--- a/tests/unit/issue-7284-connection-test-masks-429.test.ts
+++ b/tests/unit/issue-7284-connection-test-masks-429.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { validateOpenAILikeProvider } = await import(
+  "../../src/lib/providers/validation/openaiFormat.ts"
+);
+
+test("#7284: a 429 chat-probe response is reported with a rate-limit warning, not plain valid", async () => {
+  const originalFetch = globalThis.fetch;
+  let callCount = 0;
+
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    callCount += 1;
+    const href =
+      typeof url === "string" ? url : "url" in url ? url.url : url instanceof URL ? url.href : "";
+    if (href.includes("/models")) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(JSON.stringify({ error: { message: "Too Many Requests" } }), {
+      status: 429,
+    });
+  }) as typeof fetch;
+
+  try {
+    const result = await validateOpenAILikeProvider({
+      provider: "opencode-zen",
+      apiKey: "test-key",
+      baseUrl: "https://opencode.ai/zen/v1",
+      modelId: "test-model",
+      providerSpecificData: {},
+    });
+
+    assert.equal(callCount, 2, "expected a /models probe followed by a chat probe");
+
+    const typedResult = result as { valid: boolean; error: string | null; warning?: string };
+
+    assert.equal(typedResult.valid, true, "429 on the chat probe should still be treated as valid");
+    assert.equal(typedResult.error, null);
+    assert.equal(
+      typeof typedResult.warning,
+      "string",
+      "429 response must carry a warning field signaling the rate limit"
+    );
+    assert.match(typedResult.warning as string, /rate limit/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
Closes #7284

## Root cause

`src/lib/providers/validation/openaiFormat.ts::validateOpenAILikeProvider` — chat-probe status handling only special-cased `401/403` (invalid), `404/405` (unsupported), and `>=500` (unavailable). Every other status — **429 included** — fell through to the unqualified `return { valid: true, error: null }`.

This function backs every `OPENAI_LIKE_FORMATS` provider, including `opencode-zen`, a provider classified `"avoid"` in `open-sse/config/freeTierCatalog.ts` for being rate/concurrency limited. For such a permanently-throttled free tier, the dashboard connection Test's 1-token probe reports green forever while real traffic gets 429 on every request — no signal to the user that anything is wrong.

The sibling `validateBedrockProvider` in the same file already special-cases 429 with `warning: "Bedrock accepted the key but model discovery is rate limited"` while keeping `valid: true` — proving the pattern exists in this codebase and was simply never applied to the (far more heavily used) OpenAI-like path.

## Fix

Added a 429 branch to `validateOpenAILikeProvider`'s chat-probe handling, mirroring the existing Bedrock precedent: keeps `valid: true` (the key is genuinely accepted) but adds a `warning` field describing the rate limit, so the connection Test result is distinguishable from a real 200.

Only the 429 branch was added — the `401/403/404/405/>=500` branches are untouched.

## Regression test (TDD — Hard Rule #18)

`tests/unit/issue-7284-connection-test-masks-429.test.ts` mocks a 404 `/models` probe followed by a 429 chat probe.

**Note on RED shape**: this issue's proof-of-bug test asserted that the *buggy* behavior (`{ valid: true, error: null }` with no rate-limit signal) was produced — that assertion **passed** before the fix, which is what proved the bug. After the fix, the test was rewritten to assert the *correct* contract instead (`{ valid: true, error: null, warning: <string matching /rate limit/i> }`), and now passes against the fixed code. The "RED → GREEN" transition here is: the pre-fix code produces a result **failing** the corrected assertion (no `warning` field, `typeof undefined !== "string"`); the post-fix code passes it.

```
RED (before fix — result had no warning field):
✖ #7284: a 429 chat-probe response is reported with a rate-limit warning, not plain valid (14.7ms)
  AssertionError: 429 response must carry a warning field signaling the rate limit
  + actual - expected
  + 'undefined'
  - 'string'

GREEN (after fix):
✔ #7284: a 429 chat-probe response is reported with a rate-limit warning, not plain valid (15.3ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/issue-7284-connection-test-masks-429.test.ts` — new regression test
- `node --import tsx/esm --test tests/unit/provider-validation-firepass-403.test.ts tests/unit/validation-format-validators-split.test.ts` — existing tests of the touched area/file, unaffected (5/5 pass)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2054/2056 baseline, unchanged by this PR)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889/890 baseline, unchanged by this PR)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/lib/providers/validation/openaiFormat.ts tests/unit/issue-7284-connection-test-masks-429.test.ts` — clean

## Non-goals (per plan-file)

Dashboard UI rendering of the new `warning` field (amber/warning state) is out of scope for this fix — this PR only fixes the validator-layer signal. Not to be confused with #6059 (429 cascade persisted to `provider_connections.rate_limited_until`, a resilience-state issue) or `apiKeyPolicy.ts`'s own request-count rate-limit message.