### PR TITLE
fix(sse): lazy-load playwright in claudeTurnstileSolver so Termux/Android doesn't crash on boot

### DIFF
--- a/changelog.d/fixes/7265-termux-playwright-static-import.md
+++ b/changelog.d/fixes/7265-termux-playwright-static-import.md
@@ -1,0 +1,1 @@
+- fix(sse): lazy-load playwright in claudeTurnstileSolver so unsupported platforms (e.g. Termux/Android) don't crash on boot (#7265)

--- a/open-sse/services/claudeTurnstileSolver.ts
+++ b/open-sse/services/claudeTurnstileSolver.ts
@@ -10,7 +10,7 @@
  * 6. Returns fresh cookie for tls-client-node
  */
 
-import { chromium, type Browser, type Page } from "playwright";
+import type { Browser, Page } from "playwright";
 
 const CLAUDE_WEB_URL = "https://claude.ai";
 const CHALLENGE_TIMEOUT = 60000; // 60s to solve challenge
@@ -80,7 +80,9 @@ export async function solveTurnstile(options?: {
   let page: Page | null = null;
 
   try {
-    // Launch headless browser
+    // Launch headless browser (lazy import — avoids crashing platforms
+    // playwright-core doesn't support, e.g. Termux/Android, on module load)
+    const { chromium } = await import("playwright");
     browser = await chromium.launch({ headless });
     const context = await browser.newContext({
       userAgent:

--- a/tests/unit/termux-android-playwright-static-import-7265.test.ts
+++ b/tests/unit/termux-android-playwright-static-import-7265.test.ts
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Regression guard for #7265: on Termux/Android, `process.platform === "android"`.
+// `playwright-core`'s serverRegistry.js throws `Unsupported platform: android` from a
+// top-level IIFE at *require time* — merely importing the `playwright` package crashes,
+// no browser needs to be launched. `claudeTurnstileSolver.ts` used to `import { chromium }
+// from "playwright"` statically, and that module is unconditionally reachable from the
+// Next.js instrumentation hook on every boot via open-sse/executors/index.ts, so any
+// unsupported platform crashed the whole server at startup regardless of configured provider.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SOLVER = join(HERE, "../../open-sse/services/claudeTurnstileSolver.ts");
+
+test("claudeTurnstileSolver.ts does not statically import the playwright runtime", () => {
+  const src = readFileSync(SOLVER, "utf8");
+  // Only a type-only import of playwright is allowed at module top level.
+  assert.doesNotMatch(src, /^import\s*\{\s*chromium[^}]*\}\s*from\s*"playwright"/m);
+  assert.match(src, /^import type \{ Browser, Page \} from "playwright";/m);
+  // The real chromium binding must come from a lazy dynamic import inside a function body.
+  assert.match(src, /const \{ chromium \} = await import\("playwright"\);/);
+});
+
+test("importing the real executor chain does not throw on an unsupported process.platform", async () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+  Object.defineProperty(process, "platform", { value: "android", configurable: true });
+
+  try {
+    // This is the exact reachability chain from the Next.js instrumentation hook:
+    // instrumentation-node.ts -> open-sse/index.ts -> executors/index.ts -> claude-web*.ts
+    // -> claudeTurnstileSolver.ts. Before the fix, this threw
+    // "Unsupported platform: android" purely from the static playwright import.
+    await import("../../open-sse/executors/index.ts");
+  } finally {
+    Object.defineProperty(process, "platform", originalDescriptor);
+  }
+});


### PR DESCRIPTION
Closes #7265

## Root cause

`open-sse/services/claudeTurnstileSolver.ts` had a static top-level
`import { chromium } from "playwright"` — the only playwright consumer in the
codebase that isn't lazy (`browserPool.ts`, `inAppLoginService.ts` all
`await import("playwright")`).

`playwright-core`'s `serverRegistry.js` computes its cache directory in a
top-level IIFE that throws `Unsupported platform: <platform>` at *require
time* for anything outside linux/darwin/win32 — and Termux's Node reports
`process.platform === "android"`. So merely *importing* the package crashed,
with no browser ever launched.

That import is unconditionally reachable from the Next.js instrumentation
hook on every boot: `instrumentation-node.ts` → `open-sse/index.ts` →
`executors/index.ts` → `claude-web.ts` / `claude-web-with-auto-refresh.ts` →
`claudeTurnstileSolver.ts` → throw — regardless of which provider is
configured, crashing the whole server at startup.

## Fix

- `import type { Browser, Page } from "playwright"` (erased at compile time)
- Move the real `chromium` binding to a lazy `await import("playwright")`
  inside `solveTurnstile()`, matching the existing pattern used elsewhere in
  the codebase.
- Call sites (`claude-web.ts`, `claude-web-with-auto-refresh.ts`) already
  `await getCfClearanceToken(...)` — no signature change needed.

## Regression test (TDD — Hard Rule #18)

`tests/unit/termux-android-playwright-static-import-7265.test.ts`:
1. Static check that the module no longer statically imports the playwright
   runtime (only `import type`).
2. Mocks `process.platform = "android"` and imports the real
   `open-sse/executors/index.ts` chain — the exact reachability path from the
   instrumentation hook — asserting it does not throw.

**RED (before fix)**, same test file against the original static import:
```
✖ importing the real executor chain does not throw on an unsupported process.platform
  Error: Unsupported platform: android
      at .../node_modules/playwright-core/lib/coreBundle.js:28600:13
```

**GREEN (after fix)**:
```
✔ claudeTurnstileSolver.ts does not statically import the playwright runtime
✔ importing the real executor chain does not throw on an unsupported process.platform
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

## Gates run (all green)

- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-file-size.mjs` — no new violations
- `node scripts/check/check-complexity.mjs` — OK (2054, baseline 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889, baseline 890)
- Existing related unit tests, all pass:
  - `tests/unit/claude-web-auto-refresh.test.ts` (6 pass, 7 skipped pre-existing)
  - `tests/unit/claude-web-executor-split.test.ts`
  - `tests/unit/claude-web-sonnet5-registry-6209.test.ts`
  - `tests/unit/claude-web.test.ts`

## Scope

Single file changed (`claudeTurnstileSolver.ts`) + one new test file + one
changelog fragment. Did not touch `src/instrumentation-node.ts` (another PR
in flight there for an unrelated DB fix).