### PR TITLE
fix(sse): combo failover for OpenAI streams truncated without finish_reason

### DIFF
--- a/changelog.d/fixes/7285-combo-finish-reason.md
+++ b/changelog.d/fixes/7285-combo-finish-reason.md
@@ -1,0 +1,1 @@
+- fix(sse): combo failover now detects OpenAI-shape streams truncated without `finish_reason`/`[DONE]` (#7285)

--- a/open-sse/services/combo/validateQuality.ts
+++ b/open-sse/services/combo/validateQuality.ts
@@ -8,7 +8,9 @@
 
 import {
   createSSEDataLineNormalizer,
+  hasOpenAIFinishReason,
   isKnownNonClaudeStreamPayload,
+  isOpenAIChoicesPayload,
 } from "../../utils/streamHelpers.ts";
 import { evaluateResponseValidation, type ResponseValidationConfig } from "./responseValidation.ts";
 import { getReasoningTokens } from "../../../src/lib/usage/tokenAccounting.ts";
@@ -96,6 +98,29 @@ function contentBlockDeltaIsRealSignal(parsed: Record<string, unknown>): boolean
 /** A message_delta closes the lifecycle once it carries a stop_reason. */
 function messageDeltaEndsLifecycle(parsed: Record<string, unknown>): boolean {
   return asObject(parsed, "delta")?.stop_reason != null;
+}
+
+/**
+ * Mutable OpenAI-shape lifecycle flags (#7285) — tracked independently of
+ * {@link SseLifecycleFlags} because the truncation signal here (a stream that
+ * closes without ever carrying `finish_reason` or a `[DONE]` sentinel) is
+ * orthogonal to the Claude event switch and must fire even when
+ * `hasOpenAICompatibleStreamValue()` never sees real content (e.g. a
+ * role-only delta).
+ */
+interface OpenAiLifecycleFlags {
+  hasChoicePayload: boolean;
+  hasTerminalMarker: boolean;
+}
+
+/** Update `flags` in place from one parsed OpenAI-shape SSE `data:` payload. */
+function applyOpenAiLifecycleEvent(
+  parsed: Record<string, unknown>,
+  flags: OpenAiLifecycleFlags
+): void {
+  if (!isOpenAIChoicesPayload(parsed)) return;
+  flags.hasChoicePayload = true;
+  if (hasOpenAIFinishReason(parsed)) flags.hasTerminalMarker = true;
 }
 
 /**
@@ -228,6 +253,8 @@ export async function validateResponseQuality(
     };
     let anyContentFound = false;
     let sawAnyBytes = false;
+    // #7285: OpenAI-shape lifecycle tracking, parallel to `sse` above.
+    const openAi: OpenAiLifecycleFlags = { hasChoicePayload: false, hasTerminalMarker: false };
     const sseLineNormalizer = createSSEDataLineNormalizer();
     let pendingEventType = "";
 
@@ -259,7 +286,13 @@ export async function validateResponseQuality(
         }
 
         const data = trimmed.slice(5).trim();
-        if (!data || data === "[DONE]") continue;
+        if (!data) continue;
+        if (data === "[DONE]") {
+          // #7285: `[DONE]` is itself a terminal marker for OpenAI-shape
+          // streams, even when no earlier chunk carried `finish_reason`.
+          openAi.hasTerminalMarker = true;
+          continue;
+        }
 
         let parsed: Record<string, unknown>;
         try {
@@ -267,6 +300,8 @@ export async function validateResponseQuality(
         } catch {
           continue;
         }
+
+        applyOpenAiLifecycleEvent(parsed, openAi);
 
         const eventType =
           (typeof parsed.type === "string" ? parsed.type : null) || pendingEventType || "";
@@ -360,6 +395,23 @@ export async function validateResponseQuality(
               "Streaming response ended with no recognized content — marking as invalid for combo failover"
             );
             return { valid: false, reason: "streaming no recognized content" };
+          }
+
+          // Issue #7285: an OpenAI-shape stream (`choices[]` chunks) that
+          // closes without ever carrying `finish_reason` or a `[DONE]`
+          // sentinel, and without producing recognized content, is a
+          // truncated response — failover to a sibling combo target rather
+          // than forwarding the incomplete stream as a success. Does not
+          // affect Claude-shape streams (`openAi.hasChoicePayload` stays
+          // false for those) and does not regress the #3399/#3685
+          // pass-through contract: a healthy stream exits the peek loop
+          // early via the `foundContent` branch above and never reaches here.
+          if (openAi.hasChoicePayload && !openAi.hasTerminalMarker && !anyContentFound) {
+            log.warn?.(
+              "COMBO",
+              "Streaming OpenAI-shape response ended with no finish_reason or [DONE] — marking as invalid for combo failover"
+            );
+            return { valid: false, reason: "streaming openai truncated without finish_reason" };
           }
 
           // Incomplete lifecycle or non-Claude stream — replay all buffered

--- a/open-sse/utils/streamHelpers.ts
+++ b/open-sse/utils/streamHelpers.ts
@@ -317,6 +317,22 @@ function hasGeminiCandidateStreamValue(parsed: Record<string, unknown>): boolean
   });
 }
 
+// Issue #7285: an OpenAI-shape SSE stream that closes without ever emitting a
+// chunk carrying `finish_reason` (and without a `data: [DONE]` sentinel) is a
+// truncated response — combo failover needs to detect that shape independently
+// of `hasOpenAICompatibleStreamValue()` (which only looks for *content*, not
+// the terminal marker). Kept alongside the other shape-detection helpers so
+// callers can distinguish "OpenAI-shape chunk seen" from "OpenAI-shape stream
+// reached its terminal marker".
+export function isOpenAIChoicesPayload(parsed: Record<string, unknown>): boolean {
+  return Array.isArray(parsed.choices);
+}
+
+export function hasOpenAIFinishReason(parsed: Record<string, unknown>): boolean {
+  if (!Array.isArray(parsed.choices)) return false;
+  return parsed.choices.some((choice) => isRecord(choice) && choice.finish_reason != null);
+}
+
 export function isKnownNonClaudeStreamPayload(
   parsed: Record<string, unknown>,
   eventType = ""

--- a/tests/unit/combo-streaming-openai-no-finish-reason-7285.test.ts
+++ b/tests/unit/combo-streaming-openai-no-finish-reason-7285.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { validateResponseQuality } = await import("../../open-sse/services/combo.ts");
+
+const encoder = new TextEncoder();
+const silentLog = { warn: () => {} };
+
+function sseStream(body: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+}
+
+// OpenAI-shape stream: single role-only delta chunk, then the connection
+// closes. No finish_reason anywhere, no `data: [DONE]` sentinel.
+function makeTruncatedOpenAiStream(): Response {
+  const body =
+    `data: ${JSON.stringify({
+      id: "chatcmpl-test-truncated",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+    })}\n\n`;
+  return new Response(sseStream(body), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+// Healthy OpenAI-shape stream: content delta + a chunk carrying
+// finish_reason: "stop" — must keep passing through (#3399/#3685 contract).
+function makeHealthyOpenAiStream(): Response {
+  const chunks = [
+    JSON.stringify({
+      id: "chatcmpl-test-healthy",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { role: "assistant", content: "Hello" }, finish_reason: null }],
+    }),
+    JSON.stringify({
+      id: "chatcmpl-test-healthy",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    }),
+  ];
+  const body = chunks.map((c) => `data: ${c}\n\n`).join("") + "data: [DONE]\n\n";
+  return new Response(sseStream(body), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+test("#7285 RED: OpenAI-shape stream with role-only delta and NO finish_reason should fail over but currently passes as valid", async () => {
+  const res = makeTruncatedOpenAiStream();
+  const out = await validateResponseQuality(res, true, silentLog);
+  assert.equal(out.valid, false, "expected failover (valid:false)");
+});
+
+test("#7285 control: a healthy OpenAI stream ending with finish_reason still passes through (#3399/#3685 no-regression)", async () => {
+  const res = makeHealthyOpenAiStream();
+  const out = await validateResponseQuality(res, true, silentLog);
+  assert.equal(out.valid, true, "expected valid:true for a properly terminated stream");
+});


### PR DESCRIPTION
Closes #7285

## Root cause

`validateResponseQuality()` (`open-sse/services/combo/validateQuality.ts::parseAccumulatedSse()`) only recognizes **Claude** SSE lifecycle events (`message_start`, `content_block_*`, `message_stop`, `message_delta.delta.stop_reason`). `hasOpenAICompatibleStreamValue()` (`open-sse/utils/streamHelpers.ts`) only inspects `delta.content`/`reasoning_content`/`reasoning_text`/`tool_calls` — it never looks at `choice.finish_reason`.

Result: an OpenAI-shape upstream that returns HTTP 200, emits a role-only delta (or other non-content bytes), and then closes the connection **without ever sending a chunk carrying `finish_reason`** (and without `data: [DONE]`) falls through every existing failover branch and lands on the generic "replay buffered bytes" path — `{valid: true, clonedResponse}`. The truncated stream is forwarded to the client as a success instead of triggering combo failover to a sibling target. `auto/*:free` suffixes amplify exposure because they narrow the candidate pool to free-tier providers, the population most likely to truncate mid-stream.

## Fix

Added OpenAI-shape lifecycle tracking (`hasChoicePayload` / `hasTerminalMarker`) parallel to the existing Claude tracking in `validateQuality.ts`:

- New helpers in `streamHelpers.ts`: `isOpenAIChoicesPayload()` and `hasOpenAIFinishReason()`.
- `parseAccumulatedSse()` now marks `hasChoicePayload` on any `choices[]` chunk, and `hasTerminalMarker` when a choice carries `finish_reason != null` or the `data: [DONE]` sentinel appears.
- At stream end: if an OpenAI-shape chunk was seen but the stream closed with no terminal marker and no recognized content, the response is marked invalid (`{valid: false}`) so combo failover retries a sibling target.

Healthy OpenAI streams are unaffected: a stream carrying real content (or `finish_reason`) exits the bounded peek loop early via the existing `foundContent` branch, before ever reaching the new check — preserving the #3399/#3685 pass-through contract (a slow-but-healthy stream must not be misclassified as truncated). `STREAM_RECOVERY_ENABLED` stays untouched (default `false`) — this fix lives entirely in `validateResponseQuality()`, independent of `streamRecovery.ts`'s retry path.

## TDD proof (Hard Rule #18)

New regression test: `tests/unit/combo-streaming-openai-no-finish-reason-7285.test.ts`

RED (before fix):
```
✖ #7285 RED: OpenAI-shape stream with role-only delta and NO finish_reason should fail over but currently passes as valid
  AssertionError: expected failover (valid:false)
  true !== false
✔ #7285 control: a healthy OpenAI stream ending with finish_reason still passes through (#3399/#3685 no-regression)
tests 2 / pass 1 / fail 1
```

GREEN (after fix):
```
✔ #7285 RED: OpenAI-shape stream with role-only delta and NO finish_reason should fail over but currently passes as valid
✔ #7285 control: a healthy OpenAI stream ending with finish_reason still passes through (#3399/#3685 no-regression)
tests 2 / pass 2 / fail 0
```

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/combo-streaming-openai-no-finish-reason-7285.test.ts` — 2/2 pass
- Existing touched-area suites (all pass, no regressions):
  - `tests/unit/combo-quality-validator-reasoning.test.ts` (12/12)
  - `tests/unit/combo-round-robin-streaming-lock-3811.test.ts` (1/1)
  - `tests/unit/combo-stream-readiness-fallback.test.ts` (11/11)
  - `tests/unit/combo-streaming-empty-content-failover.test.ts` (6/6, #3685 contract)
  - `tests/unit/empty-response-hardening.test.ts` (12/12)
  - `tests/unit/masked-200-exhaustion-fallback-6427.test.ts` (3/3)
  - `tests/unit/streamHelpers.test.ts` (20/20)
  - `tests/unit/streaming-empty-content-block-1382.test.ts` (2/2)
  - `tests/unit/validate-response-quality.test.ts` (8/8)
  - `tests/unit/gemini-cli-ansi-sanitization.test.ts` (5/5)
  - `tests/unit/correctness/sse-parser.property.test.ts` (4/4)
- `node scripts/check/check-file-size.mjs` — OK (no growth on frozen files, new test file untouched by cap)
- `node scripts/check/check-complexity.mjs` — OK (2054 ≤ baseline 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 ≤ baseline 890)
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean, exit 0

`npm run typecheck:noimplicit:core` surfaces pre-existing implicit-`any` errors in unrelated files (`open-sse/services/combo.ts`, `open-sse/utils/usageTracking.ts`, `src/shared/services/cliRuntime.ts`) — none in the files this PR touches; not introduced by this change.

## Scope

Diff strictly scoped to the issue: `open-sse/services/combo/validateQuality.ts`, `open-sse/utils/streamHelpers.ts`, the new regression test, and a changelog fragment. No drive-by refactors.