### PR TITLE
fix(api): resolve provider display name and dedup byModel on normalized key

### DIFF
--- a/changelog.d/fixes/7534-usage-provider-display-name.md
+++ b/changelog.d/fixes/7534-usage-provider-display-name.md
@@ -1,0 +1,1 @@
+- fix(api): Usage page "by provider" table now shows the configured provider display name (e.g. "OpenAI Codex") instead of the raw internal provider id (e.g. "codex") (#7534)

--- a/changelog.d/fixes/7535-usage-model-dedup-normalized-key.md
+++ b/changelog.d/fixes/7535-usage-model-dedup-normalized-key.md
@@ -1,0 +1,1 @@
+- fix(api): Usage page "model usage" table no longer lists the same logical model twice when it was recorded under both a bare and a provider-prefixed spelling (e.g. `glm-5.2` and `z-ai/glm-5.2`) — the in-memory dedup key now uses the normalized model name (#7535)

--- a/src/app/api/usage/analytics/route.ts
+++ b/src/app/api/usage/analytics/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getProviderById } from "@/shared/constants/providers";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { getApiKeys } from "@/lib/db/apiKeys";
 import { getUserDatabaseSettings } from "@/lib/db/databaseSettings";
@@ -54,6 +55,7 @@ function getRangeStartIso(range: string): string | null {
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 type PricingByProvider = Record<string, Record<string, Record<string, unknown>>>;
+type UsageRows = Array<Record<string, unknown>>;
 type ComputeCostFromPricing = (
   pricing: Record<string, unknown> | null | undefined,
   tokens: Record<string, number | undefined> | null | undefined,
@@ -413,9 +415,8 @@ export async function GET(request: Request) {
 
     const summaryRow = getUsageSummary(unifiedSource, unifiedParams) as Record<string, unknown>;
 
-    const dailyRows = getDailyUsage(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
-
-    const dailyCostRows = getDailyCostRows(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
+    const dailyRows = getDailyUsage(unifiedSource, unifiedParams) as UsageRows;
+    const dailyCostRows = getDailyCostRows(unifiedSource, unifiedParams) as UsageRows;
 
     const heatmapStart = new Date();
     heatmapStart.setUTCDate(heatmapStart.getUTCDate() - 364);
@@ -437,30 +438,30 @@ export async function GET(request: Request) {
       });
     }
 
-    const heatmapRows = getHeatmapRows(heatmapConditions, heatmapParams) as Array<Record<string, unknown>>;
+    const heatmapRows = getHeatmapRows(heatmapConditions, heatmapParams) as UsageRows;
 
-    const modelRows = getModelUsageRows(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
+    const modelRows = getModelUsageRows(unifiedSource, unifiedParams) as UsageRows;
 
-    const providerCostRows = getProviderCostRows(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
+    const providerCostRows = getProviderCostRows(unifiedSource, unifiedParams) as UsageRows;
 
-    const providerRows = getProviderUsageRows(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
+    const providerRows = getProviderUsageRows(unifiedSource, unifiedParams) as UsageRows;
 
     const accountCostWhereClause = whereClause
       .replace(/timestamp/g, "usage_history.timestamp")
       .replace(/api_key_/g, "usage_history.api_key_");
-    const accountCostRows = getAccountCostRows(accountCostWhereClause, params) as Array<Record<string, unknown>>;
+    const accountCostRows = getAccountCostRows(accountCostWhereClause, params) as UsageRows;
 
-    const accountRows = getAccountUsageRows(accountCostWhereClause, params) as Array<Record<string, unknown>>;
+    const accountRows = getAccountUsageRows(accountCostWhereClause, params) as UsageRows;
 
     const apiKeyWhereClause = appendWhereCondition(
       whereClause,
       "(api_key_id IS NOT NULL AND api_key_id != '') OR (api_key_name IS NOT NULL AND api_key_name != '')"
     );
-    const apiKeyRows = getApiKeyUsageRows(apiKeyWhereClause, params) as Array<Record<string, unknown>>;
+    const apiKeyRows = getApiKeyUsageRows(apiKeyWhereClause, params) as UsageRows;
 
-    const serviceTierRows = getServiceTierUsageRows(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
+    const serviceTierRows = getServiceTierUsageRows(unifiedSource, unifiedParams) as UsageRows;
 
-    const apiKeyMetadataRows = getApiKeyMetadataRows(apiKeyWhereClause, params) as Array<Record<string, unknown>>;
+    const apiKeyMetadataRows = getApiKeyMetadataRows(apiKeyWhereClause, params) as UsageRows;
 
     const apiKeyMetadata = new Map<string, { latestName: string; aliases: Set<string> }>();
     for (const row of apiKeyMetadataRows) {
@@ -477,7 +478,7 @@ export async function GET(request: Request) {
       apiKeyMetadata.set(groupKey, existing);
     }
 
-    const weeklyRows = getWeeklyPatternRows(unifiedSource, unifiedParams) as Array<Record<string, unknown>>;
+    const weeklyRows = getWeeklyPatternRows(unifiedSource, unifiedParams) as UsageRows;
 
     const fallbackRow = getFallbackStats(whereClause, params) as Record<string, unknown>;
 
@@ -590,7 +591,7 @@ export async function GET(request: Request) {
         normalizeModelName,
         computeCostFromPricing
       );
-      const key = `${provider}::${model}`;
+      const key = `${provider}::${short}`;
       const existing = modelMap.get(key) || {
         model: short,
         provider,
@@ -662,7 +663,7 @@ export async function GET(request: Request) {
     }
 
     const byProvider = providerRows.map((row) => ({
-      provider: row.provider,
+      provider: getProviderById(toStringValue(row.provider))?.name ?? toStringValue(row.provider),
       requests: Number(row.requests),
       promptTokens: Number(row.promptTokens),
       completionTokens: Number(row.completionTokens),
@@ -897,16 +898,15 @@ export async function GET(request: Request) {
         }
 
         const presetSinceIso = getRangeStartIso(presetRange);
-        const { unifiedSource: presetUnifiedSource, unifiedParams: presetParams } =
-          buildPresetUnifiedSource({
-            sinceIso: presetSinceIso ?? null,
-            untilIso: null,
-            rawCutoffDate,
-            apiKeyWhere,
-            apiKeyParams: apiKeyParamEntries,
-          });
+        const { unifiedSource: pSrc, unifiedParams: pParams } = buildPresetUnifiedSource({
+          sinceIso: presetSinceIso ?? null,
+          untilIso: null,
+          rawCutoffDate,
+          apiKeyWhere,
+          apiKeyParams: apiKeyParamEntries,
+        });
 
-        const presetModelRows = getPresetCostModelRows(presetUnifiedSource, presetParams) as Array<Record<string, unknown>>;
+        const presetModelRows = getPresetCostModelRows(pSrc, pParams) as UsageRows;
 
         let presetTotalCost = 0;
         for (const row of presetModelRows) {

--- a/tests/unit/usage-analytics-model-dedup-7535.test.ts
+++ b/tests/unit/usage-analytics-model-dedup-7535.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-usage-analytics-model-dedup-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+const ORIGINAL_API_KEY_SECRET = process.env.API_KEY_SECRET;
+process.env.API_KEY_SECRET = "test-usage-analytics-model-dedup-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const usageHistory = await import("../../src/lib/usage/usageHistory.ts");
+const analyticsRoute = await import("../../src/app/api/usage/analytics/route.ts");
+const { normalizeModelName } = await import("../../src/lib/usage/costCalculator.ts");
+
+function makeRequest(url: string) {
+  return new Request(url, { method: "GET" });
+}
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  usageHistory.clearPendingRequests();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_API_KEY_SECRET === undefined) {
+    delete process.env.API_KEY_SECRET;
+  } else {
+    process.env.API_KEY_SECRET = ORIGINAL_API_KEY_SECRET;
+  }
+});
+
+test("#7535: byModel must not list the same logical model twice under one raw/one prefixed id", async () => {
+  const db = core.getDbInstance();
+  const now = new Date();
+
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, api_key_id, api_key_name, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run("zai", "glm-5.2", "test-conn", "test-key", "Primary Key", 100, 50, 1, 200, now.toISOString());
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, api_key_id, api_key_name, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    "zai",
+    "z-ai/glm-5.2",
+    "test-conn",
+    "test-key",
+    "Primary Key",
+    80,
+    40,
+    1,
+    150,
+    new Date(now.getTime() - 60_000).toISOString()
+  );
+
+  assert.equal(normalizeModelName("glm-5.2"), "glm-5.2");
+  assert.equal(normalizeModelName("z-ai/glm-5.2"), "glm-5.2");
+
+  const response = await analyticsRoute.GET(makeRequest("http://localhost/api/usage/analytics"));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  const glmEntries = body.byModel.filter((row: { model: string }) => row.model === "glm-5.2");
+  assert.equal(
+    glmEntries.length,
+    1,
+    `expected exactly one "glm-5.2" row in byModel, got ${glmEntries.length}: ${JSON.stringify(glmEntries)} (#7535)`
+  );
+  assert.equal(glmEntries[0].requests, 2, "the two raw spellings should merge into one aggregated row");
+});

--- a/tests/unit/usage-analytics-provider-display-name-7534.test.ts
+++ b/tests/unit/usage-analytics-provider-display-name-7534.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-usage-analytics-provider-name-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+const ORIGINAL_API_KEY_SECRET = process.env.API_KEY_SECRET;
+process.env.API_KEY_SECRET = "test-usage-analytics-provider-name-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const usageHistory = await import("../../src/lib/usage/usageHistory.ts");
+const analyticsRoute = await import("../../src/app/api/usage/analytics/route.ts");
+const providers = await import("../../src/shared/constants/providers.ts");
+
+function makeRequest(url: string) {
+  return new Request(url, { method: "GET" });
+}
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  usageHistory.clearPendingRequests();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_API_KEY_SECRET === undefined) {
+    delete process.env.API_KEY_SECRET;
+  } else {
+    process.env.API_KEY_SECRET = ORIGINAL_API_KEY_SECRET;
+  }
+});
+
+test("#7534: byProvider exposes the configured display name, not the raw internal provider id", async () => {
+  const db = core.getDbInstance();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, api_key_id, api_key_name, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run("codex", "gpt-5.5", "test-conn", "test-key", "Primary Key", 100, 50, 1, 200, now);
+
+  const response = await analyticsRoute.GET(makeRequest("http://localhost/api/usage/analytics"));
+  const body = await response.json();
+
+  const expectedDisplayName = providers.getProviderById("codex")?.name;
+  assert.equal(response.status, 200);
+  assert.equal(
+    body.byProvider[0].provider,
+    expectedDisplayName,
+    `expected byProvider[0].provider to be the display name "${expectedDisplayName}", ` +
+      `but got "${body.byProvider[0].provider}" (#7534)`
+  );
+});
+
+test("#7534: byProvider falls back to the raw id for providers not in the static registry", async () => {
+  const db = core.getDbInstance();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, api_key_id, api_key_name, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    "openai-compatible-custom",
+    "some-model",
+    "test-conn",
+    "test-key",
+    "Primary Key",
+    100,
+    50,
+    1,
+    200,
+    now
+  );
+
+  const response = await analyticsRoute.GET(makeRequest("http://localhost/api/usage/analytics"));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.byProvider[0].provider, "openai-compatible-custom");
+});

--- a/tests/unit/usage-analytics-route.test.ts
+++ b/tests/unit/usage-analytics-route.test.ts
@@ -144,7 +144,7 @@ test("GET /api/usage/analytics resolves Codex GPT-5.5 pricing through provider a
 
   assert.equal(response.status, 200);
   assertClose(body.summary.totalCost, 0.02);
-  assert.equal(body.byProvider[0].provider, "codex");
+  assert.equal(body.byProvider[0].provider, "OpenAI Codex");
   assertClose(body.byProvider[0].cost, 0.02);
   assert.equal(body.byModel[0].model, "gpt-5.5");
   assertClose(body.byModel[0].cost, 0.02);


### PR DESCRIPTION
Closes #7534
Closes #7535

## Root causes

**#7534** — `src/app/api/usage/analytics/route.ts`'s `byProvider` builder returned the raw internal provider id straight from `usage_history.provider` (e.g. `"codex"`). The frontend (`ProviderTable`, `ProviderCostDonut`) only applies a CSS `capitalize` class, which does not look up a friendly name — so the Usage page showed `"Codex"` instead of the configured display name `"OpenAI Codex"`.

**#7535** — the `byModel` in-memory re-aggregation loop built its dedup `key` from the **raw** `model` string (`` `${provider}::${model}` ``) while the **displayed** name is the *normalized* model (`normalizeModelName()`, which strips any `provider/` prefix). When the same logical model is recorded with and without a provider-path prefix (e.g. `"glm-5.2"` vs `"z-ai/glm-5.2"`), the raw strings hashed to different keys but rendered with the identical display name — producing two rows both labeled `"glm-5.2"`.

## Fixes

- `byProvider[].provider` now resolves through `getProviderById(id)?.name`, falling back to the raw id for providers not in the static registry (e.g. operator-configured `openai-compatible-*` connections).
- The `byModel` dedup key now uses the normalized model (`short`) instead of the raw one, so both raw spellings merge into a single aggregated row.
- Introduced a local `UsageRows` type alias in `route.ts` for the repeated `as Array<Record<string, unknown>>` casts. This was necessary to keep the file under the frozen `file-size-baseline.json` cap once touched — the file already had several lines over the 100-char print width (pre-existing prettier drift, confirmed against `origin/release/v3.8.49`), and letting the pre-commit hook's `prettier --write` wrap all of them would have pushed the file well past the baseline. The alias is a pure DRY rename (identical structural type), verified to make zero net behavioral change.

## Regression tests (TDD, Hard Rule #18)

- `tests/unit/usage-analytics-provider-display-name-7534.test.ts` — RED→GREEN for #7534, plus a fallback case for providers not in the static registry.
- `tests/unit/usage-analytics-model-dedup-7535.test.ts` — RED→GREEN for #7535 (two raw spellings of `glm-5.2` merge into one row, requests summed).
- `tests/unit/usage-analytics-route.test.ts` — the one pre-existing assertion that encoded the old buggy behavior (`body.byProvider[0].provider === "codex"`) was updated to the corrected contract (`"OpenAI Codex"`); no other assertion was weakened.

RED (reverted `route.ts` to `HEAD`, both new tests fail):
```
✖ #7535: byModel must not list the same logical model twice under one raw/one prefixed id
  AssertionError: expected exactly one "glm-5.2" row in byModel, got 2
✖ #7534: byProvider exposes the configured display name, not the raw internal provider id
  AssertionError: expected 'OpenAI Codex' == 'codex'
```

GREEN (fix applied):
```
✔ #7535: byModel must not list the same logical model twice under one raw/one prefixed id
✔ #7534: byProvider exposes the configured display name, not the raw internal provider id
✔ #7534: byProvider falls back to the raw id for providers not in the static registry
```
Full `tests/unit/usage-analytics-route.test.ts` suite: 22/22 passing (including the updated assertion).

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/usage-analytics-provider-display-name-7534.test.ts tests/unit/usage-analytics-model-dedup-7535.test.ts tests/unit/usage-analytics-route.test.ts` — 25/25 pass
- `node --import tsx/esm --test tests/unit/usage-analytics.test.ts tests/unit/db-usage-analytics-3500.test.ts tests/unit/db-usageanalytics-split.test.ts tests/unit/db-provider-daily-usage-4009.test.ts tests/unit/usage-endpoint-dimension.test.ts` — 65/65 pass (unaffected, sanity check for the touched-area sweep)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2054 ≤ baseline 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 ≤ baseline 890)
- `npm run typecheck:core` — clean (this file is not in the allowlist; see note below)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on all changed files — clean
- `npm run check:cycles` — OK

## Pre-existing issue found, NOT introduced by this PR

A full-project `tsc --noEmit -p tsconfig.json` scoped to `route.ts` surfaces ~15 `TS2352` errors ("Conversion of type 'X[]' to type 'Record<string, unknown>[]' may be a mistake") on casts like `getDailyUsage(...) as Array<Record<string, unknown>>`. This file is not covered by `typecheck:core`'s allowlist, so it's invisible to CI. I confirmed this predates this PR with a minimal repro: an identical literal `as Array<Record<string, unknown>>` cast against `usageAnalytics.ts`'s already-typed row interfaces (e.g. `DailyUsageRow[]`) produces the exact same TS2352 — my `UsageRows` type alias is structurally identical to the literal it replaces, so it doesn't introduce or change this error. Filing as a follow-up rather than fixing here to keep this PR's diff scoped to #7534/#7535.