### PR TITLE
fix(sse): stop per-byte enumeration of binary image bytes in log redaction (#7297)

### DIFF
--- a/changelog.d/fixes/7297-bedrock-images.md
+++ b/changelog.d/fixes/7297-bedrock-images.md
@@ -1,0 +1,1 @@
+- fix(sse): treat Uint8Array/Buffer as opaque binary in log redaction to stop per-byte enumeration on Bedrock Converse image requests (#7297)

--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -122,6 +122,13 @@ export function cloneBoundedForLog(value: unknown, depth = 0, key: string | null
   if (value === null || value === undefined) return value;
   if (typeof value === "string") return truncateLogString(value);
   if (typeof value !== "object") return value;
+  // Binary/opaque byte views (Uint8Array, Buffer, DataView, ...) are not
+  // "real" arrays to Array.isArray(); without this guard they fall through
+  // to the generic-object branch below and get expanded into one JS key per
+  // decoded byte instead of being treated as an opaque buffer (see #7297).
+  if (ArrayBuffer.isView(value)) {
+    return `[binary ${(value as ArrayBufferView).byteLength} bytes]`;
+  }
   if (depth >= 6) return "[MaxDepth]";
 
   if (Array.isArray(value)) {

--- a/src/lib/logPayloads.ts
+++ b/src/lib/logPayloads.ts
@@ -20,6 +20,21 @@ const SENSITIVE_KEYS = new Set([
 
 type JsonRecord = Record<string, unknown>;
 
+/**
+ * True for any binary/opaque byte view (Uint8Array, Buffer, DataView, other
+ * typed arrays). `Array.isArray()` returns false for these, so callers that
+ * branch on it before recursing would otherwise fall into the generic-object
+ * branch and enumerate one JS property key per decoded byte (#7297).
+ */
+function isOpaqueBinary(value: unknown): value is ArrayBufferView {
+  return ArrayBuffer.isView(value);
+}
+
+function describeOpaqueBinary(value: ArrayBufferView): string {
+  const byteLength = value.byteLength;
+  return `[binary ${byteLength} bytes]`;
+}
+
 export function cloneLogPayload<T>(value: T): T {
   if (value === null || value === undefined) return value;
   if (typeof globalThis.structuredClone === "function") {
@@ -43,6 +58,7 @@ export function normalizePayloadForLog(payload: unknown): unknown {
 
 export function redactPayload(payload: unknown): unknown {
   if (!payload || typeof payload !== "object") return payload;
+  if (isOpaqueBinary(payload)) return describeOpaqueBinary(payload);
   if (Array.isArray(payload)) return payload.map(redactPayload);
 
   const redacted: JsonRecord = {};
@@ -64,11 +80,14 @@ export function sanitizePayloadPII(payload: unknown): unknown {
   if (typeof payload === "string") {
     return sanitizePII(payload).text;
   }
-  if (Array.isArray(payload)) {
-    return payload.map(sanitizePayloadPII);
-  }
   if (!payload || typeof payload !== "object") {
     return payload;
+  }
+  if (isOpaqueBinary(payload)) {
+    return describeOpaqueBinary(payload);
+  }
+  if (Array.isArray(payload)) {
+    return payload.map(sanitizePayloadPII);
   }
 
   const sanitized: JsonRecord = {};

--- a/tests/unit/bedrock-image-log-redaction-7297.test.ts
+++ b/tests/unit/bedrock-image-log-redaction-7297.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7297-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { protectPayloadForLog } = await import("../../src/lib/logPayloads.ts");
+const bedrockExecutor = await import("../../open-sse/executors/bedrock.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function bedrockConverseBodyWithImages(nImages: number, imageBytes: number) {
+  const content: unknown[] = [];
+  for (let i = 0; i < nImages; i++) {
+    const raw = crypto.randomBytes(imageBytes);
+    content.push({
+      type: "image_url",
+      image_url: { url: `data:image/png;base64,${raw.toString("base64")}` },
+    });
+  }
+  content.push({ type: "text", text: "describe these images" });
+
+  const chatBody = {
+    model: "us.anthropic.claude-opus-4-8",
+    messages: [{ role: "user", content }],
+  };
+
+  // Same call BedrockExecutor.execute() makes right before
+  // prl.captureCurrentProviderRequest(url, headers, transformedBody, ...).
+  return bedrockExecutor.openAIToBedrockConverse("us.anthropic.claude-opus-4-8", chatBody);
+}
+
+test("#7297 protectPayloadForLog stays fast on a 3-image Bedrock Converse body", () => {
+  const transformedBody = bedrockConverseBodyWithImages(3, 1_000_000);
+
+  const firstImageBlock = (
+    transformedBody as { messages: Array<{ content: Array<Record<string, unknown>> }> }
+  ).messages[0].content[0] as { image?: { source?: { bytes?: unknown } } };
+  assert.ok(firstImageBlock.image?.source?.bytes instanceof Uint8Array);
+
+  const start = Date.now();
+  const result = protectPayloadForLog(transformedBody);
+  const elapsedMs = Date.now() - start;
+
+  assert.ok(
+    elapsedMs < 500,
+    `protectPayloadForLog took ${elapsedMs}ms for a 3-image request — it is walking every ` +
+      `decoded image byte as an object key instead of treating image.source.bytes as an ` +
+      `opaque buffer (see #7297)`
+  );
+
+  const redactedBytes = (
+    result as { messages: Array<{ content: Array<Record<string, unknown>> }> }
+  ).messages[0].content[0] as { image?: { source?: { bytes?: unknown } } };
+  assert.ok(
+    !(redactedBytes.image?.source?.bytes instanceof Uint8Array) &&
+      !Array.isArray(redactedBytes.image?.source?.bytes),
+    "binary bytes must be replaced with an opaque placeholder, not expanded into per-byte keys"
+  );
+});


### PR DESCRIPTION
Closes #7297

## Root cause

`BedrockExecutor.execute()` mirrors every Bedrock Converse request into the pending-request live-log tracker via `captureCurrentProviderRequest()` right after `openAIToBedrockConverse()` builds the payload — including the decoded `image.source.bytes` `Uint8Array` for every image.

`sanitizePayloadPII()` and `redactPayload()` (`src/lib/logPayloads.ts`) both gate their recursive walk on `Array.isArray(value)`, which is `false` for typed arrays. So each image's `Uint8Array` fell into the generic-object branch and got enumerated **one JS object key per decoded byte** — twice (once per function) — before `truncatePendingPreview()`'s key-count bound ever got a chance to apply. For 3× ~1MB images this cost ~4s of synchronous, event-loop-blocking work, matching the reporter's "1-2 images OK, 3+ fails" threshold (proportional to total decoded bytes, not image count) and their `--stack-size` observation (data-width pressure, not call-depth).

## Fix

Added an opaque-binary short-circuit (`ArrayBuffer.isView()`) ahead of the `Array.isArray` branch in `sanitizePayloadPII()` and `redactPayload()` (`src/lib/logPayloads.ts`), returning a fixed-size `"[binary N bytes]"` placeholder instead of recursing. Applied the same guard to `cloneBoundedForLog()` (`open-sse/utils/requestLogger.ts`) for defense-in-depth — same blind spot, only accidentally safe today via its own `MAX_LOG_OBJECT_KEYS` slice.

## Regression test (TDD — Hard Rule #18)

`tests/unit/bedrock-image-log-redaction-7297.test.ts` reproduces the reporter's exact shape (3× 1MB images) through the real `openAIToBedrockConverse()` converter and the real `protectPayloadForLog()`.

RED (before fix):
```
✖ #7297 protectPayloadForLog stays fast on a 3-image Bedrock Converse body (4016.357734ms)
AssertionError: protectPayloadForLog took 3969ms for a 3-image request — it is walking every
decoded image byte as an object key instead of treating image.source.bytes as an opaque buffer
```

GREEN (after fix):
```
✔ #7297 protectPayloadForLog stays fast on a 3-image Bedrock Converse body (34.879884ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK (143 frozen files, no growth)
- `node scripts/check/check-complexity.mjs` — OK (2054 violations, baseline 2056 — improved)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 violations, baseline 890 — improved)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- Existing tests touching the changed functions, all passing:
  - `tests/unit/request-logger-bounded-clone.test.ts` (5 tests)
  - `tests/unit/request-log-payloads.test.ts` (7 tests)
  - `tests/integration/security-hardening.test.ts` (21 tests, includes a static content-check on `logPayloads.ts`)
- New regression test: `tests/unit/bedrock-image-log-redaction-7297.test.ts` — pass

## Scope

Diff limited to the two logging/redaction utilities plus the new test and changelog fragment — no changes to the Bedrock executor, the AWS SDK path, or the OpenAI→Converse converter itself (all confirmed fine in isolation per the plan-file's supporting evidence).