### PR TITLE
fix(sse): split effort/reasoning suffix off pinned cursor model ids (#7289)

### DIFF
--- a/changelog.d/fixes/7289-cursor-effort-suffix.md
+++ b/changelog.d/fixes/7289-cursor-effort-suffix.md
@@ -1,0 +1,1 @@
+- fix(sse): split effort/reasoning suffix off pinned Claude/GPT model ids before sending to cursor's server (#7289)

--- a/open-sse/utils/cursorAgentProtobuf.ts
+++ b/open-sse/utils/cursorAgentProtobuf.ts
@@ -302,14 +302,54 @@ export function normalizeCursorModelId(modelId: string): string {
   return alias ?? id;
 }
 
+// #7289: pinned Claude/GPT model ids carry an effort/reasoning suffix
+// (e.g. "claude-opus-4-8-high", "gpt-5.5-high"). cursor's server has no route
+// for the suffixed id — it only accepts the base id plus an out-of-band
+// ModelParameter. Ground truth captured from the real cursor-agent client:
+// Claude ids surface the suffix as {id:"effort", value:<suffix>}, GPT ids as
+// {id:"reasoning", value:<suffix>}. "-fast"/"-thinking" are separate toggles
+// (already handled elsewhere / not covered by this suffix set) and must not
+// be misread as an effort value.
+const CURSOR_EFFORT_SUFFIXES = ["low", "medium", "high", "xhigh", "max"] as const;
+
+/**
+ * If `normalized` starts with `prefix` and ends with one of the known effort
+ * suffixes, split it into the base model id plus a `{id: paramId, value}`
+ * ModelParameter. Returns null when no known suffix matches, leaving the id
+ * untouched (e.g. "claude-2.5" with no suffix, or an unrecognized tail).
+ */
+function splitCursorEffortSuffix(
+  normalized: string,
+  prefix: string,
+  paramId: string
+): { modelId: string; parameters: Array<{ id: string; value: string }> } | null {
+  if (!normalized.startsWith(prefix)) {
+    return null;
+  }
+  for (const suffix of CURSOR_EFFORT_SUFFIXES) {
+    const marker = `-${suffix}`;
+    if (normalized.endsWith(marker) && normalized.length > prefix.length + marker.length) {
+      return {
+        modelId: normalized.slice(0, -marker.length),
+        parameters: [{ id: paramId, value: suffix }],
+      };
+    }
+  }
+  return null;
+}
+
 /**
  * cursor-agent rewrites model ids before putting them on the wire:
- *   "auto"            → RequestedModel { model_id: "default" }
- *   "composer-2-fast" → RequestedModel { model_id: "composer-2",
- *                                        parameters: [{id: "fast", value: "true"}] }
+ *   "auto"                 → RequestedModel { model_id: "default" }
+ *   "composer-2-fast"      → RequestedModel { model_id: "composer-2",
+ *                                             parameters: [{id: "fast", value: "true"}] }
+ *   "claude-opus-4-8-high" → RequestedModel { model_id: "claude-opus-4-8",
+ *                                             parameters: [{id: "effort", value: "high"}] }
+ *   "gpt-5.5-high"         → RequestedModel { model_id: "gpt-5.5",
+ *                                             parameters: [{id: "reasoning", value: "high"}] }
  *
- * Other ids (e.g. "claude-4.6-sonnet-medium") are passed through verbatim
- * after spelling-variant normalization (see normalizeCursorModelId).
+ * Other ids are passed through verbatim after spelling-variant normalization
+ * (see normalizeCursorModelId).
  */
 export function resolveRequestedModel(modelId: string): {
   modelId: string;
@@ -326,6 +366,14 @@ export function resolveRequestedModel(modelId: string): {
       modelId: normalized.slice(0, -"-fast".length),
       parameters: [{ id: "fast", value: "true" }],
     };
+  }
+  const claudeSplit = splitCursorEffortSuffix(normalized, "claude-", "effort");
+  if (claudeSplit) {
+    return claudeSplit;
+  }
+  const gptSplit = splitCursorEffortSuffix(normalized, "gpt-", "reasoning");
+  if (gptSplit) {
+    return gptSplit;
   }
   return { modelId: normalized, parameters: [] };
 }

--- a/tests/unit/cursor-agent-protobuf.test.ts
+++ b/tests/unit/cursor-agent-protobuf.test.ts
@@ -35,9 +35,12 @@ test("resolveRequestedModel maps cursor-agent's client-side aliases", () => {
     modelId: "composer-2",
     parameters: [{ id: "fast", value: "true" }],
   });
+  // #7289: pinned Claude ids with an effort suffix split into the base id +
+  // an "effort" ModelParameter — cursor's server has no route for the
+  // suffixed id verbatim (see cursor-model-effort-suffix-7289.test.ts).
   assert.deepEqual(resolveRequestedModel("claude-4.6-sonnet-medium"), {
-    modelId: "claude-4.6-sonnet-medium",
-    parameters: [],
+    modelId: "claude-4.6-sonnet",
+    parameters: [{ id: "effort", value: "medium" }],
   });
   assert.deepEqual(resolveRequestedModel("composer-2"), { modelId: "composer-2", parameters: [] });
 });
@@ -148,15 +151,21 @@ test("encodeAgentRunRequest sends ModelDetails for pinned thinking models (#3714
   // #3714: pinned Claude/GPT thinking variants returned an empty turn when sent only via
   // RequestedModel (field 9, bare model_id). cursor-agent's working wire format also
   // carries a ModelDetails envelope with model_id + display_model_id + display_name.
+  // #7289: the trailing effort suffix ("-xhigh") is now split off into a separate
+  // ModelParameter — the BASE id is what's shared across RequestedModel + ModelDetails.
   const modelId = "claude-opus-4-7-thinking-xhigh";
+  const baseModelId = "claude-opus-4-7-thinking";
   const buf = encodeAgentRunRequest({ modelId, userText: "hi" });
-  const occurrences = buf.toString("latin1").split(modelId).length - 1;
+  const text = buf.toString("latin1");
+  const occurrences = text.split(baseModelId).length - 1;
   // RequestedModel.model_id (1) + ModelDetails {model_id, display_model_id, display_name}
-  // (3) → the id must now appear at least 4 times (it appeared once before the fix).
+  // (3) → the base id must appear at least 4 times.
   assert.ok(
     occurrences >= 4,
-    `pinned model id must be encoded in both RequestedModel and ModelDetails (got ${occurrences})`
+    `base model id must be encoded in both RequestedModel and ModelDetails (got ${occurrences})`
   );
+  assert.ok(text.includes("effort"), "effort parameter id present (#7289)");
+  assert.ok(text.includes("xhigh"), "effort parameter value present (#7289)");
 });
 
 test("encodeAgentRunRequest keeps RequestedModel + parameters alongside ModelDetails (#3714)", () => {

--- a/tests/unit/cursor-model-effort-suffix-7289.test.ts
+++ b/tests/unit/cursor-model-effort-suffix-7289.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveRequestedModel } from "../../open-sse/utils/cursorAgentProtobuf";
+
+// Issue #7289: pinned Claude/GPT models carrying an effort/reasoning suffix
+// (e.g. "claude-opus-4-8-high") return an empty turn from cursor's server.
+//
+// Ground truth captured from the real cursor-agent 2026.07.09 (Node) client
+// via an http2/fetch preload hook: the wire request for a pinned model with
+// an effort suffix carries the BASE model id (suffix stripped) plus a
+// separate ModelParameter — "effort" for Claude models, "reasoning" for GPT
+// models — not the full suffixed id crammed into model_id.
+test("resolveRequestedModel splits the effort suffix off pinned Claude model ids (#7289)", () => {
+  assert.deepEqual(resolveRequestedModel("claude-opus-4-8-high"), {
+    modelId: "claude-opus-4-8",
+    parameters: [{ id: "effort", value: "high" }],
+  });
+});
+
+test("resolveRequestedModel splits the effort suffix off pinned Claude sonnet model ids (#7289)", () => {
+  assert.deepEqual(resolveRequestedModel("claude-sonnet-5-high"), {
+    modelId: "claude-sonnet-5",
+    parameters: [{ id: "effort", value: "high" }],
+  });
+});
+
+test("resolveRequestedModel splits the reasoning suffix off pinned GPT model ids (#7289)", () => {
+  assert.deepEqual(resolveRequestedModel("gpt-5.5-high"), {
+    modelId: "gpt-5.5",
+    parameters: [{ id: "reasoning", value: "high" }],
+  });
+});
+
+test("resolveRequestedModel does not touch the composer -fast toggle (#7289 regression guard)", () => {
+  assert.deepEqual(resolveRequestedModel("composer-2-fast"), {
+    modelId: "composer-2",
+    parameters: [{ id: "fast", value: "true" }],
+  });
+});
+
+test("resolveRequestedModel does not rewrite ids with no recognized effort suffix (#7289 regression guard)", () => {
+  assert.deepEqual(resolveRequestedModel("claude-2.5"), {
+    modelId: "claude-2.5",
+    parameters: [],
+  });
+  assert.deepEqual(resolveRequestedModel("gpt-4o"), {
+    modelId: "gpt-4o",
+    parameters: [],
+  });
+});


### PR DESCRIPTION
Closes #7289

## Root cause

`resolveRequestedModel()` in `open-sse/utils/cursorAgentProtobuf.ts` only special-cased `"auto"` (→ `default`) and the composer `-fast` suffix. Every pinned Claude/GPT id carrying an effort/reasoning suffix (e.g. `claude-opus-4-8-high`, `claude-sonnet-5-high`, `gpt-5.5-high`) fell through to a verbatim pass-through with an empty `parameters` array.

Cursor's server has no route for `model_id = "claude-opus-4-8-high"` — it only accepts the base id plus an out-of-band `ModelParameter`. It accepts the request but returns an empty turn (`finish_reason: "stop"`, 0 output tokens), matching the reporter's symptom. `cursor/auto` and `cursor/composer-2.5` were unaffected because neither carries an effort suffix.

That resolved (still-suffixed) `modelId` was also duplicated into `ModelDetails.model_id` / `display_model_id` / `display_name` (added for #3714), so fixing `resolveRequestedModel()` alone also fixes `ModelDetails` since `encodeAgentRunRequest()` derives all of them from the same resolved id.

## Fix

Split known effort suffixes (`-low`/`-medium`/`-high`/`-xhigh`/`-max`) off pinned ids:
- `claude-*` ids → base id + `{id: "effort", value: <suffix>}`
- `gpt-*` ids → base id + `{id: "reasoning", value: <suffix>}`

This matches the real `cursor-agent` client's wire format (reporter-supplied capture). The existing `-fast` composer toggle and unsuffixed ids are unaffected (dedicated regression tests added).

## Regression test

New: `tests/unit/cursor-model-effort-suffix-7289.test.ts` — reproduces the bug (RED before the fix, confirmed in the analysis worktree) and asserts the split for Claude/GPT ids plus non-regression for `-fast`/unsuffixed ids.

Updated: `tests/unit/cursor-agent-protobuf.test.ts` — the pre-existing assertion that locked in verbatim pass-through for `claude-4.6-sonnet-medium` now asserts the corrected split (this was the bug being locked in, not a weakened test); the `#3714` `ModelDetails` test now asserts against the base id (`claude-opus-4-7-thinking`) plus the split-off `effort`/`xhigh` parameter instead of the now-obsolete full suffixed id.

## Gates run (all green)

```
node scripts/check/check-file-size.mjs                    → OK (no new/grown frozen files)
node scripts/check/check-complexity.mjs                    → OK — 2054 violations (baseline 2056, improved)
node scripts/check/check-cognitive-complexity.mjs          → OK — 889 violations (baseline 890, improved)
npm run typecheck:core                                     → clean
npx eslint --suppressions-location config/quality/eslint-suppressions.json \
  open-sse/utils/cursorAgentProtobuf.ts \
  tests/unit/cursor-agent-protobuf.test.ts \
  tests/unit/cursor-model-effort-suffix-7289.test.ts       → clean
node --import tsx/esm --test tests/unit/cursor-model-effort-suffix-7289.test.ts \
  tests/unit/cursor-agent-protobuf.test.ts \
  tests/unit/cursor-agent-exec-router.test.ts \
  tests/unit/cursor-agent-session.test.ts \
  tests/unit/cursor-agent-system-prompt.test.ts \
  tests/unit/cursor-agent-tool-calls.test.ts \
  tests/unit/cursor-image-input.test.ts \
  tests/unit/cursor-protobuf-wire-split.test.ts            → 138 pass, 0 fail
```

No vitest overlap (`cursorAgentProtobuf.ts` is not referenced under `tests/vitest`).