### PR TITLE
fix(sse): sanitize empty-signature thinking blocks + hoist strict-provider system messages

### DIFF
--- a/changelog.d/fixes/6953-empty-signature-thinking-block.md
+++ b/changelog.d/fixes/6953-empty-signature-thinking-block.md
@@ -1,0 +1,1 @@
+- fix(sse): stop forwarding empty-signature thinking blocks verbatim to Anthropic-native legs, which permanently poisoned combo fallback (#6953)

--- a/changelog.d/fixes/7293-strict-system-message-hoist.md
+++ b/changelog.d/fixes/7293-strict-system-message-hoist.md
@@ -1,0 +1,1 @@
+- fix(sse): hoist client-injected `system` messages to index 0 for strict OpenAI-compatible providers (xiaomi-mimo) regardless of origin (#7293)

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -169,11 +169,6 @@
       "count": 2
     }
   },
-  "open-sse/translator/helpers/claudeHelper.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "open-sse/utils/setupPolyfill.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5

--- a/open-sse/translator/helpers/claudeHelper.ts
+++ b/open-sse/translator/helpers/claudeHelper.ts
@@ -419,10 +419,27 @@ export function prepareClaudeRequest(
         // for the latest assistant (if it already has non-empty thinking text);
         // field cleanup (signature strip, type normalization) still runs.
         const isLatestAssistant = i === latestAssistantIndex;
-        const latestHasExistingThinking =
-          isLatestAssistant &&
-          content.some((b: any) => b.type === "thinking" || b.type === "redacted_thinking");
-        if (latestHasExistingThinking && supportsRedactedThinking) {
+        const latestThinkingBlocks: ClaudeContentBlock[] = isLatestAssistant
+          ? content.filter(
+              (b: ClaudeContentBlock) => b.type === "thinking" || b.type === "redacted_thinking"
+            )
+          : [];
+        const latestHasExistingThinking = latestThinkingBlocks.length > 0;
+        // #6953: a synthetic thinking block with an EMPTY signature/data (fabricated by a
+        // non-Anthropic provider leg, e.g. codex reasoning_content) is NOT a genuine Claude
+        // replay signature. Forwarding it verbatim to a real Anthropic-native upstream always
+        // 400s ("Invalid signature in thinking block"), permanently poisoning the combo onto
+        // the non-Anthropic leg. Only skip the verbatim-preserve path when every thinking-ish
+        // block on the latest assistant message carries a non-empty signature/data — older
+        // turns are already sanitized below (redacted_thinking + DEFAULT_THINKING_CLAUDE_SIGNATURE);
+        // the latest turn must go through the same sanitization when its signature is empty.
+        const latestHasGenuineThinkingSignature = latestThinkingBlocks.every(
+          (b: ClaudeContentBlock) =>
+            b.type === "redacted_thinking"
+              ? typeof b.data === "string" && (b.data as string).length > 0
+              : typeof b.signature === "string" && b.signature.length > 0
+        );
+        if (latestHasExistingThinking && supportsRedactedThinking && latestHasGenuineThinkingSignature) {
           // Anthropic: skip all thinking-block rewrites entirely — the
           // blocks must remain verbatim (type, thinking, signature, data).
           continue;

--- a/open-sse/translator/helpers/strictSystemHoist.ts
+++ b/open-sse/translator/helpers/strictSystemHoist.ts
@@ -1,0 +1,66 @@
+import { systemMessageMustBeFirst } from "../../../src/lib/memory/injection.ts";
+
+type Message = { role: string; content: unknown; [key: string]: unknown };
+
+function toTextContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((part): part is { type: string; text?: unknown } => {
+        return Boolean(part) && typeof part === "object" && (part as { type?: unknown }).type === "text";
+      })
+      .map((part) => String(part.text ?? ""))
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * #7293: hoist every `system`-role message onto index 0 for providers that reject a
+ * non-first system message (`systemMessageMustBeFirst()` — the single source of truth
+ * already used by `src/lib/memory/injection.ts`'s memory-injection half, #6135/PR#6225).
+ *
+ * `translateRequest()` is the single outbound choke point every request passes through,
+ * including same-format (OpenAI→OpenAI) passthrough where none of the format-specific
+ * translators run — so a client-injected `system` message landing mid-array (OpenCode /
+ * Kilo Code style clients, Discussion #6129) previously reached the upstream untouched.
+ *
+ * Merge, never drop: multiple offending system messages are folded (in original order)
+ * into the single leading system message, mirroring `injectSystemFirst()`'s
+ * `${memoryText}\n${first.content}` pattern and `openai-to-claude.ts`'s system-array-merge
+ * pattern.
+ *
+ * No-op (same array reference) whenever the provider is not strict, or the request is
+ * already compliant — required for prompt-cache prefix stability (#3890 class).
+ */
+export function hoistLeadingSystemMessage(
+  messages: Message[],
+  provider: string | null | undefined
+): Message[] {
+  if (!Array.isArray(messages) || messages.length === 0) return messages;
+  if (!systemMessageMustBeFirst(provider)) return messages;
+
+  const offendingIndices: number[] = [];
+  for (let i = 1; i < messages.length; i++) {
+    if (messages[i]?.role === "system") offendingIndices.push(i);
+  }
+  if (offendingIndices.length === 0) return messages;
+
+  const offending = offendingIndices.map((i) => messages[i]);
+  const rest = messages.filter((_, i) => !offendingIndices.includes(i));
+
+  const mergedText = [
+    rest[0]?.role === "system" ? toTextContent(rest[0].content) : null,
+    ...offending.map((m) => toTextContent(m.content)),
+  ]
+    .filter((text): text is string => Boolean(text))
+    .join("\n");
+
+  if (rest[0]?.role === "system") {
+    const mergedFirst: Message = { ...rest[0], content: mergedText };
+    return [mergedFirst, ...rest.slice(1)];
+  }
+
+  const leadingSystem: Message = { role: "system", content: mergedText };
+  return [leadingSystem, ...rest];
+}

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -21,6 +21,7 @@ import { hasThinkingConfig, normalizeThinkingConfig } from "../services/provider
 import { applyThinkingBudget } from "../services/thinkingBudget.ts";
 import { getResolvedModelCapabilities, supportsReasoning } from "../services/modelCapabilities.ts";
 import { normalizeRoles } from "../services/roleNormalizer.ts";
+import { hoistLeadingSystemMessage } from "./helpers/strictSystemHoist.ts";
 import {
   lookupReasoning,
   recordReplay,
@@ -196,6 +197,21 @@ export function translateRequest(
       targetFormat,
       preserveDeveloperRole
     );
+  }
+
+  // #7293: hoist any system message at index > 0 onto index 0 for providers that reject
+  // a non-first system role (systemMessageMustBeFirst() — same source of truth as the
+  // memory-injection half, #6135/PR#6225). Runs for every path — including same-format
+  // (OpenAI→OpenAI) passthrough, where none of the format-specific translators below
+  // execute — so a client-injected mid-array system message (OpenCode/Kilo Code style
+  // clients) is still normalized before reaching the upstream. No-op for non-strict
+  // providers and for already-compliant requests (prompt-cache prefix stability).
+  if (
+    targetFormat === FORMATS.OPENAI &&
+    result.messages &&
+    Array.isArray(result.messages)
+  ) {
+    result.messages = hoistLeadingSystemMessage(result.messages, provider);
   }
 
   // If same format, skip translation steps

--- a/tests/unit/probe-7293-strict-system-hoist.test.ts
+++ b/tests/unit/probe-7293-strict-system-hoist.test.ts
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { translateRequest } from "../../open-sse/translator/index.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+function buildRepro(messageCount: number) {
+  const messages: Array<{ role: string; content: string }> = [
+    { role: "user", content: "hello" },
+  ];
+  for (let i = 1; i < messageCount - 1; i++) {
+    messages.push({ role: i % 2 === 1 ? "assistant" : "user", content: `turn ${i}` });
+  }
+  // Client-injected system message landing well past index 0.
+  messages.splice(10, 0, {
+    role: "system",
+    content: "CLIENT INJECTED: remember to answer in JSON",
+  });
+  while (messages.length < messageCount) messages.push({ role: "user", content: "filler" });
+  return messages.slice(0, messageCount);
+}
+
+test("#7293: client-injected system message at index>0 is hoisted to index 0 for a strict provider (mimo) via translateRequest", () => {
+  const messages = buildRepro(70);
+  const body = { model: "mimo-v2.5", messages };
+
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI, // same-format passthrough — exactly mimo-v2.5's path
+    "mimo-v2.5",
+    body,
+    false,
+    null,
+    "xiaomi-mimo" // provider id consulted by systemMessageMustBeFirst()
+  );
+
+  const outMessages = result.messages as Array<{ role: string; content: string }>;
+  const systemIndices = outMessages
+    .map((m, i) => (m.role === "system" ? i : -1))
+    .filter((i) => i >= 0);
+
+  assert.deepEqual(systemIndices, [0]);
+  assert.match(outMessages[0].content, /CLIENT INJECTED: remember to answer in JSON/);
+});
+
+test("#7293: multiple offending system messages are folded into the leading system message, in order", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "hello" },
+    { role: "system", content: "first injected" },
+    { role: "user", content: "more" },
+    { role: "system", content: "second injected" },
+  ];
+  const body = { model: "mimo-v2.5", messages };
+
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "mimo-v2.5",
+    body,
+    false,
+    null,
+    "xiaomi-mimo"
+  );
+
+  const outMessages = result.messages as Array<{ role: string; content: string }>;
+  const systemIndices = outMessages
+    .map((m, i) => (m.role === "system" ? i : -1))
+    .filter((i) => i >= 0);
+
+  assert.deepEqual(systemIndices, [0]);
+  assert.equal(outMessages[0].content, "first injected\nsecond injected");
+  // Non-system ordering preserved
+  assert.deepEqual(
+    outMessages.slice(1).map((m) => m.content),
+    ["hi", "hello", "more"]
+  );
+});
+
+test("#7293: existing leading system message is preserved and merges client-injected ones after it", () => {
+  const messages = [
+    { role: "system", content: "leading prompt" },
+    { role: "user", content: "hi" },
+    { role: "system", content: "mid-array injected" },
+  ];
+  const body = { model: "mimo-v2.5", messages };
+
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "mimo-v2.5",
+    body,
+    false,
+    null,
+    "xiaomi-mimo"
+  );
+
+  const outMessages = result.messages as Array<{ role: string; content: string }>;
+  assert.equal(outMessages[0].role, "system");
+  assert.equal(outMessages[0].content, "leading prompt\nmid-array injected");
+  assert.equal(outMessages.length, 2);
+});
+
+test("#7293: non-strict provider is left untouched (no hoist regression)", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "hello" },
+    { role: "system", content: "mid-array system, tolerated by this provider" },
+  ];
+  const body = { model: "gpt-5-mini", messages: JSON.parse(JSON.stringify(messages)) };
+
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "gpt-5-mini",
+    body,
+    false,
+    null,
+    null // no strict provider
+  );
+
+  const outMessages = result.messages as Array<{ role: string; content: string }>;
+  assert.deepEqual(outMessages, messages);
+});
+
+test("#7293: already-compliant strict-provider request is a no-op (prompt-cache prefix stability)", () => {
+  const messages = [
+    { role: "system", content: "leading prompt" },
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "hello" },
+  ];
+  const body = { model: "mimo-v2.5", messages };
+
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "mimo-v2.5",
+    body,
+    false,
+    null,
+    "xiaomi-mimo"
+  );
+
+  assert.deepEqual(result.messages, messages);
+});

--- a/tests/unit/repro-6953.test.ts
+++ b/tests/unit/repro-6953.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+const { prepareClaudeRequest } = await import("../../open-sse/translator/helpers/claudeHelper.ts");
+const { DEFAULT_THINKING_CLAUDE_SIGNATURE } = await import(
+  "../../open-sse/config/defaultThinkingSignature.ts"
+);
+test("#6953: latest-assistant thinking block with EMPTY signature must not be forwarded verbatim to an Anthropic-native leg", () => {
+  const body: Record<string, unknown> = {
+    thinking: { type: "enabled", budget_tokens: 4096 },
+    model: "claude-opus-4-8",
+    messages: [
+      { role: "user", content: [{ type: "text", text: "review this diff" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Reviewing Rust diff for compliance...", signature: "" },
+          { type: "text", text: "Looks fine." },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "go ahead and commit" }] },
+    ],
+  };
+  prepareClaudeRequest(body, "claude");
+  const tb = body.messages[1].content[0];
+  assert.notEqual(tb.signature, "", "empty/foreign thinking signature must not be forwarded verbatim");
+  if (tb.type === "redacted_thinking") assert.equal(tb.data, DEFAULT_THINKING_CLAUDE_SIGNATURE);
+});


### PR DESCRIPTION
Closes #6953
Closes #7293

Two distinct defects in the same translator-file cluster (`open-sse/translator/request/openai-to-claude.ts` and its helpers) — one PR per campaign guidance to avoid a merge collision on the shared file.

## #6953 — empty-signature thinking block poisons the Anthropic leg

`prepareClaudeRequest`'s "preserve latest-assistant thinking verbatim" guard (`open-sse/translator/helpers/claudeHelper.ts`, an anti-400 guard for legitimate Anthropic-native replay) did not distinguish a genuine Claude signature from an empty one fabricated by a non-Anthropic leg (e.g. codex `reasoning_content`). It forwarded `signature: ""` verbatim to a real Anthropic upstream, which always 400s ("Invalid signature in thinking block"), permanently locking combo routing onto the non-Anthropic leg. The response-side half of this bug (`openai-to-claude.ts` synthesizing the empty signature in the first place) was already fixed by PR #6982; this closes the remaining request-side half.

**Fix**: the verbatim-preserve guard now requires every thinking-ish block on the latest assistant message to carry a non-empty `signature`/`data`; otherwise it falls through to the existing sanitization path (`redacted_thinking` + `DEFAULT_THINKING_CLAUDE_SIGNATURE`) already applied to older turns.

**Regression test**: `tests/unit/repro-6953.test.ts`
- RED: `actual: ''` (empty signature forwarded verbatim)
- GREEN after fix

## #7293 — strict-provider system-message hoist (general case)

`translateRequest()` (`open-sse/translator/index.ts`) is the single outbound choke point every chat request passes through, including same-format (OpenAI→OpenAI) passthrough where none of the format-specific translators run. `systemMessageMustBeFirst()` / `PROVIDERS_SYSTEM_MUST_BE_FIRST` (`src/lib/memory/injection.ts`, #6135/PR#6225) was only consulted by the memory injector, so a client-injected `system` message landing mid-array (OpenCode/Kilo Code style clients — Discussion #6129) reached strict providers (xiaomi-mimo) untouched and 400'd.

**Fix**: new helper `open-sse/translator/helpers/strictSystemHoist.ts` hoists every `system` message onto index 0 for strict providers, reusing `systemMessageMustBeFirst()` as the single source of truth, merging (never dropping) multiple offenders in original order, and no-op'ing (same array reference) for non-strict providers and already-compliant requests — preserving prompt-cache prefix stability.

**Regression test**: `tests/unit/probe-7293-strict-system-hoist.test.ts`
- RED: `systemIndices === [10]` for a 70-message array with a client-injected system message at index 10
- GREEN after fix, plus: multi-offender merge (order preserved), existing-leading-system merge, non-strict-provider no-op, already-compliant no-op

## Gates run

- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2054 violations, baseline 2056 — improved)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 violations, baseline 890 — improved)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `npm run test:vitest` — 254/254 passed
- Directly relevant existing suites (all green): `translator-claude-helper-thinking.test.ts`, `translator-xiaomi-mimo-reasoning-replay-1321.test.ts`, `memory-system-first-6135.test.ts`, `dashscope-cache-control-openai-2069.test.ts`, `xiaomi-mimo-provider.test.ts`, `role-normalizer.test.ts`, `correctness/translation.golden.test.ts`, `correctness/translators.property.test.ts`, `translator-helper-branches.test.ts`, `translator-claude-to-openai.test.ts`, `translator-same-format-null-flush.test.ts`

`npm run test:unit` (full suite) was kicked off but did not complete within this session due to very heavy shared-devbox contention (load avg ~22 from other parallel sessions); the two new probe files and every directly-relevant existing suite were run individually to green as shown above.