### PR TITLE
fix(sse): honor per-model targetFormat override for zai/glm-coding-apikey (Defect A of #7364)

### DIFF
--- a/changelog.d/fixes/7364-zai-glm-target-format.md
+++ b/changelog.d/fixes/7364-zai-glm-target-format.md
@@ -1,0 +1,1 @@
+- fix(sse): honor per-model targetFormat override for zai/glm-coding-apikey buildUrl and make custom-model id lookup case-insensitive (#7364)

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -52,6 +52,7 @@ import {
   normalizeGigachatChatUrl,
 } from "@/lib/providers/validation/urlHelpers";
 import { forwardOpencodeClientHeaders } from "../utils/opencodeHeaders.ts";
+import { resolveZaiUrl } from "./default/zaiFormatOverride.ts";
 
 import type { PoolConfig } from "../services/sessionPool/types.ts";
 
@@ -242,10 +243,9 @@ export class DefaultExecutor extends BaseExecutor {
         return normalizeOpenAIChatUrl(baseUrl);
       }
       case "zai":
-      case "glm-coding-apikey": {
-        const zaiBaseUrl = this.resolveBaseUrl(credentials);
-        return `${zaiBaseUrl}?beta=true`;
-      }
+      case "glm-coding-apikey":
+        // #7364: format override extracted to zaiFormatOverride.ts (file-size ratchet).
+        return resolveZaiUrl(credentials, (fallback) => this.resolveBaseUrl(credentials, fallback));
       case "claude":
       case "glm":
       case "glmt":

--- a/open-sse/executors/default/zaiFormatOverride.ts
+++ b/open-sse/executors/default/zaiFormatOverride.ts
@@ -1,0 +1,25 @@
+import { GLM_DEFAULT_BASE_URLS } from "../../config/glmProvider.ts";
+
+type ZaiCredentialsLike = {
+  providerSpecificData?: { targetFormat?: unknown } | null;
+} | null;
+
+/**
+ * #7364: "zai"/"glm-coding-apikey" default to the Anthropic Messages wire format
+ * (registry format:"claude"), but a per-model `targetFormat` override (custom-model
+ * dropdown, #2905) can resolve to "openai" — e.g. for a vision model like glm-4.6v
+ * that the operator wants routed through the OpenAI-compatible endpoint instead.
+ * chatCore/executionCredentials.ts threads that resolved override onto
+ * `providerSpecificData.targetFormat`; DefaultExecutor.buildUrl() has no other way
+ * to see it, so without this check every zai/glm-coding-apikey request silently hit
+ * the Claude-format endpoint regardless of the override.
+ */
+export function resolveZaiUrl(
+  credentials: ZaiCredentialsLike,
+  resolveBaseUrl: (fallback?: string) => string
+): string {
+  if (credentials?.providerSpecificData?.targetFormat === "openai") {
+    return resolveBaseUrl(GLM_DEFAULT_BASE_URLS.international);
+  }
+  return `${resolveBaseUrl()}?beta=true`;
+}

--- a/open-sse/handlers/chatCore/executionCredentials.ts
+++ b/open-sse/handlers/chatCore/executionCredentials.ts
@@ -55,6 +55,16 @@ export function resolveExecutionCredentials(opts: {
     providerSpecificData._omnirouteForceResponsesUpstream = true;
   }
 
+  // #7364: "zai"/"glm-coding-apikey" default to the Anthropic Messages wire format
+  // (registry format:"claude"), but a per-model targetFormat override (custom-model
+  // dropdown, #2905) can resolve targetFormat to "openai" — e.g. for a vision model
+  // like glm-4.6v that the operator wants routed through the OpenAI-compatible
+  // endpoint. DefaultExecutor.buildUrl()'s "zai" branch has no other way to see that
+  // override, so surface it on providerSpecificData for buildUrl to read.
+  if (targetFormat === FORMATS.OPENAI && (provider === "zai" || provider === "glm-coding-apikey")) {
+    providerSpecificData.targetFormat = targetFormat;
+  }
+
   const withApiType = {
     ...nextCredentials,
     providerSpecificData,

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -705,10 +705,22 @@ function getCustomModelRow(providerId: string, modelId: string): JsonRecord | nu
   try {
     const models = JSON.parse(value) as unknown;
     if (!Array.isArray(models)) return null;
-    const m = models.find((x: unknown) => {
+    const isIdMatch = (x: unknown, id: string): boolean => {
       if (!x || typeof x !== "object" || Array.isArray(x)) return false;
-      return (x as { id?: string }).id === modelId;
-    }) as JsonRecord | undefined;
+      return (x as { id?: string }).id === id;
+    };
+    // #7364: exact match first; case-insensitive fallback so "glm-4.6V" resolves a
+    // custom model saved as "glm-4.6v" (see lookupCustomModelMeta in
+    // src/sse/services/model.ts for the sibling lookup this mirrors).
+    const m = (models.find((x: unknown) => isIdMatch(x, modelId)) ??
+      models.find(
+        (x: unknown) =>
+          x &&
+          typeof x === "object" &&
+          !Array.isArray(x) &&
+          typeof (x as { id?: string }).id === "string" &&
+          ((x as { id: string }).id as string).toLowerCase() === modelId.toLowerCase()
+      )) as JsonRecord | undefined;
     return m ?? null;
   } catch {
     return null;

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -74,7 +74,15 @@ async function lookupCustomModelMeta(
   try {
     const models = await getCustomModels(providerId);
     if (!Array.isArray(models)) return {};
-    const match = models.find((m: any) => m.id === modelId);
+    // #7364: exact match first (preserves existing behavior/perf); fall back to a
+    // case-insensitive match so a model saved as "glm-4.6v" is still found when the
+    // caller (dashboard, combo target, direct call) requests "glm-4.6V" — several
+    // reporters typed the uppercase "V" from Z.AI's own docs/marketing.
+    const match =
+      models.find((m: any) => m.id === modelId) ??
+      models.find(
+        (m: any) => typeof m.id === "string" && m.id.toLowerCase() === modelId.toLowerCase()
+      );
     if (!match) return {};
     return {
       apiFormat: match.apiFormat === "responses" ? "responses" : undefined,

--- a/tests/unit/zai-execution-credentials-target-format-7364.test.ts
+++ b/tests/unit/zai-execution-credentials-target-format-7364.test.ts
@@ -1,0 +1,52 @@
+// tests/unit/zai-execution-credentials-target-format-7364.test.ts
+// #7364 Defect A: resolveExecutionCredentials must thread a resolved "openai"
+// targetFormat onto providerSpecificData for the "zai"/"glm-coding-apikey" providers,
+// so DefaultExecutor.buildUrl()'s zai branch (open-sse/executors/default/zaiFormatOverride.ts)
+// can see the per-model custom-model targetFormat override (#2905) and route to the
+// OpenAI-compatible endpoint instead of the default Anthropic Messages URL.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveExecutionCredentials } from "../../open-sse/handlers/chatCore/executionCredentials.ts";
+
+const base = {
+  credentials: { providerSpecificData: { foo: "bar" } } as Record<string, unknown>,
+  nativeCodexPassthrough: false,
+  endpointPath: "/v1/messages",
+  ccSessionId: null,
+};
+
+test("zai + resolved openai targetFormat threads providerSpecificData.targetFormat", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "zai",
+    targetFormat: "openai",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar", targetFormat: "openai" });
+});
+
+test("glm-coding-apikey + resolved openai targetFormat threads providerSpecificData.targetFormat", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "glm-coding-apikey",
+    targetFormat: "openai",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar", targetFormat: "openai" });
+});
+
+test("zai + default claude targetFormat does NOT inject a targetFormat override", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "zai",
+    targetFormat: "claude",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar" });
+});
+
+test("unrelated provider (openai) with targetFormat=openai is untouched by the zai branch", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "openai",
+    targetFormat: "openai",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar" });
+});

--- a/tests/unit/zai-glm-target-format-override.test.ts
+++ b/tests/unit/zai-glm-target-format-override.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7364-zai-target-format-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const { getModelInfo } = await import("../../src/sse/services/model.ts");
+const { DefaultExecutor } = await import("../../open-sse/executors/default.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#7364 Defect A (URL): DefaultExecutor.buildUrl('zai', ...) ignores a per-model targetFormat:'openai' override and still returns the Anthropic Messages URL", () => {
+  const executor = new DefaultExecutor("zai");
+  const credentialsWithOpenAIOverride = {
+    apiKey: "test-key",
+    providerSpecificData: { targetFormat: "openai" },
+  };
+  const url = executor.buildUrl("glm-4.6v", false, 0, credentialsWithOpenAIOverride);
+  assert.notEqual(
+    url,
+    "https://api.z.ai/api/anthropic/v1/messages?beta=true",
+    "BUG #7364 Defect A: an 'openai' targetFormat override must not hit the Anthropic Messages URL, but it does"
+  );
+});
+
+test("#7364 Defect A (case-sensitivity): a custom model saved as 'glm-4.6v' is not found when looked up as 'glm-4.6V'", async () => {
+  await modelsDb.addCustomModel(
+    "zai",
+    "glm-4.6v",
+    "GLM 4.6V (vision)",
+    "manual",
+    "chat-completions",
+    ["chat"],
+    "openai" // explicit targetFormat override, mirroring the dashboard dropdown
+  );
+
+  const exact = (await getModelInfo("zai/glm-4.6v")) as { targetFormat?: string };
+  assert.equal(exact.targetFormat, "openai", "sanity check: exact-case lookup must surface the saved targetFormat");
+
+  const mixedCase = (await getModelInfo("zai/glm-4.6V")) as { targetFormat?: string };
+  assert.equal(
+    mixedCase.targetFormat,
+    "openai",
+    "BUG #7364 Defect A: case-mismatched lookup ('glm-4.6V' vs stored 'glm-4.6v') must still surface the targetFormat override, but it doesn't"
+  );
+});


### PR DESCRIPTION
## Root cause

Two independent defects were filed together in #7364; this PR fixes **Defect A** only (Defect B — the max_tokens clamp — is a separate PR, no file overlap, no shared root cause; see triage plan-file for the split rationale).

`DefaultExecutor.buildUrl()`'s `case "zai": case "glm-coding-apikey":` (`open-sse/executors/default.ts`) always returned the Anthropic Messages URL (`https://api.z.ai/api/anthropic/v1/messages?beta=true`), ignoring a per-model `targetFormat` override (the custom-model dashboard dropdown, #2905) that resolves to `"openai"` — e.g. for a vision model like `glm-4.6v` that the operator wants routed through the OpenAI-compatible endpoint instead.

`chatCore/executionCredentials.ts` already threads similar per-request routing flags onto `providerSpecificData` for other providers (the existing Azure AI / OCI `apiType=responses` forcing block right above), so this PR follows that same established pattern: when the resolved `targetFormat` is `"openai"` for `zai`/`glm-coding-apikey`, it's now surfaced on `providerSpecificData.targetFormat`, which `buildUrl()` (via the new `open-sse/executors/default/zaiFormatOverride.ts` helper — extracted to respect the file-size ratchet on `default.ts`) reads to route to the OpenAI-compatible endpoint (`GLM_DEFAULT_BASE_URLS.international`) instead.

Separately, custom-model id lookup did an exact, case-sensitive match:
- `lookupCustomModelMeta()` in `src/sse/services/model.ts`
- `getCustomModelRow()` in `src/lib/db/models.ts`

so a model saved as `glm-4.6v` was invisible when looked up as `glm-4.6V` — several reporters typed the uppercase "V" from Z.AI's own docs/marketing. Both now try an exact match first (preserving existing behavior/perf), falling back to a case-insensitive match only when the exact match misses.

## Regression tests (TDD, Hard Rule #18)

- `tests/unit/zai-glm-target-format-override.test.ts` — the triage plan-file's RED probe, reused verbatim as the permanent regression guard (was RED against `release/v3.8.49` tip, now GREEN).
- `tests/unit/zai-execution-credentials-target-format-7364.test.ts` — new, proves the production wiring in `executionCredentials.ts` actually threads the override (not just that `buildUrl` can consume it in isolation), plus a negative case confirming an unrelated provider (`openai`) is untouched.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs`
- `node scripts/check/check-complexity.mjs`
- `node scripts/check/check-cognitive-complexity.mjs`
- `npm run typecheck:core`
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>`
- `node --import tsx/esm --test tests/unit/zai-glm-target-format-override.test.ts tests/unit/zai-execution-credentials-target-format-7364.test.ts tests/unit/executor-default-base.test.ts` (existing zai/glm-coding-apikey buildUrl characterization test)
- `node --import tsx/esm --test tests/unit/custom-model-target-format.test.ts tests/unit/chatcore-execution-credentials.test.ts tests/unit/chatcore-target-format.test.ts tests/unit/model-resolver.test.ts tests/unit/model-alias-provider-resolution.test.ts tests/unit/combo-custom-provider-resolution.test.ts` (existing tests of every touched symbol/consumer)

Refs #7364