### PR TITLE
fix(sse): clamp glm-4.6v max_tokens to the 32768 ceiling (Defect B of #7364)

### DIFF
--- a/changelog.d/fixes/7364-glm-4.6v-max-tokens-clamp.md
+++ b/changelog.d/fixes/7364-glm-4.6v-max-tokens-clamp.md
@@ -1,0 +1,1 @@
+- fix(sse): clamp glm-4.6v max_tokens to the 32768 ceiling for zai and glm providers, wiring stripUnsupportedParams into GlmExecutor's own transform path (#7364)

--- a/open-sse/executors/glm.ts
+++ b/open-sse/executors/glm.ts
@@ -19,6 +19,7 @@ import {
   getGlmTransport,
 } from "../config/glmProvider.ts";
 import { applyProviderRequestDefaults } from "../services/providerRequestDefaults.ts";
+import { stripUnsupportedParams } from "../translator/paramSupport.ts";
 import { getRotatingApiKey } from "../services/apiKeyRotator.ts";
 import { CLAUDE_CLI_STAINLESS_PACKAGE_VERSION } from "../config/anthropicHeaders.ts";
 import {
@@ -282,6 +283,14 @@ export class GlmExecutor extends DefaultExecutor {
 
     const transformed = this.transformRequest(effectiveModel, body, stream, credentials);
     const record = asRecord(transformed);
+
+    // #7364: unlike DefaultExecutor.execute() (default.ts), GlmExecutor.execute()
+    // never calls the base execute() loop — it drives its own fetch via
+    // executeTransport()/transformForTransport() — so stripUnsupportedParams()
+    // (normally applied at default.ts's execute() call site) never ran for GLM
+    // requests. Without this call, a STRIP_RULES clamp entry for provider "glm"
+    // (e.g. the glm-4.6v max_tokens ceiling) would be silently dead code.
+    if (record) stripUnsupportedParams(this.provider, effectiveModel, record);
 
     // Ensure upstream receives the base model ID, not the effort-suffixed alias
     if (record && effortTier) {

--- a/open-sse/translator/paramSupport.ts
+++ b/open-sse/translator/paramSupport.ts
@@ -59,6 +59,17 @@ const STRIP_RULES: StripRule[] = [
   // OmniRoute's actual volcengine Kimi id (not a broad /kimi/i regex) so it
   // never clamps an unrelated future Kimi listing whose Ark cap may differ.
   { provider: "volcengine", match: /^kimi-k2-5-260127$/, maxOutputCap: 32768, clampToModelMaxOutput: true },
+  // #7364: Z.AI's glm-4.6v vision endpoint enforces a 32768 max_tokens ceiling
+  // server-side and 400s when a client sends a larger explicit max_tokens (e.g. a
+  // client defaulting to 65536). Scoped to both wire paths that can reach this
+  // model: "zai" (DefaultExecutor, Claude format by default — glm-4.6v is only
+  // reachable there as a custom model attached to the connection, so it is NOT in
+  // PROVIDER_MODELS["zai"] and clampToModelMaxOutput would find no catalog ceiling
+  // to clamp against, hence the fixed maxOutputCap) and "glm" (GlmExecutor, OpenAI
+  // format — glm-4.6v IS in the registry catalog there, `GLM_SHARED_MODELS` in
+  // glmProvider.ts, maxOutputTokens: 32768, so clampToModelMaxOutput suffices).
+  { provider: "zai", match: /^glm-4\.6v$/i, maxOutputCap: 32768 },
+  { provider: "glm", match: /^glm-4\.6v$/i, clampToModelMaxOutput: true },
 ];
 
 function matches(rule: StripRule, model: string): boolean {

--- a/tests/unit/glm-executor-max-tokens-clamp-7364.test.ts
+++ b/tests/unit/glm-executor-max-tokens-clamp-7364.test.ts
@@ -1,0 +1,44 @@
+// tests/unit/glm-executor-max-tokens-clamp-7364.test.ts
+// #7364 Defect B: GlmExecutor.execute() drives its own fetch flow (executeTransport /
+// transformForTransport) and never runs through DefaultExecutor.execute()'s
+// stripUnsupportedParams() call site — so a STRIP_RULES clamp entry for provider "glm"
+// was dead code until transformForTransport() called it directly. This proves the wiring,
+// not just the STRIP_RULES entry (see zai-glm-max-tokens-clamp-7364.test.ts for that).
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GlmExecutor } from "../../open-sse/executors/glm.ts";
+
+test("GlmExecutor.transformForTransport clamps an oversized client max_tokens for glm-4.6v (openai transport)", () => {
+  const executor = new GlmExecutor("glm");
+  const body = { messages: [{ role: "user", content: "describe this image" }], max_tokens: 65536 };
+
+  const transformed = executor.transformForTransport(
+    "glm-4.6v",
+    body,
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as { max_tokens?: number };
+
+  assert.equal(
+    transformed.max_tokens,
+    32768,
+    "#7364: glm-4.6v max_tokens above the catalog ceiling must be clamped by the real GlmExecutor transform path"
+  );
+});
+
+test("GlmExecutor.transformForTransport leaves an in-range max_tokens for glm-4.6v untouched", () => {
+  const executor = new GlmExecutor("glm");
+  const body = { messages: [{ role: "user", content: "describe this image" }], max_tokens: 2048 };
+
+  const transformed = executor.transformForTransport(
+    "glm-4.6v",
+    body,
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as { max_tokens?: number };
+
+  assert.equal(transformed.max_tokens, 2048);
+});

--- a/tests/unit/zai-glm-max-tokens-clamp-7364.test.ts
+++ b/tests/unit/zai-glm-max-tokens-clamp-7364.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7364-max-tokens-clamp-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const {
+  stripUnsupportedParams,
+  __STRIP_RULES_FOR_TEST,
+} = await import("../../open-sse/translator/paramSupport.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#7364 Defect B: zai/glm-4.6v max_tokens above the 32768 ceiling is clamped before dispatch", () => {
+  const body: Record<string, unknown> = {
+    model: "glm-4.6v",
+    max_tokens: 65536,
+    messages: [{ role: "user", content: "describe this image" }],
+  };
+  stripUnsupportedParams("zai", "glm-4.6v", body);
+  assert.equal(
+    body.max_tokens,
+    32768,
+    "BUG #7364 Defect B: max_tokens must be clamped to the model's 32768 ceiling, but it is passed through unchanged"
+  );
+});
+
+test("#7364 Defect B: glm/glm-4.6v (the openai-format alias) max_tokens above the ceiling is also clamped", () => {
+  const body: Record<string, unknown> = {
+    model: "glm-4.6v",
+    max_tokens: 50000,
+    messages: [{ role: "user", content: "describe this image" }],
+  };
+  stripUnsupportedParams("glm", "glm-4.6v", body);
+  assert.equal(
+    body.max_tokens,
+    32768,
+    "BUG #7364 Defect B: max_tokens must be clamped to the model's 32768 ceiling on the 'glm' provider path too"
+  );
+});
+
+test("#7364 Defect B (sanity): STRIP_RULES now has clamp entries for both zai/glm-4.6v and glm/glm-4.6v", () => {
+  const hasRuleFor = (provider: string) =>
+    __STRIP_RULES_FOR_TEST.some(
+      (rule) =>
+        rule.provider === provider &&
+        (rule.clampToModelMaxOutput || Number.isFinite(rule.maxOutputCap)) &&
+        (typeof rule.match === "function" ? rule.match("glm-4.6v") : rule.match.test("glm-4.6v"))
+    );
+  assert.equal(hasRuleFor("zai"), true, "#7364 fix: a clamp rule must exist for zai/glm-4.6v");
+  assert.equal(hasRuleFor("glm"), true, "#7364 fix: a clamp rule must exist for glm/glm-4.6v");
+});


### PR DESCRIPTION
## Root cause

Two independent defects were filed together in #7364; this PR fixes **Defect B** only (Defect A — the forced Claude-format URL — is a separate PR, #7584, no file overlap, no shared root cause; see triage plan-file for the split rationale).

`glm-4.6v` declares `maxOutputTokens: 32768` in its catalog entry (`GLM_SHARED_MODELS`, `open-sse/config/glmProvider.ts`). That ceiling is only consulted by combo candidate filtering (`exceedsKnownOutputLimit`) — which just *excludes* a candidate target — so a single-model combo or a direct call has no alternate and an oversized client `max_tokens` (e.g. a client that defaults to 65536) is forwarded straight to Z.AI, which 400s.

`open-sse/translator/paramSupport.ts` already has a working `clampToModelMaxOutput`/`maxOutputCap` mechanism (used today for a VolcEngine Kimi rule) but had zero `STRIP_RULES` entries for `provider: "zai"` or `provider: "glm"`. Added two:

- `zai`: `maxOutputCap: 32768` (fixed) — `glm-4.6v` is only reachable on the `zai` provider as a **custom model** attached to the connection, so it is **not** in `PROVIDER_MODELS["zai"]`; `clampToModelMaxOutput` would find no catalog ceiling to clamp against there, hence the fixed cap.
- `glm`: `clampToModelMaxOutput: true` — `glm-4.6v` **is** in the registry catalog for the `glm` provider (`GLM_SHARED_MODELS`, `maxOutputTokens: 32768`), so the catalog-driven clamp is correct and self-maintaining if the ceiling ever changes.

While verifying the `glm` rule would actually fire, found a second, deeper bug the triage plan-file flagged as unverified: **`GlmExecutor.execute()` never runs through `DefaultExecutor.execute()`'s `stripUnsupportedParams()` call site at all** — it drives its own fetch flow via `executeTransport()`/`transformForTransport()`, completely bypassing the base executor's request loop. Without wiring `stripUnsupportedParams()` directly into `transformForTransport()`, the new `"glm"` `STRIP_RULES` entry would have been silently dead code for every real GLM request.

## Regression tests (TDD, Hard Rule #18)

- `tests/unit/zai-glm-max-tokens-clamp-7364.test.ts` — the triage plan-file's RED probe, reused verbatim (2/3 assertions were RED against `release/v3.8.49` tip, now all 3 GREEN; the sanity assertion was updated to lock in the fix instead of the absence of a rule, per the plan-file's own note that it was expected to flip).
- `tests/unit/glm-executor-max-tokens-clamp-7364.test.ts` — new, proves the real `GlmExecutor.transformForTransport()` wiring end-to-end (not just the `STRIP_RULES` entry via `stripUnsupportedParams()` in isolation), including a negative case for an in-range `max_tokens`.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs`
- `node scripts/check/check-complexity.mjs`
- `node scripts/check/check-cognitive-complexity.mjs`
- `npm run typecheck:core`
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>`
- `node --import tsx/esm --test tests/unit/zai-glm-max-tokens-clamp-7364.test.ts tests/unit/glm-executor-max-tokens-clamp-7364.test.ts tests/unit/executors-strip-unsupported-params.test.ts tests/unit/nvidia-minimax-thinking-strip.test.ts tests/unit/glm-executor.test.ts` — 47/47 pass, no regressions.

Refs #7364