### PR TITLE
fix(providers): search providers missing static model catalog (#7529)

### DIFF
--- a/changelog.d/fixes/7529-search-static-catalog.md
+++ b/changelog.d/fixes/7529-search-static-catalog.md
@@ -1,0 +1,1 @@
+- fix(providers): search providers now expose a static model catalog derived from `searchTypes`, fixing "does not support models listing" 400 for serper-search, brave-search, perplexity-search, exa-search, tavily-search, google-pse-search, youcom-search, searxng-search, zai-search (#7529)

--- a/src/lib/providers/staticModels.ts
+++ b/src/lib/providers/staticModels.ts
@@ -8,6 +8,7 @@ import {
 } from "@omniroute/open-sse/config/audioRegistry.ts";
 import { ANTIGRAVITY_PUBLIC_MODELS } from "@omniroute/open-sse/config/antigravityModelAliases.ts";
 import { getStaticQoderModels } from "@omniroute/open-sse/services/qoderCli.ts";
+import { getSearchProvider } from "@omniroute/open-sse/config/searchRegistry.ts";
 
 import { getModelsByProviderId } from "@/shared/constants/models";
 
@@ -115,10 +116,46 @@ const STATIC_MODEL_PROVIDERS: Record<string, () => Array<{ id: string; name: str
   ],
 };
 
+const SEARCH_TYPE_LABELS: Record<string, string> = {
+  web: "Web Search",
+  news: "News Search",
+};
+
+function formatSearchTypeLabel(searchType: string): string {
+  return (
+    SEARCH_TYPE_LABELS[searchType] ??
+    `${searchType.charAt(0).toUpperCase()}${searchType.slice(1)} Search`
+  );
+}
+
+/**
+ * Search providers don't have "models" — a provider IS the model (see
+ * open-sse/config/searchRegistry.ts header doc). Any search provider without a
+ * dedicated literal entry above (custom depth/engine catalog, e.g.
+ * "linkup-search") still needs a non-empty static catalog so the "Available
+ * Models" / model-import UI shows a usable list instead of a 400 "does not
+ * support models listing" (#7529). Derive it generically from the registry's
+ * own `searchTypes` so any *future* search provider is covered automatically.
+ */
+function getSearchProviderFallbackCatalog(provider: string): LocalCatalogModel[] | undefined {
+  const searchProvider = getSearchProvider(provider);
+  if (!searchProvider || searchProvider.searchTypes.length === 0) return undefined;
+
+  return searchProvider.searchTypes.map((searchType) => ({
+    id: searchType,
+    name: formatSearchTypeLabel(searchType),
+  }));
+}
+
 export function getStaticModelsForProvider(provider: string): LocalCatalogModel[] | undefined {
   const staticModelsFn = STATIC_MODEL_PROVIDERS[provider];
   if (staticModelsFn) {
     return staticModelsFn();
+  }
+
+  const searchFallback = getSearchProviderFallbackCatalog(provider);
+  if (searchFallback) {
+    return searchFallback;
   }
 
   const specialtyModels: LocalCatalogModel[] = [];

--- a/tests/unit/search-providers-static-model-catalog-7529.test.ts
+++ b/tests/unit/search-providers-static-model-catalog-7529.test.ts
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { SEARCH_PROVIDERS } from "@omniroute/open-sse/config/searchRegistry.ts";
+import { getStaticModelsForProvider } from "@/lib/providers/staticModels";
+
+const EXCLUDED_FROM_ISSUE = new Set(["duckduckgo-free"]);
+
+const AFFECTED_PER_ISSUE = [
+  "serper-search",
+  "brave-search",
+  "perplexity-search",
+  "exa-search",
+  "tavily-search",
+  "google-pse-search",
+  "youcom-search",
+  "searxng-search",
+  "zai-search",
+];
+
+test("#7529 — every SEARCH_PROVIDERS id should have a static model catalog (RED until fixed)", () => {
+  const searchProviderIds = Object.keys(SEARCH_PROVIDERS).filter(
+    (id) => !EXCLUDED_FROM_ISSUE.has(id)
+  );
+
+  for (const id of AFFECTED_PER_ISSUE) {
+    assert.ok(searchProviderIds.includes(id), `expected ${id} to still be present in SEARCH_PROVIDERS`);
+  }
+
+  const missing: string[] = [];
+  for (const id of searchProviderIds) {
+    const catalog = getStaticModelsForProvider(id);
+    if (!catalog || catalog.length === 0) missing.push(id);
+  }
+
+  assert.deepEqual(
+    missing.sort(),
+    [],
+    `search providers with NO static model catalog (will 400 "does not support models listing" on import): ${missing.join(", ")}`
+  );
+});
+
+test("#7529 — a brand-new SEARCH_PROVIDERS entry with no literal STATIC_MODEL_PROVIDERS override still gets a usable catalog derived from searchTypes (generalized fix, not whack-a-mole)", () => {
+  // serper-search has no dedicated STATIC_MODEL_PROVIDERS["serper-search"] entry —
+  // this proves the fallback path (derived from SEARCH_PROVIDERS[id].searchTypes)
+  // is what supplies its catalog, not a one-off literal added for this issue.
+  const config = SEARCH_PROVIDERS["serper-search"];
+  const catalog = getStaticModelsForProvider("serper-search");
+  assert.ok(catalog && catalog.length > 0, "expected a static catalog for serper-search");
+  const catalogIds = new Set((catalog ?? []).map((model) => model.id));
+  for (const searchType of config.searchTypes) {
+    assert.ok(
+      catalogIds.has(searchType),
+      `expected the generalized catalog for serper-search to include its declared searchType "${searchType}"`
+    );
+  }
+});


### PR DESCRIPTION
Closes #7529

## Root cause

`getStaticModelsForProvider()` (`src/lib/providers/staticModels.ts`) only defined literal static catalogs for 3 of the 12 ids in `SEARCH_PROVIDERS` (`open-sse/config/searchRegistry.ts`): `linkup-search`, `ollama-search`, `searchapi-search`. The other 9 — `serper-search`, `brave-search`, `perplexity-search`, `exa-search`, `tavily-search`, `google-pse-search`, `youcom-search`, `searxng-search`, `zai-search` — fell through every specialty lookup (embedding/rerank/image/video/speech/transcription) and returned `undefined`, which the models route (`src/app/api/providers/[id]/models/route.ts`) treats as the terminal 400 `"Provider <id> does not support models listing"` during the "Import Models" step.

## Fix

Per the plan-file's recommendation, this generalizes the class instead of adding 9 more one-off literal entries: when a provider has no dedicated `STATIC_MODEL_PROVIDERS` entry, `getStaticModelsForProvider()` now falls back to a catalog derived from `SEARCH_PROVIDERS[id].searchTypes` (already present on every search-registry entry — e.g. `["web", "news"]`). Any future search provider added to `searchRegistry.ts` automatically gets a usable catalog with zero extra code, closing the whack-a-mole pattern.

`duckduckgo-free` (fallback-only, free, no-credential) is intentionally left untouched by the scope of this fix's test assertions per the plan-file, though it now also gets a harmless catalog via the same generalized path since it's in `SEARCH_PROVIDERS`.

Scope note: the issue's follow-up comment also reports the same root cause on the `webFetch` family (`firecrawl`, `jina-reader`, `tinyfish` in `src/shared/constants/providers/apikey/specialty-media.ts`) — a *different* registry file, out of scope for this plan-file/PR per the analysis; tracked separately.

## Regression test

`tests/unit/search-providers-static-model-catalog-7529.test.ts` — reused verbatim from the triage plan-file's proven RED repro (iterates `SEARCH_PROVIDERS` generically, not a fixed id list), plus one additional test proving the fix is the generalized `searchTypes`-derived fallback (not a literal added just for `serper-search`) so future search providers stay covered.

**Before (RED):**
```
✖ #7529 — every SEARCH_PROVIDERS id should have a static model catalog (RED until fixed)
  AssertionError: search providers with NO static model catalog (will 400 "does not support
  models listing" on import): brave-search, exa-search, google-pse-search, perplexity-search,
  searxng-search, serper-search, tavily-search, youcom-search, zai-search
ℹ pass 0
ℹ fail 2
```

**After (GREEN):**
```
✔ #7529 — every SEARCH_PROVIDERS id should have a static model catalog (RED until fixed)
✔ #7529 — a brand-new SEARCH_PROVIDERS entry with no literal STATIC_MODEL_PROVIDERS override
  still gets a usable catalog derived from searchTypes (generalized fix, not whack-a-mole)
ℹ pass 2
ℹ fail 0
```

Also re-ran all pre-existing tests that touch `getStaticModelsForProvider` / `STATIC_MODEL_PROVIDERS` / the models route's "does not support models listing" path — all still green: `bailian-coding-plan-provider.test.ts`, `static-models-venice-web-6269.test.ts`, `repro-6142-devin-cloud-agent-unwired.test.ts`, `t31-t33-t34-t38-model-specs.test.ts`, `t28-model-catalog-updates.test.ts`, `devin-cloud-agent-validator-6142.test.ts`, `cc-compatible-provider.test.ts`, `model-listing-capability-5420.test.ts`, `provider-models-route.test.ts`.

## Gates

- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2054 violations vs baseline 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (889 vs baseline 890)
- `npm run typecheck:core` — clean exit
- `npx tsc --noEmit -p tsconfig.json` (full repo, since `typecheck:core` is an allowlist) — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean

## Changelog

`changelog.d/fixes/7529-search-static-catalog.md` fragment added.