### PR TITLE
feat: add Mixedbread AI as embeddings provider (#6660)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,12 @@
 ## Project
 
 Unified AI proxy/router — route any LLM through one endpoint. Multi-provider support
-with **250 provider entries** (OpenAI, Anthropic, Gemini, DeepSeek, Groq, xAI, Mistral, Fireworks,
+with **251 provider entries** (OpenAI, Anthropic, Gemini, DeepSeek, Groq, xAI, Mistral, Fireworks,
 Cohere, NVIDIA, Cerebras, Pollinations, Puter, Cloudflare AI, HuggingFace, DeepInfra,
 SambaNova, Meta Llama API, Moonshot AI, AI21 Labs, Databricks, Snowflake, and many more)
 with **MCP Server** (94 tools), **A2A v0.3 Protocol**, and **Electron desktop app**.
 
-> **Live counts (v3.8.47)**: providers 250 · MCP tools 94 · MCP scopes 30 · A2A skills 6 ·
+> **Live counts (v3.8.49)**: providers 251 · MCP tools 94 · MCP scopes 30 · A2A skills 6 ·
 > open-sse services 134 · routing strategies 17 · auto-combo scoring factors 12 ·
 > DB modules 95 · DB migrations 110 · base tables 17 · search providers 11 ·
 > i18n locales 42. **Refresh with `npm run check:docs-all`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ For full test matrix, see `CONTRIBUTING.md` → "Running Tests". For deep archit
 
 ## Project at a Glance
 
-**OmniRoute** — unified AI proxy/router. One endpoint, 250 LLM providers, auto-fallback.
+**OmniRoute** — unified AI proxy/router. One endpoint, 251 LLM providers, auto-fallback.
 
 | Layer         | Location                | Purpose                                                                                                                                                |
 | ------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # 🚀 OmniRoute — The Free AI Gateway
 
-### Never stop coding. Connect every AI tool to **250 providers** — **90+ free** — through one endpoint.
+### Never stop coding. Connect every AI tool to **251 providers** — **90+ free** — through one endpoint.
 
 **Plug Claude Code, Codex, Cursor, Cline, Copilot & Antigravity into FREE Claude / GPT / Gemini. Auto-fallback.**
 <br/>
@@ -149,11 +149,11 @@
 
 </div>
 
-> One endpoint. **250 providers.** Never stop building — and let OmniRoute pick the cheapest one that works.
+> One endpoint. **251 providers.** Never stop building — and let OmniRoute pick the cheapest one that works.
 
 <table>
   <tr>
-    <td width="33%" valign="top"><b>🚫 Never hit limits</b><br/><sub>Auto-fallback across 250 providers in milliseconds. Quota out? Next provider takes over — zero downtime.</sub></td>
+    <td width="33%" valign="top"><b>🚫 Never hit limits</b><br/><sub>Auto-fallback across 251 providers in milliseconds. Quota out? Next provider takes over — zero downtime.</sub></td>
     <td width="33%" valign="top"><b>💸 Save up to 95% tokens</b><br/><sub>RTK + Caveman stacked compression cuts 15–95% of eligible tokens (~89% avg on tool-heavy sessions).</sub></td>
     <td width="33%" valign="top"><b>🆓 $0 to start</b><br/><sub>90+ providers with a free tier, 11 free <i>forever</i> (Kiro, Qoder, Pollinations, LongCat…). No card needed.</sub></td>
   </tr>
@@ -314,7 +314,7 @@ Result: 4 layers of fallback = zero downtime
 
 | Feature                                | OmniRoute                                                           | Other routers |
 | -------------------------------------- | ------------------------------------------------------------------- | ------------- |
-| 🌐 Providers                           | **250**                                                             | 20–100        |
+| 🌐 Providers                           | **251**                                                             | 20–100        |
 | 🆓 Free providers                      | **90+ (11 free forever)**                                           | 1–5           |
 | 🔀 Routing strategies                  | **18** (priority, weighted, cost-optimized, context-relay, fusion…) | 1–3           |
 | 🗜️ Token compression                   | **RTK + Caveman stacked (15–95%)**                                  | None / 20–40% |
@@ -399,7 +399,7 @@ Result: 4 layers of fallback = zero downtime
 
 </div>
 
-> The most complete catalog of any open-source router: **250 providers**, **90+ with a free tier**, **11 free forever**.
+> The most complete catalog of any open-source router: **251 providers**, **90+ with a free tier**, **11 free forever**.
 
 <div align="center">
 
@@ -907,7 +907,7 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 **Will I be charged by OmniRoute?** No — it's free, open-source software on your machine. You only pay paid providers directly. OmniRoute has no billing system.
 **Are FREE providers really unlimited?** Mostly — Qoder, Pollinations, LongCat, and Cloudflare are free with no per-account credit cap. Kiro is free too but capped at ~50 credits/month per account. Stack multiple free providers in a combo and auto-fallback keeps you serving for $0.
 **Will compression hurt quality?** No — it only compresses the **input**; code, URLs, JSON are always protected.
-**Does it work where AI is blocked?** Yes — 3-level proxy + 1proxy marketplace reach all 250 providers.
+**Does it work where AI is blocked?** Yes — 3-level proxy + 1proxy marketplace reach all 251 providers.
 
 📖 [User Guide](docs/guides/USER_GUIDE.md) · [API Reference](docs/reference/API_REFERENCE.md) · [Environment Config](docs/reference/ENVIRONMENT.md)
 

--- a/changelog.d/features/6660-mixedbread-embeddings-provider.md
+++ b/changelog.d/features/6660-mixedbread-embeddings-provider.md
@@ -1,0 +1,1 @@
+- feat(providers): add Mixedbread AI as an embeddings provider (`mxbai-embed-large-v1`, `mxbai-embed-2d-large-v1`, free tier) (#6660)

--- a/docs/reference/PROVIDER_REFERENCE.md
+++ b/docs/reference/PROVIDER_REFERENCE.md
@@ -1,16 +1,16 @@
 ---
 title: "Provider Reference"
-version: 3.8.47
-lastUpdated: 2026-07-13
+version: 3.8.49
+lastUpdated: 2026-07-17
 ---
 
 # Provider Reference
 
 > **Auto-generated** from `src/shared/constants/providers.ts` — do not edit by hand.
 > Regenerate with: `npm run gen:provider-reference`
-> **Last generated:** 2026-07-13
+> **Last generated:** 2026-07-17
 
-Total providers: **250**. See category breakdown below.
+Total providers: **251**. See category breakdown below.
 
 ## Categories
 
@@ -88,7 +88,7 @@ Use the dashboard at `/dashboard/providers` to enable, configure, and test each 
 | `zai-web` | `zw` | Z.ai Web (Free) | Web cookie | [link](https://chat.z.ai) | Paste the full Cookie header from chat.z.ai (must include the token=<JWT> cookie) |
 | `zenmux-free` | `zmf` | ZenMux Free (Web) | Web cookie | [link](https://zenmux.ai) | Login at zenmux.ai, then export all cookies using EditThisCookie or Cookie-Editor and paste the full Cookie header string here. Refresh every ~30 days. |
 
-## API Key Providers (paid / paid-with-free-credits) (167)
+## API Key Providers (paid / paid-with-free-credits) (168)
 
 | ID | Alias | Name | Tags | Website | Notes |
 |----|-------|------|------|---------|-------|
@@ -184,6 +184,7 @@ Use the dashboard at `/dashboard/providers` to enable, configure, and test each 
 | `minimax` | `minimax` | Minimax Coding | API key, video | [link](https://www.minimax.io) | — |
 | `minimax-cn` | `minimax-cn` | Minimax (China) | API key | [link](https://www.minimaxi.com) | — |
 | `mistral` | `mistral` | Mistral | API key | [link](https://mistral.ai) | Free Experiment tier: rate-limited access to all models, no credit card required |
+| `mixedbread` | `mxbai` | Mixedbread AI | API key | [link](https://www.mixedbread.com) | Bearer API key for the Mixedbread embeddings API. |
 | `modal` | `mdl` | Modal | API key, enterprise | [link](https://modal.com/docs) | Use the bearer token that protects your Modal deployment, if enabled. Base URL should point to your OpenAI-compatible Modal app, for example https://<workspace>--<app>.modal.run/v1. |
 | `modelscope` | `ms` | ModelScope | API key | [link](https://modelscope.cn) | Free tier via ModelScope API-Inference — Alibaba account required. |
 | `monsterapi` | `monster` | MonsterAPI | API key | [link](https://monsterapi.ai) | Get API key at monsterapi.ai |

--- a/open-sse/config/embeddingRegistry.ts
+++ b/open-sse/config/embeddingRegistry.ts
@@ -270,6 +270,29 @@ export const EMBEDDING_PROVIDERS: Record<string, EmbeddingProvider> = {
       { id: "jina-colbert-v2", name: "Jina ColBERT v2", dimensions: 128 },
     ],
   },
+
+  // Issue #6660: Mixedbread AI — OpenAI-compatible /v1/embeddings, free tier
+  // available (API key via signup, no card required). Model ids are the
+  // upstream-qualified "mixedbread-ai/<model>" form, mirroring how `together`/
+  // `fireworks` register fully-qualified upstream model ids above.
+  mixedbread: {
+    id: "mixedbread",
+    baseUrl: "https://api.mixedbread.com/v1/embeddings",
+    authType: "apikey",
+    authHeader: "bearer",
+    models: [
+      {
+        id: "mixedbread-ai/mxbai-embed-large-v1",
+        name: "Mixedbread Embed Large v1",
+        dimensions: 1024,
+      },
+      {
+        id: "mixedbread-ai/mxbai-embed-2d-large-v1",
+        name: "Mixedbread Embed 2D Large v1",
+        dimensions: 1024,
+      },
+    ],
+  },
 };
 
 const EMBEDDING_PROVIDER_ALIASES: Record<string, string> = {

--- a/src/shared/constants/providers/apikey/specialty-media.ts
+++ b/src/shared/constants/providers/apikey/specialty-media.ts
@@ -218,6 +218,18 @@ export const APIKEY_PROVIDERS_SPECIALTY = {
     passthroughModels: true,
     authHint: "Get API key at atlas.nomic.ai",
   },
+  mixedbread: {
+    id: "mixedbread",
+    alias: "mxbai",
+    name: "Mixedbread AI",
+    icon: "hub",
+    color: "#F59E0B",
+    textIcon: "MB",
+    website: "https://www.mixedbread.com",
+    hasFree: true,
+    freeNote: "Free-tier API key via signup, no credit card required.",
+    authHint: "Bearer API key for the Mixedbread embeddings API.",
+  },
   firecrawl: {
     id: "firecrawl",
     alias: "fc",

--- a/tests/unit/mixedbread-embedding-provider-6660.test.ts
+++ b/tests/unit/mixedbread-embedding-provider-6660.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getAllEmbeddingModels,
+  getEmbeddingProvider,
+  parseEmbeddingModel,
+  getEmbeddingDimension,
+} from "../../open-sse/config/embeddingRegistry.ts";
+
+// Issue #6660: Mixedbread AI embeddings provider.
+
+test("mixedbread embedding registry exposes mxbai-embed models", () => {
+  const provider = getEmbeddingProvider("mixedbread");
+
+  assert.ok(provider);
+  assert.equal(provider.baseUrl, "https://api.mixedbread.com/v1/embeddings");
+  assert.equal(provider.authType, "apikey");
+  assert.equal(provider.authHeader, "bearer");
+  assert.ok(provider.models.some((model) => model.id === "mixedbread-ai/mxbai-embed-large-v1"));
+  assert.ok(provider.models.some((model) => model.id === "mixedbread-ai/mxbai-embed-2d-large-v1"));
+});
+
+test("mixedbread model strings resolve via parseEmbeddingModel", () => {
+  const parsed = parseEmbeddingModel("mixedbread/mixedbread-ai/mxbai-embed-large-v1");
+  assert.equal(parsed.provider, "mixedbread");
+  assert.equal(parsed.model, "mixedbread-ai/mxbai-embed-large-v1");
+
+  const parsed2d = parseEmbeddingModel("mixedbread/mixedbread-ai/mxbai-embed-2d-large-v1");
+  assert.equal(parsed2d.provider, "mixedbread");
+  assert.equal(parsed2d.model, "mixedbread-ai/mxbai-embed-2d-large-v1");
+});
+
+test("mixedbread models report the correct known dimensionality (1024d)", () => {
+  assert.equal(
+    getEmbeddingDimension("mixedbread/mixedbread-ai/mxbai-embed-large-v1"),
+    1024
+  );
+  assert.equal(
+    getEmbeddingDimension("mixedbread/mixedbread-ai/mxbai-embed-2d-large-v1"),
+    1024
+  );
+});
+
+test("getAllEmbeddingModels includes both mixedbread models with provider-scoped ids", () => {
+  const all = getAllEmbeddingModels().filter((model) => model.provider === "mixedbread");
+  assert.deepEqual(
+    all.map((model) => model.id).sort(),
+    [
+      "mixedbread/mixedbread-ai/mxbai-embed-2d-large-v1",
+      "mixedbread/mixedbread-ai/mxbai-embed-large-v1",
+    ]
+  );
+  assert.ok(all.every((model) => model.dimensions === 1024));
+});

--- a/tests/unit/providers-constants-split.test.ts
+++ b/tests/unit/providers-constants-split.test.ts
@@ -36,12 +36,12 @@ test("barrel still exports every catalog + key helpers", () => {
   }
 });
 
-test("APIKEY_PROVIDERS merges the 6 family files into 167 entries (no loss / no dup)", async () => {
+test("APIKEY_PROVIDERS merges the 6 family files into 168 entries (no loss / no dup)", async () => {
   const keys = Object.keys((P as Record<string, object>).APIKEY_PROVIDERS);
-  assert.equal(keys.length, 167);
-  assert.equal(new Set(keys).size, 167, "duplicate keys after spread-merge");
+  assert.equal(keys.length, 168);
+  assert.equal(new Set(keys).size, 168, "duplicate keys after spread-merge");
   // the merged object's entry-count equals the sum of the 6 semantic family files; families are a
-  // strict partition (every provider in exactly one), so the sum must be exactly 167.
+  // strict partition (every provider in exactly one), so the sum must be exactly 168.
   const families: [string, string][] = [
     ["gateways", "APIKEY_PROVIDERS_GATEWAYS"],
     ["frontier-labs", "APIKEY_PROVIDERS_FRONTIER"],
@@ -61,7 +61,7 @@ test("APIKEY_PROVIDERS merges the 6 family files into 167 entries (no loss / no 
       seen.add(k);
     }
   }
-  assert.equal(famTotal, 167, "families must partition all 167 providers");
+  assert.equal(famTotal, 168, "families must partition all 168 providers");
 });
 
 test("AI_PROVIDERS Proxy aggregates all sections; lookups resolve", () => {


### PR DESCRIPTION
Closes #6660

## What was built

Adds Mixedbread AI (https://api.mixedbread.com) as a new embeddings provider, following the existing flat-registry pattern used by Voyage AI, Jina AI, Nomic, Cohere, Nebius, etc — no new executor/translator code needed since the embeddings handler (`open-sse/handlers/embeddings.ts`) is a generic OpenAI-compatible pass-through.

- `open-sse/config/embeddingRegistry.ts` — new `mixedbread` entry: `baseUrl: https://api.mixedbread.com/v1/embeddings`, bearer auth, models `mixedbread-ai/mxbai-embed-large-v1` and `mixedbread-ai/mxbai-embed-2d-large-v1` (both confirmed 1024d, Matryoshka-reducible). Model ids use the upstream-qualified `mixedbread-ai/<model>` form, mirroring how `together`/`fireworks` already register fully-qualified upstream model ids.
- `src/shared/constants/providers/apikey/specialty-media.ts` — matching provider metadata entry (icon/color/textIcon/website/authHint/hasFree/freeNote), modeled on the `nomic` block.
- `docs/reference/PROVIDER_REFERENCE.md` — regenerated via `npm run gen:provider-reference` (auto-generated, do not hand-edit).
- `README.md` / `AGENTS.md` / `CLAUDE.md` — synced the provider-count mentions from 250 → 251, required by the strict `check:docs-counts` gate (`Provider count: 251 (real) [STRICT]`).
- `changelog.d/features/6660-mixedbread-embeddings-provider.md` — changelog fragment.

Research (base URL, auth header, `/v1/embeddings` OpenAI-compatible `input`/`model` in → `data[].embedding` out, upstream-qualified model id, 1024d for both models) verified via WebSearch/WebFetch against Mixedbread's docs/API reference and the model's Hugging Face card during implementation, confirming and extending the triage plan-file's findings.

## Behavior test (Hard Rule #18 — TDD)

New file `tests/unit/mixedbread-embedding-provider-6660.test.ts` (node:test, the gating runner):

```
✔ mixedbread embedding registry exposes mxbai-embed models (2.76374ms)
✔ mixedbread model strings resolve via parseEmbeddingModel (0.870051ms)
✔ mixedbread models report the correct known dimensionality (1024d) (0.577143ms)
✔ getAllEmbeddingModels includes both mixedbread models with provider-scoped ids (2.518894ms)
ℹ tests 4
ℹ pass 4
ℹ fail 0
```

Also re-ran the pre-existing `embedding-rerank-provider-registry.test.ts` and `embeddings-handler.test.ts` suites (16/16 pass) to confirm no regression to the shared parsing/handler path.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK, no cap exceeded
- `node scripts/check/check-test-discovery.mjs` — OK, new test file collected
- `npm run check:complexity-ratchets` — OK (complexity 2055 ≤ baseline 2056, cognitive 889 ≤ baseline 890 — both improved, data-only change)
- `npm run typecheck:core` — clean
- `npm run typecheck:noimplicit:core` — only pre-existing baseline errors in unrelated files (`combo.ts`, `usageTracking.ts`, `cliRuntime.ts`, confirmed zero diff against base branch)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `npm run check:cycles` — no cycles
- `npm run check:provider-consistency` / `check:provider-assets` — OK
- `npm run check:docs-sync` / `npm run check:docs-all` (docs-sync-strict CI job) — PASS, including the strict provider-count check
- No provider golden snapshot exists for the embeddings path (generic pass-through, no translation logic) — confirmed none needed to regenerate.
- `npm run test:coverage` intentionally NOT run locally (heaviest gate, shared-box policy) — CI runs it authoritatively.

Not merging — leaving this open for review per policy.