### PR TITLE
docs: sync provider count to 259 (unblocks docs-counts strict gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,12 @@
 ## Project
 
 Unified AI proxy/router — route any LLM through one endpoint. Multi-provider support
-with **253 provider entries** (OpenAI, Anthropic, Gemini, DeepSeek, Groq, xAI, Mistral, Fireworks,
+with **259 provider entries** (OpenAI, Anthropic, Gemini, DeepSeek, Groq, xAI, Mistral, Fireworks,
 Cohere, NVIDIA, Cerebras, Pollinations, Puter, Cloudflare AI, HuggingFace, DeepInfra,
 SambaNova, Meta Llama API, Moonshot AI, AI21 Labs, Databricks, Snowflake, and many more)
 with **MCP Server** (94 tools), **A2A v0.3 Protocol**, and **Electron desktop app**.
 
-> **Live counts (v3.8.49)**: providers 253 · MCP tools 94 · MCP scopes 30 · A2A skills 6 ·
+> **Live counts (v3.8.49)**: providers 259 · MCP tools 94 · MCP scopes 30 · A2A skills 6 ·
 > open-sse services 134 · routing strategies 17 · auto-combo scoring factors 12 ·
 > DB modules 95 · DB migrations 110 · base tables 17 · search providers 11 ·
 > i18n locales 42. **Refresh with `npm run check:docs-all`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ For full test matrix, see `CONTRIBUTING.md` → "Running Tests". For deep archit
 
 ## Project at a Glance
 
-**OmniRoute** — unified AI proxy/router. One endpoint, 253 LLM providers, auto-fallback.
+**OmniRoute** — unified AI proxy/router. One endpoint, 259 LLM providers, auto-fallback.
 
 | Layer         | Location                | Purpose                                                                                                                                                |
 | ------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # 🚀 OmniRoute — The Free AI Gateway
 
-### Never stop coding. Connect every AI tool to **253 providers** — **90+ free** — through one endpoint.
+### Never stop coding. Connect every AI tool to **259 providers** — **90+ free** — through one endpoint.
 
 **Plug Claude Code, Codex, Cursor, Cline, Copilot & Antigravity into FREE Claude / GPT / Gemini. Auto-fallback.**
 <br/>
@@ -149,11 +149,11 @@
 
 </div>
 
-> One endpoint. **253 providers.** Never stop building — and let OmniRoute pick the cheapest one that works.
+> One endpoint. **259 providers.** Never stop building — and let OmniRoute pick the cheapest one that works.
 
 <table>
   <tr>
-    <td width="33%" valign="top"><b>🚫 Never hit limits</b><br/><sub>Auto-fallback across 253 providers in milliseconds. Quota out? Next provider takes over — zero downtime.</sub></td>
+    <td width="33%" valign="top"><b>🚫 Never hit limits</b><br/><sub>Auto-fallback across 259 providers in milliseconds. Quota out? Next provider takes over — zero downtime.</sub></td>
     <td width="33%" valign="top"><b>💸 Save up to 95% tokens</b><br/><sub>RTK + Caveman stacked compression cuts 15–95% of eligible tokens (~89% avg on tool-heavy sessions).</sub></td>
     <td width="33%" valign="top"><b>🆓 $0 to start</b><br/><sub>90+ providers with a free tier, 11 free <i>forever</i> (Kiro, Qoder, Pollinations, LongCat…). No card needed.</sub></td>
   </tr>
@@ -382,7 +382,7 @@ Result: 4 layers of fallback = zero downtime
 
 </div>
 
-> The most complete catalog of any open-source router: **253 providers**, **90+ with a free tier**, **11 free forever**.
+> The most complete catalog of any open-source router: **259 providers**, **90+ with a free tier**, **11 free forever**.
 
 <div align="center">
 
@@ -890,7 +890,7 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 **Will I be charged by OmniRoute?** No — it's free, open-source software on your machine. You only pay paid providers directly. OmniRoute has no billing system.
 **Are FREE providers really unlimited?** Mostly — Qoder, Pollinations, LongCat, and Cloudflare are free with no per-account credit cap. Kiro is free too but capped at ~50 credits/month per account. Stack multiple free providers in a combo and auto-fallback keeps you serving for $0.
 **Will compression hurt quality?** No — it only compresses the **input**; code, URLs, JSON are always protected.
-**Does it work where AI is blocked?** Yes — 3-level proxy + 1proxy marketplace reach all 253 providers.
+**Does it work where AI is blocked?** Yes — 3-level proxy + 1proxy marketplace reach all 259 providers.
 
 📖 [User Guide](docs/guides/USER_GUIDE.md) · [API Reference](docs/reference/API_REFERENCE.md) · [Environment Config](docs/reference/ENVIRONMENT.md)
 

--- a/changelog.d/maintenance/7616-docs-provider-count-259.md
+++ b/changelog.d/maintenance/7616-docs-provider-count-259.md
@@ -1,0 +1,1 @@
+- **Docs provider-count sync** (`README.md`, `AGENTS.md`, `CLAUDE.md`): provider-count mentions bumped 253 → 259 to match the auto-generated catalog, un-blocking the strict `check:docs-counts` gate that had started failing on every PR targeting the release branch (#7616).


### PR DESCRIPTION
## What

Updates the provider-count mentions in `README.md` (tagline + intro, 5), `AGENTS.md` (header + live-counts, 2) and `CLAUDE.md` (project-at-a-glance, 1) from **253 → 259**, matching the auto-generated catalog total in `docs/reference/PROVIDER_REFERENCE.md`.

## Why

`check:docs-counts` treats the provider count as **STRICT** across exactly these three files. Recent provider merges grew the catalog (253 → … → 259) without the doc bumps, so the **Docs Gates (fast-path)** job now fails for every PR targeting `release/v3.8.49` (first surfaced on #7615's run, which asked for 256 — the catalog has grown again since). Fun fact from the diagnosis: README/CLAUDE previously appeared green in this check only because `AES-256-GCM` accidentally matched the then-expected string "256".

## Validation

`npm run check:docs-counts` → Provider count ✓ on all three files, exit 0 (remaining ⚠ on executors/ARCHITECTURE.md is a pre-existing soft check, non-blocking).

Note: this number drifts by design whenever a provider lands — if another provider merges before this PR does, the gate will name a newer total and this PR can be bumped accordingly.