### PR TITLE
test(ci): exact-line assert in grok-build config test (CodeQL #740/#741)

### DIFF
--- a/tests/integration/cli-settings-grok-build.test.ts
+++ b/tests/integration/cli-settings-grok-build.test.ts
@@ -141,9 +141,12 @@ test("grok-build-settings POST: writes [model.omniroute] section and preserves e
       assert.ok(content.includes("http://localhost:20128/v1"), "Config should contain base URL");
       assert.ok(content.includes('default = "omniroute"'), "Default should point at our slot");
       // The pre-existing unrelated model section must survive untouched.
+      // Exact line membership (not URL substring) — stronger, and dodges CodeQL
+      // js/incomplete-url-substring-sanitization false positives (#740/#741).
+      const preservedLines = content.split("\n").map((line) => line.trim());
       assert.ok(
-        content.includes("[model.custom-thing]") &&
-          content.includes("https://example.test/v1"),
+        preservedLines.includes("[model.custom-thing]") &&
+          preservedLines.includes('base_url = "https://example.test/v1"'),
         "Pre-existing unrelated [model.*] section must be preserved"
       );
       // The previous default must be remembered for Reset to restore.
@@ -199,8 +202,11 @@ test("grok-build-settings DELETE: removes our section, preserves the rest, resto
       const configPath = path.join(tmpHome, ".grok", "config.toml");
       const content = fs.readFileSync(configPath, "utf-8");
       assert.ok(!content.includes("[model.omniroute]"), "Our section should be removed");
+      // Exact line membership (not URL substring) — see the preserve block above (#740/#741).
+      const survivingLines = content.split("\n").map((line) => line.trim());
       assert.ok(
-        content.includes("[model.custom-thing]") && content.includes("https://example.test/v1"),
+        survivingLines.includes("[model.custom-thing]") &&
+          survivingLines.includes('base_url = "https://example.test/v1"'),
         "Unrelated section must survive"
       );
       assert.ok(content.includes('default = "grok-build"'), "Previous default should be restored");


### PR DESCRIPTION
## What

Replaces two URL-substring assertions in `tests/integration/cli-settings-grok-build.test.ts` (lines 146 & 203) with **exact line membership**.

## Why

CodeQL `js/incomplete-url-substring-sanitization` (**HIGH**) flags `content.includes("https://example.test/v1")` as a URL-substring check. It's a **false positive** — the test asserts a TOML `[model.custom-thing]` section round-trips untouched through the grok-build config handler; there is no URL sanitization and `example.test` is a reserved test TLD.

But **#740 + #741 are the only open CodeQL alerts repo-wide** right now (they replaced #737 the moment it closed), and `check:codeql-ratchet` counts alerts repo-wide → they keep `Quality Ratchet` red on **every** open PR. This closes them at the source.

## Fix

```ts
const preservedLines = content.split("\n").map((line) => line.trim());
assert.ok(
  preservedLines.includes("[model.custom-thing]") &&
    preservedLines.includes('base_url = "https://example.test/v1"'),
  "..."
);
```

Exact line membership is **stronger** than the old substring check — it verifies the URL sits on the `base_url` key, not merely somewhere in the file — and is no longer a substring-of-URL sink, so CodeQL stops flagging it. The handler preserves the section byte-for-byte, so exact match holds.

## Validation (Hard Rule #18)

`node --import tsx/esm --test tests/integration/cli-settings-grok-build.test.ts` → **9 pass, 0 fail**.

File exists only on `release/v3.8.49` (added by #7241) — no `main` companion needed.