### PR TITLE
test(providers): fix release base-reds from today's provider merges

### DIFF
--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -1600,6 +1600,29 @@
       "stream": "https://api.freemodel.dev/v1/chat/completions"
     }
   },
+  "freetheai": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://api.freetheai.xyz/v1/chat/completions",
+      "stream": "https://api.freetheai.xyz/v1/chat/completions"
+    }
+  },
   "friendliai": {
     "format": "openai",
     "headers": {

--- a/tests/unit/model-connid-prefix-normalization-6772.test.ts
+++ b/tests/unit/model-connid-prefix-normalization-6772.test.ts
@@ -1,7 +1,7 @@
 /**
  * PROBE for issue #6772 — custom OpenAI-compat <connId>/<listedModelId> 400s when the
  * connection has a user-defined `prefix` and the listed model id (from /api/models)
- * already carries that prefix baked in ("fta/vova/gpt-5.5").
+ * already carries that prefix baked in ("zzq6772/vova/gpt-5.5").
  *
  * Root cause hypothesis: in src/sse/services/model.ts getModelInfo(), when a client
  * addresses the connection by its raw internal node id (`<connId>/...`), the matching
@@ -25,7 +25,10 @@ const modelsDb = await import("../../src/lib/db/models.ts");
 const { getModelInfo } = await import("../../src/sse/services/model.ts");
 
 const CONN_ID = "openai-compatible-chat-97b0e595-probe6772";
-const PREFIX = "fta";
+// Must be a token that is NOT a registered provider id/alias, or the resolver routes to
+// that provider before the custom-node lookup. "fta" was fine until #7602 (FreeTheAi) claimed
+// it as an alias — see gateways.ts / freetheai/index.ts. Pick a collision-free placeholder.
+const PREFIX = "zzq6772";
 const RAW_MODEL_ID = "vova/gpt-5.5"; // upstream's own model id already has a slash
 
 test.before(async () => {
@@ -53,7 +56,7 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
-test("#6772 baseline: bare alias form `fta/vova/gpt-5.5` resolves to the raw model id", async () => {
+test("#6772 baseline: bare alias form `zzq6772/vova/gpt-5.5` resolves to the raw model id", async () => {
   const info = (await getModelInfo(`${PREFIX}/${RAW_MODEL_ID}`)) as {
     provider?: string;
     model?: string;


### PR DESCRIPTION
## Problem

Two unit tests were **born red on `release/v3.8.49`** after today's provider-addition merges, so **every open release PR** fails `Unit Tests fast-path (3/4)` through no fault of its own (confirmed on #7628, #7314, and the #6917 cluster). This is a base regression, not a per-PR defect.

## Root cause & fix

**1. `model-connid-prefix-normalization-6772.test.ts`** used `PREFIX = "fta"` as a placeholder custom-node prefix. **#7602 (FreeTheAi)** registered `alias: "fta"` (`gateways.ts:243`, `freetheai/index.ts:9`), so the resolver now routes `fta/...` to the real provider **before** the custom-node lookup → the test's assumption breaks.
→ Repoint the placeholder to the collision-free `"zzq6772"`. Production behaviour (a registered alias wins) is **correct**; the fixture just picked a token that later became real. Not a masked assertion — the test still proves prefix-stripping for a custom node.

**2. `provider-translate-path-golden.test.ts`** snapshots every registered provider. #7602 added `freetheai` to the chat registry (189 → 190) → snapshot stale.
→ Regenerated via `UPDATE_GOLDEN=1`. **Audited the diff** (verify-not-mask): exactly **one key added** (`freetheai`, `format=openai`, valid `https://api.freetheai.xyz/v1/chat/completions`), **zero existing providers changed**, **zero removed**. Legitimate snapshot update.

## Validation (Hard Rule #18)

- `model-connid-prefix-normalization-6772.test.ts` → **3 pass, 0 fail**
- `provider-translate-path-golden.test.ts` (no `UPDATE_GOLDEN`) → **3 pass, 0 fail**

No production code touched — test/snapshot only. Unblocks `Unit Tests fast-path (3/4)` for all release PRs.

_(The remaining `Fast Quality Gates → check:mutation-test-coverage` and `dast-smoke` reds are separate base-reds, not addressed here.)_