### PR TITLE
feat: confirm before removing a single connection (#7361)

### DIFF
--- a/changelog.d/features/7361-confirm-remove-account.md
+++ b/changelog.d/features/7361-confirm-remove-account.md
@@ -1,0 +1,1 @@
+- feat(dashboard): confirm before removing a single connection, naming the account, mirroring the existing batch-delete confirm UX (#7361)

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -120,7 +120,7 @@ export default function ProviderDetailPageClient() {
     setProviderNode,
     fetchConnections,
     fetchProxyConfig,
-    handleDelete,
+    deleteConfirm,
     handleUpdateConnectionStatus,
     handleToggleRateLimit,
     handleToggleClaudeExtraUsage,
@@ -582,7 +582,7 @@ export default function ProviderDetailPageClient() {
                 setSelectedIds={setSelectedIds}
                 setPage={setPage}
                 setHealthFilter={setHealthFilter}
-                handleDelete={handleDelete}
+                deleteConfirm={deleteConfirm}
                 handleUpdateConnectionStatus={handleUpdateConnectionStatus}
                 handleToggleRateLimit={handleToggleRateLimit}
                 handleToggleClaudeExtraUsage={handleToggleClaudeExtraUsage}
@@ -733,6 +733,7 @@ export default function ProviderDetailPageClient() {
         handleBatchDeleteConfirm={handleBatchDeleteConfirm}
         selectedIds={selectedIds}
         batchDeleting={batchDeleting}
+        deleteConfirm={deleteConfirm}
         applyCodexModalConnectionId={applyCodexModalConnectionId}
         setApplyCodexModalConnectionId={setApplyCodexModalConnectionId}
         applyingCodexAuthId={applyingCodexAuthId}

--- a/src/app/(dashboard)/dashboard/providers/[id]/__tests__/phase1f.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/__tests__/phase1f.test.tsx
@@ -127,7 +127,6 @@ describe("useProviderConnections — initial state", () => {
     const expected = [
       "fetchConnections",
       "fetchProxyConfig",
-      "handleDelete",
       "handleUpdateConnectionStatus",
       "handleToggleRateLimit",
       "handleToggleClaudeExtraUsage",

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsListPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsListPanel.tsx
@@ -7,6 +7,7 @@ import { pickDisplayValue } from "@/shared/utils/maskEmail";
 import { readBooleanToggle, providerCountText } from "../providerPageHelpers";
 import { compareTr } from "@/shared/utils/turkishText";
 import type { CodexGlobalServiceMode } from "@/lib/providers/codexFastTier";
+import type { ConnectionDeleteConfirmState } from "../hooks/useConnectionDeleteConfirm";
 
 type ConnectionsListPanelProps = {
   connections: ConnectionRowConnection[];
@@ -37,7 +38,7 @@ type ConnectionsListPanelProps = {
   setPage: React.Dispatch<React.SetStateAction<number>>;
   setHealthFilter: (v: string) => void;
   // Callbacks from useProviderConnections
-  handleDelete: (id: string) => void;
+  deleteConfirm: ConnectionDeleteConfirmState;
   handleUpdateConnectionStatus: (id: string, isActive: boolean) => void;
   handleToggleRateLimit: (id: string, enabled: boolean) => void;
   handleToggleClaudeExtraUsage: (id: string, enabled: boolean) => void;
@@ -94,7 +95,7 @@ export default function ConnectionsListPanel({
   setSelectedIds,
   setPage,
   setHealthFilter,
-  handleDelete,
+  deleteConfirm,
   handleUpdateConnectionStatus,
   handleToggleRateLimit,
   handleToggleClaudeExtraUsage,
@@ -345,7 +346,12 @@ export default function ConnectionsListPanel({
                 onRetest={() => handleRetestConnection(conn.id)}
                 isRetesting={retestingId === conn.id}
                 onEdit={() => onOpenEditModal(conn)}
-                onDelete={() => handleDelete(conn.id)}
+                onDelete={() =>
+                  deleteConfirm.request(
+                    conn.id,
+                    pickDisplayValue([conn.name, conn.email], emailsVisible, conn.id)
+                  )
+                }
                 onReauth={
                   conn.authType === "oauth"
                     ? () => gateConnectionFlow(() => onOpenOAuth(conn))
@@ -514,7 +520,12 @@ export default function ConnectionsListPanel({
                     onRetest={() => handleRetestConnection(conn.id)}
                     isRetesting={retestingId === conn.id}
                     onEdit={() => onOpenEditModal(conn)}
-                    onDelete={() => handleDelete(conn.id)}
+                    onDelete={() =>
+                      deleteConfirm.request(
+                        conn.id,
+                        pickDisplayValue([conn.name, conn.email], emailsVisible, conn.id)
+                      )
+                    }
                     onReauth={
                       conn.authType === "oauth"
                         ? () => gateConnectionFlow(() => onOpenOAuth(conn))

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx
@@ -25,8 +25,9 @@ import { ImportClaudeAuthModal, ApplyClaudeAuthModal } from "./modals/ImportClau
 import ImportGrokCliAuthModal from "./modals/ImportGrokCliAuthModal";
 import { type ConnectionRowConnection } from "./ConnectionRow";
 import { type BatchTestResults } from "../hooks/useProviderConnections";
+import { type ConnectionDeleteConfirmState } from "../hooks/useConnectionDeleteConfirm";
 import { type ImportProgress } from "../hooks/useModelImportHandlers";
-import type { ProviderMessageTranslator } from "../providerPageHelpers";
+import { providerText, type ProviderMessageTranslator } from "../providerPageHelpers";
 
 interface ProviderInfo {
   name: string;
@@ -78,6 +79,8 @@ interface ProviderModalsPanelProps {
   handleBatchDeleteConfirm: () => void;
   selectedIds: Set<string>;
   batchDeleting: boolean;
+  // Single-connection delete confirm
+  deleteConfirm: ConnectionDeleteConfirmState;
   // Codex auth
   applyCodexModalConnectionId: string | null;
   setApplyCodexModalConnectionId: (id: string | null) => void;
@@ -171,6 +174,7 @@ export default function ProviderModalsPanel({
   handleBatchDeleteConfirm,
   selectedIds,
   batchDeleting,
+  deleteConfirm,
   applyCodexModalConnectionId,
   setApplyCodexModalConnectionId,
   applyingCodexAuthId,
@@ -302,6 +306,21 @@ export default function ProviderModalsPanel({
         confirmText={t("batchDeleteConfirmButton", "Delete")}
         cancelText={t("cancel", "Cancel")}
         loading={batchDeleting}
+      />
+      <ConfirmModal
+        isOpen={!!deleteConfirm.connection}
+        onClose={deleteConfirm.cancel}
+        onConfirm={deleteConfirm.confirm}
+        title={providerText(t, "deleteConnectionConfirm", "Delete this connection?")}
+        message={providerText(
+          t,
+          "deleteConnectionConfirmNamed",
+          "Are you sure you want to delete {name}? This action cannot be undone.",
+          { name: deleteConfirm.connection?.name ?? "" }
+        )}
+        confirmText={providerText(t, "batchDeleteConfirmButton", "Delete")}
+        cancelText={providerText(t, "cancel", "Cancel")}
+        loading={deleteConfirm.deleting}
       />
       {providerId === "codex" && applyCodexModalConnectionId && (
         <ApplyCodexAuthModal

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionDeleteConfirm.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionDeleteConfirm.ts
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * useConnectionDeleteConfirm — Issue #7361.
+ *
+ * Gates single-connection delete behind a confirmation step, mirroring the
+ * existing batch-delete confirm pattern already wired in
+ * useProviderConnections.ts (handleBatchDeleteOpenModal / handleBatchDeleteConfirm).
+ * Extracted into its own module so the frozen useProviderConnections.ts file-size
+ * ratchet does not have to absorb the extra state + handlers.
+ */
+
+import { useCallback, useState } from "react";
+
+export interface ConnectionDeleteConfirmTarget {
+  id: string;
+  name: string;
+}
+
+export interface ConnectionDeleteConfirmState {
+  connection: ConnectionDeleteConfirmTarget | null;
+  deleting: boolean;
+  request: (connectionId: string, name: string) => void;
+  confirm: () => Promise<void>;
+  cancel: () => void;
+}
+
+interface NotifyLike {
+  success: (message: string) => void;
+  error: (message: string) => void;
+}
+
+export function useConnectionDeleteConfirm(
+  fetchConnections: () => Promise<void>,
+  notify: NotifyLike
+): ConnectionDeleteConfirmState {
+  const [connection, setConnection] = useState<ConnectionDeleteConfirmTarget | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const request = useCallback((connectionId: string, name: string) => {
+    if (!connectionId) return;
+    setConnection({ id: connectionId, name });
+  }, []);
+
+  const cancel = useCallback(() => {
+    setConnection(null);
+  }, []);
+
+  const confirm = useCallback(async () => {
+    const connectionId = connection?.id;
+    if (!connectionId) {
+      setConnection(null);
+      return;
+    }
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/providers/${connectionId}`, { method: "DELETE" });
+      if (res.ok) {
+        notify.success("Connection deleted");
+        await fetchConnections();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        const message =
+          (typeof data?.error === "string" && data.error) ||
+          data?.error?.message ||
+          "Failed to delete connection";
+        notify.error(message);
+      }
+    } catch (error) {
+      console.error("Error deleting connection:", error);
+      notify.error("Failed to delete connection");
+    } finally {
+      setDeleting(false);
+      setConnection(null);
+    }
+  }, [connection, fetchConnections, notify]);
+
+  return { connection, deleting, request, confirm, cancel };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderConnections.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderConnections.ts
@@ -28,6 +28,10 @@ import { isClaudeCodeCompatibleProvider } from "@/shared/constants/providers";
 import type { ConnectionRowConnection } from "../components/ConnectionRow";
 import { normalizeCodexLimitPolicy } from "../providerPageHelpers";
 import { useReorderByAvailability } from "./useReorderByAvailability";
+import {
+  useConnectionDeleteConfirm,
+  type ConnectionDeleteConfirmState,
+} from "./useConnectionDeleteConfirm";
 
 // Max connection ids accepted per bulk request — mirrors API-side cap.
 const MAX_BULK_IDS = 100;
@@ -80,7 +84,7 @@ export interface UseProviderConnectionsReturn {
   fetchProxyConfig: () => Promise<void>;
 
   // Single-connection handlers
-  handleDelete: (connectionId: string) => Promise<void>;
+  deleteConfirm: ConnectionDeleteConfirmState;
   handleUpdateConnectionStatus: (id: string, isActive: boolean) => Promise<void>;
   handleToggleRateLimit: (connectionId: string, enabled: boolean) => Promise<void>;
   handleToggleClaudeExtraUsage: (connectionId: string, enabled: boolean) => Promise<void>;
@@ -307,29 +311,7 @@ export function useProviderConnections(
   // Single-connection handlers
   // ────────────────────────────────────────────────────────────────────────
 
-  const handleDelete = useCallback(
-    async (connectionId: string) => {
-      if (!connectionId) return;
-      try {
-        const res = await fetch(`/api/providers/${connectionId}`, { method: "DELETE" });
-        if (res.ok) {
-          notify.success("Connection deleted");
-          await fetchConnections();
-        } else {
-          const data = await res.json().catch(() => ({}));
-          const message =
-            (typeof data?.error === "string" && data.error) ||
-            data?.error?.message ||
-            "Failed to delete connection";
-          notify.error(message);
-        }
-      } catch (error) {
-        console.error("Error deleting connection:", error);
-        notify.error("Failed to delete connection");
-      }
-    },
-    [fetchConnections, notify]
-  );
+  const deleteConfirm = useConnectionDeleteConfirm(fetchConnections, notify);
 
   const handleUpdateConnectionStatus = async (id: string, isActive: boolean) => {
     try {
@@ -909,7 +891,7 @@ export function useProviderConnections(
     fetchProxyConfig,
 
     // Single-connection handlers
-    handleDelete,
+    deleteConfirm,
     handleUpdateConnectionStatus,
     handleToggleRateLimit,
     handleToggleClaudeExtraUsage,

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (للتحقق فقط)",
     "providerNotFound": "لم يتم العثور على الموفر",
     "deleteConnectionConfirm": "هل تريد حذف هذا الاتصال؟",
+    "deleteConnectionConfirmNamed": "هل أنت متأكد أنك تريد حذف {name}؟ لا يمكن التراجع عن هذا الإجراء.",
     "batchDeleteSelected": "حذف المحدد ({count})",
     "batchDeleteConfirm": "هل تريد حذف {count} اتصال(ات)؟ لا يمكن التراجع عن هذا الإجراء.",
     "batchDeleteSuccess": "تم حذف {count} اتصال(ات)",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "{name} silmək istədiyinizə əminsiniz? Bu əməliyyat geri qaytarıla bilməz.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (само за проверка)",
     "providerNotFound": "Доставчикът не е намерен",
     "deleteConnectionConfirm": "Изтриване на тази връзка?",
+    "deleteConnectionConfirmNamed": "Сигурни ли сте, че искате да изтриете {name}? Това действие не може да бъде отменено.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "আপনি কি নিশ্চিত যে আপনি {name} মুছতে চান? এই কাজটি বাতিল করা যাবে না।",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (pouze pro ověření)",
     "providerNotFound": "Poskytovatel nenalezen",
     "deleteConnectionConfirm": "Smazat toto připojení?",
+    "deleteConnectionConfirmNamed": "Opravdu chcete smazat {name}? Tuto akci nelze vrátit zpět.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (kun til validering)",
     "providerNotFound": "Udbyder blev ikke fundet",
     "deleteConnectionConfirm": "Vil du slette denne forbindelse?",
+    "deleteConnectionConfirmNamed": "Er du sikker på, at du vil slette {name}? Denne handling kan ikke fortrydes.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3776,6 +3776,7 @@
     "testKeyPlaceholder": "sk-... (nur zur Validierung)",
     "providerNotFound": "Anbieter nicht gefunden",
     "deleteConnectionConfirm": "Diese Verbindung löschen?",
+    "deleteConnectionConfirmNamed": "Möchten Sie {name} wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4132,6 +4132,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "Are you sure you want to delete {name}? This action cannot be undone.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (solo para validación)",
     "providerNotFound": "Proveedor no encontrado",
     "deleteConnectionConfirm": "¿Eliminar esta conexión?",
+    "deleteConnectionConfirmNamed": "¿Estás seguro de que deseas eliminar {name}? Esta acción no se puede deshacer.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "آیا مطمئن هستید که می‌خواهید {name} را حذف کنید؟ این عملیات قابل بازگشت نیست.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (vain vahvistusta varten)",
     "providerNotFound": "Palveluntarjoajaa ei löydy",
     "deleteConnectionConfirm": "Poistetaanko tämä yhteys?",
+    "deleteConnectionConfirmNamed": "Haluatko varmasti poistaa kohteen {name}? Tätä toimintoa ei voi kumota.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (pour validation uniquement)",
     "providerNotFound": "Fournisseur introuvable",
     "deleteConnectionConfirm": "Supprimer cette connexion ?",
+    "deleteConnectionConfirmNamed": "Êtes-vous sûr de vouloir supprimer {name} ? Cette action est irréversible.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "શું તમે ખરેખર {name} કાઢી નાખવા માંગો છો? આ ક્રિયા પૂર્વવત્ કરી શકાશે નહીં.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (לאימות בלבד)",
     "providerNotFound": "הספק לא נמצא",
     "deleteConnectionConfirm": "למחוק את החיבור הזה?",
+    "deleteConnectionConfirmNamed": "האם אתה בטוח שברצונך למחוק את {name}? לא ניתן לבטל פעולה זו.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "एसके-... (केवल सत्यापन के लिए)",
     "providerNotFound": "प्रदाता नहीं मिला",
     "deleteConnectionConfirm": "यह कनेक्शन हटाएं?",
+    "deleteConnectionConfirmNamed": "क्या आप वाकई {name} को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (csak érvényesítés céljából)",
     "providerNotFound": "Szolgáltató nem található",
     "deleteConnectionConfirm": "Törli ezt a kapcsolatot?",
+    "deleteConnectionConfirmNamed": "Biztosan törli a következőt: {name}? Ez a művelet nem vonható vissza.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (untuk validasi saja)",
     "providerNotFound": "Penyedia tidak ditemukan",
     "deleteConnectionConfirm": "Hapus koneksi ini?",
+    "deleteConnectionConfirmNamed": "Apakah Anda yakin ingin menghapus {name}? Tindakan ini tidak dapat dibatalkan.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "Are you sure you want to delete {name}? This action cannot be undone.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -4120,6 +4120,7 @@
     "testKeyPlaceholder": "sk-... (solo per la convalida)",
     "providerNotFound": "Fornitore non trovato",
     "deleteConnectionConfirm": "Eliminare questa connessione?",
+    "deleteConnectionConfirmNamed": "Sei sicuro di voler eliminare {name}? Questa azione non può essere annullata.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (検証のみ)",
     "providerNotFound": "プロバイダーが見つかりません",
     "deleteConnectionConfirm": "この接続を削除しますか?",
+    "deleteConnectionConfirmNamed": "{name}を削除してもよろしいですか？この操作は元に戻せません。",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-...(검증용으로만)",
     "providerNotFound": "공급자를 찾을 수 없습니다.",
     "deleteConnectionConfirm": "이 연결을 삭제하시겠습니까?",
+    "deleteConnectionConfirmNamed": "{name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "तुम्हाला खात्री आहे की तुम्ही {name} हटवू इच्छिता? ही क्रिया पूर्ववत केली जाऊ शकत नाही.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (untuk pengesahan sahaja)",
     "providerNotFound": "Pembekal tidak ditemui",
     "deleteConnectionConfirm": "Padamkan sambungan ini?",
+    "deleteConnectionConfirmNamed": "Adakah anda pasti mahu memadamkan {name}? Tindakan ini tidak boleh dibuat asal.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (alleen ter validatie)",
     "providerNotFound": "Aanbieder niet gevonden",
     "deleteConnectionConfirm": "Deze verbinding verwijderen?",
+    "deleteConnectionConfirmNamed": "Weet u zeker dat u {name} wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (kun for validering)",
     "providerNotFound": "Finner ikke leverandør",
     "deleteConnectionConfirm": "Vil du slette denne tilkoblingen?",
+    "deleteConnectionConfirmNamed": "Er du sikker på at du vil slette {name}? Denne handlingen kan ikke angres.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (para sa pagpapatunay lamang)",
     "providerNotFound": "Hindi nahanap ang provider",
     "deleteConnectionConfirm": "Tanggalin ang koneksyon na ito?",
+    "deleteConnectionConfirmNamed": "Sigurado ka bang gusto mong tanggalin ang {name}? Hindi na maaaring bawiin ang pagkilos na ito.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (tylko do sprawdzenia)",
     "providerNotFound": "Nie znaleziono dostawcy",
     "deleteConnectionConfirm": "Usunąć to połączenie?",
+    "deleteConnectionConfirmNamed": "Czy na pewno chcesz usunąć {name}? Tej czynności nie można cofnąć.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -4132,6 +4132,7 @@
     "testKeyPlaceholder": "sk-... (apenas para validação)",
     "providerNotFound": "Provedor não encontrado",
     "deleteConnectionConfirm": "Excluir esta conexão?",
+    "deleteConnectionConfirmNamed": "Tem certeza de que deseja excluir {name}? Essa ação não pode ser desfeita.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (apenas para validação)",
     "providerNotFound": "Provedor não encontrado",
     "deleteConnectionConfirm": "Excluir esta conexão?",
+    "deleteConnectionConfirmNamed": "Tem a certeza de que pretende eliminar {name}? Esta ação não pode ser anulada.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (doar pentru validare)",
     "providerNotFound": "Furnizorul nu a fost găsit",
     "deleteConnectionConfirm": "Ștergeți această conexiune?",
+    "deleteConnectionConfirmNamed": "Sigur doriți să ștergeți {name}? Această acțiune nu poate fi anulată.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (только для проверки)",
     "providerNotFound": "Провайдер не найден",
     "deleteConnectionConfirm": "Удалить это соединение?",
+    "deleteConnectionConfirmNamed": "Вы уверены, что хотите удалить {name}? Это действие нельзя отменить.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (len na overenie)",
     "providerNotFound": "Poskytovateľ sa nenašiel",
     "deleteConnectionConfirm": "Odstrániť toto pripojenie?",
+    "deleteConnectionConfirmNamed": "Naozaj chcete odstrániť {name}? Túto akciu nemožno vrátiť späť.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -4092,6 +4092,7 @@
     "testKeyPlaceholder": "sk-... (endast för validering)",
     "providerNotFound": "Det gick inte att hitta leverantören",
     "deleteConnectionConfirm": "Vill du ta bort den här anslutningen?",
+    "deleteConnectionConfirmNamed": "Är du säker på att du vill ta bort {name}? Denna åtgärd kan inte ångras.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "Una uhakika unataka kufuta {name}? Kitendo hiki hakiwezi kutenduliwa.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "{name} ஐ நீக்க வேண்டுமா? இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "మీరు {name} ని తొలగించాలనుకుంటున్నారా? ఈ చర్యను వెనక్కి తీసుకోలేరు.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (สำหรับการตรวจสอบเท่านั้น)",
     "providerNotFound": "ไม่พบผู้ให้บริการ",
     "deleteConnectionConfirm": "ลบการเชื่อมต่อนี้ใช่ไหม",
+    "deleteConnectionConfirmNamed": "คุณแน่ใจหรือไม่ว่าต้องการลบ {name}? การกระทำนี้ไม่สามารถย้อนกลับได้",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (yalnızca doğrulama için)",
     "providerNotFound": "Sağlayıcı bulunamadı",
     "deleteConnectionConfirm": "Bu bağlantı silinsin mi?",
+    "deleteConnectionConfirmNamed": "{name} öğesini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (лише для перевірки)",
     "providerNotFound": "Постачальник не знайдено",
     "deleteConnectionConfirm": "Видалити це підключення?",
+    "deleteConnectionConfirmNamed": "Ви впевнені, що хочете видалити {name}? Цю дію не можна скасувати.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (for validation only)",
     "providerNotFound": "Provider not found",
     "deleteConnectionConfirm": "Delete this connection?",
+    "deleteConnectionConfirmNamed": "کیا آپ واقعی {name} کو حذف کرنا چاہتے ہیں؟ یہ عمل واپس نہیں لیا جا سکتا۔",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -3771,6 +3771,7 @@
     "testKeyPlaceholder": "sk-... (chỉ để xác nhận)",
     "providerNotFound": "Không tìm thấy nhà cung cấp",
     "deleteConnectionConfirm": "Xóa kết nối này?",
+    "deleteConnectionConfirmNamed": "Bạn có chắc chắn muốn xóa {name} không? Hành động này không thể hoàn tác.",
     "batchDeleteSelected": "Delete Selected ({count})",
     "batchDeleteConfirm": "Delete {count} connection(s)? This action cannot be undone.",
     "batchDeleteSuccess": "Deleted {count} connection(s)",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4009,6 +4009,7 @@
     "testKeyPlaceholder": "sk-...（仅用于验证）",
     "providerNotFound": "未找到提供商",
     "deleteConnectionConfirm": "删除这个连接吗？",
+    "deleteConnectionConfirmNamed": "确定要删除{name}吗？此操作无法撤销。",
     "batchDeleteSelected": "删除选中（{count}）",
     "batchDeleteConfirm": "删除 {count} 个连接？此操作无法撤销。",
     "batchDeleteSuccess": "已删除 {count} 个连接",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -4124,6 +4124,7 @@
     "testKeyPlaceholder": "sk-...（僅用於驗證）",
     "providerNotFound": "未找到提供商",
     "deleteConnectionConfirm": "刪除這個連線嗎？",
+    "deleteConnectionConfirmNamed": "確定要刪除{name}嗎？此操作無法復原。",
     "batchDeleteSelected": "刪除選中（{count}）",
     "batchDeleteConfirm": "刪除 {count} 個連線？此操作無法撤銷。",
     "batchDeleteSuccess": "已刪除 {count} 個連線",

--- a/tests/unit/ui/confirm-delete-connection-7361.test.tsx
+++ b/tests/unit/ui/confirm-delete-connection-7361.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+/**
+ * Issue #7361 — single-connection delete must be gated behind a confirmation
+ * dialog naming the account, mirroring the existing batch-delete confirm UX.
+ *
+ * Wires the same production pieces the real page composes across
+ * ConnectionsListPanel (per-row onDelete -> deleteConfirm.request) and
+ * ProviderModalsPanel (ConfirmModal bound to deleteConfirm.confirm/cancel):
+ *   ConnectionRow.onDelete -> useConnectionDeleteConfirm.request(id, name)
+ *   -> ConfirmModal(open, message contains name) -> confirm() -> DELETE fetch.
+ */
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (values) {
+      return Object.entries(values).reduce(
+        (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+        key
+      );
+    }
+    return key;
+  },
+}));
+
+const notifySuccess = vi.fn();
+const notifyError = vi.fn();
+vi.mock("@/store/notificationStore", () => ({
+  useNotificationStore: () => ({
+    success: notifySuccess,
+    error: notifyError,
+    info: vi.fn(),
+    warning: vi.fn(),
+  }),
+}));
+
+import ConnectionRow, {
+  type ConnectionRowConnection,
+} from "@/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow";
+import { ConfirmModal } from "@/shared/components";
+import { useConnectionDeleteConfirm } from "@/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionDeleteConfirm";
+import { useNotificationStore } from "@/store/notificationStore";
+
+const cleanupCallbacks: Array<() => void> = [];
+
+function makeContainer(): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  cleanupCallbacks.push(() => container.remove());
+  return container;
+}
+
+const rowProps = {
+  isOAuth: false,
+  isFirst: true,
+  isLast: true,
+  onMoveUp: () => {},
+  onMoveDown: () => {},
+  onToggleActive: () => {},
+  onToggleRateLimit: () => {},
+  onRetest: () => {},
+  onEdit: () => {},
+};
+
+const TARGET_CONNECTION: ConnectionRowConnection = {
+  id: "conn-7361",
+  name: "Production Key",
+  priority: 1,
+};
+
+// Mirrors the real wiring: ConnectionsListPanel's onDelete + ProviderModalsPanel's
+// batch-delete ConfirmModal block, applied to the single-connection case.
+function Harness() {
+  const notify = useNotificationStore();
+  const deleteConfirm = useConnectionDeleteConfirm(async () => {}, notify);
+
+  return (
+    <div>
+      <ConnectionRow
+        {...(rowProps as never)}
+        connection={TARGET_CONNECTION}
+        onDelete={() => deleteConfirm.request(TARGET_CONNECTION.id!, TARGET_CONNECTION.name!)}
+      />
+      <ConfirmModal
+        isOpen={!!deleteConfirm.connection}
+        onClose={deleteConfirm.cancel}
+        onConfirm={deleteConfirm.confirm}
+        title="deleteConnectionConfirm"
+        message={`Are you sure you want to delete ${deleteConfirm.connection?.name ?? ""}?`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        loading={deleteConfirm.deleting}
+      />
+    </div>
+  );
+}
+
+describe("confirm before removing a single connection (#7361)", () => {
+  let container: HTMLElement;
+  let root: ReturnType<typeof createRoot>;
+  let fetchStub: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    fetchStub = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "",
+      headers: { get: () => null },
+    });
+    vi.stubGlobal("fetch", fetchStub);
+    notifySuccess.mockClear();
+    notifyError.mockClear();
+    container = makeContainer();
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    while (cleanupCallbacks.length) cleanupCallbacks.pop()!();
+    vi.unstubAllGlobals();
+  });
+
+  function clickDeleteButton() {
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      "button[title='delete']"
+    );
+    expect(deleteButton).toBeTruthy();
+    act(() => {
+      deleteButton!.click();
+    });
+  }
+
+  function clickConfirmButton() {
+    const dialog = container.querySelector("[role='dialog']");
+    expect(dialog).toBeTruthy();
+    const buttons = Array.from(dialog!.querySelectorAll("button"));
+    const confirmButton = buttons.find((b) => b.textContent?.trim() === "Delete");
+    expect(confirmButton).toBeTruthy();
+    return confirmButton!;
+  }
+
+  it("does NOT fire the DELETE fetch on the initial per-row delete click — it opens a confirm dialog instead", async () => {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    expect(container.querySelector("[role='dialog']")).toBeNull();
+
+    clickDeleteButton();
+
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(container.querySelector("[role='dialog']")).toBeTruthy();
+  });
+
+  it("includes the account name in the confirm dialog copy", async () => {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    clickDeleteButton();
+
+    const dialog = container.querySelector("[role='dialog']");
+    expect(dialog?.textContent).toContain("Production Key");
+  });
+
+  it("fires the DELETE fetch only after explicit confirm", async () => {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    clickDeleteButton();
+    expect(fetchStub).not.toHaveBeenCalled();
+
+    const confirmButton = clickConfirmButton();
+    await act(async () => {
+      confirmButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchStub).toHaveBeenCalledWith("/api/providers/conn-7361", { method: "DELETE" });
+    expect(notifySuccess).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Gates the per-row connection delete (`ConnectionsListPanel`'s per-connection delete button) behind a confirmation dialog that names the account, mirroring the existing batch-delete confirm UX (`handleBatchDeleteOpenModal` / `handleBatchDeleteConfirm`).
- Extracted the confirm state + handlers into a new `useConnectionDeleteConfirm` hook (`src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionDeleteConfirm.ts`) so the frozen `useProviderConnections.ts` file-size ratchet doesn't have to absorb the extra state — the hook net-shrinks that file (946 → 928 lines, well under its 954 frozen cap).
- Wired the new confirm dialog through the existing `ProviderModalsPanel`'s `ConfirmModal` (already used for batch delete), passing the account's display name (`pickDisplayValue([conn.name, conn.email], ...)`) into the dialog copy.
- Added `deleteConnectionConfirmNamed` i18n key ("Are you sure you want to delete {name}? This action cannot be undone.") to `en.json` and `pt-BR.json`, reusing the previously-unused `deleteConnectionConfirm` key as the dialog title.

Closes #7361

## Test plan

TDD (Hard Rule #18): new file `tests/unit/ui/confirm-delete-connection-7361.test.tsx` wires the real production pieces (`ConnectionRow` + `ConfirmModal` + `useConnectionDeleteConfirm`) the same way `ConnectionsListPanel`/`ProviderModalsPanel` compose them, and verifies:
- [x] clicking the per-row delete button does NOT fire the DELETE fetch — it opens the confirm dialog
- [x] the dialog copy includes the account name
- [x] the DELETE fetch fires only after explicit confirm

Verified fail→pass manually: temporarily reverted the `onDelete` wiring in the test harness to call `fetch` directly (bypassing the confirm gate) and confirmed all 3 assertions failed as expected; restored the guarded wiring and confirmed all 3 pass.

```
npx vitest run --config vitest.config.ts tests/unit/ui/confirm-delete-connection-7361.test.tsx
# Test Files  1 passed (1) / Tests  3 passed (3)

npx vitest run --config vitest.config.ts "src/app/(dashboard)/dashboard/providers/[id]/__tests__/phase1f.test.tsx"
# Test Files  1 passed (1) / Tests  10 passed (10)
```

Gates run locally (all green):
- `node scripts/check/check-file-size.mjs` — OK (useProviderConnections.ts net-shrinks: 946→928 lines vs 954 frozen cap)
- `npm run check:complexity-ratchets` — same count (2058) as pristine `origin/release/v3.8.49` tip; pre-existing base drift, not introduced by this PR (verified via a throwaway worktree of the base branch)
- `node scripts/check/check-test-discovery.mjs` — OK, new test collected
- `npm run typecheck:core` / `npm run typecheck:noimplicit:core` — clean
- `node scripts/check/check-dashboard-typecheck.mjs` — OK, 260 pre-existing errors, all within frozen baseline (no regression)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 errors/warnings
- `npm run check:cycles` — OK, no new circular deps