### PR TITLE
feat: honor excluded models in no-auth auto-combo candidate pool (#7622)

### DIFF
--- a/changelog.d/features/7622-noauth-autocombo-exclude.md
+++ b/changelog.d/features/7622-noauth-autocombo-exclude.md
@@ -1,0 +1,1 @@
+- feat(sse): honor a no-auth provider connection's **Excluded Models** field (`providerSpecificData.excludedModels`) in the auto-combo/fusion candidate pool builder, so an excluded no-auth model (e.g. `minimax-m3-free`) is filtered out upfront instead of only failing over after being picked (#7622).

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -20,6 +20,7 @@ import {
 import { buildFamilyCandidateFilter, type ModelFamily } from "./modelFamily";
 import { getHiddenModelsByProvider } from "@/models";
 import { filterPaidOnlyCandidates } from "./paidModelFilter";
+import { isModelExcludedByConnection } from "@/domain/connectionModelRules";
 
 /** #4235 Phase B: optional category/tier overlay for `auto/<category>:<tier>` combos.
  * #6453: optional `family` overlay for `auto/<family>` combos (e.g. `auto/glm`) —
@@ -138,7 +139,8 @@ function isChatAutoComboNoAuthProvider(providerDef: NoAuthProviderDefinition): b
 function getNoAuthCandidates(
   excludedProviders: Set<string>,
   blockedProviders: Set<string>,
-  disabledNoAuthProviders: Set<string>
+  disabledNoAuthProviders: Set<string>,
+  noAuthProviderSpecificData: Map<string, Record<string, unknown> | null | undefined>
 ): VirtualAutoComboCandidate[] {
   const registry = getProviderRegistry();
   const candidates: VirtualAutoComboCandidate[] = [];
@@ -178,9 +180,20 @@ function getNoAuthCandidates(
         : null;
     const routingPrefix = providerDef.alias || registryAlias || providerId;
 
+    // #7622: honor the "Excluded Models" field (`providerSpecificData.excludedModels`)
+    // already enforced at dispatch time (src/sse/services/auth.ts) for no-auth
+    // providers' own provider_connections row (#6557), so an excluded model never
+    // enters the auto-combo/fusion candidate pool in the first place.
+    const providerSpecificData =
+      noAuthProviderSpecificData.get(providerId) ??
+      (typeof providerDef.alias === "string"
+        ? noAuthProviderSpecificData.get(providerDef.alias)
+        : undefined);
+
     for (const model of registryModels) {
       const modelId = typeof model?.id === "string" && model.id.trim().length > 0 ? model.id : null;
       if (!modelId) continue;
+      if (isModelExcludedByConnection(modelId, providerSpecificData)) continue;
       candidates.push({
         provider: providerId,
         connectionId: SYNTHETIC_NOAUTH_CONNECTION_ID,
@@ -261,6 +274,19 @@ export async function createVirtualAutoCombo(
       .map((conn) => conn.provider)
   );
   const hiddenModelsMap = getHiddenModelsByProvider();
+  // #7622: a no-auth provider's own provider_connections row (#6557) can carry
+  // `providerSpecificData.excludedModels` regardless of its isActive state (the
+  // dispatch-time enforcement in auth.ts does not gate on isActive either), so
+  // gather it from BOTH the active and disabled connection lists.
+  const noAuthProviderSpecificData = new Map<
+    string,
+    Record<string, unknown> | null | undefined
+  >();
+  for (const conn of [...connections, ...disabledNoAuthConnections]) {
+    if (conn.provider in NOAUTH_PROVIDERS) {
+      noAuthProviderSpecificData.set(conn.provider, conn.providerSpecificData);
+    }
+  }
 
   const validConnections = connections.filter(hasUsableConnectionCredential);
 
@@ -296,7 +322,8 @@ export async function createVirtualAutoCombo(
     ...getNoAuthCandidates(
       new Set(validConnections.map((conn) => conn.provider)),
       blockedProviders,
-      disabledNoAuthProviders
+      disabledNoAuthProviders,
+      noAuthProviderSpecificData
     )
   );
 

--- a/tests/unit/noauth-autocombo-exclude-7622.test.ts
+++ b/tests/unit/noauth-autocombo-exclude-7622.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #7622 — no-auth provider "Excluded Models" field is stored + enforced at
+ * dispatch time (src/sse/services/auth.ts) but IGNORED by the auto-combo/fusion
+ * candidate pool builder (`getNoAuthCandidates()` in
+ * open-sse/services/autoCombo/virtualFactory.ts). An excluded no-auth model must
+ * never be advertised/selected in `auto/*` combos in the first place — it should
+ * only fail over after being picked instead.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7622-noauth-exclude-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const virtualFactory = await import("../../open-sse/services/autoCombo/virtualFactory.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  await resetStorage();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_DATA_DIR === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+});
+
+test("#7622: a no-auth model excluded via providerSpecificData.excludedModels is ABSENT from the auto-combo candidate pool", async () => {
+  const conn = await providersDb.createProviderConnection({
+    provider: "opencode",
+    authType: "no-auth",
+    name: "OpenCode Free Account 1",
+    providerSpecificData: { excludedModels: "mimo-v2.5-free" },
+  });
+  assert.ok(conn.id, "connection must be created");
+
+  const combo = await virtualFactory.createVirtualAutoCombo(undefined);
+
+  const modelStrings = combo.models.map((m: { model: string }) => m.model);
+  assert.ok(
+    !modelStrings.some((model: string) => model.endsWith("/mimo-v2.5-free")),
+    "BUG #7622: the excluded model 'mimo-v2.5-free' must not appear in the auto-combo " +
+      `candidate pool, but it did. Pool: ${JSON.stringify(modelStrings)}`
+  );
+});
+
+test("#7622: a non-excluded no-auth model from the same connection remains in the auto-combo candidate pool", async () => {
+  await providersDb.createProviderConnection({
+    provider: "opencode",
+    authType: "no-auth",
+    name: "OpenCode Free Account 1",
+    providerSpecificData: { excludedModels: "mimo-v2.5-free" },
+  });
+
+  const combo = await virtualFactory.createVirtualAutoCombo(undefined);
+
+  const modelStrings = combo.models.map((m: { model: string }) => m.model);
+  assert.ok(
+    modelStrings.some((model: string) => model.endsWith("/big-pickle")),
+    `a non-excluded model ("big-pickle") must remain in the pool. Pool: ${JSON.stringify(modelStrings)}`
+  );
+});
+
+test("#7622 regression guard: with no excludedModels set, all opencode models remain in the pool (baseline unchanged)", async () => {
+  await providersDb.createProviderConnection({
+    provider: "opencode",
+    authType: "no-auth",
+    name: "OpenCode Free Account 1",
+    providerSpecificData: { fingerprints: ["11111111111111111111111111111111"] },
+  });
+
+  const combo = await virtualFactory.createVirtualAutoCombo(undefined);
+
+  const modelStrings = combo.models.map((m: { model: string }) => m.model);
+  assert.ok(
+    modelStrings.some((model: string) => model.endsWith("/mimo-v2.5-free")),
+    `baseline: no exclusion set, mimo-v2.5-free must still be present. Pool: ${JSON.stringify(modelStrings)}`
+  );
+});


### PR DESCRIPTION
## Summary
- `getNoAuthCandidates()` (auto-combo/fusion virtual candidate pool builder for no-auth providers like opencode/mimocode) now honors the connection's **Excluded Models** field (`providerSpecificData.excludedModels`), reusing `isModelExcludedByConnection()` from `src/domain/connectionModelRules.ts` — the same helper already used at dispatch time in `src/sse/services/auth.ts`.
- Previously an excluded no-auth model (e.g. `minimax-m3-free`) was enforced only at dispatch, so it could still be advertised/selected upfront by `auto/*` combos and would only fail over after being picked. Now it never enters the candidate pool.
- No schema/migration/UI changes — the exclusion field, its validation, and the Edit Connection modal already work for no-auth connections today; this closes the one remaining gap in the auto-combo builder.

## Test plan
- [x] New `tests/unit/noauth-autocombo-exclude-7622.test.ts` (TDD): failing RED against the pre-fix `virtualFactory.ts` (verified via `git show origin/release/v3.8.49:...` diffed locally, never via git stash), GREEN after the fix.
  - excluded no-auth model (`mimo-v2.5-free`) absent from the pool
  - non-excluded model from the same connection (`big-pickle`) remains
  - regression guard: no `excludedModels` set → baseline pool unchanged
- [x] `node --import tsx/esm --test tests/unit/repro-6557-noauth-connection-disable-ignored.test.ts` — no regression on the related #6557 fix.
- [x] `npm run typecheck:core` — clean
- [x] `npm run typecheck:noimplicit:core` — pre-existing errors only in files not touched by this PR (combo.ts, usageTracking.ts, cliRuntime.ts)
- [x] `npx eslint open-sse/services/autoCombo/virtualFactory.ts tests/unit/noauth-autocombo-exclude-7622.test.ts --max-warnings 0` — clean
- [x] `node scripts/check/check-file-size.mjs`, `npm run check:complexity-ratchets`, `node scripts/check/check-test-discovery.mjs`, `npm run check:cycles` — all green

Closes #7622