### PR TITLE
chore(quality): register #6672 test in stryker tap.testFiles (base-red unblock)

### DIFF
--- a/changelog.d/maintenance/stryker-testfiles-6672.md
+++ b/changelog.d/maintenance/stryker-testfiles-6672.md
@@ -1,0 +1,1 @@
+- chore(quality): register microsoft-designer-web-6672 test in stryker tap.testFiles (unblocks Fast Quality Gates base-red)

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -190,6 +190,7 @@
       "tests/unit/masked-200-exhaustion-fallback-6427.test.ts",
       "tests/unit/memory-embedding-remote.test.ts",
       "tests/unit/memory-embedding-transformers.test.ts",
+      "tests/unit/microsoft-designer-web-6672.test.ts",
       "tests/unit/middleware-header-strip-5849.test.ts",
       "tests/unit/middleware-hooks-error-sanitization.test.ts",
       "tests/unit/model-cooldowns-route-auth.test.ts",


### PR DESCRIPTION
The current release tip's `stryker.conf.json` `tap.testFiles` is missing `tests/unit/microsoft-designer-web-6672.test.ts` (a merged PR's test covering the mutated module `open-sse/utils/publicCreds.ts`). This makes `check:mutation-test-coverage` fail inside the **Fast Quality Gates** job on **every** open PR against release/v3.8.49 (a base-red not introduced by those PRs).

One-line fix: add the missing test to `tap.testFiles` (alphabetical). Verified: the gate now reports `✓ No drift`.

This unblocks clean CI for the 11 in-flight feature PRs and all future PRs.