### PR TITLE
fix(providers): keep custom_tool_call_output image parts as input content (#7356)

### DIFF
--- a/open-sse/services/responsesInputSanitizer.ts
+++ b/open-sse/services/responsesInputSanitizer.ts
@@ -99,7 +99,16 @@ function sanitizeOutputContent(record: JsonRecord): JsonRecord {
   // Responses input. In that shape OpenAI validates `input[n].output[m].type`
   // against output content part types, so legacy Chat-style `image_url` parts
   // must be normalized here too, not only in message.content.
-  const role = record.type === "function_call_output" ? "user" : "assistant";
+  //
+  // #7356: `function_call_output` and `custom_tool_call_output` are both tool
+  // RESULTS being submitted back as input — their `.output` entries must stay
+  // input content types (input_text/input_image), same as a user message. Only
+  // a `message` item's own `output`/`content` (the model's own text) is
+  // "assistant" output that gets flattened to output_text.
+  const role =
+    record.type === "function_call_output" || record.type === "custom_tool_call_output"
+      ? "user"
+      : "assistant";
   const output = record.output.map((part) => sanitizeContentPart(part, role));
   return { ...record, output };
 }

--- a/tests/unit/responses-input-sanitizer-name.test.ts
+++ b/tests/unit/responses-input-sanitizer-name.test.ts
@@ -144,3 +144,43 @@ test("normalizes function_call_output image output parts to input_image", () => 
   });
   assert.equal(JSON.stringify(result).includes('"type":"image_url"'), false);
 });
+
+test("leaves custom_tool_call_output input_image output parts untouched (#7356)", () => {
+  const items = [
+    {
+      type: "custom_tool_call_output",
+      call_id: "call_example",
+      output: [
+        { type: "input_text", text: "image tool output" },
+        { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+      ],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "custom_tool_call_output",
+    call_id: "call_example",
+    output: [
+      { type: "input_text", text: "image tool output" },
+      { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+    ],
+  });
+  assert.equal(JSON.stringify(result).includes('"type":"output_text"'), false);
+});
+
+test("normalizes custom_tool_call_output legacy image_url output parts to input_image (#7356)", () => {
+  const items = [
+    {
+      type: "custom_tool_call_output",
+      call_id: "call_example",
+      output: [{ type: "image_url", image_url: { url: "https://example.com/tool.png" } }],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "custom_tool_call_output",
+    call_id: "call_example",
+    output: [{ type: "input_image", image_url: "https://example.com/tool.png" }],
+  });
+  assert.equal(JSON.stringify(result).includes('"type":"image_url"'), false);
+});


### PR DESCRIPTION
## Problem

A brand-new Codex conversation that submits an image through a custom tool fails
on the very first turn. Codex sends the tool result back as a
`custom_tool_call_output` item whose `output` array contains an `input_image`
part:

```json
{
  "type": "custom_tool_call_output",
  "call_id": "call_example",
  "output": [
    { "type": "input_text", "text": "image tool output" },
    { "type": "input_image", "image_url": "data:image/png;base64,..." }
  ]
}
```

OmniRoute rewrites that `input_image` part to `output_text` before forwarding
the request to the Codex upstream, which then rejects the request with an HTTP
400 — per the Responses API schema, entries inside `custom_tool_call_output.output`
must stay **input** content types.

## Root cause

`sanitizeOutputContent()` in `open-sse/services/responsesInputSanitizer.ts`
decides which "role" governs an item's `.output` array before delegating each
part to `sanitizeContentPart()`:

```ts
const role = record.type === "function_call_output" ? "user" : "assistant";
```

Only `function_call_output` was special-cased to `"user"` (tool RESULT being fed
back as input). Every other item type — including `custom_tool_call_output`,
which is exactly the same kind of tool-result-as-input item — fell through to
`"assistant"`. `sanitizeContentPart()` then hits this branch for
`role === "assistant"`:

```ts
if (role === "assistant" && record.type === "input_image") {
  const url = imageUrlToText(record.image_url);
  return { type: "output_text", text: url ? `[Image: ${url}]` : "[Image]" };
}
```

...converting the valid `input_image` part into `output_text`, which the Codex
Responses upstream then rejects. This sanitizer runs right before the request is
forwarded upstream (`open-sse/executors/codex.ts:1063`), so every Codex request
with an image routed through a custom tool hit this on the very first turn.

## Fix

Treat `custom_tool_call_output` the same as `function_call_output` when deriving
the role for `.output` content sanitization — both are tool results submitted
back as input, not the model's own generated output:

```ts
const role =
  record.type === "function_call_output" || record.type === "custom_tool_call_output"
    ? "user"
    : "assistant";
```

This only changes behavior for `custom_tool_call_output` items; legacy
`image_url` parts replayed inside a `custom_tool_call_output.output` are still
normalized forward to `input_image` (matching the existing `function_call_output`
behavior), they're just no longer collapsed to `output_text`.

## Verification

Extended `tests/unit/responses-input-sanitizer-name.test.ts` (existing sanitizer
test file, already covering the identical `function_call_output` case) with 2 new
cases. Confirmed both fail on the unfixed code and pass after the fix.

```
# before the fix (red)
$ node --import tsx/esm --test tests/unit/responses-input-sanitizer-name.test.ts
not ok 13 - leaves custom_tool_call_output input_image output parts untouched (#7356)
not ok 14 - normalizes custom_tool_call_output legacy image_url output parts to input_image (#7356)
# tests 14  # pass 12  # fail 2

# after the fix (green)
$ node --import tsx/esm --test tests/unit/responses-input-sanitizer-name.test.ts
# tests 14  # pass 14  # fail 0

# neighbouring codex executor suites — no regressions
$ node --import tsx/esm --test tests/unit/codex-executor-split.test.ts tests/unit/codex-responses-passthrough-strip-3317.test.ts tests/unit/codex-tools-split.test.ts tests/unit/responses-input-sanitizer-name.test.ts
# tests 21  # pass 21  # fail 0

# lint (with repo suppressions) + typecheck
$ npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/responsesInputSanitizer.ts tests/unit/responses-input-sanitizer-name.test.ts   # clean
$ npm run typecheck:core   # clean
```

## Diff summary

- `open-sse/services/responsesInputSanitizer.ts` — `sanitizeOutputContent()` now derives `role: "user"` for both `function_call_output` and `custom_tool_call_output`, with a comment explaining why (both are tool-result-as-input items, not model output).
- `tests/unit/responses-input-sanitizer-name.test.ts` — 2 new regression cases covering the reported `input_image` pass-through and the legacy `image_url` normalization path.

Closes #7356.

Thanks to the reporter for the precise repro payload — it made isolating the exact sanitizer branch straightforward.
