### PR TITLE
test(ci): register microsoft-designer-web-6672 in stryker tap.testFiles

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -190,6 +190,7 @@
       "tests/unit/masked-200-exhaustion-fallback-6427.test.ts",
       "tests/unit/memory-embedding-remote.test.ts",
       "tests/unit/memory-embedding-transformers.test.ts",
+      "tests/unit/microsoft-designer-web-6672.test.ts",
       "tests/unit/middleware-header-strip-5849.test.ts",
       "tests/unit/middleware-hooks-error-sanitization.test.ts",
       "tests/unit/model-cooldowns-route-auth.test.ts",


### PR DESCRIPTION
## Problem

`check:mutation-test-coverage --strict` (the **`Fast Quality Gates`** step) was **base-red on every open release PR** — the last unexplained base-red.

## Root cause

The drift guard's invariant: every `tests/unit/**` test that imports a **mutated** module (`stryker.conf.json` `mutate`) MUST be listed in `tap.testFiles`. Today's **#7609 (Microsoft Designer provider)** added `tests/unit/microsoft-designer-web-6672.test.ts`, which imports `resolvePublicCred` from the mutated module `open-sse/utils/publicCreds.ts` — but the test was never added to `tap.testFiles`. The guard fails `--strict` on exactly that drift.

## Fix

Add the test to `stryker.conf.json` `tap.testFiles` (alphabetical slot). This is the fix the gate's own docs prescribe ("Add them to tap.testFiles").

```
+ "tests/unit/microsoft-designer-web-6672.test.ts",
```

## Validation

```
node scripts/check/check-mutation-test-coverage.mjs --strict
✓ No drift — every covering unit test is listed in tap.testFiles.   (exit 0)
```

Config-only — no test or production code touched. The file exists only on `release/v3.8.49` (added by #7609), so no `main` companion is needed. Clears the last shared base-red on `Fast Quality Gates` for all release PRs.