### PR TITLE
fix(stryker): add Microsoft Designer test to tap.testFiles

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -190,6 +190,7 @@
       "tests/unit/masked-200-exhaustion-fallback-6427.test.ts",
       "tests/unit/memory-embedding-remote.test.ts",
       "tests/unit/memory-embedding-transformers.test.ts",
+      "tests/unit/microsoft-designer-web-6672.test.ts",
       "tests/unit/middleware-header-strip-5849.test.ts",
       "tests/unit/middleware-hooks-error-sanitization.test.ts",
       "tests/unit/model-cooldowns-route-auth.test.ts",


### PR DESCRIPTION
## Summary

Adds the missing mutation coverage test file to `tap.testFiles` in `stryker.conf.json` so the mutation coverage check includes the test.

## Related Issues

- Closes #7657

## Validation

- [ ] `npm run lint` (not run)
- [ ] `npm run test:unit` (not run)
- [ ] `npm run test:coverage` (not run)
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches (not run)
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below (pending CI)

Additional validation:
- ✅ `node scripts/check/check-mutation-test-coverage.mjs --strict`

## Tests Added Or Updated

- Updated `stryker.conf.json` to include:
  - `tests/unit/microsoft-designer-web-6672.test.ts`
- No test files were modified.

## Coverage Notes

No production code (`src/`, `open-sse/`, `electron/`, or `bin/`) was changed. This PR only updates the mutation test configuration.

## Reviewer Notes

Low-risk configuration change. Added the missing test entry in alphabetical order.