### PR TITLE
docs(readme): standardize all README tables to full content width

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,14 @@
 
 No combo to create. Set your model to `auto` (or a variant) and OmniRoute builds a virtual combo from your connected providers, scored live:
 
-| Model ID       | What it optimizes for                                          |
-| -------------- | -------------------------------------------------------------- |
-| `auto`         | 🎯 Balanced default (LKGP — sticks to your last good provider) |
-| `auto/coding`  | 🧑‍💻 Quality-first weights for code generation                   |
-| `auto/fast`    | ⚡ Lowest latency first                                        |
-| `auto/cheap`   | 💰 Cheapest per token first                                    |
-| `auto/offline` | 🔋 Most quota / rate-limit headroom first                      |
-| `auto/smart`   | 🔭 Quality-first + 10% exploration to discover better models   |
+| Model ID       | What it optimizes for<br><img src="docs/screenshots/spacer.svg" width="720" height="1" alt=""> |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| `auto`         | 🎯 Balanced default (LKGP — sticks to your last good provider)                                 |
+| `auto/coding`  | 🧑‍💻 Quality-first weights for code generation                                                   |
+| `auto/fast`    | ⚡ Lowest latency first                                                                        |
+| `auto/cheap`   | 💰 Cheapest per token first                                                                    |
+| `auto/offline` | 🔋 Most quota / rate-limit headroom first                                                      |
+| `auto/smart`   | 🔭 Quality-first + 10% exploration to discover better models                                   |
 
 ##
 
@@ -219,26 +219,26 @@ No combo to create. Set your model to `auto` (or a variant) and OmniRoute builds
 
 All **18** strategies — mix & match per combo step:
 
-| #   | Strategy            | What it does                                                     |
-| --- | ------------------- | ---------------------------------------------------------------- |
-| 1   | `priority`          | First-target ordered list — drain each before the next 🥇        |
-| 2   | `fill-first`        | Fill each target's quota fully before moving on                  |
-| 3   | `weighted`          | Weighted random by per-target weight                             |
-| 4   | `round-robin`       | Cycle through targets in order                                   |
-| 5   | `p2c`               | Power-of-two-choices random load balancing                       |
-| 6   | `least-used`        | Pick the target with the lowest current load                     |
-| 7   | `random`            | Uniform random pick (deduplicated)                               |
-| 8   | `strict-random`     | Random without de-duplicating repeats 🎲                         |
-| 9   | `cost-optimized`    | Minimize $ per request from live catalog pricing 💸              |
-| 10  | `headroom`          | Pick the target with the most remaining quota                    |
-| 11  | `reset-window`      | Prefer the target whose quota window resets soonest              |
-| 12  | `reset-aware`       | Rank by quota reset time — short windows first 📊                |
-| 13  | `context-relay`     | Hand off context across targets for long conversations 🧠        |
-| 14  | `context-optimized` | Pick the best fit for the current context size                   |
-| 15  | `lkgp`              | Last-Known-Good Path — sticky to the last successful target      |
-| 16  | `auto`              | 12-factor live scoring across every connection 🤖                |
-| 17  | `fusion`            | Fan out to a panel of models + a judge synthesizes one answer 🧬 |
-| 18  | `pipeline`          | Chain steps — each target's output feeds the next one 🔗         |
+| #   | Strategy            | What it does<br><img src="docs/screenshots/spacer.svg" width="630" height="1" alt=""> |
+| --- | ------------------- | ------------------------------------------------------------------------------------- |
+| 1   | `priority`          | First-target ordered list — drain each before the next 🥇                             |
+| 2   | `fill-first`        | Fill each target's quota fully before moving on                                       |
+| 3   | `weighted`          | Weighted random by per-target weight                                                  |
+| 4   | `round-robin`       | Cycle through targets in order                                                        |
+| 5   | `p2c`               | Power-of-two-choices random load balancing                                            |
+| 6   | `least-used`        | Pick the target with the lowest current load                                          |
+| 7   | `random`            | Uniform random pick (deduplicated)                                                    |
+| 8   | `strict-random`     | Random without de-duplicating repeats 🎲                                              |
+| 9   | `cost-optimized`    | Minimize $ per request from live catalog pricing 💸                                   |
+| 10  | `headroom`          | Pick the target with the most remaining quota                                         |
+| 11  | `reset-window`      | Prefer the target whose quota window resets soonest                                   |
+| 12  | `reset-aware`       | Rank by quota reset time — short windows first 📊                                     |
+| 13  | `context-relay`     | Hand off context across targets for long conversations 🧠                             |
+| 14  | `context-optimized` | Pick the best fit for the current context size                                        |
+| 15  | `lkgp`              | Last-Known-Good Path — sticky to the last successful target                           |
+| 16  | `auto`              | 12-factor live scoring across every connection 🤖                                     |
+| 17  | `fusion`            | Fan out to a panel of models + a judge synthesizes one answer 🧬                      |
+| 18  | `pipeline`          | Chain steps — each target's output feeds the next one 🔗                              |
 
 <sub>The Auto-Combo engine scores every candidate on **12 factors** (health, quota, cost, latency, success rate, freshness…) — see [`docs/routing/AUTO-COMBO.md`](docs/routing/AUTO-COMBO.md).</sub>
 
@@ -248,12 +248,12 @@ All **18** strategies — mix & match per combo step:
 
 > Running several keys against the **same upstream account** (one Codex Pro plan, one Kimi key, one GLM Coding seat)? A burst on one key can burn the whole 5-hour / hourly quota and lock everyone else out. **Quota-Share** distributes a provider's time-based quota **fairly** across the keys in a pool — and it's _work-conserving_, so an idle member's slice is lent out instead of wasted.
 
-| Knob                     | What it controls                                                                |
-| ------------------------ | ------------------------------------------------------------------------------- |
-| ⚖️ **Allocation weight** | each key's slice of the pool — e.g. `50 / 30 / 20`                              |
-| 📐 **Dimensions**        | track `%` · requests · tokens · `$`, per **5h / 7d / per-model** window         |
-| 🚦 **Policy**            | `hard` (block over share) · `soft` (deprioritize) · `burst` (use idle headroom) |
-| 🧱 **Cap**               | absolute ceiling per key, independent of mode                                   |
+| Knob                     | What it controls<br><img src="docs/screenshots/spacer.svg" width="670" height="1" alt=""> |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| ⚖️ **Allocation weight** | each key's slice of the pool — e.g. `50 / 30 / 20`                                        |
+| 📐 **Dimensions**        | track `%` · requests · tokens · `$`, per **5h / 7d / per-model** window                   |
+| 🚦 **Policy**            | `hard` (block over share) · `soft` (deprioritize) · `burst` (use idle headroom)           |
+| 🧱 **Cap**               | absolute ceiling per key, independent of mode                                             |
 
 <img src="./docs/diagrams/pool-fair-share.svg" width="100%" alt="OmniRoute key pool 'team-codex': one Codex Pro account shared by 3 keys over a 5-hour window. alice weight 50 (up to 50% of the shared 5h quota), bob weight 30, ci-bot weight 20. In generous mode (under 50% pool used) idle shares are lent out; once the pool crosses 50% strict mode holds each key to its fair share."/>
 
@@ -538,29 +538,29 @@ claude mcp add-server omniroute --type http --url http://localhost:20128/api/mcp
 
 Engines run in pipeline order; each is independently toggleable and configurable per combo:
 
-| #   | Engine            | What it does                                                        |
-| --- | ----------------- | ------------------------------------------------------------------- |
-| 1   | **Session-Dedup** | Drops content repeated across turns (content-addressed, cross-turn) |
-| 2   | **CCR**           | Archives large blocks behind retrieve markers, fetched on demand    |
-| 3   | **RTK**           | Smart tool-result filtering, dedup & truncation (command-aware)     |
+| #   | Engine            | What it does                                                                                                            |
+| --- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Session-Dedup** | Drops content repeated across turns (content-addressed, cross-turn)                                                     |
+| 2   | **CCR**           | Archives large blocks behind retrieve markers, fetched on demand                                                        |
+| 3   | **RTK**           | Smart tool-result filtering, dedup & truncation (command-aware)                                                         |
 | 4   | **Headroom**      | Lossless tabular compaction of homogeneous JSON arrays, flat or nested (~30%), via a vendored **GCF** codec (spec v3.2) |
-| 5   | **Relevance**     | Extractive sentence scoring against the last user query             |
-| 6   | **Caveman**       | Rule-based prose compression (~65–75% on output)                    |
-| 7   | **LLMLingua-2**   | ML semantic pruning via MobileBERT ONNX — code-safe, async          |
-| 8   | **Lite**          | Whitespace + image-URL trimming (latency-light baseline)            |
-| 9   | **Aggressive**    | Summarization + progressive aging of old turns                      |
-| 10  | **Ultra**         | Heuristic token pruning with an optional small-model (SLM) tier     |
+| 5   | **Relevance**     | Extractive sentence scoring against the last user query                                                                 |
+| 6   | **Caveman**       | Rule-based prose compression (~65–75% on output)                                                                        |
+| 7   | **LLMLingua-2**   | ML semantic pruning via MobileBERT ONNX — code-safe, async                                                              |
+| 8   | **Lite**          | Whitespace + image-URL trimming (latency-light baseline)                                                                |
+| 9   | **Aggressive**    | Summarization + progressive aging of old turns                                                                          |
+| 10  | **Ultra**         | Heuristic token pruning with an optional small-model (SLM) tier                                                         |
 
 Code blocks, URLs and structured data are **always preserved** byte-perfect. **One-click presets** combine the engines:
 
-| Mode                           | Savings    | Best for                    |
-| ------------------------------ | ---------- | --------------------------- |
-| 🪶 **Lite**                    | ~15%       | Always-on safe default      |
-| 🪨 **Standard (Caveman)**      | ~30%       | Daily coding                |
-| ⚡ **Aggressive**              | ~50%       | Long tool-heavy sessions    |
-| 🔥 **Ultra**                   | ~75%       | Maximum savings             |
-| 🧰 **RTK**                     | 60–90%     | Shell/test/build/git output |
-| 🔗 **Stacked (RTK → Caveman)** | **78–95%** | Mixed prompts + tool logs   |
+| Mode                           | Savings    | Best for<br><img src="docs/screenshots/spacer.svg" width="540" height="1" alt=""> |
+| ------------------------------ | ---------- | --------------------------------------------------------------------------------- |
+| 🪶 **Lite**                    | ~15%       | Always-on safe default                                                            |
+| 🪨 **Standard (Caveman)**      | ~30%       | Daily coding                                                                      |
+| ⚡ **Aggressive**              | ~50%       | Long tool-heavy sessions                                                          |
+| 🔥 **Ultra**                   | ~75%       | Maximum savings                                                                   |
+| 🧰 **RTK**                     | 60–90%     | Shell/test/build/git output                                                       |
+| 🔗 **Stacked (RTK → Caveman)** | **78–95%** | Mixed prompts + tool logs                                                         |
 
 **Real example — Standard mode:**
 
@@ -781,25 +781,25 @@ same process on one port, so there is no separate CLI-only package today.
 
 <br/>
 
-| Tier                        | Example                                  | Cost       |
-| --------------------------- | ---------------------------------------- | ---------- |
-| 💳 **Subscription**         | Claude Code Pro / Codex / Copilot        | $10–200/mo |
-| 🔑 **API Key (free tiers)** | NVIDIA NIM, Cerebras, Groq               | **FREE**   |
-| 💰 **Cheap**                | GLM-5 $0.5/1M · MiniMax M2.5 $0.3/1M     | pennies    |
-| 🆓 **Free Forever**         | Kiro, Qoder, Qwen, Pollinations, LongCat | **$0**     |
+| Tier                        | Example<br><img src="docs/screenshots/spacer.svg" width="540" height="1" alt=""> | Cost       |
+| --------------------------- | -------------------------------------------------------------------------------- | ---------- |
+| 💳 **Subscription**         | Claude Code Pro / Codex / Copilot                                                | $10–200/mo |
+| 🔑 **API Key (free tiers)** | NVIDIA NIM, Cerebras, Groq                                                       | **FREE**   |
+| 💰 **Cheap**                | GLM-5 $0.5/1M · MiniMax M2.5 $0.3/1M                                             | pennies    |
+| 🆓 **Free Forever**         | Kiro, Qoder, Qwen, Pollinations, LongCat                                         | **$0**     |
 
 **The $0 Free Stack — combine into one unbreakable combo:**
 
-| Provider          | Prefix      | Free models                                     | Quota              |
-| ----------------- | ----------- | ----------------------------------------------- | ------------------ |
-| **Kiro**          | `kr/`       | Claude Sonnet 4.5, Haiku 4.5, Opus 4.6          | 50 credits/mo      |
-| **Qoder**         | `if/`       | kimi-k2-thinking, qwen3-coder-plus, deepseek-r1 | ♾️ Unlimited       |
-| **Qwen**          | `qw/`       | qwen3-coder-plus/flash/next                     | ♾️ Unlimited       |
-| **Pollinations**  | `pol/`      | GPT-5, Claude, Gemini, DeepSeek, Llama 4        | No key needed      |
-| **LongCat**       | `lc/`       | LongCat-2.0                                     | 10M one-time (KYC) |
-| **Cloudflare AI** | `cf/`       | 50+ models                                      | 10K neurons/day    |
-| **NVIDIA NIM**    | `nvidia/`   | 129 models                                      | ~40 RPM            |
-| **Cerebras**      | `cerebras/` | Qwen3 235B, GPT-OSS 120B                        | 1M tok/day         |
+| Provider          | Prefix      | Free models<br><img src="docs/screenshots/spacer.svg" width="440" height="1" alt=""> | Quota              |
+| ----------------- | ----------- | ------------------------------------------------------------------------------------ | ------------------ |
+| **Kiro**          | `kr/`       | Claude Sonnet 4.5, Haiku 4.5, Opus 4.6                                               | 50 credits/mo      |
+| **Qoder**         | `if/`       | kimi-k2-thinking, qwen3-coder-plus, deepseek-r1                                      | ♾️ Unlimited       |
+| **Qwen**          | `qw/`       | qwen3-coder-plus/flash/next                                                          | ♾️ Unlimited       |
+| **Pollinations**  | `pol/`      | GPT-5, Claude, Gemini, DeepSeek, Llama 4                                             | No key needed      |
+| **LongCat**       | `lc/`       | LongCat-2.0                                                                          | 10M one-time (KYC) |
+| **Cloudflare AI** | `cf/`       | 50+ models                                                                           | 10K neurons/day    |
+| **NVIDIA NIM**    | `nvidia/`   | 129 models                                                                           | ~40 RPM            |
+| **Cerebras**      | `cerebras/` | Qwen3 235B, GPT-OSS 120B                                                             | 1M tok/day         |
 
 > 💡 The dashboard "cost" is a **savings tracker**, not a bill — OmniRoute never charges you. A "$290 total cost" using free models means **$290 saved**.
 
@@ -865,11 +865,11 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 
 <br/>
 
-| Env var           | Default        | Purpose                          |
-| ----------------- | -------------- | -------------------------------- |
-| `PORT`            | `20128`        | API + dashboard port             |
-| `REQUIRE_API_KEY` | `false`        | Require API key for all requests |
-| `DATA_DIR`        | `~/.omniroute` | Database & config storage        |
+| Env var           | Default        | Purpose<br><img src="docs/screenshots/spacer.svg" width="570" height="1" alt=""> |
+| ----------------- | -------------- | -------------------------------------------------------------------------------- |
+| `PORT`            | `20128`        | API + dashboard port                                                             |
+| `REQUIRE_API_KEY` | `false`        | Require API key for all requests                                                 |
+| `DATA_DIR`        | `~/.omniroute` | Database & config storage                                                        |
 
 **Will I be charged by OmniRoute?** No — it's free, open-source software on your machine. You only pay paid providers directly. OmniRoute has no billing system.
 **Are FREE providers really unlimited?** Mostly — Qoder, Pollinations, LongCat, and Cloudflare are free with no per-account credit cap. Kiro is free too but capped at ~50 credits/month per account. Stack multiple free providers in a combo and auto-fallback keeps you serving for $0.
@@ -885,14 +885,14 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 
 <br/>
 
-| Problem                                   | Quick fix                                                     |
-| ----------------------------------------- | ------------------------------------------------------------- |
-| "Language model did not provide messages" | Provider quota exhausted → use a combo fallback               |
-| Rate limiting (429)                       | Add fallback: `cc/claude → glm/glm-4.7 → if/kimi-k2-thinking` |
-| OAuth token expired                       | Auto-refreshed; if stuck, delete + re-auth in Providers       |
-| `unsupported_country_region_territory`    | Configure proxy in Settings → Proxy                           |
-| Docker SQLite locks                       | Use `--stop-timeout 40` for clean WAL checkpoint              |
-| Node runtime errors                       | Use Node `>=22.0.0 <23` or `>=24.0.0 <27`                     |
+| Problem                                   | Quick fix<br><img src="docs/screenshots/spacer.svg" width="510" height="1" alt=""> |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| "Language model did not provide messages" | Provider quota exhausted → use a combo fallback                                    |
+| Rate limiting (429)                       | Add fallback: `cc/claude → glm/glm-4.7 → if/kimi-k2-thinking`                      |
+| OAuth token expired                       | Auto-refreshed; if stuck, delete + re-auth in Providers                            |
+| `unsupported_country_region_territory`    | Configure proxy in Settings → Proxy                                                |
+| Docker SQLite locks                       | Use `--stop-timeout 40` for clean WAL checkpoint                                   |
+| Node runtime errors                       | Use Node `>=22.0.0 <23` or `>=24.0.0 <27`                                          |
 
 🐛 **Reporting a bug?** Run `npm run system-info` and attach `system-info.txt`. 📖 [`docs/guides/TROUBLESHOOTING.md`](docs/guides/TROUBLESHOOTING.md)
 
@@ -962,66 +962,66 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 
 ### 📘 Getting Started
 
-| Document                                                       | Description                                                                      |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [User Guide](docs/guides/USER_GUIDE.md)                        | Providers, combos, CLI integration, deployment                                   |
-| [Setup Guide](docs/guides/SETUP_GUIDE.md)                      | Full install methods, CLI tool configs, protocol setup, timeout tuning           |
-| [CLI Tools Guide](docs/reference/CLI-TOOLS.md)                 | Per-tool setup for Claude Code, Codex, Cursor, Cline, OpenClaw, Kilo, Copilot    |
-| [Remote Mode](docs/guides/REMOTE-MODE.md)                      | Drive a remote OmniRoute (VPS) from your laptop CLI via scoped access tokens     |
-| [Claude Code Config](docs/guides/CLAUDE-CODE-CONFIGURATION.md) | Point Claude Code at OmniRoute (local/remote) with `launch` + per-model profiles |
-| [Quick Start](README.md#-quick-start)                          | 3-step install → connect → configure                                             |
+| Document                                                       | Description<br><img src="docs/screenshots/spacer.svg" width="680" height="1" alt=""> |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [User Guide](docs/guides/USER_GUIDE.md)                        | Providers, combos, CLI integration, deployment                                       |
+| [Setup Guide](docs/guides/SETUP_GUIDE.md)                      | Full install methods, CLI tool configs, protocol setup, timeout tuning               |
+| [CLI Tools Guide](docs/reference/CLI-TOOLS.md)                 | Per-tool setup for Claude Code, Codex, Cursor, Cline, OpenClaw, Kilo, Copilot        |
+| [Remote Mode](docs/guides/REMOTE-MODE.md)                      | Drive a remote OmniRoute (VPS) from your laptop CLI via scoped access tokens         |
+| [Claude Code Config](docs/guides/CLAUDE-CODE-CONFIGURATION.md) | Point Claude Code at OmniRoute (local/remote) with `launch` + per-model profiles     |
+| [Quick Start](README.md#-quick-start)                          | 3-step install → connect → configure                                                 |
 
 ### 🔧 Operations & Deployment
 
-| Document                                                 | Description                                                    |
-| -------------------------------------------------------- | -------------------------------------------------------------- |
-| [Docker Guide](docs/guides/DOCKER_GUIDE.md)              | Docker run, Compose profiles, Caddy HTTPS, tunnels, image tags |
-| [Podman Guide](contrib/podman/README.md)                 | Quadlet systemd integration, podman-compose, SELinux           |
-| [VM Deployment](docs/ops/VM_DEPLOYMENT_GUIDE.md)         | Complete guide: VM + nginx + Cloudflare setup                  |
-| [Fly.io Deployment](docs/ops/FLY_IO_DEPLOYMENT_GUIDE.md) | Deploy to Fly.io with persistent storage                       |
-| [Termux Guide](docs/guides/TERMUX_GUIDE.md)              | Run OmniRoute on Android via Termux                            |
-| [PWA Guide](docs/guides/PWA_GUIDE.md)                    | Progressive Web App install, caching, architecture             |
-| [Uninstall Guide](docs/guides/UNINSTALL.md)              | Clean removal for all install methods                          |
-| [Environment Config](docs/reference/ENVIRONMENT.md)      | Complete `.env` variables and references                       |
+| Document                                                 | Description<br><img src="docs/screenshots/spacer.svg" width="680" height="1" alt=""> |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Docker Guide](docs/guides/DOCKER_GUIDE.md)              | Docker run, Compose profiles, Caddy HTTPS, tunnels, image tags                       |
+| [Podman Guide](contrib/podman/README.md)                 | Quadlet systemd integration, podman-compose, SELinux                                 |
+| [VM Deployment](docs/ops/VM_DEPLOYMENT_GUIDE.md)         | Complete guide: VM + nginx + Cloudflare setup                                        |
+| [Fly.io Deployment](docs/ops/FLY_IO_DEPLOYMENT_GUIDE.md) | Deploy to Fly.io with persistent storage                                             |
+| [Termux Guide](docs/guides/TERMUX_GUIDE.md)              | Run OmniRoute on Android via Termux                                                  |
+| [PWA Guide](docs/guides/PWA_GUIDE.md)                    | Progressive Web App install, caching, architecture                                   |
+| [Uninstall Guide](docs/guides/UNINSTALL.md)              | Clean removal for all install methods                                                |
+| [Environment Config](docs/reference/ENVIRONMENT.md)      | Complete `.env` variables and references                                             |
 
 ### 🧠 Features & Architecture
 
-| Document                                                                     | Description                                                                   |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Architecture](docs/architecture/ARCHITECTURE.md)                            | System architecture, data flow, and internals                                 |
-| [Compression Guide](docs/compression/COMPRESSION_GUIDE.md)                   | 7-option pipeline: off / lite / standard / aggressive / ultra / RTK / stacked |
-| [RTK Compression](docs/compression/RTK_COMPRESSION.md)                       | Command-output compression, filters, trust, verify, raw-output recovery       |
-| [Compression Engines](docs/compression/COMPRESSION_ENGINES.md)               | Caveman, RTK, stacked pipelines, dashboard/API/MCP surfaces                   |
-| [Compression Rules Format](docs/compression/COMPRESSION_RULES_FORMAT.md)     | JSON rule-pack schemas for Caveman and RTK filters                            |
-| [Compression Language Packs](docs/compression/COMPRESSION_LANGUAGE_PACKS.md) | Language detection and Caveman rule-pack authoring                            |
-| [Resilience Guide](docs/architecture/RESILIENCE_GUIDE.md)                    | Circuit breakers, cooldowns, queue, anti-thundering herd, TLS spoofing        |
-| [Auto-Combo Engine](docs/routing/AUTO-COMBO.md)                              | 12-factor scoring, mode packs, self-healing                                    |
-| [Proxy Guide](docs/ops/PROXY_GUIDE.md)                                       | 3-level proxy system, 1proxy marketplace, registry CRUD                       |
-| [Free Tiers](docs/reference/FREE_TIERS.md)                                   | 25+ free API providers consolidated directory                                 |
-| [Features Gallery](docs/guides/FEATURES.md)                                  | Visual dashboard tour with screenshots                                        |
-| [Codebase Documentation](docs/architecture/CODEBASE_DOCUMENTATION.md)        | Beginner-friendly codebase walkthrough                                        |
+| Document                                                                     | Description<br><img src="docs/screenshots/spacer.svg" width="620" height="1" alt=""> |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Architecture](docs/architecture/ARCHITECTURE.md)                            | System architecture, data flow, and internals                                        |
+| [Compression Guide](docs/compression/COMPRESSION_GUIDE.md)                   | 7-option pipeline: off / lite / standard / aggressive / ultra / RTK / stacked        |
+| [RTK Compression](docs/compression/RTK_COMPRESSION.md)                       | Command-output compression, filters, trust, verify, raw-output recovery              |
+| [Compression Engines](docs/compression/COMPRESSION_ENGINES.md)               | Caveman, RTK, stacked pipelines, dashboard/API/MCP surfaces                          |
+| [Compression Rules Format](docs/compression/COMPRESSION_RULES_FORMAT.md)     | JSON rule-pack schemas for Caveman and RTK filters                                   |
+| [Compression Language Packs](docs/compression/COMPRESSION_LANGUAGE_PACKS.md) | Language detection and Caveman rule-pack authoring                                   |
+| [Resilience Guide](docs/architecture/RESILIENCE_GUIDE.md)                    | Circuit breakers, cooldowns, queue, anti-thundering herd, TLS spoofing               |
+| [Auto-Combo Engine](docs/routing/AUTO-COMBO.md)                              | 12-factor scoring, mode packs, self-healing                                          |
+| [Proxy Guide](docs/ops/PROXY_GUIDE.md)                                       | 3-level proxy system, 1proxy marketplace, registry CRUD                              |
+| [Free Tiers](docs/reference/FREE_TIERS.md)                                   | 25+ free API providers consolidated directory                                        |
+| [Features Gallery](docs/guides/FEATURES.md)                                  | Visual dashboard tour with screenshots                                               |
+| [Codebase Documentation](docs/architecture/CODEBASE_DOCUMENTATION.md)        | Beginner-friendly codebase walkthrough                                               |
 
 ### 🤖 Protocols & APIs
 
-| Document                                          | Description                                         |
-| ------------------------------------------------- | --------------------------------------------------- |
-| [API Reference](docs/reference/API_REFERENCE.md)  | All endpoints with examples                         |
-| [OpenAPI Spec](docs/openapi.yaml)                 | OpenAPI 3.0 specification                           |
-| [MCP Server](open-sse/mcp-server/README.md)       | 95 MCP tools, IDE configs, Python/TS/Go clients     |
-| [MCP Server Guide](docs/frameworks/MCP-SERVER.md) | MCP installation, transports, and tool reference    |
-| [A2A Server](src/lib/a2a/README.md)               | JSON-RPC 2.0 protocol, skills, streaming, task mgmt |
-| [A2A Server Guide](docs/frameworks/A2A-SERVER.md) | A2A agent card, tasks, skills, and streaming        |
+| Document                                          | Description<br><img src="docs/screenshots/spacer.svg" width="700" height="1" alt=""> |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [API Reference](docs/reference/API_REFERENCE.md)  | All endpoints with examples                                                          |
+| [OpenAPI Spec](docs/openapi.yaml)                 | OpenAPI 3.0 specification                                                            |
+| [MCP Server](open-sse/mcp-server/README.md)       | 95 MCP tools, IDE configs, Python/TS/Go clients                                      |
+| [MCP Server Guide](docs/frameworks/MCP-SERVER.md) | MCP installation, transports, and tool reference                                     |
+| [A2A Server](src/lib/a2a/README.md)               | JSON-RPC 2.0 protocol, skills, streaming, task mgmt                                  |
+| [A2A Server Guide](docs/frameworks/A2A-SERVER.md) | A2A agent card, tasks, skills, and streaming                                         |
 
 ### 📋 Project & Quality
 
-| Document                                           | Description                                     |
-| -------------------------------------------------- | ----------------------------------------------- |
-| [Contributing](CONTRIBUTING.md)                    | Development setup and guidelines                |
-| [Changelog](CHANGELOG.md)                          | Full per-version release history                |
-| [Security Policy](SECURITY.md)                     | Vulnerability reporting and security practices  |
-| [i18n Guide](docs/guides/I18N.md)                  | 40+ language support, translation workflow, RTL |
-| [Release Checklist](docs/ops/RELEASE_CHECKLIST.md) | Pre-release validation steps                    |
-| [Coverage Plan](docs/ops/COVERAGE_PLAN.md)         | Test coverage strategy and 21,000+ test suite   |
+| Document                                           | Description<br><img src="docs/screenshots/spacer.svg" width="690" height="1" alt=""> |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Contributing](CONTRIBUTING.md)                    | Development setup and guidelines                                                     |
+| [Changelog](CHANGELOG.md)                          | Full per-version release history                                                     |
+| [Security Policy](SECURITY.md)                     | Vulnerability reporting and security practices                                       |
+| [i18n Guide](docs/guides/I18N.md)                  | 40+ language support, translation workflow, RTL                                      |
+| [Release Checklist](docs/ops/RELEASE_CHECKLIST.md) | Pre-release validation steps                                                         |
+| [Coverage Plan](docs/ops/COVERAGE_PLAN.md)         | Test coverage strategy and 21,000+ test suite                                        |
 
 <br/>
 
@@ -1183,7 +1183,7 @@ OmniRoute stands on the shoulders of giants. It started as a fork of **[9router]
 | Project                                                                                        |    ⭐ | How it inspired OmniRoute                                                                                                                                                                                      |
 | ---------------------------------------------------------------------------------------------- | ----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **[TOON](https://github.com/toon-format/toon)** · toon-format                                  | 24.7k | Token-Oriented Object Notation — its columnar, header-plus-rows model shaped our tabular compaction stage.                                                                                                     |
-| **[GCF – Graph Compact Format](https://github.com/blackwell-systems/gcf)** · Blackwell Systems |    14 | First inspired our tabular compaction stage; now its zero-dependency, lossless generic-profile encoder is **vendored directly** as the Headroom codec (MIT, SPDX-marked), current with GCF spec v3.2. |
+| **[GCF – Graph Compact Format](https://github.com/blackwell-systems/gcf)** · Blackwell Systems |    14 | First inspired our tabular compaction stage; now its zero-dependency, lossless generic-profile encoder is **vendored directly** as the Headroom codec (MIT, SPDX-marked), current with GCF spec v3.2.          |
 | **[token-optimizer-mcp](https://github.com/ooples/token-optimizer-mcp)** · ooples              |   421 | Brotli/SQLite cache + per-session context-delta — inspired our `session-dedup` engine.                                                                                                                         |
 | **[token-savior](https://github.com/Mibayy/token-savior)** · Mibayy                            |  1.0k | Bash-output compaction + MCP profiles — inspired our compression bail-out discipline and MCP tool-manifest reduction.                                                                                          |
 | **[token-saver](https://github.com/ppgranger/token-saver)** · ppgranger                        |   110 | Content-aware, per-file-type output compression with failure-aware bail-out — validated our per-type dispatch and minimum-gain skip.                                                                           |

--- a/changelog.d/maintenance/7666-readme-tables-full-width.md
+++ b/changelog.d/maintenance/7666-readme-tables-full-width.md
@@ -1,0 +1,1 @@
+- README: standardized all 28 tables to the same full content width — 13 tables received a calibrated invisible header spacer (`docs/screenshots/spacer.svg`), 15 already rendered full-width naturally; zero data cells changed (#7666)

--- a/docs/screenshots/spacer.svg
+++ b/docs/screenshots/spacer.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>


### PR DESCRIPTION
## What

Makes every table in the root README render at the same full content width (~890px, the GitHub markdown column max), so narrow tables no longer look inconsistent next to naturally-wide ones.

- **28 tables audited** → **13 received an invisible width spacer**, **15 skipped** (14 already ≥890px natural width — GitHub's `width: max-content; max-width: 100%` clamps them to full width on its own — plus the screenshots gallery, excluded).
- Technique: a 1×1 transparent `docs/screenshots/spacer.svg` embedded as `<br><img src="docs/screenshots/spacer.svg" width="NNN" height="1" alt="">` in the header of each table's descriptive column — `width` on `<img>` is the only sizing attribute GitHub's sanitizer preserves. NNN calibrated per table (440–720) from measured column widths, targeting ~890px total.
- Tables touched: Zero-config `auto` (720) · 18 routing strategies (630) · Quota-Share knobs (670) · compression presets (540) · pricing tiers (540) · $0 free stack (440) · env vars (570) · troubleshooting (510) · the 5 Documentation tables (620–700).

## Audit

- Word-diff (whitespace-ignored) vs base: **27 changed lines = 13 headers + 14 delimiter rows — zero data cells touched** (no text, numbers, emoji or links modified).
- Prettier clean (`--check` passes); `check:docs-sync` and `check:docs-counts` green.
- Rendered result: https://github.com/diegosouzapw/OmniRoute/blob/docs/readme-tables-full-width/README.md

## Docs-only

README + one new 1×1 SVG asset — no production code touched.