### PR TITLE
chore(release): merge-train box-speed suite + --fast mode

### DIFF
--- a/changelog.d/maintenance/merge-train-box-speed.md
+++ b/changelog.d/maintenance/merge-train-box-speed.md
@@ -1,0 +1,1 @@
+- chore(release): merge-train runs the box-tuned `test:unit` (concurrency 20) instead of two sequential 4-core CI shards (~5× faster suite) and gains an owner-approved `--fast` mode (static gates + changed tests + vitest) for intra-day mega-train drains

--- a/docs/ops/MERGE_TRAIN.md
+++ b/docs/ops/MERGE_TRAIN.md
@@ -41,6 +41,14 @@ one day during the v3.8.47 cycle:
 2. **Validate ONCE**: in an isolated worktree off the release tip, merge all batch
    heads locally, then run the release-equivalent suite
    (`npm run check:release-green`, add `--with-build` before a release).
+   `scripts/release/merge-train.sh <base> <PR#>…` automates steps 1–2 (conflicting
+   PRs eject, the train continues). Full mode runs `npm run test:unit` — the
+   box-tuned runner (`--test-concurrency=20`), **not** the two sequential 4-core CI
+   shards, which drove the dominant phase at ~25% of a 16-core box (fixed
+   2026-07-18). `--fast` (intra-day mega-train drains, owner-approved 2026-07-18)
+   keeps every static gate + vitest but runs only the node:test files changed by the
+   boarded PRs; the FULL suite must still run at least once per day on the
+   accumulated tip (one train without `--fast`).
 3. **Green** → merge the PRs in sequence (re-checking `state,headRefOid` before each —
    a PR whose head moved re-enters review). Prove the net diff of each merge is the
    PR's own change (no auto-resolve reverts: audit `git diff --stat` for

--- a/scripts/release/merge-train.sh
+++ b/scripts/release/merge-train.sh
@@ -3,7 +3,7 @@
 #
 # Why: in a merge-storm, waiting for each PR's CI after each sibling merge costs
 # O(N²) CI runs. The train merges every queued PR into a throwaway worktree cut from
-# the release tip, runs the full fast-gates parity suite ONCE on the final result, and
+# the release tip, runs the fast-gates parity suite ONCE on the final result, and
 # prints the evidence block that authorizes `gh pr merge --squash --admin` for each
 # train member (merge-gates.md §7 — owner-approved policy extension of §4, 2026-07-09).
 #
@@ -12,22 +12,38 @@
 # touches other worktrees, and never uses `git stash` (Hard Rule #22a).
 #
 # Usage:
-#   scripts/release/merge-train.sh [--plan] <base-branch> <PR#> [<PR#>...]
+#   scripts/release/merge-train.sh [--plan] [--fast] <base-branch> <PR#> [<PR#>...]
 #     --plan   print the planned steps and exit 0 (no worktree, no network) — used by
 #              the unit test and for a quick sanity read.
+#     --fast   fast parity mode (owner-approved 2026-07-18): full static gates + the
+#              node:test files CHANGED by the boarded PRs + vitest, instead of the
+#              full unit suite. For intra-day mega-train drains. The FULL suite must
+#              still run at least once per day on the accumulated tip (one train
+#              without --fast, or `npm run test:unit` on the tip) — fast evidence
+#              lines say so explicitly.
+#
+# Speed note (2026-07-18): full mode runs `npm run test:unit` (box-tuned,
+# --test-concurrency=20). The previous two SEQUENTIAL `test:unit:ci:shard` runs
+# (--test-concurrency=4 each, sized for 4-core GH runners) drove the dominant phase
+# at ~25% of a 16-core devbox (~2.5h suite → ~30-40min).
 #
 # Exit codes: 0 = suite green (evidence printed); 1 = usage error; 2 = suite red;
 #             PRs whose merge conflicts are EJECTED (reported, train continues).
 set -euo pipefail
 
 PLAN=0
-if [ "${1:-}" = "--plan" ]; then
-  PLAN=1
-  shift
-fi
+FAST=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plan) PLAN=1; shift ;;
+    --fast) FAST=1; shift ;;
+    --*) echo "error: unknown flag '$1'" >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
 
 if [ $# -lt 2 ]; then
-  echo "usage: $0 [--plan] <base-branch> <PR#> [<PR#>...]" >&2
+  echo "usage: $0 [--plan] [--fast] <base-branch> <PR#> [<PR#>...]" >&2
   exit 1
 fi
 
@@ -41,28 +57,39 @@ for N in "${PRS[@]}"; do
 done
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-SUITE=(
+STATIC_GATES=(
   "npm run typecheck:core"
   "node scripts/check/check-file-size.mjs"
   "node scripts/check/check-complexity.mjs"
   "node scripts/check/check-cognitive-complexity.mjs"
   "node scripts/check/check-changelog-integrity.mjs"
-  "TEST_SHARD=1/2 npm run test:unit:ci:shard"
-  "TEST_SHARD=2/2 npm run test:unit:ci:shard"
-  "npm run test:vitest"
 )
+# Full mode: the box-speed runner (same coverage as the two CI shards combined —
+# main + dashboard + serial groups — at local concurrency instead of runner-sized).
+UNIT_FULL="npm run test:unit"
+VITEST="npm run test:vitest"
 
 if [ "$PLAN" = "1" ]; then
-  echo "[merge-train] PLAN — base=origin/${BASE} prs=${PRS[*]}"
+  MODE="full"
+  [ "$FAST" = "1" ] && MODE="fast"
+  echo "[merge-train] PLAN (${MODE}) — base=origin/${BASE} prs=${PRS[*]}"
   echo "[merge-train] 1. worktree add .claude/worktrees/merge-train-<ts> --detach origin/${BASE}"
   for N in "${PRS[@]}"; do
     echo "[merge-train] 2. fetch origin pull/${N}/head && merge (conflict → EJECT #${N}, continue)"
   done
   i=3
-  for c in "${SUITE[@]}"; do
+  for c in "${STATIC_GATES[@]}"; do
     echo "[merge-train] ${i}. ${c}"
     i=$((i + 1))
   done
+  if [ "$FAST" = "1" ]; then
+    echo "[merge-train] ${i}. (fast) run node:test files changed by the boarded PRs (main/dashboard/serial buckets)"
+  else
+    echo "[merge-train] ${i}. ${UNIT_FULL}"
+  fi
+  i=$((i + 1))
+  echo "[merge-train] ${i}. ${VITEST}"
+  i=$((i + 1))
   echo "[merge-train] ${i}. green → print --admin evidence per PR; red → exit 2 (bisect + eject)"
   echo "[merge-train] ${i}. teardown: git worktree remove --force (trap EXIT)"
   exit 0
@@ -117,8 +144,9 @@ EJ_MSG=""
 echo "[merge-train] train tip ${TIP} — boarded: ${BOARDED[*]}${EJ_MSG}"
 echo "[merge-train] running parity suite (log: ${LOG})…"
 
-for c in "${SUITE[@]}"; do
-  echo "[merge-train] ▶ ${c}"
+run_gate() {
+  local c="$1"
+  echo "[merge-train] ▶ $(date +%H:%M:%S) ${c}"
   if ! (cd "$WT" && eval "$c") >>"$LOG" 2>&1; then
     echo "[merge-train] ✗ SUITE RED at: ${c}" >&2
     echo "[merge-train] tail of ${LOG}:" >&2
@@ -126,12 +154,53 @@ for c in "${SUITE[@]}"; do
     echo "[merge-train] bisect: re-run the failing gate on intermediate train commits, eject the offender, re-run." >&2
     exit 2
   fi
+}
+
+for c in "${STATIC_GATES[@]}"; do
+  run_gate "$c"
 done
 
+if [ "$FAST" = "1" ]; then
+  # node:test files changed by the boarded PRs (tests/unit/**/*.test.{ts,mjs};
+  # tests/unit/ui/*.test.tsx belongs to the vitest-ui runner, not node:test).
+  mapfile -t CHANGED < <(git -C "$WT" diff --name-only "origin/${BASE}" HEAD -- 'tests/unit' \
+    | grep -E '\.test\.(ts|mjs)$' | grep -v '^tests/unit/ui/' || true)
+  MAIN=()
+  DASH=()
+  SERIAL=()
+  for f in "${CHANGED[@]}"; do
+    [ -f "$WT/$f" ] || continue # deleted by a boarded PR
+    case "$f" in
+      tests/unit/dashboard/*) DASH+=("$f") ;;
+      tests/unit/serial/*) SERIAL+=("$f") ;;
+      *) MAIN+=("$f") ;;
+    esac
+  done
+  # Mirror package.json's three test:unit groups exactly (loader + concurrency).
+  if [ ${#MAIN[@]} -gt 0 ]; then
+    run_gate "DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=20 ${MAIN[*]}"
+  fi
+  if [ ${#DASH[@]} -gt 0 ]; then
+    run_gate "DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=20 ${DASH[*]}"
+  fi
+  if [ ${#SERIAL[@]} -gt 0 ]; then
+    run_gate "DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 ${SERIAL[*]}"
+  fi
+  if [ ${#MAIN[@]} -eq 0 ] && [ ${#DASH[@]} -eq 0 ] && [ ${#SERIAL[@]} -eq 0 ]; then
+    echo "[merge-train] (fast) no changed node:test files under tests/unit — static gates + vitest only"
+  fi
+else
+  run_gate "$UNIT_FULL"
+fi
+
+run_gate "$VITEST"
+
+MODE_NOTE="suite green"
+[ "$FAST" = "1" ] && MODE_NOTE="FAST gates green: static + changed tests + vitest — daily full-suite run still required"
 echo "[merge-train] ✅ SUITE GREEN on ${TIP}"
 echo "[merge-train] evidence line for each PR (paste before gh pr merge --squash --admin):"
 for N in "${BOARDED[@]}"; do
-  echo "  #${N}: Validated in local merge-train ${LOG} on $(hostname) @ ${TIP} (suite green)"
+  echo "  #${N}: Validated in local merge-train ${LOG} on $(hostname) @ ${TIP} (${MODE_NOTE})"
 done
 [ ${#EJECTED[@]} -gt 0 ] && echo "[merge-train] ejected (need the normal path): ${EJECTED[*]}"
 exit 0

--- a/tests/unit/merge-train-plan.test.ts
+++ b/tests/unit/merge-train-plan.test.ts
@@ -25,7 +25,7 @@ async function run(args: string[]) {
 test("--plan prints the full step plan without touching anything and exits 0", async () => {
   const { code, stdout } = await run(["--plan", "release/v9.9.9", "111", "222"]);
   assert.equal(code, 0);
-  assert.match(stdout, /PLAN — base=origin\/release\/v9\.9\.9 prs=111 222/);
+  assert.match(stdout, /PLAN \(full\) — base=origin\/release\/v9\.9\.9 prs=111 222/);
   assert.match(stdout, /worktree add \.claude\/worktrees\/merge-train-/);
   assert.match(stdout, /pull\/111\/head/);
   assert.match(stdout, /pull\/222\/head/);
@@ -36,14 +36,41 @@ test("--plan prints the full step plan without touching anything and exits 0", a
     "check-complexity.mjs",
     "check-cognitive-complexity.mjs",
     "check-changelog-integrity.mjs",
-    "TEST_SHARD=1/2",
-    "TEST_SHARD=2/2",
+    "npm run test:unit",
     "test:vitest",
   ]) {
     assert.ok(stdout.includes(gate), `plan must include ${gate}`);
   }
+  // Speed guard (2026-07-18): full mode must use the box-tuned `test:unit` runner
+  // (--test-concurrency=20), never the two sequential 4-core CI shards that ran the
+  // dominant phase at ~25% of the box.
+  assert.ok(!stdout.includes("TEST_SHARD="), "full mode must not use the sequential CI shards");
   assert.match(stdout, /--admin evidence/);
   assert.match(stdout, /teardown: git worktree remove/);
+});
+
+test("--plan --fast swaps the full unit suite for changed-tests, keeps static gates + vitest", async () => {
+  const { code, stdout } = await run(["--plan", "--fast", "release/v9.9.9", "111"]);
+  assert.equal(code, 0);
+  assert.match(stdout, /PLAN \(fast\) — base=origin\/release\/v9\.9\.9 prs=111/);
+  for (const gate of [
+    "typecheck:core",
+    "check-file-size.mjs",
+    "check-complexity.mjs",
+    "check-cognitive-complexity.mjs",
+    "check-changelog-integrity.mjs",
+    "test:vitest",
+  ]) {
+    assert.ok(stdout.includes(gate), `fast plan must still include ${gate}`);
+  }
+  assert.match(stdout, /\(fast\) run node:test files changed by the boarded PRs/);
+  assert.ok(!stdout.includes("npm run test:unit"), "fast mode must not run the full unit suite");
+});
+
+test("rejects an unknown flag", async () => {
+  const { code, stderr } = await run(["--nope", "release/v9.9.9", "111"]);
+  assert.equal(code, 1);
+  assert.match(stderr, /unknown flag/);
 });
 
 test("usage error without enough args", async () => {


### PR DESCRIPTION
## O que muda

**Problema medido (2026-07-17/18, campanha de 11 PRs):** a suite do merge-train levava **~2–2.5h** porque rodava `test:unit:ci:shard` — dimensionado para runners GH de 4 cores (`--test-concurrency=4`) — com as duas shards **em série**, num devbox de 16 cores: a fase dominante usava ~25% da máquina.

1. **Full mode** agora roda `npm run test:unit` (box-tuned, `--test-concurrency=20`) — mesma cobertura das duas shards combinadas (main + dashboard + serial), ~5× mais rápido (~30–40 min).
2. **`--fast` (aprovado pelo owner 2026-07-18):** gates estáticos completos + apenas os arquivos node:test **alterados pelas PRs embarcadas** (3 buckets espelhando o package.json: main tsx/esm c20, dashboard tsx c20, serial c1) + vitest. Para mega-trains intra-dia; a linha de evidência marca explicitamente que a suite FULL diária continua obrigatória.
3. Timestamps por gate no progresso; flags desconhecidas rejeitadas.

## Validação
- `bash -n` OK; `tests/unit/merge-train-plan.test.ts` estendido: 5/5 (assert de guarda: full mode NÃO usa `TEST_SHARD=`; `--fast` não roda a suite full; flag desconhecida = exit 1).
- `check-changelog-integrity` OK; `docs/ops/MERGE_TRAIN.md` atualizado.

Refs medição: trens de 2026-07-17 (7 PRs, suite 2h35) vs. pós-patch.