### PR TITLE
fix(dashboard): cut UI import chain from connection persist module (CI shard 2/4 base-red)

### DIFF
--- a/changelog.d/maintenance/agentrouter-test-import-chain.md
+++ b/changelog.d/maintenance/agentrouter-test-import-chain.md
@@ -1,0 +1,1 @@
+- chore(quality): extract pure provider input parsers to a leaf module so the agentrouter persist test no longer drags the UI import graph (@lobehub/icons ESM build crashed Node 24's CJS require in the CI unit shard)

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts
@@ -1,4 +1,4 @@
-import { parseExcludedModelsInput, parseRoutingTagsInput } from "../../providerPageHelpers";
+import { parseExcludedModelsInput, parseRoutingTagsInput } from "../../providerInputParsers";
 import {
   assignCcCompatibleRequestDefaults,
   mergeCcCompatibleRequestDefaults,

--- a/src/app/(dashboard)/dashboard/providers/[id]/providerInputParsers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerInputParsers.ts
@@ -1,0 +1,29 @@
+// Pure input parsers for provider connection forms — extracted as a leaf module
+// (no React/UI imports) so server-safe consumers like
+// connectionProviderSpecificData.ts (and its node:test suite) can import them
+// without dragging providerPageHelpers' UI import graph (@lobehub/icons ESM build
+// crashes Node's CJS require in the CI unit shard — 2026-07-18).
+
+export function parseRoutingTagsInput(value: string): string[] | undefined {
+  const tags = Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((tag) => tag.trim().toLowerCase())
+        .filter(Boolean)
+    )
+  );
+  return tags.length > 0 ? tags : undefined;
+}
+
+export function parseExcludedModelsInput(value: string): string[] | undefined {
+  const patterns = Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((pattern) => pattern.trim())
+        .filter(Boolean)
+    )
+  );
+  return patterns.length > 0 ? patterns : undefined;
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
@@ -340,29 +340,10 @@ export function isGlmProvider(providerId?: string | null) {
 // Routing-tags / excluded-models parse + format
 // ---------------------------------------------------------------------------
 
-export function parseRoutingTagsInput(value: string): string[] | undefined {
-  const tags = Array.from(
-    new Set(
-      value
-        .split(",")
-        .map((tag) => tag.trim().toLowerCase())
-        .filter(Boolean)
-    )
-  );
-  return tags.length > 0 ? tags : undefined;
-}
 
-export function parseExcludedModelsInput(value: string): string[] | undefined {
-  const patterns = Array.from(
-    new Set(
-      value
-        .split(",")
-        .map((pattern) => pattern.trim())
-        .filter(Boolean)
-    )
-  );
-  return patterns.length > 0 ? patterns : undefined;
-}
+// parseRoutingTagsInput / parseExcludedModelsInput moved to the pure leaf
+// providerInputParsers.ts (kept re-exported here for existing UI importers).
+export { parseExcludedModelsInput, parseRoutingTagsInput } from "./providerInputParsers";
 
 export function formatRoutingTagsInput(value: unknown): string {
   if (!Array.isArray(value)) return "";


### PR DESCRIPTION
**Base-red em TODO PR desde o merge do #7653**: `tests/unit/agentrouter-connection-modal-fields.test.ts` importa `connectionProviderSpecificData.ts`, cujo 1º import (`providerPageHelpers`) alcança `@lobehub/icons` — o build `es/` (ESM sem `type:module`) sob o Node 24 do runner cai no `require()` CJS → `SyntaxError: Unexpected token 'export'` → **Unit shard 2/4 vermelho em todos os PRs** (não reproduz no devbox; log: run 29639944535).

**Fix cirúrgico**: extrai `parseRoutingTagsInput`/`parseExcludedModelsInput` para o leaf puro `providerInputParsers.ts` (sem imports de UI), re-exporta em `providerPageHelpers` (API preservada) e aponta o módulo de persist para o leaf.

**Validação**: teste 6/6 com o harness exato da shard; módulo de persist carrega SEM a cadeia de UI (provado por import seco); typecheck:core, eslint, file-size, complexity (2056≤2058), cognitive (889≤890), test-discovery, dashboard-typecheck, changelog-integrity — todos OK.