### PR TITLE
[subsumed] fix(combo): derive session stickiness key from Responses API .input (#7270)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -67,6 +67,7 @@ import { estimateTokens } from "./contextManager.ts";
 import { getSessionConnection } from "./sessionManager.ts";
 import {
   applySessionStickiness,
+  extractStickinessMessages,
   recordStickyBinding,
   clearStickyBinding,
   peekStickyConnectionId,
@@ -1242,10 +1243,7 @@ export async function handleComboChat({
   );
   const _sticky = disableSessionStickiness
     ? ({ targets: orderedTargets, messageHash: null, stuck: false } as const)
-    : await applySessionStickiness(
-        orderedTargets,
-        body.messages as Array<{ role?: string; content?: unknown }>
-      );
+    : await applySessionStickiness(orderedTargets, extractStickinessMessages(body));
   orderedTargets = _sticky.targets;
   orderedTargets = orderTargetsByEvalScores(orderedTargets, config.evalRouting, log);
   orderedTargets = filterTargetsByRequestCompatibility(orderedTargets, body, log);
@@ -2666,10 +2664,7 @@ async function handleRoundRobinCombo({
   );
   const _rrSessionSticky = disableSessionStickiness
     ? ({ targets: filteredTargets, messageHash: null, stuck: false } as const)
-    : await applySessionStickiness(
-        filteredTargets,
-        body?.messages as Array<{ role?: string; content?: unknown }>
-      );
+    : await applySessionStickiness(filteredTargets, extractStickinessMessages(body));
   let rrStartIndex = startIndex;
   if (_rrSessionSticky.stuck) {
     const stickyIdx = filteredTargets.findIndex(

--- a/open-sse/services/combo/sessionStickiness.ts
+++ b/open-sse/services/combo/sessionStickiness.ts
@@ -283,6 +283,52 @@ export function deriveMessageHash(
   return createHash("sha256").update(text).digest("hex").slice(0, 16);
 }
 
+/**
+ * Normalize a request body into the `messages`-shaped array `deriveMessageHash`
+ * consumes, covering BOTH wire formats combo routing can receive (#7270):
+ *
+ * - Chat Completions (`/v1/chat/completions`): the turn lives in `.messages`.
+ * - Responses API (`/v1/responses`): the turn lives in `.input`, never
+ *   `.messages`. `.input` is either a raw prompt string or an array of input
+ *   items (`{ role, content }`, where content is a string or `input_text`
+ *   parts) — both shapes `deriveMessageHash` already understands once wrapped.
+ *
+ * Combo target ordering runs BEFORE per-target format translation, so the body
+ * reaching `applySessionStickiness` is still raw. Passing `body.messages`
+ * directly (its historical argument) resolves to `undefined` for every
+ * Responses-API request, silently disabling session stickiness across the whole
+ * `/v1/responses` surface. Deriving the key from this normalized view fixes that
+ * without teaching `deriveMessageHash` about multiple wire formats.
+ *
+ * Mirrors the same `.messages` → `.input` fallback already used for handoff
+ * source extraction in combo.ts. Returns `null` (fail-open) when neither shape
+ * carries a usable turn.
+ */
+export function extractStickinessMessages(
+  body: { messages?: unknown; input?: unknown } | null | undefined
+): Array<{ role?: string; content?: unknown }> | null {
+  if (!body || typeof body !== "object") return null;
+
+  const { messages, input } = body as { messages?: unknown; input?: unknown };
+
+  if (Array.isArray(messages) && messages.length > 0) {
+    return messages as Array<{ role?: string; content?: unknown }>;
+  }
+
+  // Responses API: a bare string prompt is the single user turn.
+  if (typeof input === "string" && input.length > 0) {
+    return [{ role: "user", content: input }];
+  }
+
+  // Responses API: an array of input items — deriveMessageHash picks the first
+  // `role: "user"` entry and hashes its text parts, so pass it through as-is.
+  if (Array.isArray(input) && input.length > 0) {
+    return input as Array<{ role?: string; content?: unknown }>;
+  }
+
+  return null;
+}
+
 /** Evict expired entries and enforce the hard cap. */
 function evict(): void {
   const now = Date.now();

--- a/tests/unit/session-stickiness-responses-input-7270.test.ts
+++ b/tests/unit/session-stickiness-responses-input-7270.test.ts
@@ -1,0 +1,170 @@
+/**
+ * tests/unit/session-stickiness-responses-input-7270.test.ts
+ *
+ * Regression guard for #7270 — combo session stickiness was a silent no-op for
+ * the entire OpenAI Responses API (`/v1/responses`) surface.
+ *
+ * Root cause: the stickiness key was derived exclusively from `body.messages`,
+ * but Responses-API requests carry the turn in `.input` (string or item array)
+ * and never populate `.messages`. The key resolved to `null`, stickiness failed
+ * open, and every request was re-ordered as if stickiness were disabled.
+ *
+ * Fix: `extractStickinessMessages(body)` normalizes both wire shapes into the
+ * `messages`-shaped array `deriveMessageHash` consumes, and the two combo call
+ * sites pass it instead of `body.messages`.
+ *
+ * Design: fully deterministic — saturation / connection-health are injected via
+ * the existing test seams; no network, no DB.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { HeadroomSaturation } from "../../open-sse/services/combo/headroomRanking.ts";
+
+const mod = await import("../../open-sse/services/combo/sessionStickiness.ts");
+const {
+  deriveMessageHash,
+  extractStickinessMessages,
+  applySessionStickiness,
+  recordStickyBinding,
+  clearAllStickyBindings,
+  __setStickinessHeadroomFetcherForTests,
+  __setStickinessConnectionFetcherForTests,
+  __setStickinessQuotaCheckerForTests,
+} = mod;
+
+function makeTarget(
+  connectionId: string
+): import("../../open-sse/services/combo/types.ts").ResolvedComboTarget {
+  return {
+    kind: "model",
+    stepId: `step-${connectionId}`,
+    executionKey: `key-${connectionId}`,
+    modelStr: `gpt-4/${connectionId}`,
+    provider: "openai",
+    providerId: null,
+    connectionId,
+    weight: 1,
+    label: null,
+  };
+}
+
+function injectSat(sat: HeadroomSaturation | undefined): void {
+  __setStickinessHeadroomFetcherForTests(async (_id: string) => sat);
+}
+
+test.beforeEach(() => {
+  clearAllStickyBindings();
+  // Healthy connection: headroom = 1.0, no terminal status, quota not exhausted.
+  injectSat({ util5h: 0, util7d: 0 });
+  __setStickinessConnectionFetcherForTests(async () => ({
+    testStatus: "active",
+    rateLimitedUntil: null,
+  }));
+  __setStickinessQuotaCheckerForTests(() => false);
+});
+
+test.after(() => {
+  __setStickinessHeadroomFetcherForTests(null);
+  __setStickinessConnectionFetcherForTests(null);
+  __setStickinessQuotaCheckerForTests(null);
+});
+
+// ─── extractStickinessMessages — normalization ───────────────────────────────
+
+test("extractStickinessMessages: Responses API string `.input` → single user turn", () => {
+  const normalized = extractStickinessMessages({ input: "Hello from responses" });
+  assert.deepEqual(normalized, [{ role: "user", content: "Hello from responses" }]);
+  assert.ok(deriveMessageHash(normalized) !== null, "hash derivable from string input");
+});
+
+test("extractStickinessMessages: Responses API item-array `.input` → hashable", () => {
+  const body = {
+    input: [
+      { role: "user", content: [{ type: "input_text", text: "First responses turn" }] },
+    ],
+  };
+  const normalized = extractStickinessMessages(body);
+  assert.ok(Array.isArray(normalized) && normalized.length === 1);
+  const hash = deriveMessageHash(normalized);
+  assert.ok(hash !== null, "hash derivable from item-array input");
+  assert.match(hash!, /^[a-f0-9]{16}$/);
+});
+
+test("extractStickinessMessages: Chat Completions `.messages` still passes through", () => {
+  const messages = [{ role: "user", content: "Chat completions turn" }];
+  assert.strictEqual(extractStickinessMessages({ messages }), messages);
+});
+
+test("extractStickinessMessages: `.messages` wins over `.input` when both present", () => {
+  const messages = [{ role: "user", content: "prefer messages" }];
+  assert.strictEqual(extractStickinessMessages({ messages, input: "ignored" }), messages);
+});
+
+test("extractStickinessMessages: empty / missing shapes → null (fail-open)", () => {
+  assert.equal(extractStickinessMessages({}), null);
+  assert.equal(extractStickinessMessages({ messages: [], input: "" }), null);
+  assert.equal(extractStickinessMessages({ input: [] }), null);
+  assert.equal(extractStickinessMessages(null), null);
+  assert.equal(extractStickinessMessages(undefined), null);
+});
+
+// ─── The bug: Responses-API body must not silently disable stickiness ─────────
+
+test("BUG #7270: raw `body.messages` yields no key for a Responses-API body", () => {
+  // This is exactly what the old call sites passed: body.messages === undefined.
+  const responsesBody = { input: "Same conversation" };
+  assert.equal(
+    deriveMessageHash(
+      (responsesBody as { messages?: Array<{ role?: string; content?: unknown }> }).messages
+    ),
+    null,
+    "old path resolves to null → stickiness no-ops"
+  );
+  // The fix path derives a stable key instead.
+  assert.ok(
+    deriveMessageHash(extractStickinessMessages(responsesBody)) !== null,
+    "normalized path resolves to a real key"
+  );
+});
+
+test("Responses API `.input` conversation pins to one connection across requests", async () => {
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B"), makeTarget("conn-C")];
+  const responsesBody = { input: "Pin this whole conversation" };
+
+  const hash = deriveMessageHash(extractStickinessMessages(responsesBody))!;
+  assert.ok(hash, "hash must be derivable from the Responses-API body");
+
+  // First successful request bound the conversation to conn-B.
+  recordStickyBinding(hash, "conn-B");
+
+  // Second request of the same conversation (same `.input`) must stick to conn-B.
+  const r1 = await applySessionStickiness(targets, extractStickinessMessages(responsesBody));
+  assert.ok(r1.stuck, "should be stuck for the Responses-API conversation");
+  assert.equal(r1.targets[0].connectionId, "conn-B");
+
+  // Repeat — still pinned.
+  const r2 = await applySessionStickiness(targets, extractStickinessMessages(responsesBody));
+  assert.ok(r2.stuck);
+  assert.equal(r2.targets[0].connectionId, "conn-B");
+});
+
+test("Different Responses API conversations spread across connections", async () => {
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+
+  const convo1 = { input: "conversation one" };
+  const convo2 = { input: "conversation two" };
+
+  const h1 = deriveMessageHash(extractStickinessMessages(convo1))!;
+  const h2 = deriveMessageHash(extractStickinessMessages(convo2))!;
+  assert.notEqual(h1, h2, "distinct conversations must produce distinct keys");
+
+  recordStickyBinding(h1, "conn-A");
+  recordStickyBinding(h2, "conn-B");
+
+  const r1 = await applySessionStickiness(targets, extractStickinessMessages(convo1));
+  const r2 = await applySessionStickiness(targets, extractStickinessMessages(convo2));
+
+  assert.equal(r1.targets[0].connectionId, "conn-A");
+  assert.equal(r2.targets[0].connectionId, "conn-B");
+});


### PR DESCRIPTION
## Problem

Combo **session stickiness** is a silent no-op for the entire OpenAI **Responses API** (`/v1/responses`) surface. A user on round-robin / random / strict-random with "session stickiness" enabled reported that the *same* conversation kept bouncing between accounts, exactly as if stickiness were off — but only on the Responses API. Chat Completions (`/v1/chat/completions`) was unaffected.

## Root cause

The stickiness key is derived exclusively from `body.messages`:

- `deriveMessageHash` (`open-sse/services/combo/sessionStickiness.ts`) guards on `Array.isArray(messages)`, then hashes the first `role: "user"` turn; it returns `null` (fail-open, silent) when `messages` is not an array.
- The two combo call sites passed `body.messages` directly:
  - `open-sse/services/combo.ts` (main strategy path)
  - `open-sse/services/combo.ts` (round-robin path)

Responses-API requests carry the turn in `.input` (a raw prompt string, or an array of input items), and **never populate `.messages`**. Combo target ordering runs *before* per-target format translation (`translateRequest` happens inside `handleSingleModel`), so the body reaching `applySessionStickiness` is still the raw Responses-API shape. `body.messages` is therefore `undefined` for every `/v1/responses` request → `deriveMessageHash(undefined)` → `null` → stickiness no-ops. Not strategy-gated; the body shape is the bug.

## Fix

Add `extractStickinessMessages(body)` in `sessionStickiness.ts`, which normalizes **both** wire shapes into the `messages`-shaped array `deriveMessageHash` already consumes:

- `.messages` (array, non-empty) → passed through unchanged;
- Responses API `.input` as a string → wrapped into a single `{ role: "user", content }` turn;
- Responses API `.input` as an item array → passed through (`deriveMessageHash` picks the first `role: "user"` item and hashes its text parts);
- otherwise → `null` (fail-open preserved).

This mirrors the exact `.messages` → `.input` fallback already used for handoff-source extraction elsewhere in `combo.ts`, and keeps `deriveMessageHash` agnostic of wire format. Both `applySessionStickiness` call sites now pass `extractStickinessMessages(body)`.

## Verification

TDD (Hard Rule #18) — `tests/unit/session-stickiness-responses-input-7270.test.ts`.

**RED** (fix reverted, test present):

```
$ node --import tsx/esm --test tests/unit/session-stickiness-responses-input-7270.test.ts
not ok 1 - extractStickinessMessages: Responses API string `.input` → single user turn
  error: 'extractStickinessMessages is not a function'
...
# tests 8
# pass 0
# fail 8
```

**GREEN** (fix applied):

```
$ node --import tsx/esm --test tests/unit/session-stickiness-responses-input-7270.test.ts
# tests 8
# pass 8
# fail 0
```

Neighbouring stickiness suites still green (no regression):

```
$ node --import tsx/esm --test \
    tests/unit/combo-session-stickiness.test.ts \
    tests/unit/combo-rr-session-stickiness-3825.test.ts \
    tests/unit/combo-disable-session-stickiness.test.ts \
    tests/unit/combo-sessionless-pin-3825.test.ts
# tests 37
# pass 37
# fail 0
```

Lint + typecheck clean on the changed files:

```
$ npx eslint --suppressions-location config/quality/eslint-suppressions.json \
    open-sse/services/combo/sessionStickiness.ts open-sse/services/combo.ts \
    tests/unit/session-stickiness-responses-input-7270.test.ts   # exit 0
$ npm run typecheck:core                                          # exit 0
```

The regression test asserts the acceptance criteria from the issue: a `/v1/responses` `.input` conversation pins to one connection across requests, distinct conversations still spread across connections, and Chat Completions `.messages` behavior is unchanged.

## Diff summary

- `open-sse/services/combo/sessionStickiness.ts` — new exported `extractStickinessMessages(body)` helper.
- `open-sse/services/combo.ts` — import it; both `applySessionStickiness` call sites now normalize the body instead of reading `body.messages`.
- `tests/unit/session-stickiness-responses-input-7270.test.ts` — new regression guard (8 tests).

Closes #7270.

Thanks for the exceptionally precise root-cause write-up on the issue — it pointed straight at the `.input`/`.messages` gap.
