### PR TITLE
fix(ci): merge-train --fast mirrors test:unit subdir allowlist

### DIFF
--- a/changelog.d/maintenance/merge-train-unit-subdir-allowlist.md
+++ b/changelog.d/maintenance/merge-train-unit-subdir-allowlist.md
@@ -1,0 +1,4 @@
+- **chore(release):** merge-train `--fast` now classifies changed tests with the same
+  `tests/unit/{…}` subdir allowlist `test:unit` runs — vitest-only subdirs (e.g.
+  `tests/unit/autoCombo/`) are skipped instead of misrun under node:test, and
+  `tests/unit/ui/**/*.test.ts` (node:test) is no longer over-excluded.

--- a/scripts/release/merge-train.sh
+++ b/scripts/release/merge-train.sh
@@ -164,7 +164,10 @@ if [ "$FAST" = "1" ]; then
   # node:test files changed by the boarded PRs (tests/unit/**/*.test.{ts,mjs};
   # tests/unit/ui/*.test.tsx belongs to the vitest-ui runner, not node:test).
   mapfile -t CHANGED < <(git -C "$WT" diff --name-only "origin/${BASE}" HEAD -- 'tests/unit' \
-    | grep -E '\.test\.(ts|mjs)$' | grep -v '^tests/unit/ui/' || true)
+    | grep -E '\.test\.(ts|mjs)$' || true)
+  # Subdirs test:unit actually runs (package.json allowlist) — anything else under
+  # tests/unit/<sub>/ belongs to another runner (e.g. autoCombo -> vitest).
+  UNIT_SUBDIRS=",api,auth,authz,build,cli,cli-helper,combo,compression,correctness,cors,db,db-adapters,docs,gamification,guardrails,lib,mcp,memory,runtime,security,services,settings,shared,ui,usage,"
   MAIN=()
   DASH=()
   SERIAL=()
@@ -173,6 +176,13 @@ if [ "$FAST" = "1" ]; then
     case "$f" in
       tests/unit/dashboard/*) DASH+=("$f") ;;
       tests/unit/serial/*) SERIAL+=("$f") ;;
+      *.test.mjs) MAIN+=("$f") ;; # tests/unit/**/*.test.mjs runs from any subdir
+      tests/unit/*/*)
+        sub="${f#tests/unit/}"; sub="${sub%%/*}"
+        case "$UNIT_SUBDIRS" in
+          *",${sub},"*) MAIN+=("$f") ;;
+          *) echo "[merge-train] (fast) skip ${f} — subdir '${sub}' not in test:unit (other runner)" ;;
+        esac ;;
       *) MAIN+=("$f") ;;
     esac
   done

--- a/tests/unit/merge-train-plan.test.ts
+++ b/tests/unit/merge-train-plan.test.ts
@@ -5,6 +5,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -65,6 +66,21 @@ test("--plan --fast swaps the full unit suite for changed-tests, keeps static ga
   }
   assert.match(stdout, /\(fast\) run node:test files changed by the boarded PRs/);
   assert.ok(!stdout.includes("npm run test:unit"), "fast mode must not run the full unit suite");
+});
+
+test("fast mode's UNIT_SUBDIRS allowlist mirrors package.json test:unit exactly", async () => {
+  // Regression for the 2026-07-18 train red: tests/unit/autoCombo/ (a vitest-only
+  // subdir) was fed to the node:test bucket because the fast filter had no subdir
+  // allowlist. The script must classify changed tests with the SAME subdir set
+  // test:unit runs, so files owned by another runner are skipped, not misrun.
+  const script = await readFile(SCRIPT, "utf8");
+  const scriptList = script.match(/UNIT_SUBDIRS=",([^"]+),"/)?.[1];
+  assert.ok(scriptList, "merge-train.sh must declare the UNIT_SUBDIRS allowlist");
+  const pkg = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8"));
+  const pkgList = pkg.scripts["test:unit"].match(/tests\/unit\/\{([^}]+)\}/)?.[1];
+  assert.ok(pkgList, "package.json test:unit must carry the {subdir} allowlist glob");
+  assert.equal(scriptList, pkgList, "merge-train.sh UNIT_SUBDIRS must equal test:unit's subdir set");
+  assert.ok(!scriptList.split(",").includes("autoCombo"), "autoCombo belongs to vitest, not node:test");
 });
 
 test("rejects an unknown flag", async () => {


### PR DESCRIPTION
## O que
O bucket node:test do modo `--fast` do merge-train alimentava TODO arquivo mudado sob `tests/unit/` — inclusive subdirs de outro runner. `tests/unit/autoCombo/` é vitest-only (importa `vi`), então qualquer PR tocando um teste de lá avermelhava o train com um falso defeito (aconteceu hoje no train da fila-104: `provider-family-combos.test.ts` red no tip puro sob node:test).

## Fix
- O classificador agora carrega a MESMA allowlist de subdirs `{api,auth,…}` que o `test:unit` do package.json; arquivo de subdir fora dela é pulado com log explícito (`skip … — subdir 'autoCombo' not in test:unit (other runner)`) — o vitest continua cobrindo-o no gate seguinte do próprio train.
- Remove o over-exclude de `tests/unit/ui/`: o `test:unit` RODA `ui/**/*.test.ts` (só `.tsx` pertence ao vitest-ui, e a extensão já filtra).
- `**/*.test.mjs` continua indo ao bucket main de qualquer subdir (paridade com o glob do package.json).

## Validação (TDD)
Teste novo em `tests/unit/merge-train-plan.test.ts`: extrai a allowlist do script e a do `test:unit` do package.json e exige igualdade byte-a-byte (sincronização à prova de drift) + garante `autoCombo` fora dela. Red no tip (o script não declara `UNIT_SUBDIRS`), green com o fix — 6/6 no arquivo. Validação ao vivo: o train da fila-104 rodou com este script e logou o skip corretamente antes do SUITE GREEN @ 306d5500.

Refs #7670