### PR TITLE
test(codex): cover image tool output replay

### DIFF
--- a/tests/unit/codex-custom-tool-image-output-7698.test.ts
+++ b/tests/unit/codex-custom-tool-image-output-7698.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.ts";
+
+test("Codex passthrough preserves image-view custom tool output input parts (#7698)", () => {
+  const executor = new CodexExecutor();
+  const body = {
+    _nativeCodexPassthrough: true,
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Inspect the image." }],
+      },
+      {
+        type: "custom_tool_call_output",
+        call_id: "call_view_image",
+        output: [
+          { type: "input_text", text: "Script completed\nOutput:\n" },
+          { type: "input_image", image_url: "data:image/png;base64,AA==" },
+        ],
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.6", body, false, {
+    requestEndpointPath: "/responses",
+  });
+  const toolOutput = result.input.find((item) => item.type === "custom_tool_call_output");
+
+  assert.deepEqual(toolOutput, body.input[1]);
+  assert.equal(JSON.stringify(toolOutput).includes('"type":"output_text"'), false);
+});


### PR DESCRIPTION
## Summary

- add an executor-level regression test for Codex Desktop image-view history replay
- verify native Codex passthrough keeps `custom_tool_call_output.output` parts as `input_text` and `input_image`
- guard against reintroducing the upstream-rejected `output_text` at `input[n].output[m]`

## Root cause

Codex Desktop stores an image-view result as a `custom_tool_call_output` with an `output` content array. OmniRoute previously treated that nested array as assistant output and changed `input_image` to `output_text`. The next Responses request then failed with:

```text
Invalid value: 'output_text'. Supported values are: 'input_text',
'input_image', 'input_file', and 'scoped_content'.
```

PR #7269 already corrected the sanitizer on the current release branch. This PR adds the missing executor-level regression coverage using the exact Codex Desktop payload shape reported in #7698.

## Validation

- `DATA_DIR=<isolated temp dir> DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --test tests/unit/responses-input-sanitizer-name.test.ts tests/unit/codex-custom-tool-image-output-7698.test.ts` — 16 passing
- `npx eslint tests/unit/codex-custom-tool-image-output-7698.test.ts`
- `npm run check:file-size`
- `git diff --check`

No production build, database, or running service was replaced or restarted during validation.

Closes #7698