### PR TITLE
fix(db): update proxies on password rotation

### DIFF
--- a/changelog.d/fixes/7703-proxy-password-rotation.md
+++ b/changelog.d/fixes/7703-proxy-password-rotation.md
@@ -1,0 +1,1 @@
+- **fix(db):** bulk proxy imports now update an existing proxy when only its password changes instead of creating a duplicate.

--- a/changelog.d/fixes/7703-proxy-password-rotation.md
+++ b/changelog.d/fixes/7703-proxy-password-rotation.md
@@ -1,1 +1,0 @@
-- **fix(db):** bulk proxy imports now update an existing proxy when only its password changes instead of creating a duplicate.

--- a/changelog.d/fixes/7707-proxy-password-rotation.md
+++ b/changelog.d/fixes/7707-proxy-password-rotation.md
@@ -1,0 +1,1 @@
+- **fix(db):** bulk proxy imports now update an existing proxy when only its password changes instead of creating a duplicate ([#7707](https://github.com/diegosouzapw/OmniRoute/pull/7707)) — thanks @floze-the-genius

--- a/src/lib/db/proxies.ts
+++ b/src/lib/db/proxies.ts
@@ -296,14 +296,17 @@ export async function createProxy(payload: ProxyPayload) {
 }
 
 /**
- * Upsert a proxy by its credential tuple (host+port+username+password).
- * If a proxy with the same host, port, username AND password already exists,
- * update it. Otherwise, create a new one. Used by the bulk import feature.
+ * Upsert a proxy by its identity tuple (host+port+username).
+ * If a proxy with the same host, port, and username already exists, update it.
+ * Otherwise, create a new one. Used by the bulk import feature.
  *
  * #7594: host+port alone is NOT a stable identity. Rotating residential/gateway
  * proxies route every credential through one shared host:port, so keying only on
  * host+port collapsed distinct-credential imports onto the first existing row
  * (the same entry got "updated" N times instead of N entries being created).
+ *
+ * #7703: password is mutable and must not be part of the identity key. Including
+ * it caused password-only credential rotations to create duplicate entries.
  */
 export async function upsertProxy(payload: ProxyPayload): Promise<{
   proxy: ProxyRegistryRecord | null;
@@ -313,13 +316,10 @@ export async function upsertProxy(payload: ProxyPayload): Promise<{
   const host = (payload.host || "").trim();
   const port = Number(payload.port);
   const username = (payload.username || "").trim();
-  const password = (payload.password || "").trim();
 
   const existing = db
-    .prepare(
-      "SELECT id FROM proxy_registry WHERE host = ? AND port = ? AND username = ? AND password = ? LIMIT 1"
-    )
-    .get(host, port, username, password) as { id?: string } | undefined;
+    .prepare("SELECT id FROM proxy_registry WHERE host = ? AND port = ? AND username = ? LIMIT 1")
+    .get(host, port, username) as { id?: string } | undefined;
 
   if (existing?.id) {
     const updated = await updateProxy(existing.id, payload);
@@ -701,13 +701,23 @@ function getOrCreateRotationRow(
   db: ReturnType<typeof getDbInstance>,
   normalizedScope: string,
   rotationScopeId: string
-): { strategy: ProxyRotationStrategy; cursor: number; stickyWindowMinutes: number; rotatedAt: string | null } {
+): {
+  strategy: ProxyRotationStrategy;
+  cursor: number;
+  stickyWindowMinutes: number;
+  rotatedAt: string | null;
+} {
   const row = db
     .prepare(
       "SELECT strategy, cursor, sticky_window_minutes, rotated_at FROM proxy_scope_rotation WHERE scope = ? AND scope_id IS ?"
     )
     .get(normalizedScope, rotationScopeId) as
-    | { strategy?: string; cursor?: number; sticky_window_minutes?: number; rotated_at?: string | null }
+    | {
+        strategy?: string;
+        cursor?: number;
+        sticky_window_minutes?: number;
+        rotated_at?: string | null;
+      }
     | undefined;
 
   if (row) {
@@ -766,7 +776,13 @@ function pickFromCandidates<T>(
       cursor = state.cursor + 1;
       db.prepare(
         "UPDATE proxy_scope_rotation SET cursor = ?, rotated_at = ?, updated_at = ? WHERE scope = ? AND scope_id IS ?"
-      ).run(cursor, new Date().toISOString(), new Date().toISOString(), normalizedScope, rotationScopeId);
+      ).run(
+        cursor,
+        new Date().toISOString(),
+        new Date().toISOString(),
+        normalizedScope,
+        rotationScopeId
+      );
     }
     const idx = ((cursor % candidates.length) + candidates.length) % candidates.length;
     return candidates[idx];

--- a/tests/unit/proxy-bulk-import-dedup-7594.test.ts
+++ b/tests/unit/proxy-bulk-import-dedup-7594.test.ts
@@ -62,10 +62,7 @@ test("upsertProxy creates distinct entries for same host:port with different cre
 
   const listed = await proxiesDb.listProxies({ includeSecrets: true });
   assert.equal(listed.length, 3);
-  assert.deepEqual(
-    listed.map((p) => p.username).sort(),
-    ["user-1", "user-2", "user-3"]
-  );
+  assert.deepEqual(listed.map((p) => p.username).sort(), ["user-1", "user-2", "user-3"]);
 });
 
 test("upsertProxy still updates when the full credential tuple matches (#7594)", async () => {
@@ -90,8 +87,35 @@ test("upsertProxy still updates when the full credential tuple matches (#7594)",
   assert.equal(listed[0].name, "Gateway Renamed");
 });
 
+test("upsertProxy updates an existing proxy when only its password changes (#7703)", async () => {
+  const payload = {
+    name: "Rotating Gateway",
+    type: "http" as const,
+    host: "rotate.proxy.local",
+    port: 8080,
+    username: "stable-user",
+    password: "pass-a",
+  };
+
+  const created = await proxiesDb.upsertProxy(payload);
+  const rotated = await proxiesDb.upsertProxy({ ...payload, password: "pass-b" });
+
+  assert.equal(created.action, "created");
+  assert.equal(rotated.action, "updated");
+  assert.equal(rotated.proxy?.id, created.proxy?.id);
+
+  const listed = await proxiesDb.listProxies({ includeSecrets: true });
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0].password, "pass-b");
+});
+
 test("upsertProxy treats auth-less proxies on same host:port as the same entry (#7594)", async () => {
-  const base = { name: "Open Gateway", type: "http" as const, host: "open.proxy.local", port: 3128 };
+  const base = {
+    name: "Open Gateway",
+    type: "http" as const,
+    host: "open.proxy.local",
+    port: 3128,
+  };
 
   const first = await proxiesDb.upsertProxy(base);
   const second = await proxiesDb.upsertProxy({ ...base, name: "Open Gateway 2" });


### PR DESCRIPTION
## Summary

- Match bulk-imported proxies by `host + port + username`.
- Treat `password` as mutable so password-only rotations update the existing row.
- Add a regression test that asserts one row remains with the rotated password.

## Related Issues

- Closes #7703
- Related to #7594

## Validation

- [x] Focused regression suite: `node --import tsx/esm --test tests/unit/proxy-bulk-import-dedup-7594.test.ts` (4/4 passed)
- [x] `npx eslint src/lib/db/proxies.ts tests/unit/proxy-bulk-import-dedup-7594.test.ts`
- [x] `npm run typecheck:core`
- [x] `npm run check:changelog-integrity`
- [ ] `npm run test:unit` — attempted, but the host volume reached 100% capacity during the run; unrelated tests failed with `ENOSPC`, `SQLITE_FULL`, and `SQLITE_IOERR_SHMSIZE`. The macOS run also hit the pre-existing `readarray: command not found` failure in `tests/unit/ops-scripts.test.ts`.
- [ ] `npm run test:coverage` — not run after the host-level disk exhaustion.

## Tests Added Or Updated

- `tests/unit/proxy-bulk-import-dedup-7594.test.ts`

## Coverage Notes

The focused regression exercises the changed `upsertProxy()` branch end to end against SQLite: importing the same host, port, and username with a new password returns `updated`, preserves the row id, leaves one row, and stores the new password.

## Reviewer Notes

No migration is needed. Existing behavior for distinct usernames and auth-less proxies remains covered by the same focused suite.