### PR TITLE
fix: correct Chutes registry baseUrl api.chutesai.com -> llm.chutes.ai (#7621)

### DIFF
--- a/changelog.d/fixes/7621-chutes-baseurl.md
+++ b/changelog.d/fixes/7621-chutes-baseurl.md
@@ -1,0 +1,1 @@
+- fix(providers): correct Chutes registry baseUrl from api.chutesai.com to llm.chutes.ai (#7621)

--- a/open-sse/config/providers/registry/chutes/index.ts
+++ b/open-sse/config/providers/registry/chutes/index.ts
@@ -5,7 +5,7 @@ export const chutesProvider: RegistryEntry = {
   alias: "chutes",
   format: "openai",
   executor: "default",
-  baseUrl: "https://api.chutesai.com/v1/chat/completions",
+  baseUrl: "https://llm.chutes.ai/v1/chat/completions",
   authType: "apikey",
   authHeader: "bearer",
   models: [{ id: "Qwen2.5-72B-Instruct", name: "Qwen2.5 72B" }],

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -746,8 +746,8 @@
       }
     },
     "url": {
-      "nonStream": "https://api.chutesai.com/v1/chat/completions",
-      "stream": "https://api.chutesai.com/v1/chat/completions"
+      "nonStream": "https://llm.chutes.ai/v1/chat/completions",
+      "stream": "https://llm.chutes.ai/v1/chat/completions"
     }
   },
   "claude": {

--- a/tests/unit/chutes-registry-baseurl-7621.test.ts
+++ b/tests/unit/chutes-registry-baseurl-7621.test.ts
@@ -1,0 +1,12 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chutesProvider } from "../../open-sse/config/providers/registry/chutes/index.ts";
+
+test("#7621: chutes registry baseUrl must use the resolvable llm.chutes.ai domain", () => {
+  assert.equal(
+    chutesProvider.baseUrl,
+    "https://llm.chutes.ai/v1/chat/completions",
+    "chutesProvider.baseUrl must point at the resolvable llm.chutes.ai host, not the " +
+      "non-resolving api.chutesai.com"
+  );
+});


### PR DESCRIPTION
Closes #7621

## Root cause
`open-sse/config/providers/registry/chutes/index.ts` hardcoded `baseUrl: "https://api.chutesai.com/v1/chat/completions"`. The domain `api.chutesai.com` does not resolve (confirmed live via `dns.lookup`: `ENOTFOUND`). The correct, resolving host is `llm.chutes.ai`, already used elsewhere in the codebase for the same provider (`providerModelsConfig.ts:184-187`). Every user selecting the built-in "Chutes" preset got `fetch failed` / `getaddrinfo ENOTFOUND api.chutesai.com` on every request, independent of API key validity.

## Fix
One-line literal change: `baseUrl` now points at `https://llm.chutes.ai/v1/chat/completions`.

## Regression test (TDD, Hard Rule #18)
`tests/unit/chutes-registry-baseurl-7621.test.ts` — RED before the fix, GREEN after:

```
✖ #7621: chutes registry baseUrl must use the resolvable llm.chutes.ai domain
  AssertionError [ERR_ASSERTION]: chutesProvider.baseUrl must point at the resolvable llm.chutes.ai host, not the non-resolving api.chutesai.com
  + actual - expected
  + 'https://api.chutesai.com/v1/chat/completions'
  - 'https://llm.chutes.ai/v1/chat/completions'
```
→ after the fix:
```
✔ #7621: chutes registry baseUrl must use the resolvable llm.chutes.ai domain
```

`tests/snapshots/provider/translate-path.json` (golden lock) regenerated — diff confirms only the `chutes` entry's URL changed, no other provider drifted.

## Gates run (all green)
- `node --import tsx/esm --test tests/unit/chutes-registry-baseurl-7621.test.ts` — RED→GREEN
- `node --import tsx/esm --test tests/unit/provider-translate-path-golden.test.ts tests/unit/free-model-catalog.test.ts tests/unit/provider-registry-freetheai.test.ts tests/unit/discontinued-providers-2026.test.ts tests/unit/providers-page-utils.test.ts tests/unit/providers-route-managed-catalog.test.ts` — 47/47 pass
- `node scripts/check/check-file-size.mjs` — no offenders on touched files
- `node scripts/check/check-complexity.mjs` — OK (2059 violações, baseline 2059, unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violações, baseline 890, unchanged)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/config/providers/registry/chutes/index.ts tests/unit/chutes-registry-baseurl-7621.test.ts` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run check:provider-consistency` — OK (198 REGISTRY entries, 276 canonical providers, 0 exceptions)

## Scope
Diff is scoped strictly to this issue: `open-sse/config/providers/registry/chutes/index.ts` (1-line literal), `tests/unit/chutes-registry-baseurl-7621.test.ts` (new regression test), `tests/snapshots/provider/translate-path.json` (golden snapshot regenerated — chutes URL only), `changelog.d/fixes/7621-chutes-baseurl.md`.