### PR TITLE
fix: strip prompt_cache_key for NVIDIA NIM (#7617)

### DIFF
--- a/changelog.d/fixes/7617-nvidia-strip-cache-key.md
+++ b/changelog.d/fixes/7617-nvidia-strip-cache-key.md
@@ -1,0 +1,1 @@
+- fix(routing): strip `prompt_cache_key` for NVIDIA NIM — Codex CLI injects it, NIM's OpenAI-compatible wrapper 400s on it (#7617)

--- a/open-sse/translator/paramSupport.ts
+++ b/open-sse/translator/paramSupport.ts
@@ -50,6 +50,11 @@ const STRIP_RULES: StripRule[] = [
   // (format:"openai") does not accept the Claude-style `thinking` body field
   // and returns 400 "Unsupported parameter(s): thinking". Upstream #2268.
   { provider: "nvidia", match: /minimax-m2\.7/i, drop: ["thinking"] },
+  // NVIDIA NIM: OpenAI-compatible wrapper 400s on `prompt_cache_key` (Codex CLI
+  // injects it natively for its own prompt caching). NIM has no documented
+  // support for this field (providerSupportsCaching already treats nvidia as
+  // non-cache-capable) — safe to drop provider-wide, not model-specific. #7617.
+  { provider: "nvidia", match: /.*/, drop: ["prompt_cache_key"] },
   // VolcEngine Ark caps the Kimi coding-plan endpoint at max_tokens <= 32768
   // server-side ("integer above maximum value, expected a value <= 32768"),
   // independent of the model's own catalog ceiling. Confirmed against two

--- a/tests/unit/nvidia-strip-prompt-cache-key.test.ts
+++ b/tests/unit/nvidia-strip-prompt-cache-key.test.ts
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripUnsupportedParams } from "../../open-sse/translator/paramSupport.ts";
+
+test("#7617: stripUnsupportedParams strips prompt_cache_key for nvidia when present", () => {
+  const body: Record<string, unknown> = {
+    model: "some-nvidia-model",
+    prompt_cache_key: "codex-cli-session-abc123",
+    max_tokens: 512,
+  };
+  stripUnsupportedParams("nvidia", "some-nvidia-model", body);
+  assert.equal(
+    body.prompt_cache_key,
+    undefined,
+    "prompt_cache_key must be stripped for nvidia"
+  );
+  assert.equal(body.max_tokens, 512, "unrelated params must be preserved");
+});
+
+test("#7617: stripUnsupportedParams preserves prompt_cache_key for non-nvidia providers (e.g. openai)", () => {
+  const body: Record<string, unknown> = {
+    model: "gpt-5.4",
+    prompt_cache_key: "some-cache-key",
+  };
+  stripUnsupportedParams("openai", "gpt-5.4", body);
+  assert.equal(
+    body.prompt_cache_key,
+    "some-cache-key",
+    "prompt_cache_key must be preserved for non-nvidia providers"
+  );
+});
+
+test("#7617: stripUnsupportedParams is a no-op for nvidia when prompt_cache_key is absent", () => {
+  const body: Record<string, unknown> = {
+    model: "some-nvidia-model",
+    max_tokens: 256,
+  };
+  stripUnsupportedParams("nvidia", "some-nvidia-model", body);
+  assert.equal("prompt_cache_key" in body, false);
+  assert.equal(body.max_tokens, 256);
+});


### PR DESCRIPTION
Closes #7617

## Root cause

`injectPromptCacheKey()` (`open-sse/handlers/chatCore/upstreamBody.ts`) only guards against the router **injecting** a new `prompt_cache_key` for nvidia/codex/xai — the `!bodyToSend.prompt_cache_key` check means it never touches a `prompt_cache_key` that arrived already present in the inbound body. Codex CLI injects this field natively for its own prompt caching, so a Codex CLI request routed to NVIDIA NIM carries `prompt_cache_key` straight through to `stripUnsupportedParams()` (`open-sse/executors/default.ts:712`, the real enforcement point for nvidia via `DefaultExecutor`). No `STRIP_RULES` entry removed it, so NIM's OpenAI-compatible wrapper 400s on the unsupported field. NIM has no documented support for prompt caching (`providerSupportsCaching` already treats nvidia as non-cache-capable).

## Fix

Added a provider-wide `STRIP_RULES` entry to `open-sse/translator/paramSupport.ts`:

```ts
{ provider: "nvidia", match: /.*/, drop: ["prompt_cache_key"] }
```

Match-all because the rejection isn't model-specific (unlike the existing nvidia rules for `reasoning`/`thinking` on specific models).

## Regression test (TDD)

`tests/unit/nvidia-strip-prompt-cache-key.test.ts` — recreates the RED repro from the triage plan-file, confirmed failing against unfixed code, now green:

RED (before fix):
```
✖ #7617: stripUnsupportedParams strips prompt_cache_key for nvidia when present
  AssertionError [ERR_ASSERTION]: prompt_cache_key must be stripped for nvidia
  + actual - expected
  + 'codex-cli-session-abc123'
  - undefined
```

GREEN (after fix): all 3 cases pass — strips for nvidia, preserves for non-nvidia providers (e.g. openai), no-op when absent.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/nvidia-strip-prompt-cache-key.test.ts` — 3/3 pass
- Sibling tests touching `paramSupport`/`STRIP_RULES`/nvidia all still pass: `param-filters-apply.test.ts`, `executors-strip-unsupported-params.test.ts`, `default-reasoning-effort-6879.test.ts`, `param-filters-db.test.ts`, `nvidia-nim-catalog-expansion-2373.test.ts`, `nvidia-minimax-thinking-strip.test.ts`, `zai-glm-max-tokens-clamp-7364.test.ts`, `glm-executor-max-tokens-clamp-7364.test.ts`
- `node scripts/check/check-file-size.mjs` — OK, no `✗`
- `node scripts/check/check-complexity.mjs` — OK, 2059 violations (baseline 2059, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` — OK, 890 violations (baseline 890, no regression)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/translator/paramSupport.ts tests/unit/nvidia-strip-prompt-cache-key.test.ts` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Note on the plan-file's author-proposed literal

The issue body's proposed `{ provider: "nvidia", drop: ["prompt_cache_key"] }` does not compile — `match` is required on `StripRule`. Followed the plan-file's corrected form instead: `{ provider: "nvidia", match: /.*/, drop: ["prompt_cache_key"] }`.