### PR TITLE
fix: degrade Arena (lmarena) cookie validation redirect to unsupported (#7542)

### DIFF
--- a/changelog.d/fixes/7542-arena-cookie-redirect.md
+++ b/changelog.d/fixes/7542-arena-cookie-redirect.md
@@ -1,0 +1,1 @@
+- fix(providers): stop reporting Arena (lmarena) cookie validation as Invalid when the `/models` probe hits a 307 redirect — degrade to `unsupported` instead, and drop the stale "no registry entry" comment for lmarena (#7542)

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -31,7 +31,12 @@ import {
   resolveBaseUrl,
 } from "./validation/urlHelpers";
 import { STANDARD_USER_AGENT, directHttpsRequest, buildBearerHeaders } from "./validation/headers";
-import { validationRead, validationWrite, toValidationErrorResult } from "./validation/transport";
+import {
+  validationRead,
+  validationWrite,
+  toValidationErrorResult,
+  toWebCookieValidationErrorResult,
+} from "./validation/transport";
 import {
   validateDeepSeekWebProvider,
   validateQwenWebProvider,
@@ -137,7 +142,7 @@ export async function validateWebCookieProvider({
 
     if (!entry) {
       // Providers listed in WEB_COOKIE_PROVIDERS without a providerRegistry entry (e.g.
-      // lmarena, gemini-business, poe-web, venice-web, v0-vercel-web) only expose a
+      // gemini-business, poe-web, venice-web, v0-vercel-web) only expose a
       // marketing website URL, not a real API host. Probing `${website}/models`
       // does not reliably signal session validity for these —
       // live verification showed most return redirects or SPA 200s regardless of
@@ -183,7 +188,7 @@ export async function validateWebCookieProvider({
     // for web-cookie auth, so a non-auth status is treated as a valid session.
     return { valid: true, error: null, unsupported: false };
   } catch (error: unknown) {
-    return toValidationErrorResult(error);
+    return toWebCookieValidationErrorResult(provider, error);
   }
 }
 

--- a/src/lib/providers/validation/transport.ts
+++ b/src/lib/providers/validation/transport.ts
@@ -92,6 +92,35 @@ export function isSecurityBlockError(error: unknown): boolean {
   return false;
 }
 
+// #7542 — web-cookie providers whose registry `baseUrl` is a POST-only streaming/completion
+// endpoint (no real `/models` listing API), so the generic `/models` probe in
+// validateWebCookieProvider() gets a redirect instead of a definitive 200/401/403. A blocked
+// redirect there is not a session-expiry signal — the endpoint just isn't shaped for the probe
+// — so it should degrade to "unsupported" the same way the discovery path already does for
+// REDIRECT_BLOCKED (#6267's buildDiscoveryErrorFallbackResponse).
+//
+// Scoped to `lmarena` only (root-caused and regression-tested for #7542): the other web-cookie
+// providers sharing a POST-only baseUrl shape (doubao-web, huggingchat, yuanbao-web,
+// zenmux-free, zai-web) have not been individually verified to actually redirect on this probe
+// rather than 404/405 — do not add them here without a proven repro per provider (see
+// #7542 plan-file, "Risks").
+const WEB_COOKIE_PROVIDERS_WITH_UNRELIABLE_MODELS_PROBE = new Set(["lmarena"]);
+
+export function toWebCookieValidationErrorResult(provider: string, error: unknown) {
+  if (
+    error instanceof SafeOutboundFetchError &&
+    error.code === "REDIRECT_BLOCKED" &&
+    WEB_COOKIE_PROVIDERS_WITH_UNRELIABLE_MODELS_PROBE.has(provider)
+  ) {
+    return {
+      valid: false,
+      error: "Provider validation not supported",
+      unsupported: true as const,
+    };
+  }
+  return toValidationErrorResult(error);
+}
+
 export function toValidationErrorResult(error: unknown) {
   const message = error instanceof Error ? error.message : String(error || "Validation failed");
   const statusCode = getSafeOutboundFetchErrorStatus(error);

--- a/tests/unit/arena-cookie-validation-redirect-7542.test.ts
+++ b/tests/unit/arena-cookie-validation-redirect-7542.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Import BEFORE mocking global.fetch — open-sse/utils/proxyFetch.ts overwrites
+// globalThis.fetch as a module-load side effect, so a mock installed before the
+// import gets clobbered (same pattern as tests/unit/provider-models-qwen-web-redirect-6267.test.ts).
+const { validateWebCookieProvider } = await import("../../src/lib/providers/validation.ts");
+
+const originalFetch = globalThis.fetch;
+test.after(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("should_not_report_Invalid_when_lmarena_models_probe_307_redirects", async () => {
+  const fetchCalls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    fetchCalls.push(url);
+    return new Response(null, { status: 307, headers: { location: "https://arena.ai/" } });
+  }) as typeof fetch;
+
+  const result = await validateWebCookieProvider({
+    provider: "lmarena",
+    apiKey: "arena_session=abc123",
+    providerSpecificData: {},
+  });
+
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0], "https://arena.ai/nextjs-api/stream/create-evaluation/models");
+  assert.equal(result.valid, false);
+  assert.equal(
+    result.unsupported,
+    true,
+    "BUG #7542: current code returns unsupported:false — dashboard renders hard Invalid"
+  );
+});
+
+test("should_still_report_SESSION_EXPIRED_for_lmarena_401", async () => {
+  globalThis.fetch = (async () => {
+    return new Response(null, { status: 401 });
+  }) as typeof fetch;
+
+  const result = await validateWebCookieProvider({
+    provider: "lmarena",
+    apiKey: "arena_session=abc123",
+    providerSpecificData: {},
+  });
+
+  assert.equal(result.valid, false);
+  assert.equal(result.unsupported, false);
+  assert.equal((result as { error?: string }).error, "SESSION_EXPIRED");
+});


### PR DESCRIPTION
Closes #7542

## Root cause

`validateWebCookieProvider`'s `/models` probe (`src/lib/providers/validation.ts`) is built from the `lmarena` `providerRegistry` entry's `baseUrl`, which #6280 registered as `https://arena.ai/nextjs-api/stream/create-evaluation` — a POST-only streaming endpoint, not a real listing API. The probe therefore hits `https://arena.ai/nextjs-api/stream/create-evaluation/models`, which arena.ai answers with a 307. `safeOutboundFetch`'s `validationRead` preset disallows redirects, so this throws `SafeOutboundFetchError{code:"REDIRECT_BLOCKED"}`, which `toValidationErrorResult` turned into `{valid:false, unsupported:false, error:"Redirect blocked..."}`. The dashboard only suppresses the hard "Invalid" state when `unsupported:true`, so a perfectly valid Arena cookie rendered as Invalid.

Also stale: the `if (!entry)` guard's comment at `validation.ts` still listed `lmarena` among providers "without a providerRegistry entry" — false since #6280 registered one, making the guard dead code for lmarena. Comment removed per owner instruction.

Same defect class was already fixed for the **discovery** path by #6267 (`buildDiscoveryErrorFallbackResponse`), never mirrored onto the cookie-validation path.

## Fix

- New `toWebCookieValidationErrorResult(provider, error)` in `src/lib/providers/validation/transport.ts`: for providers on a small allowlist whose `/models` probe is known-unreliable (currently just `lmarena`, root-caused for this issue), a `REDIRECT_BLOCKED` degrades to `{valid:false, unsupported:true}` instead of a raw redirect error.
- Deliberately scoped to `lmarena` only, not generalized to all web-cookie providers with a similarly-shaped `baseUrl` (doubao-web, huggingchat, yuanbao-web, zenmux-free, zai-web) — those have not been individually verified to actually redirect on this probe rather than 404/405, and an unconditional `REDIRECT_BLOCKED → unsupported` transform risks masking a genuine session-expired login-redirect as "unsupported" for a provider that behaves differently. See the code comment for the reasoning.
- Removed the stale `lmarena` mention from the `if (!entry)` comment in `validation.ts`.

## Testing (Hard Rule #18 — TDD)

New regression test `tests/unit/arena-cookie-validation-redirect-7542.test.ts`:
- `should_not_report_Invalid_when_lmarena_models_probe_307_redirects` — confirmed **RED** against the unfixed code (`false !== true` on `result.unsupported`), **GREEN** after the fix.
- `should_still_report_SESSION_EXPIRED_for_lmarena_401` — guards that a real 401 from the probe still reports `SESSION_EXPIRED`/`AUTH_007` (unaffected by this change).

Existing-test regression sweep (all green, no assertions weakened):
```
node --import tsx/esm --test tests/unit/lmarena-provider.test.ts tests/unit/lmarena-split-cookie-4271.test.ts \
  tests/unit/provider-validation-web-cookie-auth007.test.ts tests/unit/web-cookie-validation-fallback.test.ts \
  tests/unit/web-cookie-validation-proxy-7058.test.ts tests/unit/validation-helpers-split.test.ts \
  tests/unit/validation-web-providers-split.test.ts tests/unit/validation-format-validators-split.test.ts \
  tests/unit/bailian-coding-plan-provider.test.ts tests/unit/provider-icon-arena-themed.test.ts \
  tests/unit/t28-model-catalog-updates.test.ts tests/unit/t3chat-web-cookie-hint-5465.test.ts \
  tests/unit/web-session-credentials.test.ts tests/unit/provider-onboarding-wizard.test.ts
# 137/137 pass
npx vitest run tests/unit/ui/add-api-key-modal-unsupported-save-5565.test.tsx tests/unit/ui/web-session-cookie-modal-size-6265.test.tsx
# 3/3 pass
```

## Gates run

- `node scripts/check/check-file-size.mjs` → OK, no new violations
- `node scripts/check/check-complexity.mjs` → OK (2059/2059 baseline, unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (890/890 baseline, unchanged)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → exit 0
- `node scripts/check/check-changelog-integrity.mjs` → OK