### PR TITLE
docs: fix three stale references failing the fabricated-docs gate

### DIFF
--- a/changelog.d/fixes/docs-fabricated-claims.md
+++ b/changelog.d/fixes/docs-fabricated-claims.md
@@ -1,0 +1,1 @@
+- docs: correct three stale references caught by the fabricated-docs gate (`/api/version` → `/api/monitoring/health`, migration `125_` → `126_reasoning_routing_rules.sql`)

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -99,7 +99,7 @@ not** skip steps; each is timed.
 
 ### 4.2 Cluster-wide latency regression
 
-1. Check the most recent deploy (`/api/version` returns the SHA).
+1. Check the most recent deploy (`/api/monitoring/health` returns `appVersion`).
 2. If p95 doubled vs the 7-day baseline, **roll back** to the prior
    SHA via `bin/rollback.sh`.
 3. If the regression is provider-side, see § 4.1.

--- a/docs/PERF_BUDGETS.md
+++ b/docs/PERF_BUDGETS.md
@@ -125,7 +125,7 @@ flag in the weekly perf review.
 | Endpoint | Method | p50 | p95 | p99 |
 |---|---|---|---|---|
 | `/api/health/ping` | GET | 5 ms | 20 ms | 50 ms |
-| `/api/version` | GET | 5 ms | 20 ms | 50 ms |
+| `/api/monitoring/health` | GET | 5 ms | 20 ms | 50 ms |
 | `/api/docs` | GET | 20 ms | 80 ms | 200 ms (HTML shell, no provider call) |
 
 ---

--- a/docs/routing/REASONING_ROUTING.md
+++ b/docs/routing/REASONING_ROUTING.md
@@ -64,7 +64,7 @@ executed there. The rule decision is stored in the existing route trace without 
 
 ## Persistence
 
-The migration `src/lib/db/migrations/125_reasoning_routing_rules.sql` creates the
+The migration `src/lib/db/migrations/126_reasoning_routing_rules.sql` creates the
 `reasoning_routing_rules` table. Rules reference stored API keys, combos, and provider connections.
 Deletes clean up related rules. The database access layer in
 `src/lib/db/reasoningRoutingRules.ts` maintains an invalidatable cache for the request path.


### PR DESCRIPTION
`Docs Gates (fast-path)` is **base-red on the release tip** — `check-fabricated-docs.mjs --strict` fails on `release/v3.8.49` with no changes applied, blocking unrelated PRs.

Three stale claims, all verified against the current tree:

| Doc | Claim | Reality |
|---|---|---|
| `docs/INCIDENT_RESPONSE.md:102` | `/api/version` returns the SHA | no such route; `/api/monitoring/health` returns `appVersion` (`route.ts:150`) |
| `docs/PERF_BUDGETS.md:128` | `/api/version` latency budget row | same — retargeted to `/api/monitoring/health` |
| `docs/routing/REASONING_ROUTING.md:67` | migration `125_reasoning_routing_rules.sql` | off by one: the file is `126_reasoning_routing_rules.sql` |

Docs-only, no code touched. `node scripts/check/check-fabricated-docs.mjs --strict` now passes.