### PR TITLE
fix(quality): register 4 missing covering tests in stryker tap.testFiles

### DIFF
--- a/changelog.d/fixes/stryker-tapfiles-base-red.md
+++ b/changelog.d/fixes/stryker-tapfiles-base-red.md
@@ -1,0 +1,1 @@
+- **fix(quality):** registered 4 covering unit tests in `stryker.conf.json` `tap.testFiles` (`account-fallback-lockout-eviction`, `combo/recovery-hint`, `combo-least-used-account`, `cliproxyapi-dedicated-credential-7645`) so their mutant kills count, clearing the `check:mutation-test-coverage --strict` base-red that was failing every open PR.

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -265,7 +265,11 @@
       "tests/unit/upstream-retry-hints-toggle.test.ts",
       "tests/unit/upstream-timeout-model-override.test.ts",
       "tests/unit/usage-service-hardening.test.ts",
-      "tests/unit/validate-response-quality.test.ts"
+      "tests/unit/validate-response-quality.test.ts",
+      "tests/unit/account-fallback-lockout-eviction.test.ts",
+      "tests/unit/combo/recovery-hint.test.ts",
+      "tests/unit/combo-least-used-account.test.ts",
+      "tests/unit/cliproxyapi-dedicated-credential-7645.test.ts"
     ],
     "nodeArgs": [
       "--import",


### PR DESCRIPTION
## Problem

`check:mutation-test-coverage --strict` (job `Fast Quality Gates`) fails **on the release tip itself**, with no PR involved. Reproduced on a clean detached worktree at `313cbefda`:

```
✗ 4 covering unit test(s) across 4 module(s) are missing from stryker.conf.json tap.testFiles.
```

Every open PR inherits this red for a reason unrelated to its own changes. The drift does **not** self-heal (unlike the golden/file-size gates) and it grew from 3 → 4 entries within a day, so it keeps widening with each `--fast` merge.

## Fix

Adds the 4 missing entries to `tap.testFiles`. Diff is 4 inserted lines — no reformatting, no logic change.

## Verification

```
$ npm run check:mutation-test-coverage
Scanned 2999 unit test file(s) against 31 mutated module(s).
✓ No drift — every covering unit test is listed in tap.testFiles.
```

Not merged by me — leaving the merge decision to the release captain, since this lands on the release branch.