### PR TITLE
fix(sse): wire settings.wildcardAliases into model resolution (#7693)

### DIFF
--- a/changelog.d/fixes/7693-wildcard-alias.md
+++ b/changelog.d/fixes/7693-wildcard-alias.md
@@ -1,0 +1,1 @@
+- fix(sse): wire settings.wildcardAliases into model resolution so wildcard model aliases created in Settings actually take effect (#7693)

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -35,16 +35,41 @@ function getReservedProviderPrefixes(): Set<string> {
 }
 
 /**
- * Build a combined model alias map that merges both alias stores:
+ * Fold `settings.wildcardAliases` ({pattern,target}[]) — the store the Settings
+ * UI's "Wildcard Pattern" mode writes to (ModelAliasesUnified.tsx::addWildcardAlias
+ * -> PATCH /api/settings) — into `pattern -> target` map entries so the T13
+ * wildcard step in getModelInfoCore() (which treats every key of the merged alias
+ * map as a candidate glob pattern) can see them (#7693). Without this the
+ * feature persists but is never consulted at request time.
+ */
+function buildWildcardAliasMap(settings: Record<string, unknown>): Record<string, unknown> {
+  const wildcardEntries = Array.isArray(settings.wildcardAliases)
+    ? (settings.wildcardAliases as Array<{ pattern?: unknown; target?: unknown }>)
+    : [];
+  const wildcardMap: Record<string, unknown> = {};
+  for (const entry of wildcardEntries) {
+    if (entry && typeof entry.pattern === "string" && typeof entry.target === "string") {
+      wildcardMap[entry.pattern] = entry.target;
+    }
+  }
+  return wildcardMap;
+}
+
+/**
+ * Build a combined model alias map that merges all alias stores:
  * 1. DB-namespace aliases (key_value WHERE namespace='modelAliases') — set via
  *    /api/models/alias/ and seeded at startup.
- * 2. Settings-based aliases (settings.modelAliases) — set via the Settings UI and
+ * 2. Settings-based exact aliases (settings.modelAliases) — set via the Settings UI and
  *    /api/settings/model-aliases/ (stored as a JSON blob in namespace='settings').
+ * 3. Settings-based wildcard aliases (settings.wildcardAliases) — set via the Settings
+ *    UI's "Wildcard Pattern" mode, PATCH /api/settings (#7693).
  *
- * Settings-based aliases take priority so that UI configuration always wins.
- * Without this merge, aliases configured via the Settings UI were never consulted
- * during provider routing, causing provider inference (e.g. /^gpt-/ → openai) to
- * silently override them (issue #2618 / #2208).
+ * Settings-based exact aliases take priority over DB-namespace aliases so that UI
+ * configuration always wins. Without this merge, aliases configured via the Settings
+ * UI were never consulted during provider routing, causing provider inference (e.g.
+ * /^gpt-/ → openai) to silently override them (issue #2618 / #2208). Wildcard entries
+ * are folded in last: they are keyed by pattern string (containing `*`/`?`), which
+ * cannot collide with a real model id, so ordering never affects exact-alias lookups.
  */
 async function getCombinedModelAliases(): Promise<Record<string, unknown>> {
   const [dbAliases, settings] = await Promise.all([
@@ -59,8 +84,9 @@ async function getCombinedModelAliases(): Promise<Record<string, unknown>> {
       ? (settings.modelAliases as Record<string, unknown>)
       : {};
 
-  // Settings-based aliases win over DB-namespace aliases on key collision
-  return { ...dbAliases, ...settingsAliases };
+  const wildcardMap = buildWildcardAliasMap(settings);
+
+  return { ...dbAliases, ...settingsAliases, ...wildcardMap };
 }
 
 /**

--- a/tests/unit/wildcard-alias-settings-not-applied-7693.test.ts
+++ b/tests/unit/wildcard-alias-settings-not-applied-7693.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-wildcard-alias-7693-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+const ORIGINAL_API_KEY_SECRET = process.env.API_KEY_SECRET;
+process.env.API_KEY_SECRET = "test-wildcard-alias-7693-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const { getModelInfo } = await import("../../src/sse/services/model.ts");
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_API_KEY_SECRET === undefined) {
+    delete process.env.API_KEY_SECRET;
+  } else {
+    process.env.API_KEY_SECRET = ORIGINAL_API_KEY_SECRET;
+  }
+});
+
+test("#7693: a wildcard alias saved via settings.wildcardAliases IS applied by getModelInfo", async () => {
+  // Exactly what ModelAliasesUnified.tsx::addWildcardAlias() does: PATCH
+  // /api/settings with { wildcardAliases: [...] } -> src/lib/db/settings.ts::updateSettings().
+  await settingsDb.updateSettings({
+    wildcardAliases: [{ pattern: "claude-haiku-*", target: "openai/gpt-4o-mini" }],
+  });
+
+  // Same bare-model request Claude Code sends when routed through
+  // ~/.claude/settings.json's `model` field, exactly as reported in #7693.
+  const info = await getModelInfo("claude-haiku-4-5-20251001");
+
+  assert.equal(
+    info.provider,
+    "openai",
+    `expected the "claude-haiku-*" wildcard alias to route to provider "openai", got ${JSON.stringify(info)}`
+  );
+  assert.equal(info.model, "gpt-4o-mini");
+});
+
+test("#7693: an exact alias still wins over a wildcard alias on the same model id", async () => {
+  await settingsDb.updateSettings({
+    modelAliases: { "claude-haiku-4-5-20251001": "anthropic/claude-3-5-sonnet-20241022" },
+    wildcardAliases: [{ pattern: "claude-haiku-*", target: "openai/gpt-4o-mini" }],
+  });
+
+  const info = await getModelInfo("claude-haiku-4-5-20251001");
+
+  assert.equal(
+    info.provider,
+    "anthropic",
+    `expected the exact alias to win over the wildcard alias, got ${JSON.stringify(info)}`
+  );
+  assert.equal(info.model, "claude-3-5-sonnet-20241022");
+});


### PR DESCRIPTION
Closes #7693

## Root cause

Wildcard model aliases created via the Settings UI's "Wildcard Pattern" mode are persisted to `settings.wildcardAliases` (PATCH `/api/settings` → `src/lib/db/settings.ts::updateSettings()`), but `getCombinedModelAliases()` in `src/sse/services/model.ts` only ever merged the DB-namespace alias store and `settings.modelAliases` (exact aliases). It never read `settings.wildcardAliases`, so the T13 wildcard-matching step in `getModelInfoCore()` — which already correctly resolves glob patterns via `resolveWildcardAlias()` — never saw the user's configured patterns. Every request fell through to provider inference and, for models multiple providers claim (e.g. `claude-haiku-4-5-20251001` claimed by both `lma` and `cc`), threw the "Ambiguous model" 400 the reporter hit.

## Fix

`getCombinedModelAliases()` now folds `settings.wildcardAliases` entries (`{pattern, target}[]`) into the merged alias map as `pattern -> target` keys, via a new `buildWildcardAliasMap()` helper (kept as a separate flat function for the complexity gates). Wildcard entries are folded in last — since they're keyed by pattern strings containing `*`/`?`, they can never collide with (or shadow) an exact alias key, so exact-alias precedence is preserved.

No changes to `resolveWildcardAlias()` / `getModelInfoCore()` — they already worked correctly once given the pattern data.

## Regression test

`tests/unit/wildcard-alias-settings-not-applied-7693.test.ts` — reused from the triage-fix-bugs plan-file's proven repro.

- Test 1 reproduces the exact reported failure: saves a wildcard alias via `settingsDb.updateSettings()` (same path the UI PATCH hits) and asserts `getModelInfo()` routes through it. **Confirmed RED** against unfixed code (`AssertionError: null !== 'openai'`, `errorType: "ambiguous_model"`, same `lma`/`cc` candidates as the report) → **GREEN** after the fix.
- Test 2 (added) locks in the exact-alias-wins-over-wildcard precedence rule the plan flagged as worth covering explicitly.

```
node --import tsx/esm --test tests/unit/wildcard-alias-settings-not-applied-7693.test.ts
✔ #7693: a wildcard alias saved via settings.wildcardAliases IS applied by getModelInfo
✔ #7693: an exact alias still wins over a wildcard alias on the same model id
ℹ tests 2, pass 2, fail 0
```

Also re-ran the existing alias-precedence/resolution suites most likely to be affected by touching `getCombinedModelAliases()` — all still pass, no old-behavior assertions needed alignment (nothing referenced `wildcardAliases` before this PR):

```
node --import tsx/esm --test tests/unit/local-aliases-precedence.test.ts tests/unit/model-alias-provider-resolution.test.ts \
  tests/unit/model-alias-seed.test.ts tests/unit/model-aliases-settings-route-selfheal.test.ts \
  tests/unit/model-aliases-globalthis-5777.test.ts tests/unit/provider-alias-transitive-5918.test.ts
ℹ tests 28, pass 28, fail 0
```

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — no violations on touched files
- `node scripts/check/check-complexity.mjs` — OK (2058 violations, baseline 2059 — no growth)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violations, baseline 890 — no growth)
- `npm run typecheck:core` — clean exit
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/sse/services/model.ts tests/unit/wildcard-alias-settings-not-applied-7693.test.ts` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope

Single file touched in `src/`/`open-sse`: `src/sse/services/model.ts` (new flat helper `buildWildcardAliasMap()` extracted to keep complexity flat, wired into `getCombinedModelAliases()`). Plus the regression test and a changelog fragment. No changes to `resolveWildcardAlias()`, `wildcardRouter.ts`, or `getModelInfoCore()` — matches the plan-file's proposed fix exactly.
