### PR TITLE
fix: classify forge/jcode CLI settings routes as LOCAL_ONLY (#7263)

### DIFF
--- a/changelog.d/fixes/7263-settings-local-only.md
+++ b/changelog.d/fixes/7263-settings-local-only.md
@@ -1,0 +1,1 @@
+- fix(authz): classify /api/cli-tools/forge-settings and /api/cli-tools/jcode-settings as LOCAL_ONLY, closing an RCE-via-tunnel gap where getCliRuntimeStatus() spawns a child process without loopback enforcement (#7263)

--- a/scripts/check/check-route-guard-membership.ts
+++ b/scripts/check/check-route-guard-membership.ts
@@ -50,6 +50,8 @@ export const SPAWN_CAPABLE_ROUTE_ROOTS: ReadonlyArray<string> = [
   "src/app/api/cli-tools/runtime",
   "src/app/api/local", // T-12: 1-click local service launchers (Redis today) — every child here spawns podman/docker (Hard Rules #15 + #17)
   "src/app/api/skills/collect", // Skill Collector CLI detection: GET .../detect spawns a child process per CLI_TOOL_IDS entry via getCliRuntimeStatus() (Hard Rules #15 + #17, PR #6294 review)
+  "src/app/api/cli-tools/forge-settings", // GET calls getCliRuntimeStatus() to detect the `forge` CLI install (Hard Rules #15 + #17, #7263)
+  "src/app/api/cli-tools/jcode-settings", // GET calls getCliRuntimeStatus() to detect the `jcode` CLI install (Hard Rules #15 + #17, #7263)
 ];
 
 // Frozen pre-existing exceptions: spawn-capable routes NOT yet classified

--- a/src/server/authz/routeGuard.ts
+++ b/src/server/authz/routeGuard.ts
@@ -32,6 +32,8 @@ export const LOCAL_ONLY_API_PREFIXES: ReadonlyArray<string> = [
   "/api/cli-tools/omp-settings", // spawns `which omp` to detect the CLI install (Hard Rules #15 + #17, #6318)
   "/api/cli-tools/letta-settings", // spawns `which letta` to detect the CLI install (Hard Rules #15 + #17, #6318)
   "/api/cli-tools/grok-build-settings", // GET calls getCliRuntimeStatus("grok-build"), which spawns a child process to locate + healthcheck the `grok` binary — same transitive-spawn surface that classified /api/skills/collect/ (Hard Rules #15 + #17). Writing ~/.grok/config.toml is inherently a local-machine operation, so loopback-only costs no real capability.
+  "/api/cli-tools/forge-settings", // spawns via getCliRuntimeStatus() to detect the `forge` CLI install (Hard Rules #15 + #17, #7263)
+  "/api/cli-tools/jcode-settings", // spawns via getCliRuntimeStatus() to detect the `jcode` CLI install (Hard Rules #15 + #17, #7263)
   "/api/services/", // T-10: embedded service lifecycle (spawn child processes)
   "/dashboard/providers/services/", // T-07: reverse proxy to embedded service UIs
   "/api/copilot/", // unauthenticated LLM driver — CLI-only by default; admins can opt-in to remote access via manage-scope bypass

--- a/tests/unit/route-guard-forge-jcode-settings-local-only.test.ts
+++ b/tests/unit/route-guard-forge-jcode-settings-local-only.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Security regression: /api/cli-tools/forge-settings and /api/cli-tools/jcode-settings
+ * must be classified as LOCAL_ONLY so loopback enforcement runs unconditionally before
+ * any auth check.
+ *
+ * GET calls getCliRuntimeStatus(TOOL_ID) (src/app/api/cli-tools/forge-settings/route.ts,
+ * src/app/api/cli-tools/jcode-settings/route.ts), which spawns a child process to locate
+ * and healthcheck the CLI binary (src/shared/services/cliRuntime.ts:332). That is the same
+ * transitive-spawn surface that got /api/cli-tools/grok-build-settings and
+ * /api/skills/collect/ classified.
+ *
+ * Classifying it LOCAL_ONLY closes the remote-RCE vector: a leaked JWT over a
+ * Cloudflared/Ngrok tunnel cannot trigger process spawning.
+ * Hard Rules #15 + #17. See docs/security/ROUTE_GUARD_TIERS.md. Issue #7263.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isLocalOnlyPath } from "../../src/server/authz/routeGuard.ts";
+
+test("/api/cli-tools/forge-settings is LOCAL_ONLY (spawns via getCliRuntimeStatus)", () => {
+  assert.equal(isLocalOnlyPath("/api/cli-tools/forge-settings"), true);
+});
+
+test("/api/cli-tools/forge-settings with trailing slash is LOCAL_ONLY", () => {
+  assert.equal(isLocalOnlyPath("/api/cli-tools/forge-settings/"), true);
+});
+
+test("/api/cli-tools/jcode-settings is LOCAL_ONLY (spawns via getCliRuntimeStatus)", () => {
+  assert.equal(isLocalOnlyPath("/api/cli-tools/jcode-settings"), true);
+});
+
+test("/api/cli-tools/jcode-settings with trailing slash is LOCAL_ONLY", () => {
+  assert.equal(isLocalOnlyPath("/api/cli-tools/jcode-settings/"), true);
+});
+
+test("sibling cli-tools spawn-capable settings routes stay LOCAL_ONLY", () => {
+  // Guards against a refactor dropping the established precedent this entry follows.
+  assert.equal(isLocalOnlyPath("/api/cli-tools/omp-settings"), true);
+  assert.equal(isLocalOnlyPath("/api/cli-tools/letta-settings"), true);
+  assert.equal(isLocalOnlyPath("/api/cli-tools/grok-build-settings"), true);
+});
+
+test("non-spawning cli-tools routes are NOT over-gated by this entry", () => {
+  // The new prefixes must not accidentally widen to the whole /api/cli-tools/ subtree,
+  // which remote dashboards legitimately use.
+  assert.equal(isLocalOnlyPath("/api/cli-tools/all-statuses"), false);
+  assert.equal(isLocalOnlyPath("/api/cli-tools/keys"), false);
+});


### PR DESCRIPTION
Closes #7263

## Root cause

`GET /api/cli-tools/forge-settings` and `GET /api/cli-tools/jcode-settings` both call
`getCliRuntimeStatus()` (`src/shared/services/cliRuntime.ts:332`), which `spawn()`s a
child process to locate/healthcheck the CLI binary. Neither prefix was present in
`LOCAL_ONLY_API_PREFIXES` (`src/server/authz/routeGuard.ts`), so `isLocalOnlyPath()`
returned `false` for both — loopback enforcement was skipped, so a leaked JWT via a
tunnel could trigger the spawn (Hard Rules #15 + #17).

The gate meant to catch this (`scripts/check/check-route-guard-membership.ts`) missed
it because its `SPAWN_CAPABLE_ROUTE_ROOTS` static allowlist didn't include these two
route dirs, and its regex-based source scan only flags files that *directly* import
`child_process`/`worker_threads` or call `spawn`/`exec`/`execFile` — these routes only
call the shared `getCliRuntimeStatus()` helper, so the transitive spawn was invisible
to the regex.

## Fix

1. Added `/api/cli-tools/forge-settings` and `/api/cli-tools/jcode-settings` to
   `LOCAL_ONLY_API_PREFIXES` in `src/server/authz/routeGuard.ts`, mirroring the existing
   `grok-build-settings`/`omp-settings`/`letta-settings` precedent entries.
2. Extended `SPAWN_CAPABLE_ROUTE_ROOTS` in `scripts/check/check-route-guard-membership.ts`
   to register these two route dirs, so the gate's first subcheck now structurally
   verifies them (mirroring the `skills/collect` precedent) — without widening the
   regex-based source-scan subcheck, which would have flagged ~12 additional unrelated
   `*-settings` routes noted in the triage analysis as out of scope for this fix.

## Regression test

`tests/unit/route-guard-forge-jcode-settings-local-only.test.ts` — reused from the
triage-fix-bugs repro probe, extended with sibling-precedent and non-over-gating checks.

RED (unfixed code, 4/4 failing):
```
✖ /api/cli-tools/forge-settings is LOCAL_ONLY (spawns via getCliRuntimeStatus)
  AssertionError: false !== true
✖ /api/cli-tools/forge-settings with trailing slash is LOCAL_ONLY
  AssertionError: false !== true
✖ /api/cli-tools/jcode-settings is LOCAL_ONLY (spawns via getCliRuntimeStatus)
  AssertionError: false !== true
✖ /api/cli-tools/jcode-settings with trailing slash is LOCAL_ONLY
  AssertionError: false !== true
```

GREEN (fixed code, 6/6 passing):
```
✔ /api/cli-tools/forge-settings is LOCAL_ONLY (spawns via getCliRuntimeStatus)
✔ /api/cli-tools/forge-settings with trailing slash is LOCAL_ONLY
✔ /api/cli-tools/jcode-settings is LOCAL_ONLY (spawns via getCliRuntimeStatus)
✔ /api/cli-tools/jcode-settings with trailing slash is LOCAL_ONLY
✔ sibling cli-tools spawn-capable settings routes stay LOCAL_ONLY
✔ non-spawning cli-tools routes are NOT over-gated by this entry
```

## Scope note

The triage analysis (`_tasks/pipeline/bugs/2-implementing/7263-...plan.md`) found ~12
more `*-settings` routes with the identical `getCliRuntimeStatus()` gap
(qwen-settings, codewhale-settings, smelt-settings, deepseek-tui-settings,
kilo-settings, claude-settings, codex-settings, pi-settings, droid-settings,
cline-settings, openclaw-settings, crush-settings) plus `/api/cli-tools/status` and
`/api/cli-tools/all-statuses`. This PR intentionally fixes only the 2 routes named in
#7263, per scope. A follow-up issue should track closing the remaining ~14.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/route-guard-forge-jcode-settings-local-only.test.ts` — 6/6 pass
- `node --import tsx/esm --test tests/unit/authz/routeGuard.test.ts tests/unit/check-route-guard-membership.test.ts tests/unit/route-guard-grok-build-settings-local-only.test.ts tests/unit/openapi-security-tiers.test.ts` — 54/54 pass
- `node --import tsx/esm scripts/check/check-route-guard-membership.ts` → OK, 48 routes in 7 roots, 0 new gaps
- `node scripts/check/check-file-size.mjs` — no violations on touched files
- `node scripts/check/check-complexity.mjs` — OK (2058 vs baseline 2059)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 vs baseline 890)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 errors
- `node scripts/check/check-changelog-integrity.mjs` — OK
