### PR TITLE
fix(routing): honor eye-icon hidden models for no-auth providers in auto-combo (#7620)

### DIFF
--- a/changelog.d/fixes/7620-noauth-hidden-filter.md
+++ b/changelog.d/fixes/7620-noauth-hidden-filter.md
@@ -1,0 +1,1 @@
+- fix(routing): honor eye-icon hidden models for no-auth providers in auto-combo candidate pools (#7620)

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -140,7 +140,8 @@ function getNoAuthCandidates(
   excludedProviders: Set<string>,
   blockedProviders: Set<string>,
   disabledNoAuthProviders: Set<string>,
-  noAuthProviderSpecificData: Map<string, Record<string, unknown> | null | undefined>
+  noAuthProviderSpecificData: Map<string, Record<string, unknown> | null | undefined>,
+  hiddenModelsMap: Map<string, Set<string>>
 ): VirtualAutoComboCandidate[] {
   const registry = getProviderRegistry();
   const candidates: VirtualAutoComboCandidate[] = [];
@@ -190,10 +191,19 @@ function getNoAuthCandidates(
         ? noAuthProviderSpecificData.get(providerDef.alias)
         : undefined);
 
+    // #7620: honor the eye-icon "hidden" flag (isHidden, from the
+    // modelCompatOverrides/customModels key_value namespaces) the same way the
+    // credentialed-connection loop below does, so a hidden no-auth model never
+    // enters the auto-combo/fusion candidate pool either.
+    const hiddenModels =
+      hiddenModelsMap.get(providerId) ??
+      (typeof providerDef.alias === "string" ? hiddenModelsMap.get(providerDef.alias) : undefined);
+
     for (const model of registryModels) {
       const modelId = typeof model?.id === "string" && model.id.trim().length > 0 ? model.id : null;
       if (!modelId) continue;
       if (isModelExcludedByConnection(modelId, providerSpecificData)) continue;
+      if (hiddenModels?.has(modelId)) continue;
       candidates.push({
         provider: providerId,
         connectionId: SYNTHETIC_NOAUTH_CONNECTION_ID,
@@ -323,7 +333,8 @@ export async function createVirtualAutoCombo(
       new Set(validConnections.map((conn) => conn.provider)),
       blockedProviders,
       disabledNoAuthProviders,
-      noAuthProviderSpecificData
+      noAuthProviderSpecificData,
+      hiddenModelsMap
     )
   );
 

--- a/tests/unit/noauth-autocombo-hidden-7620.test.ts
+++ b/tests/unit/noauth-autocombo-hidden-7620.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #7620 — hiding a no-auth-provider model with the EYE icon (Dashboard → Models,
+ * `isHidden: true` written via setModelIsHidden()/mergeModelCompatOverride()) does
+ * remove it from `/v1/models`, but `getNoAuthCandidates()` in
+ * `open-sse/services/autoCombo/virtualFactory.ts` never consults
+ * `getHiddenModelsByProvider()` at all (unlike the credentialed-connection loop a
+ * few lines above it, which does). A hidden no-auth model therefore stays in the
+ * `auto/*` candidate pool and can still be selected, causing a 401 when the
+ * upstream account for that hidden model is no longer valid/allowed.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7620-noauth-hidden-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const virtualFactory = await import("../../open-sse/services/autoCombo/virtualFactory.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  await resetStorage();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+});
+
+test("#7620: a no-auth model hidden via the eye icon (isHidden:true) must be ABSENT from the auto-combo candidate pool", async () => {
+  modelsDb.setModelIsHidden("opencode", "mimo-v2.5-free", true);
+
+  const hiddenMap = modelsDb.getHiddenModelsByProvider();
+  assert.equal(
+    hiddenMap.get("opencode")?.has("mimo-v2.5-free"),
+    true,
+    "sanity: getHiddenModelsByProvider() must report opencode/mimo-v2.5-free as hidden"
+  );
+
+  const combo = await virtualFactory.createVirtualAutoCombo(undefined);
+
+  const modelStrings = combo.models.map((m: { model: string }) => m.model);
+  assert.ok(
+    !modelStrings.some((model: string) => model.endsWith("/mimo-v2.5-free")),
+    "BUG #7620: the eye-hidden model 'mimo-v2.5-free' must not appear in the auto-combo " +
+      `candidate pool, but it did. Pool: ${JSON.stringify(modelStrings)}`
+  );
+});
+
+test("#7620 baseline: with nothing hidden, opencode/mimo-v2.5-free is present in the pool", async () => {
+  const combo = await virtualFactory.createVirtualAutoCombo(undefined);
+  const modelStrings = combo.models.map((m: { model: string }) => m.model);
+  assert.ok(
+    modelStrings.some((model: string) => model.endsWith("/mimo-v2.5-free")),
+    `baseline: with nothing hidden, mimo-v2.5-free must be present. Pool: ${JSON.stringify(modelStrings)}`
+  );
+});


### PR DESCRIPTION
Closes #7620

## Root cause

`getNoAuthCandidates()` in `open-sse/services/autoCombo/virtualFactory.ts` builds
the auto-combo candidate pool for no-auth providers (opencode/mimocode/etc.) but
never consulted `getHiddenModelsByProvider()` — unlike the credentialed-connection
loop a few lines above it, which does. A model hidden via the dashboard eye icon
(`isHidden: true`, written through `setModelIsHidden()`) therefore stayed in every
`auto/*` candidate pool forever and could still be selected, causing a 401 when the
upstream account for that hidden model was no longer valid/allowed.

The reporter's own key-mismatch theory wasn't quite right, but the conclusion
(no-auth hidden models leak into auto-combo) was correct, and the fix location
(`virtualFactory.ts`) was correct too. Same class of bug as #7622 (which wired
`providerSpecificData.excludedModels` into the same function for a sibling field)
— this fix follows the same pattern for `isHidden`.

## Fix

- Added a `hiddenModelsMap` parameter to `getNoAuthCandidates()`.
- Added a `hiddenModels?.has(modelId)` check inside the per-model loop, with the
  same alias fallback already used for `providerSpecificData` lookups.
- Passed `hiddenModelsMap` at the call site alongside the existing
  `noAuthProviderSpecificData` argument.

## Regression test (TDD, Hard Rule #18)

`tests/unit/noauth-autocombo-hidden-7620.test.ts` — hides `opencode/mimo-v2.5-free`
via `setModelIsHidden()`, then builds a virtual auto-combo and asserts the model is
absent from the pool. Confirmed RED on unfixed code (model present in pool of 76
candidates), GREEN after the fix.

```
node --import tsx/esm --test tests/unit/noauth-autocombo-hidden-7620.test.ts
```

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/noauth-autocombo-hidden-7620.test.ts` — 2/2 pass
- Sibling tests of the touched function/file, all still green:
  `noauth-autocombo-exclude-7622.test.ts`, `auto-combo-hidden-models-4558.test.ts`,
  `auto-combos-free-models-routes.test.ts`, `auto-combo-context-advertising.test.ts`,
  `virtual-auto-combo.test.ts`, `auto-custom-provider-5873.test.ts`,
  `repro-6557-noauth-connection-disable-ignored.test.ts`,
  `autoCombo/paid-model-filter-6512.test.ts` (via `npx vitest run --config vitest.mcp.config.ts`)
- `node scripts/check/check-file-size.mjs` — no ✗ on touched files
- `node scripts/check/check-complexity.mjs` — OK (2058 vs baseline 2059)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890, baseline 890)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/autoCombo/virtualFactory.ts tests/unit/noauth-autocombo-hidden-7620.test.ts` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK
