### PR TITLE
fix(docs): heal release-green docs drift + eslint any-suppression drift (#7253)

### DIFF
--- a/changelog.d/fixes/7253-release-green-drift.md
+++ b/changelog.d/fixes/7253-release-green-drift.md
@@ -1,0 +1,1 @@
+- fix(docs): correct stale `/api/version` and migration-125 references + realign `no-explicit-any` suppression counts drifted by base-red realignment commits (#7253)

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -599,7 +599,7 @@
   },
   "tests/unit/base-executor-sanitize-effort.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 45
+      "count": 48
     }
   },
   "tests/unit/batch_api.test.ts": {
@@ -1024,7 +1024,7 @@
   },
   "tests/unit/combo-routing-engine.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 261
+      "count": 269
     }
   },
   "tests/unit/combo-same-provider-cascade.test.ts": {

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -99,7 +99,7 @@ not** skip steps; each is timed.
 
 ### 4.2 Cluster-wide latency regression
 
-1. Check the most recent deploy (`/api/version` returns the SHA).
+1. Check the most recent deploy (`/api/system/version` returns the SHA).
 2. If p95 doubled vs the 7-day baseline, **roll back** to the prior
    SHA via `bin/rollback.sh`.
 3. If the regression is provider-side, see § 4.1.

--- a/docs/PERF_BUDGETS.md
+++ b/docs/PERF_BUDGETS.md
@@ -125,7 +125,7 @@ flag in the weekly perf review.
 | Endpoint | Method | p50 | p95 | p99 |
 |---|---|---|---|---|
 | `/api/health/ping` | GET | 5 ms | 20 ms | 50 ms |
-| `/api/version` | GET | 5 ms | 20 ms | 50 ms |
+| `/api/system/version` | GET | 5 ms | 20 ms | 50 ms |
 | `/api/docs` | GET | 20 ms | 80 ms | 200 ms (HTML shell, no provider call) |
 
 ---

--- a/docs/routing/REASONING_ROUTING.md
+++ b/docs/routing/REASONING_ROUTING.md
@@ -64,7 +64,7 @@ executed there. The rule decision is stored in the existing route trace without 
 
 ## Persistence
 
-The migration `src/lib/db/migrations/125_reasoning_routing_rules.sql` creates the
+The migration `src/lib/db/migrations/126_reasoning_routing_rules.sql` creates the
 `reasoning_routing_rules` table. Rules reference stored API keys, combos, and provider connections.
 Deletes clean up related rules. The database access layer in
 `src/lib/db/reasoningRoutingRules.ts` maintains an invalidatable cache for the request path.

--- a/tests/unit/call-log-provider-display.test.ts
+++ b/tests/unit/call-log-provider-display.test.ts
@@ -107,8 +107,8 @@ test("buildCallLogListRows adds providerDisplay to active and completed in-memor
     ],
   });
 
-  const pending = rows.find((row: any) => row.id === "pending-1");
-  const completed = rows.find((row: any) => row.id === "completed-1");
+  const pending = rows.find((row) => row.id === "pending-1");
+  const completed = rows.find((row) => row.id === "completed-1");
 
   assert.equal(pending?.providerDisplay, "Bynara");
   assert.equal(completed?.providerDisplay, "Bynara");

--- a/tests/unit/m365-web-token-extraction-7078.test.ts
+++ b/tests/unit/m365-web-token-extraction-7078.test.ts
@@ -5,8 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const B = await import("../../src/lib/providers/validation/webProvidersB.ts");
-const extract = (raw: string) =>
-  (B as Record<string, any>).extractM365CredentialParts(raw, {});
+const extract = (raw: string) => B.extractM365CredentialParts(raw, {});
 
 test("#7078 m365.cloud.microsoft wss URL extracts access_token + chathubPath", () => {
   const raw =

--- a/tests/unit/release-green-docs-drift-7253.test.ts
+++ b/tests/unit/release-green-docs-drift-7253.test.ts
@@ -1,0 +1,39 @@
+// Issue #7253 — the "release branch not green" bot tracker for release/v3.8.49
+// found the branch genuinely red for `check:fabricated-docs --strict`: two doc
+// files referenced a migration file / API route that no longer exist under
+// those names (docs went stale after src/ moved on):
+//   - docs/routing/REASONING_ROUTING.md:67  -> migration renumbered 125 -> 126
+//   - docs/INCIDENT_RESPONSE.md / docs/PERF_BUDGETS.md -> `/api/version` route
+//     was renamed to `/api/system/version`
+//
+// This runs the real doc-accuracy checker against the live repo tree (no
+// fixture root override) so it keeps guarding against future doc drift, not
+// just the two specific lines fixed here.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runFabricatedDocsCheck, formatHumanReport } from "../../scripts/check/check-fabricated-docs.mjs";
+
+test("#7253 release-green: docs contain zero fabricated API/file-ref drift", () => {
+  const result = runFabricatedDocsCheck();
+  if (result.totalFindings > 0) {
+    assert.fail(`fabricated-docs drift found:\n${formatHumanReport(result)}`);
+  }
+  assert.equal(result.totalFindings, 0);
+});
+
+test("#7253: REASONING_ROUTING.md references the current migration filename (126, not 125)", () => {
+  const result = runFabricatedDocsCheck();
+  const hit = result.files
+    .flatMap((f) => f.findings.map((finding) => ({ file: f.rel, ...finding })))
+    .find((f) => f.value === "src/lib/db/migrations/125_reasoning_routing_rules.sql");
+  assert.equal(hit, undefined, "stale migration-125 reference must not resurface");
+});
+
+test("#7253: INCIDENT_RESPONSE.md / PERF_BUDGETS.md reference /api/system/version, not the removed /api/version", () => {
+  const result = runFabricatedDocsCheck();
+  const hit = result.files
+    .flatMap((f) => f.findings.map((finding) => ({ file: f.rel, ...finding })))
+    .find((f) => f.value === "/api/version");
+  assert.equal(hit, undefined, "stale /api/version reference must not resurface");
+});


### PR DESCRIPTION
Refs #7253

Issue #7253 is the bot-maintained "release branch not green" tracker for `release/v3.8.49` — it gets a new comment with a different failure snapshot on every push, so most historical comments describe already-superseded states. This PR fixes the two concrete gate failures reproduced against the current tip.

## Root cause

**A. `docs-sync-strict` / `check:fabricated-docs --strict`**
- `docs/routing/REASONING_ROUTING.md:67` referenced `src/lib/db/migrations/125_reasoning_routing_rules.sql`, but that migration is now numbered `126_reasoning_routing_rules.sql` (slot 125 is occupied by an unrelated migration, `125_provider_connection_quota_visibility.sql`).
- `docs/INCIDENT_RESPONSE.md` and `docs/PERF_BUDGETS.md` both referenced `/api/version`, which doesn't exist. The real route is `/api/system/version` (`src/app/api/system/version/route.ts`).

**B. ESLint — 320 errors**
- `no-explicit-any` is `error` in `tests/`, with pre-existing violations frozen per-file in `config/quality/eslint-suppressions.json` via ESLint's native bulk-suppression mechanism (any drift from the frozen count — grown or shrunk — unsuppresses **all** violations for that file+rule).
- `tests/unit/combo-routing-engine.test.ts` (frozen at 261, live 269) and `tests/unit/base-executor-sanitize-effort.test.ts` (frozen at 45, live 48) drifted because the "base-red full-suite realignment" commits (`dbc9f6081`, `764a4aee0`) grew them — the sibling test-file-size ratchet for the same growth was already rebaselined in `00b853969`, but this gate was missed in that pass. Rebaselined both counts to the live totals.
- `tests/unit/call-log-provider-display.test.ts` (2) and `tests/unit/m365-web-token-extraction-7078.test.ts` (1) had brand-new, never-baselined `any` usages — fixed the cause instead of suppressing (removed the redundant explicit `any` annotations; both already inferred correctly from context).

## Regression test

New file `tests/unit/release-green-docs-drift-7253.test.ts` drives the real `check-fabricated-docs.mjs` checker (`runFabricatedDocsCheck()`) against the live repo tree, so it also guards future doc drift, not just these two lines.

- RED (docs reverted to `origin/release/v3.8.49` state): the two `/api/version` and migration-125 assertions failed with the exact drift findings reproduced in the plan-file.
- GREEN (with the fix applied): all 3 assertions pass.

```
node --import tsx/esm --test tests/unit/release-green-docs-drift-7253.test.ts
```

## Gates run (all green)

```
node scripts/check/check-fabricated-docs.mjs --strict   # exit 0
npm run lint                                              # 0 errors, 1 pre-existing warning
node scripts/check/check-file-size.mjs                    # OK
node scripts/check/check-complexity.mjs                   # OK (2058/2059 baseline)
node scripts/check/check-cognitive-complexity.mjs         # OK (890/890 baseline)
npm run typecheck:core                                    # exit 0
npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>  # exit 0
node scripts/check/check-changelog-integrity.mjs          # OK
node --import tsx/esm --test tests/unit/check-fabricated-docs.test.ts tests/unit/validate-release-green.test.ts  # 41/41 pass
node --import tsx/esm --test tests/unit/call-log-provider-display.test.ts tests/unit/m365-web-token-extraction-7078.test.ts  # 7/7 pass
```

Scope: docs fixes + `eslint-suppressions.json` rebaseline + aligning the two test files with brand-new `any` usages. No changes to `.github/workflows/ci.yml`, per instruction.

Using `Refs #7253` (not `Closes`) because this meta-issue is a rolling bot tracker — later commits on the branch may surface a different failure snapshot; this PR only closes the two specific gate failures reproduced here.
