### PR TITLE
fix(ci): build API-only smoke workflows backend-only to fix dast-smoke timeouts (#7226)

### DIFF
--- a/.github/workflows/dast-smoke.yml
+++ b/.github/workflows/dast-smoke.yml
@@ -27,6 +27,8 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Build CLI bundle
+        env:
+          OMNIROUTE_BUILD_BACKEND_ONLY: "1"
         run: npm run build:cli
       - name: Start OmniRoute
         env:

--- a/.github/workflows/nightly-llm-security.yml
+++ b/.github/workflows/nightly-llm-security.yml
@@ -19,7 +19,9 @@ jobs:
         with: { node-version: "24", cache: npm }
       - run: npm ci
       - name: Build CLI bundle
-        env: { JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation }
+        env:
+          JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
+          OMNIROUTE_BUILD_BACKEND_ONLY: "1"
         run: npm run build:cli
       - name: Start OmniRoute (block mode)
         env:
@@ -72,7 +74,9 @@ jobs:
         if: steps.gate.outputs.run == 'true'
       - name: Build CLI bundle
         if: steps.gate.outputs.run == 'true'
-        env: { JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation }
+        env:
+          JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
+          OMNIROUTE_BUILD_BACKEND_ONLY: "1"
         run: npm run build:cli
       - name: Start OmniRoute
         if: steps.gate.outputs.run == 'true'

--- a/.github/workflows/nightly-resilience.yml
+++ b/.github/workflows/nightly-resilience.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Build CLI bundle
         env:
           JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
+          OMNIROUTE_BUILD_BACKEND_ONLY: "1"
         run: npm run build:cli
       - name: Start OmniRoute (background)
         env:

--- a/.github/workflows/nightly-schemathesis.yml
+++ b/.github/workflows/nightly-schemathesis.yml
@@ -20,7 +20,9 @@ jobs:
         with: { node-version: "24", cache: npm }
       - run: npm ci
       - name: Build CLI bundle
-        env: { JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation }
+        env:
+          JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
+          OMNIROUTE_BUILD_BACKEND_ONLY: "1"
         run: npm run build:cli
       - name: Start OmniRoute (background)
         env:

--- a/changelog.d/fixes/7226-dast-smoke-backend-only.md
+++ b/changelog.d/fixes/7226-dast-smoke-backend-only.md
@@ -1,0 +1,1 @@
+- fix(ci): build dast-smoke and nightly API-only smoke workflows with `OMNIROUTE_BUILD_BACKEND_ONLY=1` to skip the unused dashboard UI graph and stop the multi-minute build variance/timeouts (#7226)

--- a/tests/unit/build/backend-only-smoke-workflows.test.ts
+++ b/tests/unit/build/backend-only-smoke-workflows.test.ts
@@ -1,0 +1,88 @@
+// Regression guard for #7226: API-only smoke/nightly workflows must build with
+// OMNIROUTE_BUILD_BACKEND_ONLY=1 so `npm run build:cli`'s fallback full build
+// (scripts/build/prepublish.ts -> build-next-isolated.mjs) skips the ~126-leaf-page
+// dashboard UI graph these workflows never exercise. Without this env var, the
+// "Build CLI bundle" step silently runs a full Next.js production build inline,
+// which is the actual source of the multi-minute variance/timeouts reported in #7226.
+//
+// npm-publish.yml is intentionally excluded: its "Build CLI bundle (standalone app)"
+// step legitimately ships the full dashboard UI in the published npm package.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import * as yaml from "js-yaml";
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+  env?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface WorkflowJob {
+  steps: WorkflowStep[];
+  [key: string]: unknown;
+}
+
+interface WorkflowDoc {
+  jobs: Record<string, WorkflowJob>;
+  [key: string]: unknown;
+}
+
+const WORKFLOWS_DIR = path.join(process.cwd(), ".github", "workflows");
+
+function loadWorkflow(fileName: string): WorkflowDoc {
+  const raw = fs.readFileSync(path.join(WORKFLOWS_DIR, fileName), "utf8");
+  return yaml.load(raw) as WorkflowDoc;
+}
+
+function isBackendOnly(step: WorkflowStep): boolean {
+  const env = step.env || {};
+  return env.OMNIROUTE_BUILD_BACKEND_ONLY === "1" || env.OMNIROUTE_BUILD_PROFILE === "backend";
+}
+
+// jobName: null selector means "any job" — used when a file has exactly one
+// "Build CLI bundle" step but we don't want to hardcode/duplicate the job key.
+interface Target {
+  file: string;
+  jobName: string;
+  stepName: string;
+}
+
+const TARGETS: Target[] = [
+  { file: "dast-smoke.yml", jobName: "dast-smoke", stepName: "Build CLI bundle" },
+  { file: "nightly-schemathesis.yml", jobName: "schemathesis", stepName: "Build CLI bundle" },
+  { file: "nightly-resilience.yml", jobName: "k6-soak", stepName: "Build CLI bundle" },
+  { file: "nightly-llm-security.yml", jobName: "promptfoo-guard", stepName: "Build CLI bundle" },
+  { file: "nightly-llm-security.yml", jobName: "garak", stepName: "Build CLI bundle" },
+];
+
+for (const { file, jobName, stepName } of TARGETS) {
+  test(`${file} :: ${jobName} '${stepName}' step sets OMNIROUTE_BUILD_BACKEND_ONLY=1 (skips dashboard UI build the API-only smoke job never exercises)`, () => {
+    const doc = loadWorkflow(file);
+    const job = doc.jobs[jobName];
+    assert.ok(job, `${file} must have a '${jobName}' job`);
+    const step = job.steps.find((s) => s.name === stepName);
+    assert.ok(step, `${file}'s '${jobName}' job must have a '${stepName}' step`);
+    assert.equal(
+      isBackendOnly(step),
+      true,
+      `${file}'s '${jobName}' -> '${stepName}' step must set OMNIROUTE_BUILD_BACKEND_ONLY=1 or OMNIROUTE_BUILD_PROFILE=backend`
+    );
+  });
+}
+
+test("npm-publish.yml 'Build CLI bundle (standalone app)' step must NOT be backend-only (it legitimately ships the full dashboard UI)", () => {
+  const doc = loadWorkflow("npm-publish.yml");
+  const publishJob = Object.values(doc.jobs).find((job) =>
+    job.steps.some((s) => s.name === "Build CLI bundle (standalone app)")
+  );
+  assert.ok(publishJob, "npm-publish.yml must have a job with a 'Build CLI bundle (standalone app)' step");
+  const step = publishJob!.steps.find((s) => s.name === "Build CLI bundle (standalone app)")!;
+  assert.equal(
+    isBackendOnly(step),
+    false,
+    "npm-publish.yml's build step must ship the full dashboard UI, not the backend-only stub"
+  );
+});


### PR DESCRIPTION
Closes #7226

## Root cause

`dast-smoke.yml`'s "Build CLI bundle" step (and 3 sibling nightly workflows) ran `npm run build:cli` with no preceding `npm run build` step and no downloaded `.build/next` artifact. `scripts/build/prepublish.ts` silently falls back to running a **full** Next.js production build (dashboard UI + ~126 leaf pages + prerender) inline whenever `.build/next/standalone/server.js` is missing — which it always is in these jobs. That inline full build is the thing actually varying 6-29min on GitHub-hosted runners (documented in `scripts/build/build-next-isolated.mjs`'s own inline comments: "~20min -> 7min on ubuntu-latest").

These jobs only ever exercise API routes — schemathesis/promptfoo hit `/api/monitoring/health`, `/v1/chat/completions`, `/v1/models`, `/api/auth`, `/api/keys` — and never touch the dashboard UI, so they're the exact intended consumer of the codebase's existing (previously unused) `OMNIROUTE_BUILD_BACKEND_ONLY=1` escape hatch (`scripts/build/backendOnlyPages.mjs`), which stubs the dashboard page tree before the build and restores it after, leaving every `route.ts` API handler intact.

## Fix

Added `OMNIROUTE_BUILD_BACKEND_ONLY: "1"` to the "Build CLI bundle" step's `env` in:
- `.github/workflows/dast-smoke.yml`
- `.github/workflows/nightly-schemathesis.yml`
- `.github/workflows/nightly-resilience.yml` (`k6-soak` job)
- `.github/workflows/nightly-llm-security.yml` (both occurrences: `promptfoo-guard` and `garak` jobs)

`npm-publish.yml`'s "Build CLI bundle (standalone app)" step is intentionally **untouched** — that job legitimately ships the full dashboard UI in the published npm package.

## Regression test (Hard Rule #18 — TDD)

`tests/unit/build/backend-only-smoke-workflows.test.ts` (static YAML-config guard, extending the pattern in the plan-file's probe and `tests/unit/build/check-workflows.test.ts`):

```
node --import tsx/esm --test tests/unit/build/backend-only-smoke-workflows.test.ts
```

RED (before fix, 5 fail / 1 pass — all 5 "Build CLI bundle" steps across the 4 target workflows lacked the env var; the npm-publish.yml negative-assertion already passed):
```
✖ dast-smoke.yml :: dast-smoke 'Build CLI bundle' step sets OMNIROUTE_BUILD_BACKEND_ONLY=1 ...
✖ nightly-schemathesis.yml :: schemathesis 'Build CLI bundle' step sets OMNIROUTE_BUILD_BACKEND_ONLY=1 ...
✖ nightly-resilience.yml :: k6-soak 'Build CLI bundle' step sets OMNIROUTE_BUILD_BACKEND_ONLY=1 ...
✖ nightly-llm-security.yml :: promptfoo-guard 'Build CLI bundle' step sets OMNIROUTE_BUILD_BACKEND_ONLY=1 ...
✖ nightly-llm-security.yml :: garak 'Build CLI bundle' step sets OMNIROUTE_BUILD_BACKEND_ONLY=1 ...
✔ npm-publish.yml 'Build CLI bundle (standalone app)' step must NOT be backend-only ...
tests 6, pass 1, fail 5
```

GREEN (after fix):
```
✔ dast-smoke.yml :: dast-smoke ...
✔ nightly-schemathesis.yml :: schemathesis ...
✔ nightly-resilience.yml :: k6-soak ...
✔ nightly-llm-security.yml :: promptfoo-guard ...
✔ nightly-llm-security.yml :: garak ...
✔ npm-publish.yml 'Build CLI bundle (standalone app)' step must NOT be backend-only ...
tests 6, pass 6, fail 0
```

This is a static/YAML-config regression guard (per the plan-file), not a timed GH-hosted CI repro — a real timing comparison isn't practical to run repeatedly in an analysis pass.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` → OK (no new/frozen file violations)
- `node scripts/check/check-complexity.mjs` → OK (2058 vs baseline 2059)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (890 vs baseline 890)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/build/backend-only-smoke-workflows.test.ts` → exit 0
- `node scripts/check/check-changelog-integrity.mjs` → OK
- All 4 edited workflow files re-parsed with `js-yaml` to confirm valid YAML after edit

## Residual risk (flagged per the plan-file)

Not verified in this PR with a real GH-hosted run: (a) that `/api/monitoring/health`, `/v1/chat/completions`, `/v1/models`, `/api/auth`, `/api/keys` all still resolve correctly from a backend-only-stubbed standalone build, and (b) that wall-clock time/variance actually drops as expected. Per `backendOnlyPages.mjs`'s design, only UI files under `src/app/**/page|layout|...` are stubbed and `route.ts` files are untouched, so this should be safe — but the actual CI run on this PR is the first real-runner confirmation.
