### PR TITLE
fix(cli): load DATA_DIR/server.env as fallback for .env on Electron migration (#7302)

### DIFF
--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -14,7 +14,7 @@
  * All other commands are routed through Commander (bin/cli/program.mjs).
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import updateNotifier from "update-notifier";
@@ -59,6 +59,28 @@ if (process.argv.includes("--mcp")) {
   console.warn = stderrConsole.warn.bind(stderrConsole);
 }
 
+// Electron persists secrets (JWT_SECRET, API_KEY_SECRET, STORAGE_ENCRYPTION_KEY) to
+// `<DATA_DIR>/server.env` (electron/main.js), never `.env`. Migrating an existing
+// install (storage.sqlite + server.env) to the CLI left those secrets undiscoverable —
+// the CLI only ever looked for `.env`, so the STORAGE_ENCRYPTION_KEY needed to decrypt
+// the migrated database was silently dropped (#7302). One-time, one-directory migration:
+// if `<dataDir>/.env` is absent but `<dataDir>/server.env` is present, copy it to `.env`
+// so it flows through the normal env-loading path below. Never overwrites an existing
+// `.env` — an explicit `.env` always wins over a legacy `server.env`.
+function migrateElectronServerEnv(dataDir) {
+  try {
+    const envPath = join(dataDir, ".env");
+    const serverEnvPath = join(dataDir, "server.env");
+    if (existsSync(envPath) || !existsSync(serverEnvPath)) return;
+    writeFileSync(envPath, readFileSync(serverEnvPath, "utf-8"), "utf-8");
+    console.log(
+      `  \x1b[2m♻ Migrated Electron secrets from ${serverEnvPath} to ${envPath}\x1b[0m`
+    );
+  } catch {
+    // Ignore errors migrating server.env — fall back to normal env loading below.
+  }
+}
+
 function loadEnvFile() {
   const envPaths = [];
   const loadedEnvPaths = [];
@@ -68,6 +90,8 @@ function loadEnvFile() {
     seenEnvPaths.add(envPath);
     envPaths.push(envPath);
   };
+
+  migrateElectronServerEnv(process.env.DATA_DIR || getDefaultDataDir());
 
   if (process.env.DATA_DIR) {
     addEnvPath(join(process.env.DATA_DIR, ".env"));

--- a/changelog.d/fixes/7302-cli-electron-env.md
+++ b/changelog.d/fixes/7302-cli-electron-env.md
@@ -1,0 +1,1 @@
+- fix(cli): load DATA_DIR/server.env as a fallback for .env when migrating from Electron, so STORAGE_ENCRYPTION_KEY/JWT_SECRET/API_KEY_SECRET survive an Electron→CLI install migration (#7302)

--- a/tests/unit/cli-electron-to-cli-migration-server-env-7302.test.ts
+++ b/tests/unit/cli-electron-to-cli-migration-server-env-7302.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BIN = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "bin",
+  "omniroute.mjs"
+);
+
+function runCli(dataDir: string): { code: number | null; stdout: string; stderr: string } {
+  const cleanEnv = { ...process.env };
+  delete cleanEnv.STORAGE_ENCRYPTION_KEY;
+  delete cleanEnv.JWT_SECRET;
+  delete cleanEnv.API_KEY_SECRET;
+  delete cleanEnv.DATA_DIR;
+  const isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-migration-home-"));
+  try {
+    const res = spawnSync("node", [BIN, "config", "list", "--json"], {
+      cwd: dataDir,
+      env: {
+        ...cleanEnv,
+        DATA_DIR: dataDir,
+        HOME: isolatedHome,
+        USERPROFILE: isolatedHome,
+        NO_UPDATE_NOTIFIER: "1",
+        OMNIROUTE_CLI_SKIP_REPO_ENV: "1",
+      },
+      timeout: 60_000,
+      encoding: "utf-8",
+    });
+    return { code: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+  } finally {
+    fs.rmSync(isolatedHome, { recursive: true, force: true });
+  }
+}
+
+// #7302: Electron persists secrets to <DATA_DIR>/server.env (electron/main.js), but the CLI
+// (bin/omniroute.mjs) only ever loaded <DATA_DIR>/.env — so migrating storage.sqlite +
+// server.env from the desktop app to the CLI silently lost STORAGE_ENCRYPTION_KEY and
+// permanently corrupted every encrypted credential. The CLI must recognize server.env as a
+// legacy/migration fallback source when .env is absent, without letting it override an
+// existing .env.
+
+test("#7302: CLI must recognize DATA_DIR/server.env (Electron's secrets file) when migrating an existing database", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-migration-"));
+  try {
+    fs.writeFileSync(path.join(dir, "storage.sqlite"), "fake-existing-db-with-real-data");
+    const electronKey = "electron-storage-key-0123456789abcdef0123456789abcdef";
+    fs.writeFileSync(
+      path.join(dir, "server.env"),
+      [
+        "JWT_SECRET=electron-jwt-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "API_KEY_SECRET=electron-api-key-secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        `STORAGE_ENCRYPTION_KEY=${electronKey}`,
+        "STORAGE_ENCRYPTION_KEY_VERSION=v1",
+        "",
+      ].join("\n")
+    );
+
+    const { stderr } = runCli(dir);
+
+    const envPath = path.join(dir, ".env");
+    const envContent = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : "";
+    assert.match(
+      envContent,
+      new RegExp(`STORAGE_ENCRYPTION_KEY=${electronKey}`),
+      "the Electron-persisted STORAGE_ENCRYPTION_KEY from server.env must be honored " +
+        "after migrating to the CLI install — got .env content: " + JSON.stringify(envContent)
+    );
+
+    assert.doesNotMatch(
+      stderr,
+      /STORAGE_ENCRYPTION_KEY is not set but a database already exists/,
+      "the CLI should not need to refuse key generation — it should have found the " +
+        "Electron-persisted key in server.env"
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("#7302: an existing DATA_DIR/.env must still win over DATA_DIR/server.env when both exist", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-migration-winner-"));
+  try {
+    fs.writeFileSync(path.join(dir, "storage.sqlite"), "fake-existing-db-with-real-data");
+    const cliKey = "cli-owned-storage-key-fedcba9876543210fedcba9876543210";
+    const electronKey = "electron-storage-key-0123456789abcdef0123456789abcdef";
+    fs.writeFileSync(path.join(dir, ".env"), `STORAGE_ENCRYPTION_KEY=${cliKey}\n`);
+    fs.writeFileSync(path.join(dir, "server.env"), `STORAGE_ENCRYPTION_KEY=${electronKey}\n`);
+
+    runCli(dir);
+
+    const envContent = fs.readFileSync(path.join(dir, ".env"), "utf-8");
+    assert.match(
+      envContent,
+      new RegExp(`STORAGE_ENCRYPTION_KEY=${cliKey}`),
+      "an existing .env must never be overwritten by server.env"
+    );
+    assert.doesNotMatch(
+      envContent,
+      new RegExp(electronKey),
+      "server.env must not leak into an existing .env"
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #7302

## Root cause

Electron persists secrets (`JWT_SECRET`, `API_KEY_SECRET`, `STORAGE_ENCRYPTION_KEY`) to
`<DATA_DIR>/server.env` (`electron/main.js:565`), but the CLI bootstrap
(`bin/omniroute.mjs::loadEnvFile()`) only ever built candidate paths ending in `.env` —
`server.env` was never read anywhere in the CLI's own code path. Migrating an existing
install (`storage.sqlite` + `server.env`) from the Electron desktop app to the npm/CLI
install — exactly as the app's own UI text instructs users to do — silently dropped
`STORAGE_ENCRYPTION_KEY`. Because a database already existed, the CLI's own safety guard
correctly refused to auto-generate a *new* key (that would have made things worse), but it
left the key completely unset, permanently corrupting every encrypted provider credential
and breaking the dashboard.

## Fix

`bin/omniroute.mjs` now does a one-time, one-directory migration inside `loadEnvFile()`:
if `<DATA_DIR>/.env` is absent but `<DATA_DIR>/server.env` is present, copy it to `.env`
before the normal env-loading loop runs, logging a one-time message. An existing `.env` is
**never** overwritten — it always wins over a legacy `server.env`, per the plan-file's risk
callout.

## Regression test (TDD, Hard Rule #18)

`tests/unit/cli-electron-to-cli-migration-server-env-7302.test.ts` — reused verbatim from
the `/triage-fix-bugs` plan-file's proven repro, plus one added case for the ".env must win"
guarantee. Both spawn the real `bin/omniroute.mjs` against an isolated `DATA_DIR`/`HOME`.

RED (before fix):
```
✖ #7302: CLI must recognize DATA_DIR/server.env (Electron's secrets file) when migrating an existing database
  AssertionError [ERR_ASSERTION]: the Electron-persisted STORAGE_ENCRYPTION_KEY from server.env
  must be honored after migrating to the CLI install — got .env content: ""
  actual: '', expected: /STORAGE_ENCRYPTION_KEY=electron-storage-key-.../
```

GREEN (after fix):
```
✔ #7302: CLI must recognize DATA_DIR/server.env (Electron's secrets file) when migrating an existing database
✔ #7302: an existing DATA_DIR/.env must still win over DATA_DIR/server.env when both exist
ℹ tests 2, pass 2, fail 0
```

`tests/unit/cli-storage-key-bootstrap.test.ts` (the pre-existing suite the owner flagged as
must-stay-green) still passes unmodified — both its cases (fresh-install key generation,
refuse-to-generate-when-DB-exists-and-no-key-found) are unaffected since neither fixture
ever creates a `server.env`.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/cli-electron-to-cli-migration-server-env-7302.test.ts` — 2/2 pass
- `node --import tsx/esm --test tests/unit/cli-storage-key-bootstrap.test.ts tests/unit/cli-data-dir-env.test.ts tests/unit/cli-data-dir-env-loading.test.ts tests/unit/data-dir-writable-fallback.test.ts` — 11/11 pass
- `node --import tsx/esm --test tests/unit/cli-entrypoint.test.ts tests/unit/pack-artifact-entrypoint-closures.test.ts tests/unit/cli-version-fastpath.test.ts tests/unit/cli-update-notifier.test.ts` — 16/16 pass
- `node scripts/check/check-file-size.mjs` — OK, no new violations
- `node scripts/check/check-complexity.mjs` — OK (baseline 2059, unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (baseline 890, unchanged)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json bin/omniroute.mjs tests/unit/cli-electron-to-cli-migration-server-env-7302.test.ts` — 0 errors
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Windows caveat

`bin/cli/data-dir.mjs::getDefaultDataDir()` special-cases `%APPDATA%\omniroute` on
`process.platform === "win32"`, which this Linux devbox cannot execute. The fix here is
platform-agnostic (it operates on whatever `DATA_DIR` resolves to, via plain
`existsSync`/`readFileSync`/`writeFileSync`), so it should behave identically on Windows,
but the Windows-specific default-directory resolution itself was not (and could not be)
re-verified here — this mirrors the same caveat already on file in the plan-file's Risks
section. Flagging for a Windows CI runner check or reporter validation before this is
considered fully closed on that platform.

## Scope

Diff is scoped strictly to `bin/omniroute.mjs`'s env-loading bootstrap: no drive-by
refactors, no changes to the STORAGE_ENCRYPTION_KEY provisioning guard's warning text (kept
as-is — the migration now runs *before* that guard and resolves the scenario upstream, so
the guard's message never fires in the migrated-install case), and no changes to
`bin/cli/data-dir.mjs`.
