### PR TITLE
[Emergency Fix] fix(build): repair release build blockers

### DIFF
--- a/docs/routing/REASONING_ROUTING.md
+++ b/docs/routing/REASONING_ROUTING.md
@@ -1,3 +1,7 @@
+---
+title: "Reasoning Routing"
+---
+
 # Reasoning Routing
 
 Reasoning routing rules extend the existing model and combo routing. When no active rule matches,

--- a/tests/_cp_mock_module.mts
+++ b/tests/_cp_mock_module.mts
@@ -29,4 +29,6 @@ export function resetSpawnCalls() {
   spawnCalls.length = 0;
 }
 
-export default { execFile, execFileSync, fork, spawn, execSync, spawnSync };
+const childProcessMock = { execFile, execFileSync, fork, spawn, execSync, spawnSync };
+
+export default childProcessMock;

--- a/tests/unit/antigravity-streaming-passthrough.test.ts
+++ b/tests/unit/antigravity-streaming-passthrough.test.ts
@@ -1,7 +1,6 @@
-// Antigravity streaming-passthrough behavior (#7408): the non-streaming drain
-// path (raw SSE + chatCore-side parse) and the credits-extraction pass-through
-// TransformStream. Moved verbatim from tests/unit/executor-antigravity.test.ts
-// (frozen file-size cap) — same tests, same asserts.
+// Antigravity streaming-passthrough behavior (#7408): the buffered non-streaming
+// response path and the credits-extraction pass-through TransformStream. Kept
+// separate from executor-antigravity.test.ts to respect its frozen file-size cap.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 

--- a/tests/unit/dashboard/agentrouter-connection-modal-fields.test.ts
+++ b/tests/unit/dashboard/agentrouter-connection-modal-fields.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import {
   assignEditApiKeyProviderSpecificData,
   buildAddProviderSpecificData,
-} from "../../src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts";
+} from "../../../src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts";
 
 // #6850 — the AgentRouter quota tracker (open-sse/services/agentrouterQuotaFetcher.ts)
 // reads connection.providerSpecificData.consoleApiKey (New-API System Access Token) and
@@ -58,7 +58,9 @@ function baseAddOptions(overrides: Partial<Parameters<typeof buildAddProviderSpe
   };
 }
 
-function baseEditOptions(overrides: Partial<Parameters<typeof assignEditApiKeyProviderSpecificData>[0]>) {
+function baseEditOptions(
+  overrides: Partial<Parameters<typeof assignEditApiKeyProviderSpecificData>[0]>
+) {
   return {
     provider: "agentrouter",
     formData: BASE_FORM_DATA,
@@ -107,7 +109,11 @@ test("buildAddProviderSpecificData still supports bailian-coding-plan consoleApi
   const data = buildAddProviderSpecificData(
     baseAddOptions({
       provider: "bailian-coding-plan",
-      formData: { ...BASE_FORM_DATA, consoleApiKey: "oracle-token", newApiUserId: "should-not-persist" },
+      formData: {
+        ...BASE_FORM_DATA,
+        consoleApiKey: "oracle-token",
+        newApiUserId: "should-not-persist",
+      },
     })
   );
 

--- a/tests/unit/ui/lobe-provider-icons-stepfun.test.tsx
+++ b/tests/unit/ui/lobe-provider-icons-stepfun.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+describe("lobeProviderIcons Stepfun fallback", () => {
+  it("loads the icon registry and resolves the color slot to the Mono component", async () => {
+    const { getLobeProviderIcon } = await import("@/shared/components/lobeProviderIcons");
+
+    const monoIcon = getLobeProviderIcon("stepfun", "mono");
+    const colorIcon = getLobeProviderIcon("stepfun", "color");
+
+    expect(monoIcon).not.toBeNull();
+    expect(colorIcon).toBe(monoIcon);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the nonexistent Stepfun color icon import with the package's available monochrome export
- add the missing title frontmatter to the reasoning-routing documentation
- name the child-process mock default export to remove the ESLint warning
- move the AgentRouter dashboard test under the dashboard test loader so ESM-only icon dependencies load correctly
- align the Antigravity non-stream test with the executor's buffered JSON response contract

## Root causes fixed
- dashboard code was being executed by the generic `tsx/esm` test loader, which cannot consume the ESM-only Lobe icon style module in that path
- the Antigravity test still attempted to parse SSE even though `stream: false` is intentionally buffered into JSON by the executor

## Validation
- impacted Antigravity tests: 4/4 passed
- impacted dashboard tests: 62/62 passed
- test discovery check passed (3,490 tests, 25 collectors, 59 frozen orphans)
- ESLint JSON gate passed with 0 errors and 0 warnings
- commit hooks passed (Prettier, ESLint, documentation sync, any-budget, tracked artifacts)