### PR TITLE
fix(kimi): expose K3 reasoning effort levels

### DIFF
--- a/open-sse/config/providers/registry/kimi/coding/runtime.ts
+++ b/open-sse/config/providers/registry/kimi/coding/runtime.ts
@@ -18,7 +18,7 @@ export type KimiCodeThinkingPolicy = {
 const KIMI_CODE_STATIC_THINKING_POLICIES: Record<string, KimiCodeThinkingPolicy> = {
   k3: {
     supportsThinking: true,
-    supportedThinkingEfforts: ["max"],
+    supportedThinkingEfforts: ["low", "high", "max"],
     defaultThinkingEffort: "max",
   },
 };

--- a/tests/unit/chatcore-execution-credentials.test.ts
+++ b/tests/unit/chatcore-execution-credentials.test.ts
@@ -119,7 +119,7 @@ test("Kimi execution credentials carry the discovered protocol and thinking poli
   });
 });
 
-test("Kimi Code k3 uses the current offline max-effort policy before model import", () => {
+test("Kimi Code k3 exposes its documented efforts from the offline policy before model import", () => {
   const out = resolveExecutionCredentials({
     ...base,
     provider: "kimi-coding",
@@ -129,7 +129,7 @@ test("Kimi Code k3 uses the current offline max-effort policy before model impor
   const psd = out.providerSpecificData as Record<string, unknown>;
   assert.deepEqual(psd._omnirouteKimiThinking, {
     supportsThinking: true,
-    supportedThinkingEfforts: ["max"],
+    supportedThinkingEfforts: ["low", "high", "max"],
     defaultThinkingEffort: "max",
   });
 });

--- a/tests/unit/executor-kimi.test.ts
+++ b/tests/unit/executor-kimi.test.ts
@@ -182,7 +182,7 @@ describe("KimiExecutor", () => {
     });
   });
 
-  it("defaults Kimi Code k3 to the currently supported max effort", () => {
+  it("defaults Kimi Code k3 to max effort", () => {
     const executor = new KimiExecutor();
     const transformed = executor.transformRequest(
       "k3",
@@ -190,7 +190,7 @@ describe("KimiExecutor", () => {
       false,
       credentials(FORMATS.CLAUDE, {
         supportsThinking: true,
-        supportedThinkingEfforts: ["max"],
+        supportedThinkingEfforts: ["low", "high", "max"],
         defaultThinkingEffort: "max",
       })
     ) as TransformedBody;

--- a/tests/unit/kimi-coding-model-discovery.test.ts
+++ b/tests/unit/kimi-coding-model-discovery.test.ts
@@ -70,7 +70,7 @@ test("Kimi Code discovery maps protocol and current thinking metadata", () => {
   ]);
 });
 
-test("Kimi Code discovery imports k3 with its current max-effort contract", () => {
+test("Kimi Code discovery imports k3 with its documented effort contract", () => {
   const discovered = parseKimiCodingModels({
     data: [
       {
@@ -81,7 +81,7 @@ test("Kimi Code discovery imports k3 with its current max-effort contract", () =
         supports_thinking_type: "both",
         think_efforts: {
           support: true,
-          valid_efforts: ["max"],
+          valid_efforts: ["low", "high", "max"],
           default_effort: "max",
         },
         supports_image_in: true,
@@ -99,7 +99,7 @@ test("Kimi Code discovery imports k3 with its current max-effort contract", () =
       upstreamProtocol: "anthropic",
       context_length: 1048576,
       supportsThinking: true,
-      supportedThinkingEfforts: ["max"],
+      supportedThinkingEfforts: ["low", "high", "max"],
       defaultThinkingEffort: "max",
       supportsVision: true,
       supportsVideo: false,


### PR DESCRIPTION
## Summary

- expose Kimi Coding K3's documented `low`, `high`, and `max` reasoning efforts
- keep `max` as the default when no effort is requested
- preserve the separate direct Moonshot K3 max-only contract and live `/models` metadata precedence

This follows the endpoint-specific capability update in earendil-works/pi#6786 and Kimi Code's current model documentation.

## Related Issues

- Related to https://github.com/earendil-works/pi/pull/6786
- Reference: https://www.kimi.com/code/docs/en/kimi-code/models.html#model-overview

## Validation

- [x] Focused unit tests: 22 passed
- [x] `node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json`
- [x] Prettier check for all changed files
- [x] `git diff --check`
- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Focused test command:

```bash
DATA_DIR="$(mktemp -d)" DISABLE_SQLITE_AUTO_BACKUP=true \
  node --import tsx/esm \
  --import ./open-sse/utils/setupPolyfill.ts \
  --test --test-force-exit --test-concurrency=1 \
  tests/unit/chatcore-execution-credentials.test.ts \
  tests/unit/kimi-coding-model-discovery.test.ts \
  tests/unit/executor-kimi.test.ts
```

## Tests Added Or Updated

- `tests/unit/chatcore-execution-credentials.test.ts` verifies the offline Kimi Coding K3 policy exposes `low`, `high`, and `max` before model import.
- `tests/unit/kimi-coding-model-discovery.test.ts` aligns live discovery coverage with Kimi Code's documented effort contract.
- `tests/unit/executor-kimi.test.ts` preserves the default-`max` request behavior with the expanded supported effort set.

## Coverage Notes

The static fallback policy change is covered at the execution-credentials seam, and the executor test independently verifies that omitted effort still resolves to `max`.

## Reviewer Notes

- This changes only provider `kimi-coding`'s static offline fallback for model ID `k3`.
- Direct Moonshot K3 remains max-only.
- Imported live model metadata continues to take precedence field by field.
- No migrations, dependencies, or feature flags.
