### PR TITLE
fix(stream): synthesize terminal finish_reason chunk when upstream omits it (#7800)

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -684,6 +684,8 @@ export function createSSEStream(options: StreamOptions = {}) {
   let usage: UsageTokenRecord | null = null;
   /** Passthrough (OpenAI CC shape): saw tool_calls in stream before finish_reason */
   let passthroughHasToolCalls = false;
+  /** Passthrough: whether a chunk with non-null finish_reason was seen (#7800) */
+  let passthroughSawFinishReason = false;
   /** Passthrough: accumulate tool_calls deltas for call log responseBody */
   const passthroughToolCalls = new Map<string, ToolCall>();
   let passthroughToolCallSeq = 0;
@@ -1780,6 +1782,10 @@ export function createSSEStream(options: StreamOptions = {}) {
 
                   const isFinishChunk = parsed.choices?.[0]?.finish_reason;
 
+                  if (isFinishChunk) {
+                    passthroughSawFinishReason = true;
+                  }
+
                   if (isFinishChunk && passthroughHasToolCalls) {
                     toolFinishTime = now;
                     try {
@@ -2311,6 +2317,30 @@ export function createSSEStream(options: StreamOptions = {}) {
               }).catch(() => {});
             }
             if (!doneSent) {
+              // #7800: Some providers close the SSE stream without emitting a final
+              // chunk carrying a non-null finish_reason. OpenAI spec requires the
+              // terminal chunk to include finish_reason (e.g. "stop"); strict clients
+              // (pi CLI) reject the stream with "Stream ended without finish_reason".
+              // Synthesize a terminal chunk when the upstream omitted one.
+              if (shouldEmitDoneTerminator && !passthroughSawFinishReason) {
+                const syntheticFinishChunk = {
+                  id: passthroughResponsesId || `chatcmpl-${Date.now()}`,
+                  object: "chat.completion.chunk",
+                  created: Math.floor(Date.now() / 1000),
+                  model: model || "unknown",
+                  choices: [
+                    {
+                      index: 0,
+                      delta: {},
+                      finish_reason: passthroughHasToolCalls ? "tool_calls" : "stop",
+                    },
+                  ],
+                };
+                const finishOutput = `data: ${JSON.stringify(syntheticFinishChunk)}\n\n`;
+                reqLogger?.appendConvertedChunk?.(finishOutput);
+                controller.enqueue(encoder.encode(finishOutput));
+                clientPayloadCollector.push(syntheticFinishChunk);
+              }
               await emitFinalSseMetadata(controller, usage);
               doneSent = true;
               if (shouldEmitDoneTerminator) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -2224,6 +2224,15 @@ export function createSSEStream(options: StreamOptions = {}) {
                         }
                       }
                     }
+                    // #7800: track finish_reason in the flush path too, so a
+                    // final chunk without trailing newline still suppresses the
+                    // synthetic finish_reason synthesis.
+                    if (
+                      Array.isArray(flushedParsed.choices) &&
+                      (flushedParsed.choices[0] as JsonRecord | undefined)?.finish_reason
+                    ) {
+                      passthroughSawFinishReason = true;
+                    }
                     if (flushChanged) {
                       output = `data: ${JSON.stringify(flushedParsed)}\n\n`;
                     }

--- a/tests/unit/sse-finish-reason-synthesis-7800.test.ts
+++ b/tests/unit/sse-finish-reason-synthesis-7800.test.ts
@@ -1,0 +1,187 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.ts";
+
+/**
+ * Regression tests for #7800 — SSE stream omits finish_reason on final chunk.
+ *
+ * Some providers close the SSE stream without emitting a terminal chunk carrying
+ * a non-null finish_reason. The OpenAI spec requires the last chunk to include
+ * finish_reason (e.g. "stop"); strict clients (pi CLI) reject the stream with
+ * "Stream ended without finish_reason".
+ *
+ * These tests drive the REAL passthrough transform stream and verify that a
+ * synthetic finish_reason chunk is injected before [DONE] when the upstream
+ * omitted one, and that it is NOT injected when the upstream already sent one.
+ */
+
+function makeChunk(content: string | null, finishReason: string | null): string {
+  const chunk = {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    created: 1700000000,
+    model: "test-model",
+    choices: [
+      {
+        index: 0,
+        delta: content !== null ? { content } : {},
+        finish_reason: finishReason,
+      },
+    ],
+  };
+  return `data: ${JSON.stringify(chunk)}\n\n`;
+}
+
+async function runPassthrough(rawSSE: string): Promise<string> {
+  const transform = createPassthroughStreamWithLogger(
+    "test-provider",
+    null,
+    null,
+    "test-model",
+    "conn-7800",
+    { model: "test-model" }
+  );
+
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  const readAll = (async () => {
+    const out: string[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out.push(decoder.decode(value));
+    }
+    return out.join("");
+  })();
+
+  await writer.write(encoder.encode(rawSSE));
+  await writer.close();
+
+  return readAll;
+}
+
+/** Parse all SSE data payloads (excluding [DONE]) from a raw SSE string. */
+function parseDataEvents(raw: string): Record<string, unknown>[] {
+  const events: Record<string, unknown>[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      events.push(JSON.parse(payload) as Record<string, unknown>);
+    } catch {
+      // skip metadata comments / non-JSON
+    }
+  }
+  return events;
+}
+
+test("#7800: synthetic finish_reason chunk injected when upstream omits it", async () => {
+  // Provider sends content chunks with finish_reason: null, then [DONE]
+  // WITHOUT a terminal chunk carrying finish_reason.
+  const rawSSE = [
+    makeChunk("Hello", null),
+    makeChunk(" world", null),
+    "data: [DONE]\n\n",
+  ].join("");
+
+  const result = await runPassthrough(rawSSE);
+  const events = parseDataEvents(result);
+
+  // The last data event before [DONE] must have finish_reason: "stop"
+  const finishEvents = events.filter(
+    (e) => e.choices?.[0]?.finish_reason && e.choices[0].finish_reason !== null
+  );
+  assert.equal(
+    finishEvents.length,
+    1,
+    "Expected exactly one chunk with non-null finish_reason"
+  );
+  assert.equal(
+    finishEvents[0].choices[0].finish_reason,
+    "stop",
+    "Synthetic finish_reason should be 'stop'"
+  );
+  assert.equal(
+    finishEvents[0].object,
+    "chat.completion.chunk",
+    "Synthetic chunk should have correct object type"
+  );
+
+  // [DONE] should still be present
+  assert.match(result, /data: \[DONE\]/);
+});
+
+test("#7800: no synthetic chunk when upstream already sends finish_reason", async () => {
+  // Provider sends content chunks AND a proper terminal chunk with finish_reason.
+  const rawSSE = [
+    makeChunk("Hello", null),
+    makeChunk(" world", null),
+    makeChunk(null, "stop"),
+    "data: [DONE]\n\n",
+  ].join("");
+
+  const result = await runPassthrough(rawSSE);
+  const events = parseDataEvents(result);
+
+  const finishEvents = events.filter(
+    (e) => e.choices?.[0]?.finish_reason && e.choices[0].finish_reason !== null
+  );
+  assert.equal(
+    finishEvents.length,
+    1,
+    "Expected exactly one chunk with non-null finish_reason (from upstream, not synthetic)"
+  );
+  assert.equal(finishEvents[0].choices[0].finish_reason, "stop");
+
+  // [DONE] should still be present
+  assert.match(result, /data: \[DONE\]/);
+});
+
+test("#7800: synthetic finish_reason is 'tool_calls' when tool calls were used", async () => {
+  // Provider sends tool_call chunks but no finish_reason chunk, then [DONE].
+  const toolCallChunk = {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    created: 1700000000,
+    model: "test-model",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"NYC"}' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+    ],
+  };
+
+  const rawSSE = [
+    `data: ${JSON.stringify(toolCallChunk)}\n\n`,
+    "data: [DONE]\n\n",
+  ].join("");
+
+  const result = await runPassthrough(rawSSE);
+  const events = parseDataEvents(result);
+
+  const finishEvents = events.filter(
+    (e) => e.choices?.[0]?.finish_reason && e.choices[0].finish_reason !== null
+  );
+  assert.equal(finishEvents.length, 1);
+  assert.equal(
+    finishEvents[0].choices[0].finish_reason,
+    "tool_calls",
+    "Synthetic finish_reason should be 'tool_calls' when tool calls were present"
+  );
+});


### PR DESCRIPTION
## Problem

Issue #7800: OmniRoute's streamed `/v1/chat/completions` can go from `finish_reason: null` straight to `data: [DONE]` without emitting a terminal chunk with a non-null `finish_reason`. The OpenAI spec requires the terminal chunk to carry `finish_reason` (e.g. `"stop"`). Strict clients (e.g. the `pi` coding CLI) reject the stream with `Stream ended without finish_reason`.

This happens in **passthrough mode** (OpenAI Chat Completions shape) when the upstream provider closes the SSE stream without sending a final chunk with `finish_reason`.

## Fix

In `open-sse/utils/stream.ts` passthrough mode:
- Track whether a chunk with non-null `finish_reason` was seen (`passthroughSawFinishReason`).
- Before emitting `[DONE]`, if no `finish_reason` chunk was observed, synthesize a terminal chunk with `finish_reason: "stop"` (or `"tool_calls"` when tool calls were present in the stream).

Translate mode is unaffected — translators (`claude-to-openai`, `gemini-to-openai`) already guarantee a terminal `finish_reason` chunk via `finishReasonSent` / fallback defaults.

## Tests

3 new regression tests in `tests/unit/sse-finish-reason-synthesis-7800.test.ts`:
1. Synthetic `finish_reason: "stop"` injected when upstream omits it
2. No synthetic chunk when upstream already sends `finish_reason` (no duplication)
3. Synthetic `finish_reason: "tool_calls"` when tool calls were used

All 63 existing stream tests still pass.