### PR TITLE
fix(sse): voyage rerank format adapter — top_k request + data[] response normalization

### DIFF
--- a/open-sse/config/rerankRegistry.ts
+++ b/open-sse/config/rerankRegistry.ts
@@ -50,11 +50,18 @@ export const RERANK_PROVIDERS = {
     ],
   },
 
+  // Voyage rerank is NOT Cohere-shaped: it hard-rejects `top_n` with 400
+  // ("Argument 'top_n' is not supported by our API" — wants `top_k`), rejects
+  // empty-string documents, and responds {object,data:[{index,relevance_score}],
+  // model,usage} instead of {results:[…]}. The `voyage` format adapter in
+  // open-sse/handlers/rerank.ts translates both directions (#7809, confirmed
+  // live against the real API 2026-07-19).
   "voyage-ai": {
     id: "voyage-ai",
     baseUrl: "https://api.voyageai.com/v1/rerank",
     authType: "apikey",
     authHeader: "bearer",
+    format: "voyage",
     models: [
       { id: "rerank-2.5", name: "Rerank 2.5" },
       { id: "rerank-2.5-lite", name: "Rerank 2.5 Lite" },

--- a/open-sse/handlers/rerank.ts
+++ b/open-sse/handlers/rerank.ts
@@ -24,6 +24,17 @@ function buildAuthHeader(providerConfig, token) {
 }
 
 /**
+ * Normalize rerank documents (strings or Cohere {text} objects) to plain strings.
+ * Shared by the Voyage request/response transforms so the empty-string filter and
+ * the kept-index remap are computed from the exact same view of the documents.
+ */
+function voyageDocumentTexts(documents) {
+  return (Array.isArray(documents) ? documents : []).map((doc) =>
+    typeof doc === "string" ? doc : doc?.text || ""
+  );
+}
+
+/**
  * Transform request body for provider-specific formats (e.g. NVIDIA ranking API)
  */
 /* @testonly */ export function transformRequestForProvider(providerConfig, body) {
@@ -45,6 +56,21 @@ function buildAuthHeader(providerConfig, token) {
       documents: (body.documents || []).map((doc) =>
         typeof doc === "string" ? doc : doc.text || ""
       ),
+    };
+  }
+  // Voyage rerank API (#7809): hard-rejects `top_n` (wants `top_k`) and empty-string
+  // documents ("Input cannot contain empty strings"), so both are translated/filtered
+  // here — transformResponseFromProvider recomputes the same kept-index map to point
+  // results back at the caller's original document positions. `return_documents` is
+  // forced off upstream: Voyage echoes documents as plain strings (not Cohere's
+  // {text}), so document text is synthesized locally from the caller's originals.
+  if (providerConfig.format === "voyage") {
+    return {
+      model: body.model,
+      query: body.query,
+      documents: voyageDocumentTexts(body.documents).filter((text) => text !== ""),
+      top_k: body.top_n,
+      return_documents: false,
     };
   }
   // Default: Cohere-compatible format (used by Together, Fireworks, Cohere, SiliconFlow)
@@ -88,6 +114,33 @@ function buildAuthHeader(providerConfig, token) {
     return {
       id: `rerank-${Date.now()}`,
       results: topN ? scored.slice(0, topN) : scored,
+      meta: {
+        api_version: { version: "2" },
+        billed_units: { search_units: 1 },
+      },
+    };
+  }
+  // Voyage returns {object:"list", data:[{index, relevance_score}], model, usage}
+  // (#7809). Indices are positional over the FILTERED (empty-doc-free) list the
+  // request transform sent, so remap them back to the caller's original document
+  // positions and synthesize Cohere's {document:{text}} from the originals.
+  if (providerConfig.format === "voyage") {
+    const texts = voyageDocumentTexts(options.documents);
+    const keptIndices = texts
+      .map((text, index) => (text !== "" ? index : -1))
+      .filter((index) => index !== -1);
+    const returnDocuments = options.return_documents !== false;
+    const results = (Array.isArray(data.data) ? data.data : []).map((r) => {
+      const originalIndex = keptIndices[r.index] ?? r.index;
+      return {
+        index: originalIndex,
+        relevance_score: typeof r.relevance_score === "number" ? r.relevance_score : 0,
+        ...(returnDocuments ? { document: { text: texts[originalIndex] || "" } } : {}),
+      };
+    });
+    return {
+      id: `rerank-${Date.now()}`,
+      results,
       meta: {
         api_version: { version: "2" },
         billed_units: { search_units: 1 },

--- a/tests/unit/rerank-voyage-format.test.ts
+++ b/tests/unit/rerank-voyage-format.test.ts
@@ -1,0 +1,167 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolated DATA_DIR before any module that may open the SQLite singleton.
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rerank-voyage-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "rerank-voyage-test-api-key-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const { getRerankProvider } = await import("../../open-sse/config/rerankRegistry.ts");
+const rerankHandler = await import("../../open-sse/handlers/rerank.ts");
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// #7809 — Voyage is NOT Cohere-compatible: it hard-rejects `top_n` with 400
+// ("Argument 'top_n' is not supported by our API") and responds with `data[]`
+// instead of `results[]`. Without a `format: "voyage"` adapter the registry
+// entry is dead weight: every call fails even with valid credentials.
+// All upstream behaviors below were confirmed live against the real API
+// (2026-07-19); see the issue for the raw curl evidence.
+
+test("#7809 voyage-ai registry entry declares the voyage format adapter", () => {
+  const provider = getRerankProvider("voyage-ai");
+  assert.ok(provider, "voyage-ai should be a registered rerank provider");
+  assert.equal(
+    provider.format,
+    "voyage",
+    "voyage-ai must opt out of the Cohere-compatible passthrough"
+  );
+});
+
+test("#7809 voyage request sends top_k (never top_n) and string documents", () => {
+  const providerConfig = getRerankProvider("voyage-ai");
+  const body = rerankHandler.transformRequestForProvider(providerConfig, {
+    model: "rerank-2.5-lite",
+    query: "which gateway routes AI?",
+    documents: ["doc a", { text: "doc b" }],
+    top_n: 2,
+    return_documents: true,
+  });
+  assert.equal(body.top_k, 2, "Cohere top_n must be translated to Voyage top_k");
+  assert.ok(!("top_n" in body), "top_n must not reach Voyage (400 'not supported')");
+  assert.deepEqual(body.documents, ["doc a", "doc b"], "documents must be plain strings");
+  assert.equal(
+    body.return_documents,
+    false,
+    "document text is synthesized locally from the caller's originals"
+  );
+});
+
+test("#7809 voyage request drops empty-string documents (Voyage 400s on them)", () => {
+  const providerConfig = getRerankProvider("voyage-ai");
+  const body = rerankHandler.transformRequestForProvider(providerConfig, {
+    model: "rerank-2.5-lite",
+    query: "q",
+    documents: ["doc a", "", "doc b"],
+    top_n: 3,
+  });
+  assert.deepEqual(
+    body.documents,
+    ["doc a", "doc b"],
+    "empty strings must be filtered ('Input cannot contain empty strings')"
+  );
+});
+
+test("#7809 voyage data[] response is normalized to Cohere results[] with original indices", () => {
+  const providerConfig = getRerankProvider("voyage-ai");
+  // Caller sent ["doc a", "", "doc b"]; Voyage saw ["doc a", "doc b"] and
+  // ranked its index 1 ("doc b") first — which is the caller's index 2.
+  const result = rerankHandler.transformResponseFromProvider(
+    providerConfig,
+    {
+      object: "list",
+      data: [
+        { index: 1, relevance_score: 0.88 },
+        { index: 0, relevance_score: 0.12 },
+      ],
+      model: "rerank-2.5-lite",
+      usage: { total_tokens: 12 },
+    },
+    { documents: ["doc a", "", "doc b"], top_n: 3, return_documents: true }
+  );
+  assert.ok(Array.isArray(result.results), "response must be Cohere-shaped (results[])");
+  assert.deepEqual(
+    result.results.map((r) => [r.index, r.relevance_score]),
+    [
+      [2, 0.88],
+      [0, 0.12],
+    ],
+    "indices must point at the caller's ORIGINAL document positions"
+  );
+  assert.equal(result.results[0].document.text, "doc b");
+  assert.equal(
+    result.meta.billed_units.search_units,
+    1,
+    "search unit synthesized for cost telemetry (parity with nvidia/deepinfra)"
+  );
+});
+
+test("#7809 voyage response omits document text when return_documents=false", () => {
+  const providerConfig = getRerankProvider("voyage-ai");
+  const result = rerankHandler.transformResponseFromProvider(
+    providerConfig,
+    { object: "list", data: [{ index: 0, relevance_score: 0.5 }] },
+    { documents: ["doc a"], top_n: 1, return_documents: false }
+  );
+  assert.equal(result.results[0].index, 0);
+  assert.ok(!("document" in result.results[0]), "no document echo when not requested");
+});
+
+test("#7809 handleRerank end-to-end: voyage upstream body + normalized Response", async () => {
+  let upstreamUrl = "";
+  let upstreamBody: Record<string, unknown> = {};
+  globalThis.fetch = (async (url: unknown, init?: RequestInit) => {
+    upstreamUrl = String(url);
+    upstreamBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    return new Response(
+      JSON.stringify({
+        object: "list",
+        data: [
+          { index: 1, relevance_score: 0.86 },
+          { index: 0, relevance_score: 0.22 },
+        ],
+        model: "rerank-2.5-lite",
+        usage: { total_tokens: 57 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  }) as typeof fetch;
+
+  const response = (await rerankHandler.handleRerank({
+    model: "voyage/rerank-2.5-lite",
+    query: "which gateway routes AI?",
+    documents: ["irrelevant doc", "the gateway doc"],
+    top_n: 2,
+    credentials: { apiKey: "test-key" },
+  })) as Response;
+
+  assert.equal(upstreamUrl, "https://api.voyageai.com/v1/rerank");
+  assert.equal(upstreamBody.top_k, 2);
+  assert.ok(!("top_n" in upstreamBody), "top_n must never reach Voyage");
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as {
+    results?: Array<{ index: number; relevance_score: number }>;
+  };
+  assert.ok(Array.isArray(body.results), "client must receive Cohere-shaped results[]");
+  assert.deepEqual(
+    body.results.map((r) => [r.index, r.relevance_score]),
+    [
+      [1, 0.86],
+      [0, 0.22],
+    ]
+  );
+});


### PR DESCRIPTION
Closes #7809

## Problem

The `voyage-ai` rerank registry entry had **no `format` adapter**, so `handleRerank` treated Voyage as Cohere-compatible passthrough. Voyage is not Cohere-compatible — every call failed or returned an unparseable shape, even with valid credentials:

- request: Voyage hard-rejects `top_n` with `400 "Argument 'top_n' is not supported by our API"` (wants `top_k`) and rejects empty-string documents (`400 "Input cannot contain empty strings"`)
- response: Voyage returns `{object:"list", data:[{index, relevance_score}], model, usage}` — not Cohere's `{results:[…]}` — and the default passthrough handed that shape to clients unchanged

All upstream behaviors confirmed live against the real Voyage API on 2026-07-19 (raw curl evidence in #7809; also verified: whitespace-only documents accepted, `top_k` > document count accepted).

## Fix

`format: "voyage"` adapter in `open-sse/handlers/rerank.ts`, same pattern as the existing `nvidia`/`deepinfra` adapters:

- **request**: `top_n` → `top_k`; documents normalized to plain strings; empty strings filtered; `return_documents` forced off upstream (Voyage echoes plain strings, not Cohere `{text}` — document text is synthesized locally from the caller's originals)
- **response**: `data[]` → Cohere `results[]`; indices remapped to the caller's **original** document positions via the same kept-index map (shared helper `voyageDocumentTexts` guarantees request filter and response remap see identical views); `search_units: 1` synthesized for cost telemetry (parity with nvidia/deepinfra)

## Validation (Hard Rule #18 — TDD)

`tests/unit/rerank-voyage-format.test.ts` (6 tests) written against the live-measured upstream behavior:

- **Red on base** (`origin/release/v3.8.49` without the fix): `6 fail / 0 pass`
- **Green with the fix**: `6 pass / 0 fail`
- Regression — `rerank-openrouter-6574` + `media-cost-headers-handlers` (cohere/nvidia rerank paths) + `embedding-rerank-provider-registry`: **15 pass / 0 fail**
- `npx eslint` on the 3 changed files: clean

```
node --import tsx/esm --test tests/unit/rerank-voyage-format.test.ts
node --import tsx/esm --test tests/unit/rerank-openrouter-6574.test.ts tests/unit/media-cost-headers-handlers.test.ts tests/unit/embedding-rerank-provider-registry.test.ts
```