### PR TITLE
fix(stream): emit terminal SSE frames on mid-stream upstream failure (#7699)

### DIFF
--- a/open-sse/utils/streamHandler.ts
+++ b/open-sse/utils/streamHandler.ts
@@ -463,10 +463,12 @@ export function createDisconnectAwareStream(transformStream, streamController) {
   const terminalDecoder = new TextDecoder();
   let terminalTail = "";
   let clientTerminalSeen = false;
+  let bytesWereForwarded = false;
 
   const noteClientChunk = (chunk: unknown) => {
-    if (clientTerminalSeen) return;
     if (!(chunk instanceof Uint8Array)) return;
+    bytesWereForwarded = true;
+    if (clientTerminalSeen) return;
 
     terminalTail += terminalDecoder.decode(chunk, { stream: true });
     if (terminalTail.length > 4096) {
@@ -497,7 +499,11 @@ export function createDisconnectAwareStream(transformStream, streamController) {
             // response.completed / message_stop, this is a silent mid-stream
             // drop. Emit a synthetic terminal error so Anthropic SDK / Claude
             // Code don't see "Connection closed mid-response."
-            if (!clientTerminalSeen) {
+            if (
+              bytesWereForwarded &&
+              !clientTerminalSeen &&
+              streamController.clientResponseFormat
+            ) {
               streamController.handleError(
                 Object.assign(new Error("Upstream stream ended without a terminal marker"), {
                   statusCode: 502,

--- a/open-sse/utils/streamHandler.ts
+++ b/open-sse/utils/streamHandler.ts
@@ -376,7 +376,7 @@ export function createStreamController({
   return controller;
 }
 
-function buildStreamErrorChunks(
+export function buildStreamErrorChunks(
   errorMsg: string,
   statusCode: number,
   clientResponseFormat?: string | null
@@ -409,7 +409,13 @@ function buildStreamErrorChunks(
       },
     };
 
-    return encodeSseEvent(errorEvent, { event: "error" });
+    // #7699 — emit message_stop after event:error so Anthropic SDK / Claude Code
+    // see a proper terminal frame instead of a silent mid-response close.
+    // Without message_stop, clients report "Connection closed mid-response."
+    return [
+      ...encodeSseEvent(errorEvent, { event: "error" }),
+      ...encodeSseEvent({ type: "message_stop" }, { event: "message_stop" }),
+    ];
   }
 
   const errorEvent = {
@@ -486,8 +492,34 @@ export function createDisconnectAwareStream(transformStream, streamController) {
         try {
           const { done, value } = await reader.read();
           if (done) {
-            streamController.handleComplete();
-            controller.close();
+            // #7699 — upstream ended without a client-visible terminal marker.
+            // If bytes were forwarded but the stream never emitted [DONE] /
+            // response.completed / message_stop, this is a silent mid-stream
+            // drop. Emit a synthetic terminal error so Anthropic SDK / Claude
+            // Code don't see "Connection closed mid-response."
+            if (!clientTerminalSeen) {
+              streamController.handleError(
+                Object.assign(new Error("Upstream stream ended without a terminal marker"), {
+                  statusCode: 502,
+                })
+              );
+              try {
+                for (const chunk of buildStreamErrorChunks(
+                  "Upstream stream ended without a terminal marker",
+                  502,
+                  streamController.clientResponseFormat
+                )) {
+                  controller.enqueue(chunk);
+                }
+              } catch {
+                // downstream may have closed; original error already recorded
+              }
+            } else {
+              streamController.handleComplete();
+            }
+            try {
+              controller.close();
+            } catch {}
             return;
           }
           controller.enqueue(value);

--- a/open-sse/utils/streamHandler.ts
+++ b/open-sse/utils/streamHandler.ts
@@ -495,14 +495,19 @@ export function createDisconnectAwareStream(transformStream, streamController) {
           const { done, value } = await reader.read();
           if (done) {
             // #7699 — upstream ended without a client-visible terminal marker.
-            // If bytes were forwarded but the stream never emitted [DONE] /
-            // response.completed / message_stop, this is a silent mid-stream
-            // drop. Emit a synthetic terminal error so Anthropic SDK / Claude
-            // Code don't see "Connection closed mid-response."
+            // Scoped to Claude (/v1/messages) specifically, which is the
+            // issue's real scope: Anthropic's SSE spec permits a mid-stream
+            // event: error and Claude clients (Claude Code, Anthropic SDK)
+            // treat a stream that ends without message_stop as an error. For
+            // every other format (plain OpenAI chat completions included —
+            // see #7699's "Suggested Fix") a done-without-recognized-marker
+            // close is NOT necessarily a silent drop (many providers/formats
+            // legitimately have no [DONE]/response.completed equivalent), so
+            // injecting a synthetic error there would be a false positive.
             if (
               bytesWereForwarded &&
               !clientTerminalSeen &&
-              streamController.clientResponseFormat
+              streamController.clientResponseFormat === FORMATS.CLAUDE
             ) {
               streamController.handleError(
                 Object.assign(new Error("Upstream stream ended without a terminal marker"), {

--- a/tests/unit/silent-sse-close-7699.test.ts
+++ b/tests/unit/silent-sse-close-7699.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression test for #7699 — silent SSE close on mid-stream upstream failure (/v1/messages).
+ *
+ * When the upstream SSE stream fails mid-flight (after bytes have been forwarded
+ * to the client) and the upstream drops without emitting a terminal marker,
+ * OmniRoute used to silently close the connection with no terminal `event: error`
+ * or `message_stop` for Anthropic-format clients. Claude Code and the Anthropic SDK
+ * then report "Connection closed mid-response. The response above may be incomplete."
+ *
+ * Two code paths must emit a synthetic terminal frame:
+ *   1. `buildStreamErrorChunks` for the Claude format must follow `event: error`
+ *      with `event: message_stop` (the Anthropic stream terminator).
+ *   2. `createDisconnectAwareStream`'s `if (done)` branch must emit a synthetic
+ *      error + terminal frame when upstream ends without a client-visible
+ *      terminal marker (silent mid-stream drop).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildStreamErrorChunks, createDisconnectAwareStream, createStreamController } =
+  await import("../../open-sse/utils/streamHandler.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+function decodeChunks(chunks: Uint8Array[]): string {
+  return new TextDecoder().decode(
+    (chunks as Uint8Array[]).reduce((acc, c) => {
+      const merged = new Uint8Array(acc.length + c.length);
+      merged.set(acc, 0);
+      merged.set(c, acc.length);
+      return merged;
+    }, new Uint8Array(0))
+  );
+}
+
+test("#7699 buildStreamErrorChunks (Claude) emits event:error AND event:message_stop", () => {
+  const chunks = buildStreamErrorChunks(
+    "Upstream stream error",
+    502,
+    FORMATS.CLAUDE
+  ) as Uint8Array[];
+  const text = decodeChunks(chunks);
+
+  // Must include an error event...
+  assert.match(text, /event: error\r?\n/);
+  assert.match(text, /"type":\s*"error"/);
+  assert.match(text, /"message":\s*"Upstream stream error"/);
+
+  // ...AND a message_stop terminator so Anthropic SDK / Claude Code
+  // don't see a silent mid-response close (#7699).
+  assert.match(text, /event: message_stop\r?\n/);
+  assert.match(text, /"type":\s*"message_stop"/);
+});
+
+test("#7699 buildStreamErrorChunks (Claude) emits error before message_stop", () => {
+  const chunks = buildStreamErrorChunks("rate limited", 429, FORMATS.CLAUDE) as Uint8Array[];
+  const text = decodeChunks(chunks);
+
+  const errorIdx = text.indexOf("event: error");
+  const stopIdx = text.indexOf("event: message_stop");
+  assert.notEqual(errorIdx, -1, "expected event: error in output");
+  assert.notEqual(stopIdx, -1, "expected event: message_stop in output");
+  assert.ok(errorIdx < stopIdx, "event: error must precede event: message_stop");
+});
+
+test("#7699 buildStreamErrorChunks (OpenAI) still emits [DONE] terminator (unchanged)", () => {
+  const chunks = buildStreamErrorChunks("Upstream stream error", 502, null) as Uint8Array[];
+  const text = decodeChunks(chunks);
+
+  // OpenAI format: finish_reason error + [DONE]
+  assert.match(text, /"finish_reason":\s*"error"/);
+  assert.match(text, /data: \[DONE\]/);
+  // Must NOT include Claude-only markers
+  assert.doesNotMatch(text, /message_stop/);
+});
+
+test("#7699 buildStreamErrorChunks (Responses) emits response.failed (unchanged)", () => {
+  const chunks = buildStreamErrorChunks(
+    "Upstream stream error",
+    502,
+    FORMATS.OPENAI_RESPONSES
+  ) as Uint8Array[];
+  const text = decodeChunks(chunks);
+
+  assert.match(text, /event: response\.failed\r?\n/);
+  // Must NOT include Claude-only markers
+  assert.doesNotMatch(text, /message_stop/);
+});
+
+/**
+ * Helper: build a minimal TransformStream that forwards bytes unchanged
+ * so createDisconnectAwareStream can wrap it. We then feed it a synthetic
+ * upstream that ends (`done`) without ever emitting a terminal SSE marker.
+ */
+function buildPassthroughTransform(): TransformStream<Uint8Array, Uint8Array> {
+  return new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+    },
+  });
+}
+
+/**
+ * Collect all bytes from a ReadableStream into a string.
+ */
+async function drainStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const parts: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  return new TextDecoder().decode(
+    parts.reduce((acc, c) => {
+      const merged = new Uint8Array(acc.length + c.length);
+      merged.set(acc, 0);
+      merged.set(c, acc.length);
+      return merged;
+    }, new Uint8Array(0))
+  );
+}
+
+test("#7699 createDisconnectAwareStream emits synthetic error when upstream ends without terminal marker (Claude)", async () => {
+  // Upstream sends some partial content then ends (done=true) without
+  // ever emitting message_stop — reproduces the silent mid-stream close.
+  const upstream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          'data: {"type":"content_block_delta","delta":{"text":"partial"}}\n\n'
+        )
+      );
+      controller.close();
+    },
+  });
+
+  const transform = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+    },
+  });
+
+  // Pipe the upstream through the transform; the result is a ReadableStream.
+  const transformedBody = upstream.pipeThrough(transform);
+
+  const sc = createStreamController({
+    provider: "test",
+    model: "test-model",
+    clientResponseFormat: FORMATS.CLAUDE,
+  });
+
+  // createDisconnectAwareStream expects { readable, writable } — mirrors
+  // the shape produced by pipeWithDisconnect.
+  const wrapped = createDisconnectAwareStream(
+    { readable: transformedBody, writable: createNoopAbortWritableStream() },
+    sc
+  );
+
+  const text = await drainStream(wrapped);
+
+  // Must contain the partial content that was forwarded...
+  assert.match(text, /content_block_delta/);
+  // ...AND the synthetic terminal frames (error + message_stop) — NOT a silent close.
+  assert.match(text, /event: error\r?\n/);
+  assert.match(text, /event: message_stop\r?\n/);
+  assert.match(text, /Upstream stream ended without a terminal marker/);
+});
+
+// Minimal noop writable for the test wiring (mirrors createNoopAbortWritable).
+function createNoopAbortWritableStream(): { getWriter: () => { abort: () => Promise<void> } } {
+  return { getWriter: () => ({ abort: () => Promise.resolve() }) };
+}

--- a/tests/unit/stream-handler.test.ts
+++ b/tests/unit/stream-handler.test.ts
@@ -355,12 +355,8 @@ test("createDisconnectAwareStream keeps newlines escaped for Claude SSE errors",
   assert.doesNotMatch(text, /^claude line two/m);
 });
 
-// #7699/#7816 — the done-without-terminal-marker heuristic is scoped to
-// FORMATS.CLAUDE (the issue's real scope: /v1/messages). A plain successful
-// completion in any other format — including a non-SSE OpenAI passthrough
-// that forwarded bytes but has no [DONE]/response.completed/message_stop
-// equivalent — must reach the client unmodified, with no synthetic 502
-// error frame appended.
+// #7699/#7816 — heuristic is scoped to FORMATS.CLAUDE (/v1/messages); a
+// plain non-Claude completion with no [DONE]/message_stop must pass through.
 test("createDisconnectAwareStream does not append a synthetic error to a plain non-SSE OpenAI completion", async () => {
   const transformStream = {
     readable: new ReadableStream({
@@ -369,13 +365,7 @@ test("createDisconnectAwareStream does not append a synthetic error to a plain n
         controller.close();
       },
     }),
-    writable: {
-      getWriter() {
-        return {
-          abort() {},
-        };
-      },
-    },
+    writable: { getWriter: () => ({ abort() {} }) },
   };
 
   const stream = createDisconnectAwareStream(

--- a/tests/unit/stream-handler.test.ts
+++ b/tests/unit/stream-handler.test.ts
@@ -355,6 +355,40 @@ test("createDisconnectAwareStream keeps newlines escaped for Claude SSE errors",
   assert.doesNotMatch(text, /^claude line two/m);
 });
 
+// #7699/#7816 — the done-without-terminal-marker heuristic is scoped to
+// FORMATS.CLAUDE (the issue's real scope: /v1/messages). A plain successful
+// completion in any other format — including a non-SSE OpenAI passthrough
+// that forwarded bytes but has no [DONE]/response.completed/message_stop
+// equivalent — must reach the client unmodified, with no synthetic 502
+// error frame appended.
+test("createDisconnectAwareStream does not append a synthetic error to a plain non-SSE OpenAI completion", async () => {
+  const transformStream = {
+    readable: new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("plain forwarded bytes, no completion marker"));
+        controller.close();
+      },
+    }),
+    writable: {
+      getWriter() {
+        return {
+          abort() {},
+        };
+      },
+    },
+  };
+
+  const stream = createDisconnectAwareStream(
+    transformStream,
+    createStreamController({ clientResponseFormat: FORMATS.OPENAI })
+  );
+  const text = await readStreamText(stream);
+
+  assert.equal(text, "plain forwarded bytes, no completion marker");
+  assert.doesNotMatch(text, /event: error/);
+  assert.doesNotMatch(text, /"finish_reason":"error"/);
+});
+
 test("createDisconnectAwareStream cancel propagates disconnect reason and aborts the writer", async () => {
   let aborted = false;
   let disconnectEvent = null;


### PR DESCRIPTION
## What

Fixes the silent SSE close on mid-stream upstream failure for `/v1/messages` reported in #7699.

When the upstream SSE stream fails mid-flight **after** bytes have been forwarded to the client, OmniRoute used to silently close the connection with no terminal `event: error` / `message_stop`. Anthropic SDK and Claude Code then report:

> Connection closed mid-response. The response above may be incomplete.

Maintainer @diegosouzapw confirmed the bug after @glazec provided a reproducible test. No PR existed.

## Root cause

Two code paths in `open-sse/utils/streamHandler.ts` dropped the client without a terminal frame:

1. **`buildStreamErrorChunks` (Claude format)** emitted only `event: error` — without the `event: message_stop` terminator that Anthropic clients require to consider the stream closed. The Responses path already emits its own terminator (`response.failed`); the OpenAI path emits `finish_reason: error` + `[DONE]`; only the Claude path was missing its terminator.

2. **`createDisconnectAwareStream` pull()** — when the upstream readable ends (`done=true`) **without** the client having seen a terminal SSE marker (`[DONE]` / `response.completed` / `message_stop`), the code called `controller.close()` with no synthetic terminal frame. This is the exact silent mid-stream drop from the issue: upstream dies after forwarding bytes, client sees a bare close.

## Fix

1. `buildStreamErrorChunks` for `FORMATS.CLAUDE` now emits `event: message_stop` after `event: error`, so Anthropic clients receive a proper terminal frame.

2. `createDisconnectAwareStream` pull() now detects upstream `done` without a client-visible terminal marker and emits a synthetic terminal error frame (`buildStreamErrorChunks`) before closing — covering the silent-drop case.

Other formats are unchanged: OpenAI keeps `finish_reason: error` + `[DONE]`, Responses keeps `response.failed`.

## Tests

`tests/unit/silent-sse-close-7699.test.ts` (new, 5 tests):
- `buildStreamErrorChunks` (Claude) emits both `event: error` AND `event: message_stop`
- error event precedes `message_stop` (ordering)
- OpenAI format unchanged (still `[DONE]`, no Claude markers leak)
- Responses format unchanged (still `response.failed`, no Claude markers leak)
- `createDisconnectAwareStream` emits synthetic error + `message_stop` when upstream ends without a terminal marker (Claude)

Existing tests verified green: `stream-handler-client-disconnect`, `stream-recovery`, `chatcore-stream-error-result`, `claude-empty-stream-error-3685`, `gemini-midstream-error-4177`.

Refs: #7699, #7800 (same bug class).