### PR TITLE
fix: strip orphaned tool_use before antigravity/Vertex Claude dispatch (#7752)

### DIFF
--- a/changelog.d/fixes/7752-antigravity-orphan-tooluse.md
+++ b/changelog.d/fixes/7752-antigravity-orphan-tooluse.md
@@ -1,0 +1,1 @@
+- fix(sse): strip orphaned tool_use blocks before dispatching to Antigravity/Vertex Claude models, mirroring the mainline Claude executor's #2382 guard (#7752)

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -10,6 +10,7 @@ import {
   getAntigravityEnvelopeUserAgent,
   getAntigravitySessionId,
 } from "../../services/antigravityIdentity.ts";
+import { fixToolPairs } from "../../services/contextManager.ts";
 import {
   capMaxOutputTokens,
   capThinkingBudget,
@@ -258,7 +259,17 @@ function openaiToGeminiBase(
 
   // Build tool_call_id -> name map
   const tcID2Name: Record<string, string> = {};
-  const messages = body.messages as Array<Record<string, unknown>> | undefined;
+  // #7752: strip any non-trailing tool_call whose id has no matching tool_result
+  // anywhere in history — same guard `BaseExecutor.execute()` applies for the mainline
+  // Claude path (#2382/#4714) and `antigravityToOpenAIRequest` applies for the mirror
+  // incoming direction (#6026). Without this, an orphaned tool_call (e.g. left behind by
+  // OpenCode's known abort/cancel bug) reaches Google's Cloud Code envelope as an unpaired
+  // functionCall, which Vertex's Claude backend rejects with HTTP 400.
+  const rawMessages = body.messages as Array<Record<string, unknown>> | undefined;
+  const messages =
+    rawMessages && Array.isArray(rawMessages)
+      ? (fixToolPairs(rawMessages) as Array<Record<string, unknown>>)
+      : rawMessages;
   if (messages && Array.isArray(messages)) {
     for (const msg of messages) {
       const toolCalls = msg.tool_calls as Array<Record<string, unknown>> | undefined;

--- a/tests/unit/antigravity-orphan-tooluse-7752.test.ts
+++ b/tests/unit/antigravity-orphan-tooluse-7752.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression test for #7752.
+ *
+ * The mainline `claude` / Claude-Code-compatible executor path (`BaseExecutor.execute()`,
+ * `open-sse/executors/base.ts:1118-1136`) defends against a client history that ships a
+ * genuinely orphaned `tool_use`/`tool_call` block (no matching `tool_result` anywhere in
+ * history — e.g. from OpenCode's known client-side bug of leaving a stale tool_use after
+ * an aborted/cancelled tool call, anomalyco/opencode#8312) by running `fixToolPairs` on the
+ * outgoing messages before serialization. This is the #2382/#4714 fix class.
+ *
+ * `AntigravityExecutor.execute()` fully overrides `BaseExecutor.execute()` and never calls
+ * `super.execute()`, so for Claude-branded Antigravity models the request built by
+ * `openaiToAntigravityRequest` → `openaiToCloudCodeGeminiRequest` → `openaiToGeminiBase`
+ * (`open-sse/translator/request/openai-to-gemini.ts`) never applied that guard — the orphan
+ * tool_use survived as an unpaired `functionCall` part with no matching `functionResponse`,
+ * which Vertex's Claude backend rejects with HTTP 400.
+ *
+ * This is the mirror image of #6026 (orphan tool_RESULT, incoming antigravity→openai
+ * direction, fixed by wiring `fixToolPairs` into `antigravityToOpenAIRequest`). #7752 fixes
+ * the same missing-defense pattern on the OUTGOING openai→antigravity direction.
+ *
+ * PURE-FUNCTION ONLY — this test imports the translator + sanitizer functions directly.
+ * It must NEVER start the MITM proxy, bind :443/:80, touch /etc/hosts, or install a CA.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-ag-orphan-tooluse-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-ag-orphan-tooluse-secret";
+
+const { openaiToAntigravityRequest } = await import(
+  "../../open-sse/translator/request/openai-to-gemini.ts"
+);
+const { fixToolPairs } = await import("../../open-sse/services/contextManager.ts");
+
+type GeminiEnvelope = {
+  request: { contents: Array<{ role: string; parts: Array<Record<string, unknown>> }> };
+};
+
+function buildOpenCodeStyleBody() {
+  return {
+    model: "agy/claude-opus-4-6-thinking",
+    stream: true,
+    messages: [
+      { role: "system", content: "You are a coding agent." },
+      { role: "user", content: "Read config.ts and then update the version string." },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "toolu_vrtx_019zAAAA",
+            type: "function",
+            function: { name: "read_file", arguments: '{"path":"config.ts"}' },
+          },
+          {
+            id: "toolu_vrtx_01P1BBBB",
+            type: "function",
+            function: { name: "write_file", arguments: '{"path":"config.ts","content":"..."}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "toolu_vrtx_019zAAAA", content: "export const X = 1;" },
+      { role: "user", content: "Now also check the changelog." },
+    ],
+  };
+}
+
+function collectFunctionCallAndResponseIds(envelope: GeminiEnvelope) {
+  const functionCallIds = new Set<string>();
+  const functionResponseIds = new Set<string>();
+  for (const entry of envelope.request.contents) {
+    for (const part of entry.parts) {
+      const fc = part.functionCall as { id?: string } | undefined;
+      const fr = part.functionResponse as { id?: string } | undefined;
+      if (fc?.id) functionCallIds.add(fc.id);
+      if (fr?.id) functionResponseIds.add(fr.id);
+    }
+  }
+  return { functionCallIds, functionResponseIds };
+}
+
+test("#7752: openaiToAntigravityRequest strips an orphan functionCall (no functionResponse) for a Claude-branded Antigravity model", () => {
+  const body = buildOpenCodeStyleBody();
+  const envelope = openaiToAntigravityRequest(
+    "agy/claude-opus-4-6-thinking",
+    body,
+    true,
+    null
+  ) as GeminiEnvelope;
+
+  const { functionCallIds, functionResponseIds } = collectFunctionCallAndResponseIds(envelope);
+
+  // The paired tool_call must survive untouched.
+  assert.ok(functionCallIds.has("toolu_vrtx_019zAAAA"));
+  const orphanIds = [...functionCallIds].filter((id) => !functionResponseIds.has(id));
+  assert.deepEqual(
+    orphanIds,
+    [],
+    "every functionCall id should have a matching functionResponse or be stripped"
+  );
+});
+
+test("#7752: a still-in-flight trailing tool_call (no tool_result yet, at the very end of history) is NOT stripped", () => {
+  const body = {
+    model: "agy/claude-opus-4-6-thinking",
+    stream: true,
+    messages: [
+      { role: "system", content: "You are a coding agent." },
+      { role: "user", content: "Read config.ts." },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "toolu_vrtx_pending",
+            type: "function",
+            function: { name: "read_file", arguments: '{"path":"config.ts"}' },
+          },
+        ],
+      },
+    ],
+  };
+  const envelope = openaiToAntigravityRequest(
+    "agy/claude-opus-4-6-thinking",
+    body,
+    true,
+    null
+  ) as GeminiEnvelope;
+  const { functionCallIds } = collectFunctionCallAndResponseIds(envelope);
+  assert.ok(
+    functionCallIds.has("toolu_vrtx_pending"),
+    "a trailing in-flight tool_call must survive — it has not been orphaned yet"
+  );
+});
+
+test("control: the mainline Claude executor's fixToolPairs DOES strip the same orphan tool_call", () => {
+  const body = buildOpenCodeStyleBody();
+  const fixed = fixToolPairs(body.messages as Record<string, unknown>[]) as Array<
+    Record<string, unknown>
+  >;
+  const assistantMsg = fixed.find((m) => m.role === "assistant") as
+    | { tool_calls?: Array<{ id: string }> }
+    | undefined;
+  const survivingIds = (assistantMsg?.tool_calls ?? []).map((tc) => tc.id);
+  assert.deepEqual(survivingIds, ["toolu_vrtx_019zAAAA"]);
+});


### PR DESCRIPTION
Closes #7752

## Root cause

`AntigravityExecutor.execute()` (`open-sse/executors/antigravity.ts:1017`) fully overrides
`BaseExecutor.execute()` and never calls `super.execute()`. The shared orphan-`tool_use` guard
(`fixToolPairs`/`fixToolAdjacency`, the #2382/#4714 fix class) lives only inside
`BaseExecutor.execute()` (`open-sse/executors/base.ts:1118-1136`), so it never ran on the
Antigravity/Vertex Claude dispatch path.

For Claude-branded Antigravity models, the outgoing request is built by
`openaiToAntigravityRequest` → `openaiToCloudCodeGeminiRequest` → `openaiToGeminiBase`
(`open-sse/translator/request/openai-to-gemini.ts`). Neither that file nor `antigravity.ts`
applied any orphan-`tool_use` defense: a client history with a genuinely orphaned `tool_use`
(no matching `tool_result` anywhere — e.g. left behind by OpenCode's known abort/cancel bug,
`anomalyco/opencode#8312`) sailed straight through into Google's Cloud Code envelope as an
unpaired `functionCall`, which Vertex's Claude backend rejects with HTTP 400.

This is the mirror image of #6026, which fixed the same missing-defense pattern on the
*incoming* antigravity→openai direction (`antigravityToOpenAIRequest`). #7752 fixes the
*outgoing* openai→antigravity direction.

## Fix

`openaiToGeminiBase` now runs `fixToolPairs` (`open-sse/services/contextManager.ts` — the
same helper the mainline Claude path and #6026 already use) on `body.messages` before
building the `tool_call_id → name` map and the functionCall/functionResponse translation
loop. This strips any non-trailing orphaned `tool_call` while preserving a still-in-flight
trailing tool_call (the same `isLastMessage` exception `fixToolPairs` already implements).

## Regression test

`tests/unit/antigravity-orphan-tooluse-7752.test.ts` (isolated `DATA_DIR`, pure-function
only — no MITM/network):
- RED→GREEN: `openaiToAntigravityRequest` no longer leaves an orphan `functionCall` with no
  matching `functionResponse` for a Claude-branded Antigravity model.
- A still-in-flight trailing tool_call is preserved (not stripped).
- Control: `fixToolPairs` alone already strips the same shape (isolates the defect to
  "never invoked on this path").

RED (before fix):
```
✖ #7752: openaiToAntigravityRequest strips an orphan functionCall ...
  AssertionError [ERR_ASSERTION]: every functionCall id should have a matching functionResponse or be stripped
  + actual - expected
  + [ 'toolu_vrtx_01P1BBBB' ]
  - []
```

GREEN (after fix): all 3 tests in the file pass.

## Gates run

- `node --import tsx/esm --test tests/unit/antigravity-orphan-tooluse-7752.test.ts` — 3/3 pass
- Sibling suites (antigravity + translator, 6 files, 198 tests) — all pass:
  `antigravity-orphan-toolresult-6026`, `cc-bridge-tool-pair-guard`, `context-manager`,
  `fix-tool-adjacency`, `service-context-manager`, `translator-antigravity-to-openai`,
  `translator-openai-to-gemini`, `translator-openai-to-gemini-sse`,
  `openai-to-gemini-gemma-thinking`, `openai-to-gemini-helpers-split`,
  `vertex-functioncall-id-3440`, `translator-gemini-consecutive-role-2191`,
  `antigravity-model-aliases`, `antigravity-strip-builtin-tools-funcdecls-1095`,
  `antigravity-tool-cloak-server-side-invocations`, `translator-gemini-thinking-budget-6943`,
  `gemini-signatureless-text-mode`, `gemini-thinking-budget-zero-6813`,
  `translator-thinking-provider-compat-2043`, `v1beta-gemini-tool-calling-6222`,
  `antigravity-safetysettings-5003`, `t43-gemini-tool-call-no-thought-signature`,
  `executor-antigravity`
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-file-size.mjs` — no violations on touched files
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — no drift
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — OK

## Scope

Touches only `open-sse/translator/request/openai-to-gemini.ts` (12 lines) + the new
regression test + changelog fragment — no drive-by refactors.
