### PR TITLE
test(security): exact SAN-entry match in mitm leaf-cert test (CodeQL #746)

### DIFF
--- a/tests/unit/mitm-root-ca-leaf-issuance-6684.test.ts
+++ b/tests/unit/mitm-root-ca-leaf-issuance-6684.test.ts
@@ -33,9 +33,13 @@ test("issueLeafCert: issued leaf SAN matches the requested hostname", async () =
     const leaf = await issueLeafCert(host, ca);
     const leafPem = leaf.cert.split(/(?=-----BEGIN CERTIFICATE-----)/)[0];
     const cert = new X509Certificate(leafPem);
+    // Exact SAN-entry membership, not a host substring: `includes(host)` would also
+    // pass for a SAN of "notexample.com" when host is "example.com", and CodeQL flags
+    // it as js/incomplete-url-substring-sanitization (#746).
+    const sanEntries = (cert.subjectAltName ?? "").split(",").map((entry) => entry.trim());
     assert.ok(
-      cert.subjectAltName && cert.subjectAltName.includes(host),
-      `expected SAN to include ${host}, got ${cert.subjectAltName}`
+      sanEntries.includes(`DNS:${host}`),
+      `expected SAN to include DNS:${host}, got ${cert.subjectAltName}`
     );
   }
 });


### PR DESCRIPTION
## Why this matters right now

**#746 is the ONLY open CodeQL alert in the repo**, and `check:codeql-ratchet` counts alerts **repo-wide** — so it single-handedly keeps **`Quality Ratchet` red on every open PR**. Right now that is blocking ~10 contributor PRs (#7816, #7813, #7810, #7804, #7807, #7358, #7296, #6958, #7027, #7299) whose only failing checks are this base-red — they have no defect of their own.

The alert is **live on the exact tip** (`5e96d5254`), has **no open PR** covering it, and came in with #7731 (already merged). This clears it at the source.

## Root cause

`tests/unit/mitm-root-ca-leaf-issuance-6684.test.ts:37` asserted the leaf cert's SAN with a **host substring** check:

```ts
cert.subjectAltName && cert.subjectAltName.includes(host)
```

CodeQL flags this as `js/incomplete-url-substring-sanitization` (HIGH) — and it is genuinely loose: a SAN of `notexample.com` satisfies `host = "example.com"`.

## Fix

Exact SAN-entry membership instead of substring:

```ts
const sanEntries = (cert.subjectAltName ?? "").split(",").map((entry) => entry.trim());
assert.ok(
  sanEntries.includes(`DNS:${host}`),
  `expected SAN to include DNS:${host}, got ${cert.subjectAltName}`
);
```

**Stronger, not weaker** — it now verifies the full `DNS:<host>` entry rather than any coincidental substring, and it is no longer a substring-of-host sink. `allHosts()` comes from `MITM_TOOL_HOSTS` (DNS names, no IPs), so the `DNS:` prefix is correct.

## Validation (Hard Rule #18)

```
node --import tsx/esm --test tests/unit/mitm-root-ca-leaf-issuance-6684.test.ts
→ 5 pass, 0 fail
```

Test-only; no production code touched. File exists only on `release/v3.8.49` — no `main` companion needed (merge-gates §8). Once merged + rescanned, repo CodeQL count hits **0** and `Quality Ratchet` goes green across the whole open-PR queue.