### PR TITLE
fix(oauth): require chatgptUserId agreement for Codex account dedup (#7737)

### DIFF
--- a/changelog.d/fixes/7737-codex-multiaccount.md
+++ b/changelog.d/fixes/7737-codex-multiaccount.md
@@ -1,0 +1,1 @@
+- fix(oauth): stop Codex OAuth completion from collapsing distinct accounts that share an email but have no workspaceId, by requiring chatgptUserId agreement before merging (#7737)

--- a/src/app/api/oauth/[provider]/[action]/route.ts
+++ b/src/app/api/oauth/[provider]/[action]/route.ts
@@ -12,6 +12,7 @@ import {
 import {
   persistOAuthConnection,
   buildOAuthConnectionCreatePayload,
+  findExistingOAuthConnectionMatch,
 } from "@/lib/oauth/connectionPersistence";
 import { createDeviceFlowTicket, getDeviceFlowTicketStatus } from "@/lib/oauth/deviceFlowTickets";
 import {
@@ -520,17 +521,9 @@ export async function POST(
       let connection: any;
       if (tokenData.email) {
         const existing = await getProviderConnections({ provider });
-        const match = existing.find((c: any) => {
-          if (c.id && safeEqual(connectionId, c.id)) return true;
-          // safeEqual: constant-time comparison to prevent timing attacks (CWE-208, finding #258-6/7)
-          if (!safeEqual(c.email, tokenData.email) || c.authType !== "oauth") return false;
-          // For Codex, also check workspaceId to avoid overwriting different workspace connections
-          if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {
-            const existingWorkspace = c.providerSpecificData?.workspaceId;
-            return safeEqual(existingWorkspace, tokenData.providerSpecificData.workspaceId);
-          }
-          return true;
-        });
+        // Codex accounts sharing an email require workspaceId/chatgptUserId
+        // agreement to be treated as the same account (#7737).
+        const match = findExistingOAuthConnectionMatch(existing, provider, tokenData, connectionId);
         const matchId = typeof match?.id === "string" ? match.id : null;
         if (matchId) {
           connection = await updateProviderConnection(matchId, {
@@ -618,17 +611,14 @@ export async function POST(
         let connection: any;
         if (result.tokens.email) {
           const existing = await getProviderConnections({ provider });
-          const match = existing.find((c: any) => {
-            if (c.id && safeEqual(connectionId, c.id)) return true;
-            // safeEqual: constant-time comparison to prevent timing attacks (CWE-208, finding #258-8/9)
-            if (!safeEqual(c.email, result.tokens.email) || c.authType !== "oauth") return false;
-            // For Codex, also check workspaceId to avoid overwriting different workspace connections
-            if (provider === "codex" && result.tokens.providerSpecificData?.workspaceId) {
-              const existingWorkspace = c.providerSpecificData?.workspaceId;
-              return safeEqual(existingWorkspace, result.tokens.providerSpecificData.workspaceId);
-            }
-            return true;
-          });
+          // Codex accounts sharing an email require workspaceId/chatgptUserId
+          // agreement to be treated as the same account (#7737).
+          const match = findExistingOAuthConnectionMatch(
+            existing,
+            provider,
+            result.tokens,
+            connectionId
+          );
           const matchId = typeof match?.id === "string" ? match.id : null;
           if (matchId) {
             connection = await updateProviderConnection(matchId, {
@@ -754,17 +744,9 @@ export async function POST(
         let connection: any;
         if (tokenData.email) {
           const existing = await getProviderConnections({ provider });
-          const match = existing.find((c: any) => {
-            if (c.id && safeEqual(connectionId, c.id)) return true;
-            // safeEqual: constant-time comparison to prevent timing attacks (CWE-208, finding #258-6/7)
-            if (!safeEqual(c.email, tokenData.email) || c.authType !== "oauth") return false;
-            // For Codex, also check workspaceId to avoid overwriting different workspace connections
-            if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {
-              const existingWorkspace = c.providerSpecificData?.workspaceId;
-              return safeEqual(existingWorkspace, tokenData.providerSpecificData.workspaceId);
-            }
-            return true;
-          });
+          // Codex accounts sharing an email require workspaceId/chatgptUserId
+          // agreement to be treated as the same account (#7737).
+          const match = findExistingOAuthConnectionMatch(existing, provider, tokenData, connectionId);
           const matchId = typeof match?.id === "string" ? match.id : null;
           if (matchId) {
             connection = await updateProviderConnection(matchId, {

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -19,12 +19,61 @@ import { syncToCloud } from "@/lib/cloudSync";
  * Constant-time string comparison to prevent timing-oracle attacks (CWE-208).
  * Handles null/undefined safely and different-length strings.
  */
-function safeEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+export function safeEqual(a: string | null | undefined, b: string | null | undefined): boolean {
   if (a == null || b == null) return a === b;
   const ba = Buffer.from(String(a));
   const bb = Buffer.from(String(b));
   if (ba.length !== bb.length) return false;
   return timingSafeEqual(ba, bb);
+}
+
+/**
+ * #7737: does this existing Codex connection represent the SAME account as the
+ * incoming login? Prefer workspaceId when either side has one (Team plans).
+ * When NEITHER side has a workspaceId (Personal-plan logins, or two accounts
+ * that both lack a Team workspace), a bare email match is not enough to prove
+ * it's the same account — two different ChatGPT accounts can share an email
+ * alias. Require chatgptUserId to agree; otherwise treat it as a distinct
+ * account so the caller falls through to createProviderConnection (which
+ * already does this same disambiguation, added under #6706).
+ */
+function isSameCodexAccount(
+  existingProviderData: Record<string, any> | null | undefined,
+  incomingProviderData: Record<string, any> | null | undefined
+): boolean {
+  const incomingWorkspace = incomingProviderData?.workspaceId;
+  const existingWorkspace = existingProviderData?.workspaceId;
+  if (incomingWorkspace || existingWorkspace) {
+    return safeEqual(existingWorkspace, incomingWorkspace);
+  }
+  const incomingUserId = incomingProviderData?.chatgptUserId;
+  const existingUserId = existingProviderData?.chatgptUserId;
+  return Boolean(incomingUserId) && safeEqual(existingUserId, incomingUserId);
+}
+
+/**
+ * Find the existing OAuth connection (if any) that an incoming token payload
+ * should be merged into, shared by every OAuth-completion call site
+ * (persistOAuthConnection, and the exchange/poll/poll-callback branches in
+ * `src/app/api/oauth/[provider]/[action]/route.ts`). Matches by explicit
+ * connectionId first, then by same email + auth type — with Codex requiring
+ * workspaceId/chatgptUserId agreement (#7737) to avoid silently overwriting
+ * a different Codex account that merely shares an email.
+ */
+export function findExistingOAuthConnectionMatch(
+  existing: Array<Record<string, any>>,
+  provider: string,
+  tokenData: Record<string, any>,
+  connectionId?: string
+): Record<string, any> | undefined {
+  return existing.find((c) => {
+    if (c.id && safeEqual(connectionId, c.id)) return true;
+    if (!safeEqual(c.email, tokenData.email) || c.authType !== "oauth") return false;
+    if (provider === "codex") {
+      return isSameCodexAccount(c.providerSpecificData, tokenData.providerSpecificData);
+    }
+    return true;
+  });
 }
 
 /**
@@ -83,16 +132,7 @@ export async function persistOAuthConnection(
   let connection: any;
   if (tokenData.email) {
     const existing = await getProviderConnections({ provider });
-    const match = existing.find((c: any) => {
-      if (c.id && safeEqual(connectionId, c.id)) return true;
-      if (!safeEqual(c.email, tokenData.email) || c.authType !== "oauth") return false;
-      // For Codex, also check workspaceId to avoid overwriting a different workspace.
-      if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {
-        const existingWorkspace = c.providerSpecificData?.workspaceId;
-        return safeEqual(existingWorkspace, tokenData.providerSpecificData.workspaceId);
-      }
-      return true;
-    });
+    const match = findExistingOAuthConnectionMatch(existing, provider, tokenData, connectionId);
     const matchId = typeof match?.id === "string" ? match.id : null;
     if (matchId) {
       connection = await updateProviderConnection(matchId, {

--- a/tests/unit/oauth-connection-persistence-codex-dedup.test.ts
+++ b/tests/unit/oauth-connection-persistence-codex-dedup.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7737-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { persistOAuthConnection } = await import("../../src/lib/oauth/connectionPersistence.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if ((code === "EBUSY" || code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("persistOAuthConnection must not merge two distinct Codex accounts that share an email but have different chatgptUserId and no workspaceId", async () => {
+  const accountA = await persistOAuthConnection("codex", {
+    email: "shared@example.com",
+    accessToken: "token-account-a",
+    refreshToken: "refresh-account-a",
+    expiresIn: 3600,
+    providerSpecificData: { chatgptUserId: "user-a" },
+  });
+
+  const accountB = await persistOAuthConnection("codex", {
+    email: "shared@example.com",
+    accessToken: "token-account-b",
+    refreshToken: "refresh-account-b",
+    expiresIn: 3600,
+    providerSpecificData: { chatgptUserId: "user-b" },
+  });
+
+  const rows = await providersDb.getProviderConnections({ provider: "codex" });
+
+  assert.notEqual(
+    accountB.id,
+    accountA.id,
+    "second Codex login must create a distinct connection, not reuse the first account's row"
+  );
+  assert.equal(rows.length, 2, "both Codex accounts must persist as separate connections");
+
+  const rowA = rows.find((row: { id: string }) => row.id === accountA.id);
+  assert.equal(
+    rowA?.accessToken,
+    "token-account-a",
+    "account A's access token must survive account B's login unmodified"
+  );
+});
+
+test("persistOAuthConnection still merges a re-login for the SAME Codex chatgptUserId with no workspaceId", async () => {
+  const first = await persistOAuthConnection("codex", {
+    email: "solo@example.com",
+    accessToken: "token-first",
+    refreshToken: "refresh-first",
+    expiresIn: 3600,
+    providerSpecificData: { chatgptUserId: "user-solo" },
+  });
+
+  const second = await persistOAuthConnection("codex", {
+    email: "solo@example.com",
+    accessToken: "token-second",
+    refreshToken: "refresh-second",
+    expiresIn: 3600,
+    providerSpecificData: { chatgptUserId: "user-solo" },
+  });
+
+  assert.equal(second.id, first.id, "re-authenticating the same Codex user must update the same row");
+
+  const rows = await providersDb.getProviderConnections({ provider: "codex" });
+  assert.equal(rows.length, 1, "no duplicate connection should be created for the same chatgptUserId");
+  assert.equal(rows[0]?.accessToken, "token-second", "the row must reflect the latest tokens");
+});


### PR DESCRIPTION
Closes #7737

## Root cause

Codex OAuth completion collapses two distinct Codex accounts that share an email but have no `workspaceId` into a single connection row.

`createProviderConnection` (`src/lib/db/providers.ts`) was fixed under #6706 to require a matching `chatgptUserId` before merging two Codex logins that share an email but lack a `workspaceId`. That fix is real, but it is only reached when nothing has already matched upstream — and every real Codex OAuth-completion call site did its OWN, simpler pre-check first, bypassing #6706's fix entirely:

1. `src/lib/oauth/connectionPersistence.ts` (`persistOAuthConnection`) — used by the `device-complete` action, which is the path Codex actually uses in production because `auth.openai.com` blocks the server's own datacenter IP.
2. The identical inline logic duplicated 3 more times in `src/app/api/oauth/[provider]/[action]/route.ts`: `exchange`, `poll`, and `poll-callback`.

All four did:

```ts
if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {
  return safeEqual(existingWorkspace, tokenData.providerSpecificData.workspaceId);
}
return true; // no workspaceId on the incoming login → matches ANY same-email row
```

When the incoming Codex login has no `workspaceId` (a Personal-plan login, or the second of two accounts sharing an email where neither is on a Team workspace), this falls straight to `return true`, matching the FIRST Codex row with that email and calling `updateProviderConnection` on it — silently overwriting account A's tokens with account B's. `createProviderConnection`'s `chatgptUserId` check never runs.

## Fix

Extracted the matching logic into a single exported helper, `findExistingOAuthConnectionMatch()`, in `src/lib/oauth/connectionPersistence.ts`, and pointed all 4 call sites (`persistOAuthConnection` + the 3 duplicated blocks in `route.ts`) at it. When neither the incoming nor the existing Codex connection has a `workspaceId`, the match now requires `chatgptUserId` agreement; otherwise it falls through so `createProviderConnection`'s existing #6706 disambiguation applies. Same-account re-logins (same `chatgptUserId`, no `workspaceId`) still correctly update the existing row.

Note: this only prevents *future* collisions. Accounts already silently merged by the pre-existing bug cannot be un-merged — the overwritten account's original tokens are gone, so affected users need to re-authenticate that account once this ships.

## Regression test

`tests/unit/oauth-connection-persistence-codex-dedup.test.ts` — reused from the `/triage-fix-bugs` repro, proven RED on `origin/release/v3.8.49` before the fix:

```
✖ persistOAuthConnection must not merge two distinct Codex accounts that share an email but have different chatgptUserId and no workspaceId
  AssertionError [ERR_ASSERTION]: second Codex login must create a distinct connection, not reuse the first account's row
    actual: '...', expected: '...', operator: 'notStrictEqual'
```

GREEN after the fix (plus an added companion case confirming same-`chatgptUserId` re-logins still merge correctly):

```
✔ persistOAuthConnection must not merge two distinct Codex accounts that share an email but have different chatgptUserId and no workspaceId
✔ persistOAuthConnection still merges a re-login for the SAME Codex chatgptUserId with no workspaceId
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

Also re-ran the pre-existing sibling suites that cover the touched paths — all green, no behavior regressed:
- `tests/unit/db-providers-crud.test.ts` (14/14 — the #6706 `createProviderConnection` tests, untouched path)
- `tests/unit/windsurf-devin-executors.test.ts`, `tests/unit/kiro-auto-import-name-dedup-3615.test.ts`, `tests/unit/kiro-api-key-route-helpers.test.ts`, `tests/unit/oauth-keychain-import-only-guard.test.ts`, `tests/unit/oauth-callback-path-doc.test.ts`, `tests/unit/codex-oauth-remote-host-hint-7523.test.ts`, `tests/unit/oauth-cursor-auto-import.test.ts`, `tests/unit/sse-error-passthrough-3324.test.ts`, `tests/unit/oauth-legacy-services-removed.test.ts`, `tests/unit/oauth-device-code-error-transparency.test.ts`, `tests/unit/oauth-keychain-import-only-6041.test.ts` (102/102, all importing the touched route file)

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/oauth-connection-persistence-codex-dedup.test.ts` — RED then GREEN
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2076 violations vs baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (903 violations vs baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — OK, no drift
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK
