### PR TITLE
fix(db): purge in-memory key-health state when a provider connection is deleted (#7740)

### DIFF
--- a/changelog.d/fixes/7740-phantom-health-popup.md
+++ b/changelog.d/fixes/7740-phantom-health-popup.md
@@ -1,0 +1,1 @@
+- fix(db): purge in-memory API-key health/rotation state when a provider connection is deleted (#7740)

--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -12,6 +12,10 @@ import {
 } from "./encryption";
 import { createLazyRowProxy } from "./providers/lazyConnectionView";
 import { invalidateDbCache, getCachedRawProviderConnections } from "./readCache";
+import {
+  removeConnectionHealth,
+  removeConnectionIndex,
+} from "@omniroute/open-sse/services/apiKeyRotator.ts";
 import { invalidateReasoningRoutingRuleCache } from "./reasoningRoutingRules";
 import { normalizeProviderSpecificData } from "@/lib/providers/requestDefaults";
 import { bumpProxyConfigGeneration } from "./settings";
@@ -833,6 +837,8 @@ export async function deleteProviderConnection(id: string) {
 
   db.prepare("DELETE FROM quota_snapshots WHERE connection_id = ?").run(id);
   db.prepare("DELETE FROM provider_connections WHERE id = ?").run(id);
+  removeConnectionHealth(id);
+  removeConnectionIndex(id);
   bumpProxyConfigGeneration();
   const existingRecord = toRecord(existing);
   const providerId =
@@ -859,6 +865,10 @@ export async function deleteProviderConnections(ids: string[]): Promise<number> 
     return result.changes ?? 0;
   })();
 
+  for (const id of ids) {
+    removeConnectionHealth(id);
+    removeConnectionIndex(id);
+  }
   backupDbFile("pre-write");
   invalidateDbCache("connections");
   invalidateReasoningRoutingRuleCache();
@@ -884,6 +894,10 @@ export async function deleteProviderConnectionsByProvider(providerId: string) {
   }
 
   const result = db.prepare("DELETE FROM provider_connections WHERE provider = ?").run(providerId);
+  for (const connectionId of connectionIds) {
+    removeConnectionHealth(connectionId);
+    removeConnectionIndex(connectionId);
+  }
   backupDbFile("pre-write");
   invalidateDbCache("connections");
   invalidateReasoningRoutingRuleCache();

--- a/tests/unit/delete-provider-connection-purges-key-health-7740.test.ts
+++ b/tests/unit/delete-provider-connection-purges-key-health-7740.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-probe-7740-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const catalog = await import("../../src/lib/providers/catalog.ts");
+const apiKeyRotator = await import("../../open-sse/services/apiKeyRotator.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      break;
+    } catch (error: unknown) {
+      const code = (error as { code?: string } | undefined)?.code;
+      if ((code === "EBUSY" || code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else throw error;
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#7740: orphaned provider connection (id removed from catalog) keeps surfacing apiKeyHealth and 404s on click, but deleting purges in-memory key-health", async () => {
+  assert.equal(
+    catalog.resolveStaticProviderCatalogEntry("phind"),
+    null,
+    "sanity: phind must already be absent from the live catalog"
+  );
+
+  const created = await providersDb.createProviderConnection({
+    provider: "phind",
+    authType: "apikey",
+    name: "Legacy Phind key",
+    apiKey: "sk-legacy-orphan",
+    providerSpecificData: {
+      apiKeyHealth: {
+        primary: {
+          status: "invalid",
+          failures: 3,
+          lastFailure: new Date().toISOString(),
+          lastSuccess: null,
+          totalRequests: 5,
+          totalFailures: 3,
+        },
+      },
+    },
+  });
+  assert.ok(created?.id, "connection must be created");
+
+  const all = await providersDb.getProviderConnections({});
+  const orphan = all.find((c: { id: string }) => c.id === created.id) as
+    | {
+        id: string;
+        provider: string;
+        providerSpecificData?: {
+          apiKeyHealth?: { primary?: { status?: string } };
+        };
+      }
+    | undefined;
+  assert.ok(orphan, "orphaned connection must still be returned by getProviderConnections()");
+  assert.equal(orphan.provider, "phind");
+  assert.equal(
+    orphan.providerSpecificData?.apiKeyHealth?.primary?.status,
+    "invalid",
+    "the stale invalid-key health survives untouched — this is what triggers the homepage popup"
+  );
+
+  const providerInfo = catalog.resolveStaticProviderCatalogEntry(orphan.provider);
+  assert.equal(
+    providerInfo,
+    null,
+    "clicking the popup navigates to a provider id that resolves to nothing — reproduces the reported 404"
+  );
+
+  apiKeyRotator.recordKeyFailure(created.id, "primary");
+  apiKeyRotator.recordKeyFailure(created.id, "primary");
+  const beforeDelete = apiKeyRotator.getAllKeyHealth();
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(beforeDelete, `${created.id}:primary`),
+    "sanity: in-memory health entry exists before delete"
+  );
+
+  const deleted = await providersDb.deleteProviderConnection(created.id);
+  assert.equal(deleted, true, "connection row must actually be deleted");
+
+  const afterDelete = apiKeyRotator.getAllKeyHealth();
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(afterDelete, `${created.id}:primary`),
+    false,
+    "EXPECTED: deleting a connection should purge its in-memory key-health entry " +
+      "(deleteProviderConnection() should call removeConnectionHealth()/removeConnectionIndex()) " +
+      "— issue #7740 expects 'Deleted keys shouldn't be checked anymore'"
+  );
+});


### PR DESCRIPTION
Closes #7740

## Root cause

`removeConnectionHealth(connectionId)` / `removeConnectionIndex(connectionId)` in `open-sse/services/apiKeyRotator.ts` exist specifically to purge the module-level in-memory `_keyHealth`/`_keyIndexes`/`_connectionExtraKeys` maps for a connection, but were only ever called from the retest/reset flow (`src/app/api/providers/[id]/test/route.ts`) — never from any connection-deletion path. So deleting a provider connection left its stale in-memory key-health entries behind, which is what kept surfacing the "API key marked invalid" popup for keys the user believed were already deleted.

## Fix

Wired the existing cleanup calls into all three connection-deletion paths in `src/lib/db/providers.ts`:

- `deleteProviderConnection()`
- `deleteProviderConnections()` (bulk)
- `deleteProviderConnectionsByProvider()`

Fixing at the DB-module layer (rather than in the route handlers) means every caller of these functions gets the cleanup automatically, and keeps the diff scoped to the cache-invalidation path proven by the regression test. No circular-dependency risk: `apiKeyRotator.ts` has zero imports of its own.

## Regression test

`tests/unit/delete-provider-connection-purges-key-health-7740.test.ts` reproduces the full report:

1. Creates a connection for `phind` (a provider id already removed from the live catalog — an established precedent for orphaned connections, see `tests/unit/discontinued-providers-2026.test.ts`) with a pre-populated invalid `apiKeyHealth` entry, confirming it still surfaces via `getProviderConnections()` and 404s on `resolveStaticProviderCatalogEntry()`.
2. Records key failures, deletes the connection via `deleteProviderConnection()`, and asserts the in-memory key-health entry is purged.

RED (before fix):
```
✖ #7740 ...: EXPECTED: deleting a connection should purge its in-memory key-health entry ...
true !== false
```

GREEN (after fix):
```
✔ #7740: orphaned provider connection (id removed from catalog) keeps surfacing apiKeyHealth and 404s on click, but deleting purges in-memory key-health
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Scope note

The plan-file also proposed a second, independent fix (scheduler/homepage should skip connections whose `provider` id no longer resolves in the catalog, so an already-orphaned connection self-heals). That half is not covered by this regression test and is left for a separate follow-up to keep this diff surgical — the reported symptom (deleted keys still being checked / still triggering the popup) is fully addressed by this fix for any connection deleted going forward.

## Gates run

- `node --import tsx/esm --test tests/unit/delete-provider-connection-purges-key-health-7740.test.ts` — RED then GREEN (above)
- Sibling suites for touched files, all green (110 tests, exit 0): `db-providers-crud.test.ts`, `db-providers-split.test.ts`, `chatcore-key-health.test.ts`, `eviction-guards-apiKeyRotator.test.ts`, `db-health-check.test.ts`, `db-read-cache.test.ts`, `reasoning-routing.test.ts`, `quota-combos-sync.test.ts`, `usage-analytics-route-extra.test.ts`
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2076 violations vs baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (903 violations vs baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — OK (no drift; neither `providers.ts` nor `apiKeyRotator.ts` are in the mutated-module list)
- `npm run typecheck:core` — exit 0, no errors
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK
