### PR TITLE
fix: keep a retrievable preamble instead of a bare CCR marker (#7746)

### DIFF
--- a/changelog.d/fixes/7746-ccr-prompt-marker-loss.md
+++ b/changelog.d/fixes/7746-ccr-prompt-marker-loss.md
@@ -1,0 +1,1 @@
+- fix(compression): CCR no longer collapses a whole prompt into a bare, unretrievable `[CCR retrieve hash=...]` marker on non-MCP upstreams — a short preamble of the original text is always kept alongside the marker (#7746)

--- a/open-sse/services/compression/engines/ccr/index.ts
+++ b/open-sse/services/compression/engines/ccr/index.ts
@@ -519,6 +519,27 @@ export function buildCcrReference(
 }
 
 /**
+ * #7746 guard: how many leading characters of the original block to keep in front
+ * of the marker. `maybeCcrReplace` treats an entire message/part as ONE candidate
+ * block (see module docstring), so a bare marker alone would silently discard the
+ * ENTIRE prompt for any caller that cannot resolve `omniroute_ccr_retrieve`
+ * (every plain OpenAI-compatible client — it is only ever exposed as an MCP tool).
+ * Keeping a short, human-readable preamble means the model still sees the start
+ * of the user's intent even when the marker itself is unreachable, while the full
+ * text remains verbatim-retrievable by hash for MCP-capable callers.
+ */
+const MARKER_PREAMBLE_CHARS = 200;
+
+/**
+ * Build the text that replaces a compressed block: a short preamble of the
+ * original content followed by the retrieve marker, never the marker alone.
+ */
+function buildCcrReplacementText(text: string, marker: string): string {
+  const preamble = text.slice(0, MARKER_PREAMBLE_CHARS).trimEnd();
+  return `${preamble}… ${marker}`;
+}
+
+/**
  * Replace a large text block with a CCR marker if it shrinks the content.
  * Returns the new text and a flag indicating whether replacement happened.
  */
@@ -543,15 +564,18 @@ function maybeCcrReplace(
   }
 
   const marker = buildCcrMarker(hash, text.length);
+  // #7746: never leave a caller with ONLY the bare marker — keep a short preamble
+  // so the original prompt is not silently, totally unreachable for non-MCP callers.
+  const replacement = buildCcrReplacementText(text, marker);
 
   // Only replace if it actually shrinks
-  if (marker.length >= text.length) {
+  if (replacement.length >= text.length) {
     return { text, replaced: false, hash: null };
   }
 
   const stored = tryStoreBlock(text, principalId, { source: "compression" });
   if (!stored.stored) return { text, replaced: false, hash: null };
-  return { text: marker, replaced: true, hash };
+  return { text: replacement, replaced: true, hash };
 }
 
 /**

--- a/tests/unit/compression/ccr-non-mcp-full-prompt-loss-7746.test.ts
+++ b/tests/unit/compression/ccr-non-mcp-full-prompt-loss-7746.test.ts
@@ -1,0 +1,92 @@
+// Regression test for issue #7746.
+//
+// The CCR ("Content-Compression-Retrieve") engine can replace an ENTIRE
+// single-message user prompt with nothing but a bare
+// `[CCR retrieve hash=... chars=N]` marker. The MCP tool that could expand
+// that marker (`omniroute_ccr_retrieve`) is only ever exposed through
+// OmniRoute's own MCP server — never injected into the `tools` array of a
+// plain /v1/chat/completions OpenAI-compatible request. So for non-MCP
+// clients (OpenCode, Claude Code in "openai-compatible" mode, or any generic
+// proxy client), once a large first-turn prompt is compressed, the original
+// text becomes permanently unreachable from the model's point of view.
+//
+// Run: node --import tsx/esm --test tests/unit/compression/ccr-non-mcp-full-prompt-loss-7746.test.ts
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ccrEngine,
+  resetCcrStore,
+  retrieveBlock,
+} from "../../../open-sse/services/compression/engines/ccr/index.ts";
+
+// The reporter's actual Playwright-automation prompt, sent as the sole
+// message of a brand-new conversation (no prior turns, no `tools` array) —
+// the shape of a plain OpenAI-compatible request from OpenCode/Claude Code.
+const REPORTER_PROMPT = `I want you to build a Playwright automation script for AgentRouter with the following requirements.
+
+The script must:
+1. Launch a Chromium browser instance using Playwright's async API, with headless mode configurable via an environment variable.
+2. Navigate to the AgentRouter dashboard login page and authenticate using credentials pulled from environment variables (never hard-coded).
+3. Wait for the dashboard to fully load, verified by checking for a specific selector that only appears once the page is interactive.
+4. Navigate to the "Providers" section and enumerate every configured provider row, extracting the provider name, status (enabled/disabled), and current rate-limit usage percentage.
+5. For any provider whose rate-limit usage exceeds 90%, click into its detail panel and capture a full-page screenshot, saving it to a timestamped file under a "reports/" directory that the script creates if missing.
+6. Aggregate all extracted data into a single JSON report with a top-level "generatedAt" ISO timestamp and a "providers" array of objects.
+7. Write the JSON report to disk with pretty-printing (2-space indent) and also log a concise summary table to stdout using console.table.
+8. Implement robust error handling: if navigation or a selector wait times out, retry up to 3 times with exponential backoff before failing the whole run with a clear error message and non-zero exit code.
+9. Add a cleanup step in a try/finally block that always closes the browser context and browser instance, even if an assertion or navigation step throws.
+10. Structure the code into clearly separated functions (login, scrapeProviders, screenshotOverLimit, writeReport) rather than one long monolithic script, and add JSDoc comments explaining each function's parameters and return value.
+11. Make the script runnable both as a standalone Node script (via a shebang and direct invocation) and importable as a module for reuse in a larger test suite.
+12. Include a small README-style comment block at the top of the file explaining prerequisites (Node version, Playwright install command) and how to run the script with the required environment variables.
+
+Please keep the code idiomatic modern JavaScript/TypeScript, avoid unnecessary external dependencies beyond Playwright itself, and make sure timeouts and selectors are configurable constants at the top of the file rather than magic numbers scattered through the logic. Generate production-quality code that is easy to maintain and extend.`;
+
+function makeOpenCodeStyleRequestBody() {
+  return {
+    model: "hy-3:free",
+    messages: [{ role: "user", content: REPORTER_PROMPT }],
+    stream: true,
+  };
+}
+
+describe("issue #7746 — CCR must not reduce the sole user prompt to a bare, unretrievable marker", () => {
+  before(() => {
+    resetCcrStore();
+  });
+
+  it("prompt fixture is realistically sized (>= default 600-char minChars)", () => {
+    assert.ok(REPORTER_PROMPT.length >= 600, `fixture must be >= 600 chars, got ${REPORTER_PROMPT.length}`);
+  });
+
+  it("does not leave the model with only the bare CCR marker when no retrieve tool is available", () => {
+    resetCcrStore();
+    const body = makeOpenCodeStyleRequestBody();
+    const result = ccrEngine.apply(body as Record<string, unknown>, { stepConfig: {} });
+
+    assert.equal(result.compressed, true, "CCR compressed the sole user message (reproducing the report)");
+
+    const messages = result.body.messages as Array<{ role: string; content: string }>;
+    const compressedContent = messages[0].content;
+    const isBareMarkerOnly = /^\[CCR retrieve hash=[0-9a-f]{24} chars=\d+\]$/.test(compressedContent);
+
+    assert.equal(
+      isBareMarkerOnly,
+      false,
+      "BUG #7746: CCR replaced the ENTIRE sole user message with nothing but the bare " +
+        `[CCR retrieve hash=...] marker, permanently losing the original prompt for any ` +
+        `non-MCP caller that cannot resolve the marker. Got: ${JSON.stringify(compressedContent)}`
+    );
+  });
+
+  it("the original prompt remains fully retrievable by hash even after the guard applies", () => {
+    resetCcrStore();
+    const body = makeOpenCodeStyleRequestBody();
+    const result = ccrEngine.apply(body as Record<string, unknown>, { stepConfig: {} });
+
+    const messages = result.body.messages as Array<{ role: string; content: string }>;
+    const compressedContent = messages[0].content;
+    const match = compressedContent.match(/\[CCR retrieve hash=([0-9a-f]{24}) chars=\d+\]/);
+    assert.ok(match, "compressed content must still contain a resolvable CCR marker");
+    const hash = match![1];
+    assert.equal(retrieveBlock(hash), REPORTER_PROMPT, "original prompt must be stored verbatim and retrievable");
+  });
+});


### PR DESCRIPTION
Closes #7746

## Root cause

`open-sse/services/compression/engines/ccr/index.ts` (`maybeCcrReplace` / `processMessages`): despite the module docstring claiming the CCR engine "finds contiguous text blocks >= minChars" *within* a message, the implementation treats an entire string `msg.content` (or an entire `type:"text"` part) as ONE candidate block — there is no sub-scanning. When that whole block was >= `minChars` (default 600) and the `[CCR retrieve hash=<24hex> chars=N]` marker was shorter than the original, `processMessages` replaced the message's ENTIRE content with just the ~50-char marker.

The `omniroute_ccr_retrieve` MCP tool that can resolve that marker back is only ever registered inside OmniRoute's own MCP server (`open-sse/mcp-server/tools/compressionTools.ts`, scope `read:compression`). It is never injected into a plain `/v1/chat/completions` request's `tools` array. So for any non-MCP client (OpenCode, Claude Code in OpenAI-compatible mode, or any generic proxy client) with compression/CCR enabled, a large first-turn prompt above the 600-char threshold was silently, permanently reduced to an unreachable marker — exactly the reported symptom.

## Fix

`maybeCcrReplace` now always keeps a short leading preamble (first ~200 chars) of the original block alongside the marker instead of replacing the block with the bare marker alone. A caller that cannot resolve `omniroute_ccr_retrieve` still sees the start of the user's intent instead of losing the prompt entirely. The full original text remains stored verbatim and retrievable by hash for MCP-capable callers — the retrieval/MCP contract (principal scoping, IDOR isolation, H8 retrieval ramp) is unchanged.

## Regression test (TDD, Hard Rule #18)

`tests/unit/compression/ccr-non-mcp-full-prompt-loss-7746.test.ts` — reuses the reporter's ~2.5KB Playwright-automation prompt sent as the sole message of a brand-new conversation (no `tools` array), matching the shape of a plain OpenAI-compatible request.

RED (before fix, on `origin/release/v3.8.49`):
```
✖ does not leave the model with only the bare CCR marker when no retrieve tool is available
  AssertionError [ERR_ASSERTION]: BUG #7746: CCR replaced the ENTIRE sole user message with nothing
  but the bare [CCR retrieve hash=...] marker ...
  Got: "[CCR retrieve hash=fa50bdaa1a8e8bc148973c78 chars=2497]"
  true !== false
```

GREEN (after fix):
```
✔ prompt fixture is realistically sized (>= default 600-char minChars)
✔ does not leave the model with only the bare CCR marker when no retrieve tool is available
✔ the original prompt remains fully retrievable by hash even after the guard applies
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

## Sibling suites (existing CCR/compression tests re-run, all still green)

- `tests/unit/compression/ccr-marker-retrieve.test.ts` — 11/11
- `tests/unit/compression/ccr-mcp-principal-5649.test.ts` — 6/6
- `tests/unit/compression/ionizerEngine.test.ts` — 4/4
- Batch run (`ccr-mcp-integration.test.ts`, `ccr-cross-tenant.test.ts`, `ccr-retrieval-ramp.test.ts`, `retrieveRouteRanged.test.ts`, `mcp-extra-forward-6178.test.ts`, `ccrRanged.test.ts`, `ionizerSample.test.ts`) — 54/54

`fuzzyDedup.test.ts` / `sessionDedupFuzzy.test.ts` (which assert an exact bare-marker match) are unaffected — they exercise `applyFuzzyPass`/`sessionDedupEngine`, which build markers directly via `buildCcrMarker`/`tryStoreBlock`, not through the changed `maybeCcrReplace`/`processMessages` path.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/compression/ccr-non-mcp-full-prompt-loss-7746.test.ts` — RED→GREEN
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2076 violations, baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (903 violations, baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — OK, no drift
- `npx tsc --pretty false -p tsconfig.typecheck-core.json` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/compression/engines/ccr/index.ts tests/unit/compression/ccr-non-mcp-full-prompt-loss-7746.test.ts` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope

Diff is scoped to `open-sse/services/compression/engines/ccr/index.ts` (the surgical preamble-preservation guard), the new regression test, and the changelog fragment. No other compression engines touched.
