### PR TITLE
fix: document CREDENTIAL_REDACTION_ENABLED and GHE_COPILOT_OAUTH_CLIENT_ID env vars (#7793)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -358,6 +358,11 @@ ALLOW_API_KEY_REVEAL=false
 # Used by: src/middleware/promptInjectionGuard.ts — extends injection guard.
 # PII_REDACTION_ENABLED=false
 
+# Redacts well-known API-key / secret-token patterns (OpenAI, Anthropic, GitHub,
+# Slack, etc.) from request/response payloads before they reach providers/clients.
+# Opt-in; mirrors PII_REDACTION_ENABLED. Used by: src/lib/guardrails/credentialMasker.ts.
+# CREDENTIAL_REDACTION_ENABLED=false
+
 # Minimum streaming window size for PII detection (bytes). Default: 200.
 # Used by: src/lib/streamingPiiTransform.ts.
 # PII_WINDOW_SIZE=200
@@ -899,6 +904,11 @@ KIMI_CODING_OAUTH_CLIENT_ID=17e5f671-d194-4dfb-9706-5516cb48c098
 
 # ── GitHub Copilot ──
 GITHUB_OAUTH_CLIENT_ID=Iv1.b507a08c87ecfe98
+
+# ── GitHub Enterprise (GHE) Copilot ──
+# Optional override for GHE Copilot's OAuth client id. Falls back to the public
+# GITHUB_OAUTH_CLIENT_ID default when unset. Used by: src/lib/oauth/constants/oauth.ts.
+# GHE_COPILOT_OAUTH_CLIENT_ID=
 
 # ── GitLab Duo ──
 # Register an OAuth app at: https://gitlab.com/-/profile/applications

--- a/changelog.d/fixes/7793-env-doc-sync-redaction.md
+++ b/changelog.d/fixes/7793-env-doc-sync-redaction.md
@@ -1,0 +1,1 @@
+- fix(docs): document CREDENTIAL_REDACTION_ENABLED and GHE_COPILOT_OAUTH_CLIENT_ID in .env.example/ENVIRONMENT.md, closing the env-doc-sync gate drift (#7793)

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -220,6 +220,7 @@ OmniRoute provides a two-layer defense: request-side injection scanning and resp
 | `INPUT_SANITIZER_MODE`    | `warn`    | `src/middleware/promptInjectionGuard.ts` | `warn` = log only, `block` = reject request with 400, `redact` = strip suspicious patterns. |
 | `INJECTION_GUARD_MODE`    | _(unset)_ | `src/middleware/promptInjectionGuard.ts` | Legacy alias for `INPUT_SANITIZER_MODE` — same behavior.                                    |
 | `PII_REDACTION_ENABLED`   | `false`   | `src/middleware/promptInjectionGuard.ts` | Detect PII (emails, phones, SSNs) in incoming requests.                                     |
+| `CREDENTIAL_REDACTION_ENABLED` | `false` | `src/lib/guardrails/credentialMasker.ts` | Redact well-known API-key / secret-token patterns from request/response payloads. Opt-in; mirrors `PII_REDACTION_ENABLED`. |
 
 ### Response-Side: PII Sanitizer
 
@@ -475,6 +476,7 @@ Built-in credentials for **localhost development**. For remote deployments, regi
 | `ANTIGRAVITY_OAUTH_CLIENT_ID`     | Antigravity (Google)    | Requires matching `_SECRET`.                                                                                                                                                                                                                    |
 | `ANTIGRAVITY_OAUTH_CLIENT_SECRET` | Antigravity (Google)    | —                                                                                                                                                                                                                                               |
 | `GITHUB_OAUTH_CLIENT_ID`          | GitHub Copilot          | Public client.                                                                                                                                                                                                                                  |
+| `GHE_COPILOT_OAUTH_CLIENT_ID`     | GHE Copilot             | Optional override for GitHub Enterprise Copilot's OAuth client id. Falls back to `GITHUB_OAUTH_CLIENT_ID`'s public default when unset.                                                                                                          |
 | `WINDSURF_FIREBASE_API_KEY`       | Windsurf / Devin (v3.8) | Public Firebase Web API key used by Windsurf's Secure Token Service to refresh short-lived browser-flow tokens. Client-side credential (not a secret). Long-lived import tokens skip this entirely. Source: extracted from Devin CLI binary.    |
 | `WINDSURF_API_KEY`                | Windsurf / Devin (v3.8) | API key fallback used by `open-sse/executors/devin-cli.ts` when no per-connection credential is available. Optional.                                                                                                                            |
 | `CLI_DEVIN_BIN`                   | Devin CLI (v3.8)        | Custom path to the Devin CLI binary (`devin`). Resolved by `open-sse/executors/devin-cli.ts`.                                                                                                                                                   |

--- a/tests/unit/issue-7793-env-doc-sync-repro.test.ts
+++ b/tests/unit/issue-7793-env-doc-sync-repro.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runEnvDocSync } from "../../scripts/check/check-env-doc-sync.mjs";
+
+// Repro for issue #7793 ("Release branch not green: release/v3.8.49").
+test("issue #7793: real .env.example is in sync with process.env.* reads in code", () => {
+  const result = runEnvDocSync();
+
+  assert.deepEqual(
+    result.problems.codeMissingEnv,
+    [],
+    `Vars read via process.env.X in code but missing from .env.example: ${JSON.stringify(result.problems.codeMissingEnv)}`
+  );
+  assert.deepEqual(
+    result.problems.envMissingDoc,
+    [],
+    `Vars in .env.example but missing from ENVIRONMENT.md: ${JSON.stringify(result.problems.envMissingDoc)}`
+  );
+  assert.deepEqual(
+    result.problems.docMissingEnv,
+    [],
+    `Vars in ENVIRONMENT.md but missing from .env.example: ${JSON.stringify(result.problems.docMissingEnv)}`
+  );
+  assert.equal(result.ok, true);
+});


### PR DESCRIPTION
Closes #7793

## Root cause

`npm run check:env-doc-sync` was failing on the current `release/v3.8.49` tip:

```
$ node scripts/check/check-env-doc-sync.mjs
  ✗ In code but missing from .env.example: 2
     - CREDENTIAL_REDACTION_ENABLED
     - GHE_COPILOT_OAUTH_CLIENT_ID
```

Two already-merged PRs added new opt-in `process.env.X` reads without adding the corresponding
`.env.example` / `docs/reference/ENVIRONMENT.md` entries:

- `CREDENTIAL_REDACTION_ENABLED` — `src/lib/guardrails/credentialMasker.ts` (from #7683, the
  CredentialMaskerGuardrail PR). Opt-in guardrail flag, defaults to `false`.
- `GHE_COPILOT_OAUTH_CLIENT_ID` — `src/lib/oauth/constants/oauth.ts` (from #7546, the GHE
  Copilot OAuth provider PR). Optional client-id override that falls back to the existing public
  `GITHUB_OAUTH_CLIENT_ID` default — not itself a hardcoded credential.

Both are legitimate, intentional env vars — this was a pure documentation-sync gap, not a code
defect. (Note: an earlier root-cause candidate — README missing the "265 providers" count — was
already resolved on the branch before this PR; re-verified live and confirmed the env-doc-sync
gate above is the current hard failure per the bot's latest tracker comment.)

## Fix

Added commented-out `.env.example` entries (mirroring the style of neighboring
`PII_REDACTION_ENABLED` / `GITHUB_OAUTH_CLIENT_ID` entries) plus matching rows in
`docs/reference/ENVIRONMENT.md`. No production code changed.

## Regression test

`tests/unit/issue-7793-env-doc-sync-repro.test.ts` — reuses the checker's own `runEnvDocSync()`
API against the real repo files (no fixture overrides), exactly like CI does.

RED (before fix):
```
✖ issue #7793: real .env.example is in sync with process.env.* reads in code
  AssertionError [ERR_ASSERTION]: Vars read via process.env.X in code but missing from
  .env.example: ["CREDENTIAL_REDACTION_ENABLED","GHE_COPILOT_OAUTH_CLIENT_ID"]
ℹ tests 1 / pass 0 / fail 1
```

GREEN (after fix):
```
✔ issue #7793: real .env.example is in sync with process.env.* reads in code
ℹ tests 1 / pass 1 / fail 0
```

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/issue-7793-env-doc-sync-repro.test.ts` — pass
- `node --import tsx/esm --test tests/unit/check-env-doc-sync.test.ts` — 13/13 pass (existing
  sibling suite for the same checker, including the "repository contract is in sync (live data)"
  test — no assertions weakened)
- `node scripts/check/check-env-doc-sync.mjs` — in sync
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2076 violations vs baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (901 violations vs baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — no drift
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/issue-7793-env-doc-sync-repro.test.ts` — exit 0, no output
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope note

No `ci.yml` changes. Diff is limited to `.env.example`, `docs/reference/ENVIRONMENT.md`, the new
regression test, and the changelog fragment.
