### PR TITLE
fix: fix collapsed quota card session/weekly order (#7764)

### DIFF
--- a/changelog.d/fixes/7764-quota-card-order.md
+++ b/changelog.d/fixes/7764-quota-card-order.md
@@ -1,0 +1,1 @@
+- fix(dashboard): keep session/weekly quota rows in a stable fixed order on collapsed provider-quota cards, matching the already-fixed expanded view (#7764)

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx
@@ -17,6 +17,7 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
 
 interface Props {
   quotas: any[];
+  providerId?: string;
   /** When > MAX_VISIBLE, render "+N more" hint. */
   maxVisible?: number;
   loading: boolean;
@@ -82,6 +83,7 @@ function QuotaRow({ q }: { q: any }) {
 
 export default function QuotaCardBody({
   quotas,
+  providerId,
   maxVisible = MAX_VISIBLE_DEFAULT,
   loading,
   error,
@@ -121,7 +123,7 @@ export default function QuotaCardBody({
     return <div className="px-3 py-3 text-[11px] text-text-muted italic">{t("noQuotaData")}</div>;
   }
 
-  const visible = topQuotas(quotas, maxVisible);
+  const visible = topQuotas(quotas, maxVisible, providerId);
   const hidden = Math.max(0, quotas.length - visible.length);
 
   return (

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
@@ -1,4 +1,5 @@
 export { parseQuotaData } from "./quotaParsing";
+import { hasFixedQuotaOrder } from "./quotaParsing";
 
 const PROVIDER_PLAN_FALLBACKS = new Set([
   "claude code",
@@ -344,8 +345,18 @@ const STATUS_ORDER: Record<"critical" | "alert" | "ok", number> = {
   ok: 2,
 };
 
-export function topQuotas(quotas: any[], n = 3): any[] {
-  return [...quotas.filter(Boolean)]
+export function topQuotas(quotas: any[], n = 3, providerId?: string): any[] {
+  const filtered = quotas.filter(Boolean);
+
+  // Providers with a deterministic fixed-window order (codex, glm family — see
+  // quotaParsing.ts's sortCodexOrder()/sortGlmOrder()) must keep the order
+  // parseQuotaData() already established rather than being re-sorted by
+  // status/remaining-%, which would undo it (#6687's collapsed-card sibling, #7764).
+  if (hasFixedQuotaOrder(providerId)) {
+    return filtered.slice(0, n);
+  }
+
+  return [...filtered]
     .sort((a, b) => {
       const sa = STATUS_ORDER[quotaStatus(a)];
       const sb = STATUS_ORDER[quotaStatus(b)];

--- a/tests/unit/repro-7764-collapsed-quota-order.test.ts
+++ b/tests/unit/repro-7764-collapsed-quota-order.test.ts
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { topQuotas } from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils";
+import {
+  parseQuotaData,
+  hasFixedQuotaOrder,
+} from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing";
+
+test("#7764 sanity: codex has a fixed quota order (session, weekly)", () => {
+  assert.equal(hasFixedQuotaOrder("codex"), true);
+});
+
+test("#7764: topQuotas() (collapsed card order) respects hasFixedQuotaOrder instead of re-sorting by remaining %", () => {
+  const rawA = {
+    quotas: {
+      session: { used: 91, total: 100, remainingPercentage: 91, resetAt: null },
+      weekly: { used: 97, total: 100, remainingPercentage: 3, resetAt: null },
+    },
+  };
+  const rawB = {
+    quotas: {
+      session: { used: 99, total: 100, remainingPercentage: 1, resetAt: null },
+      weekly: { used: 43, total: 100, remainingPercentage: 57, resetAt: null },
+    },
+  };
+  const parsedA = parseQuotaData("codex", rawA);
+  const parsedB = parseQuotaData("codex", rawB);
+  assert.deepEqual(
+    parsedA.map((q: any) => q.name),
+    ["session", "weekly"]
+  );
+  assert.deepEqual(
+    parsedB.map((q: any) => q.name),
+    ["session", "weekly"]
+  );
+  const renderedA = topQuotas(parsedA, 3, "codex").map((q: any) => q.name);
+  const renderedB = topQuotas(parsedB, 3, "codex").map((q: any) => q.name);
+  assert.deepEqual(renderedA, ["session", "weekly"]);
+  assert.deepEqual(renderedB, ["session", "weekly"]);
+});
+
+test("#7764: providers WITHOUT a fixed order still sort worst-status-first (no regression)", () => {
+  const quotas = [
+    { name: "alpha", used: 10, total: 100, remainingPercentage: 90 },
+    { name: "beta", used: 95, total: 100, remainingPercentage: 5 },
+    { name: "gamma", used: 50, total: 100, remainingPercentage: 50 },
+  ];
+  const rendered = topQuotas(quotas, 3, "some-other-provider").map((q: any) => q.name);
+  assert.deepEqual(rendered, ["beta", "gamma", "alpha"]);
+});


### PR DESCRIPTION
Refs #7764

## Root cause

In the provider quota grid, the **collapsed** card view (`QuotaCardBody.tsx`) orders rows via `topQuotas()` in `utils.tsx`, which sorts purely by status (critical → alert → ok) then remaining percentage ascending. It never consulted `hasFixedQuotaOrder()` / `CODEX_QUOTA_ORDER` / `GLM_QUOTA_ORDER` from `quotaParsing.ts`, so Session and Weekly swap position per card depending on which one has less headroom.

This is the same defect class as #6687 / PR #6722 — but that fix only patched the **expanded** card path (`QuotaCardExpanded.tsx`'s `resolveQuotaDisplayOrder()`). The collapsed grid never received the same fix, so the bug survived in that sibling rendering path.

## Fix

- `utils.tsx`: `topQuotas(quotas, n, providerId?)` now checks `hasFixedQuotaOrder(providerId)` (imported from `quotaParsing.ts`) and, when true, skips the status/remaining-% sort entirely — keeping the order `parseQuotaData()` already established (`sortCodexOrder()` / `sortGlmOrder()`) — and only truncates to `n`. Mirrors `resolveQuotaDisplayOrder()` in `QuotaCardExpanded.tsx`.
- `QuotaCardBody.tsx`: threaded an optional `providerId` prop through to the `topQuotas(...)` call site.
- Providers without a fixed order (i.e. `hasFixedQuotaOrder()` is false) are unaffected — they still sort worst-status-first, exactly as before.

## Regression test

`tests/unit/repro-7764-collapsed-quota-order.test.ts` — reused verbatim from the `/triage-fix-bugs` repro probe:

- RED on unfixed code: two synthetic Codex cards with inverted remaining percentages both rendered `weekly` before `session`.
- GREEN after the fix: both cards render `session` before `weekly` regardless of remaining %.
- Additional test: providers **without** a fixed order still sort worst-status-first (no regression to the intentional "critical quotas first" UX).

Verified existing sibling tests that exercise `topQuotas()` / `utils.tsx` / quota parsing (`tests/unit/quota-helpers.test.ts`, `tests/unit/copilot-usage.test.ts`, `tests/unit/provider-limits-provider-filter.test.ts`, `tests/unit/t13-stale-quota-display.test.ts`, `tests/unit/provider-limits-ui.test.ts`, `tests/unit/provider-columns.test.ts`, `tests/unit/codex-plan-label-2570.test.ts`, `tests/unit/quota-parsing-claude-extra-usage.test.ts`, `tests/unit/agy-usage-quota.test.ts`) still pass unchanged — the new optional `providerId` param is backward compatible.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/repro-7764-collapsed-quota-order.test.ts` — RED then GREEN
- Sibling suites above (all pass)
- `node scripts/check/check-file-size.mjs` — no violations on touched files
- `node scripts/check/check-complexity.mjs` — OK (2076 violations vs baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (901 violations vs baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — no drift
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope

Diff is strictly scoped to the ordering logic (`topQuotas()` + threading `providerId` through `QuotaCardBody`) and its regression test — no drive-by refactors.



---

## ⚠️ Scope correction (post-implementation audit)

This PR does **not** fix the user-visible symptom in #7764, so it uses `Refs`, not `Closes`.

Audit findings:
1. `QuotaCardBody.tsx` — the only caller of `topQuotas()` — is **not in the render tree**. `QuotaCard.tsx` renders `QuotaCardExpanded` exclusively, which handles both the collapsed and expanded states internally via `getVisibleQuotas(sortedQuotas, expanded)`.
2. The live path already respects fixed ordering: `QuotaCardExpanded` calls `resolveQuotaDisplayOrder(providerId, quotas)` (added by #6722).
3. The actual root cause of #7764 is narrower than the plan assumed: `hasFixedQuotaOrder()` returns true only for `codex` and the GLM family. Every other provider falls through to `sortQuotasByRemaining()`, so session/weekly rows reorder per card by remaining-% — which is exactly the inconsistency the reporter screenshotted.

What lands here is defensive hardening plus a regression test: if `QuotaCardBody` is ever wired into the render tree, it will already honor fixed ordering. **#7764 stays open** pending a real fix in the live path (give session/weekly a stable relative order for all providers, or widen `hasFixedQuotaOrder`).
