### PR TITLE
fix(dashboard): mirror connection-row action-icon spacing under RTL (#7680)

### DIFF
--- a/changelog.d/fixes/7680-rtl-physical-utilities.md
+++ b/changelog.d/fixes/7680-rtl-physical-utilities.md
@@ -1,0 +1,1 @@
+- fix(dashboard): mirror connection-row action-icon spacing under RTL via Tailwind logical utility (#7680)

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx
@@ -883,7 +883,7 @@ export default function ConnectionRow({
           onChange={onToggleActive}
           title={(connection.isActive ?? true) ? t("disableConnection") : t("enableConnection")}
         />
-        <div className="flex gap-1 ml-1 transition-opacity">
+        <div className="flex gap-1 ms-1 transition-opacity">
           {onReauth && (
             <button
               onClick={onReauth}

--- a/tests/unit/connection-row-rtl-margin.test.ts
+++ b/tests/unit/connection-row-rtl-margin.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// Repro for issue #7680 — RTL layout compatibility.
+//
+// OmniRoute sets <html dir="rtl"> for ar/fa/he/ur locales (src/app/layout.tsx:61,
+// config/i18n.json "rtl": ["ar","fa","he","ur"]) but src/app/globals.css has zero
+// logical-property / RTL-mirroring rules, while dashboard components use Tailwind's
+// *physical* spacing utilities (ml-/mr-/pl-/pr-/left-/right-/border-l-/border-r-).
+// Tailwind v4 (this project: package.json "tailwindcss": "^4.3.0") always compiles
+// `ml-1` to the physical `margin-left` declaration — it is NOT dir-aware and will
+// NOT mirror under dir="rtl". Only the *logical* utilities (ms-/me-/ps-/pe-/start-/
+// end-) compile to CSS logical properties (margin-inline-start, etc.) that the
+// browser mirrors automatically based on the element's direction.
+//
+// This is the exact row from the reporter's screenshot: the action-icon cluster
+// (edit / proxy / delete / retest buttons) next to the connection Toggle in the
+// provider connection list. Under dir="rtl" the physical `ml-1` margin lands on
+// the wrong side of the flipped flex row, crowding the icon group against the
+// Toggle instead of spacing it away — visually reproducing the screenshot.
+const rowFile = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "app",
+  "(dashboard)",
+  "dashboard",
+  "providers",
+  "[id]",
+  "components",
+  "ConnectionRow.tsx"
+);
+
+test("ConnectionRow action-icon wrapper must use an RTL-mirroring (logical) spacing utility, not a physical one", () => {
+  const source = readFileSync(rowFile, "utf8");
+
+  const match = source.match(
+    /<div className="flex gap-1 ([^"]*)transition-opacity">/
+  );
+  assert.ok(match, "expected to find the action-icon wrapper div in ConnectionRow.tsx");
+
+  const spacingClasses = match![1];
+
+  const physicalUtilityRe = /\b(ml-|mr-|pl-|pr-|left-|right-|border-l-|border-r-)\S/;
+  assert.ok(
+    !physicalUtilityRe.test(spacingClasses),
+    `action-icon wrapper still uses a physical (non-mirroring) spacing utility: "${spacingClasses}". ` +
+      `Under dir="rtl" this class computes the same physical CSS property regardless of direction, so the ` +
+      `spacing lands on the wrong side once the flex row visually mirrors — reproducing issue #7680. ` +
+      `Use the logical equivalent (e.g. ms-1/me-1) instead.`
+  );
+});


### PR DESCRIPTION
Refs #7680

## Root cause

`src/app/layout.tsx:61` correctly wires `<html dir={isRtl ? "rtl" : "ltr"} ...>` for the RTL locales in `config/i18n.json` (`ar`, `fa`, `he`, `ur`), but `src/app/globals.css` has zero compensating logical-property/RTL rules. Meanwhile ~150 files under `src/app/(dashboard)` use Tailwind v4's *physical* spacing/position utilities (`ml-`, `mr-`, `pl-`, `pr-`, `left-`, `right-`, `border-l-`, `border-r-`), which always compile to physical CSS properties that never mirror under `dir="rtl"`. Only Tailwind's *logical* utilities (`ms-`/`me-`/`ps-`/`pe-`/`start-`/`end-`, compiling to `margin-inline-start` etc.) auto-mirror via the browser's native direction handling.

## This PR

Fixes the concrete, screenshot-traced instance: `src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx:884` — the action-icon cluster (edit/proxy/delete/retest) next to the connection `Toggle` was wrapped in `<div className="flex gap-1 ml-1 transition-opacity">`. Under `dir="rtl"` the flex row mirrors visually but `ml-1` still computes physical `margin-left`, crowding the icon group against the toggle instead of spacing it away — exactly the layout shown in the reporter's screenshot.

Changed `ml-1` → `ms-1` (Tailwind's logical, dir-aware equivalent). No `globals.css` changes needed — logical utilities mirror automatically via the browser's native `dir` handling.

Per the owner's in-thread guidance, this is a **phased conversion** — the full ~150-file physical-utility sweep across the dashboard is tracked in #7680 and will land in further follow-up PRs, converted component-family by component-family. This PR lands the first proven instance plus its permanent regression guard, per Hard Rule #18 (TDD).

## Regression test

`tests/unit/connection-row-rtl-margin.test.ts` — asserts the `ConnectionRow.tsx` action-icon wrapper `className` does not contain a physical spacing/position utility.

RED (before fix, against the unmodified source):
```
✖ ConnectionRow action-icon wrapper must use an RTL-mirroring (logical) spacing utility, not a physical one
  AssertionError: action-icon wrapper still uses a physical (non-mirroring) spacing utility: "ml-1 ".
ℹ tests 1
ℹ pass 0
ℹ fail 1
```

GREEN (after `ml-1` → `ms-1`):
```
✔ ConnectionRow action-icon wrapper must use an RTL-mirroring (logical) spacing utility, not a physical one
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/connection-row-rtl-margin.test.ts` (RED → GREEN, above)
- `node --import tsx/esm --test tests/unit/provider-connections-ui-regression.test.ts` — 3/3 pass (sibling ConnectionRow-adjacent suite)
- `npx vitest run tests/unit/ui/connection-row-token-badge-5836.test.tsx tests/unit/ui/confirm-delete-connection-7361.test.tsx tests/unit/ui/connection-row-proxy-name-7643.test.tsx` — 8/8 pass (existing ConnectionRow UI suites, unaffected by the class rename)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2076 violations vs baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (901 violations vs baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — OK, no drift
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Notes

Used `Refs #7680` rather than `Closes #7680` since this is the first phased step of a larger, explicitly staged conversion (the plan's own scope note: "implement-fix-bugs should treat this as a phased conversion rather than one PR").
