### PR TITLE
fix(compression): enable OmniGlyph for Claude Fable 5

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1395,10 +1395,13 @@ export async function handleChatCore({
           // models, which is intentionally NOT `false` so the gate still preserves images.
           supportsVision: getResolvedModelCapabilities({ provider, model: effectiveModel })
             .supportsVision,
-          // Rota direta oficial ('anthropic') vs agregadores: o engine omniglyph
-          // exige 'direct' — agregadores redimensionam imagens (medido 2026-07-06).
+          // Rotas diretas oficiais ('anthropic' API key e 'claude' OAuth) vs agregadores:
+          // o engine omniglyph exige 'direct' — agregadores redimensionam imagens
+          // (medido 2026-07-06). OAuth 'claude' é rota direta oficial (#7863).
           providerTransport:
-            provider === "anthropic" ? ("direct" as const) : ("aggregator" as const),
+            provider === "anthropic" || provider === "claude"
+              ? ("direct" as const)
+              : ("aggregator" as const),
           config: compressionConfig,
           cachingContext: cacheCtx,
           principalId: compressionPrincipalId,

--- a/src/shared/constants/visionModels.ts
+++ b/src/shared/constants/visionModels.ts
@@ -47,6 +47,7 @@ export const VISION_MODEL_ID_FRAGMENTS = [
   "gemini-3",
   "gemini-exp",
   "claude-3",
+  "claude-fable",
   "claude-opus-4",
   "claude-sonnet-4",
   "claude-haiku-4",

--- a/tests/unit/compression/omniglyph-chatcore-plumbing.test.ts
+++ b/tests/unit/compression/omniglyph-chatcore-plumbing.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("chatCore treats both Anthropic providers as direct OmniGlyph transports", () => {
+  const chatCore = readFileSync("open-sse/handlers/chatCore.ts", "utf8");
+
+  assert.match(
+    chatCore,
+    /providerTransport:\s*provider === "anthropic" \|\| provider === "claude"[\s\S]{0,80}?"direct"/
+  );
+});

--- a/tests/unit/vision-detection-consistency.test.ts
+++ b/tests/unit/vision-detection-consistency.test.ts
@@ -27,6 +27,7 @@ const VISION = [
   "llava-1.5-7b",
   "qwen-vl-max",
   "gpt-4o",
+  "claude-fable-5",
   "glm-4v",
   "kimi-vl-a3b",
   "mistral-medium-3",
@@ -38,9 +39,7 @@ function imageBody() {
     messages: [
       {
         role: "user",
-        content: [
-          { type: "image_url", image_url: { url: "data:image/png;base64,iVBOR" } },
-        ],
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,iVBOR" } }],
       },
     ],
   };


### PR DESCRIPTION
﻿## Summary
- classify the `claude` OAuth provider as a direct Anthropic transport for OmniGlyph
- recognize Claude Fable model IDs as vision-capable in the shared heuristic
- add focused regression coverage for both integration points

## Why
OmniGlyph requires both direct transport and vision support. `claude/claude-fable-5` was incorrectly treated as an aggregator and was absent from the shared vision heuristic, so compression was selected but skipped before transforming context.

## Verification
- `npx tsx --test tests/unit/vision-detection-consistency.test.ts tests/unit/compression/omniglyph-chatcore-plumbing.test.ts` (14 passed)
- `npx eslint open-sse/handlers/chatCore.ts src/shared/constants/visionModels.ts tests/unit/vision-detection-consistency.test.ts tests/unit/compression/omniglyph-chatcore-plumbing.test.ts --no-cache`
- repository pre-commit checks passed
