### PR TITLE
fix(mitm): gate Agent Bridge Repair on sudo password (#7836)

### DIFF
--- a/src/app/(dashboard)/dashboard/tools/agent-bridge/AgentBridgePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/tools/agent-bridge/AgentBridgePageClient.tsx
@@ -43,6 +43,12 @@ export interface AgentBridgeServerState {
   dnsConfigured: boolean;
   /** A crash/SIGKILL left system state behind — surfaces the repair banner. */
   orphanedStateDetected: boolean;
+  /** Session-cached sudo password from a prior MITM privileged action. */
+  hasCachedPassword?: boolean;
+  /** Server OS requires a sudo password and none is cached (#7836). */
+  needsSudoPassword?: boolean;
+  /** Whether the OmniRoute server is running on Windows. */
+  isWin?: boolean;
 }
 
 export type AgentMappingsMap = Record<string, MappingRow[]>;
@@ -261,6 +267,9 @@ export default function AgentBridgePageClient({
           <AgentBridgeMaintenanceCard
             orphanedStateDetected={data.serverState.orphanedStateDetected}
             certTrusted={data.serverState.certTrusted}
+            hasCachedPassword={data.serverState.hasCachedPassword === true}
+            needsSudoPassword={data.serverState.needsSudoPassword === true}
+            isWin={data.serverState.isWin === true}
             onError={setActionError}
             onRefresh={refresh}
           />

--- a/src/app/(dashboard)/dashboard/tools/agent-bridge/components/AgentBridgeMaintenanceCard.tsx
+++ b/src/app/(dashboard)/dashboard/tools/agent-bridge/components/AgentBridgeMaintenanceCard.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
+import { Button, Input, Modal } from "@/shared/components";
 import {
   runDiagnose,
   removeCaCert,
@@ -17,6 +18,12 @@ interface AgentBridgeMaintenanceCardProps {
   orphanedStateDetected: boolean;
   /** Whether the MITM root CA is currently trusted (gates the Remove-CA button). */
   certTrusted: boolean;
+  /** Session-cached sudo password from a prior MITM privileged action. */
+  hasCachedPassword: boolean;
+  /** Server OS requires a sudo password and none is cached. */
+  needsSudoPassword: boolean;
+  /** Whether the OmniRoute server is running on Windows. */
+  isWin: boolean;
   /** Report a sanitized error to the page-level alert banner. */
   onError: (msg: string | null) => void;
   /** Re-fetch page state after an action that mutates system state. */
@@ -41,15 +48,27 @@ function downloadJson(data: unknown, filename: string): void {
 export function AgentBridgeMaintenanceCard({
   orphanedStateDetected,
   certTrusted,
+  hasCachedPassword,
+  needsSudoPassword,
+  isWin,
   onError,
   onRefresh,
 }: AgentBridgeMaintenanceCardProps) {
   const t = useTranslations("agentBridge");
+  const tCli = useTranslations("cliTools");
   const [busy, setBusy] = useState<string | null>(null);
   const [report, setReport] = useState<DiagnoseResult | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [confirmRemoveCa, setConfirmRemoveCa] = useState(false);
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [pendingPrivilegedAction, setPendingPrivilegedAction] = useState<
+    "repair" | "remove-ca" | null
+  >(null);
+  const [sudoPassword, setSudoPassword] = useState("");
+  const [passwordModalError, setPasswordModalError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const canRunWithoutPassword = isWin || hasCachedPassword || !needsSudoPassword;
 
   const run = async (action: string, fn: () => Promise<void>) => {
     setBusy(action);
@@ -69,24 +88,70 @@ export function AgentBridgeMaintenanceCard({
       setReport(await runDiagnose());
     });
 
-  const handleRepair = () =>
-    run("repair", async () => {
-      const { repaired } = await repairMitmState();
-      setNotice(
-        repaired.length === 0
-          ? t("repairNothing") || "Nothing to repair — system state is clean."
-          : (t("repairDone") || "Repaired: {items}").replace("{items}", repaired.join(", "))
-      );
-      await onRefresh();
-    });
+  const handleRepair = async (password = "") => {
+    const { repaired } = await repairMitmState(password || undefined);
+    setNotice(
+      repaired.length === 0
+        ? t("repairNothing") || "Nothing to repair — system state is clean."
+        : (t("repairDone") || "Repaired: {items}").replace("{items}", repaired.join(", "))
+    );
+    await onRefresh();
+  };
 
-  const handleRemoveCa = () =>
-    run("remove-ca", async () => {
-      await removeCaCert();
-      setConfirmRemoveCa(false);
-      setNotice(t("removeCaDone") || "MITM root CA removed from the OS trust store.");
-      await onRefresh();
-    });
+  const handleRemoveCa = async (password = "") => {
+    await removeCaCert(password || undefined);
+    setConfirmRemoveCa(false);
+    setNotice(t("removeCaDone") || "MITM root CA removed from the OS trust store.");
+    await onRefresh();
+  };
+
+  const runPrivilegedAction = async (
+    action: "repair" | "remove-ca",
+    password = ""
+  ) => {
+    if (action === "repair") {
+      await run("repair", () => handleRepair(password));
+      return;
+    }
+    await run("remove-ca", () => handleRemoveCa(password));
+  };
+
+  const requestPrivilegedAction = (action: "repair" | "remove-ca") => {
+    if (canRunWithoutPassword) {
+      void runPrivilegedAction(action);
+      return;
+    }
+    setPendingPrivilegedAction(action);
+    setPasswordModalError(null);
+    setSudoPassword("");
+    setShowPasswordModal(true);
+  };
+
+  const handleConfirmPassword = () => {
+    if (!sudoPassword.trim()) {
+      setPasswordModalError(tCli("sudoPasswordRequiredError"));
+      return;
+    }
+    const action = pendingPrivilegedAction;
+    if (!action) return;
+    setShowPasswordModal(false);
+    setPendingPrivilegedAction(null);
+    const password = sudoPassword;
+    setSudoPassword("");
+    setPasswordModalError(null);
+    void runPrivilegedAction(action, password);
+  };
+
+  const onRepairClick = () => requestPrivilegedAction("repair");
+
+  const onRemoveCaClick = () => requestPrivilegedAction("remove-ca");
+
+  const closePasswordModal = () => {
+    setShowPasswordModal(false);
+    setPendingPrivilegedAction(null);
+    setSudoPassword("");
+    setPasswordModalError(null);
+  };
 
   const handleExport = () =>
     run("export", async () => {
@@ -117,6 +182,7 @@ export function AgentBridgeMaintenanceCard({
   };
 
   return (
+    <>
     <div className="rounded-xl border border-border/60 bg-card overflow-hidden">
       <div className="flex items-center gap-3 px-5 py-4">
         <div className="p-2 rounded-lg bg-primary/10">
@@ -158,7 +224,7 @@ export function AgentBridgeMaintenanceCard({
 
         <button
           type="button"
-          onClick={handleRepair}
+          onClick={onRepairClick}
           disabled={busy !== null}
           className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${
             orphanedStateDetected
@@ -176,7 +242,7 @@ export function AgentBridgeMaintenanceCard({
               <span className="text-red-600 dark:text-red-400">{t("removeCaConfirm") || "Remove CA?"}</span>
               <button
                 type="button"
-                onClick={handleRemoveCa}
+                onClick={onRemoveCaClick}
                 disabled={busy !== null}
                 className="rounded bg-red-500/15 text-red-600 px-2 py-0.5 font-medium hover:bg-red-500/25 disabled:opacity-50"
               >
@@ -278,5 +344,51 @@ export function AgentBridgeMaintenanceCard({
         </div>
       )}
     </div>
+
+      <Modal
+        isOpen={showPasswordModal}
+        onClose={closePasswordModal}
+        title={tCli("sudoPasswordRequiredTitle")}
+        size="sm"
+      >
+        <div className="flex flex-col gap-4">
+          <div className="flex items-start gap-3 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3">
+            <span className="material-symbols-outlined text-[20px] text-yellow-500">warning</span>
+            <p className="text-xs text-text-muted">{tCli("sudoPasswordHint")}</p>
+          </div>
+
+          <Input
+            type="password"
+            placeholder={tCli("enterSudoPassword")}
+            value={sudoPassword}
+            onChange={(event) => setSudoPassword(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && busy === null) handleConfirmPassword();
+            }}
+          />
+
+          {passwordModalError && (
+            <div className="flex items-center gap-2 rounded bg-red-500/10 px-2 py-1.5 text-xs text-red-600">
+              <span className="material-symbols-outlined text-[14px]">error</span>
+              <span>{passwordModalError}</span>
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={closePasswordModal}
+              disabled={busy !== null}
+            >
+              {tCli("cancel")}
+            </Button>
+            <Button size="sm" onClick={handleConfirmPassword} disabled={busy !== null}>
+              {tCli("confirm")}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/app/(dashboard)/dashboard/tools/agent-bridge/normalizeState.ts
+++ b/src/app/(dashboard)/dashboard/tools/agent-bridge/normalizeState.ts
@@ -71,6 +71,15 @@ export function normalizeAgentBridgeState(raw: unknown): AgentBridgePageData {
     if (typeof source.orphanedStateDetected === "boolean") {
       serverState.orphanedStateDetected = source.orphanedStateDetected;
     }
+    if (typeof source.hasCachedPassword === "boolean") {
+      serverState.hasCachedPassword = source.hasCachedPassword;
+    }
+    if (typeof source.needsSudoPassword === "boolean") {
+      serverState.needsSudoPassword = source.needsSudoPassword;
+    }
+    if (typeof source.isWin === "boolean") {
+      serverState.isWin = source.isWin;
+    }
   }
 
   return {

--- a/src/app/api/tools/agent-bridge/cert/route.ts
+++ b/src/app/api/tools/agent-bridge/cert/route.ts
@@ -6,7 +6,12 @@
 import { z } from "zod";
 import { installCertResult, uninstallCert, checkCertInstalled } from "@/mitm/cert/install";
 import { resolveMitmDataDir } from "@/mitm/dataDir";
-import { getCachedPassword } from "@/mitm/manager";
+import { getCachedPassword, setCachedPassword } from "@/mitm/manager";
+import {
+  isMitmSudoPasswordRequired,
+  normalizeMitmSudoPasswordInput,
+  resolveMitmSudoPassword,
+} from "@/mitm/sudoGate";
 import path from "path";
 import fs from "fs";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
@@ -83,8 +88,14 @@ export async function POST(request: Request): Promise<Response> {
 export async function DELETE(request: Request): Promise<Response> {
   const raw = await request.json().catch(() => ({}));
   const parsed = CertTrustBodySchema.safeParse(raw);
-  const sudoPassword =
-    (parsed.success ? parsed.data.sudoPassword : undefined) ?? getCachedPassword() ?? "";
+  const sudoPassword = resolveMitmSudoPassword(
+    parsed.success ? parsed.data.sudoPassword : undefined,
+    getCachedPassword()
+  );
+
+  if (isMitmSudoPasswordRequired(sudoPassword)) {
+    return createErrorResponse({ status: 400, message: "Missing sudoPassword" });
+  }
 
   try {
     const crtPath = certPath();
@@ -93,6 +104,12 @@ export async function DELETE(request: Request): Promise<Response> {
       return Response.json({ ok: true, trusted: false });
     }
     await uninstallCert(sudoPassword, crtPath);
+    const suppliedPassword = parsed.success
+      ? normalizeMitmSudoPasswordInput(parsed.data.sudoPassword)
+      : "";
+    if (process.platform !== "win32" && suppliedPassword) {
+      setCachedPassword(suppliedPassword);
+    }
     const trusted = await checkCertInstalled(crtPath);
     return Response.json({ ok: true, trusted });
   } catch (err) {

--- a/src/app/api/tools/agent-bridge/repair/route.ts
+++ b/src/app/api/tools/agent-bridge/repair/route.ts
@@ -9,7 +9,12 @@
  * Gap 7 — the application-layer analogue of ProxyBridge's `--cleanup` flag.
  */
 import { z } from "zod";
-import { repairMitm, getCachedPassword } from "@/mitm/manager";
+import { repairMitm, getCachedPassword, setCachedPassword } from "@/mitm/manager";
+import {
+  isMitmSudoPasswordRequired,
+  normalizeMitmSudoPasswordInput,
+  resolveMitmSudoPassword,
+} from "@/mitm/sudoGate";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 
@@ -22,11 +27,23 @@ export const RepairBodySchema = z.object({
 export async function POST(request: Request): Promise<Response> {
   const raw = await request.json().catch(() => ({}));
   const parsed = RepairBodySchema.safeParse(raw);
-  const sudoPassword =
-    (parsed.success ? parsed.data.sudoPassword : undefined) ?? getCachedPassword() ?? "";
+  const sudoPassword = resolveMitmSudoPassword(
+    parsed.success ? parsed.data.sudoPassword : undefined,
+    getCachedPassword()
+  );
+
+  if (isMitmSudoPasswordRequired(sudoPassword)) {
+    return createErrorResponse({ status: 400, message: "Missing sudoPassword" });
+  }
 
   try {
     const result = await repairMitm(sudoPassword);
+    const suppliedPassword = parsed.success
+      ? normalizeMitmSudoPasswordInput(parsed.data.sudoPassword)
+      : "";
+    if (process.platform !== "win32" && suppliedPassword) {
+      setCachedPassword(suppliedPassword);
+    }
     return Response.json({ ok: true, repaired: result.repaired });
   } catch (err) {
     const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));

--- a/src/app/api/tools/agent-bridge/state/route.ts
+++ b/src/app/api/tools/agent-bridge/state/route.ts
@@ -3,14 +3,21 @@
  * Returns global MITM server status + per-agent detection/status.
  * LOCAL_ONLY: registered in routeGuard.ts
  */
-import { getMitmStatus, getAllAgentsStatus } from "@/mitm/manager";
+import { getMitmStatus, getAllAgentsStatus, getCachedPassword } from "@/mitm/manager";
+import { isSudoPasswordRequired } from "@/mitm/dns/dnsConfig";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 
 export async function GET(): Promise<Response> {
   try {
     const [server, agents] = await Promise.all([getMitmStatus(), getAllAgentsStatus()]);
-    return Response.json({ server, agents });
+    const isWin = process.platform === "win32";
+    const hasCachedPassword = !!getCachedPassword();
+    const needsSudoPassword = !isWin && !hasCachedPassword && isSudoPasswordRequired();
+    return Response.json({
+      server: { ...server, hasCachedPassword, needsSudoPassword, isWin },
+      agents,
+    });
   } catch (err) {
     const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
     return createErrorResponse({ status: 500, message: msg });

--- a/src/lib/inspector/agentBridgeMaintenanceApi.ts
+++ b/src/lib/inspector/agentBridgeMaintenanceApi.ts
@@ -38,20 +38,20 @@ export function runDiagnose(): Promise<DiagnoseResult> {
 }
 
 /** Untrust + remove the MITM root CA from the OS store (explicit, idempotent). */
-export function removeCaCert(): Promise<{ trusted: boolean }> {
+export function removeCaCert(sudoPassword?: string): Promise<{ trusted: boolean }> {
   return requestJson<{ ok: boolean; trusted: boolean }>("/api/tools/agent-bridge/cert", {
     method: "DELETE",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({}),
+    body: JSON.stringify(sudoPassword ? { sudoPassword } : {}),
   });
 }
 
 /** Undo orphaned system state (DNS spoof, root CA, system proxy) after a crash. */
-export function repairMitmState(): Promise<{ repaired: string[] }> {
+export function repairMitmState(sudoPassword?: string): Promise<{ repaired: string[] }> {
   return requestJson<{ ok: boolean; repaired: string[] }>("/api/tools/agent-bridge/repair", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({}),
+    body: JSON.stringify(sudoPassword ? { sudoPassword } : {}),
   });
 }
 

--- a/src/mitm/sudoGate.ts
+++ b/src/mitm/sudoGate.ts
@@ -1,0 +1,30 @@
+import { isSudoPasswordRequired } from "./dns/dnsConfig.ts";
+import { isRoot } from "./systemCommands.ts";
+
+/** Trim and treat whitespace-only sudo passwords as missing (#7865 review). */
+export function normalizeMitmSudoPasswordInput(value?: string | null): string {
+  return value?.trim() ?? "";
+}
+
+/** Resolve the sudo password from the request body and in-process cache. */
+export function resolveMitmSudoPassword(
+  bodyPassword?: string,
+  cachedPassword?: string | null
+): string {
+  const body = normalizeMitmSudoPasswordInput(bodyPassword);
+  if (body) return body;
+  return normalizeMitmSudoPasswordInput(cachedPassword);
+}
+
+/**
+ * Whether a privileged MITM operation must reject because no sudo password is
+ * available. Mirrors the gate in `/api/cli-tools/antigravity-mitm` (#822) and
+ * `/api/settings/mitm` — skip on Windows, root, NOPASSWD sudoers, and hosts
+ * without sudo on PATH.
+ */
+export function isMitmSudoPasswordRequired(sudoPassword: string): boolean {
+  if (process.platform === "win32") return false;
+  if (isRoot()) return false;
+  if (normalizeMitmSudoPasswordInput(sudoPassword)) return false;
+  return isSudoPasswordRequired();
+}

--- a/tests/unit/agent-bridge-maintenance-api.test.ts
+++ b/tests/unit/agent-bridge-maintenance-api.test.ts
@@ -72,6 +72,27 @@ test("repairMitmState POSTs /repair and returns the repaired list", async () => 
     assert.deepEqual(result.repaired, ["dns", "system-proxy"]);
     assert.equal(f.calls[0].url, "/api/tools/agent-bridge/repair");
     assert.equal(f.calls[0].init?.method, "POST");
+    assert.equal(f.calls[0].init?.body, JSON.stringify({}));
+  } finally {
+    f.restore();
+  }
+});
+
+test("repairMitmState forwards sudoPassword in the POST body", async () => {
+  const f = stubFetch(() => ({ ok: true, body: { ok: true, repaired: ["dns"] } }));
+  try {
+    await repairMitmState("hunter2");
+    assert.equal(f.calls[0].init?.body, JSON.stringify({ sudoPassword: "hunter2" }));
+  } finally {
+    f.restore();
+  }
+});
+
+test("removeCaCert forwards sudoPassword in the DELETE body", async () => {
+  const f = stubFetch(() => ({ ok: true, body: { ok: true, trusted: false } }));
+  try {
+    await removeCaCert("hunter2");
+    assert.equal(f.calls[0].init?.body, JSON.stringify({ sudoPassword: "hunter2" }));
   } finally {
     f.restore();
   }

--- a/tests/unit/agent-bridge-repair-route-validation.test.ts
+++ b/tests/unit/agent-bridge-repair-route-validation.test.ts
@@ -1,7 +1,8 @@
 /**
  * POST /api/tools/agent-bridge/repair validates its body with RepairBodySchema
- * via safeParse (route validation gate t06) and falls back to the cached sudo
- * password when none is supplied. These tests pin that schema contract. (Gap 7.)
+ * via safeParse (route validation gate t06) and rejects privileged repair when
+ * no sudo password is supplied or cached (#7836). These tests pin that schema
+ * contract. (Gap 7.)
  */
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/tests/unit/agent-bridge-repair-sudo-gate.test.ts
+++ b/tests/unit/agent-bridge-repair-sudo-gate.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #7836 — Agent Bridge Repair must not spawn `sudo -S` with an empty password.
+ * Pins the shared MITM sudo gate and the repair route's 400 rejection path.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isMitmSudoPasswordRequired,
+  normalizeMitmSudoPasswordInput,
+  resolveMitmSudoPassword,
+} from "../../src/mitm/sudoGate.ts";
+import { isSudoPasswordRequired } from "../../src/mitm/dns/dnsConfig.ts";
+
+test("normalizeMitmSudoPasswordInput treats whitespace-only as empty", () => {
+  assert.equal(normalizeMitmSudoPasswordInput("   "), "");
+  assert.equal(normalizeMitmSudoPasswordInput(undefined), "");
+  assert.equal(normalizeMitmSudoPasswordInput(" secret "), "secret");
+});
+
+test("resolveMitmSudoPassword prefers body over cache and ignores whitespace-only body", () => {
+  assert.equal(resolveMitmSudoPassword("from-body", "cached"), "from-body");
+  assert.equal(resolveMitmSudoPassword(undefined, "cached"), "cached");
+  assert.equal(resolveMitmSudoPassword(undefined, null), "");
+  assert.equal(resolveMitmSudoPassword("   ", "cached"), "cached");
+  assert.equal(resolveMitmSudoPassword("   ", null), "");
+});
+
+test("isMitmSudoPasswordRequired returns false when a password is present", () => {
+  assert.equal(isMitmSudoPasswordRequired("secret"), false);
+});
+
+test("isMitmSudoPasswordRequired treats whitespace-only as missing", () => {
+  if (process.platform === "win32") return;
+  const isRootUser = !!(process.getuid && process.getuid() === 0);
+  if (isRootUser) return;
+  if (!isSudoPasswordRequired()) return;
+  assert.equal(isMitmSudoPasswordRequired("   "), true);
+});
+
+test("isMitmSudoPasswordRequired is false on Windows", () => {
+  if (process.platform !== "win32") return;
+  assert.equal(isMitmSudoPasswordRequired(""), false);
+});
+
+test("isMitmSudoPasswordRequired matches isSudoPasswordRequired when unprivileged on POSIX", () => {
+  if (process.platform === "win32") return;
+  const isRootUser = !!(process.getuid && process.getuid() === 0);
+  if (isRootUser) {
+    assert.equal(isMitmSudoPasswordRequired(""), false);
+    return;
+  }
+  assert.equal(isMitmSudoPasswordRequired(""), isSudoPasswordRequired());
+});
+
+const repairRoute = await import(
+  "../../src/app/api/tools/agent-bridge/repair/route.ts"
+);
+
+function makeRepairRequest(body: Record<string, unknown> = {}) {
+  return new Request("http://127.0.0.1/api/tools/agent-bridge/repair", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("POST /repair returns 400 Missing sudoPassword when sudo is required and none supplied", async () => {
+  if (process.platform === "win32") return;
+  if (!isSudoPasswordRequired()) return;
+  const isRootUser = !!(process.getuid && process.getuid() === 0);
+  if (isRootUser) return;
+
+  const res = await repairRoute.POST(makeRepairRequest({}));
+  assert.equal(res.status, 400);
+  const body = (await res.json()) as { error?: { message?: string } };
+  assert.match(body.error?.message ?? "", /Missing sudoPassword/);
+});
+
+test("POST /repair returns 400 for whitespace-only sudoPassword without invoking repair", async () => {
+  if (process.platform === "win32") return;
+  if (!isSudoPasswordRequired()) return;
+  const isRootUser = !!(process.getuid && process.getuid() === 0);
+  if (isRootUser) return;
+
+  const res = await repairRoute.POST(makeRepairRequest({ sudoPassword: "   " }));
+  assert.equal(res.status, 400);
+  const body = (await res.json()) as { error?: { message?: string } };
+  assert.match(body.error?.message ?? "", /Missing sudoPassword/);
+});
+
+test("resolveMitmSudoPassword passes the sudo gate for a non-empty body password", () => {
+  const resolved = resolveMitmSudoPassword("test-password", null);
+  assert.equal(resolved, "test-password");
+  assert.equal(isMitmSudoPasswordRequired(resolved), false);
+});


### PR DESCRIPTION
## Summary

Fixes #7836 — Agent Bridge **Repair** and **Remove CA** no longer spawn `sudo -S` with an empty password when no sudo credential is available.

- **API**: `/api/tools/agent-bridge/repair` and `DELETE /cert` return **400 Missing sudoPassword** before any privileged command runs (same gate pattern as `/api/cli-tools/antigravity-mitm` and `/api/settings/mitm`).
- **UI**: `AgentBridgeMaintenanceCard` shows a sudo password modal (Antigravity MITM pattern) when the server reports `needsSudoPassword` and no password is cached.
- **State**: `/api/tools/agent-bridge/state` now exposes `hasCachedPassword`, `needsSudoPassword`, and `isWin` so the UI can decide server-side.
- **Shared helper**: `src/mitm/sudoGate.ts` centralizes password resolution + requirement checks (whitespace-only passwords treated as missing).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/agent-bridge-repair-sudo-gate.test.ts`
- [x] `node --import tsx/esm --test tests/unit/agent-bridge-maintenance-api.test.ts`
- [x] `node --import tsx/esm --test tests/unit/agent-bridge-repair-route-validation.test.ts`
- [ ] Manual: on Arch/CachyOS without cached password → click Repair → modal appears → wrong password rejected without silent faillock burn from empty stdin
- [ ] Manual: with cached password (after MITM start) → Repair runs without modal