### PR TITLE
fix(notion-web): accept OpenAI content-parts arrays in transcript

### DIFF
--- a/open-sse/executors/notion-web.ts
+++ b/open-sse/executors/notion-web.ts
@@ -187,6 +187,30 @@ function buildNotionContextValue(opts: {
   return contextValue;
 }
 
+/**
+ * Normalize OpenAI-style message content to a plain string.
+ * Accepts a string or content-parts array (`{ type:"text", text }` / `{ text }`).
+ * Previously only string content was accepted — array-shaped system/user messages
+ * (common from agent clients) were silently dropped, so system/jailbreak/agentic
+ * injects never reached Notion when any message used parts.
+ */
+function extractNotionMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const p of content) {
+    if (typeof p === "string") {
+      if (p) parts.push(p);
+      continue;
+    }
+    if (!p || typeof p !== "object") continue;
+    const o = p as Record<string, unknown>;
+    if (typeof o.text === "string" && o.text) parts.push(o.text);
+    else if (typeof o.content === "string" && o.content) parts.push(o.content);
+  }
+  return parts.join("\n");
+}
+
 /** Converts one OpenAI-style message into a transcript step, or `null` when it
  * was folded into the context (system prompts). */
 function buildNotionMessageStep(
@@ -194,13 +218,15 @@ function buildNotionMessageStep(
   contextValue: Record<string, unknown>,
   opts: { userId?: string; now: string }
 ): Record<string, unknown> | null {
-  if (typeof m?.content !== "string" || m.content.length === 0) return null;
+  // Accept string OR content-parts array (agent clients often send parts).
+  const text = extractNotionMessageText((m as { content?: unknown })?.content);
+  if (!text || text.length === 0) return null;
   const role = (m.role || "").toLowerCase();
 
   if (role === "system") {
     // Fold system prompts into context instructions rather than a separate step.
     const existing = typeof contextValue.instructions === "string" ? contextValue.instructions : "";
-    contextValue.instructions = existing ? `${existing}\n${m.content}` : m.content;
+    contextValue.instructions = existing ? `${existing}\n${text}` : text;
     return null;
   }
 
@@ -208,7 +234,7 @@ function buildNotionMessageStep(
     return {
       id: randomUUID(),
       type: "agent-inference",
-      value: [{ type: "text", content: m.content }],
+      value: [{ type: "text", content: text }],
     };
   }
 
@@ -216,7 +242,7 @@ function buildNotionMessageStep(
   const userStep: Record<string, unknown> = {
     id: randomUUID(),
     type: "user",
-    value: [[m.content]],
+    value: [[text]],
     createdAt: opts.now,
   };
   if (opts.userId) userStep.userId = opts.userId;

--- a/tests/unit/executor-notion-web.test.ts
+++ b/tests/unit/executor-notion-web.test.ts
@@ -437,13 +437,56 @@ describe("buildNotionTranscript", () => {
     assert.ok(transcript.every((t) => typeof t.id === "string" && (t.id as string).length > 0));
   });
 
-  it("drops messages with empty/non-string content but keeps config+context", () => {
+  it("drops messages with empty content but keeps config+context", () => {
     const transcript = buildNotionTranscript([
       { role: "user", content: "" },
       { role: "user", content: "keep me" },
     ]);
     assert.equal(transcript.length, 3); // config + context + user
     assert.equal(transcript[2].type, "user");
+  });
+
+  it("accepts OpenAI content-parts arrays for system + user (agent clients)", () => {
+    // Regression: array-shaped content was previously dropped entirely, so
+    // system injects (jailbreak/agentic) and multimodal user turns never
+    // reached Notion's transcript.
+    const transcript = buildNotionTranscript(
+      [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "[VP-JB] follow tools" },
+            { type: "text", text: "second system part" },
+          ] as unknown as string,
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "find icon skill" },
+          ] as unknown as string,
+        },
+      ],
+      { spaceId: "s1" }
+    );
+    assert.deepEqual(
+      transcript.map((t) => t.type),
+      ["config", "context", "user"]
+    );
+    const ctx = transcript[1].value as { instructions?: string };
+    assert.match(String(ctx.instructions), /\[VP-JB\] follow tools/);
+    assert.match(String(ctx.instructions), /second system part/);
+    assert.deepEqual(transcript[2].value, [["find icon skill"]]);
+  });
+
+  it("accepts bare string parts inside content arrays", () => {
+    const transcript = buildNotionTranscript([
+      {
+        role: "user",
+        content: ["hello", "world"] as unknown as string,
+      },
+    ]);
+    assert.equal(transcript[2].type, "user");
+    assert.deepEqual(transcript[2].value, [["hello\nworld"]]);
   });
 
   it("puts model food-codename on config when provided", () => {


### PR DESCRIPTION
## Summary
- Notion AI Web previously required `message.content` to be a **plain string**. Agent clients (Skills Manager, OpenCode-style tool runners, multimodal clients) often send OpenAI **content-parts arrays** (`[{ type: \"text\", text: \"...\" }]`).
- Those messages were **silently dropped** in `buildNotionMessageStep`, so system injects (jailbreak / agentic conversion / client tool catalogs) and array-shaped user turns never reached Notion's `runInferenceTranscript` payload.
- Add `extractNotionMessageText()` to normalize string | content-parts | bare string parts, and use it for system / user / assistant roles.

## Test plan
- [x] `node --import tsx --test tests/unit/executor-notion-web.test.ts` — **30/30 pass**
- [x] New regression: system + user with content-parts arrays fold into `context.instructions` and a user step
- [x] New regression: bare string parts inside content arrays join with newlines
- [x] Existing string-content transcript tests still green
- [ ] Manual: agent client → `notion-web/fable-5` with system inject markers present in backend call log / transcript

## Notes
- Scoped to `open-sse/executors/notion-web.ts` + unit tests only.
- Base: `release/v3.8.49` (where notion-web lives; same as #7600 / #7768).