### PR TITLE
fix(gemini): strip OpenAI "strict" tool-schema keyword for Antigravity

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -16,6 +16,11 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   // leaving it in function_declarations triggers a hard upstream 400
   // ("Unknown name \"multipleOf\""). `minimum`/`maximum` ARE accepted and kept.
   "multipleOf",
+  // OpenAI "strict" tool-calling mode embeds `strict: true/false` directly inside
+  // a function's `parameters` schema (RubyLLM and other OpenAI-convention clients
+  // do this by default). Gemini's function_declarations schema doesn't recognize
+  // it and 400s the same way ("Unknown name \"strict\" ... Cannot find field").
+  "strict",
   // NOTE: `pattern` is intentionally NOT in this set. Antigravity (Gemini-derived
   // surface) accepts `pattern` on string constraints, and glob/grep/file-search
   // tools depend on it to express their argument regex. Removing it produced

--- a/tests/unit/gemini-strict-tool-schema.test.ts
+++ b/tests/unit/gemini-strict-tool-schema.test.ts
@@ -1,0 +1,66 @@
+/**
+ * antigravity/gemini returned [400] "Invalid JSON payload received.
+ * Unknown name \"strict\" at 'request.tools[0].function_declarations[0].parameters':
+ * Cannot find field."
+ *
+ * Root cause: OpenAI-convention clients (RubyLLM and others) embed
+ * `strict: true/false` directly inside a tool's `parameters` JSON schema as part
+ * of OpenAI's strict tool-calling mode. `strict` was NOT listed in
+ * `GEMINI_UNSUPPORTED_SCHEMA_KEYS`, so `cleanJSONSchemaForAntigravity` left it in
+ * the function-declaration parameters, and the Gemini/antigravity upstream
+ * (OpenAPI 3.0 schema subset) rejects the unrecognized keyword with a hard 400.
+ *
+ * Fix: add `strict` to the unsupported-keys set so it is stripped at every level.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  cleanJSONSchemaForAntigravity,
+  GEMINI_UNSUPPORTED_SCHEMA_KEYS,
+} from "../../open-sse/translator/helpers/geminiHelper.ts";
+import { openaiToGeminiRequest } from "../../open-sse/translator/request/openai-to-gemini.ts";
+
+test("strict is stripped at all levels for antigravity/gemini schemas", () => {
+  const schema = {
+    type: "object",
+    strict: true,
+    properties: {
+      query: { type: "string" },
+      filters: { type: "object", strict: false, properties: {} },
+    },
+  };
+
+  const cleaned = JSON.stringify(cleanJSONSchemaForAntigravity(schema));
+
+  assert.ok(!cleaned.includes("strict"), "strict must be removed");
+  assert.ok(cleaned.includes("query"), "unrelated properties must be preserved");
+});
+
+test("strict is in GEMINI_UNSUPPORTED_SCHEMA_KEYS", () => {
+  assert.ok(GEMINI_UNSUPPORTED_SCHEMA_KEYS.has("strict"));
+});
+
+test("OpenAI -> Gemini request strips strict from OpenAI-style function tool parameters", () => {
+  const body = {
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "search_conversations",
+          description: "search",
+          parameters: { type: "object", strict: true, properties: { query: { type: "string" } } },
+        },
+      },
+    ],
+  };
+
+  const result = openaiToGeminiRequest("gemini-3.5-flash-low", body, false) as {
+    tools?: Array<{ functionDeclarations?: Array<{ parameters: unknown }> }>;
+  };
+
+  const parameters = result.tools?.[0]?.functionDeclarations?.[0]?.parameters;
+  assert.ok(parameters, "expected a translated function declaration");
+  assert.ok(!JSON.stringify(parameters).includes("strict"), "strict must not reach the upstream request");
+});


### PR DESCRIPTION
## Problem

OpenAI-convention clients (e.g. RubyLLM, and anything using OpenAI strict tool-calling mode) embed `"strict": true/false` **inside** a function tool's `parameters` JSON schema. When such a request is routed to a Gemini-family upstream through the Antigravity translator, Gemini rejects the payload with a hard 400:

```
Invalid JSON payload received. Unknown name "strict" at
'request.tools[0].function_declarations[0].parameters': Cannot find field.
```

This breaks **every** tool-calling request from OpenAI-convention clients to `agy/gemini-*` — plain completions work, anything with `tools` 400s.

## Root cause

`GEMINI_UNSUPPORTED_SCHEMA_KEYS` in `open-sse/translator/helpers/geminiHelper.ts` strips JSON-Schema keywords Gemini's `function_declarations` doesn't accept (it already handles `multipleOf`, `minLength`, etc. for exactly this class of 400). `strict` was missing from that set, so `cleanJSONSchemaForAntigravity` forwarded it verbatim and Gemini 400'd.

## Solution

Add `strict` to `GEMINI_UNSUPPORTED_SCHEMA_KEYS`. `strict` is OpenAI tool-calling metadata, not a schema constraint, so dropping it is safe and mirrors the existing `multipleOf` handling.

## Tests

`tests/unit/gemini-strict-tool-schema.test.ts` — verifies `strict` is stripped at all schema levels and that unrelated properties survive. Ran the antigravity/gemini translator suites (`gemini-helper`, `translator-openai-to-gemini`, etc.), all green.

## Risk

Minimal. One keyword added to an existing deny-list; no behavior change for requests that never carried `strict`.

## Evidence

Reconstructed onto the current `release/v3.8.49` tip (the branch was behind `#8231`, whose `DEFAULT_SAFETY_SETTINGS` change appeared as a spurious revert in the raw diff — now preserved untouched). The `strict` keyword is added to `GEMINI_UNSUPPORTED_SCHEMA_KEYS`; regression test output:

```
$ node --import tsx/esm --test tests/unit/gemini-strict-tool-schema.test.ts
✔ strict is stripped at all levels for antigravity/gemini schemas
✔ strict is in GEMINI_UNSUPPORTED_SCHEMA_KEYS
✔ OpenAI -> Gemini request strips strict from OpenAI-style function tool parameters
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

typecheck:core clean · eslint clean · file-size OK.