### PR TITLE
fix(antigravity): collect native functionCall parts in non-streaming SSE collector

### DIFF
--- a/open-sse/executors/antigravity/sseCollect.ts
+++ b/open-sse/executors/antigravity/sseCollect.ts
@@ -88,6 +88,28 @@ export function processAntigravitySSEPayload(
     const candidate = parsed?.response?.candidates?.[0];
     if (candidate?.content?.parts) {
       for (const part of candidate.content.parts) {
+        // Native function calls: Gemini 3.x responds to functionDeclarations with a
+        // native functionCall part (usually carrying a thoughtSignature), NOT the
+        // legacy "[Tool call: ...]" textual format. Dropping these left the collected
+        // stream empty on every tools request → synthetic 502 "Provider returned
+        // empty content" (Chatwit Captain Copilot / reply suggestion outage).
+        if (part.functionCall && typeof part.functionCall.name === "string") {
+          const fc = part.functionCall;
+          collected.toolCalls.push({
+            id:
+              typeof fc.id === "string" && fc.id.length > 0
+                ? fc.id
+                : `${fc.name}-${Date.now()}-${collected.toolCalls.length}`,
+            index: collected.toolCalls.length,
+            type: "function",
+            function: {
+              name: fc.name,
+              arguments: JSON.stringify(stripZeroWidth(fc.args ?? {})),
+            },
+          });
+          collected.finishReason = "tool_calls";
+          continue;
+        }
         if (typeof part.text === "string" && !part.thought && !part.thoughtSignature) {
           const textualToolCall = parseAntigravityTextualToolCall(part.text);
           if (textualToolCall) {

--- a/tests/unit/antigravity-native-toolcall-collect.test.ts
+++ b/tests/unit/antigravity-native-toolcall-collect.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Native functionCall parts must be collected by the Antigravity SSE collector.
+ *
+ * Root cause: `processAntigravitySSEPayload` only handled `part.text` (including
+ * the legacy "[Tool call: ...]" textual format) and skipped every other part.
+ * Gemini 3.x answers native `functionDeclarations` with a native `functionCall`
+ * part (usually carrying a `thoughtSignature`), so any tools request collected
+ * to an empty stream and was rewritten into a synthetic 502 "Provider returned
+ * empty content" — breaking Chatwit Captain Copilot / reply suggestions on
+ * agy/gemini-3.5-flash-low while plain text completions kept working.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { processAntigravitySSEPayload } from "../../open-sse/executors/antigravity.ts";
+import type { AntigravityCollectedStream } from "../../open-sse/executors/antigravity/sseCollect.ts";
+
+function emptyCollected(): AntigravityCollectedStream {
+  return {
+    textContent: "",
+    finishReason: "",
+    toolCalls: [],
+    usage: null,
+    remainingCredits: null,
+  };
+}
+
+test("processAntigravitySSEPayload collects a native functionCall part as a tool call", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: { name: "search_documentation", args: { query: "horário" } },
+                  thoughtSignature: "sig-abc",
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    }),
+    collected
+  );
+
+  assert.equal(collected.toolCalls.length, 1);
+  assert.equal(collected.toolCalls[0].type, "function");
+  assert.equal(collected.toolCalls[0].function.name, "search_documentation");
+  assert.deepEqual(JSON.parse(collected.toolCalls[0].function.arguments), { query: "horário" });
+  assert.ok(collected.toolCalls[0].id.length > 0);
+});
+
+test("processAntigravitySSEPayload preserves upstream functionCall id and indexes multiple calls", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { functionCall: { id: "call-1", name: "get_contact", args: { contact_id: 7 } } },
+                { functionCall: { name: "get_conversation", args: {} } },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    collected
+  );
+
+  assert.equal(collected.toolCalls.length, 2);
+  assert.equal(collected.toolCalls[0].id, "call-1");
+  assert.equal(collected.toolCalls[0].index, 0);
+  assert.equal(collected.toolCalls[1].index, 1);
+  assert.equal(collected.toolCalls[1].function.name, "get_conversation");
+});
+
+test("processAntigravitySSEPayload still collects text alongside a functionCall part", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: "Vou buscar isso." },
+                { functionCall: { name: "search_articles", args: { query: "faq" } } },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    collected
+  );
+
+  assert.equal(collected.textContent, "Vou buscar isso.");
+  assert.equal(collected.toolCalls.length, 1);
+});
+
+test("processAntigravitySSEPayload ignores a malformed functionCall without a name", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: { candidates: [{ content: { parts: [{ functionCall: { args: {} } }] } }] },
+    }),
+    collected
+  );
+
+  assert.equal(collected.toolCalls.length, 0);
+  assert.equal(collected.textContent, "");
+});


### PR DESCRIPTION
## Problem

Non-streaming tool-calling requests to `agy/gemini-*` return a synthetic `502 "Provider returned empty content"`, even though the upstream actually answered. Symptom is very specific: **plain completions work, anything with `tools` fails** with empty content, which then trips the model-lockout/cooldown path and (for callers with a short timeout) surfaces as a 500/timeout.

## Root cause

Gemini 3.x answers native `functionDeclarations` with a native `functionCall` part (usually carrying a `thoughtSignature`), **not** the legacy `[Tool call: ...]` textual format. The Antigravity non-streaming SSE collector (`processAntigravitySSEPayload` in `open-sse/executors/antigravity/sseCollect.ts`) only read `part.text` (including the textual tool-call format) and skipped every other part type. So a native `functionCall` part was dropped, the collected stream came out empty, and `isEmptyContentResponse` rewrote the valid 200 into a synthetic 502.

## Solution

Handle native `functionCall` parts in the collector: push them onto `collected.toolCalls` (preserving the upstream call id when present, indexing multiple calls, JSON-stringifying args through the existing `stripZeroWidth`) and set `finishReason = "tool_calls"`. Text and the legacy textual format keep working unchanged.

## Tests

`tests/unit/antigravity-native-toolcall-collect.test.ts` — covers: a single native `functionCall` collected as a tool call; upstream id preservation + indexing across multiple calls; text collected alongside a `functionCall`; and a malformed `functionCall` (no name) ignored. Ran alongside the existing `executor-agy` / `antigravity-executor-split` suites, all green.

## Risk

Scoped to the Antigravity non-streaming collector. Adds handling for a part type that was previously dropped; no change to text or legacy-textual-tool-call paths.
