### PR TITLE
Restore Responses API custom tool calls

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -74,7 +74,7 @@ import { defaultClaudeToolType } from "./chatCore/claudeToolDefaults.ts";
 import { injectSystemPrompt, injectCustomSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
-import { collectResponsesCustomToolNames } from "../translator/request/openai-responses/additionalTools.ts";
+import { collectCustomToolNamesForSourceFormat } from "../translator/request/openai-responses/additionalTools.ts";
 import { sanitizeKiroTools } from "../utils/kiroSanitizer.ts";
 import { splitMisplacedToolResults } from "../translator/helpers/claudeHelper.ts";
 import {
@@ -412,11 +412,6 @@ export async function handleChatCore({
     model
   );
   const isModelScope = () => isModelScopeProvider(provider, credentials?.providerSpecificData);
-  const responsesInputItems = Array.isArray(body?.input) ? body.input : [];
-  const customToolNames =
-    apiFormat === FORMATS.OPENAI_RESPONSES
-      ? collectResponsesCustomToolNames(body?.tools, responsesInputItems)
-      : new Set<string>();
   const startTime = Date.now();
   // Per-request trace id + checkpoint helper. Lets us see exactly which await
   // a hung request was sitting on in `[STAGE_TRACE]` log lines. Uses crypto RNG
@@ -620,6 +615,13 @@ export async function handleChatCore({
     copilotCompatibleReasoning,
     clientResponseFormat,
   } = resolveChatCoreRequestFormat({ clientRawRequest, body, provider, userAgent });
+  const responsesInputItems = Array.isArray(body?.input) ? body.input : [];
+  const customToolNames = collectCustomToolNamesForSourceFormat(
+    sourceFormat,
+    FORMATS.OPENAI_RESPONSES,
+    body?.tools,
+    responsesInputItems
+  );
 
   // Check for bypass patterns (warmup, skip) - return fake response
   const bypassResponse = handleBypassRequest(body, model, userAgent);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -74,6 +74,7 @@ import { defaultClaudeToolType } from "./chatCore/claudeToolDefaults.ts";
 import { injectSystemPrompt, injectCustomSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
+import { collectResponsesCustomToolNames } from "../translator/request/openai-responses/additionalTools.ts";
 import { sanitizeKiroTools } from "../utils/kiroSanitizer.ts";
 import { splitMisplacedToolResults } from "../translator/helpers/claudeHelper.ts";
 import {
@@ -411,6 +412,11 @@ export async function handleChatCore({
     model
   );
   const isModelScope = () => isModelScopeProvider(provider, credentials?.providerSpecificData);
+  const responsesInputItems = Array.isArray(body?.input) ? body.input : [];
+  const customToolNames =
+    apiFormat === FORMATS.OPENAI_RESPONSES
+      ? collectResponsesCustomToolNames(body?.tools, responsesInputItems)
+      : new Set<string>();
   const startTime = Date.now();
   // Per-request trace id + checkpoint helper. Lets us see exactly which await
   // a hung request was sitting on in `[STAGE_TRACE]` log lines. Uses crypto RNG
@@ -4618,7 +4624,8 @@ export async function handleChatCore({
         userAgent: streamUserAgent,
         thinkingMarkerHeader,
         clientResponseFormat,
-      })
+      }),
+      customToolNames
     );
   } else {
     log?.debug?.("STREAM", `Standard passthrough mode`);

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -11,6 +11,22 @@ import { createResponsesApiTransformStream } from "../transformer/responsesTrans
 import { createSseHeartbeatTransform, HEARTBEAT_SHAPES } from "../utils/sseHeartbeat.ts";
 import { SSE_HEARTBEAT_INTERVAL_MS } from "../config/constants.ts";
 
+function collectCustomToolNames(tools: unknown[], customToolNames: Set<string>) {
+  for (const toolValue of tools) {
+    if (!toolValue || typeof toolValue !== "object" || Array.isArray(toolValue)) continue;
+    const tool = toolValue as Record<string, unknown>;
+
+    if (tool.type === "custom" && typeof tool.name === "string") {
+      const name = tool.name.trim();
+      if (name) customToolNames.add(name);
+    }
+
+    if (tool.type === "namespace" && Array.isArray(tool.tools)) {
+      collectCustomToolNames(tool.tools, customToolNames);
+    }
+  }
+}
+
 /**
  * Handle /v1/responses request
  * @param {object} options
@@ -37,12 +53,8 @@ export async function handleResponsesCore({
   signal,
 }) {
   const inputItems = Array.isArray(body?.input) ? body.input : [];
-  const customToolNames = new Set(
-    collectResponsesTools(body?.tools, inputItems)
-      .filter((tool) => tool?.type === "custom" && typeof tool.name === "string")
-      .map((tool) => tool.name.trim())
-      .filter(Boolean)
-  );
+  const customToolNames = new Set<string>();
+  collectCustomToolNames(collectResponsesTools(body?.tools, inputItems), customToolNames);
 
   // Convert Responses API format to Chat Completions format
   const convertedBody = convertResponsesApiFormat(body, credentials);

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -6,30 +6,10 @@ import { CORS_HEADERS } from "../utils/cors.ts";
 
 import { handleChatCore } from "./chatCore.ts";
 import { convertResponsesApiFormat } from "../translator/helpers/responsesApiHelper.ts";
-import { collectResponsesTools } from "../translator/request/openai-responses/additionalTools.ts";
+import { collectResponsesCustomToolNames } from "../translator/request/openai-responses/additionalTools.ts";
 import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.ts";
 import { createSseHeartbeatTransform, HEARTBEAT_SHAPES } from "../utils/sseHeartbeat.ts";
 import { SSE_HEARTBEAT_INTERVAL_MS } from "../config/constants.ts";
-
-function collectCustomToolNames(
-  tools: unknown[],
-  customToolNames: Set<string>,
-  blockedNames = new Set<string>()
-) {
-  for (const toolValue of tools) {
-    if (!toolValue || typeof toolValue !== "object" || Array.isArray(toolValue)) continue;
-    const tool = toolValue as Record<string, unknown>;
-
-    if (tool.type === "custom" && typeof tool.name === "string" && !blockedNames.has(tool.name)) {
-      const name = tool.name.trim();
-      if (name) customToolNames.add(name);
-    }
-
-    if (tool.type === "namespace" && Array.isArray(tool.tools)) {
-      collectCustomToolNames(tool.tools, customToolNames, blockedNames);
-    }
-  }
-}
 
 /**
  * Handle /v1/responses request
@@ -57,19 +37,7 @@ export async function handleResponsesCore({
   signal,
 }) {
   const inputItems = Array.isArray(body?.input) ? body.input : [];
-  const rootTools = Array.isArray(body?.tools) ? body.tools : [];
-  const topLevelToolNames = new Set(
-    rootTools
-      .filter((tool) => tool?.type !== "namespace" && typeof tool?.name === "string")
-      .map((tool) => tool.name.trim())
-      .filter(Boolean)
-  );
-  const customToolNames = new Set<string>();
-  collectCustomToolNames(
-    collectResponsesTools(body?.tools, inputItems),
-    customToolNames,
-    topLevelToolNames
-  );
+  const customToolNames = collectResponsesCustomToolNames(body?.tools, inputItems);
 
   // Convert Responses API format to Chat Completions format
   const convertedBody = convertResponsesApiFormat(body, credentials);

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -6,6 +6,7 @@ import { CORS_HEADERS } from "../utils/cors.ts";
 
 import { handleChatCore } from "./chatCore.ts";
 import { convertResponsesApiFormat } from "../translator/helpers/responsesApiHelper.ts";
+import { collectResponsesTools } from "../translator/request/openai-responses/additionalTools.ts";
 import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.ts";
 import { createSseHeartbeatTransform, HEARTBEAT_SHAPES } from "../utils/sseHeartbeat.ts";
 import { SSE_HEARTBEAT_INTERVAL_MS } from "../config/constants.ts";
@@ -35,6 +36,14 @@ export async function handleResponsesCore({
   connectionId,
   signal,
 }) {
+  const inputItems = Array.isArray(body?.input) ? body.input : [];
+  const customToolNames = new Set(
+    collectResponsesTools(body?.tools, inputItems)
+      .filter((tool) => tool?.type === "custom" && typeof tool.name === "string")
+      .map((tool) => tool.name.trim())
+      .filter(Boolean)
+  );
+
   // Convert Responses API format to Chat Completions format
   const convertedBody = convertResponsesApiFormat(body, credentials);
 
@@ -69,7 +78,7 @@ export async function handleResponsesCore({
   }
 
   // Transform SSE stream to Responses API format (no logging in worker)
-  const transformStream = createResponsesApiTransformStream(null);
+  const transformStream = createResponsesApiTransformStream(null, undefined, { customToolNames });
   const transformedBody = response.body.pipeThrough(transformStream).pipeThrough(
     createSseHeartbeatTransform({
       signal,

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -11,18 +11,22 @@ import { createResponsesApiTransformStream } from "../transformer/responsesTrans
 import { createSseHeartbeatTransform, HEARTBEAT_SHAPES } from "../utils/sseHeartbeat.ts";
 import { SSE_HEARTBEAT_INTERVAL_MS } from "../config/constants.ts";
 
-function collectCustomToolNames(tools: unknown[], customToolNames: Set<string>) {
+function collectCustomToolNames(
+  tools: unknown[],
+  customToolNames: Set<string>,
+  blockedNames = new Set<string>()
+) {
   for (const toolValue of tools) {
     if (!toolValue || typeof toolValue !== "object" || Array.isArray(toolValue)) continue;
     const tool = toolValue as Record<string, unknown>;
 
-    if (tool.type === "custom" && typeof tool.name === "string") {
+    if (tool.type === "custom" && typeof tool.name === "string" && !blockedNames.has(tool.name)) {
       const name = tool.name.trim();
       if (name) customToolNames.add(name);
     }
 
     if (tool.type === "namespace" && Array.isArray(tool.tools)) {
-      collectCustomToolNames(tool.tools, customToolNames);
+      collectCustomToolNames(tool.tools, customToolNames, blockedNames);
     }
   }
 }
@@ -53,8 +57,19 @@ export async function handleResponsesCore({
   signal,
 }) {
   const inputItems = Array.isArray(body?.input) ? body.input : [];
+  const rootTools = Array.isArray(body?.tools) ? body.tools : [];
+  const topLevelToolNames = new Set(
+    rootTools
+      .filter((tool) => tool?.type !== "namespace" && typeof tool?.name === "string")
+      .map((tool) => tool.name.trim())
+      .filter(Boolean)
+  );
   const customToolNames = new Set<string>();
-  collectCustomToolNames(collectResponsesTools(body?.tools, inputItems), customToolNames);
+  collectCustomToolNames(
+    collectResponsesTools(body?.tools, inputItems),
+    customToolNames,
+    topLevelToolNames
+  );
 
   // Convert Responses API format to Chat Completions format
   const convertedBody = convertResponsesApiFormat(body, credentials);

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -104,6 +104,8 @@ export function createResponsesApiTransformStream(
     funcArgsBuf: {},
     funcNames: {},
     funcCallIds: {},
+    funcItemAdded: {},
+    funcItemTypes: {},
     funcArgsDone: {},
     funcItemDone: {},
     completedOutputItems: [] as Array<{
@@ -277,13 +279,36 @@ export function createResponsesApiTransformStream(
     }
   };
 
+  const emitToolCallAdded = (controller, idx) => {
+    if (state.funcItemAdded[idx] || !state.funcCallIds[idx]) return;
+
+    const customTool = customToolNames.has(state.funcNames[idx] || "");
+    const itemType = customTool ? "custom_tool_call" : "function_call";
+    state.funcItemTypes[idx] = itemType;
+    state.funcItemAdded[idx] = true;
+
+    emit(controller, "response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: idx,
+      item: {
+        id: `fc_${state.funcCallIds[idx]}`,
+        type: itemType,
+        ...(customTool ? { input: "" } : { arguments: "" }),
+        call_id: state.funcCallIds[idx],
+        name: state.funcNames[idx] || "",
+        ...(customTool ? { status: "in_progress" } : {}),
+      },
+    });
+  };
+
   const closeToolCall = (controller, idx, recordAsCompleted = true) => {
     const callId = state.funcCallIds[idx];
     if (callId && !state.funcItemDone[idx]) {
       const normalizedIndex = normalizeOutputIndex(idx);
       let args = state.funcArgsBuf[idx] || "{}";
       const toolName = state.funcNames[idx] || "";
-      const isCustomTool = customToolNames.has(toolName);
+      emitToolCallAdded(controller, idx);
+      const isCustomTool = state.funcItemTypes[idx] === "custom_tool_call";
 
       // Fix #1674 & #1852: Final cleanup of empty string and empty array placeholders
       try {
@@ -624,20 +649,13 @@ export function createResponsesApiTransformStream(
 
               if (!state.funcCallIds[tcIdx] && newCallId) {
                 state.funcCallIds[tcIdx] = newCallId;
-                const isCustomTool = customToolNames.has(state.funcNames[tcIdx] || "");
+              }
 
-                emit(controller, "response.output_item.added", {
-                  type: "response.output_item.added",
-                  output_index: tcIdx,
-                  item: {
-                    id: `fc_${newCallId}`,
-                    type: isCustomTool ? "custom_tool_call" : "function_call",
-                    ...(isCustomTool ? { input: "" } : { arguments: "" }),
-                    call_id: newCallId,
-                    name: state.funcNames[tcIdx] || "",
-                    ...(isCustomTool ? { status: "in_progress" } : {}),
-                  },
-                });
+              // The provider may send the call id before the function name. Defer the
+              // lifecycle item until the name is available so custom calls are not first
+              // announced as function calls.
+              if (state.funcCallIds[tcIdx] && state.funcNames[tcIdx]) {
+                emitToolCallAdded(controller, tcIdx);
               }
 
               if (!state.funcArgsBuf[tcIdx]) state.funcArgsBuf[tcIdx] = "";
@@ -667,7 +685,8 @@ export function createResponsesApiTransformStream(
                 if (
                   refCallId &&
                   emittedDelta &&
-                  !customToolNames.has(state.funcNames[tcIdx] || "")
+                  state.funcItemAdded[tcIdx] &&
+                  state.funcItemTypes[tcIdx] !== "custom_tool_call"
                 ) {
                   emit(controller, "response.function_call_arguments.delta", {
                     type: "response.function_call_arguments.delta",

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -641,6 +641,8 @@ export function createResponsesApiTransformStream(
                 delete state.funcCallIds[tcIdx];
                 delete state.funcNames[tcIdx];
                 delete state.funcArgsBuf[tcIdx];
+                delete state.funcItemAdded[tcIdx];
+                delete state.funcItemTypes[tcIdx];
                 delete state.funcArgsDone[tcIdx];
                 delete state.funcItemDone[tcIdx];
               }

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -280,7 +280,7 @@ export function createResponsesApiTransformStream(
   };
 
   const emitToolCallAdded = (controller, idx) => {
-    if (state.funcItemAdded[idx] || !state.funcCallIds[idx]) return;
+    if (state.funcItemAdded[idx] || !state.funcCallIds[idx]) return false;
 
     const customTool = customToolNames.has(state.funcNames[idx] || "");
     const itemType = customTool ? "custom_tool_call" : "function_call";
@@ -299,6 +299,7 @@ export function createResponsesApiTransformStream(
         ...(customTool ? { status: "in_progress" } : {}),
       },
     });
+    return true;
   };
 
   const closeToolCall = (controller, idx, recordAsCompleted = true) => {
@@ -310,24 +311,27 @@ export function createResponsesApiTransformStream(
       emitToolCallAdded(controller, idx);
       const isCustomTool = state.funcItemTypes[idx] === "custom_tool_call";
 
-      // Fix #1674 & #1852: Final cleanup of empty string and empty array placeholders
-      try {
-        const parsed = JSON.parse(args);
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          let modified = false;
-          for (const [k, v] of Object.entries(parsed)) {
-            if (v === "" || (Array.isArray(v) && v.length === 0)) {
-              delete parsed[k];
-              modified = true;
+      // Fix #1674 & #1852: Final cleanup of empty string and empty array placeholders.
+      // Custom-tool input is intentionally allowed to be an empty string.
+      if (!isCustomTool) {
+        try {
+          const parsed = JSON.parse(args);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            let modified = false;
+            for (const [k, v] of Object.entries(parsed)) {
+              if (v === "" || (Array.isArray(v) && v.length === 0)) {
+                delete parsed[k];
+                modified = true;
+              }
+            }
+            if (modified) {
+              args = JSON.stringify(parsed);
+              state.funcArgsBuf[idx] = args;
             }
           }
-          if (modified) {
-            args = JSON.stringify(parsed);
-            state.funcArgsBuf[idx] = args;
-          }
+        } catch (e) {
+          // Ignore malformed JSON
         }
-      } catch (e) {
-        // Ignore malformed JSON
       }
 
       let funcItem;
@@ -657,7 +661,19 @@ export function createResponsesApiTransformStream(
               // lifecycle item until the name is available so custom calls are not first
               // announced as function calls.
               if (state.funcCallIds[tcIdx] && state.funcNames[tcIdx]) {
-                emitToolCallAdded(controller, tcIdx);
+                const itemAdded = emitToolCallAdded(controller, tcIdx);
+                if (
+                  itemAdded &&
+                  state.funcItemTypes[tcIdx] !== "custom_tool_call" &&
+                  state.funcArgsBuf[tcIdx]
+                ) {
+                  emit(controller, "response.function_call_arguments.delta", {
+                    type: "response.function_call_arguments.delta",
+                    item_id: `fc_${state.funcCallIds[tcIdx]}`,
+                    output_index: tcIdx,
+                    delta: state.funcArgsBuf[tcIdx],
+                  });
+                }
               }
 
               if (!state.funcArgsBuf[tcIdx]) state.funcArgsBuf[tcIdx] = "";

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -75,9 +75,16 @@ export function createResponsesLogger(model, logsDir = null) {
 /**
  * Create TransformStream that converts Chat Completions SSE to Responses API SSE
  * @param {Object} logger - Optional logger instance
+ * @param {number} keepaliveIntervalMs - Keepalive interval in milliseconds
+ * @param {{ customToolNames?: Iterable<string> }} options - Original Responses tool metadata
  * @returns {TransformStream}
  */
-export function createResponsesApiTransformStream(logger = null, keepaliveIntervalMs = 3000) {
+export function createResponsesApiTransformStream(
+  logger = null,
+  keepaliveIntervalMs = 3000,
+  options = {}
+) {
+  const customToolNames = new Set(options.customToolNames || []);
   const state = {
     seq: 0,
     responseId: `resp_${Date.now()}`,
@@ -275,6 +282,8 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
     if (callId && !state.funcItemDone[idx]) {
       const normalizedIndex = normalizeOutputIndex(idx);
       let args = state.funcArgsBuf[idx] || "{}";
+      const toolName = state.funcNames[idx] || "";
+      const isCustomTool = customToolNames.has(toolName);
 
       // Fix #1674 & #1852: Final cleanup of empty string and empty array placeholders
       try {
@@ -296,20 +305,51 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
         // Ignore malformed JSON
       }
 
-      emit(controller, "response.function_call_arguments.done", {
-        type: "response.function_call_arguments.done",
-        item_id: `fc_${callId}`,
-        output_index: normalizedIndex,
-        arguments: args,
-      });
+      let funcItem;
+      if (isCustomTool) {
+        let rawInput = args;
+        try {
+          const parsed = JSON.parse(args);
+          if (parsed && typeof parsed.input === "string") rawInput = parsed.input;
+        } catch {
+          // A non-JSON argument is already the raw custom-tool input.
+        }
 
-      const funcItem = {
-        id: `fc_${callId}`,
-        type: "function_call",
-        arguments: args,
-        call_id: callId,
-        name: state.funcNames[idx] || "",
-      };
+        emit(controller, "response.custom_tool_call_input.delta", {
+          type: "response.custom_tool_call_input.delta",
+          item_id: `fc_${callId}`,
+          output_index: normalizedIndex,
+          delta: rawInput,
+        });
+        emit(controller, "response.custom_tool_call_input.done", {
+          type: "response.custom_tool_call_input.done",
+          item_id: `fc_${callId}`,
+          output_index: normalizedIndex,
+          input: rawInput,
+        });
+        funcItem = {
+          id: `fc_${callId}`,
+          type: "custom_tool_call",
+          input: rawInput,
+          call_id: callId,
+          name: toolName,
+          status: "completed",
+        };
+      } else {
+        emit(controller, "response.function_call_arguments.done", {
+          type: "response.function_call_arguments.done",
+          item_id: `fc_${callId}`,
+          output_index: normalizedIndex,
+          arguments: args,
+        });
+        funcItem = {
+          id: `fc_${callId}`,
+          type: "function_call",
+          arguments: args,
+          call_id: callId,
+          name: toolName,
+        };
+      }
 
       emit(controller, "response.output_item.done", {
         type: "response.output_item.done",
@@ -584,16 +624,18 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
 
               if (!state.funcCallIds[tcIdx] && newCallId) {
                 state.funcCallIds[tcIdx] = newCallId;
+                const isCustomTool = customToolNames.has(state.funcNames[tcIdx] || "");
 
                 emit(controller, "response.output_item.added", {
                   type: "response.output_item.added",
                   output_index: tcIdx,
                   item: {
                     id: `fc_${newCallId}`,
-                    type: "function_call",
-                    arguments: "",
+                    type: isCustomTool ? "custom_tool_call" : "function_call",
+                    ...(isCustomTool ? { input: "" } : { arguments: "" }),
                     call_id: newCallId,
                     name: state.funcNames[tcIdx] || "",
+                    ...(isCustomTool ? { status: "in_progress" } : {}),
                   },
                 });
               }
@@ -622,7 +664,11 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
                 const emittedDelta = nextArgs.slice(existingArgs.length);
                 state.funcArgsBuf[tcIdx] = nextArgs;
 
-                if (refCallId && emittedDelta) {
+                if (
+                  refCallId &&
+                  emittedDelta &&
+                  !customToolNames.has(state.funcNames[tcIdx] || "")
+                ) {
                   emit(controller, "response.function_call_arguments.delta", {
                     type: "response.function_call_arguments.delta",
                     item_id: `fc_${refCallId}`,

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -684,6 +684,7 @@ export function initState(sourceFormat) {
       funcNames: {},
       funcCallIds: {},
       funcArgsDone: {},
+      funcItemAdded: {},
       funcItemDone: {},
       completedOutputItems: [],
       completedSent: false,

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -403,11 +403,20 @@ export function openaiResponsesToOpenAIRequest(
               function: {
                 name: toString(sub.name),
                 description: toString(sub.description),
-                parameters: sub.parameters ??
-                  sub.input_schema ?? {
-                    type: "object",
-                    properties: {},
-                  },
+                parameters:
+                  toString(sub.type) === "custom"
+                    ? {
+                        type: "object",
+                        properties: { input: { type: "string" } },
+                        required: ["input"],
+                        additionalProperties: false,
+                      }
+                    : (sub.parameters ??
+                      sub.input_schema ?? {
+                        type: "object",
+                        properties: {},
+                      }),
+                strict: sub.strict,
               },
             }));
         }

--- a/open-sse/translator/request/openai-responses/additionalTools.ts
+++ b/open-sse/translator/request/openai-responses/additionalTools.ts
@@ -57,14 +57,6 @@ function mergeNamespaceTools(first: unknown, second: unknown): unknown[] {
  */
 export function collectResponsesTools(rootTools: unknown, inputItems: unknown[]): unknown[] {
   const rootToolList = Array.isArray(rootTools) ? rootTools : [];
-  const rootNames = new Set(
-    rootToolList
-      .map((tool) => {
-        const record = toRecord(tool);
-        return record.type === "namespace" ? "" : toolName(tool);
-      })
-      .filter(Boolean)
-  );
   const sources: unknown[][] = [rootToolList];
 
   for (const itemValue of inputItems) {
@@ -73,6 +65,15 @@ export function collectResponsesTools(rootTools: unknown, inputItems: unknown[])
       sources.push(item.tools);
     }
   }
+  const explicitNames = new Set(
+    sources
+      .flat()
+      .map((tool) => {
+        const record = toRecord(tool);
+        return record.type === "namespace" ? "" : toolName(tool);
+      })
+      .filter(Boolean)
+  );
 
   const merged: unknown[] = [];
   const seen = new Set<string>();
@@ -84,7 +85,7 @@ export function collectResponsesTools(rootTools: unknown, inputItems: unknown[])
         const namespaceName = toolName(tool);
         const existingIndex = namespaceName ? namespaceIndexes.get(namespaceName) : undefined;
         const namespaceTools = Array.isArray(toolRecord.tools)
-          ? toolRecord.tools.filter((member) => !rootNames.has(toolName(member)))
+          ? toolRecord.tools.filter((member) => !explicitNames.has(toolName(member)))
           : toolRecord.tools;
         if (existingIndex !== undefined) {
           const existing = toRecord(merged[existingIndex]);
@@ -126,4 +127,15 @@ export function collectResponsesCustomToolNames(
   };
   visit(collectResponsesTools(rootTools, inputItems));
   return names;
+}
+
+export function collectCustomToolNamesForSourceFormat(
+  sourceFormat: string,
+  responsesFormat: string,
+  rootTools: unknown,
+  inputItems: unknown[]
+): Set<string> {
+  return sourceFormat === responsesFormat
+    ? collectResponsesCustomToolNames(rootTools, inputItems)
+    : new Set<string>();
 }

--- a/open-sse/translator/request/openai-responses/additionalTools.ts
+++ b/open-sse/translator/request/openai-responses/additionalTools.ts
@@ -56,7 +56,16 @@ function mergeNamespaceTools(first: unknown, second: unknown): unknown[] {
  * function names from reaching strict upstreams.
  */
 export function collectResponsesTools(rootTools: unknown, inputItems: unknown[]): unknown[] {
-  const sources: unknown[][] = [Array.isArray(rootTools) ? rootTools : []];
+  const rootToolList = Array.isArray(rootTools) ? rootTools : [];
+  const rootNames = new Set(
+    rootToolList
+      .map((tool) => {
+        const record = toRecord(tool);
+        return record.type === "namespace" ? "" : toolName(tool);
+      })
+      .filter(Boolean)
+  );
+  const sources: unknown[][] = [rootToolList];
 
   for (const itemValue of inputItems) {
     const item = toRecord(itemValue);
@@ -74,16 +83,21 @@ export function collectResponsesTools(rootTools: unknown, inputItems: unknown[])
       if (toolRecord.type === "namespace") {
         const namespaceName = toolName(tool);
         const existingIndex = namespaceName ? namespaceIndexes.get(namespaceName) : undefined;
+        const namespaceTools = Array.isArray(toolRecord.tools)
+          ? toolRecord.tools.filter((member) => !rootNames.has(toolName(member)))
+          : toolRecord.tools;
         if (existingIndex !== undefined) {
           const existing = toRecord(merged[existingIndex]);
           merged[existingIndex] = {
             ...toolRecord,
             ...existing,
-            tools: mergeNamespaceTools(existing.tools, toolRecord.tools),
+            tools: mergeNamespaceTools(existing.tools, namespaceTools),
           };
           continue;
         }
         if (namespaceName) namespaceIndexes.set(namespaceName, merged.length);
+        merged.push({ ...toolRecord, tools: namespaceTools });
+        continue;
       }
 
       const identity = toolIdentity(tool);

--- a/open-sse/translator/request/openai-responses/additionalTools.ts
+++ b/open-sse/translator/request/openai-responses/additionalTools.ts
@@ -106,5 +106,24 @@ export function collectResponsesTools(rootTools: unknown, inputItems: unknown[])
       merged.push(tool);
     }
   }
+
   return merged;
+}
+
+/** Return the custom/freeform tool names after applying the same precedence rules as conversion. */
+export function collectResponsesCustomToolNames(
+  rootTools: unknown,
+  inputItems: unknown[]
+): Set<string> {
+  const names = new Set<string>();
+  const visit = (tools: unknown[]) => {
+    for (const toolValue of tools) {
+      const tool = toRecord(toolValue);
+      const name = toolName(toolValue);
+      if (tool.type === "custom" && name) names.add(name);
+      if (tool.type === "namespace" && Array.isArray(tool.tools)) visit(tool.tools);
+    }
+  };
+  visit(collectResponsesTools(rootTools, inputItems));
+  return names;
 }

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -15,6 +15,7 @@ import {
   getVisibleResponsesReasoningSummaryText,
 } from "./openai-responses/pureHelpers.ts";
 import { createEventEmitter } from "./openai-responses/eventEmitter.ts";
+import { buildResponsesToolCallItem } from "./responsesToolItem.ts";
 import {
   synthesizeCompletedToolCalls,
   computeFinishReason,
@@ -428,6 +429,7 @@ function emitToolCall(state, emit, tc) {
     delete state.funcNames[tcIdx];
     delete state.funcArgsBuf[tcIdx];
     delete state.funcArgsDone[tcIdx];
+    delete state.funcItemAdded[tcIdx];
     delete state.funcItemDone[tcIdx];
   }
 
@@ -439,30 +441,26 @@ function emitToolCall(state, emit, tc) {
   const isCustomTool =
     toolName === "apply_patch" || state.customToolNames?.has?.(toolName) === true;
 
-  if (!state.funcCallIds[tcIdx] && newCallId) {
-    state.funcCallIds[tcIdx] = newCallId;
+  if (!state.funcCallIds[tcIdx] && newCallId) state.funcCallIds[tcIdx] = newCallId;
+  const callId = state.funcCallIds[tcIdx];
 
+  if (callId && toolName && !state.funcItemAdded[tcIdx]) {
     emit("response.output_item.added", {
       type: "response.output_item.added",
       output_index: outputIndex,
-      item: isCustomTool
-        ? {
-            id: `fc_${newCallId}`,
-            type: "custom_tool_call",
-            input: "",
-            call_id: newCallId,
-            name: state.funcNames[tcIdx] || "",
-            status: "in_progress",
-          }
-        : {
-            id: `fc_${newCallId}`,
-            type: "function_call",
-            arguments: "",
-            call_id: newCallId,
-            name: state.funcNames[tcIdx] || "",
-            status: "in_progress",
-          },
+      item: buildResponsesToolCallItem({ callId, toolName, custom: isCustomTool }),
     });
+    state.funcItemAdded[tcIdx] = true;
+
+    const bufferedArgs = state.funcArgsBuf[tcIdx] || "";
+    if (bufferedArgs && !isCustomTool) {
+      emit("response.function_call_arguments.delta", {
+        type: "response.function_call_arguments.delta",
+        item_id: `fc_${callId}`,
+        output_index: outputIndex,
+        delta: bufferedArgs,
+      });
+    }
   }
 
   if (!state.funcArgsBuf[tcIdx]) state.funcArgsBuf[tcIdx] = "";
@@ -475,7 +473,7 @@ function emitToolCall(state, emit, tc) {
     const emittedDelta = nextArgs.slice(existingArgs.length);
     state.funcArgsBuf[tcIdx] = nextArgs;
 
-    if (refCallId && emittedDelta && !isCustomTool) {
+    if (refCallId && emittedDelta && !isCustomTool && state.funcItemAdded[tcIdx]) {
       emit("response.function_call_arguments.delta", {
         type: "response.function_call_arguments.delta",
         item_id: `fc_${refCallId}`,

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -433,8 +433,7 @@ function emitToolCall(state, emit, tc) {
 
   if (funcName) state.funcNames[tcIdx] = funcName;
 
-  // Codex custom tools (apply_patch) are surfaced to the client as custom_tool_call items
-  // and stream their raw patch via custom_tool_call_input.* events instead of the
+  // Custom tools are surfaced as custom_tool_call items and stream raw input instead of the
   // function_call_arguments.* events used for regular function tools. (#1007)
   const toolName = state.funcNames[tcIdx] || funcName || "";
   const isCustomTool =

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -436,7 +436,9 @@ function emitToolCall(state, emit, tc) {
   // Codex custom tools (apply_patch) are surfaced to the client as custom_tool_call items
   // and stream their raw patch via custom_tool_call_input.* events instead of the
   // function_call_arguments.* events used for regular function tools. (#1007)
-  const isCustomTool = (state.funcNames[tcIdx] || funcName) === "apply_patch";
+  const toolName = state.funcNames[tcIdx] || funcName || "";
+  const isCustomTool =
+    toolName === "apply_patch" || state.customToolNames?.has?.(toolName) === true;
 
   if (!state.funcCallIds[tcIdx] && newCallId) {
     state.funcCallIds[tcIdx] = newCallId;
@@ -474,12 +476,9 @@ function emitToolCall(state, emit, tc) {
     const emittedDelta = nextArgs.slice(existingArgs.length);
     state.funcArgsBuf[tcIdx] = nextArgs;
 
-    if (refCallId && emittedDelta) {
-      const deltaEvent = isCustomTool
-        ? "response.custom_tool_call_input.delta"
-        : "response.function_call_arguments.delta";
-      emit(deltaEvent, {
-        type: deltaEvent,
+    if (refCallId && emittedDelta && !isCustomTool) {
+      emit("response.function_call_arguments.delta", {
+        type: "response.function_call_arguments.delta",
         item_id: `fc_${refCallId}`,
         output_index: outputIndex,
         delta: emittedDelta,
@@ -495,7 +494,9 @@ function closeToolCall(state, emit, idx, recordAsCompleted = true) {
       ? normalizeOutputIndex(state.reasoningIndex) + 1 + normalizeOutputIndex(idx)
       : normalizeOutputIndex(idx);
     const args = state.funcArgsBuf[idx] || "{}";
-    const isCustomTool = (state.funcNames[idx] || "") === "apply_patch";
+    const toolName = state.funcNames[idx] || "";
+    const isCustomTool =
+      toolName === "apply_patch" || state.customToolNames?.has?.(toolName) === true;
 
     let funcItem;
     if (isCustomTool) {
@@ -508,6 +509,13 @@ function closeToolCall(state, emit, idx, recordAsCompleted = true) {
       } catch {
         // Not JSON — fall back to the raw buffered arguments.
       }
+
+      emit("response.custom_tool_call_input.delta", {
+        type: "response.custom_tool_call_input.delta",
+        item_id: `fc_${callId}`,
+        output_index: normalizedIndex,
+        delta: rawInput,
+      });
 
       emit("response.custom_tool_call_input.done", {
         type: "response.custom_tool_call_input.done",

--- a/open-sse/translator/response/responsesToolItem.ts
+++ b/open-sse/translator/response/responsesToolItem.ts
@@ -1,0 +1,15 @@
+export function buildResponsesToolCallItem(options: {
+  callId: string;
+  toolName: string;
+  custom: boolean;
+}) {
+  const { callId, toolName, custom } = options;
+  return {
+    id: `fc_${callId}`,
+    type: custom ? "custom_tool_call" : "function_call",
+    ...(custom ? { input: "" } : { arguments: "" }),
+    call_id: callId,
+    name: toolName,
+    status: "in_progress",
+  };
+}

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -133,6 +133,7 @@ type StreamOptions = {
    * `RESPONSES_PASSTHROUGH_DROP_COMMENTARY` feature flag (default on).
    */
   dropResponsesCommentary?: boolean;
+  customToolNames?: ReadonlySet<string>;
   provider?: string | null;
   reqLogger?: StreamLogger | null;
   toolNameMap?: unknown;
@@ -159,6 +160,7 @@ type TranslateState = ReturnType<typeof initState> & {
   accumulatedReasoning?: string;
   /** #6951 — per-tool JSON Schema (from request `tools[]`), keyed by tool name. */
   toolSchemas?: Map<string, Record<string, unknown>> | null;
+  customToolNames?: ReadonlySet<string>;
   upstreamError?: {
     status: number;
     type: string;
@@ -631,6 +633,7 @@ export function createSSEStream(options: StreamOptions = {}) {
     onComplete = null,
     onFailure = null,
     dropResponsesCommentary,
+    customToolNames = new Set<string>(),
   } = options;
   const signatureNamespace = connectionId;
   // Request-body-size metric (for monitoring payload size distribution & correlation with TTFT).
@@ -705,6 +708,7 @@ export function createSSEStream(options: StreamOptions = {}) {
           accumulatedContent: "",
           accumulatedReasoning: "",
           toolSchemas: extractToolSchemaMap(body),
+          customToolNames,
         }
       : null;
 
@@ -2739,7 +2743,8 @@ export function createSSETransformStreamWithLogger(
   apiKeyInfo: unknown = null,
   onFailure: ((payload: StreamFailurePayload) => void | Promise<void>) | null = null,
   copilotCompatibleReasoning = false,
-  suppressThinkClose = false
+  suppressThinkClose = false,
+  customToolNames: ReadonlySet<string> = new Set()
 ) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
@@ -2756,6 +2761,7 @@ export function createSSETransformStreamWithLogger(
     onFailure,
     copilotCompatibleReasoning,
     suppressThinkClose,
+    customToolNames,
   });
 }
 

--- a/tests/unit/responses-active-stream-custom-tool.test.ts
+++ b/tests/unit/responses-active-stream-custom-tool.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-responses-stream-"));
+const { createSSETransformStreamWithLogger } = await import("../../open-sse/utils/stream.ts");
+
+test("active Responses stream restores declared custom tool metadata", async () => {
+  const source = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({
+            id: "chatcmpl_custom",
+            object: "chat.completion.chunk",
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call_exec",
+                      function: { name: "exec", arguments: '{"input":"text(\\"pong\\")"}' },
+                    },
+                  ],
+                },
+                finish_reason: "tool_calls",
+              },
+            ],
+          })}\n\n`
+        )
+      );
+      controller.close();
+    },
+  });
+  const transform = createSSETransformStreamWithLogger(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI_RESPONSES,
+    "opencode-go",
+    null,
+    null,
+    "kimi-k3",
+    null,
+    { messages: [{ role: "user", content: "run it" }] },
+    null,
+    null,
+    null,
+    false,
+    false,
+    new Set(["exec"])
+  );
+
+  const text = await new Response(source.pipeThrough(transform)).text();
+
+  assert.match(text, /"type":"custom_tool_call"/);
+  assert.match(text, /"input":"text\(\\"pong\\"\)"/);
+  assert.doesNotMatch(text, /"type":"function_call"/);
+});

--- a/tests/unit/responses-additional-tools.test.ts
+++ b/tests/unit/responses-additional-tools.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 const { openaiResponsesToOpenAIRequest } =
   await import("../../open-sse/translator/request/openai-responses.ts");
-const { collectResponsesCustomToolNames } =
+const { collectCustomToolNamesForSourceFormat, collectResponsesCustomToolNames } =
   await import("../../open-sse/translator/request/openai-responses/additionalTools.ts");
 
 interface ChatTool {
@@ -247,6 +247,83 @@ test("Responses custom metadata includes additional and namespaced custom tools"
     },
   ];
   assert.deepEqual([...collectResponsesCustomToolNames([], input)].sort(), ["apply_diff", "exec"]);
+});
+
+test("Responses source format enables custom metadata independently of model apiFormat", () => {
+  assert.deepEqual(
+    [
+      ...collectCustomToolNamesForSourceFormat(
+        "openai-responses",
+        "openai-responses",
+        [{ type: "custom", name: "exec" }],
+        []
+      ),
+    ],
+    ["exec"]
+  );
+  assert.deepEqual(
+    [
+      ...collectCustomToolNamesForSourceFormat(
+        "openai",
+        "openai-responses",
+        [{ type: "custom", name: "exec" }],
+        []
+      ),
+    ],
+    []
+  );
+});
+
+test("Responses -> Chat normalizes custom tools nested in namespaces", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "any-model",
+    {
+      input: [{ type: "message", role: "user", content: "go" }],
+      tools: [
+        {
+          type: "namespace",
+          name: "commands",
+          tools: [{ type: "custom", name: "exec", description: "Run code" }],
+        },
+      ],
+    },
+    false,
+    { provider: "another-provider" }
+  ) as ChatRequest;
+
+  assert.deepEqual(result.tools[0].function.parameters, {
+    type: "object",
+    properties: { input: { type: "string" } },
+    required: ["input"],
+    additionalProperties: false,
+  });
+});
+
+test("Responses -> Chat enforces explicit precedence within additional_tools", () => {
+  const input = [
+    {
+      type: "additional_tools",
+      tools: [
+        { type: "function", name: "exec", description: "Explicit function" },
+        {
+          type: "namespace",
+          name: "commands",
+          tools: [{ type: "custom", name: "exec", description: "Shadowed custom" }],
+        },
+      ],
+    },
+    { type: "message", role: "user", content: "go" },
+  ];
+  const result = openaiResponsesToOpenAIRequest("any-model", { input }, false, {
+    provider: "another-provider",
+  }) as ChatRequest;
+
+  assert.deepEqual(
+    result.tools.map((tool) => tool.function.name),
+    ["exec"]
+  );
+  assert.equal(result.tools[0].function.description, "Explicit function");
+  assert.deepEqual([...collectResponsesCustomToolNames([], input)], []);
 });
 
 test("Responses -> Chat validates tools supplied through additional_tools", () => {

--- a/tests/unit/responses-additional-tools.test.ts
+++ b/tests/unit/responses-additional-tools.test.ts
@@ -198,6 +198,31 @@ test("Responses -> Chat merges members from same-named namespaces", () => {
   );
 });
 
+test("Responses -> Chat gives top-level tools precedence over namespaced members", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "any-model",
+    {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "go" }] }],
+      tools: [
+        { type: "function", name: "exec", parameters: { type: "object" } },
+        {
+          type: "namespace",
+          name: "commands",
+          tools: [{ type: "custom", name: "exec", description: "Shadowed custom tool" }],
+        },
+      ],
+    },
+    false,
+    { provider: "another-provider" }
+  ) as ChatRequest;
+
+  assert.deepEqual(
+    result.tools.map((tool) => tool.function.name),
+    ["exec"]
+  );
+  assert.equal(result.tools[0].function.description, undefined);
+});
+
 test("Responses -> Chat validates tools supplied through additional_tools", () => {
   assert.throws(
     () =>

--- a/tests/unit/responses-additional-tools.test.ts
+++ b/tests/unit/responses-additional-tools.test.ts
@@ -204,7 +204,12 @@ test("Responses -> Chat gives top-level tools precedence over namespaced members
     {
       input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "go" }] }],
       tools: [
-        { type: "function", name: "exec", parameters: { type: "object" } },
+        {
+          type: "function",
+          name: "exec",
+          description: "Explicit function tool",
+          parameters: { type: "object" },
+        },
         {
           type: "namespace",
           name: "commands",
@@ -220,7 +225,7 @@ test("Responses -> Chat gives top-level tools precedence over namespaced members
     result.tools.map((tool) => tool.function.name),
     ["exec"]
   );
-  assert.equal(result.tools[0].function.description, undefined);
+  assert.equal(result.tools[0].function.description, "Explicit function tool");
 });
 
 test("Responses -> Chat validates tools supplied through additional_tools", () => {

--- a/tests/unit/responses-additional-tools.test.ts
+++ b/tests/unit/responses-additional-tools.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 const { openaiResponsesToOpenAIRequest } =
   await import("../../open-sse/translator/request/openai-responses.ts");
+const { collectResponsesCustomToolNames } =
+  await import("../../open-sse/translator/request/openai-responses/additionalTools.ts");
 
 interface ChatTool {
   function: {

--- a/tests/unit/responses-additional-tools.test.ts
+++ b/tests/unit/responses-additional-tools.test.ts
@@ -201,23 +201,24 @@ test("Responses -> Chat merges members from same-named namespaces", () => {
 });
 
 test("Responses -> Chat gives top-level tools precedence over namespaced members", () => {
+  const rootTools = [
+    {
+      type: "function",
+      name: "exec",
+      description: "Explicit function tool",
+      parameters: { type: "object" },
+    },
+    {
+      type: "namespace",
+      name: "commands",
+      tools: [{ type: "custom", name: "exec", description: "Shadowed custom tool" }],
+    },
+  ];
   const result = openaiResponsesToOpenAIRequest(
     "any-model",
     {
       input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "go" }] }],
-      tools: [
-        {
-          type: "function",
-          name: "exec",
-          description: "Explicit function tool",
-          parameters: { type: "object" },
-        },
-        {
-          type: "namespace",
-          name: "commands",
-          tools: [{ type: "custom", name: "exec", description: "Shadowed custom tool" }],
-        },
-      ],
+      tools: rootTools,
     },
     false,
     { provider: "another-provider" }
@@ -228,6 +229,24 @@ test("Responses -> Chat gives top-level tools precedence over namespaced members
     ["exec"]
   );
   assert.equal(result.tools[0].function.description, "Explicit function tool");
+  assert.deepEqual([...collectResponsesCustomToolNames(rootTools, [])], []);
+});
+
+test("Responses custom metadata includes additional and namespaced custom tools", () => {
+  const input = [
+    {
+      type: "additional_tools",
+      tools: [
+        { type: "custom", name: "exec" },
+        {
+          type: "namespace",
+          name: "server",
+          tools: [{ type: "custom", name: "apply_diff" }],
+        },
+      ],
+    },
+  ];
+  assert.deepEqual([...collectResponsesCustomToolNames([], input)].sort(), ["apply_diff", "exec"]);
 });
 
 test("Responses -> Chat validates tools supplied through additional_tools", () => {

--- a/tests/unit/responses-handler.test.ts
+++ b/tests/unit/responses-handler.test.ts
@@ -423,6 +423,27 @@ test("handleResponsesCore preserves top-level tool precedence for custom-name co
   assert.doesNotMatch(sse, /"type":"custom_tool_call"/);
 });
 
+test("handleResponsesCore restores custom tools nested in namespaces", async () => {
+  const { result } = await invokeResponsesCore({
+    body: {
+      model: "gpt-4o-mini",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] }],
+      tools: [
+        {
+          type: "namespace",
+          name: "commands",
+          tools: [{ type: "custom", name: "exec", description: "Execute freeform code" }],
+        },
+      ],
+    },
+    responseFactory: () => buildToolCallSseResponse("exec", '{"input":"pong"}'),
+  });
+
+  const sse = await result.response.text();
+  assert.match(sse, /"type":"custom_tool_call"/);
+  assert.doesNotMatch(sse, /"type":"function_call","arguments"/);
+});
+
 test("handleResponsesCore injects SSE keepalive frames for Responses streams", async (t) => {
   // PR #2233 changed the Responses-API heartbeat shape from a SSE comment
   // (`: keepalive ...`) to a `data: {"type":"response.in_progress"}` frame,

--- a/tests/unit/responses-handler.test.ts
+++ b/tests/unit/responses-handler.test.ts
@@ -92,6 +92,36 @@ function buildOpenAISseResponse(text = "hello") {
   );
 }
 
+function buildToolCallSseResponse(name: string, argumentsJson: string) {
+  return new Response(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-tool",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: { name, arguments: argumentsJson },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n"),
+    { status: 200, headers: { "Content-Type": "text/event-stream" } }
+  );
+}
+
 function buildJsonResponse(status: number, payload: unknown) {
   return new Response(JSON.stringify(payload), {
     status,
@@ -341,6 +371,56 @@ test("handleResponsesCore rejects invalid Responses API input that cannot be tra
     (error) =>
       error instanceof Error && error.message.includes("file_search tool type is not supported")
   );
+});
+
+test("handleResponsesCore restores custom tools declared through additional_tools", async () => {
+  const { result, call } = await invokeResponsesCore({
+    body: {
+      model: "gpt-4o-mini",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] },
+        {
+          type: "additional_tools",
+          tools: [{ type: "custom", name: "exec", description: "Execute freeform code" }],
+        },
+      ],
+    },
+    responseFactory: () => buildToolCallSseResponse("exec", '{"input":"text(\\"pong\\")"}'),
+  });
+
+  assert.equal(call.body.tools[0].type, "function");
+  const sse = await result.response.text();
+  assert.match(sse, /"type":"custom_tool_call"/);
+  assert.match(sse, /"input":"text\(\\"pong\\"\)"/);
+  assert.doesNotMatch(sse, /"type":"function_call","arguments"/);
+});
+
+test("handleResponsesCore preserves top-level tool precedence for custom-name collisions", async () => {
+  const { result } = await invokeResponsesCore({
+    body: {
+      model: "gpt-4o-mini",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] },
+        {
+          type: "additional_tools",
+          tools: [{ type: "custom", name: "exec", description: "Shadowed custom tool" }],
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "exec",
+          description: "Explicit function tool",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    },
+    responseFactory: () => buildToolCallSseResponse("exec", "{}"),
+  });
+
+  const sse = await result.response.text();
+  assert.match(sse, /"type":"function_call"/);
+  assert.doesNotMatch(sse, /"type":"custom_tool_call"/);
 });
 
 test("handleResponsesCore injects SSE keepalive frames for Responses streams", async (t) => {

--- a/tests/unit/responses-transformer.test.ts
+++ b/tests/unit/responses-transformer.test.ts
@@ -201,6 +201,23 @@ test("createResponsesApiTransformStream restores declared custom tools without c
   assert.equal(completed.output.find((item) => item.name === "search").arguments, '{"q":"pong"}');
 });
 
+test("createResponsesApiTransformStream preserves empty custom-tool input", async () => {
+  const output = await runTransformStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_empty","function":{"name":"exec","arguments":"{\\"input\\":\\"\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+    ],
+    null,
+    { customToolNames: new Set(["exec"]) }
+  );
+  const events = parseSseOutput(output);
+  const done = events
+    .filter((event) => event.event === "response.output_item.done")
+    .map((event) => JSON.parse(event.data).item)
+    .find((item) => item.name === "exec");
+  assert.equal(done.type, "custom_tool_call");
+  assert.equal(done.input, "");
+});
+
 test("createResponsesApiTransformStream defers custom item creation until the tool name arrives", async () => {
   const output = await runTransformStream(
     [

--- a/tests/unit/responses-transformer.test.ts
+++ b/tests/unit/responses-transformer.test.ts
@@ -10,8 +10,8 @@ const { createResponsesApiTransformStream, createResponsesLogger } =
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-async function runTransformStream(chunks, logger = null) {
-  const stream = createResponsesApiTransformStream(logger);
+async function runTransformStream(chunks, logger = null, options = {}) {
+  const stream = createResponsesApiTransformStream(logger, 3000, options);
   const writer = stream.writable.getWriter();
   const reader = stream.readable.getReader();
 
@@ -173,6 +173,32 @@ test("createResponsesApiTransformStream handles native reasoning content and too
       })),
     [{ id: "fc_call_2", call_id: "call_2", name: "lookup", arguments: "{}" }]
   );
+});
+
+test("createResponsesApiTransformStream restores declared custom tools without changing functions", async () => {
+  const output = await runTransformStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","function":{"name":"exec","arguments":"{\\"input\\":\\"text(\\\\\\"pong\\\\\\")\\"}"}}]}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_search","function":{"name":"search","arguments":"{\\"q\\":\\"pong\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+    ],
+    null,
+    { customToolNames: new Set(["exec"]) }
+  );
+
+  const events = parseSseOutput(output);
+  const added = events
+    .filter((event) => event.event === "response.output_item.added")
+    .map((event) => JSON.parse(event.data).item);
+  const completed = JSON.parse(
+    events.find((event) => event.event === "response.completed").data
+  ).response;
+
+  assert.equal(added.find((item) => item.name === "exec").type, "custom_tool_call");
+  assert.equal(added.find((item) => item.name === "search").type, "function_call");
+  assert.ok(events.some((event) => event.event === "response.custom_tool_call_input.delta"));
+  assert.ok(events.some((event) => event.event === "response.custom_tool_call_input.done"));
+  assert.equal(completed.output.find((item) => item.name === "exec").input, 'text("pong")');
+  assert.equal(completed.output.find((item) => item.name === "search").arguments, '{"q":"pong"}');
 });
 
 test("createResponsesLogger persists input and output event logs on flush", async () => {

--- a/tests/unit/responses-transformer.test.ts
+++ b/tests/unit/responses-transformer.test.ts
@@ -230,6 +230,37 @@ test("createResponsesApiTransformStream defers custom item creation until the to
   assert.equal(events.filter((event) => event.event === "response.output_item.done").length, 1);
 });
 
+test("createResponsesApiTransformStream replays buffered function arguments after the name arrives", async () => {
+  const output = await runTransformStream([
+    'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_search","function":{"arguments":"{\\"q\\":\\"pong\\"}"}}]}}]}\n\n',
+    'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"search"}}]},"finish_reason":"tool_calls"}]}\n\n',
+  ]);
+
+  const events = parseSseOutput(output);
+  const argumentDeltas = events
+    .filter((event) => event.event === "response.function_call_arguments.delta")
+    .map((event) => JSON.parse(event.data).delta);
+
+  assert.deepEqual(argumentDeltas, ['{"q":"pong"}']);
+});
+
+test("createResponsesApiTransformStream preserves empty custom-tool input", async () => {
+  const output = await runTransformStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","function":{"name":"exec","arguments":"{\\"input\\":\\"\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+    ],
+    null,
+    { customToolNames: new Set(["exec"]) }
+  );
+
+  const events = parseSseOutput(output);
+  const completed = JSON.parse(
+    events.find((event) => event.event === "response.completed").data
+  ).response;
+
+  assert.equal(completed.output.find((item) => item.name === "exec").input, "");
+});
+
 test("createResponsesLogger persists input and output event logs on flush", async () => {
   const logsDir = mkdtempSync(join(tmpdir(), "responses-transformer-"));
   const logger = createResponsesLogger("gpt-4o", logsDir);

--- a/tests/unit/responses-transformer.test.ts
+++ b/tests/unit/responses-transformer.test.ts
@@ -201,6 +201,35 @@ test("createResponsesApiTransformStream restores declared custom tools without c
   assert.equal(completed.output.find((item) => item.name === "search").arguments, '{"q":"pong"}');
 });
 
+test("createResponsesApiTransformStream defers custom item creation until the tool name arrives", async () => {
+  const output = await runTransformStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec"}]}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"exec","arguments":"{\\"input\\":\\"pong\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+    ],
+    null,
+    { customToolNames: new Set(["exec"]) }
+  );
+
+  const events = parseSseOutput(output);
+  const added = events
+    .filter((event) => event.event === "response.output_item.added")
+    .map((event) => JSON.parse(event.data).item)
+    .filter((item) => item.call_id === "call_exec");
+
+  assert.deepEqual(added, [
+    {
+      id: "fc_call_exec",
+      type: "custom_tool_call",
+      input: "",
+      call_id: "call_exec",
+      name: "exec",
+      status: "in_progress",
+    },
+  ]);
+  assert.equal(events.filter((event) => event.event === "response.output_item.done").length, 1);
+});
+
 test("createResponsesLogger persists input and output event logs on flush", async () => {
   const logsDir = mkdtempSync(join(tmpdir(), "responses-transformer-"));
   const logger = createResponsesLogger("gpt-4o", logsDir);

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -1957,52 +1957,6 @@ test("createSSETransformStreamWithLogger flushes Responses API terminal events o
   assert.doesNotMatch(text, /\[DONE\]/);
 });
 
-test("createSSETransformStreamWithLogger restores custom tool metadata on the active path", async () => {
-  const text = await readWithTransform(
-    [
-      `data: ${JSON.stringify({
-        id: "chatcmpl_custom",
-        object: "chat.completion.chunk",
-        choices: [
-          {
-            index: 0,
-            delta: {
-              tool_calls: [
-                {
-                  index: 0,
-                  id: "call_exec",
-                  function: { name: "exec", arguments: '{"input":"text(\\"pong\\")"}' },
-                },
-              ],
-            },
-            finish_reason: "tool_calls",
-          },
-        ],
-      })}\n\n`,
-    ],
-    createSSETransformStreamWithLogger(
-      FORMATS.OPENAI,
-      FORMATS.OPENAI_RESPONSES,
-      "opencode-go",
-      null,
-      null,
-      "kimi-k3",
-      null,
-      { messages: [{ role: "user", content: "run it" }] },
-      null,
-      null,
-      null,
-      false,
-      false,
-      new Set(["exec"])
-    )
-  );
-
-  assert.match(text, /"type":"custom_tool_call"/);
-  assert.match(text, /"input":"text\(\\"pong\\"\)"/);
-  assert.doesNotMatch(text, /"type":"function_call"/);
-});
-
 test("createPassthroughStreamWithLogger reuses passthrough mode helpers", async () => {
   const text = await readWithTransform(
     [

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -1957,6 +1957,52 @@ test("createSSETransformStreamWithLogger flushes Responses API terminal events o
   assert.doesNotMatch(text, /\[DONE\]/);
 });
 
+test("createSSETransformStreamWithLogger restores custom tool metadata on the active path", async () => {
+  const text = await readWithTransform(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_custom",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_exec",
+                  function: { name: "exec", arguments: '{"input":"text(\\"pong\\")"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      })}\n\n`,
+    ],
+    createSSETransformStreamWithLogger(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      "opencode-go",
+      null,
+      null,
+      "kimi-k3",
+      null,
+      { messages: [{ role: "user", content: "run it" }] },
+      null,
+      null,
+      null,
+      false,
+      false,
+      new Set(["exec"])
+    )
+  );
+
+  assert.match(text, /"type":"custom_tool_call"/);
+  assert.match(text, /"input":"text\(\\"pong\\"\)"/);
+  assert.doesNotMatch(text, /"type":"function_call"/);
+});
+
 test("createPassthroughStreamWithLogger reuses passthrough mode helpers", async () => {
   const text = await readWithTransform(
     [

--- a/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
+++ b/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
@@ -8,8 +8,9 @@ const { openaiToOpenAIResponsesResponse } =
 const { initState } = await import("../../open-sse/translator/index.ts");
 const { FORMATS } = await import("../../open-sse/translator/formats.ts");
 
-function collectEvents(chunks) {
+function collectEvents(chunks, customToolNames = new Set()) {
   const state = initState(FORMATS.OPENAI_RESPONSES);
+  state.customToolNames = customToolNames;
   const events = [];
   for (const chunk of chunks) {
     const result = openaiToOpenAIResponsesResponse(chunk, state);
@@ -163,4 +164,41 @@ test("OpenAI -> Responses: apply_patch streams as custom_tool_call with raw inpu
   const customItem = completed.data.response.output.find((o) => o.type === "custom_tool_call");
   assert.ok(customItem, "final snapshot should carry the custom_tool_call item");
   assert.equal(customItem.input, "PATCH_BODY");
+});
+
+test("OpenAI -> Responses: declared custom tools round-trip through the active translator", () => {
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-exec",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_exec",
+                  function: { name: "exec", arguments: '{"input":"text(\\"pong\\")"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+      null,
+    ],
+    new Set(["exec"])
+  );
+
+  const added = events.find((event) => event.event === "response.output_item.added");
+  const done = events.find(
+    (event) => event.event === "response.output_item.done" && event.data.item.name === "exec"
+  );
+  assert.equal(added.data.item.type, "custom_tool_call");
+  assert.equal(done.data.item.type, "custom_tool_call");
+  assert.equal(done.data.item.input, 'text("pong")');
+  assert.ok(events.some((event) => event.event === "response.custom_tool_call_input.delta"));
+  assert.ok(!events.some((event) => event.event === "response.function_call_arguments.delta"));
 });

--- a/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
+++ b/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
@@ -202,3 +202,45 @@ test("OpenAI -> Responses: declared custom tools round-trip through the active t
   assert.ok(events.some((event) => event.event === "response.custom_tool_call_input.delta"));
   assert.ok(!events.some((event) => event.event === "response.function_call_arguments.delta"));
 });
+
+test("OpenAI -> Responses: active translator defers custom item until its name arrives", () => {
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-late-name",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: "call_exec", function: { arguments: '{"input":"pong"}' } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-late-name",
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [{ index: 0, function: { name: "exec" } }] },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+      null,
+    ],
+    new Set(["exec"])
+  );
+
+  const added = events.filter((event) => event.event === "response.output_item.added");
+  assert.equal(added.length, 1);
+  assert.equal(added[0].data.item.type, "custom_tool_call");
+  assert.equal(added[0].data.item.name, "exec");
+  assert.ok(!events.some((event) => event.data?.item?.type === "function_call"));
+  const done = events.find(
+    (event) => event.event === "response.output_item.done" && event.data.item.name === "exec"
+  );
+  assert.equal(done.data.item.input, "pong");
+});


### PR DESCRIPTION
## Summary

- Restore custom tool call classification and input events in Responses API streams while preserving explicit function-tool precedence.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- Updated Responses API core and response-transformer automated tests.

## Coverage Notes

- Responses API tests cover custom tools declared through `additional_tools`, name collisions with top-level function tools, and mixed custom/function streaming output.
- No coverage regression information was provided.

## Reviewer Notes

- No migrations or feature flags are required.
- Verify custom-tool input events and final output items alongside regular function calls.