### PR TITLE
fix(sse): recover invalid Anthropic thinking signatures once

### DIFF
--- a/changelog.d/fixes/7906-anthropic-thinking-signature-recovery.md
+++ b/changelog.d/fixes/7906-anthropic-thinking-signature-recovery.md
@@ -1,0 +1,1 @@
+- **fix(sse):** Anthropic requests that reject a completed historical thinking signature now retry once with only that historical thinking omitted, while valid requests and active tool-use cycles remain unchanged. ([#7906](https://github.com/diegosouzapw/OmniRoute/pull/7906))

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -41,6 +41,7 @@ import {
   redactPassthroughThinkingSignatures,
   isClaudeCodeSemanticPassthroughRequest,
 } from "./chatCore/passthroughHelpers.ts";
+import { recoverAnthropicThinkingSignature } from "./chatCore/thinkingSignatureRecovery.ts";
 import {
   buildStreamingResponseHeaders,
   materializeDeduplicatedExecutionResult,
@@ -3391,7 +3392,7 @@ export async function handleChatCore({
   await persistCodexQuotaState(normalizeHeaders(providerResponse.headers), providerResponse.status);
 
   // Check provider response - return error info for fallback handling
-  if (!providerResponse.ok) {
+  providerFailure: if (!providerResponse.ok) {
     trackPendingRequest(model, provider, connectionId, false);
 
     let statusCode = providerResponse.status;
@@ -3413,6 +3414,45 @@ export async function handleChatCore({
       upstreamErrorCode = details.errorCode as string | undefined;
       upstreamErrorType = details.errorType as string | undefined;
     }
+
+    const signatureRecovery = await recoverAnthropicThinkingSignature({
+      provider,
+      statusCode,
+      message,
+      body: translatedBody,
+      execute: async (recoveryBody) => {
+        translatedBody = recoveryBody as typeof translatedBody;
+        return executeProviderRequest(currentModel, false);
+      },
+      parseError: (response) => parseUpstreamError(response, provider),
+    });
+    if (signatureRecovery.attempted && signatureRecovery.execution) {
+      providerResponse = signatureRecovery.execution.response;
+      if (signatureRecovery.succeeded) {
+        providerUrl = signatureRecovery.execution.url;
+        providerHeaders = signatureRecovery.execution.headers;
+        finalBody = providerRequestCapture.body(signatureRecovery.execution.transformedBody);
+        reqLogger.logTargetRequest(providerUrl, providerHeaders, finalBody);
+        updatePendingScope(pendingScope, {
+          providerRequest: finalBody,
+          providerUrl,
+          stage: "provider_response_started",
+        });
+        log?.info?.(
+          "THINKING_SIGNATURE",
+          `Recovered ${provider}/${currentModel} after one historical-thinking retry`
+        );
+      } else if (signatureRecovery.error) {
+        statusCode = signatureRecovery.error.statusCode;
+        message = signatureRecovery.error.message;
+        retryAfterMs = signatureRecovery.error.retryAfterMs;
+        upstreamErrorBody = signatureRecovery.error.responseBody;
+        upstreamErrorCode = signatureRecovery.error.errorCode as string | undefined;
+        upstreamErrorType = signatureRecovery.error.errorType as string | undefined;
+      }
+    }
+
+    if (signatureRecovery.succeeded) break providerFailure;
 
     // T06/T10/T36: classify provider errors and persist terminal account states.
     let errorType = classifyProviderError(statusCode, message, provider);

--- a/open-sse/handlers/chatCore/passthroughHelpers.ts
+++ b/open-sse/handlers/chatCore/passthroughHelpers.ts
@@ -52,6 +52,162 @@ export function redactPassthroughThinkingSignatures(
   return messages;
 }
 
+type MessageLike = {
+  role?: unknown;
+  content?: unknown;
+};
+
+type ThinkingSignatureError = {
+  provider?: string | null;
+  status?: number | null;
+  message?: string | null;
+};
+
+function isThinkingBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") return false;
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
+function hasBlock(message: MessageLike | null | undefined, type: string): boolean {
+  return (
+    !!message &&
+    Array.isArray(message.content) &&
+    message.content.some(
+      (block) => !!block && typeof block === "object" && (block as { type?: unknown }).type === type
+    )
+  );
+}
+
+/**
+ * Match only the Anthropic validation failure this recovery path understands.
+ * Generic 400s and the separate "latest assistant message cannot be modified"
+ * validation error must continue through the normal error path unchanged.
+ */
+export function isAnthropicThinkingSignatureError({
+  provider,
+  status,
+  message,
+}: ThinkingSignatureError): boolean {
+  const isAnthropicTarget =
+    provider === "claude" ||
+    (typeof provider === "string" && provider.startsWith("anthropic-compatible-"));
+  if (!isAnthropicTarget || status !== 400 || typeof message !== "string") return false;
+
+  return /invalid\s+[`'\"]?signature[`'\"]?\s+in\s+[`'\"]?thinking[`'\"]?\s+block/i.test(message);
+}
+
+/**
+ * Build a one-shot recovery body after Anthropic has explicitly rejected a
+ * thinking signature. Historical thinking blocks are omitted, but the complete
+ * active tool-use cycle is preserved verbatim: when the request ends in one or
+ * more `user[tool_result]` turns, every paired assistant `tool_use` turn in that
+ * still-open cycle keeps its thinking blocks. A trailing unresolved assistant
+ * `tool_use` turn is protected as well.
+ *
+ * This helper is intentionally NOT used eagerly. Normal same-model requests must
+ * retain their thinking history, cache shape, and current-model semantics.
+ * Returns the original body reference when no safe recovery change is possible.
+ */
+export function stripHistoricalThinkingForSignatureRecovery<T>(body: T): T {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+
+  const record = body as Record<string, unknown>;
+  if (!Array.isArray(record.messages)) return body;
+
+  const messages = record.messages as MessageLike[];
+  const protectedAssistantIndexes = new Set<number>();
+  let cursor = messages.length - 1;
+
+  // Some internal callers can resume from an unresolved assistant tool_use.
+  if (
+    cursor >= 0 &&
+    messages[cursor]?.role === "assistant" &&
+    hasBlock(messages[cursor], "tool_use")
+  ) {
+    protectedAssistantIndexes.add(cursor);
+    cursor -= 1;
+  }
+
+  // Walk the complete trailing tool-result chain. Interleaved thinking can span
+  // several assistant/tool_result pairs, so protecting only the latest assistant
+  // message is insufficient.
+  while (
+    cursor >= 0 &&
+    messages[cursor]?.role === "user" &&
+    hasBlock(messages[cursor], "tool_result")
+  ) {
+    cursor -= 1;
+    while (cursor >= 0 && messages[cursor]?.role !== "assistant") cursor -= 1;
+    if (cursor < 0 || !hasBlock(messages[cursor], "tool_use")) break;
+    protectedAssistantIndexes.add(cursor);
+    cursor -= 1;
+  }
+
+  let changed = false;
+  const recoveredMessages = messages.map((message, index) => {
+    if (
+      !message ||
+      message.role !== "assistant" ||
+      !Array.isArray(message.content) ||
+      protectedAssistantIndexes.has(index)
+    ) {
+      return message;
+    }
+
+    const content = message.content.filter((block) => !isThinkingBlock(block));
+    if (content.length === message.content.length) return message;
+    changed = true;
+    return { ...message, content };
+  });
+
+  if (!changed) return body;
+  return { ...record, messages: recoveredMessages } as T;
+}
+
+type SignatureRecoveryExecution<T> = {
+  result: T;
+  retried: boolean;
+  recoveryBody: unknown | null;
+};
+
+/** Execute the normal body once, then perform at most one exact-error recovery. */
+export async function executeWithAnthropicThinkingSignatureRecovery<T>(args: {
+  provider?: string | null;
+  body: unknown;
+  execute: (body: unknown) => Promise<T>;
+  getError: (
+    result: T
+  ) =>
+    | { status?: number | null; message?: string | null }
+    | null
+    | Promise<{ status?: number | null; message?: string | null } | null>;
+}): Promise<SignatureRecoveryExecution<T>> {
+  const first = await args.execute(args.body);
+  const failure = await args.getError(first);
+  if (
+    !failure ||
+    !isAnthropicThinkingSignatureError({
+      provider: args.provider,
+      status: failure.status,
+      message: failure.message,
+    })
+  ) {
+    return { result: first, retried: false, recoveryBody: null };
+  }
+
+  const recoveryBody = stripHistoricalThinkingForSignatureRecovery(args.body);
+  if (recoveryBody === args.body) {
+    return { result: first, retried: false, recoveryBody: null };
+  }
+
+  return {
+    result: await args.execute(recoveryBody),
+    retried: true,
+    recoveryBody,
+  };
+}
+
 export function isClaudeCodeSemanticPassthroughRequest({
   provider,
   sourceFormat,

--- a/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts
+++ b/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts
@@ -1,0 +1,97 @@
+import {
+  executeWithAnthropicThinkingSignatureRecovery,
+  isAnthropicThinkingSignatureError,
+} from "./passthroughHelpers.ts";
+
+type ProviderExecution = {
+  response: Response;
+  url?: string;
+  headers?: Headers | Record<string, string>;
+  transformedBody?: unknown;
+};
+
+type ParsedError = {
+  statusCode: number;
+  message: string;
+  retryAfterMs: number | null;
+  responseBody: unknown;
+  errorCode?: unknown;
+  errorType?: unknown;
+};
+
+export type ThinkingSignatureRecoveryResult = {
+  attempted: boolean;
+  succeeded: boolean;
+  execution: ProviderExecution | null;
+  error: ParsedError | null;
+  recoveryBody: unknown | null;
+};
+
+/**
+ * Retry exactly once after Anthropic's explicit thinking-signature validation
+ * error. The caller keeps all connection/provider resilience state untouched
+ * until this request-scoped recovery has finished.
+ */
+export async function recoverAnthropicThinkingSignature(args: {
+  provider?: string | null;
+  statusCode: number;
+  message: string;
+  body: unknown;
+  execute: (body: unknown) => Promise<ProviderExecution>;
+  parseError: (response: Response) => Promise<ParsedError>;
+}): Promise<ThinkingSignatureRecoveryResult> {
+  if (
+    !isAnthropicThinkingSignatureError({
+      provider: args.provider,
+      status: args.statusCode,
+      message: args.message,
+    })
+  ) {
+    return {
+      attempted: false,
+      succeeded: false,
+      execution: null,
+      error: null,
+      recoveryBody: null,
+    };
+  }
+
+  const firstFailure = {
+    response: new Response(null, { status: args.statusCode }),
+    status: args.statusCode,
+    message: args.message,
+  };
+  const recovery = await executeWithAnthropicThinkingSignatureRecovery({
+    provider: args.provider,
+    body: args.body,
+    execute: async (requestBody) => {
+      if (requestBody === args.body) return firstFailure;
+      return args.execute(requestBody);
+    },
+    getError: async (result) => {
+      if (result === firstFailure) return { status: result.status, message: result.message };
+      if (result.response.ok) return null;
+      const details = await args.parseError(result.response.clone());
+      return { status: details.statusCode, message: details.message };
+    },
+  });
+
+  if (!recovery.retried) {
+    return {
+      attempted: false,
+      succeeded: false,
+      execution: null,
+      error: null,
+      recoveryBody: null,
+    };
+  }
+
+  const execution = recovery.result as ProviderExecution;
+  return {
+    attempted: true,
+    succeeded: execution.response.ok,
+    execution,
+    error: execution.response.ok ? null : await args.parseError(execution.response),
+    recoveryBody: recovery.recoveryBody,
+  };
+}

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -48,6 +48,7 @@
       "tests/unit/account-fallback-route-restriction-403.test.ts",
       "tests/unit/account-fallback-service.test.ts",
       "tests/unit/accountfallback-ratelimit-400-4976.test.ts",
+      "tests/unit/anthropic-thinking-signature-recovery.test.ts",
       "tests/unit/antigravity-429-quota-tdd.test.ts",
       "tests/unit/api-key-rotator-health.test.ts",
       "tests/unit/appearance-widget-settings-schema.test.ts",

--- a/tests/unit/anthropic-thinking-signature-recovery.test.ts
+++ b/tests/unit/anthropic-thinking-signature-recovery.test.ts
@@ -1,0 +1,299 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  executeWithAnthropicThinkingSignatureRecovery,
+  isAnthropicThinkingSignatureError,
+  stripHistoricalThinkingForSignatureRecovery,
+} = await import("@omniroute/open-sse/handlers/chatCore/passthroughHelpers.ts");
+const { recoverAnthropicThinkingSignature } = await import(
+  "@omniroute/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts"
+);
+
+function makeHistory() {
+  return {
+    model: "claude-opus-4-8",
+    system: [{ type: "text", text: "system", cache_control: { type: "ephemeral", ttl: "5m" } }],
+    messages: [
+      { role: "user", content: [{ type: "text", text: "start" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "old", signature: "FOREIGN" },
+          { type: "text", text: "old answer", cache_control: { type: "ephemeral" } },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "run tools" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "active 1", signature: "ACTIVE_1" },
+          { type: "tool_use", id: "toolu_1", name: "Read", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "one" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "active 2", signature: "ACTIVE_2" },
+          { type: "tool_use", id: "toolu_2", name: "Bash", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "two" }],
+      },
+    ],
+    tools: [
+      {
+        name: "Read",
+        input_schema: { type: "object" },
+        cache_control: { type: "ephemeral", ttl: "30m" },
+      },
+    ],
+  };
+}
+
+test("Anthropic thinking-signature recovery contract", async (t) => {
+  await t.test("matches only the exact Anthropic thinking-signature 400", () => {
+    assert.equal(
+      isAnthropicThinkingSignatureError({
+        provider: "claude",
+        status: 400,
+        message: "messages.5.content.0: Invalid `signature` in `thinking` block",
+      }),
+      true
+    );
+    assert.equal(
+      isAnthropicThinkingSignatureError({
+        provider: "openrouter",
+        status: 400,
+        message: "Invalid signature in thinking block",
+      }),
+      false
+    );
+    assert.equal(
+      isAnthropicThinkingSignatureError({
+        provider: "claude",
+        status: 400,
+        message: "thinking blocks in the latest assistant message cannot be modified",
+      }),
+      false
+    );
+    assert.equal(
+      isAnthropicThinkingSignatureError({
+        provider: "claude",
+        status: 429,
+        message: "Invalid signature in thinking block",
+      }),
+      false
+    );
+  });
+
+  await t.test("chatCore wrapper skips unrelated errors", async () => {
+    let executions = 0;
+    let parses = 0;
+    const out = await recoverAnthropicThinkingSignature({
+      provider: "claude",
+      statusCode: 429,
+      message: "rate limited",
+      body: makeHistory(),
+      execute: async () => {
+        executions += 1;
+        return { response: new Response(null, { status: 200 }) };
+      },
+      parseError: async () => {
+        parses += 1;
+        throw new Error("must not parse an unrelated response");
+      },
+    });
+
+    assert.equal(out.attempted, false);
+    assert.equal(out.succeeded, false);
+    assert.equal(executions, 0);
+    assert.equal(parses, 0);
+  });
+
+  await t.test("chatCore wrapper returns a successful one-shot recovery", async () => {
+    const body = makeHistory();
+    let executions = 0;
+    const out = await recoverAnthropicThinkingSignature({
+      provider: "claude",
+      statusCode: 400,
+      message: "messages.1.content.0: Invalid `signature` in `thinking` block",
+      body,
+      execute: async (recoveryBody) => {
+        executions += 1;
+        assert.notEqual(recoveryBody, body);
+        return {
+          response: new Response(JSON.stringify({ type: "message" }), { status: 200 }),
+          url: "https://api.anthropic.com/v1/messages",
+          transformedBody: recoveryBody,
+        };
+      },
+      parseError: async () => {
+        throw new Error("successful recovery must not be parsed as an error");
+      },
+    });
+
+    assert.equal(out.attempted, true);
+    assert.equal(out.succeeded, true);
+    assert.equal(executions, 1);
+    assert.equal(out.execution?.response.status, 200);
+    assert.equal(out.error, null);
+    assert.notEqual(out.recoveryBody, body);
+  });
+
+  await t.test("chatCore wrapper parses a failed recovery once", async () => {
+    let parses = 0;
+    const out = await recoverAnthropicThinkingSignature({
+      provider: "claude",
+      statusCode: 400,
+      message: "Invalid signature in thinking block",
+      body: makeHistory(),
+      execute: async () => ({
+        response: new Response(JSON.stringify({ error: { message: "still invalid" } }), {
+          status: 400,
+        }),
+      }),
+      parseError: async (response) => {
+        parses += 1;
+        return {
+          statusCode: response.status,
+          message: "still invalid",
+          retryAfterMs: null,
+          responseBody: await response.json(),
+        };
+      },
+    });
+
+    assert.equal(out.attempted, true);
+    assert.equal(out.succeeded, false);
+    assert.equal(out.error?.statusCode, 400);
+    assert.equal(parses, 1, "parse the terminal recovery response exactly once");
+  });
+
+  await t.test("normal same-model traffic is byte-identical and never retried", async () => {
+    const body = makeHistory();
+    const snapshot = JSON.stringify(body);
+    const calls: unknown[] = [];
+
+    const out = await executeWithAnthropicThinkingSignatureRecovery({
+      provider: "claude",
+      body,
+      execute: async (requestBody) => {
+        calls.push(requestBody);
+        return { status: 200, message: "ok" };
+      },
+      getError: (result) => (result.status >= 400 ? result : null),
+    });
+
+    assert.equal(out.retried, false);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0], body, "normal path must pass the original body reference");
+    assert.equal(
+      JSON.stringify(calls[0]),
+      snapshot,
+      "normal payload and cache shape must not change"
+    );
+    assert.equal(JSON.stringify(body), snapshot, "input must not be mutated");
+  });
+
+  await t.test(
+    "exact signature 400 retries once and preserves the complete active tool-use cycle",
+    async () => {
+      const body = makeHistory();
+      const snapshot = structuredClone(body);
+      const calls: Array<ReturnType<typeof makeHistory>> = [];
+
+      const out = await executeWithAnthropicThinkingSignatureRecovery({
+        provider: "claude",
+        body,
+        execute: async (requestBody) => {
+          calls.push(requestBody as ReturnType<typeof makeHistory>);
+          return calls.length === 1
+            ? { status: 400, message: "Invalid signature in thinking block" }
+            : { status: 200, message: "ok" };
+        },
+        getError: (result) => (result.status >= 400 ? result : null),
+      });
+
+      assert.equal(out.retried, true);
+      assert.equal(calls.length, 2, "recovery is bounded to one retry");
+      assert.equal(calls[0], body);
+      assert.notEqual(calls[1], body);
+      assert.deepEqual(body, snapshot, "recovery must not mutate the caller body");
+
+      assert.deepEqual(
+        calls[1].messages[1].content.map((block: { type: string }) => block.type),
+        ["text"],
+        "completed-turn thinking is omitted"
+      );
+      assert.deepEqual(
+        calls[1].messages[3].content,
+        body.messages[3].content,
+        "first assistant/tool_result pair in the active cycle stays verbatim"
+      );
+      assert.deepEqual(
+        calls[1].messages[5].content,
+        body.messages[5].content,
+        "interleaved assistant/tool_result pair stays verbatim"
+      );
+      assert.deepEqual(calls[1].system, body.system, "system cache markers stay unchanged");
+      assert.deepEqual(calls[1].tools, body.tools, "tool cache markers stay unchanged");
+    }
+  );
+
+  await t.test("a repeated signature failure still performs only one retry", async () => {
+    let attempts = 0;
+    const out = await executeWithAnthropicThinkingSignatureRecovery({
+      provider: "anthropic-compatible-test",
+      body: makeHistory(),
+      execute: async () => {
+        attempts += 1;
+        return { status: 400, message: "Invalid signature in thinking block" };
+      },
+      getError: (result) => result,
+    });
+
+    assert.equal(out.retried, true);
+    assert.equal(out.result.status, 400);
+    assert.equal(attempts, 2);
+  });
+
+  await t.test("unsafe recovery with only active-cycle thinking sends no retry", async () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "run" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "required", signature: "ACTIVE" },
+            { type: "tool_use", id: "toolu_1", name: "Bash", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "ok" }],
+        },
+      ],
+    };
+    let attempts = 0;
+    const out = await executeWithAnthropicThinkingSignatureRecovery({
+      provider: "claude",
+      body,
+      execute: async () => {
+        attempts += 1;
+        return { status: 400, message: "Invalid signature in thinking block" };
+      },
+      getError: (result) => result,
+    });
+
+    assert.equal(out.retried, false);
+    assert.equal(attempts, 1);
+    assert.equal(stripHistoricalThinkingForSignatureRecovery(body), body);
+  });
+});


### PR DESCRIPTION
## Related issue

Fixes https://github.com/diegosouzapw/OmniRoute/issues/7899

## Summary

Anthropic can reject a historical extended-thinking block with `400 Invalid signature in thinking block`. This change performs a bounded recovery after that exact validation failure instead of removing thinking eagerly from every request.

- sends normal requests unchanged;
- matches only the exact Anthropic signature-validation 400;
- removes thinking only from completed historical assistant turns;
- retries at most once;
- preserves the complete active tool-use cycle;
- completes recovery before connection cooldown and provider-breaker accounting.

## Why recovery is conditional

Eager removal changes valid same-model requests, alters prompt-cache shape, and can modify Claude Code tool-use history unnecessarily. This patch leaves valid traffic untouched and changes the request only after Anthropic explicitly rejects a signature.

A trailing active cycle can contain several interleaved `assistant[thinking, tool_use]` → `user[tool_result]` pairs. Those assistant turns are preserved verbatim. If no completed historical thinking can be removed safely, no recovery retry is sent.

Recovery is not triggered for:

- generic 400 responses;
- 429 responses;
- non-Anthropic providers;
- Anthropic's separate "thinking blocks in the latest assistant message cannot be modified" error.

If the recovery attempt fails, the response continues through the normal error-classification path without another recovery attempt.

## Tests

- `node --import tsx/esm --test tests/unit/anthropic-thinking-signature-recovery.test.ts tests/unit/claude-passthrough-thinking-2454.test.ts`
- `node --import tsx/esm --test tests/unit/chatcore-translation-paths.test.ts`
- `npm run typecheck:core`
- `npm run lint`
