### PR TITLE
fix(dashboard): preserve quota cutoff drafts during refresh

### DIFF
--- a/changelog.d/fixes/7889-quota-cutoff-drafts.md
+++ b/changelog.d/fixes/7889-quota-cutoff-drafts.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** Provider Quota cutoff inputs preserve unsaved values across quota refreshes instead of reverting while the operator is typing ([#7889](https://github.com/diegosouzapw/OmniRoute/issues/7889)).

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCutoffModal.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCutoffModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import Modal from "@/shared/components/Modal";
 import Button from "@/shared/components/Button";
@@ -16,6 +16,8 @@ export interface QuotaCutoffModalWindow {
 interface QuotaCutoffModalProps {
   isOpen: boolean;
   onClose: () => void;
+  /** Stable identity used to distinguish refreshes from connection changes. */
+  connectionId: string;
   /** Label shown in the modal title. */
   connectionName: string;
   /** Used in the modal title for context (e.g. "(codex)"). */
@@ -44,6 +46,7 @@ interface QuotaCutoffModalProps {
 export default function QuotaCutoffModal({
   isOpen,
   onClose,
+  connectionId,
   connectionName,
   provider,
   windows,
@@ -59,10 +62,17 @@ export default function QuotaCutoffModal({
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const wasOpenRef = useRef(false);
+  const seededConnectionIdRef = useRef<string | null>(null);
 
   // Reset drafts whenever the modal opens against a new connection.
   useEffect(() => {
-    if (!isOpen) return;
+    const shouldSeed =
+      isOpen && (!wasOpenRef.current || seededConnectionIdRef.current !== connectionId);
+    wasOpenRef.current = isOpen;
+    if (!shouldSeed) return;
+
+    seededConnectionIdRef.current = connectionId;
     const initial: Record<string, string> = {};
     for (const w of windows) {
       const persisted = current?.[w.key];
@@ -70,7 +80,7 @@ export default function QuotaCutoffModal({
     }
     setDrafts(initial);
     setError(null);
-  }, [isOpen, windows, current]);
+  }, [isOpen, connectionId, windows, current]);
 
   const resolveDefaultFor = (windowKey: string): number =>
     typeof providerDefaults[windowKey] === "number"

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
@@ -1069,6 +1069,7 @@ export default function ProviderLimits({
             setCutoffModalConn(null);
             setCutoffModalWindows([]);
           }}
+          connectionId={cutoffModalConn.id}
           connectionName={
             pickDisplayValue(
               [cutoffModalConn.name, cutoffModalConn.displayName, cutoffModalConn.email],

--- a/tests/unit/ui/quota-cutoff-modal-draft-reset-7889.test.tsx
+++ b/tests/unit/ui/quota-cutoff-modal-draft-reset-7889.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/**
+ * Regression guard for #7889: quota polling recreates `windows` and `current`
+ * while the cutoff modal is open. Those identity-only prop changes must not
+ * overwrite an operator's unsaved input; opening another connection still
+ * seeds that connection's persisted values.
+ */
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const { default: QuotaCutoffModal } =
+  await import("../../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCutoffModal");
+
+const cleanupCallbacks: Array<() => void> = [];
+
+function props(connectionId: string, persisted: number) {
+  return {
+    isOpen: true,
+    onClose: () => {},
+    connectionId,
+    connectionName: connectionId,
+    provider: "codex",
+    windows: [{ key: "session", displayName: "Session" }],
+    current: { session: persisted },
+    providerDefaults: { session: 2 },
+    globalDefaultPercent: 2,
+    onSave: async () => {},
+  };
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  while (cleanupCallbacks.length) cleanupCallbacks.pop()!();
+});
+
+describe("QuotaCutoffModal draft lifetime (#7889)", () => {
+  it("preserves an unsaved draft across same-connection prop refreshes and resets for a new connection", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    cleanupCallbacks.push(() => {
+      act(() => root.unmount());
+      container.remove();
+    });
+
+    await act(async () => {
+      root.render(<QuotaCutoffModal {...props("connection-a", 2)} />);
+    });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="number"]')!;
+    expect(input.value).toBe("2");
+    setInputValue(input, "10");
+    expect(input.value).toBe("10");
+
+    // Quota polling reconstructs both objects without changing the active connection.
+    await act(async () => {
+      root.render(<QuotaCutoffModal {...props("connection-a", 2)} />);
+    });
+    expect(input.value).toBe("10");
+
+    // Switching the same mounted modal to another connection must seed its persisted value.
+    await act(async () => {
+      root.render(<QuotaCutoffModal {...props("connection-b", 7)} />);
+    });
+    expect(input.value).toBe("7");
+  });
+});


### PR DESCRIPTION
## Summary

- preserve unsaved Provider Quota cutoff values when live quota polling recreates modal props
- re-seed cutoff drafts only when the modal opens or targets a different connection
- add a focused component regression and changelog fragment

## Problem

The cutoff modal seeded local draft state from `windows` and `current` inside an effect that depended on both object references. Provider quota refreshes recreate those values, so an unrelated parent render reran the effect and replaced an operator's in-progress input with the persisted value or an empty string.

## Related Issues

- Closes #7889

## Dev Design

`QuotaCutoffModal` now receives the stable connection ID and tracks the previous open state and seeded connection. The effect keeps complete React dependencies, but only writes draft state on an open transition or connection-ID change. Save, reset, validation, provider defaults, persistence, and quota selection are unchanged.

Alternatives considered were memoizing the parent props, which would leave the modal coupled to parent allocation behavior, and dropping effect dependencies, which would risk stale seed values.

## Validation

- [x] Base RED: focused regression failed because a same-connection refresh changed the edited value from `10` back to `2`
- [x] `npx vitest run --config vitest.config.ts tests/unit/ui/quota-cutoff-modal-draft-reset-7889.test.tsx` — 1 passed
- [x] Focused quota UI matrix — 12 passed
- [x] `npm run test:vitest:ui` — 960 passed; 3 unrelated `burn-rate-chart` failures reproduced unchanged on the base revision
- [x] focused ESLint on the two production files and regression test
- [x] `npm run typecheck:core`
- [x] `npm run check:dashboard-typecheck` — within the frozen baseline
- [x] `npm run check:file-size`
- [x] `npm run check:complexity`
- [x] `npm run check:changelog-integrity`
- [x] `npm run check:test-discovery`
- [ ] `npm run test:coverage` — not run locally; remote CI owns the full coverage gate

## Tests Added Or Updated

- `tests/unit/ui/quota-cutoff-modal-draft-reset-7889.test.tsx`
  - retains an unsaved value across same-connection prop refreshes
  - loads persisted values when the active connection changes

## Coverage Notes

The regression exercises the state-lifetime branch added by this change. No production path is left without focused coverage.

## Reviewer Notes

This is limited to modal draft initialization. It does not change API payloads, persisted cutoff values, or routing behavior.
