### PR TITLE
fix(providers): treat public-host 302 as valid in Gemini Web connection test (#7859)

### DIFF
--- a/changelog.d/fixes/7859-gemini-web-redirect.md
+++ b/changelog.d/fixes/7859-gemini-web-redirect.md
@@ -1,0 +1,1 @@
+- fix(providers): Gemini Web connection test now accepts the expected 302 redirect instead of failing with 'Redirect blocked' (#7859)

--- a/src/lib/providers/validation/webProvidersB.ts
+++ b/src/lib/providers/validation/webProvidersB.ts
@@ -3,7 +3,13 @@
 // decomposition) — top-level functions with no dispatcher-state captures; behavior is byte-identical
 // to the inline defs.
 import { applyCustomUserAgent } from "./headers";
-import { toValidationErrorResult, validationRead, validationWrite } from "./transport";
+import {
+  isSecurityBlockError,
+  toValidationErrorResult,
+  validationRead,
+  validationWrite,
+} from "./transport";
+import { SafeOutboundFetchError } from "@/shared/network/safeOutboundFetch";
 import { normalizeSessionCookieHeader } from "@/lib/providers/webCookieAuth";
 import { buildJulesApiUrl } from "@/lib/cloudAgent/julesApi.ts";
 import {
@@ -234,6 +240,21 @@ export async function validateGeminiWebProvider({ apiKey, providerSpecificData =
 
     return { valid: false, error: `Gemini validation failed (${response.status})` };
   } catch (error: any) {
+    // #7859: gemini.google.com/app answers EVERY session probe (valid or not) with a
+    // 302 redirect (typically onward to accounts.google.com). validationRead() uses the
+    // no-redirect preset, so safeOutboundFetch throws REDIRECT_BLOCKED before the
+    // "200/302 = valid" status check above ever runs. A redirect to a PUBLIC host means
+    // the redirect was never followed (no SSRF) and is exactly what a valid Gemini
+    // session looks like here, so treat it as success. A redirect to a private/internal
+    // host is a genuine SSRF signal and must stay invalid — isSecurityBlockError()
+    // already makes that distinction.
+    if (
+      error instanceof SafeOutboundFetchError &&
+      error.code === "REDIRECT_BLOCKED" &&
+      !isSecurityBlockError(error)
+    ) {
+      return { valid: true, error: null };
+    }
     return toValidationErrorResult(error);
   }
 }

--- a/tests/unit/issue-7859-gemini-web-redirect-valid.test.ts
+++ b/tests/unit/issue-7859-gemini-web-redirect-valid.test.ts
@@ -1,0 +1,66 @@
+// #7859: adding a token to "Gemini Web (Free)" always failed the connection test with
+// "Redirect blocked for GET https://gemini.google.com/app (302)". Root cause:
+// validateGeminiWebProvider() probes https://gemini.google.com/app via validationRead(),
+// which uses the `validationRead` safeOutboundFetch preset (allowRedirect: false). Gemini
+// Web responds with a 302 to a public host (e.g. accounts.google.com) for EVERY session —
+// valid or not — so safeOutboundFetch always throws SafeOutboundFetchError with code
+// REDIRECT_BLOCKED *before* the "200/302 = valid" status check the function's own comment
+// describes ever runs. The throw fell through to the generic catch → toValidationErrorResult(),
+// which always returned `valid: false`, making the provider permanently unusable.
+//
+// Fix: catch REDIRECT_BLOCKED explicitly and treat a redirect to a PUBLIC host as success
+// (the session probe reached Gemini and got redirected onward — that is what a valid
+// session looks like). A redirect to a PRIVATE/internal host must still be rejected — that
+// would be a genuine SSRF signal, not a valid Gemini session.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { validateGeminiWebProvider } = await import(
+  "../../src/lib/providers/validation/webProvidersB.ts"
+);
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("gemini-web validator: 302 redirect to a PUBLIC host → valid (regression #7859)", async () => {
+  globalThis.fetch = async (url) => {
+    const target = String(url);
+    if (target.includes("gemini.google.com/app")) {
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://accounts.google.com/ServiceLogin" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${target}`);
+  };
+
+  const result = await validateGeminiWebProvider({
+    apiKey: "__Secure-1PSID=eyJvalidsession",
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(result.error, null);
+});
+
+test("gemini-web validator: 302 redirect to a PRIVATE host stays invalid (no SSRF)", async () => {
+  globalThis.fetch = async (url) => {
+    const target = String(url);
+    if (target.includes("gemini.google.com/app")) {
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data/" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${target}`);
+  };
+
+  const result = await validateGeminiWebProvider({
+    apiKey: "__Secure-1PSID=eyJvalidsession",
+  });
+
+  assert.equal(result.valid, false);
+  assert.equal((result as { securityBlocked?: boolean }).securityBlocked, true);
+});


### PR DESCRIPTION
Closes #7859

## Root cause

`validateGeminiWebProvider()` (`src/lib/providers/validation/webProvidersB.ts`) probes
`https://gemini.google.com/app` via `validationRead()`, which is the no-redirect
`validationRead` preset (`allowRedirect: false`). Gemini Web answers **every** session
probe — valid or expired — with a 302 (typically onward to `accounts.google.com`), so
`safeOutboundFetch` always threw `SafeOutboundFetchError` with code `REDIRECT_BLOCKED`
*before* the function's own `// 200/302 = valid` status check ever ran. The throw fell
into the generic `catch → toValidationErrorResult(error)`, which always returned
`valid: false` with `"Redirect blocked for GET https://gemini.google.com/app (302)"`,
making Gemini Web (Free) permanently unusable for every token.

## Fix

Catch `SafeOutboundFetchError` with `code === "REDIRECT_BLOCKED"` explicitly in
`validateGeminiWebProvider` and, when the redirect target is a **public** host (reusing
the existing `isSecurityBlockError()` from `transport.ts`, which already distinguishes
public vs. private/internal redirect targets), return `{ valid: true, error: null }`. A
redirect to a **private/internal** host still falls through to
`toValidationErrorResult()`, preserving `securityBlocked: true` and `valid: false` — no
SSRF regression. 401/403 (invalid cookie) and `>= 500` (unavailable) behavior is
unchanged.

This reuses the transport-layer `isSecurityBlockError()` helper already proven correct
for the qwen-web #3288/#3758 case — **not** `toWebCookieValidationErrorResult()`, which
maps `REDIRECT_BLOCKED` to `"unsupported"` and is scoped to `lmarena` (#7542); here a
302 is success, not "unsupported".

## Tests (TDD, Hard Rule #18)

New file `tests/unit/issue-7859-gemini-web-redirect-valid.test.ts`:

1. **RED → GREEN**: mocked `gemini.google.com/app` responding 302 with
   `location: https://accounts.google.com/ServiceLogin` → `validateGeminiWebProvider()`
   now returns `{ valid: true, error: null }` (previously `valid: false`).
2. **SSRF regression guard**: mocked 302 with
   `location: http://169.254.169.254/latest/meta-data/` (private/link-local host) →
   stays `valid: false` with `securityBlocked: true`.

Confirmed RED on the unmodified branch (`false !== true` on the public-redirect case)
before applying the fix.

## Gates

- `node --import tsx/esm --test tests/unit/issue-7859-gemini-web-redirect-valid.test.ts` — 2/2 pass
- `node --import tsx/esm --test tests/unit/provider-validation-specialty.test.ts tests/unit/validation-web-providers-split.test.ts tests/unit/provider-models-qwen-web-redirect-6267.test.ts tests/unit/safe-outbound-fetch.test.ts` — 131/131 pass (no regressions in the shared `validationRead` transport used by t3-web, claude-web, etc.)
- `node scripts/check/check-file-size.mjs` — clean on touched files
- `npx eslint --no-config-lookup --config eslint.complexity.config.mjs` / `eslint.sonarjs.config.mjs` — the 2 flagged pre-existing violations (`extractM365CredentialParts`, `validateInnerAiProvider`) are unchanged from base (verified by diffing against `origin/release/v3.8.49`'s copy of the file) — no new/regressed violations
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files — exit 0