### PR TITLE
fix(providers): read reasoning_text in Claude-format response translator (#7856)

### DIFF
--- a/changelog.d/fixes/7856-copilot-reasoning-text.md
+++ b/changelog.d/fixes/7856-copilot-reasoning-text.md
@@ -1,0 +1,1 @@
+- fix(providers): Copilot reasoning_text now surfaces in Claude-format non-stream responses, fixing spurious 502s (#7856)

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -5,6 +5,7 @@ import {
 } from "../services/geminiThoughtSignatureStore.ts";
 import { normalizeOpenAICompatibleFinishReasonString } from "../utils/finishReason.ts";
 import { containsTextualToolCallMarker } from "../utils/textualToolCall.ts";
+import { getAnyReasoningValue } from "../utils/reasoningFields.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -576,27 +577,15 @@ export function translateNonStreamingResponse(
 
 /**
  * Resolve reasoning/thinking text off a non-streaming OpenAI-format message object.
- * Checks DeepSeek-style `reasoning_content`, then the OpenRouter/StepFun aliases
- * `reasoning` and `reasoning_details[]` (array of { text | content }), mirroring the
- * streaming translator's fallback chain in open-sse/translator/response/openai-to-claude.ts.
+ * Delegates to the shared reasoning-field resolver (`open-sse/utils/reasoningFields.ts`)
+ * so every reasoning alias — DeepSeek-style `reasoning_content`, the OpenRouter/StepFun
+ * `reasoning` string, GitHub Copilot's `reasoning_text`, `thinking`/`thought`, and
+ * `reasoning_details[]` (array of { text | content }) — is read from one place instead
+ * of a divergent local copy. Mirrors the streaming translator's fallback chain in
+ * open-sse/translator/response/openai-to-claude.ts.
  */
 function resolveReasoningText(messageObj: JsonRecord): string {
-  if (messageObj.reasoning_content) {
-    return toString(messageObj.reasoning_content);
-  }
-  if (typeof messageObj.reasoning === "string" && messageObj.reasoning) {
-    return messageObj.reasoning;
-  }
-  if (Array.isArray(messageObj.reasoning_details)) {
-    const parts: string[] = [];
-    for (const detail of messageObj.reasoning_details) {
-      const detailObj = toRecord(detail);
-      const text = detailObj.text ?? detailObj.content;
-      if (typeof text === "string" && text) parts.push(text);
-    }
-    return parts.join("");
-  }
-  return "";
+  return getAnyReasoningValue(messageObj);
 }
 
 /**

--- a/tests/unit/issue-7856-copilot-reasoning-text-nonstream.test.ts
+++ b/tests/unit/issue-7856-copilot-reasoning-text-nonstream.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { translateNonStreamingResponse } from "../../open-sse/handlers/responseTranslator.ts";
+import { detectMalformedNonStream } from "../../open-sse/utils/diagnostics.ts";
+
+// GitHub Copilot (github/gemini-3.x models) returns reasoning in `message.reasoning_text`,
+// with `content` left empty. Before the fix, resolveReasoningText() in responseTranslator.ts
+// only checked reasoning_content / reasoning / reasoning_details[] and missed reasoning_text,
+// so the Claude-format translation dropped the reasoning entirely and emitted a bare
+// "(empty response)" text block, which detectMalformedNonStream() then rejects (-> 502).
+const copilotStyleResponse = {
+  id: "chatcmpl-copilot-7856",
+  object: "chat.completion",
+  created: 1783700000,
+  model: "github/gemini-3-pro",
+  choices: [
+    {
+      index: 0,
+      finish_reason: "stop",
+      message: {
+        role: "assistant",
+        content: "",
+        reasoning_text: "Let me think about the user's request before answering.",
+      },
+    },
+  ],
+  usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 },
+};
+
+test("#7856 /v1/messages non-stream translation surfaces Copilot reasoning_text as a thinking block", () => {
+  const translated = translateNonStreamingResponse(copilotStyleResponse, "openai", "claude", null) as {
+    content: Array<{ type: string; thinking?: string; text?: string }>;
+  };
+
+  const thinkingBlock = translated.content.find((block) => block.type === "thinking");
+  assert.ok(thinkingBlock, "expected a thinking block carrying the Copilot reasoning_text");
+  assert.equal(thinkingBlock?.thinking, "Let me think about the user's request before answering.");
+});
+
+test("#7856 /v1/messages non-stream translation of a Copilot reasoning_text turn is not flagged malformed", () => {
+  const translated = translateNonStreamingResponse(copilotStyleResponse, "openai", "claude", null);
+  const malformedReason = detectMalformedNonStream(translated);
+  assert.equal(malformedReason, null);
+});


### PR DESCRIPTION
Closes #7856

## Root cause

GitHub Copilot (`github/gemini-3.x` models) returns reasoning in `message.reasoning_text`, leaving `content` empty. `resolveReasoningText()` in `open-sse/handlers/responseTranslator.ts` (the non-stream OpenAI-to-Claude translator) only checked `reasoning_content`, the `reasoning` string, and `reasoning_details[]` — it never checked `reasoning_text`. Result: a successful Copilot response with reasoning and empty `content` was translated into a bare `(empty response)` text block with no `thinking` block, `detectMalformedNonStream()` then flagged it as `empty_choices`, and the caller got a spurious 502 ("no usable choices/output"). Even where it didn't hit the 502 path, the reasoning was silently dropped.

## Fix

`open-sse/utils/reasoningFields.ts` already has a shared, more complete resolver (`getAnyReasoningValue`) used elsewhere in the codebase, covering `reasoning_content`, `reasoning`, `reasoning_text`, `thinking`, `thought`, and `reasoning_details[]` in the same priority order the translator used. Rather than adding a fourth divergent copy of this logic, `resolveReasoningText()` now delegates to `getAnyReasoningValue()`, which both fixes the missing `reasoning_text` case and removes the duplicated field-parsing logic (`open-sse/handlers/responseTranslator.ts`).

Verified the delegation is behaviorally equivalent to the previous local logic for every existing case (`reasoning_content`, `reasoning` string, `reasoning_details[].text`/`.content`) before adopting it — same priority order, same string-type gating via `toString()`'s fallback semantics — so no existing test needed adjustment.

## Test (TDD, Hard Rule #18)

New file `tests/unit/issue-7856-copilot-reasoning-text-nonstream.test.ts`:
- RED (before fix): `resolveReasoningText` misses `reasoning_text`, so the translated Claude-format response has no `thinking` block and `detectMalformedNonStream()` returns `empty_choices`.
- GREEN (after fix): the response carries a `thinking` block with the Copilot reasoning text, and `detectMalformedNonStream()` returns `null`.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/issue-7856-copilot-reasoning-text-nonstream.test.ts` — 2/2 pass
- `node --import tsx/esm --test tests/unit/issue-6623-opencode-mimo-reasoning-details-nonstream.test.ts` (existing `reasoning_details` regression) — 3/3 pass
- Full neighboring translator suite (`gemini-finish-reason-normalization`, `gemini-midstream-nonstreaming-responses`, `nonstreaming-gemini-family-response-projection`, `plan3-p0`, `t19-codex-responses-empty-content`, `translator-resp-claude-to-openai`, `translator-resp-gemini-to-openai`, `translator-resp-openai-to-claude`) — 101/101 pass
- `node scripts/check/check-file-size.mjs` — no violations
- `eslint --config eslint.complexity.config.mjs` and `--config eslint.sonarjs.config.mjs` on the touched file — pre-existing violations only, confirmed byte-identical to the branch tip before this change (diffed against `origin/release/v3.8.49`); the fix does not add or worsen any
- `eslint --suppressions-location config/quality/eslint-suppressions.json` on touched files — exit 0
- `npm run typecheck:core` (`tsc -p tsconfig.typecheck-core.json`) — clean, exit 0