### PR TITLE
docs(guides): document Kaspersky Desktop-app AV false positive (#7903)

### DIFF
--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -51,6 +51,7 @@ Common problems and solutions for OmniRoute.
 | `dlopen` / `slice is not valid mach-o file` (macOS) | Run `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3 && omniroute` — see [macOS native module rebuild](#macos-native-module-rebuild) below |
 | Proxy "fetch failed"                                | Ensure proxy config is set at the correct level — see [Proxy Issues](#proxy-issues) below                                                                |
 | Antivirus quarantines `README.md`                   | False positive — see [Antivirus false positives](#antivirus-false-positives) below                                                                       |
+| Kaspersky flags the Desktop app as a Trojan         | Behavioral false positive on the unsigned installer — see [Antivirus false positives](#antivirus-false-positives) below                                  |
 
 ---
 
@@ -88,6 +89,49 @@ from quarantine.
 **Why we do not "fix" this on our side:** the examples are all `http://localhost`, and
 localhost cannot be `https` without self-signed-certificate friction. Mangling the docs to
 dodge one vendor's heuristic would hurt every reader to satisfy a scanner bug.
+
+### Kaspersky flags the Desktop app as `PDM:Trojan.Win32.Generic`
+
+**This is a false positive from a behavioral heuristic. Nothing is infected.** Kaspersky's
+`PDM:` prefix means the verdict comes from its Proactive Defense Module (System Watcher),
+which judges what the installer *does* rather than matching it against known malware. When
+it fires, Kaspersky "rolls back" the whole installation — deleting files it had already
+written — so the app ends up broken or missing.
+
+The files it flags are stock parts of declared, open-source dependencies bundled with the
+desktop app, for example:
+
+- `resources/app/.build/next/node_modules/playwright-<hash>/lib/…/agentParser.js` and
+  `workerProcessEntry.js` — [Playwright](https://playwright.dev), the browser-automation
+  library used for in-app provider login and browser-backed chat.
+- `resources/app/.build/next/node_modules/tls-client-node-<hash>/bin/tls-client-windows-64-<ver>.dll`
+  — the native binary from `tls-client-node`, used for Cloudflare-tolerant HTTP on some web
+  providers.
+
+**Why it fires:** the Windows installer is **not yet code-signed**, so an unsigned NSIS
+installer has zero reputation and behavioral heuristics run at maximum aggression. Combined
+with a bundled native DLL and hundreds of `.js` files written under
+`%LOCALAPPDATA%\Programs\OmniRoute` (including hash-suffixed package directories from the
+Next.js standalone build), that is enough to trip the heuristic. Code signing is planned;
+until it lands, new releases can repeat this.
+
+**What to do:**
+
+1. **Verify your download first** (rules out a tampered file). Every release publishes
+   `latest.yml`, whose `sha512` field (base64) covers the `OmniRoute.Setup.<version>.exe`
+   installer. In PowerShell, from the folder containing the installer:
+   ```powershell
+   $b = [System.Security.Cryptography.SHA512]::Create().ComputeHash(
+     [System.IO.File]::ReadAllBytes("$PWD\OmniRoute.Setup.<version>.exe"))
+   [Convert]::ToBase64String($b)
+   ```
+   The output must match `latest.yml` → `sha512`. If it does not, delete the file and
+   re-download only from the [GitHub releases page](https://github.com/diegosouzapw/OmniRoute/releases).
+2. **Restore + exclude** — restore the rolled-back items from quarantine and add an exclusion
+   for `%LOCALAPPDATA%\Programs\OmniRoute` (Kaspersky → Settings → Threats and Exclusions),
+   then reinstall.
+3. **Report the false positive** — <https://opentip.kaspersky.com/>. User-submitted FP
+   reports genuinely speed up allowlisting.
 
 ---
 


### PR DESCRIPTION
Documenta o falso positivo do Kaspersky reportado em #7903 na seção **Antivirus False Positives** do guia de troubleshooting (a seção já existia da nota Avast/AVG do #5946 — aqui só adiciono a subseção Kaspersky/desktop).

## O que muda
- Nova subseção **`### Kaspersky flags the Desktop app as `PDM:Trojan.Win32.Generic``** explicando:
  - `PDM:` = detecção **comportamental** (System Watcher), não assinatura de malware; a ação "rolled back" reverte a instalação inteira.
  - Quais arquivos são flagados e o que são (Playwright `agentParser.js`/`workerProcessEntry.js`, DLL nativa do `tls-client-node`) — deps OSS legítimas do bundle.
  - Por que dispara: instalador **não assinado** + DLL nativa + centenas de `.js` em `%LOCALAPPDATA%` → heurística no máximo. Signing planejado.
  - O que fazer: **verificar o sha512** contra `latest.yml` (one-liner PowerShell em base64), restaurar + excluir pasta, reportar FP em opentip.kaspersky.com.
- Uma linha nova na tabela **Quick Reference** apontando para a seção.

## Validação
Doc-only, sem código de produção. Gates de docs rodados na worktree, todos verdes:
- `check:docs-sync` PASS · `check:doc-links` PASS (803 links) · `check:fabricated-docs` PASS · `check:docs-counts` sem drift novo (os 2 soft-drifts de A2A/cloud são pré-existentes no base).

Refs #7903, #5946