### PR TITLE
fix(api): resolve local provider models via dashboard catalog fallback

### DIFF
--- a/src/app/api/v1/providers/[provider]/models/route.ts
+++ b/src/app/api/v1/providers/[provider]/models/route.ts
@@ -2,6 +2,7 @@ import { getUnifiedModelsResponse } from "@/app/api/v1/models/catalog";
 import { getServiceModels } from "@/lib/db/serviceModels";
 import { isServiceBackendPluginId } from "@/lib/services/serviceBackends";
 import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
+import { getProviderById, getProviderByAlias } from "@/shared/constants/providers";
 
 /**
  * Handle CORS preflight
@@ -43,19 +44,28 @@ export async function GET(request: Request, { params }: { params: Promise<{ prov
     providerId = providerEntry.id;
     providerAlias = providerEntry.alias || providerId;
   } else {
-    // Allow fetching models by connection ID for compatible providers
-    const isCompatibleConnectionId = /^(openai|anthropic)-compatible-chat-[a-f0-9-]+$/.test(rawProvider);
-    if (!isCompatibleConnectionId) {
-      return Response.json(
-        {
-          error: {
-            message: `Unknown provider: ${rawProvider}`,
-            type: "invalid_request_error",
-            code: "invalid_provider",
-          },
-        },
-        { status: 400 }
+    // Fall back to the dashboard-facing provider catalog (covers LOCAL_PROVIDERS, SEARCH_PROVIDERS, etc.)
+    const catalogEntry = getProviderById(rawProvider) ?? getProviderByAlias(rawProvider);
+    if (catalogEntry) {
+      providerId = catalogEntry.id;
+      providerAlias = catalogEntry.alias || providerId;
+    } else {
+      // Allow fetching models by connection ID for compatible providers
+      const isCompatibleConnectionId = /^(openai|anthropic)-compatible-chat-[a-f0-9-]+$/.test(
+        rawProvider
       );
+      if (!isCompatibleConnectionId) {
+        return Response.json(
+          {
+            error: {
+              message: `Unknown provider: ${rawProvider}`,
+              type: "invalid_request_error",
+              code: "invalid_provider",
+            },
+          },
+          { status: 400 }
+        );
+      }
     }
   }
 

--- a/tests/unit/provider-scoped-models-route.test.ts
+++ b/tests/unit/provider-scoped-models-route.test.ts
@@ -126,7 +126,9 @@ test("provider models route accepts provider alias in path", async () => {
 });
 
 test("provider models route supports service provider 9router", async () => {
-  serviceModelsDb.saveServiceModels("9router", [{ id: "gpt-4o-mini", name: "Local9R Test", available: true }]);
+  serviceModelsDb.saveServiceModels("9router", [
+    { id: "gpt-4o-mini", name: "Local9R Test", available: true },
+  ]);
 
   const response = await providerModelsRoute.GET(
     new Request("http://localhost/api/v1/providers/9router/models"),
@@ -140,11 +142,16 @@ test("provider models route supports service provider 9router", async () => {
 
   assert.equal(response.status, 200);
   assert.ok(ids.includes("gpt-4o-mini"));
-  assert.equal(ids.some((id: string) => id.includes("/")), false);
+  assert.equal(
+    ids.some((id: string) => id.includes("/")),
+    false
+  );
 });
 
 test("provider models route supports service provider cliproxyapi", async () => {
-  serviceModelsDb.saveServiceModels("cliproxyapi", [{ id: "llama-3", name: "Clip Test", available: true }]);
+  serviceModelsDb.saveServiceModels("cliproxyapi", [
+    { id: "llama-3", name: "Clip Test", available: true },
+  ]);
 
   const response = await providerModelsRoute.GET(
     new Request("http://localhost/api/v1/providers/cliproxyapi/models"),
@@ -158,7 +165,10 @@ test("provider models route supports service provider cliproxyapi", async () => 
 
   assert.equal(response.status, 200);
   assert.ok(ids.includes("llama-3"));
-  assert.equal(ids.some((id: string) => id.includes("/")), false);
+  assert.equal(
+    ids.some((id: string) => id.includes("/")),
+    false
+  );
 });
 
 test("provider models route returns 400 for unknown provider", async () => {
@@ -173,4 +183,56 @@ test("provider models route returns 400 for unknown provider", async () => {
 
   assert.equal(response.status, 400);
   assert.equal(body.error.code, "invalid_provider");
+});
+
+test("provider models route resolves local provider by canonical ID (ollama-local)", async () => {
+  const response = await providerModelsRoute.GET(
+    new Request("http://localhost/api/v1/providers/ollama-local/models"),
+    {
+      params: Promise.resolve({ provider: "ollama-local" }),
+    }
+  );
+
+  // Must NOT return 400 invalid_provider — should resolve via catalog fallback
+  assert.notEqual(response.status, 400, "ollama-local must not return 400");
+  const body = (await response.json()) as ProviderModelsResponse;
+  assert.notEqual(
+    body.error?.code,
+    "invalid_provider",
+    "ollama-local must not be rejected as unknown provider"
+  );
+});
+
+test("provider models route resolves local provider by alias (ollama)", async () => {
+  const response = await providerModelsRoute.GET(
+    new Request("http://localhost/api/v1/providers/ollama/models"),
+    {
+      params: Promise.resolve({ provider: "ollama" }),
+    }
+  );
+
+  assert.notEqual(response.status, 400, "ollama (alias) must not return 400");
+  const body = (await response.json()) as ProviderModelsResponse;
+  assert.notEqual(
+    body.error?.code,
+    "invalid_provider",
+    "ollama (alias) must not be rejected as unknown provider"
+  );
+});
+
+test("provider models route resolves another local provider by ID (lm-studio)", async () => {
+  const response = await providerModelsRoute.GET(
+    new Request("http://localhost/api/v1/providers/lm-studio/models"),
+    {
+      params: Promise.resolve({ provider: "lm-studio" }),
+    }
+  );
+
+  assert.notEqual(response.status, 400, "lm-studio must not return 400");
+  const body = (await response.json()) as ProviderModelsResponse;
+  assert.notEqual(
+    body.error?.code,
+    "invalid_provider",
+    "lm-studio must not be rejected as unknown provider"
+  );
 });


### PR DESCRIPTION
## Summary

The dashboard Test panel's model-list fetch (`GET /api/v1/providers/{id}/models`) returns `invalid_provider` for local self-hosted providers (Ollama, LM Studio, vLLM, etc.), making the provider Test panel unusable for them — even though `/v1/models` serves those same models fine.

Root cause: the route resolves the provider ID through `getRegistryEntry()` from the open-sse provider registry, which doesn't include `LOCAL_PROVIDERS`. Local providers are defined in `src/shared/constants/providers/local.ts` and never appear in the open-sse `REGISTRY`.

Fix: after `getRegistryEntry()` misses, fall back to the dashboard-facing provider catalog (`getProviderById` / `getProviderByAlias` from `@/shared/constants/providers`), which covers `LOCAL_PROVIDERS` (and all other dashboard provider categories). Registry hits retain their current precedence.

## Related Issues

- Closes #7910

## Validation

- [x] `npm run lint` — clean on both touched files (eslint)
- [x] `npm run test:unit` — 13/13 tests pass across both related test files
- [ ] `npm run test:coverage` — timed out on this VM (full suite too heavy), but c8 on affected file shows 90.43% stmts / 75% branch — well above 60% gate
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `tests/unit/provider-scoped-models-route.test.ts` — 3 new test cases:
  - `ollama-local` (canonical ID) — asserts NOT 400, NOT `invalid_provider`
  - `ollama` (alias) — same assertions
  - `lm-studio` (another local provider by ID) — same assertions

## Coverage Notes

- Only `src/app/api/v1/providers/[provider]/models/route.ts` changed. c8 on the affected file: 90.43% statements, 75% branches, 66.66% functions — all above the 60% gate.
- Uncovered lines (10-17: OPTIONS handler, 77-78: null payload guard, 88: dedup loop continue) are pre-existing, not introduced by this change.

## Reviewer Notes

- Low risk: purely additive fallback in the `else` branch when `getRegistryEntry()` misses. The existing registry path is completely unchanged. All 5 pre-existing tests pass without modification.
- The catalog fallback (`getProviderById ?? getProviderByAlias`) implicitly resolves any provider in the dashboard catalog (local, search, audio-only, etc.). Downstream filtering (`owned_by === providerId`) returns empty model lists for non-model-serving providers, so this is harmless — but worth noting.
