### PR TITLE
fix(chatCore): retry after stripping historical thinking on signature 400

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -164,6 +164,10 @@ import { recordKeyHealthStatus as recordKeyHealthStatusFor } from "./chatCore/ke
 import { getSkillsModelIdForFormat } from "./chatCore/skillsFormat.ts";
 import { readNonStreamingResponseBody } from "./chatCore/nonStreamingResponseBody.ts";
 import {
+  isThinkingSignatureError,
+  stripHistoricalThinking,
+} from "./chatCore/thinkingSignatureRecovery.ts";
+import {
   isSemaphoreCapacityError,
   createStreamingErrorResult,
   getUpstreamErrorIdentifier,
@@ -1776,6 +1780,12 @@ export async function handleChatCore({
   body = outputBudget.body;
 
   let translatedBody = body;
+  // Issue #7899: request-scoped recovery for "Invalid signature in thinking block".
+  // When an Anthropic target rejects a historical thinking block's signature
+  // (after a routing/model/account change), retry once after stripping thinking
+  // from completed historical assistant turns. The flag prevents unbounded
+  // retries; the strip helper preserves active tool_use → tool_result cycles.
+  let thinkingSignatureRetryDone = false;
   const isClaudePassthrough = sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.CLAUDE;
   const isClaudeCodeCompatible = isClaudeCodeCompatibleProvider(provider);
   const isClaudeCodeSemanticPassthrough = isClaudeCodeSemanticPassthroughRequest({
@@ -3705,30 +3715,75 @@ export async function handleChatCore({
         );
       }
     } else {
-      persistAttemptLogs({
-        status: statusCode,
-        error: errMsg,
-        providerRequest: finalBody || translatedBody,
-        providerResponse: upstreamErrorBody,
-        clientResponse: buildErrorBody(statusCode, errMsg),
-        cacheSource: "upstream",
-      });
-      persistFailureUsage(statusCode, `upstream_${statusCode}`);
+      // Issue #7899: request-scoped recovery for "Invalid signature in thinking
+      // block". Before returning the error, check if this is an Anthropic 400
+      // validation error for a stale thinking signature. If so, retry once
+      // after stripping thinking blocks from completed historical assistant
+      // turns (preserving the active tool_use cycle and the latest assistant
+      // message). This must NOT trigger for generic 400s, 429s, or the
+      // separate "latest assistant message cannot be modified" error.
+      let thinkingSignatureRecovered = false;
+      if (
+        !thinkingSignatureRetryDone &&
+        isThinkingSignatureError(statusCode, message)
+      ) {
+        const stripped = stripHistoricalThinking(translatedBody?.messages);
+        if (stripped.removed > 0) {
+          thinkingSignatureRetryDone = true;
+          translatedBody = { ...translatedBody, messages: stripped.messages };
+          log?.warn?.(
+            "THINKING_SIGNATURE",
+            `Anthropic 400: Invalid signature in thinking block — retrying after stripping ${stripped.removed} historical thinking block(s) from completed assistant turns`
+          );
+          try {
+            const retryResult = await executeProviderRequest(effectiveModel, false);
+            providerResponse = retryResult.response;
+            providerUrl = retryResult.url;
+            providerHeaders = new Headers(retryResult.headers || {});
+            finalBody = providerRequestCapture.body(retryResult.transformedBody);
+            reqLogger.logTargetRequest(providerUrl, providerHeaders, finalBody);
+            updatePendingScope(pendingScope, {
+              providerRequest: finalBody,
+              providerUrl,
+              stage: "provider_response_started",
+            });
+            if (providerResponse.ok) {
+              thinkingSignatureRecovered = true;
+              upstreamErrorParsed = false;
+            }
+          } catch {
+            // Retry threw — fall through to return the original error.
+          }
+        }
+      }
 
-      // Emergency budget fallback is orchestrated exclusively by the routing layer
-      // (src/sse/handlers/chat.ts), which resolves credentials FOR the emergency
-      // provider through account selection. The executor-level hop that used to
-      // live here re-sent the FAILING provider's credentials to the emergency
-      // provider's endpoint (e.g. the OpenAI API key to integrate.api.nvidia.com)
-      // — a cross-provider credential leak that also never succeeded upstream.
-      return createErrorResult(
-        statusCode,
-        errMsg,
-        retryAfterMs,
-        upstreamErrorCode,
-        upstreamErrorType,
-        upstreamErrorBody
-      );
+      if (!thinkingSignatureRecovered) {
+        persistAttemptLogs({
+          status: statusCode,
+          error: errMsg,
+          providerRequest: finalBody || translatedBody,
+          providerResponse: upstreamErrorBody,
+          clientResponse: buildErrorBody(statusCode, errMsg),
+          cacheSource: "upstream",
+        });
+        persistFailureUsage(statusCode, `upstream_${statusCode}`);
+
+        // Emergency budget fallback is orchestrated exclusively by the routing layer
+        // (src/sse/handlers/chat.ts), which resolves credentials FOR the emergency
+        // provider through account selection. The executor-level hop that used to
+        // live here re-sent the FAILING provider's credentials to the emergency
+        // provider's endpoint (e.g. the OpenAI API key to integrate.api.nvidia.com)
+        // — a cross-provider credential leak that also never succeeded upstream.
+        return createErrorResult(
+          statusCode,
+          errMsg,
+          retryAfterMs,
+          upstreamErrorCode,
+          upstreamErrorType,
+          upstreamErrorBody
+        );
+      }
+      // Retry succeeded — fall through to normal response processing below.
     }
     // ── End T5 ───────────────────────────────────────────────────────────────
   }

--- a/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts
+++ b/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts
@@ -1,0 +1,122 @@
+/**
+ * Request-scoped recovery for Anthropic "Invalid signature in thinking block"
+ * errors (issue #7899).
+ *
+ * When an Anthropic target rejects a multi-turn request because a historical
+ * thinking block carries a signature it cannot validate (after a routing,
+ * model, or account change), the correct response is to retry the request
+ * once after removing thinking blocks from completed historical assistant
+ * turns — while preserving the active tool-use cycle and the latest assistant
+ * message.
+ *
+ * Removing thinking from every request upfront is unsafe: it changes valid
+ * requests and can alter prompt-cache and tool-use behaviour. The recovery
+ * must only engage when the exact upstream validation error is observed.
+ */
+
+type ContentBlock = {
+  type?: string;
+  thinking?: string;
+  signature?: string;
+  [key: string]: unknown;
+};
+
+type Message = {
+  role?: string;
+  content?: string | ContentBlock[];
+  [key: string]: unknown;
+};
+
+/**
+ * Detect the Anthropic 400 "Invalid signature in thinking block" validation
+ * error from the parsed upstream error fields. This is intentionally narrow:
+ * generic 400s, 429s, and the separate "latest assistant message cannot be
+ * modified" error must NOT trigger this recovery.
+ */
+export function isThinkingSignatureError(
+  statusCode: number,
+  message: string
+): boolean {
+  if (statusCode !== 400) return false;
+  const lower = (message || "").toLowerCase();
+  // Match the exact Anthropic validation message. The field path prefix
+  // (messages.1.content.0:) varies by position, so match on the invariant
+  // substring.
+  return lower.includes("invalid") && lower.includes("signature") && lower.includes("thinking");
+}
+
+/**
+ * Remove `thinking` (and `redacted_thinking`) blocks from completed historical
+ * assistant turns. A "completed" assistant turn is any assistant message that
+ * is NOT the last message in the array AND is not part of an active
+ * tool_use → tool_result cycle (i.e. the following message is a user message
+ * that is NOT a tool_result).
+ *
+ * The last assistant message is never touched: Anthropic rejects modification
+ * of the latest assistant message with a separate "latest assistant message
+ * cannot be modified" error, and the thinking blocks there are still valid.
+ *
+ * Returns { messages, removed } where removed is the count of thinking blocks
+ * stripped. If no thinking could be removed safely, returns removed=0 so the
+ * caller can surface the original error without retrying.
+ */
+export function stripHistoricalThinking(
+  messages: unknown
+): { messages: unknown; removed: number } {
+  if (!Array.isArray(messages)) {
+    return { messages, removed: 0 };
+  }
+
+  const msgs = messages as Message[];
+  let removed = 0;
+
+  const result: Message[] = [];
+
+  for (let i = 0; i < msgs.length; i++) {
+    const msg = msgs[i];
+
+    // Only strip from assistant messages that are NOT the last message
+    // (the last assistant message may be the active turn).
+    if (
+      msg?.role === "assistant" &&
+      i < msgs.length - 1 &&
+      Array.isArray(msg.content)
+    ) {
+      const filtered = (msg.content as ContentBlock[]).filter((block) => {
+        const isThinking =
+          block?.type === "thinking" || block?.type === "redacted_thinking";
+        if (isThinking) {
+          // Check if this thinking block is part of an active tool-use cycle:
+          // if the block is immediately followed by a tool_use block in the
+          // same message, the thinking belongs to that tool_use and must be
+          // preserved (Anthropic requires the thinking preceding a tool_use
+          // to remain in place for the tool_use to be valid).
+          const blockIdx = (msg.content as ContentBlock[]).indexOf(block);
+          const nextBlock = (msg.content as ContentBlock[])[blockIdx + 1];
+          if (nextBlock?.type === "tool_use") {
+            return true; // keep thinking — it's part of an active tool cycle
+          }
+          removed++;
+          return false; // strip
+        }
+        return true;
+      });
+
+      // If we removed all content blocks, replace with a minimal text block
+      // so the assistant message is not empty (Anthropic requires non-empty
+      // content).
+      if (filtered.length === 0) {
+        result.push({
+          ...msg,
+          content: [{ type: "text", text: "" }],
+        });
+      } else {
+        result.push({ ...msg, content: filtered });
+      }
+    } else {
+      result.push(msg);
+    }
+  }
+
+  return { messages: result, removed };
+}

--- a/tests/unit/thinking-signature-recovery-7899.test.ts
+++ b/tests/unit/thinking-signature-recovery-7899.test.ts
@@ -1,0 +1,184 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  isThinkingSignatureError,
+  stripHistoricalThinking,
+} = await import("../../open-sse/handlers/chatCore/thinkingSignatureRecovery.ts");
+
+// ── isThinkingSignatureError ──────────────────────────────────────────────
+
+test("isThinkingSignatureError: matches exact Anthropic 400 validation error", () => {
+  assert.ok(isThinkingSignatureError(400, "messages.1.content.0: Invalid `signature` in `thinking` block"));
+  assert.ok(isThinkingSignatureError(400, "messages.3.content.2: Invalid signature in thinking block"));
+});
+
+test("isThinkingSignatureError: rejects generic 400s", () => {
+  assert.equal(isThinkingSignatureError(400, "Bad request"), false);
+  assert.equal(isThinkingSignatureError(400, "Invalid model"), false);
+  assert.equal(isThinkingSignatureError(400, "messages.1.content.0: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified"), false);
+});
+
+test("isThinkingSignatureError: rejects non-400 statuses", () => {
+  assert.equal(isThinkingSignatureError(429, "Invalid signature in thinking block"), false);
+  assert.equal(isThinkingSignatureError(401, "Invalid signature in thinking block"), false);
+  assert.equal(isThinkingSignatureError(500, "Invalid signature in thinking block"), false);
+});
+
+test("isThinkingSignatureError: handles empty/undefined messages", () => {
+  assert.equal(isThinkingSignatureError(400, ""), false);
+  assert.equal(isThinkingSignatureError(400, undefined as unknown as string), false);
+});
+
+// ── stripHistoricalThinking ───────────────────────────────────────────────
+
+test("stripHistoricalThinking: removes thinking from completed historical assistant turns", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "What is 12*12?" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "calculating", signature: "STALE_SIG" },
+        { type: "text", text: "144." },
+      ],
+    },
+    { role: "user", content: [{ type: "text", text: "Now multiply by 2" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "easy", signature: "VALID_SIG" },
+        { type: "text", text: "288." },
+      ],
+    },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  assert.equal(result.removed, 1, "only the historical (non-last) thinking block is removed");
+
+  // First assistant turn: thinking stripped, text preserved
+  const firstAssistant = result.messages[1] as { content: { type: string }[] };
+  assert.equal(firstAssistant.content.length, 1, "first assistant has only text block");
+  assert.equal(firstAssistant.content[0].type, "text");
+
+  // Last assistant turn: thinking preserved
+  const lastAssistant = result.messages[3] as { content: { type: string }[] };
+  assert.equal(lastAssistant.content.length, 2, "last assistant still has thinking + text");
+  assert.equal(lastAssistant.content[0].type, "thinking");
+});
+
+test("stripHistoricalThinking: preserves thinking in active tool_use cycles", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "run ls" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "need to run ls", signature: "SIG_1" },
+        { type: "tool_use", id: "toolu_1", name: "Bash", input: { cmd: "ls" } },
+      ],
+    },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "file.txt" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Here is the file." },
+      ],
+    },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  // The thinking block is immediately followed by tool_use → preserved
+  assert.equal(result.removed, 0, "thinking preceding tool_use is preserved");
+});
+
+test("stripHistoricalThinking: handles redacted_thinking blocks", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "redacted_thinking", data: "redacted", signature: "SIG" },
+        { type: "text", text: "hello" },
+      ],
+    },
+    { role: "user", content: [{ type: "text", text: "bye" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "goodbye" },
+      ],
+    },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  assert.equal(result.removed, 1, "redacted_thinking block is stripped");
+});
+
+test("stripHistoricalThinking: returns removed=0 when no thinking blocks exist", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+    { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    { role: "user", content: [{ type: "text", text: "bye" }] },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  assert.equal(result.removed, 0);
+  assert.equal(result.messages.length, messages.length);
+});
+
+test("stripHistoricalThinking: handles non-array input", () => {
+  assert.deepEqual(stripHistoricalThinking(undefined), { messages: undefined, removed: 0 });
+  assert.deepEqual(stripHistoricalThinking(null), { messages: null, removed: 0 });
+  assert.deepEqual(stripHistoricalThinking("not array"), { messages: "not array", removed: 0 });
+});
+
+test("stripHistoricalThinking: replaces empty content with minimal text block", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "only thinking", signature: "SIG" },
+      ],
+    },
+    { role: "user", content: [{ type: "text", text: "bye" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "final" },
+      ],
+    },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  assert.equal(result.removed, 1);
+  const stripped = result.messages[1] as { content: { type: string; text: string }[] };
+  assert.equal(stripped.content.length, 1);
+  assert.equal(stripped.content[0].type, "text");
+});
+
+test("stripHistoricalThinking: does not modify last assistant message", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "last turn thinking", signature: "SIG" },
+        { type: "text", text: "response" },
+      ],
+    },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  assert.equal(result.removed, 0, "last assistant message is never stripped");
+});
+
+test("stripHistoricalThinking: handles string content (not array)", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "hello" },
+    { role: "user", content: "bye" },
+  ];
+
+  const result = stripHistoricalThinking(messages);
+  assert.equal(result.removed, 0);
+});


### PR DESCRIPTION
Closes #7899.

When an Anthropic target returns `400 Invalid signature in thinking block` (after a routing/model/account change), retry the request once after removing thinking blocks from completed historical assistant turns. The active `tool_use` → `tool_result` cycle and the latest assistant message are preserved.

Narrowly scoped: only triggers on the exact 400 validation error, never on generic 400s, 429s, or the separate "latest assistant message cannot be modified" error. If no historical thinking can be safely removed, the original error is returned without retrying.

Tests: `tests/unit/thinking-signature-recovery-7899.test.ts` (11 cases covering detection, stripping, tool-use preservation, edge cases).