### PR TITLE
fix(combo): context-aware fallback ignores model_context_override

### DIFF
--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -12,6 +12,7 @@
  */
 
 import { getModelContextLimit } from "../../../src/lib/modelCapabilities";
+import { getModelContextOverride } from "../../../src/lib/db/modelContextOverrides";
 import { getComboModelString, normalizeComboStep } from "../../../src/lib/combos/steps.ts";
 import { estimateTokens } from "../contextManager.ts";
 import { getResolvedModelCapabilities } from "../modelCapabilities.ts";
@@ -504,8 +505,28 @@ function exceedsKnownOutputLimit(
  */
 function evaluateContextLimit(
   capabilities: { maxInputTokens?: number | null; contextWindow?: number | null },
-  requirements: { estimatedInputTokens: number; requiredContextTokens: number }
+  requirements: { estimatedInputTokens: number; requiredContextTokens: number },
+  modelStr?: string
 ): boolean | null {
+  // A persisted context override (Feature 5004 — operator-set or auto-discovered
+  // real usable window) wins for server-side routing. The catalog's
+  // `maxInputTokens` can be a deliberately smaller *client-facing* hint (e.g. set
+  // below the true window so coding agents auto-compact — #6191); using it to
+  // filter fallback targets wrongly drops otherwise-capable providers for large
+  // prompts, collapsing the pool to one provider and producing a hard 503 with no
+  // fallback once that provider's quota is exhausted. The override reflects the
+  // real capacity, so it supersedes both catalog limits here. Use the raw override
+  // (getModelContextOverride returns null when none is set) — NOT
+  // getModelContextLimitForModelString, which falls back to contextWindow and would
+  // therefore bypass the maxInputTokens cap for every model, not just overridden ones.
+  if (modelStr) {
+    const parsed = parseModel(modelStr);
+    const override = getModelContextOverride(parsed.provider, parsed.model);
+    if (override != null) {
+      return override >= requirements.requiredContextTokens;
+    }
+  }
+
   const hasMaxInput = capabilities.maxInputTokens != null;
   const hasContextWindow = capabilities.contextWindow != null;
 
@@ -537,7 +558,7 @@ function hasKnownCompatibleContextLimit(
 ): boolean {
   if (requirements.requiredContextTokens <= 0) return false;
   const capabilities = getResolvedModelCapabilities(target.modelStr);
-  return evaluateContextLimit(capabilities, requirements) === true;
+  return evaluateContextLimit(capabilities, requirements, target.modelStr) === true;
 }
 
 function hasOnlyContextWindowFailures(reasons: string[]): boolean {
@@ -576,7 +597,7 @@ function getTargetCompatibilityFailures(
     failures.push("output_tokens");
   }
 
-  const contextVerdict = evaluateContextLimit(capabilities, requirements);
+  const contextVerdict = evaluateContextLimit(capabilities, requirements, target.modelStr);
   if (requirements.requiredContextTokens > 0 && contextVerdict === false) {
     failures.push("context_window");
   }

--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -12,13 +12,13 @@
  */
 
 import { getModelContextLimit } from "../../../src/lib/modelCapabilities";
-import { getModelContextOverride } from "../../../src/lib/db/modelContextOverrides";
 import { getComboModelString, normalizeComboStep } from "../../../src/lib/combos/steps.ts";
 import { estimateTokens } from "../contextManager.ts";
 import { getResolvedModelCapabilities } from "../modelCapabilities.ts";
 import { parseModel } from "../model.ts";
 import { dedupeTargetsByExecutionKey, isRecord } from "./comboData.ts";
 import { getTargetProvider, MAX_COMBO_DEPTH } from "./comboPredicates.ts";
+import { evaluateContextLimit } from "./contextOverrideGate.ts";
 import { hasEstimableContent } from "./knownContextOverflow.ts";
 import {
   normalizeModelEntry,
@@ -486,70 +486,6 @@ function exceedsKnownOutputLimit(
 ): boolean {
   if (requestedOutputTokens <= 0 || maxOutputTokens === null) return false;
   return maxOutputTokens < requestedOutputTokens;
-}
-
-/**
- * Decide whether a target's known context limit accommodates the request.
- *
- * `maxInputTokens` is an **input-only** cap — the requested output reserve is
- * already enforced separately against `maxOutputTokens` (see
- * `exceedsKnownOutputLimit`), so it must NOT be re-counted here. Comparing
- * `maxInputTokens` against `estimatedInputTokens + requestedOutputTokens`
- * double-counted the output reserve and shrank the effective input allowance
- * (#7039).
- *
- * `contextWindow` is the total window, so input + output must both fit.
- *
- * Returns `true` when the known limit accommodates the request, `false` when
- * it is known to be too small, and `null` when no limit metadata is known.
- */
-function evaluateContextLimit(
-  capabilities: { maxInputTokens?: number | null; contextWindow?: number | null },
-  requirements: { estimatedInputTokens: number; requiredContextTokens: number },
-  modelStr?: string
-): boolean | null {
-  // A persisted context override (Feature 5004 — operator-set or auto-discovered
-  // real usable window) wins for server-side routing. The catalog's
-  // `maxInputTokens` can be a deliberately smaller *client-facing* hint (e.g. set
-  // below the true window so coding agents auto-compact — #6191); using it to
-  // filter fallback targets wrongly drops otherwise-capable providers for large
-  // prompts, collapsing the pool to one provider and producing a hard 503 with no
-  // fallback once that provider's quota is exhausted. The override reflects the
-  // real capacity, so it supersedes both catalog limits here. Use the raw override
-  // (getModelContextOverride returns null when none is set) — NOT
-  // getModelContextLimitForModelString, which falls back to contextWindow and would
-  // therefore bypass the maxInputTokens cap for every model, not just overridden ones.
-  if (modelStr) {
-    const parsed = parseModel(modelStr);
-    const override = getModelContextOverride(parsed.provider, parsed.model);
-    if (override != null) {
-      return override >= requirements.requiredContextTokens;
-    }
-  }
-
-  const hasMaxInput = capabilities.maxInputTokens != null;
-  const hasContextWindow = capabilities.contextWindow != null;
-
-  // Neither limit is known — cannot judge.
-  if (!hasMaxInput && !hasContextWindow) return null;
-
-  // The input-only cap must accommodate the estimated input.
-  const inputFits = hasMaxInput
-    ? capabilities.maxInputTokens! >= requirements.estimatedInputTokens
-    : true;
-
-  // The total window must accommodate input + requested output. The output
-  // reserve is enforced separately via `maxOutputTokens`, but when a model
-  // exposes both `maxInputTokens` and `contextWindow` the two must not be
-  // checked in isolation: a request whose input fits `maxInputTokens` but whose
-  // input + output exceeds `contextWindow` must still be rejected (#7039
-  // follow-up — shared-window models where `maxInputTokens` defaults to the
-  // total window size).
-  const totalFits = hasContextWindow
-    ? capabilities.contextWindow! >= requirements.requiredContextTokens
-    : true;
-
-  return inputFits && totalFits;
 }
 
 function hasKnownCompatibleContextLimit(

--- a/open-sse/services/combo/contextOverrideGate.ts
+++ b/open-sse/services/combo/contextOverrideGate.ts
@@ -1,0 +1,94 @@
+/**
+ * Context-fit evaluation for combo routing's compatibility filter, extracted
+ * from comboStructure.ts to keep that file under the file-size cap (PR
+ * #7933's model_context_override fix pushed it over).
+ *
+ * evaluateContextLimit() is the single chokepoint both compatibility-check
+ * call sites in comboStructure.ts (hasKnownCompatibleContextLimit,
+ * getTargetCompatibilityFailures) go through. It first consults a persisted
+ * per-model context override, then falls back to the catalog's
+ * maxInputTokens/contextWindow limits.
+ *
+ * Override rationale (Feature 5004): the catalog's `maxInputTokens` can be a
+ * deliberately smaller *client-facing* hint (e.g. set below the true window so
+ * coding agents auto-compact — #6191); using it to filter fallback targets
+ * wrongly drops otherwise-capable providers for large prompts, collapsing the
+ * pool to one provider and producing a hard 503 with no fallback once that
+ * provider's quota is exhausted. An operator-set or auto-discovered override
+ * reflects the real capacity, so it supersedes both catalog limits. Uses the
+ * raw override (`getModelContextOverride` returns `null` when none is set) —
+ * NOT `getModelContextLimitForModelString`, which falls back to
+ * `contextWindow` and would therefore bypass the `maxInputTokens` cap for
+ * every model, not just overridden ones.
+ */
+
+import { getModelContextOverride } from "../../../src/lib/db/modelContextOverrides";
+import { parseModel } from "../model.ts";
+
+/**
+ * Resolve the context-fit verdict from a persisted per-model override, if one
+ * is set. Returns `undefined` when there is no `modelStr` or no override
+ * exists, so the caller falls through to the catalog-based check; otherwise
+ * returns the fit verdict for the override itself.
+ */
+function resolveContextOverrideVerdict(
+  modelStr: string | undefined,
+  requiredContextTokens: number
+): boolean | undefined {
+  if (!modelStr) return undefined;
+  const parsed = parseModel(modelStr);
+  const override = getModelContextOverride(parsed.provider, parsed.model);
+  if (override == null) return undefined;
+  return override >= requiredContextTokens;
+}
+
+/**
+ * Decide whether a target's known context limit accommodates the request.
+ *
+ * `maxInputTokens` is an **input-only** cap — the requested output reserve is
+ * already enforced separately against `maxOutputTokens` (see
+ * `exceedsKnownOutputLimit` in comboStructure.ts), so it must NOT be
+ * re-counted here. Comparing `maxInputTokens` against `estimatedInputTokens +
+ * requestedOutputTokens` double-counted the output reserve and shrank the
+ * effective input allowance (#7039).
+ *
+ * `contextWindow` is the total window, so input + output must both fit.
+ *
+ * Returns `true` when the known limit accommodates the request, `false` when
+ * it is known to be too small, and `null` when no limit metadata is known.
+ */
+export function evaluateContextLimit(
+  capabilities: { maxInputTokens?: number | null; contextWindow?: number | null },
+  requirements: { estimatedInputTokens: number; requiredContextTokens: number },
+  modelStr?: string
+): boolean | null {
+  const overrideVerdict = resolveContextOverrideVerdict(
+    modelStr,
+    requirements.requiredContextTokens
+  );
+  if (overrideVerdict !== undefined) return overrideVerdict;
+
+  const hasMaxInput = capabilities.maxInputTokens != null;
+  const hasContextWindow = capabilities.contextWindow != null;
+
+  // Neither limit is known — cannot judge.
+  if (!hasMaxInput && !hasContextWindow) return null;
+
+  // The input-only cap must accommodate the estimated input.
+  const inputFits = hasMaxInput
+    ? capabilities.maxInputTokens! >= requirements.estimatedInputTokens
+    : true;
+
+  // The total window must accommodate input + requested output. The output
+  // reserve is enforced separately via `maxOutputTokens`, but when a model
+  // exposes both `maxInputTokens` and `contextWindow` the two must not be
+  // checked in isolation: a request whose input fits `maxInputTokens` but whose
+  // input + output exceeds `contextWindow` must still be rejected (#7039
+  // follow-up — shared-window models where `maxInputTokens` defaults to the
+  // total window size).
+  const totalFits = hasContextWindow
+    ? capabilities.contextWindow! >= requirements.requiredContextTokens
+    : true;
+
+  return inputFits && totalFits;
+}

--- a/tests/unit/combo-context-window-filter.test.ts
+++ b/tests/unit/combo-context-window-filter.test.ts
@@ -18,6 +18,8 @@ const { saveModelsDevCapabilities, clearModelsDevCapabilities } =
   await import("../../src/lib/modelsDevSync.ts");
 const { filterTargetsByRequestCompatibility, getKnownContextOverflow, handleComboChat } =
   await import("../../open-sse/services/combo.ts");
+const { setModelContextOverride, removeModelContextOverride } =
+  await import("../../src/lib/db/modelContextOverrides.ts");
 
 test.after(() => {
   core.resetDbInstance();
@@ -362,5 +364,55 @@ test("maxInputTokens defaulting to contextWindow still rejects when input + outp
   assert.deepEqual(
     out.map((entry) => entry.modelStr),
     ["unit-7039-window/huge"]
+  );
+});
+
+// A persisted model_context_override (Feature 5004 — operator-set or
+// auto-discovered) reflects a target's real usable window and must win over the
+// static catalog limit for server-side routing. Otherwise a provider whose
+// catalog `maxInputTokens` is a deliberately smaller client-facing hint (set
+// below the true window so coding agents auto-compact, #6191) gets wrongly
+// dropped for large-context requests, collapsing the fallback pool.
+test("model_context_override lets a small-catalog target survive a large-context request", () => {
+  saveModelsDevCapabilities({
+    "unit-override": {
+      big: capabilityEntry(1_000_000),
+      capped: capabilityEntry(8_000),
+    },
+  });
+  setModelContextOverride("unit-override", "capped", 1_000_000);
+  try {
+    const out = filterTargetsByRequestCompatibility(
+      [target("unit-override/capped"), target("unit-override/big")],
+      largeContextBody(),
+      noopLog
+    );
+    assert.deepEqual(
+      out.map((entry) => entry.modelStr).sort(),
+      ["unit-override/big", "unit-override/capped"]
+    );
+  } finally {
+    removeModelContextOverride("unit-override", "capped");
+  }
+});
+
+test("without an override the small-catalog target is still dropped for the large request", () => {
+  saveModelsDevCapabilities({
+    "unit-override": {
+      big: capabilityEntry(1_000_000),
+      capped: capabilityEntry(8_000),
+    },
+  });
+  // No override: capped (8K) is genuinely too small and must be filtered out,
+  // guarding the override read-path from masking a real too-small target.
+  const out = filterTargetsByRequestCompatibility(
+    [target("unit-override/capped"), target("unit-override/big")],
+    largeContextBody(),
+    noopLog
+  );
+
+  assert.deepEqual(
+    out.map((entry) => entry.modelStr),
+    ["unit-override/big"]
   );
 });


### PR DESCRIPTION
### Problem

`filterTargetsByRequestCompatibility` (the context-aware combo fallback) resolves each target's context capacity through `getResolvedModelCapabilities`, which is intentionally **override-free**. So a persisted `model_context_override` (Feature 5004 — operator-set via `PUT /api/provider-models`, or auto-discovered) **never reaches the compatibility filter**.

That matters because a model's catalog `maxInputTokens` is sometimes a deliberately *smaller, client-facing* hint rather than its true capacity — e.g. codex gpt-5.5 advertises `maxInputTokens: 272000` below its `contextLength: 400000` specifically so coding agents auto-compact before the hard limit (#6191). For **server-side routing**, using that hint drops an otherwise-capable target from the fallback pool on large-context requests, even when an operator has recorded the model's real larger window.

Observed in production: with a large prompt (~300–500K tokens) and codex given a context override, context-aware fallback still dropped codex using the un-overridden 272K → the pool collapsed to Claude only → once Claude's per-model quota was exhausted the combo returned a hard **503 "all upstream accounts inactive"** with no fallback path. `Trying model 1/3` in the logs had already been filtered down to a single survivor.

### Fix

`evaluateContextLimit` now consults the raw override (`getModelContextOverride`, which returns `null` when none is set) **before** the catalog limits, and only when an override actually exists:

```ts
if (modelStr) {
  const parsed = parseModel(modelStr);
  const override = getModelContextOverride(parsed.provider, parsed.model);
  if (override != null) return override >= requirements.requiredContextTokens;
}
```

Deliberately **not** `getModelContextLimitForModelString` — that helper falls back to `contextWindow`, which would bypass the `maxInputTokens` cap for *every* model, not just overridden ones. Using the raw override means a genuinely-too-small `maxInputTokens` is still enforced for non-overridden models.

This is consistent with the two other call sites in this file that already resolve context capacity override-aware (the `contextLimit` sort key and the tree-candidate filter).

Registry values are untouched — #6191's 272K client hint stays exactly as-is, and the catalog API the client reads is a separate code path from the override table.

### Testing

`tests/unit/combo-context-window-filter.test.ts` (all 14 pass on `release/v3.8.49`):

- **new** — an override lets a small-catalog target survive a large-context request (both the overridden target and the known-large target are kept)
- **new** — *without* an override the small-catalog target is still dropped for the same request (guards the read-path from masking a genuinely-too-small target)
- **unchanged** — the existing #6191 input-cap and #7039 shared-window rejection tests still pass, confirming the override only relaxes the check when explicitly set

No registry, schema, or dependency changes.

---
Separate from #7806 (plugin-path bugs) — different subsystem (combo routing vs plugin loader). Happy to adjust the override-precedence semantics if you'd prefer it to cap at `contextWindow` rather than fully supersede.
