### PR TITLE
fix(providers): route iflytek/sparkdesk to Spark's OpenAI-compatible host

### DIFF
--- a/changelog.d/fixes/7942-spark-openai-compatible-endpoint.md
+++ b/changelog.d/fixes/7942-spark-openai-compatible-endpoint.md
@@ -1,0 +1,1 @@
+- **fix(providers):** iFlytek Spark (`iflytek`, `sparkdesk`) now target the OpenAI-compatible host `spark-api-open.xf-yun.com/v1`; the previous `spark-api.xf-yun.com` is the WebSocket host and rejects bearer auth ([#7942](https://github.com/diegosouzapw/OmniRoute/pull/7942)) — thanks @FenjuFu

--- a/open-sse/config/freeModelCatalog.data.ts
+++ b/open-sse/config/freeModelCatalog.data.ts
@@ -443,7 +443,7 @@ export const FREE_MODEL_BUDGETS: FreeModelBudget[] = [
   { provider: "siliconflow", modelId: "zai-org/GLM-4.7", displayName: "GLM 4.7", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-uncapped", poolKey: "siliconflow", tos: "caution" },
   { provider: "siliconflow", modelId: "openai/gpt-oss-120b", displayName: "GPT OSS 120B", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-uncapped", poolKey: "siliconflow", tos: "caution" },
   { provider: "siliconflow", modelId: "baidu/ERNIE-4.5-300B-A47B", displayName: "ERNIE 4.5 300B", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-uncapped", poolKey: "siliconflow", tos: "caution" },
-  { provider: "sparkdesk", modelId: "general", displayName: "General", monthlyTokens: 0, creditTokens: 0, freeType: "keyless", poolKey: "sparkdesk", tos: "caution" },
+  { provider: "sparkdesk", modelId: "lite", displayName: "Spark Lite", monthlyTokens: 0, creditTokens: 0, freeType: "keyless", poolKey: "sparkdesk", tos: "caution" },
   { provider: "stepfun", modelId: "step-1v", displayName: "Step 1V", monthlyTokens: 0, creditTokens: 0, freeType: "one-time-initial", poolKey: "stepfun", tos: "ok" },
   { provider: "t3-web", modelId: "claude-opus-4", displayName: "Claude Opus 4 (via t3.chat)", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-daily", poolKey: "t3-web", tos: "avoid" },
   { provider: "t3-web", modelId: "claude-sonnet-4", displayName: "Claude Sonnet 4 (via t3.chat)", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-daily", poolKey: "t3-web", tos: "avoid" },

--- a/open-sse/config/providers/registry/iflytek/index.ts
+++ b/open-sse/config/providers/registry/iflytek/index.ts
@@ -5,11 +5,15 @@ export const iflytekProvider: RegistryEntry = {
   alias: "iflytek",
   format: "openai",
   executor: "default",
-  baseUrl: "https://spark-api.xf-yun.com/v1/chat/completions",
+  baseUrl: "https://spark-api-open.xf-yun.com/v1/chat/completions",
   authType: "apikey",
   authHeader: "bearer",
-  // Sweep 2026-06-19: confirmed exact HTTP `domain` values against the official
-  // xfyun.cn Spark docs. generalv3.5 = Max (current); 4.0Ultra is case-sensitive.
+  // `spark-api-open.xf-yun.com` is Spark's OpenAI-compatible HTTP endpoint (Bearer
+  // APIPassword). `spark-api.xf-yun.com` is the WebSocket host — `wss://.../v3.1/chat`
+  // etc., authenticated with an HMAC-SHA256 signature, not a bearer token — so it
+  // cannot serve this `format: "openai"` / `authHeader: "bearer"` entry.
+  // Model ids are the `domain` values accepted by the HTTP endpoint:
+  // generalv3.5 = Max (current); 4.0Ultra is case-sensitive.
   models: [
     { id: "4.0Ultra", name: "Spark 4.0 Ultra", contextLength: 32768 },
     { id: "generalv3.5", name: "Spark Max (V3.5)" },

--- a/open-sse/config/providers/registry/sparkdesk/index.ts
+++ b/open-sse/config/providers/registry/sparkdesk/index.ts
@@ -5,16 +5,19 @@ export const sparkdeskProvider: RegistryEntry = {
   alias: "sparkdesk",
   format: "openai",
   executor: "default",
-  baseUrl: "https://spark-api.xf-yun.com/v3.1/chat/completions",
+  baseUrl: "https://spark-api-open.xf-yun.com/v1/chat/completions",
   authType: "apikey",
   authHeader: "bearer",
-  // Sweep 2026-06-19: confirmed exact HTTP `domain` values against the official
-  // xfyun.cn Spark docs. `spark-x` was rejected — it lives on a separate /v2 (X1.5) /
-  // /x2 (X2) endpoint and would 404 on this /v3.1 base.
+  // `spark-api-open.xf-yun.com` is Spark's OpenAI-compatible HTTP endpoint (Bearer
+  // APIPassword). `spark-api.xf-yun.com` is the WebSocket host — `wss://.../v3.1/chat`
+  // etc., authenticated with an HMAC-SHA256 signature, not a bearer token — so it
+  // cannot serve this `format: "openai"` / `authHeader: "bearer"` entry.
+  // Model ids are the `domain` values accepted by the HTTP endpoint. `spark-x` is
+  // rejected: it lives on separate /v2 (X1.5) and /x2 (X2) endpoints.
   models: [
     { id: "4.0Ultra", name: "Spark 4.0 Ultra", contextLength: 32768 },
     { id: "generalv3", name: "Spark Pro", contextLength: 8192 },
     { id: "pro-128k", name: "Spark Pro 128K", contextLength: 131072 },
-    { id: "general", name: "General" },
+    { id: "lite", name: "Spark Lite", contextLength: 4096 },
   ],
 };

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -2476,8 +2476,8 @@
       }
     },
     "url": {
-      "nonStream": "https://spark-api.xf-yun.com/v1/chat/completions",
-      "stream": "https://spark-api.xf-yun.com/v1/chat/completions"
+      "nonStream": "https://spark-api-open.xf-yun.com/v1/chat/completions",
+      "stream": "https://spark-api-open.xf-yun.com/v1/chat/completions"
     }
   },
   "inference-net": {
@@ -4152,8 +4152,8 @@
       }
     },
     "url": {
-      "nonStream": "https://spark-api.xf-yun.com/v3.1/chat/completions",
-      "stream": "https://spark-api.xf-yun.com/v3.1/chat/completions"
+      "nonStream": "https://spark-api-open.xf-yun.com/v1/chat/completions",
+      "stream": "https://spark-api-open.xf-yun.com/v1/chat/completions"
     }
   },
   "stepfun": {

--- a/tests/unit/spark-openai-compatible-endpoint-7942.test.ts
+++ b/tests/unit/spark-openai-compatible-endpoint-7942.test.ts
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { iflytekProvider } from "../../open-sse/config/providers/registry/iflytek/index.ts";
+import { sparkdeskProvider } from "../../open-sse/config/providers/registry/sparkdesk/index.ts";
+import { FREE_MODEL_BUDGETS } from "../../open-sse/config/freeModelCatalog.data.ts";
+
+// #7942: both entries declare format: "openai" + authHeader: "bearer", but pointed at
+// spark-api.xf-yun.com — Spark's WebSocket host, which authenticates with an
+// HMAC-SHA256 signature over app_id/apiKey/apiSecret and rejects bearer tokens. The
+// OpenAI-compatible HTTP API lives on spark-api-open.xf-yun.com/v1.
+
+test("#7942: iflytek registry baseUrl uses Spark's OpenAI-compatible HTTP host", () => {
+  assert.equal(
+    iflytekProvider.baseUrl,
+    "https://spark-api-open.xf-yun.com/v1/chat/completions",
+    "iflytek must route through the OpenAI-compatible HTTP endpoint, not the " +
+      "WebSocket-only spark-api.xf-yun.com host (which rejects bearer auth)"
+  );
+});
+
+test("#7942: sparkdesk registry baseUrl uses Spark's OpenAI-compatible HTTP host", () => {
+  assert.equal(
+    sparkdeskProvider.baseUrl,
+    "https://spark-api-open.xf-yun.com/v1/chat/completions",
+    "sparkdesk must route through the OpenAI-compatible HTTP endpoint, not the " +
+      "WebSocket-only spark-api.xf-yun.com/v3.1 host (which rejects bearer auth)"
+  );
+});
+
+test("#7942: sparkdesk no longer advertises the WebSocket-only 'general' domain", () => {
+  const modelIds = sparkdeskProvider.models.map((m) => m.id);
+  assert.ok(
+    !modelIds.includes("general"),
+    "'general' is a WebSocket-domain value rejected by the HTTP endpoint"
+  );
+  assert.ok(
+    modelIds.includes("lite"),
+    "sparkdesk should advertise 'lite' (Spark Lite) in place of the removed 'general' domain"
+  );
+});
+
+test("#7942: free-model catalog's sparkdesk row references a model the registry still advertises", () => {
+  const sparkdeskModelIds = new Set(sparkdeskProvider.models.map((m) => m.id));
+  const catalogRows = FREE_MODEL_BUDGETS.filter((row) => row.provider === "sparkdesk");
+  assert.ok(catalogRows.length > 0, "expected at least one sparkdesk row in the free catalog");
+  for (const row of catalogRows) {
+    assert.ok(
+      sparkdeskModelIds.has(row.modelId),
+      `free catalog references sparkdesk/${row.modelId}, which the registry no longer advertises`
+    );
+  }
+});


### PR DESCRIPTION
## Problem

`iflytek` and `sparkdesk` both declare `format: "openai"` with `authType: "apikey"` / `authHeader: "bearer"`, but their `baseUrl` points at `spark-api.xf-yun.com`. That host is Spark's **WebSocket** endpoint — `wss://spark-api.xf-yun.com/v4.0/chat`, `/v3.1/chat`, `/v1.1/chat`, `/chat/max-32k` — and it authenticates with an HMAC-SHA256 signature computed over `app_id` / `apiKey` / `apiSecret`. It does not accept bearer tokens, and the paths currently configured (`/v1/chat/completions`, `/v3.1/chat/completions`) are not routes it serves.

The OpenAI-compatible HTTP API is a different host: `https://spark-api-open.xf-yun.com/v1/chat/completions`, authenticated with the console's APIPassword as a plain bearer token. As configured, neither provider can complete a request.

Sending a bearer-authenticated POST to the currently configured URLs returns:

```
HTTP 401  {"message":"HMAC signature cannot be verified: apikey not found"}
```

which is the WebSocket host's signature check rejecting the bearer credential. (For contrast, an unknown path on that host returns `403 {"message":"not found"}`, so the 401 is the auth layer, not a stray route.)

Sources: [HTTP 调用文档](https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html) gives `https://spark-api-open.xf-yun.com/v1/chat/completions` for the OpenAI-compatible interface; [Web(WebSocket) 文档](https://www.xfyun.cn/doc/spark/Web.html) gives the `wss://spark-api.xf-yun.com/...` endpoints.

## Changes

- `registry/iflytek/index.ts` — `baseUrl` → `https://spark-api-open.xf-yun.com/v1/chat/completions`. Model list is unchanged; all six ids are already exactly the `domain` values the HTTP endpoint accepts.
- `registry/sparkdesk/index.ts` — same `baseUrl` fix, plus `general` → `lite`. `general` is a WebSocket `domain` value (the v1.1 Lite tier) and is not accepted by the HTTP endpoint; `lite` is its HTTP equivalent.
- Both files: replaced the stale `Sweep 2026-06-19` comment, which described the model ids as verified against "this /v3.1 base", with a note on why the `-open` host is the one that can serve an `openai`/`bearer` entry.
- `tests/snapshots/provider/translate-path.json` — regenerated the four affected URL fields.

## Verification

- Both registry entries parse, and every model id in each is in the set the HTTP endpoint documents (`4.0Ultra`, `generalv3.5`, `max-32k`, `generalv3`, `pro-128k`, `lite`).
- Snapshot diff is exactly 4 fields (`iflytek`/`sparkdesk` × `url.stream`/`url.nonStream`); a structural walk over the whole file confirms no other entry changed, and the remaining 184 providers are byte-identical.
- Endpoint behaviour probed as quoted above.

Not verified: I do not have a funded Spark APIPassword, so there is no positive end-to-end completion in this PR — the evidence here shows the old host cannot serve a bearer request, plus the vendor docs for the correct one.

## Note for maintainers

With this fix `iflytek` and `sparkdesk` resolve to the same host, differing only in model list (`sparkdesk` is a subset). They were presumably split when the entries were believed to sit on two different API versions. Folding `sparkdesk` into an alias of `iflytek` would be the tidier end state, but that changes an id users may have configured, so I have left both intact and scoped this PR to the connectivity bug. Happy to follow up if you want them merged.
