### PR TITLE
fix: add Petals contract and repair MITM manager scope

### DIFF
--- a/open-sse/config/petals.ts
+++ b/open-sse/config/petals.ts
@@ -1,0 +1,11 @@
+import { stripTrailingSlashes } from "../utils/urlSanitize.ts";
+
+export const PETALS_DEFAULT_BASE_URL = "https://chat.petals.dev/api/v1/generate";
+export const PETALS_DEFAULT_MODEL = "meta-llama/Llama-2-70b-chat-hf";
+
+export function normalizePetalsBaseUrl(value: string | null | undefined): string {
+  const normalized = stripTrailingSlashes((value || PETALS_DEFAULT_BASE_URL).trim());
+  if (!normalized) return PETALS_DEFAULT_BASE_URL;
+
+  return normalized.endsWith("/generate") ? normalized : `${normalized}/generate`;
+}

--- a/src/mitm/manager.ts
+++ b/src/mitm/manager.ts
@@ -638,6 +638,8 @@ async function startMitmInternal(
   };
 }
 
+}
+
 /**
  * DNS teardown step of stopMitm() (#1809) — split out purely to keep
  * stopMitm()'s own cyclomatic complexity under the repo's ratchet; behavior


### PR DESCRIPTION
## Summary
- Adds the Petals module/config contract, including default base URL/model and base URL normalization.
- Repairs the MITM manager missing-scope/cleanup block, including the missing `startMitm` closure.
- Change limited to `open-sse/config/petals.ts` and `src/mitm/manager.ts`.

## Validation
- `git diff --check`: passed.
- Final upstream-base head: `a82c944e3a`; hosted validation is required.
- No routing, rate-limiter, migration, or Windows rename-retry changes.

## Tracking
Closes #7944