### PR TITLE
fix: web-cookie /models validation probe reports unsupported instead of a false valid (#7857)

### DIFF
--- a/changelog.d/fixes/7857-web-cookie-validation-probe.md
+++ b/changelog.d/fixes/7857-web-cookie-validation-probe.md
@@ -1,0 +1,1 @@
+- fix(providers): treat a non-401/403 response from the web-cookie `/models` validation probe (redirect, login-HTML 200, 404, 405, 429) as `unsupported` instead of `valid: true` for providers whose registry `baseUrl` is a conversation/completion endpoint rather than a real API root (#7857)

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -37,6 +37,7 @@ import {
   validationWrite,
   toValidationErrorResult,
   toWebCookieValidationErrorResult,
+  WEB_COOKIE_PROVIDERS_WITHOUT_MODELS_API,
 } from "./validation/transport";
 import {
   validateDeepSeekWebProvider,
@@ -162,6 +163,21 @@ export async function validateWebCookieProvider({
     // Attempt a minimal request to check if the session is valid
     // Use /models endpoint or a minimal completion request depending on the provider
     const baseUrl = normalizeBaseUrl(entry.baseUrl || "");
+
+    // Defense-in-depth: only an http(s) baseUrl without a query string is safe to
+    // probe by blindly appending `/models`. A ws(s):// baseUrl (e.g. copilot-web) is
+    // already rejected by the outbound URL guard downstream, but reject it explicitly
+    // here for the honest "unsupported" result instead of a confusing security-block
+    // message — this also covers a future http(s) baseUrl carrying a query string,
+    // which the guard does not currently block (#7857 acceptance criteria).
+    if (!/^https?:\/\//i.test(baseUrl) || baseUrl.includes("?")) {
+      return {
+        valid: false,
+        error: "Provider validation not supported",
+        unsupported: true,
+      };
+    }
+
     const testUrl = `${baseUrl}/models`;
 
     const res = await validationRead(
@@ -182,6 +198,20 @@ export async function validateWebCookieProvider({
         error: "SESSION_EXPIRED",
         errorCode: "AUTH_007",
         unsupported: false,
+      };
+    }
+
+    // #7857: for providers whose baseUrl is a conversation/completion endpoint rather
+    // than a real API root, the /models path never existed upstream — a redirect,
+    // login-HTML 200, 404, 405, or 429 from it is not a meaningful auth signal and is
+    // indistinguishable from a genuinely valid session. Report the same honest
+    // "unsupported" result the !entry branch above already gives its no-registry
+    // siblings, instead of a false `valid: true`.
+    if (WEB_COOKIE_PROVIDERS_WITHOUT_MODELS_API.has(provider)) {
+      return {
+        valid: false,
+        error: "Provider validation not supported",
+        unsupported: true,
       };
     }
 

--- a/src/lib/providers/validation/transport.ts
+++ b/src/lib/providers/validation/transport.ts
@@ -107,6 +107,28 @@ export function isSecurityBlockError(error: unknown): boolean {
 // #7542 plan-file, "Risks").
 const WEB_COOKIE_PROVIDERS_WITH_UNRELIABLE_MODELS_PROBE = new Set(["lmarena"]);
 
+// #7857 — web-cookie providers whose registry `baseUrl` is a conversation/completion
+// endpoint, not a real API root (e.g. huggingchat's baseUrl is
+// "https://huggingface.co/chat/conversation", not "https://huggingface.co"). Appending
+// `/models` to these produces a path the upstream never served, so its status
+// (200/404/405/429/redirect/login-HTML) carries no meaningful auth signal — it is NOT
+// distinguishable from a genuinely valid session. A 401/403 from the same probe IS still
+// treated as a real SESSION_EXPIRED signal (some of these hosts auth-gate every path,
+// including nonexistent ones), so providers here still get probed; only the non-401/403
+// branch is short-circuited to the honest "unsupported" result instead of `valid: true`.
+// lmarena is deliberately NOT in this set — it already degrades via the
+// WEB_COOKIE_PROVIDERS_WITH_UNRELIABLE_MODELS_PROBE/REDIRECT_BLOCKED path above (#7542).
+export const WEB_COOKIE_PROVIDERS_WITHOUT_MODELS_API = new Set([
+  "huggingchat",
+  "chatgpt-web",
+  "grok-web",
+  "notion-web",
+  "t3-web",
+  "yuanbao-web",
+  "copilot-web",
+  "copilot-m365-web",
+]);
+
 export function toWebCookieValidationErrorResult(provider: string, error: unknown) {
   if (
     error instanceof SafeOutboundFetchError &&

--- a/tests/unit/provider-validation-web-cookie-auth007.test.ts
+++ b/tests/unit/provider-validation-web-cookie-auth007.test.ts
@@ -56,9 +56,13 @@ test("should_return_AUTH_007_when_models_endpoint_returns_403", async () => {
   assert.equal(result.error, "SESSION_EXPIRED");
 });
 
-test("should_return_valid_when_models_endpoint_returns_200", async () => {
-  // A non-401/403 status from the /models probe means the cookie was accepted,
-  // so the session is treated as valid.
+test("should_return_unsupported_when_models_endpoint_returns_200_for_a_conversation_baseUrl", async () => {
+  // #7857: chatgpt-web's registry baseUrl is a conversation endpoint
+  // ("https://chatgpt.com/backend-api/conversation"), not a real API root, so
+  // "${baseUrl}/models" is a path that never existed upstream. A 200 from that
+  // nonsense path (e.g. a login-page SPA shell) is not a meaningful auth signal and
+  // is indistinguishable from a genuinely valid session — it must be reported as
+  // unsupported, not silently accepted as valid.
   mockFetch(200, JSON.stringify({ ok: true, data: [] }));
 
   const result = await validateWebCookieProvider({
@@ -68,7 +72,8 @@ test("should_return_valid_when_models_endpoint_returns_200", async () => {
   });
 
   assert.equal(fetchCalls, 1, "the /models probe must be the mocked fetch, not the live network");
-  assert.equal(result.valid, true);
+  assert.equal(result.valid, false);
+  assert.equal(result.unsupported, true);
 });
 
 test("should_return_unsupported_when_provider_not_in_registry", async () => {

--- a/tests/unit/web-cookie-validation-false-positive-7857.test.ts
+++ b/tests/unit/web-cookie-validation-false-positive-7857.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+let nextResponse: { status: number; body: string } = { status: 404, body: "Not Found" };
+let fetchCalls = 0;
+let lastUrl = "";
+
+const { validateWebCookieProvider } = await import("../../src/lib/providers/validation.ts");
+
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  fetchCalls++;
+  lastUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  return new Response(nextResponse.body, { status: nextResponse.status });
+}) as typeof fetch;
+
+function mockFetch(status: number, body: string) {
+  nextResponse = { status, body };
+  fetchCalls = 0;
+  lastUrl = "";
+}
+
+test("BUG #7857: a 404 from huggingchat's nonsense /models probe path is reported valid:true", async () => {
+  mockFetch(404, "Not Found");
+  const result = await validateWebCookieProvider({
+    provider: "huggingchat",
+    apiKey: "garbage_cookie_value_that_was_never_valid=xyz",
+    providerSpecificData: {},
+  });
+  assert.equal(fetchCalls, 1);
+  assert.equal(lastUrl, "https://huggingface.co/chat/conversation/models");
+  assert.equal(
+    result.valid,
+    false,
+    "a 404 from a nonsense probe path must never be reported as a valid cookie session"
+  );
+});
+
+test("BUG #7857: same false positive reproduces for grok-web (conversations/new endpoint)", async () => {
+  mockFetch(405, "Method Not Allowed");
+  const result = await validateWebCookieProvider({
+    provider: "grok-web",
+    apiKey: "sso=garbage; sso-rw=garbage",
+    providerSpecificData: {},
+  });
+  assert.equal(fetchCalls, 1);
+  assert.equal(
+    result.valid,
+    false,
+    "a 405 from a nonsense probe path must never be reported as a valid cookie session"
+  );
+});


### PR DESCRIPTION
Closes #7857

## Root cause

`validateWebCookieProvider()` (`src/lib/providers/validation.ts`) built its session probe as `${normalizeBaseUrl(entry.baseUrl)}/models`, blindly appending `/models` to whatever the provider registry's `baseUrl` is. For several web-cookie providers `baseUrl` is a conversation/completion endpoint, not an API root (e.g. huggingchat → `https://huggingface.co/chat/conversation`, grok-web → `https://grok.com/rest/app-chat/conversations/new`, chatgpt-web → `https://chatgpt.com/backend-api/conversation`), so the probe hits a path that never existed upstream. The status handler then treated any non-401/403 response (a redirect, a login-page 200, 404, 405, 429, …) as `valid: true` — indistinguishable from, and reported identically to, a genuinely valid session.

The codebase had already generalized this exact fix once, narrowly, for `lmarena` only (`WEB_COOKIE_PROVIDERS_WITH_UNRELIABLE_MODELS_PROBE`, added for #7542) — this PR extends the same "degrade to `unsupported` instead of trusting the status" instinct to the rest of the conversation-endpoint web-cookie providers.

## Fix

- `src/lib/providers/validation/transport.ts`: added `WEB_COOKIE_PROVIDERS_WITHOUT_MODELS_API`, listing every web-cookie provider whose registry `baseUrl` is a conversation/completion endpoint (huggingchat, chatgpt-web, grok-web, notion-web, t3-web, yuanbao-web, copilot-web, copilot-m365-web). `lmarena` stays out of this set — it's already handled via the existing `REDIRECT_BLOCKED` degrade path.
- `src/lib/providers/validation.ts` (`validateWebCookieProvider`):
  - Added a defense-in-depth guard: only an `http(s)` `baseUrl` without a query string is probed. A `ws(s)://` `baseUrl` (copilot-web, copilot-m365-web) or a future `http(s)` `baseUrl` with a query string now returns an honest `unsupported: true` instead of relying on the outbound URL guard's `securityBlocked` path.
  - 401/403 from the probe still returns `SESSION_EXPIRED` (`AUTH_007`) — that's still a real signal even on a wrong path, since some of these hosts auth-gate every route.
  - Any other status, for a provider in `WEB_COOKIE_PROVIDERS_WITHOUT_MODELS_API`, now returns `unsupported: true` instead of `valid: true`.

## Regression test

`tests/unit/web-cookie-validation-false-positive-7857.test.ts` (new) — reproduces the false positive for huggingchat (404) and grok-web (405):

```
node --import tsx/esm --test tests/unit/web-cookie-validation-false-positive-7857.test.ts
```

RED on unfixed code (`src/lib/providers/validation.ts` / `validation/transport.ts` at `origin/release/v3.8.49`):
```
✖ BUG #7857: a 404 from huggingchat's nonsense /models probe path is reported valid:true
  true !== false
✖ BUG #7857: same false positive reproduces for grok-web (conversations/new endpoint)
  true !== false
ℹ tests 2
ℹ pass 0
ℹ fail 2
```

GREEN after the fix:
```
✔ BUG #7857: a 404 from huggingchat's nonsense /models probe path is reported valid:true
✔ BUG #7857: same false positive reproduces for grok-web (conversations/new endpoint)
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

`tests/unit/provider-validation-web-cookie-auth007.test.ts` — `should_return_valid_when_models_endpoint_returns_200` encoded the bug for `chatgpt-web` (a conversation-endpoint provider): renamed/updated to `should_return_unsupported_when_models_endpoint_returns_200_for_a_conversation_baseUrl`, asserting `unsupported: true`. Its 401/403 siblings (SESSION_EXPIRED) are unchanged and still pass, since that branch runs before the new unsupported check.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/web-cookie-validation-false-positive-7857.test.ts` — RED→GREEN
- `node --import tsx/esm --test tests/unit/web-cookie-validation-proxy-7058.test.ts tests/unit/validation-helpers-split.test.ts tests/unit/validation-format-validators-split.test.ts tests/unit/validation-web-providers-split.test.ts tests/unit/web-cookie-validation-fallback.test.ts tests/unit/arena-cookie-validation-redirect-7542.test.ts tests/unit/provider-validation-web-cookie-auth007.test.ts` — 29/29 pass
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2084 violations, baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (903 violations, baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — no drift
- `node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json` (equivalent to `npm run typecheck:core`) — exit 0
- `eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope

Scoped strictly to the web-cookie `/models` validation probe path (`validateWebCookieProvider`) per the plan-file. No changes to the per-provider `SPECIALTY_VALIDATORS` (grok-web, chatgpt-web, etc. already have their own dedicated validators in production traffic and are unaffected by this change) — this fixes the generic fallback path plus hardens the shared function directly, since it is a standalone exported/tested unit.
