### PR TITLE
fix: add amazon-q to the static model catalog (#7820)

### DIFF
--- a/changelog.d/fixes/7820-amazon-q-static-models.md
+++ b/changelog.d/fixes/7820-amazon-q-static-models.md
@@ -1,0 +1,1 @@
+- fix(api): add amazon-q to the static model catalog so "Available Models" no longer 400s (#7820)

--- a/src/lib/providers/staticModels.ts
+++ b/src/lib/providers/staticModels.ts
@@ -73,6 +73,13 @@ const STATIC_MODEL_PROVIDERS: Record<string, () => Array<{ id: string; name: str
     // so the "Available Models" UI shows something instead of a hard failure (#6142).
     { id: "devin", name: "Devin (Cognition cloud agent)" },
   ],
+  "amazon-q": () => [
+    // Amazon Q Developer shares KiroExecutor + OAuth wiring with kiro but has no
+    // discovery config or registry catalog of its own — single non-selectable
+    // placeholder so the "Available Models" UI shows something instead of the
+    // hard "does not support models listing" failure (#7820).
+    { id: "amazon-q", name: "Amazon Q Developer" },
+  ],
   "linkup-search": () => [
     // Linkup web search — the "model" is the search depth (docs.linkup.so #5571).
     { id: "standard", name: "Standard (single-iteration agentic search)" },

--- a/tests/unit/repro-7820-amazon-q-static-models.test.ts
+++ b/tests/unit/repro-7820-amazon-q-static-models.test.ts
@@ -1,0 +1,14 @@
+// tests/unit/repro-7820-amazon-q-static-models.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { getStaticModelsForProvider } from "../../src/lib/providers/staticModels";
+
+test("#7820: amazon-q should expose a static model catalog like jules/devin do (no /v1/models endpoint)", () => {
+  const amazonQStaticModels = getStaticModelsForProvider("amazon-q");
+  assert.ok(
+    Array.isArray(amazonQStaticModels) && amazonQStaticModels.length > 0,
+    "amazon-q should expose a static model catalog like jules/devin do, instead of falling through " +
+      "to the models route's 'does not support models listing' hard error"
+  );
+});


### PR DESCRIPTION
Closes #7820

## Root cause

`amazon-q` is a registered provider (`src/shared/constants/providers.ts:421`), executing via `KiroExecutor` and sharing OAuth wiring with `kiro`, but has zero model-catalog wiring: no `STATIC_MODEL_PROVIDERS` entry (`src/lib/providers/staticModels.ts`), no `PROVIDER_MODELS_CONFIG` discovery entry, no registry catalog. The "Available Models" import step for an amazon-q connection therefore always falls through to `src/app/api/providers/[id]/models/route.ts:2012-2016`'s hard 400 `"Provider amazon-q does not support models listing"` — matching this issue and the linked #7362 user report.

## Fix

Added an `"amazon-q"` entry to `STATIC_MODEL_PROVIDERS` in `src/lib/providers/staticModels.ts`, in the same "non-LLM providers with no /v1/models endpoint" block as `jules`/`devin`/`linkup-search` — a single non-selectable placeholder model id, mirroring the exact pattern already proven for `devin` (#6142). This makes `getStaticModelsForProvider("amazon-q")` return a non-empty catalog, short-circuiting the `!config` hard-error branch with a normal `local_catalog` response.

## Regression test (Hard Rule #18 — TDD)

`tests/unit/repro-7820-amazon-q-static-models.test.ts`

RED (before fix):
```
✖ #7820: amazon-q should expose a static model catalog like jules/devin do (no /v1/models endpoint)
  AssertionError [ERR_ASSERTION]: amazon-q should expose a static model catalog like jules/devin do, ...
ℹ tests 1
ℹ pass 0
ℹ fail 1
```

GREEN (after fix):
```
✔ #7820: amazon-q should expose a static model catalog like jules/devin do (no /v1/models endpoint) (2.68ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/repro-7820-amazon-q-static-models.test.ts` — RED then GREEN
- Sibling suites (staticModels / provider-models-route family), all pre-existing green kept green:
  - `tests/unit/search-providers-static-model-catalog-7529.test.ts` (2 pass)
  - `tests/unit/bailian-coding-plan-provider.test.ts` (38 pass)
  - `tests/unit/static-models-venice-web-6269.test.ts` (1 pass)
  - `tests/unit/provider-models-route.test.ts` (58 pass)
  - `tests/unit/openrouter-embeddings-catalog-6976.test.ts` (4 pass)
  - `tests/unit/devin-cloud-agent-validator-6142.test.ts` (5 pass)
  - `tests/unit/probe-6699-jules-executor-misroute.test.ts` (2 pass)
  - `tests/unit/t28-model-catalog-updates.test.ts` (8 pass)
  - `tests/unit/t31-t33-t34-t38-model-specs.test.ts` (8 pass)
  - `tests/unit/repro-6142-devin-cloud-agent-unwired.test.ts` (2 pass)
  - `tests/unit/free-tier-catalog.test.ts` (4 pass)
  - `tests/unit/cli-catalog-removed.test.ts` (4 pass)
  - `tests/unit/provider-registry-models-guard.test.ts` (2 pass)
  - `tests/unit/check-known-symbols.test.ts` (35 pass)
- `node scripts/check/check-file-size.mjs` — OK, no new violations on touched files
- `node scripts/check/check-complexity.mjs` — OK, 2084 violations (baseline 2130)
- `node scripts/check/check-cognitive-complexity.mjs` — OK, 903 violations (baseline 950)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` — OK, no drift
- `npm run typecheck:core` (`tsc --pretty false -p tsconfig.typecheck-core.json`) — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/lib/providers/staticModels.ts tests/unit/repro-7820-amazon-q-static-models.test.ts` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope note

Follow-up flagged but explicitly out of scope for this minimal fix (per the plan-file): since `amazon-q` shares `KiroExecutor` and OAuth wiring with `kiro` (which has a real multi-model registry + live CodeWhisperer discovery), a richer fix could expose amazon-q's real model list the same way — but that requires live verification against AWS's CodeWhisperer/Amazon-Q-Developer API, so it's not part of this surgical fix.
