### PR TITLE
fix(cli): translate missing sqlite bindings error into actionable guidance (#7868)

### DIFF
--- a/bin/cli/sqlite.mjs
+++ b/bin/cli/sqlite.mjs
@@ -21,6 +21,18 @@ export function createSqliteNativeError(error) {
         "(rebuilds into a user-writable runtime; works without a C++ toolchain)."
     );
   }
+  if (
+    message.includes("Could not locate the bindings file") ||
+    message.includes("MODULE_NOT_FOUND") ||
+    message.includes("Cannot find module 'better-sqlite3'")
+  ) {
+    return new Error(
+      "better-sqlite3 native binding could not be found (no prebuilt addon for this platform). " +
+        "This is common under `npx`, which runs a fresh, ephemeral install that never built the addon. " +
+        "Run: omniroute runtime repair  " +
+        "(rebuilds into a user-writable runtime; works without a C++ toolchain)."
+    );
+  }
   return error;
 }
 

--- a/changelog.d/fixes/7868-reset-password-sqlite-bindings.md
+++ b/changelog.d/fixes/7868-reset-password-sqlite-bindings.md
@@ -1,0 +1,1 @@
+- fix(cli): translate missing better-sqlite3 native bindings error into actionable `omniroute runtime repair` guidance in `reset-password`/setup CLI commands (#7868)

--- a/tests/unit/cli-sqlite-bindings-not-found-7868.test.ts
+++ b/tests/unit/cli-sqlite-bindings-not-found-7868.test.ts
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createSqliteNativeError } from "../../bin/cli/sqlite.mjs";
+
+test("#7868: createSqliteNativeError() gives actionable guidance for a missing-bindings-file error", () => {
+  const rawBindingsError = new Error(
+    "Could not locate the bindings file. Tried:\n" +
+      " → /Users/agent_user/.npm/_npx/44b85dff014d9ceb/node_modules/better-sqlite3/build/better_sqlite3.node\n" +
+      " → /Users/agent_user/.npm/_npx/44b85dff014d9ceb/node_modules/better-sqlite3/build/Release/better_sqlite3.node\n" +
+      " → /Users/agent_user/.npm/_npx/44b85dff014d9ceb/node_modules/better-sqlite3/lib/binding/node-v147-darwin-arm64/better_sqlite3.node"
+  );
+
+  const translated = createSqliteNativeError(rawBindingsError);
+
+  assert.notStrictEqual(
+    translated.message,
+    rawBindingsError.message,
+    "createSqliteNativeError() passed the raw 'Could not locate the bindings file' dump through " +
+      "unchanged instead of translating it into actionable guidance (#7868)"
+  );
+  assert.match(
+    translated.message,
+    /runtime repair/i,
+    "translated error should point the user at the existing self-heal command " +
+      "(`omniroute runtime repair`), same as the ABI-mismatch branch already does"
+  );
+  assert.ok(
+    !translated.message.includes("Tried:"),
+    "a raw path dump reaching the user is itself a signal the fix regressed"
+  );
+});


### PR DESCRIPTION
Closes #7868

## Root cause

`bin/cli/sqlite.mjs::createSqliteNativeError()` only recognized the ABI-mismatch native
error class (`NODE_MODULE_VERSION` / `ERR_DLOPEN_FAILED` — binary exists, wrong Node
version) and translated it into a guidance message pointing at `omniroute runtime repair`.

Every other error class — including the `bindings` npm package's "Could not locate the
bindings file. Tried: …" error, thrown when the better-sqlite3 native addon was never
built/downloaded at all — was silently passed through unmodified. This is exactly the
error class `npx omniroute reset-password` hits, since `npx` runs a fresh, ephemeral
install that never builds the native addon. Users got a raw 12-line path dump instead of
any guidance.

This is a packaging/CLI fix — the regression test is a static guard of the
`createSqliteNativeError()` resolution path with the reporter's exact error text, not a
live global `npx` install.

## Fix

Widen the condition in `createSqliteNativeError()` to also match:
- `"Could not locate the bindings file"` (the `bindings` package's no-binary-found error)
- `MODULE_NOT_FOUND`
- `"Cannot find module 'better-sqlite3'"`

and emit the same actionable guidance pointing at `omniroute runtime repair`, explaining
this is common under `npx`.

## Regression test (TDD, Hard Rule #18)

`tests/unit/cli-sqlite-bindings-not-found-7868.test.ts` — feeds `createSqliteNativeError()`
the reporter's exact error text.

RED (before fix):
```
✖ #7868: createSqliteNativeError() gives actionable guidance for a missing-bindings-file error
  AssertionError [ERR_ASSERTION]: createSqliteNativeError() passed the raw 'Could not
  locate the bindings file' dump through unchanged instead of translating it into
  actionable guidance (#7868)
```

GREEN (after fix):
```
✔ #7868: createSqliteNativeError() gives actionable guidance for a missing-bindings-file error
ℹ pass 1
ℹ fail 0
```

Sibling test file `tests/unit/sqlite-repair-discoverability-3476.test.ts` (which already
covers the ABI-mismatch branch and the "unrelated errors pass through untouched" case)
still passes unchanged — no existing assertions were weakened.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/cli-sqlite-bindings-not-found-7868.test.ts tests/unit/sqlite-repair-discoverability-3476.test.ts` → 8/8 pass
- `node scripts/check/check-file-size.mjs` → OK
- `npx eslint --no-config-lookup --config eslint.complexity.config.mjs --format json bin/cli/sqlite.mjs` → 0 issues
- `npx eslint --no-config-lookup --config eslint.sonarjs.config.mjs --format json bin/cli/sqlite.mjs` → 0 issues
- `node scripts/check/check-complexity.mjs` → OK (2084 violations vs baseline 2130, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (903 violations vs baseline 950, no regression)
- `node scripts/check/check-mutation-test-coverage.mjs --strict` → OK, no drift
- `node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json` (typecheck:core) → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/cli-sqlite-bindings-not-found-7868.test.ts` → clean (`bin/cli/sqlite.mjs` is outside the eslint-scanned glob, pre-existing scope, unrelated to this change)
- `node scripts/check/check-changelog-integrity.mjs` → OK
- `changelog.d/fixes/7868-reset-password-sqlite-bindings.md` added

## Scope

Diff limited to `bin/cli/sqlite.mjs` (the widened condition), the new regression test,
and the changelog fragment. No drive-by refactors.
