### PR TITLE
fix(test): widen ratelimit-admission pollUntil deadline to end nightly-compat flake (#7842)

### DIFF
--- a/changelog.d/fixes/7842-nightly-compat-node2426.md
+++ b/changelog.d/fixes/7842-nightly-compat-node2426.md
@@ -1,0 +1,1 @@
+- fix(test): widen ratelimit-admission pollUntil deadline to 10s to end nightly-compat flake (#7842)

--- a/tests/unit/ratelimit-admission-control-6593.test.ts
+++ b/tests/unit/ratelimit-admission-control-6593.test.ts
@@ -36,7 +36,7 @@ function wait(ms: number) {
 // under load. Poll the live counts instead of guessing a wall-clock delay.
 async function pollUntil(
   predicate: () => boolean,
-  { timeoutMs = 2000, intervalMs = 5 } = {}
+  { timeoutMs = 10000, intervalMs = 5 } = {}
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {


### PR DESCRIPTION
Closes #7842

The bot-filed nightly-compat aggregate (8 red jobs: Node 24 & 26 × shards 1-4) is **not** a Node-version incompatibility — the failing test *sets* are byte-identical across Node 24 and Node 26 in every matching shard. It is the recurring base-red-snapshot pattern tracked in #6949 and closed 4× before (#7025/#7140/#7675/#7742).

Re-running all 18 distinct failing subtests against the current release tip (~40 commits ahead of the tested SHA `eb02d4d2`): **17/18 already pass** (fixed forward by same-day compression/i18n/registry cleanup). **1/18 is a genuine still-reproducing defect** and is what this PR fixes:

`tests/unit/ratelimit-admission-control-6593.test.ts` → `#6593 withRateLimit: fast-fails once the queue is at the configured maxQueueDepth` failed with `pollUntil: condition not met within 2000ms`. The test's `pollUntil` helper had a fixed **2000ms** deadline that races Bottleneck's QUEUED→EXECUTING event-loop-tick transition under contention (same subsystem the #7719 event-loop-starvation fix touched). The admission logic (`checkQueueAdmission`, `RATE_LIMIT_QUEUE_FULL`/429) is correct and covered by 3 passing pure-unit tests in the same file — this is a test-harness timing-margin bug only.

**Fix**: widen the default `pollUntil` deadline **2000ms → 10000ms** (one value swap; covers both integration call sites). Suite green 7/7.

Validation (Hard Rule #18): RED reproduced under load in triage (`pollUntil: condition not met within 2000ms`); GREEN after the bump. Test-only diff, no production code touched.
