### PR TITLE
feat(promptql): USD credits + multi-turn thread continuity

### DIFF
--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -95,6 +95,7 @@ import { moonshotProvider } from "./registry/moonshot/index.ts";
 import { bazaarlinkProvider } from "./registry/bazaarlink/index.ts";
 import { perplexityProvider } from "./registry/perplexity/index.ts";
 import { perplexity_webProvider } from "./registry/perplexity/web/index.ts";
+import { promptqlProvider } from "./registry/promptql/index.ts";
 import { minimaxProvider } from "./registry/minimax/index.ts";
 import { minimax_cnProvider } from "./registry/minimax/cn/index.ts";
 import { haiperProvider } from "./registry/haiper/index.ts";
@@ -281,6 +282,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   bazaarlink: bazaarlinkProvider,
   perplexity: perplexityProvider,
   "perplexity-web": perplexity_webProvider,
+  promptql: promptqlProvider,
   minimax: minimaxProvider,
   "minimax-cn": minimax_cnProvider,
   haiper: haiperProvider,

--- a/open-sse/config/providers/registry/promptql/index.ts
+++ b/open-sse/config/providers/registry/promptql/index.ts
@@ -1,0 +1,19 @@
+import type { RegistryEntry } from "../../shared.ts";
+import { PROMPTQL_FALLBACK_MODELS } from "../../../../services/promptqlModels.ts";
+
+// PromptQL playground agent (prompt.ql.app) — unofficial reverse-engineered session.
+// Live catalog: GraphQL FetchLlmConfigs; seed below is offline fallback.
+export const promptqlProvider: RegistryEntry = {
+  id: "promptql",
+  alias: "pql",
+  format: "openai",
+  executor: "promptql",
+  baseUrl: "https://data.prompt.ql.app/promptql/playground-v2-hge/v1/graphql",
+  authType: "apikey",
+  authHeader: "authorization",
+  passthroughModels: true,
+  models: PROMPTQL_FALLBACK_MODELS.map((m) => ({
+    id: m.id,
+    name: m.name,
+  })),
+};

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -16,6 +16,7 @@ import { VertexExecutor } from "./vertex.ts";
 import { CliproxyapiExecutor } from "./cliproxyapi.ts";
 import { NineRouterExecutor } from "./ninerouter.ts";
 import { PerplexityWebExecutor } from "./perplexity-web.ts";
+import { PromptQlExecutor } from "./promptql.ts";
 import { GrokWebExecutor } from "./grok-web.ts";
 import { GeminiWebExecutor } from "./gemini-web.ts";
 import { GeminiBusinessExecutor } from "./gemini-business.ts";
@@ -98,6 +99,8 @@ const executors = {
   nr: new NineRouterExecutor(), // Alias
   "perplexity-web": new PerplexityWebExecutor(),
   "pplx-web": new PerplexityWebExecutor(), // Alias
+  promptql: new PromptQlExecutor(),
+  pql: new PromptQlExecutor(), // Alias
   "grok-web": new GrokWebExecutor(),
   "claude-web": new ClaudeWebWithAutoRefresh(),
   "cw-web": new ClaudeWebWithAutoRefresh(), // Alias
@@ -217,6 +220,7 @@ export { CliproxyapiExecutor } from "./cliproxyapi.ts";
 export { NineRouterExecutor } from "./ninerouter.ts";
 export { VertexExecutor } from "./vertex.ts";
 export { PerplexityWebExecutor } from "./perplexity-web.ts";
+export { PromptQlExecutor } from "./promptql.ts";
 export { GrokWebExecutor } from "./grok-web.ts";
 export { GeminiWebExecutor } from "./gemini-web.ts";
 export { KieExecutor } from "./kie.ts";

--- a/open-sse/executors/promptql.ts
+++ b/open-sse/executors/promptql.ts
@@ -1,0 +1,1058 @@
+/**
+ * PromptQLExecutor — prompt.ql.app playground agent (Unofficial/Experimental)
+ *
+ * Reverse-engineered from the SPA (2026-07-20):
+ *   - Mutations start_thread / send_thread_message only return UserMessage
+ *   - AI output is AgentMessage rows on thread_events (Hasura stream or poll)
+ *   - Auth: Bearer JWT (Hasura enrich-token) + projectId claim
+ *   - Models: FetchLlmConfigs; optional llmConfigId on start_thread (String!)
+ *   - Credits: promptql_project_credit_summary on data.pro.ql.app (usage leaf)
+ *
+ * OpenAI multi-turn is preserved via sticky PromptQL thread_id:
+ *   - Prefer body.promptql_thread_id / X-PromptQL-Thread-Id from the client
+ *   - Else history-prefix fingerprint (full user+assistant before last user)
+ *   - First turn always start_thread (never first-user-only sticky — that
+ *     collided across SkillsManager/agent sessions and routed follow-ups to
+ *     older chats)
+ * Response always echoes X-PromptQL-Thread-Id + promptql_thread_id.
+ *
+ * Token refresh (POST auth.pro.ql.app/ddn/project/token with session cookies)
+ * is implemented best-effort and still needs production verification.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { BaseExecutor, type ExecuteInput } from "./base.ts";
+import { makeExecutorErrorResult as makeErrorResult } from "../utils/error.ts";
+import {
+  PROMPTQL_FALLBACK_MODELS,
+  clientFacingPromptQlModelId,
+  resolvePromptQlModel,
+  type PromptQlModel,
+} from "../services/promptqlModels.ts";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const PLAYGROUND_GQL =
+  process.env.PROMPTQL_GRAPHQL_ENDPOINT ||
+  "https://data.prompt.ql.app/promptql/playground-v2-hge/v1/graphql";
+const CREDITS_GQL =
+  process.env.PROMPTQL_CREDITS_ENDPOINT || "https://data.pro.ql.app/v1/graphql";
+const TOKEN_REFRESH_URL =
+  process.env.PROMPTQL_TOKEN_REFRESH_URL || "https://auth.pro.ql.app/ddn/project/token";
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+const DEFAULT_TZ = "UTC";
+const POLL_INTERVAL_MS = 1200;
+const POLL_TIMEOUT_MS = Number(process.env.PROMPTQL_POLL_TIMEOUT_MS || 180_000);
+
+// ─── GraphQL documents ──────────────────────────────────────────────────────
+
+const START_THREAD_WITH_MODEL = `
+mutation StartThreadWithModel(
+  $message: String!
+  $projectId: String!
+  $timezone: String!
+  $llmConfigId: String!
+  $uploads: [UserUploadInput!]
+  $agentResponseConfig: String
+) {
+  start_thread(
+    message: $message
+    projectId: $projectId
+    timezone: $timezone
+    llmConfigId: $llmConfigId
+    roomless: true
+    uploads: $uploads
+    agentResponseConfig: $agentResponseConfig
+  ) {
+    thread_id
+    title
+    created_at
+    thread_events { thread_event_id created_at event_data }
+  }
+}`;
+
+const START_THREAD_ROOMLESS = `
+mutation StartThreadRoomless(
+  $message: String!
+  $projectId: String!
+  $timezone: String!
+  $uploads: [UserUploadInput!]
+  $agentResponseConfig: String
+) {
+  start_thread(
+    message: $message
+    projectId: $projectId
+    timezone: $timezone
+    roomless: true
+    uploads: $uploads
+    agentResponseConfig: $agentResponseConfig
+  ) {
+    thread_id
+    title
+    created_at
+    thread_events { thread_event_id created_at event_data }
+  }
+}`;
+
+const SEND_THREAD_MESSAGE = `
+mutation SendThreadMessage(
+  $message: String!
+  $timezone: String!
+  $threadId: String!
+  $uploads: [UserUploadInput!]
+  $agentResponseConfig: String
+) {
+  send_thread_message(
+    threadId: $threadId
+    timezone: $timezone
+    message: $message
+    uploads: $uploads
+    agentResponseConfig: $agentResponseConfig
+  ) {
+    thread_event_id
+    event_data
+    created_at
+  }
+}`;
+
+const QUERY_THREAD_EVENTS = `
+query QueryThreadEvents($thread_id: uuid!, $after_event_id: bigint!) {
+  thread_events(
+    where: {
+      thread_id: {_eq: $thread_id}
+      thread_event_id: {_gt: $after_event_id}
+    }
+    order_by: {thread_event_id: asc}
+  ) {
+    thread_event_id
+    thread_id
+    event_data
+    created_at
+    user_id
+  }
+}`;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface ChatMessage {
+  role: string;
+  content: unknown;
+}
+
+interface PromptQlRequestBody {
+  messages?: ChatMessage[];
+  model?: string;
+  promptql_thread_id?: string;
+  thread_id?: string;
+}
+
+interface ThreadEvent {
+  thread_event_id: string | number;
+  event_data?: unknown;
+  created_at?: string;
+}
+
+// ─── Credential helpers ─────────────────────────────────────────────────────
+
+function readStr(v: unknown): string {
+  if (typeof v !== "string") return "";
+  const t = v.trim();
+  return t.length ? t : "";
+}
+
+function readPs(data: unknown, keys: readonly string[]): string {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return "";
+  const rec = data as Record<string, unknown>;
+  for (const k of keys) {
+    const v = readStr(rec[k]);
+    if (v) return v;
+  }
+  return "";
+}
+
+/** Accept bare JWT or `Bearer …`. */
+export function normalizePromptQlToken(raw: string): string {
+  const t = raw.trim().replace(/^Bearer\s+/i, "").trim();
+  return t;
+}
+
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const part = token.split(".")[1];
+    if (!part) return null;
+    const json = Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString(
+      "utf8"
+    );
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function extractProjectIdFromToken(token: string): string {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return "";
+  const hasura = payload["https://promptql.hasura.io"];
+  if (hasura && typeof hasura === "object" && !Array.isArray(hasura)) {
+    const id = readStr((hasura as Record<string, unknown>)["x-hasura-project-id"]);
+    if (id) return id;
+  }
+  return readStr(payload.project_id) || readStr(payload.projectId);
+}
+
+export function isJwtExpired(token: string, skewSec = 30): boolean {
+  const payload = decodeJwtPayload(token);
+  const exp = payload && typeof payload.exp === "number" ? payload.exp : 0;
+  if (!exp) return false;
+  return Math.floor(Date.now() / 1000) >= exp - skewSec;
+}
+
+export function resolvePromptQlCredentials(credentials: ExecuteInput["credentials"]): {
+  token: string;
+  projectId: string;
+  cookie: string;
+  timezone: string;
+} {
+  const direct =
+    readStr(credentials?.apiKey) ||
+    readStr((credentials as Record<string, unknown> | undefined)?.accessToken) ||
+    readStr((credentials as Record<string, unknown> | undefined)?.token);
+  const ps = credentials?.providerSpecificData;
+  const token = normalizePromptQlToken(
+    direct || readPs(ps, ["token", "jwt", "accessToken", "bearer", "apiKey"])
+  );
+  const projectId =
+    readPs(ps, ["projectId", "project_id", "x-hasura-project-id"]) ||
+    extractProjectIdFromToken(token);
+  const cookie = readPs(ps, ["cookie", "sessionCookie", "authCookie"]);
+  const timezone = readPs(ps, ["timezone", "tz"]) || DEFAULT_TZ;
+  return { token, projectId, cookie, timezone };
+}
+
+// ─── Message / content helpers ──────────────────────────────────────────────
+
+export function extractMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object") {
+          const p = part as Record<string, unknown>;
+          if (typeof p.text === "string") return p.text;
+          if (typeof p.content === "string") return p.content;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (content && typeof content === "object" && typeof (content as { text?: string }).text === "string") {
+    return (content as { text: string }).text;
+  }
+  return "";
+}
+
+function lastUserText(messages: ChatMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") {
+      return extractMessageText(messages[i]!.content).trim();
+    }
+  }
+  return "";
+}
+
+function withAgentMention(text: string): string {
+  if (!text) return "<agent_mention /> ";
+  if (text.includes("<agent_mention")) return text;
+  return `<agent_mention /> ${text}`;
+}
+
+// ─── AgentMessage text extraction ───────────────────────────────────────────
+
+export function walkStrings(
+  node: unknown,
+  out: Array<{ path: string; text: string }> = [],
+  path = ""
+): Array<{ path: string; text: string }> {
+  if (node == null) return out;
+  if (typeof node === "string") {
+    if (
+      node.length >= 1 &&
+      !/^[0-9a-f-]{36}$/i.test(node) &&
+      !/^\d{4}-\d{2}-\d{2}T/.test(node)
+    ) {
+      out.push({ path, text: node });
+    }
+    return out;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((v, i) => walkStrings(v, out, `${path}[${i}]`));
+    return out;
+  }
+  if (typeof node === "object") {
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      walkStrings(v, out, path ? `${path}.${k}` : k);
+    }
+  }
+  return out;
+}
+
+export function extractFinalResponseMessage(eventData: unknown): string | null {
+  const hits = walkStrings(eventData).filter((t) => /final_response\.message$/i.test(t.path));
+  if (hits.length) return hits[hits.length - 1]!.text;
+  // response_text XML fallback
+  const raw = walkStrings(eventData).find((t) => /response_text$/i.test(t.path));
+  if (raw) {
+    const m = raw.text.match(/<final_response>\s*([\s\S]*?)\s*<\/final_response>/i);
+    if (m) return m[1]!.trim();
+  }
+  return null;
+}
+
+export function isFinalAgentEvent(eventData: unknown): boolean {
+  const s = JSON.stringify(eventData || {});
+  if (s.includes("final_response_sent")) return true;
+  return Boolean(extractFinalResponseMessage(eventData));
+}
+
+export function eventKind(eventData: unknown): string {
+  if (!eventData || typeof eventData !== "object") return "unknown";
+  return Object.keys(eventData as object)[0] || "unknown";
+}
+
+// ─── Thread session cache (multi-turn OpenAI → one PromptQL thread) ─────────
+//
+// BUG (pre-fix): cache key = sha256(projectId + first user message only).
+// Agent clients (SkillsManager, UREW pins, shared greetings) often share the
+// same first user turn across independent chats → follow-ups land on a random
+// older PromptQL thread.
+//
+// FIX (Perplexity/Notion style):
+//  1. Prefer explicit client thread id (body.promptql_thread_id / headers)
+//  2. Else lookup by fingerprint of FULL history prefix (all non-system turns
+//     BEFORE the last user message). Requires prior assistant content.
+//  3. First turn / no assistant history → always start_thread (never sticky)
+//  4. After each successful reply, store under fingerprint(full history + asst)
+//     so the next request's prefix matches exactly one conversation.
+
+type ThreadBinding = { threadId: string; projectId: string; updatedAt: number };
+
+const memoryThreads = new Map<string, ThreadBinding>();
+const THREAD_CACHE_MAX = 200;
+
+function threadCachePath(): string | null {
+  const dataDir = process.env.DATA_DIR || process.env.OMNIROUTE_DATA_DIR;
+  if (!dataDir) return null;
+  return join(dataDir, "promptql-thread-sessions.json");
+}
+
+function loadThreadDisk(): Record<string, ThreadBinding> {
+  const p = threadCachePath();
+  if (!p || !existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf8")) as Record<string, ThreadBinding>;
+  } catch {
+    return {};
+  }
+}
+
+function saveThreadDisk(map: Record<string, ThreadBinding>) {
+  const p = threadCachePath();
+  if (!p) return;
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify(map), "utf8");
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Roles that must not participate in conversation fingerprints. */
+function isFingerprintRole(role: string): boolean {
+  const r = (role || "").toLowerCase();
+  // system/developer often carry jailbreak/agentic pins that are shared across chats
+  if (!r || r === "system" || r === "developer" || r === "tool") return false;
+  return true;
+}
+
+/**
+ * Normalize user/assistant text for fingerprints so proxy rewrites (UREW pins,
+ * agent_mention wrappers, whitespace) don't break multi-turn thread sticky.
+ */
+export function normalizeForFingerprint(text: string): string {
+  let t = (text || "").replace(/\r\n/g, "\n");
+  // PromptQL playground agent mention wrapper
+  t = t.replace(/<agent_mention\s*\/>/gi, "");
+  t = t.replace(/<\/?agent_mention>/gi, "");
+  // Soft UREW / personal-workflow pins that WinUI may inject into the last user turn
+  t = t.replace(/^[\s\S]*?\bUser request:\s*/i, "");
+  t = t.replace(/^[\s\S]*?\bHere is my request:\s*/i, "");
+  t = t.replace(/\n{3,}/g, "\n\n");
+  return t.trim().slice(0, 2000);
+}
+
+/**
+ * Stable fingerprint of an ordered conversation slice.
+ * Excludes system/developer/tool so shared injects cannot collapse distinct chats.
+ */
+export function conversationFingerprint(projectId: string, messages: ChatMessage[]): string {
+  const parts: string[] = [`project:${projectId}`];
+  for (const m of messages) {
+    const role = (m?.role || "").toLowerCase();
+    if (!isFingerprintRole(role)) continue;
+    const text = normalizeForFingerprint(extractMessageText(m?.content));
+    if (!text) continue;
+    parts.push(`${role}:${text}`);
+  }
+  const h = createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 32);
+  return `pql:${projectId}:${h}`;
+}
+
+/** Rolling sticky key: last assistant reply alone (survives last-user rewrites). */
+export function lastAssistantFingerprint(projectId: string, messages: ChatMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const role = (messages[i]?.role || "").toLowerCase();
+    if (role !== "assistant" && role !== "ai" && role !== "model") continue;
+    const text = normalizeForFingerprint(extractMessageText(messages[i]?.content));
+    if (!text) continue;
+    const h = createHash("sha256").update(text).digest("hex").slice(0, 24);
+    return `pql:${projectId}:asst:${h}`;
+  }
+  return null;
+}
+
+/** Messages before the last user turn (OpenAI multi-turn prefix). */
+export function historyPrefixBeforeLastUser(messages: ChatMessage[]): ChatMessage[] {
+  let lastUser = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i]?.role || "").toLowerCase() === "user") {
+      lastUser = i;
+      break;
+    }
+  }
+  if (lastUser <= 0) return [];
+  return messages.slice(0, lastUser);
+}
+
+export function hasAssistantMessage(messages: ChatMessage[]): boolean {
+  return messages.some((m) => {
+    const r = (m?.role || "").toLowerCase();
+    return r === "assistant" || r === "ai" || r === "model";
+  });
+}
+
+function getThreadBinding(key: string): ThreadBinding | null {
+  if (!key) return null;
+  const mem = memoryThreads.get(key);
+  if (mem) return mem;
+  const disk = loadThreadDisk()[key];
+  if (disk) {
+    memoryThreads.set(key, disk);
+    return disk;
+  }
+  return null;
+}
+
+function setThreadBinding(key: string, binding: ThreadBinding) {
+  if (!key) return;
+  memoryThreads.set(key, binding);
+  const disk = loadThreadDisk();
+  disk[key] = binding;
+  const keys = Object.keys(disk);
+  if (keys.length > THREAD_CACHE_MAX) {
+    keys
+      .sort((a, b) => (disk[a]!.updatedAt || 0) - (disk[b]!.updatedAt || 0))
+      .slice(0, keys.length - THREAD_CACHE_MAX)
+      .forEach((k) => {
+        delete disk[k];
+        memoryThreads.delete(k);
+      });
+  }
+  saveThreadDisk(disk);
+}
+
+/** Test helper — clear in-memory + optional disk cache. */
+export function clearPromptQlThreadBindingsForTests(opts?: { disk?: boolean }): void {
+  memoryThreads.clear();
+  if (opts?.disk) {
+    const p = threadCachePath();
+    if (p && existsSync(p)) {
+      try {
+        writeFileSync(p, "{}", "utf8");
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+export function readClientThreadId(
+  body: PromptQlRequestBody,
+  headers?: Record<string, string>
+): string {
+  const fromBody = readStr(body.promptql_thread_id) || readStr(body.thread_id);
+  if (fromBody) return fromBody;
+  if (!headers) return "";
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = String(v ?? "");
+  return (
+    readStr(lower["x-promptql-thread-id"]) ||
+    readStr(lower["x-thread-id"]) ||
+    readStr(lower["x-conversation-id"]) ||
+    ""
+  );
+}
+
+export type PromptQlThreadResolve = {
+  threadId: string;
+  isFollowUp: boolean;
+  /** Key used for sticky store after this turn (prefix key at resolve time). */
+  prefixKey: string | null;
+};
+
+/**
+ * Resolve PromptQL thread for this OpenAI request.
+ * Never reuses a first-user-only sticky mapping across unrelated chats.
+ *
+ * Lookup order (mirrors Notion/Perplexity multi-turn continuity):
+ *  1. Explicit client thread id
+ *  2. Full history-prefix fingerprint (user+assistant before last user)
+ *  3. Last-assistant rolling key (survives proxy last-user rewrites / UREW)
+ */
+export function resolvePromptQlThreadBinding(
+  projectId: string,
+  messages: ChatMessage[],
+  clientThreadId?: string
+): PromptQlThreadResolve {
+  const clientId = (clientThreadId || "").trim();
+  const prefix = historyPrefixBeforeLastUser(messages);
+  const prefixKey =
+    prefix.length > 0 && hasAssistantMessage(prefix)
+      ? conversationFingerprint(projectId, prefix)
+      : null;
+
+  if (clientId) {
+    return { threadId: clientId, isFollowUp: true, prefixKey };
+  }
+
+  if (prefixKey) {
+    const cached = getThreadBinding(prefixKey);
+    if (cached?.threadId && cached.projectId === projectId) {
+      return { threadId: cached.threadId, isFollowUp: true, prefixKey };
+    }
+  }
+
+  // Fallback: last assistant content (OpenAI multi-turn with rewritten user history)
+  if (hasAssistantMessage(messages)) {
+    const asstKey = lastAssistantFingerprint(projectId, prefix.length ? prefix : messages);
+    if (asstKey) {
+      const cached = getThreadBinding(asstKey);
+      if (cached?.threadId && cached.projectId === projectId) {
+        return { threadId: cached.threadId, isFollowUp: true, prefixKey: asstKey };
+      }
+    }
+  }
+
+  // First turn or no sticky match: mint a new PromptQL thread.
+  return { threadId: "", isFollowUp: false, prefixKey: null };
+}
+
+/**
+ * Persist sticky keys so the NEXT request's history prefix resolves to this thread.
+ * Stores under fingerprint(messages + assistant) which equals the next turn's prefix,
+ * plus a last-assistant rolling key that survives last-user rewrites.
+ */
+export function storePromptQlThreadAfterTurn(
+  projectId: string,
+  messages: ChatMessage[],
+  assistantText: string,
+  threadId: string
+): string | null {
+  if (!projectId || !threadId) return null;
+  const full: ChatMessage[] = [
+    ...messages,
+    { role: "assistant", content: assistantText || "" },
+  ];
+  // Only store if there is at least one user + assistant pair.
+  if (!hasAssistantMessage(full) || !messages.some((m) => (m.role || "").toLowerCase() === "user")) {
+    return null;
+  }
+  const key = conversationFingerprint(projectId, full);
+  const binding: ThreadBinding = { threadId, projectId, updatedAt: Date.now() };
+  setThreadBinding(key, binding);
+  // Also bind the current prefix key when present (idempotent re-touch).
+  const prefix = historyPrefixBeforeLastUser(messages);
+  if (prefix.length > 0 && hasAssistantMessage(prefix)) {
+    setThreadBinding(conversationFingerprint(projectId, prefix), binding);
+  }
+  // Rolling last-assistant key (full history including this reply)
+  const asstKey = lastAssistantFingerprint(projectId, full);
+  if (asstKey) setThreadBinding(asstKey, binding);
+  return key;
+}
+
+// ─── GraphQL client ─────────────────────────────────────────────────────────
+
+async function gql<T = unknown>(
+  endpoint: string,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+  operationName: string,
+  signal?: AbortSignal | null
+): Promise<T> {
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+      origin: "https://prompt.ql.app",
+      referer: "https://prompt.ql.app/",
+      "user-agent": USER_AGENT,
+    },
+    body: JSON.stringify({ query, variables, operationName }),
+    signal: signal ?? undefined,
+  });
+  const text = await res.text();
+  let json: { data?: T; errors?: Array<{ message?: string }> };
+  try {
+    json = JSON.parse(text) as typeof json;
+  } catch {
+    throw new Error(`Non-JSON GraphQL HTTP ${res.status}: ${text.slice(0, 300)}`);
+  }
+  if (!res.ok) {
+    throw new Error(`GraphQL HTTP ${res.status}: ${text.slice(0, 400)}`);
+  }
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((e) => e.message || "error").join("; "));
+  }
+  return json.data as T;
+}
+
+/**
+ * Best-effort JWT refresh. Requires browser session cookies (credentials: include
+ * in the SPA). Headless callers must store those cookies in providerSpecificData.cookie.
+ * **Not fully verified in production** — see PR notes.
+ */
+export async function tryRefreshPromptQlToken(opts: {
+  projectId: string;
+  cookie?: string;
+  signal?: AbortSignal | null;
+}): Promise<string | null> {
+  if (!opts.cookie || !opts.projectId) return null;
+  try {
+    const res = await fetch(TOKEN_REFRESH_URL, {
+      method: "POST",
+      headers: {
+        accept: "*/*",
+        "x-hasura-project-id": opts.projectId,
+        origin: "https://prompt.ql.app",
+        referer: "https://prompt.ql.app/",
+        cookie: opts.cookie,
+        "user-agent": USER_AGENT,
+      },
+      signal: opts.signal ?? undefined,
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    // Response may be raw JWT or JSON { token / accessToken / ... }
+    const trimmed = text.trim();
+    if (trimmed.startsWith("eyJ")) return normalizePromptQlToken(trimmed.replace(/^"|"$/g, ""));
+    try {
+      const j = JSON.parse(trimmed) as Record<string, unknown>;
+      const t =
+        readStr(j.token) ||
+        readStr(j.accessToken) ||
+        readStr(j.access_token) ||
+        readStr(j.jwt);
+      return t ? normalizePromptQlToken(t) : null;
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ─── OpenAI response helpers ────────────────────────────────────────────────
+
+function estimateUsage(messages: ChatMessage[] | undefined, content: string) {
+  const prompt = (messages || [])
+    .map((m) => extractMessageText(m.content))
+    .join("\n");
+  const prompt_tokens = Math.max(1, Math.ceil(prompt.length / 4));
+  const completion_tokens = Math.max(1, Math.ceil(content.length / 4));
+  return {
+    prompt_tokens,
+    completion_tokens,
+    total_tokens: prompt_tokens + completion_tokens,
+    estimated: true,
+  };
+}
+
+function chatCompletionResponse(
+  content: string,
+  model: string,
+  messages: ChatMessage[] | undefined,
+  threadId?: string
+) {
+  const id = threadId ? `chatcmpl-pql-${threadId}` : `chatcmpl-pql-${Date.now()}`;
+  return new Response(
+    JSON.stringify({
+      id,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: estimateUsage(messages, content),
+      promptql_thread_id: threadId || undefined,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        ...(threadId ? { "X-PromptQL-Thread-Id": threadId } : {}),
+      },
+    }
+  );
+}
+
+function pseudoStreamResponse(content: string, model: string, threadId?: string) {
+  const encoder = new TextEncoder();
+  const id = threadId ? `chatcmpl-pql-${threadId}` : `chatcmpl-pql-${Date.now()}`;
+  const chunk = (delta: string, finishReason: string | null) => ({
+    id,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, delta: delta ? { content: delta } : {}, finish_reason: finishReason }],
+  });
+  const readable = new ReadableStream({
+    start(controller) {
+      // Emit in ~word-ish slices for slightly better TTFT UX without true token stream
+      const parts = content.match(/\S+\s*/g) || [content];
+      let buf = "";
+      for (const p of parts) {
+        buf += p;
+        if (buf.length >= 40) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk(buf, null))}\n\n`));
+          buf = "";
+        }
+      }
+      if (buf) controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk(buf, null))}\n\n`));
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk("", "stop"))}\n\n`));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+  return new Response(readable, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      ...(threadId ? { "X-PromptQL-Thread-Id": threadId } : {}),
+    },
+  });
+}
+
+// ─── Poll assistant ─────────────────────────────────────────────────────────
+
+export async function pollAssistantText(opts: {
+  token: string;
+  threadId: string;
+  afterEventId: string;
+  signal?: AbortSignal | null;
+  timeoutMs?: number;
+  intervalMs?: number;
+}): Promise<{ text: string; lastEventId: string; events: ThreadEvent[] }> {
+  const timeoutMs = opts.timeoutMs ?? POLL_TIMEOUT_MS;
+  const intervalMs = opts.intervalMs ?? POLL_INTERVAL_MS;
+  const start = Date.now();
+  let cursor = String(opts.afterEventId || "0");
+  let best = "";
+  let sawFinal = false;
+  const collected: ThreadEvent[] = [];
+
+  while (Date.now() - start < timeoutMs) {
+    if (opts.signal?.aborted) throw new Error("aborted");
+    const data = await gql<{ thread_events: ThreadEvent[] }>(
+      PLAYGROUND_GQL,
+      opts.token,
+      QUERY_THREAD_EVENTS,
+      { thread_id: opts.threadId, after_event_id: cursor },
+      "QueryThreadEvents",
+      opts.signal
+    );
+    const batch = data.thread_events || [];
+    for (const ev of batch) {
+      collected.push(ev);
+      cursor = String(ev.thread_event_id);
+      if (eventKind(ev.event_data) !== "AgentMessage") continue;
+      const msg = extractFinalResponseMessage(ev.event_data);
+      if (msg) best = msg;
+      if (isFinalAgentEvent(ev.event_data) && msg) {
+        sawFinal = true;
+      }
+      // Strict stop: final_response_sent
+      if (JSON.stringify(ev.event_data || {}).includes("final_response_sent") && best) {
+        return { text: best, lastEventId: cursor, events: collected };
+      }
+    }
+    if (sawFinal && best) {
+      // one extra idle poll to catch trailing metadata
+      await new Promise((r) => setTimeout(r, intervalMs));
+      return { text: best, lastEventId: cursor, events: collected };
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  if (best) return { text: best, lastEventId: cursor, events: collected };
+  throw new Error(
+    `PromptQL stream timeout after ${timeoutMs}ms (thread ${opts.threadId}, events=${collected.length})`
+  );
+}
+
+// ─── Executor ───────────────────────────────────────────────────────────────
+
+export class PromptQlExecutor extends BaseExecutor {
+  constructor() {
+    super("promptql", {
+      id: "promptql",
+      baseUrl: PLAYGROUND_GQL,
+    });
+  }
+
+  async execute(input: ExecuteInput) {
+    const { model, body, stream: wantStream, credentials, signal } = input;
+    const requestBody = (body || {}) as PromptQlRequestBody;
+    let { token, projectId, cookie, timezone } = resolvePromptQlCredentials(credentials);
+
+    if (!token) {
+      return makeErrorResult(
+        401,
+        "Missing PromptQL Bearer JWT — paste the Authorization token from prompt.ql.app DevTools (Network → graphql → Authorization: Bearer …)",
+        body,
+        PLAYGROUND_GQL
+      );
+    }
+
+    // Best-effort refresh when JWT is near expiry and session cookie is present.
+    if (isJwtExpired(token) && cookie && projectId) {
+      const refreshed = await tryRefreshPromptQlToken({ projectId, cookie, signal });
+      if (refreshed) token = refreshed;
+    }
+
+    if (!projectId) {
+      projectId = extractProjectIdFromToken(token);
+    }
+    if (!projectId) {
+      return makeErrorResult(
+        400,
+        "Missing projectId — set providerSpecificData.projectId or use a JWT that embeds x-hasura-project-id",
+        body,
+        PLAYGROUND_GQL
+      );
+    }
+
+    const messages = requestBody.messages || [];
+    const userText = lastUserText(messages);
+    if (!userText) {
+      return makeErrorResult(400, "No user message found", body, PLAYGROUND_GQL);
+    }
+
+    const clientFacing = clientFacingPromptQlModelId(model || requestBody.model);
+    const resolved: PromptQlModel | null = resolvePromptQlModel(model || requestBody.model);
+    // Prefer live configId from fallback catalog; discovery map can be extended later
+    const llmConfigId =
+      resolved?.configId && !resolved.configId.startsWith("placeholder-")
+        ? resolved.configId
+        : undefined;
+
+    const inboundHeaders =
+      (input.clientHeaders as Record<string, string> | null | undefined) ??
+      ((input as { headers?: Record<string, string> }).headers as
+        | Record<string, string>
+        | undefined);
+    const clientThreadId = readClientThreadId(requestBody, inboundHeaders ?? undefined);
+    const binding = resolvePromptQlThreadBinding(projectId, messages, clientThreadId);
+
+    let threadId = binding.threadId;
+    let afterEventId = "0";
+    const agentMessage = withAgentMention(userText);
+
+    try {
+      if (!binding.isFollowUp || !threadId) {
+        // New PromptQL thread — never reuse first-user-only sticky from another chat
+        type StartData = {
+          start_thread: {
+            thread_id: string;
+            thread_events?: ThreadEvent[];
+          };
+        };
+        let start: StartData["start_thread"];
+        if (llmConfigId) {
+          try {
+            const data = await gql<StartData>(
+              PLAYGROUND_GQL,
+              token,
+              START_THREAD_WITH_MODEL,
+              {
+                message: agentMessage,
+                projectId,
+                timezone,
+                llmConfigId,
+                uploads: [],
+                agentResponseConfig: "force_respond",
+              },
+              "StartThreadWithModel",
+              signal
+            );
+            start = data.start_thread;
+          } catch {
+            const data = await gql<StartData>(
+              PLAYGROUND_GQL,
+              token,
+              START_THREAD_ROOMLESS,
+              {
+                message: agentMessage,
+                projectId,
+                timezone,
+                uploads: [],
+                agentResponseConfig: "force_respond",
+              },
+              "StartThreadRoomless",
+              signal
+            );
+            start = data.start_thread;
+          }
+        } else {
+          const data = await gql<StartData>(
+            PLAYGROUND_GQL,
+            token,
+            START_THREAD_ROOMLESS,
+            {
+              message: agentMessage,
+              projectId,
+              timezone,
+              uploads: [],
+              agentResponseConfig: "force_respond",
+            },
+            "StartThreadRoomless",
+            signal
+          );
+          start = data.start_thread;
+        }
+        threadId = start.thread_id;
+        const seed = start.thread_events || [];
+        if (seed.length) {
+          afterEventId = String(seed[seed.length - 1]!.thread_event_id);
+        }
+      } else {
+        // Follow-up on existing thread — only the latest user turn
+        try {
+          const data = await gql<{
+            send_thread_message: { thread_event_id: string | number };
+          }>(
+            PLAYGROUND_GQL,
+            token,
+            SEND_THREAD_MESSAGE,
+            {
+              message: agentMessage,
+              timezone,
+              threadId,
+              uploads: [],
+              agentResponseConfig: "force_respond",
+            },
+            "SendThreadMessage",
+            signal
+          );
+          afterEventId = String(data.send_thread_message.thread_event_id);
+        } catch (sendErr) {
+          // Stale client thread id / deleted thread → fall back to a fresh start.
+          // IMPORTANT: do NOT match bare "400"/"invalid" — GraphQL validation errors
+          // often include those words and would force a new thread every turn.
+          const sendMsg = sendErr instanceof Error ? sendErr.message : String(sendErr);
+          const isDeadThread =
+            /thread\s*(not\s*found|deleted|expired|unknown|invalid)/i.test(sendMsg) ||
+            /unknown\s*thread|no such thread|thread_id/i.test(sendMsg) ||
+            /\b404\b/.test(sendMsg);
+          if (!isDeadThread) {
+            throw sendErr;
+          }
+          const data = await gql<{
+            start_thread: {
+              thread_id: string;
+              thread_events?: ThreadEvent[];
+            };
+          }>(
+            PLAYGROUND_GQL,
+            token,
+            START_THREAD_ROOMLESS,
+            {
+              message: agentMessage,
+              projectId,
+              timezone,
+              uploads: [],
+              agentResponseConfig: "force_respond",
+            },
+            "StartThreadRoomless",
+            signal
+          );
+          threadId = data.start_thread.thread_id;
+          const seed = data.start_thread.thread_events || [];
+          afterEventId = seed.length
+            ? String(seed[seed.length - 1]!.thread_event_id)
+            : "0";
+        }
+      }
+
+      const { text } = await pollAssistantText({
+        token,
+        threadId,
+        afterEventId,
+        signal,
+      });
+
+      if (!text) {
+        return makeErrorResult(
+          502,
+          "PromptQL returned empty content",
+          body,
+          PLAYGROUND_GQL
+        );
+      }
+
+      // Sticky for next OpenAI multi-turn request (prefix = this full history)
+      storePromptQlThreadAfterTurn(projectId, messages, text, threadId);
+
+      const response = wantStream
+        ? pseudoStreamResponse(text, clientFacing, threadId)
+        : chatCompletionResponse(text, clientFacing, messages, threadId);
+
+      return {
+        response,
+        url: PLAYGROUND_GQL,
+        headers: { Authorization: "Bearer ***" },
+        transformedBody: {
+          threadId,
+          projectId,
+          model: clientFacing,
+          llmConfigId: llmConfigId || null,
+        },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const status =
+        /JWT|expired|unauthorized|401/i.test(msg) ? 401 : /timeout/i.test(msg) ? 504 : 502;
+      return makeErrorResult(status, `PromptQL: ${msg}`, body, PLAYGROUND_GQL);
+    }
+  }
+}
+
+// Re-export catalog for tests / registry
+export { PROMPTQL_FALLBACK_MODELS, PLAYGROUND_GQL, CREDITS_GQL, TOKEN_REFRESH_URL };

--- a/open-sse/services/promptqlModels.ts
+++ b/open-sse/services/promptqlModels.ts
@@ -1,0 +1,203 @@
+/**
+ * PromptQL (prompt.ql.app) model catalog helpers.
+ *
+ * Live catalog: GraphQL `FetchLlmConfigs` against the playground Hasura endpoint.
+ * Fallback: static seed captured 2026-07-20 (display_label / model_reference / model_id).
+ */
+
+export interface PromptQlModel {
+  /** Client-facing id (model_reference slug, e.g. gemini-3.5-flash). */
+  id: string;
+  /** Friendly picker label. */
+  name: string;
+  /** Hasura llm_config.id (uuid) — used as llmConfigId on start_thread. */
+  configId?: string;
+  /** Upstream model id string from PromptQL. */
+  modelId?: string;
+}
+
+/** Offline seed when discovery fails (from live FetchLlmConfigs capture). */
+export const PROMPTQL_FALLBACK_MODELS: PromptQlModel[] = [
+  {
+    id: "vertex-claude-fable-5",
+    name: "Claude Fable 5",
+    configId: "967e6517-1d6b-4e22-82fb-3463bab239c4",
+    modelId: "anthropic/claude-fable-5",
+  },
+  {
+    id: "bedrock-claude-opus-4-8",
+    name: "Claude Opus 4.8",
+    configId: "e97e7f50-9e4a-4685-bc14-1854f1f79782",
+    modelId: "us.anthropic.claude-opus-4-8",
+  },
+  {
+    id: "bedrock-claude-sonnet-4-5",
+    name: "Claude Sonnet 4.5",
+    configId: "48105d83-9a45-4ec6-8b58-f3cf44094f92",
+    modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  },
+  {
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    configId: "5a23af33-b31b-4215-892c-20ef633a8848",
+    modelId: "accounts/fireworks/models/deepseek-v4-pro",
+  },
+  {
+    id: "gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro Preview",
+    configId: "d2bda5cd-881b-4044-aeb9-02a83cc0ca27",
+    modelId: "google/gemini-3.1-pro-preview",
+  },
+  {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash",
+    configId: "c3a25aa0-ca48-4577-b52d-71282aacb687",
+    modelId: "google/gemini-3.5-flash",
+  },
+  {
+    id: "glm-5.2",
+    name: "GLM 5.2",
+    configId: "64a1fa3d-bf2e-4bb9-8c2b-fa76c218d636",
+    modelId: "accounts/fireworks/models/glm-5p2",
+  },
+  {
+    id: "gpt-5.5",
+    name: "GPT 5.5",
+    configId: "1762fbce-d5bf-4bf4-ba3d-8b1201f8e204",
+    modelId: "gpt-5.5",
+  },
+  {
+    id: "gpt-5.6-luna",
+    name: "GPT-5.6 Luna",
+    configId: "a9c45ba7-87fa-49a1-8165-76b0864c3a55",
+    modelId: "gpt-5.6-luna",
+  },
+  {
+    id: "gpt-5.6-sol",
+    name: "GPT-5.6 Sol",
+    configId: "34c80712-def3-4db3-9e7a-f57b0324b43d",
+    modelId: "gpt-5.6-sol",
+  },
+  {
+    id: "gpt-5.6-terra",
+    name: "GPT-5.6 Terra",
+    configId: "04f1a08c-42b2-4371-b6d8-75c50b9bb990",
+    modelId: "gpt-5.6-terra",
+  },
+  {
+    id: "xai-grok-4-5",
+    name: "Grok 4.5",
+    configId: "068b2ef2-e432-422b-98e5-5863a1852c47",
+    modelId: "grok-4.5",
+  },
+  {
+    id: "kimi-k2.6",
+    name: "Kimi K2.6",
+    configId: "placeholder-kimi-k2.6",
+    modelId: "accounts/fireworks/models/kimi-k2p6",
+  },
+  {
+    id: "kimi-k2.7-code",
+    name: "Kimi K2.7 Code",
+    configId: "placeholder-kimi-k2.7-code",
+    modelId: "accounts/fireworks/models/kimi-k2p7-code",
+  },
+  {
+    id: "minimax-m3",
+    name: "Minimax M3",
+    configId: "placeholder-minimax-m3",
+    modelId: "accounts/fireworks/models/minimax-m3",
+  },
+];
+
+const FETCH_LLM_CONFIGS = `
+query FetchLlmConfigs {
+  llm_config(
+    where: {deleted_at: {_is_null: true}}
+    order_by: {display_label: asc}
+  ) {
+    id
+    display_label
+    model_reference
+    model_id
+  }
+}`;
+
+export function stripPromptQlModelPrefix(model: string): string {
+  let m = (model || "").trim();
+  if (m.startsWith("promptql/")) m = m.slice("promptql/".length);
+  else if (m.startsWith("pql/")) m = m.slice(4);
+  return m;
+}
+
+/** Resolve client model slug / display name / config uuid → catalog entry. */
+export function resolvePromptQlModel(model: unknown): PromptQlModel | null {
+  const raw = typeof model === "string" ? stripPromptQlModelPrefix(model) : "";
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  const catalog = PROMPTQL_FALLBACK_MODELS;
+  return (
+    catalog.find((m) => m.id.toLowerCase() === lower) ||
+    catalog.find((m) => m.name.toLowerCase() === lower) ||
+    catalog.find((m) => (m.modelId || "").toLowerCase() === lower) ||
+    catalog.find((m) => (m.configId || "").toLowerCase() === lower) ||
+    catalog.find((m) => lower.includes(m.id.toLowerCase())) ||
+    null
+  );
+}
+
+export function clientFacingPromptQlModelId(model: unknown): string {
+  const resolved = resolvePromptQlModel(model);
+  if (resolved) return resolved.id;
+  const stripped = typeof model === "string" ? stripPromptQlModelPrefix(model) : "";
+  return stripped || "promptql-default";
+}
+
+export async function discoverPromptQlModels(opts: {
+  token: string;
+  graphqlEndpoint: string;
+  signal?: AbortSignal | null;
+}): Promise<PromptQlModel[]> {
+  const res = await fetch(opts.graphqlEndpoint, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      authorization: `Bearer ${opts.token}`,
+      origin: "https://prompt.ql.app",
+      referer: "https://prompt.ql.app/",
+    },
+    body: JSON.stringify({ query: FETCH_LLM_CONFIGS, operationName: "FetchLlmConfigs" }),
+    signal: opts.signal ?? undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`FetchLlmConfigs HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as {
+    data?: {
+      llm_config?: Array<{
+        id?: string;
+        display_label?: string;
+        model_reference?: string;
+        model_id?: string;
+      }>;
+    };
+    errors?: Array<{ message?: string }>;
+  };
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((e) => e.message || "error").join("; "));
+  }
+  const rows = json.data?.llm_config || [];
+  return rows
+    .map((r) => {
+      const id = (r.model_reference || r.model_id || r.id || "").trim();
+      if (!id) return null;
+      return {
+        id,
+        name: (r.display_label || id).trim(),
+        configId: r.id,
+        modelId: r.model_id,
+      } satisfies PromptQlModel;
+    })
+    .filter((x): x is PromptQlModel => Boolean(x));
+}

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -9,6 +9,7 @@ import { fetchDeepseekQuota, type DeepseekQuota } from "./deepseekQuotaFetcher.t
 import { fetchOpencodeQuota, type OpencodeTripleWindowQuota } from "./opencodeQuotaFetcher.ts";
 import { getOllamaCloudUsage, getOpenCodeGoUsage } from "./opencodeOllamaUsage.ts";
 import { getCodeBuddyCnUsage } from "./usage/codebuddy-cn.ts";
+import { getPromptQlUsage } from "./usage/promptql.ts";
 import {
   extractCodeAssistOnboardTierId,
   extractCodeAssistSubscriptionTier,
@@ -539,6 +540,9 @@ export const USAGE_FETCHER_PROVIDERS = [
   "vertex",
   "vertex-partner",
   "codebuddy-cn",
+  // PromptQL playground credits (data.pro.ql.app getCreditSummary)
+  "promptql",
+  "pql",
 ] as const;
 
 export type UsageFetcherProvider = (typeof USAGE_FETCHER_PROVIDERS)[number];
@@ -621,6 +625,9 @@ export async function getUsageForProvider(
       return await getXaiUsage(id || "");
     case "codebuddy-cn":
       return await getCodeBuddyCnUsage(accessToken, apiKey, providerSpecificData);
+    case "promptql":
+    case "pql":
+      return await getPromptQlUsage(apiKey || accessToken, providerSpecificData);
     default:
       return { message: `Usage API not implemented for ${provider}` };
   }

--- a/open-sse/services/usage/promptql.ts
+++ b/open-sse/services/usage/promptql.ts
@@ -1,0 +1,195 @@
+/**
+ * PromptQL project credit summary → UsageQuota for Limits page.
+ *
+ * Live GraphQL (data.pro.ql.app) — captured from prompt.ql.app SPA:
+ *   POST https://data.pro.ql.app/v1/graphql
+ *   query getCreditSummary($project_id: uuid!) {
+ *     promptql_project_credit_summary(where: {project_id: {_eq: $project_id}}) {
+ *       remaining_credits_usd_micros   // e.g. 28484763 → $28.48 left
+ *       total_drawn_usd_micros         // e.g. 21515237 → $21.52 used
+ *       available_credits_usd_micros   // e.g. 50000000 → $50.00 total
+ *       total_olus_used
+ *       last_drawdown_at
+ *     }
+ *   }
+ *
+ * Browser SPA often uses session cookies (credentials:include). Headless OmniRoute
+ * uses the playground JWT (Bearer). We send Bearer always when present and Cookie
+ * when providerSpecificData.cookie is stored — both together matches real sessions.
+ */
+import { type UsageQuota, parseResetTime } from "./quota.ts";
+
+const CREDITS_GQL =
+  process.env.PROMPTQL_CREDITS_ENDPOINT || "https://data.pro.ql.app/v1/graphql";
+
+function normalizePromptQlToken(raw: string): string {
+  return (raw || "").trim().replace(/^Bearer\s+/i, "").trim();
+}
+
+function extractProjectIdFromToken(token: string): string {
+  try {
+    const part = token.split(".")[1];
+    if (!part) return "";
+    const json = JSON.parse(
+      Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8")
+    ) as Record<string, unknown>;
+    const hasura = json["https://promptql.hasura.io"];
+    if (hasura && typeof hasura === "object" && !Array.isArray(hasura)) {
+      const id = (hasura as Record<string, unknown>)["x-hasura-project-id"];
+      if (typeof id === "string" && id.trim()) return id.trim();
+    }
+  } catch {
+    /* ignore */
+  }
+  return "";
+}
+
+const GET_CREDIT_SUMMARY = `
+query getCreditSummary($project_id: uuid!) {
+  promptql_project_credit_summary(where: {project_id: {_eq: $project_id}}) {
+    project_id
+    available_credits_usd_micros
+    total_topup_usd_micros
+    total_drawn_usd_micros
+    remaining_credits_usd_micros
+    total_olus_used
+    last_drawdown_at
+  }
+}`;
+
+export function microsToUsd(micros: unknown): number {
+  const n = typeof micros === "number" ? micros : Number(micros);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round((n / 1_000_000) * 100) / 100;
+}
+
+export function buildPromptQlCreditsQuota(row: {
+  available_credits_usd_micros?: number | null;
+  total_drawn_usd_micros?: number | null;
+  remaining_credits_usd_micros?: number | null;
+  last_drawdown_at?: string | null;
+}): UsageQuota {
+  const available = microsToUsd(row.available_credits_usd_micros ?? 0);
+  const remaining = microsToUsd(row.remaining_credits_usd_micros ?? 0);
+  const drawn = microsToUsd(row.total_drawn_usd_micros ?? 0);
+  // available = wallet top-line (e.g. $50); remaining + drawn should sum ≈ available
+  const total = available > 0 ? available : remaining + drawn;
+  const used = Math.max(0, Math.min(total, drawn > 0 ? drawn : Math.max(0, total - remaining)));
+  const rem = remaining > 0 ? remaining : Math.max(0, total - used);
+  const remainingPercentage =
+    total > 0 ? Math.round((rem / total) * 1000) / 10 : rem > 0 ? 100 : 0;
+  return {
+    used,
+    total,
+    remaining: rem,
+    remainingPercentage,
+    // last_drawdown is activity, not a hard reset — omit so UI doesn't show a false "Resets in…"
+    resetAt: null,
+    unlimited: false,
+    currency: "USD",
+    displayName: "Credits (USD)",
+  };
+}
+
+function readPs(data: unknown, keys: string[]): string {
+  if (!data || typeof data !== "object") return "";
+  const rec = data as Record<string, unknown>;
+  for (const k of keys) {
+    const v = rec[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return "";
+}
+
+export async function getPromptQlUsage(
+  apiKey?: string,
+  providerSpecificData?: Record<string, unknown> | null
+) {
+  const token = normalizePromptQlToken(apiKey || "");
+  const cookie = readPs(providerSpecificData, ["cookie", "sessionCookie", "authCookie"]);
+  if (!token && !cookie) {
+    return { message: "PromptQL JWT not available. Paste a Bearer token to view credits." };
+  }
+  const projectId =
+    readPs(providerSpecificData, ["projectId", "project_id", "x-hasura-project-id"]) ||
+    (token ? extractProjectIdFromToken(token) : "");
+  if (!projectId) {
+    return {
+      message:
+        "Missing projectId for PromptQL credits. Set providerSpecificData.projectId or use a JWT with x-hasura-project-id.",
+    };
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      accept: "application/graphql-response+json, application/json",
+      "content-type": "application/json",
+      origin: "https://prompt.ql.app",
+      referer: "https://prompt.ql.app/",
+      "hasura-client-name": "hasura-console",
+    };
+    // SPA uses cookies for data.pro.ql.app; headless uses playground JWT Bearer.
+    // Send both when available (JWT alone is enough for Hasura enrich-token).
+    if (token) headers.authorization = `Bearer ${token}`;
+    if (cookie) headers.cookie = cookie;
+
+    const res = await fetch(CREDITS_GQL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        query: GET_CREDIT_SUMMARY,
+        variables: { project_id: projectId },
+        operationName: "getCreditSummary",
+      }),
+    });
+    if (!res.ok) {
+      const bodyText = await res.text().catch(() => "");
+      return {
+        message: `PromptQL credits HTTP ${res.status}${bodyText ? `: ${bodyText.slice(0, 200)}` : ""}`,
+        plan: "PromptQL",
+      };
+    }
+    const json = (await res.json()) as {
+      data?: {
+        promptql_project_credit_summary?: Array<{
+          available_credits_usd_micros?: number;
+          total_drawn_usd_micros?: number;
+          remaining_credits_usd_micros?: number;
+          total_olus_used?: number;
+          last_drawdown_at?: string | null;
+        }>;
+      };
+      errors?: Array<{ message?: string }>;
+    };
+    if (json.errors?.length) {
+      return {
+        message: json.errors.map((e) => e.message).join("; "),
+        plan: "PromptQL",
+      };
+    }
+    const row = json.data?.promptql_project_credit_summary?.[0];
+    if (!row) {
+      return {
+        message: "No credit summary for this project (empty promptql_project_credit_summary).",
+        plan: "PromptQL",
+      };
+    }
+    const credits = buildPromptQlCreditsQuota(row);
+    return {
+      plan: "PromptQL",
+      quotas: {
+        // Key "credits" maps to "AI Credits" in WinUI; displayName clarifies USD.
+        credits,
+      },
+      olusUsed: row.total_olus_used,
+      remainingUsd: credits.remaining,
+      drawnUsd: credits.used,
+      availableUsd: credits.total,
+    };
+  } catch (err) {
+    return {
+      message: `PromptQL credits failed: ${err instanceof Error ? err.message : String(err)}`,
+      plan: "PromptQL",
+    };
+  }
+}

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -79,6 +79,9 @@ const PROVIDER_LIMITS_APIKEY_PROVIDERS = new Set([
   // Qoder connections are PAT-based (authType "apikey"); the usage fetcher
   // exchanges the PAT for a job token and reads openapi.qoder.sh/user/status.
   "qoder",
+  // PromptQL playground JWT (authType apikey) → getCreditSummary USD credits
+  "promptql",
+  "pql",
 ]);
 const DEFAULT_PROVIDER_LIMITS_SYNC_INTERVAL_MINUTES = 70;
 const PROVIDER_LIMITS_AUTO_SYNC_SETTING_KEY = "provider_limits_auto_sync_last_run";

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -416,6 +416,9 @@ export const USAGE_SUPPORTED_PROVIDERS = [
   "vertex",
   "vertex-partner",
   "codebuddy-cn",
+  // PromptQL playground credits (getCreditSummary → USD micros)
+  "promptql",
+  "pql",
 ];
 
 // ── Zod validation at module load (Phase 7.2) ──

--- a/src/shared/constants/providers/web-cookie.ts
+++ b/src/shared/constants/providers/web-cookie.ts
@@ -342,6 +342,19 @@ export const WEB_COOKIE_PROVIDERS = {
     riskNoticeVariant: "webCookie",
     authHint: "Paste the full Cookie header from chat.z.ai (must include the token=<JWT> cookie)",
   },
+  promptql: {
+    id: "promptql",
+    alias: "pql",
+    name: "PromptQL (Unofficial/Experimental)",
+    icon: "auto_awesome",
+    color: "#5B21B6",
+    textIcon: "PQL",
+    website: "https://prompt.ql.app",
+    subscriptionRisk: true,
+    riskNoticeVariant: "webCookie",
+    authHint:
+      "Paste the Bearer JWT from prompt.ql.app DevTools → Network → graphql → Authorization (token only). Optional projectId + session Cookie for refresh.",
+  },
 };
 
 /** Resolved public site for a web-session provider (href + display host). */

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -235,6 +235,13 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie", "token"],
   },
+  promptql: {
+    kind: "token",
+    credentialName: "Bearer JWT (optional: projectId, session Cookie)",
+    placeholder: "eyJ...  (Authorization Bearer from prompt.ql.app)",
+    acceptsFullCookieHeader: false,
+    storageKeys: ["token", "jwt", "apiKey", "projectId", "project_id", "cookie"],
+  },
   lmarena: {
     kind: "cookie",
     // arena.ai's auth cookie is `arena-auth-prod-v1` (the legacy hint said `session`,

--- a/tests/unit/executor-promptql.test.ts
+++ b/tests/unit/executor-promptql.test.ts
@@ -1,0 +1,433 @@
+// Unit tests for PromptQL playground executor (unofficial session bridge).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../../open-sse/executors/promptql.ts");
+const usage = await import("../../open-sse/services/usage/promptql.ts");
+const models = await import("../../open-sse/services/promptqlModels.ts");
+const { getModelsByProviderId } = await import("../../open-sse/config/providerModels.ts");
+const { WEB_COOKIE_PROVIDERS } = await import(
+  "../../src/shared/constants/providers/web-cookie.ts"
+);
+
+// Sample JWT payload (unsigned shape for claim extraction only)
+function makeFakeJwt(claims: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+const sampleJwt = makeFakeJwt({
+  "https://promptql.hasura.io": {
+    "x-hasura-project-id": "01a0fe61-baf4-4e31-9311-8cc0bb3eba91",
+    "x-hasura-email": "test@example.com",
+  },
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  iat: Math.floor(Date.now() / 1000),
+});
+
+describe("PromptQl — registry consistency", () => {
+  it("is present in WEB_COOKIE_PROVIDERS", () => {
+    const entry = (WEB_COOKIE_PROVIDERS as Record<string, Record<string, unknown>>)["promptql"];
+    assert.ok(entry, "promptql missing from WEB_COOKIE_PROVIDERS");
+    assert.equal(entry.id, "promptql");
+    assert.equal(entry.alias, "pql");
+    assert.equal(entry.subscriptionRisk, true);
+  });
+
+  it("registers a model catalog via getModelsByProviderId", () => {
+    const catalog = getModelsByProviderId("promptql");
+    assert.ok(catalog.length >= 5);
+    assert.ok(catalog.some((m) => m.id === "gemini-3.5-flash" || m.id.includes("gemini")));
+    assert.ok(catalog.some((m) => m.id.includes("gpt-5.6") || m.id.includes("fable")));
+  });
+});
+
+describe("PromptQl — helpers", () => {
+  it("normalizes Bearer tokens and extracts projectId", () => {
+    assert.equal(mod.normalizePromptQlToken("Bearer abc.def.ghi"), "abc.def.ghi");
+    assert.equal(mod.extractProjectIdFromToken(sampleJwt), "01a0fe61-baf4-4e31-9311-8cc0bb3eba91");
+  });
+
+  it("extracts final_response.message from AgentMessage event_data", () => {
+    const eventData = {
+      AgentMessage: {
+        update: {
+          content: {
+            interaction_update: {
+              main_agent: {
+                actions_parsed: {
+                  actions: [{ final_response: { message: "PONG-PROMPTQL-OK" } }],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    assert.equal(mod.extractFinalResponseMessage(eventData), "PONG-PROMPTQL-OK");
+    assert.equal(mod.isFinalAgentEvent(eventData), true);
+  });
+
+  it("parses final_response from response_text XML", () => {
+    const eventData = {
+      AgentMessage: {
+        update: {
+          content: {
+            interaction_update: {
+              main_agent: {
+                llm_response: {
+                  response_text:
+                    "<action>\n<final_response>\nHello there\n</final_response>\n</action>",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    assert.equal(mod.extractFinalResponseMessage(eventData), "Hello there");
+  });
+
+  it("resolves model slugs and prefixes", () => {
+    assert.equal(models.clientFacingPromptQlModelId("promptql/gemini-3.5-flash"), "gemini-3.5-flash");
+    assert.equal(models.clientFacingPromptQlModelId("pql/gpt-5.6-sol"), "gpt-5.6-sol");
+    const r = models.resolvePromptQlModel("Claude Fable 5");
+    assert.ok(r);
+    assert.equal(r!.id, "vertex-claude-fable-5");
+  });
+
+  it("converts credit micros to USD", () => {
+    assert.equal(usage.microsToUsd(46370444), 46.37);
+    assert.equal(usage.microsToUsd(50000000), 50);
+    const q = usage.buildPromptQlCreditsQuota({
+      available_credits_usd_micros: 50000000,
+      total_drawn_usd_micros: 3629556,
+      remaining_credits_usd_micros: 46370444,
+      last_drawdown_at: "2026-07-20T23:01:33.508593+00:00",
+    });
+    assert.equal(q.currency, "USD");
+    assert.equal(q.remaining, 46.37);
+    assert.equal(q.total, 50);
+    assert.ok((q.used ?? 0) > 0);
+  });
+
+  it("registers promptql on the usage-fetcher + limits allowlists", async () => {
+    const usageMain = await import("../../open-sse/services/usage.ts");
+    assert.ok(
+      (usageMain.USAGE_FETCHER_PROVIDERS as readonly string[]).includes("promptql"),
+      "USAGE_FETCHER_PROVIDERS must list promptql so generic quota fetcher can call it"
+    );
+    assert.ok((usageMain.USAGE_FETCHER_PROVIDERS as readonly string[]).includes("pql"));
+    const { USAGE_SUPPORTED_PROVIDERS } = await import(
+      "../../src/shared/constants/providers.ts"
+    );
+    assert.ok(
+      (USAGE_SUPPORTED_PROVIDERS as readonly string[]).includes("promptql"),
+      "USAGE_SUPPORTED_PROVIDERS must list promptql for provider-limits sync"
+    );
+  });
+
+  it("extracts OpenAI content-parts arrays", () => {
+    assert.equal(
+      mod.extractMessageText([{ type: "text", text: "hi" }, { type: "text", text: " there" }]),
+      "hi\n there"
+    );
+  });
+});
+
+describe("PromptQlExecutor — auth / validation", () => {
+  it("can be instantiated", () => {
+    const executor = new mod.PromptQlExecutor();
+    assert.ok(executor);
+    assert.equal(executor.getProvider(), "promptql");
+  });
+
+  it("returns 401 when no token is supplied", async () => {
+    const executor = new mod.PromptQlExecutor();
+    const result = await executor.execute({
+      model: "gemini-3.5-flash",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: {},
+      signal: null,
+    } as never);
+    assert.equal(result.response.status, 401);
+    const errBody = (await result.response.json()) as { error: { message: string } };
+    assert.match(errBody.error.message, /JWT|Bearer|token/i);
+  });
+
+  it("returns 400 when no user message is present", async () => {
+    const executor = new mod.PromptQlExecutor();
+    const result = await executor.execute({
+      model: "gemini-3.5-flash",
+      body: { messages: [{ role: "assistant", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: sampleJwt },
+      signal: null,
+    } as never);
+    assert.equal(result.response.status, 400);
+  });
+});
+
+describe("PromptQl — thread continuity (no cross-chat sticky)", () => {
+  const projectId = "01a0fe61-baf4-4e31-9311-8cc0bb3eba91";
+
+  it("two chats with the same first user text get different follow-up keys", () => {
+    mod.clearPromptQlThreadBindingsForTests();
+    const chatATurn1 = [{ role: "user", content: "hi" }];
+    const chatBTurn1 = [{ role: "user", content: "hi" }]; // same greeting
+
+    const a1 = mod.resolvePromptQlThreadBinding(projectId, chatATurn1);
+    const b1 = mod.resolvePromptQlThreadBinding(projectId, chatBTurn1);
+    assert.equal(a1.isFollowUp, false);
+    assert.equal(b1.isFollowUp, false);
+    assert.equal(a1.threadId, "");
+    assert.equal(b1.threadId, "");
+
+    // After distinct assistant replies, sticky keys diverge
+    mod.storePromptQlThreadAfterTurn(projectId, chatATurn1, "reply-A-unique", "thread-A");
+    mod.storePromptQlThreadAfterTurn(projectId, chatBTurn1, "reply-B-unique", "thread-B");
+
+    const chatATurn2 = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "reply-A-unique" },
+      { role: "user", content: "follow A" },
+    ];
+    const chatBTurn2 = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "reply-B-unique" },
+      { role: "user", content: "follow B" },
+    ];
+    const a2 = mod.resolvePromptQlThreadBinding(projectId, chatATurn2);
+    const b2 = mod.resolvePromptQlThreadBinding(projectId, chatBTurn2);
+    assert.equal(a2.isFollowUp, true);
+    assert.equal(b2.isFollowUp, true);
+    assert.equal(a2.threadId, "thread-A");
+    assert.equal(b2.threadId, "thread-B");
+    assert.notEqual(a2.threadId, b2.threadId);
+  });
+
+  it("does NOT reuse a first-user-only mapping when history has no matching prefix", () => {
+    mod.clearPromptQlThreadBindingsForTests();
+    // Simulate old bug residue: someone stored under a first-user key only.
+    // New resolver ignores bare first-user stickies and only matches full prefix.
+    mod.storePromptQlThreadAfterTurn(
+      projectId,
+      [{ role: "user", content: "shared greeting" }],
+      "old-asst",
+      "old-thread"
+    );
+    // Brand-new multi-turn history that only shares the first user text but has
+    // a DIFFERENT assistant — must not stick to old-thread.
+    const otherChat = [
+      { role: "user", content: "shared greeting" },
+      { role: "assistant", content: "brand-new-asst" },
+      { role: "user", content: "next" },
+    ];
+    const r = mod.resolvePromptQlThreadBinding(projectId, otherChat);
+    assert.equal(r.isFollowUp, false);
+    assert.equal(r.threadId, "");
+  });
+
+  it("honors explicit client thread id over cache", () => {
+    mod.clearPromptQlThreadBindingsForTests();
+    mod.storePromptQlThreadAfterTurn(
+      projectId,
+      [{ role: "user", content: "x" }],
+      "y",
+      "cached-thread"
+    );
+    const msgs = [
+      { role: "user", content: "x" },
+      { role: "assistant", content: "y" },
+      { role: "user", content: "z" },
+    ];
+    const r = mod.resolvePromptQlThreadBinding(projectId, msgs, "client-thread-99");
+    assert.equal(r.isFollowUp, true);
+    assert.equal(r.threadId, "client-thread-99");
+  });
+
+  it("readClientThreadId accepts body and header variants", () => {
+    assert.equal(
+      mod.readClientThreadId({ promptql_thread_id: "t1" } as never),
+      "t1"
+    );
+    assert.equal(
+      mod.readClientThreadId({ thread_id: "t2" } as never),
+      "t2"
+    );
+    assert.equal(
+      mod.readClientThreadId({} as never, { "X-PromptQL-Thread-Id": "t3" }),
+      "t3"
+    );
+    assert.equal(
+      mod.readClientThreadId({} as never, { "x-conversation-id": "t4" }),
+      "t4"
+    );
+  });
+
+  it("system messages do not collide independent user chats", () => {
+    mod.clearPromptQlThreadBindingsForTests();
+    const sys = { role: "system", content: "same agentic pin for everyone" };
+    const a = [sys, { role: "user", content: "topic A only" }];
+    const b = [sys, { role: "user", content: "topic B only" }];
+    mod.storePromptQlThreadAfterTurn(projectId, a, "asA", "thA");
+    mod.storePromptQlThreadAfterTurn(projectId, b, "asB", "thB");
+    const a2 = mod.resolvePromptQlThreadBinding(projectId, [
+      sys,
+      { role: "user", content: "topic A only" },
+      { role: "assistant", content: "asA" },
+      { role: "user", content: "more A" },
+    ]);
+    const b2 = mod.resolvePromptQlThreadBinding(projectId, [
+      sys,
+      { role: "user", content: "topic B only" },
+      { role: "assistant", content: "asB" },
+      { role: "user", content: "more B" },
+    ]);
+    assert.equal(a2.threadId, "thA");
+    assert.equal(b2.threadId, "thB");
+  });
+
+  it("follows up when last user turn was rewritten (UREW) but assistant matches", () => {
+    mod.clearPromptQlThreadBindingsForTests();
+    // Turn 1 as seen by executor (rewritten last user)
+    const turn1 = [
+      {
+        role: "user",
+        content:
+          "Hi! I'm using my local workflow…\n\nUser request:\nhello",
+      },
+    ];
+    mod.storePromptQlThreadAfterTurn(projectId, turn1, "Hello there!", "thread-rewritten");
+    // Turn 2: client history has ORIGINAL user text (proxy only rewrote outbound last user)
+    const turn2 = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "Hello there!" },
+      {
+        role: "user",
+        content: "Hi! I'm using my local workflow…\n\nUser request:\nhello 2",
+      },
+    ];
+    const r = mod.resolvePromptQlThreadBinding(projectId, turn2);
+    assert.equal(r.isFollowUp, true);
+    assert.equal(r.threadId, "thread-rewritten");
+  });
+
+  it("normalizeForFingerprint strips agent_mention and User request wrappers", () => {
+    assert.equal(
+      mod.normalizeForFingerprint("<agent_mention /> hello"),
+      "hello"
+    );
+    assert.equal(
+      mod.normalizeForFingerprint("noise\n\nUser request:\nhello 2"),
+      "hello 2"
+    );
+  });
+});
+
+describe("PromptQl credits (ge_balance capture)", () => {
+  it("maps micros like live getCreditSummary to used/remaining USD", () => {
+    // From promptql/ge_balance.txt live capture
+    const q = usage.buildPromptQlCreditsQuota({
+      available_credits_usd_micros: 50000000,
+      total_drawn_usd_micros: 21515237,
+      remaining_credits_usd_micros: 28484763,
+      last_drawdown_at: "2026-07-21T01:37:36.491359+00:00",
+    });
+    assert.equal(q.total, 50);
+    assert.equal(q.remaining, 28.48);
+    assert.equal(q.used, 21.52);
+    assert.ok((q.remainingPercentage ?? 0) > 50 && (q.remainingPercentage ?? 0) < 60);
+    assert.equal(q.currency, "USD");
+    assert.equal(q.displayName, "Credits (USD)");
+  });
+});
+
+describe("PromptQlExecutor — mocked GraphQL turn", () => {
+  it("start_thread + poll AgentMessage → chat.completion", async () => {
+    const originalFetch = globalThis.fetch;
+    let call = 0;
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+      call++;
+      const body = typeof init?.body === "string" ? init.body : "";
+      if (body.includes("StartThread") || body.includes("start_thread")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              start_thread: {
+                thread_id: "thread-1",
+                thread_events: [{ thread_event_id: "10", event_data: { UserMessage: {} } }],
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      if (body.includes("QueryThreadEvents") || body.includes("thread_events")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              thread_events: [
+                {
+                  thread_event_id: "11",
+                  event_data: {
+                    AgentMessage: {
+                      update: {
+                        content: {
+                          interaction_update: {
+                            main_agent: {
+                              actions_parsed: {
+                                actions: [{ final_response: { message: "HELLO-PQL" } }],
+                              },
+                              action_completed: {
+                                result: {
+                                  agent_loop_action_result_type: "final_response_sent",
+                                  message: "HELLO-PQL",
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      return new Response(JSON.stringify({ errors: [{ message: "unexpected" }] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    try {
+      const executor = new mod.PromptQlExecutor();
+      const result = await executor.execute({
+        model: "gemini-3.5-flash",
+        body: { messages: [{ role: "user", content: "ping" }] },
+        stream: false,
+        credentials: { apiKey: sampleJwt },
+        signal: null,
+      } as never);
+      assert.equal(result.response.status, 200);
+      const json = (await result.response.json()) as {
+        choices: Array<{ message: { content: string } }>;
+        promptql_thread_id?: string;
+        model: string;
+      };
+      assert.equal(json.choices[0]!.message.content, "HELLO-PQL");
+      assert.equal(json.promptql_thread_id, "thread-1");
+      assert.equal(json.model, "gemini-3.5-flash");
+      assert.ok(call >= 2);
+      assert.equal(result.response.headers.get("X-PromptQL-Thread-Id"), "thread-1");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Status: closed as duplicate of #7911

This PR accidentally re-introduced the full PromptQL provider against `main` as a second stack of the same files already in #7911 (`feat/promptql-web` → `release/v3.8.49`).

**Canonical PR:** https://github.com/diegosouzapw/OmniRoute/pull/7911

That PR already includes:
- PromptQL playground executor + registry wiring
- Live model discovery
- USD credits on Limits
- Sticky multi-turn thread continuity (history-prefix + last-assistant key)

No private capture/HAR artifacts belong in PR text or the tree. Closing this one to avoid double-review of the same feature.