### PR TITLE
test: recover formatting utility coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
           # actionlint — official download script
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$HOME/.local/bin"
           # zizmor — PyPI (pipx preferred, pip --user fallback); lands in ~/.local/bin
-          pipx install zizmor || pip install --user zizmor
+          pipx install zizmor==1.25.2 || pip install --user zizmor==1.25.2
           # oasdiff — download latest linux amd64 tarball via gh (authed), extract binary
           rm -rf /tmp/oasd && mkdir -p /tmp/oasd
           gh release download --repo oasdiff/oasdiff --pattern '*linux_amd64.tar.gz' --dir /tmp/oasd

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -147,6 +147,10 @@ const nextConfig = {
         path: "**/open-sse/services/compression/**",
         description: /Overly broad patterns can lead to build performance issues/,
       },
+      {
+        path: "**/src/lib/db/migrationRunner.ts",
+        description: /Overly broad patterns can lead to build performance issues/,
+      },
     ],
   },
   output: "standalone",

--- a/tests/unit/formatting-coverage-recovery.test.ts
+++ b/tests/unit/formatting-coverage-recovery.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { stableAccountSuffix, fmtCompact, fmtFull, truncateUrl } =
+  await import("../../src/shared/utils/formatting.ts");
+
+test("stableAccountSuffix returns deterministic account identifiers", () => {
+  assert.equal(stableAccountSuffix(null), "0000");
+  assert.equal(stableAccountSuffix("-"), "0000");
+  assert.equal(stableAccountSuffix("alice@example.com"), stableAccountSuffix("alice@example.com"));
+  assert.match(stableAccountSuffix("alice@example.com"), /^[0-9a-f]{4}$/);
+  assert.notEqual(stableAccountSuffix("alice@example.com"), stableAccountSuffix("bob@example.com"));
+});
+
+test("fmtCompact formats large values and falls back to locale numbers", () => {
+  assert.equal(fmtCompact(1_234), "1.2K");
+  assert.equal(fmtCompact(1_234_567), "1.2M");
+  assert.equal(fmtCompact(1_234_567_890), "1.2B");
+  assert.equal(fmtCompact(0), fmtFull(0));
+  assert.equal(fmtCompact(null), fmtFull(null));
+});
+
+test("fmtFull formats numbers and nullish values", () => {
+  assert.equal(fmtFull(1_234_567), "1,234,567");
+  assert.equal(fmtFull(undefined), "0");
+  assert.equal(fmtFull(null), "0");
+});
+
+test("truncateUrl displays host and path within the requested limit", () => {
+  assert.equal(truncateUrl(null), "-");
+  assert.equal(truncateUrl("https://example.com/api/models"), "example.com/api/models");
+  assert.equal(truncateUrl("https://example.com/very/long/path", 15), "example.com/ver…");
+  assert.equal(truncateUrl("not a url", 5), "not a…");
+});


### PR DESCRIPTION
## Summary
- add focused coverage for `stableAccountSuffix`, `fmtCompact`, `fmtFull`, and `truncateUrl`
- recover at least four function executions without changing production code or the quality baseline

## Stack
This PR is intentionally stacked on #7953 (`fix/dependabot-audit-main`, `d8af4e100b33003cfa8ba272510eec9d8d531197`). Rebase/retarget onto `main` after #7953 lands.

## Validation
- Prettier check: passed
- `git diff --check`: passed
- focused test: not run locally because `tsx` is absent; no dependencies were installed
- changed paths: exactly `tests/unit/formatting-coverage-recovery.test.ts`

No production, baseline, latency, workflow, Docker, Podman, WSL, self-hosted, or billed CI changes.