### PR TITLE
fix(electron): resolve Helper binary by productName instead of app.getName()

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -79,20 +79,21 @@ function resolveNodeExecutable(env = process.env) {
   // flash a shell window. Use the Helper binary instead — macOS treats
   // Helper processes as background tasks with no visible UI artifacts.
   if (process.platform === "darwin" && !isDev) {
-    const helperPath = path.join(path.dirname(process.execPath), `${app.getName()} Helper`);
+    const appName = path.basename(process.execPath);
+    const helperPath = path.join(path.dirname(process.execPath), `${appName} Helper`);
     if (fs.existsSync(helperPath)) {
       return helperPath;
     }
-    // Electron \u003e= 20 may use "(Renderer)" / "(GPU)" / "(Plugin)" suffixed helpers.
+    // Electron >= 20 may use "(Renderer)" / "(GPU)" / "(Plugin)" suffixed helpers.
     // The unsuffixed Helper is the one suitable for ELECTRON_RUN_AS_NODE.
     const frameworkHelper = path.join(
       path.dirname(process.execPath),
       "..",
       "Frameworks",
-      `${app.getName()} Helper.app`,
+      `${appName} Helper.app`,
       "Contents",
       "MacOS",
-      `${app.getName()} Helper`
+      `${appName} Helper`
     );
     if (fs.existsSync(frameworkHelper)) {
       return frameworkHelper;


### PR DESCRIPTION
## Problem

On macOS, launching the packaged Electron app produces two Dock icons instead of one. The second icon is the Next.js server child process running the main Electron binary instead of the Helper binary.

## Root Cause

`resolveNodeExecutable()` built the Helper path from `app.getName()`, but electron-builder names the helper bundles from `build.productName`. These fields diverge:

| Source | Value |
|---|---|
| `app.getName()` | `omniroute-desktop` |
| `build.productName` | `OmniRoute` |

The code probed for `omniroute-desktop Helper.app` but the actual bundle is `OmniRoute Helper.app`. Both `fs.existsSync()` probes failed, falling through to `process.execPath`, spawning the main binary under `ELECTRON_RUN_AS_NODE`.

## Fix

Use `path.basename(process.execPath)` instead of `app.getName()`. electron-builder generates the main binary and helper bundles from the same `productName`, so they can never drift apart.

Verified empirically (by the issue reporter): Dock icon count goes from 2 to 1, the server process switches to the Helper binary with `LSUIElement: true`, and the server remains reachable (HTTP 200).

## Testing

- Manual verification performed and documented in #7941
- No existing unit tests for `resolveNodeExecutable()`

Closes #7941