### PR TITLE
fix(models): attach models.dev pricing to GET /v1/models entries

### DIFF
--- a/src/lib/modelMetadataRegistry.ts
+++ b/src/lib/modelMetadataRegistry.ts
@@ -11,7 +11,8 @@ import {
 } from "@/shared/constants/modelSpecs";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { PROVIDER_ID_TO_ALIAS, PROVIDER_MODELS } from "@/shared/constants/models";
-import { getSyncStatus, getSyncedCapability } from "@/lib/modelsDevSync";
+import { getSyncStatus, getSyncedCapability, getModelsDevPricing } from "@/lib/modelsDevSync";
+import { getPricingForModel as getDefaultPricingForModel } from "@/shared/constants/pricing";
 import {
   CANONICAL_EFFORT_VALUES,
   extendCodexGpt56EffortValues,
@@ -257,6 +258,72 @@ export function getCanonicalModelMetadata(input: {
   };
 }
 
+function resolveCatalogPricing(
+  provider: string | null,
+  model: string | null
+): Record<string, number> | null {
+  if (!provider || !model) return null;
+
+  const findInsensitive = <T>(
+    obj: Record<string, T> | null | undefined,
+    key: string
+  ): T | undefined => {
+    if (!obj || !key) return undefined;
+    if (key in obj) return obj[key];
+    const lower = key.toLowerCase();
+    for (const [k, v] of Object.entries(obj)) {
+      if (k.toLowerCase() === lower) return v;
+    }
+    return undefined;
+  };
+
+  // Prefer models.dev synced pricing when present; fall back to hardcoded defaults.
+  try {
+    const modelsDev = getModelsDevPricing() as Record<
+      string,
+      Record<string, Record<string, number>>
+    >;
+    const providerPricing =
+      findInsensitive(modelsDev, provider) ||
+      findInsensitive(modelsDev, provider.replace(/-cn$/, ""));
+    if (providerPricing) {
+      const modelPricing =
+        findInsensitive(providerPricing, model) ||
+        findInsensitive(providerPricing, model.replace(/\./g, "-")) ||
+        findInsensitive(
+          providerPricing,
+          model.includes("/") ? model.split("/").pop() || model : model
+        );
+      if (modelPricing && typeof modelPricing === "object") {
+        const input = modelPricing.input;
+        const output = modelPricing.output;
+        if (typeof input === "number" || typeof output === "number") {
+          const pricing: Record<string, number> = {};
+          if (typeof input === "number") pricing.input = input;
+          if (typeof output === "number") pricing.output = output;
+          if (typeof modelPricing.cached === "number") pricing.cached = modelPricing.cached;
+          if (typeof modelPricing.cache_creation === "number") {
+            pricing.cache_creation = modelPricing.cache_creation;
+          }
+          return pricing;
+        }
+      }
+    }
+  } catch {
+    // pricing lookup must never break catalog assembly
+  }
+
+  try {
+    const defaults = getDefaultPricingForModel(provider, model) as Record<string, number> | null;
+    if (defaults && (typeof defaults.input === "number" || typeof defaults.output === "number")) {
+      return defaults;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
 export function enrichCatalogModelEntry<T extends JsonRecord>(
   entry: T,
   input?: { provider?: string | null; model?: string | null }
@@ -364,6 +431,11 @@ export function enrichCatalogModelEntry<T extends JsonRecord>(
   }
   if (!existingName && metadata.displayName) {
     nextEntry.name = metadata.displayName;
+  }
+
+  if (nextEntry.pricing == null) {
+    const pricing = resolveCatalogPricing(provider, model);
+    if (pricing) nextEntry.pricing = pricing;
   }
 
   return nextEntry as T;

--- a/src/lib/modelsDevSync.ts
+++ b/src/lib/modelsDevSync.ts
@@ -40,7 +40,11 @@ export {
   transformModelsDevToPricing,
   transformModelsDevToCapabilities,
 } from "./modelsDevSync/transform";
-export type { ModelCapabilityEntry, CapabilitiesByProvider } from "./modelsDevSync/transform";
+export type {
+  ModelCapabilityEntry,
+  CapabilitiesByProvider,
+  PricingByProvider,
+} from "./modelsDevSync/transform";
 
 // ─── Types ───────────────────────────────────────────────
 

--- a/tests/unit/catalog-pricing-surface-8018.test.ts
+++ b/tests/unit/catalog-pricing-surface-8018.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { enrichCatalogModelEntry } from "../../src/lib/modelMetadataRegistry.ts";
+import {
+  saveModelsDevPricing,
+  clearModelsDevPricing,
+  type PricingByProvider,
+} from "../../src/lib/modelsDevSync.ts";
+
+type CatalogPricing = {
+  input?: number;
+  output?: number;
+  cached?: number;
+  cache_creation?: number;
+};
+
+describe("catalog pricing surface (#8018)", () => {
+  before(() => {
+    const pricing: PricingByProvider = {
+      openai: {
+        "gpt-4o": { input: 2.5, output: 10 },
+        "whisper-1": { input: 0.006, output: 0 },
+      },
+    };
+    saveModelsDevPricing(pricing);
+  });
+
+  after(() => {
+    try {
+      clearModelsDevPricing();
+    } catch {
+      // ignore
+    }
+  });
+
+  it("attaches models.dev pricing onto catalog entries", () => {
+    const entry = enrichCatalogModelEntry({
+      id: "openai/gpt-4o",
+      owned_by: "openai",
+      root: "gpt-4o",
+    });
+    assert.ok(entry.pricing);
+    assert.equal((entry.pricing as CatalogPricing).input, 2.5);
+    assert.equal((entry.pricing as CatalogPricing).output, 10);
+  });
+
+  it("attaches specialty pricing when present", () => {
+    const entry = enrichCatalogModelEntry({
+      id: "openai/whisper-1",
+      owned_by: "openai",
+      root: "whisper-1",
+      type: "audio",
+      subtype: "transcription",
+    });
+    assert.ok(entry.pricing);
+    assert.equal((entry.pricing as CatalogPricing).input, 0.006);
+  });
+
+  it("omits pricing when unknown", () => {
+    const entry = enrichCatalogModelEntry({
+      id: "unknown/provider-model-xyz",
+      owned_by: "unknown",
+      root: "provider-model-xyz",
+    });
+    assert.equal(entry.pricing, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /v1/models` now surfaces `pricing` when models.dev (or hardcoded defaults) has rates for a model.
- Pricing remains omitted when unknown; no invented zeros.
- Catalog enrichment is the single attachment point, so combos/specialty/chat rows all benefit.

## Root cause
models.dev pricing was synced into `models_dev_pricing` and readable via pricing helpers, but `enrichCatalogModelEntry()` never attached `pricing` to catalog rows. Production therefore showed `pricing` on **0 / 2350** rows despite 172 synced provider pricing keys.

## Test plan
- [x] `node --import tsx --test tests/unit/catalog-pricing-surface-8018.test.ts` (3/3)
- [ ] CI unit/lint on PR

Closes #8018
Related: #979