### PR TITLE
docs: add AgentRouter multi-provider routing troubleshooting

### DIFF
--- a/docs/providers/AGENTROUTER.md
+++ b/docs/providers/AGENTROUTER.md
@@ -171,6 +171,21 @@ the provider ID starts with `anthropic-compatible-cc-` (note the trailing dash �
 see `CLAUDE_CODE_COMPATIBLE_PREFIX` in `open-sse/services/claudeCodeCompatible.ts`)
 and the feature flag is enabled.
 
+**`unauthorized client detected` / HTML error page even though an AgentRouter
+provider already exists** — you likely have **more than one** AgentRouter provider
+and your request is hitting the wrong one. If a leftover hand-made
+`anthropic-compatible-*` (non-`cc`) or `openai-compatible-chat-*` provider was
+created with the `agentrouter` prefix, it can own the `agentrouter/<model>` model
+IDs (and combos may reference it by node ID), so traffic routes to that provider —
+which sends a generic User-Agent and gets rejected — instead of the built-in
+`agentrouter` provider that already ships the correct wire image. Check where the
+model actually resolves in the omniroute logs (`ROUTING` tag shows
+`agentrouter/<model> → <providerId>/<model>`); if `<providerId>` is not
+`agentrouter`, consolidate on the native provider: point combos at
+`agentrouter/<model>` (providerId `agentrouter`) and delete the duplicate
+compatible providers. The native provider needs no wire-image configuration and no
+`customUserAgent`.
+
 ---
 
 ## See also


### PR DESCRIPTION
## What

Adds a troubleshooting entry to `docs/providers/AGENTROUTER.md` for a routing pitfall not currently covered: when more than one AgentRouter provider exists, requests can hit the wrong one.

## Why

The built-in `agentrouter` provider already ships the correct Claude Code wire image and works out of the box. But if a user earlier created a hand-made `anthropic-compatible-*` (non-`cc`) or `openai-compatible-chat-*` provider with the `agentrouter` prefix, that provider can own the `agentrouter/<model>` model IDs (and combos may reference it by node ID). Traffic then routes to the hand-made provider — which sends a generic User-Agent — and AgentRouter rejects it with `unauthorized client detected` or returns an HTML error page, even though a correctly-configured native provider exists.

This is confusing because the symptom (`unauthorized client detected`) reads like a wire-image problem, but the fix is routing: point combos at `agentrouter/<model>` (providerId `agentrouter`) and remove the duplicate compatible providers.

## How to diagnose (added to the doc)

The `ROUTING` log line shows `agentrouter/<model> → <providerId>/<model>`. If `<providerId>` is not `agentrouter`, the request is going to a duplicate provider.

## Scope

Docs-only, single file, no code changes.
