### PR TITLE
fix(antigravity): rotate image accounts on quota exhaustion

### DIFF
--- a/changelog.d/fixes/0000-antigravity-image-account-rotation.md
+++ b/changelog.d/fixes/0000-antigravity-image-account-rotation.md
@@ -1,0 +1,1 @@
+- **fix(antigravity):** rotate image-generation accounts once after an explicit quota-exhausted 429 without persisting a cooldown.

--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -356,7 +356,7 @@ export async function handleImageGeneration({
   }
 
   if (providerConfig.format === "gemini-image") {
-    return handleGeminiImageGeneration({ model, providerConfig, body, credentials, log });
+    return handleGeminiImageGeneration({ model, providerConfig, body, credentials, log, signal });
   }
 
   if (providerConfig.format === "imagen3") {
@@ -738,7 +738,7 @@ async function handleKieImageGeneration({
  * Handle Gemini-format image generation (Antigravity / Nano Banana)
  * Uses Gemini's generateContent API with responseModalities: ["TEXT", "IMAGE"]
  */
-async function handleGeminiImageGeneration({ model, providerConfig, body, credentials, log }) {
+async function handleGeminiImageGeneration({ model, providerConfig, body, credentials, log, signal = null }) {
   const startTime = Date.now();
   const url = providerConfig.baseUrl;
   const provider = "antigravity";
@@ -820,6 +820,7 @@ async function handleGeminiImageGeneration({ model, providerConfig, body, creden
       method: "POST",
       headers,
       body: JSON.stringify(antigravityBody),
+      ...(signal ? { signal } : {}),
     });
 
     if (!response.ok) {
@@ -883,6 +884,13 @@ async function handleGeminiImageGeneration({ model, providerConfig, body, creden
       },
     };
   } catch (err) {
+    if (signal?.aborted) {
+      return {
+        success: false,
+        status: 499,
+        error: "Image generation request cancelled",
+      };
+    }
     if (log) {
       log.error("IMAGE", `antigravity fetch error: ${err.message}`);
     }

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -5,6 +5,7 @@
  * context-optimized, context-relay, and fusion strategies
  */
 
+import { randomUUID } from "node:crypto";
 import {
   checkFallbackError,
   classifyLockoutReason,
@@ -26,6 +27,7 @@ import {
 } from "../utils/error.ts";
 import type { ComboDiagnostics } from "../utils/error.ts";
 import { buildTargetTimeoutRunner } from "./combo/targetTimeoutRunner.ts";
+import { nextRoutingTransition, summarizeAccountRouting } from "./combo/routingInstrumentation.ts";
 import { recordComboRequest, recordComboShadowRequest, getComboMetrics } from "./comboMetrics.ts";
 import {
   resolveComboConfig,
@@ -1014,6 +1016,9 @@ export async function handleComboChat({
   const fallbackDelayMs = resolveDelayMs(config.fallbackDelayMs, 0);
   const maxSetRetries = config.maxSetRetries ?? 0;
   const setRetryDelayMs = resolveDelayMs(config.setRetryDelayMs, 2000);
+  // Server-local correlation only; never trust a client request id for routing logs.
+  const routingCorrelationId = randomUUID();
+  const attemptedConnectionIds = new Set<string>();
 
   const isTargetSelectableForWeighted = async (target: ResolvedComboTarget): Promise<boolean> => {
     const rawModel = parseModel(target.modelStr).model || target.modelStr;
@@ -1390,6 +1395,8 @@ export async function handleComboChat({
         const modelStr = target.modelStr;
         const rawModel = parseModel(modelStr).model || modelStr;
         const provider = target.provider;
+        if (typeof target.connectionId === "string")
+          attemptedConnectionIds.add(target.connectionId);
 
         const cb = getCircuitBreaker(provider);
         if (cb.getStatus().state === "OPEN") {
@@ -2131,6 +2138,34 @@ export async function handleComboChat({
           // outage signalled via X-Omni-Fallback-Hint: connection_cooldown) apply connection
           // cooldown only — do NOT trip the whole-provider breaker.
           const nextTarget = orderedTargets[i + 1];
+          const candidateConnectionIds = orderedTargets
+            .filter((candidate) => {
+              const candidateRawModel = parseModel(candidate.modelStr).model || candidate.modelStr;
+              return candidate.provider === provider && candidateRawModel === rawModel;
+            })
+            .map((candidate) => candidate.connectionId)
+            .filter((connectionId): connectionId is string => typeof connectionId === "string");
+          const routingSummary = summarizeAccountRouting({
+            correlationId: routingCorrelationId,
+            provider,
+            model: rawModel,
+            candidateConnectionIds,
+            attemptedConnectionIds,
+          });
+          const routingTransition = nextRoutingTransition({
+            sameProvider: nextTarget?.provider === provider,
+            sameModel:
+              (parseModel(nextTarget?.modelStr || "").model || nextTarget?.modelStr) === rawModel,
+            retryableAccountFailure: fallbackResult.shouldFallback,
+            eligibleUnattemptedCount: routingSummary.eligibleUnattemptedCount,
+          });
+          log.info("ROUTING", JSON.stringify({ ...routingSummary, ...routingTransition }));
+          if (routingTransition.invariantViolation) {
+            log.warn(
+              "ROUTING",
+              JSON.stringify({ ...routingSummary, event: "invariant_violation" })
+            );
+          }
           const sameProviderNext =
             typeof nextTarget?.provider === "string" && nextTarget.provider === provider;
           if (

--- a/open-sse/services/combo/routingInstrumentation.ts
+++ b/open-sse/services/combo/routingInstrumentation.ts
@@ -1,0 +1,57 @@
+/**
+ * Request-scoped, privacy-safe routing observations. These helpers never
+ * select, exclude, or persist anything: callers may use them around existing
+ * routing transitions without changing their behaviour.
+ */
+function accountPrefix(value: string): string {
+  return value.slice(0, 8);
+}
+
+export function summarizeAccountRouting(input: {
+  correlationId: string;
+  provider: unknown;
+  model: unknown;
+  candidateConnectionIds: readonly unknown[];
+  attemptedConnectionIds: ReadonlySet<string>;
+  excludedConnectionIds?: readonly unknown[];
+}) {
+  const candidateIds = input.candidateConnectionIds.filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0
+  );
+  const excluded = (input.excludedConnectionIds || []).filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0
+  );
+  const eligibleUnattemptedIds = candidateIds.filter(
+    (id) => !input.attemptedConnectionIds.has(id) && !excluded.includes(id)
+  );
+  return {
+    event: "routing_account_scope",
+    correlationId: input.correlationId,
+    provider: typeof input.provider === "string" ? input.provider : "unknown",
+    model: typeof input.model === "string" ? input.model : "unknown",
+    candidateAccountPrefixes: candidateIds.map(accountPrefix),
+    attemptedAccountPrefixes: [...input.attemptedConnectionIds].map(accountPrefix),
+    excludedAccountPrefixes: excluded.map(accountPrefix),
+    candidateCount: candidateIds.length,
+    attemptedCount: input.attemptedConnectionIds.size,
+    excludedCount: excluded.length,
+    eligibleUnattemptedCount: eligibleUnattemptedIds.length,
+  };
+}
+
+export function nextRoutingTransition(input: {
+  sameProvider: boolean;
+  sameModel: boolean;
+  retryableAccountFailure: boolean;
+  eligibleUnattemptedCount: number;
+}) {
+  const hasEligibleUnattemptedAccount = input.eligibleUnattemptedCount > 0;
+  return {
+    transition:
+      input.sameProvider && input.sameModel ? "next_account_same_model" : "next_combo_target",
+    event: "routing_account_scope",
+    invariantViolation: Boolean(
+      input.retryableAccountFailure && !input.sameModel && hasEligibleUnattemptedAccount
+    ),
+  } as const;
+}

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -26,8 +26,14 @@ import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { calculateModalCost } from "@/lib/usage/costCalculator";
 import { generateRequestId } from "@/shared/utils/requestId";
 import { getSpecialtyModelsResponse } from "@/app/api/v1/_shared/specialtyCatalog";
+import { classify429 as classifyAntigravity429 } from "@omniroute/open-sse/services/antigravity429Engine.ts";
 
 export const dynamic = "force-dynamic";
+
+// A route retry is a new, non-idempotent upstream submission. Keep its total
+// work bounded even if an executor grows its own retry policy later.
+const MAX_ANTIGRAVITY_IMAGE_ATTEMPTS = 2;
+const ANTIGRAVITY_IMAGE_RETRY_DEADLINE_MS = 30_000;
 
 /**
  * Handle CORS preflight
@@ -85,6 +91,27 @@ function publicBaseUrlHeaders(headers: Headers): Record<string, string> {
     if (value !== null) out[key] = value;
   }
   return out;
+}
+
+export function isRetryableImageAccountFailure(result: {
+  success: boolean;
+  status?: number;
+  error?: unknown;
+}): boolean {
+  // HTTP 429 commonly means a provider-wide or short burst limit. Rotate only
+  // after an explicit Antigravity account/model quota signal; ambiguous 429s
+  // retain their final normalized upstream error without resubmitting.
+  if (result.success || result.status !== HTTP_STATUS.RATE_LIMITED) return false;
+  let errorText = "";
+  try {
+    errorText =
+      typeof result.error === "string" ? result.error : JSON.stringify(result.error ?? "");
+  } catch {
+    return false;
+  }
+  return (
+    classifyAntigravity429(errorText) === "quota_exhausted" || /resource exhausted/i.test(errorText)
+  );
 }
 
 async function postHandler(request, context) {
@@ -204,15 +231,15 @@ async function postHandler(request, context) {
     }
   }
 
-  // Resolve proxy for the connection if credentials exist (#1904)
-  let proxyInfo = null;
-  if (credentials?.connectionId) {
-    try {
-      proxyInfo = await resolveProxyForConnection(credentials.connectionId);
-    } catch {
-      log.debug("PROXY", `Failed to resolve proxy for image provider: ${provider}`);
-    }
-  }
+  const retryDeadlineAt = Date.now() + ANTIGRAVITY_IMAGE_RETRY_DEADLINE_MS;
+  const budgetController = new AbortController();
+  const abortForClient = () => budgetController.abort();
+  if (request.signal.aborted) abortForClient();
+  else request.signal.addEventListener("abort", abortForClient, { once: true });
+  const retryDeadlineTimer = setTimeout(
+    () => budgetController.abort(),
+    ANTIGRAVITY_IMAGE_RETRY_DEADLINE_MS
+  );
 
   const generateImage = () =>
     handleImageGeneration({
@@ -220,45 +247,104 @@ async function postHandler(request, context) {
       credentials,
       log,
       ...(isCustomModel && { resolvedProvider: provider }),
-      signal: request.signal,
+      signal: budgetController.signal,
       clientHeaders: publicBaseUrlHeaders(request.headers),
     });
 
-  // Execute with proxy context when available, direct otherwise (#1904)
-  const result = await (credentials?.connectionId
-    ? runWithProxyContext(proxyInfo?.proxy || null, generateImage).catch((err: any) => ({
-        success: false,
-        status: err.statusCode || 500,
-        error: err.message,
-      }))
-    : generateImage());
+  const executeImageAttempt = async () => {
+    // This intentionally resolves the proxy for every attempt. A retry can
+    // select a different account with a different assigned proxy.
+    let proxyInfo = null;
+    if (credentials?.connectionId) {
+      try {
+        proxyInfo = await resolveProxyForConnection(credentials.connectionId);
+      } catch {
+        log.debug("PROXY", `Failed to resolve proxy for image provider: ${provider}`);
+      }
+    }
+    return credentials?.connectionId
+      ? runWithProxyContext(proxyInfo?.proxy || null, generateImage).catch((err: any) => ({
+          success: false,
+          status: err.statusCode || 500,
+          error: err.message,
+        }))
+      : generateImage();
+  };
 
-  if (result.success) {
-    await clearRecoveredProviderState(credentials);
-    const n = Math.max(
-      Number(body.n) || 1,
-      (result as { data?: { data?: unknown[] } }).data?.data?.length || 0
+  let attemptCount = 1;
+  let result;
+  try {
+    result = await executeImageAttempt();
+
+    // Antigravity image requests do not pass through chatCore's account retry
+    // loop. Do not call the durable account-unavailable marker because an image
+    // quota response may be model-scoped.
+    if (provider === "antigravity") {
+      const excludedConnectionIds: string[] = [];
+      while (
+        !budgetController.signal.aborted &&
+        Date.now() < retryDeadlineAt &&
+        attemptCount < MAX_ANTIGRAVITY_IMAGE_ATTEMPTS &&
+        isRetryableImageAccountFailure(result) &&
+        typeof credentials?.connectionId === "string"
+      ) {
+        const failedConnectionId = credentials.connectionId;
+        if (!excludedConnectionIds.includes(failedConnectionId)) {
+          excludedConnectionIds.push(failedConnectionId);
+        }
+
+        const requestedModel = body.model.startsWith(`${provider}/`)
+          ? body.model.slice(provider.length + 1)
+          : body.model;
+        const nextCredentials = await getProviderCredentialsWithQuotaPreflight(
+          provider,
+          null,
+          null,
+          requestedModel,
+          { excludeConnectionIds: excludedConnectionIds }
+        ).catch(() => null);
+
+        if (!nextCredentials || nextCredentials.allRateLimited || budgetController.signal.aborted)
+          break;
+        credentials = nextCredentials;
+        result = await executeImageAttempt();
+        attemptCount++;
+      }
+    }
+
+    if (result.success) {
+      await clearRecoveredProviderState(credentials);
+      const n = Math.max(
+        Number(body.n) || 1,
+        (result as { data?: { data?: unknown[] } }).data?.data?.length || 0
+      );
+      const costUsd = await calculateModalCost("image", provider, body.model, { n });
+      const headers = new Headers({ "Content-Type": "application/json" });
+      attachOmniRouteMetaHeaders(headers, {
+        provider,
+        model: body.model,
+        costUsd,
+        latencyMs: Date.now() - startTime,
+        requestId: generateRequestId(),
+      });
+      return new Response(JSON.stringify((result as { data: unknown }).data), {
+        status: 200,
+        headers,
+      });
+    }
+
+    const errorPayload = toJsonErrorPayload(
+      (result as any).error,
+      "Image generation provider error"
     );
-    const costUsd = await calculateModalCost("image", provider, body.model, { n });
-    const headers = new Headers({ "Content-Type": "application/json" });
-    attachOmniRouteMetaHeaders(headers, {
-      provider,
-      model: body.model,
-      costUsd,
-      latencyMs: Date.now() - startTime,
-      requestId: generateRequestId(),
+    return new Response(JSON.stringify(errorPayload), {
+      status: (result as any).status,
+      headers: { "Content-Type": "application/json" },
     });
-    return new Response(JSON.stringify((result as { data: unknown }).data), {
-      status: 200,
-      headers,
-    });
+  } finally {
+    clearTimeout(retryDeadlineTimer);
+    request.signal.removeEventListener("abort", abortForClient);
   }
-
-  const errorPayload = toJsonErrorPayload((result as any).error, "Image generation provider error");
-  return new Response(JSON.stringify(errorPayload), {
-    status: (result as any).status,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 export const POST = withInjectionGuard(postHandler);

--- a/tests/unit/antigravity-image-account-rotation.test.ts
+++ b/tests/unit/antigravity-image-account-rotation.test.ts
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-ag-image-rotation-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "ag-image-rotation-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providers = await import("../../src/lib/db/providers.ts");
+const imageRoute = await import("../../src/app/api/v1/images/generations/route.ts");
+
+type PersistedConnection = { id: string; rateLimitedUntil?: string | null };
+type ErrorPayload = { error: { message: string } };
+const originalFetch = globalThis.fetch;
+
+async function resetStorage() {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedAntigravity(name: string, lastUsedAt: string | null) {
+  return providers.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name,
+    accessToken: `token-${name}`,
+    refreshToken: `refresh-${name}`,
+    projectId: `project-${name}`,
+    isActive: true,
+    testStatus: "active",
+    priority: 1,
+    lastUsedAt,
+    providerSpecificData: {},
+  });
+}
+
+function request(signal?: AbortSignal) {
+  return new Request("http://localhost/api/v1/images/generations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    signal,
+    body: JSON.stringify({
+      model: "antigravity/gemini-3.1-flash-image",
+      prompt: "a rotation test",
+      size: "1024x1024",
+    }),
+  });
+}
+
+function upstreamSuccess() {
+  return new Response(
+    JSON.stringify({
+      response: { candidates: [{ content: { parts: [{ inlineData: { data: "aW1n" } }] } }] },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+test.beforeEach(resetStorage);
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("Antigravity image quota 429 rotates to the other account without mutating production cooldown state", async () => {
+  const a = await seedAntigravity("A", "2026-01-01T00:00:00.000Z");
+  const b = await seedAntigravity("B", "2026-01-02T00:00:00.000Z");
+  const tokens: string[] = [];
+  globalThis.fetch = async (_url, options: RequestInit = {}) => {
+    tokens.push(String((options.headers as Record<string, string>).Authorization));
+    return tokens.length === 1
+      ? new Response(JSON.stringify({ error: { message: "quota exhausted" } }), { status: 429 })
+      : upstreamSuccess();
+  };
+
+  const response = await imageRoute.POST(request());
+  assert.equal(response.status, 200);
+  assert.equal(tokens.length, 2);
+  assert.notEqual(tokens[0], tokens[1]);
+  assert.deepEqual([...new Set(tokens)].sort(), ["Bearer token-A", "Bearer token-B"]);
+  const persistedA = await providers.getProviderConnectionById((a as { id: string }).id);
+  const persistedB = await providers.getProviderConnectionById((b as { id: string }).id);
+  assert.equal((persistedA as PersistedConnection | null)?.rateLimitedUntil ?? null, null);
+  assert.equal((persistedB as PersistedConnection | null)?.rateLimitedUntil ?? null, null);
+});
+
+test("Antigravity image all exhausted returns the final normalized error", async () => {
+  await seedAntigravity("A", "2026-01-01T00:00:00.000Z");
+  await seedAntigravity("B", "2026-01-02T00:00:00.000Z");
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return new Response(JSON.stringify({ error: { message: "quota exhausted" } }), { status: 429 });
+  };
+
+  const response = await imageRoute.POST(request());
+  const body = (await response.json()) as ErrorPayload;
+  assert.equal(response.status, 429);
+  assert.equal(calls, 2);
+  assert.match(body.error.message, /quota exhausted/i);
+});
+
+test("Antigravity image request-invalid error does not rotate accounts", async () => {
+  await seedAntigravity("A", "2026-01-01T00:00:00.000Z");
+  await seedAntigravity("B", "2026-01-02T00:00:00.000Z");
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return new Response(JSON.stringify({ error: { message: "invalid image configuration" } }), {
+      status: 400,
+    });
+  };
+
+  const response = await imageRoute.POST(request());
+  assert.equal(response.status, 400);
+  assert.equal(calls, 1);
+});
+
+test("Antigravity image ordinary 429 does not rotate accounts", async () => {
+  await seedAntigravity("A", "2026-01-01T00:00:00.000Z");
+  await seedAntigravity("B", "2026-01-02T00:00:00.000Z");
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return new Response(JSON.stringify({ error: { message: "too many requests; retry later" } }), {
+      status: 429,
+      headers: { "retry-after": "10" },
+    });
+  };
+
+  const response = await imageRoute.POST(request());
+  assert.equal(response.status, 429);
+  assert.equal(calls, 1);
+});
+
+test("Antigravity image propagates an in-flight client abort to fetch without rotating", async () => {
+  await seedAntigravity("A", "2026-01-01T00:00:00.000Z");
+  await seedAntigravity("B", "2026-01-02T00:00:00.000Z");
+  const controller = new AbortController();
+  let calls = 0;
+  let receivedSignal: AbortSignal | undefined;
+  let markFetchStarted: (() => void) | undefined;
+  const fetchStarted = new Promise<void>((resolve) => {
+    markFetchStarted = resolve;
+  });
+  globalThis.fetch = async (_url, options: RequestInit = {}) => {
+    calls++;
+    receivedSignal = options.signal as AbortSignal;
+    markFetchStarted?.();
+    return new Promise((_resolve, reject) => {
+      if (receivedSignal?.aborted) {
+        reject(new DOMException("aborted", "AbortError"));
+        return;
+      }
+      receivedSignal?.addEventListener(
+        "abort",
+        () => reject(new DOMException("aborted", "AbortError")),
+        {
+          once: true,
+        }
+      );
+    });
+  };
+
+  const pending = imageRoute.POST(request(controller.signal));
+  await fetchStarted;
+  controller.abort();
+  const response = await pending;
+  assert.equal(response.status, 499);
+  assert.equal(calls, 1);
+  assert.equal(receivedSignal?.aborted, true);
+});

--- a/tests/unit/combo-routing-instrumentation.test.ts
+++ b/tests/unit/combo-routing-instrumentation.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  nextRoutingTransition,
+  summarizeAccountRouting,
+} from "../../open-sse/services/combo/routingInstrumentation.ts";
+
+test("routing instrumentation emits only eight-character account prefixes", () => {
+  const firstAccountId = "abcdefgh-secret-account-id";
+  const secondAccountId = "ijklmnop-secret-account-id";
+  const summary = summarizeAccountRouting({
+    correlationId: "server-generated-correlation",
+    provider: "antigravity",
+    model: "gemini-image",
+    candidateConnectionIds: [firstAccountId, secondAccountId],
+    attemptedConnectionIds: new Set([firstAccountId]),
+    excludedConnectionIds: [firstAccountId],
+  });
+
+  const rendered = JSON.stringify(summary);
+  assert.deepEqual(summary.candidateAccountPrefixes, ["abcdefgh", "ijklmnop"]);
+  assert.deepEqual(summary.attemptedAccountPrefixes, ["abcdefgh"]);
+  assert.deepEqual(summary.excludedAccountPrefixes, ["abcdefgh"]);
+  assert.equal(summary.eligibleUnattemptedCount, 1);
+  assert.ok(!rendered.includes(firstAccountId));
+  assert.ok(!rendered.includes(secondAccountId));
+});
+
+test("routing warns when a retryable failure advances before same-model accounts are exhausted", () => {
+  assert.deepEqual(
+    nextRoutingTransition({
+      sameProvider: false,
+      sameModel: false,
+      retryableAccountFailure: true,
+      eligibleUnattemptedCount: 1,
+    }),
+    {
+      transition: "next_combo_target",
+      event: "routing_account_scope",
+      invariantViolation: true,
+    }
+  );
+  assert.deepEqual(
+    nextRoutingTransition({
+      sameProvider: true,
+      sameModel: true,
+      retryableAccountFailure: true,
+      eligibleUnattemptedCount: 0,
+    }),
+    {
+      transition: "next_account_same_model",
+      event: "routing_account_scope",
+      invariantViolation: false,
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- rotate Antigravity image generation to one alternate account only after an explicit quota-exhausted `429`
- keep both attempts inside one shared 30-second deadline and re-resolve credentials/proxy per account
- add request-scoped combo routing observations and warn if fallback advances while eligible same-model accounts remain

## Behavioral boundaries
- maximum two total image attempts
- no retry for request-invalid `400` or ambiguous/non-quota `429`
- no durable image cooldown writes from this retry path
- no change to normal combo selection or fallback semantics
- account identifiers in routing observations are limited to 8-character prefixes

## Validation
- targeted image rotation and routing instrumentation tests: 7/7 passing
- changed-file ESLint: passing
- `git diff --check`: passing
- mock validation only; no live Antigravity image quota was consumed
