### PR TITLE
fix(build): stop client bundle pulling child_process via versionCheck

### DIFF
--- a/src/app/(dashboard)/dashboard/kimiSponsorBanner.ts
+++ b/src/app/(dashboard)/dashboard/kimiSponsorBanner.ts
@@ -3,7 +3,7 @@
 // Pure logic split out of KimiSponsorBanner.tsx so the gate can be unit-tested
 // with node:test (no DOM/next-intl needed), mirroring homeAppearance.ts.
 
-import { isNewer, normalizeVersion } from "@/lib/system/versionCheck";
+import { isNewer, normalizeVersion } from "@/lib/system/versionCompare";
 
 /**
  * Last app version that still shows the Kimi sponsor banner (inclusive).

--- a/src/lib/system/versionCheck.ts
+++ b/src/lib/system/versionCheck.ts
@@ -37,37 +37,11 @@ const GITHUB_RELEASES_LATEST_URL =
 
 const LOOKUP_TIMEOUT_MS = 10_000;
 
-/**
- * Strip a leading `v`, drop pre-release/build metadata (`-`/`+` suffix), split on `.`,
- * and return a numeric tuple. Returns null when the string is empty or any segment is
- * non-numeric, so callers can fail safe instead of comparing `NaN`.
- */
-export function normalizeVersion(v: string): number[] | null {
-  if (typeof v !== "string") return null;
-  const cleaned = v.trim().replace(/^v/i, "").split(/[-+]/)[0];
-  if (!cleaned) return null;
-  const parts = cleaned.split(".").map((p) => Number(p));
-  if (parts.length === 0 || parts.some((n) => !Number.isFinite(n))) return null;
-  return parts;
-}
-
-/**
- * True iff `latest` is a strictly higher semver than `current`. Safe on null/garbage
- * (returns false rather than throwing or yielding a `NaN`-driven false positive).
- */
-export function isNewer(latest: string | null | undefined, current: string): boolean {
-  if (!latest) return false;
-  const a = normalizeVersion(latest);
-  const b = normalizeVersion(current);
-  if (!a || !b) return false;
-  const len = Math.max(a.length, b.length);
-  for (let i = 0; i < len; i++) {
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
-    if (av !== bv) return av > bv;
-  }
-  return false;
-}
+// The pure semver comparison helpers live in a Node-free module (`versionCompare`)
+// so client components can import them without pulling this file's server-only
+// `child_process` / npm-CLI code into the browser bundle. Re-exported here so
+// existing server-side importers of `versionCheck` keep working unchanged.
+export { isNewer, normalizeVersion } from "./versionCompare";
 
 /** Latest published version via the `npm` CLI (fast when npm is on PATH, e.g. source installs). */
 export async function getLatestVersionFromNpmCli(): Promise<string | null> {

--- a/src/lib/system/versionCompare.ts
+++ b/src/lib/system/versionCompare.ts
@@ -1,0 +1,41 @@
+/**
+ * Node-free semver comparison helpers.
+ *
+ * Split out of `versionCheck.ts` so client components (e.g. the Kimi sponsor
+ * banner) can import the pure comparison logic without dragging the server-only
+ * `child_process` / npm-CLI code — and thus a browser build error — along with
+ * it. `versionCheck.ts` re-exports these so existing server-side importers keep
+ * working unchanged.
+ */
+
+/**
+ * Strip a leading `v`, drop pre-release/build metadata (`-`/`+` suffix), split on `.`,
+ * and return a numeric tuple. Returns null when the string is empty or any segment is
+ * non-numeric, so callers can fail safe instead of comparing `NaN`.
+ */
+export function normalizeVersion(v: string): number[] | null {
+  if (typeof v !== "string") return null;
+  const cleaned = v.trim().replace(/^v/i, "").split(/[-+]/)[0];
+  if (!cleaned) return null;
+  const parts = cleaned.split(".").map((p) => Number(p));
+  if (parts.length === 0 || parts.some((n) => !Number.isFinite(n))) return null;
+  return parts;
+}
+
+/**
+ * True iff `latest` is a strictly higher semver than `current`. Safe on null/garbage
+ * (returns false rather than throwing or yielding a `NaN`-driven false positive).
+ */
+export function isNewer(latest: string | null | undefined, current: string): boolean {
+  if (!latest) return false;
+  const a = normalizeVersion(latest);
+  const b = normalizeVersion(current);
+  if (!a || !b) return false;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return av > bv;
+  }
+  return false;
+}


### PR DESCRIPTION
## Problem

A production build fails on the dashboard home route:

```
Build Error
Module not found: Can't resolve 'child_process'
./src/lib/system/versionCheck.ts (19:1)
> 19 | import { execFile } from "child_process";
```

Import trace:

```
src/lib/system/versionCheck.ts
  → src/app/(dashboard)/dashboard/kimiSponsorBanner.ts
    → src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx   [Client Component]
      → src/app/(dashboard)/home/page.tsx
```

`KimiSponsorBanner.tsx` is a client component. Its gate logic (`kimiSponsorBanner.ts`) imports `isNewer` / `normalizeVersion` from `lib/system/versionCheck.ts`, which also imports `node:child_process` for the npm-CLI version lookup. That drags a Node built-in into the browser bundle and breaks the build.

## Fix

Extract the two pure, Node-free semver helpers (`isNewer`, `normalizeVersion`) into a new `src/lib/system/versionCompare.ts`, and:

- `versionCheck.ts` re-exports them from `versionCompare` — **server-side importers are unchanged** (e.g. `src/app/api/system/version/route.ts`).
- The client-side `kimiSponsorBanner.ts` imports directly from `versionCompare`, severing the `child_process` path from the browser bundle.

No behavior change — same functions, same call sites. 3 files, +47/-32.

## Validation

- `npm run build` → **`✓ Compiled successfully`**, `649/649` static pages generated, exit 0. The `child_process` error is gone.
- Existing unit suites for the touched modules pass: `system-version-check-4100.test.ts`, `kimi-sponsor-banner-version-gate.test.ts`, `autoupdate-npm-win32-5542.test.ts` → **23/23**.
- Repo pre-commit gates (prettier, eslint, docs-sync, any-budget) pass.