### PR TITLE
fix: classify Google RESOURCE_EXHAUSTED quota responses

### DIFF
--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -54,6 +54,11 @@ const QUOTA_PATTERNS: ReadonlyArray<RegExp> = [
   /enable overages/i,
   /INSUFFICIENT_G1_CREDITS_BALANCE/i,
 
+  // Google APIs return this generic RESOURCE_EXHAUSTED message when a
+  // billing-period quota has been consumed. Keep the reset-window qualifier
+  // so transient Google rate limits are not treated as long-term exhaustion.
+  /resource has been exhausted.*reset after/i,
+
   // Cloudflare Workers AI daily neuron exhaustion (Issue #6980).
   // Body: "you have used up your daily free allocation of 10,000 neurons,
   //        please upgrade to Cloudflare's Workers Paid plan..."

--- a/tests/unit/classify429.test.ts
+++ b/tests/unit/classify429.test.ts
@@ -44,6 +44,19 @@ test("classify429: Antigravity 'Individual quota reached' body returns 'quota_ex
   assert.equal(classify429({ status: 429, body: { error: { message: body } } }), "quota_exhausted");
 });
 
+test("classify429: Google RESOURCE_EXHAUSTED with a billing-period reset is quota exhausted", () => {
+  const body = "Resource has been exhausted (e.g. check quota). (reset after 24h)";
+  assert.equal(looksLikeQuotaExhausted(body), true);
+  assert.equal(classify429({ status: 429, body }), "quota_exhausted");
+  assert.equal(classify429({ status: 429, body: { error: { message: body } } }), "quota_exhausted");
+});
+
+test("classify429: Google RESOURCE_EXHAUSTED without a reset remains a rate limit", () => {
+  const body = "Resource has been exhausted (e.g. check quota).";
+  assert.equal(looksLikeQuotaExhausted(body), false);
+  assert.equal(classify429({ status: 429, body }), "rate_limit");
+});
+
 test("classify429: Antigravity INSUFFICIENT_G1_CREDITS_BALANCE body returns 'quota_exhausted'", () => {
   const body = {
     error: {


### PR DESCRIPTION
## Summary

- classify Google `RESOURCE_EXHAUSTED` responses with a billing-period reset window as `quota_exhausted`
- keep generic `RESOURCE_EXHAUSTED` responses classified as transient `rate_limit`
- add string and nested-body regression coverage

## Validation

- `node --import tsx/esm --test tests/unit/classify429.test.ts tests/unit/antigravity-classify-retry.test.ts` — 19 passed
- `npm run typecheck:core`
- `npm run lint`
- signed commit and repository pre-commit quality gates passed

Fixes #8060