### PR TITLE
feat: add local Rust web fetch provider

### DIFF
--- a/open-sse/executors/rs-trafilatura-fetch.ts
+++ b/open-sse/executors/rs-trafilatura-fetch.ts
@@ -1,0 +1,115 @@
+/**
+ * Local Rust Web Fetch Executor
+ *
+ * Uses a local rs-webfetch CLI, backed by rs-trafilatura, for lightweight
+ * single-page extraction without external API credentials.
+ */
+
+import { execFile } from "node:child_process";
+import type { WebFetchFormat, WebFetchResult } from "../handlers/webFetch.ts";
+import { buildErrorBody, sanitizeErrorMessage } from "../utils/error.ts";
+
+const RS_WEBFETCH_TIMEOUT_MS = 65_000;
+const RS_WEBFETCH_MAX_BUFFER = 16 * 1024 * 1024;
+
+interface RsTrafilaturaFetchOptions {
+  url: string;
+  format: WebFetchFormat;
+  includeMetadata: boolean;
+}
+
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      { timeout: RS_WEBFETCH_TIMEOUT_MS, maxBuffer: RS_WEBFETCH_MAX_BUFFER },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr?.trim() || error.message));
+          return;
+        }
+        resolve(stdout);
+      }
+    );
+  });
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function extractMarkdownLinks(markdown: string): string[] {
+  const links = new Set<string>();
+  for (const match of markdown.matchAll(/\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/g)) {
+    links.add(match[1]);
+  }
+  return Array.from(links);
+}
+
+export async function rsTrafilaturaFetch(opts: RsTrafilaturaFetchOptions): Promise<WebFetchResult> {
+  const { url, format, includeMetadata } = opts;
+
+  if (format === "screenshot") {
+    const body = buildErrorBody(400, "Local Rust Web Fetch does not support screenshots");
+    return { success: false, status: 400, error: body.error.message };
+  }
+
+  const bin = process.env.OMNIROUTE_RS_WEBFETCH_BIN || "rs-webfetch";
+  const args = ["--format", format === "html" ? "html" : "json", "--timeout", "20"];
+  if (format === "links") args.push("--links");
+  args.push(url);
+
+  try {
+    const stdout = await execFileText(bin, args);
+
+    if (format === "html") {
+      return {
+        success: true,
+        data: {
+          provider: "rs-trafilatura",
+          url,
+          content: stdout.trim(),
+          links: [],
+          metadata: null,
+          screenshot_url: null,
+        },
+      };
+    }
+
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    const contentRecord = toRecord(parsed.content);
+    const metadataRecord = toRecord(parsed.metadata);
+    const content = typeof contentRecord.text === "string" ? contentRecord.text : "";
+
+    return {
+      success: true,
+      data: {
+        provider: "rs-trafilatura",
+        url:
+          typeof parsed.finalUrl === "string"
+            ? parsed.finalUrl
+            : typeof parsed.url === "string"
+              ? parsed.url
+              : url,
+        content: format === "links" ? "" : content,
+        links: format === "links" ? extractMarkdownLinks(content) : [],
+        metadata: includeMetadata
+          ? {
+              title: typeof metadataRecord.title === "string" ? metadataRecord.title : null,
+              description:
+                typeof metadataRecord.description === "string" ? metadataRecord.description : null,
+            }
+          : null,
+        screenshot_url: null,
+      },
+    };
+  } catch (err: unknown) {
+    const msg =
+      err instanceof Error ? sanitizeErrorMessage(err.message) : sanitizeErrorMessage(String(err));
+    const body = buildErrorBody(502, msg);
+    return { success: false, status: 502, error: body.error.message };
+  }
+}

--- a/open-sse/handlers/webFetch.ts
+++ b/open-sse/handlers/webFetch.ts
@@ -2,12 +2,12 @@
  * Web Fetch Handler
  *
  * Handles POST /v1/web/fetch requests.
- * Dispatches to a web-fetch provider executor (Firecrawl, Jina Reader, Tavily, or TinyFish).
+ * Dispatches to a web-fetch provider executor (Local Rust Web Fetch, Firecrawl, Jina Reader, Tavily, or TinyFish).
  *
  * Request format:
  * {
  *   "url": "https://example.com",
- *   "provider": "firecrawl" | "jina-reader" | "tavily-search" | "tinyfish",  // optional
+ *   "provider": "rs-trafilatura" | "firecrawl" | "jina-reader" | "tavily-search" | "tinyfish",  // optional
  *   "format": "markdown" | "html" | "links" | "screenshot",
  *   "depth": 0 | 1 | 2,
  *   "wait_for_selector": "main",
@@ -18,6 +18,7 @@
 import { buildErrorBody, sanitizeErrorMessage } from "../utils/error.ts";
 import { firecrawlFetch } from "../executors/firecrawl-fetch.ts";
 import { jinaReaderFetch } from "../executors/jina-reader-fetch.ts";
+import { rsTrafilaturaFetch } from "../executors/rs-trafilatura-fetch.ts";
 import { tavilyFetch } from "../executors/tavily-fetch.ts";
 import { tinyfishFetch } from "../executors/tinyfish-fetch.ts";
 
@@ -25,7 +26,7 @@ export type WebFetchFormat = "markdown" | "html" | "links" | "screenshot";
 
 export interface WebFetchRequest {
   url: string;
-  provider?: "firecrawl" | "jina-reader" | "tavily-search" | "tinyfish";
+  provider?: "rs-trafilatura" | "firecrawl" | "jina-reader" | "tavily-search" | "tinyfish";
   format?: WebFetchFormat;
   depth?: 0 | 1 | 2;
   wait_for_selector?: string;
@@ -52,7 +53,13 @@ export interface WebFetchCredentials {
   apiKey?: string;
 }
 
-const WEB_FETCH_PROVIDERS = ["firecrawl", "jina-reader", "tavily-search", "tinyfish"] as const;
+const WEB_FETCH_PROVIDERS = [
+  "rs-trafilatura",
+  "firecrawl",
+  "jina-reader",
+  "tavily-search",
+  "tinyfish",
+] as const;
 type WebFetchProviderId = (typeof WEB_FETCH_PROVIDERS)[number];
 
 /**
@@ -67,13 +74,20 @@ export async function handleWebFetch(
   credentials: WebFetchCredentials,
   resolvedProvider?: WebFetchProviderId
 ): Promise<WebFetchResult> {
-  const provider = resolvedProvider ?? req.provider ?? "firecrawl";
+  const provider = resolvedProvider ?? req.provider ?? "rs-trafilatura";
 
   const format: WebFetchFormat = req.format ?? "markdown";
   const includeMetadata = req.include_metadata ?? false;
 
   try {
     switch (provider) {
+      case "rs-trafilatura":
+        return await rsTrafilaturaFetch({
+          url: req.url,
+          format,
+          includeMetadata,
+        });
+
       case "firecrawl":
         return await firecrawlFetch({
           url: req.url,

--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -453,9 +453,9 @@ export const webFetchInput = z.object({
     .min(1, "URL is required")
     .describe("The URL to fetch content from"),
   provider: z
-    .enum(["firecrawl", "jina-reader", "tavily-search", "tinyfish"])
+    .enum(["rs-trafilatura", "firecrawl", "jina-reader", "tavily-search", "tinyfish"])
     .optional()
-    .describe("Specific fetch provider to use (default: first available)"),
+    .describe("Specific fetch provider to use (default: Local Rust Web Fetch when supported)"),
   format: z
     .enum(["markdown", "html", "links", "screenshot"])
     .optional()
@@ -496,7 +496,7 @@ export const webFetchOutput = z.object({
 export const webFetchTool: McpToolDefinition<typeof webFetchInput, typeof webFetchOutput> = {
   name: "omniroute_web_fetch",
   description:
-    "Fetches and extracts content from a URL using OmniRoute's web fetch gateway. Supports multiple providers (Firecrawl, Jina Reader, Tavily, TinyFish) with automatic failover. Returns the page content as markdown, HTML, links, or screenshot, along with metadata.",
+    "Fetches and extracts content from a URL using Local Rust Web Fetch when supported, or OmniRoute's web fetch gateway. Supports Local Rust Web Fetch, Firecrawl, Jina Reader, Tavily, and TinyFish with automatic failover. Returns the page content as markdown, HTML, links, or screenshot, along with metadata.",
   inputSchema: webFetchInput,
   outputSchema: webFetchOutput,
   scopes: ["execute:search"],

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { execFile } from "node:child_process";
 import {
   getComboModelProvider,
   getComboModelString,
@@ -143,6 +144,15 @@ function readMcpAccessibilityConfig(): McpAccessibilityConfig {
 type TextToolResult = {
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
+};
+
+type WebFetchArgs = {
+  url: string;
+  provider?: "rs-trafilatura" | "firecrawl" | "jina-reader" | "tavily-search" | "tinyfish";
+  format?: "markdown" | "html" | "links" | "screenshot";
+  include_metadata?: boolean;
+  depth?: number;
+  wait_for_selector?: string;
 };
 
 function toRecord(value: unknown): JsonRecord {
@@ -578,30 +588,118 @@ async function handleWebSearch(args: {
   }
 }
 
-async function handleWebFetch(args: {
-  url: string;
-  provider?: "firecrawl" | "jina-reader" | "tavily-search" | "tinyfish";
-  format?: "markdown" | "html" | "links" | "screenshot";
-  include_metadata?: boolean;
-  depth?: number;
-  wait_for_selector?: string;
-}) {
+function execFileText(
+  file: string,
+  args: string[],
+  options: { timeout: number; maxBuffer: number }
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        const message = stderr?.trim() || error.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function extractMarkdownLinks(markdown: string): string[] {
+  const links = new Set<string>();
+  for (const match of markdown.matchAll(/\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/g)) {
+    links.add(match[1]);
+  }
+  return Array.from(links);
+}
+
+function shouldTryRsWebFetch(args: WebFetchArgs): boolean {
+  if (args.provider && args.provider !== "rs-trafilatura") return false;
+  if (args.wait_for_selector) return false;
+  if (args.depth !== undefined && args.depth > 0) return false;
+  return ["markdown", "html", "links"].includes(args.format ?? "markdown");
+}
+
+async function runRsWebFetch(args: WebFetchArgs): Promise<unknown> {
+  if (!shouldTryRsWebFetch(args)) {
+    throw new Error(
+      "Local Rust Web Fetch supports markdown, html, and links without crawl depth or selectors"
+    );
+  }
+
+  const format = args.format ?? "markdown";
+  const rsArgs = ["--format", format === "html" ? "html" : "json", "--timeout", "20"];
+  if (format === "links") rsArgs.push("--links");
+  rsArgs.push(args.url);
+
+  const bin = process.env.OMNIROUTE_RS_WEBFETCH_BIN || "rs-webfetch";
+  const { stdout } = await execFileText(bin, rsArgs, {
+    timeout: 65000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+
+  if (format === "html") {
+    return {
+      provider: "rs-trafilatura",
+      url: args.url,
+      content: stdout.trim(),
+      links: [],
+      metadata: null,
+      screenshot_url: null,
+    };
+  }
+
+  const parsed = JSON.parse(stdout) as JsonRecord;
+  const contentRecord = toRecord(parsed.content);
+  const metadataRecord = toRecord(parsed.metadata);
+  const content = toString(contentRecord.text);
+  const links = format === "links" ? extractMarkdownLinks(content) : [];
+
+  return {
+    provider: "rs-trafilatura",
+    url: toString(parsed.finalUrl, toString(parsed.url, args.url)),
+    content: format === "links" ? "" : content,
+    links,
+    metadata: args.include_metadata
+      ? {
+          title: typeof metadataRecord.title === "string" ? metadataRecord.title : null,
+          description:
+            typeof metadataRecord.description === "string" ? metadataRecord.description : null,
+        }
+      : null,
+    screenshot_url: null,
+  };
+}
+
+async function runGatewayWebFetch(args: WebFetchArgs): Promise<unknown> {
+  const body: Record<string, unknown> = {
+    url: args.url,
+    format: args.format ?? "markdown",
+    include_metadata: args.include_metadata ?? false,
+  };
+  if (args.provider && args.provider !== "rs-trafilatura") body.provider = args.provider;
+  if (args.depth !== undefined) body.depth = args.depth;
+  if (args.wait_for_selector) body.wait_for_selector = args.wait_for_selector;
+
+  return omniRouteFetch("/v1/web/fetch", {
+    method: "POST",
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60000),
+  });
+}
+
+async function handleWebFetch(args: WebFetchArgs) {
   const start = Date.now();
   try {
-    const body: Record<string, unknown> = {
-      url: args.url,
-      format: args.format ?? "markdown",
-      include_metadata: args.include_metadata ?? false,
-    };
-    if (args.provider) body.provider = args.provider;
-    if (args.depth !== undefined) body.depth = args.depth;
-    if (args.wait_for_selector) body.wait_for_selector = args.wait_for_selector;
-
-    const result = await omniRouteFetch("/v1/web/fetch", {
-      method: "POST",
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(60000),
-    });
+    let result: unknown;
+    try {
+      result = shouldTryRsWebFetch(args)
+        ? await runRsWebFetch(args)
+        : await runGatewayWebFetch(args);
+    } catch (err) {
+      if (args.provider === "rs-trafilatura") throw err;
+      result = await runGatewayWebFetch(args);
+    }
     await logToolCall("omniroute_web_fetch", args, result, Date.now() - start, true);
     return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
   } catch (err) {

--- a/src/app/api/search/providers/route.ts
+++ b/src/app/api/search/providers/route.ts
@@ -14,7 +14,7 @@ import {
 import * as log from "@/sse/utils/logger";
 
 // ---------------------------------------------------------------------------
-// Fetch provider metadata (hardcoded — no registry for these 4)
+// Fetch provider metadata (hardcoded — no registry for these providers)
 // ---------------------------------------------------------------------------
 
 interface FetchProviderDef {
@@ -26,6 +26,13 @@ interface FetchProviderDef {
 }
 
 const FETCH_PROVIDERS: FetchProviderDef[] = [
+  {
+    id: "rs-trafilatura",
+    name: "Local Rust Web Fetch",
+    costPerQuery: 0,
+    freeMonthlyQuota: 0,
+    fetchFormats: ["markdown", "html", "links"],
+  },
   {
     id: "firecrawl",
     name: "Firecrawl",
@@ -74,6 +81,8 @@ async function resolveProviderStatus(
   providerId: string,
   useCredentialFallback = true
 ): Promise<ProviderStatus> {
+  if (providerId === "rs-trafilatura") return "configured";
+
   try {
     const credentials = await getProviderCredentials(providerId).catch(() => null);
 

--- a/src/app/api/v1/web/fetch/route.ts
+++ b/src/app/api/v1/web/fetch/route.ts
@@ -1,8 +1,8 @@
 /**
  * POST /v1/web/fetch
  *
- * Extract content from a URL using a configured web-fetch provider.
- * Supports Firecrawl, Jina Reader, Tavily Extract, and TinyFish Fetch.
+ * Extract content from a URL using a local or configured web-fetch provider.
+ * Supports Local Rust Web Fetch, Firecrawl, Jina Reader, Tavily Extract, and TinyFish Fetch.
  *
  * Request: { url, provider?, format?, depth?, wait_for_selector?, include_metadata? }
  * Response: { provider, url, content, links, metadata, screenshot_url }
@@ -27,8 +27,24 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Headers": "*",
 };
 
-const WEB_FETCH_PROVIDERS = ["firecrawl", "jina-reader", "tavily-search", "tinyfish"] as const;
+const WEB_FETCH_PROVIDERS = [
+  "rs-trafilatura",
+  "firecrawl",
+  "jina-reader",
+  "tavily-search",
+  "tinyfish",
+] as const;
 type WebFetchProviderId = (typeof WEB_FETCH_PROVIDERS)[number];
+
+function canUseRsTrafilatura(body: {
+  format?: string;
+  depth?: number;
+  wait_for_selector?: string;
+}) {
+  if (body.wait_for_selector) return false;
+  if (body.depth !== undefined && body.depth > 0) return false;
+  return ["markdown", "html", "links"].includes(body.format ?? "markdown");
+}
 
 export async function OPTIONS() {
   return new Response(null, { headers: CORS_HEADERS });
@@ -41,6 +57,7 @@ export async function OPTIONS() {
 async function resolveCredentials(
   providerId: WebFetchProviderId
 ): Promise<{ apiKey?: string } | null> {
+  if (providerId === "rs-trafilatura") return {};
   try {
     const creds = await getProviderCredentialsWithQuotaPreflight(providerId);
     return creds ?? null;
@@ -83,6 +100,12 @@ export async function POST(request: Request) {
 
   if (body.provider) {
     resolvedProvider = body.provider as WebFetchProviderId;
+    if (resolvedProvider === "rs-trafilatura" && !canUseRsTrafilatura(body)) {
+      return errorResponse(
+        HTTP_STATUS.BAD_REQUEST,
+        "Local Rust Web Fetch supports markdown, html, and links without crawl depth or selectors"
+      );
+    }
     const creds = await resolveCredentials(resolvedProvider);
     if (!creds) {
       return errorResponse(
@@ -93,8 +116,11 @@ export async function POST(request: Request) {
     }
     credentials = creds;
   } else {
-    // Auto-select: try providers in priority order
-    for (const pid of WEB_FETCH_PROVIDERS) {
+    // Auto-select: use local extraction when possible, otherwise try configured providers.
+    const candidates = canUseRsTrafilatura(body)
+      ? WEB_FETCH_PROVIDERS
+      : WEB_FETCH_PROVIDERS.filter((pid) => pid !== "rs-trafilatura");
+    for (const pid of candidates) {
       const creds = await resolveCredentials(pid);
       if (creds) {
         resolvedProvider = pid;

--- a/src/lib/playground/codeExport.ts
+++ b/src/lib/playground/codeExport.ts
@@ -73,7 +73,7 @@ export interface PlaygroundState {
   searchType?: "web" | "news";
   maxResults?: number;
   // Scrape-specific
-  fetchProvider?: "firecrawl" | "jina-reader" | "tavily-search";
+  fetchProvider?: "rs-trafilatura" | "firecrawl" | "jina-reader" | "tavily-search";
   fetchFormat?: "markdown" | "html" | "links" | "screenshot";
   fetchDepth?: 0 | 1 | 2;
   // Rerank-specific
@@ -110,7 +110,7 @@ export const PlaygroundStateSchema = z.object({
   searchProvider: z.string().optional(),
   searchType: z.enum(["web", "news"]).optional(),
   maxResults: z.number().int().optional(),
-  fetchProvider: z.enum(["firecrawl", "jina-reader", "tavily-search"]).optional(),
+  fetchProvider: z.enum(["rs-trafilatura", "firecrawl", "jina-reader", "tavily-search"]).optional(),
   fetchFormat: z.enum(["markdown", "html", "links", "screenshot"]).optional(),
   fetchDepth: z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
   rerankModel: z.string().optional(),

--- a/src/shared/constants/providers/noauth.ts
+++ b/src/shared/constants/providers/noauth.ts
@@ -120,4 +120,23 @@ export const NOAUTH_PROVIDERS = {
       text: "Augment (Auggie CLI) requires the `auggie` binary installed and authenticated locally (`auggie login`). OmniRoute spawns it as a subprocess and never sees or stores your Augment credentials.",
     },
   },
+  "rs-trafilatura": {
+    id: "rs-trafilatura",
+    alias: "rs-webfetch",
+    name: "Local Rust Web Fetch",
+    icon: "language",
+    color: "#64748B",
+    textIcon: "RS",
+    website: "https://github.com/SupperTomato/rs-trafilatura",
+    noAuth: true,
+    hasFree: true,
+    serviceKinds: ["webFetch"],
+    isLocalCli: true,
+    freeNote: "Local Rust-powered web extraction. No API key or external fetch provider required.",
+    authHint:
+      "No API key required. Install rs-webfetch on PATH or set OMNIROUTE_RS_WEBFETCH_BIN to the local binary path.",
+    notice: {
+      text: "Local Rust Web Fetch runs on this machine through rs-webfetch for markdown, HTML, and link extraction. It does not support screenshots, selectors, or crawl depth.",
+    },
+  },
 };

--- a/src/shared/schemas/searchTools.ts
+++ b/src/shared/schemas/searchTools.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 export const SearchProviderCatalogItemSchema = z.object({
   id: z.string(),
   name: z.string(),
-  /** "search" para os 12 search providers; "fetch" para firecrawl/jina/tavily-fetch. */
+  /** "search" for search providers; "fetch" for Local Rust Web Fetch/firecrawl/jina/tavily/tinyfish. */
   kind: z.enum(["search", "fetch"]),
   costPerQuery: z.number().nonnegative(),
   freeMonthlyQuota: z.number().int().nonnegative(),

--- a/src/shared/validation/schemas/apiV1.ts
+++ b/src/shared/validation/schemas/apiV1.ts
@@ -289,7 +289,9 @@ export const v1BatchCreateSchema = z.object({
 
 export const v1WebFetchSchema = z.object({
   url: z.string().url("url must be a valid URL (http/https)"),
-  provider: z.enum(["firecrawl", "jina-reader", "tavily-search", "tinyfish"]).optional(),
+  provider: z
+    .enum(["rs-trafilatura", "firecrawl", "jina-reader", "tavily-search", "tinyfish"])
+    .optional(),
   format: z.enum(["markdown", "html", "links", "screenshot"]).default("markdown"),
   depth: z.union([z.literal(0), z.literal(1), z.literal(2)]).default(0),
   wait_for_selector: z.string().max(256).optional(),

--- a/tests/unit/web-fetch-handler.test.ts
+++ b/tests/unit/web-fetch-handler.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const { handleWebFetch } = await import("../../open-sse/handlers/webFetch.ts");
 
@@ -95,6 +98,60 @@ test("handleWebFetch routes to tinyfish when provider=tinyfish", async () => {
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("handleWebFetch routes to rs-trafilatura without apiKey", async () => {
+  const originalBin = process.env.OMNIROUTE_RS_WEBFETCH_BIN;
+  const dir = await mkdtemp(join(tmpdir(), "omniroute-rs-webfetch-"));
+  const bin = join(dir, "rs-webfetch-mock.mjs");
+  await writeFile(
+    bin,
+    `#!/usr/bin/env node
+console.log(JSON.stringify({
+  url: "https://example.com",
+  finalUrl: "https://example.com/final",
+  content: { text: "# Local content\\n[link](https://example.com/page)" },
+  metadata: { title: "Local title", description: "Local description" }
+}));
+`
+  );
+  await chmod(bin, 0o700);
+  process.env.OMNIROUTE_RS_WEBFETCH_BIN = bin;
+
+  try {
+    const result = await handleWebFetch(
+      { url: "https://example.com", format: "markdown", include_metadata: true },
+      {},
+      "rs-trafilatura"
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(result.data?.provider, "rs-trafilatura");
+    assert.equal(result.data?.url, "https://example.com/final");
+    assert.equal(result.data?.content, "# Local content\n[link](https://example.com/page)");
+    assert.deepEqual(result.data?.metadata, {
+      title: "Local title",
+      description: "Local description",
+    });
+  } finally {
+    if (originalBin === undefined) {
+      delete process.env.OMNIROUTE_RS_WEBFETCH_BIN;
+    } else {
+      process.env.OMNIROUTE_RS_WEBFETCH_BIN = originalBin;
+    }
+  }
+});
+
+test("handleWebFetch rejects rs-trafilatura screenshots without apiKey", async () => {
+  const result = await handleWebFetch(
+    { url: "https://example.com", format: "screenshot" },
+    {},
+    "rs-trafilatura"
+  );
+
+  assert.equal(result.success, false);
+  assert.equal(result.status, 400);
+  assert.match(result.error ?? "", /does not support screenshots/);
 });
 
 test("handleWebFetch returns error 401 when no apiKey for firecrawl", async () => {


### PR DESCRIPTION
## Summary
- add Local Rust Web Fetch as a no-auth webFetch provider backed by rs-webfetch / rs-trafilatura
- wire provider support through /v1/web/fetch, MCP omniroute_web_fetch, dashboard provider catalog, search-tools fetch catalog, and playground export schema
- keep hosted providers as fallback for unsupported local modes such as screenshots, selectors, and crawl depth

## Security
- no API keys, OAuth values, cookies, sessions, .env files, SQLite data, or local machine paths are included
- binary path is configurable via OMNIROUTE_RS_WEBFETCH_BIN and defaults to rs-webfetch on PATH

## Tests
- npx --yes tsx --test tests/unit/web-fetch-handler.test.ts