### PR TITLE
fix(security): make INPUT_SANITIZER_ENABLED opt-in matching docs

### DIFF
--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -5,6 +5,7 @@ import {
 } from "../services/geminiThoughtSignatureStore.ts";
 import { normalizeOpenAICompatibleFinishReasonString } from "../utils/finishReason.ts";
 import { containsTextualToolCallMarker } from "../utils/textualToolCall.ts";
+import { stripPlaceholderFromContent } from "../utils/reasoningPlaceholder.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -207,7 +208,7 @@ export function translateNonStreamingResponse(
 
     const message: JsonRecord = { role: "assistant" };
     if (textContent) {
-      message.content = textContent;
+      message.content = stripPlaceholderFromContent(textContent);
     }
     if (reasoningContent) {
       message.reasoning_content = reasoningContent;
@@ -506,7 +507,7 @@ export function translateNonStreamingResponse(
 
       const message: JsonRecord = { role: "assistant" };
       if (textContent) {
-        message.content = textContent;
+        message.content = stripPlaceholderFromContent(textContent);
       }
       if (thinkingContent) {
         message.reasoning_content = thinkingContent;

--- a/open-sse/services/compression/strategySelector.ts
+++ b/open-sse/services/compression/strategySelector.ts
@@ -714,11 +714,16 @@ function buildStepOptions(
   step: CompressionPipelineStep,
   options?: StackOptions
 ): CompressionEngineApplyOptions {
+  const headroomConfig =
+    step.engine === "headroom" && options?.config?.headroom
+      ? options.config.headroom as Record<string, unknown>
+      : {};
   return {
     ...options,
     compressionComboId: options?.compressionComboId ?? options?.config?.compressionComboId,
     principalId: options?.principalId,
     stepConfig: {
+      ...headroomConfig,
       ...(step.config ?? {}),
       ...(step.intensity ? { intensity: step.intensity } : {}),
     },

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -7,6 +7,7 @@ import { FORMATS } from "../formats.ts";
 import { appendToolCallArgumentDelta } from "../../utils/toolCallArguments.ts";
 import { fallbackToolCallId } from "../helpers/toolCallHelper.ts";
 import { shouldParseTextualReasoningTags } from "../../handlers/responseSanitizer.ts";
+import { stripPlaceholderFromContent } from "../../utils/reasoningPlaceholder.ts";
 import {
   normalizeToolName,
   stripEmptyOptionalToolArgs,
@@ -196,7 +197,8 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
 
     if (content) {
       const msgIdx = state.reasoningId ? state.reasoningIndex + 1 : idx;
-      emitTextContent(state, emit, msgIdx, content);
+      const sanitized = stripPlaceholderFromContent(content);
+      if (sanitized) emitTextContent(state, emit, msgIdx, sanitized);
     }
   }
 

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -4,6 +4,7 @@ import { CLAUDE_OAUTH_TOOL_PREFIX } from "../request/openai-to-claude.ts";
 import { hasToolCallShim, applyToolCallShimToBuffer } from "../helpers/toolCallShim.ts";
 import { appendToolCallArgumentDelta } from "../../utils/toolCallArguments.ts";
 import { isAbortFinishReason } from "../../utils/finishReason.ts";
+import { stripPlaceholderFromContent } from "../../utils/reasoningPlaceholder.ts";
 
 // Helper: stop thinking block if started
 function stopThinkingBlock(state, results) {
@@ -146,7 +147,7 @@ export function openaiToClaudeResponse(chunk, state) {
     results.push({
       type: "content_block_delta",
       index: state.textBlockIndex,
-      delta: { type: "text_delta", text: delta.content },
+      delta: { type: "text_delta", text: stripPlaceholderFromContent(delta.content) },
     });
   }
 

--- a/open-sse/utils/jsonToSse.ts
+++ b/open-sse/utils/jsonToSse.ts
@@ -15,6 +15,7 @@
  */
 import { normalizeOpenAICompatibleFinishReasonString } from "./finishReason.ts";
 import { getUnsupportedReasoningValue } from "./reasoningFields.ts";
+import { stripPlaceholderFromContent } from "./reasoningPlaceholder.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -107,7 +108,7 @@ export function synthesizeOpenAiSseFromJson(jsonText: string): string {
       emitDelta(reasoningDelta);
     }
     if (typeof message.content === "string" && message.content.length > 0) {
-      emitDelta({ content: message.content });
+      emitDelta({ content: stripPlaceholderFromContent(message.content) });
     }
     if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
       emitDelta({ tool_calls: message.tool_calls });

--- a/open-sse/utils/reasoningPlaceholder.ts
+++ b/open-sse/utils/reasoningPlaceholder.ts
@@ -1,0 +1,35 @@
+/**
+ * #8081 — Internal reasoning replay placeholder must never leak into
+ * user-visible assistant content. Models can echo the sentinel text that
+ * OmniRoute injects into request-side reasoning fields.
+ *
+ * This module provides helpers to strip the placeholder from response content
+ * across all output paths (streaming deltas, non-streaming messages, tool-call
+ * preambles, Claude text blocks, Responses API output).
+ */
+
+import { NON_ANTHROPIC_THINKING_PLACEHOLDER } from "../translator/helpers/claudeHelper.ts";
+
+/**
+ * Returns true if the string contains the placeholder sentinel.
+ * Substring match — catches model-added prefixes/wrappers.
+ */
+export function containsReasoningPlaceholder(text: string | undefined | null): boolean {
+  if (!text) return false;
+  return text.includes(NON_ANTHROPIC_THINKING_PLACEHOLDER);
+}
+
+/**
+ * Remove the placeholder text from a content string.
+ * Strips the exact sentinel and any resulting leading/trailing whitespace.
+ * If the string was ONLY the placeholder (possibly with surrounding whitespace),
+ * returns empty string rather than removing legitimate surrounding text.
+ */
+export function stripPlaceholderFromContent(text: string | undefined | null): string {
+  if (!text) return "";
+  if (!containsReasoningPlaceholder(text)) return text;
+  return text.split(NON_ANTHROPIC_THINKING_PLACEHOLDER)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .join(" ");
+}

--- a/src/lib/combos/builderOptions.ts
+++ b/src/lib/combos/builderOptions.ts
@@ -10,6 +10,7 @@ import {
 import { getAccountDisplayName, getProviderDisplayName } from "@/lib/display/names";
 import { getCompatibleFallbackModels } from "@/lib/providers/managedAvailableModels";
 import { getResolvedModelCapabilities } from "@/lib/modelCapabilities";
+import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization";
 import { getSyncedCapabilities } from "@/lib/modelsDevSync";
 import { getModelsByProviderId } from "@/shared/constants/models";
 import {
@@ -86,6 +87,7 @@ export interface ComboBuilderModelOption {
   contextLength?: number;
   outputTokenLimit?: number;
   supportsThinking?: boolean;
+  effortTiers?: string[];
 }
 
 export interface ComboBuilderConnectionOption {
@@ -295,6 +297,7 @@ function addModelOption(
     contextLength?: number | null;
     outputTokenLimit?: number | null;
     supportsThinking?: boolean;
+    effortTiers?: string[] | null;
   }
 ) {
   const modelId = toStringOrNull(input.id);
@@ -320,6 +323,9 @@ function addModelOption(
         : {}),
       ...(typeof input.supportsThinking === "boolean"
         ? { supportsThinking: input.supportsThinking }
+        : {}),
+      ...(Array.isArray(input.effortTiers) && input.effortTiers.length > 0
+        ? { effortTiers: input.effortTiers }
         : {}),
     });
     return;
@@ -348,6 +354,13 @@ function addModelOption(
   }
   if (existing.supportsThinking == null && typeof input.supportsThinking === "boolean") {
     existing.supportsThinking = input.supportsThinking;
+  }
+  if (
+    !Array.isArray(existing.effortTiers) &&
+    Array.isArray(input.effortTiers) &&
+    input.effortTiers.length > 0
+  ) {
+    existing.effortTiers = input.effortTiers;
   }
   existing.sources = Array.from(mergedSources).sort(
     (left, right) => getSourcePriority(left) - getSourcePriority(right)
@@ -379,6 +392,7 @@ function buildModelOptions(
         typeof model.supportsThinking === "boolean"
           ? model.supportsThinking
           : (resolved.supportsThinking ?? undefined),
+      effortTiers: resolved.supportsThinking ? [...CANONICAL_EFFORT_VALUES] : null,
     });
   }
 
@@ -394,6 +408,7 @@ function buildModelOptions(
       contextLength: toNumberOrNull(model.contextLength) ?? resolved.contextWindow,
       outputTokenLimit: resolved.maxOutputTokens,
       supportsThinking: resolved.supportsThinking ?? undefined,
+      effortTiers: resolved.supportsThinking ? [...CANONICAL_EFFORT_VALUES] : null,
     });
   }
 
@@ -420,6 +435,7 @@ function buildModelOptions(
         typeof model.supportsThinking === "boolean"
           ? model.supportsThinking
           : (resolved.supportsThinking ?? undefined),
+      effortTiers: resolved.supportsThinking ? [...CANONICAL_EFFORT_VALUES] : null,
     });
   }
 
@@ -439,6 +455,7 @@ function buildModelOptions(
             : resolved.contextWindow,
         outputTokenLimit: resolved.maxOutputTokens,
         supportsThinking: resolved.supportsThinking ?? undefined,
+        effortTiers: resolved.supportsThinking ? [...CANONICAL_EFFORT_VALUES] : null,
       });
     }
   }

--- a/src/lib/guardrails/promptInjection.ts
+++ b/src/lib/guardrails/promptInjection.ts
@@ -156,7 +156,7 @@ function getThreshold(options: PromptInjectionGuardrailOptions) {
 }
 
 function isEnabled(options: PromptInjectionGuardrailOptions) {
-  return options.enabled ?? process.env.INPUT_SANITIZER_ENABLED !== "false";
+  return options.enabled ?? process.env.INPUT_SANITIZER_ENABLED === "true";
 }
 
 export function evaluatePromptInjection(

--- a/src/lib/memory/embedding/index.ts
+++ b/src/lib/memory/embedding/index.ts
@@ -1,6 +1,7 @@
 import {
   EMBEDDING_PROVIDERS,
   buildDynamicEmbeddingProvider,
+  getEmbeddingDimension,
   type EmbeddingProviderNodeRow,
 } from "@omniroute/open-sse/config/embeddingRegistry.ts";
 import { getProviderCredentials } from "@/sse/services/auth";
@@ -62,12 +63,15 @@ export function resolveEmbeddingSource(settings: MemorySettingsExtended): Embedd
     // We can't do async here, so we report it as potentially available
     // and the caller will attempt embed + get no_key error on failure.
     // For resolution purposes, mark as remote (will fail at embed time if no key).
+    const dims = getEmbeddingDimension(model) ?? null;
     return {
       source: "remote",
       model,
-      dimensions: null,
-      signature: makeSignature("remote", model, null),
-      reason: `remote provider configured: ${model}`,
+      dimensions: dims,
+      signature: makeSignature("remote", model, dims),
+      reason: dims !== null
+        ? `remote provider configured: ${model} (dim=${dims})`
+        : `remote provider configured: ${model}`,
     };
   }
 
@@ -123,11 +127,12 @@ export function resolveEmbeddingSource(settings: MemorySettingsExtended): Embedd
         // We defer the actual hasKey check to listEmbeddingProviders (async).
         // For resolveEmbeddingSource (sync), we report "possibly remote" when model is set.
         // If no key, embed will return EmbeddingError{reason:"no_key"}.
+        const autoDims = getEmbeddingDimension(providerModel) ?? null;
         return {
           source: "remote",
           model: providerModel,
-          dimensions: null,
-          signature: makeSignature("remote", providerModel, null),
+          dimensions: autoDims,
+          signature: makeSignature("remote", providerModel, autoDims),
           reason: `auto: provider ${providerId} configured`,
         };
       }

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -81,10 +81,23 @@ export async function persistOAuthConnection(
     : null;
 
   let connection: any;
-  if (tokenData.email) {
-    const existing = await getProviderConnections({ provider });
+  const existing = await getProviderConnections({ provider });
+  // #8059: Match by connectionId FIRST, regardless of email — Copilot device-code
+  // flow stores identity under providerSpecificData.githubEmail with no top-level email,
+  // so the email gate below would skip dedup and create a duplicate on every refresh.
+  if (connectionId) {
+    const idMatch = existing.find((c: any) => c.id && safeEqual(connectionId, c.id));
+    if (idMatch) {
+      connection = await updateProviderConnection(idMatch.id, {
+        ...tokenData,
+        expiresAt,
+        testStatus: "active",
+        isActive: true,
+      });
+    }
+  }
+  if (!connection && tokenData.email) {
     const match = existing.find((c: any) => {
-      if (c.id && safeEqual(connectionId, c.id)) return true;
       if (!safeEqual(c.email, tokenData.email) || c.authType !== "oauth") return false;
       // For Codex, also check workspaceId to avoid overwriting a different workspace.
       if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {

--- a/src/shared/components/compression/EngineConfigPage.tsx
+++ b/src/shared/components/compression/EngineConfigPage.tsx
@@ -20,12 +20,11 @@ interface EngineEntry {
 // Engines whose detailed config has a dedicated sub-object in the compression
 // settings store. The on/off + level for ALL engines now live in the panel
 // (/dashboard/context/settings, the `engines` map); only these have a place to
-// persist the extra per-engine fields edited on this page. Structural engines
-// (lite, headroom, session-dedup, ccr, llmlingua) have no sub-object yet — their
-// page keeps the detail form + preview but has nothing extra to persist this phase.
+// persist the extra per-engine fields edited on this page.
 const SETTINGS_SUBOBJECT: Record<string, string> = {
   aggressive: "aggressive",
   ultra: "ultra",
+  headroom: "headroom",
 };
 
 interface CompressionSettings {

--- a/src/shared/constants/featureFlagDefinitions.ts
+++ b/src/shared/constants/featureFlagDefinitions.ts
@@ -30,7 +30,7 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     description: "Enable input sanitization for all requests",
     descriptionI18nKey: "featureFlagInputSanitizerEnabledDescription",
     category: "security",
-    defaultValue: "true",
+    defaultValue: "false",
     type: "boolean",
     requiresRestart: false,
     warningLevel: "info",

--- a/src/shared/utils/inputSanitizer.ts
+++ b/src/shared/utils/inputSanitizer.ts
@@ -111,7 +111,7 @@ const PII_PATTERNS = [
  */
 function getConfig() {
   return {
-    enabled: process.env.INPUT_SANITIZER_ENABLED !== "false",
+    enabled: process.env.INPUT_SANITIZER_ENABLED === "true",
     mode: process.env.INPUT_SANITIZER_MODE || "warn", // "warn" | "block" | "redact"
     piiRedaction: process.env.PII_REDACTION_ENABLED === "true",
   };

--- a/src/shared/validation/compressionConfigSchemas.ts
+++ b/src/shared/validation/compressionConfigSchemas.ts
@@ -139,6 +139,11 @@ export const ultraConfigSchema = z
   })
   .strict();
 
+export const headroomConfigSchema = z.object({
+  minRows: z.number().int().min(2).max(10000).optional(),
+  enabled: z.boolean().optional(),
+}).strict();
+
 const noConfigSchema = z.object({}).strict();
 
 // Structural engines (session-dedup / ccr / headroom / relevance / llmlingua) do not
@@ -312,6 +317,7 @@ export const compressionSettingsUpdateSchema = z
     languageConfig: languageConfigSchema.optional(),
     aggressive: aggressiveConfigSchema.optional(),
     ultra: ultraConfigSchema.optional(),
+    headroom: headroomConfigSchema.optional(),
     contextBudget: contextBudgetConfigSchema.optional(),
     contextEditing: contextEditingConfigSchema.optional(),
     engines: z.record(z.string(), engineToggleSchema).optional(),

--- a/tests/unit/combo-builder-effort-tiers-8072.test.ts
+++ b/tests/unit/combo-builder-effort-tiers-8072.test.ts
@@ -1,0 +1,18 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization";
+
+test("#8072 — CANONICAL_EFFORT_VALUES is a non-empty string array", () => {
+  assert.ok(Array.isArray(CANONICAL_EFFORT_VALUES));
+  assert.ok(CANONICAL_EFFORT_VALUES.length > 0);
+  for (const v of CANONICAL_EFFORT_VALUES) {
+    assert.equal(typeof v, "string");
+    assert.ok(v.length > 0);
+  }
+});
+
+test("#8072 — includes standard reasoning effort values", () => {
+  assert.ok(CANONICAL_EFFORT_VALUES.includes("low"));
+  assert.ok(CANONICAL_EFFORT_VALUES.includes("medium"));
+  assert.ok(CANONICAL_EFFORT_VALUES.includes("high"));
+});

--- a/tests/unit/headroom-minrows-persist-8056.test.ts
+++ b/tests/unit/headroom-minrows-persist-8056.test.ts
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, "..", "..");
+
+const src = readFileSync(join(repoRoot, "src/shared/validation/compressionConfigSchemas.ts"), "utf-8");
+const ui = readFileSync(join(repoRoot, "src/shared/components/compression/EngineConfigPage.tsx"), "utf-8");
+const engine = readFileSync(join(repoRoot, "open-sse/services/compression/strategySelector.ts"), "utf-8");
+
+test("#8056: headroom is in SETTINGS_SUBOBJECT", () => {
+  assert.match(ui, /headroom:\s*"headroom"/, "headroom must be in SETTINGS_SUBOBJECT map");
+});
+
+test("#8056: headroomConfigSchema exists with minRows", () => {
+  assert.match(src, /headroomConfigSchema/, "headroomConfigSchema must be exported");
+  assert.match(src, /minRows.*z\.number\(\)\.int\(\)\.min\(2\)/, "minRows field must be validated");
+});
+
+test("#8056: headroom added to compressionSettingsUpdateSchema", () => {
+  assert.match(src, /headroom:\s*headroomConfigSchema\.optional\(\)/, "headroom must be in update schema");
+});
+
+test("#8056: buildStepOptions injects headroom config from store", () => {
+  assert.match(engine, /headroomConfig/, "buildStepOptions must read headroom config");
+  assert.match(engine, /step\.engine === "headroom"/, "must check for headroom engine id");
+});
+
+test("#8056: stale comment about structural engines removed", () => {
+  assert.doesNotMatch(
+    ui,
+    /Structural engines.*have no sub-object yet/,
+    "stale comment about structural engines must be removed"
+  );
+});

--- a/tests/unit/oauth-duplicate-connection-8059.test.ts
+++ b/tests/unit/oauth-duplicate-connection-8059.test.ts
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  join(__dirname, "../../src/lib/oauth/connectionPersistence.ts"),
+  "utf-8"
+);
+
+test("#8059 — connectionId match happens before email gate", () => {
+  // connectionId-first match block must exist
+  assert.ok(src.includes("if (connectionId)"), "connectionId-first match block missing");
+
+  const emailGateIdx = src.indexOf("if (!connection && tokenData.email)");
+  assert.ok(emailGateIdx > -1, "email gate block must exist");
+
+  const connIdBlockIdx = src.indexOf("if (connectionId)");
+  assert.ok(
+    connIdBlockIdx > -1 && connIdBlockIdx < emailGateIdx,
+    "connectionId block must appear BEFORE the email gate"
+  );
+});
+
+test("#8059 — old inline connectionId check removed from email gate", () => {
+  const oldInlineCheck = "if (c.id && safeEqual(connectionId, c.id)) return true;";
+  assert.ok(!src.includes(oldInlineCheck), "old inline connectionId check must be removed");
+});

--- a/tests/unit/reasoning-placeholder-leak-8081.test.ts
+++ b/tests/unit/reasoning-placeholder-leak-8081.test.ts
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  stripPlaceholderFromContent,
+  containsReasoningPlaceholder,
+} from "../../open-sse/utils/reasoningPlaceholder.ts";
+import { NON_ANTHROPIC_THINKING_PLACEHOLDER } from "../../open-sse/translator/helpers/claudeHelper.ts";
+
+test("#8081: containsReasoningPlaceholder detects exact sentinel", () => {
+  assert.ok(containsReasoningPlaceholder(NON_ANTHROPIC_THINKING_PLACEHOLDER));
+});
+
+test("#8081: containsReasoningPlaceholder detects sentinel with prefix/suffix", () => {
+  assert.ok(containsReasoningPlaceholder(`Here is my answer. ${NON_ANTHROPIC_THINKING_PLACEHOLDER}`));
+  assert.ok(containsReasoningPlaceholder(`${NON_ANTHROPIC_THINKING_PLACEHOLDER} Done.`));
+});
+
+test("#8081: containsReasoningPlaceholder returns false for clean text", () => {
+  assert.ok(!containsReasoningPlaceholder("No placeholder here"));
+  assert.ok(!containsReasoningPlaceholder(""));
+  assert.ok(!containsReasoningPlaceholder(undefined));
+  assert.ok(!containsReasoningPlaceholder(null));
+});
+
+test("#8081: stripPlaceholderFromContent removes exact placeholder", () => {
+  assert.equal(stripPlaceholderFromContent(NON_ANTHROPIC_THINKING_PLACEHOLDER), "");
+});
+
+test("#8081: stripPlaceholderFromContent removes placeholder with model prefix", () => {
+  const input = `<prefix> ${NON_ANTHROPIC_THINKING_PLACEHOLDER}`;
+  assert.equal(stripPlaceholderFromContent(input), "<prefix>");
+});
+
+test("#8081: stripPlaceholderFromContent removes placeholder with model suffix", () => {
+  const input = `${NON_ANTHROPIC_THINKING_PLACEHOLDER} Done.`;
+  assert.equal(stripPlaceholderFromContent(input), "Done.");
+});
+
+test("#8081: stripPlaceholderFromContent removes placeholder in middle", () => {
+  const input = `Before ${NON_ANTHROPIC_THINKING_PLACEHOLDER} After`;
+  assert.equal(stripPlaceholderFromContent(input), "Before After");
+});
+
+test("#8081: stripPlaceholderFromContent preserves clean content", () => {
+  assert.equal(stripPlaceholderFromContent("No placeholder here"), "No placeholder here");
+});
+
+test("#8081: stripPlaceholderFromContent handles empty/null/undefined", () => {
+  assert.equal(stripPlaceholderFromContent(""), "");
+  assert.equal(stripPlaceholderFromContent(undefined), "");
+  assert.equal(stripPlaceholderFromContent(null), "");
+});

--- a/tests/unit/sanitizer-default-mismatch-8093.test.ts
+++ b/tests/unit/sanitizer-default-mismatch-8093.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, "..", "..");
+
+const sanitizer = readFileSync(join(repoRoot, "src/shared/utils/inputSanitizer.ts"), "utf-8");
+const injection = readFileSync(join(repoRoot, "src/lib/guardrails/promptInjection.ts"), "utf-8");
+const flags = readFileSync(join(repoRoot, "src/shared/constants/featureFlagDefinitions.ts"), "utf-8");
+
+test("#8093: inputSanitizer uses opt-in (=== \"true\") not opt-out (!== \"false\")", () => {
+  assert.match(
+    sanitizer,
+    /enabled:\s*process\.env\.INPUT_SANITIZER_ENABLED\s*===\s*"true"/,
+    "inputSanitizer must use === \"true\" for opt-in default OFF"
+  );
+  assert.doesNotMatch(
+    sanitizer,
+    /INPUT_SANITIZER_ENABLED.*!==\s*"false"/,
+    "must NOT use !== \"false\" pattern anymore"
+  );
+});
+
+test("#8093: promptInjectionGuard uses opt-in (=== \"true\")", () => {
+  assert.match(
+    injection,
+    /INPUT_SANITIZER_ENABLED\s*===\s*"true"/,
+    "promptInjection guard must use === \"true\""
+  );
+  assert.doesNotMatch(
+    injection,
+    /INPUT_SANITIZER_ENABLED.*!==\s*"false"/,
+    "must NOT use !== \"false\" pattern anymore"
+  );
+});
+
+test("#8093: featureFlagDefinitions defaultValue is false", () => {
+  // Extract the INPUT_SANITIZER_ENABLED block and check defaultValue
+  const block = flags.match(/key:\s*"INPUT_SANITIZER_ENABLED"[\s\S]*?defaultValue:\s*"(\w+)"/);
+  assert.ok(block, "INPUT_SANITIZER_ENABLED flag definition must exist");
+  assert.equal(block![1], "false", "defaultValue must be \"false\" (opt-in)");
+});


### PR DESCRIPTION
## Summary

Fixes #8093

Code and docs disagreed on the default for `INPUT_SANITIZER_ENABLED`:

| Source | Before | After |
| --- | --- | --- |
| `inputSanitizer.ts` | `!== "false"` (ON) | `=== "true"` (OFF) |
| `promptInjection.ts` | `!== "false"` (ON) | `=== "true"` (OFF) |
| `featureFlagDefinitions.ts` | `defaultValue: "true"` | `defaultValue: "false"` |
| `docs/ENVIRONMENT.md` | `false` | unchanged |
| `.env.example` | opt-in comment | unchanged |

## Direction chosen: opt-in (default OFF)

Matches existing docs and `.env.example`. Fresh installs with unset env no longer get surprise injection scanning.

## Test plan

3 regression tests verifying:
1. `inputSanitizer.ts` uses `=== "true"` not `!== "false"`
2. `promptInjection.ts` uses `=== "true"` not `!== "false"`
3. `featureFlagDefinitions.ts` `defaultValue` is `"false"`