### PR TITLE
fix(providers): discover live AGY models

### DIFF
--- a/changelog.d/fixes/agy-live-model-sync.md
+++ b/changelog.d/fixes/agy-live-model-sync.md
@@ -1,0 +1,1 @@
+- **Providers**: AGY model sync now discovers newly announced chat models from the live Antigravity catalog while filtering internal and tab-completion-only models, with the bundled catalog retained as an offline fallback

--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -355,7 +355,7 @@
     "tests/unit/models-catalog-route.test.ts": 1608,
     "tests/unit/oauth-providers-config.test.ts": 845,
     "tests/unit/perplexity-web.test.ts": 1355,
-    "tests/unit/provider-models-route.test.ts": 1757,
+    "tests/unit/provider-models-route.test.ts": 1784,
     "tests/unit/provider-validation-specialty.test.ts": 2980,
     "tests/unit/providers-page-utils.test.ts": 1294,
     "tests/unit/reasoning-cache.test.ts": 980,
@@ -376,7 +376,8 @@
     "tests/unit/web-cookie-providers-new.test.ts": 890,
     "_rebaseline_2026_07_12_v3847_mergeprs_tail": "v3.8.47 /merge-prs tail: translator-openai-responses-req.test.ts 1172->1195 (+23 = #6807 reasoning-summary-for-effort-only regression tests). Frozen only shrinks.",
     "tests/unit/audio-transcription-handler.test.ts": 824,
-    "_rebaseline_2026_07_22_8056_headroom_minrows": "#8056 (@RaviTharuma, persist Headroom minRows) own growth: src/lib/db/compression.ts 850->866 (+16 HeadroomConfig+DEFAULT_HEADROOM_CONFIG+normalize/store in get/updateCompressionSettings) and open-sse/services/compression/strategySelector.ts 1054->1060 (+6 merge settings.headroom into stacked stepConfig). Cohesive settings-persistence + stacked-merge wiring at existing chokepoints, frozen at new size."
+    "_rebaseline_2026_07_22_8056_headroom_minrows": "#8056 (@RaviTharuma, persist Headroom minRows) own growth: src/lib/db/compression.ts 850->866 (+16 HeadroomConfig+DEFAULT_HEADROOM_CONFIG+normalize/store in get/updateCompressionSettings) and open-sse/services/compression/strategySelector.ts 1054->1060 (+6 merge settings.headroom into stacked stepConfig). Cohesive settings-persistence + stacked-merge wiring at existing chokepoints, frozen at new size.",
+    "_rebaseline_2026_07_22_8123_agy_live_model_sync": "#8123 (safeer/@adevwithpurpose) own test growth: provider-models-route.test.ts 1757->1783 (+26) — live AGY model discovery assertions (isDiscoverableAgyModelId + filterUserCallableAntigravityModels), composing with the #8013 fusion's antigravity discovery rewrite."
   },
   "_rebaseline_2026_06_09": "Re-baseline consciente pre-release v3.8.19: 9 arquivos cresceram durante o ciclo (features mergeadas: RequestLoggerV2 +281 request-logger rework, stream +101, combo +73, chatCore +45, catalog +32 fable-5/catalog-flag, callLogs +4, accountFallback +2, usageHistory novo 840) + core.ts +7 (fix resetAllDbModuleState, PR 3536). A catraca segue valendo destes valores — proximo crescimento falha. Decisao: encolher (esp. RequestLoggerV2/chatCore) e a issue #3501 ficam para o ciclo seguinte.",
   "_rebaseline_2026_06_11_phase1f": "Phase 1f (#3501): ProviderDetailPageClient.tsx 4948→4062 (-886 LOC); 3 novos hooks extraídos. useProviderConnections.ts=954 acima do cap=800 — justificado: extração direta do god-component (zero lógica nova), própria redução do cliente supera o custo. useProviderSettings.ts=263 e useProviderModels.ts=154 já abaixo do cap.",

--- a/open-sse/config/agyModels.ts
+++ b/open-sse/config/agyModels.ts
@@ -148,6 +148,7 @@ export const AGY_PUBLIC_MODELS = Object.freeze([
 ]);
 
 const AGY_PUBLIC_MODEL_IDS = new Set(AGY_PUBLIC_MODELS.map((model) => model.id));
+const AGY_NON_CHAT_MODEL_IDS = new Set(["tab_flash_lite_preview", "tab_jump_flash_lite_preview"]);
 
 const AGY_CLIENT_VISIBLE_MODEL_NAMES = Object.freeze(
   AGY_PUBLIC_MODELS.reduce<Record<string, string>>((acc, model) => {
@@ -162,4 +163,8 @@ export function getClientVisibleAgyModelName(modelId: string, fallbackName?: str
 
 export function isUserCallableAgyModelId(modelId: string): boolean {
   return !!modelId && AGY_PUBLIC_MODEL_IDS.has(modelId);
+}
+
+export function isDiscoverableAgyModelId(modelId: string): boolean {
+  return !!modelId && !AGY_NON_CHAT_MODEL_IDS.has(modelId);
 }

--- a/src/app/api/providers/[id]/models/discovery/normalizers.ts
+++ b/src/app/api/providers/[id]/models/discovery/normalizers.ts
@@ -11,6 +11,10 @@ import {
   isUserCallableAntigravityModelId,
   toClientAntigravityModelId,
 } from "@omniroute/open-sse/config/antigravityModelAliases.ts";
+import {
+  getClientVisibleAgyModelName,
+  isDiscoverableAgyModelId,
+} from "@omniroute/open-sse/config/agyModels.ts";
 import { normalizeAntigravityClientProfile } from "@/shared/constants/antigravityClientProfile";
 import { ensureAntigravityProjectAssigned } from "@omniroute/open-sse/services/antigravityProjectBootstrap.ts";
 import { asRecord, toNonEmptyString } from "./helpers";
@@ -20,9 +24,13 @@ const antigravityDiscoveryInflight = new Map<
   Promise<Array<{ id: string; name: string }>>
 >();
 
-export function normalizeAntigravityModelsResponse(
-  data: unknown
-): Array<{ id: string; name: string }> {
+type AntigravityDiscoveryModel = {
+  id: string;
+  name: string;
+  isInternal?: boolean;
+};
+
+export function normalizeAntigravityModelsResponse(data: unknown): AntigravityDiscoveryModel[] {
   const payload = asRecord(data).models;
 
   if (Array.isArray(payload)) {
@@ -43,9 +51,9 @@ export function normalizeAntigravityModelsResponse(
             : typeof item.name === "string"
               ? item.name
               : id;
-        return id ? { id, name } : null;
+        return id ? { id, name, ...(item.isInternal === true ? { isInternal: true } : {}) } : null;
       })
-      .filter((value): value is { id: string; name: string } => Boolean(value));
+      .filter((value): value is AntigravityDiscoveryModel => Boolean(value));
   }
 
   const modelsById = asRecord(payload);
@@ -58,23 +66,38 @@ export function normalizeAntigravityModelsResponse(
           : typeof item.name === "string"
             ? item.name
             : id;
-      return id ? { id, name } : null;
+      return id ? { id, name, ...(item.isInternal === true ? { isInternal: true } : {}) } : null;
     })
-    .filter((value): value is { id: string; name: string } => Boolean(value));
+    .filter((value): value is AntigravityDiscoveryModel => Boolean(value));
 }
 
-export function filterUserCallableAntigravityModels(models: Array<{ id: string; name: string }>) {
-  return models.filter((model) => isUserCallableAntigravityModelId(model.id));
+export function filterUserCallableAntigravityModels(
+  models: AntigravityDiscoveryModel[],
+  provider: "antigravity" | "agy" = "antigravity"
+) {
+  return models.filter(
+    (model) =>
+      model.isInternal !== true &&
+      (provider === "agy"
+        ? isDiscoverableAgyModelId(model.id)
+        : isUserCallableAntigravityModelId(model.id))
+  );
 }
 
-export function mapAntigravityModelForClient(model: { id: string; name: string }): {
+export function mapAntigravityModelForClient(
+  model: { id: string; name: string },
+  provider: "antigravity" | "agy" = "antigravity"
+): {
   id: string;
   name: string;
 } {
   const clientId = toClientAntigravityModelId(model.id);
   return {
     id: clientId,
-    name: getClientVisibleAntigravityModelName(clientId, model.name),
+    name:
+      provider === "agy"
+        ? getClientVisibleAgyModelName(clientId, model.name)
+        : getClientVisibleAntigravityModelName(clientId, model.name),
   };
 }
 
@@ -82,10 +105,11 @@ export async function fetchAntigravityDiscoveryModelsCached(
   accessToken: string,
   connectionId: string,
   proxy: unknown,
-  providerSpecificData?: unknown
+  providerSpecificData?: unknown,
+  provider: "antigravity" | "agy" = "antigravity"
 ): Promise<Array<{ id: string; name: string }>> {
   const profile = normalizeAntigravityClientProfile(asRecord(providerSpecificData).clientProfile);
-  const cacheKey = `${connectionId}:${accessToken.substring(0, 16)}:${profile}`;
+  const cacheKey = `${provider}:${connectionId}:${accessToken.substring(0, 16)}:${profile}`;
   const inflight = antigravityDiscoveryInflight.get(cacheKey);
   if (inflight) return inflight;
 
@@ -110,20 +134,21 @@ export async function fetchAntigravityDiscoveryModelsCached(
         if (!response.ok) {
           const errorText = await response.text();
           console.warn(
-            `[models] antigravity discovery failed at ${discoveryUrl} (${response.status}): ${errorText}`
+            `[models] ${provider} discovery failed at ${discoveryUrl} (${response.status}): ${errorText}`
           );
           continue;
         }
 
         const models = filterUserCallableAntigravityModels(
-          normalizeAntigravityModelsResponse(await response.json())
-        ).map(mapAntigravityModelForClient);
+          normalizeAntigravityModelsResponse(await response.json()),
+          provider
+        ).map((model) => mapAntigravityModelForClient(model, provider));
         if (models.length > 0) {
           return models;
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`[models] antigravity discovery threw for ${discoveryUrl}: ${message}`);
+        console.warn(`[models] ${provider} discovery threw for ${discoveryUrl}: ${message}`);
       }
     }
 

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -1535,14 +1535,14 @@ export async function GET(
       return buildApiDiscoveryResponse(models);
     }
 
-    if (provider === "antigravity") {
+    if (provider === "antigravity" || provider === "agy") {
       const cachedResponse = maybeReturnCachedDiscovery();
       if (cachedResponse) return cachedResponse;
 
       const autoFetchDisabledResponse = maybeReturnAutoFetchDisabled();
       if (autoFetchDisabledResponse) return autoFetchDisabledResponse;
 
-      const staticModels = getStaticModelsForProvider("antigravity") || [];
+      const staticModels = getStaticModelsForProvider(provider) || [];
 
       if (!accessToken) {
         const fallback = buildDiscoveryFallbackResponse({
@@ -1563,7 +1563,8 @@ export async function GET(
         accessToken,
         connectionId,
         proxy,
-        connection.providerSpecificData
+        connection.providerSpecificData,
+        provider
       );
       if (remoteModels.length > 0) {
         return buildApiDiscoveryResponse(remoteModels);

--- a/tests/unit/agy-provider.test.ts
+++ b/tests/unit/agy-provider.test.ts
@@ -11,6 +11,7 @@ import {
 import { supportsTokenRefresh, REFRESH_LEAD_MS } from "../../open-sse/services/tokenRefresh.ts";
 import {
   AGY_PUBLIC_MODELS,
+  isDiscoverableAgyModelId,
   isUserCallableAgyModelId,
   getClientVisibleAgyModelName,
 } from "../../open-sse/config/agyModels.ts";
@@ -106,6 +107,13 @@ test("agy model helpers resolve catalog ids and display names", () => {
   assert.equal(getClientVisibleAgyModelName("gemini-3.5-flash-low"), "Gemini 3.5 Flash (Medium)");
   assert.equal(getClientVisibleAgyModelName("gemini-3-flash-agent"), "Gemini 3.5 Flash (High)");
   assert.equal(getClientVisibleAgyModelName("unknown-model", "Fallback"), "Fallback");
+});
+
+test("agy live discovery accepts new chat models while excluding tab-completion models", () => {
+  assert.equal(isDiscoverableAgyModelId("gemini-new-live-tier"), true);
+  assert.equal(isDiscoverableAgyModelId("tab_flash_lite_preview"), false);
+  assert.equal(isDiscoverableAgyModelId("tab_jump_flash_lite_preview"), false);
+  assert.equal(isDiscoverableAgyModelId(""), false);
 });
 
 test("agy token refresh is wired on the Google (non-rotating) refresh path", () => {

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -994,6 +994,33 @@ test("provider models route retries Antigravity discovery endpoints before retur
   ]);
 });
 
+test("provider models route discovers newly announced agy models without exposing internal models", async () => {
+  const connection = await seedConnection("agy", { authType: "oauth", accessToken: "agy-access" });
+  antigravityVersion.seedAntigravityIdeVersionCache("1.22.2");
+  antigravityVersion.seedAntigravityCliVersionCache("1.22.2");
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/v1internal:loadCodeAssist")) {
+      return new Response("nope", { status: 503 });
+    }
+    return Response.json({
+      models: {
+        "gemini-new-live-tier": { displayName: "Gemini New Live Tier" },
+        tab_flash_lite_preview: { displayName: "Tab Flash Lite" },
+        "internal-eval-model": { displayName: "Internal Eval", isInternal: true },
+      },
+    });
+  };
+  const response = await callRoute(connection.id);
+  const body = (await response.json()) as {
+    source: string;
+    models: Array<{ id: string; name: string }>;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.source, "api");
+  assert.deepEqual(body.models, [{ id: "gemini-new-live-tier", name: "Gemini New Live Tier" }]);
+});
+
 test("provider models route falls back through all Antigravity discovery endpoints when needed", async () => {
   const connection = await seedConnection("antigravity", {
     authType: "oauth",


### PR DESCRIPTION
## What changed
- reuse the Antigravity live model-discovery flow for AGY connections
- accept newly announced AGY chat models while excluding internal and tab-completion-only entries
- keep the bundled AGY catalog as the offline/bootstrap fallback and isolate in-flight discovery by provider

## Tests
- 
pm run lint
- 
pm run typecheck:core
- 
ode --import tsx/esm --test tests/unit/agy-provider.test.ts tests/unit/provider-models-route.test.ts (68 passed)
- 
pm run check:cycles
- 
pm run check:fetch-targets
- 
pm run check:tracked-artifacts
- 
pm run check:test-discovery
- 
pm run check:file-size

## Notes
- 
pm run test:unit progressed past 11,000 tests but did not complete locally: multiple unrelated test workers reported esbuild The service was stopped, then the run reached the 20-minute command timeout.
- 
pm run check:provider-consistency could not run because the installed Bun executable is incompatible with this Windows host.
- 
pm run check:changelog-integrity is not meaningful from main while the repository default branch is elease/v3.8.49; it reports the release branch's existing aggregated changelog bullets as missing.

Production changes are covered by 	ests/unit/agy-provider.test.ts and 	ests/unit/provider-models-route.test.ts.