### PR TITLE
fix(providers): refresh Baidu ERNIE and Qianfan website URLs (#6271)

### DIFF
--- a/changelog.d/fixes/6271-baidu-qianfan-website-urls.md
+++ b/changelog.d/fixes/6271-baidu-qianfan-website-urls.md
@@ -1,0 +1,1 @@
+- **fix(providers):** refresh Baidu ERNIE + Qianfan provider website URLs to current developer landing pages ([#6271](https://github.com/diegosouzapw/OmniRoute/issues/6271)) — thanks @TrackCrewGalore

--- a/src/shared/constants/providers/apikey/regional.ts
+++ b/src/shared/constants/providers/apikey/regional.ts
@@ -10,7 +10,7 @@ export const APIKEY_PROVIDERS_REGIONAL = {
     icon: "cloud",
     color: "#2468F2",
     textIcon: "BD",
-    website: "https://cloud.baidu.com/product/wenxinworkshop",
+    website: "https://cloud.baidu.com/product-s/qianfan_home",
     apiHint:
       "Use a Qianfan API key from Baidu AI Cloud. The default endpoint is OpenAI-compatible v2.",
   },
@@ -224,7 +224,7 @@ export const APIKEY_PROVIDERS_REGIONAL = {
     icon: "auto_awesome",
     color: "#2932E1",
     textIcon: "BD",
-    website: "https://yiyan.baidu.com",
+    website: "https://ernie.baidu.com/",
     hasFree: true,
     freeNote: "Free ERNIE Speed/Lite models. China's #2 LLM.",
     passthroughModels: true,

--- a/tests/unit/baidu-qianfan-website-urls-6271.test.ts
+++ b/tests/unit/baidu-qianfan-website-urls-6271.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Regression guard for #6271 — Baidu / Qianfan dashboard website links must
+// point at current developer/console entry points, not retired consumer URLs.
+const { APIKEY_PROVIDERS_REGIONAL } = await import(
+  "../../src/shared/constants/providers/apikey/regional.ts"
+);
+
+test("#6271 qianfan website is the current Qianfan product home (not wenxinworkshop)", () => {
+  const entry = (APIKEY_PROVIDERS_REGIONAL as Record<string, { website?: string }>).qianfan;
+  assert.ok(entry, "qianfan regional provider entry must exist");
+  assert.equal(entry.website, "https://cloud.baidu.com/product-s/qianfan_home");
+  assert.doesNotMatch(
+    entry.website ?? "",
+    /wenxinworkshop/,
+    "stale Wenxin Workshop path must not remain",
+  );
+});
+
+test("#6271 baidu (ERNIE) website is ernie.baidu.com (not yiyan consumer nag)", () => {
+  const entry = (APIKEY_PROVIDERS_REGIONAL as Record<string, { website?: string }>).baidu;
+  assert.ok(entry, "baidu regional provider entry must exist");
+  assert.equal(entry.website, "https://ernie.baidu.com/");
+  assert.doesNotMatch(entry.website ?? "", /yiyan\.baidu\.com/, "deprecated yiyan URL must not remain");
+});
+
+test("#6271 baidu authHint still points operators at the BCE console", () => {
+  const entry = (APIKEY_PROVIDERS_REGIONAL as Record<string, { authHint?: string }>).baidu;
+  assert.match(entry.authHint ?? "", /console\.bce\.baidu\.com/);
+});


### PR DESCRIPTION
## Summary

- Update `qianfan` website from retired `wenxinworkshop` path to `https://cloud.baidu.com/product-s/qianfan_home` (current target of Baidu's 301).
- Update `baidu` (ERNIE) website from deprecated `yiyan.baidu.com` consumer nag page to `https://ernie.baidu.com/`.
- Leave `authHint` pointing at `console.bce.baidu.com` (already current).

## Related Issues

- Closes #6271

## Root cause

Dashboard provider cards linked operators to Baidu's deprecated consumer frontend and the pre-rebrand Wenxin Workshop product URL. Both still resolve, but land on a deprecation nag / 301 instead of the current developer entry points.

## Fix

Two-line refresh in `src/shared/constants/providers/apikey/regional.ts`.

Live URL check (2026-07-22):
- `https://ernie.baidu.com/` → 200
- `https://cloud.baidu.com/product-s/qianfan_home` → 200
- `https://cloud.baidu.com/product/wenxinworkshop` → 301 → `product-s/qianfan_home`

## Validation

- [x] Focused regression test: `node --experimental-strip-types --test tests/unit/baidu-qianfan-website-urls-6271.test.ts` → **3/3 pass**
- [ ] `npm run lint` (constants-only change; CI will cover)
- [ ] `npm run test:unit` / coverage (CI)
- [x] Coverage still `>= 60%` expected (no production logic change beyond two URL strings)
- Changelog fragment: `changelog.d/fixes/6271-baidu-qianfan-website-urls.md`

## Tests Added Or Updated

- `tests/unit/baidu-qianfan-website-urls-6271.test.ts` — asserts current websites and rejects stale `yiyan` / `wenxinworkshop` URLs; keeps `authHint` console URL unchanged.

## Coverage Notes

Pure catalog string refresh + unit assertions on `APIKEY_PROVIDERS_REGIONAL`. No handler/executor behavior changed.

## Reviewer Notes

Docs/link-rot only. No runtime routing, auth, or API behavior change.