### PR TITLE
fix: stop Codex/Responses sanitizer turning system image_url into output_text (#8089)

### DIFF
--- a/changelog.d/fixes/8089-responses-system-image.md
+++ b/changelog.d/fixes/8089-responses-system-image.md
@@ -1,0 +1,1 @@
+- fix(sse): stop Codex/Responses sanitizer from turning system/developer image_url parts into invalid output_text (#8089)

--- a/open-sse/services/responsesInputSanitizer.ts
+++ b/open-sse/services/responsesInputSanitizer.ts
@@ -67,7 +67,11 @@ function sanitizeContentPart(part: unknown, role: string): unknown {
 
   if (record.type === "image_url") {
     const url = imageUrlToText(record.image_url);
-    if (role === "user") {
+    // `output_text` is only a legal content-part type on assistant-role OUTPUT
+    // items. Every other role (user, system, developer, ...) is input-side and
+    // must use `input_image` -- otherwise the Codex/Responses backend rejects
+    // the replayed history with "Invalid value: 'output_text'" (#8089).
+    if (role !== "assistant") {
       const next: JsonRecord = { type: "input_image", image_url: url };
       const image = toRecord(record.image_url);
       if (image?.detail !== undefined) next.detail = image.detail;

--- a/tests/unit/codex-system-message-image-8089.test.ts
+++ b/tests/unit/codex-system-message-image-8089.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitizeResponsesInputItems } from "../../open-sse/services/responsesInputSanitizer.ts";
+import { CodexExecutor } from "../../open-sse/executors/codex.ts";
+
+test("[repro #8089] mid-conversation system-role message with image_url must NOT become output_text", () => {
+  const input = [
+    {
+      type: "message",
+      role: "system",
+      content: [
+        { type: "text", text: "Reminder: verify the diff before committing." },
+        { type: "image_url", image_url: { url: "https://example.com/diff-screenshot.png" } },
+      ],
+    },
+  ];
+
+  const sanitized = sanitizeResponsesInputItems(input, true, {}) as Array<{
+    content: Array<{ type: string }>;
+  }>;
+  const imagePart = sanitized[0].content.find(
+    (p) => p.type === "output_text" || p.type === "input_image"
+  );
+
+  assert.ok(imagePart);
+  assert.equal(imagePart?.type, "input_image");
+});
+
+test("[repro #8089] developer-role message with image_url must NOT become output_text", () => {
+  const input = [
+    {
+      type: "message",
+      role: "developer",
+      content: [{ type: "image_url", image_url: { url: "https://example.com/diff-screenshot.png" } }],
+    },
+  ];
+
+  const sanitized = sanitizeResponsesInputItems(input, true, {}) as Array<{
+    content: Array<{ type: string }>;
+  }>;
+
+  assert.equal(sanitized[0].content[0].type, "input_image");
+});
+
+test("assistant-role message with image_url still becomes output_text (unchanged behavior)", () => {
+  const input = [
+    {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "image_url", image_url: { url: "https://example.com/diff-screenshot.png" } }],
+    },
+  ];
+
+  const sanitized = sanitizeResponsesInputItems(input, true, {}) as Array<{
+    content: Array<{ type: string }>;
+  }>;
+
+  assert.equal(sanitized[0].content[0].type, "output_text");
+});
+
+test("Codex native passthrough: mid-conversation system message with image content never serializes output_text (#8089)", () => {
+  const executor = new CodexExecutor();
+  const body = {
+    _nativeCodexPassthrough: true,
+    input: [
+      {
+        type: "message",
+        role: "system",
+        content: [
+          { type: "text", text: "Reminder: verify the diff before committing." },
+          { type: "image_url", image_url: { url: "https://example.com/diff-screenshot.png" } },
+        ],
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "What do you see?" }],
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.6", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(JSON.stringify(result.input).includes('"type":"output_text"'), false);
+});


### PR DESCRIPTION
Closes #8089

## Root cause

`open-sse/services/responsesInputSanitizer.ts::sanitizeContentPart()` only special-cased `role === "user"` for a legacy `{type:"image_url"}` content part, mapping it to a valid `input_image`. Every other role — including `system` and `developer`, not just `assistant` — fell through to `return { type: "output_text", ... }`. `output_text` is only a legal content-part type on assistant-role OUTPUT items; the Responses/Codex backend rejects it on any input-side item (user/system/developer) with:

> Invalid value: 'output_text'. Supported values are: 'input_text', 'input_image', 'input_file', and 'scoped_content'.

`open-sse/executors/codex.ts` calls `sanitizeResponsesInputItems()` (native Codex passthrough) while a mid-conversation system message still carries `role === "system"` — `convertSystemToDeveloperRole()` only promotes system→developer *after* sanitization — so any `image_url` part on a system/developer-role message content array was sanitized into an invalid `output_text` before the role was even promoted.

This is the same defect class already fixed once for a different code path (#7698 / PR #7269 fixed the nested `output` array used by `function_call_output` / `custom_tool_call_output` items). That fix did not touch `sanitizeContentPart`'s top-level `message.content` branch, which still had the asymmetric role check — the live gap #8089 hit.

## Fix

Changed the `image_url` branch's condition from `role === "user"` to `role !== "assistant"` — only `assistant` (the sole role for which `output_text` is a legal content-part type) takes the `output_text` path; `user`/`system`/`developer` all take the `input_image` path. The sibling `role === "assistant" && record.type === "input_image"` branch is unchanged.

## Regression test (TDD, Hard Rule #18)

New file `tests/unit/codex-system-message-image-8089.test.ts`:
- `sanitizeResponsesInputItems()` on a `role: "system"` message with an `image_url` part → RED before fix (`output_text`), GREEN after (`input_image`).
- Same for `role: "developer"`.
- `role: "assistant"` still converts to `output_text` (unchanged behavior, guards against over-fixing).
- Executor-level test through `CodexExecutor.transformRequest()` with a native-passthrough body containing a mid-conversation system-role message with an image part — asserts the serialized `input` never contains `"type":"output_text"`.

All 4 assertions confirmed RED on the unfixed code, GREEN after the one-line fix.

## Gates run (green)

- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/responsesInputSanitizer.ts tests/unit/codex-system-message-image-8089.test.ts` — clean
- `node scripts/check/check-file-size.mjs` — no new ✗ from this diff (pre-existing `src/lib/usage/providerLimits.ts` ✗ is base-red drift, confirmed unrelated)
- `node scripts/check/check-complexity.mjs` + `node scripts/check/check-cognitive-complexity.mjs` — pre-existing complexity regression (2149 > baseline 2130) confirmed present with this fix reverted too (base-red, not caused by this change); cognitive-complexity OK
- Sibling tests of the touched area: `responses-input-sanitizer-name.test.ts`, `codex-custom-tool-image-output-7698.test.ts`, `responses-translation-fixes.test.ts` + the new regression file — 61/61 pass