### PR TITLE
fix(db): stop closing sql.js singleton in getDbInstance() probe/reopen (#7494)

### DIFF
--- a/changelog.d/fixes/7494-sqljs-close-poison.md
+++ b/changelog.d/fixes/7494-sqljs-close-poison.md
@@ -1,0 +1,1 @@
+- fix(db): stop closing the single sql.js singleton during getDbInstance()'s probe/reopen sequence, which poisoned every boot with "Database closed" once both sync SQLite drivers were unavailable (#7494)

--- a/src/lib/db/adapters/sqljsAdapter.ts
+++ b/src/lib/db/adapters/sqljsAdapter.ts
@@ -219,6 +219,16 @@ export async function createSqlJsAdapter(filePath: string): Promise<SqliteAdapte
   }, CHECKPOINT_INTERVAL_MS);
   (checkpointTimer as unknown as NodeJS.Timeout).unref?.();
 
+  const flush = (): void => {
+    if (dirty)
+      try {
+        persist();
+      } catch {}
+  };
+  process.on("beforeExit", flush);
+  process.on("SIGINT", flush);
+  process.on("SIGTERM", flush);
+
   function gracefulClose(): void {
     clearInterval(checkpointTimer as unknown as NodeJS.Timeout);
     if (saveTimer) clearTimeout(saveTimer);
@@ -230,17 +240,13 @@ export async function createSqlJsAdapter(filePath: string): Promise<SqliteAdapte
       db.close();
     } catch {}
     _isOpen = false;
+    // Without this, a closed adapter's whole closure (raw sql.js Database +
+    // buffers) stays pinned in memory forever by these 3 process-level
+    // listeners, compounding the OOM every failed boot leaves behind (#7494).
+    process.removeListener("beforeExit", flush);
+    process.removeListener("SIGINT", flush);
+    process.removeListener("SIGTERM", flush);
   }
-
-  const flush = (): void => {
-    if (dirty)
-      try {
-        persist();
-      } catch {}
-  };
-  process.on("beforeExit", flush);
-  process.on("SIGINT", flush);
-  process.on("SIGTERM", flush);
 
   return {
     driver: "sql.js",

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -158,6 +158,23 @@ function getErrorCode(error: unknown): string | undefined {
   return typeof code === "string" ? code : undefined;
 }
 
+/**
+ * Closes a probe/throwaway connection obtained from `openSqliteDatabase()` —
+ * but ONLY when it is safe to do so. better-sqlite3/node:sqlite hand back an
+ * independent handle per open() call, so closing a probe never affects a
+ * later "real" connection to the same file. sql.js has no such notion: its
+ * fallback path (`getSqlJsAdapter()`) always returns the SAME module-global
+ * cached singleton for a given filePath, so closing "the probe" closes the
+ * ONLY connection that file will ever get until process restart — every
+ * subsequent query (including the "real" connection opened right after)
+ * throws sql.js's raw "Database closed" string (#7494). Skip the close for
+ * sql.js and let the same live adapter flow through untouched.
+ */
+export function closeProbeIfSafe(adapter: SqliteDatabase | null | undefined): void {
+  if (!adapter || adapter.driver === "sql.js") return;
+  if (adapter.open) adapter.close();
+}
+
 function openSqliteDatabase(sqliteFile: string, options?: Record<string, unknown>): SqliteDatabase {
   const adapter = tryOpenSync(sqliteFile, options);
   if (adapter) return adapter;
@@ -604,7 +621,7 @@ function captureCriticalDbState(sqliteFile: string): PreservedCriticalDbState {
     return snapshot;
   } finally {
     try {
-      probe?.close();
+      closeProbeIfSafe(probe);
     } catch {
       /* ignore */
     }
@@ -1047,7 +1064,7 @@ export function getDbInstance(): SqliteDatabase {
         } catch {
           // Table might not exist at all — truly incompatible
         }
-        probe.close();
+        closeProbeIfSafe(probe);
 
         if (hasData) {
           console.log(
@@ -1061,7 +1078,7 @@ export function getDbInstance(): SqliteDatabase {
             const message = e instanceof Error ? e.message : String(e);
             console.warn("[DB] Could not clean up old schema table:", message);
           } finally {
-            fixDb.close();
+            closeProbeIfSafe(fixDb);
           }
         } else {
           const oldPath = sqliteFile + ".old-schema";
@@ -1078,7 +1095,7 @@ export function getDbInstance(): SqliteDatabase {
           }
         }
       } else {
-        probe.close();
+        closeProbeIfSafe(probe);
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
@@ -1224,7 +1241,7 @@ export function getDbInstance(): SqliteDatabase {
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       try {
-        if (db.open) db.close();
+        closeProbeIfSafe(db);
       } catch {
         /* ignore */
       }

--- a/tests/unit/db-sqljs-close-poison-7494.test.ts
+++ b/tests/unit/db-sqljs-close-poison-7494.test.ts
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Regression guard for #7494 — getDbInstance()'s probe-then-reopen pattern
+// (src/lib/db/core.ts) closes a throwaway "probe" connection and then opens
+// a "real" one right after via openSqliteDatabase(). That pattern is safe
+// for per-open-handle drivers (better-sqlite3, node:sqlite) but NOT for
+// sql.js: openSqliteDatabase()'s sql.js fallback (getSqlJsAdapter()) always
+// returns the SAME module-global cached singleton for a given filePath, so
+// closing "the probe" closes the ONLY connection that file will ever get —
+// every subsequent query (including the "real" connection) throws sql.js's
+// raw "Database closed" string, matching the reported crash-loop verbatim.
+
+test(
+  "raw sql.js singleton mechanism: closing the adapter returned by " +
+    "getSqlJsAdapter() poisons every later query against the SAME singleton " +
+    "(documents WHY the probe/close pattern is unsafe for sql.js — #7494)",
+  async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7494-mech-"));
+    const sqliteFile = path.join(dataDir, "storage.sqlite");
+    try {
+      const { preInitSqlJs, getSqlJsAdapter } = await import(
+        "../../src/lib/db/adapters/driverFactory"
+      );
+
+      const boot = await preInitSqlJs(sqliteFile);
+      boot.exec("CREATE TABLE t (id INTEGER)");
+      boot.exec("INSERT INTO t (id) VALUES (1)");
+
+      const probe = getSqlJsAdapter(sqliteFile);
+      probe!
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+        )
+        .get();
+      probe!.close();
+
+      // Same module-global singleton — a raw .close() poisons it for good.
+      const real = getSqlJsAdapter(sqliteFile);
+      assert.throws(
+        () => real!.pragma("journal_mode = WAL"),
+        /Database closed/,
+        "sanity: confirms the underlying sql.js singleton mechanism this bug exploits"
+      );
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  "closeProbeIfSafe() (src/lib/db/core.ts) must NOT close a sql.js-backed " +
+    "adapter — it is the module-global singleton getDbInstance()'s probe/reopen " +
+    "pattern relies on staying alive across the probe step (#7494)",
+  async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7494-guard-"));
+    const sqliteFile = path.join(dataDir, "storage.sqlite");
+    try {
+      const { preInitSqlJs, getSqlJsAdapter } = await import(
+        "../../src/lib/db/adapters/driverFactory"
+      );
+      const { closeProbeIfSafe } = await import("../../src/lib/db/core");
+
+      const boot = await preInitSqlJs(sqliteFile);
+      boot.exec("CREATE TABLE t (id INTEGER)");
+      boot.exec("INSERT INTO t (id) VALUES (1)");
+
+      // Simulate getDbInstance()'s probe step: inspect schema, then "close" via
+      // the guarded helper instead of a raw .close() call.
+      const probe = getSqlJsAdapter(sqliteFile);
+      probe!
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+        )
+        .get();
+      closeProbeIfSafe(probe);
+
+      assert.equal(probe!.open, true, "closeProbeIfSafe() must not close a sql.js adapter");
+
+      // Simulate the 'real' connection getDbInstance() opens right after — the
+      // SAME singleton — and must still be fully usable.
+      const real = getSqlJsAdapter(sqliteFile);
+      assert.doesNotThrow(
+        () => real!.pragma("journal_mode = WAL"),
+        "getSqlJsAdapter() must not hand back a closed/dead adapter after " +
+          "closeProbeIfSafe() (#7494)"
+      );
+
+      // Drain the sql.js adapter's debounced persist timer (SAVE_DEBOUNCE_MS)
+      // before removing the temp dir, so it doesn't fire against an
+      // already-deleted path in the background.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  "closeProbeIfSafe() still closes per-handle drivers (better-sqlite3) — the " +
+    "guard is sql.js-specific, not a blanket no-op",
+  async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7494-real-"));
+    const sqliteFile = path.join(dataDir, "storage.sqlite");
+    try {
+      const { tryOpenSync } = await import("../../src/lib/db/adapters/driverFactory");
+      const { closeProbeIfSafe } = await import("../../src/lib/db/core");
+
+      const probe = tryOpenSync(sqliteFile);
+      assert.ok(probe, "sanity: better-sqlite3/node:sqlite must be available in this test env");
+      assert.equal(probe!.driver === "sql.js", false);
+
+      closeProbeIfSafe(probe);
+
+      assert.equal(probe!.open, false, "closeProbeIfSafe() must still close non-sql.js adapters");
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  }
+);


### PR DESCRIPTION
Closes #7494

## Root cause

`getDbInstance()`'s probe-then-reopen pattern (`src/lib/db/core.ts`) opens a throwaway "probe" connection, inspects the schema, closes it, and then opens a "real" connection to the same file right after. That pattern is safe for per-open-handle drivers (better-sqlite3, node:sqlite) but not for sql.js: `openSqliteDatabase()`'s sql.js fallback (`getSqlJsAdapter()`) always returns the SAME module-global cached singleton for a given file path — there is no notion of "an independent handle to the same file" the way the sync drivers have.

So whenever both sync drivers are unavailable (ABI mismatch on Node 24/26, bad rebuild — the exact scenario the reporters hit) and the DB file already exists, `getDbInstance()` closes the ONE sql.js singleton for that file during the probe step, then reopens "the real connection" — which for sql.js is the SAME now-closed adapter. The very first `.pragma()`/query call throws sql.js's raw `Database closed` string, matching the reported crash-loop verbatim ("first boot works, every boot after that fails" — first boot has no existing file so the probe block is skipped entirely).

The reported OOM is a downstream consequence: every failed boot leaves `getDb()` null, so every independent background scheduler re-enters `preInitSqlJs()` on its own polling interval, and each closed adapter's whole closure (including its WASM buffers) was pinned forever by 3 unremoved `process.on(...)` listeners in `sqljsAdapter.ts`.

Two owner comments already shipped the ORDERING half of this issue as #7288/PR#7562 (`registerNodejs()` now awaits `ensureDbReadyForBoot()` before other startup steps). This PR fixes the two residual sub-findings the owner explicitly left #7494 open for.

## Fix

- `src/lib/db/core.ts`: adds `closeProbeIfSafe(adapter)` — closes real per-handle drivers as before, but skips the close entirely for sql.js-backed adapters (`adapter.driver === "sql.js"`) so the same live singleton flows through to the "real" connection. Applied at every probe-close site inside `getDbInstance()` / `captureCriticalDbState()`.
- `src/lib/db/adapters/sqljsAdapter.ts`: `gracefulClose()` now removes the `beforeExit`/`SIGINT`/`SIGTERM` listeners it registered, so a closed adapter's closure (raw sql.js `Database` + buffers) can actually be garbage collected instead of being pinned forever — addresses the compounding-OOM sub-finding as a consequence of the same defect.

## Regression test (TDD, Hard Rule #18)

`tests/unit/db-sqljs-close-poison-7494.test.ts` — 3 cases:
1. Documents the underlying sql.js singleton mechanism (raw `.close()` on the cached singleton poisons every later query — reproduces the exact `Database closed` string from the reports).
2. **The regression guard**: `closeProbeIfSafe()` must NOT close a sql.js-backed adapter, so the singleton stays usable across the probe/reopen sequence — confirmed **RED** on unfixed code (`closeProbeIfSafe is not a function` — pre-fix `core.ts` doesn't export it, and reverting the fix while keeping a call to the real `.close()` reproduces the poisoned-singleton failure), **GREEN** after the fix.
3. `closeProbeIfSafe()` still closes real per-handle drivers (better-sqlite3) — confirms the guard is sql.js-specific, not a blanket no-op.

RED→GREEN verified by temporarily restoring the pre-fix `src/lib/db/core.ts`/`sqljsAdapter.ts` content (via `git show HEAD:<path>`, never `git stash`) and re-running the test file, then restoring the fix.

## Gates run (all green, from inside the worktree)

- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 errors
- `node scripts/check/check-file-size.mjs` — only pre-existing `src/lib/usage/providerLimits.ts` violation (base-red drift, not touched by this PR)
- `node scripts/check/check-complexity.mjs` — pre-existing 2149-violation regression reproduces identically with and without this diff (base-red, confirmed by swapping the fixed/unfixed file content)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (943 ≤ baseline 950)
- Touched-area regression suite: `tests/unit/db-sqljs-close-poison-7494.test.ts`, `tests/unit/db-adapters/sqljsAdapter.test.ts`, `tests/unit/db-adapters/driverFactory.test.ts`, `tests/unit/instrumentation-node-boot-db-failure.test.ts`, `tests/unit/db-sqljs-preinit-ordering-gap-7288.test.ts` — 29/29 pass