### PR TITLE
fix(cli): merge node bin dir into CLI healthcheck PATH for codex detection (#8036)

### DIFF
--- a/changelog.d/fixes/8036-codex-cli-detect.md
+++ b/changelog.d/fixes/8036-codex-cli-detect.md
@@ -1,0 +1,1 @@
+- fix(cli): merge Node's own bin dir into the CLI healthcheck spawn PATH so npm-shebang tools like codex resolve under a minimal launcher PATH (#8036)

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -8,6 +8,7 @@ import { getCachedLoginShellPath, mergeShellPath } from "./loginShellPath";
 import { withSettingsFallback } from "./cliInstallFallback";
 import { GROK_BUILD_RUNTIME_ENTRY, AMP_RUNTIME_ENTRY } from "./cliRuntimeGrokBuild";
 import { isLocationTrusted, findKnownPathMatch } from "./cliRuntimeKnownPath";
+import { buildHealthcheckPath } from "./cliRuntimeHealthcheckPath";
 const VALID_RUNTIME_MODES = new Set(["auto", "host", "container"]);
 const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
 
@@ -907,7 +908,9 @@ const checkRunnable = async (
 ) => {
   // Minimal environment to prevent credential leakage to potentially malicious binaries
   const minimalEnv: Record<string, string | undefined> = {
-    PATH: env.PATH || env.Path,
+    // #8036: merge in this Node's own bin dir so `#!/usr/bin/env node` npm CLIs
+    // (e.g. codex) can resolve their interpreter under a minimal launcher PATH.
+    PATH: buildHealthcheckPath(env.PATH || env.Path || "", path.dirname(process.execPath)),
     HOME: env.HOME || env.USERPROFILE,
     USERPROFILE: env.USERPROFILE, // Windows needs this for os.homedir()
     APPDATA: env.APPDATA, // Many npm CLI tools rely on APPDATA

--- a/src/shared/services/cliRuntimeHealthcheckPath.ts
+++ b/src/shared/services/cliRuntimeHealthcheckPath.ts
@@ -1,0 +1,18 @@
+import path from "path";
+
+/**
+ * #8036: npm-installed CLIs (e.g. codex) are `#!/usr/bin/env node` shebang
+ * scripts — running them needs `node` resolvable on the child's PATH. A
+ * minimal launcher PATH (systemd/docker/PM2/Electron) may omit this Node's
+ * own bin dir even though the binary was correctly LOCATED via the
+ * PATH-independent known-path search (cliRuntime.ts's getKnownToolPaths()
+ * already merges it in for locating). Merge it into the healthcheck spawn's
+ * PATH too so the shebang can always resolve its interpreter.
+ */
+export const buildHealthcheckPath = (callerPath: string, nodeBinDir: string): string => {
+  const entries = callerPath.split(path.delimiter);
+  if (entries.includes(nodeBinDir)) {
+    return callerPath;
+  }
+  return [callerPath, nodeBinDir].filter(Boolean).join(path.delimiter);
+};

--- a/tests/unit/cliRuntime-codex-shebang-8036.test.ts
+++ b/tests/unit/cliRuntime-codex-shebang-8036.test.ts
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// #8036: npm-installed CLIs (e.g. codex) are `#!/usr/bin/env node` shebang
+// scripts. checkRunnable() in cliRuntime.ts builds a minimal spawn env whose
+// PATH comes ONLY from the caller's PATH (getLookupEnv()), never merging in
+// the running Node's own bin dir (path.dirname(process.execPath)) the way
+// locateCommand's known-path search already does at :641. When the server is
+// launched by a minimal-PATH launcher (systemd/docker/PM2) that lacks node's
+// directory, `env node` inside the shebang can't resolve → healthcheck spawn
+// fails → the CLI is (falsely) reported as not runnable even though it is
+// correctly located.
+//
+// cliRuntime.ts computes EXPECTED_PARENT_PATHS from os.homedir() at MODULE
+// LOAD time, so HOME must be redirected before the module is imported.
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-8036-home-"));
+process.env.HOME = sandboxHome;
+process.env.USERPROFILE = sandboxHome;
+process.env.npm_config_prefix = path.join(sandboxHome, "npm-prefix-unused");
+delete process.env.CLI_CODEX_BIN;
+delete process.env.CLI_EXTRA_PATHS;
+
+// Place the fake `codex` npm-shebang script at a KNOWN install location
+// (home/.local/bin, within EXPECTED_PARENT_PATHS) so it's located via the
+// PATH-independent known-path search — exactly like a real npm global
+// install would be found — isolating the test from PATH-dependent `sh`/
+// `command -v` resolution and from this test-runner box's own PATH.
+const localBinDir = path.join(sandboxHome, ".local", "bin");
+fs.mkdirSync(localBinDir, { recursive: true });
+const codexScriptPath = path.join(localBinDir, "codex");
+fs.writeFileSync(
+  codexScriptPath,
+  ["#!/usr/bin/env node", 'console.log("codex-cli 0.145.0-test");', ""].join("\n")
+);
+fs.chmodSync(codexScriptPath, 0o755);
+
+const nodeBinDir = path.dirname(process.execPath);
+
+const { getCliRuntimeStatus } = await import("../../src/shared/services/cliRuntime.ts");
+
+test("#8036: codex is reported runnable even when the launcher PATH omits node's own bin dir", async () => {
+  const originalPath = process.env.PATH;
+  // Bogus PATH: no `sh`/`env`/system dirs, and — crucially — no node's own
+  // bin dir. The known-path match above never needs PATH to LOCATE codex;
+  // this isolates whether checkRunnable()'s healthcheck spawn can still
+  // RUN it (the `#!/usr/bin/env node` shebang needs `node` resolvable via
+  // the child's PATH).
+  process.env.PATH = path.join(sandboxHome, "nonexistent-launcher-path");
+  try {
+    const status = await getCliRuntimeStatus("codex");
+    assert.equal(
+      status.installed,
+      true,
+      `expected installed=true but got installed=${status.installed} reason=${status.reason}`
+    );
+    assert.equal(
+      status.runnable,
+      true,
+      `expected runnable=true but got runnable=${status.runnable} reason=${status.reason} ` +
+        `(launcher PATH lacked node's bin dir ${nodeBinDir} — checkRunnable() must merge it in)`
+    );
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
+test.after(async () => {
+  await fsp.rm(sandboxHome, { recursive: true, force: true });
+});


### PR DESCRIPTION
Closes #8036

## Root cause
`src/shared/services/cliRuntime.ts::checkRunnable()` (~909) built the healthcheck spawn's `minimalEnv.PATH` from the caller's PATH only (`env.PATH || env.Path`), never merging in this Node's own bin dir (`path.dirname(process.execPath)`) — even though `getKnownToolPaths()`'s known-path search already does this for *locating* the binary (:641). npm-installed CLIs like `codex` are `#!/usr/bin/env node` shebang scripts, so when the server is launched by a minimal-PATH launcher (systemd/docker/PM2/Electron) that lacks node's own bin dir, the CLI is correctly LOCATED via the known-path fallback but the healthcheck spawn still fails (`env node` can't resolve the interpreter) → `reason: "healthcheck_failed"` → the tool shows as undetected in the UI, even though `which codex` works fine in the user's shell.

## Fix
Extracted a `buildHealthcheckPath()` helper (new file `src/shared/services/cliRuntimeHealthcheckPath.ts`, to keep `cliRuntime.ts` within its frozen file-size ceiling) that merges `path.dirname(process.execPath)` into the healthcheck spawn's PATH when it isn't already present — mirroring the same idiom already used for known-path location. Scoped strictly to `checkRunnable()`; no changes to the PATH-independent known-path location logic itself.

## Regression test (Hard Rule #18 — TDD)
New `tests/unit/cliRuntime-codex-shebang-8036.test.ts`:
- Installs a real npm-shebang-style `codex` script (`#!/usr/bin/env node`) at a known install location (`$HOME/.local/bin/codex`), located via the PATH-independent known-path search.
- Strips `process.env.PATH` to a nonexistent bogus directory (no system dirs, no node's own bin dir) — simulating a minimal systemd/docker/PM2 launcher PATH.
- **RED on unfixed code**: `installed:true, runnable:false, reason:"healthcheck_failed"`.
- **GREEN after the fix**: `installed:true, runnable:true`.

## Gates run (all green)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-file-size.mjs` — no new violations from this diff (pre-existing `src/lib/usage/providerLimits.ts` drift is unrelated/untouched)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (943 ≤ baseline 950)
- `node scripts/check/check-complexity.mjs` — pre-existing REGRESSÃO (2149 > baseline 2130) confirmed identical when run against the unmodified base commit (verified by temporarily restoring `HEAD:cliRuntime.ts` and re-running) — base-red, not introduced by this change
- Sibling cliRuntime tests (`cliRuntime-symlink-escape-7753`, `cli-runtime-detection`, `cli-runtime-extended`, `cli-runtime-known-path-shortcircuit-7774`, `cli-tools*`, `qodercli-windows-resolve-6263`, `repro-6701-claude-detect-fallback`, `t40-opencode-cli-tools-integration`, `tool-detector-win32-7279`) — all pass