### PR TITLE
fix(cli): surface real spawn error in process supervisor (#8091)

### DIFF
--- a/bin/cli/runtime/processSupervisor.mjs
+++ b/bin/cli/runtime/processSupervisor.mjs
@@ -72,11 +72,31 @@ export class ServerSupervisor {
     return this.child;
   }
 
-  handleExit(code) {
+  handleExit(code, err) {
     // Node.js v24+ requires process.exit() to receive a number. Spawn-error events
     // deliver err.code (a string like 'ENOENT') via the 'error' listener; normalise here.
     const exitCode = typeof code === "number" ? code : null;
     cleanupPidFile("server");
+
+    // #8091: the child's spawn 'error' listener passes `err` through as a second
+    // argument, but it used to be silently dropped — the user only ever saw the
+    // hardcoded "code=-1" with a permanently empty crash log, with no way to
+    // diagnose why the child never started (ENOENT/EACCES/bad path/etc.). Surface
+    // the real reason immediately, both on the console and in the crash-log buffer
+    // so `dumpCrashLog()` shows it too.
+    if (err) {
+      const detail = [
+        err.code && `code=${err.code}`,
+        err.syscall && `syscall=${err.syscall}`,
+        err.path && `path=${err.path}`,
+        err.message,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      const line = `⚠ Spawn error: ${detail || String(err)}`;
+      console.error(line);
+      this.crashLog.push(line);
+    }
 
     // #4425: only exit on an intentional shutdown. A spontaneous code-0 exit (e.g. a
     // systemd MemoryMax cgroup kill, which reports the process exited cleanly) is anomalous

--- a/changelog.d/fixes/8091-supervisor-spawn-err.md
+++ b/changelog.d/fixes/8091-supervisor-spawn-err.md
@@ -1,0 +1,1 @@
+- fix(cli): surface the real spawn error (err.code/path/syscall/message) in the process supervisor instead of silently swallowing it on a child spawn failure (#8091)

--- a/tests/unit/cli-process-supervisor-spawn-error-8091.test.ts
+++ b/tests/unit/cli-process-supervisor-spawn-error-8091.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #8091: when the child process itself fails to spawn (ENOENT/EACCES/etc.), the
+// 'error' listener passes `err` into handleExit(-1, err) but handleExit only ever
+// declared a single `code` parameter — the real reason (err.code/err.path/err.message)
+// was silently dropped. The user only ever saw "Server exited (code=-1)" plus a
+// permanently empty crash log, with no way to diagnose the underlying spawn failure.
+//
+// This test spawns a server that does not exist on disk, which forces a deterministic,
+// cross-platform ENOENT 'error' event (no Windows/Bun needed to reproduce the bug class),
+// and asserts the real error surfaces both via console.error and via crashLog/dumpCrashLog().
+
+process.env.PORT = "0";
+
+test("ServerSupervisor surfaces the real spawn error (ENOENT) instead of swallowing it (#8091)", async () => {
+  const { ServerSupervisor } = await import("../../bin/cli/runtime/processSupervisor.mjs");
+
+  const logs: string[] = [];
+  const origErr = console.error.bind(console);
+  console.error = (...args: unknown[]) => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+
+  const origExit = process.exit.bind(process);
+  // @ts-ignore
+  process.exit = () => {};
+
+  const supervisor = new ServerSupervisor({
+    serverPath: "/definitely/does/not/exist/server.js",
+    env: {},
+    maxRestarts: 0,
+  });
+
+  // Real spawn+'error' path the supervisor uses in production; ENOENT fires async.
+  supervisor.start();
+
+  await new Promise<void>((resolve) => {
+    const check = setInterval(() => {
+      if (logs.length || supervisor.crashLog.length) {
+        clearInterval(check);
+        resolve();
+      }
+    }, 10);
+    setTimeout(() => {
+      clearInterval(check);
+      resolve();
+    }, 2000);
+  });
+
+  // @ts-ignore
+  process.exit = origExit;
+  console.error = origErr;
+
+  const printed = logs.join("\n");
+  const inCrashLog = supervisor.crashLog.join("\n");
+
+  assert.ok(
+    printed.includes("ENOENT") || inCrashLog.includes("ENOENT"),
+    `expected the real spawn error (ENOENT) to be surfaced via console.error or crashLog, got:\nconsole.error: ${printed}\ncrashLog: ${inCrashLog}`
+  );
+});
+
+test("ServerSupervisor.handleExit(code, err) logs err.code/err.path/err.message and pushes into crashLog", async () => {
+  const { ServerSupervisor } = await import("../../bin/cli/runtime/processSupervisor.mjs");
+
+  const logs: string[] = [];
+  const origErr = console.error.bind(console);
+  console.error = (...args: unknown[]) => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+
+  const supervisor = new ServerSupervisor({
+    serverPath: "/fake/server.js",
+    env: {},
+    maxRestarts: 5,
+  });
+  // @ts-ignore — stub start() so the scheduled restart never spawns a real process
+  supervisor.start = () => null;
+  supervisor.startedAt = Date.now() - 100;
+
+  const fakeErr = Object.assign(new Error("spawn /fake/server.js ENOENT"), {
+    code: "ENOENT",
+    path: "/fake/server.js",
+    syscall: "spawn",
+  });
+  supervisor.handleExit(-1, fakeErr);
+
+  console.error = origErr;
+
+  const printed = logs.join("\n");
+  assert.ok(printed.includes("ENOENT"), `expected err.code (ENOENT) to be printed, got: ${printed}`);
+  assert.ok(
+    printed.includes("/fake/server.js"),
+    `expected err.path to be printed, got: ${printed}`
+  );
+  assert.ok(
+    supervisor.crashLog.some((l: string) => l.includes("ENOENT")),
+    `expected the error to be pushed into crashLog, got: ${JSON.stringify(supervisor.crashLog)}`
+  );
+
+  await new Promise((r) => setTimeout(r, 1100)); // drain the scheduled restart timer
+});


### PR DESCRIPTION
Refs #8091

## Root cause

In `bin/cli/runtime/processSupervisor.mjs`, the child process's `error` listener already
passed the spawn error through: `this.child.on("error", (err) => this.handleExit(-1, err));`
— but `handleExit(code)` only ever declared a single `code` parameter, so `err` was
silently discarded. On any spawn-level failure (ENOENT/EACCES/bad path/etc, e.g. the
Windows+Bun-canary case reported in #8091), the user only ever saw the hardcoded
`Server exited (code=-1)` with a permanently empty crash log
(`--- Server crash log ---\n--- End crash log ---`), because the crash-log buffer is
only fed by `child.stdout`/`child.stderr` data events, which never fire for a process
that never started. Even `--log`/`OMNIROUTE_SHOW_LOG=1` can't help here since inherited
stdio only forwards output from a process that actually started.

## Fix (diagnosability only — PARTIAL fix, see below)

`handleExit(code, err)` now accepts the second parameter and, when `err` is present:
- formats `err.code` / `err.syscall` / `err.path` / `err.message` into a diagnostic line
- prints it immediately via `console.error` (visible even before `maxRestarts` is exhausted)
- pushes it into `this.crashLog` so `dumpCrashLog()` surfaces it too

**This does NOT resolve the reporter's underlying Windows+Bun-canary spawn failure** —
it makes that failure diagnosable, which is the prerequisite for ever root-causing it.
The existing needs-info request on #8091 (Node-only test, full `--log`/`APP_LOG_LEVEL=debug`
output, retry on stable Bun 1.3.x) stays open and unchanged. This PR uses `Refs #8091`,
not `Closes`, so the issue stays open.

## Regression test

New file `tests/unit/cli-process-supervisor-spawn-error-8091.test.ts`, 2 tests:
1. Spawns `ServerSupervisor` with a nonexistent `serverPath` (forces a deterministic,
   cross-platform ENOENT `error` event) and asserts the real error surfaces via
   `console.error` and/or `crashLog`.
2. Calls `handleExit(-1, fakeErr)` directly and asserts `err.code`/`err.path` are printed
   and pushed into `crashLog`.

Both tests are RED on the unfixed code (confirmed) and GREEN after the fix:
```
✔ ServerSupervisor surfaces the real spawn error (ENOENT) instead of swallowing it (#8091)
✔ ServerSupervisor.handleExit(code, err) logs err.code/err.path/err.message and pushes into crashLog
```

All 8 pre-existing tests in `tests/unit/cli-process-supervisor.test.ts` and the 2 in
`tests/unit/cli-serve-readiness-timeout-6321.test.ts` still pass unchanged.

## Gates run (all green)

- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 errors
- `node scripts/check/check-file-size.mjs` — no new violation (pre-existing `src/lib/usage/providerLimits.ts` drift is unrelated/out of scope)
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — verified against a fresh probe worktree on the same base tip: the 2149-vs-2130 regression is pre-existing base drift (identical count with or without this diff), not introduced by this fix; cognitive complexity is within baseline (943 ≤ 950)
- `node --import tsx/esm --test tests/unit/cli-process-supervisor-spawn-error-8091.test.ts tests/unit/cli-process-supervisor.test.ts tests/unit/cli-serve-readiness-timeout-6321.test.ts tests/unit/mitm-hosts-cleanup-on-exit.test.ts` — all pass