### PR TITLE
fix(resilience): classify Google RESOURCE_EXHAUSTED 429 as quota_exhausted (#8060)

### DIFF
--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -61,6 +61,13 @@ const QUOTA_PATTERNS: ReadonlyArray<RegExp> = [
   // the 429 is misclassified as transient rate_limit and retried every
   // ~60s against a budget that only resets at UTC midnight.
   /daily free allocation/i,
+
+  // Google RPC RESOURCE_EXHAUSTED ("Resource has been exhausted (e.g. check
+  // quota). (reset after 24h)") — canonical Google quota error, emitted by
+  // Cloud Code / Antigravity and other Google APIs. Distinct from transient
+  // per-minute rate limits, which phrase it as "Rate limit exceeded ... retry
+  // in Xs", so anchoring on "has been exhausted" keeps it specific (#8060).
+  /resource has been exhausted/i,
 ];
 
 /**

--- a/tests/unit/classify429.test.ts
+++ b/tests/unit/classify429.test.ts
@@ -44,6 +44,16 @@ test("classify429: Antigravity 'Individual quota reached' body returns 'quota_ex
   assert.equal(classify429({ status: 429, body: { error: { message: body } } }), "quota_exhausted");
 });
 
+test("classify429: Google RPC RESOURCE_EXHAUSTED body returns 'quota_exhausted' (#8060)", () => {
+  // Canonical Google quota error without the Antigravity-specific
+  // INSUFFICIENT_G1_CREDITS_BALANCE marker — previously fell through to
+  // rate_limit because no pattern matched "has been exhausted".
+  const body = "Resource has been exhausted (e.g. check quota). (reset after 24h)";
+  assert.equal(looksLikeQuotaExhausted(body), true);
+  assert.equal(classify429({ status: 429, body }), "quota_exhausted");
+  assert.equal(classify429({ status: 429, body: { error: { message: body } } }), "quota_exhausted");
+});
+
 test("classify429: Antigravity INSUFFICIENT_G1_CREDITS_BALANCE body returns 'quota_exhausted'", () => {
   const body = {
     error: {


### PR DESCRIPTION
## Summary

Fixes #8060. Google RPC-style 429 bodies (`Resource has been exhausted (e.g. check quota). (reset after 24h)`) were not matched by any `QUOTA_PATTERNS` entry in `classify429.ts`, so a long-period quota exhaustion was classified as `rate_limit`. The model lockout then applied only a short Retry-After backoff instead of locking the model until the billing-period reset, causing every subsequent combo request to retry the dead model again (~25s wasted per request).

## Changes

- **`src/shared/utils/classify429.ts`**: Add `/resource has been exhausted/i` to `QUOTA_PATTERNS` — anchored on "has been exhausted" to stay specific (transient per-minute rate limits phrase it as "Rate limit exceeded ... retry in Xs")
- **`tests/unit/classify429.test.ts`**: Unit test covering string body, object body, and `classify429` integration

## Verification

- `classify429.test.ts` — 18/18 pass

2 files changed, +17