### PR TITLE
feat: native Fish Audio TTS provider on /v1/audio/speech (#8099)

### DIFF
--- a/changelog.d/features/8099-fishaudio-tts-provider.md
+++ b/changelog.d/features/8099-fishaudio-tts-provider.md
@@ -1,0 +1,1 @@
+- feat(providers): native Fish Audio TTS provider on /v1/audio/speech (#8099)

--- a/open-sse/config/audioRegistry.ts
+++ b/open-sse/config/audioRegistry.ts
@@ -397,6 +397,22 @@ export const AUDIO_SPEECH_PROVIDERS: Record<string, AudioProvider> = {
     ],
   },
 
+  fishaudio: {
+    id: "fishaudio",
+    // POST https://api.fish.audio/v1/tts
+    // Auth: Authorization: Bearer <api-key>, model as an HTTP header
+    // Response: binary audio bytes
+    baseUrl: "https://api.fish.audio/v1/tts",
+    authType: "apikey",
+    authHeader: "bearer",
+    format: "fishaudio",
+    models: [
+      { id: "s1", name: "Fish Speech S1" },
+      { id: "speech-1.6", name: "Fish Speech 1.6" },
+      { id: "speech-1.5", name: "Fish Speech 1.5" },
+    ],
+  },
+
   playht: {
     id: "playht",
     // POST https://api.play.ht/api/v2/tts/stream

--- a/open-sse/handlers/audioSpeech.ts
+++ b/open-sse/handlers/audioSpeech.ts
@@ -401,6 +401,35 @@ async function handleCartesiaSpeech(providerConfig, body, modelId, token) {
 }
 
 /**
+ * Handle Fish Audio TTS
+ * POST { text, format, reference_id, prosody } → binary audio bytes
+ * Auth: Authorization: Bearer <api-key>, model as an HTTP header
+ * Docs: https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+ */
+async function handleFishAudioSpeech(providerConfig, body, modelId, token) {
+  const res = await fetch(providerConfig.baseUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      model: modelId,
+    },
+    body: JSON.stringify({
+      text: body.input,
+      format: body.response_format || "mp3",
+      ...(body.voice ? { reference_id: body.voice } : {}),
+      ...(body.speed ? { prosody: { speed: body.speed } } : {}),
+    }),
+  });
+
+  if (!res.ok) {
+    return upstreamErrorResponse(res, await res.text());
+  }
+
+  return audioStreamResponse(res);
+}
+
+/**
  * Handle PlayHT TTS
  * POST { text, voice, voice_engine, output_format } → audio stream
  * Auth: X-USER-ID header (from token string "userId:apiKey")
@@ -784,7 +813,7 @@ export async function handleAudioSpeech({
   if (!providerConfig) {
     return errorResponse(
       400,
-      `No speech provider found for model "${body.model}". Use format provider/model. Available: openai, hyperbolic, deepgram, nvidia, elevenlabs, huggingface, inworld, cartesia, playht, kie, aws-polly, xiaomi-mimo, edgetts, gtts, coqui, tortoise, qwen`
+      `No speech provider found for model "${body.model}". Use format provider/model. Available: openai, hyperbolic, deepgram, nvidia, elevenlabs, huggingface, inworld, cartesia, fishaudio, playht, kie, aws-polly, xiaomi-mimo, edgetts, gtts, coqui, tortoise, qwen`
     );
   }
 
@@ -835,6 +864,10 @@ export async function handleAudioSpeech({
 
     if (providerConfig.format === "cartesia") {
       return handleCartesiaSpeech(providerConfig, body, modelId, token);
+    }
+
+    if (providerConfig.format === "fishaudio") {
+      return handleFishAudioSpeech(providerConfig, body, modelId, token);
     }
 
     if (providerConfig.format === "playht") {

--- a/src/shared/constants/providers/audio.ts
+++ b/src/shared/constants/providers/audio.ts
@@ -39,6 +39,15 @@ export const AUDIO_ONLY_PROVIDERS = {
     textIcon: "CA",
     website: "https://cartesia.ai",
   },
+  fishaudio: {
+    id: "fishaudio",
+    alias: "fishaudio",
+    name: "Fish Audio",
+    icon: "graphic_eq",
+    color: "#3B82F6",
+    textIcon: "FA",
+    website: "https://fish.audio",
+  },
   playht: {
     id: "playht",
     alias: "playht",

--- a/tests/unit/audio-speech-fishaudio.test.ts
+++ b/tests/unit/audio-speech-fishaudio.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { handleAudioSpeech } = await import("../../open-sse/handlers/audioSpeech.ts");
+
+test("handleAudioSpeech maps Fish Audio headers and body, and passes audio through", async () => {
+  const originalFetch = globalThis.fetch;
+  let captured;
+
+  globalThis.fetch = async (_url, options = {}) => {
+    captured = {
+      headers: options.headers,
+      body: JSON.parse(String(options.body || "{}")),
+    };
+    return new Response(new Uint8Array([7, 8, 9]), {
+      status: 200,
+      headers: { "content-type": "audio/mpeg" },
+    });
+  };
+
+  try {
+    const response = await handleAudioSpeech({
+      body: {
+        model: "fishaudio/s1",
+        input: "hi",
+        voice: "ref-123",
+        response_format: "mp3",
+        speed: 1.2,
+      },
+      credentials: { apiKey: "fk" },
+    });
+
+    assert.equal(captured.headers.Authorization, "Bearer fk");
+    assert.equal(captured.headers.model, "s1");
+    assert.deepEqual(captured.body, {
+      text: "hi",
+      format: "mp3",
+      reference_id: "ref-123",
+      prosody: { speed: 1.2 },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "audio/mpeg");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleAudioSpeech surfaces sanitized Fish Audio upstream errors (not a raw stack)", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: { message: "invalid reference_id" } }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+
+  try {
+    const response = await handleAudioSpeech({
+      body: {
+        model: "fishaudio/s1",
+        input: "hi",
+        voice: "bad-ref",
+      },
+      credentials: { apiKey: "fk" },
+    });
+    const payload = (await response.json()) as { error: { message: string } };
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error.message, "invalid reference_id");
+    assert.equal(payload.error.message.includes("at /"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleAudioSpeech requires credentials for Fish Audio", async () => {
+  const response = await handleAudioSpeech({
+    body: {
+      model: "fishaudio/s1",
+      input: "hi",
+    },
+    credentials: null,
+  });
+  const payload = (await response.json()) as { error: { message: string } };
+
+  assert.equal(response.status, 401);
+  assert.equal(payload.error.message, "No credentials for speech provider: fishaudio");
+});


### PR DESCRIPTION
## Summary

Adds a native Fish Audio TTS provider on `POST /v1/audio/speech`, following the existing per-provider handler pattern in `open-sse/handlers/audioSpeech.ts` (closest template: `handleCartesiaSpeech`).

Fish Audio upstream: `POST https://api.fish.audio/v1/tts`, `Authorization: Bearer <key>`, `model` sent as an HTTP header, body `{ text, format, reference_id, prosody }`.

OpenAI-shape mapping:
- `input` → `text`
- `voice` → `reference_id`
- `response_format` → `format` (defaults `mp3`)
- `speed` → `prosody.speed`
- resolved model → `model` header

### Changes
- `open-sse/handlers/audioSpeech.ts`: new `handleFishAudioSpeech` handler + dispatch branch + updated "Available providers" error string.
- `open-sse/config/audioRegistry.ts`: new `fishaudio` entry in `AUDIO_SPEECH_PROVIDERS` (`s1`, `speech-1.6`, `speech-1.5`).
- `src/shared/constants/providers/audio.ts`: new `fishaudio` entry in `AUDIO_ONLY_PROVIDERS` (dashboard catalog).
- `tests/unit/audio-speech-fishaudio.test.ts` (new): header/body mapping, sanitized upstream-error passthrough, missing-credentials 401.
- `changelog.d/features/8099-fishaudio-tts-provider.md`: changelog fragment.

Upstream errors are returned via the shared `upstreamErrorResponse()` helper (`open-sse/utils/audioResponse.ts`), so no raw `err.stack`/`err.message` is ever put in a response body (Hard Rule #12).

## Test plan
- [x] `node --import tsx/esm --test tests/unit/audio-speech-fishaudio.test.ts` — 3/3 passing (header+body mapping, upstream-error sanitization, 401 no-credentials)
- [x] `npm run typecheck:core` — clean
- [x] `npm run typecheck:noimplicit:core` — clean (pre-existing unrelated errors in combo.ts/usageTracking.ts/cliRuntime.ts confirmed on origin/release/v3.8.49 base, not touched by this PR)
- [x] `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 errors
- [x] `node scripts/check/check-file-size.mjs` — OK (audioSpeech.ts well under the 1061 baseline)
- [x] `node scripts/check/check-test-discovery.mjs` — OK, new test collected at top-level `tests/unit/`
- [x] `npm run check:complexity-ratchets` — cognitive OK; cyclomatic regression (2152 vs baseline 2130) verified to be pre-existing drift on `origin/release/v3.8.49` itself (confirmed by re-running the gate against the unmodified base copies of all 3 touched files — identical violation count/set before and after this change)
- [x] `npm run check:cycles` — no new cycle
- [x] `npm run check:docs-sync` — pass

Closes #8099