### PR TITLE
fix(security): bound JWT-extraction regexes to prevent polynomial ReDoS (CodeQL)

### DIFF
--- a/changelog.d/fixes/codeql-redos-adobe-jwt.md
+++ b/changelog.d/fixes/codeql-redos-adobe-jwt.md
@@ -1,0 +1,1 @@
+- fix(security): bound JWT-extraction regexes in adobeFireflyClient to prevent polynomial ReDoS (CodeQL #754/#755/#756)

--- a/open-sse/services/adobeFireflyClient.ts
+++ b/open-sse/services/adobeFireflyClient.ts
@@ -339,7 +339,7 @@ export function decodeAdobeJwtPayload(token: string): Record<string, unknown> | 
     // Do not call extractAdobeCredentialToken here (would recurse via guest checks).
     let raw = String(token || "").trim().replace(/^bearer\s+/i, "").trim();
     // If a blob was passed, take the first JWT-shaped segment.
-    const m = raw.match(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
+    const m = raw.match(/eyJ[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}/);
     if (m) raw = m[0];
     const part = raw.split(".")[1];
     if (!part) return null;
@@ -432,11 +432,11 @@ export function extractAdobeCredentialToken(raw: string): string {
   }
 
   // Authorization: Bearer eyJ...
-  const authMatch = value.match(/Authorization\s*:\s*Bearer\s+([A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)/i);
+  const authMatch = value.match(/Authorization\s*:\s*Bearer\s+([A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096})/i);
   if (authMatch?.[1] && looksLikeAdobeJwt(authMatch[1])) return authMatch[1];
 
   // Any eyJ… JWT in the blob (HAR / multi-line). Prefer user AdobeID tokens.
-  const jwtMatches = value.match(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g);
+  const jwtMatches = value.match(/eyJ[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}/g);
   if (jwtMatches && jwtMatches.length > 0) {
     const sorted = [...jwtMatches].sort((a, b) => b.length - a.length);
     const user = sorted.find((t) => looksLikeAdobeJwt(t) && isAdobeUserAccessToken(t));
@@ -485,14 +485,14 @@ export function extractAdobeCookieHeader(raw: string): string {
       if (/^bearer\s+/i.test(line)) return false;
       if (looksLikeAdobeJwt(line)) return false;
       // Drop standalone eyJ… segments
-      if (/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(line)) return false;
+      if (/^eyJ[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}$/.test(line)) return false;
       return true;
     })
     .join("; ");
 
   // Also strip inline eyJ JWT tokens that may sit inside a cookie string
   const noJwt = cleaned
-    .replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "")
+    .replace(/eyJ[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}\.[A-Za-z0-9_-]{1,4096}/g, "")
     .replace(/;\s*;/g, ";")
     .replace(/^;\s*|\s*;$/g, "")
     .trim();

--- a/tests/unit/adobe-firefly-jwt-redos-guard.test.ts
+++ b/tests/unit/adobe-firefly-jwt-redos-guard.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  decodeAdobeJwtPayload,
+  extractAdobeCredentialToken,
+  extractAdobeCookieHeader,
+} from "../../open-sse/services/adobeFireflyClient.ts";
+
+// CodeQL js/polynomial-redos (#754/#755/#756): the JWT-shaped extraction regexes in
+// adobeFireflyClient.ts used unbounded `[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`
+// sequences over attacker-controlled cookie/HAR blobs. The fix bounds every segment to
+// {1,4096} (CodeQL's endorsed remediation + the CLAUDE.md ReDoS convention). These tests
+// guard the two things that could regress from that change:
+//   (a) bounding stays GENEROUS enough that realistic long Adobe/IMS tokens still parse
+//       (a naive over-tighten like {1,64} would truncate real tokens — this catches it),
+//   (b) extraction on a pathological long input still completes within a hard time budget
+//       (tripwire against a future catastrophic/exponential regression of these patterns).
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+const SHORT_JWT = `${b64url({ alg: "RS256", typ: "JWT" })}.${b64url({
+  sub: "user-abc123",
+  exp: 9999999999,
+})}.c2lnbmF0dXJlLXBsYWNlaG9sZGVy`;
+
+// Realistic Adobe/IMS token: payloads carry many scopes/claims and run well past a few
+// hundred chars per segment. Segments here are ~1200 chars — comfortably inside {1,4096}
+// but far beyond any accidental over-tightening.
+const LONG_JWT = `${b64url({ alg: "RS256", typ: "JWT" })}.${b64url({
+  sub: "user-abc123",
+  scope: "x".repeat(1200),
+  exp: 9999999999,
+})}.${"s".repeat(700)}`;
+
+test("decodeAdobeJwtPayload still decodes a short valid JWT", () => {
+  const payload = decodeAdobeJwtPayload(SHORT_JWT);
+  assert.ok(payload, "expected a decoded payload object");
+  assert.equal(payload?.sub, "user-abc123");
+});
+
+test("decodeAdobeJwtPayload decodes a LONG token (bound {1,4096} must not truncate real tokens)", () => {
+  const payload = decodeAdobeJwtPayload(LONG_JWT);
+  assert.ok(payload, "long-token payload should decode — the {1,4096} bound must be generous");
+  assert.equal(payload?.sub, "user-abc123");
+});
+
+test("decodeAdobeJwtPayload extracts a JWT embedded in a surrounding blob", () => {
+  const payload = decodeAdobeJwtPayload(`noise-prefix ${LONG_JWT} noise-suffix`);
+  assert.ok(payload);
+  assert.equal(payload?.sub, "user-abc123");
+});
+
+test("extractAdobeCredentialToken finds a Bearer JWT in a header blob", () => {
+  const token = extractAdobeCredentialToken(`Authorization: Bearer ${SHORT_JWT}`);
+  assert.equal(token, SHORT_JWT);
+});
+
+test("JWT extraction stays within a hard time budget on pathological input (ReDoS tripwire)", () => {
+  const pathological = "eyJ" + "a".repeat(200000) + "." + "a".repeat(200000);
+  const start = process.hrtime.bigint();
+  decodeAdobeJwtPayload(pathological);
+  extractAdobeCredentialToken(`Authorization: Bearer ${pathological}`);
+  extractAdobeCookieHeader(`cookie1=${pathological}; ${pathological}`);
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+  assert.ok(
+    elapsedMs < 1000,
+    `JWT extraction on pathological input took ${elapsedMs.toFixed(1)}ms (budget 1000ms) — possible ReDoS regression`
+  );
+});


### PR DESCRIPTION
Fixes CodeQL `js/polynomial-redos` alerts #754/#755/#756 in `open-sse/services/adobeFireflyClient.ts`.

## Root cause
The JWT-shaped extraction regexes used unbounded quantifiers — `[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` — applied to attacker-controlled cookie / `Authorization` header / HAR-blob input (`decodeAdobeJwtPayload`, `extractAdobeCredentialToken`, `extractAdobeCookieHeader`). CodeQL flags the pattern shape as polynomial ReDoS.

## Fix
Bounded every segment to `{1,4096}` across all 5 JWT regexes in the file (the 3 flagged + 2 siblings, for consistency). This is CodeQL's endorsed remediation and matches the CLAUDE.md ReDoS convention ("strictly bounded, non-overlapping sequences"). `4096` is generous — any realistic Adobe/IMS token segment fits well within it.

## Validation (Hard Rule #18)
New regression test `tests/unit/adobe-firefly-jwt-redos-guard.test.ts` (5/5 green):
- valid short + **long** (~1200-char-segment) JWTs still decode/extract correctly — guards that the `{1,4096}` bound is not an over-tighten that would truncate real tokens;
- pathological 200k-char input stays within a 1000ms hard budget (ReDoS tripwire against a future catastrophic regression).

Note: empirically these particular patterns are only mildly superlinear (the `eyJ`/`Bearer` anchors + the `.`-excluding class limit real-world backtracking), so the change is defense-in-depth hardening that also clears the CodeQL alerts on re-scan — no observable behavior change for normal inputs.