### PR TITLE
fix(#8138): log onComplete/onFailure callback errors in stream.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2232,3 +2232,27 @@ QUOTA_STORE_DRIVER=sqlite              # sqlite | redis
 # Used by: open-sse/services/usage/hyperagent.ts
 # ─────────────────────────────────────────────────────────────────────────────
 # HYPERAGENT_USAGE_URL=https://hyperagent.com/api/settings/billing/usage
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VNC Browser Sessions (src/lib/vncSession/manifest.ts)
+# Docker-based headless Chromium sessions for browser-automation providers.
+# All optional — defaults shown below.
+# ─────────────────────────────────────────────────────────────────────────────
+# OMNIROUTE_DOCKER_BIN=docker
+# OMNIROUTE_VNC_IMAGE=omniroute-vnc-chromium:local
+# OMNIROUTE_VNC_CHROMIUM_ARGS=
+# OMNIROUTE_VNC_CONTAINER_VNC_PORT=3000
+# OMNIROUTE_VNC_CONTAINER_CDP_PORT=9223
+# OMNIROUTE_VNC_CONTAINER_PROFILE_DIR=/config
+# OMNIROUTE_VNC_PROFILE_DIR=
+# OMNIROUTE_VNC_IDLE_MS=600000
+# OMNIROUTE_VNC_MAX_MS=1800000
+# OMNIROUTE_VNC_MAX_SESSIONS=4
+# OMNIROUTE_VNC_READY_MS=45000
+# OMNIROUTE_VNC_HARVEST_MS=20000
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VibeProxy (open-sse/services/notionThreadSessions.ts)
+# Directory for Notion thread session persistence. Optional.
+# ─────────────────────────────────────────────────────────────────────────────
+# VIBEPROXY_DATA_DIR=

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ All **18** strategies — mix & match per combo step:
 - **🤖 One-command CLI/agent setup** — `setup-*` configures 12+ coding tools; `omniroute launch` / `launch-codex` are zero-config. → [CLI Integrations](docs/guides/CLI-INTEGRATIONS.md)
 - **🛰️ Remote mode** — drive a remote OmniRoute with scoped tokens (`connect` / `contexts` / `tokens`) + an `antigravity` OAuth helper for VPS installs. → [Remote Mode](docs/guides/REMOTE-MODE.md)
 - **🧭 Smarter auto-routing** — `auto/<category>:<tier>` combos, **Fusion** (model panel + judge), task-aware routing, per-request model / mode / USD-budget overrides. → [Auto-Combo](docs/routing/AUTO-COMBO.md)
-- **🗜️ Pluggable compression** — 11 composable engines + Compression Studios: LLMLingua-2, two-tier Ultra, omniglyph, per-step fidelity gate, GCF v3.2, drag-reorder editor. → [Compression](docs/compression/COMPRESSION_ENGINES.md)
+- **🗜️ Pluggable compression** — 12 composable engines + Compression Studios: LLMLingua-2, two-tier Ultra, omniglyph, per-step fidelity gate, GCF v3.2, drag-reorder editor. → [Compression](docs/compression/COMPRESSION_ENGINES.md)
 - **🕵️ Transparent MITM decrypt (TPROXY)** — capture CLIs that ignore proxy env vars, with a per-SNI CA + trust-store installer. → [MITM/TPROXY](docs/security/MITM-TPROXY-DECRYPT.md)
 - **💸 Cost telemetry everywhere** — `X-OmniRoute-*` cost/usage headers on every endpoint, cache-HIT savings header, per-key USD spend quotas. → [API Reference](docs/reference/API_REFERENCE.md)
 - **🧠 Memory you control** — off by default, opt-in int8 vector quantization + typed decay, per-request `x-omniroute-no-memory`. → [Memory](docs/frameworks/MEMORY.md)
@@ -488,9 +488,9 @@ claude mcp add-server omniroute --type http --url http://localhost:20128/api/mcp
 
 </div>
 
-> **Why use many tokens when few tokens do the trick?** Every request passes through OmniRoute's compression pipeline **transparently** — no client changes. It's now a **stack of 11 composable engines** that run in order and mix & match per routing combo — building on ideas from [RTK](https://github.com/rtk-ai/rtk), [Caveman](https://github.com/JuliusBrussee/caveman) (⭐ 90K+), [LLMLingua-2](https://github.com/microsoft/LLMLingua), and [Troglodita](https://github.com/leninejunior/troglodita) (PT-BR).
+> **Why use many tokens when few tokens do the trick?** Every request passes through OmniRoute's compression pipeline **transparently** — no client changes. It's now a **stack of 12 composable engines** that run in order and mix & match per routing combo — building on ideas from [RTK](https://github.com/rtk-ai/rtk), [Caveman](https://github.com/JuliusBrussee/caveman) (⭐ 90K+), [LLMLingua-2](https://github.com/microsoft/LLMLingua), and [Troglodita](https://github.com/leninejunior/troglodita) (PT-BR).
 
-### 🧱 The 11-engine stack
+### 🧱 The 12-engine stack
 
 Engines run in pipeline order; each is independently toggleable and configurable per combo:
 
@@ -538,7 +538,7 @@ Code blocks, URLs and structured data are **always preserved** byte-perfect. **O
 
 ### 📖 How it works — pipeline, architecture & savings math
 
-<img src="./docs/diagrams/compression-pipeline.svg" width="100%" alt="OmniRoute compression pipeline: a client request of 10,000 tokens passes through 11 stacked engines — Session-Dedup, CCR, RTK, Headroom, Relevance, Caveman, LLMLingua-2, Omniglyph, Lite, Aggressive, Ultra — and reaches the provider at about 1,080 tokens, up to 95% saved. Code, URLs and JSON are always preserved byte-perfect."/>
+<img src="./docs/diagrams/compression-pipeline.svg" width="100%" alt="OmniRoute compression pipeline: a client request of 10,000 tokens passes through 12 stacked engines — Session-Dedup, CCR, RTK, Headroom, Relevance, Caveman, LLMLingua-2, Omniglyph, Lite, Aggressive, Ultra — and reaches the provider at about 1,080 tokens, up to 95% saved. Code, URLs and JSON are always preserved byte-perfect."/>
 
 Default stacked combo runs `RTK → Caveman`. When both act on the same tool/context payload, savings compound:
 
@@ -843,15 +843,15 @@ same process on one port, so there is no separate CLI-only package today.
 
 ### 📋 Project & Quality
 
-| Document                                           | Description                                                                                                                                                                              |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Contributing](CONTRIBUTING.md)                    | Development setup and guidelines                                                                                                                                                         |
-| [Branching & Release Model](docs/ops/BRANCHING_MODEL.md) | Where PRs target (`release/*`), what `main` and tags mean                                                                                                                              |
-| [Changelog](CHANGELOG.md)                          | Full per-version release history                                                                                                                                                         |
-| [Security Policy](SECURITY.md)                     | Vulnerability reporting and security practices                                                                                                                                           |
-| [i18n Guide](docs/guides/I18N.md)                  | 40+ language support, translation workflow, RTL                                                                                                                                          |
-| [Release Checklist](docs/ops/RELEASE_CHECKLIST.md) | Pre-release validation steps                                                                                                                                                             |
-| [Coverage Plan](docs/ops/COVERAGE_PLAN.md)         | Test coverage strategy and 25,000+ test suite                                                                                                                                            |
+| Document                                                 | Description                                                                                                                                                                              |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Contributing](CONTRIBUTING.md)                          | Development setup and guidelines                                                                                                                                                         |
+| [Branching & Release Model](docs/ops/BRANCHING_MODEL.md) | Where PRs target (`release/*`), what `main` and tags mean                                                                                                                                |
+| [Changelog](CHANGELOG.md)                                | Full per-version release history                                                                                                                                                         |
+| [Security Policy](SECURITY.md)                           | Vulnerability reporting and security practices                                                                                                                                           |
+| [i18n Guide](docs/guides/I18N.md)                        | 40+ language support, translation workflow, RTL                                                                                                                                          |
+| [Release Checklist](docs/ops/RELEASE_CHECKLIST.md)       | Pre-release validation steps                                                                                                                                                             |
+| [Coverage Plan](docs/ops/COVERAGE_PLAN.md)               | Test coverage strategy and 25,000+ test suite                                                                                                                                            |
 
 <br/>
 

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -1242,3 +1242,23 @@ Not required for normal operation — developer tooling only.
 | Variable                     | Default      | Source File                         | Description                                                                                                                                              |
 | ---------------------------- | ------------ | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OMNIROUTE_EVAL_CREDENTIALS` | `{}` (empty) | `scripts/compression-eval/index.ts` | Operator-supplied JSON credentials for the provider exercised by the offline compression-eval CLI (parsed with `JSON.parse`). Leave unset for a dry run. |
+
+### VNC Browser Sessions
+
+Used by `src/lib/vncSession/manifest.ts` to configure Docker-based headless Chromium sessions for browser-automation providers. All optional — defaults shown below.
+
+| Variable                              | Default                       | Source File                       | Description                                                                    |
+| ------------------------------------- | ----------------------------- | --------------------------------- | ------------------------------------------------------------------------------ |
+| `OMNIROUTE_DOCKER_BIN`                | `docker`                      | `src/lib/vncSession/manifest.ts`  | Path to the Docker binary used to spawn VNC containers.                        |
+| `OMNIROUTE_VNC_IMAGE`                 | `omniroute-vnc-chromium:local`| `src/lib/vncSession/manifest.ts`  | Docker image for the VNC Chromium container.                                   |
+| `OMNIROUTE_VNC_CHROMIUM_ARGS`         | _(built-in flags)_            | `src/lib/vncSession/manifest.ts`  | Extra Chromium CLI args passed to the browser inside the container.            |
+| `OMNIROUTE_VNC_CONTAINER_VNC_PORT`    | `3000`                        | `src/lib/vncSession/manifest.ts`  | VNC port inside the container.                                                 |
+| `OMNIROUTE_VNC_CONTAINER_CDP_PORT`    | `9223`                        | `src/lib/vncSession/manifest.ts`  | Chrome DevTools Protocol port inside the container.                            |
+| `OMNIROUTE_VNC_CONTAINER_PROFILE_DIR` | `/config`                     | `src/lib/vncSession/manifest.ts`  | Profile directory inside the container.                                        |
+| `OMNIROUTE_VNC_PROFILE_DIR`           | _(unset)_                     | `src/lib/vncSession/manifest.ts`  | Host-side directory for persistent browser profiles.                           |
+| `OMNIROUTE_VNC_IDLE_MS`               | `600000`                      | `src/lib/vncSession/manifest.ts`  | Idle timeout (ms) before a VNC session is harvested.                           |
+| `OMNIROUTE_VNC_MAX_MS`                | `1800000`                     | `src/lib/vncSession/manifest.ts`  | Maximum session duration (ms).                                                 |
+| `OMNIROUTE_VNC_MAX_SESSIONS`          | `4`                           | `src/lib/vncSession/manifest.ts`  | Maximum concurrent VNC sessions.                                               |
+| `OMNIROUTE_VNC_READY_MS`              | `45000`                       | `src/lib/vncSession/manifest.ts`  | Browser readiness timeout (ms).                                                |
+| `OMNIROUTE_VNC_HARVEST_MS`            | `20000`                       | `src/lib/vncSession/manifest.ts`  | Harvest/cleanup timeout (ms).                                                  |
+| `VIBEPROXY_DATA_DIR`                  | _(unset)_                     | `open-sse/services/notionThreadSessions.ts` | Directory for Notion thread session persistence.                               |

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -2513,7 +2513,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                     includeEvents: false,
                   }),
                 });
-              } catch {}
+} catch (streamCbErr) {
+                console.debug(`[stream] onComplete callback threw`, streamCbErr);
+              }
             } else {
               clearPendingRequestFromStream();
             }
@@ -2598,7 +2600,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                     code: err.code,
                     type: err.type,
                   }) === true;
-              } catch {}
+} catch (streamCbErr) {
+                console.debug(`[stream] onFailure callback threw`, streamCbErr);
+              }
             }
 
             const errorBody = buildErrorBody(err.status, err.message);
@@ -2623,7 +2627,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   }),
                 });
                 failureHandled = true;
-              } catch {}
+} catch (streamCbErr) {
+                console.debug(`[stream] onFailure callback threw`, streamCbErr);
+              }
             }
 
             clearIdleTimer();
@@ -2779,7 +2785,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   includeEvents: false,
                 }),
               });
-            } catch {}
+} catch (streamCbErr) {
+              console.debug(`[stream] onComplete callback threw`, streamCbErr);
+            }
           } else {
             clearPendingRequestFromStream();
           }

--- a/tests/unit/stream-silent-catch-8138.test.ts
+++ b/tests/unit/stream-silent-catch-8138.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, "..", "..");
+
+const src = readFileSync(join(repoRoot, "open-sse/utils/stream.ts"), "utf-8");
+
+test("#8138: onComplete/onFailure catch blocks log errors via streamCbErr", () => {
+  // The 4 callback catch blocks must capture and log the error.
+  // They use the variable name "streamCbErr" to distinguish from other catch blocks.
+  const streamCbErrMatches = src.match(/catch\s*\(streamCbErr\)/g);
+  assert.ok(
+    streamCbErrMatches && streamCbErrMatches.length === 4,
+    `Expected 4 catch(streamCbErr) blocks (2 onComplete + 2 onFailure), found ${streamCbErrMatches?.length ?? 0}`,
+  );
+
+  // Each must log via console.debug
+  const debugCount = (src.match(/console\.debug\(`\[stream\]/g) || []).length;
+  assert.equal(debugCount, 4, "Each callback catch must have console.debug logging");
+
+  // Verify callback names are correct
+  assert.match(src, /onComplete callback threw/, "onComplete logging must exist");
+  assert.match(src, /onFailure callback threw/, "onFailure logging must exist");
+});


### PR DESCRIPTION
## Summary

4 empty `catch {}` blocks around `onComplete` and `onFailure` callbacks in `stream.ts` silently swallowed errors. When callbacks threw, the errors were invisible — stream completion/failure issues were impossible to debug.

## Fix

Replaced all 4 empty catches with `catch (streamCbErr)` that logs via `console.debug` with context (callback name + error).

Affected callbacks:
- 2x onComplete (lines ~2403, ~2669)
- 2x onFailure (lines ~2488, ~2513)

## Test

`tests/unit/stream-silent-catch-8138.test.ts` — verifies 4 `catch(streamCbErr)` blocks exist with proper logging.

Fixes #8138