### PR TITLE
chore(quality): fix 2 pre-existing lint/suppression drift issues

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1187,7 +1187,7 @@
   },
   "tests/unit/combo-routing-engine.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 269
+      "count": 271
     }
   },
   "tests/unit/combo-same-provider-cascade.test.ts": {

--- a/tests/unit/oauth-refresh-connection-dedup-8059.test.ts
+++ b/tests/unit/oauth-refresh-connection-dedup-8059.test.ts
@@ -21,9 +21,8 @@ process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "oauth-refresh-dedup-
 
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
-const { persistOAuthConnection, findExistingOAuthConnectionMatch } = await import(
-  "../../src/lib/oauth/connectionPersistence.ts"
-);
+const { persistOAuthConnection, findExistingOAuthConnectionMatch } =
+  await import("../../src/lib/oauth/connectionPersistence.ts");
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -37,9 +36,11 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
+type ProviderConnection = Awaited<ReturnType<typeof providersDb.getProviderConnections>>[number];
+
 async function oauthConns(provider: string) {
   const all = await providersDb.getProviderConnections({});
-  return all.filter((c: any) => c.provider === provider && c.authType === "oauth");
+  return all.filter((c: ProviderConnection) => c.provider === provider && c.authType === "oauth");
 }
 
 // GitHub Copilot: no top-level email, identity under providerSpecificData.


### PR DESCRIPTION
## Summary

Two small, unrelated lint-gate fixes found while rebasing a feature branch onto this release branch:

- `tests/unit/combo-routing-engine.test.ts`: `#8008` (prompt-cache affinity) added 2 more `any` usages to this test file (269 → 271) without updating the ESLint suppressions count. The suppressions mechanism requires an exact count match — any drift makes the whole file's suppression stale and reports every pre-existing violation as new, not just the delta. Refreshed the count.
- `tests/unit/oauth-refresh-connection-dedup-8059.test.ts`: `#8062` introduced this test file with an untyped `any` filter callback param, which the strict any-budget rule flags as a new (not pre-existing) violation. Typed it via `Awaited<ReturnType<typeof getProviderConnections>>[number]` instead of adding a suppression.

## Test plan

- [x] `npm run lint` passes cleanly against this branch (previously failed with 1 stale-suppression cascade + 1 new any-budget violation).
- [x] `tests/unit/oauth-refresh-connection-dedup-8059.test.ts` still passes after the type change.