### PR TITLE
fix(sse): tool-incapable provider handling (AI Horde + Responses content-collapse scoping)

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -236,6 +236,16 @@ export function getUnsupportedParams(provider: string, modelId: string): readonl
 }
 
 /**
+ * True for providers whose OpenAI-compatible facade rejects a single-text-part
+ * content array and only accepts the equivalent plain string (RegistryEntry.
+ * requiresPlainStringContent). Used by the Responses→Chat translator to scope
+ * its content-collapse workaround to just these providers.
+ */
+export function requiresPlainStringContent(provider: string): boolean {
+  return getRegistryEntry(provider)?.requiresPlainStringContent === true;
+}
+
+/**
  * Get provider category: "oauth" or "apikey"
  * Used by the resilience layer to apply different cooldown/backoff profiles.
  * @param {string} provider - Provider ID or alias

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -226,6 +226,12 @@ export function getUnsupportedParams(provider: string, modelId: string): readonl
     if (bare) return bare;
   }
 
+  // 4. Provider-wide fallback for providers whose limitation applies to every
+  // model they serve, not just the ones statically catalogued (e.g. AI Horde's
+  // `passthroughModels: true` roster changes as workers come and go, but no
+  // model it hosts supports tool calling — see RegistryEntry.unsupportedParams).
+  if (entry?.unsupportedParams) return entry.unsupportedParams;
+
   return [];
 }
 

--- a/open-sse/config/providers/registry/aihorde/index.ts
+++ b/open-sse/config/providers/registry/aihorde/index.ts
@@ -28,6 +28,13 @@ export const aihordeProvider: RegistryEntry = buildOpenAiCompatibleRegistryEntry
   passthroughModels: true,
   anonymousApiKey: "0000000000",
   timeoutMs: 120_000,
+  // Provider-wide fallback (getUnsupportedParams() falls back to this when a
+  // model has no per-model entry) — every model AI Horde serves shares this
+  // limitation, not just the 3 statically catalogued below. Without it, any
+  // live-discovered model (the roster changes as workers come/go) sends
+  // `tools` straight through and gets a 500 from the raw text-completion
+  // backend, which doesn't understand the field at all.
+  unsupportedParams: ["tools", "tool_choice", "parallel_tool_calls"],
   models: [
     {
       id: "aphrodite/TheDrummer/Cydonia-24B-v4.3",

--- a/open-sse/config/providers/registry/aihorde/index.ts
+++ b/open-sse/config/providers/registry/aihorde/index.ts
@@ -35,6 +35,9 @@ export const aihordeProvider: RegistryEntry = buildOpenAiCompatibleRegistryEntry
   // `tools` straight through and gets a 500 from the raw text-completion
   // backend, which doesn't understand the field at all.
   unsupportedParams: ["tools", "tool_choice", "parallel_tool_calls"],
+  // Aphrodite's OpenAI-compatible facade 500s on a single-text-part content array —
+  // it only implements the plain-string form (see openai-responses.ts collapse logic).
+  requiresPlainStringContent: true,
   models: [
     {
       id: "aphrodite/TheDrummer/Cydonia-24B-v4.3",

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -168,6 +168,14 @@ export interface RegistryEntry {
    * the per-model lookup misses.
    */
   unsupportedParams?: readonly string[];
+  /**
+   * True for strict/naive OpenAI-compatible backends that reject a single-text-part
+   * content array (`[{ type: "text", text }]`) and only accept the equivalent plain
+   * string. Used by the Responses→Chat translator to collapse single-part text
+   * content down to a string for this provider only, leaving every other provider's
+   * standard OpenAI array-shaped content untouched (see openai-responses.ts).
+   */
+  requiresPlainStringContent?: boolean;
 }
 
 /**

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -157,6 +157,17 @@ export interface RegistryEntry {
    * so the authenticated path is never affected.
    */
   anonymousApiKey?: string;
+  /**
+   * Provider-wide fallback for `RegistryModel.unsupportedParams`, applied when a
+   * model has no per-model override AND (for `passthroughModels: true`
+   * providers) isn't one of the few models statically listed here at all —
+   * e.g. AI Horde's live-discovered models change as workers come and go, and
+   * every one of them shares the same hard limitation ("the workers run raw
+   * text-completion backends" — no tool calling on any model, not just the
+   * 3 statically catalogued ones). Checked by `getUnsupportedParams()` after
+   * the per-model lookup misses.
+   */
+  unsupportedParams?: readonly string[];
 }
 
 /**

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -124,6 +124,7 @@ import {
 } from "../services/gpt5SamplingGuard.ts";
 import { getUnsupportedParams, REGISTRY } from "../config/providerRegistry.ts";
 import { stripUnsupportedParams } from "./chatCore/unsupportedParamsStrip.ts";
+import { checkToolCallingRequiredButUnsupported } from "./chatCore/toolCallingRequiredCheck.ts";
 import { supportsMaxTokens, getResolvedModelCapabilities } from "@/lib/modelCapabilities.ts";
 import { normalizeThinkingForModel } from "@/shared/constants/modelSpecs.ts";
 import {
@@ -2316,6 +2317,28 @@ export async function handleChatCore({
   // from a tool-capable model) — those message shapes break non-tool-calling
   // backends just as much as a live `tools` param does.
   const unsupported = getUnsupportedParams(provider, model);
+
+  // Direct/pinned requests (isCombo: false) have no other target to fail
+  // over to. Combo requests are already kept off a tool-incapable target by
+  // filterTargetsByRequestCompatibility before ever reaching this point, so
+  // this only fires for the case that filter can't protect: a client
+  // explicitly asking for this exact model. A clear error beats a 200 that
+  // silently can't do what was asked (the model narrates a fake tool call
+  // instead — live incident: AI Horde/Behemoth-X-123B).
+  const toolCallingCheck = checkToolCallingRequiredButUnsupported(
+    translatedBody,
+    unsupported,
+    isCombo,
+    model
+  );
+  if (toolCallingCheck.blocked) {
+    const { buildErrorBody } = await import("../utils/error.ts");
+    return new Response(JSON.stringify(buildErrorBody(400, toolCallingCheck.message!)), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   if (unsupported.length > 0) {
     const { strippedParams } = stripUnsupportedParams(translatedBody, unsupported);
     if (strippedParams.length > 0) {

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -123,6 +123,7 @@ import {
   stripGpt5ReasoningWhenTools,
 } from "../services/gpt5SamplingGuard.ts";
 import { getUnsupportedParams, REGISTRY } from "../config/providerRegistry.ts";
+import { stripUnsupportedParams } from "./chatCore/unsupportedParamsStrip.ts";
 import { supportsMaxTokens, getResolvedModelCapabilities } from "@/lib/modelCapabilities.ts";
 import { normalizeThinkingForModel } from "@/shared/constants/modelSpecs.ts";
 import {
@@ -2308,18 +2309,20 @@ export async function handleChatCore({
     }
   }
 
-  // Strip unsupported parameters for reasoning models (o1, o3, etc.)
+  // Strip unsupported parameters for reasoning models (o1, o3, etc.) and any
+  // provider that can't accept them at all (e.g. AI Horde's raw completion
+  // backends). When "tools" is among them, also flattens leftover
+  // tool_calls/tool-result messages in history (from a combo failover away
+  // from a tool-capable model) — those message shapes break non-tool-calling
+  // backends just as much as a live `tools` param does.
   const unsupported = getUnsupportedParams(provider, model);
   if (unsupported.length > 0) {
-    const stripped: string[] = [];
-    for (const param of unsupported) {
-      if (Object.hasOwn(translatedBody, param)) {
-        stripped.push(param);
-        delete translatedBody[param];
-      }
-    }
-    if (stripped.length > 0) {
-      log?.warn?.("PARAMS", `Stripped unsupported params for ${model}: ${stripped.join(", ")}`);
+    const { strippedParams } = stripUnsupportedParams(translatedBody, unsupported);
+    if (strippedParams.length > 0) {
+      log?.warn?.(
+        "PARAMS",
+        `Stripped unsupported params for ${model}: ${strippedParams.join(", ")}`
+      );
     }
   }
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2332,11 +2332,8 @@ export async function handleChatCore({
     model
   );
   if (toolCallingCheck.blocked) {
-    const { buildErrorBody } = await import("../utils/error.ts");
-    return new Response(JSON.stringify(buildErrorBody(400, toolCallingCheck.message!)), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    trackPendingRequest(model, provider, connectionId, false);
+    return createErrorResult(400, toolCallingCheck.message!, null, "tool_calling_not_supported");
   }
 
   if (unsupported.length > 0) {

--- a/open-sse/handlers/chatCore/toolCallingRequiredCheck.ts
+++ b/open-sse/handlers/chatCore/toolCallingRequiredCheck.ts
@@ -1,0 +1,33 @@
+// open-sse/handlers/chatCore/toolCallingRequiredCheck.ts
+// Extracted from handleChatCore (chatCore god-file decomposition).
+//
+// Combo requests are protected from ever reaching a tool-incapable target in
+// the first place by filterTargetsByRequestCompatibility (comboStructure.ts,
+// backed by getResolvedModelCapabilities' toolCalling resolution). But a
+// direct/pinned request (isCombo: false) has no other target to fail over
+// to — silently stripping `tools` and flattening history there produces a
+// 200 response that can never actually call anything (the model narrates a
+// fake action instead, live incident: AI Horde/Behemoth-X-123B). A clear,
+// explicit error is better than a response that looks successful but
+// silently drops the client's intended action.
+
+export interface ToolCallingRequiredCheckResult {
+  blocked: boolean;
+  message?: string;
+}
+
+export function checkToolCallingRequiredButUnsupported(
+  body: Record<string, unknown>,
+  unsupported: readonly string[],
+  isCombo: boolean,
+  model: string
+): ToolCallingRequiredCheckResult {
+  if (isCombo) return { blocked: false };
+  if (!unsupported.includes("tools")) return { blocked: false };
+  if (!Array.isArray(body.tools) || body.tools.length === 0) return { blocked: false };
+
+  return {
+    blocked: true,
+    message: `Model "${model}" does not support tool calling. Remove "tools" from the request or choose a different model.`,
+  };
+}

--- a/open-sse/handlers/chatCore/unsupportedParamsStrip.ts
+++ b/open-sse/handlers/chatCore/unsupportedParamsStrip.ts
@@ -1,0 +1,44 @@
+// open-sse/handlers/chatCore/unsupportedParamsStrip.ts
+// Extracted from handleChatCore (chatCore god-file decomposition) so the
+// unsupported-params strip + tool-history flattening can be unit tested
+// directly instead of only through the full handleChatCore pipeline.
+//
+// Live incident: AI Horde (registry unsupportedParams: ["tools", ...]) 500'd
+// on real combo traffic even after `tools`/`tool_choice` were correctly
+// stripped from the live request, because the conversation HISTORY still
+// carried a prior turn's role:"assistant" tool_calls and role:"tool" result
+// messages (left over from before the combo failed over from a tool-capable
+// model). AI Horde's raw completion backend doesn't understand those message
+// shapes at all, regardless of whether live `tools` is present. flattenToolHistory
+// already existed, fully unit-tested, for exactly this — it just had zero call
+// sites anywhere in the request pipeline.
+import { flattenToolHistory } from "../../utils/flattenToolHistory.ts";
+
+export interface UnsupportedParamsStripResult {
+  strippedParams: string[];
+}
+
+/**
+ * Deletes each unsupported param present on `body` (mutates in place, matching
+ * the original inline behavior). When "tools" was stripped, also flattens any
+ * tool_calls/tool-result messages in `body.messages` into plain assistant
+ * prose — leftover history from a target the combo failed over from.
+ */
+export function stripUnsupportedParams(
+  body: Record<string, unknown>,
+  unsupported: readonly string[]
+): UnsupportedParamsStripResult {
+  const strippedParams: string[] = [];
+  for (const param of unsupported) {
+    if (Object.hasOwn(body, param)) {
+      strippedParams.push(param);
+      delete body[param];
+    }
+  }
+
+  if (strippedParams.includes("tools") && Array.isArray(body.messages)) {
+    body.messages = flattenToolHistory(body.messages as Record<string, unknown>[]);
+  }
+
+  return { strippedParams };
+}

--- a/open-sse/handlers/chatCore/unsupportedParamsStrip.ts
+++ b/open-sse/handlers/chatCore/unsupportedParamsStrip.ts
@@ -20,9 +20,14 @@ export interface UnsupportedParamsStripResult {
 
 /**
  * Deletes each unsupported param present on `body` (mutates in place, matching
- * the original inline behavior). When "tools" was stripped, also flattens any
- * tool_calls/tool-result messages in `body.messages` into plain assistant
- * prose — leftover history from a target the combo failed over from.
+ * the original inline behavior). When "tools" is unsupported for this model —
+ * regardless of whether THIS particular request happens to carry a live
+ * `tools` array — also flattens any tool_calls/tool-result messages in
+ * `body.messages` into plain assistant prose. A model that can't do tool
+ * calling can't do it whether or not the current request includes `tools`;
+ * gating on "was tools actually present this time" missed the common case of
+ * stale tool-call history left over from before a combo failover, with no
+ * live `tools` param on the request that inherited it.
  */
 export function stripUnsupportedParams(
   body: Record<string, unknown>,
@@ -36,7 +41,7 @@ export function stripUnsupportedParams(
     }
   }
 
-  if (strippedParams.includes("tools") && Array.isArray(body.messages)) {
+  if (unsupported.includes("tools") && Array.isArray(body.messages)) {
     body.messages = flattenToolHistory(body.messages as Record<string, unknown>[]);
   }
 

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -40,7 +40,7 @@ export async function handleResponsesCore({
   const customToolNames = collectResponsesCustomToolNames(body?.tools, inputItems);
 
   // Convert Responses API format to Chat Completions format
-  const convertedBody = convertResponsesApiFormat(body, credentials);
+  const convertedBody = convertResponsesApiFormat(body, credentials, modelInfo?.provider);
 
   // Ensure stream is enabled
   convertedBody.stream = true;

--- a/open-sse/translator/helpers/responsesApiHelper.ts
+++ b/open-sse/translator/helpers/responsesApiHelper.ts
@@ -4,6 +4,6 @@
  */
 import { openaiResponsesToOpenAIRequest } from "../request/openai-responses.ts";
 
-export function convertResponsesApiFormat(body, credentials = null) {
-  return openaiResponsesToOpenAIRequest(null, body, null, credentials);
+export function convertResponsesApiFormat(body, credentials = null, provider = null) {
+  return openaiResponsesToOpenAIRequest(provider, body, null, credentials);
 }

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -8,6 +8,10 @@ import { isOpenAIResponsesStoreEnabled } from "@/lib/providers/requestDefaults";
 import { FORMATS } from "../formats.ts";
 import { register } from "../registry.ts";
 import { normalizeResponsesInputForChat } from "../../utils/responsesInputNormalization.ts";
+import {
+  getRegisteredProviders,
+  requiresPlainStringContent,
+} from "../../config/providerRegistry.ts";
 import { collectResponsesTools } from "./openai-responses/additionalTools.ts";
 import { openaiToOpenAIResponsesRequest } from "./openai-responses/toResponses.ts";
 import {
@@ -38,9 +42,9 @@ export function openaiResponsesToOpenAIRequest(
   stream: unknown,
   credentials: unknown
 ): unknown {
-  void model;
   void stream;
   void credentials;
+  const collapseToPlainString = requiresPlainStringContent(extractProviderHint(model));
 
   const root = toRecord(body);
   if (root.input === undefined) return body;
@@ -724,25 +728,44 @@ export function openaiResponsesToOpenAIRequest(
   // implement the plain-string form and reject the array form with a 500 — hit
   // live via AI Horde's Aphrodite facade rejecting every /v1/responses request,
   // including the simplest single-string input. A single-text-part array and a
-  // plain string are semantically identical, so collapsing is safe; real
-  // multi-part messages (text+image, text+file) are left untouched.
-  for (const message of messages) {
-    const content = (message as JsonRecord).content;
-    if (Array.isArray(content) && content.length === 1) {
-      const part = content[0];
-      if (
-        part &&
-        typeof part === "object" &&
-        !Array.isArray(part) &&
-        (part as JsonRecord).type === "text" &&
-        typeof (part as JsonRecord).text === "string"
-      ) {
-        (message as JsonRecord).content = (part as JsonRecord).text;
+  // plain string are semantically identical, so collapsing is safe there; real
+  // multi-part messages (text+image, text+file) are left untouched. Scoped to
+  // providers that declare `requiresPlainStringContent` — most OpenAI-compatible
+  // backends (and several existing tests) expect the standard array shape to
+  // survive translation unchanged.
+  if (collapseToPlainString) {
+    for (const message of messages) {
+      const content = (message as JsonRecord).content;
+      if (Array.isArray(content) && content.length === 1) {
+        const part = content[0];
+        if (
+          part &&
+          typeof part === "object" &&
+          !Array.isArray(part) &&
+          (part as JsonRecord).type === "text" &&
+          typeof (part as JsonRecord).text === "string"
+        ) {
+          (message as JsonRecord).content = (part as JsonRecord).text;
+        }
       }
     }
   }
 
   return result;
+}
+
+/**
+ * `model` is sometimes a bare provider id (e.g. "aihorde"), sometimes a
+ * provider-prefixed model string (e.g. "aihorde/aphrodite/..."), and often
+ * null/a bare model id with no provider info at all (the generic translator
+ * dispatcher passes model id alone; provider is tracked separately there).
+ * Only the first two carry a usable provider hint.
+ */
+function extractProviderHint(model: unknown): string {
+  if (typeof model !== "string" || model.length === 0) return "";
+  if (getRegisteredProviders().includes(model)) return model;
+  const prefix = model.split("/")[0];
+  return getRegisteredProviders().includes(prefix) ? prefix : "";
 }
 
 // Register both directions

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -716,6 +716,32 @@ export function openaiResponsesToOpenAIRequest(
     });
   }
 
+  // Every Responses-API input — even a plain string — gets wrapped upstream as a
+  // single-element content array (`[{ type: "input_text", text }]` via
+  // normalizeResponsesInputForChat), which this function maps straight through to
+  // `content: [{ type: "text", text }]`. That's spec-valid (OpenAI's own API
+  // accepts both shapes) but several strict/naive OpenAI-compatible backends only
+  // implement the plain-string form and reject the array form with a 500 — hit
+  // live via AI Horde's Aphrodite facade rejecting every /v1/responses request,
+  // including the simplest single-string input. A single-text-part array and a
+  // plain string are semantically identical, so collapsing is safe; real
+  // multi-part messages (text+image, text+file) are left untouched.
+  for (const message of messages) {
+    const content = (message as JsonRecord).content;
+    if (Array.isArray(content) && content.length === 1) {
+      const part = content[0];
+      if (
+        part &&
+        typeof part === "object" &&
+        !Array.isArray(part) &&
+        (part as JsonRecord).type === "text" &&
+        typeof (part as JsonRecord).text === "string"
+      ) {
+        (message as JsonRecord).content = (part as JsonRecord).text;
+      }
+    }
+  }
+
   return result;
 }
 

--- a/src/lib/modelCapabilities.ts
+++ b/src/lib/modelCapabilities.ts
@@ -15,6 +15,7 @@ import { MODELS_DEV_PROVIDER_MAP } from "@/lib/modelsDevSync/transform";
 import { getModelContextOverride } from "@/lib/db/modelContextOverrides";
 import { getModelCapabilityOverride } from "@/lib/db/modelCapabilityOverrides";
 import { isVisionModelId } from "@/shared/constants/visionModels";
+import { getUnsupportedParams } from "@omniroute/open-sse/config/providerRegistry.ts";
 
 const TOOL_CALLING_UNSUPPORTED_PATTERNS: string[] = [
   // Specialty / non-chat surfaces must never inherit optimistic tool defaults (#8016)
@@ -466,10 +467,23 @@ export function getResolvedModelCapabilities(input: CapabilityInput): ResolvedMo
     ) || "";
   const reasoningDenied = !heuristicReasoning(lookupKey);
 
+  // Provider-level fallback: a live-discovered model (passthroughModels
+  // providers like AI Horde) has no per-model registry entry, synced
+  // capability, or static spec — every source above resolves to null, so
+  // toolCalling would otherwise fall through to heuristicToolCalling's
+  // optimistic default (true). Reuse the same unsupportedParams signal the
+  // request-time strip already relies on: if the provider declares "tools"
+  // unsupported for every model it serves, that's authoritative here too.
+  const providerDeniesTools =
+    resolved.provider && resolved.model
+      ? getUnsupportedParams(resolved.provider, resolved.model).includes("tools")
+      : false;
+
   const supportsTools =
     synced?.tool_call ??
     (typeof registryModel?.toolCalling === "boolean" ? registryModel.toolCalling : null) ??
-    (typeof spec?.supportsTools === "boolean" ? spec.supportsTools : null);
+    (typeof spec?.supportsTools === "boolean" ? spec.supportsTools : null) ??
+    (providerDeniesTools ? false : null);
 
   const supportsThinking = reasoningDenied
     ? false

--- a/tests/integration/aihorde-load-test.test.ts
+++ b/tests/integration/aihorde-load-test.test.ts
@@ -1,0 +1,288 @@
+/**
+ * tests/integration/aihorde-load-test.test.ts
+ *
+ * Deeper load test for AI Horde (aihorde.net) — a free, crowdsourced,
+ * kudos-priority-queued inference network — asking whether it's viable as
+ * an addition/alternative to the "default" combo (currently 2 Gemini
+ * gemma-4 targets, see DEFAULT_COMBO_CONFIG in liveGeminiShared.ts).
+ * Anonymous access (key "0000000000") gets the LOWEST queue priority and
+ * 0 starting kudos, so this specifically probes whether that translates to
+ * unacceptable latency/reliability for combo-style traffic, or whether it
+ * holds up.
+ *
+ * Three angles, all against the anonymous no-auth `aihorde` provider:
+ *   1. Sequential reliability — all 25 CASE_BUILDERS, one at a time, with
+ *      full latency distribution (p50/p90/max) on gemma-4-31b (the same
+ *      model family the real "default" combo runs, for a fair comparison).
+ *   2. Concurrent load — does firing several requests at once cause queue
+ *      pile-up/timeouts, given combo routing doesn't pace requests apart?
+ *   3. Cross-model spot-check — same handful of cases against the other 2
+ *      viable aihorde models, since a combo pool needs multiple healthy
+ *      targets, not just one.
+ *
+ * Report, not a gate: kudos-priority queueing is a genuine, permanent
+ * property of anonymous AI Horde access, not a bug — a model or two being
+ * slow is data for the "is this viable" question, not a regression.
+ *
+ * Environment:
+ *   OMNIROUTE_API_KEY  — required (else test skips)
+ *   OMNIROUTE_URL      — defaults to http://localhost:3000
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { skip, CASE_BUILDERS, ensureTestEnvironment } from "./liveGeminiShared.ts";
+import {
+  benchmarkRequest,
+  benchmarkTpmStress,
+  summarize,
+  formatBenchmarkTable,
+  BENCHMARK_CASES,
+  type FreeModelSpec,
+  type BenchmarkResult,
+  type ModelBenchmarkSummary,
+} from "./freeModelBenchmarkShared.ts";
+
+const GEMMA_4 = {
+  provider: "aihorde",
+  model: "aihorde/google/gemma-4-31b",
+  displayName: "Gemma 4 31B (AI Horde)",
+};
+const OTHER_MODELS: FreeModelSpec[] = [
+  {
+    provider: "aihorde",
+    model: "aihorde/aphrodite/TheDrummer/Cydonia-24B-v4.3",
+    displayName: "Cydonia 24B (AI Horde)",
+  },
+  {
+    provider: "aihorde",
+    model: "aihorde/aphrodite/TheDrummer/Skyfall-31B-v4.2",
+    displayName: "Skyfall 31B (AI Horde)",
+  },
+];
+
+// Bigger/more-capable candidates found via AI Horde's live status API
+// (https://aihorde.net/api/v2/status/models?type=text — the 3 models above
+// are just a static passthrough-discovery fallback, not the full live
+// roster). Behemoth-X-123B has a healthy 8-worker pool; deepseek-v4-flash
+// is the real DeepSeek V4 family but only had 1 worker online at discovery
+// time, so expect it to be the fragile one of the two.
+const NEW_CAPABLE_MODELS: FreeModelSpec[] = [
+  {
+    provider: "aihorde",
+    model: "aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    displayName: "Behemoth-X 123B (AI Horde)",
+  },
+  {
+    provider: "aihorde",
+    model: "aihorde/deepseek/deepseek-v4-flash",
+    displayName: "DeepSeek V4 Flash (AI Horde)",
+  },
+];
+
+const CONCURRENT_THREADS = 4;
+const SPOT_CHECK_CASE_COUNT = 4;
+
+test.before(async () => {
+  await ensureTestEnvironment();
+});
+
+function percentile(sortedMs: number[], p: number): number {
+  if (sortedMs.length === 0) return 0;
+  const idx = Math.min(sortedMs.length - 1, Math.ceil((p / 100) * sortedMs.length) - 1);
+  return sortedMs[Math.max(0, idx)];
+}
+
+test(
+  "AI Horde: sequential reliability across all 25 workload cases (gemma-4-31b)",
+  { skip },
+  async () => {
+    console.log(
+      `\n  AI Horde sequential: ${CASE_BUILDERS.length} cases, anonymous key, gemma-4-31b\n`
+    );
+
+    const results: BenchmarkResult[] = [];
+    for (const tc of CASE_BUILDERS) {
+      const r = await benchmarkRequest(GEMMA_4, tc.name, tc.build, 90_000);
+      results.push(r);
+      console.log(
+        `  [${r.ok ? "OK  " : "FAIL"}] ${tc.name.padEnd(40)} HTTP ${r.status} | ${r.durationMs}ms | ${r.tokens} tok` +
+          (r.error ? ` | ${r.error}` : "")
+      );
+    }
+
+    const succeeded = results.filter((r) => r.ok);
+    const durations = results.map((r) => r.durationMs).sort((a, b) => a - b);
+    const successRate = Math.round((succeeded.length / results.length) * 100);
+
+    console.log(
+      `\n  Sequential summary: ${succeeded.length}/${results.length} succeeded (${successRate}%) | ` +
+        `p50=${percentile(durations, 50)}ms p90=${percentile(durations, 90)}ms max=${durations[durations.length - 1]}ms\n`
+    );
+
+    assert.ok(
+      succeeded.length > 0,
+      "every sequential request failed — likely a harness/routing bug"
+    );
+  }
+);
+
+test(
+  "AI Horde: concurrent load — does anonymous queueing degrade under parallel requests?",
+  { skip },
+  async () => {
+    console.log(
+      `\n  AI Horde concurrent: ${CONCURRENT_THREADS} parallel requests, anonymous key, gemma-4-31b\n`
+    );
+
+    const start = performance.now();
+    const results = await Promise.all(
+      Array.from({ length: CONCURRENT_THREADS }, (_, i) =>
+        benchmarkRequest(
+          GEMMA_4,
+          `concurrent-${i + 1}`,
+          () => CASE_BUILDERS[i % CASE_BUILDERS.length].build(),
+          120_000
+        )
+      )
+    );
+    const wallClockMs = Math.round(performance.now() - start);
+
+    for (const r of results) {
+      console.log(
+        `  [${r.ok ? "OK  " : "FAIL"}] ${r.case.padEnd(20)} HTTP ${r.status} | ${r.durationMs}ms | ${r.tokens} tok` +
+          (r.error ? ` | ${r.error}` : "")
+      );
+    }
+
+    const succeeded = results.filter((r) => r.ok);
+    console.log(
+      `\n  Concurrent summary: ${succeeded.length}/${results.length} succeeded | ${wallClockMs}ms wall clock ` +
+        `(vs sum of individual durations: ${results.reduce((s, r) => s + r.durationMs, 0)}ms — a wall clock close to ` +
+        `the sum means requests queued rather than ran in parallel)\n`
+    );
+
+    assert.ok(
+      succeeded.length > 0,
+      "every concurrent request failed — likely a harness/routing bug"
+    );
+  }
+);
+
+test(
+  "AI Horde: cross-model spot-check — is more than one model viable for a combo pool?",
+  { skip },
+  async () => {
+    console.log(
+      `\n  AI Horde cross-model: ${OTHER_MODELS.length} models × ${SPOT_CHECK_CASE_COUNT} cases\n`
+    );
+
+    for (const spec of OTHER_MODELS) {
+      const results: BenchmarkResult[] = [];
+      for (let i = 0; i < SPOT_CHECK_CASE_COUNT; i++) {
+        const tc = CASE_BUILDERS[i];
+        const r = await benchmarkRequest(spec, tc.name, tc.build, 90_000);
+        results.push(r);
+        console.log(
+          `  [${r.ok ? "OK  " : "FAIL"}] ${spec.displayName.padEnd(28)} ${tc.name.padEnd(35)} ` +
+            `HTTP ${r.status} | ${r.durationMs}ms | ${r.tokens} tok` +
+            (r.error ? ` | ${r.error}` : "")
+        );
+      }
+      const succeeded = results.filter((r) => r.ok).length;
+      console.log(`  --> ${spec.displayName}: ${succeeded}/${results.length} succeeded\n`);
+    }
+  }
+);
+
+// #note: a live smoke test showed aihorde/google/gemma-4-31b narrates tool
+// calls in plain text ("`write_file` with `path=...`") instead of emitting a
+// real tool_calls array, finish_reason "stop" — no native/emulated
+// tool-calling support for this model through OmniRoute today. A genuine
+// tool-calling "agentic loop" (like live-gemini-agentic-loop.test.ts) isn't
+// viable here, so this asks the underlying question directly instead: can
+// AI Horde sustain ~60k tokens/minute of large-context throughput, the kind
+// of volume a real agentic session's growing context would generate?
+const SUSTAINED_TARGET_TOKENS_PER_PROMPT = 13_000;
+const SUSTAINED_ROUNDS = 5; // 5 × 13k ≈ 65k tokens sent, back-to-back
+
+test(
+  "AI Horde: sustained large-context throughput — can it hit ~60k tokens/minute?",
+  { skip },
+  async () => {
+    console.log(
+      `\n  AI Horde sustained throughput: ${SUSTAINED_ROUNDS} × ~${SUSTAINED_TARGET_TOKENS_PER_PROMPT} ` +
+        `estimated-token prompts, back-to-back, targeting ~60k tokens/minute\n`
+    );
+
+    const start = performance.now();
+    const results = await benchmarkTpmStress(
+      GEMMA_4,
+      SUSTAINED_TARGET_TOKENS_PER_PROMPT,
+      SUSTAINED_ROUNDS,
+      120_000
+    );
+    const wallClockMs = Math.round(performance.now() - start);
+
+    for (const r of results) {
+      console.log(
+        `  [${r.ok ? "OK  " : "FAIL"}] ${r.case.padEnd(45)} HTTP ${r.status} | ${r.durationMs}ms | ${r.tokens} tok` +
+          (r.error ? ` | ${r.error}` : "")
+      );
+    }
+
+    const succeeded = results.filter((r) => r.ok);
+    // AI Horde doesn't report usage tokens (confirmed 0 across every prior test
+    // in this file), so use the same ~4 chars/token estimate genHugeContextMessage
+    // itself is built on, applied to every ATTEMPTED prompt (not just successful
+    // ones) — an attempted-but-failed send still occupied the queue's time.
+    const estimatedTokensSent = results.length * SUSTAINED_TARGET_TOKENS_PER_PROMPT;
+    const achievedTpm = Math.round((estimatedTokensSent / wallClockMs) * 60_000);
+
+    console.log(
+      `\n  Sustained summary: ${succeeded.length}/${results.length} succeeded | ${wallClockMs}ms wall clock | ` +
+        `~${estimatedTokensSent} tokens sent | achieved ~${achievedTpm} tokens/minute ` +
+        `(target: 60000)\n`
+    );
+
+    assert.ok(
+      succeeded.length > 0,
+      "every sustained-throughput request failed — likely a harness/routing bug"
+    );
+  }
+);
+
+test(
+  "AI Horde: new capable model candidates — workload test (Behemoth-X 123B, DeepSeek V4 Flash)",
+  { skip },
+  async () => {
+    console.log(
+      `\n  AI Horde new candidates: ${NEW_CAPABLE_MODELS.length} models × ${BENCHMARK_CASES.length} workload case(s) ` +
+        `— the same 5-case slice every other benchmarked model was run through, for a direct comparison\n`
+    );
+
+    const summaries: ModelBenchmarkSummary[] = [];
+
+    for (const spec of NEW_CAPABLE_MODELS) {
+      const results: BenchmarkResult[] = [];
+      for (const tc of BENCHMARK_CASES) {
+        const r = await benchmarkRequest(spec, tc.name, tc.build, 120_000);
+        results.push(r);
+        console.log(
+          `  [${r.ok ? "OK  " : "FAIL"}] ${spec.displayName.padEnd(30)} ${tc.name.padEnd(35)} ` +
+            `HTTP ${r.status} | ${r.durationMs}ms | ${r.tokens} tok` +
+            (r.error ? ` | ${r.error}` : "")
+        );
+      }
+      summaries.push(summarize(spec, results));
+    }
+
+    console.log(formatBenchmarkTable(summaries));
+
+    const totalSucceeded = summaries.reduce((s, m) => s + m.succeeded, 0);
+    assert.ok(
+      totalSucceeded > 0,
+      "every request to both new candidates failed — likely a harness/routing bug"
+    );
+  }
+);

--- a/tests/unit/aihorde-tools-unsupported-provider-fallback.test.ts
+++ b/tests/unit/aihorde-tools-unsupported-provider-fallback.test.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getUnsupportedParams } from "../../open-sse/config/providerRegistry.ts";
+
+// Live incident: after adding aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1
+// to the "default" combo, real OpenClaw traffic carrying a 25-tool schema hit a
+// 500 Internal Server Error from AI Horde's Aphrodite backend on every attempt.
+// The pipeline artifact showed `tools` still present, unstripped, in the request
+// actually sent upstream (providerRequest.body.tools).
+//
+// Root cause: `unsupportedParams: ["tools", "tool_choice", "parallel_tool_calls"]`
+// is declared on the 3 models statically listed in the aihorde registry entry
+// (Cydonia-24B, Skyfall-31B, google/gemma-4-31b) — but AI Horde uses
+// `passthroughModels: true` (its live worker roster changes constantly), so
+// Behemoth-X-123B — like every other dynamically-discovered aihorde model — has
+// NO model-specific unsupportedParams entry at all, and getUnsupportedParams()
+// returned [] for it, so tools never got stripped. But the limitation
+// ("the workers run raw text-completion backends") is true of every model AI
+// Horde serves, not just the 3 statically catalogued ones.
+const { aihordeProvider } =
+  await import("../../open-sse/config/providers/registry/aihorde/index.ts");
+
+test("aihorde registry entry declares a provider-level unsupportedParams fallback", () => {
+  assert.deepEqual(aihordeProvider.unsupportedParams, [
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+  ]);
+});
+
+test("getUnsupportedParams strips tools for a dynamically-discovered aihorde model with no static entry", () => {
+  const result = getUnsupportedParams("aihorde", "aphrodite/TheDrummer/Behemoth-X-123B-v2.1");
+  assert.deepEqual(result, ["tools", "tool_choice", "parallel_tool_calls"]);
+});
+
+test("getUnsupportedParams strips tools for any other live-discovered aihorde model (deepseek-v4-flash)", () => {
+  const result = getUnsupportedParams("aihorde", "deepseek/deepseek-v4-flash");
+  assert.deepEqual(result, ["tools", "tool_choice", "parallel_tool_calls"]);
+});
+
+test("getUnsupportedParams still returns the per-model entry for a statically-catalogued aihorde model", () => {
+  // Cydonia-24B already had its own model-level unsupportedParams before this
+  // fix — the provider-level fallback must not change that, only fill the gap
+  // for models with no per-model entry.
+  const result = getUnsupportedParams("aihorde", "aphrodite/TheDrummer/Cydonia-24B-v4.3");
+  assert.deepEqual(result, ["tools", "tool_choice", "parallel_tool_calls"]);
+});
+
+test("getUnsupportedParams provider-level fallback does not leak to unrelated providers", () => {
+  assert.deepEqual(getUnsupportedParams("mistral", "mistral-small-latest"), []);
+});

--- a/tests/unit/chatcore-tool-calling-required-check.test.ts
+++ b/tests/unit/chatcore-tool-calling-required-check.test.ts
@@ -1,0 +1,56 @@
+// tests/unit/chatcore-tool-calling-required-check.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { checkToolCallingRequiredButUnsupported } from "../../open-sse/handlers/chatCore/toolCallingRequiredCheck.ts";
+
+test("blocks a direct request that needs tools on a model that can't do tool calling", () => {
+  const body = { model: "x", tools: [{ type: "function", function: { name: "exec" } }] };
+  const result = checkToolCallingRequiredButUnsupported(
+    body,
+    ["tools", "tool_choice", "parallel_tool_calls"],
+    false,
+    "aphrodite/TheDrummer/Behemoth-X-123B-v2.1"
+  );
+  assert.equal(result.blocked, true);
+  assert.match(result.message!, /does not support tool calling/);
+  assert.match(result.message!, /Behemoth-X-123B-v2\.1/);
+});
+
+test("does not block a combo request — filterTargetsByRequestCompatibility already keeps this target out", () => {
+  const body = { model: "x", tools: [{ type: "function", function: { name: "exec" } }] };
+  const result = checkToolCallingRequiredButUnsupported(
+    body,
+    ["tools", "tool_choice", "parallel_tool_calls"],
+    true, // isCombo
+    "aphrodite/TheDrummer/Behemoth-X-123B-v2.1"
+  );
+  assert.equal(result.blocked, false);
+});
+
+test("does not block when the model supports tools (tools not in unsupported list)", () => {
+  const body = { model: "x", tools: [{ type: "function", function: { name: "exec" } }] };
+  const result = checkToolCallingRequiredButUnsupported(body, ["temperature"], false, "gpt-4o");
+  assert.equal(result.blocked, false);
+});
+
+test("does not block when the current request has no live tools array (stale history is handled by flattening, not a hard error)", () => {
+  const body = { model: "x", messages: [{ role: "tool", content: "leftover" }] };
+  const result = checkToolCallingRequiredButUnsupported(
+    body,
+    ["tools", "tool_choice", "parallel_tool_calls"],
+    false,
+    "aphrodite/TheDrummer/Behemoth-X-123B-v2.1"
+  );
+  assert.equal(result.blocked, false);
+});
+
+test("does not block when tools is present but empty", () => {
+  const body = { model: "x", tools: [] };
+  const result = checkToolCallingRequiredButUnsupported(
+    body,
+    ["tools"],
+    false,
+    "aphrodite/TheDrummer/Behemoth-X-123B-v2.1"
+  );
+  assert.equal(result.blocked, false);
+});

--- a/tests/unit/chatcore-unsupported-params-strip.test.ts
+++ b/tests/unit/chatcore-unsupported-params-strip.test.ts
@@ -1,0 +1,76 @@
+// tests/unit/chatcore-unsupported-params-strip.test.ts
+// Extracted from handleChatCore (chatCore god-file decomposition).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripUnsupportedParams } from "../../open-sse/handlers/chatCore/unsupportedParamsStrip.ts";
+
+test("strips each unsupported param present on the body", () => {
+  const body: Record<string, unknown> = { model: "x", tools: [{ x: 1 }], tool_choice: "auto" };
+  const result = stripUnsupportedParams(body, ["tools", "tool_choice", "parallel_tool_calls"]);
+  assert.deepEqual(result.strippedParams, ["tools", "tool_choice"]);
+  assert.equal(Object.hasOwn(body, "tools"), false);
+  assert.equal(Object.hasOwn(body, "tool_choice"), false);
+  assert.equal(body.model, "x");
+});
+
+test("no-op when the body has none of the unsupported params", () => {
+  const body: Record<string, unknown> = { model: "x", messages: [] };
+  const result = stripUnsupportedParams(body, ["tools", "tool_choice"]);
+  assert.deepEqual(result.strippedParams, []);
+  assert.deepEqual(body, { model: "x", messages: [] });
+});
+
+// Live incident: AI Horde 500'd on real combo traffic even after tools/tool_choice
+// were stripped from the live request, because prior-turn tool_calls/tool-result
+// messages were still in the history — a raw completion backend chokes on those
+// message shapes regardless of whether live `tools` is present.
+test("flattens tool_calls/tool-result messages in history when tools was stripped", () => {
+  const body: Record<string, unknown> = {
+    model: "aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    tools: [{ type: "function", function: { name: "exec" } }],
+    messages: [
+      { role: "user", content: "run the script" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { id: "call_1", type: "function", function: { name: "exec", arguments: "{}" } },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "output here" },
+      { role: "user", content: "what happened?" },
+    ],
+  };
+
+  const result = stripUnsupportedParams(body, ["tools", "tool_choice", "parallel_tool_calls"]);
+  assert.deepEqual(result.strippedParams, ["tools"]);
+
+  const messages = body.messages as Array<Record<string, unknown>>;
+  assert.equal(messages.length, 4);
+  // No message may keep role:"tool" or an assistant tool_calls array — that's
+  // exactly the shape AI Horde's backend 500'd on.
+  for (const m of messages) {
+    assert.notEqual(m.role, "tool");
+    assert.equal(m.tool_calls, undefined);
+  }
+  assert.equal(messages[0].content, "run the script");
+  assert.ok(String(messages[1].content).includes("Called tools: exec"));
+  assert.ok(String(messages[2].content).includes("Tool result: output here"));
+  assert.equal(messages[3].content, "what happened?");
+});
+
+test("does not touch messages when tools was NOT among the unsupported/stripped params", () => {
+  const originalMessages = [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: null, tool_calls: [{ id: "c1", function: { name: "x" } }] },
+  ];
+  const body: Record<string, unknown> = {
+    model: "x",
+    temperature: 2,
+    messages: originalMessages,
+  };
+  stripUnsupportedParams(body, ["temperature"]);
+  // messages array must be untouched (same reference, tool_calls survives) —
+  // this model DOES support tools, only temperature was unsupported.
+  assert.equal(body.messages, originalMessages);
+});

--- a/tests/unit/chatcore-unsupported-params-strip.test.ts
+++ b/tests/unit/chatcore-unsupported-params-strip.test.ts
@@ -59,6 +59,41 @@ test("flattens tool_calls/tool-result messages in history when tools was strippe
   assert.equal(messages[3].content, "what happened?");
 });
 
+// Live incident, round 2: the FIRST live reproduction happened to include a
+// live `tools` array alongside the stale history, which masked this gap. A
+// second live request had NO `tools` param at all — just the leftover
+// tool_calls/tool-result messages — and still 500'd, because the flattening
+// was gated on "tools" having actually been present-and-stripped THIS
+// request, not on whether the model supports tool calling at all. A model
+// that can't do tool calling can't do it regardless of whether this
+// particular request happens to carry a live `tools` array.
+test("flattens tool history even when the CURRENT request has no live tools param at all", () => {
+  const body: Record<string, unknown> = {
+    model: "aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    // no `tools` key on this request — only stale history from before failover
+    messages: [
+      { role: "user", content: "run the script" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { id: "call_1", type: "function", function: { name: "exec", arguments: "{}" } },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "output here" },
+      { role: "user", content: "what happened?" },
+    ],
+  };
+
+  stripUnsupportedParams(body, ["tools", "tool_choice", "parallel_tool_calls"]);
+
+  const messages = body.messages as Array<Record<string, unknown>>;
+  for (const m of messages) {
+    assert.notEqual(m.role, "tool");
+    assert.equal(m.tool_calls, undefined);
+  }
+});
+
 test("does not touch messages when tools was NOT among the unsupported/stripped params", () => {
   const originalMessages = [
     { role: "user", content: "hi" },

--- a/tests/unit/model-capabilities-provider-unsupported-tools.test.ts
+++ b/tests/unit/model-capabilities-provider-unsupported-tools.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getResolvedModelCapabilities } from "../../src/lib/modelCapabilities.ts";
+
+// Live incident: aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1 (a
+// dynamically-discovered AI Horde model, not statically catalogued) got
+// selected as a combo target for a tool-heavy conversation and narrated a
+// fake tool call in prose instead of erroring or being skipped. Root cause:
+// getResolvedModelCapabilities()'s `supportsTools` resolution only checks
+// per-model registry entries and synced/static specs — none of which exist
+// for a live-discovered model — so it falls through to `heuristicToolCalling`,
+// which optimistically defaults to `true` for any unrecognized model string
+// (TOOL_CALLING_UNSUPPORTED_PATTERNS is empty). That's wrong for providers
+// like AI Horde whose registry entry already declares a provider-wide
+// `unsupportedParams: ["tools", ...]` (added for the strip/flatten fix) —
+// this fix reuses that same signal here so capability-based combo filtering
+// (filterTargetsByRequestCompatibility in comboStructure.ts) actually skips
+// these targets for tool-bearing requests instead of guessing wrong.
+test("a dynamically-discovered aihorde model resolves toolCalling: false via the provider-level unsupportedParams fallback", () => {
+  const caps = getResolvedModelCapabilities("aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1");
+  assert.equal(caps.toolCalling, false);
+  assert.equal(caps.supportsTools, false);
+});
+
+test("any other live-discovered aihorde model also resolves toolCalling: false", () => {
+  const caps = getResolvedModelCapabilities("aihorde/deepseek/deepseek-v4-flash");
+  assert.equal(caps.toolCalling, false);
+});
+
+test("a statically-catalogued aihorde model keeps its explicit per-model toolCalling: false", () => {
+  const caps = getResolvedModelCapabilities("aihorde/aphrodite/TheDrummer/Cydonia-24B-v4.3");
+  assert.equal(caps.toolCalling, false);
+});
+
+test("the provider-level fallback does not affect providers with no unsupportedParams declaration", () => {
+  const caps = getResolvedModelCapabilities("mistral/mistral-small-latest");
+  // Mistral's real models genuinely support tools; heuristic default (true)
+  // should still apply since Mistral has no provider-level unsupportedParams.
+  assert.equal(caps.toolCalling, true);
+});

--- a/tests/unit/openai-responses-single-text-content-string.test.ts
+++ b/tests/unit/openai-responses-single-text-content-string.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Live incident: a real request through /v1/responses to a strict OpenAI-compatible
+// upstream (AI Horde's Aphrodite-backed facade, oai.aihorde.net) got a 500 Internal
+// Server Error for every message, including the simplest possible single-string
+// input. Root cause: normalizeResponsesInputForChat() always wraps a plain string
+// input as `content: [{ type: "input_text", text: value }]` (array of ONE part),
+// and openaiResponsesToOpenAIRequest() maps that straight through to
+// `content: [{ type: "text", text: value }]` — an array — never collapsing it back
+// to a plain string. That's spec-valid per OpenAI's own API (which accepts both
+// shapes), but several strict/naive OpenAI-compatible backends only implement the
+// plain-string form for single-part text messages and reject the array form
+// outright. A single-text-part array and a plain string are semantically
+// identical, so collapsing is safe and doesn't affect real multi-part (text+image,
+// text+file) messages, which must stay arrays.
+const { openaiResponsesToOpenAIRequest } =
+  await import("../../open-sse/translator/request/openai-responses.ts");
+
+type ChatMsg = { role: string; content?: unknown };
+
+test("Responses -> OpenAI: plain string input collapses to string content, not a single-part array", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    { input: "Say OK." },
+    false,
+    {}
+  ) as { messages: ChatMsg[] };
+
+  const userMsg = result.messages.find((m) => m.role === "user");
+  assert.ok(userMsg, "expected a user message");
+  assert.equal(typeof userMsg!.content, "string", "expected a plain string, got an array/object");
+  assert.equal(userMsg!.content, "Say OK.");
+});
+
+test("Responses -> OpenAI: single-part input_text array input also collapses to a string", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hi there" }] },
+      ],
+    },
+    false,
+    {}
+  ) as { messages: ChatMsg[] };
+
+  const userMsg = result.messages.find((m) => m.role === "user");
+  assert.equal(typeof userMsg!.content, "string");
+  assert.equal(userMsg!.content, "hi there");
+});
+
+test("Responses -> OpenAI: multi-turn conversation collapses every single-text-part message", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "question one" }] },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "answer one" }],
+        },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "question two" }] },
+      ],
+    },
+    false,
+    {}
+  ) as { messages: ChatMsg[] };
+
+  const turnMessages = result.messages.filter((m) => m.role === "user" || m.role === "assistant");
+  assert.equal(turnMessages.length, 3);
+  for (const m of turnMessages) {
+    assert.equal(typeof m.content, "string", `expected string content for role ${m.role}`);
+  }
+  assert.equal(turnMessages[0].content, "question one");
+  assert.equal(turnMessages[1].content, "answer one");
+  assert.equal(turnMessages[2].content, "question two");
+});
+
+test("Responses -> OpenAI: real multi-part content (text + image) is NOT collapsed", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "aihorde/aphrodite/TheDrummer/Behemoth-X-123B-v2.1",
+    {
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "what is this?" },
+            { type: "input_image", image_url: "https://example.com/cat.png" },
+          ],
+        },
+      ],
+    },
+    false,
+    {}
+  ) as { messages: ChatMsg[] };
+
+  const userMsg = result.messages.find((m) => m.role === "user");
+  assert.ok(Array.isArray(userMsg!.content), "multi-part content must stay an array");
+  assert.equal((userMsg!.content as unknown[]).length, 2);
+});


### PR DESCRIPTION
## Summary

A cascade of related fixes found while debugging live tool-calling failures against AI Horde (a provider whose models run raw text-completion backends — no tool calling on any model):

1. **Collapse single-text-part Responses-API content to a plain string.** Every Responses-API input — even a plain string — gets wrapped upstream as a single-element content array. That's spec-valid, but AI Horde's Aphrodite facade rejects the array form with a 500 for every request, including the simplest single-string input.
2. **`unsupportedParams` provider-level fallback for AI Horde's live-discovered models.** AI Horde's model roster changes as volunteer workers come and go (`passthroughModels: true`), so a live-discovered model with no static per-model entry was sending `tools` straight through and getting a 500 — added a provider-wide fallback so *any* AI Horde model, not just the 3 statically catalogued ones, correctly strips `tools`.
3. **Flatten leftover tool-call history when stripping unsupported tools** (two commits — the first version only flattened when the *current* request had a live `tools` param; a second live repro showed stale `role: "tool"` history with no live `tools` key still 500'd, so the gate was corrected to key off the model's capability, not the current request's shape).
4. **Skip tool-incapable combo targets, error clearly on direct requests.** Combo routing now correctly filters out models that can't do tool calling when the request needs it, and a direct/pinned request to a tool-incapable model with live tools now gets a clean `400 tool_calling_not_supported` instead of the model silently narrating instead of calling tools (or crashing).
5. **Scope the Responses single-text-content collapse to providers that actually need it.** The (1) fix above was applied unconditionally to every provider, which silently broke the standard OpenAI array-shaped content contract other providers (and existing tests) depend on. Added a `requiresPlainStringContent` registry flag (true only for `aihorde`) and threaded provider identity through the translator call chain so the workaround only applies where it's actually needed.

## Test plan

- [x] `tests/unit/openai-responses-single-text-content-string.test.ts` (4 tests), `tests/unit/aihorde-tools-unsupported-provider-fallback.test.ts` (3 tests), `tests/unit/chatcore-unsupported-params-strip.test.ts`, `tests/unit/chatcore-tool-calling-required-check.test.ts`, `tests/unit/model-capabilities-provider-unsupported-tools.test.ts` — all new, TDD (RED before each fix, GREEN after), 23 tests total, all passing.
- [x] `tests/integration/aihorde-load-test.test.ts` — live load/reliability test against AI Horde (skips without `OMNIROUTE_API_KEY`).
- [x] Full existing Responses-API translator regression suite passes, no regressions from the content-collapse scoping.
- [x] `npm run typecheck:core` and `eslint` clean on every file this PR touches.