### PR TITLE
[needs-vps] fix(kiro): align with native IDE APIs

### DIFF
--- a/open-sse/config/providerHeaderProfiles.ts
+++ b/open-sse/config/providerHeaderProfiles.ts
@@ -17,8 +17,8 @@ export const QWEN_STAINLESS_LANG = "js";
 
 export const QODER_DEFAULT_USER_AGENT = "Qoder-Cli";
 
-export const KIRO_SDK_USER_AGENT = "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0";
-export const KIRO_AMZ_USER_AGENT = "aws-sdk-js/3.0.0 kiro-ide/1.0.0";
+export const KIRO_SDK_USER_AGENT = "aws-sdk-js/1.0.0 KiroIDE-1.0.116";
+export const KIRO_AMZ_USER_AGENT = "aws-sdk-js/1.0.0 KiroIDE-1.0.116";
 export const KIRO_STREAMING_TARGET =
   "AmazonCodeWhispererStreamingService.GenerateAssistantResponse";
 
@@ -145,6 +145,8 @@ export function getKiroServiceHeaders(
     "X-Amz-Target": KIRO_STREAMING_TARGET,
     "User-Agent": KIRO_SDK_USER_AGENT,
     "X-Amz-User-Agent": KIRO_AMZ_USER_AGENT,
+    "x-amzn-kiro-agent-mode": "vibe",
+    "x-amzn-codewhisperer-optout": "true",
   };
 }
 

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 import {
   BaseExecutor,
   mergeUpstreamExtraHeaders,
@@ -6,7 +8,9 @@ import {
   type ProviderCredentials,
 } from "./base.ts";
 import { PROVIDERS } from "../config/constants.ts";
-import { v4 as uuidv4 } from "uuid";
+import { KIRO_STREAMING_TARGET } from "../config/providerHeaderProfiles.ts";
+import { buildKiroClientHeaders } from "../services/kiroClientProfile.ts";
+import { kiroRuntimeHost, resolveKiroRuntimeRegion } from "../services/kiroRegion.ts";
 import { refreshKiroToken } from "../services/tokenRefresh.ts";
 import {
   isExternalIdpAuthMethod,
@@ -19,7 +23,6 @@ import {
   type KiroThinkingState,
 } from "./kiroThinking.ts";
 import { ByteQueue, TEXT_ENCODER, parseEventFrame } from "./kiro/eventstream.ts";
-import { kiroRuntimeHost, resolveKiroRuntimeRegion } from "../services/kiroRegion.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -189,10 +192,13 @@ export class KiroExecutor extends BaseExecutor {
     void stream;
     const headers = {
       ...this.config.headers,
+      ...buildKiroClientHeaders(
+        credentials.providerSpecificData,
+        credentials.accessToken || credentials.apiKey || "",
+        "runtime"
+      ),
       "Amz-Sdk-Request": "attempt=1; max=3",
       "Amz-Sdk-Invocation-Id": uuidv4(),
-      "x-amzn-bedrock-cache-control": "enable",
-      "anthropic-beta": "prompt-caching-2024-07-31",
     };
 
     const authMethod =
@@ -263,12 +269,21 @@ export class KiroExecutor extends BaseExecutor {
     log,
     upstreamExtraHeaders,
   }: ExecuteInput) {
-    // Route to the region-specific CodeWhisperer/Amazon Q endpoint. Enterprise IAM Identity
-    // Center accounts (e.g. eu-central-1) are rejected by the default us-east-1 host; only the
-    // regional endpoint accepts the region-bound token + profileArn.
+    // Current Kiro IDE accounts use the regional native runtime. Keep the legacy
+    // CodeWhisperer/Amazon Q host for Amazon Q and long-lived Kiro API keys.
     const region = resolveKiroRegion(credentials);
-    const url = `${kiroRuntimeHost(region)}/generateAssistantResponse`;
+    const authMethod = credentials.providerSpecificData?.authMethod;
+    const useLegacyRuntime = this.provider === "amazon-q" || authMethod === "api_key";
+    const baseUrl = useLegacyRuntime
+      ? kiroRuntimeHost(region)
+      : `https://runtime.${region}.kiro.dev`;
+    const url = `${baseUrl}/generateAssistantResponse`;
     const headers = this.buildHeaders(credentials, stream);
+    if (useLegacyRuntime) {
+      headers["X-Amz-Target"] = KIRO_STREAMING_TARGET;
+    } else {
+      delete headers["X-Amz-Target"];
+    }
     mergeUpstreamExtraHeaders(headers, upstreamExtraHeaders);
     const transformedBody = await this.transformRequest(model, body, stream, credentials);
 

--- a/open-sse/services/kiroClientProfile.ts
+++ b/open-sse/services/kiroClientProfile.ts
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { platform, release } from "node:os";
+
+type JsonRecord = Record<string, unknown>;
+
+export const KIRO_IDE_VERSION = "1.0.116";
+export const KIRO_SDK_VERSION = "1.0.0";
+
+const nodeRequire = createRequire(import.meta.url);
+let nativeMachineIdSync: (() => string) | null = null;
+try {
+  const module = nodeRequire("node-machine-id") as {
+    machineIdSync?: () => string;
+    default?: { machineIdSync?: () => string };
+  };
+  nativeMachineIdSync = module.machineIdSync || module.default?.machineIdSync || null;
+} catch {
+  nativeMachineIdSync = null;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function kiroMachineId(providerSpecificData: unknown, accessToken: string): string {
+  const data = asRecord(providerSpecificData);
+  try {
+    const native = nonEmptyString(nativeMachineIdSync?.());
+    if (native && /^[a-f0-9]{64}$/i.test(native)) return native.toLowerCase();
+  } catch {
+    // Fall through to a deterministic connection-derived id.
+  }
+
+  const persisted = nonEmptyString(data.kiroMachineId) || nonEmptyString(data.machineId);
+  if (persisted && /^[a-f0-9]{64}$/i.test(persisted)) return persisted.toLowerCase();
+
+  const seed =
+    persisted ||
+    nonEmptyString(data.clientId) ||
+    nonEmptyString(data.profileArn) ||
+    accessToken ||
+    "kiro-anonymous";
+  return createHash("sha256").update(seed).digest("hex");
+}
+
+export function buildKiroClientHeaders(
+  providerSpecificData: unknown,
+  accessToken: string,
+  service: "runtime" | "control-plane"
+): Record<string, string> {
+  const machineId = kiroMachineId(providerSpecificData, accessToken);
+  const customUserAgent = `KiroIDE-${KIRO_IDE_VERSION}-${machineId}`;
+  const serviceId = service === "runtime" ? "kiroruntime" : "kirocontrolplanebearer";
+  const nodeVersion = process.versions?.node || process.version?.replace(/^v/, "") || "unknown";
+  const userAgent =
+    `aws-sdk-js/${KIRO_SDK_VERSION} ua/2.1 ` +
+    `os/${platform()}#${release()} lang/js md/nodejs#${nodeVersion} ` +
+    `api/${serviceId}#${KIRO_SDK_VERSION} m/N,E ${customUserAgent}`;
+
+  return {
+    "User-Agent": userAgent,
+    "X-Amz-User-Agent": `aws-sdk-js/${KIRO_SDK_VERSION} ${customUserAgent}`,
+    "x-amzn-codewhisperer-optout": "true",
+    ...(service === "runtime" ? { "x-amzn-kiro-agent-mode": "vibe" } : {}),
+  };
+}

--- a/open-sse/services/kiroModels.ts
+++ b/open-sse/services/kiroModels.ts
@@ -4,18 +4,17 @@
  * Kiro's model catalog is per-account / per-tier — the free tier, Pro, Pro+ and
  * Power plans expose different model sets, and AWS IAM Identity Center (enterprise)
  * orgs further restrict it to an admin-curated "approved models" list. The Kiro
- * IDE / CLI populates its model picker by calling the CodeWhisperer
- * `ListAvailableModels` operation:
+ * IDE populates its model picker from the Kiro control plane, with the legacy
+ * Amazon Q endpoint retained as a compatibility fallback:
  *
- *   GET https://q.{region}.amazonaws.com/ListAvailableModels?origin=AI_EDITOR
+ *   GET https://management.{region}.kiro.dev/List-Available-Models?origin=AI_EDITOR
  *   Authorization: Bearer <accessToken>
  *   → { models: [ { modelId, modelName?, tokenLimits?: { maxInputTokens } }, ... ] }
  *
  * This works for both "simple" Builder ID / social logins and AWS IAM Identity
  * Center accounts:
- *   - `origin=AI_EDITOR` alone is the universal call (Builder ID / IdC).
- *   - `profileArn` is only sent for desktop-style accounts that have one, and only
- *     as a retry, because sending it for Builder ID can yield 403.
+ *   - `origin=AI_EDITOR` alone is used when the connection has no profile ARN.
+ *   - `profileArn` is sent on the first request when the IDE persisted one.
  *   - The endpoint is region-matched (IdC tokens are region-bound, e.g.
  *     eu-central-1) with a us-east-1 fallback (the legacy CodeWhisperer home region).
  *
@@ -27,15 +26,11 @@ import { createHash } from "node:crypto";
 
 import { v4 as uuidv4 } from "uuid";
 
+import { buildKiroClientHeaders } from "./kiroClientProfile.ts";
 import { resolveKiroRuntimeRegion } from "./kiroRegion.ts";
 
 type RawRecord = Record<string, unknown>;
 
-const KIRO_RUNTIME_SDK_VERSION = "1.0.0";
-const KIRO_AGENT_OS = "windows";
-const KIRO_AGENT_OS_VERSION = "10.0.26200";
-const KIRO_NODE_VERSION = "22.21.1";
-const KIRO_IDE_VERSION = "0.10.32";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 const catalogCache = new Map<string, { expiresAt: number; models: KiroModel[] }>();
@@ -50,17 +45,19 @@ function toNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function toPositiveNumber(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export type KiroModel = {
   id: string;
   name: string;
   owned_by: string;
-  capabilities?: {
-    thinking: boolean;
-    agentic: boolean;
-  };
   contextLength?: number;
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
   rateMultiplier?: number;
-  upstreamModelId?: string;
   description?: string;
 };
 
@@ -92,98 +89,23 @@ export function parseKiroModels(data: unknown): KiroModel[] {
     if (!id || seen.has(id)) continue;
     seen.add(id);
     const name = toNonEmptyString(item.modelName) || toNonEmptyString(item.name) || id;
-    models.push({ id, name, owned_by: "kiro" });
+    const tokenLimits = asRecord(item.tokenLimits);
+    const inputTokenLimit = toPositiveNumber(tokenLimits.maxInputTokens);
+    const outputTokenLimit = toPositiveNumber(tokenLimits.maxOutputTokens);
+    const rateMultiplier = toPositiveNumber(item.rateMultiplier);
+    const description = toNonEmptyString(item.description);
+    models.push({
+      id,
+      name,
+      owned_by: "kiro",
+      ...(inputTokenLimit ? { contextLength: inputTokenLimit, inputTokenLimit } : {}),
+      ...(outputTokenLimit ? { outputTokenLimit } : {}),
+      ...(rateMultiplier ? { rateMultiplier } : {}),
+      ...(description ? { description } : {}),
+    });
   }
 
   return models;
-}
-
-function stripSyntheticSuffixes(id: string): string {
-  let out = id;
-  if (out.endsWith("-agentic")) out = out.slice(0, -"-agentic".length);
-  if (out.endsWith("-thinking")) out = out.slice(0, -"-thinking".length);
-  return out;
-}
-
-function formatDisplayName(modelName: unknown, modelId: string, rateMultiplier: unknown): string {
-  const base = toNonEmptyString(modelName) || modelId;
-  const rate = Number(rateMultiplier);
-  if (!Number.isFinite(rate) || Math.abs(rate - 1.0) < 1e-9 || rate <= 0) {
-    return `Kiro ${base}`;
-  }
-  return `Kiro ${base} (${rate.toFixed(1)}x credit)`;
-}
-
-function buildVariants(upstream: string, displayName: string): KiroModel[] {
-  const safeUpstream = stripSyntheticSuffixes(upstream);
-  const display = displayName || `Kiro ${safeUpstream}`;
-  const isAuto = safeUpstream === "auto" || safeUpstream === "auto-kiro";
-  const variants: KiroModel[] = [
-    {
-      id: safeUpstream,
-      name: display,
-      owned_by: "kiro",
-      capabilities: { thinking: false, agentic: false },
-    },
-    {
-      id: `${safeUpstream}-thinking`,
-      name: `${display} (Thinking)`,
-      owned_by: "kiro",
-      capabilities: { thinking: true, agentic: false },
-    },
-  ];
-
-  if (!isAuto) {
-    variants.push({
-      id: `${safeUpstream}-agentic`,
-      name: `${display} (Agentic)`,
-      owned_by: "kiro",
-      capabilities: { thinking: false, agentic: true },
-    });
-    variants.push({
-      id: `${safeUpstream}-thinking-agentic`,
-      name: `${display} (Thinking + Agentic)`,
-      owned_by: "kiro",
-      capabilities: { thinking: true, agentic: true },
-    });
-  }
-
-  return variants;
-}
-
-function expandKiroModels(data: unknown): KiroModel[] {
-  const payload = asRecord(data);
-  const items = Array.isArray(payload.models)
-    ? (payload.models as unknown[])
-    : Array.isArray(payload.availableModels)
-      ? (payload.availableModels as unknown[])
-      : [];
-  const expanded: KiroModel[] = [];
-  const seen = new Set<string>();
-
-  for (const value of items) {
-    const item = asRecord(value);
-    const upstreamId = toNonEmptyString(item.modelId) || toNonEmptyString(item.id);
-    if (!upstreamId) continue;
-    const display = formatDisplayName(item.modelName || item.name, upstreamId, item.rateMultiplier);
-    const tokenLimits = asRecord(item.tokenLimits);
-    const contextLength = Number(tokenLimits.maxInputTokens) || 200000;
-    const rateMultiplier = Number(item.rateMultiplier);
-
-    for (const variant of buildVariants(upstreamId, display)) {
-      if (seen.has(variant.id)) continue;
-      seen.add(variant.id);
-      expanded.push({
-        ...variant,
-        contextLength,
-        rateMultiplier: Number.isFinite(rateMultiplier) ? rateMultiplier : 1.0,
-        upstreamModelId: upstreamId,
-        description: toNonEmptyString(item.description) || "",
-      });
-    }
-  }
-
-  return expanded;
 }
 
 /**
@@ -205,7 +127,10 @@ export function resolveKiroRegion(providerSpecificData: unknown): string {
  */
 export function buildKiroModelsEndpoints(region: string): string[] {
   const normalized = (toNonEmptyString(region) || "us-east-1").toLowerCase();
-  const urls: string[] = [`https://q.${normalized}.amazonaws.com/ListAvailableModels`];
+  const urls: string[] = [
+    `https://management.${normalized}.kiro.dev/List-Available-Models`,
+    `https://q.${normalized}.amazonaws.com/ListAvailableModels`,
+  ];
   if (normalized !== "us-east-1") {
     urls.push("https://q.us-east-1.amazonaws.com/ListAvailableModels");
   }
@@ -241,25 +166,8 @@ function toFallbackResult(
 }
 
 function buildKiroFingerprintHeaders(providerSpecificData: unknown, accessToken: string) {
-  const psd = asRecord(providerSpecificData);
-  const seed =
-    toNonEmptyString(psd.clientId) ||
-    toNonEmptyString(psd.profileArn) ||
-    accessToken ||
-    "kiro-anonymous";
-  const machineId = createHash("sha256").update(String(seed)).digest("hex");
-  const userAgent =
-    `aws-sdk-js/${KIRO_RUNTIME_SDK_VERSION} ua/2.1 ` +
-    `os/${KIRO_AGENT_OS}#${KIRO_AGENT_OS_VERSION} ` +
-    `lang/js md/nodejs#${KIRO_NODE_VERSION} ` +
-    `api/codewhispererruntime#${KIRO_RUNTIME_SDK_VERSION} m/N,E ` +
-    `KiroIDE-${KIRO_IDE_VERSION}-${machineId}`;
-
   return {
-    "User-Agent": userAgent,
-    "x-amz-user-agent": `aws-sdk-js/${KIRO_RUNTIME_SDK_VERSION} KiroIDE-${KIRO_IDE_VERSION}-${machineId}`,
-    "x-amzn-kiro-agent-mode": "vibe",
-    "x-amzn-codewhisperer-optout": "true",
+    ...buildKiroClientHeaders(providerSpecificData, accessToken, "control-plane"),
     "amz-sdk-request": "attempt=1; max=1",
     "amz-sdk-invocation-id": uuidv4(),
     Accept: "application/json",
@@ -292,7 +200,7 @@ async function tryFetchModels(
     });
     if (!response.ok) return null;
     const data = await response.json();
-    const models = expandKiroModels(data);
+    const models = parseKiroModels(data);
     return models.length > 0 ? models : null;
   } catch {
     return null;
@@ -303,11 +211,10 @@ async function tryFetchModels(
  * Discover the Kiro model catalog live via `ListAvailableModels`, falling back
  * to the static catalog when no token is available or every attempt fails.
  *
- * Attempt order (stops at the first success):
- *   1. `origin=AI_EDITOR` on each region-matched endpoint — universal path that
- *      works for Builder ID / social ("simple") and IAM Identity Center accounts.
- *   2. `origin=AI_EDITOR&profileArn=...` on the primary endpoint, only when a
- *      profileArn is present (desktop-style accounts that require it).
+ * Attempt order stops at the first success: Kiro management first, then the
+ * region-matched Amazon Q endpoint and its us-east-1 fallback. A stored
+ * profileArn is included from the first request because current Kiro IDE social
+ * accounts reject an origin-only request as invalid.
  */
 export async function fetchKiroAvailableModels(
   options: FetchKiroModelsOptions
@@ -329,26 +236,13 @@ export async function fetchKiroAvailableModels(
   const endpoints = buildKiroModelsEndpoints(region);
   const profileArn = toNonEmptyString(asRecord(providerSpecificData).profileArn);
 
-  // Pass 1: origin-only (works for Builder ID / social / IdC).
-  for (const base of endpoints) {
-    const models = await tryFetchModels(
-      fetchImpl,
-      `${base}?origin=AI_EDITOR`,
-      token,
-      providerSpecificData
-    );
-    if (models) {
-      catalogCache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, models });
-      return { models, source: "api" };
-    }
-  }
+  const query = new URLSearchParams({
+    origin: "AI_EDITOR",
+    ...(profileArn ? { profileArn } : {}),
+  });
 
-  // Pass 2: retry with profileArn (desktop accounts that require it) on the
-  // region-matched endpoint only. Skipped for Builder ID / IdC where sending a
-  // profileArn can 403.
-  if (profileArn) {
-    const url = `${endpoints[0]}?origin=AI_EDITOR&profileArn=${encodeURIComponent(profileArn)}`;
-    const models = await tryFetchModels(fetchImpl, url, token, providerSpecificData);
+  for (const base of endpoints) {
+    const models = await tryFetchModels(fetchImpl, `${base}?${query}`, token, providerSpecificData);
     if (models) {
       catalogCache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, models });
       return { models, source: "api" };

--- a/open-sse/services/usage/kiro.ts
+++ b/open-sse/services/usage/kiro.ts
@@ -11,18 +11,21 @@
  * getKiroUsage into __testing. Behavior-preserving move.
  */
 
-import { toRecord, toNumber } from "./scalars.ts";
-import { type UsageQuota, parseResetTime } from "./quota.ts";
-import {
-  discoverKiroProfileArnAcrossRegions,
-  kiroRuntimeHost,
-  resolveKiroRuntimeRegion,
-} from "../kiroRegion.ts";
+import { v4 as uuidv4 } from "uuid";
+
+import { buildKiroClientHeaders } from "../kiroClientProfile.ts";
 import {
   isExternalIdpAuthMethod,
   KIRO_EXTERNAL_IDP_TOKEN_TYPE_HEADER,
   KIRO_EXTERNAL_IDP_TOKEN_TYPE_VALUE,
 } from "../kiroExternalIdp.ts";
+import {
+  discoverKiroProfileArnAcrossRegions,
+  kiroRuntimeHost,
+  resolveKiroRuntimeRegion,
+} from "../kiroRegion.ts";
+import { type UsageQuota, parseResetTime } from "./quota.ts";
+import { toRecord, toNumber } from "./scalars.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -163,7 +166,8 @@ export async function discoverKiroProfileArn(
 }
 
 /**
- * The three GetUsageLimits attempts (CodeWhisperer POST, regional GET, Q GET) tried in
+ * The native Kiro management request followed by the three legacy GetUsageLimits attempts
+ * (CodeWhisperer POST, regional GET, Q GET) tried in
  * order by getKiroUsage — extracted so the auth-method header variants (api_key
  * `tokentype`, external_idp `TokenType`) stay in one authHeaders object and the parent
  * function stays under the function-length gate.
@@ -180,14 +184,37 @@ export async function discoverKiroProfileArn(
  */
 function buildKiroUsageAttempts(opts: {
   authHeaders: Record<string, string>;
+  managementUrl?: string;
+  managementHeaders?: Record<string, string>;
   usageParams: URLSearchParams;
   qParams: URLSearchParams;
   payload: Record<string, unknown>;
   usageBaseUrl: string;
   qBaseUrl: string;
 }): Array<{ name: string; run: () => Promise<Response> }> {
-  const { authHeaders, usageParams, qParams, payload, usageBaseUrl, qBaseUrl } = opts;
+  const {
+    authHeaders,
+    managementUrl,
+    managementHeaders,
+    usageParams,
+    qParams,
+    payload,
+    usageBaseUrl,
+    qBaseUrl,
+  } = opts;
   return [
+    ...(managementUrl
+      ? [
+          {
+            name: "kiro-management-get",
+            run: () =>
+              fetch(managementUrl, {
+                method: "GET",
+                headers: managementHeaders,
+              }),
+          },
+        ]
+      : []),
     {
       name: "codewhisperer-post",
       run: () =>
@@ -246,6 +273,62 @@ function buildKiroAuthHeaders(
     authHeaders[KIRO_EXTERNAL_IDP_TOKEN_TYPE_HEADER] = KIRO_EXTERNAL_IDP_TOKEN_TYPE_VALUE;
   }
   return authHeaders;
+}
+
+function createKiroUsageAttempts(opts: {
+  accessToken?: string;
+  authHeaders: Record<string, string>;
+  isApiKey: boolean;
+  profileArn?: string;
+  providerSpecificData?: JsonRecord;
+  region: string;
+}): Array<{ name: string; run: () => Promise<Response> }> {
+  const { accessToken, authHeaders, isApiKey, profileArn, providerSpecificData, region } = opts;
+  const usageParams = new URLSearchParams({
+    isEmailRequired: "true",
+    origin: "AI_EDITOR",
+    resourceType: "AGENTIC_REQUEST",
+  });
+  const qParams = new URLSearchParams({
+    origin: "AI_EDITOR",
+    ...(profileArn ? { profileArn } : {}),
+    resourceType: "AGENTIC_REQUEST",
+  });
+  const payload = {
+    origin: "AI_EDITOR",
+    ...(profileArn ? { profileArn } : {}),
+    resourceType: "AGENTIC_REQUEST",
+  };
+  const managementParams = new URLSearchParams({
+    ...(profileArn ? { profileArn } : {}),
+    origin: "AI_EDITOR",
+    resourceType: "AGENTIC_REQUEST",
+    isEmailRequired: "true",
+  });
+  const managementUrl =
+    profileArn && !isApiKey
+      ? `https://management.${region}.kiro.dev/Get-Usage-Limits?${managementParams}`
+      : undefined;
+  const managementHeaders = managementUrl
+    ? {
+        ...authHeaders,
+        ...buildKiroClientHeaders(providerSpecificData, accessToken || "", "control-plane"),
+        "amz-sdk-request": "attempt=1; max=1",
+        "amz-sdk-invocation-id": uuidv4(),
+      }
+    : undefined;
+  const usageBaseUrl = region === "us-east-1" ? CODEWHISPERER_BASE_URL : kiroRuntimeHost(region);
+
+  return buildKiroUsageAttempts({
+    authHeaders,
+    managementUrl,
+    managementHeaders,
+    usageParams,
+    qParams,
+    payload,
+    usageBaseUrl,
+    qBaseUrl: `https://q.${region}.amazonaws.com`,
+  });
 }
 
 /**
@@ -324,34 +407,14 @@ export async function getKiroUsage(accessToken?: string, providerSpecificData?: 
     // The RUNTIME region is the profileArn region (us-east-1 / eu-central-1), never the IdC token
     // region. Route GetUsageLimits to that region's host so quota resolves for cross-region IdC.
     const region = resolveKiroRuntimeRegion({ region: storedRegion, profileArn });
-    const usageBaseUrl = region === "us-east-1" ? CODEWHISPERER_BASE_URL : kiroRuntimeHost(region);
-    const qBaseUrl = `https://q.${region}.amazonaws.com`;
-
     const authHeaders = buildKiroAuthHeaders(accessToken, isApiKey, providerSpecificData);
-
-    const usageParams = new URLSearchParams({
-      isEmailRequired: "true",
-      origin: "AI_EDITOR",
-      resourceType: "AGENTIC_REQUEST",
-    });
-    const qParams = new URLSearchParams({
-      origin: "AI_EDITOR",
-      ...(profileArn ? { profileArn } : {}),
-      resourceType: "AGENTIC_REQUEST",
-    });
-    const payload = {
-      origin: "AI_EDITOR",
-      ...(profileArn ? { profileArn } : {}),
-      resourceType: "AGENTIC_REQUEST",
-    };
-
-    const attempts = buildKiroUsageAttempts({
+    const attempts = createKiroUsageAttempts({
+      accessToken,
       authHeaders,
-      usageParams,
-      qParams,
-      payload,
-      usageBaseUrl,
-      qBaseUrl,
+      isApiKey,
+      profileArn,
+      providerSpecificData,
+      region,
     });
 
     const outcome = await runKiroUsageAttempts(attempts);
@@ -384,9 +447,7 @@ export async function getKiroUsage(accessToken?: string, providerSpecificData?: 
     // HTTP-status failure (most informative) over a network-level error.
     throw new Error(
       outcome.lastHttpFailure ||
-        (errors.length > 0
-          ? errors[errors.length - 1]
-          : "no usage endpoint responded")
+        (errors.length > 0 ? errors[errors.length - 1] : "no usage endpoint responded")
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -395,14 +456,14 @@ export async function getKiroUsage(accessToken?: string, providerSpecificData?: 
 }
 
 /**
- * Was this Kiro connection added via the Google/GitHub social-auth device flow
- * (POST /api/oauth/kiro/social-exchange)? That route persists
- * `{ authMethod: "imported", provider: "Google" | "Github" }` on the connection.
- * Builder-ID / IDC / kiro-cli imports use different markers and should keep the
- * existing throw-on-failure behavior.
+ * Was this Kiro connection added via Google/GitHub social auth? The legacy
+ * social-exchange route persists `imported`, while current Kiro IDE auto-import
+ * preserves the upstream `social` marker.
  */
 function isSocialAuthKiroAccount(providerSpecificData?: JsonRecord): boolean {
-  if (!providerSpecificData || providerSpecificData.authMethod !== "imported") return false;
+  if (!providerSpecificData) return false;
+  const authMethod = String(providerSpecificData.authMethod || "").toLowerCase();
+  if (authMethod !== "imported" && authMethod !== "social") return false;
   const provider =
     typeof providerSpecificData.provider === "string"
       ? providerSpecificData.provider.toLowerCase()

--- a/src/app/api/oauth/kiro/auto-import/route.ts
+++ b/src/app/api/oauth/kiro/auto-import/route.ts
@@ -111,8 +111,7 @@ async function tryKiroCliSqlite(): Promise<{
         for (const table of ["auth_kv", "ItemTable", "storage"]) {
           try {
             const row = db.prepare(`SELECT value FROM ${table} WHERE key = ?`).get(key) as
-              | { value: string }
-              | undefined;
+              { value: string } | undefined;
             if (row?.value) {
               try {
                 tokenData = JSON.parse(row.value);
@@ -139,8 +138,7 @@ async function tryKiroCliSqlite(): Promise<{
         for (const table of ["auth_kv", "ItemTable", "storage"]) {
           try {
             const row = db.prepare(`SELECT value FROM ${table} WHERE key = ?`).get(key) as
-              | { value: string }
-              | undefined;
+              { value: string } | undefined;
             if (row?.value) {
               try {
                 regData = JSON.parse(row.value);
@@ -262,11 +260,13 @@ async function tryAwsSsoCache(targetProvider: string): Promise<{
   triedPath?: string;
   refreshToken?: string;
   accessToken?: string | null;
+  expiresAt?: string | null;
   source?: string;
   clientId?: string | null;
   clientSecret?: string | null;
   region?: string | null;
   authMethod?: string | null;
+  provider?: string | null;
   profileArn?: string | null;
   tokenEndpoint?: string | null;
   scopes?: string | string[] | null;
@@ -302,6 +302,30 @@ async function tryAwsSsoCache(targetProvider: string): Promise<{
         !!data.refreshToken &&
         (isExternalIdpAuthMethod(data.authMethod) ||
           String(data.provider || "").toLowerCase() === "externalidp");
+
+      const isSocial =
+        !!data.refreshToken && String(data.authMethod || "").toLowerCase() === "social";
+
+      if (isSocial) {
+        const profileArn =
+          (typeof data.profileArn === "string" && data.profileArn.trim()) ||
+          (await readKiroIdeProfileArn());
+        const arnRegion =
+          typeof profileArn === "string"
+            ? profileArn.match(/^arn:aws:codewhisperer:([a-z0-9-]+):/)?.[1]
+            : undefined;
+        return {
+          found: true,
+          source: file,
+          refreshToken: data.refreshToken,
+          accessToken: data.accessToken || null,
+          expiresAt: data.expiresAt || null,
+          region: data.region || arnRegion || null,
+          authMethod: "social",
+          provider: typeof data.provider === "string" ? data.provider : null,
+          profileArn: profileArn || null,
+        };
+      }
 
       if (isExternalIdp) {
         const region: string | null = data.region || null;
@@ -455,6 +479,7 @@ type SaveAndRespondResult = Awaited<ReturnType<typeof tryKiroCliSqlite>> & {
   // Fields added by tryAwsSsoCache for External IdP (organization) tokens
   tokenEndpoint?: string | null;
   scopes?: string | string[] | null;
+  provider?: string | null;
 };
 
 async function saveAndRespond(
@@ -554,13 +579,17 @@ async function saveAndRespond(
     const resolvedAuthMethod =
       result.source === "kiro-cli-sqlite"
         ? "kiro-cli"
-        : result.clientId
-          ? result.authMethod || "idc"
-          : "imported";
+        : result.authMethod === "social"
+          ? "social"
+          : result.clientId
+            ? result.authMethod || "idc"
+            : "imported";
 
     const providerSpecificData: Record<string, any> = {
       authMethod: resolvedAuthMethod,
-      provider: result.source === "kiro-cli-sqlite" ? "kiro-cli SQLite" : "AWS SSO Cache",
+      provider:
+        result.provider ||
+        (result.source === "kiro-cli-sqlite" ? "kiro-cli SQLite" : "AWS SSO Cache"),
     };
 
     if (result.clientId) providerSpecificData.clientId = result.clientId;
@@ -571,7 +600,7 @@ async function saveAndRespond(
     // For the SSO-cache fallback path the token came from ~/.aws/sso/cache and has no
     // per-connection OIDC client. Register one now so this connection gets an isolated
     // refresh session (#2328). The SQLite path already sets result.clientId.
-    if (!result.clientId) {
+    if (!result.clientId && resolvedAuthMethod !== "social") {
       try {
         const reg = await runWithProxyContext(proxy, () => kiroService.registerClient());
         providerSpecificData.clientId = reg.clientId;

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -2913,25 +2913,31 @@
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0",
+        "User-Agent": "aws-sdk-js/1.0.0 KiroIDE-1.0.116",
         "X-Amz-Target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
-        "X-Amz-User-Agent": "aws-sdk-js/3.0.0 kiro-ide/1.0.0"
+        "X-Amz-User-Agent": "aws-sdk-js/1.0.0 KiroIDE-1.0.116",
+        "x-amzn-codewhisperer-optout": "true",
+        "x-amzn-kiro-agent-mode": "vibe"
       },
       "nonStream": {
         "Accept": "application/vnd.amazon.eventstream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0",
+        "User-Agent": "aws-sdk-js/1.0.0 KiroIDE-1.0.116",
         "X-Amz-Target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
-        "X-Amz-User-Agent": "aws-sdk-js/3.0.0 kiro-ide/1.0.0"
+        "X-Amz-User-Agent": "aws-sdk-js/1.0.0 KiroIDE-1.0.116",
+        "x-amzn-codewhisperer-optout": "true",
+        "x-amzn-kiro-agent-mode": "vibe"
       },
       "oauth": {
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0",
+        "User-Agent": "aws-sdk-js/1.0.0 KiroIDE-1.0.116",
         "X-Amz-Target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
-        "X-Amz-User-Agent": "aws-sdk-js/3.0.0 kiro-ide/1.0.0"
+        "X-Amz-User-Agent": "aws-sdk-js/1.0.0 KiroIDE-1.0.116",
+        "x-amzn-codewhisperer-optout": "true",
+        "x-amzn-kiro-agent-mode": "vibe"
       }
     },
     "url": {

--- a/tests/unit/executor-kiro.test.ts
+++ b/tests/unit/executor-kiro.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 
 import { KiroExecutor } from "../../open-sse/executors/kiro.ts";
 import { hasStreamReadinessSignal } from "../../open-sse/utils/streamReadiness.ts";
 
 const textEncoder = new TextEncoder();
+const { machineIdSync } = createRequire(import.meta.url)("node-machine-id") as {
+  machineIdSync: () => string;
+};
 
 function crc32(buf) {
   const table = new Uint32Array(256);
@@ -139,12 +143,39 @@ test("KiroExecutor.transformEventStreamToSSE emits an early role-only start chun
 
 test("KiroExecutor.buildHeaders includes Kiro-specific auth and metadata", () => {
   const executor = new KiroExecutor();
-  const headers = executor.buildHeaders({ accessToken: "kiro-token" }, true);
+  const headers = executor.buildHeaders(
+    {
+      accessToken: "kiro-token",
+      providerSpecificData: {
+        profileArn: "arn:aws:codewhisperer:us-east-1:123:profile/ABC",
+      },
+    },
+    true
+  );
 
   assert.equal(headers.Authorization, "Bearer kiro-token");
-  assert.equal(headers["anthropic-beta"], "prompt-caching-2024-07-31");
-  assert.equal(headers["x-amzn-bedrock-cache-control"], "enable");
+  assert.match(headers["User-Agent"], /aws-sdk-js\/1\.0\.0/);
+  assert.match(headers["User-Agent"], /api\/kiroruntime#1\.0\.0/);
+  assert.match(headers["User-Agent"], /KiroIDE-1\.0\.116-[a-f0-9]{64}$/);
+  assert.match(headers["X-Amz-User-Agent"], /KiroIDE-1\.0\.116-[a-f0-9]{64}$/);
+  assert.equal(headers["x-amzn-kiro-agent-mode"], "vibe");
+  assert.equal(headers["x-amzn-codewhisperer-optout"], "true");
+  assert.equal(headers["anthropic-beta"], undefined);
+  assert.equal(headers["x-amzn-bedrock-cache-control"], undefined);
   assert.ok(headers["Amz-Sdk-Invocation-Id"]);
+});
+
+test("KiroExecutor.buildHeaders uses the same native machine id as Kiro IDE", () => {
+  const executor = new KiroExecutor();
+  const headers = executor.buildHeaders(
+    {
+      accessToken: "kiro-token",
+      providerSpecificData: { kiroMachineId: "00000000-0000-0000-0000-000000000000" },
+    },
+    true
+  );
+
+  assert.ok(headers["User-Agent"].endsWith(`KiroIDE-1.0.116-${machineIdSync()}`));
 });
 
 test("KiroExecutor.buildHeaders marks long-lived Kiro API keys", () => {
@@ -337,6 +368,7 @@ test("KiroExecutor.execute returns upstream errors directly and transforms succe
   const executor = new KiroExecutor();
   const originalFetch = globalThis.fetch;
   const rawResponse = new Response("ok", { status: 200 });
+  const requestedUrls: string[] = [];
   let transformed = null;
   executor.transformEventStreamToSSE = (response, model) => {
     transformed = { response, model };
@@ -346,7 +378,10 @@ test("KiroExecutor.execute returns upstream errors directly and transforms succe
     });
   };
 
-  globalThis.fetch = async () => new Response("upstream error", { status: 429 });
+  globalThis.fetch = async (input) => {
+    requestedUrls.push(String(input));
+    return new Response("upstream error", { status: 429 });
+  };
   try {
     const errorResult = await executor.execute({
       model: "kiro-model",
@@ -355,6 +390,7 @@ test("KiroExecutor.execute returns upstream errors directly and transforms succe
       credentials: { accessToken: "kiro-token" },
     });
     assert.equal(errorResult.response.status, 429);
+    assert.equal(errorResult.url, "https://runtime.us-east-1.kiro.dev/generateAssistantResponse");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -371,6 +407,26 @@ test("KiroExecutor.execute returns upstream errors directly and transforms succe
     assert.equal(successResult.response.status, 200);
     assert.equal(transformed.response, rawResponse);
     assert.equal(transformed.model, "kiro-model");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  const amazonQExecutor = new KiroExecutor("amazon-q");
+  globalThis.fetch = async (input) => {
+    requestedUrls.push(String(input));
+    return new Response("upstream error", { status: 429 });
+  };
+  try {
+    const legacyResult = await amazonQExecutor.execute({
+      model: "kiro-model",
+      body: { conversationState: {} },
+      stream: true,
+      credentials: { accessToken: "kiro-token" },
+    });
+    assert.equal(
+      legacyResult.url,
+      "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse"
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/kiro-auto-import-idc-2059.test.ts
+++ b/tests/unit/kiro-auto-import-idc-2059.test.ts
@@ -49,6 +49,7 @@ const core = await import("../../src/lib/db/core.ts");
 const { GET } = await import("../../src/app/api/oauth/kiro/auto-import/route.ts");
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
 const ORIGINAL_APPDATA = process.env.APPDATA;
 const ORIGINAL_FETCH = globalThis.fetch;
 
@@ -60,6 +61,7 @@ test.beforeEach(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
   process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
   delete process.env.APPDATA;
   // Reset fetch so tests with mocks don't bleed into each other.
   globalThis.fetch = ORIGINAL_FETCH;
@@ -67,6 +69,11 @@ test.beforeEach(() => {
 
 test.afterEach(() => {
   process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_USERPROFILE !== undefined) {
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  } else {
+    delete process.env.USERPROFILE;
+  }
   if (ORIGINAL_APPDATA !== undefined) {
     process.env.APPDATA = ORIGINAL_APPDATA;
   } else {
@@ -346,6 +353,57 @@ test("auto-import: without clientIdHash, fallback still works and clientId/clien
     body.clientSecret === null || body.clientSecret === undefined,
     `clientSecret must be null/undefined when no clientIdHash, got: ${body.clientSecret}`
   );
+});
+
+test("auto-import: current Kiro IDE social cache preserves native identity fields", async () => {
+  const profileArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/SOCIAL";
+  writeAwsSsoCache({
+    tokenData: {
+      accessToken: "social-access-current",
+      refreshToken: "aorAAAAAGsocial-current",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      authMethod: "social",
+      provider: "Github",
+      profileArn,
+    },
+  });
+
+  const fetchedUrls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    fetchedUrls.push(url);
+    if (url.endsWith("/refreshToken")) {
+      return new Response(
+        JSON.stringify({
+          accessToken: "social-access-refreshed",
+          refreshToken: "aorAAAAAGsocial-refreshed",
+          expiresIn: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    if (url.endsWith("/client/register")) {
+      return new Response(JSON.stringify({ clientId: "must-not-register" }), { status: 200 });
+    }
+    throw new Error(`[kiro-social-current test] unexpected fetch to ${url}`);
+  }) as typeof fetch;
+
+  const { body } = await callGet();
+  assert.equal(body.found, true, `expected found:true, got: ${JSON.stringify(body)}`);
+  assert.equal(body.profileArn, profileArn);
+  assert.ok(fetchedUrls.some((url) => url.endsWith("/refreshToken")));
+  assert.equal(
+    fetchedUrls.some((url) => url.endsWith("/client/register")),
+    false,
+    "social imports must not register an unrelated AWS OIDC client"
+  );
+
+  const providersDb = await import("../../src/lib/db/providers.ts");
+  const [connection] = await providersDb.getProviderConnections({ provider: "kiro" });
+  const providerSpecificData = connection.providerSpecificData as Record<string, unknown>;
+  assert.equal(providerSpecificData.authMethod, "social");
+  assert.equal(providerSpecificData.provider, "Github");
+  assert.equal(providerSpecificData.profileArn, profileArn);
 });
 
 test("auto-import: clientIdHash present but registration file missing — gracefully continues without clientId", async () => {

--- a/tests/unit/kiro-available-models.test.ts
+++ b/tests/unit/kiro-available-models.test.ts
@@ -9,7 +9,7 @@ import {
   clearKiroModelCache,
 } from "../../open-sse/services/kiroModels.ts";
 
-const FALLBACK = [{ id: "auto-kiro", name: "Auto" }, { id: "claude-sonnet-4.6" }];
+const FALLBACK = [{ id: "auto-kiro", name: "Auto" }, { id: "claude-sonnet-4.5" }];
 
 beforeEach(() => {
   clearKiroModelCache();
@@ -25,19 +25,30 @@ function jsonResponse(body: unknown, status = 200): Response {
 test("parseKiroModels reads CodeWhisperer ListAvailableModels shape", () => {
   const models = parseKiroModels({
     models: [
-      { modelId: "auto", modelName: "Auto" },
-      { modelId: "claude-sonnet-4.6", modelName: "Claude Sonnet 4.6" },
-      { modelId: "claude-sonnet-4.6" }, // duplicate id is ignored
+      {
+        modelId: "auto",
+        modelName: "Auto",
+        description: "Automatically selects a model",
+        rateMultiplier: 1,
+        tokenLimits: { maxInputTokens: 1_000_000, maxOutputTokens: 64_000 },
+      },
+      { modelId: "claude-sonnet-4.5", modelName: "Claude Sonnet 4.5" },
+      { modelId: "claude-sonnet-4.5" }, // duplicate id is ignored
       { modelName: "no id" }, // missing id is skipped
     ],
   });
 
   assert.deepEqual(
     models.map((m) => m.id),
-    ["auto", "claude-sonnet-4.6"]
+    ["auto", "claude-sonnet-4.5"]
   );
-  assert.equal(models[1].name, "Claude Sonnet 4.6");
+  assert.equal(models[1].name, "Claude Sonnet 4.5");
   assert.equal(models[0].owned_by, "kiro");
+  assert.equal(models[0].contextLength, 1_000_000);
+  assert.equal(models[0].inputTokenLimit, 1_000_000);
+  assert.equal(models[0].outputTokenLimit, 64_000);
+  assert.equal(models[0].rateMultiplier, 1);
+  assert.equal(models[0].description, "Automatically selects a model");
 });
 
 test("resolveKiroRegion prefers stored region, then profileArn, else us-east-1", () => {
@@ -50,11 +61,13 @@ test("resolveKiroRegion prefers stored region, then profileArn, else us-east-1",
   assert.equal(resolveKiroRegion(null), "us-east-1");
 });
 
-test("buildKiroModelsEndpoints is region-matched with a us-east-1 fallback", () => {
+test("buildKiroModelsEndpoints prefers Kiro management and retains Amazon Q fallbacks", () => {
   assert.deepEqual(buildKiroModelsEndpoints("us-east-1"), [
+    "https://management.us-east-1.kiro.dev/List-Available-Models",
     "https://q.us-east-1.amazonaws.com/ListAvailableModels",
   ]);
   assert.deepEqual(buildKiroModelsEndpoints("eu-central-1"), [
+    "https://management.eu-central-1.kiro.dev/List-Available-Models",
     "https://q.eu-central-1.amazonaws.com/ListAvailableModels",
     "https://q.us-east-1.amazonaws.com/ListAvailableModels",
   ]);
@@ -62,9 +75,11 @@ test("buildKiroModelsEndpoints is region-matched with a us-east-1 fallback", () 
 
 test("fetchKiroAvailableModels: simple (Builder ID) account, us-east-1, origin-only", async () => {
   const calls: string[] = [];
-  const fetchImpl = (async (url: string) => {
+  let requestHeaders = new Headers();
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
     calls.push(url);
-    return jsonResponse({ models: [{ modelId: "claude-sonnet-4.6" }, { modelId: "auto" }] });
+    requestHeaders = new Headers(init?.headers);
+    return jsonResponse({ models: [{ modelId: "claude-sonnet-4.5" }, { modelId: "auto" }] });
   }) as unknown as typeof fetch;
 
   const result = await fetchKiroAvailableModels({
@@ -75,17 +90,14 @@ test("fetchKiroAvailableModels: simple (Builder ID) account, us-east-1, origin-o
   });
 
   assert.equal(result.source, "api");
-  assert.deepEqual(result.models.map((m) => m.id).sort(), [
-    "auto",
-    "auto-thinking",
-    "claude-sonnet-4.6",
-    "claude-sonnet-4.6-agentic",
-    "claude-sonnet-4.6-thinking",
-    "claude-sonnet-4.6-thinking-agentic",
-  ]);
+  assert.deepEqual(result.models.map((m) => m.id).sort(), ["auto", "claude-sonnet-4.5"]);
   assert.deepEqual(calls, [
-    "https://q.us-east-1.amazonaws.com/ListAvailableModels?origin=AI_EDITOR",
+    "https://management.us-east-1.kiro.dev/List-Available-Models?origin=AI_EDITOR",
   ]);
+  assert.match(requestHeaders.get("user-agent") || "", /api\/kirocontrolplanebearer#1\.0\.0/);
+  assert.match(requestHeaders.get("user-agent") || "", /KiroIDE-1\.0\.116-/);
+  assert.match(requestHeaders.get("x-amz-user-agent") || "", /KiroIDE-1\.0\.116-/);
+  assert.doesNotMatch(requestHeaders.get("user-agent") || "", /os\/windows#10\.0\.26200/);
 });
 
 test("fetchKiroAvailableModels: IAM Identity Center account, region-matched endpoint", async () => {
@@ -93,7 +105,7 @@ test("fetchKiroAvailableModels: IAM Identity Center account, region-matched endp
   const fetchImpl = (async (url: string) => {
     calls.push(url);
     // First (region-matched) endpoint succeeds.
-    return jsonResponse({ models: [{ modelId: "claude-opus-4.8", modelName: "Opus 4.8" }] });
+    return jsonResponse({ models: [{ modelId: "claude-haiku-4.5", modelName: "Haiku 4.5" }] });
   }) as unknown as typeof fetch;
 
   const result = await fetchKiroAvailableModels({
@@ -106,25 +118,20 @@ test("fetchKiroAvailableModels: IAM Identity Center account, region-matched endp
   assert.equal(result.source, "api");
   assert.deepEqual(
     result.models.map((m) => m.id),
-    [
-      "claude-opus-4.8",
-      "claude-opus-4.8-thinking",
-      "claude-opus-4.8-agentic",
-      "claude-opus-4.8-thinking-agentic",
-    ]
+    ["claude-haiku-4.5"]
   );
   assert.equal(
     calls[0],
-    "https://q.eu-central-1.amazonaws.com/ListAvailableModels?origin=AI_EDITOR"
+    "https://management.eu-central-1.kiro.dev/List-Available-Models?origin=AI_EDITOR"
   );
 });
 
-test("fetchKiroAvailableModels: retries with profileArn when origin-only fails", async () => {
+test("fetchKiroAvailableModels: sends a stored profileArn on the first management request", async () => {
   const calls: string[] = [];
   const fetchImpl = (async (url: string) => {
     calls.push(url);
     if (url.includes("profileArn=")) {
-      return jsonResponse({ models: [{ modelId: "claude-sonnet-4.6" }] });
+      return jsonResponse({ models: [{ modelId: "claude-sonnet-4.5" }] });
     }
     return jsonResponse({ message: "forbidden" }, 403);
   }) as unknown as typeof fetch;
@@ -142,17 +149,11 @@ test("fetchKiroAvailableModels: retries with profileArn when origin-only fails",
   assert.equal(result.source, "api");
   assert.deepEqual(
     result.models.map((m) => m.id),
-    [
-      "claude-sonnet-4.6",
-      "claude-sonnet-4.6-thinking",
-      "claude-sonnet-4.6-agentic",
-      "claude-sonnet-4.6-thinking-agentic",
-    ]
+    ["claude-sonnet-4.5"]
   );
-  // origin-only attempted first, then profileArn retry.
-  assert.equal(calls.length, 2);
-  assert.ok(calls[0].endsWith("?origin=AI_EDITOR"));
-  assert.ok(calls[1].includes("profileArn=arn%3Aaws%3Acodewhisperer"));
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].startsWith("https://management.us-east-1.kiro.dev/"));
+  assert.ok(calls[0].includes("profileArn=arn%3Aaws%3Acodewhisperer"));
 });
 
 test("fetchKiroAvailableModels: falls back to static catalog when no token", async () => {
@@ -164,7 +165,7 @@ test("fetchKiroAvailableModels: falls back to static catalog when no token", asy
   assert.equal(result.source, "fallback");
   assert.deepEqual(
     result.models.map((m) => m.id),
-    ["auto-kiro", "claude-sonnet-4.6"]
+    ["auto-kiro", "claude-sonnet-4.5"]
   );
 });
 
@@ -180,6 +181,6 @@ test("fetchKiroAvailableModels: falls back when every upstream attempt fails", a
   assert.equal(result.source, "fallback");
   assert.deepEqual(
     result.models.map((m) => m.id),
-    ["auto-kiro", "claude-sonnet-4.6"]
+    ["auto-kiro", "claude-sonnet-4.5"]
   );
 });

--- a/tests/unit/kiro-iam-profilearn-usage.test.ts
+++ b/tests/unit/kiro-iam-profilearn-usage.test.ts
@@ -131,10 +131,8 @@ test("discoverKiroProfileArn returns undefined for empty profiles or non-ok resp
   }
 });
 
-// Regression: when a Kiro account added via Google/GitHub social-auth (authMethod "imported"
-// with provider "Google" or "Github" — set by /api/oauth/kiro/social-exchange/route.ts) has its
-// token rejected by the AWS CodeWhisperer quota API (401/403), surface a clear "auth expired,
-// chat may still work" message instead of throwing a generic upstream-error blob.
+// Regression: both legacy social imports (`imported`) and current Kiro IDE imports (`social`)
+// must surface the same useful quota-auth message when the runtime token still works.
 test("getKiroUsage returns a friendly auth-expired message for social-auth Kiro on 401/403", async () => {
   const originalFetch = globalThis.fetch;
   // First call (ListAvailableProfiles for ARN discovery) succeeds with an ARN so we proceed
@@ -159,17 +157,20 @@ test("getKiroUsage returns a friendly auth-expired message for social-auth Kiro 
     });
   }) as typeof fetch;
   try {
-    const result = (await getKiroUsage("social-tok", {
-      authMethod: "imported",
-      provider: "Google",
-    })) as { message?: string; quotas?: Record<string, unknown> };
-    assert.ok(result, "should resolve, not throw");
-    assert.ok(
-      typeof result.message === "string" && /authentication expired/i.test(result.message),
-      `expected an auth-expired message, got: ${JSON.stringify(result)}`
-    );
-    assert.deepEqual(result.quotas ?? {}, {});
-    assert.ok(callIdx >= 2, "GetUsageLimits should have been called after profile discovery");
+    for (const authMethod of ["imported", "social"]) {
+      callIdx = 0;
+      const result = (await getKiroUsage("social-tok", {
+        authMethod,
+        provider: "Google",
+      })) as { message?: string; quotas?: Record<string, unknown> };
+      assert.ok(result, "should resolve, not throw");
+      assert.ok(
+        typeof result.message === "string" && /authentication expired/i.test(result.message),
+        `expected an auth-expired message for ${authMethod}, got: ${JSON.stringify(result)}`
+      );
+      assert.deepEqual(result.quotas ?? {}, {});
+      assert.ok(callIdx >= 2, "GetUsageLimits should have been called after profile discovery");
+    }
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/kiro-idc-cross-region.test.ts
+++ b/tests/unit/kiro-idc-cross-region.test.ts
@@ -257,10 +257,59 @@ test("getKiroUsage: eu-north-1 IdC account resolves quota via the eu-central-1 p
     assert.equal(result.quotas!.credit.total, 1000);
     // GetUsageLimits must have gone to the eu-central-1 runtime host, never q.eu-north-1.
     assert.ok(
-      requested.some((r) => r.includes("GetUsageLimits") && r.includes("eu-central-1")),
+      requested.some(
+        (r) =>
+          (r.includes("GetUsageLimits") || r.includes("Get-Usage-Limits")) &&
+          r.includes("eu-central-1")
+      ),
       `GetUsageLimits should hit eu-central-1, got: ${JSON.stringify(requested)}`
     );
     assert.ok(requested.every((r) => !r.includes("eu-north-1")));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getKiroUsage prefers the native Kiro management control plane", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; headers: Headers }> = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({ url: String(input), headers: new Headers(init?.headers) });
+    return new Response(
+      JSON.stringify({
+        subscriptionInfo: { subscriptionTitle: "Kiro Free" },
+        usageBreakdownList: [
+          {
+            resourceType: "CREDIT",
+            currentUsageWithPrecision: 2,
+            usageLimitWithPrecision: 50,
+          },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    const result = (await getKiroUsage("social-token", {
+      authMethod: "social",
+      provider: "Github",
+      profileArn: EU_CENTRAL_ARN,
+    })) as { plan?: string; quotas?: Record<string, { used: number; total: number }> };
+
+    assert.equal(result.plan, "Kiro Free");
+    assert.equal(result.quotas?.credit.used, 2);
+    assert.equal(
+      requests[0].url,
+      "https://management.eu-central-1.kiro.dev/Get-Usage-Limits?" +
+        "profileArn=arn%3Aaws%3Acodewhisperer%3Aeu-central-1%3A820374639727%3Aprofile%2FRX4VNUHGHGAQ&" +
+        "origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true"
+    );
+    assert.match(
+      requests[0].headers.get("user-agent") || "",
+      /api\/kirocontrolplanebearer#1\.0\.0/
+    );
+    assert.match(requests[0].headers.get("user-agent") || "", /KiroIDE-1\.0\.116-/);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary

Extracted from #6958 as the Kiro only change set.

- Align native IDE request headers and runtime identity.
- Select regional runtime and control-plane endpoints consistently.
- Make model discovery account-aware while preserving the VPS-confirmed static fallback catalog.
- Preserve reasoning content across the provider request and response path.
- Add focused discovery, executor, OAuth, and routing regression coverage.

## Why

The Kiro integration had drifted from the native IDE API contract across identity, region selection, discovery, and reasoning transport.

## Impact

This changes Kiro provider behavior only and can merge independently.

## Validation

- npm run typecheck:core
- 141 focused Kiro discovery, header, OAuth, usage, catalog, and routing tests
- git diff --check
