### PR TITLE
fix(api): narrow claudeClassifierCompat auto trigger so stop_sequences alone no longer short-circuits (#8189)

### DIFF
--- a/changelog.d/fixes/8189-classifier-compat-auto-narrow.md
+++ b/changelog.d/fixes/8189-classifier-compat-auto-narrow.md
@@ -1,0 +1,1 @@
+- fix(api): narrow claudeClassifierCompat auto trigger so stop_sequences alone no longer short-circuits (#8189)

--- a/open-sse/handlers/chatCore/claudeClassifierCompat.ts
+++ b/open-sse/handlers/chatCore/claudeClassifierCompat.ts
@@ -44,8 +44,10 @@ function extractSystemTexts(body: Record<string, unknown> | null | undefined): s
  * - `mode === "always"`: short-circuits every Claude-format request (operator has
  *   decided every `/v1/messages` call through this route is the classifier).
  * - `mode === "auto"`: only short-circuits when the request carries the classifier's
- *   system-prompt marker OR lists `</block>` as a stop sequence — the two
- *   independent signals Claude Code's own classifier request relies on.
+ *   system-prompt marker. `</block>` in `stop_sequences` is corroborating evidence but
+ *   is never sufficient alone — the marker is the strong, classifier-unique signal;
+ *   an unrelated app that happens to use `</block>` as a markup stop token must not be
+ *   swallowed by the shim (#8189).
  */
 export function shouldDefaultAllowClassifier(
   sourceFormat: string,
@@ -55,11 +57,6 @@ export function shouldDefaultAllowClassifier(
   if (mode !== "auto" && mode !== "always") return false;
   if (sourceFormat !== FORMATS.CLAUDE) return false;
   if (mode === "always") return true;
-
-  const stopSequences = Array.isArray(body?.stop_sequences)
-    ? (body!.stop_sequences as unknown[])
-    : [];
-  if (stopSequences.includes("</block>")) return true;
 
   return extractSystemTexts(body).some((text) => text.includes(SECURITY_MONITOR_MARKER));
 }

--- a/tests/unit/8189-classifier-compat-auto-narrow.test.ts
+++ b/tests/unit/8189-classifier-compat-auto-narrow.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for #8189 — "auto" claudeClassifierCompat mode was over-broad.
+ *
+ * shouldDefaultAllowClassifier() previously treated `stop_sequences` containing the
+ * literal token `</block>` as sufficient PROOF of a Claude Code classifier request in
+ * "auto" mode, with no correlation to the classifier's system-prompt marker. Any
+ * unrelated Claude-format (/v1/messages) request that merely happened to set
+ * stop_sequences=["</block>"] (e.g. an app generating markup with a stop token) was
+ * silently short-circuited with a synthetic ALLOW response — WITHOUT ever calling the
+ * configured provider.
+ *
+ * Fix: in "auto" mode, the SECURITY_MONITOR_MARKER system-prompt text is now a
+ * necessary condition. `stop_sequences` alone is no longer sufficient.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { shouldDefaultAllowClassifier } from "../../open-sse/handlers/chatCore/claudeClassifierCompat.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+test("issue #8189: 'auto' mode fires on stop_sequences alone, with NO security-monitor marker present — over-broad trigger", () => {
+  const body = {
+    model: "aug/claude-sonnet-4.6",
+    max_tokens: 20,
+    stop_sequences: ["</block>"],
+    system: "You are a helpful assistant that writes CMS page templates.",
+    messages: [{ role: "user", content: "Write a <block>...</block> template" }],
+  };
+  const result = shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "auto");
+  assert.equal(
+    result,
+    false,
+    "auto mode must not short-circuit a request that merely happens to set stop_sequences=['</block>'] for unrelated reasons and carries no security-monitor marker"
+  );
+});
+
+test("issue #8189: 'auto' mode still short-circuits when the security-monitor marker is present, even without stop_sequences", () => {
+  const body = {
+    system: [
+      {
+        type: "text",
+        text: "You are a security monitor for autonomous AI coding agents. Evaluate the following action.",
+      },
+    ],
+    stop_sequences: [],
+    messages: [{ role: "user", content: "<transcript>Bash rm -rf /</transcript>" }],
+  };
+  assert.equal(
+    shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "auto"),
+    true,
+    "marker-present must still short-circuit even without stop_sequences"
+  );
+});
+
+test("issue #8189: 'always' mode is unaffected — every Claude-format request still short-circuits (operator opted in)", () => {
+  const body = {
+    system: "You are a helpful assistant that writes CMS page templates.",
+    stop_sequences: ["</block>"],
+    messages: [{ role: "user", content: "hello" }],
+  };
+  assert.equal(
+    shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "always"),
+    true,
+    "mode='always' must short-circuit every Claude-format request regardless of signal shape"
+  );
+});
+
+test("issue #8189: 'off' mode (shipped default) never short-circuits", () => {
+  const body = {
+    system: [
+      { type: "text", text: "You are a security monitor for autonomous AI coding agents." },
+    ],
+    stop_sequences: ["</block>"],
+  };
+  assert.equal(shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "off"), false);
+  assert.equal(shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, undefined), false);
+});

--- a/tests/unit/claude-classifier-compat.test.ts
+++ b/tests/unit/claude-classifier-compat.test.ts
@@ -90,9 +90,13 @@ test("detector: auto fires on the security-monitor system-prompt marker", () => 
   assert.equal(shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "auto"), true);
 });
 
-test("detector: auto fires on the </block> stop_sequence token", () => {
+test("detector: auto does NOT fire on the </block> stop_sequence token alone (#8189 — over-broad trigger fix)", () => {
   const body = { system: [{ type: "text", text: "unrelated" }], stop_sequences: ["</block>"] };
-  assert.equal(shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "auto"), true);
+  assert.equal(
+    shouldDefaultAllowClassifier(FORMATS.CLAUDE, body, "auto"),
+    false,
+    "stop_sequences=['</block>'] alone must not short-circuit without the security-monitor marker"
+  );
 });
 
 test("detector: auto does NOT fire on a regular Claude request (no marker, no </block>)", () => {


### PR DESCRIPTION
Closes #8189

## Root cause

`shouldDefaultAllowClassifier()` in `open-sse/handlers/chatCore/claudeClassifierCompat.ts` implemented `claudeClassifierCompat`'s "auto" mode as an OR of two independent signals: (1) `stop_sequences` includes the literal string `</block>`, OR (2) the system prompt contains the `SECURITY_MONITOR_MARKER` text ("You are a security monitor for autonomous AI coding agents"). Branch (1) had no correlation requirement with branch (2), so any Claude-format (`/v1/messages`) request that merely set `stop_sequences=["</block>"]` for unrelated reasons (e.g. an app generating markup and using `</block>` as a stop token) was short-circuited with a synthetic `<block>no</block>` ALLOW response — WITHOUT ever calling the upstream provider. This matches the reporter's uniform hit across all `aug/`, `oc/`, `[removed-provider]/`, `ddgw/` model prefixes, since the short-circuit runs before provider/model resolution.

Default is `"off"` — this only fires when an operator has explicitly opted into `claudeClassifierCompat="auto"` (or `"always"`) via the dashboard toggle.

## Fix

Tightened the `"auto"` branch so `stop_sequences` alone is no longer sufficient. The `SECURITY_MONITOR_MARKER` system-prompt text is now a necessary condition for `"auto"` mode to short-circuit. Preserved:
- Marker-present still short-circuits even without `stop_sequences` (unchanged).
- `mode === "always"` unaffected — every Claude-format request still short-circuits (operator explicitly opted every call in).
- `mode === "off"` (shipped default) still never fires.

## Regression test (RED → GREEN)

New permanent test: `tests/unit/8189-classifier-compat-auto-narrow.test.ts`, reusing the plan-file's proven repro:

```
✖ issue #8189: 'auto' mode fires on stop_sequences alone, with NO security-monitor marker present — over-broad trigger
  AssertionError [ERR_ASSERTION]: true !== false
```

After the fix, all 4 assertions pass (over-broad case now `false`, marker-only case still `true`, `always` mode unaffected, `off` mode unaffected).

Also aligned the pre-existing sibling assertion in `tests/unit/claude-classifier-compat.test.ts` ("detector: auto fires on the `</block>` stop_sequence token") that encoded the old over-broad contract — it now asserts the corrected behavior (`false` when the marker is absent).

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/8189-classifier-compat-auto-narrow.test.ts` — 4/4 pass
- `node --import tsx/esm --test tests/unit/claude-classifier-compat.test.ts` — 9/9 pass (sibling suite, end-to-end `handleChatCore` short-circuit test included)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — pre-existing baseline drift (2130→2156) confirmed present on unmodified `origin/release/v3.8.49` via a throwaway probe worktree, i.e. unrelated to this diff (this diff only removes a branch, reducing complexity in the touched file)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (944 ≤ baseline 950)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK

Changelog fragment added at `changelog.d/fixes/8189-classifier-compat-auto-narrow.md`.