### PR TITLE
fix(gemini): drop HARM_CATEGORY_CIVIC_INTEGRITY from the default Gemini safety settings (#8231)

### DIFF
--- a/changelog.d/fixes/8231-gemini-civic-integrity-default.md
+++ b/changelog.d/fixes/8231-gemini-civic-integrity-default.md
@@ -1,0 +1,1 @@
+- fix(gemini): drop HARM_CATEGORY_CIVIC_INTEGRITY from the default Gemini safety settings (#8231)

--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -90,13 +90,23 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
 
 export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [...GEMINI_UNSUPPORTED_SCHEMA_KEYS];
 
-// Default safety settings
+// Default safety settings for the standard Gemini API surface.
+//
+// HARM_CATEGORY_CIVIC_INTEGRITY is intentionally NOT included here (#8231): the
+// dynamic validation on some models/endpoints rejects it with a hard 400
+// (`safety_settings[N]: element predicate failed`), taking down every request
+// through that model. The Antigravity/Cloud Code surface already worked around
+// this for #5003 (see ANTIGRAVITY_UNSUPPORTED_SAFETY_CATEGORIES in
+// open-sse/executors/antigravity.ts) — this drops the same category from the
+// standard-path default so behavior is consistent across Gemini surfaces. A
+// caller that explicitly supplies safetySettings (including one that itself
+// requests CIVIC_INTEGRITY) is still honored as-is — only this unconditional
+// default is scoped down.
 export const DEFAULT_SAFETY_SETTINGS = [
   { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "OFF" },
   { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "OFF" },
   { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "OFF" },
   { category: "HARM_CATEGORY_HARASSMENT", threshold: "OFF" },
-  { category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "OFF" },
 ];
 
 function normalizeAudioMimeType(format: unknown): string {

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -41,7 +41,10 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
     model: model,
     contents: [],
     generationConfig: {},
-    safetySettings: DEFAULT_SAFETY_SETTINGS,
+    // Honor an explicit caller-supplied safetySettings (including one that itself
+    // requests HARM_CATEGORY_CIVIC_INTEGRITY — the caller's explicit choice), matching
+    // the openai-to-gemini.ts standard-path behavior. See DEFAULT_SAFETY_SETTINGS (#8231).
+    safetySettings: body.safetySettings || DEFAULT_SAFETY_SETTINGS,
   };
 
   // ── Generation config ──────────────────────────────────────────

--- a/tests/snapshots/translation/openai-to-gemini/basic-chat.json
+++ b/tests/snapshots/translation/openai-to-gemini/basic-chat.json
@@ -33,10 +33,6 @@
     {
       "category": "HARM_CATEGORY_HARASSMENT",
       "threshold": "OFF"
-    },
-    {
-      "category": "HARM_CATEGORY_CIVIC_INTEGRITY",
-      "threshold": "OFF"
     }
   ]
 }

--- a/tests/snapshots/translation/openai-to-gemini/modern-gemini-default-thinking.json
+++ b/tests/snapshots/translation/openai-to-gemini/modern-gemini-default-thinking.json
@@ -33,10 +33,6 @@
     {
       "category": "HARM_CATEGORY_HARASSMENT",
       "threshold": "OFF"
-    },
-    {
-      "category": "HARM_CATEGORY_CIVIC_INTEGRITY",
-      "threshold": "OFF"
     }
   ]
 }

--- a/tests/snapshots/translation/openai-to-gemini/with-system.json
+++ b/tests/snapshots/translation/openai-to-gemini/with-system.json
@@ -33,10 +33,6 @@
     {
       "category": "HARM_CATEGORY_HARASSMENT",
       "threshold": "OFF"
-    },
-    {
-      "category": "HARM_CATEGORY_CIVIC_INTEGRITY",
-      "threshold": "OFF"
     }
   ],
   "systemInstruction": {

--- a/tests/unit/8231-gemini-civic-integrity-default.test.ts
+++ b/tests/unit/8231-gemini-civic-integrity-default.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { claudeToGeminiRequest } from "../../open-sse/translator/request/claude-to-gemini.ts";
+import { openaiToGeminiRequest } from "../../open-sse/translator/request/openai-to-gemini.ts";
+
+// Regression guard for #8231: the standard Gemini API surface (non-Antigravity)
+// unconditionally injected HARM_CATEGORY_CIVIC_INTEGRITY into the default
+// safetySettings, which upstream dynamic validation rejects for some
+// models/endpoints with `safety_settings[4]: element predicate failed` — a hard
+// 400 on every request through that model. #5003 already fixed this for the
+// Antigravity/Cloud Code surface (open-sse/executors/antigravity.ts); this test
+// pins the same behavior for claude-to-gemini.ts and openai-to-gemini.ts.
+
+test("[repro #8231] claude-to-gemini default safetySettings must not force HARM_CATEGORY_CIVIC_INTEGRITY", () => {
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    null
+  );
+  const categories = (result.safetySettings as Array<{ category: string }>).map(
+    (s) => s.category
+  );
+  assert.equal(
+    categories.includes("HARM_CATEGORY_CIVIC_INTEGRITY"),
+    false,
+    `got ${JSON.stringify(categories)}`
+  );
+});
+
+test("[repro #8231] openai-to-gemini default safetySettings must not force HARM_CATEGORY_CIVIC_INTEGRITY", () => {
+  const result = openaiToGeminiRequest(
+    "gemini-2.5-pro",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    null
+  );
+  const categories = (result.safetySettings as Array<{ category: string }>).map(
+    (s) => s.category
+  );
+  assert.equal(
+    categories.includes("HARM_CATEGORY_CIVIC_INTEGRITY"),
+    false,
+    `got ${JSON.stringify(categories)}`
+  );
+});
+
+test("[repro #8231] claude-to-gemini preserves caller-supplied safetySettings that explicitly request HARM_CATEGORY_CIVIC_INTEGRITY", () => {
+  const explicit = [{ category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "BLOCK_NONE" }];
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    { messages: [{ role: "user", content: "hi" }], safetySettings: explicit },
+    false,
+    null
+  );
+  assert.deepEqual(result.safetySettings, explicit);
+});
+
+test("[repro #8231] openai-to-gemini preserves caller-supplied safetySettings that explicitly request HARM_CATEGORY_CIVIC_INTEGRITY", () => {
+  const explicit = [{ category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "BLOCK_NONE" }];
+  const result = openaiToGeminiRequest(
+    "gemini-2.5-pro",
+    { messages: [{ role: "user", content: "hi" }], safetySettings: explicit },
+    false,
+    null
+  );
+  assert.deepEqual(result.safetySettings, explicit);
+});


### PR DESCRIPTION
Closes #8231

## Root cause

`DEFAULT_SAFETY_SETTINGS` in `open-sse/translator/helpers/geminiHelper.ts` unconditionally included `HARM_CATEGORY_CIVIC_INTEGRITY` as its 5th entry. It was injected with no gating on the two standard (non-Antigravity) Gemini translation entry points:
- `open-sse/translator/request/claude-to-gemini.ts` — always used the raw default, ignoring any caller-supplied `safetySettings`.
- `open-sse/translator/request/openai-to-gemini.ts` (`openaiToGeminiBase`) — `body.safetySettings || DEFAULT_SAFETY_SETTINGS`.

When the target model/endpoint's dynamic validation rejects `HARM_CATEGORY_CIVIC_INTEGRITY`, the entire request 400s with `safety_settings[4]: element predicate failed`, breaking every request through that model.

OmniRoute already worked around this exact defect for the Antigravity/Cloud Code path (`ANTIGRAVITY_UNSUPPORTED_SAFETY_CATEGORIES` in `open-sse/executors/antigravity.ts`, added for #5003) — this PR applies the same fix intent to the standard Gemini surface so behavior is consistent.

## Fix

- `geminiHelper.ts`: `DEFAULT_SAFETY_SETTINGS` now has 4 categories (dropped `HARM_CATEGORY_CIVIC_INTEGRITY`).
- `claude-to-gemini.ts`: now honors an explicit caller-supplied `safetySettings` (`body.safetySettings || DEFAULT_SAFETY_SETTINGS`), matching the pattern already used in `openai-to-gemini.ts`, so a caller that explicitly requests `HARM_CATEGORY_CIVIC_INTEGRITY` still gets it — only the unconditional default changed.
- `openai-to-gemini.ts` / `openaiToCloudCodeGeminiRequest` (Antigravity path): untouched — already correct since #5003.
- Regenerated the 3 golden snapshots under `tests/snapshots/translation/openai-to-gemini/` (`basic-chat.json`, `with-system.json`, `modern-gemini-default-thinking.json`) via `UPDATE_GOLDEN=1 node --import tsx/esm --test tests/unit/correctness/translation.golden.test.ts`. Diff confirmed to be CIVIC_INTEGRITY-removal only (no unrelated churn).

## TDD (Hard Rule #18)

New permanent regression test `tests/unit/8231-gemini-civic-integrity-default.test.ts` (4 assertions: default no longer includes CIVIC_INTEGRITY for both `claude-to-gemini` and `openai-to-gemini`, and caller-supplied CIVIC_INTEGRITY is still preserved for both).

RED (on unfixed code, matches the triage plan-file's proof):
```
✖ [repro #8231] claude-to-gemini default safetySettings must not force HARM_CATEGORY_CIVIC_INTEGRITY
  AssertionError: got [...,"HARM_CATEGORY_CIVIC_INTEGRITY"]
✖ [repro #8231] openai-to-gemini default safetySettings must not force HARM_CATEGORY_CIVIC_INTEGRITY
  AssertionError: got [...,"HARM_CATEGORY_CIVIC_INTEGRITY"]
✖ [repro #8231] claude-to-gemini preserves caller-supplied safetySettings that explicitly request HARM_CATEGORY_CIVIC_INTEGRITY
✖ [repro #8231] openai-to-gemini preserves caller-supplied safetySettings that explicitly request HARM_CATEGORY_CIVIC_INTEGRITY
```

GREEN (after fix): all 4 pass.

## Gates run (from inside the worktree, all green)

- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — pre-existing baseline drift (2156 vs 2130) confirmed present with the fix files reverted to `origin/release/v3.8.49` HEAD too, i.e. not caused by this diff (verified by temporarily checking out this PR's two touched source files back to HEAD, rerunning the check, and re-applying the fix)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (944 vs baseline 950)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- Sibling tests re-run: `antigravity-safetysettings-5003.test.ts`, `gemini-helper.test.ts`, `translator-claude-to-gemini.test.ts`, `translator-gemini-thinking-budget-6943.test.ts`, `translator-openai-to-gemini.test.ts`, `correctness/translation.golden.test.ts` — 98/98 pass
- `node scripts/check/check-changelog-integrity.mjs` — OK

Changelog fragment added at `changelog.d/fixes/8231-gemini-civic-integrity-default.md`.