### PR TITLE
fix(backend): word-boundary-safe tool-result truncation in lite compression mode (#8169)

### DIFF
--- a/changelog.d/fixes/8169-lite-word-boundary-truncation.md
+++ b/changelog.d/fixes/8169-lite-word-boundary-truncation.md
@@ -1,0 +1,1 @@
+- fix(backend): word-boundary-safe tool-result truncation in lite compression mode (#8169)

--- a/open-sse/services/compression/lite.ts
+++ b/open-sse/services/compression/lite.ts
@@ -105,6 +105,47 @@ export function dedupSystemPrompt(
   return { body: { ...body, messages }, applied };
 }
 
+// Adjust a hard cut index to the nearest whitespace within a small lookback/lookahead
+// window, so a truncated tool result never garbles the word it lands in the middle of
+// (#8169). Prefers backing off to the end of the previous word (keeps the result at or
+// under the limit); if no whitespace precedes the cut within the window (e.g. the tail
+// end of a very long unbroken run), looks forward to complete the current word instead.
+// Falls back to the original hard cut index when neither direction finds a boundary.
+const TOOL_TRUNCATION_LOOKBACK = 80;
+
+function isWordChar(char: string | undefined): boolean {
+  return char !== undefined && /\S/.test(char);
+}
+
+function findWhitespaceBackward(content: string, cutIndex: number): number {
+  const windowStart = Math.max(0, cutIndex - TOOL_TRUNCATION_LOOKBACK);
+  for (let i = cutIndex; i > windowStart; i--) {
+    if (!isWordChar(content[i - 1])) return i - 1;
+  }
+  return -1;
+}
+
+function findWhitespaceForward(content: string, cutIndex: number): number {
+  const windowEnd = Math.min(content.length, cutIndex + TOOL_TRUNCATION_LOOKBACK);
+  for (let i = cutIndex; i < windowEnd; i++) {
+    if (!isWordChar(content[i])) return i;
+  }
+  return -1;
+}
+
+function backOffToWordBoundary(content: string, cutIndex: number): number {
+  const onWordBoundary = !isWordChar(content[cutIndex - 1]) || !isWordChar(content[cutIndex]);
+  if (onWordBoundary) return cutIndex;
+
+  const backward = findWhitespaceBackward(content, cutIndex);
+  if (backward !== -1) return backward;
+
+  const forward = findWhitespaceForward(content, cutIndex);
+  if (forward !== -1) return forward;
+
+  return cutIndex;
+}
+
 export function compressToolResults(body: ChatBody): {
   body: ChatBody;
   applied: boolean;
@@ -116,9 +157,10 @@ export function compressToolResults(body: ChatBody): {
     if (msg.role !== "tool" || typeof msg.content !== "string") return msg;
     if (msg.content.length <= MAX_TOOL_LENGTH) return msg;
     applied = true;
+    const cutIndex = backOffToWordBoundary(msg.content, MAX_TOOL_LENGTH);
     return {
       ...msg,
-      content: msg.content.slice(0, MAX_TOOL_LENGTH) + "\n...[truncated]",
+      content: msg.content.slice(0, cutIndex) + "\n...[truncated]",
     };
   });
   return { body: { ...body, messages }, applied };

--- a/tests/unit/8169-lite-word-boundary-truncation.test.ts
+++ b/tests/unit/8169-lite-word-boundary-truncation.test.ts
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compressToolResults } from "../../open-sse/services/compression/lite.ts";
+
+interface TestMessage {
+  role: string;
+  content: string;
+}
+
+interface TestChatBody {
+  messages: TestMessage[];
+}
+
+function toolBody(content: string): TestChatBody {
+  return { messages: [{ role: "tool", content }] };
+}
+
+function firstMessageContent(body: TestChatBody): string {
+  return body.messages[0].content;
+}
+
+test("#8169: lite compressToolResults must not cut a word in half", () => {
+  const prefix = "x".repeat(1990);
+  const word = "authentication"; // straddles the 2000-char cut point
+  const content = prefix + word + " rest of the message continues here.";
+  const { body: out } = compressToolResults(toolBody(content));
+  const resultContent = firstMessageContent(out as TestChatBody);
+  const cutPoint = resultContent.indexOf("\n...[truncated]");
+  assert.notEqual(cutPoint, -1);
+  const lastChar = resultContent[cutPoint - 1];
+  const charAfterWouldBe = content[cutPoint];
+  const isMidWord = /[a-zA-Z0-9]/.test(lastChar) && /[a-zA-Z0-9]/.test(charAfterWouldBe);
+  assert.equal(
+    isMidWord,
+    false,
+    `mid-word cut: "...${resultContent.slice(cutPoint - 20, cutPoint)}" next="${charAfterWouldBe}"`
+  );
+});
+
+test("#8169: compressToolResults still truncates content well over MAX_TOOL_LENGTH", () => {
+  const content = "word ".repeat(1000); // 5000 chars, plenty of whitespace boundaries
+  const { body: out, applied } = compressToolResults(toolBody(content));
+  const resultContent = firstMessageContent(out as TestChatBody);
+  assert.equal(applied, true);
+  assert.ok(resultContent.length < content.length);
+  assert.ok(resultContent.endsWith("\n...[truncated]"));
+});
+
+test("#8169: compressToolResults falls back to hard cut when no whitespace found in lookback window", () => {
+  const content = "a".repeat(2100); // no whitespace anywhere
+  const { body: out, applied } = compressToolResults(toolBody(content));
+  const resultContent = firstMessageContent(out as TestChatBody);
+  assert.equal(applied, true);
+  assert.ok(resultContent.endsWith("\n...[truncated]"));
+});
+
+test("#8169: compressToolResults leaves short tool content untouched", () => {
+  const content = "short content";
+  const { body: out, applied } = compressToolResults(toolBody(content));
+  const resultContent = firstMessageContent(out as TestChatBody);
+  assert.equal(applied, false);
+  assert.equal(resultContent, content);
+});


### PR DESCRIPTION
Closes #8169

## Root cause

`open-sse/services/compression/lite.ts::compressToolResults()` — part of the `lite`
CompressionMode pipeline, documented (`engineCatalog.ts`) as the safest mode with
"zero semantic change." Despite that guarantee, it unconditionally hard-sliced any
tool-role message content longer than `MAX_TOOL_LENGTH` (2000) via a raw
character-offset `slice(0, MAX_TOOL_LENGTH)`, with no word-boundary awareness — cutting
any word straddling the boundary mid-word (e.g. `authentication` -> `authentica`),
matching the reported symptom.

## Fix

Scoped strictly to `compressToolResults()`. When the hard-cut index lands inside a
word, back off to the nearest preceding whitespace within an 80-char lookback window.
If no whitespace precedes the cut within that window (e.g. cutting into one giant
unbroken run right after a very long word-like prefix), look forward instead to
complete the current word rather than emit a garbled fragment. Only if neither
direction finds a boundary within the window does it fall back to the original hard
cut (matches old behavior for pathological all-one-token content). All other
`lite.ts` functions are whitespace/dedup-only and untouched.

## TDD (Hard Rule #18)

New regression file `tests/unit/8169-lite-word-boundary-truncation.test.ts`, reusing
the triage-fix-bugs proven repro test plus 3 supporting cases (still truncates
long content, hard-cut fallback when no boundary in window, short content untouched).

RED on unfixed code:
```
✖ #8169: lite compressToolResults must not cut a word in half
AssertionError: mid-word cut: "...xxxxxxxxxxauthentica" next="t"
```

GREEN after the fix — all 4 new tests pass, plus the sibling suites exercising this
module (`tests/unit/compression/lite.test.ts`, `tests/integration/compression-pipeline.test.ts`,
`tests/unit/vision-compression-authoritative-capability-7237.test.ts`,
`tests/unit/vision-detection-consistency.test.ts`) all remain green.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` -> OK
- `node scripts/check/check-complexity.mjs` -> pre-existing repo-wide drift
  (2156 vs baseline 2130), confirmed identical count with/without this file's diff
  (reverted the file locally, reran, same 2156) — not introduced by this change.
- `node scripts/check/check-cognitive-complexity.mjs` -> OK (944 <= baseline 950)
- `npm run typecheck:core` -> clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` -> clean
- `node scripts/check/check-changelog-integrity.mjs` -> OK
- Sibling tests touching `compressToolResults`/`compression/lite` -> all green

## Changelog

`changelog.d/fixes/8169-lite-word-boundary-truncation.md`