### PR TITLE
fix(providers): filter unsupported family-fallback candidates against the provider catalog (#8134)

### DIFF
--- a/changelog.d/fixes/8134-github-t5-fallback-filter.md
+++ b/changelog.d/fixes/8134-github-t5-fallback-filter.md
@@ -1,0 +1,1 @@
+- fix(providers): filter unsupported family-fallback candidates against the provider catalog (#8134)

--- a/open-sse/services/modelFamilyFallback.ts
+++ b/open-sse/services/modelFamilyFallback.ts
@@ -141,6 +141,38 @@ export function isContextOverflowError(status: number, errorMessage: string): bo
 // ── Fallback Resolution ──────────────────────────────────────────────────────
 
 /**
+ * All notation forms a family-fallback candidate might be registered under
+ * in a provider's catalog: the literal hyphen form, dot-notation variants
+ * (`claude-opus-4-8` -> `claude-opus-4.8`), and — for dated snapshot ids
+ * like `claude-opus-4-5-20251101` — the same variants with the trailing
+ * `-YYYYMMDD` snapshot suffix stripped, so a dated candidate can still
+ * resolve to a provider's undated catalog entry (`claude-opus-4.5`).
+ */
+function candidateNotationVariants(candidate: string): string[] {
+  const variants = [
+    candidate,
+    candidate.replace(/-(\d+)-(\d+)$/, "-$1.$2"),
+    candidate.replace(/-(\d+)-(\d+)-/, "-$1.$2-"),
+  ];
+
+  const dateStripped = candidate.replace(/-\d{8}$/, "");
+  if (dateStripped !== candidate) {
+    variants.push(dateStripped, dateStripped.replace(/-(\d+)-(\d+)$/, "-$1.$2"));
+  }
+
+  return variants;
+}
+
+/**
+ * Resolve a family candidate against the provider's supported model ids.
+ * Returns the matching notation (preferring the first variant found) or
+ * `null` if the candidate is absent from the catalog under every notation.
+ */
+function resolveCandidateNotation(candidate: string, supportedIds: Set<string>): string | null {
+  return candidateNotationVariants(candidate).find((variant) => supportedIds.has(variant)) ?? null;
+}
+
+/**
  * Get the next fallback model from the same family.
  *
  * @param currentModel  The model that just failed
@@ -170,11 +202,12 @@ export function getNextFamilyFallback(
   for (const candidate of family) {
     let resolvedCandidate = candidate;
     if (supportedIds && !supportedIds.has(candidate)) {
-      // Try dot-notation variants: claude-opus-4-8 → claude-opus-4.8
-      const dotVariant = candidate.replace(/-(\d+)-(\d+)$/, "-$1.$2");
-      const dotVariant2 = candidate.replace(/-(\d+)-(\d+)-/, "-$1.$2-");
-      if (supportedIds.has(dotVariant)) resolvedCandidate = dotVariant;
-      else if (supportedIds.has(dotVariant2)) resolvedCandidate = dotVariant2;
+      const match = resolveCandidateNotation(candidate, supportedIds);
+      // Provider catalog is known but this candidate has no match under any
+      // notation — it is provably unsupported, so skip it instead of
+      // returning an id the provider will just 400 on again.
+      if (!match) continue;
+      resolvedCandidate = match;
     }
     const fullCandidate = `${prefix}${resolvedCandidate}`;
     if (!triedModels.has(fullCandidate)) {

--- a/tests/unit/8134-github-t5-fallback-filter.test.ts
+++ b/tests/unit/8134-github-t5-fallback-filter.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getRegistryEntry } from "../../open-sse/config/providerRegistry.ts";
+
+const { getNextFamilyFallback } = await import("../../open-sse/services/modelFamilyFallback.ts");
+
+// Regression for #8134 — GitHub Copilot ("github", alias "gh") T5 family fallback
+// returned "claude-opus-4-6" verbatim even though the github registry catalog
+// (Opus 4.8 / 4.8-fast / 4.7 / 4.5) has NO 4.6 tier under any dot/hyphen
+// notation. getNextFamilyFallback() resolved `supportedIds` from the provider's
+// registry but only used it to try notation variants of a candidate, never to
+// filter out a candidate that is provably absent from the catalog — so the
+// unsupported id fell through and was returned anyway, costing a 3rd wasted
+// upstream round-trip before the family was exhausted.
+//
+// Fix: when the provider registry is resolved, getNextFamilyFallback() now
+// skips (continue) any family candidate that has no match in supportedIds
+// under ANY notation (hyphen, dot, or a dated-snapshot id with the date
+// suffix stripped) instead of returning it unfiltered.
+
+test("#8134: github claude-opus-4.8 fallback chain never returns an unsupported tier (claude-opus-4-6)", () => {
+  const github = getRegistryEntry("github");
+  assert.ok(github, "expected the github registry entry to resolve");
+  const githubIds = new Set(github.models.map((m) => m.id));
+  assert.ok(
+    !githubIds.has("claude-opus-4-6") && !githubIds.has("claude-opus-4.6"),
+    "fixture assumption broken: github registry now has a 4.6 tier"
+  );
+
+  const tried = new Set(["github/claude-opus-4.8"]);
+  const first = getNextFamilyFallback("github/claude-opus-4.8", tried);
+  assert.ok(first, "expected a first fallback candidate");
+  const firstBareId = first.replace(/^github\//, "");
+  assert.ok(
+    githubIds.has(firstBareId),
+    `first fallback "${first}" is not in github's registered model catalog: ${[...githubIds].join(", ")}`
+  );
+
+  tried.add(first);
+  const second = getNextFamilyFallback(first, tried);
+  assert.ok(second, "expected a second fallback candidate (family must not be silently exhausted)");
+  const secondBareId = second.replace(/^github\//, "");
+  assert.ok(
+    githubIds.has(secondBareId),
+    `second fallback "${second}" is not in github's registered model catalog: ${[...githubIds].join(", ")}`
+  );
+  assert.notEqual(secondBareId, "claude-opus-4-6");
+  assert.notEqual(secondBareId, "claude-opus-4.6");
+});
+
+test("#8134: getNextFamilyFallback never returns a candidate absent from the resolved provider's catalog", () => {
+  const github = getRegistryEntry("github");
+  assert.ok(github);
+  const githubIds = new Set(github.models.map((m) => m.id));
+
+  let current = "github/claude-opus-4.8";
+  const tried = new Set([current]);
+  for (let hop = 0; hop < 5; hop++) {
+    const next = getNextFamilyFallback(current, tried);
+    if (!next) break;
+    const bareId = next.replace(/^github\//, "");
+    assert.ok(
+      githubIds.has(bareId),
+      `hop ${hop + 1}: "${next}" is not in github's registered model catalog`
+    );
+    tried.add(next);
+    current = next;
+  }
+});


### PR DESCRIPTION
Closes #8134

## Root cause
`open-sse/services/modelFamilyFallback.ts::getNextFamilyFallback()` resolves a provider's supported model ids into `supportedIds` but only used that set to try dot/hyphen notation *variants* of a candidate — never to filter out a candidate that is provably absent from the provider's registered catalog under any notation. When neither the hyphen form nor a dot-variant matched, the loop fell through and returned the unresolved candidate anyway.

For the `github` (GitHub Copilot) registry entry, the Claude Opus tier list is 4.8 / 4.8-fast / 4.7 / 4.5 — there is no 4.6 tier. `MODEL_FAMILIES['claude-opus-4-8']` unconditionally includes `claude-opus-4-6`, so the second fallback hop returned `github/claude-opus-4-6` verbatim, and the upstream would 400 a third time before the family was exhausted — the wasted round-trip described in the issue.

## Fix
When the provider registry is resolved, a family candidate is now skipped (`continue`) instead of returned unfiltered if it has no match in `supportedIds` under *any* notation — hyphen, dot-variant, or (new) a dated-snapshot id (`claude-opus-4-5-20251101`) with its trailing `-YYYYMMDD` suffix stripped before the dot-variant check. The date-stripping addition was needed to keep the `kiro` sibling regression test green (see landmine note below) — without it, dated Sonnet candidates that *do* have an undated match in a provider's catalog (`claude-sonnet-4.5`) would be wrongly skipped too.

No change to `MODEL_FAMILIES` itself or to the `github`/`kiro` registries — filtering happens purely against the already-resolved catalog.

## TDD evidence (Hard Rule #18)
New permanent regression file `tests/unit/8134-github-t5-fallback-filter.test.ts`:
- RED (unfixed code): `second fallback "github/claude-opus-4-6" is not in github's registered model catalog: ...` — 2 tests, both failing.
- GREEN (fixed code): both tests pass; a 5-hop walk of the whole `github` Opus fallback chain asserts every returned candidate is a real member of `getRegistryEntry('github').models`.

## Landmine — kiro sibling test
`tests/unit/kiro-claude-sonnet-5-2267.test.ts` (guards a different fallback contract, previously broken by a naive `continue`-based fix in a reverted PR) stays **green, unmodified**. The kiro registry only has `claude-sonnet-4.5` (no `4-6` tier, no dated snapshots) — the new date-stripped dot-variant check lets `claude-sonnet-4-5-20250929` resolve to kiro's real `claude-sonnet-4.5` entry instead of being incorrectly skipped, which is what a naive "skip everything unmatched" fix would have done (and why #8143 reverted that approach).

## Gates run (from the worktree)
- `node --import tsx/esm --test tests/unit/8134-github-t5-fallback-filter.test.ts` — 2/2 pass (RED→GREEN)
- `node --import tsx/esm --test tests/unit/kiro-claude-sonnet-5-2267.test.ts tests/unit/t30-kiro-400-model-unavailable.test.ts tests/unit/repro-7268-401-model-not-supported-lockout.test.ts tests/unit/model-family-fallback-notation.test.ts` — 17/17 pass (all sibling fallback tests green, including the landmine)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — reports a pre-existing repo-wide regression (2156 vs baseline 2130) unrelated to this diff: `modelFamilyFallback.ts` itself has 0 complexity violations, and the scan scope excludes `tests/`, so nothing in this PR contributes to it.
- `node scripts/check/check-cognitive-complexity.mjs` — OK (944 ≤ baseline 950)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/modelFamilyFallback.ts tests/unit/8134-github-t5-fallback-filter.test.ts` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run test:vitest` — 271/271 pass, 30/30 files
- `npm run test:unit` — full suite run; 0 failures observed through the run

## Scope
Diff is scoped strictly to `open-sse/services/modelFamilyFallback.ts` (new pure helper functions + the fix) plus the new regression test and a changelog fragment. No changes to `MODEL_FAMILIES`, the `github` registry, or the `kiro` registry.