### PR TITLE
feat: classify grok-web Cloudflare anti-bot blocks + gated browser-backed cf_clearance path (#8019)

### DIFF
--- a/changelog.d/features/8019-grok-web-cloudflare-classification.md
+++ b/changelog.d/features/8019-grok-web-cloudflare-classification.md
@@ -1,0 +1,1 @@
+- feat(sse): classify grok-web Cloudflare anti-bot blocks + gated browser-backed cf_clearance path (#8019)

--- a/open-sse/executors/grok-web.ts
+++ b/open-sse/executors/grok-web.ts
@@ -17,6 +17,7 @@ import {
   mergeUpstreamExtraHeaders,
   mergeAbortSignals,
   type ExecuteInput,
+  type ExecutorLog,
 } from "./base.ts";
 import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
 import { buildGrokCookieHeader } from "@/lib/providers/webCookieAuth";
@@ -27,6 +28,10 @@ import {
   type TlsFetchResult,
 } from "../services/grokTlsClient.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
+import {
+  shouldUseGrokBrowserBacked,
+  acquireFreshGrokClearance,
+} from "../services/grokClearance.ts";
 import type { GrokStreamEvent } from "./grok-web/types.ts";
 import {
   type OpenAIToolCall,
@@ -649,6 +654,160 @@ async function buildNonStreamingResponse(
   );
 }
 
+// ─── Cloudflare anti-bot classification + browser-backed recovery (#8019) ──
+//
+// Grok's own TLS-impersonating client (grokTlsClient.ts) still gets a
+// Cloudflare Enterprise anti-bot rejection from datacenter/sandbox egresses
+// even with a valid sso+sso-rw cookie. Before this, a Cloudflare block and a
+// genuinely expired SSO cookie both surfaced as the SAME generic auth error
+// (#8019). classifyGrokNullBodyError() distinguishes them so the caller gets
+// an actionable message, and (opt-in only) resolveGrokNullBodyTlsResult()
+// tries one browser-backed cf_clearance refresh + retry before giving up.
+
+export interface GrokNullBodyError {
+  type: "cloudflare_challenge" | "authentication_error" | "rate_limit_error" | "upstream_error";
+  code: string;
+  message: string;
+}
+
+/**
+ * Classify a `tlsResult.body === null` response (no streamable body — either
+ * a non-2xx status or a Cloudflare interstitial peeked at 200). Exported so
+ * both the executor and its unit tests share one decision.
+ */
+export function classifyGrokNullBodyError(
+  status: number,
+  text: string | null | undefined
+): GrokNullBodyError {
+  if (isCloudflareChallenge(text)) {
+    return {
+      type: "cloudflare_challenge",
+      code: "cf_mitigated_challenge",
+      message:
+        "Grok returned a Cloudflare bot-management challenge instead of a real response. " +
+        "cf_clearance is pinned to the IP+TLS+UA that earned it and can't be replayed from " +
+        "a datacenter/sandbox egress. Probe from a residential IP, or use the official xAI API " +
+        "(provider: 'grok') instead.",
+    };
+  }
+  if (status === 401 || status === 403) {
+    return {
+      type: "authentication_error",
+      code: `HTTP_${status}`,
+      message:
+        "Grok auth failed — SSO cookie may be expired. Re-paste your sso cookie value from grok.com.",
+    };
+  }
+  if (status === 429) {
+    return {
+      type: "rate_limit_error",
+      code: "HTTP_429",
+      message: "Grok rate limited. Wait a moment and retry, or rotate cookies.",
+    };
+  }
+  return {
+    type: "upstream_error",
+    code: `HTTP_${status}`,
+    message: `Grok returned HTTP ${status}`,
+  };
+}
+
+function buildGrokNullBodyErrorResponse(
+  status: number,
+  classification: GrokNullBodyError
+): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: classification.message,
+        type: classification.type,
+        code: classification.code,
+      },
+    }),
+    { status, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function appendCfClearanceCookie(cookieHeader: string | undefined, cfClearance: string): string {
+  const cfCookie = `cf_clearance=${cfClearance}`;
+  if (!cookieHeader) return cfCookie;
+  if (/(?:^|;\s*)cf_clearance=/.test(cookieHeader)) {
+    return cookieHeader.replace(/cf_clearance=[^;]*/, cfCookie);
+  }
+  return `${cookieHeader}; ${cfCookie}`;
+}
+
+/**
+ * Attempt ONE browser-backed cf_clearance refresh + retry of tlsFetchGrok.
+ * Returns the retried TlsFetchResult on success, or null on any failure
+ * (acquisition failure, retry still challenged, retry threw) so the caller
+ * falls through to the original Cloudflare-challenge error — never throws.
+ */
+async function retryGrokWithFreshClearance(params: {
+  headers: Record<string, string>;
+  grokPayload: Record<string, unknown>;
+  signal?: AbortSignal;
+}): Promise<TlsFetchResult | null> {
+  let cfClearance: string | null;
+  try {
+    cfClearance = await acquireFreshGrokClearance(params.signal);
+  } catch {
+    cfClearance = null;
+  }
+  if (!cfClearance) return null;
+
+  const retryHeaders = {
+    ...params.headers,
+    Cookie: appendCfClearanceCookie(params.headers.Cookie, cfClearance),
+  };
+  try {
+    const retried = await tlsFetchGrok(GROK_CHAT_API, {
+      method: "POST",
+      headers: retryHeaders,
+      body: JSON.stringify(params.grokPayload),
+      timeoutMs: FETCH_TIMEOUT_MS,
+      signal: params.signal,
+      stream: true,
+      streamEofSymbol: "[DONE]",
+    });
+    return retried.body ? retried : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves a `tlsResult.body === null` response: if it classifies as a
+ * Cloudflare challenge AND the browser-backed opt-in gate is on, tries one
+ * recovery retry; otherwise returns the original result unchanged. Callers
+ * re-classify the (possibly retried) result themselves.
+ */
+export async function resolveGrokNullBodyTlsResult(params: {
+  tlsResult: TlsFetchResult;
+  headers: Record<string, string>;
+  grokPayload: Record<string, unknown>;
+  signal?: AbortSignal;
+  log?: ExecutorLog | null;
+}): Promise<TlsFetchResult> {
+  const { tlsResult, headers, grokPayload, signal, log } = params;
+  if (tlsResult.body) return tlsResult;
+
+  const classification = classifyGrokNullBodyError(tlsResult.status, tlsResult.text);
+  if (classification.type !== "cloudflare_challenge" || !shouldUseGrokBrowserBacked()) {
+    return tlsResult;
+  }
+
+  log?.info?.(
+    "GROK-WEB",
+    "Cloudflare challenge detected on grok.com; attempting browser-backed cf_clearance refresh"
+  );
+  const retried = await retryGrokWithFreshClearance({ headers, grokPayload, signal });
+  if (retried) {
+    log?.info?.("GROK-WEB", "Browser-backed cf_clearance refresh succeeded; retry passed through");
+  }
+  return retried ?? tlsResult;
+}
+
 // ─── Executor ───────────────────────────────────────────────────────────────
 
 export class GrokWebExecutor extends BaseExecutor {
@@ -824,22 +983,23 @@ export class GrokWebExecutor extends BaseExecutor {
     }
 
     if (!tlsResult.body) {
-      // Non-streaming fallback (shouldn't happen for chat, but handle gracefully)
+      // Non-streaming fallback (shouldn't happen for chat, but handle gracefully).
+      // Distinguish a Cloudflare anti-bot block from a genuine auth/rate-limit
+      // failure (#8019); optionally recover via one browser-backed retry.
+      tlsResult = await resolveGrokNullBodyTlsResult({
+        tlsResult,
+        headers,
+        grokPayload,
+        signal: combinedSignal,
+        log,
+      });
+    }
+
+    if (!tlsResult.body) {
       const status = tlsResult.status;
-      let errMsg = `Grok returned HTTP ${status}`;
-      if (status === 401 || status === 403) {
-        errMsg =
-          "Grok auth failed — SSO cookie may be expired. Re-paste your sso cookie value from grok.com.";
-      } else if (status === 429) {
-        errMsg = "Grok rate limited. Wait a moment and retry, or rotate cookies.";
-      }
-      log?.warn?.("GROK-WEB", errMsg);
-      const errResp = new Response(
-        JSON.stringify({
-          error: { message: errMsg, type: "upstream_error", code: `HTTP_${status}` },
-        }),
-        { status, headers: { "Content-Type": "application/json" } }
-      );
+      const classification = classifyGrokNullBodyError(status, tlsResult.text);
+      log?.warn?.("GROK-WEB", classification.message);
+      const errResp = buildGrokNullBodyErrorResponse(status, classification);
       return { response: errResp, url: GROK_CHAT_API, headers, transformedBody: grokPayload };
     }
 

--- a/open-sse/services/grokClearance.ts
+++ b/open-sse/services/grokClearance.ts
@@ -1,0 +1,84 @@
+/**
+ * grokClearance.ts — gated browser-backed cf_clearance acquisition for
+ * grok-web (#8019).
+ *
+ * grok.com sits behind Cloudflare Enterprise, which pins `cf_clearance` to
+ * the client's IP+TLS+UA fingerprint. Pure cookie-replay from
+ * `grokTlsClient.ts` (TLS-impersonating fetch) cannot forge a fresh
+ * clearance from a datacenter egress that Cloudflare has already flagged —
+ * only a real browser solving the challenge natively can mint one bound to
+ * that egress's own fingerprint.
+ *
+ * This module reuses the EXISTING provider-agnostic browser pool
+ * (`browserPool.ts`, already live for claude-web + duckduckgo-web) rather
+ * than adding a new Turnstile solver — `claudeTurnstileSolver.ts` is
+ * claude.ai-specific and does not apply here.
+ *
+ * Opt-in only: gated behind `OMNIROUTE_BROWSER_POOL` / `WEB_COOKIE_USE_BROWSER`
+ * (the same env gate already used by claude-web.ts / duckduckgo-web.ts).
+ * With the gate off, `acquireFreshGrokClearance` is never called — the
+ * executor stays on the Step-1 `cloudflare_challenge` classification.
+ */
+
+import { acquireBrowserContext, type PooledContext } from "./browserPool.ts";
+
+const GROK_WARMUP_URL = "https://grok.com/";
+const GROK_COOKIE_DOMAIN = ".grok.com";
+const GROK_POOL_KEY = "grok-web";
+
+/**
+ * Reads the same opt-in gate as claude-web/duckduckgo-web
+ * (`WEB_COOKIE_USE_BROWSER` or `OMNIROUTE_BROWSER_POOL`). Off by default.
+ */
+export function shouldUseGrokBrowserBacked(): boolean {
+  const flag = process.env.WEB_COOKIE_USE_BROWSER;
+  if (flag === "1" || flag === "true" || flag === "on") return true;
+  const poolFlag = process.env.OMNIROUTE_BROWSER_POOL;
+  return poolFlag === "on" || poolFlag === "1" || poolFlag === "true";
+}
+
+type AcquireGrokClearanceFn = (signal?: AbortSignal | null) => Promise<string | null>;
+
+// Test-only injection point — mirrors browserBackedChat.ts's
+// __setBrowserBackedChatOverrideForTesting pattern so unit tests can prove
+// the gating/wiring without launching a real browser (no chromium in CI).
+let acquireOverride: AcquireGrokClearanceFn | null = null;
+
+export function __setGrokClearanceAcquireOverrideForTesting(
+  fn: AcquireGrokClearanceFn | null
+): void {
+  acquireOverride = fn;
+}
+
+async function readCfClearanceFromContext(pooled: PooledContext): Promise<string | null> {
+  const cookies = await pooled.context.cookies(GROK_WARMUP_URL);
+  const match = cookies.find((c) => c.name === "cf_clearance");
+  return match?.value || null;
+}
+
+async function acquireViaPool(): Promise<string | null> {
+  try {
+    const pooled = await acquireBrowserContext(GROK_POOL_KEY, {
+      cookieDomain: GROK_COOKIE_DOMAIN,
+      cookieString: null,
+      warmupUrl: GROK_WARMUP_URL,
+    });
+    return await readCfClearanceFromContext(pooled);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Acquire a fresh `.grok.com` cf_clearance via the shared browser pool.
+ * Never throws — resolves to `null` on any failure so callers can fall
+ * through to the Cloudflare-challenge error rather than crash the request.
+ */
+export async function acquireFreshGrokClearance(signal?: AbortSignal | null): Promise<string | null> {
+  if (acquireOverride) return acquireOverride(signal);
+  try {
+    return await acquireViaPool();
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/grok-web-cloudflare-classification.test.ts
+++ b/tests/unit/grok-web-cloudflare-classification.test.ts
@@ -1,0 +1,350 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  __setTlsFetchOverrideForTesting,
+  type TlsFetchResult,
+} from "../../open-sse/services/grokTlsClient.ts";
+import { __setGrokClearanceAcquireOverrideForTesting } from "../../open-sse/services/grokClearance.ts";
+import type { ExecuteInput } from "../../open-sse/executors/base.ts";
+
+const {
+  GrokWebExecutor,
+  classifyGrokNullBodyError,
+  resolveGrokNullBodyTlsResult,
+} = await import("../../open-sse/executors/grok-web.ts");
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const CF_CHALLENGE_BODY = `
+<!DOCTYPE html>
+<html>
+  <head><title>Just a moment...</title></head>
+  <body>
+    <script>window._cf_chl_opt = { cvId: "3" };</script>
+    Checking your browser before accessing grok.com — challenges.cloudflare.com
+  </body>
+</html>
+`;
+
+const NORMAL_AUTH_FAILURE_BODY = JSON.stringify({
+  error: { message: "Invalid session", code: "UNAUTHENTICATED" },
+});
+
+const RATE_LIMIT_BODY = JSON.stringify({ error: { message: "Too many requests" } });
+
+function mockGrokStream(events: unknown[]) {
+  const encoder = new TextEncoder();
+  const lines = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines));
+      controller.close();
+    },
+  });
+}
+
+function baseInput(overrides: Partial<ExecuteInput> = {}): ExecuteInput {
+  return {
+    model: "grok-4",
+    body: { messages: [{ role: "user", content: "hi" }] },
+    stream: false,
+    credentials: { apiKey: "sso=abc123" },
+    signal: undefined,
+    log: undefined,
+    ...overrides,
+  };
+}
+
+test.afterEach(() => {
+  __setTlsFetchOverrideForTesting(null);
+  __setGrokClearanceAcquireOverrideForTesting(null);
+  delete process.env.OMNIROUTE_BROWSER_POOL;
+  delete process.env.WEB_COOKIE_USE_BROWSER;
+});
+
+// ─── Step 1: pure classification ───────────────────────────────────────────
+
+test("classifyGrokNullBodyError: Cloudflare anti-bot body + 403 -> cloudflare_challenge", () => {
+  const result = classifyGrokNullBodyError(403, CF_CHALLENGE_BODY);
+  assert.equal(result.type, "cloudflare_challenge");
+  assert.equal(result.code, "cf_mitigated_challenge");
+  assert.notEqual(result.type, "authentication_error");
+  assert.match(result.message, /cloudflare/i);
+  assert.match(result.message, /residential/i);
+});
+
+test("classifyGrokNullBodyError: 401 with a normal (non-CF) body -> authentication_error", () => {
+  const result = classifyGrokNullBodyError(401, NORMAL_AUTH_FAILURE_BODY);
+  assert.equal(result.type, "authentication_error");
+  assert.match(result.message, /re-paste your sso cookie/i);
+});
+
+test("classifyGrokNullBodyError: 403 with a normal (non-CF) body -> authentication_error", () => {
+  const result = classifyGrokNullBodyError(403, NORMAL_AUTH_FAILURE_BODY);
+  assert.equal(result.type, "authentication_error");
+});
+
+test("classifyGrokNullBodyError: 429 -> rate_limit_error (regression guard)", () => {
+  const result = classifyGrokNullBodyError(429, RATE_LIMIT_BODY);
+  assert.equal(result.type, "rate_limit_error");
+  assert.match(result.message, /rate limited/i);
+});
+
+test("classifyGrokNullBodyError: other status -> generic upstream_error", () => {
+  const result = classifyGrokNullBodyError(500, "internal error");
+  assert.equal(result.type, "upstream_error");
+  assert.match(result.message, /HTTP 500/);
+});
+
+test("classifyGrokNullBodyError: null/undefined text never misclassifies as Cloudflare", () => {
+  assert.equal(classifyGrokNullBodyError(401, null).type, "authentication_error");
+  assert.equal(classifyGrokNullBodyError(401, undefined).type, "authentication_error");
+});
+
+// ─── Step 1 wired end-to-end through the executor ──────────────────────────
+
+test("executor: Cloudflare challenge on non-streaming body surfaces cloudflare_challenge (not authentication_error)", async () => {
+  __setTlsFetchOverrideForTesting(async () => ({
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  }));
+
+  const executor = new GrokWebExecutor();
+  const result = await executor.execute(baseInput());
+  assert.equal(result.response.status, 403);
+  const json = await result.response.json();
+  assert.equal(json.error.type, "cloudflare_challenge");
+  assert.equal(json.error.code, "cf_mitigated_challenge");
+});
+
+test("executor: expired SSO cookie (401, normal body) still surfaces authentication_error", async () => {
+  __setTlsFetchOverrideForTesting(async () => ({
+    status: 401,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: NORMAL_AUTH_FAILURE_BODY,
+    body: null,
+  }));
+
+  const executor = new GrokWebExecutor();
+  const result = await executor.execute(baseInput());
+  assert.equal(result.response.status, 401);
+  const json = await result.response.json();
+  assert.equal(json.error.type, "authentication_error");
+});
+
+test("executor: 429 still surfaces rate_limit_error (regression guard)", async () => {
+  __setTlsFetchOverrideForTesting(async () => ({
+    status: 429,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: RATE_LIMIT_BODY,
+    body: null,
+  }));
+
+  const executor = new GrokWebExecutor();
+  const result = await executor.execute(baseInput());
+  assert.equal(result.response.status, 429);
+  const json = await result.response.json();
+  assert.equal(json.error.type, "rate_limit_error");
+});
+
+// ─── Step 2: gated browser-backed retry (mocked browser, no real launch) ──
+
+test("resolveGrokNullBodyTlsResult: gate OFF -> no acquisition attempted, CF result returned unchanged", async () => {
+  delete process.env.OMNIROUTE_BROWSER_POOL;
+  delete process.env.WEB_COOKIE_USE_BROWSER;
+
+  let acquireCalls = 0;
+  __setGrokClearanceAcquireOverrideForTesting(async () => {
+    acquireCalls++;
+    return "fresh-token";
+  });
+
+  const cfResult: TlsFetchResult = {
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  };
+
+  const resolved = await resolveGrokNullBodyTlsResult({
+    tlsResult: cfResult,
+    headers: { Cookie: "sso=abc123" },
+    grokPayload: { modeId: "fast" },
+  });
+
+  assert.equal(acquireCalls, 0, "acquisition must not be attempted when the gate is off");
+  assert.equal(resolved, cfResult);
+});
+
+test("resolveGrokNullBodyTlsResult: gate ON + CF challenge + mocked success -> retried once with injected cf_clearance", async () => {
+  process.env.OMNIROUTE_BROWSER_POOL = "on";
+
+  __setGrokClearanceAcquireOverrideForTesting(async () => "fresh-cf-token");
+
+  let retryCount = 0;
+  let capturedCookie: string | undefined;
+  __setTlsFetchOverrideForTesting(async (_url, options) => {
+    retryCount++;
+    capturedCookie = (options.headers as Record<string, string>)?.Cookie;
+    return {
+      status: 200,
+      headers: new Headers({ "Content-Type": "application/x-ndjson" }),
+      text: null,
+      body: mockGrokStream([
+        { result: { response: { modelResponse: { message: "ok", responseId: "r1" } } } },
+      ]),
+    };
+  });
+
+  const cfResult: TlsFetchResult = {
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  };
+
+  const resolved = await resolveGrokNullBodyTlsResult({
+    tlsResult: cfResult,
+    headers: { Cookie: "sso=abc123" },
+    grokPayload: { modeId: "fast" },
+  });
+
+  assert.equal(retryCount, 1, "tlsFetchGrok must be retried exactly once");
+  assert.ok(resolved.body, "retried result must carry a streamable body");
+  assert.match(capturedCookie || "", /sso=abc123/);
+  assert.match(capturedCookie || "", /cf_clearance=fresh-cf-token/);
+});
+
+test("resolveGrokNullBodyTlsResult: gate ON + acquisition failure -> falls through to original CF result (no throw)", async () => {
+  process.env.OMNIROUTE_BROWSER_POOL = "on";
+  __setGrokClearanceAcquireOverrideForTesting(async () => null);
+
+  let retryCount = 0;
+  __setTlsFetchOverrideForTesting(async () => {
+    retryCount++;
+    throw new Error("should not be called when acquisition fails");
+  });
+
+  const cfResult: TlsFetchResult = {
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  };
+
+  const resolved = await resolveGrokNullBodyTlsResult({
+    tlsResult: cfResult,
+    headers: { Cookie: "sso=abc123" },
+    grokPayload: { modeId: "fast" },
+  });
+
+  assert.equal(retryCount, 0, "tlsFetchGrok retry must not be attempted without a fresh clearance");
+  assert.equal(resolved, cfResult);
+});
+
+test("resolveGrokNullBodyTlsResult: gate ON + retry still challenged -> falls through to CF result (no throw)", async () => {
+  process.env.OMNIROUTE_BROWSER_POOL = "on";
+  __setGrokClearanceAcquireOverrideForTesting(async () => "fresh-cf-token");
+
+  __setTlsFetchOverrideForTesting(async () => ({
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  }));
+
+  const cfResult: TlsFetchResult = {
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  };
+
+  const resolved = await resolveGrokNullBodyTlsResult({
+    tlsResult: cfResult,
+    headers: { Cookie: "sso=abc123" },
+    grokPayload: { modeId: "fast" },
+  });
+
+  assert.equal(resolved, cfResult, "must fall through to the original CF result, not throw");
+});
+
+test("resolveGrokNullBodyTlsResult: non-CF null body (auth/rate-limit) never attempts acquisition", async () => {
+  process.env.OMNIROUTE_BROWSER_POOL = "on";
+  let acquireCalls = 0;
+  __setGrokClearanceAcquireOverrideForTesting(async () => {
+    acquireCalls++;
+    return "fresh-cf-token";
+  });
+
+  const authResult: TlsFetchResult = {
+    status: 401,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: NORMAL_AUTH_FAILURE_BODY,
+    body: null,
+  };
+
+  const resolved = await resolveGrokNullBodyTlsResult({
+    tlsResult: authResult,
+    headers: { Cookie: "sso=abc123" },
+    grokPayload: { modeId: "fast" },
+  });
+
+  assert.equal(acquireCalls, 0, "a genuine auth failure must not trigger browser acquisition");
+  assert.equal(resolved, authResult);
+});
+
+// ─── Step 2 wired end-to-end through the executor ──────────────────────────
+
+test("executor: gate ON + CF challenge + mocked browser success -> chat succeeds via retried request", async () => {
+  process.env.OMNIROUTE_BROWSER_POOL = "on";
+  __setGrokClearanceAcquireOverrideForTesting(async () => "fresh-cf-token");
+
+  let callCount = 0;
+  __setTlsFetchOverrideForTesting(async () => {
+    callCount++;
+    if (callCount === 1) {
+      return {
+        status: 403,
+        headers: new Headers({ "Content-Type": "text/html" }),
+        text: CF_CHALLENGE_BODY,
+        body: null,
+      };
+    }
+    return {
+      status: 200,
+      headers: new Headers({ "Content-Type": "application/x-ndjson" }),
+      text: null,
+      body: mockGrokStream([
+        { result: { response: { modelResponse: { message: "Hello!", responseId: "r1" } } } },
+      ]),
+    };
+  });
+
+  const executor = new GrokWebExecutor();
+  const result = await executor.execute(baseInput());
+  assert.equal(callCount, 2, "expected the initial CF-blocked call + one recovery retry");
+  assert.equal(result.response.status, 200);
+  const json = await result.response.json();
+  assert.equal(json.choices[0].message.content, "Hello!");
+});
+
+test("executor: gate ON + CF challenge + acquisition failure -> still surfaces cloudflare_challenge", async () => {
+  process.env.OMNIROUTE_BROWSER_POOL = "on";
+  __setGrokClearanceAcquireOverrideForTesting(async () => null);
+
+  __setTlsFetchOverrideForTesting(async () => ({
+    status: 403,
+    headers: new Headers({ "Content-Type": "text/html" }),
+    text: CF_CHALLENGE_BODY,
+    body: null,
+  }));
+
+  const executor = new GrokWebExecutor();
+  const result = await executor.execute(baseInput());
+  assert.equal(result.response.status, 403);
+  const json = await result.response.json();
+  assert.equal(json.error.type, "cloudflare_challenge");
+});


### PR DESCRIPTION
## Summary

Ports the existing stealth-browser / `cf_clearance` infra (already live for `claude-web` and `duckduckgo-web`) to `grok-web`, in two parts.

**Part 1 (primary, fully unit-tested, no browser dependency).** `grok-web.ts` already imported `isCloudflareChallenge` from `grokTlsClient.ts` but never called it — so a Cloudflare anti-bot block ("Request rejected by anti-bot rules") was misclassified as a generic `authentication_error`, the exact complaint in #8019. A new pure helper `classifyGrokNullBodyError(status, text)` now distinguishes:
- Cloudflare challenge body → `type: "cloudflare_challenge"`, `code: "cf_mitigated_challenge"`, with an actionable message (cf_clearance is pinned to IP+TLS+UA and can't be replayed from a datacenter egress; use a residential IP or the official xAI API).
- 401/403 with a normal body → `authentication_error` (unchanged behavior, re-paste SSO cookie).
- 429 → `rate_limit_error` (regression guard, unchanged behavior).
- anything else → `upstream_error` (unchanged).

**Part 2 (secondary, gated; real-world effectiveness is VPS-gated).** Behind the existing `OMNIROUTE_BROWSER_POOL` / `WEB_COOKIE_USE_BROWSER` opt-in gate (same env vars already used by `claude-web.ts` / `duckduckgo-web.ts`), on a detected Cloudflare challenge the executor now attempts ONE browser-backed `cf_clearance` refresh via the provider-agnostic browser pool (`browserPool.ts` → new `open-sse/services/grokClearance.ts` helper) and retries `tlsFetchGrok` once with the fresh cookie injected. No new Turnstile solver — `claudeTurnstileSolver.ts` is claude.ai-specific and out of scope; this reuses the same generic pool primitive already live for the other two providers. On any acquisition/retry failure it falls through to the Part-1 `cloudflare_challenge` error — never throws.

Gate stays **off by default** (env var unset). Nothing changes for existing grok-web users who don't opt in.

## Files changed
- `open-sse/executors/grok-web.ts` — classification + gated retry wiring
- `open-sse/services/grokClearance.ts` (new) — `shouldUseGrokBrowserBacked()` gate + `acquireFreshGrokClearance()` (test-seam injectable, mirrors `browserBackedChat.ts`'s override pattern)
- `tests/unit/grok-web-cloudflare-classification.test.ts` (new) — 16 tests covering pure classification, executor wiring, and gated retry (gate OFF / gate ON+success / gate ON+acquisition-failure / gate ON+retry-still-challenged), all with a mocked TLS client and mocked browser acquisition — no real network/browser in CI
- `changelog.d/features/8019-grok-web-cloudflare-classification.md`

## Testing
- `node --import tsx/esm --test tests/unit/grok-web-cloudflare-classification.test.ts` — 16/16 green
- `node --import tsx/esm --test tests/unit/grok-web.test.ts tests/unit/grok-web-executor-split.test.ts` — 65/65 green (no regression)
- `npm run typecheck:core` / `npm run typecheck:noimplicit:core` — clean on changed files (pre-existing unrelated errors on `combo.ts`/`usageTracking.ts`/`cliRuntime.ts` confirmed identical on `origin/release/v3.8.49`, not touched by this PR)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files — clean
- `npm run check:complexity-ratchets` — flags a pre-existing regression (2156 vs baseline 2130) that is **identical** on a clean `origin/release/v3.8.49` checkout with none of this PR's changes applied (verified in an isolated detached worktree) — confirmed base-red, not introduced here. My new/edited functions in `grok-web.ts` do not appear in the ESLint complexity report at all.
- `node scripts/check/check-test-discovery.mjs` — new test file collected, OK
- `node scripts/check/check-file-size.mjs` — OK, `grok-web.ts` within baseline
- `npm run check:cycles` — OK, no new cycles

## Live check needed before Part 2 is fully trusted
Part 2's real-world effectiveness (whether the browser pool actually mints a usable cf_clearance from a Cloudflare-flagged datacenter egress) needs a live VPS check per Hard Rule #18: deploy to 192.168.0.15, connect a grok-web sso cookie from a flagged egress, set `OMNIROUTE_BROWSER_POOL=on`, issue a chat request, and confirm either a successful recovery or the distinct `cloudflare_challenge` error. Part 1 (the classification fix) is fully proven by the unit tests above and needs no live check.

Closes #8019