### PR TITLE
fix(dashboard): keep Compression Studio last after exclusions page (base-red slice 5)

### DIFF
--- a/src/shared/constants/sidebarVisibility/sections.ts
+++ b/src/shared/constants/sidebarVisibility/sections.ts
@@ -189,15 +189,6 @@ export const COMPRESSION_CONTEXT_GROUP: SidebarItemGroup = {
       icon: "grain",
     },
     {
-      id: "compression-studio",
-      href: "/dashboard/compression/studio",
-      i18nKey: "compressionStudio",
-      labelFallback: "Compression Studio",
-      subtitleKey: "compressionStudioSubtitle",
-      subtitleFallback: "Live engine cascade",
-      icon: "monitoring",
-    },
-    {
       id: "compression-exclusions",
       href: "/dashboard/compression/exclusions",
       i18nKey: "compressionExclusions",
@@ -205,6 +196,17 @@ export const COMPRESSION_CONTEXT_GROUP: SidebarItemGroup = {
       subtitleKey: "compressionExclusionsSubtitle",
       subtitleFallback: "Per-model/endpoint bypass",
       icon: "block",
+    },
+    // Compression Studio stays the final showcase item of the compression group
+    // (sidebar-engine-items "Studio must be last" invariant); new pages go above it.
+    {
+      id: "compression-studio",
+      href: "/dashboard/compression/studio",
+      i18nKey: "compressionStudio",
+      labelFallback: "Compression Studio",
+      subtitleKey: "compressionStudioSubtitle",
+      subtitleFallback: "Live engine cascade",
+      icon: "monitoring",
     },
   ],
 };

--- a/tests/unit/sidebar-visibility.test.ts
+++ b/tests/unit/sidebar-visibility.test.ts
@@ -57,6 +57,7 @@ test("primary sidebar items place limits after cache", () => {
       "context-aggressive",
       "context-ultra",
       "context-omniglyph",
+      "compression-exclusions",
       "compression-studio",
       "cli-code",
       "cli-agents",


### PR DESCRIPTION
## Cluster: sidebar exclusions ordering (base-red slice 5)

Quinto slice (após #8254, #8256, #8257, #8258). #8034/#8064 (per-model/endpoint compression exclusion filter) apendou `compression-exclusions` no **fim** do grupo de compressão, depois de `compression-studio`, quebrando o invariante deliberado "Compression Studio é o último item do grupo" (2 testes: `sidebar-engine-items` "Studio must be last" e o array de ordem exata de `sidebar-visibility`).

### Fix
Em vez de enfraquecer o invariante, movi `compression-exclusions` para **antes** de `compression-studio` em `sections.ts` (páginas novas ficam acima da vitrine Studio) e inseri o item no array esperado de `sidebar-visibility`.

### Validação
Todos os 5 suites de sidebar verdes: `sidebar-engine-items` 14/0, `sidebar-visibility` 7/0, `sidebar-monitoring-reorg` 7/0, `sidebar-back-compat` 6/0, `sidebar-tools-group` 5/0.