### PR TITLE
[v3.8.50] test(tail): realign 3 stale base-red guards + note 2 env-only false positives (slice 6)

### DIFF
--- a/tests/unit/i18n-missing-placeholder-fallback.test.ts
+++ b/tests/unit/i18n-missing-placeholder-fallback.test.ts
@@ -29,11 +29,7 @@ function loadLocale(locale: string): Record<string, unknown> {
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
-function collectPlaceholderLeaves(
-  node: unknown,
-  pathPrefix: string,
-  out: string[]
-): void {
+function collectPlaceholderLeaves(node: unknown, pathPrefix: string, out: string[]): void {
   if (node === null || typeof node !== "object") {
     if (typeof node === "string" && node.startsWith(PLACEHOLDER_PREFIX)) {
       out.push(pathPrefix);
@@ -47,18 +43,12 @@ function collectPlaceholderLeaves(
 }
 
 // ---------------------------------------------------------------------------
-// 1. Focused repro: the exact keys from the issue report
+// 1. (Retired) The original repro asserted zh-TW.json STILL carried raw
+// __MISSING__: placeholders. That translation backlog has since been filled, so
+// the sentinel no longer ships on disk — the invariant "no locale has a raw
+// __MISSING__: leaf" (test 3 below) is the durable guard. Keeping a test that
+// requires the backlog to EXIST would fail exactly when the content is healthy.
 // ---------------------------------------------------------------------------
-
-test("#7258 repro: zh-TW keys carry a raw __MISSING__: placeholder before the fix is exercised", () => {
-  const zhTW = loadLocale("zh-TW");
-  const leaves: string[] = [];
-  collectPlaceholderLeaves(zhTW, "", leaves);
-  assert.ok(
-    leaves.length > 0,
-    "expected zh-TW.json to still contain __MISSING__: placeholders (translation content backlog)"
-  );
-});
 
 test("#7258: deepMergeFallback replaces an untranslated __MISSING__ placeholder with the EN fallback value", () => {
   const target: Record<string, unknown> = {

--- a/tests/unit/qianfan-provider.test.ts
+++ b/tests/unit/qianfan-provider.test.ts
@@ -26,7 +26,7 @@ test("qianfan registers Baidu ERNIE as an OpenAI-compatible API key provider", (
 
   assert.ok(APIKEY_PROVIDERS.qianfan, "qianfan should be visible in API key providers");
   assert.equal(APIKEY_PROVIDERS.qianfan.name, "Baidu Qianfan");
-  assert.equal(APIKEY_PROVIDERS.qianfan.website, "https://cloud.baidu.com/product/wenxinworkshop");
+  assert.equal(APIKEY_PROVIDERS.qianfan.website, "https://cloud.baidu.com/product-s/qianfan_home");
   assert.equal(APIKEY_PROVIDERS.qianfan.passthroughModels, undefined);
 
   assert.equal(PROVIDERS.qianfan.baseUrl, registryEntry.baseUrl);


### PR DESCRIPTION
## Cluster: tail stale guards (base-red slice 6)

Sexto e último slice. Três guards de teste desatualizados, independentes, **test-only**:

- **i18n #7258**: o "focused repro" assertava que `zh-TW.json` **ainda** carrega placeholders `__MISSING__:`. Esse backlog de tradução foi preenchido, então o sentinel não é mais enviado no disco. Aposentei o repro (ele falha justamente quando o conteúdo está saudável); o guard durável "nenhum locale tem folha `__MISSING__:`" já cobre o fix.
- **OAuthModal #7610**: o aviso de bare-JWT foi **reformulado** ("...not just the JWT `key` field", ainda tagueado `#7610`) — a proteção está intacta, só a cópia mudou. Regexes de source-scan atualizadas.
- **qianfan**: a Baidu renomeou a página do produto (`product/wenxinworkshop`→`product-s/qianfan_home`); URL esperada atualizada.

### ⚠️ 2 falsos base-reds descobertos (NÃO consertados — não são bugs)
`mcp-extra-forward-6178` e `ccr-mcp-integration` **só falham com `OMNIROUTE_API_KEY` setada no shell** — `resolveCcrPrincipal` prefere o principal resolvido via env ao `extra` do stdio. Em CI limpo (sem essa var) passam. Meu run local completo inicial (54 falhas) estava inflado por essa poluição de ambiente.

### Validação (env limpo)
i18n **4/0**, oauth-modal-grok **2/0**, qianfan **5/0**.