### PR TITLE
fix(providers): add Poe registry entry so model discovery resolves base URL (#8082)

### DIFF
--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -171,6 +171,7 @@ import { chenzkProvider } from "./registry/chenzk/index.ts";
 import { factoryProvider } from "./registry/factory/index.ts";
 import { databricksProvider } from "./registry/databricks/index.ts";
 import { rekaProvider } from "./registry/reka/index.ts";
+import { poeProvider } from "./registry/poe/index.ts";
 import { vercel_ai_gatewayProvider } from "./registry/vercel-ai-gateway/index.ts";
 import { v0_vercelProvider } from "./registry/v0-vercel/index.ts";
 import { opencode_zenProvider } from "./registry/opencode/zen/index.ts";
@@ -380,6 +381,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   factory: factoryProvider,
   databricks: databricksProvider,
   reka: rekaProvider,
+  poe: poeProvider,
   "vercel-ai-gateway": vercel_ai_gatewayProvider,
   "v0-vercel": v0_vercelProvider,
   "opencode-zen": opencode_zenProvider,

--- a/open-sse/config/providers/registry/poe/index.ts
+++ b/open-sse/config/providers/registry/poe/index.ts
@@ -1,0 +1,18 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+export const poeProvider: RegistryEntry = {
+  id: "poe",
+  alias: "poe",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://api.poe.com/v1/chat/completions",
+  authType: "apikey",
+  authHeader: "bearer",
+  models: [
+    // Poe is a passthrough gateway — the live /v1/models catalog is the real
+    // source of truth. These are seed entries for offline fallback only.
+    { id: "GPT-4o", name: "GPT-4o" },
+    { id: "Claude-Sonnet-4", name: "Claude Sonnet 4" },
+    { id: "Gemini-2.5-Pro", name: "Gemini 2.5 Pro" },
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes #8082. The built-in Poe provider could not fetch or import models — model discovery failed with `No base URL configured for provider`, even though inference worked fine.

## Root Cause

Poe was listed in `NAMED_OPENAI_STYLE_PROVIDERS` (so model discovery tried to use it), but had **no registry entry** in `open-sse/config/providers/`. `getRegistryEntry('poe')` returned `undefined`, so `registryEntry?.baseUrl` was null → error.

Inference worked because it resolves the endpoint through the executor path (`open-sse/executors/poe-web.ts`), which has its own URL resolution independent of the registry.

## Changes

- **`open-sse/config/providers/registry/poe/index.ts`** (new): Minimal registry entry with `baseUrl: "https://api.poe.com/v1/chat/completions"`, `format: "openai"`, `authType: "apikey"`, and seed models for offline fallback. The live `/v1/models` catalog remains the real source of truth (`passthroughModels: true` in gateways.ts).
- **`open-sse/config/providers/index.ts`**: Import and register `poe: poeProvider` in the REGISTRY.

## Verification

- `npx tsc --pretty false -p tsconfig.typecheck-core.json` — zero errors
- `tests/unit/acp-registry.test.ts` — 5/5 pass

2 files changed, +20