### PR TITLE
fix(providers): update Learn more documentation link

### DIFF
--- a/changelog.d/fixes/8284-provider-docs-link.md
+++ b/changelog.d/fixes/8284-provider-docs-link.md
@@ -1,0 +1,1 @@
+- **fix(providers):** the Providers page Learn more button now opens the maintained GitHub documentation instead of the retired `docs.omniroute.io` page ([#8284](https://github.com/diegosouzapw/OmniRoute/pull/8284)) - thanks @KaynXu

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -828,7 +828,7 @@ export default function ProvidersPage() {
                 {providerText(t, "onboardingWizard", "Provider Onboarding Wizard")}
               </Button>
               <a
-                href="https://docs.omniroute.io/providers"
+                href="https://github.com/diegosouzapw/OmniRoute#-documentation"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border border-border text-text-muted hover:text-text-main hover:bg-bg-subtle transition-colors"

--- a/tests/unit/provider-learn-more-link.test.ts
+++ b/tests/unit/provider-learn-more-link.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const providersPage = readFileSync(
+  join(repoRoot, "src/app/(dashboard)/dashboard/providers/page.tsx"),
+  "utf8"
+);
+
+test("provider Learn more link uses the maintained documentation entry point", () => {
+  assert.match(
+    providersPage,
+    /href="https:\/\/github\.com\/diegosouzapw\/OmniRoute#-documentation"/,
+    "the provider help CTA should open the maintained GitHub documentation section"
+  );
+});
+
+test("provider Learn more link does not use the retired documentation host", () => {
+  assert.doesNotMatch(
+    providersPage,
+    /https:\/\/docs\.omniroute\.io\/providers/,
+    "docs.omniroute.io/providers is no longer reachable"
+  );
+});


### PR DESCRIPTION
## Summary

- replace the Providers page's unreachable `docs.omniroute.io/providers` Learn more target with the maintained GitHub documentation section
- add a regression guard that requires the maintained URL and rejects the retired host

## Root cause

The Providers dashboard hard-coded a documentation host that no longer completes a TLS connection. The maintained documentation entry point now lives in the repository README.

## User impact

The Learn more button on the Providers page opens working documentation again instead of a dead page.

## Validation

- `curl -L https://docs.omniroute.io/providers` -> TLS failure / HTTP 000
- `curl -L https://github.com/diegosouzapw/OmniRoute#-documentation` -> HTTP 200
- `npx -y tsx@4.20.6 --test tests/unit/provider-learn-more-link.test.ts` -> 2 passed
- `npx -y prettier@3.9.6 --check ...` -> passed
- `node scripts/check/check-file-size.mjs` -> passed
- `git diff --check` -> passed

Targeted ESLint was not available locally because the repository dependency install stalled in `tls-client-node`'s postinstall before npm completed the dependency tree. CI should provide the authoritative lint result.

Reported and verified by @KaynXu.
