### PR TITLE
fix(resilience): skip terminal connections in token health check sweep (#8182)

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -399,6 +399,17 @@ export async function checkConnection(conn) {
   const intervalMin = conn.healthCheckInterval ?? DEFAULT_HEALTH_CHECK_INTERVAL_MIN;
   if (intervalMin <= 0) return;
   if (!conn.isActive) return;
+
+  // #8182: skip terminal connections (credits_exhausted / banned / expired).
+  // These can never self-heal via a token refresh — probing them wastes
+  // CPU and network on every sweep cycle. Mirrors isTerminalConnectionStatus
+  // in src/sse/services/auth.ts and TERMINAL_CONNECTION_STATUSES in
+  // src/lib/quota/connectionRecovery.ts.
+  const terminalStatuses = new Set(["credits_exhausted", "banned", "expired"]);
+  if (typeof conn.testStatus === "string" && terminalStatuses.has(conn.testStatus.toLowerCase())) {
+    return;
+  }
+
   if (!conn.refreshToken || typeof conn.refreshToken !== "string") {
     if (isGitHubAccessTokenOnlyConnection(conn)) {
       const now = new Date().toISOString();


### PR DESCRIPTION
## Summary

Fixes #8182. Background token health check sweep was probing connections with terminal statuses (`credits_exhausted` / `banned` / `expired`) on every cycle, wasting CPU and network. These connections can never self-heal via token refresh — they need manual re-auth or credit top-up.

## Root Cause

`checkConnection()` in `src/lib/tokenHealthCheck.ts` only checked `isActive` before probing. A connection with `testStatus: "credits_exhausted"` and `isActive: true` was still probed every sweep cycle (~60s). The request path (`auth.ts`) and recovery path (`connectionRecovery.ts`) both skip terminal statuses, but the health check sweep did not.

Reporter confirmed: after manually disabling 11 `credits_exhausted` connections, CPU dropped from ~53% to ~2.7%.

## Changes

- **`src/lib/tokenHealthCheck.ts`**: Add terminal status guard in `checkConnection()` — skip connections with `testStatus` in `{credits_exhausted, banned, expired}`. Mirrors the existing `isTerminalConnectionStatus()` in `src/sse/services/auth.ts` and `TERMINAL_CONNECTION_STATUSES` in `src/lib/quota/connectionRecovery.ts`.

## Verification

- `npx tsc --pretty false -p tsconfig.typecheck-core.json` — zero errors
- `tests/unit/auth-terminal-status.test.ts` + `tests/unit/apikey-connection-health-check.test.ts` — 15/15 pass

1 file changed, +11