### PR TITLE
fix(sanitizer): strip zero-width chars from Anthropic-native streaming text_delta (#8271)

### DIFF
--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -519,10 +519,7 @@ function sanitizeResponsesUsage(usage: unknown): unknown {
 
   const inputDetails = toRecord(normalized.input_tokens_details) || {};
   const cachedTokens = normalized.cached_tokens ?? normalized.cache_read_input_tokens;
-  if (
-    cachedTokens !== undefined &&
-    inputDetails.cached_tokens === undefined
-  ) {
+  if (cachedTokens !== undefined && inputDetails.cached_tokens === undefined) {
     inputDetails.cached_tokens = cachedTokens;
   }
   if (
@@ -1003,6 +1000,23 @@ export function sanitizeStreamingChunk(parsed: unknown): unknown {
   const eventType = toString(parsedRecord.type) || "";
   if (eventType.startsWith("response.") || parsedRecord.object === "response") {
     return sanitizeResponsesStreamingEvent(parsedRecord);
+  }
+
+  // #8271: Anthropic-native streaming events (content_block_delta with
+  // text_delta / thinking_delta) bypass the OpenAI choices[].delta.content
+  // path below. Strip zero-width characters from their text payloads so
+  // U+200D and friends don't leak to the client on the Messages API.
+  if (eventType === "content_block_delta") {
+    const deltaRecord = toRecord(parsedRecord.delta);
+    if (deltaRecord) {
+      if (typeof deltaRecord.text === "string") {
+        deltaRecord.text = stripZeroWidthText(deltaRecord.text);
+      }
+      if (typeof deltaRecord.thinking === "string") {
+        deltaRecord.thinking = stripZeroWidthText(deltaRecord.thinking);
+      }
+    }
+    return parsedRecord;
   }
 
   // Build sanitized chunk


### PR DESCRIPTION
## Summary

Fixes #8271. `sanitizeStreamingChunk()` only stripped zero-width characters (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`) from OpenAI-format `choices[].delta.content`. Anthropic-native `content_block_delta` events with `text_delta` or `thinking_delta` payloads bypassed that path entirely, leaking zero-width characters to clients on the Messages API streaming route.

## Root Cause

The sanitizer had two code paths:
1. `response.*` events → `sanitizeResponsesStreamingEvent()`
2. OpenAI `choices[].delta.content` → zero-width strip

Anthropic `content_block_delta` events fell through as unrecognized and were returned with only `id`/`object`/`created`/`model` stripped — text payloads (`delta.text`, `delta.thinking`) passed through unmodified.

## Changes

- **`open-sse/handlers/responseSanitizer.ts`**: Add a `content_block_delta` branch that strips zero-width characters from `delta.text` and `delta.thinking` before returning the event. Matches the existing OpenAI path behavior from #5857.

## Verification

- `npx tsc --pretty false -p tsconfig.typecheck-core.json` — zero errors
- `tests/unit/response-sanitizer.test.ts` — 50/50 pass

1 file changed, +17