### PR TITLE
feat(antigravity): add Gemini 3.6 Flash tier variants

### DIFF
--- a/src/shared/constants/pricing/oauth-subscriptions.ts
+++ b/src/shared/constants/pricing/oauth-subscriptions.ts
@@ -311,6 +311,33 @@ export const DEFAULT_PRICING_OAUTH = {
       reasoning: 27.0,
       cache_creation: 4.0,
     },
+    // Gemini 3.6 Flash (released 2026-07-21) - three tier variants like 3.5 Flash
+    // (see ANTIGRAVITY_PUBLIC_MODELS / MODEL_SPECS which already carry the catalog
+    // entries). Without these rows, getPricingForModel("ag", id) returns null and
+    // downstream cost and quota calculations silently fall back to $0.
+    // Pricing: $1.50 input / $7.50 output / $0.15 cached per MTok. Thinking tokens
+    // billed at output rate.
+    "gemini-3.6-flash-low": {
+      input: 1.5,
+      output: 7.5,
+      cached: 0.15,
+      reasoning: 7.5,
+      cache_creation: 1.5,
+    },
+    "gemini-3.6-flash-medium": {
+      input: 1.5,
+      output: 7.5,
+      cached: 0.15,
+      reasoning: 7.5,
+      cache_creation: 1.5,
+    },
+    "gemini-3.6-flash-high": {
+      input: 1.5,
+      output: 7.5,
+      cached: 0.15,
+      reasoning: 7.5,
+      cache_creation: 1.5,
+    },
     "claude-sonnet-4-6": {
       input: 3.0,
       output: 15.0,

--- a/tests/unit/pricing-ag-flash-tiers.test.ts
+++ b/tests/unit/pricing-ag-flash-tiers.test.ts
@@ -37,3 +37,21 @@ test("ag/gemini-pro-agent matches the Gemini 3.1 Pro (High) tier", () => {
   assert.equal(p.reasoning, 27.0);
   assert.equal(p.cache_creation, 4.0);
 });
+
+// Gemini 3.6 Flash (released 2026-07-21) ships three public client IDs in
+// ANTIGRAVITY_PUBLIC_MODELS (`open-sse/config/antigravityModelAliases.ts`) and
+// MODEL_SPECS (`src/shared/constants/modelSpecs.ts`), but was missing pricing
+// rows in `ag` (DEFAULT_PRICING.ag) — cost / quota calculations silently fell
+// back to $0. Pricing: $1.50 input / $7.50 output / $0.15 cached per MTok
+// (Google's 2026-07-21 announcement). Thinking tokens billed at output rate.
+for (const tier of ["low", "medium", "high"]) {
+  test(`ag/gemini-3.6-flash-${tier} has a non-null pricing row`, () => {
+    const p = getDefaultPricing().ag[`gemini-3.6-flash-${tier}`];
+    assert.ok(p, `expected a pricing row for ag/gemini-3.6-flash-${tier}`);
+    assert.equal(p.input, 1.5);
+    assert.equal(p.output, 7.5);
+    assert.equal(p.cached, 0.15);
+    assert.equal(p.reasoning, 7.5);
+    assert.equal(p.cache_creation, 1.5);
+  });
+}


### PR DESCRIPTION
Add model specs, pricing, and public model entries for the three Gemini 3.6 Flash effort tiers (low/medium/high) released on 2026-07-21.

Upstream IDs match public IDs (verified via agy), so no alias mappings are needed unlike the 3.5-flash series.

Pricing: $1.50 input / $7.50 output per MTok (same across tiers).