### PR TITLE
fix(api): enforce image generation API key auth

### DIFF
--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -26,6 +26,8 @@ import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { calculateModalCost } from "@/lib/usage/costCalculator";
 import { generateRequestId } from "@/shared/utils/requestId";
 import { getSpecialtyModelsResponse } from "@/app/api/v1/_shared/specialtyCatalog";
+import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
 
 export const dynamic = "force-dynamic";
 
@@ -102,6 +104,16 @@ async function postHandler(request, context) {
   }
   const body = validation.data;
   const startTime = Date.now();
+
+  // Authenticate before policy enforcement. Policy checks intentionally allow
+  // keyless local mode and assume the route has already rejected invalid keys.
+  const apiKeyRaw = extractApiKey(request);
+  if (isRequireApiKeyEnabled() && !apiKeyRaw) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required");
+  }
+  if (apiKeyRaw && !(await isValidApiKey(apiKeyRaw))) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
 
   // Enforce API key policies (model restrictions + budget limits)
   const policy = await enforceApiKeyPolicy(request, body.model);
@@ -215,14 +227,21 @@ async function postHandler(request, context) {
   }
 
   const generateImage = () =>
-    handleImageGeneration({
-      body,
-      credentials,
-      log,
-      ...(isCustomModel && { resolvedProvider: provider }),
-      signal: request.signal,
-      clientHeaders: publicBaseUrlHeaders(request.headers),
-    });
+    runWithCallLogApiKeyContext(
+      {
+        apiKeyId: policy.apiKeyInfo?.id ?? null,
+        apiKeyName: policy.apiKeyInfo?.name ?? null,
+      },
+      () =>
+        handleImageGeneration({
+          body,
+          credentials,
+          log,
+          ...(isCustomModel && { resolvedProvider: provider }),
+          signal: request.signal,
+          clientHeaders: publicBaseUrlHeaders(request.headers),
+        })
+    );
 
   // Execute with proxy context when available, direct otherwise (#1904)
   const result = await (credentials?.connectionId

--- a/src/app/api/v1/providers/[provider]/images/generations/route.ts
+++ b/src/app/api/v1/providers/[provider]/images/generations/route.ts
@@ -13,6 +13,8 @@ import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 import { v1ImageGenerationSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
 
 /**
  * Handle CORS preflight
@@ -55,6 +57,14 @@ export async function POST(request, { params }) {
     body.model = `${rawProvider}/${body.model}`;
   }
 
+  const apiKeyRaw = extractApiKey(request);
+  if (isRequireApiKeyEnabled() && !apiKeyRaw) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required");
+  }
+  if (apiKeyRaw && !(await isValidApiKey(apiKeyRaw))) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
+
   // Enforce API key policies (model restrictions + budget limits)
   const policy = await enforceApiKeyPolicy(request, body.model);
   if (policy.rejection) return policy.rejection;
@@ -84,7 +94,13 @@ export async function POST(request, { params }) {
     );
   }
 
-  const result = await handleImageGeneration({ body, credentials, log });
+  const result = await runWithCallLogApiKeyContext(
+    {
+      apiKeyId: policy.apiKeyInfo?.id ?? null,
+      apiKeyName: policy.apiKeyInfo?.name ?? null,
+    },
+    () => handleImageGeneration({ body, credentials, log })
+  );
 
   if (result.success) {
     await clearRecoveredProviderState(credentials);

--- a/src/lib/usage/callLogApiKeyContext.ts
+++ b/src/lib/usage/callLogApiKeyContext.ts
@@ -1,0 +1,26 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface CallLogApiKeyContext {
+  apiKeyId: string | null;
+  apiKeyName: string | null;
+}
+
+const callLogApiKeyContext = new AsyncLocalStorage<CallLogApiKeyContext>();
+
+/**
+ * Bind API-key attribution to every call log emitted by one request.
+ *
+ * Modal handlers fan out into provider-specific helpers that write their own
+ * call logs. Request-scoped storage keeps that attribution available without
+ * threading identity parameters through every provider handler.
+ */
+export function runWithCallLogApiKeyContext<TResult>(
+  context: CallLogApiKeyContext,
+  callback: () => TResult
+): TResult {
+  return callLogApiKeyContext.run(context, callback);
+}
+
+export function getCallLogApiKeyContext(): CallLogApiKeyContext | null {
+  return callLogApiKeyContext.getStore() ?? null;
+}

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -12,6 +12,7 @@ import { getDbInstance } from "../db/core";
 import { collectReferencedArtifacts, selectCallLogIdsBefore } from "./callLogsBoundedQueries";
 import { getRequestDetailLogByCallLogId } from "../db/detailedLogs";
 import { shouldPersistToDisk } from "./migrations";
+import { getCallLogApiKeyContext } from "./callLogApiKeyContext";
 import {
   getLoggedInputTokens,
   getLoggedOutputTokens,
@@ -550,7 +551,9 @@ export async function saveCallLog(entry: any) {
   if (!shouldPersistToDisk) return;
 
   try {
-    const apiKeyId = entry.apiKeyId || null;
+    const apiKeyContext = getCallLogApiKeyContext();
+    const apiKeyId = entry.apiKeyId ?? apiKeyContext?.apiKeyId ?? null;
+    const apiKeyName = entry.apiKeyName ?? apiKeyContext?.apiKeyName ?? null;
     const noLogEnabled = Boolean(entry.noLog) || (apiKeyId ? isNoLog(apiKeyId) : false);
 
     const protectedRequestBody = noLogEnabled ? null : protectPayloadForLog(entry.requestBody);
@@ -597,7 +600,7 @@ export async function saveCallLog(entry: any) {
       sourceFormat: entry.sourceFormat || null,
       targetFormat: entry.targetFormat || null,
       apiKeyId,
-      apiKeyName: entry.apiKeyName || null,
+      apiKeyName,
       comboName: entry.comboName || null,
       comboStepId: toStringOrNull(entry.comboStepId),
       comboExecutionKey:

--- a/tests/unit/image-generation-route.test.ts
+++ b/tests/unit/image-generation-route.test.ts
@@ -12,7 +12,10 @@ const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
+const { getCallLogs } = await import("../../src/lib/usage/callLogs.ts");
 const imageRoute = await import("../../src/app/api/v1/images/generations/route.ts");
+const providerImageRoute =
+  await import("../../src/app/api/v1/providers/[provider]/images/generations/route.ts");
 const imageEditRoute = await import("../../src/app/api/v1/images/edits/route.ts");
 const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
 
@@ -42,6 +45,22 @@ async function seedConnection(provider: string, overrides: { apiKey?: string | n
     testStatus: "active",
     providerSpecificData: {},
   });
+}
+
+async function waitForCallLog(apiKeyId: string, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const logs = await getCallLogs({ apiKey: apiKeyId, limit: 5 });
+    const match = logs.find((log: { apiKeyId?: string | null }) => log.apiKeyId === apiKeyId);
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const body = (await response.json()) as { error?: { message?: unknown } };
+  return typeof body.error?.message === "string" ? body.error.message : "";
 }
 
 test.beforeEach(async () => {
@@ -143,6 +162,170 @@ test("v1 image generation POST still requires prompts for text-input models", as
 
   assert.equal(response.status, 400);
   assert.match(body.error.message, /Prompt is required for image model: openai\/gpt-image-2/);
+});
+
+test("v1 image generation POST requires an API key when REQUIRE_API_KEY is enabled", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "openai/gpt-image-2",
+          prompt: "authentication test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Authentication required/);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+test("v1 image generation POST rejects an invalid presented API key", async () => {
+  const originalOmniRouteApiKey = process.env.OMNIROUTE_API_KEY;
+  process.env.OMNIROUTE_API_KEY = "valid-image-route-key";
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer invalid-image-route-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "openai/gpt-image-2",
+          prompt: "invalid authentication test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Invalid API key/);
+  } finally {
+    if (originalOmniRouteApiKey === undefined) {
+      delete process.env.OMNIROUTE_API_KEY;
+    } else {
+      process.env.OMNIROUTE_API_KEY = originalOmniRouteApiKey;
+    }
+  }
+});
+
+test("v1 image generation POST attributes its call log to the validated API key", async () => {
+  const createdKey = await apiKeysDb.createApiKey(
+    "Image generation caller",
+    "machine-image-generation"
+  );
+  await seedConnection("openai", { apiKey: "image-provider-key" });
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    return new Response(
+      JSON.stringify({
+        created: 123,
+        data: [{ url: "https://cdn.example.com/attributed-image.png" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/api/v1/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createdKey.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "openai/gpt-image-2",
+        prompt: "call log attribution test",
+      }),
+    })
+  );
+
+  assert.equal(response.status, 200);
+  const logged = await waitForCallLog(createdKey.id);
+  assert.ok(logged, "expected an attributed image-generation call log");
+  assert.equal(logged.apiKeyId, createdKey.id);
+  assert.equal(logged.apiKeyName, "Image generation caller");
+});
+
+test("provider-scoped image generation requires an API key when configured", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await providerImageRoute.POST(
+      new Request("http://localhost/api/v1/providers/openai/images/generations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-image-2",
+          prompt: "provider-scoped authentication test",
+        }),
+      }),
+      { params: Promise.resolve({ provider: "openai" }) }
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Authentication required/);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+test("provider-scoped image generation attributes its call log to the validated API key", async () => {
+  const createdKey = await apiKeysDb.createApiKey(
+    "Provider-scoped image caller",
+    "machine-provider-image"
+  );
+  await seedConnection("openai", { apiKey: "provider-scoped-upstream-key" });
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    return new Response(
+      JSON.stringify({
+        created: 456,
+        data: [{ url: "https://cdn.example.com/provider-scoped-image.png" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await providerImageRoute.POST(
+    new Request("http://localhost/api/v1/providers/openai/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createdKey.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-image-2",
+        prompt: "provider-scoped attribution test",
+      }),
+    }),
+    { params: Promise.resolve({ provider: "openai" }) }
+  );
+
+  assert.equal(response.status, 200);
+  const logged = await waitForCallLog(createdKey.id);
+  assert.ok(logged, "expected an attributed provider-scoped image-generation call log");
+  assert.equal(logged.apiKeyId, createdKey.id);
+  assert.equal(logged.apiKeyName, "Provider-scoped image caller");
 });
 
 test("v1 image edit POST enforces disabled API key policy", async () => {


### PR DESCRIPTION
## Summary

- Enforce `REQUIRE_API_KEY` and reject invalid presented keys on canonical and provider-scoped image generation routes.
- Propagate validated API-key identity through request-scoped storage so every provider-specific image call log records `api_key_id` and `api_key_name`.
- Restore per-key no-log behavior for image generation calls.

## Related Issues

- No linked issue; prompted by a production call-log attribution incident.

## Validation

- [x] `npm run lint`
- [ ] `npm run test:unit` (targeted route suite passes 13/13; full suite exits 1 on unrelated baseline/platform failures described below)
- [ ] `npm run test:coverage` (coverage thresholds pass, but the command exits 1 on the same unrelated test failures)
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
- [x] `npm run typecheck:core`
- [x] `npm run build`

## Tests Added Or Updated

- `tests/unit/image-generation-route.test.ts`
  - rejects missing keys when `REQUIRE_API_KEY=true`
  - rejects invalid presented keys
  - persists API-key id/name for canonical image generation
  - covers auth and attribution on the provider-scoped route

## Coverage Notes

The updated route suite exercises both authentication branches and successful call-log attribution. Full coverage completed above the configured thresholds: 83.04% statements, 83.04% lines, 87.05% functions, and 78.18% branches.

The full unit/coverage command still exits 1 on failures unrelated to this change, including CRLF-sensitive golden snapshots on this checkout and `tls-profiles-valid-5591` rejecting the existing `chrome_149` profile while the installed wreq-js catalog ends at `chrome_147`.

## Reviewer Notes

Image provider handlers emit call logs in many provider-specific branches. `AsyncLocalStorage` keeps the validated key identity request-scoped and concurrency-safe without threading attribution arguments through each handler. Explicit call-log API-key fields still take precedence. No schema or migration changes are required.

The local Husky scripts are checked out with CRLF and cannot execute under `/usr/bin/env sh`; their documented commands were run manually before committing. The pre-push hook is intentionally a no-op.