### PR TITLE
fix(runtime): isolate unique repairs from #8177

### DIFF
--- a/changelog.d/fixes/8298-focused-8177-runtime-fixes.md
+++ b/changelog.d/fixes/8298-focused-8177-runtime-fixes.md
@@ -1,0 +1,1 @@
+- **fix(runtime):** sanitize Muse Spark fetch failures before logging and resolve the sql.js WASM asset without the unexported package metadata subpath ([#8298](https://github.com/diegosouzapw/OmniRoute/pull/8298)) — thanks @backryun

--- a/open-sse/executors/muse-spark-web.ts
+++ b/open-sse/executors/muse-spark-web.ts
@@ -942,7 +942,9 @@ async function graphqlPost(
   } catch (err) {
     return {
       ok: false,
-      error: `${label} fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      error: `${label} fetch failed: ${sanitizeErrorMessage(
+        err instanceof Error ? err.message : String(err)
+      )}`,
     };
   }
 }

--- a/scripts/check/check-error-helper.mjs
+++ b/scripts/check/check-error-helper.mjs
@@ -43,10 +43,6 @@ export const KNOWN_MISSING_ERROR_HELPER = new Set([
   // --- original open-sse/executors + handlers scope (pre-6A.8) ---
   // --- 6A.8 expanded scope: src/app/api/**/route.ts pre-existing violations ---
   // TODO(6A.8): pre-existing, triage — route through buildErrorBody()/sanitizeErrorMessage()
-  // open-sse/executors/muse-spark-web.ts has its own local buildErrorResponse() + errorResult()
-  // that follow the same contract (wraps message inside error:{message,type}). The helper
-  // import would create a circular dep. Verified: no raw internal-stack-leak path.
-  "open-sse/executors/muse-spark-web.ts",
 ]);
 
 // Import specifiers that count as "uses the error helper" (path ends in utils/error).

--- a/src/lib/db/adapters/sqljsAdapter.ts
+++ b/src/lib/db/adapters/sqljsAdapter.ts
@@ -31,18 +31,6 @@ function resolveSqlJsWasmPath(): string {
     const sqlJsEntry = _require.resolve("sql.js");
     candidatePaths.push(path.join(path.dirname(sqlJsEntry), "sql-wasm.wasm"));
   } catch {}
-  // #8135: Use a dynamic expression to avoid Next.js bundler's static analysis
-  // producing a "Can't resolve 'sql.js/package.json'" build warning. The package.json
-  // resolution is only needed for the WASM path, and the try/catch is still required
-  // at runtime since sql.js is an optional dependency.
-  try {
-    const pkgName = "sql.js" + "/package.json";
-    const sqlJsPackage = _require.resolve(pkgName);
-    candidatePaths.push(
-      path.join(path.dirname(sqlJsPackage), "dist", "sql-wasm.wasm"),
-      path.join(path.dirname(sqlJsPackage), "sql-wasm.wasm")
-    );
-  } catch {}
 
   for (const candidatePath of candidatePaths) {
     if (fs.existsSync(candidatePath)) {

--- a/tests/unit/muse-spark-web-continuation.test.ts
+++ b/tests/unit/muse-spark-web-continuation.test.ts
@@ -241,16 +241,27 @@ test("muse-spark-web: fetch failures do not expose stack traces or source paths"
   __resetMuseSparkConversationCacheForTesting();
   const executor = new MuseSparkWebExecutor();
   const originalFetch = globalThis.fetch;
+  const errorLogs: string[] = [];
   globalThis.fetch = async () => {
     throw new Error("socket failed at /srv/omniroute/secrets.ts:42\n    at fetchGraphql");
   };
 
   try {
-    const result = await executor.execute(withConnection("conn-fetch-error"));
+    const result = await executor.execute(
+      withConnection("conn-fetch-error", {
+        log: {
+          error(_tag, message) {
+            errorLogs.push(message);
+          },
+        },
+      })
+    );
     assert.equal(result.response.status, 502);
     const body = await result.response.json();
     assert.equal(body.error.message, "Warmup fetch failed: socket failed at <path>");
     assert.doesNotMatch(body.error.message, /secrets\.ts|fetchGraphql|\n/);
+    assert.deepEqual(errorLogs, ["Warmup failed: Warmup fetch failed: socket failed at <path>"]);
+    assert.doesNotMatch(errorLogs[0], /secrets\.ts|fetchGraphql|\n/);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/sqljs-build-warning-8135.test.ts
+++ b/tests/unit/sqljs-build-warning-8135.test.ts
@@ -35,4 +35,10 @@ test("#8135: sqljsAdapter must not statically resolve sql.js at build time", () 
     source.includes("/* webpackIgnore: true */"),
     "sqljsAdapter dynamic import should include /* webpackIgnore: true */ magic comment"
   );
+
+  // sql.js does not export ./package.json. Resolving its public entrypoint is
+  // sufficient to locate the adjacent WASM asset and avoids repeated bundler
+  // diagnostics for the private package metadata subpath.
+  assert.match(source, /_require\.resolve\(["']sql\.js["']\)/);
+  assert.doesNotMatch(source, /sql\.js\/package\.json/);
 });


### PR DESCRIPTION
## Summary

- Follow up on the maintainer feedback in #8177 with a focused branch against the current `release/v3.8.49` tip.
- Sanitize Muse Spark GraphQL fetch exceptions before they reach either executor logs or client-facing error handling.
- Resolve the sql.js WASM asset from the package's public entrypoint and remove the unexported `sql.js/package.json` lookup.
- Remove the now-obsolete Muse Spark exception from the error-helper gate.

## Scope

This intentionally excludes the overlapping base-red reconciliation work from #8177:

- `reasoningPlaceholder` is owned by #8254.
- the adaptive compression ladder is owned by #8256.
- `chat.ts` / `chatPredicates.ts` are owned by #8258.
- complexity and ESLint baseline reconciliation remain release-captain work.

Only the two runtime fixes that remain unique on the current release tip are included.

## Root cause

Muse Spark sanitized its HTTP response after a GraphQL fetch failure, but logged the intermediate error first. That left absolute source paths and stack-tail text visible in executor logs.

The sql.js fallback resolved `sql.js/package.json`, but sql.js does not export that private subpath. The already-present public `sql.js` entrypoint resolves beside `sql-wasm.wasm`, so the metadata lookup is unnecessary and causes repeated Turbopack diagnostics.

## Validation

- `node --import tsx/esm --test tests/unit/muse-spark-web-continuation.test.ts tests/unit/sqljs-build-warning-8135.test.ts` — 8/8 passed.
- `npm run typecheck:core` — passed.
- `node scripts/check/check-error-helper.mjs` — passed with zero frozen exceptions.
- `npm run build` — passed; the `sql.js/package.json` missing-subpath warning is absent.
- `git diff --check` — passed.
