### PR TITLE
fix(api): enforce image generation API key auth

### DIFF
--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -28,6 +28,8 @@ import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { calculateModalCost } from "@/lib/usage/costCalculator";
 import { generateRequestId } from "@/shared/utils/requestId";
 import { getSpecialtyModelsResponse } from "@/app/api/v1/_shared/specialtyCatalog";
+import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
 
 export const dynamic = "force-dynamic";
 
@@ -104,6 +106,16 @@ async function postHandler(request, context) {
   }
   const body = validation.data;
   const startTime = Date.now();
+
+  // Authenticate before policy enforcement. Policy checks intentionally allow
+  // keyless local mode and assume the route has already rejected invalid keys.
+  const apiKeyRaw = extractApiKey(request);
+  if (isRequireApiKeyEnabled() && !apiKeyRaw) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required");
+  }
+  if (apiKeyRaw && !(await isValidApiKey(apiKeyRaw))) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
 
   // Enforce API key policies (model restrictions + budget limits)
   const policy = await enforceApiKeyPolicy(request, body.model);
@@ -231,14 +243,21 @@ async function postHandler(request, context) {
   }
 
   const generateImage = () =>
-    handleImageGeneration({
-      body,
-      credentials,
-      log,
-      ...(isCustomModel && { resolvedProvider: provider }),
-      signal: request.signal,
-      clientHeaders: publicBaseUrlHeaders(request.headers),
-    });
+    runWithCallLogApiKeyContext(
+      {
+        apiKeyId: policy.apiKeyInfo?.id ?? null,
+        apiKeyName: policy.apiKeyInfo?.name ?? null,
+      },
+      () =>
+        handleImageGeneration({
+          body,
+          credentials,
+          log,
+          ...(isCustomModel && { resolvedProvider: provider }),
+          signal: request.signal,
+          clientHeaders: publicBaseUrlHeaders(request.headers),
+        })
+    );
 
   // Execute with proxy context when available, direct otherwise (#1904)
   const result = await (credentials?.connectionId

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -3,8 +3,6 @@ import { withInjectionGuard } from "@/middleware/promptInjectionGuard";
 import {
   getProviderCredentialsWithQuotaPreflight,
   clearRecoveredProviderState,
-  extractApiKey,
-  isValidApiKey,
 } from "@/sse/services/auth";
 import {
   parseImageModel,
@@ -28,7 +26,7 @@ import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { calculateModalCost } from "@/lib/usage/costCalculator";
 import { generateRequestId } from "@/shared/utils/requestId";
 import { getSpecialtyModelsResponse } from "@/app/api/v1/_shared/specialtyCatalog";
-import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { enforceClientApiRouteAuth } from "@/shared/utils/clientApiRouteAuth";
 import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
 
 export const dynamic = "force-dynamic";
@@ -109,13 +107,8 @@ async function postHandler(request, context) {
 
   // Authenticate before policy enforcement. Policy checks intentionally allow
   // keyless local mode and assume the route has already rejected invalid keys.
-  const apiKeyRaw = extractApiKey(request);
-  if (isRequireApiKeyEnabled() && !apiKeyRaw) {
-    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required");
-  }
-  if (apiKeyRaw && !(await isValidApiKey(apiKeyRaw))) {
-    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
-  }
+  const authRejection = await enforceClientApiRouteAuth(request);
+  if (authRejection) return authRejection;
 
   // Enforce API key policies (model restrictions + budget limits)
   const policy = await enforceApiKeyPolicy(request, body.model);

--- a/src/app/api/v1/providers/[provider]/images/generations/route.ts
+++ b/src/app/api/v1/providers/[provider]/images/generations/route.ts
@@ -13,6 +13,8 @@ import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 import { v1ImageGenerationSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
 
 /**
  * Handle CORS preflight
@@ -55,6 +57,14 @@ export async function POST(request, { params }) {
     body.model = `${rawProvider}/${body.model}`;
   }
 
+  const apiKeyRaw = extractApiKey(request);
+  if (isRequireApiKeyEnabled() && !apiKeyRaw) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required");
+  }
+  if (apiKeyRaw && !(await isValidApiKey(apiKeyRaw))) {
+    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
+
   // Enforce API key policies (model restrictions + budget limits)
   const policy = await enforceApiKeyPolicy(request, body.model);
   if (policy.rejection) return policy.rejection;
@@ -84,7 +94,13 @@ export async function POST(request, { params }) {
     );
   }
 
-  const result = await handleImageGeneration({ body, credentials, log });
+  const result = await runWithCallLogApiKeyContext(
+    {
+      apiKeyId: policy.apiKeyInfo?.id ?? null,
+      apiKeyName: policy.apiKeyInfo?.name ?? null,
+    },
+    () => handleImageGeneration({ body, credentials, log })
+  );
 
   if (result.success) {
     await clearRecoveredProviderState(credentials);

--- a/src/app/api/v1/providers/[provider]/images/generations/route.ts
+++ b/src/app/api/v1/providers/[provider]/images/generations/route.ts
@@ -4,8 +4,6 @@ import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 import {
   getProviderCredentialsWithQuotaPreflight,
   clearRecoveredProviderState,
-  extractApiKey,
-  isValidApiKey,
 } from "@/sse/services/auth";
 import { getImageProvider } from "@omniroute/open-sse/config/imageRegistry.ts";
 import * as log from "@/sse/utils/logger";
@@ -13,7 +11,7 @@ import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 import { v1ImageGenerationSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
-import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { enforceClientApiRouteAuth } from "@/shared/utils/clientApiRouteAuth";
 import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
 
 /**
@@ -57,13 +55,8 @@ export async function POST(request, { params }) {
     body.model = `${rawProvider}/${body.model}`;
   }
 
-  const apiKeyRaw = extractApiKey(request);
-  if (isRequireApiKeyEnabled() && !apiKeyRaw) {
-    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required");
-  }
-  if (apiKeyRaw && !(await isValidApiKey(apiKeyRaw))) {
-    return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
-  }
+  const authRejection = await enforceClientApiRouteAuth(request);
+  if (authRejection) return authRejection;
 
   // Enforce API key policies (model restrictions + budget limits)
   const policy = await enforceApiKeyPolicy(request, body.model);

--- a/src/lib/usage/callLogApiKeyContext.ts
+++ b/src/lib/usage/callLogApiKeyContext.ts
@@ -1,0 +1,26 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface CallLogApiKeyContext {
+  apiKeyId: string | null;
+  apiKeyName: string | null;
+}
+
+const callLogApiKeyContext = new AsyncLocalStorage<CallLogApiKeyContext>();
+
+/**
+ * Bind API-key attribution to every call log emitted by one request.
+ *
+ * Modal handlers fan out into provider-specific helpers that write their own
+ * call logs. Request-scoped storage keeps that attribution available without
+ * threading identity parameters through every provider handler.
+ */
+export function runWithCallLogApiKeyContext<TResult>(
+  context: CallLogApiKeyContext,
+  callback: () => TResult
+): TResult {
+  return callLogApiKeyContext.run(context, callback);
+}
+
+export function getCallLogApiKeyContext(): CallLogApiKeyContext | null {
+  return callLogApiKeyContext.getStore() ?? null;
+}

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -12,6 +12,7 @@ import { getDbInstance } from "../db/core";
 import { collectReferencedArtifacts, selectCallLogIdsBefore } from "./callLogsBoundedQueries";
 import { getRequestDetailLogByCallLogId } from "../db/detailedLogs";
 import { shouldPersistToDisk } from "./migrations";
+import { getCallLogApiKeyContext } from "./callLogApiKeyContext";
 import {
   getLoggedInputTokens,
   getLoggedOutputTokens,
@@ -572,7 +573,9 @@ export async function saveCallLog(entry: any) {
   if (!shouldPersistToDisk) return;
 
   try {
-    const apiKeyId = entry.apiKeyId || null;
+    const apiKeyContext = getCallLogApiKeyContext();
+    const apiKeyId = entry.apiKeyId ?? apiKeyContext?.apiKeyId ?? null;
+    const apiKeyName = entry.apiKeyName ?? apiKeyContext?.apiKeyName ?? null;
     const noLogEnabled = Boolean(entry.noLog) || (apiKeyId ? isNoLog(apiKeyId) : false);
 
     const protectedRequestBody = noLogEnabled ? null : protectPayloadForLog(entry.requestBody);
@@ -619,7 +622,7 @@ export async function saveCallLog(entry: any) {
       sourceFormat: entry.sourceFormat || null,
       targetFormat: entry.targetFormat || null,
       apiKeyId,
-      apiKeyName: entry.apiKeyName || null,
+      apiKeyName,
       comboName: entry.comboName || null,
       comboStepId: toStringOrNull(entry.comboStepId),
       comboExecutionKey:

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -574,8 +574,11 @@ export async function saveCallLog(entry: any) {
 
   try {
     const apiKeyContext = getCallLogApiKeyContext();
-    const apiKeyId = entry.apiKeyId ?? apiKeyContext?.apiKeyId ?? null;
-    const apiKeyName = entry.apiKeyName ?? apiKeyContext?.apiKeyName ?? null;
+    // `||` (not `??`): an empty-string apiKeyId/apiKeyName is "unattributed",
+    // same as before this fallback existed — it must not be persisted verbatim
+    // nor block the request-scoped context.
+    const apiKeyId = entry.apiKeyId || apiKeyContext?.apiKeyId || null;
+    const apiKeyName = entry.apiKeyName || apiKeyContext?.apiKeyName || null;
     const noLogEnabled = Boolean(entry.noLog) || (apiKeyId ? isNoLog(apiKeyId) : false);
 
     const protectedRequestBody = noLogEnabled ? null : protectPayloadForLog(entry.requestBody);

--- a/src/shared/utils/clientApiRouteAuth.ts
+++ b/src/shared/utils/clientApiRouteAuth.ts
@@ -1,0 +1,50 @@
+/**
+ * Route-level authentication guard for CLIENT_API (`/api/v1/*`) handlers.
+ *
+ * Defence-in-depth companion to `clientApiPolicy`
+ * (src/server/authz/policies/clientApi.ts), which already fronts these routes
+ * through `src/proxy.ts`. The handler-level check must never be *stricter*
+ * than the middleware, otherwise callers the pipeline admits get a 401 from
+ * the route instead:
+ *
+ *  - a presented key must be valid, but is only rejected while
+ *    `REQUIRE_API_KEY=true`; with enforcement off a stale CLI key degrades to
+ *    anonymous instead of failing the whole request (#2257);
+ *  - a cookie-authenticated dashboard session is accepted in place of a key —
+ *    the dashboard Media page and Playground call these routes with a session
+ *    only (same fix as the preset auth mismatch in
+ *    `src/app/api/playground/presets/route.ts`);
+ *  - anonymous traffic stays allowed while `REQUIRE_API_KEY=false`.
+ *
+ * @module shared/utils/clientApiRouteAuth
+ */
+
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+import { extractApiKey, isValidApiKey } from "@/sse/services/auth";
+import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { isDashboardSessionAuthenticated } from "@/shared/utils/apiAuth";
+
+/**
+ * Authenticate a client-API request at the route level.
+ *
+ * @param request - The incoming request.
+ * @returns A 401 `Response` the handler must return, or `null` when the
+ *          request may proceed to policy enforcement.
+ */
+export async function enforceClientApiRouteAuth(request: Request): Promise<Response | null> {
+  const apiKeyRaw = extractApiKey(request);
+
+  if (apiKeyRaw) {
+    if (await isValidApiKey(apiKeyRaw)) return null;
+    return isRequireApiKeyEnabled()
+      ? errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key")
+      : null;
+  }
+
+  if (await isDashboardSessionAuthenticated(request)) return null;
+
+  return isRequireApiKeyEnabled()
+    ? errorResponse(HTTP_STATUS.UNAUTHORIZED, "Authentication required")
+    : null;
+}

--- a/tests/unit/image-generation-route-auth.test.ts
+++ b/tests/unit/image-generation-route-auth.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Auth + call-log attribution contract for the image generation routes.
+ *
+ * Split out of image-generation-route.test.ts to stay under the 800-line
+ * new-test-file cap enforced by `npm run check:file-size`.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-image-route-auth-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "image-route-test-api-key-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const { getCallLogs } = await import("../../src/lib/usage/callLogs.ts");
+const imageRoute = await import("../../src/app/api/v1/images/generations/route.ts");
+const providerImageRoute =
+  await import("../../src/app/api/v1/providers/[provider]/images/generations/route.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+const originalFetch = globalThis.fetch;
+
+async function resetStorage() {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  v1ModelsCatalog.__resetCatalogBuilderRunsForTest();
+}
+
+async function seedConnection(provider: string, apiKey: string) {
+  return providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    name: `${provider}-${Math.random().toString(16).slice(2, 8)}`,
+    apiKey,
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {},
+  });
+}
+
+async function waitForCallLog(apiKeyId: string, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const logs = await getCallLogs({ apiKey: apiKeyId, limit: 5 });
+    const match = logs.find((log: { apiKeyId?: string | null }) => log.apiKeyId === apiKeyId);
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const body = (await response.json()) as { error?: { message?: unknown } };
+  return typeof body.error?.message === "string" ? body.error.message : "";
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("v1 image generation POST requires an API key when REQUIRE_API_KEY is enabled", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "openai/gpt-image-2",
+          prompt: "authentication test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Authentication required/);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+test("v1 image generation POST rejects an invalid presented API key", async () => {
+  const originalOmniRouteApiKey = process.env.OMNIROUTE_API_KEY;
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.OMNIROUTE_API_KEY = "valid-image-route-key";
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer invalid-image-route-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "openai/gpt-image-2",
+          prompt: "invalid authentication test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Invalid API key/);
+  } finally {
+    if (originalOmniRouteApiKey === undefined) {
+      delete process.env.OMNIROUTE_API_KEY;
+    } else {
+      process.env.OMNIROUTE_API_KEY = originalOmniRouteApiKey;
+    }
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+// Issue #2257: with enforcement off, a stale key in a CLI config must degrade to
+// anonymous exactly like clientApiPolicy does — the route guard must not be
+// stricter than the middleware that already fronts it.
+test("v1 image generation POST ignores an invalid presented key while REQUIRE_API_KEY is off", async () => {
+  const originalOmniRouteApiKey = process.env.OMNIROUTE_API_KEY;
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.OMNIROUTE_API_KEY = "valid-image-route-key";
+  process.env.REQUIRE_API_KEY = "false";
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "http://localhost:7860/sdapi/v1/txt2img");
+    return new Response(JSON.stringify({ images: ["YW5vbnltb3Vz"] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer stale-cli-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "sdwebui/stable-diffusion-v1-5",
+          prompt: "stale key degrades to anonymous",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 200);
+  } finally {
+    if (originalOmniRouteApiKey === undefined) {
+      delete process.env.OMNIROUTE_API_KEY;
+    } else {
+      process.env.OMNIROUTE_API_KEY = originalOmniRouteApiKey;
+    }
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+// The dashboard Media page and Playground call these routes with a session
+// cookie and no Bearer. clientApiPolicy admits them; the route guard must too.
+test("v1 image generation POST accepts a dashboard session when REQUIRE_API_KEY is enabled", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  const originalJwtSecret = process.env.JWT_SECRET;
+  process.env.REQUIRE_API_KEY = "true";
+  process.env.JWT_SECRET = "image-route-dashboard-session-secret";
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "http://localhost:7860/sdapi/v1/txt2img");
+    return new Response(JSON.stringify({ images: ["ZGFzaGJvYXJk"] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const { SignJWT } = await import("jose");
+    const token = await new SignJWT({ sub: "dashboard" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode(process.env.JWT_SECRET));
+
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: {
+          Cookie: `auth_token=${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "sdwebui/stable-diffusion-v1-5",
+          prompt: "dashboard session test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 200);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+  }
+});
+
+test("v1 image generation POST attributes its call log to the validated API key", async () => {
+  const createdKey = await apiKeysDb.createApiKey(
+    "Image generation caller",
+    "machine-image-generation"
+  );
+  await seedConnection("openai", "image-provider-key");
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    return new Response(
+      JSON.stringify({
+        created: 123,
+        data: [{ url: "https://cdn.example.com/attributed-image.png" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/api/v1/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createdKey.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "openai/gpt-image-2",
+        prompt: "call log attribution test",
+      }),
+    })
+  );
+
+  assert.equal(response.status, 200);
+  const logged = await waitForCallLog(createdKey.id);
+  assert.ok(logged, "expected an attributed image-generation call log");
+  assert.equal(logged.apiKeyId, createdKey.id);
+  assert.equal(logged.apiKeyName, "Image generation caller");
+});
+
+test("provider-scoped image generation requires an API key when configured", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await providerImageRoute.POST(
+      new Request("http://localhost/api/v1/providers/openai/images/generations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-image-2",
+          prompt: "provider-scoped authentication test",
+        }),
+      }),
+      { params: Promise.resolve({ provider: "openai" }) }
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Authentication required/);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+test("provider-scoped image generation attributes its call log to the validated API key", async () => {
+  const createdKey = await apiKeysDb.createApiKey(
+    "Provider-scoped image caller",
+    "machine-provider-image"
+  );
+  await seedConnection("openai", "provider-scoped-upstream-key");
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    return new Response(
+      JSON.stringify({
+        created: 456,
+        data: [{ url: "https://cdn.example.com/provider-scoped-image.png" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await providerImageRoute.POST(
+    new Request("http://localhost/api/v1/providers/openai/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createdKey.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-image-2",
+        prompt: "provider-scoped attribution test",
+      }),
+    }),
+    { params: Promise.resolve({ provider: "openai" }) }
+  );
+
+  assert.equal(response.status, 200);
+  const logged = await waitForCallLog(createdKey.id);
+  assert.ok(logged, "expected an attributed provider-scoped image-generation call log");
+  assert.equal(logged.apiKeyId, createdKey.id);
+  assert.equal(logged.apiKeyName, "Provider-scoped image caller");
+});

--- a/tests/unit/image-generation-route.test.ts
+++ b/tests/unit/image-generation-route.test.ts
@@ -12,7 +12,10 @@ const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
+const { getCallLogs } = await import("../../src/lib/usage/callLogs.ts");
 const imageRoute = await import("../../src/app/api/v1/images/generations/route.ts");
+const providerImageRoute =
+  await import("../../src/app/api/v1/providers/[provider]/images/generations/route.ts");
 const imageEditRoute = await import("../../src/app/api/v1/images/edits/route.ts");
 const { MAX_BODY_BYTES_IMAGE_EDIT } = await import("../../src/shared/middleware/bodySizeGuard.ts");
 const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
@@ -99,6 +102,22 @@ async function seedConnection(
   });
 }
 
+async function waitForCallLog(apiKeyId: string, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const logs = await getCallLogs({ apiKey: apiKeyId, limit: 5 });
+    const match = logs.find((log: { apiKeyId?: string | null }) => log.apiKeyId === apiKeyId);
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const body = (await response.json()) as { error?: { message?: unknown } };
+  return typeof body.error?.message === "string" ? body.error.message : "";
+}
+
 test.beforeEach(async () => {
   await resetStorage();
 });
@@ -108,6 +127,20 @@ test.after(() => {
   apiKeysDb.resetApiKeyState();
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("image routes expose CORS preflight handlers", async () => {
+  const responses = await Promise.all([
+    imageRoute.OPTIONS(),
+    providerImageRoute.OPTIONS(),
+    imageEditRoute.OPTIONS(),
+  ]);
+
+  for (const response of responses) {
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("Access-Control-Allow-Methods") ?? "", /POST/);
+    assert.equal(response.headers.get("Access-Control-Allow-Headers"), "*");
+  }
 });
 
 test("v1 image models GET exposes image-only modalities for credential-backed image-only models", async () => {
@@ -215,6 +248,170 @@ test("v1 image edit POST rejects a declared body above the image-edit admission 
 
   assert.equal(response.status, 413);
   assert.match(body.error.message, /30 MiB limit/i);
+});
+
+test("v1 image generation POST requires an API key when REQUIRE_API_KEY is enabled", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "openai/gpt-image-2",
+          prompt: "authentication test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Authentication required/);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+test("v1 image generation POST rejects an invalid presented API key", async () => {
+  const originalOmniRouteApiKey = process.env.OMNIROUTE_API_KEY;
+  process.env.OMNIROUTE_API_KEY = "valid-image-route-key";
+
+  try {
+    const response = await imageRoute.POST(
+      new Request("http://localhost/api/v1/images/generations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer invalid-image-route-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "openai/gpt-image-2",
+          prompt: "invalid authentication test",
+        }),
+      })
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Invalid API key/);
+  } finally {
+    if (originalOmniRouteApiKey === undefined) {
+      delete process.env.OMNIROUTE_API_KEY;
+    } else {
+      process.env.OMNIROUTE_API_KEY = originalOmniRouteApiKey;
+    }
+  }
+});
+
+test("v1 image generation POST attributes its call log to the validated API key", async () => {
+  const createdKey = await apiKeysDb.createApiKey(
+    "Image generation caller",
+    "machine-image-generation"
+  );
+  await seedConnection("openai", { apiKey: "image-provider-key" });
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    return new Response(
+      JSON.stringify({
+        created: 123,
+        data: [{ url: "https://cdn.example.com/attributed-image.png" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/api/v1/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createdKey.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "openai/gpt-image-2",
+        prompt: "call log attribution test",
+      }),
+    })
+  );
+
+  assert.equal(response.status, 200);
+  const logged = await waitForCallLog(createdKey.id);
+  assert.ok(logged, "expected an attributed image-generation call log");
+  assert.equal(logged.apiKeyId, createdKey.id);
+  assert.equal(logged.apiKeyName, "Image generation caller");
+});
+
+test("provider-scoped image generation requires an API key when configured", async () => {
+  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
+  process.env.REQUIRE_API_KEY = "true";
+
+  try {
+    const response = await providerImageRoute.POST(
+      new Request("http://localhost/api/v1/providers/openai/images/generations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-image-2",
+          prompt: "provider-scoped authentication test",
+        }),
+      }),
+      { params: Promise.resolve({ provider: "openai" }) }
+    );
+
+    assert.equal(response.status, 401);
+    assert.match(await readErrorMessage(response), /Authentication required/);
+  } finally {
+    if (originalRequireApiKey === undefined) {
+      delete process.env.REQUIRE_API_KEY;
+    } else {
+      process.env.REQUIRE_API_KEY = originalRequireApiKey;
+    }
+  }
+});
+
+test("provider-scoped image generation attributes its call log to the validated API key", async () => {
+  const createdKey = await apiKeysDb.createApiKey(
+    "Provider-scoped image caller",
+    "machine-provider-image"
+  );
+  await seedConnection("openai", { apiKey: "provider-scoped-upstream-key" });
+
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    return new Response(
+      JSON.stringify({
+        created: 456,
+        data: [{ url: "https://cdn.example.com/provider-scoped-image.png" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await providerImageRoute.POST(
+    new Request("http://localhost/api/v1/providers/openai/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createdKey.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-image-2",
+        prompt: "provider-scoped attribution test",
+      }),
+    }),
+    { params: Promise.resolve({ provider: "openai" }) }
+  );
+
+  assert.equal(response.status, 200);
+  const logged = await waitForCallLog(createdKey.id);
+  assert.ok(logged, "expected an attributed provider-scoped image-generation call log");
+  assert.equal(logged.apiKeyId, createdKey.id);
+  assert.equal(logged.apiKeyName, "Provider-scoped image caller");
 });
 
 test("v1 image edit POST enforces disabled API key policy", async () => {

--- a/tests/unit/image-generation-route.test.ts
+++ b/tests/unit/image-generation-route.test.ts
@@ -12,7 +12,6 @@ const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
-const { getCallLogs } = await import("../../src/lib/usage/callLogs.ts");
 const imageRoute = await import("../../src/app/api/v1/images/generations/route.ts");
 const providerImageRoute =
   await import("../../src/app/api/v1/providers/[provider]/images/generations/route.ts");
@@ -100,22 +99,6 @@ async function seedConnection(
     testStatus: "active",
     providerSpecificData: overrides.providerSpecificData ?? {},
   });
-}
-
-async function waitForCallLog(apiKeyId: string, timeoutMs = 2000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const logs = await getCallLogs({ apiKey: apiKeyId, limit: 5 });
-    const match = logs.find((log: { apiKeyId?: string | null }) => log.apiKeyId === apiKeyId);
-    if (match) return match;
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  return null;
-}
-
-async function readErrorMessage(response: Response): Promise<string> {
-  const body = (await response.json()) as { error?: { message?: unknown } };
-  return typeof body.error?.message === "string" ? body.error.message : "";
 }
 
 test.beforeEach(async () => {
@@ -248,170 +231,6 @@ test("v1 image edit POST rejects a declared body above the image-edit admission 
 
   assert.equal(response.status, 413);
   assert.match(body.error.message, /30 MiB limit/i);
-});
-
-test("v1 image generation POST requires an API key when REQUIRE_API_KEY is enabled", async () => {
-  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
-  process.env.REQUIRE_API_KEY = "true";
-
-  try {
-    const response = await imageRoute.POST(
-      new Request("http://localhost/api/v1/images/generations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: "openai/gpt-image-2",
-          prompt: "authentication test",
-        }),
-      })
-    );
-
-    assert.equal(response.status, 401);
-    assert.match(await readErrorMessage(response), /Authentication required/);
-  } finally {
-    if (originalRequireApiKey === undefined) {
-      delete process.env.REQUIRE_API_KEY;
-    } else {
-      process.env.REQUIRE_API_KEY = originalRequireApiKey;
-    }
-  }
-});
-
-test("v1 image generation POST rejects an invalid presented API key", async () => {
-  const originalOmniRouteApiKey = process.env.OMNIROUTE_API_KEY;
-  process.env.OMNIROUTE_API_KEY = "valid-image-route-key";
-
-  try {
-    const response = await imageRoute.POST(
-      new Request("http://localhost/api/v1/images/generations", {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer invalid-image-route-key",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "openai/gpt-image-2",
-          prompt: "invalid authentication test",
-        }),
-      })
-    );
-
-    assert.equal(response.status, 401);
-    assert.match(await readErrorMessage(response), /Invalid API key/);
-  } finally {
-    if (originalOmniRouteApiKey === undefined) {
-      delete process.env.OMNIROUTE_API_KEY;
-    } else {
-      process.env.OMNIROUTE_API_KEY = originalOmniRouteApiKey;
-    }
-  }
-});
-
-test("v1 image generation POST attributes its call log to the validated API key", async () => {
-  const createdKey = await apiKeysDb.createApiKey(
-    "Image generation caller",
-    "machine-image-generation"
-  );
-  await seedConnection("openai", { apiKey: "image-provider-key" });
-
-  globalThis.fetch = async (url) => {
-    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
-    return new Response(
-      JSON.stringify({
-        created: 123,
-        data: [{ url: "https://cdn.example.com/attributed-image.png" }],
-      }),
-      { status: 200, headers: { "content-type": "application/json" } }
-    );
-  };
-
-  const response = await imageRoute.POST(
-    new Request("http://localhost/api/v1/images/generations", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${createdKey.key}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "openai/gpt-image-2",
-        prompt: "call log attribution test",
-      }),
-    })
-  );
-
-  assert.equal(response.status, 200);
-  const logged = await waitForCallLog(createdKey.id);
-  assert.ok(logged, "expected an attributed image-generation call log");
-  assert.equal(logged.apiKeyId, createdKey.id);
-  assert.equal(logged.apiKeyName, "Image generation caller");
-});
-
-test("provider-scoped image generation requires an API key when configured", async () => {
-  const originalRequireApiKey = process.env.REQUIRE_API_KEY;
-  process.env.REQUIRE_API_KEY = "true";
-
-  try {
-    const response = await providerImageRoute.POST(
-      new Request("http://localhost/api/v1/providers/openai/images/generations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: "gpt-image-2",
-          prompt: "provider-scoped authentication test",
-        }),
-      }),
-      { params: Promise.resolve({ provider: "openai" }) }
-    );
-
-    assert.equal(response.status, 401);
-    assert.match(await readErrorMessage(response), /Authentication required/);
-  } finally {
-    if (originalRequireApiKey === undefined) {
-      delete process.env.REQUIRE_API_KEY;
-    } else {
-      process.env.REQUIRE_API_KEY = originalRequireApiKey;
-    }
-  }
-});
-
-test("provider-scoped image generation attributes its call log to the validated API key", async () => {
-  const createdKey = await apiKeysDb.createApiKey(
-    "Provider-scoped image caller",
-    "machine-provider-image"
-  );
-  await seedConnection("openai", { apiKey: "provider-scoped-upstream-key" });
-
-  globalThis.fetch = async (url) => {
-    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
-    return new Response(
-      JSON.stringify({
-        created: 456,
-        data: [{ url: "https://cdn.example.com/provider-scoped-image.png" }],
-      }),
-      { status: 200, headers: { "content-type": "application/json" } }
-    );
-  };
-
-  const response = await providerImageRoute.POST(
-    new Request("http://localhost/api/v1/providers/openai/images/generations", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${createdKey.key}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "gpt-image-2",
-        prompt: "provider-scoped attribution test",
-      }),
-    }),
-    { params: Promise.resolve({ provider: "openai" }) }
-  );
-
-  assert.equal(response.status, 200);
-  const logged = await waitForCallLog(createdKey.id);
-  assert.ok(logged, "expected an attributed provider-scoped image-generation call log");
-  assert.equal(logged.apiKeyId, createdKey.id);
-  assert.equal(logged.apiKeyName, "Provider-scoped image caller");
 });
 
 test("v1 image edit POST enforces disabled API key policy", async () => {


### PR DESCRIPTION
## Summary

- Enforce `REQUIRE_API_KEY` and reject invalid presented keys on the canonical and provider-scoped image generation routes.
- Propagate validated API-key identity through request-scoped storage so provider-specific image call logs record `api_key_id` and `api_key_name`.
- Restore per-key no-log behavior for image generation calls.
- Share one route-level auth guard (`shared/utils/clientApiRouteAuth`) that mirrors the `clientApiPolicy` contract, so the handler check can never be stricter than the authz middleware already fronting `/api/v1/*`.

## Related Issues

- Supersedes #8293.
- Rebuilt as a focused branch from `release/v3.8.49`, as requested in #8293.

## Validation

- [x] `tests/unit/image-generation-route*.test.ts`: 24/24 passing
- [x] `call-log*` + `tests/unit/usage/**`: 68/68 passing
- [x] `npm run typecheck:core`
- [x] `eslint` on all changed files
- [x] `npm run check:file-size` — `[test-file-size] OK`
- [x] pre-commit gates: `check-docs-sync`, `check:any-budget:t11`, `check-tracked-artifacts`

## Tests Added Or Updated

- `tests/unit/image-generation-route-auth.test.ts` (new — split out of the main image-route suite to stay under the 800-line new-test-file cap)
  - rejects missing keys when `REQUIRE_API_KEY=true`
  - rejects invalid presented keys when `REQUIRE_API_KEY=true`
  - **ignores** invalid presented keys when `REQUIRE_API_KEY=false` (matches `clientApiPolicy`, #2257)
  - **accepts a cookie-authenticated dashboard session** when `REQUIRE_API_KEY=true`
  - persists API-key id/name for canonical and provider-scoped image generation
- `tests/unit/image-generation-route.test.ts` — keeps the CORS preflight coverage for the three image-route `OPTIONS` handlers.

## Coverage Notes

The tests cover every branch of the shared guard (valid key / invalid key × enforcement on-off / dashboard session / anonymous), successful call-log attribution on both routes, and the `OPTIONS` handlers that keep the function-coverage ratchet from regressing. The coverage baseline was not changed.

## Reviewer Notes

Scope is the image routes, the shared client-API route guard, call-log attribution, and their tests — 7 files. The earlier release-repair commits are dropped; that set lives in #8307 and the base has since resolved most of it. This branch is rebased on the current `release/v3.8.49` head and merges cleanly.

Image provider handlers emit call logs in multiple provider-specific branches. `AsyncLocalStorage` keeps validated key identity request-scoped and concurrency-safe without threading attribution arguments through every handler. Explicit call-log API-key fields still take precedence. No schema or migration changes are required.

`check:complexity-ratchets` and two `check:file-size` freezes (`dashboard/providers/page.tsx`, `lib/tokenHealthCheck.ts`) fail identically on a clean `origin/release/v3.8.49` checkout — inherited base-red, deliberately not touched here.
