### PR TITLE
fix(cpa): isolate credential-pool failures

### DIFF
--- a/open-sse/executors/cliproxyapi.ts
+++ b/open-sse/executors/cliproxyapi.ts
@@ -428,7 +428,7 @@ export class CliproxyapiExecutor extends BaseExecutor {
       input.log?.warn?.("CPA", `CLIProxyAPI rate limited: ${response.status}`);
     }
 
-    return { response, url, headers, transformedBody };
+    return { response, url, headers, transformedBody, transport: "cliproxyapi" as const };
   }
 
   /**

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2988,7 +2988,11 @@ export async function handleChatCore({
           rawResult._executionCredentials?.connectionId &&
           rawResult._executionCredentials?.apiKey
         ) {
-          recordKeyHealthStatus(status, rawResult._executionCredentials);
+          recordKeyHealthStatus(
+            status,
+            rawResult._executionCredentials,
+            rawResult.transport
+          );
         }
         releaseRawResultAccountSemaphore =
           typeof rawResult._accountSemaphoreRelease === "function"

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -549,8 +549,9 @@ export async function handleChatCore({
   // and delegate so the existing call sites stay byte-identical.
   const recordKeyHealthStatus = (
     status: number,
-    creds: Record<string, unknown> | null | undefined
-  ): void => recordKeyHealthStatusFor(status, creds, log);
+    creds: Record<string, unknown> | null | undefined,
+    transport?: string
+  ): void => recordKeyHealthStatusFor(status, creds, log, transport);
 
   const persistCodexQuotaState = async (headers: Record<string, string> | null, status = 0) => {
     const currentConnectionId = getCurrentConnectionId();

--- a/open-sse/handlers/chatCore/keyHealth.ts
+++ b/open-sse/handlers/chatCore/keyHealth.ts
@@ -31,8 +31,13 @@ type KeyHealthLog = {
 export function recordKeyHealthStatus(
   status: number,
   creds: Record<string, unknown> | null | undefined,
-  log?: KeyHealthLog
+  log?: KeyHealthLog,
+  transport?: string
 ): void {
+  // CLIProxyAPI owns a shared external credential pool. Its auth failures cannot be
+  // attributed to the native OmniRoute connection selected before proxy dispatch.
+  if (transport === "cliproxyapi") return;
+
   const connId = creds?.connectionId as string | undefined;
   if (!connId) return;
 

--- a/open-sse/handlers/chatCore/upstreamTimeouts.ts
+++ b/open-sse/handlers/chatCore/upstreamTimeouts.ts
@@ -106,8 +106,15 @@ export function normalizeExecutorResult(
         url?: string;
         headers?: Record<string, string>;
         transformedBody?: unknown;
+        transport?: string;
       }
-): { response: Response; url: string; headers: Record<string, string>; transformedBody: unknown } {
+): {
+  response: Response;
+  url: string;
+  headers: Record<string, string>;
+  transformedBody: unknown;
+  transport?: string;
+} {
   if (result instanceof Response) {
     return { response: result, url: "", headers: {}, transformedBody: null };
   }
@@ -116,6 +123,7 @@ export function normalizeExecutorResult(
     url: result.url || "",
     headers: result.headers || {},
     transformedBody: result.transformedBody ?? null,
+    transport: result.transport,
   };
 }
 

--- a/tests/unit/chatcore-key-health.test.ts
+++ b/tests/unit/chatcore-key-health.test.ts
@@ -68,3 +68,9 @@ test("non-401 / non-2xx status does not touch key health", () => {
   recordKeyHealthStatus(500, creds(conn), noopLog);
   assert.equal(getAllKeyHealth()[`${conn}:primary`], undefined);
 });
+
+test("CPA pool failures do not poison the selected native connection key", () => {
+  const conn = "kh-cpa-pool-isolation";
+  recordKeyHealthStatus(401, creds(conn), noopLog, "cliproxyapi");
+  assert.equal(getAllKeyHealth()[`${conn}:primary`], undefined);
+});


### PR DESCRIPTION
## Summary

- propagate CLIProxyAPI transport provenance through executor normalization
- prevent shared CPA OAuth-pool failures from mutating the native OmniRoute connection key selected before proxy dispatch
- preserve native key-health behavior for native executor responses
- add focused key-health regression coverage

## Verification

- `node --import tsx/esm --test tests/unit/chatcore-key-health.test.ts` — 6 passed
- `npm run typecheck:core` — passed
- focused `git diff --check` — passed

The broad CI failure set matches the repository baseline on merged PRs #8292 and #8296: Docs Gates, Fast Quality Gates, Vitest, and all four unit shards fail independently of this five-file CPA diff. No unrelated baseline files were modified.

This is the focused CPA credential-pool isolation follow-up; the Kimi non-stream half is handled separately in #8302.

Refs #8280