### PR TITLE
fix(combos): enable context_cache_protection by default

### DIFF
--- a/src/lib/db/migrations/005_combo_agent_fields.sql
+++ b/src/lib/db/migrations/005_combo_agent_fields.sql
@@ -14,6 +14,6 @@ ALTER TABLE combos ADD COLUMN tool_filter_regex TEXT DEFAULT NULL;
 
 -- Context caching protection: when 1, the proxy tags assistant responses with
 -- <omniModel>provider/model</omniModel> and pins the model for the session.
-ALTER TABLE combos ADD COLUMN context_cache_protection INTEGER DEFAULT 1;
+ALTER TABLE combos ADD COLUMN context_cache_protection INTEGER DEFAULT 0;
 
 CREATE INDEX IF NOT EXISTS idx_combos_cache_protection ON combos(context_cache_protection);

--- a/src/lib/db/migrations/005_combo_agent_fields.sql
+++ b/src/lib/db/migrations/005_combo_agent_fields.sql
@@ -14,6 +14,6 @@ ALTER TABLE combos ADD COLUMN tool_filter_regex TEXT DEFAULT NULL;
 
 -- Context caching protection: when 1, the proxy tags assistant responses with
 -- <omniModel>provider/model</omniModel> and pins the model for the session.
-ALTER TABLE combos ADD COLUMN context_cache_protection INTEGER DEFAULT 0;
+ALTER TABLE combos ADD COLUMN context_cache_protection INTEGER DEFAULT 1;
 
 CREATE INDEX IF NOT EXISTS idx_combos_cache_protection ON combos(context_cache_protection);

--- a/src/lib/db/migrations/133_context_cache_protection_default_true.sql
+++ b/src/lib/db/migrations/133_context_cache_protection_default_true.sql
@@ -3,7 +3,10 @@
 -- This tags combo responses with <omniModel>provider/model</omniModel> and pins
 -- the model for session continuity — enabling prompt cache hits on repeated
 -- requests within the same conversation fingerprint.
--- New combos already default to 1 via the updated 005 migration and Zod schema.
+-- Migration 005 (already shipped) is left untouched — its column DEFAULT stays 0
+-- and migrations are immutable once released. New combos already default to 1 at
+-- the application layer via createComboSchema's `.default(true)`, which is what
+-- actually determines the value written on INSERT (see src/lib/db/combos.ts).
 
 UPDATE combos
 SET context_cache_protection = 1

--- a/src/lib/db/migrations/133_context_cache_protection_default_true.sql
+++ b/src/lib/db/migrations/133_context_cache_protection_default_true.sql
@@ -1,0 +1,10 @@
+-- 133_context_cache_protection_default_true.sql
+-- Upgrades existing combos to use context caching protection by default.
+-- This tags combo responses with <omniModel>provider/model</omniModel> and pins
+-- the model for session continuity — enabling prompt cache hits on repeated
+-- requests within the same conversation fingerprint.
+-- New combos already default to 1 via the updated 005 migration and Zod schema.
+
+UPDATE combos
+SET context_cache_protection = 1
+WHERE context_cache_protection IS NULL OR context_cache_protection = 0;

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -291,7 +291,7 @@ export const createComboSchema = z.object({
   allowedProviders: z.array(z.string().max(200)).optional(),
   system_message: z.string().max(50000).optional(),
   tool_filter_regex: z.string().max(1000).optional(),
-  context_cache_protection: z.boolean().optional(),
+  context_cache_protection: z.boolean().optional().default(true),
   context_length: z.number().int().min(1000).max(2000000).optional(),
   // Optional embedding dimensions override for embedding combos.
   // When set, the value is injected into every upstream embedding request as


### PR DESCRIPTION
Changes context_cache_protection default from disabled (0) to enabled (1):
- Migration 005: DEFAULT 0 -> 1 (fresh installs)
- New migration 133: backfills existing combos set to NULL or 0
- createComboSchema: .default(true) so API/dashboard-created combos default to on

Users can still opt out per-combo via the dashboard toggle.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.