### PR TITLE
fix(providers): classify HTTP 400 model-unavailable as MODEL_NOT_FOUND so Antigravity Pro fallback locks out the deprecated model

### DIFF
--- a/changelog.d/fixes/8136-antigravity-400-lockout.md
+++ b/changelog.d/fixes/8136-antigravity-400-lockout.md
@@ -1,0 +1,1 @@
+- fix(providers): classify HTTP 400 model-unavailable as MODEL_NOT_FOUND so Antigravity Pro fallback locks out the deprecated model

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -232,8 +232,18 @@ export function classifyProviderError(
   }
   if (statusCode >= 500) return PROVIDER_ERROR_TYPES.SERVER_ERROR;
 
-  if (statusCode === 400 && isContextOverflow(bodyStr)) {
-    return PROVIDER_ERROR_TYPES.CONTEXT_OVERFLOW;
+  if (statusCode === 400) {
+    if (isContextOverflow(bodyStr)) {
+      return PROVIDER_ERROR_TYPES.CONTEXT_OVERFLOW;
+    }
+    // Some providers (e.g. Antigravity's Pro-fallback chain, #8136) return a
+    // plain 400 for a model that is no longer available, instead of 404/401.
+    // Without this check the error falls through to `return null`, so
+    // lockModel() never fires and the same dead model gets retried on every
+    // request. Detect the phrasing here, same as the 401 branch above (#7268).
+    if (containsModelUnavailableMessage(bodyStr)) {
+      return PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND;
+    }
   }
 
   return null;

--- a/tests/unit/repro-8136-antigravity-400-model-not-supported-lockout.test.ts
+++ b/tests/unit/repro-8136-antigravity-400-model-not-supported-lockout.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+const { classifyProviderError, PROVIDER_ERROR_TYPES } = await import(
+  "../../open-sse/services/errorClassifier.ts"
+);
+
+test("#8136: classifyProviderError(400, Antigravity 'model is not supported' body) returns MODEL_NOT_FOUND", () => {
+  const body = {
+    error: {
+      code: 400,
+      message: "The model gemini-3.1-pro-low is not supported for this project.",
+      status: "INVALID_ARGUMENT",
+    },
+  };
+  const classified = classifyProviderError(400, body, "antigravity");
+  assert.equal(
+    classified,
+    PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND,
+    `expected MODEL_NOT_FOUND, got ${JSON.stringify(classified)}`
+  );
+});
+
+test("#8136: same phrasing at 401 still works (regression guard for #7268)", () => {
+  const body = { error: { message: "The model gemini-3.1-pro-low is not supported for this project." } };
+  assert.equal(classifyProviderError(401, body, "antigravity"), PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND);
+});
+
+test("#8136: plain 400 context-overflow still classifies as CONTEXT_OVERFLOW, not MODEL_NOT_FOUND", () => {
+  const body = {
+    error: {
+      message: "This model's maximum context length is 128000 tokens. Please reduce the length of the messages.",
+    },
+  };
+  assert.equal(
+    classifyProviderError(400, body, "antigravity"),
+    PROVIDER_ERROR_TYPES.CONTEXT_OVERFLOW
+  );
+});
+
+test("#8136: a generic 400 bad-request body (no model-unavailable phrasing) is not reclassified as MODEL_NOT_FOUND", () => {
+  const body = { error: { message: "Invalid request: missing required field 'messages'." } };
+  assert.equal(classifyProviderError(400, body, "antigravity"), null);
+});


### PR DESCRIPTION
Closes #8136

## Root cause
`classifyProviderError()` in `open-sse/services/errorClassifier.ts` had exactly one HTTP 400 branch — context-overflow — and fell through to `return null` for anything else, including Antigravity's Pro-fallback-chain 400 "model is not supported" body. Because the error was never classified into a known `PROVIDER_ERROR_TYPES` value, `chatCore.ts` never called `lockModel()`, so the dead `gemini-3.1-pro-low` / `gemini-pro-agent` model was retried from scratch on every request instead of being locked out (matches the reporter's repeated-400 log pattern).

The fix mirrors the existing 401 branch (fixed for #7268): the 400 path now also calls the shared `containsModelUnavailableMessage()` helper and returns `MODEL_NOT_FOUND` when the body matches the model-unavailable phrasing, after the context-overflow check (so a genuine context-overflow 400 is unaffected). A generic 400 bad-request with no model-unavailable wording still returns `null`, unchanged.

## TDD evidence (Hard Rule #18)
`tests/unit/repro-8136-antigravity-400-model-not-supported-lockout.test.ts`:
- RED before the fix: `classifyProviderError(400, <Antigravity model-unavailable body>, "antigravity")` returned `null` instead of `model_not_found`.
- GREEN after the fix (4/4 tests): 400 model-unavailable -> `MODEL_NOT_FOUND`; 401 sibling from #7268 still `MODEL_NOT_FOUND` (no regression); 400 context-overflow still `CONTEXT_OVERFLOW` (precedence preserved); generic 400 bad-request still `null` (no over-classification).

Sibling suites re-run and green (52/52): `errorClassifier-noauth-403-6315.test.ts`, `errorclassifier-antigravity-403.test.ts`, `repro-7268-401-model-not-supported-lockout.test.ts`, `error-classifier.test.ts`, `services-branch-hardening.test.ts`, `combo-skip-conn-disable-plugin-block-7806.test.ts`, `empty-content-stopreason-3572.test.ts`, `issue-6623-opencode-mimo-reasoning-details-nonstream.test.ts`.

## Scope
Only `open-sse/services/errorClassifier.ts` touched (12 lines). No changes to `chatCore.ts`, `modelFamilyFallback.ts`, or `proFallbackChain.ts` — the existing `MODEL_NOT_FOUND` lockout wiring in `chatCore.ts` already calls `lockModel()` regardless of original status code, so it fires for free once the classification gap is closed.

## Gates run (all green)
- `node scripts/check/check-file-size.mjs` — OK (no frozen-file growth)
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — both flagged 2167/956 violations, but a probe worktree pinned to `origin/release/v3.8.49` (unfixed tip) shows the identical 2167/956 counts — pre-existing repo-wide drift, not introduced by this diff (confirmed via isolated worktree, not stash)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK
- Sibling errorClassifier/proFallbackChain tests — 52/52 pass