### PR TITLE
fix(providers): carve cookie-auth providers out of terminal 401 'expired' classification so one 401 cooldowns instead of killing the connection

### DIFF
--- a/changelog.d/fixes/8200-perplexity-web-401-cooldown.md
+++ b/changelog.d/fixes/8200-perplexity-web-401-cooldown.md
@@ -1,0 +1,1 @@
+- fix(providers): carve cookie-auth providers out of terminal 401 'expired' classification so one 401 cooldowns instead of killing the connection

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -373,10 +373,21 @@ function isTerminalConnectionStatus(connection: ProviderConnectionView): boolean
   return status === "credits_exhausted" || status === "banned" || status === "expired";
 }
 
+// #8200: cookie-auth providers (perplexity-web, grok-web, ...) use a rotating browser
+// session, not a static API key — a 401 means "session needs a refresh", not "dead".
+function isRecoverableCookieAuth401(provider: string | null, providerErrorType: string | null): boolean {
+  return (
+    providerErrorType !== PROVIDER_ERROR_TYPES.ACCOUNT_DEACTIVATED &&
+    provider != null &&
+    resolveProviderId(provider) in WEB_COOKIE_PROVIDERS
+  );
+}
+
 function resolveTerminalConnectionStatus(
   status: number,
   result: { permanent?: boolean; creditsExhausted?: boolean },
-  providerErrorType: string | null = null
+  providerErrorType: string | null = null,
+  provider: string | null = null
 ): string | null {
   if (result.creditsExhausted || status === 402) return "credits_exhausted";
   if (
@@ -389,9 +400,10 @@ function resolveTerminalConnectionStatus(
     return "banned";
   }
   if (
-    providerErrorType === PROVIDER_ERROR_TYPES.ACCOUNT_DEACTIVATED ||
-    providerErrorType === PROVIDER_ERROR_TYPES.UNAUTHORIZED ||
-    status === 401
+    (providerErrorType === PROVIDER_ERROR_TYPES.ACCOUNT_DEACTIVATED ||
+      providerErrorType === PROVIDER_ERROR_TYPES.UNAUTHORIZED ||
+      status === 401) &&
+    !isRecoverableCookieAuth401(provider, providerErrorType)
   ) {
     return "expired";
   }
@@ -2086,7 +2098,8 @@ export async function markAccountUnavailable(
     const terminalStatus = resolveTerminalConnectionStatus(
       status,
       result as { permanent?: boolean; creditsExhausted?: boolean },
-      providerErrorType
+      providerErrorType,
+      provider
     );
     const cooldownMs = terminalStatus ? 0 : rawCooldownMs;
 

--- a/tests/unit/8200-perplexity-web-401-cooldown.test.ts
+++ b/tests/unit/8200-perplexity-web-401-cooldown.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Permanent regression guard for #8200: a single recoverable 401 on a
+// cookie-auth provider (perplexity-web) must NOT terminal-expire the only
+// connection. Before the fix, resolveTerminalConnectionStatus() mapped ANY
+// non-OAuth 401 to the TERMINAL testStatus "expired" (cooldownMs 0, no
+// self-heal), which then made getProviderCredentials() filter the
+// connection out on the very next request -> "No active credentials".
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-8200-perplexity-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("BUG #8200: single perplexity-web 401 (cookie expiry) does not terminal-expire the only connection", async () => {
+  await resetStorage();
+
+  const conn = await providersDb.createProviderConnection({
+    provider: "perplexity-web",
+    authType: "apikey",
+    apiKey: "__Secure-next-auth.session-token=stale-cookie",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = String(conn.id);
+
+  await auth.markAccountUnavailable(
+    connId,
+    401,
+    "Perplexity auth failed — session cookie may be expired. Re-paste your __Secure-next-auth.session-token.",
+    "perplexity-web",
+    "pplx-auto"
+  );
+
+  const after = await providersDb.getProviderConnectionById(connId);
+  assert.equal(after.isActive, true, "connection row should stay active");
+  assert.notEqual(
+    after.testStatus,
+    "expired",
+    "a recoverable perplexity-web 401 must not be classified terminal 'expired'"
+  );
+
+  const credentials = await auth.getProviderCredentials("perplexity-web");
+  assert.notEqual(
+    credentials,
+    null,
+    "getProviderCredentials must still return the connection after exactly one 401"
+  );
+});
+
+test("markAccountUnavailable keeps the existing 401->expired terminal mapping for plain apikey providers", async () => {
+  await resetStorage();
+
+  const conn = await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    apiKey: "sk-expired",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = String(conn.id);
+
+  await auth.markAccountUnavailable(connId, 401, "unauthorized", "openai", "gpt-4.1");
+
+  const after = await providersDb.getProviderConnectionById(connId);
+  assert.equal(after.testStatus, "expired");
+});


### PR DESCRIPTION
Refs #8200 (part A — one-401 terminal misclassification fixed; part B cookie rotation/keepalive tracked as follow-up, issue kept open)

## Root cause

`src/sse/services/auth.ts::resolveTerminalConnectionStatus()` mapped ANY HTTP 401
that wasn't classified `OAUTH_INVALID_TOKEN`/`PROJECT_ROUTE_ERROR` to the TERMINAL
`testStatus: "expired"` via the fallthrough `providerErrorType === UNAUTHORIZED ||
status === 401`. `perplexity-web` is registered `authType: "apikey"` (cookie-based),
so its recoverable session-expiry 401s went through `classifyProviderError()` as plain
`UNAUTHORIZED` and landed on the terminal branch — with `checkFallbackError`'s
`status_401` rule giving a hard-coded `cooldownMs: 0`, `markAccountUnavailable()`
persisted a permanent `testStatus: "expired"` on the very first 401. Then
`getProviderCredentials()` filters connections via `isTerminalConnectionStatus()`
regardless of `isActive`, so the connection dropped out of selection on the next
request, surfacing as `404 No active credentials for provider: perplexity-web` —
even though the row stayed `is_active=1` and the account was still configured.

This 401→expired mapping is intentional/tested for ordinary API-key providers, but
`perplexity-web` (and other cookie/session-auth providers) had no carve-out — unlike
`grok-web`, which already gets a non-terminal, mode-local lockout for its 403s.

## Fix

Added a `provider` parameter to `resolveTerminalConnectionStatus()` and a small
`isRecoverableCookieAuth401()` helper: a 401/`UNAUTHORIZED` classification on any
provider registered in `WEB_COOKIE_PROVIDERS` (perplexity-web, grok-web, etc.) is now
routed to the ordinary recoverable-cooldown path instead of the zero-cooldown terminal
`expired` path — mirroring the existing OAuth-invalid-token / grok-web carve-outs.
`ACCOUNT_DEACTIVATED` (a confirmed permanent signal) is explicitly excluded from the
carve-out, so genuine terminal bans still terminal-expire.

Scoped strictly to this issue: no changes to cookie rotation/`Set-Cookie` capture
(issue's part B) — that is tracked separately and is a larger, independently-testable
change (new `mergeRefreshedCookie`-style helper + executor wiring) that this repro
does not cover.

## TDD evidence (Hard Rule #18)

New permanent regression test: `tests/unit/8200-perplexity-web-401-cooldown.test.ts`

RED (before fix):
```
AssertionError [ERR_ASSERTION]: a recoverable perplexity-web 401 must not be classified terminal 'expired'
  actual: 'expired', expected: 'expired', operator: 'notStrictEqual'
```

GREEN (after fix):
```
✔ BUG #8200: single perplexity-web 401 (cookie expiry) does not terminal-expire the only connection
✔ markAccountUnavailable keeps the existing 401->expired terminal mapping for plain apikey providers
ℹ tests 2, pass 2, fail 0
```

Sibling tests re-run and green: `tests/unit/auth-terminal-status.test.ts` (10/10),
`tests/unit/auth-ollama-cloud-per-model-403-3027.test.ts` (3/3),
`tests/unit/combo-skip-conn-disable-plugin-block-7806.test.ts` (4/4),
`tests/unit/perplexity-web.test.ts` (31/31).

## Gates run

- `node scripts/check/check-file-size.mjs` → OK (`src/sse/services/auth.ts` 2461 lines, under the 2462 baseline)
- `node scripts/check/check-complexity.mjs` → pre-existing repo-wide drift (2167 vs baseline 2130) confirmed identical on a clean `origin/release/v3.8.49` probe worktree — not introduced by this diff; touched functions have zero reported violations
- `node scripts/check/check-cognitive-complexity.mjs` → same pre-existing drift confirmed (956 vs baseline 951 on both this branch and the pure tip)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/sse/services/auth.ts tests/unit/8200-perplexity-web-401-cooldown.test.ts` → exit 0
- `node scripts/check/check-changelog-integrity.mjs` → OK

## Related

PR #8201 (same reporter) proposed essentially this diagnosis + a cookie-rotation
follow-up but was closed for catastrophic base drift (547 files, diff exceeded
GitHub's API limit), not on technical merits. This PR is a fresh, focused
implementation off the current `release/v3.8.49` tip covering part (A) of that
diagnosis, proven by a clean TDD repro.