### PR TITLE
fix(providers): route noauth opencode-zen connections through their assigned proxy

### DIFF
--- a/changelog.d/fixes/7993-noauth-proxy-routing.md
+++ b/changelog.d/fixes/7993-noauth-proxy-routing.md
@@ -1,0 +1,1 @@
+- fix(providers): route noauth opencode-zen connections through their assigned proxy

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -75,6 +75,7 @@ import {
 } from "./sessionAffinityPin";
 import { isNoAuthProviderBlockedBySettings } from "./noAuthProviderSettings";
 import { resolveAccountProxiesFromRegistry } from "./noAuthProxyResolution";
+import { getNoAuthHydrationProviderIds } from "./noAuthProviderSiblings";
 import * as log from "../utils/logger";
 import { fisherYatesShuffle, getNextFromDeckSync } from "@/shared/utils/shuffleDeck";
 
@@ -716,28 +717,40 @@ function buildSyntheticNoAuthCredentials(providerSpecificData: JsonRecord = {}):
   };
 }
 
+/** Merge one connection's fingerprints/accountProxies into `hydrated`, first-wins. */
+function mergeNoAuthProviderSpecificData(hydrated: JsonRecord, conn: { providerSpecificData?: unknown }): void {
+  const psd = conn.providerSpecificData;
+  if (!psd || typeof psd !== "object") return;
+  const record = psd as JsonRecord;
+  if (Array.isArray(record.fingerprints) && !Array.isArray(hydrated.fingerprints)) {
+    hydrated.fingerprints = record.fingerprints;
+  }
+  if (Array.isArray(record.accountProxies) && !Array.isArray(hydrated.accountProxies)) {
+    hydrated.accountProxies = record.accountProxies;
+  }
+}
+
 /**
  * #4954 / #5217 (Gap 1) — no-auth providers persist a connection row whose
  * `providerSpecificData` carries `fingerprints` + `accountProxies`. Hydrate those
  * and resolve by-id Proxy Pool references to live records (./noAuthProxyResolution)
  * so the executor gets a resolved inline `proxy`. Best-effort: failures → empty.
+ *
+ * #7993: also checks sibling ids (e.g. "opencode-zen" -> "opencode") so a
+ * proxy/fingerprint row saved under the no-auth id is still found when
+ * credentials are hydrated for the apikey-gateway id that shares its public
+ * endpoint.
  */
 async function loadNoAuthProviderSpecificData(providerId: string): Promise<JsonRecord> {
   try {
-    const connectionsRaw = await getProviderConnections({ provider: providerId });
-    const connections = (Array.isArray(connectionsRaw) ? connectionsRaw : []).map(
-      toProviderConnection
-    );
+    const providerIdsToQuery = getNoAuthHydrationProviderIds(providerId);
     const hydrated: JsonRecord = {};
-    for (const conn of connections) {
-      const psd = conn.providerSpecificData;
-      if (!psd || typeof psd !== "object") continue;
-      if (Array.isArray(psd.fingerprints) && !Array.isArray(hydrated.fingerprints)) {
-        hydrated.fingerprints = psd.fingerprints;
-      }
-      if (Array.isArray(psd.accountProxies) && !Array.isArray(hydrated.accountProxies)) {
-        hydrated.accountProxies = psd.accountProxies;
-      }
+    for (const pid of providerIdsToQuery) {
+      const connectionsRaw = await getProviderConnections({ provider: pid });
+      const connections = (Array.isArray(connectionsRaw) ? connectionsRaw : []).map(
+        toProviderConnection
+      );
+      for (const conn of connections) mergeNoAuthProviderSpecificData(hydrated, conn);
     }
     if (Array.isArray(hydrated.accountProxies)) {
       hydrated.accountProxies = await resolveAccountProxiesFromRegistry(hydrated.accountProxies);

--- a/src/sse/services/noAuthProviderSiblings.ts
+++ b/src/sse/services/noAuthProviderSiblings.ts
@@ -1,0 +1,24 @@
+/**
+ * #7993 — "OpenCode Free" is served by TWO distinct provider identities that
+ * are never unified: the no-auth "opencode" provider (NOAUTH_PROVIDERS,
+ * alias "oc" — the id the NoAuthAccountCard UI writes fingerprints +
+ * accountProxies onto via a `provider_connections` row) and the
+ * "opencode-zen" / "opencode-go" APIKEY_PROVIDERS gateways (which carry
+ * `anonymousFallback: true` for the same public endpoint).
+ *
+ * A model string resolved to the canonical/full prefix ("opencode/<model>")
+ * routes to "opencode-zen", not "opencode" (see the #2901 guard in
+ * open-sse/services/model.ts). When that happens, credential hydration for
+ * "opencode-zen" must still be able to find the user's proxy/fingerprint
+ * config, which physically lives on the "opencode" connection row — this
+ * sibling map lets `loadNoAuthProviderSpecificData()` look there too.
+ */
+const NOAUTH_SIBLING_PROVIDER_IDS: Record<string, string[]> = {
+  "opencode-zen": ["opencode"],
+  "opencode-go": ["opencode"],
+};
+
+/** Provider ids to query when hydrating no-auth `providerSpecificData` for `providerId`. */
+export function getNoAuthHydrationProviderIds(providerId: string): string[] {
+  return [providerId, ...(NOAUTH_SIBLING_PROVIDER_IDS[providerId] || [])];
+}

--- a/tests/unit/7993-noauth-proxy-routing.test.ts
+++ b/tests/unit/7993-noauth-proxy-routing.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #7993 — "OpenCode Free" is served by TWO distinct provider identities that
+ * are never unified: the no-auth "opencode" provider (NOAUTH_PROVIDERS —
+ * the id the NoAuthAccountCard UI writes fingerprints + accountProxies onto
+ * via a `provider_connections` row) and the "opencode-zen" APIKEY_PROVIDERS
+ * gateway (anonymousFallback: true, resolved from the canonical
+ * "opencode/<model>" prefix via the #2901 alias override in
+ * open-sse/services/model.ts).
+ *
+ * Before the fix, `getProviderCredentials("opencode-zen")` fell through to
+ * `maybeSyntheticNoAuthFallback("opencode-zen", ...)`, which hydrated
+ * `providerSpecificData` by querying `provider_connections` filtered by
+ * `provider === "opencode-zen"` — a DIFFERENT id than the one the user's
+ * connection row is saved under ("opencode") — so the assigned proxy was
+ * silently dropped and the request egressed direct.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7993-noauth-proxy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { getProviderCredentials } = await import("../../src/sse/services/auth.ts");
+const { createProviderConnection } = await import("../../src/lib/db/providers.ts");
+const { OpencodeExecutor } = await import("../../open-sse/executors/opencode.ts");
+const { resolveProxyForRequest } = await import("../../open-sse/utils/proxyFetch.ts");
+
+const log = { debug() {}, info() {}, warn() {}, error() {} };
+const FINGERPRINT = "cccccccccccccccccccccccccccccccc";
+
+let proxyServer: net.Server;
+let proxyPort = 0;
+
+function listen(server: net.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as net.AddressInfo).port);
+    });
+  });
+}
+
+test.before(async () => {
+  proxyServer = net.createServer((s) => s.destroy());
+  proxyPort = await listen(proxyServer);
+
+  // Mirror exactly what the NoAuthAccountCard UI writes: a `provider_connections`
+  // row filed under the no-auth id "opencode" (NOT "opencode-zen"), carrying the
+  // configured account proxy.
+  await createProviderConnection({
+    provider: "opencode",
+    authType: "no-auth",
+    name: "opencode-noauth-account",
+    isActive: true,
+    providerSpecificData: {
+      fingerprints: [FINGERPRINT],
+      accountProxies: [
+        {
+          fingerprint: FINGERPRINT,
+          proxy: { type: "http", host: "127.0.0.1", port: proxyPort },
+        },
+      ],
+    },
+  });
+});
+
+test.after(() => {
+  proxyServer?.close();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#7993 getProviderCredentials('opencode-zen') hydrates the proxy saved under the sibling 'opencode' connection", async () => {
+  const creds = (await getProviderCredentials("opencode-zen")) as {
+    connectionId?: string;
+    providerSpecificData?: { fingerprints?: unknown; accountProxies?: unknown };
+  } | null;
+
+  assert.ok(creds, "opencode-zen must resolve to synthetic no-auth credentials");
+  assert.equal(creds!.connectionId, "noauth");
+  const psd = creds!.providerSpecificData || {};
+  assert.ok(
+    Array.isArray(psd.fingerprints) && psd.fingerprints.length === 1,
+    `expected the sibling opencode connection's fingerprints to be hydrated, got ${JSON.stringify(psd)}`
+  );
+  assert.ok(
+    Array.isArray(psd.accountProxies) && psd.accountProxies.length === 1,
+    `expected the sibling opencode connection's accountProxies to be hydrated, got ${JSON.stringify(psd)}`
+  );
+});
+
+test("#7993 a canonical 'opencode/<model>' resolved combo/catalog target egresses through the assigned proxy, not direct", async () => {
+  const creds = await getProviderCredentials("opencode-zen");
+
+  const exec = new OpencodeExecutor("opencode-zen");
+  let observedSource: string | null = null;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) => {
+    const url = typeof input === "string" ? input : (input as { url?: string })?.url || String(input);
+    observedSource = resolveProxyForRequest(url).source;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+
+  try {
+    const result = await exec.execute({
+      model: "grok-code",
+      body: { messages: [{ role: "user", content: "hi" }], stream: false },
+      stream: false,
+      signal: null,
+      credentials: creds as never,
+      log,
+    });
+    assert.strictEqual((result as { response: Response }).response.status, 200);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.strictEqual(
+    observedSource,
+    "context",
+    `combo/catalog-path ('opencode-zen') must ALSO egress through the assigned proxy — got source=${observedSource}, expected 'context'`
+  );
+});


### PR DESCRIPTION
Closes #7993

## Root cause

"OpenCode Free" is served by two distinct provider identities that are never unified:
- `opencode` — the `NOAUTH_PROVIDERS` entry (alias `oc`). The `NoAuthAccountCard` UI writes fingerprints + `accountProxies` onto a `provider_connections` row filed under this id.
- `opencode-zen` — the `APIKEY_PROVIDERS` gateway entry (`anonymousFallback: true`) that `open-sse/services/model.ts`'s `#2901` alias override resolves the canonical `opencode/<model>` prefix to.

In `src/sse/services/auth.ts`, `getProviderCredentials()`'s no-auth early-return only fires when `NOAUTH_PROVIDERS[resolvedId]?.noAuth` is true — true for `opencode`, **false** for `opencode-zen`. For `opencode-zen` the code fell through to `maybeSyntheticNoAuthFallback('opencode-zen', ...)`, whose `loadNoAuthProviderSpecificData('opencode-zen')` queried `provider_connections` filtered by `provider === 'opencode-zen'` — a different id than the one the user's connection row is actually saved under (`opencode`) — so the assigned proxy/fingerprints were silently dropped and `OpencodeExecutor` fell back to a bare default account with `proxy: null`, taking the direct-egress fast path.

## Fix

Defense-in-depth fix at the credential-hydration layer (`src/sse/services/auth.ts::loadNoAuthProviderSpecificData`), not the alias-resolution layer: a new sibling map (`src/sse/services/noAuthProviderSiblings.ts`) lets hydration for an apikey-gateway id (`opencode-zen`, `opencode-go`) also query the sibling no-auth id (`opencode`) that shares its public endpoint, merging fingerprints/accountProxies from whichever connection row actually carries them.

This intentionally does **not** touch `open-sse/services/model.ts`'s `resolveProviderAlias`/`ALIAS_TO_PROVIDER_ID` — the `#2901` guard (`oc` stops at the no-auth `opencode` provider) and the deliberate `opencode -> opencode-zen` full-prefix override (asserted by `tests/unit/provider-alias-transitive-5918.test.ts`) are both preserved untouched, and `freeModelCatalog` keeps its canonical `provider: 'opencode-zen'`.

## TDD (Hard Rule #18)

New regression test: `tests/unit/7993-noauth-proxy-routing.test.ts`.

- RED confirmed against unmodified `origin/release/v3.8.49` `auth.ts`:
  - `AssertionError: expected the sibling opencode connection's fingerprints to be hydrated, got {}`
  - `AssertionError: combo/catalog-path ('opencode-zen') must ALSO egress through the assigned proxy — got source=direct, expected 'context'`
- GREEN after the fix (both tests pass).

## Gates run

- `node scripts/check/check-file-size.mjs` → OK (auth.ts 2461/2462 baseline).
- `node scripts/check/check-complexity.mjs` → pre-existing drift (2167 > baseline 2130) confirmed **unchanged** on the pure `origin/release/v3.8.49` tip too — not caused by this diff.
- `node scripts/check/check-cognitive-complexity.mjs` → pre-existing drift (956 > baseline 951) confirmed **unchanged** on the pure tip; this diff adds 0 new violations (extracted the merge loop into `mergeNoAuthProviderSpecificData` to keep it flat).
- `npm run typecheck:core` → exit 0.
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → exit 0.
- `node scripts/check/check-changelog-integrity.mjs` → OK.
- Sibling tests touching `getProviderCredentials`/`opencode-zen`/`NOAUTH_PROVIDERS`/`resolveProviderAlias` (~55 files) run individually — all green, including `provider-alias-transitive-5918.test.ts` (confirms the `#2901` alias contract is untouched) and `opencode-proxy-rotation-4954.test.ts`/`opencode-executor.test.ts` (confirm the executor proxy wiring is untouched).

## Landmine handling

- `#2901` alias guard preserved (`resolveProviderAlias("oc") === "opencode"`, `resolveProviderAlias("opencode") === "opencode-zen"` — unchanged, still asserted by `tests/unit/provider-alias-transitive-5918.test.ts`).
- `freeModelCatalog` canonical `provider: 'opencode-zen'` untouched.
- New logic extracted into a new module (`src/sse/services/noAuthProviderSiblings.ts`) instead of growing the frozen `auth.ts` god-file past its file-size baseline.