### PR TITLE
fix(security): remove quadratic trailing-slash trim in Alibaba endpoint normalization

### DIFF
--- a/src/shared/constants/alibabaProviderRegions.ts
+++ b/src/shared/constants/alibabaProviderRegions.ts
@@ -52,10 +52,24 @@ function canonicalProviderFamily(providerId: string): AlibabaProviderFamily | nu
   return null;
 }
 
+const SLASH_CHAR_CODE = 47;
+
+/**
+ * Strip every trailing "/" in linear time.
+ *
+ * Deliberately not a regex: `/\/+$/` has no left anchor, so the engine retries at
+ * every start offset and each attempt re-walks the slash run before failing `$` —
+ * quadratic on an endpoint made of many slashes (CodeQL js/polynomial-redos).
+ * Connection base URLs are operator-supplied, so they reach this trim directly.
+ */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === SLASH_CHAR_CODE) end--;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function normalizeEndpoint(value: string): string {
-  return value
-    .trim()
-    .replace(/\/+$/, "")
+  return stripTrailingSlashes(value.trim())
     .replace(/\/(?:chat\/completions|messages)$/i, "")
     .toLowerCase();
 }
@@ -138,10 +152,9 @@ export function resolveAlibabaProviderModelsUrl(
   providerSpecificData?: unknown,
   fallback = ""
 ): string {
-  const baseUrl = resolveAlibabaProviderBaseUrl(providerId, providerSpecificData, fallback)
-    .trim()
-    .replace(/\/+$/, "")
-    .replace(/\/(?:chat\/completions|messages|models)$/i, "");
+  const baseUrl = stripTrailingSlashes(
+    resolveAlibabaProviderBaseUrl(providerId, providerSpecificData, fallback).trim()
+  ).replace(/\/(?:chat\/completions|messages|models)$/i, "");
   return baseUrl ? `${baseUrl}/models` : "";
 }
 
@@ -154,9 +167,9 @@ export function resolveAlibabaProviderMediaBaseUrl(
   providerSpecificData?: unknown,
   fallback = ""
 ): string {
-  return resolveAlibabaProviderBaseUrl(providerId, providerSpecificData, fallback)
-    .trim()
-    .replace(/\/+$/, "")
+  return stripTrailingSlashes(
+    resolveAlibabaProviderBaseUrl(providerId, providerSpecificData, fallback).trim()
+  )
     .replace(/\/compatible-mode\/v1(?:\/(?:chat\/completions|models))?$/i, "/api/v1")
     .replace(/\/apps\/anthropic(?:\/v1)?(?:\/messages)?$/i, "/api/v1");
 }

--- a/tests/unit/alibaba-provider-regions.test.ts
+++ b/tests/unit/alibaba-provider-regions.test.ts
@@ -12,6 +12,7 @@ import {
   isAlibabaRegionalProvider,
   normalizeAlibabaProviderRegion,
   resolveAlibabaProviderBaseUrl,
+  resolveAlibabaProviderMediaBaseUrl,
   resolveAlibabaProviderModelsUrl,
 } from "../../src/shared/constants/alibabaProviderRegions.ts";
 import { APIKEY_PROVIDERS } from "../../src/shared/constants/providers.ts";
@@ -301,4 +302,57 @@ test("dashboard folds legacy China connections into the unified Alibaba card", (
   ]) {
     assert.equal(isAlibabaRegionalProvider(providerId), true);
   }
+});
+
+/**
+ * Regression guard for CodeQL `js/polynomial-redos` (alerts #765/#766).
+ *
+ * The trailing-slash trim used to be `/\/+$/`. That regex has no left anchor, so
+ * the engine retries the match at every start offset and each attempt walks the
+ * whole run of slashes before failing `$` — O(n^2) on a connection baseUrl made
+ * of many slashes. Measured on the vulnerable version: 10k slashes = 102ms,
+ * 30k = 968ms, 60k = 4028ms (clean quadratic). The linear strip runs in <1ms.
+ *
+ * `providerSpecificData.baseUrl` is operator-supplied config, so this input
+ * reaches the trim through isFamilyPresetUrl() -> normalizeEndpoint() and
+ * through both resolve*Url() helpers.
+ */
+test("trailing-slash normalization is linear on pathological slash runs (ReDoS guard)", () => {
+  const pathological = { baseUrl: `${"/".repeat(60_000)}x` };
+  const budgetMs = 500;
+
+  const started = performance.now();
+  resolveAlibabaProviderModelsUrl("alibaba", pathological);
+  resolveAlibabaProviderMediaBaseUrl("alibaba", pathological);
+  resolveAlibabaProviderBaseUrl("alibaba", pathological);
+  const elapsed = performance.now() - started;
+
+  assert.ok(
+    elapsed < budgetMs,
+    `trailing-slash trim must stay linear; took ${elapsed.toFixed(0)}ms (budget ${budgetMs}ms). ` +
+      "A quadratic trim (/\\/+$/) takes seconds on this input."
+  );
+});
+
+test("trailing-slash normalization keeps its exact behavior", () => {
+  // Every trailing slash is removed (not a bounded subset), and only trailing ones.
+  const withSlashes = { baseUrl: "https://example.test/v1////" };
+  assert.equal(
+    resolveAlibabaProviderModelsUrl("alibaba", withSlashes),
+    "https://example.test/v1/models"
+  );
+
+  // Interior slashes are preserved.
+  const interior = { baseUrl: "https://example.test//deep//path/" };
+  assert.equal(
+    resolveAlibabaProviderBaseUrl("alibaba", interior),
+    "https://example.test//deep//path/"
+  );
+  assert.equal(
+    resolveAlibabaProviderModelsUrl("alibaba", interior),
+    "https://example.test//deep//path/models"
+  );
+
+  // A string that is nothing but slashes collapses to empty.
+  assert.equal(resolveAlibabaProviderModelsUrl("alibaba", { baseUrl: "////" }), "");
 });


### PR DESCRIPTION
Fecha os alertas CodeQL **#765/#766** (`js/polynomial-redos`, high) em `src/shared/constants/alibabaProviderRegions.ts`.

## Não é falso positivo — medido

`/\/+$/` não tem âncora à esquerda, então o motor de regex retenta o match em **cada offset de início**, e cada tentativa percorre toda a sequência de barras antes de falhar no `$`. É O(n²).

Medição no código vulnerável (`.replace(/\/+$/, "")` isolado):

| barras | tempo |
|--------|-------|
| 10.000 | 102 ms |
| 30.000 | 968 ms |
| 60.000 | **4.028 ms** |

Crescimento quadrático limpo. Pelos resolvers públicos (que aplicam o trim 3×), o mesmo input levou **22 segundos**. O scan linear faz o mesmo em **0,4 ms**.

## Alcançabilidade

`providerSpecificData.baseUrl` é config fornecida pelo operador e chega ao trim por dois caminhos:
- `resolveAlibabaProviderBaseUrl()` → `isFamilyPresetUrl()` → `normalizeEndpoint()`
- `resolveAlibabaProviderModelsUrl()` / `resolveAlibabaProviderMediaBaseUrl()` diretamente

## Fix

Troca as **três** ocorrências idênticas por um `stripTrailingSlashes()` linear (`charCodeAt`, sem regex). O CodeQL flagou só duas; a terceira (`resolveAlibabaProviderModelsUrl`, linha 143) tem exatamente o mesmo defeito e foi corrigida junto em vez de ficar para trás.

**Comportamento inalterado** (não é bound/truncamento): todas as barras finais continuam sendo removidas, barras internas preservadas, e string só-de-barras ainda colapsa para vazio.

## Validação (TDD — Hard Rule #18)

Teste escrito **antes** do fix, em `tests/unit/alibaba-provider-regions.test.ts`:

- `ReDoS guard` — **RED: 22.008 ms** (budget 500 ms) → **GREEN: 20 ms** (~1.100× mais rápido)
- `keeps its exact behavior` — trava a semântica do trim (passava antes e depois, garantindo que o fix não alterou comportamento)

Rodado:
- `alibaba-provider-regions.test.ts`: **14/14 pass**
- Consumidores do módulo (image/video media, qwen-cloud-token-plan, bailian-coding-plan): **34/34 pass**
- `typecheck:core`: limpo · `eslint`: exit 0 · `prettier --check`: OK