### PR TITLE
[v3.8.50] feat(sse): Cursor plan images via Agent CLI (IMAGE_PROVIDERS.cursor)

### DIFF
--- a/changelog.d/features/cursor-agent-image-provider.md
+++ b/changelog.d/features/cursor-agent-image-provider.md
@@ -1,0 +1,1 @@
+- feat(sse): add Cursor plan image generation via Agent CLI (`IMAGE_PROVIDERS.cursor`, format `cursor-agent-image`), reusing the chat Cursor OAuth connection

--- a/docs/getting-started/PROVIDERS-GUIDE.md
+++ b/docs/getting-started/PROVIDERS-GUIDE.md
@@ -221,3 +221,7 @@ Go to Providers → click on the provider → click **Disconnect**.
 - **[Free Tiers Guide](./FREE-TIERS-GUIDE.md)** — Get free AI with no credit card
 - **[Troubleshooting](./TROUBLESHOOTING.md)** — Fix common issues
 - **[Provider Reference](../reference/PROVIDER_REFERENCE.md)** — Full list of 226 providers
+
+## Cursor images
+
+Cursor plan images use `IMAGE_PROVIDERS.cursor` (`cursor-agent-image`). See [CURSOR_IMAGE.md](../providers/CURSOR_IMAGE.md).

--- a/docs/providers/CURSOR_IMAGE.md
+++ b/docs/providers/CURSOR_IMAGE.md
@@ -1,0 +1,51 @@
+---
+title: "Cursor Image Generation"
+version: 3.8.49
+lastUpdated: 2026-07-23
+---
+
+# Cursor Image Generation
+
+OmniRoute exposes Cursor plan **image generation** on `POST /v1/images/generations` through the same provider id as chat: `cursor` (alias `cu`).
+
+| Field | Value |
+|-------|--------|
+| `IMAGE_PROVIDERS` id | `cursor` |
+| Format | `cursor-agent-image` |
+| Auth | Same OAuth / API-key connection as chat (`provider_connections.provider = "cursor"`) |
+| Models | `cursor/auto`, `cursor/composer-2`, `cursor/composer-2.5` |
+
+## Why the Agent CLI
+
+Cursor chat in OmniRoute uses `agent.v1.AgentService/Run` (protobuf). That path **rejects** built-in client tools (shell, write, …). Image generation is a Cursor-native tool executed by the **`agent` CLI** against the seat. The image handler therefore spawns `agent` with a locked prompt and a per-request temp workspace (same shape as community seat bridges), then returns OpenAI-compatible `b64_json`.
+
+## Requirements
+
+1. A connected Cursor account in the dashboard (OAuth or `crsr_…` API key).
+2. The Cursor Agent binary available to the OmniRoute process:
+   - env `CURSOR_AGENT_BIN=/path/to/agent`, or
+   - `~/.local/bin/agent`, or
+   - `providerSpecificData.agentBin` on the Cursor connection.
+
+Optional tuning:
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `CURSOR_IMG_TIMEOUT_MS` | `210000` | Per-image wall clock |
+| `CURSOR_IMG_MAX_CONCURRENT` | `2` | Shared-seat concurrency gate |
+| `CURSOR_IMG_MODEL` | (request model / `auto`) | Override CLI `--model` |
+
+## Example
+
+```bash
+curl -sS https://<host>/v1/images/generations \
+  -H "Authorization: Bearer <omni-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"cursor/auto","prompt":"a lantern in fog","size":"1024x1024"}'
+```
+
+Generation typically takes 1–2 minutes. Prefer an internal network path; edge proxies with ~100s timeouts will fail.
+
+## LiteLLM
+
+Register an image model with `mode: image_generation`, `api_base: http://omniroute:20128/v1`, and `model: openai/cursor/auto` (or bare `cursor/auto` depending on your LiteLLM version).

--- a/docs/reference/PROVIDER_REFERENCE.md
+++ b/docs/reference/PROVIDER_REFERENCE.md
@@ -45,7 +45,7 @@ Use the dashboard at `/dashboard/providers` to enable, configure, and test each 
 | `clinepass` | `cp` | ClinePass | OAuth | [link](https://cline.bot/cline-pass) | ClinePass is Cline's $9.99/mo subscription bundling 10 open coding models. Sign in with your Cline account (same login as the Cline CLI/IDE), or paste a direct ClinePass API key (app.cline.bot → Settings → API Keys). A ClinePass subscription unlocks the cline-pass/* models. Reuses the Cline WorkOS OAuth flow. |
 | `codebuddy-cn` | `cbcn` | CodeBuddy CN | OAuth | [link](https://copilot.tencent.com) | Tencent CodeBuddy CN (copilot.tencent.com). Sign in via the official CLI device-code flow, or paste a direct API key (sent as Authorization: Bearer). Catalog: GLM / Kimi / MiniMax / DeepSeek / Hunyuan. |
 | `codex` | `cx` | OpenAI Codex | OAuth | — | — |
-| `cursor` | `cu` | Cursor IDE | OAuth | — | — |
+| `cursor` | `cu` | Cursor IDE | OAuth, image | — | Image via Agent CLI (`CURSOR_AGENT_BIN`); same seat as chat |
 | `devin-cli` | `dv` | Devin CLI (Official) | OAuth | [link](https://cli.devin.ai) | Requires the Devin CLI binary. Run `devin auth login` to authenticate, or provide your WINDSURF_API_KEY. Install: https://cli.devin.ai |
 | `ghe-copilot` | `ghe-copilot` | GitHub Enterprise Copilot | OAuth | — | Enter your GHE instance URL (e.g., https://ghe.company.com) in provider settings, then authenticate via device flow. |
 | `github` | `gh` | GitHub Copilot | OAuth | — | — |

--- a/open-sse/config/imageRegistry.ts
+++ b/open-sse/config/imageRegistry.ts
@@ -209,6 +209,25 @@ export const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
     supportedSizes: ["1024x1024", "1024x1536", "1536x1024"],
   },
 
+  // Cursor plan image generation via the Agent CLI native `generateImage` tool.
+  // Reuses the same OAuth/API-key connection as chat (`provider: "cursor"`).
+  // Requires the `agent` binary (CURSOR_AGENT_BIN) — see cursorAgentImage handler.
+  cursor: {
+    id: "cursor",
+    alias: "cu",
+    // Sentinel: execution is local Agent CLI, not an HTTP image API.
+    baseUrl: "agent://cursor-agent",
+    authType: "oauth",
+    authHeader: "bearer",
+    format: "cursor-agent-image",
+    models: [
+      { id: "auto", name: "Cursor Auto (Image)" },
+      { id: "composer-2", name: "Composer 2 (Image)" },
+      { id: "composer-2.5", name: "Composer 2.5 (Image)" },
+    ],
+    supportedSizes: ["1024x1024", "1024x1792", "1792x1024", "1024x1536", "1536x1024"],
+  },
+
   "microsoft-designer-web": {
     id: "microsoft-designer-web",
     alias: "msdesigner",

--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -72,6 +72,7 @@ import {
 import { handleNvidiaNimImageGeneration } from "./imageGeneration/providers/nvidiaNim.ts";
 import { handleSegmindImageGeneration } from "./imageGeneration/providers/segmind.ts";
 import { handleDesignerWebImageGeneration } from "./imageGeneration/providers/designerWeb.ts";
+import { handleCursorAgentImageGeneration } from "./imageGeneration/providers/cursorAgentImage.ts";
 import { handleMinimaxImageGeneration } from "./imageGeneration/providers/minimax.ts";
 import { handleAdobeFireflyImageGeneration } from "./imageGeneration/providers/adobeFirefly.ts";
 import { handleAlibabaImageGeneration } from "./imageGeneration/providers/alibabaImage.ts";
@@ -492,6 +493,17 @@ export async function handleImageGeneration({
       log,
       signal,
       clientHeaders,
+    });
+  }
+
+  if (providerConfig.format === "cursor-agent-image") {
+    return handleCursorAgentImageGeneration({
+      model,
+      provider,
+      providerConfig,
+      body,
+      credentials,
+      log,
     });
   }
 

--- a/open-sse/handlers/imageGeneration/providers/cursorAgentImage.ts
+++ b/open-sse/handlers/imageGeneration/providers/cursorAgentImage.ts
@@ -1,0 +1,410 @@
+/**
+ * Cursor Agent image generation — OpenAI `/v1/images/generations` backed by the
+ * Cursor Agent CLI's native `generateImage` tool (real diffusion, not SVG).
+ *
+ * Why CLI (not AgentService/Run): OmniRoute's Cursor chat executor talks to
+ * `agent.v1.AgentService/Run` over protobuf and **rejects** built-in tools
+ * (shell/write/…). Image generation is a Cursor-native client tool that the
+ * `agent` binary executes locally against the seat. Spawning the CLI with a
+ * locked prompt + per-request workspace mirrors the proven seat bridge shape
+ * and reuses the same `provider_connections` row as chat (`provider: "cursor"`).
+ *
+ * Auth: `credentials.accessToken` / `apiKey` from the Cursor OAuth (or API-key)
+ * connection. Tokens matching `crsr_…` are exported as `CURSOR_API_KEY`; other
+ * session JWTs as `CURSOR_AUTH_TOKEN`. The `account::token` composite used by
+ * the chat executor is normalized the same way (`split("::")[1]`).
+ *
+ * Binary: `CURSOR_AGENT_BIN` → `providerSpecificData.agentBin` → PATH / default
+ * shim under `~/.local/bin/agent`. Missing binary → HTTP 501 with install hint.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { sanitizeErrorMessage } from "../../../utils/error.ts";
+import { saveImageErrorResult, saveImageSuccessResult } from "../../imageGeneration.ts";
+
+export const CURSOR_AGENT_IMAGE_FORMAT = "cursor-agent-image";
+
+const DEFAULT_TIMEOUT_MS = 210_000;
+const DEFAULT_MAX_CONCURRENT = 2;
+const DEFAULT_MODEL = "auto";
+const MAX_N = 4;
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff]);
+
+/** Locked instruction — ingress callers can only trigger image gen, never a shell. */
+export function buildCursorAgentImagePrompt(userPrompt: string, outPath: string, size?: unknown): string {
+  const sizeHint =
+    typeof size === "string" && size.trim() ? ` Target size/aspect: ${size.trim()}.` : "";
+  return [
+    "You have a native image-generation tool. Use it to generate ONE image.",
+    "Do NOT write code, do NOT hand-author SVG, do NOT install packages — use your built-in image generation.",
+    `Image to generate: ${userPrompt}.${sizeHint}`,
+    `Save the resulting image to exactly this path: ${outPath}.`,
+    "When the file exists at that exact path, reply with only the word DONE.",
+  ].join(" ");
+}
+
+/** Strip OmniRoute `account::token` composites the same way CursorExecutor does. */
+export function normalizeCursorSeatToken(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  return trimmed.includes("::") ? trimmed.split("::").slice(1).join("::").trim() || trimmed : trimmed;
+}
+
+/**
+ * Map a Cursor connection token into the env vars the Agent CLI reads.
+ * Prefer API keys (`crsr_…`) as `CURSOR_API_KEY`; otherwise session JWT → `CURSOR_AUTH_TOKEN`.
+ */
+export function buildCursorAgentAuthEnv(token: string): Record<string, string> {
+  const clean = normalizeCursorSeatToken(token);
+  if (clean.startsWith("crsr_")) {
+    return { CURSOR_API_KEY: clean };
+  }
+  return { CURSOR_AUTH_TOKEN: clean };
+}
+
+export function resolveCursorAgentBin(override?: string | null): string | null {
+  // Explicit connection override wins even when the path is missing — the handler
+  // returns 501 so operators see a clear misconfiguration instead of a silent fallback.
+  if (typeof override === "string" && override.trim()) {
+    return override.trim();
+  }
+  const envBin = process.env.CURSOR_AGENT_BIN?.trim();
+  if (envBin) return envBin;
+
+  const defaultShim = join(homedir(), ".local", "bin", "agent");
+  if (existsSync(defaultShim)) return defaultShim;
+
+  // Last resort: bare `agent` on PATH (spawn fails with ENOENT → 501).
+  return "agent";
+}
+
+export function isRasterImageBuffer(buf: Buffer): boolean {
+  if (buf.length >= 8 && buf.subarray(0, 8).equals(PNG_MAGIC)) return true;
+  if (buf.length >= 3 && buf.subarray(0, 3).equals(JPEG_MAGIC)) return true;
+  return false;
+}
+
+export async function findCursorAgentImageOutput(
+  workspace: string,
+  preferredPath: string
+): Promise<string | null> {
+  if (existsSync(preferredPath)) return preferredPath;
+  try {
+    const entries = await readdir(workspace);
+    const match = entries.find((name) => /\.(png|jpe?g|webp)$/i.test(name));
+    return match ? join(workspace, match) : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizePositiveInt(value: unknown, fallback: number, max?: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  const i = Math.floor(n);
+  return typeof max === "number" ? Math.min(i, max) : i;
+}
+
+type CursorAgentImageCredentials = {
+  apiKey?: string;
+  accessToken?: string;
+  providerSpecificData?: Record<string, unknown> | null;
+};
+
+function extractSeatToken(credentials: CursorAgentImageCredentials): string {
+  const raw = credentials?.accessToken || credentials?.apiKey || "";
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function extractAgentBinOverride(credentials: CursorAgentImageCredentials): string | null {
+  const psd = credentials?.providerSpecificData;
+  if (!psd || typeof psd !== "object" || Array.isArray(psd)) return null;
+  const bin = psd.agentBin;
+  return typeof bin === "string" && bin.trim() ? bin.trim() : null;
+}
+
+function extractAgentModel(credentials: CursorAgentImageCredentials, requestModel: string): string {
+  const psd = credentials?.providerSpecificData;
+  if (psd && typeof psd === "object" && !Array.isArray(psd)) {
+    const fromPsd = psd.imageModel;
+    if (typeof fromPsd === "string" && fromPsd.trim()) return fromPsd.trim();
+  }
+  if (process.env.CURSOR_IMG_MODEL?.trim()) return process.env.CURSOR_IMG_MODEL.trim();
+  // IMAGE_PROVIDERS model id is usually "auto" — pass through to the CLI.
+  return requestModel && requestModel !== "cursor" ? requestModel : DEFAULT_MODEL;
+}
+
+// ─── process-wide concurrency gate (one shared Cursor seat) ─────────────────
+
+type Waiter = () => void;
+let activeGenerations = 0;
+const waitQueue: Waiter[] = [];
+
+export function __resetCursorAgentImageConcurrencyForTests(): void {
+  activeGenerations = 0;
+  waitQueue.length = 0;
+}
+
+function maxConcurrent(): number {
+  return normalizePositiveInt(process.env.CURSOR_IMG_MAX_CONCURRENT, DEFAULT_MAX_CONCURRENT);
+}
+
+async function acquireSlot(): Promise<void> {
+  if (activeGenerations < maxConcurrent()) {
+    activeGenerations += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    waitQueue.push(() => {
+      activeGenerations += 1;
+      resolve();
+    });
+  });
+}
+
+function releaseSlot(): void {
+  activeGenerations = Math.max(0, activeGenerations - 1);
+  const next = waitQueue.shift();
+  if (next) next();
+}
+
+export type RunCursorAgentImageOptions = {
+  agentBin: string;
+  workspace: string;
+  prompt: string;
+  model: string;
+  authEnv: Record<string, string>;
+  timeoutMs: number;
+  spawnImpl?: typeof spawn;
+};
+
+/** Spawn `agent -p --force …` and resolve when it exits 0 (or reject on timeout/error). */
+export function runCursorAgentImageProcess(opts: RunCursorAgentImageOptions): Promise<{
+  stdout: string;
+  stderr: string;
+}> {
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const args = [
+    "-p",
+    "--force",
+    "--model",
+    opts.model,
+    "--workspace",
+    opts.workspace,
+    "--output-format",
+    "text",
+    opts.prompt,
+  ];
+
+  return new Promise((resolve, reject) => {
+    const child = spawnImpl(opts.agentBin, args, {
+      cwd: opts.workspace,
+      env: {
+        ...process.env,
+        ...opts.authEnv,
+        HOME: process.env.HOME || homedir(),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Cursor Agent image generation timed out after ${opts.timeoutMs}ms`));
+    }, opts.timeoutMs);
+
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `Cursor Agent exited ${code}: ${(stderr || stdout).trim().slice(0, 400) || "no output"}`
+        )
+      );
+    });
+  });
+}
+
+async function generateOneImage(params: {
+  userPrompt: string;
+  size: unknown;
+  agentBin: string;
+  model: string;
+  authEnv: Record<string, string>;
+  timeoutMs: number;
+  spawnImpl?: typeof spawn;
+}): Promise<Buffer> {
+  const workspace = await mkdtemp(join(tmpdir(), "omni-cursor-img-"));
+  const outPath = join(workspace, "out.png");
+  const prompt = buildCursorAgentImagePrompt(params.userPrompt, outPath, params.size);
+
+  try {
+    await runCursorAgentImageProcess({
+      agentBin: params.agentBin,
+      workspace,
+      prompt,
+      model: params.model,
+      authEnv: params.authEnv,
+      timeoutMs: params.timeoutMs,
+      spawnImpl: params.spawnImpl,
+    });
+
+    const found = await findCursorAgentImageOutput(workspace, outPath);
+    if (!found) {
+      throw new Error("Cursor Agent produced no image file in the workspace");
+    }
+    const buf = await readFile(found);
+    if (!isRasterImageBuffer(buf)) {
+      throw new Error("Cursor Agent output is not a PNG/JPEG raster");
+    }
+    return buf;
+  } finally {
+    await rm(workspace, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+export async function handleCursorAgentImageGeneration({
+  model,
+  provider,
+  providerConfig: _providerConfig,
+  body,
+  credentials,
+  log,
+  spawnImpl,
+}: {
+  model: string;
+  provider: string;
+  providerConfig: { baseUrl?: string };
+  body: {
+    prompt?: unknown;
+    size?: unknown;
+    n?: unknown;
+    timeout_ms?: unknown;
+  };
+  credentials: CursorAgentImageCredentials;
+  log?: { info?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
+  /** Test seam — defaults to node:child_process.spawn */
+  spawnImpl?: typeof spawn;
+}) {
+  const startTime = Date.now();
+  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+  if (!prompt) {
+    return saveImageErrorResult({
+      provider,
+      model,
+      status: 400,
+      startTime,
+      error: "Prompt is required for Cursor Agent image generation",
+    });
+  }
+
+  const token = extractSeatToken(credentials);
+  if (!token) {
+    return saveImageErrorResult({
+      provider,
+      model,
+      status: 401,
+      startTime,
+      error: "Cursor credentials missing accessToken — reconnect the Cursor provider",
+    });
+  }
+
+  const agentBin = resolveCursorAgentBin(extractAgentBinOverride(credentials));
+  if (!agentBin || (agentBin !== "agent" && !existsSync(agentBin))) {
+    // Bare "agent" may still resolve via PATH; only hard-fail when an explicit path is missing.
+    if (agentBin !== "agent") {
+      return saveImageErrorResult({
+        provider,
+        model,
+        status: 501,
+        startTime,
+        error:
+          "Cursor Agent CLI not found. Install the Cursor `agent` binary and set CURSOR_AGENT_BIN, or set providerSpecificData.agentBin on the Cursor connection.",
+      });
+    }
+  }
+
+  const timeoutMs = normalizePositiveInt(
+    body.timeout_ms,
+    normalizePositiveInt(process.env.CURSOR_IMG_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
+  );
+  const count = normalizePositiveInt(body.n, 1, MAX_N);
+  const agentModel = extractAgentModel(credentials, model);
+  const authEnv = buildCursorAgentAuthEnv(token);
+
+  if (log?.info) {
+    log.info(
+      "IMAGE",
+      `${provider}/${model} (cursor-agent-image) | n=${count} model=${agentModel} bin=${agentBin}`
+    );
+  }
+
+  const images: Array<{ b64_json: string; revised_prompt: string }> = [];
+
+  try {
+    for (let i = 0; i < count; i++) {
+      await acquireSlot();
+      try {
+        const buf = await generateOneImage({
+          userPrompt: prompt,
+          size: body.size,
+          agentBin: agentBin || "agent",
+          model: agentModel,
+          authEnv,
+          timeoutMs,
+          spawnImpl,
+        });
+        images.push({ b64_json: buf.toString("base64"), revised_prompt: prompt });
+      } finally {
+        releaseSlot();
+      }
+    }
+
+    return saveImageSuccessResult({
+      provider,
+      model,
+      startTime,
+      images,
+    });
+  } catch (err) {
+    const errorText = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    if (log?.error) {
+      log.error("IMAGE", `${provider} cursor-agent-image error: ${errorText}`);
+    }
+    // ENOENT from spawn → treat as missing CLI
+    const status =
+      err && typeof err === "object" && "code" in err && (err as { code?: string }).code === "ENOENT"
+        ? 501
+        : 502;
+    return saveImageErrorResult({
+      provider,
+      model,
+      status,
+      startTime,
+      error:
+        status === 501
+          ? "Cursor Agent CLI not found on PATH. Set CURSOR_AGENT_BIN to the `agent` binary."
+          : errorText,
+    });
+  }
+}

--- a/open-sse/handlers/imageGeneration/providers/cursorAgentImage.ts
+++ b/open-sse/handlers/imageGeneration/providers/cursorAgentImage.ts
@@ -25,6 +25,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { sanitizeErrorMessage } from "../../../utils/error.ts";
 import { saveImageErrorResult, saveImageSuccessResult } from "../../imageGeneration.ts";
+import { IMAGE_PROVIDERS } from "../../../config/imageRegistry.ts";
 
 export const CURSOR_AGENT_IMAGE_FORMAT = "cursor-agent-image";
 
@@ -32,6 +33,26 @@ const DEFAULT_TIMEOUT_MS = 210_000;
 const DEFAULT_MAX_CONCURRENT = 2;
 const DEFAULT_MODEL = "auto";
 const MAX_N = 4;
+
+// Upper bound on a caller-supplied `timeout_ms`. The Cursor seat is shared and
+// CURSOR_IMG_MAX_CONCURRENT defaults to only 2 slots, so a huge per-request
+// timeout must not hog a slot and starve every other caller.
+const MAX_TIMEOUT_MS = 300_000;
+
+// Models the Agent CLI `--model` argv may receive — kept in sync with the
+// registry entry (auto | composer-2 | composer-2.5). The request `model` is
+// untrusted input forwarded straight into a spawned CLI, so we mirror the
+// auggie executor: anything outside this set (unknown model, or a flag-shaped
+// value like "--foo" / "-x") is clamped to DEFAULT_MODEL and never reaches argv.
+const CURSOR_IMAGE_MODEL_ALLOWLIST: ReadonlySet<string> = new Set(
+  (IMAGE_PROVIDERS.cursor?.models ?? []).map((m) => m.id)
+);
+
+/** Clamp a model candidate to the allowlist; unknown/flag-shaped → "auto". */
+export function resolveCursorImageModel(candidate: unknown): string {
+  const requested = typeof candidate === "string" ? candidate.trim() : "";
+  return CURSOR_IMAGE_MODEL_ALLOWLIST.has(requested) ? requested : DEFAULT_MODEL;
+}
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff]);
@@ -111,6 +132,20 @@ function normalizePositiveInt(value: unknown, fallback: number, max?: number): n
   return typeof max === "number" ? Math.min(i, max) : i;
 }
 
+/**
+ * Effective per-image wall clock: a caller-supplied `timeout_ms` clamped to
+ * MAX_TIMEOUT_MS. When the request omits it, fall back to the operator default
+ * (CURSOR_IMG_TIMEOUT_MS) / DEFAULT_TIMEOUT_MS uncapped — operator config is
+ * trusted; only the untrusted request value is clamped.
+ */
+export function resolveCursorImageTimeoutMs(rawTimeout: unknown): number {
+  return normalizePositiveInt(
+    rawTimeout,
+    normalizePositiveInt(process.env.CURSOR_IMG_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    MAX_TIMEOUT_MS
+  );
+}
+
 type CursorAgentImageCredentials = {
   apiKey?: string;
   accessToken?: string;
@@ -136,8 +171,13 @@ function extractAgentModel(credentials: CursorAgentImageCredentials, requestMode
     if (typeof fromPsd === "string" && fromPsd.trim()) return fromPsd.trim();
   }
   if (process.env.CURSOR_IMG_MODEL?.trim()) return process.env.CURSOR_IMG_MODEL.trim();
-  // IMAGE_PROVIDERS model id is usually "auto" — pass through to the CLI.
-  return requestModel && requestModel !== "cursor" ? requestModel : DEFAULT_MODEL;
+  // The request's `model=cursor/<…>` field is untrusted and flows into the CLI
+  // `--model` argv — clamp it to the registry allowlist (unknown/flag-shaped →
+  // "auto"). The operator overrides above (connection psd / CURSOR_IMG_MODEL)
+  // are trusted deployment config and pass through unchanged.
+  return resolveCursorImageModel(
+    requestModel && requestModel !== "cursor" ? requestModel : DEFAULT_MODEL
+  );
 }
 
 // ─── process-wide concurrency gate (one shared Cursor seat) ─────────────────
@@ -344,10 +384,7 @@ export async function handleCursorAgentImageGeneration({
     }
   }
 
-  const timeoutMs = normalizePositiveInt(
-    body.timeout_ms,
-    normalizePositiveInt(process.env.CURSOR_IMG_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
-  );
+  const timeoutMs = resolveCursorImageTimeoutMs(body.timeout_ms);
   const count = normalizePositiveInt(body.n, 1, MAX_N);
   const agentModel = extractAgentModel(credentials, model);
   const authEnv = buildCursorAgentAuthEnv(token);

--- a/tests/unit/cursor-agent-image.test.ts
+++ b/tests/unit/cursor-agent-image.test.ts
@@ -1,0 +1,159 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { IMAGE_PROVIDERS, parseImageModel, getImageProvider } from "../../open-sse/config/imageRegistry.ts";
+import {
+  buildCursorAgentAuthEnv,
+  buildCursorAgentImagePrompt,
+  CURSOR_AGENT_IMAGE_FORMAT,
+  handleCursorAgentImageGeneration,
+  isRasterImageBuffer,
+  normalizeCursorSeatToken,
+  __resetCursorAgentImageConcurrencyForTests,
+} from "../../open-sse/handlers/imageGeneration/providers/cursorAgentImage.ts";
+
+test("cursor is registered in IMAGE_PROVIDERS with cursor-agent-image format", () => {
+  const entry = IMAGE_PROVIDERS.cursor;
+  assert.ok(entry, "expected IMAGE_PROVIDERS.cursor");
+  assert.equal(entry.id, "cursor");
+  assert.equal(entry.alias, "cu");
+  assert.equal(entry.format, CURSOR_AGENT_IMAGE_FORMAT);
+  assert.equal(entry.authType, "oauth");
+  assert.equal(entry.authHeader, "bearer");
+  assert.ok(entry.models.some((m) => m.id === "auto"));
+  assert.deepEqual(getImageProvider("cursor"), entry);
+});
+
+test("parseImageModel resolves cursor/auto and cu/auto to the cursor image provider", () => {
+  assert.deepEqual(parseImageModel("cursor/auto"), { provider: "cursor", model: "auto" });
+  assert.deepEqual(parseImageModel("cu/auto"), { provider: "cursor", model: "auto" });
+});
+
+test("normalizeCursorSeatToken strips account:: prefix like CursorExecutor", () => {
+  assert.equal(normalizeCursorSeatToken("acct::tok_abc"), "tok_abc");
+  assert.equal(normalizeCursorSeatToken("  crsr_live  "), "crsr_live");
+  assert.equal(normalizeCursorSeatToken("a::b::c"), "b::c");
+});
+
+test("buildCursorAgentAuthEnv maps crsr_ to CURSOR_API_KEY and JWTs to CURSOR_AUTH_TOKEN", () => {
+  assert.deepEqual(buildCursorAgentAuthEnv("crsr_abc"), { CURSOR_API_KEY: "crsr_abc" });
+  assert.deepEqual(buildCursorAgentAuthEnv("user::crsr_abc"), { CURSOR_API_KEY: "crsr_abc" });
+  assert.deepEqual(buildCursorAgentAuthEnv("eyJhbGciOi.jwt"), {
+    CURSOR_AUTH_TOKEN: "eyJhbGciOi.jwt",
+  });
+});
+
+test("buildCursorAgentImagePrompt locks the agent to native generateImage + exact out path", () => {
+  const prompt = buildCursorAgentImagePrompt("a red cube", "/tmp/out.png", "1024x1024");
+  assert.match(prompt, /native image-generation tool/i);
+  assert.match(prompt, /Do NOT write code/);
+  assert.match(prompt, /a red cube/);
+  assert.match(prompt, /1024x1024/);
+  assert.match(prompt, /\/tmp\/out\.png/);
+  assert.match(prompt, /\bDONE\b/);
+});
+
+test("isRasterImageBuffer accepts PNG and JPEG magics", () => {
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+  const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+  assert.equal(isRasterImageBuffer(png), true);
+  assert.equal(isRasterImageBuffer(jpeg), true);
+  assert.equal(isRasterImageBuffer(Buffer.from("not-an-image")), false);
+});
+
+test("handleCursorAgentImageGeneration rejects empty prompt and missing credentials", async () => {
+  __resetCursorAgentImageConcurrencyForTests();
+  const noPrompt = await handleCursorAgentImageGeneration({
+    model: "auto",
+    provider: "cursor",
+    providerConfig: { baseUrl: "agent://cursor-agent" },
+    body: { prompt: "   " },
+    credentials: { accessToken: "crsr_x" },
+  });
+  assert.equal(noPrompt.success, false);
+  assert.equal(noPrompt.status, 400);
+
+  const noCreds = await handleCursorAgentImageGeneration({
+    model: "auto",
+    provider: "cursor",
+    providerConfig: { baseUrl: "agent://cursor-agent" },
+    body: { prompt: "hi" },
+    credentials: {},
+  });
+  assert.equal(noCreds.success, false);
+  assert.equal(noCreds.status, 401);
+});
+
+test("handleCursorAgentImageGeneration returns 501 when agentBin path is missing", async () => {
+  __resetCursorAgentImageConcurrencyForTests();
+  const result = await handleCursorAgentImageGeneration({
+    model: "auto",
+    provider: "cursor",
+    providerConfig: { baseUrl: "agent://cursor-agent" },
+    body: { prompt: "a lantern" },
+    credentials: {
+      accessToken: "crsr_test",
+      providerSpecificData: { agentBin: "/nonexistent/cursor-agent-bin" },
+    },
+  });
+  assert.equal(result.success, false);
+  assert.equal(result.status, 501);
+  assert.match(String(result.error), /CURSOR_AGENT_BIN|agentBin/i);
+});
+
+/**
+ * Minimal fake `spawn` that writes a tiny PNG to the out path embedded in the
+ * prompt and exits 0 — exercises the success path without a real Cursor Agent.
+ */
+test("handleCursorAgentImageGeneration returns b64_json via injectable spawn", async () => {
+  __resetCursorAgentImageConcurrencyForTests();
+  const { writeFile, mkdir } = await import("node:fs/promises");
+  const path = await import("node:path");
+
+  const tinyPng = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  ]);
+
+  const fakeSpawn = ((bin: string, args: string[]) => {
+    assert.ok(bin, "agent bin required");
+    const prompt = args[args.length - 1] || "";
+    const marker = "Save the resulting image to exactly this path: ";
+    const idx = prompt.indexOf(marker);
+    assert.ok(idx >= 0, "prompt must contain out path");
+    const after = prompt.slice(idx + marker.length);
+    const end = after.indexOf(". When the file exists");
+    assert.ok(end > 0, "prompt must end out path before DONE clause");
+    const outPath = after.slice(0, end);
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: () => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => undefined;
+    queueMicrotask(async () => {
+      await mkdir(path.dirname(outPath), { recursive: true });
+      await writeFile(outPath, tinyPng);
+      child.emit("close", 0);
+    });
+    return child;
+  }) as unknown as typeof import("node:child_process").spawn;
+
+  // Use an existing path so the preflight existsSync check passes; spawn is faked.
+  const result = await handleCursorAgentImageGeneration({
+    model: "auto",
+    provider: "cursor",
+    providerConfig: { baseUrl: "agent://cursor-agent" },
+    body: { prompt: "a lantern in fog", size: "1024x1024", n: 1 },
+    credentials: {
+      accessToken: "crsr_test",
+      providerSpecificData: { agentBin: process.execPath },
+    },
+    spawnImpl: fakeSpawn,
+  });
+
+  assert.equal(result.success, true);
+  assert.ok(result.data?.data?.[0]?.b64_json);
+  assert.equal(result.data.data[0].b64_json, tinyPng.toString("base64"));
+});

--- a/tests/unit/cursor-agent-image.test.ts
+++ b/tests/unit/cursor-agent-image.test.ts
@@ -9,6 +9,8 @@ import {
   handleCursorAgentImageGeneration,
   isRasterImageBuffer,
   normalizeCursorSeatToken,
+  resolveCursorImageModel,
+  resolveCursorImageTimeoutMs,
   __resetCursorAgentImageConcurrencyForTests,
 } from "../../open-sse/handlers/imageGeneration/providers/cursorAgentImage.ts";
 
@@ -156,4 +158,93 @@ test("handleCursorAgentImageGeneration returns b64_json via injectable spawn", a
   assert.equal(result.success, true);
   assert.ok(result.data?.data?.[0]?.b64_json);
   assert.equal(result.data.data[0].b64_json, tinyPng.toString("base64"));
+});
+
+test("resolveCursorImageModel allows only registry models, clamping everything else to auto", () => {
+  // The three ids declared in IMAGE_PROVIDERS.cursor.models pass through verbatim.
+  for (const m of IMAGE_PROVIDERS.cursor.models) {
+    assert.equal(resolveCursorImageModel(m.id), m.id);
+  }
+  // Unknown models and (crucially) flag-shaped / injection-y strings fall back to auto.
+  assert.equal(resolveCursorImageModel("--dangerously-allow-shell"), "auto");
+  assert.equal(resolveCursorImageModel("-p"), "auto");
+  assert.equal(resolveCursorImageModel("composer-9"), "auto");
+  assert.equal(resolveCursorImageModel("  composer-2  "), "composer-2"); // trimmed, still valid
+  assert.equal(resolveCursorImageModel(""), "auto");
+  assert.equal(resolveCursorImageModel(undefined), "auto");
+  assert.equal(resolveCursorImageModel(42), "auto");
+});
+
+/**
+ * End-to-end guard: an odd/flag-shaped `model` from the request must never reach
+ * the spawned Agent CLI argv — the handler resolves it to "auto" first.
+ */
+test("handleCursorAgentImageGeneration never forwards a flag-shaped model into CLI argv", async () => {
+  __resetCursorAgentImageConcurrencyForTests();
+  const { writeFile, mkdir } = await import("node:fs/promises");
+  const path = await import("node:path");
+
+  const tinyPng = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  ]);
+
+  let capturedArgs: string[] = [];
+  const fakeSpawn = ((_bin: string, args: string[]) => {
+    capturedArgs = args;
+    const prompt = args[args.length - 1] || "";
+    const marker = "Save the resulting image to exactly this path: ";
+    const idx = prompt.indexOf(marker);
+    const after = prompt.slice(idx + marker.length);
+    const outPath = after.slice(0, after.indexOf(". When the file exists"));
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: () => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => undefined;
+    queueMicrotask(async () => {
+      await mkdir(path.dirname(outPath), { recursive: true });
+      await writeFile(outPath, tinyPng);
+      child.emit("close", 0);
+    });
+    return child;
+  }) as unknown as typeof import("node:child_process").spawn;
+
+  const result = await handleCursorAgentImageGeneration({
+    model: "--dangerously-allow-shell", // untrusted, flag-shaped
+    provider: "cursor",
+    providerConfig: { baseUrl: "agent://cursor-agent" },
+    body: { prompt: "a lantern in fog", n: 1 },
+    credentials: {
+      accessToken: "crsr_test",
+      providerSpecificData: { agentBin: process.execPath },
+    },
+    spawnImpl: fakeSpawn,
+  });
+
+  assert.equal(result.success, true);
+  const modelIdx = capturedArgs.indexOf("--model");
+  assert.ok(modelIdx >= 0, "expected --model in the CLI argv");
+  assert.equal(capturedArgs[modelIdx + 1], "auto", "flag-shaped model must resolve to auto");
+  assert.ok(
+    !capturedArgs.includes("--dangerously-allow-shell"),
+    "the raw flag-shaped model must not appear anywhere in argv"
+  );
+});
+
+test("resolveCursorImageTimeoutMs clamps caller timeout_ms to the 300s ceiling", () => {
+  const prev = process.env.CURSOR_IMG_TIMEOUT_MS;
+  delete process.env.CURSOR_IMG_TIMEOUT_MS; // isolate from any operator default
+  try {
+    assert.equal(resolveCursorImageTimeoutMs(5_000), 5_000); // under the cap: unchanged
+    assert.equal(resolveCursorImageTimeoutMs(300_000), 300_000); // exactly at the cap
+    assert.equal(resolveCursorImageTimeoutMs(999_999_999), 300_000); // over the cap: clamped
+    assert.equal(resolveCursorImageTimeoutMs(-1), 210_000); // invalid → default fallback
+    assert.equal(resolveCursorImageTimeoutMs(undefined), 210_000); // absent → default fallback
+  } finally {
+    if (prev === undefined) delete process.env.CURSOR_IMG_TIMEOUT_MS;
+    else process.env.CURSOR_IMG_TIMEOUT_MS = prev;
+  }
 });


### PR DESCRIPTION
## Summary

Adds Cursor **plan image generation** to `IMAGE_PROVIDERS` under the same provider id as chat (`cursor` / alias `cu`), format `cursor-agent-image`.

- Reuses the existing Cursor OAuth/API-key connection (`getProviderCredentialsWithQuotaPreflight("cursor")`).
- Drives the Cursor Agent CLI native `generateImage` tool with a locked prompt + per-request temp workspace (OpenAI-compatible `b64_json` response).
- Chat already uses `AgentService/Run` and rejects built-in tools; image gen is a client-native tool, so CLI spawn is the seat-accurate path (same shape as existing community bridges).

## Why this design

| Concern | Choice |
|---------|--------|
| Provider id | `cursor` — one seat connection for chat + images |
| Transport | Agent CLI (`CURSOR_AGENT_BIN`), not protobuf chat path |
| Safety | Locked prompt (no shell); per-request workspace deleted after |
| Ops | Clear HTTP 501 when CLI missing; concurrency gate via `CURSOR_IMG_MAX_CONCURRENT` |

## Test plan

- [x] `node --import tsx/esm … --test tests/unit/cursor-agent-image.test.ts` (9/9)
- [ ] Manual: connect Cursor seat → set `CURSOR_AGENT_BIN` → `POST /v1/images/generations` with `model=cursor/auto`
- [ ] Confirm missing binary returns 501 with install hint

## Docs

- `docs/providers/CURSOR_IMAGE.md`
- `docs/reference/PROVIDER_REFERENCE.md` (cursor row)
- changelog fragment under `changelog.d/features/`