### PR TITLE
fix(kiro): align request headers with native IDE

### DIFF
--- a/open-sse/config/providerHeaderProfiles.ts
+++ b/open-sse/config/providerHeaderProfiles.ts
@@ -17,8 +17,8 @@ export const QWEN_STAINLESS_LANG = "js";
 
 export const QODER_DEFAULT_USER_AGENT = "Qoder-Cli";
 
-export const KIRO_SDK_USER_AGENT = "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0";
-export const KIRO_AMZ_USER_AGENT = "aws-sdk-js/3.0.0 kiro-ide/1.0.0";
+export const KIRO_SDK_USER_AGENT = "aws-sdk-js/1.0.0 KiroIDE-1.0.203";
+export const KIRO_AMZ_USER_AGENT = "aws-sdk-js/1.0.0 KiroIDE-1.0.203";
 export const KIRO_STREAMING_TARGET =
   "AmazonCodeWhispererStreamingService.GenerateAssistantResponse";
 
@@ -145,6 +145,8 @@ export function getKiroServiceHeaders(
     "X-Amz-Target": KIRO_STREAMING_TARGET,
     "User-Agent": KIRO_SDK_USER_AGENT,
     "X-Amz-User-Agent": KIRO_AMZ_USER_AGENT,
+    "x-amzn-kiro-agent-mode": "vibe",
+    "x-amzn-codewhisperer-optout": "true",
   };
 }
 

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 import {
   BaseExecutor,
   mergeUpstreamExtraHeaders,
@@ -6,7 +8,7 @@ import {
   type ProviderCredentials,
 } from "./base.ts";
 import { PROVIDERS } from "../config/constants.ts";
-import { v4 as uuidv4 } from "uuid";
+import { buildKiroClientHeaders } from "../services/kiroClientProfile.ts";
 import { refreshKiroToken } from "../services/tokenRefresh.ts";
 import {
   isExternalIdpAuthMethod,
@@ -189,10 +191,13 @@ export class KiroExecutor extends BaseExecutor {
     void stream;
     const headers = {
       ...this.config.headers,
+      ...buildKiroClientHeaders(
+        credentials.providerSpecificData,
+        credentials.accessToken || credentials.apiKey || "",
+        "runtime"
+      ),
       "Amz-Sdk-Request": "attempt=1; max=3",
       "Amz-Sdk-Invocation-Id": uuidv4(),
-      "x-amzn-bedrock-cache-control": "enable",
-      "anthropic-beta": "prompt-caching-2024-07-31",
     };
 
     const authMethod =

--- a/open-sse/services/kiroClientProfile.ts
+++ b/open-sse/services/kiroClientProfile.ts
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { platform, release } from "node:os";
+
+type JsonRecord = Record<string, unknown>;
+
+export const KIRO_IDE_VERSION = "1.0.203";
+export const KIRO_SDK_VERSION = "1.0.0";
+
+const nodeRequire = createRequire(import.meta.url);
+let nativeMachineIdSync: (() => string) | null = null;
+try {
+  const module = nodeRequire("node-machine-id") as {
+    machineIdSync?: () => string;
+    default?: { machineIdSync?: () => string };
+  };
+  nativeMachineIdSync = module.machineIdSync || module.default?.machineIdSync || null;
+} catch {
+  nativeMachineIdSync = null;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function kiroMachineId(providerSpecificData: unknown, accessToken: string): string {
+  const data = asRecord(providerSpecificData);
+  try {
+    const native = nonEmptyString(nativeMachineIdSync?.());
+    if (native && /^[a-f0-9]{64}$/i.test(native)) return native.toLowerCase();
+  } catch {
+    // Fall through to a deterministic connection-derived id.
+  }
+
+  const persisted = nonEmptyString(data.kiroMachineId) || nonEmptyString(data.machineId);
+  if (persisted && /^[a-f0-9]{64}$/i.test(persisted)) return persisted.toLowerCase();
+
+  const seed =
+    persisted ||
+    nonEmptyString(data.clientId) ||
+    nonEmptyString(data.profileArn) ||
+    accessToken ||
+    "kiro-anonymous";
+  return createHash("sha256").update(seed).digest("hex");
+}
+
+export function buildKiroClientHeaders(
+  providerSpecificData: unknown,
+  accessToken: string,
+  service: "runtime" | "control-plane"
+): Record<string, string> {
+  const machineId = kiroMachineId(providerSpecificData, accessToken);
+  const customUserAgent = `KiroIDE-${KIRO_IDE_VERSION}-${machineId}`;
+  const serviceId = service === "runtime" ? "kiroruntime" : "kirocontrolplanebearer";
+  const nodeVersion = process.versions?.node || process.version?.replace(/^v/, "") || "unknown";
+  const userAgent =
+    `aws-sdk-js/${KIRO_SDK_VERSION} ua/2.1 ` +
+    `os/${platform()}#${release()} lang/js md/nodejs#${nodeVersion} ` +
+    `api/${serviceId}#${KIRO_SDK_VERSION} m/N,E ${customUserAgent}`;
+
+  return {
+    "User-Agent": userAgent,
+    "X-Amz-User-Agent": `aws-sdk-js/${KIRO_SDK_VERSION} ${customUserAgent}`,
+    "x-amzn-codewhisperer-optout": "true",
+    ...(service === "runtime" ? { "x-amzn-kiro-agent-mode": "vibe" } : {}),
+  };
+}

--- a/open-sse/services/kiroModels.ts
+++ b/open-sse/services/kiroModels.ts
@@ -27,6 +27,7 @@ import { createHash } from "node:crypto";
 
 import { v4 as uuidv4 } from "uuid";
 
+import { KIRO_IDE_VERSION } from "./kiroClientProfile.ts";
 import { resolveKiroRuntimeRegion } from "./kiroRegion.ts";
 
 type RawRecord = Record<string, unknown>;
@@ -34,8 +35,7 @@ type RawRecord = Record<string, unknown>;
 const KIRO_RUNTIME_SDK_VERSION = "1.0.0";
 const KIRO_AGENT_OS = "windows";
 const KIRO_AGENT_OS_VERSION = "10.0.26200";
-const KIRO_NODE_VERSION = "22.21.1";
-const KIRO_IDE_VERSION = "0.10.32";
+const KIRO_NODE_VERSION = "22.22.0";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 const catalogCache = new Map<string, { expiresAt: number; models: KiroModel[] }>();

--- a/tests/unit/executor-kiro.test.ts
+++ b/tests/unit/executor-kiro.test.ts
@@ -1,10 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 
 import { KiroExecutor } from "../../open-sse/executors/kiro.ts";
+import { buildKiroClientHeaders } from "../../open-sse/services/kiroClientProfile.ts";
 import { hasStreamReadinessSignal } from "../../open-sse/utils/streamReadiness.ts";
 
 const textEncoder = new TextEncoder();
+const { machineIdSync } = createRequire(import.meta.url)("node-machine-id") as {
+  machineIdSync: () => string;
+};
 
 function crc32(buf) {
   const table = new Uint32Array(256);
@@ -139,12 +144,48 @@ test("KiroExecutor.transformEventStreamToSSE emits an early role-only start chun
 
 test("KiroExecutor.buildHeaders includes Kiro-specific auth and metadata", () => {
   const executor = new KiroExecutor();
-  const headers = executor.buildHeaders({ accessToken: "kiro-token" }, true);
+  const headers = executor.buildHeaders(
+    {
+      accessToken: "kiro-token",
+      providerSpecificData: {
+        profileArn: "arn:aws:codewhisperer:us-east-1:123:profile/ABC",
+      },
+    },
+    true
+  );
 
   assert.equal(headers.Authorization, "Bearer kiro-token");
-  assert.equal(headers["anthropic-beta"], "prompt-caching-2024-07-31");
-  assert.equal(headers["x-amzn-bedrock-cache-control"], "enable");
+  assert.match(headers["User-Agent"], /aws-sdk-js\/1\.0\.0/);
+  assert.match(headers["User-Agent"], /api\/kiroruntime#1\.0\.0/);
+  assert.match(headers["User-Agent"], /KiroIDE-1\.0\.203-[a-f0-9]{64}$/);
+  assert.match(headers["X-Amz-User-Agent"], /KiroIDE-1\.0\.203-[a-f0-9]{64}$/);
+  assert.equal(headers["x-amzn-kiro-agent-mode"], "vibe");
+  assert.equal(headers["x-amzn-codewhisperer-optout"], "true");
+  assert.equal(headers["anthropic-beta"], undefined);
+  assert.equal(headers["x-amzn-bedrock-cache-control"], undefined);
   assert.ok(headers["Amz-Sdk-Invocation-Id"]);
+});
+
+test("KiroExecutor.buildHeaders uses the same native machine id as Kiro IDE", () => {
+  const executor = new KiroExecutor();
+  const headers = executor.buildHeaders(
+    {
+      accessToken: "kiro-token",
+      providerSpecificData: { kiroMachineId: "00000000-0000-0000-0000-000000000000" },
+    },
+    true
+  );
+
+  assert.ok(headers["User-Agent"].endsWith(`KiroIDE-1.0.203-${machineIdSync()}`));
+});
+
+test("buildKiroClientHeaders emits the control-plane identity without runtime agent mode", () => {
+  const headers = buildKiroClientHeaders({}, "kiro-token", "control-plane");
+
+  assert.match(headers["User-Agent"], /api\/kirocontrolplanebearer#1\.0\.0/);
+  assert.match(headers["User-Agent"], /KiroIDE-1\.0\.203-[a-f0-9]{64}$/);
+  assert.equal(headers["x-amzn-codewhisperer-optout"], "true");
+  assert.equal(headers["x-amzn-kiro-agent-mode"], undefined);
 });
 
 test("KiroExecutor.buildHeaders marks long-lived Kiro API keys", () => {


### PR DESCRIPTION
## Summary

- Add a machine-ID-based Kiro IDE client profile for runtime and control-plane request identities.
- Apply the native runtime User-Agent, agent-mode, and opt-out headers in the Kiro executor.
- Remove the non-native prompt-caching headers from Kiro runtime requests.
- Add focused header coverage for runtime identity, control-plane identity, and native machine ID use.

## Scope

This is the focused header/identity slice Diego requested after closing #8229. That PR mixed the useful native-IDE identity work with catalog and discovery rewrites that threatened the VPS-verified Kiro catalog from #6170.

- This PR does **not** change the Kiro model registry, the #6170 catalog, or its catalog guard tests.
- No fabricated model IDs are restored, including `claude-opus-4.8`, `claude-opus-4.7`, `claude-opus-4.6`, `claude-sonnet-4.6`, or `auto-kiro`.
- Discovery and control-plane endpoint changes are deferred to a follow-up that requires live VPS validation.
- The existing Kiro runtime endpoint selection remains unchanged; this PR only aligns request identity and headers.

## Validation

- `npm run typecheck:core`
- `node --import tsx/esm --test tests/unit/executor-kiro.test.ts tests/unit/kiro-catalog-real-models.test.ts` — 17 passed
- `npx eslint open-sse/services/kiroClientProfile.ts open-sse/executors/kiro.ts open-sse/config/providerHeaderProfiles.ts tests/unit/executor-kiro.test.ts`
- `git diff --check origin/release/v3.8.49...HEAD`
- Empty diff: `open-sse/config/providers/registry/kiro/`
- Empty diff: `tests/unit/kiro-catalog-real-models.test.ts`
