### PR TITLE
fix(sse): stop stripInternalReasoningPlaceholder from eating inter-word spaces

### DIFF
--- a/open-sse/utils/reasoningPlaceholder.ts
+++ b/open-sse/utils/reasoningPlaceholder.ts
@@ -14,7 +14,16 @@ export function isInternalReasoningPlaceholder(value: unknown): boolean {
  * echo the sentinel through ordinary `message.content` / `delta.content`
  * (#8081). Removes all occurrences and trims; returns "" when nothing
  * meaningful remains so callers can skip emission entirely.
+ *
+ * The trim only applies when the sentinel was actually present. This is
+ * called per streaming `delta.content` chunk, not on the fully-assembled
+ * message — tokenizers routinely emit sub-word tokens with a leading space
+ * as part of the token (e.g. " en", " riktig"), so unconditionally trimming
+ * every chunk silently ate the space between words for the (overwhelming)
+ * majority of chunks that never contain the sentinel at all, producing
+ * streamed text with words run together ("Bilden är en" -> "Bildenären").
  */
 export function stripInternalReasoningPlaceholder(value: string): string {
+  if (!value.includes(NON_ANTHROPIC_THINKING_PLACEHOLDER)) return value;
   return value.replaceAll(NON_ANTHROPIC_THINKING_PLACEHOLDER, "").trim();
 }

--- a/tests/unit/reasoning-placeholder-strip.test.ts
+++ b/tests/unit/reasoning-placeholder-strip.test.ts
@@ -1,0 +1,55 @@
+/**
+ * tests/unit/reasoning-placeholder-strip.test.ts
+ *
+ * Live incident: streamed assistant text was losing the spaces BETWEEN words
+ * (e.g. "Bilden är en riktig JPEG nu" -> "Bildenärenriktig JPEG nu") on the
+ * Responses-API / Claude streaming paths. Root cause: stripInternalReasoning
+ * Placeholder() (open-sse/utils/reasoningPlaceholder.ts, added by #8081/#8162)
+ * is called on every individual `delta.content` chunk, and it unconditionally
+ * called .trim() even when the placeholder sentinel was never present in that
+ * chunk. Tokenizers commonly emit sub-word tokens with a LEADING space as
+ * part of the token (e.g. " en", " riktig") — each such chunk got its only
+ * whitespace character (the inter-word space) silently trimmed away before
+ * being appended to the accumulated message, while the words themselves
+ * stayed intact. Punctuation-only chunks were largely unaffected, matching
+ * what was observed live.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  NON_ANTHROPIC_THINKING_PLACEHOLDER,
+  stripInternalReasoningPlaceholder,
+} from "../../open-sse/utils/reasoningPlaceholder.ts";
+
+test("a plain word-token chunk with a leading space is NOT trimmed (no placeholder present)", () => {
+  assert.equal(stripInternalReasoningPlaceholder(" en"), " en");
+  assert.equal(stripInternalReasoningPlaceholder(" riktig"), " riktig");
+});
+
+test("a plain word-token chunk with a trailing space is NOT trimmed (no placeholder present)", () => {
+  assert.equal(stripInternalReasoningPlaceholder("Bilden "), "Bilden ");
+});
+
+test("reassembling word-token chunks preserves inter-word spaces", () => {
+  const chunks = ["Bilden", " är", " en", " riktig", " JPEG", " nu"];
+  const rebuilt = chunks.map(stripInternalReasoningPlaceholder).join("");
+  assert.equal(rebuilt, "Bilden är en riktig JPEG nu");
+});
+
+test("a chunk that IS exactly the placeholder collapses to empty string", () => {
+  assert.equal(stripInternalReasoningPlaceholder(NON_ANTHROPIC_THINKING_PLACEHOLDER), "");
+  assert.equal(stripInternalReasoningPlaceholder(`  ${NON_ANTHROPIC_THINKING_PLACEHOLDER}  `), "");
+});
+
+test("a chunk with the placeholder mixed into real text strips it (trim only affects the outer ends)", () => {
+  // replaceAll leaves a double space where the placeholder was removed; trim()
+  // only strips the string's own leading/trailing whitespace, not internal gaps.
+  assert.equal(
+    stripInternalReasoningPlaceholder(`foo ${NON_ANTHROPIC_THINKING_PLACEHOLDER} bar`),
+    "foo  bar",
+  );
+});
+
+test("an empty string stays empty", () => {
+  assert.equal(stripInternalReasoningPlaceholder(""), "");
+});


### PR DESCRIPTION
## Summary

Live incident: streamed assistant text was losing the spaces BETWEEN words (e.g. `"Bilden är en riktig JPEG nu"` -> `"Bildenärenriktig JPEG nu"`) on the Responses-API and Claude streaming paths, reported as recurring across several messages.

`stripInternalReasoningPlaceholder()` (added by #8081/#8162) is called on every individual `delta.content` streaming chunk, and unconditionally called `.trim()` even when its sentinel (`"(prior reasoning summary unavailable)"`) was never present in that chunk. Tokenizers commonly emit sub-word tokens with a **leading space as part of the token** (e.g. `" en"`, `" riktig"`) — each such chunk got its only whitespace character (the inter-word space) silently trimmed away before being appended to the accumulated message, while the words themselves stayed intact. Punctuation-only chunks were largely unaffected, matching what was observed live.

Fix: only trim when the sentinel is actually present in the chunk — preserves the original #8081 intent (collapse a placeholder-only chunk to `""`) without touching the overwhelming majority of chunks that never contain it. Three call sites affected: `open-sse/translator/response/openai-responses.ts`, `open-sse/transformer/responsesTransformer.ts`, `open-sse/translator/response/openai-to-claude.ts`.

## Test plan

- [x] `tests/unit/reasoning-placeholder-strip.test.ts` (new, 6 tests) — TDD: confirmed RED (reassembling `["Bilden", " är", " en", " riktig", " JPEG", " nu"]` produced `"BildenärenriktigJPEGnu"`, reproducing the live symptom almost exactly) before the fix, GREEN after. Also covers the placeholder-only-chunk collapse and mixed-content cases so the original #8081 behavior stays intact.
- [x] `tests/unit/translator-resp-openai-to-claude.test.ts` — including the existing `"#8081 regression"` test — still passes, confirming this fix doesn't reintroduce #8081.
- [x] Full `responses-*` translator regression suite (94 tests across 8 files) passes, no regressions.
- [x] `npm run typecheck:core` and `eslint` clean.