### PR TITLE
Clicking a provider card hitting back loses scroll position

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -177,12 +177,12 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
       },
       highlight() {
         const el = innerRef.current;
+        (el.firstElementChild as HTMLElement)?.focus();
         const surface = el.firstElementChild?.firstElementChild as HTMLElement | undefined;
         surface?.animate(
           [
             { backgroundColor: "rgba(59,130,246,0.22)" },
             { backgroundColor: "rgba(59,130,246,0.08)" },
-            { backgroundColor: "rgba(59,130,246,0.22)" },
             { backgroundColor: "transparent" },
           ],
           { duration: 3000, easing: "ease-in-out" }

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { MouseEvent, ReactNode } from "react";
-import { useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -74,6 +74,8 @@ interface ProviderCardProps {
   stats: ProviderStats;
   authType?: string;
   onToggle: (active: boolean) => void;
+  shouldHighlight?: boolean;
+  onBeforeNavigate?: (id: string) => void;
 }
 
 const DOT_COLORS: Record<string, string> = {
@@ -152,17 +154,36 @@ function getStatusDisplay(
   return parts;
 }
 
-export default function ProviderCard({
-  providerId,
-  provider,
-  stats,
-  authType = "apikey",
-  onToggle,
-}: ProviderCardProps) {
+const ProviderCard = forwardRef<HTMLDivElement, ProviderCardProps>(function ProviderCard(
+  { providerId, provider, stats, authType = "apikey", onToggle, shouldHighlight, onBeforeNavigate },
+  ref
+) {
   const t = useTranslations("providers");
   const tc = useTranslations("common");
   const tp = useTranslations("miniPlayground");
   const [testExpanded, setTestExpanded] = useState<boolean>(false);
+  const innerRef = useRef<HTMLDivElement>(null);
+  useImperativeHandle(ref, () => innerRef.current, []);
+
+  useEffect(() => {
+    // Handle the case where the parent wants the card to be highlighted
+    // so the user's eye will be drawn to this card.
+    // There is a small animation that comes in and fades away.
+    if (!shouldHighlight) {
+      return;
+    }
+
+    const surface = innerRef.current?.firstElementChild?.firstElementChild as
+      HTMLElement | undefined;
+    surface?.animate(
+      [
+        { backgroundColor: "rgba(59,130,246,0.22)" },
+        { backgroundColor: "rgba(59,130,246,0.08)" },
+        { backgroundColor: "transparent" },
+      ],
+      { duration: 2500, easing: "ease-in-out" }
+    );
+  }, [shouldHighlight, providerId, innerRef]);
 
   // Show the Test button for LLM providers (when serviceKinds includes "llm"
   // OR when the provider has no explicit serviceKinds but is a regular LLM provider
@@ -260,9 +281,17 @@ export default function ProviderCard({
     onToggle(allDisabled);
   };
 
+  const handleCardClick = useCallback(() => {
+    onBeforeNavigate?.(providerId);
+  }, [onBeforeNavigate, providerId]);
+
   return (
-    <div className="flex flex-col h-full">
-      <Link href={`/dashboard/providers/${providerId}`} className="group flex-1 flex flex-col">
+    <div ref={innerRef} id={`provider-${providerId}`} className="flex flex-col h-full">
+      <Link
+        href={`/dashboard/providers/${providerId}`}
+        className="group flex-1 flex flex-col focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/60"
+        onClick={handleCardClick}
+      >
         <Card
           padding="xs"
           className={`h-full flex flex-col hover:bg-black/5 dark:hover:bg-white/5 transition-colors cursor-pointer ${
@@ -422,7 +451,7 @@ export default function ProviderCard({
                     <Toggle
                       size="xs"
                       checked={!allDisabled}
-                      onChange={() => {}}
+                      onChange={undefined}
                       title={allDisabled ? t("enableProvider") : t("disableProvider")}
                     />
                   </div>
@@ -461,4 +490,6 @@ export default function ProviderCard({
       )}
     </div>
   );
-}
+});
+
+export default ProviderCard;

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -168,6 +168,7 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
   const tp = useTranslations("miniPlayground");
   const [testExpanded, setTestExpanded] = useState<boolean>(false);
   const innerRef = useRef<HTMLDivElement>(null);
+  const linkElementRef = useRef<HTMLAnchorElement>(null);
 
   useImperativeHandle(
     ref,
@@ -178,8 +179,8 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
       highlight() {
         const el = innerRef.current;
         if (!el) return;
-        (el.firstElementChild as HTMLElement)?.focus();
-        const surface = el.firstElementChild?.firstElementChild as HTMLElement | undefined;
+        linkElementRef.current?.focus();
+        const surface = linkElementRef.current?.firstElementChild;
         surface?.animate(
           [
             { backgroundColor: "rgba(59,130,246,0.22)" },
@@ -195,7 +196,7 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
         el.scrollIntoView({ behavior: "auto", block: "center" });
       },
     }),
-    [providerId]
+    [providerId, innerRef, linkElementRef]
   );
 
   // Show the Test button for LLM providers (when serviceKinds includes "llm"
@@ -301,6 +302,7 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
   return (
     <div ref={innerRef} id={`provider-${providerId}`} className="flex flex-col h-full">
       <Link
+        ref={linkElementRef}
         href={`/dashboard/providers/${providerId}`}
         className="group flex-1 flex flex-col focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/60"
         onClick={handleCardClick}

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { MouseEvent, ReactNode } from "react";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -74,7 +74,6 @@ interface ProviderCardProps {
   stats: ProviderStats;
   authType?: string;
   onToggle: (active: boolean) => void;
-  shouldHighlight?: boolean;
   onBeforeNavigate?: (id: string) => void;
 }
 
@@ -154,8 +153,14 @@ function getStatusDisplay(
   return parts;
 }
 
-const ProviderCard = forwardRef<HTMLDivElement, ProviderCardProps>(function ProviderCard(
-  { providerId, provider, stats, authType = "apikey", onToggle, shouldHighlight, onBeforeNavigate },
+export type ProviderCardHandle = {
+  highlight: () => void;
+  getProviderId(): string;
+  scrollIntoView: (options?: ScrollIntoViewOptions) => void;
+};
+
+const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function ProviderCard(
+  { providerId, provider, stats, authType = "apikey", onToggle, onBeforeNavigate },
   ref
 ) {
   const t = useTranslations("providers");
@@ -163,27 +168,34 @@ const ProviderCard = forwardRef<HTMLDivElement, ProviderCardProps>(function Prov
   const tp = useTranslations("miniPlayground");
   const [testExpanded, setTestExpanded] = useState<boolean>(false);
   const innerRef = useRef<HTMLDivElement>(null);
-  useImperativeHandle(ref, () => innerRef.current, []);
 
-  useEffect(() => {
-    // Handle the case where the parent wants the card to be highlighted
-    // so the user's eye will be drawn to this card.
-    // There is a small animation that comes in and fades away.
-    if (!shouldHighlight) {
-      return;
-    }
-
-    const surface = innerRef.current?.firstElementChild?.firstElementChild as
-      HTMLElement | undefined;
-    surface?.animate(
-      [
-        { backgroundColor: "rgba(59,130,246,0.22)" },
-        { backgroundColor: "rgba(59,130,246,0.08)" },
-        { backgroundColor: "transparent" },
-      ],
-      { duration: 2500, easing: "ease-in-out" }
-    );
-  }, [shouldHighlight, providerId, innerRef]);
+  useImperativeHandle(
+    ref,
+    () => ({
+      getProviderId() {
+        return providerId;
+      },
+      highlight() {
+        const el = innerRef.current;
+        const surface = el.firstElementChild?.firstElementChild as HTMLElement | undefined;
+        surface?.animate(
+          [
+            { backgroundColor: "rgba(59,130,246,0.22)" },
+            { backgroundColor: "rgba(59,130,246,0.08)" },
+            { backgroundColor: "rgba(59,130,246,0.22)" },
+            { backgroundColor: "transparent" },
+          ],
+          { duration: 3000, easing: "ease-in-out" }
+        );
+      },
+      scrollIntoView() {
+        const el = innerRef.current;
+        if (!el) return;
+        el.scrollIntoView({ behavior: "auto", block: "center" });
+      },
+    }),
+    [providerId]
+  );
 
   // Show the Test button for LLM providers (when serviceKinds includes "llm"
   // OR when the provider has no explicit serviceKinds but is a regular LLM provider

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -177,6 +177,7 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
       },
       highlight() {
         const el = innerRef.current;
+        if (!el) return;
         (el.firstElementChild as HTMLElement)?.focus();
         const surface = el.firstElementChild?.firstElementChild as HTMLElement | undefined;
         surface?.animate(

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -74,7 +74,7 @@ interface ProviderCardProps {
   stats: ProviderStats;
   authType?: string;
   onToggle: (active: boolean) => void;
-  onBeforeNavigate?: (id: string) => void;
+  onCardClick?: (id: string) => void;
 }
 
 const DOT_COLORS: Record<string, string> = {
@@ -160,7 +160,7 @@ export type ProviderCardHandle = {
 };
 
 const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function ProviderCard(
-  { providerId, provider, stats, authType = "apikey", onToggle, onBeforeNavigate },
+  { providerId, provider, stats, authType = "apikey", onToggle, onCardClick },
   ref
 ) {
   const t = useTranslations("providers");
@@ -294,8 +294,8 @@ const ProviderCard = forwardRef<ProviderCardHandle, ProviderCardProps>(function 
   };
 
   const handleCardClick = useCallback(() => {
-    onBeforeNavigate?.(providerId);
-  }, [onBeforeNavigate, providerId]);
+    onCardClick?.(providerId);
+  }, [onCardClick, providerId]);
 
   return (
     <div ref={innerRef} id={`provider-${providerId}`} className="flex flex-col h-full">

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -34,6 +34,7 @@ import {
   loadProviderPageData,
 } from "./providerPageUtils";
 import type { ProviderEntry } from "./providerPageUtils";
+import { recordProviderNavigation, resolveHighlightedCard } from "./providerPageHighlightUtils";
 import {
   readProviderDisplayModePreference,
   shouldSyncProviderDisplayMode,
@@ -213,19 +214,12 @@ export default function ProvidersPage() {
   });
 
   const handleCardClick = useCallback((id: string) => {
-    // upon navigating to a provider, we want to set the providerId in the history state
-    // so that if the user refreshes the page, we can scroll it into view and highlight the provider card
-    window.history.replaceState({ providerId: id }, "");
+    recordProviderNavigation(id);
   }, []);
 
   const highlightedCardRef = useCallback(
     (handle: ProviderCardHandle | null) => {
-      if (handle?.getProviderId() === highlightedProviderId) {
-        // we should scroll this card into view and highlight it
-        handle?.scrollIntoView({ behavior: "auto", block: "center" });
-        handle?.highlight();
-      }
-      setHighlightedProviderId(null);
+      resolveHighlightedCard(handle, highlightedProviderId, () => setHighlightedProviderId(null));
     },
     [highlightedProviderId, setHighlightedProviderId]
   );

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -205,6 +205,26 @@ export default function ProvidersPage() {
   // #4240: media-category (serviceKind) filter — composes with activeCategory,
   // search and configured-only. null = no serviceKind filter.
   const [activeServiceKind, setActiveServiceKind] = useState<string | null>(null);
+  const [highlightedProviderId, setHighlightedProviderId] = useState<string | null>(() => {
+    return history.state?.providerId ?? null;
+  });
+
+  const handleProviderNavigate = useCallback((id: string) => {
+    // upon navigating to a provider, we want to set the providerId in the history state
+    // so that if the user refreshes the page, we can scroll it into view and highlight the provider card
+    window.history.replaceState({ providerId: id }, "");
+  }, []);
+
+  const highlightedCardRef = useCallback(
+    // This gets invoked when the ref is assigned. We check to see if the card is the one that should be highlighted, and if so, we scroll it into view.
+    (node: HTMLDivElement | null) => {
+      if (node && highlightedProviderId && node.id === `provider-${highlightedProviderId}`) {
+        node.scrollIntoView({ behavior: "auto", block: "center" });
+      }
+      setHighlightedProviderId(null); // Clear the highlighted provider ID so we don't keep scrolling to it on re-renders
+    },
+    [highlightedProviderId, setHighlightedProviderId]
+  );
   const notify = useNotificationStore();
   const sectionCategoryAliases: Record<string, string> = {
     cloud: "cloudagent",
@@ -918,6 +938,9 @@ export default function ProvidersPage() {
                 onToggle={(active) =>
                   handleToggleProvider(entry.providerId, entry.toggleAuthType, active)
                 }
+                shouldHighlight={entry.providerId === highlightedProviderId}
+                onBeforeNavigate={handleProviderNavigate}
+                ref={highlightedCardRef}
               />
             ))}
           </div>
@@ -1004,6 +1027,9 @@ export default function ProvidersPage() {
                         onToggle={(active) =>
                           handleToggleProvider(providerId, toggleAuthType, active)
                         }
+                        shouldHighlight={providerId === highlightedProviderId}
+                        onBeforeNavigate={handleProviderNavigate}
+                        ref={highlightedCardRef}
                       />
                     )
                   )}
@@ -1078,6 +1104,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   ))}
               </div>
@@ -1136,6 +1165,9 @@ export default function ProvidersPage() {
                         onToggle={(active) =>
                           handleToggleProvider(providerId, toggleAuthType, active)
                         }
+                        shouldHighlight={providerId === highlightedProviderId}
+                        onBeforeNavigate={handleProviderNavigate}
+                        ref={highlightedCardRef}
                       />
                     )
                   )}
@@ -1184,6 +1216,9 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="web-cookie"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                    shouldHighlight={providerId === highlightedProviderId}
+                    onBeforeNavigate={handleProviderNavigate}
+                    ref={highlightedCardRef}
                   />
                 ))}
               </div>
@@ -1232,6 +1267,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1285,6 +1323,9 @@ export default function ProvidersPage() {
                           onToggle={(active) =>
                             handleToggleProvider(providerId, toggleAuthType, active)
                           }
+                          shouldHighlight={providerId === highlightedProviderId}
+                          onBeforeNavigate={handleProviderNavigate}
+                          ref={highlightedCardRef}
                         />
                       )
                     )}
@@ -1351,6 +1392,9 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="upstream-proxy"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                    shouldHighlight={providerId === highlightedProviderId}
+                    onBeforeNavigate={handleProviderNavigate}
+                    ref={highlightedCardRef}
                   />
                 ))}
               </div>
@@ -1383,6 +1427,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1416,6 +1463,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1449,6 +1499,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1499,6 +1552,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1546,6 +1602,9 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="local"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                    shouldHighlight={providerId === highlightedProviderId}
+                    onBeforeNavigate={handleProviderNavigate}
+                    ref={highlightedCardRef}
                   />
                 ))}
               </div>
@@ -1592,6 +1651,9 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="search"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                    shouldHighlight={providerId === highlightedProviderId}
+                    onBeforeNavigate={handleProviderNavigate}
+                    ref={highlightedCardRef}
                   />
                 ))}
               </div>
@@ -1624,6 +1686,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1657,6 +1722,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}
@@ -1704,6 +1772,9 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="audio"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                    shouldHighlight={providerId === highlightedProviderId}
+                    onBeforeNavigate={handleProviderNavigate}
+                    ref={highlightedCardRef}
                   />
                 ))}
               </div>
@@ -1736,6 +1807,9 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
+                      shouldHighlight={providerId === highlightedProviderId}
+                      onBeforeNavigate={handleProviderNavigate}
+                      ref={highlightedCardRef}
                     />
                   )
                 )}

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -50,6 +50,7 @@ import { CategoryDot } from "./components/CategoryDot";
 import { ImportProvidersFromFileModal } from "./components/ImportProvidersFromFileModal";
 import NoAuthProvidersSection from "./components/NoAuthProvidersSection";
 import ProviderCard from "./components/ProviderCard";
+import type { ProviderCardHandle } from "./components/ProviderCard";
 import ProviderCountBadge from "./components/ProviderCountBadge";
 import ProviderSummaryCard from "./components/ProviderSummaryCard";
 import {
@@ -216,12 +217,13 @@ export default function ProvidersPage() {
   }, []);
 
   const highlightedCardRef = useCallback(
-    // This gets invoked when the ref is assigned. We check to see if the card is the one that should be highlighted, and if so, we scroll it into view.
-    (node: HTMLDivElement | null) => {
-      if (node && highlightedProviderId && node.id === `provider-${highlightedProviderId}`) {
-        node.scrollIntoView({ behavior: "auto", block: "center" });
+    (handle: ProviderCardHandle | null) => {
+      if (handle?.getProviderId() === highlightedProviderId) {
+        // we should scroll this card into view and highlight it
+        handle?.scrollIntoView({ behavior: "auto", block: "center" });
+        handle?.highlight();
       }
-      setHighlightedProviderId(null); // Clear the highlighted provider ID so we don't keep scrolling to it on re-renders
+      setHighlightedProviderId(null);
     },
     [highlightedProviderId, setHighlightedProviderId]
   );
@@ -938,7 +940,7 @@ export default function ProvidersPage() {
                 onToggle={(active) =>
                   handleToggleProvider(entry.providerId, entry.toggleAuthType, active)
                 }
-                shouldHighlight={entry.providerId === highlightedProviderId}
+
                 onBeforeNavigate={handleProviderNavigate}
                 ref={highlightedCardRef}
               />
@@ -1027,7 +1029,7 @@ export default function ProvidersPage() {
                         onToggle={(active) =>
                           handleToggleProvider(providerId, toggleAuthType, active)
                         }
-                        shouldHighlight={providerId === highlightedProviderId}
+
                         onBeforeNavigate={handleProviderNavigate}
                         ref={highlightedCardRef}
                       />
@@ -1104,7 +1106,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1165,7 +1167,7 @@ export default function ProvidersPage() {
                         onToggle={(active) =>
                           handleToggleProvider(providerId, toggleAuthType, active)
                         }
-                        shouldHighlight={providerId === highlightedProviderId}
+
                         onBeforeNavigate={handleProviderNavigate}
                         ref={highlightedCardRef}
                       />
@@ -1216,7 +1218,7 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="web-cookie"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                    shouldHighlight={providerId === highlightedProviderId}
+
                     onBeforeNavigate={handleProviderNavigate}
                     ref={highlightedCardRef}
                   />
@@ -1267,7 +1269,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1323,7 +1325,7 @@ export default function ProvidersPage() {
                           onToggle={(active) =>
                             handleToggleProvider(providerId, toggleAuthType, active)
                           }
-                          shouldHighlight={providerId === highlightedProviderId}
+
                           onBeforeNavigate={handleProviderNavigate}
                           ref={highlightedCardRef}
                         />
@@ -1392,7 +1394,7 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="upstream-proxy"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                    shouldHighlight={providerId === highlightedProviderId}
+
                     onBeforeNavigate={handleProviderNavigate}
                     ref={highlightedCardRef}
                   />
@@ -1427,7 +1429,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1463,7 +1465,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1499,7 +1501,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1552,7 +1554,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1602,7 +1604,7 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="local"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                    shouldHighlight={providerId === highlightedProviderId}
+
                     onBeforeNavigate={handleProviderNavigate}
                     ref={highlightedCardRef}
                   />
@@ -1651,7 +1653,7 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="search"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                    shouldHighlight={providerId === highlightedProviderId}
+
                     onBeforeNavigate={handleProviderNavigate}
                     ref={highlightedCardRef}
                   />
@@ -1686,7 +1688,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1722,7 +1724,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />
@@ -1772,7 +1774,7 @@ export default function ProvidersPage() {
                     stats={stats}
                     authType="audio"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                    shouldHighlight={providerId === highlightedProviderId}
+
                     onBeforeNavigate={handleProviderNavigate}
                     ref={highlightedCardRef}
                   />
@@ -1807,7 +1809,7 @@ export default function ProvidersPage() {
                       onToggle={(active) =>
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
-                      shouldHighlight={providerId === highlightedProviderId}
+
                       onBeforeNavigate={handleProviderNavigate}
                       ref={highlightedCardRef}
                     />

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -206,11 +206,13 @@ export default function ProvidersPage() {
   // #4240: media-category (serviceKind) filter — composes with activeCategory,
   // search and configured-only. null = no serviceKind filter.
   const [activeServiceKind, setActiveServiceKind] = useState<string | null>(null);
+
+  // a highlighted card is one that we should scroll into view and highlight upon navigation
   const [highlightedProviderId, setHighlightedProviderId] = useState<string | null>(() => {
     return history.state?.providerId ?? null;
   });
 
-  const handleProviderNavigate = useCallback((id: string) => {
+  const handleCardClick = useCallback((id: string) => {
     // upon navigating to a provider, we want to set the providerId in the history state
     // so that if the user refreshes the page, we can scroll it into view and highlight the provider card
     window.history.replaceState({ providerId: id }, "");
@@ -941,7 +943,7 @@ export default function ProvidersPage() {
                   handleToggleProvider(entry.providerId, entry.toggleAuthType, active)
                 }
 
-                onBeforeNavigate={handleProviderNavigate}
+                onCardClick={handleCardClick}
                 ref={highlightedCardRef}
               />
             ))}
@@ -1030,7 +1032,7 @@ export default function ProvidersPage() {
                           handleToggleProvider(providerId, toggleAuthType, active)
                         }
 
-                        onBeforeNavigate={handleProviderNavigate}
+                        onCardClick={handleCardClick}
                         ref={highlightedCardRef}
                       />
                     )
@@ -1107,7 +1109,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   ))}
@@ -1168,7 +1170,7 @@ export default function ProvidersPage() {
                           handleToggleProvider(providerId, toggleAuthType, active)
                         }
 
-                        onBeforeNavigate={handleProviderNavigate}
+                        onCardClick={handleCardClick}
                         ref={highlightedCardRef}
                       />
                     )
@@ -1219,7 +1221,7 @@ export default function ProvidersPage() {
                     authType="web-cookie"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
 
-                    onBeforeNavigate={handleProviderNavigate}
+                    onCardClick={handleCardClick}
                     ref={highlightedCardRef}
                   />
                 ))}
@@ -1270,7 +1272,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1326,7 +1328,7 @@ export default function ProvidersPage() {
                             handleToggleProvider(providerId, toggleAuthType, active)
                           }
 
-                          onBeforeNavigate={handleProviderNavigate}
+                          onCardClick={handleCardClick}
                           ref={highlightedCardRef}
                         />
                       )
@@ -1395,7 +1397,7 @@ export default function ProvidersPage() {
                     authType="upstream-proxy"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
 
-                    onBeforeNavigate={handleProviderNavigate}
+                    onCardClick={handleCardClick}
                     ref={highlightedCardRef}
                   />
                 ))}
@@ -1430,7 +1432,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1466,7 +1468,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1502,7 +1504,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1555,7 +1557,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1605,7 +1607,7 @@ export default function ProvidersPage() {
                     authType="local"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
 
-                    onBeforeNavigate={handleProviderNavigate}
+                    onCardClick={handleCardClick}
                     ref={highlightedCardRef}
                   />
                 ))}
@@ -1654,7 +1656,7 @@ export default function ProvidersPage() {
                     authType="search"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
 
-                    onBeforeNavigate={handleProviderNavigate}
+                    onCardClick={handleCardClick}
                     ref={highlightedCardRef}
                   />
                 ))}
@@ -1689,7 +1691,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1725,7 +1727,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )
@@ -1775,7 +1777,7 @@ export default function ProvidersPage() {
                     authType="audio"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
 
-                    onBeforeNavigate={handleProviderNavigate}
+                    onCardClick={handleCardClick}
                     ref={highlightedCardRef}
                   />
                 ))}
@@ -1810,7 +1812,7 @@ export default function ProvidersPage() {
                         handleToggleProvider(providerId, toggleAuthType, active)
                       }
 
-                      onBeforeNavigate={handleProviderNavigate}
+                      onCardClick={handleCardClick}
                       ref={highlightedCardRef}
                     />
                   )

--- a/src/app/(dashboard)/dashboard/providers/providerPageHighlightUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageHighlightUtils.ts
@@ -1,0 +1,27 @@
+import type { ProviderCardHandle } from "./components/ProviderCard";
+
+/**
+ * Called before navigating to a provider detail page. Persists the provider
+ * id in history.state so the list page can scroll to it on back-navigation.
+ */
+export function recordProviderNavigation(id: string) {
+  window.history.replaceState({ providerId: id }, "");
+}
+
+/**
+ * Ref callback for ProviderCard. When the rendered card's provider id
+ * matches the highlighted id, scrolls it into view and triggers the
+ * highlight animation. Always clears the highlighted id afterward so
+ * subsequent re-renders don't re-scroll.
+ */
+export function resolveHighlightedCard(
+  handle: ProviderCardHandle | null,
+  highlightedProviderId: string | null,
+  onAfterHighlight: () => void
+) {
+  if (handle?.getProviderId() === highlightedProviderId) {
+    handle.scrollIntoView({ behavior: "auto", block: "center" });
+    handle.highlight();
+  }
+  onAfterHighlight();
+}

--- a/tests/unit/ui/providerCardHandle.test.tsx
+++ b/tests/unit/ui/providerCardHandle.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+/**
+ * ProviderCardHandle imperative API — highlight(), scrollIntoView(), getProviderId().
+ *
+ * NOTE on placement: see providerCardKimiPartnerAccent.test.tsx for rationale
+ * on keeping tests in tests/unit/ui/ (both vitest configs discover it here).
+ */
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProviderCard, {
+  type ProviderCardHandle,
+} from "@/app/(dashboard)/dashboard/providers/components/ProviderCard";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
+vi.mock("@/shared/components/ProviderTestSlideOver", () => ({ default: () => null }));
+vi.mock("@/shared/components/ProviderIcon", () => ({ default: () => null }));
+
+// jsdom does not implement scrollIntoView or animate
+if (typeof Element.prototype.scrollIntoView === "undefined") {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    value: vi.fn(),
+    writable: true,
+    configurable: true,
+  });
+}
+if (typeof Element.prototype.animate === "undefined") {
+  Object.defineProperty(Element.prototype, "animate", {
+    value: () => ({ cancel: () => {}, finished: Promise.resolve() }),
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("ProviderCardHandle imperative API", () => {
+  let container: HTMLDivElement | null = null;
+  let handle: ProviderCardHandle | null = null;
+
+  afterEach(() => {
+    handle = null;
+    if (container) {
+      document.body.removeChild(container);
+      container = null;
+    }
+  });
+
+  const PROVIDER_ID = "openai";
+  const PROVIDER_NAME = "OpenAI";
+
+  function renderAndCapture() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ProviderCard
+          ref={(h) => {
+            handle = h;
+          }}
+          providerId={PROVIDER_ID}
+          provider={{ id: PROVIDER_ID, name: PROVIDER_NAME }}
+          stats={{ total: 1, connected: 1, error: 0, warning: 0 }}
+          authType="apikey"
+          onToggle={() => {}}
+        />
+      );
+    });
+  }
+
+  it("getProviderId returns the providerId passed as a prop", () => {
+    renderAndCapture();
+    expect(handle).not.toBeNull();
+    expect(handle!.getProviderId()).toBe(PROVIDER_ID);
+  });
+
+  it("scrollIntoView calls Element.scrollIntoView on the wrapper div", () => {
+    renderAndCapture();
+    const spy = vi.spyOn(Element.prototype, "scrollIntoView");
+    act(() => {
+      handle!.scrollIntoView();
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ behavior: "auto", block: "center" });
+    spy.mockRestore();
+  });
+
+  it("highlight calls animate on the Card surface", () => {
+    renderAndCapture();
+    const spy = vi.spyOn(Element.prototype, "animate");
+    act(() => {
+      handle!.highlight();
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const keyframes = spy.mock.calls[0][0] as Keyframe[];
+    expect(keyframes).toHaveLength(3);
+    expect((keyframes[0] as Record<string, string>).backgroundColor).toBe("rgba(59,130,246,0.22)");
+    expect((keyframes[2] as Record<string, string>).backgroundColor).toBe("transparent");
+    spy.mockRestore();
+  });
+
+  it("highlight focuses the link element", () => {
+    renderAndCapture();
+    const focusSpy = vi.fn();
+    const link = container!.querySelector("a");
+    if (link) link.focus = focusSpy;
+    act(() => {
+      handle!.highlight();
+    });
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("getProviderId returns the correct id for a different provider", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let h: ProviderCardHandle | null = null;
+    act(() => {
+      root.render(
+        <ProviderCard
+          ref={(n) => {
+            h = n;
+          }}
+          providerId="kimi-coding"
+          provider={{ id: "kimi-coding", name: "Kimi Code CLI" }}
+          stats={{ total: 0, connected: 0, error: 0, warning: 0 }}
+          authType="oauth"
+          onToggle={() => {}}
+        />
+      );
+    });
+    expect(h!.getProviderId()).toBe("kimi-coding");
+  });
+});

--- a/tests/unit/ui/providerPageHighlightLogic.test.tsx
+++ b/tests/unit/ui/providerPageHighlightLogic.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the page-level highlighted-card matching/clearing logic
+ * extracted into providerPageHighlightUtils.ts.
+ *
+ * These import the real production functions — not copied code.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderCardHandle } from "@/app/(dashboard)/dashboard/providers/components/ProviderCard";
+import {
+  recordProviderNavigation,
+  resolveHighlightedCard,
+} from "@/app/(dashboard)/dashboard/providers/providerPageHighlightUtils";
+
+function createMockHandle(
+  id: string,
+  callbacks?: { onScroll?(): void; onHighlight?(): void }
+): ProviderCardHandle {
+  return {
+    getProviderId() {
+      return id;
+    },
+    scrollIntoView() {
+      callbacks?.onScroll?.();
+    },
+    highlight() {
+      callbacks?.onHighlight?.();
+    },
+  };
+}
+
+describe("resolveHighlightedCard", () => {
+  it("calls scrollIntoView + highlight when handle matches highlighted id", () => {
+    const onScroll = vi.fn();
+    const onHighlight = vi.fn();
+    const onAfterHighlight = vi.fn();
+    const handle = createMockHandle("openai", { onScroll, onHighlight });
+
+    resolveHighlightedCard(handle, "openai", onAfterHighlight);
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    expect(onHighlight).toHaveBeenCalledTimes(1);
+    expect(onAfterHighlight).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call scrollIntoView or highlight when ids do not match", () => {
+    const onScroll = vi.fn();
+    const onHighlight = vi.fn();
+    const onAfterHighlight = vi.fn();
+    const handle = createMockHandle("openai", { onScroll, onHighlight });
+
+    resolveHighlightedCard(handle, "anthropic", onAfterHighlight);
+
+    expect(onScroll).not.toHaveBeenCalled();
+    expect(onHighlight).not.toHaveBeenCalled();
+    expect(onAfterHighlight).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onAfterHighlight even when handle is null", () => {
+    const onAfterHighlight = vi.fn();
+    resolveHighlightedCard(null, "openai", onAfterHighlight);
+    expect(onAfterHighlight).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onAfterHighlight even when ids do not match", () => {
+    const onAfterHighlight = vi.fn();
+    const handle = createMockHandle("kimi-coding");
+    resolveHighlightedCard(handle, "openai", onAfterHighlight);
+    expect(onAfterHighlight).toHaveBeenCalledTimes(1);
+  });
+
+  it("only the matching handle triggers scroll + highlight among multiple", () => {
+    const calls: string[] = [];
+    const onAfterHighlight = vi.fn();
+    const handles = [
+      createMockHandle("openai", {
+        onScroll: () => calls.push("openai-scroll"),
+        onHighlight: () => calls.push("openai-highlight"),
+      }),
+      createMockHandle("anthropic", {
+        onScroll: () => calls.push("anthropic-scroll"),
+        onHighlight: () => calls.push("anthropic-highlight"),
+      }),
+      createMockHandle("cursor", {
+        onScroll: () => calls.push("cursor-scroll"),
+        onHighlight: () => calls.push("cursor-highlight"),
+      }),
+    ];
+
+    resolveHighlightedCard(handles[0], "cursor", onAfterHighlight);
+    resolveHighlightedCard(handles[1], "cursor", onAfterHighlight);
+    resolveHighlightedCard(handles[2], "cursor", onAfterHighlight);
+
+    expect(calls).toEqual(["cursor-scroll", "cursor-highlight"]);
+    expect(onAfterHighlight).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("recordProviderNavigation", () => {
+  const originalReplaceState = window.history.replaceState;
+
+  afterEach(() => {
+    window.history.replaceState = originalReplaceState;
+  });
+
+  it("calls history.replaceState with the provider id", () => {
+    const replaceSpy = vi.fn();
+    window.history.replaceState = replaceSpy;
+
+    recordProviderNavigation("openai");
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(replaceSpy).toHaveBeenCalledWith({ providerId: "openai" }, "");
+  });
+
+  it("sets different provider ids on successive calls", () => {
+    const replaceSpy = vi.fn();
+    window.history.replaceState = replaceSpy;
+
+    recordProviderNavigation("openai");
+    recordProviderNavigation("anthropic");
+    recordProviderNavigation("kimi-coding");
+
+    expect(replaceSpy).toHaveBeenCalledTimes(3);
+    expect(replaceSpy.mock.calls[0][0]).toEqual({ providerId: "openai" });
+    expect(replaceSpy.mock.calls[1][0]).toEqual({ providerId: "anthropic" });
+    expect(replaceSpy.mock.calls[2][0]).toEqual({ providerId: "kimi-coding" });
+  });
+});


### PR DESCRIPTION
## Problem

When clicking a provider card on the Providers page and navigating back, the scroll position is lost — the user lands at the top with no visual indication of which card they came from.

Scenario - I want to triage my providers. Click in, see some details, come back, and continue down the list. However, often times I need to scroll down to my provider.

The intention of this PR is to ensure that we scroll to the ProviderCard that was last clicked on, so the user will still have context. We will also highlight the card (small animation) to animate the background.

## Solution

I wanted to make sure that page.tsx controls the DOM and eventually calls `scrollIntoView`. Otherwise I could have made changes only in ProviderCard.tsx. I think page.tsx being the "owner" is appropriate since the `ProviderCard` is just an element in the list.

ProviderCard exposes a handle that has functions `getProviderId`, `highlight()`, and `scrollIntoView` that are invoked by page.tsx via utility functions.

Also, ensured that when the user navigated to a provider via keyboard/enter key, and returned back, that the focus gets set, and that the `focus-visible:*` classes are on the appropriate div.

Video/discussion here: https://github.com/diegosouzapw/OmniRoute/discussions/8352

TODO (should create issues @diegosouzapw)?
1. Adjacent feature - we should have the URL be updated when search text is entered? This way when users navigate back, the search filter will still be active.
2. I think we can reduce some duplicate lines of code by making use of `{...props}` in creating the `ProviderCard`s. Maybe look at this in a future PR.

Two files changed, +133/-12.

### page.tsx — owns history state and orchestration

- `highlightedProviderId` state, initialized from `history.state?.providerId` on mount
- `handleCardClick(id)` calls `history.replaceState({ providerId: id }, "")` before navigation
- `highlightedCardRef` is a callback ref that receives a `ProviderCardHandle` — calls `scrollIntoView()` + `highlight()` on the matching card, then clears `highlightedProviderId`
- All 18 `<ProviderCard>` instances receive `onCardClick={handleCardClick}` and `ref={highlightedCardRef}`

### ProviderCard.tsx — forwardRef with imperative handle

- Converted to `forwardRef<ProviderCardHandle, ProviderCardProps>`
- Exposes three methods via `useImperativeHandle`:
  - `highlight()` — pulses the Card surface background blue twice over 3s (Web Animations API)
  - `scrollIntoView()` — scrolls the wrapper div into view (`block: center`)
  - `getProviderId()` — returns the card's provider ID
- `onCardClick` prop — called with `providerId` on click, before Next.js navigation
- Wrapper div gets `id="provider-{id}"` and `ref={innerRef}`; Link gets `focus-visible:outline-*`

### What was NOT done

- No URL hash manipulation
- No `sessionStorage`
- No DOM queries from the parent into child elements
- ProviderCard has zero knowledge of history.state — it only exposes an imperative API and reacts to callbacks
