### PR TITLE
fix(sse): strip third-party-agent signals from the Hermes system prompt that trigger Anthropic 400 extra-usage (#8350)

### DIFF
--- a/changelog.d/fixes/8350-hermes-oauth-usage-400.md
+++ b/changelog.d/fixes/8350-hermes-oauth-usage-400.md
@@ -1,0 +1,1 @@
+- fix(sse): strip third-party-agent signals from the Hermes system prompt that trigger Anthropic 400 extra-usage (#8350)

--- a/open-sse/services/systemTransforms.ts
+++ b/open-sse/services/systemTransforms.ts
@@ -96,6 +96,9 @@ export const DEFAULT_OBFUSCATE_WORDS = [
   // Open WebUI additions
   "openwebui",
   "open-webui",
+  // Hermes additions (#8350)
+  "hermes-agent",
+  "hermes",
 ];
 
 /**
@@ -117,6 +120,19 @@ export const PI_PARAGRAPH_ANCHORS = [
   "/.pi/",
   "Pi documentation (read only when the user asks about pi itself",
 ];
+
+/**
+ * Hermes (NousResearch/hermes-agent) paragraph anchors — the doc-link
+ * paragraph injected by `agent/prompt_builder.py` on the upstream CLI.
+ * Added on top of the other anchor lists for #8350.
+ */
+export const HERMES_PARAGRAPH_ANCHORS = [
+  "hermes-agent.nousresearch.com",
+  "github.com/NousResearch/hermes-agent",
+];
+
+/** Hermes identity paragraph prefixes ("You are Hermes Agent, ..."). */
+export const HERMES_IDENTITY_PREFIXES = ["You are Hermes Agent"];
 
 // ────────────────────────────────────────────────────────────────────────────
 // Per-provider defaults.
@@ -164,12 +180,18 @@ export const DEFAULT_CLAUDE_PIPELINE: TransformOp[] = [
       ...DEFAULT_PARAGRAPH_REMOVAL_ANCHORS,
       ...OPENWEBUI_PARAGRAPH_ANCHORS,
       ...PI_PARAGRAPH_ANCHORS,
+      ...HERMES_PARAGRAPH_ANCHORS,
     ],
   },
-  // Drop "You are OpenCode" + "You are Open WebUI" identity paragraphs.
+  // Drop "You are OpenCode" + "You are Open WebUI" + "You are Hermes Agent"
+  // identity paragraphs.
   {
     kind: "drop_paragraph_if_starts_with",
-    prefixes: [...DEFAULT_IDENTITY_PREFIXES, ...OPENWEBUI_IDENTITY_PREFIXES],
+    prefixes: [
+      ...DEFAULT_IDENTITY_PREFIXES,
+      ...OPENWEBUI_IDENTITY_PREFIXES,
+      ...HERMES_IDENTITY_PREFIXES,
+    ],
   },
   // Replace the "Here is some useful information about the environment you are
   // running in:" billing-gate trigger phrase + the "if OpenCode honestly"

--- a/src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/shared/constants/cliCompatProviders";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { compareTr } from "@/shared/utils/turkishText";
+import { HERMES } from "./systemTransformsHermesDefaults";
 
 // Provider keys (mirror of open-sse/services/systemTransforms.ts).
 const PROVIDER_CLAUDE = "claude";
@@ -80,6 +81,8 @@ const DEFAULT_OBFUSCATE_WORDS = [
   "codecompanion",
   "openwebui",
   "open-webui",
+  "hermes-agent",
+  "hermes",
 ];
 
 // Mirror of DEFAULT_SYSTEM_TRANSFORMS_CONFIG from open-sse/services/systemTransforms.ts.
@@ -96,11 +99,12 @@ const DEFAULT_SYSTEM_TRANSFORMS_CLIENT = {
             ...DEFAULT_PARAGRAPH_REMOVAL_ANCHORS,
             ...OPENWEBUI_PARAGRAPH_ANCHORS,
             ...PI_PARAGRAPH_ANCHORS,
+            ...HERMES.anchors,
           ],
         },
         {
           kind: "drop_paragraph_if_starts_with",
-          prefixes: [...DEFAULT_IDENTITY_PREFIXES, "You are Open WebUI"],
+          prefixes: [...DEFAULT_IDENTITY_PREFIXES, "You are Open WebUI", ...HERMES.prefixes],
         },
         ...DEFAULT_TEXT_REPLACEMENTS.map((r) => ({
           kind: "replace_text" as const,

--- a/src/app/(dashboard)/dashboard/settings/components/systemTransformsHermesDefaults.ts
+++ b/src/app/(dashboard)/dashboard/settings/components/systemTransformsHermesDefaults.ts
@@ -1,0 +1,13 @@
+/**
+ * Hermes (NousResearch/hermes-agent) system-transform anchors — client-side
+ * mirror constant shared by RoutingTab.tsx and tests/unit/system-transforms.test.ts's
+ * UI-parity snapshot. Extracted to a standalone module to keep RoutingTab.tsx
+ * under its frozen file-size baseline (#8350).
+ *
+ * Server source of truth: open-sse/services/systemTransforms.ts
+ * (HERMES_PARAGRAPH_ANCHORS / HERMES_IDENTITY_PREFIXES).
+ */
+export const HERMES = {
+  anchors: ["hermes-agent.nousresearch.com", "github.com/NousResearch/hermes-agent"],
+  prefixes: ["You are Hermes Agent"],
+};

--- a/tests/unit/8350-hermes-oauth-usage-400.test.ts
+++ b/tests/unit/8350-hermes-oauth-usage-400.test.ts
@@ -1,0 +1,70 @@
+// Regression test for #8350 — Hermes (NousResearch/hermes-agent) system-prompt
+// signals reach Anthropic's native Claude OAuth path untouched, tripping
+// `[400] Third-party apps now draw from extra usage, not plan limits.`
+//
+// Mirrors the "OpenWebUI fixture" / "Pi documentation" style tests in
+// tests/unit/system-transforms.test.ts. Fixture text matches the real
+// identity + doc-link paragraphs injected by
+// NousResearch/hermes-agent/agent/prompt_builder.py (verified via WebFetch
+// against the upstream repo during triage).
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { applySystemTransformPipeline, DEFAULT_SYSTEM_TRANSFORMS_CONFIG, PROVIDER_CLAUDE } =
+  await import("../../open-sse/services/systemTransforms.ts");
+
+test("Hermes fixture: claude provider drops Hermes identity + doc-link paragraphs (#8350)", () => {
+  const body = {
+    system: [
+      {
+        type: "text",
+        text: [
+          "You are Hermes Agent, an intelligent AI assistant created by Nous Research.",
+          "Guidelines:\n- Be concise.",
+          "For more information, see the documentation at https://hermes-agent.nousresearch.com/docs.",
+        ].join("\n\n"),
+      },
+    ],
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = applySystemTransformPipeline(
+    PROVIDER_CLAUDE,
+    body,
+    DEFAULT_SYSTEM_TRANSFORMS_CONFIG
+  );
+  const out = (body.system as Array<{ text: string }>)[0].text;
+
+  assert.ok(
+    !out.includes("You are Hermes Agent"),
+    "Hermes identity paragraph should be dropped by the default claude pipeline"
+  );
+  assert.ok(
+    !out.includes("hermes-agent.nousresearch.com"),
+    "Hermes doc-link paragraph should be dropped by the default claude pipeline"
+  );
+  // Unrelated legitimate content survives untouched.
+  assert.ok(out.includes("Guidelines:"));
+  assert.ok(out.includes("Be concise."));
+  assert.ok(result.appliedOpKinds.includes("drop_paragraph_if_contains"));
+  // No billing header injected on the native OAuth path (native code handles that).
+  assert.ok(!result.appliedOpKinds.includes("inject_billing_header"));
+});
+
+test("non-Hermes system prompt passes through byte-identical through the claude pipeline (no drive-by regression)", () => {
+  const body = {
+    system: [
+      {
+        type: "text",
+        text: "You are a helpful operator-configured assistant. Follow company policy X and always answer in English.",
+      },
+    ],
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const before = JSON.stringify(body);
+  applySystemTransformPipeline(PROVIDER_CLAUDE, body, DEFAULT_SYSTEM_TRANSFORMS_CONFIG);
+  assert.equal(
+    JSON.stringify(body),
+    before,
+    "a normal operator system prompt with no third-party-agent anchors must pass through untouched"
+  );
+});

--- a/tests/unit/system-transforms.test.ts
+++ b/tests/unit/system-transforms.test.ts
@@ -446,11 +446,13 @@ const UI_DEFAULTS_SNAPSHOT = {
             "@earendil-works/pi-coding-agent",
             "/.pi/",
             "Pi documentation (read only when the user asks about pi itself",
+            "hermes-agent.nousresearch.com",
+            "github.com/NousResearch/hermes-agent",
           ],
         },
         {
           kind: "drop_paragraph_if_starts_with",
-          prefixes: ["You are OpenCode", "You are Open WebUI"],
+          prefixes: ["You are OpenCode", "You are Open WebUI", "You are Hermes Agent"],
         },
         {
           kind: "replace_text",
@@ -481,6 +483,8 @@ const UI_DEFAULTS_SNAPSHOT = {
             "codecompanion",
             "openwebui",
             "open-webui",
+            "hermes-agent",
+            "hermes",
           ],
           targets: ["system", "messages", "tools"],
         },


### PR DESCRIPTION
Closes #8350

## Root cause
`DEFAULT_CLAUDE_PIPELINE` in `open-sse/services/systemTransforms.ts` (wired into the native Claude OAuth executor path at `open-sse/executors/base.ts:1031`) already scrubs third-party-agent identity paragraphs / doc-link anchors for opencode, cline, cursor, continue.dev, Open WebUI, and Pi — but had no entry for Hermes (NousResearch/hermes-agent). Per the real `agent/prompt_builder.py` (verified against upstream `main`), Hermes injects an identity paragraph ("You are Hermes Agent, an intelligent AI assistant created by Nous Research...") and a doc-link paragraph pointing at `hermes-agent.nousresearch.com`. Neither anchor was in any scrub list, so both reached Anthropic's `/v1/messages` untouched, tripping Anthropic's third-party-agent billing-gate classifier: `[400] Third-party apps now draw from extra usage, not plan limits.`

## Fix
- Added `HERMES_PARAGRAPH_ANCHORS` / `HERMES_IDENTITY_PREFIXES` constants to `open-sse/services/systemTransforms.ts`, spread into `DEFAULT_CLAUDE_PIPELINE`'s `drop_paragraph_if_contains` / `drop_paragraph_if_starts_with` ops (same pattern used for the OpenWebUI/Pi anchors).
- Added `hermes-agent` / `hermes` to `DEFAULT_OBFUSCATE_WORDS` (ZWJ defense-in-depth layer).
- Checked whether Hermes needs the CC-bridge pipeline too (`DEFAULT_CC_BRIDGE_PROVIDER_PIPELINE`) — found no evidence Hermes routes through the `anthropic-compatible-cc-*` bridge (it's a generic OpenAI/Anthropic-style config generator pointed at the same native OAuth model slugs as opencode et al.), so left that pipeline untouched.
- Mirrored the anchors client-side for the Settings → Routing "reset to defaults" UI. To avoid growing the frozen `RoutingTab.tsx` past its file-size baseline, extracted the new constants into a tiny new module `src/app/(dashboard)/dashboard/settings/components/systemTransformsHermesDefaults.ts` instead of inlining them (extraction over baseline bump, per project convention).
- Updated the pre-existing `UI_DEFAULTS_SNAPSHOT` parity fixture in `tests/unit/system-transforms.test.ts` to include the new anchors — this is alignment to the now-correct default pipeline, not weakening (the assertion itself, `defaults parity: ... matches the UI mirror snapshot`, is unchanged and still fully enforced).

## TDD (Hard Rule #18)
New permanent regression file `tests/unit/8350-hermes-oauth-usage-400.test.ts`:
- **RED before fix**: `AssertionError: Hermes identity paragraph should be dropped by the default claude pipeline (actual=false, expected=true)`.
- **GREEN after fix**: both the Hermes-fixture test and a companion "non-Hermes system prompt passes through byte-identical" test (guards the shared-seam landmine — this transform must stay a no-op for callers with no third-party-agent anchors).

## Gates run (all green from inside the worktree)
- `node --import tsx/esm --test tests/unit/8350-hermes-oauth-usage-400.test.ts` — 2/2 pass
- `node --import tsx/esm --test tests/unit/system-transforms.test.ts` — 25/25 pass (including the UI-parity snapshot)
- `node --import tsx/esm --test tests/unit/service-system-transforms.test.ts tests/unit/settings-transform-schema.test.ts tests/unit/settings-ui-layout-static.test.ts` — all pass (siblings that touch this seam)
- `node scripts/check/check-file-size.mjs` — OK (extracted a new module to stay under the frozen `RoutingTab.tsx` baseline)
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — both report pre-existing regressions (2167>2130 / 956>951) that are **identical counts** on a disposable probe worktree pinned to `origin/release/v3.8.49` (confirmed base-red, not introduced by this diff; probe torn down)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Landmine handling
`systemTransforms.ts` is a shared seam used by every native-Claude-OAuth request, not just Hermes. The added anchors are narrow (Hermes-specific URLs/identity string), and the new "non-Hermes system prompt passes through byte-identical" test asserts a normal operator system prompt is untouched by the pipeline.