### PR TITLE
fix(backend): keep combo routing from dispatching image requests to text-only targets (#8332)

### DIFF
--- a/changelog.d/fixes/8332-combo-vision-fallback.md
+++ b/changelog.d/fixes/8332-combo-vision-fallback.md
@@ -1,0 +1,1 @@
+- fix(backend): keep combo routing from dispatching image requests to text-only targets (#8332)

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -178,6 +178,7 @@ import { resolveShadowTargets, scheduleShadowRouting } from "./combo/shadowRouti
 import { attemptCompatRejectedFallback } from "./combo/comboCompatFallback.ts";
 import { applyContextRequirements } from "./combo/contextRequirements.ts";
 import {
+  computeCompatRejectedTargets,
   filterTargetsByRequestCompatibility,
   resolveComboRuntimeUnits,
   resolveComboTargets,
@@ -2912,8 +2913,7 @@ async function handleRoundRobinCombo({
   // BEFORE availability is known; if every compat-kept target then turns out to be
   // runtime-unavailable, we must reconsider these before returning 503, instead of
   // permanently dropping a compat-rejected-but-healthy provider.
-  const compatKeptSet = new Set(filteredTargets);
-  const compatRejectedTargets = evalRankedTargets.filter((target) => !compatKeptSet.has(target));
+  const compatRejectedTargets = computeCompatRejectedTargets(evalRankedTargets, filteredTargets, body);
   let modelCount = filteredTargets.length;
   if (modelCount === 0) {
     return comboModelNotFoundResponse("Round-robin combo has no executable targets");

--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -501,6 +501,38 @@ function hasOnlyContextWindowFailures(reasons: string[]): boolean {
   return reasons.length > 0 && reasons.every((reason) => reason === "context_window");
 }
 
+/**
+ * #8332: vision is a hard requirement, not a soft preference — a target whose vision
+ * support is not confirmed can never succeed on an image_url request. Callers
+ * reconsidering compat-rejected targets (fallback tiers, degrade-to-unfiltered) MUST
+ * exclude these via this predicate.
+ */
+export function isVisionIncompatibleTarget(
+  target: ResolvedComboTarget,
+  requirements: RequestCompatibilityRequirements
+): boolean {
+  if (!requirements.requiresVision) return false;
+  const capabilities = getResolvedModelCapabilities(target.modelStr);
+  return capabilities.supportsVision !== true;
+}
+
+/**
+ * Builds the #6238 last-resort fallback candidate set: ranked targets the compat
+ * pre-filter rejected, minus anything rejected for vision (#8332 — see
+ * isVisionIncompatibleTarget).
+ */
+export function computeCompatRejectedTargets(
+  rankedTargets: ResolvedComboTarget[],
+  compatKeptTargets: ResolvedComboTarget[],
+  body: Record<string, unknown>
+): ResolvedComboTarget[] {
+  const requirements = deriveRequestCompatibilityRequirements(body);
+  const keptSet = new Set(compatKeptTargets);
+  return rankedTargets.filter(
+    (target) => !keptSet.has(target) && !isVisionIncompatibleTarget(target, requirements)
+  );
+}
+
 function getTargetCompatibilityFailures(
   target: ResolvedComboTarget,
   requirements: RequestCompatibilityRequirements
@@ -633,6 +665,11 @@ export function filterTargetsByRequestCompatibility(
         .map((entry) => `${entry.target.modelStr}(${entry.reasons.join("+")})`)
         .join(", ")}`
     );
+    // #8332: vision is never safe to guess — this safety net must not resurrect a
+    // vision-rejected target, even if nothing else remains.
+    if (requirements.requiresVision) {
+      return targets.filter((target) => !isVisionIncompatibleTarget(target, requirements));
+    }
     return targets;
   }
 

--- a/tests/unit/8332-combo-vision-fallback.test.ts
+++ b/tests/unit/8332-combo-vision-fallback.test.ts
@@ -1,0 +1,199 @@
+// Regression guard for #8332: combo routing's #6238 last-resort compat-fallback
+// tier dispatched an image_url-bearing request to a text-only (vision-incapable)
+// target. filterTargetsByRequestCompatibility correctly rejects such targets
+// up front (comboStructure.ts), but the round-robin path rebuilt its rejected
+// set from the raw evalRankedTargets list (discarding the per-target rejection
+// reasons), so `attemptCompatRejectedFallback` reconsidered a vision-rejected
+// target exactly like any other compat-rejected-but-healthy target and sent it
+// the unmodified image body — producing the upstream
+// `400: unknown variant "image_url", expected "text"`.
+//
+// The fix makes vision a hard capability requirement for the fallback tier:
+// a target rejected because it cannot confirm vision support must never be
+// reconsidered, even as a last resort.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rr-compat-8332-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+const core = await import("../../src/lib/db/core.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const { saveModelsDevCapabilities, clearModelsDevCapabilities } =
+  await import("../../src/lib/modelsDevSync.ts");
+const { resetAllComboMetrics } = await import("../../open-sse/services/comboMetrics.ts");
+const { resetAllCircuitBreakers } = await import("../../src/shared/utils/circuitBreaker.ts");
+const { resetAll: resetAllSemaphores } =
+  await import("../../open-sse/services/rateLimitSemaphore.ts");
+
+function createLog() {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+function okResponse(body: unknown = { choices: [{ message: { content: "ok" } }] }) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function capabilityEntry(limitContext: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    tool_call: true,
+    reasoning: false,
+    attachment: false,
+    structured_output: true,
+    temperature: true,
+    modalities_input: JSON.stringify(["text"]),
+    modalities_output: JSON.stringify(["text"]),
+    knowledge_cutoff: null,
+    release_date: null,
+    last_updated: null,
+    status: null,
+    family: null,
+    open_weights: false,
+    limit_context: limitContext,
+    limit_input: limitContext,
+    limit_output: 4096,
+    interleaved_field: null,
+    ...overrides,
+  };
+}
+
+const imageRequestBody = {
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "What is in this image?" },
+        { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
+      ],
+    },
+  ],
+};
+
+test.beforeEach(() => {
+  resetAllComboMetrics();
+  resetAllCircuitBreakers();
+  resetAllSemaphores();
+  clearModelsDevCapabilities();
+});
+
+test.after(() => {
+  resetAllComboMetrics();
+  resetAllCircuitBreakers();
+  resetAllSemaphores();
+  clearModelsDevCapabilities();
+  settingsDb.clearAllLKGP();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+});
+
+test(
+  "round-robin last-resort compat fallback never dispatches an image_url request " +
+    "to a vision-incapable target (#8332)",
+  async () => {
+    // rr-blind is text-only (attachment:false -> supportsVision:false) -> the
+    // vision-requiring request makes the compat pre-filter reject it. rr-vision-a
+    // and rr-vision-b are vision-capable -> kept, but both are simulated
+    // runtime-unavailable, forcing recordedAttempts === 0 and triggering the
+    // #6238 last-resort tier. Only the vision-rejected rr-blind is "healthy".
+    saveModelsDevCapabilities({
+      openai: {
+        "rr-blind": capabilityEntry(128000, { attachment: false }),
+        "rr-vision-a": capabilityEntry(128000, { attachment: true }),
+        "rr-vision-b": capabilityEntry(128000, { attachment: true }),
+      },
+    });
+
+    const attempted: string[] = [];
+
+    const result = await handleComboChat({
+      body: imageRequestBody,
+      combo: {
+        name: "rr-compat-fallback-8332-vision",
+        strategy: "round-robin",
+        models: ["openai/rr-blind", "openai/rr-vision-a", "openai/rr-vision-b"],
+        config: { maxRetries: 0, concurrencyPerModel: 1, queueTimeoutMs: 1000 },
+      },
+      handleSingleModel: async (_body, modelStr) => {
+        attempted.push(modelStr);
+        return okResponse({ choices: [{ message: { content: `served by ${modelStr}` } }] });
+      },
+      // Only the vision-rejected rr-blind is "available"; the vision-capable
+      // compat-kept targets are all runtime-unavailable.
+      isModelAvailable: async (modelStr) => modelStr === "openai/rr-blind",
+      log: createLog(),
+      settings: null,
+      relayOptions: null,
+      allCombos: null,
+    });
+
+    // Before the fix, rr-blind (vision-incapable but "available") was dispatched
+    // the raw image_url body as the #6238 last-resort fallback. After the fix it
+    // must never be attempted, and since no other target is available, the combo
+    // must surface its normal exhaustion error instead of a corrupted 200.
+    assert.deepEqual(
+      attempted,
+      [],
+      "vision-incapable rr-blind must never receive the image_url body, even as a last-resort fallback"
+    );
+    assert.notEqual(result.status, 200, "must not silently succeed via the vision-incapable target");
+  }
+);
+
+test(
+  "round-robin last-resort compat fallback still serves a healthy non-vision-rejected " +
+    "target for an image request (#8332 — does not overcorrect #6238)",
+  async () => {
+    // rr-no-tools is tool-incapable (irrelevant here; no tools requested) but IS
+    // vision-capable, so it is not rejected for vision. rr-vision-a is also
+    // vision-capable and compat-kept, but runtime-unavailable, forcing the
+    // #6238 last-resort tier. This proves the vision-only exclusion does not
+    // also swallow legitimate non-vision-rejection fallback targets.
+    saveModelsDevCapabilities({
+      openai: {
+        "rr-vision-a": capabilityEntry(128000, { attachment: true }),
+      },
+    });
+
+    const attempted: string[] = [];
+
+    const result = await handleComboChat({
+      body: imageRequestBody,
+      combo: {
+        name: "rr-compat-fallback-8332-sanity",
+        strategy: "round-robin",
+        models: ["openai/rr-vision-a"],
+        config: { maxRetries: 0, concurrencyPerModel: 1, queueTimeoutMs: 1000 },
+      },
+      handleSingleModel: async (_body, modelStr) => {
+        attempted.push(modelStr);
+        return okResponse({ choices: [{ message: { content: `served by ${modelStr}` } }] });
+      },
+      isModelAvailable: async () => true,
+      log: createLog(),
+      settings: null,
+      relayOptions: null,
+      allCombos: null,
+    });
+
+    assert.equal(result.status, 200);
+    assert.deepEqual(attempted, ["openai/rr-vision-a"]);
+  }
+);

--- a/tests/unit/combo-vision-aware-routing.test.ts
+++ b/tests/unit/combo-vision-aware-routing.test.ts
@@ -15,8 +15,13 @@
  *     known-multimodal families (pixtral, llava, qwen-vl, gpt-4o, …) resolve to
  *     `true` when there is no synced/registry/spec data.
  *  B) the combo filter treats anything that is not confirmed `=== true` as
- *     vision-incompatible for image requests, while the existing
- *     "keep all when none qualify" fallback prevents any regression.
+ *     vision-incompatible for image requests. Unlike the other requirement
+ *     dimensions (tools, structured output, context window), the "keep all when
+ *     none qualify" degrade-to-unfiltered safety net does NOT apply to vision
+ *     (#8332): dispatching an image body to a confirmed-non-vision model can
+ *     never succeed upstream, so a combo with zero confirmed-vision members must
+ *     return no targets for an image request rather than resurrecting a
+ *     guaranteed-to-fail one.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -95,14 +100,23 @@ test("image request: combo drops the non-vision target, keeps the vision target"
   assert.ok(!ids.includes("mistral/ministral-14b-latest"), "non-vision target must be dropped");
 });
 
-test("image request with NO confirmed-vision target: keep all (fallback, no regression)", () => {
-  const out = filterTargetsByRequestCompatibility(
-    [target("mistral/ministral-14b-latest"), target("groq/llama-3.1-8b-instant")],
-    imageBody,
-    noopLog
-  );
-  assert.equal(out.length, 2, "must not strip every target when none is confirmed vision");
-});
+test(
+  "image request with NO confirmed-vision target: strip all (#8332 — never dispatch " +
+    "an image body to a confirmed-non-vision target, even as a last resort)",
+  () => {
+    const out = filterTargetsByRequestCompatibility(
+      [target("mistral/ministral-14b-latest"), target("groq/llama-3.1-8b-instant")],
+      imageBody,
+      noopLog
+    );
+    assert.equal(
+      out.length,
+      0,
+      "an image request with zero confirmed-vision targets must yield no executable targets, " +
+        "not a guaranteed-to-fail dispatch to a text-only model"
+    );
+  }
+);
 
 test("text-only request: targets are untouched by the vision filter", () => {
   const out = filterTargetsByRequestCompatibility(


### PR DESCRIPTION
Closes #8332

## Root cause

`filterTargetsByRequestCompatibility` (`open-sse/services/combo/comboStructure.ts`) correctly rejects targets without confirmed vision support when a request carries an `image_url` content part. But two paths reintroduced vision-rejected targets after that filter ran:

1. **Round-robin last-resort compat fallback (#6238 tier).** `open-sse/services/combo.ts` rebuilt its `compatRejectedTargets` set as `evalRankedTargets.filter(t => !compatKeptSet.has(t))` — a bare target list with no rejection reasons. When every compat-kept (vision-capable) target was runtime-unavailable, `attemptCompatRejectedFallback` (`open-sse/services/combo/comboCompatFallback.ts`) treated *every* rejected target — vision, tools, structured-output, context-window alike — as fair game, sent the raw unmodified `image_url` body, and produced the upstream `400: unknown variant "image_url", expected "text"`.
2. **`filterTargetsByRequestCompatibility`'s `compatible.length === 0` degrade-to-unfiltered branch.** When a combo has zero confirmed-vision members, this branch returned the full unfiltered target list — no vision protection at all, on any strategy.

## Fix

- New `isVisionIncompatibleTarget()` predicate in `comboStructure.ts` (mirrors the existing per-target vision check at line ~524): a target whose vision support is not confirmed `=== true` is a hard fail for a vision-requiring request, never eligible for reconsideration.
- New `computeCompatRejectedTargets()` (also in `comboStructure.ts`, to stay under the file-size cap for `comboCompatFallback.ts`'s sibling) builds the #6238 fallback candidate set, excluding vision-incompatible targets. `combo.ts`'s round-robin path now calls this instead of the bare `evalRankedTargets.filter(...)`.
- The `compatible.length === 0` branch now also excludes vision-incompatible targets when `requiresVision` is set — even in the "preserve strategy order" degrade case, since dispatching an image body to a confirmed-non-vision model can never succeed (unlike e.g. an unknown context window, which might still work). If that leaves zero targets, the combo returns its normal exhaustion error instead of a guaranteed-to-fail dispatch.

## TDD evidence (Hard Rule #18)

New permanent regression file `tests/unit/8332-combo-vision-fallback.test.ts`, modeled on `tests/unit/combo-roundrobin-compat-fallback-6238.test.ts`:

- **RED before the fix** (confirmed by checking out `origin/release/v3.8.49`'s `combo.ts`/`comboStructure.ts` and re-running): `attempted: ["openai/rr-blind"]` — the vision-incapable "available" target received the image body.
- **GREEN after the fix**: `attempted: []`, non-200 status — the vision-incapable target is never dispatched.
- A second sanity test confirms the vision-only exclusion does not overcorrect: a healthy non-vision-rejected target still serves the #6238 last-resort tier normally.

Also updated `tests/unit/combo-vision-aware-routing.test.ts`'s "keep all when none qualify" assertion — that test encoded the exact second contributing path above (the `compatible.length === 0` degrade branch for a combo with zero confirmed-vision members). Per the plan's acceptance criteria this policy needed to be explicitly decided and asserted; changed it to assert the new (correct) behavior: an image request against a combo with no confirmed-vision members now returns no executable targets rather than resurrecting a guaranteed-to-fail text-only model.

## Landmine handling

- Kept `tests/unit/combo-roundrobin-compat-fallback-6238.test.ts` (the non-vision contract) green and unmodified — verified it still passes.
- Did not touch `src/lib/combos/` or `src/app/api/combos/` (another session's in-flight scope) — changes are scoped to `open-sse/services/combo.ts` and `open-sse/services/combo/comboStructure.ts`.
- Did not treat unknown/unset vision capability as "no vision" for any dimension other than vision itself — the existing `supportsVision !== true` predicate (already in the codebase pre-fix) is reused verbatim, not broadened.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/8332-combo-vision-fallback.test.ts` (RED→GREEN, see above)
- `node --import tsx/esm --test tests/unit/combo-roundrobin-compat-fallback-6238.test.ts` (unmodified, still green)
- `node --import tsx/esm --test tests/unit/combo-vision-aware-routing.test.ts` (updated assertion, green)
- Sibling sweep: `combo-routing-engine.test.ts`, `combo-context-window-filter.test.ts`, `combo-context-requirements.test.ts`, `model-capabilities-provider-unsupported-tools.test.ts`, `chatcore-tool-calling-required-check.test.ts` — all green
- `node scripts/check/check-file-size.mjs` — OK (extracted `computeCompatRejectedTargets` into `comboStructure.ts` to keep `combo.ts` at its frozen 3630-line baseline; `comboStructure.ts` stays under its 800-line new-file cap)
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — both report pre-existing base-red counts (2167/956), confirmed identical via a disposable probe worktree pinned to `origin/release/v3.8.49` — not introduced by this diff
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK