### PR TITLE
chore(ci): cancel superseded runs, skip DAST on docs-only PRs, TIA shadow evidence

### DIFF
--- a/.github/workflows/dast-smoke.yml
+++ b/.github/workflows/dast-smoke.yml
@@ -2,8 +2,20 @@ name: DAST smoke (PR)
 on:
   pull_request:
     branches: ["main", "release/**"]
+    # Runner-cost guard (#8084): the CLI-bundle build alone is 6-11min; a docs-only PR
+    # cannot change DAST behavior, so skip the whole workflow for pure docs/markdown
+    # changes. Any code path in the diff still runs the full smoke.
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 permissions:
   contents: read
+
+# Superseded runs on the same PR must not stack 25-minute advisory builds
+# (force-push storms were holding 2-3 runners each). Same group rule as quality.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   dast-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -177,17 +177,26 @@ jobs:
           git fetch --no-tags origin "$GITHUB_BASE_REF" || true
           node scripts/quality/build-test-impact-map.mjs
           SEL="$(node scripts/quality/select-impacted-tests.mjs)"
-          if [ -z "$SEL" ]; then echo "No source/test changes — skipping unit tests"; exit 0; fi
+          # Shadow evidence (#8084): persist every selection so TIA false negatives can
+          # be measured against fast-unit's full-suite verdict across releases BEFORE
+          # any gate authority moves off ordinary PRs. Artifact uploaded below.
+          printf '%s\n' "$SEL" > tia-selection.txt
+          if [ -z "$SEL" ]; then
+            echo "TIA selection: empty (no source/test changes)" >> "$GITHUB_STEP_SUMMARY"
+            echo "No source/test changes — skipping unit tests"; exit 0
+          fi
           # CI runners are 4-vCPU; run at --test-concurrency=4 (matching the ci.yml unit
           # job) rather than test:unit's local-tuned concurrency=20. Oversubscribing the
           # runner makes timing-sensitive tests (db-backup, upstream-timeout, ...) flake,
           # which must not happen on a blocking gate. DATA_DIR isolation keeps the parallel
           # run race-free regardless of concurrency.
           if echo "$SEL" | grep -q "__RUN_ALL__"; then
+            echo "TIA selection: __RUN_ALL__ (fail-safe) — full-suite authority stays with fast-unit" >> "$GITHUB_STEP_SUMMARY"
             echo "Fail-safe: __RUN_ALL__ — deferring FULL unit suite to fast-unit (4-shard)."
             echo "Not re-running unsharded test:unit:ci here (duplicate of fast-unit coverage)."
             exit 0
           fi
+          echo "TIA selection: $(grep -c . tia-selection.txt) impacted test file(s) — full suite still runs in fast-unit (shadow-evidence phase, #8084)" >> "$GITHUB_STEP_SUMMARY"
           echo "Running impacted tests:"; echo "$SEL"
           mapfile -t FILES <<< "$SEL"
           # Loader parity with test:unit:ci:shard (#6787): tests/unit/dashboard/** runs
@@ -210,6 +219,16 @@ jobs:
             node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=4 "${DASH[@]}" || RC=$?
           fi
           exit $RC
+      # #8084 shadow evidence: keep the raw selection downloadable so TIA misses can be
+      # audited against fast-unit failures on the same run (gate moves need this data).
+      - name: Upload TIA selection (shadow evidence)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tia-selection
+          path: tia-selection.txt
+          if-no-files-found: ignore
+          retention-days: 30
 
   fast-vitest:
     name: Vitest (fast-path)

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -6,6 +6,12 @@ on:
     branches: ["main"]
 permissions:
   contents: read
+
+# Cancel superseded PR runs (same rule as quality.yml). No paths filter on purpose:
+# p/secrets must keep scanning docs-only diffs too — credentials leak in .md files.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   semgrep:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

First immediate slice of the CI-cost direction discussed in #8084 (@nguyenha935's pipeline review): stop paying for runs that cannot change the outcome, and start collecting the evidence that lets TIA actually replace cost later.

## Changes

1. **`dast-smoke.yml`** — `concurrency` + `cancel-in-progress` (superseded 25-minute advisory builds were stacking on force-push storms, holding 2-3 runners each), and `paths-ignore` for `docs/**` + `**/*.md`: a docs-only PR cannot change DAST behavior but was paying the 6-11min CLI-bundle build on every push (observed on the docs-only #8362).
2. **`semgrep.yml`** — `concurrency` + `cancel-in-progress` only. Deliberately **no** paths filter: `p/secrets` must keep scanning docs-only diffs, credentials leak in `.md` files too.
3. **`quality.yml` (TIA step)** — persist the per-PR impacted-test selection as a `tia-selection` artifact (30-day retention) + a `GITHUB_STEP_SUMMARY` line (`empty` / `__RUN_ALL__` / `N files`). This is the **shadow-evidence phase** from #8084: TIA false negatives become measurable against `fast-unit`'s full-suite verdict on the same run, across releases, BEFORE any gate authority moves off ordinary PRs. No gate semantics change in this PR.

## Validation

- All three files parse (`js-yaml` load) and `quality.yml` keeps its 7 jobs intact.
- No required-status impact: the release-branch ruleset has no required status checks, and both touched standalone workflows are advisory (`continue-on-error`).
- Advisory-only + docs-path semantics: zero change to any blocking gate.

## Not in this PR (tracked in the rail / #8084)

- Lane consolidation (9× `npm ci` per code PR today) — 3.8.51.
- `ci.yml` vs `quality.yml` policy unification — 3.8.52.
- Full-suite authority move to merge queue (needs the shadow evidence this PR starts collecting) — 3.8.54.
- CodeQL default-setup language trim (c-cpp/python analyze on a TS repo) — repo settings, operator-only.

Refs #8084
