### PR TITLE
docs: one contributor golden path (template/CONTRIBUTING/GEMINI/AGENTS) + CI milestones in ROADMAP

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,10 +9,12 @@
 
 ## Validation
 
+Run only the focused loop for what you changed — the full unit suite, Vitest, the
+60% coverage gate, and the production build all run in CI on this PR (#8329):
+
+- [ ] Focused tests for the change: `node --import tsx/esm --test tests/unit/<file>.test.ts`
 - [ ] `npm run lint`
-- [ ] `npm run test:unit`
-- [ ] `npm run test:coverage`
-- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
+- [ ] Production-code changes include a new or updated automated test in this PR
 - [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
 
 ## Tests Added Or Updated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,12 +570,16 @@ This repository is a fork of `diegosouzapw/OmniRoute`. Keep fork-only operationa
 changes (for example GHCR image publishing, personal deployment workflows, or local
 automation) out of upstream contribution PRs.
 
-When preparing a PR for upstream, always start the work branch from `upstream/main`,
-not from this fork's `main`:
+When preparing a PR for upstream, always start the work branch from the upstream
+**default branch** — the active `release/vX.Y.Z` line (today `release/v3.8.49`).
+Never branch from `main`: `main` only receives release squash-merges, so a branch
+cut there is weeks behind and produces conflict-heavy PRs
+(see `CONTRIBUTING.md` and `docs/ops/BRANCHING_MODEL.md`):
 
 ```bash
 git fetch upstream
-git switch -c <branch-name> upstream/main
+# the default branch is the active release line, e.g. release/v3.8.49
+git switch -c <branch-name> upstream/release/vX.Y.Z
 ```
 
 Only cherry-pick or reapply the changes intended for the upstream PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,11 +198,14 @@ Coverage notes:
 
 ### Pull Request Requirements
 
-Before opening or merging a PR:
+Before opening a PR, run the focused loop for what you changed. The full unit suite
+(4 CI shards), Vitest, the **60%+** coverage gate, and the production build are CI's
+responsibility — running them locally adds no signal the PR checks will not already
+give you, and on smaller machines it can saturate the host (#8084):
 
-- Run `npm run test:unit`
-- Run `npm run test:coverage`
-- Ensure the coverage gate stays at **60%+** statements/lines/functions/branches
+- Run the test files that cover your change: `node --import tsx/esm --test tests/unit/<file>.test.ts`
+- Run `npm run lint`
+- Include or update automated tests in the same PR whenever production code changes
 - Include the changed or added test files in the PR description when production code changed
 - Check the SonarQube result on the PR when the project secrets are configured in CI
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,7 +27,7 @@ When creating _any_ validation tests or one-off logic scripts, default to using 
 7. **Never bypass Husky hooks** (`--no-verify`, `--no-gpg-sign`) without explicit operator approval.
 8. **Always validate inputs with Zod schemas** from `src/shared/validation/schemas.ts`.
 9. **Always include tests when changing production code** (`src/`, `open-sse/`, `electron/`, `bin/`).
-10. **Coverage must stay** ≥ 75 % statements / 75 % lines / 75 % functions / 70 % branches (real measured: ~82 %).
+10. **Coverage must stay** ≥ 60 % statements / lines / functions / branches — the official CI gate (`npm run test:coverage`). The ratchet baseline in `quality-baseline.json` may freeze a higher floor; never regress it.
 
 ## 3. Codebase navigation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,10 +26,10 @@ mandatory quality-gate battery before new merges open.
 | Version | Focus |
 | --- | --- |
 | 3.8.50 | CI safety net on release branches · dead-code cleanup · community-reported catalog/topology bug fixes · contributor "golden path" guide |
-| 3.8.51 | Executor registry (in-place) · end-to-end provider-journey contract test becomes a CI gate · official scoped-test dev loop |
-| 3.8.52 | `combo.ts` decomposition · routing-strategy registry · unified model-catalog contract for `/v1/models` |
+| 3.8.51 | Executor registry (in-place) · end-to-end provider-journey contract test becomes a CI gate · official scoped-test dev loop · CI lane consolidation (shared install/setup across gate jobs, #8084) |
+| 3.8.52 | `combo.ts` decomposition · routing-strategy registry · unified model-catalog contract for `/v1/models` · one CI policy for PRs to `release/**` and `main` (#8084) |
 | 3.8.53 | `chatCore.ts` decomposition · headless mode (`OMNIROUTE_HEADLESS=1`) · local candidate build/promote loop |
-| 3.8.54 | Release infrastructure (dormant): channels, labels, PR templates, merge queue · public feature-freeze announcement |
+| 3.8.54 | Release infrastructure (dormant): channels, labels, PR templates, merge queue · full-regression authority moves to the merge queue once TIA shadow evidence clears (#8084) · public feature-freeze announcement |
 
 ## Phase 2 — Validation (3.8.55 → 3.8.59)
 
@@ -41,7 +41,7 @@ the v4 channel when it opens). Fixes, docs, i18n, and provider updates keep flow
 | 3.8.55 | Characterization tests for every extraction candidate · coupling re-measurement |
 | 3.8.56 | Extended canary · performance baselines (heap, TTFB, build) |
 | 3.8.57 | Security & compliance sweep · publish provenance (OIDC) rehearsal |
-| 3.8.58 | Full dry-run of the 3.9.0 cut (branches, channels, forward-port) |
+| 3.8.58 | Full dry-run of the 3.9.0 cut (branches, channels, forward-port) — includes the PR preview-artifact + build-once promotion rehearsal (#8084) |
 | 3.8.59 | Final freeze · full-suite audit · GO/NO-GO |
 
 ## Phase 3 — v3.9.0 LTS


### PR DESCRIPTION
## Summary

One golden path, stated once, everywhere the same — the doc-drift slice of #8329, with the exact contradictions reported in @nguyenha935's #8084 pipeline review.

## What was contradicting what

| File | Said | Now says |
| --- | --- | --- |
| `.github/pull_request_template.md` | run `test:unit` + `test:coverage` locally | focused test files + lint; full suite/coverage/build are CI's job |
| `CONTRIBUTING.md` (PR Requirements) | run `test:unit` + `test:coverage` locally | same golden path, with the why (full local chain has saturated 16GB hosts, #8084) |
| `GEMINI.md` hard rule 10 | coverage >= 75/75/75/70 | official CI gate: 60/60/60/60 + ratchet baseline note |
| `AGENTS.md` fork workflow | branch from `upstream/main` | branch from the default branch = active `release/vX.Y.Z` (main only gets release squash-merges) |

## ROADMAP: #8084 direction made explicit

- 3.8.51: CI lane consolidation (shared install/setup across gate jobs)
- 3.8.52: one CI policy for PRs to `release/**` and `main`
- 3.8.54: full-regression authority moves to the merge queue once TIA shadow evidence clears
- 3.8.58: dry-run explicitly includes the PR preview-artifact + build-once promotion rehearsal — this also answers the milestone question raised in #8084

Docs-only; no gate or workflow semantics change (the runner-cost slice is #8379).

Refs #8329
Refs #8084
