### PR TITLE
fix(compression): rank codex-responses in adaptive-ladder maps

### DIFF
--- a/open-sse/services/compression/adaptiveCompression/ladder.ts
+++ b/open-sse/services/compression/adaptiveCompression/ladder.ts
@@ -25,8 +25,8 @@ export const DEFAULT_LADDER: LadderStage[] = [
  * engines that ship in `open-sse/services/compression/engines/index.ts` but are not part
  * of DEFAULT_LADDER: `ccr` and `llmlingua` are intentionally excluded from the AUTOMATIC
  * ladder (see DEFAULT_LADDER doc comment) yet must still rank correctly when an operator
- * adds them via `ladderOverride` — same for `ionizer`, `relevance`, `llm`, and
- * `read-lifecycle`. Placement follows each engine's documented `stackPriority` in
+ * adds them via `ladderOverride` — same for `ionizer`, `relevance`, `llm`, `read-lifecycle`,
+ * and `codex-responses`. Placement follows each engine's documented `stackPriority` in
  * `engineCatalog.ts` / its own module header, interpolated onto the existing 7-tier scale
  * (the `lite` exception — ranked after `headroom` despite a lower stackPriority — is a
  * pre-existing, deliberate design call and is left untouched).
@@ -36,6 +36,7 @@ const AGGRESSIVENESS: Record<string, number> = {
   "session-dedup": 10, // stackPriority 3 — lossless cross-turn dedup
   ccr: 15, // stackPriority 4 — reversible retrieval marker, only if it shrinks
   rtk: 20, // stackPriority 10 — command-output filtering
+  "codex-responses": 22, // stackPriority 12 (#8010) — conservative Responses tool-output compression
   ionizer: 25, // stackPriority 13 — tabular row sampling (lighter than headroom)
   headroom: 30, // stackPriority 15 — tabular JSON compaction
   lite: 40, // pri 5, but cheap prose pass (pre-existing reorder, kept as-is)
@@ -64,6 +65,7 @@ const REDUCTION_FACTOR: Record<string, number> = {
   "session-dedup": 0.95,
   ccr: 0.9, // conservative: only replaces a block when the marker is shorter than it
   rtk: 0.85,
+  "codex-responses": 0.84, // stackPriority 12 (#8010) — lossless-first, bounded diagnostic trims
   ionizer: 0.83, // row sampling, lighter than headroom's full tabular compaction
   headroom: 0.8,
   lite: 0.92,


### PR DESCRIPTION
## Root cause

#8010 registered the `codex-responses` compression engine in the catalog
(`open-sse/services/compression/engineCatalog.ts`, `stackPriority: 12`,
sitting between `rtk` at 10 and `headroom` at 15) but never added a
corresponding entry to `open-sse/services/compression/adaptiveCompression/ladder.ts`'s
`AGGRESSIVENESS` and `REDUCTION_FACTOR` maps.

That file's own header comment documents that these two maps must cover
every real registered catalog/registry engine, not just the 7 shipped in
`DEFAULT_LADDER` — because any engine missing from them silently falls
back to `aggressivenessOf() === 0` (indistinguishable from `"off"`) and
`expectedReductionFactor() === 0.9` (the generic fallback), which breaks
floor-mode escalation ranking for any ladder (default or `ladderOverride`)
that includes it.

## Fix

Add `"codex-responses"` to both maps, positioned between `rtk` and
`ionizer` to preserve the existing stackPriority-consistent interpolation
(`rtk` stackPriority 10 → `ionizer` stackPriority 13, with codex-responses
at 12 in between):

- `AGGRESSIVENESS["codex-responses"] = 22` (between rtk's 20 and ionizer's 25)
- `REDUCTION_FACTOR["codex-responses"] = 0.84` (between rtk's 0.85 and
  ionizer's 0.83), reflecting the "lossless-first, bounded diagnostic
  compression" guidance already documented for this engine in
  `engineCatalog.ts`

Also updated the maps' header comment, which explicitly names the
non-`DEFAULT_LADDER` engines that require interpolation, to include
`codex-responses`.

## Validation (TDD, red → green)

`tests/unit/ladder-engine-maps-6533.test.ts` drives its assertions from
the real registered engine catalog (`listCompressionEngines()`), so it
already had failing coverage for this gap:

**Before fix:**
```
✖ every registered catalog engine has an aggressivenessOf() rank above the 'off' default
  AssertionError: engine "codex-responses" must rank above "off" (got 0)
✖ every registered catalog engine has a non-default expectedReductionFactor()
  AssertionError: engine "codex-responses" must be rankable
ℹ pass 1  ℹ fail 2
```

**After fix:**
```
✔ every registered catalog engine has an aggressivenessOf() rank above the 'off' default
✔ every registered catalog engine has a non-default expectedReductionFactor()
✔ aggressivenessOf ranks are internally consistent with described engine severity
ℹ pass 3  ℹ fail 0
```

Sanity-checked neighboring suites (both green, unaffected):
- `tests/unit/compression-exclusions.test.ts` (8/8 pass)
- `tests/unit/compression/adaptive-resolve-plan.test.ts` (10/10 pass)

`npx eslint` on the touched file reports no issues.

Refs #8010