### PR TITLE
fix(sse): gate reasoning-placeholder strip to chunks that contain the sentinel

### DIFF
--- a/open-sse/utils/reasoningPlaceholder.ts
+++ b/open-sse/utils/reasoningPlaceholder.ts
@@ -16,5 +16,6 @@ export function isInternalReasoningPlaceholder(value: unknown): boolean {
  * meaningful remains so callers can skip emission entirely.
  */
 export function stripInternalReasoningPlaceholder(value: string): string {
+  if (!value.includes(NON_ANTHROPIC_THINKING_PLACEHOLDER)) return value;
   return value.replaceAll(NON_ANTHROPIC_THINKING_PLACEHOLDER, "").trim();
 }

--- a/tests/unit/translator-resp-openai-to-claude.test.ts
+++ b/tests/unit/translator-resp-openai-to-claude.test.ts
@@ -166,6 +166,63 @@ test("OpenAI stream: placeholder-only content bundled with finish_reason still e
   );
 });
 
+test("OpenAI stream: multi-chunk content without the placeholder passes through byte-identical, boundary whitespace preserved (#8162 regression)", () => {
+  // Regression guard for the unconditional `.trim()` in
+  // stripInternalReasoningPlaceholder (#8162, port of #8081): when a chunk's
+  // content does NOT contain the sentinel, the function must be a no-op —
+  // including leading/trailing whitespace, which is a real word boundary
+  // between streaming fragments. Trimming it glues adjacent chunks together
+  // (e.g. "Hello, " + "world." + " Bye." -> "Hello,world.Bye.").
+  const state = createState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-space1",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "Hello, " }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-space1",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "world." }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk3 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-space1",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: " Bye." }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk4 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-space1",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 3, completion_tokens: 5, total_tokens: 8 },
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2, chunk3, chunk4]);
+
+  const textDeltas = result.filter(
+    (event) => event.type === "content_block_delta" && event.delta?.type === "text_delta"
+  );
+  // Each chunk's delta text must be emitted verbatim — no per-chunk trimming.
+  assert.deepEqual(
+    textDeltas.map((event) => event.delta.text),
+    ["Hello, ", "world.", " Bye."]
+  );
+  assert.equal(
+    textDeltas.map((event) => event.delta.text).join(""),
+    "Hello, world. Bye."
+  );
+});
+
 test("OpenAI stream: tool calls strip Claude OAuth prefix and keep cache usage", () => {
   const state = createState();
   const started = openaiToClaudeResponse(


### PR DESCRIPTION
## Root cause

`#8162` (port of `#8081`) added `open-sse/utils/reasoningPlaceholder.ts::stripInternalReasoningPlaceholder()` with an **unconditional** `.trim()`:

```ts
export function stripInternalReasoningPlaceholder(value: string): string {
  return value.replaceAll(NON_ANTHROPIC_THINKING_PLACEHOLDER, "").trim();
}
```

This function is called on every **streaming** `delta.content` chunk at 3 call-sites:

- `open-sse/translator/response/openai-to-claude.ts:219`
- `open-sse/translator/response/openai-responses.ts:205`
- `open-sse/transformer/responsesTransformer.ts:546`

In a streamed response, leading/trailing whitespace at a chunk boundary is a real word boundary between fragments (e.g. `"Hello, "` + `"world."` + `" Bye."`). The unconditional `.trim()` eats that boundary whitespace on **every** chunk, regardless of whether the placeholder sentinel was even present, so adjacent chunks get glued together client-side:

```
"Hello, " + "world." + " Bye."  ->  "Hello,world.Bye."
```

instead of the correct `"Hello, world. Bye."`. This affects any OpenAI-shaped stream translated to Claude, or any stream passing through `responsesTransformer.ts`.

The pre-existing regression guard `tests/unit/streaming-reasoning-dedup-5786.test.ts` ("#5786 (A-guard) a well-behaved stream ... passed through UNCHANGED") caught this exactly — it was **RED** on `release/v3.8.49` before this fix.

## Fix

Gate the strip on `.includes()` first, so the function is a true no-op when the sentinel is absent from the chunk (the common case for ordinary streaming content):

```ts
export function stripInternalReasoningPlaceholder(value: string): string {
  if (!value.includes(NON_ANTHROPIC_THINKING_PLACEHOLDER)) return value;
  return value.replaceAll(NON_ANTHROPIC_THINKING_PLACEHOLDER, "").trim();
}
```

Behavior when the sentinel **is** present is unchanged (still stripped + trimmed, same as `#8081`/`#8162` intended). Only the single shared utility function was touched — none of the 3 call-sites or `open-sse/handlers/responseSanitizer.ts` were modified.

## Validation

TDD, per Hard Rule #18. All commands run with `env -u OMNIROUTE_API_KEY node --import tsx/esm --test <file>`.

**`tests/unit/streaming-reasoning-dedup-5786.test.ts`** (pre-existing regression guard for the exact bug):
- Before fix: `3 pass / 1 fail` — `#5786 (A-guard)` failed with `actual: 'Hello,world.Bye.'` vs `expected: 'Hello, world. Bye.'`.
- After fix: `4 pass / 0 fail`.

**`tests/unit/translator-resp-openai-to-claude.test.ts`** (new test added: `multi-chunk content without the placeholder passes through byte-identical, boundary whitespace preserved (#8162 regression)` — exercises call-site 1 directly at the unit level):
- Before fix (confirmed by temporarily reverting only the guard line, not stashing): `12 pass / 1 fail` — new test failed with `actual: ['Hello,', 'world.', 'Bye.']` vs `expected: ['Hello, ', 'world.', ' Bye.']`.
- After fix: `13 pass / 0 fail`.

**No-regression sweep** — every other suite exercising the shared placeholder utility (covers call-site 3 / `responsesTransformer.ts`, and `responseSanitizer.ts`'s non-streaming call-sites), same pass count before and after the fix:
- `tests/unit/responses-transformer.test.ts`: `17/17` both before and after.
- `tests/unit/responses-transformer-dense-output.test.ts`: `3/3` both before and after.
- `tests/unit/response-sanitizer.test.ts`, `responsesanitizer-reasoning-split.test.ts`, `strip-reasoning-header.test.ts`, `textual-toolcall-sanitizer-false-positive.test.ts`, `moonshot-k3.test.ts`, `tool-request-sanitization.test.ts`, `reasoning-cache.test.ts` (combined): `160/160` after fix.

Quality gates on the touched files:
- `npx eslint open-sse/utils/reasoningPlaceholder.ts tests/unit/translator-resp-openai-to-claude.test.ts --suppressions-location config/quality/eslint-suppressions.json` — clean (the file's 14 pre-existing `no-explicit-any` suppressions are unrelated to this change and shift line numbers only).
- `npm run typecheck:core` — clean.

## Impact

Any OpenAI-shaped provider streamed and translated to a Claude-format client (`openai-to-claude.ts`), any OpenAI Responses-API stream translated to Claude (`openai-responses.ts`), or any stream passing through the Responses-API transformer (`responsesTransformer.ts`) — whenever a `delta.content` chunk boundary lands on a space, the space was silently dropped and adjacent words were glued together in the client-visible output. No placeholder sentinel needs to be present for the bug to trigger; it fires on ordinary streaming content.

Refs #8162
Refs #8081
