### PR TITLE
fix(resilience): keep GitHub Copilot no_refresh_token self-heal reachable past the terminal-status skip

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -405,8 +405,23 @@ export async function checkConnection(conn) {
   // CPU and network on every sweep cycle. Mirrors isTerminalConnectionStatus
   // in src/sse/services/auth.ts and TERMINAL_CONNECTION_STATUSES in
   // src/lib/quota/connectionRecovery.ts.
+  //
+  // #5326 exception: a GitHub Copilot access-token-only connection parked in
+  // "expired" with errorCode "no_refresh_token" is NOT actually terminal — it's
+  // the exact target of the self-heal below (canClearGitHubNoRefreshTokenState),
+  // which clears that stale status back to "active" once the Copilot sub-token
+  // proves usable. Treating it as terminal here made that self-heal unreachable,
+  // leaving healthy Copilot connections stuck at "expired" forever.
+  const isRecoverableGithubCopilotNoRefresh =
+    conn.testStatus === "expired" &&
+    conn.errorCode === "no_refresh_token" &&
+    isGitHubAccessTokenOnlyConnection(conn);
   const terminalStatuses = new Set(["credits_exhausted", "banned", "expired"]);
-  if (typeof conn.testStatus === "string" && terminalStatuses.has(conn.testStatus.toLowerCase())) {
+  if (
+    typeof conn.testStatus === "string" &&
+    terminalStatuses.has(conn.testStatus.toLowerCase()) &&
+    !isRecoverableGithubCopilotNoRefresh
+  ) {
     return;
   }
 

--- a/tests/unit/token-health-no-refresh-token-expired-5326.test.ts
+++ b/tests/unit/token-health-no-refresh-token-expired-5326.test.ts
@@ -174,3 +174,44 @@ test("checkConnection clears stale no_refresh_token state for usable GitHub Copi
   assert.equal(updated?.lastError ?? null, null);
   assert.ok(updated?.lastHealthCheckAt);
 });
+
+// Boundary regression for #8182 vs #5326: the terminal-skip guard added by #8182
+// must keep skipping a GitHub Copilot connection that is "expired" for a DIFFERENT
+// reason than the recoverable no_refresh_token self-heal above (e.g. a manually
+// banned/invalidated account). Only the EXACT no_refresh_token shape is exempted
+// from the terminal skip — this proves the #5326 fix did not reopen #8182's
+// wasted-probe fix for every "expired" GitHub connection.
+test("checkConnection still skips a GitHub Copilot connection expired for a non-no_refresh_token reason (#8182 boundary)", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "github",
+    authType: "oauth",
+    name: "GitHub Genuinely Expired Account",
+    accessToken: "github-access-token",
+    refreshToken: null,
+    providerSpecificData: {
+      copilotToken: "copilot-token",
+      copilotTokenExpiresAt: Math.floor((Date.now() + 60 * 60 * 1000) / 1000),
+    },
+    testStatus: "expired",
+    errorCode: "invalid_grant",
+    lastError: "Manually invalidated by operator.",
+    isActive: true,
+  });
+
+  await tokenHealthCheck.checkConnection(connection);
+
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
+  assert.equal(
+    updated?.testStatus,
+    "expired",
+    "terminal-skip must still apply outside the exact no_refresh_token shape"
+  );
+  assert.equal(updated?.errorCode, "invalid_grant");
+  assert.equal(
+    updated?.lastHealthCheckAt ?? null,
+    null,
+    "checkConnection must return early without touching the row at all"
+  );
+});


### PR DESCRIPTION
## Root cause

99ad15a37f (#8182 / #8286) added a terminal-connection guard in
`checkConnection()` (`src/lib/tokenHealthCheck.ts`) that returns early
for any `testStatus` in `{credits_exhausted, banned, expired}`, to stop
the sweep from wasting CPU/network on connections that can never
self-heal via a token refresh.

But `testStatus="expired"` + `errorCode="no_refresh_token"` is exactly
the state the **pre-existing** GitHub Copilot self-heal targets
(`isGitHubAccessTokenOnlyConnection` + `canClearGitHubNoRefreshTokenState`,
same file, ~lines 83-97 / 413-492): a Copilot connection with no OAuth
refresh token but a still-valid `copilotToken`, which the sweep is
supposed to flip back to `"active"` once the Copilot sub-token proves
usable. With the new guard placed unconditionally ahead of that block,
the self-heal became unreachable for exactly the state it exists to
clear.

**Impact**: healthy GitHub Copilot connections that once lost their
OAuth refresh token got stuck at `testStatus="expired"` in the
dashboard forever, even though their Copilot sub-token kept working
and the sweep would have cleared the stale status back to `"active"`
every cycle before #8182.

## Fix

Carve out the exact recoverable shape from the terminal-skip guard:

```ts
const isRecoverableGithubCopilotNoRefresh =
  conn.testStatus === "expired" &&
  conn.errorCode === "no_refresh_token" &&
  isGitHubAccessTokenOnlyConnection(conn);
```

and require `!isRecoverableGithubCopilotNoRefresh` in the early-return
condition. `isGitHubAccessTokenOnlyConnection` was already defined in
this file (no new import). Every other terminal case — `credits_exhausted`,
`banned`, and `expired` for any *other* reason — is still skipped
untouched, matching #8182's original intent.

## Validation (TDD)

`tests/unit/token-health-no-refresh-token-expired-5326.test.ts` was
**red before the fix** (1 fail / 4 pass):

- `checkConnection clears stale no_refresh_token state for usable
  GitHub Copilot connections` — asserted `testStatus` flips back to
  `"active"`, got `"expired"`.

**Green after the fix** (6/6 — added one boundary test):

- Added `checkConnection still skips a GitHub Copilot connection
  expired for a non-no_refresh_token reason (#8182 boundary)` — proves
  the exception is scoped tightly: a GitHub Copilot connection expired
  for a *different* reason (e.g. `errorCode: "invalid_grant"`, manually
  banned) is still skipped and left completely untouched
  (`lastHealthCheckAt` stays `null`), so #8182's original fix is not
  reopened for the general case.

Also reran every other `checkConnection`/`tokenHealthCheck`-adjacent
suite sequentially (`env -u OMNIROUTE_API_KEY`) to confirm no
regression in #8182's own behavior (it shipped without a dedicated
test file — confirmed via `git show --stat 99ad15a37f`, 11 lines added
to `tokenHealthCheck.ts` only):

- `tests/unit/token-health-check.test.ts` — 9/9
- `tests/unit/token-health-check-circuit-breaker.test.ts` — 7/7
- `tests/unit/apikey-connection-health-check.test.ts` — 5/5
- `tests/unit/token-health-check-sweep.test.ts`,
  `token-health-check-tickms-defined.test.ts`,
  `tokenHealthCheck-batchSize.test.ts`,
  `codex-oauth-refresh-persist-6352.test.ts`,
  `oauth-providers-error-handling.test.ts` — 25/25 combined

`npm run typecheck:core` — clean.

Refs #8182
Refs #8286
Refs #5326