### PR TITLE
fix(sse): repair orphaned PROVIDER_BREAKER_FAILURE_STATUSES reference on the all-rate-limited path

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -75,6 +75,7 @@ import {
 } from "./chatHelpers";
 import {
   isAntigravityMissingProjectError,
+  PROVIDER_BREAKER_FAILURE_STATUSES,
   shouldTripProviderBreakerForResult,
 } from "./chatPredicates";
 import { connectionHasExtraKeys } from "@omniroute/open-sse/services/apiKeyRotator.ts";

--- a/src/sse/handlers/chatPredicates.ts
+++ b/src/sse/handlers/chatPredicates.ts
@@ -1,7 +1,7 @@
 import { isLocalStreamLifecycleError } from "../../shared/utils/circuitBreaker";
 import { isRequestScopedUpstreamFailure } from "./comboFailureLogging";
 
-const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504]);
+export const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504]);
 
 // #7907/#7908: single-model breaker trip bypasses the `isFailure` option (only applies
 // inside `breaker.execute()`), so it needs its own `isLocalStreamLifecycleError` guard —

--- a/tests/unit/nvidia-quota-phase1.test.ts
+++ b/tests/unit/nvidia-quota-phase1.test.ts
@@ -214,16 +214,19 @@ test("semaphore.getStats reflects nvidia's per-connection gate key", async () =>
 // ── Failure-mode separation regression guard ────────────────────────────────
 
 test("nvidia 429 does not trip the provider circuit breaker (unchanged 408/500/502/503/504-only classification)", () => {
-  // This PR does not touch src/sse/handlers/chat.ts or the circuit breaker — this
-  // is a documentation-alignment guard proving Phase 1 didn't accidentally widen
+  // This PR does not touch the circuit breaker classification — this is a
+  // documentation-alignment guard proving Phase 1 didn't accidentally widen
   // PROVIDER_BREAKER_FAILURE_STATUSES to include 429 (which would collapse the
   // per-model lockout this PR adds into a whole-connection/provider outage).
+  // #8013 extracted the const from src/sse/handlers/chat.ts into chatPredicates.ts
+  // (still consumed by chat.ts's breaker paths) — read the declaration from its
+  // current home.
   const chatHandlerPath = path.join(
     process.cwd(),
     "src",
     "sse",
     "handlers",
-    "chat.ts"
+    "chatPredicates.ts"
   );
   const source = fs.readFileSync(chatHandlerPath, "utf8");
   const match = source.match(/PROVIDER_BREAKER_FAILURE_STATUSES\s*=\s*new Set\(\[([^\]]+)\]\)/);


### PR DESCRIPTION
## Root cause

#8013 extracted `shouldTripProviderBreakerForResult()` from `src/sse/handlers/chat.ts` into the new `src/sse/handlers/chatPredicates.ts`, taking the (non-exported) `const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504])` with it.

A second, independent use of that const survived in `chat.ts`'s `handleSingleModelChat()`, in the "all credentials rate-limited" block (~line 1340):

```ts
if (!forceLiveComboTest && credentials?.allRateLimited && PROVIDER_BREAKER_FAILURE_STATUSES.has(breakerFailureStatus)) {
  breaker._onFailure();
}
```

The extraction removed the local declaration but left this second reference behind, orphaned.

## Production impact

Any request where every credential for a provider+model is simultaneously rate-limited hits `ReferenceError: PROVIDER_BREAKER_FAILURE_STATUSES is not defined` at runtime in this code path. Concretely:

- `breaker._onFailure()` was unreachable on the all-rate-limited path — the provider circuit breaker could never trip from it.
- The uncaught `ReferenceError` propagated up and got mapped to a generic `502`, masking the real `503` upstream-unavailable status in combo responses.
- The issue-agent route surfaced a generic `400` instead of the actual `429` provider-rate-limited response.

This sits in the central chat resilience path (`handleSingleModelChat`), so it fires for any provider whenever all of its credentials are simultaneously cooling down — not an edge case.

## Fix

Two-line production fix, no behavior change:

- `src/sse/handlers/chatPredicates.ts`: export `PROVIDER_BREAKER_FAILURE_STATUSES`.
- `src/sse/handlers/chat.ts`: add it to the existing import block from `./chatPredicates`.

The classification set (`[408, 500, 502, 503, 504]`) is unchanged — this only repairs the broken reference.

Also re-points `tests/unit/nvidia-quota-phase1.test.ts`'s regex-based declaration check at `chatPredicates.ts`, where the const now actually lives (it previously read `chat.ts` via fs+regex and silently failed to find the declaration — a stale test left behind by the same #8013 extraction). The regex and the classification assertions are unchanged; the test still proves `429` is excluded from the whole-provider breaker.

## Validation (TDD — red before fix, green after)

All 6 affected files run sequentially with `env -u OMNIROUTE_API_KEY`:

| Test file | Before | After |
| --- | --- | --- |
| `tests/unit/chat-rate-limit-body-lock.test.ts` | 0/2 (2 `ReferenceError`) | 2/2 |
| `tests/unit/chat-cooldown-aware-retry.test.ts` | 4/6 (2 `ReferenceError`) | 6/6 |
| `tests/unit/chat-combo-live-test.test.ts` | 4/5 (1 `ReferenceError`) | 5/5 |
| `tests/unit/chat-route-coverage.test.ts` | 12/15 (503→502 masked + 2 `ReferenceError`) | 15/15 |
| `tests/unit/issue-agent-route-execution.test.ts` | 1/2 (400 instead of 429) | 2/2 |
| `tests/unit/nvidia-quota-phase1.test.ts` | 12/13 (regex found no declaration) | 13/13 |
| **Total** | **33/43** | **43/43** |

Also verified:
- `npm run typecheck:core` — clean.
- `npx eslint` on the 3 changed files — clean.
- Adjacent `tests/unit/combo-breaker-429.test.ts` (uses a deliberately independent, locally-declared const of the same name in `open-sse/services/combo/comboPredicates.ts`, to avoid an `open-sse` → `src/sse` import cycle) — unaffected, still 9/9 green. Confirms this fix is contained to the orphaned single-model path and does not touch the separate combo-layer classification.

Refs #8013