### PR TITLE
fix(sse): scope auto-combo no-auth allowlist to tier pools, family combos keep every family backend

### DIFF
--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -143,11 +143,23 @@ const SYNTHETIC_NOAUTH_CONNECTION_ID = "noauth";
 // and the others are unreliable. The excluded providers stay fully usable via
 // direct `<alias>/<model>` calls — they are just kept OUT of auto-routing until
 // re-verified. Re-add an id here to bring it back into every auto/* pool.
+//
+// Scope (operator decision 2026-07-24, refs #8183/#6453/#7032): this allowlist
+// targets public-HTTP-egress reliability for the category/tier and flat-variant
+// `auto/*` pools (auto/best-free, auto/coding:fast, ...). It does NOT apply to
+// `auto/<family>` pools (auto/glm, auto/zai, ...) — a family combo is an
+// identity selector ("whatever genuinely serves GLM"), not a reliability-curated
+// pool, so it admits any no-auth backend that genuinely serves the family (e.g.
+// auggie, a local CLI subprocess with zero HTTP egress, belongs in auto/glm
+// regardless of this list). See the `bypassAllowlist` param below.
 const AUTO_COMBO_NOAUTH_ALLOWLIST = new Set<string>(["opencode", "felo-web"]);
 
-function isChatAutoComboNoAuthProvider(providerDef: NoAuthProviderDefinition): boolean {
+function isChatAutoComboNoAuthProvider(
+  providerDef: NoAuthProviderDefinition,
+  bypassAllowlist: boolean
+): boolean {
   if (providerDef.noAuth !== true) return false;
-  if (!AUTO_COMBO_NOAUTH_ALLOWLIST.has(providerDef.id)) return false;
+  if (!bypassAllowlist && !AUTO_COMBO_NOAUTH_ALLOWLIST.has(providerDef.id)) return false;
   if (!Array.isArray(providerDef.serviceKinds) || providerDef.serviceKinds.length === 0)
     return true;
   return providerDef.serviceKinds.includes("llm");
@@ -158,13 +170,14 @@ function getNoAuthCandidates(
   blockedProviders: Set<string>,
   disabledNoAuthProviders: Set<string>,
   noAuthProviderSpecificData: Map<string, Record<string, unknown> | null | undefined>,
-  hiddenModelsMap: Map<string, Set<string>>
+  hiddenModelsMap: Map<string, Set<string>>,
+  bypassAllowlist: boolean
 ): VirtualAutoComboCandidate[] {
   const registry = getProviderRegistry();
   const candidates: VirtualAutoComboCandidate[] = [];
 
   for (const providerDef of Object.values(NOAUTH_PROVIDERS) as NoAuthProviderDefinition[]) {
-    if (!isChatAutoComboNoAuthProvider(providerDef)) continue;
+    if (!isChatAutoComboNoAuthProvider(providerDef, bypassAllowlist)) continue;
 
     const providerId = providerDef.id;
     if (!providerId || excludedProviders.has(providerId)) continue;
@@ -386,7 +399,13 @@ export async function createVirtualAutoCombo(
       blockedProviders,
       disabledNoAuthProviders,
       noAuthProviderSpecificData,
-      hiddenModelsMap
+      hiddenModelsMap,
+      // #6453/#8183 (operator decision 2026-07-24): auto/<family> combos are an
+      // identity selector, not a reliability-curated pool — bypass the no-auth
+      // allowlist gate so any backend that genuinely serves the family (e.g.
+      // auggie for auto/glm) is admitted. Category/tier and flat-variant pools
+      // (spec.family unset) keep the allowlist gate intact.
+      Boolean(spec?.family)
     )
   );
 


### PR DESCRIPTION
## Root cause

`AUTO_COMBO_NOAUTH_ALLOWLIST` (#8183) gates no-auth (keyless) providers out of every `auto/*` candidate pool, narrowed to `opencode`/`felo-web` after verifying the others were flaky on the reference egress (VPS .15). The gate (`isChatAutoComboNoAuthProvider()` → `getNoAuthCandidates()`) runs unconditionally inside `createVirtualAutoCombo()`, **before** any category/tier or family narrowing is applied — so it silently also excluded no-auth backends from `auto/<family>` pools (#6453). #8183's own regression tests (`noauth-autocombo-allowlist.test.ts`, `virtual-auto-combo.test.ts`) never called `createVirtualAutoCombo` with a `family` spec, so this never surfaced.

`auggie` (a fully local CLI subprocess — `auggie://cli/stdio`, zero HTTP egress, so the reliability concern #8183 targets doesn't even apply to it) advertises a literal `glm-5.2` model in its registry and had an explicit seat in the `auto/glm` pool by design since #7032. #8183 silently dropped it, which `tests/unit/autoCombo/provider-family-combos.test.ts:136` caught as a regression (`assert.deepEqual(providerIds, ["auggie", "glm", "zai"])`).

## Decision

Operator decision (2026-07-24): `auto/<family>` (`auto/glm`, `auto/zai`, ...) is an identity selector — "route to whatever genuinely serves this family" — not a reliability-curated pool. The no-auth allowlist gate:
- **stays intact** for category/tier and flat-variant `auto/*` pools (`auto/best-free`, `auto/coding:fast`, `auto/best-coding`, ...).
- **is bypassed** for `auto/<family>` pools — any no-auth backend that genuinely serves the family is admitted.

## Fix

`open-sse/services/autoCombo/virtualFactory.ts`: threaded a `bypassAllowlist: boolean` parameter through `isChatAutoComboNoAuthProvider()` and `getNoAuthCandidates()`, set to `Boolean(spec?.family)` at the single call site in `createVirtualAutoCombo()`. The existing family candidate filter (`buildFamilyCandidateFilter`) still runs immediately afterward, so a bypassed no-auth candidate only survives in the final pool if its model actually belongs to the requested family — a bypassed candidate from an unrelated family is filtered right back out. Added inline comments documenting the scope/decision at both the allowlist definition and the call site.

## Validation

- **TDD**: `tests/unit/autoCombo/provider-family-combos.test.ts:136` was red (expected `["auggie","glm","zai"]`, got `["glm","zai"]`) before the fix — green (11/11 passing) after.
- `tests/unit/noauth-autocombo-allowlist.test.ts` (3/3) and `tests/unit/virtual-auto-combo.test.ts` (10/10, including "restricts the no-auth pool to the allowlist") stay green — the #8183 gate is verified untouched for spec-less / category-tier pools (none of these call sites pass a `family` spec).
- Full `tests/unit/autoCombo/` vitest sweep: 5 files, 36/36 passing.
- `npm run typecheck:core` clean.
- `npx eslint` / `npx prettier --check` clean on the touched file.
- 4 failures in `tests/unit/auto-combo-credentialed-model-pool.test.ts` were investigated and confirmed **pre-existing** on `origin/release/v3.8.49` (reproduced against the unmodified file via `git show HEAD:<path>`, no `git stash` used) — unrelated `antigravity`/`gemini-3.5` credentialed-pool logic, untouched by this change.

```
env -u OMNIROUTE_API_KEY npx vitest run --config vitest.mcp.config.ts tests/unit/autoCombo/provider-family-combos.test.ts
env -u OMNIROUTE_API_KEY node --import tsx/esm --test tests/unit/noauth-autocombo-allowlist.test.ts
env -u OMNIROUTE_API_KEY node --import tsx/esm --test tests/unit/virtual-auto-combo.test.ts
env -u OMNIROUTE_API_KEY npx vitest run --config vitest.mcp.config.ts tests/unit/autoCombo/
npm run typecheck:core
```

Refs #8183, Refs #6453, Refs #7032