### PR TITLE
fix(api): accept a missing status query-param on GET /api/plugins instead of rejecting null with Invalid status value (#8374)

### DIFF
--- a/changelog.d/fixes/8374-plugins-status-optional.md
+++ b/changelog.d/fixes/8374-plugins-status-optional.md
@@ -1,0 +1,1 @@
+- fix(api): accept a missing status query-param on GET /api/plugins instead of rejecting null with Invalid status value (#8374)

--- a/src/app/api/plugins/route.ts
+++ b/src/app/api/plugins/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
   const authError = await requireManagementAuth(request);
   if (authError) return authError;
   const url = new URL(request.url);
-  const statusResult = StatusSchema.safeParse(url.searchParams.get("status"));
+  const statusResult = StatusSchema.safeParse(url.searchParams.get("status") ?? undefined);
   if (!statusResult.success) {
     return NextResponse.json(
       { error: "Invalid status value", details: statusResult.error.issues },

--- a/tests/unit/8374-plugins-status-optional.test.ts
+++ b/tests/unit/8374-plugins-status-optional.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for #8374 — GET /api/plugins returns "Invalid status value"
+ * when no `?status=` filter is passed.
+ *
+ * Root cause: `URLSearchParams.get("status")` returns `null` (not `undefined`)
+ * when the query param is absent. `z.enum([...]).optional()` widens the schema
+ * to accept `undefined`, but NOT `null` — so `safeParse(null)` fails and the
+ * route returns HTTP 400, even though the caller passed no filter at all.
+ *
+ * Fix: coerce `null` -> `undefined` before handing it to Zod, matching the
+ * repo's own established idiom (see registered-keys/route.ts,
+ * suggested-models/route.ts, quota/preview/route.ts).
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// Hermetic DB: isolate from the shared dev DATA_DIR so this test never
+// touches or depends on real plugin rows, and so a fresh install has no
+// configured password (isAuthRequired() -> false -> GET reachable directly).
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-plugins-8374-"));
+const originalDataDir = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const pluginsDb = await import("../../src/lib/db/plugins.ts");
+const { GET } = await import("../../src/app/api/plugins/route.ts");
+
+before(() => {
+  pluginsDb.insertPlugin({
+    id: "test-plugin-8374",
+    name: "test-plugin-8374",
+    version: "1.0.0",
+    main: "index.js",
+    manifest: {},
+    status: "active",
+    pluginDir: "/tmp/test-plugin-8374",
+  });
+});
+
+after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+test("BUG #8374: GET /api/plugins with no ?status= returns 200, not 400", async () => {
+  // @ts-ignore - handler accepts NextRequest at runtime
+  const req = new NextRequest("http://localhost:3000/api/plugins");
+  const res = await GET(req);
+  const body = await res.json();
+  assert.equal(res.status, 200, `expected 200, got ${res.status}: ${JSON.stringify(body)}`);
+  assert.ok(Array.isArray(body.plugins), "response body must contain a plugins array");
+});
+
+test("GET /api/plugins with a valid ?status= filter still works and filters", async () => {
+  // @ts-ignore
+  const req = new NextRequest("http://localhost:3000/api/plugins?status=active");
+  const res = await GET(req);
+  const body = await res.json();
+  assert.equal(res.status, 200);
+  assert.ok(
+    body.plugins.every((p: { status: string }) => p.status === "active"),
+    "all returned plugins must have the requested status"
+  );
+  assert.ok(
+    body.plugins.some((p: { id: string }) => p.id === "test-plugin-8374"),
+    "the seeded active plugin must be present in the filtered result"
+  );
+});
+
+test("GET /api/plugins with an invalid ?status= still returns 400", async () => {
+  // @ts-ignore
+  const req = new NextRequest("http://localhost:3000/api/plugins?status=bogus");
+  const res = await GET(req);
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.error, "Invalid status value");
+});


### PR DESCRIPTION
Closes #8374

## Root cause
`GET /api/plugins` rejected the exact call the plugins page makes after a scan (no `?status=` at all). `URLSearchParams.get("status")` returns `null` when the param is absent; `z.enum([...]).optional()` widens the schema to accept `undefined` but NOT `null` (zod v4 treats `.optional()` and `.nullable()` as distinct), so `safeParse(null)` failed and the route returned HTTP 400 `{"error":"Invalid status value", ...}` — byte-for-byte the body from the report.

The DB layer (`src/lib/db/plugins.ts`) is not implicated — `insertPlugin()` always stores a valid enum member. This is purely a query-param-to-Zod boundary bug in the route handler.

## Fix
One-line change in `src/app/api/plugins/route.ts`, matching the repo's own established idiom for this exact pitfall (already used in `v1/registered-keys/route.ts`, `v1/providers/suggested-models/route.ts`, `quota/preview/route.ts`):
```ts
const statusResult = StatusSchema.safeParse(url.searchParams.get("status") ?? undefined);
```

## TDD evidence (Hard Rule #18)
New permanent regression test `tests/unit/8374-plugins-status-optional.test.ts`:
- RED on unfixed code: `GET /api/plugins` with no `?status=` → 400 `AssertionError: expected 200, got 400`
- GREEN after the fix: same request → 200 with the plugins array
- Also asserts a valid `?status=active` filter still works/filters, and an invalid `?status=bogus` still 400s (no assertion weakened).

## Scope
Out of scope: the reporter's separate "plugin hooks not triggered" concern — a different subsystem (hook dispatch/loader), noted as a possible new issue, not folded into this fix.

## Gates run (all green)
- `node --import tsx/esm --test tests/unit/8374-plugins-status-optional.test.ts` — RED→GREEN
- Sibling tests: `tests/unit/plugins-route-error-sanitization.test.ts`, `tests/unit/plugins-api-routes.test.ts` — 38/38 pass
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` + `check-cognitive-complexity.mjs` — pre-existing baseline drift (2167/2130, 956/951) confirmed identical on a disposable probe worktree pinned to `origin/release/v3.8.49` — not introduced by this diff (single-line change, no new/changed function)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/app/api/plugins/route.ts tests/unit/8374-plugins-status-optional.test.ts` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK