### PR TITLE
fix(backend): stop prompt-cache affinity from silently reordering an explicit priority combo across models (#8370)

### DIFF
--- a/changelog.d/fixes/8370-priority-affinity-reorder.md
+++ b/changelog.d/fixes/8370-priority-affinity-reorder.md
@@ -1,0 +1,1 @@
+- fix(backend): stop prompt-cache affinity from silently reordering an explicit priority combo across models (#8370)

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -90,6 +90,7 @@ import {
   expandPromptCacheAffinityTargets,
   expandPromptCacheAffinityTargetsFromConnections,
   resolvePromptCacheAffinityKey,
+  shouldProtectOriginalFirst,
 } from "./combo/promptCacheAffinity.ts";
 import type { CompressionMode } from "./compression/types.ts";
 import { getCachedProviderConnections } from "../../src/lib/db/readCache";
@@ -1389,10 +1390,7 @@ export async function handleComboChat({
   );
   if (promptCacheAffinity.applied) {
     const protectedOriginal =
-      (_sticky.stuck ||
-        autoUsedExplicitRouter ||
-        strategy === "quota-share" ||
-        strategy === "weighted") &&
+      shouldProtectOriginalFirst(_sticky.stuck, autoUsedExplicitRouter, strategy) &&
       orderedTargets[0];
     const protectedFirst = protectedOriginal
       ? (promptCacheAffinity.targets.find(

--- a/open-sse/services/combo/promptCacheAffinity.ts
+++ b/open-sse/services/combo/promptCacheAffinity.ts
@@ -238,6 +238,34 @@ export function expandPromptCacheAffinityTargetsFromConnections(
 }
 
 /**
+ * #8370: decide whether the strategy-selected first target must be re-pinned
+ * ahead of a global, cross-model prompt-cache-affinity reorder.
+ *
+ * `priority`, `fill-first`, and `lkgp` are deterministic, operator-ordered
+ * strategies: their first target is a meaningful choice (explicit priority
+ * order, first-available slot, last-known-good pin) that a rendezvous-hash
+ * reorder must not silently override, even though affinity is still free to
+ * pick among the remaining/fallback targets. `quota-share` and `weighted`
+ * were already protected before this fix; session stickiness and an explicit
+ * auto-router pin remain independently protected via their own flags.
+ */
+export function shouldProtectOriginalFirst(
+  stickyStuck: boolean,
+  autoUsedExplicitRouter: boolean,
+  strategy: string
+): boolean {
+  return (
+    stickyStuck ||
+    autoUsedExplicitRouter ||
+    strategy === "quota-share" ||
+    strategy === "weighted" ||
+    strategy === "priority" ||
+    strategy === "fill-first" ||
+    strategy === "lkgp"
+  );
+}
+
+/**
  * Order eligible targets using rendezvous hashing. The original order is used
  * as the final tie-breaker, so targets sharing one account identity remain
  * stable without using modelStr as the affinity identity.

--- a/tests/unit/8370-priority-affinity-reorder.test.ts
+++ b/tests/unit/8370-priority-affinity-reorder.test.ts
@@ -1,0 +1,178 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyPromptCacheAffinity,
+  expandPromptCacheAffinityTargetsFromConnections,
+  shouldProtectOriginalFirst,
+} from "../../open-sse/services/combo/promptCacheAffinity.ts";
+import type { ResolvedComboTarget } from "../../open-sse/services/combo/types.ts";
+
+// #8370: a `priority` combo declares an explicit, operator-chosen model order.
+// Cross-model prompt-cache affinity (a global rendezvous-hash sort over the
+// fully expanded, model-blind target list) was silently reordering that
+// declaration, letting a lower-priority model's single account jump ahead of
+// every account belonging to the highest-priority model. This file is the
+// permanent regression guard for that fix (`shouldProtectOriginalFirst` in
+// `open-sse/services/combo/promptCacheAffinity.ts`, wired into
+// `open-sse/services/combo.ts`'s `protectedOriginal` gate).
+
+function modelTarget(
+  stepId: string,
+  modelStr: string,
+  provider: string,
+  allowedConnectionIds?: string[]
+): ResolvedComboTarget {
+  return {
+    kind: "model",
+    stepId,
+    executionKey: stepId,
+    modelStr,
+    provider,
+    providerId: null,
+    connectionId: null,
+    weight: 1,
+    label: null,
+    ...(allowedConnectionIds ? { allowedConnectionIds } : {}),
+  } as ResolvedComboTarget;
+}
+
+// Mirrors combo.ts's exact application of the fix: expand model-level targets
+// to concrete accounts, run affinity, then re-pin the strategy's declared
+// first target ahead of the affinity-sorted list when the strategy warrants it.
+function applyComboLikeAffinityPin(
+  orderedTargets: ResolvedComboTarget[],
+  connectionsByProvider: Map<string, Array<Record<string, unknown>>>,
+  body: Record<string, unknown>,
+  strategy: string
+): ResolvedComboTarget[] {
+  const expanded = expandPromptCacheAffinityTargetsFromConnections(
+    orderedTargets,
+    connectionsByProvider
+  );
+  const affinity = applyPromptCacheAffinity(expanded, body, true);
+  if (!affinity.applied) return affinity.targets;
+
+  const protectedOriginal = shouldProtectOriginalFirst(false, false, strategy) && orderedTargets[0];
+
+  const protectedFirst = protectedOriginal
+    ? (affinity.targets.find(
+        (target) =>
+          target === protectedOriginal ||
+          target.executionKey === protectedOriginal.executionKey ||
+          target.executionKey.startsWith(`${protectedOriginal.executionKey}@`)
+      ) ?? protectedOriginal)
+    : null;
+
+  return protectedFirst
+    ? [protectedFirst, ...affinity.targets.filter((target) => target !== protectedFirst)]
+    : affinity.targets;
+}
+
+function buildCrossModelScenario() {
+  // Model A (priority 1) has 5 accounts; models B and C (priority 2/3) have 1 each —
+  // mirrors the issue's reported 3-models-expanded-to-N-accounts shape.
+  const orderedTargets = [
+    modelTarget("step-a", "antigravity/gemini-3-pro", "antigravity"),
+    modelTarget("step-b", "ollamacloud/minimax-m3", "ollamacloud"),
+    modelTarget("step-c", "oc/deepseek-v4", "oc"),
+  ];
+  const connectionsByProvider = new Map<string, Array<Record<string, unknown>>>([
+    [
+      "antigravity",
+      [
+        { id: "antigravity-acct-1" },
+        { id: "antigravity-acct-2" },
+        { id: "antigravity-acct-3" },
+        { id: "antigravity-acct-4" },
+        { id: "antigravity-acct-5" },
+      ],
+    ],
+    ["ollamacloud", [{ id: "minimax-acct-1" }]],
+    ["oc", [{ id: "deepseek-acct-1" }]],
+  ]);
+  return { orderedTargets, connectionsByProvider };
+}
+
+// Brute-force a prompt_cache_key whose rendezvous winner is NOT one of model
+// A's accounts, so the bug (if unfixed) is guaranteed to reproduce rather
+// than passing by chance of the hash landing on model A anyway.
+function findKeyThatWinsOutsideModelA(
+  connectionsByProvider: Map<string, Array<Record<string, unknown>>>,
+  orderedTargets: ResolvedComboTarget[]
+): string {
+  const expanded = expandPromptCacheAffinityTargetsFromConnections(
+    orderedTargets,
+    connectionsByProvider
+  );
+  for (let i = 0; i < 500; i++) {
+    const key = `probe-key-${i}`;
+    const ranked = applyPromptCacheAffinity(expanded, { prompt_cache_key: key }, true);
+    if (ranked.targets[0]?.provider !== "antigravity") return key;
+  }
+  throw new Error("could not find a probe key whose rendezvous winner is outside model A");
+}
+
+test("BUG #8370: priority combo keeps its declared model-1-first order despite cross-model affinity", () => {
+  const { orderedTargets, connectionsByProvider } = buildCrossModelScenario();
+  const key = findKeyThatWinsOutsideModelA(connectionsByProvider, orderedTargets);
+  const body = { prompt_cache_key: key };
+
+  // Sanity: without the fix's protection, raw affinity really does let a
+  // model B/C account win the global sort (proves the scenario reproduces).
+  const expanded = expandPromptCacheAffinityTargetsFromConnections(
+    orderedTargets,
+    connectionsByProvider
+  );
+  const rawAffinity = applyPromptCacheAffinity(expanded, body, true);
+  assert.notEqual(
+    rawAffinity.targets[0]?.provider,
+    "antigravity",
+    "test setup invariant: raw affinity must pick outside model A for this key"
+  );
+
+  const result = applyComboLikeAffinityPin(orderedTargets, connectionsByProvider, body, "priority");
+
+  assert.equal(
+    result[0]?.provider,
+    "antigravity",
+    "priority combo must keep its declared highest-priority model first, not the rendezvous winner"
+  );
+});
+
+test("shouldProtectOriginalFirst covers priority, fill-first, and lkgp", () => {
+  for (const strategy of ["priority", "fill-first", "lkgp"]) {
+    assert.equal(
+      shouldProtectOriginalFirst(false, false, strategy),
+      true,
+      `expected ${strategy} to be protected`
+    );
+  }
+});
+
+test("shouldProtectOriginalFirst still covers the pre-existing quota-share/weighted/sticky/auto-router cases", () => {
+  assert.equal(shouldProtectOriginalFirst(false, false, "quota-share"), true);
+  assert.equal(shouldProtectOriginalFirst(false, false, "weighted"), true);
+  assert.equal(shouldProtectOriginalFirst(true, false, "round-robin"), true);
+  assert.equal(shouldProtectOriginalFirst(false, true, "round-robin"), true);
+});
+
+test("round-robin combo is NOT protected — it still gets full cross-model affinity reordering", () => {
+  const { orderedTargets, connectionsByProvider } = buildCrossModelScenario();
+  const key = findKeyThatWinsOutsideModelA(connectionsByProvider, orderedTargets);
+  const body = { prompt_cache_key: key };
+
+  assert.equal(shouldProtectOriginalFirst(false, false, "round-robin"), false);
+
+  const result = applyComboLikeAffinityPin(
+    orderedTargets,
+    connectionsByProvider,
+    body,
+    "round-robin"
+  );
+
+  assert.notEqual(
+    result[0]?.provider,
+    "antigravity",
+    "round-robin combo must still let prompt-cache affinity pick the winning account across models"
+  );
+});


### PR DESCRIPTION
Closes #8370

## Root cause

`open-sse/services/combo.ts` runs cross-model prompt-cache affinity (`applyPromptCacheAffinity`) as a single global rendezvous-hash sort over the fully expanded, per-connection target list, spanning all configured models at once. The comparator only knows `connectionId`/`executionKey` — it never reads `modelStr`/`provider`. The `protectedOriginal` guard that re-pins the strategy-selected first target ahead of that hash-sorted list only covered `quota-share` and `weighted` (plus sticky/explicit-auto-router hits). `priority`, `fill-first`, and `lkgp` — all deterministic, operator-ordered strategies — were not in that list, so a `priority` combo's declared model order could be silently reshuffled: a lower-priority model's single account could jump ahead of every account belonging to the highest-priority model, exactly matching the reported `Trying model 1/13: ollamacloud/minimax-m3` despite the priority-1 model being healthy.

## Fix

Extracted the `protectedOriginal` predicate into a small, independently testable pure function — `shouldProtectOriginalFirst()` in `open-sse/services/combo/promptCacheAffinity.ts` — and extended it to also cover `priority`, `fill-first`, and `lkgp`, alongside the pre-existing `quota-share`/`weighted`/sticky/explicit-auto-router cases. `combo.ts` now calls this helper instead of inlining the boolean expression (net diff to the 3630-line `combo.ts` god-file: +2/-4 lines only — the predicate logic itself now lives in `promptCacheAffinity.ts`).

Prompt-cache affinity is still free to choose among the remaining/fallback targets (including which of the top-priority model's own accounts to prefer) — it just can no longer displace the strategy's declared top choice for these deterministic strategies.

## TDD evidence (Hard Rule #18)

New permanent regression file: `tests/unit/8370-priority-affinity-reorder.test.ts`.

- **RED on unfixed code**: ran the same test file against a disposable detached worktree pinned to `origin/release/v3.8.49` (no fix applied) — it fails immediately because `shouldProtectOriginalFirst` does not exist yet on that tip (`SyntaxError: ... does not provide an export named 'shouldProtectOriginalFirst'`), proving the fix code is genuinely new.
- **GREEN after fix**: all 4 new tests pass, including the core repro — a 3-model priority combo (5 accounts on model A, 1 each on models B/C) with a brute-forced `prompt_cache_key` whose raw rendezvous winner sits outside model A; after the fix, the `priority`-strategy result still keeps model A first, while an equivalent `round-robin` combo (not in the protected list) is correctly still fully cross-model reordered by affinity.
- Sibling coverage re-run and green: `tests/unit/prompt-cache-affinity.test.ts` (8/8), `tests/unit/combo-routing-engine.test.ts`, `tests/unit/combo-target-defensive-modelstr.test.ts`, `tests/unit/combo-apply-strategy-ordering-split.test.ts` (92/92 combined).

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK (net-zero growth on the frozen `combo.ts`; new logic extracted into `promptCacheAffinity.ts` instead of growing the god-file)
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — both report pre-existing baseline drift (2167/956) that reproduces **identically** on a clean, unmodified `origin/release/v3.8.49` probe worktree — confirmed base-red, not from this diff
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK
- Changelog fragment added: `changelog.d/fixes/8370-priority-affinity-reorder.md`

## Scope

Diff strictly scoped to the reported defect: `open-sse/services/combo.ts` (predicate extraction only, no other logic touched), `open-sse/services/combo/promptCacheAffinity.ts` (new pure helper), plus the new test file and changelog fragment. No drive-by refactors.