### PR TITLE
fix(resilience): import PROVIDER_BREAKER_FAILURE_STATUSES in chat.ts (Fixes #8405)

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -76,6 +76,7 @@ import {
 import {
   isAntigravityMissingProjectError,
   shouldTripProviderBreakerForResult,
+  PROVIDER_BREAKER_FAILURE_STATUSES,
 } from "./chatPredicates";
 import { connectionHasExtraKeys } from "@omniroute/open-sse/services/apiKeyRotator.ts";
 import {

--- a/src/sse/handlers/chatPredicates.ts
+++ b/src/sse/handlers/chatPredicates.ts
@@ -1,7 +1,7 @@
 import { isLocalStreamLifecycleError } from "../../shared/utils/circuitBreaker";
 import { isRequestScopedUpstreamFailure } from "./comboFailureLogging";
 
-const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504]);
+export const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504]);
 
 // #7907/#7908: single-model breaker trip bypasses the `isFailure` option (only applies
 // inside `breaker.execute()`), so it needs its own `isLocalStreamLifecycleError` guard —


### PR DESCRIPTION
Fixes #8405

Exports `PROVIDER_BREAKER_FAILURE_STATUSES` in `chatPredicates.ts` and imports it in `chat.ts` to prevent `ReferenceError` when all credentials for a provider are rate-limited.