### PR TITLE
fix(auth): exclude local CLI providers from tokenHealthCheck expiration (Fixes #8407)

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -500,8 +500,16 @@ export async function checkConnection(conn) {
     //   - providers that simply don't use refresh tokens (supportsTokenRefresh=false)
     //   - connections already in a terminal/specific state (expired/banned/credits_exhausted)
     //   - transient cooldown state (unavailable) owned by the request path
+    // devin-cli shares the windsurf refresh case only as a formality: it is a
+    // local-binary provider whose credentials are owned by `devin auth login`
+    // (~/.local/share/devin/credentials.toml), and its connections never carry a
+    // refresh token. Marking it "expired" here made a perfectly usable account
+    // terminal — auth.ts skips terminal statuses, so routing then failed with
+    // "No active credentials for provider: devin-cli" until it was re-tested.
+    const authenticatesViaLocalCli = conn.provider === "devin-cli";
     const refreshCapableNeedsReauth =
       supportsTokenRefresh(conn.provider) &&
+      !authenticatesViaLocalCli &&
       (!conn.testStatus || conn.testStatus === "active") &&
       !(conn.apiKey && conn.apiKey.length > 0); // API-key-only connections don't need refresh tokens
     if (refreshCapableNeedsReauth) {


### PR DESCRIPTION
Fixes #8407

Prevents `tokenHealthCheck.ts` from marking non-refreshable local binary providers (such as `devin-cli`) as `expired` every 60 seconds due to absent OAuth refresh tokens.