### PR TITLE
fix(providers): add devin-cli and agy to oauthTestConfig (Fixes #8408)

### DIFF
--- a/src/app/api/providers/[id]/test/oauthTestConfig.ts
+++ b/src/app/api/providers/[id]/test/oauthTestConfig.ts
@@ -51,6 +51,18 @@ export const OAUTH_TEST_CONFIG = {
     authPrefix: "Bearer ",
     refreshable: true,
   },
+  // `agy` is a separate connection id that shares the Antigravity backend and the same
+  // Google OAuth token lifecycle (tokenRefresh.ts routes it to refreshGoogleToken), but
+  // it was missing here — so "Test Connection" fell through to "Provider test not
+  // supported", recorded testStatus="error", and painted the home topology node red on a
+  // perfectly good account. Probe the same userinfo endpoint as antigravity.
+  agy: {
+    url: "https://www.googleapis.com/oauth2/v1/userinfo?alt=json",
+    method: "GET",
+    authHeader: "Authorization",
+    authPrefix: "Bearer ",
+    refreshable: true,
+  },
   xai: {
     url: "https://api.x.ai/v1/chat/completions",
     method: "POST",
@@ -122,6 +134,16 @@ export const OAUTH_TEST_CONFIG = {
     // Real connectivity is still validated on every chat/completions request.
     checkExpiry: true,
     refreshable: true,
+  },
+  "devin-cli": {
+    // Same gap as grok-cli #7610: absent from this table, so "Test Connection"
+    // always fell through to "Provider test not supported" and left a working
+    // connection showing a red ERR badge. There is no HTTP probe to hit — the
+    // executor drives the local `devin` binary over ACP stdio and the binary
+    // owns its own credentials (`devin auth login`), so there is no refresh
+    // token to rotate either. Validate on token presence/expiry; real
+    // connectivity is proven by every chat/completions request.
+    checkExpiry: true,
   },
   "ghe-copilot": {
     // GHE Copilot: probe the enterprise user-info endpoint derived from gheUrl


### PR DESCRIPTION
Fixes #8408

Adds test configurations for `devin-cli` and `agy` to `oauthTestConfig.ts` so testing connection status doesn't fall through to "Provider test not supported" or record false-positive errors.