### PR TITLE
test(sse): regression guard for PROVIDER_BREAKER_FAILURE_STATUSES import (#8405)

### DIFF
--- a/changelog.d/fixes/8424-breaker-failure-statuses-import-guard.md
+++ b/changelog.d/fixes/8424-breaker-failure-statuses-import-guard.md
@@ -1,0 +1,1 @@
+- **fix(sse):** add regression guard that `PROVIDER_BREAKER_FAILURE_STATUSES` stays exported from `chatPredicates` and imported by `chat.ts` — production fix already landed via #8390; this keeps the credential-exhaustion path from regressing to a ReferenceError ([#8424](https://github.com/diegosouzapw/OmniRoute/pull/8424)) — thanks @MumuTW

--- a/skills/cli-backup-sync/SKILL.md
+++ b/skills/cli-backup-sync/SKILL.md
@@ -75,15 +75,6 @@ omniroute backup disable
 
 ### `backup status`
 
-**Flags:**
-
-- `--name <name>`
-- `--cloud`
-- `--encrypt`
-- `--key-file <path>`
-- `--exclude <pattern>`
-- `--retention <n>`
-
 **Example:**
 
 ```bash

--- a/tests/unit/breaker-failure-statuses-8405.test.ts
+++ b/tests/unit/breaker-failure-statuses-8405.test.ts
@@ -1,0 +1,37 @@
+// #8405: PROVIDER_BREAKER_FAILURE_STATUSES was unexported in chatPredicates.ts,
+// causing a ReferenceError on the credential-exhaustion path in chat.ts.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("#8405: chatPredicates exports PROVIDER_BREAKER_FAILURE_STATUSES as a Set of failure statuses", async () => {
+  const chatPredicates = await import("../../src/sse/handlers/chatPredicates.ts");
+  assert.ok(
+    chatPredicates.PROVIDER_BREAKER_FAILURE_STATUSES,
+    "PROVIDER_BREAKER_FAILURE_STATUSES must be exported from chatPredicates"
+  );
+  assert.ok(
+    chatPredicates.PROVIDER_BREAKER_FAILURE_STATUSES instanceof Set,
+    "PROVIDER_BREAKER_FAILURE_STATUSES must be a Set"
+  );
+  assert.deepEqual(
+    Array.from(chatPredicates.PROVIDER_BREAKER_FAILURE_STATUSES).sort(),
+    [408, 500, 502, 503, 504]
+  );
+});
+
+test("#8405: chat.ts imports PROVIDER_BREAKER_FAILURE_STATUSES without throwing ReferenceError", async () => {
+  const chatSource = fs.readFileSync(
+    new URL("../../src/sse/handlers/chat.ts", import.meta.url),
+    "utf-8"
+  );
+
+  assert.match(
+    chatSource,
+    /import\s*\{[^}]*PROVIDER_BREAKER_FAILURE_STATUSES[^}]*\}\s*from\s*["']\.\/chatPredicates["']/,
+    "chat.ts must explicitly import PROVIDER_BREAKER_FAILURE_STATUSES from chatPredicates"
+  );
+
+  const chatModule = await import("../../src/sse/handlers/chat.ts");
+  assert.ok(chatModule, "chat.ts must import cleanly without runtime error");
+});


### PR DESCRIPTION
Rebased onto tip (`release/v3.8.49`). Reduced to regression-test-only as the production fix landed in #8390.

Adds unit test `tests/unit/breaker-failure-statuses-8405.test.ts` to assert that `chatPredicates.ts` exports `PROVIDER_BREAKER_FAILURE_STATUSES` as a `Set` with the expected failure statuses `[408, 500, 502, 503, 504]` and that `chat.ts` explicitly imports it without ReferenceError.