### PR TITLE
fix(auth): exclude local CLI providers from tokenHealthCheck expiration (Fixes #8407)

### DIFF
--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -472,7 +472,11 @@ export function supportsTokenRefresh(provider) {
     "cline",
     "kimi-coding",
     "windsurf",
-    "devin-cli",
+    // #8407: do NOT list "devin-cli" here. It is import-token / local-CLI owned
+    // (`devin auth login`); connections never carry a refresh token. Leaving it
+    // in this set made tokenHealthCheck treat it as refresh-capable and force
+    // testStatus="expired" / errorCode="no_refresh_token". Keep it out of the
+    // explicit set (same idea as not listing non-refresh local-CLI providers).
     "gitlab-duo",
     "codebuddy-cn",
   ]);

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -500,8 +500,16 @@ export async function checkConnection(conn) {
     //   - providers that simply don't use refresh tokens (supportsTokenRefresh=false)
     //   - connections already in a terminal/specific state (expired/banned/credits_exhausted)
     //   - transient cooldown state (unavailable) owned by the request path
+    // devin-cli shares the windsurf refresh case only as a formality: it is a
+    // local-binary provider whose credentials are owned by `devin auth login`
+    // (~/.local/share/devin/credentials.toml), and its connections never carry a
+    // refresh token. Marking it "expired" here made a perfectly usable account
+    // terminal — auth.ts skips terminal statuses, so routing then failed with
+    // "No active credentials for provider: devin-cli" until it was re-tested.
+    const authenticatesViaLocalCli = conn.provider === "devin-cli";
     const refreshCapableNeedsReauth =
       supportsTokenRefresh(conn.provider) &&
+      !authenticatesViaLocalCli &&
       (!conn.testStatus || conn.testStatus === "active") &&
       !(conn.apiKey && conn.apiKey.length > 0); // API-key-only connections don't need refresh tokens
     if (refreshCapableNeedsReauth) {

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -498,18 +498,12 @@ export async function checkConnection(conn) {
     // cosmetic "Token Expired". Surface reality as a terminal "expired" status instead.
     // Guard tightly so we do NOT clobber:
     //   - providers that simply don't use refresh tokens (supportsTokenRefresh=false)
+    //     (see #8407: local-CLI import-token providers like devin-cli must not be
+    //     listed in supportsTokenRefresh's explicit set)
     //   - connections already in a terminal/specific state (expired/banned/credits_exhausted)
     //   - transient cooldown state (unavailable) owned by the request path
-    // devin-cli shares the windsurf refresh case only as a formality: it is a
-    // local-binary provider whose credentials are owned by `devin auth login`
-    // (~/.local/share/devin/credentials.toml), and its connections never carry a
-    // refresh token. Marking it "expired" here made a perfectly usable account
-    // terminal — auth.ts skips terminal statuses, so routing then failed with
-    // "No active credentials for provider: devin-cli" until it was re-tested.
-    const authenticatesViaLocalCli = conn.provider === "devin-cli";
     const refreshCapableNeedsReauth =
       supportsTokenRefresh(conn.provider) &&
-      !authenticatesViaLocalCli &&
       (!conn.testStatus || conn.testStatus === "active") &&
       !(conn.apiKey && conn.apiKey.length > 0); // API-key-only connections don't need refresh tokens
     if (refreshCapableNeedsReauth) {

--- a/tests/unit/token-health-check-devin-cli-8407.test.ts
+++ b/tests/unit/token-health-check-devin-cli-8407.test.ts
@@ -1,4 +1,5 @@
-// #8407: devin-cli local CLI connections must not be force-expired by health check sweep
+// #8407: devin-cli must not be treated as refresh-capable, so the health sweep
+// never force-expires local CLI connections that legitimately have no refresh token.
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
@@ -13,6 +14,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const tokenHealthCheck = await import("../../src/lib/tokenHealthCheck.ts");
+const { supportsTokenRefresh } = await import("../../open-sse/services/tokenRefresh.ts");
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -30,6 +32,18 @@ function getCreatedConnectionId(connection: { id?: unknown }): string {
 test.after(async () => {
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("supportsTokenRefresh excludes devin-cli (#8407)", () => {
+  // Root fix: drop "devin-cli" from the explicit set so the health sweep's
+  // supportsTokenRefresh=false guard applies (same idea as not listing a
+  // non-refresh local-CLI provider). windsurf stays refresh-capable.
+  assert.equal(
+    supportsTokenRefresh("devin-cli"),
+    false,
+    "devin-cli is local import-token / CLI-owned — not refresh-capable"
+  );
+  assert.equal(supportsTokenRefresh("windsurf"), true);
 });
 
 test("checkConnection leaves a devin-cli connection with no refresh token untouched (#8407)", async () => {

--- a/tests/unit/token-health-check-devin-cli-8407.test.ts
+++ b/tests/unit/token-health-check-devin-cli-8407.test.ts
@@ -1,0 +1,53 @@
+// #8407: devin-cli local CLI connections must not be force-expired by health check sweep
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+process.env.NODE_ENV = "test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-hc-devin-cli-8407-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const tokenHealthCheck = await import("../../src/lib/tokenHealthCheck.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+function getCreatedConnectionId(connection: { id?: unknown }): string {
+  assert.equal(typeof connection.id, "string");
+  return connection.id as string;
+}
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("checkConnection leaves a devin-cli connection with no refresh token untouched (#8407)", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "devin-cli",
+    authType: "oauth",
+    name: "Devin CLI Local Account",
+    accessToken: "local-cli-access-token",
+    refreshToken: null,
+    testStatus: "active",
+    isActive: true,
+  });
+
+  await tokenHealthCheck.checkConnection(connection);
+
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
+  assert.equal(updated?.testStatus, "active", "devin-cli testStatus must remain active");
+  assert.notEqual(updated?.errorCode, "no_refresh_token", "devin-cli must not be marked no_refresh_token");
+});


### PR DESCRIPTION
## Summary

Fixes #8407

`devin-cli` is a local import-token / CLI-owned provider (`devin auth login`). It never carries a refresh token, but it was listed in `supportsTokenRefresh()`'s `explicitlySupported` set. That made the token health sweep treat it as refresh-capable and write terminal `testStatus="expired"` / `errorCode="no_refresh_token"`, after which routing failed with `No active credentials for provider: devin-cli`.

### Changes

1. **Root fix** — remove `"devin-cli"` from `explicitlySupported` in `open-sse/services/tokenRefresh.ts` (keep `windsurf`). The existing `supportsTokenRefresh=false` guard in `tokenHealthCheck` then skips the expiry write.
2. **No provider hardcode** in `tokenHealthCheck` — one source of truth is enough.
3. **Unit tests** — assert `supportsTokenRefresh("devin-cli") === false`, and that `checkConnection` leaves a no-refresh-token `devin-cli` connection `active`.

## Test plan

- [x] `node --import tsx --test tests/unit/token-health-check-devin-cli-8407.test.ts` → **2/2 pass**
- [ ] Manual: add Devin CLI provider → wait for health sweep → connection stays `active` / routable

## Related

- Pairs with #8408 / #8427 (manual Test Connection `unsupported`) — kept separate.