### PR TITLE
fix(ui): decouple healthy and last-routed states in ProviderTopology (Fixes #8409)

### DIFF
--- a/src/app/(dashboard)/home/ProviderTopology.tsx
+++ b/src/app/(dashboard)/home/ProviderTopology.tsx
@@ -39,12 +39,18 @@ type ProviderNodeData = {
   error: boolean;
   /** Connection-health base state: a healthy connection with no in-flight traffic. */
   healthy: boolean;
+  /** Most recently routed provider. Orthogonal to health — it can be last *and* healthy. */
+  last: boolean;
 };
 
 function ProviderNode({ data }: { data: ProviderNodeData }) {
-  const { label, color, providerId, active, error, healthy } = data;
+  const { label, color, providerId, active, error, healthy, last } = data;
   const GREEN = FLOW_EDGE_COLORS.active;
   const RED = FLOW_EDGE_COLORS.error;
+  const AMBER = FLOW_EDGE_COLORS.last;
+  // "Last routed" is a traffic annotation, not a health state: the border keeps saying
+  // whether the connection is up, and only the dot turns amber to mark recency.
+  const dotColor = active ? color : last ? AMBER : GREEN;
 
   return (
     <div
@@ -102,8 +108,8 @@ function ProviderNode({ data }: { data: ProviderNodeData }) {
         {label}
       </span>
 
-      {(active || error || healthy) && (
-        <StatusDot color={active ? color : GREEN} error={error} pulse={active || error} />
+      {(active || error || healthy || last) && (
+        <StatusDot color={dotColor} error={error} pulse={active || error} />
       )}
     </div>
   );
@@ -225,8 +231,13 @@ function buildLayout(
       // still reflects "what is connected" at rest instead of going blank after a restart.
       const trafficError = !active && errorSet.has(pid);
       const last = !active && !trafficError && lastSet.has(pid);
-      const healthError = !active && !trafficError && !last && p.status === "error";
-      const healthy = !active && !trafficError && !last && !healthError && p.status === "active";
+      // Health is orthogonal to recency: having just served a request does not make a
+      // connection any less connected. `last` used to suppress `healthy`/`healthError`,
+      // and because the node had no `last` visual it fell all the way through to the idle
+      // grey — so the provider you had just used rendered *less* connected than an idle
+      // peer, while its edge was amber. Health drives the border, `last` only the dot.
+      const healthError = !active && !trafficError && p.status === "error";
+      const healthy = !active && !trafficError && !healthError && p.status === "active";
       const error = trafficError || healthError;
       const config = getProviderConfig(p.provider);
       const nodeId = `provider-${p.provider}`;
@@ -247,6 +258,7 @@ function buildLayout(
           active,
           error,
           healthy,
+          last,
         } satisfies ProviderNodeData,
         draggable: false,
       });

--- a/tests/unit/topology-connection-health.test.ts
+++ b/tests/unit/topology-connection-health.test.ts
@@ -37,19 +37,52 @@ test("HomeProviderTopologySection forwards the status field on each provider", (
 });
 
 test("ProviderTopology renders a connection-health base layer under the traffic signals", () => {
-  // Traffic (live/recent/error) must still take precedence over the static health colour.
+  // Live traffic and traffic errors still take precedence over the static health colour,
+  // but `last` (most recently routed) must NOT: it used to null out `healthy`, and since
+  // the node had no `last` visual the just-used provider rendered as idle grey with an
+  // amber edge — less connected-looking than an untouched peer. Health owns the border,
+  // recency owns the dot.
   assert.match(
     providerTopologySrc,
-    /const healthy =\s*!active && !trafficError && !last && !healthError && p\.status === "active"/,
-    "healthy is only shown when there is no stronger traffic signal"
+    /const healthy =\s*!active && !trafficError && !healthError && p\.status === "active"/,
+    "healthy must survive the last-used annotation"
+  );
+  assert.doesNotMatch(
+    providerTopologySrc,
+    /const healthy =[^;]*!last/,
+    "last-used must not suppress the health colour"
+  );
+  assert.match(
+    providerTopologySrc,
+    /const healthError =\s*!active && !trafficError && p\.status === "error"/,
+    "healthError must survive the last-used annotation"
   );
   assert.match(
     providerTopologySrc,
     /edgeStyle\(active, last, error, healthy\)/,
     "the healthy state must reach the edge palette"
   );
+
   // The node must render the health state (green border / static dot) — a non-pulsing dot
   // distinguishes "connected" from "active".
   assert.match(providerTopologySrc, /pulse=\{active \|\| error\}/);
-  assert.match(providerTopologySrc, /active \|\| error \|\| healthy/);
+  assert.match(providerTopologySrc, /active \|\| error \|\| healthy \|\| last/);
+});
+
+test("ProviderTopology marks the last-routed provider with an amber dot, not a grey node", () => {
+  assert.match(
+    providerTopologySrc,
+    /const AMBER = FLOW_EDGE_COLORS\.last/,
+    "recency reuses the shared amber from the edge palette"
+  );
+  assert.match(
+    providerTopologySrc,
+    /const dotColor = active \? color : last \? AMBER : GREEN/,
+    "the dot encodes recency while the border keeps encoding health"
+  );
+  assert.match(
+    providerTopologySrc,
+    /borderColor: error \? RED : active \? color : healthy \? GREEN : "var\(--color-border\)"/,
+    "border stays health-driven — grey is reserved for genuinely idle/unconfigured"
+  );
 });

--- a/tests/unit/ui/home-topology-last-used-node-color.test.tsx
+++ b/tests/unit/ui/home-topology-last-used-node-color.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+//
+// The home topology painted the most recently routed provider as an idle grey node with
+// no status dot, while its edge was amber — so the provider you had just used looked
+// *less* connected than an untouched one. `last` was ANDed into `healthy`, and the node
+// component had no `last` state to fall back on. Health now owns the border and recency
+// owns the dot; this renders the real ProviderNode and reads the computed styles rather
+// than pattern-matching the source.
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { FLOW_EDGE_COLORS } from "../../../src/shared/components/flow/edgeStyles";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+vi.mock("@/shared/components/ProviderIcon", () => ({
+  default: () => <span data-testid="icon" />,
+}));
+// Render each node through its registered node type directly: ReactFlow's own layout
+// needs real measurement, which jsdom cannot provide, and it is not what we're asserting.
+vi.mock("@/shared/components/flow/FlowCanvas", () => ({
+  FlowCanvas: ({
+    nodes,
+    edges,
+    nodeTypes,
+  }: {
+    nodes: Array<{ id: string; type?: string; data: Record<string, unknown> }>;
+    edges: Array<{ id: string; target: string; style?: { stroke?: string } }>;
+    nodeTypes?: Record<string, React.ComponentType<{ data: Record<string, unknown> }>>;
+  }) => (
+    <div>
+      {nodes.map((n) => {
+        const Comp = n.type ? nodeTypes?.[n.type] : undefined;
+        const edge = edges.find((e) => e.target === n.id);
+        return (
+          <div key={n.id} data-testid={n.id} data-edge-stroke={edge?.style?.stroke ?? ""}>
+            {Comp ? <Comp data={n.data} /> : null}
+          </div>
+        );
+      })}
+    </div>
+  ),
+}));
+vi.mock("@xyflow/react", () => ({
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+}));
+
+const ProviderTopology = (
+  await import("../../../src/app/(dashboard)/home/ProviderTopology")
+).default;
+
+// jsdom normalises inline hex colours to `rgb(...)`, so compare in that space.
+const rgb = (hex: string) => {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+};
+const GREEN = rgb(FLOW_EDGE_COLORS.active);
+const AMBER = rgb(FLOW_EDGE_COLORS.last);
+const RED = rgb(FLOW_EDGE_COLORS.error);
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+type Entry = { id: string; provider: string; name?: string; status?: string };
+
+function render(providers: Entry[], lastProvider = "") {
+  act(() => {
+    root.render(
+      <ProviderTopology
+        providers={providers as never}
+        activeRequests={[]}
+        lastProvider={lastProvider}
+        errorProvider=""
+      />
+    );
+  });
+}
+
+const node = (provider: string) =>
+  container.querySelector(`[data-testid="provider-${provider}"]`) as HTMLElement;
+const box = (provider: string) => node(provider).querySelector("div.border-2") as HTMLElement;
+const dot = (provider: string) =>
+  node(provider).querySelector("span.rounded-full:not(.animate-ping)") as HTMLElement | null;
+
+it("keeps the connected border on the last-routed provider and marks recency on the dot", () => {
+  render(
+    [
+      { id: "a", provider: "devin-cli", name: "Devin CLI", status: "active" },
+      { id: "b", provider: "claude", name: "Claude Code", status: "active" },
+    ],
+    "devin-cli"
+  );
+
+  // The just-used provider: still green (connected), amber dot (most recent).
+  expect(box("devin-cli").style.borderColor).toBe(GREEN);
+  expect(dot("devin-cli")).not.toBeNull();
+  expect(dot("devin-cli")!.style.backgroundColor).toBe(AMBER);
+  // Its edge keeps the amber last-used stroke (raw attribute, not a normalised style).
+  expect(node("devin-cli").dataset.edgeStroke).toBe(FLOW_EDGE_COLORS.last);
+
+  // An untouched but connected peer is unchanged: green border, green dot.
+  expect(box("claude").style.borderColor).toBe(GREEN);
+  expect(dot("claude")!.style.backgroundColor).toBe(GREEN);
+});
+
+it("still greys out a provider that is genuinely idle", () => {
+  render([{ id: "a", provider: "kimi-coding", name: "Kimi", status: "idle" }]);
+  expect(box("kimi-coding").style.borderColor).toBe("var(--color-border)");
+  expect(dot("kimi-coding")).toBeNull();
+});
+
+it("shows an errored connection as red even when it was the last one routed", () => {
+  render([{ id: "a", provider: "agy", name: "Antigravity", status: "error" }], "agy");
+  expect(box("agy").style.borderColor).toBe(RED);
+  expect(node("agy").dataset.edgeStroke).toBe(FLOW_EDGE_COLORS.error);
+});


### PR DESCRIPTION
## Summary

Fixes #8409

On the home Provider topology, the most recently routed node was painted as idle grey with no status dot while its edge stayed amber — health and recency were incorrectly coupled (`!last` ANDed into `healthy` / `healthError`), and the node had no `last` visual.

### Changes

1. **Decouple health from recency** — `healthy` / `healthError` no longer depend on `!last`
2. **Border = health** (green / red); **dot = recency** when `last` (amber via `FLOW_EDGE_COLORS.last`)
3. **Tests** — update source-regex guards; add jsdom render tests for healthy+last / idle / error+last

Distinct from #8328 (custom nodes missing from the graph entirely).

## Test plan

- [x] `node --import tsx --test tests/unit/topology-connection-health.test.ts` → **4/4 pass**
- [x] `vitest run tests/unit/ui/home-topology-last-used-node-color.test.tsx` → **3/3 pass**
- [ ] Manual: route a request → last-used node keeps green border + amber dot; edge stays amber