### PR TITLE
fix(backend): make disabling the global per-key proxy toggle override existing per-key proxy assignments (#8385)

### DIFF
--- a/changelog.d/fixes/8385-perkey-proxy-global-toggle.md
+++ b/changelog.d/fixes/8385-perkey-proxy-global-toggle.md
@@ -1,0 +1,1 @@
+- fix(backend): make disabling the global per-key proxy toggle override existing per-key proxy assignments (#8385)

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -523,8 +523,10 @@ export async function resolveProxyForConnection(
 
   // Step 2: API key-level proxy (only if per-key proxy is enabled globally or per-connection)
   if (apiKeyId) {
-    // Check if per-key proxy is allowed: globally OR per-connection
-    const perKeyEnabled = globalPerKeyProxyEnabled || connectionPerKeyProxyEnabled;
+    // Check if per-key proxy is allowed: the global toggle is a true override —
+    // when it is off, no connection's per-key assignment may apply, regardless
+    // of that connection's own per_key_proxy_enabled flag (#8385).
+    const perKeyEnabled = globalPerKeyProxyEnabled && connectionPerKeyProxyEnabled;
 
     if (perKeyEnabled) {
       try {

--- a/tests/unit/8385-perkey-proxy-global-toggle.test.ts
+++ b/tests/unit/8385-perkey-proxy-global-toggle.test.ts
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-8385-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const proxiesDb = await import("../../src/lib/db/proxies.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+
+interface ConnectionRef {
+  id: string;
+}
+
+interface ProxyResolution {
+  level: string | null;
+  proxy: unknown;
+}
+
+async function resetStorage() {
+  delete process.env.INITIAL_PASSWORD;
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("issue #8385: global perKeyProxyEnabled=false must override a connection's per_key_proxy_enabled=1", async () => {
+  await resetStorage();
+
+  core
+    .getDbInstance()
+    .prepare(
+      "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'perKeyProxyEnabled', 'false')"
+    )
+    .run();
+
+  const conn = (await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "conn-8385",
+    apiKey: "sk-8385",
+  })) as unknown as ConnectionRef;
+  await providersDb.updateProviderConnection(conn.id, { perKeyProxyEnabled: true });
+
+  const proxy = await proxiesDb.createProxy({
+    name: "Per-Key Proxy 8385",
+    type: "http",
+    host: "perkey.8385.local",
+    port: 8080,
+  });
+
+  const key = await apiKeysDb.createApiKey("probe-8385-key", "machine-8385");
+  await apiKeysDb.updateApiKeyPermissions(key.id, { proxyId: proxy.id });
+
+  const resolved = (await settingsDb.resolveProxyForConnection(
+    conn.id,
+    key.id
+  )) as unknown as ProxyResolution;
+
+  assert.notEqual(
+    resolved?.level,
+    "apiKey",
+    `expected global-off to override per-key assignment, but got level=${resolved?.level} proxy=${JSON.stringify(resolved?.proxy)}`
+  );
+});
+
+test("issue #8385: global perKeyProxyEnabled=true still allows the per-key assignment to apply", async () => {
+  await resetStorage();
+
+  core
+    .getDbInstance()
+    .prepare(
+      "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'perKeyProxyEnabled', 'true')"
+    )
+    .run();
+
+  const conn = (await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "conn-8385-on",
+    apiKey: "sk-8385-on",
+  })) as unknown as ConnectionRef;
+  await providersDb.updateProviderConnection(conn.id, { perKeyProxyEnabled: true });
+
+  const proxy = await proxiesDb.createProxy({
+    name: "Per-Key Proxy 8385 On",
+    type: "http",
+    host: "perkey-on.8385.local",
+    port: 8081,
+  });
+
+  const key = await apiKeysDb.createApiKey("probe-8385-key-on", "machine-8385-on");
+  await apiKeysDb.updateApiKeyPermissions(key.id, { proxyId: proxy.id });
+
+  const resolved = (await settingsDb.resolveProxyForConnection(
+    conn.id,
+    key.id
+  )) as unknown as ProxyResolution;
+
+  assert.equal(
+    resolved?.level,
+    "apiKey",
+    `expected global-on to allow the per-key assignment, but got level=${resolved?.level}`
+  );
+});

--- a/tests/unit/proxy-registry.test.ts
+++ b/tests/unit/proxy-registry.test.ts
@@ -304,6 +304,7 @@ test("resolveProxyForConnection uses apiKey proxy before account-level proxy", a
     name: "api-key-proxy",
     apiKey: "sk-apikey-proxy",
   });
+  const connId = (conn as any).id;
 
   const accountProxy = await proxiesDb.createProxy({
     name: "Account Proxy",
@@ -311,17 +312,20 @@ test("resolveProxyForConnection uses apiKey proxy before account-level proxy", a
     host: "account.local",
     port: 8081,
   });
-  await proxiesDb.assignProxyToScope("account", (conn as any).id, accountProxy.id);
+  await proxiesDb.assignProxyToScope("account", connId, accountProxy.id);
 
   const key = await apiKeysDb.createApiKey("proxy-test-key", "machine-p1");
 
-  // Enable per-key proxy globally so the API key's proxy_id is honored
+  // Enable per-key proxy globally (master gate) and on the connection itself
+  // (#8385: the global toggle is a true AND-override, not an independent
+  // opt-in path — both must be on for the api-key-level proxy to apply).
   core
     .getDbInstance()
     .prepare(
       "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'perKeyProxyEnabled', 'true')"
     )
     .run();
+  await providersDb.updateProviderConnection(connId, { perKeyProxyEnabled: true });
 
   const apiKeyProxy = await proxiesDb.createProxy({
     name: "API Key Proxy",
@@ -331,7 +335,7 @@ test("resolveProxyForConnection uses apiKey proxy before account-level proxy", a
   });
   await apiKeysDb.updateApiKeyPermissions(key.id, { proxyId: apiKeyProxy.id });
 
-  const resolved = await settingsDb.resolveProxyForConnection((conn as any).id, key.id);
+  const resolved = await settingsDb.resolveProxyForConnection(connId, key.id);
   assert.ok(resolved);
   assert.equal((resolved as any).level, "apiKey");
   assert.equal((resolved as any).proxy.host, "apikey.local");

--- a/tests/unit/resolve-proxy-family.test.ts
+++ b/tests/unit/resolve-proxy-family.test.ts
@@ -115,12 +115,16 @@ test("api-key-level proxy carries family=ipv6 (Step 2 object literal)", async ()
     name: "key-ipv6",
     apiKey: "sk-key-ipv6",
   });
+  const connId = (conn as any).id;
   core
     .getDbInstance()
     .prepare(
       "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'perKeyProxyEnabled', 'true')"
     )
     .run();
+  // #8385: the global toggle is a true AND-override — the connection's own
+  // per_key_proxy_enabled must also be on for the api-key-level proxy to apply.
+  await providersDb.updateProviderConnection(connId, { perKeyProxyEnabled: true });
   const proxy = await proxiesDb.createProxy({
     name: "IPv6 API Key Proxy",
     type: "https",
@@ -131,7 +135,7 @@ test("api-key-level proxy carries family=ipv6 (Step 2 object literal)", async ()
   const key = await apiKeysDb.createApiKey("family-key", "machine-f1");
   await apiKeysDb.updateApiKeyPermissions(key.id, { proxyId: proxy.id });
 
-  const resolved = await settingsDb.resolveProxyForConnection((conn as any).id, key.id);
+  const resolved = await settingsDb.resolveProxyForConnection(connId, key.id);
   assert.ok(resolved);
   assert.equal((resolved as any).level, "apiKey");
   assert.equal((resolved as any).proxy.family, "ipv6");


### PR DESCRIPTION
Closes #8385

## Root cause

`resolveProxyForConnection` (`src/lib/db/settings.ts`, Step 2 "API key-level proxy") gated the api-key-level proxy with:

```ts
const perKeyEnabled = globalPerKeyProxyEnabled || connectionPerKeyProxyEnabled;
```

Because this was an OR, turning the global `perKeyProxyEnabled` setting off had zero effect on any connection whose own `per_key_proxy_enabled=1` — the stored per-key `proxy_id` on `api_keys` was still applied. The global toggle's UI copy ("When enabled, each provider connection can use its own proxy assignment") frames the global flag as a prerequisite gate, so admins reasonably expect global=off to be a kill switch, not a second independent opt-in path.

## Fix

Changed the gate to AND semantics so the global toggle is a true override:

```ts
const perKeyEnabled = globalPerKeyProxyEnabled && connectionPerKeyProxyEnabled;
```

- Global OFF → per-key proxy is never applied, regardless of the connection's own flag.
- Global ON → per-key proxy still requires the connection's own flag to be on (matches the UI copy).
- The stored per-key assignment (`api_keys.proxy_id`, `provider_connections.per_key_proxy_enabled`) is never deleted — only whether it's *applied* is gated, so re-enabling the global toggle restores prior behavior immediately.

## Regression test (TDD, Hard Rule #18)

New permanent test file `tests/unit/8385-perkey-proxy-global-toggle.test.ts`:
- RED before the fix: `global=false` + connection `per_key_proxy_enabled=1` + `api_keys.proxy_id` set → `resolveProxyForConnection` still returned `level: "apiKey"` (AssertionError, actual: 'apiKey', expected: not 'apiKey').
- GREEN after the fix: same setup now resolves to a non-`apiKey` level (falls through to the next resolution step).
- Second case confirms global=on + connection flag=on still applies the per-key assignment (no regression on the happy path).

## Sibling tests aligned to the corrected contract

Two existing tests encoded the old OR semantics (asserted `level === "apiKey"` with `global=true` but the connection's own `per_key_proxy_enabled` left at its default `0`), which is no longer sufficient under AND semantics. Legitimately aligned (not weakened) by also enabling the connection-level flag, matching the intended "both must opt in" contract:
- `tests/unit/proxy-registry.test.ts` — "resolveProxyForConnection uses apiKey proxy before account-level proxy"
- `tests/unit/resolve-proxy-family.test.ts` — "api-key-level proxy carries family=ipv6 (Step 2 object literal)"

## Gates run

- `node --import tsx/esm --test tests/unit/8385-perkey-proxy-global-toggle.test.ts tests/unit/proxy-registry.test.ts tests/unit/resolve-proxy-family.test.ts` plus the full sibling proxy/settings suite (203 tests) — all green.
- `npm run typecheck:core` — clean.
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean.
- `node scripts/check/check-file-size.mjs`, `check-complexity.mjs`, `check-cognitive-complexity.mjs` — pre-existing baseline drift confirmed identical against a disposable `origin/release/v3.8.49` probe worktree (2169/956 violations, 5 unrelated frozen files), none introduced by this diff.
- `node scripts/check/check-changelog-integrity.mjs` — OK.
- Changelog fragment added: `changelog.d/fixes/8385-perkey-proxy-global-toggle.md`.