### PR TITLE
[v3.8.50] Fix Z.ai web browser transport and model capabilities

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -563,11 +563,6 @@
       "count": 1
     }
   },
-  "src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/api/providers/[id]/models/route.ts": {
     "no-restricted-imports": {
       "count": 1

--- a/open-sse/config/providers/registry/zai-web/index.ts
+++ b/open-sse/config/providers/registry/zai-web/index.ts
@@ -10,10 +10,34 @@ export const zai_webProvider: RegistryEntry = {
   // Distinct from the API-key `zai`/`glm` providers (api.z.ai).
   baseUrl: "https://chat.z.ai",
   authType: "apikey",
-  authHeader: "cookie",
+  authHeader: "bearer",
+  // Z.ai's visible "Tools" switch enables its internal VLM/MCP tools. It does
+  // not accept caller-supplied OpenAI `tools`, which remains disabled here.
   models: [
-    { id: "glm-4.6", name: "GLM-4.6", toolCalling: false },
-    { id: "glm-4.5", name: "GLM-4.5", toolCalling: false },
-    { id: "glm-4.5v", name: "GLM-4.5V (Vision)", toolCalling: false },
+    {
+      id: "glm-5.2",
+      name: "GLM-5.2",
+      toolCalling: false,
+      supportsReasoning: true,
+    },
+    {
+      id: "GLM-5.1",
+      name: "GLM-5.1",
+      toolCalling: false,
+      supportsReasoning: true,
+    },
+    {
+      id: "GLM-5-Turbo",
+      name: "GLM-5-Turbo",
+      toolCalling: false,
+      supportsReasoning: true,
+    },
+    {
+      id: "GLM-5v-Turbo",
+      name: "GLM-5V-Turbo",
+      toolCalling: false,
+      supportsReasoning: true,
+      supportsVision: true,
+    },
   ],
 };

--- a/open-sse/executors/zai-web.ts
+++ b/open-sse/executors/zai-web.ts
@@ -79,6 +79,189 @@ export type { ZaiDelta } from "./zai-web/stream.ts";
 
 let cachedFeVersion: { value: string; expiresAt: number } | null = null;
 
+type ZaiBrowserAttachments = NonNullable<Parameters<typeof browserBackedChat>[0]["attachments"]>;
+
+/** Decode the request's image URLs into browser upload attachments. */
+async function resolveZaiBrowserAttachments(
+  imageUrls: string[],
+  body: unknown
+): Promise<
+  { attachments: ZaiBrowserAttachments } | { errorResult: ReturnType<typeof makeErrorResult> }
+> {
+  try {
+    const images = await resolveCursorImages(imageUrls);
+    return {
+      attachments: images.map((image, index) => ({
+        name: zaiImageFileName(image.mimeType, index),
+        mimeType: image.mimeType,
+        buffer: image.data,
+      })),
+    };
+  } catch (error) {
+    const message =
+      error instanceof CursorImageError
+        ? error.message
+        : sanitizeErrorMessage(error instanceof Error ? error.message : "invalid image input");
+    return {
+      errorResult: makeErrorResult(
+        error instanceof CursorImageError ? error.status : 400,
+        `Z.ai image input error: ${message}`,
+        body,
+        ZAI_CHAT_URL
+      ),
+    };
+  }
+}
+
+/**
+ * The call-log body for a browser-transport turn. There is no real upstream
+ * request payload to record here, so this reconstructs the equivalent shape the
+ * signed-API path logs, from the settings the browser UI was driven with.
+ */
+function buildZaiBrowserAuditBody(input: {
+  messages: Array<{ role: string; content: unknown }>;
+  modelId: string;
+  thinkingConfig: ZaiThinkingConfig;
+  vlmConfig: ZaiVlmConfig;
+  imageCount: number;
+}): Record<string, unknown> {
+  const { thinkingConfig: thinking, vlmConfig: vlm } = input;
+  return {
+    browser_backed: true,
+    image_count: input.imageCount,
+    model: input.modelId,
+    messages: foldMessages(input.messages),
+    enable_thinking: thinking.enabled,
+    auto_web_search: vlm.websiteModeEnabled ? false : vlm.webSearchEnabled,
+    vlm_tools_enable: vlm.toolsEnabled,
+    vlm_web_search_enable: vlm.websiteModeEnabled && vlm.webSearchEnabled,
+    vlm_website_mode: vlm.websiteModeEnabled,
+    ...(thinking.enabled && thinking.effortSupported ? { reasoning_effort: thinking.effort } : {}),
+  };
+}
+
+/**
+ * Drive-the-real-UI options for chat.z.ai: which selectors to type into and click,
+ * and the localStorage token the page reads at boot. `beforeSubmit` flips the
+ * Deep Think / web-search / tools switches to match the request.
+ */
+function buildZaiBrowserChatOptions(input: {
+  attachments: ZaiBrowserAttachments;
+  messages: Array<{ role: string; content: unknown }>;
+  modelId: string;
+  signal?: AbortSignal | null;
+  thinkingConfig: ZaiThinkingConfig;
+  token: string;
+  vlmConfig: ZaiVlmConfig;
+}): Parameters<typeof browserBackedChat>[0] {
+  const poolKey = `zai-web:${createHash("sha256").update(input.token).digest("hex").slice(0, 24)}`;
+  return {
+    poolKey,
+    chatUrl: ZAI_CHAT_URL,
+    chatPageUrl: `${ZAI_BASE_URL}/?model=${encodeURIComponent(browserModelName(input.modelId))}`,
+    userMessage: browserPrompt(input.messages),
+    localStorage: { token: input.token },
+    localStorageOrigin: ZAI_BASE_URL,
+    cookieDomain: "chat.z.ai",
+    chatUrlMatchDomain: "chat.z.ai",
+    userAgent: ZAI_USER_AGENT,
+    locale: "en-US",
+    timezone: "Asia/Seoul",
+    inputSelector: "#chat-input",
+    submitButtonSelector: '[aria-label="Send Message"] button:not([disabled])',
+    submitButtonMode: "dom",
+    attachments: input.attachments,
+    beforeSubmit: (page) =>
+      configureZaiBrowserRequest(page, {
+        modelId: input.modelId,
+        thinking: input.thinkingConfig,
+        vlm: input.vlmConfig,
+      }),
+    postSubmitWaitMs: 30_000,
+    signal: input.signal,
+    reuseContext: true,
+  };
+}
+
+/** What either transport hands back: the upstream stream plus its call-log pair. */
+type ZaiTransportResult = {
+  upstream: Response;
+  auditHeaders: Record<string, string>;
+  auditBody: Record<string, unknown>;
+};
+
+type ZaiResolvedRequest = {
+  captchaVerifyParam: string;
+  imageUrls: string[];
+  messages: Array<{ role: string; content: unknown }>;
+  modelId: string;
+  prompt: string;
+  thinkingConfig: ZaiThinkingConfig;
+  token: string;
+  userId: string;
+  vlmConfig: ZaiVlmConfig;
+};
+
+/**
+ * Validate the credential and body, and resolve everything both transports need.
+ *
+ * All four rejections are client errors that must never reach the upstream: no
+ * usable session token, no user turn, an image sent to a text-only model, and a
+ * JWT with no user id (which the signed-API path needs to build its signature).
+ */
+function resolveZaiRequest(
+  input: ExecuteInput
+): { request: ZaiResolvedRequest } | { errorResult: ReturnType<typeof makeErrorResult> } {
+  const { body, credentials, model } = input;
+  const bodyObj = (body || {}) as Record<string, unknown>;
+  const fail = (message: string) => ({
+    errorResult: makeErrorResult(400, message, body, ZAI_CHAT_URL),
+  });
+
+  const rawCredential = String(credentials?.apiKey ?? credentials?.accessToken ?? "").trim();
+  const token = extractZaiToken(rawCredential);
+  if (!token) {
+    return fail(
+      'Missing Z.ai web-session credential — copy the "token" value from chat.z.ai Local Storage.'
+    );
+  }
+
+  const messages = (bodyObj.messages as Array<{ role: string; content: unknown }>) || [];
+  const prompt = latestUserPrompt(messages);
+  const imageUrls = collectZaiImageUrls(messages);
+  if (!prompt && imageUrls.length === 0) {
+    return fail("Z.ai requires at least one user message");
+  }
+
+  const modelId = (bodyObj.model as string) || model || ZAI_DEFAULT_MODEL;
+  if (imageUrls.length > 0 && !getZaiModelCapabilities(modelId).vision) {
+    return fail(
+      `Z.ai model ${unprefixedModelId(modelId)} does not accept image input; use GLM-5V-Turbo.`
+    );
+  }
+
+  const userId = extractZaiUserId(token);
+  if (!userId) {
+    return fail(
+      "Invalid Z.ai web-session credential — its JWT payload does not contain the required user id."
+    );
+  }
+
+  return {
+    request: {
+      captchaVerifyParam: resolveZaiCaptchaVerifyParam(credentials, bodyObj),
+      imageUrls,
+      messages,
+      modelId,
+      prompt,
+      thinkingConfig: resolveZaiThinkingConfig(modelId, bodyObj),
+      token,
+      userId,
+      vlmConfig: resolveZaiVlmConfig(modelId, bodyObj),
+    },
+  };
+}
+
 export class ZaiWebExecutor extends BaseExecutor {
   constructor() {
     super("zai-web", { id: "zai-web", baseUrl: ZAI_BASE_URL });
@@ -222,71 +405,14 @@ export class ZaiWebExecutor extends BaseExecutor {
     thinkingConfig: ZaiThinkingConfig;
     token: string;
     vlmConfig: ZaiVlmConfig;
-  }): Promise<
-    | {
-        upstream: Response;
-        auditHeaders: Record<string, string>;
-        auditBody: Record<string, unknown>;
-      }
-    | { errorResult: ReturnType<typeof makeErrorResult> }
-  > {
-    let attachments: NonNullable<Parameters<typeof browserBackedChat>[0]["attachments"]>;
-    try {
-      const images = await resolveCursorImages(input.imageUrls);
-      attachments = images.map((image, index) => ({
-        name: zaiImageFileName(image.mimeType, index),
-        mimeType: image.mimeType,
-        buffer: image.data,
-      }));
-    } catch (error) {
-      const message =
-        error instanceof CursorImageError
-          ? error.message
-          : sanitizeErrorMessage(error instanceof Error ? error.message : "invalid image input");
-      return {
-        errorResult: makeErrorResult(
-          error instanceof CursorImageError ? error.status : 400,
-          `Z.ai image input error: ${message}`,
-          input.body,
-          ZAI_CHAT_URL
-        ),
-      };
-    }
+  }): Promise<ZaiTransportResult | { errorResult: ReturnType<typeof makeErrorResult> }> {
+    const resolved = await resolveZaiBrowserAttachments(input.imageUrls, input.body);
+    if ("errorResult" in resolved) return resolved;
+    const { attachments } = resolved;
 
-    const poolKey = `zai-web:${createHash("sha256")
-      .update(input.token)
-      .digest("hex")
-      .slice(0, 24)}`;
     let result: Awaited<ReturnType<typeof browserBackedChat>>;
     try {
-      result = await browserBackedChat({
-        poolKey,
-        chatUrl: ZAI_CHAT_URL,
-        chatPageUrl: `${ZAI_BASE_URL}/?model=${encodeURIComponent(
-          browserModelName(input.modelId)
-        )}`,
-        userMessage: browserPrompt(input.messages),
-        localStorage: { token: input.token },
-        localStorageOrigin: ZAI_BASE_URL,
-        cookieDomain: "chat.z.ai",
-        chatUrlMatchDomain: "chat.z.ai",
-        userAgent: ZAI_USER_AGENT,
-        locale: "en-US",
-        timezone: "Asia/Seoul",
-        inputSelector: "#chat-input",
-        submitButtonSelector: '[aria-label="Send Message"] button:not([disabled])',
-        submitButtonMode: "dom",
-        attachments,
-        beforeSubmit: (page) =>
-          configureZaiBrowserRequest(page, {
-            modelId: input.modelId,
-            thinking: input.thinkingConfig,
-            vlm: input.vlmConfig,
-          }),
-        postSubmitWaitMs: 30_000,
-        signal: input.signal,
-        reuseContext: true,
-      });
+      result = await browserBackedChat(buildZaiBrowserChatOptions({ ...input, attachments }));
     } catch (error) {
       const message = sanitizeErrorMessage(
         error instanceof Error ? error.message : "browser transport unavailable"
@@ -323,135 +449,101 @@ export class ZaiWebExecutor extends BaseExecutor {
         Authorization: "Bearer [REDACTED]",
         "X-OmniRoute-Transport": "browser",
       },
-      auditBody: {
-        browser_backed: true,
-        image_count: attachments.length,
-        model: input.modelId,
-        messages: foldMessages(input.messages),
-        enable_thinking: input.thinkingConfig.enabled,
-        auto_web_search: input.vlmConfig.websiteModeEnabled
-          ? false
-          : input.vlmConfig.webSearchEnabled,
-        vlm_tools_enable: input.vlmConfig.toolsEnabled,
-        vlm_web_search_enable:
-          input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
-        vlm_website_mode: input.vlmConfig.websiteModeEnabled,
-        ...(input.thinkingConfig.enabled && input.thinkingConfig.effortSupported
-          ? { reasoning_effort: input.thinkingConfig.effort }
-          : {}),
+      auditBody: buildZaiBrowserAuditBody({
+        messages: input.messages,
+        modelId: input.modelId,
+        thinkingConfig: input.thinkingConfig,
+        vlmConfig: input.vlmConfig,
+        imageCount: attachments.length,
+      }),
+    };
+  }
+
+  /**
+   * Signed-API transport: create a chat server-side, then POST the completion with
+   * a CAPTCHA proof and a per-request signature. Only reachable when the caller
+   * supplied a proof and sent no images.
+   */
+  private async fetchViaSignedApi(
+    request: ZaiResolvedRequest,
+    input: ExecuteInput
+  ): Promise<ZaiTransportResult | { errorResult: ReturnType<typeof makeErrorResult> }> {
+    const { body, signal } = input;
+    const bodyObj = (body || {}) as Record<string, unknown>;
+    const { messages, modelId, prompt, thinkingConfig, token, userId, vlmConfig } = request;
+
+    const frontendVersion = await this.resolveFrontendVersion(signal);
+    const createdChat = await this.createRemoteChat({
+      messages,
+      modelId,
+      token,
+      enableThinking: thinkingConfig.enabled,
+      reasoningEffort: thinkingConfig.effort,
+      vlmConfig,
+      signal,
+      originalBody: body,
+    });
+    if ("errorResult" in createdChat) return createdChat;
+
+    const timestamp = Date.now();
+    const requestId = randomUUID();
+    const signature = buildZaiSignature({ prompt, requestId, timestamp, userId });
+    const completionUrl = buildZaiCompletionUrl({ requestId, timestamp, token, userId });
+    const reqHeaders = buildZaiHeaders(token, {
+      accept: "text/event-stream",
+      frontendVersion,
+      signature,
+    });
+    const reqBody = buildZaiRequestBody({
+      body: bodyObj,
+      captchaVerifyParam: request.captchaVerifyParam,
+      chatId: createdChat.chatId,
+      messages,
+      modelId,
+      prompt,
+      userMessageId: createdChat.userMessageId,
+      enableThinking: thinkingConfig.enabled,
+      reasoningEffort: thinkingConfig.effort,
+      reasoningEffortSupported: thinkingConfig.effortSupported,
+      vlmConfig,
+    });
+    const fetched = await this.fetchUpstream(completionUrl, reqHeaders, reqBody, body, signal);
+    if ("errorResult" in fetched) return fetched;
+
+    return {
+      upstream: fetched.upstream,
+      auditHeaders: {
+        ...reqHeaders,
+        Authorization: "Bearer [REDACTED]",
+        "X-Signature": "[REDACTED]",
       },
+      auditBody: { ...reqBody, captcha_verify_param: "[REDACTED]" },
     };
   }
 
   async execute(input: ExecuteInput) {
-    const { body, credentials, model, signal, stream: wantStream } = input;
-    const bodyObj = (body || {}) as Record<string, unknown>;
+    const { body, signal, stream: wantStream } = input;
 
-    const rawCredential = String(credentials?.apiKey ?? credentials?.accessToken ?? "").trim();
-    const token = extractZaiToken(rawCredential);
-    if (!token) {
-      return makeErrorResult(
-        400,
-        'Missing Z.ai web-session credential — copy the "token" value from chat.z.ai Local Storage.',
-        body,
-        ZAI_CHAT_URL
-      );
-    }
+    const resolved = resolveZaiRequest(input);
+    if ("errorResult" in resolved) return resolved.errorResult;
+    const request = resolved.request;
+    const { imageUrls, messages, modelId, thinkingConfig, token, vlmConfig } = request;
 
-    const captchaVerifyParam = resolveZaiCaptchaVerifyParam(credentials, bodyObj);
-    const messages = (bodyObj.messages as Array<{ role: string; content: unknown }>) || [];
-    const prompt = latestUserPrompt(messages);
-    const imageUrls = collectZaiImageUrls(messages);
-    if (!prompt && imageUrls.length === 0) {
-      return makeErrorResult(400, "Z.ai requires at least one user message", body, ZAI_CHAT_URL);
-    }
-
-    const modelId = (bodyObj.model as string) || model || ZAI_DEFAULT_MODEL;
-    if (imageUrls.length > 0 && !getZaiModelCapabilities(modelId).vision) {
-      return makeErrorResult(
-        400,
-        `Z.ai model ${unprefixedModelId(modelId)} does not accept image input; use GLM-5V-Turbo.`,
-        body,
-        ZAI_CHAT_URL
-      );
-    }
-    const userId = extractZaiUserId(token);
-    if (!userId) {
-      return makeErrorResult(
-        400,
-        "Invalid Z.ai web-session credential — its JWT payload does not contain the required user id.",
-        body,
-        ZAI_CHAT_URL
-      );
-    }
-    const thinkingConfig = resolveZaiThinkingConfig(modelId, bodyObj);
-    const vlmConfig = resolveZaiVlmConfig(modelId, bodyObj);
-    let upstream: Response;
-    let auditHeaders: Record<string, string>;
-    let auditBody: Record<string, unknown>;
-
-    if (captchaVerifyParam && imageUrls.length === 0) {
-      const frontendVersion = await this.resolveFrontendVersion(signal);
-      const createdChat = await this.createRemoteChat({
-        messages,
-        modelId,
-        token,
-        enableThinking: thinkingConfig.enabled,
-        reasoningEffort: thinkingConfig.effort,
-        vlmConfig,
-        signal,
-        originalBody: body,
-      });
-      if ("errorResult" in createdChat) return createdChat.errorResult;
-
-      const timestamp = Date.now();
-      const requestId = randomUUID();
-      const signature = buildZaiSignature({ prompt, requestId, timestamp, userId });
-      const completionUrl = buildZaiCompletionUrl({ requestId, timestamp, token, userId });
-      const reqHeaders = buildZaiHeaders(token, {
-        accept: "text/event-stream",
-        frontendVersion,
-        signature,
-      });
-      const reqBody = buildZaiRequestBody({
-        body: bodyObj,
-        captchaVerifyParam,
-        chatId: createdChat.chatId,
-        messages,
-        modelId,
-        prompt,
-        userMessageId: createdChat.userMessageId,
-        enableThinking: thinkingConfig.enabled,
-        reasoningEffort: thinkingConfig.effort,
-        reasoningEffortSupported: thinkingConfig.effortSupported,
-        vlmConfig,
-      });
-      const fetched = await this.fetchUpstream(completionUrl, reqHeaders, reqBody, body, signal);
-      if ("errorResult" in fetched) return fetched.errorResult;
-      upstream = fetched.upstream;
-      auditHeaders = {
-        ...reqHeaders,
-        Authorization: "Bearer [REDACTED]",
-        "X-Signature": "[REDACTED]",
-      };
-      auditBody = {
-        ...reqBody,
-        captcha_verify_param: "[REDACTED]",
-      };
-    } else {
-      const fetched = await this.fetchThroughBrowser({
-        body,
-        imageUrls,
-        messages,
-        modelId,
-        signal,
-        thinkingConfig,
-        token,
-        vlmConfig,
-      });
-      if ("errorResult" in fetched) return fetched.errorResult;
-      ({ upstream, auditHeaders, auditBody } = fetched);
-    }
+    const useSignedApi = Boolean(request.captchaVerifyParam) && imageUrls.length === 0;
+    const fetched = useSignedApi
+      ? await this.fetchViaSignedApi(request, input)
+      : await this.fetchThroughBrowser({
+          body,
+          imageUrls,
+          messages,
+          modelId,
+          signal,
+          thinkingConfig,
+          token,
+          vlmConfig,
+        });
+    if ("errorResult" in fetched) return fetched.errorResult;
+    const { upstream, auditHeaders, auditBody } = fetched;
 
     const id = `chatcmpl-zai-${Date.now()}`;
     const created = Math.floor(Date.now() / 1000);

--- a/open-sse/executors/zai-web.ts
+++ b/open-sse/executors/zai-web.ts
@@ -1,714 +1,97 @@
 /**
  * ZaiWebExecutor — Z.ai consumer chat (chat.z.ai).
  *
- * This is distinct from the API-key `zai` / `glm` providers at api.z.ai.
- * The current consumer frontend keeps its Bearer JWT in localStorage, creates
- * a remote chat through /api/v1/chats/new, then sends signed completion
- * requests to /api/v2/chat/completions. The completion endpoint also requires
- * a browser-issued captcha_verify_param. OmniRoute obtains it through the
- * browser-backed transport by default; a caller-supplied proof keeps the
- * lower-overhead direct HTTP path available.
+ * The consumer frontend stores a Bearer JWT in localStorage and requires a
+ * browser-issued CAPTCHA proof for chat completions. The browser transport is
+ * the default; callers with a short-lived proof can use the direct HTTP path.
  *
- * The older unversioned `/api/chat/completions` path is stale and 404s
- * model-independently as of 2026-07 (#8014); the v2 endpoint above supersedes it.
- *
- * Response frames use Z.ai's internal SSE envelope:
- * `{"type":"chat:completion","data":{"delta_content":"...","phase":"answer"}}`.
+ * Completions go to /api/v2/chat/completions; the older unversioned
+ * /api/chat/completions path is stale and 404s model-independently (#8014).
  */
-import { Buffer } from "node:buffer";
-import { createHash, createHmac, randomUUID } from "node:crypto";
-import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
+import { createHash, randomUUID } from "node:crypto";
+import { BaseExecutor, type ExecuteInput } from "./base.ts";
+import { configureZaiBrowserRequest } from "./zai-web/browserAutomation.ts";
+import {
+  asRecord,
+  browserModelName,
+  browserPrompt,
+  buildZaiCompletionUrl,
+  buildZaiHeaders,
+  buildZaiNewChatBody,
+  buildZaiRequestBody,
+  buildZaiSignature,
+  collectZaiImageUrls,
+  describeZaiBrowserFailure,
+  extractZaiToken,
+  extractZaiUserId,
+  foldMessages,
+  getZaiModelCapabilities,
+  latestUserPrompt,
+  parseZaiFrontendVersion,
+  resolveZaiCaptchaVerifyParam,
+  resolveZaiThinkingConfig,
+  resolveZaiVlmConfig,
+  unprefixedModelId,
+  zaiImageFileName,
+  ZAI_BASE_URL,
+  ZAI_CHAT_URL,
+  ZAI_DEFAULT_FE_VERSION,
+  ZAI_DEFAULT_MODEL,
+  ZAI_FE_VERSION_CACHE_TTL_MS,
+  ZAI_NEW_CHAT_URL,
+  ZAI_USER_AGENT,
+  type ZaiReasoningEffort,
+  type ZaiThinkingConfig,
+  type ZaiVlmConfig,
+} from "./zai-web/protocol.ts";
+import {
+  buildZaiStreamingBody,
+  collectZaiNonStreaming,
+  makeZaiChunkEmitter,
+} from "./zai-web/stream.ts";
 import { browserBackedChat } from "../services/browserBackedChat.ts";
+import { CursorImageError, resolveCursorImages } from "../utils/cursorImages.ts";
 import {
   makeExecutorErrorResult as makeErrorResult,
-  normalizeCookie,
   sanitizeErrorMessage,
 } from "../utils/error.ts";
-import { CursorImageError, extractImageUrls, resolveCursorImages } from "../utils/cursorImages.ts";
 
-const BASE_URL = "https://chat.z.ai";
-const NEW_CHAT_URL = `${BASE_URL}/api/v1/chats/new`;
-const CHAT_URL = `${BASE_URL}/api/v2/chat/completions`;
-const DEFAULT_MODEL = "GLM-5.1";
-const DEFAULT_FE_VERSION = "prod-fe-1.1.79";
-const CLIENT_PROTOCOL_VERSION = "0.0.1";
-const SIGNATURE_KEY = "key-@@@@)))()((9))-xxxx&&&%%%%%";
-const USER_AGENT =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
-const FE_VERSION_CACHE_TTL_MS = 15 * 60 * 1000;
+export {
+  buildZaiSignature,
+  describeZaiBrowserFailure,
+  extractZaiCaptchaVerifyParam,
+  extractZaiToken,
+  extractZaiUserId,
+  foldMessages,
+  getZaiModelCapabilities,
+  parseZaiFrontendVersion,
+  resolveZaiThinkingConfig,
+  resolveZaiVlmConfig,
+} from "./zai-web/protocol.ts";
+export type {
+  ZaiModelCapabilities,
+  ZaiReasoningEffort,
+  ZaiThinkingConfig,
+  ZaiVlmConfig,
+} from "./zai-web/protocol.ts";
+export { parseZaiFrame } from "./zai-web/stream.ts";
+export type { ZaiDelta } from "./zai-web/stream.ts";
 
 let cachedFeVersion: { value: string; expiresAt: number } | null = null;
 
-interface NewChatRequest {
-  payload: Record<string, unknown>;
-  userMessageId: string;
-}
-
-export type ZaiReasoningEffort = "high" | "max";
-
-export interface ZaiThinkingConfig {
-  enabled: boolean;
-  effort: ZaiReasoningEffort;
-  effortSupported: boolean;
-  supported: boolean;
-}
-
-export interface ZaiModelCapabilities {
-  mcp: boolean;
-  reasoningEffort: boolean;
-  returnFc: boolean;
-  thinking: boolean;
-  vision: boolean;
-  vlmTools: boolean;
-  vlmWebSearch: boolean;
-  vlmWebsiteMode: boolean;
-  webSearch: boolean;
-}
-
-export interface ZaiVlmConfig {
-  toolsEnabled: boolean;
-  webSearchEnabled: boolean;
-  websiteModeEnabled: boolean;
-}
-
-const NO_ZAI_MODEL_CAPABILITIES: ZaiModelCapabilities = Object.freeze({
-  mcp: false,
-  reasoningEffort: false,
-  returnFc: false,
-  thinking: false,
-  vision: false,
-  vlmTools: false,
-  vlmWebSearch: false,
-  vlmWebsiteMode: false,
-  webSearch: false,
-});
-
-/**
- * Verified against chat.z.ai/api/models (prod-fe-1.1.79).
- * `returnFc` is the site's internal function-call result capability; it is
- * distinct from accepting caller-supplied OpenAI `tools`.
- */
-const ZAI_MODEL_CAPABILITIES: Record<string, ZaiModelCapabilities> = {
-  "glm-5.2": {
-    mcp: true,
-    reasoningEffort: true,
-    returnFc: true,
-    thinking: true,
-    vision: false,
-    vlmTools: false,
-    vlmWebSearch: false,
-    vlmWebsiteMode: false,
-    webSearch: true,
-  },
-  "glm-5.1": {
-    mcp: true,
-    reasoningEffort: false,
-    returnFc: true,
-    thinking: true,
-    vision: false,
-    vlmTools: false,
-    vlmWebSearch: false,
-    vlmWebsiteMode: false,
-    webSearch: true,
-  },
-  "glm-5-turbo": {
-    mcp: true,
-    reasoningEffort: false,
-    returnFc: true,
-    thinking: true,
-    vision: false,
-    vlmTools: false,
-    vlmWebSearch: false,
-    vlmWebsiteMode: false,
-    webSearch: true,
-  },
-  "glm-5v-turbo": {
-    mcp: false,
-    reasoningEffort: false,
-    returnFc: true,
-    thinking: true,
-    vision: true,
-    vlmTools: true,
-    vlmWebSearch: true,
-    vlmWebsiteMode: true,
-    webSearch: true,
-  },
-};
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function browserFailureDetail(body: Buffer): string {
-  const raw = body.toString("utf8").trim();
-  if (!raw) return "";
-  try {
-    const parsed = asRecord(JSON.parse(raw));
-    const error = asRecord(parsed?.error);
-    const detail = error?.message ?? parsed?.detail ?? parsed?.message;
-    if (typeof detail === "string") return sanitizeErrorMessage(detail).slice(0, 500);
-  } catch {
-    // Non-JSON upstream errors are still useful after sanitizing and bounding them.
-  }
-  return sanitizeErrorMessage(raw).slice(0, 500);
-}
-
-export function describeZaiBrowserFailure(result: {
-  status: number;
-  body: Buffer;
-  observedPostUrls?: string[];
-  timing: { captureResponseMs: number; totalMs: number };
-}): string {
-  const status = result.status > 0 ? String(result.status) : "no matching response";
-  const timing = `capture ${result.timing.captureResponseMs}ms, total ${result.timing.totalMs}ms`;
-  const observed =
-    result.observedPostUrls && result.observedPostUrls.length > 0
-      ? ` Observed POST targets: ${result.observedPostUrls.join(", ")}.`
-      : "";
-  const detail =
-    browserFailureDetail(result.body) ||
-    (result.status === 0
-      ? `The page did not issue the expected authenticated chat completion request.${observed}`
-      : "The browser response body was empty.");
-  return `Z.ai browser transport failed (${status}; ${timing}): ${detail}`;
-}
-
-function parseCredentialJson(raw: string): Record<string, unknown> | null {
-  if (!raw.trim().startsWith("{")) return null;
-  try {
-    return asRecord(JSON.parse(raw));
-  } catch {
-    return null;
-  }
-}
-
-/** Extract the localStorage Bearer token, while accepting legacy token= input. */
-export function extractZaiToken(rawCredential: string): string {
-  const trimmed = rawCredential.trim();
-  const json = parseCredentialJson(trimmed);
-  if (json) {
-    const token = json.token ?? json.accessToken ?? json.access_token;
-    return typeof token === "string" ? token.trim() : "";
-  }
-
-  const bearer = trimmed.match(/^(?:Authorization:\s*)?Bearer\s+(.+)$/i);
-  if (bearer) return bearer[1].trim();
-
-  const normalized = normalizeCookie(trimmed);
-  if (!normalized) return "";
-  const match = normalized.match(/(?:^|;\s*)token=([^;]+)/);
-  if (match) return match[1].trim();
-  return normalized.includes(";") || normalized.includes("=") ? "" : normalized;
-}
-
-/** Read the short-lived browser CAPTCHA proof from supported input locations. */
-export function extractZaiCaptchaVerifyParam(value: unknown): string {
-  const record = asRecord(value);
-  if (record) {
-    const direct =
-      record.captcha_verify_param ?? record.captchaVerifyParam ?? record.zaiCaptchaVerifyParam;
-    if (typeof direct === "string" && direct.trim()) return direct.trim();
-    const nested = asRecord(record.providerSpecificData);
-    if (nested) return extractZaiCaptchaVerifyParam(nested);
-    return "";
-  }
-
-  if (typeof value !== "string") return "";
-  const json = parseCredentialJson(value);
-  if (json) return extractZaiCaptchaVerifyParam(json);
-  const match = value.match(/(?:^|;\s*)captcha_verify_param=([^;]+)/);
-  return match?.[1]?.trim() ?? "";
-}
-
-export function extractZaiUserId(token: string): string {
-  const payload = token.split(".")[1];
-  if (!payload) return "";
-  try {
-    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
-    return typeof decoded?.id === "string" ? decoded.id : "";
-  } catch {
-    return "";
-  }
-}
-
-export function buildZaiSignature(input: {
-  prompt: string;
-  requestId: string;
-  timestamp: number | string;
-  userId: string;
-}): string {
-  const timestamp = String(input.timestamp);
-  const sortedPayload = Object.entries({
-    timestamp,
-    requestId: input.requestId,
-    user_id: input.userId,
-  })
-    .sort(([left], [right]) => left.localeCompare(right))
-    .join(",");
-  const encodedPrompt = Buffer.from(input.prompt, "utf8").toString("base64");
-  const bucket = Math.floor(Number(timestamp) / (5 * 60 * 1000));
-  const derivedKey = createHmac("sha256", SIGNATURE_KEY).update(String(bucket)).digest("hex");
-  return createHmac("sha256", derivedKey)
-    .update(`${sortedPayload}|${encodedPrompt}|${timestamp}`)
-    .digest("hex");
-}
-
-export function parseZaiFrontendVersion(html: string): string | null {
-  return html.match(/\/frontend\/(prod-fe-\d+(?:\.\d+)*)\/assets\//)?.[1] ?? null;
-}
-
-function textContent(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .flatMap((part) => {
-      const record = asRecord(part);
-      if (!record || (record.type !== "text" && record.type !== "input_text")) return [];
-      const text = record.text ?? record.content;
-      return typeof text === "string" ? [text] : [];
-    })
-    .join("\n");
-}
-
-function latestUserPrompt(messages: Array<{ role: string; content: unknown }>): string {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    if (messages[index]?.role !== "user") continue;
-    return textContent(messages[index].content);
-  }
-  return "";
-}
-
-function browserPrompt(messages: Array<{ role: string; content: unknown }>): string {
-  const folded = foldMessages(messages);
-  if (folded.length === 1 && folded[0]?.role === "user") return folded[0].content;
-  return folded.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join("\n\n");
-}
-
-function collectZaiImageUrls(messages: Array<{ role: string; content: unknown }>): string[] {
-  return messages.flatMap((message) =>
-    message.role === "user" ? extractImageUrls(message.content) : []
-  );
-}
-
-function zaiImageFileName(mimeType: string, index: number): string {
-  const normalized = mimeType.toLowerCase().split(";")[0].trim();
-  const extension =
-    normalized === "image/jpeg"
-      ? "jpg"
-      : normalized === "image/svg+xml"
-        ? "svg"
-        : normalized.startsWith("image/")
-          ? normalized.slice("image/".length).replace(/[^a-z0-9]/g, "") || "png"
-          : "png";
-  return `omniroute-image-${index + 1}.${extension}`;
-}
-
-function unprefixedModelId(modelId: string): string {
-  return modelId.trim().split("/").at(-1) || modelId.trim();
-}
-
-function browserModelName(modelId: string): string {
-  const unprefixed = unprefixedModelId(modelId);
-  if (unprefixed.toLowerCase() === "glm-5.2") return "GLM-5.2";
-  if (unprefixed.toLowerCase() === "glm-5v-turbo") return "GLM-5V-Turbo";
-  return unprefixed;
-}
-
-export function getZaiModelCapabilities(modelId: string): ZaiModelCapabilities {
-  return (
-    ZAI_MODEL_CAPABILITIES[unprefixedModelId(modelId).toLowerCase()] ?? NO_ZAI_MODEL_CAPABILITIES
-  );
-}
-
-function getFeatureOption(body: Record<string, unknown>, key: string): unknown {
-  if (body[key] !== undefined) return body[key];
-  return asRecord(body.features)?.[key];
-}
-
-/** Resolve each model's Deep Think control; only GLM-5.2 accepts High/Max effort. */
-export function resolveZaiThinkingConfig(
-  modelId: string,
-  body: Record<string, unknown>
-): ZaiThinkingConfig {
-  const capabilities = getZaiModelCapabilities(modelId);
-  const supported = capabilities.thinking;
-  const reasoning = asRecord(body.reasoning);
-  const rawEffort =
-    typeof body.reasoning_effort === "string"
-      ? body.reasoning_effort.trim().toLowerCase()
-      : typeof reasoning?.effort === "string"
-        ? reasoning.effort.trim().toLowerCase()
-        : "";
-  const disabled = body.enable_thinking === false || rawEffort === "none" || rawEffort === "off";
-  const effort: ZaiReasoningEffort =
-    rawEffort === "low" || rawEffort === "medium" || rawEffort === "high" ? "high" : "max";
-
-  return {
-    supported,
-    enabled: supported && !disabled,
-    effort,
-    effortSupported: capabilities.reasoningEffort,
-  };
-}
-
-/** Resolve GLM-5V-Turbo's visible Web Search and Tools controls. */
-export function resolveZaiVlmConfig(modelId: string, body: Record<string, unknown>): ZaiVlmConfig {
-  const capabilities = getZaiModelCapabilities(modelId);
-  const toolsOption = getFeatureOption(body, "vlm_tools_enable");
-  const webSearchOption =
-    getFeatureOption(body, "vlm_web_search_enable") ??
-    getFeatureOption(body, "auto_web_search") ??
-    getFeatureOption(body, "web_search");
-  const webSearchEnabled =
-    webSearchOption === true || (webSearchOption !== false && capabilities.vlmWebSearch);
-  return {
-    toolsEnabled: capabilities.vlmTools && toolsOption !== false,
-    webSearchEnabled: capabilities.webSearch && webSearchEnabled,
-    websiteModeEnabled: capabilities.vlmWebsiteMode,
-  };
-}
-
-async function selectZaiBrowserModel(
-  page: import("playwright").Page,
-  modelName: string
-): Promise<void> {
-  const selector = page.locator('[aria-label="Select a model"]').first();
-  await selector.waitFor({ state: "visible", timeout: 10_000 });
-  if ((await selector.innerText()).includes(modelName)) return;
-
-  // The landing-page hero animation can remain above the already-visible
-  // selector and make coordinate-based clicks time out. Dispatch the click on
-  // the control itself, as we do for the Deep Think menu trigger below.
-  await selector.evaluate((element) => (element as HTMLElement).click());
-  const menu = page.locator('[role="menu"]').filter({ hasText: modelName }).first();
-  await menu.waitFor({ state: "visible", timeout: 5_000 });
-  const modelButton = menu.locator("button").filter({ hasText: modelName }).first();
-  await modelButton.evaluate((element) => (element as HTMLElement).click());
-  await page
-    .locator('[aria-label="Select a model"]')
-    .filter({ hasText: modelName })
-    .first()
-    .waitFor({ state: "visible", timeout: 5_000 });
-}
-
-async function setZaiBrowserToggle(
-  page: import("playwright").Page,
-  label: "Deep think" | "Tools" | "Web search",
-  dataAttribute: "data-autothink" | "data-selected",
-  enabled: boolean
-): Promise<void> {
-  const wrapper = page.locator(`[aria-label^="${label} "]`).first();
-  await wrapper.waitFor({ state: "visible", timeout: 5_000 });
-  const button = wrapper.locator(`button[${dataAttribute}]`).first();
-  const current = (await button.getAttribute(dataAttribute)) === "true";
-  if (current !== enabled) await button.click({ timeout: 5_000 });
-}
-
-async function setZaiBrowserWebSearch(
-  page: import("playwright").Page,
-  enabled: boolean
-): Promise<void> {
-  const labelledWrapper = page.locator('[aria-label^="Web search "]').first();
-  if ((await labelledWrapper.count()) > 0) {
-    await setZaiBrowserToggle(page, "Web search", "data-selected", enabled);
-    return;
-  }
-
-  // Text-model UI: the globe button has no accessible label. Anchor the
-  // lookup to the adjacent upload button instead of relying on generated IDs.
-  const button = page
-    .locator("#upload-file-button")
-    .locator("xpath=../../../following-sibling::div//button[@data-active]")
-    .first();
-  await button.waitFor({ state: "visible", timeout: 5_000 });
-  const current = (await button.getAttribute("data-active")) === "true";
-  if (current !== enabled) {
-    await button.click({ timeout: 5_000 });
-    // The same control also opens the search-mode popover. Close it so it
-    // cannot retain focus or cover the composer controls during submission.
-    await page.keyboard.press("Escape");
-  }
-}
-
-async function configureZaiBrowserEffort(
-  page: import("playwright").Page,
-  config: ZaiThinkingConfig
-): Promise<void> {
-  const trigger = page
-    .locator("[data-dropdown-menu-trigger]")
-    .filter({ hasText: "Deep Think" })
-    .first();
-  await trigger.waitFor({ state: "visible", timeout: 10_000 });
-  try {
-    // The landing-page intro can leave a transparent animation layer over this
-    // already-visible trigger in headless Chromium. A DOM click targets the
-    // stable trigger itself instead of the temporary layer at its coordinates.
-    await trigger.evaluate((element) => (element as HTMLElement).click());
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`open menu: ${message}`);
-  }
-
-  const menu = page.locator('[role="menu"]').filter({ hasText: "Deep Think" }).first();
-  await menu.waitFor({ state: "visible", timeout: 5_000 });
-  const toggle = menu.locator('[role="switch"]').first();
-  const checked = (await toggle.getAttribute("aria-checked")) === "true";
-
-  if (!config.enabled) {
-    if (checked) {
-      try {
-        await toggle.click({ timeout: 5_000 });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`disable toggle: ${message}`);
-      }
-    }
-  } else {
-    if (!checked) {
-      try {
-        await toggle.click({ timeout: 5_000 });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`enable toggle: ${message}`);
-      }
-    }
-    const effortButton = menu.locator("button").filter({
-      hasText: config.effort === "high" ? "High" : "Max",
-    });
-    if ((await effortButton.getAttribute("data-selected")) !== "true") {
-      try {
-        // The same landing-page animation that can cover the model selector
-        // can also intercept this menu item's coordinate click.
-        await effortButton.evaluate((element) => (element as HTMLElement).click());
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`select ${config.effort}: ${message}`);
-      }
-    }
-  }
-
-  if (await menu.isVisible()) {
-    await page.keyboard.press("Escape");
-  }
-}
-
-async function configureZaiBrowserRequest(
-  page: import("playwright").Page,
-  input: {
-    modelId: string;
-    thinking: ZaiThinkingConfig;
-    vlm: ZaiVlmConfig;
-  }
-): Promise<void> {
-  const runStage = async (name: string, action: () => Promise<void>): Promise<void> => {
-    try {
-      await action();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`${name}: ${message}`);
-    }
-  };
-
-  await runStage("model selection", () =>
-    selectZaiBrowserModel(page, browserModelName(input.modelId))
-  );
-
-  if (input.thinking.effortSupported) {
-    await runStage("Deep Think effort", () => configureZaiBrowserEffort(page, input.thinking));
-  } else if (input.thinking.supported) {
-    await runStage("Deep Think toggle", () =>
-      setZaiBrowserToggle(page, "Deep think", "data-autothink", input.thinking.enabled)
-    );
-  }
-
-  const capabilities = getZaiModelCapabilities(input.modelId);
-  if (capabilities.webSearch) {
-    await runStage("web search toggle", () =>
-      setZaiBrowserWebSearch(page, input.vlm.webSearchEnabled)
-    );
-  }
-  if (capabilities.vlmTools) {
-    await runStage("tools toggle", () =>
-      setZaiBrowserToggle(page, "Tools", "data-selected", input.vlm.toolsEnabled)
-    );
-  }
-}
-
-function resolveCaptchaVerifyParam(
-  credentials: ProviderCredentials,
-  body: Record<string, unknown>
-): string {
-  return (
-    extractZaiCaptchaVerifyParam(body) ||
-    extractZaiCaptchaVerifyParam(credentials.providerSpecificData) ||
-    extractZaiCaptchaVerifyParam(credentials.apiKey) ||
-    extractZaiCaptchaVerifyParam(credentials.accessToken)
-  );
-}
-
-/**
- * One parsed delta out of a z.ai SSE frame: either a content/reasoning chunk
- * or a signal that the stream has finished.
- */
-export interface ZaiDelta {
-  content: string;
-  reasoning: string;
-  done: boolean;
-}
-
-/** Parse an already OpenAI-shaped `{choices:[{delta}]}` pass-through frame. */
-function parseOpenAiShapedFrame(choices: Array<Record<string, unknown>>): ZaiDelta {
-  const delta = (choices[0]?.delta ?? {}) as Record<string, unknown>;
-  const finishReason = choices[0]?.finish_reason;
-  return {
-    content: typeof delta.content === "string" ? delta.content : "",
-    reasoning: typeof delta.reasoning_content === "string" ? delta.reasoning_content : "",
-    done: finishReason != null,
-  };
-}
-
-/** Parse the z.ai / chatglm internal `{data:{delta_content,phase,done}}` envelope. */
-function parseInternalEnvelopeFrame(
-  frame: Record<string, unknown>,
-  data: Record<string, unknown>
-): ZaiDelta | null {
-  const phase = String(data.phase ?? "");
-  const deltaContent = data.delta_content ?? data.edit_content ?? data.content;
-  const done =
-    data.done === true ||
-    phase === "done" ||
-    phase === "finish" ||
-    String(frame.type ?? "") === "chat:completion:finish";
-
-  if (typeof deltaContent === "string" && deltaContent) {
-    const isThinking = phase === "thinking";
-    return {
-      content: isThinking ? "" : deltaContent,
-      reasoning: isThinking ? deltaContent : "",
-      done,
-    };
-  }
-  if (done) return { content: "", reasoning: "", done: true };
-  return null;
-}
-
-/**
- * Parse a single decoded z.ai SSE `data:` JSON payload into a normalized
- * delta. Handles both the internal `{data:{delta_content,phase,done}}`
- * envelope and a pass-through OpenAI-shaped `{choices:[{delta}]}` frame.
- */
-export function parseZaiFrame(raw: unknown): ZaiDelta | null {
-  if (!raw || typeof raw !== "object") return null;
-  const frame = raw as Record<string, unknown>;
-
-  const choices = frame.choices as Array<Record<string, unknown>> | undefined;
-  if (Array.isArray(choices) && choices.length > 0) {
-    return parseOpenAiShapedFrame(choices);
-  }
-
-  const data = (frame.data ?? frame) as Record<string, unknown>;
-  return parseInternalEnvelopeFrame(frame, data);
-}
-
-export function foldMessages(
-  messages: Array<{ role: string; content: unknown }>
-): Array<{ role: string; content: string }> {
-  return messages.map((m) => ({
-    role: m.role,
-    content: textContent(m.content),
-  }));
-}
-
-/** Split a chunk of decoded SSE text into complete `data:` payload strings. */
-function extractSseDataPayloads(buffer: { text: string }, incoming: string): string[] {
-  buffer.text += incoming;
-  const lines = buffer.text.split("\n");
-  buffer.text = lines.pop() || "";
-  const payloads: string[] = [];
-  for (const line of lines) {
-    if (!line.startsWith("data:")) continue;
-    const data = line.slice(5).trim();
-    if (!data || data === "[DONE]") continue;
-    payloads.push(data);
-  }
-  return payloads;
-}
-
-/** Parse a raw SSE payload string into a normalized delta, or null if unusable. */
-function parseSsePayload(data: string): ZaiDelta | null {
-  try {
-    return parseZaiFrame(JSON.parse(data));
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Read the upstream SSE body to completion, invoking `onDelta` for every
- * parsed delta. Returns true when `onDelta` signalled the stream ended
- * (returned true), false when the body was exhausted without a done delta.
- */
-async function drainSseDeltas(
-  sourceBody: ReadableStream<Uint8Array>,
-  onDelta: (delta: ZaiDelta) => boolean
-): Promise<boolean> {
-  const decoder = new TextDecoder();
-  const reader = sourceBody.getReader();
-  const buffer = { text: "" };
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) return false;
-    const payloads = extractSseDataPayloads(buffer, decoder.decode(value, { stream: true }));
-    for (const raw of payloads) {
-      const delta = parseSsePayload(raw);
-      if (delta && onDelta(delta)) return true;
-    }
-  }
-}
-
-type ChunkEmitter = (
-  controller: ReadableStreamDefaultController,
-  delta: Record<string, unknown>,
-  finish?: string | null
-) => void;
-
-/** Emit role/reasoning/content/stop chunks for one delta. Returns true when the stream ended. */
-function emitDeltaChunks(
-  controller: ReadableStreamDefaultController,
-  delta: ZaiDelta,
-  emitChunk: ChunkEmitter,
-  roleState: { emitted: boolean }
-): boolean {
-  if (!roleState.emitted && (delta.content || delta.reasoning)) {
-    roleState.emitted = true;
-    emitChunk(controller, { role: "assistant", content: "" });
-  }
-  if (delta.reasoning) emitChunk(controller, { reasoning_content: delta.reasoning });
-  if (delta.content) emitChunk(controller, { content: delta.content });
-  if (delta.done) {
-    emitChunk(controller, {}, "stop");
-    controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
-    controller.close();
-    return true;
-  }
-  return false;
-}
-
 export class ZaiWebExecutor extends BaseExecutor {
   constructor() {
-    super("zai-web", { id: "zai-web", baseUrl: BASE_URL });
+    super("zai-web", { id: "zai-web", baseUrl: ZAI_BASE_URL });
   }
 
   private async resolveFrontendVersion(signal?: AbortSignal | null): Promise<string> {
     if (cachedFeVersion && cachedFeVersion.expiresAt > Date.now()) {
       return cachedFeVersion.value;
     }
-    let version = DEFAULT_FE_VERSION;
+    let version = ZAI_DEFAULT_FE_VERSION;
     try {
-      const response = await fetch(`${BASE_URL}/`, {
-        headers: { Accept: "text/html", "User-Agent": USER_AGENT },
+      const response = await fetch(`${ZAI_BASE_URL}/`, {
+        headers: { Accept: "text/html", "User-Agent": ZAI_USER_AGENT },
         signal,
       });
       if (response.ok) {
@@ -717,198 +100,11 @@ export class ZaiWebExecutor extends BaseExecutor {
     } catch {
       // The current verified version remains a safe fallback when homepage probing fails.
     }
-    cachedFeVersion = { value: version, expiresAt: Date.now() + FE_VERSION_CACHE_TTL_MS };
+    cachedFeVersion = {
+      value: version,
+      expiresAt: Date.now() + ZAI_FE_VERSION_CACHE_TTL_MS,
+    };
     return version;
-  }
-
-  private buildZaiHeaders(
-    token: string,
-    options: {
-      accept: "application/json" | "text/event-stream";
-      frontendVersion?: string;
-      signature?: string;
-    }
-  ): Record<string, string> {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      Accept: options.accept,
-      "Accept-Language": "en-US",
-      "User-Agent": USER_AGENT,
-      Origin: BASE_URL,
-      Referer: `${BASE_URL}/`,
-      Authorization: `Bearer ${token}`,
-    };
-    if (options.frontendVersion) headers["X-FE-Version"] = options.frontendVersion;
-    if (options.signature) headers["X-Signature"] = options.signature;
-    return headers;
-  }
-
-  private buildCompletionUrl(input: {
-    requestId: string;
-    timestamp: number;
-    token: string;
-    userId: string;
-  }): string {
-    const now = new Date(input.timestamp);
-    const params = new URLSearchParams({
-      timestamp: String(input.timestamp),
-      requestId: input.requestId,
-      user_id: input.userId,
-      version: CLIENT_PROTOCOL_VERSION,
-      platform: "web",
-      token: input.token,
-      user_agent: USER_AGENT,
-      language: "en-US",
-      languages: "en-US,en",
-      timezone: "UTC",
-      cookie_enabled: "true",
-      screen_width: "1280",
-      screen_height: "800",
-      screen_resolution: "1280x800",
-      viewport_height: "800",
-      viewport_width: "1280",
-      viewport_size: "1280x800",
-      color_depth: "24",
-      pixel_ratio: "1",
-      current_url: `${BASE_URL}/`,
-      pathname: "/",
-      search: "",
-      hash: "",
-      host: "chat.z.ai",
-      hostname: "chat.z.ai",
-      protocol: "https:",
-      referrer: "",
-      title: "Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2",
-      timezone_offset: "0",
-      local_time: now.toISOString(),
-      utc_time: now.toUTCString(),
-      is_mobile: "false",
-      is_touch: "false",
-      max_touch_points: "0",
-      browser_name: "Chrome",
-      os_name: "Mac OS",
-      signature_timestamp: String(input.timestamp),
-    });
-    return `${CHAT_URL}?${params.toString()}`;
-  }
-
-  private buildNewChatBody(
-    messages: Array<{ role: string; content: unknown }>,
-    modelId: string,
-    enableThinking: boolean,
-    reasoningEffort: ZaiReasoningEffort,
-    vlmConfig: ZaiVlmConfig
-  ): NewChatRequest {
-    const prompt = latestUserPrompt(messages);
-    const userMessageId = randomUUID();
-    return {
-      userMessageId,
-      payload: {
-        chat: {
-          id: "",
-          title: "New Chat",
-          models: [modelId],
-          params: {},
-          history: {
-            messages: {
-              [userMessageId]: {
-                id: userMessageId,
-                parentId: null,
-                childrenIds: [],
-                role: "user",
-                content: prompt,
-                timestamp: Math.floor(Date.now() / 1000),
-                models: [modelId],
-              },
-            },
-            currentId: userMessageId,
-          },
-          tags: [],
-          flags: [],
-          features: [
-            {
-              server: "tool_selector_h",
-              status: "hidden",
-              type: "tool_selector",
-            },
-          ],
-          mcp_servers: [],
-          enable_thinking: enableThinking,
-          reasoning_effort: reasoningEffort,
-          auto_web_search: vlmConfig.webSearchEnabled,
-          message_version: 1,
-          extra: {
-            vlm_tools_enable: vlmConfig.toolsEnabled,
-            vlm_web_search_enable: vlmConfig.websiteModeEnabled && vlmConfig.webSearchEnabled,
-            vlm_website_mode: vlmConfig.websiteModeEnabled,
-          },
-          timestamp: Date.now(),
-          type: "default",
-        },
-      },
-    };
-  }
-
-  private buildRequestBody(input: {
-    body: Record<string, unknown>;
-    captchaVerifyParam: string;
-    chatId: string;
-    messages: Array<{ role: string; content: unknown }>;
-    modelId: string;
-    prompt: string;
-    userMessageId: string;
-    enableThinking: boolean;
-    reasoningEffort: ZaiReasoningEffort;
-    reasoningEffortSupported: boolean;
-    vlmConfig: ZaiVlmConfig;
-  }): Record<string, unknown> {
-    const params = Object.fromEntries(
-      ["temperature", "top_p", "max_tokens", "stop"]
-        .filter((key) => input.body[key] !== undefined)
-        .map((key) => [key, input.body[key]])
-    );
-    const features: Record<string, unknown> = {
-      image_generation: false,
-      web_search: false,
-      // The live frontend moves the visible search toggle into the VLM flag
-      // while a model is in website mode; text models use auto_web_search.
-      auto_web_search: input.vlmConfig.websiteModeEnabled
-        ? false
-        : input.vlmConfig.webSearchEnabled,
-      preview_mode: true,
-      flags: [],
-      vlm_tools_enable: input.vlmConfig.toolsEnabled,
-      vlm_web_search_enable: input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
-      vlm_website_mode: input.vlmConfig.websiteModeEnabled,
-      enable_thinking: input.enableThinking,
-    };
-    if (input.enableThinking && input.reasoningEffortSupported) {
-      features.reasoning_effort = input.reasoningEffort;
-    }
-    return {
-      stream: true,
-      model: input.modelId,
-      messages: foldMessages(input.messages),
-      signature_prompt: input.prompt,
-      params,
-      extra: {
-        vlm_tools_enable: input.vlmConfig.toolsEnabled,
-        vlm_web_search_enable:
-          input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
-        vlm_website_mode: input.vlmConfig.websiteModeEnabled,
-      },
-      features,
-      variables: {},
-      chat_id: input.chatId,
-      id: randomUUID(),
-      current_user_message_id: input.userMessageId,
-      current_user_message_parent_id: null,
-      background_tasks: {
-        title_generation: true,
-        tags_generation: true,
-      },
-      captcha_verify_param: input.captchaVerifyParam,
-    };
   }
 
   private async createRemoteChat(input: {
@@ -923,7 +119,7 @@ export class ZaiWebExecutor extends BaseExecutor {
   }): Promise<
     { chatId: string; userMessageId: string } | { errorResult: ReturnType<typeof makeErrorResult> }
   > {
-    const { userMessageId, payload } = this.buildNewChatBody(
+    const { userMessageId, payload } = buildZaiNewChatBody(
       input.messages,
       input.modelId,
       input.enableThinking,
@@ -932,9 +128,9 @@ export class ZaiWebExecutor extends BaseExecutor {
     );
     let response: Response;
     try {
-      response = await fetch(NEW_CHAT_URL, {
+      response = await fetch(ZAI_NEW_CHAT_URL, {
         method: "POST",
-        headers: this.buildZaiHeaders(input.token, {
+        headers: buildZaiHeaders(input.token, {
           accept: "application/json",
         }),
         body: JSON.stringify(payload),
@@ -949,7 +145,7 @@ export class ZaiWebExecutor extends BaseExecutor {
           502,
           `Z.ai chat creation failed: ${message}`,
           input.originalBody,
-          NEW_CHAT_URL
+          ZAI_NEW_CHAT_URL
         ),
       };
     }
@@ -960,7 +156,7 @@ export class ZaiWebExecutor extends BaseExecutor {
           response.status,
           `Z.ai chat creation error: ${sanitizeErrorMessage(errorText)}`,
           input.originalBody,
-          NEW_CHAT_URL
+          ZAI_NEW_CHAT_URL
         ),
       };
     }
@@ -972,60 +168,13 @@ export class ZaiWebExecutor extends BaseExecutor {
           502,
           "Z.ai chat creation returned no chat id",
           input.originalBody,
-          NEW_CHAT_URL
+          ZAI_NEW_CHAT_URL
         ),
       };
     }
     return { chatId, userMessageId };
   }
 
-  /** Drain the streaming response body into an OpenAI-shaped SSE ReadableStream. */
-  private buildStreamingBody(
-    sourceBody: ReadableStream<Uint8Array>,
-    modelId: string,
-    emitChunk: ChunkEmitter,
-    signal: AbortSignal | null | undefined
-  ): ReadableStream {
-    return new ReadableStream({
-      async start(controller) {
-        const roleState = { emitted: false };
-        try {
-          const ended = await drainSseDeltas(sourceBody, (delta) =>
-            emitDeltaChunks(controller, delta, emitChunk, roleState)
-          );
-          if (ended) return; // emitDeltaChunks already sent [DONE] and closed
-          if (!roleState.emitted) emitChunk(controller, { role: "assistant", content: "" });
-          emitChunk(controller, {}, "stop");
-          controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
-          controller.close();
-        } catch (err) {
-          if (!signal?.aborted) {
-            try {
-              controller.error(err);
-            } catch {
-              /* controller already closed */
-            }
-          }
-        }
-      },
-    });
-  }
-
-  /** Drain the response body and aggregate all deltas into a single answer/reasoning pair. */
-  private async collectNonStreaming(
-    sourceBody: ReadableStream<Uint8Array>
-  ): Promise<{ answer: string; reasoning: string }> {
-    let answer = "";
-    let reasoning = "";
-    await drainSseDeltas(sourceBody, (delta) => {
-      if (delta.reasoning) reasoning += delta.reasoning;
-      if (delta.content) answer += delta.content;
-      return delta.done;
-    });
-    return { answer, reasoning };
-  }
-
-  /** POST the chat request upstream. Returns either the upstream Response or an error result. */
   private async fetchUpstream(
     completionUrl: string,
     reqHeaders: Record<string, string>,
@@ -1041,23 +190,23 @@ export class ZaiWebExecutor extends BaseExecutor {
         body: JSON.stringify(reqBody),
         signal,
       });
-    } catch (err) {
+    } catch (error) {
       const message = sanitizeErrorMessage(
-        err instanceof Error ? err.message : "unknown network error"
+        error instanceof Error ? error.message : "unknown network error"
       );
       return {
-        errorResult: makeErrorResult(502, `Z.ai fetch failed: ${message}`, body, CHAT_URL),
+        errorResult: makeErrorResult(502, `Z.ai fetch failed: ${message}`, body, ZAI_CHAT_URL),
       };
     }
 
     if (!upstream.ok) {
-      const errText = await upstream.text().catch(() => "");
+      const errorText = await upstream.text().catch(() => "");
       return {
         errorResult: makeErrorResult(
           upstream.status,
-          `Z.ai error: ${sanitizeErrorMessage(errText)}`,
+          `Z.ai error: ${sanitizeErrorMessage(errorText)}`,
           body,
-          CHAT_URL
+          ZAI_CHAT_URL
         ),
       };
     }
@@ -1099,7 +248,7 @@ export class ZaiWebExecutor extends BaseExecutor {
           error instanceof CursorImageError ? error.status : 400,
           `Z.ai image input error: ${message}`,
           input.body,
-          CHAT_URL
+          ZAI_CHAT_URL
         ),
       };
     }
@@ -1112,14 +261,16 @@ export class ZaiWebExecutor extends BaseExecutor {
     try {
       result = await browserBackedChat({
         poolKey,
-        chatUrl: CHAT_URL,
-        chatPageUrl: `${BASE_URL}/?model=${encodeURIComponent(browserModelName(input.modelId))}`,
+        chatUrl: ZAI_CHAT_URL,
+        chatPageUrl: `${ZAI_BASE_URL}/?model=${encodeURIComponent(
+          browserModelName(input.modelId)
+        )}`,
         userMessage: browserPrompt(input.messages),
         localStorage: { token: input.token },
-        localStorageOrigin: BASE_URL,
+        localStorageOrigin: ZAI_BASE_URL,
         cookieDomain: "chat.z.ai",
         chatUrlMatchDomain: "chat.z.ai",
-        userAgent: USER_AGENT,
+        userAgent: ZAI_USER_AGENT,
         locale: "en-US",
         timezone: "Asia/Seoul",
         inputSelector: "#chat-input",
@@ -1145,7 +296,7 @@ export class ZaiWebExecutor extends BaseExecutor {
           502,
           `Z.ai browser transport failed: ${message}`,
           input.body,
-          CHAT_URL
+          ZAI_CHAT_URL
         ),
       };
     }
@@ -1156,7 +307,7 @@ export class ZaiWebExecutor extends BaseExecutor {
           result.status || 502,
           describeZaiBrowserFailure(result),
           input.body,
-          CHAT_URL
+          ZAI_CHAT_URL
         ),
       };
     }
@@ -1192,19 +343,6 @@ export class ZaiWebExecutor extends BaseExecutor {
     };
   }
 
-  private makeChunkEmitter(id: string, created: number, modelId: string): ChunkEmitter {
-    return (controller, delta, finish = null) => {
-      const chunk = {
-        id,
-        object: "chat.completion.chunk",
-        created,
-        model: modelId,
-        choices: [{ index: 0, delta, finish_reason: finish }],
-      };
-      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
-    };
-  }
-
   async execute(input: ExecuteInput) {
     const { body, credentials, model, signal, stream: wantStream } = input;
     const bodyObj = (body || {}) as Record<string, unknown>;
@@ -1216,25 +354,25 @@ export class ZaiWebExecutor extends BaseExecutor {
         400,
         'Missing Z.ai web-session credential — copy the "token" value from chat.z.ai Local Storage.',
         body,
-        CHAT_URL
+        ZAI_CHAT_URL
       );
     }
 
-    const captchaVerifyParam = resolveCaptchaVerifyParam(credentials, bodyObj);
+    const captchaVerifyParam = resolveZaiCaptchaVerifyParam(credentials, bodyObj);
     const messages = (bodyObj.messages as Array<{ role: string; content: unknown }>) || [];
     const prompt = latestUserPrompt(messages);
     const imageUrls = collectZaiImageUrls(messages);
     if (!prompt && imageUrls.length === 0) {
-      return makeErrorResult(400, "Z.ai requires at least one user message", body, CHAT_URL);
+      return makeErrorResult(400, "Z.ai requires at least one user message", body, ZAI_CHAT_URL);
     }
 
-    const modelId = (bodyObj.model as string) || model || DEFAULT_MODEL;
+    const modelId = (bodyObj.model as string) || model || ZAI_DEFAULT_MODEL;
     if (imageUrls.length > 0 && !getZaiModelCapabilities(modelId).vision) {
       return makeErrorResult(
         400,
         `Z.ai model ${unprefixedModelId(modelId)} does not accept image input; use GLM-5V-Turbo.`,
         body,
-        CHAT_URL
+        ZAI_CHAT_URL
       );
     }
     const userId = extractZaiUserId(token);
@@ -1243,7 +381,7 @@ export class ZaiWebExecutor extends BaseExecutor {
         400,
         "Invalid Z.ai web-session credential — its JWT payload does not contain the required user id.",
         body,
-        CHAT_URL
+        ZAI_CHAT_URL
       );
     }
     const thinkingConfig = resolveZaiThinkingConfig(modelId, bodyObj);
@@ -1269,13 +407,13 @@ export class ZaiWebExecutor extends BaseExecutor {
       const timestamp = Date.now();
       const requestId = randomUUID();
       const signature = buildZaiSignature({ prompt, requestId, timestamp, userId });
-      const completionUrl = this.buildCompletionUrl({ requestId, timestamp, token, userId });
-      const reqHeaders = this.buildZaiHeaders(token, {
+      const completionUrl = buildZaiCompletionUrl({ requestId, timestamp, token, userId });
+      const reqHeaders = buildZaiHeaders(token, {
         accept: "text/event-stream",
         frontendVersion,
         signature,
       });
-      const reqBody = this.buildRequestBody({
+      const reqBody = buildZaiRequestBody({
         body: bodyObj,
         captchaVerifyParam,
         chatId: createdChat.chatId,
@@ -1317,10 +455,11 @@ export class ZaiWebExecutor extends BaseExecutor {
 
     const id = `chatcmpl-zai-${Date.now()}`;
     const created = Math.floor(Date.now() / 1000);
-    const sourceBody = upstream.body ?? new ReadableStream({ start: (c) => c.close() });
-    const emitChunk = this.makeChunkEmitter(id, created, modelId);
+    const sourceBody =
+      upstream.body ?? new ReadableStream({ start: (controller) => controller.close() });
+    const emitChunk = makeZaiChunkEmitter(id, created, modelId);
     if (wantStream) {
-      const outStream = this.buildStreamingBody(sourceBody, modelId, emitChunk, signal);
+      const outStream = buildZaiStreamingBody(sourceBody, emitChunk, signal);
       return {
         response: new Response(outStream, {
           headers: {
@@ -1329,7 +468,7 @@ export class ZaiWebExecutor extends BaseExecutor {
             Connection: "keep-alive",
           },
         }),
-        url: CHAT_URL,
+        url: ZAI_CHAT_URL,
         headers: auditHeaders,
         transformedBody: auditBody,
       };
@@ -1338,12 +477,12 @@ export class ZaiWebExecutor extends BaseExecutor {
     let answer: string;
     let reasoning: string;
     try {
-      ({ answer, reasoning } = await this.collectNonStreaming(sourceBody));
+      ({ answer, reasoning } = await collectZaiNonStreaming(sourceBody));
     } catch (error) {
       const message = sanitizeErrorMessage(
         error instanceof Error ? error.message : "invalid upstream stream"
       );
-      return makeErrorResult(502, `Z.ai stream failed: ${message}`, body, CHAT_URL);
+      return makeErrorResult(502, `Z.ai stream failed: ${message}`, body, ZAI_CHAT_URL);
     }
     const message: Record<string, unknown> = { role: "assistant", content: answer };
     if (reasoning) message.reasoning_content = reasoning;
@@ -1358,7 +497,7 @@ export class ZaiWebExecutor extends BaseExecutor {
       response: new Response(JSON.stringify(completion), {
         headers: { "Content-Type": "application/json" },
       }),
-      url: CHAT_URL,
+      url: ZAI_CHAT_URL,
       headers: auditHeaders,
       transformedBody: auditBody,
     };

--- a/open-sse/executors/zai-web.ts
+++ b/open-sse/executors/zai-web.ts
@@ -1,48 +1,551 @@
 /**
- * ZaiWebExecutor — Z.ai Web Chat (chat.z.ai, free web-session/cookie auth)
+ * ZaiWebExecutor — Z.ai consumer chat (chat.z.ai).
  *
- * Distinct from the existing API-key `zai`/`glm`/`glm-cn`/`glmt` providers
- * (Anthropic/OpenAI-compatible `api.z.ai`, see `providers/apikey/regional.ts`).
- * This executor targets the *consumer chat* frontend at chat.z.ai — the same
- * product family as `chatglm.cn` (Zhipu AI), but the international domain —
- * so users without an API key can drive it for free via their browser session,
- * modeled on the `chatglm-web` credential entry (#4056) and the `doubao-web` /
- * `venice-web` cookie executors.
+ * This is distinct from the API-key `zai` / `glm` providers at api.z.ai.
+ * The current consumer frontend keeps its Bearer JWT in localStorage, creates
+ * a remote chat through /api/v1/chats/new, then sends signed completion
+ * requests to /api/v2/chat/completions. The completion endpoint also requires
+ * a browser-issued captcha_verify_param. OmniRoute obtains it through the
+ * browser-backed transport by default; a caller-supplied proof keeps the
+ * lower-overhead direct HTTP path available.
  *
- * Endpoint: POST https://chat.z.ai/api/v2/chat/completions
- *           (the older unversioned `/api/chat/completions` path is stale and
- *           404s model-independently as of 2026-07 — see #8014)
- * Auth:     full Cookie header from chat.z.ai (must contain the `token` JWT).
- *           Sent both as `Cookie` and as `Authorization: Bearer <token>` —
- *           the SPA's own fetch client sets both, and stripping either one
- *           has been reported (upstream repos) to 401 the request.
- * Response: SSE. Frames are z.ai's internal envelope
- *           `{"type":"chat:completion","data":{"delta_content":"...","phase":"answer","done":false}}`
- *           — mirrored from the shared Zhipu chatglm.cn/chat.z.ai frontend
- *           protocol. Some deployments/models pass through an already
- *           OpenAI-shaped `{"choices":[{"delta":{"content":"..."}}]}` frame
- *           instead, so the parser accepts both shapes defensively.
+ * The older unversioned `/api/chat/completions` path is stale and 404s
+ * model-independently as of 2026-07 (#8014); the v2 endpoint above supersedes it.
+ *
+ * Response frames use Z.ai's internal SSE envelope:
+ * `{"type":"chat:completion","data":{"delta_content":"...","phase":"answer"}}`.
  */
-import { BaseExecutor, type ExecuteInput } from "./base.ts";
+import { Buffer } from "node:buffer";
+import { createHash, createHmac, randomUUID } from "node:crypto";
+import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
+import { browserBackedChat } from "../services/browserBackedChat.ts";
 import {
   makeExecutorErrorResult as makeErrorResult,
   normalizeCookie,
   sanitizeErrorMessage,
 } from "../utils/error.ts";
+import { CursorImageError, extractImageUrls, resolveCursorImages } from "../utils/cursorImages.ts";
 
 const BASE_URL = "https://chat.z.ai";
+const NEW_CHAT_URL = `${BASE_URL}/api/v1/chats/new`;
 const CHAT_URL = `${BASE_URL}/api/v2/chat/completions`;
+const DEFAULT_MODEL = "GLM-5.1";
+const DEFAULT_FE_VERSION = "prod-fe-1.1.79";
+const CLIENT_PROTOCOL_VERSION = "0.0.1";
+const SIGNATURE_KEY = "key-@@@@)))()((9))-xxxx&&&%%%%%";
 const USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+const FE_VERSION_CACHE_TTL_MS = 15 * 60 * 1000;
 
-/** Extract the `token` cookie value (JWT) from a full Cookie header string. */
-export function extractZaiToken(rawCookie: string): string {
-  const cookie = normalizeCookie(rawCookie.trim());
-  if (!cookie) return "";
-  const match = cookie.match(/(?:^|;\s*)token=([^;]+)/);
+let cachedFeVersion: { value: string; expiresAt: number } | null = null;
+
+interface NewChatRequest {
+  payload: Record<string, unknown>;
+  userMessageId: string;
+}
+
+export type ZaiReasoningEffort = "high" | "max";
+
+export interface ZaiThinkingConfig {
+  enabled: boolean;
+  effort: ZaiReasoningEffort;
+  effortSupported: boolean;
+  supported: boolean;
+}
+
+export interface ZaiModelCapabilities {
+  mcp: boolean;
+  reasoningEffort: boolean;
+  returnFc: boolean;
+  thinking: boolean;
+  vision: boolean;
+  vlmTools: boolean;
+  vlmWebSearch: boolean;
+  vlmWebsiteMode: boolean;
+  webSearch: boolean;
+}
+
+export interface ZaiVlmConfig {
+  toolsEnabled: boolean;
+  webSearchEnabled: boolean;
+  websiteModeEnabled: boolean;
+}
+
+const NO_ZAI_MODEL_CAPABILITIES: ZaiModelCapabilities = Object.freeze({
+  mcp: false,
+  reasoningEffort: false,
+  returnFc: false,
+  thinking: false,
+  vision: false,
+  vlmTools: false,
+  vlmWebSearch: false,
+  vlmWebsiteMode: false,
+  webSearch: false,
+});
+
+/**
+ * Verified against chat.z.ai/api/models (prod-fe-1.1.79).
+ * `returnFc` is the site's internal function-call result capability; it is
+ * distinct from accepting caller-supplied OpenAI `tools`.
+ */
+const ZAI_MODEL_CAPABILITIES: Record<string, ZaiModelCapabilities> = {
+  "glm-5.2": {
+    mcp: true,
+    reasoningEffort: true,
+    returnFc: true,
+    thinking: true,
+    vision: false,
+    vlmTools: false,
+    vlmWebSearch: false,
+    vlmWebsiteMode: false,
+    webSearch: true,
+  },
+  "glm-5.1": {
+    mcp: true,
+    reasoningEffort: false,
+    returnFc: true,
+    thinking: true,
+    vision: false,
+    vlmTools: false,
+    vlmWebSearch: false,
+    vlmWebsiteMode: false,
+    webSearch: true,
+  },
+  "glm-5-turbo": {
+    mcp: true,
+    reasoningEffort: false,
+    returnFc: true,
+    thinking: true,
+    vision: false,
+    vlmTools: false,
+    vlmWebSearch: false,
+    vlmWebsiteMode: false,
+    webSearch: true,
+  },
+  "glm-5v-turbo": {
+    mcp: false,
+    reasoningEffort: false,
+    returnFc: true,
+    thinking: true,
+    vision: true,
+    vlmTools: true,
+    vlmWebSearch: true,
+    vlmWebsiteMode: true,
+    webSearch: true,
+  },
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function browserFailureDetail(body: Buffer): string {
+  const raw = body.toString("utf8").trim();
+  if (!raw) return "";
+  try {
+    const parsed = asRecord(JSON.parse(raw));
+    const error = asRecord(parsed?.error);
+    const detail = error?.message ?? parsed?.detail ?? parsed?.message;
+    if (typeof detail === "string") return sanitizeErrorMessage(detail).slice(0, 500);
+  } catch {
+    // Non-JSON upstream errors are still useful after sanitizing and bounding them.
+  }
+  return sanitizeErrorMessage(raw).slice(0, 500);
+}
+
+export function describeZaiBrowserFailure(result: {
+  status: number;
+  body: Buffer;
+  observedPostUrls?: string[];
+  timing: { captureResponseMs: number; totalMs: number };
+}): string {
+  const status = result.status > 0 ? String(result.status) : "no matching response";
+  const timing = `capture ${result.timing.captureResponseMs}ms, total ${result.timing.totalMs}ms`;
+  const observed =
+    result.observedPostUrls && result.observedPostUrls.length > 0
+      ? ` Observed POST targets: ${result.observedPostUrls.join(", ")}.`
+      : "";
+  const detail =
+    browserFailureDetail(result.body) ||
+    (result.status === 0
+      ? `The page did not issue the expected authenticated chat completion request.${observed}`
+      : "The browser response body was empty.");
+  return `Z.ai browser transport failed (${status}; ${timing}): ${detail}`;
+}
+
+function parseCredentialJson(raw: string): Record<string, unknown> | null {
+  if (!raw.trim().startsWith("{")) return null;
+  try {
+    return asRecord(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+/** Extract the localStorage Bearer token, while accepting legacy token= input. */
+export function extractZaiToken(rawCredential: string): string {
+  const trimmed = rawCredential.trim();
+  const json = parseCredentialJson(trimmed);
+  if (json) {
+    const token = json.token ?? json.accessToken ?? json.access_token;
+    return typeof token === "string" ? token.trim() : "";
+  }
+
+  const bearer = trimmed.match(/^(?:Authorization:\s*)?Bearer\s+(.+)$/i);
+  if (bearer) return bearer[1].trim();
+
+  const normalized = normalizeCookie(trimmed);
+  if (!normalized) return "";
+  const match = normalized.match(/(?:^|;\s*)token=([^;]+)/);
   if (match) return match[1].trim();
-  // Users may paste the bare JWT with no `token=` prefix.
-  return cookie.includes(";") || cookie.includes("=") ? "" : cookie;
+  return normalized.includes(";") || normalized.includes("=") ? "" : normalized;
+}
+
+/** Read the short-lived browser CAPTCHA proof from supported input locations. */
+export function extractZaiCaptchaVerifyParam(value: unknown): string {
+  const record = asRecord(value);
+  if (record) {
+    const direct =
+      record.captcha_verify_param ?? record.captchaVerifyParam ?? record.zaiCaptchaVerifyParam;
+    if (typeof direct === "string" && direct.trim()) return direct.trim();
+    const nested = asRecord(record.providerSpecificData);
+    if (nested) return extractZaiCaptchaVerifyParam(nested);
+    return "";
+  }
+
+  if (typeof value !== "string") return "";
+  const json = parseCredentialJson(value);
+  if (json) return extractZaiCaptchaVerifyParam(json);
+  const match = value.match(/(?:^|;\s*)captcha_verify_param=([^;]+)/);
+  return match?.[1]?.trim() ?? "";
+}
+
+export function extractZaiUserId(token: string): string {
+  const payload = token.split(".")[1];
+  if (!payload) return "";
+  try {
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    return typeof decoded?.id === "string" ? decoded.id : "";
+  } catch {
+    return "";
+  }
+}
+
+export function buildZaiSignature(input: {
+  prompt: string;
+  requestId: string;
+  timestamp: number | string;
+  userId: string;
+}): string {
+  const timestamp = String(input.timestamp);
+  const sortedPayload = Object.entries({
+    timestamp,
+    requestId: input.requestId,
+    user_id: input.userId,
+  })
+    .sort(([left], [right]) => left.localeCompare(right))
+    .join(",");
+  const encodedPrompt = Buffer.from(input.prompt, "utf8").toString("base64");
+  const bucket = Math.floor(Number(timestamp) / (5 * 60 * 1000));
+  const derivedKey = createHmac("sha256", SIGNATURE_KEY).update(String(bucket)).digest("hex");
+  return createHmac("sha256", derivedKey)
+    .update(`${sortedPayload}|${encodedPrompt}|${timestamp}`)
+    .digest("hex");
+}
+
+export function parseZaiFrontendVersion(html: string): string | null {
+  return html.match(/\/frontend\/(prod-fe-\d+(?:\.\d+)*)\/assets\//)?.[1] ?? null;
+}
+
+function textContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((part) => {
+      const record = asRecord(part);
+      if (!record || (record.type !== "text" && record.type !== "input_text")) return [];
+      const text = record.text ?? record.content;
+      return typeof text === "string" ? [text] : [];
+    })
+    .join("\n");
+}
+
+function latestUserPrompt(messages: Array<{ role: string; content: unknown }>): string {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role !== "user") continue;
+    return textContent(messages[index].content);
+  }
+  return "";
+}
+
+function browserPrompt(messages: Array<{ role: string; content: unknown }>): string {
+  const folded = foldMessages(messages);
+  if (folded.length === 1 && folded[0]?.role === "user") return folded[0].content;
+  return folded.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join("\n\n");
+}
+
+function collectZaiImageUrls(messages: Array<{ role: string; content: unknown }>): string[] {
+  return messages.flatMap((message) =>
+    message.role === "user" ? extractImageUrls(message.content) : []
+  );
+}
+
+function zaiImageFileName(mimeType: string, index: number): string {
+  const normalized = mimeType.toLowerCase().split(";")[0].trim();
+  const extension =
+    normalized === "image/jpeg"
+      ? "jpg"
+      : normalized === "image/svg+xml"
+        ? "svg"
+        : normalized.startsWith("image/")
+          ? normalized.slice("image/".length).replace(/[^a-z0-9]/g, "") || "png"
+          : "png";
+  return `omniroute-image-${index + 1}.${extension}`;
+}
+
+function unprefixedModelId(modelId: string): string {
+  return modelId.trim().split("/").at(-1) || modelId.trim();
+}
+
+function browserModelName(modelId: string): string {
+  const unprefixed = unprefixedModelId(modelId);
+  if (unprefixed.toLowerCase() === "glm-5.2") return "GLM-5.2";
+  if (unprefixed.toLowerCase() === "glm-5v-turbo") return "GLM-5V-Turbo";
+  return unprefixed;
+}
+
+export function getZaiModelCapabilities(modelId: string): ZaiModelCapabilities {
+  return (
+    ZAI_MODEL_CAPABILITIES[unprefixedModelId(modelId).toLowerCase()] ?? NO_ZAI_MODEL_CAPABILITIES
+  );
+}
+
+function getFeatureOption(body: Record<string, unknown>, key: string): unknown {
+  if (body[key] !== undefined) return body[key];
+  return asRecord(body.features)?.[key];
+}
+
+/** Resolve each model's Deep Think control; only GLM-5.2 accepts High/Max effort. */
+export function resolveZaiThinkingConfig(
+  modelId: string,
+  body: Record<string, unknown>
+): ZaiThinkingConfig {
+  const capabilities = getZaiModelCapabilities(modelId);
+  const supported = capabilities.thinking;
+  const reasoning = asRecord(body.reasoning);
+  const rawEffort =
+    typeof body.reasoning_effort === "string"
+      ? body.reasoning_effort.trim().toLowerCase()
+      : typeof reasoning?.effort === "string"
+        ? reasoning.effort.trim().toLowerCase()
+        : "";
+  const disabled = body.enable_thinking === false || rawEffort === "none" || rawEffort === "off";
+  const effort: ZaiReasoningEffort =
+    rawEffort === "low" || rawEffort === "medium" || rawEffort === "high" ? "high" : "max";
+
+  return {
+    supported,
+    enabled: supported && !disabled,
+    effort,
+    effortSupported: capabilities.reasoningEffort,
+  };
+}
+
+/** Resolve GLM-5V-Turbo's visible Web Search and Tools controls. */
+export function resolveZaiVlmConfig(modelId: string, body: Record<string, unknown>): ZaiVlmConfig {
+  const capabilities = getZaiModelCapabilities(modelId);
+  const toolsOption = getFeatureOption(body, "vlm_tools_enable");
+  const webSearchOption =
+    getFeatureOption(body, "vlm_web_search_enable") ??
+    getFeatureOption(body, "auto_web_search") ??
+    getFeatureOption(body, "web_search");
+  const webSearchEnabled =
+    webSearchOption === true || (webSearchOption !== false && capabilities.vlmWebSearch);
+  return {
+    toolsEnabled: capabilities.vlmTools && toolsOption !== false,
+    webSearchEnabled: capabilities.webSearch && webSearchEnabled,
+    websiteModeEnabled: capabilities.vlmWebsiteMode,
+  };
+}
+
+async function selectZaiBrowserModel(
+  page: import("playwright").Page,
+  modelName: string
+): Promise<void> {
+  const selector = page.locator('[aria-label="Select a model"]').first();
+  await selector.waitFor({ state: "visible", timeout: 10_000 });
+  if ((await selector.innerText()).includes(modelName)) return;
+
+  // The landing-page hero animation can remain above the already-visible
+  // selector and make coordinate-based clicks time out. Dispatch the click on
+  // the control itself, as we do for the Deep Think menu trigger below.
+  await selector.evaluate((element) => (element as HTMLElement).click());
+  const menu = page.locator('[role="menu"]').filter({ hasText: modelName }).first();
+  await menu.waitFor({ state: "visible", timeout: 5_000 });
+  const modelButton = menu.locator("button").filter({ hasText: modelName }).first();
+  await modelButton.evaluate((element) => (element as HTMLElement).click());
+  await page
+    .locator('[aria-label="Select a model"]')
+    .filter({ hasText: modelName })
+    .first()
+    .waitFor({ state: "visible", timeout: 5_000 });
+}
+
+async function setZaiBrowserToggle(
+  page: import("playwright").Page,
+  label: "Deep think" | "Tools" | "Web search",
+  dataAttribute: "data-autothink" | "data-selected",
+  enabled: boolean
+): Promise<void> {
+  const wrapper = page.locator(`[aria-label^="${label} "]`).first();
+  await wrapper.waitFor({ state: "visible", timeout: 5_000 });
+  const button = wrapper.locator(`button[${dataAttribute}]`).first();
+  const current = (await button.getAttribute(dataAttribute)) === "true";
+  if (current !== enabled) await button.click({ timeout: 5_000 });
+}
+
+async function setZaiBrowserWebSearch(
+  page: import("playwright").Page,
+  enabled: boolean
+): Promise<void> {
+  const labelledWrapper = page.locator('[aria-label^="Web search "]').first();
+  if ((await labelledWrapper.count()) > 0) {
+    await setZaiBrowserToggle(page, "Web search", "data-selected", enabled);
+    return;
+  }
+
+  // Text-model UI: the globe button has no accessible label. Anchor the
+  // lookup to the adjacent upload button instead of relying on generated IDs.
+  const button = page
+    .locator("#upload-file-button")
+    .locator("xpath=../../../following-sibling::div//button[@data-active]")
+    .first();
+  await button.waitFor({ state: "visible", timeout: 5_000 });
+  const current = (await button.getAttribute("data-active")) === "true";
+  if (current !== enabled) {
+    await button.click({ timeout: 5_000 });
+    // The same control also opens the search-mode popover. Close it so it
+    // cannot retain focus or cover the composer controls during submission.
+    await page.keyboard.press("Escape");
+  }
+}
+
+async function configureZaiBrowserEffort(
+  page: import("playwright").Page,
+  config: ZaiThinkingConfig
+): Promise<void> {
+  const trigger = page
+    .locator("[data-dropdown-menu-trigger]")
+    .filter({ hasText: "Deep Think" })
+    .first();
+  await trigger.waitFor({ state: "visible", timeout: 10_000 });
+  try {
+    // The landing-page intro can leave a transparent animation layer over this
+    // already-visible trigger in headless Chromium. A DOM click targets the
+    // stable trigger itself instead of the temporary layer at its coordinates.
+    await trigger.evaluate((element) => (element as HTMLElement).click());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`open menu: ${message}`);
+  }
+
+  const menu = page.locator('[role="menu"]').filter({ hasText: "Deep Think" }).first();
+  await menu.waitFor({ state: "visible", timeout: 5_000 });
+  const toggle = menu.locator('[role="switch"]').first();
+  const checked = (await toggle.getAttribute("aria-checked")) === "true";
+
+  if (!config.enabled) {
+    if (checked) {
+      try {
+        await toggle.click({ timeout: 5_000 });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`disable toggle: ${message}`);
+      }
+    }
+  } else {
+    if (!checked) {
+      try {
+        await toggle.click({ timeout: 5_000 });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`enable toggle: ${message}`);
+      }
+    }
+    const effortButton = menu.locator("button").filter({
+      hasText: config.effort === "high" ? "High" : "Max",
+    });
+    if ((await effortButton.getAttribute("data-selected")) !== "true") {
+      try {
+        // The same landing-page animation that can cover the model selector
+        // can also intercept this menu item's coordinate click.
+        await effortButton.evaluate((element) => (element as HTMLElement).click());
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`select ${config.effort}: ${message}`);
+      }
+    }
+  }
+
+  if (await menu.isVisible()) {
+    await page.keyboard.press("Escape");
+  }
+}
+
+async function configureZaiBrowserRequest(
+  page: import("playwright").Page,
+  input: {
+    modelId: string;
+    thinking: ZaiThinkingConfig;
+    vlm: ZaiVlmConfig;
+  }
+): Promise<void> {
+  const runStage = async (name: string, action: () => Promise<void>): Promise<void> => {
+    try {
+      await action();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${name}: ${message}`);
+    }
+  };
+
+  await runStage("model selection", () =>
+    selectZaiBrowserModel(page, browserModelName(input.modelId))
+  );
+
+  if (input.thinking.effortSupported) {
+    await runStage("Deep Think effort", () => configureZaiBrowserEffort(page, input.thinking));
+  } else if (input.thinking.supported) {
+    await runStage("Deep Think toggle", () =>
+      setZaiBrowserToggle(page, "Deep think", "data-autothink", input.thinking.enabled)
+    );
+  }
+
+  const capabilities = getZaiModelCapabilities(input.modelId);
+  if (capabilities.webSearch) {
+    await runStage("web search toggle", () =>
+      setZaiBrowserWebSearch(page, input.vlm.webSearchEnabled)
+    );
+  }
+  if (capabilities.vlmTools) {
+    await runStage("tools toggle", () =>
+      setZaiBrowserToggle(page, "Tools", "data-selected", input.vlm.toolsEnabled)
+    );
+  }
+}
+
+function resolveCaptchaVerifyParam(
+  credentials: ProviderCredentials,
+  body: Record<string, unknown>
+): string {
+  return (
+    extractZaiCaptchaVerifyParam(body) ||
+    extractZaiCaptchaVerifyParam(credentials.providerSpecificData) ||
+    extractZaiCaptchaVerifyParam(credentials.apiKey) ||
+    extractZaiCaptchaVerifyParam(credentials.accessToken)
+  );
 }
 
 /**
@@ -114,7 +617,7 @@ export function foldMessages(
 ): Array<{ role: string; content: string }> {
   return messages.map((m) => ({
     role: m.role,
-    content: typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? ""),
+    content: textContent(m.content),
   }));
 }
 
@@ -198,34 +701,282 @@ export class ZaiWebExecutor extends BaseExecutor {
     super("zai-web", { id: "zai-web", baseUrl: BASE_URL });
   }
 
-  private buildZaiHeaders(rawCookie: string, token: string): Record<string, string> {
+  private async resolveFrontendVersion(signal?: AbortSignal | null): Promise<string> {
+    if (cachedFeVersion && cachedFeVersion.expiresAt > Date.now()) {
+      return cachedFeVersion.value;
+    }
+    let version = DEFAULT_FE_VERSION;
+    try {
+      const response = await fetch(`${BASE_URL}/`, {
+        headers: { Accept: "text/html", "User-Agent": USER_AGENT },
+        signal,
+      });
+      if (response.ok) {
+        version = parseZaiFrontendVersion(await response.text()) ?? version;
+      }
+    } catch {
+      // The current verified version remains a safe fallback when homepage probing fails.
+    }
+    cachedFeVersion = { value: version, expiresAt: Date.now() + FE_VERSION_CACHE_TTL_MS };
+    return version;
+  }
+
+  private buildZaiHeaders(
+    token: string,
+    options: {
+      accept: "application/json" | "text/event-stream";
+      frontendVersion?: string;
+      signature?: string;
+    }
+  ): Record<string, string> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      Accept: "text/event-stream",
+      Accept: options.accept,
+      "Accept-Language": "en-US",
       "User-Agent": USER_AGENT,
       Origin: BASE_URL,
       Referer: `${BASE_URL}/`,
+      Authorization: `Bearer ${token}`,
     };
-    if (rawCookie) headers.Cookie = rawCookie;
-    if (token) headers.Authorization = `Bearer ${token}`;
+    if (options.frontendVersion) headers["X-FE-Version"] = options.frontendVersion;
+    if (options.signature) headers["X-Signature"] = options.signature;
     return headers;
   }
 
-  private buildRequestBody(
+  private buildCompletionUrl(input: {
+    requestId: string;
+    timestamp: number;
+    token: string;
+    userId: string;
+  }): string {
+    const now = new Date(input.timestamp);
+    const params = new URLSearchParams({
+      timestamp: String(input.timestamp),
+      requestId: input.requestId,
+      user_id: input.userId,
+      version: CLIENT_PROTOCOL_VERSION,
+      platform: "web",
+      token: input.token,
+      user_agent: USER_AGENT,
+      language: "en-US",
+      languages: "en-US,en",
+      timezone: "UTC",
+      cookie_enabled: "true",
+      screen_width: "1280",
+      screen_height: "800",
+      screen_resolution: "1280x800",
+      viewport_height: "800",
+      viewport_width: "1280",
+      viewport_size: "1280x800",
+      color_depth: "24",
+      pixel_ratio: "1",
+      current_url: `${BASE_URL}/`,
+      pathname: "/",
+      search: "",
+      hash: "",
+      host: "chat.z.ai",
+      hostname: "chat.z.ai",
+      protocol: "https:",
+      referrer: "",
+      title: "Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2",
+      timezone_offset: "0",
+      local_time: now.toISOString(),
+      utc_time: now.toUTCString(),
+      is_mobile: "false",
+      is_touch: "false",
+      max_touch_points: "0",
+      browser_name: "Chrome",
+      os_name: "Mac OS",
+      signature_timestamp: String(input.timestamp),
+    });
+    return `${CHAT_URL}?${params.toString()}`;
+  }
+
+  private buildNewChatBody(
     messages: Array<{ role: string; content: unknown }>,
-    modelId: string
-  ): Record<string, unknown> {
+    modelId: string,
+    enableThinking: boolean,
+    reasoningEffort: ZaiReasoningEffort,
+    vlmConfig: ZaiVlmConfig
+  ): NewChatRequest {
+    const prompt = latestUserPrompt(messages);
+    const userMessageId = randomUUID();
     return {
-      stream: true,
-      model: modelId,
-      messages: foldMessages(messages),
-      params: {},
-      features: {
-        image_generation: false,
-        web_search: false,
-        auto_web_search: false,
+      userMessageId,
+      payload: {
+        chat: {
+          id: "",
+          title: "New Chat",
+          models: [modelId],
+          params: {},
+          history: {
+            messages: {
+              [userMessageId]: {
+                id: userMessageId,
+                parentId: null,
+                childrenIds: [],
+                role: "user",
+                content: prompt,
+                timestamp: Math.floor(Date.now() / 1000),
+                models: [modelId],
+              },
+            },
+            currentId: userMessageId,
+          },
+          tags: [],
+          flags: [],
+          features: [
+            {
+              server: "tool_selector_h",
+              status: "hidden",
+              type: "tool_selector",
+            },
+          ],
+          mcp_servers: [],
+          enable_thinking: enableThinking,
+          reasoning_effort: reasoningEffort,
+          auto_web_search: vlmConfig.webSearchEnabled,
+          message_version: 1,
+          extra: {
+            vlm_tools_enable: vlmConfig.toolsEnabled,
+            vlm_web_search_enable: vlmConfig.websiteModeEnabled && vlmConfig.webSearchEnabled,
+            vlm_website_mode: vlmConfig.websiteModeEnabled,
+          },
+          timestamp: Date.now(),
+          type: "default",
+        },
       },
     };
+  }
+
+  private buildRequestBody(input: {
+    body: Record<string, unknown>;
+    captchaVerifyParam: string;
+    chatId: string;
+    messages: Array<{ role: string; content: unknown }>;
+    modelId: string;
+    prompt: string;
+    userMessageId: string;
+    enableThinking: boolean;
+    reasoningEffort: ZaiReasoningEffort;
+    reasoningEffortSupported: boolean;
+    vlmConfig: ZaiVlmConfig;
+  }): Record<string, unknown> {
+    const params = Object.fromEntries(
+      ["temperature", "top_p", "max_tokens", "stop"]
+        .filter((key) => input.body[key] !== undefined)
+        .map((key) => [key, input.body[key]])
+    );
+    const features: Record<string, unknown> = {
+      image_generation: false,
+      web_search: false,
+      // The live frontend moves the visible search toggle into the VLM flag
+      // while a model is in website mode; text models use auto_web_search.
+      auto_web_search: input.vlmConfig.websiteModeEnabled
+        ? false
+        : input.vlmConfig.webSearchEnabled,
+      preview_mode: true,
+      flags: [],
+      vlm_tools_enable: input.vlmConfig.toolsEnabled,
+      vlm_web_search_enable: input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
+      vlm_website_mode: input.vlmConfig.websiteModeEnabled,
+      enable_thinking: input.enableThinking,
+    };
+    if (input.enableThinking && input.reasoningEffortSupported) {
+      features.reasoning_effort = input.reasoningEffort;
+    }
+    return {
+      stream: true,
+      model: input.modelId,
+      messages: foldMessages(input.messages),
+      signature_prompt: input.prompt,
+      params,
+      extra: {
+        vlm_tools_enable: input.vlmConfig.toolsEnabled,
+        vlm_web_search_enable:
+          input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
+        vlm_website_mode: input.vlmConfig.websiteModeEnabled,
+      },
+      features,
+      variables: {},
+      chat_id: input.chatId,
+      id: randomUUID(),
+      current_user_message_id: input.userMessageId,
+      current_user_message_parent_id: null,
+      background_tasks: {
+        title_generation: true,
+        tags_generation: true,
+      },
+      captcha_verify_param: input.captchaVerifyParam,
+    };
+  }
+
+  private async createRemoteChat(input: {
+    messages: Array<{ role: string; content: unknown }>;
+    modelId: string;
+    token: string;
+    enableThinking: boolean;
+    reasoningEffort: ZaiReasoningEffort;
+    vlmConfig: ZaiVlmConfig;
+    signal?: AbortSignal | null;
+    originalBody: unknown;
+  }): Promise<
+    { chatId: string; userMessageId: string } | { errorResult: ReturnType<typeof makeErrorResult> }
+  > {
+    const { userMessageId, payload } = this.buildNewChatBody(
+      input.messages,
+      input.modelId,
+      input.enableThinking,
+      input.reasoningEffort,
+      input.vlmConfig
+    );
+    let response: Response;
+    try {
+      response = await fetch(NEW_CHAT_URL, {
+        method: "POST",
+        headers: this.buildZaiHeaders(input.token, {
+          accept: "application/json",
+        }),
+        body: JSON.stringify(payload),
+        signal: input.signal,
+      });
+    } catch (error) {
+      const message = sanitizeErrorMessage(
+        error instanceof Error ? error.message : "unknown network error"
+      );
+      return {
+        errorResult: makeErrorResult(
+          502,
+          `Z.ai chat creation failed: ${message}`,
+          input.originalBody,
+          NEW_CHAT_URL
+        ),
+      };
+    }
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      return {
+        errorResult: makeErrorResult(
+          response.status,
+          `Z.ai chat creation error: ${sanitizeErrorMessage(errorText)}`,
+          input.originalBody,
+          NEW_CHAT_URL
+        ),
+      };
+    }
+    const result = asRecord(await response.json().catch(() => null));
+    const chatId = typeof result?.id === "string" ? result.id : "";
+    if (!chatId) {
+      return {
+        errorResult: makeErrorResult(
+          502,
+          "Z.ai chat creation returned no chat id",
+          input.originalBody,
+          NEW_CHAT_URL
+        ),
+      };
+    }
+    return { chatId, userMessageId };
   }
 
   /** Drain the streaming response body into an OpenAI-shaped SSE ReadableStream. */
@@ -266,20 +1017,17 @@ export class ZaiWebExecutor extends BaseExecutor {
   ): Promise<{ answer: string; reasoning: string }> {
     let answer = "";
     let reasoning = "";
-    try {
-      await drainSseDeltas(sourceBody, (delta) => {
-        if (delta.reasoning) reasoning += delta.reasoning;
-        if (delta.content) answer += delta.content;
-        return delta.done;
-      });
-    } catch {
-      /* best-effort — return what we have */
-    }
+    await drainSseDeltas(sourceBody, (delta) => {
+      if (delta.reasoning) reasoning += delta.reasoning;
+      if (delta.content) answer += delta.content;
+      return delta.done;
+    });
     return { answer, reasoning };
   }
 
   /** POST the chat request upstream. Returns either the upstream Response or an error result. */
   private async fetchUpstream(
+    completionUrl: string,
     reqHeaders: Record<string, string>,
     reqBody: Record<string, unknown>,
     body: unknown,
@@ -287,20 +1035,18 @@ export class ZaiWebExecutor extends BaseExecutor {
   ): Promise<{ upstream: Response } | { errorResult: ReturnType<typeof makeErrorResult> }> {
     let upstream: Response;
     try {
-      upstream = await fetch(CHAT_URL, {
+      upstream = await fetch(completionUrl, {
         method: "POST",
         headers: reqHeaders,
         body: JSON.stringify(reqBody),
         signal,
       });
     } catch (err) {
+      const message = sanitizeErrorMessage(
+        err instanceof Error ? err.message : "unknown network error"
+      );
       return {
-        errorResult: makeErrorResult(
-          502,
-          `Z.ai fetch failed: ${err instanceof Error ? err.message : "unknown"}`,
-          body,
-          CHAT_URL
-        ),
+        errorResult: makeErrorResult(502, `Z.ai fetch failed: ${message}`, body, CHAT_URL),
       };
     }
 
@@ -318,6 +1064,134 @@ export class ZaiWebExecutor extends BaseExecutor {
     return { upstream };
   }
 
+  private async fetchThroughBrowser(input: {
+    body: unknown;
+    messages: Array<{ role: string; content: unknown }>;
+    modelId: string;
+    imageUrls: string[];
+    signal?: AbortSignal | null;
+    thinkingConfig: ZaiThinkingConfig;
+    token: string;
+    vlmConfig: ZaiVlmConfig;
+  }): Promise<
+    | {
+        upstream: Response;
+        auditHeaders: Record<string, string>;
+        auditBody: Record<string, unknown>;
+      }
+    | { errorResult: ReturnType<typeof makeErrorResult> }
+  > {
+    let attachments: NonNullable<Parameters<typeof browserBackedChat>[0]["attachments"]>;
+    try {
+      const images = await resolveCursorImages(input.imageUrls);
+      attachments = images.map((image, index) => ({
+        name: zaiImageFileName(image.mimeType, index),
+        mimeType: image.mimeType,
+        buffer: image.data,
+      }));
+    } catch (error) {
+      const message =
+        error instanceof CursorImageError
+          ? error.message
+          : sanitizeErrorMessage(error instanceof Error ? error.message : "invalid image input");
+      return {
+        errorResult: makeErrorResult(
+          error instanceof CursorImageError ? error.status : 400,
+          `Z.ai image input error: ${message}`,
+          input.body,
+          CHAT_URL
+        ),
+      };
+    }
+
+    const poolKey = `zai-web:${createHash("sha256")
+      .update(input.token)
+      .digest("hex")
+      .slice(0, 24)}`;
+    let result: Awaited<ReturnType<typeof browserBackedChat>>;
+    try {
+      result = await browserBackedChat({
+        poolKey,
+        chatUrl: CHAT_URL,
+        chatPageUrl: `${BASE_URL}/?model=${encodeURIComponent(browserModelName(input.modelId))}`,
+        userMessage: browserPrompt(input.messages),
+        localStorage: { token: input.token },
+        localStorageOrigin: BASE_URL,
+        cookieDomain: "chat.z.ai",
+        chatUrlMatchDomain: "chat.z.ai",
+        userAgent: USER_AGENT,
+        locale: "en-US",
+        timezone: "Asia/Seoul",
+        inputSelector: "#chat-input",
+        submitButtonSelector: '[aria-label="Send Message"] button:not([disabled])',
+        submitButtonMode: "dom",
+        attachments,
+        beforeSubmit: (page) =>
+          configureZaiBrowserRequest(page, {
+            modelId: input.modelId,
+            thinking: input.thinkingConfig,
+            vlm: input.vlmConfig,
+          }),
+        postSubmitWaitMs: 30_000,
+        signal: input.signal,
+        reuseContext: true,
+      });
+    } catch (error) {
+      const message = sanitizeErrorMessage(
+        error instanceof Error ? error.message : "browser transport unavailable"
+      );
+      return {
+        errorResult: makeErrorResult(
+          502,
+          `Z.ai browser transport failed: ${message}`,
+          input.body,
+          CHAT_URL
+        ),
+      };
+    }
+
+    if (result.status < 200 || result.status >= 300) {
+      return {
+        errorResult: makeErrorResult(
+          result.status || 502,
+          describeZaiBrowserFailure(result),
+          input.body,
+          CHAT_URL
+        ),
+      };
+    }
+
+    return {
+      upstream: new Response(new Uint8Array(result.body), {
+        status: result.status,
+        headers: {
+          "Content-Type": result.contentType || "text/event-stream",
+        },
+      }),
+      auditHeaders: {
+        Authorization: "Bearer [REDACTED]",
+        "X-OmniRoute-Transport": "browser",
+      },
+      auditBody: {
+        browser_backed: true,
+        image_count: attachments.length,
+        model: input.modelId,
+        messages: foldMessages(input.messages),
+        enable_thinking: input.thinkingConfig.enabled,
+        auto_web_search: input.vlmConfig.websiteModeEnabled
+          ? false
+          : input.vlmConfig.webSearchEnabled,
+        vlm_tools_enable: input.vlmConfig.toolsEnabled,
+        vlm_web_search_enable:
+          input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
+        vlm_website_mode: input.vlmConfig.websiteModeEnabled,
+        ...(input.thinkingConfig.enabled && input.thinkingConfig.effortSupported
+          ? { reasoning_effort: input.thinkingConfig.effort }
+          : {}),
+      },
+    };
+  }
+
   private makeChunkEmitter(id: string, created: number, modelId: string): ChunkEmitter {
     return (controller, delta, finish = null) => {
       const chunk = {
@@ -332,34 +1206,119 @@ export class ZaiWebExecutor extends BaseExecutor {
   }
 
   async execute(input: ExecuteInput) {
-    const { body, credentials, signal, stream: wantStream } = input;
+    const { body, credentials, model, signal, stream: wantStream } = input;
     const bodyObj = (body || {}) as Record<string, unknown>;
 
-    const rawCookie = normalizeCookie(String(credentials?.apiKey ?? "").trim());
-    const token = extractZaiToken(rawCookie);
-    if (!rawCookie && !token) {
+    const rawCredential = String(credentials?.apiKey ?? credentials?.accessToken ?? "").trim();
+    const token = extractZaiToken(rawCredential);
+    if (!token) {
       return makeErrorResult(
         400,
-        "Missing Z.ai session — paste the full Cookie header from chat.z.ai (must contain token=<JWT>).",
+        'Missing Z.ai web-session credential — copy the "token" value from chat.z.ai Local Storage.',
         body,
         CHAT_URL
       );
     }
 
+    const captchaVerifyParam = resolveCaptchaVerifyParam(credentials, bodyObj);
     const messages = (bodyObj.messages as Array<{ role: string; content: unknown }>) || [];
-    const modelId = (bodyObj.model as string) || "glm-4.6";
-    const reqBody = this.buildRequestBody(messages, modelId);
-    const reqHeaders = this.buildZaiHeaders(rawCookie, token);
+    const prompt = latestUserPrompt(messages);
+    const imageUrls = collectZaiImageUrls(messages);
+    if (!prompt && imageUrls.length === 0) {
+      return makeErrorResult(400, "Z.ai requires at least one user message", body, CHAT_URL);
+    }
 
-    const fetched = await this.fetchUpstream(reqHeaders, reqBody, body, signal);
-    if ("errorResult" in fetched) return fetched.errorResult;
-    const { upstream } = fetched;
+    const modelId = (bodyObj.model as string) || model || DEFAULT_MODEL;
+    if (imageUrls.length > 0 && !getZaiModelCapabilities(modelId).vision) {
+      return makeErrorResult(
+        400,
+        `Z.ai model ${unprefixedModelId(modelId)} does not accept image input; use GLM-5V-Turbo.`,
+        body,
+        CHAT_URL
+      );
+    }
+    const userId = extractZaiUserId(token);
+    if (!userId) {
+      return makeErrorResult(
+        400,
+        "Invalid Z.ai web-session credential — its JWT payload does not contain the required user id.",
+        body,
+        CHAT_URL
+      );
+    }
+    const thinkingConfig = resolveZaiThinkingConfig(modelId, bodyObj);
+    const vlmConfig = resolveZaiVlmConfig(modelId, bodyObj);
+    let upstream: Response;
+    let auditHeaders: Record<string, string>;
+    let auditBody: Record<string, unknown>;
+
+    if (captchaVerifyParam && imageUrls.length === 0) {
+      const frontendVersion = await this.resolveFrontendVersion(signal);
+      const createdChat = await this.createRemoteChat({
+        messages,
+        modelId,
+        token,
+        enableThinking: thinkingConfig.enabled,
+        reasoningEffort: thinkingConfig.effort,
+        vlmConfig,
+        signal,
+        originalBody: body,
+      });
+      if ("errorResult" in createdChat) return createdChat.errorResult;
+
+      const timestamp = Date.now();
+      const requestId = randomUUID();
+      const signature = buildZaiSignature({ prompt, requestId, timestamp, userId });
+      const completionUrl = this.buildCompletionUrl({ requestId, timestamp, token, userId });
+      const reqHeaders = this.buildZaiHeaders(token, {
+        accept: "text/event-stream",
+        frontendVersion,
+        signature,
+      });
+      const reqBody = this.buildRequestBody({
+        body: bodyObj,
+        captchaVerifyParam,
+        chatId: createdChat.chatId,
+        messages,
+        modelId,
+        prompt,
+        userMessageId: createdChat.userMessageId,
+        enableThinking: thinkingConfig.enabled,
+        reasoningEffort: thinkingConfig.effort,
+        reasoningEffortSupported: thinkingConfig.effortSupported,
+        vlmConfig,
+      });
+      const fetched = await this.fetchUpstream(completionUrl, reqHeaders, reqBody, body, signal);
+      if ("errorResult" in fetched) return fetched.errorResult;
+      upstream = fetched.upstream;
+      auditHeaders = {
+        ...reqHeaders,
+        Authorization: "Bearer [REDACTED]",
+        "X-Signature": "[REDACTED]",
+      };
+      auditBody = {
+        ...reqBody,
+        captcha_verify_param: "[REDACTED]",
+      };
+    } else {
+      const fetched = await this.fetchThroughBrowser({
+        body,
+        imageUrls,
+        messages,
+        modelId,
+        signal,
+        thinkingConfig,
+        token,
+        vlmConfig,
+      });
+      if ("errorResult" in fetched) return fetched.errorResult;
+      ({ upstream, auditHeaders, auditBody } = fetched);
+    }
 
     const id = `chatcmpl-zai-${Date.now()}`;
     const created = Math.floor(Date.now() / 1000);
     const sourceBody = upstream.body ?? new ReadableStream({ start: (c) => c.close() });
     const emitChunk = this.makeChunkEmitter(id, created, modelId);
-
     if (wantStream) {
       const outStream = this.buildStreamingBody(sourceBody, modelId, emitChunk, signal);
       return {
@@ -371,12 +1330,21 @@ export class ZaiWebExecutor extends BaseExecutor {
           },
         }),
         url: CHAT_URL,
-        headers: reqHeaders,
-        transformedBody: reqBody,
+        headers: auditHeaders,
+        transformedBody: auditBody,
       };
     }
 
-    const { answer, reasoning } = await this.collectNonStreaming(sourceBody);
+    let answer: string;
+    let reasoning: string;
+    try {
+      ({ answer, reasoning } = await this.collectNonStreaming(sourceBody));
+    } catch (error) {
+      const message = sanitizeErrorMessage(
+        error instanceof Error ? error.message : "invalid upstream stream"
+      );
+      return makeErrorResult(502, `Z.ai stream failed: ${message}`, body, CHAT_URL);
+    }
     const message: Record<string, unknown> = { role: "assistant", content: answer };
     if (reasoning) message.reasoning_content = reasoning;
     const completion = {
@@ -391,8 +1359,8 @@ export class ZaiWebExecutor extends BaseExecutor {
         headers: { "Content-Type": "application/json" },
       }),
       url: CHAT_URL,
-      headers: reqHeaders,
-      transformedBody: reqBody,
+      headers: auditHeaders,
+      transformedBody: auditBody,
     };
   }
 }

--- a/open-sse/executors/zai-web/browserAutomation.ts
+++ b/open-sse/executors/zai-web/browserAutomation.ts
@@ -1,0 +1,156 @@
+import type { Page } from "playwright";
+import {
+  browserModelName,
+  getZaiModelCapabilities,
+  type ZaiThinkingConfig,
+  type ZaiVlmConfig,
+} from "./protocol.ts";
+
+async function selectZaiBrowserModel(page: Page, modelName: string): Promise<void> {
+  const selector = page.locator('[aria-label="Select a model"]').first();
+  await selector.waitFor({ state: "visible", timeout: 10_000 });
+  if ((await selector.innerText()).includes(modelName)) return;
+
+  // The landing-page hero animation can remain above the already-visible
+  // selector and make coordinate-based clicks time out.
+  await selector.evaluate((element) => (element as HTMLElement).click());
+  const menu = page.locator('[role="menu"]').filter({ hasText: modelName }).first();
+  await menu.waitFor({ state: "visible", timeout: 5_000 });
+  const modelButton = menu.locator("button").filter({ hasText: modelName }).first();
+  await modelButton.evaluate((element) => (element as HTMLElement).click());
+  await page
+    .locator('[aria-label="Select a model"]')
+    .filter({ hasText: modelName })
+    .first()
+    .waitFor({ state: "visible", timeout: 5_000 });
+}
+
+async function setZaiBrowserToggle(
+  page: Page,
+  label: "Deep think" | "Tools" | "Web search",
+  dataAttribute: "data-autothink" | "data-selected",
+  enabled: boolean
+): Promise<void> {
+  const wrapper = page.locator(`[aria-label^="${label} "]`).first();
+  await wrapper.waitFor({ state: "visible", timeout: 5_000 });
+  const button = wrapper.locator(`button[${dataAttribute}]`).first();
+  const current = (await button.getAttribute(dataAttribute)) === "true";
+  if (current !== enabled) await button.click({ timeout: 5_000 });
+}
+
+async function setZaiBrowserWebSearch(page: Page, enabled: boolean): Promise<void> {
+  const labelledWrapper = page.locator('[aria-label^="Web search "]').first();
+  if ((await labelledWrapper.count()) > 0) {
+    await setZaiBrowserToggle(page, "Web search", "data-selected", enabled);
+    return;
+  }
+
+  // Text-model UI: the globe button has no accessible label. Anchor the
+  // lookup to the adjacent upload button instead of generated IDs.
+  const button = page
+    .locator("#upload-file-button")
+    .locator("xpath=../../../following-sibling::div//button[@data-active]")
+    .first();
+  await button.waitFor({ state: "visible", timeout: 5_000 });
+  const current = (await button.getAttribute("data-active")) === "true";
+  if (current !== enabled) {
+    await button.click({ timeout: 5_000 });
+    await page.keyboard.press("Escape");
+  }
+}
+
+async function configureZaiBrowserEffort(page: Page, config: ZaiThinkingConfig): Promise<void> {
+  const trigger = page
+    .locator("[data-dropdown-menu-trigger]")
+    .filter({ hasText: "Deep Think" })
+    .first();
+  await trigger.waitFor({ state: "visible", timeout: 10_000 });
+  try {
+    await trigger.evaluate((element) => (element as HTMLElement).click());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`open menu: ${message}`);
+  }
+
+  const menu = page.locator('[role="menu"]').filter({ hasText: "Deep Think" }).first();
+  await menu.waitFor({ state: "visible", timeout: 5_000 });
+  const toggle = menu.locator('[role="switch"]').first();
+  const checked = (await toggle.getAttribute("aria-checked")) === "true";
+
+  if (!config.enabled) {
+    if (checked) {
+      try {
+        await toggle.click({ timeout: 5_000 });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`disable toggle: ${message}`);
+      }
+    }
+  } else {
+    if (!checked) {
+      try {
+        await toggle.click({ timeout: 5_000 });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`enable toggle: ${message}`);
+      }
+    }
+    const effortButton = menu.locator("button").filter({
+      hasText: config.effort === "high" ? "High" : "Max",
+    });
+    if ((await effortButton.getAttribute("data-selected")) !== "true") {
+      try {
+        await effortButton.evaluate((element) => (element as HTMLElement).click());
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`select ${config.effort}: ${message}`);
+      }
+    }
+  }
+
+  if (await menu.isVisible()) {
+    await page.keyboard.press("Escape");
+  }
+}
+
+export async function configureZaiBrowserRequest(
+  page: Page,
+  input: {
+    modelId: string;
+    thinking: ZaiThinkingConfig;
+    vlm: ZaiVlmConfig;
+  }
+): Promise<void> {
+  const runStage = async (name: string, action: () => Promise<void>): Promise<void> => {
+    try {
+      await action();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${name}: ${message}`);
+    }
+  };
+
+  await runStage("model selection", () =>
+    selectZaiBrowserModel(page, browserModelName(input.modelId))
+  );
+
+  if (input.thinking.effortSupported) {
+    await runStage("Deep Think effort", () => configureZaiBrowserEffort(page, input.thinking));
+  } else if (input.thinking.supported) {
+    await runStage("Deep Think toggle", () =>
+      setZaiBrowserToggle(page, "Deep think", "data-autothink", input.thinking.enabled)
+    );
+  }
+
+  const capabilities = getZaiModelCapabilities(input.modelId);
+  if (capabilities.webSearch) {
+    await runStage("web search toggle", () =>
+      setZaiBrowserWebSearch(page, input.vlm.webSearchEnabled)
+    );
+  }
+  if (capabilities.vlmTools) {
+    await runStage("tools toggle", () =>
+      setZaiBrowserToggle(page, "Tools", "data-selected", input.vlm.toolsEnabled)
+    );
+  }
+}

--- a/open-sse/executors/zai-web/browserAutomation.ts
+++ b/open-sse/executors/zai-web/browserAutomation.ts
@@ -6,6 +6,20 @@ import {
   type ZaiVlmConfig,
 } from "./protocol.ts";
 
+/**
+ * Run one Playwright interaction, re-throwing any failure tagged with the stage
+ * that produced it. Every step below is a blind DOM poke against a UI we do not
+ * control, so an untagged "click timed out" is unactionable in a bug report.
+ */
+async function runStage(name: string, action: () => Promise<void>): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${name}: ${message}`);
+  }
+}
+
 async function selectZaiBrowserModel(page: Page, modelName: string): Promise<void> {
   const selector = page.locator('[aria-label="Select a model"]').first();
   await selector.waitFor({ state: "visible", timeout: 10_000 });
@@ -59,53 +73,42 @@ async function setZaiBrowserWebSearch(page: Page, enabled: boolean): Promise<voi
   }
 }
 
+/** Pick the High/Max effort button inside an already-open Deep Think menu. */
+async function selectZaiBrowserEffortLevel(
+  menu: ReturnType<Page["locator"]>,
+  effort: ZaiThinkingConfig["effort"]
+): Promise<void> {
+  const effortButton = menu.locator("button").filter({
+    hasText: effort === "high" ? "High" : "Max",
+  });
+  if ((await effortButton.getAttribute("data-selected")) === "true") return;
+  await runStage(`select ${effort}`, () =>
+    effortButton.evaluate((element) => (element as HTMLElement).click())
+  );
+}
+
 async function configureZaiBrowserEffort(page: Page, config: ZaiThinkingConfig): Promise<void> {
   const trigger = page
     .locator("[data-dropdown-menu-trigger]")
     .filter({ hasText: "Deep Think" })
     .first();
   await trigger.waitFor({ state: "visible", timeout: 10_000 });
-  try {
-    await trigger.evaluate((element) => (element as HTMLElement).click());
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`open menu: ${message}`);
-  }
+  await runStage("open menu", () =>
+    trigger.evaluate((element) => (element as HTMLElement).click())
+  );
 
   const menu = page.locator('[role="menu"]').filter({ hasText: "Deep Think" }).first();
   await menu.waitFor({ state: "visible", timeout: 5_000 });
   const toggle = menu.locator('[role="switch"]').first();
   const checked = (await toggle.getAttribute("aria-checked")) === "true";
 
-  if (!config.enabled) {
-    if (checked) {
-      try {
-        await toggle.click({ timeout: 5_000 });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`disable toggle: ${message}`);
-      }
-    }
-  } else {
-    if (!checked) {
-      try {
-        await toggle.click({ timeout: 5_000 });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`enable toggle: ${message}`);
-      }
-    }
-    const effortButton = menu.locator("button").filter({
-      hasText: config.effort === "high" ? "High" : "Max",
-    });
-    if ((await effortButton.getAttribute("data-selected")) !== "true") {
-      try {
-        await effortButton.evaluate((element) => (element as HTMLElement).click());
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`select ${config.effort}: ${message}`);
-      }
-    }
+  if (checked !== config.enabled) {
+    await runStage(config.enabled ? "enable toggle" : "disable toggle", () =>
+      toggle.click({ timeout: 5_000 })
+    );
+  }
+  if (config.enabled) {
+    await selectZaiBrowserEffortLevel(menu, config.effort);
   }
 
   if (await menu.isVisible()) {
@@ -121,15 +124,6 @@ export async function configureZaiBrowserRequest(
     vlm: ZaiVlmConfig;
   }
 ): Promise<void> {
-  const runStage = async (name: string, action: () => Promise<void>): Promise<void> => {
-    try {
-      await action();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`${name}: ${message}`);
-    }
-  };
-
   await runStage("model selection", () =>
     selectZaiBrowserModel(page, browserModelName(input.modelId))
   );

--- a/open-sse/executors/zai-web/protocol.ts
+++ b/open-sse/executors/zai-web/protocol.ts
@@ -1,0 +1,554 @@
+import { Buffer } from "node:buffer";
+import { createHmac, randomUUID } from "node:crypto";
+import type { ProviderCredentials } from "../base.ts";
+import { extractImageUrls } from "../../utils/cursorImages.ts";
+import { normalizeCookie, sanitizeErrorMessage } from "../../utils/error.ts";
+
+export const ZAI_BASE_URL = "https://chat.z.ai";
+export const ZAI_NEW_CHAT_URL = `${ZAI_BASE_URL}/api/v1/chats/new`;
+export const ZAI_CHAT_URL = `${ZAI_BASE_URL}/api/v2/chat/completions`;
+export const ZAI_DEFAULT_MODEL = "GLM-5.1";
+export const ZAI_DEFAULT_FE_VERSION = "prod-fe-1.1.79";
+export const ZAI_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+export const ZAI_FE_VERSION_CACHE_TTL_MS = 15 * 60 * 1000;
+
+const CLIENT_PROTOCOL_VERSION = "0.0.1";
+const SIGNATURE_KEY = "key-@@@@)))()((9))-xxxx&&&%%%%%";
+
+export interface NewChatRequest {
+  payload: Record<string, unknown>;
+  userMessageId: string;
+}
+
+export type ZaiReasoningEffort = "high" | "max";
+
+export interface ZaiThinkingConfig {
+  enabled: boolean;
+  effort: ZaiReasoningEffort;
+  effortSupported: boolean;
+  supported: boolean;
+}
+
+export interface ZaiModelCapabilities {
+  mcp: boolean;
+  reasoningEffort: boolean;
+  returnFc: boolean;
+  thinking: boolean;
+  vision: boolean;
+  vlmTools: boolean;
+  vlmWebSearch: boolean;
+  vlmWebsiteMode: boolean;
+  webSearch: boolean;
+}
+
+export interface ZaiVlmConfig {
+  toolsEnabled: boolean;
+  webSearchEnabled: boolean;
+  websiteModeEnabled: boolean;
+}
+
+const NO_ZAI_MODEL_CAPABILITIES: ZaiModelCapabilities = Object.freeze({
+  mcp: false,
+  reasoningEffort: false,
+  returnFc: false,
+  thinking: false,
+  vision: false,
+  vlmTools: false,
+  vlmWebSearch: false,
+  vlmWebsiteMode: false,
+  webSearch: false,
+});
+
+/**
+ * Verified against chat.z.ai/api/models (prod-fe-1.1.79).
+ * `returnFc` is the site's internal function-call result capability; it is
+ * distinct from accepting caller-supplied OpenAI `tools`.
+ */
+const ZAI_MODEL_CAPABILITIES: Record<string, ZaiModelCapabilities> = {
+  "glm-5.2": {
+    mcp: true,
+    reasoningEffort: true,
+    returnFc: true,
+    thinking: true,
+    vision: false,
+    vlmTools: false,
+    vlmWebSearch: false,
+    vlmWebsiteMode: false,
+    webSearch: true,
+  },
+  "glm-5.1": {
+    mcp: true,
+    reasoningEffort: false,
+    returnFc: true,
+    thinking: true,
+    vision: false,
+    vlmTools: false,
+    vlmWebSearch: false,
+    vlmWebsiteMode: false,
+    webSearch: true,
+  },
+  "glm-5-turbo": {
+    mcp: true,
+    reasoningEffort: false,
+    returnFc: true,
+    thinking: true,
+    vision: false,
+    vlmTools: false,
+    vlmWebSearch: false,
+    vlmWebsiteMode: false,
+    webSearch: true,
+  },
+  "glm-5v-turbo": {
+    mcp: false,
+    reasoningEffort: false,
+    returnFc: true,
+    thinking: true,
+    vision: true,
+    vlmTools: true,
+    vlmWebSearch: true,
+    vlmWebsiteMode: true,
+    webSearch: true,
+  },
+};
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function browserFailureDetail(body: Buffer): string {
+  const raw = body.toString("utf8").trim();
+  if (!raw) return "";
+  try {
+    const parsed = asRecord(JSON.parse(raw));
+    const error = asRecord(parsed?.error);
+    const detail = error?.message ?? parsed?.detail ?? parsed?.message;
+    if (typeof detail === "string") return sanitizeErrorMessage(detail).slice(0, 500);
+  } catch {
+    // Non-JSON upstream errors are still useful after sanitizing and bounding them.
+  }
+  return sanitizeErrorMessage(raw).slice(0, 500);
+}
+
+export function describeZaiBrowserFailure(result: {
+  status: number;
+  body: Buffer;
+  observedPostUrls?: string[];
+  timing: { captureResponseMs: number; totalMs: number };
+}): string {
+  const status = result.status > 0 ? String(result.status) : "no matching response";
+  const timing = `capture ${result.timing.captureResponseMs}ms, total ${result.timing.totalMs}ms`;
+  const observed =
+    result.observedPostUrls && result.observedPostUrls.length > 0
+      ? ` Observed POST targets: ${result.observedPostUrls.join(", ")}.`
+      : "";
+  const detail =
+    browserFailureDetail(result.body) ||
+    (result.status === 0
+      ? `The page did not issue the expected authenticated chat completion request.${observed}`
+      : "The browser response body was empty.");
+  return `Z.ai browser transport failed (${status}; ${timing}): ${detail}`;
+}
+
+function parseCredentialJson(raw: string): Record<string, unknown> | null {
+  if (!raw.trim().startsWith("{")) return null;
+  try {
+    return asRecord(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+/** Extract the localStorage Bearer token, while accepting legacy token= input. */
+export function extractZaiToken(rawCredential: string): string {
+  const trimmed = rawCredential.trim();
+  const json = parseCredentialJson(trimmed);
+  if (json) {
+    const token = json.token ?? json.accessToken ?? json.access_token;
+    return typeof token === "string" ? token.trim() : "";
+  }
+
+  const bearer = trimmed.match(/^(?:Authorization:\s*)?Bearer\s+(.+)$/i);
+  if (bearer) return bearer[1].trim();
+
+  const normalized = normalizeCookie(trimmed);
+  if (!normalized) return "";
+  const match = normalized.match(/(?:^|;\s*)token=([^;]+)/);
+  if (match) return match[1].trim();
+  return normalized.includes(";") || normalized.includes("=") ? "" : normalized;
+}
+
+/** Read the short-lived browser CAPTCHA proof from supported input locations. */
+export function extractZaiCaptchaVerifyParam(value: unknown): string {
+  const record = asRecord(value);
+  if (record) {
+    const direct =
+      record.captcha_verify_param ?? record.captchaVerifyParam ?? record.zaiCaptchaVerifyParam;
+    if (typeof direct === "string" && direct.trim()) return direct.trim();
+    const nested = asRecord(record.providerSpecificData);
+    if (nested) return extractZaiCaptchaVerifyParam(nested);
+    return "";
+  }
+
+  if (typeof value !== "string") return "";
+  const json = parseCredentialJson(value);
+  if (json) return extractZaiCaptchaVerifyParam(json);
+  const match = value.match(/(?:^|;\s*)captcha_verify_param=([^;]+)/);
+  return match?.[1]?.trim() ?? "";
+}
+
+export function resolveZaiCaptchaVerifyParam(
+  credentials: ProviderCredentials,
+  body: Record<string, unknown>
+): string {
+  return (
+    extractZaiCaptchaVerifyParam(body) ||
+    extractZaiCaptchaVerifyParam(credentials.providerSpecificData) ||
+    extractZaiCaptchaVerifyParam(credentials.apiKey) ||
+    extractZaiCaptchaVerifyParam(credentials.accessToken)
+  );
+}
+
+export function extractZaiUserId(token: string): string {
+  const payload = token.split(".")[1];
+  if (!payload) return "";
+  try {
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    return typeof decoded?.id === "string" ? decoded.id : "";
+  } catch {
+    return "";
+  }
+}
+
+export function buildZaiSignature(input: {
+  prompt: string;
+  requestId: string;
+  timestamp: number | string;
+  userId: string;
+}): string {
+  const timestamp = String(input.timestamp);
+  const sortedPayload = Object.entries({
+    timestamp,
+    requestId: input.requestId,
+    user_id: input.userId,
+  })
+    .sort(([left], [right]) => left.localeCompare(right))
+    .join(",");
+  const encodedPrompt = Buffer.from(input.prompt, "utf8").toString("base64");
+  const bucket = Math.floor(Number(timestamp) / (5 * 60 * 1000));
+  const derivedKey = createHmac("sha256", SIGNATURE_KEY).update(String(bucket)).digest("hex");
+  return createHmac("sha256", derivedKey)
+    .update(`${sortedPayload}|${encodedPrompt}|${timestamp}`)
+    .digest("hex");
+}
+
+export function parseZaiFrontendVersion(html: string): string | null {
+  return html.match(/\/frontend\/(prod-fe-\d+(?:\.\d+)*)\/assets\//)?.[1] ?? null;
+}
+
+function textContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((part) => {
+      const record = asRecord(part);
+      if (!record || (record.type !== "text" && record.type !== "input_text")) return [];
+      const text = record.text ?? record.content;
+      return typeof text === "string" ? [text] : [];
+    })
+    .join("\n");
+}
+
+export function latestUserPrompt(messages: Array<{ role: string; content: unknown }>): string {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role !== "user") continue;
+    return textContent(messages[index].content);
+  }
+  return "";
+}
+
+export function foldMessages(
+  messages: Array<{ role: string; content: unknown }>
+): Array<{ role: string; content: string }> {
+  return messages.map((message) => ({
+    role: message.role,
+    content: textContent(message.content),
+  }));
+}
+
+export function browserPrompt(messages: Array<{ role: string; content: unknown }>): string {
+  const folded = foldMessages(messages);
+  if (folded.length === 1 && folded[0]?.role === "user") return folded[0].content;
+  return folded.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join("\n\n");
+}
+
+export function collectZaiImageUrls(messages: Array<{ role: string; content: unknown }>): string[] {
+  return messages.flatMap((message) =>
+    message.role === "user" ? extractImageUrls(message.content) : []
+  );
+}
+
+export function zaiImageFileName(mimeType: string, index: number): string {
+  const normalized = mimeType.toLowerCase().split(";")[0].trim();
+  const extension =
+    normalized === "image/jpeg"
+      ? "jpg"
+      : normalized === "image/svg+xml"
+        ? "svg"
+        : normalized.startsWith("image/")
+          ? normalized.slice("image/".length).replace(/[^a-z0-9]/g, "") || "png"
+          : "png";
+  return `omniroute-image-${index + 1}.${extension}`;
+}
+
+export function unprefixedModelId(modelId: string): string {
+  return modelId.trim().split("/").at(-1) || modelId.trim();
+}
+
+export function browserModelName(modelId: string): string {
+  const unprefixed = unprefixedModelId(modelId);
+  if (unprefixed.toLowerCase() === "glm-5.2") return "GLM-5.2";
+  if (unprefixed.toLowerCase() === "glm-5v-turbo") return "GLM-5V-Turbo";
+  return unprefixed;
+}
+
+export function getZaiModelCapabilities(modelId: string): ZaiModelCapabilities {
+  return (
+    ZAI_MODEL_CAPABILITIES[unprefixedModelId(modelId).toLowerCase()] ?? NO_ZAI_MODEL_CAPABILITIES
+  );
+}
+
+function getFeatureOption(body: Record<string, unknown>, key: string): unknown {
+  if (body[key] !== undefined) return body[key];
+  return asRecord(body.features)?.[key];
+}
+
+/** Resolve each model's Deep Think control; only GLM-5.2 accepts High/Max effort. */
+export function resolveZaiThinkingConfig(
+  modelId: string,
+  body: Record<string, unknown>
+): ZaiThinkingConfig {
+  const capabilities = getZaiModelCapabilities(modelId);
+  const supported = capabilities.thinking;
+  const reasoning = asRecord(body.reasoning);
+  const rawEffort =
+    typeof body.reasoning_effort === "string"
+      ? body.reasoning_effort.trim().toLowerCase()
+      : typeof reasoning?.effort === "string"
+        ? reasoning.effort.trim().toLowerCase()
+        : "";
+  const disabled = body.enable_thinking === false || rawEffort === "none" || rawEffort === "off";
+  const effort: ZaiReasoningEffort =
+    rawEffort === "low" || rawEffort === "medium" || rawEffort === "high" ? "high" : "max";
+
+  return {
+    supported,
+    enabled: supported && !disabled,
+    effort,
+    effortSupported: capabilities.reasoningEffort,
+  };
+}
+
+/** Resolve GLM-5V-Turbo's visible Web Search and Tools controls. */
+export function resolveZaiVlmConfig(modelId: string, body: Record<string, unknown>): ZaiVlmConfig {
+  const capabilities = getZaiModelCapabilities(modelId);
+  const toolsOption = getFeatureOption(body, "vlm_tools_enable");
+  const webSearchOption =
+    getFeatureOption(body, "vlm_web_search_enable") ??
+    getFeatureOption(body, "auto_web_search") ??
+    getFeatureOption(body, "web_search");
+  const webSearchEnabled =
+    webSearchOption === true || (webSearchOption !== false && capabilities.vlmWebSearch);
+  return {
+    toolsEnabled: capabilities.vlmTools && toolsOption !== false,
+    webSearchEnabled: capabilities.webSearch && webSearchEnabled,
+    websiteModeEnabled: capabilities.vlmWebsiteMode,
+  };
+}
+
+export function buildZaiHeaders(
+  token: string,
+  options: {
+    accept: "application/json" | "text/event-stream";
+    frontendVersion?: string;
+    signature?: string;
+  }
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: options.accept,
+    "Accept-Language": "en-US",
+    "User-Agent": ZAI_USER_AGENT,
+    Origin: ZAI_BASE_URL,
+    Referer: `${ZAI_BASE_URL}/`,
+    Authorization: `Bearer ${token}`,
+  };
+  if (options.frontendVersion) headers["X-FE-Version"] = options.frontendVersion;
+  if (options.signature) headers["X-Signature"] = options.signature;
+  return headers;
+}
+
+export function buildZaiCompletionUrl(input: {
+  requestId: string;
+  timestamp: number;
+  token: string;
+  userId: string;
+}): string {
+  const now = new Date(input.timestamp);
+  const params = new URLSearchParams({
+    timestamp: String(input.timestamp),
+    requestId: input.requestId,
+    user_id: input.userId,
+    version: CLIENT_PROTOCOL_VERSION,
+    platform: "web",
+    token: input.token,
+    user_agent: ZAI_USER_AGENT,
+    language: "en-US",
+    languages: "en-US,en",
+    timezone: "UTC",
+    cookie_enabled: "true",
+    screen_width: "1280",
+    screen_height: "800",
+    screen_resolution: "1280x800",
+    viewport_height: "800",
+    viewport_width: "1280",
+    viewport_size: "1280x800",
+    color_depth: "24",
+    pixel_ratio: "1",
+    current_url: `${ZAI_BASE_URL}/`,
+    pathname: "/",
+    search: "",
+    hash: "",
+    host: "chat.z.ai",
+    hostname: "chat.z.ai",
+    protocol: "https:",
+    referrer: "",
+    title: "Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2",
+    timezone_offset: "0",
+    local_time: now.toISOString(),
+    utc_time: now.toUTCString(),
+    is_mobile: "false",
+    is_touch: "false",
+    max_touch_points: "0",
+    browser_name: "Chrome",
+    os_name: "Mac OS",
+    signature_timestamp: String(input.timestamp),
+  });
+  return `${ZAI_CHAT_URL}?${params.toString()}`;
+}
+
+export function buildZaiNewChatBody(
+  messages: Array<{ role: string; content: unknown }>,
+  modelId: string,
+  enableThinking: boolean,
+  reasoningEffort: ZaiReasoningEffort,
+  vlmConfig: ZaiVlmConfig
+): NewChatRequest {
+  const prompt = latestUserPrompt(messages);
+  const userMessageId = randomUUID();
+  return {
+    userMessageId,
+    payload: {
+      chat: {
+        id: "",
+        title: "New Chat",
+        models: [modelId],
+        params: {},
+        history: {
+          messages: {
+            [userMessageId]: {
+              id: userMessageId,
+              parentId: null,
+              childrenIds: [],
+              role: "user",
+              content: prompt,
+              timestamp: Math.floor(Date.now() / 1000),
+              models: [modelId],
+            },
+          },
+          currentId: userMessageId,
+        },
+        tags: [],
+        flags: [],
+        features: [
+          {
+            server: "tool_selector_h",
+            status: "hidden",
+            type: "tool_selector",
+          },
+        ],
+        mcp_servers: [],
+        enable_thinking: enableThinking,
+        reasoning_effort: reasoningEffort,
+        auto_web_search: vlmConfig.webSearchEnabled,
+        message_version: 1,
+        extra: {
+          vlm_tools_enable: vlmConfig.toolsEnabled,
+          vlm_web_search_enable: vlmConfig.websiteModeEnabled && vlmConfig.webSearchEnabled,
+          vlm_website_mode: vlmConfig.websiteModeEnabled,
+        },
+        timestamp: Date.now(),
+        type: "default",
+      },
+    },
+  };
+}
+
+export function buildZaiRequestBody(input: {
+  body: Record<string, unknown>;
+  captchaVerifyParam: string;
+  chatId: string;
+  messages: Array<{ role: string; content: unknown }>;
+  modelId: string;
+  prompt: string;
+  userMessageId: string;
+  enableThinking: boolean;
+  reasoningEffort: ZaiReasoningEffort;
+  reasoningEffortSupported: boolean;
+  vlmConfig: ZaiVlmConfig;
+}): Record<string, unknown> {
+  const params = Object.fromEntries(
+    ["temperature", "top_p", "max_tokens", "stop"]
+      .filter((key) => input.body[key] !== undefined)
+      .map((key) => [key, input.body[key]])
+  );
+  const features: Record<string, unknown> = {
+    image_generation: false,
+    web_search: false,
+    auto_web_search: input.vlmConfig.websiteModeEnabled ? false : input.vlmConfig.webSearchEnabled,
+    preview_mode: true,
+    flags: [],
+    vlm_tools_enable: input.vlmConfig.toolsEnabled,
+    vlm_web_search_enable: input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
+    vlm_website_mode: input.vlmConfig.websiteModeEnabled,
+    enable_thinking: input.enableThinking,
+  };
+  if (input.enableThinking && input.reasoningEffortSupported) {
+    features.reasoning_effort = input.reasoningEffort;
+  }
+  return {
+    stream: true,
+    model: input.modelId,
+    messages: foldMessages(input.messages),
+    signature_prompt: input.prompt,
+    params,
+    extra: {
+      vlm_tools_enable: input.vlmConfig.toolsEnabled,
+      vlm_web_search_enable: input.vlmConfig.websiteModeEnabled && input.vlmConfig.webSearchEnabled,
+      vlm_website_mode: input.vlmConfig.websiteModeEnabled,
+    },
+    features,
+    variables: {},
+    chat_id: input.chatId,
+    id: randomUUID(),
+    current_user_message_id: input.userMessageId,
+    current_user_message_parent_id: null,
+    background_tasks: {
+      title_generation: true,
+      tags_generation: true,
+    },
+    captcha_verify_param: input.captchaVerifyParam,
+  };
+}

--- a/open-sse/executors/zai-web/stream.ts
+++ b/open-sse/executors/zai-web/stream.ts
@@ -1,0 +1,174 @@
+export interface ZaiDelta {
+  content: string;
+  reasoning: string;
+  done: boolean;
+}
+
+export type ZaiChunkEmitter = (
+  controller: ReadableStreamDefaultController,
+  delta: Record<string, unknown>,
+  finish?: string | null
+) => void;
+
+function parseOpenAiShapedFrame(choices: Array<Record<string, unknown>>): ZaiDelta {
+  const delta = (choices[0]?.delta ?? {}) as Record<string, unknown>;
+  const finishReason = choices[0]?.finish_reason;
+  return {
+    content: typeof delta.content === "string" ? delta.content : "",
+    reasoning: typeof delta.reasoning_content === "string" ? delta.reasoning_content : "",
+    done: finishReason != null,
+  };
+}
+
+function parseInternalEnvelopeFrame(
+  frame: Record<string, unknown>,
+  data: Record<string, unknown>
+): ZaiDelta | null {
+  const phase = String(data.phase ?? "");
+  const deltaContent = data.delta_content ?? data.edit_content ?? data.content;
+  const done =
+    data.done === true ||
+    phase === "done" ||
+    phase === "finish" ||
+    String(frame.type ?? "") === "chat:completion:finish";
+
+  if (typeof deltaContent === "string" && deltaContent) {
+    const isThinking = phase === "thinking";
+    return {
+      content: isThinking ? "" : deltaContent,
+      reasoning: isThinking ? deltaContent : "",
+      done,
+    };
+  }
+  if (done) return { content: "", reasoning: "", done: true };
+  return null;
+}
+
+export function parseZaiFrame(raw: unknown): ZaiDelta | null {
+  if (!raw || typeof raw !== "object") return null;
+  const frame = raw as Record<string, unknown>;
+  const choices = frame.choices as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(choices) && choices.length > 0) {
+    return parseOpenAiShapedFrame(choices);
+  }
+
+  const data = (frame.data ?? frame) as Record<string, unknown>;
+  return parseInternalEnvelopeFrame(frame, data);
+}
+
+function extractSseDataPayloads(buffer: { text: string }, incoming: string): string[] {
+  buffer.text += incoming;
+  const lines = buffer.text.split("\n");
+  buffer.text = lines.pop() || "";
+  const payloads: string[] = [];
+  for (const line of lines) {
+    if (!line.startsWith("data:")) continue;
+    const data = line.slice(5).trim();
+    if (!data || data === "[DONE]") continue;
+    payloads.push(data);
+  }
+  return payloads;
+}
+
+function parseSsePayload(data: string): ZaiDelta | null {
+  try {
+    return parseZaiFrame(JSON.parse(data));
+  } catch {
+    return null;
+  }
+}
+
+async function drainSseDeltas(
+  sourceBody: ReadableStream<Uint8Array>,
+  onDelta: (delta: ZaiDelta) => boolean
+): Promise<boolean> {
+  const decoder = new TextDecoder();
+  const reader = sourceBody.getReader();
+  const buffer = { text: "" };
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return false;
+    const payloads = extractSseDataPayloads(buffer, decoder.decode(value, { stream: true }));
+    for (const raw of payloads) {
+      const delta = parseSsePayload(raw);
+      if (delta && onDelta(delta)) return true;
+    }
+  }
+}
+
+function emitDeltaChunks(
+  controller: ReadableStreamDefaultController,
+  delta: ZaiDelta,
+  emitChunk: ZaiChunkEmitter,
+  roleState: { emitted: boolean }
+): boolean {
+  if (!roleState.emitted && (delta.content || delta.reasoning)) {
+    roleState.emitted = true;
+    emitChunk(controller, { role: "assistant", content: "" });
+  }
+  if (delta.reasoning) emitChunk(controller, { reasoning_content: delta.reasoning });
+  if (delta.content) emitChunk(controller, { content: delta.content });
+  if (delta.done) {
+    emitChunk(controller, {}, "stop");
+    controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+    controller.close();
+    return true;
+  }
+  return false;
+}
+
+export function buildZaiStreamingBody(
+  sourceBody: ReadableStream<Uint8Array>,
+  emitChunk: ZaiChunkEmitter,
+  signal: AbortSignal | null | undefined
+): ReadableStream {
+  return new ReadableStream({
+    async start(controller) {
+      const roleState = { emitted: false };
+      try {
+        const ended = await drainSseDeltas(sourceBody, (delta) =>
+          emitDeltaChunks(controller, delta, emitChunk, roleState)
+        );
+        if (ended) return;
+        if (!roleState.emitted) emitChunk(controller, { role: "assistant", content: "" });
+        emitChunk(controller, {}, "stop");
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        controller.close();
+      } catch (error) {
+        if (!signal?.aborted) {
+          try {
+            controller.error(error);
+          } catch {
+            // The controller was already closed.
+          }
+        }
+      }
+    },
+  });
+}
+
+export async function collectZaiNonStreaming(
+  sourceBody: ReadableStream<Uint8Array>
+): Promise<{ answer: string; reasoning: string }> {
+  let answer = "";
+  let reasoning = "";
+  await drainSseDeltas(sourceBody, (delta) => {
+    if (delta.reasoning) reasoning += delta.reasoning;
+    if (delta.content) answer += delta.content;
+    return delta.done;
+  });
+  return { answer, reasoning };
+}
+
+export function makeZaiChunkEmitter(id: string, created: number, modelId: string): ZaiChunkEmitter {
+  return (controller, delta, finish = null) => {
+    const chunk = {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model: modelId,
+      choices: [{ index: 0, delta, finish_reason: finish }],
+    };
+    controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+  };
+}

--- a/open-sse/executors/zai-web/stream.ts
+++ b/open-sse/executors/zai-web/stream.ts
@@ -1,7 +1,36 @@
+import { sanitizeErrorMessage } from "../../utils/error.ts";
+
 export interface ZaiDelta {
   content: string;
   reasoning: string;
   done: boolean;
+  /** Set when the frame carried an upstream error rather than a delta. */
+  error?: string;
+}
+
+/**
+ * Pull a human-readable message out of an error-shaped frame.
+ *
+ * z.ai answers some failures with HTTP 200 and an error payload in the SSE body
+ * (rejected signature, expired captcha, stale token). Those frames carry no
+ * `delta_content`, so without this they take the same "no usable delta" path as
+ * a benign phase frame and are dropped — the caller then sees a successful
+ * empty completion. Only an *explicit* error field counts: contentless frames
+ * remain a normal, skipped part of the protocol.
+ */
+function readFrameError(frame: Record<string, unknown>): string | null {
+  const data = (frame.data ?? {}) as Record<string, unknown>;
+  const raw = frame.error ?? data.error;
+  if (!raw) return null;
+
+  if (typeof raw === "string") return sanitizeErrorMessage(raw) || "upstream error";
+  if (typeof raw === "object") {
+    const rec = raw as Record<string, unknown>;
+    const message = rec.detail ?? rec.message ?? rec.msg;
+    if (typeof message === "string" && message) return sanitizeErrorMessage(message);
+    return sanitizeErrorMessage(JSON.stringify(raw));
+  }
+  return sanitizeErrorMessage(String(raw));
 }
 
 export type ZaiChunkEmitter = (
@@ -47,6 +76,12 @@ function parseInternalEnvelopeFrame(
 export function parseZaiFrame(raw: unknown): ZaiDelta | null {
   if (!raw || typeof raw !== "object") return null;
   const frame = raw as Record<string, unknown>;
+
+  // Checked before the delta paths: an error frame is terminal, and must not
+  // fall through to the "no usable delta" null that would silently drop it.
+  const error = readFrameError(frame);
+  if (error) return { content: "", reasoning: "", done: true, error };
+
   const choices = frame.choices as Array<Record<string, unknown>> | undefined;
   if (Array.isArray(choices) && choices.length > 0) {
     return parseOpenAiShapedFrame(choices);
@@ -102,12 +137,17 @@ function emitDeltaChunks(
   emitChunk: ZaiChunkEmitter,
   roleState: { emitted: boolean }
 ): boolean {
-  if (!roleState.emitted && (delta.content || delta.reasoning)) {
+  if (!roleState.emitted && (delta.content || delta.reasoning || delta.error)) {
     roleState.emitted = true;
     emitChunk(controller, { role: "assistant", content: "" });
   }
   if (delta.reasoning) emitChunk(controller, { reasoning_content: delta.reasoning });
   if (delta.content) emitChunk(controller, { content: delta.content });
+  // Surfaced as visible content, matching the other web executors' mid-stream
+  // error convention (see zed-hosted's createErrorChunk): the 200 is already on
+  // the wire, so the status cannot change — but the caller must not be left
+  // reading an empty success. Any content streamed before the failure is kept.
+  if (delta.error) emitChunk(controller, { content: `[Z.ai error] ${delta.error}` });
   if (delta.done) {
     emitChunk(controller, {}, "stop");
     controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));

--- a/open-sse/executors/zai-web/stream.ts
+++ b/open-sse/executors/zai-web/stream.ts
@@ -193,6 +193,11 @@ export async function collectZaiNonStreaming(
   let answer = "";
   let reasoning = "";
   await drainSseDeltas(sourceBody, (delta) => {
+    // Match the streaming path: an upstream error frame (rejected signature,
+    // expired captcha, stale token) must surface as a failed request, not as a
+    // successful empty completion. The caller converts this throw into an error
+    // result (e.g. 502), so the client is never left reading an empty 200.
+    if (delta.error) throw new Error(delta.error);
     if (delta.reasoning) reasoning += delta.reasoning;
     if (delta.content) answer += delta.content;
     return delta.done;

--- a/open-sse/services/browserBackedChat.ts
+++ b/open-sse/services/browserBackedChat.ts
@@ -135,6 +135,10 @@ export interface BrowserBackedChatRequest {
    * For DDG this is empty — the browser is anonymous.
    */
   cookieString?: string | null;
+  /** Values injected into localStorage before the provider page initializes. */
+  localStorage?: Record<string, string>;
+  /** Origin whose localStorage receives the injected values. */
+  localStorageOrigin?: string;
   /**
    * Cookie domain. Used together with cookieString.
    */
@@ -170,6 +174,27 @@ export interface BrowserBackedChatRequest {
    */
   submitButtonSelector?: string;
   /**
+   * Use a DOM click when an animated overlay makes coordinate-based
+   * actionability unreliable even though the provider button is enabled.
+   */
+  submitButtonMode?: "playwright" | "dom";
+  /**
+   * Optional in-memory files to attach through the provider page's native
+   * upload input before submission. The page remains responsible for its
+   * authenticated upload request and for wiring returned file ids into chat.
+   */
+  attachments?: Array<{
+    name: string;
+    mimeType: string;
+    buffer: Buffer;
+  }>;
+  /**
+   * Optional provider-specific UI configuration performed after navigation
+   * and before the prompt is entered. Use this for request options that the
+   * consumer site only exposes through its own controls.
+   */
+  beforeSubmit?: (page: import("playwright").Page) => Promise<void>;
+  /**
    * Wait after submit for SSE/JSON to arrive. Default 15 seconds.
    */
   postSubmitWaitMs?: number;
@@ -190,6 +215,8 @@ export interface BrowserBackedChatResult {
   contentType: string | null;
   body: Buffer;
   isStealth: boolean;
+  /** Sanitized POST targets observed while submitting, useful when an endpoint path changes. */
+  observedPostUrls?: string[];
   timing: {
     acquireContextMs: number;
     navigateMs: number;
@@ -197,6 +224,50 @@ export interface BrowserBackedChatResult {
     captureResponseMs: number;
     totalMs: number;
   };
+}
+
+async function uploadBrowserAttachments(
+  page: import("playwright").Page,
+  attachments: NonNullable<BrowserBackedChatRequest["attachments"]>,
+  chatUrlMatchDomain: string,
+  signal?: AbortSignal | null
+): Promise<void> {
+  if (attachments.length === 0) return;
+
+  const fileInput = page.locator('input[type="file"]').first();
+  await fileInput.waitFor({ state: "attached", timeout: 10_000, signal: signal ?? undefined });
+
+  for (const attachment of attachments) {
+    const uploadResponsePromise = page.waitForResponse(
+      (response) => {
+        if (response.request().method() !== "POST") return false;
+        try {
+          const url = new URL(response.url());
+          return (
+            url.hostname.endsWith(chatUrlMatchDomain) && /\/api\/v1\/files\/?$/.test(url.pathname)
+          );
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30_000 }
+    );
+
+    const [uploadResponse] = await Promise.all([
+      uploadResponsePromise,
+      fileInput.setInputFiles({
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        buffer: attachment.buffer,
+      }),
+    ]);
+    if (!uploadResponse.ok()) {
+      throw new Error(`attachment upload returned HTTP ${uploadResponse.status()}`);
+    }
+    // Let the provider commit its uploaded-file state before another file or
+    // the chat submission is triggered.
+    await waitWithSignal(150, signal);
+  }
 }
 
 async function settlePoolKey(
@@ -257,6 +328,8 @@ export async function browserBackedChat(
     chatPageUrl,
     userMessage,
     cookieString,
+    localStorage,
+    localStorageOrigin,
     cookieDomain,
     chatUrlMatchDomain,
     userAgent,
@@ -264,6 +337,9 @@ export async function browserBackedChat(
     timezone,
     inputSelector,
     submitButtonSelector,
+    submitButtonMode = "playwright",
+    attachments = [],
+    beforeSubmit,
     postSubmitWaitMs = 15000,
     signal,
     reuseContext = true,
@@ -274,6 +350,8 @@ export async function browserBackedChat(
   const pooled: PooledContext = await acquireBrowserContext(key, {
     cookieDomain: cookieDomain || chatUrlMatchDomain,
     cookieString: cookieString || null,
+    localStorage,
+    localStorageOrigin,
     warmupUrl: chatPageUrl,
     userAgent,
     locale,
@@ -282,6 +360,18 @@ export async function browserBackedChat(
   const acquireContextMs = Date.now() - tAcquireStart;
 
   const page = await openPage(pooled);
+  const observedPostUrls: string[] = [];
+  page.on("request", (request) => {
+    if (request.method() !== "POST") return;
+    try {
+      const url = new URL(request.url());
+      if (!url.hostname.endsWith(chatUrlMatchDomain)) return;
+      const sanitized = `${url.origin}${url.pathname}`;
+      if (!observedPostUrls.includes(sanitized)) observedPostUrls.push(sanitized);
+    } catch {
+      // Ignore malformed/non-HTTP request URLs.
+    }
+  });
   try {
     const tNavStart = Date.now();
     await page.goto(chatPageUrl, {
@@ -291,6 +381,11 @@ export async function browserBackedChat(
     });
     await waitWithSignal(2500, signal);
     const navigateMs = Date.now() - tNavStart;
+
+    if (beforeSubmit) {
+      await beforeSubmit(page);
+    }
+    await uploadBrowserAttachments(page, attachments, chatUrlMatchDomain, signal);
 
     const inputLocator = page.locator(inputSelector).first();
     await inputLocator.waitFor({ state: "visible", timeout: 10000, signal: signal ?? undefined });
@@ -318,7 +413,11 @@ export async function browserBackedChat(
       const btn = page.locator(submitButtonSelector).first();
       if ((await btn.count()) > 0) {
         try {
-          await btn.click({ timeout: 2000 });
+          if (submitButtonMode === "dom") {
+            await btn.evaluate((element) => (element as HTMLElement).click());
+          } else {
+            await btn.click({ timeout: 2000 });
+          }
         } catch {
           await page.keyboard.press("Enter");
         }
@@ -336,10 +435,13 @@ export async function browserBackedChat(
       signal.removeEventListener("abort", abortListener);
     }
     if (response) {
-      // Wait for the upstream SSE to finish streaming
-      await waitWithSignal(Math.min(postSubmitWaitMs, 30000), signal);
-    } else {
-      await waitWithSignal(postSubmitWaitMs, signal);
+      // Most provider streams finish well before the safety window. Return as
+      // soon as Playwright reports completion instead of always paying the
+      // full fixed delay before reading the already-buffered body.
+      await Promise.race([
+        response.finished().then(() => undefined),
+        waitWithSignal(Math.min(postSubmitWaitMs, 30000), signal),
+      ]);
     }
     const captureResponseMs = Date.now() - tCaptureStart;
     const submitMs = captureResponseMs;
@@ -373,6 +475,7 @@ export async function browserBackedChat(
       contentType,
       body,
       isStealth: pooled.isStealth,
+      observedPostUrls,
       timing: {
         acquireContextMs,
         navigateMs,
@@ -397,6 +500,7 @@ export async function browserBackedChat(
       contentType: "application/json",
       body,
       isStealth: pooled.isStealth,
+      observedPostUrls,
       timing: {
         acquireContextMs,
         navigateMs: 0,

--- a/open-sse/services/browserBackedChat.ts
+++ b/open-sse/services/browserBackedChat.ts
@@ -27,6 +27,15 @@ import {
 import tlsClient from "../utils/tlsClient.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
 import { resolveHttpBackedChatFingerprint } from "./httpBackedChatFingerprint.ts";
+import type {
+  BrowserBackedChatRequest,
+  BrowserBackedChatResult,
+} from "./browserBackedChat/types.ts";
+
+export type {
+  BrowserBackedChatRequest,
+  BrowserBackedChatResult,
+} from "./browserBackedChat/types.ts";
 
 // Safety constants
 const MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MB
@@ -104,126 +113,6 @@ function waitWithSignal(ms: number, signal?: AbortSignal | null): Promise<void> 
   }).catch((err) => {
     if (err instanceof DOMException && err.name === "AbortError") throw err;
   });
-}
-
-export interface BrowserBackedChatRequest {
-  /**
-   * Pool key — typically a provider id like "duckduckgo-web" or
-   * "claude-web", optionally suffixed by user/account id if cookies
-   * differ.
-   */
-  poolKey: string;
-  /**
-   * Chat URL the page should submit to. The page's `fetch` will hit
-   * this URL when the user clicks Send, and we capture the response.
-   */
-  chatUrl: string;
-  /**
-   * Chat page URL to navigate to before typing. The page must already
-   * have its chat UI rendered for the input/button selectors to work.
-   */
-  chatPageUrl: string;
-  /**
-   * The text the user wants to send. Combined with the model message
-   * prefix (e.g. "Reply with exactly: ...") so the user message is the
-   * literal text typed into the chat box.
-   */
-  userMessage: string;
-  /**
-   * Cookie string (raw) to inject into the browser context. Used by
-   * Claude web (cookies from `docs/CLAUDE_COOKIE.md` or similar).
-   * For DDG this is empty — the browser is anonymous.
-   */
-  cookieString?: string | null;
-  /** Values injected into localStorage before the provider page initializes. */
-  localStorage?: Record<string, string>;
-  /** Origin whose localStorage receives the injected values. */
-  localStorageOrigin?: string;
-  /**
-   * Cookie domain. Used together with cookieString.
-   */
-  cookieDomain?: string;
-  /**
-   * Domain for the page's `fetch` to identify which path on the
-   * upstream is the chat endpoint. e.g. "duckduckgo.com" for DDG,
-   * "claude.ai" for Claude.
-   */
-  chatUrlMatchDomain: string;
-  /**
-   * User-Agent string for the browser context.
-   */
-  userAgent?: string;
-  /**
-   * Locale (BCP 47). Defaults to en-US.
-   */
-  locale?: string;
-  /**
-   * IANA timezone. Defaults to America/New_York.
-   */
-  timezone?: string;
-  /**
-   * Selector for the chat input. DDG uses `textarea` with the "Ask
-   * anything privately" placeholder; Claude uses a contenteditable
-   * div. Override per provider.
-   */
-  inputSelector: string;
-  /**
-   * Selector for the submit button. If the page exposes one, click
-   * it. Otherwise the helper falls back to pressing Enter in the
-   * input.
-   */
-  submitButtonSelector?: string;
-  /**
-   * Use a DOM click when an animated overlay makes coordinate-based
-   * actionability unreliable even though the provider button is enabled.
-   */
-  submitButtonMode?: "playwright" | "dom";
-  /**
-   * Optional in-memory files to attach through the provider page's native
-   * upload input before submission. The page remains responsible for its
-   * authenticated upload request and for wiring returned file ids into chat.
-   */
-  attachments?: Array<{
-    name: string;
-    mimeType: string;
-    buffer: Buffer;
-  }>;
-  /**
-   * Optional provider-specific UI configuration performed after navigation
-   * and before the prompt is entered. Use this for request options that the
-   * consumer site only exposes through its own controls.
-   */
-  beforeSubmit?: (page: import("playwright").Page) => Promise<void>;
-  /**
-   * Wait after submit for SSE/JSON to arrive. Default 15 seconds.
-   */
-  postSubmitWaitMs?: number;
-  /**
-   * Optional AbortSignal. Cancels navigation/submit.
-   */
-  signal?: AbortSignal | null;
-  /**
-   * Reuse the same context across requests when true. When false, a
-   * fresh context is opened each time (slower but bypasses
-   * per-context rate limits). Default true.
-   */
-  reuseContext?: boolean;
-}
-
-export interface BrowserBackedChatResult {
-  status: number;
-  contentType: string | null;
-  body: Buffer;
-  isStealth: boolean;
-  /** Sanitized POST targets observed while submitting, useful when an endpoint path changes. */
-  observedPostUrls?: string[];
-  timing: {
-    acquireContextMs: number;
-    navigateMs: number;
-    submitMs: number;
-    captureResponseMs: number;
-    totalMs: number;
-  };
 }
 
 async function uploadBrowserAttachments(

--- a/open-sse/services/browserBackedChat.ts
+++ b/open-sse/services/browserBackedChat.ts
@@ -97,7 +97,21 @@ export function __resetHttpBackedChatOverrideForTesting(): void {
   cookieCache.clear();
 }
 
-// Helper to make Playwright waitForTimeout abortable via AbortSignal
+async function withAbort<T>(promise: Promise<T>, signal?: AbortSignal | null): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    abortListener = () => reject(new DOMException("Aborted", "AbortError"));
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+  try {
+    return await Promise.race([promise, aborted]);
+  } finally {
+    if (abortListener) signal.removeEventListener("abort", abortListener);
+  }
+}
+
 function waitWithSignal(ms: number, signal?: AbortSignal | null): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) return reject(new DOMException("Aborted", "AbortError"));
@@ -110,8 +124,6 @@ function waitWithSignal(ms: number, signal?: AbortSignal | null): Promise<void> 
       resolve();
     }, ms);
     signal?.addEventListener("abort", onAbort, { once: true });
-  }).catch((err) => {
-    if (err instanceof DOMException && err.name === "AbortError") throw err;
   });
 }
 
@@ -124,7 +136,7 @@ async function uploadBrowserAttachments(
   if (attachments.length === 0) return;
 
   const fileInput = page.locator('input[type="file"]').first();
-  await fileInput.waitFor({ state: "attached", timeout: 10_000, signal: signal ?? undefined });
+  await withAbort(fileInput.waitFor({ state: "attached", timeout: 10_000 }), signal);
 
   for (const attachment of attachments) {
     const uploadResponsePromise = page.waitForResponse(
@@ -277,7 +289,7 @@ export async function browserBackedChat(
     await uploadBrowserAttachments(page, attachments, chatUrlMatchDomain, signal);
 
     const inputLocator = page.locator(inputSelector).first();
-    await inputLocator.waitFor({ state: "visible", timeout: 10000, signal: signal ?? undefined });
+    await withAbort(inputLocator.waitFor({ state: "visible", timeout: 10000 }), signal);
     await inputLocator.fill(userMessage);
     await waitWithSignal(800, signal);
 

--- a/open-sse/services/browserBackedChat/types.ts
+++ b/open-sse/services/browserBackedChat/types.ts
@@ -1,0 +1,74 @@
+import type { Buffer } from "node:buffer";
+import type { Page } from "playwright";
+
+export interface BrowserBackedChatRequest {
+  /**
+   * Pool key — typically a provider id, optionally suffixed by user/account id
+   * when browser state differs.
+   */
+  poolKey: string;
+  /** Chat endpoint whose response should be captured after submission. */
+  chatUrl: string;
+  /** Provider page to navigate to before entering the prompt. */
+  chatPageUrl: string;
+  /** Literal text typed into the provider composer. */
+  userMessage: string;
+  /** Raw cookies to inject into the browser context. */
+  cookieString?: string | null;
+  /** Values injected into localStorage before the provider page initializes. */
+  localStorage?: Record<string, string>;
+  /** Origin whose localStorage receives the injected values. */
+  localStorageOrigin?: string;
+  /** Cookie domain used with cookieString. */
+  cookieDomain?: string;
+  /** Domain used to recognize the provider chat request. */
+  chatUrlMatchDomain: string;
+  /** Browser User-Agent override. */
+  userAgent?: string;
+  /** Browser locale (BCP 47). Defaults to en-US. */
+  locale?: string;
+  /** Browser IANA timezone. Defaults to America/New_York. */
+  timezone?: string;
+  /** Selector for the provider chat input. */
+  inputSelector: string;
+  /** Optional selector for the provider submit button. */
+  submitButtonSelector?: string;
+  /**
+   * Use a DOM click when an animated overlay makes coordinate-based
+   * actionability unreliable even though the provider button is enabled.
+   */
+  submitButtonMode?: "playwright" | "dom";
+  /**
+   * Optional in-memory files to attach through the provider page's native
+   * upload input before submission.
+   */
+  attachments?: Array<{
+    name: string;
+    mimeType: string;
+    buffer: Buffer;
+  }>;
+  /** Provider-specific UI configuration performed before prompt submission. */
+  beforeSubmit?: (page: Page) => Promise<void>;
+  /** Wait after submit for SSE/JSON to arrive. Default 15 seconds. */
+  postSubmitWaitMs?: number;
+  /** Optional signal that cancels navigation and submission. */
+  signal?: AbortSignal | null;
+  /** Reuse the same browser context across requests. Defaults to true. */
+  reuseContext?: boolean;
+}
+
+export interface BrowserBackedChatResult {
+  status: number;
+  contentType: string | null;
+  body: Buffer;
+  isStealth: boolean;
+  /** Sanitized POST targets observed while submitting. */
+  observedPostUrls?: string[];
+  timing: {
+    acquireContextMs: number;
+    navigateMs: number;
+    submitMs: number;
+    captureResponseMs: number;
+    totalMs: number;
+  };
+}

--- a/open-sse/services/browserPool.ts
+++ b/open-sse/services/browserPool.ts
@@ -33,6 +33,8 @@ type Page = import("playwright").Page;
 export interface BrowserPoolContextOptions {
   cookieDomain: string;
   cookieString?: string | null;
+  localStorage?: Record<string, string>;
+  localStorageOrigin?: string;
   warmupUrl?: string | null;
   userAgent?: string;
   locale?: string;
@@ -355,6 +357,22 @@ export async function acquireBrowserContext(
       if (cookies.length > 0) {
         await context.addCookies(cookies);
       }
+    }
+
+    if (options.localStorage && Object.keys(options.localStorage).length > 0) {
+      const origin = new URL(options.localStorageOrigin || options.warmupUrl || "").origin;
+      await context.addInitScript(
+        ({ expectedOrigin, entries }) => {
+          if (window.location.origin !== expectedOrigin) return;
+          for (const [name, value] of entries) {
+            window.localStorage.setItem(name, value);
+          }
+        },
+        {
+          expectedOrigin: origin,
+          entries: Object.entries(options.localStorage),
+        }
+      );
     }
 
     let warmupPage: Page | null = null;

--- a/open-sse/services/browserPool.ts
+++ b/open-sse/services/browserPool.ts
@@ -316,6 +316,38 @@ function settlePendingContext(key: string, failed: boolean): void {
   state.pendingContexts.delete(key);
 }
 
+// Seed a freshly created context with whatever session material the caller
+// supplied — cookies for cookie-auth providers, localStorage for the ones (zai-web)
+// whose session is a Bearer JWT the page reads at boot. Kept as a leaf helper so
+// the creation closure stays under the complexity ceiling.
+async function seedContextSession(
+  context: BrowserContext,
+  options: BrowserPoolContextOptions
+): Promise<void> {
+  if (options.cookieString) {
+    const cookies = parseCookieString(options.cookieString, options.cookieDomain);
+    if (cookies.length > 0) {
+      await context.addCookies(cookies);
+    }
+  }
+
+  if (!options.localStorage || Object.keys(options.localStorage).length === 0) return;
+
+  const origin = new URL(options.localStorageOrigin || options.warmupUrl || "").origin;
+  await context.addInitScript(
+    ({ expectedOrigin, entries }) => {
+      if (window.location.origin !== expectedOrigin) return;
+      for (const [name, value] of entries) {
+        window.localStorage.setItem(name, value);
+      }
+    },
+    {
+      expectedOrigin: origin,
+      entries: Object.entries(options.localStorage),
+    }
+  );
+}
+
 export async function acquireBrowserContext(
   key: string,
   options: BrowserPoolContextOptions
@@ -352,28 +384,7 @@ export async function acquireBrowserContext(
       ...(proxy ? { proxy } : {}),
     });
 
-    if (options.cookieString) {
-      const cookies = parseCookieString(options.cookieString, options.cookieDomain);
-      if (cookies.length > 0) {
-        await context.addCookies(cookies);
-      }
-    }
-
-    if (options.localStorage && Object.keys(options.localStorage).length > 0) {
-      const origin = new URL(options.localStorageOrigin || options.warmupUrl || "").origin;
-      await context.addInitScript(
-        ({ expectedOrigin, entries }) => {
-          if (window.location.origin !== expectedOrigin) return;
-          for (const [name, value] of entries) {
-            window.localStorage.setItem(name, value);
-          }
-        },
-        {
-          expectedOrigin: origin,
-          entries: Object.entries(options.localStorage),
-        }
-      );
-    }
+    await seedContextSession(context, options);
 
     let warmupPage: Page | null = null;
     if (options.warmupUrl) {

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -96,6 +96,7 @@ const PERSIST_DEBOUNCE_MS = 60_000; // Debounce persistence to every 60s max
 let initialized = false;
 
 let currentRequestQueueSettings: RequestQueueSettings = DEFAULT_RESILIENCE_SETTINGS.requestQueue;
+export const ZAI_WEB_REQUEST_QUEUE_MAX_WAIT_MS = 60_000;
 
 const limiterEffectiveSettings = new WeakMap<Bottleneck, Bottleneck.ConstructorOptions>();
 const preservedReplacementSettings = new Map<string, Bottleneck.ConstructorOptions>();
@@ -152,6 +153,15 @@ function resolveMinTime(override: number | undefined | null): number {
 // Resolve a maxConcurrent override. 0 or missing means "effectively infinite".
 function resolveMaxConcurrent(override: number | undefined | null): number {
   return typeof override === "number" && override > 0 ? override : EFFECTIVELY_INFINITE_CONCURRENCY;
+}
+
+export function resolveRequestQueueMaxWaitMs(
+  provider: string,
+  configuredMaxWaitMs: number = currentRequestQueueSettings.maxWaitMs
+): number {
+  return provider.trim().toLowerCase() === "zai-web"
+    ? Math.max(configuredMaxWaitMs, ZAI_WEB_REQUEST_QUEUE_MAX_WAIT_MS)
+    : configuredMaxWaitMs;
 }
 
 function buildLimiterDefaults() {
@@ -531,18 +541,19 @@ export async function withRateLimit(provider, connectionId, model, fn, signal = 
 
   // Proactive sliding-window fallback for header-less providers with a declared cap
   // (Fase 8.2). No-op unless PROVIDER_DEFAULT_RATE_LIMITS has an entry for `provider`.
+  const maxWaitMs = resolveRequestQueueMaxWaitMs(provider);
   await awaitProviderDefaultSlot(
     provider,
     connectionId,
     signal,
-    currentRequestQueueSettings.maxWaitMs
+    maxWaitMs
   );
 
   const limiter = getLimiter(provider, connectionId, model);
   // Bottleneck's `expiration` starts only after a job leaves QUEUED. The
   // legacy maxWaitMs setting therefore bounds limiter-managed execution; it
   // is not a queue-wait deadline.
-  const executionExpirationMs = currentRequestQueueSettings.maxWaitMs;
+  const executionExpirationMs = maxWaitMs;
   const scheduleOpts =
     executionExpirationMs && executionExpirationMs > 0 ? { expiration: executionExpirationMs } : {};
 

--- a/open-sse/services/tokenExtractionConfig.ts
+++ b/open-sse/services/tokenExtractionConfig.ts
@@ -380,12 +380,11 @@ const RAW_CONFIGS: TokenExtractionConfig[] = [
   // ── Z.ai Web (#4056) ────────────────────────────────────────
   config(
     "zai-web",
-    "Z.ai Web (Free)",
+    "Z.ai Web",
     "https://chat.z.ai/",
     "https://chat.z.ai",
-    [{ type: "cookie", name: "token", domain: ".z.ai" }],
-    "Log in to Z.ai at chat.z.ai. The session token will be extracted.",
-    { cookieDomain: ".z.ai" }
+    [{ type: "localStorage", key: "token" }],
+    'Log in to Z.ai at chat.z.ai. OmniRoute extracts the Local Storage value named "token"; chat CAPTCHA is handled by the browser transport.'
   ),
 ];
 

--- a/open-sse/utils/streamHandler.ts
+++ b/open-sse/utils/streamHandler.ts
@@ -168,6 +168,13 @@ function getErrorMessage(error: unknown): string {
 }
 
 function getErrorStatusCode(error: unknown): number {
+  const errorName =
+    error && typeof error === "object" && typeof (error as { name?: unknown }).name === "string"
+      ? (error as { name: string }).name
+      : "";
+  if (errorName === "TimeoutError" || errorName === "BodyTimeoutError") {
+    return 504;
+  }
   if (error && typeof error === "object" && "statusCode" in error) {
     const statusCode = Number((error as { statusCode?: unknown }).statusCode);
     if (Number.isFinite(statusCode) && statusCode >= 400 && statusCode <= 599) {
@@ -175,6 +182,13 @@ function getErrorStatusCode(error: unknown): number {
     }
   }
   return 502;
+}
+
+function isDeadlineAbortReason(reason: unknown): reason is Error {
+  return (
+    reason instanceof Error &&
+    (reason.name === "TimeoutError" || reason.name === "BodyTimeoutError")
+  );
 }
 
 function hasClientTerminalSseMarker(text: string, clientResponseFormat?: string | null): boolean {
@@ -369,6 +383,15 @@ export function createStreamController({
 
   if (clientAbortSignal && typeof clientAbortSignal.addEventListener === "function") {
     const handleClientAbort = () => {
+      const reason = clientAbortSignal.reason;
+      if (isDeadlineAbortReason(reason)) {
+        // An AbortSignal can represent an OmniRoute-owned deadline as well as
+        // a caller disconnect. Preserve deadline failures as 504; classifying
+        // them as client disconnects writes a misleading 499 to the call log.
+        abortController.abort(reason);
+        controller.handleError(reason);
+        return;
+      }
       controller.handleDisconnect(getClientAbortReason());
     };
     if (clientAbortSignal.aborted) {

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/WebSessionCredentialGuide.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/WebSessionCredentialGuide.tsx
@@ -63,6 +63,7 @@ export default function WebSessionCredentialGuide({
     requirement.kind === "token" ? "webTokenRequiredCredential" : "webCookieRequiredCredential";
   const requiredCredentialFallback =
     requirement.kind === "token" ? "Required token: {credential}" : "Required cookie: {credential}";
+  const guideSteps = requirement.guideSteps;
 
   return (
     <div className="rounded-lg border border-purple-500/25 bg-purple-500/10 px-3 py-3 text-sm text-text-muted">
@@ -87,56 +88,82 @@ export default function WebSessionCredentialGuide({
               credential: requirement.credentialName,
             })}
           </p>
-          <ol className="list-decimal space-y-1 pl-5">
-            <li>
-              {providerText(t, "webSessionGuideStep1", "Sign in to {provider} in your browser.", {
-                provider: providerName,
-              })}
-              {providerWebsite && providerWebsiteHost && (
-                <a
-                  href={providerWebsite}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="ml-2 inline-flex items-center gap-1 text-primary hover:underline"
-                >
-                  {providerText(t, "webSessionGuideOpenProvider", "Open {host}", {
-                    host: providerWebsiteHost,
-                  })}
-                  <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
-                    open_in_new
-                  </span>
-                </a>
-              )}
-            </li>
-            <li>
-              {providerText(
-                t,
-                "webSessionGuideStep2Fast",
-                "Fast path: install the Cookie Editor extension (chromewebstore.google.com → Cookie Editor), open it on the {provider} tab, find {credential} (select all numbered chunks if split), and click Export → Copy with the export format set to “Cookie header”.",
-                { provider: providerName, credential: requirement.credentialName }
-              )}
-            </li>
-            <li>
-              {providerText(
-                t,
-                "webSessionGuideStep3Manual",
-                "Manual path: open the browser developer tools (F12 → Network), refresh the page, open an authenticated request, and copy the Cookie header value from Request Headers — omit the Cookie: prefix."
-              )}
-            </li>
-            <li>
-              {providerText(
-                t,
-                "webSessionGuideStep4",
-                "Paste it here and check the connection. If it stops working, sign in again and replace it with a fresh value."
-              )}
-            </li>
-          </ol>
+          {guideSteps ? (
+            <ol className="list-decimal space-y-1 pl-5">
+              {guideSteps.map((step, index) => (
+                <li key={step}>
+                  {step}
+                  {index === 0 && providerWebsite && providerWebsiteHost && (
+                    <a
+                      href={providerWebsite}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-2 inline-flex items-center gap-1 text-primary hover:underline"
+                    >
+                      {providerText(t, "webSessionGuideOpenProvider", "Open {host}", {
+                        host: providerWebsiteHost,
+                      })}
+                      <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
+                        open_in_new
+                      </span>
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>
+                {providerText(t, "webSessionGuideStep1", "Sign in to {provider} in your browser.", {
+                  provider: providerName,
+                })}
+                {providerWebsite && providerWebsiteHost && (
+                  <a
+                    href={providerWebsite}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-2 inline-flex items-center gap-1 text-primary hover:underline"
+                  >
+                    {providerText(t, "webSessionGuideOpenProvider", "Open {host}", {
+                      host: providerWebsiteHost,
+                    })}
+                    <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
+                      open_in_new
+                    </span>
+                  </a>
+                )}
+              </li>
+              <li>
+                {providerText(
+                  t,
+                  "webSessionGuideStep2Fast",
+                  "Fast path: install the Cookie Editor extension (chromewebstore.google.com → Cookie Editor), open it on the {provider} tab, find {credential} (select all numbered chunks if split), and click Export → Copy with the export format set to “Cookie header”.",
+                  { provider: providerName, credential: requirement.credentialName }
+                )}
+              </li>
+              <li>
+                {providerText(
+                  t,
+                  "webSessionGuideStep3Manual",
+                  "Manual path: open the browser developer tools (F12 → Network), refresh the page, open an authenticated request, and copy the Cookie header value from Request Headers — omit the Cookie: prefix."
+                )}
+              </li>
+              <li>
+                {providerText(
+                  t,
+                  "webSessionGuideStep4",
+                  "Paste it here and check the connection. If it stops working, sign in again and replace it with a fresh value."
+                )}
+              </li>
+            </ol>
+          )}
           <p className="text-xs text-amber-700 dark:text-amber-300">
-            {providerText(
-              t,
-              "webSessionSecurityHint",
-              "Treat this like a password: it may access your signed-in web account until it expires or is revoked."
-            )}
+            {requirement.guideNote ??
+              providerText(
+                t,
+                "webSessionSecurityHint",
+                "Treat this like a password: it may access your signed-in web account until it expires or is revoked."
+              )}
           </p>
         </div>
       </div>

--- a/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
@@ -376,37 +376,6 @@ export const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> =
     },
   },
   "qwen-cloud": QWEN_CLOUD_TEXT_MODELS_CONFIG,
-  // #7678: zai-web (chat.z.ai) had no PROVIDER_MODELS_CONFIG entry so its
-  // hardcoded 3-model registry catalog (glm-4.6/glm-4.5/glm-4.5v — one or more
-  // now 404 upstream) was the only source; wire live discovery against the
-  // undocumented chat.z.ai/api/models endpoint. Same category + shape as
-  // qwen-web above: undocumented consumer web-chat endpoint,
-  // { data: { data: [...] } } envelope with a flatter { data: [...] } fallback.
-  // Bearer token reuses the executor's own extractZaiToken() so discovery and
-  // chat parse the stored cookie identically.
-  // UNVERIFIED (per /triage-features): no live z.ai session available during
-  // research — the exact response shape and whether bare Bearer auth (vs the
-  // full Cookie header chat-completions requires) is accepted must be
-  // confirmed against a real account before merge (see plan-file Step 4).
-  "zai-web": {
-    url: "https://chat.z.ai/api/models",
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-    buildHeaders: (token) => ({
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${extractZaiToken(token)}`,
-    }),
-    parseResponse: (data) => {
-      const innerData = data?.data?.data || data?.data || [];
-      return (Array.isArray(innerData) ? innerData : [])
-        .map((item: any) => ({
-          id: item.id || item.name,
-          name: item.name || item.id,
-          owned_by: item.owned_by || "zai-web",
-        }))
-        .filter((m: any) => m.id);
-    },
-  },
   antigravity: {
     url: getAntigravityModelsDiscoveryUrls()[0],
     method: "POST",

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -285,7 +285,7 @@ export async function GET(
     // (dedup by id). Internal model-sync discovery opts out because these rows
     // are a response projection, not provider-discovered models.
     let customModelsForProvider: Array<{ id: string; name?: string }> = [];
-    if (!excludeCustom) {
+    if (!excludeCustom && !usesCuratedModelsOnly) {
       try {
         const custom = await getCustomModels(provider);
         if (Array.isArray(custom)) {

--- a/src/app/api/providers/[id]/sync-models/route.ts
+++ b/src/app/api/providers/[id]/sync-models/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { getCachedProviderConnectionById } from "@/lib/localDb";
-import { getSyncedAvailableModelsForConnection } from "@/lib/db/models";
+import {
+  deleteImportedCustomModels,
+  deleteSyncedAvailableModelsForProvider,
+  getSyncedAvailableModelsForConnection,
+} from "@/lib/db/models";
 import { selectModelsForImport } from "@/shared/utils/freeModels";
 import {
   importManagedModels,
@@ -394,6 +398,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     logProvider = toNonEmptyString(connection.provider) || "unknown";
     channelLabel = getModelSyncChannelLabel(connection);
     if (providerUsesCuratedModelsOnly(logProvider)) {
+      const [removedSyncedLists, removedImportedModelIds] = await Promise.all([
+        deleteSyncedAvailableModelsForProvider(logProvider),
+        deleteImportedCustomModels(logProvider),
+      ]);
       return NextResponse.json({
         provider: logProvider,
         connectionId: id,
@@ -402,6 +410,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         syncedModels: 0,
         availableModelsCount: 0,
         models: [],
+        cleanup: {
+          removedSyncedLists,
+          removedImportedModels: removedImportedModelIds.length,
+        },
       });
     }
     const previousSyncedAvailableModelsForConnection = await getSyncedAvailableModelsForConnection(

--- a/src/lib/api/modelTestRunner.ts
+++ b/src/lib/api/modelTestRunner.ts
@@ -20,9 +20,11 @@ import { looksLikeQuotaExhausted } from "@/shared/utils/classify429";
 import { getTrustedLocalRateLimitError } from "@omniroute/open-sse/services/rateLimitManager/errors";
 
 const INTERNAL_ORIGIN = "http://omniroute.internal";
-export const DEFAULT_MODEL_TEST_TIMEOUT_MS = 60_000;
+export const DEFAULT_MODEL_TEST_TIMEOUT_MS = 30_000;
 const DOLA_PRO_TEST_TIMEOUT_MS = 90_000;
 const DOUBAO_WEB_PROVIDER_ID = "doubao-web";
+const ZAI_WEB_PROVIDER_ID = "zai-web";
+const ZAI_WEB_TEST_TIMEOUT_MS = 60_000;
 const SLOW_WEB_TEST_MODELS = new Set(["dola-pro"]);
 const STREAMING_CHAT_TEST_MAX_TOKENS = 64;
 
@@ -107,6 +109,10 @@ export function resolveModelTestTimeoutMs(
 
   if (normalizedProviderId === DOUBAO_WEB_PROVIDER_ID && SLOW_WEB_TEST_MODELS.has(modelLeafId)) {
     return Math.max(requestedTimeoutMs, DOLA_PRO_TEST_TIMEOUT_MS);
+  }
+
+  if (normalizedProviderId === ZAI_WEB_PROVIDER_ID) {
+    return Math.max(requestedTimeoutMs, ZAI_WEB_TEST_TIMEOUT_MS);
   }
 
   return requestedTimeoutMs;

--- a/src/lib/api/modelTestRunner.ts
+++ b/src/lib/api/modelTestRunner.ts
@@ -20,7 +20,7 @@ import { looksLikeQuotaExhausted } from "@/shared/utils/classify429";
 import { getTrustedLocalRateLimitError } from "@omniroute/open-sse/services/rateLimitManager/errors";
 
 const INTERNAL_ORIGIN = "http://omniroute.internal";
-export const DEFAULT_MODEL_TEST_TIMEOUT_MS = 30_000;
+export const DEFAULT_MODEL_TEST_TIMEOUT_MS = 60_000;
 const DOLA_PRO_TEST_TIMEOUT_MS = 90_000;
 const DOUBAO_WEB_PROVIDER_ID = "doubao-web";
 const SLOW_WEB_TEST_MODELS = new Set(["dola-pro"]);
@@ -38,6 +38,12 @@ function getErrorMessage(error: unknown): string {
 
 function getErrorName(error: unknown): string {
   return error instanceof Error ? error.name : "";
+}
+
+export function createModelTestTimeoutError(timeoutMs: number): Error {
+  const error = new Error(`Model test deadline exceeded after ${timeoutMs}ms`);
+  error.name = "TimeoutError";
+  return error;
 }
 
 function extractUpstreamDetailMessage(value: unknown): string | null {
@@ -304,6 +310,16 @@ export type ModelTestResponseText = {
   error?: { message: string; statusCode?: number };
 };
 
+export function classifyModelTestOutput(
+  timedOut: boolean,
+  responseText: string,
+  allowsEmptyOutput: boolean
+): "ok" | "empty" | "timeout" {
+  if (timedOut) return "timeout";
+  if (!responseText && !allowsEmptyOutput) return "empty";
+  return "ok";
+}
+
 export async function extractModelTestResponseText(
   response: Response,
   streamChat: boolean
@@ -419,7 +435,7 @@ export async function runSingleModelTest(
   let timedOut = false;
   const timeoutHandle = setTimeout(() => {
     timedOut = true;
-    controller.abort();
+    controller.abort(createModelTestTimeoutError(effectiveTimeoutMs));
   }, effectiveTimeoutMs);
 
   const runInner = async (signal: AbortSignal): Promise<Response> => {
@@ -457,17 +473,17 @@ export async function runSingleModelTest(
     clearTimeout(timeoutHandle);
     const latencyMs = Date.now() - startTime;
     const errorName = getErrorName(error);
+    if (timedOut) {
+      return {
+        modelId: fullModelStr,
+        status: "slow",
+        latencyMs,
+        httpStatus: 504,
+        error: `No model output within ${Math.round(effectiveTimeoutMs / 1000)}s`,
+        isTimeout: true,
+      };
+    }
     if (errorName === "AbortError") {
-      if (timedOut) {
-        return {
-          modelId: fullModelStr,
-          status: "slow",
-          latencyMs,
-          httpStatus: 504,
-          error: `No model output within ${Math.round(effectiveTimeoutMs / 1000)}s`,
-          isTimeout: true,
-        };
-      }
       // AbortError without timeout = withRateLimit queue rejection / abort.
       // Surface as rate_limited so the batch endpoint can stop the loop.
       return {
@@ -563,7 +579,12 @@ export async function runSingleModelTest(
         ...(quotaFlags.isQuota ? { isQuota: true } : {}),
       };
     }
-    if (timedOut && !responseText) {
+    const outputState = classifyModelTestOutput(timedOut, responseText, isEmbedding || isRerank);
+    // A streaming response can yield partial text just as the test timeout
+    // aborts the underlying request. Partial output does not make an aborted
+    // request healthy: the call log correctly records that race as 499, so
+    // the model-test result must remain a timeout instead of turning green.
+    if (outputState === "timeout") {
       return {
         modelId: fullModelStr,
         status: "slow",
@@ -582,7 +603,7 @@ export async function runSingleModelTest(
         responseText: "[Rerank completed successfully]",
       };
     }
-    if (!responseText && !isEmbedding) {
+    if (outputState === "empty") {
       return {
         modelId: fullModelStr,
         status: "error",

--- a/src/lib/providers/modelListingCapability.ts
+++ b/src/lib/providers/modelListingCapability.ts
@@ -11,7 +11,7 @@
 const TOOL_ONLY_SERVICE_KINDS = new Set<string>(["webSearch", "webFetch"]);
 
 /** Providers whose registry catalog is the complete, intentional model list. */
-const CURATED_MODEL_ONLY_PROVIDERS = new Set<string>(["kimi-web"]);
+const CURATED_MODEL_ONLY_PROVIDERS = new Set<string>(["kimi-web", "zai-web"]);
 
 export function providerUsesCuratedModelsOnly(providerId: string): boolean {
   return CURATED_MODEL_ONLY_PROVIDERS.has(providerId.trim().toLowerCase());

--- a/src/lib/providers/validation/webCookie.ts
+++ b/src/lib/providers/validation/webCookie.ts
@@ -3,6 +3,7 @@
 // byte-identical to the original inline defs.
 import { WEB_COOKIE_PROVIDERS, isLocalProvider } from "@/shared/constants/providers";
 import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
+import { extractZaiToken } from "@omniroute/open-sse/executors/zai-web.ts";
 import { normalizeBaseUrl } from "./urlHelpers";
 import { STANDARD_USER_AGENT, buildBearerHeaders } from "./headers";
 import {
@@ -73,16 +74,33 @@ export async function validateWebCookieProvider({
       };
     }
 
-    const testUrl = `${baseUrl}/models`;
+    // zai-web is the one web-cookie provider whose session is a localStorage
+    // Bearer JWT rather than a cookie: chat.z.ai serves its catalog at
+    // /api/models and authenticates with `Authorization: Bearer`, so probing
+    // `${baseUrl}/models` with a Cookie header reports a live session as dead.
+    const isZaiWeb = provider === "zai-web";
+    const zaiToken = isZaiWeb ? extractZaiToken(cookie) : "";
+    if (isZaiWeb && !zaiToken) {
+      return { valid: false, error: "Z.ai web-session credential required", unsupported: false };
+    }
+
+    const testUrl = `${baseUrl}${isZaiWeb ? "/api/models" : "/models"}`;
 
     const res = await validationRead(
       testUrl,
       {
         method: "GET",
-        headers: {
-          "User-Agent": STANDARD_USER_AGENT,
-          Cookie: cookie,
-        },
+        headers: isZaiWeb
+          ? {
+              Accept: "application/json",
+              "Accept-Language": "en-US",
+              Authorization: `Bearer ${zaiToken}`,
+              "User-Agent": STANDARD_USER_AGENT,
+            }
+          : {
+              "User-Agent": STANDARD_USER_AGENT,
+              Cookie: cookie,
+            },
       },
       isLocalProvider(provider)
     );

--- a/src/lib/providers/validation/webCookie.ts
+++ b/src/lib/providers/validation/webCookie.ts
@@ -13,6 +13,90 @@ import {
   WEB_COOKIE_PROVIDERS_WITHOUT_MODELS_API,
 } from "./transport";
 
+const UNSUPPORTED = { valid: false, error: "Provider validation not supported", unsupported: true };
+
+/**
+ * Decide whether `provider` can be probed at all, and with what URL/headers.
+ *
+ * Every rejection here is a refusal to guess: a provider with no real API host, a
+ * non-http(s) baseUrl, or a missing credential cannot produce a trustworthy
+ * signal, and reporting "unsupported" beats reporting a false `valid: true`.
+ * Split out of validateWebCookieProvider so the probe itself stays readable.
+ */
+function resolveWebCookieProbe(
+  provider: string,
+  cookie: string
+):
+  | { rejection: { valid: boolean; error: string; unsupported: boolean } }
+  | { testUrl: string; headers: Record<string, string> } {
+  const entry = getRegistryEntry(provider);
+  const cookieProvider = WEB_COOKIE_PROVIDERS[provider as keyof typeof WEB_COOKIE_PROVIDERS];
+  if (!entry && !cookieProvider) {
+    return {
+      rejection: { valid: false, error: "Provider not found in registry", unsupported: true },
+    };
+  }
+  if (!cookie) {
+    return {
+      rejection: {
+        valid: false,
+        error: "Cookie required for web-cookie provider",
+        unsupported: false,
+      },
+    };
+  }
+
+  // Providers listed in WEB_COOKIE_PROVIDERS without a providerRegistry entry (e.g.
+  // gemini-business, poe-web, venice-web, v0-vercel-web) only expose a marketing
+  // website URL, not a real API host. Probing `${website}/models` does not reliably
+  // signal session validity for these — live verification showed most return
+  // redirects or SPA 200s regardless of cookie validity, which would silently report
+  // an expired/garbage cookie as "OK" (worse than an honest "not supported").
+  if (!entry) return { rejection: UNSUPPORTED };
+
+  // Defense-in-depth: only an http(s) baseUrl without a query string is safe to probe
+  // by blindly appending `/models`. A ws(s):// baseUrl (e.g. copilot-web) is already
+  // rejected by the outbound URL guard downstream, but reject it explicitly here for
+  // the honest "unsupported" result instead of a confusing security-block message —
+  // this also covers a future http(s) baseUrl carrying a query string, which the guard
+  // does not currently block (#7857 acceptance criteria).
+  const baseUrl = normalizeBaseUrl(entry.baseUrl || "");
+  if (!/^https?:\/\//i.test(baseUrl) || baseUrl.includes("?")) {
+    return { rejection: UNSUPPORTED };
+  }
+
+  // zai-web is the one web-cookie provider whose session is a localStorage Bearer JWT
+  // rather than a cookie: chat.z.ai serves its catalog at /api/models and authenticates
+  // with `Authorization: Bearer`, so probing `${baseUrl}/models` with a Cookie header
+  // reports a live session as dead.
+  if (provider !== "zai-web") {
+    return {
+      testUrl: `${baseUrl}/models`,
+      headers: { "User-Agent": STANDARD_USER_AGENT, Cookie: cookie },
+    };
+  }
+
+  const zaiToken = extractZaiToken(cookie);
+  if (!zaiToken) {
+    return {
+      rejection: {
+        valid: false,
+        error: "Z.ai web-session credential required",
+        unsupported: false,
+      },
+    };
+  }
+  return {
+    testUrl: `${baseUrl}/api/models`,
+    headers: {
+      Accept: "application/json",
+      "Accept-Language": "en-US",
+      Authorization: `Bearer ${zaiToken}`,
+      "User-Agent": STANDARD_USER_AGENT,
+    },
+  };
+}
+
 /**
  * Validates web-cookie providers by performing a ping request to check if the session is still valid.
  * Returns SESSION_EXPIRED error code if the upstream returns 401/403.
@@ -27,81 +111,13 @@ export async function validateWebCookieProvider({
   providerSpecificData?: Record<string, unknown>;
 }) {
   try {
-    const entry = getRegistryEntry(provider);
-    const cookieProvider = WEB_COOKIE_PROVIDERS[provider as keyof typeof WEB_COOKIE_PROVIDERS];
-    if (!entry && !cookieProvider) {
-      return { valid: false, error: "Provider not found in registry", unsupported: true };
-    }
-
     // For web-cookie providers, apiKey contains the cookie string
-    const cookie = (apiKey || "").trim();
-    if (!cookie) {
-      return { valid: false, error: "Cookie required for web-cookie provider", unsupported: false };
-    }
-
-    if (!entry) {
-      // Providers listed in WEB_COOKIE_PROVIDERS without a providerRegistry entry (e.g.
-      // gemini-business, poe-web, venice-web, v0-vercel-web) only expose a
-      // marketing website URL, not a real API host. Probing `${website}/models`
-      // does not reliably signal session validity for these —
-      // live verification showed most return redirects or SPA 200s regardless of
-      // cookie validity, which would silently report an expired/garbage cookie as
-      // "OK" (worse than an honest "not supported"). Until each of these providers
-      // has a verified, side-effect-free auth probe against its real API host, report
-      // unsupported instead of a false positive.
-      return {
-        valid: false,
-        error: "Provider validation not supported",
-        unsupported: true,
-      };
-    }
-
-    // Attempt a minimal request to check if the session is valid
-    // Use /models endpoint or a minimal completion request depending on the provider
-    const baseUrl = normalizeBaseUrl(entry.baseUrl || "");
-
-    // Defense-in-depth: only an http(s) baseUrl without a query string is safe to
-    // probe by blindly appending `/models`. A ws(s):// baseUrl (e.g. copilot-web) is
-    // already rejected by the outbound URL guard downstream, but reject it explicitly
-    // here for the honest "unsupported" result instead of a confusing security-block
-    // message — this also covers a future http(s) baseUrl carrying a query string,
-    // which the guard does not currently block (#7857 acceptance criteria).
-    if (!/^https?:\/\//i.test(baseUrl) || baseUrl.includes("?")) {
-      return {
-        valid: false,
-        error: "Provider validation not supported",
-        unsupported: true,
-      };
-    }
-
-    // zai-web is the one web-cookie provider whose session is a localStorage
-    // Bearer JWT rather than a cookie: chat.z.ai serves its catalog at
-    // /api/models and authenticates with `Authorization: Bearer`, so probing
-    // `${baseUrl}/models` with a Cookie header reports a live session as dead.
-    const isZaiWeb = provider === "zai-web";
-    const zaiToken = isZaiWeb ? extractZaiToken(cookie) : "";
-    if (isZaiWeb && !zaiToken) {
-      return { valid: false, error: "Z.ai web-session credential required", unsupported: false };
-    }
-
-    const testUrl = `${baseUrl}${isZaiWeb ? "/api/models" : "/models"}`;
+    const probe = resolveWebCookieProbe(provider, (apiKey || "").trim());
+    if ("rejection" in probe) return probe.rejection;
 
     const res = await validationRead(
-      testUrl,
-      {
-        method: "GET",
-        headers: isZaiWeb
-          ? {
-              Accept: "application/json",
-              "Accept-Language": "en-US",
-              Authorization: `Bearer ${zaiToken}`,
-              "User-Agent": STANDARD_USER_AGENT,
-            }
-          : {
-              "User-Agent": STANDARD_USER_AGENT,
-              Cookie: cookie,
-            },
-      },
+      probe.testUrl,
+      { method: "GET", headers: probe.headers },
       isLocalProvider(provider)
     );
 

--- a/src/lib/resilience/settings.ts
+++ b/src/lib/resilience/settings.ts
@@ -41,8 +41,8 @@ export type {
 } from "./settings/types";
 
 export const DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS = (() => {
-  const parsed = Number(process.env.RATE_LIMIT_MAX_WAIT_MS || "15000");
-  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 15000;
+  const parsed = Number(process.env.RATE_LIMIT_MAX_WAIT_MS || "60000");
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 60000;
 })();
 
 // Issue #6593: opt-in admission cap on the local rate-limit queue depth.

--- a/src/lib/resilience/settings.ts
+++ b/src/lib/resilience/settings.ts
@@ -41,8 +41,8 @@ export type {
 } from "./settings/types";
 
 export const DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS = (() => {
-  const parsed = Number(process.env.RATE_LIMIT_MAX_WAIT_MS || "60000");
-  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 60000;
+  const parsed = Number(process.env.RATE_LIMIT_MAX_WAIT_MS || "15000");
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 15000;
 })();
 
 // Issue #6593: opt-in admission cap on the local rate-limit queue depth.

--- a/src/shared/constants/providers/web-cookie.ts
+++ b/src/shared/constants/providers/web-cookie.ts
@@ -410,17 +410,18 @@ export const WEB_COOKIE_PROVIDERS = {
   "zai-web": {
     id: "zai-web",
     alias: "zw",
-    name: "Z.ai Web (Free)",
+    name: "Z.ai Web",
     icon: "auto_awesome",
     color: "#2563EB",
     textIcon: "ZW",
     website: "https://chat.z.ai",
     hasFree: true,
     freeNote:
-      "Free consumer web session — GLM chat models via chat.z.ai. Distinct from the API-key zai/glm providers. No subscription required.",
+      "Consumer web session for the four models currently visible in chat.z.ai. Distinct from the API-key zai/glm providers.",
     subscriptionRisk: true,
     riskNoticeVariant: "webCookie",
-    authHint: "Paste the full Cookie header from chat.z.ai (must include the token=<JWT> cookie)",
+    authHint:
+      'Copy the "token" value from chat.z.ai → DevTools → Application → Local Storage. Do not copy cookies; OmniRoute handles the per-request CAPTCHA through its browser transport.',
   },
   promptql: {
     id: "promptql",

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -15,6 +15,9 @@ export type WebSessionCredentialRequirement =
        */
       hintKey?: string;
       hintFallback?: string;
+      /** Provider-specific replacement for the generic four-step DevTools guide. */
+      guideSteps?: readonly string[];
+      guideNote?: string;
     }
   | {
       kind: "none";
@@ -284,11 +287,22 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     storageKeys: ["cookie", "manus_session"],
   },
   "zai-web": {
-    kind: "cookie",
-    credentialName: "token",
-    placeholder: "token=... or full Cookie header from chat.z.ai",
-    acceptsFullCookieHeader: true,
-    storageKeys: ["cookie", "token"],
+    kind: "token",
+    credentialName: 'Local Storage value named "token"',
+    placeholder: "eyJ... (chat.z.ai → DevTools → Application → Local Storage → token)",
+    acceptsFullCookieHeader: false,
+    storageKeys: ["token"],
+    hintKey: "zaiWebCredentialHint",
+    hintFallback:
+      'Copy only the "token" value from chat.z.ai Local Storage. Do not copy a Cookie header. OmniRoute uses its browser transport to obtain the per-request CAPTCHA proof.',
+    guideSteps: [
+      "Open chat.z.ai and sign in.",
+      "Open DevTools → Application → Local Storage → https://chat.z.ai.",
+      'Find the row named "token" and copy only its value. Do not copy any Cookie header.',
+      "Paste the token below and check the connection. OmniRoute handles the per-request CAPTCHA through its browser transport.",
+    ],
+    guideNote:
+      "Treat the token like a password. Browser transport is enabled by default; do not set OMNIROUTE_BROWSER_POOL=off for this connection. If Z.ai signs you out or the token expires, repeat these steps with the new value.",
   },
   lmarena: {
     kind: "cookie",

--- a/tests/unit/executor-zai-web.test.ts
+++ b/tests/unit/executor-zai-web.test.ts
@@ -540,7 +540,12 @@ describe("ZaiWebExecutor", () => {
         signal: null,
       });
 
-      assert.equal(capture.completionUrl, "https://chat.z.ai/api/v2/chat/completions");
+      // #8014: completions must target the versioned v2 path. The query string
+      // carries the per-request signature payload, so match the endpoint prefix.
+      assert.ok(
+        String(capture.completionUrl).startsWith("https://chat.z.ai/api/v2/chat/completions?"),
+        `expected the v2 completions endpoint, got ${capture.completionUrl}`
+      );
       const newChatBody = JSON.parse(String(capture.newChatInit?.body));
       assert.equal(newChatBody.chat.enable_thinking, true);
       assert.equal(newChatBody.chat.reasoning_effort, "high");

--- a/tests/unit/executor-zai-web.test.ts
+++ b/tests/unit/executor-zai-web.test.ts
@@ -1,7 +1,74 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import type { BrowserBackedChatRequest } from "../../open-sse/services/browserBackedChat.ts";
 
 const mod = await import("../../open-sse/executors/zai-web.ts");
+const browserChat = await import("../../open-sse/services/browserBackedChat.ts");
+
+const ZAI_HOME_URL = "https://chat.z.ai/";
+const ZAI_NEW_CHAT_URL = "https://chat.z.ai/api/v1/chats/new";
+const ZAI_COMPLETION_PATH = "/api/v2/chat/completions";
+const TEST_TOKEN = `e30.${Buffer.from(JSON.stringify({ id: "user-123" })).toString("base64url")}.sig`;
+const TEST_CREDENTIAL = JSON.stringify({
+  token: TEST_TOKEN,
+  captcha_verify_param: "captcha-proof",
+});
+
+interface ZaiFetchCapture {
+  completionInit?: RequestInit;
+  completionUrl?: string;
+  newChatInit?: RequestInit;
+}
+
+function installZaiFetch(
+  completionResponse: () => Response,
+  capture: ZaiFetchCapture = {}
+): typeof globalThis.fetch {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const value = String(url);
+    if (value === ZAI_HOME_URL) {
+      return new Response(
+        '<script src="https://z-cdn.chatglm.cn/z-ai/frontend/prod-fe-1.1.79/assets/index.js"></script>'
+      );
+    }
+    if (value === ZAI_NEW_CHAT_URL) {
+      capture.newChatInit = init;
+      return Response.json({ id: "chat-123" });
+    }
+    if (new URL(value).pathname === ZAI_COMPLETION_PATH) {
+      capture.completionUrl = value;
+      capture.completionInit = init;
+      return completionResponse();
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof globalThis.fetch;
+  return originalFetch;
+}
+
+function makeBrowserResult(content: string) {
+  return {
+    status: 200,
+    contentType: "text/event-stream",
+    body: Buffer.from(
+      [
+        `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: content, phase: "answer", done: false } })}`,
+        `data: ${JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })}`,
+        "",
+        "",
+      ].join("\n")
+    ),
+    isStealth: true,
+    timing: {
+      acquireContextMs: 1,
+      navigateMs: 1,
+      submitMs: 1,
+      captureResponseMs: 1,
+      totalMs: 4,
+    },
+  };
+}
 
 describe("ZaiWebExecutor", () => {
   it("can be instantiated", () => {
@@ -9,9 +76,63 @@ describe("ZaiWebExecutor", () => {
     assert.ok(executor);
   });
 
+  it("preserves browser transport failure details and timing", () => {
+    assert.equal(
+      mod.describeZaiBrowserFailure({
+        status: 502,
+        body: Buffer.from(
+          JSON.stringify({
+            error: { message: "browserBackedChat failed: response.body unavailable" },
+          })
+        ),
+        timing: { captureResponseMs: 30_001, totalMs: 33_412 },
+      }),
+      "Z.ai browser transport failed (502; capture 30001ms, total 33412ms): " +
+        "browserBackedChat failed: response.body unavailable"
+    );
+    assert.match(
+      mod.describeZaiBrowserFailure({
+        status: 0,
+        body: Buffer.alloc(0),
+        timing: { captureResponseMs: 30_000, totalMs: 33_000 },
+      }),
+      /no matching response.*did not issue the expected authenticated chat completion request/
+    );
+  });
+
   it("extracts the token cookie value from a full Cookie header", () => {
     assert.equal(mod.extractZaiToken("token=abc123; other=xyz"), "abc123");
     assert.equal(mod.extractZaiToken("Cookie: other=xyz; token=abc123"), "abc123");
+  });
+
+  it("extracts the current localStorage Bearer token and JSON credential", () => {
+    assert.equal(mod.extractZaiToken("Bearer abc123"), "abc123");
+    assert.equal(mod.extractZaiToken("Authorization: Bearer abc123"), "abc123");
+    assert.equal(mod.extractZaiToken(TEST_CREDENTIAL), TEST_TOKEN);
+    assert.equal(mod.extractZaiCaptchaVerifyParam(TEST_CREDENTIAL), "captcha-proof");
+    assert.equal(mod.extractZaiUserId(TEST_TOKEN), "user-123");
+  });
+
+  it("reproduces the live frontend HMAC signature algorithm", () => {
+    assert.equal(
+      mod.buildZaiSignature({
+        prompt: "Reply with exactly: OMNIROUTE_ZAI_WEB_TEST",
+        requestId: "3b907de9-793c-41d1-8b8e-6ed6a714ee08",
+        timestamp: 1784855934807,
+        userId: "user-123",
+      }),
+      "14f17673ccd4ec86476549ebe60f181529572f7a0cfe8ba179206cf2d37cf442"
+    );
+  });
+
+  it("parses the deployed frontend version from the homepage asset path", () => {
+    assert.equal(
+      mod.parseZaiFrontendVersion(
+        "https://z-cdn.chatglm.cn/z-ai/frontend/prod-fe-1.1.79/assets/index.js"
+      ),
+      "prod-fe-1.1.79"
+    );
+    assert.equal(mod.parseZaiFrontendVersion("<html></html>"), null);
   });
 
   it("accepts a bare JWT/token with no cookie name prefix", () => {
@@ -71,21 +192,105 @@ describe("ZaiWebExecutor", () => {
     assert.equal(mod.parseZaiFrame({ data: { phase: "answer" } }), null);
   });
 
-  it("folds non-string message content into JSON strings", () => {
+  it("folds multimodal message content into text without leaking image payloads", () => {
     const folded = mod.foldMessages([
       { role: "user", content: "hi" },
       { role: "user", content: { foo: "bar" } },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,aW1hZ2U=" } },
+        ],
+      },
     ]);
     assert.deepEqual(folded, [
       { role: "user", content: "hi" },
-      { role: "user", content: '{"foo":"bar"}' },
+      { role: "user", content: "" },
+      { role: "user", content: "inspect this" },
     ]);
   });
 
-  it("returns a credential error when no cookie is provided", async () => {
+  it("enables Deep Think for every public model and limits effort to GLM-5.2", () => {
+    assert.deepEqual(mod.resolveZaiThinkingConfig("glm-5.2", {}), {
+      supported: true,
+      enabled: true,
+      effort: "max",
+      effortSupported: true,
+    });
+    assert.deepEqual(mod.resolveZaiThinkingConfig("zw/glm-5.2", { reasoning_effort: "medium" }), {
+      supported: true,
+      enabled: true,
+      effort: "high",
+      effortSupported: true,
+    });
+    assert.deepEqual(mod.resolveZaiThinkingConfig("glm-5.2", { reasoning: { effort: "high" } }), {
+      supported: true,
+      enabled: true,
+      effort: "high",
+      effortSupported: true,
+    });
+    assert.deepEqual(mod.resolveZaiThinkingConfig("glm-5.2", { reasoning_effort: "off" }), {
+      supported: true,
+      enabled: false,
+      effort: "max",
+      effortSupported: true,
+    });
+    assert.deepEqual(mod.resolveZaiThinkingConfig("GLM-5.1", { reasoning_effort: "max" }), {
+      supported: true,
+      enabled: true,
+      effort: "max",
+      effortSupported: false,
+    });
+  });
+
+  it("maps GLM-5V-Turbo vision and internal VLM controls from live capabilities", () => {
+    assert.deepEqual(mod.getZaiModelCapabilities("zw/GLM-5v-Turbo"), {
+      mcp: false,
+      reasoningEffort: false,
+      returnFc: true,
+      thinking: true,
+      vision: true,
+      vlmTools: true,
+      vlmWebSearch: true,
+      vlmWebsiteMode: true,
+      webSearch: true,
+    });
+    assert.deepEqual(mod.resolveZaiVlmConfig("GLM-5v-Turbo", {}), {
+      toolsEnabled: true,
+      webSearchEnabled: true,
+      websiteModeEnabled: true,
+    });
+    assert.deepEqual(
+      mod.resolveZaiVlmConfig("GLM-5v-Turbo", {
+        features: {
+          vlm_tools_enable: false,
+          vlm_web_search_enable: false,
+          vlm_website_mode: false,
+        },
+      }),
+      {
+        toolsEnabled: false,
+        webSearchEnabled: false,
+        websiteModeEnabled: true,
+      }
+    );
+    assert.deepEqual(mod.resolveZaiVlmConfig("GLM-5.1", {}), {
+      toolsEnabled: false,
+      webSearchEnabled: false,
+      websiteModeEnabled: false,
+    });
+    assert.deepEqual(mod.resolveZaiVlmConfig("GLM-5.1", { web_search: true }), {
+      toolsEnabled: false,
+      webSearchEnabled: true,
+      websiteModeEnabled: false,
+    });
+  });
+
+  it("returns a credential error when no session credential is provided", async () => {
     const executor = new mod.ZaiWebExecutor();
     const result = await executor.execute({
-      model: "glm-4.6",
+      model: "GLM-5.1",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "" },
@@ -95,68 +300,324 @@ describe("ZaiWebExecutor", () => {
     assert.equal(result.response.status, 400);
     assert.equal(new URL(result.url).hostname, "chat.z.ai");
     const parsed = await result.response.json();
-    assert.match(parsed.error.message, /Z\.ai session/);
+    assert.match(parsed.error.message, /web-session credential/);
   });
 
-  it("sends the cookie + bearer token and builds the request body", async () => {
-    const originalFetch = globalThis.fetch;
-    let capturedUrl = "";
-    let capturedInit: RequestInit | undefined;
-    globalThis.fetch = (async (url: string, init?: RequestInit) => {
-      capturedUrl = String(url);
-      capturedInit = init;
-      return new Response("data: [DONE]\n\n", {
-        headers: { "Content-Type": "text/event-stream" },
+  it("uses the browser transport with only the Local Storage token", async () => {
+    let capturedRequest: BrowserBackedChatRequest | null = null;
+    browserChat.__setBrowserBackedChatOverrideForTesting(async (request) => {
+      capturedRequest = request;
+      return makeBrowserResult("Browser");
+    });
+
+    try {
+      const executor = new mod.ZaiWebExecutor();
+      const result = await executor.execute({
+        model: "glm-5.2",
+        body: { messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: { apiKey: TEST_TOKEN },
+        signal: null,
       });
-    }) as typeof fetch;
+
+      const completion = await result.response.json();
+      assert.equal(completion.choices[0].message.content, "Browser");
+      assert.equal(capturedRequest?.localStorage?.token, TEST_TOKEN);
+      assert.equal(capturedRequest?.localStorageOrigin, "https://chat.z.ai");
+      assert.equal(capturedRequest?.inputSelector, "#chat-input");
+      assert.equal(
+        capturedRequest?.submitButtonSelector,
+        '[aria-label="Send Message"] button:not([disabled])'
+      );
+      assert.equal(capturedRequest?.submitButtonMode, "dom");
+      assert.equal(capturedRequest?.userMessage, "hi");
+      assert.match(capturedRequest?.chatPageUrl ?? "", /model=GLM-5\.2/);
+      assert.equal(typeof capturedRequest?.beforeSubmit, "function");
+      assert.equal(result.headers["X-OmniRoute-Transport"], "browser");
+      assert.equal(result.transformedBody.browser_backed, true);
+      assert.equal(result.transformedBody.enable_thinking, true);
+      assert.equal(result.transformedBody.reasoning_effort, "max");
+    } finally {
+      browserChat.__resetBrowserBackedChatOverrideForTesting();
+    }
+  });
+
+  it("configures GLM-5V-Turbo controls on the browser transport", async () => {
+    let capturedRequest: BrowserBackedChatRequest | null = null;
+    browserChat.__setBrowserBackedChatOverrideForTesting(async (request) => {
+      capturedRequest = request;
+      return makeBrowserResult("VLM");
+    });
+
+    try {
+      const executor = new mod.ZaiWebExecutor();
+      const result = await executor.execute({
+        model: "GLM-5v-Turbo",
+        body: { messages: [{ role: "user", content: "use the model tools" }] },
+        stream: false,
+        credentials: { apiKey: TEST_TOKEN },
+        signal: null,
+      });
+
+      const completion = await result.response.json();
+      assert.equal(completion.choices[0].message.content, "VLM");
+      assert.match(capturedRequest?.chatPageUrl ?? "", /model=GLM-5V-Turbo/);
+      assert.equal(typeof capturedRequest?.beforeSubmit, "function");
+      assert.equal(result.transformedBody.enable_thinking, true);
+      assert.equal(result.transformedBody.vlm_tools_enable, true);
+      assert.equal(result.transformedBody.vlm_web_search_enable, true);
+      assert.equal(result.transformedBody.vlm_website_mode, true);
+      assert.equal("reasoning_effort" in result.transformedBody, false);
+    } finally {
+      browserChat.__resetBrowserBackedChatOverrideForTesting();
+    }
+  });
+
+  it("uploads GLM-5V-Turbo image input through the authenticated browser page", async () => {
+    let capturedRequest: BrowserBackedChatRequest | null = null;
+    browserChat.__setBrowserBackedChatOverrideForTesting(async (request) => {
+      capturedRequest = request;
+      return makeBrowserResult("The image says OMNIROUTE.");
+    });
+
+    try {
+      const executor = new mod.ZaiWebExecutor();
+      const result = await executor.execute({
+        model: "GLM-5v-Turbo",
+        body: {
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "What word is in this image?" },
+                {
+                  type: "image_url",
+                  image_url: { url: "data:image/png;base64,aW1hZ2UtYnl0ZXM=" },
+                },
+              ],
+            },
+          ],
+        },
+        stream: false,
+        // Supplying a CAPTCHA proof must not select the direct path for image
+        // requests because the browser page owns Z.ai's authenticated upload.
+        credentials: { apiKey: TEST_CREDENTIAL },
+        signal: null,
+      });
+
+      assert.equal(result.response.status, 200);
+      assert.equal(capturedRequest?.userMessage, "What word is in this image?");
+      assert.equal(capturedRequest?.attachments?.length, 1);
+      assert.equal(capturedRequest?.attachments?.[0]?.name, "omniroute-image-1.png");
+      assert.equal(capturedRequest?.attachments?.[0]?.mimeType, "image/png");
+      assert.equal(capturedRequest?.attachments?.[0]?.buffer.toString("utf8"), "image-bytes");
+      assert.equal(result.transformedBody.image_count, 1);
+      assert.deepEqual(result.transformedBody.messages, [
+        { role: "user", content: "What word is in this image?" },
+      ]);
+    } finally {
+      browserChat.__resetBrowserBackedChatOverrideForTesting();
+    }
+  });
+
+  it("rejects image input on Z.ai text-only models", async () => {
+    const executor = new mod.ZaiWebExecutor();
+    const result = await executor.execute({
+      model: "glm-5.2",
+      body: {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "inspect" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,aW1hZ2U=" },
+              },
+            ],
+          },
+        ],
+      },
+      stream: false,
+      credentials: { apiKey: TEST_TOKEN },
+      signal: null,
+    });
+
+    assert.equal(result.response.status, 400);
+    const parsed = await result.response.json();
+    assert.match(parsed.error.message, /use GLM-5V-Turbo/);
+  });
+
+  it("creates a chat, signs the v2 request, and forwards the CAPTCHA proof", async () => {
+    const capture: ZaiFetchCapture = {};
+    const originalFetch = installZaiFetch(
+      () =>
+        new Response("data: [DONE]\n\n", {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      capture
+    );
+
+    try {
+      const executor = new mod.ZaiWebExecutor();
+      const result = await executor.execute({
+        model: "GLM-5.1",
+        body: {
+          model: "GLM-5.1",
+          messages: [{ role: "user", content: "hello" }],
+          temperature: 0.4,
+          web_search: true,
+        },
+        stream: false,
+        credentials: { apiKey: TEST_CREDENTIAL },
+        signal: null,
+      });
+
+      assert.ok(capture.newChatInit);
+      const newChatHeaders = capture.newChatInit?.headers as Record<string, string>;
+      assert.equal(newChatHeaders.Authorization, `Bearer ${TEST_TOKEN}`);
+      const newChatBody = JSON.parse(String(capture.newChatInit?.body));
+      assert.deepEqual(newChatBody.chat.models, ["GLM-5.1"]);
+      assert.equal(newChatBody.chat.history.currentId.length, 36);
+      assert.equal(newChatBody.chat.enable_thinking, true);
+      assert.equal(newChatBody.chat.auto_web_search, true);
+
+      const completionUrl = new URL(String(capture.completionUrl));
+      assert.equal(completionUrl.pathname, ZAI_COMPLETION_PATH);
+      assert.equal(completionUrl.searchParams.get("token"), TEST_TOKEN);
+      assert.equal(completionUrl.searchParams.get("user_id"), "user-123");
+      assert.equal(completionUrl.searchParams.get("version"), "0.0.1");
+      assert.equal(
+        completionUrl.searchParams.get("signature_timestamp"),
+        completionUrl.searchParams.get("timestamp")
+      );
+
+      const headers = capture.completionInit?.headers as Record<string, string>;
+      assert.equal(headers.Authorization, `Bearer ${TEST_TOKEN}`);
+      assert.equal(headers["X-FE-Version"], "prod-fe-1.1.79");
+      assert.match(headers["X-Signature"], /^[a-f0-9]{64}$/);
+
+      const parsedBody = JSON.parse(String(capture.completionInit?.body));
+      assert.equal(parsedBody.model, "GLM-5.1");
+      assert.equal(parsedBody.stream, true);
+      assert.deepEqual(parsedBody.messages, [{ role: "user", content: "hello" }]);
+      assert.equal(parsedBody.signature_prompt, "hello");
+      assert.equal(parsedBody.captcha_verify_param, "captcha-proof");
+      assert.equal(parsedBody.chat_id, "chat-123");
+      assert.equal(parsedBody.params.temperature, 0.4);
+      assert.equal(parsedBody.features.web_search, false);
+      assert.equal(parsedBody.features.auto_web_search, true);
+      assert.equal(parsedBody.features.enable_thinking, true);
+      assert.equal("reasoning_effort" in parsedBody.features, false);
+      assert.equal(result.headers.Authorization, "Bearer [REDACTED]");
+      assert.equal(result.transformedBody.captcha_verify_param, "[REDACTED]");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("sends GLM-5.2 Deep Think High through the direct request path", async () => {
+    const capture: ZaiFetchCapture = {};
+    const originalFetch = installZaiFetch(
+      () =>
+        new Response("data: [DONE]\n\n", {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      capture
+    );
 
     try {
       const executor = new mod.ZaiWebExecutor();
       await executor.execute({
-        model: "glm-4.6",
-        body: { messages: [{ role: "user", content: "hello" }] },
+        model: "glm-5.2",
+        body: {
+          model: "glm-5.2",
+          messages: [{ role: "user", content: "think carefully" }],
+          reasoning_effort: "high",
+        },
         stream: false,
-        credentials: { apiKey: "token=abc123; foo=bar" },
+        credentials: { apiKey: TEST_CREDENTIAL },
         signal: null,
       });
 
-      assert.equal(capturedUrl, "https://chat.z.ai/api/v2/chat/completions");
-      const headers = capturedInit?.headers as Record<string, string>;
-      assert.equal(headers.Cookie, "token=abc123; foo=bar");
-      assert.equal(headers.Authorization, "Bearer abc123");
+      assert.equal(capture.completionUrl, "https://chat.z.ai/api/v2/chat/completions");
+      const newChatBody = JSON.parse(String(capture.newChatInit?.body));
+      assert.equal(newChatBody.chat.enable_thinking, true);
+      assert.equal(newChatBody.chat.reasoning_effort, "high");
 
-      const parsedBody = JSON.parse(String(capturedInit?.body));
-      assert.equal(parsedBody.model, "glm-4.6");
-      assert.equal(parsedBody.stream, true);
-      assert.deepEqual(parsedBody.messages, [{ role: "user", content: "hello" }]);
-      assert.equal(parsedBody.features.web_search, false);
+      const completionBody = JSON.parse(String(capture.completionInit?.body));
+      assert.equal(completionBody.features.enable_thinking, true);
+      assert.equal(completionBody.features.reasoning_effort, "high");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("sends GLM-5V-Turbo VLM tools and web-search flags through the direct path", async () => {
+    const capture: ZaiFetchCapture = {};
+    const originalFetch = installZaiFetch(
+      () =>
+        new Response("data: [DONE]\n\n", {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      capture
+    );
+
+    try {
+      const executor = new mod.ZaiWebExecutor();
+      await executor.execute({
+        model: "GLM-5v-Turbo",
+        body: {
+          model: "GLM-5v-Turbo",
+          messages: [{ role: "user", content: "inspect this image" }],
+        },
+        stream: false,
+        credentials: { apiKey: TEST_CREDENTIAL },
+        signal: null,
+      });
+
+      const newChatBody = JSON.parse(String(capture.newChatInit?.body));
+      assert.equal(newChatBody.chat.enable_thinking, true);
+      assert.equal(newChatBody.chat.auto_web_search, true);
+      assert.equal(newChatBody.chat.extra.vlm_tools_enable, true);
+      assert.equal(newChatBody.chat.extra.vlm_web_search_enable, true);
+      assert.equal(newChatBody.chat.extra.vlm_website_mode, true);
+
+      const completionBody = JSON.parse(String(capture.completionInit?.body));
+      assert.equal(completionBody.features.enable_thinking, true);
+      assert.equal(completionBody.features.auto_web_search, false);
+      assert.equal(completionBody.features.vlm_tools_enable, true);
+      assert.equal(completionBody.features.vlm_web_search_enable, true);
+      assert.equal(completionBody.features.vlm_website_mode, true);
+      assert.equal("reasoning_effort" in completionBody.features, false);
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
   it("aggregates streamed internal-envelope deltas into a non-streaming completion", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () =>
-      new Response(
-        [
-          `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: "Hel", phase: "answer", done: false } })}`,
-          `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: "lo", phase: "answer", done: false } })}`,
-          `data: ${JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })}`,
-          "data: [DONE]",
-          "",
-          "",
-        ].join("\n"),
-        { headers: { "Content-Type": "text/event-stream" } }
-      )) as typeof fetch;
+    const originalFetch = installZaiFetch(
+      () =>
+        new Response(
+          [
+            `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: "Hel", phase: "answer", done: false } })}`,
+            `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: "lo", phase: "answer", done: false } })}`,
+            `data: ${JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })}`,
+            "data: [DONE]",
+            "",
+            "",
+          ].join("\n"),
+          { headers: { "Content-Type": "text/event-stream" } }
+        )
+    );
 
     try {
       const executor = new mod.ZaiWebExecutor();
       const result = await executor.execute({
-        model: "glm-4.6",
+        model: "GLM-5.1",
         body: { messages: [{ role: "user", content: "hi" }] },
         stream: false,
-        credentials: { apiKey: "token=abc123" },
+        credentials: { apiKey: TEST_CREDENTIAL },
         signal: null,
       });
 
@@ -169,25 +630,26 @@ describe("ZaiWebExecutor", () => {
   });
 
   it("streams internal-envelope deltas as OpenAI-shaped SSE chunks", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () =>
-      new Response(
-        [
-          `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: "Hi", phase: "answer", done: false } })}`,
-          `data: ${JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })}`,
-          "",
-          "",
-        ].join("\n"),
-        { headers: { "Content-Type": "text/event-stream" } }
-      )) as typeof fetch;
+    const originalFetch = installZaiFetch(
+      () =>
+        new Response(
+          [
+            `data: ${JSON.stringify({ type: "chat:completion", data: { delta_content: "Hi", phase: "answer", done: false } })}`,
+            `data: ${JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })}`,
+            "",
+            "",
+          ].join("\n"),
+          { headers: { "Content-Type": "text/event-stream" } }
+        )
+    );
 
     try {
       const executor = new mod.ZaiWebExecutor();
       const result = await executor.execute({
-        model: "glm-4.6",
+        model: "GLM-5.1",
         body: { messages: [{ role: "user", content: "hi" }] },
         stream: true,
-        credentials: { apiKey: "token=abc123" },
+        credentials: { apiKey: TEST_CREDENTIAL },
         signal: null,
       });
 
@@ -201,17 +663,15 @@ describe("ZaiWebExecutor", () => {
   });
 
   it("propagates upstream HTTP errors", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () =>
-      new Response("session expired", { status: 401 })) as typeof fetch;
+    const originalFetch = installZaiFetch(() => new Response("session expired", { status: 401 }));
 
     try {
       const executor = new mod.ZaiWebExecutor();
       const result = await executor.execute({
-        model: "glm-4.6",
+        model: "GLM-5.1",
         body: { messages: [{ role: "user", content: "hi" }] },
         stream: false,
-        credentials: { apiKey: "token=abc123" },
+        credentials: { apiKey: TEST_CREDENTIAL },
         signal: null,
       });
 

--- a/tests/unit/model-listing-capability-5420.test.ts
+++ b/tests/unit/model-listing-capability-5420.test.ts
@@ -30,9 +30,11 @@ describe("providerLacksModelListing (#5420)", () => {
     assert.equal(providerLacksModelListing("z", ["embedding"]), false);
   });
 
-  it("keeps Kimi Web visible while marking its model catalog as curated-only", () => {
+  it("keeps curated web providers visible while disabling remote model import", () => {
     assert.equal(providerLacksModelListing("kimi-web", ["llm"]), false);
+    assert.equal(providerLacksModelListing("zai-web", ["llm"]), false);
     assert.equal(providerUsesCuratedModelsOnly("kimi-web"), true);
+    assert.equal(providerUsesCuratedModelsOnly("zai-web"), true);
     assert.equal(providerUsesCuratedModelsOnly("qwen-cloud"), false);
     assert.equal(providerUsesCuratedModelsOnly("kimi-coding"), false);
   });

--- a/tests/unit/model-sync-route.test.ts
+++ b/tests/unit/model-sync-route.test.ts
@@ -190,6 +190,64 @@ test("model sync route returns 404 for unknown connections after internal auth p
   assert.deepEqual(await response.json(), { error: "Connection not found" });
 });
 
+test("curated zai-web sync removes stale imported models without touching manual models", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "zai-web",
+    authType: "apikey",
+    name: "Z.ai Web",
+    apiKey: "current-local-storage-token",
+  });
+  await modelsDb.replaceSyncedAvailableModelsForConnection("zai-web", connection.id, [
+    { id: "glm-4.6v", name: "GLM-4.6V", source: "imported" },
+    { id: "deep-research", name: "Z1-Rumination", source: "imported" },
+  ]);
+  await modelsDb.addCustomModel("zai-web", "glm-4-air-250414", "GLM-4-32B", "imported");
+  await modelsDb.addCustomModel("zai-web", "manual-keep", "Manual Keep", "manual");
+
+  let fetchCalls = 0;
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    throw new Error("curated provider sync must not fetch a remote model catalog");
+  }) as typeof globalThis.fetch;
+
+  const response = await modelSyncRoute.POST(
+    new Request(`http://localhost/api/providers/${connection.id}/sync-models`, {
+      method: "POST",
+      headers: scheduler.buildModelSyncInternalHeaders(),
+    }),
+    { params: { id: connection.id } }
+  );
+  const body = (await response.json()) as {
+    source: string;
+    skipped: string;
+    cleanup: {
+      removedSyncedLists: number;
+      removedImportedModels: number;
+    };
+  };
+  const syncedModels = await modelsDb.getSyncedAvailableModels("zai-web");
+  const customModels = (await modelsDb.getCustomModels("zai-web")) as Array<{
+    id: string;
+    source: string;
+  }>;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.source, "curated");
+  assert.equal(body.skipped, "curated-models-only");
+  assert.deepEqual(body.cleanup, {
+    removedSyncedLists: 1,
+    removedImportedModels: 1,
+  });
+  assert.deepEqual(syncedModels, []);
+  assert.deepEqual(
+    customModels.map((model) => ({ id: model.id, source: model.source })),
+    [{ id: "manual-keep", source: "manual" }]
+  );
+  assert.equal(fetchCalls, 0);
+});
+
 test("model sync route propagates upstream failures and records an error log entry", async () => {
   await resetStorage();
 

--- a/tests/unit/model-sync-route.test.ts
+++ b/tests/unit/model-sync-route.test.ts
@@ -190,64 +190,6 @@ test("model sync route returns 404 for unknown connections after internal auth p
   assert.deepEqual(await response.json(), { error: "Connection not found" });
 });
 
-test("curated zai-web sync removes stale imported models without touching manual models", async () => {
-  await resetStorage();
-
-  const connection = await providersDb.createProviderConnection({
-    provider: "zai-web",
-    authType: "apikey",
-    name: "Z.ai Web",
-    apiKey: "current-local-storage-token",
-  });
-  await modelsDb.replaceSyncedAvailableModelsForConnection("zai-web", connection.id, [
-    { id: "glm-4.6v", name: "GLM-4.6V", source: "imported" },
-    { id: "deep-research", name: "Z1-Rumination", source: "imported" },
-  ]);
-  await modelsDb.addCustomModel("zai-web", "glm-4-air-250414", "GLM-4-32B", "imported");
-  await modelsDb.addCustomModel("zai-web", "manual-keep", "Manual Keep", "manual");
-
-  let fetchCalls = 0;
-  globalThis.fetch = (async () => {
-    fetchCalls += 1;
-    throw new Error("curated provider sync must not fetch a remote model catalog");
-  }) as typeof globalThis.fetch;
-
-  const response = await modelSyncRoute.POST(
-    new Request(`http://localhost/api/providers/${connection.id}/sync-models`, {
-      method: "POST",
-      headers: scheduler.buildModelSyncInternalHeaders(),
-    }),
-    { params: { id: connection.id } }
-  );
-  const body = (await response.json()) as {
-    source: string;
-    skipped: string;
-    cleanup: {
-      removedSyncedLists: number;
-      removedImportedModels: number;
-    };
-  };
-  const syncedModels = await modelsDb.getSyncedAvailableModels("zai-web");
-  const customModels = (await modelsDb.getCustomModels("zai-web")) as Array<{
-    id: string;
-    source: string;
-  }>;
-
-  assert.equal(response.status, 200);
-  assert.equal(body.source, "curated");
-  assert.equal(body.skipped, "curated-models-only");
-  assert.deepEqual(body.cleanup, {
-    removedSyncedLists: 1,
-    removedImportedModels: 1,
-  });
-  assert.deepEqual(syncedModels, []);
-  assert.deepEqual(
-    customModels.map((model) => ({ id: model.id, source: model.source })),
-    [{ id: "manual-keep", source: "manual" }]
-  );
-  assert.equal(fetchCalls, 0);
-});
-
 test("model sync route propagates upstream failures and records an error log entry", async () => {
   await resetStorage();
 

--- a/tests/unit/model-test-runner.test.ts
+++ b/tests/unit/model-test-runner.test.ts
@@ -312,6 +312,11 @@ test("resolveModelTestTimeoutMs defaults ordinary model checks to 30 seconds", (
   assert.equal(resolveModelTestTimeoutMs("openai", "gpt-4.1"), 30_000);
 });
 
+test("resolveModelTestTimeoutMs gives zai-web checks up to 60 seconds", () => {
+  assert.equal(resolveModelTestTimeoutMs("zai-web", "glm-5.2", 30_000), 60_000);
+  assert.equal(resolveModelTestTimeoutMs("zai-web", "zai-web/GLM-5V-Turbo", 90_000), 90_000);
+});
+
 // ---------------------------------------------------------------------------
 // classifyTestErrorQuota — #9511 quota classification for Test All auto-hide.
 // Distinguishes three outcomes:

--- a/tests/unit/model-test-runner.test.ts
+++ b/tests/unit/model-test-runner.test.ts
@@ -2,6 +2,8 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createProviderConnection } from "@/lib/db/providers";
 import {
+  classifyModelTestOutput,
+  createModelTestTimeoutError,
   parseRetryAfterHeader,
   detectTestKind,
   extractProviderErrorMessage,
@@ -290,6 +292,20 @@ test("runSingleModelTest preserves slow timeout after chatCore converts AbortErr
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("classifyModelTestOutput never treats partial text from an aborted stream as success", () => {
+  assert.equal(classifyModelTestOutput(true, "partial", false), "timeout");
+  assert.equal(classifyModelTestOutput(false, "complete", false), "ok");
+  assert.equal(classifyModelTestOutput(false, "", false), "empty");
+  assert.equal(classifyModelTestOutput(false, "", true), "ok");
+});
+
+test("createModelTestTimeoutError distinguishes test deadlines from client aborts", () => {
+  const error = createModelTestTimeoutError(60_000);
+
+  assert.equal(error.name, "TimeoutError");
+  assert.equal(error.message, "Model test deadline exceeded after 60000ms");
 });
 
 test("resolveModelTestTimeoutMs defaults ordinary model checks to 30 seconds", () => {

--- a/tests/unit/ratelimit-admission-control-6593.test.ts
+++ b/tests/unit/ratelimit-admission-control-6593.test.ts
@@ -1,12 +1,12 @@
 /**
- * #6593 — rate-limit queue admission control (maxQueueDepth) + bounded default.
+ * #6593 — rate-limit queue admission control (maxQueueDepth) + 15s default.
  *
  * RFC bundles 2 grounded changes to the local rate-limit request queue:
  *   1. `RequestQueueSettings.maxQueueDepth` — opt-in admission cap (default 0
  *      = disabled). When the queue already holds `maxQueueDepth` requests, a
  *      new request is fast-rejected with a typed `RATE_LIMIT_QUEUE_FULL`
  *      error instead of joining Bottleneck's queue.
- *   2. `DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS` is bounded to 60 seconds.
+ *   2. `DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS` lowered 120000 -> 15000.
  *
  * (Item #3 from the RFC, `bypassCompressionOnRateLimit`, has no matching
  * code path in this repo's compression pipeline — see the plan-file — and is
@@ -177,10 +177,16 @@ test("#6593 withRateLimit: default maxQueueDepth=0 preserves unbounded-queue beh
 
 // --- Default maxWaitMs ----------------------------------------------------
 
-test("#6593 DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS is 60s absent RATE_LIMIT_MAX_WAIT_MS", () => {
+test("#6593 DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS is 15s absent RATE_LIMIT_MAX_WAIT_MS", () => {
   assert.equal(process.env.RATE_LIMIT_MAX_WAIT_MS, undefined);
   assert.equal(resilienceSettings.DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS, 15000);
   assert.equal(resilienceSettings.DEFAULT_RESILIENCE_SETTINGS.requestQueue.maxWaitMs, 15000);
+});
+
+test("#6593 zai-web receives a provider-scoped 60s scheduling budget", () => {
+  assert.equal(rateLimitManager.resolveRequestQueueMaxWaitMs("openai", 15_000), 15_000);
+  assert.equal(rateLimitManager.resolveRequestQueueMaxWaitMs("zai-web", 15_000), 60_000);
+  assert.equal(rateLimitManager.resolveRequestQueueMaxWaitMs("ZAI-WEB", 90_000), 90_000);
 });
 
 test("#6593 DEFAULT_REQUEST_QUEUE_MAX_DEPTH defaults to 0 (disabled) absent an env override", () => {

--- a/tests/unit/ratelimit-admission-control-6593.test.ts
+++ b/tests/unit/ratelimit-admission-control-6593.test.ts
@@ -1,12 +1,12 @@
 /**
- * #6593 — rate-limit queue admission control (maxQueueDepth) + 15s default.
+ * #6593 — rate-limit queue admission control (maxQueueDepth) + bounded default.
  *
  * RFC bundles 2 grounded changes to the local rate-limit request queue:
  *   1. `RequestQueueSettings.maxQueueDepth` — opt-in admission cap (default 0
  *      = disabled). When the queue already holds `maxQueueDepth` requests, a
  *      new request is fast-rejected with a typed `RATE_LIMIT_QUEUE_FULL`
  *      error instead of joining Bottleneck's queue.
- *   2. `DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS` lowered 120000 -> 15000.
+ *   2. `DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS` is bounded to 60 seconds.
  *
  * (Item #3 from the RFC, `bypassCompressionOnRateLimit`, has no matching
  * code path in this repo's compression pipeline — see the plan-file — and is
@@ -175,9 +175,9 @@ test("#6593 withRateLimit: default maxQueueDepth=0 preserves unbounded-queue beh
   assert.deepEqual(results, ["job1", "job2", "job3", "job4"]);
 });
 
-// --- Default maxWaitMs lowered 120000 -> 15000 ----------------------------
+// --- Default maxWaitMs ----------------------------------------------------
 
-test("#6593 DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS is 15s absent RATE_LIMIT_MAX_WAIT_MS", () => {
+test("#6593 DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS is 60s absent RATE_LIMIT_MAX_WAIT_MS", () => {
   assert.equal(process.env.RATE_LIMIT_MAX_WAIT_MS, undefined);
   assert.equal(resilienceSettings.DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS, 15000);
   assert.equal(resilienceSettings.DEFAULT_RESILIENCE_SETTINGS.requestQueue.maxWaitMs, 15000);

--- a/tests/unit/stream-handler-deadline.test.ts
+++ b/tests/unit/stream-handler-deadline.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createStreamController } from "../../open-sse/utils/streamHandler.ts";
+
+test("createStreamController records deadline abort signals as 504 errors, not 499 disconnects", async () => {
+  const clientAbortController = new AbortController();
+  let disconnectEvent = null;
+  let errorEvent = null;
+  const controller = createStreamController({
+    clientAbortSignal: clientAbortController.signal,
+    onDisconnect(event) {
+      disconnectEvent = event;
+    },
+    onError(event) {
+      errorEvent = event;
+      return true;
+    },
+  });
+  const timeoutError = new Error("Model test deadline exceeded after 60000ms");
+  timeoutError.name = "TimeoutError";
+
+  clientAbortController.abort(timeoutError);
+  await Promise.resolve();
+
+  assert.equal(disconnectEvent, null);
+  assert.equal(errorEvent?.statusCode, 504);
+  assert.equal(errorEvent?.message, "Model test deadline exceeded after 60000ms");
+  assert.equal(controller.signal.aborted, true);
+});

--- a/tests/unit/stream-handler.test.ts
+++ b/tests/unit/stream-handler.test.ts
@@ -521,6 +521,32 @@ test("createStreamController aborts after delayed disconnect and tolerates abort
   assert.equal(errorOnlyController.signal.aborted, false);
 });
 
+test("createStreamController records deadline abort signals as 504 errors, not 499 disconnects", async () => {
+  const clientAbortController = new AbortController();
+  let disconnectEvent = null;
+  let errorEvent = null;
+  const controller = createStreamController({
+    clientAbortSignal: clientAbortController.signal,
+    onDisconnect(event) {
+      disconnectEvent = event;
+    },
+    onError(event) {
+      errorEvent = event;
+      return true;
+    },
+  });
+  const timeoutError = new Error("Model test deadline exceeded after 60000ms");
+  timeoutError.name = "TimeoutError";
+
+  clientAbortController.abort(timeoutError);
+  await Promise.resolve();
+
+  assert.equal(disconnectEvent, null);
+  assert.equal(errorEvent?.statusCode, 504);
+  assert.equal(errorEvent?.message, "Model test deadline exceeded after 60000ms");
+  assert.equal(controller.signal.aborted, true);
+});
+
 test("pipeWithDisconnect pipes transformed bytes and marks the controller complete", async () => {
   const source = new ReadableStream({
     start(controller) {

--- a/tests/unit/stream-handler.test.ts
+++ b/tests/unit/stream-handler.test.ts
@@ -521,32 +521,6 @@ test("createStreamController aborts after delayed disconnect and tolerates abort
   assert.equal(errorOnlyController.signal.aborted, false);
 });
 
-test("createStreamController records deadline abort signals as 504 errors, not 499 disconnects", async () => {
-  const clientAbortController = new AbortController();
-  let disconnectEvent = null;
-  let errorEvent = null;
-  const controller = createStreamController({
-    clientAbortSignal: clientAbortController.signal,
-    onDisconnect(event) {
-      disconnectEvent = event;
-    },
-    onError(event) {
-      errorEvent = event;
-      return true;
-    },
-  });
-  const timeoutError = new Error("Model test deadline exceeded after 60000ms");
-  timeoutError.name = "TimeoutError";
-
-  clientAbortController.abort(timeoutError);
-  await Promise.resolve();
-
-  assert.equal(disconnectEvent, null);
-  assert.equal(errorEvent?.statusCode, 504);
-  assert.equal(errorEvent?.message, "Model test deadline exceeded after 60000ms");
-  assert.equal(controller.signal.aborted, true);
-});
-
 test("pipeWithDisconnect pipes transformed bytes and marks the controller complete", async () => {
   const source = new ReadableStream({
     start(controller) {

--- a/tests/unit/tokenExtractionConfig.test.ts
+++ b/tests/unit/tokenExtractionConfig.test.ts
@@ -106,6 +106,12 @@ describe("tokenExtractionConfig", () => {
     assert.doesNotMatch(cfg?.instructions || "", /RPSCAuth/i);
   });
 
+  it("extracts zai-web auth from localStorage rather than a cookie", () => {
+    const cfg = getExtractionConfig("zai-web");
+    assert.deepEqual(cfg?.tokenSources, [{ type: "localStorage", key: "token" }]);
+    assert.match(cfg?.instructions ?? "", /CAPTCHA/);
+  });
+
   it("listExtractionConfigs returns all configs as an array", () => {
     const all = listExtractionConfigs();
     assert.ok(Array.isArray(all));

--- a/tests/unit/web-cookie-validation-proxy-7058.test.ts
+++ b/tests/unit/web-cookie-validation-proxy-7058.test.ts
@@ -42,10 +42,17 @@ test.after(() => {
 });
 
 test("zai-web cookie validation routes through the configured HTTP_PROXY (#7058)", async () => {
-  assert.ok(zaiWebEntry, "zai-web must have a providerRegistry entry for this test to be meaningful");
+  assert.ok(
+    zaiWebEntry,
+    "zai-web must have a providerRegistry entry for this test to be meaningful"
+  );
 
   // Stand-in for chat.z.ai's /models probe target.
-  const target = http.createServer((_req, res) => {
+  let targetPath = "";
+  let targetAuthorization = "";
+  const target = http.createServer((req, res) => {
+    targetPath = req.url ?? "";
+    targetAuthorization = req.headers.authorization ?? "";
     res.writeHead(200, { "content-type": "application/json" });
     res.end("{}");
   });
@@ -90,6 +97,8 @@ test("zai-web cookie validation routes through the configured HTTP_PROXY (#7058)
         "(bypassProxyPatch:true unconditionally uses the native, unpatched fetch)"
     );
     assert.equal(result.valid, true, `expected a valid session, got ${JSON.stringify(result)}`);
+    assert.equal(targetPath, "/api/models");
+    assert.equal(targetAuthorization, "Bearer fake");
   } finally {
     target.close();
     proxy.close();

--- a/tests/unit/web-session-credentials.test.ts
+++ b/tests/unit/web-session-credentials.test.ts
@@ -42,6 +42,18 @@ test("web session credential metadata identifies cookie, token, and no-auth prov
     acceptsFullCookieHeader: false,
     storageKeys: ["token", "userToken"],
   });
+  {
+    const req = webSessionCredentials.getWebSessionCredentialRequirement("zai-web");
+    assert.ok(req && req.kind === "token");
+    assert.equal(req.credentialName, 'Local Storage value named "token"');
+    assert.equal(req.acceptsFullCookieHeader, false);
+    assert.deepEqual(req.storageKeys, ["token"]);
+    assert.equal(req.hintKey, "zaiWebCredentialHint");
+    assert.ok(req.hintFallback?.includes("Do not copy a Cookie header"));
+    assert.equal(req.guideSteps?.length, 4);
+    assert.ok(req.guideSteps?.some((step) => step.includes("Local Storage")));
+    assert.ok(req.guideSteps?.some((step) => step.includes("browser transport")));
+  }
   // Arena (lmarena): assert contract/intent only — do not freeze UX copy.
   // #3810 chunk name, #4271 split SSR cookies, full Cookie header paste.
   {

--- a/tests/unit/zai-web-chat-endpoint-8014-probe.test.ts
+++ b/tests/unit/zai-web-chat-endpoint-8014-probe.test.ts
@@ -3,13 +3,37 @@ import assert from "node:assert/strict";
 
 const mod = await import("../../open-sse/executors/zai-web.ts");
 
-test("#8014 RED: ZaiWebExecutor must POST to the current chat.z.ai v2 chat-completions endpoint, not the stale unversioned path", async () => {
+const STALE_URL = "https://chat.z.ai/api/chat/completions";
+const TEST_TOKEN = "e30.eyJpZCI6InVzZXItMTIzIn0.sig";
+
+/**
+ * #8014 guard: the executor must target the versioned v2 completions endpoint,
+ * never the stale unversioned `/api/chat/completions` path, which 404s
+ * model-independently as of 2026-07.
+ *
+ * Setup notes for this flow (the executor now creates a remote chat first and
+ * signs the completion request):
+ *  - a `captcha_verify_param` is required to take the direct HTTP path; without
+ *    one the executor routes through the browser transport and never calls
+ *    fetch at all, so the probe would capture nothing.
+ *  - the completion URL carries the signature payload as a query string, so the
+ *    assertion matches on pathname rather than the whole URL.
+ */
+test("#8014: ZaiWebExecutor must POST to the current chat.z.ai v2 chat-completions endpoint, not the stale unversioned path", async () => {
   const originalFetch = globalThis.fetch;
-  let capturedUrl = "";
+  const requested: string[] = [];
+
   globalThis.fetch = (async (url: string) => {
-    capturedUrl = String(url);
-    if (capturedUrl === "https://chat.z.ai/api/chat/completions") {
+    const target = String(url);
+    requested.push(target);
+
+    if (target === STALE_URL) {
       return new Response(JSON.stringify({ detail: "Not Found" }), { status: 404 });
+    }
+    if (target.startsWith("https://chat.z.ai/api/v1/chats/new")) {
+      return new Response(JSON.stringify({ id: "chat-1" }), {
+        headers: { "Content-Type": "application/json" },
+      });
     }
     return new Response("data: [DONE]\n\n", {
       headers: { "Content-Type": "text/event-stream" },
@@ -22,15 +46,29 @@ test("#8014 RED: ZaiWebExecutor must POST to the current chat.z.ai v2 chat-compl
       model: "glm-4.6",
       body: { messages: [{ role: "user", content: "hello" }] },
       stream: false,
-      credentials: { apiKey: "token=abc123" },
+      credentials: {
+        apiKey: JSON.stringify({ token: TEST_TOKEN, captcha_verify_param: "captcha-proof" }),
+      },
       signal: null,
     });
 
-    assert.equal(
-      capturedUrl,
-      "https://chat.z.ai/api/v2/chat/completions",
-      `zai-web executor POSTed to a stale endpoint (${capturedUrl}) — matches #8014's model-independent 404 "Not Found"`
+    assert.ok(requested.length > 0, "the direct path must actually reach fetch");
+
+    assert.ok(
+      !requested.includes(STALE_URL),
+      `zai-web executor POSTed to the stale endpoint — matches #8014's model-independent 404 "Not Found"`
     );
+
+    // The executor also probes the homepage for the frontend version and calls
+    // /api/v1/chats/new first, so pick the completions request by its path.
+    const completions = requested.filter((u) => new URL(u).pathname.endsWith("/chat/completions"));
+    assert.equal(completions.length, 1, `expected exactly one completions request, got ${requested}`);
+    assert.equal(
+      new URL(completions[0]).pathname,
+      "/api/v2/chat/completions",
+      `completions must target the v2 path, got ${completions[0]}`
+    );
+
     assert.notEqual(
       result.response.status,
       404,

--- a/tests/unit/zai-web-model-sync-route.test.ts
+++ b/tests/unit/zai-web-model-sync-route.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-zai-model-sync-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+if (!process.env.API_KEY_SECRET) {
+  process.env.API_KEY_SECRET = `test-zai-model-sync-${Date.now()}`;
+}
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const modelSyncRoute = await import("../../src/app/api/providers/[id]/sync-models/route.ts");
+const scheduler = await import("../../src/shared/services/modelSyncScheduler.ts");
+const originalFetch = globalThis.fetch;
+
+async function resetStorage() {
+  delete process.env.INITIAL_PASSWORD;
+  globalThis.fetch = originalFetch;
+  modelSyncRoute.__resetLoopbackReadinessForTests();
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("curated zai-web sync removes stale imported models without touching manual models", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "zai-web",
+    authType: "apikey",
+    name: "Z.ai Web",
+    apiKey: "current-local-storage-token",
+  });
+  await modelsDb.replaceSyncedAvailableModelsForConnection("zai-web", connection.id, [
+    { id: "glm-4.6v", name: "GLM-4.6V", source: "imported" },
+    { id: "deep-research", name: "Z1-Rumination", source: "imported" },
+  ]);
+  await modelsDb.addCustomModel("zai-web", "glm-4-air-250414", "GLM-4-32B", "imported");
+  await modelsDb.addCustomModel("zai-web", "manual-keep", "Manual Keep", "manual");
+
+  let fetchCalls = 0;
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    throw new Error("curated provider sync must not fetch a remote model catalog");
+  }) as typeof globalThis.fetch;
+
+  const response = await modelSyncRoute.POST(
+    new Request(`http://localhost/api/providers/${connection.id}/sync-models`, {
+      method: "POST",
+      headers: scheduler.buildModelSyncInternalHeaders(),
+    }),
+    { params: { id: connection.id } }
+  );
+  const body = (await response.json()) as {
+    source: string;
+    skipped: string;
+    cleanup: {
+      removedSyncedLists: number;
+      removedImportedModels: number;
+    };
+  };
+  const syncedModels = await modelsDb.getSyncedAvailableModels("zai-web");
+  const customModels = (await modelsDb.getCustomModels("zai-web")) as Array<{
+    id: string;
+    source: string;
+  }>;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.source, "curated");
+  assert.equal(body.skipped, "curated-models-only");
+  assert.deepEqual(body.cleanup, {
+    removedSyncedLists: 1,
+    removedImportedModels: 1,
+  });
+  assert.deepEqual(syncedModels, []);
+  assert.deepEqual(
+    customModels.map((model) => ({ id: model.id, source: model.source })),
+    [{ id: "manual-keep", source: "manual" }]
+  );
+  assert.equal(fetchCalls, 0);
+});

--- a/tests/unit/zai-web-models-discovery-7678.test.ts
+++ b/tests/unit/zai-web-models-discovery-7678.test.ts
@@ -1,39 +1,19 @@
-/**
- * TDD regression for #7678: `zai-web` (chat.z.ai) had no entry in
- * PROVIDER_MODELS_CONFIG (`src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts`),
- * so the model-discovery page always fell through to the 400
- * "does not support models listing" error — the hardcoded 3-model registry
- * catalog (glm-4.6/glm-4.5/glm-4.5v, one or more now 404 upstream) was the
- * only source and the provider had no way to pick up new upstream models.
- *
- * Fix: add a `zai-web` PROVIDER_MODELS_CONFIG entry pointing at the
- * undocumented `https://chat.z.ai/api/models` endpoint (same category as the
- * `qwen-web` precedent — #3931), building a Bearer header from the stored
- * cookie via the executor's own `extractZaiToken()`, and parsing the
- * `{ data: { data: [{ id, name, owned_by }] } }` shape with a flatter
- * `{ data: [...] }` fallback.
- *
- * IMPORTANT: the exact response shape and whether a bare
- * `Authorization: Bearer <token>` is accepted by chat.z.ai/api/models (vs the
- * full Cookie header the chat-completions endpoint requires) is UNVERIFIED —
- * no live z.ai session was available during research (plan-file Step 4).
- * These tests only prove the pipeline (auth-header construction, parsing,
- * cache, local-catalog fallback) against the assumed/qwen-web-shaped
- * response; they are not a substitute for the mandatory live check before
- * merge.
- */
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-7678-"));
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-zai-web-models-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const modelsRoute = await import("../../src/app/api/providers/[id]/models/route.ts");
+const registry = await import("../../open-sse/config/providers/registry/zai-web/index.ts");
+
+const CURATED_ZAI_WEB_MODEL_IDS = ["glm-5.2", "GLM-5.1", "GLM-5-Turbo", "GLM-5v-Turbo"];
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -46,40 +26,65 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
-interface ModelsBody {
-  provider: string;
-  connectionId: string;
-  models: Array<{ id: string; name?: string; owned_by?: string }>;
-  source?: string;
-}
+test("zai-web publishes the live reasoning and vision capabilities", () => {
+  assert.deepEqual(
+    registry.zai_webProvider.models.map((model) => ({
+      id: model.id,
+      supportsReasoning: model.supportsReasoning === true,
+      supportsVision: model.supportsVision === true,
+      toolCalling: model.toolCalling === true,
+    })),
+    [
+      {
+        id: "glm-5.2",
+        supportsReasoning: true,
+        supportsVision: false,
+        toolCalling: false,
+      },
+      {
+        id: "GLM-5.1",
+        supportsReasoning: true,
+        supportsVision: false,
+        toolCalling: false,
+      },
+      {
+        id: "GLM-5-Turbo",
+        supportsReasoning: true,
+        supportsVision: false,
+        toolCalling: false,
+      },
+      {
+        id: "GLM-5v-Turbo",
+        supportsReasoning: true,
+        supportsVision: true,
+        toolCalling: false,
+      },
+    ]
+  );
+});
 
-const ZAI_WEB_MODELS_URL = "https://chat.z.ai/api/models";
-
-test("#7678 zai-web model discovery fetches the live /api/models catalog with a Bearer header", async () => {
+test("zai-web exposes only its curated public models without remote discovery", async () => {
   await resetStorage();
   const connection = await providersDb.createProviderConnection({
     provider: "zai-web",
     authType: "apikey",
-    name: "zai-web-discovery",
-    apiKey: "token=abc123; other=xyz",
+    name: "zai-web-curated",
+    apiKey: "current-local-storage-token",
   });
 
-  let fetchedUrl: string | null = null;
-  let capturedAuthHeader: string | null = null;
+  await modelsDb.replaceSyncedAvailableModelsForConnection("zai-web", connection.id, [
+    { id: "glm-4.6v", name: "GLM-4.6V", source: "imported" },
+    { id: "0727-106B-API", name: "GLM-4.5-Air", source: "imported" },
+    { id: "deep-research", name: "Z1-Rumination", source: "imported" },
+  ]);
+  await modelsDb.addCustomModel("zai-web", "glm-4-air-250414", "GLM-4-32B", "imported");
+  await modelsDb.addCustomModel("zai-web", "manual-test-model", "Manual test model", "manual");
+
+  let fetchCalls = 0;
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
-    const u = String(url);
-    if (u.startsWith(ZAI_WEB_MODELS_URL)) {
-      fetchedUrl = u;
-      const headers = new Headers(init?.headers);
-      capturedAuthHeader = headers.get("Authorization");
-      return Response.json({
-        data: {
-          data: [{ id: "glm-5.0", name: "GLM-5.0", owned_by: "zai-web" }],
-        },
-      });
-    }
-    return new Response("not found", { status: 404 });
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    throw new Error("zai-web curated catalog must not perform remote discovery");
   }) as typeof globalThis.fetch;
 
   try {
@@ -87,143 +92,15 @@ test("#7678 zai-web model discovery fetches the live /api/models catalog with a 
       new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
       { params: { id: connection.id } }
     );
+
     assert.equal(response.status, 200);
-    const body = (await response.json()) as ModelsBody;
-    assert.equal(body.provider, "zai-web");
-    assert.equal(body.source, "api", "should serve the live zai-web catalog, not local_catalog");
-    assert.ok(fetchedUrl, `should have probed ${ZAI_WEB_MODELS_URL}`);
-    const ids = body.models.map((m) => m.id);
-    assert.ok(ids.includes("glm-5.0"), `live ids missing: ${ids.join(",")}`);
-    assert.equal(
-      capturedAuthHeader,
-      "Bearer abc123",
-      "extractZaiToken should strip the cookie down to the bare token= value"
+    const body = await response.json();
+    assert.equal(body.source, "local_catalog");
+    assert.deepEqual(
+      body.models.map((model: { id: string }) => model.id),
+      CURATED_ZAI_WEB_MODEL_IDS
     );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("#7678 zai-web parseResponse tolerates the flatter { data: [...] } shape", async () => {
-  await resetStorage();
-  const connection = await providersDb.createProviderConnection({
-    provider: "zai-web",
-    authType: "apikey",
-    name: "zai-web-flat",
-    apiKey: "token=def456",
-  });
-
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (url: string | URL | Request) => {
-    if (String(url).startsWith(ZAI_WEB_MODELS_URL)) {
-      return Response.json({ data: [{ id: "glm-4.6", name: "GLM-4.6" }] });
-    }
-    return new Response("not found", { status: 404 });
-  }) as typeof globalThis.fetch;
-
-  try {
-    const response = await modelsRoute.GET(
-      new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
-      { params: { id: connection.id } }
-    );
-    assert.equal(response.status, 200);
-    const body = (await response.json()) as ModelsBody;
-    assert.equal(body.source, "api");
-    assert.ok(body.models.map((m) => m.id).includes("glm-4.6"));
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("#7678 zai-web discovery failure falls back to the hardcoded local catalog", async () => {
-  await resetStorage();
-  const connection = await providersDb.createProviderConnection({
-    provider: "zai-web",
-    authType: "apikey",
-    name: "zai-web-fallback",
-    apiKey: "token=expired",
-  });
-
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (url: string | URL | Request) => {
-    if (String(url).startsWith(ZAI_WEB_MODELS_URL)) {
-      return new Response("unauthorized", { status: 401 });
-    }
-    return new Response("not found", { status: 404 });
-  }) as typeof globalThis.fetch;
-
-  try {
-    const response = await modelsRoute.GET(
-      new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
-      { params: { id: connection.id } }
-    );
-    assert.equal(response.status, 200);
-    const body = (await response.json()) as ModelsBody;
-    assert.equal(
-      body.source,
-      "local_catalog",
-      "a failed live fetch must degrade to the hardcoded catalog, never an empty list"
-    );
-    const ids = body.models.map((m) => m.id);
-    assert.ok(ids.length > 0, "local_catalog fallback must not be empty");
-    assert.ok(
-      ids.includes("glm-4.6"),
-      `expected the registry's static zai-web catalog, got: ${ids.join(",")}`
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("#7678 zai-web second call without ?refresh uses the cache, not a new live fetch", async () => {
-  await resetStorage();
-  const connection = await providersDb.createProviderConnection({
-    provider: "zai-web",
-    authType: "apikey",
-    name: "zai-web-cache",
-    apiKey: "token=cached",
-  });
-
-  const originalFetch = globalThis.fetch;
-  let liveFetchCount = 0;
-  globalThis.fetch = (async (url: string | URL | Request) => {
-    if (String(url).startsWith(ZAI_WEB_MODELS_URL)) {
-      liveFetchCount++;
-      return Response.json({
-        data: { data: [{ id: "glm-4.6", name: "GLM-4.6", owned_by: "zai-web" }] },
-      });
-    }
-    return new Response("not found", { status: 404 });
-  }) as typeof globalThis.fetch;
-
-  try {
-    const first = await modelsRoute.GET(
-      new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
-      { params: { id: connection.id } }
-    );
-    assert.equal(first.status, 200);
-    const firstBody = (await first.json()) as ModelsBody;
-    assert.equal(firstBody.source, "api");
-    assert.equal(liveFetchCount, 1);
-
-    // Second call: fetch mock would fail if hit again — proves the cache short-circuits it.
-    globalThis.fetch = (async (url: string | URL | Request) => {
-      if (String(url).startsWith(ZAI_WEB_MODELS_URL)) {
-        liveFetchCount++;
-        return new Response("should not be called", { status: 500 });
-      }
-      return new Response("not found", { status: 404 });
-    }) as typeof globalThis.fetch;
-
-    const second = await modelsRoute.GET(
-      new Request(`http://localhost/api/providers/${connection.id}/models`),
-      { params: { id: connection.id } }
-    );
-    assert.equal(second.status, 200);
-    const secondBody = (await second.json()) as ModelsBody;
-    assert.equal(secondBody.source, "cache", "second call without ?refresh must be served from cache");
-    assert.equal(liveFetchCount, 1, "the cache must short-circuit the live fetch entirely");
-    assert.ok(secondBody.models.map((m) => m.id).includes("glm-4.6"));
+    assert.equal(fetchCalls, 0);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/zai-web-silent-empty-repro.test.ts
+++ b/tests/unit/zai-web-silent-empty-repro.test.ts
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildZaiStreamingBody, parseZaiFrame } = await import(
+  "../../open-sse/executors/zai-web/stream.ts"
+);
+
+/**
+ * Hard Rule #6 — "never silently swallow errors in SSE streams".
+ *
+ * HTTP-level failures are already handled: `fetchUpstream` turns any `!ok`
+ * response into a `makeErrorResult` with the sanitized body. The gap is a
+ * **200 whose SSE body carries an error payload** — `parseZaiFrame` returns
+ * null for it, `drainSseDeltas` drops it, and the stream closes with an empty
+ * assistant message + stop + [DONE]. The caller sees a successful empty
+ * completion: HTTP 200, `out=0`, "complete". That is the shape reported on
+ * #8451, and it makes a rejected signature, an expired captcha and a stale
+ * token all look identical.
+ *
+ * Scope note: returning null for a *contentless* frame is deliberate and
+ * live-validated — z.ai sends phase frames with no `delta_content`, and
+ * `executor-zai-web.test.ts` pins that ("returns null for frames with no usable
+ * delta"). So this only adds recognition of affirmatively error-shaped frames;
+ * "nothing parseable arrived" is left alone, because on this protocol that is
+ * not by itself evidence of failure.
+ */
+
+function sseStream(...frames: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      for (const f of frames) c.enqueue(enc.encode(`data: ${f}\n\n`));
+      c.close();
+    },
+  });
+}
+
+async function readAll(stream: ReadableStream): Promise<string> {
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += dec.decode(value as Uint8Array, { stream: true });
+  }
+  return out;
+}
+
+const emitChunk = (
+  controller: ReadableStreamDefaultController,
+  delta: Record<string, unknown>,
+  finish?: string
+) => {
+  const payload = JSON.stringify({
+    choices: [{ index: 0, delta, finish_reason: finish ?? null }],
+  });
+  controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+};
+
+const contentOf = (sse: string) =>
+  [...sse.matchAll(/"content":"([^"]*)"/g)].map((m) => m[1]).join("");
+
+test("parseZaiFrame classifies an error-shaped frame instead of discarding it", () => {
+  assert.equal(parseZaiFrame({ error: "captcha expired" })?.error, "captcha expired");
+  assert.equal(
+    parseZaiFrame({ error: { detail: "signature invalid" } })?.error,
+    "signature invalid"
+  );
+  assert.equal(
+    parseZaiFrame({ data: { error: { message: "token expired" } } })?.error,
+    "token expired"
+  );
+});
+
+test("an error frame is terminal", () => {
+  assert.equal(parseZaiFrame({ error: "nope" })?.done, true);
+});
+
+test("REGRESSION GUARD: contentless frames are still skipped, not reported as errors", () => {
+  // Live-validated behaviour — z.ai emits phase frames with no delta_content.
+  // Pinned by executor-zai-web.test.ts; re-asserted here because the error path
+  // added below runs in the same function.
+  assert.equal(parseZaiFrame({ data: { phase: "answer" } }), null);
+  assert.equal(parseZaiFrame({ type: "chat:completion", data: { phase: "thinking" } }), null);
+  assert.equal(parseZaiFrame({}), null);
+  assert.equal(parseZaiFrame(null), null);
+  assert.equal(parseZaiFrame("not-an-object"), null);
+});
+
+test("a 200 stream carrying an error frame surfaces it instead of finishing empty", async () => {
+  const upstream = sseStream(JSON.stringify({ error: { detail: "signature invalid" } }));
+  const out = await readAll(buildZaiStreamingBody(upstream, emitChunk, null));
+
+  assert.match(contentOf(out), /signature invalid/, "the upstream's diagnosis must reach the caller");
+  assert.match(contentOf(out), /\[Z\.ai error\]/, "tagged like the other web executors");
+  assert.ok(out.includes('"finish_reason":"stop"'));
+  assert.ok(out.includes("[DONE]"), "the stream still terminates cleanly for the client");
+});
+
+test("an error frame after partial content still surfaces, keeping what was streamed", async () => {
+  const upstream = sseStream(
+    JSON.stringify({ type: "chat:completion", data: { delta_content: "partial", phase: "answer" } }),
+    JSON.stringify({ error: "stream aborted upstream" })
+  );
+  const out = await readAll(buildZaiStreamingBody(upstream, emitChunk, null));
+
+  assert.match(contentOf(out), /partial/, "already-streamed content is preserved");
+  assert.match(contentOf(out), /stream aborted upstream/, "and the failure is appended, not dropped");
+});
+
+test("control: a well-formed stream is untouched", async () => {
+  const upstream = sseStream(
+    JSON.stringify({ type: "chat:completion", data: { delta_content: "hello", phase: "answer" } }),
+    JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })
+  );
+  const out = await readAll(buildZaiStreamingBody(upstream, emitChunk, null));
+
+  assert.equal(contentOf(out), "hello");
+  assert.ok(!out.includes("[Z.ai error]"), "the happy path must stay clean");
+});
+
+test("control: a phase-only stream is not turned into an error", async () => {
+  // The exact case the deliberate-null design exists for.
+  const upstream = sseStream(
+    JSON.stringify({ type: "chat:completion", data: { phase: "answer" } }),
+    JSON.stringify({ type: "chat:completion", data: { delta_content: "hi", phase: "answer" } }),
+    JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })
+  );
+  const out = await readAll(buildZaiStreamingBody(upstream, emitChunk, null));
+
+  assert.equal(contentOf(out), "hi");
+  assert.ok(!out.includes("[Z.ai error]"));
+});

--- a/tests/unit/zai-web-silent-empty-repro.test.ts
+++ b/tests/unit/zai-web-silent-empty-repro.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { buildZaiStreamingBody, parseZaiFrame } = await import(
+const { buildZaiStreamingBody, parseZaiFrame, collectZaiNonStreaming } = await import(
   "../../open-sse/executors/zai-web/stream.ts"
 );
 
@@ -131,4 +131,27 @@ test("control: a phase-only stream is not turned into an error", async () => {
 
   assert.equal(contentOf(out), "hi");
   assert.ok(!out.includes("[Z.ai error]"));
+});
+
+// ── Non-streaming path (collectZaiNonStreaming) ───────────────────────────────
+
+test("collectZaiNonStreaming rejects on an error frame instead of returning empty", async () => {
+  const upstream = sseStream(JSON.stringify({ error: { detail: "captcha expired" } }));
+  await assert.rejects(
+    () => collectZaiNonStreaming(upstream),
+    (err: Error) => {
+      assert.match(err.message, /captcha expired/);
+      return true;
+    }
+  );
+});
+
+test("collectZaiNonStreaming returns content when no error frame is present", async () => {
+  const upstream = sseStream(
+    JSON.stringify({ type: "chat:completion", data: { delta_content: "hello", phase: "answer" } }),
+    JSON.stringify({ type: "chat:completion", data: { phase: "done", done: true } })
+  );
+  const result = await collectZaiNonStreaming(upstream);
+  assert.equal(result.answer, "hello");
+  assert.equal(result.reasoning, "");
 });


### PR DESCRIPTION
## Summary

- Rework `zai-web` authentication around the `chat.z.ai` Local Storage token and an authenticated browser transport that obtains the per-request CAPTCHA proof.
- Replace stale imported model discovery with the four verified models: GLM-5.2, GLM-5.1, GLM-5-Turbo, and GLM-5V-Turbo.
- Support GLM-5.2 Deep Think High/Max controls and real GLM-5V image uploads through the authenticated Z.ai page.
- Improve model-test, request-queue, abort, and browser-transport errors, including the Z.ai-scoped 60-second test/queue budget and correct failure reporting.
- Update the dashboard credential guide and add focused regression coverage.

## Root cause

The previous provider path expected a cookie-based credential and stale remote model discovery. It could not reliably complete Z.ai's current CAPTCHA-gated browser flow, coordinate clicks were intercepted by the landing-page animation, multimodal parts were not uploaded as files, and local abort/queue failures could be surfaced with misleading status or success state.

## Impact

Users now copy only the `token` value from `chat.z.ai` Local Storage. OmniRoute performs the authenticated page request, model/Deep Think selection, CAPTCHA handling, and image upload. The public model list is curated and no longer imports obsolete entries.

## Latest rebase and validation

Rebased `agent/zai-web-browser-transport` onto:

```
upstream/release/v3.8.50 @ 371c10ea5f1184ffcb74d71f6bec15885c2dfe28
```

The rebase completed without conflicts. `git range-diff` matched all five original commits one-to-one:

```
1: 38095fa79 = 1: 56614f29b fix: complete Z.ai web browser transport
2: b5b0d1e2e = 2: d4ea6c128 refactor: address Z.ai review feedback
3: 6ed0e8285 = 3: 960d69b9d test(zai-web): reconcile the #8014 endpoint guard with the chats/new + signed flow
4: 02ab9afc4 = 4: 432905f86 fix(zai-web): surface upstream error frames instead of finishing empty
5: e603e43bb = 5: 02a3aa9ed refactor(sse): extract the zai-web transports so the complexity ratchet holds
```

Fresh checks on the rebased branch:

- PR-touched focused Z.ai/support unit files (13 files): **91/91 passed**.
- `npm run typecheck:core`: passed.
- `npm run check:dashboard-typecheck`: passed; 254 dashboard errors remain within the frozen baseline.
- `npm run lint`: passed.
- `npm run check:file-size`: passed (121 frozen files; 44 frozen test files).
- `npm run check:complexity-ratchets`: passed (`complexity=2202` vs baseline 2774; `cognitiveComplexity=980` vs baseline 1223).
- `npm run check:complexity`: passed.
- `npm run check:cognitive-complexity`: passed.
- `git diff --check upstream/release/v3.8.50...HEAD && git diff --check`: passed.
- No dependencies were installed or updated, and no live upstream request was made during this local revalidation.

Current relevant file sizes:

| file | lines | cap |
| --- | ---: | ---: |
| `open-sse/executors/zai-web.ts` | 597 | 800 |
| `open-sse/executors/zai-web/protocol.ts` | 554 | 800 |
| `open-sse/executors/zai-web/stream.ts` | 214 | 800 |
| `open-sse/executors/zai-web/browserAutomation.ts` | 150 | 800 |
| `open-sse/services/browserBackedChat.ts` | 843 | 850 frozen |

