### PR TITLE
chore(sse): drop deprecated baseUrl from open-sse tsconfig for TS 7.0 readiness

### DIFF
--- a/open-sse/tsconfig.json
+++ b/open-sse/tsconfig.json
@@ -13,12 +13,10 @@
     "strict": false,
     "jsx": "react-jsx",
     "lib": ["dom", "esnext"],
-    "ignoreDeprecations": "5.0",
-    "baseUrl": "..",
     "paths": {
-      "@/*": ["./src/*"],
-      "@omniroute/open-sse": ["./open-sse"],
-      "@omniroute/open-sse/*": ["./open-sse/*"]
+      "@/*": ["../src/*"],
+      "@omniroute/open-sse": ["../open-sse"],
+      "@omniroute/open-sse/*": ["../open-sse/*"]
     }
   },
   "include": ["**/*.ts", "**/*.js"]

--- a/scripts/check/check-type-coverage.mjs
+++ b/scripts/check/check-type-coverage.mjs
@@ -11,8 +11,12 @@
 //   - Rationale: the only tsconfig that covers the full open-sse workspace
 //     (src+open-sse together). `tsconfig.json` excludes open-sse; the
 //     `tsconfig.typecheck-core.json` only lists 26 explicit files (partial).
-//     open-sse/tsconfig.json sets `baseUrl: ".."` and path aliases so it
-//     resolves both workspaces correctly and yields a representative global %.
+//     open-sse/tsconfig.json declares path aliases (`@/*`, `@omniroute/open-sse/*`)
+//     relative to its own directory, so it resolves both workspaces correctly and
+//     yields a representative global %. It carried a `baseUrl: ".."` until TS 7
+//     readiness removed it; that also stopped `electron/*.js` from being pulled
+//     into the program via root-relative resolution, which moved the measured %
+//     up (~92.2% -> ~94.0%).
 //
 // Direction: up (% can only improve; ratchet blocks drops once wired into INT).
 // Eps: 0.05 (float noise tolerance — type-coverage may vary by ~0.01% between runs).

--- a/tests/unit/tsconfig-ts7-readiness.test.ts
+++ b/tests/unit/tsconfig-ts7-readiness.test.ts
@@ -1,0 +1,148 @@
+/**
+ * TS 7.0 readiness guard for tsconfig files.
+ *
+ * TypeScript 6.x raises `TS5101: Option 'baseUrl' is deprecated and will stop
+ * functioning in TypeScript 7.0` for any tsconfig that still declares
+ * `compilerOptions.baseUrl`. The only offender was `open-sse/tsconfig.json`,
+ * which paired it with `ignoreDeprecations: "5.0"` to silence the warning.
+ *
+ * Dropping `baseUrl` changes how `paths` are resolved: without it, every path
+ * mapping is resolved relative to the directory containing the tsconfig rather
+ * than relative to `baseUrl`. So asserting "no baseUrl" alone is not enough —
+ * the mappings have to keep pointing at real directories, or `@/*` and
+ * `@omniroute/open-sse/*` silently stop resolving. Both halves are asserted here.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** Directories that hold generated/vendored copies of tsconfig files. */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".build",
+  ".next",
+  ".next-playwright",
+  ".claude",
+  ".git",
+  "dist",
+  "dist-electron",
+  "coverage",
+  ".source",
+  ".tmp",
+  "_tasks",
+  "_ideia",
+  "_mono_repo",
+  "_references",
+]);
+
+function collectTsconfigs(dir: string, found: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectTsconfigs(path.join(dir, entry.name), found);
+    } else if (/^tsconfig(\..+)?\.json$/.test(entry.name)) {
+      found.push(path.join(dir, entry.name));
+    }
+  }
+  return found;
+}
+
+/**
+ * tsconfig is JSONC (comments + trailing commas allowed), and glob values like
+ * `"**​/*.ts"` contain `/*` — so a hand-rolled comment stripper corrupts them.
+ * Use TypeScript's own parser. `extends` is deliberately NOT resolved: each file
+ * is asserted on what it literally declares.
+ */
+function readTsconfig(file: string): { compilerOptions?: Record<string, unknown> } {
+  const { config, error } = ts.readConfigFile(file, (p) => fs.readFileSync(p, "utf8"));
+  assert.equal(
+    error,
+    undefined,
+    `${path.relative(REPO_ROOT, file)} is not parseable: ${
+      error && ts.flattenDiagnosticMessageText(error.messageText, " ")
+    }`
+  );
+  return config as { compilerOptions?: Record<string, unknown> };
+}
+
+const TSCONFIGS = collectTsconfigs(REPO_ROOT);
+
+test("repo actually has tsconfig files to check", () => {
+  assert.ok(TSCONFIGS.length > 0, "no tsconfig files discovered — the walker is broken");
+});
+
+test("no tsconfig declares the TS 7.0-removed 'baseUrl' option", () => {
+  const offenders = TSCONFIGS.filter(
+    (file) => readTsconfig(file).compilerOptions?.baseUrl !== undefined
+  ).map((file) => path.relative(REPO_ROOT, file));
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `'baseUrl' is removed in TypeScript 7.0 (TS5101). Drop it and rewrite 'paths' ` +
+      `relative to the tsconfig's own directory. Offenders: ${offenders.join(", ")}`
+  );
+});
+
+test("no tsconfig needs 'ignoreDeprecations' to silence removed options", () => {
+  const offenders = TSCONFIGS.filter(
+    (file) => readTsconfig(file).compilerOptions?.ignoreDeprecations !== undefined
+  ).map((file) => path.relative(REPO_ROOT, file));
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `'ignoreDeprecations' only suppresses the symptom — remove the deprecated ` +
+      `option itself. Offenders: ${offenders.join(", ")}`
+  );
+});
+
+test("every tsconfig 'paths' mapping resolves to a real file or directory", () => {
+  const broken: string[] = [];
+
+  for (const file of TSCONFIGS) {
+    const compilerOptions = readTsconfig(file).compilerOptions;
+    const paths = compilerOptions?.paths as Record<string, string[]> | undefined;
+    if (!paths) continue;
+
+    // Without baseUrl, path mappings resolve relative to the tsconfig's directory.
+    const resolveRoot = path.dirname(file);
+
+    for (const [alias, targets] of Object.entries(paths)) {
+      for (const target of targets) {
+        // Strip the trailing wildcard segment: "../src/*" -> "../src"
+        const concrete = target.replace(/\/?\*+$/, "");
+        const absolute = path.resolve(resolveRoot, concrete);
+        if (!fs.existsSync(absolute)) {
+          broken.push(`${path.relative(REPO_ROOT, file)}: "${alias}" -> "${target}"`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(
+    broken,
+    [],
+    `path alias targets that do not exist on disk:\n  ${broken.join("\n  ")}`
+  );
+});
+
+test("open-sse aliases point at the repo-root src/ and open-sse/ directories", () => {
+  const file = path.join(REPO_ROOT, "open-sse/tsconfig.json");
+  const paths = readTsconfig(file).compilerOptions?.paths as Record<string, string[]>;
+
+  assert.ok(paths, "open-sse/tsconfig.json must keep its path aliases");
+
+  const resolveRoot = path.dirname(file);
+  const resolveAlias = (alias: string) =>
+    path.resolve(resolveRoot, paths[alias][0].replace(/\/?\*+$/, ""));
+
+  assert.equal(resolveAlias("@/*"), path.join(REPO_ROOT, "src"));
+  assert.equal(resolveAlias("@omniroute/open-sse"), path.join(REPO_ROOT, "open-sse"));
+  assert.equal(resolveAlias("@omniroute/open-sse/*"), path.join(REPO_ROOT, "open-sse"));
+});


### PR DESCRIPTION
## Problem

`open-sse/tsconfig.json` is the only tsconfig in the repo that still declares `baseUrl`. With the pinned TypeScript 6.0.3 this is a hard error, surfaced in-editor on every open-sse file:

```
open-sse/tsconfig.json(17,5): error TS5101: Option 'baseUrl' is deprecated and will
stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"'
to silence this error.
```

The existing `"ignoreDeprecations": "5.0"` no longer covers it — TS 6 demands `"6.0"`. Bumping that string would only re-hide the problem for one more major, so this removes the deprecated option instead.

## Change

Drop `baseUrl: ".."` and rewrite `paths` relative to the tsconfig's own directory, which is how TypeScript resolves path mappings when no `baseUrl` is set:

| alias | before (resolved via `baseUrl: ".."`) | after |
| --- | --- | --- |
| `@/*` | `./src/*` | `../src/*` |
| `@omniroute/open-sse` | `./open-sse` | `../open-sse` |
| `@omniroute/open-sse/*` | `./open-sse/*` | `../open-sse/*` |

All three still resolve to the same directories. `ignoreDeprecations` is removed too — `baseUrl` was the only deprecated option it was suppressing.

## Validation (Hard Rule #18 — TDD)

Failing-then-passing guard test: `tests/unit/tsconfig-ts7-readiness.test.ts` (4 of 5 assertions failed before the fix, 5/5 after).

It asserts no tsconfig reintroduces `baseUrl` or `ignoreDeprecations`, **and** that every `paths` target still resolves to a real directory. The second half is the load-bearing one: removing `baseUrl` silently changes what the mappings point at, so a "no baseUrl" check on its own would happily pass a config whose aliases had stopped resolving.

### tsc error-set diff

Raw error counts are misleading here — `TS5101` is a config-level error that aborts type-checking, so the pre-fix run reported exactly 1 error while masking everything behind it. To get a real comparison the base config was re-run with only `ignoreDeprecations` flipped to `"6.0"`, letting compilation proceed, and the two full error sets were diffed:

| | errors | `TS2307` (unresolved module) |
| --- | --- | --- |
| base (`baseUrl: ".."`, `ignoreDeprecations: "6.0"`) | 335 | 3 |
| this PR | 307 | 1 |

**Zero new errors.** The 28 that disappeared are all in `electron/*.js` (`main.js` 22, `loginManager.js` 5, `lib/resolveNodeHelper.js` 1) — files `baseUrl: ".."` had been pulling into the open-sse program through root-relative resolution. The remaining `TS2307` (`log-wrapper` in `comboManifestMetrics.ts`) is pre-existing and present in both runs. The 307 are long-standing type errors that were hidden behind the config error; this PR does not touch them and no CI job type-checks against this tsconfig.

`--traceResolution` confirms aliases still resolve, e.g. `@/lib/proxyHealth` → `src/lib/proxyHealth.ts`, `@omniroute/open-sse/utils/proxyFamily` → `open-sse/utils/proxyFamily.ts`.

### Gates

| gate | result |
| --- | --- |
| `tests/unit/tsconfig-ts7-readiness.test.ts` | 5/5 pass |
| `npm run typecheck:core` | clean |
| `npm run check:type-coverage` | pass — **92.17% → 94.01%** |
| `check-type-coverage` / `quality-ratchet` / `check-openapi-breaking-ratchet` unit tests | 44/44 pass |
| `eslint` on changed files | 0 errors |

## One thing to decide

`check:type-coverage` measures against this exact tsconfig, so narrowing the program lifted it from 92.17% to 94.01%. The ratchet direction is `up`, so the gate passes and CI is green either way — but I deliberately **did not** run `quality:ratchet --update`. The gain comes from excluding untyped `electron/*.js`, not from new typing work, and re-baselining is a separate call from this fix. Say the word if you want the baseline moved to 94.01 in this PR; leaving it at 92.17 does mean the gate tolerates a drop it otherwise wouldn't.

The rationale comment in `scripts/check/check-type-coverage.mjs` cited `baseUrl` as the reason that tsconfig was chosen, so it is updated to match.
