### PR TITLE
fix(sse): export PROVIDER_BREAKER_FAILURE_STATUSES — conflict resolved

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -77,6 +77,7 @@ import {
   isAntigravityMissingProjectError,
   PROVIDER_BREAKER_FAILURE_STATUSES,
   shouldTripProviderBreakerForResult,
+  PROVIDER_BREAKER_FAILURE_STATUSES,
 } from "./chatPredicates";
 import { connectionHasExtraKeys } from "@omniroute/open-sse/services/apiKeyRotator.ts";
 import {

--- a/tests/unit/nvidia-quota-phase1.test.ts
+++ b/tests/unit/nvidia-quota-phase1.test.ts
@@ -189,7 +189,11 @@ test("getProviderConcurrencyCap resolves override -> static default -> fallback"
   );
   setProviderQuotaOverrides({ nvidia: { concurrency: 3 } });
   try {
-    assert.equal(getProviderConcurrencyCap("nvidia", 99), 3, "override wins over the static default");
+    assert.equal(
+      getProviderConcurrencyCap("nvidia", 99),
+      3,
+      "override wins over the static default"
+    );
   } finally {
     setProviderQuotaOverrides(null);
   }
@@ -218,16 +222,9 @@ test("nvidia 429 does not trip the provider circuit breaker (unchanged 408/500/5
   // documentation-alignment guard proving Phase 1 didn't accidentally widen
   // PROVIDER_BREAKER_FAILURE_STATUSES to include 429 (which would collapse the
   // per-model lockout this PR adds into a whole-connection/provider outage).
-  // #8013 extracted the const from src/sse/handlers/chat.ts into chatPredicates.ts
-  // (still consumed by chat.ts's breaker paths) — read the declaration from its
-  // current home.
-  const chatHandlerPath = path.join(
-    process.cwd(),
-    "src",
-    "sse",
-    "handlers",
-    "chatPredicates.ts"
-  );
+  // The PROVIDER_BREAKER_FAILURE_STATUSES declaration was extracted from chat.ts into
+  // the sibling chatPredicates.ts (chat.ts now imports it); read it from its home.
+  const chatHandlerPath = path.join(process.cwd(), "src", "sse", "handlers", "chatPredicates.ts");
   const source = fs.readFileSync(chatHandlerPath, "utf8");
   const match = source.match(/PROVIDER_BREAKER_FAILURE_STATUSES\s*=\s*new Set\(\[([^\]]+)\]\)/);
   assert.ok(match, "PROVIDER_BREAKER_FAILURE_STATUSES declaration found");


### PR DESCRIPTION
Conflict-resolved rebase of upstream PR #8258. Cherry-picked ba247bedd + b18fa2719 onto latest upstream/release/v3.8.49. Minor conflict in nvidia test comment resolved.