### PR TITLE
test(antigravity): align catalog tests with model realignment — conflict resolved

### DIFF
--- a/tests/unit/auto-combo-credentialed-model-pool.test.ts
+++ b/tests/unit/auto-combo-credentialed-model-pool.test.ts
@@ -87,9 +87,9 @@ test("credentialed providers expose one logical candidate per visible registry m
   );
   for (const model of [
     "antigravity/claude-sonnet-4-6",
-    "antigravity/gemini-3-flash-agent",
-    "antigravity/gemini-3.5-flash-low",
-    "antigravity/gemini-3.5-flash-extra-low",
+    "antigravity/gemini-3.6-flash-low",
+    "antigravity/gemini-3.6-flash-medium",
+    "antigravity/gemini-3.6-flash-high",
   ]) {
     assert.ok(modelStrings.includes(model), `${model} should be eligible for auto routing`);
   }
@@ -134,8 +134,10 @@ test("connection model exclusions narrow only that model's account allowlist", a
     assert.deepEqual(candidate.allowedConnectionIds, [second.id]);
   }
 
-  const sonnet = candidates.find((candidate) => candidate.model === "antigravity/claude-sonnet-4-6");
-  assert.ok(sonnet, "Claude Sonnet 4.6 should remain in the candidate pool");
+  const sonnet = candidates.find(
+    (candidate) => candidate.model === "antigravity/claude-sonnet-4-6"
+  );
+  assert.ok(sonnet, "Claude Sonnet 5 should remain in the candidate pool");
   assert.deepEqual([...(sonnet.allowedConnectionIds ?? [])].sort(), [first.id, second.id].sort());
 });
 
@@ -148,9 +150,9 @@ test("hiding the first registry model does not drop the credentialed provider", 
 
   assert.equal(modelStrings.includes("antigravity/claude-sonnet-4-6"), false);
   for (const model of [
-    "antigravity/gemini-3-flash-agent",
-    "antigravity/gemini-3.5-flash-low",
-    "antigravity/gemini-3.5-flash-extra-low",
+    "antigravity/gemini-3.6-flash-low",
+    "antigravity/gemini-3.6-flash-medium",
+    "antigravity/gemini-3.6-flash-high",
   ]) {
     assert.ok(modelStrings.includes(model), `${model} should remain after Sonnet is hidden`);
   }

--- a/tests/unit/model-alias-seed.test.ts
+++ b/tests/unit/model-alias-seed.test.ts
@@ -42,6 +42,8 @@ test("default model alias seed writes missing aliases and is idempotent", async 
   assert.equal(aliases["gemini-3-flash-preview"], undefined);
 
   const routed = await sseModelService.getModelInfo("gemini-3.1-pro");
+  // The stored alias target is "agy/gemini-pro-agent", but getModelInfo canonicalizes
+  // the "agy" alias to its provider id "antigravity" (ALIAS_TO_PROVIDER_ID, #8013).
   assert.deepEqual(routed, {
     provider: "antigravity",
     model: "gemini-pro-agent",

--- a/tests/unit/t31-t33-t34-t38-model-specs.test.ts
+++ b/tests/unit/t31-t33-t34-t38-model-specs.test.ts
@@ -15,11 +15,14 @@ const {
   capThinkingBudget,
 } = await import("../../src/shared/constants/modelSpecs.ts");
 
-test("T31: antigravity static catalog exposes client-visible Gemini model IDs", () => {
-  // Antigravity's static catalog surfaces the live, client-visible model IDs returned by
-  // the model selector (#8013 refactor: gemini-3.6-flash-high is the current defaultAgentModelId).
+test("T31: antigravity static catalog exposes client-visible Gemini preview IDs", () => {
+  // Antigravity exposes client-visible Gemini IDs even though the upstream still
+  // accepts its internal model identifiers. #8013 (align official clients / callable
+  // catalog) retired the `gemini-3-pro-preview` alias, so assert the current
+  // client-visible top flash tier instead.
   const staticIds = (getStaticModelsForProvider("antigravity") || []).map((m) => m.id);
   assert.ok(staticIds.includes("gemini-3.6-flash-high"));
+  assert.ok(!staticIds.includes("gemini-3-pro-preview"));
   // #3303 (agy parity, discussion #3184): the Gemini + Claude budget tiers ARE
   // client-visible on the Antigravity OAuth backend (Claude was never removed).
   assert.ok(staticIds.includes("gemini-3.1-pro-low"));


### PR DESCRIPTION
Conflict-resolved rebase of upstream PR #8257. Cherry-picked 59152050e + 006c2ca6f onto latest upstream/release/v3.8.49. Conflicts in test model references (gemini-3.5-flash → 3.6-flash) resolved.