### PR TITLE
fix(sse): call the real abort-signal helper in the Gemini Business executor

### DIFF
--- a/open-sse/executors/gemini-business.ts
+++ b/open-sse/executors/gemini-business.ts
@@ -150,13 +150,18 @@ export class GeminiBusinessExecutor extends BaseExecutor {
       headers["Authorization"] = computeSapisidHash(sapisid, baseOrigin);
     }
 
+    // Cap the upstream call, and honor the caller's cancellation when there is one.
+    // `ExecuteInput.signal` is optional while mergeAbortSignals() needs two real signals,
+    // so fall back to the timeout alone — same guard the other web executors use.
+    const timeoutSignal = AbortSignal.timeout(GEMINI_BUSINESS_FETCH_TIMEOUT_MS);
+
     let response: Response;
     try {
       response = await fetch(streamUrl, {
         method: "POST",
         headers,
         body: formBody.toString(),
-        signal: combineAbortSignals(signal, AbortSignal.timeout(GEMINI_BUSINESS_FETCH_TIMEOUT_MS)),
+        signal: signal ? mergeAbortSignals(signal, timeoutSignal) : timeoutSignal,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : "fetch failed";

--- a/tests/unit/gemini-business-provider.test.ts
+++ b/tests/unit/gemini-business-provider.test.ts
@@ -77,6 +77,92 @@ test("GeminiBusinessExecutor.execute returns 400 when no user message is provide
   assert.ok(text.includes("No user message found"));
 });
 
+// ─── Upstream request path ──────────────────────────────────────────────────
+
+/**
+ * Regression guard: `execute()` built its fetch options with `combineAbortSignals(...)`,
+ * a function that exists nowhere in the codebase (the module imports `mergeAbortSignals`
+ * and never used it). Evaluating the options object threw `ReferenceError` *before* fetch
+ * was called; the surrounding try/catch turned that into a generic 502 "network error",
+ * so every Gemini Business request failed while looking like an upstream outage.
+ *
+ * It went unnoticed because `open-sse/tsconfig.json` could not be type-checked (the
+ * deprecated `baseUrl` aborted the run with TS5101) and `typecheck:core` only covers a
+ * curated 26-file allowlist that excludes this executor.
+ */
+test("GeminiBusinessExecutor.execute reaches the upstream fetch and passes an abort signal", async () => {
+  const ex = new GeminiBusinessExecutor();
+  const originalFetch = globalThis.fetch;
+  let fetchCalled = false;
+  let receivedSignal: unknown;
+
+  // Same wire shape the parseStreamResponse tests below use: inner[4][0] is a
+  // [metadata, text_list] pair. An empty body would take the "returned no text" 502
+  // branch and mask what this test is actually asserting.
+  const inner = new Array(80).fill(null);
+  inner[4] = [[null, ["Hello from Gemini Business"]]];
+  const upstreamBody = `[["wrb.fr", null, ${JSON.stringify(JSON.stringify(inner))}]]`;
+
+  globalThis.fetch = (async (_url: unknown, init?: { signal?: unknown }) => {
+    fetchCalled = true;
+    receivedSignal = init?.signal;
+    return new Response(upstreamBody, { status: 200 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    const result = await ex.execute({
+      model: "gemini-2.5-pro",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: false,
+      credentials: { apiKey: "__Secure-1PSID=fake; __Secure-1PSIDTS=fake" },
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(fetchCalled, true, "execute() must reach the upstream fetch");
+    assert.ok(
+      receivedSignal instanceof AbortSignal,
+      "the upstream fetch must receive a combined AbortSignal"
+    );
+    assert.notEqual(
+      result.response.status,
+      502,
+      "a ReferenceError while building fetch options must not surface as an upstream 502"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("GeminiBusinessExecutor.execute still applies a timeout when the caller passes no signal", async () => {
+  const ex = new GeminiBusinessExecutor();
+  const originalFetch = globalThis.fetch;
+  let receivedSignal: unknown;
+
+  globalThis.fetch = (async (_url: unknown, init?: { signal?: unknown }) => {
+    receivedSignal = init?.signal;
+    return new Response("", { status: 200 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    // `ExecuteInput.signal` is `AbortSignal | null | undefined`; mergeAbortSignals()
+    // requires two real signals, so the null case must fall back to the timeout alone.
+    await ex.execute({
+      model: "gemini-2.5-pro",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: false,
+      credentials: { apiKey: "__Secure-1PSID=fake; __Secure-1PSIDTS=fake" },
+      signal: null,
+    });
+
+    assert.ok(
+      receivedSignal instanceof AbortSignal,
+      "a timeout signal must still be applied when the caller supplies none"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 // ─── parseStreamResponse ────────────────────────────────────────────────────
 
 test("parseStreamResponse extracts text from a single wrb.fr chunk", () => {


### PR DESCRIPTION
## The bug

`open-sse/executors/gemini-business.ts:159` builds its upstream fetch options with `combineAbortSignals(...)` — a function that **exists nowhere in the repository**:

```
$ grep -rn "combineAbortSignals" --include="*.ts" --include="*.js" . --exclude-dir=node_modules
open-sse/executors/gemini-business.ts:159:        signal: combineAbortSignals(signal, AbortSignal.timeout(...)),
```

Line 31 of the same file imports `mergeAbortSignals` from `./base.ts` and never uses it, so this looks like a rename that was only half applied.

**Impact: every Gemini Business request fails.** The call sits inside the fetch options object literal, so the `ReferenceError` is thrown while *constructing the arguments*, before `fetch()` runs. The surrounding `try/catch` catches it and returns:

```
502  "Gemini Business network error: combineAbortSignals is not defined"
```

— which reads like an upstream outage rather than a code fault. The provider is registered and reachable (`"gemini-business": new GeminiBusinessExecutor()` in `open-sse/executors/index.ts`), so this is the whole provider, not an edge case.

## The fix

`mergeAbortSignals(primary: AbortSignal, secondary: AbortSignal)` requires two real signals, while `ExecuteInput.signal` is `AbortSignal | null | undefined`. So the call is guarded and falls back to the timeout alone — the same shape already used by `huggingchat.ts`, `grok-web.ts`, `claude-web.ts`, and `ninerouter.ts`:

```ts
const timeoutSignal = AbortSignal.timeout(GEMINI_BUSINESS_FETCH_TIMEOUT_MS);
// ...
signal: signal ? mergeAbortSignals(signal, timeoutSignal) : timeoutSignal,
```

## Why CI never caught it

Two gaps line up:

1. This file is only type-checked by `open-sse/tsconfig.json`, and **every run of that config aborts at `TS5101`** — the deprecated `baseUrl` — before a single file is checked. `TS2304: Cannot find name 'combineAbortSignals'` was sitting behind it. (Removing that config error is #8473; this bug is what the first full run surfaced.)
2. `typecheck:core` uses a curated 26-file allowlist that contains no executors.

## Validation (Hard Rule #18 — TDD)

Two tests added to `tests/unit/gemini-business-provider.test.ts`. Both **fail on the parent commit** and pass with the fix:

| test | on parent | with fix |
| --- | --- | --- |
| `…reaches the upstream fetch and passes an abort signal` | ✖ `execute() must reach the upstream fetch` — `false !== true` | ✔ |
| `…still applies a timeout when the caller passes no signal` | ✖ no signal reaches fetch | ✔ |

The first stubs `globalThis.fetch`, asserts the executor actually reaches it, and that a real `AbortSignal` arrives in the request init. It returns a realistic `wrb.fr` body (same wire shape as the existing `parseStreamResponse` fixtures) so the assertion isn't masked by the separate "returned no text" 502 branch. The second covers the null-signal path — that is where an *unguarded* `mergeAbortSignals` would throw next.

`gemini-business-provider.test.ts` 15/15, `typecheck:core` clean, lint clean.

## Note

One more `TS2304` is behind the same config error: `DuckDuckGoChallengeResult` is used in `open-sse/executors/duckduckgo-web/challenge.ts:121` but declared as a non-exported local type in `duckduckgo-web.ts:139`. That one is types-only with no runtime effect, so it rides along with the executor type slice rather than this fix. Tracked in #8484.
