### PR TITLE
fix(providers): honor Extra API Keys rotation in OpencodeExecutor

### DIFF
--- a/changelog.d/fixes/8467-opencode-extra-keys.md
+++ b/changelog.d/fixes/8467-opencode-extra-keys.md
@@ -1,0 +1,1 @@
+- **fix(providers):** OpencodeExecutor honors Extra API Keys rotation via `resolveEffectiveKey` (empty primary + extras no longer omit Authorization) ([#8467](https://github.com/diegosouzapw/OmniRoute/issues/8467)) — thanks @Prudhvivuda

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -352,12 +352,15 @@ export class BaseExecutor {
       (credentials.providerSpecificData?.extraApiKeys as string[] | undefined) ?? [];
     const selectedKeyId = (credentials.providerSpecificData as Record<string, unknown> | undefined)
       ?.selectedKeyId as string | undefined;
+    const validExtras = extraKeys.filter((k) => typeof k === "string" && k.trim().length > 0);
     let effectiveKey = credentials.apiKey;
-    if (extraKeys.length > 0 && credentials.connectionId && credentials.apiKey) {
+    // Rotate whenever extras exist — including empty primary + populated extras (#8467).
+    // getValidApiKey already skips a blank primary and round-robins the extras alone.
+    if (validExtras.length > 0 && credentials.connectionId) {
       const resolved = resolveKeyForRequest(
         credentials.connectionId,
-        credentials.apiKey,
-        extraKeys,
+        credentials.apiKey || "",
+        validExtras,
         selectedKeyId ?? null
       );
       effectiveKey = resolved?.key ?? credentials.apiKey;

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -415,7 +415,7 @@ export class BaseExecutor {
 
     if (credentials.accessToken) {
       headers["Authorization"] = `Bearer ${credentials.accessToken}`;
-    } else if (credentials.apiKey) {
+    } else if (effectiveKey) {
       headers["Authorization"] = `Bearer ${effectiveKey}`;
     }
 

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -251,7 +251,11 @@ export class OpencodeExecutor extends BaseExecutor {
     model?: string
   ) {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
-    const key = credentials?.apiKey || credentials?.accessToken;
+    // #8467: honor Extra API Keys rotation via BaseExecutor.resolveEffectiveKey.
+    // Fall back to accessToken only when no apiKey/extras resolve to a key.
+    const key = credentials
+      ? this.resolveEffectiveKey(credentials) || credentials.accessToken
+      : undefined;
 
     if (key) {
       if (this._requestFormat === "claude") {

--- a/tests/unit/base-executor-buildheaders-extra-keys-8493.test.ts
+++ b/tests/unit/base-executor-buildheaders-extra-keys-8493.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { BaseExecutor } from "../../open-sse/executors/base.ts";
+
+/**
+ * Generic BaseExecutor consumer — no buildHeaders() override — representing
+ * every provider (xai, cliproxyapi, chipotle, mimocode, ninerouter, theoldllm,
+ * gitlab, ...) that relies on BaseExecutor.buildHeaders() as-is.
+ *
+ * Regression guard for #8467/#8493: resolveEffectiveKey() already rotates to
+ * an extra key when the primary apiKey is empty, but the header-write gate in
+ * buildHeaders() tested the raw `credentials.apiKey` instead of the resolved
+ * `effectiveKey` — so with an empty primary + populated extras, no
+ * Authorization header was ever written, even though a valid key existed.
+ */
+class GenericExecutor extends BaseExecutor {
+  constructor() {
+    super("generic-provider", {
+      baseUrls: ["https://default.example/v1/chat/completions"],
+    });
+  }
+
+  async transformRequest(model: string, body: unknown, stream: boolean) {
+    return body;
+  }
+}
+
+test("buildHeaders: writes Authorization from the rotated extra key when primary apiKey is empty (#8467/#8493)", () => {
+  const executor = new GenericExecutor();
+  const headers = executor.buildHeaders({
+    apiKey: "",
+    connectionId: "generic-empty-primary",
+    providerSpecificData: { extraApiKeys: ["sk-extra-only"] },
+  });
+
+  assert.equal(headers["Authorization"], "Bearer sk-extra-only");
+});

--- a/tests/unit/refactor-buildHeaders-opencode.test.ts
+++ b/tests/unit/refactor-buildHeaders-opencode.test.ts
@@ -108,3 +108,88 @@ test("OpencodeExecutor.buildHeaders: preserves x-opencode-client from client hea
   });
   assert.equal(headers["x-opencode-client"], "desktop");
 });
+
+// ---------------------------------------------------------------------------
+// #8467 — Extra API Keys rotation (resolveEffectiveKey)
+// ---------------------------------------------------------------------------
+
+test("OpencodeExecutor.buildHeaders: rotates extra API keys (Bearer)", () => {
+  const executor = new OpencodeExecutor("opencode-zen");
+  const credentials = {
+    apiKey: "primary-key",
+    connectionId: "opencode-rotation-bearer",
+    providerSpecificData: { extraApiKeys: ["extra-key"] } as Record<string, unknown>,
+  };
+
+  // Clear sticky selectedKeyId between calls so getValidApiKey round-robin is exercised.
+  const seen = new Set<string>();
+  for (let i = 0; i < 4; i++) {
+    delete credentials.providerSpecificData.selectedKeyId;
+    const headers = executor.buildHeaders(credentials, true);
+    const token = headers["Authorization"]?.replace(/^Bearer /, "");
+    assert.ok(token === "primary-key" || token === "extra-key", `unexpected token: ${token}`);
+    seen.add(token ?? "");
+  }
+  assert.ok(seen.has("primary-key"));
+  assert.ok(seen.has("extra-key"));
+  assert.ok(
+    typeof credentials.providerSpecificData.selectedKeyId === "string" &&
+      credentials.providerSpecificData.selectedKeyId.length > 0,
+    "selectedKeyId should be persisted after rotation"
+  );
+});
+
+test("OpencodeExecutor.buildHeaders: rotates extra API keys (claude x-api-key)", () => {
+  const executor = new OpencodeExecutor("opencode-zen");
+  executor._requestFormat = "claude";
+  const credentials = {
+    apiKey: "primary-key",
+    connectionId: "opencode-rotation-claude",
+    providerSpecificData: { extraApiKeys: ["extra-key"] } as Record<string, unknown>,
+  };
+
+  const seen = new Set<string>();
+  for (let i = 0; i < 4; i++) {
+    delete credentials.providerSpecificData.selectedKeyId;
+    const headers = executor.buildHeaders(credentials, true);
+    const key = headers["x-api-key"];
+    assert.ok(key === "primary-key" || key === "extra-key", `unexpected x-api-key: ${key}`);
+    seen.add(key ?? "");
+  }
+  assert.ok(seen.has("primary-key"));
+  assert.ok(seen.has("extra-key"));
+});
+
+test("OpencodeExecutor.buildHeaders: empty primary + extras still sends Authorization", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const headers = executor.buildHeaders(
+    {
+      apiKey: "",
+      connectionId: "opencode-empty-primary",
+      providerSpecificData: { extraApiKeys: ["only-extra-key"] },
+    },
+    true
+  );
+  assert.equal(headers["Authorization"], "Bearer only-extra-key");
+});
+
+test("OpencodeExecutor.buildHeaders: #8467 guard — override uses resolveEffectiveKey path", async () => {
+  // Source-level guard: OpencodeExecutor overrides buildHeaders and must not
+  // reintroduce a direct credentials.apiKey read that bypasses extra-keys rotation.
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const source = fs.readFileSync(
+    path.resolve(here, "../../open-sse/executors/opencode.ts"),
+    "utf8"
+  );
+  const buildHeadersStart = source.indexOf("buildHeaders(");
+  assert.ok(buildHeadersStart >= 0);
+  const buildHeadersBody = source.slice(buildHeadersStart, buildHeadersStart + 1200);
+  assert.match(buildHeadersBody, /resolveEffectiveKey\s*\(/);
+  assert.doesNotMatch(
+    buildHeadersBody,
+    /credentials\?\.apiKey\s*\|\|\s*credentials\?\.accessToken/
+  );
+});

--- a/tests/unit/refactor-buildHeaders-preamble.test.ts
+++ b/tests/unit/refactor-buildHeaders-preamble.test.ts
@@ -70,6 +70,18 @@ test("resolveEffectiveKey: returns accessToken when apiKey is undefined", () => 
   assert.equal(result, undefined);
 });
 
+test("resolveEffectiveKey: empty primary + extras returns an extra key (#8467)", () => {
+  const executor = new TestExecutor();
+  const credentials = {
+    apiKey: "",
+    connectionId: "preamble-empty-primary",
+    providerSpecificData: { extraApiKeys: ["sk-extra-only"] } as Record<string, unknown>,
+  };
+  const result = executor.publicResolveEffectiveKey(credentials);
+  assert.equal(result, "sk-extra-only");
+  assert.equal(credentials.providerSpecificData.selectedKeyId, "extra_0");
+});
+
 // ---------------------------------------------------------------------------
 // buildHeadersPreamble tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `OpencodeExecutor.buildHeaders` now calls `resolveEffectiveKey()` so Extra API Keys round-robin works for opencode / opencode-go / opencode-zen.
- Empty primary + populated `extraApiKeys` now sends a valid Authorization / x-api-key header instead of omitting auth.
- Unit coverage for Bearer + Claude formats, empty-primary extras, and a source guard against reintroducing the direct `apiKey` bypass.

Closes #8467

## Test plan
- [x] `node --import tsx/esm --test tests/unit/refactor-buildHeaders-opencode.test.ts tests/unit/refactor-buildHeaders-preamble.test.ts`
- [ ] CI green on this PR
