### PR TITLE
refactor(sse): stop three executors shadowing BaseExecutor.buildHeaders

### DIFF
--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -8,6 +8,26 @@ import {
 import { sanitizeResponsesInputItems } from "../services/responsesInputSanitizer.ts";
 import { stripUnsupportedParams } from "../translator/paramSupport.ts";
 
+/**
+ * What a Copilot credential refresh resolves to.
+ *
+ * `refreshCredentials()` returns one of three shapes — the raw GitHub token pair, that pair
+ * plus the minted Copilot token, or the Copilot token folded onto the existing credentials —
+ * and `null` when nothing could be refreshed. Left to inference, the union of those literals
+ * is narrower than the contract subclasses actually honor: `GheCopilotExecutor` carries a
+ * wider `providerSpecificData` (it also records the enterprise proxy URL) and omits
+ * `expiresIn`, which made a valid override fail with TS2416. Every field is therefore
+ * optional here — callers already treat them as such.
+ */
+export interface RefreshedCopilotCredentials {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  copilotToken?: string;
+  copilotTokenExpiresAt?: string | number;
+  providerSpecificData?: Record<string, unknown>;
+}
+
 export class GithubExecutor extends BaseExecutor {
   constructor() {
     super("github", PROVIDERS.github);
@@ -367,7 +387,7 @@ export class GithubExecutor extends BaseExecutor {
     }
   }
 
-  async refreshCredentials(credentials, log) {
+  async refreshCredentials(credentials, log): Promise<RefreshedCopilotCredentials | null> {
     let copilotResult = await this.refreshCopilotToken(credentials.accessToken, log);
 
     if (!copilotResult && credentials.refreshToken) {

--- a/open-sse/executors/hailuo-web.ts
+++ b/open-sse/executors/hailuo-web.ts
@@ -253,7 +253,7 @@ export class HailuoWebExecutor extends BaseExecutor {
     super("hailuo-web", { id: "hailuo-web", baseUrl: BASE_URL });
   }
 
-  private buildHeaders(token: string, yy: string): Record<string, string> {
+  private buildStreamHeaders(token: string, yy: string): Record<string, string> {
     return {
       Accept: "text/event-stream",
       "User-Agent": USER_AGENT,
@@ -357,7 +357,7 @@ export class HailuoWebExecutor extends BaseExecutor {
     form.set("chatID", chatID);
     form.set("searchMode", "0");
 
-    return { url: `${BASE_URL}${pathAndQuery}`, headers: this.buildHeaders(token, yy), form };
+    return { url: `${BASE_URL}${pathAndQuery}`, headers: this.buildStreamHeaders(token, yy), form };
   }
 
   /** POST the signed multipart request and normalize both network + upstream-status errors. */

--- a/open-sse/executors/lmarena.ts
+++ b/open-sse/executors/lmarena.ts
@@ -73,11 +73,13 @@ export class LMArenaExecutor extends BaseExecutor {
     super("lmarena", { format: "openai", ...providerConfig });
   }
 
-  protected buildUrl(_model: string, _credentials: unknown): string {
+  // Public to match BaseExecutor.buildUrl — a subclass may widen visibility but not
+  // narrow it. This was masked behind the buildHeaders TS2416 until that one cleared.
+  buildUrl(_model: string, _credentials: unknown): string {
     return LMARENA_STREAM_URL;
   }
 
-  protected buildHeaders(
+  protected buildRequestHeaders(
     _model: string,
     credentials: unknown,
     _body: unknown
@@ -91,7 +93,7 @@ export class LMArenaExecutor extends BaseExecutor {
     return headers;
   }
 
-  protected transformRequest(body: unknown, model: string, credentials?: unknown): unknown {
+  transformRequest(body: unknown, model: string, credentials?: unknown): unknown {
     const openaiBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
     const messages = Array.isArray(openaiBody.messages)
       ? (openaiBody.messages as OpenAIMessage[])
@@ -115,7 +117,7 @@ export class LMArenaExecutor extends BaseExecutor {
   async execute(input: ExecuteInput) {
     const { model, body, stream, credentials, signal, log } = input;
     const url = this.buildUrl(model, credentials);
-    const headers = this.buildHeaders(model, credentials, body);
+    const headers = this.buildRequestHeaders(model, credentials, body);
     const cookie = readLMArenaCookie(credentials);
 
     if (!cookie) {

--- a/open-sse/executors/qwen-web.ts
+++ b/open-sse/executors/qwen-web.ts
@@ -94,7 +94,7 @@ export class QwenWebExecutor extends BaseExecutor {
     super("qwen-web", { id: "qwen-web", baseUrl: BASE_URL });
   }
 
-  private buildHeaders(
+  private buildApiHeaders(
     token: string,
     cookieHeader: string,
     chatId?: string
@@ -139,7 +139,7 @@ export class QwenWebExecutor extends BaseExecutor {
     try {
       const newChatRes = await fetch(CHATS_NEW_URL, {
         method: "POST",
-        headers: this.buildHeaders(token, cookieHeader),
+        headers: this.buildApiHeaders(token, cookieHeader),
         body: JSON.stringify({
           title: "New Chat",
           models: [modelId],
@@ -186,7 +186,7 @@ export class QwenWebExecutor extends BaseExecutor {
     try {
       upstream = await fetch(completionUrl, {
         method: "POST",
-        headers: this.buildHeaders(token, cookieHeader, chatId),
+        headers: this.buildApiHeaders(token, cookieHeader, chatId),
         body: JSON.stringify(msgPayload),
         signal,
       });
@@ -251,7 +251,7 @@ export class QwenWebExecutor extends BaseExecutor {
         },
       }),
       url: completionUrl,
-      headers: this.buildHeaders(token, cookieHeader, chatId),
+      headers: this.buildApiHeaders(token, cookieHeader, chatId),
       transformedBody: msgPayload,
     };
   }

--- a/tests/unit/lmarena-provider.test.ts
+++ b/tests/unit/lmarena-provider.test.ts
@@ -30,7 +30,7 @@ const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 type LMArenaExecutorTestAccess = {
   provider: string;
   buildUrl: (model: string, credentials: unknown) => string;
-  buildHeaders: (model: string, credentials: unknown, body: unknown) => Record<string, string>;
+  buildRequestHeaders: (model: string, credentials: unknown, body: unknown) => Record<string, string>;
   transformRequest: (
     body: unknown,
     model: string,
@@ -133,7 +133,7 @@ describe("LMArena Executor", () => {
 
   it("builds headers with cookie", () => {
     const executor = new LMArenaExecutor();
-    const headers = access(executor).buildHeaders("gpt-4", { cookie: "session=abc123" }, {});
+    const headers = access(executor).buildRequestHeaders("gpt-4", { cookie: "session=abc123" }, {});
     assert.ok(headers.Cookie, "Should have Cookie header");
     assert.equal(headers.Cookie, "session=abc123");
     assert.equal(headers["Content-Type"], "application/json");
@@ -142,7 +142,7 @@ describe("LMArena Executor", () => {
 
   it("builds headers without cookie when not provided", () => {
     const executor = new LMArenaExecutor();
-    const headers = access(executor).buildHeaders("gpt-4", {}, {});
+    const headers = access(executor).buildRequestHeaders("gpt-4", {}, {});
     assert.ok(!headers.Cookie, "Should not have Cookie header when no cookie provided");
   });
 
@@ -151,19 +151,19 @@ describe("LMArena Executor", () => {
     const ex = access(executor);
 
     // Direct cookie field
-    let headers = ex.buildHeaders("gpt-4", { cookie: "session=abc" }, {});
+    let headers = ex.buildRequestHeaders("gpt-4", { cookie: "session=abc" }, {});
     assert.equal(headers.Cookie, "session=abc");
 
     // apiKey field (dashboard form)
-    headers = ex.buildHeaders("gpt-4", { apiKey: "session=def" }, {});
+    headers = ex.buildRequestHeaders("gpt-4", { apiKey: "session=def" }, {});
     assert.equal(headers.Cookie, "session=def");
 
     // providerSpecificData.cookie
-    headers = ex.buildHeaders("gpt-4", { providerSpecificData: { cookie: "session=ghi" } }, {});
+    headers = ex.buildRequestHeaders("gpt-4", { providerSpecificData: { cookie: "session=ghi" } }, {});
     assert.equal(headers.Cookie, "session=ghi");
 
     // Priority: direct > apiKey > providerSpecificData
-    headers = ex.buildHeaders("gpt-4", { cookie: "session=abc", apiKey: "session=def" }, {});
+    headers = ex.buildRequestHeaders("gpt-4", { cookie: "session=abc", apiKey: "session=def" }, {});
     assert.equal(headers.Cookie, "session=abc");
   });
 

--- a/tests/unit/lmarena-split-cookie-4271.test.ts
+++ b/tests/unit/lmarena-split-cookie-4271.test.ts
@@ -22,7 +22,7 @@ import { getWebSessionCredentialRequirement } from "../../src/shared/providers/w
 
 function cookieHeaderFor(credentials: unknown): string | undefined {
   const executor = new LMArenaExecutor();
-  const headers = (executor as any).buildHeaders("gpt-4", credentials, {});
+  const headers = (executor as any).buildRequestHeaders("gpt-4", credentials, {});
   return headers.Cookie;
 }
 

--- a/tests/unit/ts7-executor-override-signatures.test.ts
+++ b/tests/unit/ts7-executor-override-signatures.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Guards the executor override signatures fixed for TS 7 readiness.
+ *
+ * Three executors declared a *private/protected* `buildHeaders()` helper whose signature
+ * has nothing to do with `BaseExecutor.buildHeaders(credentials, stream?, clientHeaders?,
+ * model?, health?)`:
+ *
+ *   hailuo-web  (token: string, yy: string)
+ *   lmarena     (_model: string, credentials: unknown, _body: unknown)
+ *   qwen-web    (token: string, cookieHeader: string, chatId?: string)
+ *
+ * They were name collisions, not overrides — each shadowed the inherited member with an
+ * incompatible signature (TS2416). `BaseExecutor` calls `this.buildHeaders(credentials,
+ * false)` from `countTokens()`, so the shadow sat on a live dispatch path; it was never
+ * reached only because `buildCountTokensUrl()` returns null unless `config.format` is
+ * `"claude"`, and none of these three is. Latent rather than live — but one `format`
+ * change away from passing a credentials object where a token string was expected.
+ *
+ * The helpers are renamed, so these assertions pin both halves: the inherited method is
+ * no longer shadowed, and the early return that kept it harmless still holds.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { BaseExecutor } from "../../open-sse/executors/base.ts";
+import { HailuoWebExecutor } from "../../open-sse/executors/hailuo-web.ts";
+import { LMArenaExecutor } from "../../open-sse/executors/lmarena.ts";
+import { QwenWebExecutor } from "../../open-sse/executors/qwen-web.ts";
+
+const CASES = [
+  { name: "hailuo-web", make: () => new HailuoWebExecutor(), helper: "buildStreamHeaders" },
+  { name: "lmarena", make: () => new LMArenaExecutor(), helper: "buildRequestHeaders" },
+  { name: "qwen-web", make: () => new QwenWebExecutor(), helper: "buildApiHeaders" },
+];
+
+for (const { name, make, helper } of CASES) {
+  test(`${name}: buildHeaders resolves to BaseExecutor, not a local helper`, () => {
+    const executor = make() as unknown as Record<string, unknown>;
+
+    assert.equal(
+      executor.buildHeaders,
+      BaseExecutor.prototype.buildHeaders,
+      `${name} must not shadow BaseExecutor.buildHeaders — countTokens() dispatches through it`
+    );
+  });
+
+  test(`${name}: its own header helper is still present under the renamed key`, () => {
+    const executor = make() as unknown as Record<string, unknown>;
+
+    assert.equal(
+      typeof executor[helper],
+      "function",
+      `${name} should keep its provider-specific header builder as ${helper}()`
+    );
+    assert.notEqual(
+      executor[helper],
+      BaseExecutor.prototype.buildHeaders,
+      "the renamed helper must be the provider's own function, not the inherited one"
+    );
+  });
+
+  test(`${name}: countTokens() short-circuits before reaching buildHeaders`, async () => {
+    const executor = make();
+
+    // buildCountTokensUrl() returns null unless config.format === "claude" and the URL
+    // carries /messages. That early return is what kept the old shadow unreachable; if it
+    // ever changes, the inherited buildHeaders must be the one that runs.
+    const result = await executor.countTokens({
+      model: "whatever",
+      body: { messages: [] },
+      credentials: {},
+      signal: new AbortController().signal,
+      log: null,
+    });
+
+    assert.equal(result, null, `${name} does not support the Anthropic count_tokens endpoint`);
+  });
+}
+
+test("LMArenaExecutor does not narrow visibility of inherited members", () => {
+  // TS2415: a subclass may widen a member's visibility but never narrow it. `buildUrl` and
+  // `transformRequest` were `protected` here while public on BaseExecutor — masked behind
+  // the buildHeaders TS2416 until that cleared. Runtime has no visibility, so this asserts
+  // the members are reachable, which is what the type change encodes.
+  const executor = new LMArenaExecutor() as unknown as Record<string, unknown>;
+
+  for (const member of ["buildUrl", "transformRequest"]) {
+    assert.equal(typeof executor[member], "function", `${member} must stay callable`);
+  }
+});


### PR DESCRIPTION
Part of #8484. Type-only; no toolchain change.

## The collisions

`BaseExecutor.buildHeaders(credentials, stream?, clientHeaders?, model?, health?)` was shadowed in three executors by same-named helpers whose signatures have nothing to do with it:

| executor | declared as | signature |
| --- | --- | --- |
| `hailuo-web` | `private` | `(token: string, yy: string)` |
| `lmarena` | `protected` | `(_model: string, credentials: unknown, _body: unknown)` |
| `qwen-web` | `private` | `(token: string, cookieHeader: string, chatId?: string)` |

Name collisions, not overrides — each reported `TS2416`. Renamed to `buildStreamHeaders` / `buildRequestHeaders` / `buildApiHeaders`, with the two lmarena test files that call the helper directly updated alongside.

**Latent, not live — stating it precisely.** `BaseExecutor.countTokens()` calls `this.buildHeaders(credentials, false)` and all three inherit `countTokens()`, so the shadow sat on a real dispatch path. It is unreachable today only because `buildCountTokensUrl()` returns `null` unless `config.format === "claude"` **and** the URL carries `/messages`; hailuo-web and qwen-web set no format and lmarena sets `"openai"`, so `countTokens()` returns at the guard one line above. One `format` change away from passing a credentials object where a token string is expected — but not a bug today, and I'm not going to dress it up as one.

## Two more, surfaced by clearing the first

TypeScript reports these one at a time, so each fix revealed the next:

- **`lmarena` narrowed inherited visibility** — `buildUrl` and `transformRequest` were `protected` while both are public on `BaseExecutor` (`TS2415`: a subclass may widen visibility, never narrow it). Verified identical on the pristine base ref, so pre-existing and masked behind the `buildHeaders` error. Runtime is unaffected — JavaScript has no member visibility.

- **`GithubExecutor.refreshCredentials` had no declared return type**, so TypeScript inferred the union of its four literal returns. `GheCopilotExecutor` legitimately overrides it with a wider `providerSpecificData` (it also records the enterprise proxy URL) and no `expiresIn` — not assignable to that inferred union. Declared as `RefreshedCopilotCredentials | null`. Same shape of fix as #8489, different method.

## Validation

| | diagnostics |
| --- | --- |
| base | 335 |
| this PR | **331** |
| **new errors** | **0** (line-number-agnostic diff of the two error sets) |

The remaining two `TS2416` (`felo-web`, `gitlab` — both `execute`) are #8489's; untouched here.

| gate | result |
| --- | --- |
| `npm run typecheck:core` | clean |
| new `tests/unit/ts7-executor-override-signatures.test.ts` | 10/10 |
| 15 existing test files importing a touched executor | pass |

Two known base-red conditions, neither caused nor touched here: `plan3-p0.test.ts` (reads the developer's real `~/.omniroute` DB instead of a test-scoped `DATA_DIR`) and `npm run lint` (stale suppression count in `claude-to-openai-think-close-5123.test.ts`). Both are addressed in #8490.

## Tests

The renames are behavior-preserving, so the guard targets what actually changed — that the inherited method is no longer shadowed:

```
assert.equal(executor.buildHeaders, BaseExecutor.prototype.buildHeaders)
```

Verified to **fail on the base**, where all three prototypes still carry their own `buildHeaders`. The suite also pins that each provider keeps its own helper under the new name, and that the `countTokens()` early return which kept the shadow harmless still holds — so if that guard ever changes, the inherited method is the one that runs.

## Overlap note

This touches `open-sse/executors/github.ts`, as does #8489 — different methods (`execute` guard there, `refreshCredentials` signature here) in well-separated regions, so they should auto-merge. Flagging it in case you want a merge order.
