### PR TITLE
fix(providers): expose base-URL override for Kimi/Moonshot CN-region keys (#7447)

### DIFF
--- a/changelog.d/fixes/7447-kimi-cn-key-format.md
+++ b/changelog.d/fixes/7447-kimi-cn-key-format.md
@@ -1,0 +1,1 @@
+- fix(providers): expose a base-URL override for Kimi/Moonshot so CN-region API keys (issued on platform.kimi.com / moonshot.cn) can be pointed at api.moonshot.cn instead of being rejected by the international host (#7447)

--- a/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
@@ -223,6 +223,16 @@ export const CONFIGURABLE_BASE_URL_PROVIDERS = new Set([
   "searxng-search",
   "petals",
   "comfyui",
+  // #7447 — Moonshot/Kimi's international host (api.moonshot.ai) rejects
+  // CN-region keys (issued on platform.kimi.com/moonshot.cn — a separate
+  // account/keyspace). Neither "kimi" (legacy id) nor "moonshot" (current
+  // user-facing id) previously exposed a base-URL field at Add-connection
+  // time, so a CN-region user had no way to point a new connection at
+  // api.moonshot.cn. resolveBaseUrl()/buildUrl() already honor a
+  // providerSpecificData.baseUrl override generically — this only exposes
+  // the existing override affordance for these two ids.
+  "kimi",
+  "moonshot",
 ]);
 
 export const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
@@ -234,6 +244,11 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
   "searxng-search": "http://localhost:8888/search",
   petals: "https://chat.petals.dev/api/v1/generate",
   comfyui: "http://localhost:8188",
+  // #7447 — default stays the international host so existing/new
+  // international Kimi/Moonshot users see the same prefilled value as
+  // before; a CN-region user overrides it (see placeholder hint below).
+  kimi: "https://api.moonshot.ai/v1",
+  moonshot: "https://api.moonshot.ai/v1",
 };
 
 export function getLocalProviderMetadata(providerId?: string | null) {
@@ -327,6 +342,11 @@ export function getProviderBaseUrlPlaceholder(providerId?: string | null) {
       return "https://example-account.snowflakecomputing.com";
     case "searxng-search":
       return "http://localhost:8888/search";
+    case "kimi":
+    case "moonshot":
+      // #7447 — surfaces the CN-region alternative host as the placeholder
+      // example (mirrors the siliconflow.com/siliconflow.cn pattern above).
+      return "https://api.moonshot.cn/v1";
     default:
       return "";
   }

--- a/tests/unit/kimi-cn-region-baseurl.test.ts
+++ b/tests/unit/kimi-cn-region-baseurl.test.ts
@@ -1,0 +1,50 @@
+// #7447 — Kimi/Moonshot CN-region API keys were rejected because the built-in
+// "kimi"/"moonshot" registry entries are hard-coded to the international host
+// (api.moonshot.ai) and neither provider exposed a base-URL field at
+// Add-connection time, so a CN-region key (issued on platform.kimi.com /
+// moonshot.cn — a separate account/keyspace) had no supported way to point a
+// new connection at api.moonshot.cn. Fix: expose the existing generic
+// providerSpecificData.baseUrl override affordance for "kimi" and "moonshot"
+// via CONFIGURABLE_BASE_URL_PROVIDERS, defaulting to the unchanged
+// international host so existing users see no behavior change.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getRegistryEntry } from "../../open-sse/config/providerRegistry.ts";
+import {
+  isBaseUrlConfigurableProvider,
+  getProviderBaseUrlDefault,
+  getProviderBaseUrlPlaceholder,
+} from "../../src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts";
+
+test("kimi/moonshot registry entries still default to the international api.moonshot.ai host", () => {
+  const kimi = getRegistryEntry("kimi");
+  const moonshot = getRegistryEntry("moonshot");
+  assert.ok(kimi, "expected a registered 'kimi' provider entry");
+  assert.ok(moonshot, "expected a registered 'moonshot' provider entry");
+  assert.equal(kimi!.baseUrl, "https://api.moonshot.ai/v1/chat/completions");
+  assert.equal(moonshot!.baseUrl, "https://api.moonshot.ai/v1/chat/completions");
+});
+
+test("kimi and moonshot are base-URL configurable at Add-connection time (regression guard for #7447)", () => {
+  assert.equal(
+    isBaseUrlConfigurableProvider("kimi"),
+    true,
+    "expected 'kimi' to be base-URL configurable so a CN-region key can be pointed at api.moonshot.cn"
+  );
+  assert.equal(
+    isBaseUrlConfigurableProvider("moonshot"),
+    true,
+    "expected 'moonshot' to be base-URL configurable so a CN-region key can be pointed at api.moonshot.cn"
+  );
+});
+
+test("default base URL for kimi/moonshot stays international (no behavior change for existing users)", () => {
+  assert.equal(getProviderBaseUrlDefault("kimi"), "https://api.moonshot.ai/v1");
+  assert.equal(getProviderBaseUrlDefault("moonshot"), "https://api.moonshot.ai/v1");
+});
+
+test("placeholder surfaces the CN-region alternative host for kimi/moonshot", () => {
+  assert.equal(getProviderBaseUrlPlaceholder("kimi"), "https://api.moonshot.cn/v1");
+  assert.equal(getProviderBaseUrlPlaceholder("moonshot"), "https://api.moonshot.cn/v1");
+});


### PR DESCRIPTION
Closes #7447

## Root cause
CN-region Moonshot/Kimi API keys (issued on the domestic `platform.kimi.com`/`moonshot.cn` account) belong to a completely separate account/keyspace than the international `platform.kimi.ai`/`api.moonshot.ai` account. OmniRoute's built-in `kimi`/`moonshot` provider registry entries are hard-coded to `https://api.moonshot.ai/v1/chat/completions`, so a CN-region key gets a genuine upstream 401 from that host, which the UI renders as the generic "Invalid API key" message. It is not a key-format/regex check — there is no such validator anywhere in the path. The real gap is that neither `kimi` (legacy id) nor `moonshot` (current user-facing id, name "Kimi") was in `CONFIGURABLE_BASE_URL_PROVIDERS`, so the Add-connection modal never rendered a base-URL field for them, leaving a CN-region user with no supported way — not even manually — to point a new Kimi connection at `api.moonshot.cn`.

## Fix
Added `"kimi"` and `"moonshot"` to `CONFIGURABLE_BASE_URL_PROVIDERS` in `src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts`, with `DEFAULT_PROVIDER_BASE_URLS` defaulting to the unchanged international host (so existing/new international users see the exact same prefilled value as before) and a `getProviderBaseUrlPlaceholder` case surfacing `https://api.moonshot.cn/v1` as the CN-region example (mirrors the existing `siliconflow.com`/`siliconflow.cn` placeholder pattern). This is additive and minimal: it only exposes the `providerSpecificData.baseUrl` override affordance that `resolveBaseUrl()`/`buildUrl()` (used by both connection validation and live request execution) already honor generically for every provider — no change to registry entries, executors, or validator logic.

## Regression test (Hard Rule #18)
`tests/unit/kimi-cn-region-baseurl.test.ts` — RED before the fix, GREEN after.
```
RED (against origin/release/v3.8.49):
✖ kimi and moonshot are base-URL configurable at Add-connection time (regression guard for #7447)
  AssertionError: expected false to equal true (isBaseUrlConfigurableProvider("kimi"))
✖ default base URL for kimi/moonshot stays international (no behavior change for existing users)
  AssertionError: expected '' to equal 'https://api.moonshot.ai/v1'
✖ placeholder surfaces the CN-region alternative host for kimi/moonshot
  AssertionError: expected '' to equal 'https://api.moonshot.cn/v1'

GREEN (with the fix):
✔ kimi/moonshot registry entries still default to the international api.moonshot.ai host
✔ kimi and moonshot are base-URL configurable at Add-connection time (regression guard for #7447)
✔ default base URL for kimi/moonshot stays international (no behavior change for existing users)
✔ placeholder surfaces the CN-region alternative host for kimi/moonshot
tests 4, pass 4, fail 0
```

## Gates run
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean, no new warnings/errors
- `node scripts/check/check-file-size.mjs` — only the 5 documented pre-existing frozen-file overages (tokenHealthCheck.ts, chat.ts, auth.ts, accountFallback.ts, combo.ts), none of which this PR touches
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered by the Node native runner
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — both report the same "regression" (2169/2130 and 956/951 respectively) whether or not this PR's diff is applied — measured directly against `origin/release/v3.8.49` with and without the fix, byte-identical counts in both cases. This is pre-existing baseline drift on the release tip, not introduced by this PR.
- Existing tests in the touched area (`provider-page-helpers-3501`, `provider-connections-ui-regression`, `routing-settings-ux-6147`, `modal-credential-combine`, and 8 other files referencing `providerPageHelpers`) — all 69 tests pass unchanged, none encoded the old "kimi/moonshot not configurable" behavior