### PR TITLE
fix(cli): fall back to node:sqlite when better-sqlite3 is unavailable in omniroute doctor (#7586)

### DIFF
--- a/bin/cli/sqlite.mjs
+++ b/bin/cli/sqlite.mjs
@@ -5,13 +5,32 @@ import { ensureSettingsSchema, hashManagementPassword, updateSettings } from "./
 
 async function loadSqlite() {
   if (process.versions.bun) {
-    return (await import("bun:sqlite")).Database;
+    return { Database: (await import("bun:sqlite")).Database };
   }
   try {
-    return (await import("better-sqlite3")).default;
-  } catch {
-    throw new Error("better-sqlite3 is not installed. Run npm install before using setup.");
+    return { Database: (await import("better-sqlite3")).default };
+  } catch (error) {
+    return { error };
   }
+}
+
+// #7586: unlike the real server (src/lib/db/adapters/driverFactory.ts::tryOpenSync),
+// this CLI helper historically had NO fallback beyond better-sqlite3 — so on any
+// machine where better-sqlite3's native binary is unavailable (Windows without a
+// prebuilt addon, etc.), every `omniroute doctor` DB check reported a false FAIL
+// even when the actual server was healthy via its own (correct) driver cascade.
+// Reuse that same cascade here instead of re-deriving it.
+async function openWithSyncDriverFallback(dbPath, options, importError) {
+  try {
+    const { tryOpenSync } = await import("../../src/lib/db/adapters/driverFactory.ts");
+    const adapter = tryOpenSync(dbPath, options);
+    if (adapter) {
+      return adapter;
+    }
+  } catch {
+    // fall through to the original better-sqlite3 error below
+  }
+  throw createSqliteNativeError(importError);
 }
 
 function openBunSqlite(Database, dbPath, options) {
@@ -91,19 +110,25 @@ export function createSqliteNativeError(error) {
 }
 
 async function openSqliteDatabase(dbPath, options = {}) {
-  const Database = await loadSqlite();
+  const loaded = await loadSqlite();
   if (process.versions.bun) {
     if (options.fileMustExist && !fs.existsSync(dbPath)) {
       throw new Error(`SQLite file does not exist: ${dbPath}`);
     }
-    options = options.readonly
+    const bunOptions = options.readonly
       ? { readonly: true }
       : { readwrite: true, create: options.fileMustExist !== true };
+    try {
+      return openBunSqlite(loaded.Database, dbPath, bunOptions);
+    } catch (error) {
+      throw createSqliteNativeError(error);
+    }
+  }
+  if (loaded.error) {
+    return openWithSyncDriverFallback(dbPath, options, loaded.error);
   }
   try {
-    return process.versions.bun
-      ? openBunSqlite(Database, dbPath, options)
-      : new Database(dbPath, options);
+    return new loaded.Database(dbPath, options);
   } catch (error) {
     throw createSqliteNativeError(error);
   }

--- a/changelog.d/fixes/7586-windows-sqlite-launch.md
+++ b/changelog.d/fixes/7586-windows-sqlite-launch.md
@@ -1,0 +1,1 @@
+- fix(cli): fall back to the node:sqlite driver cascade in `bin/cli/sqlite.mjs` so `omniroute doctor` no longer reports a false "FAIL Database"/"FAIL Storage/encryption" on machines without a working better-sqlite3 native binary (#7586)

--- a/tests/unit/cli-sqlite-no-fallback-7586.test.ts
+++ b/tests/unit/cli-sqlite-no-fallback-7586.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+// #7586: `omniroute doctor`'s "Database" and "Storage/encryption" checks call
+// readDatabaseHealth()/readEncryptedCredentialSamples() from bin/cli/sqlite.mjs,
+// which — unlike the real server's driver cascade
+// (src/lib/db/adapters/driverFactory.ts::tryOpenSync, which tries
+// bun:sqlite -> better-sqlite3 -> node:sqlite) — used to have NO fallback beyond
+// better-sqlite3. On any machine where better-sqlite3's native binary is
+// unavailable (Windows without a prebuilt addon, per @jmaxdev's report), doctor
+// would ALWAYS report "FAIL Database" / "FAIL Storage/encryption" even when the
+// real server was perfectly healthy via its own resilient driver selection.
+//
+// This test simulates that exact machine by intercepting the ESM specifier
+// "better-sqlite3" (the one `bin/cli/sqlite.mjs::loadSqlite()` imports) so it
+// throws the same "Could not locate the bindings file" error jmax hit, then
+// proves readDatabaseHealth() still succeeds by falling back to node:sqlite.
+register(
+  "data:text/javascript," +
+    encodeURIComponent(`
+      export async function resolve(specifier, context, nextResolve) {
+        if (specifier === "better-sqlite3") {
+          return {
+            url:
+              "data:text/javascript," +
+              encodeURIComponent(
+                "throw new Error(" +
+                  JSON.stringify(
+                    "Could not locate the bindings file. Tried:\\n \\u2192 /fake/path/better_sqlite3.node"
+                  ) +
+                  ");"
+              ),
+            shortCircuit: true,
+          };
+        }
+        return nextResolve(specifier, context);
+      }
+    `),
+  import.meta.url
+);
+
+const { readDatabaseHealth } = await import("../../bin/cli/sqlite.mjs");
+
+test("#7586: readDatabaseHealth() falls back to node:sqlite when better-sqlite3 is unavailable", async (t) => {
+  const dbPath = path.join(os.tmpdir(), `cli-sqlite-no-fallback-7586-${Date.now()}.sqlite`);
+  t.after(() => {
+    try {
+      fs.unlinkSync(dbPath);
+    } catch {}
+  });
+
+  // Seed a normal, healthy DB using node:sqlite directly — simulating what the
+  // ACTUAL server (which DOES have a node:sqlite fallback) would have created
+  // on a machine without a better-sqlite3 native binary.
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(
+    "CREATE TABLE _omniroute_migrations (version TEXT PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT);" +
+      "INSERT INTO _omniroute_migrations (version, name, applied_at) VALUES ('001', 'initial_schema', datetime('now'));"
+  );
+  seed.close();
+
+  // Exercise the CLI helper's own health check — the exact function
+  // `omniroute doctor` calls (bin/cli/commands/doctor.mjs:checkDatabase ->
+  // readDatabaseHealth). Before the fix this threw "better-sqlite3 is not
+  // installed..." even though the DB is perfectly healthy.
+  const result = await readDatabaseHealth(dbPath);
+
+  assert.equal(
+    result.quickCheckValue,
+    "ok",
+    "readDatabaseHealth() should report a healthy DB via the node:sqlite fallback, " +
+      "not throw, when better-sqlite3 is unavailable (#7586)"
+  );
+  assert.equal(result.hasMigrationTable, true);
+  assert.deepEqual(result.appliedMigrationVersions, ["001"]);
+});


### PR DESCRIPTION
Closes #7586

## Root cause

`omniroute doctor`'s "Database" and "Storage/encryption" checks call `readDatabaseHealth()`/`readEncryptedCredentialSamples()` from `bin/cli/sqlite.mjs`, which — unlike the real server's driver cascade (`src/lib/db/adapters/driverFactory.ts::tryOpenSync`, which tries `bun:sqlite` -> `better-sqlite3` -> `node:sqlite`) — had NO fallback beyond `better-sqlite3`. On any machine where `better-sqlite3`'s native binary is unavailable (Windows without a prebuilt addon, per the reporter's diagnostics), `bin/cli/sqlite.mjs::loadSqlite()` threw immediately, so `omniroute doctor` always reported a false FAIL for both checks — even when the actual server was perfectly healthy via its own resilient driver selection.

Note: this issue also originally reported a real request-time 500 (a separate defect where a startup schema probe closed the process-wide sql.js singleton connection). That defect was already fixed upstream by PR #8153 (issue #7494) before this PR — this PR is scoped to the remaining, still-open defect: the CLI diagnostic path's missing fallback.

## Fix

`bin/cli/sqlite.mjs::openSqliteDatabase()` now falls back to `tryOpenSync()` (from `src/lib/db/adapters/driverFactory.ts`) whenever `better-sqlite3` fails to import — reusing the exact same already-tested driver cascade the real server uses, instead of re-deriving a second one. This makes `readDatabaseHealth()`, `readEncryptedCredentialSamples()`, `readManagementPasswordState()`, `resetManagementPassword()`, and every other CLI command that opens the DB (`providers.mjs`, `backup.mjs`, `auth-export.mjs`, `setup.mjs`, `keys.mjs`) correctly succeed via `node:sqlite` whenever the real server would too, eliminating the false-FAIL class entirely.

The Bun path and the "better-sqlite3 genuinely missing" translated error message (`createSqliteNativeError()`) are both preserved unchanged.

## Regression test (Hard Rule #18)

`tests/unit/cli-sqlite-no-fallback-7586.test.ts` — RED before the fix, GREEN after. The test intercepts the ESM specifier `"better-sqlite3"` (the one `loadSqlite()` imports) so it throws the exact "Could not locate the bindings file" error from the reporter's machine, then asserts `readDatabaseHealth()` succeeds against a real DB seeded with `node:sqlite` — simulating a machine identical to the reporter's.

RED (against unfixed `bin/cli/sqlite.mjs`, verified via a throwaway detached worktree on `origin/release/v3.8.49`):
```
✖ #7586: readDatabaseHealth() falls back to node:sqlite when better-sqlite3 is unavailable
  Error: better-sqlite3 is not installed. Run npm install before using setup.
      at loadSqlite (bin/cli/sqlite.mjs:13:11)
      at async openSqliteDatabase (bin/cli/sqlite.mjs:94:20)
      at async withReadonlySqlite (bin/cli/sqlite.mjs:127:14)
```

GREEN (after the fix):
```
✔ #7586: readDatabaseHealth() falls back to node:sqlite when better-sqlite3 is unavailable (1647.557615ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Gates run

- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json bin/cli/sqlite.mjs tests/unit/cli-sqlite-no-fallback-7586.test.ts` — 0 errors
- `node scripts/check/check-file-size.mjs` — no NEW ✗; only the 5 documented pre-existing base-red entries on `release/v3.8.49` (`tokenHealthCheck.ts`, `sse/handlers/chat.ts`, `sse/services/auth.ts`, `accountFallback.ts`, `combo.ts`) — none touched by this PR
- `node scripts/check/check-complexity.mjs` / `node scripts/check/check-cognitive-complexity.mjs` — both report the same total-violation count on the pure `origin/release/v3.8.49` tip (verified via a throwaway detached probe worktree) as on this branch (2169/2130 and 956/951 respectively); `bin/cli/sqlite.mjs` itself has **zero** complexity/cognitive findings from either config — the regression count is pre-existing repo-wide drift, not introduced by this diff
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered
- Existing tests of the touched area (`tests/unit/cli-sqlite-bindings-not-found-7868.test.ts`, `tests/unit/db-adapters/cliSqlite.test.mjs`, `tests/unit/sqlite-repair-discoverability-3476.test.ts`) — all still pass
- Manual smoke: `openOmniRouteDb()` on a machine WITH a working `better-sqlite3` still opens via the fast primary path unchanged (`typeof db.pragma === "function"`, `typeof db.prepare === "function"`)