### PR TITLE
fix(backend): compute AgentBridge diagnose DNS check per-agent instead of hard-coded Antigravity (#8466)

### DIFF
--- a/changelog.d/fixes/8466-agentbridge-dns-per-agent.md
+++ b/changelog.d/fixes/8466-agentbridge-dns-per-agent.md
@@ -1,0 +1,1 @@
+- fix(backend): compute AgentBridge diagnose `dnsConfigured` per-agent instead of hard-coded to Antigravity hosts (#8466)

--- a/src/app/api/tools/agent-bridge/diagnose/route.ts
+++ b/src/app/api/tools/agent-bridge/diagnose/route.ts
@@ -37,9 +37,10 @@ function probeTcp(port: number, host = "127.0.0.1", timeoutMs = 1500): Promise<b
   });
 }
 
-export async function GET(): Promise<Response> {
+export async function GET(request: Request): Promise<Response> {
   try {
-    const status = await getMitmStatus();
+    const agentId = new URL(request.url).searchParams.get("agentId") ?? undefined;
+    const status = await getMitmStatus(agentId);
     const certPath = path.join(resolveMitmDataDir(), "mitm", "server.crt");
     const certExists = fs.existsSync(certPath);
     const certTrusted = certExists ? await checkCertInstalled(certPath) : false;

--- a/src/mitm/dns/dnsConfig.ts
+++ b/src/mitm/dns/dnsConfig.ts
@@ -257,6 +257,19 @@ export function checkDNSEntry(): boolean {
 }
 
 /**
+ * Check whether ALL hosts for the given agent are present in /etc/hosts.
+ * Falls back to the Antigravity legacy hosts when `agentId` is omitted or
+ * unknown, via `resolveHostsForAgent()` — so callers get the same host set
+ * that `addDNSEntry`/`removeDNSEntry` already use for that agent. Used by
+ * `getMitmStatus()` to answer "are THIS agent's hosts spoofed?" instead of
+ * always checking the Antigravity-only set (#8466).
+ */
+export function checkDNSEntryForAgent(agentId?: string): boolean {
+  const hostsContent = readHostsFile();
+  return resolveHostsForAgent(agentId).every((h) => hasHostEntry(hostsContent, h));
+}
+
+/**
  * Add DNS entries for the Antigravity default hosts, or for a specific agent
  * when `agentId` is provided.
  * Delegates to `addDNSEntries` — backward compat wrapper.

--- a/src/mitm/manager.ts
+++ b/src/mitm/manager.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from "child_process";
 import path from "path";
 import fs from "fs";
 import { resolveMitmDataDir } from "./dataDir.ts";
-import { removeDNSEntry, removeDNSEntries } from "./dns/dnsConfig.ts";
+import { removeDNSEntry, removeDNSEntries, checkDNSEntryForAgent } from "./dns/dnsConfig.ts";
 import { provisionDnsEntries } from "./dns/provision.ts";
 import { generateCert } from "./cert/generate.ts";
 import { installCertResult, installCaCert } from "./cert/install.ts";
@@ -353,9 +353,16 @@ export async function handleExitCleanup(
 }
 
 /**
- * Get MITM status
+ * Get MITM status.
+ *
+ * @param agentId - Optional agent whose hosts should be checked in DNS. When
+ * omitted, preserves the legacy Antigravity-only check (unchanged behavior
+ * for the existing no-agentId call sites: state/route.ts, server/route.ts,
+ * settings/mitm/route.ts, cli-tools/antigravity-mitm/route.ts). When
+ * provided (e.g. by the diagnose route), checks that agent's own hosts
+ * instead of always checking the Antigravity host set (#8466).
  */
-export async function getMitmStatus(): Promise<{
+export async function getMitmStatus(agentId?: string): Promise<{
   running: boolean;
   pid: number | null;
   dnsConfigured: boolean;
@@ -387,11 +394,17 @@ export async function getMitmStatus(): Promise<{
     }
   }
 
-  // Check DNS configuration
+  // Check DNS configuration. When an agentId is provided, check THAT agent's
+  // own hosts (#8466) instead of always checking the Antigravity host set —
+  // callers that don't pass agentId keep the legacy Antigravity-only check.
   let dnsConfigured = false;
   try {
-    const hostsContent = fs.readFileSync("/etc/hosts", "utf-8");
-    dnsConfigured = /\bdaily-cloudcode-pa\.googleapis\.com\b/.test(hostsContent);
+    if (agentId) {
+      dnsConfigured = checkDNSEntryForAgent(agentId);
+    } else {
+      const hostsContent = fs.readFileSync("/etc/hosts", "utf-8");
+      dnsConfigured = /\bdaily-cloudcode-pa\.googleapis\.com\b/.test(hostsContent);
+    }
   } catch {
     // Ignore
   }

--- a/tests/unit/agent-bridge-dns-per-agent-8466.test.ts
+++ b/tests/unit/agent-bridge-dns-per-agent-8466.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for issue #8466: AgentBridge diagnostics `dnsConfigured`
+ * was hard-wired to the Antigravity host regex (src/mitm/manager.ts) instead
+ * of being computed per-agent via `resolveHostsForAgent(agentId)`
+ * (src/mitm/dns/dnsConfig.ts).
+ *
+ * We mock fs.readFileSync so the real /etc/hosts is never touched, then
+ * exercise getMitmStatus() -- the exact function named in the issue -- with
+ * hosts-file contents representing each failure direction, plus the
+ * diagnose route to prove the agentId query param is threaded through.
+ */
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+test("FALSE NEGATIVE: Claude Code host correctly spoofed, no Antigravity host present -> dnsConfigured should be true when checked for claude-code", async () => {
+  const realReadFileSync = fs.readFileSync.bind(fs);
+  mock.method(fs, "readFileSync", (p: string, enc?: BufferEncoding) => {
+    if (p === "/etc/hosts") {
+      // Claude Code target hosts = ["api.anthropic.com"] (src/mitm/targets/claudeCode.ts).
+      // The user correctly spoofed it. No Antigravity host present at all.
+      return "127.0.0.1 localhost\n127.0.0.1 api.anthropic.com\n::1 api.anthropic.com\n";
+    }
+    return realReadFileSync(p, enc);
+  });
+
+  const { getMitmStatus } = await import("../../src/mitm/manager.ts?probe=8466-negative");
+  const status = await getMitmStatus("claude-code");
+
+  assert.equal(
+    status.dnsConfigured,
+    true,
+    "dnsConfigured must be true when the agent being diagnosed (Claude Code) has its own host spoofed"
+  );
+});
+
+test("FALSE POSITIVE: only a leftover Antigravity host is present, Claude Code host is missing -> dnsConfigured should be false when checked for claude-code", async () => {
+  const realReadFileSync = fs.readFileSync.bind(fs);
+  mock.method(fs, "readFileSync", (p: string, enc?: BufferEncoding) => {
+    if (p === "/etc/hosts") {
+      // Leftover Antigravity entry from a previous setup. Claude Code's host
+      // (api.anthropic.com) is NOT present.
+      return "127.0.0.1 localhost\n127.0.0.1 daily-cloudcode-pa.googleapis.com\n";
+    }
+    return realReadFileSync(p, enc);
+  });
+
+  const { getMitmStatus } = await import("../../src/mitm/manager.ts?probe=8466-positive");
+  const status = await getMitmStatus("claude-code");
+
+  assert.equal(
+    status.dnsConfigured,
+    false,
+    "dnsConfigured must be false when the agent being diagnosed (Claude Code) has no host spoofed, even if a leftover Antigravity host is present"
+  );
+});
+
+test("no-agentId call sites keep legacy Antigravity-only behavior unchanged", async () => {
+  const realReadFileSync = fs.readFileSync.bind(fs);
+  mock.method(fs, "readFileSync", (p: string, enc?: BufferEncoding) => {
+    if (p === "/etc/hosts") {
+      // Claude Code host spoofed, but NO Antigravity host present. A caller
+      // that omits agentId (state/route.ts, server/route.ts, settings/mitm,
+      // cli-tools/antigravity-mitm) must still evaluate the legacy
+      // Antigravity-only regex, so this should remain false.
+      return "127.0.0.1 localhost\n127.0.0.1 api.anthropic.com\n::1 api.anthropic.com\n";
+    }
+    return realReadFileSync(p, enc);
+  });
+
+  const { getMitmStatus } = await import("../../src/mitm/manager.ts?probe=8466-legacy");
+  const status = await getMitmStatus();
+
+  assert.equal(
+    status.dnsConfigured,
+    false,
+    "callers that omit agentId must keep the legacy Antigravity-only check"
+  );
+});
+
+test("diagnose route: threads ?agentId= query param through to getMitmStatus", async () => {
+  const realReadFileSync = fs.readFileSync.bind(fs);
+  mock.method(fs, "readFileSync", (p: string, enc?: BufferEncoding) => {
+    if (p === "/etc/hosts") {
+      return "127.0.0.1 localhost\n127.0.0.1 api.anthropic.com\n::1 api.anthropic.com\n";
+    }
+    return realReadFileSync(p, enc);
+  });
+
+  const { GET } = await import(
+    "../../src/app/api/tools/agent-bridge/diagnose/route.ts?probe=8466-route"
+  );
+  const res = await GET(
+    new Request("http://localhost/api/tools/agent-bridge/diagnose?agentId=claude-code")
+  );
+  const body = (await res.json()) as {
+    checks: Array<{ name: string; ok: boolean }>;
+  };
+  const dnsCheck = body.checks.find((c) => c.name === "dns-configured");
+
+  assert.ok(dnsCheck, "expected a dns-configured check in the diagnostics report");
+  assert.equal(
+    dnsCheck?.ok,
+    true,
+    "diagnose route must pass agentId through to getMitmStatus so dns-configured reflects the diagnosed agent's hosts"
+  );
+});


### PR DESCRIPTION
Closes #8466

## Root cause
`getMitmStatus()` (`src/mitm/manager.ts:391-396`) computed `dnsConfigured` by reading `/etc/hosts` directly and matching a single literal Antigravity hostname regex (`daily-cloudcode-pa.googleapis.com`), regardless of which agent was actually being diagnosed. The diagnose route (`src/app/api/tools/agent-bridge/diagnose/route.ts`) called `getMitmStatus()` with no arguments and had no way to pass an `agentId`, even though `resolveHostsForAgent(agentId)` (`src/mitm/dns/dnsConfig.ts`) already existed and correctly resolves per-agent host sets — but its only callers were `addDNSEntry`/`removeDNSEntry` (setup/teardown), never the diagnostics path. Net effect: the diagnostics `dns-configured` check and overall `healthy` verdict answered "are Antigravity's hosts present?" for every agent, producing both false negatives (a correctly-spoofed non-Antigravity agent reported as unconfigured) and false positives (a stale Antigravity entry reported as healthy while the actual agent's host was missing).

## Fix
- `src/mitm/dns/dnsConfig.ts`: added `checkDNSEntryForAgent(agentId?)`, reusing the existing `readHostsFile()`/`hasHostEntry()` helpers and `resolveHostsForAgent()`'s per-target host resolution (falls back to the Antigravity hosts when `agentId` is omitted/unknown).
- `src/mitm/manager.ts`: `getMitmStatus()` now accepts an optional `agentId`. When provided, it delegates to `checkDNSEntryForAgent(agentId)`; when omitted, it keeps the exact legacy Antigravity-only regex check unchanged, so the other 4 existing no-agentId call sites (`state/route.ts`, `server/route.ts`, `settings/mitm/route.ts`, `cli-tools/antigravity-mitm/route.ts`) are unaffected.
- `src/app/api/tools/agent-bridge/diagnose/route.ts`: `GET` now accepts a `Request`, parses `?agentId=` (same pattern as `bypass/route.ts`), and passes it through to `getMitmStatus(agentId)`.

This is the minimal, backward-compatible fork from the plan-file: it does not touch `summarizeDiagnostics()`'s missing-hosts hint (out of scope for this fix) and does not remove the now-mostly-unused `checkDNSEntry()` legacy wrapper.

## Regression test (Hard Rule #18)
`tests/unit/agent-bridge-dns-per-agent-8466.test.ts` — RED before the fix, GREEN after (mocks `fs.readFileSync` so the real `/etc/hosts` is never touched).

RED (documented in the plan-file's proven repro, same assertions):
```
✖ FALSE NEGATIVE: Claude Code host correctly spoofed, no Antigravity host present -> dnsConfigured should be true but is false
  AssertionError [ERR_ASSERTION]: false !== true
✖ FALSE POSITIVE: only a leftover Antigravity host is present, Claude Code host is missing -> dnsConfigured should be false but is true
  AssertionError [ERR_ASSERTION]: true !== false
ℹ tests 2
ℹ pass 0
ℹ fail 2
```

GREEN (after the fix, all 4 assertions including the new no-agentId-unchanged and route-wiring cases):
```
✔ FALSE NEGATIVE: Claude Code host correctly spoofed, no Antigravity host present -> dnsConfigured should be true when checked for claude-code
✔ FALSE POSITIVE: only a leftover Antigravity host is present, Claude Code host is missing -> dnsConfigured should be false when checked for claude-code
✔ no-agentId call sites keep legacy Antigravity-only behavior unchanged
✔ diagnose route: threads ?agentId= query param through to getMitmStatus
ℹ tests 4
ℹ pass 4
ℹ fail 0
```

## Gates run
- `npm run typecheck:core` — exit 0, clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 findings
- `node scripts/check/check-file-size.mjs` — 5 violations, all pre-existing base-red on `release/v3.8.49` tip (`tokenHealthCheck.ts`, `chat.ts`, `auth.ts`, `accountFallback.ts`, `combo.ts`) — none introduced by this PR
- `node scripts/check/check-complexity.mjs` — 2169 > baseline 2130; discriminated against the pure `origin/release/v3.8.49` tip (measured in a throwaway detached worktree) which shows the **identical** 2169 > 2130 — pre-existing base-red, not introduced by this PR. The touched functions in this diff have 0 complexity findings via `eslint.complexity.config.mjs` (only pre-existing `startMitmInternal` at manager.ts:458 is flagged, unrelated to this change).
- `node scripts/check/check-cognitive-complexity.mjs` — 956 > baseline 951; same discrimination — the pure tip shows the identical 956 > 951, pre-existing base-red. `eslint.sonarjs.config.mjs` on the touched files shows only the same pre-existing `startMitmInternal` finding.
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered
- Existing regression suite for the touched area (all green): `tests/unit/agent-bridge-dns-sudo-gate.test.ts`, `tests/unit/agent-bridge-server-route-dynamic-import.test.ts`, `tests/unit/mitm-hosts-cleanup-on-exit.test.ts`, `tests/unit/mitm-sudo-gate-822.test.ts`, `tests/unit/mitm-diagnostics.test.ts`, `tests/unit/dns-config-generic.test.ts`, `tests/unit/mitm-manager-stub.test.ts`, `tests/unit/mitm-dnsConfig.test.ts`