### PR TITLE
fix(providers): repoint zai-web executor to chat.z.ai v2 chat-completions endpoint (#8014)

### DIFF
--- a/changelog.d/fixes/8014-zai-web-auth.md
+++ b/changelog.d/fixes/8014-zai-web-auth.md
@@ -1,0 +1,1 @@
+- fix(providers): repoint the zai-web executor at chat.z.ai's current v2 chat-completions endpoint, fixing model-independent 404s (#8014)

--- a/open-sse/executors/zai-web.ts
+++ b/open-sse/executors/zai-web.ts
@@ -9,7 +9,9 @@
  * modeled on the `chatglm-web` credential entry (#4056) and the `doubao-web` /
  * `venice-web` cookie executors.
  *
- * Endpoint: POST https://chat.z.ai/api/chat/completions
+ * Endpoint: POST https://chat.z.ai/api/v2/chat/completions
+ *           (the older unversioned `/api/chat/completions` path is stale and
+ *           404s model-independently as of 2026-07 — see #8014)
  * Auth:     full Cookie header from chat.z.ai (must contain the `token` JWT).
  *           Sent both as `Cookie` and as `Authorization: Bearer <token>` —
  *           the SPA's own fetch client sets both, and stripping either one
@@ -29,7 +31,7 @@ import {
 } from "../utils/error.ts";
 
 const BASE_URL = "https://chat.z.ai";
-const CHAT_URL = `${BASE_URL}/api/chat/completions`;
+const CHAT_URL = `${BASE_URL}/api/v2/chat/completions`;
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
 

--- a/tests/unit/executor-zai-web.test.ts
+++ b/tests/unit/executor-zai-web.test.ts
@@ -120,7 +120,7 @@ describe("ZaiWebExecutor", () => {
         signal: null,
       });
 
-      assert.equal(capturedUrl, "https://chat.z.ai/api/chat/completions");
+      assert.equal(capturedUrl, "https://chat.z.ai/api/v2/chat/completions");
       const headers = capturedInit?.headers as Record<string, string>;
       assert.equal(headers.Cookie, "token=abc123; foo=bar");
       assert.equal(headers.Authorization, "Bearer abc123");

--- a/tests/unit/zai-web-chat-endpoint-8014-probe.test.ts
+++ b/tests/unit/zai-web-chat-endpoint-8014-probe.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../../open-sse/executors/zai-web.ts");
+
+test("#8014 RED: ZaiWebExecutor must POST to the current chat.z.ai v2 chat-completions endpoint, not the stale unversioned path", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  globalThis.fetch = (async (url: string) => {
+    capturedUrl = String(url);
+    if (capturedUrl === "https://chat.z.ai/api/chat/completions") {
+      return new Response(JSON.stringify({ detail: "Not Found" }), { status: 404 });
+    }
+    return new Response("data: [DONE]\n\n", {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const executor = new mod.ZaiWebExecutor();
+    const result = await executor.execute({
+      model: "glm-4.6",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: false,
+      credentials: { apiKey: "token=abc123" },
+      signal: null,
+    });
+
+    assert.equal(
+      capturedUrl,
+      "https://chat.z.ai/api/v2/chat/completions",
+      `zai-web executor POSTed to a stale endpoint (${capturedUrl}) — matches #8014's model-independent 404 "Not Found"`
+    );
+    assert.notEqual(
+      result.response.status,
+      404,
+      "chat call must not 404 when the endpoint path is correct"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
Closes #8014

## Root cause
`open-sse/executors/zai-web.ts` hardcoded `CHAT_URL = ${BASE_URL}/api/chat/completions`, and posted every chat request there unconditionally. That unversioned path is stale — chat.z.ai's current consumer web-chat protocol serves chat completions at `/api/v2/chat/completions` instead. Because the endpoint itself no longer exists (not a per-model or auth problem), the 404 was model-independent, exactly matching the reporter's symptom (glm-4.6, glm-5.2, glm-4.7 all 404 the same way) while cookie validation and `/api/models` discovery (a different, still-live endpoint) succeeded. Confirmed against a maintained sibling implementation of the same chat.z.ai cookie-session protocol (`_references/_sistemas_proxys/Chat2API`), which uses `${ZAI_API_BASE}/api/v2/chat/completions`.

## Fix
Repointed `CHAT_URL` in `open-sse/executors/zai-web.ts` from `${BASE_URL}/api/chat/completions` to `${BASE_URL}/api/v2/chat/completions` — the minimal, locally-provable fix for the model-independent 404. No OAuth client_id/secret or Firebase key is involved (this executor uses a pasted browser Cookie/JWT, not an embedded public credential), so `resolvePublicCred()` does not apply here.

Scope note: the reference implementation also suggests the v2 flow may require a prior `POST /api/v1/chats/new` (chatId) and an `X-Signature` HMAC header. Those cannot be verified without a live chat.z.ai cookie session, so they are intentionally **not** included in this PR — keeping the diff surgical to what the regression test proves is broken, per Hard Rule #18. Filed as a documented follow-up rather than guessed at here.

## Regression test (Hard Rule #18)
`tests/unit/zai-web-chat-endpoint-8014-probe.test.ts` — RED before the fix, GREEN after. Also updated the pre-existing `tests/unit/executor-zai-web.test.ts` assertion that encoded the old stale endpoint URL.

RED (before):
```
✖ #8014 RED: ZaiWebExecutor must POST to the current chat.z.ai v2 chat-completions endpoint, not the stale unversioned path
  AssertionError [ERR_ASSERTION]: zai-web executor POSTed to a stale endpoint (https://chat.z.ai/api/chat/completions) — matches #8014's model-independent 404 "Not Found"
  + actual - expected
  + 'https://chat.z.ai/api/chat/completions'
  - 'https://chat.z.ai/api/v2/chat/completions'
```

GREEN (after):
```
✔ #8014 RED: ZaiWebExecutor must POST to the current chat.z.ai v2 chat-completions endpoint, not the stale unversioned path (15.029305ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

`tests/unit/executor-zai-web.test.ts` (full file, 16 tests): all pass after aligning the stale-endpoint assertion.

## Gates run
- `npm run typecheck:core` — clean (exit 0)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-file-size.mjs` — same 5 pre-existing ✗ as the documented base-red on release/v3.8.49 (tokenHealthCheck.ts, chat.ts, auth.ts, accountFallback.ts, combo.ts); nothing new
- `node scripts/check/check-complexity.mjs` — REGRESSÃO 2169>2130, confirmed identical on the pure origin/release/v3.8.49 tip (measured via a throwaway detached probe worktree) — pre-existing drift, not introduced by this PR
- `node scripts/check/check-cognitive-complexity.mjs` — REGRESSÃO 956>951, likewise confirmed identical on the pure tip — pre-existing drift, not introduced by this PR
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered
- `node --import tsx/esm --test tests/unit/executor-zai-web.test.ts tests/unit/zai-web-chat-endpoint-8014-probe.test.ts` — 17/17 pass