### PR TITLE
fix(sse): stop stream readiness from treating a choices-less error frame as success (#7503)

### DIFF
--- a/changelog.d/fixes/7503-empty-choices-stream-readiness.md
+++ b/changelog.d/fixes/7503-empty-choices-stream-readiness.md
@@ -1,0 +1,1 @@
+- fix(sse): stop stream readiness from treating a choices-less mid-stream error frame as a successful stream, so combo can fail over instead of returning zero `choices` (#7503)

--- a/open-sse/utils/streamReadiness.ts
+++ b/open-sse/utils/streamReadiness.ts
@@ -81,11 +81,40 @@ function getPayloadType(payload: unknown, eventType = ""): string {
   return typeof type === "string" ? type : eventType;
 }
 
+// Keys that indicate a frame carries (or is starting to carry) actual model
+// output — as opposed to a bare `{error:{...}}` frame with no output signal
+// at all. A stream that only ever emits error-only frames (e.g. a CLI
+// passthrough executor's mid-stream spawn failure, #7503) must NOT be
+// classified as "ready" — treating it as ready lets the malformed frame
+// reach the client as a fake 200 success and blocks combo fallback to the
+// next candidate.
+const CONTENT_BEARING_KEYS = [
+  "choices",
+  "candidates",
+  "content_block",
+  "delta",
+  "output",
+  "response",
+  "parts",
+  "tool_calls",
+  "tool_use",
+  "function_call",
+  "function_call_output",
+];
+
+function isErrorOnlyStructuredPayload(payload: Record<string, unknown>): boolean {
+  if (!("error" in payload)) return false;
+  return !CONTENT_BEARING_KEYS.some((key) => key in payload);
+}
+
 function hasNonPingStructuredPayload(payload: unknown, eventType = ""): boolean {
   const type = getPayloadType(payload, eventType);
   if (isPingEventType(eventType) || isPingEventType(type)) return false;
   if (Array.isArray(payload)) return payload.length > 0;
-  if (isRecord(payload)) return Object.keys(payload).length > 0;
+  if (isRecord(payload)) {
+    if (Object.keys(payload).length === 0) return false;
+    return !isErrorOnlyStructuredPayload(payload);
+  }
   return payload !== null && payload !== undefined;
 }
 

--- a/tests/unit/repro-7503-no-choices.test.ts
+++ b/tests/unit/repro-7503-no-choices.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { hasStreamReadinessSignal } = await import("@omniroute/open-sse/utils/streamReadiness");
+const { buildErrorBody } = await import("@omniroute/open-sse/utils/error");
+const { AuggieExecutor } = await import("@omniroute/open-sse/executors/auggie");
+
+test("hasStreamReadinessSignal wrongly reports readiness for a choices-less mid-stream error frame", () => {
+  const errorBody = buildErrorBody(502, "Auggie CLI not found: auggie.cmd");
+  assert.equal("choices" in errorBody, false, "sanity check: buildErrorBody() output really has no choices key");
+
+  const sse = `data: ${JSON.stringify(errorBody)}\n\ndata: [DONE]\n\n`;
+  const ready = hasStreamReadinessSignal(sse);
+
+  assert.equal(
+    ready,
+    false,
+    "a stream carrying only a choices-less error frame should NOT be reported as 'ready' " +
+      "(successful) — it gives the combo router no signal to fail over to the next candidate, " +
+      "and the client accumulates zero `choices` for the whole request, which is exactly what " +
+      "makes strict OpenAI-SDK clients (VS Code Copilot, Cline) throw 'Response contained no choices.'"
+  );
+});
+
+test("AuggieExecutor's real streaming error path emits an SSE body with zero populated `choices` (end-to-end)", async () => {
+  const executor = new AuggieExecutor();
+  const previousBin = process.env.AUGGIE_BIN;
+  process.env.AUGGIE_BIN = "/definitely/does/not/exist/auggie-xyz-7503";
+  try {
+    const { response } = await executor.execute({
+      model: "claude-sonnet-4.6",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: true,
+      credentials: {} as never,
+      signal: null,
+      log: { info: () => {}, debug: () => {}, warn: () => {} },
+    });
+
+    const text = await response.text();
+    const dataLines = text.split("\n").filter((l) => l.startsWith("data: "))
+      .map((l) => l.slice("data: ".length).trim()).filter((d) => d !== "[DONE]");
+    assert.ok(dataLines.length > 0, "expected at least one SSE data event");
+
+    const anyPopulatedChoices = dataLines.some((d) => {
+      const parsed = JSON.parse(d);
+      return Array.isArray(parsed.choices) && parsed.choices.length > 0 &&
+        (parsed.choices[0]?.delta?.content || parsed.choices[0]?.message?.content);
+    });
+
+    assert.equal(anyPopulatedChoices, false,
+      "AuggieExecutor's CLI-failure SSE stream never carries a populated `choices` entry — " +
+      "it is only a choices-less {error:...} frame + [DONE]");
+  } finally {
+    if (previousBin === undefined) delete process.env.AUGGIE_BIN;
+    else process.env.AUGGIE_BIN = previousBin;
+  }
+});


### PR DESCRIPTION
Refs #7503

## Root cause
When a mid-stream provider failure (e.g. the `auggie` CLI passthrough executor failing to spawn its local binary) emits an SSE `data: {"error":{...}}` frame with no `choices` key, OmniRoute's stream-readiness gate (`open-sse/utils/streamReadiness.ts`) classified that frame as a valid "ready" (successful) stream signal, because `hasNonPingStructuredPayload()` treated ANY non-empty JSON object — including a bare `{error:...}` frame — as readiness confirmation. This blocked combo fallback to the next candidate and let the malformed frame reach the client as a fake HTTP 200. OpenAI-SDK-based clients (VS Code Copilot, Cline) then throw a hard client-side error because they never received a single populated `choices` entry for the whole request — "Response contained no choices."

## Fix
`hasNonPingStructuredPayload()` now recognizes an error-only structured payload (has an `error` key, and none of the content-bearing keys — `choices`, `candidates`, `delta`, `tool_calls`, etc.) and does NOT treat it as a readiness signal. A stream that only ever emits such frames now falls through to the existing `STREAM_EARLY_EOF` / timeout failure paths, which combo already uses to fail over to the next candidate. Frames that legitimately carry both an `error` field and real content-bearing keys are unaffected.

## Regression test (Hard Rule #18)
`tests/unit/repro-7503-no-choices.test.ts` — RED before the fix, GREEN after.
```
RED:
✖ hasStreamReadinessSignal wrongly reports readiness for a choices-less mid-stream error frame (9.3ms)
  AssertionError [ERR_ASSERTION]: ... true !== false
✔ AuggieExecutor's real streaming error path emits an SSE body with zero populated `choices` (end-to-end) (156.3ms)
ℹ tests 2, pass 1, fail 1

GREEN:
✔ hasStreamReadinessSignal wrongly reports readiness for a choices-less mid-stream error frame (15.9ms)
✔ AuggieExecutor's real streaming error path emits an SSE body with zero populated `choices` (end-to-end) (176.9ms)
ℹ tests 2, pass 2, fail 0
```

## Gates run
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/utils/streamReadiness.ts tests/unit/repro-7503-no-choices.test.ts` — clean
- `node scripts/check/check-file-size.mjs` — same 5 pre-existing frozen violations as the pure `release/v3.8.49` tip (`tokenHealthCheck.ts`, `sse/handlers/chat.ts`, `sse/services/auth.ts`, `accountFallback.ts`, `combo.ts`); nothing new
- `node scripts/check/check-complexity.mjs` — reports 2169 > baseline 2130, but probed against a throwaway detached worktree of the pure `origin/release/v3.8.49` tip: identical violation set (only line numbers shift), so this is pre-existing drift, not introduced here
- `node scripts/check/check-cognitive-complexity.mjs` — same: 956 > baseline 951 reproduces identically on the pure tip in a throwaway probe worktree; not introduced by this PR
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered
- `node --import tsx/esm --test tests/unit/stream-readiness.test.ts tests/unit/combo-stream-readiness-fallback.test.ts tests/unit/stream-readiness-policy.test.ts tests/unit/runtime-timeouts.test.ts tests/unit/executor-kiro.test.ts tests/unit/auggie-executor.test.ts` — 90/90 pass, no regressions in the existing stream-readiness/combo-fallback/executor suites

---

> ⚠️ **Scope note (maintainer audit):** switched `Closes` → `Refs`. This PR fixes the proven `hasStreamReadinessSignal()` defect (a `choices`-less `{error:…}` SSE frame classified as a READY stream), which is the reported symptom's mechanism. It does **not** yet reconcile the `AUTO_COMBO_NOAUTH_ALLOWLIST` gate in `open-sse/services/autoCombo/virtualFactory.ts`, which the analysis flagged as a secondary lead to carry into the fix (the flat variant `auto/best-coding-fast` reaching `auggie`). #7503 stays open until that angle is closed out.