### PR TITLE
fix(ci): resync stale ESLint no-explicit-any suppression count (#8007)

### DIFF
--- a/changelog.d/fixes/8007-eslint-any-suppression-mismatch.md
+++ b/changelog.d/fixes/8007-eslint-any-suppression-mismatch.md
@@ -1,0 +1,1 @@
+- fix(ci): resync the stale ESLint `no-explicit-any` suppression count for `tests/unit/claude-to-openai-think-close-5123.test.ts` so the lint gate is release-green again (#8007)

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -890,11 +890,6 @@
       "count": 8
     }
   },
-  "tests/unit/claude-to-openai-think-close-5123.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
   "tests/unit/cli-a2a-invoke-commands.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 16

--- a/tests/unit/claude-to-openai-think-close-5123.test.ts
+++ b/tests/unit/claude-to-openai-think-close-5123.test.ts
@@ -29,6 +29,8 @@ function collectChunks(results: ReturnType<typeof claudeToOpenAIResponse>[]): un
   return results.flatMap((r) => (Array.isArray(r) ? r : r ? [r] : []));
 }
 
+type OpenAIChatChunk = { choices?: Array<{ delta?: { content?: string } }> };
+
 // ─── Case (a): thinking block followed by tool_use ───────────────────────────
 // This is the regression case. Before the fix, </think> appears as a spurious
 // assistant text chunk right before the tool_calls delta, corrupting clients.
@@ -95,7 +97,7 @@ test("thinking block followed by tool_use: </think> must NOT appear in any conte
   const chunks = collectChunks(allResults);
 
   const spuriousThinkClose = chunks.filter(
-    (chunk: any) => chunk?.choices?.[0]?.delta?.content === "</think>"
+    (chunk: OpenAIChatChunk) => chunk?.choices?.[0]?.delta?.content === "</think>"
   );
 
   assert.equal(
@@ -168,7 +170,7 @@ test("thinking block followed by text: </think> emitted when suppressThinkClose=
   const chunks = collectChunks(allResults);
 
   const hasThinkClose = chunks.some(
-    (chunk: any) => chunk?.choices?.[0]?.delta?.content === "</think>"
+    (chunk: OpenAIChatChunk) => chunk?.choices?.[0]?.delta?.content === "</think>"
   );
 
   assert.ok(
@@ -217,9 +219,11 @@ test("thinking block followed by text: </think> suppressed when suppressThinkClo
 
   const chunks = collectChunks(allResults);
   const hasThinkClose = chunks.some(
-    (chunk: any) => chunk?.choices?.[0]?.delta?.content === "</think>"
+    (chunk: OpenAIChatChunk) => chunk?.choices?.[0]?.delta?.content === "</think>"
   );
   assert.equal(hasThinkClose, false, "marker must not leak into content under #8245 default");
-  const hasText = chunks.some((chunk: any) => chunk?.choices?.[0]?.delta?.content === "Hello!");
+  const hasText = chunks.some(
+    (chunk: OpenAIChatChunk) => chunk?.choices?.[0]?.delta?.content === "Hello!"
+  );
   assert.ok(hasText, "assistant text must still be emitted");
 });


### PR DESCRIPTION
Closes #8007

## Root cause
PR #8309 (`fix(sse): suppress </think> by default on Chat Completions`, commit 14f4c67598) appended a third test case to `tests/unit/claude-to-openai-think-close-5123.test.ts` with 2 new `(chunk: any) =>` callbacks, on top of 2 pre-existing ones. Since `no-explicit-any` is an error in `tests/` (per #6218), the pre-existing 2 were frozen in `config/quality/eslint-suppressions.json` at `{"count": 2}`. PR #8309 did not update that entry. Because actual violations (4) no longer matched the frozen count (2), ESLint's suppression matching treated the whole file+rule entry as stale and unsuppressed ALL 4 occurrences, reporting them as hard errors and blocking the release-green lint gate.

## Fix
Replaced the 4 `(chunk: any) =>` callback parameter types with a minimal local `OpenAIChatChunk` type (`{ choices?: Array<{ delta?: { content?: string } }> }`), driving `no-explicit-any` violations in this file to 0. Then pruned the now-stale `{"count": 2}` suppression entry via `npx eslint ... --prune-suppressions` so the frozen budget doesn't silently re-permit future `any`s in this file. No production code touched.

## Regression test (Hard Rule #18)
`npx eslint tests/unit/claude-to-openai-think-close-5123.test.ts --format json --suppressions-location config/quality/eslint-suppressions.json --pass-on-unpruned-suppressions`

RED before the fix:
```
EXIT:1
tests/unit/claude-to-openai-think-close-5123.test.ts errorCount=4 warningCount=0
  98:13  @typescript-eslint/no-explicit-any
  171:13 @typescript-eslint/no-explicit-any
  220:13 @typescript-eslint/no-explicit-any
  223:39 @typescript-eslint/no-explicit-any
```

GREEN after the fix:
```
EXIT:0
tests/unit/claude-to-openai-think-close-5123.test.ts errorCount=0 warningCount=0
```

The 3 functional tests in the file also still pass under the actual test runner (`node --import tsx/esm --test tests/unit/claude-to-openai-think-close-5123.test.ts`) — 3/3 pass.

## Gates run
- `npm run typecheck:core` — clean (exit 0)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/claude-to-openai-think-close-5123.test.ts` — 0 errors, 0 warnings
- `node scripts/check/check-file-size.mjs` — only the 5 documented pre-existing frozen-file violations remain (`src/lib/tokenHealthCheck.ts`, `src/sse/handlers/chat.ts`, `src/sse/services/auth.ts`, `open-sse/services/accountFallback.ts`, `open-sse/services/combo.ts`), none touched by this PR
- `node scripts/check/check-complexity.mjs` — 2169 violations, matches the documented pre-existing baseline drift (2130→2169), not introduced by this PR (confirmed 0 errors in the touched file via a scoped complexity-config run)
- `node scripts/check/check-cognitive-complexity.mjs` — 956 violations, matches the documented pre-existing baseline drift (951→956), not introduced by this PR
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, 3812 test files discovered
- `node --import tsx/esm --test tests/unit/claude-to-openai-think-close-5123.test.ts` — 3/3 pass

The file-size, cyclomatic-complexity, and cognitive-complexity drift figures above are the pre-existing base-red on `release/v3.8.49` documented in the triage plan-file for #8007 — this PR does not touch, grow, or worsen any of them.