### PR TITLE
fix(api): probe provider alias in models.dev reverse capability lookup (#8429)

### DIFF
--- a/changelog.d/fixes/8429-capability-alias-canonicalization.md
+++ b/changelog.d/fixes/8429-capability-alias-canonicalization.md
@@ -1,0 +1,1 @@
+- fix(api): reach synced model_capabilities rows for canonical provider ids that only appear as an alias in MODELS_DEV_PROVIDER_MAP, e.g. codex/claude (#8429)

--- a/src/lib/modelCapabilities.ts
+++ b/src/lib/modelCapabilities.ts
@@ -281,9 +281,21 @@ function reverseModelsDevProviders(provider: string): string[] {
   // models.dev may store capabilities under a different OmniRoute provider id
   // that also maps from the same upstream models.dev provider. Build reverse
   // candidates from MODELS_DEV_PROVIDER_MAP (e.g. openai ↔ cx).
+  //
+  // MODELS_DEV_PROVIDER_MAP's RHS is inconsistent: most providers list their
+  // canonical id directly, but the OAuth CLI providers (codex/claude) only
+  // list their alias (cx/cc), never the canonical id. Also probe the
+  // provider's alias so a canonical id like "codex"/"claude" still matches
+  // the map entries keyed only by "cx"/"cc" (#8429).
   const out = new Set<string>();
+  const providerAlias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   for (const [modelsDevId, omniIds] of Object.entries(MODELS_DEV_PROVIDER_MAP)) {
-    if (omniIds.includes(provider) || modelsDevId === provider) {
+    if (
+      omniIds.includes(provider) ||
+      omniIds.includes(providerAlias) ||
+      modelsDevId === provider ||
+      modelsDevId === providerAlias
+    ) {
       out.add(modelsDevId);
       for (const id of omniIds) out.add(id);
     }

--- a/tests/unit/repro-8429-capability-canonicalization.test.ts
+++ b/tests/unit/repro-8429-capability-canonicalization.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-repro-8429-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const modelsDevSync = await import("../../src/lib/modelsDevSync.ts");
+const modelCapabilities = await import("../../src/lib/modelCapabilities.ts");
+
+function buildCapability(overrides: Record<string, unknown> = {}) {
+  return {
+    tool_call: null, reasoning: null, attachment: null, structured_output: null,
+    temperature: null, modalities_input: "[]", modalities_output: "[]",
+    knowledge_cutoff: null, release_date: null, last_updated: null, status: null,
+    family: null, open_weights: null, limit_context: null, limit_input: null,
+    limit_output: null, interleaved_field: null, ...overrides,
+  };
+}
+
+function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(() => { resetStorage(); });
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#8429: synced model_capabilities row written under models.dev mapping is unreachable via the canonical 'codex' provider id", () => {
+  modelsDevSync.saveModelsDevCapabilities({
+    openai: { "gpt-6-codex-preview": buildCapability({ tool_call: false }) },
+    cx: { "gpt-6-codex-preview": buildCapability({ tool_call: false }) },
+  });
+  const viaAlias = modelsDevSync.getSyncedCapability("cx", "gpt-6-codex-preview");
+  assert.equal(viaAlias?.tool_call, false, "row must exist under the alias 'cx'");
+
+  const resolved = modelCapabilities.getResolvedModelCapabilities({
+    provider: "codex",
+    model: "gpt-6-codex-preview",
+  });
+
+  assert.equal(
+    resolved.supportsTools,
+    false,
+    `expected synced tool_call=false to be resolved for provider "codex" (it was ${resolved.supportsTools})`
+  );
+});
+
+test("#8429: synced model_capabilities row is unreachable via the canonical 'claude' provider id (same class, alias 'cc')", () => {
+  modelsDevSync.saveModelsDevCapabilities({
+    anthropic: { "claude-preview-9-9": buildCapability({ tool_call: false }) },
+    cc: { "claude-preview-9-9": buildCapability({ tool_call: false }) },
+  });
+  const viaAlias = modelsDevSync.getSyncedCapability("cc", "claude-preview-9-9");
+  assert.equal(viaAlias?.tool_call, false, "row must exist under the alias 'cc'");
+
+  const resolved = modelCapabilities.getResolvedModelCapabilities({
+    provider: "claude",
+    model: "claude-preview-9-9",
+  });
+
+  assert.equal(
+    resolved.supportsTools,
+    false,
+    `expected synced tool_call=false to be resolved for provider "claude" (it was ${resolved.supportsTools})`
+  );
+});


### PR DESCRIPTION
Refs #8429

## Root cause
`reverseModelsDevProviders()` (`src/lib/modelCapabilities.ts`) builds the candidate provider ids to probe `model_capabilities` with by scanning `MODELS_DEV_PROVIDER_MAP` and matching only the CANONICAL OmniRoute provider id. But the map's RHS is inconsistent: for most providers the canonical id is listed directly (`deepseek: ["deepseek","if"]`, `cursor: ["cu","cursor"]`), but for the OAuth CLI providers `codex` (alias `cx`) and `claude` (alias `cc`) the map only lists the ALIAS on the RHS (`openai: ["openai","cx"]`, `anthropic: ["anthropic","cc"]`) — never the canonical id itself.

The models.dev sync job writes `model_capabilities` rows under `provider="openai"`/`"cx"` and `"anthropic"`/`"cc"` (never `"codex"`/`"claude"`). When the combo `auto` gate resolves a target with `modelStr = "codex/<model>"` or `"claude/<model>"`, the provider is canonicalized to `"codex"`/`"claude"` — and `reverseModelsDevProviders("codex")`/`("claude")` returns an empty candidate set, so the synced row that objectively exists in the DB under `"cx"`/`"cc"` is never found. `synced` resolves to `null` for every codex/claude target regardless of what the sync job actually wrote (tool_call, context limits, attachment support, structured_output, etc).

Note: for `toolCalling` specifically this gap is largely masked for codex/claude by static fallbacks (codex's registry sets `toolCalling: true` explicitly; claude's `MODEL_SPECS` sets `supportsTools: true`), so this fix alone may not fully explain the reporter's literal 13→4 tool-calling collapse — the `contextWindow`/`maxInputTokens` fields fed by the same unreachable `synced` object have much weaker fallbacks and are at least as plausible a driver via the "Context-aware fallback: kept X/Y" gate. Using `Refs` (not `Closes`) so the issue stays open until that angle is confirmed/ruled out with the reporter, per the plan-file's disposition guidance.

## Fix
In `reverseModelsDevProviders()`, also probe the provider's alias (via the already-imported `PROVIDER_ID_TO_ALIAS`) when scanning `MODELS_DEV_PROVIDER_MAP`, not just the canonical id. This is the minimal point-fix scoped exactly to the proven defect — no changes to the map itself or to any other resolution layer.

## Regression test (Hard Rule #18)
`tests/unit/repro-8429-capability-canonicalization.test.ts` — RED before the fix, GREEN after.

RED (unfixed `reverseModelsDevProviders`):
```
✖ #8429: synced model_capabilities row written under models.dev mapping is unreachable via the canonical 'codex' provider id
  AssertionError: expected synced tool_call=false to be resolved for provider "codex" (it was null)
✖ #8429: synced model_capabilities row is unreachable via the canonical 'claude' provider id (same class, alias 'cc')
  AssertionError: expected synced tool_call=false to be resolved for provider "claude" (it was null)
tests 2, pass 0, fail 2
```

GREEN (fixed):
```
✔ #8429: synced model_capabilities row written under models.dev mapping is unreachable via the canonical 'codex' provider id
✔ #8429: synced model_capabilities row is unreachable via the canonical 'claude' provider id (same class, alias 'cc')
tests 2, pass 2, fail 0
```

## Gates run
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/lib/modelCapabilities.ts tests/unit/repro-8429-capability-canonicalization.test.ts` — clean, 0 problems
- `node scripts/check/check-file-size.mjs` — only the 5 documented pre-existing base-red violations on `release/v3.8.49` (tokenHealthCheck.ts, chat.ts, auth.ts, accountFallback.ts, combo.ts); none of my files
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — both report the same violation counts (2169/2130, 956/951) on the pure `origin/release/v3.8.49` tip via a throwaway detached probe worktree, confirming this regression is pre-existing/base-red, not introduced by this diff
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file is runner-discovered
- `node --import tsx/esm --test tests/unit/repro-8429-capability-canonicalization.test.ts` — 2/2 pass
- Existing regression suite for the touched area: `tests/unit/model-capabilities-registry.test.ts`, `tests/unit/modelsDevSync.test.ts`, `tests/unit/opencode-zen-alias-combo-e2e.test.ts` (36/36 pass), plus the broader modelCapabilities-consuming suite (combo-vision-aware-routing, gpt-max-input-tokens-6191, guardrails/visionBridge, kimi/kiro/minimax/mimo/mistral/moonshot/xiaomi capability tests, model-capability-overrides, model-context-override-readpath, provider-models-context-window-override-4125, reasoning-replay-big-pickle, services-branch-hardening, [provider removed at its operator's request]-context-length-4184, translator-thinking-provider-compat-2043, vision-compression-authoritative-capability-7237, vision-detection-consistency) — 148/148 pass, no regressions