### PR TITLE
fix(translator): set status:completed on Responses input items to satisfy strict upstream validators (#8083)

### DIFF
--- a/changelog.d/fixes/8083-responses-input-items-status.md
+++ b/changelog.d/fixes/8083-responses-input-items-status.md
@@ -1,0 +1,1 @@
+- fix(translator): set `status: "completed"` on translated OpenAI Responses `input` items so strict Responses-compatible upstreams stop rejecting them with 400 MissingParameter input.status (#8083)

--- a/open-sse/translator/request/openai-responses/toResponses.ts
+++ b/open-sse/translator/request/openai-responses/toResponses.ts
@@ -120,6 +120,7 @@ export function openaiToOpenAIResponsesRequest(
         type: "message",
         role: "developer",
         content: buildResponsesTextParts(msg.content),
+        status: "completed",
       });
       continue;
     }
@@ -185,6 +186,7 @@ export function openaiToOpenAIResponsesRequest(
         type: "message",
         role: "user",
         content,
+        status: "completed",
       });
     }
 
@@ -223,6 +225,7 @@ export function openaiToOpenAIResponsesRequest(
           type: "message",
           role: "assistant",
           content: outputContent,
+          status: "completed",
         });
       }
 
@@ -241,6 +244,7 @@ export function openaiToOpenAIResponsesRequest(
             call_id: clampCallId(toString(toolCall.id).trim() || generateToolCallId()),
             name: fnName,
             arguments: toString(fn.arguments, "{}"),
+            status: "completed",
           });
         }
       }
@@ -255,6 +259,7 @@ export function openaiToOpenAIResponsesRequest(
             call_id: clampCallId(`call_${fnName}`),
             name: fnName,
             arguments: toString(fc.arguments, "{}"),
+            status: "completed",
           });
         }
       }
@@ -276,6 +281,7 @@ export function openaiToOpenAIResponsesRequest(
                   return c;
                 })
               : String(msg.content ?? ""),
+        status: "completed",
       });
     }
 
@@ -285,6 +291,7 @@ export function openaiToOpenAIResponsesRequest(
         type: "function_call_output",
         call_id: clampCallId(`call_${toString(msg.name)}`),
         output: typeof msg.content === "string" ? msg.content : String(msg.content ?? ""),
+        status: "completed",
       });
     }
   }

--- a/tests/unit/responses-input-item-status-8083.test.ts
+++ b/tests/unit/responses-input-item-status-8083.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Kept in its own file rather than growing the frozen
+// tests/unit/translator-openai-responses-req.test.ts (file-size ratchet).
+const { openaiToOpenAIResponsesRequest } = await import(
+  "../../open-sse/translator/request/openai-responses.ts"
+);
+
+// --- Issue #8083: strict Responses-compatible upstreams reject items whose
+// `type` is set without an accompanying `status`, returning
+// 400 MissingParameter input.status. `status` is optional per OpenAI's own
+// schema, so setting it to "completed" on translated history items (which by
+// construction always represent an already-completed prior turn) is a safe
+// superset fix that also satisfies stricter third-party validators.
+test("Chat -> Responses sets status:completed on every input item (#8083)", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-4o",
+    {
+      messages: [
+        { role: "system", content: "Rules" },
+        // Mid-conversation developer turn -> developer-role message item.
+        { role: "developer", content: "Follow up instruction" },
+        { role: "user", content: "Hello" },
+        {
+          role: "assistant",
+          content: "Done",
+          tool_calls: [
+            { id: "call_1", type: "function", function: { name: "read_file", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+        // Deprecated function_call / function role pair.
+        {
+          role: "assistant",
+          function_call: { name: "legacy_fn", arguments: "{}" },
+        },
+        { role: "function", name: "legacy_fn", content: "legacy ok" },
+      ],
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  const input = result.input as Array<Record<string, unknown>>;
+  assert.ok(input.length > 0, "input array must not be empty");
+  for (const item of input) {
+    assert.equal(
+      item.status,
+      "completed",
+      `input item of type "${item.type}" is missing status:"completed" — strict Responses-compatible ` +
+        `upstreams reject this with 400 MissingParameter input.status (#8083)`
+    );
+  }
+});

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -360,22 +360,26 @@ test("Chat -> Responses converts messages, tool calls, tool outputs, tools and p
         { type: "input_image", image_url: "https://example.com/cat.png", detail: "high" },
         { type: "input_file", file_data: "abc", filename: "doc.txt" },
       ],
+      status: "completed",
     },
     {
       type: "message",
       role: "assistant",
       content: [{ type: "output_text", text: "Done" }],
+      status: "completed",
     },
     {
       type: "function_call",
       call_id: "call_1",
       name: "read_file",
       arguments: '{"path":"/tmp/a"}',
+      status: "completed",
     },
     {
       type: "function_call_output",
       call_id: "call_1",
       output: [{ type: "input_text", text: "ok" }],
+      status: "completed",
     },
   ]);
   assert.deepEqual((result as any).tools, [
@@ -520,6 +524,7 @@ test("Chat -> Responses converts assistant image_url history parts to output_tex
         { type: "output_text", text: "I inspected the screenshot." },
         { type: "output_text", text: "[Image: https://example.com/scope.png]" },
       ],
+      status: "completed",
     },
   ]);
   assert.equal(JSON.stringify(result).includes('"image_url"'), false);


### PR DESCRIPTION
Closes #8083

## Root cause
`openaiToOpenAIResponsesRequest()` in `open-sse/translator/request/openai-responses/toResponses.ts` builds the Responses-API `input` array (message / function_call / function_call_output items) with an explicit `type` field but never sets `status` on any item. A user's opencode/reasonix client is routed through a custom `openai-compatible-<uuid>` provider connection whose `providerSpecificData.apiType` is `"responses"`, which routes the request through this exact translator. The upstream behind that custom connection validates strictly against the published Responses-API item schema and rejects items whose `type` is explicitly set without a `status`, returning `400 MissingParameter input.status`. `status` is documented OPTIONAL (not forbidden) in OpenAI's own Responses API type defs, so setting `status: "completed"` on translated history items (which by construction always represent an already-completed prior turn) is always valid for the real API and additionally satisfies stricter third-party validators.

## Fix
Add `status: "completed"` to every input item this translator constructs: the developer-role message push, the user message push, the assistant message push, each `function_call` push (both the `tool_calls` and the deprecated `function_call` paths), and the `function_call_output` push (both `role==="tool"` and the deprecated `role==="function"` paths). The reverse direction (`openaiResponsesToOpenAIRequest()` in `translator/response/openai-responses.ts`) already reads/ignores `status` correctly and was left untouched — this is a minimal, surgical fix scoped to exactly what the repro test proved was missing.

## Regression test (Hard Rule #18)
`tests/unit/responses-input-item-status-8083.test.ts` — RED before the fix, GREEN after. (Kept as its own file rather than growing the frozen `tests/unit/translator-openai-responses-req.test.ts`, whose two `deepEqual` assertions covering full `input` array shape were updated in place to include the new `status:"completed"` field.)

RED (before fix, via `git checkout -- open-sse/translator/request/openai-responses/toResponses.ts`):
```
✖ Chat -> Responses sets status:completed on every input item (#8083) (2.4ms)
  AssertionError [ERR_ASSERTION]: input item of type "message" is missing status:"completed" — strict Responses-compatible upstreams reject this with 400 MissingParameter input.status (#8083)
  + actual - expected
  + undefined
  - 'completed'
```

GREEN (after fix):
```
✔ Chat -> Responses sets status:completed on every input item (#8083) (9.1ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Gates run
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 problems
- `node scripts/check/check-file-size.mjs` — only the 5 documented pre-existing base-red violations on `release/v3.8.49` (`tokenHealthCheck.ts`, `chat.ts`, `auth.ts`, `accountFallback.ts`, `combo.ts`); no new violations from this PR (test file additions kept the frozen `translator-openai-responses-req.test.ts` within its baseline by moving the new regression test into its own file)
- `node scripts/check/check-complexity.mjs` / `node scripts/check/check-cognitive-complexity.mjs` — both report the same pre-existing regressed counts (2169>2130 cyclomatic, 956>951 cognitive) measured directly on a clean detached checkout of `origin/release/v3.8.49` with no changes applied — confirmed inherited base-red, not introduced by this PR
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered by the Node native test runner
- `node --import tsx/esm --test tests/unit/translator-openai-responses-req.test.ts tests/unit/responses-input-item-status-8083.test.ts` plus the full sweep of every test file in `tests/unit/` referencing `openaiToOpenAIResponsesRequest`/`toResponses` (empty-tool-name-loop, executor-codex-gpt56, headroom-responses-format, openai-responses-reasoning-effort, openai-responses-request-split, openai-responses-verbosity, orphaned-tool-filter, repro-7023, responses-translation-fixes, stream-helpers) — all green