### PR TITLE
fix(mitm): DNS status check uses all agent hosts instead of Antigravity-only

### DIFF
--- a/src/mitm/dns/dnsConfig.ts
+++ b/src/mitm/dns/dnsConfig.ts
@@ -244,7 +244,7 @@ export async function removeDNSEntries(
 }
 
 // ---------------------------------------------------------------------------
-// Legacy API — backward compat wrappers for manager.ts callers
+// DNS status helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -255,6 +255,21 @@ export function checkDNSEntry(): boolean {
   const hostsContent = readHostsFile();
   return ANTIGRAVITY_HOSTS.every((h) => hasHostEntry(hostsContent, h));
 }
+
+/**
+ * Check whether any registered MITM target has at least one host configured
+ * in the hosts file. Used by getMitmStatus() to report accurate DNS status
+ * for all agents, not just Antigravity.
+ */
+export function hasDNSConfiguredForAnyAgent(): boolean {
+  const hostsContent = readHostsFile();
+  if (!hostsContent) return false;
+  return ALL_TARGETS.some((t) => t.hosts.some((h) => hasHostEntry(hostsContent, h)));
+}
+
+// ---------------------------------------------------------------------------
+// Legacy API — backward compat wrappers for manager.ts callers
+// ---------------------------------------------------------------------------
 
 /**
  * Add DNS entries for the Antigravity default hosts, or for a specific agent

--- a/src/mitm/manager.ts
+++ b/src/mitm/manager.ts
@@ -2,7 +2,11 @@ import { spawn, type ChildProcess } from "child_process";
 import path from "path";
 import fs from "fs";
 import { resolveMitmDataDir } from "./dataDir.ts";
-import { removeDNSEntry, removeDNSEntries } from "./dns/dnsConfig.ts";
+import {
+  hasDNSConfiguredForAnyAgent,
+  removeDNSEntry,
+  removeDNSEntries,
+} from "./dns/dnsConfig.ts";
 import { provisionDnsEntries } from "./dns/provision.ts";
 import { generateCert } from "./cert/generate.ts";
 import { installCertResult, installCaCert } from "./cert/install.ts";
@@ -387,11 +391,10 @@ export async function getMitmStatus(): Promise<{
     }
   }
 
-  // Check DNS configuration
+  // Check DNS configuration — report true when any agent's hosts are present
   let dnsConfigured = false;
   try {
-    const hostsContent = fs.readFileSync("/etc/hosts", "utf-8");
-    dnsConfigured = /\bdaily-cloudcode-pa\.googleapis\.com\b/.test(hostsContent);
+    dnsConfigured = hasDNSConfiguredForAnyAgent();
   } catch {
     // Ignore
   }


### PR DESCRIPTION
Fixes #8466

## Problem

getMitmStatus() in src/mitm/manager.ts:394 was hard-coded to check for a single Antigravity host (daily-cloudcode-pa.googleapis.com) in /etc/hosts. Every non-Antigravity agent (Claude Code, Cursor, Copilot, Codex, Kiro, Zed, etc.) always reported dns-configured: false even when the user had correctly spoofed that agent's hosts.

Additionally, the hosts file path was hard-coded to /etc/hosts, ignoring the platform-aware resolver in dnsConfig.ts that handles Windows hosts files.

## Fix

- Added hasDNSConfiguredForAnyAgent() to src/mitm/dns/dnsConfig.ts — iterates ALL_TARGETS and returns true when any registered agent has at least one host entry present in the hosts file.
- Replaced the hard-coded Antigravity regex in getMitmStatus() with a call to the new helper.
- The new helper uses the existing platform-aware readHostsFile() / hasHostEntry() from dnsConfig.ts, fixing the Windows hosts file path issue as a bonus.

The legacy checkDNSEntry() function is preserved unchanged for backward compatibility.