### PR TITLE
fix(cli): backup create/auto enable — remove option-shadowing legacy fallback

### DIFF
--- a/bin/cli/commands/backup.mjs
+++ b/bin/cli/commands/backup.mjs
@@ -78,18 +78,15 @@ export function registerBackup(program) {
       if (exitCode !== 0) process.exit(exitCode);
     });
 
-  // Legacy: `omniroute backup` without subcommand still creates a backup
+  // Legacy: `omniroute backup` without a subcommand still creates a backup
+  // (documented as the canonical usage in USER_GUIDE.md / CLI-TOOLS.md /
+  // AGENT-SKILLS.md). No flags are declared here — declaring the same
+  // option names as `create`/`auto enable` here previously shadowed them
+  // (#8512), and no doc shows `omniroute backup` invoked with flags.
   backup.action(async (opts) => {
     const exitCode = await runBackupCommand(opts);
     if (exitCode !== 0) process.exit(exitCode);
   });
-  backup
-    .option("--name <name>", t("backup.nameOpt"))
-    .option("--cloud", t("backup.cloudOpt"))
-    .option("--encrypt", t("backup.encryptOpt"))
-    .option("--key-file <path>", t("backup.keyFileOpt"))
-    .option("--exclude <pattern>", t("backup.excludeOpt"), (v, prev = []) => [...prev, v], [])
-    .option("--retention <n>", t("backup.retentionOpt"), parseInt);
 }
 
 export function registerRestore(program) {

--- a/changelog.d/fixes/8512-backup-option-shadowing.md
+++ b/changelog.d/fixes/8512-backup-option-shadowing.md
@@ -1,0 +1,1 @@
+- fix(cli): `backup create` / `backup auto enable` — option shadowing by the parent `backup` command removed; all flags (`--cloud`, `--encrypt`, `--retention`, `--name`, `--exclude`, `--key-file`) now reach the subcommand handler with their actual values instead of being silently discarded

--- a/tests/unit/cli-expanded-commands.test.ts
+++ b/tests/unit/cli-expanded-commands.test.ts
@@ -82,6 +82,117 @@ test("backup auto status sem arquivo retorna 0", async () => {
   }
 });
 
+// Regressão #8512: `backup` re-declara os mesmos nomes de opção que `create`/
+// `auto enable` no fallback legacy ("omniroute backup" sem subcomando) — o
+// Commander resolve a opção no ancestral mais próximo que a declara, então o
+// valor do subcomando é descartado silenciosamente e substituído pelo default
+// da própria opção do subcomando (null/false/[]).
+test("backup auto enable — nenhuma opção é sombreada pelo parent backup", async () => {
+  const { registerBackup } = await import("../../bin/cli/commands/backup.mjs");
+  const { Command } = await import("commander");
+  const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const dataDir = mkdtempSync(join(tmpdir(), "omniroute-backup-test-"));
+  const origDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = dataDir;
+  try {
+    const prog = new Command().exitOverride();
+    registerBackup(prog);
+    await prog.parseAsync(
+      [
+        "node",
+        "x",
+        "backup",
+        "auto",
+        "enable",
+        "--cron",
+        "0 4 * * *",
+        "--cloud",
+        "--encrypt",
+        "--retention",
+        "7",
+      ],
+      { from: "node" }
+    );
+    const schedule = JSON.parse(readFileSync(join(dataDir, "backup-schedule.json"), "utf8"));
+    assert.equal(schedule.cron, "0 4 * * *");
+    assert.equal(schedule.cloud, true, "--cloud não deve ser sombreado pelo parent backup");
+    assert.equal(schedule.encrypt, true, "--encrypt não deve ser sombreado pelo parent backup");
+    assert.equal(schedule.retention, 7, "--retention não deve ser sombreado pelo parent backup");
+  } finally {
+    if (origDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = origDataDir;
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("backup create — nenhuma opção é sombreada pelo parent backup", async () => {
+  const { registerBackup } = await import("../../bin/cli/commands/backup.mjs");
+  const { Command } = await import("commander");
+  const prog = new Command().exitOverride();
+  registerBackup(prog);
+  const backupCmd = prog.commands.find((c) => c.name() === "backup");
+  const createCmd = backupCmd.commands.find((c) => c.name() === "create");
+  let capturedOpts = null;
+  createCmd.action((opts) => {
+    capturedOpts = opts;
+  });
+  await prog.parseAsync(
+    [
+      "node",
+      "x",
+      "backup",
+      "create",
+      "--name",
+      "foo",
+      "--cloud",
+      "--encrypt",
+      "--retention",
+      "7",
+      "--exclude",
+      "*.log",
+    ],
+    { from: "node" }
+  );
+  assert.ok(capturedOpts, "action deve ter sido chamada");
+  assert.equal(capturedOpts.name, "foo", "--name não deve ser sombreado");
+  assert.equal(capturedOpts.cloud, true, "--cloud não deve ser sombreado");
+  assert.equal(capturedOpts.encrypt, true, "--encrypt não deve ser sombreado");
+  assert.equal(capturedOpts.retention, 7, "--retention não deve ser sombreado");
+  assert.deepEqual(capturedOpts.exclude, ["*.log"], "--exclude não deve ser sombreado");
+});
+
+// Regressão de documentação: `omniroute backup` sem subcomando é o uso
+// canônico documentado em USER_GUIDE.md / CLI-TOOLS.md / AGENT-SKILLS.md
+// ("omniroute backup # Snapshot config + DB"). Remover só as opções
+// duplicadas do parent (causa real do #8512) não pode remover essa ação.
+test("backup — sem subcomando ainda cria um backup (uso legado documentado)", async () => {
+  const { registerBackup } = await import("../../bin/cli/commands/backup.mjs");
+  const { Command } = await import("commander");
+  const { mkdtempSync, existsSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const dataDir = mkdtempSync(join(tmpdir(), "omniroute-backup-bare-test-"));
+  const origDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = dataDir;
+  try {
+    const prog = new Command().exitOverride();
+    registerBackup(prog);
+    await prog.parseAsync(["node", "x", "backup"], { from: "node" });
+    assert.ok(
+      existsSync(join(dataDir, "backups")),
+      "omniroute backup deve criar o diretório de backups"
+    );
+  } finally {
+    if (origDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = origDataDir;
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("tunnel — registerTunnel registra list/create/stop/status/logs/info/rotate", async () => {
   const { registerTunnel } = await import("../../bin/cli/commands/tunnel.mjs");
   const { Command } = await import("commander");


### PR DESCRIPTION
Closes #8512

## Root cause

`bin/cli/commands/backup.mjs` (pre-fix) declared options on the parent `backup` command in a "legacy: omniroute backup without subcommand" fallback. Commander resolves a CLI option at the **nearest ancestor that declares it** rather than at the deepest subcommand — so every flag shared between the parent and its children `create` and `auto enable` was intercepted by the parent and replaced by the child's own default (null/false/[]). Only `--cron` survived because it was the one option not duplicated on the parent.

Verified with an isolated Commander-only reproducer:

```ts
import { Command } from "commander";
const program = new Command().exitOverride();
const backup = program.command("backup");
const auto = backup.command("auto");
auto.command("enable")
  .option("--cron <expr>", "cron", "0 3 * * *")
  .option("--cloud", "cloud")
  .option("--encrypt", "encrypt")
  .option("--retention <n>", "retention", parseInt)
  .action((opts) => console.log(opts));
backup
  .option("--cloud", "cloud")
  .option("--encrypt", "encrypt")
  .option("--retention <n>", "retention", parseInt);
await program.parseAsync(["node","x","backup","auto","enable","--cloud","--encrypt","--retention","7"]);
// → { cron: '0 3 * * *' }  ← --cloud, --encrypt, --retention lost
```

## Fix

Removed only the option declarations from the parent `backup` command (the 6 `.option(...)` lines that duplicated the children's flags). The bare action handler `backup.action(...)` is preserved — `omniroute backup` (no subcommand, matching the documented usage in `docs/guides/USER_GUIDE.md`, `docs/reference/CLI-TOOLS.md`, `docs/frameworks/AGENT-SKILLS.md` and translations) still creates a backup.

No other command in `bin/cli/commands/*.mjs` re-declares a child's options on its parent (verified by grep across all 14 files) — this is the only instance of the pattern.

## TDD

RED before fix:

```
✖ backup auto enable — nenhuma opção é sombreada pelo parent backup
  AssertionError [ERR_ASSERTION]: --cloud não deve ser sombreado pelo parent backup
  + expected - actual
  - false
  + true
✖ backup create — nenhuma opção é sombreada pelo parent backup
  AssertionError [ERR_ASSERTION]: --name não deve ser sombreado
  + expected - actual
  - undefined
  + 'foo'
```

GREEN after fix, plus a third regression test (`backup — sem subcomando ainda cria um backup`) asserting `omniroute backup` still works bare. 22/22 suite-wide.

## Gates run

- `node --import tsx/esm --test tests/unit/cli-expanded-commands.test.ts` — 22/22, exit 0
- `npx vitest run --config vitest.mcp.config.ts` — 274/274, exit 0
- `npm run lint` — exit 0
- `npm run typecheck:core` — exit 0
- Pre-commit hooks: prettier, eslint, any-budget, docs-sync, tracked-artifacts — passed

## Changelog

`changelog.d/fixes/8512-backup-option-shadowing.md` (fragment)