### PR TITLE
refactor(sse): restore three executor types the runtime already relied on

### DIFF
--- a/open-sse/executors/mimocode.ts
+++ b/open-sse/executors/mimocode.ts
@@ -100,6 +100,12 @@ interface AccountState {
   expiresAt: number;
   cooldownUntil: number;
   consecutiveFails: number;
+  /**
+   * #3837/#5521: the account's resolved proxy, or `null` when none is configured.
+   * Always present (never `undefined`) so callers can read `acct.proxy` directly —
+   * syncAccountsFromCredentials() writes it on every account on every sync.
+   */
+  proxy: AccountProxyConfig["proxy"];
 }
 
 function parseJwtExp(jwt: string): number {

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -338,13 +338,11 @@ export class OpencodeExecutor extends BaseExecutor {
     ) {
       delete (modifiedBody as Record<string, unknown>).client_metadata;
     }
-    if (
-      modifiedBody &&
-      typeof modifiedBody === "object" &&
-      Array.isArray(modifiedBody.tools) &&
-      modifiedBody.tools.length > 128
-    ) {
-      modifiedBody.tools = modifiedBody.tools.slice(0, 128);
+    if (modifiedBody && typeof modifiedBody === "object" && !Array.isArray(modifiedBody)) {
+      const mb = modifiedBody as Record<string, unknown>;
+      if (Array.isArray(mb.tools) && mb.tools.length > 128) {
+        mb.tools = mb.tools.slice(0, 128);
+      }
     }
     if (modifiedBody && typeof modifiedBody === "object" && !Array.isArray(modifiedBody)) {
       const mb = modifiedBody as Record<string, unknown>;

--- a/open-sse/executors/zed-hosted.ts
+++ b/open-sse/executors/zed-hosted.ts
@@ -117,8 +117,18 @@ function createErrorChunk(model: string, message: string): Record<string, unknow
   };
 }
 
+/**
+ * The single controller capability these SSE helpers use. They only ever enqueue —
+ * never `close()`, never read `desiredSize` — so typing them by that one method lets
+ * the same code serve both stream kinds. The wider
+ * `ReadableStreamDefaultController` annotation rejected every call site, because the
+ * helpers are driven from a TransformStream and `TransformStreamDefaultController`
+ * has no `close()`.
+ */
+type SseEnqueueTarget = Pick<ReadableStreamDefaultController<Uint8Array>, "enqueue">;
+
 function enqueueSseObject(
-  controller: ReadableStreamDefaultController<Uint8Array>,
+  controller: SseEnqueueTarget,
   encoder: TextEncoder,
   chunk: unknown
 ): void {
@@ -202,7 +212,7 @@ function wrapZedCompletionStream(
   let buffer = "";
   let done = false;
 
-  const finish = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+  const finish = (controller: SseEnqueueTarget) => {
     if (done) return;
     const finalChunk = convertProviderEvent(provider, null, state);
     enqueueSseObject(controller, encoder, finalChunk);
@@ -210,7 +220,7 @@ function wrapZedCompletionStream(
     done = true;
   };
 
-  const processLine = (line: string, controller: ReadableStreamDefaultController<Uint8Array>) => {
+  const processLine = (line: string, controller: SseEnqueueTarget) => {
     if (done) return;
     const payload = unwrapZedLine(line);
     if (!payload) return;

--- a/tests/unit/ts7-executor-shared-shapes.test.ts
+++ b/tests/unit/ts7-executor-shared-shapes.test.ts
@@ -1,0 +1,145 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { OpencodeExecutor } = await import("../../open-sse/executors/opencode.ts");
+const { MimocodeExecutor } = await import("../../open-sse/executors/mimocode.ts");
+
+/**
+ * Behavioral guards for the three type-only fixes in the TS 7 executor slice
+ * (see #8484). Each fix restored a type the code already depended on at runtime;
+ * these tests pin the runtime contracts so a future "simplification" of the
+ * annotations cannot silently change behavior.
+ *
+ * The zed-hosted `SseEnqueueTarget` fix is already covered end-to-end by
+ * `zed-hosted-think-close-marker.test.ts`, which drives the same TransformStream
+ * that failed to type-check — no duplicate added here.
+ */
+
+describe("OpencodeExecutor — tools truncation survives the narrowing fix", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const CREDENTIALS = { apiKey: "k" } as Record<string, unknown>;
+
+  const tools = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      type: "function",
+      function: { name: `tool_${i}`, parameters: {} },
+    }));
+
+  function bodyWith(toolCount: number) {
+    return {
+      model: "oc/kimi-k2.6",
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+      tools: tools(toolCount),
+    };
+  }
+
+  it("truncates an over-long tools array to 128 entries", () => {
+    const out = executor.transformRequest("oc/kimi-k2.6", bodyWith(200), true, CREDENTIALS) as {
+      tools: unknown[];
+    };
+    assert.equal(out.tools.length, 128, "upstream rejects more than 128 tools");
+    assert.deepEqual(
+      (out.tools[127] as { function: { name: string } }).function.name,
+      "tool_127",
+      "truncation keeps the first 128 in order, not an arbitrary slice"
+    );
+  });
+
+  it("leaves a within-limit tools array untouched", () => {
+    const out = executor.transformRequest("oc/kimi-k2.6", bodyWith(10), true, CREDENTIALS) as {
+      tools: unknown[];
+    };
+    assert.equal(out.tools.length, 10);
+  });
+
+  it("is a no-op when the body carries no tools", () => {
+    const body = {
+      model: "oc/kimi-k2.6",
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const out = executor.transformRequest("oc/kimi-k2.6", body, true, CREDENTIALS) as Record<
+      string,
+      unknown
+    >;
+    assert.equal("tools" in out, false);
+    assert.ok(Array.isArray(out.messages), "messages preserved");
+  });
+
+  it("leaves an array-shaped body alone (pins the !Array.isArray guard)", () => {
+    // The pre-fix condition reached `.tools` on any object, arrays included, and
+    // relied on `Array.isArray(undefined)` short-circuiting. The explicit
+    // !Array.isArray() guard must keep that outcome identical.
+    const arrayBody = [{ role: "user", content: "hi" }] as unknown as Record<string, unknown>;
+    const out = executor.transformRequest("oc/kimi-k2.6", arrayBody, true, CREDENTIALS);
+    assert.ok(Array.isArray(out), "array body must pass through as an array");
+    assert.equal((out as unknown[]).length, 1);
+  });
+});
+
+describe("MimocodeExecutor — AccountState.proxy is always present (#3837/#5521)", () => {
+  const FP = "fingerprint-1";
+
+  function accountsOf(exec: unknown): Array<Record<string, unknown>> {
+    return (exec as { accounts: Array<Record<string, unknown>> }).accounts;
+  }
+
+  function sync(exec: unknown, credentials: unknown): void {
+    (exec as { syncAccountsFromCredentials(c: unknown): void }).syncAccountsFromCredentials(
+      credentials
+    );
+  }
+
+  it("defaults proxy to null — not undefined — when no accountProxies are configured", () => {
+    const exec = new MimocodeExecutor();
+    accountsOf(exec).length = 0;
+    accountsOf(exec).push({
+      fingerprint: FP,
+      jwt: "",
+      expiresAt: 0,
+      cooldownUntil: 0,
+      consecutiveFails: 0,
+    });
+
+    sync(exec, { providerSpecificData: {} });
+
+    const account = accountsOf(exec)[0];
+    assert.ok("proxy" in account, "every account must expose a proxy key");
+    assert.equal(account.proxy, null, "unconfigured proxy is null, never undefined");
+  });
+
+  it("resolves a configured proxy onto the matching account", () => {
+    const exec = new MimocodeExecutor();
+    accountsOf(exec).length = 0;
+    accountsOf(exec).push({
+      fingerprint: FP,
+      jwt: "",
+      expiresAt: 0,
+      cooldownUntil: 0,
+      consecutiveFails: 0,
+    });
+
+    const proxy = { type: "http", host: "p1.example.com", port: 1080 };
+    sync(exec, { providerSpecificData: { accountProxies: [{ fingerprint: FP, proxy }] } });
+
+    assert.deepEqual(accountsOf(exec)[0].proxy, proxy);
+  });
+
+  it("clears a previously-resolved proxy back to null when config drops it", () => {
+    const exec = new MimocodeExecutor();
+    accountsOf(exec).length = 0;
+    accountsOf(exec).push({
+      fingerprint: FP,
+      jwt: "",
+      expiresAt: 0,
+      cooldownUntil: 0,
+      consecutiveFails: 0,
+      proxy: { type: "http", host: "stale.example.com", port: 8080 },
+    });
+
+    sync(exec, { providerSpecificData: { accountProxies: [] } });
+
+    assert.equal(accountsOf(exec)[0].proxy, null, "a removed proxy must not linger on the account");
+  });
+});


### PR DESCRIPTION
Part of #8484. Sixth slice of the TS 7 executor work; type-only, no toolchain changes.

Three independent root causes, each a declaration that had drifted behind the code using it. Grouped by kind rather than by file, as flagged at the end of #8499.

## 1. `mimocode` — `AccountState` was missing `proxy` (4 diagnostics)

`syncAccountsFromCredentials()` writes `acct.proxy` on **every** account on every sync, and `getProxyDispatcher()` reads it — but the interface never declared it. The #3837/#5521 contract existed only as a comment at the write site:

> default the per-account proxy to null (not undefined) … so an executor with no `accountProxies` config still exposes `acct.proxy === null` on every account

Declared as `AccountProxyConfig["proxy"]` rather than re-spelling the shape, so the exported config type and the runtime state cannot drift apart again.

## 2. `opencode` — narrowing dropped on the tools block (4)

The `client_metadata` block immediately above uses the full idiom — `typeof === "object"` **and** `!Array.isArray()` **and** a `Record<string, unknown>` cast. The tools-truncation block used only the first, so `modifiedBody` stayed `object` and `.tools` was unreachable. Adopted the neighbouring idiom.

**Behavior is identical.** The old condition reached `.tools` on arrays too and relied on `Array.isArray(undefined)` short-circuiting to a no-op; the explicit guard produces the same outcome. There is a test pinning exactly that (see below), because it is the one place in this PR where control flow was rewritten rather than annotated.

## 3. `zed-hosted` — controller typed wider than used (3)

`enqueueSseObject` / `finish` / `processLine` were annotated `ReadableStreamDefaultController<Uint8Array>`, but every call site drives them from a `TransformStream`, and `TransformStreamDefaultController` has no `close()`. All three only ever call `.enqueue()`, so they are now typed by that single capability:

```ts
type SseEnqueueTarget = Pick<ReadableStreamDefaultController<Uint8Array>, "enqueue">;
```

Narrowing the parameter rather than widening it to a union keeps the helpers honest about what they touch, and both controller kinds satisfy it.

## Verification

**310 → 299, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set (measured with the #8473 tsconfig applied locally, since `baseUrl`/TS5101 still masks everything on this base).

<details><summary>Fixed diagnostics</summary>

```
mimocode.ts   TS2353 'proxy' does not exist in type 'AccountState'   x2
mimocode.ts   TS2339 Property 'proxy' does not exist on 'AccountState'   x2
opencode.ts   TS2339 Property 'tools' does not exist on type 'object'   x4
zed-hosted.ts TS2345 TransformStreamDefaultController not assignable to
              ReadableStreamDefaultController   x3
```

</details>

- `npm run typecheck:core` — clean
- `npm run lint` — clean on the changed files (the 4 pre-existing `no-explicit-any` errors in `claude-to-openai-think-close-5123.test.ts` are base-red, fixed by #8490 / #8505)
- **300/300** across the 26 affected existing test files (`*opencode*`, `mimocode-executor`, `zed-hosted-think-close-marker`, `zed-provider`)

## On the tests

These are **preservation guards, not TDD red/green** — there is no bug here, and I would rather say so than dress them up. I verified that by reverting the three sources to the parent commit and re-running the new file: **7/7 pass there too**, which is the evidence for the "no behavior change" claim above.

`tests/unit/ts7-executor-shared-shapes.test.ts` adds:

- **opencode tools truncation** — 200 → 128, order preserved; within-limit untouched; absent-tools no-op; **array-shaped body passes through**, pinning the `!Array.isArray()` guard. This behavior had **no test at all** before, which is why it is worth adding alongside a rewrite of its condition.
- **mimocode `proxy` contract** — null (not undefined) when unconfigured; resolved when configured; **reset to null when config drops it**, so a stale proxy cannot linger on an account across syncs.

No test added for zed-hosted: `zed-hosted-think-close-marker.test.ts` already drives the exact TransformStream that failed to type-check, end to end. Duplicating it would add lines, not coverage.

## Scope

`open-sse/executors` is down to ~13 diagnostics after this, all genuine singles or pairs now (Node 26 `Buffer`/`Uint8Array` generics in `edgeTts`/`windsurf`, four `TS2352` unsafe casts, and scattered one-offs). Slice status tracked in #8484.
