### PR TITLE
refactor(guardrails): narrow the documented void return at the dispatch site

### DIFF
--- a/src/lib/guardrails/registry.ts
+++ b/src/lib/guardrails/registry.ts
@@ -1,8 +1,29 @@
-import { BaseGuardrail, type GuardrailContext, type GuardrailExecutionResult } from "./base";
+import {
+  BaseGuardrail,
+  type GuardrailContext,
+  type GuardrailExecutionResult,
+  type GuardrailResult,
+} from "./base";
 import { PIIMaskerGuardrail } from "./piiMasker";
 import { PromptInjectionGuardrail } from "./promptInjection";
 import { VisionBridgeGuardrail } from "./visionBridge";
 import { CredentialMaskerGuardrail } from "./credentialMasker";
+
+/**
+ * `preCall`/`postCall` may legitimately return nothing — that is the documented
+ * "no change" signal, alongside `{}` and `{ block: false }`
+ * (`docs/security/GUARDRAILS.md`), and `CredentialMaskerGuardrail` still declares
+ * the `| void` arm.
+ *
+ * `void` is not a value the checker lets us inspect, so neither `result?.block`
+ * nor a truthiness test compiles against `GuardrailResult | void`. Funnel the
+ * return through `unknown` once, here, and hand the dispatch loops a plain
+ * optional. Runtime behavior is unchanged: a guardrail that returns nothing
+ * still yields `undefined` and is still treated as "passed".
+ */
+function asGuardrailResult(raw: unknown): GuardrailResult<unknown> | undefined {
+  return raw && typeof raw === "object" ? (raw as GuardrailResult<unknown>) : undefined;
+}
 
 type HeadersLike = Headers | Record<string, unknown> | null | undefined;
 
@@ -128,7 +149,7 @@ export class GuardrailRegistry {
       }
 
       try {
-        const result = await guardrail.preCall(currentPayload, context);
+        const result = asGuardrailResult(await guardrail.preCall(currentPayload, context));
         const modified = result?.modifiedPayload !== undefined;
         const meta = result?.meta || null;
 
@@ -201,7 +222,7 @@ export class GuardrailRegistry {
       }
 
       try {
-        const result = await guardrail.postCall(currentResponse, context);
+        const result = asGuardrailResult(await guardrail.postCall(currentResponse, context));
         const modified = result?.modifiedResponse !== undefined;
         const meta = result?.meta || null;
 

--- a/tests/unit/guardrails-void-no-change-contract.test.ts
+++ b/tests/unit/guardrails-void-no-change-contract.test.ts
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { BaseGuardrail, GuardrailRegistry } from "../../src/lib/guardrails/index.ts";
+
+/**
+ * `docs/security/GUARDRAILS.md`: "A guardrail signals 'no change' by returning
+ * either `void`, `{}`, or ...".
+ *
+ * The `void` arm of that contract had no test — `guardrails-registry.test.ts`
+ * covers guardrails that return a result and one that throws, but never one
+ * that simply returns nothing. These tests pin it, because the registry's
+ * dispatch reads the return value's properties and must keep treating "nothing"
+ * as a clean pass rather than a block or a modification.
+ */
+
+class SilentGuardrail extends BaseGuardrail {
+  constructor(name = "silent") {
+    super(name, { priority: 10 });
+  }
+
+  override async preCall() {
+    // no return — the documented "no change" signal
+  }
+
+  override async postCall() {
+    // no return — the documented "no change" signal
+  }
+}
+
+class EmptyResultGuardrail extends BaseGuardrail {
+  constructor(name = "empty") {
+    super(name, { priority: 10 });
+  }
+
+  override async preCall() {
+    return {};
+  }
+
+  override async postCall() {
+    return {};
+  }
+}
+
+test("a preCall returning nothing passes the payload through untouched", async () => {
+  const registry = new GuardrailRegistry();
+  registry.register(new SilentGuardrail());
+
+  const payload = { messages: [{ role: "user", content: "hello" }] };
+  const result = await registry.runPreCallHooks(payload, {});
+
+  assert.equal(result.blocked, false, "returning nothing must not block");
+  assert.deepEqual(result.payload, payload, "payload must be forwarded unchanged");
+
+  const execution = result.results[0];
+  assert.equal(execution?.guardrail, "silent");
+  assert.equal(execution?.blocked, false);
+  assert.equal(execution?.modified, false, "nothing returned means nothing modified");
+  assert.equal(execution?.skipped, false, "the guardrail ran — it is not 'skipped'");
+  assert.equal(execution?.error, undefined, "a silent pass is not an error");
+  assert.equal(execution?.stage, "pre");
+});
+
+test("a postCall returning nothing passes the response through untouched", async () => {
+  const registry = new GuardrailRegistry();
+  registry.register(new SilentGuardrail());
+
+  const response = { choices: [{ message: { content: "hi" } }] };
+  const result = await registry.runPostCallHooks(response, {});
+
+  assert.equal(result.blocked, false);
+  assert.deepEqual(result.response, response);
+
+  const execution = result.results[0];
+  assert.equal(execution?.modified, false);
+  assert.equal(execution?.skipped, false);
+  assert.equal(execution?.error, undefined);
+  assert.equal(execution?.stage, "post");
+});
+
+test("returning an empty object behaves identically to returning nothing", async () => {
+  const payload = { messages: [{ role: "user", content: "hello" }] };
+
+  const silent = new GuardrailRegistry();
+  silent.register(new SilentGuardrail("g"));
+  const silentResult = await silent.runPreCallHooks(payload, {});
+
+  const empty = new GuardrailRegistry();
+  empty.register(new EmptyResultGuardrail("g"));
+  const emptyResult = await empty.runPreCallHooks(payload, {});
+
+  assert.deepEqual(
+    silentResult.results,
+    emptyResult.results,
+    "the two documented no-change signals must produce the same execution record"
+  );
+  assert.deepEqual(silentResult.payload, emptyResult.payload);
+});
+
+test("a silent guardrail does not stop later guardrails from modifying", async () => {
+  class AppendGuardrail extends BaseGuardrail {
+    constructor() {
+      super("append", { priority: 20 });
+    }
+
+    override async preCall(payload: unknown) {
+      return { modifiedPayload: { ...(payload as Record<string, unknown>), seen: true } };
+    }
+  }
+
+  const registry = new GuardrailRegistry();
+  registry.register(new SilentGuardrail());
+  registry.register(new AppendGuardrail());
+
+  const result = await registry.runPreCallHooks({ messages: [] }, {});
+
+  assert.equal((result.payload as Record<string, unknown>).seen, true);
+  assert.equal(result.results.length, 2);
+  assert.equal(result.results[0]?.modified, false, "silent guardrail ran first, modified nothing");
+  assert.equal(result.results[1]?.modified, true, "the later guardrail still applied");
+});


### PR DESCRIPTION
Part of #8484. Type-only, no toolchain changes. Clears `src/lib/guardrails` — 12 of its 13 diagnostics, all in one file, all one root cause.

## What the errors were

Every one of the 12 is the same shape:

```
registry.ts: TS2339: Property 'block' does not exist on type 'void | GuardrailResult<unknown>'.
                     'message'  x4    'meta'  x2    'modifiedPayload'  x2
                     'modifiedResponse'  x2         'block'  x2
```

One union, six property reads, across the two dispatch loops.

## The `| void` is deliberate — it stays

My first instinct was that `| void` on `BaseGuardrail.preCall`/`postCall` was vestigial: the base implementations both `return { block: false }`, and three of the four shipped guardrails already declare the narrower `Promise<GuardrailResult<unknown>>`. Removing it would have made all 12 disappear.

That would have been wrong. `docs/security/GUARDRAILS.md` documents it as part of the extension contract:

> A guardrail signals "no change" by returning either `void`, `{}`, or `{ block: false }`

and `CredentialMaskerGuardrail` still declares the `| void` arm. It is a public affordance for anyone adding a guardrail, not dead type surface. **No signature is narrowed in this PR.**

## The fix is at the consumption site

`registry.ts` already reads defensively — `result?.block`, `result?.meta`, and so on. But optional chaining does not make `void` inspectable; `void` is "do not observe this", so `?.` and a truthiness test are both rejected against `GuardrailResult | void`. The registry genuinely *does* observe the value, so the mismatch is real and belongs where the observing happens.

One local helper, used at both dispatch sites:

```ts
function asGuardrailResult(raw: unknown): GuardrailResult<unknown> | undefined {
  return raw && typeof raw === "object" ? (raw as GuardrailResult<unknown>) : undefined;
}
```

`unknown` absorbs the `void` once, and the loops work against a plain optional from there. Callers outside this file are unaffected; no guardrail implementation changed.

## Verification

**280 → 268, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set. (I also normalize the worktree path out of the diff — TS embeds absolute paths in TS2345 messages, which otherwise reads as two phantom regressions.)

- `npm run typecheck:core` — clean
- `eslint` on the changed file — clean
- **75/75** across the 13 guardrail suites (`guardrails-registry`, `guardrails-api-3496`, `credential-masker-guardrail`, `pii-opt-in-default`, `prompt-injection-guard` ×2, `vision-bridge` ×4, `chatcore-postcall-guardrail-context`, `input-sanitizer-pii-redaction`)

## Tests — a real gap, not a formality

The `void` arm of the documented contract had **no coverage at all**. `guardrails-registry.test.ts` covers guardrails that return a result, and one that throws (`ExplodingGuardrail`), but never one that simply returns nothing — the exact path this PR rewrites.

`tests/unit/guardrails-void-no-change-contract.test.ts`, 4 tests:

| test | pins |
| --- | --- |
| silent `preCall` | payload forwarded unchanged; recorded as ran — `blocked:false`, `modified:false`, `skipped:false`, `error:undefined` |
| silent `postCall` | same for the response path |
| `{}` vs nothing | the two documented no-change signals produce an **identical** execution record |
| silent + modifying pair | a silent guardrail does not stop a later one from applying `modifiedPayload` |

The `skipped:false` / `error:undefined` assertions matter: "returned nothing" must not be confused with "was disabled" or "failed open", and those are three different branches in the same loop.

As with the other slices in this campaign these are **preservation guards, not TDD red/green** — there is no bug. I verified that by reverting `registry.ts` to the parent commit and re-running: **4/4 pass there too**, which is the evidence behind the no-behavior-change claim.

## Note on Rule #20

This touches the guardrail dispatch loop, which is the application point for the PII flags. Nothing here changes when a guardrail runs, whether it mutates, or any default — `PII_REDACTION_ENABLED` / `PII_RESPONSE_SANITIZATION` remain untouched, and `pii-opt-in-default.test.ts` is in the suite run above.
