### PR TITLE
refactor(sse): type the rerank response adapter's options parameter

### DIFF
--- a/open-sse/handlers/rerank.ts
+++ b/open-sse/handlers/rerank.ts
@@ -16,6 +16,25 @@ import { resolveProxyForConnection } from "@/lib/db/settings";
 import { runWithProxyContext } from "../utils/proxyFetch.ts";
 import * as log from "@/sse/utils/logger";
 
+/** A document as the Cohere-compatible rerank API accepts it: a bare string or `{ text }`. */
+type RerankDocument = string | { text?: string };
+
+/**
+ * The caller-side request fields the response adapters need to rebuild Cohere's
+ * `results[]`. Upstreams either omit the documents entirely (DeepInfra returns
+ * bare scores) or echo them in their own shape (Voyage returns plain strings),
+ * so document text is always synthesized from the caller's originals — and
+ * `top_n` / `return_documents` are honored here rather than upstream.
+ *
+ * Every field is optional: the parameter defaults to `{}` and the unit suites
+ * call it with subsets (e.g. `{ documents: ["a", "b"] }`).
+ */
+interface RerankResponseOptions {
+  documents?: RerankDocument[];
+  return_documents?: boolean;
+  top_n?: number;
+}
+
 /**
  * Build authorization header for a rerank provider
  */
@@ -76,7 +95,11 @@ function buildAuthHeader(providerConfig, token) {
 /**
  * Transform response from provider-specific formats back to Cohere format
  */
-/* @testonly */ export function transformResponseFromProvider(providerConfig, data, options = {}) {
+/* @testonly */ export function transformResponseFromProvider(
+  providerConfig,
+  data,
+  options: RerankResponseOptions = {}
+) {
   if (providerConfig.format === "nvidia") {
     return {
       id: data.id != null ? String(data.id) : `rerank-${Date.now()}`,

--- a/tests/unit/rerank-object-documents-response-path.test.ts
+++ b/tests/unit/rerank-object-documents-response-path.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { getRerankProvider } = await import("../../open-sse/config/rerankRegistry.ts");
+const { transformResponseFromProvider } = await import("../../open-sse/handlers/rerank.ts");
+
+/**
+ * The Cohere-compatible rerank API accepts each document as either a bare string
+ * or `{ text }`, and the DeepInfra/Voyage **response** adapters synthesize
+ * `document.text` from the caller's originals (upstreams either omit documents
+ * or echo them in their own shape — #7809/#7811).
+ *
+ * The `{ text }` form was only ever exercised through the *request* adapter
+ * (`#5332 deepinfra request adapter`, `#7809 voyage request adapter handles
+ * {text} object documents`). Every response-adapter test passed plain strings,
+ * so the `typeof doc === "string" ? doc : doc?.text` branch on the response side
+ * was uncovered — which is also the branch that gives
+ * `RerankResponseOptions.documents` its union type.
+ */
+
+test("deepinfra response adapter resolves document text from {text} objects", () => {
+  const cfg = getRerankProvider("deepinfra");
+  const out = transformResponseFromProvider(
+    cfg,
+    { scores: [0.1, 0.9] },
+    { documents: [{ text: "Washington DC" }, { text: "Paris" }], return_documents: true }
+  );
+
+  assert.equal(out.results[0].index, 1, "0.9 ranks first");
+  assert.equal(out.results[0].document.text, "Paris");
+  assert.equal(out.results[1].document.text, "Washington DC");
+});
+
+test("deepinfra response adapter handles a mixed string/{text} document array", () => {
+  const cfg = getRerankProvider("deepinfra");
+  const out = transformResponseFromProvider(
+    cfg,
+    { scores: [0.2, 0.8] },
+    { documents: ["plain string", { text: "object form" }], return_documents: true }
+  );
+
+  assert.equal(out.results[0].document.text, "object form");
+  assert.equal(out.results[1].document.text, "plain string");
+});
+
+test("deepinfra response adapter falls back to empty text for a {text}-less object", () => {
+  const cfg = getRerankProvider("deepinfra");
+  const out = transformResponseFromProvider(
+    cfg,
+    { scores: [0.5] },
+    { documents: [{} as { text?: string }], return_documents: true }
+  );
+
+  assert.equal(out.results[0].document.text, "", "a document with no text must not yield undefined");
+});
+
+test("voyage response adapter resolves document text from {text} objects", () => {
+  const cfg = getRerankProvider("voyage-ai");
+  const out = transformResponseFromProvider(
+    cfg,
+    { data: [{ index: 0, relevance_score: 0.4 }, { index: 1, relevance_score: 0.7 }] },
+    { documents: [{ text: "alpha" }, { text: "beta" }], return_documents: true }
+  );
+
+  assert.equal(out.results[0].index, 1, "0.7 ranks first");
+  assert.equal(out.results[0].document.text, "beta");
+  assert.equal(out.results[1].document.text, "alpha");
+});
+
+test("voyage response adapter remaps indices past an empty {text} document", () => {
+  // The request adapter drops exact-empty documents before sending, so the
+  // upstream indices refer to the filtered array. The response adapter rebuilds
+  // that filter to map back — this must work for the object form too, not just
+  // strings.
+  const cfg = getRerankProvider("voyage-ai");
+  const out = transformResponseFromProvider(
+    cfg,
+    { data: [{ index: 1, relevance_score: 0.9 }] },
+    { documents: [{ text: "kept" }, { text: "" }, { text: "also kept" }], return_documents: true }
+  );
+
+  assert.equal(out.results[0].index, 2, "filtered index 1 maps back to original index 2");
+  assert.equal(out.results[0].document.text, "also kept");
+});


### PR DESCRIPTION
Part of #8484. Type-only, no toolchain changes. First slice into `open-sse/handlers` — see the scope note at the bottom, because that area turned out not to be what the tracking issue said it was.

## One untyped parameter, 12 diagnostics

```ts
export function transformResponseFromProvider(providerConfig, data, options = {}) {
```

No annotation, so TS infers `options` as `{}` from the default value. Every read of it fails:

```
rerank.ts: TS2339: Property 'top_n' does not exist on type '{}'.              x6
           TS2339: Property 'documents' does not exist on type '{}'.          x4
           TS2339: Property 'return_documents' does not exist on type '{}'.   x2
```

Six of those are `top_n` alone, because the DeepInfra and Voyage branches each spell it three times in one expression.

## Fix

Declared the shape the JSDoc on `handleRerank` already documents:

```ts
type RerankDocument = string | { text?: string };

interface RerankResponseOptions {
  documents?: RerankDocument[];
  return_documents?: boolean;
  top_n?: number;
}
```

All fields optional — the parameter defaults to `{}`, and the existing suites call it with subsets (`{ documents: ["a", "b"] }`).

`RerankDocument` is a union rather than `string[]` because the Cohere-compatible API accepts both forms and both adapters already branch on it:

```ts
const text = typeof doc === "string" ? doc : doc?.text || "";
```

`providerConfig` and `data` are left unannotated. Only `options` produced errors — it is the one parameter with a default value, which is what handed TS the `{}` — so only `options` is touched.

## Verification

**280 → 268, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set (with the worktree path normalized out — TS embeds absolute paths in some messages, which otherwise reads as phantom regressions).

- `npm run typecheck:core` — clean
- `eslint` on both changed files — clean
- **43/43** across the 6 affected suites (`rerank`, `rerank-providers-5332`, `rerank-voyage-7809`, `rerank-openrouter-6574`, `rerank-proxy-pinning-7350`, `media-cost-headers-handlers`)

## Tests — the union had a real hole

Existing coverage of these three options is genuinely good: `top_n` truncation, descending sort, `return_documents: false` omitting text, and Voyage's index remapping are all asserted on both adapters. My first read was that there was nothing worth adding.

That was wrong, and the distinction matters. The `{ text }` document form is tested — but **only through the *request* adapter**:

- `#5332 deepinfra request adapter → {queries,documents} (string + {text})`
- `#7809 voyage request adapter handles {text} object documents`

Every **response**-adapter test passes plain strings. So `typeof doc === "string" ? doc : doc?.text` on the response side had no coverage — and that branch is precisely what makes `RerankDocument` a union rather than `string`. Nothing would have caught a later "simplification" to `documents?: string[]`.

`tests/unit/rerank-object-documents-response-path.test.ts`, 5 tests:

| test | pins |
| --- | --- |
| deepinfra, `{ text }` documents | text resolved from objects, ranking order preserved |
| deepinfra, mixed array | `["plain string", { text: "object form" }]` both resolve |
| deepinfra, `{}` with no `text` | falls back to `""`, never `undefined` |
| voyage, `{ text }` documents | same through the second adapter |
| voyage, empty `{ text: "" }` | filtered index 1 maps back to original index 2 |

As with the other slices in this campaign these are **preservation guards, not TDD red/green** — there is no bug. I verified that by reverting `rerank.ts` to the parent commit and re-running: **5/5 pass there too**.

## Scope note on `open-sse/handlers`

#8484 previously described this area as "121 diagnostics — chatCore/stream, standalone, last, heaviest validation". Measured, that is wrong: only **39** are in `chatCore.ts`. The other **82 are peripheral handlers with no dependency on it** — `rerank.ts` (12), `designerWeb.ts` (10), `audioTranscription.ts` (8), `responsesHandler.ts` (5), and so on. They are sliceable now rather than blocked behind the chatCore work.

They do **not** share a root cause with each other, though — `audioTranscription` is mostly TS2769 overloads, `imageGeneration` is TS2554 arity plus a `Buffer` → `BlobPart` mismatch. `rerank.ts` is the only clean single-cause cluster in the group, which is why it goes first. The rest slice per-file. Issue body updated with the breakdown.
