### PR TITLE
refactor(sse): retag the designer-web result unions with string discriminants

### DIFF
--- a/open-sse/handlers/imageGeneration/providers/designerWeb.ts
+++ b/open-sse/handlers/imageGeneration/providers/designerWeb.ts
@@ -104,15 +104,26 @@ interface DesignerWebRequestConfig {
   pollIntervalMs: number;
 }
 
+/**
+ * Outcome of request validation. String-discriminated rather than `ok: boolean`
+ * because `open-sse` compiles with `strictNullChecks: false`, where a
+ * boolean-literal discriminant narrows the positive branch but leaves the
+ * negative one as the full union — so `if (!resolved.ok)` would not expose
+ * `status`/`error`. All three unions in this file shared that root cause.
+ */
+type DesignerWebRequestResolution =
+  | { state: "resolved"; config: DesignerWebRequestConfig }
+  | { state: "invalid"; status: number; error: string };
+
 /** Validates the request and resolves auth + poll timing. Returns an error status/message on failure. */
 function resolveDesignerWebRequest(
   body: { prompt?: unknown; size?: unknown; timeout_ms?: unknown; poll_interval_ms?: unknown },
   credentials: { apiKey?: string; accessToken?: string }
-): { ok: true; config: DesignerWebRequestConfig } | { ok: false; status: number; error: string } {
+): DesignerWebRequestResolution {
   const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
   if (!prompt) {
     return {
-      ok: false,
+      state: "invalid",
       status: 400,
       error: "Prompt is required for Microsoft Designer image generation",
     };
@@ -120,7 +131,11 @@ function resolveDesignerWebRequest(
 
   const accessToken = credentials?.apiKey || credentials?.accessToken;
   if (!accessToken) {
-    return { ok: false, status: 401, error: "Microsoft Designer credentials missing access_token" };
+    return {
+      state: "invalid",
+      status: 401,
+      error: "Microsoft Designer credentials missing access_token",
+    };
   }
 
   const timeoutMs = normalizePositiveNumber(
@@ -139,7 +154,7 @@ function resolveDesignerWebRequest(
   );
 
   return {
-    ok: true,
+    state: "resolved",
     config: {
       prompt,
       accessToken,
@@ -151,10 +166,20 @@ function resolveDesignerWebRequest(
   };
 }
 
-type DesignerWebStepResult =
-  | { done: false; waitMs: number }
-  | { done: true; success: true; imageUrls: string[] }
-  | { done: true; success: false; status: number; error: string };
+type DesignerWebPending = { state: "pending"; waitMs: number };
+type DesignerWebReady = { state: "ready"; imageUrls: string[] };
+type DesignerWebFailed = { state: "failed"; status: number; error: string };
+
+/** One poll cycle: still working, finished with images, or finished with an error. */
+type DesignerWebStepResult = DesignerWebPending | DesignerWebReady | DesignerWebFailed;
+
+/**
+ * What the poll loop hands back. Deliberately excludes the pending arm — the
+ * loop either returns a terminal step or synthesizes a 504, and never surfaces
+ * `pending` to its caller. The previous signature admitted it, which is why
+ * `outcome.success` did not exist on every member of that union.
+ */
+type DesignerWebOutcome = DesignerWebReady | DesignerWebFailed;
 
 /** Runs one submit/poll fetch cycle and classifies the outcome. */
 async function stepDesignerWebPoll(
@@ -167,23 +192,29 @@ async function stepDesignerWebPoll(
   const resp = await fetchImpl(baseUrl, { method: "POST", headers, body: formBody });
 
   if (!resp.ok) {
-    return { done: true, success: false, status: resp.status, error: sanitizeErrorMessage(await resp.text()) };
+    return {
+      state: "failed",
+      status: resp.status,
+      error: sanitizeErrorMessage(await resp.text()),
+    };
   }
 
   const parsed = parseDesignerWebResponse(await resp.json());
 
   if (parsed.status === "ready") {
-    return { done: true, success: true, imageUrls: parsed.imageUrls };
+    return { state: "ready", imageUrls: parsed.imageUrls };
   }
   if (parsed.status === "empty") {
     return {
-      done: true,
-      success: false,
+      state: "failed",
       status: 502,
       error: "Microsoft Designer response did not contain image data or polling metadata",
     };
   }
-  return { done: false, waitMs: Math.min(parsed.pollIntervalMs ?? pollIntervalMs, pollIntervalMs) };
+  return {
+    state: "pending",
+    waitMs: Math.min(parsed.pollIntervalMs ?? pollIntervalMs, pollIntervalMs),
+  };
 }
 
 /** Drives the submit-then-poll loop to completion, timeout, or a terminal error. */
@@ -192,7 +223,7 @@ async function runDesignerWebPollLoop(
   config: DesignerWebRequestConfig,
   fetchImpl: typeof fetch,
   log?: { info?: (...args: unknown[]) => void }
-): Promise<DesignerWebStepResult | { done: true; success: false; status: 504; error: string }> {
+): Promise<DesignerWebOutcome> {
   const deadline = Date.now() + config.timeoutMs;
   let attempt = 0;
 
@@ -205,14 +236,13 @@ async function runDesignerWebPollLoop(
       config.pollIntervalMs,
       fetchImpl
     );
-    if (step.done) return step;
+    if (step.state !== "pending") return step;
     log?.info?.("IMAGE", `designer-web pending, poll #${attempt} in ${step.waitMs}ms`);
     await new Promise((resolve) => setTimeout(resolve, step.waitMs));
   }
 
   return {
-    done: true,
-    success: false,
+    state: "failed",
     status: 504,
     error: "Microsoft Designer image generation timed out waiting for a result",
   };
@@ -237,13 +267,19 @@ export async function handleDesignerWebImageGeneration({
 }) {
   const startTime = Date.now();
   const resolved = resolveDesignerWebRequest(body, credentials);
-  if (!resolved.ok) {
-    return saveImageErrorResult({ provider, model, status: resolved.status, startTime, error: resolved.error });
+  if (resolved.state === "invalid") {
+    return saveImageErrorResult({
+      provider,
+      model,
+      status: resolved.status,
+      startTime,
+      error: resolved.error,
+    });
   }
 
   try {
     const outcome = await runDesignerWebPollLoop(providerConfig.baseUrl, resolved.config, fetchImpl, log);
-    if (outcome.success) {
+    if (outcome.state === "ready") {
       return saveImageSuccessResult({
         provider,
         model,

--- a/tests/unit/designer-web-empty-response-502.test.ts
+++ b/tests/unit/designer-web-empty-response-502.test.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { handleDesignerWebImageGeneration } = await import(
+  "../../open-sse/handlers/imageGeneration/providers/designerWeb.ts"
+);
+
+/**
+ * `stepDesignerWebPoll` classifies an unrecognized upstream body as a terminal
+ * 502 — the "empty" arm of the step union, alongside pending / ready / upstream
+ * failure.
+ *
+ * `microsoft-designer-web-6672.test.ts` covers every other arm end-to-end
+ * (400 no prompt, 401 no token, immediate ready, poll-then-ready, non-OK
+ * upstream, 504 timeout) but tests "empty" only at the parser level
+ * (`parseDesignerWebResponse: unrecognized shape is 'empty'`) — it never drives
+ * the handler with one, so the 502 the handler synthesizes from it was
+ * unasserted.
+ */
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+const BASE = {
+  model: "dall-e-3",
+  provider: "microsoft-designer-web",
+  providerConfig: { baseUrl: "https://designerapp.officeapps.live.com/designerapp/DallE.ashx" },
+  credentials: { apiKey: "tok-abc" },
+};
+
+test("a 200 with an unrecognized body is a terminal 502, not a retry", async () => {
+  let calls = 0;
+  const result = await handleDesignerWebImageGeneration({
+    ...BASE,
+    body: { prompt: "a cat astronaut", timeout_ms: 5_000, poll_interval_ms: 1 },
+    fetchImpl: async () => {
+      calls += 1;
+      return jsonResponse(200, { unexpected: true });
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.status, 502, "an unparseable success body is a bad-gateway, not a timeout");
+  assert.match(String(result.error), /did not contain image data or polling metadata/);
+  assert.equal(calls, 1, "the empty classification is terminal — it must not keep polling");
+});
+
+test("a 200 with neither images nor polling metadata does not fall through to 504", async () => {
+  // The distinction matters: 502 says "the upstream answered with something we
+  // cannot use", 504 says "the upstream never finished". A timeout_ms generous
+  // enough to allow several polls proves the 502 came from classification, not
+  // from the deadline.
+  const result = await handleDesignerWebImageGeneration({
+    ...BASE,
+    body: { prompt: "a cat astronaut", timeout_ms: 10_000, poll_interval_ms: 1 },
+    fetchImpl: async () => jsonResponse(200, { polling_response: {} }),
+  });
+
+  assert.equal(result.status, 502);
+  assert.notEqual(result.status, 504);
+});


### PR DESCRIPTION
Part of #8484. Clears `designerWeb.ts` — all 10 of its diagnostics, one root cause.

## Same root cause as #8483 / #8499

Every one is the `strictNullChecks: false` narrowing limitation `open-sse` compiles under: a **boolean-literal discriminant narrows the positive branch but leaves the negative one as the full union**. So `if (!resolved.ok) { … resolved.status }` and everything after `if (outcome.success)` cannot see their fields.

Three unions in the file, 10 errors:

| union | errors |
| --- | --- |
| `{ ok: true; config } \| { ok: false; status; error }` | 2 (`status`, `error`) |
| `DesignerWebStepResult` (`done`/`success`) | 2 (`waitMs`) |
| the poll loop's return | 6 (`success`, `imageUrls`, `status` ×2, `error` ×2) |

## Retag, not predicates — and why

#8499 used type predicates for the same root cause. The rule recorded there is **retag when the union is module-private, use a predicate when it is exported** — a predicate exists to avoid churning a public shape and the assertions that depend on it.

Here nothing is exported: `resolveDesignerWebRequest`, `stepDesignerWebPoll`, `runDesignerWebPollLoop` and `DesignerWebStepResult` are all module-private, and no test references them. So retagging is the cheaper, clearer fix:

```
resolveDesignerWebRequest   ok: true|false   ->  state: "resolved" | "invalid"
DesignerWebStepResult       done + success   ->  state: "pending" | "ready" | "failed"
```

The step union is the interesting one: it encoded **three states across two booleans**. That is also the direct cause of the third cluster — `{ done: false; waitMs }` has no `success` property at all, so `outcome.success` was not "unnarrowed", it genuinely did not exist on every member. One discriminant for three states removes both problems.

## A too-wide signature, fixed alongside

```ts
- ): Promise<DesignerWebStepResult | { done: true; success: false; status: 504; error: string }> {
+ ): Promise<DesignerWebOutcome> {   // = DesignerWebReady | DesignerWebFailed
```

`runDesignerWebPollLoop` returns a step **only after confirming it is terminal** (`if (step.state !== "pending") return step`), and otherwise synthesizes a 504. It can never hand back a pending step. The old signature claimed it could, which is what admitted `{ waitMs }` into the union its caller destructures. The inline `{ …status: 504… }` arm also disappears — it was already exactly `DesignerWebFailed`.

## Verification

**280 → 270, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set (worktree path normalized out).

- `npm run typecheck:core` — clean
- `eslint` on both changed files — clean
- **61/61** across `microsoft-designer-web-6672`, `image-generation-handler`, and the new file

## Tests — this slice actually needed them

The earlier slices in this campaign were pure annotations. **This one rewrote three conditionals**, so behavior preservation is a real claim rather than a formality.

The existing suite carries it: `microsoft-designer-web-6672.test.ts` drives `handleDesignerWebImageGeneration` end-to-end through **400** (no prompt), **401** (no token), **immediate ready**, **poll-then-ready** (the `pending` → `waitMs` loop), **non-OK upstream**, and **504 timeout** — every arm of all three unions but one. Because those tests are black-box through the exported handler, they are agnostic to the discriminant rename: **18/18 pass against the parent commit as well as after**, which is the evidence that the retag changes nothing observable.

The gap was the `"empty"` arm — an unrecognized 200 body, which the step classifier turns into a terminal **502**. That was tested only at the parser level (`parseDesignerWebResponse: unrecognized shape is 'empty'`); no test ever drove the handler with one, so the 502 the handler synthesizes was unasserted.

`tests/unit/designer-web-empty-response-502.test.ts`, 2 tests:

- an unrecognized 200 yields **502**, with **exactly one fetch** — proving the classification is terminal and does not keep polling
- with a deliberately generous `timeout_ms`, the result is still 502 and **not 504** — the distinction being "the upstream answered with something unusable" vs. "the upstream never finished"

Third slice running where the untested path turned out to be precisely the one the new type describes (after #8525's `void` arm and #8528's `{ text }` documents). I have started checking each declared arm explicitly rather than reading overall coverage as sufficient; noted on #8484.
