### PR TITLE
fix(db): classify compressionDetailNormalizers as db-internal in check-db-rules

### DIFF
--- a/scripts/check/check-db-rules.mjs
+++ b/scripts/check/check-db-rules.mjs
@@ -48,6 +48,7 @@ export const INTENTIONALLY_INTERNAL = new Set([
   "comboForecast", // intentionally-internal: src/lib/usage/comboForecast.ts
   "commandCodeAuth", // intentionally-internal: 5 API routes em /api/providers/command-code/auth/*
   "compression", // intentionally-internal: 2 API routes (settings/compression, context/rtk/config)
+  "compressionDetailNormalizers", // db-internal: importado só por db/compression.ts (normalizeSessionDedupConfig/normalizeCcrConfig/buildDetailConfigDefaults/applyDetailConfigUpdate — normalizadores do detail-config split do compression.ts, #8404)
   "vacuumScheduler", // intentionally-internal: src/instrumentation-node.ts (dynamic import, lifecycle wiring per Rule #2)
   "detailedLogs", // intentionally-internal: 3 callers (callLogs.ts, logs/detail route, embeddings handler)
   "discovery", // DEAD?: 0 importers na auditoria de 2026-06-11; lib/discovery/index.ts não usa db/discovery

--- a/tests/unit/check-db-rules-classification.test.ts
+++ b/tests/unit/check-db-rules-classification.test.ts
@@ -121,7 +121,7 @@ test("INTENTIONALLY_INTERNAL is exported from check-db-rules.mjs", () => {
   assert.ok(INTENTIONALLY_INTERNAL.size > 0, "INTENTIONALLY_INTERNAL must not be empty");
 });
 
-test("INTENTIONALLY_INTERNAL contains the expected 36 audited modules", () => {
+test("INTENTIONALLY_INTERNAL contains the expected 37 audited modules", () => {
   const expected = [
     "_rowTypes",
     "accessTokens",
@@ -133,6 +133,7 @@ test("INTENTIONALLY_INTERNAL contains the expected 36 audited modules", () => {
     "comboForecast",
     "commandCodeAuth",
     "compression",
+    "compressionDetailNormalizers",
     "detailedLogs",
     "discovery",
     "domainState",


### PR DESCRIPTION
## Problem

`check:db-rules` fails on `release/v3.8.49` **at its own HEAD** (`7a8f9156d`) — no PR content involved:

```
[check-db-rules] FALHOU:

[#2 re-export] 1 módulo(s) db/ não re-exportado(s) por src/lib/localDb.ts:
  ✗ src/lib/db/compressionDetailNormalizers.ts
```

Two consequences, one root cause:

- It is a step in the `Fast Quality Gates` job, so the job is red for every PR→`release/**`. It was hidden behind `check:file-size` (steps stop at the first failure) and surfaces as soon as that one passes — see #8524, where the step list now reads `success  check:file-size` / `failure  check:db-rules`.
- `tests/unit/check-db-rules.test.ts` fails its `live repo: no NEW unexported db modules beyond the frozen allowlist` case, which is one of the failures showing up on the `Unit Tests fast-path` shards.

The module was added by #8404 (`1cafd328c`, compression engine detail settings) and is neither re-exported from `localDb.ts` nor listed in `INTENTIONALLY_INTERNAL`, which is exactly the "conscious decision required" state the gate is designed to force.

## Why `INTENTIONALLY_INTERNAL` rather than a re-export

Its only importer is its sibling, via a relative import from inside `src/lib/db/`:

```
src/lib/db/compression.ts:43:
  import { applyDetailConfigUpdate, buildDetailConfigDefaults } from "./compressionDetailNormalizers";
```

(The only other mention in the tree is a comment reference in `open-sse/services/compression/stepDetailConfig.ts`.) Its exports are pure normalizer helpers — `normalizeSessionDedupConfig`, `normalizeCcrConfig`, `buildDetailConfigDefaults`, `applyDetailConfigUpdate` — split out of `compression.ts`.

That is the `db-internal` classification the list already documents and uses for `apiKeyColumnFallbacks` (imported only by `db/apiKeys.ts`) and `caseMapping` (imported only by `db/core.ts`). Re-exporting it from `localDb.ts` would advertise internal helpers as part of the compat surface and, per the comment at the top of the list, "INCENTIVARIA o anti-padrão proibido" of barrel-importing (Hard Rule #2).

## Verification

Red → green on this branch, one-line change:

| | Before | After |
| --- | --- | --- |
| `npm run check:db-rules` | FALHOU, 1 module | `OK (106 módulos db/, 69 re-exportados, 37 intencionalmente-internos)` |
| `node --import tsx/esm --test tests/unit/check-db-rules.test.ts` | **21/22** (`live repo` case failing) | **22/22** |
| `prettier --check` on the file | — | clean |

The gate's own stale-enforcement (`assertNoStale`) passes, confirming the new entry suppresses a real violation rather than becoming dead weight.

## Scope

One entry in one allowlist. No production code, no other gate touched. The remaining base-red gates on this tip (`check:mutation-test-coverage`, `check:complexity-ratchets`, the stale-suppression `lint:json` exit-2, and three backoff unit tests) are untouched and independent — mapped in more detail in a comment on #8524.