### PR TITLE
test(sse): update three backoff assertions stale since the #8396 cooldown cap

### DIFF
--- a/tests/unit/error-classification.test.ts
+++ b/tests/unit/error-classification.test.ts
@@ -98,13 +98,21 @@ test("502 transient: exponential backoff doubles until the configured max backof
     assert.equal(result.newBackoffLevel, level + 1);
     assert.equal(result.reason, RateLimitReason.SERVER_ERROR);
   }
+  // #8396: the scaled cooldown is now clamped by capScaledCooldownMs
+  // (open-sse/services/accountFallback/cooldownCap.ts). With no provider the
+  // ceiling is BACKOFF_CONFIG.max, so the doubling stops there instead of
+  // running on to transientInitial * 32.
+  assert.ok(
+    COOLDOWN_MS.transientInitial * 32 > BACKOFF_CONFIG.max,
+    "precondition: the 6th step must exceed the cap, or this test proves nothing"
+  );
   assert.deepEqual(cooldowns, [
     COOLDOWN_MS.transientInitial,
     COOLDOWN_MS.transientInitial * 2,
     COOLDOWN_MS.transientInitial * 4,
     COOLDOWN_MS.transientInitial * 8,
     COOLDOWN_MS.transientInitial * 16,
-    COOLDOWN_MS.transientInitial * 32,
+    BACKOFF_CONFIG.max,
   ]);
 });
 
@@ -237,8 +245,14 @@ test("subscription quota uses long cooldown when upstream retry hints are disabl
 test("high transient backoff levels clamp to the configured maxBackoffSteps", () => {
   const result = checkFallbackError(502, "", BACKOFF_CONFIG.maxLevel + 5, null, null);
   assert.equal(result.newBackoffLevel, BACKOFF_CONFIG.maxLevel);
+  // #8396: the level still clamps at maxLevel, but the resulting duration is
+  // additionally capped — unclamped this would be ~45.5h, which is the blackout
+  // that PR removed.
   assert.equal(
     result.cooldownMs,
-    COOLDOWN_MS.transientInitial * Math.pow(2, BACKOFF_CONFIG.maxLevel)
+    Math.min(
+      COOLDOWN_MS.transientInitial * Math.pow(2, BACKOFF_CONFIG.maxLevel),
+      BACKOFF_CONFIG.max
+    )
   );
 });

--- a/tests/unit/thundering-herd.test.ts
+++ b/tests/unit/thundering-herd.test.ts
@@ -39,9 +39,15 @@ test("API profile has shorter transient cooldown", () => {
 test("Exponential backoff clamps to the configured maxBackoffLevel", () => {
   const result = checkFallbackError(502, "", 20, null, null);
   assert.equal(result.newBackoffLevel, BACKOFF_CONFIG.maxLevel);
+  // #8396: the level still clamps at maxLevel, but capScaledCooldownMs also
+  // bounds the duration — with no provider profile the ceiling is
+  // BACKOFF_CONFIG.max rather than the unbounded baseCooldownMs * 2^level.
   assert.equal(
     result.cooldownMs,
-    COOLDOWN_MS.transientInitial * Math.pow(2, BACKOFF_CONFIG.maxLevel)
+    Math.min(
+      COOLDOWN_MS.transientInitial * Math.pow(2, BACKOFF_CONFIG.maxLevel),
+      BACKOFF_CONFIG.max
+    )
   );
 });
 


### PR DESCRIPTION
## Problem

Three unit tests fail on `release/v3.8.49` **at its own HEAD** (`7a8f9156d`), with no PR content applied. They show up on the `Unit Tests fast-path` shards:

| Test | File | Expected | Actual |
| --- | --- | --- | --- |
| `502 transient: exponential backoff doubles until the configured max backoff step` | `error-classification.test.ts` | `160000` | `120000` |
| `high transient backoff levels clamp to the configured maxBackoffSteps` | `error-classification.test.ts` | `163840000` | `120000` |
| `Exponential backoff clamps to the configured maxBackoffLevel` | `thundering-herd.test.ts` | `163840000` | `120000` |

## Root cause: the tests assert the behavior #8396 deliberately removed

`163840000` ms is **45.5 hours** — `transientInitial * 2^maxLevel`. That unbounded growth is exactly what #8396 fixed. From the header of the module it added:

> `accountFallback/cooldownCap.ts` — [...] Fixes #8396 — after a sustained 429 burst pushed backoffLevel high, `baseCooldownMs * 2^level` had no upper bound on this path and **could black a connection out for hours, long past any real rate-limit reset window.**

`capScaledCooldownMs` now bounds every scaled cooldown by the operator-configured `profile.maxCooldownMs`, falling back to `BACKOFF_CONFIG.max` when the profile does not set one. All three cases call `checkFallbackError(502, "", level, null, null)` with a **null provider**, so no profile resolves and the fallback ceiling applies — hence `120000` across the board.

So the production behavior is correct and intentional; the assertions are stale. #8396 landed the cap and its own test but did not update these three pre-existing cases. (The same PR also left its test unregistered in `stryker.conf.json` — that half is #8538.)

## Change

Only the expected **durations** move. The backoff-*level* clamping each case was written to guard (`newBackoffLevel === maxLevel` / `=== level + 1`) is untouched and still asserted.

- Expectations keep the original formula wrapped in the cap — `Math.min(COOLDOWN_MS.transientInitial * Math.pow(2, BACKOFF_CONFIG.maxLevel), BACKOFF_CONFIG.max)` — rather than a bare `120000`, so the relationship between the exponential series and the ceiling stays readable and survives a constant change.
- The first case gains a precondition assertion:

```ts
assert.ok(
  COOLDOWN_MS.transientInitial * 32 > BACKOFF_CONFIG.max,
  "precondition: the 6th step must exceed the cap, or this test proves nothing"
);
```

so it cannot silently become vacuous if `transientInitial` or `BACKOFF_CONFIG.max` is retuned later.

- Each site carries a comment pointing at #8396 and `cooldownCap.ts`, so the next reader does not mistake this for a relaxed assertion.

## Verification

```
node --import tsx/esm --test tests/unit/error-classification.test.ts tests/unit/thundering-herd.test.ts
# tests 33 / pass 33 / fail 0
```

`eslint` exit 0 and `prettier --check` clean on both files. No production code touched.

## Note for maintainers

`CLAUDE.md` → Resilience Runtime State → Connection Cooldown still documents the pre-#8396 rule:

> Repeated recoverable failures use exponential backoff: `baseCooldownMs * 2 ** failureIndex`

with no mention of the ceiling. That is now inaccurate. I left it alone to keep this PR to the test change — happy to send a docs follow-up if you want the cap documented there.