### PR TITLE
chore(ci): resync stale no-explicit-any suppression count for proxy-registry.test.ts

### DIFF
--- a/changelog.d/maintenance/lint-suppression-resync-proxy-registry.md
+++ b/changelog.d/maintenance/lint-suppression-resync-proxy-registry.md
@@ -1,0 +1,1 @@
+- chore(ci): resync the stale `no-explicit-any` suppression count for `tests/unit/proxy-registry.test.ts` (frozen at 55, actual 54 since #8447) — ESLint was failing the whole run with "There are suppressions left that do not occur anymore", turning `npm run lint` red on `release/v3.8.49` for every PR branched off it

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1937,7 +1937,7 @@
   },
   "tests/unit/proxy-registry.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 55
+      "count": 54
     }
   },
   "tests/unit/proxy-resolution-status-filter.test.ts": {


### PR DESCRIPTION
Same class as #8007 / #8490, different file.

## Problem

`npm run lint` exits **2** on `release/v3.8.49` — for every PR branched off it:

```
There are suppressions left that do not occur anymore.
Consider re-running the command with `--prune-suppressions`.
```

`config/quality/eslint-suppressions.json` freezes `tests/unit/proxy-registry.test.ts` at **55** `no-explicit-any` violations, but the file has had **54** since #8447 (`d7f947586`) removed one. ESLint fails the whole run on an over-counted suppression.

## Fix

One line, produced by `--prune-suppressions`:

```diff
   "tests/unit/proxy-registry.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 55
+      "count": 54
```

There is no code to fix here — the count simply drifted down when the code got better. Unlike #8490 (which narrowed a chunk type so the annotations were no longer needed), this file needs no source change at all.

## Verification

- `npm run lint` → **exit 0** (was 2)
- `npm run typecheck:core` → clean
- `node --import tsx/esm --test tests/unit/proxy-registry.test.ts` → 20/20 pass
- Both `eslint-suppressions.json` and `proxy-registry.test.ts` are byte-identical to `release/v3.8.49` at branch point, confirming the staleness is inherited base-red and not introduced here.

## Why standalone

Three follow-up decomposition PRs all trip this same gate. Landing it separately keeps that one-line change out of three unrelated diffs.