### PR TITLE
refactor(sse): extract combo 400-classification predicates into a leaf module

### DIFF
--- a/changelog.d/maintenance/combo-error-classifiers.md
+++ b/changelog.d/maintenance/combo-error-classifiers.md
@@ -1,0 +1,1 @@
+- chore(sse): extract the combo 400-classification predicates (`isContextOverflow400`, `isParamValidation400`, `isModelScoped400`) into `combo/errorClassification.ts` — behavior-preserving move that takes `combo.ts` from 3640 to 3610 lines, restoring headroom under the frozen file-size ratchet so ordinary fixes to that file are no longer blocked by the gate

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -680,49 +680,15 @@ async function isPinnedModelDurablyUnhealthy(pinnedModel: string): Promise<boole
 // is NOT body-specific — different combo targets have different context windows /
 // output limits, so the request should fall through to the next target instead of
 // being short-circuited. Exported as pure predicates so the guard is unit-testable.
-/** @param {string} errorText */
-export function isContextOverflow400(errorText) {
-  return (
-    /\bcontext.*(?:length_exceeded|too long|overflow|exceeded|window|limit)\b/i.test(errorText) ||
-    /exceeds.*context/i.test(errorText) ||
-    /your input exceeds/i.test(errorText) ||
-    // Reuse accountFallback.ts's CONTEXT_OVERFLOW_PATTERNS (single source of truth)
-    // so wording like Kimi's "exceeded model token limit" — which never says the
-    // literal word "context" — is still recognized as an overflow/fallback-worthy
-    // 400 instead of halting the whole combo (issue #6637).
-    CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(errorText))
-  );
-}
-/** @param {string} errorText */
-export function isParamValidation400(errorText) {
-  return (
-    /\bmax_tokens\b.*(?:illegal|must|range|invalid)/i.test(errorText) ||
-    /\bparameter is illegal\b/i.test(errorText) ||
-    /\bis illegal.*range\b/i.test(errorText)
-  );
-}
-/**
- * #5249 / #2101: model-scoped 400s must NEVER stop the combo.
- * Upstream often wraps "model X is not supported" in `invalid_request_error` /
- * "Bad Request" envelopes. Those wrapper words match the body-specific stop
- * substrings, so without this exemption the combo hard-stops on the first
- * unavailable model instead of trying the next target. Keep the models in the
- * combo — if one rejects, advance.
- * @param {string} errorText
- */
-export function isModelScoped400(errorText) {
-  const text = String(errorText || "");
-  if (!text) return false;
-  if (MODEL_ACCESS_DENIED_PATTERNS.some((p) => p.test(text))) return true;
-  // Extra model-rejection shapes that providers emit outside the shared list
-  // (Responses API, Copilot, gateway wrappers).
-  return (
-    /\bmodel\b[\s\S]{0,80}?\b(?:not\s+supported|unsupported|unknown|unavailable)\b/i.test(text) ||
-    /\b(?:not\s+supported|unsupported|unknown)\b[\s\S]{0,80}?\bmodel\b/i.test(text) ||
-    /\bunsupported_api_for_model\b/i.test(text) ||
-    /\bdoes\s+not\s+support\s+(?:the\s+)?responses\s+api\b/i.test(text)
-  );
-}
+// The 400 classifiers live in ./combo/errorClassification.ts. Imported for local use in the
+// fallback guard below and re-exported for the historical public surface
+// (combo-param-validation-fallback-4519 imports them from combo.ts).
+import {
+  isContextOverflow400,
+  isParamValidation400,
+  isModelScoped400,
+} from "./combo/errorClassification.ts";
+export { isContextOverflow400, isParamValidation400, isModelScoped400 };
 
 /** @param {object} options */
 export async function handleComboChat({
@@ -2924,7 +2890,11 @@ async function handleRoundRobinCombo({
   // BEFORE availability is known; if every compat-kept target then turns out to be
   // runtime-unavailable, we must reconsider these before returning 503, instead of
   // permanently dropping a compat-rejected-but-healthy provider.
-  const compatRejectedTargets = computeCompatRejectedTargets(evalRankedTargets, filteredTargets, body);
+  const compatRejectedTargets = computeCompatRejectedTargets(
+    evalRankedTargets,
+    filteredTargets,
+    body
+  );
   let modelCount = filteredTargets.length;
   if (modelCount === 0) {
     return comboModelNotFoundResponse("Round-robin combo has no executable targets");

--- a/open-sse/services/combo/errorClassification.ts
+++ b/open-sse/services/combo/errorClassification.ts
@@ -1,0 +1,55 @@
+/**
+ * Upstream 400 classification for combo fallback (extracted from combo.ts).
+ *
+ * These three predicates decide whether a 400 should ADVANCE the combo to the next target or
+ * hard-stop it. They are pure classifiers over the upstream error text and share the canonical
+ * pattern lists in accountFallback.ts, so they do not belong inside the routing loop.
+ *
+ * combo.ts re-exports them, so the public surface is unchanged (combo-param-validation-fallback-4519
+ * imports them from combo.ts). Behavior-preserving move — bodies are identical to the originals.
+ */
+import { CONTEXT_OVERFLOW_PATTERNS, MODEL_ACCESS_DENIED_PATTERNS } from "../accountFallback.ts";
+
+/** @param {string} errorText */
+export function isContextOverflow400(errorText) {
+  return (
+    /\bcontext.*(?:length_exceeded|too long|overflow|exceeded|window|limit)\b/i.test(errorText) ||
+    /exceeds.*context/i.test(errorText) ||
+    /your input exceeds/i.test(errorText) ||
+    // Reuse accountFallback.ts's CONTEXT_OVERFLOW_PATTERNS (single source of truth)
+    // so wording like Kimi's "exceeded model token limit" — which never says the
+    // literal word "context" — is still recognized as an overflow/fallback-worthy
+    // 400 instead of halting the whole combo (issue #6637).
+    CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(errorText))
+  );
+}
+/** @param {string} errorText */
+export function isParamValidation400(errorText) {
+  return (
+    /\bmax_tokens\b.*(?:illegal|must|range|invalid)/i.test(errorText) ||
+    /\bparameter is illegal\b/i.test(errorText) ||
+    /\bis illegal.*range\b/i.test(errorText)
+  );
+}
+/**
+ * #5249 / #2101: model-scoped 400s must NEVER stop the combo.
+ * Upstream often wraps "model X is not supported" in `invalid_request_error` /
+ * "Bad Request" envelopes. Those wrapper words match the body-specific stop
+ * substrings, so without this exemption the combo hard-stops on the first
+ * unavailable model instead of trying the next target. Keep the models in the
+ * combo — if one rejects, advance.
+ * @param {string} errorText
+ */
+export function isModelScoped400(errorText) {
+  const text = String(errorText || "");
+  if (!text) return false;
+  if (MODEL_ACCESS_DENIED_PATTERNS.some((p) => p.test(text))) return true;
+  // Extra model-rejection shapes that providers emit outside the shared list
+  // (Responses API, Copilot, gateway wrappers).
+  return (
+    /\bmodel\b[\s\S]{0,80}?\b(?:not\s+supported|unsupported|unknown|unavailable)\b/i.test(text) ||
+    /\b(?:not\s+supported|unsupported|unknown)\b[\s\S]{0,80}?\bmodel\b/i.test(text) ||
+    /\bunsupported_api_for_model\b/i.test(text) ||
+    /\bdoes\s+not\s+support\s+(?:the\s+)?responses\s+api\b/i.test(text)
+  );
+}


### PR DESCRIPTION
Unblocks #8553 and the follow-up #7847 work. Behavior-preserving move, no logic change.

## The problem this solves

`combo.ts` is 3640 lines against a **frozen file-size ratchet of 3642**. The gate is shrink-only, so **any** change that adds a line to that file is rejected — including a one-line bug fix plus the comment explaining it.

Both in-flight #7847 fixes hit this. Worse, one of them **shipped a violation**: `lint-staged`s Prettier reflowed an unrelated over-long line during `pre-commit`

```diff
-  const compatRejectedTargets = computeCompatRejectedTargets(evalRankedTargets, filteredTargets, body);
+  const compatRejectedTargets = computeCompatRejectedTargets(
+    evalRankedTargets,
+    filteredTargets,
+    body
+  );
```

— **+4 lines, after** the gate had already been checked. That is a trap for anyone touching this file: verifying `check-file-size` before committing is not sufficient, because the formatter runs later and can grow the file on its own.

Trimming comments until they fit is optimizing the wrong thing. This restores real headroom.

## What moves

The three 400-classification predicates — `isContextOverflow400`, `isParamValidation400`, `isModelScoped400` — decide whether an upstream 400 should advance the combo to the next target or hard-stop it. They are pure string classifiers that share the canonical pattern lists in `accountFallback.ts`; nothing about them belongs inside the routing loop.

`combo.ts` **3640 → 3610** (30 lines of headroom), new leaf is 55 lines.

## Behavior preservation

Verified mechanically, not by eye: each body was extracted from both revisions and compared after normalizing whitespace.

```
✅ isContextOverflow400
✅ isParamValidation400
✅ isModelScoped400
```

`combo.ts` imports them for its own fallback guard **and** re-exports them, so the public surface is unchanged — `tests/unit/combo-param-validation-fallback-4519.test.ts` still imports them from `combo.ts` with no modification and passes 6/6.

One thing worth flagging for anyone repeating this pattern: a bare `export { x } from "./leaf"` re-exports without binding the name locally, so `combo.ts`s own use of the predicates needed a separate `import`. `typecheck:core` caught it — a decomposition that only re-exports will compile-fail rather than fail silently.

## Verification

| check | result |
| --- | --- |
| body faithfulness | **3/3 byte-identical** |
| `combo-param-validation-fallback-4519` (existing suite, unmodified) | **6/6 pass** |
| combo regression sweep | pass, except the base-red below |
| `typecheck:core`, `check-file-size`, `check:any-budget:t11` | clean |

## Inherited base-red (not from this PR)

Confirmed red on `upstream/release/v3.8.49` untouched: `live repo: no NEW unexported db modules beyond the frozen allowlist`. Plus the repo-wide **lint** (stale suppression — #8544) and **file-size** (`providers/page.tsx`, `tokenHealthCheck.ts` — #8532 / #8524).