### PR TITLE
add misilelab docker workflow and claude model strip fallback

### DIFF
--- a/.github/workflows/dockerhub-misilelab.yml
+++ b/.github/workflows/dockerhub-misilelab.yml
@@ -1,0 +1,63 @@
+name: Publish misilelab/omniroute to Docker Hub
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: misilelab/omniroute
+
+jobs:
+  publish:
+    name: Build and push image
+    if: github.repository == 'MisileLab/OmniRoute'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+          labels: |
+            org.opencontainers.image.title=omniroute
+            org.opencontainers.image.description=Unified AI proxy/router
+            org.opencontainers.image.url=https://github.com/MisileLab/OmniRoute
+            org.opencontainers.image.source=https://github.com/MisileLab/OmniRoute
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: runner-base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/open-sse/services/systemTransforms.ts
+++ b/open-sse/services/systemTransforms.ts
@@ -439,12 +439,13 @@ export function applyTransformPipeline(
 export function applySystemTransformPipeline(
   providerId: string,
   body: RequestBody,
-  config: SystemTransformsConfig = getSystemTransformsConfig()
+  config: SystemTransformsConfig = getSystemTransformsConfig(),
+  modelId?: string
 ): ApplyPipelineResult {
   if (!body || typeof body !== "object") return { body, appliedOpKinds: [] };
   if (!config || !config.providers) return { body, appliedOpKinds: [] };
 
-  const providerConfig = resolveProviderConfig(providerId, config);
+  const providerConfig = resolveProviderConfig(providerId, config, modelId);
   if (!providerConfig || !providerConfig.enabled) {
     return { body, appliedOpKinds: [] };
   }
@@ -454,7 +455,8 @@ export function applySystemTransformPipeline(
 
 function resolveProviderConfig(
   providerId: string,
-  config: SystemTransformsConfig
+  config: SystemTransformsConfig,
+  modelId?: string
 ): ProviderTransformsConfig | undefined {
   if (!providerId) return undefined;
   const exact = config.providers[providerId];
@@ -463,6 +465,17 @@ function resolveProviderConfig(
   // CC bridge providers (anthropic-compatible-cc-*) all share one config.
   if (providerId.startsWith(`${PROVIDER_CC_BRIDGE}-`) || providerId === PROVIDER_CC_BRIDGE) {
     return config.providers[PROVIDER_CC_BRIDGE];
+  }
+
+  // Apply Claude strip pipeline for any model id that starts with "claude".
+  // This ensures Anthropic-family slugs routed through non-`claude` providers
+  // still get the same third-party-agent signal stripping.
+  if (
+    typeof modelId === "string" &&
+    /^claude(?:[/-]|$)/i.test(modelId.trim()) &&
+    config.providers[PROVIDER_CLAUDE]
+  ) {
+    return config.providers[PROVIDER_CLAUDE];
   }
   return undefined;
 }

--- a/open-sse/services/targetRequestSanitizer.ts
+++ b/open-sse/services/targetRequestSanitizer.ts
@@ -9,6 +9,7 @@
 
 import { stripUnsupportedParams } from "../translator/paramSupport.ts";
 import { sanitizeReasoningEffortForProvider } from "../executors/base/reasoningEffort.ts";
+import { applySystemTransformPipeline } from "./systemTransforms.ts";
 
 type JsonRecord = Record<string, unknown>;
 type LoggerLike =
@@ -78,6 +79,7 @@ export function sanitizeRequestForResolvedTarget<T extends JsonRecord>(
   // Apply operator-configured provider/model filters at the common dispatch
   // boundary so custom executors cannot accidentally bypass them.
   stripUnsupportedParams(options.provider, options.model, next);
+  applySystemTransformPipeline(options.provider || "", next, undefined, options.model);
 
   if (stripped.length > 0) {
     options.log?.debug?.(

--- a/tests/unit/service-system-transforms.test.ts
+++ b/tests/unit/service-system-transforms.test.ts
@@ -62,6 +62,19 @@ describe("systemTransforms", () => {
       const result = mod.applySystemTransformPipeline("claude", null as any);
       assert.equal(result.appliedOpKinds.length, 0);
     });
+
+    it("applies claude strip pipeline when model id starts with claude", () => {
+      mod.resetSystemTransformsConfig();
+      const body = {
+        system: [{ type: "text", text: "You are Hermes Agent.\n\nhttps://hermes-agent.nousresearch.com" }],
+        messages: [{ role: "user", content: "hi" }],
+      };
+      const result = mod.applySystemTransformPipeline("openrouter", body, undefined, "claude-3-5-sonnet");
+      const out = (body.system as Array<{ text: string }>)[0].text;
+      assert.ok(result.appliedOpKinds.length > 0);
+      assert.ok(!out.includes("You are Hermes Agent"));
+      assert.ok(!out.includes("hermes-agent.nousresearch.com"));
+    });
   });
 
   describe("constants", () => {


### PR DESCRIPTION
## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Run only the focused loop for what you changed — the full unit suite, Vitest, the
60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Focused tests for the change: `node --import tsx/esm --test tests/unit/<file>.test.ts`
- [ ] `npm run lint`
- [ ] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.