### PR TITLE
chore(ci): prune stale ESLint suppression count for proxy-registry.test.ts

### DIFF
--- a/changelog.d/maintenance/prune-stale-eslint-suppressions.md
+++ b/changelog.d/maintenance/prune-stale-eslint-suppressions.md
@@ -1,0 +1,1 @@
+- chore(ci): prune the stale ESLint suppression count that reddened the `No new ESLint warnings` gate on every open PR

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1937,7 +1937,7 @@
   },
   "tests/unit/proxy-registry.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 55
+      "count": 54
     }
   },
   "tests/unit/proxy-resolution-status-filter.test.ts": {


### PR DESCRIPTION
## Problem

`No new ESLint warnings` is currently red on **every open PR** in the repo, and not because of any PR's code. On the pure `release/v3.8.49` tip (measured at `7a8f9156da`, still true at `30709255c9`):

```
$ npm run lint:json -- --max-warnings 0
There are suppressions left that do not occur anymore. Consider re-running the command with `--prune-suppressions`.
$ echo $?
1
```

That is a **stale-suppressions** condition, not a lint violation — so no contributor or maintainer PR can clear it by fixing their own code.

## Root cause

`config/quality/eslint-suppressions.json` froze `tests/unit/proxy-registry.test.ts` at `@typescript-eslint/no-explicit-any: { count: 55 }`. #8447 (per-key proxy global toggle, merged earlier today) edited that test file and removed one `any` occurrence, leaving 54 actual violations against a frozen count of 55. ESLint's suppression matcher treats an over-count as a stale entry and fails the run.

## Fix

Ran the tool's own remedy and kept the result minimal:

```
npx eslint --suppressions-location config/quality/eslint-suppressions.json --prune-suppressions .
```

Net diff is **one line** — `55` → `54`. No entry added, none removed (481 before, 481 after). The prune writer also stripped the file's trailing newline; that was restored by hand so the diff carries nothing but the count.

## Verification

- `npm run lint:json -- --max-warnings 0` → **exit 0** (was exit 1 on the tip)
- `config/quality/eslint-suppressions.json` parses, 481 entries, trailing newline intact
- `node scripts/check/check-changelog-integrity.mjs` → OK

## Scope note

Deliberately scoped to the one stale count. No suppression was added, no violation was newly suppressed, and no other ratchet baseline was touched — this only re-syncs a frozen count with reality so the gate can go green again.

Refs #8007