### PR TITLE
fix(backend): add error.code to synthOpenAIErrorChunk for guard compatibility

### DIFF
--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -122,6 +122,7 @@ export function synthOpenAIErrorChunk(opts: {
     error: {
       message: safeMessage,
       type: "upstream_empty_response",
+      code: "upstream_empty_response",
     },
   };
   return `data: ${JSON.stringify(body)}\n\n`;

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -39,6 +39,7 @@ test("synthOpenAIErrorChunk payload has expected OpenAI chunk shape", () => {
   assert.equal(payload.choices.length, 1);
   assert.ok(payload.error, "must have error field");
   assert.equal(payload.error.type, "upstream_empty_response");
+  assert.equal(payload.error.code, "upstream_empty_response");
   assert.ok(typeof payload.error.message === "string" && payload.error.message.length > 0);
 });
 


### PR DESCRIPTION
Closes #8469

## Problem
synthOpenAIErrorChunk() sets error.type to upstream_empty_response but omits error.code. The isRequestScopedUpstreamFailure guard only checks type for context_length_exceeded, so an upstream_empty_response error slips past it.

## Fix
- Added code: upstream_empty_response to the error object in synthOpenAIErrorChunk()
- Added test assertion verifying error.code matches error.type

This ensures the guard correctly identifies upstream empty responses as request-scoped failures.
