### PR TITLE
chore(deps): patch js-yaml + postcss (2 high Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ink-text-input": "^6.0.0",
         "ioredis": "^5.10.1",
         "jose": "^6.2.3",
-        "js-yaml": "^5.0.0",
+        "js-yaml": "^5.2.2",
         "jsonc-parser": "^3.3.1",
         "lowdb": "^7.0.1",
         "lucide-react": "^1.21.0",
@@ -103,7 +103,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
@@ -23683,9 +23683,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -27778,9 +27778,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -30080,9 +30080,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -30099,7 +30099,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "ink-text-input": "^6.0.0",
     "ioredis": "^5.10.1",
     "jose": "^6.2.3",
-    "js-yaml": "^5.0.0",
+    "js-yaml": "^5.2.2",
     "jsonc-parser": "^3.3.1",
     "lowdb": "^7.0.1",
     "lucide-react": "^1.21.0",
@@ -394,7 +394,7 @@
     "dompurify": "^3.4.12",
     "fast-xml-parser": "^5.10.1",
     "sharp": "^0.35.0",
-    "postcss": "^8.5.14",
+    "postcss": "^8.5.18",
     "ip-address": "10.2.0",
     "qs": "^6.15.2",
     "uuid": "^14.0.0",
@@ -418,6 +418,12 @@
     "concurrently": {
       "shell-quote": "^1.9.0"
     },
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "promptfoo": {
+      "js-yaml": "^5.2.2",
+      "@apidevtools/json-schema-ref-parser": {
+        "js-yaml": "^4.2.0"
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes the two open Dependabot alerts on `release/v3.8.49`.

| Alert | Package | Advisory | Severity | Fix |
|---|---|---|---|---|
| #148 | js-yaml `5.2.1` | [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) (CWE-407, CVSS 7.5) | high | → `5.2.2` |
| #146 | postcss `8.5.14` | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (CWE-22, CVSS 7.5) | high | → `8.5.23` |

**js-yaml** — flow collections parse in exponential time: when a flow-sequence entry turns out to be a `key: value` pair, the parser rewinds and re-parses it as the key, so a nested payload under 200 bytes is O(2^n) and hangs any `load()`/`loadAll()` on untrusted input. `maxDepth: 100` does not help — 30–40 levels already exhaust the budget.

**postcss** — `previous-map.js` auto-loads the path in a `/*# sourceMappingURL=... */` comment on every `parse()`/`process()` unless the caller passes `map: false` (opt-out, not opt-in). The annotation is attacker-controlled and reaches `join(dirname(opts.from), annotation)` unsanitized, so `../../..` discloses an arbitrary `.map` file.

### Changes

- `package.json`: `js-yaml` floor `^5.0.0` → `^5.2.2`; `overrides.postcss` `^8.5.14` → `^8.5.18`.
- New scoped override for `promptfoo`, which pins `js-yaml@5.2.1` exactly and would otherwise keep the vulnerable copy nested in the tree. The inner override keeps `@apidevtools/json-schema-ref-parser` on `js-yaml ^4.2.0` — without it npm applies the override across the whole `promptfoo` subtree and silently majors that dependency from 4.x to 5.x.

### Verification

Structural `packages{}` diff against the base — three versions, nothing added, nothing removed:

```
node_modules/js-yaml: 5.2.1 → 5.2.2
node_modules/postcss: 8.5.14 → 8.5.23   (>= the 8.5.18 patch)
node_modules/nanoid:  3.3.11 → 3.3.16   (postcss's own dep)
```

No vulnerable copy remains anywhere in the lockfile. `npm run check:lockfile` passes.

Lockfile-only for the resolved tree; no source changes, so no test changes.