### PR TITLE
fix(sse): cache tls-client-node binary under DATA_DIR (#8579)

### DIFF
--- a/open-sse/services/chatgptTlsClient.ts
+++ b/open-sse/services/chatgptTlsClient.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mkdtemp, open, unlink, rmdir, stat, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { buildNativeTlsClientOptions } from "./tlsClientDownloadDir.ts";
 
 let clientPromise: Promise<unknown> | null = null;
 let exitHookInstalled = false;
@@ -130,7 +131,7 @@ async function getClient(): Promise<{
         // Native mode loads the shared library directly via koffi, avoiding the
         // managed sidecar's localhost HTTP calls that OmniRoute's global fetch
         // proxy patch interferes with.
-        const client = new TLSClient({ runtimeMode: "native" }) as {
+        const client = new TLSClient(buildNativeTlsClientOptions()) as {
           start: () => Promise<void>;
           request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike>;
         };

--- a/open-sse/services/claudeTlsClient.ts
+++ b/open-sse/services/claudeTlsClient.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mkdtemp, open, unlink, rmdir, stat } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { buildNativeTlsClientOptions } from "./tlsClientDownloadDir.ts";
 
 let clientPromise: Promise<unknown> | null = null;
 let exitHookInstalled = false;
@@ -129,7 +130,7 @@ async function getClient(): Promise<{
         // Native mode loads the shared library directly via koffi, avoiding the
         // managed sidecar's localhost HTTP calls that OmniRoute's global fetch
         // proxy patch interferes with.
-        const client = new TLSClient({ runtimeMode: "native" }) as {
+        const client = new TLSClient(buildNativeTlsClientOptions()) as {
           start: () => Promise<void>;
           request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike>;
         };

--- a/open-sse/services/grokTlsClient.ts
+++ b/open-sse/services/grokTlsClient.ts
@@ -21,6 +21,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { mkdtemp, open, unlink, rmdir, stat } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { buildNativeTlsClientOptions } from "./tlsClientDownloadDir.ts";
 
 let clientPromise: Promise<unknown> | null = null;
 let exitHookInstalled = false;
@@ -133,7 +134,7 @@ async function getClient(): Promise<{
         // Native mode loads the shared library directly via koffi, avoiding the
         // managed sidecar's localhost HTTP calls that OmniRoute's global fetch
         // proxy patch interferes with.
-        const client = new TLSClient({ runtimeMode: "native" }) as {
+        const client = new TLSClient(buildNativeTlsClientOptions()) as {
           start: () => Promise<void>;
           request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike>;
         };

--- a/open-sse/services/lmarenaTlsClient.ts
+++ b/open-sse/services/lmarenaTlsClient.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { mkdtemp, open, unlink, rmdir, stat } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { buildNativeTlsClientOptions } from "./tlsClientDownloadDir.ts";
 
 let clientPromise: Promise<unknown> | null = null;
 let exitHookInstalled = false;
@@ -132,7 +133,7 @@ async function getClient(): Promise<{
         // Native mode loads the shared library directly via koffi, avoiding the
         // managed sidecar's localhost HTTP calls that OmniRoute's global fetch
         // proxy patch interferes with.
-        const client = new TLSClient({ runtimeMode: "native" }) as {
+        const client = new TLSClient(buildNativeTlsClientOptions()) as {
           start: () => Promise<void>;
           request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike>;
         };

--- a/open-sse/services/notionTlsClient.ts
+++ b/open-sse/services/notionTlsClient.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mkdtemp, open, unlink, rmdir, stat } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { buildNativeTlsClientOptions } from "./tlsClientDownloadDir.ts";
 
 let clientPromise: Promise<unknown> | null = null;
 let exitHookInstalled = false;
@@ -131,7 +132,7 @@ async function getClient(): Promise<{
         // Native mode loads the shared library directly via koffi, avoiding the
         // managed sidecar's localhost HTTP calls that OmniRoute's global fetch
         // proxy patch interferes with.
-        const client = new TLSClient({ runtimeMode: "native" }) as {
+        const client = new TLSClient(buildNativeTlsClientOptions()) as {
           start: () => Promise<void>;
           request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike>;
         };

--- a/open-sse/services/perplexityTlsClient.ts
+++ b/open-sse/services/perplexityTlsClient.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mkdtemp, open, unlink, rmdir, stat } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { buildNativeTlsClientOptions } from "./tlsClientDownloadDir.ts";
 
 let clientPromise: Promise<unknown> | null = null;
 let exitHookInstalled = false;
@@ -131,7 +132,7 @@ async function getClient(): Promise<{
         // Native mode loads the shared library directly via koffi, avoiding the
         // managed sidecar's localhost HTTP calls that OmniRoute's global fetch
         // proxy patch interferes with.
-        const client = new TLSClient({ runtimeMode: "native" }) as {
+        const client = new TLSClient(buildNativeTlsClientOptions()) as {
           start: () => Promise<void>;
           request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike>;
         };

--- a/open-sse/services/tlsClientDownloadDir.ts
+++ b/open-sse/services/tlsClientDownloadDir.ts
@@ -1,0 +1,23 @@
+import { join } from "node:path";
+import { resolveDataDir } from "@/lib/dataPaths";
+
+/**
+ * Writable cache directory for tls-client-node's native binary.
+ *
+ * Without an explicit `downloadDir`, the library defaults to its own package
+ * `node_modules/tls-client-node/bin`, which is root-owned on global installs
+ * and fails with EACCES for normal users (#8579).
+ */
+export function resolveTlsClientDownloadDir(): string {
+  return join(resolveDataDir(), "tls-client", "bin");
+}
+
+export function buildNativeTlsClientOptions(): {
+  runtimeMode: "native";
+  downloadDir: string;
+} {
+  return {
+    runtimeMode: "native",
+    downloadDir: resolveTlsClientDownloadDir(),
+  };
+}

--- a/tests/unit/tls-client-download-dir-8579.test.ts
+++ b/tests/unit/tls-client-download-dir-8579.test.ts
@@ -1,0 +1,71 @@
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+const TLS_CLIENT_MODULES = [
+  "open-sse/services/chatgptTlsClient.ts",
+  "open-sse/services/claudeTlsClient.ts",
+  "open-sse/services/grokTlsClient.ts",
+  "open-sse/services/perplexityTlsClient.ts",
+  "open-sse/services/lmarenaTlsClient.ts",
+  "open-sse/services/notionTlsClient.ts",
+] as const;
+
+const originalDataDir = process.env.DATA_DIR;
+
+afterEach(() => {
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+});
+
+test("resolveTlsClientDownloadDir caches native binary under DATA_DIR/tls-client/bin (#8579)", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "omniroute-tls-client-8579-"));
+  process.env.DATA_DIR = dataDir;
+
+  const { resolveTlsClientDownloadDir } = await import(
+    "../../open-sse/services/tlsClientDownloadDir.ts"
+  );
+
+  assert.equal(resolveTlsClientDownloadDir(), join(dataDir, "tls-client", "bin"));
+});
+
+test("buildNativeTlsClientOptions passes downloadDir to tls-client-node (#8579)", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "omniroute-tls-client-opts-8579-"));
+  process.env.DATA_DIR = dataDir;
+
+  const { buildNativeTlsClientOptions } = await import(
+    "../../open-sse/services/tlsClientDownloadDir.ts"
+  );
+
+  const options = buildNativeTlsClientOptions();
+
+  assert.equal(options.runtimeMode, "native");
+  assert.equal(options.downloadDir, join(dataDir, "tls-client", "bin"));
+});
+
+test("all web-provider tls clients wire downloadDir through buildNativeTlsClientOptions (#8579)", () => {
+  for (const relPath of TLS_CLIENT_MODULES) {
+    const source = readFileSync(join(ROOT, relPath), "utf8");
+    assert.match(
+      source,
+      /buildNativeTlsClientOptions\(\)/,
+      `${relPath} must pass buildNativeTlsClientOptions() to TLSClient`
+    );
+    assert.doesNotMatch(
+      source,
+      /new TLSClient\(\{\s*runtimeMode:\s*"native"\s*\}\)/,
+      `${relPath} must not construct TLSClient without downloadDir`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Pass explicit `downloadDir` to every `tls-client-node` `TLSClient` bootstrap so the native binary is cached under `<DATA_DIR>/tls-client/bin` instead of the root-owned package path inside `node_modules`.
- Add shared helper `buildNativeTlsClientOptions()` in `open-sse/services/tlsClientDownloadDir.ts` and wire all six web-provider TLS clients through it (chatgpt-web, claude-web, grok-web, perplexity-web, lmarena, notion-web).
- Add regression tests asserting the download path resolves under `DATA_DIR` and that no TLS client constructs `TLSClient` without `downloadDir`.

Fixes #8579

## Root cause

On global install (`npm i -g omniroute`), `tls-client-node` defaulted to downloading into `node_modules/tls-client-node/bin`, which is root-owned and fails with `EACCES` for normal users.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/tls-client-download-dir-8579.test.ts` (3 passed)
