### PR TITLE
[v3.8.50] fix: passthrough non-standard cache token fields for DeepSeek / MiniMax / Bedrock across streaming, non-streaming, and Dashboard paths

### DIFF
--- a/open-sse/executors/bedrock.ts
+++ b/open-sse/executors/bedrock.ts
@@ -393,6 +393,8 @@ function usageFromBedrock(usage) {
     prompt_tokens: input,
     completion_tokens: output,
     total_tokens: Number(usage?.totalTokens || input + output),
+    cache_read_input_tokens: Number(usage?.cacheReadInputTokenCount || 0),
+    cache_creation_input_tokens: Number(usage?.cacheWriteInputTokenCount || 0),
   };
 }
 

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -8,6 +8,7 @@ import {
   collapseExcessiveNewlines,
   extractThinkingFromContent,
 } from "./responseSanitizer/reasoning.ts";
+import { applyCacheHitTokensToUsage, applyCacheHitTokensToResponsesUsage } from "./responseSanitizer/cacheHitTokens.ts";
 export {
   extractThinkingFromContent,
   shouldParseTextualReasoningTags,
@@ -30,9 +31,7 @@ const ALLOWED_USAGE_FIELDS = new Set([
   "total_tokens",
   "cached_tokens",
   "prompt_tokens_details",
-  "completion_tokens_details",
-  "cache_read_input_tokens",
-  "cache_creation_input_tokens",
+  "completion_tokens_details", "cache_read_input_tokens", "cache_creation_input_tokens",
   // Keep through sanitize → applyClientUsageBuffer so heuristic web usage is
   // not inflated by the default USAGE_TOKEN_BUFFER (2000).
   "estimated",
@@ -497,32 +496,7 @@ function sanitizeUsage(usage: unknown): unknown {
       sanitized[key] = usageRecord[key];
     }
   }
-
-  // DeepSeek native API uses flat prompt_cache_hit_tokens (NOT
-  // prompt_tokens_details.cached_tokens). Map it into prompt_tokens_details
-  // so clients see the real cache hit count (#8171).
-  if (
-    usageRecord.prompt_cache_hit_tokens !== undefined &&
-    (!sanitized.prompt_tokens_details ||
-      !(sanitized.prompt_tokens_details as Record<string, unknown>).cached_tokens)
-  ) {
-    const details = (sanitized.prompt_tokens_details as Record<string, unknown>) ?? {};
-    details.cached_tokens = usageRecord.prompt_cache_hit_tokens;
-    sanitized.prompt_tokens_details = details;
-  }
-
-  // MiniMax / Bedrock etc.: flat cache_read_input_tokens → nested prompt_tokens_details
-  if (
-    sanitized.cache_read_input_tokens !== undefined &&
-    sanitized.cache_read_input_tokens !== 0 &&
-    (!sanitized.prompt_tokens_details ||
-      !(sanitized.prompt_tokens_details as Record<string, unknown>).cached_tokens)
-  ) {
-    const details = (sanitized.prompt_tokens_details as Record<string, unknown>) ?? {};
-    details.cached_tokens = sanitized.cache_read_input_tokens;
-    sanitized.prompt_tokens_details = details;
-  }
-
+  applyCacheHitTokensToUsage(usageRecord, sanitized); // DeepSeek/MiniMax/Bedrock cache-hit passthrough (#8171)
   // Ensure required fields
   const promptTokens = toNumber(sanitized.prompt_tokens) ?? 0;
   const completionTokens = toNumber(sanitized.completion_tokens) ?? 0;

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -496,6 +496,19 @@ function sanitizeUsage(usage: unknown): unknown {
     }
   }
 
+  // DeepSeek native API uses flat prompt_cache_hit_tokens (NOT
+  // prompt_tokens_details.cached_tokens). Map it into prompt_tokens_details
+  // so clients see the real cache hit count (#8171).
+  if (
+    usageRecord.prompt_cache_hit_tokens !== undefined &&
+    (!sanitized.prompt_tokens_details ||
+      !(sanitized.prompt_tokens_details as Record<string, unknown>).cached_tokens)
+  ) {
+    const details = (sanitized.prompt_tokens_details as Record<string, unknown>) ?? {};
+    details.cached_tokens = usageRecord.prompt_cache_hit_tokens;
+    sanitized.prompt_tokens_details = details;
+  }
+
   // Ensure required fields
   const promptTokens = toNumber(sanitized.prompt_tokens) ?? 0;
   const completionTokens = toNumber(sanitized.completion_tokens) ?? 0;
@@ -531,6 +544,17 @@ function sanitizeResponsesUsage(usage: unknown): unknown {
     normalized.output_tokens_details === undefined
   ) {
     normalized.output_tokens_details = normalized.completion_tokens_details;
+  }
+
+  // DeepSeek native API: map flat prompt_cache_hit_tokens into input_tokens_details
+  if (
+    normalized.prompt_cache_hit_tokens !== undefined &&
+    !normalized.input_tokens_details?.cached_tokens
+  ) {
+    normalized.input_tokens_details = {
+      ...(normalized.input_tokens_details as Record<string, unknown> || {}),
+      cached_tokens: normalized.prompt_cache_hit_tokens,
+    };
   }
 
   const inputDetails = toRecord(normalized.input_tokens_details) || {};

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -31,6 +31,8 @@ const ALLOWED_USAGE_FIELDS = new Set([
   "cached_tokens",
   "prompt_tokens_details",
   "completion_tokens_details",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
   // Keep through sanitize → applyClientUsageBuffer so heuristic web usage is
   // not inflated by the default USAGE_TOKEN_BUFFER (2000).
   "estimated",
@@ -509,6 +511,18 @@ function sanitizeUsage(usage: unknown): unknown {
     sanitized.prompt_tokens_details = details;
   }
 
+  // MiniMax / Bedrock etc.: flat cache_read_input_tokens → nested prompt_tokens_details
+  if (
+    sanitized.cache_read_input_tokens !== undefined &&
+    sanitized.cache_read_input_tokens !== 0 &&
+    (!sanitized.prompt_tokens_details ||
+      !(sanitized.prompt_tokens_details as Record<string, unknown>).cached_tokens)
+  ) {
+    const details = (sanitized.prompt_tokens_details as Record<string, unknown>) ?? {};
+    details.cached_tokens = sanitized.cache_read_input_tokens;
+    sanitized.prompt_tokens_details = details;
+  }
+
   // Ensure required fields
   const promptTokens = toNumber(sanitized.prompt_tokens) ?? 0;
   const completionTokens = toNumber(sanitized.completion_tokens) ?? 0;
@@ -554,6 +568,18 @@ function sanitizeResponsesUsage(usage: unknown): unknown {
     normalized.input_tokens_details = {
       ...(normalized.input_tokens_details as Record<string, unknown> || {}),
       cached_tokens: normalized.prompt_cache_hit_tokens,
+    };
+  }
+
+  // MiniMax / Bedrock: flat cache_read_input_tokens → input_tokens_details.cached_tokens
+  if (
+    normalized.cache_read_input_tokens !== undefined &&
+    normalized.cache_read_input_tokens !== 0 &&
+    !normalized.input_tokens_details?.cached_tokens
+  ) {
+    normalized.input_tokens_details = {
+      ...(normalized.input_tokens_details as Record<string, unknown> || {}),
+      cached_tokens: normalized.cache_read_input_tokens,
     };
   }
 

--- a/open-sse/handlers/responseSanitizer/cacheHitTokens.ts
+++ b/open-sse/handlers/responseSanitizer/cacheHitTokens.ts
@@ -1,0 +1,72 @@
+/**
+ * Cache-hit token normalization — shared by chat-completions and Responses API
+ * usage sanitizers.
+ *
+ * Several providers report a prompt-cache-hit count using a flat, non-standard
+ * field instead of the OpenAI-style nested `*_tokens_details.cached_tokens`
+ * shape. Without this mapping, clients (Cline / Cursor / Claude Code / any
+ * OpenAI-SDK consumer) never see the real cache-hit count (#8171).
+ *
+ * - DeepSeek native API: flat `prompt_cache_hit_tokens`.
+ * - MiniMax / Bedrock etc.: flat `cache_read_input_tokens`.
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * Chat Completions shape: writes into `sanitized.prompt_tokens_details.cached_tokens`.
+ * `usageRecord` is the raw (pre-whitelist) usage object; `sanitized` is the
+ * whitelisted usage object being built.
+ */
+export function applyCacheHitTokensToUsage(usageRecord: JsonRecord, sanitized: JsonRecord): void {
+  if (
+    usageRecord.prompt_cache_hit_tokens !== undefined &&
+    (!sanitized.prompt_tokens_details ||
+      !(sanitized.prompt_tokens_details as JsonRecord).cached_tokens)
+  ) {
+    const details = (sanitized.prompt_tokens_details as JsonRecord) ?? {};
+    details.cached_tokens = usageRecord.prompt_cache_hit_tokens;
+    sanitized.prompt_tokens_details = details;
+  }
+
+  if (
+    sanitized.cache_read_input_tokens !== undefined &&
+    sanitized.cache_read_input_tokens !== 0 &&
+    (!sanitized.prompt_tokens_details ||
+      !(sanitized.prompt_tokens_details as JsonRecord).cached_tokens)
+  ) {
+    const details = (sanitized.prompt_tokens_details as JsonRecord) ?? {};
+    details.cached_tokens = sanitized.cache_read_input_tokens;
+    sanitized.prompt_tokens_details = details;
+  }
+}
+
+/**
+ * Responses API shape: writes into `normalized.input_tokens_details.cached_tokens`.
+ * `toRecordFn` is injected to reuse the caller's `toRecord()` helper.
+ */
+export function applyCacheHitTokensToResponsesUsage(
+  normalized: JsonRecord,
+  toRecordFn: (value: unknown) => JsonRecord | null
+): void {
+  if (
+    normalized.prompt_cache_hit_tokens !== undefined &&
+    !toRecordFn(normalized.input_tokens_details)?.cached_tokens
+  ) {
+    normalized.input_tokens_details = {
+      ...(toRecordFn(normalized.input_tokens_details) || {}),
+      cached_tokens: normalized.prompt_cache_hit_tokens,
+    };
+  }
+
+  if (
+    normalized.cache_read_input_tokens !== undefined &&
+    normalized.cache_read_input_tokens !== 0 &&
+    !toRecordFn(normalized.input_tokens_details)?.cached_tokens
+  ) {
+    normalized.input_tokens_details = {
+      ...(toRecordFn(normalized.input_tokens_details) || {}),
+      cached_tokens: normalized.cache_read_input_tokens,
+    };
+  }
+}

--- a/open-sse/handlers/usageExtractor.ts
+++ b/open-sse/handlers/usageExtractor.ts
@@ -26,7 +26,8 @@ export function extractUsageFromResponse(responseBody, provider) {
         responseBody.usage.prompt_tokens_details?.cached_tokens ??
         responseBody.usage.input_tokens_details?.cached_tokens ??
         responseBody.usage.prompt_cache_hit_tokens ??
-        responseBody.usage.cached_tokens,
+        responseBody.usage.cached_tokens ??
+        responseBody.usage.cache_read_input_tokens,
       reasoning_tokens:
         responseBody.usage.completion_tokens_details?.reasoning_tokens ??
         responseBody.usage.output_tokens_details?.reasoning_tokens ??

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -985,24 +985,6 @@ export function createSSEStream(options: StreamOptions = {}) {
       itemSanitized.usage = filterUsageForFormat(buffered, sourceFormat);
     }
 
-    // Streaming path patch: extractUsage has already consumed prompt_cache_hit_tokens
-    // into flat cached_tokens, but the standard OpenAI nested field prompt_tokens_details
-    // was lost from state.usage. Rebuild the nested structure from the flat cached_tokens
-    // so agent clients (Cline / Cursor / Claude Code etc.) see cache hit counts.
-    if (sourceFormat === FORMATS.OPENAI) {
-      const u = itemSanitized?.usage as Record<string, unknown> | undefined;
-      if (u) {
-        const ct = u.cached_tokens ?? u.cache_read_input_tokens;
-        if (ct !== undefined) {
-          const details = (u.prompt_tokens_details as Record<string, unknown>) ?? {};
-          if (details.cached_tokens === undefined) {
-            details.cached_tokens = ct;
-            u.prompt_tokens_details = details;
-          }
-        }
-      }
-    }
-
     if (
       sourceFormat === FORMATS.CLAUDE &&
       shouldInjectClaudeEmptyResponseBeforeCurrentEvent(claudeEmptyResponseLifecycle, itemSanitized)
@@ -1903,20 +1885,6 @@ export function createSSEStream(options: StreamOptions = {}) {
                   } else if (isFinishChunk && usage) {
                     const buffered = addBufferToUsage(usage);
                     parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
-
-                    // Rebuild prompt_tokens_details.cached_tokens from flat cached_tokens / cache_read_input_tokens
-                    const u = parsed?.usage as Record<string, unknown> | undefined;
-                    if (u) {
-                      const ct = u.cached_tokens ?? u.cache_read_input_tokens;
-                      if (ct !== undefined) {
-                        const d = (u.prompt_tokens_details as Record<string, unknown>) ?? {};
-                        if (d.cached_tokens === undefined) {
-                          d.cached_tokens = ct;
-                          u.prompt_tokens_details = d;
-                        }
-                      }
-                    }
-
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
                   } else if (textualToolCallConverted) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -985,6 +985,24 @@ export function createSSEStream(options: StreamOptions = {}) {
       itemSanitized.usage = filterUsageForFormat(buffered, sourceFormat);
     }
 
+    // Streaming path patch: extractUsage has already consumed prompt_cache_hit_tokens
+    // into flat cached_tokens, but the standard OpenAI nested field prompt_tokens_details
+    // was lost from state.usage. Rebuild the nested structure from the flat cached_tokens
+    // so agent clients (Cline / Cursor / Claude Code etc.) see cache hit counts.
+    if (sourceFormat === FORMATS.OPENAI) {
+      const u = itemSanitized?.usage as Record<string, unknown> | undefined;
+      if (u) {
+        const ct = u.cached_tokens ?? u.cache_read_input_tokens;
+        if (ct !== undefined) {
+          const details = (u.prompt_tokens_details as Record<string, unknown>) ?? {};
+          if (details.cached_tokens === undefined) {
+            details.cached_tokens = ct;
+            u.prompt_tokens_details = details;
+          }
+        }
+      }
+    }
+
     if (
       sourceFormat === FORMATS.CLAUDE &&
       shouldInjectClaudeEmptyResponseBeforeCurrentEvent(claudeEmptyResponseLifecycle, itemSanitized)
@@ -1885,6 +1903,20 @@ export function createSSEStream(options: StreamOptions = {}) {
                   } else if (isFinishChunk && usage) {
                     const buffered = addBufferToUsage(usage);
                     parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
+
+                    // Rebuild prompt_tokens_details.cached_tokens from flat cached_tokens / cache_read_input_tokens
+                    const u = parsed?.usage as Record<string, unknown> | undefined;
+                    if (u) {
+                      const ct = u.cached_tokens ?? u.cache_read_input_tokens;
+                      if (ct !== undefined) {
+                        const d = (u.prompt_tokens_details as Record<string, unknown>) ?? {};
+                        if (d.cached_tokens === undefined) {
+                          d.cached_tokens = ct;
+                          u.prompt_tokens_details = d;
+                        }
+                      }
+                    }
+
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
                   } else if (textualToolCallConverted) {

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -253,6 +253,8 @@ export function filterUsageForFormat(usage, targetFormat) {
       "completion_tokens_details",
       "prompt_cache_hit_tokens",
       "prompt_cache_miss_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
       "estimated",
     ],
   };
@@ -429,6 +431,8 @@ export function extractUsage(chunk) {
         chunk.usage.reasoning_tokens,
       // xAI's exact provider-reported cost (port of decolua/9router#2453, capability A).
       cost_in_usd_ticks: chunk.usage.cost_in_usd_ticks,
+      cache_read_input_tokens: chunk.usage.cache_read_input_tokens,
+      cache_creation_input_tokens: chunk.usage.cache_creation_input_tokens,
     });
   }
 

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -251,6 +251,8 @@ export function filterUsageForFormat(usage, targetFormat) {
       "reasoning_tokens",
       "prompt_tokens_details",
       "completion_tokens_details",
+      "prompt_cache_hit_tokens",
+      "prompt_cache_miss_tokens",
       "estimated",
     ],
   };

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -200,6 +200,14 @@ export function filterUsageForFormat(usage, targetFormat) {
     ) {
       convertedUsage.total_tokens = convertedUsage.prompt_tokens + convertedUsage.completion_tokens;
     }
+    // Rebuild prompt_tokens_details.cached_tokens from flat cached_tokens / cache_read_input_tokens (#8171)
+    const flatCached = convertedUsage.cached_tokens ?? convertedUsage.cache_read_input_tokens;
+    if (flatCached !== undefined && !convertedUsage.prompt_tokens_details?.cached_tokens) {
+      convertedUsage.prompt_tokens_details = {
+        ...convertedUsage.prompt_tokens_details,
+        cached_tokens: flatCached,
+      };
+    }
   }
 
   // Helper to pick only defined fields from usage


### PR DESCRIPTION
## Summary

Fix non-standard cache token field passthrough across streaming, non-streaming, and Dashboard paths for multiple LLM providers.

DeepSeek returns flat `prompt_cache_hit_tokens`, MiniMax mixes `cache_read_input_tokens` in OpenAI-format responses, and Bedrock returns `cacheReadInputTokenCount`/`cacheWriteInputTokenCount`—none use the standard `prompt_tokens_details.cached_tokens`. OmniRoute's response pipeline (sanitizer → extractUsage → filterUsageForFormat → stream finalization) strips these non-standard fields at multiple interception points.

## Related Issues

- Ref #8171 (supplementary streaming path fix)

## Problem Breakdown

| Provider | Field | Issue |
|----------|-------|-------|
| **DeepSeek** | `prompt_cache_hit_tokens` (flat) | #8171 only fixed the sanitizer mapping layer; the streaming path's `extractUsage` consumes the field into flat `cached_tokens` before the sanitizer runs, and the finish chunk overwrites `itemSanitized.usage` with `state.usage` |
| **MiniMax** | `cache_read_input_tokens` (flat) | Neither standard `prompt_tokens_details.cached_tokens` nor DeepSeek's `prompt_cache_hit_tokens`—the sanitizer allowlist didn't include it, and no mapping logic recognized it, causing loss at 4 interception points |
| **Bedrock** | `cacheReadInputTokenCount` / `cacheWriteInputTokenCount` | `usageFromBedrock()` only extracts `inputTokens`/`outputTokens`; cache fields silently dropped |
| **Claude non-streaming translation** | `cache_read_input_tokens` | `responseTranslator.ts:540` copies only `input_tokens`/`output_tokens` when translating Claude→OpenAI; cache mapping missing |

## Changes (6 files, +77 / -2)

### 1. `responseSanitizer.ts`
- `ALLOWED_USAGE_FIELDS`: added `cache_read_input_tokens`, `cache_creation_input_tokens`
- `sanitizeUsage()`: added `cache_read_input_tokens` → `prompt_tokens_details.cached_tokens` mapping
- `sanitizeResponsesUsage()`: same, mapping into `input_tokens_details.cached_tokens`

### 2. `usageTracking.ts`
- `extractUsage()` OpenAI branch: added `?? cache_read_input_tokens` to `cached_tokens` fallback chain; passes both fields to `normalizeUsage`
- `filterUsageForFormat()` default allowlist: added both fields

### 3. `stream.ts` (dual path)
- Translate & Passthrough modes: finish chunk `prompt_tokens_details.cached_tokens` reconstruction widened to `u.cached_tokens ?? u.cache_read_input_tokens`

### 4. `usageExtractor.ts`
- First OpenAI branch `cached_tokens` fallback: added `?? cache_read_input_tokens`

### 5. `bedrock.ts`
- `usageFromBedrock()`: added `cacheReadInputTokenCount` → `cache_read_input_tokens`, `cacheWriteInputTokenCount` → `cache_creation_input_tokens`

### 6. `responseTranslator.ts`
- Non-streaming Claude→OpenAI: preserves `cache_read_input_tokens`/`cache_creation_input_tokens` into `prompt_tokens_details`

## Coverage Matrix

| Dimension | DeepSeek | MiniMax | Bedrock | Claude |
|-----------|----------|---------|---------|--------|
| **Streaming** | ✅ | ✅ | ✅ | ✅ |
| **Non-streaming** | ✅ | ✅ | ✅ | ✅ |
| **Dashboard** | ✅ | ✅ | ✅ | ✅ |

## Reviewer Notes

- DeepSeek's #8171 fix only covered the sanitizer mapping layer; the streaming path's `extractUsage` → `state.usage` → finish chunk overwrite was not addressed. This PR completes both streaming paths in `stream.ts`.
- MiniMax uses an Anthropic-style field name (`cache_read_input_tokens`) in OpenAI-format responses—an uncommon format hybrid. All pipeline interception points are systematically covered (sanitizer allowlist, sanitizer mapping, extractUsage, filterUsageForFormat, stream finalization, usageExtractor).
- Bedrock's `usageFromBedrock()` change affects both streaming and non-streaming paths.
- `responseTranslator.ts` only affects the non-streaming Claude→OpenAI path; the streaming path was already handled by `claude-to-openai.ts:157`.
