### PR TITLE
test(context): isolate context-manager suite from local DATA_DIR

### DIFF
--- a/changelog.d/fixes/8568-context-manager-data-dir.md
+++ b/changelog.d/fixes/8568-context-manager-data-dir.md
@@ -1,0 +1,1 @@
+- fix(test): isolate `context-manager` unit tests on a temp `DATA_DIR` so `getTokenLimit` resolves against the registry fallback instead of the developer's local models.dev sync

--- a/tests/unit/context-manager.test.ts
+++ b/tests/unit/context-manager.test.ts
@@ -1,8 +1,23 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-context-manager-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
 
 const { compressContext, estimateTokens, getTokenLimit } =
   await import("../../open-sse/services/contextManager.ts");
+const core = await import("../../src/lib/db/core.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
 
 // ─── estimateTokens ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Pin `tests/unit/context-manager.test.ts` to a temporary `DATA_DIR` before importing `contextManager`, matching the isolation pattern used by other DB-touching unit suites.
- Restore the previous `DATA_DIR` and call `resetDbInstance()` in `test.after` so the suite no longer reads the developer's real `~/.omniroute` / models.dev sync.
- Add a changelog fragment for the test isolation fix.

Fixes #8568

## Test plan
- [x] `node --import tsx/esm --test tests/unit/context-manager.test.ts` → 16/16 pass
- [x] Confirm the suite opens SQLite under the temp `DATA_DIR` (not `~/.omniroute`)
- [ ] Re-run the same file with a populated local `~/.omniroute` models.dev sync and confirm it still stays green