### PR TITLE
fix(sse): route task-aware defaults by intent, fix fitness pattern shadowing (#8602, #8603)

### DIFF
--- a/changelog.d/fixes/8604-task-routing-config-restore.md
+++ b/changelog.d/fixes/8604-task-routing-config-restore.md
@@ -1,0 +1,1 @@
+- **fix(sse):** restore Task-Aware Routing config from `settings.taskRouting` at boot and keep it on `globalThis` so multi-graph imports share one store — stops the feature silently reverting to disabled on every restart (#8601) ([#8604](https://github.com/diegosouzapw/OmniRoute/pull/8604)) — thanks @MumuTW

--- a/changelog.d/fixes/8605-task-routing-auto-intent-fitness.md
+++ b/changelog.d/fixes/8605-task-routing-auto-intent-fitness.md
@@ -1,0 +1,1 @@
+- **fix(sse):** task-aware routing defaults use `auto/*` intents instead of hardcoded provider/model ids (#8602), and the longest-pattern-first fitness table match that landed upstream in 9f5be229b gains a direct regression guard, so rows like `gpt-4o-mini` cannot be shadowed by `gpt-4o` again (#8603) ([#8605](https://github.com/diegosouzapw/OmniRoute/pull/8605)) — thanks @MumuTW

--- a/open-sse/services/autoCombo/__tests__/taskFitness-pattern-order-8603.test.ts
+++ b/open-sse/services/autoCombo/__tests__/taskFitness-pattern-order-8603.test.ts
@@ -1,0 +1,56 @@
+/**
+ * TDD regression for #8603: the static fitness table was matched with
+ * `String.includes` over declaration order, so a SHORTER pattern declared earlier
+ * shadowed a model's own, more specific row.
+ *
+ * `FITNESS_TABLE.coding` declares `"gpt-4o": 0.9` before `"gpt-4o-mini": 0.8`, so
+ * `"gpt-4o-mini".includes("gpt-4o")` hit first and an explicitly cheap model
+ * inherited the flagship's task fitness. Its own row was unreachable.
+ *
+ * The fix matches longest-pattern-first, so the most specific row always wins
+ * regardless of how the table happens to be authored.
+ *
+ * Blast radius: `taskFit` is weight 0.08 in DEFAULT_WEIGHTS and 0.37 in the
+ * `quality-first` mode pack. The static table is layer 4 of the 5-layer resolution
+ * chain, so this surfaces for models with no arena_elo / models.dev coverage — the
+ * long tail of the provider catalog.
+ */
+import { describe, it, expect } from "vitest";
+import { getStaticFitnessTableScore } from "../taskFitness";
+
+describe("#8603 static fitness table matches longest pattern first", () => {
+  it("scores gpt-4o-mini from its own row, not gpt-4o's", () => {
+    // Before the fix this returned 0.9 (the flagship's score).
+    expect(getStaticFitnessTableScore("gpt-4o-mini", "coding")).toBe(0.8);
+  });
+
+  it("scores deepseek-v3.2 from its own row, not deepseek-v3's", () => {
+    // Before the fix this returned 0.85.
+    expect(getStaticFitnessTableScore("deepseek-v3.2", "coding")).toBe(0.86);
+  });
+
+  it("keeps the flagship rows intact", () => {
+    expect(getStaticFitnessTableScore("gpt-4o", "coding")).toBe(0.9);
+    expect(getStaticFitnessTableScore("deepseek-v3", "coding")).toBe(0.85);
+  });
+
+  it("still resolves rows that were already correct", () => {
+    expect(getStaticFitnessTableScore("gemini-2.5-flash", "coding")).toBe(0.82);
+    expect(getStaticFitnessTableScore("o4-mini", "coding")).toBe(0.88);
+    expect(getStaticFitnessTableScore("gpt-4-turbo", "coding")).toBe(0.88);
+  });
+
+  it("resolves provider-prefixed and suffixed ids to the most specific row", () => {
+    // Real ids carry prefixes/suffixes; the longest matching pattern must still win.
+    expect(getStaticFitnessTableScore("openai/gpt-4o-mini-2024-07-18", "coding")).toBe(0.8);
+  });
+
+  it("falls back to the default table for an unknown task type", () => {
+    // "claude-sonnet" is absent from a nonexistent table but present in `default`.
+    expect(getStaticFitnessTableScore("claude-sonnet", "no-such-task")).toBe(0.85);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(getStaticFitnessTableScore("totally-unknown-model", "coding")).toBeNull();
+  });
+});

--- a/open-sse/services/autoCombo/taskFitness.ts
+++ b/open-sse/services/autoCombo/taskFitness.ts
@@ -301,13 +301,34 @@ export function getModelsDevTierFitness(model: string, taskType: string): number
 
 // ─── Resolution chain ───────────────────────────────────────────────────
 
-function lookupStaticFitnessTable(normalizedModel: string, normalizedTask: string): number | null {
+/**
+ * Resolve a model id against the static fitness table, LONGEST PATTERN FIRST (#8603).
+ *
+ * The shadowing itself is already fixed on `release/v3.8.49` (9f5be229b): matching used
+ * to return the first `String.includes` hit in declaration order, so a shorter pattern
+ * declared earlier shadowed a model's own, more specific row — `FITNESS_TABLE.coding`
+ * declares `"gpt-4o": 0.9` before `"gpt-4o-mini": 0.8`, so `gpt-4o-mini` inherited the
+ * flagship's 0.9 and its own row was unreachable (same for `deepseek-v3.2` vs
+ * `deepseek-v3`). The length-ranked scan below is that upstream fix, unchanged.
+ *
+ * What this PR adds is only the exported seam: the surrounding resolution chain hits the
+ * DB (user_override / arena_elo / models.dev tier) before reaching layer 4, so pinning
+ * the ordering guarantee through `getTaskFitness` would depend on DB fixture state.
+ * `taskFitness-pattern-order-8603.test.ts` calls this directly instead.
+ */
+export function getStaticFitnessTableScore(model: string, taskType: string): number | null {
+  const normalizedModel = model.toLowerCase();
+  const normalizedTask = taskType.toLowerCase();
   const table = FITNESS_TABLE[normalizedTask] || FITNESS_TABLE.default;
   const entries = Object.entries(table).sort((a, b) => b[0].length - a[0].length);
   for (const [pattern, score] of entries) {
     if (normalizedModel.includes(pattern)) return score;
   }
   return null;
+}
+
+function lookupStaticFitnessTable(normalizedModel: string, normalizedTask: string): number | null {
+  return getStaticFitnessTableScore(normalizedModel, normalizedTask);
 }
 
 function lookupWildcardBoosts(normalizedModel: string, normalizedTask: string): number {

--- a/open-sse/services/taskAwareRouter.ts
+++ b/open-sse/services/taskAwareRouter.ts
@@ -1,17 +1,21 @@
 /**
  * Task-Aware Smart Router — T05
  *
- * Detects the semantic type of an incoming chat request and routes
- * to the most appropriate (optimal cost/quality) model for that task type.
+ * Detects the semantic type of an incoming chat request and routes it to a routing
+ * INTENT, letting the auto-combo scorer pick the concrete model from whatever the
+ * operator has connected. Defaults never name a provider/model id (#8602).
  *
- * Task types:
- *   - coding        → fast reasoning models (deepseek, codex, claude-sonnet)
- *   - creative      → expressive models (claude-opus, gpt-5)
- *   - analysis      → long-context + smart models (gemini-2.5-pro, claude-opus)
- *   - vision        → multimodal models (gpt-4o, gemini-2.5-flash, claude-3.5)
- *   - summarization → cheap fast models (gemini-flash, gpt-4o-mini)
- *   - background    → cheap utility models (same as backgroundTaskDetector)
- *   - chat          → default/balanced (no override)
+ * Task types → default intent:
+ *   - coding        → auto/coding
+ *   - analysis      → auto/reasoning
+ *   - vision        → auto/vision
+ *   - summarization → auto/chat:fast
+ *   - background    → auto/chat:cheap
+ *   - creative      → no override (use requested model)
+ *   - chat          → no override (use requested model)
+ *
+ * Operators can still point any task type at a specific model via
+ * PUT /api/settings/task-routing — the defaults just stop shipping stale ones.
  */
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -148,15 +152,33 @@ const TASK_PATTERNS: Record<TaskType, TaskPattern> = {
   },
 };
 
-// ── Default task → model map ─────────────────────────────────────────────────
+// ── Default task → routing-intent map ────────────────────────────────────────
 
+/**
+ * Defaults route by INTENT (`auto/<category>[:<tier>]`), never to a concrete
+ * provider/model id (#8602).
+ *
+ * The previous defaults named literal models (`openai/gpt-4o`,
+ * `gemini/gemini-2.5-flash-lite`, …). That was wrong twice over:
+ *
+ *  - The list rotted. Those ids aged out by a generation or two, and every model
+ *    release made them staler. Naming an intent instead removes the maintenance.
+ *  - It bypassed the router. `applyTaskAwareRouting` overwrites `body.model`, so a
+ *    literal target skipped auto-combo's 13-factor scoring (quota, circuit-breaker
+ *    health, cost, latency, stability), connection cooldown and model lockout — and
+ *    hard-failed for any operator who simply had no connection for that provider.
+ *
+ * `auto/*` ids resolve on demand against the operator's actually-connected backends
+ * (`autoCombo/suffixComposition.ts` → `autoCombo/virtualFactory.ts`) and degrade
+ * gracefully as backends rotate. Keep every entry here an `auto/` id.
+ */
 const DEFAULT_TASK_MODEL_MAP: Record<TaskType, string> = {
-  coding: "deepseek/deepseek-chat", // DeepSeek V3.2 — best coding OSS
+  coding: "auto/coding", // Best-scoring connected coding model
   creative: "", // No override — use requested model
-  analysis: "gemini/gemini-2.5-pro", // Best long-context reasoning
-  vision: "openai/gpt-4o", // Best vision baseline
-  summarization: "gemini/gemini-2.5-flash", // Fast + cheap for summarization
-  background: "gemini/gemini-2.5-flash-lite", // Cheapest for utility tasks
+  analysis: "auto/reasoning", // Reasoning-capable candidates only
+  vision: "auto/vision", // Vision-capable candidates only
+  summarization: "auto/chat:fast", // Latency-weighted pack
+  background: "auto/chat:cheap", // Cost-weighted pack for utility traffic
   chat: "", // No override — use requested model
 };
 

--- a/open-sse/services/taskAwareRouter.ts
+++ b/open-sse/services/taskAwareRouter.ts
@@ -17,13 +17,7 @@
 // ── Types ───────────────────────────────────────────────────────────────────
 
 export type TaskType =
-  | "coding"
-  | "creative"
-  | "analysis"
-  | "vision"
-  | "summarization"
-  | "background"
-  | "chat";
+  "coding" | "creative" | "analysis" | "vision" | "summarization" | "background" | "chat";
 
 interface TaskPattern {
   patterns: string[];
@@ -168,33 +162,90 @@ const DEFAULT_TASK_MODEL_MAP: Record<TaskType, string> = {
 
 // ── State ────────────────────────────────────────────────────────────────────
 
-let _config: TaskRoutingConfig = {
-  enabled: false, // User must explicitly enable
-  taskModelMap: { ...DEFAULT_TASK_MODEL_MAP },
-  detectionEnabled: true,
-  stats: { detected: 0, routed: 0 },
-};
+// #8601: the config MUST live on globalThis, NOT in a module-level `let`. A plain
+// module-level binding is DUPLICATED per module graph, so the boot hydration in
+// src/instrumentation-node.ts would land on the instrumentation graph's copy and
+// never reach the copy src/sse/handlers/chat.ts reads — exactly the #5312 fix-A
+// break proven on the VPS. Mirrors thinkingBudget.ts (#5312) and systemPrompt.ts (#2470).
+const GLOBAL_KEY = "__omniroute_taskRouting_config__";
+const _store = globalThis as unknown as Record<string, TaskRoutingConfig | undefined>;
+
+function freshConfig(): TaskRoutingConfig {
+  return {
+    enabled: false, // User must explicitly enable
+    taskModelMap: { ...DEFAULT_TASK_MODEL_MAP },
+    detectionEnabled: true,
+    stats: { detected: 0, routed: 0 },
+  };
+}
+
+function getConfig(): TaskRoutingConfig {
+  if (!_store[GLOBAL_KEY]) {
+    _store[GLOBAL_KEY] = freshConfig();
+  }
+  return _store[GLOBAL_KEY]!;
+}
 
 // ── Config Management ────────────────────────────────────────────────────────
 
 export function setTaskRoutingConfig(config: Partial<TaskRoutingConfig>): void {
-  _config = {
-    ..._config,
+  const current = getConfig();
+  _store[GLOBAL_KEY] = {
+    ...current,
     ...config,
-    stats: _config.stats, // preserve stats across config changes
+    stats: current.stats, // preserve stats across config changes
   };
 }
 
 export function getTaskRoutingConfig(): TaskRoutingConfig {
+  const current = getConfig();
   return {
-    ..._config,
-    taskModelMap: { ..._config.taskModelMap },
-    stats: { ..._config.stats },
+    ...current,
+    taskModelMap: { ...current.taskModelMap },
+    stats: { ...current.stats },
   };
 }
 
 export function resetTaskRoutingStats(): void {
-  _config.stats = { detected: 0, routed: 0 };
+  getConfig().stats = { detected: 0, routed: 0 };
+}
+
+/**
+ * Restore the persisted Task-Aware Routing config at boot (#8601).
+ *
+ * `PUT /api/settings/task-routing` writes the config to `settings.taskRouting` as a
+ * JSON string, but nothing ever read it back — so the feature silently reverted to
+ * `enabled: false` + the default model map on every restart. `applyRuntimeSettings`
+ * does not cover this key, so it needs an explicit hydration step, same as the
+ * Global System Prompt (#2470) and the Thinking-Budget config (#5312).
+ *
+ * Accepts either the JSON string the route persists or an already-parsed object.
+ * Returns true when a config was applied, false for missing/malformed values
+ * (fail-open: the in-memory defaults stay in place).
+ */
+export function hydrateTaskRoutingConfig(settings: unknown): boolean {
+  const raw =
+    settings && typeof settings === "object" && !Array.isArray(settings)
+      ? (settings as Record<string, unknown>).taskRouting
+      : undefined;
+  if (raw === undefined || raw === null) return false;
+
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    if (raw.trim().length === 0) return false;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return false;
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+
+  // `stats` is runtime telemetry, never restored from the persisted blob — the route
+  // already strips it on write, but a hand-edited settings row must not resurrect it.
+  const { stats: _ignoredStats, ...persisted } = parsed as Partial<TaskRoutingConfig>;
+  setTaskRoutingConfig(persisted);
+  return true;
 }
 
 export function getDefaultTaskModelMap(): Record<TaskType, string> {
@@ -299,14 +350,15 @@ export function applyTaskAwareRouting(
   originalModel: string,
   body: any
 ): { model: string; taskType: TaskType; wasRouted: boolean } {
-  if (!_config.enabled || !_config.detectionEnabled) {
+  const config = getConfig();
+  if (!config.enabled || !config.detectionEnabled) {
     return { model: originalModel, taskType: "chat", wasRouted: false };
   }
 
   const taskType = detectTaskType(body);
-  _config.stats.detected++;
+  config.stats.detected++;
 
-  const preferred = _config.taskModelMap[taskType];
+  const preferred = config.taskModelMap[taskType];
 
   // No override configured for this task type
   if (!preferred || preferred === "") {
@@ -321,6 +373,6 @@ export function applyTaskAwareRouting(
     // This is a conservative heuristic — full override can be enabled via settting
   }
 
-  _config.stats.routed++;
+  config.stats.routed++;
   return { model: preferred, taskType, wasRouted: true };
 }

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -402,6 +402,17 @@ export async function registerNodejs(): Promise<void> {
       console.log("[STARTUP] Thinking-Budget config restored from settings");
     }
 
+    // Restore the Task-Aware Smart Routing config (#8601). It lives in
+    // `settings.taskRouting` (written as a JSON string by PUT /api/settings/task-routing)
+    // and is NOT covered by applyRuntimeSettings, so without this the feature silently
+    // reverts to disabled + the default model map on every restart. Same shape as the
+    // Thinking-Budget restore above; must live here, not in the unused server-init.ts.
+    const { hydrateTaskRoutingConfig } =
+      await import("@omniroute/open-sse/services/taskAwareRouter.ts");
+    if (hydrateTaskRoutingConfig(settings)) {
+      console.log("[STARTUP] Task-Aware Routing config restored from settings");
+    }
+
     const seededModelAliases = await seedDefaultModelAliases();
     console.log(
       `[STARTUP] Model alias seed: applied=${seededModelAliases.applied.length}, skipped=${seededModelAliases.skipped.length}, removed=${seededModelAliases.removed.length}, failed=${seededModelAliases.failed.length}`

--- a/tests/unit/task-router-auto-intent-8602.test.ts
+++ b/tests/unit/task-router-auto-intent-8602.test.ts
@@ -1,0 +1,97 @@
+/**
+ * TDD regression for #8602: DEFAULT_TASK_MODEL_MAP hardcoded literal provider/model
+ * ids (`openai/gpt-4o`, `gemini/gemini-2.5-flash-lite`, …) as routing destinations.
+ *
+ * Two problems, both guarded here:
+ *
+ *  1. The ids rot. They pointed at models one to two generations old, and refreshing
+ *     the strings would only reset the rot clock — so the guard is structural: no
+ *     concrete provider/model literal may appear in the default map at all.
+ *
+ *  2. The shape bypasses the router. `src/sse/handlers/chat.ts` applies the override by
+ *     overwriting `body.model`, so a hardcoded target skips the 13-factor auto-combo
+ *     scoring (quota / circuit-breaker health / cost / latency / stability), connection
+ *     cooldown and model lockout. An operator with no OpenAI connection got a request
+ *     rewritten to `openai/gpt-4o` and a failure, where pass-through would have worked.
+ *
+ * The defaults must therefore be `auto/*` INTENT ids, which resolve against whatever
+ * backends the operator actually has connected.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getDefaultTaskModelMap,
+  setTaskRoutingConfig,
+  applyTaskAwareRouting,
+  type TaskType,
+} from "../../open-sse/services/taskAwareRouter.ts";
+import { isRecognizedBuiltinAuto } from "../../open-sse/services/autoCombo/builtinCatalog.ts";
+
+/** Task types that intentionally carry no override (pass the requested model through). */
+const NO_OVERRIDE: TaskType[] = ["creative", "chat"];
+
+test("#8602 default task→model map contains no concrete provider/model literals", () => {
+  const map = getDefaultTaskModelMap();
+
+  for (const [taskType, target] of Object.entries(map)) {
+    if (NO_OVERRIDE.includes(taskType as TaskType)) {
+      assert.equal(target, "", `${taskType} must stay pass-through`);
+      continue;
+    }
+    assert.notEqual(target, "", `${taskType} should route somewhere`);
+    assert.ok(
+      target.startsWith("auto/"),
+      `${taskType} must route by intent, not to a hardcoded model — got "${target}"`
+    );
+  }
+});
+
+test("#8602 every default target is a resolvable built-in auto id", () => {
+  const map = getDefaultTaskModelMap();
+
+  for (const [taskType, target] of Object.entries(map)) {
+    if (target === "") continue;
+    const suffix = target.slice("auto/".length);
+    assert.ok(
+      isRecognizedBuiltinAuto(target, suffix),
+      `${taskType} → "${target}" is not a recognized auto id, so it would fail to resolve`
+    );
+  }
+});
+
+test("#8602 no default target names a known provider prefix", () => {
+  // Belt-and-braces: catches a regression that reintroduces a literal while still
+  // (incorrectly) prefixing it, e.g. "auto/openai/gpt-4o".
+  const PROVIDER_LITERALS = ["openai/", "gemini/", "deepseek/", "anthropic/", "claude/", "glm/"];
+  for (const [taskType, target] of Object.entries(getDefaultTaskModelMap())) {
+    for (const literal of PROVIDER_LITERALS) {
+      assert.ok(
+        !target.includes(literal),
+        `${taskType} → "${target}" still embeds the provider literal "${literal}"`
+      );
+    }
+  }
+});
+
+test("#8602 routing a detected task yields the auto intent id", () => {
+  setTaskRoutingConfig({
+    enabled: true,
+    detectionEnabled: true,
+    taskModelMap: getDefaultTaskModelMap(),
+  });
+
+  try {
+    const result = applyTaskAwareRouting("some-provider/some-model", {
+      messages: [{ role: "user", content: "please implement a binary search function" }],
+    });
+
+    assert.equal(result.taskType, "coding");
+    assert.equal(result.wasRouted, true);
+    assert.ok(
+      result.model.startsWith("auto/"),
+      `expected an auto intent id, got "${result.model}"`
+    );
+  } finally {
+    setTaskRoutingConfig({ enabled: false, taskModelMap: getDefaultTaskModelMap() });
+  }
+});

--- a/tests/unit/task-routing-config-restore-8601.test.ts
+++ b/tests/unit/task-routing-config-restore-8601.test.ts
@@ -1,0 +1,132 @@
+/**
+ * TDD regression for #8601: the Task-Aware Smart Routing (T05) config is persisted
+ * to `settings.taskRouting` by PUT /api/settings/task-routing but never read back,
+ * so it silently reverts to `enabled: false` + the hardcoded default model map on
+ * every restart.
+ *
+ * Two independent root causes, one test each:
+ *
+ *  A. No hydration entry point existed at all. `hydrateTaskRoutingConfig(settings)`
+ *     must parse the persisted value (a JSON *string*, as the route writes it) and
+ *     apply it, mirroring `hydrateThinkingBudgetConfig` (#5312) and
+ *     `setSystemPromptConfig` (#2470).
+ *
+ *  B. The config lived in a plain module-level `let`, which is DUPLICATED per module
+ *     graph — so a boot hydration on the instrumentation graph would never reach the
+ *     copy that `src/sse/handlers/chat.ts` reads. This is the exact break #5312 fix-A
+ *     hit on the VPS. The store must live on `globalThis`, like `thinkingBudget.ts`
+ *     and `systemPrompt.ts`. Importing the module under two distinct specifiers gives
+ *     two real module instances, which reproduces the duplication directly.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  hydrateTaskRoutingConfig,
+  setTaskRoutingConfig,
+  getTaskRoutingConfig,
+  getDefaultTaskModelMap,
+} from "../../open-sse/services/taskAwareRouter.ts";
+
+const MODULE_PATH = "../../open-sse/services/taskAwareRouter.ts";
+
+function resetConfig(): void {
+  setTaskRoutingConfig({
+    enabled: false,
+    taskModelMap: getDefaultTaskModelMap(),
+    detectionEnabled: true,
+  });
+}
+
+// ── A. hydration from persisted settings ─────────────────────────────────────
+
+test("#8601 hydrateTaskRoutingConfig restores a JSON-string persisted config", () => {
+  resetConfig();
+
+  // Shape written by src/app/api/settings/task-routing/route.ts:66
+  const persisted = JSON.stringify({
+    enabled: true,
+    detectionEnabled: true,
+    taskModelMap: { ...getDefaultTaskModelMap(), coding: "auto/coding" },
+  });
+
+  assert.equal(hydrateTaskRoutingConfig({ taskRouting: persisted }), true);
+
+  const config = getTaskRoutingConfig();
+  assert.equal(config.enabled, true);
+  assert.equal(config.taskModelMap.coding, "auto/coding");
+
+  resetConfig();
+});
+
+test("#8601 hydrateTaskRoutingConfig accepts an already-parsed object", () => {
+  resetConfig();
+
+  assert.equal(
+    hydrateTaskRoutingConfig({ taskRouting: { enabled: true, detectionEnabled: false } }),
+    true
+  );
+  assert.equal(getTaskRoutingConfig().enabled, true);
+  assert.equal(getTaskRoutingConfig().detectionEnabled, false);
+
+  resetConfig();
+});
+
+test("#8601 hydrateTaskRoutingConfig is a no-op for missing/invalid settings", () => {
+  resetConfig();
+
+  for (const settings of [
+    undefined,
+    null,
+    {},
+    { taskRouting: "" },
+    { taskRouting: "not json" },
+    { taskRouting: "[]" },
+    { taskRouting: 42 },
+  ]) {
+    assert.equal(
+      hydrateTaskRoutingConfig(settings),
+      false,
+      `should ignore ${JSON.stringify(settings)}`
+    );
+    assert.equal(getTaskRoutingConfig().enabled, false);
+  }
+
+  resetConfig();
+});
+
+test("#8601 hydration never resurrects stats from the persisted blob", () => {
+  resetConfig();
+
+  hydrateTaskRoutingConfig({
+    taskRouting: JSON.stringify({ enabled: true, stats: { detected: 999, routed: 999 } }),
+  });
+
+  const { stats } = getTaskRoutingConfig();
+  assert.equal(stats.detected, 0);
+  assert.equal(stats.routed, 0);
+
+  resetConfig();
+});
+
+// ── B. cross-module-graph sharing (the #5312 fix-A trap) ─────────────────────
+
+test("#8601 config store is shared across duplicated module instances", async () => {
+  resetConfig();
+
+  // Distinct specifiers → two genuinely separate module records, the same way the
+  // Next.js instrumentation graph and the app-route/open-sse graph each get their own.
+  const graphA = await import(`${MODULE_PATH}?graph=a`);
+  const graphB = await import(`${MODULE_PATH}?graph=b`);
+
+  graphA.setTaskRoutingConfig({ enabled: true, detectionEnabled: true });
+
+  assert.equal(
+    graphB.getTaskRoutingConfig().enabled,
+    true,
+    "a config set on one module instance must be visible from another — otherwise boot " +
+      "hydration lands on the instrumentation copy and the chat handler never sees it"
+  );
+
+  graphA.setTaskRoutingConfig({ enabled: false });
+  resetConfig();
+});


### PR DESCRIPTION
Fixes #8602, fixes #8603.

Two defects in the hand-maintained model-quality tables that the auto-router leans on.

## #8602 — task-aware defaults hardcoded stale model ids

```ts
coding: "deepseek/deepseek-chat",
analysis: "gemini/gemini-2.5-pro",
vision: "openai/gpt-4o",                    // 2024-05
summarization: "gemini/gemini-2.5-flash",
background: "gemini/gemini-2.5-flash-lite",
```

Wrong twice over:

- **The ids rot.** They aged out by a generation or two, and every model release made them staler.
- **The shape bypasses the router.** `applyTaskAwareRouting` overwrites `body.model` (`src/sse/handlers/chat.ts:573`), so a literal target skips auto-combo's 13-factor scoring (quota, circuit-breaker health, cost, latency, stability), connection cooldown and model lockout. An operator with no OpenAI connection got a `vision` request rewritten to `openai/gpt-4o` and a hard failure, where pass-through would have worked.

Refreshing the strings would only reset the rot clock, so the defaults now name **intents**:

| task | before | after |
| --- | --- | --- |
| `coding` | `deepseek/deepseek-chat` | `auto/coding` |
| `analysis` | `gemini/gemini-2.5-pro` | `auto/reasoning` |
| `vision` | `openai/gpt-4o` | `auto/vision` |
| `summarization` | `gemini/gemini-2.5-flash` | `auto/chat:fast` |
| `background` | `gemini/gemini-2.5-flash-lite` | `auto/chat:cheap` |

`creative` and `chat` stay pass-through. These resolve on demand against the operator's actually-connected backends (`suffixComposition.ts` → `virtualFactory.ts`) and degrade gracefully as backends rotate. No provider/model literal remains in the module — the stale header comment is updated too.

Operators who pinned a specific model via `PUT /api/settings/task-routing` are unaffected; only the shipped defaults change. The feature remains off by default.

## #8603 — fitness table matched the wrong row

`lookupStaticFitnessTable` returned the first `String.includes` hit in declaration order. `FITNESS_TABLE.coding` declares `"gpt-4o": 0.9` before `"gpt-4o-mini": 0.8`, so an explicitly cheap model inherited the flagship's task fitness and its own row was unreachable:

```
gpt-4o-mini    -> matched "gpt-4o"      = 0.9   (own row = 0.8)
deepseek-v3.2  -> matched "deepseek-v3" = 0.85  (own row = 0.86)
```

Now matches **longest-pattern-first**, so the most specific row wins regardless of authoring order and the table can be extended without ordering hazards. Extracted as the exported `getStaticFitnessTableScore` — the surrounding resolution chain queries the DB (user_override / arena_elo / models.dev tier) before reaching layer 4, so testing through `getTaskFitness` would depend on DB fixture state.

Bounded but real: `taskFit` is weight `0.08` in `DEFAULT_WEIGHTS`, `0.37` in the `quality-first` mode pack, and layer 4 is what the long tail of the provider catalog actually lands on.

## Validation (Hard Rule #18 — TDD)

Both written first and confirmed red.

`tests/unit/task-router-auto-intent-8602.test.ts` (node runner) — 4 cases, red before:

```
expected an auto intent id, got "deepseek/deepseek-chat"
```

`open-sse/services/autoCombo/__tests__/taskFitness-pattern-order-8603.test.ts` (vitest) — 7 cases, red before:

```
TypeError: getStaticFitnessTableScore is not a function
```

Green after, plus the full blocking vitest job:

```
node --import tsx/esm --test tests/unit/task-router-auto-intent-8602.test.ts   # 4/4
npm run test:vitest                                # Test Files 32 passed / Tests 281 passed
```

The #8602 guard is structural, not a value check — it asserts no default may be a concrete provider/model literal, so the rot cannot come back.

## Gates

- `npm run typecheck:core` — clean
- `npm run test:vitest` — 32 files / 281 tests, all pass
- `npx eslint` on changed files — 4 `no-explicit-any` in `taskAwareRouter.ts`, all pre-existing (`eslint-suppressions.json` records `count: 4` for this file); `taskFitness.ts` clean. No new violations.

## Not in scope

The detection patterns (`taskAwareRouter.ts:46-155`) are English-only literal substrings, so non-English prompts always fall through to `chat`. Noted in #8602, deliberately not addressed here. The static `FITNESS_TABLE` should eventually be deleted rather than curated once arena_elo/models.dev coverage is measured — noted in #8603.
