### PR TITLE
fix(providers): declare explicit OpenCode plugin feature-flag defaults

### DIFF
--- a/@omniroute/opencode-plugin/package.json
+++ b/@omniroute/opencode-plugin/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf dist",
-    "test": "node --import tsx/esm --test tests/scaffold.test.ts tests/auth.test.ts tests/options-schema.test.ts tests/multi-instance.test.ts tests/fetch-interceptor.test.ts tests/provider.test.ts tests/gemini-sanitize.test.ts tests/combos.test.ts tests/config-shim.test.ts tests/features.test.ts tests/usable-combo.test.ts tests/disk-snapshot-perms.test.ts tests/fork-features.test.ts tests/auto-combo-context.test.ts tests/provider-id-routing.test.ts tests/management-read-token.test.ts tests/auto-sync.test.ts",
+    "test": "node --import tsx/esm --test tests/scaffold.test.ts tests/auth.test.ts tests/options-schema.test.ts tests/multi-instance.test.ts tests/fetch-interceptor.test.ts tests/provider.test.ts tests/gemini-sanitize.test.ts tests/combos.test.ts tests/config-shim.test.ts tests/features.test.ts tests/feature-defaults.test.ts tests/usable-combo.test.ts tests/disk-snapshot-perms.test.ts tests/fork-features.test.ts tests/auto-combo-context.test.ts tests/provider-id-routing.test.ts tests/management-read-token.test.ts tests/auto-sync.test.ts",
     "prepublishOnly": "npm run clean && npm run build && npm test"
   },
   "keywords": [

--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -216,6 +216,59 @@ const optionsSchema = z
  */
 export type OmniRoutePluginOptions = z.infer<typeof optionsSchema>;
 
+/**
+ * Explicit default state for every boolean `features.*` toggle.
+ *
+ * #7624: `featuresSchema` marks every flag `.optional()` with no default, and
+ * the effective value is applied implicitly at each read site (default-ON flags
+ * use the `features.X !== false` convention, default-OFF flags use
+ * `features.X === true`). That implicit convention is scattered across the file,
+ * so an operator who omits the `features` block cannot tell whether
+ * combos / autoCombos / enrichment are enabled — they think features are
+ * disabled when they are actually on. Centralising the declared defaults here
+ * (mirroring the read-site conventions exactly, so runtime behaviour is
+ * unchanged) makes the effective flags introspectable and self-documenting.
+ */
+export const OMNIROUTE_FEATURE_DEFAULTS = {
+  // default-ON (read sites use `features.X !== false`)
+  combos: true,
+  autoCombos: true,
+  enrichment: true,
+  diskCache: true,
+  providerTag: true,
+  fetchInterceptor: true,
+  geminiSanitization: true,
+  // default-OFF (read sites use `features.X === true`)
+  compressionMetadata: false,
+  usableOnly: false,
+  mcpAutoEmit: false,
+  debugLog: false,
+  startupDebug: false,
+} as const;
+
+/** Union of the boolean feature-flag keys declared in `OMNIROUTE_FEATURE_DEFAULTS`. */
+export type OmniRouteFeatureFlag = keyof typeof OMNIROUTE_FEATURE_DEFAULTS;
+
+/**
+ * Resolve the EFFECTIVE boolean state of every feature toggle, applying the
+ * declared default for any flag the operator omitted. A missing `features`
+ * block (or an empty one) yields the full default set — so callers and the
+ * startup diagnostics can surface exactly which features are active instead of
+ * relying on the implicit `!== false` / `=== true` conventions. Purely
+ * derived: it does not mutate options nor change any read-site behaviour.
+ */
+export function resolveEffectiveFeatureFlags(
+  features?: OmniRoutePluginOptions["features"]
+): Record<OmniRouteFeatureFlag, boolean> {
+  const f: Partial<Record<OmniRouteFeatureFlag, boolean>> = features ?? {};
+  const out = {} as Record<OmniRouteFeatureFlag, boolean>;
+  for (const key of Object.keys(OMNIROUTE_FEATURE_DEFAULTS) as OmniRouteFeatureFlag[]) {
+    const val = f[key];
+    out[key] = typeof val === "boolean" ? val : OMNIROUTE_FEATURE_DEFAULTS[key];
+  }
+  return out;
+}
+
 export const OMNIROUTE_PROVIDER_KEY = "omniroute" as const;
 
 /** Deployed plugin version (injected at build time by tsup define). */
@@ -2000,6 +2053,7 @@ async function writeStartupDiagnostics(params: {
   autoComboCount: number;
   enrichment: OmniRouteEnrichmentMap;
   autoCombos: OmniRouteRawAutoCombo[];
+  features?: OmniRoutePluginOptions["features"];
 }): Promise<void> {
   const {
     providerId,
@@ -2010,6 +2064,7 @@ async function writeStartupDiagnostics(params: {
     autoComboCount,
     enrichment,
     autoCombos,
+    features,
   } = params;
   const enriched = [...enrichment.entries()];
   const withName = enriched.filter(([, e]) => e.name);
@@ -2021,6 +2076,16 @@ async function writeStartupDiagnostics(params: {
   lines.push(`providerId=${providerId} baseURL=${baseURL}`);
   lines.push(
     `models=${modelCount} combos=${comboCount} enrichment=${enrichmentSize} autoCombos=${autoComboCount}`
+  );
+  // #7624: surface the EFFECTIVE feature flags so an operator who omitted the
+  // `features` block can see combos/autoCombos/enrichment are on (the counts
+  // above can read 0 for reasons unrelated to the flags — e.g. missing auth).
+  const effectiveFlags = resolveEffectiveFeatureFlags(features);
+  lines.push(
+    `features(effective): ` +
+      (Object.keys(effectiveFlags) as OmniRouteFeatureFlag[])
+        .map((k) => `${k}=${effectiveFlags[k] ? "on" : "off"}`)
+        .join(" ")
   );
   lines.push(
     `enrichment: ${withName.length} with name, ${withPricing.length} with pricing, ${withFree.length} free`
@@ -3130,6 +3195,7 @@ export function createOmniRouteProviderHook(
             autoComboCount: rawAutoCombos.length,
             enrichment: rawEnrichment,
             autoCombos: rawAutoCombos,
+            features: resolved.features,
           });
         }
       }
@@ -5208,6 +5274,7 @@ export function createOmniRouteConfigHook(
           autoComboCount: rawAutoCombos.length,
           enrichment: rawEnrichment,
           autoCombos: rawAutoCombos,
+          features: resolved.features,
         });
       }
 

--- a/@omniroute/opencode-plugin/tests/feature-defaults.test.ts
+++ b/@omniroute/opencode-plugin/tests/feature-defaults.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #7624 — explicit feature-flag defaults.
+ *
+ * The `features` block in opencode.json marks every toggle `.optional()` with
+ * no default. The effective value was previously only knowable by tracing the
+ * implicit `features.X !== false` (default-ON) / `features.X === true`
+ * (default-OFF) convention scattered across each read site, which left
+ * operators unsure whether combos / autoCombos / enrichment were enabled when
+ * they omitted the block.
+ *
+ * `OMNIROUTE_FEATURE_DEFAULTS` declares those defaults explicitly and
+ * `resolveEffectiveFeatureFlags(features)` derives the effective state for any
+ * (possibly-undefined) features object, mirroring the read-site conventions
+ * exactly. These are purely derived — runtime routing behaviour is unchanged.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  OMNIROUTE_FEATURE_DEFAULTS,
+  resolveEffectiveFeatureFlags,
+} from "../src/index.js";
+
+const DEFAULT_ON = [
+  "combos",
+  "autoCombos",
+  "enrichment",
+  "diskCache",
+  "providerTag",
+  "fetchInterceptor",
+  "geminiSanitization",
+] as const;
+
+const DEFAULT_OFF = [
+  "compressionMetadata",
+  "usableOnly",
+  "mcpAutoEmit",
+  "debugLog",
+  "startupDebug",
+] as const;
+
+test("OMNIROUTE_FEATURE_DEFAULTS: declares each flag with its documented default", () => {
+  for (const key of DEFAULT_ON) {
+    assert.equal(OMNIROUTE_FEATURE_DEFAULTS[key], true, `${key} defaults ON`);
+  }
+  for (const key of DEFAULT_OFF) {
+    assert.equal(OMNIROUTE_FEATURE_DEFAULTS[key], false, `${key} defaults OFF`);
+  }
+});
+
+test("resolveEffectiveFeatureFlags: undefined features → full declared default set", () => {
+  const flags = resolveEffectiveFeatureFlags(undefined);
+  for (const key of DEFAULT_ON) {
+    assert.equal(flags[key], true, `${key} effective ON when features omitted`);
+  }
+  for (const key of DEFAULT_OFF) {
+    assert.equal(flags[key], false, `${key} effective OFF when features omitted`);
+  }
+});
+
+test("resolveEffectiveFeatureFlags: empty features object → same as omitted", () => {
+  assert.deepEqual(
+    resolveEffectiveFeatureFlags({}),
+    resolveEffectiveFeatureFlags(undefined)
+  );
+});
+
+test("resolveEffectiveFeatureFlags: explicit false disables a default-ON flag", () => {
+  const flags = resolveEffectiveFeatureFlags({ autoCombos: false });
+  assert.equal(flags.autoCombos, false, "explicit autoCombos:false honoured");
+  // Untouched flags keep their declared defaults.
+  assert.equal(flags.combos, true);
+  assert.equal(flags.enrichment, true);
+});
+
+test("resolveEffectiveFeatureFlags: explicit true enables a default-OFF flag", () => {
+  const flags = resolveEffectiveFeatureFlags({ compressionMetadata: true });
+  assert.equal(flags.compressionMetadata, true, "explicit compressionMetadata:true honoured");
+  assert.equal(flags.usableOnly, false, "other opt-in flags stay OFF");
+});
+
+test("resolveEffectiveFeatureFlags: non-boolean sibling keys do not leak into flags", () => {
+  // features may also carry mcpToken/logLevel/apiFormat — the resolver must
+  // only ever return the boolean toggle keys.
+  const flags = resolveEffectiveFeatureFlags({
+    mcpAutoEmit: true,
+    mcpToken: "sk-mcp-token-abc",
+    logLevel: "debug",
+  });
+  assert.equal(flags.mcpAutoEmit, true);
+  assert.equal(Object.keys(flags).length, Object.keys(OMNIROUTE_FEATURE_DEFAULTS).length);
+  assert.equal("mcpToken" in flags, false);
+  assert.equal("logLevel" in flags, false);
+});


### PR DESCRIPTION
## Summary

The OpenCode plugin's `features` block marks every toggle `.optional()` with no default; the effective value is applied implicitly via scattered `!== false` (default-ON) / `=== true` (default-OFF) conventions at each read site. Nothing declares these defaults in one place and nothing surfaces the effective flags, so an operator who omits the `features` block can't tell that combos/autoCombos/enrichment are actually enabled — the `autoCombos=0` startup diagnostic is an unrelated *count* (0 for reasons like missing auth), which reads as "features disabled".

This is purely additive:
- `OMNIROUTE_FEATURE_DEFAULTS` — an explicit default map mirroring the read-site conventions exactly (7 default-ON, 5 default-OFF).
- `resolveEffectiveFeatureFlags(features)` — derives the effective booleans for any/undefined `features` object (returns only the boolean toggle keys, never `mcpToken`/`logLevel`/`apiFormat`).
- a `features(effective): combos=on autoCombos=on …` line in `writeStartupDiagnostics`.

No read-site or schema changes — runtime routing behavior is unchanged, and the existing `parseOmniRoutePluginOptions({ features: {} }) → { features: {} }` pass-through contract (`tests/features.test.ts`) is preserved. This deliberately avoids the issue's "Option C" (Zod `.default(true)`), which would break that pass-through guard.

## Test plan

- New `@omniroute/opencode-plugin/tests/feature-defaults.test.ts` (6 tests): default map declares each documented default; `resolveEffectiveFeatureFlags(undefined)` → full default set; empty `{}` equals omitted; explicit `false` disables a default-ON flag while untouched flags keep defaults; explicit `true` enables a default-OFF flag; non-boolean sibling keys don't leak. Fails before the fix (symbols undefined on base), passes after.
- `npm test` (full plugin suite) → 287/287 pass; `npm run build` (tsup + DTS) green; plugin `tsc --noEmit` exit 0; `eslint` on changed files clean.

Closes #7624