### PR TITLE
fix(resilience): report local queue expiry as unavailable

### DIFF
--- a/changelog.d/fixes/8613-local-queue-timeout.md
+++ b/changelog.d/fixes/8613-local-queue-timeout.md
@@ -1,0 +1,1 @@
+- **fix(resilience):** report local request-queue expirations as service-unavailable capacity failures instead of upstream 502 errors, preventing incorrect provider cooldowns and same-target retries ([#8613](https://github.com/diegosouzapw/OmniRoute/pull/8613)).

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -3234,21 +3234,23 @@ export async function handleChatCore({
     // can't tell apart from a per-model 5xx).
     const isProxyUnreachableFailure =
       !isRequestAborted && (error as { errorCode?: unknown })?.errorCode === "proxy_unreachable";
+    const errorCode = getUpstreamErrorIdentifier(error);
+    const isLocalQueueTimeout = errorCode === "RATE_LIMIT_QUEUE_TIMEOUT";
     const failureStatus = isRequestAborted
       ? 499
       : isProxyUnreachableFailure
         ? HTTP_STATUS.BAD_GATEWAY
-        : error.name === "TimeoutError" || error.name === "BodyTimeoutError"
-          ? HTTP_STATUS.GATEWAY_TIMEOUT
-          : error.status && typeof error.status === "number"
-            ? error.status
-            : HTTP_STATUS.BAD_GATEWAY;
+        : isLocalQueueTimeout
+          ? HTTP_STATUS.SERVICE_UNAVAILABLE
+          : error.name === "TimeoutError" || error.name === "BodyTimeoutError"
+            ? HTTP_STATUS.GATEWAY_TIMEOUT
+            : error.status && typeof error.status === "number"
+              ? error.status
+              : HTTP_STATUS.BAD_GATEWAY;
     const failureMessage = isRequestAborted
       ? "Request aborted"
       : formatProviderError(error, provider, model, failureStatus);
-    const upstreamErrorCode = isProxyUnreachableFailure
-      ? "proxy_unreachable"
-      : getUpstreamErrorIdentifier(error);
+    const upstreamErrorCode = isProxyUnreachableFailure ? "proxy_unreachable" : errorCode;
     // Tag our own deadline timeouts (fetch-start TimeoutError / body BodyTimeoutError,
     // both surfaced as a 504) as "upstream_timeout" so the cooldown layer can tell a
     // slow-but-not-failed request apart from a real provider 5xx. (Antigravity already


### PR DESCRIPTION
## Summary

OmniRoute's local request-queue expiry carries the RATE_LIMIT_QUEUE_TIMEOUT code, but handleChatCore currently falls through to the generic upstream-failure status and returns HTTP 502.

This change is intentionally scoped to status classification only:

- Return HTTP 503 Service Unavailable for RATE_LIMIT_QUEUE_TIMEOUT.
- Preserve the existing retry, lockout, cooldown, and combo behavior for separate follow-up work.

A local queue-expiry response should be distinguishable from an upstream gateway failure while retaining the existing resilience behavior.

## Validation

- 	ests/unit/rate-limit-queue-timeout-message-4165.test.ts
- 	ests/unit/rate-limit-queue-timeout-lockout.test.ts
- 
pm run typecheck:core
- Focused ESLint on the changed handler

Follow-up to the queue behavior documented in #4165.