### PR TITLE
fix(sse): reconcile combo cooldown-wait contract with its gate (#8541)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2714,21 +2714,21 @@ export async function handleComboChat({
         // a SHORT transient cooldown and re-run the whole set loop. Guarded by
         // the helper (quota_exhausted/auth/not-found excluded, ceiling,
         // attempts, budget). MAX_GLOBAL_ATTEMPTS still bounds total dispatches.
-        // Available to ALL combo strategies (not just quota-share).
+        // SCOPE (#8541): quota-share and auto ONLY, via isComboCooldownWaitEligible
+        // (comboConfig.ts). This used to claim "ALL combo strategies" — a
+        // generalization never wired into the gate. The narrow scope is
+        // load-bearing: the same predicate raises the per-target timeout floor,
+        // so widening it changes the timeout for every strategy too.
         if (comboCooldownWaitEnabled && status === 429) {
-          // ONE decision path for EVERY strategy. The reason that drives the
-          // wait is always the target's REAL model-lockout reason, resolved
-          // through the helper's allow-list — never a hardcoded literal.
+          // The reason driving the wait is always the target's REAL model-lockout
+          // reason, resolved through the helper's allow-list — never a literal.
           //
           // SECURITY (see comboCooldownRetry.ts header): the allow-list is the
-          // PRIMARY barrier and `maxWaitMs` only the SECOND one. Hardcoding
-          // reason:"rate_limit" for non-quota-share strategies would drop the
-          // primary barrier and leave only the ceiling — which does NOT cover a
-          // quota_exhausted lock carrying a SHORT upstream retry-after (e.g.
-          // 3s < maxWaitMs): the combo would wait, redispatch against a model
-          // locked until midnight, and burn the attempt. Model lockouts are
-          // recorded for all strategies (recordModelLockoutFailure above is not
-          // gated on quota-share), so the real reason is always available.
+          // PRIMARY barrier and `maxWaitMs` only the SECOND. Hardcoding
+          // reason:"rate_limit" would drop the primary barrier and leave only the
+          // ceiling — which does NOT cover a quota_exhausted lock carrying a SHORT
+          // upstream retry-after (e.g. 3s < maxWaitMs): the combo would wait,
+          // redispatch against a model locked until midnight, and burn the attempt.
           const decision: ResolveComboCooldownDecisionResult = resolveComboCooldownWaitDecision({
             targets: orderedTargets,
             earliestRetryAfter,

--- a/tests/unit/serial/combo-quota-share-cooldown-wait-timing.test.ts
+++ b/tests/unit/serial/combo-quota-share-cooldown-wait-timing.test.ts
@@ -17,15 +17,28 @@
  * was the dominant source of contention, matching the repo's established
  * remedy pattern for this class of test.
  *
- * The non-quota-share (priority) scenario was UPDATED for the "universal
- * cooldown-aware retry" change: comboCooldownWait is no longer gated on
- * `strategy === "quota-share"` — every combo strategy now waits out a SHORT
- * transient 429 and re-dispatches (using a "rate_limit" reason and the
- * earliest retry-after hint directly, since non quota-share strategies have no
- * per-connection model-lockout tracking to consult). It used to assert the
- * OPPOSITE (immediate propagation, no wait) — that assertion is now testing
- * dead behavior, so it was rewritten to assert the new intended behavior
- * instead of being deleted or weakened.
+ * #8541 — the non-quota-share (priority) scenarios below were rewritten AGAIN,
+ * back to asserting no-wait. An earlier revision had rewritten them for a
+ * "universal cooldown-aware retry" (every strategy waits out a SHORT transient
+ * 429), but that generalization never reached the gate: `comboCooldownWait` is
+ * still admitted only for `quota-share` and `auto` by
+ * isComboCooldownWaitEligible() (comboConfig.ts), which
+ * tests/unit/combo-config.test.ts asserts directly. So the assertions were
+ * describing behavior no code path could produce, and they were red on the base
+ * branch. The scope stays narrow deliberately — the same predicate also raises
+ * the per-target timeout floor, so widening it is a behavior change for every
+ * strategy, not a comment fix.
+ *
+ * The quota_exhausted scenario ALSO had to move to `quota-share`. Its point is
+ * that the allow-list (barrier 1) rejects a quota_exhausted lock even when the
+ * wait is short enough to clear `maxWaitMs` (barrier 2) — but the branch it
+ * guards only opens for a wait-eligible strategy, so on `priority` it was
+ * asserting against a branch that could never execute. Its model order also had
+ * to flip: since #8508 (30709255c) `lastStatus` is last-write-wins so the
+ * surfaced status and message always come from the SAME target, and the branch
+ * requires `status === 429`. A trailing 403 target therefore drives the whole
+ * response to 403 and the wait is never even considered. The 429 target now
+ * goes last so the branch actually opens and barrier 1 is the thing under test.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -142,16 +155,16 @@ test("quota-share: 403 quota_exhausted → NO wait, error propagated immediately
   assert.ok(elapsed < 10000, `quota_exhausted must not wait out a cooldown, but ${elapsed}ms elapsed`);
 });
 
-test("non quota-share (priority): short 429 cooldown → waits and re-dispatches (2nd pass 200)", async () => {
+test("non quota-share (priority): short 429 cooldown → NO wait, 429 propagated (#8541)", async () => {
   let calls = 0;
   const handleSingleModel = async () => {
     calls += 1;
-    // 1st dispatch: transient 429 with a short retry-after hint. 2nd dispatch
-    // (after the universal cooldown wait): success. Priority combos have no
-    // per-connection model-lockout tracking, so this exercises the
-    // `shouldWaitForComboCooldown({ reason: "rate_limit", ... })` path fed
-    // directly by the earliest retry-after hint (not resolveComboCooldownWaitDecision's
-    // per-target lock lookup, which stays quota-share-only).
+    // 1st dispatch: transient 429 with a short retry-after hint. The 2nd would
+    // succeed — that asymmetry is the point. `priority` is not wait-eligible
+    // (isComboCooldownWaitEligible admits only quota-share/auto), so the
+    // cooldown-wait branch never opens and the 429 crystallizes. Had a wait
+    // fired, this combo would have returned 200 instead, so asserting 429 is a
+    // positive proof of no-redispatch, not just an absence check.
     return calls === 1 ? rateLimitResponse(429) : okResponse();
   };
 
@@ -167,33 +180,41 @@ test("non quota-share (priority): short 429 cooldown → waits and re-dispatches
   });
   const elapsed = Date.now() - startedAt;
 
-  assert.equal(res.status, 200, "expected the retried dispatch to succeed with 200");
-  assert.equal(calls, 2, "expected exactly one wait+redispatch (2 upstream calls)");
+  assert.equal(res.status, 429, "a non-eligible strategy must propagate the 429, not retry it");
+  assert.equal(calls, 1, "a non-eligible strategy must NOT wait+redispatch");
+  // Secondary sanity check: we must not have burned the retry-after window.
+  // Loose bound — the first combo dispatch pays DB/import overhead.
   assert.ok(
-    elapsed >= RETRY_AFTER_MS - 50,
-    `expected to have waited out the cooldown, only ${elapsed}ms elapsed`
+    elapsed < 10000,
+    `a non-eligible strategy must not wait out a cooldown, but ${elapsed}ms elapsed`
   );
 });
 
-test("non quota-share (priority): a quota_exhausted lock drives the decision with a SHORT wait → NO wait (the reason allow-list is the PRIMARY barrier; the maxWaitMs ceiling does NOT cover this)", async () => {
+test("quota-share: a quota_exhausted lock drives the decision with a SHORT wait → NO wait (the reason allow-list is the PRIMARY barrier; the maxWaitMs ceiling does NOT cover this)", async () => {
   // THE regression guard for the two-barrier policy documented in
   // comboCooldownRetry.ts ("SECURITY — quota_exhausted must be excluded" /
   // "The small maxWaitMs ceiling is the second barrier").
   //
   // Barrier 1 = the reason allow-list. Barrier 2 = the maxWaitMs ceiling.
   // This scenario is engineered so ONLY barrier 1 can stop the wait:
-  //   - modelLockout.errorCodes is [403] ONLY, so model-a's 429 crystallizes
-  //     status 429 (the sole status that opens the cooldown-wait branch) WITHOUT
-  //     recording a competing `rate_limit` lock.
-  //   - model-b's 403 records the only lock in play: `quota_exhausted`. It is
+  //   - the strategy is `quota-share`, the wait-eligible one. On a non-eligible
+  //     strategy the branch never opens and this would assert nothing (#8541).
+  //   - modelLockout.errorCodes is [403] ONLY, so the 429 target does NOT record
+  //     a competing `rate_limit` lock.
+  //   - the 403 target records the only lock in play: `quota_exhausted`. It is
   //     therefore the lock resolveComboCooldownWaitDecision picks, so its reason
   //     is what drives the decision.
-  //   - The resulting wait is SHORT (well under maxWaitMs=5000), so barrier 2
+  //   - the 429 target is dispatched LAST so it wins `lastStatus` (last-write-
+  //     wins since #8508) and the branch's `status === 429` guard opens. With
+  //     the 403 last, the whole response would crystallize 403 and the wait
+  //     would never be considered.
+  //   - the resulting wait is SHORT (well under maxWaitMs=5000), so barrier 2
   //     lets it through. Only the allow-list can reject it.
   //
-  // With the reason hardcoded to "rate_limit" (as the non-quota-share path did
-  // before), barrier 1 is gone and this exact input waits + redispatches against
-  // a quota-exhausted model — verified: the same test yields 6 dispatches.
+  // Positive control (run while writing this): make the lock reason `rate_limit`
+  // instead — both targets 429 with errorCodes [429] — and this same shape waits
+  // and re-dispatches to 12 upstream calls. So the 2 calls asserted below are
+  // barrier 1 doing its job, not an absence of any wait machinery.
   const calls: string[] = [];
   const handleSingleModel = async (_body: unknown, modelStr: string) => {
     calls.push(modelStr);
@@ -201,11 +222,12 @@ test("non quota-share (priority): a quota_exhausted lock drives the decision wit
   };
 
   const res = await handleComboChat({
-    body: { model: "openai/gpt-4" },
+    body: { model: "anthropic/claude-3-5-sonnet" },
     combo: {
-      name: "priority-quota-exhausted-short-wait",
-      strategy: "priority",
-      models: ["openai/gpt-4", "anthropic/claude-3-5-sonnet"],
+      name: "quota-share-quota-exhausted-short-wait",
+      strategy: "quota-share",
+      // 403 first, 429 last — see the lastStatus note above.
+      models: ["anthropic/claude-3-5-sonnet", "openai/gpt-4"],
       config: { maxRetries: 0, retryDelayMs: 0, fallbackDelayMs: 0, maxSetRetries: 0 },
     },
     handleSingleModel,
@@ -225,11 +247,11 @@ test("non quota-share (priority): a quota_exhausted lock drives the decision wit
   assert.equal(res.status, 429, "the crystallized 429 must be propagated, not retried");
   // Deterministic proof (no wall-clock dependency, so it cannot flake under
   // CI-runner contention): each target is dispatched EXACTLY ONCE. Had the wait
-  // fired, the whole set loop would re-run — maxAttempts=2 within the 8s budget
-  // produces 6 dispatches, not 2.
+  // fired, the whole set loop would re-run — the rate_limit control above
+  // produces 12 dispatches, not 2.
   assert.deepEqual(
     calls,
-    ["openai/gpt-4", "anthropic/claude-3-5-sonnet"],
+    ["anthropic/claude-3-5-sonnet", "openai/gpt-4"],
     "a quota_exhausted lock must NOT trigger a wait+redispatch, even when the wait would be short enough to clear the maxWaitMs ceiling"
   );
 });


### PR DESCRIPTION
Closes #8541.

## The contradiction

`combo.ts` documented the cooldown-aware 429 retry as available to every combo strategy; the gate that reaches it admits only two. The statements sit ~1200 lines apart in the same file.

| Source | Says |
| --- | --- |
| `combo.ts:2717` comment | "Available to ALL combo strategies (not just quota-share)" |
| `combo.ts:2719` comment | "ONE decision path for EVERY strategy" |
| `comboConfig.ts:52` | `quota-share` or `auto` only |

Two tests in `tests/unit/serial/combo-quota-share-cooldown-wait-timing.test.ts` had been rewritten to match the *comment*, so they asserted behavior no code path could produce. They are red on the base branch and surface on `Unit Tests fast-path`, making every PR→`release/**` that selects them red.

## Which side won, and why

#8541 left A (widen the gate) vs B (narrow the contract) open. **B.** The issue framed this as "comments + test vs implementation", but it is actually **test vs test** — a third source already asserts the narrow contract directly, and a fourth documents it:

```ts
// tests/unit/combo-config.test.ts:328  (carries its own #7360 rationale)
assert.equal(isComboCooldownWaitEligible("priority",   { enabled: true }), false);
assert.equal(isComboCooldownWaitEligible("fill-first", { enabled: true }), false);
```

```ts
// src/lib/resilience/settings.ts:99
// quota-share and auto combos, and only for transient (non quota_exhausted) reasons.
```

So three sources agree with the gate and only the prose disagreed.

Widening would also not have been a comment fix. `resolveComboTargetTimeoutMsForCombo` uses the **same predicate** to raise the per-target timeout floor, so option A would lift the default per-target timeout from 120s to 150s for every strategy, and require deleting the assertions above. That is a deliberate feature change; if the generalization is still wanted it belongs in its own PR, not in base-red cleanup.

## Changes

**`open-sse/services/combo.ts`** — correct the two scope comments.

Comment-only: `git diff` filtered to non-comment lines is empty. The file stays at **exactly 3640 lines**, so the frozen file-size baseline is untouched (an earlier, wordier draft pushed it to 3651 > 3642 and was tightened rather than rebaselined — this file is mid-decomposition under #3501 and should not grow).

**Timing test — "short 429 cooldown"** — assert `priority` propagates the 429 without redispatching.

The stub still returns 200 on a hypothetical 2nd dispatch, so asserting 429 is *positive* proof that no wait fired, not merely an absence check.

**Timing test — "quota_exhausted lock"** — moved from `priority` to `quota-share`, model order flipped.

Two separate defects, neither covered by #8541:

1. On a non-eligible strategy the branch it guards never opens, so on `priority` it was asserting against unreachable code — vacuous regardless of A or B.
2. Since **#8508** (`30709255c`) `lastStatus` is last-write-wins, so the surfaced status and message always come from the same target. The branch requires `status === 429`; with the 403 target dispatched last, the response crystallizes 403 and the wait is never even considered. That is why this test reports `403 !== 429` — a *precondition* failure, so its actual subject never ran. Putting the 429 target last makes the allow-list the thing genuinely under test.

## Non-vacuousness

The rewritten quota_exhausted test was checked against a positive control before being trusted: swap the lock reason to `rate_limit` (both targets 429, `errorCodes: [429]`) and the same shape waits and re-dispatches to **12** upstream calls instead of 2. So the 2 asserted calls are barrier 1 (the allow-list) doing its job, not an absence of wait machinery.

## Verification

| Command | Result |
| --- | --- |
| `combo-quota-share-cooldown-wait-timing.test.ts` | 4/4, green on **3 consecutive runs** (timing-sensitive, so repeated) |
| `combo-config.test.ts` | 44/44 — untouched by this diff |
| `combo-cooldown-retry` + `cooldown-aware-retry-budget` + `resilience-settings-combo-cooldown-wait` + `quota-share-strategy` + `chat-cooldown-aware-retry` | 77/77 |
| `combo-antigravity-missing-project-reset-8486.test.ts` | green (the #8508 regression guard) |
| `npm run typecheck:core` | clean |
| `npm run lint` | clean |
| `npm run check:file-size` | OK |
| `npm run check:known-symbols` | OK — 20/20 strategies |
| `npm run check:complexity-ratchets` | 2169 / 956 |

## Base

Branched off `4053e2314` rather than the `release/v3.8.49` tip, matching the other in-flight combo PRs.

`check:complexity-ratchets` reports 2169/956 vs frozen 2130/951 — **byte-identical to the base**, so this PR contributes zero. That is the pre-existing base-red owned by #8580. `Fast Quality Gates` will stay red until #8580 merges; see #8542 for why the fail-fast ordering means a later gate cannot demonstrate its own fix.

## Scope note

This closes the `Unit Tests fast-path` half of the base-red. It does **not** touch `isComboCooldownWaitEligible` — no runtime behavior changes in this PR.
