### PR TITLE
fix(resilience): recover idle wedged limiters

### DIFF
--- a/changelog.d/fixes/8616-rate-limit-state-instrumentation.md
+++ b/changelog.d/fixes/8616-rate-limit-state-instrumentation.md
@@ -1,1 +1,1 @@
-- **chore(resilience):** log limiter state when a local request-queue job expires to distinguish RPM depletion, concurrency pressure, and wedged queues ([#8616](https://github.com/diegosouzapw/OmniRoute/pull/8616)).
+- **fix(resilience):** recover a wedged local request limiter after an idle-capacity queue expiry and log the state needed to distinguish RPM depletion, concurrency pressure, and scheduler wedges ([#8616](https://github.com/diegosouzapw/OmniRoute/pull/8616)).

--- a/changelog.d/fixes/8616-rate-limit-state-instrumentation.md
+++ b/changelog.d/fixes/8616-rate-limit-state-instrumentation.md
@@ -1,0 +1,1 @@
+- **chore(resilience):** log limiter state when a local request-queue job expires to distinguish RPM depletion, concurrency pressure, and wedged queues ([#8616](https://github.com/diegosouzapw/OmniRoute/pull/8616)).

--- a/changelog.d/fixes/8616-rate-limit-state-instrumentation.md
+++ b/changelog.d/fixes/8616-rate-limit-state-instrumentation.md
@@ -1,1 +1,1 @@
-- **fix(resilience):** recover a wedged local request limiter after an idle-capacity queue expiry and log the state needed to distinguish RPM depletion, concurrency pressure, and scheduler wedges ([#8616](https://github.com/diegosouzapw/OmniRoute/pull/8616)).
+- **fix(resilience):** recover a wedged local request limiter after an idle-capacity queue expiry by retrying the request on a fresh limiter ([#8616](https://github.com/diegosouzapw/OmniRoute/pull/8616)).

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -104,7 +104,6 @@ let currentRequestQueueSettings: RequestQueueSettings = DEFAULT_RESILIENCE_SETTI
 // jobs are dispatched). When the reservoir/refresh state desyncs from reality,
 // this catches it and force-resets so traffic isn't stuck forever.
 const lastDispatchAt = new Map<string, number>();
-const limiterCreatedAt = new Map<string, number>();
 let watchdogInterval: ReturnType<typeof setInterval> | null = null;
 const WATCHDOG_INTERVAL_MS = 30_000;
 // Threshold has to exceed any *legitimate* gap between dispatches:
@@ -235,7 +234,6 @@ function watchdogTick() {
       if (counts.QUEUED === 0 && counts.RUNNING === 0 && counts.EXECUTING === 0) {
         limiters.delete(key);
         lastDispatchAt.delete(key);
-        limiterCreatedAt.delete(key);
         limiterLastUsed.delete(key);
         logRateLimit(
           `🧹 [RATE-LIMIT] Evicting idle limiter: ${key} (inactive for ${Math.round((now - lastUsed) / 1000)}s)`
@@ -314,7 +312,6 @@ function evictWedgeLimiter(key: string, limiter: Bottleneck): void {
   if (limiters.get(key) !== limiter) return;
   limiters.delete(key);
   lastDispatchAt.delete(key);
-  limiterCreatedAt.delete(key);
   limiterLastUsed.delete(key);
   trackAsyncOperation(limiter.disconnect());
   trackAsyncOperation(
@@ -335,7 +332,6 @@ function shutdownLimiters(): void {
   }
   limiters.clear();
   lastDispatchAt.clear();
-  limiterCreatedAt.clear();
   limiterLastUsed.clear();
 }
 
@@ -445,7 +441,6 @@ export function disableRateLimitProtection(connectionId) {
     if (key.includes(connectionId)) {
       limiters.delete(key);
       lastDispatchAt.delete(key);
-      limiterCreatedAt.delete(key);
       limiterLastUsed.delete(key);
       trackAsyncOperation(limiter.disconnect());
     }
@@ -480,7 +475,6 @@ export function refreshConnectionRateLimits(connectionId, overrides) {
     if (key.includes(connectionId)) {
       limiters.delete(key);
       lastDispatchAt.delete(key);
-      limiterCreatedAt.delete(key);
       limiterLastUsed.delete(key);
       trackAsyncOperation(limiter.disconnect());
     }
@@ -547,7 +541,6 @@ function getLimiter(provider, connectionId, model = null) {
 
     limiters.set(key, limiter);
     lastDispatchAt.set(key, Date.now());
-    limiterCreatedAt.set(key, Date.now());
     limiterLastUsed.set(key, Date.now());
   }
 
@@ -566,14 +559,7 @@ function getLimiter(provider, connectionId, model = null) {
  * @param {AbortSignal} signal - Optional abort signal to cancel waiting
  * @returns {Promise<unknown>} Result of fn()
  */
-async function getQueueStateSnapshot(
-  provider: string,
-  connectionId: string,
-  model: string | null | undefined,
-  key: string,
-  limiter: Bottleneck,
-  enqueuedAt: number
-) {
+async function getQueueHealthSnapshot(key: string, limiter: Bottleneck) {
   const counts = limiter.counts();
   let reservoirRemaining: number | null = null;
   try {
@@ -581,29 +567,13 @@ async function getQueueStateSnapshot(
   } catch {
     // Snapshot logging must never affect request handling.
   }
-  const overrides = connectionRateLimitOverrides.get(connectionId);
   const lastDispatch = lastDispatchAt.get(key);
-  const createdAt = limiterCreatedAt.get(key);
   return {
-    provider,
-    connectionId,
-    model: model || null,
-    key,
-    queueWaitMs: Date.now() - enqueuedAt,
     queued: counts.QUEUED,
     running: counts.RUNNING,
     executing: counts.EXECUTING,
     reservoirRemaining,
-    configuredRpm:
-      typeof overrides?.rpm === "number" && overrides.rpm > 0
-        ? overrides.rpm
-        : currentRequestQueueSettings.requestsPerMinute,
-    configuredMaxConcurrent:
-      typeof overrides?.maxConcurrent === "number" && overrides.maxConcurrent > 0
-        ? overrides.maxConcurrent
-        : currentRequestQueueSettings.concurrentRequests,
     lastDispatchAgeMs: lastDispatch ? Date.now() - lastDispatch : null,
-    limiterAgeMs: createdAt ? Date.now() - createdAt : null,
   };
 }
 
@@ -637,7 +607,6 @@ export async function withRateLimit(
   );
 
   const limiter = getLimiter(provider, connectionId, model);
-  const enqueuedAt = Date.now();
   const maxWaitMs = currentRequestQueueSettings.maxWaitMs;
   const scheduleOpts = maxWaitMs && maxWaitMs > 0 ? { expiration: maxWaitMs } : {};
 
@@ -703,18 +672,10 @@ export async function withRateLimit(
     // Reset it and retry this never-dispatched function once on a fresh limiter.
     if (err?.message?.includes("This job timed out")) {
       const key = getLimiterKey(provider, connectionId, model);
-      const queueState = await getQueueStateSnapshot(
-        provider,
-        connectionId,
-        model,
-        key,
-        limiter,
-        enqueuedAt
-      );
+      const queueState = await getQueueHealthSnapshot(key, limiter);
       logRateLimit(
         `⏰ [RATE-LIMIT] ${key} — job expired after ${Math.ceil((maxWaitMs || 0) / 1000)}s in queue, dropping`
       );
-      logRateLimit(`🧭 [RATE-LIMIT] queue-timeout-state ${JSON.stringify(queueState)}`);
       const limiterIsWedged =
         retryAfterWedge &&
         queueState.running === 0 &&
@@ -808,7 +769,6 @@ export function updateFromHeaders(provider, connectionId, headers, status, model
     // the abandoned Bottleneck; under sustained quota pressure that is a real leak.
     limiters.delete(limiterKey);
     lastDispatchAt.delete(limiterKey);
-    limiterCreatedAt.delete(limiterKey);
     limiterLastUsed.delete(limiterKey);
     trackAsyncOperation(limiter.disconnect());
     return;

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -104,6 +104,7 @@ let currentRequestQueueSettings: RequestQueueSettings = DEFAULT_RESILIENCE_SETTI
 // jobs are dispatched). When the reservoir/refresh state desyncs from reality,
 // this catches it and force-resets so traffic isn't stuck forever.
 const lastDispatchAt = new Map<string, number>();
+const limiterCreatedAt = new Map<string, number>();
 let watchdogInterval: ReturnType<typeof setInterval> | null = null;
 const WATCHDOG_INTERVAL_MS = 30_000;
 // Threshold has to exceed any *legitimate* gap between dispatches:
@@ -234,6 +235,7 @@ function watchdogTick() {
       if (counts.QUEUED === 0 && counts.RUNNING === 0 && counts.EXECUTING === 0) {
         limiters.delete(key);
         lastDispatchAt.delete(key);
+        limiterCreatedAt.delete(key);
         limiterLastUsed.delete(key);
         logRateLimit(
           `🧹 [RATE-LIMIT] Evicting idle limiter: ${key} (inactive for ${Math.round((now - lastUsed) / 1000)}s)`
@@ -261,6 +263,7 @@ function watchdogTick() {
     );
     limiters.delete(key);
     lastDispatchAt.delete(key);
+    limiterCreatedAt.delete(key);
     limiterLastUsed.delete(key);
     // Live incident (log id 1784465227489-a2cbc0): disconnect() releases the
     // heartbeat timer but does NOT reject the QUEUED jobs already sitting on
@@ -326,6 +329,7 @@ function shutdownLimiters(): void {
   }
   limiters.clear();
   lastDispatchAt.clear();
+  limiterCreatedAt.clear();
   limiterLastUsed.clear();
 }
 
@@ -435,6 +439,7 @@ export function disableRateLimitProtection(connectionId) {
     if (key.includes(connectionId)) {
       limiters.delete(key);
       lastDispatchAt.delete(key);
+      limiterCreatedAt.delete(key);
       limiterLastUsed.delete(key);
       trackAsyncOperation(limiter.disconnect());
     }
@@ -469,6 +474,7 @@ export function refreshConnectionRateLimits(connectionId, overrides) {
     if (key.includes(connectionId)) {
       limiters.delete(key);
       lastDispatchAt.delete(key);
+      limiterCreatedAt.delete(key);
       limiterLastUsed.delete(key);
       trackAsyncOperation(limiter.disconnect());
     }
@@ -535,6 +541,7 @@ function getLimiter(provider, connectionId, model = null) {
 
     limiters.set(key, limiter);
     lastDispatchAt.set(key, Date.now());
+    limiterCreatedAt.set(key, Date.now());
     limiterLastUsed.set(key, Date.now());
   }
 
@@ -553,6 +560,47 @@ function getLimiter(provider, connectionId, model = null) {
  * @param {AbortSignal} signal - Optional abort signal to cancel waiting
  * @returns {Promise<unknown>} Result of fn()
  */
+async function getQueueStateSnapshot(
+  provider: string,
+  connectionId: string,
+  model: string | null | undefined,
+  key: string,
+  limiter: Bottleneck,
+  enqueuedAt: number
+) {
+  const counts = limiter.counts();
+  let reservoirRemaining: number | null = null;
+  try {
+    reservoirRemaining = await limiter.currentReservoir();
+  } catch {
+    // Snapshot logging must never affect request handling.
+  }
+  const overrides = connectionRateLimitOverrides.get(connectionId);
+  const lastDispatch = lastDispatchAt.get(key);
+  const createdAt = limiterCreatedAt.get(key);
+  return {
+    provider,
+    connectionId,
+    model: model || null,
+    key,
+    queueWaitMs: Date.now() - enqueuedAt,
+    queued: counts.QUEUED,
+    running: counts.RUNNING,
+    executing: counts.EXECUTING,
+    reservoirRemaining,
+    configuredRpm:
+      typeof overrides?.rpm === "number" && overrides.rpm > 0
+        ? overrides.rpm
+        : currentRequestQueueSettings.requestsPerMinute,
+    configuredMaxConcurrent:
+      typeof overrides?.maxConcurrent === "number" && overrides.maxConcurrent > 0
+        ? overrides.maxConcurrent
+        : currentRequestQueueSettings.concurrentRequests,
+    lastDispatchAgeMs: lastDispatch ? Date.now() - lastDispatch : null,
+    limiterAgeMs: createdAt ? Date.now() - createdAt : null,
+  };
+}
+
 export async function withRateLimit(provider, connectionId, model, fn, signal = null) {
   if (!enabledConnections.has(connectionId)) {
     return fn();
@@ -576,6 +624,7 @@ export async function withRateLimit(provider, connectionId, model, fn, signal = 
   );
 
   const limiter = getLimiter(provider, connectionId, model);
+  const enqueuedAt = Date.now();
   const maxWaitMs = currentRequestQueueSettings.maxWaitMs;
   const scheduleOpts = maxWaitMs && maxWaitMs > 0 ? { expiration: maxWaitMs } : {};
 
@@ -640,9 +689,18 @@ export async function withRateLimit(provider, connectionId, model, fn, signal = 
     // Behavior is unchanged — the job is still dropped so combo can fall back.
     if (err?.message?.includes("This job timed out")) {
       const key = getLimiterKey(provider, connectionId, model);
+      const queueState = await getQueueStateSnapshot(
+        provider,
+        connectionId,
+        model,
+        key,
+        limiter,
+        enqueuedAt
+      );
       logRateLimit(
         `⏰ [RATE-LIMIT] ${key} — job expired after ${Math.ceil((maxWaitMs || 0) / 1000)}s in queue, dropping`
       );
+      logRateLimit(`🧭 [RATE-LIMIT] queue-timeout-state ${JSON.stringify(queueState)}`);
       const queueErr = new Error(
         `Request dropped after exceeding the local rate-limit queue budget maxWaitMs (${maxWaitMs}ms) for ` +
           `${model ? `${provider}/${model}` : provider} — this is OmniRoute's request queue ` +
@@ -723,6 +781,7 @@ export function updateFromHeaders(provider, connectionId, headers, status, model
     // the abandoned Bottleneck; under sustained quota pressure that is a real leak.
     limiters.delete(limiterKey);
     lastDispatchAt.delete(limiterKey);
+    limiterCreatedAt.delete(limiterKey);
     limiterLastUsed.delete(limiterKey);
     trackAsyncOperation(limiter.disconnect());
     return;

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -261,10 +261,6 @@ function watchdogTick() {
     warnRateLimit(
       `🚨 [RATE-LIMIT] WEDGED: ${key} queued=${counts.QUEUED} running=0 executing=0 stalled=${stalledMs}ms — force-resetting`
     );
-    limiters.delete(key);
-    lastDispatchAt.delete(key);
-    limiterCreatedAt.delete(key);
-    limiterLastUsed.delete(key);
     // Live incident (log id 1784465227489-a2cbc0): disconnect() releases the
     // heartbeat timer but does NOT reject the QUEUED jobs already sitting on
     // this instance — withRateLimit's `limiter.schedule()` for those callers
@@ -288,9 +284,7 @@ function watchdogTick() {
     // no future getLimiter() call can ever hand out this now-stopped instance
     // — the "permanently rejects future .schedule()" behavior stop() has is
     // therefore moot; nothing will call .schedule() on it again.
-    trackAsyncOperation(
-      limiter.stop({ dropWaitingJobs: true, dropErrorMessage: "rate-limit-watchdog-wedge-reset" })
-    );
+    evictWedgeLimiter(key, limiter);
   }
 }
 
@@ -314,6 +308,18 @@ export function stopRateLimitWatchdog(): void {
   if (!watchdogInterval) return;
   clearInterval(watchdogInterval);
   watchdogInterval = null;
+}
+
+function evictWedgeLimiter(key: string, limiter: Bottleneck): void {
+  if (limiters.get(key) !== limiter) return;
+  limiters.delete(key);
+  lastDispatchAt.delete(key);
+  limiterCreatedAt.delete(key);
+  limiterLastUsed.delete(key);
+  trackAsyncOperation(limiter.disconnect());
+  trackAsyncOperation(
+    limiter.stop({ dropWaitingJobs: true, dropErrorMessage: "rate-limit-watchdog-wedge-reset" })
+  );
 }
 
 /**
@@ -601,7 +607,14 @@ async function getQueueStateSnapshot(
   };
 }
 
-export async function withRateLimit(provider, connectionId, model, fn, signal = null) {
+export async function withRateLimit(
+  provider,
+  connectionId,
+  model,
+  fn,
+  signal = null,
+  retryAfterWedge = true
+) {
   if (!enabledConnections.has(connectionId)) {
     return fn();
   }
@@ -686,7 +699,8 @@ export async function withRateLimit(provider, connectionId, model, fn, signal = 
     // bodies / call-log `last_error` and gets misdiagnosed as a provider outage
     // (#4165). Rewrite it into a clear, OmniRoute-owned error (knob named,
     // upstream disclaimed, original kept as `cause`, `code` for classification).
-    // Behavior is unchanged — the job is still dropped so combo can fall back.
+    // If the limiter is idle with capacity after the expiry, the scheduler is wedged.
+    // Reset it and retry this never-dispatched function once on a fresh limiter.
     if (err?.message?.includes("This job timed out")) {
       const key = getLimiterKey(provider, connectionId, model);
       const queueState = await getQueueStateSnapshot(
@@ -701,6 +715,19 @@ export async function withRateLimit(provider, connectionId, model, fn, signal = 
         `⏰ [RATE-LIMIT] ${key} — job expired after ${Math.ceil((maxWaitMs || 0) / 1000)}s in queue, dropping`
       );
       logRateLimit(`🧭 [RATE-LIMIT] queue-timeout-state ${JSON.stringify(queueState)}`);
+      const limiterIsWedged =
+        retryAfterWedge &&
+        queueState.running === 0 &&
+        queueState.executing === 0 &&
+        typeof queueState.reservoirRemaining === "number" &&
+        queueState.reservoirRemaining > 0 &&
+        typeof queueState.lastDispatchAgeMs === "number" &&
+        queueState.lastDispatchAgeMs >= Math.max(1, maxWaitMs || 0);
+      if (limiterIsWedged) {
+        logRateLimit(`🔄 [RATE-LIMIT] ${key} — recovering idle limiter after queue expiry`);
+        evictWedgeLimiter(key, limiter);
+        return withRateLimit(provider, connectionId, model, fn, signal, false);
+      }
       const queueErr = new Error(
         `Request dropped after exceeding the local rate-limit queue budget maxWaitMs (${maxWaitMs}ms) for ` +
           `${model ? `${provider}/${model}` : provider} — this is OmniRoute's request queue ` +

--- a/tests/unit/rate-limit-manager.test.ts
+++ b/tests/unit/rate-limit-manager.test.ts
@@ -12,6 +12,7 @@ const providersDb = await import("../../src/lib/db/providers.ts");
 const resilienceSettings = await import("../../src/lib/resilience/settings.ts");
 const rateLimitManager = await import("../../open-sse/services/rateLimitManager.ts");
 const accountFallback = await import("../../open-sse/services/accountFallback.ts");
+const Bottleneck = (await import("bottleneck")).default;
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -57,6 +58,45 @@ test("rate limit manager bypasses disabled connections and exposes inactive stat
     running: 0,
   });
   assert.deepEqual(rateLimitManager.getAllRateLimitStatus(), {});
+});
+
+test("idle-capacity queue expiry resets the limiter and retries once", async () => {
+  await rateLimitManager.applyRequestQueueSettings({
+    ...resilienceSettings.DEFAULT_RESILIENCE_SETTINGS.requestQueue,
+    autoEnableApiKeyProviders: false,
+    maxWaitMs: 20,
+    requestsPerMinute: 0,
+    concurrentRequests: 1,
+    minTimeBetweenRequestsMs: 0,
+    maxQueueDepth: 0,
+  });
+
+  const originalSchedule = Bottleneck.prototype.schedule;
+  let attempts = 0;
+  Bottleneck.prototype.schedule = function (...args) {
+    attempts++;
+    if (attempts === 1) {
+      return new Promise((_, reject) => {
+        setTimeout(() => reject(new Error("This job timed out after 20 ms.")), 30);
+      });
+    }
+    return originalSchedule.apply(this, args);
+  };
+
+  try {
+    rateLimitManager.enableRateLimitProtection("idle-capacity-conn");
+    const result = await rateLimitManager.withRateLimit(
+      "openai",
+      "idle-capacity-conn",
+      "gpt-4o",
+      async () => "recovered"
+    );
+
+    assert.equal(result, "recovered");
+    assert.equal(attempts, 2, "the expired job should be retried once on a fresh limiter");
+  } finally {
+    Bottleneck.prototype.schedule = originalSchedule;
+  }
 });
 
 test("withRateLimit forwards AbortController DOMException without mutating it", async () => {


### PR DESCRIPTION
## Summary

Bottleneck can leave a request queued with no running or executing jobs even though reservoir capacity is available. The request then waits until the local queue budget expires.

This change:

- Detects that idle-capacity wedge at queue expiry.
- Evicts the stranded limiter and drops its orphaned queue.
- Retries the never-dispatched request once on a fresh limiter.
- Retains the watchdog reset for wedges that persist beyond the queue budget.

## Validation

- 10 rate-limit-manager tests pass
- `npm run typecheck:core`
- Focused ESLint on changed files
- Regression test covers idle-capacity expiry and fresh-limiter retry

Follow-up to the recurring queue wedge behavior documented in #4165.