### PR TITLE
Providers Page: update URL as search filter gets updated

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -34,7 +34,11 @@ import {
   loadProviderPageData,
 } from "./providerPageUtils";
 import type { ProviderEntry } from "./providerPageUtils";
-import { recordProviderNavigation, resolveHighlightedCard } from "./providerPageHighlightUtils";
+import {
+  recordProviderNavigation,
+  resolveHighlightedCard,
+  syncSearchToUrl,
+} from "./providerPageUrlState";
 import {
   readProviderDisplayModePreference,
   shouldSyncProviderDisplayMode,
@@ -256,6 +260,10 @@ export default function ProvidersPage() {
       setSearchQuery(searchFromUrl);
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    syncSearchToUrl(searchQuery);
+  }, [searchQuery]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/app/(dashboard)/dashboard/providers/providerPageUrlState.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUrlState.ts
@@ -9,6 +9,21 @@ export function recordProviderNavigation(id: string) {
 }
 
 /**
+ * Syncs the provider search filter to the URL search params without
+ * triggering a Next.js navigation. Preserves the search filter across
+ * browser back/forward navigation.
+ */
+export function syncSearchToUrl(searchQuery: string) {
+  const url = new URL(window.location.href);
+  if (searchQuery) {
+    url.searchParams.set("search", searchQuery);
+  } else {
+    url.searchParams.delete("search");
+  }
+  window.history.replaceState(window.history.state, "", url.toString());
+}
+
+/**
  * Ref callback for ProviderCard. When the rendered card's provider id
  * matches the highlighted id, scrolls it into view and triggers the
  * highlight animation. Always clears the highlighted id afterward so

--- a/tests/unit/ui/providerPageHighlightLogic.test.tsx
+++ b/tests/unit/ui/providerPageHighlightLogic.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /**
  * Tests for the page-level highlighted-card matching/clearing logic
- * extracted into providerPageHighlightUtils.ts.
+ * extracted into providerPageUrlState.ts.
  *
  * These import the real production functions — not copied code.
  */
@@ -10,7 +10,8 @@ import type { ProviderCardHandle } from "@/app/(dashboard)/dashboard/providers/c
 import {
   recordProviderNavigation,
   resolveHighlightedCard,
-} from "@/app/(dashboard)/dashboard/providers/providerPageHighlightUtils";
+  syncSearchToUrl,
+} from "@/app/(dashboard)/dashboard/providers/providerPageUrlState";
 
 function createMockHandle(
   id: string,
@@ -125,5 +126,77 @@ describe("recordProviderNavigation", () => {
     expect(replaceSpy.mock.calls[0][0]).toEqual({ providerId: "openai" });
     expect(replaceSpy.mock.calls[1][0]).toEqual({ providerId: "anthropic" });
     expect(replaceSpy.mock.calls[2][0]).toEqual({ providerId: "kimi-coding" });
+  });
+});
+
+describe("syncSearchToUrl", () => {
+  const originalReplaceState = window.history.replaceState;
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    window.history.replaceState = originalReplaceState;
+    Object.defineProperty(window, "location", { value: originalLocation, writable: true });
+  });
+
+  it("sets search param in URL when query is non-empty", () => {
+    const replaceSpy = vi.fn();
+    window.history.replaceState = replaceSpy;
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost:3000/dashboard/providers" },
+      writable: true,
+    });
+
+    syncSearchToUrl("openai");
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    const [, , url] = replaceSpy.mock.calls[0];
+    expect(url).toContain("search=openai");
+  });
+
+  it("removes search param when query is empty", () => {
+    const replaceSpy = vi.fn();
+    window.history.replaceState = replaceSpy;
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost:3000/dashboard/providers?search=openai" },
+      writable: true,
+    });
+
+    syncSearchToUrl("");
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    const [, , url] = replaceSpy.mock.calls[0];
+    expect(url).not.toContain("search=");
+  });
+
+  it("preserves existing search params when updating", () => {
+    const replaceSpy = vi.fn();
+    window.history.replaceState = replaceSpy;
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost:3000/dashboard/providers?tab=oauth" },
+      writable: true,
+    });
+
+    syncSearchToUrl("anthropic");
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    const [, , url] = replaceSpy.mock.calls[0];
+    expect(url).toContain("search=anthropic");
+    expect(url).toContain("tab=oauth");
+  });
+
+  it("preserves current history state", () => {
+    const replaceSpy = vi.fn();
+    window.history.replaceState = replaceSpy;
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost:3000/dashboard/providers" },
+      writable: true,
+    });
+    const existingState = { providerId: "openai" };
+    window.history.replaceState(existingState, "");
+
+    syncSearchToUrl("anthropic");
+
+    const [state] = replaceSpy.mock.calls[0];
+    expect(state).toBe(existingState);
   });
 });

--- a/tests/unit/ui/providerPageHighlightLogic.test.tsx
+++ b/tests/unit/ui/providerPageHighlightLogic.test.tsx
@@ -131,11 +131,15 @@ describe("recordProviderNavigation", () => {
 
 describe("syncSearchToUrl", () => {
   const originalReplaceState = window.history.replaceState;
-  const originalLocation = window.location;
+  const originalLocationDesc = Object.getOwnPropertyDescriptor(window, "location");
 
   afterEach(() => {
     window.history.replaceState = originalReplaceState;
-    Object.defineProperty(window, "location", { value: originalLocation, writable: true });
+    if (originalLocationDesc) {
+      Object.defineProperty(window, "location", originalLocationDesc);
+    } else {
+      Reflect.deleteProperty(window, "location");
+    }
   });
 
   it("sets search param in URL when query is non-empty", () => {


### PR DESCRIPTION
# Preserve provider search filter in URL across navigation

## Problem

On the Providers dashboard page, the search filter (`searchQuery`) was only held in React component state. Navigating to a provider detail page and pressing **Back** lost the filter, forcing the user to re-type their search.

## Solution

Sync the search filter to the browser URL as a `?search=` query parameter using `window.history.replaceState`. On mount, the existing `useSearchParams` effect already reads `?search=` from the URL — so the filter is now restored on back/forward navigation.

Using `replaceState` instead of `router.replace` avoids triggering Next.js route re-renders, prevents history-entry spam on every keystroke, and keeps the provider-highlight history state intact.

## Changes

| File | What changed |
|---|---|
| `providerPageHighlightUtils.ts` → `providerPageUrlState.ts` | Renamed to reflect broader URL-state scope; added `syncSearchToUrl()` |
| `page.tsx` | Import updated; new `useEffect` calls `syncSearchToUrl(searchQuery)` on change |
| `providerPageHighlightLogic.test.tsx` | Import paths updated; 4 new tests for `syncSearchToUrl` (set, remove, preserve params, preserve state) |

## Test plan

- `npx vitest run tests/unit/ui/providerPageHighlightLogic.test.tsx` — all 11 tests pass
- `tsc --noEmit` — no new type errors
