### PR TITLE
fix(providers): recover Kimi after quota reset

### DIFF
--- a/changelog.d/fixes/8632-kimi-quota-reset-recovery.md
+++ b/changelog.d/fixes/8632-kimi-quota-reset-recovery.md
@@ -1,0 +1,1 @@
+- **fix(providers):** Kimi Coding billing-cycle quota errors now recover automatically at the cached reset instead of remaining unavailable ([#8632](https://github.com/diegosouzapw/OmniRoute/pull/8632)) — thanks @glazec

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -4,6 +4,7 @@ import {
   isDailyQuotaExhausted,
   isOAuthInvalidToken,
 } from "./accountFallback.ts";
+import { isSubscriptionQuotaText } from "./quotaTextCooldowns.ts";
 import { getProviderCategory, getRegistryEntry } from "../config/providerRegistry.ts";
 
 // Terminal stop signals where an empty content payload is still a legitimate,
@@ -136,15 +137,16 @@ export function classifyProviderError(
 ): string | null {
   const bodyStr = responseBodyToString(responseBody);
   const creditsExhausted = isCreditsExhausted(bodyStr);
+  const subscriptionQuotaExhausted = isSubscriptionQuotaText(bodyStr.toLowerCase());
   const accountDeactivated = isAccountDeactivated(bodyStr);
   const oauthInvalid = isOAuthInvalidToken(bodyStr);
   const preserveQuota429 = shouldPreserveQuotaSignalsFor429(provider);
 
-  if (creditsExhausted && [400, 402, 403].includes(statusCode)) {
+  if ((creditsExhausted || subscriptionQuotaExhausted) && [400, 402, 403].includes(statusCode)) {
     return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
   }
 
-  if (creditsExhausted && statusCode === 429 && preserveQuota429) {
+  if ((creditsExhausted || subscriptionQuotaExhausted) && statusCode === 429 && preserveQuota429) {
     return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
   }
 

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -441,6 +441,13 @@ export async function maybeClearRecoveredQuotaState(
 ): Promise<ProviderConnectionLike> {
   if (!hasUsableQuota(usage)) return connection;
   if (isTerminalStatusForQuotaRecovery(connection.testStatus)) return connection;
+  if (
+    connection.lastErrorType === "quota_exhausted" &&
+    connection.rateLimitedUntil &&
+    new Date(connection.rateLimitedUntil).getTime() > Date.now()
+  ) {
+    return connection;
+  }
 
   const hasTransientState =
     connection.testStatus === "unavailable" ||

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -491,6 +491,12 @@ function getEarliestFutureDate(candidates: Array<string | null>): string | null 
   );
 }
 
+function getCachedQuotaResetAt(connectionId: string): string | null {
+  const entry = getQuotaCache(connectionId);
+  if (!entry?.quotas) return null;
+  return getEarliestFutureDate(Object.values(entry.quotas).map((quota) => quota.resetAt));
+}
+
 function isRetryableModelLockoutReason(reason: unknown): boolean {
   return typeof reason === "string" && reason.length > 0
     ? !NON_RETRYABLE_MODEL_LOCKOUT_REASONS.has(reason)
@@ -2121,7 +2127,17 @@ export async function markAccountUnavailable(
       providerErrorType,
       provider
     );
-    const cooldownMs = terminalStatus ? 0 : rawCooldownMs;
+    const cachedQuotaResetAt =
+      providerErrorType === PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED ||
+      reason === RateLimitReason.QUOTA_EXHAUSTED
+        ? getCachedQuotaResetAt(connectionId)
+        : null;
+    const cachedQuotaResetMs = parseFutureDateMs(cachedQuotaResetAt);
+    const cooldownMs = terminalStatus
+      ? 0
+      : cachedQuotaResetMs
+        ? cachedQuotaResetMs - Date.now()
+        : rawCooldownMs;
 
     // ── #3027: per-model subscription/permission 403 → model-only lockout ──
     if (isPerModelQuotaProvider && status === 403 && provider && model && !terminalStatus) {

--- a/tests/unit/error-classifier.test.ts
+++ b/tests/unit/error-classifier.test.ts
@@ -29,6 +29,20 @@ test("classifyProviderError: 400 + billing signal => QUOTA_EXHAUSTED", () => {
   assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
 });
 
+test("classifyProviderError: Kimi billing-cycle 403 => QUOTA_EXHAUSTED", () => {
+  const result = classifyProviderError(
+    403,
+    {
+      error: {
+        message:
+          "You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle.",
+      },
+    },
+    "kimi-coding"
+  );
+  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
+});
+
 test("classifyProviderError: 429 without billing signal => RATE_LIMITED", () => {
   const result = classifyProviderError(429, { error: { message: "too many requests" } });
   assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);

--- a/tests/unit/kimi-quota-reset-recovery.test.ts
+++ b/tests/unit/kimi-quota-reset-recovery.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-kimi-quota-reset-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-kimi-quota-reset-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+const quotaCache = await import("../../src/domain/quotaCache.ts");
+
+test.after(() => {
+  quotaCache.__clearForTests();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("Kimi billing-cycle quota errors remain active and recover at the cached reset", async () => {
+  await settingsDb.updateSettings({ autoDisableBannedAccounts: true });
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "kimi-coding",
+    authType: "oauth",
+    accessToken: "kimi-access-token",
+    refreshToken: "kimi-refresh-token",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connectionId = (connection as { id: string }).id;
+  const resetAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+  quotaCache.setQuotaCache(connectionId, "kimi-coding", {
+    Ratelimit: { remainingPercentage: 0, resetAt },
+    Weekly: {
+      remainingPercentage: 62,
+      resetAt: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connectionId,
+    403,
+    "You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle.",
+    "kimi-coding",
+    "kimi-for-coding"
+  );
+  const after = await providersDb.getProviderConnectionById(connectionId);
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(Math.abs(result.cooldownMs - 30 * 60 * 1000) < 2_000);
+  assert.equal(after.isActive, true);
+  assert.equal(after.testStatus, "unavailable");
+  assert.equal(after.lastErrorType, "quota_exhausted");
+  assert.ok(
+    Math.abs(new Date(after.rateLimitedUntil).getTime() - new Date(resetAt).getTime()) < 100
+  );
+});

--- a/tests/unit/provider-limits-recovery.test.ts
+++ b/tests/unit/provider-limits-recovery.test.ts
@@ -237,6 +237,37 @@ test("error-only quota response does not clear transient state", async () => {
   assert.equal(updated.lastErrorType, "rate_limited");
 });
 
+test("partial quota refresh does not clear a quota cooldown before its reset", async () => {
+  const resetAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+  const created = await providersDb.createProviderConnection({
+    provider: "kimi-coding",
+    authType: "oauth",
+    accessToken: "kimi-access-token",
+    refreshToken: "kimi-refresh-token",
+    testStatus: "unavailable",
+    isActive: true,
+    lastError: "usage limit reached",
+    lastErrorType: "quota_exhausted",
+    errorCode: 403,
+    rateLimitedUntil: resetAt,
+    backoffLevel: 1,
+  });
+  const connectionId = (created as { id: string }).id;
+  const connection = await providersDb.getProviderConnectionById(connectionId);
+
+  await providerLimits.maybeClearRecoveredQuotaState(connection, {
+    quotas: {
+      Ratelimit: { remainingPercentage: 0 },
+      Weekly: { remainingPercentage: 62 },
+    },
+  });
+  const after = await providersDb.getProviderConnectionById(connectionId);
+
+  assert.equal(after.testStatus, "unavailable");
+  assert.equal(after.lastErrorType, "quota_exhausted");
+  assert.equal(after.rateLimitedUntil, resetAt);
+});
+
 test("CAS primitive clears when expected state matches", async () => {
   const created = await createGlmConnectionWithTransientCooldown();
   const connectionId = (created as { id: string }).id;


### PR DESCRIPTION
## Summary

- Classify Kimi Coding billing-cycle 403 responses as recoverable quota exhaustion.
- Align the connection cooldown with the earliest cached quota reset so the existing recovery scheduler can reactivate it automatically.
- Preserve the exhausted cooldown when another quota window still reports capacity before that reset.

## Related Issues

- Closes #8631

## Validation

Run only the focused loop for what you changed — the full unit suite, Vitest, the
60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Focused tests for the change: `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/error-classifier.test.ts tests/unit/kimi-quota-reset-recovery.test.ts tests/unit/provider-limits-recovery.test.ts` (28 passed)
- [x] `npm run lint`
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Additional local checks:

- `npm run typecheck:core`
- `npm run build`
- `npm run test:coverage`: coverage thresholds passed with 84.09% statements and lines, 78.4% branches, and 87.96% functions. The command remained nonzero because five unrelated macOS and MCP tests fail on this checkout.

## Tests Added Or Updated

- `tests/unit/error-classifier.test.ts`
- `tests/unit/kimi-quota-reset-recovery.test.ts`
- `tests/unit/provider-limits-recovery.test.ts`

## Coverage Notes

The tests cover the Kimi 403 classification, reset-aware cooldown persistence, and protection against a partially refreshed quota snapshot clearing that cooldown early.

## Reviewer Notes

The failure was caused by the Kimi billing-cycle message falling through as `forbidden`, which used the generic cooldown path. A partial weekly quota snapshot could then clear the unavailable state before the exhausted short window reset. This patch reuses the existing quota cache and recovery scheduler. It adds no migration, feature flag, dashboard change, or provider-specific scheduler.

Sanitized live verification on the reporter's Railway deployment produced a successful Kimi Coding request after quota reset. The persistent 14m dashboard warning is intentionally outside this PR so the provider recovery fix remains atomic.

The five unrelated local full-suite failures are `ccr-mcp-integration`, `mcp-extra-forward-6178`, `restore-policies` on macOS Bash 3, and two `ServiceSupervisor` PID inspection cases. None of those files or subsystems are changed here.
