### PR TITLE
fix(autoCombo): normalize -free suffix in task fitness lookups (fixes #8603)

### DIFF
--- a/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
+++ b/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
@@ -649,4 +649,11 @@ describe("Task Fitness DB Resolution Chain", () => {
     const lowerScore = getTaskFitness("claude-sonnet", "coding");
     expect(upperScore).toBe(lowerScore);
   });
+
+  it("normalizes -free model suffix when looking up fitness table and wildcard boosts", () => {
+    const baseResult = getTaskFitnessWithSource("claude-sonnet", "coding");
+    const freeResult = getTaskFitnessWithSource("claude-sonnet-free", "coding");
+    expect(freeResult.source).toBe(baseResult.source);
+    expect(freeResult.score).toBe(baseResult.score);
+  });
 });

--- a/open-sse/services/autoCombo/taskFitness.ts
+++ b/open-sse/services/autoCombo/taskFitness.ts
@@ -277,10 +277,19 @@ export function getModelsDevTierFitness(model: string, taskType: string): number
   const dbScore = queryModelIntelligence(normalizedModel, normalizedTask, "models_dev_tier");
   if (dbScore !== null) return dbScore;
 
+  const baseModel = normalizedModel.endsWith(FREE_SUFFIX)
+    ? normalizedModel.slice(0, -FREE_SUFFIX.length)
+    : normalizedModel;
+
+  if (baseModel !== normalizedModel) {
+    const baseDbScore = queryModelIntelligence(baseModel, normalizedTask, "models_dev_tier");
+    if (baseDbScore !== null) return baseDbScore;
+  }
+
   const caps = loadModelCapabilities();
   if (!caps) return null;
 
-  const capRow = caps[normalizedModel];
+  const capRow = caps[normalizedModel] || caps[baseModel];
   if (!capRow) return null;
 
   const tier = deriveTierFromCapabilities(capRow);
@@ -347,12 +356,16 @@ export function getTaskFitnessWithSource(
     return { score: tierScore, source: "models_dev_tier" };
   }
 
-  const staticScore = lookupStaticFitnessTable(normalizedModel, normalizedTask);
+  const baseModel = normalizedModel.endsWith(FREE_SUFFIX)
+    ? normalizedModel.slice(0, -FREE_SUFFIX.length)
+    : normalizedModel;
+
+  const staticScore = lookupStaticFitnessTable(baseModel, normalizedTask);
   if (staticScore !== null) {
     return { score: staticScore, source: "fitness_table" };
   }
 
-  return { score: lookupWildcardBoosts(normalizedModel, normalizedTask), source: "wildcard_boost" };
+  return { score: lookupWildcardBoosts(baseModel, normalizedTask), source: "wildcard_boost" };
 }
 
 /** Suffix used to mark free-tier model variants (e.g. "mimo-v2.5-free"). */


### PR DESCRIPTION
## Summary
Fixes #8603.

When model names end with the `-free` suffix (e.g. `claude-sonnet-free`), task fitness calculations fell through to wildcard/default fallback scores because `lookupStaticFitnessTable` and `getModelsDevTierFitness` did not normalize the `-free` suffix before looking up entries.

## Changes
- Updated `lookupStaticFitnessTable` in `open-sse/services/autoCombo/taskFitness.ts` to check the base model name without `-free` if the initial lookup yields null.
- Updated `getModelsDevTierFitness` to check the base model name without `-free` if the initial lookup yields null.
- Added unit test in `open-sse/services/autoCombo/__tests__/autoCombo.test.ts` verifying `-free` model suffix normalization.