### PR TITLE
fix(contextManager): pass raw message array to estimateTokens to support image token estimation (fixes #8594)

### DIFF
--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -146,7 +146,10 @@ function extractImageTokens(node: unknown, seen: Set<unknown>): { node: unknown;
 
   const record = node as Record<string, unknown>;
   if (isInlineBase64ImageBlock(record)) {
-    return { node: { __image_token_estimate__: IMAGE_TOKEN_ESTIMATE }, tokens: IMAGE_TOKEN_ESTIMATE };
+    return {
+      node: { __image_token_estimate__: IMAGE_TOKEN_ESTIMATE },
+      tokens: IMAGE_TOKEN_ESTIMATE,
+    };
   }
 
   let tokens = 0;
@@ -294,7 +297,7 @@ export function compressContext(
   const targetTokens = Math.max(0, maxTokens - reserveTokens);
 
   let messages = [...body.messages];
-  let currentTokens = estimateTokens(JSON.stringify(messages));
+  let currentTokens = estimateTokens(messages);
   const stats = { original: currentTokens, layers: [] as { name: string; tokens: number }[] };
 
   // Already fits
@@ -304,7 +307,7 @@ export function compressContext(
 
   // Layer 1: Trim tool_result/tool messages
   messages = trimToolMessages(messages, 2000); // Max 2000 chars per tool result
-  currentTokens = estimateTokens(JSON.stringify(messages));
+  currentTokens = estimateTokens(messages);
   stats.layers.push({ name: "trim_tools", tokens: currentTokens });
 
   if (currentTokens <= targetTokens) {
@@ -317,7 +320,7 @@ export function compressContext(
 
   // Layer 2: Compress structured thinking blocks (remove from non-last assistant messages)
   messages = compressThinking(messages);
-  currentTokens = estimateTokens(JSON.stringify(messages));
+  currentTokens = estimateTokens(messages);
   stats.layers.push({ name: "compress_thinking", tokens: currentTokens });
 
   if (currentTokens <= targetTokens) {
@@ -330,7 +333,7 @@ export function compressContext(
 
   // Layer 3: Aggressive purification — drop oldest messages keeping system + last N pairs
   messages = purifyHistory(messages, targetTokens);
-  currentTokens = estimateTokens(JSON.stringify(messages));
+  currentTokens = estimateTokens(messages);
   stats.layers.push({ name: "purify_history", tokens: currentTokens });
 
   return {
@@ -416,7 +419,7 @@ function purifyHistory(messages: Record<string, unknown>[], targetTokens: number
     // orphan tool_results that Claude rejects ("tool_result without preceding tool_use").
     candidate = fixToolPairs(candidate);
     candidate = stripTrailingAssistantOrphanToolUse(candidate);
-    const tokens = estimateTokens(JSON.stringify(candidate));
+    const tokens = estimateTokens(candidate);
     if (tokens <= targetTokens) break;
     keep = Math.max(2, Math.floor(keep * 0.7)); // Drop 30% each iteration
   }

--- a/tests/unit/context-manager.test.ts
+++ b/tests/unit/context-manager.test.ts
@@ -284,3 +284,26 @@ test("Layer 3: preserves intact tool_use/tool_result pairs after compression", (
   );
   assert.ok(toolMsg, "tool_result for call_1 should survive compression");
 });
+
+test("compressContext: image_url in messages correctly uses image tokens in compressContext", () => {
+  // A long base64 string (~4000 base64 chars) simulating an image payload (~1000 tokens as raw text)
+  const base64Data =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==".repeat(
+      40
+    );
+  const imageMsg = {
+    role: "user",
+    content: [
+      { type: "text", text: "Look at this image" },
+      { type: "image_url", image_url: { url: `data:image/png;base64,${base64Data}` } },
+    ],
+  };
+  const body = { model: "test", messages: [imageMsg] };
+  // Without the image token extraction fix (if stringified raw), 4000+ chars would be ~1200+ tokens.
+  // With image token extraction, the base64 is replaced by a placeholder and imageTokens added (~1000 tokens for image), but the base64 text length is stripped out.
+  const result = compressContext(body, { maxTokens: 10000, reserveTokens: 100 });
+  assert.ok(
+    result.stats.original < 1500,
+    `Original token count should be bounded, got ${result.stats.original}`
+  );
+});


### PR DESCRIPTION
## Summary
Fixes #8594.

## Root Cause
In `compressContext`, `JSON.stringify(messages)` was being passed into `estimateTokens`. Since `estimateTokens` inspects payload objects to strip base64 data and calculate image tokens via `extractImageTokens`, stringifying the array into a primitive string bypassed object inspection. As a result, inline base64 image strings were estimated based on raw text length rather than image token counts.

## Changes
- Pass `messages` directly as an array/object to `estimateTokens` inside `compressContext`.
- Added unit test in `context-manager.test.ts` verifying image token estimation within `compressContext`.