### PR TITLE
refactor(sse): retag the Adobe Firefly IMS token-check union

### DIFF
--- a/open-sse/services/adobeFireflyClient.ts
+++ b/open-sse/services/adobeFireflyClient.ts
@@ -1569,8 +1569,8 @@ async function imsCheckToken(opts: {
   guestAllowed: boolean;
   fetchImpl: typeof fetch;
 }): Promise<
-  | { ok: true; token: string; data: ImsTokenResponse }
-  | { ok: false; status: number; error: string }
+  | { state: "ok"; token: string; data: ImsTokenResponse }
+  | { state: "failed"; status: number; error: string }
 > {
   const form = new URLSearchParams({
     client_id: opts.clientId,
@@ -1602,7 +1602,7 @@ async function imsCheckToken(opts: {
 
   if (!resp.ok) {
     return {
-      ok: false,
+      state: "failed",
       status: resp.status,
       error: sanitizeErrorMessage(
         data?.error_description || data?.error || text.slice(0, 200) || `HTTP ${resp.status}`
@@ -1613,14 +1613,14 @@ async function imsCheckToken(opts: {
   const token = String(data?.access_token || "").trim();
   if (!token) {
     return {
-      ok: false,
+      state: "failed",
       status: 401,
       error: sanitizeErrorMessage(
         data?.error_description || data?.error || "IMS response missing access_token"
       ),
     };
   }
-  return { ok: true, token, data: data || {} };
+  return { state: "ok", token, data: data || {} };
 }
 
 /**
@@ -1667,7 +1667,7 @@ export async function exchangeAdobeCookieForAccessToken(
       guestAllowed: false,
       fetchImpl,
     });
-    if (authed.ok) {
+    if (authed.state === "ok") {
       if (
         isAdobeGuestAccessToken(authed.token) ||
         authed.data.account_type === "guest" ||
@@ -1690,7 +1690,7 @@ export async function exchangeAdobeCookieForAccessToken(
       guestAllowed: true,
       fetchImpl,
     });
-    if (guest.ok) {
+    if (guest.state === "ok") {
       if (
         guest.data.account_type === "guest" ||
         guest.data.guestId ||


### PR DESCRIPTION
Part of #8484. Type-only. **7 lines changed, 0 added.** Clears `adobeFireflyClient.ts` — all 6 of its diagnostics, one cause.

## Same root cause, fourth time

```
adobeFireflyClient.ts: TS2339: Property 'status' does not exist on type
  '{ ok: true; token: string; data: ImsTokenResponse } | { ok: false; status: number; error: string }'   x2
                        Property 'error' …                                                               x4
```

`open-sse` compiles with `strictNullChecks: false`, where a **boolean-literal discriminant narrows the positive branch but leaves the negative one as the full union**. So this:

```ts
if (authed.ok) { … } else { lastStatus = authed.status; lastError = authed.error; }
```

cannot see `status`/`error` in the `else`. Same shape as #8483, #8499 and #8531.

## Retag, per the recorded rule

`imsCheckToken` is **module-private** — no `export`, no test reference — so this retags the discriminant rather than adding a type predicate. That is the rule written down on #8499: a predicate exists to avoid churning an exported shape and the assertions that depend on it, and there is no exported shape here.

```diff
 }): Promise<
-  | { ok: true; token: string; data: ImsTokenResponse }
-  | { ok: false; status: number; error: string }
+  | { state: "ok"; token: string; data: ImsTokenResponse }
+  | { state: "failed"; status: number; error: string }
 > {
```

plus the three `return`s and the two `if`s. Seven lines, all replacements.

## Kept inline on purpose

My first pass extracted a named `ImsTokenCheck` type with a doc comment explaining the narrowing. That took the file from 2317 to **2325** and failed `check:file-size` — this file is frozen with **zero** headroom.

So the union stays inline in the return position, which is line-for-line identical to what was there. Same lesson as #8557 on `stream.ts`: on a frozen file the explanation belongs in the commit message, not in the source.

## Verification

**208 → 202, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint` — clean
- `check:file-size` — OK (file unchanged in length)
- **50/50** across the three Adobe Firefly suites

## No test added — the arms were already covered

Checking each arm of the retagged union is now standard for these slices, and here it comes back clean. **`cookie exchange rejects guest IMS tokens` drives both arms in a single flow:**

| request | IMS response | arm exercised |
| --- | --- | --- |
| `guest_allowed=false` | **400** `"All session cookies are empty"` | `state: "failed"` — reads `status` **and** `error` |
| `guest_allowed=true` | 200 + guest token | `state: "ok"` — reads `token`, `data` |

That test's assertion depends on the `error` text matching `/session cookies are empty/i`, which is one of the four reads that failed to typecheck — so the failed arm is not merely reachable, it is load-bearing in an existing assertion.

The same three suites pass on the parent commit, which is the evidence that the retag changes nothing observable.

## Scope note

`open-sse/services` has 27 diagnostics left after this, but they do **not** share a cause — 13 files, at most 6 apiece, and the other 6-error file (`browserBackedChat.ts`) is six unrelated problems rather than one. Those slice individually. Tracked in #8484.
