### PR TITLE
refactor(db): let the provider-nodes cache keep the row type it already returns

### DIFF
--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -137,7 +137,7 @@ export async function getCachedRawProviderConnections(
 }
 
 const connectionByIdCache = new TTLCache<Record<string, unknown> | null>(CONNECTIONS_TTL_MS, 10_000);
-const nodesCache = new TTLCache<unknown[]>(CONNECTIONS_TTL_MS);
+const nodesCache = new TTLCache<(Record<string, unknown> | null)[]>(CONNECTIONS_TTL_MS);
 
 /**
  * Cached wrapper for getProviderConnectionById.
@@ -164,7 +164,7 @@ export async function getCachedProviderConnectionById(
  */
 export async function getCachedProviderNodes(
   filter?: Record<string, unknown>
-): Promise<unknown[]> {
+): Promise<(Record<string, unknown> | null)[]> {
   const cacheKey = filter ? JSON.stringify(filter) : "all";
   const cached = nodesCache.get(cacheKey);
   if (cached) return cached;


### PR DESCRIPTION
Part of #8484. **Two lines, one file** — and it clears 14 diagnostics across two consumer files it never touches.

## A wrapper throwing away its source's type

```ts
export async function getCachedProviderNodes(
  filter?: Record<string, unknown>
): Promise<unknown[]> {           // ← declared
  …
  const value = await getProviderNodes(filter);   // ← returns camelCased rows
```

`getProviderNodes()` maps rows through `rowToCamel`. The cache wrapper in front of it declared `unknown[]`, so every consumer lost the shape:

| file | diagnostics |
| --- | ---: |
| `src/sse/services/model.ts` | 10 — `node.prefix` / `node.id` on `'unknown'` |
| `src/lib/images/imageRouteModel.ts` | 4 — `node.id` on `'unknown'` |

Three further call sites already work around it with **`as unknown as` double casts** — `embeddings/service.ts` (×2) and `memory/embedding/index.ts`. A double cast is the usual sign that a declared return type is narrower than what the function really produces; here it was papering over the same gap from the other side.

## Fix

```diff
-const nodesCache = new TTLCache<unknown[]>(CONNECTIONS_TTL_MS);
+const nodesCache = new TTLCache<(Record<string, unknown> | null)[]>(CONNECTIONS_TTL_MS);

 ): Promise<unknown[]> {
+): Promise<(Record<string, unknown> | null)[]> {
```

No casts added, no consumer touched, no runtime code changed.

## The nullability is deliberate — and one gate caught what the other missed

My first attempt declared `Record<string, unknown>[]`. It measured clean against `open-sse/tsconfig.json` (which has `strict: false`, so `null` is absorbed) — but **`typecheck:core` runs with `strictNullChecks` ON** and rejected it:

```
src/lib/db/readCache.ts(174,28): error TS2345:
  Argument of type '(JsonRecord | null)[]' is not assignable to
  parameter of type 'Record<string, unknown>[]'.
```

`rowToCamel`'s element type is `JsonRecord | null`, so the accurate declaration keeps the null. The looser form would have been a lie that only one of the two gates could see — worth noting for anyone typing DB accessors: **check both**, they disagree on nullability by design.

## Verification

**202 → 188, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean (this is the one that caught the nullability)
- `open-sse` tsc — clean
- `eslint`, `check:file-size`, `check:db-rules` — clean
- **278/278** across the 38 affected suites (provider-node ×6, model-sync ×4, read-cache, image-route, embedding)

## No new tests

This is a declaration matching behavior that already exists — no control flow touched, no runtime diff. The existing 278 cover the consumers; `db-read-cache.test.ts` covers the wrapper itself including its TTL/invalidations.

Checking each arm of the declared type is standard for these slices; here the type has no arms to speak of, and the one judgement call in it — the `| null` — is exactly what `typecheck:core` verifies on every run.

## Scope

Leaves the other 4 diagnostics in `model.ts` (`combo.models.length` via `getComboByName`) alone: different accessor, and unlike provider nodes there is **no shared combo row type** to propagate — only UI-local `Combo` shapes. That one needs a domain type introduced rather than an existing one plumbed through, so it belongs in its own slice. Tracked in #8484.
