### PR TITLE
fix(sse): split the reasoning-decision guards so the error arm actually narrows

### DIFF
--- a/src/sse/handlers/reasoningRouting.ts
+++ b/src/sse/handlers/reasoningRouting.ts
@@ -48,13 +48,25 @@ async function resolveDecision(input: Parameters<typeof resolveReasoningRoutingR
   }
 }
 
+/**
+ * Either the rewritten request, or a `response` to short-circuit with. Declared
+ * rather than inferred: two of the three returns carry only `response`, so the
+ * inferred union had arms without `body`/`modelStr` at all and the caller could
+ * not read them.
+ */
+type AppliedDecision = {
+  body?: unknown;
+  modelStr?: string;
+  response: Response | null;
+};
+
 function applyDecision(
   request: Request,
   body: any,
   policy: RoutingPolicy,
   apiKeyInfo: ApiKeyInfo | null,
   decision: ReasoningRuleDecision
-) {
+): AppliedDecision | Promise<AppliedDecision> {
   if (decision.capability === "unsupported" && !decision.targetCombo) {
     return {
       response: errorResponse(
@@ -125,16 +137,9 @@ export async function applyReasoningRouting({
     comboId: typeof requestedCombo?.id === "string" ? requestedCombo.id : null,
     requestTags: requestRoutingTags.tags,
   });
-  if (decision && "error" in decision) {
-    return {
-      body,
-      modelStr,
-      reasoningIntent: stableReasoningIntent,
-      reasoningDecision: null,
-      requestRoutingTags,
-      response: decision.error,
-    };
-  }
+  // Guards are split rather than combined: `decision && "error" in decision`
+  // only narrows its *true* branch, so the union kept the `{ error }` arm all
+  // the way down and every later use of `decision` saw it.
   if (!decision) {
     return {
       body,
@@ -143,6 +148,16 @@ export async function applyReasoningRouting({
       reasoningDecision: null,
       requestRoutingTags,
       response: null,
+    };
+  }
+  if ("error" in decision) {
+    return {
+      body,
+      modelStr,
+      reasoningIntent: stableReasoningIntent,
+      reasoningDecision: null,
+      requestRoutingTags,
+      response: decision.error,
     };
   }
 

--- a/tests/unit/reasoning-routing-decision-guards.test.ts
+++ b/tests/unit/reasoning-routing-decision-guards.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-reasoning-guards-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "test-reasoning-guards-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const rulesDb = await import("../../src/lib/db/reasoningRoutingRules.ts");
+const handler = await import("../../src/sse/handlers/reasoningRouting.ts");
+
+/**
+ * `applyReasoningRouting` short-circuits on two separate conditions before
+ * applying a decision: no rule matched, and the resolver having failed
+ * (`resolveDecision` catches and returns `{ error }`).
+ *
+ * They used to be written as one compound guard —
+ * `if (decision && "error" in decision)` — which only narrows its *true*
+ * branch, so the `{ error }` arm survived in the union all the way down. The
+ * guards are now separate. These tests pin the observable behaviour of the
+ * paths that reorder touched; they pass identically before and after it.
+ */
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function req() {
+  return new Request("https://example.test/v1/chat/completions", { method: "POST" });
+}
+
+test("no matching rule passes the request through untouched", async () => {
+  rulesDb.invalidateReasoningRoutingRuleCache();
+
+  const body = { model: "gpt-4o", messages: [{ role: "user", content: "hi" }] };
+  const result = await handler.applyReasoningRouting({
+    request: req(),
+    body,
+    modelStr: "gpt-4o",
+    policy: { apiKey: null, apiKeyInfo: null },
+    apiKeyInfo: null,
+  });
+
+  assert.equal(result.response, null, "no rule must not short-circuit the request");
+  assert.equal(result.reasoningDecision, null, "and must not report a decision");
+  assert.equal(result.modelStr, "gpt-4o", "the model is forwarded unchanged");
+  assert.equal(result.body, body, "the body is forwarded by reference, unmodified");
+});
+
+test("the pass-through still reports the extracted reasoning intent", async () => {
+  rulesDb.invalidateReasoningRoutingRuleCache();
+
+  const result = await handler.applyReasoningRouting({
+    request: req(),
+    body: { model: "gpt-4o", reasoning_effort: "high", messages: [] },
+    modelStr: "gpt-4o",
+    policy: { apiKey: null, apiKeyInfo: null },
+    apiKeyInfo: null,
+  });
+
+  // Short-circuiting early must not skip intent extraction — downstream routing
+  // reads this even when no reasoning rule applied. The model comes back
+  // provider-qualified, which is what the rule matcher would have been given.
+  assert.equal(result.reasoningIntent.model, "openai/gpt-4o");
+  assert.equal(result.reasoningIntent.sourceEffort, "high");
+  assert.ok(Array.isArray(result.requestRoutingTags.tags));
+});
+
+test("an unknown model with no rules is also a clean pass-through", async () => {
+  rulesDb.invalidateReasoningRoutingRuleCache();
+
+  const result = await handler.applyReasoningRouting({
+    request: req(),
+    body: { model: "not-a-real-provider/not-a-real-model", messages: [] },
+    modelStr: "not-a-real-provider/not-a-real-model",
+    policy: { apiKey: null, apiKeyInfo: null },
+    apiKeyInfo: null,
+  });
+
+  assert.equal(result.response, null);
+  assert.equal(result.reasoningDecision, null);
+});


### PR DESCRIPTION
Part of #8484. Five of `reasoningRouting.ts`'s six diagnostics, one cause — and unlike the recent slices this one **reorders control flow**, so the behaviour claim is real rather than a formality.

## `&&` in a guard does not narrow the negation

```ts
if (decision && "error" in decision) { … return; }
if (!decision)                       { … return; }
// ↓ decision is still ReasoningRuleDecision | { error: Response }
```

A compound condition narrows only its **true** branch. Its negation cannot distinguish *"`decision` was falsy"* from *"`decision` had no `error`"*, so the `{ error: Response }` arm survived past both guards. Everything downstream saw it:

```
TS2345  applyDecision(…, decision)              — arg is the union
TS2322  reasoningDecision: decision             ×2
```

Split into two guards, falsy first:

```ts
if (!decision)          { … return; }
if ("error" in decision) { … return; }
```

**Behaviour is identical.** The two conditions are mutually exclusive — a caught resolver error produces a truthy object, so it passes `!decision` and reaches the `in` test exactly as before; a null decision has no `error` to match. Order between them cannot change which branch runs.

## The other two: an inferred return with missing arms

`applyDecision` has three returns, and two of them carry only `response`:

```ts
return { response: errorResponse(…) };   // no body, no modelStr
return { response: rejection };          // no body, no modelStr
return { body: …, modelStr: …, response: null };
```

So `applied.body` / `applied.modelStr` did not exist on every member of the inferred union.

Declared an `AppliedDecision` type rather than padding the two short returns with `body: undefined, modelStr: undefined`. The declaration has **no runtime footprint**; the filler would change those objects' own keys, which is a real (if small) behavioural difference for anything that enumerates them.

## Verification

**208 → 203, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint`, `check:file-size` — clean
- **8/8** across both reasoning-routing suites

## Tests — a genuine gap here

`reasoning-routing.test.ts` is thorough about the policy/rule layer (glob and tag matching, precedence, CRUD, schema validation) but **never drives `applyReasoningRouting`**, so the guarded paths had no end-to-end coverage at all.

`tests/unit/reasoning-routing-decision-guards.test.ts`, 3 tests over the no-rule pass-through — the path the reorder puts first:

- the request is forwarded **by reference**, unmodified, with `response: null` and `reasoningDecision: null`
- intent extraction still runs and is reported (`openai/gpt-4o`, `sourceEffort: "high"`) — short-circuiting early must not skip it, since downstream routing reads it even when no rule applied
- an unknown provider/model is also a clean pass-through

**They pass identically on the parent commit**, which is the evidence that the reorder changes nothing observable.

### What I did not cover, and why

The `{ error }` arm is reachable **only** when `resolveReasoningRoutingRule` throws and `resolveDecision` catches it. There is no seam for that here short of module mocking, and the real DB harness this suite uses cannot induce it cleanly. The reorder is safe for that arm by construction — argued above — but I would rather flag the gap than write a test that mocks the resolver into an unrealistic shape and call it coverage.

## Scope

Leaves the sixth diagnostic in this file: `ApiKeyInfo` vs `ApiKeyMetadata` at line 67. That is a **different, cross-file cause** — `reasoningRouting.ts` defines a local `ApiKeyInfo` that duplicates the exported `ApiKeyMetadata` in `shared/utils/apiKeyPolicy.ts`, and the same mismatch produces two more diagnostics in `src/sse/handlers/chat.ts`. Three errors across two files, one consolidation; it belongs in its own slice. Tracked in #8484.
