### PR TITLE
fix(openai-to-claude): skip empty reasoning_content string deltas (fixes #8601)

### DIFF
--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -191,7 +191,11 @@ export function openaiToClaudeResponse(chunk, state) {
     }
     if (parts.length > 0) reasoningContent = parts.join("");
   }
-  if (reasoningContent && !isInternalReasoningPlaceholder(reasoningContent)) {
+  if (
+    typeof reasoningContent === "string" &&
+    reasoningContent !== "" &&
+    !isInternalReasoningPlaceholder(reasoningContent)
+  ) {
     stopTextBlock(state, results);
 
     if (!state.thinkingBlockStarted) {

--- a/tests/unit/translator-openai-to-claude-empty-reasoning.test.ts
+++ b/tests/unit/translator-openai-to-claude-empty-reasoning.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { openaiToClaudeResponse } from "../../open-sse/translator/response/openai-to-claude.ts";
+
+test("openai-to-claude ignores zero-length reasoning_content empty string deltas", () => {
+  const state = {
+    messageStartSent: true,
+    thinkingBlockStarted: false,
+    thinkingBlockIndex: -1,
+    textBlockStarted: false,
+    textBlockIndex: -1,
+    textBlockClosed: false,
+    nextBlockIndex: 0,
+    _pendingXmlToolCalls: [],
+  };
+
+  const chunk = {
+    choices: [
+      {
+        delta: {
+          reasoning_content: "",
+        },
+      },
+    ],
+  };
+
+  const results = openaiToClaudeResponse(chunk, state) || [];
+  assert.equal(results.length, 0);
+  assert.equal(state.thinkingBlockStarted, false);
+});


### PR DESCRIPTION
## Summary
Fixes #8601.

## Changes
- Updated `openaiToClaudeResponse` in `open-sse/translator/response/openai-to-claude.ts` to verify `typeof reasoningContent === "string" && reasoningContent !== ""` before initializing or emitting thinking blocks.
- Added unit test in `tests/unit/translator-openai-to-claude-empty-reasoning.test.ts` verifying zero-length `reasoning_content` empty string deltas are safely ignored.

## Verification
- Ran `node --import tsx/esm --test tests/unit/translator-openai-to-claude-empty-reasoning.test.ts` (100% pass).
- Ran `npx tsc --pretty false -p tsconfig.typecheck-core.json` (0 errors).