### PR TITLE
refactor(sse): use the shared ApiKeyMetadata in reasoningRouting instead of a local duck-type

### DIFF
--- a/src/sse/handlers/reasoningRouting.ts
+++ b/src/sse/handlers/reasoningRouting.ts
@@ -1,7 +1,7 @@
 import { getComboForModel, getModelInfo } from "../services/model";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
 import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
-import { validateApiKeyRoutingTarget } from "@/shared/utils/apiKeyPolicy";
+import { validateApiKeyRoutingTarget, type ApiKeyMetadata } from "@/shared/utils/apiKeyPolicy";
 import { resolveRequestRoutingTags } from "@/domain/tagRouter";
 import * as log from "../utils/logger";
 import {
@@ -14,15 +14,10 @@ import {
   type ReasoningRuleDecision,
 } from "@/lib/reasoningRouting/policy";
 
-type ApiKeyInfo = {
-  id?: string | null;
-  scopes?: string[];
-  [key: string]: unknown;
-};
 
 type RoutingPolicy = {
   apiKey?: string | null;
-  apiKeyInfo?: ApiKeyInfo | null;
+  apiKeyInfo?: ApiKeyMetadata | null;
 };
 
 type ReasoningRoutingResult = {
@@ -52,7 +47,7 @@ function applyDecision(
   request: Request,
   body: any,
   policy: RoutingPolicy,
-  apiKeyInfo: ApiKeyInfo | null,
+  apiKeyInfo: ApiKeyMetadata | null,
   decision: ReasoningRuleDecision
 ) {
   if (decision.capability === "unsupported" && !decision.targetCombo) {
@@ -99,7 +94,7 @@ export async function applyReasoningRouting({
   body: any;
   modelStr: string;
   policy: RoutingPolicy;
-  apiKeyInfo: ApiKeyInfo | null;
+  apiKeyInfo: ApiKeyMetadata | null;
   reasoningIntent?: ExtractedReasoningIntent | null;
 }): Promise<ReasoningRoutingResult> {
   const stableReasoningIntent = reasoningIntent || extractReasoningIntent(modelStr, body);
@@ -198,7 +193,7 @@ export async function applyConnectionReasoningRule({
   provider: string;
   effectiveModel: string;
   credentials: any;
-  apiKeyInfo: ApiKeyInfo | null;
+  apiKeyInfo: ApiKeyMetadata | null;
   reasoningIntent?: ExtractedReasoningIntent | null;
   reasoningDecision?: ReasoningRuleDecision | null;
   requestRoutingTags?: string[];


### PR DESCRIPTION
Part of #8484. Type-only, **net −5 lines**. Three diagnostics across two files, one cause.

## Two types for one value

`reasoningRouting.ts` declared its own shape for the API-key metadata:

```ts
type ApiKeyInfo = {
  id?: string | null;
  scopes?: string[];
  [key: string]: unknown;
};
```

The rest of the pipeline already types that exact value as **`ApiKeyMetadata`** (`shared/utils/apiKeyPolicy.ts`, exported, ~20 fields). Neither is assignable to the other:

- the local one requires a **string index signature**, which an interface cannot provide
- the shared one has `id: string`; the local has `id?: string | null`

| file | diagnostic |
| --- | --- |
| `reasoningRouting.ts` | `ApiKeyInfo` → `ApiKeyMetadata` (the `validateApiKeyRoutingTarget` argument) |
| `chat.ts` | `ApiKeyMetadata` → `ApiKeyInfo` (the `applyReasoningRouting` argument) |
| `chat.ts` | `ApiKeyPolicyResult` → `RoutingPolicy` |

The third fell out for free. `RoutingPolicy` is also local to this file, and its `apiKeyInfo` field was the **only** reason `ApiKeyPolicyResult` — literally `{ apiKey, apiKeyInfo: ApiKeyMetadata | null, rejection }` — would not fit it.

## Fix

Delete the duck-type, import the shared interface. That is the whole change.

The one place that reads the field does `apiKeyInfo?.id ?? null`, so making `id` required *on the interface* while the value stays nullable (`ApiKeyMetadata | null`) is safe.

## Verification

**208 → 205, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint`, `check:file-size` — clean
- **258/258** across the 22 affected suites (reasoning-routing, api-key policy, sse-chat)

## No new tests

Type-only, no control flow touched. The runtime value flowing through these signatures was **always the same `ApiKeyMetadata` object** — the local type merely described it loosely, which is why the mismatch was invisible until the checker looked.

Arm-checking the declared type is standard for these slices; here there are no arms — one interface replaces one looser structural alias for the same value.

## Not included

`chat.ts:548` — `apiKeyInfo as Record<string, unknown>`. That fails for a related but distinct reason: the shared interface has no index signature, so the cast is "insufficiently overlapping". Resolving it means either widening the hook's parameter type or casting through `unknown`, which is a judgement about the hook contract rather than a type consolidation. Left for its own slice; tracked in #8484.
