### PR TITLE
fix(middleware): declare withInjectionGuard's context parameter optional

### DIFF
--- a/src/middleware/promptInjectionGuard.ts
+++ b/src/middleware/promptInjectionGuard.ts
@@ -52,7 +52,7 @@ export function createInjectionGuard(options: PromptInjectionGuardrailOptions = 
 export function withInjectionGuard(handler: any, options: any = {}) {
   const guard = createInjectionGuard(options);
 
-  return async function guardedHandler(request: any, context: any) {
+  return async function guardedHandler(request: any, context?: any) {
     // Only apply to POST/PUT/PATCH
     if (!["POST", "PUT", "PATCH"].includes(request.method)) {
       return handler(request, context);


### PR DESCRIPTION
Part of #8484. **One character.** Clears all five diagnostics in `src/lib/batches/dispatch.ts`.

## A declaration that was wrong about its own runtime

```
Type '(request: any, context: any) => Promise<any>' is not assignable to type 'BatchRouteHandler'.
  Target signature provides too few arguments. Expected 2 or more, but got 1.        ×5
```

`withInjectionGuard()` returns

```ts
return async function guardedHandler(request: any, context: any) {
```

with the second parameter **required**, so every route it wraps advertises arity 2. The batch dispatcher's handler type is `(request: Request) => Promise<Response> | Response`, and TS correctly refuses to assign a function that needs an argument the caller will never pass.

The interesting part is which side was wrong. `dispatch.ts:48` **already** calls it with one argument:

```ts
return await handler(request);
```

and has been doing so in production. `context` is only forwarded on to the inner handler, where routes that do not read it receive `undefined` — which is exactly what one-argument invocation produces. So the parameter has always been optional in practice; the signature just did not say so.

```diff
-  return async function guardedHandler(request: any, context: any) {
+  return async function guardedHandler(request: any, context?: any) {
```

Widening `BatchRouteHandler` to take two parameters would have been the other option, but that fixes it at the consumer and leaves four other wrapped routes still misdescribing their own arity.

## Verification

**208 → 203, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint`, `check:file-size` — clean
- **370/370** across the 43 affected suites (injection-guard, batch, embeddings, moderations)

Nothing executable changed — an optional marker has no runtime representation.

## No test added — the path is the existing behaviour

Checking coverage of what the declaration now permits is standard for these slices, and here it is already thorough. `embeddings-auth.test.ts` (4 call sites) and `embeddings-route-apikeymeta-6929.test.ts` call `POST(req)` **with a single argument** straight through `withInjectionGuard` — precisely the arity this change legalises, exercised end-to-end and passing before and after.

Worth noting what is *not* covered: `batch-processor.test.ts` mocks `dispatchBatchApiRequest`, so the batch path never reaches a real guarded handler. That gap predates this change and is unaffected by it — the one-argument contract is proven by the route tests instead.
