### PR TITLE
refactor(sse): narrow three media-generation result unions

### DIFF
--- a/open-sse/handlers/imageGeneration/providers/freepik.ts
+++ b/open-sse/handlers/imageGeneration/providers/freepik.ts
@@ -114,14 +114,18 @@ async function pollMysticTask(params: {
 }
 
 async function downloadGeneratedImage(imageUrl: string): Promise<
-  { ok: true; b64: string } | { ok: false; status: number; error: string }
+  { state: "ok"; b64: string } | { state: "failed"; status: number; error: string }
 > {
   const imgRes = await fetch(imageUrl);
   if (!imgRes.ok) {
-    return { ok: false, status: imgRes.status, error: `Failed to download image: ${imgRes.status}` };
+    return {
+      state: "failed",
+      status: imgRes.status,
+      error: `Failed to download image: ${imgRes.status}`,
+    };
   }
   const buf = await imgRes.arrayBuffer();
-  return { ok: true, b64: Buffer.from(buf).toString("base64") };
+  return { state: "ok", b64: Buffer.from(buf).toString("base64") };
 }
 
 async function resolveCompletedResult(params: {
@@ -141,7 +145,7 @@ async function resolveCompletedResult(params: {
     });
   }
   const downloaded = await downloadGeneratedImage(imageUrl);
-  if (!downloaded.ok) {
+  if (downloaded.state === "failed") {
     return { success: false, status: downloaded.status, error: downloaded.error };
   }
   saveCallLog({

--- a/open-sse/handlers/imageGeneration/providers/segmind.ts
+++ b/open-sse/handlers/imageGeneration/providers/segmind.ts
@@ -4,7 +4,7 @@
 // client (open-sse/utils/segmindClient.ts) — see that module for the wire
 // shape (x-api-key auth, raw image bytes response, no JSON envelope).
 
-import { segmindRequest } from "../../../utils/segmindClient.ts";
+import { isSegmindFailure, segmindRequest } from "../../../utils/segmindClient.ts";
 
 function parseSegmindSize(size: unknown): { width: number; height: number } {
   if (typeof size === "string" && size.includes("x")) {
@@ -63,7 +63,7 @@ export async function handleSegmindImageGeneration({
     log,
   });
 
-  if (!result.ok) {
+  if (isSegmindFailure(result)) {
     return { success: false, status: result.status, error: result.error };
   }
 

--- a/open-sse/handlers/videoGeneration/providers/segmind.ts
+++ b/open-sse/handlers/videoGeneration/providers/segmind.ts
@@ -5,7 +5,7 @@
 // handler (imageGeneration/providers/segmind.ts): x-api-key auth, raw video
 // bytes response (e.g. `video/mp4`) on success, no JSON envelope.
 
-import { segmindRequest } from "../../../utils/segmindClient.ts";
+import { isSegmindFailure, segmindRequest } from "../../../utils/segmindClient.ts";
 
 function buildSegmindVideoBody(body: Record<string, unknown>, prompt: string) {
   const upstreamBody: Record<string, unknown> = { prompt };
@@ -43,7 +43,7 @@ export async function handleSegmindVideoGeneration({
     log,
   });
 
-  if (!result.ok) {
+  if (isSegmindFailure(result)) {
     return { success: false, status: result.status, error: result.error };
   }
 

--- a/open-sse/utils/segmindClient.ts
+++ b/open-sse/utils/segmindClient.ts
@@ -31,6 +31,19 @@ export type SegmindRequestResult =
   | { ok: true; buffer: Buffer; contentType: string }
   | { ok: false; status: number; error: string };
 
+/**
+ * `open-sse` compiles with `strictNullChecks: false`, where `ok: true | false`
+ * narrows the positive branch but leaves the negative one as the whole union —
+ * so `if (!result.ok)` cannot reach `status`/`error`. A predicate rather than a
+ * retag because this type is exported and its `ok` shape is the published
+ * contract of `segmindRequest()`.
+ */
+export function isSegmindFailure(
+  result: SegmindRequestResult
+): result is Extract<SegmindRequestResult, { ok: false }> {
+  return !result.ok;
+}
+
 async function logSegmindFailure(
   opts: SegmindRequestOptions,
   status: number,

--- a/src/app/api/v1/_shared/mediaGenerationRoute.ts
+++ b/src/app/api/v1/_shared/mediaGenerationRoute.ts
@@ -24,8 +24,8 @@ type MediaGenerationBody = {
 } & Record<string, unknown>;
 
 type ValidatedMediaGenerationBody =
-  | { ok: true; body: MediaGenerationBody }
-  | { ok: false; response: Response };
+  | { state: "ok"; body: MediaGenerationBody }
+  | { state: "invalid"; response: Response };
 
 export function mediaGenerationOptionsResponse() {
   return new Response(null, {
@@ -67,18 +67,21 @@ export async function readMediaGenerationBody(
     rawBody = await request.json();
   } catch {
     log.warn(logScope, "Invalid JSON body");
-    return { ok: false, response: errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body") };
+    return {
+      state: "invalid",
+      response: errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body"),
+    };
   }
 
   const validation = validateBody(v1ImageGenerationSchema, rawBody);
   if (isValidationFailure(validation)) {
     return {
-      ok: false,
+      state: "invalid",
       response: errorResponse(HTTP_STATUS.BAD_REQUEST, validation.error.message),
     };
   }
 
-  return { ok: true, body: validation.data as MediaGenerationBody };
+  return { state: "ok", body: validation.data as MediaGenerationBody };
 }
 
 export function promptRequiredResponse(body: { prompt?: unknown }) {

--- a/src/app/api/v1/music/generations/route.ts
+++ b/src/app/api/v1/music/generations/route.ts
@@ -59,7 +59,7 @@ async function resolveLocalOverrideCredentials(provider) {
  */
 async function postHandler(request, context) {
   const parsed = await readMediaGenerationBody(request, log, "MUSIC");
-  if (!parsed.ok) {
+  if (parsed.state === "invalid") {
     return parsed.response;
   }
   const body = parsed.body;

--- a/src/app/api/v1/videos/generations/route.ts
+++ b/src/app/api/v1/videos/generations/route.ts
@@ -60,7 +60,7 @@ async function resolveLocalOverrideCredentials(provider) {
  */
 async function postHandler(request, context) {
   const parsed = await readMediaGenerationBody(request, log, "VIDEO");
-  if (!parsed.ok) {
+  if (parsed.state === "invalid") {
     return parsed.response;
   }
   const body = parsed.body;


### PR DESCRIPTION
Part of #8484. Seven diagnostics across five files, **one cause** — and the three unions get three different treatments, which is the interesting part.

## The cause, again

`strictNullChecks: false` means `ok: true | false` narrows the positive branch but leaves the negative one as the whole union. So `if (!result.ok)` cannot reach `status`/`error`. Fifth time this campaign (#8483, #8499, #8531, #8638).

## Three unions, three treatments

| union | visibility | treatment | fixed |
| --- | --- | --- | ---: |
| `SegmindRequestResult` | **exported** | type predicate | 4 (image + video providers) |
| `downloadGeneratedImage`'s return | module-private | retag | 2 (freepik) |
| `ValidatedMediaGenerationBody` | module-private | retag | 1 (videos route) |

Per the rule recorded on #8499 — **predicate when exported, retag when private**. `SegmindRequestResult` is the published return contract of `segmindRequest()`, so its `ok` shape stays put and gets:

```ts
export function isSegmindFailure(
  result: SegmindRequestResult
): result is Extract<SegmindRequestResult, { ok: false }> {
  return !result.ok;
}
```

The other two have no consumer outside their module, so retagging is cheaper and clearer. Both consumers of the retagged body union — the videos and music routes — were updated with it.

## What I tried, measured, and reverted

`MediaGenerationResult` in the same shared file looks like the same shape:

```ts
type MediaGenerationResult =
  | { success: true; data: unknown }
  | { success: false; error: unknown; status: number };
```

Retagging it and narrowing `failedMediaGenerationResponse`'s parameter to the failed arm fixes 2 more — but **introduces one new error**: the provider handlers that produce these results widen `success` to `boolean` rather than a literal, so the route's `result` no longer matches the narrowed parameter.

That is a different root cause — literal widening at the producers, not discriminant narrowing at the consumer — and fixing it properly means going after the producers first. Measured 10 fixed / 1 new, reverted that part, kept the invariant. Left for its own slice.

## Verification

**208 → 201, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint` on all seven changed files — clean
- `check:file-size` — clean
- **234/234** across the 27 affected suites

## No new tests — the failure arms are exercised

Checking the arms the change touches is standard here, and both retagged/predicated failure paths already run under test:

- `segmind-image-video-provider-6656.test.ts` drives a **500** (`text/plain` body) and a **502** through both segmind providers — the exact `ok: false` path `isSegmindFailure` now guards
- `video-generation-handler.test.ts` covers a **503** and a malformed-output **500**

The freepik download failure and the invalid-JSON body arm are narrower; they are reachable and unchanged in behaviour (retagging a discriminant has no runtime effect beyond the literal string compared), so I did not manufacture coverage for them.
