### PR TITLE
refactor(sse): declare the semantic-cache read path's parameters

### DIFF
--- a/open-sse/handlers/chatCore/semanticCache.ts
+++ b/open-sse/handlers/chatCore/semanticCache.ts
@@ -26,16 +26,18 @@ export async function checkSemanticCache({
   apiKeyId,
 }: {
   semanticCacheEnabled: boolean;
-  body: Record<string, unknown>;
-  clientRawRequest: unknown;
+  // Only the fields this read path actually touches are named; everything else
+  // on the request body stays `unknown` via the index signature.
+  body: Record<string, unknown> & { temperature?: number; top_p?: number };
+  clientRawRequest: { headers?: unknown } | null;
   model: string;
   provider: string;
   stream: boolean;
-  reqLogger: unknown;
-  effectiveServiceTier: unknown;
+  reqLogger: { logConvertedResponse: (response: Record<string, unknown>) => void };
+  effectiveServiceTier: string | null | undefined;
   connectionId: string | null;
   startTime: number;
-  log: unknown;
+  log: { debug?: (...args: unknown[]) => void } | null;
   persistAttemptLogs: (args: unknown) => void;
   apiKeyId?: string | null;
 }) {


### PR DESCRIPTION
Part of #8484. All five diagnostics in `chatCore/semanticCache.ts`, one cause — the function's own parameter list.

## Declared `unknown`, then read through

```ts
clientRawRequest: unknown;      →  clientRawRequest?.headers
reqLogger: unknown;             →  reqLogger.logConvertedResponse(…)
log: unknown;                   →  log?.debug?.(…)
effectiveServiceTier: unknown;  →  passed where a string is expected
body: Record<string, unknown>;  →  body.temperature / body.top_p
```

The last one is the least obvious: they go into `generateSignature(model, conversation, temperature = 0, topP = 1, …)`, whose defaults infer `number`, so `unknown` from the index signature will not fit.

## Fix

Named only the fields this read path actually touches:

```ts
body: Record<string, unknown> & { temperature?: number; top_p?: number };
clientRawRequest: { headers?: unknown } | null;
reqLogger: { logConvertedResponse: (response: Record<string, unknown>) => void };
effectiveServiceTier: string | null | undefined;
log: { debug?: (...args: unknown[]) => void } | null;
```

Everything else on the request body stays `unknown` behind the index signature — this is not an attempt to type the whole chat body, just to stop the parameters lying about what the function does with them.

No casts added, no call site changed, nothing executable touched.

## Verification

**208 → 203, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint`, `check:file-size` — clean
- **401/401** across the 47 cache suites

## No new tests

Parameter declarations matching how the arguments were already being used — no control flow altered, no runtime diff. `reqLogger.logConvertedResponse` is called unconditionally so it is declared required; `log.debug` is called with `?.` so it stays optional, which is what the existing callers already pass.
