### PR TITLE
refactor(sse): peel the bare Response off handleChatCore's union in responsesHandler

### DIFF
--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -60,6 +60,13 @@ export async function handleResponsesCore({
     comboName: null,
   });
 
+  // handleChatCore's union includes a bare Response (early returns that never
+  // reach the {success, response} envelope). Peel it off first so the envelope
+  // checks below are reading a shape that actually has those fields — the
+  // outcome is unchanged, a bare Response was already returned as-is.
+  if (result instanceof Response) {
+    return result;
+  }
   if (!result.success || !result.response) {
     return result;
   }


### PR DESCRIPTION
Part of #8484. Three of the five diagnostics in `responsesHandler.ts` — a **7-line guard**, no runtime change.

## A union with a bare `Response` in it

`handleChatCore` returns

```
Response
| { success: boolean; response: Response }
| { success: boolean; status: number; errorType: string; …; response: Response }
| { … }
```

Early returns that never build an envelope contribute the bare `Response` arm. `responsesHandler` read `result.success` / `result.response` straight off the union, so three diagnostics fired on the arm that has neither.

```ts
if (result instanceof Response) {
  return result;
}
if (!result.success || !result.response) {
  return result;
}
```

**The outcome is unchanged.** A bare `Response` already fell through the second check — `result.success` is `undefined`, so `!result.success` is true — and was returned as-is. It is now returned one branch earlier, explicitly. Same value, same caller behaviour; the guard just lets the checker see which arm it is.

## Verification

**208 → 205, zero new errors**, on a line-number-agnostic diff of the full `tsc` error set.

- `npm run typecheck:core` — clean
- `eslint`, `check:file-size` — clean
- **400/400** across the responses suites

## The other two are deliberately left

Declaring `convertResponsesApiFormat`'s return type fixes them — and immediately surfaces the **next** masked error at the `handleChatCore` call: `onStreamFailure` is declared required in that parameter object, while `responsesHandler` has always omitted it in production (so it has always been `undefined` there, and works).

That is the same "declaration is wrong about its own runtime" shape as #8644, but the declaration in question lives on `chatCore.ts`'s signature — which belongs with the chatCore work, not bolted onto a three-line guard. Measured **5 fixed / 1 new**, reverted that half, kept the zero-new invariant.

Tracked in #8484 alongside the rest of the chatCore cluster.
