### PR TITLE
fix(autoCombo): handle missing model_capabilities table in taskFitness (#8603)

### DIFF
--- a/open-sse/services/autoCombo/taskFitness.ts
+++ b/open-sse/services/autoCombo/taskFitness.ts
@@ -239,6 +239,11 @@ function loadModelCapabilities(): Record<string, ModelCapRow> | null {
 
   try {
     const db = getDbInstance();
+    const tableExists = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='model_capabilities'")
+      .get();
+    if (!tableExists) return null;
+
     const rows = db.prepare("SELECT * FROM model_capabilities").all() as Record<string, unknown>[];
     const cache: Record<string, ModelCapRow> = {};
 

--- a/tests/unit/task-fitness-missing-table-8603.test.ts
+++ b/tests/unit/task-fitness-missing-table-8603.test.ts
@@ -1,0 +1,10 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getModelsDevTierFitness } from "../../open-sse/services/autoCombo/taskFitness.ts";
+
+describe("taskFitness - missing model_capabilities table (#8603)", () => {
+  it("returns null safely when model_capabilities table does not exist in DB", () => {
+    const result = getModelsDevTierFitness("claude-sonnet-3-5-20241022", "coding");
+    assert.equal(result, null);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #8603.

## Changes
- Safely check if the `model_capabilities` table exists in SQLite before attempting to query it in `loadModelCapabilities()`.
- Avoids SQL error throwing when autoCombo runs on a freshly initialized or schema-partial DB.
- Added regression unit test in `tests/unit/task-fitness-missing-table-8603.test.ts`.