### PR TITLE
fix(autoCombo): match longest pattern first in lookupStaticFitnessTable (#8603)

### DIFF
--- a/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
+++ b/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
@@ -622,6 +622,12 @@ describe("Task Fitness DB Resolution Chain", () => {
     expect(() => invalidateFitnessCache()).not.toThrow();
   });
 
+  it("resolution chain: static table matches longest pattern first (gpt-4o-mini vs gpt-4o)", () => {
+    // gpt-4o-mini must match "gpt-4o-mini" (0.8) rather than earlier "gpt-4o" (0.9)
+    const score = getTaskFitness("gpt-4o-mini", "coding");
+    expect(score).toBe(0.8);
+  });
+
   it("resolution chain: static table takes priority over wildcard for known models", () => {
     // "claude-sonnet" is in the static table with coding=0.95
     // It does NOT match "coder" wildcard because the static table is checked first

--- a/open-sse/services/autoCombo/taskFitness.ts
+++ b/open-sse/services/autoCombo/taskFitness.ts
@@ -294,7 +294,8 @@ export function getModelsDevTierFitness(model: string, taskType: string): number
 
 function lookupStaticFitnessTable(normalizedModel: string, normalizedTask: string): number | null {
   const table = FITNESS_TABLE[normalizedTask] || FITNESS_TABLE.default;
-  for (const [pattern, score] of Object.entries(table)) {
+  const entries = Object.entries(table).sort((a, b) => b[0].length - a[0].length);
+  for (const [pattern, score] of entries) {
     if (normalizedModel.includes(pattern)) return score;
   }
   return null;


### PR DESCRIPTION
## Summary
Fixes #8603 (static table lookup pattern matching order).

## Changes
- Sort `FITNESS_TABLE` pattern entries by length descending before substring matching in `lookupStaticFitnessTable()`.
- Ensures specific model variants (e.g. `gpt-4o-mini`) match their exact score (0.8) rather than incorrectly falling through to shorter prefix keys like `gpt-4o` (0.9).
- Added unit test in `open-sse/services/autoCombo/__tests__/autoCombo.test.ts`.