### PR TITLE
fix(providers): sync search query to URL query param (#8624)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -30,6 +30,7 @@ import {
   shouldFilterProviderEntriesForDisplayMode,
   shouldShowFirstProviderHint,
   shouldShowProviderSection,
+  syncSearchToUrl,
   upsertProviderNodeById,
   loadProviderPageData,
 } from "./providerPageUtils";
@@ -238,6 +239,10 @@ export default function ProvidersPage() {
       setSearchQuery(searchFromUrl);
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    syncSearchToUrl(searchQuery);
+  }, [searchQuery]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -70,6 +70,23 @@ export function shouldShowFirstProviderHint(
   return connectionCount === 0 && !searchQuery?.trim();
 }
 
+export function syncSearchToUrl(searchQuery: string): void {
+  if (typeof window === "undefined") return;
+
+  const url = new URL(window.location.href);
+  const currentSearch = url.searchParams.get("search") || "";
+
+  if (searchQuery.trim()) {
+    if (currentSearch !== searchQuery) {
+      url.searchParams.set("search", searchQuery);
+      window.history.replaceState(window.history.state, "", url.toString());
+    }
+  } else if (url.searchParams.has("search")) {
+    url.searchParams.delete("search");
+    window.history.replaceState(window.history.state, "", url.toString());
+  }
+}
+
 export function shouldShowProviderSection(
   category: string,
   activeCategory: string | null,

--- a/tests/unit/sync-search-to-url-8624.test.ts
+++ b/tests/unit/sync-search-to-url-8624.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { syncSearchToUrl } from "../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts";
+
+describe("syncSearchToUrl (#8624)", () => {
+  it("does not throw when window is undefined (SSR environment)", () => {
+    assert.doesNotThrow(() => {
+      syncSearchToUrl("openai");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #8624.

## Changes
- Export `syncSearchToUrl` in `providerPageUtils.ts` to update or delete the `?search=` URL query parameter via `window.history.replaceState`.
- Call `syncSearchToUrl(searchQuery)` inside a `useEffect` in `src/app/(dashboard)/dashboard/providers/page.tsx`.
- Added unit test coverage in `tests/unit/sync-search-to-url-8624.test.ts`.