### PR TITLE
chore(skills): regenerate cli-backup-sync SKILL.md to match catalog

### DIFF
--- a/changelog.d/maintenance/8657-agent-skills-cli-backup-sync-stale.md
+++ b/changelog.d/maintenance/8657-agent-skills-cli-backup-sync-stale.md
@@ -1,0 +1,1 @@
+- **chore(skills):** regenerate `skills/cli-backup-sync/SKILL.md` so it matches the agent-skills catalog — drops stale `backup status` flags the generator no longer emits; unblocks Merge integrity (`check:agent-skills-sync`) for every PR against `release/v3.8.49` ([#8657](https://github.com/diegosouzapw/OmniRoute/pull/8657)) — thanks @MumuTW

--- a/skills/cli-backup-sync/SKILL.md
+++ b/skills/cli-backup-sync/SKILL.md
@@ -75,15 +75,6 @@ omniroute backup disable
 
 ### `backup status`
 
-**Flags:**
-
-- `--name <name>`
-- `--cloud`
-- `--encrypt`
-- `--key-file <path>`
-- `--exclude <pattern>`
-- `--retention <n>`
-
 **Example:**
 
 ```bash


### PR DESCRIPTION
## Summary

`Merge integrity (changelog + generated skills)` has been failing on every PR→`release/v3.8.49` with:

```
check:agent-skills-sync
Generated: 1 · … + cli-backup-sync
```

Tip's `skills/cli-backup-sync/SKILL.md` was stale vs the catalog: it still listed `backup status` flags (`--name`, `--cloud`, `--encrypt`, …) the generator no longer emits.

## Fix

```bash
node --import tsx/esm scripts/skills/generate-agent-skills.mjs --apply
```

Diff is **−9 lines** in `skills/cli-backup-sync/SKILL.md` only. After apply, dry-run is `Generated: 0 · Unchanged: 45`.

## Why this matters

Unblocks Merge integrity for the whole queue (including #8424, #8580, #8589, #8604, #8605, #8619).

## Test plan

- [x] `npm run check:agent-skills-sync` green on this branch
- [x] Diff limited to generated skill file