### PR TITLE
refactor(sse): guard the KIE task-id and callback-url reads at their source

### DIFF
--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -32,6 +32,7 @@ import { sleep } from "../utils/sleep.ts";
 import {
   getKieErrorMessage,
   getKieErrorStatus,
+  getKieTaskId,
   isJsonObject,
   parseKieResultJson,
 } from "../utils/kieTask.ts";
@@ -758,7 +759,7 @@ async function handleKieImageGeneration({
       payload,
       endpoint,
     });
-    const taskId = createData?.data?.taskId || createData?.taskId;
+    const taskId = getKieTaskId(createData);
 
     if (!taskId) {
       const errorMessage =

--- a/open-sse/handlers/musicGeneration.ts
+++ b/open-sse/handlers/musicGeneration.ts
@@ -25,7 +25,12 @@ import {
   resolveComfyUiBaseUrl,
 } from "../utils/comfyuiClient.ts";
 import { saveCallLog } from "@/lib/usageDb";
-import { getKieCallbackUrl, isJsonObject, parseKieResultJson } from "../utils/kieTask.ts";
+import {
+  getKieCallbackUrl,
+  getKieTaskId,
+  isJsonObject,
+  parseKieResultJson,
+} from "../utils/kieTask.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
 
 function normalizeKieSunoModel(model: string): string {
@@ -341,7 +346,7 @@ async function handleKieMusicGeneration({
   try {
     const endpoint = new URL(url).pathname;
     const createData = await kieExecutor.createTask({ baseUrl, token, payload, endpoint });
-    const taskId = createData?.data?.taskId || createData?.taskId;
+    const taskId = getKieTaskId(createData);
     if (!taskId) {
       const errorMessage =
         createData?.msg ||

--- a/open-sse/handlers/videoGeneration.ts
+++ b/open-sse/handlers/videoGeneration.ts
@@ -19,7 +19,7 @@ import { handleXaiVideoGeneration } from "./videoGeneration/xaiGrokImagineHandle
 import { handleSegmindVideoGeneration } from "./videoGeneration/providers/segmind.ts";
 import { handleAdobeFireflyVideoGeneration } from "./videoGeneration/adobeFireflyHandler.ts";
 import { getExecutor } from "../executors/index.ts";
-import { isJsonObject, parseKieResultJson } from "../utils/kieTask.ts";
+import { getKieTaskId, isJsonObject, parseKieResultJson } from "../utils/kieTask.ts";
 import {
   buildRunwayApiUrl,
   buildRunwayHeaders,
@@ -540,7 +540,7 @@ async function handleKieVideoGeneration({
 
   try {
     const createData = await kieExecutor.createTask({ baseUrl, token, payload });
-    const taskId = createData?.data?.taskId || createData?.taskId;
+    const taskId = getKieTaskId(createData);
     if (!taskId) {
       const errorMessage =
         createData?.msg ||

--- a/open-sse/utils/kieTask.ts
+++ b/open-sse/utils/kieTask.ts
@@ -2,12 +2,6 @@ export type JsonObject = Record<string, unknown>;
 
 export type KieTaskState = "success" | "failed" | "pending";
 
-export type KieCallbackBody = {
-  callBackUrl?: unknown;
-  callback_url?: unknown;
-  callbackUrl?: unknown;
-};
-
 const FALLBACK_KIE_CALLBACK_URL = "https://omniroute.local/api/kie/callback";
 
 export function isJsonObject(value: unknown): value is JsonObject {
@@ -42,8 +36,9 @@ function getConfiguredKieCallbackUrl(): string {
   );
 }
 
-export function getKieCallbackUrl(body: KieCallbackBody = {}): string {
-  const callbackUrl = body.callBackUrl ?? body.callback_url ?? body.callbackUrl;
+export function getKieCallbackUrl(body: unknown = {}): string {
+  const record = isJsonObject(body) ? body : {};
+  const callbackUrl = record.callBackUrl ?? record.callback_url ?? record.callbackUrl;
   return typeof callbackUrl === "string" && callbackUrl.trim().length > 0
     ? callbackUrl
     : getConfiguredKieCallbackUrl();
@@ -63,6 +58,13 @@ export function parseKieResultJson(recordData: unknown): JsonObject {
   }
 
   return isJsonObject(resultJson) ? resultJson : {};
+}
+
+export function getKieTaskId(createData: unknown): string | null {
+  const record = isJsonObject(createData) ? createData : {};
+  const data = isJsonObject(record.data) ? record.data : {};
+  const taskId = data.taskId || record.taskId;
+  return taskId ? String(taskId) : null;
 }
 
 export function normalizeKieTaskState(recordData: unknown): KieTaskState {

--- a/tests/unit/kie-task-helpers.test.ts
+++ b/tests/unit/kie-task-helpers.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getKieCallbackUrl, getKieTaskId } from "../../open-sse/utils/kieTask.ts";
+
+// getKieTaskId replaces the expression `createData?.data?.taskId || createData?.taskId`
+// that image/video/music generation each duplicated. Every arm below is one the three
+// handlers could hit, since `createTask()` returns whatever the KIE upstream sent.
+
+test("getKieTaskId reads the nested data.taskId first", () => {
+  assert.equal(getKieTaskId({ data: { taskId: "abc123" } }), "abc123");
+});
+
+test("getKieTaskId falls back to a top-level taskId", () => {
+  assert.equal(getKieTaskId({ taskId: "top-level" }), "top-level");
+});
+
+test("getKieTaskId prefers the nested id when both are present", () => {
+  assert.equal(getKieTaskId({ taskId: "top", data: { taskId: "nested" } }), "nested");
+});
+
+test("getKieTaskId coerces a non-string id, as the pollTask callers did with String()", () => {
+  assert.equal(getKieTaskId({ data: { taskId: 42 } }), "42");
+});
+
+test("getKieTaskId ignores a non-object data envelope and still checks the top level", () => {
+  // KIE has returned `data` as a string, an array and null on error responses.
+  assert.equal(getKieTaskId({ data: "not-an-object", taskId: "fallback" }), "fallback");
+  assert.equal(getKieTaskId({ data: ["nope"], taskId: "fallback" }), "fallback");
+  assert.equal(getKieTaskId({ data: null, taskId: "fallback" }), "fallback");
+  assert.equal(getKieTaskId({ data: "not-an-object" }), null);
+});
+
+test("getKieTaskId returns null when no id is present, keeping the handlers' 502 branch", () => {
+  assert.equal(getKieTaskId({}), null);
+  assert.equal(getKieTaskId({ data: {} }), null);
+  assert.equal(getKieTaskId({ msg: "createTask failed" }), null);
+});
+
+test("getKieTaskId treats falsy ids as absent, matching the previous `!taskId` guard", () => {
+  assert.equal(getKieTaskId({ data: { taskId: "" } }), null);
+  assert.equal(getKieTaskId({ data: { taskId: 0 } }), null);
+});
+
+test("getKieTaskId tolerates a non-object response", () => {
+  assert.equal(getKieTaskId(null), null);
+  assert.equal(getKieTaskId(undefined), null);
+  assert.equal(getKieTaskId("boom"), null);
+});
+
+test("getKieCallbackUrl accepts all three casings the handlers forward", () => {
+  assert.equal(getKieCallbackUrl({ callBackUrl: "https://a.test/cb" }), "https://a.test/cb");
+  assert.equal(getKieCallbackUrl({ callback_url: "https://b.test/cb" }), "https://b.test/cb");
+  assert.equal(getKieCallbackUrl({ callbackUrl: "https://c.test/cb" }), "https://c.test/cb");
+});
+
+test("getKieCallbackUrl falls back for blank, absent and non-object bodies", () => {
+  const previous = process.env.KIE_CALLBACK_URL;
+  process.env.KIE_CALLBACK_URL = "https://configured.test/api/kie/callback";
+  try {
+    const configured = "https://configured.test/api/kie/callback";
+    assert.equal(getKieCallbackUrl({ callBackUrl: "   " }), configured);
+    assert.equal(getKieCallbackUrl({}), configured);
+    assert.equal(getKieCallbackUrl(), configured);
+    // The music handler passes an untyped request body straight through.
+    assert.equal(getKieCallbackUrl({ prompt: "a song" }), configured);
+    assert.equal(getKieCallbackUrl(null), configured);
+    assert.equal(getKieCallbackUrl("not-an-object"), configured);
+  } finally {
+    if (previous === undefined) delete process.env.KIE_CALLBACK_URL;
+    else process.env.KIE_CALLBACK_URL = previous;
+  }
+});


### PR DESCRIPTION
Part of the TS7 readiness campaign (#8484). One root cause, **5 diagnostics, zero new**.

## Root cause

`kieExecutor.createTask()` returns `JsonObject` — i.e. `Record<string, unknown>` — so `createData.data` is `unknown`. Three handlers each carried the same unguarded read verbatim:

```ts
const taskId = createData?.data?.taskId || createData?.taskId;
```

`open-sse/utils/kieTask.ts` already holds two helpers with exactly this shape: `normalizeKieTaskState()` and `parseKieResultJson()` both take `unknown`, guard with `isJsonObject()`, and return a declared type. `normalizeKieTaskState()` even does the identical `record.data` dance. So this fixes the read at its source rather than at each of the three call sites, following the neighbour rather than inventing a third idiom.

Separately, `getKieCallbackUrl()` took `KieCallbackBody` — a **weak type** (every property optional). Passing a request body whose declared keys are `prompt` / `timeout_ms` / `poll_interval_ms` shares no property with it, which is TS2559 at both music call sites. The function receives arbitrary upstream request bodies, so it now takes `unknown` and guards the same way its neighbours do. `KieCallbackBody` had no other reference in the repo and is removed.

## Diagnostics fixed

| file | count | code |
| --- | ---: | --- |
| `open-sse/handlers/imageGeneration.ts` | 1 | TS2339 `taskId` on `unknown` |
| `open-sse/handlers/videoGeneration.ts` | 1 | TS2339 `taskId` on `unknown` |
| `open-sse/handlers/musicGeneration.ts` | 3 | 1x TS2339 + 2x TS2559 `KieCallbackBody` |

Measured as a line-number-agnostic diff of the complete `tsc -p open-sse/tsconfig.json` error set against a freshly re-measured base: **208 → 203, 5 fixed, 0 new.** Also verified on top of the eight other open TS7 slices (160 → 155), where it applies without conflict.

## Behaviour is unchanged

- `isJsonObject()` rejects arrays and `null` in exactly the positions where optional chaining already produced `undefined`, so the fallback to a top-level `taskId` is reached in the same cases.
- The callers' `String(taskId)` coercion moved inside the helper, so a numeric id still reaches `pollTask()` as a string.
- A falsy id (`""`, `0`, missing) still returns nothing and still takes the handlers' 502 branch.
- `getKieCallbackUrl()` only widens what it accepts; the three key casings, the blank-string rejection and the configured-URL fallback are untouched.

## Test plan

New `tests/unit/kie-task-helpers.test.ts` — 10 tests covering **every arm** of the two helpers, including the ones the old inline expression never had coverage for:

- nested `data.taskId`, top-level fallback, nested-wins-over-top-level
- numeric id coercion
- non-object `data` (string / array / `null`) still falling through to the top level
- falsy ids (`""`, `0`) treated as absent, preserving the `!taskId` guard
- non-object response (`null`, `undefined`, a string)
- all three callback-url casings, blank-string rejection, and the fallback for `{}` / no-arg / non-object bodies

```
node --import tsx/esm --test tests/unit/kie-task-helpers.test.ts   # 10/10
```

Regression run over the handlers this touches — `kie-executor-routing`, `image-generation-handler`, `image-generation-route`, `music-generation-handler`, `google-flow-video-4569`, `video-deepinfra-6653`, `alibaba-video-media`, `new-content-providers`, `audio-speech-handler`, `audio-transcription-handler`, `comfyui-baseurl-override-6928`: **182 pass, 0 fail**.

Gates: `typecheck:core` clean, `check:file-size` OK, `check:known-symbols` OK, ESLint clean on the touched files (the two `no-explicit-any` reports in `musicGeneration.ts` / `videoGeneration.ts` are the pre-existing `catch (err: any)` entries already frozen at count 1 each in `eslint-suppressions.json`; this PR adds none).

> The one red check, `Merge integrity (changelog + generated skills)`, is base-red on `release/v3.8.49` and unrelated to this diff — it reproduces on the bare tip and is being fixed by #8657 / tracked in #8658.
