### PR TITLE
fix(maritalk): refresh supported model catalog

### DIFF
--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -398,7 +398,7 @@ export const CHAT_OPENAI_COMPAT_MODELS: Record<string, RegistryModel[]> = {
   // from the menu; old refs auto-forward via the codestral-2405 deprecation alias.
   codestral: buildModels(["codestral-2508", "codestral-latest"]),
   upstage: buildModels(["solar-pro3", "solar-mini"]),
-  maritalk: buildModels(["sabia-4", "sabia-3.1", "sabiazinho-4", "sabiazinho-3"]),
+  maritalk: buildModels(["sabia-4", "sabia-4-thinking", "sabiazinho-4"]),
   "xiaomi-mimo": [
     { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", contextLength: 1048576, maxOutputTokens: 131072 },
     { id: "mimo-v2.5", name: "MiMo-V2.5", contextLength: 1048576, maxOutputTokens: 131072 },

--- a/tests/unit/maritalk-model-catalog.test.ts
+++ b/tests/unit/maritalk-model-catalog.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getRegistryEntry } from "../../open-sse/config/providerRegistry.ts";
+
+test("Maritalk exposes only the current non-Brazilian-Portuguese model variants", () => {
+  const maritalk = getRegistryEntry("maritalk");
+
+  assert.ok(maritalk);
+  assert.deepEqual(
+    maritalk.models.map((model) => model.id),
+    ["sabia-4", "sabia-4-thinking", "sabiazinho-4"]
+  );
+  assert.ok(maritalk.models.every((model) => !model.id.endsWith("-br-sp")));
+});


### PR DESCRIPTION
## Summary

- refresh the built-in `maritalk` catalog to the current general model lineup
- add `sabia-4-thinking`
- remove the discontinued `sabia-3.1` and `sabiazinho-3` entries
- intentionally exclude the regional `*-br-sp` variants
- add a focused registry regression test that locks the exact public catalog

## Why

Maritaca's platform now lists the Sabiá 4 family and reports that `sabia-3`,
`sabia-3.1`, and `sabiazinho-3` were discontinued on July 16, 2026. OmniRoute's
static catalog still exposed two of those retired models and did not expose
`sabia-4-thinking`.

This left the provider model picker and other registry consumers out of sync
with the provider's current lineup.

## User and developer impact

The built-in `maritalk` catalog now exposes exactly:

- `sabia-4`
- `sabia-4-thinking`
- `sabiazinho-4`

This is a catalog-only update. It does not change Maritalk authentication,
request translation, executor selection, base URLs, endpoint construction,
provider IDs, schemas, or persisted connection data.

The removed entries were already discontinued upstream. The regional
`sabia-4-br-sp`, `sabia-4-thinking-br-sp`, and `sabiazinho-4-br-sp` variants
remain intentionally unadvertised.

## Validation

- `node --import tsx/esm --test tests/unit/maritalk-model-catalog.test.ts`
- `node --import tsx/esm --test tests/unit/provider-validation-specialty.test.ts`
  - 122 tests passed
- `npm run check:provider-consistency`
- `npm run lint`
- `npm run typecheck:core`
- `npm run check:file-size`
- commit hooks, including Prettier, ESLint, documentation sync, explicit-any
  budget, and tracked-artifact checks
