### PR TITLE
[v3.8.50] fix(security): override tar to ^7.5.22 (GHSA-w8wr-v893-vjvp) — unblocks the Lint job on every PR

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -3225,9 +3225,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -37,7 +37,8 @@
     "plist": "^4.0.0",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",
-    "undici": "^7.28.0"
+    "undici": "^7.28.0",
+    "tar": "^7.5.22"
   },
   "build": {
     "appId": "online.omniroute.desktop",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34341,9 +34341,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -413,6 +413,7 @@
     "hono": "^4.12.27",
     "@hono/node-server": "^2.0.5",
     "fast-uri": "^3.1.3",
+    "tar": "^7.5.22",
     "body-parser": "^2.3.0",
     "@yarnpkg/parsers": {
       "js-yaml": "^4.2.0"


### PR DESCRIPTION
## CI is red on `main` — every PR's Lint job dies before ESLint runs

`npm audit --audit-level=critical` currently fails on `main`, and the Lint job runs
`audit:deps` **before** `lint:json`. So the job exits at that step, the
`.artifacts/eslint-results.json` artifact is never produced (`No files were found with the
provided path` in the log), and the failure looks like a lint failure when it isn't one.

## The advisory

[GHSA-w8wr-v893-vjvp](https://github.com/advisories/GHSA-w8wr-v893-vjvp) — node-tar process
crash via PAX numeric path type confusion, `tar <= 7.5.20`, fixed in 7.5.21.

`tar` is transitive in **both** workspaces:

| | resolved before | critical count before | after |
|---|---|---|---|
| root | 7.5.16 | 1 | 0 |
| `electron/` | 7.5.x | 1 | 0 |

## The change

Adds `"tar": "^7.5.22"` to the existing `overrides` block in `package.json` and
`electron/package.json` — the same mechanism already used here for `dompurify`,
`fast-xml-parser`, `undici`, `form-data` and friends.

Verified after the change: root and electron critical counts are both 0, and the whole
`audit:deps` chain exits 0.

One note in case it saves someone time: on Windows npm runs scripts through `cmd`, where the
`(cmd || echo '::warning::…')` group does **not** swallow the non-zero exit code, so running
`npm run audit:deps` locally on Windows reports a failure even when the gate is green. Check
it under `sh` (as CI does) instead.
