### PR TITLE
fix(dashboard): broken icon allignment in `SegmentedControl.tsx`

### DIFF
--- a/src/shared/components/SegmentedControl.tsx
+++ b/src/shared/components/SegmentedControl.tsx
@@ -53,7 +53,8 @@ export default function SegmentedControl({
             sizes[size],
             value === option.value
               ? "bg-white dark:bg-white/10 text-text-main shadow-sm"
-              : "text-text-muted hover:text-text-main"
+              : "text-text-muted hover:text-text-main",
+            option.icon && "flex items-center",
           )}
         >
           {option.icon && (


### PR DESCRIPTION
## Summary

Was setting up the project and found some alignment issue with the buttons in [SegmentedControl.tsx](https://github.com/diegosouzapw/OmniRoute/blob/release/v3.8.49/src/shared/components/SegmentedControl.tsx) file.

Before:
<img width="746" height="227" alt="image" src="https://github.com/user-attachments/assets/22302de4-f407-4ba4-ae41-ee0c59954139" />

After:
<img width="765" height="277" alt="image" src="https://github.com/user-attachments/assets/20c56594-4c92-41d9-9e61-5327f49b674d" />

It fixes the same issue in couple of more places where this component is being used.