### PR TITLE
fix(providers): mark Monster API as deprecated (fixes #8676)

### DIFF
--- a/src/shared/constants/providers/apikey/inference-hosts.ts
+++ b/src/shared/constants/providers/apikey/inference-hosts.ts
@@ -29,7 +29,8 @@ export const APIKEY_PROVIDERS_INFERENCE = {
     textIcon: "OV",
     website: "https://openvecta.com",
     hasFree: true,
-    freeNote: "Free credits on signup for OpenAI-compatible inference across LLMs, embeddings, and reasoning models",
+    freeNote:
+      "Free credits on signup for OpenAI-compatible inference across LLMs, embeddings, and reasoning models",
   },
   fireworks: {
     id: "fireworks",
@@ -292,6 +293,9 @@ export const APIKEY_PROVIDERS_INFERENCE = {
       "One-time signup trial credits for decentralized GPU inference (no recurring free plan). No credit card required.",
     passthroughModels: true,
     authHint: "Get API key at monsterapi.ai",
+    isDeprecated: true,
+    deprecationReason:
+      "Monster API shuttered operations on 2026-06-30. Use alternative OpenAI-compatible providers.",
   },
   modelscope: {
     id: "modelscope",

--- a/tests/unit/8676-monsterapi-deprecation.test.ts
+++ b/tests/unit/8676-monsterapi-deprecation.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { APIKEY_PROVIDERS_INFERENCE } from "../../src/shared/constants/providers/apikey/inference-hosts.ts";
+
+test("Monster API provider is marked as deprecated (fixes #8676)", () => {
+  const monsterEntry = APIKEY_PROVIDERS_INFERENCE.monsterapi;
+  assert.ok(monsterEntry, "monsterapi entry must exist in APIKEY_PROVIDERS_INFERENCE");
+  assert.equal(
+    (monsterEntry as Record<string, unknown>).isDeprecated,
+    true,
+    "monsterapi must be marked isDeprecated"
+  );
+  assert.ok(
+    typeof (monsterEntry as Record<string, unknown>).deprecationReason === "string",
+    "monsterapi must specify deprecationReason"
+  );
+});


### PR DESCRIPTION
## Summary
Fixes #8676. Monster API shuttered operations on 2026-06-30.

## Changes
- Updated `INFERENCE_HOSTS` entry for `monsterapi` with `isDeprecated: true` and explanatory `deprecationReason`.
- Added unit test `tests/unit/8676-monsterapi-deprecation.test.ts` verifying the flag and reason.
- Verified snapshot golden tests pass cleanly.