### PR TITLE
fix(quality): register the #8494 covering test in stryker tap.testFiles

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -49,6 +49,7 @@
       "tests/unit/8332-combo-vision-fallback.test.ts",
       "tests/unit/8376-econnrefused-breaker.test.ts",
       "tests/unit/8396-cooldown-429-cap.test.ts",
+      "tests/unit/8488-capability-filter-fail-closed.test.ts",
       "tests/unit/account-fallback-anthropic-quota.test.ts",
       "tests/unit/account-fallback-lockout-eviction.test.ts",
       "tests/unit/account-fallback-retry-after-json.test.ts",


### PR DESCRIPTION
## Problem

`release/v3.8.49` currently fails its own `check:mutation-test-coverage --strict`
gate, so the **Fast Quality Gates** job is red on every PR cut from it:

```
open-sse/services/combo/comboStructure.ts
  + tests/unit/8488-capability-filter-fail-closed.test.ts

✗ 1 covering unit test(s) across 1 module(s) are missing from stryker.conf.json tap.testFiles.
```

`tests/unit/8488-capability-filter-fail-closed.test.ts` landed with #8494
("fail closed when capability filters empty the combo pool") and covers
`open-sse/services/combo/comboStructure.ts`, one of the instrumented modules,
but was never registered in `tap.testFiles`.

## Fix

One line: add the test file to `stryker.conf.json` → `tap.testFiles`
(alphabetical position, matching the rest of the list).

## Verification

```
$ node scripts/check/check-mutation-test-coverage.mjs --strict
Scanned 3374 unit test file(s) against 31 mutated module(s).
✓ No drift — every covering unit test is listed in tap.testFiles.
```

Config-only change: no production code, no test behavior change. Side effect is
the intended one — that test's mutant kills now count toward the module's
mutation score in the nightly run.

Note: this is a different base-red condition from #8686 (which refreshes the
file-size / complexity / quality baselines). Both are needed to get the base green.