### PR TITLE
[v3.8.50] fix(github): honor per-model targetFormat override for Copilot custom models

### DIFF
--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -59,8 +59,24 @@ export class GithubExecutor extends BaseExecutor {
     return !(m.includes("gemini") || m.includes("claude"));
   }
 
-  buildUrl(model: string, _stream: boolean, _urlIndex = 0) {
-    const targetFormat = getModelTargetFormat("gh", model);
+  buildUrl(
+    model: string,
+    _stream: boolean,
+    _urlIndex = 0,
+    credentials?: ProviderCredentials | null
+  ) {
+    // #2905/#7364-pattern: a custom Copilot model's per-model targetFormat
+    // override isn't in the static PROVIDER_MODELS registry, so
+    // getModelTargetFormat() can't see it. chatCore/executionCredentials.ts
+    // threads the resolved override onto providerSpecificData.targetFormat
+    // for exactly this case — prefer it when present.
+    const overrideTargetFormat = (
+      credentials as { providerSpecificData?: { targetFormat?: unknown } }
+    )?.providerSpecificData?.targetFormat;
+    const targetFormat =
+      typeof overrideTargetFormat === "string"
+        ? overrideTargetFormat
+        : getModelTargetFormat("gh", model);
     // Claude models: route to Copilot's Anthropic-native /v1/messages shim — the
     // only Copilot endpoint that surfaces prompt-cache token counts for Claude and
     // avoids a lossy round-trip of tool_use/tool_result/thinking content blocks

--- a/open-sse/handlers/chatCore/executionCredentials.ts
+++ b/open-sse/handlers/chatCore/executionCredentials.ts
@@ -150,8 +150,18 @@ export function resolveExecutionCredentials(opts: {
     providerSpecificData.targetFormat = targetFormat;
   }
 
-  applyKimiExecutionMetadata(providerSpecificData, provider, targetFormat, modelInfo);
+  // GitHub Copilot custom models (custom-model dropdown, #2905) can carry a
+  // per-model targetFormat override resolving to "openai-responses" so a
+  // Codex-family custom model routes through Copilot's native /responses
+  // endpoint. GithubExecutor.buildUrl() only consults the static
+  // PROVIDER_MODELS registry via getModelTargetFormat() and has no other way
+  // to see a custom model's override — mirrors the zai/glm-coding-apikey fix
+  // (#7364) for the same class of bug.
+  if (targetFormat === FORMATS.OPENAI_RESPONSES && provider === "github") {
+    providerSpecificData.targetFormat = targetFormat;
+  }
 
+  applyKimiExecutionMetadata(providerSpecificData, provider, targetFormat, modelInfo);
   const withApiType = {
     ...nextCredentials,
     providerSpecificData,

--- a/tests/unit/github-copilot-custom-model-target-format.test.ts
+++ b/tests/unit/github-copilot-custom-model-target-format.test.ts
@@ -1,0 +1,86 @@
+// tests/unit/github-copilot-custom-model-target-format.test.ts
+// GitHub Copilot custom models (custom-model dropdown, #2905) can carry a
+// per-model targetFormat override resolving to "openai-responses" — e.g. a
+// Codex-family custom model (gpt-5.6-terra/gpt-5.6-luna) that the operator
+// wants routed through Copilot's native /responses endpoint instead of
+// /chat/completions. GithubExecutor.buildUrl() only reads the static
+// PROVIDER_MODELS registry via getModelTargetFormat("gh", model) and has no
+// other way to see a custom model's override, so every custom Copilot model
+// silently hit /chat/completions regardless of the dashboard's Target Format
+// setting and got rejected upstream with "not accessible via the
+// /chat/completions endpoint". Mirrors the zai/glm-coding-apikey fix (#7364)
+// for the same class of bug.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GithubExecutor } from "../../open-sse/executors/github.ts";
+import { resolveExecutionCredentials } from "../../open-sse/handlers/chatCore/executionCredentials.ts";
+
+test("BUG: GithubExecutor.buildUrl ignores a per-model targetFormat:'openai-responses' override and still returns the chat/completions URL", () => {
+  const executor = new GithubExecutor();
+  const credentialsWithoutOverride = { apiKey: "test-token" };
+  const url = executor.buildUrl("gpt-5.6-terra", false, 0, credentialsWithoutOverride);
+  assert.ok(
+    !url.endsWith("/responses"),
+    "sanity check: with no override and a non-codex custom model id, buildUrl falls back to chat/completions"
+  );
+});
+
+test("FIX: GithubExecutor.buildUrl honors providerSpecificData.targetFormat:'openai-responses' for a custom model", () => {
+  const executor = new GithubExecutor();
+  const credentialsWithOverride = {
+    apiKey: "test-token",
+    providerSpecificData: { targetFormat: "openai-responses" },
+  };
+  const url = executor.buildUrl("gpt-5.6-terra", false, 0, credentialsWithOverride);
+  assert.ok(
+    url.endsWith("/responses"),
+    `expected the /responses endpoint when the override is set, got: ${url}`
+  );
+});
+
+test("FIX: a Gemini/Claude custom model is never routed to /responses even with the override set (supportsResponsesEndpoint gate)", () => {
+  const executor = new GithubExecutor();
+  const credentialsWithOverride = {
+    apiKey: "test-token",
+    providerSpecificData: { targetFormat: "openai-responses" },
+  };
+  const url = executor.buildUrl("gemini-2.5-pro", false, 0, credentialsWithOverride);
+  assert.ok(
+    !url.endsWith("/responses"),
+    "9router#1536 invariant: Gemini/Claude models must never route to /responses, even with a targetFormat override"
+  );
+});
+
+const base = {
+  credentials: { providerSpecificData: { foo: "bar" } } as Record<string, unknown>,
+  nativeCodexPassthrough: false,
+  endpointPath: "/v1/messages",
+  ccSessionId: null,
+};
+
+test("github + resolved openai-responses targetFormat threads providerSpecificData.targetFormat", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "github",
+    targetFormat: "openai-responses",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar", targetFormat: "openai-responses" });
+});
+
+test("github + default (non-responses) targetFormat does NOT inject a targetFormat override", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "github",
+    targetFormat: "openai",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar" });
+});
+
+test("unrelated provider (openai) with targetFormat=openai-responses is untouched by the github branch", () => {
+  const out = resolveExecutionCredentials({
+    ...base,
+    provider: "openai",
+    targetFormat: "openai-responses",
+  }) as Record<string, unknown>;
+  assert.deepEqual(out.providerSpecificData, { foo: "bar" });
+});


### PR DESCRIPTION
## Problem

A custom GitHub Copilot model (added via the custom-model dropdown, #2905) with its
"Target Format" set to "OpenAI Responses API" still gets rejected with:

```
[400]: model "gpt-5.6-terra" is not accessible via the /chat/completions endpoint
```

This happens even when the client calls `/v1/responses` directly instead of
`/v1/chat/completions` — proving OmniRoute ignores both the client's chosen endpoint and the
custom model's own saved configuration.

## Root cause

`chatCore.ts` correctly resolves the per-request `targetFormat`, including a custom model's
override, via `resolveChatCoreTargetFormat()`. But that resolved value was never threaded past
`chatCore` into the executor's own URL-building decision.

`GithubExecutor.buildUrl()` (`open-sse/executors/github.ts`) independently recomputes the target
format via `getModelTargetFormat("gh", model)`, which only reads the static `PROVIDER_MODELS`
registry. Custom models aren't in that registry at all, so for a custom model the lookup returns
`null`, `buildUrl()` falls through to the default `/chat/completions` base URL, and the dashboard's
"Target Format" setting has no effect on real routing.

This is the exact same class of bug already fixed for `zai`/`glm-coding-apikey` in #7364
(`265d00c0e`): a per-model `targetFormat` override invisible to a provider-specific `buildUrl()`
branch that only consults the static registry.

## Solution

Mirrors the #7364 fix:

- `open-sse/handlers/chatCore/executionCredentials.ts`: when the resolved `targetFormat` is
  `openai-responses` and `provider === "github"`, surface it onto
  `providerSpecificData.targetFormat` so the executor can see it.
- `open-sse/executors/github.ts`: `buildUrl()` now accepts `credentials` and prefers
  `providerSpecificData.targetFormat` over the static registry lookup when present, still gated by
  the existing `supportsResponsesEndpoint()` check so Gemini/Claude custom models are never routed
  to `/responses` (preserves the 9router#1536 invariant).

## Tests

New: `tests/unit/github-copilot-custom-model-target-format.test.ts` (6 tests) — covers the bug
reproduction, the fix, the Gemini/Claude non-regression gate, and the `resolveExecutionCredentials`
wiring (including the negative case for unrelated providers/target formats).

All green, plus all pre-existing `github`/executor test suites (95 tests) unaffected:

```
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts \
  --test tests/unit/github-copilot-custom-model-target-format.test.ts \
         tests/unit/t27-github-copilot-response-format.test.ts \
         tests/unit/executor-github.test.ts \
         tests/unit/github-claude-reasoning-effort-granular.test.ts \
         tests/unit/github-copilot-gpt-4o-mini.test.ts \
         tests/unit/provider-registry-github-copilot-gpt-4o.test.ts \
         tests/unit/executor-default-base.test.ts \
         tests/unit/chatcore-executor-proxy.test.ts
# 101 pass, 0 fail
```

`npm run typecheck:core` clean.

## Production

Deployed and live-verified on production: `gh/gpt-5.6-terra` (a real custom model configured with
`targetFormat: openai-responses`) now returns a real completion via `/v1/chat/completions` instead
of the 400.

## Risk

Low. The change only takes effect when `providerSpecificData.targetFormat` is explicitly set to
`"openai-responses"` by `executionCredentials.ts` (i.e. only for GitHub Copilot custom models with
that override configured) — the default path for every existing static-registry model is
byte-identical, and the Gemini/Claude gate is unchanged.
