### PR TITLE
[v3.8.50] fix(combo): fallback to t.provider in comboTargetLimits & add null guard in getTokenLimit (fixes #8708, fixes #8716)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1706,7 +1706,7 @@ export async function handleChatCore({
           );
           comboTargetLimits = targets.map((t: { modelStr?: string; provider?: string }) => {
             const parsed = parseModel(t.modelStr);
-            const provider = t.provider || parsed.provider || parsed.providerAlias;
+            const provider = t.provider || parsed.provider || parsed.providerAlias || "unknown";
             return getTokenLimit(provider, parsed.model);
           });
         }

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1704,9 +1704,10 @@ export async function handleChatCore({
             comboConfig as unknown as { name: string; models: unknown[] },
             allCombosData as unknown as { name: string; models: unknown[] }[]
           );
-          comboTargetLimits = targets.map((t: { modelStr?: string }) => {
+          comboTargetLimits = targets.map((t: { modelStr?: string; provider?: string }) => {
             const parsed = parseModel(t.modelStr);
-            return getTokenLimit(parsed.provider, parsed.model);
+            const provider = t.provider || parsed.provider || parsed.providerAlias;
+            return getTokenLimit(provider, parsed.model);
           });
         }
         // chatCore executes per concrete target (handleSingleModel resolves

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -23,7 +23,8 @@ const DEFAULT_LIMITS: Record<string, number> = {
 };
 
 // Environment variable overrides (highest priority)
-function getEnvOverride(provider: string): number | null {
+function getEnvOverride(provider: string | null | undefined): number | null {
+  if (!provider) return null;
   const envKey = `CONTEXT_LENGTH_${provider.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
   const envValue = process.env[envKey];
   if (envValue) {
@@ -191,7 +192,10 @@ export function estimateTokens(text: string | object | null | undefined): number
  * Get token limit for a provider/model combination
  * Priority: Env override > models.dev DB > Registry defaultContextLength > DEFAULT_LIMITS
  */
-export function getTokenLimit(provider: string, model: string | null = null): number {
+export function getTokenLimit(
+  provider: string | null | undefined,
+  model: string | null = null
+): number {
   return resolveTokenLimit(provider, model).limit;
 }
 
@@ -202,23 +206,24 @@ export function getTokenLimit(provider: string, model: string | null = null): nu
  * catch-all default.
  */
 function resolveTokenLimit(
-  provider: string,
+  provider: string | null | undefined,
   model: string | null = null
 ): { limit: number; specific: boolean } {
+  const safeProvider = provider || "unknown";
   // 1. Check environment variable override first
-  const envOverride = getEnvOverride(provider);
+  const envOverride = getEnvOverride(safeProvider);
   if (envOverride) return { limit: envOverride, specific: true };
 
   const lowerModel = (model || "").toLowerCase();
 
   // 2. Check models.dev synced DB for per-model context limit
   if (model) {
-    const dbLimit = getModelContextLimit(provider, model);
+    const dbLimit = getModelContextLimit(safeProvider, model);
     if (dbLimit && dbLimit > 0) return { limit: dbLimit, specific: true };
   }
 
   // 3. Check registry for provider default
-  const registryEntry = REGISTRY[provider];
+  const registryEntry = REGISTRY[safeProvider];
   if (registryEntry?.defaultContextLength) {
     return { limit: registryEntry.defaultContextLength, specific: true };
   }
@@ -238,7 +243,7 @@ function resolveTokenLimit(
   }
 
   // 5. Fallback to DEFAULT_LIMITS or default
-  if (DEFAULT_LIMITS[provider]) return { limit: DEFAULT_LIMITS[provider], specific: true };
+  if (DEFAULT_LIMITS[safeProvider]) return { limit: DEFAULT_LIMITS[safeProvider], specific: true };
   return { limit: DEFAULT_LIMITS.default, specific: false };
 }
 

--- a/tests/unit/combo-target-limits-provider.test.ts
+++ b/tests/unit/combo-target-limits-provider.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveComboTargets } from "../../open-sse/services/combo/comboStructure.ts";
+import { getTokenLimit } from "../../open-sse/services/contextManager.ts";
+import { parseModel } from "../../open-sse/services/model.ts";
+
+test("comboTargetLimits resolution respects t.provider override", () => {
+  const comboConfig = {
+    name: "test-combo",
+    models: [
+      { model: "openai/gpt-4o", providerId: "custom-provider-id" },
+      { model: "anthropic/claude-3-5-sonnet" },
+    ],
+  };
+  const targets = resolveComboTargets(comboConfig, null);
+
+  const comboTargetLimits = targets.map((t: { modelStr?: string; provider?: string }) => {
+    const parsed = parseModel(t.modelStr);
+    const provider = t.provider || parsed.provider || parsed.providerAlias;
+    return getTokenLimit(provider, parsed.model);
+  });
+
+  assert.equal(targets.length, 2);
+  assert.equal(targets[0].provider, "custom-provider-id");
+  assert.equal(typeof comboTargetLimits[0], "number");
+  assert.equal(comboTargetLimits[1], 200000);
+});


### PR DESCRIPTION
## Summary
Fixes #8708 and #8716.

## Root Cause & Solution
1. **Target Provider Resolution (#8708)**:
   In `open-sse/handlers/chatCore.ts`, when mapping `targets` to compute `comboTargetLimits`, the code called `parseModel(t.modelStr)` and used `parsed.provider`. Resolved combo targets explicitly set `t.provider` (e.g. from `providerId`). Skipping `t.provider` caused custom target providers to fall back to `parsed.providerAlias` or default limits.
   **Fix**: Update fallback chain to `t.provider || parsed.provider || parsed.providerAlias || "unknown"`.

2. **Null/Undefined Provider Guard (#8716)**:
   In `open-sse/services/contextManager.ts`, `getTokenLimit` and internal helper `getEnvOverride` assumed `provider` was non-null string, which could throw type errors when passed `null` or `undefined` target providers.
   **Fix**: Accept `string | null | undefined` in `getTokenLimit`, sanitize to `safeProvider = provider || "unknown"`, and guard `getEnvOverride` against falsy values.

## Verification
- Added unit test `tests/unit/combo-target-limits-provider.test.ts` verifying `t.provider` override is preserved when calculating target token limits.
- Validated core typecheck with `npx tsc --pretty false -p tsconfig.typecheck-core.json` (0 errors).