### PR TITLE
fix(sse): fall back to target provider for combo compression limits (#8716)

### DIFF
--- a/changelog.d/fixes/8716-combo-compression-null-provider.md
+++ b/changelog.d/fixes/8716-combo-compression-null-provider.md
@@ -1,0 +1,1 @@
+- **fix(sse):** combo compression-limit resolution falls back to `ResolvedComboTarget.provider` when `modelStr` lacks a `provider/` prefix, so `getTokenLimit` no longer crashes with `null.toUpperCase()` (#8716) — thanks @DinonowDev

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -315,6 +315,7 @@ import {
   compressContext,
   estimateTokens,
   getTokenLimit,
+  getComboTargetTokenLimit,
   resolveComboContextLimit,
 } from "../services/contextManager.ts";
 import { resolveBackgroundTaskRedirect } from "./chatCore/backgroundRedirect.ts";
@@ -1691,7 +1692,6 @@ export async function handleChatCore({
       log?.info?.("CONTEXT", `Attempting to resolve combo limits for comboName=${comboName}`);
       try {
         const { getComboByName } = await import("../../src/lib/localDb");
-        const { parseModel } = await import("../services/model.ts");
         const { resolveComboTargets } = await import("../services/combo.ts");
         let comboConfig = await getComboByName(comboName);
         if (!comboConfig && comboName.startsWith("combo/")) {
@@ -1704,10 +1704,14 @@ export async function handleChatCore({
             comboConfig as unknown as { name: string; models: unknown[] },
             allCombosData as unknown as { name: string; models: unknown[] }[]
           );
-          comboTargetLimits = targets.map((t: { modelStr?: string }) => {
-            const parsed = parseModel(t.modelStr);
-            return getTokenLimit(parsed.provider, parsed.model);
-          });
+          comboTargetLimits = targets.map((t: { modelStr?: string; provider?: string }) =>
+            // Fall back to ResolvedComboTarget.provider when modelStr lacks a
+            // provider/ prefix — parseModel alone returns provider:null (#8716).
+            getComboTargetTokenLimit({
+              modelStr: t.modelStr,
+              provider: t.provider,
+            })
+          );
         }
         // chatCore executes per concrete target (handleSingleModel resolves
         // provider/effectiveModel before delegating). Compress against THIS

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -7,6 +7,7 @@
 
 import { REGISTRY } from "../config/providerRegistry.ts";
 import { getModelContextLimit } from "../../src/lib/modelCapabilities.ts";
+import { parseModel } from "./model.ts";
 import { jsonLength } from "../utils/jsonSize.ts";
 
 // Default token limits per provider (fallbacks when not in registry)
@@ -193,6 +194,34 @@ export function estimateTokens(text: string | object | null | undefined): number
  */
 export function getTokenLimit(provider: string, model: string | null = null): number {
   return resolveTokenLimit(provider, model).limit;
+}
+
+/**
+ * Resolve a combo target's token limit without crashing when `parseModel(modelStr)`
+ * returns `provider: null` (model id with no `provider/` prefix).
+ *
+ * `ResolvedComboTarget.provider` is populated independently of `modelStr`, so fall
+ * back to it before calling `getTokenLimit` (#8716).
+ */
+export function getComboTargetTokenLimit(options: {
+  modelStr?: string | null;
+  provider?: string | null;
+  parsedProvider?: string | null;
+  parsedModel?: string | null;
+  targetProvider?: string | null;
+}): number {
+  let parsedProvider = options.parsedProvider;
+  let parsedModel = options.parsedModel;
+  if (
+    (parsedProvider === undefined || parsedModel === undefined) &&
+    Object.prototype.hasOwnProperty.call(options, "modelStr")
+  ) {
+    const parsed = parseModel(options.modelStr);
+    if (parsedProvider === undefined) parsedProvider = parsed.provider;
+    if (parsedModel === undefined) parsedModel = parsed.model;
+  }
+  const provider = parsedProvider ?? options.targetProvider ?? options.provider ?? "unknown";
+  return getTokenLimit(provider, parsedModel ?? null);
 }
 
 /**

--- a/tests/unit/combo-target-token-limit-8716.test.ts
+++ b/tests/unit/combo-target-token-limit-8716.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #8716 — combo compression-limit resolution must not crash when a target's
+ * modelStr lacks a provider/ prefix (parseModel returns provider: null).
+ *
+ * Root cause: chatCore mapped targets via getTokenLimit(parsed.provider, …)
+ * and getEnvOverride() does provider.toUpperCase() unconditionally.
+ * ResolvedComboTarget already carries provider independently of modelStr.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { parseModel } = await import("../../open-sse/services/model.ts");
+const { getTokenLimit, getComboTargetTokenLimit } =
+  await import("../../open-sse/services/contextManager.ts");
+
+test("#8716 getTokenLimit(null provider) throws via toUpperCase (documents crash)", () => {
+  assert.throws(
+    () => getTokenLimit(null as unknown as string, "gpt-4o"),
+    (err: unknown) => err instanceof TypeError && String(err.message).includes("toUpperCase")
+  );
+});
+
+test("#8716 parseModel without provider prefix yields null provider", () => {
+  const parsed = parseModel("gpt-4o");
+  assert.equal(parsed.provider, null);
+  assert.equal(parsed.model, "gpt-4o");
+});
+
+test("#8716 getComboTargetTokenLimit falls back to target.provider (no throw)", () => {
+  assert.equal(typeof getComboTargetTokenLimit, "function");
+
+  const parsed = parseModel("gpt-4o");
+  assert.equal(parsed.provider, null);
+
+  const limit = getComboTargetTokenLimit({
+    modelStr: "gpt-4o",
+    provider: "openai",
+  });
+  assert.ok(Number.isFinite(limit) && limit > 0);
+
+  // Same inputs via pre-parsed fields (matches chatCore call shape).
+  const limit2 = getComboTargetTokenLimit({
+    parsedProvider: parsed.provider,
+    parsedModel: parsed.model,
+    targetProvider: "openai",
+  });
+  assert.equal(limit2, limit);
+});
+
+test("#8716 getComboTargetTokenLimit prefers parseModel provider when present", () => {
+  const withPrefix = getComboTargetTokenLimit({
+    modelStr: "anthropic/claude-sonnet-4-6",
+    provider: "openai",
+  });
+  const fromParsedOnly = getComboTargetTokenLimit({
+    parsedProvider: "anthropic",
+    parsedModel: "claude-sonnet-4-6",
+    targetProvider: "openai",
+  });
+  assert.equal(withPrefix, fromParsedOnly);
+});
+
+test("#8716 getComboTargetTokenLimit uses unknown when both providers missing", () => {
+  const limit = getComboTargetTokenLimit({
+    parsedProvider: null,
+    parsedModel: "some-model",
+    targetProvider: null,
+  });
+  assert.ok(Number.isFinite(limit) && limit > 0);
+});
+
+test("#8716 chatCore combo-limit map uses getComboTargetTokenLimit (source guard)", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+  const src = fs.readFileSync(path.join(root, "open-sse/handlers/chatCore.ts"), "utf8");
+  assert.match(
+    src,
+    /getComboTargetTokenLimit\s*\(/,
+    "chatCore must resolve combo target limits via getComboTargetTokenLimit"
+  );
+  assert.doesNotMatch(
+    src,
+    /comboTargetLimits\s*=\s*targets\.map\(\s*\([^)]*\)\s*=>\s*\{\s*const parsed = parseModel\(t\.modelStr\);\s*return getTokenLimit\(parsed\.provider/,
+    "chatCore must not pass parseModel().provider directly into getTokenLimit"
+  );
+});


### PR DESCRIPTION
## Summary
- Fix combo compression-limit resolution crashing with `null.toUpperCase()` when a target `modelStr` lacks a `provider/` prefix.
- Fall back to `ResolvedComboTarget.provider` via new `getComboTargetTokenLimit()` before calling `getTokenLimit`.
- Add unit regression coverage for the crash path and the fallback behavior.

## Related Issues
- Closes #8716

## Validation
- [x] Focused tests: `node --import tsx/esm --test tests/unit/combo-target-token-limit-8716.test.ts` (6 passed)
- [x] Related: `node --import tsx/esm --test tests/unit/auto-combo-context-advertising.test.ts` (8 passed)
- [x] `npm run check:changelog-integrity`
- [x] Production-code changes include a new automated test in this PR

## Tests Added Or Updated
- `tests/unit/combo-target-token-limit-8716.test.ts`

## Coverage Notes
- Covers `open-sse/services/contextManager.ts` (`getComboTargetTokenLimit`) and the `chatCore.ts` combo-limit call site via source guard + behavioral tests.

## Reviewer Notes
- Surgical change: only the combo compression-limit map path; no routing strategy changes.