### PR TITLE
fix: hydration mismatch, duplicate React keys, and missing ponytail i18n

### DIFF
--- a/src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx
+++ b/src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import { APP_CONFIG } from "@/shared/constants/appConfig";
@@ -15,6 +15,9 @@ const KIMI_CODING_AFF_URL = "https://www.kimi.com/code?aff=omniroute";
 // offer/copy ever changes materially enough to warrant re-showing it to
 // users who already dismissed the previous version.
 const DISMISS_STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v1";
+// Same-tab signal for the dismiss button, since writing localStorage doesn't
+// fire a "storage" event in the tab that wrote it.
+const DISMISS_EVENT = "omniroute:kimi-sponsor-banner-dismissed";
 
 function isNotDismissed(): boolean {
   try {
@@ -24,18 +27,31 @@ function isNotDismissed(): boolean {
   }
 }
 
+function subscribe(callback: () => void) {
+  window.addEventListener(DISMISS_EVENT, callback);
+  return () => window.removeEventListener(DISMISS_EVENT, callback);
+}
+
+// SSR has no localStorage, so the server always renders the banner visible;
+// useSyncExternalStore reconciles that against the real client-side value
+// right after hydration (mirroring useTheme's systemPrefersDark pattern),
+// with no hydration mismatch and no setState-in-effect.
+function getServerSnapshot() {
+  return true;
+}
+
 /**
  * Dismissable banner announcing the Kimi (Moonshot AI) official OmniRoute
  * partnership on the dashboard home page. Self-contained: reads the app's own
  * version (APP_CONFIG.version) to decide whether it is still inside the
  * agreed display window (see kimiSponsorBannerGate.ts) and persists dismissal via
- * localStorage, mirroring RiskNoticeBanner's lazy-useState pattern. The
- * logomark reuses <ProviderIcon providerId="moonshot" .../> so it stays
- * theme-aware for free via the THEMED_SVGS wiring in ProviderIcon.tsx.
+ * localStorage. The logomark reuses <ProviderIcon providerId="moonshot" .../>
+ * so it stays theme-aware for free via the THEMED_SVGS wiring in
+ * ProviderIcon.tsx.
  */
 export default function KimiSponsorBanner() {
   const t = useTranslations("kimiSponsorBanner");
-  const [visible, setVisible] = useState<boolean>(isNotDismissed);
+  const visible = useSyncExternalStore(subscribe, isNotDismissed, getServerSnapshot);
 
   if (!visible || !shouldShowKimiSponsorBanner(APP_CONFIG.version)) {
     return null;
@@ -47,7 +63,7 @@ export default function KimiSponsorBanner() {
     } catch {
       // ignore — worst case the banner reappears next visit
     }
-    setVisible(false);
+    window.dispatchEvent(new Event(DISMISS_EVENT));
   };
 
   return (

--- a/src/app/(dashboard)/dashboard/tools/agent-bridge/components/RiskNoticeBanner.tsx
+++ b/src/app/(dashboard)/dashboard/tools/agent-bridge/components/RiskNoticeBanner.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
 
 const STORAGE_KEY = "omniroute-agentbridge-risk-dismissed";
+// Same-tab signal for the dismiss button, since writing localStorage doesn't
+// fire a "storage" event in the tab that wrote it.
+const DISMISS_EVENT = "omniroute:agentbridge-risk-dismissed";
 
 function isNotDismissed(): boolean {
   try {
@@ -13,14 +16,25 @@ function isNotDismissed(): boolean {
   }
 }
 
+function subscribe(callback: () => void) {
+  window.addEventListener(DISMISS_EVENT, callback);
+  return () => window.removeEventListener(DISMISS_EVENT, callback);
+}
+
+// SSR has no localStorage, so the server always renders the banner visible;
+// useSyncExternalStore reconciles that against the real client-side value
+// right after hydration, with no hydration mismatch and no setState-in-effect.
+function getServerSnapshot() {
+  return true;
+}
+
 /**
  * Amber dismissable banner shown at the top of the AgentBridge page.
  * Persisted via localStorage so it only shows once per user.
- * Uses lazy useState initializer to read localStorage without useEffect.
  */
 export function RiskNoticeBanner() {
   const t = useTranslations("agentBridge");
-  const [visible, setVisible] = useState<boolean>(isNotDismissed);
+  const visible = useSyncExternalStore(subscribe, isNotDismissed, getServerSnapshot);
 
   const dismiss = () => {
     try {
@@ -28,7 +42,7 @@ export function RiskNoticeBanner() {
     } catch {
       // ignore
     }
-    setVisible(false);
+    window.dispatchEvent(new Event(DISMISS_EVENT));
   };
 
   if (!visible) return null;

--- a/src/app/api/usage/analytics/route.ts
+++ b/src/app/api/usage/analytics/route.ts
@@ -590,7 +590,10 @@ export async function GET(request: Request) {
         normalizeModelName,
         computeCostFromPricing
       );
-      const key = `${provider}::${short}`;
+      // Keyed by model name alone (not provider) — the table renders one row per
+      // model, so the same model served via multiple provider connections/accounts
+      // must be merged here rather than producing duplicate `key={m.model}` rows.
+      const key = short;
       const existing = modelMap.get(key) || {
         model: short,
         provider,

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -7271,6 +7271,10 @@
         "label": "كود أقل",
         "description": "سلم YAGNI: أصغر تغيير فعال، بدون تجريدات غير مطلوبة."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK مقتضب (文言)",
         "description": "أسلوب صيني كلاسيكي فائق الاقتضاب (متاح للغة الصينية فقط)."

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -7271,6 +7271,10 @@
         "label": "Daha az kod",
         "description": "YAGNI pilləkəni: ən kiçik işlək dəyişiklik, tələb olunmayan mücərrədliklər olmadan."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Yığcam CJK (文言)",
         "description": "Klassik Çin ultra-yığcam üslubu (yalnız Çin dili üçün əlçatandır)."

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -7271,6 +7271,10 @@
         "label": "По-малко код",
         "description": "YAGNI стълбица: най-малката работеща промяна, без непоискани абстракции."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Сбит CJK (文言)",
         "description": "Класически китайски ултра-сбит стил (наличен само за китайски)."

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -7271,6 +7271,10 @@
         "label": "কম কোড",
         "description": "YAGNI ল্যাডার: ক্ষুদ্রতম কার্যকরী পরিবর্তন, কোনো অনুরোধহীন অ্যাবস্ট্রাকশন নয়।"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "সংক্ষিপ্ত CJK (文言)",
         "description": "ক্লাসিক্যাল-চাইনিজ অতি-সংক্ষিপ্ত শৈলী (শুধুমাত্র চাইনিজ ভাষার জন্য উপলব্ধ)।"

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -7271,6 +7271,10 @@
         "label": "Méně kódu",
         "description": "Žebříček YAGNI: nejmenší funkční změna, žádné nevyžádané abstrakce."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Stručné CJK (文言)",
         "description": "Klasický čínský ultra stručný styl (k dispozici pouze pro čínštinu)."

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -7271,6 +7271,10 @@
         "label": "Mindre kode",
         "description": "YAGNI-stige: mindste fungerende ændring, ingen uanmodede abstraktioner."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Kortfattet CJK (文言)",
         "description": "Klassisk kinesisk ultra-kortfattet stil (kun tilgængelig for kinesisk)."

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -7271,6 +7271,10 @@
         "label": "Weniger Code",
         "description": "YAGNI-Leiter: kleinste funktionierende Änderung, keine ungefragten Abstraktionen."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Knappe CJK (文言)",
         "description": "Klassisch-chinesischer, extrem knapper Stil (nur für Chinesisch verfügbar)."

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -7271,6 +7271,10 @@
         "label": "Less code",
         "description": "YAGNI ladder: smallest working change, no unrequested abstractions."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Terse CJK (文言)",
         "description": "Classical-Chinese ultra-terse style (available only for Chinese)."

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -7271,6 +7271,10 @@
         "label": "Less code",
         "description": "YAGNI ladder: smallest working change, no unrequested abstractions."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Terse CJK (文言)",
         "description": "Classical-Chinese ultra-terse style (available only for Chinese)."

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -7271,6 +7271,10 @@
         "label": "کد کمتر",
         "description": "نردبان YAGNI: کوچک‌ترین تغییر کارآمد، بدون انتزاع‌های ناخواسته."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK موجز (文言)",
         "description": "سبک فوق‌موجز چینی کلاسیک (فقط برای زبان چینی در دسترس است)."

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -7271,6 +7271,10 @@
         "label": "Vähemmän koodia",
         "description": "YAGNI-portaat: pienin toimiva muutos, ei pyytämättömiä abstraktioita."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Tiivis CJK (文言)",
         "description": "Klassisen kiinan ultra-tiivis tyyli (saatavilla vain kiinaksi)."

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -7271,6 +7271,10 @@
         "label": "Moins de code",
         "description": "Échelle YAGNI : le plus petit changement fonctionnel, pas d'abstractions non demandées."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK concis (文言)",
         "description": "Style ultra-concis en chinois classique (disponible uniquement pour le chinois)."

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -7271,6 +7271,10 @@
         "label": "ઓછો કોડ",
         "description": "YAGNI લેડર: સૌથી નાનો કાર્યકારી ફેરફાર, કોઈ વિનંતી ન કરેલ એબ્સ્ટ્રેક્શન્સ નહીં."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "સંક્ષિપ્ત CJK (文言)",
         "description": "ક્લાસિકલ-ચાઇનીઝ અલ્ટ્રા-સંક્ષિપ્ત શૈલી (ફક્ત ચાઇનીઝ માટે ઉપલબ્ધ)."

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -7271,6 +7271,10 @@
         "label": "פחות קוד",
         "description": "סולם YAGNI: השינוי העובד הקטן ביותר, ללא הפשטות שלא נדרשו."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK תמציתי (文言)",
         "description": "סגנון סיני קלאסי אולטרה-תמציתי (זמין עבור סינית בלבד)."

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -7271,6 +7271,10 @@
         "label": "कम कोड",
         "description": "YAGNI लैडर: सबसे छोटा काम करने वाला बदलाव, कोई अवांछित एब्स्ट्रैक्शन नहीं।"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "संक्षिप्त CJK (文言)",
         "description": "शास्त्रीय-चीनी अति-संक्षिप्त शैली (केवल चीनी भाषा के लिए उपलब्ध)।"

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -7271,6 +7271,10 @@
         "label": "Kevesebb kód",
         "description": "YAGNI-létra: a legkisebb működő változtatás, nem kért absztrakciók nélkül."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Tömör CJK (文言)",
         "description": "Klasszikus kínai ultratömör stílus (csak kínai nyelven érhető el)."

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -7271,6 +7271,10 @@
         "label": "Lebih sedikit kode",
         "description": "Tangga YAGNI: perubahan kerja terkecil, tanpa abstraksi yang tidak diminta."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK Ringkas (文言)",
         "description": "Gaya ultra-ringkas Tionghoa Klasik (hanya tersedia untuk bahasa Tionghoa)."

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -7271,6 +7271,10 @@
         "label": "Lebih sedikit kode",
         "description": "Tangga YAGNI: perubahan kerja terkecil, tanpa abstraksi yang tidak diminta."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK Ringkas (文言)",
         "description": "Gaya ultra-ringkas Tionghoa Klasik (hanya tersedia untuk bahasa Tionghoa)."

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -7271,6 +7271,10 @@
         "label": "Meno codice",
         "description": "Scala YAGNI: la più piccola modifica funzionante, nessuna astrazione non richiesta."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK conciso (文言)",
         "description": "Stile ultra-conciso in cinese classico (disponibile solo per il cinese)."

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -7271,6 +7271,10 @@
         "label": "コード削減",
         "description": "YAGNIラダー: 動作する最小限の変更、要求されていない抽象化の排除。"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "簡潔なCJK (文言)",
         "description": "漢文の超簡潔スタイル (中国語でのみ利用可能)。"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -7271,6 +7271,10 @@
         "label": "코드 최소화",
         "description": "YAGNI 사다리: 작동하는 최소한의 변경, 요청되지 않은 추상화 배제."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "간결한 CJK (文言)",
         "description": "한문 초간결 스타일 (중국어만 지원)."

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -7271,6 +7271,10 @@
         "label": "कमी कोड",
         "description": "YAGNI शिडी: सर्वात लहान कार्यरत बदल, कोणतीही न मागितलेली ॲब्स्ट्रॅक्शन्स नाहीत."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "संक्षिप्त CJK (文言)",
         "description": "अभिजात-चिनी अति-संक्षिप्त शैली (केवळ चिनी भाषेसाठी उपलब्ध)."

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -7271,6 +7271,10 @@
         "label": "Kurang kod",
         "description": "Tangga YAGNI: perubahan berfungsi terkecil, tiada abstraksi yang tidak diminta."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK Ringkas (文言)",
         "description": "Gaya ultra-ringkas Bahasa Cina Klasik (hanya tersedia untuk bahasa Cina)."

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -7271,6 +7271,10 @@
         "label": "Minder code",
         "description": "YAGNI-ladder: kleinste werkende wijziging, geen ongevraagde abstracties."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Beknopt CJK (文言)",
         "description": "Klassiek-Chinese ultra-beknopte stijl (alleen beschikbaar voor Chinees)."

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -7271,6 +7271,10 @@
         "label": "Mindre kode",
         "description": "YAGNI-stige: minste fungerende endring, ingen ubedte abstraksjoner."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Kortfattet CJK (文言)",
         "description": "Klassisk-kinesisk ultrakortfattet stil (kun tilgjengelig for kinesisk)."

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -7271,6 +7271,10 @@
         "label": "Mas kaunting code",
         "description": "YAGNI ladder: pinakamaliit na gumaganang pagbabago, walang hindi hiniling na mga abstraction."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Maikling CJK (文言)",
         "description": "Klasikong Tsino na ultra-maikling estilo (magagamit lamang para sa Tsino)."

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -7271,6 +7271,10 @@
         "label": "Mniej kodu",
         "description": "Drabina YAGNI: najmniejsza działająca zmiana, brak nieproszonych abstrakcji."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Zwięzłe CJK (文言)",
         "description": "Klasyczny chiński styl ultra-zwięzły (dostępny tylko dla języka chińskiego)."

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -7271,6 +7271,10 @@
         "label": "Menos código",
         "description": "Escada YAGNI: menor alteração funcional, sem abstrações não solicitadas."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK conciso (文言)",
         "description": "Estilo ultraconciso em chinês clássico (disponível apenas para chinês)."

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -7271,6 +7271,10 @@
         "label": "Menos código",
         "description": "Escada YAGNI: a menor alteração funcional, sem abstrações não solicitadas."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK conciso (文言)",
         "description": "Estilo ultraconciso em chinês clássico (disponível apenas para chinês)."

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -7271,6 +7271,10 @@
         "label": "Mai puțin cod",
         "description": "Scara YAGNI: cea mai mică modificare funcțională, fără abstracții nesolicitate."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK concis (文言)",
         "description": "Stil ultra-concis în chineza clasică (disponibil doar pentru chineză)."

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -7271,6 +7271,10 @@
         "label": "Меньше кода",
         "description": "Лестница YAGNI: минимальное рабочее изменение, никаких незапрошенных абстракций."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Краткий CJK (文言)",
         "description": "Ультракраткий классический китайский стиль (доступно только для китайского языка)."

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -7271,6 +7271,10 @@
         "label": "Menej kódu",
         "description": "Rebríček YAGNI: najmenšia funkčná zmena, žiadne nevyžiadané abstrakcie."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Stručné CJK (文言)",
         "description": "Klasický čínsky ultra stručný štýl (dostupný len pre čínštinu)."

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -7271,6 +7271,10 @@
         "label": "Mindre kod",
         "description": "YAGNI-stege: minsta fungerande ändring, inga oombedda abstraktioner."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Kortfattad CJK (文言)",
         "description": "Klassisk kinesisk ultrakortfattad stil (endast tillgänglig för kinesiska)."

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -7271,6 +7271,10 @@
         "label": "Msimbo mchache",
         "description": "Ngazi ya YAGNI: mabadiliko madogo zaidi yanayofanya kazi, bila dhahania zisizoombwa."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK Fupi (文言)",
         "description": "Mtindo mfupi zaidi wa Kichina cha Kale (inapatikana kwa Kichina pekee)."

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -7271,6 +7271,10 @@
         "label": "குறைந்த குறியீடு",
         "description": "YAGNI ஏணி: மிகச்சிறிய வேலை செய்யும் மாற்றம், கோரப்படாத சுருக்கங்கள் இல்லை."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "சுருக்கமான CJK (文言)",
         "description": "செம்மொழி-சீன மிகச் சுருக்கமான நடை (சீன மொழிக்கு மட்டுமே கிடைக்கும்)."

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -7271,6 +7271,10 @@
         "label": "తక్కువ కోడ్",
         "description": "YAGNI లాడర్: చిన్న పని మార్పు, అభ్యర్థించని అబ్‌స్ట్రాక్షన్‌లు లేవు."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "సంక్షిప్త CJK (文言)",
         "description": "క్లాసికల్-చైనీస్ అల్ట్రా-సంక్షిప్త శైలి (చైనీస్ కోసం మాత్రమే అందుబాటులో ఉంది)."

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -7271,6 +7271,10 @@
         "label": "โค้ดน้อยลง",
         "description": "บันได YAGNI: การเปลี่ยนแปลงที่เล็กที่สุดที่ใช้งานได้จริง โดยไม่มีการสร้าง Abstraction ที่ไม่ได้ร้องขอ"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK แบบกระชับ (文言)",
         "description": "สไตล์ภาษาจีนคลาสสิกแบบกระชับอย่างยิ่ง (ใช้ได้เฉพาะภาษาจีนเท่านั้น)"

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -7271,6 +7271,10 @@
         "label": "Daha az kod",
         "description": "YAGNI merdiveni: çalışan en küçük değişiklik, talep edilmeyen soyutlamalar yok."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Kısa ve öz CJK (文言)",
         "description": "Klasik Çince ultra kısa ve öz stil (yalnızca Çince için kullanılabilir)."

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -7271,6 +7271,10 @@
         "label": "Менше коду",
         "description": "Драбина YAGNI: найменша робоча зміна, жодних незапитуваних абстракцій."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "Стисла CJK (文言)",
         "description": "Класичний китайський ультрастислий стиль (доступно тільки для китайської)."

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -7271,6 +7271,10 @@
         "label": "کم کوڈ",
         "description": "YAGNI سیڑھی: سب سے چھوٹی کام کرنے والی تبدیلی، کوئی غیر مطلوبہ خلاصہ نہیں۔"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "مختصر CJK (文言)",
         "description": "کلاسیکی چینی انتہائی مختصر انداز (صرف چینی زبان کے لیے دستیاب ہے)۔"

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -7271,6 +7271,10 @@
         "label": "Ít mã hơn",
         "description": "Theo nguyên tắc YAGNI: thay đổi nhỏ nhất có thể chạy được, không thêm lớp trừu tượng ngoài yêu cầu."
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "CJK súc tích (文言)",
         "description": "Văn phong Hán cổ cực kỳ súc tích (chỉ khả dụng với tiếng Trung)."

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -7271,6 +7271,10 @@
         "label": "更少代码",
         "description": "YAGNI 阶梯：最小可行改动，无未要求的抽象。"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "精简 CJK (文言)",
         "description": "文言文极简风格 (仅适用于中文)。"

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -7271,6 +7271,10 @@
         "label": "更少程式碼",
         "description": "YAGNI 階梯：最小可行變更，不建立未要求的抽象層。"
       },
+      "ponytail": {
+        "label": "Ponytail (lazy senior dev)",
+        "description": "Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff."
+      },
       "terse-cjk": {
         "label": "精簡 CJK（文言）",
         "description": "文言文極簡風格（僅適用於中文）。"

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -147,19 +147,26 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
 
   const grouped = useMemo<PaletteGroup[]>(() => {
     const groups: PaletteGroup[] = [];
+    const sectionById = new Map<string, PaletteGroup>();
     filtered.forEach((item, flatIndex) => {
-      let section = groups[groups.length - 1];
-      if (!section || section.sectionId !== item.sectionId) {
+      // Look up the section/subgroup by id across the whole list, not just the
+      // previous item — a section's children can interleave root items and
+      // groups (e.g. "omni-proxy" has a trailing root item after its groups),
+      // which would otherwise produce two separate "_root" subgroups sharing
+      // the same React key.
+      let section = sectionById.get(item.sectionId);
+      if (!section) {
         section = {
           sectionId: item.sectionId,
           sectionLabel: item.sectionLabel,
           subgroups: [],
         };
+        sectionById.set(item.sectionId, section);
         groups.push(section);
       }
       const itemSubgroupId = item.subgroupId ?? null;
-      let subgroup = section.subgroups[section.subgroups.length - 1];
-      if (!subgroup || subgroup.subgroupId !== itemSubgroupId) {
+      let subgroup = section.subgroups.find((sg) => sg.subgroupId === itemSubgroupId);
+      if (!subgroup) {
         subgroup = {
           subgroupId: itemSubgroupId,
           subgroupLabel: item.subgroupLabel ?? null,


### PR DESCRIPTION
## Summary
- `KimiSponsorBanner`/`RiskNoticeBanner`: read the localStorage dismissal flag via `useSyncExternalStore` (server snapshot = visible) instead of a `useState` lazy initializer, so the first client render matches SSR (which has no `localStorage`) instead of diverging on hydration.
- `usage/analytics` route: key the per-model aggregation map by model name alone instead of `${provider}::${model}`, matching the table's one-row-per-model display and eliminating duplicate `key={m.model}` rows when a model is served through multiple provider connections/accounts.
- `CommandPalette`: look up existing section/subgroup by id across the whole list instead of only comparing to the previous item, so sections whose children interleave root items and groups (e.g. `omni-proxy`) don't produce two subgroups sharing the same `"_root"` key.
- Add the missing `compressionOutputStyle.ponytail` label/description to all 43 locale message files (present in the style catalog but never added to any locale, causing a `MISSING_MESSAGE` crash).

## Test plan
- [x] Loaded `/home` and confirmed the Kimi banner hydrates cleanly with no console error
- [x] Loaded `/dashboard/analytics` and confirmed no duplicate-key warning in the model table
- [x] Opened the command palette (⌘K) and confirmed the OmniProxy section renders without a duplicate-key warning
- [x] Loaded `/dashboard/context/settings` and confirmed the "Ponytail (lazy senior dev)" output style renders its label/description with no `MISSING_MESSAGE` error
- [x] `lint-staged` (prettier + eslint) passes on all changed files