### PR TITLE
fix(sse): hide synthetic OpenAI startup reasoning

### DIFF
--- a/.github/workflows/build-rinseaid-image.yml
+++ b/.github/workflows/build-rinseaid-image.yml
@@ -1,0 +1,39 @@
+name: Build Rinseaid OmniRoute image
+
+on:
+  push:
+    branches: [build-k3-reasoning-image]
+    paths:
+      - Dockerfile
+      - package-lock.json
+      - package.json
+      - open-sse/**
+      - scripts/build/**
+      - .github/workflows/build-rinseaid-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runner-base
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/rinseaid/omniroute:k3-reasoning-${{ github.sha }}

--- a/open-sse/handlers/responseSanitizer/reasoning.ts
+++ b/open-sse/handlers/responseSanitizer/reasoning.ts
@@ -130,6 +130,7 @@ export function isTextualReasoningTagNativeRoute(providerId: string, modelId: st
     /deepseek[-_/]?r1\b/.test(routeId) ||
     /r1[-_/]?distill\b/.test(routeId) ||
     /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId) ||
+    (providerId === "kimi-coding" && /(?:^|[/_-])k3(?:[/._:-]|$)/.test(modelId)) ||
     // 9router#2231: MiniMax M3 leaks raw <think>...</think> into `content` on its
     // OpenAI-format provider tiers (trae, huggingchat, bazaarlink, ollama-cloud,
     // opencode, cline, opencode-zen, codebuddy-cn). The direct minimax/minimax-cn

--- a/open-sse/utils/earlyStreamKeepalive.ts
+++ b/open-sse/utils/earlyStreamKeepalive.ts
@@ -34,27 +34,9 @@ const KEEPALIVE_FRAME = ENCODER.encode(": omniroute-keepalive\n\n");
 export const OPENAI_KEEPALIVE_FRAME = ENCODER.encode(
   'data: {"id":"omniroute-keepalive","object":"chat.completion.chunk","created":0,"model":"omniroute","choices":[{"index":0,"delta":{},"finish_reason":null}]}\n\n'
 );
-// #7360 follow-up: the FIRST frame of the slow path carries visible content
-// instead of an empty delta, framed as a reasoning/thinking chunk (the same
-// shape OmniRoute already emits for real upstream reasoning — see
-// open-sse/translator/response/claude-to-openai.ts's createChunk) so
-// reasoning-aware clients render it instead of silently ignoring it. This is
-// what lets OmniRoute safely wait out a longer Gemini rate-limit cooldown
-// (see comboCooldownWait/waitForCooldown budgetMs) without the client's own
-// first-event/idle-read timeout firing — the client sees a real byte
-// immediately, it just says we're still working on it.
-const STARTUP_THINKING_TEXT = "OmniRoute: got request, sending to provider";
-export const OPENAI_STARTUP_THINKING_FRAME = ENCODER.encode(
-  `data: ${JSON.stringify({
-    id: "omniroute-keepalive",
-    object: "chat.completion.chunk",
-    created: 0,
-    model: "omniroute",
-    choices: [
-      { index: 0, delta: { reasoning_content: STARTUP_THINKING_TEXT }, finish_reason: null },
-    ],
-  })}\n\n`
-);
+// The first slow-path frame must be a valid OpenAI chunk without creating
+// visible reasoning that clients persist into the conversation.
+export const OPENAI_STARTUP_FRAME = OPENAI_KEEPALIVE_FRAME;
 // Anthropic Messages-format keepalive: a REAL `ping` SSE event, not a comment.
 // Anthropic clients (Claude Code, the Anthropic SDK) reset their stream/first-token
 // watchdog on real SSE events but ignore SSE comments (`: ...`), so on a slow first
@@ -70,6 +52,7 @@ export const ANTHROPIC_PING_FRAME = ENCODER.encode('event: ping\ndata: {"type":"
 // response.created lifecycle from scratch; this placeholder item never
 // carries a response_id and isn't meant to be continued.
 const RESPONSES_STARTUP_ITEM_ID = "rs_omniroute_keepalive";
+const STARTUP_THINKING_TEXT = "OmniRoute: got request, sending to provider";
 export const RESPONSES_STARTUP_THINKING_FRAME = ENCODER.encode(
   [
     {

--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -8,7 +8,7 @@ import { acceptHeaderForcesStream } from "@omniroute/open-sse/utils/aiSdkCompat.
 import {
   OPENAI_CHAT_ERROR_FRAME,
   OPENAI_KEEPALIVE_FRAME,
-  OPENAI_STARTUP_THINKING_FRAME,
+  OPENAI_STARTUP_FRAME,
   withEarlyStreamKeepalive,
 } from "@omniroute/open-sse/utils/earlyStreamKeepalive";
 import { resolveKeepaliveThreshold } from "@omniroute/open-sse/utils/keepaliveThreshold";
@@ -160,7 +160,7 @@ export async function POST(request) {
         signal: request.signal,
         thresholdMs: resolveKeepaliveThreshold(parsedBody?.model),
         keepaliveFrame: OPENAI_KEEPALIVE_FRAME,
-        startupFrame: OPENAI_STARTUP_THINKING_FRAME,
+        startupFrame: OPENAI_STARTUP_FRAME,
         errorFrame: OPENAI_CHAT_ERROR_FRAME,
         extraHeaders: { "X-Correlation-Id": reqId },
       });

--- a/tests/unit/early-stream-keepalive.test.ts
+++ b/tests/unit/early-stream-keepalive.test.ts
@@ -5,7 +5,7 @@ import {
   withEarlyStreamKeepalive,
   ANTHROPIC_PING_FRAME,
   OPENAI_KEEPALIVE_FRAME,
-  OPENAI_STARTUP_THINKING_FRAME,
+  OPENAI_STARTUP_FRAME,
   RESPONSES_STARTUP_THINKING_FRAME,
   OPENAI_CHAT_ERROR_FRAME,
   OPENAI_RESPONSES_ERROR_FRAME,
@@ -101,24 +101,14 @@ test("slow handler emits the custom OpenAI keepalive chunk before the body", asy
   assert.match(body, /data: \[DONE\]/);
 });
 
-// #7360 follow-up: many clients time out waiting for the first SSE byte, and
-// during a long Gemini rate-limit cooldown wait there's nothing real to send
-// yet — OPENAI_STARTUP_THINKING_FRAME gives them a real, visible "we're still
-// working on it" reasoning delta instead of an empty/no-op keepalive.
-test("OPENAI_STARTUP_THINKING_FRAME is a reasoning_content delta chunk with the expected text", () => {
-  const decoded = new TextDecoder().decode(OPENAI_STARTUP_THINKING_FRAME);
+test("OPENAI_STARTUP_FRAME is a parseable empty delta", () => {
+  const decoded = new TextDecoder().decode(OPENAI_STARTUP_FRAME);
   assert.match(decoded, /^data: /);
   assert.doesNotMatch(decoded, /^:/, "must not be an SSE comment");
 
   const payload = JSON.parse(decoded.slice("data: ".length).trim());
   assert.equal(payload.object, "chat.completion.chunk");
-  assert.deepEqual(payload.choices, [
-    {
-      index: 0,
-      delta: { reasoning_content: "OmniRoute: got request, sending to provider" },
-      finish_reason: null,
-    },
-  ]);
+  assert.deepEqual(payload.choices, [{ index: 0, delta: {}, finish_reason: null }]);
 });
 
 test("slow handler emits startupFrame once, then falls back to keepaliveFrame on later ticks", async () => {
@@ -133,17 +123,13 @@ test("slow handler emits startupFrame once, then falls back to keepaliveFrame on
     thresholdMs: 20,
     intervalMs: 250,
     keepaliveFrame: OPENAI_KEEPALIVE_FRAME,
-    startupFrame: OPENAI_STARTUP_THINKING_FRAME,
+    startupFrame: OPENAI_STARTUP_FRAME,
   });
 
   const body = await readAll(result);
   const frames = body.split("\n\n").filter(Boolean);
   const firstPayload = JSON.parse(frames[0].slice("data: ".length));
-  assert.equal(
-    firstPayload.choices[0].delta.reasoning_content,
-    "OmniRoute: got request, sending to provider",
-    "the very first frame must carry the startup thinking text"
-  );
+  assert.deepEqual(firstPayload.choices[0].delta, {});
 
   // At least one subsequent keepalive tick should have fired before the real
   // body arrived (interval 30ms, handler resolves at 150ms) — those ticks use

--- a/tests/unit/responsesanitizer-reasoning-split.test.ts
+++ b/tests/unit/responsesanitizer-reasoning-split.test.ts
@@ -52,6 +52,21 @@ describe("responseSanitizer/reasoning — shouldParseTextualReasoningTags", () =
   });
 });
 
+describe("responseSanitizer/reasoning — Kimi Code K3 textual reasoning-tag route", () => {
+  it("extracts <think> blocks from the Kimi Code K3 route", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { content: "<think>reasoning here</think>final answer" } }],
+    };
+    const sanitized = sanitizeOpenAIResponse(chunk, {
+      parseTextualReasoningTags: shouldParseTextualReasoningTags("kimi-coding", "k3"),
+    }) as { choices: Array<{ delta: { content: string; reasoning_content?: string } }> };
+
+    const delta = sanitized.choices[0].delta;
+    assert.equal(delta.content, "final answer");
+    assert.equal(delta.reasoning_content, "reasoning here");
+  });
+});
+
 // ── MiniMax M3 textual reasoning-tag route (9router#2231) ──────────────────────
 //
 // MiniMax M3 leaks raw <think>...</think> into `content` instead of a separate


### PR DESCRIPTION
Removes the visible synthetic reasoning keepalive from OpenAI Chat Completions.

Slow streams still receive a parseable empty OpenAI-compatible chunk, so strict clients remain connected without persisting provider status text into the conversation.

Validated with `tests/unit/early-stream-keepalive.test.ts` and targeted ESLint.