### PR TITLE
fix(providers): support multi-token search in provider filter (#8659)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -13,7 +13,7 @@ import {
 } from "@/shared/constants/providers";
 import { getModelsByProviderId } from "@/shared/constants/models";
 import { providerHasServiceKind } from "@/lib/providers/serviceKindIndex";
-import { compareTr, matchesSearch } from "@/shared/utils/turkishText";
+import { compareTr, matchesAnyToken, matchesSearch } from "@/shared/utils/turkishText";
 import { fetchWithTimeout } from "@/shared/utils/fetchTimeout";
 import type { ProviderDisplayMode } from "./providerPageStorage";
 import { isFeaturedProviderId } from "./featuredProviders";
@@ -325,8 +325,8 @@ export function filterConfiguredProviderEntries<TProvider>(
     filtered = filtered.filter((entry) => {
       const provider = entry.provider as Record<string, unknown>;
       return (
-        matchesSearch(String(provider.name || ""), searchQuery) ||
-        matchesSearch(entry.providerId, searchQuery)
+        matchesAnyToken(String(provider.name || ""), searchQuery) ||
+        matchesAnyToken(entry.providerId, searchQuery)
       );
     });
   }

--- a/src/shared/utils/turkishText.ts
+++ b/src/shared/utils/turkishText.ts
@@ -47,6 +47,22 @@ export function matchesSearch(
   return normalizeForSearch(text).includes(q);
 }
 
+/**
+ * Checks if `text` matches any whitespace-separated token in `query`.
+ * Returns `true` if `query` is empty or if any token is found in `text`.
+ */
+export function matchesAnyToken(
+  text: string | null | undefined,
+  query: string | null | undefined
+): boolean {
+  const q = normalizeForSearch(query);
+  if (!q) return true;
+  const tokens = q.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return true;
+  const normText = normalizeForSearch(text);
+  return tokens.some((token) => normText.includes(token));
+}
+
 const trCollator = new Intl.Collator("tr", {
   sensitivity: "base",
   numeric: true,

--- a/tests/unit/turkishText.test.ts
+++ b/tests/unit/turkishText.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   normalizeForSearch,
   matchesSearch,
+  matchesAnyToken,
   compareTr,
 } from "../../src/shared/utils/turkishText.ts";
 
@@ -72,4 +73,30 @@ test("compareTr: null/undefined argümanları güvenli (?? '' guard)", () => {
   assert.equal(compareTr(null, "a") < 0, true);
   assert.equal(compareTr("a", null) > 0, true);
   assert.equal(compareTr(null, undefined), 0);
+});
+
+test("matchesAnyToken: tek token eşleşmesi", () => {
+  assert.equal(matchesAnyToken("pollinations", "pollinations sambanova"), true);
+});
+
+test("matchesAnyToken: birden fazla token'dan biri eşleşir", () => {
+  assert.equal(matchesAnyToken("sambanova", "pollinations sambanova huggingface"), true);
+});
+
+test("matchesAnyToken: hiçbir token eşleşmez", () => {
+  assert.equal(matchesAnyToken("openai", "pollinations sambanova"), false);
+});
+
+test("matchesAnyToken: Türkçe ve aksan duyarsız çoklu token eşleşmesi", () => {
+  assert.equal(matchesAnyToken("İstanbul Provider", "ankara istanbul"), true);
+});
+
+test("matchesAnyToken: boş veya yalnızca boşluk sorgusu her şeyi eşler", () => {
+  assert.equal(matchesAnyToken("herhangi", ""), true);
+  assert.equal(matchesAnyToken("herhangi", "   "), true);
+});
+
+test("matchesAnyToken: null/undefined text/query güvenli", () => {
+  assert.equal(matchesAnyToken(null, "test"), false);
+  assert.equal(matchesAnyToken("test", null), true);
 });


### PR DESCRIPTION
## Summary
Fixes #8659.

## Changes
- Introduced `matchesAnyToken` helper in `src/shared/utils/turkishText.ts` to split queries by whitespace and match any token (accent- and case-insensitive).
- Updated `filterProviders` in `src/app/(dashboard)/dashboard/providers/providerPageUtils.ts` to use `matchesAnyToken` instead of `matchesSearch`.
- Added unit tests covering single and multi-token matches in `tests/unit/turkishText.test.ts`.

## Verification
- Unit tests: `node --import tsx/esm --test tests/unit/turkishText.test.ts` (PASS, 21/21).