### PR TITLE
fix(plugins): delete the generated host script synchronously so plugin loads stop leaking temp files

### DIFF
--- a/changelog.d/fixes/plugin-host-script-sync-delete.md
+++ b/changelog.d/fixes/plugin-host-script-sync-delete.md
@@ -1,0 +1,1 @@
+- **fix(plugins):** the generated plugin host script is now deleted synchronously — an async `rm()` lost the race against process exit, so every plugin load under `node --test --test-force-exit` leaked one temp `.mjs` into the OS temp dir; two plugin manager tests also stopped leaking child processes

--- a/src/lib/plugins/loader.ts
+++ b/src/lib/plugins/loader.ts
@@ -9,7 +9,8 @@
  */
 
 import { spawn } from "child_process";
-import { writeFile, rm, readFile } from "fs/promises";
+import { writeFile, readFile } from "fs/promises";
+import { rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { randomUUID, createHash } from "crypto";
@@ -81,6 +82,19 @@ function forwardChildOutput(
       newlineIndex = buffer.indexOf("\n");
     }
   });
+}
+
+/**
+ * Delete the generated host script synchronously. An async unlink loses the race
+ * against process exit — under `node --test --test-force-exit` the runner exits
+ * before the promise settles, leaking one temp .mjs per plugin load.
+ */
+function removeHostScript(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // Best-effort: a leftover temp script is harmless; a throw from an exit handler is not.
+  }
 }
 
 // ── Plugin host script (runs in child process over IPC) ──
@@ -236,7 +250,7 @@ export async function loadPlugin(
       pending.reject(new Error(`Plugin process exited with code ${code}`));
     }
     pendingCalls.clear();
-    rm(hostScriptPath, { force: true }).catch(() => {});
+    removeHostScript(hostScriptPath);
   });
 
   // Call a hook in the child process with timeout + SIGTERM + SIGKILL escalation
@@ -358,7 +372,7 @@ export async function loadPlugin(
       } catch {}
     }, SIGKILL_GRACE_MS);
     child.once("exit", () => clearTimeout(killTimer));
-    rm(hostScriptPath, { force: true }).catch(() => {});
+    removeHostScript(hostScriptPath);
     log.info("loader.cleanup", { name: manifest.name });
   };
 

--- a/tests/unit/plugins-loader.test.ts
+++ b/tests/unit/plugins-loader.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -195,5 +196,68 @@ export async function onUninstall(_payload) {}
 
     // The wired method must bridge to the worker without throwing (fire-and-forget).
     await loaded.plugin.onActivate?.({ name: "lifecycle-test", version: "1.0.0" });
+  }
+);
+
+// Regression (Hard Rule #18): the generated host script used to be deleted with a
+// fire-and-forget `rm(...).catch()`. That unlink loses the race against process exit —
+// under `npm run test:unit` (--test-force-exit) the runner tore the process down before
+// the promise settled, so every plugin load leaked one omniroute-plugin-host-*.mjs into
+// TMPDIR and they accumulated run over run. cleanup() must have removed it by return.
+test(
+  "cleanup() removes the generated host script before returning",
+  { timeout: 5_000 },
+  async (t) => {
+    const pluginDir = await mkdtemp(join(tmpdir(), "omniroute-plugin-loader-"));
+    const entryPoint = join(pluginDir, "index.mjs");
+    // Redirect the loader's tmpdir() so a concurrent test file's host scripts cannot
+    // land in the directory we count (test:unit runs at --test-concurrency=20).
+    // POSIX reads TMPDIR, Windows reads TEMP/TMP — set all three.
+    const hostScriptDir = await mkdtemp(join(tmpdir(), "omniroute-hostscript-"));
+    const tmpEnvKeys = ["TMPDIR", "TEMP", "TMP"] as const;
+    const savedEnv = tmpEnvKeys.map((k) => [k, process.env[k]] as const);
+    let loaded: LoadedPlugin | undefined;
+
+    t.after(async () => {
+      loaded?.cleanup();
+      for (const [key, value] of savedEnv) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await rm(pluginDir, { recursive: true, force: true });
+      await rm(hostScriptDir, { recursive: true, force: true });
+    });
+
+    await writeFile(entryPoint, "export async function onRequest() { return {}; }\n", "utf-8");
+    for (const key of tmpEnvKeys) process.env[key] = hostScriptDir;
+
+    loaded = await loadPlugin(entryPoint, {
+      name: "host-script-cleanup-test",
+      version: "1.0.0",
+      license: "MIT",
+      main: "index.mjs",
+      source: "local",
+      tags: [],
+      requires: { permissions: [] },
+      hooks: { onRequest: true, onResponse: false, onError: false },
+      skills: [],
+      enabledByDefault: false,
+      configSchema: {},
+    });
+
+    assert.deepEqual(
+      readdirSync(hostScriptDir).filter((f) => f.startsWith("omniroute-plugin-host-")).length,
+      1,
+      "sanity: loadPlugin writes exactly one host script"
+    );
+
+    loaded.cleanup();
+    loaded = undefined;
+
+    assert.deepEqual(
+      readdirSync(hostScriptDir).filter((f) => f.startsWith("omniroute-plugin-host-")),
+      [],
+      "cleanup() must delete the host script synchronously, not on a later tick"
+    );
   }
 );

--- a/tests/unit/plugins-manager-lifecycle.test.ts
+++ b/tests/unit/plugins-manager-lifecycle.test.ts
@@ -24,7 +24,9 @@ function makeTmpPlugin(name: string, manifest: Record<string, unknown> = {}) {
 }
 
 function cleanup(name: string) {
-  try { db.deletePlugin(name); } catch {}
+  try {
+    db.deletePlugin(name);
+  } catch {}
 }
 
 describe("pluginManager lifecycle", () => {
@@ -37,7 +39,9 @@ describe("pluginManager lifecycle", () => {
     getDbInstance();
     // Clean up test plugins
     for (const name of testPlugins) {
-      try { db.deletePlugin(name); } catch {}
+      try {
+        db.deletePlugin(name);
+      } catch {}
     }
     testPlugins.length = 0;
   });
@@ -73,6 +77,10 @@ describe("pluginManager lifecycle", () => {
         const dbRow = db.getPluginByName("activate-test");
         assert.equal(dbRow!.status, "active");
       } finally {
+        // deactivate() is the only path that reaches the loader's cleanup() and kills
+        // the plugin's child process — without it the child outlives the test and its
+        // IPC channel keeps this process's event loop alive after the suite finishes.
+        await mod.pluginManager.deactivate("activate-test").catch(() => {});
         rmSync(dir.split("/").slice(0, -1).join("/"), { recursive: true, force: true });
       }
     });

--- a/tests/unit/plugins-manager-restart-reload-7806.test.ts
+++ b/tests/unit/plugins-manager-restart-reload-7806.test.ts
@@ -46,9 +46,15 @@ function makeTmpPlugin(name: string, manifest: Record<string, unknown> = {}) {
 function simulateRestart(name: string) {
   // loadedPlugins is private — this is exactly the module-state loss a real restart
   // causes (a fresh process never had this entry in the first place).
-  (mod.pluginManager as unknown as { loadedPlugins: Map<string, unknown> }).loadedPlugins.delete(
-    name
-  );
+  const loadedPlugins = (
+    mod.pluginManager as unknown as { loadedPlugins: Map<string, { cleanup: () => void }> }
+  ).loadedPlugins;
+  // Drop the entry without cleanup() and the child process becomes unreachable —
+  // deactivate() in the test's finally can then only reach the *reloaded* child, and
+  // this one dangles. A real restart takes the whole process tree down, so killing it
+  // here is both the faithful simulation and the only way to avoid the leak.
+  loadedPlugins.get(name)?.cleanup();
+  loadedPlugins.delete(name);
 }
 
 describe("pluginManager reload after restart (#7806)", () => {


### PR DESCRIPTION
## Problem

`loadPlugin()` writes a generated host script to the OS temp dir and deletes it on
child-process exit / `cleanup()` with an **async** `rm(hostScriptPath, { force: true }).catch(() => {})`.

That promise loses the race against process exit. Under `node --test --test-force-exit`
the runner tears the process down before the unlink settles, so **every plugin load leaks
one temp `.mjs`** into the temp dir. Two plugin manager tests were additionally leaking
child processes across cases.

## Fix

- `src/lib/plugins/loader.ts`: replace both async `rm()` callsites with a `removeHostScript()`
  helper using `rmSync(path, { force: true })`, wrapped in try/catch so a throw from an exit
  handler can never propagate (a leftover temp script is harmless; a throwing exit handler is not).
- `tests/unit/plugins-manager-lifecycle.test.ts`, `tests/unit/plugins-manager-restart-reload-7806.test.ts`:
  release child processes in cleanup so the suites stop leaking.

## Validation (Hard Rule #18 — TDD)

New regression guard `tests/unit/plugins-loader.test.ts` (+64), test 8
`cleanup() removes the generated host script before returning`.

Reverting `loader.ts` to the base version and re-running the new test:

```
not ok 8 - cleanup() removes the generated host script before returning
    cleanup() must delete the host script synchronously, not on a later tick
# tests 8 | pass 7 | fail 1
```

With the fix applied:

```
tests/unit/plugins-loader.test.ts                     # tests 8 | pass 8 | fail 0
tests/unit/plugins-manager-lifecycle.test.ts          # tests 9 | pass 9 | fail 0
tests/unit/plugins-manager-restart-reload-7806.test.ts # tests 2 | pass 2 | fail 0
```

`npm run typecheck:core` and `npm run lint` are both clean.

## Notes

The fix was originally written alongside the #7847 request-body heap benchmark. The
benchmark itself (`scripts/perf/agentPayloadCorpus.ts`, `tests/unit/heap-benchmark-corpus.test.ts`,
its changelog fragment) already landed in the 2026-07-26 batch; this loader fix was the one
piece that never got submitted. Cherry-picked onto current `release/v3.8.49` rather than
rebasing the 66-commit-stale original branch.
