### PR TITLE
fix(sse): update ANTHROPIC_PING heartbeat data payload to {"type":"ping"} (fixes #8744, fixes #8750)

### DIFF
--- a/open-sse/utils/sseHeartbeat.ts
+++ b/open-sse/utils/sseHeartbeat.ts
@@ -32,7 +32,7 @@ function buildHeartbeatPayload(
 ): string {
   switch (shape) {
     case HEARTBEAT_SHAPES.ANTHROPIC_PING:
-      return "event: ping\ndata: {}\n\n";
+      return 'event: ping\ndata: {"type":"ping"}\n\n';
     case HEARTBEAT_SHAPES.OPENAI_RESPONSES_IN_PROGRESS:
       return 'data: {"type":"response.in_progress"}\n\n';
     case HEARTBEAT_SHAPES.OPENAI_CHUNK: {

--- a/tests/unit/sse-heartbeat-integration.test.ts
+++ b/tests/unit/sse-heartbeat-integration.test.ts
@@ -118,7 +118,7 @@ test("integration: openai-chunk heartbeat is valid JSON parseable by SDKs", asyn
 });
 
 test("integration: shapeForClientFormat + createSseHeartbeatTransform pipeline (claude path)", async () => {
-  // Simulates what chatCore.ts does at line 4276
+  // Simulates what chatCore.ts does
   const shape = shapeForClientFormat("claude");
   assert.equal(shape, HEARTBEAT_SHAPES.ANTHROPIC_PING);
 
@@ -136,6 +136,6 @@ test("integration: shapeForClientFormat + createSseHeartbeatTransform pipeline (
   const reader = upstream.pipeThrough(transform).getReader();
   await reader.read(); // first real
   const { value } = await readWithTimeout(reader);
-  assert.match(decodeChunk(value), /^event: ping\ndata: \{\}\n\n$/);
+  assert.match(decodeChunk(value), /^event: ping\ndata: \{"type":"ping"\}\n\n$/);
   await reader.cancel();
 });

--- a/tests/unit/sse-heartbeat.test.ts
+++ b/tests/unit/sse-heartbeat.test.ts
@@ -106,7 +106,7 @@ test("shape: anthropic-ping emits event: ping with empty JSON data", async () =>
     await writer.close();
     await pump;
 
-    assert.equal(emitted[0], "event: ping\ndata: {}\n\n");
+    assert.equal(emitted[0], 'event: ping\ndata: {"type":"ping"}\n\n');
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #8744 and #8750.

## Changes
- Updated `HEARTBEAT_SHAPES.ANTHROPIC_PING` in `open-sse/utils/sseHeartbeat.ts` to emit `event: ping\ndata: {"type":"ping"}\n\n` instead of empty object `{}`.
- Updated unit & integration test expectations in `tests/unit/sse-heartbeat.test.ts` and `tests/unit/sse-heartbeat-integration.test.ts`.