### PR TITLE
fix(bedrock): preserve additionalModelRequestFields in converse payload (fixes #8746)

### DIFF
--- a/open-sse/executors/bedrock.ts
+++ b/open-sse/executors/bedrock.ts
@@ -366,6 +366,10 @@ export function openAIToBedrockConverse(model, body) {
   const toolConfig = toolConfigFromOpenAI(request.tools, request.tool_choice);
   if (toolConfig) payload.toolConfig = toolConfig;
 
+  if (request.additionalModelRequestFields !== undefined) {
+    payload.additionalModelRequestFields = request.additionalModelRequestFields;
+  }
+
   return payload;
 }
 

--- a/tests/unit/executor-bedrock.test.ts
+++ b/tests/unit/executor-bedrock.test.ts
@@ -97,6 +97,19 @@ test("openAIToBedrockConverse avoids duplicate Bedrock toolUse ids from mixed to
   assert.equal(payload.messages[2].content[0].toolResult.toolUseId, "call_dup");
 });
 
+test("openAIToBedrockConverse preserves additionalModelRequestFields", () => {
+  const payload = openAIToBedrockConverse("anthropic.claude-3-7-sonnet-20250219-v1:0", {
+    messages: [{ role: "user", content: "Hello" }],
+    additionalModelRequestFields: {
+      thinking: { type: "enabled", budget_tokens: 2048 },
+    },
+  });
+
+  assert.deepStrictEqual(payload.additionalModelRequestFields, {
+    thinking: { type: "enabled", budget_tokens: 2048 },
+  });
+});
+
 test("openAIToBedrockConverse drops duplicate pending tool call ids", () => {
   const payload = openAIToBedrockConverse("anthropic.claude-sonnet-4-6", {
     messages: [


### PR DESCRIPTION
## Summary
Fixes #8746.

## Changes
- Updated  in  to pass through  when present.
- Ensures reasoning/thinking configuration set by translators (e.g. Kiro to Bedrock / Anthropic reasoning fields) is properly passed to Bedrock Converse API requests.
- Added unit test in  to verify  preservation.