### PR TITLE
fix(docs): use correct kebab-case CLI flags in OpenCode guide (take 2)

### DIFF
--- a/docs/frameworks/OPENCODE.md
+++ b/docs/frameworks/OPENCODE.md
@@ -1,7 +1,7 @@
 ---
 title: "OpenCode Integration"
 version: 3.8.40
-lastUpdated: 2026-06-28
+lastUpdated: 2027-07-25
 ---
 
 # OpenCode Integration
@@ -24,8 +24,8 @@ Recommended for end users. Ships with OmniRoute. Writes `opencode.json` in place
 ```bash
 # After installing OmniRoute (npm i -g @omniroute/cli or local clone)
 omniroute config opencode \
-  --baseUrl http://localhost:20128 \
-  --apiKey "$OMNIROUTE_API_KEY"
+  --base-url http://localhost:20128 \
+  --api-key "$OMNIROUTE_API_KEY"
 ```
 
 Behind the scenes the CLI calls `mergeOpenCodeConfigText()` (`src/shared/services/opencodeConfig.ts:104`), so an existing `opencode.json` keeps its other providers and comments. The OmniRoute entry is added/replaced atomically.

--- a/docs/frameworks/OPENCODE.md
+++ b/docs/frameworks/OPENCODE.md
@@ -1,7 +1,7 @@
 ---
 title: "OpenCode Integration"
 version: 3.8.40
-lastUpdated: 2027-07-25
+lastUpdated: 2027-07-27
 ---
 
 # OpenCode Integration


### PR DESCRIPTION
The OpenCode integration guide (`docs/frameworks/OPENCODE.md`) used `--baseUrl` and `--apiKey` — camelCase JavaScript property names, not valid CLI flags. Users copying the example hit:

```
error: unknown option '--apikey'
error: unknown option '--baseurl'
```

The CLI defines these as global Commander options in `bin/cli/program.mjs:26-27`:

```
--api-key <key>   (kebab-case)
--base-url <url>  (kebab-case)
```

Commander auto-converts to camelCase `opts.apiKey` / `opts.baseUrl` at runtime, but the command line requires the kebab-case form. This fix corrects the example and bumps `lastUpdated`.
