### PR TITLE
perf(api): skip the full catalog build for quota-exclusive keys

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -12,12 +12,6 @@ import {
 } from "@/lib/localDb";
 import { createLazyConnectionView } from "@/lib/db/providers/lazyConnectionView";
 import { extractAliasBackedModels } from "./aliasBackedModels";
-import { appendNoThinkingVariants } from "@omniroute/open-sse/utils/noThinkingAlias";
-import { appendClaudeEffortVariants } from "@omniroute/open-sse/utils/claudeEffortVariants";
-import { appendSyncedEffortVariants } from "@omniroute/open-sse/utils/syncedEffortVariants";
-import { appendCcDiscoveryAliases } from "@omniroute/open-sse/utils/ccDiscoveryAliases";
-import { isCcAliasGlobalEnabled, getCcAliasSettingsBulk } from "@/lib/db/ccDiscoveryAliases";
-import { buildCcAliasPredicate } from "./ccAliasPredicate";
 import { buildSyncedCapabilities, mergeSyncedCapabilities } from "./syncedCapabilities";
 import { getAllEmbeddingModels } from "@omniroute/open-sse/config/embeddingRegistry";
 import {
@@ -47,18 +41,13 @@ import { getOpenRouterCatalog } from "@/lib/catalog/openrouterCatalog";
 import { hasEligibleConnectionForModel } from "@/domain/connectionModelRules";
 import {
   INTERNAL_PROXY_ERROR,
-  enrichCatalogModelEntry,
   getCanonicalModelMetadata,
   getCatalogDiagnosticsHeaders,
-  disambiguateCatalogModelNames,
 } from "@/lib/modelMetadataRegistry";
 import { getSyncedCapability } from "@/lib/modelsDevSync";
 import { getModelSpec } from "@/shared/constants/modelSpecs";
-import {
-  isModelCatalogNamesEnabled,
-  getModelsCatalogPrefixMode,
-} from "@/shared/utils/featureFlags";
-import { dedupeExactCatalogIds } from "./catalogDedupe";
+import { getModelsCatalogPrefixMode } from "@/shared/utils/featureFlags";
+import { applyCatalogPostFilters, finalizeCatalogResponse } from "./catalogResponse";
 import {
   isNoAuthProviderBlocked,
   isNoAuthProviderKey,
@@ -538,6 +527,38 @@ async function buildUnifiedModelsResponseCore(
     const models = [];
     const timestamp = Math.floor(Date.now() / 1000);
     const listedIds = new Set<string>();
+
+    // #8770 follow-up: a quota-exclusive key (allowedQuotas non-empty) only ever
+    // receives the pool's `qtSd/*` combos — the key-permission step further down
+    // discards the entire catalog for it. Building that catalog first costs ~1.2s
+    // of CPU on a 1 vCPU host (measured), enough for Claude Code's 3s gateway model
+    // discovery to time out under contention, and every byte of it is thrown away.
+    // Everything the quota path needs (`combos`, `timestamp`,
+    // `buildComboCatalogMetadata`) already exists here, so return before the
+    // provider/auto-combo/registry loops start.
+    const earlyApiKey = extractApiKey(request);
+    if (earlyApiKey) {
+      const { getApiKeyMetadata } = await import("@/lib/db/apiKeys");
+      const earlyKeyMeta = await getApiKeyMetadata(earlyApiKey);
+      if (earlyKeyMeta?.allowedQuotas && earlyKeyMeta.allowedQuotas.length > 0) {
+        const { buildQuotaExclusiveModels } = await import("@/lib/quota/quotaCombos");
+        const quotaModels = await buildQuotaExclusiveModels(
+          earlyKeyMeta.allowedQuotas,
+          combos,
+          timestamp,
+          (c) => buildComboCatalogMetadata(c, combos)
+        );
+        const quotaFinal = applyCatalogPostFilters(request, quotaModels, {
+          connections,
+          prefixMode,
+          aliasToProviderId,
+        });
+        return finalizeCatalogResponse(request, quotaFinal, () => undefined, {
+          ...corsHeaders,
+          ...diagnosticHeaders,
+        });
+      }
+    }
 
     // #4164: advertise the built-in zero-setup `auto/*` combos at the very top.
     // #4189: enrich each with the combo's advertised context/output limits (computed
@@ -1410,62 +1431,11 @@ async function buildUnifiedModelsResponseCore(
       }
     }
     // ?configuredOnly — hide models that have no eligible DB connection.
-    // Applied after the API-key filter so the key filter runs first, then
-    // variants are only generated for surviving models.
-    if (new URL(request.url).searchParams.get("configuredOnly") === "true") {
-      finalModels = finalModels.filter((m) => {
-        if (!m.root) return true;
-        return hasEligibleConnectionForModel(connections, m.root);
-      });
-    }
-
-    // Advertise Claude reasoning-effort variants (claude/<model>-{low,medium,high[,xhigh]}).
-    // Derived from the already key-filtered list so a variant only appears when its real
-    // model is permitted. Runs before the no-thinking pass: the gateway already routes these
-    // suffixed ids (claudeEffortVariant.ts), this just makes them selectable in catalog-only
-    // clients (OpenCode) that can't set a reasoning_effort config the way VS Code does.
-    finalModels = appendClaudeEffortVariants(
-      finalModels,
-      prefixMode === "canonical" ? aliasToProviderId : undefined
-    );
-
-    // Advertise no-thinking gateway variants (Fase 8.1). Derived from the already
-    // key-filtered list, so a variant only appears when its real model is permitted.
-    finalModels = appendNoThinkingVariants(
-      finalModels,
-      prefixMode === "canonical" ? aliasToProviderId : undefined
-    );
-
-    // Advertise `claude/<id>` discovery-mirror aliases so Claude Code's gateway
-    // model discovery (which only lists `claude`/`anthropic`-prefixed ids) can see
-    // every model this gate allows. Gated 3 levels deep (global > provider > model,
-    // see ccDiscoveryAliases.ts) and default-off. Deliberately NOT filtered by model
-    // `type` here — non-chat entries (embedding/image/etc.) get a mirror too; the
-    // gate itself (default-off + explicit opt-in) is the operator's filter, not a
-    // hardcoded type allowlist.
-    const ccAliasGlobal = isCcAliasGlobalEnabled();
-    const ccAliasSettings = getCcAliasSettingsBulk();
-    if (ccAliasGlobal || ccAliasSettings.providers.size > 0 || ccAliasSettings.models.size > 0) {
-      finalModels = appendCcDiscoveryAliases(
-        finalModels,
-        buildCcAliasPredicate({
-          global: ccAliasGlobal,
-          providers: ccAliasSettings.providers,
-          models: ccAliasSettings.models,
-        })
-      );
-    }
-
-    // #7694: advertise `<provider>/<model>-<tier>` variants for synced models that
-    // captured `reasoning.supported_efforts` at sync time (capabilities.effort_tiers).
-    // Derived from the already key-filtered list; skips codex/kimi (own suffix mechanism).
-    finalModels = appendSyncedEffortVariants(finalModels);
-
-    // #4424 follow-up — drop exact-duplicate ids that slip through the per-source push
-    // guards (e.g. `codex/gpt-5.5`, `veo-free/seedance` listed twice). Keyed by listing
-    // identity (id, type, subtype) so the intentional same-id audio transcription/speech
-    // pair survives. Independent of MODELS_CATALOG_PREFIX_MODE; runs as the final guard.
-    finalModels = dedupeExactCatalogIds(finalModels);
+    finalModels = applyCatalogPostFilters(request, finalModels, {
+      connections,
+      prefixMode,
+      aliasToProviderId,
+    });
 
     const getDefaultContextFallback = (model: any): number | undefined => {
       if (typeof model.context_length === "number") return undefined;
@@ -1484,47 +1454,9 @@ async function buildUnifiedModelsResponseCore(
       return modelId ? getTokenLimit(canonicalId, modelId) : getTokenLimit(canonicalId);
     };
 
-    const includeModelNames = isModelCatalogNamesEnabled();
-    const enrichedModels = disambiguateCatalogModelNames(
-      finalModels.map((model) => {
-        if (model.owned_by === "combo") {
-          return maybeOmitCatalogModelName(model, includeModelNames);
-        }
-        const enriched = enrichCatalogModelEntry(model);
-        const fallbackContextLength = getDefaultContextFallback(enriched);
-        const listedModel = fallbackContextLength
-          ? { ...enriched, context_length: fallbackContextLength }
-          : enriched;
-        return maybeOmitCatalogModelName(listedModel, includeModelNames);
-      })
-    );
-    // Codex CLI compatibility: its model-catalog refresh (codex_models_manager) does
-    // GET /v1/models?client_version=<v> and decodes a JSON object with a TOP-LEVEL
-    // `models` array, so the OpenAI-standard `{object,data}` shape makes it fail with
-    // "missing field `models`" and log "failed to refresh available models" on every
-    // startup. For codex clients only (detected by the codex originator/user-agent) we add
-    // an EMPTY `models: []` so the decode succeeds and the error disappears. Every other
-    // OpenAI consumer keeps the byte-identical `{object,data}` response.
-    //
-    // We deliberately keep it EMPTY rather than mirroring the catalog: codex replaces its
-    // built-in per-model agent prompt (`base_instructions`, ~21k chars) with whatever a
-    // populated entry carries for the selected model, so emitting our models with an
-    // empty/foreign `base_instructions` would drop codex's agent prompt to nothing and
-    // break its agent behavior (verified empirically against codex 0.137). An empty array
-    // keeps codex on its built-in model info — same inference as today, minus the error.
-    const responseBody: Record<string, unknown> = {
-      object: "list",
-      data: enrichedModels,
-    };
-    if (isCodexModelCatalogClient(request)) {
-      responseBody.models = [];
-    }
-
-    return Response.json(responseBody, {
-      headers: {
-        ...corsHeaders,
-        ...diagnosticHeaders,
-      },
+    return finalizeCatalogResponse(request, finalModels, getDefaultContextFallback, {
+      ...corsHeaders,
+      ...diagnosticHeaders,
     });
   } catch (error) {
     console.log("Error fetching models:", error);

--- a/src/app/api/v1/models/catalogResponse.ts
+++ b/src/app/api/v1/models/catalogResponse.ts
@@ -1,0 +1,156 @@
+/**
+ * catalogResponse.ts — the tail of the /v1/models build: the post-filter chain and
+ * the response envelope.
+ *
+ * Extracted from catalog.ts so the full catalog build and the quota-exclusive
+ * short-circuit share one implementation. Two paths emitting the same envelope by
+ * copy would drift; the quota path in particular silently lost the discovery
+ * mirrors the first time it was written as a duplicate.
+ */
+
+import { appendNoThinkingVariants } from "@omniroute/open-sse/utils/noThinkingAlias";
+import { appendClaudeEffortVariants } from "@omniroute/open-sse/utils/claudeEffortVariants";
+import { appendSyncedEffortVariants } from "@omniroute/open-sse/utils/syncedEffortVariants";
+import { appendCcDiscoveryAliases } from "@omniroute/open-sse/utils/ccDiscoveryAliases";
+import { isCcAliasGlobalEnabled, getCcAliasSettingsBulk } from "@/lib/db/ccDiscoveryAliases";
+import { buildCcAliasPredicate } from "./ccAliasPredicate";
+import { hasEligibleConnectionForModel } from "@/domain/connectionModelRules";
+import { dedupeExactCatalogIds } from "./catalogDedupe";
+import {
+  disambiguateCatalogModelNames,
+  enrichCatalogModelEntry,
+} from "@/lib/modelMetadataRegistry";
+import { isModelCatalogNamesEnabled } from "@/shared/utils/featureFlags";
+import { maybeOmitCatalogModelName } from "./catalogHelpers";
+import { isCodexModelCatalogClient } from "./catalogRequest";
+
+/**
+ * Post-filter chain applied AFTER the API-key filter, so variants and mirrors are
+ * only derived from models the caller may actually see.
+ *
+ * Shared by the full build and by the quota-exclusive short-circuit: the quota path
+ * returns early, but it still owes the caller these steps — the discovery mirrors in
+ * particular are what let Claude Code see a quota pool's models at all.
+ */
+export function applyCatalogPostFilters(
+  request: Request,
+  models: Array<Record<string, any>>,
+  ctx: {
+    connections: any;
+    prefixMode: string;
+    aliasToProviderId: Record<string, string>;
+  }
+): Array<Record<string, any>> {
+  let finalModels = models;
+
+  // variants are only generated for surviving models.
+  if (new URL(request.url).searchParams.get("configuredOnly") === "true") {
+    finalModels = finalModels.filter((m) => {
+      if (!m.root) return true;
+      return hasEligibleConnectionForModel(ctx.connections, m.root);
+    });
+  }
+
+  // Advertise Claude reasoning-effort variants (claude/<model>-{low,medium,high[,xhigh]}).
+  // Derived from the already key-filtered list so a variant only appears when its real
+  // model is permitted. Runs before the no-thinking pass: the gateway already routes these
+  // suffixed ids (claudeEffortVariant.ts), this just makes them selectable in catalog-only
+  // clients (OpenCode) that can't set a reasoning_effort config the way VS Code does.
+  finalModels = appendClaudeEffortVariants(
+    finalModels,
+    ctx.prefixMode === "canonical" ? ctx.aliasToProviderId : undefined
+  );
+
+  // Advertise no-thinking gateway variants (Fase 8.1). Derived from the already
+  // key-filtered list, so a variant only appears when its real model is permitted.
+  finalModels = appendNoThinkingVariants(
+    finalModels,
+    ctx.prefixMode === "canonical" ? ctx.aliasToProviderId : undefined
+  );
+
+  // Advertise `claude/<id>` discovery-mirror aliases so Claude Code's gateway
+  // model discovery (which only lists `claude`/`anthropic`-prefixed ids) can see
+  // every model this gate allows. Gated 3 levels deep (global > provider > model,
+  // see ccDiscoveryAliases.ts) and default-off. Deliberately NOT filtered by model
+  // `type` here — non-chat entries (embedding/image/etc.) get a mirror too; the
+  // gate itself (default-off + explicit opt-in) is the operator's filter, not a
+  // hardcoded type allowlist.
+  const ccAliasGlobal = isCcAliasGlobalEnabled();
+  const ccAliasSettings = getCcAliasSettingsBulk();
+  if (ccAliasGlobal || ccAliasSettings.providers.size > 0 || ccAliasSettings.models.size > 0) {
+    finalModels = appendCcDiscoveryAliases(
+      finalModels,
+      buildCcAliasPredicate({
+        global: ccAliasGlobal,
+        providers: ccAliasSettings.providers,
+        models: ccAliasSettings.models,
+      })
+    );
+  }
+
+  // #7694: advertise `<provider>/<model>-<tier>` variants for synced models that
+  // captured `reasoning.supported_efforts` at sync time (capabilities.effort_tiers).
+  // Derived from the already key-filtered list; skips codex/kimi (own suffix mechanism).
+  finalModels = appendSyncedEffortVariants(finalModels);
+
+  // #4424 follow-up — drop exact-duplicate ids that slip through the per-source push
+  // guards (e.g. `codex/gpt-5.5`, `veo-free/seedance` listed twice). Keyed by listing
+  // identity (id, type, subtype) so the intentional same-id audio transcription/speech
+  // pair survives. Independent of MODELS_CATALOG_PREFIX_MODE; runs as the final guard.
+  finalModels = dedupeExactCatalogIds(finalModels);
+
+  return finalModels;
+}
+
+/**
+ * Enrich the selected models and serialise the catalog response.
+ *
+ * Shared by the full build and by the quota-exclusive short-circuit so both emit a
+ * byte-identical envelope. `getContextFallback` supplies the registry default
+ * context length for non-combo entries; the quota path passes a no-op because its
+ * entries are all `owned_by: "combo"`, which skips enrichment entirely.
+ */
+export function finalizeCatalogResponse(
+  request: Request,
+  finalModels: Array<Record<string, unknown>>,
+  getContextFallback: (model: Record<string, unknown>) => number | undefined,
+  headers: Record<string, string>
+): Response {
+  const includeModelNames = isModelCatalogNamesEnabled();
+  const enrichedModels = disambiguateCatalogModelNames(
+    finalModels.map((model) => {
+      if (model.owned_by === "combo") {
+        return maybeOmitCatalogModelName(model, includeModelNames);
+      }
+      const enriched = enrichCatalogModelEntry(model);
+      const fallbackContextLength = getContextFallback(enriched);
+      const listedModel = fallbackContextLength
+        ? { ...enriched, context_length: fallbackContextLength }
+        : enriched;
+      return maybeOmitCatalogModelName(listedModel, includeModelNames);
+    })
+  );
+  // Codex CLI compatibility: its model-catalog refresh (codex_models_manager) does
+  // GET /v1/models?client_version=<v> and decodes a JSON object with a TOP-LEVEL
+  // `models` array, so the OpenAI-standard `{object,data}` shape makes it fail with
+  // "missing field `models`" and log "failed to refresh available models" on every
+  // startup. For codex clients only (detected by the codex originator/user-agent) we add
+  // an EMPTY `models: []` so the decode succeeds and the error disappears. Every other
+  // OpenAI consumer keeps the byte-identical `{object,data}` response.
+  //
+  // We deliberately keep it EMPTY rather than mirroring the catalog: codex replaces its
+  // built-in per-model agent prompt (`base_instructions`, ~21k chars) with whatever a
+  // populated entry carries for the selected model, so emitting our models with an
+  // empty/foreign `base_instructions` would drop codex's agent prompt to nothing and
+  // break its agent behavior (verified empirically against codex 0.137). An empty array
+  // keeps codex on its built-in model info — same inference as today, minus the error.
+  const responseBody: Record<string, unknown> = {
+    object: "list",
+    data: enrichedModels,
+  };
+  if (isCodexModelCatalogClient(request)) {
+    responseBody.models = [];
+  }
+
+  return Response.json(responseBody, { headers });
+}

--- a/tests/unit/quota-exclusive-catalog-short-circuit.test.ts
+++ b/tests/unit/quota-exclusive-catalog-short-circuit.test.ts
@@ -1,0 +1,173 @@
+/**
+ * tests/unit/quota-exclusive-catalog-short-circuit.test.ts
+ *
+ * A quota-exclusive key must not pay for a catalog it never sees.
+ *
+ * `buildUnifiedModelsResponseCore` builds the WHOLE catalog first — every
+ * provider's models, the `auto/*` combos with their candidate scoring, the
+ * embedding/image/rerank/audio/moderation/video/music registries, the OpenRouter
+ * catalog, custom models — and only at the very end, when the caller turns out to
+ * be scoped to a quota pool (`allowedQuotas` non-empty), throws all of it away and
+ * returns the pool's `qtSd/*` combos instead.
+ *
+ * Measured on a shared-quota box (1 vCPU, 2026-07-27): ~1.2s of CPU per cold
+ * build to return 10 models. Claude Code's gateway model discovery aborts at 3s,
+ * so on a contended host the discovery silently falls back.
+ *
+ * The observable used here is the OpenRouter catalog fetch: it is part of the full
+ * build and reaches the network, so a request that performs it did the whole build.
+ * The quota-exclusive request runs FIRST, while OpenRouter's 24h cache is still
+ * cold — otherwise a cached second call would make the assertion vacuous.
+ *
+ * The behavioural contract (which models a quota-exclusive key sees) is pinned by
+ * tests/unit/quota-exclusive-catalog-4806.test.ts and must stay green alongside.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-quota-shortcircuit-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "quota-shortcircuit-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const poolsDb = await import("../../src/lib/db/quotaPools.ts");
+const groupsDb = await import("../../src/lib/db/quotaGroups.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+const { syncQuotaCombos } = await import("../../src/lib/quota/quotaCombos.ts");
+const { isQuotaModelName } = await import("../../src/lib/quota/quotaModelNaming.ts");
+
+const originalFetch = globalThis.fetch;
+let openRouterCalls = 0;
+
+/** Count OpenRouter catalog fetches; never touch the network. */
+function installFetchCounter(): void {
+  openRouterCalls = 0;
+  globalThis.fetch = (async (input: unknown, init?: unknown) => {
+    const url = typeof input === "string" ? input : String((input as { url?: string })?.url ?? "");
+    if (url.includes("openrouter.ai")) {
+      openRouterCalls++;
+      return new Response(JSON.stringify({ data: [{ id: "some/model" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return originalFetch(input as never, init as never);
+  }) as typeof globalThis.fetch;
+}
+
+test.after(async () => {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+await test("chave quota-exclusive não constrói o catálogo completo", async (t) => {
+  installFetchCounter();
+
+  // Uma conexão OpenRouter ativa: é ela que faz o build completo ir à rede.
+  await providersDb.createProviderConnection({
+    provider: "openrouter",
+    authType: "apikey",
+    name: "shortcircuit-openrouter",
+    apiKey: "sk-or-shortcircuit",
+  });
+
+  // Pool de cota sobre uma conexão glm (lista estável no registry estático).
+  const group = groupsDb.createGroup("Curto");
+  const conn = await providersDb.createProviderConnection({
+    provider: "glm",
+    authType: "apikey",
+    name: "shortcircuit-glm",
+    apiKey: "sk-glm-shortcircuit",
+  });
+  const pool = poolsDb.createPool({
+    connectionId: (conn as Record<string, unknown>).id as string,
+    name: "Curto",
+    groupId: group.id,
+  });
+  await syncQuotaCombos(pool.id);
+
+  const quotaKey = await apiKeysDb.createApiKey("Chave de cota", "machine-shortcircuit");
+  await apiKeysDb.updateApiKeyPermissions(quotaKey.id, { allowedQuotas: [pool.id] });
+  const normalKey = await apiKeysDb.createApiKey("Chave normal", "machine-normal");
+
+  await t.test("a chave de cota não dispara o fetch do catálogo OpenRouter", async () => {
+    const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+      new Request("http://localhost/api/v1/models", {
+        headers: { Authorization: `Bearer ${quotaKey.key}` },
+      })
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { data: Array<{ id: string }> };
+
+    // O contrato de conteúdo continua valendo: só os qtSd/* do pool.
+    assert.ok(body.data.length > 0, "a chave de cota deve enxergar os modelos do pool");
+    for (const m of body.data) {
+      assert.ok(isQuotaModelName(m.id), `vazou modelo fora do pool: ${m.id}`);
+    }
+
+    assert.equal(
+      openRouterCalls,
+      0,
+      `a chave quota-exclusive descarta o catálogo completo, então não deve construí-lo; ` +
+        `houve ${openRouterCalls} fetch(es) ao OpenRouter`
+    );
+  });
+
+  await t.test("os espelhos de discovery continuam valendo no caminho de cota", async () => {
+    // A cadeia de pós-filtros (variantes de esforço, no-thinking, espelhos
+    // `claude/*` do discovery, dedupe) roda DEPOIS do filtro por chave, então o
+    // atalho da cota também a deve. Sem isso o Claude Code deixa de enxergar os
+    // modelos de um pool — que é justamente o fluxo-alvo.
+    const prev = process.env.EXPOSE_CC_DISCOVERY_ALIASES;
+    process.env.EXPOSE_CC_DISCOVERY_ALIASES = "1";
+    // A chave do cache é `prefix|isCodex|apiKey|configuredOnly` — um query param
+    // qualquer NÃO a invalida, então a resposta do subteste anterior seria servida.
+    v1ModelsCatalog.__expireCatalogCacheForTest(
+      v1ModelsCatalog.CATALOG_STALE_WHILE_REVALIDATE_MS + 1000
+    );
+    try {
+      const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+        new Request("http://localhost/api/v1/models", {
+          headers: { Authorization: `Bearer ${quotaKey.key}` },
+        })
+      );
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { data: Array<{ id: string }> };
+      const mirrors = body.data.filter((m) => m.id.startsWith("claude/"));
+      assert.ok(
+        mirrors.length > 0,
+        `com a flag ligada, a lista da chave de cota deve trazer espelhos claude/*; ` +
+          `ids=${JSON.stringify(body.data.map((m) => m.id).slice(0, 6))}`
+      );
+    } finally {
+      if (prev === undefined) delete process.env.EXPOSE_CC_DISCOVERY_ALIASES;
+      else process.env.EXPOSE_CC_DISCOVERY_ALIASES = prev;
+    }
+  });
+
+  await t.test("uma chave normal continua construindo o catálogo completo", async () => {
+    // Prova que o observável funciona: sem a chave de cota, o build vai à rede.
+    const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+      new Request("http://localhost/api/v1/models", {
+        headers: { Authorization: `Bearer ${normalKey.key}` },
+      })
+    );
+    assert.equal(res.status, 200);
+    assert.ok(
+      openRouterCalls > 0,
+      "o caminho normal deve continuar buscando o catálogo do OpenRouter"
+    );
+  });
+});


### PR DESCRIPTION
## O desperdício

`buildUnifiedModelsResponseCore` monta o **catálogo inteiro** — modelos de todos os providers, os `auto/*` com o scoring de candidatos, os registries de embedding/imagem/rerank/áudio/moderação/vídeo/música, o catálogo do OpenRouter, custom models — e só no fim, quando descobre que o chamador está escopado a um pool de cota (`allowedQuotas` não vazio), **descarta tudo** e devolve os `qtSd/*` do pool.

Medido num host de 1 vCPU: **~1,2 s de CPU por build frio** para devolver 10 modelos, e **4,4–7,1 s sob contenção**. O discovery de modelos por gateway do Claude Code aborta em **3 s** — ou seja, num host ocupado ele cai fora em silêncio.

## A mudança

Tudo que o caminho de cota precisa (`combos`, `timestamp`, `buildComboCatalogMetadata`) já existe **antes** dos laços caros começarem. Então resolve-se o metadado da chave ali e retorna-se cedo.

Para não haver dois caminhos divergindo, dois helpers vão para `./catalogResponse`:

| Helper | O que faz |
| --- | --- |
| `applyCatalogPostFilters` | a cadeia que roda **depois** do filtro por chave: `configuredOnly`, variantes de esforço do Claude, variantes no-thinking, espelhos do cc-discovery, variantes de esforço sincronizadas, dedupe |
| `finalizeCatalogResponse` | enriquecimento + o campo `models: []` de compatibilidade com o codex + o envelope da resposta |

**Essa cadeia não é opcional para o caminho de cota.** Os espelhos do cc-discovery são exatamente o que faz o Claude Code enxergar os modelos de um pool — e a primeira versão desta mudança os perdeu, por retornar antes deles. A regressão está fixada por um teste que eu **verifiquei falhar** sem a chamada.

`catalog.ts`: 1615 → **1480** linhas.

## Validação (TDD)

`tests/unit/quota-exclusive-catalog-short-circuit.test.ts` usa o **fetch do catálogo do OpenRouter** como observável: ele faz parte do build completo e vai à rede, então uma requisição que o executa fez o build inteiro. A requisição da chave de cota roda **primeiro**, com o cache de 24h do OpenRouter ainda frio — senão uma segunda chamada em cache tornaria a asserção vazia.

```
antes:  ✖ houve 1 fetch(es) ao OpenRouter
depois: ✔ pass 4 / fail 0
```

Os três casos: (a) a chave de cota não dispara o fetch e continua vendo só os `qtSd/*` do pool; (b) com `EXPOSE_CC_DISCOVERY_ALIASES=1` os espelhos `claude/*` continuam aparecendo para ela; (c) uma chave normal continua construindo o catálogo completo — o que prova que o observável funciona.

Nota: a chave do cache do catálogo é `prefix|isCodex|apiKey|configuredOnly`, então um query param **não** a invalida — o teste usa `__expireCatalogCacheForTest`, e isso está comentado no arquivo.

**Guards de comportamento verdes:** `quota-exclusive-catalog-4806` (2), `quota-key-models-route` (18), `cc-discovery-aliases-catalog` (9), `catalog-helpers-extraction` (12), `cc-compatible-model-catalog` (1), `instrumentation-warm-catalog-cache` (3), `catalog-pricing-surface-8018` (3), `apikeypolicy-quota-only` (6).

`typecheck:core`, `lint` e `check:file-size` limpos.
