### PR TITLE
fix(db): repair the extra-migration-dirs test and env contract on CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -805,6 +805,15 @@ PROVIDER_LIMITS_SYNC_SPACING_MS=1500
 # Default: <repo>/src/lib/db/migrations.
 #OMNIROUTE_MIGRATIONS_DIR=
 
+# Additional migration directories, as `namespace=dir` entries separated by the
+# platform path delimiter (`:` on POSIX, `;` on Windows). Files found there are
+# recorded as `<namespace>-<number>` (e.g. `ee-134`), a version space that cannot
+# collide with the upstream numeric slots — so a distribution shipping its own
+# migrations never silently loses one to a number the upstream set also claimed.
+# A malformed entry, an invalid namespace or a missing directory aborts startup
+# rather than skipping the schema. Unset = no extra directories (the default).
+#OMNIROUTE_EXTRA_MIGRATIONS_DIRS=ee=/opt/app/enterprise/db/migrations
+
 # Mass-pending-migrations safety threshold (#3416). If more than this many
 # migrations are pending on an existing DB, startup aborts (a wiped tracking
 # table could cause data loss). Raise it to restore an older backup; set to 0

--- a/tests/unit/db-migration-runner-extra-dirs.test.ts
+++ b/tests/unit/db-migration-runner-extra-dirs.test.ts
@@ -11,15 +11,30 @@
  * records one name for it and silently treats the other as already applied — the
  * migration never runs, on every already-provisioned database.
  *
- * This suite pins a generic extension point: `OMNIROUTE_EXTRA_MIGRATIONS_DIRS`
- * maps `namespace=directory` entries (separated by `path.delimiter`), and files
- * found there are recorded as `<namespace>-<number>` so they can never collide
- * with the upstream numeric slots. Unset (the default, and always the case for a
- * plain install) the runner behaves exactly as before.
+ * This suite pins the extension point: `OMNIROUTE_EXTRA_MIGRATIONS_DIRS` maps
+ * `namespace=directory` entries (separated by `path.delimiter`), and files found
+ * there are recorded as `<namespace>-<number>` so they can never collide with the
+ * upstream numeric slots. Unset (the default, and always the case for a plain
+ * install) the runner behaves exactly as before.
  *
  * Misconfiguration fails LOUDLY rather than silently skipping schema — a typo'd
  * namespace or a moved directory is the same class of defect this mechanism
  * exists to prevent.
+ *
+ * TEST SHAPE — read before editing. Two constraints, both learned from CI:
+ *
+ *  1. `MIGRATIONS_DIR` is resolved ONCE, at module evaluation of
+ *     migrationRunner.ts, so the core directory is fixed here BEFORE the first
+ *     import and never changed again. Re-importing under a cache-busting query
+ *     string to pick up a new value is not reliable under the loader chain CI uses
+ *     (`--import tsx/esm --import setupPolyfill --import isolateDataDir`); an
+ *     earlier revision did that, passed locally and failed in CI. The extra
+ *     directories, by contrast, are resolved at CALL time, so each test varies only
+ *     `OMNIROUTE_EXTRA_MIGRATIONS_DIRS`.
+ *
+ *  2. Tests are registered WITHOUT top-level `await`. The bodies are synchronous,
+ *     so awaiting each one drains the event loop between tests and `--test-force-exit`
+ *     (used by every CI test script) cancels the rest of the file.
  */
 
 import test from "node:test";
@@ -27,7 +42,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import Database from "better-sqlite3";
 
 const tempDirs: string[] = [];
@@ -44,60 +58,16 @@ function writeMigrations(dir: string, files: Record<string, string>): void {
   }
 }
 
-async function importFreshRunner() {
-  const modulePath = path.resolve("src/lib/db/migrationRunner.ts");
-  const url = pathToFileURL(modulePath).href;
-  return import(`${url}?extradirs=${Date.now()}-${Math.random().toString(16).slice(2)}`);
-}
+// ── The core directory must be fixed BEFORE migrationRunner.ts is imported ──────
+const CORE_DIR = mkTempDir("mig-core-");
+writeMigrations(CORE_DIR, {
+  "001_initial_schema.sql": "CREATE TABLE core_one (id INTEGER);",
+  "002_core_two.sql": "CREATE TABLE core_two (id INTEGER);",
+});
+process.env.OMNIROUTE_MIGRATIONS_DIR = CORE_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
 
-interface RunResult {
-  count: number;
-  rows: Array<{ version: string; name: string }>;
-  tables: string[];
-}
-
-/**
- * Point the runner at a temp core dir plus the given extra dirs, run it against a
- * fresh in-memory DB and report what got applied.
- */
-async function runWithDirs(
-  coreFiles: Record<string, string>,
-  extraSpec: string | null
-): Promise<RunResult> {
-  const coreDir = mkTempDir("omniroute-core-mig-");
-  writeMigrations(coreDir, coreFiles);
-
-  const prevCore = process.env.OMNIROUTE_MIGRATIONS_DIR;
-  const prevExtra = process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-  const prevBackup = process.env.DISABLE_SQLITE_AUTO_BACKUP;
-  process.env.OMNIROUTE_MIGRATIONS_DIR = coreDir;
-  process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
-  if (extraSpec === null) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-  else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = extraSpec;
-
-  const db = new Database(":memory:");
-  try {
-    const { runMigrations } = await importFreshRunner();
-    const count = runMigrations(db as never, { isNewDb: true });
-    const rows = db
-      .prepare("SELECT version, name FROM _omniroute_migrations ORDER BY rowid")
-      .all() as Array<{ version: string; name: string }>;
-    const tables = (
-      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
-        name: string;
-      }>
-    ).map((r) => r.name);
-    return { count, rows, tables };
-  } finally {
-    db.close();
-    if (prevCore === undefined) delete process.env.OMNIROUTE_MIGRATIONS_DIR;
-    else process.env.OMNIROUTE_MIGRATIONS_DIR = prevCore;
-    if (prevExtra === undefined) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-    else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = prevExtra;
-    if (prevBackup === undefined) delete process.env.DISABLE_SQLITE_AUTO_BACKUP;
-    else process.env.DISABLE_SQLITE_AUTO_BACKUP = prevBackup;
-  }
-}
+const { runMigrations } = await import("../../src/lib/db/migrationRunner.ts");
 
 // Cleanup on process exit, NOT via test.after(): the root after-hook fires as soon
 // as the first top-level test settles, while a later test has already registered its
@@ -112,13 +82,39 @@ process.on("exit", () => {
   }
 });
 
-const CORE = {
-  "001_initial_schema.sql": "CREATE TABLE core_one (id INTEGER);",
-  "002_core_two.sql": "CREATE TABLE core_two (id INTEGER);",
-};
+interface RunResult {
+  count: number;
+  rows: Array<{ version: string; name: string }>;
+  tables: string[];
+}
 
-await test("sem a env, o runner só enxerga o diretório core (comportamento atual)", async () => {
-  const r = await runWithDirs(CORE, null);
+/** Run the migrations against a fresh in-memory DB with the given extra-dir spec. */
+function runWithExtras(extraSpec: string | null): RunResult {
+  const prev = process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
+  if (extraSpec === null) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
+  else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = extraSpec;
+
+  const db = new Database(":memory:");
+  try {
+    const count = runMigrations(db as never, { isNewDb: true });
+    const rows = db
+      .prepare("SELECT version, name FROM _omniroute_migrations ORDER BY rowid")
+      .all() as Array<{ version: string; name: string }>;
+    const tables = (
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+        name: string;
+      }>
+    ).map((r) => r.name);
+    return { count, rows, tables };
+  } finally {
+    db.close();
+    if (prev === undefined) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
+    else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = prev;
+  }
+}
+
+test("sem a env, o runner só enxerga o diretório core (comportamento atual)", async () => {
+  const r = runWithExtras(null);
   assert.deepEqual(
     r.rows.map((x) => x.version),
     ["001", "002"]
@@ -126,11 +122,11 @@ await test("sem a env, o runner só enxerga o diretório core (comportamento atu
   assert.ok(r.tables.includes("core_one") && r.tables.includes("core_two"));
 });
 
-await test("migration de diretório extra é aplicada e gravada com versão namespaced", async () => {
+test("migration de diretório extra é aplicada e gravada com versão namespaced", async () => {
   const eeDir = mkTempDir("mig-ee-");
   writeMigrations(eeDir, { "001_ee_lending.sql": "CREATE TABLE ee_lending (id INTEGER);" });
 
-  const r = await runWithDirs(CORE, `ee=${eeDir}`);
+  const r = runWithExtras(`ee=${eeDir}`);
 
   assert.ok(
     r.tables.includes("ee_lending"),
@@ -145,13 +141,13 @@ await test("migration de diretório extra é aplicada e gravada com versão name
   assert.equal(r.rows.at(-1)?.name, "ee_lending");
 });
 
-await test("o mesmo número em core e em diretório extra NÃO colide — ambas rodam", async () => {
-  const eeDir = mkTempDir("omniroute-ee-collide-");
+test("o mesmo número em core e em diretório extra NÃO colide — ambas rodam", async () => {
+  const eeDir = mkTempDir("mig-collide-");
   // Mesmo prefixo numérico de uma migration core: é exatamente o caso que hoje
   // faz uma das duas ser silenciosamente considerada já aplicada.
   writeMigrations(eeDir, { "002_ee_same_slot.sql": "CREATE TABLE ee_same_slot (id INTEGER);" });
 
-  const r = await runWithDirs(CORE, `ee=${eeDir}`);
+  const r = runWithExtras(`ee=${eeDir}`);
 
   assert.ok(r.tables.includes("core_two"), "a core 002 deve ter rodado");
   assert.ok(r.tables.includes("ee_same_slot"), "a extra 002 deve ter rodado também");
@@ -161,13 +157,13 @@ await test("o mesmo número em core e em diretório extra NÃO colide — ambas 
   );
 });
 
-await test("dois namespaces extras coexistem, cada um no seu espaço de versão", async () => {
-  const a = mkTempDir("omniroute-nsa-");
-  const b = mkTempDir("omniroute-nsb-");
+test("dois namespaces extras coexistem, cada um no seu espaço de versão", async () => {
+  const a = mkTempDir("mig-nsa-");
+  const b = mkTempDir("mig-nsb-");
   writeMigrations(a, { "001_from_a.sql": "CREATE TABLE from_a (id INTEGER);" });
   writeMigrations(b, { "001_from_b.sql": "CREATE TABLE from_b (id INTEGER);" });
 
-  const r = await runWithDirs(CORE, `ee=${a}${path.delimiter}lab=${b}`);
+  const r = runWithExtras(`ee=${a}${path.delimiter}lab=${b}`);
 
   assert.ok(r.tables.includes("from_a") && r.tables.includes("from_b"));
   assert.deepEqual(
@@ -176,60 +172,60 @@ await test("dois namespaces extras coexistem, cada um no seu espaço de versão"
   );
 });
 
-await test("número duplicado DENTRO de um namespace extra é erro (não pode ser pulado em silêncio)", async () => {
-  const eeDir = mkTempDir("omniroute-ee-dup-");
+test("número duplicado DENTRO de um namespace extra é erro (não pode ser pulado em silêncio)", async () => {
+  const eeDir = mkTempDir("mig-dup-");
   writeMigrations(eeDir, {
     "003_first.sql": "CREATE TABLE ee_first (id INTEGER);",
     "003_second.sql": "CREATE TABLE ee_second (id INTEGER);",
   });
 
-  await assert.rejects(
-    () => runWithDirs(CORE, `ee=${eeDir}`),
+  assert.throws(
+    () => runWithExtras(`ee=${eeDir}`),
     /collision/i,
     "duas migrations com o mesmo número no mesmo namespace têm que estourar"
   );
 });
 
-await test("spec malformada estoura em vez de ignorar o diretório", async () => {
-  const eeDir = mkTempDir("omniroute-ee-malformed-");
+test("spec malformada estoura em vez de ignorar o diretório", async () => {
+  const eeDir = mkTempDir("mig-malformed-");
   writeMigrations(eeDir, { "001_x.sql": "CREATE TABLE x (id INTEGER);" });
 
-  await assert.rejects(
-    () => runWithDirs(CORE, eeDir), // sem "namespace="
+  assert.throws(
+    () => runWithExtras(eeDir), // sem "namespace="
     /OMNIROUTE_EXTRA_MIGRATIONS_DIRS/,
     "entrada sem namespace= é configuração inválida, não um diretório a ignorar"
   );
 });
 
-await test("namespace inválido estoura (só minúsculas/dígitos, começando por letra)", async () => {
-  const eeDir = mkTempDir("omniroute-ee-badns-");
+test("namespace inválido estoura (só minúsculas/dígitos, começando por letra)", async () => {
+  const eeDir = mkTempDir("mig-badns-");
   writeMigrations(eeDir, { "001_x.sql": "CREATE TABLE x (id INTEGER);" });
 
-  await assert.rejects(
-    () => runWithDirs(CORE, `EE Corp=${eeDir}`),
+  assert.throws(
+    () => runWithExtras(`EE Corp=${eeDir}`),
     /namespace/i,
     "namespace fora de [a-z][a-z0-9]* tem que estourar"
   );
 });
 
-await test("diretório configurado que não existe estoura (schema faltando em silêncio é o bug)", async () => {
-  const missing = path.join(os.tmpdir(), `omniroute-nao-existe-${Date.now()}`);
-  await assert.rejects(
-    () => runWithDirs(CORE, `ee=${missing}`),
-    /does not exist|não existe|not exist/i,
+test("diretório configurado que não existe estoura (schema faltando em silêncio é o bug)", async () => {
+  const missing = path.join(os.tmpdir(), `mig-nao-existe-${process.pid}`);
+  assert.throws(
+    () => runWithExtras(`ee=${missing}`),
+    /does not exist/i,
     "um diretório explicitamente configurado e ausente é erro de configuração"
   );
 });
 
-await test("arquivos que não casam NNN_nome.sql são ignorados, como no diretório core", async () => {
-  const eeDir = mkTempDir("omniroute-ee-junk-");
+test("arquivos que não casam NNN_nome.sql são ignorados, como no diretório core", async () => {
+  const eeDir = mkTempDir("mig-junk-");
   writeMigrations(eeDir, {
     "001_ok.sql": "CREATE TABLE ee_ok (id INTEGER);",
     "README.md": "# não é migration",
     "rascunho.sql": "CREATE TABLE nope (id INTEGER);",
   });
 
-  const r = await runWithDirs(CORE, `ee=${eeDir}`);
+  const r = runWithExtras(`ee=${eeDir}`);
 
   assert.ok(r.tables.includes("ee_ok"));
   assert.ok(!r.tables.includes("nope"), "arquivo .sql sem prefixo numérico não deve rodar");
@@ -239,69 +235,48 @@ await test("arquivos que não casam NNN_nome.sql são ignorados, como no diretó
   );
 });
 
-await test("diretório core ausente não impede as migrations dos extras", async () => {
+test("diretório core ausente não impede as migrations dos extras", async () => {
   // O runner devolve [] assim que MIGRATIONS_DIR não existe. Os extras são um
   // conjunto independente: um core ausente não pode fazê-los desaparecer em
   // silêncio — é a mesma falha de "schema some sem avisar" que isto previne.
+  // MIGRATIONS_DIR é lido a cada chamada por fs.existsSync, então basta remover
+  // o diretório durante o teste e recriá-lo depois.
   const eeDir = mkTempDir("mig-extra-only-");
   writeMigrations(eeDir, { "001_ee_solo.sql": "CREATE TABLE ee_solo (id INTEGER);" });
-  const missingCore = path.join(os.tmpdir(), `mig-core-ausente-${process.pid}-${Date.now()}`);
 
-  const prevCore = process.env.OMNIROUTE_MIGRATIONS_DIR;
-  const prevExtra = process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-  const prevBackup = process.env.DISABLE_SQLITE_AUTO_BACKUP;
-  process.env.OMNIROUTE_MIGRATIONS_DIR = missingCore;
-  process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = `ee=${eeDir}`;
-  process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
-
-  const db = new Database(":memory:");
+  const backup = fs.readdirSync(CORE_DIR).map((f) => ({
+    name: f,
+    body: fs.readFileSync(path.join(CORE_DIR, f), "utf-8"),
+  }));
+  fs.rmSync(CORE_DIR, { recursive: true, force: true });
   try {
-    const { runMigrations } = await importFreshRunner();
-    runMigrations(db as never, { isNewDb: true });
-    const tables = (
-      db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{
-        name: string;
-      }>
-    ).map((r) => r.name);
-    assert.ok(tables.includes("ee_solo"), `tabelas: ${tables.join(", ")}`);
+    const r = runWithExtras(`ee=${eeDir}`);
+    assert.ok(r.tables.includes("ee_solo"), `tabelas: ${r.tables.join(", ")}`);
+    assert.deepEqual(
+      r.rows.map((x) => x.version),
+      ["ee-001"]
+    );
   } finally {
-    db.close();
-    if (prevCore === undefined) delete process.env.OMNIROUTE_MIGRATIONS_DIR;
-    else process.env.OMNIROUTE_MIGRATIONS_DIR = prevCore;
-    if (prevExtra === undefined) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-    else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = prevExtra;
-    if (prevBackup === undefined) delete process.env.DISABLE_SQLITE_AUTO_BACKUP;
-    else process.env.DISABLE_SQLITE_AUTO_BACKUP = prevBackup;
+    fs.mkdirSync(CORE_DIR, { recursive: true });
+    for (const f of backup) fs.writeFileSync(path.join(CORE_DIR, f.name), f.body, "utf-8");
   }
 });
 
-await test("rodar duas vezes não reaplica as migrations do diretório extra", async () => {
-  const eeDir = mkTempDir("omniroute-ee-idem-");
+test("rodar duas vezes não reaplica as migrations do diretório extra", async () => {
+  const eeDir = mkTempDir("mig-idem-");
   writeMigrations(eeDir, { "001_ee_idem.sql": "CREATE TABLE ee_idem (id INTEGER);" });
-  const coreDir = mkTempDir("omniroute-core-idem-");
-  writeMigrations(coreDir, CORE);
 
-  const prevCore = process.env.OMNIROUTE_MIGRATIONS_DIR;
-  const prevExtra = process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-  const prevBackup = process.env.DISABLE_SQLITE_AUTO_BACKUP;
-  process.env.OMNIROUTE_MIGRATIONS_DIR = coreDir;
+  const prev = process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
   process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = `ee=${eeDir}`;
-  process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
-
   const db = new Database(":memory:");
   try {
-    const { runMigrations } = await importFreshRunner();
     const first = runMigrations(db as never, { isNewDb: true });
     const second = runMigrations(db as never);
     assert.equal(first, 3, "primeira execução aplica core 001/002 + ee-001");
     assert.equal(second, 0, "segunda execução não tem nada pendente");
   } finally {
     db.close();
-    if (prevCore === undefined) delete process.env.OMNIROUTE_MIGRATIONS_DIR;
-    else process.env.OMNIROUTE_MIGRATIONS_DIR = prevCore;
-    if (prevExtra === undefined) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
-    else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = prevExtra;
-    if (prevBackup === undefined) delete process.env.DISABLE_SQLITE_AUTO_BACKUP;
-    else process.env.DISABLE_SQLITE_AUTO_BACKUP = prevBackup;
+    if (prev === undefined) delete process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS;
+    else process.env.OMNIROUTE_EXTRA_MIGRATIONS_DIRS = prev;
   }
 });


### PR DESCRIPTION
Conserta duas falhas que **eu introduzi no #8770** e que estão vermelhas no `release/v3.8.49`.

## 1. Contrato env/docs

`OMNIROUTE_EXTRA_MIGRATIONS_DIRS` foi documentada no `ENVIRONMENT.md` mas nunca adicionada ao `.env.example`. Derrubou o gate **Docs Gates** e dois testes: `check-env-doc-sync` e `issue-7793-env-doc-sync-repro`.

## 2. O teste passava local e falhava no CI

Duas causas, ambas só visíveis sob a invocação do CI — que eu não usei para validar. Erro de método meu.

**(a) Re-import com cache-buster.** O teste re-importava `migrationRunner.ts` com query string para pegar um `MIGRATIONS_DIR` novo a cada caso. Isso não é confiável sob a cadeia de loaders do CI (`--import tsx/esm --import setupPolyfill --import isolateDataDir`): o segundo caso recebia um runner ainda apontado para o diretório **real** de migrations e tentava aplicar a `127_usage_history_account_identity` num banco em memória vazio —

```
[Migration] FAILED: 127_usage_history_account_identity — no such column: account_key
✖ migration de diretório extra é aplicada e gravada com versão namespaced
```

Agora o diretório core é fixado **uma vez, antes do primeiro import**, e só os diretórios extras variam por caso — que é exatamente o que o desenho já resolvia em tempo de chamada.

**(b) `await` no topo com corpos síncronos.** Depois de tornar os corpos síncronos, cada `await test(...)` drenava o event loop entre os casos e o `--test-force-exit` (usado por todos os scripts de teste do CI) cancelava o resto do arquivo — `cancelled 1`. Os testes agora são registrados sem `await`.

Ambas as restrições ficaram escritas no cabeçalho do arquivo para a próxima edição não reintroduzi-las.

## Validação

Com a invocação **exata** do CI, não com o runner cru:

```
ℹ pass 11   ℹ fail 0   ℹ cancelled 0
```

Vizinhas verdes sob as mesmas flags: `db-migration-runner` (26), `check-migration-numbering` (15), `db-migrationrunner-constants-split` (7), `db-migration-version-uniqueness` (2), `check-env-doc-sync` (13), `issue-7793-env-doc-sync-repro` (1).
