### PR TITLE
[v3.8.50] fix(open-sse): filter non-numeric values in comboTargetLimits before min calculation

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1705,14 +1705,19 @@ export async function handleChatCore({
             comboConfig as unknown as { name: string; models: unknown[] },
             allCombosData as unknown as { name: string; models: unknown[] }[]
           );
-          comboTargetLimits = targets.map((t: { modelStr?: string; provider?: string }) =>
-            // Fall back to ResolvedComboTarget.provider when modelStr lacks a
-            // provider/ prefix — parseModel alone returns provider:null (#8716).
-            getComboTargetTokenLimit({
-              modelStr: t.modelStr,
-              provider: t.provider,
-            })
-          );
+          comboTargetLimits = targets
+            .map((t: { modelStr?: string; provider?: string }) =>
+              // Fall back to ResolvedComboTarget.provider when modelStr lacks a
+              // provider/ prefix — parseModel alone returns provider:null (#8716).
+              getComboTargetTokenLimit({
+                modelStr: t.modelStr,
+                provider: t.provider,
+              })
+            )
+            .filter(
+              (limit): limit is number =>
+                typeof limit === "number" && Number.isFinite(limit) && limit > 0
+            );
         }
         // chatCore executes per concrete target (handleSingleModel resolves
         // provider/effectiveModel before delegating). Compress against THIS

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1705,14 +1705,11 @@ export async function handleChatCore({
             comboConfig as unknown as { name: string; models: unknown[] },
             allCombosData as unknown as { name: string; models: unknown[] }[]
           );
+          // Fall back to ResolvedComboTarget.provider when modelStr lacks a
+          // provider/ prefix — parseModel alone returns provider:null (#8716).
           comboTargetLimits = targets
             .map((t: { modelStr?: string; provider?: string }) =>
-              // Fall back to ResolvedComboTarget.provider when modelStr lacks a
-              // provider/ prefix — parseModel alone returns provider:null (#8716).
-              getComboTargetTokenLimit({
-                modelStr: t.modelStr,
-                provider: t.provider,
-              })
+              getComboTargetTokenLimit({ modelStr: t.modelStr, provider: t.provider })
             )
             .filter(
               (limit): limit is number =>

--- a/tests/unit/resolveComboContextLimit.test.ts
+++ b/tests/unit/resolveComboContextLimit.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveComboContextLimit } from "../../open-sse/services/contextManager.ts";
+
+test("resolveComboContextLimit handles array of combo target objects ({ name, models }) in comboTargetLimits", () => {
+  const result = resolveComboContextLimit({
+    provider: "unknown_provider",
+    model: "unknown_model",
+    comboTargetLimits: [
+      { name: "subcombo1", models: [{ provider: "openai", model: "gpt-4" }] },
+      { name: "subcombo2", models: [{ provider: "anthropic", model: "claude-3-5-sonnet" }] },
+    ] as unknown as number[],
+  });
+
+  // Default fallback limit for unknown provider should be returned without throwing NaN or crash
+  assert.equal(typeof result.limit, "number");
+  assert.ok(!Number.isNaN(result.limit));
+  assert.ok(result.limit > 0);
+  assert.equal(result.source, "fallback");
+});
+


### PR DESCRIPTION
## Summary
Filters non-numeric values in comboTargetLimits before min calculation.