### PR TITLE
fix(electron): strip stale native modules from NEXT_DIST_DIR, not hardcoded .next

### DIFF
--- a/scripts/build/prepare-electron-standalone.mjs
+++ b/scripts/build/prepare-electron-standalone.mjs
@@ -83,6 +83,24 @@ function removeNativeModules(baseDir, prefixes = ["keytar"]) {
   }
 }
 
+// Fail the build if hashed native copies survived the cleanup above. Without this,
+// a wrong baseDir makes removeNativeModules() a silent no-op (it early-returns when
+// the directory does not exist) and the ABI mismatch only surfaces at runtime on a
+// user machine as "Internal Server Error" on every route.
+function assertNoStaleHashedNatives(baseDir, prefixes) {
+  if (!existsSync(baseDir)) return;
+  const leftovers = readdirSync(baseDir).filter((dir) =>
+    prefixes.some((p) => dir.startsWith(p))
+  );
+  if (leftovers.length > 0) {
+    throw new Error(
+      `[electron] stale native module copies survived cleanup in ${baseDir}: ` +
+        `${leftovers.join(", ")}. These carry the plain-Node ABI and shadow the ` +
+        `Electron-rebuilt binaries at runtime (ERR_DLOPEN_FAILED -> sql.js fallback -> OOM).`
+    );
+  }
+}
+
 // --- Electron-UNIQUE: rebuild better-sqlite3 against the Electron ABI --------
 //
 // The `npm ci` at the repo root compiles better-sqlite3 for the CI *Node* ABI
@@ -197,7 +215,16 @@ removeGeneratedElectronArtifacts();
 // so it cannot shadow the rebuilt one.
 rebuildBetterSqlite3ForElectron(join(ELECTRON_STANDALONE_DIR, "node_modules"));
 removeNativeModules(join(ELECTRON_STANDALONE_DIR, "node_modules"), ["keytar"]);
-removeNativeModules(join(ELECTRON_STANDALONE_DIR, ".next", "node_modules"), [
+removeNativeModules(join(ELECTRON_STANDALONE_DIR, NEXT_DIST_DIR, "node_modules"), [
+  "better-sqlite3",
+  "keytar",
+]);
+
+// Post-condition: the cleanup above must actually have removed the stale Node-ABI
+// copies. It silently no-opped across releases because the path was hardcoded to
+// ".next" while distDir is ".build/next", so an ABI-mismatched better_sqlite3.node
+// shipped inside the installer and the app fell back to sql.js and OOM-ed.
+assertNoStaleHashedNatives(join(ELECTRON_STANDALONE_DIR, NEXT_DIST_DIR, "node_modules"), [
   "better-sqlite3",
   "keytar",
 ]);


### PR DESCRIPTION
Fixes the packaging defect behind the recurring "Internal Server Error on every route" reports on the Electron desktop build.

Reported with full forensics in #8792. Supersedes the abandoned #7123 (closed unmerged, `CONFLICTING`).

## The bug

`prepare-electron-standalone.mjs` strips stale native module copies after rebuilding `better-sqlite3` for the Electron ABI, but the cleanup call hardcodes `".next"`:

```js
const NEXT_DIST_DIR = process.env.NEXT_DIST_DIR || ".build/next";   // line 14
...
removeNativeModules(join(ELECTRON_STANDALONE_DIR, ".next", "node_modules"), [   // line 200
  "better-sqlite3",
  "keytar",
]);
```

The real `distDir` is `.build/next`. Since `removeNativeModules()` early-returns when the directory does not exist, **the cleanup silently no-ops** and the plain-Node-ABI copy produced by `next build` ships inside the installer.

The intent was already documented in the surrounding comment — only the path was wrong:

> *"also drop any stray Node-ABI better-sqlite3 under .next/node_modules so it cannot shadow the rebuilt one."*

## Runtime impact

The standalone server runs under `ELECTRON_RUN_AS_NODE`, so it needs the Electron ABI (148 for electron 43), but gets the Node one (137):

```
ERR_DLOPEN_FAILED
  -> "Nenhum driver SQLite disponível ... better-sqlite3 (falhou)"
  -> fallback to sql.js (WASM)
  -> "Database closed" reconnect loop, WASM memory never reclaimed
  -> "[DB] Out of memory while probing storage.sqlite"
  -> HTTP 500 on /, /api/health, /v1/models
```

Verified on a clean install of v3.8.48 (Windows 11, Electron 43.1.0). Auditing every `.node` in the package by `require()`-ing it inside the app's own Electron runtime showed exactly one mismatch:

```
<app>\.build\next\node_modules\better-sqlite3-90e2652d1716b047\...\better_sqlite3.node  FAILED  built_for_NMV=137
<app>\.build\next\node_modules\keytar-eb44cd511463a26b\...\keytar.node                  OK      built_for_NMV=148
<app>\.build\next\node_modules\wreq-js-3b69dd5e46bd26d3\...\wreq-js.win32-x64-msvc.node OK      built_for_NMV=148
<app>\node_modules\better-sqlite3\build\Release\better_sqlite3.node                     OK      built_for_NMV=148
```

Overwriting the bundled copy with the correctly-built one that already ships in the same package restores the app immediately: HTTP 200 within ~2s, zero OOM entries, real `/v1/messages` completions succeed.

## Changes

1. **`removeNativeModules(... NEXT_DIST_DIR ...)`** instead of the hardcoded `".next"`.
2. **`assertNoStaleHashedNatives()`** — throws if any hashed native copies survive the cleanup.

The second change is the reason this PR is not a one-liner. The failure mode here is a *silent* no-op: a wrong `baseDir` produces a green build and a broken installer, and the mismatch only surfaces on a user machine after their DB grows enough that `sql.js` can no longer load it. That is why this has regressed at least twice:

| | ABI | Issue |
|---|---|---|
| Apr 2026 | 127 vs 145 | #1497 |
| Jul 2026 | 137 vs 148 | #7082, #7681, #8792 |

With the assertion, a wrong path fails the build instead of shipping.

## Notes

- No behaviour change when the cleanup already works — the assertion is a no-op on a correct build.
- `assertNoStaleHashedNatives()` reuses `existsSync` / `readdirSync`, already imported in this file.
- Syntax validated with `node --check`.
- I could not run the full Electron packaging pipeline locally, so I would appreciate a CI run on this branch to confirm the build passes end to end.

Refs #7082, #7681, #1497, #8792.
