### PR TITLE
fix(combo): fail open when strict context filter empties unknown-only pools (#8786)

### DIFF
--- a/docs/combo-context-requirements.md
+++ b/docs/combo-context-requirements.md
@@ -51,7 +51,7 @@ Add `contextRequirements` to your combo's runtime config:
 - **Type**: `"strict"` | `"lenient"`
 - **Default**: `"lenient"`
 - **Description**: How to handle models with unknown context window limits
-  - `"strict"`: Excludes models with unknown context limits
+  - `"strict"`: Excludes models with unknown context limits when a known-good target remains; fail-opens to unknowns if the pool would otherwise be empty (#8786)
   - `"lenient"`: Includes models with unknown context limits
 
 ## Behavior
@@ -77,8 +77,13 @@ When `minContextWindow` is set:
 **Strict mode**:
 
 - ✅ Includes models with context >= minContextWindow
-- ❌ Excludes models with unknown context limits
+- ❌ Excludes models with unknown context limits (when at least one known-good target remains)
 - ❌ Excludes models with context < minContextWindow
+- ⚠️ **Fail-open (#8786)**: if strict filtering would empty the pool and at least one
+  unknown-context target exists, those unknowns are restored instead of returning
+  `404 Combo has no executable targets`. Known-too-small targets are never resurrected.
+  When the pool is still empty (every known target is below `minContextWindow`), the
+  API returns `terminalReason: "context_requirements_exhausted"` with a recovery hint.
 
 ### Sorting Logic
 

--- a/open-sse/services/combo/contextRequirements.ts
+++ b/open-sse/services/combo/contextRequirements.ts
@@ -30,6 +30,10 @@ function getTargetContextWindow(target: ResolvedComboTarget): number | null {
  * - contextFilterMode determines handling of unknown context limits:
  *   - "strict": excludes models with unknown context limits
  *   - "lenient": includes models with unknown context limits
+ * - #8786 fail-open: when "strict" would empty the pool and at least one
+ *   unknown-context target exists, restore those unknowns instead of returning
+ *   [] (which becomes a false 404 "no executable targets"). Known-too-small
+ *   targets are never resurrected.
  *
  * Sorting logic:
  * - If preferLargeContext is true, sorts remaining targets by context size (descending)
@@ -58,17 +62,39 @@ export function applyContextRequirements(
   if (minContextWindow && minContextWindow > 0) {
     const beforeFilterCount = filtered.length;
 
-    filtered = filtered.filter((target) => {
-      const contextWindow = getTargetContextWindow(target);
+    const classified = filtered.map((target) => ({
+      target,
+      contextWindow: getTargetContextWindow(target),
+    }));
 
-      // Unknown context limit handling
-      if (contextWindow === null) {
-        return contextFilterMode === "lenient";
+    filtered = classified
+      .filter(({ contextWindow }) => {
+        // Unknown context limit handling
+        if (contextWindow === null) {
+          return contextFilterMode === "lenient";
+        }
+
+        // Known context limit - check threshold
+        return contextWindow >= minContextWindow;
+      })
+      .map(({ target }) => target);
+
+    // #8786: strict must not turn an otherwise-executable combo into an empty
+    // pool solely because the capability catalog lacks context metadata. When
+    // no known-good target survives, fail open to the unknown-context set
+    // (same spirit as the request-compat context fail-open path).
+    if (filtered.length === 0 && beforeFilterCount > 0 && contextFilterMode === "strict") {
+      const unknowns = classified
+        .filter(({ contextWindow }) => contextWindow === null)
+        .map(({ target }) => target);
+      if (unknowns.length > 0) {
+        log.warn(
+          "COMBO",
+          `Context requirements: strict mode would empty the pool (${beforeFilterCount} targets, none known >= ${minContextWindow}); failing open to ${unknowns.length} unknown-context target(s)`
+        );
+        filtered = unknowns;
       }
-
-      // Known context limit - check threshold
-      return contextWindow >= minContextWindow;
-    });
+    }
 
     if (filtered.length < beforeFilterCount) {
       log.info(

--- a/open-sse/services/combo/pinRecovery.ts
+++ b/open-sse/services/combo/pinRecovery.ts
@@ -47,6 +47,12 @@ export function buildRecoveryHint(
         next_step:
           "This combo has no executable targets in the current account pool. Pick a different combo or reconnect the missing providers.",
       };
+    case "context_requirements_exhausted":
+      return {
+        action: "switch-combo",
+        next_step:
+          "Strict context requirements removed every target (known context windows are below minContextWindow). Lower minContextWindow, switch contextFilterMode to lenient, or add larger-context models.",
+      };
     default:
       return {
         action: "retry",
@@ -69,5 +75,49 @@ export function buildNoUpstreamResponseDiagnostics(poolSize: number): ComboDiagn
     excluded: [],
     attemptOrder: [],
     terminalReason: "no_upstream_response",
+  };
+}
+
+/**
+ * #8786: empty-pool payload after `applyContextRequirements`. When the
+ * pre-filter pool was non-empty, surface `context_requirements_exhausted`
+ * (with excluded targets) instead of a generic `no_executable_targets` 404.
+ * Lives here so combo.ts / targetResolution stay under the file-size freeze.
+ */
+export function buildEmptyComboTargetsPayload(
+  preContextTargets: ReadonlyArray<{ provider: string; modelStr: string }>,
+  minContextWindow?: number
+): { message: string; diagnostics: ComboDiagnostics } {
+  if (preContextTargets.length > 0) {
+    const minCtxLabel =
+      typeof minContextWindow === "number" && minContextWindow > 0
+        ? ` (minContextWindow: ${minContextWindow})`
+        : "";
+    return {
+      message: `Combo has no executable targets after context requirements filtering${minCtxLabel}`,
+      diagnostics: {
+        poolSize: preContextTargets.length,
+        attempted: 0,
+        excluded: preContextTargets.map((t) => ({
+          provider: t.provider,
+          model: t.modelStr,
+          reason: "context_requirements",
+        })),
+        attemptOrder: [],
+        terminalReason: "context_requirements_exhausted",
+        recovery: buildRecoveryHint("context_requirements_exhausted"),
+      },
+    };
+  }
+  return {
+    message: "Combo has no executable targets",
+    diagnostics: {
+      poolSize: 0,
+      attempted: 0,
+      excluded: [],
+      attemptOrder: [],
+      terminalReason: "no_executable_targets",
+      recovery: buildRecoveryHint("no_executable_targets"),
+    },
   };
 }

--- a/open-sse/services/combo/targetResolution.ts
+++ b/open-sse/services/combo/targetResolution.ts
@@ -54,7 +54,7 @@ import {
 import { applyContextRequirements } from "./contextRequirements.ts";
 import { recordComboFailure } from "./failureTracker.ts";
 import { getKnownContextOverflow } from "./knownContextOverflow.ts";
-import { buildRecoveryHint } from "./pinRecovery.ts";
+import { buildEmptyComboTargetsPayload, buildRecoveryHint } from "./pinRecovery.ts";
 import {
   applyPromptCacheAffinity,
   expandPromptCacheAffinityTargets,
@@ -447,6 +447,8 @@ async function orderByStrategy(
  * May return `{ earlyResponse }` when hard capability filters (#8488 / #8494) empty
  * the pool — tools / vision / structured_output fail closed as 400 capability_mismatch
  * unless `compatFilterFailOpen` is set on the combo config or settings.
+ * Also returns `{ earlyResponse }` for #8786 when context requirements leave no
+ * survivors (`context_requirements_exhausted`).
  */
 async function applyContinuityFilters(
   deps: ResolveComboTargetPipelineDeps,
@@ -518,7 +520,26 @@ async function applyContinuityFilters(
       };
     }
   }
+  // #8786: capture pre-filter pool so a strict/minContextWindow wipe can
+  // surface context_requirements_exhausted instead of a generic 404.
+  const preContextTargets = orderedTargets;
   orderedTargets = applyContextRequirements(orderedTargets, config.contextRequirements, log);
+  if (orderedTargets.length === 0 && preContextTargets.length > 0) {
+    const effectiveSessionId: string | null = combo.context_cache_protection
+      ? (relayOptions?.sessionId ?? null)
+      : null;
+    recordComboFailure(effectiveSessionId, combo.name);
+    const { message, diagnostics } = buildEmptyComboTargetsPayload(
+      preContextTargets,
+      config.contextRequirements?.minContextWindow
+    );
+    return {
+      earlyResponse: errorResponseWithComboDiagnostics(404, message, diagnostics, {
+        code: "model_not_found",
+        type: "invalid_request_error",
+      }),
+    };
+  }
   return { orderedTargets, sticky };
 }
 

--- a/tests/unit/combo/context-requirements-integration.test.ts
+++ b/tests/unit/combo/context-requirements-integration.test.ts
@@ -13,27 +13,33 @@ const mockLog = {
 
 describe("Context Requirements Integration", () => {
   it("should filter and sort targets with full context requirements", () => {
+    // Mix a catalog-known model (gpt-4o ~128k) with unknowns so strict mode has
+    // at least one known-good survivor and does not fail-open to the unknowns.
     const targets = [
-      { modelStr: "gpt-3.5-turbo", provider: "openai", weight: 1 },
-      { modelStr: "gpt-4", provider: "openai", weight: 1 },
-      { modelStr: "gpt-4-turbo", provider: "openai", weight: 1 },
-      { modelStr: "claude-3-opus-20240229", provider: "anthropic", weight: 1 },
-      { modelStr: "gemini-1.5-pro", provider: "google", weight: 1 },
+      { modelStr: "gpt-4o", provider: "openai", weight: 1 },
+      { modelStr: "unknown-small-8786", provider: "custom", weight: 1 },
+      { modelStr: "another-unknown-8786", provider: "custom", weight: 1 },
     ];
 
     const requirements = {
-      minContextWindow: 100000,
+      minContextWindow: 32000,
       preferLargeContext: true,
       contextFilterMode: "strict" as const,
     };
 
     const result = applyContextRequirements(targets, requirements, mockLog);
-    // Should filter out models with <100k context and, in strict mode, also drop
-    // models whose context window is unknown in the current catalog snapshot.
     assert.ok(result.length < targets.length);
     assert.ok(
       result.every((target) => targets.some((original) => original.modelStr === target.modelStr)),
       "Filtered targets should be a subset of the original list"
+    );
+    assert.ok(
+      result.some((t) => t.modelStr === "gpt-4o"),
+      "Known-good gpt-4o should survive minContextWindow=32k"
+    );
+    assert.ok(
+      !result.some((t) => t.modelStr.includes("unknown")),
+      "Unknowns stay excluded when a known-good target remains"
     );
   });
 
@@ -61,7 +67,7 @@ describe("Context Requirements Integration", () => {
 
   it("should handle lenient mode with unknown context models", () => {
     const targets = [
-      { modelStr: "gpt-4", provider: "openai", weight: 1 },
+      { modelStr: "gpt-4o", provider: "openai", weight: 1 },
       { modelStr: "unknown-model", provider: "custom", weight: 1 },
     ];
 
@@ -80,8 +86,9 @@ describe("Context Requirements Integration", () => {
   });
 
   it("should handle strict mode with unknown context models", () => {
+    // Known-good survivor required — otherwise #8786 fail-open would restore unknowns.
     const targets = [
-      { modelStr: "claude-3-opus-20240229", provider: "anthropic", weight: 1 },
+      { modelStr: "gpt-4o", provider: "openai", weight: 1 },
       { modelStr: "unknown-model", provider: "custom", weight: 1 },
     ];
 
@@ -92,10 +99,10 @@ describe("Context Requirements Integration", () => {
 
     const result = applyContextRequirements(targets, requirements, mockLog);
 
-    // Should exclude unknown-model in strict mode
     assert.ok(
       !result.some((t) => t.modelStr === "unknown-model"),
-      "Should exclude unknown model in strict mode"
+      "Should exclude unknown model in strict mode when a known-good target remains"
     );
+    assert.ok(result.some((t) => t.modelStr === "gpt-4o"));
   });
 });

--- a/tests/unit/combo/pin-recovery.test.ts
+++ b/tests/unit/combo/pin-recovery.test.ts
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import {
   buildRecoveryHint,
   buildNoUpstreamResponseDiagnostics,
+  buildEmptyComboTargetsPayload,
 } from "../../../open-sse/services/combo/pinRecovery.ts";
 
 test("buildRecoveryHint: reasoning_budget_exhausted maps to switch-combo", () => {
@@ -51,6 +52,12 @@ test("buildRecoveryHint: no_executable_targets maps to switch-combo", () => {
   assert.match(hint.next_step, /no executable targets/);
 });
 
+test("buildRecoveryHint: context_requirements_exhausted maps to switch-combo (#8786)", () => {
+  const hint = buildRecoveryHint("context_requirements_exhausted");
+  assert.equal(hint.action, "switch-combo");
+  assert.match(hint.next_step, /minContextWindow|contextFilterMode|lenient/i);
+});
+
 test("buildRecoveryHint: unknown terminalReason falls back to retry", () => {
   const hint = buildRecoveryHint("some_unrecognized_reason");
   assert.equal(hint.action, "retry");
@@ -72,4 +79,29 @@ test("buildNoUpstreamResponseDiagnostics: zero poolSize is passed through as-is"
   const diag = buildNoUpstreamResponseDiagnostics(0);
   assert.equal(diag.poolSize, 0);
   assert.equal(diag.terminalReason, "no_upstream_response");
+});
+
+test("buildEmptyComboTargetsPayload: pre-filter pool → context_requirements_exhausted (#8786)", () => {
+  const { message, diagnostics } = buildEmptyComboTargetsPayload(
+    [
+      { provider: "openai", modelStr: "gpt-4o" },
+      { provider: "custom", modelStr: "tiny" },
+    ],
+    500000
+  );
+  assert.match(message, /context requirements filtering/);
+  assert.match(message, /minContextWindow: 500000/);
+  assert.equal(diagnostics.terminalReason, "context_requirements_exhausted");
+  assert.equal(diagnostics.poolSize, 2);
+  assert.equal(diagnostics.excluded?.length, 2);
+  assert.equal(diagnostics.excluded?.[0]?.reason, "context_requirements");
+  assert.equal(diagnostics.recovery?.action, "switch-combo");
+});
+
+test("buildEmptyComboTargetsPayload: empty pre-filter pool → generic no_executable_targets", () => {
+  const { message, diagnostics } = buildEmptyComboTargetsPayload([], 128000);
+  assert.equal(message, "Combo has no executable targets");
+  assert.equal(diagnostics.terminalReason, "no_executable_targets");
+  assert.equal(diagnostics.poolSize, 0);
+  assert.deepEqual(diagnostics.excluded, []);
 });

--- a/tests/unit/combo/strict-context-failopen-8786.test.ts
+++ b/tests/unit/combo/strict-context-failopen-8786.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression #8786: strict contextFilterMode must not empty an otherwise-
+ * executable combo pool when every target has an unknown context limit.
+ *
+ * Repro: combo with minContextWindow + contextFilterMode:"strict" whose
+ * targets are missing from the runtime capability catalog → filtered to []
+ * → 404 "Combo has no executable targets", even though dashboard test and
+ * direct model calls succeed. Lenient mode already keeps unknowns.
+ *
+ * Fix: when strict filtering would leave zero targets and at least one
+ * unknown-context target remains, fail open to those unknowns (same spirit
+ * as the request-compat context fail-open path).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-8786-ctx-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../../src/lib/db/core.ts");
+const { getModelContextLimit } = await import("../../../src/lib/modelCapabilities.ts");
+const { applyContextRequirements } = await import(
+  "../../../open-sse/services/combo/contextRequirements.ts"
+);
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function target(provider: string, modelStr: string) {
+  return {
+    kind: "model" as const,
+    stepId: modelStr,
+    executionKey: `${provider}/${modelStr}`,
+    modelStr,
+    provider,
+    providerId: null,
+    connectionId: null,
+    weight: 1,
+    label: null,
+  };
+}
+
+const noopLog = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+const UNKNOWN_TARGETS = [
+  target("custom-unknown-8786", "codex-proxy-model"),
+  target("custom-unknown-8786", "glm-proxy-model"),
+  target("custom-unknown-8786", "minimax-proxy-model"),
+  target("custom-unknown-8786", "deepseek-proxy-model"),
+];
+
+test("catalog sanity: fixture models have unknown context limits", () => {
+  for (const t of UNKNOWN_TARGETS) {
+    assert.equal(
+      getModelContextLimit(t.provider, t.modelStr),
+      null,
+      `${t.provider}/${t.modelStr} must be unknown in the catalog for this regression`
+    );
+  }
+});
+
+test("#8786: strict mode with ALL-unknown targets fails open instead of emptying the pool", () => {
+  const warnings: string[] = [];
+  const log = {
+    ...noopLog,
+    warn(_tag: string, msg: string) {
+      warnings.push(msg);
+    },
+  };
+
+  const result = applyContextRequirements(
+    UNKNOWN_TARGETS,
+    {
+      minContextWindow: 372000,
+      preferLargeContext: true,
+      contextFilterMode: "strict",
+    },
+    log
+  );
+
+  assert.equal(
+    result.length,
+    UNKNOWN_TARGETS.length,
+    "strict+all-unknown must fail open to the original unknown targets, not return []"
+  );
+  assert.deepEqual(
+    result.map((t) => t.modelStr),
+    UNKNOWN_TARGETS.map((t) => t.modelStr)
+  );
+  assert.ok(
+    warnings.some((w) => /failing open|unknown-context/i.test(w)),
+    "must log a fail-open warning so operators can see strict degraded to unknowns"
+  );
+});
+
+test("#8786: strict mode still drops unknowns when at least one known-good target remains", () => {
+  // gpt-4o ships in the static capability catalog (~128k); keep threshold below that.
+  const knownOk = target("openai", "gpt-4o");
+  const unknown = target("custom-unknown-8786", "ghost-model");
+
+  assert.ok(
+    (getModelContextLimit(knownOk.provider, knownOk.modelStr) ?? 0) >= 32000,
+    "known fixture must clear minContextWindow"
+  );
+  assert.equal(getModelContextLimit(unknown.provider, unknown.modelStr), null);
+
+  const result = applyContextRequirements(
+    [knownOk, unknown],
+    {
+      minContextWindow: 32000,
+      contextFilterMode: "strict",
+    },
+    noopLog
+  );
+
+  assert.deepEqual(
+    result.map((t) => t.modelStr),
+    [knownOk.modelStr],
+    "unknowns stay excluded in strict mode when a known-good target exists"
+  );
+});
+
+test("#8786: strict mode with only known-below-threshold targets stays empty (no false fail-open)", () => {
+  const small = target("openai", "gpt-4o"); // 128k
+  const result = applyContextRequirements(
+    [small],
+    {
+      minContextWindow: 500000,
+      contextFilterMode: "strict",
+    },
+    noopLog
+  );
+  assert.equal(result.length, 0, "known-too-small must not be resurrected");
+});
+
+test("#8786: strict mode with known-below + unknowns fails open to unknowns only", () => {
+  const small = target("openai", "gpt-4o"); // 128k < 372k
+  const unknown = target("custom-unknown-8786", "maybe-large-model");
+
+  const result = applyContextRequirements(
+    [small, unknown],
+    {
+      minContextWindow: 372000,
+      contextFilterMode: "strict",
+    },
+    noopLog
+  );
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].modelStr, unknown.modelStr);
+});
+
+test("#8786: lenient mode still includes unknowns (unchanged)", () => {
+  const result = applyContextRequirements(
+    UNKNOWN_TARGETS.slice(0, 2),
+    {
+      minContextWindow: 372000,
+      contextFilterMode: "lenient",
+    },
+    noopLog
+  );
+  assert.equal(result.length, 2);
+});


### PR DESCRIPTION
## Summary
- Fixes #8786: `contextFilterMode: "strict"` no longer empties an otherwise-executable combo pool when every target has an unknown context limit in the capability catalog (false `404 Combo has no executable targets`).
- Strict filtering now fail-opens to unknown-context targets when no known-good survivor remains; known-too-small models are never resurrected.
- When the pool is still empty after filtering, returns `terminalReason: "context_requirements_exhausted"` with a recovery hint instead of a generic no-targets 404.

## Test plan
- [x] `node --import tsx/esm --test tests/unit/combo/strict-context-failopen-8786.test.ts`
- [x] `node --import tsx/esm --test tests/unit/combo/pin-recovery.test.ts tests/unit/combo/context-requirements-integration.test.ts tests/unit/combo-context-requirements.test.ts`
- [ ] Manual: configure a combo with `minContextWindow` + `contextFilterMode: "strict"` whose targets lack catalog context metadata; `/v1/chat/completions` should route instead of 404; lower threshold with a known-too-small-only pool should still return `context_requirements_exhausted`.