### PR TITLE
fix(api): treat cx/* and codex/* as equivalent API-key model permissions

### DIFF
--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -17,6 +17,7 @@ import {
 } from "./apiKeyUsageLimitFields";
 import { setNoLog } from "../compliance/noLog";
 import { resolveModelAlias } from "@omniroute/open-sse/services/modelDeprecation.ts";
+import { getProviderAlias, resolveProviderId } from "@/shared/constants/providers";
 import { getSyncedAvailableModelsByConnection, getCustomModels, getModelIsHidden } from "./models";
 import {
   CLAUDE_CODE_PROVIDER_PREFIXES,
@@ -24,6 +25,7 @@ import {
   stripExtendedContextSuffix,
   isPotentialUnprefixedClaudeCodeModel,
   addModelCandidate,
+  addProviderAliasScopedCandidates,
   modelPatternMatches,
   hasClaudeCodeWildcardPermission,
   matchesWildcardPattern,
@@ -306,6 +308,15 @@ async function getModelPermissionCandidates(modelId: string): Promise<string[]> 
       addModelCandidate(candidates, providerScopedModel);
       addModelCandidate(candidates, `cc/${providerScopedModel}`);
       addModelCandidate(candidates, `claude/${providerScopedModel}`);
+    }
+    if (providerScopedModel) {
+      addProviderAliasScopedCandidates(
+        candidates,
+        providerOrAlias,
+        providerScopedModel,
+        resolveProviderId,
+        getProviderAlias
+      );
     }
     return Array.from(candidates);
   }

--- a/src/lib/db/apiKeys/modelPermissions.ts
+++ b/src/lib/db/apiKeys/modelPermissions.ts
@@ -39,6 +39,29 @@ export function addModelCandidate(candidates: Set<string>, modelId: string): voi
   candidates.add(stripExtendedContextSuffix(clean));
 }
 
+/**
+ * Expand provider-scoped model ids with canonical provider id + public alias forms
+ * (e.g. codex/gpt-5.6-terra ↔ cx/gpt-5.6-terra) so API-key allow/block patterns match
+ * dashboard restrictions regardless of which prefix the client sends.
+ */
+export function addProviderAliasScopedCandidates(
+  candidates: Set<string>,
+  providerOrAlias: string,
+  providerScopedModel: string,
+  resolveProviderId: (aliasOrId: string) => string,
+  getProviderAlias: (providerId: string) => string
+): void {
+  if (!providerScopedModel) return;
+  const canonicalId = resolveProviderId(providerOrAlias);
+  const alias = getProviderAlias(canonicalId);
+  if (canonicalId !== providerOrAlias) {
+    addModelCandidate(candidates, `${canonicalId}/${providerScopedModel}`);
+  }
+  if (alias !== providerOrAlias && alias !== canonicalId) {
+    addModelCandidate(candidates, `${alias}/${providerScopedModel}`);
+  }
+}
+
 export function modelPatternMatches(pattern: string, candidates: string[]): boolean {
   for (const candidate of candidates) {
     if (pattern === candidate) return true;

--- a/tests/unit/apikeys-model-permissions-split.test.ts
+++ b/tests/unit/apikeys-model-permissions-split.test.ts
@@ -16,6 +16,7 @@ test("module exposes the matching helpers + Claude-Code alias sets", () => {
     "hasClaudeCodeWildcardPermission",
     "isPotentialUnprefixedClaudeCodeModel",
     "addModelCandidate",
+    "addProviderAliasScopedCandidates",
     "stripExtendedContextSuffix",
   ]) {
     assert.equal(typeof (M as Record<string, unknown>)[name], "function", `missing ${name}`);

--- a/tests/unit/db-apiKeys-crud.test.ts
+++ b/tests/unit/db-apiKeys-crud.test.ts
@@ -272,6 +272,43 @@ test("isModelAllowedForKey wildcard match", async () => {
   assert.equal(await apiKeys.isModelAllowedForKey(created.key, "gpt-4"), false);
 });
 
+test("isModelAllowedForKey treats cx and codex provider prefixes as equivalent (allowed cx, request codex)", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("Codex Alias Allow Cx", "ma-cx-001");
+  await apiKeys.updateApiKeyPermissions(created.id, { allowedModels: ["cx/gpt-5.6-terra"] });
+  apiKeys.resetApiKeyState();
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "codex/gpt-5.6-terra"), true);
+});
+
+test("isModelAllowedForKey treats cx and codex provider prefixes as equivalent (allowed codex, request cx)", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("Codex Alias Allow Codex", "ma-cx-002");
+  await apiKeys.updateApiKeyPermissions(created.id, { allowedModels: ["codex/gpt-5.6-terra"] });
+  apiKeys.resetApiKeyState();
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "cx/gpt-5.6-terra"), true);
+});
+
+test("isModelAllowedForKey cx wildcard allows codex-prefixed model variants", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("Codex Wildcard", "ma-cx-003");
+  await apiKeys.updateApiKeyPermissions(created.id, { allowedModels: ["cx/gpt-5.6-terra*"] });
+  apiKeys.resetApiKeyState();
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "codex/gpt-5.6-terra-high"), true);
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "openai/gpt-5.6-terra"), false);
+});
+
+test("isModelAllowedForKey blockedModels treats cx and codex provider prefixes as equivalent", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("Codex Block Alias", "ma-cx-004");
+  await apiKeys.updateApiKeyPermissions(created.id, {
+    allowedModels: ["codex/*"],
+    blockedModels: ["cx/gpt-5.6-terra"],
+  });
+  apiKeys.resetApiKeyState();
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "codex/gpt-5.6-terra"), false);
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "codex/gpt-5.6-other"), true);
+});
+
 // ──────────────── updateApiKeyPermissions ────────────────
 
 test("updateApiKeyPermissions updates name", async () => {


### PR DESCRIPTION
## Summary
- Dashboard Codex restrictions use the public `cx/` alias, while `/v1/responses` normalizes bare Codex model IDs to `codex/` before API-key permission checks.
- Expand `getModelPermissionCandidates` via the provider registry alias map so `cx/*` and `codex/*` match for both `allowedModels` and `blockedModels`.
- Adds regression coverage for allow/block alias equivalence and wildcard patterns.

Closes #8803

## Test plan
- [x] `node --import tsx/esm --test tests/unit/db-apiKeys-crud.test.ts`
- [x] `node --import tsx/esm --test tests/unit/apikeys-model-permissions-split.test.ts`
- [ ] Restrict an API key to `cx/gpt-5.6-terra` in the Dashboard, then `POST /v1/responses` with bare `gpt-5.6-terra` (or `codex/gpt-5.6-terra`) and confirm 200 instead of 403
- [ ] Confirm `openai/gpt-5.6-terra` remains denied when only `cx/gpt-5.6-terra*` is allowed