### PR TITLE
fix(sse): pass real response payload into plugin onResponse hooks

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -4554,7 +4554,14 @@ export async function handleChatCore({
     // #8395: the streaming branch below already calls this; the non-streaming
     // (stream:false) branch returned without it, so onResponse never fired for
     // non-streaming requests at all.
-    await runPluginOnResponseHook({ requestId: traceId, body, model, provider, apiKeyInfo });
+    await runPluginOnResponseHook({
+      requestId: traceId,
+      body,
+      model,
+      provider,
+      apiKeyInfo,
+      response: { status: 200, data: translatedResponse },
+    });
 
     return {
       success: true,
@@ -4937,7 +4944,14 @@ export async function handleChatCore({
   await emitRequestGamificationEvent({ apiKeyId: apiKeyInfo?.id, model, provider });
 
   // ── Plugin onResponse hook (fire-and-forget) ──
-  await runPluginOnResponseHook({ requestId: traceId, body, model, provider, apiKeyInfo });
+  await runPluginOnResponseHook({
+    requestId: traceId,
+    body,
+    model,
+    provider,
+    apiKeyInfo,
+    response: { status: 200, streamed: true },
+  });
 
   return {
     success: true,

--- a/open-sse/handlers/chatCore/pluginOnResponse.ts
+++ b/open-sse/handlers/chatCore/pluginOnResponse.ts
@@ -3,10 +3,20 @@
  * #3501).
  *
  * Extracted from handleChatCore's streaming finalization: runs the registered plugin `onResponse`
- * hooks for a completed (status 200) response. Fire-and-forget and fail-open — the inner run is
- * not awaited and both the dynamic import and the run swallow their own errors, so a misbehaving
- * plugin never affects the response. Behaviour is byte-identical to the previous inline block.
+ * hooks for a completed response. Fire-and-forget and fail-open — the inner run is not awaited
+ * and both the dynamic import and the run swallow their own errors, so a misbehaving plugin never
+ * affects the response. Non-streaming callers pass the translated JSON body as `data`; streaming
+ * callers pass `{ streamed: true }` because the SSE body is not materialized yet (#8711).
  */
+
+/** Payload passed to plugin onResponse hooks from chatCore success paths. */
+export type PluginOnResponsePayload = {
+  status: number;
+  /** Client-facing JSON body (non-streaming only). */
+  data?: unknown;
+  /** True when the handler returns an SSE stream whose body is not yet available. */
+  streamed?: boolean;
+};
 
 export async function runPluginOnResponseHook(args: {
   requestId: string;
@@ -14,6 +24,7 @@ export async function runPluginOnResponseHook(args: {
   model: string | null | undefined;
   provider: string | null | undefined;
   apiKeyInfo: unknown;
+  response: PluginOnResponsePayload;
 }): Promise<void> {
   try {
     const { runOnResponse } = await import("@/lib/plugins/hooks");
@@ -26,7 +37,7 @@ export async function runPluginOnResponseHook(args: {
         apiKeyInfo: args.apiKeyInfo,
         metadata: {},
       },
-      { status: 200 }
+      args.response
     ).catch(() => {});
   } catch (_) {
     /* plugin onResponse optional */

--- a/tests/unit/8395-plugin-hooks-fire.test.ts
+++ b/tests/unit/8395-plugin-hooks-fire.test.ts
@@ -132,13 +132,9 @@ test("chatCore.ts calls runPluginOnResponseHook from both the non-streaming and 
   );
 
   const nonStreamingReturnIndex = source.indexOf("buildNonStreamingJsonResponse(translatedResponse");
-  const hookCallIndex = source.indexOf(
-    "await runPluginOnResponseHook({ requestId: traceId, body, model, provider, apiKeyInfo });"
-  );
-  const secondHookCallIndex = source.indexOf(
-    "await runPluginOnResponseHook({ requestId: traceId, body, model, provider, apiKeyInfo });",
-    hookCallIndex + 1
-  );
+  const hookCallNeedle = "await runPluginOnResponseHook({";
+  const hookCallIndex = source.indexOf(hookCallNeedle);
+  const secondHookCallIndex = source.indexOf(hookCallNeedle, hookCallIndex + 1);
 
   assert.notEqual(hookCallIndex, -1, "expected at least one runPluginOnResponseHook call site");
   assert.notEqual(
@@ -146,6 +142,14 @@ test("chatCore.ts calls runPluginOnResponseHook from both the non-streaming and 
     -1,
     "expected TWO runPluginOnResponseHook call sites — one per success branch " +
       "(non-streaming JSON return and streaming SSE return)"
+  );
+  assert.ok(
+    source.indexOf("response: { status: 200, data: translatedResponse }") !== -1,
+    "non-streaming branch must pass translatedResponse as plugin response data (#8711)"
+  );
+  assert.ok(
+    source.indexOf("response: { status: 200, streamed: true }") !== -1,
+    "streaming branch must pass streamed:true without materializing SSE body (#8711)"
   );
   assert.ok(
     hookCallIndex < nonStreamingReturnIndex,

--- a/tests/unit/chatcore-plugin-onresponse.test.ts
+++ b/tests/unit/chatcore-plugin-onresponse.test.ts
@@ -1,7 +1,8 @@
 // Characterization of runPluginOnResponseHook — the plugin onResponse hook extracted from
 // handleChatCore's streaming finalization (chatCore god-file decomposition, #3501). Hooks are
-// in-memory (no DB). Locks: a registered onResponse hook receives the request context + status-200
-// response, and the helper is fire-and-forget / fail-open (no registered hooks → no-op).
+// in-memory (no DB). Locks: a registered onResponse hook receives the request context plus the
+// real response payload (status + data or streamed flag), and the helper is fire-and-forget /
+// fail-open (no registered hooks → no-op). #8711: must not hardcode { status: 200 } only.
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
 
@@ -29,16 +30,22 @@ test("no registered hooks → resolves without throwing (no-op)", async () => {
       model: "gpt-x",
       provider: "openai",
       apiKeyInfo: null,
+      response: { status: 200, data: { choices: [] } },
     })
   );
 });
 
-test("registered onResponse hook receives the request context and status-200 response", async () => {
+test("registered onResponse hook receives the request context and response payload (#8711)", async () => {
   let captured: Record<string, unknown> | undefined;
   registerHook("onResponse", "test-onresponse-plugin", async (ctx: Record<string, unknown>) => {
     captured = ctx;
     return {};
   });
+
+  const responseBody = {
+    id: "chatcmpl-test",
+    choices: [{ message: { role: "assistant", content: "hello" } }],
+  };
 
   await runPluginOnResponseHook({
     requestId: "req-42",
@@ -46,6 +53,7 @@ test("registered onResponse hook receives the request context and status-200 res
     model: "gpt-4o",
     provider: "openai",
     apiKeyInfo: { id: "key-1" },
+    response: { status: 200, data: responseBody },
   });
 
   await waitFor(() => captured !== undefined);
@@ -53,7 +61,28 @@ test("registered onResponse hook receives the request context and status-200 res
   assert.equal(captured!.requestId, "req-42");
   assert.equal(captured!.model, "gpt-4o");
   assert.equal(captured!.provider, "openai");
-  assert.deepEqual(captured!.response, { status: 200 });
+  assert.deepEqual(captured!.response, { status: 200, data: responseBody });
+});
+
+test("streaming success path passes streamed flag without materialized body", async () => {
+  let captured: Record<string, unknown> | undefined;
+  registerHook("onResponse", "test-onresponse-plugin", async (ctx: Record<string, unknown>) => {
+    captured = ctx;
+    return {};
+  });
+
+  await runPluginOnResponseHook({
+    requestId: "req-stream",
+    body: { messages: [{ role: "user", content: "hi" }], stream: true },
+    model: "gpt-4o",
+    provider: "openai",
+    apiKeyInfo: null,
+    response: { status: 200, streamed: true },
+  });
+
+  await waitFor(() => captured !== undefined);
+  assert.deepEqual(captured!.response, { status: 200, streamed: true });
+  assert.equal((captured!.response as { data?: unknown }).data, undefined);
 });
 
 test("a throwing hook never rejects the caller (fail-open)", async () => {
@@ -67,6 +96,7 @@ test("a throwing hook never rejects the caller (fail-open)", async () => {
       model: "m",
       provider: "p",
       apiKeyInfo: null,
+      response: { status: 200, data: { ok: true } },
     })
   );
   await new Promise((r) => setTimeout(r, 30));


### PR DESCRIPTION
## Summary
- `runPluginOnResponseHook` always forwarded a hard-coded `{ status: 200 }` stub, so plugins never saw response bodies.
- Non-streaming success paths now pass `{ status: 200, data: translatedResponse }`.
- Streaming success paths pass `{ status: 200, streamed: true }` without materializing/double-reading the SSE body.

Closes #8711

## Test plan
- [x] `node --import tsx/esm --test tests/unit/chatcore-plugin-onresponse.test.ts tests/unit/8395-plugin-hooks-fire.test.ts`
- [x] `node --import tsx/esm --test tests/unit/plugins-hooks.test.ts`
- [ ] Enable request-logger with `includeBody` on a non-streaming chat completion and confirm logged `response.data`
- [ ] Confirm streaming completions still succeed and plugins observe `streamed: true`