### PR TITLE
[TS7] [v3.8.50] refactor(db): preserve normalized combo model types

### DIFF
--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -62,10 +62,10 @@ function normalizeStoredCombo(
   combo: JsonRecord,
   db: ReturnType<typeof getDbInstance>,
   extraNames: string[] = []
-): JsonRecord {
+) {
   return normalizeComboRecord(combo, {
     allCombos: getComboNameSet(db, extraNames),
-  }) as JsonRecord;
+  });
 }
 
 function parseComboRow(row: unknown): JsonRecord | null {


### PR DESCRIPTION
Part of #8484. One erased producer type, four diagnostics, zero new.

## Root cause

`normalizeComboRecord()` already returns a normalized combo whose `models` field is
`ComboStep[]`. `normalizeStoredCombo()` immediately erased that information with both an
explicit `JsonRecord` return type and an `as JsonRecord` assertion. The combo lookup paths
therefore exposed `models` as `unknown`, causing four valid `.length` checks in
`src/sse/services/model.ts` to fail.

This removes only those two type erasures. Runtime behavior is unchanged.

## Diagnostics

Re-measured on `release/v3.8.50` at `371c10ea5f`:

- TypeScript 6.0.3 diagnostics: **125 → 121**
- TypeScript 7.0.2 diagnostics: **124 → 120**
- Canonicalized diagnostic multiset: **4 removed, 0 added**

All four removed diagnostics are `TS2339` reports for `.length` on the erased `models` type
in `src/sse/services/model.ts`.

## Validation

- TypeScript 6.0.3 and 7.0.2 full `open-sse/tsconfig.json` diagnostic comparison
- 21/21 focused combo tests:
  - `tests/unit/combo-id-resolution-4446.test.ts`
  - `tests/unit/combo-bracket-names.test.ts`
  - `tests/unit/db-combos-crud.test.ts`
  - `tests/unit/combo-model-name-collision-8530.test.ts`
- ESLint on `src/lib/db/combos.ts`
- `npm run check:file-size`
- `git diff --check`

The whole-file Prettier check has the same pre-existing failure on the base and patched file,
so this type-only PR deliberately avoids unrelated formatting changes.
