### PR TITLE
fix(types): export session-pool web executor types

### DIFF
--- a/open-sse/services/sessionPool/index.ts
+++ b/open-sse/services/sessionPool/index.ts
@@ -20,9 +20,11 @@ export type {
   PoolConfig,
   PoolStats,
   PoolSessionDetail,
+} from "./types.ts";
+export type {
   WebExecutorFn,
   WebExecutorRequest,
   WebExecutorResponse,
-} from "./types.ts";
+} from "./webExecutorWrapper.ts";
 
 export { DEFAULT_POOL_CONFIG } from "./types.ts";


### PR DESCRIPTION
Part of #8484. One incorrect barrel source, three diagnostics, zero new.

## Root cause

`open-sse/services/sessionPool/index.ts` re-exported `WebExecutorFn`,
`WebExecutorRequest`, and `WebExecutorResponse` from `types.ts`, but those interfaces are
defined and exported by `webExecutorWrapper.ts`.

This points the type-only barrel export at the defining module. Runtime exports and behavior
are unchanged.

## Diagnostics

Measured independently against `release/v3.8.49` at `0eeb8f45c`:

- TypeScript 6 open-sse diagnostics: **150 → 147**
- TypeScript 7.0.2 native diagnostics: **149 → 146**
- Full line-number-agnostic error-set diff: **3 fixed, 0 new**

The three removed diagnostics are the TS2305 missing-export errors for
`WebExecutorFn`, `WebExecutorRequest`, and `WebExecutorResponse`.

With #8809 included, the cumulative projection is **TS6 143 / TS7 142**.

## Validation

- `npm run typecheck:core`
- `node --import tsx/esm --test tests/unit/session-pool.test.ts tests/unit/session-pool-modular.test.ts`
  — **80/80 passed**
- ESLint on `open-sse/services/sessionPool/index.ts`
- `npm run check:file-size`
- Prettier and `git diff --check`

No new runtime test was added because this changes only a type-only export source; the full
TypeScript checks directly verify the corrected barrel contract.
