### PR TITLE
fix(types): preserve reasoning policy record shapes

### DIFF
--- a/src/lib/reasoningRouting/policy.ts
+++ b/src/lib/reasoningRouting/policy.ts
@@ -127,7 +127,7 @@ function detectThinkingBudget(
   thinking: JsonRecord,
   thinkingConfig: JsonRecord
 ): boolean {
-  return [
+  const budgetFields: Array<[JsonRecord, string]> = [
     [thinking, "budget_tokens"],
     [thinking, "budgetTokens"],
     [reasoning, "budget_tokens"],
@@ -137,7 +137,8 @@ function detectThinkingBudget(
     [body, "thinkingBudget"],
     [thinkingConfig, "thinkingBudget"],
     [thinkingConfig, "thinking_budget"],
-  ].some(([record, key]) => hasNumericField(record, key));
+  ];
+  return budgetFields.some(([record, key]) => hasNumericField(record, key));
 }
 
 function hasReasoningSignal(
@@ -503,7 +504,7 @@ export function attachReasoningRuleDirective(
   decision: ReasoningRuleDecision
 ): JsonRecord {
   const source = asRecord(bodyInput);
-  const body = {
+  const body: JsonRecord = {
     ...source,
     model: decision.rule.scope === "connection" ? source.model : decision.targetModel,
   };


### PR DESCRIPTION
Part of #8484. Two widened inference boundaries, three diagnostics, zero new.

## Root cause

`detectThinkingBudget()` built a heterogeneous nested array without a contextual type, so each
destructured pair widened to `string | JsonRecord`. Separately,
`attachReasoningRuleDirective()` inferred its spread result as a closed `{ model: unknown }`
object even though the function deliberately appends internal directive fields and returns a
`JsonRecord`.

This declares the existing contracts at those two boundaries:

- budget-field pairs are `[JsonRecord, string]`
- the directive-bearing body is a `JsonRecord`

Runtime values and routing behavior are unchanged.

## Diagnostics

Measured independently against `release/v3.8.49` at `0eeb8f45c`:

- TypeScript 6 open-sse diagnostics: **150 → 147**
- TypeScript 7.0.2 native diagnostics: **149 → 146**
- Full line-number-agnostic error-set diff: **3 fixed, 0 new**

With #8809 and #8810 included, the cumulative projection is **TS6 140 / TS7 139**.

## Validation

- `npm run typecheck:core`
- Reasoning routing unit, pipeline, and Codex WebSocket tests — **16/16 passed**
- ESLint on `src/lib/reasoningRouting/policy.ts`
- `npm run check:file-size`
- Prettier and `git diff --check`

No new runtime test was added because the values and branches are unchanged, while the existing
tests already cover budget-only intent, directive application, Chat Completions, Responses,
Anthropic Messages, combo filtering, connection rules, and the Codex WebSocket path.
