### PR TITLE
fix(types): preserve compression detail config shapes

### DIFF
--- a/open-sse/services/compression/stepDetailConfig.ts
+++ b/open-sse/services/compression/stepDetailConfig.ts
@@ -12,14 +12,14 @@ import type { CompressionConfig, CompressionPipelineStep } from "./types.ts";
 export function resolveStepDetailConfig(
   engine: CompressionPipelineStep["engine"],
   config: CompressionConfig | undefined
-): Record<string, unknown> {
+) {
   switch (engine) {
     case "headroom":
-      return (config?.headroom as Record<string, unknown> | undefined) ?? {};
+      return config?.headroom ?? {};
     case "session-dedup":
-      return (config?.sessionDedup as Record<string, unknown> | undefined) ?? {};
+      return config?.sessionDedup ?? {};
     case "ccr":
-      return (config?.ccr as Record<string, unknown> | undefined) ?? {};
+      return config?.ccr ?? {};
     default:
       return {};
   }


### PR DESCRIPTION
Part of #8484. Three unnecessary type erasures, three diagnostics, zero new.

## Root cause

`resolveStepDetailConfig()` forced `HeadroomConfig`, `SessionDedupConfig`, and `CcrConfig`
through `Record<string, unknown>` assertions even though its only consumer immediately spreads the
returned detail object into `stepConfig`. These interfaces intentionally have specific fields and
no string index signature, so the assertions triggered TS2352.

This removes the explicit `Record` return annotation and the three assertions, allowing the
existing detail-config union to flow into the spread operation. Returned values and pipeline
behavior are unchanged.

## Diagnostics

Measured independently against `release/v3.8.49` at `0eeb8f45c`:

- TypeScript 6 open-sse diagnostics: **150 → 147**
- TypeScript 7.0.2 native diagnostics: **149 → 146**
- Full line-number-agnostic error-set diff: **3 fixed, 0 new**

With #8809, #8810, and #8811 included, the cumulative projection is
**TS6 137 / TS7 136**.

## Validation

- `npm run typecheck:core`
- Compression detail persistence, Headroom merge, and stacked-pipeline integration tests —
  **14/14 passed**
- ESLint on `open-sse/services/compression/stepDetailConfig.ts`
- `npm run check:file-size`
- Prettier and `git diff --check`

No new runtime test was added because the returned objects and merge order are unchanged, while
the existing focused tests cover all three persisted detail sections and the stacked-pipeline
consumer.
