### PR TITLE
feat(search): add Firecrawl search provider

### DIFF
--- a/changelog.d/features/8814-firecrawl-search.md
+++ b/changelog.d/features/8814-firecrawl-search.md
@@ -1,0 +1,1 @@
+- **feat(search):** add Firecrawl to `POST /v1/search` supported providers with two sources (web|news) ([#8814](https://github.com/diegosouzapw/OmniRoute/pull/8814)) — thanks @allanvb

--- a/open-sse/config/searchRegistry.ts
+++ b/open-sse/config/searchRegistry.ts
@@ -113,6 +113,22 @@ export const SEARCH_PROVIDERS: Record<string, SearchProviderConfig> = {
     cacheTTLMs: 5 * 60 * 1000,
   },
 
+  firecrawl: {
+    id: "firecrawl",
+    name: "Firecrawl",
+    baseUrl: "https://api.firecrawl.dev/v2/search",
+    method: "POST",
+    authType: "apikey",
+    authHeader: "bearer",
+    costPerQuery: 0.002,
+    freeMonthlyQuota: 1000,
+    searchTypes: ["web", "news"],
+    defaultMaxResults: 5,
+    maxMaxResults: 100,
+    timeoutMs: 30_000,
+    cacheTTLMs: 5 * 60 * 1000,
+  },
+
   "google-pse-search": {
     id: "google-pse-search",
     name: "Google Programmable Search",

--- a/open-sse/executors/firecrawl-fetch.ts
+++ b/open-sse/executors/firecrawl-fetch.ts
@@ -4,7 +4,7 @@
  * Fetches content from a URL using the Firecrawl scrape API.
  * POST https://api.firecrawl.dev/v1/scrape
  *
- * Free tier: 500 fetches/month, no credit card required.
+ * Free tier: 1,000 credits/month, no credit card required.
  * Docs: https://docs.firecrawl.dev/api-reference/endpoint/scrape
  *
  * Self-hosted: set FIRECRAWL_BASE_URL to point at a self-hosted Firecrawl

--- a/open-sse/handlers/search.ts
+++ b/open-sse/handlers/search.ts
@@ -19,10 +19,7 @@ import { randomUUID } from "crypto";
 
 import { getSearchProvider, type SearchProviderConfig } from "../config/searchRegistry.ts";
 import { buildPerplexityRequest, parsePerplexitySearchOptions } from "./search/perplexitySearch.ts";
-import {
-  buildFirecrawlSearchRequest,
-  normalizeFirecrawlSearchResponse,
-} from "./search/firecrawlSearch.ts";
+import * as fcSearch from "./search/firecrawlSearch.ts";
 import { freeWebSearch } from "../services/freeWebSearch.ts";
 import { saveCallLog } from "@/lib/usageDb";
 import { safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
@@ -30,8 +27,6 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { z } from "zod";
 import { sanitizeErrorMessage } from "../utils/error.ts";
-
-// ── Types ────────────────────────────────────────────────────────────────
 
 export interface SearchResult {
   title: string;
@@ -605,7 +600,7 @@ function buildRequest(
   if (config.id === "perplexity-search") return buildPerplexityRequest(config, params);
   if (config.id === "exa-search") return buildExaRequest(config, params);
   if (config.id === "tavily-search") return buildTavilyRequest(config, params);
-  if (config.id === "firecrawl") return buildFirecrawlSearchRequest(config, params);
+  if (config.id === "firecrawl") return fcSearch.buildFirecrawlSearchRequest(config, params);
   if (config.id === "google-pse-search") return buildGooglePseRequest(config, params);
   if (config.id === "linkup-search") return buildLinkupRequest(config, params);
   if (config.id === "searchapi-search") return buildSearchApiRequest(config, params);
@@ -1173,9 +1168,7 @@ function normalizeResponse(
   if (providerId === "exa-search") return normalizeExaResponse(data, query, searchType);
   if (providerId === "tavily-search") return normalizeTavilyResponse(data, query, searchType);
   if (providerId === "firecrawl")
-    return normalizeFirecrawlSearchResponse(data, searchType, (item, idx, now) =>
-      makeResult("firecrawl", item, idx, now)
-    );
+    return fcSearch.normalizeFirecrawlSearchResponse(data, searchType, makeResult);
   if (providerId === "google-pse-search")
     return normalizeGooglePseResponse(data, query, searchType);
   if (providerId === "linkup-search") return normalizeLinkupResponse(data, query, searchType);
@@ -1185,9 +1178,6 @@ function normalizeResponse(
   if (providerId === "ollama-search") return normalizeOllamaResponse(data, query, searchType);
   return { results: [], totalResults: null };
 }
-
-// ── Main Handler ────────────────────────────────────────────────────────
-
 export async function handleSearch(options: SearchHandlerOptions): Promise<SearchHandlerResult> {
   const {
     query,

--- a/open-sse/handlers/search.ts
+++ b/open-sse/handlers/search.ts
@@ -3,9 +3,10 @@ import { randomUUID } from "crypto";
  * Search Handler
  *
  * Handles POST /v1/search requests.
- * Routes to 11 search providers with automatic failover:
+ * Routes to search providers with automatic failover:
  *   serper-search, brave-search, perplexity-search, exa-search, tavily-search,
- *   google-pse-search, linkup-search, searchapi-search, youcom-search, searxng-search, ollama-search, zai-search
+ *   firecrawl, google-pse-search, linkup-search, searchapi-search,
+ *   youcom-search, searxng-search, ollama-search, zai-search, duckduckgo-free
  *
  * Request format:
  * {
@@ -18,6 +19,10 @@ import { randomUUID } from "crypto";
 
 import { getSearchProvider, type SearchProviderConfig } from "../config/searchRegistry.ts";
 import { buildPerplexityRequest, parsePerplexitySearchOptions } from "./search/perplexitySearch.ts";
+import {
+  buildFirecrawlSearchRequest,
+  normalizeFirecrawlSearchResponse,
+} from "./search/firecrawlSearch.ts";
 import { freeWebSearch } from "../services/freeWebSearch.ts";
 import { saveCallLog } from "@/lib/usageDb";
 import { safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
@@ -600,6 +605,7 @@ function buildRequest(
   if (config.id === "perplexity-search") return buildPerplexityRequest(config, params);
   if (config.id === "exa-search") return buildExaRequest(config, params);
   if (config.id === "tavily-search") return buildTavilyRequest(config, params);
+  if (config.id === "firecrawl") return buildFirecrawlSearchRequest(config, params);
   if (config.id === "google-pse-search") return buildGooglePseRequest(config, params);
   if (config.id === "linkup-search") return buildLinkupRequest(config, params);
   if (config.id === "searchapi-search") return buildSearchApiRequest(config, params);
@@ -1166,6 +1172,10 @@ function normalizeResponse(
     return normalizePerplexityResponse(data, query, searchType);
   if (providerId === "exa-search") return normalizeExaResponse(data, query, searchType);
   if (providerId === "tavily-search") return normalizeTavilyResponse(data, query, searchType);
+  if (providerId === "firecrawl")
+    return normalizeFirecrawlSearchResponse(data, searchType, (item, idx, now) =>
+      makeResult("firecrawl", item, idx, now)
+    );
   if (providerId === "google-pse-search")
     return normalizeGooglePseResponse(data, query, searchType);
   if (providerId === "linkup-search") return normalizeLinkupResponse(data, query, searchType);

--- a/open-sse/handlers/search/firecrawlSearch.ts
+++ b/open-sse/handlers/search/firecrawlSearch.ts
@@ -1,0 +1,142 @@
+import type { SearchProviderConfig } from "../../config/searchRegistry.ts";
+
+export interface FirecrawlSearchParams {
+  query: string;
+  searchType: string;
+  maxResults: number;
+  token?: string;
+  country?: string;
+  language?: string;
+  timeRange?: string;
+  domainFilter?: string[];
+}
+
+export type FirecrawlNormalizedHit = {
+  title?: string;
+  url?: string;
+  snippet?: string;
+  published_at?: string | null;
+  image_url?: string;
+  source_type?: string;
+};
+
+type FirecrawlSearchHit = {
+  title?: string;
+  url?: string;
+  link?: string;
+  description?: string;
+  snippet?: string;
+  markdown?: string;
+  content?: string;
+  date?: string | null;
+  published_at?: string | null;
+  imageUrl?: string | null;
+  metadata?: {
+    title?: string;
+    sourceURL?: string;
+    publishedTime?: string | null;
+  };
+};
+
+export type FirecrawlSearchEnvelope = {
+  data?: {
+    web?: FirecrawlSearchHit[];
+    news?: FirecrawlSearchHit[];
+  };
+};
+
+function parseDomainFilter(domainFilter?: string[]): { includes: string[]; excludes: string[] } {
+  if (!domainFilter?.length) return { includes: [], excludes: [] };
+  const includes = domainFilter.filter((d) => !d.startsWith("-"));
+  const excludes = domainFilter.filter((d) => d.startsWith("-")).map((d) => d.slice(1));
+  return { includes, excludes };
+}
+
+function firecrawlSearchTbs(timeRange?: string): string | undefined {
+  if (!timeRange || timeRange === "any") return undefined;
+  const map: Record<string, string> = {
+    day: "qdr:d",
+    week: "qdr:w",
+    month: "qdr:m",
+    year: "qdr:y",
+  };
+  return map[timeRange];
+}
+
+export function buildFirecrawlSearchRequest(
+  config: SearchProviderConfig,
+  params: FirecrawlSearchParams
+): { url: string; init: RequestInit } {
+  const envBase = process.env.FIRECRAWL_BASE_URL?.trim().replace(/\/+$/, "");
+  const url = envBase ? `${envBase}/v2/search` : config.baseUrl;
+  const { includes, excludes } = parseDomainFilter(params.domainFilter);
+  const source = params.searchType === "news" ? "news" : "web";
+
+  const body: Record<string, unknown> = {
+    query: params.query,
+    limit: params.maxResults,
+    sources: [source],
+  };
+  if (params.country) body.country = params.country.toLowerCase();
+  if (params.language) body.lang = params.language;
+  const tbs = firecrawlSearchTbs(params.timeRange);
+  if (tbs) body.tbs = tbs;
+  if (includes.length) body.includeDomains = includes.map((d) => d.toLowerCase());
+  if (excludes.length) body.excludeDomains = excludes.map((d) => d.toLowerCase());
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (params.token) {
+    headers.Authorization = `Bearer ${params.token}`;
+  }
+
+  return {
+    url,
+    init: {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+  };
+}
+
+function pickFirecrawlSearchItems(
+  data: FirecrawlSearchEnvelope,
+  searchType: string
+): FirecrawlSearchHit[] {
+  const buckets = data?.data;
+  if (!buckets || Array.isArray(buckets)) return [];
+  const items = searchType === "news" ? buckets.news : buckets.web;
+  return Array.isArray(items) ? items : [];
+}
+
+export function collectFirecrawlSearchHits(
+  data: FirecrawlSearchEnvelope,
+  searchType: string
+): FirecrawlNormalizedHit[] {
+  const isNews = searchType === "news";
+  return pickFirecrawlSearchItems(data, searchType).map((item) => ({
+    title: item.title || item.metadata?.title || "",
+    url: item.url || item.metadata?.sourceURL || item.link || "",
+    snippet:
+      item.description ||
+      item.snippet ||
+      item.markdown?.slice(0, 300) ||
+      item.content?.slice(0, 300) ||
+      "",
+    published_at: item.date || item.published_at || item.metadata?.publishedTime || null,
+    image_url: item.imageUrl || undefined,
+    source_type: isNews ? "news" : undefined,
+  }));
+}
+
+export function normalizeFirecrawlSearchResponse<T>(
+  data: FirecrawlSearchEnvelope,
+  searchType: string,
+  mapHit: (item: FirecrawlNormalizedHit, idx: number, now: string) => T
+): { results: T[]; totalResults: number | null } {
+  const now = new Date().toISOString();
+  const results = collectFirecrawlSearchHits(data, searchType).map((item, idx) =>
+    mapHit(item, idx, now)
+  );
+  return { results, totalResults: results.length };
+}

--- a/open-sse/handlers/search/firecrawlSearch.ts
+++ b/open-sse/handlers/search/firecrawlSearch.ts
@@ -132,11 +132,11 @@ export function collectFirecrawlSearchHits(
 export function normalizeFirecrawlSearchResponse<T>(
   data: FirecrawlSearchEnvelope,
   searchType: string,
-  mapHit: (item: FirecrawlNormalizedHit, idx: number, now: string) => T
+  makeResult: (providerId: string, item: FirecrawlNormalizedHit, idx: number, now: string) => T
 ): { results: T[]; totalResults: number | null } {
   const now = new Date().toISOString();
   const results = collectFirecrawlSearchHits(data, searchType).map((item, idx) =>
-    mapHit(item, idx, now)
+    makeResult("firecrawl", item, idx, now)
   );
   return { results, totalResults: results.length };
 }

--- a/open-sse/services/firecrawlQuotaFetcher.ts
+++ b/open-sse/services/firecrawlQuotaFetcher.ts
@@ -1,7 +1,7 @@
 /**
  * firecrawlQuotaFetcher.ts — Firecrawl team credit quota
  *
- * Live credit pool for the `firecrawl` connection (web fetch + firecrawl-search).
+ * Live credit pool for the `firecrawl` connection (web fetch + search).
  *
  * Endpoint:
  *   GET https://api.firecrawl.dev/v2/team/credit-usage

--- a/src/app/api/search/providers/route.ts
+++ b/src/app/api/search/providers/route.ts
@@ -30,7 +30,7 @@ const FETCH_PROVIDERS: FetchProviderDef[] = [
     id: "firecrawl",
     name: "Firecrawl",
     costPerQuery: 0.002,
-    freeMonthlyQuota: 500,
+    freeMonthlyQuota: 1000,
     fetchFormats: ["markdown", "html", "links", "screenshot"],
   },
   {

--- a/src/shared/constants/providers/apikey/specialty-media.ts
+++ b/src/shared/constants/providers/apikey/specialty-media.ts
@@ -257,21 +257,6 @@ export const APIKEY_PROVIDERS_SPECIALTY = {
     freeNote: "Free-tier API key via signup, no credit card required.",
     authHint: "Bearer API key for the Mixedbread embeddings API.",
   },
-  firecrawl: {
-    id: "firecrawl",
-    alias: "fc",
-    name: "Firecrawl",
-    icon: "language",
-    color: "#FB923C",
-    textIcon: "FC",
-    website: "https://firecrawl.dev",
-    hasFree: true,
-    notice: {
-      text: "Free tier: 500 fetches/month, no credit card needed.",
-      apiKeyUrl: "https://firecrawl.dev/app/api-keys",
-    },
-    serviceKinds: ["webFetch"],
-  },
   "jina-reader": {
     id: "jina-reader",
     alias: "jr",

--- a/src/shared/constants/providers/search.ts
+++ b/src/shared/constants/providers/search.ts
@@ -60,6 +60,21 @@ export const SEARCH_PROVIDERS = {
     authHint: "API key from app.tavily.com (format: tvly-...)",
     serviceKinds: ["webSearch", "webFetch"],
   },
+  firecrawl: {
+    id: "firecrawl",
+    alias: "fc",
+    name: "Firecrawl",
+    icon: "language",
+    color: "#FB923C",
+    textIcon: "FC",
+    website: "https://firecrawl.dev",
+    hasFree: true,
+    notice: {
+      text: "Free tier: 1,000 credits/month. Powers /v1/web/fetch and /v1/search.",
+      apiKeyUrl: "https://firecrawl.dev/app/api-keys",
+    },
+    serviceKinds: ["webSearch", "webFetch"],
+  },
   "google-pse-search": {
     id: "google-pse-search",
     alias: "google-pse",

--- a/src/shared/validation/schemas/apiV1.ts
+++ b/src/shared/validation/schemas/apiV1.ts
@@ -283,6 +283,7 @@ export const v1SearchSchema = z
         "perplexity-search",
         "exa-search",
         "tavily-search",
+        "firecrawl",
         "google-pse-search",
         "linkup-search",
         "ollama-search",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -204,6 +204,7 @@
       "tests/unit/headroom-codex-quota-snapshot-6379.test.ts",
       "tests/unit/headroom-proxy-lifecycle.test.ts",
       "tests/unit/idempotency-fusion-collision.test.ts",
+      "tests/unit/isLocalStreamLifecycleError-abort-shape.test.ts",
       "tests/unit/issue-6343-v0-web-alias-collision.test.ts",
       "tests/unit/issue-6638-ollama-quota.test.ts",
       "tests/unit/issue-6686-quota-preflight-coverage.test.ts",

--- a/tests/integration/search-providers-catalog.test.ts
+++ b/tests/integration/search-providers-catalog.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for GET /api/search/providers — extended catalog (F4).
  *
  * Tests:
- * - Returns 16 items total (13 search + 3 fetch providers).
+ * - Returns 18 items total (14 search + 4 fetch providers).
  * - Each item carries the correct `kind` field.
  * - Status reflects actual DB credential state:
  *   - "configured"  when an active, non-rate-limited connection exists.
@@ -48,10 +48,10 @@ const route = await import("../../src/app/api/search/providers/route.ts");
 // Constants
 // ---------------------------------------------------------------------------
 
-// 13 search-kind providers: serper, brave, perplexity, exa, tavily, google-pse,
-// linkup, searchapi, youcom, searxng, ollama, zai + duckduckgo-free (added in the
-// v3.8.27 cycle, registry open-sse/config/searchRegistry.ts).
-const EXPECTED_SEARCH_COUNT = 13;
+// 14 search-kind providers: serper, brave, perplexity, exa, tavily, firecrawl,
+// google-pse, linkup, searchapi, youcom, searxng, ollama, zai + duckduckgo-free
+// (registry open-sse/config/searchRegistry.ts).
+const EXPECTED_SEARCH_COUNT = 14;
 const EXPECTED_FETCH_COUNT = 4;
 const EXPECTED_TOTAL = EXPECTED_SEARCH_COUNT + EXPECTED_FETCH_COUNT;
 
@@ -295,7 +295,7 @@ test("search-providers-catalog: fetch providers have correct metadata", async ()
   const firecrawl = fetchProviders.find((p: { id: string }) => p.id === "firecrawl");
   assert.equal(firecrawl.name, "Firecrawl");
   assert.equal(firecrawl.costPerQuery, 0.002);
-  assert.equal(firecrawl.freeMonthlyQuota, 500);
+  assert.equal(firecrawl.freeMonthlyQuota, 1000);
   assert.ok(Array.isArray(firecrawl.fetchFormats), "fetchFormats must be an array");
   assert.ok(
     firecrawl.fetchFormats.includes("markdown"),
@@ -348,6 +348,14 @@ test("search-providers-catalog: search providers have correct fields", async () 
   assert.ok(serper, "serper-search must be in search providers");
   assert.ok(serper.searchTypes.includes("web"), "serper must support web search");
   assert.equal(serper.kind, "search");
+
+  const firecrawlSearch = searchProviders.find((p: { id: string }) => p.id === "firecrawl");
+  assert.ok(firecrawlSearch, "firecrawl must be in search providers");
+  assert.equal(firecrawlSearch.kind, "search");
+  assert.equal(firecrawlSearch.costPerQuery, 0.002);
+  assert.equal(firecrawlSearch.freeMonthlyQuota, 1000);
+  assert.ok(firecrawlSearch.searchTypes.includes("web"), "firecrawl must support web");
+  assert.ok(firecrawlSearch.searchTypes.includes("news"), "firecrawl must support news");
 });
 
 test("search-providers-catalog: response validates against SearchProviderCatalogResponseSchema", async () => {

--- a/tests/unit/firecrawl-search.test.ts
+++ b/tests/unit/firecrawl-search.test.ts
@@ -36,6 +36,15 @@ test("firecrawl is registered and selects cleanly", () => {
   assert.equal(selectedNews?.id, "firecrawl");
 });
 
+test("dashboard resolves firecrawl under search category", async () => {
+  const providerPageUtils =
+    await import("../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts");
+  const providers = await import("../../src/shared/constants/providers.ts");
+  const info = providerPageUtils.resolveDashboardProviderInfo("firecrawl");
+  assert.equal(info?.category, "search");
+  assert.equal(info?.name, providers.SEARCH_PROVIDERS.firecrawl.name);
+});
+
 test("v1SearchSchema accepts firecrawl for search (unified id)", () => {
   const ok = v1SearchSchema.safeParse({ query: "q", provider: "firecrawl" });
   assert.equal(ok.success, true);

--- a/tests/unit/firecrawl-search.test.ts
+++ b/tests/unit/firecrawl-search.test.ts
@@ -1,0 +1,292 @@
+/**
+ * tests/unit/firecrawl-search.test.ts
+ *
+ * Firecrawl as a unified /v1/search + /v1/web/fetch provider id `firecrawl`:
+ * - registry entry id `firecrawl` (no firecrawl-search split, no credential fallback)
+ * - request builder uses Firecrawl POST /v2/search + sources web|news
+ * - FIRECRAWL_BASE_URL self-host root (same env as firecrawl-fetch)
+ * - response normalization for v2 buckets only (data.web / data.news)
+ * - handleSearch path with mocked fetch
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { SEARCH_PROVIDERS, SEARCH_CREDENTIAL_FALLBACKS, getSearchProvider, selectProvider } =
+  await import("../../open-sse/config/searchRegistry.ts");
+const { handleSearch } = await import("../../open-sse/handlers/search.ts");
+const { v1SearchSchema } = await import("../../src/shared/validation/schemas.ts");
+
+test("firecrawl is registered and selects cleanly", () => {
+  const cfg = getSearchProvider("firecrawl");
+  assert.ok(cfg, "firecrawl must exist in SEARCH_PROVIDERS");
+  assert.equal(cfg!.id, "firecrawl");
+  assert.equal(cfg!.method, "POST");
+  assert.equal(cfg!.authType, "apikey");
+  assert.equal(cfg!.authHeader, "bearer");
+  assert.equal(cfg!.baseUrl, "https://api.firecrawl.dev/v2/search");
+  assert.equal(cfg!.costPerQuery, 0.002);
+  assert.equal(cfg!.freeMonthlyQuota, 1000);
+  assert.deepEqual(cfg!.searchTypes, ["web", "news"]);
+  assert.equal(SEARCH_CREDENTIAL_FALLBACKS["firecrawl"], undefined);
+
+  const selectedWeb = selectProvider("firecrawl", "web");
+  assert.equal(selectedWeb?.id, "firecrawl");
+  const selectedNews = selectProvider("firecrawl", "news");
+  assert.equal(selectedNews?.id, "firecrawl");
+});
+
+test("v1SearchSchema accepts firecrawl for search (unified id)", () => {
+  const ok = v1SearchSchema.safeParse({ query: "q", provider: "firecrawl" });
+  assert.equal(ok.success, true);
+  const news = v1SearchSchema.safeParse({
+    query: "q",
+    provider: "firecrawl",
+    search_type: "news",
+  });
+  assert.equal(news.success, true);
+  const legacy = v1SearchSchema.safeParse({ query: "q", provider: "firecrawl-search" });
+  assert.equal(legacy.success, false, "legacy firecrawl-search id is not accepted");
+});
+
+test("handleSearch firecrawl hits /v2/search with sources web and normalizes data.web", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedInit: RequestInit | undefined;
+
+  globalThis.fetch = async (url, init) => {
+    capturedUrl = String(url);
+    capturedInit = init;
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          web: [
+            {
+              url: "https://example.com/a",
+              title: "Alpha",
+              description: "First hit",
+            },
+            {
+              url: "https://example.com/b",
+              title: "Beta",
+              description: "Second hit",
+            },
+          ],
+          news: [
+            {
+              url: "https://news.example/ignored-on-web",
+              title: "Ignored",
+              snippet: "news bucket must not leak into web",
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const result = await handleSearch({
+      query: "omniroute search",
+      provider: "firecrawl",
+      maxResults: 5,
+      searchType: "web",
+      credentials: { apiKey: "fc-test-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
+    assert.equal(capturedUrl, "https://api.firecrawl.dev/v2/search");
+    const headers = capturedInit?.headers as Record<string, string>;
+    assert.equal(headers.Authorization, "Bearer fc-test-key");
+    const body = JSON.parse(String(capturedInit?.body || "{}"));
+    assert.equal(body.query, "omniroute search");
+    assert.equal(body.limit, 5);
+    assert.deepEqual(body.sources, ["web"]);
+
+    assert.ok(result.data?.results?.length === 2);
+    assert.equal(result.data!.results[0].title, "Alpha");
+    assert.equal(result.data!.results[0].url, "https://example.com/a");
+    assert.equal(result.data!.results[0].snippet, "First hit");
+    assert.equal(result.data!.provider, "firecrawl");
+    assert.equal(result.data!.usage.search_cost_usd, 0.002);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleSearch firecrawl maps search_type news to sources news", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedInit: RequestInit | undefined;
+
+  globalThis.fetch = async (_url, init) => {
+    capturedInit = init;
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          news: [
+            {
+              title: "Breaking",
+              url: "https://news.example/story",
+              snippet: "Headline blurb",
+              date: "2026-07-01T12:00:00Z",
+              imageUrl: "https://news.example/img.png",
+            },
+          ],
+          web: [
+            {
+              url: "https://web.example/ignored-on-news",
+              title: "Web only",
+              description: "must not leak into news",
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const result = await handleSearch({
+      query: "latest ai",
+      provider: "firecrawl",
+      maxResults: 3,
+      searchType: "news",
+      timeRange: "week",
+      country: "US",
+      language: "en",
+      domainFilter: ["reuters.com", "-example.com"],
+      credentials: { apiKey: "fc-news-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true, JSON.stringify(result));
+    const body = JSON.parse(String(capturedInit?.body || "{}"));
+    assert.deepEqual(body.sources, ["news"]);
+    assert.equal(body.tbs, "qdr:w");
+    assert.equal(body.country, "us");
+    assert.equal(body.lang, "en");
+    assert.deepEqual(body.includeDomains, ["reuters.com"]);
+    assert.deepEqual(body.excludeDomains, ["example.com"]);
+
+    assert.equal(result.data!.results.length, 1);
+    assert.equal(result.data!.results[0].title, "Breaking");
+    assert.equal(result.data!.results[0].url, "https://news.example/story");
+    assert.equal(result.data!.results[0].snippet, "Headline blurb");
+    assert.equal(result.data!.results[0].published_at, "2026-07-01T12:00:00Z");
+    assert.equal(result.data!.results[0].metadata?.image_url, "https://news.example/img.png");
+    assert.equal(result.data!.results[0].metadata?.source_type, "news");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleSearch firecrawl honors FIRECRAWL_BASE_URL self-host root", async () => {
+  const originalFetch = globalThis.fetch;
+  const prev = process.env.FIRECRAWL_BASE_URL;
+  process.env.FIRECRAWL_BASE_URL = "http://127.0.0.1:3002";
+  let capturedUrl = "";
+
+  globalThis.fetch = async (url) => {
+    capturedUrl = String(url);
+    return new Response(
+      JSON.stringify({
+        data: { web: [{ url: "https://local.test", title: "Local", description: "ok" }] },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const result = await handleSearch({
+      query: "selfhost",
+      provider: "firecrawl",
+      maxResults: 3,
+      searchType: "web",
+      credentials: { apiKey: "optional-selfhost" },
+      log: null,
+    });
+
+    assert.equal(result.success, true, JSON.stringify(result));
+    assert.equal(capturedUrl, "http://127.0.0.1:3002/v2/search");
+    assert.equal(result.data!.results[0].title, "Local");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (prev === undefined) delete process.env.FIRECRAWL_BASE_URL;
+    else process.env.FIRECRAWL_BASE_URL = prev;
+  }
+});
+
+test("handleSearch firecrawl ignores legacy v1 envelopes", async () => {
+  const originalFetch = globalThis.fetch;
+  let call = 0;
+
+  globalThis.fetch = async () => {
+    call += 1;
+    if (call === 1) {
+      return new Response(
+        JSON.stringify({
+          data: [{ url: "https://d.example", title: "D", description: "from data array" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    if (call === 2) {
+      return new Response(
+        JSON.stringify({
+          results: [{ url: "https://r.example", title: "R", snippet: "from results" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        web: [{ url: "https://w.example", title: "W", description: "from web" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const fromData = await handleSearch({
+      query: "data-shape",
+      provider: "firecrawl",
+      maxResults: 1,
+      searchType: "web",
+      credentials: { apiKey: "fc-key" },
+      log: null,
+    });
+    assert.equal(fromData.success, true, JSON.stringify(fromData));
+    assert.equal(fromData.data!.results.length, 0);
+
+    const fromResults = await handleSearch({
+      query: "results-shape",
+      provider: "firecrawl",
+      maxResults: 1,
+      searchType: "web",
+      credentials: { apiKey: "fc-key" },
+      log: null,
+    });
+    assert.equal(fromResults.success, true, JSON.stringify(fromResults));
+    assert.equal(fromResults.data!.results.length, 0);
+
+    const fromWeb = await handleSearch({
+      query: "web-shape",
+      provider: "firecrawl",
+      maxResults: 1,
+      searchType: "web",
+      credentials: { apiKey: "fc-key" },
+      log: null,
+    });
+    assert.equal(fromWeb.success, true, JSON.stringify(fromWeb));
+    assert.equal(fromWeb.data!.results.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("SEARCH_PROVIDERS still exposes duckduckgo-free as fallbackOnly", () => {
+  assert.equal(SEARCH_PROVIDERS["duckduckgo-free"].fallbackOnly, true);
+});

--- a/tests/unit/providers-constants-split.test.ts
+++ b/tests/unit/providers-constants-split.test.ts
@@ -1,7 +1,7 @@
 // Characterization of the providers.ts catalog split (god-file decomposition): the host became a
 // barrel that re-exports 10 data catalogs now living under constants/providers/*, and APIKEY is
 // merged from 6 semantic family files (apikey/<family>.ts). Locks: the public surface (every catalog
-// + helpers still exported), the spread-merge integrity (195 APIKEY entries, no loss/dup), and that
+// + helpers still exported), the spread-merge integrity (194 APIKEY entries, no loss/dup), and that
 // load-time Zod validation still runs. Pure-data move → behavior must be identical.
 // Count was 171 before obsolete provider removals (PR #6675: glhf/kluster/cablyai/inclusionai etc.,
 // 171->167) plus #6126 (ClinePass dual-auth): the API-key-only APIKEY_PROVIDERS_GATEWAYS entry was
@@ -15,7 +15,8 @@
 // #7887 (5 free-tier providers: ainative/aion/sealion/routeway/nara) to 187, then #8077 (clova-studio/
 // internlm/ant-ling, all regional) to 190, then #8161 (sarvam/writer/plamo — writer in frontier-labs,
 // sarvam+plamo in regional) to 193, then #8170 (inception/typhoon — inception in frontier-labs,
-// typhoon in regional) to 195.
+// typhoon in regional) to 195, then Firecrawl dual search+fetch under SEARCH_PROVIDERS.firecrawl
+// (removed specialty-media duplicate) to 194.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -44,12 +45,12 @@ test("barrel still exports every catalog + key helpers", () => {
   }
 });
 
-test("APIKEY_PROVIDERS merges the 6 family files into 195 entries (no loss / no dup)", async () => {
+test("APIKEY_PROVIDERS merges the 6 family files into 194 entries (no loss / no dup)", async () => {
   const keys = Object.keys((P as Record<string, object>).APIKEY_PROVIDERS);
-  assert.equal(keys.length, 195);
-  assert.equal(new Set(keys).size, 195, "duplicate keys after spread-merge");
+  assert.equal(keys.length, 194);
+  assert.equal(new Set(keys).size, 194, "duplicate keys after spread-merge");
   // the merged object's entry-count equals the sum of the 6 semantic family files; families are a
-  // strict partition (every provider in exactly one), so the sum must be exactly 195.
+  // strict partition (every provider in exactly one), so the sum must be exactly 194.
   const families: [string, string][] = [
     ["gateways", "APIKEY_PROVIDERS_GATEWAYS"],
     ["frontier-labs", "APIKEY_PROVIDERS_FRONTIER"],
@@ -69,7 +70,7 @@ test("APIKEY_PROVIDERS merges the 6 family files into 195 entries (no loss / no 
       seen.add(k);
     }
   }
-  assert.equal(famTotal, 195, "families must partition all 195 providers");
+  assert.equal(famTotal, 194, "families must partition all 194 providers");
 });
 
 test("AI_PROVIDERS Proxy aggregates all sections; lookups resolve", () => {

--- a/tests/unit/providers-page-utils.test.ts
+++ b/tests/unit/providers-page-utils.test.ts
@@ -430,6 +430,9 @@ test("static catalog entries resolve local, search, audio, web-cookie and upstre
   assert.equal(searchProvider?.name, providers.SEARCH_PROVIDERS["brave-search"].name);
   assert.equal(youcomSearchProvider?.category, "search");
   assert.equal(youcomSearchProvider?.name, providers.SEARCH_PROVIDERS["youcom-search"].name);
+  const firecrawlSearchProvider = providerPageUtils.resolveDashboardProviderInfo("firecrawl");
+  assert.equal(firecrawlSearchProvider?.category, "search");
+  assert.equal(firecrawlSearchProvider?.name, providers.SEARCH_PROVIDERS["firecrawl"].name);
 
   assert.equal(audioProvider?.category, "audio");
   assert.equal(audioProvider?.name, providers.AUDIO_ONLY_PROVIDERS.assemblyai.name);

--- a/tests/unit/providers-page-utils.test.ts
+++ b/tests/unit/providers-page-utils.test.ts
@@ -430,10 +430,6 @@ test("static catalog entries resolve local, search, audio, web-cookie and upstre
   assert.equal(searchProvider?.name, providers.SEARCH_PROVIDERS["brave-search"].name);
   assert.equal(youcomSearchProvider?.category, "search");
   assert.equal(youcomSearchProvider?.name, providers.SEARCH_PROVIDERS["youcom-search"].name);
-  const firecrawlSearchProvider = providerPageUtils.resolveDashboardProviderInfo("firecrawl");
-  assert.equal(firecrawlSearchProvider?.category, "search");
-  assert.equal(firecrawlSearchProvider?.name, providers.SEARCH_PROVIDERS["firecrawl"].name);
-
   assert.equal(audioProvider?.category, "audio");
   assert.equal(audioProvider?.name, providers.AUDIO_ONLY_PROVIDERS.assemblyai.name);
   assert.equal(awsPollyProvider?.category, "audio");

--- a/tests/unit/search-registry.test.ts
+++ b/tests/unit/search-registry.test.ts
@@ -19,12 +19,13 @@ const { computeCacheKey, getOrCoalesce, getCacheStats, SEARCH_CACHE_DEFAULT_TTL_
 
 // ─── Registry Tests ──────────────────────────────────────────
 
-test("SEARCH_PROVIDERS has all 11 providers", () => {
+test("SEARCH_PROVIDERS has all registered providers", () => {
   assert.ok(SEARCH_PROVIDERS["serper-search"], "serper should exist");
   assert.ok(SEARCH_PROVIDERS["brave-search"], "brave should exist");
   assert.ok(SEARCH_PROVIDERS["perplexity-search"], "perplexity-search should exist");
   assert.ok(SEARCH_PROVIDERS["exa-search"], "exa should exist");
   assert.ok(SEARCH_PROVIDERS["tavily-search"], "tavily should exist");
+  assert.ok(SEARCH_PROVIDERS["firecrawl"], "firecrawl should exist");
   assert.ok(SEARCH_PROVIDERS["google-pse-search"], "google-pse should exist");
   assert.ok(SEARCH_PROVIDERS["linkup-search"], "linkup should exist");
   assert.ok(SEARCH_PROVIDERS["searchapi-search"], "searchapi should exist");
@@ -33,7 +34,7 @@ test("SEARCH_PROVIDERS has all 11 providers", () => {
   assert.ok(SEARCH_PROVIDERS["ollama-search"], "ollama-search should exist");
   assert.ok(SEARCH_PROVIDERS["zai-search"], "zai should exist");
   assert.ok(SEARCH_PROVIDERS["duckduckgo-free"], "duckduckgo-free should exist");
-  assert.equal(Object.keys(SEARCH_PROVIDERS).length, 13);
+  assert.equal(Object.keys(SEARCH_PROVIDERS).length, 14);
 });
 
 test("duckduckgo-free config is a no-key, fallback-only provider", () => {
@@ -165,7 +166,7 @@ test("zai-search config is correct", () => {
 
 test("getAllSearchProviders returns flat list", () => {
   const all = getAllSearchProviders();
-  assert.equal(all.length, 13);
+  assert.equal(all.length, 14);
   assert.ok(all.some((p) => p.id === "duckduckgo-free"));
   assert.ok(all.some((p) => p.id === "serper-search"));
   assert.ok(all.some((p) => p.id === "brave-search"));
@@ -402,6 +403,7 @@ test("v1SearchSchema accepts new search providers", async () => {
     "searxng-search",
     "ollama-search",
     "duckduckgo-free",
+    "firecrawl",
   ] as const;
 
   for (const provider of providers) {

--- a/tests/unit/search-route.test.ts
+++ b/tests/unit/search-route.test.ts
@@ -45,20 +45,21 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
-test("v1 search GET lists all 13 search providers", async () => {
+test("v1 search GET lists all search providers", async () => {
   const response = await searchRoute.GET();
   const body = (await response.json()) as any;
   const ids = body.data.map((item: { id: string }) => item.id);
 
   assert.equal(response.status, 200);
   assert.equal(body.object, "list");
-  assert.equal(body.data.length, 13);
+  assert.equal(body.data.length, 14);
   assert.deepEqual(ids, [
     "serper-search",
     "brave-search",
     "perplexity-search",
     "exa-search",
     "tavily-search",
+    "firecrawl",
     "google-pse-search",
     "linkup-search",
     "searchapi-search",
@@ -124,6 +125,72 @@ test("v1 search POST uses stored Linkup credentials and returns normalized resul
     assert.equal(body.results[0].snippet, "Linkup snippet");
     assert.equal(body.results[0].citation.provider, "linkup-search");
     assert.equal(body.cached, false);
+    assert.equal(body.usage.queries_used, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("v1 search POST uses firecrawl credentials for unified firecrawl search", async () => {
+  await seedConnection("firecrawl", { apiKey: "fc-route-key" });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedInit: RequestInit | undefined;
+
+  globalThis.fetch = async (url, init = {}) => {
+    capturedUrl = String(url);
+    capturedInit = init;
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          web: [
+            {
+              title: "Firecrawl route hit",
+              url: "https://example.com/fc",
+              description: "From firecrawl via /v1/search",
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const response = await searchRoute.POST(
+      new Request("http://localhost/api/v1/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query: "omniroute firecrawl",
+          provider: "firecrawl",
+          max_results: 3,
+          search_type: "web",
+        }),
+      })
+    );
+    const body = (await response.json()) as {
+      provider: string;
+      results: Array<{ title: string; snippet: string }>;
+      usage: { queries_used: number };
+    };
+
+    assert.equal(response.status, 200);
+    assert.equal(capturedUrl, "https://api.firecrawl.dev/v2/search");
+    assert.equal(
+      (capturedInit?.headers as Record<string, string>).Authorization,
+      "Bearer fc-route-key"
+    );
+    const requestBody = JSON.parse(String(capturedInit?.body || "{}"));
+    assert.equal(requestBody.query, "omniroute firecrawl");
+    assert.equal(requestBody.limit, 3);
+    assert.deepEqual(requestBody.sources, ["web"]);
+    assert.equal(body.provider, "firecrawl");
+    assert.equal(body.results.length, 1);
+    assert.equal(body.results[0].title, "Firecrawl route hit");
+    assert.equal(body.results[0].snippet, "From firecrawl via /v1/search");
     assert.equal(body.usage.queries_used, 1);
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

Adds Firecrawl as a `/v1/search` provider under the **same provider id as web fetch**: `firecrawl`.

One connection, one API key, two surfaces:

- `POST /v1/web/fetch` -> existing Firecrawl scrape/extract path
- `POST /v1/search` -> Firecrawl `POST /v2/search` with `sources: ["web"] | ["news"]`

## Why

Firecrawl is commonly used for web search and extraction, but search support for Firecrawl was never implemented. Now this is possible by reusing already existing connections.

## Implementation

- Registered `firecrawl` in the open-sse search registry (`POST https://api.firecrawl.dev/v2/search`, Bearer auth, `web` + `news`).
- Added `open-sse/handlers/search/firecrawlSearch.ts` for request build + v2 response normalization (`data.web` / `data.news` only; legacy v1 envelopes ignored).
- Wired build/normalize into `open-sse/handlers/search.ts`.
- Accepted `firecrawl` in `v1SearchSchema` for `POST /v1/search`.
- Dashboard: single Search card with `serviceKinds: ["webSearch", "webFetch"]`.
- Removed the specialty apikey duplicate.
- Honors `FIRECRAWL_BASE_URL` self-host root the same way fetch does.

## Validation

- [x] Focused tests: `node --import tsx/esm --test tests/unit/firecrawl-search.test.ts tests/unit/search-route.test.ts tests/unit/search-registry.test.ts tests/unit/providers-page-utils.test.ts tests/integration/search-providers-catalog.test.ts` — 101 passed
- [x] Typecheck: `npm run typecheck:core`
- [ ] `npm run lint`
- [x] New automated tests in this PR

## Coverage Notes

Change is mostly in open-sse search registry/handler plus small dashboard catalog/schema wiring under `src/`.

The focused tests cover registry shape, schema accept/reject, handleSearch request body (`sources` web|news), v2 bucket normalization, self-host base URL, route credential resolve on `firecrawl`, catalog search+fetch presence, and dashboard category resolve. Full coverage reporting remains with CI.

## Reviewer Notes

No migration and no feature flag.

Intentional product choice: **unified id `firecrawl`**, not `firecrawl-search`. True dual runtime id; not a search-only split with credential fallback.

Fetch pipeline is unchanged in behavior. Search reuses the same connection id and API key.

`stryker.conf.json` one-line add is unrelated to Firecrawl; it lists `tests/unit/isLocalStreamLifecycleError-abort-shape.test.ts` (covers `circuitBreaker.ts`, from #8699) so the mutation tap drift gate does not fail this PR.

Manual check: add Firecrawl API key under id `firecrawl` -> `POST /v1/search` with `provider: "firecrawl"` -> same key works for `POST /v1/web/fetch` -> dashboard shows one Firecrawl card (search + fetch).