### PR TITLE
fix(types): declare virtual chaos combo config

### DIFF
--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -28,6 +28,7 @@ import {
   SYNTHETIC_NOAUTH_CONNECTION_ID as RESILIENCE_NOAUTH_CONNECTION_ID,
   type ConnectionResilienceView,
 } from "./resilienceCandidateFilter";
+import type { ChaosTuning } from "./chaosEngine";
 
 /** #4235 Phase B: optional category/tier overlay for `auto/<category>:<tier>` combos.
  * #6453: optional `family` overlay for `auto/<family>` combos (e.g. `auto/glm`) —
@@ -95,6 +96,12 @@ type VirtualAutoCombo = AutoComboConfig & {
       weights: ScoringWeights;
       explorationRate: number;
       routerStrategy: string;
+    };
+    chaos?: {
+      enabled: true;
+      panelSize: number;
+      judgeModel?: string;
+      tuning: ChaosTuning;
     };
   };
 };


### PR DESCRIPTION
Part of #8484. One incomplete producer contract, three diagnostics, zero new.

## Root cause

`createVirtualAutoCombo("chaos")` already emits `config.chaos` with the enablement flag,
panel metadata, judge model, and tuning values. Its `VirtualAutoCombo` return type described only
`config.auto`, so the real factory integration test could not access the chaos configuration
without TS2339 errors.

This adds the existing optional chaos shape to the producer contract and reuses the shared
`ChaosTuning` type. Runtime values and routing behavior are unchanged; the test remains untouched.

## Diagnostics

Measured independently against `release/v3.8.49` at `0eeb8f45c`:

- TypeScript 6 open-sse diagnostics: **150 → 147**
- TypeScript 7.0.2 native diagnostics: **149 → 146**
- Full line-number-agnostic error-set diff: **3 fixed, 0 new**

With #8809, #8810, #8811, and #8812 included, the cumulative projection is
**TS6 134 / TS7 133**.

## Validation

- `npm run typecheck:core`
- Auto-combo factory, chaos dispatch, and scoring tests — **70/70 passed**
- ESLint on `open-sse/services/autoCombo/virtualFactory.ts`
- `npm run check:file-size`
- Prettier and `git diff --check`

No new test was added because the existing `chaosVirtualCombo` integration test directly verifies
every field added to the return contract.

## Known inherited CI failures

The current base is red on an unrelated React hook dependency and a stale
`pack-artifact-policy.test.ts` expected list. Both failures were reproduced identically on
`release/v3.8.49@0eeb8f45c` and #8809's head; this diff touches neither area.
