### PR TITLE
fix(types): type memory skills injection logger

### DIFF
--- a/open-sse/handlers/chatCore/memorySkillsInjection.ts
+++ b/open-sse/handlers/chatCore/memorySkillsInjection.ts
@@ -5,6 +5,8 @@ import { injectSkills } from "@/lib/skills/injection";
 import { FORMATS } from "../../translator/formats.ts";
 import { detectCachingContext } from "../../services/compression/cachingAware.ts";
 
+type MemorySkillsLogger = { debug?: (...args: unknown[]) => void } | null | undefined;
+
 export function getSkillsProviderForFormat(format: string): "openai" | "anthropic" | "google" | "other" {
   switch (format) {
     case FORMATS.CLAUDE:
@@ -33,7 +35,7 @@ export async function injectMemoryAndSkills({
   sourceFormat: string;
   targetFormat: string;
   backgroundReason: string | null;
-  log: unknown;
+  log: MemorySkillsLogger;
 }) {
   const memorySettings = memoryOwnerId
     ? await getMemorySettings().catch(() => DEFAULT_MEMORY_SETTINGS)


### PR DESCRIPTION
## Summary

- declare the minimal request logger contract used by memory and skill injection
- keep `null`, `undefined`, and debug-capable logger inputs compatible
- remove three TS6/TS7 property-access errors without changing runtime behavior

## Root cause

`injectMemoryAndSkills()` accepted `log` as `unknown` but called its optional `debug` method in three places. TypeScript reports each property access independently even though all three share the same missing boundary contract.

## Diagnostics

Re-measured after rebasing onto `release/v3.8.49` at `d6c06932e`:

- TypeScript 6: `141 → 138`
- TypeScript 7: `140 → 137`
- full canonicalized error-set diff: 3 removed, 0 added

## Validation

- `npm run typecheck:core`
- `npx eslint open-sse/handlers/chatCore/memorySkillsInjection.ts`
- `npm run check:file-size`
- `node --import tsx/esm --test tests/unit/chatcore-memory-skills-injection.test.ts` (6/6)
- Prettier run on the touched file
- `git diff --check`

No new runtime test is needed because this is a type-only input-contract change; the existing focused suite covers both a debug-capable logger and the `null` logger path.

## CI note

The new release root includes the `pack-artifact-policy.test.ts` fixture fix, and that focused test now passes. The unrelated `ProviderAccountRoutingCard.tsx:87` hook-dependency ESLint error still reproduces on the base; this PR does not touch that area.
