### PR TITLE
[TS7] [v3.8.50] fix(types): preserve browser abort handling

### DIFF
--- a/open-sse/services/browserBackedChat.ts
+++ b/open-sse/services/browserBackedChat.ts
@@ -90,7 +90,7 @@ export function __resetHttpBackedChatOverrideForTesting(): void {
 
 // Helper to make Playwright waitForTimeout abortable via AbortSignal
 function waitWithSignal(ms: number, signal?: AbortSignal | null): Promise<void> {
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) return reject(new DOMException("Aborted", "AbortError"));
     const onAbort = () => {
       clearTimeout(timer);


### PR DESCRIPTION
Part of #8484. One explicit promise result type, two diagnostics, zero new.

## Summary

- give the abort-aware delay its declared `Promise<void>` contract
- keep the existing abort listener, cleanup, and Playwright calls unchanged

## Root cause

`waitWithSignal()` declares `Promise<void>` but constructed an untyped promise. TypeScript
therefore inferred `Promise<unknown>` and also required `resolve()` to receive a value.
Specifying `new Promise<void>` matches the function contract and removes both diagnostics
without changing runtime behavior.

The earlier `runAbortable()` and Playwright option changes are intentionally absent: the
current dependency baseline no longer reports those diagnostics, and changing cancellation
semantics is outside this type-only slice.

## Diagnostics

Re-measured on `release/v3.8.50` at `371c10ea5f`:

- TypeScript 6.0.3 diagnostics: **125 → 123**
- TypeScript 7.0.2 diagnostics: **124 → 122**
- Canonicalized diagnostic multiset: **2 removed, 0 added**

The removed reports are `TS2322` for `Promise<unknown>` and `TS2794` for `resolve()` without
a value.

## Validation

- TypeScript 6.0.3 and 7.0.2 full `open-sse/tsconfig.json` diagnostic comparison
- 23/23 browser fallback, matcher, media-body, and Claude fingerprint tests
- ESLint and Prettier on `open-sse/services/browserBackedChat.ts`
- `npm run check:file-size`
- `git diff --check`
