### PR TITLE
fix(types): align web fallback contracts

### DIFF
--- a/open-sse/services/webFetchInterception.ts
+++ b/open-sse/services/webFetchInterception.ts
@@ -16,6 +16,10 @@ export const OMNIROUTE_WEB_FETCH_FALLBACK_TOOL_NAME = "omniroute_web_fetch";
 const WEB_FETCH_TOOL_TYPES = new Set(["web_fetch", "web_fetch_20250910"]);
 
 type JsonRecord = Record<string, unknown>;
+type WebFetchFallbackBody = JsonRecord & {
+  tools?: unknown;
+  tool_choice?: unknown;
+};
 
 export interface WebFetchFallbackPlan {
   enabled: boolean;
@@ -88,7 +92,7 @@ export function supportsNativeWebFetchFallbackBypass({
 }: {
   provider?: string | null;
   sourceFormat?: string | null;
-  targetFormat: string | null | undefined;
+  targetFormat?: string | null;
   nativeCodexPassthrough: boolean;
   // Per-model rule (#3384/#7339) — resolveInterceptFetch() in src/lib/db/interceptionRules.ts.
   // true = force interception; anything else (false/undefined, i.e. no operator
@@ -104,7 +108,7 @@ export function supportsNativeWebFetchFallbackBypass({
   return interceptFetchOverride !== true;
 }
 
-export function prepareWebFetchFallbackBody<T extends JsonRecord>(
+export function prepareWebFetchFallbackBody<T extends WebFetchFallbackBody>(
   body: T,
   options: {
     provider?: string | null;

--- a/open-sse/services/webSearchFallback.ts
+++ b/open-sse/services/webSearchFallback.ts
@@ -9,6 +9,10 @@ const SEARCH_CONTEXT_DEFAULTS: Record<string, number> = {
 };
 
 type JsonRecord = Record<string, unknown>;
+type WebSearchFallbackBody = JsonRecord & {
+  tools?: unknown;
+  tool_choice?: unknown;
+};
 
 export interface WebSearchFallbackPlan {
   enabled: boolean;
@@ -146,7 +150,7 @@ export function supportsNativeWebSearchFallbackBypass({
 }: {
   provider?: string | null;
   sourceFormat?: string | null;
-  targetFormat: string | null | undefined;
+  targetFormat?: string | null;
   nativeCodexPassthrough: boolean;
   // Per-model rule (#3384) — resolveInterceptSearch() in src/lib/db/interceptionRules.ts.
   // true = force interception (never bypass); false = force native bypass; undefined =
@@ -172,7 +176,7 @@ export function supportsNativeWebSearchFallbackBypass({
   return false;
 }
 
-export function prepareWebSearchFallbackBody<T extends JsonRecord>(
+export function prepareWebSearchFallbackBody<T extends WebSearchFallbackBody>(
   body: T,
   options: {
     provider?: string | null;


### PR DESCRIPTION
## Summary

- declare the `tools` and `tool_choice` fields used by both fallback body transformers
- align each native-bypass predicate with the optional `targetFormat` accepted by its caller
- preserve all web-search and web-fetch transformation behavior

## Root cause

Both structural-twin modules constrained their generic request body only as `Record<string, unknown>`. That permits indexed reads but does not guarantee a named `tool_choice` property on the generic result when the transformer rewrites it. Their preparation options also allowed an omitted `targetFormat`, while the bypass predicate receiving the same object declared that field as required.

## Diagnostics

Re-measured after rebasing onto `release/v3.8.49` at `d6c06932e`:

- TypeScript 6: `141 → 137`
- TypeScript 7: `140 → 136`
- full canonicalized error-set diff: 4 removed, 0 added

## Validation

- `npm run typecheck:core`
- `npx eslint open-sse/services/webFetchInterception.ts open-sse/services/webSearchFallback.ts`
- `npm run check:file-size`
- web-search, web-fetch, and chat-core interception tests (32/32)
- Prettier run on both touched files
- `git diff --check`

No new runtime test is needed because this is a type-only contract correction and the existing focused suites cover native bypass, flat/nested tool shapes, `tool_choice` rewriting, opt-in behavior, and byte-identical no-op paths.

## CI note

The new release root includes the `pack-artifact-policy.test.ts` fixture fix, and that focused test now passes. The unrelated `ProviderAccountRoutingCard.tsx:87` hook-dependency ESLint error still reproduces on the base; this PR does not touch that area.
