### PR TITLE
fix(types): declare idempotency input contracts

### DIFF
--- a/open-sse/handlers/chatCore/idempotency.ts
+++ b/open-sse/handlers/chatCore/idempotency.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 import { getIdempotencyKey, checkIdempotency } from "@/lib/idempotencyLayer";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
+import type { EffectiveServiceTier } from "./serviceTier.ts";
+
+type HeadersLike = Headers | Record<string, unknown> | null | undefined;
+type IdempotencyRequest = { headers?: HeadersLike } | null | undefined;
+type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
 
 /**
  * NEXA fusion-idempotency fix: compose the effective idempotency key from the raw
@@ -55,13 +60,13 @@ export async function checkIdempotencyCache({
   startTime,
   log,
 }: {
-  clientRawRequest: unknown;
+  clientRawRequest: IdempotencyRequest;
   provider: string;
   model: string;
   body?: unknown;
-  effectiveServiceTier: unknown;
+  effectiveServiceTier: EffectiveServiceTier | null | undefined;
   startTime: number;
-  log: unknown;
+  log: LoggerLike;
 }): Promise<{ hit: { success: true; response: Response } | null; idempotencyKey: string | null }> {
   // NEXA fusion-idempotency fix: namespace the raw header key (see composeIdempotencyKey).
   const rawIdempotencyKey = getIdempotencyKey(clientRawRequest?.headers);


### PR DESCRIPTION
## Summary

- declare the request-header shape consumed by the idempotency lookup
- reuse the existing effective service-tier contract for cached cost calculation
- declare the optional debug logger used on cache hits
- preserve all idempotency key, replay, and response behavior

## Root cause

`checkIdempotencyCache()` accepted its request, service tier, and logger inputs as `unknown`, then immediately read `headers`, called `debug`, and forwarded the tier to `calculateCost()`. The new types state the existing caller contracts without changing runtime values or control flow.

## Diagnostics

Re-measured after rebasing onto `release/v3.8.49` at `d6c06932e`:

- TypeScript 6: `141 → 138`
- TypeScript 7: `140 → 137`
- full canonicalized error-set diff: 3 removed, 0 added

## Validation

- `npm run typecheck:core`
- `npx eslint open-sse/handlers/chatCore/idempotency.ts`
- `npm run check:file-size`
- idempotency extraction and fusion-collision tests (12/12)
- Prettier
- `git diff --check`

No new runtime test is needed because this is a type-only contract correction and the focused suites already cover cache misses, replay hits, absent headers, fusion separation, judge separation, and genuine retry stability.

## CI note

The new release root includes the `pack-artifact-policy.test.ts` fixture fix, and that focused test now passes. The unrelated `ProviderAccountRoutingCard.tsx:87` hook-dependency ESLint error still reproduces on the base; this PR does not touch that area.
