### PR TITLE
fix(types): normalize Kie transcription result envelopes

### DIFF
--- a/open-sse/handlers/audioTranscription.ts
+++ b/open-sse/handlers/audioTranscription.ts
@@ -24,6 +24,7 @@ import { buildAuthHeaders } from "../config/registryUtils.ts";
 import { kieExecutor } from "../executors/kie.ts";
 import { vertexTranscribe } from "../executors/vertexMedia.ts";
 import { errorResponse } from "../utils/error.ts";
+import { isJsonObject } from "../utils/kieTask.ts";
 import { handleOpenRouterTranscription } from "./openrouterTranscription.ts";
 
 type TranscriptionCredentials = {
@@ -393,6 +394,18 @@ async function handleHuggingFaceTranscription(providerConfig, file, modelId, tok
 /**
  * Handle Kie.ai transcription
  */
+function normalizeKieTranscriptionText(recordData: unknown): string {
+  const record = isJsonObject(recordData) ? recordData : {};
+  const data = isJsonObject(record.data) ? record.data : {};
+  const response = isJsonObject(data.response) ? data.response : {};
+
+  for (const value of [response.text, data.resultText, data.text, record.text]) {
+    if (typeof value === "string") return value;
+  }
+
+  return "";
+}
+
 async function handleKieAudioTranscription(providerConfig, file, modelId, token) {
   const baseUrl = providerConfig.baseUrl.replace(/\/$/, "");
   const fileBuffer = await file.arrayBuffer();
@@ -456,12 +469,7 @@ async function pollKieTranscriptionResult(baseUrl, modelId, taskId, token) {
     });
 
     if (state === "success") {
-      const text =
-        data?.data?.response?.text ||
-        data?.data?.resultText ||
-        data?.data?.text ||
-        data?.text ||
-        "";
+      const text = normalizeKieTranscriptionText(data);
       return Response.json({ text }, { headers: { ...CORS_HEADERS } });
     }
   } catch (err: unknown) {

--- a/tests/unit/kie-audio-transcription-result.test.ts
+++ b/tests/unit/kie-audio-transcription-result.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { handleAudioTranscription } = await import("../../open-sse/handlers/audioTranscription.ts");
+
+function buildFormData(): FormData {
+  const formData = new FormData();
+  formData.append("model", "kie/elevenlabs/speech-to-text");
+  formData.append("file", new File([Buffer.from("audio")], "clip.wav", { type: "audio/wav" }));
+  return formData;
+}
+
+test("Kie transcription returns text from every supported result envelope", async () => {
+  const originalFetch = globalThis.fetch;
+  const cases = [
+    {
+      name: "nested response",
+      record: { data: { status: "SUCCESS", response: { text: "response text" } } },
+      expected: "response text",
+    },
+    {
+      name: "resultText fallback",
+      record: {
+        data: {
+          status: "SUCCESS",
+          response: { text: { malformed: true } },
+          resultText: "result text",
+        },
+      },
+      expected: "result text",
+    },
+    {
+      name: "nested text fallback",
+      record: { data: { status: "SUCCESS", text: "nested text" } },
+      expected: "nested text",
+    },
+    {
+      name: "top-level text fallback",
+      record: { data: { status: "SUCCESS" }, text: "top-level text" },
+      expected: "top-level text",
+    },
+  ];
+
+  try {
+    for (const testCase of cases) {
+      const calls: string[] = [];
+      globalThis.fetch = async (url, options = {}) => {
+        const requestUrl = String(url);
+        calls.push(requestUrl);
+
+        if (requestUrl === "https://api.kie.ai/api/v1/jobs/createTask") {
+          const payload = JSON.parse(String(options.body));
+          assert.equal(payload.model, "elevenlabs/speech-to-text", testCase.name);
+          return Response.json({ data: { taskId: "task-1" } });
+        }
+
+        assert.equal(
+          requestUrl,
+          "https://api.kie.ai/api/v1/jobs/recordInfo?taskId=task-1",
+          testCase.name
+        );
+        return Response.json(testCase.record);
+      };
+
+      const response = await handleAudioTranscription({
+        formData: buildFormData(),
+        credentials: { apiKey: "kie-key" },
+      });
+
+      assert.equal(response.status, 200, testCase.name);
+      assert.deepEqual(await response.json(), { text: testCase.expected }, testCase.name);
+      assert.equal(calls.length, 2, testCase.name);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## What changed

- Validate nested Kie task results as JSON objects before reading transcription fields.
- Preserve the supported `response.text` → `resultText` → nested `text` → top-level `text` fallback order.
- Add an end-to-end handler test for all four envelopes, including a malformed earlier field.

## Why

`KieExecutor.pollTask()` returns a generic JSON object whose nested values remain `unknown`.
The transcription handler read those nested values directly, producing three TS2339 diagnostics
under both TypeScript 6 and native TypeScript 7. It could also return a non-string value when an
earlier field had an unexpected shape.

## Impact

The request and successful-response shapes are unchanged. Kie speech-to-text responses now
guarantee a string `text` value and continue to a later supported envelope when an earlier value
is malformed.

## Validation

- Re-measured on `release/v3.8.49` at `b4776a2d8` with a complete line-number-agnostic diagnostic diff:
  - TypeScript 6: 131 → 128; 3 fixed, 0 new
  - native TypeScript 7: 130 → 127; 3 fixed, 0 new
- Audio transcription tests: 25/25 passing
- Core typecheck passing
- Focused ESLint passing
- `check:file-size`, T11 any-budget, Prettier, and `git diff --check` passing

Tracking: #8484

