### PR TITLE
chore(quality): add an RTL layout ratchet

### DIFF
--- a/changelog.d/maintenance/rtl-physical-class-ratchet.md
+++ b/changelog.d/maintenance/rtl-physical-class-ratchet.md
@@ -1,0 +1,1 @@
+- chore(quality): add an RTL layout ratchet — counts physical directional Tailwind classes (ml/mr/pl/pr/left/right/text-left/border-l/rounded-l) that do not mirror under `dir=rtl`, seeded at 1011 so the backlog behind `tests/unit/ui/rtl-logical-classes.test.tsx` ("#3541, partial, core layout") cannot grow while it is worked through

--- a/config/quality/quality-baseline.json
+++ b/config/quality/quality-baseline.json
@@ -349,6 +349,12 @@
       "value": 83.18,
       "direction": "up",
       "dedicatedGate": true
+    },
+    "rtlPhysicalClasses": {
+      "value": 1011,
+      "direction": "down",
+      "eps": 0,
+      "_seeded_2026_07_28": "Measured by scripts/check/check-rtl-ratchet.mjs. tests/unit/ui/rtl-logical-classes.test.tsx pins four components and states it is partial (#3541); this bounds the remainder."
     }
   },
   "_coverage_note": "Pisos anti-flake ~2pt abaixo do real do CI mergeado MEDIDO COM os 135 testes religados (run 27247237268: statements 78.4 / lines 78.4 / functions 83.84 / branches 75.73). O religamento da 6A.1 HONESTIFICOU a regua: os ~82.5 anteriores eram inflados porque modulos nunca importados ficavam fora do denominador do c8. Apertar via --require-tighten na Fase 6A (2026-06-16).",

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "check:bundle-size": "node scripts/check/check-bundle-size.mjs",
     "check:circular-deps": "node scripts/check/check-circular-deps.mjs",
     "check:mutation-ratchet": "node scripts/check/check-mutation-ratchet.mjs",
+    "check:rtl-ratchet": "node scripts/check/check-rtl-ratchet.mjs",
     "check:licenses": "node scripts/check/check-licenses.mjs",
     "check:pr-evidence": "node scripts/check/check-pr-evidence.mjs",
     "check:vuln-ratchet": "node scripts/check/check-vuln-ratchet.mjs",

--- a/scripts/check/check-rtl-ratchet.mjs
+++ b/scripts/check/check-rtl-ratchet.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// scripts/check/check-rtl-ratchet.mjs
+// RTL layout ratchet. Counts physical directional Tailwind classes in TSX.
+//
+// tests/unit/ui/rtl-logical-classes.test.tsx pins four high-impact components
+// and says so: "#3541 (partial, core layout)". This measures the rest, so the
+// remaining backlog cannot grow while it is worked through.
+//
+// Physical classes (ml/mr/pl/pr/left/right/text-left/border-l/rounded-l ...) do
+// not mirror under dir=rtl. Tailwind v4 logical utilities (ms/me/ps/pe/start/
+// end/text-start/border-s/rounded-s) do.
+//
+// Output:  rtlPhysicalClasses=N
+//
+// Advisory by default (exit 0). With --ratchet, reads
+// metrics.rtlPhysicalClasses.value from config/quality/quality-baseline.json and
+// exits 1 only when the measured count is HIGHER (direction: down).
+//
+//   node scripts/check/check-rtl-ratchet.mjs
+//   node scripts/check/check-rtl-ratchet.mjs --list     # show the worst files
+//   node scripts/check/check-rtl-ratchet.mjs --ratchet  # blocking
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT = process.cwd();
+const QUIET = process.argv.includes("--quiet");
+const LIST = process.argv.includes("--list");
+const RATCHET = process.argv.includes("--ratchet");
+const BASELINE_PATH = path.join(ROOT, "config/quality/quality-baseline.json");
+const SCAN_DIRS = ["src", "electron"];
+const SKIP = new Set(["node_modules", ".next", "dist", "build", "out", "coverage", ".git"]);
+
+// Physical utilities that govern placement and do not mirror under dir=rtl.
+const PHYSICAL =
+  /(?<![\w-])(?:ml|mr|pl|pr|left|right|border-l|border-r|rounded-l|rounded-r)-[a-z0-9.[\]/]+|(?<![\w-])text-(?:left|right)(?![\w-])/g;
+
+/**
+ * Count violations in one file's source.
+ *
+ * Two exemptions, both direction independent rather than oversights:
+ *  - a class already scoped to an `rtl:` variant, which is a deliberate override
+ *  - `left-…` paired with `right-…` on the same element, which spans both edges
+ */
+export function countViolations(source) {
+  let count = 0;
+  for (const line of source.split("\n")) {
+    const spansBothEdges = /(?<![\w-])left-[a-z0-9.[\]/]+/.test(line) &&
+      /(?<![\w-])right-[a-z0-9.[\]/]+/.test(line);
+    for (const match of line.matchAll(PHYSICAL)) {
+      const before = line.slice(0, match.index);
+      if (/rtl:[\w-]*$/.test(before)) continue;
+      if (spansBothEdges && /^(left|right)-/.test(match[0])) continue;
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (entry.name.endsWith(".tsx")) yield full;
+  }
+}
+
+function measure() {
+  const perFile = [];
+  let total = 0;
+  for (const dir of SCAN_DIRS) {
+    for (const file of walk(path.join(ROOT, dir))) {
+      const n = countViolations(fs.readFileSync(file, "utf-8"));
+      if (n > 0) {
+        perFile.push({ file: path.relative(ROOT, file), count: n });
+        total += n;
+      }
+    }
+  }
+  perFile.sort((a, b) => b.count - a.count);
+  return { total, perFile };
+}
+
+function main() {
+  const { total, perFile } = measure();
+  console.log(`rtlPhysicalClasses=${total}`);
+
+  if (LIST) {
+    for (const { file, count } of perFile.slice(0, 25)) {
+      console.log(`  ${String(count).padStart(4)}  ${file}`);
+    }
+    console.log(`  ${perFile.length} file(s) affected`);
+  }
+
+  if (!RATCHET) return 0;
+
+  let baseline;
+  try {
+    const json = JSON.parse(fs.readFileSync(BASELINE_PATH, "utf-8"));
+    baseline = json?.metrics?.rtlPhysicalClasses?.value;
+  } catch (err) {
+    // A measurement failure must not block, only a measured regression.
+    if (!QUIET) console.log(`rtlPhysicalClasses=SKIP reason=baseline-unreadable (${err.message})`);
+    return 0;
+  }
+  if (typeof baseline !== "number") {
+    if (!QUIET) console.log("rtlPhysicalClasses=SKIP reason=baseline-absent");
+    return 0;
+  }
+  if (total > baseline) {
+    console.error(
+      `RTL ratchet: ${total} physical directional classes, baseline ${baseline}. ` +
+        `Use logical utilities (ms/me/ps/pe/start/end/text-start) so the layout ` +
+        `mirrors under dir=rtl, or re-baseline with justification.`,
+    );
+    return 1;
+  }
+  if (!QUIET) console.log(`rtlPhysicalClasses OK (${total} <= ${baseline})`);
+  return 0;
+}
+
+// Only run when invoked directly, so countViolations can be unit tested.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(main());
+}

--- a/tests/unit/scripts/check-rtl-ratchet.test.ts
+++ b/tests/unit/scripts/check-rtl-ratchet.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+import { countViolations } from "../../../scripts/check/check-rtl-ratchet.mjs";
+
+describe("check-rtl-ratchet — countViolations", () => {
+  it("counts physical directional utilities", () => {
+    expect(countViolations('<span className="mr-2" />')).toBe(1);
+    expect(countViolations('<td className="pr-3 text-left" />')).toBe(2);
+    expect(countViolations('<div className="border-l-2 rounded-r-md" />')).toBe(2);
+  });
+
+  it("ignores logical utilities, which already mirror", () => {
+    expect(countViolations('<span className="me-2 ps-3 text-start" />')).toBe(0);
+    expect(countViolations('<div className="border-s-2 rounded-e-md" />')).toBe(0);
+  });
+
+  it("ignores a class already scoped to an rtl: variant", () => {
+    expect(countViolations('<div className="rtl:mr-0" />')).toBe(0);
+    // Only the unscoped half of a pair counts.
+    expect(countViolations('<div className="rtl:mr-0 mr-2" />')).toBe(1);
+  });
+
+  it("ignores left/right paired on one element, which spans both edges", () => {
+    expect(countViolations('<div className="absolute left-0 right-0 top-0" />')).toBe(0);
+    // A lone edge offset is still directional.
+    expect(countViolations('<div className="absolute left-0 top-0" />')).toBe(1);
+  });
+
+  it("does not match unrelated identifiers containing the prefixes", () => {
+    expect(countViolations('<div className="control-panel highlight-2" />')).toBe(0);
+    expect(countViolations("const marginLeft = 2;")).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`tests/unit/ui/rtl-logical-classes.test.tsx` pins four components and says so in its own header:

> RTL layout regression test — #3541 (partial, core layout)

Nothing bounds the remainder, so the backlog can grow while it is being worked through. This measures it.

Physical directional utilities (`ml`/`mr`/`pl`/`pr`/`left`/`right`/`text-left`/`border-l`/`rounded-l`) do not mirror under `dir=rtl`; the Tailwind v4 logical equivalents do. Current count is **1011 across 168 files**, seeded as `metrics.rtlPhysicalClasses` with `direction: down`.

Worst offenders, via `--list`:

```
  45  src/shared/components/analytics/charts.tsx
  38  src/app/(dashboard)/dashboard/provider-stats/page.tsx
  37  src/shared/components/UsageStats.tsx
  23  .../endpoint/components/MCPDashboard.tsx
```

## Why a ratchet rather than a fix

1011 call sites is not a reviewable PR, and many need a judgement call per element. A ratchet stops the backlog growing without asking anyone to rewrite the dashboard, which is the same trade the complexity and cognitive-complexity ratchets already make here.

## Shape

Follows the existing ratchets: advisory by default, blocking with `--ratchet`, reading `config/quality/quality-baseline.json`. A baseline that cannot be read **skips rather than blocks**, so a measurement failure never fails a build.

Two exemptions, both direction-independent rather than oversights:

- a class already scoped to an `rtl:` variant, which is a deliberate override
- `left-*` paired with `right-*` on one element, which spans both edges

## Verified

It blocks. Adding a file with three physical classes takes the count to 1014 and exits 1; removing it returns to 1011 and exits 0. The exemptions and the negative cases are covered by `tests/unit/scripts/check-rtl-ratchet.test.ts`, 11 assertions.

Not wired into any CI job in this PR — it is advisory until you decide where it belongs.

## Checklist

- [ ] Tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

Unticked honestly: I have not installed this project's dependencies, so I ran the script and its assertions directly under Node rather than through vitest. The new file is a standalone `.mjs` with no imports beyond `node:fs`/`node:path`/`node:url`. Happy to run the full suite if you would like that before merging.