### PR TITLE
fix(providers): correct Codex GPT-5.6 context window

### DIFF
--- a/changelog.d/fixes/8838-codex-gpt56-context-window.md
+++ b/changelog.d/fixes/8838-codex-gpt56-context-window.md
@@ -1,0 +1,1 @@
+- **Providers**: Codex GPT-5.6 Sol/Terra/Luna report the current upstream context window of 272000 instead of a stale 372000, so catalog consumers stop compacting past the Codex backend real input limit. Public OpenAI API GPT-5.6 metadata is unchanged

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -247,7 +247,7 @@ export const GPT_5_6_API_CAPABILITIES = {
   maxOutputTokens: 128000,
 } as const;
 
-// Codex's live catalog reports a 372K context window for GPT-5.6.
+// Codex's live catalog reports a 272K input context window for GPT-5.6.
 // Keep the input and output limits explicit for catalog consumers that expose them separately.
 export const GPT_5_6_CODEX_CAPABILITIES = {
   targetFormat: "openai-responses",
@@ -255,8 +255,8 @@ export const GPT_5_6_CODEX_CAPABILITIES = {
   supportsReasoning: true,
   supportsVision: true,
   supportsXHighEffort: true,
-  contextLength: 372000,
-  maxInputTokens: 372000,
+  contextLength: 272000,
+  maxInputTokens: 272000,
   maxOutputTokens: 128000,
 } as const;
 

--- a/tests/unit/codex-gpt56-catalog.test.ts
+++ b/tests/unit/codex-gpt56-catalog.test.ts
@@ -36,8 +36,8 @@ test("Codex catalog exposes the GPT-5.6 lineup in configured priority order", ()
   for (const modelId of expectedIds) {
     const model = models.find((entry) => entry.id === modelId);
     assert.ok(model, `codex must expose ${modelId}`);
-    assert.equal(model.contextLength, 372000);
-    assert.equal(model.maxInputTokens, 372000);
+    assert.equal(model.contextLength, 272000);
+    assert.equal(model.maxInputTokens, 272000);
     assert.equal(model.maxOutputTokens, 128000);
     assert.equal(model.targetFormat, "openai-responses");
     assert.equal(model.toolCalling, true);

--- a/tests/unit/provider-models-route-codex.test.ts
+++ b/tests/unit/provider-models-route-codex.test.ts
@@ -181,10 +181,10 @@ test("provider models route merges live Codex models with the local catalog then
   // merge conservatively — the smaller of live vs. pinned wins, never the
   // larger, so a stale/inflated live number can never make OmniRoute promise
   // more context than the account can actually serve (#7012). Here the pinned
-  // GPT-5.6 Codex contract (372000/128000, see GPT_5_6_CODEX_CAPABILITIES) is
+  // GPT-5.6 Codex contract (272000/128000, see GPT_5_6_CODEX_CAPABILITIES) is
   // smaller than the live payload's 999999/999999, so the pinned value wins.
   assert.equal(liveModel?.name, "GPT 5.6 Sol Live");
-  assert.equal(liveModel?.inputTokenLimit, 372000);
+  assert.equal(liveModel?.inputTokenLimit, 272000);
   assert.equal(liveModel?.outputTokenLimit, 128000);
   assert.equal(liveModel?.apiFormat, "responses");
   assert.deepEqual(liveModel?.supportedEndpoints, ["responses"]);
@@ -218,7 +218,7 @@ test("provider models route: live token limit wins when it is SMALLER than the p
       return Response.json({ models: [] });
     }
     // Live reports a SMALLER budget than the pinned GPT-5.6 Codex contract
-    // (372000/128000, GPT_5_6_CODEX_CAPABILITIES) — e.g. a temporary
+    // (272000/128000, GPT_5_6_CODEX_CAPABILITIES) — e.g. a temporary
     // account-level cap. The conservative merge must take the smaller live
     // value here, not the larger pinned one (#7012).
     return Response.json({

--- a/tests/unit/vscode-token-routes-gpt56.test.ts
+++ b/tests/unit/vscode-token-routes-gpt56.test.ts
@@ -82,9 +82,9 @@ test("vscode raw models route exposes native GPT-5.6 IDs and effort tiers", asyn
   assert.equal(typeof defaultModel.created, "number");
   assert.equal(defaultModel.owned_by, "codex");
   assert.equal(defaultModel.name, "Codex GPT 5.6 Sol");
-  assert.equal(defaultModel.context_length, 372000);
+  assert.equal(defaultModel.context_length, 272000);
   assert.equal(defaultModel.max_output_tokens, 128000);
-  assert.equal(defaultModel.max_input_tokens, 372000);
+  assert.equal(defaultModel.max_input_tokens, 272000);
   assert.deepEqual(defaultModel.capabilities, {
     vision: true,
     tool_calling: true,

--- a/tests/unit/vscode-token-routes.test.ts
+++ b/tests/unit/vscode-token-routes.test.ts
@@ -255,7 +255,7 @@ test("vscode combos route resolves combo names through Ollama api/show", async (
   assert.equal(body.model, "show-combo");
   assert.equal(body.modelfile, "FROM show-combo");
   assert.equal(body.details.family, "show-combo");
-  assert.equal(body.model_info.context_length, 372000);
+  assert.equal(body.model_info.context_length, 272000);
   assert.deepEqual(body.supportsReasoningEffort, ["none", "low", "medium", "high", "xhigh"]);
   assert.equal(body.model_info.capabilities.reasoning, true);
 });
@@ -290,7 +290,7 @@ test("vscode tokenized combos root route exposes importable combo metadata", asy
   assert.equal(response.status, 200);
   assert.ok(combo, "expected balanced-load in combo root response");
   assert.equal(combo.url.includes("/responses#models.ai.azure.com"), true);
-  assert.equal(combo.maxInputTokens, 372000);
+  assert.equal(combo.maxInputTokens, 272000);
   assert.equal(combo.toolCalling, true);
   assert.deepEqual(combo.supportsReasoningEffort, ["none", "low", "medium", "high", "xhigh"]);
 });
@@ -1075,7 +1075,7 @@ test("vscode tokenized api/show route exposes explicit reasoning effort metadata
   assert.equal(body.configurationSchema?.properties?.reasoningEffort?.default, "low");
   assert.equal(body.model_info["general.basename"], "Codex GPT 5.6 Sol (Default)");
   assert.equal(body.model_info["general.architecture"], "codex");
-  assert.equal(body.model_info["codex.context_length"], 372000);
+  assert.equal(body.model_info["codex.context_length"], 272000);
   assert.deepEqual(body.model_info.supports_reasoning_effort, [
     "low",
     "medium",


### PR DESCRIPTION
## Summary

- Update Codex GPT-5.6 Sol/Terra/Luna metadata from `372000` to the current upstream `272000` context window.
- Keep public OpenAI API GPT-5.6 metadata unchanged.
- Prevent catalog consumers such as Pi from compacting after the Codex backend's real input limit.

## Related Issues

- Closes #7702
- Related to #6191

## Validation

Run only the focused loop for what you changed — the full unit suite, Vitest, the
60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Focused tests for the change: `node --import tsx/esm --test tests/unit/codex-gpt56-catalog.test.ts tests/unit/gpt-max-input-tokens-6191.test.ts`
- [ ] `npm run lint`
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- Updated `tests/unit/codex-gpt56-catalog.test.ts` to pin `contextLength` and `maxInputTokens` at `272000` for every registered Codex GPT-5.6 variant.

## Coverage Notes

- `tests/unit/codex-gpt56-catalog.test.ts` directly exercises every registry entry using `GPT_5_6_CODEX_CAPABILITIES`.
- Focused run: 5 tests passed, 0 failed.

## Reviewer Notes

- Source of truth: https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json
- OpenAI changed these models from `372000` to `272000` in https://github.com/openai/codex/commit/d26a9bf671b1c03aabfc32e1092d137c1feb3962 and shipped the correction in Codex `0.144.6`.
- No migration or feature flag.
