### PR TITLE
[v3.8.50] fix(api): defer media body size limits to providers

### DIFF
--- a/changelog.d/fixes/8843-provider-media-body-limits.md
+++ b/changelog.d/fixes/8843-provider-media-body-limits.md
@@ -1,0 +1,1 @@
+- **fix(api):** Let image and video providers enforce their own request-size limits instead of rejecting media payloads at OmniRoute's 10 MB global default ([#8843](https://github.com/diegosouzapw/OmniRoute/pull/8843)) — thanks @artickc

--- a/src/shared/middleware/bodySizeGuard.ts
+++ b/src/shared/middleware/bodySizeGuard.ts
@@ -31,8 +31,15 @@ export const MAX_BODY_BYTES_FILE = 500 * 1024 * 1024;
 /** Larger limit for LLM request payloads: 50 MB */
 export const MAX_BODY_BYTES_LLM_API = 50 * 1024 * 1024;
 
-/** Allows one 20 MiB image as multipart or base64 JSON plus envelope overhead. */
-export const MAX_BODY_BYTES_IMAGE_EDIT = 30 * 1024 * 1024;
+/**
+ * Media (image generate / edit / upscale / video) is not capped by OmniRoute.
+ * JSON + base64 inflates payloads by roughly 33%, and provider limits vary by model,
+ * so the provider should decide whether a media request is too large.
+ */
+export const MAX_BODY_BYTES_MEDIA = Number.POSITIVE_INFINITY;
+
+/** @deprecated Use MAX_BODY_BYTES_MEDIA — kept as alias for any external imports. */
+export const MAX_BODY_BYTES_IMAGE_EDIT = MAX_BODY_BYTES_MEDIA;
 
 /** Configured limit — reads from env or falls back to 10 MB */
 export const MAX_BODY_BYTES = parseRequestBodyLimitBytes(process.env.MAX_BODY_SIZE_BYTES);
@@ -43,10 +50,13 @@ const ROUTE_LIMITS: BodySizeRule[] = [
   { prefix: "/api/db-backups/import", limit: MAX_BODY_BYTES_IMPORT },
   { prefix: "/api/v1/chat/completions", limit: MAX_BODY_BYTES_LLM_API },
   { prefix: "/api/v1/responses", limit: MAX_BODY_BYTES_LLM_API },
-  { prefix: "/api/v1/images/edits", limit: MAX_BODY_BYTES_IMAGE_EDIT },
+  { prefix: "/api/v1/images", limit: MAX_BODY_BYTES_MEDIA },
+  { prefix: "/api/v1/videos", limit: MAX_BODY_BYTES_MEDIA },
   { prefix: "/api/v1/audio/transcriptions", limit: MAX_BODY_BYTES_AUDIO },
   { prefix: "/api/v1/files", limit: MAX_BODY_BYTES_FILE },
 ];
+
+const PROVIDER_IMAGE_GENERATION_ROUTE = /^\/api\/v1\/providers\/[^/]+\/images\/generations(?:\/|$)/;
 
 export function getConfiguredBodySizeLimitBytes(settings?: Record<string, unknown>): number {
   const configuredMb = normalizeRequestBodyLimitMb(settings?.maxBodySizeMb);
@@ -58,6 +68,7 @@ export function getConfiguredBodySizeLimitBytes(settings?: Record<string, unknow
  */
 export function getBodySizeLimit(pathname: string, settings?: Record<string, unknown>): number {
   const configuredLimit = getConfiguredBodySizeLimitBytes(settings);
+  if (PROVIDER_IMAGE_GENERATION_ROUTE.test(pathname)) return MAX_BODY_BYTES_MEDIA;
   const customRule = ROUTE_LIMITS.find((rule) => pathname.startsWith(rule.prefix));
   return customRule ? Math.max(customRule.limit, configuredLimit) : configuredLimit;
 }

--- a/tests/unit/body-size-guard.test.ts
+++ b/tests/unit/body-size-guard.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_BODY_BYTES_AUDIO,
   MAX_BODY_BYTES_FILE,
   MAX_BODY_BYTES_IMAGE_EDIT,
+  MAX_BODY_BYTES_MEDIA,
   MAX_BODY_BYTES_LLM_API,
   RequestBodyTooLargeError,
   readRequestBodyWithLimit,
@@ -45,7 +46,7 @@ test("body size guard keeps dedicated upload limits as lower bounds", () => {
   );
   assert.equal(
     getBodySizeLimit("/api/v1/images/edits", { maxBodySizeMb: 10 }),
-    MAX_BODY_BYTES_IMAGE_EDIT
+    MAX_BODY_BYTES_MEDIA
   );
 });
 
@@ -170,4 +171,68 @@ test("/api/v1/files route guard allows 15 MB (10 MB+ real-world scenario)", () =
     headers: { "content-length": String(fifteenMb) },
   });
   assert.equal(checkBodySize(request, getBodySizeLimit("/api/v1/files")), null);
+});
+
+test("media routes bypass OmniRoute's configured body-size limit", () => {
+  assert.equal(MAX_BODY_BYTES_MEDIA, Number.POSITIVE_INFINITY);
+  assert.equal(MAX_BODY_BYTES_IMAGE_EDIT, MAX_BODY_BYTES_MEDIA);
+  assert.equal(
+    getBodySizeLimit("/api/v1/images/generations", { maxBodySizeMb: 10 }),
+    MAX_BODY_BYTES_MEDIA
+  );
+  assert.equal(
+    getBodySizeLimit("/api/v1/images/edits", { maxBodySizeMb: 10 }),
+    MAX_BODY_BYTES_MEDIA
+  );
+  assert.equal(
+    getBodySizeLimit("/api/v1/images/upscale", { maxBodySizeMb: 10 }),
+    MAX_BODY_BYTES_MEDIA
+  );
+  assert.equal(
+    getBodySizeLimit("/api/v1/videos/generations", { maxBodySizeMb: 10 }),
+    MAX_BODY_BYTES_MEDIA
+  );
+  assert.equal(
+    getBodySizeLimit("/api/v1/providers/openai/images/generations", { maxBodySizeMb: 10 }),
+    MAX_BODY_BYTES_MEDIA
+  );
+});
+
+test("media routes never return OmniRoute's PAYLOAD_TOO_LARGE response", () => {
+  for (const pathname of [
+    "/api/v1/images/generations",
+    "/api/v1/videos/generations",
+    "/api/v1/providers/openai/images/generations",
+  ]) {
+    const request = new Request(`http://localhost${pathname}`, {
+      method: "POST",
+      headers: { "content-length": String(Number.MAX_SAFE_INTEGER) },
+    });
+    assert.equal(checkBodySize(request, getBodySizeLimit(pathname, { maxBodySizeMb: 10 })), null);
+  }
+});
+
+test("provider media matching does not unbound adjacent provider routes", () => {
+  const configuredLimit = requestBodyLimitMbToBytes(10);
+  for (const pathname of [
+    "/api/v1/providers/openai/chat/completions",
+    "/api/v1/providers/openai/embeddings",
+    "/api/v1/providers/openai/images/generations-extra",
+  ]) {
+    assert.equal(getBodySizeLimit(pathname, { maxBodySizeMb: 10 }), configuredLimit);
+  }
+});
+
+test("image edit body reader does not enforce an OmniRoute media limit", async () => {
+  const request = new Request("http://localhost/api/v1/images/edits", {
+    method: "POST",
+    headers: { "content-length": String(Number.MAX_SAFE_INTEGER) },
+    body: new Uint8Array([1, 2, 3, 4]),
+  });
+
+  const body = await readRequestBodyWithLimit(
+    request,
+    getBodySizeLimit("/api/v1/images/edits", { maxBodySizeMb: 10 })
+  );
+  assert.deepEqual(body, new Uint8Array([1, 2, 3, 4]));
 });

--- a/tests/unit/image-generation-route.test.ts
+++ b/tests/unit/image-generation-route.test.ts
@@ -16,7 +16,6 @@ const imageRoute = await import("../../src/app/api/v1/images/generations/route.t
 const providerImageRoute =
   await import("../../src/app/api/v1/providers/[provider]/images/generations/route.ts");
 const imageEditRoute = await import("../../src/app/api/v1/images/edits/route.ts");
-const { MAX_BODY_BYTES_IMAGE_EDIT } = await import("../../src/shared/middleware/bodySizeGuard.ts");
 const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
 
 const originalFetch = globalThis.fetch;
@@ -216,21 +215,22 @@ test("v1 image generation POST still requires prompts for text-input models", as
   assert.match(body.error.message, /Prompt is required for image model: openai\/gpt-image-2/);
 });
 
-test("v1 image edit POST rejects a declared body above the image-edit admission limit", async () => {
+test("v1 image edit POST defers body-size validation to the provider", async () => {
   const response = await imageEditRoute.POST(
     new Request("http://localhost/api/v1/images/edits", {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "content-length": String(MAX_BODY_BYTES_IMAGE_EDIT + 1),
+        "content-length": String(Number.MAX_SAFE_INTEGER),
       },
       body: "{}",
     })
   );
   const body = (await response.json()) as ErrorResponseBody;
 
-  assert.equal(response.status, 413);
-  assert.match(body.error.message, /30 MiB limit/i);
+  assert.equal(response.status, 400);
+  assert.match(body.error.message, /Missing required field: prompt/i);
+  assert.doesNotMatch(body.error.message, /request body|payload too large/i);
 });
 
 test("v1 image edit POST enforces disabled API key policy", async () => {


### PR DESCRIPTION
## Summary

- Stop OmniRoute from returning its hardcoded `413 PAYLOAD_TOO_LARGE` response for `/api/v1/images/*`, `/api/v1/videos/*`, and `/api/v1/providers/{provider}/images/generations`.
- Resolve direct media routes and the narrowly matched provider-specific image-generation route to an unbounded guard sentinel so both the global `Content-Length` admission check and the streamed image-edit reader defer size validation to the selected provider.
- Keep the existing finite limits unchanged for chat/responses, audio, files, backups, and every other route.
- Add the required changelog fragment for the user-visible fix.

The reported failure happened before provider dispatch in `src/shared/middleware/bodySizeGuard.ts`:

```json
{"error":{"message":"Request body too large. Maximum allowed: 10 MB","type":"payload_too_large","code":"PAYLOAD_TOO_LARGE"}}
```

Base64 media adds roughly 33% envelope overhead and provider limits vary by model, so OmniRoute's global 10 MB default was not an appropriate authority for image/video payloads.

## Related Issues

- Related to #8791

## Validation

- [x] Focused tests: `node --import tsx/esm --test tests/unit/body-size-guard.test.ts tests/unit/image-generation-route.test.ts` — 34/34 passed
- [x] `npm run lint` — passed
- [x] `npm run typecheck:core` — passed
- [x] `npm run check:changelog-integrity` — passed
- [x] Production-code changes include updated automated tests in this PR
- [x] Refreshed GitHub CI: DAST, all four unit shards, Fast Quality/typechecks, lint, Vitest, docs, changelog integrity, and Semgrep passed; the non-blocking advisory Next build was canceled by a runner shutdown while the workflow concluded success

## Tests Added Or Updated

- `tests/unit/body-size-guard.test.ts`
  - asserts direct image generation, image edits, image upscale, video generation, and provider-specific image generation resolve to the unbounded media limit;
  - asserts even `Number.MAX_SAFE_INTEGER` in `Content-Length` cannot produce OmniRoute's media `PAYLOAD_TOO_LARGE` response;
  - exercises the streamed image-edit reader with the same declaration;
  - verifies adjacent provider chat, embeddings, and lookalike paths remain bounded;`n  - preserves existing tests that verify finite non-media limits still reject oversized requests.
- `tests/unit/image-generation-route.test.ts`
  - replaces the old 413 contract with a route-level assertion that a huge declared image-edit body reaches ordinary request validation;
  - verifies the response is the expected missing-prompt 400 and does not contain a payload-size error.

## Coverage Notes

The focused suites cover direct media and provider-specific image-generation matching in `src/shared/middleware/bodySizeGuard.ts` through both consumers, `checkBodySize()` and `readRequestBodyWithLimit()`, plus the real image-edit route. No coverage was removed.

## Reviewer Notes

This removes only OmniRoute's own media admission cap. Runtime/framework constraints and each upstream provider's native validation still apply. Non-media protections are unchanged.