### PR TITLE
fix(ci): raise the git ls-files buffer in check:tracked-artifacts

### DIFF
--- a/changelog.d/fixes/8844-tracked-artifacts-ls-files-buffer.md
+++ b/changelog.d/fixes/8844-tracked-artifacts-ls-files-buffer.md
@@ -1,0 +1,1 @@
+- **CI**: `check:tracked-artifacts` raises the `git ls-files` stdout ceiling to 64 MiB — the default 1 MiB `execFileSync` buffer had only ~6 KB of headroom against the tracked tree, and overflowing it throws ENOBUFS in the pre-commit hook, breaking `git commit` for everyone working the repo

--- a/scripts/check/check-tracked-artifacts.mjs
+++ b/scripts/check/check-tracked-artifacts.mjs
@@ -51,8 +51,17 @@ export function checkTrackedArtifacts(trackedFiles, trackedSymlinks = []) {
   return violations;
 }
 
+/**
+ * `execFileSync` defaults to a 1 MiB stdout buffer and throws ENOBUFS past it.
+ * This check runs on pre-commit, so crossing that line breaks committing for
+ * the whole repo, not just the change that crossed it. `git ls-files -s` is
+ * already at ~1.04 MB here and only grows, so the ceiling is set far above any
+ * plausible tree instead of just above today's.
+ */
+const GIT_LS_OPTS = { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 };
+
 function getTrackedFiles() {
-  const output = execFileSync("git", ["ls-files"], { encoding: "utf8" });
+  const output = execFileSync("git", ["ls-files"], GIT_LS_OPTS);
   return output
     .split("\n")
     .map((l) => l.trim())
@@ -62,7 +71,7 @@ function getTrackedFiles() {
 function getTrackedSymlinks() {
   // git ls-files -s prints: <mode> <hash> <stage>\t<path>
   // mode 120000 = symlink
-  const output = execFileSync("git", ["ls-files", "-s"], { encoding: "utf8" });
+  const output = execFileSync("git", ["ls-files", "-s"], GIT_LS_OPTS);
   const symlinks = [];
   for (const line of output.split("\n")) {
     if (line.startsWith("120000")) {


### PR DESCRIPTION
## The problem

`check:tracked-artifacts` shells out to `git ls-files` twice through `execFileSync`, which defaults to a **1 MiB** stdout buffer and throws `ENOBUFS` past it.

On this repo right now:

```
git ls-files -s  →  1,042,494 bytes  (11,091 tracked files)
execFileSync cap →  1,048,576 bytes
                    ---------------
                    6,082 bytes of headroom
```

Roughly sixty more tracked files and it goes over.

## Why it is worth fixing before that happens

The check runs on **pre-commit**. Once the listing crosses the line, `execFileSync` throws and the hook fails — so committing breaks for *everyone* working the repo, not just for the change that pushed it over. The person who hits it has no obvious connection between "I added some files" and "git commit stopped working", and the error is a raw ENOBUFS stack trace.

This is not hypothetical. The private fork hit it this week: a sync landed ~214 translation files, `git ls-files -s` went from 1,028,401 to 1,049,080 bytes — **504 bytes** over — and every commit failed the hook until this same fix landed.

## The fix

Both call sites share a `GIT_LS_OPTS` with a 64 MiB ceiling. Set far above any plausible tree rather than just above today's, since the listing only ever grows — a snug bump would just move the reincidence a few hundred files down the road.

## Verification

```
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```

No dedicated test exists for this script; the failure mode is an environment-size threshold rather than logic, and reproducing it in a test would mean fabricating an 11k-file tree.