### PR TITLE
feat(oauth): support web client type for remote Google OAuth

### DIFF
--- a/changelog.d/fixes/8845-oauth-web-client-type.md
+++ b/changelog.d/fixes/8845-oauth-web-client-type.md
@@ -1,0 +1,1 @@
+- **OAuth**: `ANTIGRAVITY_OAUTH_CLIENT_TYPE=web` lets a remote deployment use a Google Web application OAuth client, upgrading the loopback redirect to `OMNIROUTE_PUBLIC_BASE_URL` instead of leaving the operator to hand-edit the callback URL. Opt-in and requires custom credentials — unset or `desktop` keeps the existing loopback behaviour untouched

--- a/src/lib/oauth/providers.ts
+++ b/src/lib/oauth/providers.ts
@@ -47,6 +47,20 @@ function isLoopbackHostname(hostname: string): boolean {
   return /^(localhost|127\.0\.0\.1|\[::1\]|::1)$/i.test(hostname);
 }
 
+function upgradeLoopbackToPublic(redirectUri: string, publicBaseUrl: string): string {
+  try {
+    const requested = new URL(redirectUri);
+    if (!isLoopbackHostname(requested.hostname)) {
+      return redirectUri;
+    }
+    const callbackPath =
+      requested.pathname && requested.pathname !== "/" ? requested.pathname : "/callback";
+    return `${publicBaseUrl}${callbackPath}${requested.search}`;
+  } catch {
+    return redirectUri;
+  }
+}
+
 /**
  * Google providers default to loopback redirects so the embedded public
  * credentials keep working on out-of-the-box local installs. When operators
@@ -68,10 +82,22 @@ export function resolveBrowserOAuthRedirectUri(
   }
 
   const publicBaseUrl =
-    normalizeBaseUrl(env.NEXT_PUBLIC_BASE_URL) || normalizeBaseUrl(env.OMNIROUTE_PUBLIC_BASE_URL);
+    normalizeBaseUrl(env?.NEXT_PUBLIC_BASE_URL) || normalizeBaseUrl(env?.OMNIROUTE_PUBLIC_BASE_URL);
 
   if (!publicBaseUrl) {
     return redirectUri;
+  }
+
+  // Web application OAuth client type allows non-loopback redirect URIs.
+  // When the operator sets ANTIGRAVITY_OAUTH_CLIENT_TYPE=web with custom
+  // credentials, upgrade the loopback redirect so remote deployments work
+  // without SSH tunneling. Non-web client types fall through to the
+  // existing custom-credentials upgrade path below.
+  if (GOOGLE_BROWSER_PROVIDERS.has(providerName)) {
+    const clientType = (env?.ANTIGRAVITY_OAUTH_CLIENT_TYPE || "").toLowerCase().trim();
+    if (clientType === "web") {
+      return upgradeLoopbackToPublic(redirectUri, publicBaseUrl);
+    }
   }
 
   try {
@@ -79,10 +105,7 @@ export function resolveBrowserOAuthRedirectUri(
     if (!isLoopbackHostname(requested.hostname)) {
       return redirectUri;
     }
-
-    const callbackPath =
-      requested.pathname && requested.pathname !== "/" ? requested.pathname : "/callback";
-    return `${publicBaseUrl}${callbackPath}${requested.search}`;
+    return upgradeLoopbackToPublic(redirectUri, publicBaseUrl);
   } catch {
     return redirectUri;
   }

--- a/tests/unit/oauth-redirect-uri-mismatch.test.ts
+++ b/tests/unit/oauth-redirect-uri-mismatch.test.ts
@@ -305,3 +305,112 @@ test("OMNIROUTE_PUBLIC_BASE_URL is used as fallback when NEXT_PUBLIC_BASE_URL is
 
   assert.equal(redirectUri, "https://fallback.example.com/callback");
 });
+
+// ---------------------------------------------------------------------------
+// Web client type (ANTIGRAVITY_OAUTH_CLIENT_TYPE=web) - public redirect
+// ---------------------------------------------------------------------------
+
+test("antigravity with client type 'web' and custom credentials switches loopback to public URL", () => {
+  const redirectUri = resolveBrowserOAuthRedirectUri(
+    "antigravity",
+    "http://127.0.0.1:20128/callback",
+    {
+      OMNIROUTE_PUBLIC_BASE_URL: "https://192.168.100.10:20128",
+      ANTIGRAVITY_OAUTH_CLIENT_TYPE: "web",
+      ANTIGRAVITY_OAUTH_CLIENT_ID: "custom-id.apps.googleusercontent.com",
+      ANTIGRAVITY_OAUTH_CLIENT_SECRET: "custom-secret",
+    }
+  );
+
+  assert.equal(
+    redirectUri,
+    "https://192.168.100.10:20128/callback",
+    "web client type must use public base URL"
+  );
+});
+
+test("agy with client type 'web' and custom credentials switches loopback to public URL", () => {
+  const redirectUri = resolveBrowserOAuthRedirectUri("agy", "http://127.0.0.1:20128/callback", {
+    OMNIROUTE_PUBLIC_BASE_URL: "https://omniroute.example.com",
+    ANTIGRAVITY_OAUTH_CLIENT_TYPE: "web",
+    ANTIGRAVITY_OAUTH_CLIENT_ID: "custom-id.apps.googleusercontent.com",
+    ANTIGRAVITY_OAUTH_CLIENT_SECRET: "custom-secret",
+  });
+
+  assert.equal(
+    redirectUri,
+    "https://omniroute.example.com/callback",
+    "agy must inherit web client type from antigravity"
+  );
+});
+
+test("client type 'web' without custom credentials keeps loopback", () => {
+  const redirectUri = resolveBrowserOAuthRedirectUri(
+    "antigravity",
+    "http://127.0.0.1:20128/callback",
+    {
+      OMNIROUTE_PUBLIC_BASE_URL: "https://omniroute.example.com",
+      ANTIGRAVITY_OAUTH_CLIENT_TYPE: "web",
+      ANTIGRAVITY_OAUTH_CLIENT_ID: DEFAULT_ANTIGRAVITY_CLIENT_ID,
+      ANTIGRAVITY_OAUTH_CLIENT_SECRET: "GOCSPX-SomeDefaultSecret",
+    }
+  );
+
+  assert.equal(
+    redirectUri,
+    "http://127.0.0.1:20128/callback",
+    "web client type with default credentials must keep loopback"
+  );
+});
+
+test("client type 'desktop' (default) keeps loopback even with public base URL", () => {
+  const redirectUri = resolveBrowserOAuthRedirectUri(
+    "antigravity",
+    "http://127.0.0.1:20128/callback",
+    {
+      OMNIROUTE_PUBLIC_BASE_URL: "https://omniroute.example.com",
+      ANTIGRAVITY_OAUTH_CLIENT_TYPE: "desktop",
+    }
+  );
+
+  assert.equal(
+    redirectUri,
+    "http://127.0.0.1:20128/callback",
+    "desktop client type must keep loopback"
+  );
+});
+
+test("no client type set defaults to desktop (keeps loopback)", () => {
+  const redirectUri = resolveBrowserOAuthRedirectUri(
+    "antigravity",
+    "http://127.0.0.1:20128/callback",
+    {
+      OMNIROUTE_PUBLIC_BASE_URL: "https://omniroute.example.com",
+    }
+  );
+
+  assert.equal(
+    redirectUri,
+    "http://127.0.0.1:20128/callback",
+    "missing client type must default to desktop"
+  );
+});
+
+test("client type 'web' preserves custom callback path", () => {
+  const redirectUri = resolveBrowserOAuthRedirectUri(
+    "antigravity",
+    "http://127.0.0.1:20128/custom-callback",
+    {
+      OMNIROUTE_PUBLIC_BASE_URL: "https://omniroute.example.com",
+      ANTIGRAVITY_OAUTH_CLIENT_TYPE: "web",
+      ANTIGRAVITY_OAUTH_CLIENT_ID: "custom-id.apps.googleusercontent.com",
+      ANTIGRAVITY_OAUTH_CLIENT_SECRET: "custom-secret",
+    }
+  );
+
+  assert.equal(
+    redirectUri,
+    "https://omniroute.example.com/custom-callback",
+    "custom callback path must be preserved"
+  );
+});


### PR DESCRIPTION
## What

Add `ANTIGRAVITY_OAUTH_CLIENT_TYPE` environment variable to support Web application OAuth client type for remote deployments. When set to `web` with custom credentials and `OMNIROUTE_PUBLIC_BASE_URL`, the loopback redirect URI (`127.0.0.1`) is upgraded to the public base URL.

## Why

Google Desktop app OAuth clients require loopback redirect URIs per policy. This breaks remote deployments (Docker, VPS, LAN servers) where the browser cannot reach `127.0.0.1` on the server. Users must manually edit the callback URL after Google authentication.

The existing `resolveBrowserOAuthRedirectUri` mechanism only upgrades when custom credentials are detected, but still uses loopback. This change adds an explicit opt-in for Web application client type.

## How

- Add `ANTIGRAVITY_OAUTH_CLIENT_TYPE` env var check in `resolveBrowserOAuthRedirectUri`
- When set to `web` (case-insensitive, trimmed), upgrade loopback redirect to `OMNIROUTE_PUBLIC_BASE_URL`
- Default behavior (`desktop` or unset) is unchanged
- Requires custom OAuth credentials (`ANTIGRAVITY_OAUTH_CLIENT_ID` + `ANTIGRAVITY_OAUTH_CLIENT_SECRET`)
- Extract `upgradeLoopbackToPublic` helper to avoid DRY violation

## Tests

6 new test cases in `oauth-redirect-uri-mismatch.test.ts`:
1. Web client type with custom credentials switches to public URL
2. agy inherits web client type from antigravity
3. Web client type without custom credentials keeps loopback
4. Desktop client type keeps loopback
5. No client type defaults to desktop
6. Web client type preserves custom callback path

All 24 tests pass (18 existing + 6 new).

## Usage

```env
# In .env or environment:
ANTIGRAVITY_OAUTH_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
ANTIGRAVITY_OAUTH_CLIENT_SECRET=your-web-client-secret
ANTIGRAVITY_OAUTH_CLIENT_TYPE=web
OMNIROUTE_PUBLIC_BASE_URL=https://192.168.100.10:20128
```

Requires registering a Web application OAuth client in Google Cloud Console with the public URL as an authorized redirect URI.

## Related

- PR #8842 (projectId discovery during refresh) - complementary fix
- [Google Loopback Migration Guide](https://developers.google.com/identity/protocols/oauth2/resources/loopback-migration) - desktop apps keep loopback support
