### PR TITLE
fix(oauth): support Test Connection for xAI OAuth

### DIFF
--- a/changelog.d/fixes/xai-oauth-test-connection.md
+++ b/changelog.d/fixes/xai-oauth-test-connection.md
@@ -1,0 +1,1 @@
+- **fix(oauth):** wire Test Connection for xAI OAuth (`xai-oauth` / `xao`) so dashboard no longer returns "Provider test not supported" ([#8862](https://github.com/diegosouzapw/OmniRoute/pull/8862)) — thanks @allanvb

--- a/src/app/api/providers/[id]/test/oauthTestConfig.ts
+++ b/src/app/api/providers/[id]/test/oauthTestConfig.ts
@@ -7,6 +7,23 @@ const CLINE_OAUTH_TEST_CONFIG = {
   refreshable: true,
 };
 
+// Shared api.x.ai chat probe for apikey `xai` and OAuth `xai-oauth` / alias `xao`.
+const XAI_CHAT_OAUTH_TEST_CONFIG = {
+  url: "https://api.x.ai/v1/chat/completions",
+  method: "POST",
+  authHeader: "Authorization",
+  authPrefix: "Bearer ",
+  extraHeaders: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    model: "grok-4.3",
+    messages: [{ role: "user", content: "ping" }],
+    max_tokens: 1,
+    stream: false,
+    reasoning: { effort: "high" },
+  }),
+  refreshable: true,
+};
+
 // OAuth provider test endpoints. Extracted from route.ts (#7610) so adding a
 // provider entry doesn't grow the frozen route.ts file past its check-file-size
 // cap — this module carries no logic of its own beyond the GitLab URL builder.
@@ -63,21 +80,9 @@ export const OAUTH_TEST_CONFIG = {
     authPrefix: "Bearer ",
     refreshable: true,
   },
-  xai: {
-    url: "https://api.x.ai/v1/chat/completions",
-    method: "POST",
-    authHeader: "Authorization",
-    authPrefix: "Bearer ",
-    extraHeaders: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: "grok-4.3",
-      messages: [{ role: "user", content: "ping" }],
-      max_tokens: 1,
-      stream: false,
-      reasoning: { effort: "high" },
-    }),
-    refreshable: true,
-  },
+  xai: XAI_CHAT_OAUTH_TEST_CONFIG,
+  "xai-oauth": XAI_CHAT_OAUTH_TEST_CONFIG,
+  xao: XAI_CHAT_OAUTH_TEST_CONFIG,
   github: {
     url: "https://api.github.com/user",
     method: "GET",

--- a/tests/unit/oauth-test-config-8408.test.ts
+++ b/tests/unit/oauth-test-config-8408.test.ts
@@ -16,7 +16,6 @@ const GRANDFATHERED_WITHOUT_TEST_CONFIG = new Set([
   "zed-hosted",
   "trae",
   "windsurf",
-  "xai-oauth",
 ]);
 
 test("#8408: devin-cli and agy are present in OAUTH_TEST_CONFIG", () => {

--- a/tests/unit/xai-oauth-test-supported.test.ts
+++ b/tests/unit/xai-oauth-test-supported.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// xai-oauth was grandfathered without OAUTH_TEST_CONFIG (#8408), so dashboard
+// "Test Connection" always returned "Provider test not supported" and stored
+// testStatus=error on a working OAuth account. Mirror grok-cli #7610 coverage.
+const { testOAuthConnection } = await import("../../src/app/api/providers/[id]/test/route.ts");
+const { OAUTH_TEST_CONFIG } =
+  await import("../../src/app/api/providers/[id]/test/oauthTestConfig.ts");
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("OAUTH_TEST_CONFIG covers xai-oauth and alias xao", () => {
+  assert.ok((OAUTH_TEST_CONFIG as Record<string, unknown>)["xai-oauth"]);
+  assert.ok((OAUTH_TEST_CONFIG as Record<string, unknown>).xao);
+});
+
+test("xai-oauth Test Connection is no longer unsupported", async () => {
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+  const result = await testOAuthConnection({
+    provider: "xai-oauth",
+    accessToken: "healthy-access-token",
+    refreshToken: "healthy-refresh-token",
+    tokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+
+  assert.notEqual(result.diagnosis?.type, "unsupported");
+  assert.notEqual(result.error, "Provider test not supported");
+  assert.equal(result.valid, true);
+});
+
+test("xao alias Test Connection uses the same probe", async () => {
+  let calledUrl = "";
+  globalThis.fetch = async (url) => {
+    calledUrl = String(url);
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  const result = await testOAuthConnection({
+    provider: "xao",
+    accessToken: "healthy-access-token",
+    tokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(calledUrl, "https://api.x.ai/v1/chat/completions");
+});


### PR DESCRIPTION
## Summary

Fixes dashboard **Test Connection** for **xAI OAuth (Grok)** (`xai-oauth`, alias `xao`).

Until now, testing an xAI OAuth connection always failed with **"Provider test not supported"** and could leave a healthy account marked as error. The OAuth connection id was never wired into the OAuth test table, even though the shared api.x.ai chat probe already existed for the apikey `xai` entry.

Test Connection now uses the same live probe the runtime chat path uses: `POST https://api.x.ai/v1/chat/completions` with the connection access token.

## Implementation

- Reuse the existing api.x.ai chat probe (`grok-4.3`, `max_tokens: 1`, `reasoning.effort: high`) as a shared config.
- Register it for `xai`, `xai-oauth`, and alias `xao`.
- Remove `xai-oauth` from the #8408 grandfathered “no test config” list.
- Add focused regression coverage so Test Connection is no longer reported as unsupported.

## Validation

- [x] Focused tests: `node --import tsx/esm --test tests/unit/xai-oauth-test-supported.test.ts tests/unit/oauth-test-config-8408.test.ts tests/unit/grok-cli-oauth-test-supported-7610.test.ts` (6 passed)
- [ ] `npm run lint`
- [x] New automated tests in this PR

## Coverage Notes

Change is small and lives in the OAuth Test Connection config plus unit coverage around `testOAuthConnection`. Focused tests cover config presence, the unsupported-path regression for `xai-oauth`, and the `xao` alias probe URL.

## Reviewer Notes

No migration, no feature flag.

Probe path matches registry/runtime: `xai-oauth` inherits `https://api.x.ai/v1/chat/completions` from the apikey `xai` provider. Auth is `Authorization: Bearer *** same as `XaiExecutor` / `BaseExecutor.buildHeaders`.

`xao` is included because that public alias is used elsewhere in routing/usage; DB connections are normally `xai-oauth`.

Manual check: connect xAI OAuth -> Providers -> Test Connection. Expected: real auth result (ok / 401), not "Provider test not supported".