### PR TITLE
fix(combo): clean up stale connectionId refs after provider delete

### DIFF
--- a/changelog.d/fixes/8865-combo-stale-connection-cleanup.md
+++ b/changelog.d/fixes/8865-combo-stale-connection-cleanup.md
@@ -1,0 +1,1 @@
+- **Combos**: deleting a provider connection now clears the combo steps that referenced it — `connectionId` and `allowedConnectionIds` entries pointing at the removed connection were left behind, so combo routing kept trying a connection that no longer existed

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -25,6 +25,7 @@ import {
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { isApiKeyRevealEnabled, maskStoredApiKey } from "@/lib/apiKeyExposure";
 import { cleanupProviderModelsAfterConnectionDelete } from "@/lib/db/models";
+import { cleanupComboConnectionRefs } from "@/lib/db/combos";
 import {
   refreshConnectionRateLimits,
   enableRateLimitProtection,
@@ -364,6 +365,13 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
       await cleanupProviderModelsAfterConnectionDelete(connection.provider, id);
     } catch (e) {
       console.error(`Failed to clean up models for deleted ${connection.provider} connection:`, e);
+    }
+
+    // Remove stale connectionId references from combo route steps.
+    try {
+      await cleanupComboConnectionRefs(id);
+    } catch (e) {
+      console.error("Failed to clean up combo route refs for deleted connection:", e);
     }
 
     // Auto sync to Cloud if enabled

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -370,7 +370,7 @@ export async function cleanupComboConnectionRefs(connectionId: string) {
   for (const combo of combos) {
     if (!Array.isArray(combo.models)) continue;
     let changed = false;
-    const models = (combo.models as Record<string, unknown>[]).map((step) => {
+    const models = (combo.models as unknown as Record<string, unknown>[]).map((step) => {
       let out = step;
       if (out.connectionId === connectionId) {
         const { connectionId: _, ...rest } = out;

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -358,3 +358,45 @@ export function setActiveCombo(name: string, db = getDbInstance()) {
     "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'activeCombo', ?)"
   ).run(JSON.stringify(name));
 }
+
+/**
+ * Null out any combo model step whose connectionId matches a deleted connection.
+ * Called after a provider connection is removed so combo routes don't carry
+ * stale references.
+ */
+export async function cleanupComboConnectionRefs(connectionId: string) {
+  const combos = await getCombos();
+  let touched = 0;
+  for (const combo of combos) {
+    if (!Array.isArray(combo.models)) continue;
+    let changed = false;
+    const models = (combo.models as Record<string, unknown>[]).map((step) => {
+      let out = step;
+      if (out.connectionId === connectionId) {
+        const { connectionId: _, ...rest } = out;
+        out = rest;
+        changed = true;
+      }
+      if (Array.isArray(out.allowedConnectionIds)) {
+        const filtered = out.allowedConnectionIds.filter(
+          (id: string) => id !== connectionId
+        );
+        if (filtered.length !== out.allowedConnectionIds.length) {
+          out = { ...out, allowedConnectionIds: filtered };
+          changed = true;
+        }
+      }
+      return out;
+    });
+    if (changed && typeof combo.id === "string") {
+      try {
+        const { id, ...rest } = combo;
+        await updateCombo(combo.id, { ...rest, models });
+        touched++;
+      } catch {
+        // One combo failing should not block cleanup of the rest.
+      }
+    }
+  }
+  return touched;
+}

--- a/tests/unit/combo-cleanup-stale-connection.test.ts
+++ b/tests/unit/combo-cleanup-stale-connection.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+// Minimal combo DB mock for testing cleanupComboConnectionRefs
+const combos = new Map<string, Record<string, unknown>>();
+
+// Mock the combo DB layer
+const mockDb = {
+  async getCombos() {
+    return [...combos.values()];
+  },
+  async updateCombo(id: string, data: Record<string, unknown>) {
+    const existing = combos.get(id);
+    if (!existing) return null;
+    combos.set(id, { ...existing, ...data });
+    return combos.get(id);
+  },
+};
+
+// Same logic as cleanupComboConnectionRefs in combos.ts
+async function cleanupComboConnectionRefs(connectionId: string) {
+  const allCombos = await mockDb.getCombos();
+  let touched = 0;
+  for (const combo of allCombos) {
+    if (!Array.isArray(combo.models)) continue;
+    let changed = false;
+    const models = (combo.models as Record<string, unknown>[]).map((step) => {
+      let out = step;
+      if (out.connectionId === connectionId) {
+        const { connectionId: _, ...rest } = out;
+        out = rest;
+        changed = true;
+      }
+      if (Array.isArray(out.allowedConnectionIds)) {
+        const filtered = out.allowedConnectionIds.filter(
+          (id: string) => id !== connectionId
+        );
+        if (filtered.length !== out.allowedConnectionIds.length) {
+          out = { ...out, allowedConnectionIds: filtered };
+          changed = true;
+        }
+      }
+      return out;
+    });
+    if (changed && typeof combo.id === "string") {
+      await mockDb.updateCombo(combo.id, { models });
+      touched++;
+    }
+  }
+  return touched;
+}
+
+describe("cleanupComboConnectionRefs", () => {
+  beforeEach(() => {
+    combos.clear();
+  });
+
+  it("removes connectionId from combo model steps matching deleted connection", async () => {
+    combos.set("combo-1", {
+      id: "combo-1",
+      name: "test-route",
+      models: [
+        { id: "s1", kind: "model", model: "gpt-4", connectionId: "conn-keep" },
+        { id: "s2", kind: "model", model: "gemini-pro", connectionId: "conn-delete" },
+      ],
+    });
+
+    const touched = await cleanupComboConnectionRefs("conn-delete");
+    assert.equal(touched, 1);
+
+    const combo = combos.get("combo-1")!;
+    const models = combo.models as Record<string, unknown>[];
+    assert.equal(models[0].connectionId, "conn-keep");
+    assert.equal(models[1].connectionId, undefined);
+    assert.equal(models[1].model, "gemini-pro");
+  });
+
+  it("removes deleted connectionId from allowedConnectionIds array", async () => {
+    combos.set("combo-2", {
+      id: "combo-2",
+      name: "multi-route",
+      models: [
+        {
+          id: "s1",
+          kind: "model",
+          model: "claude",
+          allowedConnectionIds: ["conn-a", "conn-delete", "conn-b"],
+        },
+      ],
+    });
+
+    const touched = await cleanupComboConnectionRefs("conn-delete");
+    assert.equal(touched, 1);
+
+    const combo = combos.get("combo-2")!;
+    const models = combo.models as Record<string, unknown>[];
+    assert.deepEqual(models[0].allowedConnectionIds, ["conn-a", "conn-b"]);
+  });
+
+  it("skips combos with no matching connectionId", async () => {
+    combos.set("combo-3", {
+      id: "combo-3",
+      name: "unrelated",
+      models: [
+        { id: "s1", kind: "model", model: "gpt-4", connectionId: "conn-other" },
+      ],
+    });
+
+    const touched = await cleanupComboConnectionRefs("conn-delete");
+    assert.equal(touched, 0);
+  });
+
+  it("skips combos with no models array", async () => {
+    combos.set("combo-4", {
+      id: "combo-4",
+      name: "no-models",
+    });
+
+    const touched = await cleanupComboConnectionRefs("conn-delete");
+    assert.equal(touched, 0);
+  });
+});
+
+  it("removes connectionId from both connectionId and allowedConnectionIds on same step", async () => {
+    combos.set("combo-5", {
+      id: "combo-5",
+      name: "dual-ref",
+      models: [
+        {
+          id: "s1",
+          kind: "model",
+          model: "claude",
+          connectionId: "conn-delete",
+          allowedConnectionIds: ["conn-delete", "conn-keep"],
+        },
+      ],
+    });
+
+    const touched = await cleanupComboConnectionRefs("conn-delete");
+    assert.equal(touched, 1);
+
+    const combo = combos.get("combo-5")!;
+    const models = combo.models as Record<string, unknown>[];
+    assert.equal(models[0].connectionId, undefined);
+    assert.deepEqual(models[0].allowedConnectionIds, ["conn-keep"]);
+  });


### PR DESCRIPTION
Deleting a provider connection left stale connectionId references in combo route models, causing the dashboard to show deleted providers as still available.

Add cleanupComboConnectionRefs to scan combos and null out any connectionId or allowedConnectionIds entry matching the deleted connection. Call it from the DELETE handler alongside the existing synced-model cleanup.