### PR TITLE
fix(logs): avoid giant provider pills for failed auto family requests

### DIFF
--- a/changelog.d/fixes/8867-rejected-combo-provider-label.md
+++ b/changelog.d/fixes/8867-rejected-combo-provider-label.md
@@ -1,0 +1,1 @@
+- **Logs**: a failed `auto/<family>` request no longer writes every attempted model into `call_logs.provider` — the logs page builds its quick-filter pills from that column, so one failure produced a giant chip that flooded the filter row. Rejected combo requests are now labelled `auto` (for `auto/*`) or by the combo's own name

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -908,16 +908,13 @@ export async function handleChat(
     // (success:false) so gate/breaker-rejected traffic is counted per key — support-mesh 2026-07-08.
     if (!response.ok) {
       try {
-        const { recordRejectedRequestUsage } =
+        const { recordRejectedRequestUsage, resolveRejectedComboProvider } =
           await import("./rejectedRequestUsage");
         await recordRejectedRequestUsage({
           status: response.status,
           model: body?.model || resolvedModelStr,
           requestedModel: body?.model || resolvedModelStr,
-          provider:
-            (body?.model || resolvedModelStr)?.startsWith("auto/")
-              ? "auto"
-              : combo.name || "combo",
+          provider: resolveRejectedComboProvider(body?.model || resolvedModelStr, combo.name),
           endpoint: clientRawRequest?.endpoint,
           error: await getComboFailureLogError(response, combo.name),
           comboName: combo.name,

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -908,13 +908,16 @@ export async function handleChat(
     // (success:false) so gate/breaker-rejected traffic is counted per key — support-mesh 2026-07-08.
     if (!response.ok) {
       try {
-        const { recordRejectedRequestUsage, summarizeComboAttemptedModels } =
+        const { recordRejectedRequestUsage } =
           await import("./rejectedRequestUsage");
         await recordRejectedRequestUsage({
           status: response.status,
           model: body?.model || resolvedModelStr,
           requestedModel: body?.model || resolvedModelStr,
-          provider: summarizeComboAttemptedModels(combo?.models),
+          provider:
+            (body?.model || resolvedModelStr)?.startsWith("auto/")
+              ? "auto"
+              : combo.name || "combo",
           endpoint: clientRawRequest?.endpoint,
           error: await getComboFailureLogError(response, combo.name),
           comboName: combo.name,

--- a/src/sse/handlers/rejectedRequestUsage.ts
+++ b/src/sse/handlers/rejectedRequestUsage.ts
@@ -127,3 +127,20 @@ export function summarizeComboAttemptedModels(models: unknown): string {
     .filter((entry): entry is string => Boolean(entry));
   return modelStrings.length > 0 ? modelStrings.join(", ") : "-";
 }
+
+/**
+ * Provider label for a REJECTED combo request (#8867).
+ *
+ * summarizeComboAttemptedModels() joins every attempted model, which is right for
+ * diagnostics but wrong for `call_logs.provider`: the logs page builds its quick-filter
+ * pills from that column, so one failed `auto/gemma` turned into a chip listing a dozen
+ * models and flooded the filter row. Keep it short and categorical instead — `auto` for
+ * auto/* requests, otherwise the combo's own name.
+ */
+export function resolveRejectedComboProvider(
+  model: string | null | undefined,
+  comboName: string | null | undefined
+): string {
+  if (typeof model === "string" && model.startsWith("auto/")) return "auto";
+  return comboName || "combo";
+}

--- a/tests/unit/rejected-request-usage.test.ts
+++ b/tests/unit/rejected-request-usage.test.ts
@@ -24,7 +24,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 const core = await import("../../src/lib/db/core.ts");
 const usageHistory = await import("../../src/lib/usage/usageHistory.ts");
 const callLogs = await import("../../src/lib/usage/callLogs.ts");
-const { recordRejectedRequestUsage, summarizeComboAttemptedModels } =
+const { recordRejectedRequestUsage, summarizeComboAttemptedModels, resolveRejectedComboProvider } =
   await import("../../src/sse/handlers/rejectedRequestUsage.ts");
 
 test.beforeEach(() => {
@@ -174,4 +174,25 @@ test("summarizeComboAttemptedModels falls back to '-' for empty, missing, or inv
   assert.equal(summarizeComboAttemptedModels(null), "-");
   assert.equal(summarizeComboAttemptedModels("not-an-array"), "-");
   assert.equal(summarizeComboAttemptedModels([{ kind: "combo-ref" }, { foo: "bar" }]), "-");
+});
+
+test("#8867: resolveRejectedComboProvider keeps the provider label short for auto/* failures", () => {
+  // The logs page builds quick-filter pills from call_logs.provider — a failed
+  // auto/<family> used to write every attempted model there and flood the filter row.
+  assert.equal(resolveRejectedComboProvider("auto/gemma", "my-combo"), "auto");
+  assert.equal(resolveRejectedComboProvider("auto/gemini", null), "auto");
+  assert.equal(resolveRejectedComboProvider("auto/anything-at-all", undefined), "auto");
+});
+
+test("#8867: a non-auto combo failure is labelled with the combo name", () => {
+  assert.equal(resolveRejectedComboProvider("gpt-5.6-sol", "balanced-load"), "balanced-load");
+  assert.equal(resolveRejectedComboProvider(null, "balanced-load"), "balanced-load");
+});
+
+test("#8867: falls back to 'combo' when there is no name, and 'auto' never leaks into it", () => {
+  assert.equal(resolveRejectedComboProvider("gpt-5.6-sol", null), "combo");
+  assert.equal(resolveRejectedComboProvider(undefined, undefined), "combo");
+  assert.equal(resolveRejectedComboProvider("", ""), "combo");
+  // bare "auto" (no slash) is NOT a family request — it must not be collapsed
+  assert.equal(resolveRejectedComboProvider("auto", "named-combo"), "named-combo");
 });


### PR DESCRIPTION
## Problem

Failed `auto/<family>` requests currently write the attempted model list into `call_logs.provider`:

- `cerebras/gemma-4-31b, nvidia/google/gemma-4-31b-it, ...`
- `lmarena/gemini-3.1-flash-lite, ...`

The logs page uses `provider` to build quick-filter pills, so one failed `auto/gemma` or `auto/gemini` request creates a giant provider chip that floods the filter row.

## Root Cause

`src/sse/handlers/chat.ts` calls `recordRejectedRequestUsage()` on combo failures and passes:

```ts
provider: summarizeComboAttemptedModels(combo?.models)
```

That helper joins every attempted model with `, `.

## Fix

For rejected combo requests, keep `provider` short and categorical:

- `auto` for `auto/*` failures
- `combo.name` for other combo failures
- fallback `combo`

This preserves the logs UI provider filter semantics and avoids giant pills. The detailed failure info is still carried by the error/combo fields.

## Verified

Locally verified against failing `auto/gemini` requests: new `call_logs` rows now store `provider = "auto"` instead of the comma-joined candidate list.
