### PR TITLE
fix(opencode): complete generated model limits

### DIFF
--- a/changelog.d/fixes/8869-opencode-complete-model-limits.md
+++ b/changelog.d/fixes/8869-opencode-complete-model-limits.md
@@ -1,0 +1,1 @@
+- **fix(opencode):** generate schema-complete model limits so OpenCode accepts catalog entries without an explicit output cap ([#8869](https://github.com/diegosouzapw/OmniRoute/pull/8869)) — thanks @xiaoyaner0201

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
         "lint-staged": "^17.0.8",
         "lockfile-lint": "^5.0.0",
         "node-loader": "^2.1.0",
+        "opencode-ai": "1.18.8",
         "playwright-ctrf-json-reporter": "^0.0.29",
         "prettier": "^3.8.3",
         "promptfoo": "^0.121.18",
@@ -29004,6 +29005,205 @@
           "optional": true
         }
       }
+    },
+    "node_modules/opencode-ai": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-ai/-/opencode-ai-1.18.8.tgz",
+      "integrity": "sha512-eZvYK0rIc/NUDQ+s3LsO9gyUU3MswsbNOLZz06iPwVhbg/2jF6bkTaroBgiIdFWKwUn5sj+kSMc4TBYxFkMrNQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.18.8",
+        "opencode-darwin-x64": "1.18.8",
+        "opencode-darwin-x64-baseline": "1.18.8",
+        "opencode-linux-arm64": "1.18.8",
+        "opencode-linux-arm64-musl": "1.18.8",
+        "opencode-linux-x64": "1.18.8",
+        "opencode-linux-x64-baseline": "1.18.8",
+        "opencode-linux-x64-baseline-musl": "1.18.8",
+        "opencode-linux-x64-musl": "1.18.8",
+        "opencode-windows-arm64": "1.18.8",
+        "opencode-windows-x64": "1.18.8",
+        "opencode-windows-x64-baseline": "1.18.8"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.8.tgz",
+      "integrity": "sha512-ZZCIEgTvHxOHk52Aeqhq59t/R0aqs29bPIgu45XE4rkgjmn/XCkTWalCPtyzJHipdcEbq/g0lqsE1OlJV0oNbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-darwin-x64/-/opencode-darwin-x64-1.18.8.tgz",
+      "integrity": "sha512-2EXRMJbRKnFPWI9oDU9tb7jDGmKiPmfjCLtwJMe3EF57h5wfcdEH9sP25bR3Og5NbE2M+PtMcJm0jMeHn2XoLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.8.tgz",
+      "integrity": "sha512-eLXa2tK9LRuZ5e20QG2k4dmWAA5xnLgJ1afRTSD0/ybE6CAeK02i8vFCnFFDaxuBo+gnq+yqO8AkqvN1m64V/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-linux-arm64/-/opencode-linux-arm64-1.18.8.tgz",
+      "integrity": "sha512-7kj3c9JEdryHgK+o8zE/N9KzTOdbiDn6KpY8dl+hM9n5Cnmxezx4IAlgJeC9QxpIx8Omop6CYuZ+17KfrKdKLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.8.tgz",
+      "integrity": "sha512-tww5TF/LIOv/GoTNyzGYgqDRhbJrhoMu8R+p5yD/SpnXPg3rcfYREw2wRy9yikyPU9sAQksuIIteTsyGerPjlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-linux-x64/-/opencode-linux-x64-1.18.8.tgz",
+      "integrity": "sha512-Sm4fbQ9BdLI6hgN6FYYX8Nql+Sqe/2EKHJu3iWg0UYs93AXN4ROi0rvOmRbMk+ycYgOchb0hL6Ti2opxLx17sg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.8.tgz",
+      "integrity": "sha512-egeEF4tk1rK9flIQjjeSVB9cR/X3zUti0pNAHW6ROJkNkj72z2C2FmjK1hZbfjtteCueMXPLptS23JROHGWL1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.8.tgz",
+      "integrity": "sha512-S+438BXs48gLeXX/ya4TSNytDy9mliU3sOAf6j9rfFjzGiF/S08LedemSAnHkr0riBtamik1aRPSmTjhQ0dOBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.8.tgz",
+      "integrity": "sha512-c+E4Zsp0DYVcuqcDtgxw/4YcFLrVYWdGBR8x4CzpW48ga3RshaH+BlmUiy+GY0yr1x6UR+e2V3w4uzvzm/L9UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-windows-arm64/-/opencode-windows-arm64-1.18.8.tgz",
+      "integrity": "sha512-7NjdtEIiX28kmsKD9jHbFG4bbwBB5T4dAe2UwdnOqCBb2cl+ETV5eO6kbdC/xWxrgOghgZM1Wtw791T5pQPyag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-windows-x64/-/opencode-windows-x64-1.18.8.tgz",
+      "integrity": "sha512-G+NEgEMvu/dEYshH5IaqHVTmsHVuGdORBvVmgphFiknT7q/NXPuoZCMtMIdfNlEFbu54BlzRDdJCR3Mqe98gUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.8.tgz",
+      "integrity": "sha512-IGbjFyWoSN9rdGUJX7TWkQ1Yl673Q3dDna54b5NtqeRcZ839p+Z47zzM5m883HKAxrdKCC6Z22HYuDcXLV0laA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/opener": {
       "version": "1.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29008,7 +29008,7 @@
     },
     "node_modules/opencode-ai": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-ai/-/opencode-ai-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.8.tgz",
       "integrity": "sha512-eZvYK0rIc/NUDQ+s3LsO9gyUU3MswsbNOLZz06iPwVhbg/2jF6bkTaroBgiIdFWKwUn5sj+kSMc4TBYxFkMrNQ==",
       "cpu": [
         "arm64",
@@ -29042,7 +29042,7 @@
     },
     "node_modules/opencode-darwin-arm64": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.8.tgz",
       "integrity": "sha512-ZZCIEgTvHxOHk52Aeqhq59t/R0aqs29bPIgu45XE4rkgjmn/XCkTWalCPtyzJHipdcEbq/g0lqsE1OlJV0oNbA==",
       "cpu": [
         "arm64"
@@ -29055,7 +29055,7 @@
     },
     "node_modules/opencode-darwin-x64": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-darwin-x64/-/opencode-darwin-x64-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.8.tgz",
       "integrity": "sha512-2EXRMJbRKnFPWI9oDU9tb7jDGmKiPmfjCLtwJMe3EF57h5wfcdEH9sP25bR3Og5NbE2M+PtMcJm0jMeHn2XoLQ==",
       "cpu": [
         "x64"
@@ -29068,7 +29068,7 @@
     },
     "node_modules/opencode-darwin-x64-baseline": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.8.tgz",
       "integrity": "sha512-eLXa2tK9LRuZ5e20QG2k4dmWAA5xnLgJ1afRTSD0/ybE6CAeK02i8vFCnFFDaxuBo+gnq+yqO8AkqvN1m64V/Q==",
       "cpu": [
         "x64"
@@ -29081,7 +29081,7 @@
     },
     "node_modules/opencode-linux-arm64": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-linux-arm64/-/opencode-linux-arm64-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.8.tgz",
       "integrity": "sha512-7kj3c9JEdryHgK+o8zE/N9KzTOdbiDn6KpY8dl+hM9n5Cnmxezx4IAlgJeC9QxpIx8Omop6CYuZ+17KfrKdKLw==",
       "cpu": [
         "arm64"
@@ -29094,7 +29094,7 @@
     },
     "node_modules/opencode-linux-arm64-musl": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.8.tgz",
       "integrity": "sha512-tww5TF/LIOv/GoTNyzGYgqDRhbJrhoMu8R+p5yD/SpnXPg3rcfYREw2wRy9yikyPU9sAQksuIIteTsyGerPjlA==",
       "cpu": [
         "arm64"
@@ -29110,7 +29110,7 @@
     },
     "node_modules/opencode-linux-x64": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-linux-x64/-/opencode-linux-x64-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.8.tgz",
       "integrity": "sha512-Sm4fbQ9BdLI6hgN6FYYX8Nql+Sqe/2EKHJu3iWg0UYs93AXN4ROi0rvOmRbMk+ycYgOchb0hL6Ti2opxLx17sg==",
       "cpu": [
         "x64"
@@ -29123,7 +29123,7 @@
     },
     "node_modules/opencode-linux-x64-baseline": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.8.tgz",
       "integrity": "sha512-egeEF4tk1rK9flIQjjeSVB9cR/X3zUti0pNAHW6ROJkNkj72z2C2FmjK1hZbfjtteCueMXPLptS23JROHGWL1w==",
       "cpu": [
         "x64"
@@ -29136,7 +29136,7 @@
     },
     "node_modules/opencode-linux-x64-baseline-musl": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.8.tgz",
       "integrity": "sha512-S+438BXs48gLeXX/ya4TSNytDy9mliU3sOAf6j9rfFjzGiF/S08LedemSAnHkr0riBtamik1aRPSmTjhQ0dOBg==",
       "cpu": [
         "x64"
@@ -29152,7 +29152,7 @@
     },
     "node_modules/opencode-linux-x64-musl": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.8.tgz",
       "integrity": "sha512-c+E4Zsp0DYVcuqcDtgxw/4YcFLrVYWdGBR8x4CzpW48ga3RshaH+BlmUiy+GY0yr1x6UR+e2V3w4uzvzm/L9UQ==",
       "cpu": [
         "x64"
@@ -29168,7 +29168,7 @@
     },
     "node_modules/opencode-windows-arm64": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-windows-arm64/-/opencode-windows-arm64-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.8.tgz",
       "integrity": "sha512-7NjdtEIiX28kmsKD9jHbFG4bbwBB5T4dAe2UwdnOqCBb2cl+ETV5eO6kbdC/xWxrgOghgZM1Wtw791T5pQPyag==",
       "cpu": [
         "arm64"
@@ -29181,7 +29181,7 @@
     },
     "node_modules/opencode-windows-x64": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-windows-x64/-/opencode-windows-x64-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.8.tgz",
       "integrity": "sha512-G+NEgEMvu/dEYshH5IaqHVTmsHVuGdORBvVmgphFiknT7q/NXPuoZCMtMIdfNlEFbu54BlzRDdJCR3Mqe98gUw==",
       "cpu": [
         "x64"
@@ -29194,7 +29194,7 @@
     },
     "node_modules/opencode-windows-x64-baseline": {
       "version": "1.18.8",
-      "resolved": "https://registry.npmmirror.com/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.8.tgz",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.8.tgz",
       "integrity": "sha512-IGbjFyWoSN9rdGUJX7TWkQ1Yl673Q3dDna54b5NtqeRcZ839p+Z47zzM5m883HKAxrdKCC6Z22HYuDcXLV0laA==",
       "cpu": [
         "x64"

--- a/package.json
+++ b/package.json
@@ -363,6 +363,7 @@
     "lint-staged": "^17.0.8",
     "lockfile-lint": "^5.0.0",
     "node-loader": "^2.1.0",
+    "opencode-ai": "1.18.8",
     "playwright-ctrf-json-reporter": "^0.0.29",
     "prettier": "^3.8.3",
     "promptfoo": "^0.121.18",

--- a/src/lib/cli-helper/config-generator/opencode.ts
+++ b/src/lib/cli-helper/config-generator/opencode.ts
@@ -21,10 +21,11 @@ const CONFIG_PATH = path.join(os.homedir(), ".config", "opencode", "opencode.jso
 export function assertSafeCatalogUrl(rawUrl: string): URL {
   const url = parseOutboundUrl(rawUrl); // throws on bad protocol / embedded creds
   if (isCloudMetadataHost(url.hostname)) {
-    throw new OutboundUrlGuardError(
-      "Blocked cloud-metadata catalog URL (SSRF protection)",
-      { code: "OUTBOUND_URL_GUARD_BLOCKED", url: url.toString(), hostname: url.hostname }
-    );
+    throw new OutboundUrlGuardError("Blocked cloud-metadata catalog URL (SSRF protection)", {
+      code: "OUTBOUND_URL_GUARD_BLOCKED",
+      url: url.toString(),
+      hostname: url.hostname,
+    });
   }
   // Return the re-parsed URL so callers fetch the validated value (a `new URL()`
   // round-trip is a recognized request-forgery barrier — clears CodeQL #326).
@@ -127,9 +128,7 @@ export async function fetchOmniRouteCatalog(
       signal: controller.signal,
     });
     if (!response.ok) {
-      throw new Error(
-        `OmniRoute /v1/models returned ${response.status} ${response.statusText}`
-      );
+      throw new Error(`OmniRoute /v1/models returned ${response.status} ${response.statusText}`);
     }
     const body = (await response.json()) as unknown;
     const list: unknown[] = Array.isArray(body)
@@ -219,10 +218,7 @@ function buildModelEntry(
   // (OpenCode v1 defaults to 128K when `limit.context` is missing.)
   const userLimit = existing?.limit?.context;
   const catalogLimit = catalog ? resolveContextLength(catalog) : undefined;
-  const context =
-    typeof userLimit === "number" && userLimit > 0
-      ? userLimit
-      : catalogLimit;
+  const context = typeof userLimit === "number" && userLimit > 0 ? userLimit : catalogLimit;
 
   // `limit.output` is REQUIRED by OpenCode's v1 provider schema (configV1).
   // Use the catalog's max_output_tokens when available; otherwise fall
@@ -237,21 +233,18 @@ function buildModelEntry(
       ? catalog.max_output_tokens
       : undefined;
   const output =
-    typeof userOutput === "number" && userOutput > 0
-      ? userOutput
-      : catalogOutput ?? 8_192;
+    typeof userOutput === "number" && userOutput > 0 ? userOutput : (catalogOutput ?? 8_192);
 
   // Emit `limit` only if we have at least one of context/output. We never
   // emit a half-baked limit block with only an `output` (would be misleading).
-  if (typeof context === "number" || typeof userOutput === "number" || typeof catalogOutput === "number") {
+  if (
+    typeof context === "number" ||
+    typeof userOutput === "number" ||
+    typeof catalogOutput === "number"
+  ) {
     const limit: { context?: number; input?: number; output?: number } = {};
     if (typeof context === "number") limit.context = context;
-    if (typeof userOutput === "number" || typeof catalogOutput === "number") {
-      limit.output =
-        typeof userOutput === "number" && userOutput > 0
-          ? userOutput
-          : catalogOutput ?? 8_192;
-    }
+    limit.output = output;
     const userInput = existing?.limit?.input;
     if (typeof userInput === "number" && userInput > 0) {
       limit.input = userInput;
@@ -324,9 +317,7 @@ export interface GenerateOpencodeOptions {
  *  - Throws if the catalog fetch fails — the user must fix the upstream
  *    before we can generate a reliable opencode.json.
  */
-export async function generateOpencodeConfig(
-  options: GenerateOpencodeOptions
-): Promise<string> {
+export async function generateOpencodeConfig(options: GenerateOpencodeOptions): Promise<string> {
   const cleanBase = options.baseUrl.replace(/\/+$/, "");
   const baseURL = cleanBase.endsWith("/v1") ? cleanBase : `${cleanBase}/v1`;
 

--- a/tests/integration/opencode-config-startup.test.ts
+++ b/tests/integration/opencode-config-startup.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { after, it } from "node:test";
+
+const OPENCODE_VERSION = "1.18.8";
+const require = createRequire(import.meta.url);
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-opencode-8849-"));
+const originalHome = process.env.HOME;
+const originalFetch = globalThis.fetch;
+
+process.env.HOME = testHome;
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+function runOpencode(binary: string, args: string[]) {
+  const xdgRoot = path.join(testHome, "xdg");
+  const result = spawnSync(binary, args, {
+    cwd: testHome,
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      XDG_CONFIG_HOME: path.join(xdgRoot, "config"),
+      XDG_DATA_HOME: path.join(xdgRoot, "data"),
+      XDG_CACHE_HOME: path.join(xdgRoot, "cache"),
+      XDG_STATE_HOME: path.join(xdgRoot, "state"),
+      NO_COLOR: "1",
+      OPENCODE_DISABLE_AUTOUPDATE: "1",
+    },
+  });
+
+  assert.ifError(result.error);
+  return result;
+}
+
+it("#8849 generated config is accepted by pinned OpenCode schema and startup", async () => {
+  const packageJsonPath = require.resolve("opencode-ai/package.json");
+  const opencodeBinary = path.join(path.dirname(packageJsonPath), "bin", "opencode.exe");
+  assert.ok(fs.existsSync(opencodeBinary), `missing pinned OpenCode ${OPENCODE_VERSION} binary`);
+
+  const version = runOpencode(opencodeBinary, ["--version"]);
+  assert.strictEqual(version.status, 0, version.stderr);
+  assert.strictEqual(version.stdout.trim(), OPENCODE_VERSION);
+
+  const catalog = {
+    object: "list",
+    data: [
+      { id: "context-only", context_length: 131072 },
+      { id: "context-input", context_length: 131072, max_input_tokens: 100000 },
+      {
+        id: "context-input-output",
+        context_length: 131072,
+        max_input_tokens: 100000,
+        max_output_tokens: 32768,
+      },
+      { id: "no-limit-metadata" },
+    ],
+  };
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(catalog), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  const { generateOpencodeConfig } =
+    await import("../../src/lib/cli-helper/config-generator/opencode.ts");
+  const generatedConfig = await generateOpencodeConfig({
+    baseUrl: "http://127.0.0.1:9/v1",
+    apiKey: "sk-test",
+    providerId: "issue8849",
+  });
+
+  const configDir = path.join(testHome, "xdg", "config", "opencode");
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, "opencode.json"), generatedConfig);
+
+  const configCheck = runOpencode(opencodeBinary, ["debug", "config", "--pure"]);
+  assert.strictEqual(configCheck.status, 0, configCheck.stderr);
+  assert.doesNotMatch(configCheck.stderr, /Missing key .*\.limit\.output/);
+  const resolvedConfig = JSON.parse(configCheck.stdout);
+  assert.ok(resolvedConfig.provider.issue8849.models["context-only"].limit.output > 0);
+  assert.strictEqual(
+    resolvedConfig.provider.issue8849.models["context-input-output"].limit.output,
+    32768
+  );
+  assert.strictEqual(
+    resolvedConfig.provider.issue8849.models["no-limit-metadata"].limit,
+    undefined
+  );
+
+  const startup = runOpencode(opencodeBinary, ["debug", "startup", "--pure"]);
+  assert.strictEqual(startup.status, 0, startup.stderr);
+  assert.match(startup.stdout.trim(), /^\d+(?:\.\d+)?$/);
+  assert.doesNotMatch(startup.stderr, /Missing key .*\.limit\.output/);
+});

--- a/tests/unit/cli-helper/config-generator.test.ts
+++ b/tests/unit/cli-helper/config-generator.test.ts
@@ -23,9 +23,7 @@ function readUiHermesRoleIds(): string[] {
 }
 
 function readEnMessages(): { cliTools?: Record<string, string> } {
-  const enJsonPath = fileURLToPath(
-    new URL("../../../src/i18n/messages/en.json", import.meta.url)
-  );
+  const enJsonPath = fileURLToPath(new URL("../../../src/i18n/messages/en.json", import.meta.url));
   return JSON.parse(readFileSync(enJsonPath, "utf-8"));
 }
 
@@ -49,9 +47,8 @@ describe("config-generator", () => {
 
   describe("assertSafeCatalogUrl (SSRF guard, CodeQL #326)", () => {
     it("allows the loopback OmniRoute target (the legitimate default) and returns a URL", async () => {
-      const { assertSafeCatalogUrl } = await import(
-        "../../../src/lib/cli-helper/config-generator/opencode.ts"
-      );
+      const { assertSafeCatalogUrl } =
+        await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
       // The catalog source IS the user's own OmniRoute — localhost must stay allowed.
       assert.doesNotThrow(() => assertSafeCatalogUrl("http://localhost:20128/v1/models"));
       assert.doesNotThrow(() => assertSafeCatalogUrl("http://127.0.0.1:20128/v1/models"));
@@ -62,26 +59,21 @@ describe("config-generator", () => {
     });
 
     it("allows a public OmniRoute Cloud target", async () => {
-      const { assertSafeCatalogUrl } = await import(
-        "../../../src/lib/cli-helper/config-generator/opencode.ts"
-      );
+      const { assertSafeCatalogUrl } =
+        await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
       assert.doesNotThrow(() => assertSafeCatalogUrl("https://api.omniroute.online/v1/models"));
     });
 
     it("blocks the cloud-metadata SSRF→IAM pivot (169.254.169.254)", async () => {
-      const { assertSafeCatalogUrl } = await import(
-        "../../../src/lib/cli-helper/config-generator/opencode.ts"
-      );
+      const { assertSafeCatalogUrl } =
+        await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
       assert.throws(() => assertSafeCatalogUrl("http://169.254.169.254/v1/models"));
-      assert.throws(() =>
-        assertSafeCatalogUrl("http://metadata.google.internal/v1/models")
-      );
+      assert.throws(() => assertSafeCatalogUrl("http://metadata.google.internal/v1/models"));
     });
 
     it("blocks non-http(s) protocols and embedded credentials", async () => {
-      const { assertSafeCatalogUrl } = await import(
-        "../../../src/lib/cli-helper/config-generator/opencode.ts"
-      );
+      const { assertSafeCatalogUrl } =
+        await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
       assert.throws(() => assertSafeCatalogUrl("file:///etc/passwd"));
       assert.throws(() => assertSafeCatalogUrl("http://user:pass@example.com/v1/models"));
     });
@@ -231,7 +223,9 @@ describe("config-generator", () => {
       assert.ok(arrayMatch, "could not locate HERMES_ROLES array in HermesAgentToolCard.tsx");
       const body = arrayMatch[1];
       const roleEntries = Array.from(
-        body.matchAll(/id:\s*"([a-z0-9_]+)"[\s\S]*?labelKey:\s*"([A-Za-z0-9]+)"[\s\S]*?descriptionKey:\s*"([A-Za-z0-9]+)"/g)
+        body.matchAll(
+          /id:\s*"([a-z0-9_]+)"[\s\S]*?labelKey:\s*"([A-Za-z0-9]+)"[\s\S]*?descriptionKey:\s*"([A-Za-z0-9]+)"/g
+        )
       ).map((m) => ({ id: m[1], labelKey: m[2], descriptionKey: m[3] }));
       assert.ok(roleEntries.length > 0, "expected at least one role entry to be parsed");
 
@@ -350,10 +344,20 @@ describe("config-generator", () => {
     }
 
     const SAMPLE_CATALOG: unknown[] = [
-      { id: "ds/deepseek-v4-flash", owned_by: "deepseek", context_length: 1_000_000, max_input_tokens: 1_000_000 },
+      {
+        id: "ds/deepseek-v4-flash",
+        owned_by: "deepseek",
+        context_length: 1_000_000,
+        max_input_tokens: 1_000_000,
+      },
       { id: "llama3", owned_by: "llama", max_context_window_tokens: 8192 },
       { id: "MASTER", owned_by: "combo", context_length: 131072, max_input_tokens: 131072 },
-      { id: "Opencode FREE Omni", owned_by: "combo", context_length: 200000, max_input_tokens: 160000 },
+      {
+        id: "Opencode FREE Omni",
+        owned_by: "combo",
+        context_length: 200000,
+        max_input_tokens: 160000,
+      },
       // Combo whose targets have no known context — generator must NOT
       // fabricate a default. The model is emitted without limit.context.
       { id: "NO_CTX_COMBO", owned_by: "combo" },
@@ -381,9 +385,8 @@ describe("config-generator", () => {
     it("emits limit.context from the catalog (no hardcoded fallback)", async () => {
       const stub = stubFetchOnce(makeCatalogResponse(SAMPLE_CATALOG));
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",
@@ -403,9 +406,8 @@ describe("config-generator", () => {
     it("does NOT fabricate a default context when the catalog has no entry", async () => {
       const stub = stubFetchOnce(makeCatalogResponse(SAMPLE_CATALOG));
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",
@@ -429,9 +431,8 @@ describe("config-generator", () => {
     it("prefers max_context_window_tokens when context_length is absent", async () => {
       const stub = stubFetchOnce(makeCatalogResponse(SAMPLE_CATALOG));
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",
@@ -454,9 +455,8 @@ describe("config-generator", () => {
         throw new Error("ECONNREFUSED");
       }) as typeof fetch;
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         let threw = false;
         try {
           await generateOpencodeConfig({
@@ -479,9 +479,8 @@ describe("config-generator", () => {
     it("writes a top-level model prefixed with provider id when options.model is supplied", async () => {
       const stub = stubFetchOnce(makeCatalogResponse(SAMPLE_CATALOG));
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",
@@ -500,9 +499,8 @@ describe("config-generator", () => {
       // the catalog's actual value.
       const stub = stubFetchOnce(makeCatalogResponse(SAMPLE_CATALOG));
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",
@@ -532,9 +530,8 @@ describe("config-generator", () => {
       ];
       const stub = stubFetchOnce(makeCatalogResponse(catalog));
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",
@@ -594,9 +591,8 @@ describe("config-generator", () => {
         ])
       );
       try {
-        const { generateOpencodeConfig } = await import(
-          "../../../src/lib/cli-helper/config-generator/opencode.ts"
-        );
+        const { generateOpencodeConfig } =
+          await import("../../../src/lib/cli-helper/config-generator/opencode.ts");
         const out = await generateOpencodeConfig({
           baseUrl: "http://localhost:20128",
           apiKey: "sk-test",

--- a/tests/unit/cli-helper/config-generator.test.ts
+++ b/tests/unit/cli-helper/config-generator.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import assert from "node:assert";
-import { readFileSync } from "node:fs";
+import fs, { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as generator from "../../../src/lib/cli-helper/config-generator/index.ts";
 
@@ -515,6 +515,106 @@ describe("config-generator", () => {
         );
       } finally {
         stub.restore();
+      }
+    });
+
+    it("#8849 emits a complete limit for catalog metadata without fabricating one", async () => {
+      const catalog = [
+        { id: "context-only", context_length: 131072 },
+        { id: "context-input", context_length: 131072, max_input_tokens: 100000 },
+        {
+          id: "context-input-output",
+          context_length: 131072,
+          max_input_tokens: 100000,
+          max_output_tokens: 32768,
+        },
+        { id: "no-metadata" },
+      ];
+      const stub = stubFetchOnce(makeCatalogResponse(catalog));
+      try {
+        const { generateOpencodeConfig } = await import(
+          "../../../src/lib/cli-helper/config-generator/opencode.ts"
+        );
+        const out = await generateOpencodeConfig({
+          baseUrl: "http://localhost:20128",
+          apiKey: "sk-test",
+          providerId: "issue8849",
+        });
+        const models = JSON.parse(out).provider.issue8849.models;
+
+        assert.deepStrictEqual(models["context-only"].limit, {
+          context: 131072,
+          output: 8192,
+        });
+        assert.deepStrictEqual(models["context-input"].limit, {
+          context: 131072,
+          input: 100000,
+          output: 8192,
+        });
+        assert.deepStrictEqual(models["context-input-output"].limit, {
+          context: 131072,
+          input: 100000,
+          output: 32768,
+        });
+        assert.strictEqual(models["no-metadata"].limit, undefined);
+
+        for (const model of Object.values(models) as Array<{ limit?: { output?: number } }>) {
+          assert.ok(
+            model.limit === undefined ||
+              (typeof model.limit.output === "number" && model.limit.output > 0),
+            "every emitted limit must contain a positive output"
+          );
+        }
+      } finally {
+        stub.restore();
+      }
+    });
+
+    it("#8849 preserves manual output precedence over catalog and fallback values", async () => {
+      const existingConfig = {
+        provider: {
+          issue8849: {
+            models: {
+              "manual-vs-catalog": { limit: { output: 16384 } },
+              "manual-vs-fallback": { limit: { output: 4096 } },
+            },
+          },
+        },
+      };
+      mock.method(fs, "existsSync", () => true);
+      mock.method(fs, "readFileSync", () => JSON.stringify(existingConfig));
+      const stub = stubFetchOnce(
+        makeCatalogResponse([
+          {
+            id: "manual-vs-catalog",
+            context_length: 131072,
+            max_output_tokens: 32768,
+          },
+          { id: "manual-vs-fallback", context_length: 131072 },
+        ])
+      );
+      try {
+        const { generateOpencodeConfig } = await import(
+          "../../../src/lib/cli-helper/config-generator/opencode.ts"
+        );
+        const out = await generateOpencodeConfig({
+          baseUrl: "http://localhost:20128",
+          apiKey: "sk-test",
+          providerId: "issue8849",
+        });
+        const models = JSON.parse(out).provider.issue8849.models;
+
+        assert.deepStrictEqual(models["manual-vs-catalog"].limit, {
+          context: 131072,
+          output: 16384,
+        });
+        assert.deepStrictEqual(models["manual-vs-fallback"].limit, {
+          context: 131072,
+          output: 4096,
+        });
+      } finally {
+        stub.restore();
+        mock.restoreAll();
       }
     });
   });


### PR DESCRIPTION
## Summary

Fixes the OpenCode config generator so every emitted `limit` object is schema-complete while preserving the existing rule that models with no limit metadata omit `limit` entirely.

Fixes #8849.

## Root cause

`buildModelEntry()` computed an `8_192` output fallback, but the emission branch only assigned `limit.output` when an existing config or catalog value was already present. Catalog entries with context/input metadata but no output metadata therefore produced partial objects that OpenCode 1.18.8 rejects before startup.

## Changes

- complete emitted OpenCode model limits with the existing output fallback when catalog limit metadata exists but output is unknown;
- preserve explicit manual output overrides and verified catalog output values;
- keep models with no limit metadata free of a fabricated `limit` object;
- cover context-only, context+input, context+input+output, no-limit, and manual-override cases;
- pin `opencode-ai@1.18.8` as a test fixture and validate generated config through both the current schema and `debug startup`;
- keep the lockfile on the approved `https://registry.npmjs.org` registry.
- add the required `changelog.d/fixes/8869-opencode-complete-model-limits.md` fragment after the Draft PR number was assigned.

## TDD evidence

- Unit RED at `85398fd92185bbaaa3655388666ad38faff8e847`: the new #8849 matrix reproduced the incomplete-output regression (`1/2` issue tests passed; the regression assertion failed as expected).
- Unit GREEN at `f619612c1584adf8cd98661b572c853752d0cc62`: both #8849 issue tests passed.
- Integration RED at `99081f6526d689c2ef9b61036aa1687c3da3f7ce`: the startup test failed because the pinned OpenCode fixture was not installed (`Cannot find module 'opencode-ai/package.json'`).
- Fresh-install GREEN after `5fc74e87ccada210229dc501e2c85c9152fd1dd2` + `2d9471a4b44a142329ed5bcc1b8c3ec661a8f174`: clean `npm ci` and the CI-parity integration command passed against OpenCode 1.18.8.

## Verification

Code candidate after non-destructively merging the latest `release/v3.8.49`:

- base: `43625ecc3246e2bcb0e23fe265c6a36e3e1d260f`
- tested HEAD: `1737570ce4d86a412759922313f796cc60c43a5f`
- tested tree: `cd974b8258bcbe2bcd149df18e19fce34d998a18`
- final publication HEAD: `f1482b8a14239a5f3464dbdba5ba69d30eb9c749`
- final publication tree: `e9f7bbf080b8dfb7a6f82152238e69f0b5a851e2` (adds only the required changelog fragment)

Passed on the tested code tree:

- focused #8849 unit tests: `2/2`
- full related config-generator unit file: `30/30`
- pinned OpenCode schema/startup integration: `1/1`
- `npm run check:file-size`
- `npm run check:lockfile`
- `npm run check:test-discovery`
- `npm run check:test-runner-api`
- `npm run typecheck:core`
- Prettier check on all changed files
- ESLint on changed source/tests
- `npm ci --dry-run --ignore-scripts`
- full `npm run lint`
- full `npm run build` (passes with the repository's existing Turbopack broad-pattern warnings)
- `git diff --check upstream/release/v3.8.49...HEAD`

On the final publication tree, `npm run check:changelog-integrity`, Prettier for the fragment, the repository pre-commit hooks, and `git diff --check` also pass.

## Broader-suite caveat

A full `npm run test` was attempted. It did not terminate after more than 11 minutes because unrelated existing tests remained pending (`auth-noauth-fallback-loop-3061.test.ts` and `quota-redis-store.test.ts`). Before termination, four tests in `antigravity-oauth-postexchange-nonblocking.test.ts` were cancelled by the parent runner due pending-promise/event-loop interaction. That file is outside this PR's diff; run independently, it passes `5/5` on both this branch and the exact upstream base, each in about 32 seconds. No #8849-focused or related test failed.

## Review

An independent read-only review returned PASS with no unresolved blocking findings on the feature tree `2d9471a4b44a142329ed5bcc1b8c3ec661a8f174` / `340b3a5bb3213bc3377e4558f43e358a7e1588ae`. Final system acceptance was repeated after merging newer non-overlapping upstream commits and re-running the gates above.
