### PR TITLE
feat(db): add node sqlite adapter parity

### DIFF
--- a/changelog.d/features/8870-node-sqlite-adapter-parity.md
+++ b/changelog.d/features/8870-node-sqlite-adapter-parity.md
@@ -1,0 +1,1 @@
+- **Database**: The `node:sqlite` fallback now uses SQLite's native backup API and real immediate write transactions, improving backup consistency and concurrent-write behavior when `better-sqlite3` is unavailable

--- a/src/lib/db/adapters/nodeSqliteShared.ts
+++ b/src/lib/db/adapters/nodeSqliteShared.ts
@@ -19,6 +19,7 @@ export function createNodeSqliteAdapterFromDatabase(
   onClose?: () => void
 ): SqliteAdapter {
   let _isOpen = true;
+  let transactionDepth = 0;
   type NodeSqliteStatement = ReturnType<NodeSqliteDatabaseLike["prepare"]>;
   interface CachedStatement {
     stmt: NodeSqliteStatement;
@@ -66,6 +67,27 @@ export function createNodeSqliteAdapterFromDatabase(
         db.exec(`RELEASE "${sp}"`);
       } catch {}
       throw err;
+    }
+  }
+
+  function runImmediate(fn: () => void): void {
+    if (transactionDepth > 0) {
+      runSavepoint(fn);
+      return;
+    }
+
+    db.exec("BEGIN IMMEDIATE");
+    transactionDepth += 1;
+    try {
+      fn();
+      db.exec("COMMIT");
+    } catch (error) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {} // The failed transaction may already have released its write lock.
+      throw error;
+    } finally {
+      transactionDepth -= 1;
     }
   }
 
@@ -124,12 +146,25 @@ export function createNodeSqliteAdapterFromDatabase(
       return db.prepare(sql).all();
     },
     transaction<T>(fn: (...args: unknown[]) => T): (...args: unknown[]) => T {
-      return (...args: unknown[]) => runSavepoint(fn, ...args);
+      return (...args: unknown[]) => {
+        transactionDepth += 1;
+        try {
+          return runSavepoint(fn, ...args);
+        } finally {
+          transactionDepth -= 1;
+        }
+      };
     },
     immediate(fn: () => void): void {
-      runSavepoint(() => fn());
+      runImmediate(fn);
     },
     async backup(destination: string): Promise<void> {
+      const { backup } = await import("node:sqlite");
+      if (typeof backup === "function") {
+        await backup(db as never, destination);
+        return;
+      }
+
       try {
         db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
       } catch {}

--- a/tests/unit/db-adapters/driverFactory.test.ts
+++ b/tests/unit/db-adapters/driverFactory.test.ts
@@ -1,4 +1,4 @@
-import { test, describe } from "node:test";
+import { test, describe, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -20,7 +20,7 @@ function forceNodeSqlite() {
   });
 }
 
-function createTempDatabasePath(t: Parameters<typeof test>[1]) {
+function createTempDatabasePath(t: TestContext) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-node-sqlite-"));
   const databasePath = path.join(dir, "database.sqlite");
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -119,6 +119,7 @@ describe("driverFactory", () => {
         DatabaseSync: new (filePath: string) => {
           close(): void;
           exec(sql: string): void;
+          prepare(sql: string): { get(): unknown };
         };
       };
       const seed = new DatabaseSync(databasePath);
@@ -151,6 +152,101 @@ describe("driverFactory", () => {
         code: "ERR_INVALID_STATE",
       });
       adapter.close();
+    });
+
+    test("forced node:sqlite backup preserves WAL-backed data", async (t) => {
+      const sourcePath = createTempDatabasePath(t);
+      const destinationPath = path.join(path.dirname(sourcePath), "backup.sqlite");
+      const openNodeSqlite = forceNodeSqlite();
+      const source = openNodeSqlite(sourcePath);
+      assert.ok(source);
+      assert.equal(source.driver, "node:sqlite");
+      source.exec("PRAGMA journal_mode = WAL; CREATE TABLE items (value TEXT);");
+      source.prepare("INSERT INTO items VALUES (?)").run("backup value");
+
+      await source.backup(destinationPath);
+      source.close();
+
+      const destination = openNodeSqlite(destinationPath, { fileMustExist: true });
+      assert.ok(destination);
+      assert.equal(destination.driver, "node:sqlite");
+      assert.equal(
+        (destination.prepare("SELECT value FROM items").get() as { value: string }).value,
+        "backup value"
+      );
+      destination.close();
+    });
+
+    test("forced node:sqlite immediate commits, rolls back, and nests savepoints", (t) => {
+      const databasePath = createTempDatabasePath(t);
+      const adapter = forceNodeSqlite()(databasePath);
+      assert.ok(adapter);
+      assert.equal(adapter.driver, "node:sqlite");
+      adapter.exec("CREATE TABLE items (value TEXT)");
+
+      adapter.immediate(() => {
+        adapter.prepare("INSERT INTO items VALUES (?)").run("committed");
+      });
+      assert.throws(() =>
+        adapter.immediate(() => {
+          adapter.prepare("INSERT INTO items VALUES (?)").run("rolled back");
+          throw new Error("rollback");
+        })
+      );
+      adapter.immediate(() => {
+        adapter.prepare("INSERT INTO items VALUES (?)").run("outer before");
+        const nested = adapter.transaction(() => {
+          adapter.prepare("INSERT INTO items VALUES (?)").run("inner rolled back");
+          throw new Error("nested rollback");
+        });
+        assert.throws(() => nested());
+        adapter.prepare("INSERT INTO items VALUES (?)").run("outer after");
+      });
+
+      const rows = adapter.prepare("SELECT value FROM items ORDER BY rowid").all() as Array<{
+        value: string;
+      }>;
+      assert.deepEqual(
+        rows.map((row) => row.value),
+        ["committed", "outer before", "outer after"]
+      );
+      adapter.close();
+    });
+
+    test("forced node:sqlite immediate blocks a competing writer", (t) => {
+      const databasePath = createTempDatabasePath(t);
+      const openNodeSqlite = forceNodeSqlite();
+      const first = openNodeSqlite(databasePath);
+      assert.ok(first);
+      first.exec("CREATE TABLE items (value TEXT)");
+
+      const { DatabaseSync } = require("node:sqlite") as {
+        DatabaseSync: new (
+          filePath: string,
+          options: { timeout: number }
+        ) => {
+          close(): void;
+          exec(sql: string): void;
+        };
+      };
+      const second = new DatabaseSync(databasePath, { timeout: 50 });
+      try {
+        first.immediate(() => {
+          assert.throws(() => second.exec("INSERT INTO items VALUES ('competing writer')"), {
+            code: "ERR_SQLITE_ERROR",
+          });
+          first.prepare("INSERT INTO items VALUES (?)").run("owner");
+        });
+
+        const rows = first.prepare("SELECT value FROM items").all() as Array<{ value: string }>;
+        assert.deepEqual(
+          rows.map((row) => row.value),
+          ["owner"]
+        );
+      } finally {
+        second.close();
+        first.close();
+      }
     });
   }
 

--- a/tests/unit/db-adapters/nodeSqliteShared.test.ts
+++ b/tests/unit/db-adapters/nodeSqliteShared.test.ts
@@ -80,6 +80,46 @@ test("createNodeSqliteAdapterFromDatabase uses savepoints for transactions", () 
   assert.equal(db.execCalls[1].startsWith("RELEASE "), true);
 });
 
+test("createNodeSqliteAdapterFromDatabase uses BEGIN IMMEDIATE outside transactions", () => {
+  const db = new FakeDb();
+  const adapter = createNodeSqliteAdapterFromDatabase(db, ":memory:");
+
+  adapter.immediate(() => {});
+
+  assert.deepEqual(db.execCalls, ["BEGIN IMMEDIATE", "COMMIT"]);
+});
+
+test("createNodeSqliteAdapterFromDatabase rolls back failed immediate transactions", () => {
+  const db = new FakeDb();
+  const adapter = createNodeSqliteAdapterFromDatabase(db, ":memory:");
+
+  assert.throws(() =>
+    adapter.immediate(() => {
+      throw new Error("fail");
+    })
+  );
+
+  assert.deepEqual(db.execCalls, ["BEGIN IMMEDIATE", "ROLLBACK"]);
+});
+
+test("createNodeSqliteAdapterFromDatabase nests transactions in immediate savepoints", () => {
+  const db = new FakeDb();
+  const adapter = createNodeSqliteAdapterFromDatabase(db, ":memory:");
+
+  adapter.immediate(() => {
+    const nested = adapter.transaction(() => {
+      throw new Error("inner failure");
+    });
+    assert.throws(() => nested());
+  });
+
+  assert.equal(db.execCalls[0], "BEGIN IMMEDIATE");
+  assert.match(db.execCalls[1], /^SAVEPOINT /);
+  assert.match(db.execCalls[2], /^ROLLBACK TO /);
+  assert.match(db.execCalls[3], /^RELEASE /);
+  assert.equal(db.execCalls[4], "COMMIT");
+});
+
 test("createNodeSqliteAdapterFromDatabase finalizes cached statements on close", () => {
   const db = new FakeDb();
   let closedHookCalls = 0;


### PR DESCRIPTION
## PR 2 of issue #8707 (staged native SQLite baseline)

PR #8724 established safe `node:sqlite` fallback open semantics while retaining `better-sqlite3` preference. This follow-up adds backup and transaction parity when the real `node:sqlite` fallback is active.

### Native backup

The Node adapter now uses Node's native SQLite backup API when available, retaining the existing checkpoint-and-copy fallback for older Node runtimes.

Value:
- Produces a SQLite-consistent backup destination.
- Preserves existing backup scheduling, throttling, retention, manual/pre-restore, and auto-backup opt-out policy.
- Does not change `better-sqlite3` backup behavior or driver preference.

Issue context:
- #5406 establishes Windows WAL, close, and handle-release constraints around import/restore. This PR does not claim to fix import locking or replace its retry policy.
- #5871 establishes backup scheduling and opt-out policy as correctness requirements. This PR changes only the `node:sqlite` backup mechanism.

### Immediate and nested transactions

The Node adapter previously implemented `immediate()` as a savepoint, which does not acquire SQLite's write reservation at transaction start. It now uses `BEGIN IMMEDIATE` with explicit commit/rollback behavior. Transactions nested inside an immediate scope retain savepoint isolation.

Value:
- Competing writers follow SQLite's bounded busy-timeout behavior rather than proceeding as deferred transactions.
- A thrown callback leaves no partial writes.
- An inner failure rolls back to its savepoint while intended outer writes may continue and commit.

Issue context:
- #7784 demonstrates why reliable immediate acquisition and nested atomicity matter for concurrent settings mutations. This PR supplies adapter correctness only; it does not add revisions, ETags, conflict responses, or settings API changes.

## Validation

Ran the focused Node adapter test files through the repository-pinned Node 24 runtime:

- `tests/unit/db-adapters/nodeSqliteShared.test.ts`
- `tests/unit/db-adapters/driverFactory.test.ts`

Result: 24 tests passed. The suite verifies native `node:sqlite` backup destination integrity from a WAL-backed source; immediate transaction commit and rollback final state; nested savepoint rollback while the outer transaction continues; and bounded contention between two real connections. It also asserts the generated immediate and savepoint control-SQL ordering deterministically.

Also ran repository lint, core TypeScript checking, changelog-integrity, `check:any-budget:t11`, and `check:tracked-artifacts` successfully.

The full unit shards, coverage gate, production build, Vitest, and SonarQube remain CI evidence rather than local claims.

## Boundaries

- `better-sqlite3` remains preferred.
- No backup policy, retention, import/restore, or handle-release redesign.
- No generic lock-retry strategy.
- No settings ETag/revision work.
- No vector loading, dependency churn, Electron packaging, or driver-policy change.

## Follow-up

This is PR 2 of #8707. After it merges, PR 3 will add only the trusted, package-resolved `sqlite-vec` enable/load/disable lifecycle and a two-cycle Windows Electron package smoke against one persisted data directory.

PR 3 will provide target-specific evidence for the package/startup context in #7132, #7592, #7346, and #6796. It will validate the merged packaging baseline from #6794 and #7353 rather than duplicate it, and will not claim to close those issues without package-specific reproduction and maintainer confirmation.