### PR TITLE
fix(cli): default Codex wire API to responses

### DIFF
--- a/changelog.d/fixes/8876-codex-responses-wire-default.md
+++ b/changelog.d/fixes/8876-codex-responses-wire-default.md
@@ -1,0 +1,1 @@
+- **fix(cli):** default omitted Codex CLI wire API settings to Responses and clear stale Chat state after reset ([#8876](https://github.com/diegosouzapw/OmniRoute/pull/8876)) — thanks @xiaoyaner0201

--- a/src/app/(dashboard)/dashboard/cli-code/components/CodexToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/CodexToolCard.tsx
@@ -32,7 +32,7 @@ export default function CodexToolCard({
   const [selectedModel, setSelectedModel] = useState("gpt-5.6-sol");
   const [modelMappings, setModelMappings] = useState<Record<string, string>>({});
   const [reasoningEffort, setReasoningEffort] = useState("xhigh");
-  const [wireApi, setWireApi] = useState("chat");
+  const [wireApi, setWireApi] = useState("responses");
   const [modalOpen, setModalOpen] = useState(false);
   const [modalTarget, setModalTarget] = useState<string | null>(null); // null = default model, string = mapping key
   const [modelAliases, setModelAliases] = useState({});
@@ -78,6 +78,10 @@ export default function CodexToolCard({
 
   // Parse config content
   useEffect(() => {
+    if (codexStatus && !codexStatus.config) {
+      setWireApi("responses");
+    }
+
     if (codexStatus?.config) {
       const modelMatch = codexStatus.config.match(/^model\s*=\s*"([^"]+)"/im);
       if (modelMatch) setSelectedModel(modelMatch[1]);
@@ -86,7 +90,7 @@ export default function CodexToolCard({
       if (effortMatch) setReasoningEffort(effortMatch[1]);
 
       const wireMatch = codexStatus.config.match(/^wire_api\s*=\s*"([^"]+)"/im);
-      if (wireMatch) setWireApi(wireMatch[1]);
+      setWireApi(wireMatch?.[1] || "responses");
 
       const newMappings: Record<string, string> = {};
       const migrationsBlock = codexStatus.config.split("[notice.model_migrations]")[1];

--- a/src/app/api/cli-tools/codex-settings/route.ts
+++ b/src/app/api/cli-tools/codex-settings/route.ts
@@ -266,14 +266,15 @@ export async function POST(request: Request) {
       delete parsed._root.model_reasoning_effort;
     }
 
-    const normalizedBaseUrl = normalizeCodexBaseUrl(baseUrl, wireApi || "chat");
+    const effectiveWireApi = wireApi ?? "responses";
+    const normalizedBaseUrl = normalizeCodexBaseUrl(baseUrl, effectiveWireApi);
 
     // Always create a custom provider to reliably pass wire_api and use OMNIROUTE_API_KEY
     parsed._root.model_provider = "omniroute";
     parsed._sections["model_providers.omniroute"] = {
       name: "OmniRoute",
       base_url: normalizedBaseUrl,
-      wire_api: wireApi || "chat",
+      wire_api: effectiveWireApi,
       env_key: "OPENAI_API_KEY",
     };
     delete parsed._root.openai_base_url;

--- a/tests/unit/codex-settings-wire-api-default.test.ts
+++ b/tests/unit/codex-settings-wire-api-default.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SignJWT } from "jose";
+
+const TEST_HOME = path.join(os.tmpdir(), `omniroute-codex-wire-api-${process.pid}-${Date.now()}`);
+const CONFIG_PATH = path.join(TEST_HOME, ".codex", "config.toml");
+const originalHome = os.homedir;
+const originalJwtSecret = process.env.JWT_SECRET;
+const originalWriteFlag = process.env.CLI_ALLOW_CONFIG_WRITES;
+
+os.homedir = () => TEST_HOME;
+process.env.CLI_ALLOW_CONFIG_WRITES = "true";
+
+const route = await import("../../src/app/api/cli-tools/codex-settings/route.ts");
+
+const authCookie = async (): Promise<string> => {
+  process.env.JWT_SECRET = "codex-wire-api-default-test-secret";
+  const token = await new SignJWT({ sub: "codex-wire-api-default-test" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(new TextEncoder().encode(process.env.JWT_SECRET));
+  return `auth_token=${token}`;
+};
+
+const post = async (body: Record<string, unknown>) =>
+  route.POST(
+    new Request("http://localhost/api/cli-tools/codex-settings", {
+      method: "POST",
+      headers: {
+        cookie: await authCookie(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        apiKey: "sk-test-only",
+        model: "gpt-5.6-sol",
+        ...body,
+      }),
+    })
+  );
+
+test.after(async () => {
+  os.homedir = originalHome;
+  await fs.rm(TEST_HOME, { recursive: true, force: true });
+  if (originalJwtSecret === undefined) delete process.env.JWT_SECRET;
+  else process.env.JWT_SECRET = originalJwtSecret;
+  if (originalWriteFlag === undefined) delete process.env.CLI_ALLOW_CONFIG_WRITES;
+  else process.env.CLI_ALLOW_CONFIG_WRITES = originalWriteFlag;
+});
+
+test("POST resolves the Codex wire API before URL normalization and TOML generation", async (t) => {
+  const cases = [
+    {
+      name: "omitted wireApi defaults to responses",
+      body: { baseUrl: "http://localhost:20128/api/v1/responses" },
+      expectedBaseUrl: "http://localhost:20128/v1",
+      expectedWireApi: "responses",
+    },
+    {
+      name: "explicit responses remains responses",
+      body: {
+        baseUrl: "http://localhost:20128/api/v1/responses",
+        wireApi: "responses",
+      },
+      expectedBaseUrl: "http://localhost:20128/v1",
+      expectedWireApi: "responses",
+    },
+    {
+      name: "explicit chat remains chat",
+      body: { baseUrl: "http://localhost:20128/api/v1", wireApi: "chat" },
+      expectedBaseUrl: "http://localhost:20128/v1",
+      expectedWireApi: "chat",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      await fs.rm(TEST_HOME, { recursive: true, force: true });
+      const response = await post(testCase.body);
+      assert.equal(response.status, 200);
+
+      const config = await fs.readFile(CONFIG_PATH, "utf8");
+      assert.match(config, new RegExp(`^base_url = "${testCase.expectedBaseUrl}"$`, "m"));
+      assert.match(config, new RegExp(`^wire_api = "${testCase.expectedWireApi}"$`, "m"));
+    });
+  }
+});

--- a/tests/unit/ui/codex-tool-card-wire-api-default.test.tsx
+++ b/tests/unit/ui/codex-tool-card-wire-api-default.test.tsx
@@ -1,0 +1,131 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const translate = (key: string) => key;
+
+vi.mock("next-intl", () => ({ useTranslations: () => translate }));
+vi.mock("@/shared/components/ProviderIcon", () => ({ default: () => null }));
+vi.mock("@/app/(dashboard)/dashboard/cli-code/components/CliStatusBadge", () => ({
+  default: () => null,
+}));
+vi.mock("@/shared/components", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    loading,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    loading?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled || loading}>
+      {children}
+    </button>
+  ),
+  ModelSelectModal: () => null,
+  ManualConfigModal: () => null,
+}));
+
+import CodexToolCard from "@/app/(dashboard)/dashboard/cli-code/components/CodexToolCard";
+
+const mounted: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  json: async () => body,
+});
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 2000) => {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error("waitFor timed out");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+};
+
+const wireApiSelect = (container: HTMLElement): HTMLSelectElement | null =>
+  Array.from(container.querySelectorAll("select")).find((select) => {
+    const values = Array.from(select.options).map((option) => option.value);
+    return values.length === 2 && values[0] === "chat" && values[1] === "responses";
+  }) ?? null;
+
+afterEach(() => {
+  for (const { container, root } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("CodexToolCard wire API default", () => {
+  it("restores responses after reset returns config without wire_api", async () => {
+    let statusRequests = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url === "/api/cli-tools/codex-settings" && init?.method === "DELETE") {
+          return jsonResponse({ success: true });
+        }
+        if (url === "/api/cli-tools/codex-settings") {
+          statusRequests += 1;
+          return jsonResponse({
+            installed: true,
+            runnable: true,
+            config:
+              statusRequests === 1
+                ? 'model = "gpt-5.6-sol"\nbase_url = "http://localhost:20128/v1"\nwire_api = "chat"\n'
+                : 'model = "gpt-5.6-sol"\n',
+          });
+        }
+        if (url === "/api/models/alias") return jsonResponse({ aliases: {} });
+        if (url === "/api/cli-tools/codex-profiles") return jsonResponse({ profiles: [] });
+        if (url === "/api/cli-tools/backups?tool=codex") return jsonResponse({ backups: [] });
+        throw new Error(`Unexpected fetch: ${url}`);
+      })
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+
+    await act(async () => {
+      root.render(
+        <CodexToolCard
+          tool={{ name: "Codex" }}
+          isExpanded
+          baseUrl="http://localhost:20128"
+          apiKeys={[]}
+          activeProviders={[]}
+          cloudEnabled={false}
+          batchStatus={null}
+          lastConfiguredAt={null}
+        />
+      );
+    });
+
+    await waitFor(() => wireApiSelect(container)?.value === "chat");
+
+    const reset = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "restorereset"
+    );
+    expect(reset).toBeDefined();
+
+    await act(async () => {
+      reset!.click();
+    });
+    await waitFor(() => statusRequests === 2);
+
+    expect(wireApiSelect(container)?.value).toBe("responses");
+  });
+});


### PR DESCRIPTION
## Summary

- Default omitted Codex CLI `wireApi` settings to `responses` in both the dashboard and settings route.
- Reset stale dashboard state to `responses` when returned status/config has no `wire_api` line.
- Preserve explicit legacy `chat` and explicit `responses` selections unchanged.

## Related Issues

- Related to #8874

## Validation

Run only the focused loop for what changed; the full unit suite, Vitest suite, coverage gate, and production build run in CI on this PR.

- [x] Focused route tests: `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/codex-settings-wire-api-default.test.ts` — 4/4 pass
- [x] Focused UI test: `npx vitest run --config vitest.config.ts tests/unit/ui/codex-tool-card-wire-api-default.test.tsx` — 1/1 pass
- [ ] `npm run lint` — full-repository lint not repeated locally; changed-file ESLint is clean and CI is running
- [x] Production-code changes include new automated tests in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below — pending

Additional final-tree gates:

- related Codex Node matrix — 22/22 pass
- related Codex UI matrix — 6/6 pass
- changed-file Prettier and ESLint — pass
- `npm run typecheck:core` — pass
- `npm run test:security` — 23/23 pass
- `tests/integration/security-hardening.test.ts` — 21/21 pass
- `git diff --check` — pass
- `npm run check:changelog-integrity` — pass

## Tests Added Or Updated

- `tests/unit/codex-settings-wire-api-default.test.ts`
- `tests/unit/ui/codex-tool-card-wire-api-default.test.tsx`

Strict TDD evidence:

- tests-only RED checkpoint: `993d1eaa4e921762ae1cfbf94c7415717df0c24f`
  - omitted route value resolved to legacy `chat` and produced a noncanonical `/responses/v1` URL;
  - reset/status without `wire_api` retained stale `chat` state in the dashboard.
- GREEN implementation checkpoint: `498a285c6c3db2c3ec32b1b1b6d0072a00838a4f`
- final PR HEAD: `98a90966d35bbf3c4c6108d73fc8b133cfa88649`
- final PR tree: `5f857bc3ad493f26abf379fa8f3e4b09c8f8922b`

## Coverage Notes

The route test exercises omitted, explicit `responses`, and explicit legacy `chat` values through the real POST handler, including generated TOML and URL normalization. The component test exercises prior `chat` state followed by reset/status hydration with no `wire_api` line.

## Reviewer Notes

- Scope is limited to two production defaults, two focused behavior tests, and the required numbered changelog fragment. Shared Codex URL defaults, schemas, auth, reset deletion, and runtime Responses handling are unchanged.
- Independent exact-tree review of the final HEAD/tree found no unresolved blocking issues.
- The final changelog-only commit was reviewed separately; production and test blobs are byte-identical to the earlier reviewed implementation tree.
- `npm run typecheck:noimplicit:core` and `npm run check:route-validation:t06` remain failing with the same unrelated baseline findings reproduced at the tests-only checkpoint; neither failure touches this PR's files.
- Full unit/coverage/build gates were not repeated locally and remain CI-owned. This PR stays Draft; it is not marked Ready by this submission.
