### PR TITLE
fix(proxy): isolate registry credentials from autofill

### DIFF
--- a/changelog.d/fixes/8883-proxy-credential-autofill.md
+++ b/changelog.d/fixes/8883-proxy-credential-autofill.md
@@ -1,0 +1,1 @@
+- **fix(proxy):** isolate new proxy credential fields from browser and password-manager autofill after form reset ([#8883](https://github.com/diegosouzapw/OmniRoute/pull/8883)) — thanks @xiaoyaner0201

--- a/src/app/(dashboard)/dashboard/settings/components/ProxyRegistryManager.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ProxyRegistryManager.tsx
@@ -1014,6 +1014,9 @@ export default function ProxyRegistryManager({
               <input
                 className="w-full px-3 py-2 rounded bg-bg-subtle border border-border"
                 value={form.username}
+                autoComplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true"
                 placeholder={editingId ? t("usernamePlaceholderEdit") : ""}
                 onChange={(e) => setForm((prev) => ({ ...prev, username: e.target.value }))}
               />
@@ -1024,6 +1027,9 @@ export default function ProxyRegistryManager({
                 type="password"
                 className="w-full px-3 py-2 rounded bg-bg-subtle border border-border"
                 value={form.password}
+                autoComplete="new-password"
+                data-1p-ignore="true"
+                data-lpignore="true"
                 placeholder={editingId ? t("passwordPlaceholderEdit") : ""}
                 onChange={(e) => setForm((prev) => ({ ...prev, password: e.target.value }))}
               />

--- a/tests/unit/ui/ProxyRegistryManager-credential-autofill.test.tsx
+++ b/tests/unit/ui/ProxyRegistryManager-credential-autofill.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const translate = (key: string) => key;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => translate,
+}));
+
+const SEEDED_PROXY = {
+  id: "proxy-8855",
+  name: "Seeded proxy",
+  type: "http",
+  host: "127.0.0.1",
+  port: 8080,
+  username: "stored-user",
+  password: "stored-password",
+  status: "active",
+  family: "auto",
+};
+
+let root: Root;
+let container: HTMLDivElement;
+let postBody: Record<string, unknown> | undefined;
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response;
+}
+
+function findButton(text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+    candidate.textContent?.includes(text)
+  );
+  if (!button) throw new Error(`Button not found: ${text}`);
+  return button;
+}
+
+function findCredentialInput(label: string): HTMLInputElement {
+  const labelNode = Array.from(container.querySelectorAll("label")).find(
+    (candidate) => candidate.textContent?.trim() === label
+  );
+  const input = labelNode?.parentElement?.querySelector<HTMLInputElement>("input");
+  if (!input) throw new Error(`Credential input not found: ${label}`);
+  return input;
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  if (!setter) throw new Error("HTMLInputElement value setter is unavailable");
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function click(element: HTMLElement) {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function waitFor(assertion: () => void, timeoutMs = 2000) {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt <= timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+    }
+  }
+  throw lastError;
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  postBody = undefined;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/settings/proxies" && init?.method === "POST") {
+        postBody = JSON.parse(String(init.body));
+        return jsonResponse({ item: { ...SEEDED_PROXY, ...postBody } });
+      }
+      if (url === "/api/settings/proxies") {
+        return jsonResponse({ items: [SEEDED_PROXY] });
+      }
+      if (url.startsWith("/api/settings/proxies/health")) {
+        return jsonResponse({ items: [] });
+      }
+      if (url.startsWith("/api/settings/proxies/assignments")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    })
+  );
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ProxyRegistryManager credential autofill regression #8855", () => {
+  it("keeps Edit → close → Add credentials blank and isolates both fields from autofill", async () => {
+    const { default: ProxyRegistryManager } =
+      await import("@/app/(dashboard)/dashboard/settings/components/ProxyRegistryManager");
+
+    await act(async () => {
+      root.render(<ProxyRegistryManager />);
+    });
+    await waitFor(() => expect(container.textContent).toContain(SEEDED_PROXY.name));
+
+    await click(findButton("edit"));
+    const editUsername = findCredentialInput("labelUsername");
+    const editPassword = findCredentialInput("labelPassword");
+    expect(editUsername.value).toBe("");
+    expect(editPassword.value).toBe("");
+
+    setInputValue(editUsername, "edit-user-sentinel");
+    setInputValue(editPassword, "edit-password-sentinel");
+    await click(container.querySelector<HTMLButtonElement>('button[aria-label="close"]')!);
+    await click(
+      container.querySelector<HTMLButtonElement>('[data-testid="proxy-registry-open-create"]')!
+    );
+
+    const createUsername = findCredentialInput("labelUsername");
+    const createPassword = findCredentialInput("labelPassword");
+    expect(createUsername.value).toBe("");
+    expect(createPassword.value).toBe("");
+
+    expect.soft(createUsername.getAttribute("autocomplete")).toBe("off");
+    expect.soft(createPassword.getAttribute("autocomplete")).toBe("new-password");
+    for (const input of [createUsername, createPassword]) {
+      expect.soft(input.getAttribute("data-1p-ignore")).toBe("true");
+      expect.soft(input.getAttribute("data-lpignore")).toBe("true");
+    }
+
+    setInputValue(
+      container.querySelector<HTMLInputElement>('[data-testid="proxy-registry-name-input"]')!,
+      "New proxy"
+    );
+    setInputValue(
+      container.querySelector<HTMLInputElement>('[data-testid="proxy-registry-host-input"]')!,
+      "proxy.example.test"
+    );
+    await click(findButton("save"));
+    await waitFor(() => expect(postBody).toBeDefined());
+
+    expect([undefined, ""]).toContain(postBody?.username);
+    expect([undefined, ""]).toContain(postBody?.password);
+    expect(postBody?.username).not.toBe("edit-user-sentinel");
+    expect(postBody?.password).not.toBe("edit-password-sentinel");
+  });
+});


### PR DESCRIPTION
## Summary

Prevent browser and password-manager autofill from silently repopulating proxy credentials after the proxy registry form is reset.

Relates to #8855. This is a narrow UI hardening change and does not claim to resolve every create/edit/import path described in the issue before maintainer review.

## Changes

- add explicit autofill-isolation metadata to the existing proxy username and password inputs
- add a production-component regression covering Edit populated proxy → close → Add New Proxy
- verify the new form renders blank controlled credential values and submits no stale credentials
- preserve edit-mode credential submission, including trimmed explicit replacements
- add the required numbered changelog fragment

## Scope and non-goals

Changed files:

- `src/app/(dashboard)/dashboard/settings/components/ProxyRegistryManager.tsx`
- `tests/unit/ui/ProxyRegistryManager-credential-autofill.test.tsx`
- `changelog.d/fixes/8883-proxy-credential-autofill.md`

No database/schema, proxy import/deduplication, provider/network, API authorization, or persistence behavior changes. No broad modal refactor.

## Exact tree

- base: `release/v3.8.50` at `ed2db6cb19ba534980c5b3e046501e8a5c40c458` (tree `0846c1e9d01896f00591974eaa9fcfa4ca01811f`)
- reviewed implementation head: `4a2b02678f7fb144aa602ef2106d9f1cff3d4dc8` (tree `dce82d10a2e47758daf5a126f1d7e8bfe2e291cc`)
- final publication head: `78f8d23953669180df439eeaaeb1f45454dacf45`
- final publication tree: `65b7ba22e96facf62b80146bf373b0be089bde0e`
- branch: `fix/8855-proxy-credential-autofill`
- diff: 3 files, 177 insertions, 0 deletions

The upstream default branch remained `release/v3.8.50` at the same base during final acceptance; no refresh was required.

## RED → GREEN evidence

RED at tests-only commit `4c96029c79d679c89c5cf4ed0636419bd2100436`:

- `npm exec vitest -- run tests/unit/ui/ProxyRegistryManager-credential-autofill.test.tsx --reporter=verbose`
- expected exit 1: the production component lacked six asserted field-level attributes (`autocomplete` on both fields plus `data-1p-ignore` and `data-lpignore` on both fields)

GREEN on the reviewed implementation tree, then rerun on the final publication tree after adding only the numbered changelog fragment:

- `npm exec vitest -- run tests/unit/ui/ProxyRegistryManager-credential-autofill.test.tsx tests/unit/ui/ProxyRegistryManager-tdz-render.test.tsx --reporter=verbose` — 2 files, 2 tests passed
- related proxy-registry and dashboard-typecheck helper suites — 28 tests passed
- `npm run check:dashboard-typecheck` — passed; 254 pre-existing dashboard errors remained within the frozen baseline
- Prettier check on both changed files — passed
- ESLint with no cache on both changed files — passed
- `git diff --check upstream/release/v3.8.50...HEAD` — passed
- `npm run check:changelog-integrity` and Prettier on the numbered fragment — passed
- independent exact-tree review reported no unresolved blocking findings

## Caveats

- jsdom verifies the rendered DOM contract and real component state/submission behavior, but cannot fully emulate every browser or password-manager heuristic
- the full repository test suite and production build were not rerun for this six-attribute UI-only change; acceptance used focused component tests, related proxy-registry tests, the dashboard typecheck ratchet, and changed-file static gates

## Reviewer notes

Please review whether the chosen browser/password-manager hints are appropriate for the supported environments. Credential values remain controlled by the existing React form state; this change does not read, expose, migrate, or persist credentials through a new path.
