### PR TITLE
fix(test): stop autostart tests from disabling the developer's real systemd service

### DIFF
--- a/tests/unit/cli-tray.test.ts
+++ b/tests/unit/cli-tray.test.ts
@@ -1,22 +1,41 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 let tmpDir: string;
 let origHome: string | undefined;
+let origPath: string | undefined;
 
 test.before(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "omniroute-tray-test-"));
   origHome = process.env.HOME;
   // Redirecionar HOME para tmpDir para isolar testes de autostart
   process.env.HOME = tmpDir;
+
+  // HOME alone does NOT isolate this test: `enable()`/`disable()` shell out to
+  // `systemctl --user enable|start` and `systemctl --user disable --now
+  // omniroute.service`, which reach the caller's real systemd bus (XDG_RUNTIME_DIR,
+  // not HOME) and therefore stopped and disabled the developer's REAL omniroute
+  // service every time this suite ran. Shadow systemctl/loginctl with failing
+  // stubs so `isSystemdUserAvailable()` is false and the systemd branch is skipped;
+  // the XDG desktop-file branch still runs and is properly isolated by HOME.
+  // Same rationale documented at length in tests/unit/cli/autostart-linux.test.ts.
+  origPath = process.env.PATH;
+  const stubBin = join(tmpDir, "stub-bin");
+  mkdirSync(stubBin, { recursive: true });
+  for (const name of ["systemctl", "loginctl"]) {
+    writeFileSync(join(stubBin, name), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  }
+  process.env.PATH = `${stubBin}:${origPath ?? ""}`;
 });
 
 test.after(() => {
   if (origHome === undefined) delete process.env.HOME;
   else process.env.HOME = origHome;
+  if (origPath === undefined) delete process.env.PATH;
+  else process.env.PATH = origPath;
   try {
     rmSync(tmpDir, { recursive: true, force: true });
   } catch {}

--- a/tests/unit/cli/autostart-linux.test.ts
+++ b/tests/unit/cli/autostart-linux.test.ts
@@ -1,21 +1,52 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 let tmpDir: string;
 let origHome: string | undefined;
+let origPath: string | undefined;
+
+/**
+ * Redirecting HOME is NOT enough to isolate this test.
+ *
+ * `disableLinux()` runs `systemctl --user disable --now omniroute.service` and
+ * `enableLinux()` runs `systemctl --user enable` + `start`. `systemctl --user`
+ * talks to the caller's systemd bus via XDG_RUNTIME_DIR and does not care about
+ * HOME, so on any Linux developer machine that actually runs omniroute as a user
+ * service these tests stopped and disabled the REAL service — repeatedly, since
+ * the pair enable()/disable() ping-pongs it. Symptom: an ordered `Stopped` that
+ * `Restart=always` will not recover from, plus a silently `disabled` unit.
+ *
+ * Fix: shadow `systemctl` and `loginctl` with stubs that always fail, so
+ * `isSystemdUserAvailable()` returns false and the whole systemd branch is
+ * skipped. The XDG desktop-file branch still runs and IS isolated by HOME, so
+ * the test keeps its coverage.
+ */
+function installSystemctlStubs(binDir: string): void {
+  mkdirSync(binDir, { recursive: true });
+  for (const name of ["systemctl", "loginctl"]) {
+    const stub = join(binDir, name);
+    writeFileSync(stub, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  }
+}
 
 test.before(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "omniroute-autostart-linux-"));
   origHome = process.env.HOME;
   process.env.HOME = tmpDir;
+  origPath = process.env.PATH;
+  const stubBin = join(tmpDir, "stub-bin");
+  installSystemctlStubs(stubBin);
+  process.env.PATH = `${stubBin}:${origPath ?? ""}`;
 });
 
 test.after(() => {
   if (origHome === undefined) delete process.env.HOME;
   else process.env.HOME = origHome;
+  if (origPath === undefined) delete process.env.PATH;
+  else process.env.PATH = origPath;
   try {
     rmSync(tmpDir, { recursive: true, force: true });
   } catch {}


### PR DESCRIPTION
Running `npm run test:unit` (or `test:coverage`) on a Linux machine that runs OmniRoute as a systemd **user service** stops **and disables** that service.

It is not a flaky interaction — the tests literally execute `systemctl` against the real unit.

## Root cause

`tests/unit/cli/autostart-linux.test.ts` and `tests/unit/cli-tray.test.ts` call the real `enable()` / `disable()` from `bin/cli/tray/autostart.mjs`. Their only isolation is overriding `process.env.HOME` to a temp dir.

That isolates the **file paths**, but not systemd:

```js
// bin/cli/tray/autostart.mjs
const LINUX_SERVICE_NAME = "omniroute.service";   // the real unit name

function disableLinux() {
  if (isSystemdUserAvailable()) {
    runUserSystemctl(["disable", "--now", LINUX_SERVICE_NAME]);   // --now => stops it
```

`systemctl --user` reaches the caller's systemd bus through `XDG_RUNTIME_DIR` and ignores `HOME`, and the unit name is the literal `omniroute.service`. So `disable()` runs, for real:

```
systemctl --user disable --now omniroute.service
```

Consequences on a developer box:

- The service is **stopped**. Because it is an *ordered* stop, `Restart=always` does not recover from it.
- The unit is left **`disabled`**, so it does not come back on the next login either.
- `enable()` (which runs `systemctl --user enable` + `start`) and `disable()` **ping-pong** the service, producing a `Started` immediately followed by `Stopping`.

Observed on my machine — eight stop/disable cycles in one night of running the suite:

```
jul 29 00:29:30 Started omniroute.service ...
jul 29 00:29:31 Stopping omniroute.service ...
jul 29 00:29:31 Stopped omniroute.service ...
(repeats at 00:49, 01:00, 01:21, 02:07, 02:33, 03:04 ...)
```

with `systemctl --user is-enabled omniroute.service` → `disabled` afterwards.

## Fix

Shadow `systemctl` and `loginctl` with stubs that exit non-zero for the duration of these two tests, so `isSystemdUserAvailable()` returns `false` and the entire systemd branch is skipped.

No production code changed. The XDG desktop-file branch still runs and **is** correctly isolated by `HOME`, so coverage is preserved: both files still exercise `enable()` / `disable()` end to end and assert the generated autostart entries.

## Verification

On this branch, on top of `release/v3.8.50`:

```
$ node --import tsx/esm --test tests/unit/cli/autostart-linux.test.ts tests/unit/cli-tray.test.ts
ℹ tests 11
ℹ pass 11
ℹ fail 0
```

and the real service is untouched before and after:

```
before: active running | enabled
after:  active running | enabled
```

`journalctl --user -u omniroute.service` records no stop during the run. Before the fix, the same command produced a `Stopping` / `Stopped` pair every time.

## Notes

- Linux-only in effect; the macOS/Windows autostart tests are unaffected.
- CI containers were never hurt by this because they do not run `omniroute.service` — which is exactly why it went unnoticed. It only bites contributors who dogfood the service locally.