### PR TITLE
fix(combos): include id column in getCombos query

### DIFF
--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -96,7 +96,7 @@ function getNextSortOrder() {
 export async function getCombos(limit?: number, offset?: number) {
   const db = getDbInstance();
   let sql =
-    "SELECT data, sort_order, context_cache_protection FROM combos ORDER BY sort_order ASC, name COLLATE NOCASE ASC";
+    "SELECT id, data, sort_order, context_cache_protection FROM combos ORDER BY sort_order ASC, name COLLATE NOCASE ASC";
   const params: unknown[] = [];
   if (limit !== undefined) {
     sql += " LIMIT ? OFFSET ?";


### PR DESCRIPTION
getCombos() SELECT was missing the id column, so returned combo objects had their id come only from the JSON data blob. If the data blob lacked an id field, callers (including the Dashboard) saw null — making the combo appear to have no primary key and impossible to delete.

Add id to the SELECT so the database column value is always available.

Reproduction: create a combo via Dashboard, then check the returned object — before this fix, the id field was missing from the SQL result and fell through to the JSON blob.