### PR TITLE
fix(quota): clean managed combos when deleting pools

### DIFF
--- a/changelog.d/fixes/8906-quota-pool-combo-cleanup.md
+++ b/changelog.d/fixes/8906-quota-pool-combo-cleanup.md
@@ -1,0 +1,1 @@
+- **fix(quota):** Deleting a quota pool now removes its scoped managed combos without racing in-flight pool mutations ([#8906](https://github.com/diegosouzapw/OmniRoute/pull/8906)) — thanks @xiaoyaner0201

--- a/src/app/api/quota/pools/[id]/route.ts
+++ b/src/app/api/quota/pools/[id]/route.ts
@@ -73,9 +73,7 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
     // helpers. Without the pre-update removal, a group/provider switch would leave
     // orphan qtSd/ combos a quota key still sees. Guarded + non-fatal.
     const combosNeedResync =
-      body !== null &&
-      typeof body === "object" &&
-      ("connectionIds" in body || "groupId" in body);
+      body !== null && typeof body === "object" && ("connectionIds" in body || "groupId" in body);
     if (combosNeedResync) {
       try {
         const { removeQuotaCombosForPool } = await import("@/lib/quota/quotaCombos");
@@ -106,7 +104,7 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
         id,
         prevApiKeyIds,
         nextApiKeyIds,
-        parsed.data.exclusive ?? false,
+        parsed.data.exclusive ?? false
       );
     }
 
@@ -132,7 +130,7 @@ export async function DELETE(request: Request, { params }: RouteParams): Promise
 
   try {
     const { id } = await params;
-    const existed = deletePool(id);
+    const existed = await deletePool(id);
     if (!existed) {
       return NextResponse.json(buildErrorBody(404, "Pool not found"), { status: 404 });
     }

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -17,6 +17,12 @@ import { getDbInstance } from "./core";
 const quotaComboMaintenance = new Map<string, Promise<unknown>>();
 const deletingPools = new Set<string>();
 
+/** Reset module-level state for test isolation. Call in test.after() hooks. */
+export function resetQuotaPoolsModuleState(): void {
+  deletingPools.clear();
+  quotaComboMaintenance.clear();
+}
+
 function serializeQuotaComboMaintenance<T>(
   poolId: string,
   operation: () => Promise<T>

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -14,6 +14,23 @@ import { getDbInstance } from "./core";
 // risk between db/ and quota/ modules. Sync hooks are fire-and-forget; deletion
 // awaits its guarded cleanup while metadata is available. Combo failures never
 // break pool CRUD.
+const quotaComboMaintenance = new Map<string, Promise<unknown>>();
+const deletingPools = new Set<string>();
+
+function serializeQuotaComboMaintenance<T>(
+  poolId: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = quotaComboMaintenance.get(poolId);
+  const current = previous ? previous.catch(() => undefined).then(operation) : operation();
+  quotaComboMaintenance.set(poolId, current);
+  const cleanup = () => {
+    if (quotaComboMaintenance.get(poolId) === current) quotaComboMaintenance.delete(poolId);
+  };
+  void current.then(cleanup, cleanup);
+  return current;
+}
+
 async function syncQuotaCombosGuarded(poolId: string): Promise<void> {
   try {
     const { syncQuotaCombos } = await import("@/lib/quota/quotaCombos");
@@ -401,7 +418,7 @@ export function createPool(input: PoolCreate): QuotaPool {
   );
 
   // Phase B2: fire-and-forget combo sync; failures are logged but never thrown.
-  void syncQuotaCombosGuarded(id);
+  void serializeQuotaComboMaintenance(id, () => syncQuotaCombosGuarded(id));
 
   return result;
 }
@@ -413,6 +430,8 @@ export function createPool(input: PoolCreate): QuotaPool {
  * connection_id (primary) is synced to connectionIds[0].
  */
 export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
+  if (deletingPools.has(id)) return null;
+
   const database = getDb();
   const existing = database
     .prepare<PoolRow>(
@@ -476,7 +495,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
   const result = rowToPool(existing, getAllocations(id));
 
   // Phase B2: fire-and-forget combo sync; failures are logged but never thrown.
-  void syncQuotaCombosGuarded(id);
+  void serializeQuotaComboMaintenance(id, () => syncQuotaCombosGuarded(id));
 
   return result;
 }
@@ -487,27 +506,37 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
  * Returns true if a row was deleted, false if not found.
  */
 export async function deletePool(id: string): Promise<boolean> {
-  // Phase B2: remove quota combos BEFORE deleting the pool row so that
-  // removeQuotaCombosForPool can still resolve the pool name → slug.
-  await removeQuotaCombosGuarded(id);
+  if (deletingPools.has(id)) return false;
+  const exists = getDb().prepare<{ id: string }>("SELECT id FROM quota_pools WHERE id = ?").get(id);
+  if (!exists) return false;
+  deletingPools.add(id);
 
-  const database = getDb();
-  const doDelete = database.transaction(() => {
-    database.prepare("DELETE FROM quota_pool_connections WHERE pool_id = ?").run(id);
-    // Prune this pool id from every key's allowed_quotas JSON array.
-    database
-      .prepare(
-        `UPDATE api_keys SET allowed_quotas = COALESCE(
+  const deletion = serializeQuotaComboMaintenance(id, async () => {
+    // Phase B2: remove quota combos BEFORE deleting the pool row so that
+    // removeQuotaCombosForPool can still resolve the pool name → slug.
+    await removeQuotaCombosGuarded(id);
+
+    const database = getDb();
+    const doDelete = database.transaction(() => {
+      database.prepare("DELETE FROM quota_pool_connections WHERE pool_id = ?").run(id);
+      // Prune this pool id from every key's allowed_quotas JSON array.
+      database
+        .prepare(
+          `UPDATE api_keys SET allowed_quotas = COALESCE(
          (SELECT json_group_array(value) FROM json_each(api_keys.allowed_quotas) WHERE value != ?),
          '[]')
        WHERE allowed_quotas IS NOT NULL AND allowed_quotas != '[]'
          AND EXISTS (SELECT 1 FROM json_each(api_keys.allowed_quotas) WHERE value = ?)`
-      )
-      .run(id, id);
-    return database.prepare("DELETE FROM quota_pools WHERE id = ?").run(id);
+        )
+        .run(id, id);
+      return database.prepare("DELETE FROM quota_pools WHERE id = ?").run(id);
+    });
+    const result = doDelete();
+    return result.changes > 0;
   });
-  const result = doDelete();
-  return result.changes > 0;
+  const clearDeleting = () => deletingPools.delete(id);
+  void deletion.then(clearDeleting, clearDeleting);
+  return deletion;
 }
 
 /**
@@ -547,6 +576,8 @@ export async function deletePool(id: string): Promise<boolean> {
  * Runs atomically: all pool writes are inside a single SQLite transaction.
  */
 export function upsertAllocations(poolId: string, allocations: PoolAllocation[]): void {
+  if (deletingPools.has(poolId)) return;
+
   const database = getDb();
 
   // Normalize: when all weights are 0, distribute equally so the pool is usable
@@ -603,7 +634,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
 
   // Phase B2: fire-and-forget combo sync for the target pool only; failures are
   // logged but never thrown. Sibling pools' combos are synced on their own lifecycle.
-  void syncQuotaCombosGuarded(poolId);
+  void serializeQuotaComboMaintenance(poolId, () => syncQuotaCombosGuarded(poolId));
 }
 
 /**

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -11,8 +11,9 @@
 import { getDbInstance } from "./core";
 // Phase B2: auto-mint/prune quotaShared-* combos when pool allocations change.
 // Imported lazily (dynamic import in the hook) to avoid circular-dependency
-// risk between db/ and quota/ modules. The import is fire-and-forget; combo
-// failures never break pool CRUD.
+// risk between db/ and quota/ modules. Sync hooks are fire-and-forget; deletion
+// awaits its guarded cleanup while metadata is available. Combo failures never
+// break pool CRUD.
 async function syncQuotaCombosGuarded(poolId: string): Promise<void> {
   try {
     const { syncQuotaCombos } = await import("@/lib/quota/quotaCombos");
@@ -485,10 +486,10 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
  * Also removes join rows in quota_pool_connections.
  * Returns true if a row was deleted, false if not found.
  */
-export function deletePool(id: string): boolean {
+export async function deletePool(id: string): Promise<boolean> {
   // Phase B2: remove quota combos BEFORE deleting the pool row so that
   // removeQuotaCombosForPool can still resolve the pool name → slug.
-  void removeQuotaCombosGuarded(id);
+  await removeQuotaCombosGuarded(id);
 
   const database = getDb();
   const doDelete = database.transaction(() => {

--- a/src/lib/quota/quotaCombos.ts
+++ b/src/lib/quota/quotaCombos.ts
@@ -152,7 +152,10 @@ export async function syncQuotaCombos(poolId: string): Promise<void> {
   for (const connId of pool.connectionIds) {
     let connection: Record<string, unknown> | null = null;
     try {
-      connection = (await getCachedProviderConnectionById(connId)) as Record<string, unknown> | null;
+      connection = (await getCachedProviderConnectionById(connId)) as Record<
+        string,
+        unknown
+      > | null;
     } catch {
       // Connection lookup failure — skip this connection.
       continue;
@@ -202,6 +205,10 @@ export async function syncQuotaCombos(poolId: string): Promise<void> {
     }));
     try {
       const existing = await getComboByName(comboName);
+      // A pool may be deleted while this fire-and-forget sync is awaiting combo
+      // lookups. Re-check immediately before the synchronous DB upsert so stale
+      // create/update work cannot recreate managed combos after delete cleanup.
+      if (!getPool(poolId)) return;
       const payload = {
         name: comboName,
         models: steps,

--- a/tests/integration/quota-pool-delete-combo-cleanup.test.ts
+++ b/tests/integration/quota-pool-delete-combo-cleanup.test.ts
@@ -19,7 +19,8 @@ const poolsDb = await import("../../src/lib/db/quotaPools.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const compliance = await import("../../src/lib/compliance/index.ts");
 const poolIdRoute = await import("../../src/app/api/quota/pools/[id]/route.ts");
-const { syncQuotaCombos } = await import("../../src/lib/quota/quotaCombos.ts");
+const { removeQuotaCombosForPool, syncQuotaCombos } =
+  await import("../../src/lib/quota/quotaCombos.ts");
 const { parseQuotaModelName, quotaGroupSlug } =
   await import("../../src/lib/quota/quotaModelNaming.ts");
 
@@ -210,13 +211,142 @@ test("DELETE pool waits for scoped quota-combo cleanup before returning 204", as
   );
 });
 
+test("DELETE prevents an in-flight create sync from recreating quota combos", async () => {
+  const group = groupsDb.createGroup("Immediate Create Delete Group");
+  const connectionId = await createConnection("openrouter", "immediate-create-delete");
+  const pool = poolsDb.createPool({
+    connectionId,
+    name: "Immediate Create Delete Pool",
+    groupId: group.id,
+  });
+
+  const deleted = await poolsDb.deletePool(pool.id);
+  await nextImmediate();
+  await nextImmediate();
+
+  assert.equal(deleted, true);
+  assert.equal(poolsDb.getPool(pool.id), null);
+  assert.deepEqual(
+    quotaNamesFor(await combosDb.getCombos(), group.name, "openrouter"),
+    [],
+    "a create sync already in flight must not mint quota combos after pool deletion"
+  );
+});
+
+test("DELETE prevents an in-flight update sync from recreating quota combos", async () => {
+  const group = groupsDb.createGroup("Immediate Update Delete Group");
+  const connectionId = await createConnection("openrouter", "immediate-update-delete");
+  const pool = poolsDb.createPool({
+    connectionId,
+    name: "Immediate Update Delete Pool",
+    groupId: group.id,
+  });
+  await syncQuotaCombos(pool.id);
+  await nextImmediate();
+  await nextImmediate();
+  await removeQuotaCombosForPool(pool.id);
+  assert.deepEqual(quotaNamesFor(await combosDb.getCombos(), group.name, "openrouter"), []);
+
+  assert.ok(poolsDb.updatePool(pool.id, { name: "Updated Then Deleted Pool" }));
+  const deleted = await poolsDb.deletePool(pool.id);
+  await nextImmediate();
+  await nextImmediate();
+
+  assert.equal(deleted, true);
+  assert.equal(poolsDb.getPool(pool.id), null);
+  assert.deepEqual(
+    quotaNamesFor(await combosDb.getCombos(), group.name, "openrouter"),
+    [],
+    "an update sync already in flight must not recreate quota combos after pool deletion"
+  );
+});
+
+test("DELETE rejects a synchronous pool update once deletion has started", async () => {
+  const oldGroup = groupsDb.createGroup("Deleting Pool Old Group");
+  const newGroup = groupsDb.createGroup("Deleting Pool New Group");
+  const connectionId = await createConnection("openrouter", "delete-update-race");
+  const pool = poolsDb.createPool({
+    connectionId,
+    name: "Delete Update Race Pool",
+    groupId: oldGroup.id,
+  });
+  await syncQuotaCombos(pool.id);
+  await nextImmediate();
+  await nextImmediate();
+  assert.ok(quotaNamesFor(await combosDb.getCombos(), oldGroup.name, "openrouter").length > 0);
+
+  const deleting = poolsDb.deletePool(pool.id);
+  const updated = poolsDb.updatePool(pool.id, { groupId: newGroup.id });
+  const deleted = await deleting;
+  await nextImmediate();
+  await nextImmediate();
+
+  assert.equal(updated, null, "a pool must become immutable as soon as deletion starts");
+  assert.equal(deleted, true);
+  assert.equal(poolsDb.getPool(pool.id), null);
+  assert.deepEqual(quotaNamesFor(await combosDb.getCombos(), oldGroup.name, "openrouter"), []);
+  assert.deepEqual(quotaNamesFor(await combosDb.getCombos(), newGroup.name, "openrouter"), []);
+});
+
+test("DELETE makes a synchronous allocation upsert a no-op once deletion has started", async () => {
+  const group = groupsDb.createGroup("Deleting Pool Allocation Group");
+  const targetConnectionId = await createConnection("openrouter", "delete-allocation-target");
+  const siblingConnectionId = await createConnection("baidu", "delete-allocation-sibling");
+  const targetPool = poolsDb.createPool({
+    connectionId: targetConnectionId,
+    name: "Delete Allocation Target",
+    groupId: group.id,
+  });
+  const siblingPool = poolsDb.createPool({
+    connectionId: siblingConnectionId,
+    name: "Delete Allocation Sibling",
+    groupId: group.id,
+  });
+  const apiKey = await apiKeysDb.createApiKey("Delete Allocation Key", "delete-allocation-key");
+  await nextImmediate();
+  await nextImmediate();
+
+  const deleting = poolsDb.deletePool(targetPool.id);
+  poolsDb.upsertAllocations(targetPool.id, [{ apiKeyId: apiKey.id, weight: 100, policy: "hard" }]);
+  const deleted = await deleting;
+
+  assert.equal(deleted, true);
+  assert.equal(poolsDb.getPool(targetPool.id), null);
+  assert.deepEqual(
+    poolsDb.getPool(siblingPool.id)?.allocations,
+    [],
+    "an allocation upsert on a deleting pool must not mutate sibling pools"
+  );
+});
+
+test("concurrent DELETE calls report one deletion and one missing pool", async () => {
+  const group = groupsDb.createGroup("Concurrent Delete Group");
+  const connectionId = await createConnection("openrouter", "concurrent-delete");
+  const pool = poolsDb.createPool({
+    connectionId,
+    name: "Concurrent Delete Pool",
+    groupId: group.id,
+  });
+
+  const results = await Promise.all([poolsDb.deletePool(pool.id), poolsDb.deletePool(pool.id)]);
+
+  assert.deepEqual(results, [true, false]);
+  assert.equal(poolsDb.getPool(pool.id), null);
+  assert.deepEqual(quotaNamesFor(await combosDb.getCombos(), group.name, "openrouter"), []);
+});
+
 test("DELETE nonexistent pool returns sanitized 404 without changing combos", async () => {
+  const missingPoolId = "pool-that-never-existed";
   const group = groupsDb.createGroup("Missing Pool Control Group");
   const connectionId = await createConnection("baidu", "missing-pool-control-baidu");
   const pool = poolsDb.createPool({
     connectionId,
     name: "Missing Pool Control",
     groupId: group.id,
+  });
+  const apiKey = await apiKeysDb.createApiKey("Missing Pool Key", "missing-pool-key");
+  await apiKeysDb.updateApiKeyPermissions(apiKey.id, {
+    allowedQuotas: [missingPoolId, pool.id],
   });
   await syncQuotaCombos(pool.id);
   await nextImmediate();
@@ -229,13 +359,18 @@ test("DELETE nonexistent pool returns sanitized 404 without changing combos", as
   const before = await combosDb.getCombos();
   assert.ok(quotaNamesFor(before, group.name, "baidu").length > 0);
 
-  const response = await deletePoolThroughRoute("pool-that-never-existed");
+  const response = await deletePoolThroughRoute(missingPoolId);
   const body = await response.json();
 
   assert.equal(response.status, 404);
   assert.equal(body.error?.message, "Pool not found");
   assert.doesNotMatch(JSON.stringify(body), /\s+at\s+\//, "404 must not expose a stack trace");
   assert.deepEqual(await combosDb.getCombos(), before);
+  assert.deepEqual(
+    getAllowedQuotas(apiKey.id),
+    [missingPoolId, pool.id],
+    "a missing-pool DELETE must not mutate API key permissions"
+  );
   assert.ok(poolsDb.getPool(pool.id), "unrelated pool must remain");
 });
 

--- a/tests/integration/quota-pool-delete-combo-cleanup.test.ts
+++ b/tests/integration/quota-pool-delete-combo-cleanup.test.ts
@@ -1,0 +1,292 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { makeManagementSessionRequest } from "../helpers/managementSession.ts";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-quota-pool-delete-combo-cleanup-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-quota-pool-delete-combo-cleanup-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const groupsDb = await import("../../src/lib/db/quotaGroups.ts");
+const poolsDb = await import("../../src/lib/db/quotaPools.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const compliance = await import("../../src/lib/compliance/index.ts");
+const poolIdRoute = await import("../../src/app/api/quota/pools/[id]/route.ts");
+const { syncQuotaCombos } = await import("../../src/lib/quota/quotaCombos.ts");
+const { parseQuotaModelName, quotaGroupSlug } =
+  await import("../../src/lib/quota/quotaModelNaming.ts");
+
+type Combo = Awaited<ReturnType<typeof combosDb.getCombos>>[number];
+
+type Db = {
+  prepare: (sql: string) => {
+    all: (...params: unknown[]) => unknown[];
+    get: (...params: unknown[]) => unknown;
+  };
+};
+
+function resetDb() {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+function quotaNamesFor(combos: Combo[], groupName: string, provider: string): string[] {
+  const groupSlug = quotaGroupSlug(groupName);
+  return combos
+    .map((combo) => (typeof combo.name === "string" ? combo.name : ""))
+    .filter((name) => {
+      const parsed = parseQuotaModelName(name);
+      return parsed?.groupSlug === groupSlug && parsed.provider === provider;
+    })
+    .sort();
+}
+
+async function createConnection(provider: "openrouter" | "baidu", name: string) {
+  const connection = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    name,
+    apiKey: `test-only-${name}`,
+  });
+  const id = (connection as Record<string, unknown>).id;
+  assert.equal(typeof id, "string", `${provider} connection should have an id`);
+  return id as string;
+}
+
+async function deletePoolThroughRoute(poolId: string): Promise<Response> {
+  const request = await makeManagementSessionRequest(`http://localhost/api/quota/pools/${poolId}`, {
+    method: "DELETE",
+  });
+  return poolIdRoute.DELETE(request, { params: Promise.resolve({ id: poolId }) });
+}
+
+function getAllowedQuotas(apiKeyId: string): string[] {
+  const db = core.getDbInstance() as unknown as Db;
+  const row = db.prepare("SELECT allowed_quotas FROM api_keys WHERE id = ?").get(apiKeyId) as {
+    allowed_quotas: string;
+  };
+  return JSON.parse(row.allowed_quotas) as string[];
+}
+
+function countRows(sql: string, id: string): number {
+  const db = core.getDbInstance() as unknown as Db;
+  const row = db.prepare(sql).get(id) as { count: number };
+  return row.count;
+}
+
+function nextImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test.beforeEach(() => {
+  resetDb();
+  compliance.initAuditLog();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("DELETE pool waits for scoped quota-combo cleanup before returning 204", async () => {
+  const targetGroup = groupsDb.createGroup("Delete Target Group");
+  const otherGroup = groupsDb.createGroup("Delete Other Group");
+  const targetConnectionId = await createConnection("openrouter", "delete-target-openrouter");
+  const sameGroupConnectionId = await createConnection("baidu", "delete-control-baidu");
+  const otherGroupConnectionId = await createConnection("openrouter", "delete-control-openrouter");
+  const apiKey = await apiKeysDb.createApiKey("Delete Pool Key", "delete-pool-machine");
+
+  const targetPool = poolsDb.createPool({
+    connectionId: targetConnectionId,
+    name: "Delete Target Pool",
+    groupId: targetGroup.id,
+    allocations: [{ apiKeyId: apiKey.id, weight: 100, policy: "hard" }],
+  });
+  const sameGroupPool = poolsDb.createPool({
+    connectionId: sameGroupConnectionId,
+    name: "Same Group Different Provider",
+    groupId: targetGroup.id,
+  });
+  const otherGroupPool = poolsDb.createPool({
+    connectionId: otherGroupConnectionId,
+    name: "Different Group Same Provider",
+    groupId: otherGroup.id,
+  });
+  await apiKeysDb.updateApiKeyPermissions(apiKey.id, {
+    allowedQuotas: [targetPool.id, otherGroupPool.id],
+  });
+
+  await syncQuotaCombos(targetPool.id);
+  await syncQuotaCombos(sameGroupPool.id);
+  await syncQuotaCombos(otherGroupPool.id);
+  await nextImmediate();
+  await nextImmediate();
+  const ordinaryCombo = await combosDb.createCombo({
+    name: "ordinary-delete-control",
+    models: [{ kind: "model", model: "openrouter/control-model", weight: 100 }],
+    strategy: "priority",
+  });
+
+  const before = await combosDb.getCombos();
+  const targetNames = quotaNamesFor(before, targetGroup.name, "openrouter");
+  const sameGroupControlNames = quotaNamesFor(before, targetGroup.name, "baidu");
+  const otherGroupControlNames = quotaNamesFor(before, otherGroup.name, "openrouter");
+  assert.ok(targetNames.length > 0, "target openrouter quota combos must exist before DELETE");
+  assert.ok(sameGroupControlNames.length > 0, "same-group baidu control combos must exist");
+  assert.ok(otherGroupControlNames.length > 0, "other-group openrouter control combos must exist");
+  assert.ok(
+    await combosDb.getComboByName(ordinaryCombo.name as string),
+    "ordinary combo must exist"
+  );
+  assert.ok(poolsDb.getPool(targetPool.id), "target pool row must exist before DELETE");
+  assert.equal(
+    countRows(
+      "SELECT count(*) AS count FROM quota_pool_connections WHERE pool_id = ?",
+      targetPool.id
+    ),
+    1
+  );
+  assert.equal(
+    countRows("SELECT count(*) AS count FROM quota_allocations WHERE pool_id = ?", targetPool.id),
+    1
+  );
+  assert.deepEqual(getAllowedQuotas(apiKey.id), [targetPool.id, otherGroupPool.id]);
+
+  const response = await deletePoolThroughRoute(targetPool.id);
+
+  assert.equal(response.status, 204);
+  const after = await combosDb.getCombos();
+  assert.deepEqual(
+    quotaNamesFor(after, targetGroup.name, "openrouter"),
+    [],
+    "DELETE must not return while target group+provider quota combos remain"
+  );
+  assert.deepEqual(
+    quotaNamesFor(after, targetGroup.name, "baidu"),
+    sameGroupControlNames,
+    "same-group combos for another provider must remain byte/name-identical"
+  );
+  assert.deepEqual(
+    quotaNamesFor(after, otherGroup.name, "openrouter"),
+    otherGroupControlNames,
+    "same-provider combos for another group must remain byte/name-identical"
+  );
+  assert.deepEqual(
+    await combosDb.getComboByName(ordinaryCombo.name as string),
+    ordinaryCombo,
+    "ordinary user combo must remain unchanged"
+  );
+  assert.equal(poolsDb.getPool(targetPool.id), null);
+  assert.equal(
+    countRows(
+      "SELECT count(*) AS count FROM quota_pool_connections WHERE pool_id = ?",
+      targetPool.id
+    ),
+    0
+  );
+  assert.equal(
+    countRows("SELECT count(*) AS count FROM quota_allocations WHERE pool_id = ?", targetPool.id),
+    0
+  );
+  assert.deepEqual(getAllowedQuotas(apiKey.id), [otherGroupPool.id]);
+  const auditEvents = compliance.getAuditLog({ action: "quota.pool.deleted", limit: 10 });
+  assert.ok(
+    auditEvents.some(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as Record<string, unknown>).target === targetPool.id
+    ),
+    "successful DELETE must record quota.pool.deleted audit event"
+  );
+});
+
+test("DELETE nonexistent pool returns sanitized 404 without changing combos", async () => {
+  const group = groupsDb.createGroup("Missing Pool Control Group");
+  const connectionId = await createConnection("baidu", "missing-pool-control-baidu");
+  const pool = poolsDb.createPool({
+    connectionId,
+    name: "Missing Pool Control",
+    groupId: group.id,
+  });
+  await syncQuotaCombos(pool.id);
+  await nextImmediate();
+  await nextImmediate();
+  await combosDb.createCombo({
+    name: "ordinary-missing-delete-control",
+    models: [{ kind: "model", model: "baidu/control-model", weight: 100 }],
+    strategy: "priority",
+  });
+  const before = await combosDb.getCombos();
+  assert.ok(quotaNamesFor(before, group.name, "baidu").length > 0);
+
+  const response = await deletePoolThroughRoute("pool-that-never-existed");
+  const body = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(body.error?.message, "Pool not found");
+  assert.doesNotMatch(JSON.stringify(body), /\s+at\s+\//, "404 must not expose a stack trace");
+  assert.deepEqual(await combosDb.getCombos(), before);
+  assert.ok(poolsDb.getPool(pool.id), "unrelated pool must remain");
+});
+
+test("DELETE keeps relational cleanup non-fatal when quota-combo listing fails", async () => {
+  const group = groupsDb.createGroup("Cleanup Failure Group");
+  const connectionId = await createConnection("openrouter", "cleanup-failure-openrouter");
+  const apiKey = await apiKeysDb.createApiKey("Cleanup Failure Key", "cleanup-failure-machine");
+  const pool = poolsDb.createPool({
+    connectionId,
+    name: "Cleanup Failure Pool",
+    groupId: group.id,
+    allocations: [{ apiKeyId: apiKey.id, weight: 100, policy: "hard" }],
+  });
+  await apiKeysDb.updateApiKeyPermissions(apiKey.id, { allowedQuotas: [pool.id] });
+  await syncQuotaCombos(pool.id);
+  await nextImmediate();
+  await nextImmediate();
+  assert.ok(quotaNamesFor(await combosDb.getCombos(), group.name, "openrouter").length > 0);
+
+  const db = core.getDbInstance();
+  const originalPrepare = db.prepare.bind(db);
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  db.prepare = ((sql: string) => {
+    if (sql.startsWith("SELECT data, sort_order, context_cache_protection FROM combos ORDER BY")) {
+      throw new Error("forced quota combo listing failure");
+    }
+    return originalPrepare(sql);
+  }) as typeof db.prepare;
+
+  let response: Response;
+  try {
+    response = await deletePoolThroughRoute(pool.id);
+    await nextImmediate();
+    await nextImmediate();
+  } finally {
+    db.prepare = originalPrepare as typeof db.prepare;
+    process.off("unhandledRejection", onUnhandled);
+  }
+
+  assert.equal(response!.status, 204);
+  assert.deepEqual(unhandled, [], "guarded combo failure must not produce unhandledRejection");
+  assert.equal(poolsDb.getPool(pool.id), null);
+  assert.equal(
+    countRows("SELECT count(*) AS count FROM quota_pool_connections WHERE pool_id = ?", pool.id),
+    0
+  );
+  assert.equal(
+    countRows("SELECT count(*) AS count FROM quota_allocations WHERE pool_id = ?", pool.id),
+    0
+  );
+  assert.deepEqual(getAllowedQuotas(apiKey.id), []);
+});

--- a/tests/unit/db-quota-pools.test.ts
+++ b/tests/unit/db-quota-pools.test.ts
@@ -137,15 +137,15 @@ test("updatePool returns null for unknown id", () => {
   assert.equal(result, null);
 });
 
-test("deletePool removes pool and returns true", () => {
+test("deletePool removes pool and returns true", async () => {
   const pool = poolsDb.createPool({ connectionId: "c6", name: "Deletable" });
-  const deleted = poolsDb.deletePool(pool.id);
+  const deleted = await poolsDb.deletePool(pool.id);
   assert.equal(deleted, true);
   assert.equal(poolsDb.getPool(pool.id), null);
 });
 
-test("deletePool returns false for unknown id", () => {
-  const result = poolsDb.deletePool("ghost-pool");
+test("deletePool returns false for unknown id", async () => {
+  const result = await poolsDb.deletePool("ghost-pool");
   assert.equal(result, false);
 });
 
@@ -190,14 +190,14 @@ test("upsertAllocations with empty array removes all allocations", () => {
 // FK CASCADE: delete pool → allocations gone
 // ---------------------------------------------------------------------------
 
-test("deletePool cascades to allocations", () => {
+test("deletePool cascades to allocations", async () => {
   const pool = poolsDb.createPool({
     connectionId: "c9",
     name: "With Allocs",
     allocations: [{ apiKeyId: "k-cascade", weight: 100, policy: "hard" }],
   });
 
-  poolsDb.deletePool(pool.id);
+  await poolsDb.deletePool(pool.id);
 
   // After pool is deleted, listAllocationsForApiKey should find nothing for k-cascade
   const remaining = poolsDb.listAllocationsForApiKey("k-cascade");

--- a/tests/unit/quota-pool-connections.test.ts
+++ b/tests/unit/quota-pool-connections.test.ts
@@ -57,9 +57,7 @@ test.after(async () => {
 // ── D1.1: Migration file ────────────────────────────────────────────────────
 
 test("migration 086 file exists and contains quota_pool_connections DDL", () => {
-  const migrationPath = path.resolve(
-    "src/lib/db/migrations/087_quota_pool_connections.sql"
-  );
+  const migrationPath = path.resolve("src/lib/db/migrations/087_quota_pool_connections.sql");
   assert.ok(fs.existsSync(migrationPath), `migration file not found: ${migrationPath}`);
 
   const sql = fs.readFileSync(migrationPath, "utf8");
@@ -153,14 +151,14 @@ test("updatePool without connectionIds leaves join rows untouched", () => {
 
 // ── D1.4: deletePool removes join rows ────────────────────────────────────
 
-test("deletePool removes quota_pool_connections rows", () => {
+test("deletePool removes quota_pool_connections rows", async () => {
   const pool = poolsDb.createPool({
     connectionId: "del-a",
     name: "To Delete",
     connectionIds: ["del-a", "del-b"],
   });
 
-  const deleted = poolsDb.deletePool(pool.id);
+  const deleted = await poolsDb.deletePool(pool.id);
   assert.equal(deleted, true, "deletePool should return true");
 
   // Pool should be gone.

--- a/tests/unit/quota-pool-delete-prune.test.ts
+++ b/tests/unit/quota-pool-delete-prune.test.ts
@@ -23,8 +23,7 @@ import path from "node:path";
 // ── DB harness (same pattern as quota-exclusivity-reconcile.test.ts) ─────────
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-pool-delete-prune-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
-process.env.API_KEY_SECRET =
-  process.env.API_KEY_SECRET || "delete-prune-test-secret-32chars!!";
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "delete-prune-test-secret-32chars!!";
 
 const core = await import("../../src/lib/db/core.ts");
 const poolsDb = await import("../../src/lib/db/quotaPools.ts");
@@ -62,9 +61,8 @@ test.after(async () => {
 // ── Helper: get allowed_quotas for a key by id from DB ───────────────────────
 function getAllowedQuotasById(keyId: string): string[] {
   const db = core.getDbInstance();
-  const row = (db as any)
-    .prepare("SELECT allowed_quotas FROM api_keys WHERE id = ?")
-    .get(keyId) as { allowed_quotas: string } | undefined;
+  const row = (db as any).prepare("SELECT allowed_quotas FROM api_keys WHERE id = ?").get(keyId) as
+    { allowed_quotas: string } | undefined;
   if (!row) return [];
   try {
     const parsed = JSON.parse(row.allowed_quotas ?? "[]");
@@ -85,7 +83,7 @@ test("deletePool prunes its id from api_key allowed_quotas", async () => {
   const before = getAllowedQuotasById(keyObj.id);
   assert.ok(before.includes(pool.id), `pool.id should be in allowed_quotas before delete`);
 
-  poolsDb.deletePool(pool.id);
+  await poolsDb.deletePool(pool.id);
 
   const after = getAllowedQuotasById(keyObj.id);
   assert.ok(!after.includes(pool.id), `pool.id should NOT be in allowed_quotas after delete`);
@@ -103,7 +101,7 @@ test("deletePool preserves unrelated pool ids in allowed_quotas", async () => {
     allowedQuotas: [poolToDelete.id, otherPool.id, unrelatedId],
   });
 
-  poolsDb.deletePool(poolToDelete.id);
+  await poolsDb.deletePool(poolToDelete.id);
 
   const after = getAllowedQuotasById(keyObj.id);
   assert.ok(!after.includes(poolToDelete.id), "deleted pool id should be removed");
@@ -121,7 +119,7 @@ test("deletePool does not modify keys that don't reference the deleted pool", as
   // This key only references otherPool, not poolToDelete
   await apiKeysDb.updateApiKeyPermissions(keyObj.id, { allowedQuotas: [otherPool.id] });
 
-  poolsDb.deletePool(poolToDelete.id);
+  await poolsDb.deletePool(poolToDelete.id);
 
   const after = getAllowedQuotasById(keyObj.id);
   assert.deepEqual(after, [otherPool.id], "key referencing only other pool should be unchanged");
@@ -134,7 +132,7 @@ test("deletePool: key with empty allowed_quotas stays empty", async () => {
   const keyObj = await apiKeysDb.createApiKey("Prune Key 4", "machine-prune-4");
   // Don't set allowedQuotas — default is []
 
-  poolsDb.deletePool(pool.id);
+  await poolsDb.deletePool(pool.id);
 
   const after = getAllowedQuotasById(keyObj.id);
   assert.deepEqual(after, [], "empty allowed_quotas should remain empty after delete");
@@ -156,7 +154,7 @@ test("deletePool prunes pool id from ALL keys that reference it", async () => {
     await apiKeysDb.updateApiKeyPermissions(k.id, { allowedQuotas: [pool.id, otherPoolId] });
   }
 
-  poolsDb.deletePool(pool.id);
+  await poolsDb.deletePool(pool.id);
 
   for (const k of keys) {
     const after = getAllowedQuotasById(k.id);
@@ -167,23 +165,31 @@ test("deletePool prunes pool id from ALL keys that reference it", async () => {
 
 // ── 6. deletePool still returns true/false correctly ─────────────────────────
 
-test("deletePool returns true for existing pool, false for non-existent", () => {
+test("deletePool returns true for existing pool, false for non-existent", async () => {
   const pool = poolsDb.createPool({ connectionId: "conn-ret-1", name: "Return Test" });
-  assert.equal(poolsDb.deletePool(pool.id), true, "should return true for existing pool");
-  assert.equal(poolsDb.deletePool(pool.id), false, "should return false for already-deleted pool");
-  assert.equal(poolsDb.deletePool("nonexistent-id"), false, "should return false for unknown id");
+  assert.equal(await poolsDb.deletePool(pool.id), true, "should return true for existing pool");
+  assert.equal(
+    await poolsDb.deletePool(pool.id),
+    false,
+    "should return false for already-deleted pool"
+  );
+  assert.equal(
+    await poolsDb.deletePool("nonexistent-id"),
+    false,
+    "should return false for unknown id"
+  );
 });
 
 // ── 7. Pool row and allocation rows are gone after delete (regression guard) ──
 
-test("deletePool removes pool and allocation rows from DB", () => {
+test("deletePool removes pool and allocation rows from DB", async () => {
   const pool = poolsDb.createPool({
     connectionId: "conn-reg-1",
     name: "Regression Pool",
     allocations: [{ apiKeyId: "key-reg-1", weight: 50, policy: "hard" }],
   });
 
-  poolsDb.deletePool(pool.id);
+  await poolsDb.deletePool(pool.id);
 
   assert.equal(poolsDb.getPool(pool.id), null, "getPool should return null after delete");
   const { items: allPools } = poolsDb.listPools();


### PR DESCRIPTION
## Summary

- make quota-pool deletion await scoped managed-combo cleanup before removing pool metadata
- serialize pool combo maintenance and invalidate synchronous pool mutations once deletion starts
- preserve relational cleanup, missing-pool behavior, and unrelated quota/user combos

Addresses #8880.

## Changes

- `src/lib/db/quotaPools.ts`: make deletion asynchronous, serialize per-pool combo maintenance, reject/no-op mutations during deletion, and keep missing-pool deletion side-effect free
- `src/lib/quota/quotaCombos.ts`: re-check pool existence before managed-combo upsert
- `src/app/api/quota/pools/[id]/route.ts`: await the corrected deletion contract before returning `204` or `404`
- add a real-SQLite/real-route integration suite plus update affected quota-pool unit callers
- add the required numbered changelog fragment for this PR

## Validation

- [x] focused deletion integration: 8/8
- [x] related seven-file quota pool/combo/route matrix: 63/63
- [x] adversarial create→delete, update→delete, and delete→update probes: 40/40 each
- [x] `npm run lint`
- [x] `npm run typecheck:core`
- [x] DB rules, cycles, error-helper, public-creds, file-size, test-runner API, test-masking absolute scan, tracked-artifacts, build-scope, changelog-integrity, changed-file ESLint/Prettier, and `git diff --check`
- [ ] full `npm run test` — **UNVERIFIED**: the final implementation-tree run exceeded 11 minutes and remained alive after more than 15,650 tests because repeated ioredis `ECONNREFUSED` open-handle noise prevented process termination; this is not claimed as a pass

## Review and upstream acceptance

- independent read-only review found zero P0/P1/P2 on implementation HEAD `bf02b1999e7023453462bc5c25b0aea0fbcdd1a7` / tree `75f9a3d9ad1e0e5ac731e11618043fda44874a6d`
- final publication HEAD `ef250a425f0d3f716eeaa7307993b9bd89922a2c` / tree `1b202f7c0f8fb60e4ef4679961a92941b8d222fe` differs from that reviewed implementation tree only by `changelog.d/fixes/8906-quota-pool-combo-cleanup.md`; the focused 8/8 suite and changelog integrity gate were rerun on the final tree
- independent read-only review completed on the cited implementation tree with no unresolved blocking findings
- target `release/v3.8.50` is the active/default development branch; the open v3.8.49 freeze does not freeze this next-cycle branch
- bounded scope: 3 production files (+65/-28), 4 test files (+458/-27), and one numbered changelog fragment; no schema/migration, dependency, lockfile, generated artifact, provider/network, or production-data migration
- code gate: PASS; CI readiness: local focused/static gates pass with the full-suite caveat above; merge-queue eligibility remains pending repository CI and maintainer review; no separate architecture decision is required

## Non-goals

No orphan backfill endpoint, schema change, quota naming/strategy change, broad async DB refactor, or production/provider-state operation.
