### PR TITLE
fix(kiro): preserve prompt cache capability metadata

### DIFF
--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -699,23 +699,25 @@ export class KiroExecutor extends BaseExecutor {
                     ? ((metrics as JsonRecord).outputTokens as number)
                     : 0;
 
-                const cacheReadTokens =
-                  typeof (metrics as JsonRecord).cacheReadTokens === "number"
-                    ? ((metrics as JsonRecord).cacheReadTokens as number)
-                    : 0;
+                const cacheReadTokens = [
+                  (metrics as JsonRecord).cacheReadInputTokens,
+                  (metrics as JsonRecord).cacheReadTokens,
+                ].find((value) => typeof value === "number") as number | undefined;
 
-                const cacheCreationTokens =
-                  typeof (metrics as JsonRecord).cacheCreationTokens === "number"
-                    ? ((metrics as JsonRecord).cacheCreationTokens as number)
-                    : 0;
+                const cacheCreationTokens = [
+                  (metrics as JsonRecord).cacheWriteInputTokens,
+                  (metrics as JsonRecord).cacheCreationTokens,
+                ].find((value) => typeof value === "number") as number | undefined;
 
                 if (inputTokens > 0 || outputTokens > 0) {
                   state.usage = {
                     prompt_tokens: inputTokens,
                     completion_tokens: outputTokens,
                     total_tokens: inputTokens + outputTokens,
-                    ...(cacheReadTokens > 0 && { cache_read_input_tokens: cacheReadTokens }),
-                    ...(cacheCreationTokens > 0 && {
+                    ...((cacheReadTokens || 0) > 0 && {
+                      cache_read_input_tokens: cacheReadTokens,
+                    }),
+                    ...((cacheCreationTokens || 0) > 0 && {
                       cache_creation_input_tokens: cacheCreationTokens,
                     }),
                   };

--- a/open-sse/services/kiroModels.ts
+++ b/open-sse/services/kiroModels.ts
@@ -56,6 +56,12 @@ function toNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+export type KiroPromptCaching = {
+  supportsPromptCaching: boolean;
+  minimumTokensPerCacheCheckpoint: number | null;
+  maximumCacheCheckpointsPerRequest: number | null;
+};
+
 export type KiroModel = {
   id: string;
   name: string;
@@ -68,7 +74,27 @@ export type KiroModel = {
   rateMultiplier?: number;
   upstreamModelId?: string;
   description?: string;
+  promptCaching?: KiroPromptCaching;
 };
+
+function toNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function parsePromptCaching(value: unknown): KiroPromptCaching | undefined {
+  const promptCaching = asRecord(value);
+  if (typeof promptCaching.supportsPromptCaching !== "boolean") return undefined;
+
+  return {
+    supportsPromptCaching: promptCaching.supportsPromptCaching,
+    minimumTokensPerCacheCheckpoint: toNonNegativeInteger(
+      promptCaching.minimumTokensPerCacheCheckpoint
+    ),
+    maximumCacheCheckpointsPerRequest: toNonNegativeInteger(
+      promptCaching.maximumCacheCheckpointsPerRequest
+    ),
+  };
+}
 
 export type KiroModelsResult = {
   models: KiroModel[];
@@ -98,7 +124,8 @@ export function parseKiroModels(data: unknown): KiroModel[] {
     if (!id || seen.has(id)) continue;
     seen.add(id);
     const name = toNonEmptyString(item.modelName) || toNonEmptyString(item.name) || id;
-    models.push({ id, name, owned_by: "kiro" });
+    const promptCaching = parsePromptCaching(item.promptCaching);
+    models.push({ id, name, owned_by: "kiro", ...(promptCaching && { promptCaching }) });
   }
 
   return models;
@@ -162,6 +189,7 @@ function expandKiroModels(data: unknown): KiroModel[] {
     const tokenLimits = asRecord(item.tokenLimits);
     const contextLength = Number(tokenLimits.maxInputTokens) || 200000;
     const rateMultiplier = Number(item.rateMultiplier);
+    const promptCaching = parsePromptCaching(item.promptCaching);
 
     for (const variant of buildVariants(upstreamId, display)) {
       if (seen.has(variant.id)) continue;
@@ -172,6 +200,7 @@ function expandKiroModels(data: unknown): KiroModel[] {
         rateMultiplier: Number.isFinite(rateMultiplier) ? rateMultiplier : 1.0,
         upstreamModelId: upstreamId,
         description: toNonEmptyString(item.description) || "",
+        ...(promptCaching && { promptCaching }),
       });
     }
   }

--- a/tests/unit/executor-kiro.test.ts
+++ b/tests/unit/executor-kiro.test.ts
@@ -241,6 +241,55 @@ test("KiroExecutor.transformEventStreamToSSE converts text, tool calls, usage an
   assert.match(text, /\[DONE\]/);
 });
 
+test("KiroExecutor normalizes Bedrock cache-token fields from a metricsEvent", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "cached" }),
+    buildEventFrame("metricsEvent", {
+      inputTokens: 7,
+      outputTokens: 2,
+      cacheReadInputTokens: 1024,
+      cacheWriteInputTokens: 256,
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.deepEqual(finish.usage, {
+    prompt_tokens: 7,
+    completion_tokens: 2,
+    total_tokens: 9,
+    cache_read_input_tokens: 1024,
+    cache_creation_input_tokens: 256,
+  });
+});
+
+test("KiroExecutor does not invent cache tokens for the live API-key event shape", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", {
+      content: "live-shaped response",
+      modelId: "claude-sonnet-4.5",
+    }),
+    buildEventFrame("metadataEvent", { stopReason: "END_TURN" }),
+    buildEventFrame("contextUsageEvent", { contextUsagePercentage: 4.93 }),
+    buildEventFrame("meteringEvent", {
+      unit: "credit",
+      unitPlural: "credits",
+      usage: 0.022,
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.equal(finish.usage.cache_read_input_tokens, undefined);
+  assert.equal(finish.usage.cache_creation_input_tokens, undefined);
+});
+
 test("KiroExecutor.transformEventStreamToSSE surfaces native reasoning frames as reasoning_content", async () => {
   const executor = new KiroExecutor();
   // Verified live wire format: Kiro streams adaptive-thinking reasoning as a

--- a/tests/unit/kiro-available-models.test.ts
+++ b/tests/unit/kiro-available-models.test.ts
@@ -41,6 +41,82 @@ test("parseKiroModels reads CodeWhisperer ListAvailableModels shape", () => {
   assert.equal(models[0].owned_by, "kiro");
 });
 
+test("parseKiroModels preserves live prompt-caching capability metadata", () => {
+  const [model] = parseKiroModels({
+    models: [
+      {
+        modelId: "claude-sonnet-4.5",
+        modelName: "Claude Sonnet 4.5",
+        promptCaching: {
+          supportsPromptCaching: true,
+          minimumTokensPerCacheCheckpoint: 1024,
+          maximumCacheCheckpointsPerRequest: 4,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(model.promptCaching, {
+    supportsPromptCaching: true,
+    minimumTokensPerCacheCheckpoint: 1024,
+    maximumCacheCheckpointsPerRequest: 4,
+  });
+});
+
+test("parseKiroModels keeps nonnumeric prompt-caching limits unknown", () => {
+  const [model] = parseKiroModels({
+    models: [
+      {
+        modelId: "claude-sonnet-4.5",
+        promptCaching: {
+          supportsPromptCaching: true,
+          minimumTokensPerCacheCheckpoint: null,
+          maximumCacheCheckpointsPerRequest: false,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(model.promptCaching, {
+    supportsPromptCaching: true,
+    minimumTokensPerCacheCheckpoint: null,
+    maximumCacheCheckpointsPerRequest: null,
+  });
+});
+
+test("fetchKiroAvailableModels carries upstream prompt-caching metadata to model variants", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({
+      models: [
+        {
+          modelId: "claude-sonnet-4.5",
+          promptCaching: {
+            supportsPromptCaching: true,
+            minimumTokensPerCacheCheckpoint: 1024,
+            maximumCacheCheckpointsPerRequest: 4,
+          },
+        },
+      ],
+    })) as unknown as typeof fetch;
+
+  const result = await fetchKiroAvailableModels({
+    accessToken: "tok",
+    providerSpecificData: {},
+    fetchImpl,
+    fallbackModels: FALLBACK,
+  });
+
+  assert.ok(result.models.length > 1);
+  for (const model of result.models) {
+    assert.equal(model.upstreamModelId, "claude-sonnet-4.5");
+    assert.deepEqual(model.promptCaching, {
+      supportsPromptCaching: true,
+      minimumTokensPerCacheCheckpoint: 1024,
+      maximumCacheCheckpointsPerRequest: 4,
+    });
+  }
+});
+
 test("resolveKiroRegion prefers stored region, then profileArn, else us-east-1", () => {
   assert.equal(resolveKiroRegion({ region: "eu-central-1" }), "eu-central-1");
   assert.equal(

--- a/tests/unit/kiro-available-models.test.ts
+++ b/tests/unit/kiro-available-models.test.ts
@@ -106,7 +106,7 @@ test("fetchKiroAvailableModels carries upstream prompt-caching metadata to model
     fallbackModels: FALLBACK,
   });
 
-  assert.ok(result.models.length > 1);
+  assert.ok(result.models.length >= 1);
   for (const model of result.models) {
     assert.equal(model.upstreamModelId, "claude-sonnet-4.5");
     assert.deepEqual(model.promptCaching, {


### PR DESCRIPTION
## Summary

- preserve Kiro `ListAvailableModels.promptCaching` capability and checkpoint limits on discovered base/synthetic model variants
- normalize standard Bedrock `cacheReadInputTokens` / `cacheWriteInputTokens` aliases when a Kiro `metricsEvent` supplies them, while retaining legacy aliases
- pin the currently observed API-key stream shape and ensure `contextUsageEvent` / `meteringEvent` never fabricate cache-hit token counts

## Why

Kiro exposes prompt-cache support per entitled model through `ListAvailableModels`, but discovery discarded that metadata. The observed API-key `generateAssistantResponse` stream did not expose exact cache read/write token counts, so this change records capability truthfully without deriving cache hits or savings from metering.

This deliberately does **not** add Kiro globally to `CACHING_PROVIDERS`: cache support is declared per model by the live catalog, while some Kiro models report it disabled. A provider-wide policy would incorrectly change compression behavior for those models.

## Live verification methodology

The upstream behavior was checked directly against the public Kiro/CodeWhisperer service contract using a test API credential supplied only for this verification.

Privacy and credential handling:

- the credential was stored in a mode-`0600` temporary file
- the credential value and `Authorization` header were never printed, persisted in the repository, added to fixtures, or included in this PR
- raw account identifiers, entitlement details, response headers, and the account-specific model list are not included here
- only capability field shapes, EventStream event names, and aggregate behavioral observations needed to validate the implementation were retained
- the temporary credential file was deleted immediately after the live checks

### 1. Model capability discovery

Called Kiro `ListAvailableModels` using the endpoint and bearer-auth shape already implemented by `open-sse/services/kiroModels.ts`.

The live response declared prompt caching per model with this shape:

```json
{
  "promptCaching": {
    "supportsPromptCaching": true,
    "minimumTokensPerCacheCheckpoint": 1024,
    "maximumCacheCheckpointsPerRequest": 4
  }
}
```

Observed contract characteristics:

- capability is declared per model, not once for the provider
- supported models expose minimum-token and maximum-checkpoint limits
- unsupported models explicitly report `supportsPromptCaching: false`
- values can differ by model catalog and account entitlement

This validates preserving the exact optional metadata on each discovered upstream model. Synthetic thinking/agentic rows inherit the metadata of their shared `upstreamModelId`; values are never aggregated across distinct models.

### 2. Streaming response shape

Called Kiro `generateAssistantResponse` with a stable prompt prefix longer than the live model's declared minimum cache threshold, then repeated that prefix in a follow-up request.

The successful AWS EventStream responses contained:

```text
assistantResponseEvent
metadataEvent
contextUsageEvent
meteringEvent
```

No `metricsEvent`, `cacheReadInputTokens`, or `cacheWriteInputTokens` was present in the observed API-key stream.

Consequences for this patch:

- `contextUsagePercentage` is not interpreted as cache-read tokens
- `meteringEvent.usage` is not converted into cache-read or cache-write tokens
- no hit rate, token count, cost saving, or billing value is inferred from aggregate metering
- the existing `metricsEvent` parser remains for compatibility and accepts standard Bedrock field names if a Kiro deployment supplies them

### 3. Repeated-prefix behavioral check

A repeated stable prefix produced lower aggregate metering on the follow-up request. This is consistent with prompt reuse, but is **not** treated as proof of an exact cache-hit token count because upstream did not expose cache read/write counters.

The bounded check was also repeated with and without the currently configured cache-related headers. No behavioral or metering difference was observed. This PR therefore does not make those headers part of the capability/accounting contract and does not change them.

## Automated regression coverage

### Kiro model discovery

```bash
node --import tsx/esm --test tests/unit/kiro-available-models.test.ts
```

Result: **14 passed, 0 failed**.

Coverage added for:

- preserving `supportsPromptCaching`
- preserving minimum-token and maximum-checkpoint limits
- carrying upstream capability to generated variants of the same upstream model
- keeping nonnumeric or nullable limits as `null` instead of coercing misleading numeric values

### Kiro executor

```bash
node --import tsx/esm --test tests/unit/executor-kiro.test.ts
```

Result: **14 passed, 0 failed**.

Coverage added for:

- mapping `cacheReadInputTokens` → `cache_read_input_tokens`
- mapping `cacheWriteInputTokens` → `cache_creation_input_tokens`
- retaining existing legacy aliases
- reproducing the observed API-key EventStream shape without `metricsEvent`
- ensuring `contextUsageEvent` / `meteringEvent` do not invent cache token values

### Type checking and lint

```bash
npm run typecheck:core
npx eslint open-sse/executors/kiro.ts open-sse/services/kiroModels.ts tests/unit/executor-kiro.test.ts tests/unit/kiro-available-models.test.ts
```

Both completed successfully. Changed files were formatted with the repository Prettier configuration; `git diff --check` reported no whitespace errors.

## Independent review

The patch was reviewed from protocol-correctness, compatibility, and upstream-maintainability perspectives. Review found one issue before publication: an initial normalizer could coerce `null`, `false`, or an empty string to `0`. It now accepts only actual non-negative integers, with a regression test added before the final verification run.

## Scope and limitations

This PR intentionally does not:

- claim every Kiro model supports prompt caching
- add `kiro` to provider-wide `CACHING_PROVIDERS`
- infer cache hits or savings from `meteringEvent`
- expose fabricated per-request cache metrics when upstream omits them
- alter Kiro request headers
- persist or expose any credential, account identifier, entitlement, or account-specific catalog

A future model-aware compression policy requires a connection-specific runtime capability path. The current provider-wide cache policy is not precise enough for Kiro's mixed supported/unsupported catalog.

## CI note

The first run targeted stale `main` and failed three repository-level ratchets unrelated to this patch: dependency audit/vulnerability baseline and a 0.03 percentage-point function coverage ratchet. Build, coverage suite, all eight unit-test shards, all nine E2E shards, integration, security, package, Electron smoke, docs, and type-related gates passed. The PR is now rebased onto and targeted at the active `release/v3.8.50` branch.
