### PR TITLE
fix(providers): expose dual-auth actions for CodeBuddy CN

### DIFF
--- a/changelog.d/fixes/8921-codebuddy-cn-dual-auth-actions.md
+++ b/changelog.d/fixes/8921-codebuddy-cn-dual-auth-actions.md
@@ -1,0 +1,1 @@
+- **fix(providers):** expose both OAuth Connect and manual API-key actions for dual-auth providers such as CodeBuddy CN ([#8921](https://github.com/diegosouzapw/OmniRoute/pull/8921)) — thanks @Llliao1113

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -14,6 +14,7 @@ import {
   isAnthropicCompatibleProvider,
   isClaudeCodeCompatibleProvider,
   supportsApiKeyOnFreeProvider,
+  supportsDualAuthProvider,
 } from "@/shared/constants/providers";
 import { getModelsByProviderId } from "@/shared/constants/models";
 import {
@@ -221,6 +222,7 @@ export default function ProviderDetailPageClient() {
   } = useConnectionGate({ providerId, subscriptionRisk });
 
   const providerSupportsPat = supportsApiKeyOnFreeProvider(providerId);
+  const supportsDualAuth = supportsDualAuthProvider(providerId);
   const isOAuth = providerSupportsOAuth && !providerSupportsPat;
   const providerAlias = getProviderAlias(providerId);
   const isFreeNoAuth =
@@ -501,6 +503,7 @@ export default function ProviderDetailPageClient() {
             isCompatible={isCompatible}
             isCommandCode={isCommandCode}
             isOAuth={isOAuth}
+            supportsDualAuth={supportsDualAuth}
             providerSupportsPat={providerSupportsPat}
             connections={connections}
             batchTesting={batchTesting}
@@ -547,6 +550,7 @@ export default function ProviderDetailPageClient() {
               isCompatible={isCompatible}
               isCommandCode={isCommandCode}
               providerId={providerId}
+              supportsDualAuth={supportsDualAuth}
               providerSupportsPat={providerSupportsPat}
               commandCodeAuthState={commandCodeAuthState}
               gateConnectionFlow={gateConnectionFlow}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsHeaderToolbar.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsHeaderToolbar.tsx
@@ -10,6 +10,7 @@ type ConnectionsHeaderToolbarProps = {
   isCompatible: boolean;
   isCommandCode: boolean;
   isOAuth: boolean;
+  supportsDualAuth: boolean;
   providerSupportsPat: boolean;
   connections: any[]; // ConnectionRowConnection[]
   batchTesting: boolean;
@@ -57,6 +58,7 @@ export default function ConnectionsHeaderToolbar({
   isCompatible,
   isCommandCode,
   isOAuth,
+  supportsDualAuth,
   providerSupportsPat,
   connections,
   batchTesting,
@@ -268,7 +270,7 @@ export default function ConnectionsHeaderToolbar({
         )}
         {!isCompatible ? (
           <>
-            {isCommandCode || providerId === "clinepass" ? (
+            {isCommandCode || supportsDualAuth ? (
               <>
                 <Button
                   size="sm"

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/EmptyConnectionsPlaceholder.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/EmptyConnectionsPlaceholder.tsx
@@ -14,6 +14,7 @@ interface EmptyConnectionsPlaceholderProps {
   isCompatible: boolean;
   isCommandCode: boolean;
   providerId: string;
+  supportsDualAuth: boolean;
   providerSupportsPat: boolean;
   commandCodeAuthState: CommandCodeAuthState;
   gateConnectionFlow: (callback: () => void) => void;
@@ -33,6 +34,7 @@ export default function EmptyConnectionsPlaceholder({
   isCompatible,
   isCommandCode,
   providerId,
+  supportsDualAuth,
   providerSupportsPat,
   commandCodeAuthState,
   gateConnectionFlow,
@@ -55,7 +57,7 @@ export default function EmptyConnectionsPlaceholder({
       <p className="text-sm text-text-muted mb-4">{t("addFirstConnectionHint")}</p>
       {!isCompatible && (
         <div className="flex items-center justify-center gap-2">
-          {isCommandCode || providerId === "clinepass" ? (
+          {isCommandCode || supportsDualAuth ? (
             <>
               <Button
                 icon="open_in_new"

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/dual-auth-actions.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/dual-auth-actions.test.tsx
@@ -33,8 +33,8 @@ const t = ((key: string) => translations[key] ?? key) as ProviderMessageTranslat
 t.has = () => false;
 
 function getButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
-  return Array.from(container.querySelectorAll("button")).find(
-    (button) => button.textContent?.includes(label)
+  return Array.from(container.querySelectorAll("button")).find((button) =>
+    button.textContent?.includes(label)
   );
 }
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/dual-auth-actions.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/dual-auth-actions.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ConnectionsHeaderToolbar from "../ConnectionsHeaderToolbar";
+import EmptyConnectionsPlaceholder from "../EmptyConnectionsPlaceholder";
+import type { ProviderMessageTranslator } from "../../providerPageHelpers";
+
+const cleanups: Array<() => void> = [];
+
+function renderComponent(node: React.ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(node));
+  cleanups.push(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+  return container;
+}
+
+const translations: Record<string, string> = {
+  add: "Add",
+  addConnection: "Add connection",
+  connections: "Connections",
+  noConnectionsYet: "No connections yet",
+  addFirstConnectionHint: "Add your first connection",
+  providerProxy: "Proxy",
+  providerProxyConfigureHint: "Configure proxy",
+};
+const t = ((key: string) => translations[key] ?? key) as ProviderMessageTranslator;
+t.has = () => false;
+
+function getButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent?.includes(label)
+  );
+}
+
+function createActions() {
+  const openApiKeyAddFlow = vi.fn();
+  const openPrimaryAddFlow = vi.fn();
+  const gateConnectionFlow = vi.fn((callback: () => void) => callback());
+  return { openApiKeyAddFlow, openPrimaryAddFlow, gateConnectionFlow };
+}
+
+function renderEmptyProvider({
+  providerId,
+  supportsDualAuth,
+  providerSupportsPat,
+}: {
+  providerId: string;
+  supportsDualAuth: boolean;
+  providerSupportsPat: boolean;
+}) {
+  const actions = createActions();
+  const props: React.ComponentProps<typeof EmptyConnectionsPlaceholder> & {
+    supportsDualAuth: boolean;
+  } = {
+    isOAuth: !providerSupportsPat,
+    isCompatible: false,
+    isCommandCode: false,
+    providerId,
+    supportsDualAuth,
+    providerSupportsPat,
+    commandCodeAuthState: { phase: "idle" },
+    ...actions,
+    handleOpenCommandCodeConnect: vi.fn(),
+    onOpenOAuthModal: vi.fn(),
+    onOpenImportCodex: vi.fn(),
+    onOpenImportClaude: vi.fn(),
+    onOpenImportGemini: vi.fn(),
+    onOpenImportGrokCli: vi.fn(),
+    t,
+  };
+  return { container: renderComponent(<EmptyConnectionsPlaceholder {...props} />), ...actions };
+}
+
+function renderPopulatedCodeBuddy() {
+  const actions = createActions();
+  const props: React.ComponentProps<typeof ConnectionsHeaderToolbar> & {
+    supportsDualAuth: boolean;
+  } = {
+    providerId: "codebuddy-cn",
+    providerInfo: { id: "codebuddy-cn", name: "CodeBuddy CN" },
+    isCompatible: false,
+    isCommandCode: false,
+    isOAuth: true,
+    supportsDualAuth: true,
+    providerSupportsPat: false,
+    connections: [{ id: "connection-1", authType: "oauth" }],
+    batchTesting: false,
+    batchRetesting: false,
+    retestingId: null,
+    proxyConfig: null,
+    reorderingByAvailability: false,
+    handleReorderByAvailability: vi.fn(),
+    preferClaudeCodeForUnprefixedClaudeModels: false,
+    claudeRoutingSettingsLoaded: true,
+    claudeRoutingSettingsLoadError: null,
+    savingClaudeRoutingPreference: false,
+    handleToggleClaudeRoutingPreference: vi.fn(),
+    loadClaudeRoutingSettings: vi.fn(),
+    codexGlobalServiceMode: "auto",
+    codexGlobalServiceModeOptions: [],
+    codexSettingsLoaded: true,
+    codexSettingsLoadError: null,
+    savingCodexGlobalServiceMode: false,
+    handleChangeCodexGlobalServiceMode: vi.fn(),
+    loadCodexSettings: vi.fn(),
+    onSetProxyTarget: vi.fn(),
+    handleDistributeProxies: vi.fn(),
+    handleBatchTestAll: vi.fn(),
+    ...actions,
+    openExternalLinkFlow: vi.fn(),
+    handleOpenCommandCodeConnect: vi.fn(),
+    commandCodeAuthState: { phase: "idle" },
+    onOpenOAuthModal: vi.fn(),
+    onOpenCodexCliGuide: vi.fn(),
+    onOpenImportCodex: vi.fn(),
+    onOpenImportClaude: vi.fn(),
+    onOpenImportGemini: vi.fn(),
+    onOpenImportGrokCli: vi.fn(),
+    t,
+  };
+  return { container: renderComponent(<ConnectionsHeaderToolbar {...props} />), ...actions };
+}
+
+function expectDualAuthActions(
+  container: HTMLElement,
+  actions: ReturnType<typeof createActions>
+): void {
+  const connect = getButton(container, "Connect");
+  const manualApiKey = getButton(container, "Manual API key");
+  expect(connect, "OAuth Connect action must be rendered").toBeDefined();
+  expect(manualApiKey, "Manual API key action must be rendered").toBeDefined();
+
+  act(() => connect?.click());
+  expect(actions.gateConnectionFlow).toHaveBeenCalledWith(actions.openPrimaryAddFlow);
+  expect(actions.openPrimaryAddFlow).toHaveBeenCalledOnce();
+
+  act(() => manualApiKey?.click());
+  expect(actions.gateConnectionFlow).toHaveBeenCalledWith(actions.openApiKeyAddFlow);
+  expect(actions.openApiKeyAddFlow).toHaveBeenCalledOnce();
+}
+
+describe("dual-auth provider actions (#8882)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()?.();
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders OAuth Connect and Manual API key for empty CodeBuddy CN", () => {
+    const rendered = renderEmptyProvider({
+      providerId: "codebuddy-cn",
+      supportsDualAuth: true,
+      providerSupportsPat: false,
+    });
+    expectDualAuthActions(rendered.container, rendered);
+  });
+
+  it("renders OAuth Connect and Manual API key for populated CodeBuddy CN", () => {
+    const rendered = renderPopulatedCodeBuddy();
+    expectDualAuthActions(rendered.container, rendered);
+  });
+
+  it("preserves ClinePass dual-auth actions", () => {
+    const rendered = renderEmptyProvider({
+      providerId: "clinepass",
+      supportsDualAuth: true,
+      providerSupportsPat: false,
+    });
+    expectDualAuthActions(rendered.container, rendered);
+  });
+
+  it("preserves Qoder PAT-primary and experimental OAuth actions", () => {
+    const { container } = renderEmptyProvider({
+      providerId: "qoder",
+      supportsDualAuth: false,
+      providerSupportsPat: true,
+    });
+    expect(getButton(container, "Add PAT")).toBeDefined();
+    expect(getButton(container, "Experimental OAuth")).toBeDefined();
+    expect(getButton(container, "Connect")).toBeUndefined();
+    expect(getButton(container, "Manual API key")).toBeUndefined();
+  });
+
+  it("preserves an ordinary OAuth provider primary action", () => {
+    const { container } = renderEmptyProvider({
+      providerId: "gemini",
+      supportsDualAuth: false,
+      providerSupportsPat: false,
+    });
+    expect(getButton(container, "Add connection")).toBeDefined();
+    expect(getButton(container, "Manual API key")).toBeUndefined();
+  });
+
+  it("preserves an ordinary free API-key provider PAT-primary action", () => {
+    const { container } = renderEmptyProvider({
+      providerId: "mimocode",
+      supportsDualAuth: false,
+      providerSupportsPat: true,
+    });
+    expect(getButton(container, "Add PAT")).toBeDefined();
+    expect(getButton(container, "Connect")).toBeUndefined();
+    expect(getButton(container, "Manual API key")).toBeUndefined();
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -10,6 +10,7 @@ import {
 import {
   isClaudeCodeCompatibleProvider,
   supportsApiKeyOnFreeProvider,
+  supportsDualAuthProvider,
 } from "@/shared/constants/providers";
 import { getModelsByProviderId } from "@/shared/constants/models";
 import { providerHasServiceKind } from "@/lib/providers/serviceKindIndex";
@@ -135,6 +136,7 @@ export function connectionMatchesProviderCard(
   if (cardAuthType === "free") return true;
   if (
     supportsApiKeyOnFreeProvider(providerId) ||
+    supportsDualAuthProvider(providerId) ||
     OAUTH_CARD_API_KEY_CONNECTION_PROVIDER_IDS.has(providerId)
   ) {
     return conn.authType === "oauth" || conn.authType === "apikey" || conn.authType === "api_key";

--- a/src/lib/providers/catalog.ts
+++ b/src/lib/providers/catalog.ts
@@ -10,6 +10,7 @@ import {
   WEB_COOKIE_PROVIDERS,
   isClaudeCodeCompatibleProvider,
   supportsApiKeyOnFreeProvider,
+  supportsDualAuthProvider,
   type RiskNoticeVariant,
 } from "@/shared/constants/providers";
 
@@ -88,8 +89,7 @@ export interface ResolvedCompatibleProviderCatalogEntry extends ProviderCatalogM
 }
 
 export type ResolvedProviderCatalogEntry =
-  | ResolvedStaticProviderCatalogEntry
-  | ResolvedCompatibleProviderCatalogEntry;
+  ResolvedStaticProviderCatalogEntry | ResolvedCompatibleProviderCatalogEntry;
 
 export const STATIC_PROVIDER_CATALOG_GROUPS: Record<
   StaticProviderCatalogCategory,
@@ -196,22 +196,9 @@ export function resolveStaticProviderCatalogEntry(
   return null;
 }
 
-/**
- * OAuth-primary providers that ALSO accept a direct BYOK API key (dual-auth),
- * admitted through the managed-connection API-key gate independent of the OAuth
- * catalog. These are deliberately kept OUT of `FREE_APIKEY_PROVIDER_IDS`: that
- * set flips `providerSupportsPat` true, which turns `isOAuth` false and would
- * make the dashboard's primary "Connect" button route to the API-key modal
- * instead of the OAuth flow. Admitting them here lets POST /api/providers
- * persist an `apikey` connection (the reliable BYOK path) while the provider
- * stays OAuth-primary (isOAuth=true). clinepass is the dual-auth case: sign in
- * with a Cline account OR paste a ClinePass API key.
- */
-const DUAL_AUTH_APIKEY_PROVIDER_IDS = new Set<string>(["clinepass"]);
-
 export function isManagedProviderConnectionId(providerId: string): boolean {
   if (supportsApiKeyOnFreeProvider(providerId)) return true;
-  if (DUAL_AUTH_APIKEY_PROVIDER_IDS.has(providerId)) return true;
+  if (supportsDualAuthProvider(providerId)) return true;
 
   const entry = resolveStaticProviderCatalogEntry(providerId);
   return !!(entry && MANAGED_PROVIDER_CONNECTION_CATEGORIES.has(entry.category));

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -33,10 +33,6 @@ export const FREE_APIKEY_PROVIDER_IDS = new Set([
   "mimocode",
   "opencode",
   "dahl",
-  // codebuddy-cn is OAuth-primary but the Tencent gateway also accepts a direct
-  // API key (Authorization: Bearer). Admit it through the same managed-provider
-  // gate so POST /api/providers accepts the dual-auth shape.
-  "codebuddy-cn",
   // auggie is a fully local, credential-less CLI passthrough (auth handled by
   // `auggie login` outside OmniRoute). Admitted here purely so POST /api/providers
   // accepts an optional connection row for display/priority/testStatus tracking —
@@ -46,6 +42,14 @@ export const FREE_APIKEY_PROVIDER_IDS = new Set([
 
 export function supportsApiKeyOnFreeProvider(providerId: unknown): boolean {
   return typeof providerId === "string" && FREE_APIKEY_PROVIDER_IDS.has(providerId);
+}
+
+// OAuth-primary providers that also accept a direct API key. Keep these out of
+// FREE_APIKEY_PROVIDER_IDS so the dashboard's primary action remains OAuth.
+const DUAL_AUTH_PROVIDER_IDS = new Set(["clinepass", "codebuddy-cn"]);
+
+export function supportsDualAuthProvider(providerId: unknown): boolean {
+  return typeof providerId === "string" && DUAL_AUTH_PROVIDER_IDS.has(providerId);
 }
 
 // Web / Cookie Providers

--- a/tests/unit/clinepass-provider.test.ts
+++ b/tests/unit/clinepass-provider.test.ts
@@ -1,8 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { APIKEY_PROVIDERS, OAUTH_PROVIDERS, supportsApiKeyOnFreeProvider } =
-  await import("../../src/shared/constants/providers.ts");
+const {
+  APIKEY_PROVIDERS,
+  OAUTH_PROVIDERS,
+  supportsApiKeyOnFreeProvider,
+  supportsDualAuthProvider,
+} = await import("../../src/shared/constants/providers.ts");
 const { isManagedProviderConnectionId } = await import("../../src/lib/providers/catalog.ts");
 const { PROVIDERS: oauthFlows } = await import("../../src/lib/oauth/providers/index.ts");
 const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
@@ -309,6 +313,7 @@ test("ClinePass API-key connections pass the managed gate while staying OAuth-pr
     !supportsApiKeyOnFreeProvider("clinepass"),
     "clinepass must NOT be in FREE_APIKEY_PROVIDER_IDS — that would flip isOAuth false"
   );
+  assert.equal(supportsDualAuthProvider("clinepass"), true);
 });
 
 // ── Catalog ↔ registry alias consistency (routing prefix) ───────────────────

--- a/tests/unit/clinepass-provider.test.ts
+++ b/tests/unit/clinepass-provider.test.ts
@@ -8,6 +8,8 @@ const {
   supportsDualAuthProvider,
 } = await import("../../src/shared/constants/providers.ts");
 const { isManagedProviderConnectionId } = await import("../../src/lib/providers/catalog.ts");
+const { connectionMatchesProviderCard } =
+  await import("../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts");
 const { PROVIDERS: oauthFlows } = await import("../../src/lib/oauth/providers/index.ts");
 const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
 const { unwrapClinepassEnvelope } = await import("../../open-sse/utils/clinepassEnvelope.ts");
@@ -314,6 +316,12 @@ test("ClinePass API-key connections pass the managed gate while staying OAuth-pr
     "clinepass must NOT be in FREE_APIKEY_PROVIDER_IDS — that would flip isOAuth false"
   );
   assert.equal(supportsDualAuthProvider("clinepass"), true);
+  for (const authType of ["apikey", "api_key"]) {
+    assert.equal(
+      connectionMatchesProviderCard({ provider: "clinepass", authType }, "clinepass", "oauth"),
+      true
+    );
+  }
 });
 
 // ── Catalog ↔ registry alias consistency (routing prefix) ───────────────────

--- a/tests/unit/codebuddy-cn-provider.test.ts
+++ b/tests/unit/codebuddy-cn-provider.test.ts
@@ -5,7 +5,9 @@ import {
   AI_PROVIDERS,
   USAGE_SUPPORTED_PROVIDERS,
   FREE_APIKEY_PROVIDER_IDS,
+  supportsDualAuthProvider,
 } from "../../src/shared/constants/providers.ts";
+import { isManagedProviderConnectionId } from "../../src/lib/providers/catalog.ts";
 import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
 import { getExecutor } from "../../open-sse/executors/index.ts";
 import { CodeBuddyCnExecutor } from "../../open-sse/executors/codebuddy-cn.ts";
@@ -105,7 +107,11 @@ test("CodeBuddyCnExecutor.transformRequest forces stream:true and leaves reasoni
     false,
     "plain request must not inject reasoning_effort (opt-in only)"
   );
-  assert.notEqual(body.reasoning_summary, "auto", "plain request must not inject reasoning_summary");
+  assert.notEqual(
+    body.reasoning_summary,
+    "auto",
+    "plain request must not inject reasoning_summary"
+  );
 });
 
 test("CodeBuddyCnExecutor preserves explicit reasoning_effort", () => {
@@ -136,13 +142,17 @@ test("CodeBuddyCnExecutor strips reasoning_effort when caller asks for none/off"
       false,
       `reasoning_effort must be omitted for ${effort}`
     );
-    assert.notEqual(body.reasoning_summary, "auto", `reasoning_summary must not be auto for ${effort}`);
+    assert.notEqual(
+      body.reasoning_summary,
+      "auto",
+      `reasoning_summary must not be auto for ${effort}`
+    );
   }
 });
 
 test("codebuddy-cn OAuth provider is wired with device_code flow and GET-poll on state", async () => {
   assert.equal(OAUTH_PROVIDER_IDS.CODEBUDDY_CN, "codebuddy-cn");
-  const map = (PROVIDERS_MAP as Record<string, any>);
+  const map = PROVIDERS_MAP as Record<string, any>;
   const cb = map["codebuddy-cn"];
   assert.ok(cb, "PROVIDERS map must include 'codebuddy-cn'");
   assert.equal(cb.flowType, "device_code");
@@ -187,9 +197,7 @@ test("codebuddy-cn token refresh handler is wired in tokenRefresh.ts", () => {
 
 test("codebuddy-cn is in USAGE_SUPPORTED_PROVIDERS and quota handler parses Tencent accounts", async () => {
   assert.ok(USAGE_SUPPORTED_PROVIDERS.includes("codebuddy-cn"));
-  const { getCodeBuddyCnUsage } = await import(
-    "../../open-sse/services/usage/codebuddy-cn.ts"
-  );
+  const { getCodeBuddyCnUsage } = await import("../../open-sse/services/usage/codebuddy-cn.ts");
 
   const origFetch = globalThis.fetch;
   // Compose a mixed payload: one refill (CycleEndTime << DeductionEndTime) and
@@ -259,11 +267,12 @@ test("codebuddy-cn is in USAGE_SUPPORTED_PROVIDERS and quota handler parses Tenc
   }
 });
 
-test("codebuddy-cn is treated as a managed dual-auth provider (oauth + apikey accepted by POST /api/providers)", async () => {
-  // The provider creation gate trusts FREE_APIKEY_PROVIDER_IDS to admit
-  // OAuth-category providers that also accept a direct API key (like qoder).
-  assert.ok(
+test("codebuddy-cn stays OAuth-primary while the managed gate accepts its API-key path", () => {
+  assert.equal(
     FREE_APIKEY_PROVIDER_IDS.has("codebuddy-cn"),
-    "codebuddy-cn must be admitted by the dual-auth gate"
+    false,
+    "codebuddy-cn must not be classified as PAT-primary"
   );
+  assert.equal(supportsDualAuthProvider("codebuddy-cn"), true);
+  assert.equal(isManagedProviderConnectionId("codebuddy-cn"), true);
 });

--- a/tests/unit/codebuddy-cn-provider.test.ts
+++ b/tests/unit/codebuddy-cn-provider.test.ts
@@ -8,6 +8,7 @@ import {
   supportsDualAuthProvider,
 } from "../../src/shared/constants/providers.ts";
 import { isManagedProviderConnectionId } from "../../src/lib/providers/catalog.ts";
+import { connectionMatchesProviderCard } from "../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts";
 import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
 import { getExecutor } from "../../open-sse/executors/index.ts";
 import { CodeBuddyCnExecutor } from "../../open-sse/executors/codebuddy-cn.ts";
@@ -275,4 +276,14 @@ test("codebuddy-cn stays OAuth-primary while the managed gate accepts its API-ke
   );
   assert.equal(supportsDualAuthProvider("codebuddy-cn"), true);
   assert.equal(isManagedProviderConnectionId("codebuddy-cn"), true);
+  for (const authType of ["apikey", "api_key"]) {
+    assert.equal(
+      connectionMatchesProviderCard(
+        { provider: "codebuddy-cn", authType },
+        "codebuddy-cn",
+        "oauth"
+      ),
+      true
+    );
+  }
 });

--- a/tests/unit/providers-page-utils.test.ts
+++ b/tests/unit/providers-page-utils.test.ts
@@ -1074,6 +1074,15 @@ test("connectionMatchesProviderCard counts a dual-auth provider's PAT (apikey) c
     connectionMatchesProviderCard({ provider: "kiro", authType: "api_key" }, "kiro", "oauth"),
     true
   );
+  for (const providerId of ["codebuddy-cn", "clinepass"]) {
+    for (const authType of ["apikey", "api_key"]) {
+      assert.equal(
+        connectionMatchesProviderCard({ provider: providerId, authType }, providerId, "oauth"),
+        true,
+        `${providerId} ${authType} connection should count on its OAuth card`
+      );
+    }
+  }
   assert.equal(
     connectionMatchesProviderCard({ provider: "qoder", authType: "oauth" }, "qoder", "oauth"),
     true

--- a/tests/unit/providers-page-utils.test.ts
+++ b/tests/unit/providers-page-utils.test.ts
@@ -1074,15 +1074,6 @@ test("connectionMatchesProviderCard counts a dual-auth provider's PAT (apikey) c
     connectionMatchesProviderCard({ provider: "kiro", authType: "api_key" }, "kiro", "oauth"),
     true
   );
-  for (const providerId of ["codebuddy-cn", "clinepass"]) {
-    for (const authType of ["apikey", "api_key"]) {
-      assert.equal(
-        connectionMatchesProviderCard({ provider: providerId, authType }, providerId, "oauth"),
-        true,
-        `${providerId} ${authType} connection should count on its OAuth card`
-      );
-    }
-  }
   assert.equal(
     connectionMatchesProviderCard({ provider: "qoder", authType: "oauth" }, "qoder", "oauth"),
     true


### PR DESCRIPTION
## Summary

- show OAuth Connect and manual API-key actions together for providers registered as dual-auth
- recognize dual-auth API-key connections on OAuth-primary provider cards
- keep ordinary OAuth-only, Qoder, free-provider, mismatch, and null-connection behavior unchanged

Addresses #8882.

## Changes

- generalize the existing ClinePass dual-auth UI path into a shared provider capability
- register CodeBuddy CN as OAuth-primary with an admitted manual API-key path
- count `apikey` and `api_key` connections for dual-auth OAuth cards
- add rendered component coverage plus provider-specific and provider-utility regressions

## Testing

- `node --import tsx/esm --test tests/unit/providers-page-utils.test.ts tests/unit/codebuddy-cn-provider.test.ts tests/unit/clinepass-provider.test.ts` — 57 passed
- `npx vitest run 'src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/dual-auth-actions.test.tsx'` — 6 passed
- `node --import tsx/esm --test 'tests/unit/provider-detail-'*.test.ts 'tests/unit/providers-api'*.test.ts 'tests/unit/provider-connection'*.test.ts` — 26 passed
- changed-file ESLint with repository suppressions — passed
- changed-file Prettier — passed
- provider consistency, provider assets, public credential, changelog integrity, file-size, and `git diff --check` gates — passed

## Notes

- The native `better-sqlite3` addon in this local checkout targets Node ABI 137 while the active Node runtime requires ABI 147. The focused tests logged that mismatch, successfully used the repository's fallback synchronous driver, and passed; no native dependency was rebuilt or changed.
- Full repository tests and a production build were intentionally not rerun for this bounded Draft publication gate.
- This remains a Draft for maintainer review; it does not merge, release, or alter provider credentials or production state.

## Attribution

Thanks @Llliao1113 for reporting the dual-registration UI gap and documenting the expected dual-auth behavior in #8882.
