### PR TITLE
fix(kiro): keep interleaved tool results grouped without dropping assistant text (#8903)

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -47,6 +47,59 @@ function wrapSystemReminder(text: string): string {
 }
 
 /**
+ * Does this message carry Anthropic-style `tool_result` content blocks? Such a
+ * user message is part of an open tool-result batch rather than new user input.
+ */
+function carriesToolResults(msg): boolean {
+  return Array.isArray(msg?.content) && msg.content.some((c) => c.type === "tool_result");
+}
+
+/**
+ * Lookahead for issue #8903: is the text-only assistant message at `index`
+ * genuinely sandwiched inside a tool-result batch?
+ *
+ * True only when a later `tool` message (or a `tool_result` content block on a
+ * user message) still belongs to the same assistant turn — i.e. it appears
+ * before the conversation moves on with real user text or a new assistant
+ * tool-call turn. Consecutive text-only assistant messages are skipped so a
+ * `tool -> assistant -> assistant -> tool` run still counts as interleaved.
+ *
+ * Returning false for the ordinary `tool -> assistant(final reply)` shape is
+ * what keeps that reply on the normal flush path instead of being deferred.
+ */
+function hasFollowingToolResult(messages, index: number): boolean {
+  for (let j = index + 1; j < messages.length; j++) {
+    const next = messages[j];
+    if (next.role === "tool") return true;
+
+    if (next.role === "user") {
+      const blocks = Array.isArray(next.content) ? next.content : [];
+      // A user message carrying only tool_result blocks is still part of the
+      // batch; one with real text ends it.
+      if (blocks.some((c) => c.type === "tool_result")) {
+        const hasText = blocks.some((c) => (c.type === "text" || c.text) && c.text?.trim());
+        if (!hasText) return true;
+      }
+      return false;
+    }
+
+    if (next.role === "assistant") {
+      const isTextOnly =
+        (!next.tool_calls || next.tool_calls.length === 0) &&
+        !(Array.isArray(next.content) && next.content.some((c) => c.type === "tool_use"));
+      // Skip further text-only assistant messages; a new tool-call turn ends
+      // the current batch.
+      if (isTextOnly) continue;
+      return false;
+    }
+
+    // system or any other role ends the batch
+    return false;
+  }
+  return false;
+}
+
+/**
  * Convert OpenAI messages to Kiro format
  * Rules: system/tool/user -> user role, merge consecutive same roles
  */
@@ -57,6 +110,11 @@ function convertMessages(messages, tools, model) {
   let pendingUserContent = [];
   let pendingAssistantContent = [];
   let pendingToolResults = [];
+  // Text-only assistant turns that arrived in the middle of an open tool-result
+  // batch. They are held back so the batch stays contiguous, then emitted as
+  // their own assistant turn right after the batch flushes — see
+  // `interruptsOpenToolBatch` below (issue #8903).
+  let deferredAssistantContent: string[] = [];
   let pendingImages: Array<{ format: string; source: { bytes: string } }> = [];
   let currentRole = null;
   let toolsAttached = false;
@@ -159,6 +217,19 @@ function convertMessages(messages, tools, model) {
       pendingUserContent = [];
       pendingToolResults = [];
       pendingImages = [];
+
+      // The tool batch is now closed, so any assistant text that was held back
+      // to keep it contiguous can be emitted as its own turn (issue #8903).
+      // Without this the deferred text would sit in a queue nothing drains and
+      // be silently dropped from the transcript.
+      if (deferredAssistantContent.length > 0) {
+        history.push({
+          assistantResponseMessage: {
+            content: deferredAssistantContent.join("\n\n").trim() || "(empty)",
+          },
+        });
+        deferredAssistantContent = [];
+      }
     } else if (currentRole === "assistant") {
       const content = pendingAssistantContent.join("\n\n").trim() || "(empty)";
       const assistantMsg = {
@@ -188,15 +259,22 @@ function convertMessages(messages, tools, model) {
     // and the interleaved flush would emit the first tool result and drop the
     // rest, leaving advertised `toolUses` without matching `toolResults`.
     // Bedrock rejects that transcript with 400 "Expected toolResult blocks"
-    // (issue #8903). Buffer the assistant text instead and let the tool batch
-    // stay contiguous; the text is emitted with the assistant turn that
-    // follows the completed batch.
+    // (issue #8903). Defer the assistant text instead so the tool batch stays
+    // contiguous; the text is re-emitted as its own assistant turn as soon as
+    // the batch flushes.
+    //
+    // The lookahead matters: without it, an ordinary trailing assistant reply
+    // (`tool -> assistant`, with no further tool message) would also be
+    // deferred and its text lost. Only a genuine sandwich qualifies.
     const isTextOnlyAssistant =
       msg.role === "assistant" &&
       (!msg.tool_calls || msg.tool_calls.length === 0) &&
       !(Array.isArray(msg.content) && msg.content.some((c) => c.type === "tool_use"));
     const interruptsOpenToolBatch =
-      isTextOnlyAssistant && currentRole === "user" && pendingToolResults.length > 0;
+      isTextOnlyAssistant &&
+      currentRole === "user" &&
+      pendingToolResults.length > 0 &&
+      hasFollowingToolResult(messages, i);
 
     if (interruptsOpenToolBatch) {
       const deferredText =
@@ -209,15 +287,29 @@ function convertMessages(messages, tools, model) {
                 .join("\n")
                 .trim()
             : "";
-      if (deferredText) pendingAssistantContent.push(deferredText);
+      if (deferredText) deferredAssistantContent.push(deferredText);
       continue;
+    }
+
+    // Once assistant text has been deferred, the tool batch is logically over
+    // as soon as a message arrives that is not itself a tool result. Flush now
+    // so the pending batch + deferred assistant turn are emitted before the new
+    // user text, instead of that text merging into the tool-result turn and
+    // leaving the deferred reply stranded after it (issue #8903).
+    if (
+      deferredAssistantContent.length > 0 &&
+      currentRole === "user" &&
+      msg.role !== "tool" &&
+      !carriesToolResults(msg)
+    ) {
+      flushPending();
+      currentRole = null;
     }
 
     if (role !== currentRole && currentRole !== null) {
       flushPending();
     }
     currentRole = role;
-
     if (role === "user") {
       // Extract content
       let content = "";

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -181,6 +181,38 @@ function convertMessages(messages, tools, model) {
     }
 
     // If role changes, flush pending
+    //
+    // Exception: a text-only assistant message must not split a batch of tool
+    // results that answers a single assistant turn. `tool` is normalized to
+    // `user` above, so `tool -> assistant -> tool` looks like two role changes
+    // and the interleaved flush would emit the first tool result and drop the
+    // rest, leaving advertised `toolUses` without matching `toolResults`.
+    // Bedrock rejects that transcript with 400 "Expected toolResult blocks"
+    // (issue #8903). Buffer the assistant text instead and let the tool batch
+    // stay contiguous; the text is emitted with the assistant turn that
+    // follows the completed batch.
+    const isTextOnlyAssistant =
+      msg.role === "assistant" &&
+      (!msg.tool_calls || msg.tool_calls.length === 0) &&
+      !(Array.isArray(msg.content) && msg.content.some((c) => c.type === "tool_use"));
+    const interruptsOpenToolBatch =
+      isTextOnlyAssistant && currentRole === "user" && pendingToolResults.length > 0;
+
+    if (interruptsOpenToolBatch) {
+      const deferredText =
+        typeof msg.content === "string"
+          ? msg.content.trim()
+          : Array.isArray(msg.content)
+            ? msg.content
+                .filter((c) => c.type === "text" || c.text)
+                .map((c) => c.text || "")
+                .join("\n")
+                .trim()
+            : "";
+      if (deferredText) pendingAssistantContent.push(deferredText);
+      continue;
+    }
+
     if (role !== currentRole && currentRole !== null) {
       flushPending();
     }

--- a/tests/unit/kiro-interleaved-tool-results-8903.test.ts
+++ b/tests/unit/kiro-interleaved-tool-results-8903.test.ts
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildKiroPayload } = await import("../../open-sse/translator/request/openai-to-kiro.ts");
+
+const CREDENTIALS = {
+  accessToken: "test-token",
+  profileArn: "arn:aws:codewhisperer:us-east-1:000000000000:profile/TEST",
+  region: "us-east-1",
+};
+
+const PARALLEL_TOOL_CALLS = {
+  role: "assistant",
+  content: null,
+  tool_calls: [
+    { id: "call_A", type: "function", function: { name: "list_files", arguments: "{}" } },
+    { id: "call_B", type: "function", function: { name: "read_file", arguments: "{}" } },
+  ],
+};
+
+function build(messages) {
+  return buildKiroPayload(
+    "claude-sonnet-4.5",
+    { model: "claude-sonnet-4.5", messages },
+    false,
+    CREDENTIALS
+  );
+}
+
+/**
+ * Collect every toolUseId advertised by assistant turns and every toolUseId
+ * answered by a toolResult, across history plus currentMessage.
+ *
+ * Bedrock rejects a transcript where an assistant turn advertises toolUses
+ * that are never answered ("Expected toolResult blocks"), so these two sets
+ * must match.
+ */
+function collectToolIds(payload) {
+  const history = payload?.conversationState?.history ?? [];
+  const advertised = [];
+  const answered = [];
+
+  for (const entry of history) {
+    const toolUses = entry?.assistantResponseMessage?.toolUses;
+    if (Array.isArray(toolUses)) {
+      for (const use of toolUses) advertised.push(use.toolUseId ?? use.id);
+    }
+    const toolResults = entry?.userInputMessage?.userInputMessageContext?.toolResults;
+    if (Array.isArray(toolResults)) {
+      for (const result of toolResults) answered.push(result.toolUseId);
+    }
+  }
+
+  const currentResults =
+    payload?.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+      ?.toolResults;
+  if (Array.isArray(currentResults)) {
+    for (const result of currentResults) answered.push(result.toolUseId);
+  }
+
+  return { advertised, answered };
+}
+
+// --- Characterization: shapes that already work must keep working ----------
+
+test("kiro #8903: consecutive tool messages answer every parallel tool call", () => {
+  const payload = build([
+    { role: "user", content: "list files then read one" },
+    PARALLEL_TOOL_CALLS,
+    { role: "tool", tool_call_id: "call_A", content: "a.txt\nb.txt" },
+    { role: "tool", tool_call_id: "call_B", content: "hello" },
+    { role: "user", content: "thanks" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised, ["call_A", "call_B"]);
+  assert.deepEqual(answered.sort(), ["call_A", "call_B"]);
+});
+
+test("kiro #8903: three parallel tool calls are all answered", () => {
+  const payload = build([
+    { role: "user", content: "go" },
+    {
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        { id: "c1", type: "function", function: { name: "f1", arguments: "{}" } },
+        { id: "c2", type: "function", function: { name: "f2", arguments: "{}" } },
+        { id: "c3", type: "function", function: { name: "f3", arguments: "{}" } },
+      ],
+    },
+    { role: "tool", tool_call_id: "c1", content: "r1" },
+    { role: "tool", tool_call_id: "c2", content: "r2" },
+    { role: "tool", tool_call_id: "c3", content: "r3" },
+    { role: "user", content: "next" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised.sort(), ["c1", "c2", "c3"]);
+  assert.deepEqual(answered.sort(), ["c1", "c2", "c3"]);
+});
+
+test("kiro #8903: two sequential rounds of parallel tool calls are all answered", () => {
+  const payload = build([
+    { role: "user", content: "go" },
+    PARALLEL_TOOL_CALLS,
+    { role: "tool", tool_call_id: "call_A", content: "r1" },
+    { role: "tool", tool_call_id: "call_B", content: "r2" },
+    {
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "call_C", type: "function", function: { name: "grep", arguments: "{}" } }],
+    },
+    { role: "tool", tool_call_id: "call_C", content: "r3" },
+    { role: "user", content: "done" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised.sort(), ["call_A", "call_B", "call_C"]);
+  assert.deepEqual(answered.sort(), ["call_A", "call_B", "call_C"]);
+});
+
+test("kiro #8903: transcript ending on tool results still answers every tool call", () => {
+  const payload = build([
+    { role: "user", content: "go" },
+    PARALLEL_TOOL_CALLS,
+    { role: "tool", tool_call_id: "call_A", content: "r1" },
+    { role: "tool", tool_call_id: "call_B", content: "r2" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised, ["call_A", "call_B"]);
+  assert.deepEqual(answered.sort(), ["call_A", "call_B"]);
+});
+
+test("kiro #8903: structured array tool content is answered for every tool call", () => {
+  const payload = build([
+    { role: "user", content: "go" },
+    PARALLEL_TOOL_CALLS,
+    { role: "tool", tool_call_id: "call_A", content: [{ type: "text", text: "r1" }] },
+    { role: "tool", tool_call_id: "call_B", content: [{ type: "text", text: "r2" }] },
+    { role: "user", content: "done" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised, ["call_A", "call_B"]);
+  assert.deepEqual(answered.sort(), ["call_A", "call_B"]);
+});
+
+// --- RED: interleaved assistant text drops the trailing tool result --------
+
+test("kiro #8903: assistant text between tool results does not drop a tool result", () => {
+  const payload = build([
+    { role: "user", content: "list files then read one" },
+    PARALLEL_TOOL_CALLS,
+    { role: "tool", tool_call_id: "call_A", content: "a.txt\nb.txt" },
+    { role: "assistant", content: "Let me check that file." },
+    { role: "tool", tool_call_id: "call_B", content: "hello" },
+    { role: "user", content: "thanks" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised, ["call_A", "call_B"]);
+  assert.deepEqual(
+    answered.sort(),
+    ["call_A", "call_B"],
+    "every advertised toolUse must have a matching toolResult; Bedrock rejects the transcript otherwise"
+  );
+});

--- a/tests/unit/kiro-interleaved-tool-results-8903.test.ts
+++ b/tests/unit/kiro-interleaved-tool-results-8903.test.ts
@@ -61,6 +61,49 @@ function collectToolIds(payload) {
   return { advertised, answered };
 }
 
+/**
+ * Flatten history + currentMessage into an ordered, easy-to-assert turn list.
+ *
+ * Tool-id assertions alone are not enough: a translator can keep every
+ * toolUseId paired and still silently delete assistant prose or reorder turns.
+ * These tests assert content and order too.
+ */
+function collectTurns(payload) {
+  const history = payload?.conversationState?.history ?? [];
+  const turns = history.map((entry) => {
+    if (entry?.userInputMessage) {
+      return {
+        role: "user",
+        content: String(entry.userInputMessage.content ?? ""),
+        toolResults: (entry.userInputMessage.userInputMessageContext?.toolResults ?? []).map(
+          (r) => r.toolUseId
+        ),
+      };
+    }
+    return {
+      role: "assistant",
+      content: String(entry?.assistantResponseMessage?.content ?? ""),
+      toolUses: (entry?.assistantResponseMessage?.toolUses ?? []).map((u) => u.toolUseId ?? u.id),
+    };
+  });
+
+  const current = payload?.conversationState?.currentMessage?.userInputMessage;
+  if (current) {
+    turns.push({
+      role: "user",
+      current: true,
+      content: String(current.content ?? ""),
+      toolResults: (current.userInputMessageContext?.toolResults ?? []).map((r) => r.toolUseId),
+    });
+  }
+
+  return turns;
+}
+
+function assistantContents(turns) {
+  return turns.filter((t) => t.role === "assistant").map((t) => t.content);
+}
+
 // --- Characterization: shapes that already work must keep working ----------
 
 test("kiro #8903: consecutive tool messages answer every parallel tool call", () => {
@@ -166,4 +209,112 @@ test("kiro #8903: assistant text between tool results does not drop a tool resul
     ["call_A", "call_B"],
     "every advertised toolUse must have a matching toolResult; Bedrock rejects the transcript otherwise"
   );
+});
+
+// --- Content + order: grouping must not be paid for with lost assistant text -
+
+test("kiro #8903 probe A: a final text-only assistant reply survives a tool result", () => {
+  const payload = build([
+    { role: "user", content: "what is the weather" },
+    {
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "call_A", type: "function", function: { name: "wx", arguments: "{}" } }],
+    },
+    { role: "tool", tool_call_id: "call_A", content: "sunny" },
+    { role: "assistant", content: "It is sunny. THIS_TEXT_MUST_SURVIVE" },
+  ]);
+
+  const turns = collectTurns(payload);
+  assert.ok(
+    assistantContents(turns).some((c) => c.includes("THIS_TEXT_MUST_SURVIVE")),
+    `the final assistant reply must not be dropped; got ${JSON.stringify(turns)}`
+  );
+
+  // Order: the reply belongs after the turn carrying call_A's result.
+  const resultIdx = turns.findIndex((t) => (t.toolResults ?? []).includes("call_A"));
+  const replyIdx = turns.findIndex((t) => t.content.includes("THIS_TEXT_MUST_SURVIVE"));
+  assert.ok(resultIdx >= 0, "call_A's toolResult must be present");
+  assert.ok(replyIdx > resultIdx, "the assistant reply must come after the tool result turn");
+});
+
+test("kiro #8903 probe C: a mid-conversation assistant answer survives a later user turn", () => {
+  const payload = build([
+    { role: "user", content: "q1" },
+    {
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "call_A", type: "function", function: { name: "a", arguments: "{}" } }],
+    },
+    { role: "tool", tool_call_id: "call_A", content: "res A" },
+    { role: "assistant", content: "ANSWER_TURN_1" },
+    { role: "user", content: "q2" },
+  ]);
+
+  const turns = collectTurns(payload);
+  assert.ok(
+    assistantContents(turns).some((c) => c.includes("ANSWER_TURN_1")),
+    `the previous turn's assistant answer must not be erased; got ${JSON.stringify(turns)}`
+  );
+
+  const answerIdx = turns.findIndex((t) => t.content.includes("ANSWER_TURN_1"));
+  const q2Idx = turns.findIndex((t) => t.current);
+  assert.ok(q2Idx > answerIdx, "the new user question must come after the previous answer");
+  assert.ok(
+    turns[q2Idx].content.includes("q2"),
+    "the new user question must be the current message"
+  );
+});
+
+test("kiro #8903 probe B: deferred assistant text survives AND the tool batch stays grouped", () => {
+  const payload = build([
+    { role: "user", content: "check two things" },
+    PARALLEL_TOOL_CALLS,
+    { role: "tool", tool_call_id: "call_A", content: "res A" },
+    { role: "assistant", content: "DEFERRED_TEXT_HERE" },
+    { role: "tool", tool_call_id: "call_B", content: "res B" },
+    { role: "user", content: "thanks" },
+  ]);
+
+  const turns = collectTurns(payload);
+
+  // 1. grouping: both results answered from a single turn
+  const batchTurn = turns.find((t) => (t.toolResults ?? []).length > 0);
+  assert.ok(batchTurn, "a turn carrying toolResults must exist");
+  assert.deepEqual(
+    [...batchTurn.toolResults].sort(),
+    ["call_A", "call_B"],
+    "call_A and call_B must stay in one toolResults batch"
+  );
+
+  // 2. no data loss: the interleaved text is still in the transcript
+  assert.ok(
+    assistantContents(turns).some((c) => c.includes("DEFERRED_TEXT_HERE")),
+    `interleaved assistant text must not be dropped; got ${JSON.stringify(turns)}`
+  );
+
+  // 3. order: text after the batch, final user question last
+  const batchIdx = turns.indexOf(batchTurn);
+  const textIdx = turns.findIndex((t) => t.content.includes("DEFERRED_TEXT_HERE"));
+  const currentIdx = turns.findIndex((t) => t.current);
+  assert.ok(textIdx > batchIdx, "the deferred text must be emitted after the tool batch");
+  assert.ok(currentIdx > textIdx, "the final user turn must come last");
+  assert.ok(turns[currentIdx].content.includes("thanks"));
+
+  // 4. the tool results must not have leaked into user prose
+  assert.ok(
+    !turns[currentIdx].content.includes("res B"),
+    "call_B's result must be a toolResult, not stuffed into user text"
+  );
+});
+
+test("kiro #8903: assistant text is preserved on an ordinary non-tool transcript", () => {
+  const payload = build([
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "PLAIN_REPLY" },
+    { role: "user", content: "again" },
+  ]);
+
+  const turns = collectTurns(payload);
+  assert.deepEqual(assistantContents(turns), ["PLAIN_REPLY"]);
 });


### PR DESCRIPTION
## Summary

Fixes a transcript-corruption bug in the Kiro request translator: when an assistant text
message is interleaved between two `role: "tool"` messages answering the **same** batch of
`tool_calls`, the batch was closed early. The assistant turn still advertised every `toolUse`,
but only the first `toolResult` was emitted, and Bedrock rejects that transcript with
`400 "Expected toolResult blocks"`.

Because `tool` is normalized to `user`, the sequence `tool -> assistant -> tool` reads as two
role changes, so the interleaved flush split the batch.

The fix keeps the tool-result batch contiguous **without** dropping assistant text:

- Gate the deferral behind a lookahead (`hasFollowingToolResult`) so only a genuine
  `tool -> assistant -> tool` sandwich defers; an ordinary trailing assistant reply takes the
  normal flush path.
- Buffer deferred text in its own queue and emit it as a standalone assistant turn immediately
  after the tool batch flushes.
- Flush the open batch (plus the deferred turn) as soon as a non-tool-result message arrives,
  so the deferred reply lands before the next user turn.

The naive version of this fix (buffering into `pendingAssistantContent`, which is only drained
by the assistant flush branch) silently **dropped** the deferred text — including ordinary
final replies in any tool-using conversation. That regression was caught in review and is
covered by dedicated tests (`probe A`, `probe B`, `probe C` below), which assert assistant
**content and turn order**, not just tool-result ids.

## Related Issues

- Closes #8903

## Exact tree under review

| Item | Value |
| ---- | ----- |
| Branch | `fix/kiro-consecutive-tool-results` |
| Base (frozen at review time) | `ed2db6cb19ba534980c5b3e046501e8a5c40c458` (`release/v3.8.50` dev cycle open) |
| Accepted commit | `90e8c7675cb27636fb7b6eb479cb43846fbe728f` |
| Accepted tree | `669ee1310c81ffb61519658bac1af3d4102635d9` |
| Diff vs base | 2 files, +445 / -1 |

Changed files:

- `open-sse/translator/request/openai-to-kiro.ts` (+126 / -1)
- `tests/unit/kiro-interleaved-tool-results-8903.test.ts` (new, 320 lines)

No `package.json` / lockfile / `tsconfig` / config / executor / OAuth / schema changes.

## Validation

These are **focused** results, re-run on the accepted tree immediately before opening this PR.
They are explicitly **not** a full-suite run — the full unit suite, Vitest, the coverage gate,
and the production build run in CI on this PR.

```bash
# focused suite for this change
node --import tsx/esm --test tests/unit/kiro-interleaved-tool-results-8903.test.ts
# -> tests 10 / pass 10 / fail 0

# kiro + translator regression set (all *kiro* and *translator* unit files)
node --import tsx/esm --test $(ls tests/unit/*kiro*.test.ts tests/unit/*ranslator*.test.ts)
# -> tests 969 / suites 23 / pass 969 / fail 0

npx prettier --check open-sse/translator/request/openai-to-kiro.ts \
  tests/unit/kiro-interleaved-tool-results-8903.test.ts
# -> "All matched files use Prettier code style!" (exit 0)

npx eslint open-sse/translator/request/openai-to-kiro.ts \
  tests/unit/kiro-interleaved-tool-results-8903.test.ts
# -> exit 0

npm run typecheck:core
# -> tsc --pretty false -p tsconfig.typecheck-core.json, exit 0
```

RED credibility (the tests actually fail without the fix, verified in throwaway detached
worktrees, never mutating this branch):

| Tree | Result |
| ---- | ------ |
| Frozen base `ed2db6cb1` | 10 tests / 8 pass / **2 fail** (original #8903 case + probe B) |
| Rejected intermediate `89ecd8a80` | 10 tests / 7 pass / **3 fail** (probes A, B, C — the assistant-text data loss) |
| Accepted tree `669ee1310` | 10 / 10 pass |

- [x] Focused tests for the change
- [x] `eslint` on both changed files (clean)
- [x] Production-code change includes a new automated test in this PR
- [ ] SonarQube PR analysis — not yet reported; will be read from this PR's checks

## Tests Added Or Updated

- `tests/unit/kiro-interleaved-tool-results-8903.test.ts` (new, 10 tests):
  - the interleaved `tool -> assistant -> tool` case from #8903
  - characterization tests for the five shapes that already worked (consecutive results,
    three parallel calls, two sequential rounds, transcript ending on tool results,
    structured array tool content), so the fix cannot regress them
  - probe A: a final text-only assistant reply survives a tool result
  - probe B: deferred assistant text survives **and** the tool batch stays grouped
  - probe C: a mid-conversation assistant answer survives a later user turn
  - assistant text preserved on an ordinary non-tool transcript

## Coverage Notes

Only `open-sse/translator/request/openai-to-kiro.ts` changes in production code. Every new
branch (lookahead gate, deferred-text queue, early flush on non-tool-result) is exercised by
the 10 focused tests above, and the surrounding translator behaviour is pinned by the 969-test
kiro + translator regression set.

## Reviewer Notes

### Risk surface

This is a hot path: `open-sse/translator/request/openai-to-kiro.ts` runs on **every** Kiro
(`kr/*`) tool-calling request, and this PR changes message-grouping behaviour. The change is
small in line count but behavioural, so it warrants a one-to-one read rather than a rubber
stamp. Comparable merged PRs touching `open-sse/translator/` for calibration: #8642
(+35/-1, 2 files), #8705 (+406/-95, 10 files), #8565 (+846/-367, 32 files).

### Upstream readiness flags (recorded separately — code correctness is NOT upstream readiness)

- **`code gate PASS`** — yes. Independent read-only exact-tree review on
  `90e8c7675` / tree `669ee1310` returned PASS: focused 10/10, kiro+translator regression
  969/969, prettier + eslint + `typecheck:core` clean, RED reproduced on both the frozen base
  and the rejected intermediate tree, zero unresolved P0/P1/P2 attributable to this tree.
  Re-run and reproduced again before opening this PR.
- **`CI-ready`** — yes, as far as can be judged locally: branch is a clean fast-forward from
  `release/v3.8.50` (`git rev-list --left-right --count upstream/release/v3.8.50...HEAD`
  → `0  2`, merge-base = `ed2db6cb1`, no rebase needed), lint/format/typecheck clean, tests
  added. The authoritative answer is this PR's own check-runs, which had not reported yet at
  the time of opening; SonarQube and the coverage gate are unverified locally by design.
- **`merge-train eligible`** — **no, not yet.** There is an open freeze marker,
  issue #8873 (`release-freeze: v3.8.49 in progress`). Per
  `docs/ops/BRANCHING_MODEL.md`, a freeze does not stop development, and this PR correctly
  targets the active (highest) release line `release/v3.8.50` — which is also the live
  `default_branch`. But merge mechanics are the owner's `queue` label → Mergify
  (`docs/ops/MERGE_TRAIN.md`); this PR is a **draft** and claims no queue eligibility.
- **`one-to-one review required`** — **yes.** `.github/CODEOWNERS` assigns `*` to
  @diegosouzapw, and this touches a translator hot path with a behavioural change to message
  grouping. A maintainer read is required; the contributor makes no self-approval.
- **`waiting maintainer decision`** — **yes** (always true at this stage). Draft, unmerged,
  not marked Ready for review. No merge, no force-push, no release, no version bump.

### Known-unrelated, pre-existing limitation (explicitly out of scope)

A `system` message interleaved **into** a tool-result batch also splits the batch:
`hasFollowingToolResult` returns `false` for `system`
(`open-sse/translator/request/openai-to-kiro.ts:96-97`), so a trailing tool result degrades
into user prose. This reproduces **byte-identically on the frozen base `ed2db6cb1`** and is
therefore pre-existing baseline behaviour, not introduced or worsened here. It is deliberately
**not** fixed in this PR to keep the diff reviewable; happy to open a separate issue for it if
a maintainer agrees it is worth addressing.
