### PR TITLE
fix(sse): preserve Claude Code cache breakpoints

### DIFF
--- a/open-sse/executors/claudeIdentity.ts
+++ b/open-sse/executors/claudeIdentity.ts
@@ -323,6 +323,23 @@ function isContext1mModel(model: unknown): boolean {
   );
 }
 
+export function shouldUseMidConversationSystem(
+  body: Record<string, unknown> | null | undefined,
+  model?: string | null
+): boolean {
+  const payload = body || {};
+  const hasSystem =
+    !!payload.system &&
+    (typeof payload.system === "string" ||
+      (Array.isArray(payload.system) && payload.system.length > 0));
+  const hasTools = Array.isArray(payload.tools) && payload.tools.length > 0;
+  const effectiveModel = model ?? (typeof payload.model === "string" ? payload.model : "");
+
+  return (
+    hasSystem && hasTools && matchesModelPrefix(effectiveModel, CONTEXT_1M_BETA_MODEL_PREFIXES)
+  );
+}
+
 /**
  * Pick the anthropic-beta flag set that matches the request shape. Real CLI
  * uses three patterns: minimal probe, structured-output, and full agent.
@@ -373,8 +390,7 @@ export function selectBetaFlags(
   const isFullAgent = hasTools && hasSystem;
   const effectiveModel = model ?? (typeof b.model === "string" ? b.model : "");
   const isHeavyAgent = isFullAgent && isHeavyAgentModel(effectiveModel);
-  const isOpusAgent =
-    isFullAgent && matchesModelPrefix(effectiveModel, CONTEXT_1M_BETA_MODEL_PREFIXES);
+  const isOpusAgent = shouldUseMidConversationSystem(b, effectiveModel);
   const isContext1m = isFullAgent && isContext1mModel(effectiveModel);
 
   const flags: string[] = [];

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -78,6 +78,7 @@ import { FORMATS } from "../translator/formats.ts";
 import { collectCustomToolNamesForSourceFormat } from "../translator/request/openai-responses/additionalTools.ts";
 import { sanitizeKiroTools } from "../utils/kiroSanitizer.ts";
 import { splitMisplacedToolResults } from "../translator/helpers/claudeHelper.ts";
+import { ensureCacheControlOnLastUserMessage } from "../services/claudeCodeConstraints.ts";
 import {
   createSSETransformStreamWithLogger,
   createPassthroughStreamWithLogger,
@@ -2085,6 +2086,9 @@ export async function handleChatCore({
           translatedBody.messages = splitMisplacedToolResults(
             translatedBody.messages as ClaudeMessage[]
           ) as typeof translatedBody.messages;
+        }
+        if (provider === "claude") {
+          ensureCacheControlOnLastUserMessage(translatedBody);
         }
       } else {
         normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -119,6 +119,7 @@ import {
   normalizeClaudeAdaptiveThinking,
   normalizeClaudeDisabledThinkingEffort,
 } from "../services/claudeAdaptiveThinking.ts";
+import { shouldUseMidConversationSystem } from "../executors/claudeIdentity.ts";
 import { normalizeClaudeHaikuConstraints } from "../services/claudeHaikuConstraints.ts";
 import { applyDefaultReasoningEffort } from "../services/defaultReasoningEffort.ts";
 import { echoModelInObject } from "../services/responseModelEcho.ts";
@@ -2073,15 +2074,15 @@ export async function handleChatCore({
         }
       }
 
-      // Fix #2468: always extract role:"system" → top-level system.
-      // The semantic passthrough correctly skips the Claude→OpenAI→Claude
-      // round-trip, but even pure Claude bodies may carry system content as
-      // role:"system" messages rather than the top-level system field, which
-      // Anthropic's Messages API now rejects with a 400.
+      // Legacy models reject role:"system" messages. Opus accepts them behind
+      // its beta, and hoisting them breaks the prompt cache prefix.
       if (isClaudeCodeSemanticPassthrough) {
-        // Only lift system/developer messages — preserves Claude Code's
-        // native payload structure (documents, tool chains, thinking, etc.)
-        extractSystemRoleMessages(translatedBody);
+        if (
+          provider !== "claude" ||
+          !shouldUseMidConversationSystem(translatedBody, effectiveModel)
+        ) {
+          extractSystemRoleMessages(translatedBody);
+        }
         if (Array.isArray(translatedBody.messages)) {
           translatedBody.messages = splitMisplacedToolResults(
             translatedBody.messages as ClaudeMessage[]

--- a/open-sse/services/claudeCodeConstraints.ts
+++ b/open-sse/services/claudeCodeConstraints.ts
@@ -128,6 +128,20 @@ export function ensureCacheControlOnLastUserMessage(body: Record<string, unknown
   const messages = body.messages as Array<Record<string, unknown>> | undefined;
   if (!Array.isArray(messages) || messages.length === 0) return;
 
+  const system = body.system as Array<Record<string, unknown>> | undefined;
+  const systemCacheControlCount = Array.isArray(system)
+    ? system.filter((block) => block.cache_control).length
+    : 0;
+
+  for (const message of messages) {
+    const content = message.content as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(content) && content.some((block) => block.cache_control)) {
+      return;
+    }
+  }
+
+  if (systemCacheControlCount >= MAX_CACHE_CONTROL_BLOCKS) return;
+
   // Find the last user message
   for (let i = messages.length - 1; i >= 0; i--) {
     if (String(messages[i].role) === "user") {

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -759,6 +759,60 @@ test("chatCore normalizes native Claude Code messages for native Claude OAuth pa
   assert.equal(call.body.messages[2].content[0].type, "tool_result");
 });
 
+test("chatCore preserves Opus 5 mid-conversation system cache breakpoints", async () => {
+  await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
+  invalidateCacheControlSettingsCache();
+
+  const { call, result } = await invokeChatCore({
+    provider: "claude",
+    model: "claude-opus-5",
+    endpoint: "/v1/messages",
+    credentials: { apiKey: "claude-key", providerSpecificData: {} },
+    body: {
+      model: "claude-opus-5",
+      max_tokens: 64,
+      system: [
+        {
+          type: "text",
+          text: "stable system prompt",
+          cache_control: { type: "ephemeral", ttl: "5m" },
+        },
+      ],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "first turn" }] },
+        { role: "assistant", content: [{ type: "text", text: "first response" }] },
+        {
+          role: "system",
+          content: [
+            {
+              type: "text",
+              text: "compact continuation",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+        { role: "user", content: [{ type: "text", text: "latest turn" }] },
+      ],
+      tools: [{ name: "Bash", input_schema: { type: "object", properties: {} } }],
+    },
+    userAgent: "Claude-Code/2.1.220",
+    requestHeaders: { "x-app": "cli", "x-claude-code-session-id": "session-123" },
+    responseFormat: "claude",
+  });
+
+  assert.equal(result.success, true);
+  assert.deepEqual(
+    call.body.messages.map((message: { role: string }) => message.role),
+    ["user", "assistant", "system", "user"]
+  );
+  assert.deepEqual(call.body.messages[2].content[0].cache_control, { type: "ephemeral" });
+  assert.equal(
+    call.body.system.some((block: { text?: string }) => block.text === "compact continuation"),
+    false
+  );
+  assert.equal(call.body.messages[3].content[0].cache_control, undefined);
+});
+
 test("chatCore keeps Claude normalization for non-Claude-Code Claude passthrough", async () => {
   const { call, result } = await invokeChatCore({
     provider: "claude",

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -930,6 +930,52 @@ test("chatCore preserves cache_control automatically for Claude Code single-mode
   assert.equal(call.body.tools[0].cache_control, undefined);
 });
 
+test("chatCore supplements a missing message cache breakpoint for native Claude Code requests", async () => {
+  await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
+  invalidateCacheControlSettingsCache();
+
+  const { call } = await invokeChatCore({
+    provider: "claude",
+    model: "claude-sonnet-4-6",
+    endpoint: "/v1/messages",
+    credentials: { apiKey: "claude-key", providerSpecificData: {} },
+    body: {
+      model: "claude-sonnet-4-6",
+      max_tokens: 64,
+      system: [
+        {
+          type: "text",
+          text: "stable system prompt",
+          cache_control: { type: "ephemeral", ttl: "5m" },
+        },
+        {
+          type: "text",
+          text: "stable project instructions",
+          cache_control: { type: "ephemeral", ttl: "5m" },
+        },
+      ],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "first turn" }] },
+        { role: "assistant", content: [{ type: "text", text: "first response" }] },
+        { role: "user", content: [{ type: "text", text: "latest turn" }] },
+      ],
+      tools: [
+        {
+          name: "lookup_weather",
+          description: "Fetch weather",
+          input_schema: { type: "object" },
+          cache_control: { type: "ephemeral", ttl: "5m" },
+        },
+      ],
+    },
+    userAgent: "Claude-Code/1.0.0",
+    responseFormat: "claude",
+  });
+
+  assert.deepEqual(call.body.messages[2].content[0].cache_control, { type: "ephemeral" });
+  assert.equal(call.body.tools[0].cache_control, undefined);
+});
+
 test("chatCore auto cache policy becomes false for nondeterministic combos", async () => {
   await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
   invalidateCacheControlSettingsCache();

--- a/tests/unit/claude-code-parity.test.ts
+++ b/tests/unit/claude-code-parity.test.ts
@@ -341,15 +341,59 @@ describe("enforceCacheControlLimit", () => {
 });
 
 describe("ensureCacheControlOnLastUserMessage", () => {
-  it("does not throw on a valid messages array", () => {
+  it("adds a breakpoint to the last user message when messages have none", () => {
     const body = {
+      system: [
+        { type: "text", text: "s1", cache_control: { type: "ephemeral" } },
+        { type: "text", text: "s2", cache_control: { type: "ephemeral" } },
+      ],
       messages: [
         { role: "user", content: [{ type: "text", text: "Hello" }] },
         { role: "assistant", content: [{ type: "text", text: "Hi!" }] },
         { role: "user", content: [{ type: "text", text: "Follow up" }] },
       ],
     };
-    assert.doesNotThrow(() => ensureCacheControlOnLastUserMessage(body));
+
+    ensureCacheControlOnLastUserMessage(body);
+
+    assert.deepEqual(body.messages[2].content[0].cache_control, { type: "ephemeral" });
+  });
+
+  it("keeps an existing message breakpoint without adding another", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Hello",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+        { role: "user", content: [{ type: "text", text: "Follow up" }] },
+      ],
+    };
+
+    ensureCacheControlOnLastUserMessage(body);
+
+    assert.equal(body.messages[1].content[0].cache_control, undefined);
+  });
+
+  it("does not exceed four surviving system and message breakpoints", () => {
+    const body = {
+      system: Array.from({ length: 4 }, (_, index) => ({
+        type: "text",
+        text: `s${index}`,
+        cache_control: { type: "ephemeral" },
+      })),
+      messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+    };
+
+    ensureCacheControlOnLastUserMessage(body);
+
+    assert.equal(body.messages[0].content[0].cache_control, undefined);
   });
 
   it("handles body without messages without throwing", () => {


### PR DESCRIPTION
## Summary

- Add a cache breakpoint to the latest user message when native Claude Code history has none and the four-breakpoint limit permits it.
- Preserve existing client message breakpoints unchanged.
- Keep supported Opus mid-conversation system blocks in `messages[]`.
- Prevent a mid-conversation cache marker from being hoisted into top-level `system`, which invalidates the cached conversation prefix.
- Keep the legacy system-message hoist for unsupported models and providers.

## Why this change

Anthropic documents two cache behaviors that apply to the affected Claude Code requests.

First, "Cache writes happen only at your breakpoint." Anthropic checks up to 20 blocks behind each breakpoint for a prior write and supports up to four breakpoints. A request with cache markers on static system or tool content, but none in `messages[]`, does not write a recent conversation-prefix entry. As the conversation grows, the last usable write can fall outside the lookback window. This patch adds a marker to the latest user content only when no message marker exists and a breakpoint slot remains. See [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching).

Second, Anthropic hashes the prompt in `tools`, `system`, then `messages` order. Its documentation says, "A cache hit requires the prefix to match a recent request exactly, byte for byte." Hoisting a system message from the middle of `messages[]` into top-level `system` changes an earlier part of that hash and invalidates every cached message after it. Anthropic recommends appending the instruction as a `role: "system"` message instead because "The cached prefix stays the same." This patch preserves that structure for eligible Opus full-agent requests while retaining the legacy hoist elsewhere. See [Anthropic mid-conversation system messages](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages).

The cost difference is material. Anthropic prices a 5-minute cache write at 1.25 times the base input-token rate and a cache read at 0.1 times that rate. Rewriting a large prefix instead of reading it can cost 12.5 times as much for those tokens. See [Anthropic prompt caching pricing](https://platform.claude.com/docs/en/build-with-claude/prompt-caching).

## Related issues

- None.

## Validation

- [x] Red/green request-path regression for an Opus 5 mid-conversation system cache breakpoint
- [x] Focused handler, cache-control, system-role, beta-flag, and Claude identity tests
- [x] `npm run typecheck:core`
- [x] ESLint passes for the changed production files
- [x] Prettier passes for all changed files
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
- [x] Production Docker image built successfully for the first commit
- [x] Isolated Opus 5 validation wrote 13,893 cache tokens, then read all 13,893 on the identical request

## Tests added or updated

- `tests/unit/chatcore-translation-paths.test.ts`
- `tests/unit/claude-code-parity.test.ts`

## Coverage notes

The request-path regression runs native Claude passthrough through the executor and inspects the final upstream body. It verifies that Opus 5 keeps the original message order, preserves the mid-conversation cache marker, does not hoist that block into top-level `system`, and does not add a redundant marker to the latest user turn.

The existing Sonnet and generic-client tests continue to cover the legacy hoisting path. The parity tests cover existing message markers and the four surviving-breakpoint limit.

## Reviewer notes

The new behavior is limited to native Claude full-agent requests for supported Opus models. The same eligibility helper controls both the payload behavior and the Anthropic beta header, so unsupported request shapes keep the old normalization.

This PR does not change database state, migrations, or user settings.
