### PR TITLE
fix(ci): unblock the npm publish — dynamic runner + reuse CI's next-build artifact

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,8 +56,15 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    # Same dynamic-runner rule as ci.yml's `build`/`test-unit`: `build:cli` falls back to a
+    # full `next build`, whose working set outgrew the 16 GB hosted runner during the
+    # v3.8.49 cycle — the publish died with "The runner has received a shutdown signal"
+    # mid-"Creating an optimized production build" while v3.8.48 had still fit in 16min.
+    # This job never runs on `pull_request`, so the fork-safety clause is always true here;
+    # it is kept verbatim so the expression stays greppable against ci.yml.
+    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-release"]') || 'ubuntu-latest' }}
     permissions:
+      actions: read # find + download the CI run's next-build artifact for this SHA
       contents: write # gh release upload (attach SBOM to the GitHub Release)
       id-token: write # npm provenance
       packages: write # publish to npm.pkg.github.com
@@ -144,6 +151,41 @@ jobs:
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      # Fast path: CI already built the standalone tree for THIS commit and uploaded it as
+      # `next-build`. `build:cli` (scripts/build/prepublish.ts) only shells out to a full
+      # `next build` when `.build/next/standalone/server.js` is missing — restoring the
+      # artifact turns the heaviest step of the publish into a download. Matching on
+      # `head_sha` is the tree-equality guarantee: same commit, same tree.
+      # Best-effort by design (retention is 1 day): every miss falls through to the build
+      # step below, which is why the dynamic runner above matters as the backstop.
+      - name: Reuse CI's next-build artifact (skips the heavy rebuild)
+        if: steps.resolve.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          RUN=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+            --jq '[.workflow_runs[] | select(.name == "CI" and .conclusion == "success")] | .[0].id // empty') || RUN=""
+          if [ -z "$RUN" ]; then
+            echo "::notice::no successful CI run for $HEAD_SHA — falling back to a full build"
+            exit 0
+          fi
+          if ! gh run download "$RUN" --repo "$REPO" --name next-build --dir /tmp/next-build; then
+            echo "::notice::next-build artifact unavailable for run $RUN (expired?) — falling back to a full build"
+            exit 0
+          fi
+          tar -xzf /tmp/next-build/e2e-build.tar.gz -C .
+          rm -rf /tmp/next-build
+          if [ -f .build/next/standalone/server.js ]; then
+            echo "✅ standalone tree restored from CI run $RUN — build:cli will skip next build"
+          else
+            echo "::notice::extract did not yield .build/next/standalone — falling back to a full build"
+            rm -rf .build
+          fi
 
       - name: Build CLI bundle (standalone app)
         if: steps.resolve.outputs.skip != 'true'


### PR DESCRIPTION
## Why

The **v3.8.49 npm publish failed** ([run 30503231974](https://github.com/diegosouzapw/OmniRoute/actions/runs/30503231974)). The `Build CLI bundle` step runs `npm run build:cli`, which shells out to a full `next build` when `.build/next/standalone/server.js` is missing:

```
00:39:05  Creating an optimized production build ...
00:45:25  ##[error]The runner has received a shutdown signal.
```

Every step after it was `skipped` — artifact validation, SBOM, tarball boot-smoke, and the staged publish. The registry is still on `3.8.48`.

**This is the build outgrowing the runner, not the runner degrading:** the same job passed in **16 minutes** for v3.8.48. The production build's working set was measured at **~18–20 GB RSS** during this cycle's homologation, against 16 GB on a GitHub-hosted runner. It is the same root cause that killed the `ci.yml` `Build` job **7 times** this cycle.

`ci.yml` already routes its heavy jobs around this with the `USE_VPS_RUNNER` expression. `npm-publish.yml` had `runs-on: ubuntu-latest` hardcoded and zero references to that variable — so there was no way to move the publish off the hosted pool without editing it.

## What changed

**1. Dynamic runner.** The `publish` job now uses the *same* expression as `ci.yml`'s `build` / `test-unit` / `test-vitest`, so the release captain can send it to the 32-core self-hosted runner. The fork-safety clause is always true here (this workflow never triggers on `pull_request`) but is kept verbatim so the expression stays greppable across workflows.

**2. Reuse CI's `next-build` artifact.** A best-effort step restores the standalone tree CI already built for the **same commit**, matched on `head_sha` — same commit means same tree, so the match *is* the equality guarantee. `build:cli` then finds `.build/next/standalone/server.js` and skips the build entirely, turning the heaviest step of the publish into a download.

Retention on that artifact is one day, so every miss — no successful CI run for the SHA, expired artifact, unexpected archive layout — emits a `::notice::` and falls through to the build. That is precisely why change **1** is the necessary backstop rather than a nice-to-have.

## Safety

- Needs `actions: read` to look up the run and download the artifact.
- All values reach the script through `env:` (`GH_TOKEN`, `HEAD_SHA`, `REPO`) — nothing is interpolated into the shell body.
- `continue-on-error: true` plus explicit `exit 0` on each miss: the fast path can never fail the publish.

## Validation

- `python3 -c "yaml.safe_load(...)"` — parses; `publish` job now has 16 steps.
- `npm run check:workflows` → **189** zizmor findings, unchanged. The baseline is `190`, which its own `_rebaseline_2026_07_28_ci_runner_delta` entry records as the runner-side reading of the same 189 measured on the devbox. No rebaseline needed: the new step uses the `gh` CLI instead of a new `uses:`, so it adds no `unpinned-uses` finding.
- Workflow-only change — no `src/`, `open-sse/`, `electron/` or `bin/` files touched.

## Follow-up

Once merged, the publish is re-dispatched against `main` with `USE_VPS_RUNNER=true` so the build lands on the self-hosted runner; the owner then completes the staged publish with `npm stage approve <id>` (2FA).