### PR TITLE
fix(responses): use protocol-neutral keepalive before response starts

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -27,7 +27,8 @@ import {
   isStripReasoningRequested,
 } from "./chatCore/headers.ts";
 import {
-  isCodexTransientAccountFailure,
+  classifyCodexFailoverFailure,
+  isCodexOverloadStatus,
   markCodexScopeRateLimited,
 } from "./chatCore/codexFailover.ts";
 import { isCodexOriginatedHeaders } from "../config/codexIdentity.ts";
@@ -2820,18 +2821,27 @@ export async function handleChatCore({
                 }
               }
 
-              // Codex transient account-rotation failover (disabled for context-relay so
-              // combo.ts can inject handoff).  In v3.8.49 this branch only handled 429,
-              // leaving direct Codex overload responses (HTTP 502/503/504) to return to
-              // the client without trying another account.  The Codex upstream uses 502
-              // for "Our servers are currently overloaded"; keep rotation bounded to the
-              // existing three-attempt Codex budget.
-              if (
+              // Codex account rotation (disabled for context-relay so combo.ts can inject
+              // handoff). Preserve the existing 429 cooldown behavior. For 502/503/504,
+              // rotate only when the response explicitly says Codex is overloaded/at
+              // capacity, and exclude that connection only within this request.
+              const shouldInspectCodexFailure =
                 provider === "codex" &&
                 comboStrategy !== "context-relay" &&
-                isCodexTransientAccountFailure(res.response.status) &&
-                attempts < maxAttempts - 1
-              ) {
+                attempts < maxAttempts - 1 &&
+                (res.response.status === 429 || isCodexOverloadStatus(res.response.status));
+              const codexFailoverDecision = shouldInspectCodexFailure
+                ? classifyCodexFailoverFailure(
+                    res.response.status,
+                    res.response.status === 429
+                      ? ""
+                      : await res.response
+                          .clone()
+                          .text()
+                          .catch(() => "")
+                  )
+                : null;
+              if (codexFailoverDecision) {
                 const failedConnectionId =
                   execCreds?.connectionId || credentials?.connectionId || connectionId;
                 const normalizedHeaders = normalizeHeaders(res.response.headers);
@@ -2843,44 +2853,47 @@ export async function handleChatCore({
                   ? Math.max(retryAfterSeconds * 1000, 0)
                   : null;
                 const failureStatus = res.response.status;
-                const failureLabel = failureStatus === 429 ? "429" : `${failureStatus} transient`;
+                const failureLabel =
+                  codexFailoverDecision.reason === "rate_limit"
+                    ? "429 rate limit"
+                    : `${failureStatus} Codex overload`;
 
                 log?.warn?.(
                   "CODEX_FAILOVER",
                   `${failureLabel} on connection ${String(failedConnectionId).slice(0, 8)} (attempt ${attempts + 1}/${maxAttempts}), rotating account`
                 );
 
-                // Mark only the current Codex model scope as temporarily unavailable.
                 if (failedConnectionId) {
-                  await markCodexScopeRateLimited({
-                    failedConnectionId: String(failedConnectionId),
-                    model: modelToCall || model || requestedModel || null,
-                    rateLimitedUntil: new Date(Date.now() + (retryAfterMs || 60_000)).toISOString(),
-                    credentials,
-                    status: failureStatus,
-                  });
-                  // Fix B: also persist the cooldown to
-                  // `provider_connections.rate_limited_until`. Without this,
-                  // the Codex 429 cascade survives the current request (via
-                  // `markCodexScopeRateLimited`'s in-memory Map) but is lost
-                  // on process restart — the same exhausted Codex key is
-                  // re-picked on the very next request. Mirrors
-                  // `open-sse/executors/antigravity.ts:343`.
-                  // Best-effort: never crash the chat path on DB write failure.
-                  try {
-                    const { setConnectionRateLimitUntil } = await import("@/lib/db/providers");
-                    const untilMs = Date.now() + (retryAfterMs || 60_000);
-                    setConnectionRateLimitUntil(String(failedConnectionId), untilMs);
-                  } catch {
-                    // ignore — best effort
+                  if (codexFailoverDecision.persistCooldown) {
+                    await markCodexScopeRateLimited({
+                      failedConnectionId: String(failedConnectionId),
+                      model: modelToCall || model || requestedModel || null,
+                      rateLimitedUntil: new Date(
+                        Date.now() + (retryAfterMs || 60_000)
+                      ).toISOString(),
+                      credentials,
+                    });
+                    // Preserve the existing 429 connection cooldown across restarts.
+                    // Best-effort: never crash the chat path on DB write failure.
+                    try {
+                      const { setConnectionRateLimitUntil } = await import("@/lib/db/providers");
+                      const untilMs = Date.now() + (retryAfterMs || 60_000);
+                      setConnectionRateLimitUntil(String(failedConnectionId), untilMs);
+                    } catch {
+                      // ignore — best effort
+                    }
                   }
+                  // Both 429 and overload skip the failed account for the remaining
+                  // attempts of this request. Overload deliberately writes no shared
+                  // account/scope state because it is not evidence of an account fault.
                   if (!codexExcludedIds.includes(String(failedConnectionId))) {
                     codexExcludedIds.push(String(failedConnectionId));
                   }
                 }
 
-                // Clear session affinity so next request won't be pinned to the failing account
-                if (codexSessionAffinityKey) {
+                // 429 is account-specific, so future requests should not remain pinned.
+                // An overload is upstream-wide and must not alter future affinity.
+                if (codexFailoverDecision.persistCooldown && codexSessionAffinityKey) {
                   try {
                     deleteSessionAccountAffinity(codexSessionAffinityKey, "codex");
                   } catch {
@@ -2933,6 +2946,8 @@ export async function handleChatCore({
                     new_connection_id: newConnectionId,
                     attempt: attempts + 1,
                     retry_after_ms: retryAfterMs,
+                    failure_reason: codexFailoverDecision.reason,
+                    cooldown_persisted: codexFailoverDecision.persistCooldown,
                   },
                 });
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -26,7 +26,10 @@ import {
   resolveCompressionHeader,
   isStripReasoningRequested,
 } from "./chatCore/headers.ts";
-import { markCodexScopeRateLimited } from "./chatCore/codexFailover.ts";
+import {
+  isCodexTransientAccountFailure,
+  markCodexScopeRateLimited,
+} from "./chatCore/codexFailover.ts";
 import { isCodexOriginatedHeaders } from "../config/codexIdentity.ts";
 import { trackDevice, extractIpFromHeaders } from "../services/deviceTracker.ts";
 import { getCombosCached } from "./chatCore/comboContextCache.ts";
@@ -2694,7 +2697,7 @@ export async function handleChatCore({
           const isModelScopeForRequest = isModelScope();
           const maxAttempts = isModelScopeForRequest ? 3 : provider === "codex" ? 3 : 1;
 
-          // ── Codex 429 account-rotation state ─────────────────────────────────
+          // ── Codex transient account-rotation state ─────────────────────────────
           // Track excluded connection IDs for codex failover across attempts.
           const codexExcludedIds: string[] = [];
           // Derive session affinity key once for codex failover (used to clear affinity on 429).
@@ -2817,33 +2820,44 @@ export async function handleChatCore({
                 }
               }
 
-              // Codex 429 account-rotation failover (disabled for context-relay so combo.ts can inject handoff)
+              // Codex transient account-rotation failover (disabled for context-relay so
+              // combo.ts can inject handoff).  In v3.8.49 this branch only handled 429,
+              // leaving direct Codex overload responses (HTTP 502/503/504) to return to
+              // the client without trying another account.  The Codex upstream uses 502
+              // for "Our servers are currently overloaded"; keep rotation bounded to the
+              // existing three-attempt Codex budget.
               if (
                 provider === "codex" &&
                 comboStrategy !== "context-relay" &&
-                res.response.status === 429 &&
+                isCodexTransientAccountFailure(res.response.status) &&
                 attempts < maxAttempts - 1
               ) {
                 const failedConnectionId =
                   execCreds?.connectionId || credentials?.connectionId || connectionId;
                 const normalizedHeaders = normalizeHeaders(res.response.headers);
                 const retryAfterHeader = normalizedHeaders["retry-after"] ?? null;
-                const retryAfterMs = retryAfterHeader
-                  ? Number.parseFloat(retryAfterHeader) * 1000
+                const retryAfterSeconds = retryAfterHeader
+                  ? Number.parseFloat(retryAfterHeader)
+                  : Number.NaN;
+                const retryAfterMs = Number.isFinite(retryAfterSeconds)
+                  ? Math.max(retryAfterSeconds * 1000, 0)
                   : null;
+                const failureStatus = res.response.status;
+                const failureLabel = failureStatus === 429 ? "429" : `${failureStatus} transient`;
 
                 log?.warn?.(
                   "CODEX_FAILOVER",
-                  `429 on connection ${String(failedConnectionId).slice(0, 8)} (attempt ${attempts + 1}/${maxAttempts}), rotating account`
+                  `${failureLabel} on connection ${String(failedConnectionId).slice(0, 8)} (attempt ${attempts + 1}/${maxAttempts}), rotating account`
                 );
 
-                // Mark only the current Codex model scope as rate-limited.
+                // Mark only the current Codex model scope as temporarily unavailable.
                 if (failedConnectionId) {
                   await markCodexScopeRateLimited({
                     failedConnectionId: String(failedConnectionId),
                     model: modelToCall || model || requestedModel || null,
                     rateLimitedUntil: new Date(Date.now() + (retryAfterMs || 60_000)).toISOString(),
                     credentials,
+                    status: failureStatus,
                   });
                   // Fix B: also persist the cooldown to
                   // `provider_connections.rate_limited_until`. Without this,
@@ -2886,7 +2900,10 @@ export async function handleChatCore({
                 ).catch(() => null);
 
                 if (!nextCreds || nextCreds.allRateLimited) {
-                  log?.warn?.("CODEX_FAILOVER", "No more codex accounts available — returning 429");
+                  log?.warn?.(
+                    "CODEX_FAILOVER",
+                    `No more codex accounts available — returning ${failureStatus}`
+                  );
                   if (stream) {
                     releaseAccountSemaphore();
                     return {

--- a/open-sse/handlers/chatCore/codexFailover.ts
+++ b/open-sse/handlers/chatCore/codexFailover.ts
@@ -7,18 +7,54 @@ type CodexFailoverCredentials = {
   providerSpecificData?: unknown;
 };
 
-/**
- * Return true when a Codex response is an upstream transient-capacity failure
- * that should move this request to another OAuth account.
- *
- * Codex overloads have appeared both as HTTP 502/503/504 JSON responses and as
- * a Responses SSE `response.failed` event carrying
- * `response.error.code=server_is_overloaded`.  Keep this status-bounded so
- * local validation/auth errors never rotate accounts.
- */
-export function isCodexTransientAccountFailure(status: number): boolean {
-  if (status === 429) return true;
+export type CodexFailoverDecision =
+  { reason: "rate_limit"; persistCooldown: true } | { reason: "overload"; persistCooldown: false };
+
+const CODEX_OVERLOAD_CODES = [
+  "server_is_overloaded",
+  "service_unavailable_error",
+  "model_at_capacity",
+  "model_capacity",
+] as const;
+
+const CODEX_OVERLOAD_MESSAGES = [
+  /\bservers?\s+(?:are\s+|is\s+)?(?:currently\s+|temporarily\s+)?overloaded\b/i,
+  /\bselected model is at capacity\b/i,
+  /\bmodel\s+(?:is\s+)?(?:currently\s+|temporarily\s+)?at capacity\b/i,
+] as const;
+
+export function isCodexOverloadStatus(status: number): boolean {
   return status === 502 || status === 503 || status === 504;
+}
+
+/**
+ * Classify the narrow Codex failures that may rotate to another OAuth account.
+ *
+ * A 429 preserves the existing persisted account/scope cooldown semantics.
+ * A 502/503/504 only qualifies when its body explicitly identifies Codex
+ * overload/model capacity. Those failures are upstream-wide rather than proof
+ * that an account is bad, so the failed connection is excluded only from the
+ * current request and no cooldown is persisted.
+ */
+export function classifyCodexFailoverFailure(
+  status: number,
+  responseBody: string
+): CodexFailoverDecision | null {
+  if (status === 429) {
+    return { reason: "rate_limit", persistCooldown: true };
+  }
+  if (!isCodexOverloadStatus(status)) return null;
+
+  const body = String(responseBody || "");
+  const explicitCode = /"(?:code|type)"\s*:\s*"([^"]+)"/gi;
+  const hasExplicitCode = Array.from(body.matchAll(explicitCode), (match) =>
+    String(match[1]).toLowerCase()
+  ).some((value) => CODEX_OVERLOAD_CODES.some((code) => value === code));
+  const hasExplicitMessage = CODEX_OVERLOAD_MESSAGES.some((pattern) => pattern.test(body));
+
+  return hasExplicitCode || hasExplicitMessage
+    ? { reason: "overload", persistCooldown: false }
+    : null;
 }
 
 function asProviderData(value: unknown): Record<string, unknown> {
@@ -30,10 +66,10 @@ export async function markCodexScopeRateLimited(params: {
   model: string | null;
   rateLimitedUntil: string;
   credentials?: CodexFailoverCredentials | null;
-  /** Optional status/message for non-429 transient capacity failures. */
-  status?: number;
 }): Promise<void> {
-  const connection = await getCachedProviderConnectionById(params.failedConnectionId).catch(() => null);
+  const connection = await getCachedProviderConnectionById(params.failedConnectionId).catch(
+    () => null
+  );
   const existingProviderData = connection
     ? asProviderData(connection.providerSpecificData)
     : asProviderData(params.credentials?.providerSpecificData);
@@ -48,8 +84,8 @@ export async function markCodexScopeRateLimited(params: {
 
   updateProviderConnection(params.failedConnectionId, {
     ...(connection ? { providerSpecificData: nextProviderData } : {}),
-    lastError: `${params.status ?? 429} transient upstream failure — codex account rotation`,
-    errorCode: params.status ?? 429,
+    lastError: "429 rate limited — codex account rotation",
+    errorCode: 429,
   }).catch(() => {});
 
   if (params.credentials && String(params.credentials.connectionId) === params.failedConnectionId) {

--- a/open-sse/handlers/chatCore/codexFailover.ts
+++ b/open-sse/handlers/chatCore/codexFailover.ts
@@ -7,6 +7,20 @@ type CodexFailoverCredentials = {
   providerSpecificData?: unknown;
 };
 
+/**
+ * Return true when a Codex response is an upstream transient-capacity failure
+ * that should move this request to another OAuth account.
+ *
+ * Codex overloads have appeared both as HTTP 502/503/504 JSON responses and as
+ * a Responses SSE `response.failed` event carrying
+ * `response.error.code=server_is_overloaded`.  Keep this status-bounded so
+ * local validation/auth errors never rotate accounts.
+ */
+export function isCodexTransientAccountFailure(status: number): boolean {
+  if (status === 429) return true;
+  return status === 502 || status === 503 || status === 504;
+}
+
 function asProviderData(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 }
@@ -16,6 +30,8 @@ export async function markCodexScopeRateLimited(params: {
   model: string | null;
   rateLimitedUntil: string;
   credentials?: CodexFailoverCredentials | null;
+  /** Optional status/message for non-429 transient capacity failures. */
+  status?: number;
 }): Promise<void> {
   const connection = await getCachedProviderConnectionById(params.failedConnectionId).catch(() => null);
   const existingProviderData = connection
@@ -32,8 +48,8 @@ export async function markCodexScopeRateLimited(params: {
 
   updateProviderConnection(params.failedConnectionId, {
     ...(connection ? { providerSpecificData: nextProviderData } : {}),
-    lastError: "429 rate limited — codex account rotation",
-    errorCode: 429,
+    lastError: `${params.status ?? 429} transient upstream failure — codex account rotation`,
+    errorCode: params.status ?? 429,
   }).catch(() => {});
 
   if (params.credentials && String(params.credentials.connectionId) === params.failedConnectionId) {

--- a/open-sse/utils/earlyStreamKeepalive.ts
+++ b/open-sse/utils/earlyStreamKeepalive.ts
@@ -27,7 +27,7 @@
  */
 
 const ENCODER = new TextEncoder();
-const KEEPALIVE_FRAME = ENCODER.encode(": omniroute-keepalive\n\n");
+export const KEEPALIVE_FRAME = ENCODER.encode(": omniroute-keepalive\n\n");
 // OpenAI-compatible keepalive: a syntactically valid empty streaming chunk.
 // Some OpenAI-compatible clients parse every non-empty SSE line as JSON and
 // reject legal SSE comments before their first provider chunk arrives.
@@ -43,60 +43,6 @@ export const OPENAI_STARTUP_FRAME = OPENAI_KEEPALIVE_FRAME;
 // token the comment frame lets the client abort and retry the stream. Anthropic's own
 // API emits `event: ping` for exactly this reason; the /v1/messages route mirrors it.
 export const ANTHROPIC_PING_FRAME = ENCODER.encode('event: ping\ndata: {"type":"ping"}\n\n');
-// Responses API keepalive: a self-contained, self-closed synthetic reasoning
-// item (added -> summary_part.added -> text.delta -> summary_part.done),
-// matching the abbreviated close pattern open-sse/utils/stream.ts's own
-// emitSyntheticResponsesReasoningSummary already uses for real mid-stream
-// reasoning. Closed within this one frame (not left dangling open) since the
-// real upstream response — once it arrives — starts its own independent
-// response.created lifecycle from scratch; this placeholder item never
-// carries a response_id and isn't meant to be continued.
-const RESPONSES_STARTUP_ITEM_ID = "rs_omniroute_keepalive";
-const STARTUP_THINKING_TEXT = "OmniRoute: got request, sending to provider";
-export const RESPONSES_STARTUP_THINKING_FRAME = ENCODER.encode(
-  [
-    {
-      event: "response.output_item.added",
-      data: {
-        type: "response.output_item.added",
-        output_index: 0,
-        item: { id: RESPONSES_STARTUP_ITEM_ID, type: "reasoning", summary: [] },
-      },
-    },
-    {
-      event: "response.reasoning_summary_part.added",
-      data: {
-        type: "response.reasoning_summary_part.added",
-        item_id: RESPONSES_STARTUP_ITEM_ID,
-        output_index: 0,
-        summary_index: 0,
-        part: { type: "summary_text", text: "" },
-      },
-    },
-    {
-      event: "response.reasoning_summary_text.delta",
-      data: {
-        type: "response.reasoning_summary_text.delta",
-        item_id: RESPONSES_STARTUP_ITEM_ID,
-        output_index: 0,
-        summary_index: 0,
-        delta: STARTUP_THINKING_TEXT,
-      },
-    },
-    {
-      event: "response.reasoning_summary_part.done",
-      data: {
-        type: "response.reasoning_summary_part.done",
-        item_id: RESPONSES_STARTUP_ITEM_ID,
-        output_index: 0,
-        summary_index: 0,
-        part: { type: "summary_text", text: STARTUP_THINKING_TEXT },
-      },
-    },
-  ]
-    .map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`)
-    .join("")
-);
 // Anthropic Messages API default — Anthropic's own spec really does use a named
 // `event: error` SSE frame, so this is correct there. It is WRONG for the OpenAI-
 // format routes below: Chat Completions and Responses streaming never use the SSE
@@ -177,8 +123,7 @@ export type EarlyStreamKeepaliveOptions = {
  * type-check. A string discriminant narrows both branches under the same settings.
  */
 type SettledHandler =
-  | { status: "fulfilled"; response: Response }
-  | { status: "rejected"; error: unknown };
+  { status: "fulfilled"; response: Response } | { status: "rejected"; error: unknown };
 
 export async function withEarlyStreamKeepalive(
   handlerPromise: Promise<Response>,

--- a/src/app/api/v1/responses/route.ts
+++ b/src/app/api/v1/responses/route.ts
@@ -1,7 +1,6 @@
 import { handleChat } from "@/sse/handlers/chat";
 import {
   withEarlyStreamKeepalive,
-  RESPONSES_STARTUP_THINKING_FRAME,
   OPENAI_RESPONSES_ERROR_FRAME,
 } from "@omniroute/open-sse/utils/earlyStreamKeepalive";
 import { withInjectionGuard } from "@/middleware/promptInjectionGuard";
@@ -102,7 +101,6 @@ async function postHandler(request: any, context: any, preParsedBody: any = null
     return await withEarlyStreamKeepalive(handleChat(resolved, null, resolvedBody), {
       signal: request.signal,
       thresholdMs,
-      startupFrame: RESPONSES_STARTUP_THINKING_FRAME,
       errorFrame: OPENAI_RESPONSES_ERROR_FRAME,
     });
   }

--- a/tests/unit/codex-failover.test.ts
+++ b/tests/unit/codex-failover.test.ts
@@ -12,7 +12,10 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { isCodexTransientAccountFailure } from "../../open-sse/handlers/chatCore/codexFailover.ts";
+import {
+  classifyCodexFailoverFailure,
+  isCodexOverloadStatus,
+} from "../../open-sse/handlers/chatCore/codexFailover.ts";
 
 // ── Helpers imported directly (no SQLite dependency) ────────────────────────
 const authModule = await import("../../src/sse/services/auth.ts");
@@ -154,34 +157,81 @@ test("codex failover: Object.assign patches credentials with new account", () =>
   );
 });
 
-// ── Test 6: failover only triggers on bounded transient statuses ─────────────
-test("codex failover: rotates on 429/502/503/504, not arbitrary errors", () => {
+// ── Test 6: failover only triggers for 429 or explicit Codex overload ─────────
+test("codex failover: 429 rotates and preserves persisted cooldown behavior", () => {
+  assert.deepEqual(classifyCodexFailoverFailure(429, ""), {
+    reason: "rate_limit",
+    persistCooldown: true,
+  });
+});
+
+test("codex failover: explicit overload/capacity 502/503/504 rotates request-locally", () => {
+  const overloadBodies = [
+    [
+      502,
+      '{\n  "error": {\n    "code":  "server_is_overloaded",\n    "message": "Our servers are overloaded"\n  }\n}',
+    ],
+    [503, '{"error":{"type":"service_unavailable_error","message":"Please retry"}}'],
+    [503, '{"error":{"message":"Selected model is at capacity. Please retry."}}'],
+    [504, '{"response":{"error":{"message":"Our servers are currently overloaded."}}}'],
+  ] as const;
+
+  for (const [status, body] of overloadBodies) {
+    assert.deepEqual(classifyCodexFailoverFailure(status, body), {
+      reason: "overload",
+      persistCooldown: false,
+    });
+  }
+});
+
+test("codex failover: arbitrary 5xx does not rotate accounts", () => {
+  const nonOverloadFailures = [
+    [500, '{"error":{"code":"server_is_overloaded"}}'],
+    [502, '{"error":{"code":"bad_gateway","message":"Bad gateway"}}'],
+    [503, '{"error":{"code":"service_unavailable","message":"Service temporarily unavailable"}}'],
+    [503, '{"error":{"message":"Chat admission capacity is temporarily unavailable"}}'],
+    [504, '{"error":{"code":"gateway_timeout","message":"Upstream request timed out"}}'],
+  ] as const;
+
+  for (const [status, body] of nonOverloadFailures) {
+    assert.equal(classifyCodexFailoverFailure(status, body), null);
+  }
+});
+
+test("codex failover: only overload candidate statuses require body inspection", () => {
+  assert.equal(isCodexOverloadStatus(429), false);
+  assert.equal(isCodexOverloadStatus(500), false);
+  assert.equal(isCodexOverloadStatus(502), true);
+  assert.equal(isCodexOverloadStatus(503), true);
+  assert.equal(isCodexOverloadStatus(504), true);
+});
+
+test("codex failover: provider/attempt guards remain bounded to Codex and three attempts", () => {
   const shouldTriggerFailover = (
     provider: string,
     status: number,
+    body: string,
     attempt: number,
     maxAttempts: number
   ) =>
     provider === "codex" &&
-    isCodexTransientAccountFailure(status) &&
+    classifyCodexFailoverFailure(status, body) !== null &&
     attempt < maxAttempts - 1;
 
-  assert.equal(shouldTriggerFailover("codex", 429, 0, 3), true, "Codex 429 attempt 0 → rotate");
-  assert.equal(shouldTriggerFailover("codex", 429, 1, 3), true, "Codex 429 attempt 1 → rotate");
-  assert.equal(shouldTriggerFailover("codex", 502, 0, 3), true, "Codex 502 attempt 0 → rotate");
-  assert.equal(shouldTriggerFailover("codex", 503, 0, 3), true, "Codex 503 attempt 0 → rotate");
-  assert.equal(shouldTriggerFailover("codex", 504, 0, 3), true, "Codex 504 attempt 0 → rotate");
+  assert.equal(shouldTriggerFailover("codex", 429, "", 0, 3), true);
   assert.equal(
-    shouldTriggerFailover("codex", 429, 2, 3),
-    false,
-    "Codex 429 last attempt → no rotate"
+    shouldTriggerFailover("codex", 503, '{"error":{"code":"server_is_overloaded"}}', 1, 3),
+    true
   );
-  assert.equal(shouldTriggerFailover("codex", 500, 0, 3), false, "Codex 500 → no rotate");
-  assert.equal(shouldTriggerFailover("codex", 200, 0, 3), false, "Codex 200 → no rotate");
   assert.equal(
-    shouldTriggerFailover("openai", 429, 0, 1),
+    shouldTriggerFailover("codex", 429, "", 2, 3),
     false,
-    "OpenAI 429 → no rotate (not codex)"
+    "last attempt does not rotate"
+  );
+  assert.equal(
+    shouldTriggerFailover("openai", 429, "", 0, 3),
+    false,
+    "other providers do not rotate"
   );
 });
 

--- a/tests/unit/codex-failover.test.ts
+++ b/tests/unit/codex-failover.test.ts
@@ -12,6 +12,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { isCodexTransientAccountFailure } from "../../open-sse/handlers/chatCore/codexFailover.ts";
 
 // ── Helpers imported directly (no SQLite dependency) ────────────────────────
 const authModule = await import("../../src/sse/services/auth.ts");
@@ -153,17 +154,23 @@ test("codex failover: Object.assign patches credentials with new account", () =>
   );
 });
 
-// ── Test 6: failover only triggers on 429, not other errors ──────────────────
-test("codex failover: only 429 triggers account rotation", () => {
+// ── Test 6: failover only triggers on bounded transient statuses ─────────────
+test("codex failover: rotates on 429/502/503/504, not arbitrary errors", () => {
   const shouldTriggerFailover = (
     provider: string,
     status: number,
     attempt: number,
     maxAttempts: number
-  ) => provider === "codex" && status === 429 && attempt < maxAttempts - 1;
+  ) =>
+    provider === "codex" &&
+    isCodexTransientAccountFailure(status) &&
+    attempt < maxAttempts - 1;
 
   assert.equal(shouldTriggerFailover("codex", 429, 0, 3), true, "Codex 429 attempt 0 → rotate");
   assert.equal(shouldTriggerFailover("codex", 429, 1, 3), true, "Codex 429 attempt 1 → rotate");
+  assert.equal(shouldTriggerFailover("codex", 502, 0, 3), true, "Codex 502 attempt 0 → rotate");
+  assert.equal(shouldTriggerFailover("codex", 503, 0, 3), true, "Codex 503 attempt 0 → rotate");
+  assert.equal(shouldTriggerFailover("codex", 504, 0, 3), true, "Codex 504 attempt 0 → rotate");
   assert.equal(
     shouldTriggerFailover("codex", 429, 2, 3),
     false,

--- a/tests/unit/codex-sse-capacity-fallback.test.ts
+++ b/tests/unit/codex-sse-capacity-fallback.test.ts
@@ -9,7 +9,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { CodexExecutor, __setCodexWebSocketTransportForTesting } from "../../open-sse/executors/codex.ts";
+import {
+  CodexExecutor,
+  __setCodexWebSocketTransportForTesting,
+} from "../../open-sse/executors/codex.ts";
 
 test.afterEach(() => {
   __setCodexWebSocketTransportForTesting(undefined);
@@ -88,6 +91,37 @@ test("CodexExecutor.execute converts server_is_overloaded / service_unavailable_
     });
 
     assert.equal(result.response.status, 503);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("CodexExecutor.execute converts nested response.failed server_is_overloaded into a 503 Response", async () => {
+  const executor = new CodexExecutor();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () =>
+    new Response(
+      sseStreamFromChunks([
+        'event: response.failed\ndata: {"type":"response.failed","response":{"status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}\n\n',
+      ]),
+      {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }
+    );
+
+  try {
+    const result = await executor.execute({
+      model: "gpt-5.5",
+      body: { model: "gpt-5.5", input: [{ role: "user", content: "hello" }] },
+      stream: true,
+      credentials: { accessToken: "codex-token" },
+    });
+
+    assert.equal(result.response.status, 503);
+    const body = await result.response.json();
+    assert.match(body.error.message, /currently overloaded/i);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/early-stream-keepalive.test.ts
+++ b/tests/unit/early-stream-keepalive.test.ts
@@ -4,9 +4,9 @@ import assert from "node:assert/strict";
 import {
   withEarlyStreamKeepalive,
   ANTHROPIC_PING_FRAME,
+  KEEPALIVE_FRAME,
   OPENAI_KEEPALIVE_FRAME,
   OPENAI_STARTUP_FRAME,
-  RESPONSES_STARTUP_THINKING_FRAME,
   OPENAI_CHAT_ERROR_FRAME,
   OPENAI_RESPONSES_ERROR_FRAME,
 } from "../../open-sse/utils/earlyStreamKeepalive.ts";
@@ -166,53 +166,16 @@ test("startupFrame defaults to keepaliveFrame when omitted (no behavior change)"
   );
 });
 
-// #7360 follow-up round 2: OpenClaw calls via /v1/responses (Responses API
-// format), which only had the generic bare-comment keepalive — a live
-// incident showed it disconnecting after ~56s waiting on a slow gemma-4
-// response. RESPONSES_STARTUP_THINKING_FRAME gives Responses-API clients the
-// same real-content keepalive OpenAI chat/completions already got, as a
-// self-contained (opened AND closed within this one frame) synthetic
-// reasoning item — it never claims a response_id, so it can't collide with
-// the real response's own independent response.created lifecycle that follows.
-test("RESPONSES_STARTUP_THINKING_FRAME is a self-closed synthetic reasoning item with the expected text", () => {
-  const decoded = new TextDecoder().decode(RESPONSES_STARTUP_THINKING_FRAME);
-  const events = decoded
-    .split("\n\n")
-    .filter(Boolean)
-    .map((frame) => {
-      const [eventLine, dataLine] = frame.split("\n");
-      return {
-        event: eventLine.replace(/^event: /, ""),
-        data: JSON.parse(dataLine.replace(/^data: /, "")),
-      };
-    });
-
-  assert.deepEqual(
-    events.map((e) => e.event),
-    [
-      "response.output_item.added",
-      "response.reasoning_summary_part.added",
-      "response.reasoning_summary_text.delta",
-      "response.reasoning_summary_part.done",
-    ]
-  );
-
-  const [added, partAdded, delta, partDone] = events;
-  assert.equal(added.data.item.type, "reasoning");
-  const itemId = added.data.item.id;
-  assert.ok(itemId, "reasoning item must have an id");
-
-  assert.equal(partAdded.data.item_id, itemId);
-  assert.equal(delta.data.item_id, itemId);
-  assert.equal(delta.data.delta, "OmniRoute: got request, sending to provider");
-  assert.equal(partDone.data.item_id, itemId);
-  assert.equal(partDone.data.part.text, "OmniRoute: got request, sending to provider");
-});
-
-test("slow handler emits the Responses API startup frame before the real body", async () => {
+test("slow Responses handler uses comments without creating a synthetic output item", async () => {
   const slow = new Promise<Response>((resolve) => {
     setTimeout(
-      () => resolve(sseResponse("event: response.created\ndata: {}\n\ndata: [DONE]\n\n")),
+      () =>
+        resolve(
+          sseResponse(
+            'event: response.created\ndata: {"type":"response.created"}\n\n' +
+              'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+          )
+        ),
       120
     );
   });
@@ -220,15 +183,15 @@ test("slow handler emits the Responses API startup frame before the real body", 
   const result = await withEarlyStreamKeepalive(slow, {
     thresholdMs: 25,
     intervalMs: 20,
-    startupFrame: RESPONSES_STARTUP_THINKING_FRAME,
+    keepaliveFrame: KEEPALIVE_FRAME,
   });
 
   const body = await readAll(result);
-  assert.match(body, /event: response\.output_item\.added/);
-  assert.match(body, /OmniRoute: got request, sending to provider/);
-  assert.match(body, /event: response\.reasoning_summary_part\.done/);
+  assert.match(body, /^: omniroute-keepalive\n\n/);
+  assert.doesNotMatch(body, /rs_omniroute_keepalive/);
+  assert.doesNotMatch(body, /event: response\.output_item\.added/);
   assert.match(body, /event: response\.created/, "should forward the real upstream body");
-  assert.match(body, /data: \[DONE\]/);
+  assert.match(body, /event: response\.completed/, "should forward terminal completion");
 });
 
 test("slow handler emits the custom keepaliveFrame (Anthropic ping) before the body", async () => {


### PR DESCRIPTION
## Problem

The Responses endpoint emitted a synthetic `rs_omniroute_keepalive` reasoning item while waiting for a slow provider. That item had `response.output_item.added` and summary events but no `response.output_item.done`. Codex can therefore keep the turn in a running state (spinner/pause) after the real response emits `response.completed`.

## Fix

Use the existing SSE comment heartbeat for the Responses startup frame. Comments keep the HTTP connection alive without creating a fake response/output item or polluting the Responses lifecycle. The route continues to forward real `response.created` and `response.completed` events unchanged.

Also add coverage for the observed nested `response.failed` + `server_is_overloaded` SSE shape so the HTTP Codex capacity fallback converts it to 503.

## Verification

- `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/early-stream-keepalive.test.ts` (17 passing)
- `node --import tsx/esm --test tests/unit/early-stream-keepalive.test.ts tests/unit/codex-sse-capacity-fallback.test.ts` (21 passing)
- `git diff --check`
