### PR TITLE
chore(skills): regenerate SKILL.md for routes shipped in v3.8.49

### DIFF
--- a/skills/omni-auth/SKILL.md
+++ b/skills/omni-auth/SKILL.md
@@ -36,6 +36,37 @@ curl -X POST https://localhost:20128/api/auth/logout \
   -d '{}'
 ```
 
+### GET /api/auth/oidc/login
+
+Start OIDC login for the dashboard admin gate
+
+Builds an authorization URL from the configured OIDC issuer/client (discovered
+via `{issuer}/.well-known/openid-configuration`, falling back to `{issuer}/authorize`),
+sets a short-lived `oidc_state` cookie, and redirects the browser. Password login
+remains available as a fallback while OIDC is enabled.
+
+
+```bash
+curl https://localhost:20128/api/auth/oidc/login \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### GET /api/auth/oidc/callback
+
+Complete OIDC login for the dashboard admin gate
+
+Validates the `state` cookie, exchanges the authorization `code` for tokens,
+verifies the ID token against the issuer's JWKS (audience = client id), and —
+if `oidcAllowedSubjects` is configured — checks the token's `sub`/`email` against
+that allowlist. On success it mints the same 30-day `auth_token` dashboard-session
+JWT used by password login and redirects to `/dashboard`.
+
+
+```bash
+curl https://localhost:20128/api/auth/oidc/callback \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
 ## Payloads
 
 See the full OpenAPI specification at `GET /api/openapi/spec` or `docs/openapi.yaml` for detailed request/response schemas.

--- a/skills/omni-inference/SKILL.md
+++ b/skills/omni-inference/SKILL.md
@@ -219,6 +219,87 @@ curl https://localhost:20128/api/v1/providers/{provider}/models \
   -H "Authorization: Bearer $OMNIROUTE_TOKEN"
 ```
 
+### GET /api/v1/management/proxy-subscriptions
+
+List proxy subscriptions
+
+Lists all operator-supplied proxy subscription links. Also starts the background auto-refresh scheduler (idempotent) so enabled subscriptions stay in sync. Credentials embedded in `url` are redacted in the response.
+
+```bash
+curl https://localhost:20128/api/v1/management/proxy-subscriptions \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### POST /api/v1/management/proxy-subscriptions
+
+Create a proxy subscription
+
+Creates a subscription record. If `mode` is `rule`, at least one entry in `ruleProviders` is required. `updateIntervalMinutes` defaults to 60 and `enabled` defaults to `false` when omitted or not exactly `true`.
+
+```bash
+curl -X POST https://localhost:20128/api/v1/management/proxy-subscriptions \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### GET /api/v1/management/proxy-subscriptions/{id}
+
+Get a proxy subscription
+
+```bash
+curl https://localhost:20128/api/v1/management/proxy-subscriptions/{id} \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### PATCH /api/v1/management/proxy-subscriptions/{id}
+
+Update a proxy subscription
+
+Partial update — only fields present in the body are changed (name/url/mode/ruleProviders/localCoreEndpoint/updateIntervalMinutes/enabled).
+
+```bash
+curl -X PATCH https://localhost:20128/api/v1/management/proxy-subscriptions/{id} \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### DELETE /api/v1/management/proxy-subscriptions/{id}
+
+Delete a proxy subscription
+
+Removes the subscription record and unbinds/drops its synced proxy_registry rows.
+
+```bash
+curl -X DELETE https://localhost:20128/api/v1/management/proxy-subscriptions/{id} \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### GET /api/v1/management/proxy-subscriptions/{id}/nodes
+
+Get a subscription's last-parsed node summary
+
+Returns the last-parsed node list without re-fetching the (possibly slow) subscription URL.
+
+```bash
+curl https://localhost:20128/api/v1/management/proxy-subscriptions/{id}/nodes \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### POST /api/v1/management/proxy-subscriptions/{id}/refresh
+
+Refresh a proxy subscription
+
+Re-fetches and re-parses the subscription URL, syncs its nodes into `proxy_registry`, and (re)binds the pool.
+
+```bash
+curl -X POST https://localhost:20128/api/v1/management/proxy-subscriptions/{id}/refresh \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 ### POST /api/v1/ocr
 
 Document OCR

--- a/skills/omni-usage-logs/SKILL.md
+++ b/skills/omni-usage-logs/SKILL.md
@@ -110,6 +110,33 @@ curl -X POST https://localhost:20128/api/usage/budget \
   -d '{}'
 ```
 
+### GET /api/usage/cache-health
+
+Get prompt-cache health summary
+
+Summarizes the `write/read` cache ratio from `call_logs` for a time window:
+distribution (p50/p90/p99/max of cache-write tokens), warm/cold/rewrite/uncached
+call counts, the "heavy write" outlier share (10x the window median, floored at
+1024 tokens — Anthropic's cache-creation minimum), and a per-model breakdown.
+Only successful (`status = 200`) calls with a non-null cache column are counted.
+
+
+```bash
+curl https://localhost:20128/api/usage/cache-health \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### GET /api/usage/model-latency-stats
+
+Get per-model/provider latency statistics
+
+Aggregates `usage_history` rows into per-(provider, model) latency stats (avg/p50/p95/p99, std-dev, TTFT, tokens/sec) over a rolling window. Falls back from successful-only to all-sample rows when the successful count is below `minSamples`.
+
+```bash
+curl https://localhost:20128/api/usage/model-latency-stats \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
 ## Payloads
 
 See the full OpenAPI specification at `GET /api/openapi/spec` or `docs/openapi.yaml` for detailed request/response schemas.


### PR DESCRIPTION
`check:agent-skills-sync` fails on the tip of release/v3.8.50: the generator
reports `Generated: 3 · Unchanged: 42`, exit 2. Three agent-skill documents are
behind the route catalog they are generated from.

Measured, not assumed — the same generator on three refs:

    release/v3.8.50 @ ed2db6cb19 (pre sync-back)  Generated: 0  ✅
    main                                          Generated: 3  ❌
    release/v3.8.50 @ d61798fb31 (post sync-back) Generated: 3  ❌

So the drift came from main — the v3.8.49 release itself — and the sync-back
faithfully propagated it. Nothing was deleted: all three files exist in all
three refs, and the regeneration is purely additive (139 insertions, zero
deletions) covering routes that landed during the cycle:

    omni-auth        GET /api/auth/oidc/login, GET /api/auth/oidc/callback
    omni-inference   +81 lines
    omni-usage-logs  +27 lines

Why CI never caught it at the source: the gate lives in the PR-only
"Merge integrity" job (its changelog half needs a base to diff against), and
this cycle's merge trains landed in batches with `--admin`, which bypasses
required checks. A gate that only runs on PRs and can be bypassed at merge
lets the violation reach main, where it becomes a base-red blocking every PR
into the next cycle's branch.

Generated with `node scripts/skills/generate-agent-skills.mjs --apply` — the
files are outputs, not hand-edited. `check:agent-skills-sync` now exits 0
(`Generated: 0 · Unchanged: 45`) and the 19 tests in
tests/integration/agent-skills-content.test.ts pass.