### PR TITLE
chore(sse): drop the iflow entry from the token-refresh TTL map

### DIFF
--- a/changelog.d/maintenance/8966-remove-iflow-ttl.md
+++ b/changelog.d/maintenance/8966-remove-iflow-ttl.md
@@ -1,0 +1,1 @@
+- **chore(sse):** dropped the leftover `iflow` entry from the token-refresh TTL map — the provider was removed from the product but its 24-hour refresh lead outlived it, and the identifier had exactly two occurrences left repo-wide ([#8966](https://github.com/diegosouzapw/OmniRoute/pull/8966))

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -109,8 +109,6 @@ export const REFRESH_LEAD_MS: Record<string, number> = {
   "gitlab-duo": 5 * 60 * 1000, // GitLab token family revocation on misuse
   kiro: 5 * 60 * 1000, // AWS SSO OIDC issues one-time-use refresh tokens
   "kimi-coding": 5 * 60 * 1000, // Moonshot rotates per-refresh
-  // Non-rotating providers — longer lead is safe.
-  iflow: 24 * 60 * 60 * 1000, // 24 hours
   // Google OAuth refresh_tokens are permanent (non-rotating) — longer lead
   // is safe and reduces unnecessary upstream chatter.
   antigravity: 15 * 60 * 1000,

--- a/tests/unit/service-token-refresh.test.ts
+++ b/tests/unit/service-token-refresh.test.ts
@@ -9,13 +9,16 @@ describe("tokenRefresh helpers", () => {
       assert.equal(mod.getRefreshLeadMs("codex"), 5 * 60 * 1000);
       assert.equal(mod.getRefreshLeadMs("openai"), 5 * 60 * 1000);
       assert.equal(mod.getRefreshLeadMs("claude"), 5 * 60 * 1000);
-      assert.equal(mod.getRefreshLeadMs("iflow"), 24 * 60 * 60 * 1000);
       assert.equal(mod.getRefreshLeadMs("antigravity"), 15 * 60 * 1000);
     });
 
     it("falls back to TOKEN_EXPIRY_BUFFER_MS for unknown providers", () => {
       assert.equal(mod.getRefreshLeadMs("unknown-provider"), mod.TOKEN_EXPIRY_BUFFER_MS);
       assert.equal(mod.getRefreshLeadMs(""), mod.TOKEN_EXPIRY_BUFFER_MS);
+      // `iflow` was removed from the product; its 24h entry outlived it in the TTL map.
+      // Asserted here rather than deleted from the "known providers" case above, so a
+      // silent reintroduction of the entry turns this red instead of passing unnoticed.
+      assert.equal(mod.getRefreshLeadMs("iflow"), mod.TOKEN_EXPIRY_BUFFER_MS);
     });
 
     it("honors a positive per-connection refreshLeadMs override", () => {


### PR DESCRIPTION
The `iflow` provider was removed from the product, but its 24-hour refresh-lead
entry outlived it in REFRESH_LEAD_MS. Surfaced during v3.8.49 homologation on the
production VPS, where startup logs carry:

    [CREDENTIALS] Warning: unknown provider "iflow" in credentials file, skipping.

Measured across src/, open-sse/, tests/ and docs/ — the identifier had exactly two
occurrences repo-wide: the map entry and one test assertion. Nothing dispatches on
it, so `getRefreshLeadMs("iflow")` now falls through to TOKEN_EXPIRY_BUFFER_MS like
any other unknown provider.

The test assertion was not deleted, it was MOVED: from "returns explicit lead time
for known providers" to "falls back to TOKEN_EXPIRY_BUFFER_MS for unknown
providers". That is alignment to the new behavior and strictly more coverage than
before — a silent reintroduction of the entry now turns the fallback case red
instead of passing unnoticed. Flagged explicitly because the test-masking gate
rightly treats a removed assertion as suspicious.

Also removes the now-redundant "Non-rotating providers" section header: every
remaining entry under it is Google-backed and the following comment already says
"permanent (non-rotating)".

    node --import tsx/esm --test tests/unit/service-token-refresh.test.ts
    # 14 pass, 0 fail