### PR TITLE
feat(responses): add encrypted reasoning replay opt-in

### DIFF
--- a/changelog.d/features/9000-encrypted-reasoning-replay.md
+++ b/changelog.d/features/9000-encrypted-reasoning-replay.md
@@ -1,1 +1,1 @@
-- Add an opt-in Codex connection setting that forwards client-supplied encrypted Responses reasoning items for replay, including per-target combo routing.
+- Add a default-off connection setting for Codex, OpenAI, and OpenAI-compatible Responses API providers that preserves client-supplied `reasoning.encrypted_content` items for replay, including per-target combo routing.

--- a/changelog.d/features/9000-encrypted-reasoning-replay.md
+++ b/changelog.d/features/9000-encrypted-reasoning-replay.md
@@ -1,1 +1,2 @@
 - Add a default-off connection setting for Codex, OpenAI, and OpenAI-compatible Responses API providers that preserves client-supplied `reasoning.encrypted_content` items for replay, including per-target combo routing.
+- Omit opaque encrypted reasoning values from persisted call logs while retaining compact diagnostic markers.

--- a/changelog.d/features/9000-encrypted-reasoning-replay.md
+++ b/changelog.d/features/9000-encrypted-reasoning-replay.md
@@ -1,0 +1,1 @@
+- Add an opt-in Codex connection setting that forwards client-supplied encrypted Responses reasoning items for replay, including per-target combo routing.

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -261,11 +261,15 @@ function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
  * This function:
  *   1. Removes bare string references ("rs_abc123") from the input array
  *   2. Removes object items with type "item_reference" (explicit stored-item refs)
- *   3. Strips the "id" field from any object in input whose id matches a
- *      server-generated prefix (rs_, fc_, resp_, msg_) — so the content is
- *      preserved but the backend won't try to look it up
+ *   3. Removes reasoning items unless encrypted reasoning preservation is enabled
+ *      and the item has non-empty encrypted_content
+ *   4. Strips the "id" field from any remaining object in input whose id matches
+ *      a server-generated prefix (rs_, fc_, resp_, msg_)
  */
-export function stripStoredItemReferences(body: Record<string, unknown>): void {
+export function stripStoredItemReferences(
+  body: Record<string, unknown>,
+  preserveEncryptedReasoning = false
+): void {
   if (Array.isArray(body.input) && body.input.length === 0) {
     body.input = [
       {
@@ -299,21 +303,24 @@ export function stripStoredItemReferences(body: Record<string, unknown>): void {
       return false;
     }
 
-    // Reasoning blobs (encrypted_content) are unusable with store=false since
-    // previous_response_id is deleted — strip them to avoid wasting context
-    // tokens (O(n^2) growth across agentic turns).
+    // Reasoning items normally cannot be replayed with store=false. A selected
+    // connection may explicitly preserve encrypted reasoning input, which is
+    // self-contained and must remain unchanged for the upstream to consume it.
     if (
       item &&
       typeof item === "object" &&
       !Array.isArray(item) &&
       (item as Record<string, unknown>).type === "reasoning"
     ) {
+      const encryptedContent = (item as Record<string, unknown>).encrypted_content;
+      if (preserveEncryptedReasoning && typeof encryptedContent === "string" && encryptedContent) {
+        return true;
+      }
       strippedCount++;
       return false;
     }
 
     // Object items with server-generated IDs: strip the id field but keep the item.
-    // e.g. { id: "rs_...", type: "reasoning", summary: [...] } → keep content, remove id
     // e.g. { id: "fc_...", type: "function_call", ... } → keep content, remove id
     if (item && typeof item === "object" && !Array.isArray(item)) {
       const record = item as Record<string, unknown>;
@@ -1392,9 +1399,12 @@ export class CodexExecutor extends BaseExecutor {
     });
 
     // Strip stored response item references (rs_, resp_, msg_ IDs) from input.
-    // The /codex/responses endpoint does not persist responses even with store=true,
-    // so any references to previous response items would cause 404 errors.
-    stripStoredItemReferences(body);
+    // The selected connection may opt into replaying self-contained encrypted
+    // reasoning items; plaintext and summary-only reasoning remains stripped.
+    stripStoredItemReferences(
+      body,
+      credentials?.providerSpecificData?.preserveEncryptedReasoning === true
+    );
 
     // Issue #806: Even for native passthrough, some clients (purist completions) might indiscriminately inject
     // a `messages` or `prompt` array which the strict Codex Responses schema rejects.

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -32,6 +32,7 @@ import {
 } from "../config/codexIdentity.ts";
 import { getAccessToken } from "../services/tokenRefresh.ts";
 import { sanitizeResponsesInputItems } from "../services/responsesInputSanitizer.ts";
+import { applyResponsesInputPolicy } from "../services/responsesInputPolicy.ts";
 import { normalizeCodexVerbosity } from "../services/codexVerbosity.ts";
 import { getThinkingBudgetConfig, ThinkingMode } from "../services/thinkingBudget.ts";
 import { CORS_HEADERS } from "../utils/cors.ts";
@@ -245,98 +246,6 @@ function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
     if (isSystemMessage) {
       item.role = "developer";
     }
-  }
-}
-
-/**
- * Strip server-generated item IDs from the input array.
- *
- * The Codex /codex/responses endpoint does not persist response items even when
- * store=true is sent. When proxy clients (e.g. OpenClaw) include response items
- * from previous turns in the input array, those items carry server-assigned IDs
- * (prefixed with "rs_", "fc_", "resp_", "msg_"). The Codex backend tries to
- * validate these IDs against its persistence store and returns 404 when the items
- * are not found (because store was effectively false).
- *
- * This function:
- *   1. Removes bare string references ("rs_abc123") from the input array
- *   2. Removes object items with type "item_reference" (explicit stored-item refs)
- *   3. Removes reasoning items unless encrypted reasoning preservation is enabled
- *      and the item has non-empty encrypted_content
- *   4. Strips the "id" field from any remaining object in input whose id matches
- *      a server-generated prefix (rs_, fc_, resp_, msg_)
- */
-export function stripStoredItemReferences(
-  body: Record<string, unknown>,
-  preserveEncryptedReasoning = false
-): void {
-  if (Array.isArray(body.input) && body.input.length === 0) {
-    body.input = [
-      {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: "continue" }],
-      },
-    ];
-  }
-
-  if (!Array.isArray(body.input)) return;
-
-  const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
-  let strippedCount = 0;
-
-  body.input = body.input.filter((item) => {
-    // Bare string references: "rs_abc123", "resp_abc123"
-    if (typeof item === "string" && SERVER_ID_PATTERN.test(item)) {
-      strippedCount++;
-      return false;
-    }
-
-    // Object references: { type: "item_reference", id: "rs_..." }
-    if (
-      item &&
-      typeof item === "object" &&
-      !Array.isArray(item) &&
-      (item as Record<string, unknown>).type === "item_reference"
-    ) {
-      strippedCount++;
-      return false;
-    }
-
-    // Reasoning items normally cannot be replayed with store=false. A selected
-    // connection may explicitly preserve encrypted reasoning input, which is
-    // self-contained and must remain unchanged for the upstream to consume it.
-    if (
-      item &&
-      typeof item === "object" &&
-      !Array.isArray(item) &&
-      (item as Record<string, unknown>).type === "reasoning"
-    ) {
-      const encryptedContent = (item as Record<string, unknown>).encrypted_content;
-      if (preserveEncryptedReasoning && typeof encryptedContent === "string" && encryptedContent) {
-        return true;
-      }
-      strippedCount++;
-      return false;
-    }
-
-    // Object items with server-generated IDs: strip the id field but keep the item.
-    // e.g. { id: "fc_...", type: "function_call", ... } → keep content, remove id
-    if (item && typeof item === "object" && !Array.isArray(item)) {
-      const record = item as Record<string, unknown>;
-      if (typeof record.id === "string" && SERVER_ID_PATTERN.test(record.id)) {
-        delete record.id;
-        strippedCount++;
-      }
-    }
-
-    return true;
-  });
-
-  if (strippedCount > 0) {
-    console.debug(
-      `[Codex] stripStoredItemReferences: sanitized ${strippedCount} server-generated ID(s) from input`
-    );
   }
 }
 
@@ -1276,7 +1185,7 @@ export class CodexExecutor extends BaseExecutor {
     }
 
     // Issue #1832 & #1853: Map messages to input for clients like Cursor 5.5 that use responses/compact but send messages instead of input.
-    // This MUST run before convertSystemToDeveloperRole and stripStoredItemReferences.
+    // This MUST run before convertSystemToDeveloperRole.
     if (!body.input && Array.isArray(body.messages)) {
       body.input = body.messages.map((msg: ResponsesMessageInput) => ({
         type: "message",
@@ -1398,14 +1307,6 @@ export class CodexExecutor extends BaseExecutor {
       preserveCustomTools: nativeCodexPassthrough,
     });
 
-    // Strip stored response item references (rs_, resp_, msg_ IDs) from input.
-    // The selected connection may opt into replaying self-contained encrypted
-    // reasoning items; plaintext and summary-only reasoning remains stripped.
-    stripStoredItemReferences(
-      body,
-      credentials?.providerSpecificData?.preserveEncryptedReasoning === true
-    );
-
     // Issue #806: Even for native passthrough, some clients (purist completions) might indiscriminately inject
     // a `messages` or `prompt` array which the strict Codex Responses schema rejects.
     delete body.messages;
@@ -1496,6 +1397,11 @@ export class CodexExecutor extends BaseExecutor {
     // but the upstream Codex API strictly rejects them as unsupported parameters.
     delete body.session_id;
     delete body.conversation_id;
+
+    applyResponsesInputPolicy(
+      body,
+      credentials?.providerSpecificData?.preserveEncryptedReasoning === true
+    );
 
     if (nativeCodexPassthrough) {
       return body;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -20,6 +20,7 @@ import { assembleStreamingResponseHeaders } from "./chatCore/streamingResponseHe
 import { storeStreamingSemanticCacheResponse } from "./chatCore/streamingSemanticCacheStore.ts";
 import { assembleStreamingPipeline } from "./chatCore/streamingPipeline.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
+import { applyResponsesInputPolicy } from "../services/responsesInputPolicy.ts";
 import {
   getHeaderValueCaseInsensitive,
   isNoMemoryRequested,
@@ -1053,6 +1054,13 @@ export async function handleChatCore({
   });
   if (cacheHit) {
     return cacheHit;
+  }
+
+  if (targetFormat === FORMATS.OPENAI_RESPONSES && body && typeof body === "object") {
+    applyResponsesInputPolicy(
+      body as Record<string, unknown>,
+      credentials?.providerSpecificData?.preserveEncryptedReasoning === true
+    );
   }
 
   body = sanitizeChatRequestBody(body, sourceFormat, targetFormat);

--- a/open-sse/services/responsesInputPolicy.ts
+++ b/open-sse/services/responsesInputPolicy.ts
@@ -1,0 +1,55 @@
+type JsonRecord = Record<string, unknown>;
+
+const SERVER_ITEM_ID_PATTERN = /^(rs|fc|resp|msg)_/;
+
+/**
+ * Applies the persistence-independent policy for replayed Responses input items.
+ * Stored references can only be resolved by the upstream that created them, so
+ * they are always removed. Self-contained encrypted reasoning is retained only
+ * when the selected connection explicitly opts in.
+ */
+export function applyResponsesInputPolicy(
+  body: Record<string, unknown>,
+  preserveEncryptedReasoning = false
+): void {
+  if (Array.isArray(body.input) && body.input.length === 0) {
+    body.input = [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "continue" }],
+      },
+    ];
+  }
+
+  if (!Array.isArray(body.input)) return;
+
+  body.input = body.input.filter((item) => {
+    if (typeof item === "string" && SERVER_ITEM_ID_PATTERN.test(item)) {
+      return false;
+    }
+
+    const record =
+      item && typeof item === "object" && !Array.isArray(item) ? (item as JsonRecord) : null;
+    if (!record) return true;
+
+    if (record.type === "item_reference") {
+      return false;
+    }
+
+    if (
+      record.type === "reasoning" &&
+      (!preserveEncryptedReasoning ||
+        typeof record.encrypted_content !== "string" ||
+        record.encrypted_content.trim().length === 0)
+    ) {
+      return false;
+    }
+
+    if (typeof record.id === "string" && SERVER_ITEM_ID_PATTERN.test(record.id)) {
+      delete record.id;
+    }
+
+    return true;
+  });
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -127,6 +127,7 @@ export default function EditConnectionModal({
     codexReasoningEffort: "medium",
     codexServiceTier: "default" as CodexServiceTier,
     codexOpenaiStoreEnabled: false,
+    codexPreserveEncryptedReasoning: false,
     consoleApiKey: "",
     newApiUserId: "",
     ...EMPTY_GLM_TEAM_QUOTA_FIELDS,
@@ -312,6 +313,8 @@ export default function EditConnectionModal({
         codexReasoningEffort: codexRequestDefaults.reasoningEffort,
         codexServiceTier: codexRequestDefaults.serviceTier ?? "default",
         codexOpenaiStoreEnabled: connection.providerSpecificData?.openaiStoreEnabled === true,
+        codexPreserveEncryptedReasoning:
+          connection.providerSpecificData?.preserveEncryptedReasoning === true,
         consoleApiKey: existingConsoleApiKey,
         newApiUserId: existingNewApiUserId,
         glmOrganizationId: existingGlmOrganizationId,
@@ -580,6 +583,8 @@ export default function EditConnectionModal({
           };
           updates.providerSpecificData.openaiStoreEnabled =
             formData.codexOpenaiStoreEnabled === true;
+          updates.providerSpecificData.preserveEncryptedReasoning =
+            formData.codexPreserveEncryptedReasoning === true;
         }
         if (isAntigravityFamily) {
           updates.providerSpecificData.projectId = trimmedCloudCodeProjectId || null;
@@ -695,6 +700,22 @@ export default function EditConnectionModal({
               onChange={(checked) => setFormData({ ...formData, codexOpenaiStoreEnabled: checked })}
               label={t("openaiResponsesStoreLabel")}
               description={t("openaiResponsesStoreDescription")}
+            />
+            <Toggle
+              checked={formData.codexPreserveEncryptedReasoning}
+              onChange={(checked) =>
+                setFormData({ ...formData, codexPreserveEncryptedReasoning: checked })
+              }
+              label={providerText(
+                t,
+                "preserveEncryptedReasoningLabel",
+                "Preserve encrypted reasoning"
+              )}
+              description={providerText(
+                t,
+                "preserveEncryptedReasoningDescription",
+                "Forward encrypted Responses reasoning items supplied by the client."
+              )}
             />
           </div>
         )}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -649,6 +649,19 @@ export default function EditConnectionModal({
       ? ERROR_TYPE_LABELS[testResult.diagnosis.type] || null
       : null;
 
+  const preserveEncryptedReasoningToggle = isResponsesConnection ? (
+    <Toggle
+      checked={formData.preserveEncryptedReasoning}
+      onChange={(checked) => setFormData({ ...formData, preserveEncryptedReasoning: checked })}
+      label={providerText(t, "preserveEncryptedReasoningLabel", "Preserve encrypted reasoning")}
+      description={providerText(
+        t,
+        "preserveEncryptedReasoningDescription",
+        "Forward encrypted Responses reasoning items supplied by the client."
+      )}
+    />
+  ) : null;
+
   return (
     <Modal isOpen={isOpen} title={t("editConnection")} onClose={onClose}>
       <div className="flex flex-col gap-4">
@@ -742,6 +755,7 @@ export default function EditConnectionModal({
               description={t("importFreeModelsOnlyHint")}
             />
           )}
+          {preserveEncryptedReasoningToggle}
           <Toggle
             checked={formData.disableCooling}
             onChange={(checked) => setFormData({ ...formData, disableCooling: checked })}
@@ -1078,25 +1092,6 @@ export default function EditConnectionModal({
               t,
               "apiProtocolHint",
               "Some providers publish the same models over more than one protocol. Leave the default unless you need the alternative."
-            )}
-          />
-        )}
-
-        {isResponsesConnection && (
-          <Toggle
-            checked={formData.preserveEncryptedReasoning}
-            onChange={(checked) =>
-              setFormData({ ...formData, preserveEncryptedReasoning: checked })
-            }
-            label={providerText(
-              t,
-              "preserveEncryptedReasoningLabel",
-              "Preserve encrypted reasoning"
-            )}
-            description={providerText(
-              t,
-              "preserveEncryptedReasoningDescription",
-              "Forward encrypted Responses reasoning items supplied by the client."
             )}
           />
         )}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -127,7 +127,7 @@ export default function EditConnectionModal({
     codexReasoningEffort: "medium",
     codexServiceTier: "default" as CodexServiceTier,
     codexOpenaiStoreEnabled: false,
-    codexPreserveEncryptedReasoning: false,
+    preserveEncryptedReasoning: false,
     consoleApiKey: "",
     newApiUserId: "",
     ...EMPTY_GLM_TEAM_QUOTA_FIELDS,
@@ -192,6 +192,13 @@ export default function EditConnectionModal({
   const openRouterPreset = useOpenRouterPresetControl(provider, t);
   const setOpenRouterPreset = openRouterPreset.setValue;
   const isCodex = provider === "codex";
+  const isResponsesConnection =
+    isCodex ||
+    provider === "openai" ||
+    (isOpenAICompatibleProvider(provider) &&
+      (provider.startsWith("openai-compatible-responses-") ||
+        connectionProviderSpecificData?.apiType === "responses" ||
+        formData.targetFormat === "openai-responses"));
   const isClaude = provider === "claude";
   const isAntigravityFamily = provider === "antigravity" || provider === "agy";
   const localProviderMetadata = getLocalProviderMetadata(provider);
@@ -313,7 +320,7 @@ export default function EditConnectionModal({
         codexReasoningEffort: codexRequestDefaults.reasoningEffort,
         codexServiceTier: codexRequestDefaults.serviceTier ?? "default",
         codexOpenaiStoreEnabled: connection.providerSpecificData?.openaiStoreEnabled === true,
-        codexPreserveEncryptedReasoning:
+        preserveEncryptedReasoning:
           connection.providerSpecificData?.preserveEncryptedReasoning === true,
         consoleApiKey: existingConsoleApiKey,
         newApiUserId: existingNewApiUserId,
@@ -583,8 +590,6 @@ export default function EditConnectionModal({
           };
           updates.providerSpecificData.openaiStoreEnabled =
             formData.codexOpenaiStoreEnabled === true;
-          updates.providerSpecificData.preserveEncryptedReasoning =
-            formData.codexPreserveEncryptedReasoning === true;
         }
         if (isAntigravityFamily) {
           updates.providerSpecificData.projectId = trimmedCloudCodeProjectId || null;
@@ -607,6 +612,10 @@ export default function EditConnectionModal({
         if (showProtocolSelector) {
           updates.providerSpecificData.targetFormat = formData.targetFormat || null;
         }
+      }
+      if (isResponsesConnection && updates.providerSpecificData) {
+        updates.providerSpecificData.preserveEncryptedReasoning =
+          formData.preserveEncryptedReasoning === true;
       }
       const freeOnlyChanged =
         showFreeModelsToggle &&
@@ -700,22 +709,6 @@ export default function EditConnectionModal({
               onChange={(checked) => setFormData({ ...formData, codexOpenaiStoreEnabled: checked })}
               label={t("openaiResponsesStoreLabel")}
               description={t("openaiResponsesStoreDescription")}
-            />
-            <Toggle
-              checked={formData.codexPreserveEncryptedReasoning}
-              onChange={(checked) =>
-                setFormData({ ...formData, codexPreserveEncryptedReasoning: checked })
-              }
-              label={providerText(
-                t,
-                "preserveEncryptedReasoningLabel",
-                "Preserve encrypted reasoning"
-              )}
-              description={providerText(
-                t,
-                "preserveEncryptedReasoningDescription",
-                "Forward encrypted Responses reasoning items supplied by the client."
-              )}
             />
           </div>
         )}
@@ -1085,6 +1078,25 @@ export default function EditConnectionModal({
               t,
               "apiProtocolHint",
               "Some providers publish the same models over more than one protocol. Leave the default unless you need the alternative."
+            )}
+          />
+        )}
+
+        {isResponsesConnection && (
+          <Toggle
+            checked={formData.preserveEncryptedReasoning}
+            onChange={(checked) =>
+              setFormData({ ...formData, preserveEncryptedReasoning: checked })
+            }
+            label={providerText(
+              t,
+              "preserveEncryptedReasoningLabel",
+              "Preserve encrypted reasoning"
+            )}
+            description={providerText(
+              t,
+              "preserveEncryptedReasoningDescription",
+              "Forward encrypted Responses reasoning items supplied by the client."
             )}
           />
         )}

--- a/src/lib/logPayloads.ts
+++ b/src/lib/logPayloads.ts
@@ -20,6 +20,29 @@ const SENSITIVE_KEYS = new Set([
 
 type JsonRecord = Record<string, unknown>;
 
+const ENCRYPTED_REASONING_KEY = "encrypted_content";
+
+function encryptedReasoningOmissionMarker(length?: number): string {
+  return length === undefined
+    ? "[omitted: encrypted reasoning]"
+    : `[omitted: encrypted reasoning, ${length} chars]`;
+}
+
+// Matches a JSON string field in captured SSE text. Alternatives inside the value are disjoint,
+// keeping the scan linear even for large encrypted blobs.
+const SERIALIZED_ENCRYPTED_REASONING_RE = /(\"encrypted_content\"\s*:\s*\")((?:\\.|[^\"\\])*)\"/g;
+const STREAM_CHUNK_TIMESTAMP_RE = /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] /;
+
+export function omitEncryptedReasoningFromLogChunks(chunks: string[]): string[] {
+  const combined = chunks.map((chunk) => chunk.replace(STREAM_CHUNK_TIMESTAMP_RE, "")).join("");
+  let found = false;
+  const omitted = combined.replace(SERIALIZED_ENCRYPTED_REASONING_RE, (_match, prefix: string) => {
+    found = true;
+    return `${prefix}${encryptedReasoningOmissionMarker()}\"`;
+  });
+  return found ? [omitted] : chunks;
+}
+
 /**
  * True for any binary/opaque byte view (Uint8Array, Buffer, DataView, other
  * typed arrays). `Array.isArray()` returns false for these, so callers that
@@ -54,6 +77,28 @@ export function normalizePayloadForLog(payload: unknown): unknown {
   } catch {
     return { _rawText: payload };
   }
+}
+
+/**
+ * Remove opaque encrypted reasoning from log copies. The value is replayable by clients but
+ * provides no useful diagnostics, so retaining its size is sufficient for observability.
+ */
+export function omitEncryptedReasoningForLog(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") return payload;
+  if (isOpaqueBinary(payload)) return describeOpaqueBinary(payload);
+  if (Array.isArray(payload)) return payload.map(omitEncryptedReasoningForLog);
+
+  const omitted: JsonRecord = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (key === ENCRYPTED_REASONING_KEY && typeof value === "string" && value.length > 0) {
+      omitted[key] = encryptedReasoningOmissionMarker(value.length);
+    } else if (typeof value === "object" && value !== null) {
+      omitted[key] = omitEncryptedReasoningForLog(value);
+    } else {
+      omitted[key] = value;
+    }
+  }
+  return omitted;
 }
 
 export function redactPayload(payload: unknown): unknown {
@@ -100,7 +145,8 @@ export function sanitizePayloadPII(payload: unknown): unknown {
 export function protectPayloadForLog(payload: unknown): unknown {
   if (payload === null || payload === undefined) return null;
   const normalized = normalizePayloadForLog(payload);
-  const piiSanitized = sanitizePayloadPII(normalized);
+  const reasoningOmitted = omitEncryptedReasoningForLog(normalized);
+  const piiSanitized = sanitizePayloadPII(reasoningOmitted);
   return redactPayload(piiSanitized);
 }
 

--- a/src/lib/providers/requestDefaults.ts
+++ b/src/lib/providers/requestDefaults.ts
@@ -192,6 +192,13 @@ export function normalizeProviderSpecificData(
     delete normalized.openaiStoreEnabled;
   }
 
+  if (
+    "preserveEncryptedReasoning" in normalized &&
+    typeof normalized.preserveEncryptedReasoning !== "boolean"
+  ) {
+    delete normalized.preserveEncryptedReasoning;
+  }
+
   if ("blockExtraUsage" in normalized && typeof normalized.blockExtraUsage !== "boolean") {
     delete normalized.blockExtraUsage;
   }

--- a/src/lib/usage/callLogs/format.ts
+++ b/src/lib/usage/callLogs/format.ts
@@ -1,6 +1,6 @@
 import type { RequestPipelinePayloads } from "@omniroute/open-sse/utils/requestLogger.ts";
 import { sanitizePII } from "../../piiSanitizer";
-import { protectPayloadForLog } from "../../logPayloads";
+import { omitEncryptedReasoningFromLogChunks, protectPayloadForLog } from "../../logPayloads";
 import type { CallLogDetailState } from "../callLogArtifacts";
 // #7879: re-export the canonical helper so existing consumers of this module
 // keep importing `toNumber` from here unchanged.
@@ -79,9 +79,12 @@ export function protectPipelinePayloads(payloads: unknown): RequestPipelinePaylo
     if (key === "streamChunks" && value && typeof value === "object") {
       const chunks = value as Record<string, unknown>;
       const compacted = Object.fromEntries(
-        Object.entries(chunks).filter(
-          ([, chunkValue]) => Array.isArray(chunkValue) && chunkValue.length > 0
-        )
+        Object.entries(chunks)
+          .filter(([, chunkValue]) => Array.isArray(chunkValue) && chunkValue.length > 0)
+          .map(([stage, chunkValue]) => [
+            stage,
+            omitEncryptedReasoningFromLogChunks(chunkValue as string[]),
+          ])
       );
       if (Object.keys(compacted).length > 0) {
         protectedPayloads.streamChunks = protectPayloadForLog(

--- a/src/shared/validation/providerSpecificData.ts
+++ b/src/shared/validation/providerSpecificData.ts
@@ -154,6 +154,15 @@ export function validateProviderSpecificData(
     });
   }
 
+  const preserveEncryptedReasoning = data.preserveEncryptedReasoning;
+  if (preserveEncryptedReasoning !== undefined && typeof preserveEncryptedReasoning !== "boolean") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "providerSpecificData.preserveEncryptedReasoning must be a boolean",
+      path: ["preserveEncryptedReasoning"],
+    });
+  }
+
   const blockExtraUsage = data.blockExtraUsage;
   if (blockExtraUsage !== undefined && typeof blockExtraUsage !== "boolean") {
     ctx.addIssue({

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -538,6 +538,80 @@ test("chatCore honors providerSpecificData.apiType for legacy openai-compatible 
   assert.equal(payload.choices[0].message.content, "ok");
 });
 
+test("chatCore applies Responses input policy to openai-compatible targets", async () => {
+  const reasoningItems = [
+    { id: "rs_valid", type: "reasoning", encrypted_content: "encrypted-blob" },
+    { type: "reasoning", encrypted_content: "" },
+    { type: "reasoning", summary: [{ text: "not self-contained" }] },
+    { type: "item_reference", id: "rs_reference" },
+    { id: "fc_call", type: "function_call", call_id: "call_1", name: "search", arguments: "{}" },
+  ];
+
+  for (const preserveEncryptedReasoning of [false, true]) {
+    const { call, result } = await invokeChatCore({
+      provider: "openai-compatible-sp-openai",
+      model: "gpt-5.4",
+      endpoint: "/v1/responses",
+      credentials: {
+        apiKey: "sk-test",
+        providerSpecificData: {
+          apiType: "responses",
+          baseUrl: "https://proxy.example.com/v1",
+          prefix: "sp-openai",
+          preserveEncryptedReasoning,
+        },
+      },
+      body: { model: "gpt-5.4", stream: false, input: reasoningItems },
+      responseFormat: "openai-responses",
+    });
+
+    assert.equal(result.success, true);
+    const input = call.body.input as Array<Record<string, unknown>>;
+    assert.deepEqual(
+      input.filter((item) => item.type === "reasoning"),
+      preserveEncryptedReasoning ? [{ type: "reasoning", encrypted_content: "encrypted-blob" }] : []
+    );
+    assert.equal(
+      input.some((item) => item.type === "item_reference"),
+      false
+    );
+    assert.equal(input.find((item) => item.type === "function_call")?.id, undefined);
+  }
+});
+
+test("chatCore preserves opted-in encrypted reasoning for Codex", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "codex",
+    model: "gpt-5.1-codex",
+    endpoint: "/v1/responses",
+    credentials: {
+      accessToken: "codex-token",
+      providerSpecificData: { preserveEncryptedReasoning: true },
+    },
+    body: {
+      model: "gpt-5.1-codex",
+      stream: false,
+      input: [
+        { id: "rs_valid", type: "reasoning", encrypted_content: "encrypted-blob" },
+        { type: "reasoning", encrypted_content: "" },
+        { type: "item_reference", id: "rs_reference" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+      ],
+    },
+    responseFormat: "openai-responses",
+  });
+
+  assert.equal(result.success, true);
+  assert.deepEqual(
+    call.body.input.filter((item) => item.type === "reasoning"),
+    [{ type: "reasoning", encrypted_content: "encrypted-blob" }]
+  );
+  assert.equal(
+    call.body.input.some((item) => item.type === "item_reference"),
+    false
+  );
+});
+
 test("chatCore helper exports detect responses passthrough paths and token expiry windows", () => {
   assert.equal(
     shouldUseNativeCodexPassthrough({

--- a/tests/unit/provider-specific-data-schema.test.ts
+++ b/tests/unit/provider-specific-data-schema.test.ts
@@ -42,6 +42,36 @@ test("provider schemas reject non-boolean openaiStoreEnabled values", () => {
   assert.equal(updated.success, false);
 });
 
+test("provider schemas accept boolean preserveEncryptedReasoning in providerSpecificData", () => {
+  const created = createProviderSchema.safeParse({
+    provider: "codex",
+    apiKey: "token",
+    name: "Codex",
+    providerSpecificData: { preserveEncryptedReasoning: true },
+  });
+  const updated = updateProviderConnectionSchema.safeParse({
+    providerSpecificData: { preserveEncryptedReasoning: false },
+  });
+
+  assert.equal(created.success, true);
+  assert.equal(updated.success, true);
+});
+
+test("provider schemas reject non-boolean preserveEncryptedReasoning values", () => {
+  const created = createProviderSchema.safeParse({
+    provider: "codex",
+    apiKey: "token",
+    name: "Codex",
+    providerSpecificData: { preserveEncryptedReasoning: "yes" },
+  });
+  const updated = updateProviderConnectionSchema.safeParse({
+    providerSpecificData: { preserveEncryptedReasoning: 1 },
+  });
+
+  assert.equal(created.success, false);
+  assert.equal(updated.success, false);
+});
+
 test("provider schemas accept boolean CC-compatible request defaults", () => {
   const created = createProviderSchema.safeParse({
     provider: "anthropic-compatible-cc-demo",

--- a/tests/unit/request-defaults-store-session.test.ts
+++ b/tests/unit/request-defaults-store-session.test.ts
@@ -15,6 +15,21 @@ test("Codex request defaults accept max but leave ultra to the Codex client", ()
   assert.equal(normalizeCodexReasoningEffort("ultra"), undefined);
 });
 
+test("normalizeProviderSpecificData keeps only boolean preserveEncryptedReasoning", () => {
+  assert.equal(
+    normalizeProviderSpecificData("codex", { preserveEncryptedReasoning: true })
+      ?.preserveEncryptedReasoning,
+    true
+  );
+  assert.equal(
+    normalizeProviderSpecificData("codex", {
+      preserveEncryptedReasoning: "yes",
+      tag: "primary",
+    })?.preserveEncryptedReasoning,
+    undefined
+  );
+});
+
 test("buildOpenAIStoreSessionId normalizes external and generated session ids", () => {
   assert.equal(
     buildOpenAIStoreSessionId("ext:client session/abc"),

--- a/tests/unit/request-log-payloads.test.ts
+++ b/tests/unit/request-log-payloads.test.ts
@@ -1,3 +1,4 @@
+import { protectPipelinePayloads } from "../../src/lib/usage/callLogs/format.ts";
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -32,6 +33,46 @@ test("normalizes JSON strings before log protection and redacts sensitive keys",
       apiKey: "[REDACTED]",
     },
   });
+});
+
+test("omits encrypted reasoning values from structured log payloads", () => {
+  const encryptedContent = "encrypted".repeat(128);
+  const payload = {
+    output: [
+      {
+        type: "reasoning",
+        encrypted_content: encryptedContent,
+        reasoning_content: "visible diagnostic reasoning",
+      },
+    ],
+  };
+
+  const protectedPayload = protectPayloadForLog(payload) as typeof payload;
+
+  assert.equal(
+    protectedPayload.output[0].encrypted_content,
+    `[omitted: encrypted reasoning, ${encryptedContent.length} chars]`
+  );
+  assert.equal(protectedPayload.output[0].reasoning_content, "visible diagnostic reasoning");
+  assert.equal(payload.output[0].encrypted_content, encryptedContent);
+});
+
+test("omits encrypted reasoning split across captured SSE chunks", () => {
+  const encryptedContent = "opaque-replay-state".repeat(128);
+  const protectedPipeline = protectPipelinePayloads({
+    streamChunks: {
+      provider: [
+        '[12:00:00.000] data: {"type":"response.completed","response":{"output":[{"type":"reasoning","encrypted_',
+        `[12:00:00.001] content":"${encryptedContent}","summary":[]}]}}\n\n`,
+      ],
+    },
+  });
+
+  const storedChunks = protectedPipeline?.streamChunks?.provider ?? [];
+  assert.equal(storedChunks.length, 1);
+  assert.equal(storedChunks[0].includes(encryptedContent), false);
+  assert.equal(storedChunks[0].includes("[omitted: encrypted reasoning]"), true);
+  assert.equal(storedChunks[0].includes('"summary":[]'), true);
 });
 
 test("wraps raw text payloads in JSON-safe objects", () => {

--- a/tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts
+++ b/tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { stripStoredItemReferences } from "../../open-sse/executors/codex.ts";
+import { CodexExecutor, stripStoredItemReferences } from "../../open-sse/executors/codex.ts";
 import { filterToOpenAIFormat } from "../../open-sse/translator/helpers/openaiHelper.ts";
 
 // Port of decolua/9router#1599 — strip reasoning blobs from agentic context to
@@ -43,6 +43,69 @@ test("stripStoredItemReferences drops object items with type=reasoning", () => {
   assert.equal(input[0].type, "message");
   assert.equal(input[1].type, "function_call");
   assert.equal(input[1].id, undefined, "fc_ server id stripped, item kept");
+});
+
+test("Codex selected connection preserves encrypted reasoning input", () => {
+  const encryptedReasoning = {
+    id: "rs_encrypted123",
+    type: "reasoning",
+    encrypted_content: "encrypted-blob",
+    summary: [{ type: "summary_text", text: "safe summary" }],
+  };
+  const executor = new CodexExecutor();
+
+  const result = executor.transformRequest(
+    "gpt-5.3-codex",
+    {
+      _nativeCodexPassthrough: true,
+      input: [
+        encryptedReasoning,
+        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+      ],
+    },
+    true,
+    { providerSpecificData: { preserveEncryptedReasoning: true } }
+  );
+
+  assert.deepEqual(result.input, [
+    encryptedReasoning,
+    { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+  ]);
+});
+
+test("preserving encrypted reasoning still removes stored references", () => {
+  const body: Record<string, unknown> = {
+    input: [
+      { id: "rs_encrypted123", type: "reasoning", encrypted_content: "encrypted-blob" },
+      "rs_stored123",
+      { type: "item_reference", id: "resp_stored123" },
+      { type: "function_call", id: "fc_stored123", call_id: "call_1" },
+    ],
+  };
+
+  stripStoredItemReferences(body, true);
+
+  assert.deepEqual(body.input, [
+    { id: "rs_encrypted123", type: "reasoning", encrypted_content: "encrypted-blob" },
+    { type: "function_call", call_id: "call_1" },
+  ]);
+});
+
+test("stripStoredItemReferences still drops summary-only reasoning when preservation is enabled", () => {
+  const body: Record<string, unknown> = {
+    input: [
+      { id: "rs_summary123", type: "reasoning", summary: [{ text: "thinking..." }] },
+      { type: "reasoning", encrypted_content: "" },
+      { type: "reasoning", encrypted_content: 42 },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+    ],
+  };
+
+  stripStoredItemReferences(body, true);
+
+  assert.deepEqual(body.input, [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+  ]);
 });
 
 test("filterToOpenAIFormat strips reasoning_content from assistant+tool_calls messages", () => {

--- a/tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts
+++ b/tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts
@@ -1,19 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { CodexExecutor, stripStoredItemReferences } from "../../open-sse/executors/codex.ts";
+import { applyResponsesInputPolicy } from "../../open-sse/services/responsesInputPolicy.ts";
 import { filterToOpenAIFormat } from "../../open-sse/translator/helpers/openaiHelper.ts";
 
-// Port of decolua/9router#1599 — strip reasoning blobs from agentic context to
-// prevent O(n^2) token growth across turns.
-//
-// (1) codex.ts stripStoredItemReferences: object items of type "reasoning"
-//     (encrypted_content) are unusable with store=false (previous_response_id is
-//     deleted) and must be dropped from the Responses `input` array.
-// (2) openaiHelper.ts filterToOpenAIFormat: assistant+tool_calls messages must
-//     have `reasoning_content` stripped instead of being returned as-is.
+// Port of decolua/9router#1599 — strip unusable reasoning blobs from agentic
+// context to prevent O(n^2) token growth across turns. Encrypted reasoning is
+// self-contained and may be replayed only through an explicit connection opt-in.
 
-test("stripStoredItemReferences drops object items with type=reasoning", () => {
+test("applyResponsesInputPolicy drops object items with type=reasoning", () => {
   const body: Record<string, unknown> = {
     input: [
       { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
@@ -29,7 +24,7 @@ test("stripStoredItemReferences drops object items with type=reasoning", () => {
     ],
   };
 
-  stripStoredItemReferences(body);
+  applyResponsesInputPolicy(body);
 
   const input = body.input as Array<Record<string, unknown>>;
   // Both reasoning items must be gone.
@@ -45,30 +40,27 @@ test("stripStoredItemReferences drops object items with type=reasoning", () => {
   assert.equal(input[1].id, undefined, "fc_ server id stripped, item kept");
 });
 
-test("Codex selected connection preserves encrypted reasoning input", () => {
-  const encryptedReasoning = {
-    id: "rs_encrypted123",
-    type: "reasoning",
-    encrypted_content: "encrypted-blob",
-    summary: [{ type: "summary_text", text: "safe summary" }],
+test("selected connection policy preserves encrypted reasoning input", () => {
+  const body: Record<string, unknown> = {
+    input: [
+      {
+        id: "rs_encrypted123",
+        type: "reasoning",
+        encrypted_content: "encrypted-blob",
+        summary: [{ type: "summary_text", text: "safe summary" }],
+      },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+    ],
   };
-  const executor = new CodexExecutor();
 
-  const result = executor.transformRequest(
-    "gpt-5.3-codex",
+  applyResponsesInputPolicy(body, true);
+
+  assert.deepEqual(body.input, [
     {
-      _nativeCodexPassthrough: true,
-      input: [
-        encryptedReasoning,
-        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
-      ],
+      type: "reasoning",
+      encrypted_content: "encrypted-blob",
+      summary: [{ type: "summary_text", text: "safe summary" }],
     },
-    true,
-    { providerSpecificData: { preserveEncryptedReasoning: true } }
-  );
-
-  assert.deepEqual(result.input, [
-    encryptedReasoning,
     { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
   ]);
 });
@@ -83,15 +75,15 @@ test("preserving encrypted reasoning still removes stored references", () => {
     ],
   };
 
-  stripStoredItemReferences(body, true);
+  applyResponsesInputPolicy(body, true);
 
   assert.deepEqual(body.input, [
-    { id: "rs_encrypted123", type: "reasoning", encrypted_content: "encrypted-blob" },
+    { type: "reasoning", encrypted_content: "encrypted-blob" },
     { type: "function_call", call_id: "call_1" },
   ]);
 });
 
-test("stripStoredItemReferences still drops summary-only reasoning when preservation is enabled", () => {
+test("applyResponsesInputPolicy still drops summary-only reasoning when enabled", () => {
   const body: Record<string, unknown> = {
     input: [
       { id: "rs_summary123", type: "reasoning", summary: [{ text: "thinking..." }] },
@@ -101,7 +93,7 @@ test("stripStoredItemReferences still drops summary-only reasoning when preserva
     ],
   };
 
-  stripStoredItemReferences(body, true);
+  applyResponsesInputPolicy(body, true);
 
   assert.deepEqual(body.input, [
     { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },

--- a/tests/unit/ui/edit-connection-modal-free-models.test.tsx
+++ b/tests/unit/ui/edit-connection-modal-free-models.test.tsx
@@ -261,6 +261,11 @@ describe("EditConnectionModal — encrypted Responses reasoning", () => {
     expect(
       el.querySelector('button[role="switch"][aria-label="openaiResponsesStoreLabel"]')
     ).toBeTruthy();
+    const cooldownToggle = el.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="disableCoolingLabel"]'
+    )!;
+    const reasoningToggle = el.querySelector<HTMLButtonElement>(PRESERVE_TOGGLE)!;
+    expect(reasoningToggle.parentElement?.nextElementSibling).toBe(cooldownToggle.parentElement);
     const saveBtn = Array.from(el.querySelectorAll("button")).find(
       (button) => button.textContent?.trim() === "save"
     )!;

--- a/tests/unit/ui/edit-connection-modal-free-models.test.tsx
+++ b/tests/unit/ui/edit-connection-modal-free-models.test.tsx
@@ -169,6 +169,49 @@ describe("EditConnectionModal — import only free models", () => {
   });
 });
 
+describe("EditConnectionModal — encrypted Codex reasoning", () => {
+  const PRESERVE_TOGGLE = 'button[role="switch"][aria-label="Preserve encrypted reasoning"]';
+
+  it("defaults existing Codex connections to disabled", () => {
+    const el = render({
+      providerId: "codex",
+      connection: {
+        id: "conn-codex-default",
+        provider: "codex",
+        authType: "oauth",
+        providerSpecificData: {},
+      },
+    });
+
+    expect(el.querySelector(PRESERVE_TOGGLE)?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("loads and saves the persisted boolean", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const el = render({
+      providerId: "codex",
+      connection: {
+        id: "conn-codex-preserve",
+        provider: "codex",
+        authType: "oauth",
+        providerSpecificData: { preserveEncryptedReasoning: true },
+      },
+      onSave,
+    });
+    const toggle = el.querySelector<HTMLButtonElement>(PRESERVE_TOGGLE)!;
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+    act(() => toggle.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    const saveBtn = Array.from(el.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "save"
+    )!;
+    act(() => saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    await waitFor(() => onSave.mock.calls.length > 0);
+    expect(onSave.mock.calls[0][0].providerSpecificData?.preserveEncryptedReasoning).toBe(false);
+  });
+});
+
 describe("EditConnectionModal — quota scraping fields", () => {
   it("saves OpenCode Go workspace and replacement auth cookie", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);

--- a/tests/unit/ui/edit-connection-modal-free-models.test.tsx
+++ b/tests/unit/ui/edit-connection-modal-free-models.test.tsx
@@ -169,46 +169,104 @@ describe("EditConnectionModal — import only free models", () => {
   });
 });
 
-describe("EditConnectionModal — encrypted Codex reasoning", () => {
+describe("EditConnectionModal — encrypted Responses reasoning", () => {
   const PRESERVE_TOGGLE = 'button[role="switch"][aria-label="Preserve encrypted reasoning"]';
 
-  it("defaults existing Codex connections to disabled", () => {
-    const el = render({
-      providerId: "codex",
-      connection: {
-        id: "conn-codex-default",
-        provider: "codex",
-        authType: "oauth",
-        providerSpecificData: {},
-      },
-    });
-
-    expect(el.querySelector(PRESERVE_TOGGLE)?.getAttribute("aria-checked")).toBe("false");
-  });
-
-  it("loads and saves the persisted boolean", async () => {
+  it("loads and saves the opt-in for an OpenAI-compatible Responses connection", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     const el = render({
-      providerId: "codex",
+      providerId: "openai-compatible-responses-12345678-1234-1234-1234-123456789abc",
       connection: {
-        id: "conn-codex-preserve",
-        provider: "codex",
-        authType: "oauth",
+        id: "conn-responses",
+        provider: "openai-compatible-responses-12345678-1234-1234-1234-123456789abc",
+        authType: "apikey",
         providerSpecificData: { preserveEncryptedReasoning: true },
       },
       onSave,
     });
     const toggle = el.querySelector<HTMLButtonElement>(PRESERVE_TOGGLE)!;
     expect(toggle.getAttribute("aria-checked")).toBe("true");
-
     act(() => toggle.dispatchEvent(new MouseEvent("click", { bubbles: true })));
     const saveBtn = Array.from(el.querySelectorAll("button")).find(
       (button) => button.textContent?.trim() === "save"
     )!;
     act(() => saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
-
     await waitFor(() => onSave.mock.calls.length > 0);
     expect(onSave.mock.calls[0][0].providerSpecificData?.preserveEncryptedReasoning).toBe(false);
+  });
+
+  it("defaults off and persists an opt-in for first-party OpenAI", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const el = render({
+      providerId: "openai",
+      connection: {
+        id: "conn-openai",
+        provider: "openai",
+        authType: "apikey",
+        providerSpecificData: {},
+      },
+      onSave,
+    });
+    const toggle = el.querySelector<HTMLButtonElement>(PRESERVE_TOGGLE)!;
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    act(() => toggle.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    const saveBtn = Array.from(el.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "save"
+    )!;
+    act(() => saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    await waitFor(() => onSave.mock.calls.length > 0);
+    expect(onSave.mock.calls[0][0].providerSpecificData?.preserveEncryptedReasoning).toBe(true);
+  });
+
+  it("is absent for a chat-only compatible connection", () => {
+    const el = render({
+      providerId: "openai-compatible-chat-12345678-1234-1234-1234-123456789abc",
+      connection: {
+        id: "conn-chat",
+        provider: "openai-compatible-chat-12345678-1234-1234-1234-123456789abc",
+        authType: "apikey",
+        providerSpecificData: {},
+      },
+    });
+    expect(el.querySelector(PRESERVE_TOGGLE)).toBeNull();
+  });
+
+  it("appears when a compatible connection selects the Responses target format", () => {
+    const el = render({
+      providerId: "openai-compatible-chat-12345678-1234-1234-1234-123456789abc",
+      connection: {
+        id: "conn-selected-responses",
+        provider: "openai-compatible-chat-12345678-1234-1234-1234-123456789abc",
+        authType: "apikey",
+        providerSpecificData: { targetFormat: "openai-responses" },
+      },
+    });
+    expect(el.querySelector(PRESERVE_TOGGLE)?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("keeps Codex controls and persists the opt-in on its OAuth save path", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const el = render({
+      providerId: "codex",
+      connection: {
+        id: "conn-codex",
+        provider: "codex",
+        authType: "oauth",
+        providerSpecificData: { preserveEncryptedReasoning: true },
+      },
+      onSave,
+    });
+    expect(el.querySelector(PRESERVE_TOGGLE)?.getAttribute("aria-checked")).toBe("true");
+    expect(el.textContent).toContain("defaultThinkingStrengthLabel");
+    expect(
+      el.querySelector('button[role="switch"][aria-label="openaiResponsesStoreLabel"]')
+    ).toBeTruthy();
+    const saveBtn = Array.from(el.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "save"
+    )!;
+    act(() => saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    await waitFor(() => onSave.mock.calls.length > 0);
+    expect(onSave.mock.calls[0][0].providerSpecificData?.preserveEncryptedReasoning).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- add a default-off connection toggle for encrypted OpenAI Responses reasoning replay
- apply the selected connection policy to Codex, first-party OpenAI, and OpenAI-compatible Responses upstreams, including combo targets
- preserve only self-contained `reasoning.encrypted_content` input items when enabled
- always remove stored item references and sanitize server-generated response item IDs
- validate and normalize the persisted setting
- place the replay toggle with connection-level controls, immediately above **Disable cooldown for this connection**
- omit opaque `encrypted_content` values from persisted structured payloads and captured SSE chunks while retaining compact diagnostic markers

Closes #9000

## Tests

Changed test files:
- `tests/unit/chatcore-translation-paths.test.ts`
- `tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts`
- `tests/unit/provider-specific-data-schema.test.ts`
- `tests/unit/request-defaults-store-session.test.ts`
- `tests/unit/request-log-payloads.test.ts`
- `tests/unit/ui/edit-connection-modal-free-models.test.tsx`

Commands run after rebasing onto current `release/v3.8.50`:
- `node --import tsx/esm --test tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts tests/unit/chatcore-translation-paths.test.ts tests/unit/provider-specific-data-schema.test.ts tests/unit/request-defaults-store-session.test.ts tests/unit/executor-codex.test.ts` — 133 passed
- `npm exec -- vitest run tests/unit/ui/edit-connection-modal-free-models.test.tsx` — 12 passed
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/request-log-payloads.test.ts` — 9 passed
- `./node_modules/.bin/eslint src/lib/logPayloads.ts src/lib/usage/callLogs/format.ts tests/unit/request-log-payloads.test.ts --suppressions-location config/quality/eslint-suppressions.json` — passed
- `npm run test:coverage` — coverage thresholds passed: 84.35% statements, 84.35% lines, 88.23% functions, 78.64% branches. Unrelated existing suite failures kept command exit nonzero, including provider golden snapshot drift and service-supervisor port adoption.

## Manual combo validation

Validated one session against a combo containing `gpt-5.6-sol` and `kimi-k3`:

1. Initial turns routed to `gpt-5.6-sol`; encrypted reasoning content was returned and preserved in client replay history.
2. Removed `gpt-5.6-sol` from the combo; the same session switched to `kimi-k3` and continued successfully. OmniRoute omitted the Codex-only encrypted reasoning item from the non-Responses upstream request while the client retained it.
3. Restored `gpt-5.6-sol`; the same session switched back and continued successfully with the retained encrypted reasoning available again.

This confirms mixed-provider combo switching does not break the session and Codex encrypted reasoning survives a temporary hop through a non-Responses target for reuse when routing returns to Codex.

## Context

Inspired by OpenAI's report that retained reasoning and compaction tripled ARC-AGI-3 scores while reducing output tokens: https://openai.com/index/how-two-settings-tripled-our-arc-agi-3-scores/

This PR intentionally adds only user-controlled passthrough for encrypted reasoning already present in request input. It adds no replay cache, stored-response lineage, or server-side compaction policy.
