### PR TITLE
fix(executors): backfill missing tool message names for Kimi K3 and strict BYOK providers

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -28,6 +28,7 @@ import {
   getTargetFormat,
   isClaudeCodeCompatible,
 } from "../services/provider.ts";
+import { ensureToolMessageNames } from "./kimiToolNames.ts";
 import { getSapResourceGroup } from "../config/sap.ts";
 import {
   normalizeBailianMessagesUrl,
@@ -575,6 +576,20 @@ export class DefaultExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     const cleanedBody = super.transformRequest(model, body, stream, credentials);
     let withDefaults = applyProviderRequestDefaults(cleanedBody, this.config.requestDefaults);
+
+    // ponytail: backfill missing tool message names for strict OpenAI-compatible providers.
+    // Kimi K3 and some BYOK endpoints reject tool messages whose `name` field was stripped
+    // during combo routing or format translation. Build a tool_call_id → function.name
+    // lookup from assistant messages and restore missing names before forwarding.
+    if (
+      withDefaults &&
+      typeof withDefaults === "object" &&
+      !Array.isArray(withDefaults) &&
+      Array.isArray((withDefaults as Record<string, unknown>).messages)
+    ) {
+      withDefaults = ensureToolMessageNames(withDefaults as Record<string, unknown>);
+    }
+
     withDefaults = this.applyJsonSchemaFallback(withDefaults);
     withDefaults = this.defaultResponsesTextFormat(withDefaults);
 

--- a/open-sse/executors/kimi.ts
+++ b/open-sse/executors/kimi.ts
@@ -7,6 +7,7 @@ import {
 import { FORMATS } from "../translator/formats.ts";
 import { DefaultExecutor } from "./default.ts";
 import type { ProviderCredentials } from "./base.ts";
+import { ensureToolMessageNames } from "./kimiToolNames.ts";
 
 type JsonRecord = Record<string, unknown>;
 type KimiProtocol = "openai" | "claude";
@@ -410,11 +411,17 @@ export class KimiExecutor extends DefaultExecutor {
     const cleanedBody = super.transformRequest(model, body, stream, credentials);
     const record = asRecord(cleanedBody);
     if (!record) return cleanedBody;
+
+    // ponytail: backfill missing tool message names before protocol normalization.
+    // Kimi K3 rejects tool messages whose `name` field was stripped during
+    // combo routing or format translation.
+    const withNames = ensureToolMessageNames(record);
+
     const policy = getThinkingPolicy(credentials);
     const normalized =
-      resolveKimiProtocol(credentials, record) === "claude"
-        ? normalizeAnthropicRequest(record, policy)
-        : normalizeOpenAIRequest(record, stream, policy);
+      resolveKimiProtocol(credentials, withNames) === "claude"
+        ? normalizeAnthropicRequest(withNames, policy)
+        : normalizeOpenAIRequest(withNames, stream, policy);
     return stream ? { ...normalized, stream: true } : normalized;
   }
 }

--- a/open-sse/executors/kimiToolNames.ts
+++ b/open-sse/executors/kimiToolNames.ts
@@ -1,0 +1,42 @@
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+// ponytail: Kimi K3 (Moonshot) enforces a stricter tool-message contract than most
+// OpenAI-compatible APIs: every role:"tool" message must carry a `name` field matching
+// the function that issued the tool_call_id. When requests arrive through combo routing
+// or format translation, the `name` field is frequently stripped, causing a 400.
+// This builds a tool_call_id -> function.name lookup from assistant tool_calls and
+// backfills missing names. Shared by KimiExecutor and DefaultExecutor (for BYOK providers).
+// Upgrade path: if Moonshot relaxes this requirement, this function becomes a no-op.
+export function ensureToolMessageNames(record: JsonRecord): JsonRecord {
+  if (!Array.isArray(record.messages)) return record;
+
+  const callIdToName = new Map<string, string>();
+  for (const msg of record.messages) {
+    const m = asRecord(msg);
+    if (!m || m.role !== "assistant" || !Array.isArray(m.tool_calls)) continue;
+    for (const tc of m.tool_calls as { id?: string; function?: { name?: string } }[]) {
+      if (tc?.id && typeof tc.function?.name === "string") {
+        callIdToName.set(String(tc.id), tc.function.name);
+      }
+    }
+  }
+
+  if (callIdToName.size === 0) return record;
+
+  let modified = false;
+  const messages = record.messages.map((msg: unknown) => {
+    const m = asRecord(msg);
+    if (!m || m.role !== "tool" || typeof m.name === "string") return msg;
+    const callId = String(m.tool_call_id ?? "");
+    const resolvedName = callIdToName.get(callId);
+    if (!resolvedName) return msg;
+    modified = true;
+    return { ...m, name: resolvedName };
+  });
+
+  return modified ? { ...record, messages } : record;
+}


### PR DESCRIPTION
## Problem

Kimi K3 (Moonshot) enforces a stricter tool-message contract than most OpenAI-compatible APIs: every `role:"tool"` message must carry a `name` field matching the function that issued the `tool_call_id`. When requests arrive through combo routing or format translation, the `name` field is frequently stripped, causing a **400 error**.

This also affects other strict BYOK `openai-compatible-*` providers that validate tool message structure.

## Fix

Adds a shared `open-sse/executors/kimiToolNames.ts` module with `ensureToolMessageNames()` that:

1. Builds a `tool_call_id → function.name` lookup from assistant messages
2. Backfills missing `name` fields on `role:"tool"` messages

Wired into both:
- **`KimiExecutor.transformRequest()`** — fixes Kimi K3 specifically
- **`DefaultExecutor.transformRequest()`** — fixes all `openai-compatible-*` BYOK providers

## Changes

| File | Change |
|------|--------|
| `open-sse/executors/kimiToolNames.ts` | New shared module |
| `open-sse/executors/kimi.ts` | Import + call `ensureToolMessageNames` before normalization |
| `open-sse/executors/default.ts` | Import + call `ensureToolMessageNames` in `transformRequest` |

## Testing

- All existing lint/ESLint/Prettier/docs-sync checks pass
- Manual testing confirms tool calls work through Kimi K3 after fix

## Upgrade Path

If Moonshot relaxes this requirement in the future, `ensureToolMessageNames()` becomes a no-op (returns the record unchanged when no tool messages lack names).