### PR TITLE
fix(dashboard): persist model param-filter edits on popover close (#8910)

### DIFF
--- a/changelog.d/fixes/9013-model-param-filter-save.md
+++ b/changelog.d/fixes/9013-model-param-filter-save.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** model-level allowed/blocked param edits now persist when the compatibility popover is closed by clicking outside, and a failed save no longer clears the edit or reports success ([#9013](https://github.com/diegosouzapw/OmniRoute/pull/9013))

--- a/config/quality/dashboard-typecheck-baseline.json
+++ b/config/quality/dashboard-typecheck-baseline.json
@@ -127,12 +127,6 @@
   "src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsListPanel.tsx": {
     "TS2322": 2
   },
-  "src/app/(dashboard)/dashboard/providers/[id]/components/CustomModelsSection.tsx": {
-    "TS2739": 1
-  },
-  "src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx": {
-    "TS2304": 5
-  },
   "src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx": {
     "TS2322": 3,
     "TS2739": 1,
@@ -146,9 +140,6 @@
   },
   "src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPlaygroundPanel.tsx": {
     "TS2503": 1
-  },
-  "src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/phase1d.test.tsx": {
-    "TS2739": 2
   },
   "src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx": {
     "TS2322": 1

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CustomModelsSection.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CustomModelsSection.tsx
@@ -695,6 +695,8 @@ export default function CustomModelsSection({
                   </button>
                   <ModelCompatPopover
                     t={t}
+                    providerId={providerId}
+                    modelId={model.id!}
                     effectiveModelNormalize={(p) =>
                       effectiveNormalizeForProtocol(model.id!, p, customMap, overrideMap)
                     }

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -96,6 +96,8 @@ export interface ModelCompatPopoverProps {
 
 export default function ModelCompatPopover({
   t,
+  providerId,
+  modelId,
   effectiveModelNormalize,
   effectiveModelPreserveDeveloper,
   getUpstreamHeadersRecord,
@@ -109,7 +111,6 @@ export default function ModelCompatPopover({
   const [headerRows, setHeaderRows] = useState<HeaderDraftRow[]>([]);
   const [blockText, setBlockText] = useState("");
   const [allowText, setAllowText] = useState("");
-  const [paramDirty, setParamDirty] = useState(false);
   const [paramSaving, setParamSaving] = useState(false);
   const [valuePeekRowId, setValuePeekRowId] = useState<string | null>(null);
   const [valueFocusRowId, setValueFocusRowId] = useState<string | null>(null);
@@ -124,6 +125,22 @@ export default function ModelCompatPopover({
   const headerRowIdRef = useRef(0);
   const headerRowsRef = useRef<HeaderDraftRow[]>([]);
   headerRowsRef.current = headerRows;
+
+  // Param-filter drafts are mirrored into refs so the close/unmount save path reads the
+  // latest typed values instead of the values captured when the handler was created (#8910).
+  const paramDirtyRef = useRef(false);
+  const paramSavingRef = useRef(false);
+  const blockTextRef = useRef("");
+  const allowTextRef = useRef("");
+  blockTextRef.current = blockText;
+  allowTextRef.current = allowText;
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const genHeaderRowId = () => {
     headerRowIdRef.current += 1;
@@ -167,40 +184,66 @@ export default function ModelCompatPopover({
   // Load model-level block/allow from param-filters API
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     (async () => {
       try {
         const res = await fetch(`/api/providers/${providerId}/param-filters`);
+        if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
         const data = await res.json();
+        if (cancelled || !mountedRef.current) return;
         const modelCfg = data?.models?.[modelId];
         setBlockText(modelCfg ? (modelCfg.block ?? []).join(", ") : "");
         setAllowText(modelCfg ? (modelCfg.allow ?? []).join(", ") : "");
+        // Only the freshly loaded server state is clean — a failed load must not
+        // discard drafts the user already typed (#8910).
+        paramDirtyRef.current = false;
       } catch {
-        setBlockText("");
-        setAllowText("");
+        // Keep whatever the user has in the fields (and its dirty flag) on load failure.
       }
-      setParamDirty(false);
     })();
-  }, [open]);
+    return () => {
+      cancelled = true;
+    };
+    // Reload only when opening or when the popover targets a different provider/model.
+  }, [open, providerId, modelId]);
 
   const saveModelParamFilters = useCallback(async () => {
-    if (!paramDirty) return;
-    setParamSaving(true);
+    if (!paramDirtyRef.current || paramSavingRef.current) return;
+    paramSavingRef.current = true;
+    if (mountedRef.current) setParamSaving(true);
     try {
       const res = await fetch(`/api/providers/${providerId}/param-filters`);
+      if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
       const current = await res.json();
-      const payload = buildModelParamFilterPayload(current, modelId, blockText, allowText);
-      await fetch(`/api/providers/${providerId}/param-filters`, {
+      const payload = buildModelParamFilterPayload(
+        current,
+        modelId,
+        blockTextRef.current,
+        allowTextRef.current
+      );
+      const putRes = await fetch(`/api/providers/${providerId}/param-filters`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-      setParamDirty(false);
+      if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
+      // Stay dirty unless the write actually succeeded, so a later close can retry.
+      paramDirtyRef.current = false;
     } catch {
-      // Silently ignore save error
+      // Save failed — drafts and dirty state are intentionally preserved.
     } finally {
-      setParamSaving(false);
+      paramSavingRef.current = false;
+      if (mountedRef.current) setParamSaving(false);
     }
-  }, [paramDirty, blockText, allowText]);
+  }, [providerId, modelId]);
+
+  // Persist pending param-filter drafts when the popover closes or unmounts (#8910).
+  useEffect(() => {
+    if (!open) return;
+    return () => {
+      void saveModelParamFilters();
+    };
+  }, [open, saveModelParamFilters]);
 
   useEffect(() => {
     setValuePeekRowId(null);
@@ -361,7 +404,8 @@ export default function ModelCompatPopover({
                     value={blockText}
                     onChange={(e) => {
                       setBlockText(e.target.value);
-                      setParamDirty(true);
+                      blockTextRef.current = e.target.value;
+                      paramDirtyRef.current = true;
                     }}
                     onBlur={() => saveModelParamFilters()}
                     placeholder={t("compatBlockedParamsPlaceholder")}
@@ -379,7 +423,8 @@ export default function ModelCompatPopover({
                     value={allowText}
                     onChange={(e) => {
                       setAllowText(e.target.value);
-                      setParamDirty(true);
+                      allowTextRef.current = e.target.value;
+                      paramDirtyRef.current = true;
                     }}
                     onBlur={() => saveModelParamFilters()}
                     placeholder={t("compatAllowedParamsPlaceholder")}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -31,6 +31,29 @@ function recordToHeaderRows(rec: Record<string, string>, genId: () => string): H
 // payload that no longer matches what the user typed (#8910).
 const PARAM_SAVE_MAX_ATTEMPTS = 3;
 
+// Param filters are stored as one document per provider. Model rows render independent popover
+// instances, so their GET -> whole-document PUT transactions must share a provider-level queue;
+// instance-local saving refs cannot prevent sibling rows from overwriting each other's updates.
+const paramFilterSaveQueues = new Map<string, Promise<void>>();
+
+async function serializeProviderParamFilterSave<T>(
+  providerId: string,
+  save: () => Promise<T>
+): Promise<T> {
+  const previous = paramFilterSaveQueues.get(providerId) ?? Promise.resolve();
+  const result = previous.then(save);
+  const tail = result.then(
+    () => undefined,
+    () => undefined
+  );
+  paramFilterSaveQueues.set(providerId, tail);
+  try {
+    return await result;
+  } finally {
+    if (paramFilterSaveQueues.get(providerId) === tail) paramFilterSaveQueues.delete(providerId);
+  }
+}
+
 function parseCommaList(text: string): string[] {
   return text
     ? text
@@ -324,24 +347,28 @@ export default function ModelCompatPopover({
         const draft = paramDraftsRef.current.get(key);
         if (!draft) return true;
         try {
-          const res = await fetch(`/api/providers/${draft.providerId}/param-filters`);
-          if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
-          const current = await res.json();
-          // The fetched config belongs to draft.providerId; if the draft was replaced by a newer
-          // one for the same target while the GET was in flight, restart with a fresh read.
-          if (paramDraftsRef.current.get(key) !== draft) continue;
-          const payload = buildModelParamFilterPayload(
-            current,
-            draft.modelId,
-            draft.block,
-            draft.allow
-          );
-          const putRes = await fetch(`/api/providers/${draft.providerId}/param-filters`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload),
+          const wroteDraft = await serializeProviderParamFilterSave(draft.providerId, async () => {
+            const res = await fetch(`/api/providers/${draft.providerId}/param-filters`);
+            if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
+            const current = await res.json();
+            // The fetched config belongs to draft.providerId; if the draft was replaced by a newer
+            // one while the GET (or this instance's queue wait) was in flight, restart fresh.
+            if (paramDraftsRef.current.get(key) !== draft) return false;
+            const payload = buildModelParamFilterPayload(
+              current,
+              draft.modelId,
+              draft.block,
+              draft.allow
+            );
+            const putRes = await fetch(`/api/providers/${draft.providerId}/param-filters`, {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
+            return true;
           });
-          if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
+          if (!wroteDraft) continue;
           // Only the exact draft that was written may be discarded.
           if (paramDraftsRef.current.get(key) === draft) {
             paramDraftsRef.current.delete(key);

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -58,6 +58,10 @@ interface ParamFilterDraft {
   allow: string;
 }
 
+function paramTargetKeyOf(providerId: string, modelId: string): string {
+  return `${providerId}\u0000${modelId}`;
+}
+
 // Builds the PUT body for the model-level block/allow save. Extracted so the
 // caller's async handler stays simple — this is pure payload-shaping logic.
 function buildModelParamFilterPayload(
@@ -146,13 +150,17 @@ export default function ModelCompatPopover({
   // Param-filter drafts are mirrored into a ref so the close/unmount save path reads the
   // latest typed values instead of the values captured when the handler was created (#8910).
   const paramSavingRef = useRef(false);
-  // The single unsaved draft, together with the provider/model it was typed for. Non-null means
-  // "dirty". Recorded when the draft is edited — never derived from a completed load — so an
-  // unsaved draft is protected even when no load ever succeeded for that target, and every write
-  // lands on the draft's own target rather than whatever the popover currently points at (#8910).
-  const paramDraftRef = useRef<ParamFilterDraft | null>(null);
+  // Every unsaved draft, keyed by the provider/model it was typed for. A per-target map (rather
+  // than a single slot) is required because a live popover can be re-pointed at another target
+  // while a draft is still unsaved: with one slot the next keystroke on the new target destroyed
+  // the previous target's unsaved work, and the new target's successful save then cleared the
+  // failure indicator — a green UI over data that was never written, i.e. exactly the silent
+  // data loss reported in #8910. Drafts are recorded when edited — never derived from a completed
+  // load — so an unsaved draft survives even when no load ever succeeded for that target, and
+  // every write lands on the draft's own target rather than whatever the popover now points at.
+  const paramDraftsRef = useRef<Map<string, ParamFilterDraft>>(new Map());
 
-  const paramTargetKey = `${providerId}\u0000${modelId}`;
+  const paramTargetKey = paramTargetKeyOf(providerId, modelId);
   const paramTargetRef = useRef<{ key: string; providerId: string; modelId: string }>({
     key: paramTargetKey,
     providerId,
@@ -165,19 +173,44 @@ export default function ModelCompatPopover({
   const allowTextRef = useRef("");
   blockTextRef.current = blockText;
   allowTextRef.current = allowText;
+  // Which target the values currently in the fields belong to. Guards the invariant that
+  // blockTextRef/allowTextRef never hold content belonging to a target other than the one being
+  // displayed — the desync that let one model's server values be saved under another (#8910).
+  const fieldsTargetKeyRef = useRef<string | null>(null);
 
-  // Every edit replaces the draft with a fresh object bound to the CURRENT target. Object
-  // identity doubles as the draft revision an in-flight save compares against (#8910).
-  const markParamDraftDirty = useCallback(() => {
-    const target = paramTargetRef.current;
-    paramDraftRef.current = {
-      key: target.key,
-      providerId: target.providerId,
-      modelId: target.modelId,
-      block: blockTextRef.current,
-      allow: allowTextRef.current,
-    };
+  const applyParamFields = useCallback((targetKey: string, block: string, allow: string) => {
+    fieldsTargetKeyRef.current = targetKey;
+    blockTextRef.current = block;
+    allowTextRef.current = allow;
+    setBlockText(block);
+    setAllowText(allow);
   }, []);
+
+  // Every edit rewrites the draft for the CURRENT target. The counterpart field is only trusted
+  // when the values on screen belong to this target; otherwise it is taken from this target's own
+  // pending draft (or empty), so another target's value can never be captured into this draft and
+  // then persisted here (#8910). Object identity doubles as the draft revision an in-flight save
+  // compares against.
+  const editParamDraft = useCallback(
+    (field: "block" | "allow", value: string) => {
+      const target = paramTargetRef.current;
+      const fieldsOwned = fieldsTargetKeyRef.current === target.key;
+      const pending = paramDraftsRef.current.get(target.key);
+      const block =
+        field === "block" ? value : fieldsOwned ? blockTextRef.current : (pending?.block ?? "");
+      const allow =
+        field === "allow" ? value : fieldsOwned ? allowTextRef.current : (pending?.allow ?? "");
+      applyParamFields(target.key, block, allow);
+      paramDraftsRef.current.set(target.key, {
+        key: target.key,
+        providerId: target.providerId,
+        modelId: target.modelId,
+        block,
+        allow,
+      });
+    },
+    [applyParamFields]
+  );
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -228,12 +261,20 @@ export default function ModelCompatPopover({
   // Load model-level block/allow from param-filters API
   useEffect(() => {
     if (!open) return;
-    const draftKey = `${providerId}\u0000${modelId}`;
-    // A draft that is still dirty for this exact provider/model was never persisted (failed or
-    // exhausted save). Reloading server state here would silently revert it — the very complaint
-    // behind #8910 — so keep the draft on screen and let the user retry instead.
-    const draftIsDirtyForThisTarget = () => paramDraftRef.current?.key === draftKey;
-    if (draftIsDirtyForThisTarget()) return;
+    const draftKey = paramTargetKeyOf(providerId, modelId);
+    const draftForThisTarget = () => paramDraftsRef.current.get(draftKey);
+    // The fields must always show THIS target's content, and nothing else may ever be read back
+    // out of them. A draft that is still pending for this exact provider/model was never persisted
+    // (failed or exhausted save): restore it into the inputs instead of loading server state over
+    // it, because reloading here would silently revert it — the very complaint behind #8910.
+    const pending = draftForThisTarget();
+    if (pending) {
+      applyParamFields(draftKey, pending.block, pending.allow);
+      return;
+    }
+    // No draft for this target: drop whatever the previously displayed target left on screen so
+    // the fields can never present (or contribute) another target's values.
+    if (fieldsTargetKeyRef.current !== draftKey) applyParamFields(draftKey, "", "");
     let cancelled = false;
     (async () => {
       try {
@@ -243,14 +284,17 @@ export default function ModelCompatPopover({
         if (cancelled || !mountedRef.current) return;
         // Re-check after the await: the user may have typed while the GET was in flight, and a
         // load result must never overwrite (or acknowledge) a draft that is not on the server.
-        if (draftIsDirtyForThisTarget()) return;
+        if (draftForThisTarget()) return;
         const modelCfg = data?.models?.[modelId];
-        setBlockText(modelCfg ? (modelCfg.block ?? []).join(", ") : "");
-        setAllowText(modelCfg ? (modelCfg.allow ?? []).join(", ") : "");
-        // A load never clears the draft: any draft still pending here belongs to a DIFFERENT
+        applyParamFields(
+          draftKey,
+          modelCfg ? (modelCfg.block ?? []).join(", ") : "",
+          modelCfg ? (modelCfg.allow ?? []).join(", ") : ""
+        );
+        // A load never clears a draft: any draft still pending here belongs to a DIFFERENT
         // target and is still owed a write to that target (#8910). The failure indicator is
         // only cleared once nothing is left unsaved anywhere.
-        if (!paramDraftRef.current) setParamSaveFailed(false);
+        if (paramDraftsRef.current.size === 0) setParamSaveFailed(false);
       } catch {
         // Keep whatever the user has in the fields (and its dirty flag) on load failure.
       }
@@ -259,57 +303,68 @@ export default function ModelCompatPopover({
       cancelled = true;
     };
     // Reload only when opening or when the popover targets a different provider/model.
-  }, [open, providerId, modelId]);
+  }, [open, providerId, modelId, applyParamFields]);
 
-  // The save always writes through the draft's OWN provider/model — never the props this
-  // callback happens to be bound to — so a draft typed for target A can never be persisted under
-  // a target B the user never edited (#8910). The draft is re-read after every await for the same
-  // reason the load effect re-checks its guard: the target can change while the save is in flight.
+  // Drains EVERY pending draft, each written through its OWN provider/model — never the props this
+  // callback happens to be bound to — so a draft typed for target A can never be persisted under a
+  // target B the user never edited, and re-pointing the popover cannot destroy target A's unsaved
+  // work (#8910). Each draft is re-read after every await for the same reason the load effect
+  // re-checks its guard: the user can keep typing while a write is in flight.
   const saveModelParamFilters = useCallback(async () => {
-    if (!paramDraftRef.current || paramSavingRef.current) return;
+    if (paramDraftsRef.current.size === 0 || paramSavingRef.current) return;
     paramSavingRef.current = true;
     if (mountedRef.current) setParamSaving(true);
-    try {
+
+    // Returns true once nothing is owed for this target any more.
+    const saveDraftForTarget = async (key: string): Promise<boolean> => {
       // Re-run while the draft changed under the in-flight write: the payload is snapshotted
       // before the PUT resolves, so a keystroke landing in that window would otherwise be
-      // acknowledged (dirty cleared) but never persisted — the #8910 lost update.
+      // acknowledged (draft dropped) but never persisted — the #8910 lost update.
       for (let attempt = 0; attempt < PARAM_SAVE_MAX_ATTEMPTS; attempt += 1) {
-        const draft = paramDraftRef.current;
-        if (!draft) return;
-        const res = await fetch(`/api/providers/${draft.providerId}/param-filters`);
-        if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
-        const current = await res.json();
-        // The fetched config belongs to draft.providerId; if the draft was replaced by one for
-        // another provider/model while the GET was in flight, restart with a matching GET.
-        if (paramDraftRef.current?.key !== draft.key) continue;
-        const payload = buildModelParamFilterPayload(
-          current,
-          draft.modelId,
-          draft.block,
-          draft.allow
-        );
-        const putRes = await fetch(`/api/providers/${draft.providerId}/param-filters`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-        if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
-        // Only the exact draft that was written may clear the dirty flag.
-        if (paramDraftRef.current === draft) {
-          paramDraftRef.current = null;
-          if (mountedRef.current) setParamSaveFailed(false);
-          return;
+        const draft = paramDraftsRef.current.get(key);
+        if (!draft) return true;
+        try {
+          const res = await fetch(`/api/providers/${draft.providerId}/param-filters`);
+          if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
+          const current = await res.json();
+          // The fetched config belongs to draft.providerId; if the draft was replaced by a newer
+          // one for the same target while the GET was in flight, restart with a fresh read.
+          if (paramDraftsRef.current.get(key) !== draft) continue;
+          const payload = buildModelParamFilterPayload(
+            current,
+            draft.modelId,
+            draft.block,
+            draft.allow
+          );
+          const putRes = await fetch(`/api/providers/${draft.providerId}/param-filters`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
+          // Only the exact draft that was written may be discarded.
+          if (paramDraftsRef.current.get(key) === draft) {
+            paramDraftsRef.current.delete(key);
+            return true;
+          }
+        } catch {
+          // Save failed — the draft (and the target it belongs to) is intentionally preserved so
+          // the next blur/close/unmount save retries it against its own provider/model.
+          return false;
         }
       }
-      // Budget exhausted (the user is still typing): stay dirty and flag it, so the draft is
-      // kept on reopen and the next blur/close retries it.
-      if (mountedRef.current) setParamSaveFailed(true);
-    } catch {
-      // Save failed — the draft (and the target it belongs to) is intentionally preserved, and
-      // the failure is surfaced in the panel instead of being silently swallowed. An orphaned
-      // draft whose target is no longer displayed is neither dropped nor redirected: it keeps its
-      // own provider/model and is retried by the next blur/close/unmount save.
-      if (mountedRef.current) setParamSaveFailed(true);
+      // Budget exhausted (the user is still typing): stay dirty for this target.
+      return false;
+    };
+
+    try {
+      const failures: string[] = [];
+      for (const key of Array.from(paramDraftsRef.current.keys())) {
+        if (!(await saveDraftForTarget(key))) failures.push(key);
+      }
+      // The indicator tracks unsaved work across ALL targets: a successful write for the target
+      // now on screen must not signal "saved" while another target's draft is still owed a write.
+      if (mountedRef.current) setParamSaveFailed(failures.length > 0);
     } finally {
       paramSavingRef.current = false;
       if (mountedRef.current) setParamSaving(false);
@@ -482,11 +537,7 @@ export default function ModelCompatPopover({
                   <input
                     type="text"
                     value={blockText}
-                    onChange={(e) => {
-                      setBlockText(e.target.value);
-                      blockTextRef.current = e.target.value;
-                      markParamDraftDirty();
-                    }}
+                    onChange={(e) => editParamDraft("block", e.target.value)}
                     onBlur={() => saveModelParamFilters()}
                     placeholder={t("compatBlockedParamsPlaceholder")}
                     disabled={disabled}
@@ -510,11 +561,7 @@ export default function ModelCompatPopover({
                   <input
                     type="text"
                     value={allowText}
-                    onChange={(e) => {
-                      setAllowText(e.target.value);
-                      allowTextRef.current = e.target.value;
-                      markParamDraftDirty();
-                    }}
+                    onChange={(e) => editParamDraft("allow", e.target.value)}
                     onBlur={() => saveModelParamFilters()}
                     placeholder={t("compatAllowedParamsPlaceholder")}
                     disabled={disabled}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -47,6 +47,17 @@ interface ParamFilterConfigLike {
   autoLearn?: boolean;
 }
 
+// An unsaved param-filter draft, bound to the provider/model it was typed for. The save path
+// writes through THIS target instead of the props the callback happens to close over, so a draft
+// can never be persisted under a provider/model the user never edited (#8910).
+interface ParamFilterDraft {
+  key: string;
+  providerId: string;
+  modelId: string;
+  block: string;
+  allow: string;
+}
+
 // Builds the PUT body for the model-level block/allow save. Extracted so the
 // caller's async handler stays simple — this is pure payload-shaping logic.
 function buildModelParamFilterPayload(
@@ -132,30 +143,40 @@ export default function ModelCompatPopover({
   const headerRowsRef = useRef<HeaderDraftRow[]>([]);
   headerRowsRef.current = headerRows;
 
-  // Param-filter drafts are mirrored into refs so the close/unmount save path reads the
+  // Param-filter drafts are mirrored into a ref so the close/unmount save path reads the
   // latest typed values instead of the values captured when the handler was created (#8910).
-  const paramDirtyRef = useRef(false);
   const paramSavingRef = useRef(false);
-  // Monotonic draft revision — bumped on every edit so an in-flight save can tell whether the
-  // draft it snapshotted is still the newest one (#8910 lost update).
-  const paramRevRef = useRef(0);
-  // Provider/model the currently displayed draft belongs to. Recorded when the draft is marked
-  // dirty — never derived from a completed load — so an unsaved draft is protected even when no
-  // load ever succeeded for that target (slow or failing initial GET, #8910).
-  const paramDirtyKeyRef = useRef<string | null>(null);
+  // The single unsaved draft, together with the provider/model it was typed for. Non-null means
+  // "dirty". Recorded when the draft is edited — never derived from a completed load — so an
+  // unsaved draft is protected even when no load ever succeeded for that target, and every write
+  // lands on the draft's own target rather than whatever the popover currently points at (#8910).
+  const paramDraftRef = useRef<ParamFilterDraft | null>(null);
+
+  const paramTargetKey = `${providerId}\u0000${modelId}`;
+  const paramTargetRef = useRef<{ key: string; providerId: string; modelId: string }>({
+    key: paramTargetKey,
+    providerId,
+    modelId,
+  });
+  paramTargetRef.current = { key: paramTargetKey, providerId, modelId };
+
+  // Mirrors of the displayed text, so an edit can snapshot both fields synchronously.
   const blockTextRef = useRef("");
   const allowTextRef = useRef("");
   blockTextRef.current = blockText;
   allowTextRef.current = allowText;
 
-  const paramTargetKey = `${providerId}\u0000${modelId}`;
-  const paramTargetKeyRef = useRef(paramTargetKey);
-  paramTargetKeyRef.current = paramTargetKey;
-
+  // Every edit replaces the draft with a fresh object bound to the CURRENT target. Object
+  // identity doubles as the draft revision an in-flight save compares against (#8910).
   const markParamDraftDirty = useCallback(() => {
-    paramDirtyRef.current = true;
-    paramDirtyKeyRef.current = paramTargetKeyRef.current;
-    paramRevRef.current += 1;
+    const target = paramTargetRef.current;
+    paramDraftRef.current = {
+      key: target.key,
+      providerId: target.providerId,
+      modelId: target.modelId,
+      block: blockTextRef.current,
+      allow: allowTextRef.current,
+    };
   }, []);
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -211,8 +232,7 @@ export default function ModelCompatPopover({
     // A draft that is still dirty for this exact provider/model was never persisted (failed or
     // exhausted save). Reloading server state here would silently revert it — the very complaint
     // behind #8910 — so keep the draft on screen and let the user retry instead.
-    const draftIsDirtyForThisTarget = () =>
-      paramDirtyRef.current && paramDirtyKeyRef.current === draftKey;
+    const draftIsDirtyForThisTarget = () => paramDraftRef.current?.key === draftKey;
     if (draftIsDirtyForThisTarget()) return;
     let cancelled = false;
     (async () => {
@@ -227,11 +247,10 @@ export default function ModelCompatPopover({
         const modelCfg = data?.models?.[modelId];
         setBlockText(modelCfg ? (modelCfg.block ?? []).join(", ") : "");
         setAllowText(modelCfg ? (modelCfg.allow ?? []).join(", ") : "");
-        // Only the freshly loaded server state is clean — a failed load must not
-        // discard drafts the user already typed (#8910).
-        paramDirtyRef.current = false;
-        paramDirtyKeyRef.current = null;
-        setParamSaveFailed(false);
+        // A load never clears the draft: any draft still pending here belongs to a DIFFERENT
+        // target and is still owed a write to that target (#8910). The failure indicator is
+        // only cleared once nothing is left unsaved anywhere.
+        if (!paramDraftRef.current) setParamSaveFailed(false);
       } catch {
         // Keep whatever the user has in the fields (and its dirty flag) on load failure.
       }
@@ -242,8 +261,12 @@ export default function ModelCompatPopover({
     // Reload only when opening or when the popover targets a different provider/model.
   }, [open, providerId, modelId]);
 
+  // The save always writes through the draft's OWN provider/model — never the props this
+  // callback happens to be bound to — so a draft typed for target A can never be persisted under
+  // a target B the user never edited (#8910). The draft is re-read after every await for the same
+  // reason the load effect re-checks its guard: the target can change while the save is in flight.
   const saveModelParamFilters = useCallback(async () => {
-    if (!paramDirtyRef.current || paramSavingRef.current) return;
+    if (!paramDraftRef.current || paramSavingRef.current) return;
     paramSavingRef.current = true;
     if (mountedRef.current) setParamSaving(true);
     try {
@@ -251,26 +274,29 @@ export default function ModelCompatPopover({
       // before the PUT resolves, so a keystroke landing in that window would otherwise be
       // acknowledged (dirty cleared) but never persisted — the #8910 lost update.
       for (let attempt = 0; attempt < PARAM_SAVE_MAX_ATTEMPTS; attempt += 1) {
-        const rev = paramRevRef.current;
-        const res = await fetch(`/api/providers/${providerId}/param-filters`);
+        const draft = paramDraftRef.current;
+        if (!draft) return;
+        const res = await fetch(`/api/providers/${draft.providerId}/param-filters`);
         if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
         const current = await res.json();
+        // The fetched config belongs to draft.providerId; if the draft was replaced by one for
+        // another provider/model while the GET was in flight, restart with a matching GET.
+        if (paramDraftRef.current?.key !== draft.key) continue;
         const payload = buildModelParamFilterPayload(
           current,
-          modelId,
-          blockTextRef.current,
-          allowTextRef.current
+          draft.modelId,
+          draft.block,
+          draft.allow
         );
-        const putRes = await fetch(`/api/providers/${providerId}/param-filters`, {
+        const putRes = await fetch(`/api/providers/${draft.providerId}/param-filters`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         });
         if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
-        // Only the revision that was actually written may clear the dirty flag.
-        if (paramRevRef.current === rev) {
-          paramDirtyRef.current = false;
-          paramDirtyKeyRef.current = null;
+        // Only the exact draft that was written may clear the dirty flag.
+        if (paramDraftRef.current === draft) {
+          paramDraftRef.current = null;
           if (mountedRef.current) setParamSaveFailed(false);
           return;
         }
@@ -279,22 +305,25 @@ export default function ModelCompatPopover({
       // kept on reopen and the next blur/close retries it.
       if (mountedRef.current) setParamSaveFailed(true);
     } catch {
-      // Save failed — drafts and dirty state are intentionally preserved, and the failure is
-      // surfaced in the panel instead of being silently swallowed.
+      // Save failed — the draft (and the target it belongs to) is intentionally preserved, and
+      // the failure is surfaced in the panel instead of being silently swallowed. An orphaned
+      // draft whose target is no longer displayed is neither dropped nor redirected: it keeps its
+      // own provider/model and is retried by the next blur/close/unmount save.
       if (mountedRef.current) setParamSaveFailed(true);
     } finally {
       paramSavingRef.current = false;
       if (mountedRef.current) setParamSaving(false);
     }
-  }, [providerId, modelId]);
+  }, []);
 
-  // Persist pending param-filter drafts when the popover closes or unmounts (#8910).
+  // Persist pending param-filter drafts when the popover closes, unmounts, or is re-pointed at a
+  // different provider/model (#8910).
   useEffect(() => {
     if (!open) return;
     return () => {
       void saveModelParamFilters();
     };
-  }, [open, saveModelParamFilters]);
+  }, [open, paramTargetKey, saveModelParamFilters]);
 
   useEffect(() => {
     setValuePeekRowId(null);

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -139,16 +139,22 @@ export default function ModelCompatPopover({
   // Monotonic draft revision — bumped on every edit so an in-flight save can tell whether the
   // draft it snapshotted is still the newest one (#8910 lost update).
   const paramRevRef = useRef(0);
-  // Provider/model the currently displayed draft was loaded for, so a reopen of the same target
-  // does not clobber a draft that is still pending a (previously failed) save.
-  const paramLoadedKeyRef = useRef<string | null>(null);
+  // Provider/model the currently displayed draft belongs to. Recorded when the draft is marked
+  // dirty — never derived from a completed load — so an unsaved draft is protected even when no
+  // load ever succeeded for that target (slow or failing initial GET, #8910).
+  const paramDirtyKeyRef = useRef<string | null>(null);
   const blockTextRef = useRef("");
   const allowTextRef = useRef("");
   blockTextRef.current = blockText;
   allowTextRef.current = allowText;
 
+  const paramTargetKey = `${providerId}\u0000${modelId}`;
+  const paramTargetKeyRef = useRef(paramTargetKey);
+  paramTargetKeyRef.current = paramTargetKey;
+
   const markParamDraftDirty = useCallback(() => {
     paramDirtyRef.current = true;
+    paramDirtyKeyRef.current = paramTargetKeyRef.current;
     paramRevRef.current += 1;
   }, []);
   const mountedRef = useRef(true);
@@ -205,7 +211,9 @@ export default function ModelCompatPopover({
     // A draft that is still dirty for this exact provider/model was never persisted (failed or
     // exhausted save). Reloading server state here would silently revert it — the very complaint
     // behind #8910 — so keep the draft on screen and let the user retry instead.
-    if (paramDirtyRef.current && paramLoadedKeyRef.current === draftKey) return;
+    const draftIsDirtyForThisTarget = () =>
+      paramDirtyRef.current && paramDirtyKeyRef.current === draftKey;
+    if (draftIsDirtyForThisTarget()) return;
     let cancelled = false;
     (async () => {
       try {
@@ -213,13 +221,16 @@ export default function ModelCompatPopover({
         if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
         const data = await res.json();
         if (cancelled || !mountedRef.current) return;
+        // Re-check after the await: the user may have typed while the GET was in flight, and a
+        // load result must never overwrite (or acknowledge) a draft that is not on the server.
+        if (draftIsDirtyForThisTarget()) return;
         const modelCfg = data?.models?.[modelId];
         setBlockText(modelCfg ? (modelCfg.block ?? []).join(", ") : "");
         setAllowText(modelCfg ? (modelCfg.allow ?? []).join(", ") : "");
         // Only the freshly loaded server state is clean — a failed load must not
         // discard drafts the user already typed (#8910).
         paramDirtyRef.current = false;
-        paramLoadedKeyRef.current = draftKey;
+        paramDirtyKeyRef.current = null;
         setParamSaveFailed(false);
       } catch {
         // Keep whatever the user has in the fields (and its dirty flag) on load failure.
@@ -259,6 +270,7 @@ export default function ModelCompatPopover({
         // Only the revision that was actually written may clear the dirty flag.
         if (paramRevRef.current === rev) {
           paramDirtyRef.current = false;
+          paramDirtyKeyRef.current = null;
           if (mountedRef.current) setParamSaveFailed(false);
           return;
         }

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -358,13 +358,25 @@ export default function ModelCompatPopover({
     };
 
     try {
-      const failures: string[] = [];
-      for (const key of Array.from(paramDraftsRef.current.keys())) {
-        if (!(await saveDraftForTarget(key))) failures.push(key);
+      // Do not snapshot the keys once: a second target can become dirty while an earlier target's
+      // PUT is in flight. Keep selecting live drafts until only revisions that already failed in
+      // this drain remain. Remember the failed object (not just its key), so a newer edit for that
+      // target that lands while another request is pending still gets one save attempt.
+      const failedDrafts = new Map<string, ParamFilterDraft>();
+      while (true) {
+        const next = Array.from(paramDraftsRef.current.entries()).find(
+          ([key, draft]) => failedDrafts.get(key) !== draft
+        );
+        if (!next) break;
+        const [key] = next;
+        if (!(await saveDraftForTarget(key))) {
+          const failedDraft = paramDraftsRef.current.get(key);
+          if (failedDraft) failedDrafts.set(key, failedDraft);
+        }
       }
       // The indicator tracks unsaved work across ALL targets: a successful write for the target
       // now on screen must not signal "saved" while another target's draft is still owed a write.
-      if (mountedRef.current) setParamSaveFailed(failures.length > 0);
+      if (mountedRef.current) setParamSaveFailed(paramDraftsRef.current.size > 0);
     } finally {
       paramSavingRef.current = false;
       if (mountedRef.current) setParamSaving(false);

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -26,6 +26,11 @@ function recordToHeaderRows(rec: Record<string, string>, genId: () => string): H
   return entries.map(([name, value]) => ({ id: genId(), name, value }));
 }
 
+// Bounded re-run budget for the model param-filter save: if the draft changed while the PUT was
+// in flight, the save repeats with the newer draft instead of clearing the dirty flag on a
+// payload that no longer matches what the user typed (#8910).
+const PARAM_SAVE_MAX_ATTEMPTS = 3;
+
 function parseCommaList(text: string): string[] {
   return text
     ? text
@@ -112,6 +117,7 @@ export default function ModelCompatPopover({
   const [blockText, setBlockText] = useState("");
   const [allowText, setAllowText] = useState("");
   const [paramSaving, setParamSaving] = useState(false);
+  const [paramSaveFailed, setParamSaveFailed] = useState(false);
   const [valuePeekRowId, setValuePeekRowId] = useState<string | null>(null);
   const [valueFocusRowId, setValueFocusRowId] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -130,10 +136,21 @@ export default function ModelCompatPopover({
   // latest typed values instead of the values captured when the handler was created (#8910).
   const paramDirtyRef = useRef(false);
   const paramSavingRef = useRef(false);
+  // Monotonic draft revision — bumped on every edit so an in-flight save can tell whether the
+  // draft it snapshotted is still the newest one (#8910 lost update).
+  const paramRevRef = useRef(0);
+  // Provider/model the currently displayed draft was loaded for, so a reopen of the same target
+  // does not clobber a draft that is still pending a (previously failed) save.
+  const paramLoadedKeyRef = useRef<string | null>(null);
   const blockTextRef = useRef("");
   const allowTextRef = useRef("");
   blockTextRef.current = blockText;
   allowTextRef.current = allowText;
+
+  const markParamDraftDirty = useCallback(() => {
+    paramDirtyRef.current = true;
+    paramRevRef.current += 1;
+  }, []);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -184,6 +201,11 @@ export default function ModelCompatPopover({
   // Load model-level block/allow from param-filters API
   useEffect(() => {
     if (!open) return;
+    const draftKey = `${providerId}\u0000${modelId}`;
+    // A draft that is still dirty for this exact provider/model was never persisted (failed or
+    // exhausted save). Reloading server state here would silently revert it — the very complaint
+    // behind #8910 — so keep the draft on screen and let the user retry instead.
+    if (paramDirtyRef.current && paramLoadedKeyRef.current === draftKey) return;
     let cancelled = false;
     (async () => {
       try {
@@ -197,6 +219,8 @@ export default function ModelCompatPopover({
         // Only the freshly loaded server state is clean — a failed load must not
         // discard drafts the user already typed (#8910).
         paramDirtyRef.current = false;
+        paramLoadedKeyRef.current = draftKey;
+        setParamSaveFailed(false);
       } catch {
         // Keep whatever the user has in the fields (and its dirty flag) on load failure.
       }
@@ -212,25 +236,40 @@ export default function ModelCompatPopover({
     paramSavingRef.current = true;
     if (mountedRef.current) setParamSaving(true);
     try {
-      const res = await fetch(`/api/providers/${providerId}/param-filters`);
-      if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
-      const current = await res.json();
-      const payload = buildModelParamFilterPayload(
-        current,
-        modelId,
-        blockTextRef.current,
-        allowTextRef.current
-      );
-      const putRes = await fetch(`/api/providers/${providerId}/param-filters`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
-      // Stay dirty unless the write actually succeeded, so a later close can retry.
-      paramDirtyRef.current = false;
+      // Re-run while the draft changed under the in-flight write: the payload is snapshotted
+      // before the PUT resolves, so a keystroke landing in that window would otherwise be
+      // acknowledged (dirty cleared) but never persisted — the #8910 lost update.
+      for (let attempt = 0; attempt < PARAM_SAVE_MAX_ATTEMPTS; attempt += 1) {
+        const rev = paramRevRef.current;
+        const res = await fetch(`/api/providers/${providerId}/param-filters`);
+        if (!res.ok) throw new Error(`param-filters GET failed: ${res.status}`);
+        const current = await res.json();
+        const payload = buildModelParamFilterPayload(
+          current,
+          modelId,
+          blockTextRef.current,
+          allowTextRef.current
+        );
+        const putRes = await fetch(`/api/providers/${providerId}/param-filters`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!putRes.ok) throw new Error(`param-filters PUT failed: ${putRes.status}`);
+        // Only the revision that was actually written may clear the dirty flag.
+        if (paramRevRef.current === rev) {
+          paramDirtyRef.current = false;
+          if (mountedRef.current) setParamSaveFailed(false);
+          return;
+        }
+      }
+      // Budget exhausted (the user is still typing): stay dirty and flag it, so the draft is
+      // kept on reopen and the next blur/close retries it.
+      if (mountedRef.current) setParamSaveFailed(true);
     } catch {
-      // Save failed — drafts and dirty state are intentionally preserved.
+      // Save failed — drafts and dirty state are intentionally preserved, and the failure is
+      // surfaced in the panel instead of being silently swallowed.
+      if (mountedRef.current) setParamSaveFailed(true);
     } finally {
       paramSavingRef.current = false;
       if (mountedRef.current) setParamSaving(false);
@@ -405,7 +444,7 @@ export default function ModelCompatPopover({
                     onChange={(e) => {
                       setBlockText(e.target.value);
                       blockTextRef.current = e.target.value;
-                      paramDirtyRef.current = true;
+                      markParamDraftDirty();
                     }}
                     onBlur={() => saveModelParamFilters()}
                     placeholder={t("compatBlockedParamsPlaceholder")}
@@ -415,6 +454,15 @@ export default function ModelCompatPopover({
                   <p className="text-[10px] text-text-muted">
                     {t("compatBlockedParamsHint") ?? "Blocked params (stripped from requests)"}
                     {paramSaving && ` ● ${t("compatSaving")}`}
+                    {paramSaveFailed && !paramSaving && (
+                      <span
+                        role="alert"
+                        className="ml-1 font-medium text-red-600 dark:text-red-400"
+                        title={t("failedSaveConnectionRetry")}
+                      >
+                        ● {t("failed")}
+                      </span>
+                    )}
                   </p>
                 </div>
                 <div>
@@ -424,7 +472,7 @@ export default function ModelCompatPopover({
                     onChange={(e) => {
                       setAllowText(e.target.value);
                       allowTextRef.current = e.target.value;
-                      paramDirtyRef.current = true;
+                      markParamDraftDirty();
                     }}
                     onBlur={() => saveModelParamFilters()}
                     placeholder={t("compatAllowedParamsPlaceholder")}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-concurrency.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-concurrency.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+// Regression coverage for the concurrency defects found while fixing #8910:
+//   1. an edit landing after the PUT payload snapshot but before the PUT resolves must still
+//      be persisted (lost update);
+//   2. a save that failed must not be silently reverted on reopen, and the failure must be
+//      visible in the panel.
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+interface ParamFilterState {
+  block: string[];
+  allow: string[];
+  models?: Record<string, { block: string[]; allow: string[] }>;
+  autoLearn: boolean;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects() {
+  await act(async () => {
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+  });
+}
+
+function blockInput() {
+  return document.querySelector(
+    'input[placeholder="compatBlockedParamsPlaceholder"]'
+  ) as HTMLInputElement | null;
+}
+
+function renderPopover() {
+  act(() => {
+    root.render(
+      <ModelCompatPopover
+        t={(key) => key}
+        providerId="openai"
+        modelId="gpt-test"
+        effectiveModelNormalize={() => false}
+        effectiveModelPreserveDeveloper={() => true}
+        getUpstreamHeadersRecord={() => ({})}
+        onCompatPatch={vi.fn()}
+      />
+    );
+  });
+}
+
+async function openPopover() {
+  const trigger = container.querySelector("button") as HTMLButtonElement;
+  await act(async () => trigger.click());
+  await flushEffects();
+}
+
+async function closePopoverByOutsideClick() {
+  await act(async () => {
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  });
+  await flushEffects();
+}
+
+describe("ModelCompatPopover param-filter save concurrency (#8910)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("persists an edit typed after the payload snapshot but before the PUT resolves", async () => {
+    let serverState: ParamFilterState = { block: [], allow: [], models: {}, autoLearn: false };
+    let releasePut: (() => void) | null = null;
+    let holdPut = false;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          serverState = JSON.parse(String(init.body)) as ParamFilterState;
+          if (holdPut) {
+            await new Promise<void>((resolve) => {
+              releasePut = resolve;
+            });
+          }
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        return { ok: true, json: async () => structuredClone(serverState) } as Response;
+      })
+    );
+
+    renderPopover();
+    await openPopover();
+
+    await act(async () => setInputValue(blockInput()!, "temperature"));
+    holdPut = true;
+    // Blur starts the save: GET resolves, payload is snapshotted, PUT is issued and held open.
+    await act(async () => {
+      blockInput()!.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+    await flushEffects();
+    expect(releasePut).not.toBeNull();
+
+    // The user keeps typing while that PUT is still in flight, then closes the popover.
+    await act(async () => setInputValue(blockInput()!, "temperature, seed"));
+    await closePopoverByOutsideClick();
+
+    holdPut = false;
+    await act(async () => {
+      releasePut?.();
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    expect(serverState.models).toEqual({
+      "gpt-test": { block: ["temperature", "seed"], allow: [] },
+    });
+  });
+
+  it("keeps the draft and surfaces the failure when the save fails, instead of reverting on reopen", async () => {
+    const serverState: ParamFilterState = { block: [], allow: [], models: {}, autoLearn: false };
+    let putAttempts = 0;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          putAttempts += 1;
+          return { ok: false, status: 500, json: async () => ({}) } as Response;
+        }
+        return { ok: true, json: async () => structuredClone(serverState) } as Response;
+      })
+    );
+
+    renderPopover();
+    await openPopover();
+
+    await act(async () => setInputValue(blockInput()!, "temperature"));
+    await closePopoverByOutsideClick();
+    expect(putAttempts).toBe(1);
+
+    // Reopening must NOT clobber the unsaved draft with server state (#8910 complaint class).
+    await openPopover();
+    expect(blockInput()!.value).toBe("temperature");
+    // The failure is visible to the user rather than silently swallowed.
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain("failed");
+
+    // ...and the retained draft is actually retryable through the normal close path.
+    await closePopoverByOutsideClick();
+    expect(putAttempts).toBe(2);
+  });
+
+  it("clears the failure indicator once a later save succeeds", async () => {
+    let serverState: ParamFilterState = { block: [], allow: [], models: {}, autoLearn: false };
+    let failNextPut = true;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          if (failNextPut) return { ok: false, status: 500, json: async () => ({}) } as Response;
+          serverState = JSON.parse(String(init.body)) as ParamFilterState;
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        return { ok: true, json: async () => structuredClone(serverState) } as Response;
+      })
+    );
+
+    renderPopover();
+    await openPopover();
+    await act(async () => setInputValue(blockInput()!, "temperature"));
+    await act(async () => {
+      blockInput()!.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+    await flushEffects();
+    expect(document.querySelector('[role="alert"]')).not.toBeNull();
+
+    failNextPut = false;
+    await act(async () => setInputValue(blockInput()!, "temperature, seed"));
+    await act(async () => {
+      blockInput()!.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+    await flushEffects();
+
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+    expect(serverState.models).toEqual({
+      "gpt-test": { block: ["temperature", "seed"], allow: [] },
+    });
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-cross-instance.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-cross-instance.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+// Regression coverage for #8910: sibling model-row popovers for the same provider must serialize
+// their whole-document param-filter updates so one successful save cannot erase the other.
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+
+type ParamFilterState = {
+  block: string[];
+  allow: string[];
+  models?: Record<string, { block: string[]; allow: string[] }>;
+  autoLearn: boolean;
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let releaseFirstPut: (() => void) | null;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects(rounds = 60) {
+  await act(async () => {
+    for (let i = 0; i < rounds; i += 1) await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  releaseFirstPut = null;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    releaseFirstPut?.();
+    await Promise.resolve();
+  });
+  act(() => root.unmount());
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+it("preserves both model updates when sibling popovers save the same provider concurrently", async () => {
+  let server: ParamFilterState = { block: [], allow: [], models: {}, autoLearn: false };
+  let putCount = 0;
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        putCount += 1;
+        const body = JSON.parse(String(init.body)) as ParamFilterState;
+        if (putCount === 1) {
+          await new Promise<void>((resolve) => {
+            releaseFirstPut = resolve;
+          });
+        }
+        server = { ...body, models: body.models ?? {} };
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+      return { ok: true, json: async () => structuredClone(server) } as Response;
+    })
+  );
+
+  const props = (modelId: string) => ({
+    t: (key: string) => key,
+    providerId: "openai",
+    modelId,
+    effectiveModelNormalize: () => false,
+    effectiveModelPreserveDeveloper: () => true,
+    getUpstreamHeadersRecord: () => ({}),
+    onCompatPatch: vi.fn(),
+  });
+
+  act(() => {
+    root.render(
+      <div>
+        <div id="model-a">
+          <ModelCompatPopover {...props("model-a")} />
+        </div>
+        <div id="model-b">
+          <ModelCompatPopover {...props("model-b")} />
+        </div>
+      </div>
+    );
+  });
+
+  const triggerA = container.querySelector("#model-a button") as HTMLButtonElement;
+  const triggerB = container.querySelector("#model-b button") as HTMLButtonElement;
+  const blockInput = () =>
+    document.querySelector(
+      'input[placeholder="compatBlockedParamsPlaceholder"]'
+    ) as HTMLInputElement;
+
+  await act(async () => triggerA.click());
+  await flushEffects();
+  await act(async () => setInputValue(blockInput(), "aaa"));
+  await act(async () => {
+    blockInput().dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+  await flushEffects();
+  expect(releaseFirstPut).not.toBeNull();
+
+  await act(async () => {
+    triggerB.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  });
+  await flushEffects();
+  await act(async () => triggerB.click());
+  await flushEffects();
+  await act(async () => setInputValue(blockInput(), "bbb"));
+  await act(async () => {
+    blockInput().dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+  await flushEffects();
+
+  await act(async () => {
+    releaseFirstPut?.();
+    await Promise.resolve();
+  });
+  await flushEffects();
+
+  expect(server.models).toEqual({
+    "model-a": { block: ["aaa"], allow: [] },
+    "model-b": { block: ["bbb"], allow: [] },
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-cross-target.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-cross-target.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+// Regression coverage for the cross-target write defect found while fixing #8910.
+//
+// ModelCompatPopover instances are not always keyed by a stable identity (CompatibleModelsSection
+// keys by `${alias}:${modelId}`, PassthroughModelsSection by the full model string, and providerId
+// is threaded from route/page state), so a re-render can re-point a LIVE, mounted popover at a
+// different provider/model. When the draft for the old target failed to save, the save callback —
+// now bound to the new target — used to PUT the old draft into the new target's config,
+// destructively overwriting a model/provider the user never edited.
+//
+// Contract asserted here: a write always lands on the provider/model the draft was typed for, and
+// an orphaned draft whose target is no longer displayed is preserved (retried later) rather than
+// silently dropped or redirected.
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+interface ParamFilterState {
+  block: string[];
+  allow: string[];
+  models: Record<string, { block: string[]; allow: string[] }>;
+  autoLearn: boolean;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects(rounds = 40) {
+  await act(async () => {
+    for (let i = 0; i < rounds; i += 1) await Promise.resolve();
+  });
+}
+
+function blockInput() {
+  return document.querySelector(
+    'input[placeholder="compatBlockedParamsPlaceholder"]'
+  ) as HTMLInputElement | null;
+}
+
+function renderPopover(props: { providerId: string; modelId: string }) {
+  act(() => {
+    root.render(
+      <ModelCompatPopover
+        t={(key) => key}
+        providerId={props.providerId}
+        modelId={props.modelId}
+        effectiveModelNormalize={() => false}
+        effectiveModelPreserveDeveloper={() => true}
+        getUpstreamHeadersRecord={() => ({})}
+        onCompatPatch={vi.fn()}
+      />
+    );
+  });
+}
+
+async function openPopover() {
+  const trigger = container.querySelector("button") as HTMLButtonElement;
+  await act(async () => trigger.click());
+  await flushEffects();
+}
+
+async function closePopoverByOutsideClick() {
+  await act(async () => {
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  });
+  await flushEffects();
+}
+
+describe("ModelCompatPopover param-filter cross-target writes (#8910)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    try {
+      act(() => root.unmount());
+    } catch {
+      // already unmounted by the test
+    }
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("never writes a draft typed for one model under a different model", async () => {
+    const server: ParamFilterState = {
+      block: [],
+      allow: [],
+      models: { "model-b": { block: ["bval"], allow: [] } },
+      autoLearn: false,
+    };
+    const puts: { url: string; models?: Record<string, unknown> }[] = [];
+    let getFails = true;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "PUT") {
+          const body = JSON.parse(String(init.body));
+          puts.push({ url, models: body.models });
+          server.models = body.models ?? {};
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        if (getFails) return { ok: false, status: 503, json: async () => ({}) } as Response;
+        return { ok: true, json: async () => structuredClone(server) } as Response;
+      })
+    );
+
+    renderPopover({ providerId: "openai", modelId: "model-a" });
+    await openPopover();
+    // The load failed, so the fields are empty; the user types a draft for model-a.
+    await act(async () => setInputValue(blockInput()!, "aaa"));
+
+    // A re-render re-points this live popover at model-b while model-a's draft is still dirty.
+    // The close-time save for model-a runs here and fails (its GET is still 503).
+    renderPopover({ providerId: "openai", modelId: "model-b" });
+    await flushEffects();
+
+    // The network recovers and the popover closes: the retried save must target model-a.
+    getFails = false;
+    await closePopoverByOutsideClick();
+
+    // model-b's real server config is untouched...
+    expect(server.models["model-b"]).toEqual({ block: ["bval"], allow: [] });
+    // ...and the orphaned model-a draft is not silently dropped either — it lands on model-a.
+    expect(server.models["model-a"]).toEqual({ block: ["aaa"], allow: [] });
+    expect(puts.every((p) => p.url.includes("/openai/"))).toBe(true);
+  });
+
+  it("never writes a draft typed for one provider under a different provider", async () => {
+    const byProvider: Record<string, ParamFilterState> = {
+      alpha: { block: [], allow: [], models: {}, autoLearn: false },
+      beta: {
+        block: [],
+        allow: [],
+        models: { "gpt-test": { block: ["betaval"], allow: [] } },
+        autoLearn: false,
+      },
+    };
+    const puts: { providerId: string; models?: Record<string, unknown> }[] = [];
+    let getFails = true;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const providerId = url.match(/providers\/([^/]+)\//)![1];
+        if (init?.method === "PUT") {
+          const body = JSON.parse(String(init.body));
+          puts.push({ providerId, models: body.models });
+          byProvider[providerId].models = body.models ?? {};
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        if (getFails) return { ok: false, status: 503, json: async () => ({}) } as Response;
+        return { ok: true, json: async () => structuredClone(byProvider[providerId]) } as Response;
+      })
+    );
+
+    renderPopover({ providerId: "alpha", modelId: "gpt-test" });
+    await openPopover();
+    await act(async () => setInputValue(blockInput()!, "alpha-only"));
+
+    // Re-point the live popover at provider beta while alpha's draft is dirty and its save fails.
+    renderPopover({ providerId: "beta", modelId: "gpt-test" });
+    await flushEffects();
+
+    getFails = false;
+    await closePopoverByOutsideClick();
+
+    // beta must receive no write at all; its stored config survives intact.
+    expect(puts.filter((p) => p.providerId === "beta")).toEqual([]);
+    expect(byProvider.beta.models).toEqual({ "gpt-test": { block: ["betaval"], allow: [] } });
+    // The alpha draft is preserved and eventually persisted under alpha.
+    expect(byProvider.alpha.models).toEqual({ "gpt-test": { block: ["alpha-only"], allow: [] } });
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-load-clobber.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-load-clobber.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+// Regression coverage for the load-effect clobber defects found while fixing #8910:
+//   1. a draft typed while the initial load GET is still in flight must survive the load
+//      result and still be persisted on close (otherwise keystrokes vanish silently);
+//   2. after a failed initial load, the retained draft must not be destroyed by the next
+//      successful reopen load — that reopen is the user's retry.
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+interface ParamFilterState {
+  block: string[];
+  allow: string[];
+  models?: Record<string, { block: string[]; allow: string[] }>;
+  autoLearn: boolean;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects(rounds = 12) {
+  await act(async () => {
+    for (let i = 0; i < rounds; i += 1) await Promise.resolve();
+  });
+}
+
+function blockInput() {
+  return document.querySelector(
+    'input[placeholder="compatBlockedParamsPlaceholder"]'
+  ) as HTMLInputElement | null;
+}
+
+function renderPopover() {
+  act(() => {
+    root.render(
+      <ModelCompatPopover
+        t={(key) => key}
+        providerId="openai"
+        modelId="gpt-test"
+        effectiveModelNormalize={() => false}
+        effectiveModelPreserveDeveloper={() => true}
+        getUpstreamHeadersRecord={() => ({})}
+        onCompatPatch={vi.fn()}
+      />
+    );
+  });
+}
+
+async function openPopover() {
+  const trigger = container.querySelector("button") as HTMLButtonElement;
+  await act(async () => trigger.click());
+  await flushEffects();
+}
+
+async function closePopoverByOutsideClick() {
+  await act(async () => {
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  });
+  await flushEffects();
+}
+
+describe("ModelCompatPopover param-filter load clobber (#8910)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    try {
+      act(() => root.unmount());
+    } catch {
+      // already unmounted by the test
+    }
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps and saves a draft typed while the initial load GET is still in flight", async () => {
+    const serverState: ParamFilterState = {
+      block: [],
+      allow: [],
+      models: { "gpt-test": { block: ["old"], allow: [] } },
+      autoLearn: false,
+    };
+    const puts: ParamFilterState[] = [];
+    let releaseGet: (() => void) | null = null;
+    let heldFirstGet = false;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          puts.push(JSON.parse(String(init.body)) as ParamFilterState);
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        if (!heldFirstGet) {
+          heldFirstGet = true;
+          await new Promise<void>((resolve) => {
+            releaseGet = resolve;
+          });
+        }
+        return { ok: true, json: async () => structuredClone(serverState) } as Response;
+      })
+    );
+
+    renderPopover();
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => trigger.click());
+    await flushEffects();
+
+    // The field is already rendered while the load GET is still pending — the user types into it.
+    await act(async () => setInputValue(blockInput()!, "temperature"));
+    await act(async () => {
+      releaseGet?.();
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    // The load result must not overwrite the dirty draft.
+    expect(blockInput()!.value).toBe("temperature");
+
+    await closePopoverByOutsideClick();
+
+    expect(puts.length).toBe(1);
+    expect(puts[0]?.models).toEqual({ "gpt-test": { block: ["temperature"], allow: [] } });
+  });
+
+  it("does not clobber a retained draft with the successful reopen load after a failed initial load", async () => {
+    const serverState: ParamFilterState = {
+      block: [],
+      allow: [],
+      models: { "gpt-test": { block: ["serverval"], allow: [] } },
+      autoLearn: false,
+    };
+    const puts: ParamFilterState[] = [];
+    let failGet = true;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          puts.push(JSON.parse(String(init.body)) as ParamFilterState);
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        if (failGet) return { ok: false, status: 503, json: async () => ({}) } as Response;
+        return { ok: true, json: async () => structuredClone(serverState) } as Response;
+      })
+    );
+
+    renderPopover();
+    // First open: the load GET fails, so nothing is loaded and the field stays empty.
+    await openPopover();
+    expect(blockInput()!.value).toBe("");
+
+    await act(async () => setInputValue(blockInput()!, "temperature"));
+    // Close: the save's own GET still fails, so the draft is retained and flagged as failed.
+    await closePopoverByOutsideClick();
+    expect(puts.length).toBe(0);
+
+    // The network recovers and the user reopens the popover to retry the save.
+    failGet = false;
+    await openPopover();
+    expect(blockInput()!.value).toBe("temperature");
+    // The unsaved-state indicator must still be visible — nothing was persisted.
+    expect(document.querySelector('[role="alert"]')).not.toBeNull();
+
+    await closePopoverByOutsideClick();
+    expect(puts.length).toBe(1);
+    expect(puts[0]?.models).toEqual({ "gpt-test": { block: ["temperature"], allow: [] } });
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-new-target.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-new-target.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects(rounds = 40) {
+  await act(async () => {
+    for (let i = 0; i < rounds; i += 1) await Promise.resolve();
+  });
+}
+
+it("O5 preserves a new target edited while the older target save is in flight", async () => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  let server = {
+    block: [] as string[],
+    allow: [] as string[],
+    models: {} as Record<string, { block: string[]; allow: string[] }>,
+    autoLearn: false,
+  };
+  let releaseFirstPut: (() => void) | null = null;
+  let putCount = 0;
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        putCount += 1;
+        const body = JSON.parse(String(init.body)) as typeof server;
+        if (putCount === 1) {
+          await new Promise<void>((resolve) => {
+            releaseFirstPut = resolve;
+          });
+        }
+        server = body;
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+      return { ok: true, json: async () => structuredClone(server) } as Response;
+    })
+  );
+
+  const renderFor = (modelId: string) => {
+    act(() => {
+      root.render(
+        <ModelCompatPopover
+          t={(key) => key}
+          providerId="openai"
+          modelId={modelId}
+          effectiveModelNormalize={() => false}
+          effectiveModelPreserveDeveloper={() => true}
+          getUpstreamHeadersRecord={() => ({})}
+          onCompatPatch={vi.fn()}
+        />
+      );
+    });
+  };
+  const blockInput = () =>
+    document.querySelector(
+      'input[placeholder="compatBlockedParamsPlaceholder"]'
+    ) as HTMLInputElement;
+  const blurBlock = async () => {
+    await act(async () => {
+      blockInput().dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+    await flushEffects();
+  };
+
+  renderFor("model-a");
+  await act(async () => (container.querySelector("button") as HTMLButtonElement).click());
+  await flushEffects();
+  await act(async () => setInputValue(blockInput(), "aaa"));
+  await blurBlock();
+  expect(releaseFirstPut).not.toBeNull();
+
+  renderFor("model-b");
+  await flushEffects();
+  expect(blockInput().value).toBe("");
+  await act(async () => setInputValue(blockInput(), "bbb"));
+  await blurBlock();
+
+  await act(async () => {
+    releaseFirstPut?.();
+    await Promise.resolve();
+  });
+  await flushEffects();
+
+  expect(server.models).toEqual({
+    "model-a": { block: ["aaa"], allow: [] },
+    "model-b": { block: ["bbb"], allow: [] },
+  });
+  expect(document.querySelector('[role="alert"]')).toBeNull();
+
+  act(() => root.unmount());
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-new-target.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-new-target.test.tsx
@@ -18,7 +18,7 @@ async function flushEffects(rounds = 40) {
   });
 }
 
-it("O5 preserves a new target edited while the older target save is in flight", async () => {
+it("preserves a new target edited while the older target save is in flight", async () => {
   (
     globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
   ).IS_REACT_ACT_ENVIRONMENT = true;

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-unmount.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-unmount.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects(rounds = 40) {
+  await act(async () => {
+    for (let i = 0; i < rounds; i += 1) await Promise.resolve();
+  });
+}
+
+it("O5 does not lose the new target when unmounted during the older target save", async () => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  let server = {
+    block: [] as string[],
+    allow: [] as string[],
+    models: {} as Record<string, { block: string[]; allow: string[] }>,
+    autoLearn: false,
+  };
+  let releaseFirstPut: (() => void) | null = null;
+  let putCount = 0;
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        putCount += 1;
+        const body = JSON.parse(String(init.body)) as typeof server;
+        if (putCount === 1) {
+          await new Promise<void>((resolve) => {
+            releaseFirstPut = resolve;
+          });
+        }
+        server = body;
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+      return { ok: true, json: async () => structuredClone(server) } as Response;
+    })
+  );
+
+  const renderFor = (modelId: string) => {
+    act(() => {
+      root.render(
+        <ModelCompatPopover
+          t={(key) => key}
+          providerId="openai"
+          modelId={modelId}
+          effectiveModelNormalize={() => false}
+          effectiveModelPreserveDeveloper={() => true}
+          getUpstreamHeadersRecord={() => ({})}
+          onCompatPatch={vi.fn()}
+        />
+      );
+    });
+  };
+  const blockInput = () =>
+    document.querySelector(
+      'input[placeholder="compatBlockedParamsPlaceholder"]'
+    ) as HTMLInputElement;
+  const blurBlock = async () => {
+    await act(async () => {
+      blockInput().dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+    await flushEffects();
+  };
+
+  renderFor("model-a");
+  await act(async () => (container.querySelector("button") as HTMLButtonElement).click());
+  await flushEffects();
+  await act(async () => setInputValue(blockInput(), "aaa"));
+  await blurBlock();
+  expect(releaseFirstPut).not.toBeNull();
+
+  renderFor("model-b");
+  await flushEffects();
+  await act(async () => setInputValue(blockInput(), "bbb"));
+  await blurBlock();
+
+  // Every close/unmount save is rejected while model-a owns paramSavingRef. The active save took
+  // its key snapshot before model-b existed, so model-b has no later save scheduled.
+  act(() => root.unmount());
+  await act(async () => {
+    releaseFirstPut?.();
+    await Promise.resolve();
+  });
+  await flushEffects();
+  console.log("O5 server after unmount:", JSON.stringify(server.models), "PUTs:", putCount);
+
+  expect(server.models).toEqual({
+    "model-a": { block: ["aaa"], allow: [] },
+    "model-b": { block: ["bbb"], allow: [] },
+  });
+
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-unmount.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-midflight-unmount.test.tsx
@@ -18,7 +18,7 @@ async function flushEffects(rounds = 40) {
   });
 }
 
-it("O5 does not lose the new target when unmounted during the older target save", async () => {
+it("does not lose the new target when unmounted during the older target save", async () => {
   (
     globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
   ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -98,7 +98,7 @@ it("O5 does not lose the new target when unmounted during the older target save"
     await Promise.resolve();
   });
   await flushEffects();
-  console.log("O5 server after unmount:", JSON.stringify(server.models), "PUTs:", putCount);
+
 
   expect(server.models).toEqual({
     "model-a": { block: ["aaa"], allow: [] },

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-target-repoint.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filter-target-repoint.test.tsx
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+// Regression coverage for the two target-re-point defects found while fixing #8910.
+//
+// A ModelCompatPopover instance is not always keyed by a stable identity, so a re-render can
+// re-point a LIVE, still-open popover at a different provider/model while a draft for the previous
+// target is unsaved. Two failures followed from that:
+//
+//   1. (C10) The inputs are driven by blockText/allowText, which used to be written only by the
+//      load effect — and that effect early-returned whenever a draft was dirty. Re-pointing
+//      A -> B -> A therefore left B's server values on screen under A, and the next keystroke
+//      snapshotted them into A's draft, persisting B's content into A's entry.
+//   2. (C11) The pending draft lived in a single slot that every edit overwrote, so typing into
+//      the new target destroyed the previous target's unsaved work, and the new target's
+//      successful save cleared the failure indicator — a green UI over data never written.
+//
+// Contract asserted here: the fields always show the displayed target's own content (its pending
+// draft when it has one), never another target's; and every target's unsaved draft survives until
+// it is actually persisted to its own provider/model.
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+interface ParamFilterState {
+  block: string[];
+  allow: string[];
+  models: Record<string, { block: string[]; allow: string[] }>;
+  autoLearn: boolean;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects(rounds = 40) {
+  await act(async () => {
+    for (let i = 0; i < rounds; i += 1) await Promise.resolve();
+  });
+}
+
+function blockInput() {
+  return document.querySelector(
+    'input[placeholder="compatBlockedParamsPlaceholder"]'
+  ) as HTMLInputElement | null;
+}
+
+function renderPopover(modelId: string) {
+  act(() => {
+    root.render(
+      <ModelCompatPopover
+        t={(key) => key}
+        providerId="openai"
+        modelId={modelId}
+        effectiveModelNormalize={() => false}
+        effectiveModelPreserveDeveloper={() => true}
+        getUpstreamHeadersRecord={() => ({})}
+        onCompatPatch={vi.fn()}
+      />
+    );
+  });
+}
+
+// React 19 delegates onBlur through focusout — a bare "blur" event does not reach the handler.
+async function blurBlockInput() {
+  await act(async () => {
+    blockInput()!.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+  await flushEffects();
+}
+
+describe("ModelCompatPopover param-filter target re-point (#8910)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    try {
+      act(() => root.unmount());
+    } catch {
+      // already unmounted by the test
+    }
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("restores the dirty draft into the fields on return, instead of showing the other model's values", async () => {
+    const server: ParamFilterState = {
+      block: [],
+      allow: [],
+      models: { "model-b": { block: ["secret-b"], allow: [] } },
+      autoLearn: false,
+    };
+    let putFails = true;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          if (putFails) return { ok: false, status: 500, json: async () => ({}) } as Response;
+          const body = JSON.parse(String(init.body));
+          server.models = body.models ?? {};
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        return { ok: true, json: async () => structuredClone(server) } as Response;
+      })
+    );
+
+    renderPopover("model-a");
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => trigger.click());
+    await flushEffects();
+
+    // model-a has no server entry, so the field loads empty; the user types a draft whose save fails.
+    await act(async () => setInputValue(blockInput()!, "aaa"));
+    await blurBlockInput();
+    expect(blockInput()!.value).toBe("aaa");
+
+    // The live popover is re-pointed at model-b, which does have a server value...
+    renderPopover("model-b");
+    await flushEffects();
+    expect(blockInput()!.value).toBe("secret-b");
+
+    // ...and back to model-a, whose draft is still unsaved: the field must show model-a's draft.
+    renderPopover("model-a");
+    await flushEffects();
+    expect(blockInput()!.value).toBe("aaa");
+
+    // The user appends to what they can see and closes; the write must stay inside model-a.
+    putFails = false;
+    await act(async () => setInputValue(blockInput()!, `${blockInput()!.value}, extra`));
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    await flushEffects();
+
+    expect(server.models["model-a"]).toEqual({ block: ["aaa", "extra"], allow: [] });
+    expect(JSON.stringify(server.models["model-a"])).not.toContain("secret-b");
+    expect(server.models["model-b"]).toEqual({ block: ["secret-b"], allow: [] });
+  });
+
+  it("keeps one model's unsaved draft alive while the user edits another model", async () => {
+    const server: ParamFilterState = { block: [], allow: [], models: {}, autoLearn: false };
+    let putFails = true;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          if (putFails) return { ok: false, status: 500, json: async () => ({}) } as Response;
+          const body = JSON.parse(String(init.body));
+          server.models = body.models ?? {};
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        return { ok: true, json: async () => structuredClone(server) } as Response;
+      })
+    );
+
+    renderPopover("model-a");
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => trigger.click());
+    await flushEffects();
+
+    await act(async () => setInputValue(blockInput()!, "aaa"));
+    await blurBlockInput();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain("failed");
+
+    // Re-pointed at model-b; the network recovers and the user edits model-b.
+    renderPopover("model-b");
+    await flushEffects();
+    putFails = false;
+    await act(async () => setInputValue(blockInput()!, "bbb"));
+    await blurBlockInput();
+
+    // model-a's draft must not have been destroyed by the model-b edit: both are persisted...
+    expect(server.models["model-a"]).toEqual({ block: ["aaa"], allow: [] });
+    expect(server.models["model-b"]).toEqual({ block: ["bbb"], allow: [] });
+    // ...and with nothing left unsaved anywhere the failure indicator is finally cleared.
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("does not report success while another target's draft is still unsaved", async () => {
+    const byProvider: Record<string, ParamFilterState> = {
+      alpha: { block: [], allow: [], models: {}, autoLearn: false },
+      beta: { block: [], allow: [], models: {}, autoLearn: false },
+    };
+    let failing = new Set(["alpha"]);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const providerId = url.match(/providers\/([^/]+)\//)![1];
+        if (init?.method === "PUT") {
+          if (failing.has(providerId)) {
+            return { ok: false, status: 503, json: async () => ({}) } as Response;
+          }
+          const body = JSON.parse(String(init.body));
+          byProvider[providerId].models = body.models ?? {};
+          return { ok: true, json: async () => ({ success: true }) } as Response;
+        }
+        return { ok: true, json: async () => structuredClone(byProvider[providerId]) } as Response;
+      })
+    );
+
+    const renderFor = (providerId: string) => {
+      act(() => {
+        root.render(
+          <ModelCompatPopover
+            t={(key) => key}
+            providerId={providerId}
+            modelId="gpt-test"
+            effectiveModelNormalize={() => false}
+            effectiveModelPreserveDeveloper={() => true}
+            getUpstreamHeadersRecord={() => ({})}
+            onCompatPatch={vi.fn()}
+          />
+        );
+      });
+    };
+
+    renderFor("alpha");
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => trigger.click());
+    await flushEffects();
+    await act(async () => setInputValue(blockInput()!, "alpha-draft"));
+    await blurBlockInput();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain("failed");
+
+    // beta saves fine, but alpha is still broken: the indicator must stay up.
+    renderFor("beta");
+    await flushEffects();
+    await act(async () => setInputValue(blockInput()!, "beta-draft"));
+    await blurBlockInput();
+
+    expect(byProvider.beta.models).toEqual({ "gpt-test": { block: ["beta-draft"], allow: [] } });
+    expect(byProvider.alpha.models).toEqual({});
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain("failed");
+
+    // Once alpha recovers, the preserved draft is written to alpha and the indicator clears.
+    failing = new Set();
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    await flushEffects();
+    expect(byProvider.alpha.models).toEqual({ "gpt-test": { block: ["alpha-draft"], allow: [] } });
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filters.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-param-filters.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+interface ParamFilterState {
+  block: string[];
+  allow: string[];
+  models: Record<string, { block: string[]; allow: string[] }>;
+  autoLearn: boolean;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function openPopover() {
+  const trigger = container.querySelector("button") as HTMLButtonElement;
+  await act(async () => trigger.click());
+  await flushEffects();
+}
+
+describe("ModelCompatPopover model param filters (#8910)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("persists the latest block and allow drafts when an outside mousedown closes the popover", async () => {
+    const apiPath = "/api/providers/openai/param-filters";
+    let serverState: ParamFilterState = {
+      block: ["provider-block"],
+      allow: ["provider-allow"],
+      models: {
+        "other-model": { block: ["keep-block"], allow: ["keep-allow"] },
+      },
+      autoLearn: true,
+    };
+    const putBodies: unknown[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) !== apiPath) throw new Error(`Unexpected param-filter URL: ${input}`);
+      if (init?.method === "PUT") {
+        const body = JSON.parse(String(init.body)) as ParamFilterState;
+        putBodies.push(body);
+        serverState = body;
+      }
+      return {
+        ok: true,
+        json: async () => structuredClone(serverState),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    act(() => {
+      root.render(
+        <ModelCompatPopover
+          t={(key) => key}
+          providerId="openai"
+          modelId="gpt-test"
+          effectiveModelNormalize={() => false}
+          effectiveModelPreserveDeveloper={() => true}
+          getUpstreamHeadersRecord={() => ({})}
+          onCompatPatch={vi.fn()}
+        />
+      );
+    });
+
+    await openPopover();
+    const blockInput = document.querySelector(
+      'input[placeholder="compatBlockedParamsPlaceholder"]'
+    ) as HTMLInputElement;
+    const allowInput = document.querySelector(
+      'input[placeholder="compatAllowedParamsPlaceholder"]'
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      setInputValue(blockInput, "temperature, top_p");
+      setInputValue(allowInput, "tools, response_format");
+    });
+
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    await flushEffects();
+
+    expect(
+      document.querySelector('input[placeholder="compatBlockedParamsPlaceholder"]')
+    ).toBeNull();
+    expect(putBodies).toEqual([
+      {
+        block: ["provider-block"],
+        allow: ["provider-allow"],
+        models: {
+          "other-model": { block: ["keep-block"], allow: ["keep-allow"] },
+          "gpt-test": {
+            block: ["temperature", "top_p"],
+            allow: ["tools", "response_format"],
+          },
+        },
+        autoLearn: true,
+      },
+    ]);
+
+    await openPopover();
+    expect(
+      (
+        document.querySelector(
+          'input[placeholder="compatBlockedParamsPlaceholder"]'
+        ) as HTMLInputElement
+      ).value
+    ).toBe("temperature, top_p");
+    expect(
+      (
+        document.querySelector(
+          'input[placeholder="compatAllowedParamsPlaceholder"]'
+        ) as HTMLInputElement
+      ).value
+    ).toBe("tools, response_format");
+  });
+});

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/phase1d.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/phase1d.test.tsx
@@ -177,6 +177,8 @@ describe("phase-1d extractions (#3501)", () => {
     const c = renderComponent(
       <ModelCompatPopover
         t={(k: string) => k}
+        providerId="openai"
+        modelId="gpt-test"
         effectiveModelNormalize={() => false}
         effectiveModelPreserveDeveloper={() => true}
         getUpstreamHeadersRecord={() => ({})}
@@ -190,6 +192,8 @@ describe("phase-1d extractions (#3501)", () => {
     const c = renderComponent(
       <ModelCompatPopover
         t={(k: string) => k}
+        providerId="openai"
+        modelId="gpt-test"
         effectiveModelNormalize={() => true}
         effectiveModelPreserveDeveloper={() => false}
         getUpstreamHeadersRecord={() => ({ "X-Custom": "value" })}


### PR DESCRIPTION
## Summary

Fixes #8910 — model-level **Allowed / Blocked params** edits made in `ModelCompatPopover` could silently vanish, and a failed save could be presented as a success.

The compatibility toggles use a separate immediate patch path and always persisted; the param-filter text fields kept edits in local component state and only wrote them from the input's `onBlur`. Clicking outside closes and unmounts the portalled popover from the document-level `mousedown` handler, so the `onBlur` commit never ran — the edit disappeared with no feedback. The save helper also cleared the dirty state without checking whether the `PUT` had actually succeeded.

Working through the fix surfaced a family of related silent-data-loss defects on the same path, each covered by its own regression test.

## What changed

`src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx`:

- **Close/unmount commit.** Pending param-filter edits are flushed on popover close and on unmount, not only on `onBlur`.
- **No false success.** The dirty state / failure indicator is only cleared when the `PUT` actually succeeded; a failed `GET` or `PUT` keeps the edit and keeps the failure visible.
- **Lost-update protection.** A save no longer acknowledges a payload snapshotted before its `PUT` resolved, so a keystroke landing mid-flight is not discarded.
- **Load-effect clobber.** The load effect can no longer overwrite a dirty draft (or clear its dirty/failure state) — including a draft typed while the initial `GET` was still in flight, and a retained draft after a failed initial load.
- **Cross-target correctness.** `ModelCompatPopover` is not always keyed by a stable identity (`CompatibleModelsSection` keys by `${alias}:${modelId}`, `PassthroughModelsSection` by the full model string, and `providerId` is threaded from route/page state), so a re-render can re-point a live, mounted popover at a different provider/model. The save is now driven by a `ParamFilterDraft` that carries the provider, model and field values captured at edit time — never the props it happens to close over. This prevents writing one model's filter list into another model's config.
- **Per-target draft map + serialized saves.** Drafts are keyed by provider/model instead of living in a single overwritten slot, the save drains every pending draft against its own target, and cross-row saves are serialized so a later row's success cannot mask an earlier row's unwritten work.

Also: one entry removed from `config/quality/dashboard-typecheck-baseline.json` (the touched file no longer produces those baseline errors), and a small binding change in `CustomModelsSection.tsx`.

## Test evidence

8 new regression test files under `src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/` (14 cases), each written RED against the preceding commit and GREEN here:

| File | Cases |
| --- | --- |
| `modelCompatPopover-param-filters.test.tsx` | 1 |
| `modelCompatPopover-param-filter-load-clobber.test.tsx` | 2 |
| `modelCompatPopover-param-filter-cross-target.test.tsx` | 2 |
| `modelCompatPopover-param-filter-target-repoint.test.tsx` | 3 |
| `modelCompatPopover-param-filter-midflight-unmount.test.tsx` | 1 |
| `modelCompatPopover-param-filter-midflight-new-target.test.tsx` | 1 |
| `modelCompatPopover-param-filter-cross-instance.test.tsx` | 1 |
| `modelCompatPopover-param-filter-concurrency.test.tsx` | 3 |

Gates run on this exact tree (`537bbe1bda8278d3cf10dacfcaed16bec0aa29e3`):

```
$ npx vitest run --config vitest.config.ts 'src/app/(dashboard)'
 Test Files  9 failed | 20 passed (29)
      Tests  4 failed | 95 passed (99)
```

All 9 failing files are pre-existing and unrelated to this change, and fail identically on the base branch:
`dashboard/cache/__tests__` (5 files — `Cannot find module '@testing-library/dom'` collection errors), `discovery/DiscoveryPageClient` (same collection error), `webhooks/webhook-wizard` ("Next on step 2 posts kind:slack"), `providers/[id]/ProviderDetailPageClient` ("kicks off provider data loading on mount", `t.rich is not a function`), and `endpoint/ApiEndpointsTab` (2 tests). All 9 param-filter / `phase1d` files pass.

```
$ npm run lint
(clean)

$ node scripts/check/check-dashboard-typecheck.mjs
dashboardTypecheckErrors=246
[dashboard-typecheck] OK — 246 pre-existing error(s), all within frozen baseline.
```

## Scope / non-goals

No change to param-filter request semantics, no DB/schema/migration, no provider or network call change, no compatibility-policy redesign, no broad popover refactor. Existing compatibility toggles and upstream-header behavior are unchanged.

---

Opened as a **Draft** pending maintainer review. Branch is based on `release/v3.8.50`; the accepted tree is `537bbe1bda8278d3cf10dacfcaed16bec0aa29e3` at commit `dcddbe11cdf3964ee6289c0e1057aab8b41d33cd`. A changelog fragment will be added as a follow-up commit once the PR number exists (per `changelog.d/README.md`).
