### PR TITLE
docs(troubleshooting): document the chat_admission_busy 503 and how to tune heavyweight chat concurrency

### DIFF
--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -40,19 +40,19 @@ Common problems and solutions for OmniRoute.
 
 ## Quick Fixes
 
-| Problem                                                    | Solution                                                                                                                                                  |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| First login not working                                    | Set `INITIAL_PASSWORD` in `.env` (no hardcoded default)                                                                                                   |
-| Dashboard opens on wrong port                              | Set `PORT=20128` and `NEXT_PUBLIC_BASE_URL=http://localhost:20128`                                                                                        |
-| No logs written to disk                                    | Set `APP_LOG_TO_FILE=true` and verify call log capture is enabled                                                                                         |
-| EACCES: permission denied                                  | Set `DATA_DIR=/path/to/writable/dir` to override `~/.omniroute`                                                                                           |
-| Routing strategy not saving                                | Update to the latest v3.x release (Zod schema fix for settings persistence shipped in earlier versions)                                                   |
-| Login crash / blank page                                   | Check Node.js version — see [Node.js Compatibility](#nodejs-compatibility) below                                                                          |
-| `dlopen` / `slice is not valid mach-o file` (macOS)        | Run `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3 && omniroute` — see [macOS native module rebuild](#macos-native-module-rebuild) below  |
-| Proxy "fetch failed"                                       | Ensure proxy config is set at the correct level — see [Proxy Issues](#proxy-issues) below                                                                 |
+| Problem                                             | Solution                                                                                                                                                 |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| First login not working                             | Set `INITIAL_PASSWORD` in `.env` (no hardcoded default)                                                                                                  |
+| Dashboard opens on wrong port                       | Set `PORT=20128` and `NEXT_PUBLIC_BASE_URL=http://localhost:20128`                                                                                       |
+| No logs written to disk                             | Set `APP_LOG_TO_FILE=true` and verify call log capture is enabled                                                                                        |
+| EACCES: permission denied                           | Set `DATA_DIR=/path/to/writable/dir` to override `~/.omniroute`                                                                                          |
+| Routing strategy not saving                         | Update to the latest v3.x release (Zod schema fix for settings persistence shipped in earlier versions)                                                  |
+| Login crash / blank page                            | Check Node.js version — see [Node.js Compatibility](#nodejs-compatibility) below                                                                         |
+| `dlopen` / `slice is not valid mach-o file` (macOS) | Run `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3 && omniroute` — see [macOS native module rebuild](#macos-native-module-rebuild) below |
+| Proxy "fetch failed"                                | Ensure proxy config is set at the correct level — see [Proxy Issues](#proxy-issues) below                                                                |
 | Docker `curl: (56) Recv failure: Connection reset by peer` | Your Docker port bind may be landing on IPv6. Use `-p 127.0.0.1:20128:20128` to force IPv4, or test with `curl -4`. See [Docker IPv6](#docker-ipv6) below |
-| Antivirus quarantines `README.md`                          | False positive — see [Antivirus false positives](#antivirus-false-positives) below                                                                        |
-| Kaspersky flags the Desktop app as a Trojan                | Behavioral false positive on the unsigned installer — see [Antivirus false positives](#antivirus-false-positives) below                                   |
+| Antivirus quarantines `README.md`                   | False positive — see [Antivirus false positives](#antivirus-false-positives) below                                                                       |
+| Kaspersky flags the Desktop app as a Trojan         | Behavioral false positive on the unsigned installer — see [Antivirus false positives](#antivirus-false-positives) below                                  |
 
 ---
 
@@ -95,7 +95,7 @@ dodge one vendor's heuristic would hurt every reader to satisfy a scanner bug.
 
 **This is a false positive from a behavioral heuristic. Nothing is infected.** Kaspersky's
 `PDM:` prefix means the verdict comes from its Proactive Defense Module (System Watcher),
-which judges what the installer _does_ rather than matching it against known malware. When
+which judges what the installer *does* rather than matching it against known malware. When
 it fires, Kaspersky "rolls back" the whole installation — deleting files it had already
 written — so the app ends up broken or missing.
 
@@ -306,7 +306,6 @@ see [`docs/guides/KIRO_SETUP.md`](./KIRO_SETUP.md).
 **Cause:** `docker run -p 20128:20128` publishes on both `0.0.0.0` (IPv4) and `::` (IPv6), but the process inside the container listens on IPv4 only. On hosts where `localhost` resolves to `::1` first, the connection lands on the IPv6 published port with no listener behind it → connection reset.
 
 **Fix:**
-
 1. **Quick diagnostic:** Run `curl -4 http://localhost:20128/v1/models`. If it works with `-4` but fails without, you have an IPv6 bind mismatch.
 2. **Permanent fix:** Bind to IPv4 explicitly by using `-p 127.0.0.1:20128:20128` in your `docker run` command:
    ```bash

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -40,19 +40,19 @@ Common problems and solutions for OmniRoute.
 
 ## Quick Fixes
 
-| Problem                                             | Solution                                                                                                                                                 |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| First login not working                             | Set `INITIAL_PASSWORD` in `.env` (no hardcoded default)                                                                                                  |
-| Dashboard opens on wrong port                       | Set `PORT=20128` and `NEXT_PUBLIC_BASE_URL=http://localhost:20128`                                                                                       |
-| No logs written to disk                             | Set `APP_LOG_TO_FILE=true` and verify call log capture is enabled                                                                                        |
-| EACCES: permission denied                           | Set `DATA_DIR=/path/to/writable/dir` to override `~/.omniroute`                                                                                          |
-| Routing strategy not saving                         | Update to the latest v3.x release (Zod schema fix for settings persistence shipped in earlier versions)                                                  |
-| Login crash / blank page                            | Check Node.js version — see [Node.js Compatibility](#nodejs-compatibility) below                                                                         |
-| `dlopen` / `slice is not valid mach-o file` (macOS) | Run `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3 && omniroute` — see [macOS native module rebuild](#macos-native-module-rebuild) below |
-| Proxy "fetch failed"                                | Ensure proxy config is set at the correct level — see [Proxy Issues](#proxy-issues) below                                                                |
+| Problem                                                    | Solution                                                                                                                                                  |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| First login not working                                    | Set `INITIAL_PASSWORD` in `.env` (no hardcoded default)                                                                                                   |
+| Dashboard opens on wrong port                              | Set `PORT=20128` and `NEXT_PUBLIC_BASE_URL=http://localhost:20128`                                                                                        |
+| No logs written to disk                                    | Set `APP_LOG_TO_FILE=true` and verify call log capture is enabled                                                                                         |
+| EACCES: permission denied                                  | Set `DATA_DIR=/path/to/writable/dir` to override `~/.omniroute`                                                                                           |
+| Routing strategy not saving                                | Update to the latest v3.x release (Zod schema fix for settings persistence shipped in earlier versions)                                                   |
+| Login crash / blank page                                   | Check Node.js version — see [Node.js Compatibility](#nodejs-compatibility) below                                                                          |
+| `dlopen` / `slice is not valid mach-o file` (macOS)        | Run `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3 && omniroute` — see [macOS native module rebuild](#macos-native-module-rebuild) below  |
+| Proxy "fetch failed"                                       | Ensure proxy config is set at the correct level — see [Proxy Issues](#proxy-issues) below                                                                 |
 | Docker `curl: (56) Recv failure: Connection reset by peer` | Your Docker port bind may be landing on IPv6. Use `-p 127.0.0.1:20128:20128` to force IPv4, or test with `curl -4`. See [Docker IPv6](#docker-ipv6) below |
-| Antivirus quarantines `README.md`                   | False positive — see [Antivirus false positives](#antivirus-false-positives) below                                                                       |
-| Kaspersky flags the Desktop app as a Trojan         | Behavioral false positive on the unsigned installer — see [Antivirus false positives](#antivirus-false-positives) below                                  |
+| Antivirus quarantines `README.md`                          | False positive — see [Antivirus false positives](#antivirus-false-positives) below                                                                        |
+| Kaspersky flags the Desktop app as a Trojan                | Behavioral false positive on the unsigned installer — see [Antivirus false positives](#antivirus-false-positives) below                                   |
 
 ---
 
@@ -95,7 +95,7 @@ dodge one vendor's heuristic would hurt every reader to satisfy a scanner bug.
 
 **This is a false positive from a behavioral heuristic. Nothing is infected.** Kaspersky's
 `PDM:` prefix means the verdict comes from its Proactive Defense Module (System Watcher),
-which judges what the installer *does* rather than matching it against known malware. When
+which judges what the installer _does_ rather than matching it against known malware. When
 it fires, Kaspersky "rolls back" the whole installation — deleting files it had already
 written — so the app ends up broken or missing.
 
@@ -306,6 +306,7 @@ see [`docs/guides/KIRO_SETUP.md`](./KIRO_SETUP.md).
 **Cause:** `docker run -p 20128:20128` publishes on both `0.0.0.0` (IPv4) and `::` (IPv6), but the process inside the container listens on IPv4 only. On hosts where `localhost` resolves to `::1` first, the connection lands on the IPv6 published port with no listener behind it → connection reset.
 
 **Fix:**
+
 1. **Quick diagnostic:** Run `curl -4 http://localhost:20128/v1/models`. If it works with `-4` but fails without, you have an IPv6 bind mismatch.
 2. **Permanent fix:** Bind to IPv4 explicitly by using `-p 127.0.0.1:20128:20128` in your `docker run` command:
    ```bash
@@ -484,11 +485,15 @@ The byte-based response body is:
 The structure-based response uses the same type and code, with the message
 `Structurally heavy chat request capacity is busy; retry shortly.` and
 `reason: "structure_limit"`.
+At the default thresholds, a request is structurally heavy when it has at least `200` messages,
+at least `64` tools, or at least `32,000` estimated tokens, or when bounded structure estimation
+exhausts its bounds of `10,000` visited nodes or depth `12`.
 
 **Cause:** This is deliberate load shedding inside OmniRoute, not an upstream-provider failure.
 Each process uses a process-local guard to reserve limited heavyweight capacity before retaining
 and parsing a large request body. A heavyweight lease remains held for the lifetime of an SSE
 response.
+Current heavyweight lease occupancy is not surfaced in the dashboard.
 Settings → Resilience → Request Queue → Concurrent Requests does not control this; that setting
 governs a separate provider request-queue mechanism.
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -458,6 +458,55 @@ Provider profiles support these settings:
 
 When many concurrent requests hit a rate-limited provider, OmniRoute uses mutex + auto rate-limiting to serialize requests and prevent cascading failures. This is automatic for API key providers.
 
+### Chat requests fail with 503 / chat_admission_busy
+
+**Symptoms:**
+
+- The chat completions endpoint returns a retryable `503` response whose error code is
+  `chat_admission_busy`.
+- The response includes `Retry-After`; the byte-based path uses 2 seconds, while the
+  structure-based path uses 1 second and includes `reason: "structure_limit"`.
+- This can happen while another heavyweight chat or long-running streaming response is still
+  in flight.
+
+The byte-based response body is:
+
+```json
+{
+  "error": {
+    "message": "Chat admission capacity is temporarily unavailable. Retry shortly.",
+    "type": "server_error",
+    "code": "chat_admission_busy"
+  }
+}
+```
+
+The structure-based response uses the same type and code, with the message
+`Structurally heavy chat request capacity is busy; retry shortly.` and
+`reason: "structure_limit"`.
+
+**Cause:** This is deliberate load shedding inside OmniRoute, not an upstream-provider failure.
+Each process uses a process-local guard to reserve limited heavyweight capacity before retaining
+and parsing a large request body. A heavyweight lease remains held for the lifetime of an SSE
+response.
+Settings → Resilience → Request Queue → Concurrent Requests does not control this; that setting
+governs a separate provider request-queue mechanism.
+
+**Fix:**
+
+1. Retry first. Clients should honor `Retry-After` and use backoff rather than immediately
+   repeating the request.
+2. If normal deployment traffic repeatedly exhausts the guard, you can cautiously raise
+   `OMNIROUTE_CHAT_MAX_HEAVY_IN_FLIGHT` from its default of `1`. Increase it one step at a time,
+   restart OmniRoute after each change, and observe memory headroom under representative load.
+   Every additional heavyweight request can increase concurrent V8 heap use and container or
+   host OOM risk. No value is safe for every deployment; validate the setting against your own
+   traffic and memory limits rather than assuming that `2` is universally safe.
+
+See the [environment-variable reference](../reference/ENVIRONMENT.md#4-security--authentication)
+for the authoritative admission settings. Loosening the heavyweight classification thresholds
+can let expensive requests bypass this guard and is riskier than a cautious in-flight increase.
+
 ---
 
 ## Optional RAG / LLM failure taxonomy (16 problems)


### PR DESCRIPTION
Documentation-only entry for issue #9012: the chat completions endpoint can return a retryable `503` with `code: "chat_admission_busy"`, and until now the English troubleshooting guide had no entry for that exact code — so operators had no documented way to tell it apart from an upstream-provider failure or from the dashboard's ordinary request-concurrency setting.

Refs #9012

## What this adds

One new section in `docs/guides/TROUBLESHOOTING.md` (`### Chat requests fail with 503 / chat_admission_busy`), placed next to the existing provider concurrency material:

- **Symptoms** — the retryable `503`, the `Retry-After` values (2s on the byte-based path, 1s plus `reason: "structure_limit"` on the structure-based path), and the fact that it can fire while another heavyweight chat or long-running SSE response is still in flight.
- **The exact response bodies**, copied verbatim from `src/shared/middleware/chatBodyAdmission.ts` rather than paraphrased.
- **Structure-heavy classification thresholds** (added in review round 2) — at the defaults, a request is structurally heavy at ≥ `200` messages, ≥ `64` tools, or ≥ `32,000` estimated tokens, or when bounded structure estimation exhausts its bounds of `10,000` visited nodes or depth `12`. Verified against `CHAT_HEAVY_MESSAGE_COUNT` / `CHAT_HEAVY_TOOL_COUNT` / `CHAT_HEAVY_ESTIMATED_TOKENS` and `estimateStructureTokens()` in `src/shared/middleware/chatBodyAdmission.ts`.
- **Cause** — deliberate process-local load shedding: a heavyweight lease is reserved *before* the large request body is retained and parsed, and is held for the lifetime of an SSE response. Explicitly states that Settings → Resilience → Request Queue → Concurrent Requests is a *different* mechanism and does not control this guard.
- **Observability note** (added in review round 2) — current heavyweight lease occupancy is not surfaced in the dashboard. This is deliberately scoped to dashboard occupancy rather than a broader "no metrics anywhere" claim, so the sentence stays verifiable: `activeHeavy` has no reader outside `chatBodyAdmission.ts`.
- **Fix** — retry first, honouring `Retry-After` with backoff; only then cautiously raise `OMNIROUTE_CHAT_MAX_HEAVY_IN_FLIGHT` one step at a time, restarting and watching memory headroom, because each additional heavyweight request increases concurrent V8 heap use and OOM risk.
- A link to the authoritative environment-variable reference, plus a note that loosening the heavyweight *classification* thresholds is riskier than a cautious in-flight increase.

## Deliberate non-goals

- The documented default stays `1`. The doc does **not** claim `2` is universally safe — it tells operators to validate against their own traffic and memory limits.
- No runtime, environment-default, UI, schema, or dependency change. No translated-doc changes, no changelog change.
- Docs-only diff: 1 file, +53/-0 against the base.

## Verification

Run on the exact pushed commit `fb52c1ea7894e342fe946df3871416928163b0bf` (tree `e7dcf844e0cfdef7b30bcdc548f374431670a941`), based on `release/v3.8.50` @ `9b3efef806b291bd5833ba678b57c4e071b65255` (tree `796208321e5b84f87f63ce2715838f057296395a`):

| Gate | Result |
| --- | --- |
| `node --import tsx/esm --test tests/unit/chat-body-admission.test.ts` | 22 pass / 0 fail |
| `npm run check:docs-all` | pass |
| `npm run check:fabricated-docs` | pass — 134 docs, no fabricated refs |
| `npm run check:doc-links` | pass — 814 internal links |
| `npm run check:docs-symbols` | pass |
| `npm run check:env-doc-sync` | pass |
| `npm run check:api-docs-refs` | pass |
| `npm run check:changelog-integrity` | pass |
| `git diff --check` | clean |

Every user-visible string and numeric threshold in the new section (error message, `code`, `type`, `reason`, env var names, default values, estimator bounds) was asserted against `src/shared/middleware/chatBodyAdmission.ts` — no synthesized names or values.

**Known pre-existing Prettier drift, disclosed:** `npx prettier --check docs/guides/TROUBLESHOOTING.md` fails on this branch, but it fails *identically* on the untouched base commit `9b3efef80` — the same hunks at the same original offsets (Quick Fixes table column padding at ~L40, an `*does*`→`_does_` emphasis normalisation at ~L95, and a missing blank line before the Docker IPv6 list at ~L306). None of them fall inside the added section, which is Prettier-clean when checked in isolation. I left the base drift alone rather than mixing an unrelated reformat into a documentation PR — happy to fix it here or in a separate PR if you'd prefer.

**Changelog fragment:** not added. `changelog.d/README.md` requires the PR number as the filename prefix, and the most recent docs-only commit on this line (#8991) shipped without a fragment. Glad to add `changelog.d/maintenance/9021-chat-admission-troubleshooting.md` on request.

Opened as a **Draft** pending maintainer confirmation that the scope and placement are what you want for #9012.
