### PR TITLE
fix(chat): resolve stored combo names before image-model validation (#8986)

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -44,7 +44,7 @@ import { checkAndRefreshToken } from "../services/tokenRefresh";
 import { createHookContext, runHooks, initPreRequestRegistry } from "@/lib/middleware/registry";
 import { rejectPeerRequest } from "@/shared/resilience/peerRouting";
 import { deleteHandoff, getHandoff } from "@/lib/db/contextHandoffs";
-import { updateCombo } from "@/lib/db/combos";
+import { getComboByName, updateCombo } from "@/lib/db/combos";
 import { isModelAllowedForKey } from "@/lib/db/apiKeys";
 import { promoteSuccessfulComboModel } from "@/lib/combos/autoPromote";
 import {
@@ -453,10 +453,14 @@ export async function handleChat(
   // image-registry match is only image-only when the same provider/model pair is
   // absent from the chat catalog.
   const imageModel = getImageModelEntry(modelStr);
+  // Exact stored combo names take precedence over colliding bare image aliases.
+  // Keep this narrower than getComboForModel() so mappings and synthetic aliases
+  // retain their existing resolution order.
+  const isExactStoredCombo = imageModel ? Boolean(await getComboByName(modelStr)) : false;
   const isChatCatalogModel = imageModel
     ? getModelsByProviderId(imageModel.provider).some((model) => model.id === imageModel.model)
     : false;
-  if (imageModel && !isChatCatalogModel) {
+  if (imageModel && !isExactStoredCombo && !isChatCatalogModel) {
     log.warn("CHAT", `Rejecting image-generation model on chat endpoint: ${modelStr}`);
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,

--- a/tests/unit/chat-rejects-image-only-model.test.ts
+++ b/tests/unit/chat-rejects-image-only-model.test.ts
@@ -11,8 +11,11 @@ import assert from "node:assert/strict";
 import { createChatPipelineHarness } from "../integration/_chatPipelineHarness.ts";
 
 const harness = await createChatPipelineHarness("chat-rejects-image-only-model");
-const { buildRequest, handleChat, resetStorage } = harness as {
+const { buildRequest, combosDb, handleChat, resetStorage } = harness as {
   buildRequest: (opts: { body: unknown }) => Request;
+  combosDb: {
+    createCombo: (data: Record<string, unknown>) => Promise<unknown>;
+  };
   handleChat: (req: Request) => Promise<Response>;
   resetStorage: () => void | Promise<void>;
 };
@@ -69,6 +72,32 @@ test("POST /v1/chat/completions with a chat model still reaches routing (guard i
     const body = (await res.json()) as { error?: { message?: string } };
     const msg = body?.error?.message || JSON.stringify(body);
     assert.doesNotMatch(msg, /image-generation model/i, "chat model must not trip the image guard");
+  }
+});
+
+test("POST /v1/chat/completions routes a stored chat combo whose name is an image alias (#8986)", async () => {
+  await combosDb.createCombo({
+    name: "fast",
+    strategy: "priority",
+    models: ["openai/gpt-4o"],
+  });
+
+  const request = buildRequest({
+    body: {
+      model: "fast",
+      messages: [{ role: "user", content: "hi" }],
+    },
+  });
+
+  const res = await handleChat(request);
+  if (res.status === 400) {
+    const body = (await res.json()) as { error?: { message?: string } };
+    const msg = body?.error?.message || JSON.stringify(body);
+    assert.doesNotMatch(
+      msg,
+      /image-generation model/i,
+      "a stored chat combo must take precedence over a colliding image alias"
+    );
   }
 });
 


### PR DESCRIPTION
Fixes #8986

## Problem

`src/sse/handlers/chat.ts` runs `getImageModelEntry(modelStr)` before combo resolution. Because that lookup accepts bare IDs, a stored chat combo named `fast` matched the static `stability-ai` entry `Fast Upscale` and the request was rejected with HTTP 400 (`... is an image-generation model and cannot be used on /v1/chat/completions`) before it ever reached combo routing — even though `/v1/models` advertises the combo as `chat` and it contains no image target.

## Change

Exact stored combo names now take precedence over a colliding bare image alias. The guard consults `getComboByName(modelStr)` only when the image-registry lookup already matched, so ordering is unchanged for every request that does not hit this collision.

Deliberately narrower than `getComboForModel()`: model→combo mappings and synthetic/auto aliases keep their existing resolution order. No image registry, combo schema, migration, provider configuration, dependency, lockfile, UI or docs change.

Scope: 2 files, +36/-3.

- `src/sse/handlers/chat.ts`
- `tests/unit/chat-rejects-image-only-model.test.ts`

## Behavior matrix (verified by route-level probes)

| Case | Before | After |
| --- | --- | --- |
| stored chat combo `fast` (targets `openai/gpt-4o`) | 400 image-generation, 0 dispatch | 200, routed to `gpt-4o` |
| bare image alias `fast` with no combo stored | 400 + `/v1/images/generations` hint | unchanged |
| real image-only model (HuggingFace) | 400 + generations hint | unchanged |
| model registered for both chat and image (`codex/gpt-5.6-sol`) | allowed | unchanged |
| unknown bare model | 400 | unchanged |

## Tests

TDD lineage is preserved as two commits: `ff4863180` (RED, tests only) then `6c4c0a007` (GREEN, minimum fix).

- RED reproduced at `ff4863180`: 3 pass / 1 fail, failure reason "stored combo fast rejected by image-generation guard".
- Focused: `node --import tsx/esm --test tests/unit/chat-rejects-image-only-model.test.ts` → 4/4 pass.
- Related unit sweep (247 files matching chat / image / combo / api-key-policy / bare-model / schema-validation / body-admission): 1733 tests, 1730 pass, 3 fail — all 3 pre-existing and unrelated. `json-migration-combos.test.ts` (2 failures) fails identically on the untouched base `9b3efef80`; `combo-resource-404-health.test.ts` fails only with an `ENOTEMPTY` tmpdir teardown race under high parallelism and passes 1/1 in isolation.
- Static gates all green at this tree: Prettier and ESLint on both changed files, `typecheck:core`, `check:cycles`, `check:db-rules`, `check:build-scope`, `check:error-helper`, `check:public-creds`, `check:openapi-security-tiers`, `git diff --check`.

Environment note: the local `better-sqlite3` native binary does not match this Node ABI, so the repository's SQLite fallback driver was used throughout. That does not affect the guard being exercised.

Base: `9b3efef806b291bd5833ba678b57c4e071b65255` (current `release/v3.8.50` tip). Head: `6c4c0a00749f6d60287a1254be74dfeb1fc935cd`, tree `93479165d54c843c23684dc30f1a85468e660d19`.

Opened as Draft for maintainer review.
