### PR TITLE
fix(kiro): read usage from the frames Kiro actually sends

### DIFF
--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -6,6 +6,7 @@ import {
   type ProviderCredentials,
 } from "./base.ts";
 import { PROVIDERS } from "../config/constants.ts";
+import { getRegistryEntry } from "../config/providerRegistry.ts";
 import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.ts";
 import {
@@ -130,7 +131,45 @@ function buildKiroFinishChunk(
   return finishChunk;
 }
 
-function ensureKiroUsage(state: KiroStreamState) {
+/**
+ * Kiro's fallback input-token budget when the model is absent from the registry.
+ * Mirrors the registry's own `defaultContextLength` and kiro-gateway's
+ * DEFAULT_MAX_INPUT_TOKENS.
+ */
+const KIRO_DEFAULT_MAX_INPUT_TOKENS = 200000;
+
+/**
+ * Input-token budget for a Kiro model, used to turn `contextUsagePercentage`
+ * into an absolute token count.
+ *
+ * Kiro reports only a percentage, so the budget it is a percentage OF decides the
+ * result. A fixed 200000 undercounts every model with a larger window by the
+ * ratio of the two windows — claude-sonnet-5 (1M) by 5x, gpt-5.6-* (272k) by
+ * ~26% — and those numbers land in usage_history and the API-key token-limit
+ * counters.
+ */
+function resolveKiroMaxInputTokens(model: string): number {
+  const entry = getRegistryEntry("kiro");
+  const modelEntry = entry?.models?.find((m) => m.id === model);
+  return modelEntry?.contextLength || entry?.defaultContextLength || KIRO_DEFAULT_MAX_INPUT_TOKENS;
+}
+
+/**
+ * Synthesize a usage block when Kiro sent no token counts of its own.
+ *
+ * Live `generateAssistantResponse` traffic carries no token counts at all — only
+ * `contextUsageEvent.contextUsagePercentage` and a `meteringEvent` credit figure
+ * (verified against the live API: frames are assistantResponseEvent /
+ * metadataEvent / contextUsageEvent / meteringEvent). So these numbers are
+ * ESTIMATES, derived the same way kiro-gateway derives them: the percentage
+ * yields the total, the response text yields the completion, and the prompt is
+ * the remainder.
+ *
+ * Subtracting matters: the percentage already covers the whole context, so
+ * adding a separately-estimated completion on top would double-count it and
+ * inflate `total_tokens`.
+ */
+function ensureKiroUsage(state: KiroStreamState, model: string) {
   if (state.usage) return;
 
   const estimatedOutputTokens =
@@ -138,17 +177,30 @@ function ensureKiroUsage(state: KiroStreamState) {
       ? Math.max(1, Math.floor(state.totalContentLength / 4))
       : 0;
 
-  const estimatedInputTokens =
+  const estimatedTotalTokens =
     state.contextUsagePercentage && state.contextUsagePercentage > 0
-      ? Math.floor((state.contextUsagePercentage * 200000) / 100)
+      ? Math.floor((state.contextUsagePercentage * resolveKiroMaxInputTokens(model)) / 100)
       : 0;
 
-  if (estimatedInputTokens <= 0 && estimatedOutputTokens <= 0) return;
+  if (estimatedTotalTokens <= 0 && estimatedOutputTokens <= 0) return;
+
+  // Without a percentage there is no total to split, so the output estimate is
+  // all that is known and stands on its own.
+  if (estimatedTotalTokens <= 0) {
+    state.usage = {
+      prompt_tokens: 0,
+      completion_tokens: estimatedOutputTokens,
+      total_tokens: estimatedOutputTokens,
+    };
+    return;
+  }
+
+  const promptTokens = Math.max(0, estimatedTotalTokens - estimatedOutputTokens);
 
   state.usage = {
-    prompt_tokens: estimatedInputTokens,
+    prompt_tokens: promptTokens,
     completion_tokens: estimatedOutputTokens,
-    total_tokens: estimatedInputTokens + estimatedOutputTokens,
+    total_tokens: promptTokens + estimatedOutputTokens,
   };
 }
 
@@ -685,37 +737,74 @@ export class KiroExecutor extends BaseExecutor {
               state.hasMeteringEvent = true;
             }
 
-            // Handle metricsEvent for token usage
-            if (eventType === "metricsEvent") {
-              // Extract usage data from metricsEvent payload
-              const metrics = event.payload?.metricsEvent || event.payload;
+            // Handle token usage. Kiro reports it under more than one frame: the
+            // `metricsEvent` shape covered by unit tests, and a `metadataEvent`
+            // carrying a nested `usage` object — the shape observed on live
+            // API-key traffic (see tests/unit/executor-kiro.test.ts, the
+            // "live API-key event shape" case, whose frames are
+            // assistantResponseEvent / metadataEvent / contextUsageEvent /
+            // meteringEvent with no metricsEvent at all). Reading only
+            // `metricsEvent` meant cache tokens were never picked up in
+            // production even after their field names were corrected, because
+            // the branch holding that code never ran.
+            if (eventType === "metricsEvent" || eventType === "metadataEvent") {
+              const metrics =
+                event.payload?.metricsEvent ||
+                event.payload?.usage ||
+                (event.payload?.metadataEvent as JsonRecord)?.usage ||
+                event.payload;
               if (metrics && typeof metrics === "object") {
+                const readNumber = (...candidates: unknown[]) =>
+                  candidates.find((value) => typeof value === "number") as number | undefined;
+
+                // Bedrock-style (`inputTokens`) and OpenAI-style
+                // (`prompt_tokens`) spellings both appear across Kiro frames.
                 const inputTokens =
-                  typeof (metrics as JsonRecord).inputTokens === "number"
-                    ? ((metrics as JsonRecord).inputTokens as number)
-                    : 0;
+                  readNumber(
+                    (metrics as JsonRecord).inputTokens,
+                    (metrics as JsonRecord).prompt_tokens
+                  ) || 0;
                 const outputTokens =
-                  typeof (metrics as JsonRecord).outputTokens === "number"
-                    ? ((metrics as JsonRecord).outputTokens as number)
-                    : 0;
+                  readNumber(
+                    (metrics as JsonRecord).outputTokens,
+                    (metrics as JsonRecord).completion_tokens
+                  ) || 0;
 
-                const cacheReadTokens =
-                  typeof (metrics as JsonRecord).cacheReadTokens === "number"
-                    ? ((metrics as JsonRecord).cacheReadTokens as number)
-                    : 0;
+                const cacheReadTokens = readNumber(
+                  (metrics as JsonRecord).cacheReadInputTokens,
+                  (metrics as JsonRecord).cacheReadTokens,
+                  (metrics as JsonRecord).cache_read_input_tokens
+                );
 
-                const cacheCreationTokens =
-                  typeof (metrics as JsonRecord).cacheCreationTokens === "number"
-                    ? ((metrics as JsonRecord).cacheCreationTokens as number)
-                    : 0;
+                const cacheCreationTokens = readNumber(
+                  (metrics as JsonRecord).cacheWriteInputTokens,
+                  (metrics as JsonRecord).cacheCreationTokens,
+                  (metrics as JsonRecord).cache_creation_input_tokens
+                );
 
                 if (inputTokens > 0 || outputTokens > 0) {
                   state.usage = {
                     prompt_tokens: inputTokens,
                     completion_tokens: outputTokens,
                     total_tokens: inputTokens + outputTokens,
-                    ...(cacheReadTokens > 0 && { cache_read_input_tokens: cacheReadTokens }),
-                    ...(cacheCreationTokens > 0 && {
+                    ...((cacheReadTokens || 0) > 0 && {
+                      cache_read_input_tokens: cacheReadTokens,
+                    }),
+                    ...((cacheCreationTokens || 0) > 0 && {
+                      cache_creation_input_tokens: cacheCreationTokens,
+                    }),
+                  };
+                } else if ((cacheReadTokens || 0) > 0 || (cacheCreationTokens || 0) > 0) {
+                  // Cache counts can arrive on a frame that carries no
+                  // input/output totals. Preserve them instead of dropping the
+                  // whole frame, and let ensureKiroUsage() fill the totals from
+                  // contextUsagePercentage.
+                  state.usage = {
+                    ...(state.usage || {}),
+                    ...((cacheReadTokens || 0) > 0 && {
+                      cache_read_input_tokens: cacheReadTokens,
+                    }),
+                    ...((cacheCreationTokens || 0) > 0 && {
                       cache_creation_input_tokens: cacheCreationTokens,
                     }),
                   };
@@ -772,7 +861,7 @@ export class KiroExecutor extends BaseExecutor {
           // Emit finish chunk if not already sent
           if (!state.finishEmitted) {
             state.finishEmitted = true;
-            ensureKiroUsage(state);
+            ensureKiroUsage(state, model);
             const finishChunk = buildKiroFinishChunk(state, responseId, created, model, true);
             controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
           }

--- a/open-sse/services/kiroModels.ts
+++ b/open-sse/services/kiroModels.ts
@@ -56,6 +56,12 @@ function toNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+export type KiroPromptCaching = {
+  supportsPromptCaching: boolean;
+  minimumTokensPerCacheCheckpoint: number | null;
+  maximumCacheCheckpointsPerRequest: number | null;
+};
+
 export type KiroModel = {
   id: string;
   name: string;
@@ -68,7 +74,27 @@ export type KiroModel = {
   rateMultiplier?: number;
   upstreamModelId?: string;
   description?: string;
+  promptCaching?: KiroPromptCaching;
 };
+
+function toNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function parsePromptCaching(value: unknown): KiroPromptCaching | undefined {
+  const promptCaching = asRecord(value);
+  if (typeof promptCaching.supportsPromptCaching !== "boolean") return undefined;
+
+  return {
+    supportsPromptCaching: promptCaching.supportsPromptCaching,
+    minimumTokensPerCacheCheckpoint: toNonNegativeInteger(
+      promptCaching.minimumTokensPerCacheCheckpoint
+    ),
+    maximumCacheCheckpointsPerRequest: toNonNegativeInteger(
+      promptCaching.maximumCacheCheckpointsPerRequest
+    ),
+  };
+}
 
 export type KiroModelsResult = {
   models: KiroModel[];
@@ -98,7 +124,8 @@ export function parseKiroModels(data: unknown): KiroModel[] {
     if (!id || seen.has(id)) continue;
     seen.add(id);
     const name = toNonEmptyString(item.modelName) || toNonEmptyString(item.name) || id;
-    models.push({ id, name, owned_by: "kiro" });
+    const promptCaching = parsePromptCaching(item.promptCaching);
+    models.push({ id, name, owned_by: "kiro", ...(promptCaching && { promptCaching }) });
   }
 
   return models;
@@ -162,6 +189,7 @@ function expandKiroModels(data: unknown): KiroModel[] {
     const tokenLimits = asRecord(item.tokenLimits);
     const contextLength = Number(tokenLimits.maxInputTokens) || 200000;
     const rateMultiplier = Number(item.rateMultiplier);
+    const promptCaching = parsePromptCaching(item.promptCaching);
 
     for (const variant of buildVariants(upstreamId, display)) {
       if (seen.has(variant.id)) continue;
@@ -172,6 +200,7 @@ function expandKiroModels(data: unknown): KiroModel[] {
         rateMultiplier: Number.isFinite(rateMultiplier) ? rateMultiplier : 1.0,
         upstreamModelId: upstreamId,
         description: toNonEmptyString(item.description) || "",
+        ...(promptCaching && { promptCaching }),
       });
     }
   }

--- a/tests/unit/executor-kiro.test.ts
+++ b/tests/unit/executor-kiro.test.ts
@@ -241,6 +241,218 @@ test("KiroExecutor.transformEventStreamToSSE converts text, tool calls, usage an
   assert.match(text, /\[DONE\]/);
 });
 
+test("KiroExecutor normalizes Bedrock cache-token fields from a metricsEvent", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "cached" }),
+    buildEventFrame("metricsEvent", {
+      inputTokens: 7,
+      outputTokens: 2,
+      cacheReadInputTokens: 1024,
+      cacheWriteInputTokens: 256,
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.deepEqual(finish.usage, {
+    prompt_tokens: 7,
+    completion_tokens: 2,
+    total_tokens: 9,
+    cache_read_input_tokens: 1024,
+    cache_creation_input_tokens: 256,
+  });
+});
+
+test("KiroExecutor does not invent cache tokens for the live API-key event shape", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", {
+      content: "live-shaped response",
+      modelId: "claude-sonnet-4.5",
+    }),
+    buildEventFrame("metadataEvent", { stopReason: "END_TURN" }),
+    buildEventFrame("contextUsageEvent", { contextUsagePercentage: 4.93 }),
+    buildEventFrame("meteringEvent", {
+      unit: "credit",
+      unitPlural: "credits",
+      usage: 0.022,
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.equal(finish.usage.cache_read_input_tokens, undefined);
+  assert.equal(finish.usage.cache_creation_input_tokens, undefined);
+});
+
+// The cache-field fix in d205650a7 landed inside the `metricsEvent` branch, but
+// live API-key traffic (the test above) sends no `metricsEvent` at all — it sends
+// a `metadataEvent`. The corrected code was therefore unreachable in production
+// and cache stats stayed empty. Usage extraction now accepts both frames.
+test("KiroExecutor reads usage and cache tokens from a metadataEvent frame", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "cached reply" }),
+    buildEventFrame("metadataEvent", {
+      stopReason: "END_TURN",
+      usage: {
+        inputTokens: 12,
+        outputTokens: 3,
+        cacheReadInputTokens: 2048,
+        cacheWriteInputTokens: 512,
+      },
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.deepEqual(finish.usage, {
+    prompt_tokens: 12,
+    completion_tokens: 3,
+    total_tokens: 15,
+    cache_read_input_tokens: 2048,
+    cache_creation_input_tokens: 512,
+  });
+});
+
+// Cache counts can arrive on a frame carrying no input/output totals. Dropping
+// the frame (the old behavior, gated on `inputTokens > 0 || outputTokens > 0`)
+// lost the cache accounting entirely.
+test("KiroExecutor keeps cache tokens that arrive without input/output totals", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "hi" }),
+    buildEventFrame("contextUsageEvent", { contextUsagePercentage: 10 }),
+    buildEventFrame("metadataEvent", {
+      usage: { cacheReadInputTokens: 900 },
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.equal(finish.usage.cache_read_input_tokens, 900);
+  assert.equal(finish.usage.cache_creation_input_tokens, undefined);
+});
+
+// snake_case spellings appear on some Kiro frames; a cache count must not be
+// dropped just because it is not the Bedrock camelCase spelling.
+test("KiroExecutor accepts snake_case cache token spellings", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "ok" }),
+    buildEventFrame("metadataEvent", {
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 1,
+        cache_read_input_tokens: 64,
+        cache_creation_input_tokens: 32,
+      },
+    }),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const chunks = parseSSEJsonChunks(await transformed.text());
+  const finish = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.deepEqual(finish.usage, {
+    prompt_tokens: 5,
+    completion_tokens: 1,
+    total_tokens: 6,
+    cache_read_input_tokens: 64,
+    cache_creation_input_tokens: 32,
+  });
+});
+
+// Live generateAssistantResponse sends NO token counts — only
+// contextUsageEvent.contextUsagePercentage plus a meteringEvent credit figure.
+// The synthesized usage is therefore an estimate, and the context budget the
+// percentage applies to decides it. A fixed 200000 undercounts claude-sonnet-5
+// (1M window) by 5x, and those numbers feed usage_history and the API-key
+// token-limit counters.
+test("KiroExecutor scales the usage estimate by the model's own context window", async () => {
+  const executor = new KiroExecutor();
+  const estimateFor = async (model) => {
+    const response = buildEventStreamResponse([
+      buildEventFrame("assistantResponseEvent", { content: "x".repeat(400) }),
+      buildEventFrame("contextUsageEvent", { contextUsagePercentage: 10 }),
+    ]);
+    const chunks = parseSSEJsonChunks(
+      await executor.transformEventStreamToSSE(response, model).text()
+    );
+    return chunks.find((chunk) => chunk.choices?.[0]?.finish_reason).usage;
+  };
+
+  // 10% of 200000, with the 100-token completion carved out of the total.
+  assert.deepEqual(await estimateFor("claude-sonnet-4.5"), {
+    prompt_tokens: 19900,
+    completion_tokens: 100,
+    total_tokens: 20000,
+  });
+
+  // 10% of 1000000 — a fixed 200000 budget would have reported 20000 here.
+  assert.deepEqual(await estimateFor("claude-sonnet-5"), {
+    prompt_tokens: 99900,
+    completion_tokens: 100,
+    total_tokens: 100000,
+  });
+
+  // 10% of 272000.
+  assert.equal((await estimateFor("gpt-5.6-sol")).total_tokens, 27200);
+
+  // Registry models without their own contextLength inherit defaultContextLength,
+  // and an unknown id falls back to the same budget rather than reporting zero.
+  assert.equal((await estimateFor("glm-5")).total_tokens, 20000);
+  assert.equal((await estimateFor("not-a-kiro-model")).total_tokens, 20000);
+});
+
+// The percentage already covers the whole context, so adding a separately
+// estimated completion on top would double-count it and inflate total_tokens
+// past what Kiro reported.
+test("KiroExecutor carves the completion estimate out of the reported total", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "y".repeat(800) }),
+    buildEventFrame("contextUsageEvent", { contextUsagePercentage: 5 }),
+  ]);
+
+  const chunks = parseSSEJsonChunks(
+    await executor.transformEventStreamToSSE(response, "claude-sonnet-4.5").text()
+  );
+  const usage = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason).usage;
+
+  // 5% of 200000 is 10000 and must stay the total, not become 10000 + 200.
+  assert.equal(usage.total_tokens, 10000);
+  assert.equal(usage.completion_tokens, 200);
+  assert.equal(usage.prompt_tokens, 9800);
+});
+
+// With no percentage there is no total to split, so the output estimate has to
+// stand on its own instead of being silently dropped.
+test("KiroExecutor still reports a completion estimate without a context percentage", async () => {
+  const executor = new KiroExecutor();
+  const response = buildEventStreamResponse([
+    buildEventFrame("assistantResponseEvent", { content: "z".repeat(400) }),
+  ]);
+
+  const chunks = parseSSEJsonChunks(
+    await executor.transformEventStreamToSSE(response, "claude-sonnet-4.5").text()
+  );
+  const usage = chunks.find((chunk) => chunk.choices?.[0]?.finish_reason).usage;
+
+  assert.equal(usage.prompt_tokens, 0);
+  assert.equal(usage.completion_tokens, 100);
+  assert.equal(usage.total_tokens, 100);
+});
+
 test("KiroExecutor.transformEventStreamToSSE surfaces native reasoning frames as reasoning_content", async () => {
   const executor = new KiroExecutor();
   // Verified live wire format: Kiro streams adaptive-thinking reasoning as a

--- a/tests/unit/kiro-available-models.test.ts
+++ b/tests/unit/kiro-available-models.test.ts
@@ -41,6 +41,82 @@ test("parseKiroModels reads CodeWhisperer ListAvailableModels shape", () => {
   assert.equal(models[0].owned_by, "kiro");
 });
 
+test("parseKiroModels preserves live prompt-caching capability metadata", () => {
+  const [model] = parseKiroModels({
+    models: [
+      {
+        modelId: "claude-sonnet-4.5",
+        modelName: "Claude Sonnet 4.5",
+        promptCaching: {
+          supportsPromptCaching: true,
+          minimumTokensPerCacheCheckpoint: 1024,
+          maximumCacheCheckpointsPerRequest: 4,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(model.promptCaching, {
+    supportsPromptCaching: true,
+    minimumTokensPerCacheCheckpoint: 1024,
+    maximumCacheCheckpointsPerRequest: 4,
+  });
+});
+
+test("parseKiroModels keeps nonnumeric prompt-caching limits unknown", () => {
+  const [model] = parseKiroModels({
+    models: [
+      {
+        modelId: "claude-sonnet-4.5",
+        promptCaching: {
+          supportsPromptCaching: true,
+          minimumTokensPerCacheCheckpoint: null,
+          maximumCacheCheckpointsPerRequest: false,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(model.promptCaching, {
+    supportsPromptCaching: true,
+    minimumTokensPerCacheCheckpoint: null,
+    maximumCacheCheckpointsPerRequest: null,
+  });
+});
+
+test("fetchKiroAvailableModels carries upstream prompt-caching metadata to model variants", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({
+      models: [
+        {
+          modelId: "claude-sonnet-4.5",
+          promptCaching: {
+            supportsPromptCaching: true,
+            minimumTokensPerCacheCheckpoint: 1024,
+            maximumCacheCheckpointsPerRequest: 4,
+          },
+        },
+      ],
+    })) as unknown as typeof fetch;
+
+  const result = await fetchKiroAvailableModels({
+    accessToken: "tok",
+    providerSpecificData: {},
+    fetchImpl,
+    fallbackModels: FALLBACK,
+  });
+
+  assert.ok(result.models.length >= 1);
+  for (const model of result.models) {
+    assert.equal(model.upstreamModelId, "claude-sonnet-4.5");
+    assert.deepEqual(model.promptCaching, {
+      supportsPromptCaching: true,
+      minimumTokensPerCacheCheckpoint: 1024,
+      maximumCacheCheckpointsPerRequest: 4,
+    });
+  }
+});
+
 test("resolveKiroRegion prefers stored region, then profileArn, else us-east-1", () => {
   assert.equal(resolveKiroRegion({ region: "eu-central-1" }), "eu-central-1");
   assert.equal(


### PR DESCRIPTION
## Summary

Kiro's token and cache accounting never reached the client. All usage extraction lived inside an `eventType === "metricsEvent"` branch, and live `generateAssistantResponse` traffic does not send that frame — so the code never ran, regardless of which field names it read.

This supersedes #8907, which corrected the cache field names but left them in that unreachable branch.

## Live verification

Verified directly against the API with a test credential. The credential value and `Authorization` header were never printed, committed, or added to fixtures; account identifiers, entitlements and the account-specific model list are excluded. Only frame names and payload shapes needed to validate the parser were kept.

A successful stream contained exactly:

```text
assistantResponseEvent
metadataEvent      {"stopReason":"END_TURN"}
contextUsageEvent  {"contextUsagePercentage":10.867}
meteringEvent      {"unit":"credit","unitPlural":"credits","usage":0.0897}
```

Two observations follow, and they drive the whole patch:

1. **No `metricsEvent`.** The branch holding every usage/cache read is dead on this traffic.
2. **No token counts anywhere.** `metadataEvent` carries only `stopReason`. Kiro reports a context *percentage* and a *credit* figure — never `inputTokens`/`outputTokens`, and never `cacheReadInputTokens`/`cacheWriteInputTokens`.

The prompt used was ~75 KB (well past the 1024-token minimum checkpoint the catalog declares), so the absent cache fields are not a below-threshold artifact.

## Changes

**Read the frames that actually arrive**

- Extract usage from `metadataEvent` as well as `metricsEvent`, including a nested `usage` object.
- Accept snake_case cache spellings alongside the Bedrock camelCase ones.
- Keep cache counts that arrive on a frame with no input/output totals. The old `inputTokens > 0 || outputTokens > 0` gate discarded the entire frame, taking the cache accounting with it.

**Scale the token estimate by the model's context window**

`ensureKiroUsage` multiplied `contextUsagePercentage` by a hardcoded `200000`. Since Kiro reports only a percentage, the budget it applies to decides the result:

| model | window | before | after |
|---|---|---|---|
| claude-sonnet-4.5 | 200k | 21,734 | 21,734 |
| claude-sonnet-5 | 1M | 21,734 | **108,670** |
| gpt-5.6-sol | 272k | 21,734 | **29,558** |

(measured at the observed `contextUsagePercentage: 10.867`)

These numbers feed `usage_history` and the API-key token-limit counters, so `claude-sonnet-5` was undercounted 5x. The per-model `contextLength` was already in the registry; it just was not consulted. Unknown ids fall back to `defaultContextLength`.

The completion estimate is now **subtracted** from the reported total instead of added on top — the percentage already covers the whole context, so adding it double-counted and inflated `total_tokens`.

**Preserve capability metadata** (carried over from #8907)

`ListAvailableModels.promptCaching` and its checkpoint limits are kept on discovered model variants. Nonnumeric or nullable limits stay `null` rather than coercing to a misleading `0`.

## Scope and honesty about limits

Token counts here are **estimates**, and the code says so. Kiro sends no token counts on this endpoint, so there is nothing exact to report.

Cache read/write **cannot** be derived from a single context percentage, and this PR does not try. It does not add `kiro` to provider-wide `CACHING_PROVIDERS` (capability is per model), infer cache hits from `meteringEvent`, or alter request headers. If upstream ever supplies cache counters on either frame, they are now read and surfaced; until then nothing is fabricated.

## Tests

```bash
node --import tsx/esm --test tests/unit/executor-kiro.test.ts tests/unit/kiro-available-models.test.ts
# 34 passed, 0 failed
```

Each new test was confirmed to fail against the pre-fix executor, so they defend real behavior rather than restating it:

- usage + cache tokens read from a `metadataEvent`
- cache tokens kept when input/output totals are absent
- snake_case cache spellings accepted
- estimate scaled per model, including `defaultContextLength` inheritance and unknown-id fallback
- completion carved out of the reported total, not added to it
- completion estimate still reported when no context percentage arrives
- the live API-key frame shape continues to invent no cache fields
