### PR TITLE
fix(kiro): keep relocated tool documentation on multi-turn requests

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -46,6 +46,69 @@ function wrapSystemReminder(text: string): string {
   return `<system-reminder>\n${text}\n</system-reminder>`;
 }
 
+/** Kiro rejects a `toolSpecification.description` longer than ~10000 chars. */
+const KIRO_TOOL_DESC_MAX = 10000;
+
+/** OpenAI- and Anthropic-shaped tool declarations, as clients actually send them. */
+type KiroToolInput = {
+  name?: string;
+  description?: string;
+  parameters?: unknown;
+  input_schema?: unknown;
+  function?: { name?: string; description?: string; parameters?: unknown };
+};
+
+/**
+ * Build Kiro `toolSpecification` entries, relocating any oversized description
+ * out of the schema and returning it separately.
+ *
+ * Kiro answers a raw upstream 400 for a description over
+ * {@link KIRO_TOOL_DESC_MAX}, so the schema keeps a pointer and the full text is
+ * handed back to be prepended to the current turn's content — the same
+ * relocation kiro-gateway performs in
+ * `converters_core.py::process_tools_with_long_descriptions`.
+ *
+ * The docs are *returned* rather than stashed on the message object, because the
+ * tool-bearing user turn is moved into `history` on every multi-turn request
+ * (see the currentMessage promotion below). Carrying them on the message lost
+ * them there — the model then saw only the pointer and no documentation — and
+ * also leaked an unknown `_toolDocs` field into the upstream payload, which Kiro
+ * rejects.
+ */
+function buildKiroToolSpecs(tools: KiroToolInput[]): {
+  specs: Array<Record<string, unknown>>;
+  docs: string;
+} {
+  const docs: string[] = [];
+  const specs = tools.map((t) => {
+    const name = t.function?.name || t.name;
+    let description = t.function?.description || t.description || "";
+
+    if (!description.trim()) {
+      description = `Tool: ${name}`;
+    }
+
+    if (description.length > KIRO_TOOL_DESC_MAX) {
+      docs.push(`## Tool: ${name}\n\n${description}`);
+      description = `[Full documentation in system prompt under '## Tool: ${name}']`;
+    }
+
+    return {
+      toolSpecification: {
+        name,
+        description,
+        inputSchema: {
+          json: normalizeKiroToolSchema(
+            t.function?.parameters || t.parameters || t.input_schema || {}
+          ),
+        },
+      },
+    };
+  });
+
+  return { specs, docs: docs.join("\n\n---\n\n") };
+}
+
 /**
  * Convert OpenAI messages to Kiro format
  * Rules: system/tool/user -> user role, merge consecutive same roles
@@ -60,6 +123,7 @@ function convertMessages(messages, tools, model) {
   let pendingImages: Array<{ format: string; source: { bytes: string } }> = [];
   let currentRole = null;
   let toolsAttached = false;
+  let toolDocs = "";
 
   // Only Claude models support images in Kiro. Kiro also routes non-Claude
   // models (deepseek, minimax, glm, qwen3-coder-next) that do not accept image
@@ -89,7 +153,6 @@ function convertMessages(messages, tools, model) {
             tools?: Array<Record<string, unknown>>;
           };
         };
-        _toolDocs?: string;
       } = {
         userInputMessage: {
           content: content,
@@ -118,39 +181,9 @@ function convertMessages(messages, tools, model) {
         if (!userMsg.userInputMessage.userInputMessageContext) {
           userMsg.userInputMessage.userInputMessageContext = {};
         }
-        // Kiro API rejects requests with tool descriptions > ~10000 chars.
-        // Move long descriptions to system prompt (same approach as kiro-gateway).
-        const TOOL_DESC_MAX = 10000;
-        const toolDocs: string[] = [];
-        userMsg.userInputMessage.userInputMessageContext.tools = tools.map((t) => {
-          const name = t.function?.name || t.name;
-          let description = t.function?.description || t.description || "";
-
-          if (!description.trim()) {
-            description = `Tool: ${name}`;
-          }
-
-          if (description.length > TOOL_DESC_MAX) {
-            toolDocs.push(`## Tool: ${name}\n\n${description}`);
-            description = `[Full documentation in system prompt under '## Tool: ${name}']`;
-          }
-
-          return {
-            toolSpecification: {
-              name,
-              description,
-              inputSchema: {
-                json: normalizeKiroToolSchema(
-                  t.function?.parameters || t.parameters || t.input_schema || {}
-                ),
-              },
-            },
-          };
-        });
-        // Attach tool docs to message so buildKiroPayload can prepend to content
-        if (toolDocs.length > 0) {
-          userMsg._toolDocs = toolDocs.join("\n\n---\n\n");
-        }
+        const built = buildKiroToolSpecs(tools);
+        userMsg.userInputMessage.userInputMessageContext.tools = built.specs;
+        if (built.docs) toolDocs = built.docs;
         toolsAttached = true;
       }
 
@@ -370,21 +403,9 @@ function convertMessages(messages, tools, model) {
     if (!currentMessage.userInputMessage.userInputMessageContext) {
       currentMessage.userInputMessage.userInputMessageContext = {};
     }
-    currentMessage.userInputMessage.userInputMessageContext.tools = tools.map((t) => {
-      const name = t.function?.name || t.name;
-      const description = t.function?.description || t.description || `Tool: ${name}`;
-      return {
-        toolSpecification: {
-          name,
-          description,
-          inputSchema: {
-            json: normalizeKiroToolSchema(
-              t.function?.parameters || t.parameters || t.input_schema || {}
-            ),
-          },
-        },
-      };
-    });
+    const built = buildKiroToolSpecs(tools);
+    currentMessage.userInputMessage.userInputMessageContext.tools = built.specs;
+    if (built.docs) toolDocs = built.docs;
     toolsAttached = true;
   }
 
@@ -577,7 +598,7 @@ function convertMessages(messages, tools, model) {
     alternatingHistory.push(item);
   }
 
-  return { history: alternatingHistory, currentMessage, toolsAttached };
+  return { history: alternatingHistory, currentMessage, toolsAttached, toolDocs };
 }
 
 /** Kiro's accepted reasoning-effort levels (`output_config.effort`). */
@@ -723,7 +744,7 @@ export function buildKiroPayload(model, body, stream, credentials) {
     }
   }
 
-  const { history, currentMessage, toolsAttached } = convertMessages(
+  const { history, currentMessage, toolsAttached, toolDocs } = convertMessages(
     messages,
     tools,
     normalizedModel
@@ -735,8 +756,10 @@ export function buildKiroPayload(model, body, stream, credentials) {
   const timestamp = new Date().toISOString();
   finalContent = `[Context: Current time is ${timestamp}]\n\n${finalContent}`;
 
-  // Prepend tool documentation for tools with long descriptions (moved from toolSpecification)
-  const toolDocs = (currentMessage as { _toolDocs?: string } | null)?._toolDocs;
+  // Prepend documentation for tools whose description was relocated out of
+  // `toolSpecification` (see buildKiroToolSpecs). Driven by convertMessages'
+  // return value, not the message object, so the docs survive the tool-bearing
+  // turn being moved into `history` on a multi-turn request.
   if (toolDocs) {
     finalContent = `# Tool Documentation\n\n${toolDocs}\n\n---\n\n${finalContent}`;
   }

--- a/tests/unit/kiro-long-tool-description-docs.test.ts
+++ b/tests/unit/kiro-long-tool-description-docs.test.ts
@@ -1,0 +1,198 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildKiroPayload } from "../../open-sse/translator/request/openai-to-kiro.ts";
+
+// Kiro rejects a `toolSpecification.description` longer than ~10000 chars, so the
+// translator relocates an oversized description into the current turn's content
+// and leaves a pointer in the schema (mirroring kiro-gateway's
+// `converters_core.py::process_tools_with_long_descriptions`).
+//
+// The relocation used to be carried on the message object as `_toolDocs`, which
+// broke in two ways: the tool-bearing user turn is moved into `history` on every
+// multi-turn request, so the docs were dropped and the model saw only the
+// pointer; and the field leaked into the upstream payload, which Kiro rejects
+// because it refuses unknown top-level keys.
+
+const POINTER = "[Full documentation in system prompt under '## Tool: big_tool']";
+const DOCS_HEADING = "# Tool Documentation";
+
+function bigToolWithDescriptionLength(length: number) {
+  return [
+    {
+      type: "function",
+      function: {
+        name: "big_tool",
+        description: "D".repeat(length),
+        parameters: { type: "object", properties: {} },
+      },
+    },
+  ];
+}
+
+const TURN_SHAPES = {
+  "single user turn": [{ role: "user", content: "a" }],
+  "multi-turn conversation": [
+    { role: "user", content: "a" },
+    { role: "assistant", content: "b" },
+    { role: "user", content: "c" },
+  ],
+  "deep multi-turn conversation": [
+    { role: "user", content: "a" },
+    { role: "assistant", content: "b" },
+    { role: "user", content: "c" },
+    { role: "assistant", content: "d" },
+    { role: "user", content: "e" },
+  ],
+  "assistant-first conversation": [
+    { role: "assistant", content: "hello" },
+    { role: "user", content: "hi" },
+  ],
+  // No user turn at all: currentMessage is the synthesized filler turn, which
+  // reaches the tools schema through the fallback attachment path.
+  "no user messages": [{ role: "assistant", content: "only" }],
+};
+
+test("relocated tool documentation reaches the current turn for every turn shape", () => {
+  for (const [label, messages] of Object.entries(TURN_SHAPES)) {
+    const payload = buildKiroPayload(
+      "claude-sonnet-4.5",
+      { messages, tools: bigToolWithDescriptionLength(12000) },
+      true,
+      {}
+    );
+    const current = payload.conversationState.currentMessage.userInputMessage;
+
+    assert.ok(
+      current.content.includes(DOCS_HEADING),
+      `${label}: full tool documentation must be prepended to the current turn`
+    );
+    assert.ok(
+      current.content.includes("D".repeat(12000)),
+      `${label}: the relocated description text itself must survive`
+    );
+    assert.equal(
+      current.userInputMessageContext?.tools[0].toolSpecification.description,
+      POINTER,
+      `${label}: the oversized description must be replaced by the pointer`
+    );
+  }
+});
+
+test("relocation never leaks an unknown field into the upstream payload", () => {
+  for (const [label, messages] of Object.entries(TURN_SHAPES)) {
+    const payload = buildKiroPayload(
+      "claude-sonnet-4.5",
+      { messages, tools: bigToolWithDescriptionLength(12000) },
+      true,
+      {}
+    );
+
+    assert.ok(
+      !JSON.stringify(payload).includes("_toolDocs"),
+      `${label}: Kiro rejects unknown top-level keys, so _toolDocs must not be serialized`
+    );
+  }
+});
+
+test("a description within the limit is left alone and adds no documentation block", () => {
+  const payload = buildKiroPayload(
+    "claude-sonnet-4.5",
+    {
+      messages: TURN_SHAPES["multi-turn conversation"],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "ok_tool",
+            description: "short desc",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    },
+    true,
+    {}
+  );
+  const current = payload.conversationState.currentMessage.userInputMessage;
+
+  assert.equal(
+    current.userInputMessageContext?.tools[0].toolSpecification.description,
+    "short desc",
+    "a description under the limit must reach Kiro verbatim"
+  );
+  assert.ok(
+    !current.content.includes(DOCS_HEADING),
+    "no documentation block should be injected when nothing was relocated"
+  );
+});
+
+// A description exactly at the limit must pass through: the guard triggers only
+// above it, and an off-by-one here would relocate a description Kiro accepts.
+test("the relocation boundary triggers above the limit, not at it", () => {
+  const messages = TURN_SHAPES["multi-turn conversation"];
+
+  const atLimit = buildKiroPayload(
+    "claude-sonnet-4.5",
+    { messages, tools: bigToolWithDescriptionLength(10000) },
+    true,
+    {}
+  );
+  const atLimitCurrent = atLimit.conversationState.currentMessage.userInputMessage;
+  assert.equal(
+    atLimitCurrent.userInputMessageContext?.tools[0].toolSpecification.description.length,
+    10000,
+    "a description exactly at the limit must not be relocated"
+  );
+  assert.ok(
+    !atLimitCurrent.content.includes(DOCS_HEADING),
+    "no documentation block at the boundary"
+  );
+
+  const overLimit = buildKiroPayload(
+    "claude-sonnet-4.5",
+    { messages, tools: bigToolWithDescriptionLength(10001) },
+    true,
+    {}
+  );
+  assert.equal(
+    overLimit.conversationState.currentMessage.userInputMessage.userInputMessageContext?.tools[0]
+      .toolSpecification.description,
+    POINTER,
+    "one char over the limit must be relocated"
+  );
+});
+
+// Only the oversized tool is relocated; a mixed inventory must keep the short
+// descriptions inline so the model still sees them next to the schema.
+test("only oversized descriptions are relocated in a mixed tool inventory", () => {
+  const payload = buildKiroPayload(
+    "claude-sonnet-4.5",
+    {
+      messages: TURN_SHAPES["multi-turn conversation"],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "small_tool",
+            description: "compact",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+        ...bigToolWithDescriptionLength(12000),
+      ],
+    },
+    true,
+    {}
+  );
+  const current = payload.conversationState.currentMessage.userInputMessage;
+  const specs = current.userInputMessageContext?.tools;
+
+  assert.equal(specs[0].toolSpecification.description, "compact");
+  assert.equal(specs[1].toolSpecification.description, POINTER);
+  assert.ok(current.content.includes("## Tool: big_tool"));
+  assert.ok(
+    !current.content.includes("## Tool: small_tool"),
+    "a tool that was never relocated must not get a documentation section"
+  );
+});


### PR DESCRIPTION
## Summary

Kiro rejects a `toolSpecification.description` over ~10000 chars, so the translator relocates an oversized description into the current turn's content and leaves a pointer in the schema. On **any multi-turn request the relocated documentation was dropped**, leaving the model with a pointer to text it never received.

## The bug

The relocated text was stashed on the message object as `_toolDocs`, but `buildKiroPayload` read it from `currentMessage` only. The tool-bearing user turn is moved into `history` on every request with more than one user turn, so the docs went with it and were never emitted.

Reproduced with one tool whose description exceeds the limit:

```text
single-turn  docs in current content: true
multi-turn   docs in current content: false   ← model sees only the pointer
```

The schema still said `[Full documentation in system prompt under '## Tool: X']`, so the model was told where to look and the section was not there.

`_toolDocs` also rode along inside `conversationState.history`, sending ~12 KB of a field Kiro has no use for. It sat nested rather than at the top level, so `transformRequest`'s whitelist did not strip it. I did not observe Kiro rejecting it — the cost is wasted payload, not a 400.

A second gap: the fallback tool-attachment path (used when no user turn carried the schema) bypassed the length guard entirely, emitting full oversized descriptions that Kiro *does* reject.

## Fix

Return the relocated docs from `convertMessages` instead of carrying them on a message, so they survive the turn being moved into history, and route both attachment paths through one `buildKiroToolSpecs` builder so the guard cannot be bypassed.

This also removes the `_toolDocs` field entirely, so nothing extraneous is serialized.

## Tests

```bash
node --import tsx/esm --test tests/unit/kiro-long-tool-description-docs.test.ts \
  tests/unit/translator-openai-to-kiro.test.ts \
  tests/unit/openai-to-kiro-helpers-split.test.ts \
  tests/unit/kiro-tool-schema-sanitize-1375.test.ts \
  tests/unit/kiro-system-reminder-2306.test.ts \
  tests/unit/kiro-continue-filler-5231.test.ts
# 62 passed, 0 failed
```

New coverage, each confirmed to fail against the pre-fix translator:

- docs reach the current turn across single-turn, multi-turn, deep multi-turn, assistant-first, and no-user-turn shapes
- no unknown field is serialized into the payload
- a description within the limit is left verbatim and adds no documentation block
- the boundary triggers above 10000, not at it
- in a mixed inventory only the oversized tool is relocated

Also verified manually: multiple oversized tools each get their own `## Tool: <name>` section, Anthropic-shaped declarations (`input_schema` at top level) work, and the documentation block is prepended ahead of the timestamp so the cacheable prefix ordering is unchanged.
