### PR TITLE
fix(open-sse): route GitHub Copilot gpt-5.6 sol/terra/luna to /responses

### DIFF
--- a/open-sse/config/providers/registry/github/index.ts
+++ b/open-sse/config/providers/registry/github/index.ts
@@ -122,9 +122,24 @@ export const githubProvider: RegistryEntry = {
       contextLength: 1000000,
       maxOutputTokens: 64000,
     },
-    { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", maxOutputTokens: 128000 },
-    { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", maxOutputTokens: 128000 },
-    { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", maxOutputTokens: 128000 },
+    {
+      id: "gpt-5.6-sol",
+      name: "GPT-5.6 Sol",
+      targetFormat: "openai-responses",
+      maxOutputTokens: 128000,
+    },
+    {
+      id: "gpt-5.6-terra",
+      name: "GPT-5.6 Terra",
+      targetFormat: "openai-responses",
+      maxOutputTokens: 128000,
+    },
+    {
+      id: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      targetFormat: "openai-responses",
+      maxOutputTokens: 128000,
+    },
     { id: "gpt-5.5", name: "GPT-5.5", ...GPT_5_5_CODEX_CAPABILITIES, maxOutputTokens: 128000 },
     {
       id: "gpt-5.4",

--- a/tests/unit/executor-github.test.ts
+++ b/tests/unit/executor-github.test.ts
@@ -98,6 +98,21 @@ test("GithubExecutor.buildUrl routes unlisted Codex models to /responses (9route
   );
 });
 
+test("GithubExecutor.buildUrl routes gpt-5.6-sol/terra/luna to /responses (regression)", () => {
+  // These models were registered in the `gh` registry without targetFormat, so
+  // getModelTargetFormat returned null and requests fell through to
+  // /chat/completions -> upstream 400 "model is not accessible via the
+  // /chat/completions endpoint". They only support /responses upstream.
+  const executor = new GithubExecutor();
+  for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    assert.equal(
+      executor.buildUrl(model, true),
+      "https://api.githubcopilot.com/responses",
+      `${model} must route to /responses`
+    );
+  }
+});
+
 test("GithubExecutor.transformRequest injects JSON response instructions for Claude and strips reasoning fields", () => {
   const executor = new GithubExecutor();
   const body = {


### PR DESCRIPTION
gh registry entries for gpt-5.6-sol/terra/luna lacked targetFormat, so requests fell through to /chat/completions where Copilot upstream returns 400 "model is not accessible via the /chat/completions endpoint". ghe-copilot already had targetFormat set correctly for the same model ids.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Run only the focused loop for what you changed — the full unit suite, Vitest, the
60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Focused tests for the change: `node --import tsx/esm --test tests/unit/<file>.test.ts`
- [ ] `npm run lint`
- [ ] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.