### PR TITLE
docs: use hard links, not a symlink, for a worktree's node_modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,9 +461,17 @@ own dedicated branch, and you MUST confirm the base branch with the operator bef
    git fetch origin "$BASE_BRANCH"
    git worktree add ".claude/worktrees/${TASK##*/}" -b "$TASK" "origin/$BASE_BRANCH"
    cd ".claude/worktrees/${TASK##*/}"
-   # symlink node_modules from the main checkout to skip a per-worktree npm install:
-   ln -s "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
+   # Reuse the main checkout's node_modules to skip a per-worktree npm install.
+   # HARD LINKS (`cp -al`), never a symlink: ~5s for the whole tree and near-zero extra
+   # disk (the inodes are shared), and unlike a symlink it does not break the dev server.
+   cp -al "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
    ```
+
+   **Never `ln -s` node_modules.** Turbopack rejects a symlink that resolves outside the
+   project root, so `npm run dev` dies with a FATAL panic (`Symlink [project]/node_modules
+   is invalid, it points out of the filesystem root`) while typecheck, lint and the test
+   runners all keep passing — the error names "filesystem root", not the worktree, so it
+   reads like a Next/build bug and costs real time to trace (incident 2026-07-31, #9043).
 
    In Claude Code prefer the native `EnterWorktree` tool (it already creates worktrees under
    `.claude/worktrees/`): create the worktree with the command above, then call `EnterWorktree`

--- a/docs/i18n/pl/CLAUDE.md
+++ b/docs/i18n/pl/CLAUDE.md
@@ -461,9 +461,17 @@ own dedicated branch, and you MUST confirm the base branch with the operator bef
    git fetch origin "$BASE_BRANCH"
    git worktree add ".claude/worktrees/${TASK##*/}" -b "$TASK" "origin/$BASE_BRANCH"
    cd ".claude/worktrees/${TASK##*/}"
-   # symlink node_modules from the main checkout to skip a per-worktree npm install:
-   ln -s "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
+   # Reuse the main checkout's node_modules to skip a per-worktree npm install.
+   # HARD LINKS (`cp -al`), never a symlink: ~5s for the whole tree and near-zero extra
+   # disk (the inodes are shared), and unlike a symlink it does not break the dev server.
+   cp -al "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
    ```
+
+   **Never `ln -s` node_modules.** Turbopack rejects a symlink that resolves outside the
+   project root, so `npm run dev` dies with a FATAL panic (`Symlink [project]/node_modules
+   is invalid, it points out of the filesystem root`) while typecheck, lint and the test
+   runners all keep passing — the error names "filesystem root", not the worktree, so it
+   reads like a Next/build bug and costs real time to trace (incident 2026-07-31, #9043).
 
    In Claude Code prefer the native `EnterWorktree` tool (it already creates worktrees under
    `.claude/worktrees/`): create the worktree with the command above, then call `EnterWorktree`

--- a/docs/i18n/zh-CN/CLAUDE.md
+++ b/docs/i18n/zh-CN/CLAUDE.md
@@ -415,9 +415,17 @@ git push -u origin feat/your-feature
    git fetch origin "$BASE_BRANCH"
    git worktree add ".claude/worktrees/${TASK##*/}" -b "$TASK" "origin/$BASE_BRANCH"
    cd ".claude/worktrees/${TASK##*/}"
-   # 从主工作区符号链接 node_modules，省去每个 worktree 的 npm install：
-   ln -s "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
+   # 复用主工作区的 node_modules，省去每个 worktree 的 npm install。
+   # 必须用硬链接（`cp -al`），绝不能用符号链接：整棵树约 5 秒，几乎不占额外磁盘
+   # （inode 是共享的），而且与符号链接不同，它不会破坏开发服务器。
+   cp -al "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
    ```
+
+   **绝不要对 node_modules 使用 `ln -s`。** Turbopack 会拒绝解析到项目根目录之外的符号链接，
+   因此 `npm run dev` 会以 FATAL panic 崩溃（`Symlink [project]/node_modules is invalid, it
+   points out of the filesystem root`），而 typecheck、lint 和测试运行器却都照常通过 —— 错误信息
+   提到的是 "filesystem root" 而不是 worktree，看起来像 Next/构建的 bug，排查会浪费大量时间
+   （事故 2026-07-31，#9043）。
 
    在 Claude Code 中优先使用原生的 `EnterWorktree` 工具（它已经在 `.claude/worktrees/` 下创建 worktree）：先用上述命令创建 worktree，然后用其 `path` 调用 `EnterWorktree`。
 


### PR DESCRIPTION
The worktree-isolation recipe in `CLAUDE.md` told agents to symlink `node_modules` from the main checkout. That silently breaks the dev server.

## The defect

Turbopack refuses a symlink that resolves outside the project root:

```
FATAL: An unexpected Turbopack error occurred.
Error [TurbopackInternalError]: Symlink [project]/node_modules is invalid, it points out of the filesystem root
```

What makes it expensive: `typecheck:core`, `lint` and both test runners pass normally, so the setup looks fine until someone needs `npm run dev` — and the message names "filesystem root", not the worktree, so it reads like a Next/build problem rather than a symlink problem.

Hit while validating #9043 end-to-end (Task 9 of that plan needs a running server).

## The fix

`cp -al` — hard links. Same benefit (no per-worktree `npm install`), none of the defect:

- ~5 seconds for the 4.4 GB tree
- near-zero extra disk: hard links share inodes
- Verified on the worktree that produced this PR: `stat` reports the same inode as the main checkout and a link count of 2

Also added an explicit "never `ln -s`" note with the exact panic text, so the next agent recognises it instead of tracing it.

## Scope

- `CLAUDE.md` — the recipe + the warning
- `docs/i18n/zh-CN/CLAUDE.md` — mirrored and translated
- `docs/i18n/pl/CLAUDE.md` — mirrored in English, matching its surrounding section (that file's translation of this whole block is already incomplete upstream; not widening scope to fix that here)

Those are the only three files in the repo carrying the command (verified by grep). The other 40 translated `CLAUDE.md` copies do not include this block.

## Validation

Docs-only change. `npm run check:docs-sync` and `npm run check:docs-all` (link check + fabricated-claim gate, 134 markdown files) both pass.