### PR TITLE
fix(a2a): timing-safe bearer comparison + drop per-request debug log

### DIFF
--- a/changelog.d/fixes/9083-a2a-auth-timing-safe.md
+++ b/changelog.d/fixes/9083-a2a-auth-timing-safe.md
@@ -1,0 +1,1 @@
+- **fix(a2a):** the A2A JSON-RPC router now compares the bearer token against `OMNIROUTE_API_KEY` in constant time (`crypto.timingSafeEqual`) instead of `===`, closing a token-length timing side-channel, and no longer logs the request URL to server logs on every call ([#9083](https://github.com/diegosouzapw/OmniRoute/pull/9083))

--- a/src/app/a2a/route.ts
+++ b/src/app/a2a/route.ts
@@ -10,6 +10,7 @@
  * Auth: Bearer token via Authorization header
  */
 
+import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { getTaskManager } from "@/lib/a2a/taskManager";
 import { logRoutingDecision } from "@/lib/a2a/routingLogger";
@@ -64,6 +65,20 @@ function toMessageArray(raw: unknown): A2AMessage[] | null {
 
 // ============ Auth ============
 
+/**
+ * Constant-time comparison of the presented bearer token against the configured
+ * key. A plain `===` short-circuits on the first differing byte, leaking the
+ * length of the shared prefix through response timing; `timingSafeEqual` does
+ * not. It requires equal-length buffers, so mismatched lengths are rejected up
+ * front (the length itself is not secret).
+ */
+function tokensMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
 function authenticate(req: NextRequest): boolean {
   // If no API key is configured, allow all requests
   const configuredKey = process.env.OMNIROUTE_API_KEY;
@@ -71,7 +86,7 @@ function authenticate(req: NextRequest): boolean {
 
   const authHeader = req.headers.get("authorization") || "";
   const token = authHeader.replace(/^Bearer\s+/i, "");
-  return token === configuredKey;
+  return tokensMatch(token, configuredKey);
 }
 
 // ============ JSON-RPC Helpers ============
@@ -106,7 +121,6 @@ async function rejectIfA2ADisabled(id: string | number | null) {
 // ============ Route Handler ============
 
 export async function POST(req: NextRequest) {
-  console.log("==> HIT A2A ROUTER:", req.url);
   // Auth check
   if (!authenticate(req)) {
     return jsonRpcError(null, -32600, "Unauthorized: missing or invalid API key");

--- a/tests/unit/a2a-auth-timing-safe.test.ts
+++ b/tests/unit/a2a-auth-timing-safe.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { NextRequest } from "next/server";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-a2a-auth-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+const ORIGINAL_OMNIROUTE_API_KEY = process.env.OMNIROUTE_API_KEY;
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+delete process.env.OMNIROUTE_API_KEY;
+
+const core = await import("../../src/lib/db/core.ts");
+const a2aRoute = await import("../../src/app/a2a/route.ts");
+
+const API_KEY = "test-secret";
+
+function makeJsonRpcRequest(token?: string): NextRequest {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token !== undefined) headers.authorization = `Bearer ${token}`;
+  return new Request("http://localhost/a2a?trace=should-not-be-logged", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "auth-check",
+      method: "message/send",
+      params: { message: { role: "user", content: "hello" } },
+    }),
+  }) as unknown as NextRequest;
+}
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  process.env.OMNIROUTE_API_KEY = API_KEY;
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+
+  if (ORIGINAL_OMNIROUTE_API_KEY === undefined) delete process.env.OMNIROUTE_API_KEY;
+  else process.env.OMNIROUTE_API_KEY = ORIGINAL_OMNIROUTE_API_KEY;
+});
+
+test("a valid bearer token passes auth (reaches the disabled-endpoint check)", async () => {
+  // A2A is disabled by default, so a correctly-authenticated request gets past
+  // auth and is rejected with -32000 (disabled) rather than -32600 (unauthorized).
+  const response = await a2aRoute.POST(makeJsonRpcRequest(API_KEY));
+  const body = (await response.json()) as { error?: { code?: number } };
+
+  assert.equal(response.status, 503);
+  assert.equal(body.error?.code, -32000);
+});
+
+test("a same-length but different token is rejected", async () => {
+  // "xxxxxxxxxxx" has the same byte length as "test-secret"; this exercises the
+  // timingSafeEqual comparison itself, not just the length pre-check.
+  const wrongSameLength = "x".repeat(API_KEY.length);
+  assert.equal(wrongSameLength.length, API_KEY.length);
+
+  const response = await a2aRoute.POST(makeJsonRpcRequest(wrongSameLength));
+  const body = (await response.json()) as { error?: { code?: number; message?: string } };
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error?.code, -32600);
+  assert.match(body.error?.message || "", /Unauthorized/i);
+});
+
+test("a different-length token is rejected without throwing", async () => {
+  // timingSafeEqual throws on unequal-length buffers; the length pre-check must
+  // short-circuit so this never surfaces as a 500.
+  const response = await a2aRoute.POST(makeJsonRpcRequest("short"));
+  const body = (await response.json()) as { error?: { code?: number } };
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error?.code, -32600);
+});
+
+test("the router does not log the request URL on every call", async () => {
+  const original = console.log;
+  const logged: string[] = [];
+  console.log = (...args: unknown[]) => {
+    logged.push(args.map(String).join(" "));
+  };
+
+  try {
+    await a2aRoute.POST(makeJsonRpcRequest(API_KEY));
+  } finally {
+    console.log = original;
+  }
+
+  assert.ok(
+    !logged.some((line) => line.includes("/a2a") || line.includes("HIT A2A ROUTER")),
+    `expected no per-request URL logging, got: ${JSON.stringify(logged)}`
+  );
+});


### PR DESCRIPTION
## What & why

Two small hardening fixes to the A2A JSON-RPC router (`src/app/a2a/route.ts`):

**1. Timing-safe bearer-token comparison.** `authenticate()` compared the presented token against `OMNIROUTE_API_KEY` with `===`:

```ts
return token === configuredKey;
```

`===` on strings short-circuits at the first differing byte, so response time scales with the length of the shared prefix — a classic timing side-channel against a secret. Replaced with a constant-time `crypto.timingSafeEqual`, guarding the equal-length precondition it requires (the length itself isn't secret, so an early length mismatch is fine):

```ts
function tokensMatch(provided: string, expected: string): boolean {
  const a = Buffer.from(provided);
  const b = Buffer.from(expected);
  if (a.length !== b.length) return false;
  return timingSafeEqual(a, b);
}
```

**2. Drop a per-request debug log.** The top of `POST` unconditionally ran:

```ts
console.log("==> HIT A2A ROUTER:", req.url);
```

Leftover debug output — it printed the full request URL to server logs on every A2A call. Removed.

## Scope note

I initially looked at also sanitizing the client-facing error strings, but the task store deliberately keeps the raw error message (`executeA2ATaskWithState` → `tasks/get`), and that behavior is asserted by `tests/unit/t09-a2a-lifecycle.test.ts` and `open-sse/mcp-server/__tests__/a2aLifecycle.test.ts`. Since that's intentional, I left it alone and kept this PR to the two unambiguous hardening changes.

## Tests

Adds `tests/unit/a2a-auth-timing-safe.test.ts`:
- a valid bearer token passes auth (reaches the disabled-endpoint check);
- a same-length-but-different token is rejected (exercises the compare itself, not just the length pre-check);
- a different-length token is rejected without throwing (the length guard prevents `timingSafeEqual` from throwing → no accidental 500);
- the router no longer logs the request URL on every call.

```
✔ tests/unit/a2a-auth-timing-safe.test.ts — 4 pass
✔ tests/unit/a2a-enabled-route.test.ts + t09-a2a-lifecycle.test.ts — 8 pass (no regressions)
```

No behavior change for valid clients; no public API surface touched.
