### PR TITLE
[TS7] fix(types): validate chat context estimation inputs

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,6 +1,7 @@
 import { injectMemoryAndSkills } from "./chatCore/memorySkillsInjection.ts";
 import { resolveChatCoreRequestSetup } from "./chatCore/requestSetup.ts";
 import { buildFailureUsageRecord } from "./chatCore/failureUsage.ts";
+import { estimateFinalInputTokens } from "./chatCore/contextEstimation.ts";
 import { extractSystemRoleMessages } from "./chatCore/claudeSystemRole.ts";
 export { extractSystemRoleMessages } from "./chatCore/claudeSystemRole.ts";
 import { checkIdempotencyCache } from "./chatCore/idempotency.ts";
@@ -1809,27 +1810,6 @@ export async function handleChatCore({
   // filtering is advisory and may preserve an all-incompatible pool; this is the
   // hard boundary that prevents a too-large prompt (or a negative token budget)
   // from reaching an OpenAI-compatible upstream such as NVIDIA NIM.
-  const estimateFinalInputTokens = (requestBody: Record<string, unknown> | null | undefined) => {
-    const adapted = requestBody
-      ? adaptBodyForCompression(requestBody as Record<string, unknown>).body
-      : null;
-    const messages =
-      adapted?.messages ||
-      requestBody?.contents ||
-      requestBody?.request?.contents ||
-      (Array.isArray(requestBody?.input)
-        ? requestBody.input
-        : requestBody?.input && typeof requestBody.input === "object"
-          ? requestBody.input
-          : []);
-    return (
-      estimateTokens(messages) +
-      (Array.isArray(requestBody?.tools) ? estimateTokens(requestBody.tools) : 0) +
-      estimateTokens(requestBody?.system) +
-      estimateTokens(requestBody?.instructions)
-    );
-  };
-
   let finalEstimatedInputTokens = estimateFinalInputTokens(body as Record<string, unknown>);
   // Reuse the already-resolved `contextLimit` (may have been narrowed to the
   // per-target combo window above, resolveComboContextLimit) instead of a bare

--- a/open-sse/handlers/chatCore/contextEstimation.ts
+++ b/open-sse/handlers/chatCore/contextEstimation.ts
@@ -1,0 +1,29 @@
+import { adaptBodyForCompression } from "../../services/compression/bodyAdapter.ts";
+import { estimateTokens } from "../../services/contextManager.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+function asJsonRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+export function estimateFinalInputTokens(requestBody: JsonRecord | null | undefined): number {
+  const adapted = requestBody ? adaptBodyForCompression(requestBody).body : null;
+  const nestedRequest = asJsonRecord(requestBody?.request);
+  const messages =
+    adapted?.messages ||
+    requestBody?.contents ||
+    nestedRequest?.contents ||
+    (Array.isArray(requestBody?.input)
+      ? requestBody.input
+      : requestBody?.input && typeof requestBody.input === "object"
+        ? requestBody.input
+        : []);
+
+  return (
+    estimateTokens(messages) +
+    (Array.isArray(requestBody?.tools) ? estimateTokens(requestBody.tools) : 0) +
+    estimateTokens(requestBody?.system) +
+    estimateTokens(requestBody?.instructions)
+  );
+}

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -254,7 +254,7 @@ function extractImageTokens(node: unknown, seen: Set<unknown>): { node: unknown;
  * budget instead of measuring its base64 payload as raw text, then the
  * remainder of the structure is measured normally via the char/4 heuristic.
  */
-export function estimateTokens(text: string | object | null | undefined): number {
+export function estimateTokens(text: unknown): number {
   if (!text) return 0;
   if (typeof text === "string") {
     return Math.ceil(text.length / CHARS_PER_TOKEN);

--- a/tests/unit/chatcore-context-estimation.test.ts
+++ b/tests/unit/chatcore-context-estimation.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { estimateFinalInputTokens } from "../../open-sse/handlers/chatCore/contextEstimation.ts";
+import { estimateTokens } from "../../open-sse/services/contextManager.ts";
+
+test("estimateFinalInputTokens counts nested request contents and auxiliary fields", () => {
+  const contents = [{ role: "user", parts: [{ text: "nested Gemini request" }] }];
+  const tools = [{ name: "lookup", description: "find a record" }];
+  const body = {
+    request: { contents },
+    tools,
+    system: "system prompt",
+    instructions: 42,
+  };
+
+  assert.equal(
+    estimateFinalInputTokens(body),
+    estimateTokens(contents) +
+      estimateTokens(tools) +
+      estimateTokens(body.system) +
+      estimateTokens(body.instructions)
+  );
+});
+
+test("estimateFinalInputTokens ignores a malformed nested request and uses input", () => {
+  const input = [{ role: "user", content: "fallback input" }];
+  const body = {
+    request: "not an object",
+    input,
+  };
+
+  assert.equal(estimateFinalInputTokens(body), estimateTokens(input));
+});
+
+test("estimateTokens accepts the unknown JSON values it already serializes", () => {
+  assert.equal(estimateTokens(true), 1);
+  assert.equal(estimateTokens(42), 1);
+  assert.equal(estimateTokens(undefined), 0);
+});


### PR DESCRIPTION
## Summary

- Recovered the reviewed context-estimation TypeScript slice from `e57929667a13dab725234c3df224ff175df778a8`.
- Moved the final input-token estimator out of `chatCore.ts` and guarded nested `request` records before reading `contents`.
- Widened `estimateTokens()` to `unknown`, matching its existing runtime traversal.
- Scope is limited to the four context-estimation files; independent of #8809 and #8818.

Base: `release/v3.8.50` @ `371c10ea5f1184ffcb74d71f6bec15885c2dfe28`
Head: `35dd35c8f`

## Diagnostics

Canonicalized TS diagnostic multiset comparison against the base:

- TypeScript 6.0.3: `125 → 122`; removed exactly 3 diagnostics, added `0`.
- TypeScript 7.0.2: `124 → 121`; removed exactly 3 diagnostics, added `0`.
- Removed in both versions: `chatCore.ts TS2339 Property 'contents' does not exist on type 'unknown'` ×1 and `TS2345 Argument of type 'unknown' is not assignable to parameter of type 'string | object'` ×2.

The compiler commands retain unrelated baseline diagnostics and therefore exit non-zero; no new diagnostics were introduced.

## Validation

- `node --import tsx/esm --test tests/unit/chatcore-context-estimation.test.ts` — 3/3 passed.
- ESLint on all four changed files — passed.
- Prettier check on all four changed files — passed.
- `npm run check:file-size` — passed.
- `git diff --check` — passed.

## Changed files

- `open-sse/handlers/chatCore.ts`
- `open-sse/handlers/chatCore/contextEstimation.ts`
- `open-sse/services/contextManager.ts`
- `tests/unit/chatcore-context-estimation.test.ts`
