### PR TITLE
[TS7] fix(types): narrow stream response output

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -226,8 +226,8 @@ function restoreResponsesPassthroughFunctionCallIdentity(
     return restoreItem(parsed.item);
   }
 
-  if (parsed.type === "response.completed" && Array.isArray(parsed.response?.output)) {
-    return (parsed.response as JsonRecord).output.reduce(
+  if (parsed.type === "response.completed" && Array.isArray(asRecord(parsed.response).output)) {
+    return (asRecord(parsed.response).output as unknown[]).reduce<boolean>(
       (changed: boolean, item: unknown) => restoreItem(item) || changed,
       false
     );

--- a/tests/unit/stream-utilities.test.ts
+++ b/tests/unit/stream-utilities.test.ts
@@ -91,6 +91,52 @@ test("createPassthroughStreamWithLogger omits [DONE] for Responses clients", asy
   assert.doesNotMatch(result, /data: \[DONE\]/);
 });
 
+test("createPassthroughStreamWithLogger restores namespace identity in completed output", async () => {
+  const transform = createPassthroughStreamWithLogger(
+    "codex",
+    null,
+    null,
+    "gpt-5.5-low",
+    null,
+    null,
+    null,
+    null,
+    null,
+    "openai-responses",
+    new Map([["read", { namespace: "mcp__files", name: "read" }]])
+  );
+
+  const writer = transform.writable.getWriter();
+  await writer.write(
+    new TextEncoder().encode(
+      [
+        "event: response.output_item.done",
+        'data: {"type":"response.output_item.done","response_id":"resp_namespace","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"read","arguments":"{}"}}',
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"id":"resp_namespace","status":"completed","output":[]}}',
+        "",
+      ].join("\n")
+    )
+  );
+  await writer.close();
+
+  const reader = transform.readable.getReader();
+  const decoder = new TextDecoder();
+  let result = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    result += decoder.decode(value);
+  }
+
+  const completed = result
+    .split(/\n\n+/)
+    .find((block) => block.includes('"type":"response.completed"'));
+  assert.ok(completed, "expected a response.completed event on the wire");
+  assert.match(completed, /"namespace":"mcp__files"/);
+  assert.match(completed, /"name":"read"/);
+});
+
 test("createPassthroughStreamWithLogger separates K3 thinking tags", async () => {
   const transform = createPassthroughStreamWithLogger(
     "kimi-coding",


### PR DESCRIPTION
## Summary

- Narrow the already-guarded `response.completed.response.output` array in `open-sse/utils/stream.ts` for TypeScript 6 and 7.
- Preserve the existing Responses namespace/name restoration, stream framing, and cancellation behavior.
- Add a focused regression guard and the implementation plan at `docs/superpowers/plans/2026-08-01-ts7-stream-response-output-types.md`.

## Root cause

`restoreResponsesPassthroughFunctionCallIdentity` already checked that `response.output` was an array, but TypeScript 6/7 still saw the optional response field as `unknown` and could not infer the boolean reducer accumulator. The fix uses the existing null-safe `asRecord` helper and an explicit `unknown[]`/`boolean` reducer type without changing runtime control flow.

## Validation

- TS 6.0.3 from `/private/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/tmp.K6zv2yl8jN/base/node_modules`: `stream.ts` diagnostics 9 → 7.
- TS 7.0.2 from `/Users/backryun/.npm/_npx/1ac1eddd0355a233/node_modules`: `stream.ts` diagnostics 9 → 7 with the same canonicalized remaining multiset.
- Removed exactly TS2339 at 228/229; added 0 new canonicalized diagnostics.
- `open-sse/utils/stream.ts`: 2884 → 2884 lines.
- Focused stream suites: 62/62 passing.
- Prettier, targeted ESLint, `npm run check:file-size`, and `git diff --check`: passing.
- No dependency installation or update performed.
