### PR TITLE
[TS7] [v3.8.50] fix(types): preserve SSE tool call function shape

### DIFF
--- a/open-sse/handlers/sseParser.ts
+++ b/open-sse/handlers/sseParser.ts
@@ -244,10 +244,8 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
             existing.index = tc.index;
           }
           if (tc?.function?.name && !existing.function?.name) {
-            existing.function = existing.function || {};
             existing.function.name = tc.function.name;
           }
-          existing.function = existing.function || {};
           existing.function.arguments = appendToolCallArgumentDelta(
             existing.function.arguments,
             deltaArgs


### PR DESCRIPTION
## Summary

- remove two unreachable empty-object fallbacks from streamed OpenAI tool-call accumulation
- preserve the complete `{ name, arguments }` function record initialized for every accumulated call
- keep runtime tool-call assembly unchanged while making the existing contract visible to TypeScript 6 and 7

## Why

`AccumulatedToolCall.function` is required and initialized before an entry reaches the existing-call branch. Reassigning it through `existing.function || {}` widened the value to an incomplete object and produced two TS2322 diagnostics even though the empty arm cannot occur at runtime.

## Impact

No valid request or response behavior changes. Tool-call names, argument delta concatenation, numeric IDs, ordering, and finish-reason normalization retain their existing paths.

## Validation

Base: `release/v3.8.50@371c10ea5f1184ffcb74d71f6bec15885c2dfe28`

- TypeScript 6: **125 → 123**
- TypeScript 7: **124 → 122**
- complete line-number/worktree-path-normalized diagnostic multiset: **2 removed, 0 added** under each compiler
- SSE parser focused suites: **36/36 passed**
- changed-file ESLint with repository suppressions: passed
- Prettier and `git diff --check`: passed
- file-size, complexity, cognitive-complexity, and complexity-ratchet gates: passed