### PR TITLE
[TS7] fix(types): narrow CCR store rejections

### DIFF
--- a/open-sse/mcp-server/tools/compressionTools.ts
+++ b/open-sse/mcp-server/tools/compressionTools.ts
@@ -256,6 +256,7 @@ import {
   getCcrStoreStats,
   handleCcrRetrieve,
   inspectCcrBlock,
+  isCcrStoreRejection,
   listCcrBlocks,
   tryStoreBlock,
 } from "../../services/compression/engines/ccr/index.ts";
@@ -298,7 +299,7 @@ export async function handleCcrStoreTool(
     ttlSeconds: args.ttlSeconds,
   });
   const auditInput = buildCcrStoreAuditInput(args);
-  if (!result.stored) {
+  if (isCcrStoreRejection(result)) {
     const output = { stored: false as const, reason: result.reason };
     await logToolCall(
       "omniroute_ccr_store",

--- a/open-sse/services/compression/engines/ccr/index.ts
+++ b/open-sse/services/compression/engines/ccr/index.ts
@@ -105,6 +105,12 @@ export type StoreCcrBlockResult =
       reason: "block_too_large" | "principal_budget_exceeded" | "global_budget_exceeded";
     };
 
+export function isCcrStoreRejection(
+  result: StoreCcrBlockResult
+): result is Extract<StoreCcrBlockResult, { stored: false }> {
+  return result.stored === false;
+}
+
 export interface CcrStoreStats {
   storage: "memory";
   entries: number;
@@ -330,7 +336,9 @@ export function storeBlock(
   options: StoreCcrBlockOptions = {}
 ): string {
   const result = tryStoreBlock(text, principalId, options);
-  if (!result.stored) throw new RangeError(`CCR store rejected block: ${result.reason}`);
+  if (isCcrStoreRejection(result)) {
+    throw new RangeError(`CCR store rejected block: ${result.reason}`);
+  }
   return result.hash;
 }
 

--- a/tests/unit/compression/ccr-mcp-integration.test.ts
+++ b/tests/unit/compression/ccr-mcp-integration.test.ts
@@ -156,6 +156,14 @@ describe("CCR MCP contracts and handlers", () => {
     if (!result.stored) assert.equal(result.reason, "block_too_large");
   });
 
+  it("propagates store rejection reasons without changing the MCP result shape", async () => {
+    const result = await tools.handleCcrStoreTool(
+      { content: "x".repeat(ccr.MAX_CCR_BLOCK_BYTES + 1), contentType: "text/plain" },
+      writeExtra
+    );
+    assert.deepEqual(result, { stored: false, reason: "block_too_large" });
+  });
+
   it("stores through MCP and exposes metadata without content in inspect/list", async () => {
     const stored = await tools.handleCcrStoreTool(
       { content: "sensitive body", contentType: "text/plain", ttlSeconds: 120 },


### PR DESCRIPTION
## Summary

- Fix Task 2 CCR store rejection narrowing with a real `isCcrStoreRejection` type predicate.
- Keep the existing `{ stored: true, ... } | { stored: false, reason, ... }` runtime result shape unchanged; no retagging or new discriminator is emitted.
- Use the predicate at the three existing `reason` access sites in `storeBlock` and the MCP store handler.

## Base and commit

- Base repository: `diegosouzapw/OmniRoute`
- Base branch: `release/v3.8.50`
- Base SHA: `371c10ea5f1184ffcb74d71f6bec15885c2dfe28`
- Head: `4420353345a48660e5d3feca0158c080f5c652cb`

## TypeScript diagnostic evidence

Complete `open-sse/tsconfig.json` diagnostics were compared as multisets after removing line and column numbers.

| Compiler | Version | Before | After | Removed | New |
| --- | ---: | ---: | ---: | ---: | ---: |
| TS6 | 6.0.3 | 125 | 122 | 3 | 0 |
| TS7 | 7.0.2 | 124 | 121 | 3 | 0 |

The exact removed diagnostics were the three existing TS2339 `Property 'reason' does not exist on type 'StoreCcrBlockResult'` occurrences: two in `open-sse/mcp-server/tools/compressionTools.ts` and one in `open-sse/services/compression/engines/ccr/index.ts`. The compiler totals differ by one between TS6 and TS7 because of the compiler environment; within each compiler's normalized multiset, only these three entries were removed and no new entries appeared.

Commands and dependency locations:

```text
/private/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/tmp.K6zv2yl8jN/base/node_modules/.bin/tsc --pretty false --typeRoots /private/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/tmp.K6zv2yl8jN/base/node_modules/@types -p open-sse/tsconfig.json
/Users/backryun/.npm/_npx/1ac1eddd0355a233/node_modules/.bin/tsc --pretty false --typeRoots /private/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/tmp.K6zv2yl8jN/base/node_modules/@types -p open-sse/tsconfig.json
```

TS6 and TS7 were run from the existing dependency trees; no dependency installation was performed.

## Tests and checks

- `node --import tsx/esm --test tests/unit/compression/ccr-mcp-integration.test.ts tests/unit/compression/ccr-cross-tenant.test.ts`: 29 passed, 0 failed.
- `npx --no-install prettier --write ...` and `npx --no-install prettier --check ...`: passed.
- `npm run lint`: passed.
- `npm run check:file-size`: passed.
- `npm run check:complexity-ratchets`: passed.
- `npm run check:complexity`: passed.
- `npm run check:cognitive-complexity`: passed.
- `git diff --check`: passed.
