### PR TITLE
[TS7] fix(types): preserve array-buffer response bodies

### DIFF
--- a/open-sse/executors/duckduckgo-web.ts
+++ b/open-sse/executors/duckduckgo-web.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import vm from "node:vm";
 import { solveDuckDuckGoChallenge, makeDuckDuckGoFeSignals } from "./duckduckgo-web/challenge.ts";
@@ -499,7 +500,7 @@ export class DuckDuckGoWebExecutor extends BaseExecutor {
         // Wrap the captured body as a Response so processResponse
         // (already a streaming/non-streaming transformer) can be
         // reused unchanged.
-        const upstreamResp = new Response(result.body, {
+        const upstreamResp = new Response(Buffer.from(result.body), {
           status: result.status,
           headers: {
             "Content-Type": result.contentType || "text/event-stream",

--- a/open-sse/executors/edgeTts.ts
+++ b/open-sse/executors/edgeTts.ts
@@ -58,7 +58,7 @@ export interface EdgeTtsSynthInput {
 }
 
 export interface EdgeTtsSynthResult {
-  audio: Buffer;
+  audio: Buffer<ArrayBuffer>;
   contentType: string;
 }
 
@@ -189,9 +189,7 @@ export function isTurnEndMessage(message: string): boolean {
  * ASCII headers, then the remaining bytes are audio data. Returns `null`
  * for a frame too short to contain a valid header-length prefix.
  */
-export function demuxAudioChunk(
-  frame: Buffer
-): { headers: string; audio: Buffer } | null {
+export function demuxAudioChunk(frame: Buffer): { headers: string; audio: Buffer } | null {
   if (!Buffer.isBuffer(frame) || frame.length < 2) return null;
   const headerLength = frame.readUInt16BE(0);
   if (2 + headerLength > frame.length) return null;

--- a/open-sse/executors/windsurf.ts
+++ b/open-sse/executors/windsurf.ts
@@ -168,7 +168,7 @@ function encodeVarint(value: number): Uint8Array {
   return new Uint8Array(bytes);
 }
 
-function concatBytes(arrays: Uint8Array[]): Uint8Array {
+function concatBytes(arrays: Uint8Array[]): Uint8Array<ArrayBuffer> {
   const total = arrays.reduce((n, a) => n + a.length, 0);
   const out = new Uint8Array(total);
   let off = 0;
@@ -626,7 +626,8 @@ export class WindsurfExecutor extends BaseExecutor {
                 const { done, value } = await reader.read();
                 if (done) break;
                 if (!value) continue;
-                pending = pending.length === 0 ? value : concatBytes([pending, value]);
+                pending =
+                  pending.length === 0 ? Uint8Array.from(value) : concatBytes([pending, value]);
                 drainFrames();
               }
             } finally {

--- a/src/lib/skills/builtins.ts
+++ b/src/lib/skills/builtins.ts
@@ -148,7 +148,7 @@ async function readResponseText(response: Response, maxBytes: number) {
 function normalizeBody(body: unknown, headers?: Record<string, string>) {
   if (body === undefined || body === null) return undefined;
   if (typeof body === "string") return body;
-  if (body instanceof Uint8Array) return body;
+  if (body instanceof Uint8Array) return new Uint8Array(body);
   if (typeof body === "object") {
     if (headers && !Object.keys(headers).some((key) => key.toLowerCase() === "content-type")) {
       headers["Content-Type"] = "application/json";
@@ -388,14 +388,7 @@ export const builtinSkills: Record<string, SkillHandler> = {
   },
 
   web_fetch: async (input, context) => {
-    const {
-      url,
-      format,
-      depth,
-      wait_for_selector,
-      include_metadata,
-      provider,
-    } = input as {
+    const { url, format, depth, wait_for_selector, include_metadata, provider } = input as {
       url: string;
       format?: "markdown" | "html" | "links" | "screenshot";
       depth?: 0 | 1 | 2;


### PR DESCRIPTION
## Summary

Preserve ArrayBuffer-backed response-body contracts at the four Task 1 producer/collection boundaries:

- Copy the browser-backed DuckDuckGo buffer before constructing a Response.
- Declare EdgeTTS synthesized audio as `Buffer<ArrayBuffer>`.
- Keep Windsurf response accumulation ArrayBuffer-backed.
- Copy Uint8Array skill request bodies before passing them to `safeOutboundFetch`.

The runtime changes are byte-preserving copies or type narrowing. The remaining diff is formatting-only cleanup of pre-existing Prettier drift in two owned files.

## Base and scope

- Base: `release/v3.8.50`
- Base SHA: `371c10ea5f1184ffcb74d71f6bec15885c2dfe28`
- Head: `20e14459e13abc006f7848ffa56dd7ba4490ab58`
- Branch: `agent/ts7-arraybuffer-body-contracts`
- Changed production files: `open-sse/executors/duckduckgo-web.ts`, `open-sse/executors/edgeTts.ts`, `open-sse/executors/windsurf.ts`, `src/lib/skills/builtins.ts`
- Focused test files were not changed.

## Diagnostic evidence

Using `open-sse/tsconfig.json`, comparing the complete TS diagnostic multisets while ignoring line and column numbers:

| Compiler | Before | After | Removed | New |
| --- | ---: | ---: | ---: | ---: |
| TypeScript 6 | 125 | 121 | 4 | 0 |
| TypeScript 7.0.2 | 124 | 120 | 4 | 0 |

The same four diagnostics were removed in both compilers:

- DuckDuckGo `Buffer<ArrayBufferLike>` passed as `BodyInit` (TS2345)
- EdgeTTS `Buffer<ArrayBufferLike>` passed as `BodyInit` (TS2345)
- Windsurf `Uint8Array<ArrayBufferLike>` assigned to `Uint8Array<ArrayBuffer>` (TS2322)
- Skills `string | Uint8Array<ArrayBufferLike>` passed as `BodyInit` (TS2322)

The full compiler still exits non-zero only because the base contains the remaining 121/120 unrelated diagnostics; the patched multiset adds none.

## Verification

- DuckDuckGo focused test: 15/15
- EdgeTTS focused test: 23/23
- Windsurf/Devin focused test: 41/41
- Skills sandbox focused test: 13/13
- Focused total: 92/92 passed, 0 failed
- `npm run typecheck:core`: passed
- `npm run lint`: passed
- Prettier check on all four changed files: passed
- `npm run check:file-size`: passed
- `npm run check:complexity`: passed
- `npm run check:complexity-ratchets`: passed
- `git diff --check`: passed

