### PR TITLE
[TS7] fix(types): narrow media generation failures

### DIFF
--- a/src/app/api/v1/_shared/mediaGenerationRoute.ts
+++ b/src/app/api/v1/_shared/mediaGenerationRoute.ts
@@ -14,8 +14,22 @@ type MediaModelListEntry = {
 };
 
 type MediaGenerationResult =
-  | { success: true; data: unknown }
-  | { success: false; error: unknown; status: number };
+  { success: true; data: unknown } | { success: false; error: unknown; status: number };
+
+type MediaGenerationFailure = Extract<MediaGenerationResult, { success: false }>;
+
+export type MediaGenerationResultLike = {
+  success: boolean;
+  data?: unknown;
+  error?: unknown;
+  status?: number;
+};
+
+export function isMediaGenerationFailure(
+  result: MediaGenerationResultLike
+): result is MediaGenerationFailure {
+  return result.success === false && "error" in result && typeof result.status === "number";
+}
 
 type MediaGenerationBody = {
   model: string;
@@ -24,8 +38,7 @@ type MediaGenerationBody = {
 } & Record<string, unknown>;
 
 type ValidatedMediaGenerationBody =
-  | { state: "ok"; body: MediaGenerationBody }
-  | { state: "invalid"; response: Response };
+  { state: "ok"; body: MediaGenerationBody } | { state: "invalid"; response: Response };
 
 export function mediaGenerationOptionsResponse() {
   return new Response(null, {
@@ -128,6 +141,12 @@ export function failedMediaGenerationResponse(
   result: MediaGenerationResult,
   fallbackMessage: string
 ) {
+  if (!isMediaGenerationFailure(result)) {
+    return new Response(JSON.stringify(toJsonErrorPayload(undefined, fallbackMessage)), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const errorPayload = toJsonErrorPayload(result.error, fallbackMessage);
   return new Response(JSON.stringify(errorPayload), {
     status: result.status,

--- a/src/app/api/v1/videos/generations/route.ts
+++ b/src/app/api/v1/videos/generations/route.ts
@@ -16,11 +16,13 @@ import {
 } from "@/app/api/v1/_shared/rateLimit";
 import {
   failedMediaGenerationResponse,
+  isMediaGenerationFailure,
   mediaGenerationOptionsResponse,
   promptRequiredResponse,
   readMediaGenerationBody,
   successfulMediaGenerationResponse,
 } from "@/app/api/v1/_shared/mediaGenerationRoute";
+import type { MediaGenerationResultLike } from "@/app/api/v1/_shared/mediaGenerationRoute";
 import { getSpecialtyModelsResponse } from "@/app/api/v1/_shared/specialtyCatalog";
 
 export const dynamic = "force-dynamic";
@@ -118,21 +120,21 @@ async function postHandler(request, context) {
     credentials = await resolveLocalOverrideCredentials(provider);
   }
 
-  const result = await handleVideoGeneration({ body, credentials, log });
+  const result: MediaGenerationResultLike = await handleVideoGeneration({ body, credentials, log });
 
-  if (result.success) {
-    await clearRecoveredProviderState(credentials);
-    return successfulMediaGenerationResponse({
-      result,
-      billingMode: "video",
-      provider,
-      model: body.model,
-      startTime,
-      duration: body.duration,
-    });
+  if (isMediaGenerationFailure(result)) {
+    return failedMediaGenerationResponse(result, "Video generation provider error");
   }
 
-  return failedMediaGenerationResponse(result, "Video generation provider error");
+  await clearRecoveredProviderState(credentials);
+  return successfulMediaGenerationResponse({
+    result: { data: result.data },
+    billingMode: "video",
+    provider,
+    model: body.model,
+    startTime,
+    duration: body.duration,
+  });
 }
 
 export const POST = withInjectionGuard(postHandler);

--- a/tests/unit/media-cost-headers-handlers.test.ts
+++ b/tests/unit/media-cost-headers-handlers.test.ts
@@ -16,6 +16,7 @@ const rerankHandler = await import("../../open-sse/handlers/rerank.ts");
 const moderationHandler = await import("../../open-sse/handlers/moderations.ts");
 const speechRoute = await import("../../src/app/api/v1/audio/speech/route.ts");
 const transcriptionRoute = await import("../../src/app/api/v1/audio/transcriptions/route.ts");
+const videoRoute = await import("../../src/app/api/v1/videos/generations/route.ts");
 
 const originalFetch = globalThis.fetch;
 
@@ -31,6 +32,33 @@ test.after(() => {
   restoreGlobals();
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("v1 video generation failure preserves provider status and error payload", async () => {
+  globalThis.fetch = (async (url: unknown) => {
+    assert.equal(String(url), "http://localhost:7860/animatediff/v1/generate");
+    return new Response("provider busy", { status: 503 });
+  }) as typeof fetch;
+
+  const response = await videoRoute.POST(
+    new Request("http://localhost/api/v1/videos/generations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "sdwebui/animatediff-webui",
+        prompt: "media failure test",
+      }),
+    })
+  );
+
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), {
+    error: {
+      message: "provider busy",
+      type: "upstream_error",
+      code: "upstream_error",
+    },
+  });
 });
 
 // Shared assertions: every successful media Response must carry the


### PR DESCRIPTION
## Summary

- Narrow media-generation failure handling with an exported runtime predicate.
- Preserve the shared `success: true` / `success: false` literal discriminants.
- Keep the video success payload and failure status/error JSON unchanged.
- Add a route-level regression test for provider status and normalized error payload.

## Base and head

- Base: `release/v3.8.50` at `371c10ea5f1184ffcb74d71f6bec15885c2dfe28`
- Head: `c7e76b900` (`agent/ts7-media-generation-results`)

## TypeScript diagnostic multiset

The full `open-sse/tsconfig.json` diagnostic multisets were compared with line/column numbers and
worktree-specific absolute paths normalized.

- TypeScript 6: `125 -> 121`; removed `4`; new `0`
- TypeScript 7: `124 -> 120`; removed `4`; new `0`
- Removed diagnostics: two shared-helper property-access errors and two video-route
  result-shape errors.

`handleVideoGeneration` currently infers `success: boolean` across its return branches, so
the video route uses a boundary input type only at that call site. The shared result union
itself retains literal success discriminants, and the predicate validates the failure arm
before `error` and `status` are read.

## Verification

- Focused media tests: `19/19` passed
- `npm run typecheck:core`: passed
- `npm run lint`: passed
- Prettier check: passed
- `npm run check:file-size`: passed
- `npm run check:complexity-ratchets`: passed (`complexity=2203`, `cognitiveComplexity=980`)
- `git diff --check`: passed
- Commit hooks: docs-sync, any-budget, and tracked-artifacts checks passed
