### PR TITLE
[TS7] fix(types): preserve Veo polling delay result

### DIFF
--- a/changelog.d/maintenance/9104-veoaifree-polling-delay-type.md
+++ b/changelog.d/maintenance/9104-veoaifree-polling-delay-type.md
@@ -1,0 +1,1 @@
+- **fix(types):** preserved the Veo polling delay promise result as `void` for TypeScript 7 compatibility without changing runtime polling behavior ([#9104](https://github.com/diegosouzapw/OmniRoute/pull/9104))

--- a/open-sse/executors/veoaifree-web.ts
+++ b/open-sse/executors/veoaifree-web.ts
@@ -102,7 +102,7 @@ async function fetchWithTimeout(
 function waitForDuration(ms: number, signal?: AbortSignal): Promise<void> {
   throwIfAborted(signal);
   let abort: (() => void) | undefined;
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(resolve, ms);
     abort = () => {
       clearTimeout(timeout);


### PR DESCRIPTION
Part of #8484.

## Summary

- Declare the abort-aware Veo polling delay promise as Promise<void>, matching its existing function contract.
- Preserve timeout, abort-listener cleanup, rejection, and polling behavior unchanged.
- Runtime JavaScript output is unchanged because the edit is type-only.

## Diagnostics

Re-measured against release/v3.8.50 at 371c10ea5f with complete line, column, and worktree-path-normalized diagnostic multisets:

- TypeScript 6.0.3: 125 → 124
- TypeScript 7.0.2: 124 → 123
- Removed: 1 TS2322 Promise<unknown> to Promise<void> diagnostic
- Added: 0

## Validation

- Veo executor and route tests: 15/15 passed
- npm run typecheck:core
- npm run lint
- npm run check:cycles
- npm run check:file-size
- Prettier and git diff --check