### PR TITLE
[TS7] fix(types): import compression stats from defining module

### DIFF
--- a/changelog.d/maintenance/9105-compression-stats-type-import.md
+++ b/changelog.d/maintenance/9105-compression-stats-type-import.md
@@ -1,0 +1,1 @@
+- **fix(types):** imported compression analytics statistics from their defining module so TypeScript 7 resolves the existing interface correctly ([#9105](https://github.com/diegosouzapw/OmniRoute/pull/9105))

--- a/open-sse/handlers/chatCore/compressionAnalyticsWrite.ts
+++ b/open-sse/handlers/chatCore/compressionAnalyticsWrite.ts
@@ -10,7 +10,7 @@
  * stays under the complexity cap.
  */
 
-import { type CompressionStats } from "../../services/compression/stats.ts";
+import { type CompressionStats } from "../../services/compression/types.ts";
 
 type LoggerLike =
   | {


### PR DESCRIPTION
Part of #8484.

## Summary

- Import CompressionStats from compression/types.ts, where the interface is defined and exported.
- Stop relying on compression/stats.ts, which imports the type internally but does not re-export it.
- Runtime JavaScript output is unchanged because the import is type-only.

## Diagnostics

Re-measured against release/v3.8.50 at 371c10ea5f with complete line, column, and worktree-path-normalized diagnostic multisets:

- TypeScript 6.0.3: 125 → 124
- TypeScript 7.0.2: 124 → 123
- Removed: 1 TS2724 missing-export diagnostic
- Added: 0

## Validation

- Compression analytics tests: 5/5 passed
- npm run typecheck:core
- npm run lint
- npm run check:cycles
- npm run check:file-size
- Prettier and git diff --check