### PR TITLE
fix(antigravity): alias gemini-3.1-pro-high to gemini-pro-agent

### DIFF
--- a/open-sse/config/antigravityModelAliases.ts
+++ b/open-sse/config/antigravityModelAliases.ts
@@ -144,6 +144,9 @@ export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
 
 export const ANTIGRAVITY_MODEL_ALIASES = Object.freeze({
   // gemini-3.1-pro-low is not aliased: the upstream accepts it verbatim.
+  // gemini-3.1-pro-high: the discovery slot returns HTTP 400 on v1internal;
+  // the live upstream id is gemini-pro-agent (see ANTIGRAVITY_PUBLIC_MODELS).
+  "gemini-3.1-pro-high": "gemini-pro-agent",
   "gemini-3-pro-image-preview": "gemini-3-pro-image",
   // Legacy Claude display ids → current upstream ids. NOTE: an earlier comment here
   // assumed Claude was removed from Antigravity 2.0 and would 404; discussion #3184

--- a/tests/unit/antigravity-model-aliases.test.ts
+++ b/tests/unit/antigravity-model-aliases.test.ts
@@ -89,7 +89,7 @@ test("isUserCallableAntigravityModelId only allows public chat-capable model IDs
   assert.equal(isUserCallableAntigravityModelId("claude-sonnet-4-6"), true);
   assert.equal(isUserCallableAntigravityModelId("claude-sonnet-5"), false);
   // The advertised pro-high discovery slot rejects content requests; use pro-agent High.
-  assert.equal(isUserCallableAntigravityModelId("gemini-3.1-pro-high"), false);
+  assert.equal(isUserCallableAntigravityModelId("gemini-3.1-pro-high"), true);
   assert.equal(isUserCallableAntigravityModelId("gemini-pro-agent"), true);
   assert.equal(isUserCallableAntigravityModelId("gemini-3.1-pro-low"), true);
   assert.equal(isUserCallableAntigravityModelId("tab_flash_lite_preview"), false);

--- a/tests/unit/antigravity-retired-public-models.test.ts
+++ b/tests/unit/antigravity-retired-public-models.test.ts
@@ -17,7 +17,6 @@ import { CLI_TOOLS } from "../../src/shared/constants/cliTools.ts";
 
 const RETIRED_PUBLIC_MODELS = [
   "gemini-3-pro-preview",
-  "gemini-3.1-pro-high",
   "gemini-2.5-pro",
   "gemini-2.5-computer-use-preview-10-2025",
 ] as const;
@@ -82,7 +81,7 @@ test("AGY free-model metadata excludes unavailable Gemini 2.5 Pro", () => {
   );
 });
 
-test("Antigravity and AGY expose gemini-pro-agent as the only Gemini 3.1 Pro High id", () => {
+test("Antigravity and AGY expose gemini-pro-agent and gemini-3.1-pro-high as callable Gemini 3.1 Pro High ids", () => {
   const antigravityModels = new Map(
     ANTIGRAVITY_PUBLIC_MODELS.map((model) => [model.id, model.name])
   );
@@ -91,7 +90,7 @@ test("Antigravity and AGY expose gemini-pro-agent as the only Gemini 3.1 Pro Hig
 
   assert.equal(antigravityModels.has("gemini-3.1-pro-high"), false);
   assert.equal(agyModels.has("gemini-3.1-pro-high"), false);
-  assert.equal(isUserCallableAntigravityModelId("gemini-3.1-pro-high"), false);
+  assert.equal(isUserCallableAntigravityModelId("gemini-3.1-pro-high"), true);
   assert.equal(isUserCallableAgyModelId("gemini-3.1-pro-high"), false);
   assert.deepEqual(getAntigravityModelFallbacks("gemini-3.1-pro-high"), []);
   assert.equal(


### PR DESCRIPTION
The discovery slot `gemini-3.1-pro-high` returns HTTP 400 on the `v1internal:streamGenerateContent` endpoint. The live upstream id is `gemini-pro-agent` (documented in `ANTIGRAVITY_PUBLIC_MODELS` and confirmed via live API probe).

Without this alias, requests for `gemini-3.1-pro-high` are sent verbatim to the upstream, triggering 400 errors that cascade into family-level lockouts affecting all Gemini models including `gemini-3.6-flash-high`.

**Verification**:
- Live API probe: `gemini-3.1-pro-high` → HTTP 400, `gemini-pro-agent` → HTTP 200
- MITM alias DB has `gemini-pro-agent` but not `gemini-3.1-pro-high`
- Code comment in `ANTIGRAVITY_PUBLIC_MODELS` explicitly documents this