### PR TITLE
[TS7] fix(types): preserve thinking signature recovery failure

### DIFF
--- a/changelog.d/maintenance/8484-thinking-signature-recovery-types.md
+++ b/changelog.d/maintenance/8484-thinking-signature-recovery-types.md
@@ -1,0 +1,1 @@
+- **fix(types):** preserved the known first-failure record while reading Anthropic thinking-signature recovery details so TypeScript 7 keeps the retry result union narrow ([#8484](https://github.com/diegosouzapw/OmniRoute/issues/8484))

--- a/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts
+++ b/open-sse/handlers/chatCore/thinkingSignatureRecovery.ts
@@ -69,7 +69,9 @@ export async function recoverAnthropicThinkingSignature(args: {
       return args.execute(requestBody);
     },
     getError: async (result) => {
-      if (result === firstFailure) return { status: result.status, message: result.message };
+      if (result === firstFailure) {
+        return { status: firstFailure.status, message: firstFailure.message };
+      }
       if (result.response.ok) return null;
       const details = await args.parseError(result.response.clone());
       return { status: details.statusCode, message: details.message };


### PR DESCRIPTION
Part of #8484.

## Summary

- Read the known synthetic first-failure record directly inside its identity branch.
- Keep the Anthropic thinking-signature retry, error parsing, and response handling unchanged.
- Avoid widening the recovery result union when TypeScript checks `status` and `message`.

## Diagnostics

Measured against `release/v3.8.50@1b5f7dd7e6808be31d6a258b57b60b2941058897` with complete line, column, and worktree-path-normalized diagnostic multisets:

- TypeScript 6.0.3: 125 → 123
- TypeScript 7.0.2: 124 → 122
- Removed: 2 TS2339 diagnostics in `thinkingSignatureRecovery.ts`
- Added: 0

## Validation

- Anthropic thinking-signature recovery tests: 9/9 passed
- `npm run typecheck:core`
- `npm run lint`
- `npm run check:cycles`
- `npm run check:file-size`
- `npm run check:complexity-ratchets`
- `npm run check:changelog-integrity`
- Prettier and `git diff --check`
