### PR TITLE
[TS7] fix(types): validate combo model collections

### DIFF
--- a/changelog.d/maintenance/9116-validate-combo-model-collections.md
+++ b/changelog.d/maintenance/9116-validate-combo-model-collections.md
@@ -1,0 +1,1 @@
+- **fix(types):** combo lookup producers now expose normalized model collections as arrays, preserving exact, prefixed, id, and case-insensitive resolution paths ([#9116](https://github.com/diegosouzapw/OmniRoute/pull/9116))

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -7,11 +7,12 @@ import { getDbInstance } from "./core";
 import { backupDbFile } from "./backup";
 import { invalidateDbCache } from "./readCache";
 import { invalidateReasoningRoutingRuleCache } from "./reasoningRoutingRules";
-import { normalizeComboRecord } from "@/lib/combos/steps";
+import { normalizeComboRecord, type ComboStep } from "@/lib/combos/steps";
 import { clearSessionModelHistoryForCombo } from "./contextHandoffs";
 import { validateComboInvariant } from "@/lib/combos/invariants";
 
 type JsonRecord = Record<string, unknown>;
+type NormalizedCombo = JsonRecord & { models: ComboStep[] };
 
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
@@ -62,10 +63,10 @@ function normalizeStoredCombo(
   combo: JsonRecord,
   db: ReturnType<typeof getDbInstance>,
   extraNames: string[] = []
-): JsonRecord {
+): NormalizedCombo {
   return normalizeComboRecord(combo, {
     allCombos: getComboNameSet(db, extraNames),
-  }) as JsonRecord;
+  });
 }
 
 function parseComboRow(row: unknown): JsonRecord | null {
@@ -125,7 +126,7 @@ export function getCombosCount(): number {
   return row.cnt;
 }
 
-export async function getComboById(id: string) {
+export async function getComboById(id: string): Promise<NormalizedCombo | null> {
   const db = getDbInstance();
   const row = db
     .prepare("SELECT data, sort_order, context_cache_protection FROM combos WHERE id = ?")
@@ -135,7 +136,7 @@ export async function getComboById(id: string) {
   return normalizeStoredCombo(combo, db, typeof combo.name === "string" ? [combo.name] : []);
 }
 
-export async function getComboByName(name: string) {
+export async function getComboByName(name: string): Promise<NormalizedCombo | null> {
   const db = getDbInstance();
   const row = db
     .prepare("SELECT data, sort_order, context_cache_protection FROM combos WHERE name = ?")
@@ -150,7 +151,7 @@ export async function getComboByName(name: string) {
 // "MASTER-LIGHT"; the default BINARY collation of getComboByName misses it.
 // Used only as a fallback after the exact match fails, so it cannot change the
 // resolution of any combo that already resolves today.
-export async function getComboByNameInsensitive(name: string) {
+export async function getComboByNameInsensitive(name: string): Promise<NormalizedCombo | null> {
   const db = getDbInstance();
   const row = db
     .prepare(
@@ -378,9 +379,7 @@ export async function cleanupComboConnectionRefs(connectionId: string) {
         changed = true;
       }
       if (Array.isArray(out.allowedConnectionIds)) {
-        const filtered = out.allowedConnectionIds.filter(
-          (id: string) => id !== connectionId
-        );
+        const filtered = out.allowedConnectionIds.filter((id: string) => id !== connectionId);
         if (filtered.length !== out.allowedConnectionIds.length) {
           out = { ...out, allowedConnectionIds: filtered };
           changed = true;

--- a/tests/unit/combo-id-resolution-4446.test.ts
+++ b/tests/unit/combo-id-resolution-4446.test.ts
@@ -34,6 +34,60 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
+test("getCombo preserves exact, prefixed, id, and case-insensitive lookup paths", async () => {
+  const created = await combosDb.createCombo({
+    name: "MASTER-LIGHT",
+    models: [{ provider: "groq", model: "llama-3.1-8b-instant" }],
+  });
+
+  const resolvedCombos = await Promise.all([
+    sseModelService.getCombo("MASTER-LIGHT"),
+    sseModelService.getCombo("combo/MASTER-LIGHT"),
+    sseModelService.getCombo(String(created.id)),
+    sseModelService.getCombo("master-light"),
+  ]);
+
+  for (const combo of resolvedCombos) {
+    assert.ok(combo, "expected each getCombo lookup path to resolve");
+    assert.equal(combo.models.length, 1);
+  }
+});
+
+test("combo producers normalize malformed stored model collections to arrays", async () => {
+  const db = core.getDbInstance();
+  const now = new Date().toISOString();
+
+  db.prepare(
+    "INSERT INTO combos (id, name, data, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(
+    "malformed-models",
+    "BROKEN-MODELS",
+    JSON.stringify({
+      id: "malformed-models",
+      name: "BROKEN-MODELS",
+      models: { unexpected: true },
+      strategy: "priority",
+    }),
+    1,
+    now,
+    now
+  );
+
+  const producers = [
+    ["name", () => combosDb.getComboByName("BROKEN-MODELS")],
+    ["id", () => combosDb.getComboById("malformed-models")],
+    ["insensitive name", () => combosDb.getComboByNameInsensitive("broken-models")],
+  ] as const;
+
+  for (const [label, loadCombo] of producers) {
+    const combo = await loadCombo();
+    assert.ok(combo, `${label} lookup should return the stored combo`);
+    assert.deepEqual(combo.models, [], `${label} lookup should normalize malformed models`);
+  }
+
+  assert.equal(await sseModelService.getCombo("BROKEN-MODELS"), null);
+});
+
 test("#4446 getComboForModel resolves a combo by a case-insensitive name (lowercased slug)", async () => {
   await combosDb.createCombo({
     name: "MASTER-LIGHT",


### PR DESCRIPTION
## Summary

- Restore the normalized combo producer contract so `models` is typed as `ComboStep[]`.
- Keep `getCombo()`'s exact, `combo/`-prefixed, id, and case-insensitive lookup behavior unchanged.
- Add regression coverage for all four lookup paths and malformed persisted model collections.
- Add the required maintenance changelog fragment.

## Root cause

`normalizeComboRecord()` already converts any stored `models` value through `normalizeComboModels()`,
which uses an explicit `Array.isArray` boundary and returns `ComboStep[]`. `normalizeStoredCombo()`
then erased that producer guarantee with a `JsonRecord` return type and a cast, leaving
`getCombo()` consumers with `unknown` for `combo.models`.

The fix exposes the existing producer guarantee as `NormalizedCombo` and annotates
`getComboById`, `getComboByName`, and `getComboByNameInsensitive`. No runtime lookup logic changed.

## Base and head

- Base: `release/v3.8.50` at `1b5f7dd7e6808be31d6a258b57b60b2941058897`
- Head: `f73126c59b0b82921927812efa0f55fb4c00ffb0`

## TypeScript diagnostic multiset

Measured with the explicit `open-sse/tsconfig.json` TS6/TS7 commands. The comparison removes
line/column information and worktree-specific absolute paths only; diagnostic messages are preserved.

- TypeScript 6: `125 -> 121`; removed `4`; added `0`
- TypeScript 7: `124 -> 120`; removed `4`; added `0`
- The four removed diagnostics are the four `TS2339` `combo.models.length` accesses in
  `src/sse/services/model.ts`.

## Verification

- Focused combo/db tests: `12/12` passed
- `npm run typecheck:core`: passed
- `npm run lint`: passed
- `npm run check:cycles`: passed
- `npm run check:file-size`: passed
- Prettier check: passed
- `git diff --check`: passed
- `npm run check:changelog-integrity`: passed
- `npm run check:complexity-ratchets`: passed
- Commit hooks: docs-sync, any-budget, and tracked-artifacts checks passed
