### PR TITLE
[TS7] fix(types): preserve semantic cache signature inputs

### DIFF
--- a/changelog.d/maintenance/9117-ts7-semantic-cache-signature-inputs.md
+++ b/changelog.d/maintenance/9117-ts7-semantic-cache-signature-inputs.md
@@ -1,0 +1,1 @@
+- **chore(types):** align semantic cache signature inputs with the numeric request contract so both cache-write paths remain runtime-equivalent while TypeScript 7 checks them safely ([#9117](https://github.com/diegosouzapw/OmniRoute/pull/9117))

--- a/open-sse/handlers/chatCore/semanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/semanticCacheStore.ts
@@ -20,8 +20,8 @@ type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
 type CacheBody = {
   messages?: unknown;
   input?: unknown;
-  temperature?: unknown;
-  top_p?: unknown;
+  temperature?: number;
+  top_p?: number;
 };
 
 type UsageLike = { prompt_tokens?: number; completion_tokens?: number } | null | undefined;
@@ -47,7 +47,7 @@ export function storeSemanticCacheResponse(
     headers: unknown;
     translatedResponse: unknown;
     model: string;
-    apiKeyId?: string | number;
+    apiKeyId?: string;
     usage?: UsageLike;
     log?: LoggerLike;
   },

--- a/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
@@ -21,8 +21,8 @@ type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
 type CacheBody = {
   messages?: unknown;
   input?: unknown;
-  temperature?: unknown;
-  top_p?: unknown;
+  temperature?: number;
+  top_p?: number;
 };
 
 export interface StreamingSemanticCacheStoreDeps {
@@ -46,7 +46,7 @@ interface StreamingCacheArgs {
   body: CacheBody;
   headers: unknown;
   model: string;
-  apiKeyId?: string | number;
+  apiKeyId?: string;
   streamUsage?: Record<string, unknown> | null;
   log?: LoggerLike;
 }
@@ -73,7 +73,10 @@ function writeStreamingCacheEntry(
     );
     const tokensSaved = streamTokensSaved(args.streamUsage);
     deps.setCachedResponse(sig, args.model, cleanBody, tokensSaved);
-    args.log?.debug?.("CACHE", `Stored streaming response for ${args.model} (${tokensSaved} tokens)`);
+    args.log?.debug?.(
+      "CACHE",
+      `Stored streaming response for ${args.model} (${tokensSaved} tokens)`
+    );
   } catch {
     // Cache write failed — non-critical
   }

--- a/tests/unit/chatcore-semantic-cache-store.test.ts
+++ b/tests/unit/chatcore-semantic-cache-store.test.ts
@@ -6,9 +6,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-const { storeSemanticCacheResponse } = await import(
-  "../../open-sse/handlers/chatCore/semanticCacheStore.ts"
-);
+const { storeSemanticCacheResponse } =
+  await import("../../open-sse/handlers/chatCore/semanticCacheStore.ts");
 
 type Stored = { sig: unknown; model: string; response: unknown; tokens: number };
 
@@ -50,6 +49,33 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
   } as Parameters<typeof storeSemanticCacheResponse>[0];
 }
 
+function assertNumericSignatureInputs(
+  deps: Parameters<typeof storeSemanticCacheResponse>[1]
+): void {
+  if (process.env.NODE_ENV === "__semantic_cache_type_contract__") {
+    storeSemanticCacheResponse(
+      {
+        enabled: true,
+        body: {
+          messages: [],
+          // @ts-expect-error temperature is a numeric producer field
+          temperature: "0",
+          top_p: 1,
+        },
+        headers: undefined,
+        translatedResponse: {},
+        model: "gpt-x",
+      },
+      deps
+    );
+  }
+}
+
+test("signature input contract keeps temperature numeric", () => {
+  const { deps } = makeDeps();
+  assertNumericSignatureInputs(deps);
+});
+
 test("happy path → stores under a signature, tokensSaved = prompt + completion", () => {
   const { deps, stored } = makeDeps();
   storeSemanticCacheResponse(baseArgs(), deps);
@@ -57,6 +83,8 @@ test("happy path → stores under a signature, tokensSaved = prompt + completion
   assert.equal(stored[0].model, "gpt-x");
   assert.deepEqual(stored[0].response, { id: "resp-1" });
   assert.equal(stored[0].tokens, 15);
+  const signatureArgs = JSON.parse(String(stored[0].sig).slice("sig:".length)) as unknown[];
+  assert.deepEqual(signatureArgs.slice(2, 4), [0, 1]);
 });
 
 test("disabled → no store, no gate calls past enabled", () => {

--- a/tests/unit/chatcore-streaming-cache-store.test.ts
+++ b/tests/unit/chatcore-streaming-cache-store.test.ts
@@ -6,9 +6,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-const { storeStreamingSemanticCacheResponse } = await import(
-  "../../open-sse/handlers/chatCore/streamingSemanticCacheStore.ts"
-);
+const { storeStreamingSemanticCacheResponse } =
+  await import("../../open-sse/handlers/chatCore/streamingSemanticCacheStore.ts");
 
 type Stored = { sig: unknown; model: string; body: Record<string, unknown>; tokens: number };
 
@@ -18,8 +17,12 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
     isCacheableForWrite: () => true,
     isSmallEnoughForSemanticCache: () => true,
     generateSignature: (...a: unknown[]) => `sig:${JSON.stringify(a)}`,
-    setCachedResponse: (sig: unknown, model: string, body: Record<string, unknown>, tokens: number) =>
-      stored.push({ sig, model, body, tokens }),
+    setCachedResponse: (
+      sig: unknown,
+      model: string,
+      body: Record<string, unknown>,
+      tokens: number
+    ) => stored.push({ sig, model, body, tokens }),
     ...overrides,
   } as Parameters<typeof storeStreamingSemanticCacheResponse>[1];
   return { deps, stored };
@@ -40,6 +43,34 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
   } as Parameters<typeof storeStreamingSemanticCacheResponse>[0];
 }
 
+function assertNumericSignatureInputs(
+  deps: Parameters<typeof storeStreamingSemanticCacheResponse>[1]
+): void {
+  if (process.env.NODE_ENV === "__semantic_cache_type_contract__") {
+    storeStreamingSemanticCacheResponse(
+      {
+        enabled: true,
+        streamStatus: 200,
+        streamResponseBody: {},
+        body: {
+          messages: [],
+          temperature: 0,
+          // @ts-expect-error top_p is a numeric producer field
+          top_p: "1",
+        },
+        headers: undefined,
+        model: "gpt-x",
+      },
+      deps
+    );
+  }
+}
+
+test("signature input contract keeps top_p numeric", () => {
+  const { deps } = makeDeps();
+  assertNumericSignatureInputs(deps);
+});
+
 test("happy path → stores cleaned body (no _streamed), tokens = prompt + completion", () => {
   const { deps, stored } = makeDeps();
   storeStreamingSemanticCacheResponse(baseArgs(), deps);
@@ -48,6 +79,8 @@ test("happy path → stores cleaned body (no _streamed), tokens = prompt + compl
   assert.equal(stored[0].tokens, 20);
   assert.equal("_streamed" in stored[0].body, false);
   assert.equal(stored[0].body.id, "resp-1");
+  const signatureArgs = JSON.parse(String(stored[0].sig).slice("sig:".length)) as unknown[];
+  assert.deepEqual(signatureArgs.slice(2, 4), [0, 1]);
 });
 
 test("non-200 stream status → no store", () => {


### PR DESCRIPTION
## Summary

- Align the semantic-cache write helpers' `temperature` and `top_p` inputs with the numeric request-body producer contract.
- Keep the existing signature payload and cache-write runtime behavior unchanged; narrow the API-key namespace id to the string contract used by the cache signature.
- Add focused type/runtime characterization coverage and a maintenance changelog fragment.

## Validation

- Focused semantic-cache tests: 17 passed.
- `npm run typecheck:core`: passed.
- `npm run lint`: passed.
- `npm run check:cycles`: passed.
- `npm run check:file-size`: passed.
- `npm run check:changelog-integrity`: passed.
- Prettier check and `git diff --check`: passed.
- Exact open-sse diagnostic multiset (duplicates preserved; only line/column and worktree paths normalized): TS6 125 → 123, TS7 124 → 122; removed the two intended `TS2345` diagnostics in each compiler, added 0.