### PR TITLE
[TS7] fix(types): preserve non-streaming response metadata

### DIFF
--- a/changelog.d/maintenance/9118-ts7-response-meta-header-inputs.md
+++ b/changelog.d/maintenance/9118-ts7-response-meta-header-inputs.md
@@ -1,0 +1,1 @@
+- **fix(types):** narrowed non-streaming chat response metadata inputs to the shared header contract without changing emitted metadata headers ([#9118](https://github.com/diegosouzapw/OmniRoute/pull/9118))

--- a/open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts
+++ b/open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts
@@ -16,9 +16,9 @@ export function buildNonStreamingResponseHeaders(
     provider: string | null | undefined;
     model: string | null | undefined;
     startTime: number;
-    responseUsage: unknown;
+    responseUsage: Record<string, unknown> | null | undefined;
     estimatedCost: number;
-    requestId: unknown;
+    requestId: string | null | undefined;
     compressionResponseMeta?: string | null | undefined;
     comboStrategy?: string | null | undefined;
   },

--- a/tests/unit/chatcore-nonstreaming-response-headers.test.ts
+++ b/tests/unit/chatcore-nonstreaming-response-headers.test.ts
@@ -6,14 +6,16 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-const { buildNonStreamingResponseHeaders } = await import(
-  "../../open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts"
-);
+const { buildNonStreamingResponseHeaders } =
+  await import("../../open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts");
 
 function makeDeps(now = 1000) {
   const metaCalls: Array<{ headers: Record<string, string>; meta: Record<string, unknown> }> = [];
   const deps = {
-    attachOmniRouteMetaHeaders: (headers: Record<string, string>, meta: Record<string, unknown>) => {
+    attachOmniRouteMetaHeaders: (
+      headers: Record<string, string>,
+      meta: Record<string, unknown>
+    ) => {
       metaCalls.push({ headers, meta });
       headers["x-omniroute-meta"] = "attached";
     },
@@ -34,6 +36,17 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
     ...overrides,
   } as Parameters<typeof buildNonStreamingResponseHeaders>[0];
 }
+
+function acceptsAttachMetaInputContract(args: {
+  responseUsage: Record<string, unknown> | null | undefined;
+  requestId: string | null | undefined;
+}) {
+  return args;
+}
+
+test("builder input types match the metadata attachment contract", () => {
+  acceptsAttachMetaInputContract(baseArgs());
+});
 
 test("static headers: Content-Type json + cache MISS", () => {
   const { deps } = makeDeps();
@@ -59,7 +72,10 @@ test("meta receives provider/model/cacheHit false/latency/usage/cost/requestId",
 
 test("no compression meta → no compression header", () => {
   const { deps } = makeDeps();
-  const h = buildNonStreamingResponseHeaders(baseArgs({ compressionResponseMeta: undefined }), deps);
+  const h = buildNonStreamingResponseHeaders(
+    baseArgs({ compressionResponseMeta: undefined }),
+    deps
+  );
   assert.ok(!Object.values(h).includes("engine:x"));
 });
 


### PR DESCRIPTION
## Summary

- Narrow `buildNonStreamingResponseHeaders`'s `responseUsage` and `requestId` inputs to the existing `attachOmniRouteMetaHeaders` contract.
- Preserve the emitted non-streaming response metadata and runtime behavior; no `any`, cast, caller, or shared helper changes.
- Add a compile-time focused contract assertion and a maintenance changelog fragment.

## Base and diagnostics

- Base: `upstream/release/v3.8.50@1b5f7dd7e6808be31d6a258b57b60b2941058897`
- TS6 command: `/Users/backryun/OmniRoute/node_modules/.bin/tsc --pretty false --typeRoots /Users/backryun/OmniRoute/node_modules/@types -p open-sse/tsconfig.json`
- TS7 command: `/Users/backryun/.npm/_npx/1ac1eddd0355a233/node_modules/.bin/tsc --pretty false --typeRoots /Users/backryun/OmniRoute/node_modules/@types -p open-sse/tsconfig.json`

| Compiler | Before | After | Removed | Added |
| --- | ---: | ---: | ---: | ---: |
| TS6 | 125 | 123 | 2 | 0 |
| TS7 | 124 | 122 | 2 | 0 |

The full diagnostic multisets preserve duplicate records and normalize only worktree paths and line/column locations. The two removed records are the existing TS2322 diagnostics in `open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts` for the usage and request ID inputs; no new diagnostic record was added.

## Verification

- Focused Node tests: **12 passed, 0 failed** (`chatcore-nonstreaming-response-headers.test.ts`, `omniroute-decision-header.test.ts`)
- `npm run typecheck:core` — passed
- `npm run lint` — passed
- `npm run check:cycles` — passed
- `npm run check:file-size` — passed
- Prettier check — passed
- `npm run check:changelog-integrity` — passed
- `git diff --check` — passed

The full `npm test` run was intentionally stopped after an unrelated external DeepSeek connectivity timeout; the required focused and local gates above completed successfully.
