### PR TITLE
[TS7] fix(types): preserve Responses transform options

### DIFF
--- a/changelog.d/maintenance/8484-responses-transform-options-type.md
+++ b/changelog.d/maintenance/8484-responses-transform-options-type.md
@@ -1,0 +1,1 @@
+- Preserve the Responses API transform options contract under TypeScript 7.

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -87,7 +87,7 @@ export function createResponsesLogger(model, logsDir = null) {
 export function createResponsesApiTransformStream(
   logger = null,
   keepaliveIntervalMs = 3000,
-  options = {}
+  options: { customToolNames?: Iterable<string> } = {}
 ) {
   const customToolNames = new Set(options.customToolNames || []);
   const state = {


### PR DESCRIPTION
## Summary

- declare the existing customToolNames option on the Responses API transform boundary
- preserve runtime behavior while preventing the default empty object from erasing the option contract
- add a maintenance changelog fragment

## TypeScript diagnostics

- TypeScript 6: 125 -> 124; removed 1; added 0
- TypeScript 7: 124 -> 123; removed 1; added 0
- Complete duplicate-preserving multisets were compared after normalizing line, column, and worktree paths.

## Validation

- responses-transformer focused tests: 17/17
- npm run typecheck:core
- npm run lint
- npm run check:cycles
- npm run check:file-size
- npm run check:changelog-integrity
- npm run check:complexity-ratchets
- Prettier check
- git diff --check

Tracks #8484.