### PR TITLE
[TS7] fix(types): preserve validation failure narrowing

### DIFF
--- a/changelog.d/maintenance/8484-validation-failure-narrowing.md
+++ b/changelog.d/maintenance/8484-validation-failure-narrowing.md
@@ -1,0 +1,1 @@
+- **fix(types):** reuse the validation failure predicate when building malformed-body responses so the existing error envelope remains type-safe and unchanged.

--- a/src/shared/validation/helpers.ts
+++ b/src/shared/validation/helpers.ts
@@ -64,8 +64,7 @@ export function isValidationFailure<TData>(
  * do `if (!r.success) return r.response;` without knowing the envelope shape.
  */
 export type ValidatedJsonBodyResult<TData> =
-  | { success: true; data: TData }
-  | { success: false; response: NextResponse };
+  { success: true; data: TData } | { success: false; response: NextResponse };
 
 /**
  * Parse a request body as JSON and validate it against a Zod schema in one
@@ -106,12 +105,12 @@ export async function validatedJsonBody<TSchema extends z.ZodTypeAny>(
   }
 
   const validation = validateBody(schema, raw);
-  if (validation.success) {
-    return { success: true, data: validation.data };
+  if (isValidationFailure(validation)) {
+    return {
+      success: false,
+      response: NextResponse.json({ error: validation.error }, { status: 400 }),
+    };
   }
 
-  return {
-    success: false,
-    response: NextResponse.json({ error: validation.error }, { status: 400 }),
-  };
+  return { success: true, data: validation.data };
 }

--- a/tests/unit/api/validated-json-body.test.ts
+++ b/tests/unit/api/validated-json-body.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { z } from "zod";
-import { validatedJsonBody } from "@/shared/validation/helpers";
+import { isValidationFailure, validateBody, validatedJsonBody } from "@/shared/validation/helpers";
 
 function makeRequest(body: string, contentType = "application/json"): Request {
   return new Request("http://localhost/test", {
@@ -71,6 +71,15 @@ describe("validatedJsonBody", () => {
       const fields = body.error.details.map((d: { field: string }) => d.field);
       assert.ok(fields.includes("name"));
       assert.ok(fields.includes("count"));
+    }
+  });
+
+  test("isValidationFailure narrows a validateBody failure", () => {
+    const result = validateBody(schema, { name: "", count: -1 });
+    assert.equal(isValidationFailure(result), true);
+    if (isValidationFailure(result)) {
+      assert.equal(result.error.message, "Invalid request");
+      assert.equal(result.error.details.length, 2);
     }
   });
 


### PR DESCRIPTION
## Summary

- Reuse the existing `isValidationFailure` predicate in `validatedJsonBody` to narrow the `ValidationResult` failure branch.
- Preserve the public result shapes, 400 status, and existing `{ error: ... }` response envelope exactly.
- Add focused runtime/type-contract coverage for the existing predicate and a maintenance changelog fragment.

## Base and diagnostic multiset

- Base: `upstream/release/v3.8.50@1b5f7dd7e6808be31d6a258b57b60b2941058897`
- TS6 command: `/Users/backryun/OmniRoute/node_modules/.bin/tsc --pretty false --typeRoots /Users/backryun/OmniRoute/node_modules/@types -p open-sse/tsconfig.json`
- TS7 command: `/Users/backryun/.npm/_npx/1ac1eddd0355a233/node_modules/.bin/tsc --pretty false --typeRoots /Users/backryun/OmniRoute/node_modules/@types -p open-sse/tsconfig.json`

| Compiler | Before | After | Removed | Added |
| --- | ---: | ---: | ---: | ---: |
| TS6 | 125 | 124 | 1 | 0 |
| TS7 | 124 | 123 | 1 | 0 |

The comparison preserves duplicate diagnostics and normalizes only line/column and absolute/worktree import paths. Both compilers remove exactly one `src/shared/validation/helpers.ts` TS2339 (`validation.error` not narrowed); no new diagnostic record is added.

## Verification

- Focused test: **7 passed, 0 failed** (`tests/unit/api/validated-json-body.test.ts`)
- `npm run typecheck:core` — passed
- `npm run lint` — passed
- `npm run check:cycles` — passed
- `npm run check:file-size` — passed
- Prettier check — passed
- `npm run check:changelog-integrity` — passed
- `git diff --check` — passed

No issue #8484 or MEMANTO content was changed. The full `npm test` suite was not run, per instruction, because it is unrelated to this type-only slice and may depend on external network access.
