### PR TITLE
[TS7] fix(types): preserve vision capability literal

### DIFF
--- a/changelog.d/maintenance/8484-vision-capability-literal.md
+++ b/changelog.d/maintenance/8484-vision-capability-literal.md
@@ -1,0 +1,1 @@
+- **fix(types):** preserve the literal `capabilities.vision: true` contract for catalog vision fields so custom-model capability composition remains type-safe under TypeScript 7 ([#9121](https://github.com/diegosouzapw/OmniRoute/pull/9121))

--- a/src/app/api/v1/models/catalogVision.ts
+++ b/src/app/api/v1/models/catalogVision.ts
@@ -6,7 +6,11 @@ import { isVisionModelId } from "@/shared/constants/visionModels";
 // Re-exported (here and from ./catalog.ts) for callers/tests that imported it from there.
 export { isVisionModelId };
 
-export function getVisionCapabilityFields(modelId: string) {
+export function getVisionCapabilityFields(modelId: string): {
+  capabilities: { vision: true };
+  input_modalities: string[];
+  output_modalities: string[];
+} | null {
   if (!isVisionModelId(modelId)) return null;
   return {
     capabilities: { vision: true },

--- a/tests/unit/catalog-helpers-extraction.test.ts
+++ b/tests/unit/catalog-helpers-extraction.test.ts
@@ -130,6 +130,12 @@ test("catalogVision: re-exports isVisionModelId and derives capability fields", 
   // id-based heuristic
   const visionFields = getVisionCapabilityFields("gpt-4o");
   assert.ok(visionFields, "gpt-4o must be detected as vision-capable");
+  const typedVisionFields: {
+    capabilities: { vision: true };
+    input_modalities: string[];
+    output_modalities: string[];
+  } | null = visionFields;
+  assert.equal(typedVisionFields?.capabilities.vision, true);
   assert.equal(visionFields?.capabilities.vision, true);
   assert.equal(getVisionCapabilityFields("kimi-k2"), null);
 });


### PR DESCRIPTION
## Summary
- annotate `getVisionCapabilityFields` with the existing literal `capabilities.vision: true` producer contract
- keep runtime values and detection behavior unchanged
- add a focused catalog helper type-contract assertion

## Verification
- focused catalog helper tests: 12 passed
- TS6 exact open-sse diagnostics: 125 -> 124 (removed 1, added 0)
- TS7 exact open-sse diagnostics: 124 -> 123 (removed 1, added 0)
- `npm run typecheck:core`
- `npm run lint`
- `npm run check:cycles`
- `npm run check:file-size`
- `npm run check:changelog-integrity`
- Prettier check and `git diff --check`

Closes no issue; this is the independent TS7 vision capability slice for the release/v3.8.50 base.