### PR TITLE
[TS7] fix(types): preserve client usage format contract

### DIFF
--- a/changelog.d/maintenance/8484-client-usage-format-contract.md
+++ b/changelog.d/maintenance/8484-client-usage-format-contract.md
@@ -1,0 +1,1 @@
+- **fix(types):** preserve the client response format contract while estimating usage for non-streaming responses

--- a/open-sse/handlers/chatCore/clientUsageBuffer.ts
+++ b/open-sse/handlers/chatCore/clientUsageBuffer.ts
@@ -24,10 +24,13 @@ import {
   estimateUsage as defaultEstimateUsage,
 } from "../../utils/usageTracking.ts";
 
-type ResponseLike = {
-  usage?: unknown;
-  choices?: Array<{ message?: { content?: unknown } }>;
-} | null | undefined;
+type ResponseLike =
+  | {
+      usage?: unknown;
+      choices?: Array<{ message?: { content?: unknown } }>;
+    }
+  | null
+  | undefined;
 
 export interface ClientUsageBufferDeps {
   addBufferToUsage: typeof defaultAddBuffer;
@@ -95,7 +98,7 @@ export interface ApplyClientUsageBufferOptions {
 export function applyClientUsageBuffer(
   translatedResponse: ResponseLike,
   body: unknown,
-  clientResponseFormat: unknown,
+  clientResponseFormat: string,
   options: ApplyClientUsageBufferOptions = {},
   deps: ClientUsageBufferDeps = DEFAULT_DEPS
 ): void {

--- a/tests/unit/chatcore-client-usage-buffer.test.ts
+++ b/tests/unit/chatcore-client-usage-buffer.test.ts
@@ -6,9 +6,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-const { applyClientUsageBuffer } = await import(
-  "../../open-sse/handlers/chatCore/clientUsageBuffer.ts"
-);
+const { applyClientUsageBuffer } =
+  await import("../../open-sse/handlers/chatCore/clientUsageBuffer.ts");
+const { resolveChatCoreRequestFormat } =
+  await import("../../open-sse/handlers/chatCore/requestFormat.ts");
 
 function makeDeps(overrides: Record<string, unknown> = {}) {
   const calls = { buffer: [] as unknown[], estimate: [] as unknown[], filter: [] as unknown[] };
@@ -29,6 +30,25 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
   } as Parameters<typeof applyClientUsageBuffer>[4];
   return { deps, calls };
 }
+
+test("request format producer forwards its string contract to usage estimation", () => {
+  const { clientResponseFormat } = resolveChatCoreRequestFormat({
+    clientRawRequest: { endpoint: "/v1/chat/completions" },
+    body: { messages: [] },
+    provider: "openai",
+    userAgent: null,
+  });
+  const { deps, calls } = makeDeps();
+  const resp: Record<string, unknown> = {
+    choices: [{ message: { content: "hello" } }],
+  };
+
+  applyClientUsageBuffer(resp, { messages: [] }, clientResponseFormat, {}, deps);
+
+  const args = calls.estimate[0] as unknown[];
+  assert.equal(typeof clientResponseFormat, "string");
+  assert.equal(args[2], clientResponseFormat);
+});
 
 test("usage present → buffer then filter, mutates in place", () => {
   const { deps, calls } = makeDeps();
@@ -107,9 +127,15 @@ test("preserveContextBudgetInVisibleUsage folds context_budget_* back into visib
     usage: { prompt_tokens: 5, input_tokens: 5, total_tokens: 10 },
   };
 
-  applyClientUsageBuffer(resp, { messages: [] }, "openai", {
-    preserveContextBudgetInVisibleUsage: true,
-  }, deps);
+  applyClientUsageBuffer(
+    resp,
+    { messages: [] },
+    "openai",
+    {
+      preserveContextBudgetInVisibleUsage: true,
+    },
+    deps
+  );
 
   const filtered = calls.filter[0] as Record<string, unknown>;
   assert.equal(filtered.prompt_tokens, 2005, "Claude-Code path re-folds the buffered value");


### PR DESCRIPTION
## Summary

- Narrow `applyClientUsageBuffer`'s client response format boundary from `unknown` to the string contract produced by `resolveChatCoreRequestFormat`.
- Add focused coverage that traces the producer value through usage estimation without changing runtime response behavior.
- Add the required maintenance changelog fragment.

## Verification

- Base: `1b5f7dd7e6808be31d6a258b57b60b2941058897`
- TS6 full open-sse diagnostics: `125 -> 124`; removed `1` intended `TS2345` at `clientUsageBuffer.ts:117`; added `0`.
- TS7 full open-sse diagnostics: `124 -> 123`; removed `1` intended `TS2345` at `clientUsageBuffer.ts:117`; added `0`.
- Diagnostic comparison preserved duplicate entries and normalized only line/column and worktree paths.
- Focused tests: `13/13` passed across `chatcore-client-usage-buffer.test.ts` and `8331-usage-buffer-inflation.test.ts`.
- Passed: `npm run typecheck:core`, `npm run lint`, `npm run check:cycles`, `npm run check:file-size`, `npm run check:changelog-integrity`, Prettier check, and `git diff --check`.

No issue tracker or MEMANTO content was modified.
