### PR TITLE
[TS7] fix(types): preserve request rule input contracts

### DIFF
--- a/open-sse/services/payloadRules.ts
+++ b/open-sse/services/payloadRules.ts
@@ -85,7 +85,7 @@ function clonePayloadRulesConfig(config: PayloadRulesConfig): PayloadRulesConfig
 
 function normalizeModelSpecs(value: unknown): PayloadRuleModelSpec[] {
   return toArray<JsonRecord>(value)
-    .map((item) => {
+    .map((item): PayloadRuleModelSpec | null => {
       const name = typeof item?.name === "string" ? item.name.trim() : "";
       const protocol = typeof item?.protocol === "string" ? item.protocol.trim() : "";
       if (!name) return null;

--- a/open-sse/services/specificityTypes.ts
+++ b/open-sse/services/specificityTypes.ts
@@ -30,6 +30,7 @@ export interface RuleInput {
   messages: Array<{ role?: string; content?: string | unknown }>;
   systemPrompt?: string;
   tools?: Array<{
+    type?: string;
     function?: { name: string; description?: string; parameters?: unknown };
   }>;
   model?: string;


### PR DESCRIPTION
## Summary

- preserve the declared payload-rule model contract through normalization
- accept the standard OpenAI function-tool `type` discriminator in specificity inputs
- keep runtime behavior unchanged while removing three existing compiler diagnostics

## Root cause

TypeScript inferred a narrower union from `normalizeModelSpecs()` than the exported `PayloadRuleModelSpec` predicate, and `RuleInput.tools` omitted the standard top-level `type` property already used by callers and tests.

## Validation

- TypeScript 6 diagnostic multiset: 3 removed, 0 added
- TypeScript 7 diagnostic multiset: 3 removed, 0 added
- `tests/unit/service-payload-rules.test.ts` and `open-sse/services/__tests__/specificityDetector.test.ts`: 37 passed
- ESLint and Prettier checks on changed files
- `npm run check:file-size -- --files open-sse/services/payloadRules.ts open-sse/services/specificityTypes.ts`
- `git diff --check`
