### PR TITLE
[TS7] fix(types): simplify Codex service tier narrowing

### DIFF
--- a/src/lib/providers/codexFastTier.ts
+++ b/src/lib/providers/codexFastTier.ts
@@ -96,7 +96,7 @@ export function getCodexEffectiveServiceTier(
   // Dashboard global modes are explicit overrides; use "none" to preserve the
   // per-connection requestDefaults.serviceTier value.
   if (globalServiceMode === true) return "priority";
-  if (globalServiceMode && globalServiceMode !== false && globalServiceMode !== "none") {
+  if (globalServiceMode && globalServiceMode !== "none") {
     return globalServiceMode;
   }
   return getCodexConnectionServiceTier(providerSpecificData);


### PR DESCRIPTION
## Summary

- remove the redundant `false` comparison after the existing truthiness guard
- preserve global Codex service-tier precedence and per-connection fallback behavior
- remove one existing TS6/TS7 diagnostic without adding diagnostics

## Root cause

After handling `true` explicitly and checking `globalServiceMode` for truthiness, TypeScript has already excluded the boolean `false` case. Comparing that narrowed string union against `false` is therefore impossible.

## Validation

- TypeScript 6 diagnostic multiset: 1 removed, 0 added
- TypeScript 7 diagnostic multiset: 1 removed, 0 added
- `tests/unit/codex-fast-tier.test.ts`: 7 passed
- ESLint and Prettier checks
- `npm run check:file-size -- --files src/lib/providers/codexFastTier.ts`
- `git diff --check`
