### PR TITLE
[TS7] fix(types): tighten extracted chatCore contracts

### DIFF
--- a/open-sse/handlers/chatCore/clineResponseEnvelope.ts
+++ b/open-sse/handlers/chatCore/clineResponseEnvelope.ts
@@ -4,7 +4,7 @@ function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function hasOpenAIChoices(value: unknown): boolean {
+function hasOpenAIChoices(value: unknown): value is JsonRecord & { choices: unknown[] } {
   return isRecord(value) && Array.isArray(value.choices);
 }
 

--- a/open-sse/handlers/chatCore/streamingPipeline.ts
+++ b/open-sse/handlers/chatCore/streamingPipeline.ts
@@ -61,12 +61,12 @@ const DEFAULT_DEPS: StreamingPipelineDeps = {
 
 export function assembleStreamingPipeline(
   args: {
-    providerResponse: unknown;
-    transformStream: unknown;
-    streamController: { signal: AbortSignal };
+    providerResponse: Parameters<typeof defaultPipeWithDisconnect>[0];
+    transformStream: Parameters<typeof defaultPipeWithDisconnect>[1];
+    streamController: Parameters<typeof defaultPipeWithDisconnect>[2];
     createPiiTransform: unknown;
     clientRawRequestHeaders: HeadersLike;
-    clientResponseFormat: unknown;
+    clientResponseFormat: Parameters<typeof defaultShape>[0];
     echoModel: string | null | undefined;
     responseHeaders: Record<string, string>;
   },

--- a/tests/unit/chatcore-streaming-pipeline.test.ts
+++ b/tests/unit/chatcore-streaming-pipeline.test.ts
@@ -10,6 +10,21 @@ import assert from "node:assert/strict";
 const { assembleStreamingPipeline } =
   await import("../../open-sse/handlers/chatCore/streamingPipeline.ts");
 
+type PipeWithDisconnectParameters = Parameters<
+  typeof import("../../open-sse/utils/streamHandler.ts").pipeWithDisconnect
+>;
+type ShapeForClientFormatParameters = Parameters<
+  typeof import("../../open-sse/utils/sseHeartbeat.ts").shapeForClientFormat
+>;
+
+function assertPipelineInputContracts(args: Parameters<typeof assembleStreamingPipeline>[0]) {
+  const providerResponse: PipeWithDisconnectParameters[0] = args.providerResponse;
+  const transformStream: PipeWithDisconnectParameters[1] = args.transformStream;
+  const streamController: PipeWithDisconnectParameters[2] = args.streamController;
+  const clientResponseFormat: ShapeForClientFormatParameters[0] = args.clientResponseFormat;
+  return { providerResponse, transformStream, streamController, clientResponseFormat };
+}
+
 // A fake stream: each pipeThrough appends the transform's tag and returns a new fake stream.
 function fakeStream(tag: string, log: string[]) {
   return {
@@ -50,6 +65,30 @@ function baseArgs(over: Record<string, unknown> = {}) {
     ...over,
   } as Parameters<typeof assembleStreamingPipeline>[0];
 }
+
+test("pipeline arguments preserve the dependency parameter contracts", () => {
+  const args = baseArgs({
+    providerResponse: new Response(),
+    transformStream: new TransformStream<Uint8Array, Uint8Array>(),
+    streamController: {
+      signal: new AbortController().signal,
+      startTime: Date.now(),
+      isConnected: () => true,
+      handleDisconnect: () => {},
+      handleComplete: () => {},
+      markClientTerminalSeen: () => {},
+      handleError: () => {},
+      abort: () => {},
+      clientResponseFormat: "openai",
+    },
+    clientResponseFormat: "openai",
+  });
+  const contracts = assertPipelineInputContracts(args);
+  assert.ok(contracts.providerResponse instanceof Response);
+  assert.ok(contracts.transformStream instanceof TransformStream);
+  assert.equal(contracts.streamController.clientResponseFormat, "openai");
+  assert.equal(contracts.clientResponseFormat, "openai");
+});
 
 test("baseline (no pii, no progress, no echo) → only heartbeat in the chain", () => {
   const { deps, log } = makeDeps();


### PR DESCRIPTION
## Summary
- make `hasOpenAIChoices` a real `JsonRecord & { choices: unknown[] }` type predicate
- derive streaming pipeline inputs from the exact `pipeWithDisconnect` and `shapeForClientFormat` parameter types
- preserve runtime behavior; add a focused compile-time contract characterization

## Verification
- latest base: `upstream/release/v3.8.50` at `8fac6bcd48090e56ccb361a78579db3b80eaf2d9`
- TS6 exact open-sse diagnostics: 125 -> 122 (removed 3, added 0)
- TS7 exact open-sse diagnostics: 124 -> 121 (removed 3, added 0)
- focused suites: 13 tests passed (`cline-response-envelope`, `chatcore-streaming-pipeline`)
- changed-file ESLint and Prettier checks
- `npm run typecheck:core`
- `npm run check:cycles`
- `npm run check:file-size`
- `git diff --check`

The three removed diagnostics are the assigned cline envelope spread error and the two extracted streaming pipeline contract errors.