### PR TITLE
[TS7] fix(types): align web executor event and model contracts

### DIFF
--- a/open-sse/executors/claude-web/stream.ts
+++ b/open-sse/executors/claude-web/stream.ts
@@ -148,7 +148,8 @@ async function* decodeSseData(
 }
 
 function safeMetadataValue(value: unknown): string | number | boolean | null | undefined {
-  if (value === null || typeof value === "boolean") return value;
+  if (value === null) return null;
+  if (typeof value === "boolean") return value;
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string" && value.length <= 128 && /^[A-Za-z0-9._:+/@-]+$/.test(value)) {
     return value;
@@ -715,7 +716,7 @@ async function pullStreamingChunk(
     while (!state.terminal) {
       const next = await state.iterator.next();
       if (state.control.cancelled) return;
-      if (next.done) {
+      if (next.done === true) {
         throw new ClaudeWebProtocolError("Claude Web stream ended without a terminal event");
       }
       await queueSemanticEvent(state, next.value, options);

--- a/open-sse/executors/inner-ai.ts
+++ b/open-sse/executors/inner-ai.ts
@@ -23,6 +23,7 @@ interface InnerAiModel {
   unavailable_api?: boolean;
   pro_only?: boolean;
   ultra_only?: boolean;
+  ai_model_categories?: Array<Record<string, unknown>>;
 }
 
 interface CredentialCache {
@@ -283,9 +284,7 @@ async function resolveModels(
     if (m.enable === false || m.unavailable_api) return false;
     if (m.ultra_only && !isUltra) return false;
     if (m.pro_only && !isPro) return false;
-    const cats = Array.isArray((m as Record<string, unknown>).ai_model_categories)
-      ? ((m as Record<string, unknown>).ai_model_categories as Array<Record<string, unknown>>)
-      : null;
+    const cats = Array.isArray(m.ai_model_categories) ? m.ai_model_categories : null;
     if (cats && cats.length > 0) {
       return cats.some((c) => String(c.unique_identifier ?? c.name ?? "").toLowerCase() === "text");
     }


### PR DESCRIPTION
## Summary

- preserve Claude Web metadata narrowing for `null` and boolean values
- make the async-iterator completion branch explicit before consuming semantic events
- model Inner.ai's returned `ai_model_categories` field directly instead of casting through an unrelated record shape

## Root cause

The compiler did not retain the intended narrowing across a combined unknown-value condition or the broad async-iterator `done` branch. Inner.ai's declared model shape also omitted metadata that the filtering code already consumes at runtime.

## Validation

- TypeScript 6 diagnostic multiset: 4 removed, 0 added
- TypeScript 7 diagnostic multiset: 4 removed, 0 added
- Claude Web stream and Inner.ai focused suites: 18 passed
- ESLint and Prettier checks on changed files
- `npm run check:file-size -- --files open-sse/executors/claude-web/stream.ts open-sse/executors/inner-ai.ts`
- `npm run check:cycles`
- `git diff --check`
