### PR TITLE
[TS7] fix(types): align web provider support contracts

### DIFF
--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -44,7 +44,6 @@ const SENTINEL_PREPARE_URL = `${CHATGPT_BASE}/backend-api/sentinel/chat-requirem
 const SENTINEL_CR_URL = `${CHATGPT_BASE}/backend-api/sentinel/chat-requirements`;
 const CONV_URL = `${CHATGPT_BASE}/backend-api/f/conversation`;
 const USER_LAST_USED_MODEL_CONFIG_URL = `${CHATGPT_BASE}/backend-api/settings/user_last_used_model_config`;
-
 const DEFAULT_PRO_POLL_TIMEOUT_MS = 20 * 60_000;
 const DEFAULT_PRO_POLL_INTERVAL_MS = 4_000;
 
@@ -2263,7 +2262,7 @@ interface ResolverContext {
   deviceId: string;
   cookie: string;
   signal?: AbortSignal | null;
-  log?: { debug?: (tag: string, msg: string) => void; warn?: (tag: string, msg: string) => void };
+  log?: Partial<Record<"debug" | "info" | "warn", (tag: string, msg: string) => void>>;
   /**
    * Absolute base URL that downstream clients should use to fetch cached
    * images served by /v1/chatgpt-web/image/<id>. Derived from the inbound
@@ -2697,9 +2696,10 @@ async function pollForAsyncImage(
         const message = node?.message;
         const parts = message?.content?.parts;
         if (!Array.isArray(parts)) continue;
-        const pointers = extractImagePointers(parts).map(
-          (pointer) => ({ pointer, messageId: message?.id })
-        );
+        const pointers = extractImagePointers(parts).map((pointer) => ({
+          pointer,
+          messageId: message?.id,
+        }));
         if (pointers.length === 0) continue;
         const at = message?.create_time ?? 0;
         if (!newest || at >= newest.at) newest = { pointers, at };

--- a/open-sse/executors/duckduckgo-web.ts
+++ b/open-sse/executors/duckduckgo-web.ts
@@ -136,11 +136,6 @@ interface DuckDuckGoModelCapabilities {
   reasoningEffort: string | null;
 }
 
-type DuckDuckGoChallengeResult = {
-  client_hashes?: unknown;
-  [key: string]: unknown;
-};
-
 let durablePublicKey: JsonWebKey | null = null;
 
 function extractDuckDuckGoContent(data: unknown): string {

--- a/open-sse/executors/duckduckgo-web/challenge.ts
+++ b/open-sse/executors/duckduckgo-web/challenge.ts
@@ -102,6 +102,11 @@ export function sha256Base64(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("base64");
 }
 
+type DuckDuckGoChallengeResult = {
+  client_hashes?: unknown;
+  [key: string]: unknown;
+};
+
 export async function solveDuckDuckGoChallenge(
   challenge: string,
   userAgent: string

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -299,7 +299,7 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     hintFallback:
       "Open arena.ai, sign in, then copy the full Cookie header from a Network request. Include arena-auth-prod-v1.0 and arena-auth-prod-v1.1 (and further chunks if present), preferably with cf_clearance. Do not paste only the empty arena-auth-prod-v1 cookie. Optional: providerSpecificData.recaptchaV3Token if create-evaluation still returns 403.",
   },
-  "promptql": {
+  promptql: {
     kind: "token",
     credentialName: "Bearer JWT (optional: projectId, session Cookie)",
     placeholder: "eyJ...  (Authorization Bearer from prompt.ql.app)",
@@ -317,7 +317,8 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie", "token", "access_token", "accessToken"],
   },
-} satisfies Record<keyof typeof WEB_COOKIE_PROVIDERS, WebSessionCredentialRequirement>;
+} satisfies Record<string, WebSessionCredentialRequirement> &
+  Record<keyof typeof WEB_COOKIE_PROVIDERS, WebSessionCredentialRequirement>;
 
 export function getWebSessionCredentialRequirement(
   providerId: unknown

--- a/tests/unit/duckduckgo-challenge-split.test.ts
+++ b/tests/unit/duckduckgo-challenge-split.test.ts
@@ -16,6 +16,7 @@ test("leaf hosts the solver and does not import the host", () => {
   const src = readFileSync(LEAF, "utf8");
   assert.match(src, /export async function solveDuckDuckGoChallenge\b/);
   assert.match(src, /export function makeDuckDuckGoFeSignals\b/);
+  assert.match(src, /type DuckDuckGoChallengeResult\s*=/);
   assert.doesNotMatch(src, /from "\.\.\/duckduckgo-web\.ts"/);
   // The vm sandbox timeout must survive the move (security invariant).
   assert.match(src, /timeout/);
@@ -24,6 +25,7 @@ test("leaf hosts the solver and does not import the host", () => {
 test("host imports the solver back from the leaf", () => {
   const host = readFileSync(HOST, "utf8");
   assert.match(host, /from "\.\/duckduckgo-web\/challenge\.ts"/);
+  assert.doesNotMatch(host, /type DuckDuckGoChallengeResult\s*=/);
 });
 
 test("makeDuckDuckGoFeSignals returns a base64 string", async () => {


### PR DESCRIPTION
## Summary

- Align the ChatGPT Web resolver logger contract with its existing optional `info` call.
- Keep `DuckDuckGoChallengeResult` local to the extracted challenge leaf instead of the host executor.
- Validate every string-keyed web-session credential requirement while still requiring all `WEB_COOKIE_PROVIDERS` keys.
- Preserve runtime behavior; the focused split test now guards the host/leaf type ownership.

## Verification

- Base: `8fac6bcd48090e56ccb361a78579db3b80eaf2d9` (`upstream/release/v3.8.50`)
- Head: `0eccdbeeccac623e993771b26232e67a93187721`
- TS6 full open-sse diagnostics: `125 -> 121`; removed exactly 4 assigned diagnostics; added `0`.
- TS7 full open-sse diagnostics: `124 -> 120`; removed exactly 4 assigned diagnostics; added `0`.
- Diagnostic comparison preserved duplicates and normalized only line/column and worktree paths.
- Focused tests: `94/94` passed across ChatGPT Web, async image shapes, DuckDuckGo challenge split, and web-session credentials.
- Passed: `npm run typecheck:core`, `npm run lint`, `npm run check:cycles`, `npm run check:file-size`, `npm run check:changelog-integrity`, Prettier check, and `git diff --check`.
