### PR TITLE
fix(api): flatten single-row embedding vectors to OpenAI shape

### DIFF
--- a/open-sse/handlers/embeddings.ts
+++ b/open-sse/handlers/embeddings.ts
@@ -42,6 +42,31 @@ interface ClientRawRequest {
 }
 
 /**
+ * Flatten a single embedding item's vector to the OpenAI-spec `number[]` shape.
+ *
+ * Some OpenAI-compatible embedding backends — notably a llama.cpp
+ * `llama-server --embedding --pooling ...` instance — return each vector wrapped in one
+ * extra array level: `[[...floats]]` instead of `[...floats]` for a single input. That
+ * extra level is silently spec-breaking, since a standard OpenAI-SDK consumer reading
+ * `response.data[i].embedding` gets a length-1 array holding the real vector instead of
+ * the vector itself. Unwrap only that single redundant level; vectors that are already
+ * flat (or genuinely multi-row) are left untouched. See issue #9089.
+ */
+function flattenSingleRowEmbedding(item: unknown): void {
+  if (!item || typeof item !== "object" || !("embedding" in item)) return;
+  const record = item as { embedding: unknown };
+  const embedding = record.embedding;
+  if (
+    Array.isArray(embedding) &&
+    embedding.length === 1 &&
+    Array.isArray(embedding[0]) &&
+    typeof embedding[0][0] === "number"
+  ) {
+    record.embedding = embedding[0];
+  }
+}
+
+/**
  * Handle embedding request.
  * Supports both hardcoded cloud providers and dynamic local provider_nodes.
  * When resolvedProvider is passed, uses it directly (injection pattern from route handler).
@@ -358,6 +383,19 @@ export async function handleEmbedding({
 
     // Log provider response
     reqLogger.logProviderResponse(response.status, "", response.headers, data);
+
+    // OpenAI-spec compliance (#9089): each item's `embedding` must be a flat number[].
+    // Some OpenAI-compatible backends (e.g. a llama.cpp `llama-server --embedding`
+    // instance) return the vector wrapped in one extra array level — `[[...floats]]`
+    // instead of `[...floats]` — for a single input, which silently breaks any standard
+    // OpenAI-SDK consumer doing `response.data[i].embedding`. Flatten that one redundant
+    // level without touching providers that already return flat vectors.
+    const responseItems = data.data || data;
+    if (Array.isArray(responseItems)) {
+      for (const item of responseItems) {
+        flattenSingleRowEmbedding(item);
+      }
+    }
 
     // Normalize response to OpenAI format
     const normalizedResponse = {

--- a/tests/unit/embeddings-flatten-single-row-9089.test.ts
+++ b/tests/unit/embeddings-flatten-single-row-9089.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-embeddings-9089-"));
+
+const { handleEmbedding } = await import("../../open-sse/handlers/embeddings.ts");
+
+const localProvider = {
+  id: "localembed",
+  baseUrl: "http://localhost:8080/embeddings",
+  authType: "none" as const,
+  authHeader: "none" as const,
+  models: [],
+};
+
+function mockUpstream(payload: unknown): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+// #9089: a custom "OpenAI Compatible" (Embeddings) provider pointed at a llama.cpp
+// `llama-server --embedding --pooling cls` backend returns each vector wrapped in one
+// extra array level — `[[...floats]]` instead of `[...floats]`. The OpenAI spec requires a
+// flat `number[]`; the extra level silently breaks any SDK consumer doing
+// `response.data[0].embedding` (it gets a length-1 array holding the real vector).
+test("handleEmbedding flattens a single-row 2D embedding vector (#9089)", async () => {
+  const restore = mockUpstream({
+    data: [{ object: "embedding", embedding: [[0.1, 0.2, 0.3]], index: 0 }],
+    usage: { prompt_tokens: 2, total_tokens: 2 },
+  });
+  try {
+    const result = await handleEmbedding({
+      body: { model: "localembed/bge-m3", input: "test" },
+      credentials: null,
+      resolvedProvider: localProvider,
+      resolvedModel: "bge-m3",
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    const rows = result.data.data as Array<{ embedding: number[] }>;
+    assert.deepEqual(rows[0].embedding, [0.1, 0.2, 0.3]);
+    assert.equal(rows[0].embedding.length, 3);
+    assert.equal(typeof rows[0].embedding[0], "number");
+  } finally {
+    restore();
+  }
+});
+
+test("handleEmbedding leaves an already-flat embedding untouched (#9089 regression guard)", async () => {
+  const restore = mockUpstream({
+    data: [{ object: "embedding", embedding: [0.1, 0.2, 0.3], index: 0 }],
+    usage: { prompt_tokens: 2, total_tokens: 2 },
+  });
+  try {
+    const result = await handleEmbedding({
+      body: { model: "localembed/bge-m3", input: "test" },
+      credentials: null,
+      resolvedProvider: localProvider,
+      resolvedModel: "bge-m3",
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    const rows = result.data.data as Array<{ embedding: number[] }>;
+    assert.deepEqual(rows[0].embedding, [0.1, 0.2, 0.3]);
+  } finally {
+    restore();
+  }
+});
+
+test("handleEmbedding flattens single-row vectors for every item in a batch (#9089)", async () => {
+  const restore = mockUpstream({
+    data: [
+      { object: "embedding", embedding: [[1, 2]], index: 0 },
+      { object: "embedding", embedding: [[3, 4]], index: 1 },
+    ],
+    usage: { total_tokens: 4 },
+  });
+  try {
+    const result = await handleEmbedding({
+      body: { model: "localembed/bge-m3", input: ["a", "b"] },
+      credentials: null,
+      resolvedProvider: localProvider,
+      resolvedModel: "bge-m3",
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    const rows = result.data.data as Array<{ embedding: number[] }>;
+    assert.deepEqual(rows[0].embedding, [1, 2]);
+    assert.deepEqual(rows[1].embedding, [3, 4]);
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary

`POST /v1/embeddings` returned each item's `embedding` double-nested — `[[...floats]]` instead of the OpenAI-spec-correct `[...floats]` — when routed through a custom "OpenAI Compatible" (Embeddings API Type) provider pointed at a llama.cpp `llama-server --embedding` backend. Such backends wrap a single input's vector in one extra array level; the embeddings handler forwarded the upstream `data.data` verbatim, so the extra level reached the client. A standard OpenAI-SDK consumer doing `response.data[0].embedding` then silently receives a length-1 array holding the real vector instead of the vector itself — an HTTP 200 with a wrong-shaped payload, the worst failure mode for downstream vector-store inserts and similarity search.

## Root cause

The request path `/v1/embeddings` → `createEmbeddingResponse` (`src/lib/embeddings/service.ts`) → `handleEmbedding` (`open-sse/handlers/embeddings.ts`) passes the upstream response's `data.data` through unchanged. When the upstream returns a single-row 2D vector (`embedding: [[...]]`), that shape is forwarded as-is, violating the OpenAI embeddings spec (`embedding` must be a flat `number[]`).

## Fix

Add a `flattenSingleRowEmbedding()` helper in `open-sse/handlers/embeddings.ts` that unwraps exactly one redundant array level per response item — only when the vector is a length-1 array whose single element is itself a numeric array. Already-flat vectors, and genuinely multi-row responses, are left untouched.

## Tests

Per the TDD protocol (Hard Rule #18): added `tests/unit/embeddings-flatten-single-row-9089.test.ts`, which fails before the fix and passes after. It covers three cases:

- single-row 2D vector `[[...]]` → flattened to `[...]`
- already-flat vector → unchanged (regression guard)
- batch input → every item flattened

Verification run locally:

- `node --import tsx/esm --test tests/unit/embeddings-flatten-single-row-9089.test.ts` → 3/3 pass (2/3 failed before the fix)
- all 57 embeddings unit tests pass; existing `embeddings-handler.test.ts` unchanged (9/9)
- `npx eslint` clean on both files; `npm run typecheck:core` → 0 errors

Fixes #9089.
