### PR TITLE
test(dashboard): drop stale next-intl mock breaking ProviderDetailPageClient smoke

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/__tests__/ProviderDetailPageClient.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/__tests__/ProviderDetailPageClient.test.tsx
@@ -54,11 +54,6 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-vi.mock("next-intl", () => ({
-  // Echo the key back so assertions don't depend on a full message catalog.
-  useTranslations: (namespace?: string) => (key: string) => (namespace ? `${namespace}.${key}` : key),
-}));
-
 function renderProviderPage() {
   const container = document.createElement("div");
   document.body.appendChild(container);


### PR DESCRIPTION
## What

Pre-existing test failure on `release/v3.8.50`: `ProviderDetailPageClient.test.tsx` crashes with `TypeError: t.rich is not a function` (`ProviderParamFilterSection.tsx:199`).

## Root cause

The file carries a local `vi.mock("next-intl")` added back in v3.8.22 (#3623) that echoes keys and exposes no `.rich`. It overrides the global polyfill (#7935), which is backed by the real `createTranslator` and provides `.rich`.

## Fix

Remove the stale local mock; the global #7935 polyfill covers this file. Test-only change — no production code touched.

## Validation (TDD)

- Base: `vitest run ProviderDetailPageClient.test.tsx` → **1 failed / 2 passed** (`t.rich is not a function`)
- After: **3/3 passed**; whole `providers/[id]` zone → **11 files / 68 tests green**
- `node scripts/check/check-dashboard-typecheck.mjs` → OK (254 errors, all within frozen baseline)

## Out of scope

- TS2322 `CodexGlobalServiceMode` narrowing in `ConnectionsListPanel.tsx` and the 251 other baselined dashboard typecheck errors: no failing test proves them (Hard Rule #18 — "a fix without a test is a guess"). The typecheck gate is a ratchet, not a sweep mandate; these belong to PRs that already touch those files (pattern: NotifyStore absorbed in #9149).
