### PR TITLE
test(mcp): guard Node 24 bundled MCP startup

### DIFF
--- a/tests/unit/build/mcp-bundle-startup.test.ts
+++ b/tests/unit/build/mcp-bundle-startup.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Regression guard for the Node 24 MCP startup crash caused by an ESM init cycle.
+// The published bundle is produced by this exact esbuild invocation in
+// scripts/build/prepublish.ts. Importing the generated file in a fresh Node process
+// catches syntax/link failures that `node --check` does not report for this bundle.
+
+const repoRoot = process.cwd();
+
+test("MCP server bundle imports successfully on Node 24", () => {
+  // Keep the generated bundle below the repository so Node's ESM resolver can
+  // find the repository's external production dependencies (for example zod).
+  const outDir = mkdtempSync(join(repoRoot, ".mcp-bundle-startup-"));
+  const outFile = join(outDir, "server.js");
+
+  try {
+    execFileSync(
+      "npx",
+      [
+        "esbuild",
+        "open-sse/mcp-server/server.ts",
+        "--bundle",
+        "--platform=node",
+        "--packages=external",
+        "--format=esm",
+        `--outfile=${outFile}`,
+      ],
+      { cwd: repoRoot, stdio: "pipe" }
+    );
+
+    const bundled = readFileSync(outFile, "utf8");
+    assert.doesNotMatch(
+      bundled,
+      /init_googApiKeyAuth[\s\S]{0,300}await init_auth\(\)/,
+      "MCP bundle must not contain the auth ↔ googApiKeyAuth circular initializer"
+    );
+
+    const importScript = `await import(${JSON.stringify(pathToFileURL(outFile).href)});`;
+    assert.doesNotThrow(() => {
+      execFileSync(process.execPath, ["--input-type=module", "-e", importScript], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          DATA_DIR: join(outDir, "data"),
+          DISABLE_SQLITE_AUTO_BACKUP: "true",
+          JWT_SECRET: "mcp-bundle-startup-test-jwt-secret-000",
+          API_KEY_SECRET: "mcp-bundle-startup-test-api-key-secret",
+        },
+        stdio: "pipe",
+      });
+    }, "the generated MCP bundle must be importable by the supported Node runtime");
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add a regression test that builds the published MCP bundle and imports it in a fresh Node 24 process
- preserve coverage for the MCP startup failure previously surfaced by Codex as `connection closed: initialize response`

## Why this PR is test-only now

The active `release/v3.8.50` base already contains the production circular-import fix in commit `7d6a64b05` (`fix(mcp): break circular import between googApiKeyAuth.ts and auth.ts (#9297)`). During reconciliation, the duplicate source and changelog changes were dropped. This PR now contributes only the missing Node 24 bundled-startup regression guard.

## Runtime validation

Validated in a clean Linux environment with:

- Node.js `v24.18.0`
- Codex CLI `v0.147.0`
- the MCP server bundled from this branch
- a successful Codex MCP invocation of `omniroute_agent_skills_coverage({})`, which returned structured coverage data
- no MCP handshake or `initialize response` failure

## Verification

- `node --import tsx/esm --test tests/unit/build/mcp-bundle-startup.test.ts` — pass (1/1)
- `npm run check:build-scope` — pass
- `npm run check:cycles` — pass, zero cycles across the checked MCP and core modules
- `npm run lint` — pass

Per `CONTRIBUTING.md`, broader unit shards, Vitest, coverage, and production build remain CI-owned for this test-only build/deploy-scope change.

## Review scope

- one commit
- one new file: `tests/unit/build/mcp-bundle-startup.test.ts`
- 60 insertions
- no production source or dependency changes