### PR TITLE
fix(rate-limit): separate queue wait from execution timeout

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -158,6 +158,7 @@ import {
   isStreamReadinessFailureErrorBody,
   isStreamEarlyEofErrorBody,
   isTokenLimitBreachErrorBody,
+  isLocalQueueCapacityErrorBody,
   toRecordedTarget,
   getExhaustedTargetSkipReason,
   clampPercent,
@@ -1657,6 +1658,7 @@ export async function handleComboChat({
           // FIX 5: a local per-API-key token-limit 429 must not cool shared accounts.
           const isTokenLimitBreach =
             result.status === 429 && isTokenLimitBreachErrorBody(errorBody);
+          const isLocalQueueCapacity = isLocalQueueCapacityErrorBody(errorBody);
 
           // Fix #1681: Status 499 means client disconnected — stop combo loop immediately.
           // There is no point trying fallback models when nobody is listening.
@@ -1673,6 +1675,22 @@ export async function handleComboChat({
             // executeTarget must return the {ok,response} contract — a raw Response
             // here makes the speculative loop's res.ok/res.response checks both miss,
             // so the combo would wrongly fall through to the next model after a 499.
+            return { ok: false, response: result };
+          }
+          if (isLocalQueueCapacity) {
+            log.info(
+              "COMBO",
+              `Local rate-limit queue capacity reached for ${modelStr} — returning without upstream fallback`
+            );
+            recordComboRequest(combo.name, modelStr, {
+              success: false,
+              latencyMs: Date.now() - startTime,
+              fallbackCount,
+              strategy,
+              target: toRecordedTarget(target),
+            });
+            recordedAttempts++;
+            if (i > 0) fallbackCount++;
             return { ok: false, response: result };
           }
 
@@ -2989,6 +3007,23 @@ async function handleRoundRobinCombo({
 
         // FIX 5: a local per-API-key token-limit 429 must not cool shared accounts.
         const isTokenLimitBreach = result.status === 429 && isTokenLimitBreachErrorBody(errorBody);
+        const isLocalQueueCapacity = isLocalQueueCapacityErrorBody(errorBody);
+
+        if (isLocalQueueCapacity) {
+          log.info(
+            "COMBO-RR",
+            `Local rate-limit queue capacity reached for ${modelStr} — returning without upstream fallback`
+          );
+          recordComboRequest(combo.name, modelStr, {
+            success: false,
+            latencyMs: Date.now() - startTime,
+            fallbackCount,
+            strategy: "round-robin",
+            target: toRecordedTarget(target),
+          });
+          recordedAttempts++;
+          return result;
+        }
 
         // Round-robin uses the same target-level fallback rule as other combo
         // strategies: non-ok target responses fall through to the next target.

--- a/open-sse/services/combo/comboPredicates.ts
+++ b/open-sse/services/combo/comboPredicates.ts
@@ -197,6 +197,10 @@ const REQUEST_SCOPED_UPSTREAM_ERROR_CODES: Record<string, true> = {
   upstream_response_failed: true,
   // Local combo per-target timer (targetTimeoutRunner) — not a connection health signal.
   combo_target_timeout: true,
+  // Local limiter queue-capacity codes — not a provider/connection health signal.
+  rate_limit_queue_timeout: true,
+  rate_limit_queue_full: true,
+  rate_limit_queue_wedged: true,
 };
 
 /** Request/model-specific failures must not poison provider-wide resilience state. */
@@ -206,7 +210,11 @@ export function isRequestScopedUpstreamFailure(error?: {
 }): boolean {
   const code = typeof error?.code === "string" ? error.code.toLowerCase() : "";
   const type = typeof error?.type === "string" ? error.type.toLowerCase() : "";
-  return REQUEST_SCOPED_UPSTREAM_ERROR_CODES[code] === true || type === "context_length_exceeded";
+  return (
+    REQUEST_SCOPED_UPSTREAM_ERROR_CODES[code] === true ||
+    type === "context_length_exceeded" ||
+    type === "local_queue_capacity"
+  );
 }
 
 /** Request-scoped classification that also has access to the HTTP body. */
@@ -356,6 +364,21 @@ export function isTokenLimitBreachErrorBody(errorBody: unknown): boolean {
   const error = (errorBody as Record<string, unknown>).error;
   if (!error || typeof error !== "object") return false;
   return (error as Record<string, unknown>).code === "TOKEN_LIMIT_EXCEEDED";
+}
+
+/** Local limiter capacity is not an upstream/provider failure and must not cascade. */
+export function isLocalQueueCapacityErrorBody(errorBody: unknown): boolean {
+  if (!errorBody || typeof errorBody !== "object") return false;
+  const error = (errorBody as Record<string, unknown>).error;
+  if (!error || typeof error !== "object") return false;
+  const code = String((error as Record<string, unknown>).code || "").toUpperCase();
+  const type = String((error as Record<string, unknown>).type || "").toLowerCase();
+  return (
+    code === "RATE_LIMIT_QUEUE_TIMEOUT" ||
+    code === "RATE_LIMIT_QUEUE_FULL" ||
+    code === "RATE_LIMIT_QUEUE_WEDGED" ||
+    type === "local_queue_capacity"
+  );
 }
 
 export function toRecordedTarget(target: ResolvedComboTarget) {

--- a/tests/unit/rate-limit-local-capacity-classification.test.ts
+++ b/tests/unit/rate-limit-local-capacity-classification.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { isLocalQueueCapacityErrorBody, isRequestScopedUpstreamFailure, shouldSkipConnDisable } =
+  await import("../../open-sse/services/combo/comboPredicates.ts");
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+
+function localQueueResponse() {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "Local rate-limit queue wait exceeded",
+        code: "RATE_LIMIT_QUEUE_TIMEOUT",
+        type: "local_queue_capacity",
+      },
+    }),
+    { status: 429, headers: { "content-type": "application/json" } }
+  );
+}
+
+function createLog() {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+}
+
+test("local queue capacity is request-scoped and never disables a healthy connection", () => {
+  assert.equal(
+    isRequestScopedUpstreamFailure({
+      code: "RATE_LIMIT_QUEUE_TIMEOUT",
+      type: "local_queue_capacity",
+    }),
+    true
+  );
+  assert.equal(
+    shouldSkipConnDisable(
+      {
+        status: 429,
+        errorCode: "RATE_LIMIT_QUEUE_TIMEOUT",
+        errorType: "local_queue_capacity",
+      },
+      false,
+      false,
+      "nvidia"
+    ),
+    true
+  );
+  assert.equal(
+    isLocalQueueCapacityErrorBody({
+      error: { code: "RATE_LIMIT_QUEUE_TIMEOUT", type: "local_queue_capacity" },
+    }),
+    true
+  );
+});
+
+test("combo returns a local queue capacity response without retrying or rotating targets", async () => {
+  let calls = 0;
+  const response = await handleComboChat({
+    body: { model: "openai/gpt-4" },
+    combo: {
+      name: `local-queue-capacity-${Math.random().toString(16).slice(2)}`,
+      strategy: "priority",
+      models: ["openai/gpt-4", "openai/gpt-4o-mini"],
+      config: { maxRetries: 2, maxSetRetries: 1, retryDelayMs: 0, fallbackDelayMs: 0 },
+    },
+    handleSingleModel: async () => {
+      calls += 1;
+      return localQueueResponse();
+    },
+    isModelAvailable: async () => true,
+    log: createLog() as never,
+    settings: {},
+    allCombos: null,
+  });
+
+  assert.equal(response.status, 429);
+  assert.equal(calls, 1, "a local queue limit must not amplify into retries or fallback calls");
+  const body = await response.json();
+  assert.equal(body.error.code, "RATE_LIMIT_QUEUE_TIMEOUT");
+  assert.equal(body.error.type, "local_queue_capacity");
+});


### PR DESCRIPTION
## Summary

- Apply `requestQueue.maxWaitMs` only while a request waits for limiter admission, not while an admitted upstream request is executing.
- Prevent timed-out queued placeholders from starting upstream work later.
- Classify local queue timeout, full, and wedge conditions as local capacity errors rather than provider failures.
- Prevent local limiter errors from poisoning connection health or cascading through combo retries and fallback targets.

## Problem

The rate limiter passed `requestQueue.maxWaitMs` to Bottleneck as job `expiration`. Bottleneck applied that deadline to the complete scheduled job, including an already-running upstream request.

A slow but valid request could therefore be rejected locally even though the provider had not failed. The resulting local error was surfaced as a provider-style `503`, which could mark accounts or models unavailable, rotate through other connections, and amplify one timeout into repeated fallback calls.

The underlying upstream request could also remain active after the wrapper timed out and continue consuming local concurrency.

## Fix

- Add queue-wait-only scheduling through `scheduleWithQueueWaitBudget`.
- Once admitted, let existing upstream timeout and cancellation controls govern execution.
- Ensure timed-out or aborted queued placeholders cannot invoke upstream work later.
- Map `RATE_LIMIT_QUEUE_TIMEOUT`, `RATE_LIMIT_QUEUE_FULL`, and `RATE_LIMIT_QUEUE_WEDGED` to HTTP 429 with type `local_queue_capacity`.
- Treat these errors as request-scoped and skip connection disablement.
- Return local queue-capacity responses from priority and round-robin combos without retrying or rotating targets.

## Validation

Focused regression tests passed for:

- queue timeout before admission
- prevention of delayed upstream execution
- long-running admitted requests exceeding `maxWaitMs`
- queued-request cancellation
- local capacity classification
- prevention of combo retry/fallback amplification
- limiter wedge recovery
- queue-depth admission control
- existing connection-disable guards

Focused ESLint validation passed for all modified source and test files.

## Files Changed

- `open-sse/services/rateLimitManager.ts`
- `open-sse/services/rateLimitManager/admission.ts`
- `open-sse/handlers/chatCore.ts`
- `open-sse/services/combo/comboPredicates.ts`
- `open-sse/services/combo.ts`
- `tests/unit/rate-limit-queue-timeout-message-4165.test.ts`
- `tests/unit/rate-limit-local-capacity-classification.test.ts`
