### PR TITLE
fix(api): list registry-only Claude models (opus-5/sonnet-5) in /v1/models when a sync omits them

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -39,6 +39,7 @@ import { getCompatibleFallbackModels } from "@/lib/providers/managedAvailableMod
 import { providerUsesCuratedModelsOnly } from "@/lib/providers/modelListingCapability";
 import { getOpenRouterCatalog } from "@/lib/catalog/openrouterCatalog";
 import { hasEligibleConnectionForModel } from "@/domain/connectionModelRules";
+import { shouldSkipStaticForSynced } from "./syncedStaticEligibility";
 import {
   INTERNAL_PROXY_ERROR,
   getCanonicalModelMetadata,
@@ -662,6 +663,23 @@ async function buildUnifiedModelsResponseCore(
         return Array.isArray(models) && models.length > 0;
       })
     );
+    // #9167: index synced model ids by the SAME canonical provider id the static
+    // loop reads (`canonicalProviderId`), so a static entry is skipped only when a
+    // synced row genuinely replaces it — not merely because the provider synced
+    // something. Registry-only models (opus-5/sonnet-5) then survive.
+    const syncedIdsByCanonicalProvider = new Map<string, Set<string>>();
+    for (const [pid, syncedModels] of Object.entries(syncedModelsByProvider)) {
+      if (providerUsesCuratedModelsOnly(pid)) continue;
+      if (!Array.isArray(syncedModels) || syncedModels.length === 0) continue;
+      const syncedAlias = providerIdToPrefix[pid] || providerIdToAlias[pid] || pid;
+      const syncedCanonical = resolveCanonicalProviderId(syncedAlias, pid);
+      let idSet = syncedIdsByCanonicalProvider.get(syncedCanonical);
+      if (!idSet) {
+        idSet = new Set<string>();
+        syncedIdsByCanonicalProvider.set(syncedCanonical, idSet);
+      }
+      for (const sm of syncedModels) idSet.add(sm.id);
+    }
     const isRegisteredEffortVariant = (
       providerModels: Array<{ id: string }>,
       modelId: string
@@ -694,10 +712,16 @@ async function buildUnifiedModelsResponseCore(
 
       for (const model of providerModels) {
         // Synced models replace static base entries, but they do not carry aliases
-        // registered for provider-specific reasoning variants.
+        // registered for provider-specific reasoning variants. #9167: replace only
+        // when the synced set actually carries this id, so registry-only models survive.
         if (
-          providersWithSyncedModels.has(canonicalProviderId) &&
-          !isRegisteredEffortVariant(providerModels, model.id)
+          shouldSkipStaticForSynced(
+            providerModels,
+            model.id,
+            providersWithSyncedModels.has(canonicalProviderId),
+            syncedIdsByCanonicalProvider.get(canonicalProviderId),
+            isRegisteredEffortVariant
+          )
         )
           continue;
         if (!providerSupportsModel(canonicalProviderId, model.id)) continue;

--- a/src/app/api/v1/models/syncedStaticEligibility.ts
+++ b/src/app/api/v1/models/syncedStaticEligibility.ts
@@ -1,0 +1,23 @@
+/**
+ * #9167 — "synced replaces static" skip decision for the /v1/models catalog builder,
+ * extracted as a pure leaf for unit testing.
+ *
+ * When a non-curated provider has synced ≥1 live model, the builder prefers synced
+ * rows over static registry rows to avoid duplicate ids. The original guard skipped
+ * EVERY static registry model for such a provider, which dropped brand-new registry
+ * models (e.g. `claude-opus-5` / `claude-sonnet-5`) that the upstream provider's live
+ * `/v1/models` does not advertise yet. This restores those by skipping a static entry
+ * only when the synced set actually carries the same id.
+ */
+export function shouldSkipStaticForSynced(
+  providerModels: Array<{ id: string }>,
+  modelId: string,
+  hasSyncedModels: boolean,
+  syncedIds: Set<string> | undefined,
+  isRegisteredEffortVariant: (pm: Array<{ id: string }>, id: string) => boolean
+): boolean {
+  if (!hasSyncedModels) return false;
+  // Effort variants are gateway-synthesized, never synced — they must always survive.
+  if (isRegisteredEffortVariant(providerModels, modelId)) return false;
+  return syncedIds?.has(modelId) === true;
+}

--- a/tests/unit/catalog-registry-only-survives-sync-9167.test.ts
+++ b/tests/unit/catalog-registry-only-survives-sync-9167.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #9167 — built-in registry models (claude-opus-5 / claude-sonnet-5) were dropped
+ * from GET /v1/models once the Claude provider synced ANY live model, because the
+ * catalog builder skipped every static registry entry for a synced provider. The
+ * fix (`shouldSkipStaticForSynced`) skips a static entry only when the synced set
+ * actually carries that id, so registry-only models survive.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { shouldSkipStaticForSynced } from "../../src/app/api/v1/models/syncedStaticEligibility.ts";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-9167-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "catalog-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+const CLAUDE_MODELS = [
+  { id: "claude-opus-4-8" },
+  { id: "claude-opus-5" },
+  { id: "claude-sonnet-5" },
+];
+
+const isRegisteredEffortVariant = (
+  providerModels: Array<{ id: string }>,
+  modelId: string
+): boolean => {
+  for (const suffix of ["none", "low", "medium", "high", "max", "xhigh"]) {
+    const suffixWithSeparator = `-${suffix}`;
+    if (!modelId.endsWith(suffixWithSeparator)) continue;
+    const baseModelId = modelId.slice(0, -suffixWithSeparator.length);
+    return providerModels.some((candidate) => candidate.id === baseModelId);
+  }
+  return false;
+};
+
+test("#9167 registry-only model survives when synced set lacks it", () => {
+  const syncedIds = new Set(["claude-opus-4-8"]);
+  assert.equal(
+    shouldSkipStaticForSynced(
+      CLAUDE_MODELS,
+      "claude-opus-5",
+      true,
+      syncedIds,
+      isRegisteredEffortVariant
+    ),
+    false,
+    "claude-opus-5 is not in the synced set, so the static entry must survive"
+  );
+});
+
+test("#9167 synced-and-static model is still skipped (no duplicate, synced wins)", () => {
+  const syncedIds = new Set(["claude-opus-4-8"]);
+  assert.equal(
+    shouldSkipStaticForSynced(
+      CLAUDE_MODELS,
+      "claude-opus-4-8",
+      true,
+      syncedIds,
+      isRegisteredEffortVariant
+    ),
+    true,
+    "claude-opus-4-8 is in the synced set, so the static entry is skipped to avoid a duplicate"
+  );
+});
+
+test("#9167 provider that synced nothing keeps all static entries", () => {
+  assert.equal(
+    shouldSkipStaticForSynced(
+      CLAUDE_MODELS,
+      "claude-opus-4-8",
+      false,
+      undefined,
+      isRegisteredEffortVariant
+    ),
+    false,
+    "with no synced models the static entry must always survive"
+  );
+});
+
+test("#9167 effort variant of a registry-only model is never skipped", () => {
+  const syncedIds = new Set(["claude-opus-4-8"]);
+  const providerModels = [...CLAUDE_MODELS, { id: "claude-opus-5-high" }];
+  assert.equal(
+    shouldSkipStaticForSynced(
+      providerModels,
+      "claude-opus-5-high",
+      true,
+      syncedIds,
+      isRegisteredEffortVariant
+    ),
+    false,
+    "registered effort variants are gateway-synthesized and must survive regardless of the synced set"
+  );
+});
+
+test("#9167 end-to-end: GET /v1/models lists a registry-only model the sync omits", async () => {
+  await resetStorage();
+  const connection = await providersDb.createProviderConnection({
+    provider: "claude",
+    authType: "oauth",
+    name: "claude-9167-account",
+    isActive: true,
+    testStatus: "active",
+  });
+  // Synced list carries opus-4-8 but NOT opus-5 (mirrors Anthropic's live list
+  // lagging the OmniRoute registry). Pre-fix this dropped every static claude
+  // registry model, so opus-5 vanished from /v1/models.
+  await modelsDb.replaceSyncedAvailableModelsForConnection("claude", String(connection.id), [
+    { id: "claude-opus-4-8", name: "Claude Opus 4.8" },
+  ]);
+
+  const response = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<{ id: string }> };
+  const ids = body.data.map((m) => m.id);
+  const idSet = new Set(ids);
+
+  assert.equal(response.status, 200);
+  assert.ok(
+    idSet.has("claude/claude-opus-5"),
+    "registry-only claude-opus-5 must appear even though the synced list omits it"
+  );
+  assert.ok(
+    idSet.has("claude/claude-sonnet-5"),
+    "registry-only claude-sonnet-5 must appear even though the synced list omits it"
+  );
+  assert.ok(idSet.has("claude/claude-opus-4-8"), "the synced model must still appear");
+  assert.equal(
+    ids.filter((id) => id === "claude/claude-opus-4-8").length,
+    1,
+    "the synced-and-static model must not be duplicated"
+  );
+
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

`GET /v1/models` silently dropped built-in registry models `claude-opus-5` and `claude-sonnet-5` for the `claude`/`cc` provider, even though they are fully defined in the Claude registry, `modelSpecs`, and pricing — while sibling models like `claude-opus-4-8` were served.

Root cause is in the `/v1/models` catalog builder (`src/app/api/v1/models/catalog.ts`). When a non-curated provider has synced ≥1 live model, the static-registry loop skipped **every** static entry for that provider (keeping only effort variants), on the assumption that the synced list fully replaces the static registry:

```ts
if (
  providersWithSyncedModels.has(canonicalProviderId) &&
  !isRegisteredEffortVariant(providerModels, model.id)
)
  continue;
```

But the synced list is the provider's **live** `/v1/models`, which lags OmniRoute's registry for brand-new models. So a model that exists in the registry but not yet in the upstream live list (Opus 5 / Sonnet 5) was dropped wholesale. `claude-opus-4-8` survived only because the sync happens to return it.

This PR changes the skip so a static entry is dropped **only when the synced set actually carries that same id** (i.e. only when it is genuinely being replaced). Registry-only models then survive; their reasoning-effort variants follow automatically because `appendClaudeEffortVariants` derives them from the surviving base entry.

The decision is extracted into a pure, unit-tested helper `shouldSkipStaticForSynced`, and the synced-id index is keyed by the **same** `canonicalProviderId` the static loop reads, so the lookup and the existing `providersWithSyncedModels.has(canonicalProviderId)` check always agree. `providersWithSyncedModels` is left untouched (the OpenRouter block depends on its semantics).

### Reproduction (live, v3.8.49–v3.8.50)

- `omniroute models` / dashboard list "Claude Opus 5" and "Claude Sonnet 5".
- `GET /v1/models` omits `cc/claude-opus-5`, `claude/claude-opus-5`, `cc/claude-sonnet-5`, `claude/claude-sonnet-5` while serving `cc/claude-opus-4-8`, `cc/claude-sonnet-4-6`, etc.
- A **custom** `claude-opus-5[1m]` on the same connection **is** served — proving the connection can route Opus 5 and isolating the bug to the static-vs-synced catalog path (not entitlement/routing).

## Related Issues

- Closes #9167

## Validation

- [x] Change type: **provider / routing** (catalog build for `GET /v1/models`)
- [x] Focused tests: `tests/unit/catalog-registry-only-survives-sync-9167.test.ts` (4 pure-helper cases + 1 end-to-end `getUnifiedModelsResponse` assertion) — all pass; the e2e assertion **fails on the pre-fix condition** (verified by reverting the guard) and passes with the fix.
- [x] No regressions in adjacent suites: `noauth-imported-models-3200`, `claude-web-sonnet5-registry-6209`, `synced-model-hide-persist-3782`, `catalog-helpers-extraction`, `8327-models-owned-by-prefix` (23/23 pass).
- [x] `npm run lint` — ESLint with the repo suppressions baseline is clean on the changed files (the single `no-restricted-imports` note on `catalog.ts` line 3 is pre-existing and already in the baseline). Prettier clean on all changed files.
- [x] Reconciled with the current active release base (`release/v3.8.50`, HEAD `ec150a0`).
- [x] Production-code change includes new automated tests in this PR.

Commands run:

```sh
# focused tests
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts \
  --test --test-force-exit tests/unit/catalog-registry-only-survives-sync-9167.test.ts   # 5/5 pass

# no-regression sweep of adjacent catalog/synced tests
node ... --test tests/unit/noauth-imported-models-3200.test.ts \
  tests/unit/claude-web-sonnet5-registry-6209.test.ts \
  tests/unit/synced-model-hide-persist-3782.test.ts \
  tests/unit/catalog-helpers-extraction.test.ts \
  tests/unit/8327-models-owned-by-prefix.test.ts                                          # 23/23 pass

# lint (with suppressions baseline) + prettier — clean on changed files
eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>   # exit 0
prettier --check <changed files>                                                          # all clean
```

## Tests Added Or Updated

- **Added** `tests/unit/catalog-registry-only-survives-sync-9167.test.ts`:
  - unit: registry-only model survives when the synced set lacks it (the bug);
  - unit: synced-and-static model is still skipped (no duplicate, synced wins — original intent preserved);
  - unit: provider that synced nothing keeps all static entries;
  - unit: effort variant of a registry-only model is never skipped;
  - e2e: seeds an active `claude` OAuth connection + a synced set containing `claude-opus-4-8` but not `claude-opus-5`, then asserts `GET /v1/models` includes `claude/claude-opus-5` and `claude/claude-sonnet-5`, still includes the synced `claude/claude-opus-4-8`, and does not duplicate it.

## Coverage Notes

- Touches `src/` (catalog builder). The new pure helper `shouldSkipStaticForSynced` is fully branch-covered by the four unit cases; the modified skip site is exercised by the end-to-end test through `getUnifiedModelsResponse`.

## Reviewer Notes

- **Highest-risk detail:** the synced-id index is keyed by `canonicalProviderId` (resolved with the same `resolveCanonicalProviderId(alias, providerId)` the synced loop uses) so it agrees with the `providersWithSyncedModels.has(canonicalProviderId)` check. For `claude` raw id === canonical; the canonical keying is what keeps this correct for compatible providers with UUID raw ids.
- `providersWithSyncedModels` semantics are unchanged (the OpenRouter block at `!providersWithSyncedModels.has("openrouter")` relies on them).
- No duplicates introduced: a model in both registry and synced set is still emitted once (by the synced loop); a registry-only model is emitted by the registry loop; a synced-only model by the synced loop. `dedupeExactCatalogIds` remains as an independent backstop but the logic does not rely on it.
- Depends on `modelSpecs` entries for `claude-opus-5` / `claude-sonnet-5` (both present with `supportsThinking: true`) so their effort variants and enrichment work — verified in `src/shared/constants/modelSpecs.ts`.