### PR TITLE
fix(translator): translate Codex agent messages for Chat

### DIFF
--- a/open-sse/utils/responsesInputNormalization.ts
+++ b/open-sse/utils/responsesInputNormalization.ts
@@ -1,5 +1,36 @@
 type JsonRecord = Record<string, unknown>;
 
+function normalizeAgentMessageForChat(item: JsonRecord): JsonRecord | null {
+  if (item.type !== "agent_message") return null;
+
+  if (!Array.isArray(item.content)) return null;
+
+  const textParts: string[] = [];
+  for (const partValue of item.content) {
+    if (!partValue || typeof partValue !== "object" || Array.isArray(partValue)) {
+      return null;
+    }
+
+    const part = partValue as JsonRecord;
+    if (part.type === "encrypted_content") {
+      // Chat Completions has no encrypted agent-message equivalent. Do not leak a
+      // partial plaintext envelope or forward an opaque payload the model cannot use.
+      return null;
+    }
+    if (part.type !== "input_text" || typeof part.text !== "string") return null;
+    textParts.push(part.text);
+  }
+
+  const text = textParts.join("\n");
+  if (!text.trim()) return null;
+
+  return {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "input_text", text }],
+  };
+}
+
 function textPartTypeForRole(role: string): "input_text" | "output_text" {
   return role === "assistant" ? "output_text" : "input_text";
 }
@@ -82,6 +113,15 @@ function normalizeResponsesInputItemForChat(value: unknown): unknown {
   const item = { ...(value as JsonRecord) };
   const hasType = typeof item.type === "string" && item.type.length > 0;
   const hasRole = typeof item.role === "string" && item.role.length > 0;
+
+  const agentMessage = normalizeAgentMessageForChat(item);
+  if (agentMessage) return agentMessage;
+  if (item.type === "agent_message") {
+    // Encrypted or malformed agent messages have no lossless Chat equivalent.
+    // Treat them like other Responses-only metadata instead of failing the whole turn.
+    return { type: "reasoning" };
+  }
+
   if (hasType || hasRole) {
     if (!hasType && hasRole) item.type = "message";
     return item;

--- a/tests/unit/responses-chat-translation-gaps.test.ts
+++ b/tests/unit/responses-chat-translation-gaps.test.ts
@@ -138,6 +138,46 @@ test("Responses -> Chat rejects input item types without a lossless Chat equival
   }
 });
 
+test("Responses -> Chat converts plaintext agent_message items to assistant history", () => {
+  const result = translate({
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "Run the task" }] },
+      {
+        type: "agent_message",
+        author: "worker",
+        recipient: "parent",
+        content: [{ type: "input_text", text: "Task completed" }],
+      },
+    ],
+  });
+
+  assert.deepEqual(result.messages, [
+    { role: "user", content: [{ type: "text", text: "Run the task" }] },
+    { role: "assistant", content: [{ type: "text", text: "Task completed" }] },
+  ]);
+});
+
+test("Responses -> Chat skips encrypted or mixed agent_message items", () => {
+  const result = translate({
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "Run the task" }] },
+      {
+        type: "agent_message",
+        author: "worker",
+        recipient: "parent",
+        content: [
+          { type: "input_text", text: "Message Type: NEW_TASK\nPayload:\n" },
+          { type: "encrypted_content", encrypted_content: "opaque" },
+        ],
+      },
+    ],
+  });
+
+  assert.deepEqual(result.messages, [
+    { role: "user", content: [{ type: "text", text: "Run the task" }] },
+  ]);
+});
+
 test("Responses -> Chat consumes additional_tools input items without emitting messages", () => {
   const result = translate({
     input: [


### PR DESCRIPTION
## Summary

Fixes Codex native-subagent requests that fail when routed through OmniRoute Responses-to-Chat translation.

## Problem

Codex sends native subagent history through `/v1/responses` using an input item like:

```json
{
  "type": "agent_message",
  "author": "/root",
  "recipient": "/root/worker",
  "content": [
    {"type": "input_text", "text": "Message Type: NEW_TASK\\nPayload:\\n"},
    {"type": "encrypted_content", "encrypted_content": "gAAAA..."}
  ]
}
```

OmniRoute downgraded the request to Chat Completions, but the Responses-to-Chat translator did not recognize `agent_message`. It raised:

```text
Unsupported Responses API feature: input item type agent_message cannot be represented in Chat Completions
```

The error occurred before the request reached the configured upstream provider, so the delegated worker turn failed immediately.

## Root Cause

`normalizeResponsesInputForChat()` passed `agent_message` through unchanged. The request translator then handled known message/tool/metadata item types and fell through to its unsupported-feature error for `agent_message`.

## Fix

- Convert fully plaintext `agent_message` content into an assistant history message.
- Treat encrypted or mixed encrypted `agent_message` items as Responses-only metadata and skip them during Chat conversion.
- Add regression coverage for both plaintext and the mixed plaintext/encrypted shape emitted by Codex.

Encrypted content is provider-specific and has no lossless Chat Completions representation, so OmniRoute intentionally does not forward ciphertext to a non-Codex Chat backend.

## Related Issues

- No exact existing OmniRoute issue matches this regression.
- Related to [OpenAI Codex #17598](https://github.com/openai/codex/issues/17598)
- Related to [OmniRoute #8146](https://github.com/diegosouzapw/OmniRoute/issues/8146)

## Validation

- [x] Change type: other — Responses/Chat translator compatibility
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` — repository command resolves a global ESLint 6 binary and fails on local ESLint 9 option `--suppressions-location`; equivalent local ESLint 9 invocation passes:
      `node node_modules/eslint/bin/eslint.js . --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json`
- [x] Reconciled with the current active release base (`release/v3.8.50`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below — pending CI

## Tests Added Or Updated

- `tests/unit/responses-chat-translation-gaps.test.ts`
  - plaintext `agent_message` becomes assistant history;
  - mixed plaintext/encrypted `agent_message` is skipped without raising an unsupported-feature error.

## Coverage Notes

- `open-sse/utils/responsesInputNormalization.ts` is covered by the updated Responses-to-Chat translation tests above.
- No migrations, generated files, feature flags, or catalog changes.

## Reviewer Notes

- This fixes the OmniRoute-side translator rejection; it does not decrypt Codex encrypted agent payloads. Full native-subagent execution still requires a backend with Codex encrypted-agent-message support.
- The first PR Quality Gates run reported `check:file-size` violations in `open-sse/executors/base.ts`, `open-sse/handlers/chatCore.ts`, and `tests/unit/chatcore-translation-paths.test.ts`; none are changed by this PR, and the same baseline violations are present outside this diff.
- Focused validation passed:
  - `node --import tsx/esm --test tests/unit/responses-chat-translation-gaps.test.ts tests/unit/responses-translation-fixes.test.ts tests/unit/responses-tool-search-call-skip.test.ts tests/unit/responses-input-sanitizer-name.test.ts`
  - `npm run typecheck:core`
  - local ESLint 9 invocation listed above