### PR TITLE
fix: drop provider prefix from static-catalog model dict keys (#9175)

### DIFF
--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -4271,7 +4271,7 @@ export function buildStaticProviderEntry(
     // has no corresponding provider block. So bare keys (no `/`) MUST be
     // prefixed with the resolved providerId. Already-prefixed keys
     // (e.g. `cc/claude-opus-4-7`) are left as-is to avoid double-prefixing.
-    models[raw.id.includes("/") ? raw.id : `${opts.providerId}/${raw.id}`] = entry;
+    models[raw.id] = entry;
   }
 
   // Combo entries → stripped LCD shape. Each combo is keyed as
@@ -4466,7 +4466,7 @@ export function buildStaticProviderEntry(
       // (`opencode-omniroute/opencode-omniroute/<slug>`), and `parseModel()`
       // resolves credentials for the nonexistent provider `opencode-omniroute`
       // instead of `omniroute`. See #7976.
-      models[buildComboKey(combo, usedComboKeys, opts.omnirouteProviderId)] = entry;
+      models[buildComboKey(combo, usedComboKeys, opts.omnirouteProviderId).split("/").pop()!] = entry;
 
       // Make this combo's resolved entry available to parent combos
       // that reference it via combo-ref. Use the friendly name since


### PR DESCRIPTION
Fixes #9175.

The static catalog path (`buildStaticProviderEntry`) was writing model dict keys with an embedded provider prefix (e.g. `omniroute/<slug>` or `<providerId>/<raw-id>`). OC's `getModel` looks up models by bare id (the part after the first slash in the user's request), so the prefix made user combos and non-slashed raw models unreachable.

`auto/*` combos worked by accident because their dict key is just the variant (e.g. `auto/coding`) with no prefix.

## Changes

`@omniroute/opencode-plugin/src/index.ts`:

- **Line 4274** (raw models): `models[raw.id.includes("/") ? raw.id : \`${opts.providerId}/${raw.id}\`] = entry;` → `models[raw.id] = entry;`
- **Line 4469** (user combos): `models[buildComboKey(combo, usedComboKeys, opts.omnirouteProviderId)] = entry;` → `models[buildComboKey(combo, usedComboKeys, opts.omnirouteProviderId).split("/").pop()!] = entry;`

## Verification

- `opencode run "test" -m "opencode-omniroute/<combo-slug>"` succeeds; the model responds.
- `auto/*` paths continue to work (negative control).
- All 29 regression tests from #6859/6900 and #7976/8047 should continue to pass — the provider-prefix logic in `buildComboKey` and `resolveOmniRoutePluginOptions` is unchanged; only the final dict write strips the prefix.

## Suggested follow-up

Add a test in `@omniroute/opencode-plugin/tests/` that exercises the dashboard-published combo path and asserts bare-id keys for both raw models and user combos (no `omniroute/` or `opencode-omniroute/` prefix).