### PR TITLE
fix(dashboard): make connection Default Model editable and optional (#9172)

### DIFF
--- a/changelog.d/fixes/9172-default-model-editable.md
+++ b/changelog.d/fixes/9172-default-model-editable.md
@@ -1,1 +1,0 @@
-- **fix(dashboard):** the "Default Model" of an OpenAI-compatible connection is now visible and editable after creation (was set once, then invisible), and it is no longer required when creating a connection — matching the API which always treated it as optional. ([#9172](https://github.com/diegosouzapw/OmniRoute/issues/9172))

--- a/changelog.d/fixes/9172-default-model-editable.md
+++ b/changelog.d/fixes/9172-default-model-editable.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** the "Default Model" of an OpenAI-compatible connection is now visible and editable after creation (was set once, then invisible), and it is no longer required when creating a connection — matching the API which always treated it as optional. ([#9172](https://github.com/diegosouzapw/OmniRoute/issues/9172))

--- a/changelog.d/fixes/9179-default-model-editable.md
+++ b/changelog.d/fixes/9179-default-model-editable.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** the "Default Model" of an OpenAI-compatible connection is now visible and editable after creation (was set once, then invisible), and it is no longer required when creating a connection — matching the API which always treated it as optional. ([#9179](https://github.com/diegosouzapw/OmniRoute/pull/9179))

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx
@@ -40,6 +40,7 @@ export interface ConnectionRowConnection {
   errorCode?: string | number;
   globalPriority?: number;
   providerSpecificData?: Record<string, unknown>;
+  defaultModel?: string | null;
   expiresAt?: string;
   tokenExpiresAt?: string;
   maxConcurrent?: number | null;

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
@@ -948,7 +948,6 @@ export default function AddApiKeyModal({
                 disabled={
                   !formData.name ||
                   (!isCompatible && !apiKeyOptional && !formData.apiKey) ||
-                  (isCompatible && !formData.defaultModel.trim()) ||
                   (isGooglePse && !formData.cx.trim()) ||
                   saving ||
                   (usesBaseUrl && !formData.baseUrl.trim() && !defaultBaseUrl)

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -68,6 +68,7 @@ export interface EditConnectionModalConnection {
   provider?: string;
   apiKey?: string;
   providerSpecificData?: Record<string, unknown>;
+  defaultModel?: string | null;
   healthCheckInterval?: number;
   projectId?: string | null;
 }
@@ -114,6 +115,7 @@ export default function EditConnectionModal({
     region: "",
     apiRegion: "international",
     validationModelId: "",
+    defaultModel: "",
     tag: "",
     routingTags: "",
     excludedModels: "",
@@ -308,6 +310,7 @@ export default function EditConnectionModal({
         region: existingRegion || (showsRegion ? defaultRegion : ""),
         apiRegion: (connection.providerSpecificData?.apiRegion as string) || "international",
         validationModelId: (connection.providerSpecificData?.validationModelId as string) || "",
+        defaultModel: (connection.defaultModel as string) || "",
         tag: (connection.providerSpecificData?.tag as string) || "",
         routingTags: formatRoutingTagsInput(connection.providerSpecificData?.tags),
         excludedModels: formatExcludedModelsInput(
@@ -542,6 +545,9 @@ export default function EditConnectionModal({
         }
       }
       if (!isOAuth) {
+        if (isCompatible) {
+          updates.defaultModel = formData.defaultModel.trim() || null;
+        }
         updates.providerSpecificData = {
           ...(connection.providerSpecificData || {}),
         };
@@ -1022,6 +1028,20 @@ export default function EditConnectionModal({
                   </div>
                 </div>
               </div>
+            )}
+            {isCompatible && (
+              <Input
+                label={t("compatibleDefaultModelLabel")}
+                value={formData.defaultModel}
+                onChange={(e) => setFormData({ ...formData, defaultModel: e.target.value })}
+                placeholder={
+                  isAnthropicCompatibleProvider(provider)
+                    ? "claude-3-5-sonnet-latest"
+                    : "gpt-4o-mini"
+                }
+                hint={t("compatibleDefaultModelHint")}
+                data-testid="compat-default-model-input"
+              />
             )}
             <Input
               label={t("validationModelIdLabel")}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/__tests__/connModals.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/__tests__/connModals.test.tsx
@@ -418,4 +418,109 @@ describe("conn-modals (Phase 1c extraction)", () => {
       )
     ).not.toThrow();
   });
+
+  it("AddApiKeyModal allows saving a compatible connection without a Default Model", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const c = renderModal(
+      <AddApiKeyModal
+        isOpen={true}
+        provider="openai-compatible-test"
+        providerName="Test Compatible"
+        isCompatible={true}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    const saveButton = Array.from(c.querySelectorAll("button")).find(
+      (button) => button.textContent === "providers.save"
+    );
+    expect(saveButton).toBeDefined();
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+    await act(async () => {
+      saveButton!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const payload = onSave.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toHaveProperty("defaultModel");
+    expect(payload.defaultModel).toBeUndefined();
+  });
+
+  it("EditConnectionModal renders and prefills the Default Model for a compatible connection", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const connection = {
+      id: "conn-compat",
+      name: "Test Compat",
+      provider: "openai-compatible-test",
+      authType: "apikey",
+      priority: 1,
+      defaultModel: "gpt-4o-mini",
+    };
+    const c = renderModal(
+      <EditConnectionModal
+        isOpen={true}
+        connection={connection}
+        providerId="openai-compatible-test"
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    const input = c.querySelector<HTMLInputElement>('[data-testid="compat-default-model-input"]');
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("gpt-4o-mini");
+  });
+
+  it("EditConnectionModal does not render Default Model for non-compatible connections", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const connection = {
+      id: "conn-openai",
+      name: "OpenAI",
+      provider: "openai",
+      authType: "apikey",
+      priority: 1,
+      defaultModel: "gpt-4o-mini",
+    };
+    const c = renderModal(
+      <EditConnectionModal
+        isOpen={true}
+        connection={connection}
+        providerId="openai"
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    expect(c.querySelector('[data-testid="compat-default-model-input"]')).toBeNull();
+  });
+
+  it("EditConnectionModal sends defaultModel null when the field is cleared", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const connection = {
+      id: "conn-compat",
+      name: "Test Compat",
+      provider: "openai-compatible-test",
+      authType: "apikey",
+      priority: 1,
+      defaultModel: "gpt-4o-mini",
+    };
+    const c = renderModal(
+      <EditConnectionModal
+        isOpen={true}
+        connection={connection}
+        providerId="openai-compatible-test"
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    const input = c.querySelector<HTMLInputElement>('[data-testid="compat-default-model-input"]');
+    setInputValue(input!, "");
+    const saveButton = Array.from(c.querySelectorAll("button")).find(
+      (button) => button.textContent === "providers.save"
+    );
+    await act(async () => {
+      saveButton!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ defaultModel: null }));
+  });
 });


### PR DESCRIPTION
## Summary

- The "Default Model" of an OpenAI-compatible connection is now visible and editable after creation (it was set once at creation, then invisible in the edit modal).
- The field is no longer required at creation time, matching the API which always treated it as optional.

## Related Issues

- Closes #9172

## Validation

- [x] Change type: UI
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `src/app/(dashboard)/dashboard/providers/[id]/components/modals/__tests__/connModals.test.tsx` — 4 tests added:
  - `AddApiKeyModal allows saving a compatible connection without a Default Model` (save enabled + payload `defaultModel: undefined`)
  - `EditConnectionModal renders and prefills the Default Model for a compatible connection`
  - `EditConnectionModal does not render Default Model for non-compatible connections`
  - `EditConnectionModal sends defaultModel null when the field is cleared`

## Coverage Notes

- The modal tests run against `vitest.config.ts` (`npm run test:vitest` collects them via `vitest.mcp.config.ts`). Verified: `npx vitest run --config vitest.config.ts "src/app/(dashboard)/dashboard/providers/[id]/components/modals/__tests__/connModals.test.tsx"` → 19/19 passing.
- No coverage regression in touched files: the changes are additive (a new optional field) plus one condition removal.

## Reviewer Notes

- The changelog fragment `changelog.d/fixes/9172-default-model-editable.md` uses the issue number as a placeholder; it will be renamed to the actual PR number before merge (repo convention).
- `EditConnectionModal`: clearing the field sends `defaultModel: null` (clears in DB); for non-compatible providers the key is omitted so the stored value is preserved.
