### PR TITLE
fix(settings): allow hidePaidModels updates

### DIFF
--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -118,6 +118,7 @@ export const updateSettingsSchema = z.object({
   baseUrl: z.string().max(500).optional(),
   setupComplete: z.boolean().optional(),
   blockedProviders: z.array(z.string().max(100)).optional(),
+  hidePaidModels: z.boolean().optional(),
   hideHealthCheckLogs: z.boolean().optional(),
   hideEndpointCloudflaredTunnel: z.boolean().optional(),
   hideEndpointTailscaleFunnel: z.boolean().optional(),

--- a/tests/unit/hide-paid-models-settings-schema.test.ts
+++ b/tests/unit/hide-paid-models-settings-schema.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { updateSettingsSchema } from "../../src/shared/validation/settingsSchemas.ts";
+
+test("hidePaidModels is accepted and preserved by the settings PATCH schema", () => {
+  for (const hidePaidModels of [true, false]) {
+    const validation = updateSettingsSchema.safeParse({ hidePaidModels });
+
+    assert.equal(validation.success, true);
+    if (!validation.success) continue;
+    assert.equal(validation.data.hidePaidModels, hidePaidModels);
+  }
+});
+
+test("hidePaidModels defaults to undefined when not provided", () => {
+  const validation = updateSettingsSchema.safeParse({});
+
+  assert.equal(validation.success, true);
+  if (!validation.success) return;
+  assert.equal(validation.data.hidePaidModels, undefined);
+});
+
+test("hidePaidModels rejects non-boolean values", () => {
+  const validation = updateSettingsSchema.safeParse({
+    hidePaidModels: "true",
+  });
+
+  assert.equal(validation.success, false);
+});


### PR DESCRIPTION
## Summary

- add `hidePaidModels` to `updateSettingsSchema`
- preserve both `true` and `false` values instead of silently stripping the field from `PATCH /api/settings`
- add focused regression coverage for accepted, omitted, and invalid values

## Related Issues

- Fixes #9076

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/dev/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: other — settings validation / API
- [x] Focused test: `node --import tsx/esm --test tests/unit/hide-paid-models-settings-schema.test.ts` — 3 passed, 0 failed
- [ ] `npm run lint` — delegated to PR CI; the focused-test checkout did not install the full dependency tree
- [x] Reconciled with the current active release base `release/v3.8.50` at `fc35dc248f46354e80fdcdaa551e6598abcf5124`; focused checks were rerun afterward
- [x] Production-code changes include a new automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below — pending PR CI

Additional check:

- [x] `git diff --check`

## Tests Added Or Updated

- `tests/unit/hide-paid-models-settings-schema.test.ts`
  - accepts and preserves `true` and `false`
  - leaves the field undefined when omitted
  - rejects non-boolean input

## Coverage Notes

The focused schema test directly exercises the added `hidePaidModels` field across valid, omitted, and invalid input paths.

## Reviewer Notes

This is a narrowly scoped schema correction. `hidePaidModels` already exists in settings defaults and is consumed by model-catalog and `auto/*` filtering.

The change does not alter its default, add a migration, or modify filtering behavior. It only makes the existing setting writable through the settings PATCH schema.
