### PR TITLE
fix(health): skip disabled provider connections

### DIFF
--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -200,7 +200,9 @@ export async function sweep(): Promise<void> {
   state.sweepInProgress = true;
 
   try {
-    // Get all provider connections (API-key + OAuth)
+    // Get active provider connections only (API-key + OAuth). Disabled
+    // connections are excluded from routing and must not consume health-check
+    // concurrency or delay the scheduler with avoidable upstream timeouts.
     let connections: Array<{
       id: string;
       provider: string;
@@ -208,7 +210,7 @@ export async function sweep(): Promise<void> {
     }>;
 
     try {
-      const raw = await getProviderConnections({});
+      const raw = await getProviderConnections({ isActive: true });
       connections = (Array.isArray(raw) ? raw : []).filter(
         (conn: any) => conn && conn.id && (conn.authType === "apikey" || conn.authType === "oauth")
       ) as Array<{

--- a/tests/unit/credential-health-active-connections-9180.test.ts
+++ b/tests/unit/credential-health-active-connections-9180.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const schedulerSource = fs.readFileSync(
+  new URL("../../src/lib/credentialHealth/scheduler.ts", import.meta.url),
+  "utf8"
+);
+
+function getSweepConnectionSelection(): string {
+  const start = schedulerSource.indexOf("export async function sweep(): Promise<void>");
+  assert.notEqual(start, -1, "credential-health sweep must exist");
+
+  const end = schedulerSource.indexOf(
+    "\n    if (connections.length === 0) return;",
+    start
+  );
+  assert.notEqual(end, -1, "credential-health connection-selection block must exist");
+
+  return schedulerSource.slice(start, end);
+}
+
+test("#9180 credential-health sweep queries active connections only", () => {
+  const selection = getSweepConnectionSelection();
+
+  assert.match(
+    selection,
+    /getProviderConnections\(\{\s*isActive:\s*true\s*\}\)/,
+    "the scheduler must request only active provider connections"
+  );
+
+  assert.doesNotMatch(
+    selection,
+    /getProviderConnections\(\{\s*\}\)/,
+    "the scheduler must not load disabled connections through an unfiltered query"
+  );
+});
+
+test("#9180 active-only selection retains API-key and OAuth scope", () => {
+  const selection = getSweepConnectionSelection();
+
+  assert.match(
+    selection,
+    /conn\.authType === "apikey"/,
+    "API-key connections must remain eligible"
+  );
+
+  assert.match(
+    selection,
+    /conn\.authType === "oauth"/,
+    "OAuth connections must remain eligible"
+  );
+});


### PR DESCRIPTION
## Summary

- restrict the credential-health scheduler to active provider connections
- preserve health checks for active API-key and OAuth connections
- prevent disabled connections from consuming health-check concurrency or delaying scheduler sweeps
- add focused regression coverage for the scheduler connection-selection contract

## Related Issues

- Fixes #9180

## Root Cause

The credential-health scheduler called `getProviderConnections({})` and then filtered only by authentication type.

As a result, disabled API-key and OAuth connections were still tested during background health-check sweeps, even though disabled connections are excluded from normal routing.

An unavailable disabled connection could consume a health-check slot and delay later batches until its network timeout completed.

## Fix

The scheduler now calls `getProviderConnections({ isActive: true })`.

The existing API-key and OAuth filtering remains unchanged.

## Validation

- [x] Change type: scheduler / credential health
- [x] Focused test: `node --import tsx/esm --test tests/unit/credential-health-active-connections-9180.test.ts`
- [x] 2 tests passed
- [x] 0 tests failed
- [x] Verified the scheduler uses `isActive: true`
- [x] Verified the unfiltered connection query is absent
- [x] Verified active API-key and OAuth connections remain eligible
- [x] `git diff --check`
- [x] Reconciled with `release/v3.8.50` at `fc35dc248f46354e80fdcdaa551e6598abcf5124`
- [ ] Full lint, unit suite, coverage, and production build pending PR CI

## Tests Added

`tests/unit/credential-health-active-connections-9180.test.ts`

The regression test verifies that:

- the scheduler requests only active provider connections
- the scheduler does not regress to an unfiltered database query
- active API-key and OAuth connections remain eligible

## Reviewer Notes

This change does not affect manual connection testing or provider validation.

It only changes the background scheduler's initial database selection so inactive connections are excluded before backoff calculations, batching, and upstream validation.
