### PR TITLE
fix(db): honor ENABLE_REQUEST_LOGS override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1338,6 +1338,10 @@ APP_LOG_TO_FILE=true
 # Default: 100000
 # CALL_LOGS_TABLE_MAX_ROWS=100000
 
+# Force detailed request logging on or off, overriding the dashboard setting.
+# Values: true | false  |  Default: unset (follow dashboard setting)
+# ENABLE_REQUEST_LOGS=false
+
 # Maximum age for orphaned active request log entries before the in-memory
 # pending-request reaper removes them. Accepts milliseconds.
 # Default: 3600000 (1 hour)

--- a/changelog.d/fixes/9187-enable-request-logs.md
+++ b/changelog.d/fixes/9187-enable-request-logs.md
@@ -1,0 +1,1 @@
+- **fix(db):** honor the `ENABLE_REQUEST_LOGS` environment override for detailed request persistence. (thanks @RobertsXML)

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -714,6 +714,7 @@ The logging system writes to both stdout and rotated log files. All configuratio
 | `CALL_LOG_RETENTION_DAYS`                 | `7`                        | Days to keep request/call log entries in the database.                            |
 | `CALL_LOG_MAX_ENTRIES`                    | `10000`                    | Max call log entries in the in-memory buffer.                                     |
 | `CALL_LOGS_TABLE_MAX_ROWS`                | `100000`                   | Max rows in the `call_logs` SQLite table before pruning.                          |
+| `ENABLE_REQUEST_LOGS`                     | _(unset)_                  | Force detailed request logging on or off, overriding the dashboard setting.       |
 | `MAX_PENDING_REQUEST_AGE_MS`              | `3600000` (1 hour)         | Max age for orphaned active request log entries before in-memory cleanup.         |
 | `CALL_LOG_PIPELINE_CAPTURE_STREAM_CHUNKS` | `true`                     | Store stream chunks in pipeline artifacts when `call_log_pipeline_enabled=true`.  |
 | `CALL_LOG_PIPELINE_MAX_SIZE_KB`           | `512`                      | Max pipeline call log artifact size in KB when `call_log_pipeline_enabled=true`.  |

--- a/src/lib/db/detailedLogs.ts
+++ b/src/lib/db/detailedLogs.ts
@@ -54,6 +54,11 @@ export function resetRequestDetailLogsTableExistsCache(): void {
 
 /** Returns true if detailed logging is enabled in settings */
 export async function isDetailedLoggingEnabled(): Promise<boolean> {
+  const envOverride = process.env.ENABLE_REQUEST_LOGS;
+  if (envOverride !== undefined) {
+    return envOverride.trim().toLowerCase() === "true";
+  }
+
   try {
     const settings = await getSettings();
     const val = settings.call_log_pipeline_enabled;
@@ -120,8 +125,7 @@ export function getRequestDetailLogById(id: string): RequestDetailLog | null {
   if (!requestDetailLogsTableExists()) return null;
   const db = getDbInstance();
   const row = db.prepare("SELECT * FROM request_detail_logs WHERE id = ?").get(id) as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   return row ? mapDetailedLogRow(row) : null;
 }
 

--- a/tests/unit/db-detailed-logs.test.ts
+++ b/tests/unit/db-detailed-logs.test.ts
@@ -9,6 +9,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const ORIGINAL_PII_ENABLED = process.env.PII_RESPONSE_SANITIZATION;
 const ORIGINAL_PII_MODE = process.env.PII_RESPONSE_SANITIZATION_MODE;
+const ORIGINAL_ENABLE_REQUEST_LOGS = process.env.ENABLE_REQUEST_LOGS;
 process.env.PII_RESPONSE_SANITIZATION = "true";
 process.env.PII_RESPONSE_SANITIZATION_MODE = "redact";
 process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "task-303-detailed-secret";
@@ -44,6 +45,7 @@ async function resetStorage() {
 }
 
 test.beforeEach(async () => {
+  delete process.env.ENABLE_REQUEST_LOGS;
   await resetStorage();
 });
 
@@ -63,12 +65,32 @@ test.after(async () => {
   } else {
     process.env.PII_RESPONSE_SANITIZATION_MODE = ORIGINAL_PII_MODE;
   }
+
+  if (ORIGINAL_ENABLE_REQUEST_LOGS === undefined) {
+    delete process.env.ENABLE_REQUEST_LOGS;
+  } else {
+    process.env.ENABLE_REQUEST_LOGS = ORIGINAL_ENABLE_REQUEST_LOGS;
+  }
 });
 
 test("isDetailedLoggingEnabled follows the stored setting", async () => {
   assert.equal(await detailedLogsDb.isDetailedLoggingEnabled(), false);
 
   await settingsDb.updateSettings({ call_log_pipeline_enabled: "true" });
+
+  assert.equal(await detailedLogsDb.isDetailedLoggingEnabled(), true);
+});
+
+test("ENABLE_REQUEST_LOGS=false disables detailed logging despite the stored setting", async () => {
+  await settingsDb.updateSettings({ call_log_pipeline_enabled: "true" });
+  process.env.ENABLE_REQUEST_LOGS = "false";
+
+  assert.equal(await detailedLogsDb.isDetailedLoggingEnabled(), false);
+});
+
+test("ENABLE_REQUEST_LOGS=true enables detailed logging despite the stored setting", async () => {
+  await settingsDb.updateSettings({ call_log_pipeline_enabled: "false" });
+  process.env.ENABLE_REQUEST_LOGS = "true";
 
   assert.equal(await detailedLogsDb.isDetailedLoggingEnabled(), true);
 });


### PR DESCRIPTION
## Summary

- Honor `ENABLE_REQUEST_LOGS` as an explicit override for detailed request persistence.
- Preserve the dashboard-backed setting when the environment variable is unset.
- Document the environment contract and cover both override directions.

## Attribution

Thanks to [@RobertsXML](https://github.com/RobertsXML) for the original implementation.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/db-detailed-logs.test.ts` (8/8)
- [x] `npm run typecheck:core`
- [x] `npm run typecheck:noimplicit:core`
- [x] `npm run test:vitest` (291/291)
- [x] `npm run check:docs-all`
- [x] `npm run check:cycles`
- [ ] `npm run check` — the release base already fails `tests/unit/mcp-extra-forward-6178.test.ts` identically, and the full runner remains alive on Redis retry handles after that failure.