### PR TITLE
fix(sse): evict a principal's own CCR blocks before another principal's (#9146)

### DIFF
--- a/open-sse/services/compression/engines/ccr/index.ts
+++ b/open-sse/services/compression/engines/ccr/index.ts
@@ -61,7 +61,12 @@ const RETRIEVAL_THRESHOLD = 3;
  * ramp (only the >= threshold cliff remains — the legacy binary behavior).
  */
 const RETRIEVAL_RAMP_FACTOR_DEFAULT = 2;
-/** Maximum number of entries in the principal-scoped, LRU-ordered store. */
+/**
+ * Maximum number of entries in the LRU-ordered store, across every principal. The store
+ * is keyed per principal, but this cap is not: the only per-principal cap is
+ * `MAX_CCR_PRINCIPAL_BYTES`. Eviction under this cap takes the storing principal's own
+ * blocks first (see `enforceGlobalBudget`).
+ */
 export const MAX_CCR_ENTRIES = 5_000;
 export const MAX_CCR_BLOCK_BYTES = 2 * 1024 * 1024;
 export const MAX_CCR_PRINCIPAL_BYTES = 16 * 1024 * 1024;
@@ -257,12 +262,30 @@ function enforcePrincipalBudget(owner: string, bytes: number): boolean {
   return principalBytes(owner) + bytes <= MAX_CCR_PRINCIPAL_BYTES;
 }
 
-function enforceGlobalBudget(bytes: number): boolean {
-  while (
-    (ccrStore.size >= MAX_CCR_ENTRIES || ccrTotalBytes + bytes > MAX_CCR_GLOBAL_BYTES) &&
-    evictOldestMatching(() => true)
-  ) {
-    // Enforce both entry and global byte caps with LRU eviction.
+/**
+ * Enforce the entry and global byte caps, giving up the storing principal's own
+ * least-recently-used blocks before anyone else's.
+ *
+ * The caps here are global while the only per-principal cap is `MAX_CCR_PRINCIPAL_BYTES`,
+ * so nothing bounds a principal's entry *count*. Blocks start at `DEFAULT_MIN_CHARS`, so
+ * 5,000 of them is around 3 MB, under a fifth of one principal's 16 MB byte allowance,
+ * and enough to exhaust the shared entry budget on its own. Evicting the globally oldest
+ * entry from there took a block from whoever had been quiet longest, because LRU keeps
+ * promoting the busy principal's own entries to the tail.
+ *
+ * Preferring `owner` keeps the global bound exactly as strict and makes a principal pay
+ * for its own pressure first. Falling back to any principal preserves the previous
+ * behaviour for the case that actually needs it: a newcomer storing into a store held
+ * entirely by others, which would otherwise never fit.
+ */
+function enforceGlobalBudget(owner: string, bytes: number): boolean {
+  const overBudget = () =>
+    ccrStore.size >= MAX_CCR_ENTRIES || ccrTotalBytes + bytes > MAX_CCR_GLOBAL_BYTES;
+
+  while (overBudget()) {
+    if (evictOldestMatching((entry) => entry.principalId === owner)) continue;
+    if (evictOldestMatching(() => true)) continue;
+    break;
   }
   return ccrTotalBytes + bytes <= MAX_CCR_GLOBAL_BYTES;
 }
@@ -300,7 +323,7 @@ export function tryStoreBlock(
     return rejectStore(hash, owner, "principal_budget_exceeded");
   }
 
-  if (!enforceGlobalBudget(bytes)) {
+  if (!enforceGlobalBudget(owner, bytes)) {
     return rejectStore(hash, owner, "global_budget_exceeded");
   }
 

--- a/tests/unit/compression/ccr-eviction-scope-9146.test.ts
+++ b/tests/unit/compression/ccr-eviction-scope-9146.test.ts
@@ -1,0 +1,79 @@
+/**
+ * #9146. The CCR entry cap is global while the only per-principal cap is bytes, so one
+ * principal can exhaust the shared 5,000-entry budget with small blocks while staying
+ * well inside its own 16 MB allowance. Eviction then took the globally oldest block,
+ * which belongs to whoever has been quiet longest.
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MAX_CCR_ENTRIES,
+  MAX_CCR_PRINCIPAL_BYTES,
+  inspectCcrBlock,
+  resetCcrStore,
+  tryStoreBlock,
+  getCcrStoreStats,
+} from "../../../open-sse/services/compression/engines/ccr/index.ts";
+
+/** Distinct content per index, at the engine's minimum block size. */
+function block(seed: number): string {
+  return `${seed}`.padEnd(600, "x");
+}
+
+describe("CCR eviction stays inside the storing principal (#9146)", () => {
+  beforeEach(() => {
+    resetCcrStore();
+  });
+
+  it("keeps a quiet principal's block when a busy principal fills the entry cap", () => {
+    const quiet = tryStoreBlock(block(0), "principal-quiet");
+    assert.equal(quiet.stored, true);
+
+    // One principal, many small blocks: enough to exhaust the shared entry budget.
+    for (let i = 1; i <= MAX_CCR_ENTRIES; i++) {
+      tryStoreBlock(block(i), "principal-busy");
+    }
+
+    assert.notEqual(
+      inspectCcrBlock(quiet.hash, "principal-quiet"),
+      null,
+      "a principal that stored one block must not lose it to another principal's traffic"
+    );
+  });
+
+  it("the busy principal stayed well inside its own byte budget while doing it", () => {
+    for (let i = 1; i <= MAX_CCR_ENTRIES; i++) {
+      tryStoreBlock(block(i), "principal-busy");
+    }
+
+    const stats = getCcrStoreStats("principal-busy");
+    assert.ok(
+      stats.bytes < MAX_CCR_PRINCIPAL_BYTES / 4,
+      `expected the busy principal to sit under a quarter of its byte cap, got ${stats.bytes}`
+    );
+  });
+
+  it("still bounds the store at the entry cap", () => {
+    for (let i = 0; i <= MAX_CCR_ENTRIES + 50; i++) {
+      tryStoreBlock(block(i), "principal-busy");
+    }
+
+    const stats = getCcrStoreStats("principal-busy");
+    assert.ok(
+      stats.entries <= MAX_CCR_ENTRIES,
+      `entry cap must still hold, got ${stats.entries}`
+    );
+  });
+
+  it("falls back to another principal's blocks when the storing one has none", () => {
+    // A store held entirely by someone else must still admit a newcomer, or a full cache
+    // would permanently lock out every principal that arrives late.
+    for (let i = 0; i < MAX_CCR_ENTRIES; i++) {
+      tryStoreBlock(block(i), "principal-incumbent");
+    }
+
+    const newcomer = tryStoreBlock(block(MAX_CCR_ENTRIES + 1), "principal-newcomer");
+    assert.equal(newcomer.stored, true);
+    assert.notEqual(inspectCcrBlock(newcomer.hash, "principal-newcomer"), null);
+  });
+});


### PR DESCRIPTION
## Summary

- `enforceGlobalBudget` evicted with `evictOldestMatching(() => true)`, so a store by any principal took the globally oldest block. Nothing caps a principal's entry count, only its bytes, so one principal can fill the shared 5,000-entry budget with about 3MB of minimum-size blocks and then evict whoever has been quiet longest.
- It now takes the storing principal's own LRU entries first, and falls back to any principal only when it has none left. The global bound is exactly as strict as before.
- Also fixes the `MAX_CCR_ENTRIES` comment, which claimed a scope the code never implemented.

## Related Issues

- Closes #9146

## Validation

- [x] Focused tests for the change: `node --import tsx/esm --test tests/unit/compression/ccr-eviction-scope-9146.test.ts`
- [x] `npm run lint`
- [x] Production-code changes include a new or updated automated test in this PR
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

SonarQube is unchecked because it has not reported yet at open time. It runs in CI on this PR.

Failing before the fix:

```
not ok 1 - keeps a quiet principal's block when a busy principal fills the entry cap
  error: "a principal that stored one block must not lose it to another principal's traffic"
# tests 4  # pass 3  # fail 1
```

Passing after: `# tests 4  # pass 4  # fail 0`. The other three pass on both sides by design, since they guard what the fix must not break rather than reproduce the bug. 103 CCR/ionizer tests green, `typecheck:core` clean.

## Tests Added Or Updated

- `tests/unit/compression/ccr-eviction-scope-9146.test.ts` (new, 4 tests)

## Coverage Notes

One production file, `open-sse/services/compression/engines/ccr/index.ts`, +31/−8. The new tests cover the eviction path directly: the quiet principal's block surviving, the entry cap still holding, the busy principal's byte usage, and the fallback for a newcomer.

## Reviewer Notes

- The fallback to any principal is deliberate and has its own test. Without it a full cache would permanently lock out every principal that arrives late.
- Cut from `release/v3.8.50` (`371c10ea`) with nothing from #9061 in it.
- Left alone: `getCcrStoreStats` returns a per-principal `entries` next to the global `maxEntries`, so a caller reads its own usage against a shared cap. Changing that changes the response shape and there are dashboard consumers, so it needs its own PR. Noted in #9146.
