### PR TITLE
fix(responses): normalize terminal usage for Codex

### DIFF
--- a/open-sse/utils/passthroughTailProcessor.ts
+++ b/open-sse/utils/passthroughTailProcessor.ts
@@ -3,6 +3,7 @@ import { parseSSEDataPayload } from "./streamHelpers.ts";
 import {
   backfillResponsesCompletedOutput,
   normalizeResponsesSseIds,
+  normalizeResponsesCompletedUsage,
   pushUniqueResponsesOutputItems,
   stringifyIdValue,
   stripResponsesLifecycleEcho,
@@ -174,13 +175,20 @@ function handleResponsesTailPayload(
   const outputPayload = textualToolCallBackfilled
     ? context.toResponsesCompletedWithToolCalls(parsed)
     : parsed;
+  const usageNormalized = normalizeResponsesCompletedUsage(outputPayload);
   const stripped = stripResponsesLifecycleEcho(outputPayload);
   const backfilled = backfillResponsesCompletedOutput(
     outputPayload,
     context.passthroughResponsesOutputItems
   );
 
-  if (stripped || backfilled || textualToolCallBackfilled || responsesIdsNormalized) {
+  if (
+    stripped ||
+    backfilled ||
+    textualToolCallBackfilled ||
+    responsesIdsNormalized ||
+    usageNormalized
+  ) {
     output = `data: ${JSON.stringify(outputPayload)}\n\n`;
   }
 

--- a/open-sse/utils/responsesStreamHelpers.ts
+++ b/open-sse/utils/responsesStreamHelpers.ts
@@ -138,6 +138,49 @@ export function backfillResponsesCompletedOutput(
   return true;
 }
 
+/**
+ * Keep the terminal Responses payload compatible with strict clients such as Codex.
+ * Upstreams may expose only input/output counts (or omit usage entirely), while the
+ * client deserializer requires all three canonical token fields.
+ */
+export function normalizeResponsesCompletedUsage(parsed: unknown): boolean {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const obj = parsed as JsonRecord;
+  if (obj.type !== "response.completed") return false;
+  if (!obj.response || typeof obj.response !== "object" || Array.isArray(obj.response)) {
+    return false;
+  }
+
+  const response = obj.response as JsonRecord;
+  const current =
+    response.usage && typeof response.usage === "object" && !Array.isArray(response.usage)
+      ? (response.usage as JsonRecord)
+      : {};
+  const finiteNumber = (value: unknown): number | null => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+  const inputTokens =
+    finiteNumber(current.input_tokens) ?? finiteNumber(current.prompt_tokens) ?? 0;
+  const outputTokens =
+    finiteNumber(current.output_tokens) ?? finiteNumber(current.completion_tokens) ?? 0;
+  const totalTokens = finiteNumber(current.total_tokens) ?? inputTokens + outputTokens;
+
+  const normalized: JsonRecord = {
+    ...current,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+  };
+  normalized.total_tokens = totalTokens;
+  const changed =
+    !response.usage ||
+    current.input_tokens !== inputTokens ||
+    current.output_tokens !== outputTokens ||
+    current.total_tokens !== totalTokens;
+  response.usage = normalized;
+  return changed;
+}
+
 const RESPONSES_LIFECYCLE_EVENT_TYPES = new Set([
   "response.created",
   "response.in_progress",

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -50,6 +50,7 @@ import {
 import {
   backfillResponsesCompletedOutput,
   normalizeResponsesSseIds,
+  normalizeResponsesCompletedUsage,
   pushUniqueResponsesOutputItems,
   stringifyIdValue,
   stripResponsesLifecycleEcho,
@@ -1576,6 +1577,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                       ...passthroughToolCalls.values(),
                     ]) as typeof parsed;
                   }
+                  const usageNormalized = normalizeResponsesCompletedUsage(parsed);
                   const stripped = stripResponsesLifecycleEcho(parsed);
                   const backfilled = backfillResponsesCompletedOutput(
                     parsed,
@@ -1585,7 +1587,8 @@ export function createSSEStream(options: StreamOptions = {}) {
                     stripped ||
                     backfilled ||
                     textualToolCallBackfilled ||
-                    responsesIdsNormalized
+                    responsesIdsNormalized ||
+                    usageNormalized
                   ) {
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
@@ -2281,7 +2284,8 @@ export function createSSEStream(options: StreamOptions = {}) {
                   const isResponses = flushedType.startsWith("response.");
                   const isClaude = isClaudeEventPayload(flushedParsed);
                   if (isResponses) {
-                    if (normalizeResponsesSseIds(flushedParsed)) {
+                    const usageNormalized = normalizeResponsesCompletedUsage(flushedParsed);
+                    if (normalizeResponsesSseIds(flushedParsed) || usageNormalized) {
                       output = `data: ${JSON.stringify(flushedParsed)}\n\n`;
                     }
                   } else if (!isClaude) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -49,8 +49,8 @@ import {
 } from "../services/sessionManager.ts";
 import {
   backfillResponsesCompletedOutput,
-  normalizeResponsesSseIds,
   normalizeResponsesCompletedUsage,
+  normalizeResponsesSseIds,
   pushUniqueResponsesOutputItems,
   stringifyIdValue,
   stripResponsesLifecycleEcho,
@@ -1577,7 +1577,6 @@ export function createSSEStream(options: StreamOptions = {}) {
                       ...passthroughToolCalls.values(),
                     ]) as typeof parsed;
                   }
-                  const usageNormalized = normalizeResponsesCompletedUsage(parsed);
                   const stripped = stripResponsesLifecycleEcho(parsed);
                   const backfilled = backfillResponsesCompletedOutput(
                     parsed,
@@ -1588,7 +1587,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                     backfilled ||
                     textualToolCallBackfilled ||
                     responsesIdsNormalized ||
-                    usageNormalized
+                    normalizeResponsesCompletedUsage(parsed)
                   ) {
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
@@ -2284,8 +2283,10 @@ export function createSSEStream(options: StreamOptions = {}) {
                   const isResponses = flushedType.startsWith("response.");
                   const isClaude = isClaudeEventPayload(flushedParsed);
                   if (isResponses) {
-                    const usageNormalized = normalizeResponsesCompletedUsage(flushedParsed);
-                    if (normalizeResponsesSseIds(flushedParsed) || usageNormalized) {
+                    if (
+                      normalizeResponsesSseIds(flushedParsed) ||
+                      normalizeResponsesCompletedUsage(flushedParsed)
+                    ) {
                       output = `data: ${JSON.stringify(flushedParsed)}\n\n`;
                     }
                   } else if (!isClaude) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -49,7 +49,7 @@ import {
 } from "../services/sessionManager.ts";
 import {
   backfillResponsesCompletedOutput,
-  normalizeResponsesCompletedUsage,
+  normalizeResponsesCompletedUsage as normalizeUsage,
   normalizeResponsesSseIds,
   pushUniqueResponsesOutputItems,
   stringifyIdValue,
@@ -1587,7 +1587,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                     backfilled ||
                     textualToolCallBackfilled ||
                     responsesIdsNormalized ||
-                    normalizeResponsesCompletedUsage(parsed)
+                    normalizeUsage(parsed)
                   ) {
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
@@ -2275,7 +2275,6 @@ export function createSSEStream(options: StreamOptions = {}) {
                 }
                 clientPayloadCollector.push(bufferedPayload);
 
-                // Normalize numeric IDs for final buffered data: chunk (same as transform path)
                 if (typeof bufferedPayload === "object" && !Array.isArray(bufferedPayload)) {
                   const flushedParsed = bufferedPayload as JsonRecord;
                   const flushedType =
@@ -2283,10 +2282,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   const isResponses = flushedType.startsWith("response.");
                   const isClaude = isClaudeEventPayload(flushedParsed);
                   if (isResponses) {
-                    if (
-                      normalizeResponsesSseIds(flushedParsed) ||
-                      normalizeResponsesCompletedUsage(flushedParsed)
-                    ) {
+                    if (normalizeResponsesSseIds(flushedParsed) || normalizeUsage(flushedParsed)) {
                       output = `data: ${JSON.stringify(flushedParsed)}\n\n`;
                     }
                   } else if (!isClaude) {

--- a/tests/unit/responses-commentary-passthrough-6199.test.ts
+++ b/tests/unit/responses-commentary-passthrough-6199.test.ts
@@ -173,10 +173,7 @@ test("commentary-phase output text is NOT forwarded when dropping is enabled (#6
     "commentary-phase text must be dropped from the passthrough stream"
   );
   // The commentary item announcement / completion must not leak either.
-  assert.ok(
-    !output.includes("msg_commentary"),
-    "commentary item events must be dropped entirely"
-  );
+  assert.ok(!output.includes("msg_commentary"), "commentary item events must be dropped entirely");
   // The real answer must always be forwarded.
   assert.ok(output.includes(FINAL_TEXT), "the final answer text must be forwarded");
   assert.ok(output.includes("msg_final"), "the final answer item must be forwarded");
@@ -193,4 +190,110 @@ test("commentary passes through when dropping is disabled (gate/regression) (#61
     "with the flag disabled, commentary text must pass through untouched"
   );
   assert.ok(output.includes(FINAL_TEXT), "the final answer text must still be forwarded");
+});
+
+test("response.completed always includes total_tokens for strict Codex clients", async () => {
+  const output = await readTransformed(
+    [
+      sse({
+        type: "response.completed",
+        response: {
+          id: "resp_codex_usage",
+          status: "completed",
+          output: [],
+          usage: {
+            input_tokens: 88,
+            output_tokens: 6,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        },
+      }),
+    ],
+    PASSTHROUGH_RESPONSES_OPTIONS
+  );
+
+  const completedLine = output
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("data:") && line.includes('"response.completed"'));
+  assert.ok(completedLine, "the terminal Responses event must be forwarded");
+
+  const completed = JSON.parse(completedLine.slice(5).trim());
+  assert.deepEqual(completed.response.usage, {
+    input_tokens: 88,
+    output_tokens: 6,
+    total_tokens: 94,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens_details: { reasoning_tokens: 0 },
+  });
+});
+
+test("response.completed synthesizes zero usage when upstream omits usage", async () => {
+  const completed = {
+    type: "response.completed",
+    response: { id: "resp_codex_no_usage", status: "completed", output: [] },
+  };
+  const output = await readTransformed(
+    [`data: ${JSON.stringify(completed)}`],
+    PASSTHROUGH_RESPONSES_OPTIONS
+  );
+  const completedLine = output
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("data:") && line.includes('"response.completed"'));
+  assert.ok(completedLine, "the terminal Responses event must be forwarded");
+  const forwarded = JSON.parse(completedLine.slice(5).trim());
+  assert.deepEqual(forwarded.response.usage, {
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+  });
+});
+
+test("Claude to Responses translation includes canonical Codex usage", async () => {
+  const output = await readTransformed(
+    [
+      sse({
+        type: "message_start",
+        message: {
+          id: "msg_agentrouter_claude",
+          type: "message",
+          role: "assistant",
+          model: "gpt-5.6-sol",
+          usage: { input_tokens: 88, output_tokens: 0 },
+        },
+      }),
+      sse({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      sse({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "probe-ok" },
+      }),
+      sse({ type: "content_block_stop", index: 0 }),
+      sse({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 6 },
+      }),
+      sse({ type: "message_stop" }),
+    ],
+    {
+      mode: "translate",
+      targetFormat: "claude",
+      sourceFormat: "openai-responses",
+      provider: "agentrouter",
+      body: { model: "agentrouter/gpt-5.6-sol" },
+    }
+  );
+  const completedLine = output
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("data:") && line.includes('"response.completed"'));
+  assert.ok(completedLine, "the translated terminal event must be emitted");
+  const completed = JSON.parse(completedLine.slice(5).trim());
+  assert.equal(completed.response.usage.input_tokens, 88);
+  assert.equal(completed.response.usage.output_tokens, 6);
+  assert.equal(completed.response.usage.total_tokens, 94);
 });


### PR DESCRIPTION
## Problem

Codex CLI can terminate a Responses stream with `missing field total_tokens` when an upstream `response.completed` event contains only partial usage fields or no usage object.

## Fix

- Normalize terminal Responses usage at the shared passthrough boundary.
- Preserve upstream usage details.
- Synthesize `input_tokens`, `output_tokens`, and `total_tokens` when missing.
- Cover normal, no-newline tail, and Claude-to-Responses paths with regression tests.

## Validation

- `node --import tsx/esm --test tests/unit/responses-commentary-passthrough-6199.test.ts tests/unit/responses-transformer.test.ts tests/unit/responses-transformer-dense-output.test.ts tests/unit/responses-usage-trailing-6906.test.ts tests/unit/agentrouter-chatcore-protocols.test.ts`
- `npm run typecheck:core`
- ESLint and Prettier on changed files
- `git diff --check`

Fixes Codex retries/looping caused by an invalid terminal Responses payload.
