### PR TITLE
fix(model): normalize client context-window suffixes

### DIFF
--- a/changelog.d/fixes/9193-context-window-suffix.md
+++ b/changelog.d/fixes/9193-context-window-suffix.md
@@ -1,0 +1,1 @@
+- **fix(model):** normalize client context-window suffixes for combo routing. (thanks @b1nhm1nh)

--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -13,13 +13,10 @@
 
 import { getModelContextLimit } from "../../../src/lib/modelCapabilities";
 import { getComboModelString, normalizeComboStep } from "../../../src/lib/combos/steps.ts";
-import {
-  getProviderByAlias,
-  getProviderById,
-} from "../../../src/shared/constants/providers.ts";
+import { getProviderByAlias, getProviderById } from "../../../src/shared/constants/providers.ts";
 import { estimateTokens } from "../contextManager.ts";
 import { getResolvedModelCapabilities } from "../modelCapabilities.ts";
-import { parseModel } from "../model.ts";
+import { parseModel, stripContextWindowSuffix } from "../model.ts";
 import { dedupeTargetsByExecutionKey, isRecord } from "./comboData.ts";
 import { getTargetProvider, MAX_COMBO_DEPTH } from "./comboPredicates.ts";
 import { evaluateContextLimit } from "./contextOverrideGate.ts";
@@ -323,7 +320,8 @@ export function getComboModelsFromData(
   modelStr: string,
   combosData: ComboCollectionLike
 ): string[] | null {
-  const combo = getComboFromData(modelStr, combosData);
+  const baseModelStr = stripContextWindowSuffix(modelStr);
+  const combo = getComboFromData(baseModelStr || modelStr, combosData);
   if (!combo) return null;
   return combo.models.map((m) => normalizeModelEntry(m).model);
 }

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -16,6 +16,16 @@ type ResolvedModelTarget = {
   model: string | null;
 };
 
+// Client context-window tags are routing hints, not part of provider model IDs.
+const CONTEXT_WINDOW_SUFFIX_RE = /\[(\d+)([kKmM])?\]\s*$/;
+
+export function stripContextWindowSuffix(
+  modelStr: string | null | undefined
+): string | null | undefined {
+  if (typeof modelStr !== "string" || !modelStr) return modelStr;
+  return modelStr.replace(CONTEXT_WINDOW_SUFFIX_RE, "").trimEnd();
+}
+
 // Derive alias→provider mapping from the single source of truth (PROVIDER_ID_TO_ALIAS)
 // This prevents the two maps from drifting out of sync
 const ALIAS_TO_PROVIDER_ID: Record<string, string> = {};
@@ -391,12 +401,12 @@ export function parseModel(modelStr: string | null | undefined): ParsedModel {
     };
   }
 
-  // Extract [1m] suffix before parsing provider/model
+  // Extract the legacy [1m] marker while stripping all client context tags.
   let extendedContext = false;
-  let cleanStr = modelStr;
-  if (cleanStr.endsWith("[1m]")) {
+  const cleanStripped = stripContextWindowSuffix(modelStr) as string;
+  let cleanStr = cleanStripped;
+  if (/\[1m\]\s*$/i.test(modelStr)) {
     extendedContext = true;
-    cleanStr = cleanStr.slice(0, -4);
   }
   cleanStr = cleanStr.trim();
 
@@ -600,7 +610,9 @@ async function resolveModelByProviderInference(modelId: string, extendedContext:
 
   // Canonicalize candidates (deduplicate alias providers pointing to the same provider ID)
   const canonicalCandidates = Array.from(
-    new Set(candidatesToUse.map((p) => resolveProviderAlias(p)).filter((p): p is string => p !== null))
+    new Set(
+      candidatesToUse.map((p) => resolveProviderAlias(p)).filter((p): p is string => p !== null)
+    )
   );
 
   // Filter candidates by active connections configured in the database

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -17,7 +17,8 @@ import {
   recordModelLockoutFailure,
   isDailyQuotaExhausted,
 } from "@omniroute/open-sse/services/accountFallback.ts";
-import { getModelInfo, getComboForModel } from "../services/model";
+import { getCombo, getComboForModel, getModelInfo } from "../services/model";
+import { stripContextWindowSuffix } from "@omniroute/open-sse/services/model.ts";
 import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
 import { getImageModelEntry } from "@omniroute/open-sse/config/imageRegistry.ts";
@@ -394,6 +395,17 @@ export async function handleChat(
   // resolveRoutingModel). The resolved model still passes through
   // enforceApiKeyPolicy below, so it cannot bypass per-key allowlists.
   let modelStr = resolveRoutingModel(request, body);
+  if (typeof modelStr === "string") {
+    // Preserve literal combo names such as "Claude [1m]". Context tags are
+    // stripped only when the exact request does not identify a combo.
+    const exactCombo = await getCombo(modelStr);
+    if (!exactCombo) {
+      modelStr = stripContextWindowSuffix(modelStr) || modelStr;
+      if (body?.model !== modelStr) {
+        body = { ...body, model: modelStr };
+      }
+    }
+  }
 
   // cc discovery alias (`claude/<provider>/<model>`, `claude/combo/<name>`):
   // resolve back to the real id before any combo lookup / resolveModelOrError()

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -13,10 +13,11 @@ import {
   parseModel,
   getModelInfoCore,
   splitSyncedEffortSuffix,
+  stripContextWindowSuffix,
 } from "@omniroute/open-sse/services/model.ts";
 import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry.ts";
 
-export { parseModel };
+export { parseModel, stripContextWindowSuffix };
 
 /**
  * Reserved provider prefixes — built-in provider ids + aliases. User-defined
@@ -140,7 +141,10 @@ function resolveSyncedModelIdAndEffort(
   }
   if (findSyncedModelMeta(syncedModels, modelId)) return { modelId, effort: null };
 
-  for (const candidate of syncedModels as Array<{ id?: unknown; supportedThinkingEfforts?: unknown }>) {
+  for (const candidate of syncedModels as Array<{
+    id?: unknown;
+    supportedThinkingEfforts?: unknown;
+  }>) {
     if (typeof candidate?.id !== "string" || !Array.isArray(candidate.supportedThinkingEfforts)) {
       continue;
     }
@@ -396,13 +400,21 @@ export async function getCombo(modelStr) {
  */
 export async function getComboForModel(modelStr) {
   // 1. Existing behavior — exact combo name match
-  const combo = await getCombo(modelStr);
+  let combo = await getCombo(modelStr);
   if (combo) return combo;
+
+  // Client context tags are ignored only after exact lookup, preserving literal
+  // combo names such as "Claude [1m]" while allowing "Claude[500k]" to use "Claude".
+  const baseModelStr = stripContextWindowSuffix(modelStr);
+  if (baseModelStr && baseModelStr !== modelStr) {
+    combo = await getCombo(baseModelStr);
+    if (combo) return combo;
+  }
 
   // 2. NEW — check model-combo mappings table (pattern match)
   try {
     const { resolveComboForModel } = await import("@/lib/localDb");
-    const mapped = await resolveComboForModel(modelStr);
+    const mapped = await resolveComboForModel(baseModelStr || modelStr);
     if (mapped && (mapped as any).models?.length > 0) {
       return mapped;
     }

--- a/tests/unit/chat-route-edge-cases.test.ts
+++ b/tests/unit/chat-route-edge-cases.test.ts
@@ -15,6 +15,7 @@ const {
   settingsDb,
   idempotencyLayerModule,
   semanticCacheModule,
+  combosDb,
 } = harness;
 
 const { getBackgroundDegradationConfig } =
@@ -64,6 +65,61 @@ test("handleChat resolves model alias before routing", async () => {
 
   assert.equal(response.status, 200, "Should succeed with 200 OK");
   assert.equal(seenModels[0], "gpt-4.1", "Model alias should be resolved to gpt-4.1");
+});
+
+test("handleChat strips client context-window tags before combo routing and dispatch", async () => {
+  await seedConnection("openai", { apiKey: "sk-openai-context-tag" });
+  await combosDb.createCombo({
+    name: "context-tag-combo",
+    models: ["openai/gpt-4.1"],
+  });
+
+  const seenModels = [];
+  globalThis.fetch = async (_url, init = {}) => {
+    const body = JSON.parse(String(init.body));
+    seenModels.push(body.model);
+    return buildOpenAIResponse("Context tag response");
+  };
+
+  const response = await handleChat(
+    buildRequest({
+      body: {
+        model: "context-tag-combo[500k]",
+        stream: false,
+        messages: [{ role: "user", content: "Use the context-tagged combo" }],
+      },
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(seenModels, ["gpt-4.1"]);
+});
+
+test("handleChat preserves a literal context-tagged combo name", async () => {
+  await seedConnection("openai", { apiKey: "sk-openai-literal-context-tag" });
+  await combosDb.createCombo({
+    name: "literal [1m]",
+    models: ["openai/gpt-4.1"],
+  });
+
+  const seenModels = [];
+  globalThis.fetch = async (_url, init = {}) => {
+    seenModels.push(JSON.parse(String(init.body)).model);
+    return buildOpenAIResponse("Literal combo response");
+  };
+
+  const response = await handleChat(
+    buildRequest({
+      body: {
+        model: "literal [1m]",
+        stream: false,
+        messages: [{ role: "user", content: "Use the literal combo" }],
+      },
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(seenModels, ["gpt-4.1"]);
 });
 
 test("Test 3: handleChat returns cached response directly for Semantic Cache hits", async () => {

--- a/tests/unit/combo-bracket-names.test.ts
+++ b/tests/unit/combo-bracket-names.test.ts
@@ -65,7 +65,7 @@ test("getComboForModel treats an exact bracketed name as a combo before model su
   assert.equal(parsedAsModel.model, "Claude");
 });
 
-test("getComboForModel does not strip bracket suffix when no exact bracketed combo exists", async () => {
+test("getComboForModel falls back to the base combo when no exact context-tagged combo exists", async () => {
   await combosDb.createCombo({
     name: "Claude",
     models: [{ provider: "claude", model: "claude-sonnet-4-6" }],
@@ -74,7 +74,7 @@ test("getComboForModel does not strip bracket suffix when no exact bracketed com
   const resolved = await sseModelService.getComboForModel("Claude [1m]");
   const parsedAsModel = sseModelService.parseModel("Claude [1m]");
 
-  assert.equal(resolved, null);
+  assert.equal(resolved?.name, "Claude");
   assert.equal(parsedAsModel.extendedContext, true);
   assert.equal(parsedAsModel.model, "Claude");
 });

--- a/tests/unit/combo-routing-engine.test.ts
+++ b/tests/unit/combo-routing-engine.test.ts
@@ -187,6 +187,14 @@ test("getComboFromData and getComboModelsFromData resolve combos from array and 
   assert.deepEqual(models, ["openai/gpt-4o-mini", "claude/sonnet"]);
 });
 
+test("getComboModelsFromData strips context-window tags before matching a combo", () => {
+  const combos = [{ name: "alpha", models: ["openai/gpt-4o-mini"] }];
+
+  assert.deepEqual(getComboModelsFromData("alpha[500k]", combos), ["openai/gpt-4o-mini"]);
+  assert.deepEqual(getComboModelsFromData("alpha[1M]", combos), ["openai/gpt-4o-mini"]);
+  assert.equal(getComboModelsFromData("alpha[beta]", combos), null);
+});
+
 test("validateComboDAG rejects circular references and resolveNestedComboModels expands nested combos", () => {
   const combos = [
     { name: "root", models: ["child-a", "openai/gpt-4o-mini"] },

--- a/tests/unit/model-parse.test.ts
+++ b/tests/unit/model-parse.test.ts
@@ -1,10 +1,24 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeCrossProxyModelId, parseModel } from "../../open-sse/services/model.ts";
+import {
+  normalizeCrossProxyModelId,
+  parseModel,
+  stripContextWindowSuffix,
+} from "../../open-sse/services/model.ts";
+
+test("context-window suffix helper strips client tags without changing the base model", () => {
+  assert.strictEqual(stripContextWindowSuffix("my-glm52[500k]"), "my-glm52");
+});
 
 // [1m] extended context suffix — PR #311 (DavyMassoneto)
 test("[1m] suffix: strips suffix and sets extendedContext=true", () => {
   const result = parseModel("claude-sonnet-4-6[1m]");
+  assert.strictEqual(result.model, "claude-sonnet-4-6");
+  assert.strictEqual(result.extendedContext, true);
+});
+
+test("[1M] suffix: preserves the extended-context flag case-insensitively", () => {
+  const result = parseModel("claude-sonnet-4-6[1M]");
   assert.strictEqual(result.model, "claude-sonnet-4-6");
   assert.strictEqual(result.extendedContext, true);
 });


### PR DESCRIPTION
## Summary\n\n- Normalize trailing client context-window suffixes such as , , , and  before model routing.\n- Preserve exact combo-name precedence, so literal combo names containing these suffixes continue to resolve unchanged.\n- Keep the legacy  extended-context behavior while applying normalization consistently to modern and legacy routing paths.\n\n## Attribution\n\nThanks to [@b1nhm1nh](https://github.com/b1nhm1nh) for the original implementation.\n\n## Scope reconciliation\n\nOllama Cloud quota tracking and proactive OAuth refresh already exist in OmniRoute, so this PR ports only the missing context-window suffix behavior and does not duplicate those systems.\n\n## Test plan\n\n- [x] [MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Cross-proxy alias applied: "gpt-oss:120b" → "gpt-oss-120b"
[MODEL] Cross-proxy alias applied: "qwen3-coder:480b" → "Qwen/Qwen3-Coder-480B-A35B-Instruct"
✔ context-window suffix helper strips client tags without changing the base model (5.337895ms)
✔ [1m] suffix: strips suffix and sets extendedContext=true (2.217325ms)
✔ [1M] suffix: preserves the extended-context flag case-insensitively (1.085515ms)
✔ [1m] suffix: normal model has extendedContext=false (0.903294ms)
✔ [1m] suffix: works with provider prefix (1.806604ms)
✔ parseModel trims provider prefix and model id (1.164573ms)
✔ parseModel treats exact slashful model ids as models, not provider prefixes (4.553937ms)
✔ normalizeCrossProxyModelId maps supported external dialects to canonical ids (4.322218ms)
ℹ tests 8
ℹ suites 0
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1308.791983 (8 passed)\n- [x] [DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-brackets-V9YMmy/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-brackets-V9YMmy, SQLITE_FILE=/tmp/omniroute-combo-brackets-V9YMmy/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-brackets-V9YMmy/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-brackets-V9YMmy, SQLITE_FILE=/tmp/omniroute-combo-brackets-V9YMmy/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
✔ combo schemas accept names with spaces and square brackets (22.064559ms)
✔ combo schemas still reject control characters and whitespace-only names (8.033327ms)
✔ getComboForModel treats an exact bracketed name as a combo before model suffix parsing (535.307462ms)
✔ getComboForModel falls back to the base combo when no exact context-tagged combo exists (596.257242ms)
ℹ tests 4
ℹ suites 0
ℹ pass 4
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 4749.173828 (4 passed)\n- [x] [DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ getComboFromData and getComboModelsFromData resolve combos from array and object containers (462.965167ms)
✔ getComboModelsFromData strips context-window tags before matching a combo (525.957376ms)
✔ validateComboDAG rejects circular references and resolveNestedComboModels expands nested combos (514.048414ms)
✔ resolveNestedComboModels expands explicit combo-ref steps (525.194204ms)
✔ validateComboDAG enforces maximum nesting depth (553.794018ms)
✔ handleComboChat priority strategy defaults to first model and records success metrics (668.49594ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat runs shadow targets without changing the primary response or metrics (573.000073ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat isolates nested shadow request bodies (705.505785ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat honors shadow sampleRate zero (620.926916ms)
✔ handleComboChat priority strategy honors composite tier order before fallback (538.53698ms)
✔ handleComboChat weighted strategy selects by weight and falls back in descending weight order (504.645752ms)
✔ handleComboChat preserves the weighted primary before prompt-cache affinity reordering (567.359743ms)
✔ handleComboChat weighted strategy falls back to uniform random when all weights are zero (560.46418ms)
✔ handleComboChat random strategy uses shuffled model order (409.198107ms)
✔ handleComboChat fill-first explicitly preserves priority order (324.211935ms)
✔ handleComboChat p2c selects the better of two random choices by metrics (317.403544ms)
✔ handleComboChat least-used strategy prefers the model with fewer recorded requests (346.961156ms)
✔ handleComboChat skips unavailable models and falls through to the next active target (363.872097ms)
✔ handleComboChat falls through empty successful responses and records failure metrics before succeeding (415.069414ms)
✔ handleComboChat records per-target metrics separately when the same model repeats with different accounts (386.405301ms)
✔ handleComboChat surfaces the last failing target's status AND error message together, not a cross-target mismatch (#8486) (458.097845ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat global comboTimeoutMs stops iterating remaining targets and returns 504 with aggregated diagnostics (404.82719ms)
✔ handleComboChat comboTimeoutMs=0 (default) never trips the global timeout, all targets still tried (464.002866ms)
✔ handleComboChat round-robin rotates sequentially across requests (412.235076ms)
✔ handleComboChat round-robin starts from composite tier default ordering (474.682126ms)
✔ combo helpers short-circuit safely for missing combos, cycles, and excessive depth (482.064607ms)
✔ handleComboChat accepts binary and Responses-style 200 bodies but falls through malformed success payloads (486.974924ms)
✔ handleComboChat accepts text-mode SSE payloads as valid non-streaming passthrough responses (392.886997ms)
✔ handleComboChat falls through invalid JSON and embedded 200 error bodies before succeeding (372.107259ms)
✔ handleComboChat returns the earliest retry-after when all priority targets are rate-limited (430.89395ms)
✔ handleComboChat returns 404 model_not_found when a combo has no executable targets (430.875532ms)
✔ handleComboChat round-robin returns 404 when no models are configured (442.896294ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat round-robin falls through semaphore timeouts and malformed success payloads (488.521706ms)
✔ handleComboChat round-robin surfaces retry-after metadata after exhausting all models (384.699059ms)
✔ handleComboChat falls through generic 400s when a later priority target succeeds (438.102322ms)
✔ handleComboChat preserves fallback request bodies when zero-latency optimizations are disabled (466.673875ms)
✔ handleComboChat applies fallback compression only after explicit zero-latency opt-in (1870.664238ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat suppresses hedging unless zero-latency optimizations are enabled (401.429011ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat starts hedged fallback only after explicit zero-latency opt-in (323.724819ms)
✔ handleComboChat round-robin falls through generic 400s when a later model succeeds (365.668542ms)
✔ handleComboChat round-robin falls through 400s and returns the LAST target's status+message together, not a cross-target mismatch (#8486) (395.702676ms)
✔ handleComboChat strict-random uses the shared deck without repeating within a cycle (329.695071ms)
✔ handleComboChat cost-optimized orders models by the cheapest configured input price (379.125343ms)
✔ handleComboChat weighted strategy resolves nested combos before falling back to the next weighted target (527.550215ms)
✔ handleComboChat context-optimized orders models by the largest synced context window (342.262603ms)
✔ handleComboChat context-optimized preserves order when all context limits are unknown (396.464044ms)
✔ handleComboChat skips fallback targets with too small context windows (319.709125ms)
✔ handleComboChat skips tool, vision, and structured-output incompatible fallbacks (390.794165ms)
✔ handleComboChat fails closed when context-aware filtering rejects all targets (#8488) (396.615086ms)
✔ handleComboChat compatFilterFailOpen restores dispatch when all targets fail tools (#8488) (355.282581ms)
✔ handleComboChat eval-driven routing prioritizes higher scoring evaluated targets (340.832624ms)
✔ cache-optimized preserves eval routing when no reusable cache key exists (456.128102ms)
✔ handleComboChat eval-driven routing ignores stale and undersized eval runs (353.068991ms)
✔ handleComboChat eval-driven routing can match bare model eval target ids (403.244034ms)
✔ handleComboChat normalizes legacy strategy names at runtime (549.881322ms)
✔ handleComboChat returns a 503 when every model is unavailable before execution (391.550032ms)
✔ handleComboChat treats provider circuit breaker responses as ordinary target failures (436.750217ms)
✔ handleComboChat auto strategy honors LKGP after filtering to tool-capable models (546.363269ms)
✔ handleComboChat auto strategy preserves selected same-provider connection identity (448.082915ms)
✔ handleComboChat standalone lkgp strategy prioritizes the last known good provider (416.693811ms)
✔ handleComboChat standalone lkgp strategy falls back to original order when no state exists (427.155926ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[MODEL] Treating "openai/gpt-oss-120b" as an exact model id
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
✔ handleComboChat standalone lkgp strategy updates LKGP after a successful call (397.694604ms)
✔ handleComboChat auto strategy falls back to the full pool when tool filtering empties candidates (477.380866ms)
✔ handleComboChat auto strategy falls back to rules when a custom router strategy throws (522.265427ms)
✔ handleComboChat auto strategy reads strategyName from combo.config.auto and can prefer latency (500.3976ms)
✔ handleComboChat auto strategy can route by SLA targets (460.799252ms)
✔ handleComboChat context cache protection pins the model and tags tool-call responses (419.08103ms)
✔ handleComboChat context cache protection does not inject omniModel tag in streamed output (452.522559ms)
✔ handleComboChat context cache protection does not inject tag for tool-call-only streams (370.517163ms)
✔ handleComboChat context cache protection flushes cleanly when a stream ends without content (589.958078ms)
✔ handleComboChat round-robin resolves nested combos and returns inactive when every target is skipped (407.851539ms)
✔ handleComboChat round-robin treats provider circuit breaker responses as ordinary target failures (348.036599ms)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Sync driver 'better-sqlite3' failed to open, will try next driver: Cannot open database because the directory does not exist
[DB] Sync driver 'node:sqlite' failed to open, will try next driver: unable to open database file
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /tmp/omniroute-combo-routing-Yhr2or/storage.sqlite (DATA_DIR=/tmp/omniroute-combo-routing-Yhr2or, SQLITE_FILE=/tmp/omniroute-combo-routing-Yhr2or/storage.sqlite)
[DB] SQLite WAL checkpoint completed (TRUNCATE).
✔ handleComboChat round-robin retries a transient failure on the same model before succeeding (533.732562ms)
✔ handleComboChat round-robin recovers from 400s when a later model succeeds (379.361259ms)
✔ handleComboChat single-target quality failure returns explicit quality error instead of ALL_ACCOUNTS_INACTIVE (429.614471ms)
✔ handleComboChat round-robin single-target quality failure returns explicit quality error instead of ALL_ACCOUNTS_INACTIVE (420.992102ms)
✔ handleComboChat falls back to next model when first model returns all-accounts-rate-limited 503 (577.357975ms)
✔ handleComboChat round-robin falls back when all-accounts-rate-limited 503 is returned (442.156744ms)
✔ handleComboChat aborts combo when 503 response does NOT contain the unavailable signal (446.264879ms)
✔ #3587 reasoning model gets max_tokens buffer applied (338.656514ms)
✔ #3587 reasoning buffer preserves max_tokens when the full buffer exceeds model cap (554.582989ms)
✔ #3587 reasoning buffer is disabled without explicit model capability data (473.032385ms)
✔ #3588 reasoning token buffer feature flag preserves client max_tokens (412.613022ms)
✔ #3587 non-reasoning model does not get max_tokens buffer (421.319932ms)
✔ #3587 round-robin buffer does NOT compound across reasoning models (465.959734ms)
✔ #3588 round-robin honors disabled reasoning token buffer feature flag (473.820721ms)
✔ #3587 round-robin keeps near-cap reasoning max_tokens unchanged (438.843848ms)
ℹ tests 87
ℹ suites 0
ℹ pass 87
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 48017.201843 (87 passed)\n- [x] Focused  probes (2 passed)\n- [x] 
> omniroute@3.8.50 typecheck:core
> tsc --pretty false -p tsconfig.typecheck-core.json\n- [x] 
> omniroute@3.8.50 test:vitest
> vitest run --config vitest.mcp.config.ts


 RUN  v4.1.10 /home/diegosouzapw/dev/proxys/OmniRoute/.claude/worktrees/port-upstream-features/.claude/worktrees/fix-port-pr-2975-context-window-suffix


 Test Files  34 passed (34)
      Tests  291 passed (291)
   Start at  02:26:19
   Duration  28.35s (transform 185.37s, setup 0ms, import 265.29s, tests 19.04s, environment 15.70s) (291 passed)\n- [x] 
> omniroute@3.8.50 check:docs-all
> npm run check:docs-sync && npm run check:docs-counts && npm run check:env-doc-sync && npm run check:deprecated-versions && npm run check:doc-links && npm run check:fabricated-docs


> omniroute@3.8.50 check:docs-sync
> node scripts/check/check-docs-sync.mjs

[docs-sync] package.json version: 3.8.50
[docs-sync] openapi.yaml info.version matches: 3.8.50
[docs-sync] changelog has top Unreleased section
[docs-sync] latest changelog release matches package version: 3.8.50
[docs-sync] llm.txt i18n mirrors match root content: 42 locales
[docs-sync] CHANGELOG.md i18n translations validated: 42 locales (version sections + size check)
[docs-sync] PASS - documentation version sync is consistent.

> omniroute@3.8.50 check:docs-counts
> node scripts/check/check-docs-counts-sync.mjs

Docs counts sync report
=======================

• Provider count: 290 (real) [STRICT]
  ✓ README.md mentions "290"
  ✓ AGENTS.md mentions "290"
  ✓ CLAUDE.md mentions "290"

• i18n locales count: 43 (real) [STRICT]
  ✓ docs/README.md mentions "43"
  ✓ docs/guides/I18N.md mentions "43"
  ✓ AGENTS.md mentions "43"

• Free-tier headline (live catalog): ~1.53B steady / 43 pools (real) [STRICT]
  ✓ README.md — 4 headline claim(s) match the live catalog
  ✓ docs/reference/FREE_TIERS.md — 4 headline claim(s) match the live catalog

• compression engines (live code): 12 (real) [STRICT]
  ✓ README.md — 4 compression engines claim(s) match the code

• MCP tools (live code): 104 (real) [STRICT]
  ✓ README.md — 3 MCP tools claim(s) match the code
  ✓ CLAUDE.md — 1 MCP tools claim(s) match the code
  ✓ AGENTS.md — 2 MCP tools claim(s) match the code
  ✓ docs/frameworks/MCP-SERVER.md — 2 MCP tools claim(s) match the code

• MCP scopes (live code): 31 (real) [STRICT]
  ✓ README.md — 1 MCP scopes claim(s) match the code
  ✓ CLAUDE.md — 1 MCP scopes claim(s) match the code
  ✓ AGENTS.md — 1 MCP scopes claim(s) match the code

• CLI tools (live code): 33 (real) [STRICT]
  ✓ README.md — 1 CLI tools claim(s) match the code

• Executors count: 89 (real) [soft]
  ⚠ docs/architecture/ARCHITECTURE.md does NOT mention "89" for executors
  ⚠ docs/architecture/CODEBASE_DOCUMENTATION.md does NOT mention "89" for executors

• Routing strategies count: 19 (real) [soft]
  ✓ docs/routing/AUTO-COMBO.md mentions "19"
  ✓ docs/architecture/RESILIENCE_GUIDE.md mentions "19"

• OAuth providers count: 21 (real) [soft]
  ⚠ docs/architecture/ARCHITECTURE.md does NOT mention "21" for OAuth providers

• A2A skills count: 6 (real) [soft]
  ✓ docs/frameworks/A2A-SERVER.md mentions "6"

• Cloud agents count: 4 (real) [soft]
  ✓ docs/frameworks/CLOUD_AGENT.md mentions "4"
  ✓ docs/frameworks/AGENT_PROTOCOLS_GUIDE.md mentions "4"


> omniroute@3.8.50 check:env-doc-sync
> node scripts/check/check-env-doc-sync.mjs

Env var contract sync report
============================
Code references:          464 unique vars
In .env.example:          595 unique vars
In docs/reference/ENVIRONMENT.md: 613 unique vars

  ✓ In code but missing from .env.example: none
  ✓ In .env.example but missing from ENVIRONMENT.md: none
  ✓ In ENVIRONMENT.md but missing from .env.example: none

✓ Env / docs contract is in sync.

> omniroute@3.8.50 check:deprecated-versions
> node scripts/check/check-deprecated-versions.mjs

Version drift report (current: v3.8.50)
========================================

  docs/architecture/CODEBASE_DOCUMENTATION.md
    L118 [stale-version] 3.1.1: #### 3.1.1 `src/app/(dashboard)/dashboard/` — UI pages
    L127 [stale-version] 3.1.2: #### 3.1.2 `src/app/api/` — Top-level API groups
    L227 [stale-version] 3.1.3: #### 3.1.3 `src/app/api/v1/` — OpenAI-compatible public API
    L331 [stale-version] 3.2.1: #### 3.2.1 `src/lib/db/`

  docs/architecture/cluster-decisions.md
    L42 [stale-version] v1.12.4: | `qdrant` | `qdrant/qdrant:v1.12.4` | `6333` HTTP | HNSW index; persistent volume `omniroute_qdrant
    L60 [stale-version] 1.5.21: | `bifrost` | `ghcr.io/maximhq/bifrost:1.5.21` | `8080` | Go-based Tier-1 router; persistent logs vo

  docs/compression/COMPRESSION_ENGINES.md
    L151 [stale-version] 2.0.3: | `@atjsh/llmlingua-2` | `2.0.3`       | Entry package; declares the others as peers    |
    L153 [stale-version] 1.0.20: | `js-tiktoken`        | `^1.0.20`     | Tokenizer                                      |
    L155 [stale-version] 3.5.2: `@huggingface/transformers` is pinned at `3.5.2` as an **optional** dependency (shared with
    L170 [stale-version] 2.0.3: npm install @atjsh/llmlingua-2@2.0.3 @tensorflow/tfjs@4.22.0 js-tiktoken

  docs/frameworks/AGENTBRIDGE.md
    L553 [stale-version] v1.0.19: Note: GitHub Copilot CLI ≥v1.0.19 supports `COPILOT_PROVIDER_BASE_URL` — use direct config instead o

  docs/frameworks/EMBEDDED-SERVICES.md
    L366 [stale-version] 1.2.3: "installedVersion": "1.2.3",
    L367 [stale-version] 1.2.4: "latestVersion": "1.2.4",

  docs/frameworks/MCP-SERVER.md
    L406 [stale-version] 1.8.1: "version": "1.8.1",

  docs/frameworks/PLUGIN_MARKETPLACE.md
    L302 [stale-version] 1.0.0: | `version`       | TEXT    | semver; default `1.0.0`                          |

  docs/frameworks/PLUGIN_SDK.md
    L73 [stale-version] 1.0.0: return addMetadata({ source: "my-plugin", version: "1.0.0" });
    L94 [stale-version] 1.0.0: "version": "1.0.0",

  docs/frameworks/SKILLS.md
    L233 [stale-version] 1.0.0: "version": "1.0.0",

  docs/guides/CLAUDE-CODE-CONFIGURATION.md
    L218 [stale-version] v2.1.219: v2.1.219+ and `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`. Only `claude*` /

  docs/guides/FEATURES.md
    L101 [stale-version] v2.0.9: ## 🎮 Model Playground _(v2.0.9+)_
    L107 [stale-version] v2.0.5: ## 🎨 Themes _(v2.0.5+)_
    L137 [stale-version] v2.0.11: ## 🤖 CLI Agents _(v2.0.11+)_
    L149 [stale-version] v3.5.5: ## 🔗 Context Relay _(v3.5.5+)_
    L177 [stale-version] v3.5.5: ## 🛡️ Proxy Hardening _(v3.5.5+)_
    ... and 14 more

  docs/guides/UNINSTALL.md
    L15 [stale-version] v3.6.2: ## Quick Uninstall (v3.6.2+)

  docs/ops/FLY_IO_DEPLOYMENT_GUIDE.md
    L327 [stale-version] v3.4.7: git show --no-patch --oneline v3.4.7
    L349 [stale-version] v3.4.7: If you want to align with a specific release tag (e.g. `v3.4.7`), first verify that the tag is alrea
    L352 [stale-version] v3.4.7: git merge-base --is-ancestor v3.4.7 upstream/main

  docs/ops/PROXY_GUIDE.md
    L648 [stale-version] 1.2.3: invalidateProxyHealth("http://user:pass@1.2.3.4:8080");
    L810 [stale-version] 1.2.3: const removed = await failOneproxyProxy("1.2.3.4", 8080);

  docs/ops/RELEASE_CHECKLIST.md
    L313 [stale-version] 1.2.3: - [ ] `curl -H "X-Forwarded-For: 1.2.3.4" http://localhost:20128/api/services/9router/start` returns
    L314 [stale-version] 1.2.3: - [ ] `curl -H "X-Forwarded-For: 1.2.3.4" http://localhost:20128/api/services/cliproxy/start` return
    L329 [stale-version] 3.5.2: `@huggingface/transformers@3.5.2`, `@tensorflow/tfjs`, `js-tiktoken`) survive an update.
    L334 [stale-version] 3.5.2: `dist/node_modules` so the worker resolves a SINGLE `@huggingface/transformers` 3.5.2

  docs/providers/AGENTROUTER.md
    L133 [stale-version] 2.1.219: | `User-Agent`                                | `claude-cli/2.1.219 (external, sdk-cli)`            

  docs/reference/API_REFERENCE.md
    L679 [stale-version] v3.6.1: ### OAuth Environment Repair _(v3.6.1+)_
    L1150 [stale-version] 1.0.45: "version": "1.0.45",

  docs/reference/CLI-TOOLS.md
    L495 [stale-version] 1.0.0: "version": "1.0.0",

  docs/reference/ENVIRONMENT.md
    L304 [stale-version] 1.0.0: | `OPENCODE_USER_AGENT`                   | `opencode-cli/1.0.0`                                    
    L532 [stale-version] 2.1.219: | `CLAUDE_USER_AGENT`              | `claude-cli/2.1.219 (external, cli)`          | When Anthropic 
    L537 [stale-version] 2.0.1: | `ANTIGRAVITY_USER_AGENT`         | `antigravity/2.0.1 darwin/arm64`              | When Antigravit
    L538 [stale-version] 1.0.0: | `KIRO_USER_AGENT`                | `AWS-SDK-JS/3.0.0 kiro-ide/1.0.0`             | When Kiro IDE u
    L578 [stale-version] 1.36.0: | `KIMI_CLI_VERSION`      | `1.36.0`             | `src/lib/oauth/providers/kimi-coding.ts` | Overri

  docs/reference/FREE_TIERS.md
    L113 [stale-version] 2.2.1: | `cloudflare-ai`  | caution   | Cloudflare Self-Serve ToS §2.2.1(j) prohibits using Services to "pr

  docs/security/STEALTH_GUIDE.md
    L91 [stale-version] 2.1.219: - `CLAUDE_CODE_COMPATIBLE_USER_AGENT = "claude-cli/2.1.219 (external, sdk-cli)"`
    L215 [stale-version] 2.1.219: | `CLAUDE_USER_AGENT`      | `claude-cli/2.1.219 (external, cli)`                            |
    L218 [stale-version] 2.0.1: | `ANTIGRAVITY_USER_AGENT` | `antigravity/2.0.1 linux/arm64 google-api-nodejs-client/10.3.0` |
    L219 [stale-version] 1.0.0: | `KIRO_USER_AGENT`        | `AWS-SDK-JS/3.0.0 kiro-ide/1.0.0`                               |


> omniroute@3.8.50 check:doc-links
> node scripts/check/check-doc-links.mjs

[doc-links] scanned 135 docs, checked 819 internal links
[doc-links] PASS — no broken internal links

> omniroute@3.8.50 check:fabricated-docs
> node scripts/check/check-fabricated-docs.mjs --strict

Doc accuracy gate — fabricated-claim detection
================================================
Scanned 135 markdown file(s)
Codebase: 1212 api routes · 823 env vars · 509 cli commands

✓ No fabricated API/env/CLI/hook/file references found.\n- [x] 
> omniroute@3.8.50 check:cycles
> node scripts/check/check-cycles.mjs

[cycles] OK - no cycles detected across 391 files in: src/shared/components, src/lib/db, src/lib/compliance, open-sse/translator, open-sse/mcp-server\n- [ ] 
> omniroute@3.8.50 typecheck:noimplicit:core
> tsc --pretty false -p tsconfig.typecheck-noimplicit-core.json

open-sse/utils/usageTracking.ts(129,34): error TS7006: Parameter 'usage' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(166,38): error TS7006: Parameter 'usage' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(166,45): error TS7006: Parameter 'targetFormat' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(205,23): error TS7006: Parameter 'fields' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(209,9): error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
open-sse/utils/usageTracking.ts(270,32): error TS7006: Parameter 'usage' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(274,25): error TS7006: Parameter 'key' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(274,30): error TS7006: Parameter 'value' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(309,31): error TS7006: Parameter 'usage' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(335,30): error TS7006: Parameter 'chunk' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(466,29): error TS7006: Parameter 'text' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(494,37): error TS7006: Parameter 'body' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(523,38): error TS7006: Parameter 'contentLength' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(535,29): error TS7006: Parameter 'inputTokens' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(535,42): error TS7006: Parameter 'outputTokens' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(535,56): error TS7006: Parameter 'targetFormat' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(560,31): error TS7006: Parameter 'body' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(560,37): error TS7006: Parameter 'contentLength' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(568,3): error TS7006: Parameter 'provider' implicitly has an 'any' type.
open-sse/utils/usageTracking.ts(569,3): error TS7006: Parameter 'usage' implicitly has an 'any' type.
src/shared/services/cliRuntime.ts(768,15): error TS7006: Parameter 'l' implicitly has an 'any' type.
src/shared/services/cliRuntime.ts(774,37): error TS7006: Parameter 'l' implicitly has an 'any' type. — blocked by pre-existing implicit-any errors outside this diff in  and \n\n## Notes\n\n- No public route shape, shared contract, dependency, migration, or i18n changes.\n- The documentation gate passes; it reports only existing soft/stale drift notices.