### PR TITLE
docs(readme): Affiliates Promo section (AgentRouter coupon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ curl http://localhost:20128/v1/chat/completions \
 
 <br/>
 
-<details>
+<details open>
 <summary><sub><b>🎟️ Affiliates Promo</b> — free signup coupons from providers we don't sponsor (click to expand)</sub></summary>
 
 <sub><i>This section is for referral/coupon codes only. Sponsored partnerships live in <b>🤝 Supported by our Open Source Friends</b> above. OmniRoute has no sponsorship or partnership with the providers listed here — these are public coupons anyone can use.</i></sub>

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ curl http://localhost:20128/v1/chat/completions \
       <br/><sub><b>AgentRouter</b></sub><br/><sub>agentrouter.org</sub>
     </td>
     <td>
-      <sub><b><a href="https://agentrouter.org/register?aff=70LM">AgentRouter</a></b> — affiliate signup · <b>$100 free credits</b> on signup (free server, expect higher latency — best for testing, not production). First-class support in OmniRoute since <b>v3.8.50</b>: Chat Completions, the Anthropic-compatible wire format and the OpenAI-compatible path. Available models include <code>claude-opus-4-8</code>, <code>claude-opus-5</code>, <code>gpt-5.6-sol</code> and more — see the live list at <a href="https://agentrouter.org/v1/models">agentrouter.org/v1/models</a>. <b><a href="https://agentrouter.org/register?aff=70LM">Grab your $100 →</a></b></sub>
+      <sub><b><a href="https://agentrouter.org/register?aff=70LM">AgentRouter</a></b> — affiliate signup · <b>$100 free credits</b> on signup (free server, expect higher latency — best for testing, not production). First-class support in OmniRoute since <b>v3.8.50</b>: Chat Completions, the Anthropic-compatible wire format and the OpenAI-compatible path. Available models include <code>claude-opus-4-8</code>, <code>claude-opus-5</code>, <code>gpt-5.6-sol</code> and more. <b><a href="https://agentrouter.org/register?aff=70LM">Grab your $100 →</a></b></sub>
       <br/><br/>
       <sub>⚠️ <i>Affiliate link — OmniRoute has no sponsorship or partnership with this provider.</i></sub>
     </td>

--- a/README.md
+++ b/README.md
@@ -261,6 +261,33 @@ curl http://localhost:20128/v1/chat/completions \
 
 <br/>
 
+<details>
+<summary><sub><b>🎟️ Affiliates Promo</b> — free signup coupons from providers we don't sponsor (click to expand)</sub></summary>
+
+<sub><i>This section is for referral/coupon codes only. Sponsored partnerships live in <b>🤝 Supported by our Open Source Friends</b> above. OmniRoute has no sponsorship or partnership with the providers listed here — these are public coupons anyone can use.</i></sub>
+
+<table>
+  <tr>
+    <td align="center" width="120">
+      <a href="https://agentrouter.org/register?aff=70LM">
+        <img src="public/providers/agentrouter.png" width="32" alt="AgentRouter"/>
+      </a>
+      <br/><sub><b>AgentRouter</b></sub><br/><sub>agentrouter.org</sub>
+    </td>
+    <td>
+      <sub><b><a href="https://agentrouter.org/register?aff=70LM">AgentRouter</a></b> — affiliate signup · <b>$100 free credits</b> on signup (free server, expect higher latency — best for testing, not production). First-class support in OmniRoute since <b>v3.8.50</b>: Chat Completions, the Anthropic-compatible wire format and the OpenAI-compatible path. Available models include <code>claude-opus-4-8</code>, <code>claude-opus-5</code>, <code>gpt-5.6-sol</code> and more — see the live list at <a href="https://agentrouter.org/v1/models">agentrouter.org/v1/models</a>. <b><a href="https://agentrouter.org/register?aff=70LM">Grab your $100 →</a></b></sub>
+      <br/><br/>
+      <sub>⚠️ <i>Affiliate link — OmniRoute has no sponsorship or partnership with this provider.</i></sub>
+    </td>
+  </tr>
+</table>
+
+<sub>Know another provider with a generous free signup coupon that benefits OmniRoute users? Open an issue and we'll add it here.</sub>
+
+</details>
+
+<br/>
+
 <div align="center">
 
 ## 🎯 Combos — The Flagship


### PR DESCRIPTION
## Mudança
- **Nova seção** '🎟️ Affiliates Promo' abaixo de '🤝 Supported by our Open Source Friends'.
- Bloco colapsável (`<details>`), ícone 32px (metade do Kimi/Cheaper), texto em `<sub>` (fonte ~90%).
- **Entrada 1**: AgentRouter — $100 de crédito no signup (valor do FREE_TIERS.md), servidor grátis (latência alta), first-class no OmniRoute desde v3.8.50.
- Modelos listados: claude-opus-4-8, claude-opus-5, gpt-5.6-sol, com link para a lista ao vivo em agentrouter.org/v1/models.
- Aviso visível: 'Affiliate link — OmniRoute has no sponsorship or partnership with this provider.'
- Footer convidando mais cupons via issue.

## Escopo
- Só `README.md`, +27 linhas, 0 exclusões.
- Categoria nova ('Affiliates Promo') explicitamente separada dos sponsors oficiais.

## Auditoria
- Valor $100 vem de `docs/reference/FREE_TIERS.md` (não inventado).
- v3.8.50 confirmado por commits `ec150a`/`564c20` (fixes agentrouter).
- Models não validados independentemente (a página carrega via JS; curl retorna 401 em /v1/models); o link 'see live list' dá ao usuário um caminho de checagem.