### PR TITLE
fix(open-sse): populate empty message content when reasoning text is present on tool_calls finish

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -2483,6 +2483,8 @@ export function createSSEStream(options: StreamOptions = {}) {
                   console.warn(
                     `[STREAM] Empty assistant response after tool_calls completion (${provider || "provider"}:${model || "unknown"}) — sessionId=${sessionId}`
                   );
+                } else if (passthroughHasToolCalls && !content.trim() && reasoning.trim()) {
+                  message.content = "";
                 }
 
                 const responseBody = {

--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -15,6 +15,7 @@ import { getCliRuntimeStatus } from "@/shared/services/cliRuntime";
 import { getAccessToken } from "@omniroute/open-sse/services/tokenRefresh.ts";
 import { rotationGroupFor } from "@omniroute/open-sse/services/refreshSerializer.ts";
 import { saveCallLog } from "@/lib/usageDb";
+import { shouldHideLogs } from "@/lib/tokenHealthCheck";
 import { logProxyEvent } from "@/lib/proxyLogger";
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { isGitLabDirectAccessDisabled } from "@/lib/oauth/gitlab";
@@ -743,18 +744,21 @@ export async function testSingleConnection(connectionId: string, validationModel
 
   // Log to Logger tab (call_logs table)
   try {
-    saveCallLog({
-      method: "POST",
-      path: "/api/providers/test",
-      status: result.valid ? 200 : result.statusCode || 401,
-      model: "connection-test",
-      provider,
-      connectionId,
-      duration: latencyMs,
-      error: result.valid ? null : result.error || null,
-      sourceFormat: "test",
-      targetFormat: "test",
-    }).catch(() => {});
+    const hideLogs = await shouldHideLogs();
+    if (!hideLogs) {
+      saveCallLog({
+        method: "POST",
+        path: "/api/providers/test",
+        status: result.valid ? 200 : result.statusCode || 401,
+        model: "connection-test",
+        provider,
+        connectionId,
+        duration: latencyMs,
+        error: result.valid ? null : result.error || null,
+        sourceFormat: "test",
+        targetFormat: "test",
+      }).catch(() => {});
+    }
   } catch {}
 
   // Log to Proxy tab (proxy_logs table)

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -210,7 +210,7 @@ let cacheTimestamp = 0;
 let pendingHideLogs: Promise<boolean> | null = null;
 const CACHE_TTL = 30_000; // Cache settings for 30 seconds
 
-async function shouldHideLogs(): Promise<boolean> {
+export async function shouldHideLogs(): Promise<boolean> {
   if (
     isEnvFlagEnabled("OMNIROUTE_HIDE_HEALTHCHECK_LOGS") ||
     isBuildProcess() ||

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -950,6 +950,7 @@ export { fisherYatesShuffle, getNextFromDeckSync as getNextFromDeck };
 const PROVIDER_SEARCH_PAIRS: string[][] = [
   ["nvidia", "nvidia_nim"],
   ["kimi-coding", "kimi-coding-apikey"],
+  ["antigravity", "agy"],
 ];
 /**
  * Resolve provider aliases (e.g., nvidia -> nvidia_nim) for DB lookup

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -1096,6 +1096,16 @@ test("getProviderCredentials resolves the nvidia special alias pool", async () =
   assert.equal(selected.connectionId, connection.id);
 });
 
+test("getProviderCredentials resolves the antigravity / agy alias pool", async () => {
+  const connection = await seedConnection("agy", {
+    name: "antigravity-alias-connection",
+  });
+
+  const selected = await auth.getProviderCredentials("antigravity");
+
+  assert.equal(selected.connectionId, connection.id);
+});
+
 test("getProviderCredentials exposes copilotToken when present in providerSpecificData", async () => {
   const connection = await seedConnection("codex", {
     authType: "oauth",


### PR DESCRIPTION
Fixes issue where reasoning models like Gemini 3.6 Flash return reasoning text with zero text content during tool_calls completion, causing downstream OpenAI-compatible clients (e.g. Hermes) to receive null content and throw empty response retries.