### PR TITLE
[codex] Honor disabled compression for reactive compaction

### DIFF
--- a/changelog.d/fixes/9200-compression-off-reactive-compaction.md
+++ b/changelog.d/fixes/9200-compression-off-reactive-compaction.md
@@ -1,0 +1,1 @@
+- **fix(compression):** honor the global compression-off setting for proactive and last-resort context compaction, preventing disabled compression from rewriting tool-call histories ([#9200](https://github.com/diegosouzapw/OmniRoute/pull/9200)) — thanks @joachimBrindeau

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1091,6 +1091,10 @@ export async function handleChatCore({
   // settings read below, then threaded to executor.execute() further down. Lives at
   // function scope because the read happens inside the per-message compression block.
   let contextEditingEnabled = false;
+  // The dashboard's global compression switch must also control the built-in
+  // reactive and last-resort compaction passes. Otherwise an operator selecting
+  // "off" still has large histories rewritten by trim_tools/purify_history.
+  let reactiveContextCompactionEnabled = false;
   // Hoisted to function scope (not just the compression-block scope below) so the
   // combo-resolved override survives to the final enforceOutputTokenBudget() call
   // further down — see #8378 (context limit resolved by the combo was silently
@@ -1107,6 +1111,7 @@ export async function handleChatCore({
       compressionSettings?.exclusions
     );
     let promptCompressionEnabled = compressionSettingsResult.enabled && !compressionExcluded;
+    reactiveContextCompactionEnabled = compressionSettingsResult.enabled && !compressionExcluded;
     contextEditingEnabled = compressionSettingsResult.contextEditingEnabled;
     if (compressionExcluded) {
       void writeCompressionSkip(
@@ -1756,7 +1761,7 @@ export async function handleChatCore({
     // engines (Caveman/RTK). Codex Desktop / Responses clients need this path even
     // when those engines are off, otherwise multi-turn image sessions hard-reject
     // at the budget check below (#8560).
-    if (estimatedTokens > threshold) {
+    if (reactiveContextCompactionEnabled && estimatedTokens > threshold) {
       log?.info?.(
         "CONTEXT",
         `Proactive compression triggered: ${estimatedTokens} tokens > ${threshold} threshold (${contextLimit} limit)`
@@ -1847,7 +1852,7 @@ export async function handleChatCore({
 
   // Last-resort compaction against the concrete input budget (not the 70% threshold).
   // Covers cases where the proactive pass was skipped or still left the request oversized (#8560).
-  if (finalEstimatedInputTokens >= finalContextLimit && body) {
+  if (reactiveContextCompactionEnabled && finalEstimatedInputTokens >= finalContextLimit && body) {
     const lastResortTarget = Math.max(1, finalContextLimit - toolsReserve - 1);
     const lastResortAdapter = adaptBodyForCompression(body as Record<string, unknown>);
     const lastResortResult = compressContext(lastResortAdapter.body, {

--- a/tests/unit/reactive-context-compaction-policy.test.mjs
+++ b/tests/unit/reactive-context-compaction-policy.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../../open-sse/handlers/chatCore.ts", import.meta.url),
+  "utf8"
+);
+
+test("global compression off gates reactive and last-resort context compaction", () => {
+  assert.match(
+    source,
+    /reactiveContextCompactionEnabled\s*=\s*compressionSettingsResult\.enabled\s*&&\s*!compressionExcluded;/
+  );
+  assert.match(source, /reactiveContextCompactionEnabled\s*&&\s*estimatedTokens\s*>\s*threshold/);
+  assert.match(
+    source,
+    /reactiveContextCompactionEnabled\s*&&\s*finalEstimatedInputTokens\s*>=\s*finalContextLimit/
+  );
+});


### PR DESCRIPTION
## What changed

- Gate proactive reactive context compaction on the global compression setting.
- Gate the last-resort compaction pass on the same setting.
- Add a regression test that locks both conditions to `compressionSettingsResult.enabled`.

## Root cause

The dashboard global compression switch disabled the optional prompt-compression engines, but `chatCore` still ran its built-in reactive and last-resort `compressContext` passes. As a result, histories could still be rewritten with compression disabled, including removal of old tool-use/tool-result blocks. That can leave clients such as Pi and Codex with invalid tool-call histories on later turns.

## Impact

When compression is globally off (or the model/provider is excluded), OmniRoute now forwards the history without proxy-side reactive compaction. When compression is enabled, existing proactive and last-resort behavior is unchanged.

## Validation

- `node --test tests/unit/reactive-context-compaction-policy.test.mjs`
- `npm run typecheck:core`
- `git diff --check`
- Prettier on both changed files


## Related

- Complements #8933 for Chat Completions/Pi paths.
- Related to #8932 and #8946.
