### PR TITLE
fix(responses): avoid Codex usage normalization short-circuit

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1582,12 +1582,13 @@ export function createSSEStream(options: StreamOptions = {}) {
                     parsed,
                     passthroughResponsesOutputItems
                   );
+                  const usageNormalized = normalizeUsage(parsed);
                   if (
                     stripped ||
                     backfilled ||
                     textualToolCallBackfilled ||
                     responsesIdsNormalized ||
-                    normalizeUsage(parsed)
+                    usageNormalized
                   ) {
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
@@ -2282,7 +2283,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   const isResponses = flushedType.startsWith("response.");
                   const isClaude = isClaudeEventPayload(flushedParsed);
                   if (isResponses) {
-                    if (normalizeResponsesSseIds(flushedParsed) || normalizeUsage(flushedParsed)) {
+                    const idsNormalized = normalizeResponsesSseIds(flushedParsed);
+                    const usageNormalized = normalizeUsage(flushedParsed);
+                    if (idsNormalized || usageNormalized) {
                       output = `data: ${JSON.stringify(flushedParsed)}\n\n`;
                     }
                   } else if (!isClaude) {

--- a/tests/unit/responses-commentary-passthrough-6199.test.ts
+++ b/tests/unit/responses-commentary-passthrough-6199.test.ts
@@ -228,6 +228,42 @@ test("response.completed always includes total_tokens for strict Codex clients",
   });
 });
 
+test("response.completed normalizes usage when lifecycle echoes are stripped", async () => {
+  const output = await readTransformed(
+    [
+      sse({
+        type: "response.completed",
+        response: {
+          id: "resp_agentrouter_live_shape",
+          status: "completed",
+          instructions: "echoed upstream instructions",
+          tools: [{ type: "function", name: "echoed_tool" }],
+          output: [],
+          usage: {
+            prompt_tokens: 91,
+            completion_tokens: 0,
+            input_tokens: 91,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      }),
+    ],
+    PASSTHROUGH_RESPONSES_OPTIONS
+  );
+
+  const completedLine = output
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("data:") && line.includes('"response.completed"'));
+  assert.ok(completedLine, "the terminal Responses event must be forwarded");
+
+  const completed = JSON.parse(completedLine.slice(5).trim());
+  assert.equal("instructions" in completed.response, false);
+  assert.equal("tools" in completed.response, false);
+  assert.equal(completed.response.usage.total_tokens, 91);
+});
+
 test("response.completed synthesizes zero usage when upstream omits usage", async () => {
   const completed = {
     type: "response.completed",
@@ -246,6 +282,34 @@ test("response.completed synthesizes zero usage when upstream omits usage", asyn
     input_tokens: 0,
     output_tokens: 0,
     total_tokens: 0,
+  });
+});
+
+test("buffered response.completed normalizes IDs and usage independently", async () => {
+  const completed = {
+    type: "response.completed",
+    response: {
+      id: 12345,
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 12, output_tokens: 3 },
+    },
+  };
+  const output = await readTransformed(
+    [`data: ${JSON.stringify(completed)}`],
+    PASSTHROUGH_RESPONSES_OPTIONS
+  );
+  const completedLine = output
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("data:") && line.includes('"response.completed"'));
+  assert.ok(completedLine, "the buffered terminal Responses event must be forwarded");
+
+  const forwarded = JSON.parse(completedLine.slice(5).trim());
+  assert.equal(forwarded.response.id, "12345");
+  assert.deepEqual(forwarded.response.usage, {
+    input_tokens: 12,
+    output_tokens: 3,
+    total_tokens: 15,
   });
 });
 


### PR DESCRIPTION
## Summary

- normalize Responses terminal usage before lifecycle-echo serialization short-circuits
- normalize buffered terminal Responses payload IDs and usage independently
- add regressions matching AgentRouter's live `prompt_tokens`/`completion_tokens` payload

## Validation

- `node --import tsx/esm --test tests/unit/responses-commentary-passthrough-6199.test.ts`
- `node --import tsx/esm --test tests/unit/stream-utils.test.ts tests/unit/agentrouter-chatcore-protocols.test.ts tests/unit/agentrouter-executor-protocols.test.ts`
- `npx eslint open-sse/utils/stream.ts tests/unit/responses-commentary-passthrough-6199.test.ts`
