### PR TITLE
feat(usage): surface Claude thinking token counts to clients

### DIFF
--- a/changelog.d/features/9214-claude-thinking-token-counts.md
+++ b/changelog.d/features/9214-claude-thinking-token-counts.md
@@ -1,0 +1,1 @@
+- **feat(usage):** surface Claude thinking token counts to clients. (thanks @luoyide)

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -547,11 +547,20 @@ export function translateNonStreamingResponse(
         const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
         const promptTokens = toNumber(usage.input_tokens, 0) + cachedTokens;
         const completionTokens = toNumber(usage.output_tokens, 0);
+        const reasoningTokens = firstPositiveNumber(
+          toRecord(usage.output_tokens_details).thinking_tokens,
+          toRecord(usage.completion_tokens_details).reasoning_tokens,
+          usage.reasoning_tokens
+        );
         const usageOut: JsonRecord = {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
           total_tokens: promptTokens + completionTokens,
         };
+        if (reasoningTokens > 0) {
+          usageOut.reasoning_tokens = reasoningTokens;
+          usageOut.completion_tokens_details = { reasoning_tokens: reasoningTokens };
+        }
         if (cachedTokens > 0 || cacheCreationTokens > 0) {
           const details: JsonRecord = {};
           if (cachedTokens > 0) details.cached_tokens = cachedTokens;

--- a/open-sse/handlers/usageExtractor.ts
+++ b/open-sse/handlers/usageExtractor.ts
@@ -63,6 +63,9 @@ export function extractUsageFromResponse(responseBody, provider) {
       completion_tokens: responseBody.usage.output_tokens || 0,
       cache_read_input_tokens: cacheRead,
       cache_creation_input_tokens: cacheCreation,
+      ...(typeof responseBody.usage.output_tokens_details?.thinking_tokens === "number"
+        ? { reasoning_tokens: responseBody.usage.output_tokens_details.thinking_tokens }
+        : {}),
     };
   }
 

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -5,9 +5,13 @@ type OpenAIUsage = {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  reasoning_tokens?: number;
   prompt_tokens_details?: {
     cached_tokens?: number;
     cache_creation_tokens?: number;
+  };
+  completion_tokens_details?: {
+    reasoning_tokens?: number;
   };
 };
 
@@ -153,6 +157,10 @@ export function claudeToOpenAIResponse(chunk, state) {
           typeof chunk.usage.input_tokens === "number" ? chunk.usage.input_tokens : 0;
         const outputTokens =
           typeof chunk.usage.output_tokens === "number" ? chunk.usage.output_tokens : 0;
+        const thinkingTokens =
+          typeof chunk.usage.output_tokens_details?.thinking_tokens === "number"
+            ? chunk.usage.output_tokens_details.thinking_tokens
+            : undefined;
         const cacheReadTokens =
           typeof chunk.usage.cache_read_input_tokens === "number"
             ? chunk.usage.cache_read_input_tokens
@@ -180,6 +188,14 @@ export function claudeToOpenAIResponse(chunk, state) {
           input_tokens: billableInputTokens,
           output_tokens: outputTokens,
         };
+
+        // Anthropic includes thinking in output_tokens. Surface the separately
+        // reported portion without adding it to completion_tokens a second time.
+        if (thinkingTokens !== undefined) {
+          state.usage.reasoning_tokens = thinkingTokens;
+          state.usage.completion_tokens_details = { reasoning_tokens: thinkingTokens };
+          state.usage.output_tokens_details = { thinking_tokens: thinkingTokens };
+        }
 
         // Store cache tokens if present (needed for prompt_tokens_details in final chunk)
         const effectiveCacheReadTokens = cacheReadTokens || previousCacheReadTokens;
@@ -252,6 +268,14 @@ export function claudeToOpenAIResponse(chunk, state) {
             total_tokens: totalTokens,
           };
 
+          const reasoningTokens = state.usage.reasoning_tokens;
+          if (typeof reasoningTokens === "number") {
+            finalChunk.usage.reasoning_tokens = reasoningTokens;
+            finalChunk.usage.completion_tokens_details = {
+              reasoning_tokens: reasoningTokens,
+            };
+          }
+
           // Add prompt_tokens_details if cached tokens exist
           if (cachedTokens > 0 || cacheCreationTokens > 0) {
             finalChunk.usage.prompt_tokens_details = {};
@@ -281,6 +305,14 @@ export function claudeToOpenAIResponse(chunk, state) {
                   prompt_tokens: state.usage.input_tokens || 0,
                   completion_tokens: state.usage.output_tokens || 0,
                   total_tokens: (state.usage.input_tokens || 0) + (state.usage.output_tokens || 0),
+                  ...(typeof state.usage.reasoning_tokens === "number"
+                    ? {
+                        reasoning_tokens: state.usage.reasoning_tokens,
+                        completion_tokens_details: {
+                          reasoning_tokens: state.usage.reasoning_tokens,
+                        },
+                      }
+                    : {}),
                 },
               }
             : {};

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -217,6 +217,7 @@ export function filterUsageForFormat(usage, targetFormat) {
     [FORMATS.CLAUDE]: [
       "input_tokens",
       "output_tokens",
+      "output_tokens_details",
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "estimated",
@@ -371,6 +372,7 @@ export function extractUsage(chunk) {
       output_tokens: chunk.usage.output_tokens || 0,
       cache_read_input_tokens: chunk.usage.cache_read_input_tokens,
       cache_creation_input_tokens: chunk.usage.cache_creation_input_tokens,
+      reasoning_tokens: chunk.usage.output_tokens_details?.thinking_tokens,
     });
   }
 

--- a/tests/unit/translator-resp-claude-to-openai.test.ts
+++ b/tests/unit/translator-resp-claude-to-openai.test.ts
@@ -6,6 +6,7 @@ const { claudeToOpenAIResponse } =
 const { translateNonStreamingResponse } =
   await import("../../open-sse/handlers/responseTranslator.ts");
 const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+const { filterUsageForFormat } = await import("../../open-sse/utils/usageTracking.ts");
 
 function createState() {
   return {
@@ -13,6 +14,16 @@ function createState() {
     toolNameMap: new Map([["proxy_read_file", "read_file"]]),
   };
 }
+
+type OpenAIUsageResult = {
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    reasoning_tokens?: number;
+    completion_tokens_details?: { reasoning_tokens?: number };
+  };
+};
 
 test("Claude non-stream: text, thinking and tool_use become OpenAI assistant message", () => {
   const result = translateNonStreamingResponse(
@@ -74,6 +85,51 @@ test("Claude non-stream: end_turn becomes stop and empty text is preserved", () 
   assert.equal(((result as any).choices[0] as any).message.content, "");
   assert.equal((result as any).choices[0].finish_reason, "stop");
   assert.equal((result as any).model, "claude-3-5-haiku");
+});
+
+test("Claude non-stream: usage exposes thinking token details without inflating completion", () => {
+  const result = translateNonStreamingResponse(
+    {
+      id: "msg_thinking",
+      model: "claude-sonnet-4-6",
+      content: [{ type: "text", text: "Final answer" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 22,
+        output_tokens: 267,
+        output_tokens_details: { thinking_tokens: 85 },
+      },
+    },
+    FORMATS.CLAUDE,
+    FORMATS.OPENAI
+  ) as OpenAIUsageResult;
+
+  assert.equal(result.usage.completion_tokens, 267);
+  assert.equal(result.usage.reasoning_tokens, 85);
+  assert.equal(result.usage.completion_tokens_details.reasoning_tokens, 85);
+});
+
+test("usage filtering preserves Claude thinking details and OpenAI aliases", () => {
+  const usage = {
+    input_tokens: 22,
+    output_tokens: 267,
+    output_tokens_details: { thinking_tokens: 85 },
+    reasoning_tokens: 85,
+    completion_tokens_details: { reasoning_tokens: 85 },
+  };
+
+  assert.deepEqual(filterUsageForFormat(usage, FORMATS.CLAUDE), {
+    input_tokens: 22,
+    output_tokens: 267,
+    output_tokens_details: { thinking_tokens: 85 },
+  });
+  assert.deepEqual(filterUsageForFormat(usage, FORMATS.OPENAI), {
+    prompt_tokens: 22,
+    completion_tokens: 267,
+    total_tokens: 289,
+    reasoning_tokens: 85,
+    completion_tokens_details: { reasoning_tokens: 85 },
+  });
 });
 
 test("Claude stream: message_start emits initial assistant role chunk", () => {
@@ -209,6 +265,31 @@ test("Claude stream: message_delta maps stop reason and usage including cache to
   assert.equal(result[0].usage.prompt_tokens_details.cached_tokens, 2);
   // cache_creation is exposed for auditing but does NOT inflate prompt_tokens
   assert.equal(result[0].usage.prompt_tokens_details.cache_creation_tokens, 1);
+});
+
+test("Claude stream: message_delta exposes thinking token details", () => {
+  const state = createState();
+  claudeToOpenAIResponse(
+    { type: "message_start", message: { id: "msg-thinking", model: "claude-sonnet-4-6" } },
+    state
+  );
+
+  const result = claudeToOpenAIResponse(
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: {
+        input_tokens: 22,
+        output_tokens: 267,
+        output_tokens_details: { thinking_tokens: 85 },
+      },
+    },
+    state
+  );
+
+  assert.equal(result[0].usage.completion_tokens, 267);
+  assert.equal(result[0].usage.reasoning_tokens, 85);
+  assert.equal(result[0].usage.completion_tokens_details.reasoning_tokens, 85);
 });
 
 test("Claude stream: #2215 — short prompt with large cache_creation does not inflate prompt_tokens", () => {

--- a/tests/unit/usage-extractor.test.ts
+++ b/tests/unit/usage-extractor.test.ts
@@ -180,6 +180,27 @@ test("extractUsageFromResponse totals Claude prompt tokens with cache read and c
   });
 });
 
+test("extractUsageFromResponse surfaces Claude thinking tokens without inflating completion", () => {
+  const usage = extractUsageFromResponse(
+    {
+      usage: {
+        input_tokens: 22,
+        output_tokens: 267,
+        output_tokens_details: { thinking_tokens: 85 },
+      },
+    },
+    "claude"
+  );
+
+  assert.deepEqual(usage, {
+    prompt_tokens: 22,
+    completion_tokens: 267,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_tokens: 85,
+  });
+});
+
 test("extractUsageFromResponse reads Gemini usageMetadata and thinking tokens", () => {
   const usage = extractUsageFromResponse(
     {
@@ -240,6 +261,20 @@ test("extractUsage reads response.completed with prompt_tokens_details.cached_to
   assert.equal(usage.completion_tokens, 50);
   assert.equal(usage.cached_tokens, 30);
   assert.equal(usage.reasoning_tokens, 10);
+});
+
+test("extractUsage surfaces Claude message_delta thinking tokens", () => {
+  const usage = extractUsage({
+    type: "message_delta",
+    usage: {
+      input_tokens: 22,
+      output_tokens: 267,
+      output_tokens_details: { thinking_tokens: 85 },
+    },
+  });
+
+  assert.equal(usage.reasoning_tokens, 85);
+  assert.equal(usage.completion_tokens, 267);
 });
 
 test("extractUsage reads response.done with input_tokens_details and output_tokens_details", () => {


### PR DESCRIPTION
## Summary

- surfaces Anthropic `output_tokens_details.thinking_tokens` as OpenAI-compatible reasoning usage
- preserves the count across streaming, non-streaming, request-detail extraction, and format filtering
- keeps `completion_tokens` unchanged because Anthropic already includes thinking tokens in `output_tokens`

## Dependency

This usage-surface change should land after #9212, which owns the pricing-side reasoning delta and prevents the surfaced subset from being billed twice.

## Attribution

Thanks to [@luoyide](https://github.com/luoyide) for the original implementation.

## Changes

- expose `reasoning_tokens` and `completion_tokens_details.reasoning_tokens` to OpenAI clients
- preserve Claude `output_tokens_details.thinking_tokens` through the Claude usage allow-list
- record thinking tokens in streaming and non-streaming usage extractors
- add behavioral coverage for translated, filtered, and extracted usage

## Test plan

- [x] RED probe reproduced missing thinking-token usage
- [x] focused node:test suite: 53/53
- [x] `npm run typecheck:core`
- [x] targeted configured ESLint on the clean production/test subset
- [x] `npm run check:any-budget:t11`
- [x] `npm run check:docs-all`
- [x] `npm run check:cycles`
- [x] test-runner API and discovery checks
- [ ] `npm run typecheck:noimplicit:core` — pre-existing implicit-any debt in `usageTracking.ts` and `cliRuntime.ts`
- [ ] `npm run test:vitest` — 28 files / 256 tests passed; 6 suites could not load because the shared install resolves `js-tiktoken` to a missing `node_modules/node_modules/base64-js`
- [ ] `npm run check:file-size` — pre-existing frozen-base violations outside this diff
