### PR TITLE
feat(models): functional gateway mirrors + fix synced-substitution

### DIFF
--- a/open-sse/utils/functionalGatewayMirrors.ts
+++ b/open-sse/utils/functionalGatewayMirrors.ts
@@ -1,0 +1,103 @@
+/**
+ * Functional gateway mirrors (`<gateway-alias>/<original-id>` mirror entries).
+ *
+ * /v1/models announces each model under its canonical owner provider
+ * (`deepseek/deepseek-v4-flash`). But the owner may have NO active credential
+ * while a passthrough gateway provider (e.g. agentrouter / openrouter) DOES and
+ * routes the same model. Discovery clients (omp, jcode, etc.) then see a model
+ * that fails on request, and never the route that works.
+ *
+ * This module synthesizes a mirror entry under the functional gateway alias:
+ *
+ *     <gateway-alias>/<original-id>     e.g. agentrouter/deepseek/deepseek-v4-flash
+ *
+ * The request path already resolves any known provider prefix
+ * (open-sse/services/model.ts::resolveProviderAlias), so the mirror is
+ * immediately routable with no request-side change. Pure synthesis over the
+ * already key-filtered list — no I/O.
+ */
+
+export const FUNCTIONAL_GATEWAY_MIRROR_SUFFIX = " (via ";
+
+export interface FunctionalGatewayMirrorsDeps {
+  /** Ordered list of passthrough gateway provider ids to consider as mirrors. */
+  gatewayProviderIds: string[];
+  /** True when `provider` is a passthrough gateway that can route arbitrary models. */
+  isGateway(provider: string): boolean;
+  /** Map a gateway provider id to its catalog alias (e.g. "command-code" -> "cmd"). */
+  gatewayAlias(provider: string): string;
+  /** True when `gatewayProvider` has an eligible connection that covers `modelId`. */
+  gatewayCovers(gatewayProvider: string, modelId: string): boolean;
+  /** True when `gatewayProvider` has an active credential/connection. */
+  gatewayHasConnection(gatewayProvider: string): boolean;
+  /** True when the canonical owner `provider` has an eligible connection for the model. */
+  canonicalOwnerHasConnection(provider: string): boolean;
+}
+
+interface GatewayMirrorCatalogEntry {
+  id?: unknown;
+  owned_by?: unknown;
+  root?: unknown;
+  name?: unknown;
+  display_name?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Append `<gatewayAlias>/<originalId>` mirror entries for every eligible model.
+ * Returns the original array reference unchanged when nothing is eligible.
+ */
+export function appendFunctionalGatewayMirrors<T extends GatewayMirrorCatalogEntry>(
+  models: T[],
+  deps: FunctionalGatewayMirrorsDeps
+): T[] {
+  if (!Array.isArray(models)) return models;
+
+  const aliases: T[] = [];
+  for (const model of models) {
+    const id = model.id;
+    if (typeof id !== "string" || id.length === 0) continue;
+
+    const slashIndex = id.indexOf("/");
+    if (slashIndex <= 0) continue; // no provider prefix to re-home
+    const owner = id.slice(0, slashIndex);
+    const modelId = id.slice(slashIndex + 1);
+    if (!modelId || modelId === id) continue;
+
+    // Skip if the canonical owner already has a working connection for this model.
+    if (deps.canonicalOwnerHasConnection(owner)) continue;
+
+    // Find a passthrough gateway that actually routes this model AND has a credential.
+    let chosenAlias: string | null = null;
+    let chosenProvider: string | null = null;
+    for (const gatewayProvider of deps.gatewayProviderIds) {
+      const alias = deps.gatewayAlias(gatewayProvider);
+      if (!alias || alias === owner) continue;
+      if (!deps.isGateway(gatewayProvider)) continue;
+      if (!deps.gatewayHasConnection(gatewayProvider)) continue;
+      if (!deps.gatewayCovers(gatewayProvider, modelId)) continue;
+      chosenAlias = alias;
+      chosenProvider = gatewayProvider;
+      break;
+    }
+    if (!chosenAlias || !chosenProvider) continue;
+
+    const aliasId = `${chosenAlias}/${id}`;
+    // Skip if the mirror already exists in the list.
+    if (models.some((m) => m.id === aliasId)) continue;
+    // Skip if the id already starts with this gateway alias (would double-prefix).
+    if (id.startsWith(`${chosenAlias}/`)) continue;
+
+    const label =
+      typeof model.name === "string" && model.name ? model.name : modelId;
+    aliases.push({
+      ...model,
+      id: aliasId,
+      root: id,
+      owned_by: chosenProvider,
+      display_name: `${label}${FUNCTIONAL_GATEWAY_MIRROR_SUFFIX}${chosenProvider})`,
+    } as T);
+  }
+
+  return aliases.length > 0 ? [...models, ...aliases] : models;
+}

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -12,6 +12,10 @@ import {
 } from "@/lib/localDb";
 import { createLazyConnectionView } from "@/lib/db/providers/lazyConnectionView";
 import { extractAliasBackedModels } from "./aliasBackedModels";
+import {
+  buildSyncedModelIdsByCanonicalProvider,
+  shouldSuppressStaticModelBySyncedCoverage,
+} from "./catalogSyncedCoverage";
 import { buildSyncedCapabilities, mergeSyncedCapabilities } from "./syncedCapabilities";
 import { getAllEmbeddingModels } from "@omniroute/open-sse/config/embeddingRegistry";
 import {
@@ -100,31 +104,6 @@ import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 // are still importable from here.
 export { isVisionModelId } from "@/shared/constants/visionModels";
 export { getCustomVisionCapabilityFields };
-
-/**
- * Decide whether a static registry model should be suppressed because a provider's
- * synced model list covers it.
- *
- * The synced discovery list (from a provider's `modelsUrl`) REPLACES the static
- * registry models in the catalog (see #7694 reasoning). But it must only replace
- * models the synced list actually covers. Before this helper, any provider with
- * ANY synced model dropped ALL its static models — so static models the upstream
- * discovery does not list (e.g. command-code's `deepseek/deepseek-v4-flash`) were
- * silently removed from the catalog even though the gateway routes them (200 OK).
- *
- * `syncedModelIds` are the display-model ids already normalized by the synced loop
- * (`displayModelId`), i.e. without the provider alias prefix. Match the static
- * model id exactly.
- */
-export function shouldSuppressStaticModelBySyncedCoverage(opts: {
-  providerHasSynced: boolean;
-  staticModelId: string;
-  syncedModelIds: string[];
-}): boolean {
-  if (!opts.providerHasSynced) return false;
-  if (opts.syncedModelIds.length === 0) return false;
-  return opts.syncedModelIds.includes(opts.staticModelId);
-}
 
 // The response cache (coalescing, short-TTL memoization and stale-while-revalidate)
 // lives in ./catalogCache. Re-exported here because the existing tests import the
@@ -702,20 +681,13 @@ async function buildUnifiedModelsResponseCore(
 
     // Map canonical provider id -> set of synced display-model ids, so the static
     // loop below can decide which static models a provider's synced discovery list
-    // actually covers (and which static models it must preserve — see
-    // shouldSuppressStaticModelBySyncedCoverage). Keyed by canonical provider id
-    // because the static loop addresses providers that way.
-    const syncedModelIdsByCanonicalProvider = new Map<string, Set<string>>();
-    for (const [providerId, syncedModels] of Object.entries(syncedModelsByProvider)) {
-      if (!Array.isArray(syncedModels)) continue;
-      const alias = providerIdToPrefix[providerId] || providerIdToAlias[providerId] || providerId;
-      const canonicalId = resolveCanonicalProviderId(alias, providerId);
-      const set = syncedModelIdsByCanonicalProvider.get(canonicalId) || new Set<string>();
-      for (const sm of syncedModels) {
-        if (typeof sm?.id === "string" && sm.id.length > 0) set.add(sm.id);
-      }
-      syncedModelIdsByCanonicalProvider.set(canonicalId, set);
-    }
+    // actually covers (and which static models it must preserve).
+    const syncedModelIdsByCanonicalProvider = buildSyncedModelIdsByCanonicalProvider(
+      syncedModelsByProvider,
+      resolveCanonicalProviderId,
+      providerIdToPrefix,
+      providerIdToAlias
+    );
 
     // Add provider models (chat)
     for (const [alias, providerModels] of Object.entries(PROVIDER_MODELS)) {

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -101,6 +101,31 @@ import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 export { isVisionModelId } from "@/shared/constants/visionModels";
 export { getCustomVisionCapabilityFields };
 
+/**
+ * Decide whether a static registry model should be suppressed because a provider's
+ * synced model list covers it.
+ *
+ * The synced discovery list (from a provider's `modelsUrl`) REPLACES the static
+ * registry models in the catalog (see #7694 reasoning). But it must only replace
+ * models the synced list actually covers. Before this helper, any provider with
+ * ANY synced model dropped ALL its static models — so static models the upstream
+ * discovery does not list (e.g. command-code's `deepseek/deepseek-v4-flash`) were
+ * silently removed from the catalog even though the gateway routes them (200 OK).
+ *
+ * `syncedModelIds` are the display-model ids already normalized by the synced loop
+ * (`displayModelId`), i.e. without the provider alias prefix. Match the static
+ * model id exactly.
+ */
+export function shouldSuppressStaticModelBySyncedCoverage(opts: {
+  providerHasSynced: boolean;
+  staticModelId: string;
+  syncedModelIds: string[];
+}): boolean {
+  if (!opts.providerHasSynced) return false;
+  if (opts.syncedModelIds.length === 0) return false;
+  return opts.syncedModelIds.includes(opts.staticModelId);
+}
+
 // The response cache (coalescing, short-TTL memoization and stale-while-revalidate)
 // lives in ./catalogCache. Re-exported here because the existing tests import the
 // hooks from this module, and CATALOG_STALE_WHILE_REVALIDATE_MS is part of the
@@ -675,6 +700,23 @@ async function buildUnifiedModelsResponseCore(
       return false;
     };
 
+    // Map canonical provider id -> set of synced display-model ids, so the static
+    // loop below can decide which static models a provider's synced discovery list
+    // actually covers (and which static models it must preserve — see
+    // shouldSuppressStaticModelBySyncedCoverage). Keyed by canonical provider id
+    // because the static loop addresses providers that way.
+    const syncedModelIdsByCanonicalProvider = new Map<string, Set<string>>();
+    for (const [providerId, syncedModels] of Object.entries(syncedModelsByProvider)) {
+      if (!Array.isArray(syncedModels)) continue;
+      const alias = providerIdToPrefix[providerId] || providerIdToAlias[providerId] || providerId;
+      const canonicalId = resolveCanonicalProviderId(alias, providerId);
+      const set = syncedModelIdsByCanonicalProvider.get(canonicalId) || new Set<string>();
+      for (const sm of syncedModels) {
+        if (typeof sm?.id === "string" && sm.id.length > 0) set.add(sm.id);
+      }
+      syncedModelIdsByCanonicalProvider.set(canonicalId, set);
+    }
+
     // Add provider models (chat)
     for (const [alias, providerModels] of Object.entries(PROVIDER_MODELS)) {
       const providerId = aliasToProviderId[alias] || alias;
@@ -693,10 +735,20 @@ async function buildUnifiedModelsResponseCore(
       }
 
       for (const model of providerModels) {
-        // Synced models replace static base entries, but they do not carry aliases
-        // registered for provider-specific reasoning variants.
+        // Synced models replace static base entries they COVER, but they do not
+        // carry aliases registered for provider-specific reasoning variants, and
+        // static models the synced list does NOT cover must be preserved (the
+        // gateway still routes them — e.g. command-code's static
+        // `deepseek/deepseek-v4-flash` which its discovery never lists). Before
+        // the fix, a provider with any synced model silently dropped ALL its
+        // static models.
+        const syncedForProvider = syncedModelIdsByCanonicalProvider.get(canonicalProviderId);
         if (
-          providersWithSyncedModels.has(canonicalProviderId) &&
+          shouldSuppressStaticModelBySyncedCoverage({
+            providerHasSynced: syncedForProvider !== undefined && syncedForProvider.size > 0,
+            staticModelId: model.id,
+            syncedModelIds: syncedForProvider ? [...syncedForProvider] : [],
+          }) &&
           !isRegisteredEffortVariant(providerModels, model.id)
         )
           continue;

--- a/src/app/api/v1/models/catalogResponse.ts
+++ b/src/app/api/v1/models/catalogResponse.ts
@@ -12,8 +12,15 @@ import { appendNoThinkingVariants } from "@omniroute/open-sse/utils/noThinkingAl
 import { appendClaudeEffortVariants } from "@omniroute/open-sse/utils/claudeEffortVariants";
 import { appendSyncedEffortVariants } from "@omniroute/open-sse/utils/syncedEffortVariants";
 import { appendCcDiscoveryAliases } from "@omniroute/open-sse/utils/ccDiscoveryAliases";
+import { appendFunctionalGatewayMirrors } from "@omniroute/open-sse/utils/functionalGatewayMirrors";
 import { isCcAliasGlobalEnabled, getCcAliasSettingsBulk } from "@/lib/db/ccDiscoveryAliases";
 import { buildCcAliasPredicate } from "./ccAliasPredicate";
+import {
+  isFunctionalGatewayGlobalEnabled,
+  getFunctionalGatewaySettingsBulk,
+} from "@/lib/db/functionalGatewayMirrors";
+import { buildFunctionalGatewayPredicate } from "./functionalGatewayPredicate";
+import { getPassthroughProviders, REGISTRY } from "@omniroute/open-sse/config/providerRegistry";
 import { hasEligibleConnectionForModel } from "@/domain/connectionModelRules";
 import { dedupeExactCatalogIds } from "./catalogDedupe";
 import {
@@ -85,6 +92,40 @@ export function applyCatalogPostFilters(
         providers: ccAliasSettings.providers,
         models: ccAliasSettings.models,
       })
+    );
+  }
+
+  // Advertise `<gateway-alias>/<id>` functional-gateway mirrors so discovery
+  // clients surface the route that actually has a credential, even when the
+  // canonical owner provider has none (e.g. `deepseek/deepseek-v4-flash` fails
+  // 404 but `agentrouter/deepseek/deepseek-v4-flash` returns 200). Gated 3
+  // levels deep (global > provider > model, see db/functionalGatewayMirrors.ts)
+  // and default-off. Only emits a mirror when the canonical owner has no
+  // eligible connection for the model AND a passthrough gateway with an active
+  // credential covers it.
+  const fgGlobal = isFunctionalGatewayGlobalEnabled();
+  const fgSettings = getFunctionalGatewaySettingsBulk();
+  if (fgGlobal || fgSettings.providers.size > 0 || fgSettings.models.size > 0) {
+    const gatewayProviderIds = [...getPassthroughProviders()];
+    finalModels = appendFunctionalGatewayMirrors(finalModels, {
+      gatewayProviderIds,
+      isGateway: (provider) => getPassthroughProviders().has(provider),
+      gatewayAlias: (provider) => REGISTRY[provider]?.alias || provider,
+      gatewayCovers: (provider, modelId) =>
+        hasEligibleConnectionForModel(
+          ctx.connections.filter((c) => c.provider === provider),
+          modelId
+        ),
+      gatewayHasConnection: (provider) =>
+        ctx.connections.some((c) => c.provider === provider),
+      canonicalOwnerHasConnection: (owner) =>
+        hasEligibleConnectionForModel(
+          ctx.connections.filter((c) => c.provider === owner),
+          owner
+        ),
+    });
+    finalModels = finalModels.filter((m) =>
+      buildFunctionalGatewayPredicate({ global: fgGlobal, ...fgSettings })(m)
     );
   }
 

--- a/src/app/api/v1/models/catalogSyncedCoverage.ts
+++ b/src/app/api/v1/models/catalogSyncedCoverage.ts
@@ -1,0 +1,61 @@
+/**
+ * catalogSyncedCoverage.ts — synced-model coverage for the /v1/models static loop.
+ *
+ * The synced discovery list (from a provider's `modelsUrl`) REPLACES the static
+ * registry models in the catalog (see #7694 reasoning). But it must only replace
+ * models the synced list actually covers. Before this helper, any provider with
+ * ANY synced model dropped ALL its static models — so static models the upstream
+ * discovery does not list (e.g. command-code's `deepseek/deepseek-v4-flash`) were
+ * silently removed from the catalog even though the gateway routes them (200 OK).
+ *
+ * Pure module (no DB import) so it is unit-testable and keeps catalog.ts lean.
+ */
+
+export interface SyncedModelRow {
+  id?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Decide whether a static registry model should be suppressed because a provider's
+ * synced model list covers it.
+ *
+ * `syncedModelIds` are the display-model ids already normalized by the synced loop
+ * (`displayModelId`), i.e. without the provider alias prefix. Match the static
+ * model id exactly.
+ */
+export function shouldSuppressStaticModelBySyncedCoverage(opts: {
+  providerHasSynced: boolean;
+  staticModelId: string;
+  syncedModelIds: string[];
+}): boolean {
+  if (!opts.providerHasSynced) return false;
+  if (opts.syncedModelIds.length === 0) return false;
+  return opts.syncedModelIds.includes(opts.staticModelId);
+}
+
+/**
+ * Build a Map of canonical provider id -> set of synced display-model ids, so the
+ * static loop can decide which static models a provider's synced discovery list
+ * actually covers (and which static models it must preserve). Keyed by canonical
+ * provider id because the static loop addresses providers that way.
+ */
+export function buildSyncedModelIdsByCanonicalProvider(
+  syncedModelsByProvider: Record<string, SyncedModelRow[]>,
+  resolveCanonicalProviderId: (aliasOrId: string, fallbackProviderId?: string) => string,
+  providerIdToPrefix: Record<string, string>,
+  providerIdToAlias: Record<string, string>
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const [providerId, syncedModels] of Object.entries(syncedModelsByProvider)) {
+    if (!Array.isArray(syncedModels)) continue;
+    const alias = providerIdToPrefix[providerId] || providerIdToAlias[providerId] || providerId;
+    const canonicalId = resolveCanonicalProviderId(alias, providerId);
+    const set = map.get(canonicalId) || new Set<string>();
+    for (const sm of syncedModels) {
+      if (typeof sm?.id === "string" && sm.id.length > 0) set.add(sm.id);
+    }
+    map.set(canonicalId, set);
+  }
+  return map;
+}

--- a/src/app/api/v1/models/functionalGatewayPredicate.ts
+++ b/src/app/api/v1/models/functionalGatewayPredicate.ts
@@ -1,0 +1,50 @@
+/**
+ * functionalGatewayPredicate.ts — catalog-side predicate for the functional
+ * gateway mirror gate.
+ *
+ * Mirrors the 3-level gate of ccDiscoveryAliases (global > provider > model) but
+ * for functional gateway mirrors. Storage reuses the same `key_value` namespace
+ * conventions but under a dedicated feature flag (see db wiring in Task 4).
+ */
+
+export type FunctionalGatewaySetting = "on" | "off" | null;
+
+export interface FunctionalGatewayGateSnapshot {
+  global: boolean;
+  providers: Map<string, FunctionalGatewaySetting>;
+  models: Map<string, FunctionalGatewaySetting>;
+}
+
+function resolveSetting(
+  model: FunctionalGatewaySetting,
+  provider: FunctionalGatewaySetting,
+  global: boolean
+): boolean {
+  if (model === "off") return false;
+  if (model === "on") return true;
+  if (provider === "off") return false;
+  if (provider === "on") return true;
+  return global;
+}
+
+/**
+ * Builds a predicate suitable for filtering `appendFunctionalGatewayMirrors`
+ * output from a single settings snapshot.
+ */
+export function buildFunctionalGatewayPredicate(
+  snapshot: FunctionalGatewayGateSnapshot
+): (entry: { id?: unknown; owned_by?: unknown }) => boolean {
+  return (entry) => {
+    const id = entry.id;
+    if (typeof id !== "string" || id.length === 0) return false;
+
+    const slashIndex = id.indexOf("/");
+    if (slashIndex === -1) return snapshot.global;
+
+    const providerId = id.slice(0, slashIndex);
+    const modelId = id.slice(slashIndex + 1);
+    const provider = snapshot.providers.get(providerId) ?? null;
+    const model = snapshot.models.get(`${providerId}/${modelId}`) ?? null;
+    return resolveSetting(model, provider, snapshot.global);
+  };
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -12182,5 +12182,6 @@
     "cta": "احصل على Kimi Code",
     "partnerLinkNote": "رابط شريك",
     "dismissAriaLabel": "تجاهل"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code əldə et",
     "partnerLinkNote": "Tərəfdaş linki",
     "dismissAriaLabel": "Bağla"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -12182,5 +12182,6 @@
     "cta": "Вземете Kimi Code",
     "partnerLinkNote": "Партньорска връзка",
     "dismissAriaLabel": "Затваряне"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code পান",
     "partnerLinkNote": "পার্টনার লিঙ্ক",
     "dismissAriaLabel": "খারিজ করুন"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -12182,5 +12182,6 @@
     "cta": "Získat Kimi Code",
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavřít"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -12182,5 +12182,6 @@
     "cta": "Hent Kimi Code",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Afvis"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code holen",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Schließen"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -12207,5 +12207,6 @@
     "cta": "Get Kimi Code",
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -12182,5 +12182,6 @@
     "cta": "Obtener Kimi Code",
     "partnerLinkNote": "Enlace de socio",
     "dismissAriaLabel": "Descartar"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -12182,5 +12182,6 @@
     "cta": "دریافت Kimi Code",
     "partnerLinkNote": "لینک همکاری",
     "dismissAriaLabel": "بستن"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -12182,5 +12182,6 @@
     "cta": "Hanki Kimi Code",
     "partnerLinkNote": "Kumppanilinkki",
     "dismissAriaLabel": "Sulje"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -12182,5 +12182,6 @@
     "cta": "Obtenir Kimi Code",
     "partnerLinkNote": "Lien partenaire",
     "dismissAriaLabel": "Ignorer"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code મેળવો",
     "partnerLinkNote": "પાર્ટનર લિંક",
     "dismissAriaLabel": "બંધ કરો"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -12182,5 +12182,6 @@
     "cta": "קבל את Kimi Code",
     "partnerLinkNote": "קישור שותף",
     "dismissAriaLabel": "התעלם"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code प्राप्त करें",
     "partnerLinkNote": "पार्टनर लिंक",
     "dismissAriaLabel": "खारिज करें"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code beszerzése",
     "partnerLinkNote": "Partnerhivatkozás",
     "dismissAriaLabel": "Elvetés"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -12182,5 +12182,6 @@
     "cta": "Dapatkan Kimi Code",
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -12182,5 +12182,6 @@
     "cta": "Dapatkan Kimi Code",
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -12182,5 +12182,6 @@
     "cta": "Ottieni Kimi Code",
     "partnerLinkNote": "Link partner",
     "dismissAriaLabel": "Ignora"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code を取得",
     "partnerLinkNote": "パートナーリンク",
     "dismissAriaLabel": "閉じる"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code 가져오기",
     "partnerLinkNote": "파트너 링크",
     "dismissAriaLabel": "닫기"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code मिळवा",
     "partnerLinkNote": "भागीदार लिंक",
     "dismissAriaLabel": "बंद करा"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -12182,5 +12182,6 @@
     "cta": "Dapatkan Kimi Code",
     "partnerLinkNote": "Pautan rakan kongsi",
     "dismissAriaLabel": "Tutup"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code ophalen",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Sluiten"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -12182,5 +12182,6 @@
     "cta": "Hent Kimi Code",
     "partnerLinkNote": "Partnerlenke",
     "dismissAriaLabel": "Avvis"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -12182,5 +12182,6 @@
     "cta": "Kumuha ng Kimi Code",
     "partnerLinkNote": "Link ng kasosyo",
     "dismissAriaLabel": "I-dismiss"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -12204,5 +12204,6 @@
     "cta": "Uzyskaj Kimi Code",
     "partnerLinkNote": "Link partnerski",
     "dismissAriaLabel": "Odrzuć"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -12207,5 +12207,6 @@
     "cta": "Obter Kimi Code",
     "partnerLinkNote": "Link de parceiro",
     "dismissAriaLabel": "Descartar"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -12182,5 +12182,6 @@
     "cta": "Obter Kimi Code",
     "partnerLinkNote": "Link de parceiro",
     "dismissAriaLabel": "Dispensar"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -12182,5 +12182,6 @@
     "cta": "Obține Kimi Code",
     "partnerLinkNote": "Link de partener",
     "dismissAriaLabel": "Închide"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -12182,5 +12182,6 @@
     "cta": "Получить Kimi Code",
     "partnerLinkNote": "Партнерская ссылка",
     "dismissAriaLabel": "Закрыть"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -12182,5 +12182,6 @@
     "cta": "Získať Kimi Code",
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavrieť"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -12182,5 +12182,6 @@
     "cta": "Hämta Kimi Code",
     "partnerLinkNote": "Partnerlänk",
     "dismissAriaLabel": "Avvisa"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -12182,5 +12182,6 @@
     "cta": "Pata Kimi Code",
     "partnerLinkNote": "Kiungo cha mshirika",
     "dismissAriaLabel": "Ondoa"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code-ஐப் பெறுங்கள்",
     "partnerLinkNote": "பங்குதாரர் இணைப்பு",
     "dismissAriaLabel": "நிராகரி"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code పొందండి",
     "partnerLinkNote": "భాగస్వామి లింక్",
     "dismissAriaLabel": "తీసివేయి"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -12182,5 +12182,6 @@
     "cta": "รับ Kimi Code",
     "partnerLinkNote": "ลิงก์พันธมิตร",
     "dismissAriaLabel": "ปิด"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code Edin",
     "partnerLinkNote": "Ortaklık bağlantısı",
     "dismissAriaLabel": "Kapat"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -12182,5 +12182,6 @@
     "cta": "Отримати Kimi Code",
     "partnerLinkNote": "Партнерське посилання",
     "dismissAriaLabel": "Закрити"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -12182,5 +12182,6 @@
     "cta": "Kimi Code حاصل کریں",
     "partnerLinkNote": "پارٹنر لنک",
     "dismissAriaLabel": "خارج کریں"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -12207,5 +12207,6 @@
     "cta": "Get Kimi Code",
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -12208,5 +12208,5 @@
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
   },
-  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "Công bố các id phản chiếu &lt;gateway-alias&gt;/&lt;model&gt; trên /v1/models cho các mô hình có chủ sở hữu chuẩn không có thông tin xác thực hoạt động nhưng một cổng chuyển tiếp có thông tin xác thực hoạt động định tuyến được chúng. Cảnh báo: khi bật, số mục trong danh mục tăng lên với mọi client."
 }

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -12182,5 +12182,6 @@
     "cta": "获取 Kimi Code",
     "partnerLinkNote": "合作伙伴链接",
     "dismissAriaLabel": "关闭"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -12182,5 +12182,6 @@
     "cta": "取得 Kimi Code",
     "partnerLinkNote": "合作夥伴連結",
     "dismissAriaLabel": "關閉"
-  }
+  },
+  "featureFlagExposeFunctionalGatewayMirrorsDescription": "__MISSING__:Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally."
 }

--- a/src/lib/db/functionalGatewayMirrors.ts
+++ b/src/lib/db/functionalGatewayMirrors.ts
@@ -1,0 +1,128 @@
+/**
+ * db/functionalGatewayMirrors.ts — functional-gateway mirror gate.
+ *
+ * Storage: `key_value` table, namespace `functionalGatewayMirrors`, following the
+ * ccDiscoveryAliases pattern. Global flag `EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS`
+ * (env "1"|"true" > DB flag > default false). Provider/model overrides stored as
+ * `provider:<id>` and `model:<provider>/<model>` keys with value "on"/"off".
+ */
+import { getFeatureFlagOverride } from "./featureFlags";
+import { getDbInstance } from "./core";
+
+const NAMESPACE = "functionalGatewayMirrors";
+const FLAG_KEY = "EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS";
+
+export type FunctionalGatewaySetting = "on" | "off" | null;
+
+function parseSetting(value: string | undefined): FunctionalGatewaySetting {
+  if (value === "on" || value === "off") return value;
+  return null;
+}
+
+function providerKey(providerId: string): string {
+  return `provider:${providerId}`;
+}
+
+function modelKey(modelId: string): string {
+  return `model:${modelId}`;
+}
+
+export function getFunctionalGatewayProviderSetting(providerId: string): FunctionalGatewaySetting {
+  const db = getDbInstance();
+  const row = db
+    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+    .get(NAMESPACE, providerKey(providerId)) as { value: string } | undefined;
+  return parseSetting(row?.value);
+}
+
+export function setFunctionalGatewayProviderSetting(
+  providerId: string,
+  v: FunctionalGatewaySetting
+): void {
+  const db = getDbInstance();
+  const key = providerKey(providerId);
+  if (v === null) {
+    db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(NAMESPACE, key);
+    return;
+  }
+  db.prepare("INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES (?, ?, ?)").run(
+    NAMESPACE,
+    key,
+    v
+  );
+}
+
+export function getFunctionalGatewayModelSetting(modelId: string): FunctionalGatewaySetting {
+  const db = getDbInstance();
+  const row = db
+    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+    .get(NAMESPACE, modelKey(modelId)) as { value: string } | undefined;
+  return parseSetting(row?.value);
+}
+
+export function setFunctionalGatewayModelSetting(
+  modelId: string,
+  v: FunctionalGatewaySetting
+): void {
+  const db = getDbInstance();
+  const key = modelKey(modelId);
+  if (v === null) {
+    db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(NAMESPACE, key);
+    return;
+  }
+  db.prepare("INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES (?, ?, ?)").run(
+    NAMESPACE,
+    key,
+    v
+  );
+}
+
+export function getFunctionalGatewaySettingsBulk(): {
+  providers: Map<string, "on" | "off">;
+  models: Map<string, "on" | "off">;
+} {
+  const db = getDbInstance();
+  const rows = db
+    .prepare("SELECT key, value FROM key_value WHERE namespace = ?")
+    .all(NAMESPACE) as Array<{ key: string; value: string }>;
+
+  const providers = new Map<string, "on" | "off">();
+  const models = new Map<string, "on" | "off">();
+
+  for (const row of rows) {
+    const setting = parseSetting(row.value);
+    if (setting === null) continue;
+    if (row.key.startsWith("provider:")) {
+      providers.set(row.key.slice("provider:".length), setting);
+    } else if (row.key.startsWith("model:")) {
+      models.set(row.key.slice("model:".length), setting);
+    }
+  }
+
+  return { providers, models };
+}
+
+function envForcesGlobalOn(): boolean {
+  const raw = process.env[FLAG_KEY];
+  return raw === "1" || raw === "true";
+}
+
+export function getFunctionalGatewayGlobalState(): {
+  enabled: boolean;
+  source: "env" | "db" | "default";
+} {
+  if (envForcesGlobalOn()) {
+    return { enabled: true, source: "env" };
+  }
+
+  const dbOverride = getFeatureFlagOverride(FLAG_KEY);
+  if (dbOverride !== undefined) {
+    return { enabled: dbOverride === "true" || dbOverride === "1", source: "db" };
+  }
+
+  return { enabled: false, source: "default" };
+}
+
+export function isFunctionalGatewayGlobalEnabled(): boolean {
+  return getFunctionalGatewayGlobalState().enabled;
+}

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -808,3 +808,4 @@ export * from "./db/interceptionRules"; // Per-model web-search/web-fetch interc
 export * from "./db/relayProbeStats"; // Relay probe latency/health stats (#6909)
 export * from "./db/ccDiscoveryAliases"; // Claude Code discovery-alias gate (flag + per-provider/model overrides)
 export * from "./db/ccDiscoveryMetrics"; // Claude Code discovery-alias usage counters (alias requests + discovery hits)
+export * from "./db/functionalGatewayMirrors"; // Functional-gateway mirror gate (flag + per-provider/model overrides)

--- a/src/shared/constants/featureFlagDefinitions.ts
+++ b/src/shared/constants/featureFlagDefinitions.ts
@@ -409,6 +409,18 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     requiresRestart: false,
     warningLevel: "info",
   },
+  {
+    key: "EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS",
+    label: "Functional Gateway Mirrors",
+    description:
+      "Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally.",
+    descriptionI18nKey: "featureFlagExposeFunctionalGatewayMirrorsDescription",
+    category: "runtime",
+    defaultValue: "false",
+    type: "boolean",
+    requiresRestart: false,
+    warningLevel: "info",
+  },
 
   // ──────────────── CLI (5) ────────────────
   {

--- a/tests/unit/catalog-synced-static-preservation.test.ts
+++ b/tests/unit/catalog-synced-static-preservation.test.ts
@@ -1,9 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-// Extract the substitution decision into a pure helper so it's unit-testable
-// without a DB. The helper lives in catalog.ts and is exported for tests.
-import { shouldSuppressStaticModelBySyncedCoverage } from "../../src/app/api/v1/models/catalog.ts";
+import {
+  buildSyncedModelIdsByCanonicalProvider,
+  shouldSuppressStaticModelBySyncedCoverage,
+} from "../../src/app/api/v1/models/catalogSyncedCoverage.ts";
 
 test("static model covered by synced list IS suppressed (current behavior kept)", () => {
   assert.equal(
@@ -47,4 +48,28 @@ test("no synced models -> nothing suppressed", () => {
     }),
     false
   );
+});
+
+test("buildSyncedModelIdsByCanonicalProvider groups synced ids by canonical provider", () => {
+  const byCanonical = buildSyncedModelIdsByCanonicalProvider(
+    {
+      "command-code": [
+        { id: "gpt-5.6-luna" },
+        { id: "moonshotai/Kimi-K3" },
+        { id: "" }, // empty id ignored
+      ],
+      deepseek: [{ id: "deepseek-v4-flash" }],
+    },
+    (aliasOrId, fallback) => aliasOrId === "cmd" ? "command-code" : (fallback || aliasOrId),
+    {},
+    { "command-code": "cmd" }
+  );
+  const cmd = byCanonical.get("command-code");
+  assert.ok(cmd);
+  assert.ok(cmd.has("gpt-5.6-luna"));
+  assert.ok(cmd.has("moonshotai/Kimi-K3"));
+  assert.equal(cmd.has(""), false);
+  const ds = byCanonical.get("deepseek");
+  assert.ok(ds);
+  assert.ok(ds.has("deepseek-v4-flash"));
 });

--- a/tests/unit/catalog-synced-static-preservation.test.ts
+++ b/tests/unit/catalog-synced-static-preservation.test.ts
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// Extract the substitution decision into a pure helper so it's unit-testable
+// without a DB. The helper lives in catalog.ts and is exported for tests.
+import { shouldSuppressStaticModelBySyncedCoverage } from "../../src/app/api/v1/models/catalog.ts";
+
+test("static model covered by synced list IS suppressed (current behavior kept)", () => {
+  assert.equal(
+    shouldSuppressStaticModelBySyncedCoverage({
+      providerHasSynced: true,
+      staticModelId: "gpt-5.6-luna",
+      syncedModelIds: ["gpt-5.6-luna", "moonshotai/Kimi-K3"],
+    }),
+    true
+  );
+});
+
+test("static model NOT covered by synced list is preserved (the bug fix)", () => {
+  assert.equal(
+    shouldSuppressStaticModelBySyncedCoverage({
+      providerHasSynced: true,
+      staticModelId: "deepseek/deepseek-v4-flash",
+      syncedModelIds: ["gpt-5.6-luna", "moonshotai/Kimi-K3"],
+    }),
+    false
+  );
+});
+
+test("static model covered by synced list with prefix normalization IS suppressed", () => {
+  assert.equal(
+    shouldSuppressStaticModelBySyncedCoverage({
+      providerHasSynced: true,
+      staticModelId: "deepseek/deepseek-v4-flash",
+      syncedModelIds: ["deepseek/deepseek-v4-flash", "gpt-5.6-luna"],
+    }),
+    true
+  );
+});
+
+test("no synced models -> nothing suppressed", () => {
+  assert.equal(
+    shouldSuppressStaticModelBySyncedCoverage({
+      providerHasSynced: false,
+      staticModelId: "deepseek/deepseek-v4-flash",
+      syncedModelIds: [],
+    }),
+    false
+  );
+});

--- a/tests/unit/feature-flags-settings.test.ts
+++ b/tests/unit/feature-flags-settings.test.ts
@@ -30,13 +30,13 @@ const {
   isControlPlaneProxyDirectFallbackEnabled,
 } = await import("../../src/shared/utils/featureFlags.ts");
 
-const EXPECTED_FEATURE_FLAG_COUNT = 42;
+const EXPECTED_FEATURE_FLAG_COUNT = 43;
 
 // ──────────────────────────────────────────────────────
 // Test group 1 — Flag definitions registry
 // ──────────────────────────────────────────────────────
 describe("featureFlagDefinitions", () => {
-  it("has exactly 42 flag definitions", () => {
+  it("has exactly 43 flag definitions", () => {
     assert.strictEqual(FEATURE_FLAG_DEFINITIONS.length, EXPECTED_FEATURE_FLAG_COUNT);
   });
 
@@ -321,7 +321,7 @@ describe("resolveFeatureFlag", () => {
   });
 
   describe("resolveAllFeatureFlags", () => {
-    it("returns all 42 flags", () => {
+    it("returns all 43 flags", () => {
       const all = resolveAllFeatureFlags();
       assert.strictEqual(all.length, EXPECTED_FEATURE_FLAG_COUNT);
     });

--- a/tests/unit/functional-gateway-mirrors-append.test.ts
+++ b/tests/unit/functional-gateway-mirrors-append.test.ts
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { appendFunctionalGatewayMirrors } from "../../open-sse/utils/functionalGatewayMirrors.ts";
+
+interface CatalogEntry {
+  id: string;
+  owned_by?: string;
+  root?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+// Simulate: canonical owner "deepseek" has no eligible connection; passthrough
+// gateway "agentrouter" (alias "agentrouter") has one and routes arbitrary models.
+const deps = {
+  gatewayProviderIds: ["agentrouter", "openrouter"],
+  isGateway: (p: string) => p === "agentrouter" || p === "openrouter",
+  gatewayAlias: (p: string) => p, // agentrouter has no distinct alias
+  gatewayCovers: (p: string, modelId: string) => p === "agentrouter", // routes anything
+  gatewayHasConnection: (p: string) => p === "agentrouter",
+  canonicalOwnerHasConnection: (owner: string) => owner !== "deepseek",
+};
+
+test("synthesizes a gateway-alias mirror when canonical owner has no connection", () => {
+  const models: CatalogEntry[] = [
+    {
+      id: "deepseek/deepseek-v4-flash",
+      owned_by: "deepseek",
+      root: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+    },
+  ];
+  const out = appendFunctionalGatewayMirrors(models, deps);
+
+  assert.ok(out.some((m) => m.id === "agentrouter/deepseek/deepseek-v4-flash"));
+  const mirror = out.find((m) => m.id === "agentrouter/deepseek/deepseek-v4-flash");
+  assert.equal(mirror!.root, "deepseek/deepseek-v4-flash");
+  assert.equal(mirror!.owned_by, "agentrouter");
+  assert.equal(mirror!.display_name, "DeepSeek V4 Flash (via agentrouter)");
+});
+
+test("does NOT mirror when the canonical owner already has a connection", () => {
+  const models: CatalogEntry[] = [
+    { id: "kimi/kimi-k2.7-code", owned_by: "kimi", root: "kimi-k2.7-code" },
+  ];
+  const out = appendFunctionalGatewayMirrors(models, {
+    gatewayProviderIds: ["agentrouter"],
+    isGateway: () => false,
+    gatewayAlias: (p) => p,
+    gatewayCovers: () => false,
+    gatewayHasConnection: () => true,
+    canonicalOwnerHasConnection: () => true,
+  });
+  assert.equal(out.length, 1); // unchanged
+});
+
+test("does NOT mirror when the gateway has no connection", () => {
+  const models: CatalogEntry[] = [
+    { id: "deepseek/deepseek-v4-flash", owned_by: "deepseek", root: "deepseek-v4-flash" },
+  ];
+  const out = appendFunctionalGatewayMirrors(models, {
+    gatewayProviderIds: ["agentrouter"],
+    isGateway: () => true,
+    gatewayAlias: (p) => p,
+    gatewayCovers: () => true,
+    gatewayHasConnection: () => false, // no gateway credential
+    canonicalOwnerHasConnection: () => false,
+  });
+  assert.equal(out.length, 1); // unchanged
+});
+
+test("never mirrors ids that already carry the gateway alias prefix", () => {
+  const models: CatalogEntry[] = [
+    {
+      id: "agentrouter/deepseek/deepseek-v4-flash",
+      owned_by: "deepseek",
+      root: "deepseek-v4-flash",
+    },
+  ];
+  const out = appendFunctionalGatewayMirrors(models, deps);
+  assert.equal(out.length, 1); // unchanged
+});

--- a/tests/unit/functional-gateway-mirrors-db.test.ts
+++ b/tests/unit/functional-gateway-mirrors-db.test.ts
@@ -1,0 +1,52 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { resetDbInstance } from "../../src/lib/db/core.ts";
+import {
+  removeFeatureFlagOverride,
+  setFeatureFlagOverride,
+} from "../../src/lib/db/featureFlags.ts";
+import {
+  getFunctionalGatewayGlobalState,
+  getFunctionalGatewayProviderSetting,
+  getFunctionalGatewayModelSetting,
+  setFunctionalGatewayProviderSetting,
+  setFunctionalGatewayModelSetting,
+  getFunctionalGatewaySettingsBulk,
+} from "../../src/lib/db/functionalGatewayMirrors.ts";
+
+const FLAG_KEY = "EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS";
+
+after(() => {
+  removeFeatureFlagOverride(FLAG_KEY);
+  resetDbInstance();
+});
+
+test("global state defaults to off", () => {
+  const { enabled } = getFunctionalGatewayGlobalState();
+  assert.equal(enabled, false);
+});
+
+test("can flip global on via feature-flag override (the dashboard/env mechanism)", () => {
+  setFeatureFlagOverride(FLAG_KEY, "true");
+  const { enabled, source } = getFunctionalGatewayGlobalState();
+  assert.equal(enabled, true);
+  assert.equal(source, "db");
+});
+
+test("provider and model settings default to null", () => {
+  assert.equal(getFunctionalGatewayProviderSetting("agentrouter"), null);
+  assert.equal(
+    getFunctionalGatewayModelSetting("agentrouter/deepseek/deepseek-v4-flash"),
+    null
+  );
+});
+
+test("bulk settings reflect provider/model overrides", () => {
+  setFunctionalGatewayProviderSetting("agentrouter", "on");
+  setFunctionalGatewayModelSetting("openrouter/deepseek/deepseek-v4-flash", "off");
+  const { providers, models } = getFunctionalGatewaySettingsBulk();
+  assert.equal(providers.get("agentrouter"), "on");
+  assert.equal(models.get("openrouter/deepseek/deepseek-v4-flash"), "off");
+  setFunctionalGatewayProviderSetting("agentrouter", null);
+  setFunctionalGatewayModelSetting("openrouter/deepseek/deepseek-v4-flash", null);
+});

--- a/tests/unit/functional-gateway-predicate.test.ts
+++ b/tests/unit/functional-gateway-predicate.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildFunctionalGatewayPredicate,
+  type FunctionalGatewayGateSnapshot,
+} from "../../src/app/api/v1/models/functionalGatewayPredicate.ts";
+
+test("provider on makes its gateway-owned models eligible", () => {
+  const snapshot: FunctionalGatewayGateSnapshot = {
+    global: false,
+    providers: new Map([["agentrouter", "on"]]),
+    models: new Map(),
+  };
+  const pred = buildFunctionalGatewayPredicate(snapshot);
+  assert.equal(
+    pred({ id: "agentrouter/deepseek/deepseek-v4-flash", owned_by: "agentrouter" }),
+    true
+  );
+  assert.equal(pred({ id: "deepseek/deepseek-v4-flash", owned_by: "deepseek" }), false);
+});
+
+test("model off wins over provider on", () => {
+  const snapshot: FunctionalGatewayGateSnapshot = {
+    global: false,
+    providers: new Map([["agentrouter", "on"]]),
+    models: new Map([["agentrouter/deepseek/deepseek-v4-flash", "off"]]),
+  };
+  const pred = buildFunctionalGatewayPredicate(snapshot);
+  assert.equal(
+    pred({ id: "agentrouter/deepseek/deepseek-v4-flash", owned_by: "agentrouter" }),
+    false
+  );
+});
+
+test("global on makes everything eligible, model off still wins", () => {
+  const snapshot: FunctionalGatewayGateSnapshot = {
+    global: true,
+    providers: new Map(),
+    models: new Map([["agentrouter/deepseek/deepseek-v4-flash", "off"]]),
+  };
+  const pred = buildFunctionalGatewayPredicate(snapshot);
+  assert.equal(pred({ id: "agentrouter/gpt-5.6-luna", owned_by: "agentrouter" }), true);
+  assert.equal(
+    pred({ id: "agentrouter/deepseek/deepseek-v4-flash", owned_by: "agentrouter" }),
+    false
+  );
+});

--- a/tests/unit/models-catalog-functional-gateway.test.ts
+++ b/tests/unit/models-catalog-functional-gateway.test.ts
@@ -1,0 +1,62 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { applyCatalogPostFilters } from "../../src/app/api/v1/models/catalogResponse.ts";
+import {
+  removeFeatureFlagOverride,
+  setFeatureFlagOverride,
+} from "../../src/lib/db/featureFlags.ts";
+import { setFunctionalGatewayProviderSetting } from "../../src/lib/db/functionalGatewayMirrors.ts";
+import { resetDbInstance } from "../../src/lib/db/core.ts";
+
+const FLAG_KEY = "EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS";
+
+after(() => {
+  removeFeatureFlagOverride(FLAG_KEY);
+  setFunctionalGatewayProviderSetting("agentrouter", null);
+  resetDbInstance();
+});
+
+// Minimal Request shim for applyCatalogPostFilters.
+function makeRequest(query = ""): Request {
+  return new Request(`http://localhost/v1/models${query}`);
+}
+
+test("catalog post-filters do not add mirrors when gate off (default)", () => {
+  const models = [
+    { id: "deepseek/deepseek-v4-flash", owned_by: "deepseek", root: "deepseek-v4-flash" },
+  ];
+  const out = applyCatalogPostFilters(makeRequest(), models, {
+    connections: [],
+    prefixMode: "dual",
+    aliasToProviderId: {},
+  });
+  assert.deepEqual(out, models);
+});
+
+test("catalog post-filters synthesize a gateway mirror when gate on and gateway has a connection", () => {
+  setFeatureFlagOverride(FLAG_KEY, "true");
+  setFunctionalGatewayProviderSetting("agentrouter", "on");
+
+  const models = [
+    { id: "deepseek/deepseek-v4-flash", owned_by: "deepseek", root: "deepseek-v4-flash" },
+  ];
+  const out = applyCatalogPostFilters(makeRequest(), models, {
+    connections: [
+      {
+        id: "conn-1",
+        provider: "agentrouter",
+        isActive: true,
+        providerSpecificData: {},
+      },
+    ],
+    prefixMode: "dual",
+    aliasToProviderId: {},
+  });
+  // The mirror pass is wired and synthesizes agentrouter/deepseek/deepseek-v4-flash
+  // when the gate is on AND agentrouter (a passthrough gateway) has an active
+  // connection covering the model.
+  assert.ok(
+    out.some((m) => m.id === "agentrouter/deepseek/deepseek-v4-flash"),
+    `expected mirror to be synthesized, got: ${out.map((m) => m.id).join(", ")}`
+  );
+});


### PR DESCRIPTION
## Resumo

Resolve o descompasso no `/v1/models` onde modelos **funcionalmente roteáveis** não eram anunciados no catálogo — clientes de discovery (omp, jcode, etc.) viam rotas que falham (`deepseek/deepseek-v4-flash` → 404) e escondiam rotas que funcionam (`cmd/deepseek/deepseek-v4-flash` → 200).

Duas mudanças independentes:

### 1. Fix do synced-substitution (`catalog.ts`)
**Causa raiz:** quando um provider tem synced models (descobertos via `modelsUrl`), o catálogo descartava **todos** os modelos estáticos do registry. O command-code sincroniza só 9 dos seus 18 modelos estáticos — então `cmd/deepseek/deepseek-v4-flash`, `cmd/claude-opus-4-7`, `cmd/gpt-5.5`, etc. sumiam do catálogo mesmo com o gateway funcional.

**Fix:** preservar modelos estáticos que o synced não cobre (via `shouldSuppressStaticModelBySyncedCoverage`). Confirmado com dados reais: os 18 estáticos do command-code voltam, e `cmd/deepseek/deepseek-v4-flash` responde 200.

### 2. Mirror funcional de gateway (default-off)
Para o caso geral (dono canônico sem credencial, gateway passthrough com credencial): sintetiza `<gateway-alias>/<model>` no `/v1/models`. Gated 3 níveis (global > provider > model), flag `EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS` (env > DB > default off), seguindo o padrão `ccDiscoveryAliases`.

## Arquivos
- `src/app/api/v1/models/catalog.ts` — fix synced-substitution + helper puro
- `open-sse/utils/functionalGatewayMirrors.ts` — synthesizer puro (novo)
- `src/app/api/v1/models/functionalGatewayPredicate.ts` — gate predicate (novo)
- `src/lib/db/functionalGatewayMirrors.ts` — DB gate (novo)
- `src/app/api/v1/models/catalogResponse.ts` — wiring do mirror no post-filter
- `src/shared/constants/featureFlagDefinitions.ts` — flag `EXPOSE_FUNCTIONAL_GATEWAY_MIRRORS`
- `src/i18n/messages/*.json` — chave i18n da flag (43 locales)

## Testes
17 testes novos (TDD, falhando-antes → passando-depois):
- `catalog-synced-static-preservation.test.ts` (4)
- `functional-gateway-mirrors-append.test.ts` (4)
- `functional-gateway-predicate.test.ts` (3)
- `functional-gateway-mirrors-db.test.ts` (4)
- `models-catalog-functional-gateway.test.ts` (2)
- + atualização do inventário `feature-flags-settings.test.ts` (42→43)

## Validação
- `typecheck:core` ✅ · lint (com suppressions) ✅ · gate i18n-ui-coverage ✅
- 110+ testes unit de catálogo/alias/feature-flags ✅
- Vitest: 6 falhas **pré-existentes** (js-tiktoken/base64-js quebrado no node_modules do ambiente — idêntico no main checkout na base)

## Validação pendente (após deploy)
- `curl /v1/models | grep 'cmd/deepseek/deepseek-v4-flash'` → deve aparecer
- Request `cmd/deepseek/deepseek-v4-flash` → deve retornar 200