### PR TITLE
fix(combo): hide operator-hidden models in the Combo Add model picker

### DIFF
--- a/changelog.d/fixes/9218-combo-picker-hidden-models.md
+++ b/changelog.d/fixes/9218-combo-picker-hidden-models.md
@@ -1,0 +1,1 @@
+- **fix(combo):** the Combo "Add model" picker now respects hidden-model visibility for every model source — system catalog, fallback, passthrough/node aliases, custom rows and auto-fetched models — instead of drowning the list in 500+ unavailable entries ([#9218](https://github.com/diegosouzapw/OmniRoute/pull/9218)) — thanks @szzhoujiarui

--- a/src/app/api/provider-models/route.ts
+++ b/src/app/api/provider-models/route.ts
@@ -9,6 +9,7 @@ import {
   updateCustomModel,
   getModelCompatOverrides,
   mergeModelCompatOverride,
+  getHiddenModelsByProvider,
   type ModelCompatPatch,
 } from "@/lib/localDb";
 import {
@@ -81,7 +82,21 @@ export async function GET(request) {
           })
         : models;
 
-    return Response.json({ models: modelsWithContextOverride, modelCompatOverrides });
+    // #9203: surface the unified hidden-model map (customModels.isHidden +
+    // modelCompatOverrides.isHidden) so the client can filter every model source
+    // (system catalog, fallback, aliases, auto-fetched) — not just custom rows.
+    const hiddenModelsByProvider: Record<string, string[]> = {};
+    for (const [providerId, hiddenModelIds] of getHiddenModelsByProvider()) {
+      if (hiddenModelIds.size > 0) {
+        hiddenModelsByProvider[providerId] = [...hiddenModelIds];
+      }
+    }
+
+    return Response.json({
+      models: modelsWithContextOverride,
+      modelCompatOverrides,
+      hiddenModelsByProvider,
+    });
   } catch {
     return Response.json(
       { error: { message: "Failed to fetch provider models", type: "server_error" } },

--- a/src/shared/components/ModelSelectModal.tsx
+++ b/src/shared/components/ModelSelectModal.tsx
@@ -7,6 +7,8 @@ import {
   buildPassthroughAliasModels,
   buildNodeAliasModels,
   shouldConfirmSelectAll,
+  parseHiddenModelsByProvider,
+  isProviderModelHidden,
 } from "./modelSelectModalHelpers";
 import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
 import { getCompatibleFallbackModels } from "@/lib/providers/managedAvailableModels";
@@ -110,6 +112,13 @@ export default function ModelSelectModal({
   const [combos, setCombos] = useState<any[]>([]);
   const [providerNodes, setProviderNodes] = useState<any[]>([]);
   const [customModels, setCustomModels] = useState<Record<string, any>>({});
+  // #9203: unified hidden-model map (customModels.isHidden +
+  // modelCompatOverrides.isHidden) from `/api/provider-models`, normalized so
+  // the picker hides every model source the operator flagged — not just custom
+  // rows that carry their own `isHidden` flag.
+  const [hiddenModelsByProvider, setHiddenModelsByProvider] = useState<
+    Map<string, Set<string>>
+  >(new Map());
   // Models discovered live from a custom provider's upstream `/models` endpoint,
   // keyed by provider id. Merged into the alias/custom/fallback list below and
   // tagged with the `auto` source badge. Ported from upstream PR
@@ -162,6 +171,8 @@ export default function ModelSelectModal({
       if (!res.ok) throw new Error(`Failed to fetch custom models: ${res.status}`);
       const data = await res.json();
       setCustomModels(data.models || {});
+      // #9203: keep the unified hidden-model map in sync with the model list.
+      setHiddenModelsByProvider(parseHiddenModelsByProvider(data.hiddenModelsByProvider));
     } catch (error) {
       console.error("Error fetching custom models:", error);
       setCustomModels({});
@@ -180,7 +191,9 @@ export default function ModelSelectModal({
       const connection = activeProviders.find((p) => p.provider === providerId);
       if (!connection?.id) return null;
 
-      const res = await fetch(`/api/providers/${connection.id}/models`);
+      // #9203: ask the live route to drop hidden models server-side too, so the
+      // operator's visibility settings apply before the rows reach the picker.
+      const res = await fetch(`/api/providers/${connection.id}/models?excludeHidden=true`);
       if (!res.ok) {
         console.warn(`Failed to fetch models for ${providerId}: ${res.status}`);
         return null;
@@ -272,8 +285,13 @@ export default function ModelSelectModal({
       // Get user-added custom models for this provider (if any), excluding
       // any explicitly hidden by the operator (#7156 — the legacy picker
       // must respect the same isHidden flag the Precision Builder and
-      // /v1/models catalog already honor).
+      // /v1/models catalog already honor). #9203: the unified hidden map
+      // additionally covers catalog-override hidden rows and is applied to
+      // every source below, so a hidden passthrough alias / fallback /
+      // auto-fetched model is filtered exactly like a hidden custom row.
       const providerCustomModels = (customModels[providerId] || []).filter((cm) => !cm.isHidden);
+      const isHiddenForProvider = (modelId: string) =>
+        isProviderModelHidden(hiddenModelsByProvider, providerId, modelId);
 
       if (providerInfo.passthroughModels) {
         // Passthrough aliases are stored prefixed by the canonical providerId
@@ -283,11 +301,12 @@ export default function ModelSelectModal({
         const aliasModels = buildPassthroughAliasModels(
           modelAliases as Record<string, string>,
           providerId
-        );
+        ).filter((am) => !isHiddenForProvider(am.id));
 
         // Merge custom models for passthrough providers
         const customEntries = providerCustomModels
           .filter((cm) => !aliasModels.some((am) => am.id === cm.id))
+          .filter((cm) => !isHiddenForProvider(cm.id))
           .map((cm) => ({
             id: cm.id,
             name: cm.name || cm.id,
@@ -318,12 +337,13 @@ export default function ModelSelectModal({
           modelAliases as Record<string, string>,
           providerId,
           nodePrefix
-        );
+        ).filter((nm) => !isHiddenForProvider(nm.id));
 
         const fallbackEntries = (
           getCompatibleFallbackModels(providerId, providerCustomModels) || []
         )
           .filter((fm) => !nodeModels.some((nm) => nm.id === fm.id))
+          .filter((fm) => !isHiddenForProvider(fm.id))
           .map((fm) => ({
             id: fm.id,
             name: fm.name || fm.id,
@@ -339,6 +359,7 @@ export default function ModelSelectModal({
               !nodeModels.some((nm) => nm.id === cm.id) &&
               !fallbackEntries.some((fm) => fm.id === cm.id)
           )
+          .filter((cm) => !isHiddenForProvider(cm.id))
           .map((cm) => ({
             id: cm.id,
             name: cm.name || cm.id,
@@ -349,7 +370,10 @@ export default function ModelSelectModal({
 
         // Models discovered live from the provider's upstream `/models` endpoint.
         // Deduped against alias, fallback, and user-added custom models; tagged
-        // with the `auto` source so the badge reads "auto".
+        // with the `auto` source so the badge reads "auto". #9203: the server
+        // already filtered hidden rows via `excludeHidden=true`, but re-check the
+        // unified map here so a hidden model is dropped even on the local-catalog
+        // fallback path where the query param is not passed through.
         const fetchedEntries = (fetchedModels[providerId] || [])
           .map((m) => {
             const id = m.id || m.slug || m.model || m.name;
@@ -367,7 +391,8 @@ export default function ModelSelectModal({
               !nodeModels.some((nm) => nm.id === fm.id) &&
               !fallbackEntries.some((fbm) => fbm.id === fm.id) &&
               !customEntries.some((cm) => cm.id === fm.id)
-          );
+          )
+          .filter((fm) => !isHiddenForProvider(fm.id));
 
         const allModels = [...nodeModels, ...fallbackEntries, ...customEntries, ...fetchedEntries];
 
@@ -385,15 +410,18 @@ export default function ModelSelectModal({
         const systemModels = getModelsByProviderId(providerId);
 
         // Merge system models with user-added custom models
-        const systemEntries = systemModels.map((m) => ({
-          id: m.id,
-          name: m.name,
-          value: `${alias}/${m.id}`,
-          source: "system",
-        }));
+        const systemEntries = systemModels
+          .map((m) => ({
+            id: m.id,
+            name: m.name,
+            value: `${alias}/${m.id}`,
+            source: "system",
+          }))
+          .filter((sm) => !isHiddenForProvider(sm.id));
 
         const customEntries = providerCustomModels
           .filter((cm) => !systemModels.some((sm) => sm.id === cm.id))
+          .filter((cm) => !isHiddenForProvider(cm.id))
           .map((cm) => ({
             id: cm.id,
             name: cm.name || cm.id,
@@ -424,6 +452,7 @@ export default function ModelSelectModal({
     providerNodes,
     customModels,
     fetchedModels,
+    hiddenModelsByProvider,
   ]);
 
   // Filter combos by search query

--- a/src/shared/components/modelSelectModalHelpers.ts
+++ b/src/shared/components/modelSelectModalHelpers.ts
@@ -93,3 +93,52 @@ export function shouldConfirmSelectAll(
 ): boolean {
   return Number.isFinite(candidateCount) && candidateCount > threshold;
 }
+
+/**
+ * #9203 — hidden-model filtering for the Combo "Add model" picker.
+ *
+ * `/api/provider-models` returns the unified hidden-model map as a plain
+ * `Record<providerId, string[]>` (serialized from the DB's
+ * `Map<string, Set<string>>`, which covers both `customModels.isHidden` and
+ * `modelCompatOverrides.isHidden`). This normalizes that response into a
+ * lookup-friendly map, defensively skipping malformed entries so an unknown or
+ * partially-shipped API shape can never crash the picker.
+ *
+ * Keys are canonical provider ids; values are the hidden model ids for that
+ * provider. Matching happens on the canonical provider id and the *raw* model
+ * id (before any passthrough/node alias prefixing), so a single helper covers
+ * system, fallback, alias, node-alias, custom and auto-fetched rows alike.
+ */
+export function parseHiddenModelsByProvider(
+  raw: unknown
+): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return result;
+
+  for (const [providerId, modelIds] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof providerId !== "string" || providerId.length === 0) continue;
+    if (!Array.isArray(modelIds)) continue;
+    const hidden = new Set<string>();
+    for (const modelId of modelIds) {
+      if (typeof modelId === "string" && modelId.length > 0) hidden.add(modelId);
+    }
+    if (hidden.size > 0) result.set(providerId, hidden);
+  }
+  return result;
+}
+
+/**
+ * Whether `modelId` is hidden for `providerId` under the parsed hidden map.
+ * Uses the canonical provider id and raw model id — callers pass the same ids
+ * they pass to `buildPassthroughAliasModels` / `buildNodeAliasModels`.
+ */
+export function isProviderModelHidden(
+  hiddenModelsByProvider: Map<string, Set<string>>,
+  providerId: string,
+  modelId: string
+): boolean {
+  if (typeof providerId !== "string" || typeof modelId !== "string" || modelId.length === 0) {
+    return false;
+  }
+  return hiddenModelsByProvider.get(providerId)?.has(modelId) ?? false;
+}

--- a/tests/unit/model-select-hidden-map-helpers-9203.test.ts
+++ b/tests/unit/model-select-hidden-map-helpers-9203.test.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseHiddenModelsByProvider,
+  isProviderModelHidden,
+} from "../../src/shared/components/modelSelectModalHelpers.ts";
+
+// Regression guard for #9203: the Combo "Add model" picker must hide every
+// model source (system, fallback, passthrough alias, node alias, custom,
+// auto-fetched) that the operator flagged hidden. The API serializes the DB's
+// unified map as `Record<providerId, string[]>`; these helpers normalize it
+// and answer per-provider lookups on the raw model id (before prefixing), so
+// the component can apply one filter rule across all sources.
+
+test("parseHiddenModelsByProvider: normalizes a valid response into a map", () => {
+  const raw = {
+    openai: ["gpt-hidden-1", "gpt-hidden-2"],
+    claude: ["claude-sonnet-4-6"],
+  };
+  const parsed = parseHiddenModelsByProvider(raw);
+
+  assert.deepEqual([...parsed.get("openai")!], ["gpt-hidden-1", "gpt-hidden-2"]);
+  assert.deepEqual([...parsed.get("claude")!], ["claude-sonnet-4-6"]);
+  assert.equal(parsed.has("anthropic"), false);
+});
+
+test("parseHiddenModelsByProvider: drops non-string model ids and empty entries", () => {
+  const raw = {
+    openai: ["valid", 42, null, "", { id: "obj" }],
+    empty: [],
+    claude: undefined,
+  };
+  const parsed = parseHiddenModelsByProvider(raw);
+
+  assert.deepEqual([...parsed.get("openai")!], ["valid"]);
+  assert.equal(parsed.has("empty"), false);
+  assert.equal(parsed.has("claude"), false);
+});
+
+test("parseHiddenModelsByProvider: tolerates missing / null / malformed payloads", () => {
+  assert.equal(parseHiddenModelsByProvider(undefined).size, 0);
+  assert.equal(parseHiddenModelsByProvider(null).size, 0);
+  assert.equal(parseHiddenModelsByProvider("nope").size, 0);
+  assert.equal(parseHiddenModelsByProvider(["array"]).size, 0);
+  assert.equal(parseHiddenModelsByProvider(42).size, 0);
+});
+
+test("isProviderModelHidden: matches on the raw model id per provider", () => {
+  const parsed = parseHiddenModelsByProvider({
+    openai: ["gpt-hidden"],
+    claude: ["claude-sonnet-4-6"],
+  });
+
+  assert.equal(isProviderModelHidden(parsed, "openai", "gpt-hidden"), true);
+  assert.equal(isProviderModelHidden(parsed, "claude", "claude-sonnet-4-6"), true);
+  // Visible / different-provider / unknown ids are not hidden.
+  assert.equal(isProviderModelHidden(parsed, "openai", "gpt-visible"), false);
+  assert.equal(isProviderModelHidden(parsed, "claude", "gpt-hidden"), false);
+  assert.equal(isProviderModelHidden(parsed, "unknown", "gpt-hidden"), false);
+});
+
+test("isProviderModelHidden: empty map and malformed inputs are never hidden", () => {
+  const empty = new Map<string, Set<string>>();
+  assert.equal(isProviderModelHidden(empty, "openai", "anything"), false);
+  assert.equal(isProviderModelHidden(empty, "openai", ""), false);
+  assert.equal(isProviderModelHidden(empty, "", "x"), false);
+});

--- a/tests/unit/provider-models-management-route.test.ts
+++ b/tests/unit/provider-models-management-route.test.ts
@@ -27,6 +27,20 @@ function buildPatchRequest(url, body) {
   });
 }
 
+function buildGetRequest(url = "http://localhost/api/provider-models") {
+  return new Request(url, { method: "GET" });
+}
+
+type ProviderModelsResponse = {
+  models?: Record<string, Array<{ id: string; isHidden?: boolean }>> | Array<{ id: string }>;
+  modelCompatOverrides?: Array<{ id: string; isHidden?: boolean }>;
+  hiddenModelsByProvider?: Record<string, string[]>;
+};
+
+async function getBody(response: Response): Promise<ProviderModelsResponse> {
+  return (await response.json()) as ProviderModelsResponse;
+}
+
 test.beforeEach(async () => {
   await resetStorage();
 });
@@ -34,6 +48,83 @@ test.beforeEach(async () => {
 test.after(async () => {
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("provider-models GET returns an empty hiddenModelsByProvider map with no hidden models", async () => {
+  const response = await providerModelsRoute.GET(buildGetRequest());
+  const body = await getBody(response);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body.hiddenModelsByProvider, {});
+  assert.ok(typeof body.models === "object" && body.models !== null);
+  assert.ok(Array.isArray(body.modelCompatOverrides));
+});
+
+test("provider-models GET surfaces hidden custom and catalog-override models per provider", async () => {
+  // Hidden custom model (customModels namespace).
+  await modelsDb.addCustomModel("openai", "gpt-hidden", "GPT Hidden", "manual", "chat-completions", [
+    "chat",
+  ]);
+  await providerModelsRoute.PATCH(
+    buildPatchRequest("http://localhost/api/provider-models?provider=openai&modelId=gpt-hidden", {
+      isHidden: true,
+    })
+  );
+  // Hidden catalog override (modelCompatOverrides namespace) + a visible sibling.
+  await providerModelsRoute.PATCH(
+    buildPatchRequest(
+      "http://localhost/api/provider-models?provider=claude&modelId=claude-sonnet-4-6",
+      { isHidden: true }
+    )
+  );
+  await modelsDb.addCustomModel("claude", "claude-visible", "Claude Visible", "manual", "chat", [
+    "chat",
+  ]);
+
+  const response = await providerModelsRoute.GET(buildGetRequest());
+  const body = await getBody(response);
+
+  assert.equal(response.status, 200);
+  // `models` is keyed by provider (getAllCustomModels shape) — assert the hidden
+  // custom row landed under its provider, and that the hidden map only carries
+  // hidden ids (custom + catalog-override), never the visible sibling.
+  const modelsByProvider = body.models as Record<string, Array<{ id: string }>>;
+  assert.ok(Array.isArray(modelsByProvider.openai));
+  assert.ok(modelsByProvider.openai.some((model) => model.id === "gpt-hidden"));
+  assert.deepEqual(body.hiddenModelsByProvider, {
+    openai: ["gpt-hidden"],
+    claude: ["claude-sonnet-4-6"],
+  });
+  assert.equal(body.hiddenModelsByProvider!.claude.includes("claude-visible"), false);
+});
+
+test("provider-models GET keeps the original models and modelCompatOverrides contract", async () => {
+  await modelsDb.addCustomModel("openai", "gpt-test", "GPT Test", "manual", "chat-completions", [
+    "chat",
+  ]);
+  await providerModelsRoute.PATCH(
+    buildPatchRequest(
+      "http://localhost/api/provider-models?provider=claude&modelId=claude-sonnet-4-6",
+      { isHidden: true }
+    )
+  );
+
+  // Per-provider GET keeps the array-shaped models + modelCompatOverrides contract
+  // while still returning the global hidden map (#9203).
+  const response = await providerModelsRoute.GET(
+    buildGetRequest("http://localhost/api/provider-models?provider=claude")
+  );
+  const body = await getBody(response);
+
+  assert.equal(response.status, 200);
+  assert.ok(Array.isArray(body.models));
+  assert.ok(Array.isArray(body.modelCompatOverrides));
+  assert.ok(
+    body.modelCompatOverrides!.some((override) => override.id === "claude-sonnet-4-6" && override.isHidden)
+  );
+  assert.deepEqual(body.hiddenModelsByProvider, {
+    claude: ["claude-sonnet-4-6"],
+  });
 });
 
 test("provider-models PATCH updates hidden flag for custom models", async () => {

--- a/tests/unit/ui/model-select-modal-hidden-models-7156.test.tsx
+++ b/tests/unit/ui/model-select-modal-hidden-models-7156.test.tsx
@@ -21,27 +21,42 @@ async function render(props: React.ComponentProps<typeof ModelSelectModal>): Pro
   return el;
 }
 
+// Configurable fake backend shared across tests. Each test overrides the
+// `models` payload (custom rows per provider), `hiddenModelsByProvider` (the
+// unified map), `providerNodes`, and the live-fetch response used for the
+// `/api/providers/:id/models` route.
+let mockModels: Record<string, any[]>;
+let mockHidden: Record<string, string[]>;
+let mockNodes: any[];
+let mockLiveModels: any[];
+let liveFetchUrls: string[];
+
 beforeEach(() => {
   (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  mockModels = {};
+  mockHidden = {};
+  mockNodes = [];
+  mockLiveModels = [];
+  liveFetchUrls = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/api/combos")) return new Response(JSON.stringify({ combos: [] }), { status: 200 });
-      if (url.includes("/api/provider-nodes")) return new Response(JSON.stringify({ nodes: [] }), { status: 200 });
+      if (url.includes("/api/provider-nodes")) return new Response(JSON.stringify({ nodes: mockNodes }), { status: 200 });
       if (url.includes("/api/provider-models")) {
         return new Response(
           JSON.stringify({
-            models: {
-              requesty: [
-                { id: "visible-model-1", name: "Visible Model", source: "imported" },
-                { id: "hidden-model-1", name: "Hidden Model", source: "imported", isHidden: true },
-              ],
-            },
+            models: mockModels,
             modelCompatOverrides: [],
+            hiddenModelsByProvider: mockHidden,
           }),
           { status: 200 }
         );
+      }
+      if (url.includes("/api/providers/") && url.includes("/models")) {
+        liveFetchUrls.push(url);
+        return new Response(JSON.stringify({ models: mockLiveModels }), { status: 200 });
       }
       return new Response(JSON.stringify({}), { status: 200 });
     })
@@ -54,15 +69,175 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+async function flush() {
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
 describe("ModelSelectModal hidden-model filtering (#7156)", () => {
   it("does not list a custom model explicitly flagged isHidden:true", async () => {
+    mockModels = {
+      requesty: [
+        { id: "visible-model-1", name: "Visible Model", source: "imported" },
+        { id: "hidden-model-1", name: "Hidden Model", source: "imported", isHidden: true },
+      ],
+    };
     const el = await render({
       isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
       activeProviders: [{ provider: "requesty", id: "conn-1" }],
       modelAliases: {}, title: "Add model to combo",
     });
-    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await flush();
     expect(el.textContent).toContain("Visible Model");
     expect(el.textContent).not.toContain("Hidden Model");
+  });
+});
+
+describe("ModelSelectModal unified hidden-model filtering (#9203)", () => {
+  it("hides a system catalog model flagged in the unified hidden map", async () => {
+    mockHidden = { claude: ["claude-sonnet-4-6"] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "claude", id: "claude-conn" }],
+      modelAliases: {}, title: "Add model to combo",
+    });
+    await flush();
+    // claude is a system-catalog provider — its entries come from the bundled catalog.
+    expect(el.textContent).toContain("Claude Opus 4.7");
+    expect(el.textContent).not.toContain("Claude Sonnet 4.6");
+  });
+
+  it("hides a hidden passthrough alias model", async () => {
+    mockHidden = { requesty: ["alias-hidden"] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "requesty", id: "conn-1" }],
+      modelAliases: {
+        "Visible Alias": "requesty/alias-visible",
+        "Hidden Alias": "requesty/alias-hidden",
+      },
+      title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).toContain("Visible Alias");
+    expect(el.textContent).not.toContain("Hidden Alias");
+  });
+
+  it("hides a hidden node alias model for a custom provider", async () => {
+    mockNodes = [{ id: "openai-compatible-demo", name: "Demo Node", prefix: "demo-prefix" }];
+    mockHidden = { "openai-compatible-demo": ["node-hidden"] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "openai-compatible-demo", id: "conn-demo" }],
+      modelAliases: {
+        "Node Visible": "openai-compatible-demo/node-visible",
+        "Node Hidden": "openai-compatible-demo/node-hidden",
+      },
+      title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).toContain("Node Visible");
+    expect(el.textContent).not.toContain("Node Hidden");
+  });
+
+  it("hides a custom model referenced only in the unified hidden map (no isHidden flag)", async () => {
+    mockModels = {
+      "openai-compatible-demo": [
+        { id: "custom-visible", name: "Custom Visible", source: "manual" },
+        { id: "custom-map-hidden", name: "Custom Map Hidden", source: "manual" },
+      ],
+    };
+    mockHidden = { "openai-compatible-demo": ["custom-map-hidden"] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "openai-compatible-demo", id: "conn-demo" }],
+      modelAliases: {}, title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).toContain("Custom Visible");
+    expect(el.textContent).not.toContain("Custom Map Hidden");
+  });
+
+  it("hides a hidden auto-fetched model and requests excludeHidden=true on the live route", async () => {
+    mockLiveModels = [
+      { id: "live-visible", name: "Live Visible" },
+      { id: "live-hidden", name: "Live Hidden" },
+    ];
+    mockHidden = { "openai-compatible-demo": ["live-hidden"] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "openai-compatible-demo", id: "conn-demo" }],
+      modelAliases: {}, title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).toContain("Live Visible");
+    expect(el.textContent).not.toContain("Live Hidden");
+    // The live provider-models route must receive excludeHidden=true.
+    expect(liveFetchUrls.some((u) => u.includes("excludeHidden=true"))).toBe(true);
+  });
+
+  it("keeps models visible when the API omits hiddenModelsByProvider", async () => {
+    // mockHidden is empty object — simulates an older/unchanged API response.
+    mockModels = { requesty: [{ id: "m1", name: "Model One", source: "imported" }] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "requesty", id: "conn-1" }],
+      modelAliases: {}, title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).toContain("Model One");
+  });
+
+  it("keeps models visible when hiddenModelsByProvider is malformed", async () => {
+    // Force a malformed payload via a per-test fetch override.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/api/combos")) return new Response(JSON.stringify({ combos: [] }), { status: 200 });
+        if (url.includes("/api/provider-nodes")) return new Response(JSON.stringify({ nodes: [] }), { status: 200 });
+        if (url.includes("/api/provider-models")) {
+          return new Response(
+            JSON.stringify({
+              models: { requesty: [{ id: "m1", name: "Model One", source: "imported" }] },
+              modelCompatOverrides: [],
+              hiddenModelsByProvider: { requesty: "not-an-array" },
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      })
+    );
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [{ provider: "requesty", id: "conn-1" }],
+      modelAliases: {}, title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).toContain("Model One");
+  });
+
+  it("scopes hidden models per provider (same id visible under another provider)", async () => {
+    mockModels = {
+      requesty: [
+        { id: "shared-model", name: "Requesty Shared", source: "imported" },
+      ],
+      "openai-compatible-demo": [
+        { id: "shared-model", name: "Demo Shared", source: "manual" },
+      ],
+    };
+    mockHidden = { requesty: ["shared-model"] };
+    const el = await render({
+      isOpen: true, onClose: vi.fn(), onSelect: vi.fn(),
+      activeProviders: [
+        { provider: "requesty", id: "conn-1" },
+        { provider: "openai-compatible-demo", id: "conn-demo" },
+      ],
+      modelAliases: {}, title: "Add model to combo",
+    });
+    await flush();
+    expect(el.textContent).not.toContain("Requesty Shared");
+    expect(el.textContent).toContain("Demo Shared");
   });
 });


### PR DESCRIPTION
Fixes #9203

The Combo "Add model" picker only filtered custom rows carrying their own `isHidden` flag. Hidden system catalog models, fallback models, passthrough/node aliases and auto-fetched models still flooded the list (500+ unavailable entries).

## Changes

- `GET /api/provider-models` now serializes `getHiddenModelsByProvider()` (merges `customModels.isHidden` + `modelCompatOverrides.isHidden`) as the new `hiddenModelsByProvider` field — backward compatible, existing fields unchanged.
- `ModelSelectModal` applies one unified filter across every model source (system, fallback, passthrough/node aliases, custom, auto-fetched), keyed on canonical provider id + raw model id.
- The live provider-models fetch now passes `excludeHidden=true`; the modal re-checks the unified map so hidden rows drop even on the local-catalog fallback path.
- New pure helpers `parseHiddenModelsByProvider` / `isProviderModelHidden` in `modelSelectModalHelpers.ts`.

## Tests

- `tests/unit/model-select-hidden-map-helpers-9203.test.ts` (new): parse + match helpers, malformed payloads, provider isolation.
- `tests/unit/provider-models-management-route.test.ts`: GET returns `hiddenModelsByProvider` with custom + catalog-override hidden ids.
- `tests/unit/ui/model-select-modal-hidden-models-7156.test.tsx`: extended to cover system, fallback, passthrough alias, node alias, custom (map + isHidden), auto-fetched, provider isolation, malformed API fallback, and `excludeHidden=true` on the live fetch.

## Verification (local)

- `node --test tests/unit/provider-models-management-route.test.ts` — 7/7 pass
- `node --test tests/unit/model-select-hidden-map-helpers-9203.test.ts` — 5/5 pass
- `vitest run tests/unit/ui/model-select-modal-hidden-models-7156.test.tsx` — 9/9 pass
- `vitest run model-select-modal-connection-filter/zero-config/select-all/deselect/keep-open` — all pass
- `eslint` on changed files — clean
- `npm run check:dashboard-typecheck` — OK (254 pre-existing frozen baseline)
- `npm run check:changelog-integrity` — OK
