### PR TITLE
fix(codex): normalize additional_tools passthrough items

### DIFF
--- a/changelog.d/fixes/9219-codex-additional-tools-normalization.md
+++ b/changelog.d/fixes/9219-codex-additional-tools-normalization.md
@@ -1,0 +1,1 @@
+- **fix(codex):** normalize additional_tools passthrough items. (thanks @SalyyS1)

--- a/open-sse/utils/responsesInputNormalization.ts
+++ b/open-sse/utils/responsesInputNormalization.ts
@@ -46,8 +46,17 @@ function normalizeCodexResponsesInputItem(itemValue: unknown): unknown {
   const role = typeof item.role === "string" ? item.role : "user";
   const type = typeof item.type === "string" ? item.type : "";
 
+  if (type === "additional_tools") {
+    delete item.content;
+    return item;
+  }
+
   if (!type && item.content === undefined && typeof item.text === "string") {
-    return { type: "message", role, content: [{ type: textPartTypeForRole(role), text: item.text }] };
+    return {
+      type: "message",
+      role,
+      content: [{ type: textPartTypeForRole(role), text: item.text }],
+    };
   }
 
   if (!type && role) item.type = "message";

--- a/tests/unit/codex-responses-passthrough-strip-3317.test.ts
+++ b/tests/unit/codex-responses-passthrough-strip-3317.test.ts
@@ -39,6 +39,32 @@ test("codex native responses passthrough strips client-only params (#3317)", asy
   assert.ok(Array.isArray(result.input), "input array preserved");
 });
 
+test("codex native responses passthrough normalizes additional_tools items", async () => {
+  const executor = new CodexExecutor();
+  const messageContent = [{ type: "input_text", text: "run the terminal tool" }];
+  const tools = [{ type: "function", name: "terminal", parameters: { type: "object" } }];
+  const body = {
+    _nativeCodexPassthrough: true,
+    model: "gpt-5.5",
+    input: [
+      {
+        type: "additional_tools",
+        role: "developer",
+        content: [{ type: "input_text", text: "unsupported wrapper content" }],
+        tools,
+      },
+      { type: "message", role: "user", content: messageContent },
+    ],
+  };
+
+  const result = (await executor.transformRequest("gpt-5.5", body, true, {} as never)) as {
+    input: Array<Record<string, unknown>>;
+  };
+
+  assert.deepEqual(result.input[0], { type: "additional_tools", role: "developer", tools });
+  assert.deepEqual(result.input[1], { type: "message", role: "user", content: messageContent });
+});
+
 test.after(() => {
   try {
     core.resetDbInstance?.();

--- a/tests/unit/responses-translation-fixes.test.ts
+++ b/tests/unit/responses-translation-fixes.test.ts
@@ -126,6 +126,29 @@ test("Codex Responses input: null input normalizes to an empty list (not [null])
   assert.deepEqual(body.input, []);
 });
 
+test("Codex Responses input: additional_tools drops unsupported content", () => {
+  const body: Record<string, unknown> = {
+    input: [
+      {
+        type: "additional_tools",
+        role: "developer",
+        content: [{ type: "input_text", text: "unsupported wrapper content" }],
+        tools: [{ type: "function", name: "terminal", parameters: { type: "object" } }],
+      },
+    ],
+  };
+
+  normalizeCodexResponsesInput(body);
+
+  assert.deepEqual(body.input, [
+    {
+      type: "additional_tools",
+      role: "developer",
+      tools: [{ type: "function", name: "terminal", parameters: { type: "object" } }],
+    },
+  ]);
+});
+
 test("Codex Responses input: assistant history normalized to output_text (OpenAI/Codex rejects input_text on assistant turns)", () => {
   const body: Record<string, unknown> = {
     input: [


### PR DESCRIPTION
## Summary

Codex Responses passthrough requests containing `additional_tools` items could send an unsupported `content` field upstream, producing errors such as `Unknown parameter: input[0].content`.

This change removes only `content` from `type: "additional_tools"` items while preserving `role`, `tools`, and any other fields. Normal message items remain unchanged.

## Tests

- `node --import tsx/esm --test tests/unit/responses-translation-fixes.test.ts tests/unit/codex-responses-passthrough-strip-3317.test.ts` — 44/44 passed
- `npm run typecheck:core` — passed
- `npm run check:cycles` — passed
- `npm run check:any-budget:t11` — passed
- `npm run check:docs-all` — passed; existing soft documentation drift warnings remain
- `npm run typecheck:noimplicit:core` — inherited release failures in `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`
- `npm run test:vitest` — blocked by missing dependencies in the isolated installation (`zod`, `base64-js`, and VertexAI icon module)
- `npm run check` — integral unit run was interrupted after an unrelated `#6178` MCP failure and an indefinitely reconnecting optional Redis test; the port-specific tests were green within the run

## Attribution

Thanks to [@SalyyS1](https://github.com/SalyyS1) for the original implementation.
