### PR TITLE
fix(azure): normalize GPT-5 chat completion parameters

### DIFF
--- a/changelog.d/fixes/9223-azure-gpt5-chat-parameters.md
+++ b/changelog.d/fixes/9223-azure-gpt5-chat-parameters.md
@@ -1,0 +1,1 @@
+- **fix(azure):** normalize GPT-5 chat completion parameters. (thanks @royanrosyad85)

--- a/open-sse/executors/azure-openai.ts
+++ b/open-sse/executors/azure-openai.ts
@@ -3,6 +3,7 @@ import type { ProviderCredentials } from "./base.ts";
 import { stripTrailingSlashes } from "../utils/urlSanitize.ts";
 
 const DEFAULT_API_VERSION = "2024-12-01-preview";
+const GPT5_OR_REASONING_DEPLOYMENT = /(?:^|[/_-])(?:gpt-5|o(?:1|3|4))(?:[._-]|$)/i;
 
 function normalizeAzureBaseUrl(rawBaseUrl?: string | null): string {
   const normalized = stripTrailingSlashes((rawBaseUrl || "").trim());
@@ -44,5 +45,45 @@ export class AzureOpenAIExecutor extends DefaultExecutor {
 
     headers.Accept = stream ? "text/event-stream" : "application/json";
     return headers;
+  }
+
+  override transformRequest(
+    model: string,
+    body: unknown,
+    stream: boolean,
+    credentials: ProviderCredentials
+  ): unknown {
+    const transformed = super.transformRequest(model, body, stream, credentials);
+    if (!GPT5_OR_REASONING_DEPLOYMENT.test(model)) return transformed;
+    if (!transformed || typeof transformed !== "object" || Array.isArray(transformed)) {
+      return transformed;
+    }
+
+    const original =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>)
+        : null;
+    const normalized = { ...(transformed as Record<string, unknown>) };
+
+    if (original?.max_completion_tokens !== undefined) {
+      normalized.max_completion_tokens = original.max_completion_tokens;
+    } else if (
+      normalized.max_completion_tokens === undefined &&
+      original?.max_tokens !== undefined
+    ) {
+      normalized.max_completion_tokens = original.max_tokens;
+    }
+    delete normalized.max_tokens;
+
+    if (normalized.temperature !== undefined && normalized.temperature !== 1) {
+      delete normalized.temperature;
+    }
+
+    const hasTools = Array.isArray(normalized.tools) && normalized.tools.length > 0;
+    if (hasTools || normalized.reasoning_effort === "none") {
+      delete normalized.reasoning_effort;
+    }
+
+    return normalized;
   }
 }

--- a/tests/unit/azure-openai-executor.test.ts
+++ b/tests/unit/azure-openai-executor.test.ts
@@ -42,3 +42,93 @@ test("AzureOpenAIExecutor uses api-key auth headers instead of Bearer auth", () 
     Accept: "text/event-stream",
   });
 });
+
+test("AzureOpenAIExecutor normalizes GPT-5 token parameters without mutating the source", () => {
+  const executor = new AzureOpenAIExecutor();
+  const body = Object.freeze({
+    max_tokens: 4096,
+    messages: Object.freeze([{ role: "user", content: "Hello" }]),
+  });
+
+  const result = executor.transformRequest("gpt-5-chat-deployment", body, false, {});
+
+  assert.deepEqual(result, {
+    max_completion_tokens: 4096,
+    messages: body.messages,
+  });
+  assert.equal(body.max_tokens, 4096);
+});
+
+test("AzureOpenAIExecutor preserves explicit max_completion_tokens", () => {
+  const executor = new AzureOpenAIExecutor();
+
+  const result = executor.transformRequest(
+    "o3-reasoning-deployment",
+    { max_tokens: 1024, max_completion_tokens: 8192 },
+    false,
+    {}
+  );
+
+  assert.deepEqual(result, { max_completion_tokens: 8192 });
+});
+
+test("AzureOpenAIExecutor omits unsupported GPT-5 temperature values", () => {
+  const executor = new AzureOpenAIExecutor();
+
+  assert.deepEqual(
+    executor.transformRequest("gpt-5-chat-deployment", { temperature: 0.2 }, false, {}),
+    {}
+  );
+  assert.deepEqual(
+    executor.transformRequest("gpt-5-chat-deployment", { temperature: 1 }, false, {}),
+    { temperature: 1 }
+  );
+});
+
+test("AzureOpenAIExecutor removes incompatible reasoning effort and preserves tools", () => {
+  const executor = new AzureOpenAIExecutor();
+  const tools = Object.freeze([{ type: "function", function: { name: "get_weather" } }]);
+  const body = Object.freeze({
+    tools,
+    tool_choice: "auto",
+    reasoning_effort: "medium",
+  });
+
+  const withTools = executor.transformRequest("gpt-5-chat-deployment", body, false, {});
+  const none = executor.transformRequest(
+    "o4-mini-deployment",
+    { reasoning_effort: "none" },
+    false,
+    {}
+  );
+  const withoutTools = executor.transformRequest(
+    "o3-reasoning-deployment",
+    { reasoning_effort: "medium" },
+    false,
+    {}
+  );
+
+  assert.deepEqual(withTools, { tools, tool_choice: "auto" });
+  assert.deepEqual(none, {});
+  assert.deepEqual(withoutTools, { reasoning_effort: "medium" });
+  assert.equal(body.reasoning_effort, "medium");
+});
+
+test("AzureOpenAIExecutor keeps GPT-4 parameters while retaining generic sanitization", () => {
+  const executor = new AzureOpenAIExecutor();
+  const body = {
+    max_tokens: 1024,
+    temperature: 0.2,
+    reasoning_effort: "none",
+    prompt_cache_retention: "24h",
+  };
+
+  const result = executor.transformRequest("gpt-4o-deployment", body, false, {});
+
+  assert.deepEqual(result, {
+    max_tokens: 1024,
+    temperature: 0.2,
+    reasoning_effort: "none",
+  });
+  assert.equal(body.prompt_cache_retention, "24h");
+});


### PR DESCRIPTION
## Summary

- normalize Azure OpenAI GPT-5/o1/o3/o4 Chat Completions parameters
- convert `max_tokens` to `max_completion_tokens` while preserving an explicit `max_completion_tokens`
- omit unsupported custom temperature values and incompatible `reasoning_effort` combinations
- retain the existing generic executor sanitization and leave GPT-4 parameter behavior unchanged

## Validation

- `node --import tsx/esm --test tests/unit/azure-openai-executor.test.ts` (8 passed)
- `npm run typecheck:core`
- `npm run check:cycles`
- `npm run check:any-budget:t11`
- `npm run check:docs-all`
- `npx prettier --check open-sse/executors/azure-openai.ts tests/unit/azure-openai-executor.test.ts`
- `git diff --check`

`npm run typecheck:noimplicit:core` still reports the pre-existing implicit-any debt in `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`; this change introduces no new errors.

The focused test emits the existing local SQLite migration-renumbering warning before running; all Azure assertions pass.

## Attribution

Thanks to [@royanrosyad85](https://github.com/royanrosyad85) for the original implementation.