### PR TITLE
fix(images): refresh OAuth credentials and rotate accounts after 401

### DIFF
--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -19,7 +19,8 @@ import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 import { v1ImageGenerationSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 
-import { getAllCustomModels, resolveProxyForConnection } from "@/lib/localDb";
+import { getAllCustomModels } from "@/lib/db/models";
+import { resolveProxyForConnection } from "@/lib/db/settings";
 import { resolveImageRouteModel } from "@/lib/images/imageRouteModel";
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
@@ -28,6 +29,7 @@ import { generateRequestId } from "@/shared/utils/requestId";
 import { getSpecialtyModelsResponse } from "@/app/api/v1/_shared/specialtyCatalog";
 import { enforceClientApiRouteAuth } from "@/shared/utils/clientApiRouteAuth";
 import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
+import { executeImageWithCredentialFallback } from "@/sse/services/imageCredentialRetry";
 
 export const dynamic = "force-dynamic";
 
@@ -121,7 +123,7 @@ async function postHandler(request, context) {
   body.model = await resolveImageRouteModel(body.model);
 
   // Parse model to get provider
-  let { provider } = parseImageModel(body.model);
+  let { provider, model: requestedModel } = parseImageModel(body.model);
   let isCustomModel = false;
 
   // If not in built-in registry, check custom models tagged for images
@@ -136,6 +138,7 @@ async function postHandler(request, context) {
           const fullId = `${providerId}/${model.id}`;
           if (fullId === body.model) {
             provider = providerId;
+            requestedModel = model.id;
             isCustomModel = true;
             break;
           }
@@ -184,7 +187,12 @@ async function postHandler(request, context) {
   // Get credentials — skip for local providers (authType: "none")
   let credentials = null;
   if (providerConfig && providerConfig.authType !== "none") {
-    credentials = await getProviderCredentialsWithQuotaPreflight(provider);
+    credentials = await getProviderCredentialsWithQuotaPreflight(
+      provider,
+      null,
+      null,
+      requestedModel
+    );
     if (!credentials) {
       return errorResponse(
         HTTP_STATUS.BAD_REQUEST,
@@ -200,7 +208,12 @@ async function postHandler(request, context) {
       );
     }
   } else if (isCustomModel) {
-    credentials = await getProviderCredentialsWithQuotaPreflight(provider);
+    credentials = await getProviderCredentialsWithQuotaPreflight(
+      provider,
+      null,
+      null,
+      requestedModel
+    );
     if (!credentials) {
       return errorResponse(
         HTTP_STATUS.BAD_REQUEST,
@@ -219,47 +232,59 @@ async function postHandler(request, context) {
     // #6928: best-effort per-connection base-URL override lookup for local
     // no-auth media providers (ComfyUI). A connection is optional here — unlike
     // the authType !== "none" branch above, we never 400 when none exists.
-    const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
+    const localCredentials = await getProviderCredentialsWithQuotaPreflight(
+      provider,
+      null,
+      null,
+      requestedModel
+    );
     if (localCredentials && !isAllRateLimitedCredentials(localCredentials)) {
       credentials = localCredentials;
     }
   }
 
-  // Resolve proxy for the connection if credentials exist (#1904)
-  let proxyInfo = null;
-  if (credentials?.connectionId) {
-    try {
-      proxyInfo = await resolveProxyForConnection(credentials.connectionId);
-    } catch {
-      log.debug("PROXY", `Failed to resolve proxy for image provider: ${provider}`);
-    }
-  }
+  const execution = await executeImageWithCredentialFallback({
+    provider,
+    requestedModel,
+    credentials,
+    execute: async (attemptCredentials) => {
+      let proxyInfo = null;
+      if (attemptCredentials?.connectionId) {
+        try {
+          proxyInfo = await resolveProxyForConnection(attemptCredentials.connectionId);
+        } catch {
+          log.debug("PROXY", `Failed to resolve proxy for image provider: ${provider}`);
+        }
+      }
 
-  const generateImage = () =>
-    runWithCallLogApiKeyContext(
-      {
-        apiKeyId: policy.apiKeyInfo?.id ?? null,
-        apiKeyName: policy.apiKeyInfo?.name ?? null,
-      },
-      () =>
-        handleImageGeneration({
-          body,
-          credentials,
-          log,
-          ...(isCustomModel && { resolvedProvider: provider }),
-          signal: request.signal,
-          clientHeaders: publicBaseUrlHeaders(request.headers),
-        })
-    );
+      const generateImage = () =>
+        runWithCallLogApiKeyContext(
+          {
+            apiKeyId: policy.apiKeyInfo?.id ?? null,
+            apiKeyName: policy.apiKeyInfo?.name ?? null,
+          },
+          () =>
+            handleImageGeneration({
+              body,
+              credentials: attemptCredentials,
+              log,
+              ...(isCustomModel && { resolvedProvider: provider }),
+              signal: request.signal,
+              clientHeaders: publicBaseUrlHeaders(request.headers),
+            })
+        );
 
-  // Execute with proxy context when available, direct otherwise (#1904)
-  const result = await (credentials?.connectionId
-    ? runWithProxyContext(proxyInfo?.proxy || null, generateImage).catch((err: any) => ({
-        success: false,
-        status: err.statusCode || 500,
-        error: err.message,
-      }))
-    : generateImage());
+      return attemptCredentials?.connectionId
+        ? runWithProxyContext(proxyInfo?.proxy || null, generateImage).catch((err: any) => ({
+            success: false,
+            status: err.statusCode || 500,
+            error: err.message,
+          }))
+        : generateImage();
+    },
+  });
+  credentials = execution.credentials;
+  const result = execution.result;
 
   if (result.success) {
     await clearRecoveredProviderState(credentials);

--- a/src/app/api/v1/providers/[provider]/images/generations/route.ts
+++ b/src/app/api/v1/providers/[provider]/images/generations/route.ts
@@ -13,6 +13,7 @@ import { v1ImageGenerationSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { enforceClientApiRouteAuth } from "@/shared/utils/clientApiRouteAuth";
 import { runWithCallLogApiKeyContext } from "@/lib/usage/callLogApiKeyContext";
+import { executeImageWithCredentialFallback } from "@/sse/services/imageCredentialRetry";
 
 /**
  * Handle CORS preflight
@@ -71,7 +72,13 @@ export async function POST(request, { params }) {
     );
   }
 
-  const credentials = await getProviderCredentialsWithQuotaPreflight(rawProvider);
+  const requestedModel = body.model.slice(rawProvider.length + 1);
+  let credentials = await getProviderCredentialsWithQuotaPreflight(
+    rawProvider,
+    null,
+    null,
+    requestedModel
+  );
   if (!credentials) {
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,
@@ -87,13 +94,21 @@ export async function POST(request, { params }) {
     );
   }
 
-  const result = await runWithCallLogApiKeyContext(
-    {
-      apiKeyId: policy.apiKeyInfo?.id ?? null,
-      apiKeyName: policy.apiKeyInfo?.name ?? null,
-    },
-    () => handleImageGeneration({ body, credentials, log })
-  );
+  const execution = await executeImageWithCredentialFallback({
+    provider: rawProvider,
+    requestedModel,
+    credentials,
+    execute: (attemptCredentials) =>
+      runWithCallLogApiKeyContext(
+        {
+          apiKeyId: policy.apiKeyInfo?.id ?? null,
+          apiKeyName: policy.apiKeyInfo?.name ?? null,
+        },
+        () => handleImageGeneration({ body, credentials: attemptCredentials, log })
+      ),
+  });
+  credentials = execution.credentials;
+  const result = execution.result;
 
   if (result.success) {
     await clearRecoveredProviderState(credentials);

--- a/src/sse/services/imageCredentialRetry.ts
+++ b/src/sse/services/imageCredentialRetry.ts
@@ -1,0 +1,119 @@
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
+
+import { getProviderCredentialsWithQuotaPreflight } from "./auth";
+import { checkAndRefreshToken } from "./tokenRefresh";
+import * as log from "../utils/logger";
+
+interface ImageGenerationResult {
+  success: boolean;
+  status?: number;
+  error?: unknown;
+  data?: unknown;
+}
+
+interface ImageCredentialRetryOptions {
+  provider: string;
+  requestedModel: string | null;
+  credentials: any;
+  execute: (credentials: any) => Promise<ImageGenerationResult>;
+}
+
+interface ImageCredentialRetryResult {
+  credentials: any;
+  result: ImageGenerationResult;
+}
+
+function connectionIdOf(credentials: any): string | null {
+  const connectionId = credentials?.connectionId;
+  return typeof connectionId === "string" && connectionId.trim().length > 0
+    ? connectionId.trim()
+    : null;
+}
+
+function isCredentialSentinel(credentials: any): boolean {
+  return Boolean(credentials?.allRateLimited || credentials?.allExpired);
+}
+
+async function selectNextCredentials(
+  provider: string,
+  requestedModel: string | null,
+  excludedConnectionIds: Set<string>
+) {
+  return getProviderCredentialsWithQuotaPreflight(provider, null, null, requestedModel, {
+    excludeConnectionIds: Array.from(excludedConnectionIds),
+  });
+}
+
+/**
+ * Keep image requests on the same credential lifecycle as chat requests.
+ *
+ * Each connection is attempted at most once. A refresh failure or upstream 401
+ * excludes only that connection for the current request; it does not mutate the
+ * account into a terminal state because another request may refresh it normally.
+ */
+export async function executeImageWithCredentialFallback({
+  provider,
+  requestedModel,
+  credentials,
+  execute,
+}: ImageCredentialRetryOptions): Promise<ImageCredentialRetryResult> {
+  // Local/no-auth image providers intentionally have no credential row. They
+  // still need one direct attempt, but there is no account identity to refresh
+  // or rotate after a 401.
+  if (!credentials) {
+    return { credentials, result: await execute(credentials) };
+  }
+
+  const excludedConnectionIds = new Set<string>();
+  let currentCredentials = credentials;
+  let lastCredentials = credentials;
+  let lastResult: ImageGenerationResult | null = null;
+
+  while (currentCredentials && !isCredentialSentinel(currentCredentials)) {
+    const connectionId = connectionIdOf(currentCredentials);
+    if (connectionId && excludedConnectionIds.has(connectionId)) break;
+    if (connectionId) excludedConnectionIds.add(connectionId);
+
+    try {
+      currentCredentials = await checkAndRefreshToken(provider, currentCredentials);
+    } catch (error) {
+      log.warn("IMAGE", "Credential refresh failed; trying another image-provider account", {
+        provider,
+        connectionId,
+        error: sanitizeErrorMessage(error instanceof Error ? error : new Error(String(error))),
+      });
+      if (!connectionId) throw error;
+      currentCredentials = await selectNextCredentials(
+        provider,
+        requestedModel,
+        excludedConnectionIds
+      );
+      continue;
+    }
+
+    lastCredentials = currentCredentials;
+    lastResult = await execute(currentCredentials);
+    if (lastResult.success || Number(lastResult.status) !== 401 || !connectionId) {
+      return { credentials: lastCredentials, result: lastResult };
+    }
+
+    log.warn("IMAGE", "Image provider rejected credentials; trying another account", {
+      provider,
+      connectionId,
+    });
+    currentCredentials = await selectNextCredentials(
+      provider,
+      requestedModel,
+      excludedConnectionIds
+    );
+  }
+
+  return {
+    credentials: lastCredentials,
+    result: lastResult || {
+      success: false,
+      status: 401,
+      error: "Authentication failed for all eligible image-provider accounts",
+    },
+  };
+}

--- a/tests/unit/image-generation-route.test.ts
+++ b/tests/unit/image-generation-route.test.ts
@@ -86,15 +86,27 @@ async function resetStorage() {
 async function seedConnection(
   provider: string,
   overrides: {
+    authType?: string;
     apiKey?: string | null;
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: string;
+    projectId?: string;
+    priority?: number;
     providerSpecificData?: Record<string, unknown>;
   } = {}
 ) {
+  const authType = overrides.authType ?? "apikey";
   return providersDb.createProviderConnection({
     provider,
-    authType: "apikey",
+    authType,
     name: `${provider}-${Math.random().toString(16).slice(2, 8)}`,
-    apiKey: overrides.apiKey ?? "test-key",
+    ...(authType === "apikey" ? { apiKey: overrides.apiKey ?? "test-key" } : {}),
+    ...(overrides.accessToken ? { accessToken: overrides.accessToken } : {}),
+    ...(overrides.refreshToken ? { refreshToken: overrides.refreshToken } : {}),
+    ...(overrides.expiresAt ? { expiresAt: overrides.expiresAt } : {}),
+    ...(overrides.projectId ? { projectId: overrides.projectId } : {}),
+    ...(overrides.priority ? { priority: overrides.priority } : {}),
     isActive: true,
     testStatus: "active",
     providerSpecificData: overrides.providerSpecificData ?? {},
@@ -606,4 +618,137 @@ test("v1 image generation POST executes directly when credentials.connectionId i
   const body = (await response.json()) as ImageResponseBody;
   assert.equal(response.status, 200);
   assert.ok(body.data, "should have image data");
+});
+
+test("v1 image generation POST rotates to the next account after an upstream 401", async () => {
+  await seedConnection("openai", { apiKey: "expired-image-key", priority: 1 });
+  await seedConnection("openai", { apiKey: "healthy-image-key", priority: 2 });
+  const authorizationHeaders: string[] = [];
+
+  globalThis.fetch = async (url, options: RequestInit = {}) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    const authorization = new Headers(options.headers).get("authorization") ?? "";
+    authorizationHeaders.push(authorization);
+    if (authorization === "Bearer expired-image-key") {
+      return new Response(JSON.stringify({ error: { message: "expired access token" } }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    assert.equal(authorization, "Bearer healthy-image-key");
+    return new Response(
+      JSON.stringify({ created: 123, data: [{ url: "https://cdn.example.com/rotated.png" }] }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/api/v1/images/generations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "openai/gpt-image-2", prompt: "rotate image account" }),
+    })
+  );
+  const body = (await response.json()) as ImageResponseBody;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.data[0].url, "https://cdn.example.com/rotated.png");
+  assert.deepEqual(authorizationHeaders, ["Bearer expired-image-key", "Bearer healthy-image-key"]);
+});
+
+test("provider-scoped image generation POST uses the shared 401 account fallback", async () => {
+  await seedConnection("openai", { apiKey: "provider-expired-key", priority: 1 });
+  await seedConnection("openai", { apiKey: "provider-healthy-key", priority: 2 });
+  const authorizationHeaders: string[] = [];
+
+  globalThis.fetch = async (_url, options: RequestInit = {}) => {
+    const authorization = new Headers(options.headers).get("authorization") ?? "";
+    authorizationHeaders.push(authorization);
+    if (authorization === "Bearer provider-expired-key") {
+      return new Response(JSON.stringify({ error: { message: "expired access token" } }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({ created: 123, data: [{ url: "https://cdn.example.com/provider.png" }] }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await providerImageRoute.POST(
+    new Request("http://localhost/api/v1/providers/openai/images/generations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-image-2", prompt: "provider route rotation" }),
+    }),
+    { params: Promise.resolve({ provider: "openai" }) }
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(authorizationHeaders, [
+    "Bearer provider-expired-key",
+    "Bearer provider-healthy-key",
+  ]);
+});
+
+test("v1 image generation POST refreshes an expired Antigravity token before dispatch", async () => {
+  await seedConnection("antigravity", {
+    authType: "oauth",
+    accessToken: "expired-antigravity-token",
+    refreshToken: "valid-antigravity-refresh-token",
+    expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    projectId: "test-cloud-code-project",
+  });
+  const calls: Array<{ url: string; authorization: string }> = [];
+
+  globalThis.fetch = async (url, options: RequestInit = {}) => {
+    const stringUrl = String(url);
+    const authorization = new Headers(options.headers).get("authorization") ?? "";
+    calls.push({ url: stringUrl, authorization });
+
+    if (stringUrl.includes("oauth2.googleapis.com/token")) {
+      return new Response(
+        JSON.stringify({
+          access_token: "fresh-antigravity-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+
+    assert.equal(stringUrl, "https://daily-cloudcode-pa.googleapis.com/v1internal:generateContent");
+    assert.equal(authorization, "Bearer fresh-antigravity-token");
+    return new Response(
+      JSON.stringify({
+        response: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: "image/jpeg", data: "ZnJlc2gtaW1hZ2U=" } }],
+              },
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/api/v1/images/generations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "antigravity/gemini-3.1-flash-image",
+        prompt: "refresh before image generation",
+      }),
+    })
+  );
+  const body = (await response.json()) as ImageResponseBody;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.data[0].b64_json, "ZnJlc2gtaW1hZ2U=");
+  assert.equal(calls.filter((call) => call.url.includes("oauth2.googleapis.com/token")).length, 1);
 });


### PR DESCRIPTION
## Summary

- pass the parsed image model id into quota-aware credential selection
- proactively refresh expiring OAuth credentials before image generation
- retry an upstream 401 with each remaining eligible connection at most once
- recalculate per-connection proxy context for every attempt
- share the lifecycle across both image-generation entry points while preserving no-auth providers

Fixes #9230.

## Why

The chat route calls `checkAndRefreshToken()` before dispatch and has account fallback, but `/v1/images/generations` previously selected one credential and sent it unchanged. An expired access token therefore caused an immediate 401 even when its refresh token was valid or another healthy connection was available.

## Validation

- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/image-generation-route.test.ts` (20/20)
- `npm run typecheck:core`
- ESLint on all changed files
- Prettier check on all changed files
- `npm run check:cycles`

New route coverage verifies:

- expired Antigravity OAuth access token is refreshed and persisted before image dispatch;
- upstream 401 rotates to a second account and succeeds;
- provider-scoped image generation uses the same fallback;
- existing no-auth SD WebUI behavior remains successful.