### PR TITLE
fix(ci): merge-queue tolerance for Build (advisory), drops paid-tier batching

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,13 @@
 #   • Fallback path if Mergify misbehaves or the OSS plan changes: the manual
 #     merge-train runbook (docs/ops/MERGE_TRAIN.md) — remove labels, proceed by hand.
 
+# Auto-enqueue (current Mergify model, 2026): auto_merge_conditions in
+# merge_protections_settings — the rules-based queue action / autoqueue path is
+# deprecated (EOL 2026-07-16). The owner-applied `queue` label IS the approval.
+merge_protections_settings:
+  auto_merge_conditions:
+    - label = queue
+
 queue_rules:
   - name: release
     # Any current or future release branch — the reason GitHub's native queue was

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,14 +34,20 @@ queue_rules:
     # is intentionally NOT a condition here: the owner-applied `queue` label IS the
     # approval in this repo's single-maintainer model (see governance header).
     merge_conditions:
-      - "#check-failure=0"
+      # "Zero failures" — EXCEPT the advisory dast-smoke: it is continue-on-error by
+      # design and its GH-hosted CLI build hangs recurrently (drafts #7184/#7221 were
+      # dequeued solely by it). Any OTHER failure still blocks (anti-fail-open kept).
+      - or:
+          - "#check-failure=0"
+          - and:
+              - "#check-failure=1"
+              - check-failure=dast-smoke
       - "#check-pending=0"
       - "#check-success>=1"
       - check-success=Merge integrity (changelog + generated skills)
-    # Batching: validate up to 10 queued PRs together (the manual train's sweet spot);
-    # don't hold a lone PR hostage waiting for siblings.
-    batch_size: 10
-    batch_max_wait_time: 5 min
+    # NO batching: 'Merge Queue Batch' requires a paid Mergify tier (live finding
+    # 2026-07-15 — the queue command fails with "Cannot use Merge Queue batch" on
+    # the free plan). Serial queue (1 PR at a time) still automates the train.
     # Squash keeps the one-commit-per-PR history the CHANGELOG reconciliation expects.
     merge_method: squash
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,14 +41,20 @@ queue_rules:
     # is intentionally NOT a condition here: the owner-applied `queue` label IS the
     # approval in this repo's single-maintainer model (see governance header).
     merge_conditions:
-      # "Zero failures" — EXCEPT the advisory dast-smoke: it is continue-on-error by
-      # design and its GH-hosted CLI build hangs recurrently (drafts #7184/#7221 were
-      # dequeued solely by it). Any OTHER failure still blocks (anti-fail-open kept).
+      # "Zero failures" — EXCEPT the advisory "Build (advisory)" job (quality.yml):
+      # continue-on-error by design, and its GH-hosted Turbopack build hangs
+      # recurrently mid-"Creating an optimized production build" (100% failure rate
+      # across every sampled PR since the job was added 2026-07-27, always killed by
+      # a runner timeout/shutdown signal, never a real compile error). Any OTHER
+      # failure still blocks (anti-fail-open kept). The prior dast-smoke exception
+      # (#7225) was dropped here: dast-smoke's hang (#7226) has been dormant for
+      # weeks (0 failures in the last 30 runs; 2 all-time, none since 2026-07-13) —
+      # carrying its tolerance forward would mask problems it no longer causes.
       - or:
           - "#check-failure=0"
           - and:
               - "#check-failure=1"
-              - check-failure=dast-smoke
+              - check-failure=Build (advisory)
       - "#check-pending=0"
       - "#check-success>=1"
       - check-success=Merge integrity (changelog + generated skills)


### PR DESCRIPTION
## Summary
- Restores #7220's removal of `batch_size`/`batch_max_wait_time` (paid-tier Mergify feature, breaks on the free plan) and #7225's auto-enqueue mechanism (`merge_protections_settings.auto_merge_conditions`), both silently reverted two weeks ago by #7329 (an unrelated cliproxy PR that touched `.mergify.yml` from a stale branch)
- Retargets the merge-queue's advisory-check exception from `dast-smoke` to `Build (advisory)`: evidence review showed `dast-smoke`'s hang (#7226) has been dormant for weeks (0/30 recent runs, 2 failures all-time, none since 2026-07-13), while `Build (advisory)` (added to quality.yml 2026-07-27) has a 100% failure rate on every sampled PR since, confirmed via job logs to be the same class of runner hang (dies mid-"Creating an optimized production build", never a real compile error) — just in a check the old tolerance never covered
- No PR has used the `queue` label since #7329 landed, so both the original regression and the stale targeting went unnoticed until now