### PR TITLE
feat(providers): filter detail connections server-side

### DIFF
--- a/changelog.d/features/9247-provider-detail-connections.md
+++ b/changelog.d/features/9247-provider-detail-connections.md
@@ -1,0 +1,1 @@
+- **feat(providers):** filter provider detail connections server-side while preserving full-page search and pagination. (thanks @RobertsXML)

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderConnections.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderConnections.ts
@@ -26,7 +26,10 @@ import { useTranslations } from "next-intl";
 import { useNotificationStore } from "@/store/notificationStore";
 import { isClaudeCodeCompatibleProvider } from "@/shared/constants/providers";
 import type { ConnectionRowConnection } from "../components/ConnectionRow";
-import { connectionBelongsToProviderPage } from "../../providerPageUtils";
+import {
+  connectionBelongsToProviderPage,
+  getProviderConnectionsRequestUrl,
+} from "../../providerPageUtils";
 import { normalizeCodexLimitPolicy } from "../providerPageHelpers";
 import { useProviderQuotaVisibility } from "./useProviderQuotaVisibility";
 import { useReorderByAvailability } from "./useReorderByAvailability";
@@ -199,8 +202,9 @@ export function useProviderConnections(
 
   const fetchConnections = useCallback(async () => {
     try {
+      const connectionsUrl = getProviderConnectionsRequestUrl(providerId);
       const [connectionsRes, nodesRes] = await Promise.all([
-        fetch("/api/providers", { cache: "no-store" }),
+        fetch(connectionsUrl, { cache: "no-store" }),
         fetch("/api/provider-nodes", { cache: "no-store" }),
       ]);
       const connectionsData = await connectionsRes.json();

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -110,6 +110,13 @@ const PROVIDER_CONNECTION_ALIASES: Record<string, readonly string[]> = {
   "kimi-coding": ["kimi-coding-apikey"],
 };
 
+export function getProviderConnectionsRequestUrl(providerId: string): string {
+  const hasAliases = (PROVIDER_CONNECTION_ALIASES[providerId]?.length ?? 0) > 0;
+  return hasAliases
+    ? "/api/providers"
+    : `/api/providers?provider=${encodeURIComponent(providerId)}`;
+}
+
 export function connectionBelongsToProviderPage(
   connectionProvider: string | null | undefined,
   providerId: string

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -47,6 +47,7 @@ export async function GET(request: Request) {
 
   try {
     const url = new URL(request.url);
+    const provider = url.searchParams.get("provider")?.trim();
     const limitValue = url.searchParams.get("limit");
     const offsetValue = url.searchParams.get("offset");
     const parsedLimit = limitValue ? Number.parseInt(limitValue, 10) : undefined;
@@ -55,9 +56,10 @@ export async function GET(request: Request) {
       Number.isInteger(parsedLimit) && parsedLimit && parsedLimit > 0 ? parsedLimit : undefined;
     const offset =
       Number.isInteger(parsedOffset) && parsedOffset && parsedOffset > 0 ? parsedOffset : 0;
+    const filter = provider ? { provider } : {};
 
-    const connections = await getProviderConnections({}, limit, offset);
-    const total = getProviderConnectionsCount();
+    const connections = await getProviderConnections(filter, limit, offset);
+    const total = getProviderConnectionsCount(filter);
     const revealKeys = isApiKeyRevealEnabled();
 
     // Hide or mask sensitive fields

--- a/tests/unit/provider-connections-fetch-url-2998.test.ts
+++ b/tests/unit/provider-connections-fetch-url-2998.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getProviderConnectionsRequestUrl } from "../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts";
+
+test("provider detail requests only the exact provider when no aliases are configured", () => {
+  assert.equal(getProviderConnectionsRequestUrl("openai"), "/api/providers?provider=openai");
+});
+
+test("provider detail keeps alias-backed pages on the unfiltered request", () => {
+  assert.equal(getProviderConnectionsRequestUrl("alibaba"), "/api/providers");
+  assert.equal(getProviderConnectionsRequestUrl("kimi-coding"), "/api/providers");
+});

--- a/tests/unit/provider-connections-pagination-2998.test.ts
+++ b/tests/unit/provider-connections-pagination-2998.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { makeManagementSessionRequest } from "../helpers/managementSession.ts";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-provider-page-2998-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.JWT_SECRET = "test-jwt-secret-for-provider-pagination-2998";
+process.env.INITIAL_PASSWORD = "admin-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const providersRoute = await import("../../src/app/api/providers/route.ts");
+
+function resetDb() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function createConnection(provider: string, name: string) {
+  await providersDb.createProviderConnection({
+    provider,
+    name,
+    authType: "apikey",
+    apiKey: `${provider}-${name}-key`,
+  });
+}
+
+test.beforeEach(resetDb);
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("GET /api/providers filters and counts before applying limit/offset", async () => {
+  await createConnection("synthetic", "Synthetic A");
+  await createConnection("synthetic", "Synthetic B");
+  await createConnection("poe", "Poe A");
+
+  const response = await providersRoute.GET(
+    await makeManagementSessionRequest(
+      "http://localhost/api/providers?provider=synthetic&limit=1&offset=1"
+    )
+  );
+  const body = (await response.json()) as {
+    connections: Array<{ provider: string }>;
+    total: number;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.total, 2);
+  assert.equal(body.connections.length, 1);
+  assert.equal(body.connections[0].provider, "synthetic");
+});
+
+test("GET /api/providers keeps the unfiltered contract when provider is absent", async () => {
+  await createConnection("synthetic", "Synthetic A");
+  await createConnection("poe", "Poe A");
+
+  const response = await providersRoute.GET(
+    await makeManagementSessionRequest("http://localhost/api/providers")
+  );
+  const body = (await response.json()) as {
+    connections: Array<{ provider: string }>;
+    total: number;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.total, 2);
+  assert.deepEqual(
+    new Set(body.connections.map((connection) => connection.provider)),
+    new Set(["synthetic", "poe"])
+  );
+});


### PR DESCRIPTION
## Summary

- filter provider detail connection requests at the database boundary
- preserve the complete per-provider set used by search, pagination, health filters, and bulk actions
- keep alias-backed Alibaba and Kimi pages on the existing aggregate request path

Thanks @RobertsXML for the original contribution.

## Validation

- targeted provider route and alias regressions: 32/32 passed
- focused TDD suite: 4/4 passed
- Vitest: 291/291 passed
- TypeScript core, dependency cycles, docs, route validation, file-size, and explicit-any gates passed
- real-browser smoke covered login, provider search, OpenAI detail, and Kimi detail with 0 console errors/warnings
- global `npm run check`: ESLint passed and the unit run advanced through thousands of tests; its final summary is blocked by a pre-existing Redis test that keeps reconnecting to an unavailable local port with no runner timeout. The same hang was reproduced on the release-base SHA, where all five assertions in that test passed before the process remained open.