### PR TITLE
fix(cli-tools): enable Apply for compatible providers

### DIFF
--- a/changelog.d/fixes/9250-cli-compatible-provider-apply.md
+++ b/changelog.d/fixes/9250-cli-compatible-provider-apply.md
@@ -1,0 +1,1 @@
+- **fix(cli-tools):** keep Apply enabled for active OpenAI-compatible and Anthropic-compatible providers without static catalog entries. (thanks @lazysaltyfish)

--- a/src/app/(dashboard)/dashboard/cli-code/components/ToolDetailClient.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/ToolDetailClient.tsx
@@ -133,10 +133,55 @@ export default function ToolDetailClient({ toolId, category }: ToolDetailClientP
           });
         }
       });
+
+      if (providerModels.length === 0) {
+        const prefix =
+          typeof conn.providerSpecificData?.prefix === "string" &&
+          conn.providerSpecificData.prefix.trim()
+            ? conn.providerSpecificData.prefix.trim()
+            : alias;
+        const fallbackModels: Array<{ id: string; name: string }> = [];
+        const addFallbackModel = (model: any) => {
+          const id = typeof model?.id === "string" ? model.id.trim() : "";
+          if (!id || fallbackModels.some((candidate) => candidate.id === id)) return;
+          fallbackModels.push({
+            id,
+            name: typeof model?.name === "string" && model.name.trim() ? model.name.trim() : id,
+          });
+        };
+
+        if (typeof conn.defaultModel === "string" && conn.defaultModel.trim()) {
+          addFallbackModel({ id: conn.defaultModel });
+        }
+        if (Array.isArray(conn.providerSpecificData?.customModels)) {
+          conn.providerSpecificData.customModels.forEach(addFallbackModel);
+        }
+        if (fallbackModels.length === 0 && conn.testStatus === "active") {
+          addFallbackModel({ id: "model-id", name: `${prefix}/model-id` });
+        }
+
+        fallbackModels.forEach((model) => {
+          const modelValue = `${prefix}/${model.id}`;
+          if (seenModels.has(modelValue)) return;
+          seenModels.add(modelValue);
+          models.push({
+            value: modelValue,
+            label: modelValue,
+            provider: conn.provider,
+            alias: prefix,
+            connectionName: conn.name,
+            modelId: model.id,
+          });
+        });
+      }
     });
 
     const activeAliases = new Set(
-      activeProviders.map((c) => PROVIDER_ID_TO_ALIAS[c.provider] || c.provider)
+      activeProviders.flatMap((connection) => {
+        const alias = PROVIDER_ID_TO_ALIAS[connection.provider] || connection.provider;
+        const prefix = connection.providerSpecificData?.prefix;
+        return typeof prefix === "string" && prefix.trim() ? [alias, prefix.trim()] : [alias];
+      })
     );
     const activeProviderIds = new Set(activeProviders.map((c) => c.provider));
     dynamicModels.forEach((dm) => {

--- a/tests/unit/ui/ToolDetailClient.test.tsx
+++ b/tests/unit/ui/ToolDetailClient.test.tsx
@@ -106,7 +106,13 @@ vi.mock("@/shared/constants/models", () => ({
 
 // Stub specialized cards — render a testid so we can identify which was rendered
 vi.mock("../../../src/app/(dashboard)/dashboard/cli-code/components/index", () => ({
-  ClaudeToolCard: () => <div data-testid="ClaudeToolCard" />,
+  ClaudeToolCard: ({ hasActiveProviders, availableModels }: any) => (
+    <div
+      data-testid="ClaudeToolCard"
+      data-has-active-providers={String(hasActiveProviders)}
+      data-available-models={JSON.stringify(availableModels)}
+    />
+  ),
   CodexToolCard: () => <div data-testid="CodexToolCard" />,
   DroidToolCard: () => <div data-testid="DroidToolCard" />,
   OpenClawToolCard: () => <div data-testid="OpenClawToolCard" />,
@@ -127,9 +133,8 @@ vi.mock("../../../src/app/(dashboard)/dashboard/cli-code/components/CliproxyapiT
 
 // ── Import after mocks ────────────────────────────────────────────────────────
 
-const { default: ToolDetailClient } = await import(
-  "@/app/(dashboard)/dashboard/cli-code/components/ToolDetailClient"
-);
+const { default: ToolDetailClient } =
+  await import("@/app/(dashboard)/dashboard/cli-code/components/ToolDetailClient");
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -153,7 +158,10 @@ beforeEach(() => {
   (
     globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
   ).IS_REACT_ACT_ENVIRONMENT = true;
-  mockFetch.mockClear();
+  mockFetch.mockReset().mockResolvedValue({
+    ok: true,
+    json: async () => ({ connections: [], keys: [], data: [], cloudEnabled: false }),
+  });
 });
 
 afterEach(() => {
@@ -183,6 +191,93 @@ describe("ToolDetailClient", () => {
     const container = renderDetail("custom", "code");
     await act(async () => {});
     expect(container.querySelector("[data-testid='CustomCliCard']")).not.toBeNull();
+  });
+
+  it("keeps Apply available for an active dynamic compatible provider", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/providers") {
+        return {
+          ok: true,
+          json: async () => ({
+            connections: [
+              {
+                provider: "openai-compatible-chat-node-123",
+                name: "Kimi gateway",
+                isActive: true,
+                testStatus: "active",
+                defaultModel: "Kimi-K3",
+                providerSpecificData: { prefix: "kimi-gateway" },
+              },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ keys: [], data: [], cloudEnabled: false }),
+      };
+    });
+
+    const container = renderDetail("claude", "code");
+    await act(async () => {});
+
+    const card = container.querySelector("[data-testid='ClaudeToolCard']");
+    expect(card?.getAttribute("data-has-active-providers")).toBe("true");
+    expect(JSON.parse(card?.getAttribute("data-available-models") || "[]")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: "kimi-gateway/Kimi-K3",
+          provider: "openai-compatible-chat-node-123",
+          modelId: "Kimi-K3",
+        }),
+      ])
+    );
+  });
+
+  it("accepts compatible-provider models published under the connection prefix", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/providers") {
+        return {
+          ok: true,
+          json: async () => ({
+            connections: [
+              {
+                provider: "anthropic-compatible-node-456",
+                name: "Claude gateway",
+                isActive: true,
+                providerSpecificData: { prefix: "claude-gateway" },
+              },
+            ],
+          }),
+        };
+      }
+      if (url === "/v1/models") {
+        return {
+          ok: true,
+          json: async () => ({ data: [{ id: "claude-gateway/claude-sonnet" }] }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ keys: [], cloudEnabled: false }),
+      };
+    });
+
+    const container = renderDetail("claude", "code");
+    await act(async () => {});
+
+    const card = container.querySelector("[data-testid='ClaudeToolCard']");
+    expect(card?.getAttribute("data-has-active-providers")).toBe("true");
+    expect(JSON.parse(card?.getAttribute("data-available-models") || "[]")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: "claude-gateway/claude-sonnet",
+          modelId: "claude-sonnet",
+        }),
+      ])
+    );
   });
 
   it("renders DefaultToolCard for unknown tool (forge, configType:custom)", async () => {


### PR DESCRIPTION
## Summary

Dynamic OpenAI-compatible and Anthropic-compatible connections use UUID-backed provider IDs that are not present in the static model catalog. The CLI Tools detail page therefore treated an active connection as having no available providers and left Apply disabled.

This port resolves the connection's public prefix and default/custom model fallback, and accepts compatible-provider models already published under that prefix by `/v1/models`. Built-in provider catalog behavior is unchanged.

## Validation

- `tests/unit/ui/ToolDetailClient.test.tsx` plus the `cli-code` and `cli-agents` detail-page regressions: 13/13
- `npm run check:file-size`
- `npm run typecheck:core`
- `npm run check:cycles`
- `npm run check:docs-all`
- `npm run check:route-validation:t06`
- `npm run check:any-budget:t11`
- `npm run test:vitest`: 291/291
- Real Playwright smoke with an isolated temporary instance: compatible model selected and Apply enabled

`npm run typecheck:noimplicit:core` still reports only the release-base errors in `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`. The initial MCP run was blocked by a broken shared `node_modules`; a clean install in this port worktree passed all 34 Vitest suites.

## Attribution

Thanks to [@lazysaltyfish](https://github.com/lazysaltyfish) for the original implementation.
