### PR TITLE
fix(translator): harden Claude format detection for model validation

### DIFF
--- a/changelog.d/fixes/9253-translator-format-detection-2949.md
+++ b/changelog.d/fixes/9253-translator-format-detection-2949.md
@@ -1,0 +1,1 @@
+- **fix(translator):** harden Claude format detection for relative message endpoints and kebab-case version metadata. (thanks @ervareza)

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -135,7 +135,17 @@ export function detectFormatFromEndpoint(body, endpointPath = "") {
 // Thin wrapper for call sites that only have the full request URL (not the bare endpoint
 // path chatCore already threads) — single source of truth stays detectFormatFromEndpoint.
 export function detectFormatFromUrl(body, requestUrl) {
-  return detectFormatFromEndpoint(body, new URL(requestUrl).pathname);
+  const rawUrl = typeof requestUrl === "string" ? requestUrl : "";
+  let pathname = rawUrl;
+  try {
+    // Supplying a base URL keeps relative client endpoints (for example,
+    // `/v1/messages`) valid while preserving pathname-only detection.
+    pathname = new URL(rawUrl || "/", "http://omniroute.local").pathname;
+  } catch {
+    // Fall back to the raw value; detectFormatFromEndpoint is intentionally
+    // safe for unknown or malformed paths.
+  }
+  return detectFormatFromEndpoint(body, pathname);
 }
 
 // Detect request format from body structure
@@ -193,7 +203,7 @@ export function detectFormat(body) {
       if (firstContent?.type === "text" && !body.model?.includes("/")) {
         // Could be Claude or OpenAI multimodal
         // Check for Claude-specific fields
-        if (body.system || body.anthropic_version) {
+        if (body.system || body.anthropic_version || body["anthropic-version"]) {
           return "claude";
         }
         // Check if image format is Claude (source.type) vs OpenAI (image_url.url)
@@ -216,7 +226,7 @@ export function detectFormat(body) {
 
     // If content is string, it's likely OpenAI (Claude also supports this)
     // Check for other Claude-specific indicators
-    if (body.system !== undefined || body.anthropic_version) {
+    if (body.system !== undefined || body.anthropic_version || body["anthropic-version"]) {
       return "claude";
     }
 

--- a/tests/unit/translator-format-detection-2949.test.ts
+++ b/tests/unit/translator-format-detection-2949.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { detectFormat, detectFormatFromUrl } from "../../open-sse/services/provider.ts";
+
+test("detectFormatFromUrl accepts a relative /messages endpoint", () => {
+  assert.equal(
+    detectFormatFromUrl(
+      { messages: [{ role: "user", content: "validate this model" }] },
+      "/v1/messages"
+    ),
+    "claude"
+  );
+});
+
+test("detectFormat recognizes the kebab-case anthropic-version body field", () => {
+  assert.equal(
+    detectFormat({
+      messages: [{ role: "user", content: "validate this model" }],
+      "anthropic-version": "2023-06-01",
+    }),
+    "claude"
+  );
+});


### PR DESCRIPTION
## Summary

- accept relative Claude message endpoints during request-format detection
- recognize kebab-case `anthropic-version` metadata as a Claude-format signal
- preserve the existing endpoint-first detection and absolute-URL behavior

## Attribution

Thanks to [@ervareza](https://github.com/ervareza) for the original implementation.

## Changes

- make `detectFormatFromUrl` parse relative and absolute URLs safely
- add `anthropic-version` detection for array and string message content
- add focused regressions for Claude Code model-validation requests

## Test plan

- [x] focused + neighboring Node tests: 17 passed
- [x] ESLint on changed files
- [x] Prettier on changed files
- [x] `npm run typecheck:core`
- [x] `npm run check:docs-all`
- [x] `npm run check:cycles`
- [ ] `npm run typecheck:noimplicit:core` — blocked by existing implicit-any errors in `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`
- [ ] `npm run test:vitest` — 28 files / 256 tests passed; 6 MCP suites cannot import `js-tiktoken` because the local `base64-js` installation is empty (the same failure reproduces in the release checkout)
- [ ] `npm run check` — lint completed; the broad unit run was interrupted after reproducing the same dependency-layout failure plus credential-dependent 401 checks