### PR TITLE
fix(minimax): normalize unsigned thinking block starts

### DIFF
--- a/changelog.d/fixes/9256-minimax-thinking-signature.md
+++ b/changelog.d/fixes/9256-minimax-thinking-signature.md
@@ -1,0 +1,1 @@
+- **fix(minimax):** add the required empty signature placeholder to unsigned thinking block starts. (thanks @rixzkiye)

--- a/open-sse/config/providers/registry/minimax/cn/index.ts
+++ b/open-sse/config/providers/registry/minimax/cn/index.ts
@@ -12,6 +12,7 @@ export const minimax_cnProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "bearer",
   headers: getAnthropicCompatHeaders(),
+  ensureThinkingSignature: true,
   models: [
     // Keep parity with minimax to ensure model discovery works for minimax-cn connections.
     // #3110: MiniMax M3 — frontier coding model with 1M context

--- a/open-sse/config/providers/registry/minimax/index.ts
+++ b/open-sse/config/providers/registry/minimax/index.ts
@@ -12,6 +12,7 @@ export const minimaxProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "bearer",
   headers: getAnthropicCompatHeaders(),
+  ensureThinkingSignature: true,
   models: [
     // T12/T28: MiniMax default upgraded from M2.5 to M2.7
     // #3110: MiniMax M3 — frontier coding model with 1M context

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -177,6 +177,12 @@ export interface RegistryEntry {
    */
   requiresPlainStringContent?: boolean;
   /**
+   * Anthropic-compatible providers that omit the required `signature` field
+   * from streamed thinking block starts. The passthrough stream adds only an
+   * empty placeholder; later provider `signature_delta` events remain intact.
+   */
+  ensureThinkingSignature?: boolean;
+  /**
    * Protocolos alternativos que este provedor aceita (ex.: um endpoint
    * Anthropic-compatible alem do OpenAI-compatible padrao). A conexao escolhe
    * via providerSpecificData.targetFormat; ver config/providers/alternateFormats.ts.

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1,5 +1,6 @@
 import { translateResponse, initState } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
+import { getRegistryEntry } from "../config/providerRegistry.ts";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb";
 import {
   extractUsage,
@@ -713,6 +714,8 @@ export function createSSEStream(options: StreamOptions = {}) {
   // once per stream — never on the hot per-chunk path.
   const shouldDropResponsesCommentary =
     dropResponsesCommentary ?? isFeatureFlagEnabled("RESPONSES_PASSTHROUGH_DROP_COMMENTARY");
+  const ensureThinkingSignature =
+    provider !== null && getRegistryEntry(provider)?.ensureThinkingSignature === true;
 
   const clientExpectsResponsesStream =
     (mode === STREAM_MODE.PASSTHROUGH
@@ -1595,6 +1598,19 @@ export function createSSEStream(options: StreamOptions = {}) {
                   }
                 } else if (isClaudeSSE) {
                   // Claude SSE: extract usage, track content, forward as-is
+                  let thinkingSignatureInjected = false;
+                  if (
+                    ensureThinkingSignature &&
+                    parsed.type === "content_block_start" &&
+                    parsed.content_block?.type === "thinking" &&
+                    parsed.content_block.signature === undefined
+                  ) {
+                    // Strict Anthropic Messages clients deserialize this field before a
+                    // later signature_delta arrives. Add only the empty envelope
+                    // placeholder; never synthesize or replace a provider signature.
+                    parsed.content_block.signature = "";
+                    thinkingSignatureInjected = true;
+                  }
                   const extracted = extractUsage(parsed);
                   if (extracted) {
                     // Non-destructive merge: never overwrite a positive value with 0
@@ -1636,7 +1652,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                       parsed.delta.thinking
                     );
                   }
-                  if (restoredToolName) {
+                  if (restoredToolName || thinkingSignatureInjected) {
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     injectedUsage = true;
                   }

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1,6 +1,5 @@
 import { translateResponse, initState } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
-import { getRegistryEntry } from "../config/providerRegistry.ts";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb";
 import {
   extractUsage,
@@ -22,6 +21,7 @@ import {
   appendBoundedText,
   buildSyntheticChatChunk,
   hasActiveDeltaValue,
+  injectThinkingSignature,
 } from "./streamHelpers.ts";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { buildOmniRouteSseMetadataComment } from "@/domain/omnirouteResponseMeta";
@@ -710,13 +710,9 @@ export function createSSEStream(options: StreamOptions = {}) {
   }
 
   // Drop internal commentary-phase Responses output before forwarding (#6199).
-  // Explicit option wins; otherwise read the feature flag (default on). Resolved
-  // once per stream — never on the hot per-chunk path.
+  // Explicit option wins; otherwise read the feature flag (default on) — resolved once per stream.
   const shouldDropResponsesCommentary =
     dropResponsesCommentary ?? isFeatureFlagEnabled("RESPONSES_PASSTHROUGH_DROP_COMMENTARY");
-  const ensureThinkingSignature =
-    provider !== null && getRegistryEntry(provider)?.ensureThinkingSignature === true;
-
   const clientExpectsResponsesStream =
     (mode === STREAM_MODE.PASSTHROUGH
       ? clientResponseFormat === FORMATS.OPENAI_RESPONSES
@@ -1598,19 +1594,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   }
                 } else if (isClaudeSSE) {
                   // Claude SSE: extract usage, track content, forward as-is
-                  let thinkingSignatureInjected = false;
-                  if (
-                    ensureThinkingSignature &&
-                    parsed.type === "content_block_start" &&
-                    parsed.content_block?.type === "thinking" &&
-                    parsed.content_block.signature === undefined
-                  ) {
-                    // Strict Anthropic Messages clients deserialize this field before a
-                    // later signature_delta arrives. Add only the empty envelope
-                    // placeholder; never synthesize or replace a provider signature.
-                    parsed.content_block.signature = "";
-                    thinkingSignatureInjected = true;
-                  }
+                  const thinkingSignatureInjected = injectThinkingSignature(parsed, provider);
                   const extracted = extractUsage(parsed);
                   if (extracted) {
                     // Non-destructive merge: never overwrite a positive value with 0

--- a/open-sse/utils/streamHelpers.ts
+++ b/open-sse/utils/streamHelpers.ts
@@ -13,6 +13,7 @@
 
 import { FORMATS } from "../translator/formats.ts";
 import { hasAnyReasoningSignal } from "./reasoningFields.ts";
+import { getRegistryEntry } from "../config/providerRegistry.ts";
 
 type SSEPayloadOptions = {
   eventType?: string;
@@ -522,4 +523,25 @@ export function hasActiveDeltaValue(value: unknown): boolean {
     return Object.values(value).some((entry) => hasActiveDeltaValue(entry));
   }
   return value !== null && value !== undefined;
+}
+
+// Claude SSE content_block_start normalization for providers (e.g. MiniMax) whose thinking
+// blocks omit `signature` on the opening event. Strict Anthropic Messages clients deserialize
+// this field before a later signature_delta arrives — inject only the empty envelope
+// placeholder, never synthesize/replace a provider-supplied signature.
+export function injectThinkingSignature(
+  parsed: { type?: string; content_block?: { type?: string; signature?: string } },
+  provider: string | null
+): boolean {
+  if (
+    provider !== null &&
+    getRegistryEntry(provider)?.ensureThinkingSignature === true &&
+    parsed.type === "content_block_start" &&
+    parsed.content_block?.type === "thinking" &&
+    parsed.content_block.signature === undefined
+  ) {
+    parsed.content_block.signature = "";
+    return true;
+  }
+  return false;
 }

--- a/tests/unit/minimax-thinking-signature-2706.test.ts
+++ b/tests/unit/minimax-thinking-signature-2706.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+import { getRegistryEntry } from "../../open-sse/config/providerRegistry.ts";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.ts";
+
+const encoder = new TextEncoder();
+
+async function runPassthrough(provider: string, input: string, chunkSize = input.length) {
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let index = 0; index < input.length; index += chunkSize) {
+        controller.enqueue(encoder.encode(input.slice(index, index + chunkSize)));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(
+    source.pipeThrough(
+      createPassthroughStreamWithLogger(
+        provider,
+        null,
+        null,
+        "MiniMax-M2.7",
+        "minimax-thinking-signature-2706",
+        { messages: [] },
+        null,
+        null,
+        null,
+        FORMATS.CLAUDE
+      )
+    )
+  ).text();
+}
+
+function parseDataEvents(raw: string): Record<string, unknown>[] {
+  return raw
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice(6))
+    .filter((payload) => payload && payload !== "[DONE]")
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>);
+}
+
+function thinkingStart(signature?: string) {
+  return {
+    type: "content_block_start",
+    index: 0,
+    content_block: {
+      type: "thinking",
+      thinking: "",
+      ...(signature === undefined ? {} : { signature }),
+    },
+  };
+}
+
+test("MiniMax registries opt into thinking signature normalization", () => {
+  assert.equal(getRegistryEntry("minimax")?.ensureThinkingSignature, true);
+  assert.equal(getRegistryEntry("minimax-cn")?.ensureThinkingSignature, true);
+});
+
+test("unsigned MiniMax thinking block starts receive an empty signature", async () => {
+  const event = thinkingStart();
+  const output = await runPassthrough(
+    "minimax",
+    `event: content_block_start\ndata: ${JSON.stringify(event)}\n\n`
+  );
+  const firstEvent = parseDataEvents(output)[0];
+
+  assert.equal((firstEvent.content_block as Record<string, unknown>).signature, "");
+});
+
+test("fragmented MiniMax streams preserve real signatures and later signature deltas", async () => {
+  const start = thinkingStart();
+  const signatureDelta = {
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "signature_delta", signature: "minimax-signature" },
+  };
+  const input =
+    `event: content_block_start\ndata: ${JSON.stringify(start)}\n\n` +
+    `event: content_block_delta\ndata: ${JSON.stringify(signatureDelta)}\n\n`;
+  const events = parseDataEvents(await runPassthrough("minimax-cn", input, 7));
+
+  assert.equal((events[0].content_block as Record<string, unknown>).signature, "");
+  assert.deepEqual(events[1].delta, signatureDelta.delta);
+
+  const existing = parseDataEvents(
+    await runPassthrough(
+      "minimax",
+      `event: content_block_start\ndata: ${JSON.stringify(thinkingStart("real-signature"))}\n\n`
+    )
+  )[0];
+  assert.equal((existing.content_block as Record<string, unknown>).signature, "real-signature");
+});
+
+test("unrelated providers do not receive the MiniMax signature placeholder", async () => {
+  const events = parseDataEvents(
+    await runPassthrough(
+      "deepseek",
+      `event: content_block_start\ndata: ${JSON.stringify(thinkingStart())}\n\n`
+    )
+  );
+
+  assert.equal("signature" in (events[0].content_block as Record<string, unknown>), false);
+});


### PR DESCRIPTION
## Summary

- add the empty `signature` envelope field required by strict Anthropic Messages clients when MiniMax omits it from a thinking block start
- scope the normalization to the `minimax` and `minimax-cn` registry entries
- preserve existing block signatures, later `signature_delta` events, fragmented SSE frames, and unrelated providers

## Attribution

Thanks to [@rixzkiye](https://github.com/rixzkiye) for the original implementation.

## Changes

- add a typed provider-registry capability for unsigned thinking block starts
- resolve the capability once per stream and reserialize only affected Claude SSE events
- add focused coverage for both MiniMax variants, fragmentation, signature preservation, and provider isolation

## Test plan

- [x] RED before implementation: 3 failed / 1 passed
- [x] focused + neighboring Node tests: 58 passed
- [x] ESLint on changed files
- [x] Prettier on changed files
- [x] `npm run typecheck:core`
- [x] `npm run check:cycles`
- [x] `npm run check:any-budget:t11`
- [x] `npm run check:route-validation:t06`
- [x] `npm run check:docs-all`
- [ ] `npm run typecheck:noimplicit:core` — blocked by existing implicit-any errors in `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`
- [ ] `npm run test:vitest` — 28 files / 256 tests passed; 6 MCP suites cannot import `js-tiktoken` because the shared local `base64-js` installation is empty

