### PR TITLE
docs(marketing): track Cheaper Inference link clicks via ?utm_source=omniroute

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ curl http://localhost:20128/v1/chat/completions \
   </tr>
   <tr>
     <td align="center" width="150">
-      <a href="https://cheaperinference.com">
+      <a href="https://cheaperinference.com/?utm_source=omniroute">
         <img src="public/providers/cheaperinference.svg" width="64" alt="Cheaper Inference"/>
       </a>
       <br/><b>Cheaper Inference</b><br/><sub>cheaperinference.com</sub><br/><br/>
@@ -252,7 +252,7 @@ curl http://localhost:20128/v1/chat/completions \
     <td>
       Thanks to <b>Cheaper Inference</b>, an OmniRoute Open Source Friend, for backing this project! Cheaper Inference is a cost-ranked gateway that resells 42 frontier models — Claude, GPT-5.x, Gemini, Kimi K3, GLM, DeepSeek, Grok and MiniMax — behind one OpenAI-compatible endpoint, routing each request to the cheapest eligible provider without ever charging above the model maker's list price.
       <br/><br/>
-      <b>First-class support in OmniRoute:</b> Chat Completions, the native <code>/v1/responses</code> endpoint, vision, tool calling and 3 image models (<code>grok-imagine</code>, <code>nano-banana-pro</code>, <code>nano-banana-2</code>, reachable as <code>cheaperinference/&lt;model&gt;</code>). <a href="https://cheaperinference.com"><b>Get an API key →</b></a>
+      <b>First-class support in OmniRoute:</b> Chat Completions, the native <code>/v1/responses</code> endpoint, vision, tool calling and 3 image models (<code>grok-imagine</code>, <code>nano-banana-pro</code>, <code>nano-banana-2</code>, reachable as <code>cheaperinference/&lt;model&gt;</code>). <a href="https://cheaperinference.com/?utm_source=omniroute"><b>Get an API key →</b></a>
     </td>
   </tr>
 </table>

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -14,9 +14,9 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     icon: "savings",
     color: "#31f889",
     textIcon: "CI",
-    website: "https://cheaperinference.com",
+    website: "https://cheaperinference.com/?utm_source=omniroute",
     apiHint:
-      "Create an API key at https://cheaperinference.com (needs the `inference` scope), then paste the ir_live_… token here.",
+      "Create an API key at https://cheaperinference.com/?utm_source=omniroute (needs the `inference` scope), then paste the ir_live_… token here.",
     passthroughModels: true,
   },
   "charm-hyper": {


### PR DESCRIPTION
Adds the `?utm_source=omniroute` tracking parameter to every public-facing URL where Cheaper Inference is clickable — so click-throughs from OmniRoute surfaces show up in their analytics.

## Changed

- `README.md` — the two `<a href>` targets in the Open Source Friends table row (the logo and the "Get an API key →" CTA)
- `src/shared/constants/providers/apikey/gateways.ts` — the `website` field shown on the provider detail page and the `apiHint` text shown above the API-key input in the dashboard

## Deliberately NOT changed

- Every `api.cheaperinference.com/*` URL — these are technical endpoints, not user clicks (the gateway itself never redirects from a parameterized URL)
- JSDoc comments that mention `https://cheaperinference.com` — descriptive text, not links
- The `<sub>cheaperinference.com</sub>` text in the README — plain text label under the logo, not a link

## Verified

`grep -rn 'cheaperinference.com' --include='*.{ts,tsx,md,json,svg,mjs}'` after the change shows every remaining plain reference is either:
- an `api.cheaperinference.com/*` endpoint (excluded by design), or
- a non-link plain text label, or
- a JSDoc comment

`npm run typecheck:core` and `npm run check:docs-sync` both pass.