### PR TITLE
fix(dashboard): open webhook wizard in edit mode

### DIFF
--- a/src/app/(dashboard)/dashboard/webhooks/WebhooksPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/webhooks/WebhooksPageClient.tsx
@@ -24,6 +24,7 @@ export function WebhooksPageClient() {
   const [testingId, setTestingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<FeedbackState>(null);
   const [wizardOpen, setWizardOpen] = useState(false);
+  const [editingWebhook, setEditingWebhook] = useState<WebhookItem | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<WebhookItem | null>(null);
   const [deleting, setDeleting] = useState(false);
 
@@ -101,6 +102,21 @@ export function WebhooksPageClient() {
     }
   };
 
+  const handleAddWebhook = () => {
+    setEditingWebhook(null);
+    setWizardOpen(true);
+  };
+
+  const handleEditWebhook = (webhook: WebhookItem) => {
+    setEditingWebhook(webhook);
+    setWizardOpen(true);
+  };
+
+  const handleCloseWizard = () => {
+    setWizardOpen(false);
+    setEditingWebhook(null);
+  };
+
   const handleDelete = async () => {
     if (!deleteTarget) return;
     setDeleting(true);
@@ -134,7 +150,7 @@ export function WebhooksPageClient() {
         </div>
         <button
           type="button"
-          onClick={() => setWizardOpen(true)}
+          onClick={handleAddWebhook}
           className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary/90"
         >
           <span className="material-symbols-outlined text-[18px]">add</span>
@@ -221,7 +237,7 @@ export function WebhooksPageClient() {
                 t={tFn}
                 onTest={(wh) => void handleTest(wh)}
                 onToggleEnabled={(wh) => void handleToggleEnabled(wh)}
-                onEdit={() => setWizardOpen(true)}
+                onEdit={handleEditWebhook}
                 onDelete={setDeleteTarget}
               />
             </div>
@@ -237,11 +253,12 @@ export function WebhooksPageClient() {
 
       <AddWebhookWizard
         isOpen={wizardOpen}
-        onClose={() => setWizardOpen(false)}
+        onClose={handleCloseWizard}
         onCreated={async () => {
           await load();
         }}
         t={tFn}
+        editingWebhook={editingWebhook}
       />
 
       <ConfirmModal

--- a/src/app/(dashboard)/dashboard/webhooks/components/AddWebhookWizard.tsx
+++ b/src/app/(dashboard)/dashboard/webhooks/components/AddWebhookWizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Modal } from "@/shared/components";
 import { Step1ChooseIntegration } from "./steps/Step1ChooseIntegration";
 import {
@@ -12,6 +12,7 @@ import {
 } from "./steps/Step2ConfigureIntegration";
 import { Step3EventsAndTest } from "./steps/Step3EventsAndTest";
 import { HowItWorksSidebar } from "./HowItWorksSidebar";
+import type { WebhookItem } from "./WebhookCard";
 import type { WebhookKind } from "./shared/IntegrationCard";
 
 interface AddWebhookWizardProps {
@@ -19,6 +20,7 @@ interface AddWebhookWizardProps {
   onClose: () => void;
   onCreated: () => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
+  editingWebhook?: WebhookItem | null;
 }
 
 const STEPS = [1, 2, 3] as const;
@@ -45,22 +47,56 @@ const INITIAL: WizardState = {
   description: "",
 };
 
-function step2Valid(state: WizardState): boolean {
+function stateFromWebhook(webhook: WebhookItem | null | undefined): WizardState {
+  if (!webhook) return INITIAL;
+
+  return {
+    kind: webhook.kind,
+    slack: { webhookUrl: webhook.kind === "slack" ? webhook.url : "" },
+    telegram: { botToken: "", chatId: webhook.kind === "telegram" ? webhook.url : "" },
+    discord: { webhookUrl: webhook.kind === "discord" ? webhook.url : "" },
+    custom: { endpointUrl: webhook.kind === "custom" ? webhook.url : "", secretKey: "" },
+    events: webhook.events.length > 0 ? webhook.events : ["*"],
+    enabled: webhook.enabled,
+    description: webhook.description,
+  };
+}
+
+function step2Valid(state: WizardState, isEditing: boolean): boolean {
   const { kind } = state;
   if (kind === "slack") return state.slack.webhookUrl.trim().length > 0;
-  if (kind === "telegram")
-    return state.telegram.botToken.trim().length > 0 && state.telegram.chatId.trim().length > 0;
+  if (kind === "telegram") {
+    return (
+      state.telegram.chatId.trim().length > 0 &&
+      (isEditing || state.telegram.botToken.trim().length > 0)
+    );
+  }
   if (kind === "discord") return state.discord.webhookUrl.trim().length > 0;
   if (kind === "custom") return state.custom.endpointUrl.trim().length > 0;
   return false;
 }
 
-export function AddWebhookWizard({ isOpen, onClose, onCreated, t }: AddWebhookWizardProps) {
+export function AddWebhookWizard({
+  isOpen,
+  onClose,
+  onCreated,
+  t,
+  editingWebhook,
+}: AddWebhookWizardProps) {
+  const isEditing = Boolean(editingWebhook);
   const [step, setStep] = useState(1);
   const [state, setState] = useState<WizardState>(INITIAL);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdId, setCreatedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setStep(1);
+    setState(stateFromWebhook(editingWebhook));
+    setError(null);
+    setCreatedId(editingWebhook?.id ?? null);
+  }, [editingWebhook, isOpen]);
 
   const handleClose = () => {
     if (saving) return;
@@ -77,7 +113,11 @@ export function AddWebhookWizard({ isOpen, onClose, onCreated, t }: AddWebhookWi
     if (kind === "slack") return { kind, url: state.slack.webhookUrl };
     if (kind === "discord") return { kind, url: state.discord.webhookUrl };
     if (kind === "telegram") {
-      return { kind, url: state.telegram.chatId, metadata: { botToken: state.telegram.botToken } };
+      const payload: Record<string, unknown> = { kind, url: state.telegram.chatId };
+      if (state.telegram.botToken.trim()) {
+        payload.metadata = { botToken: state.telegram.botToken };
+      }
+      return payload;
     }
     const payload: Record<string, unknown> = { kind, url: state.custom.endpointUrl };
     if (state.custom.secretKey.trim()) payload.secret = state.custom.secretKey.trim();
@@ -126,6 +166,7 @@ export function AddWebhookWizard({ isOpen, onClose, onCreated, t }: AddWebhookWi
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          ...buildConfigPayload(),
           events: state.events,
           enabled: state.enabled,
           description: state.description,
@@ -142,7 +183,7 @@ export function AddWebhookWizard({ isOpen, onClose, onCreated, t }: AddWebhookWi
     }
   };
 
-  const canGoNext = step === 1 ? true : step === 2 ? step2Valid(state) : true;
+  const canGoNext = step === 1 ? true : step === 2 ? step2Valid(state, isEditing) : true;
 
   const stepTitle =
     step === 1
@@ -155,7 +196,7 @@ export function AddWebhookWizard({ isOpen, onClose, onCreated, t }: AddWebhookWi
     <Modal
       isOpen={isOpen}
       onClose={handleClose}
-      title={`${t("addWebhook")} — ${stepTitle}`}
+      title={`${t(isEditing ? "editWebhook" : "addWebhook")} — ${stepTitle}`}
       size="xl"
       footer={
         <div className="flex w-full items-center justify-between">
@@ -243,6 +284,7 @@ export function AddWebhookWizard({ isOpen, onClose, onCreated, t }: AddWebhookWi
               onChangeDiscord={(v) => setState((s) => ({ ...s, discord: v }))}
               onChangeCustom={(v) => setState((s) => ({ ...s, custom: v }))}
               t={t}
+              isEditing={isEditing}
             />
           )}
           {step === 3 && (

--- a/src/app/(dashboard)/dashboard/webhooks/components/steps/Step2ConfigureIntegration.tsx
+++ b/src/app/(dashboard)/dashboard/webhooks/components/steps/Step2ConfigureIntegration.tsx
@@ -35,7 +35,14 @@ export function Step2ConfigureIntegration({
 }: Step2ConfigureIntegrationProps) {
   if (kind === "slack") return <SlackConfigForm value={slack} onChange={onChangeSlack} t={t} />;
   if (kind === "telegram")
-    return <TelegramConfigForm value={telegram} onChange={onChangeTelegram} t={t} />;
+    return (
+      <TelegramConfigForm
+        value={telegram}
+        onChange={onChangeTelegram}
+        t={t}
+        isEditing={isEditing}
+      />
+    );
   if (kind === "discord")
     return <DiscordConfigForm value={discord} onChange={onChangeDiscord} t={t} />;
   return <CustomConfigForm value={custom} onChange={onChangeCustom} t={t} isEditing={isEditing} />;

--- a/src/app/(dashboard)/dashboard/webhooks/components/steps/integrations/TelegramConfigForm.tsx
+++ b/src/app/(dashboard)/dashboard/webhooks/components/steps/integrations/TelegramConfigForm.tsx
@@ -9,9 +9,15 @@ interface TelegramConfigFormProps {
   value: TelegramConfig;
   onChange: (v: TelegramConfig) => void;
   t: (key: string) => string;
+  isEditing?: boolean;
 }
 
-export function TelegramConfigForm({ value, onChange, t }: TelegramConfigFormProps) {
+export function TelegramConfigForm({
+  value,
+  onChange,
+  t,
+  isEditing,
+}: TelegramConfigFormProps) {
   return (
     <div className="space-y-4">
       <div>
@@ -22,7 +28,7 @@ export function TelegramConfigForm({ value, onChange, t }: TelegramConfigFormPro
           type="password"
           value={value.botToken}
           onChange={(e) => onChange({ ...value, botToken: e.target.value })}
-          placeholder={t("telegram.botTokenPlaceholder")}
+          placeholder={isEditing ? t("secretEditPlaceholder") : t("telegram.botTokenPlaceholder")}
           autoComplete="new-password"
           className="mt-1 w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-main focus:outline-none focus:ring-2 focus:ring-primary/40"
         />

--- a/tests/unit/webhook-edit-wizard-regression.test.ts
+++ b/tests/unit/webhook-edit-wizard-regression.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const pageClientSource = readFileSync(
+  "src/app/(dashboard)/dashboard/webhooks/WebhooksPageClient.tsx",
+  "utf8"
+);
+const wizardSource = readFileSync(
+  "src/app/(dashboard)/dashboard/webhooks/components/AddWebhookWizard.tsx",
+  "utf8"
+);
+
+test("webhook edit action opens the wizard in edit mode", () => {
+  assert.match(pageClientSource, /const \[editingWebhook, setEditingWebhook\]/);
+  assert.match(pageClientSource, /const handleEditWebhook = \(webhook: WebhookItem\) => \{/);
+  assert.match(pageClientSource, /setEditingWebhook\(webhook\);/);
+  assert.match(pageClientSource, /onEdit=\{handleEditWebhook\}/);
+  assert.match(pageClientSource, /editingWebhook=\{editingWebhook\}/);
+  assert.doesNotMatch(pageClientSource, /onEdit=\{\(\) => setWizardOpen\(true\)\}/);
+});
+
+test("webhook wizard title reflects add versus edit mode", () => {
+  assert.match(wizardSource, /editingWebhook\?: WebhookItem \| null;/);
+  assert.match(wizardSource, /const isEditing = Boolean\(editingWebhook\);/);
+  assert.match(wizardSource, /title=\{`\$\{t\(isEditing \? "editWebhook" : "addWebhook"\)\}/);
+});
+
+test("editing an existing webhook reuses the current webhook payload", () => {
+  assert.match(wizardSource, /function stateFromWebhook\(webhook: WebhookItem \| null \| undefined\)/);
+  assert.match(wizardSource, /setState\(stateFromWebhook\(editingWebhook\)\);/);
+  assert.match(wizardSource, /setCreatedId\(editingWebhook\?\.id \?\? null\);/);
+  assert.match(wizardSource, /\.\.\.buildConfigPayload\(\),/);
+  assert.match(wizardSource, /step2Valid\(state, isEditing\)/);
+});


### PR DESCRIPTION
## Summary
- Fixes the `/dashboard/webhooks` edit action so it stores the selected webhook before opening the wizard.
- Updates the webhook wizard to support add/edit title modes and prefill the selected webhook payload.
- Preserves existing Telegram/custom secret behavior during edits without forcing users to re-enter secrets.

## Test plan
- [x] `node --import tsx/esm --test tests/unit/webhook-edit-wizard-regression.test.ts`
- [x] Checked linter diagnostics for changed files in Cursor

Fixes #9271