### PR TITLE
fix(mcp): remove non-standard x-provider field from omniroute_test_combo body

### DIFF
--- a/open-sse/mcp-server/__tests__/advancedTools.test.ts
+++ b/open-sse/mcp-server/__tests__/advancedTools.test.ts
@@ -9,9 +9,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+const { handleTestCombo } = await import("../tools/advancedTools.ts");
+
 describe("MCP Advanced Tools", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    // Re-assert the stub: importing advancedTools.ts triggers OmniRoute's own
+    // startup side effects (DB init, global fetch proxy patch) that overwrite
+    // globalThis.fetch after the top-level vi.stubGlobal() above ran.
+    vi.stubGlobal("fetch", mockFetch);
   });
 
   describe("simulate_route", () => {
@@ -81,6 +87,32 @@ describe("MCP Advanced Tools", () => {
       const combo = combos.find((c: { id?: string }) => c.id === "test-combo");
       expect(combo).toBeDefined();
       expect(combo.models).toHaveLength(2);
+    });
+
+    it("does not send a non-standard 'x-provider' body field upstream (regression, strict providers like Groq reject it with HTTP 400)", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            {
+              id: "groq-combo",
+              models: [{ provider: "groq", model: "groq/llama-3.1-8b-instant" }],
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ model: "llama-3.1-8b-instant", cost: 0, usage: {} }),
+        });
+
+      await handleTestCombo({ comboId: "groq-combo", testPrompt: "hi" });
+
+      const chatCompletionsCall = mockFetch.mock.calls.find(([url]) =>
+        String(url).includes("/v1/chat/completions")
+      );
+      expect(chatCompletionsCall).toBeDefined();
+      const sentBody = JSON.parse(chatCompletionsCall![1].body);
+      expect(sentBody).not.toHaveProperty("x-provider");
     });
   });
 

--- a/open-sse/mcp-server/tools/advancedTools.ts
+++ b/open-sse/mcp-server/tools/advancedTools.ts
@@ -548,7 +548,6 @@ export async function handleTestCombo(args: { comboId: string; testPrompt: strin
                 messages: [{ role: "user", content: prompt }],
                 max_tokens: 50,
                 stream: false,
-                "x-provider": model.provider,
               }),
             })
           );


### PR DESCRIPTION
## Summary
- `omniroute_test_combo` injected a stray `x-provider` property into the outbound `/v1/chat/completions` JSON body when testing each model in a combo.
- Strict OpenAI-compatible providers (Groq) reject unknown top-level body properties, so every Groq entry in a tested combo failed with `[400]: property 'x-provider' is unsupported`, even though the same model works fine outside the test-combo path.
- The field was never read back anywhere — the model string already encodes the provider — so it's just dropped.
- Confirmed this only affected the `omniroute_test_combo` diagnostic tool, not real combo/priority routing (no other file in `open-sse/` references `x-provider`).

## Test plan
- [x] TDD: added a regression test in `open-sse/mcp-server/__tests__/advancedTools.test.ts` that imports the real `handleTestCombo` handler (previous tests in this file only exercised mocked fetch plumbing, never the actual implementation) and asserts the outbound body has no `x-provider` key
- [x] Confirmed the test fails against the pre-fix code (reproduces the bug) and passes after the fix
- [x] `npx vitest run open-sse/mcp-server/__tests__/advancedTools.test.ts` — 10/10 passing, no regressions