### PR TITLE
feat(dashboard): persist provider screen filters to URL for bookmarking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
@@ -3692,9 +3692,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3710,9 +3707,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3730,9 +3724,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3748,9 +3739,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3768,9 +3756,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3786,9 +3771,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3806,9 +3788,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3825,9 +3804,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3843,9 +3819,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3869,9 +3842,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3893,9 +3863,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3919,9 +3886,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3943,9 +3907,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3969,9 +3930,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3994,9 +3952,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4018,9 +3973,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5393,9 +5345,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5411,9 +5360,6 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5431,9 +5377,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5449,9 +5392,6 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10739,9 +10679,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10759,9 +10696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10779,9 +10713,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10799,9 +10730,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12894,9 +12822,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12910,9 +12835,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12926,9 +12848,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12942,9 +12861,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12958,9 +12874,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12974,9 +12887,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"

--- a/src/app/(dashboard)/dashboard/providers/hooks/useProviderUrlFilters.ts
+++ b/src/app/(dashboard)/dashboard/providers/hooks/useProviderUrlFilters.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import {
+  readProviderFiltersFromUrl,
+  syncProviderFiltersToUrl,
+} from "../providerPageUtils";
+import {
+  readProviderDisplayModePreference,
+  type ProviderDisplayMode,
+} from "../providerPageStorage";
+
+interface UseProviderUrlFiltersArgs {
+  searchParams: ReadonlyURLSearchParams;
+  providerDisplayMode: ProviderDisplayMode;
+  setProviderDisplayMode: (mode: ProviderDisplayMode) => void;
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  modelSearchQuery: string;
+  setModelSearchQuery: (value: string) => void;
+  activeCategory: string | null;
+  setActiveCategory: (value: string | null) => void;
+  showFreeOnly: boolean;
+  setShowFreeOnly: (value: boolean) => void;
+  activeServiceKind: string | null;
+  setActiveServiceKind: (value: string | null) => void;
+}
+
+/**
+ * useProviderUrlFilters — two-way sync between the providers dashboard filter
+ * state and the URL query string, so a filtered/searched view is bookmarkable
+ * and shareable.
+ *
+ * Hydration guard: the filter→URL sync effect must not write the URL before
+ * the initial URL→state read has applied, or a bookmarked view would be
+ * transiently clobbered by the default state on the first paint.
+ *
+ * Returns `displayModePreferenceReady`, which the caller also gates other
+ * display-mode-dependent effects on.
+ */
+export function useProviderUrlFilters({
+  searchParams,
+  providerDisplayMode,
+  setProviderDisplayMode,
+  searchQuery,
+  setSearchQuery,
+  modelSearchQuery,
+  setModelSearchQuery,
+  activeCategory,
+  setActiveCategory,
+  showFreeOnly,
+  setShowFreeOnly,
+  activeServiceKind,
+  setActiveServiceKind,
+}: UseProviderUrlFiltersArgs): { displayModePreferenceReady: boolean } {
+  const [displayModePreferenceReady, setDisplayModePreferenceReady] = useState(false);
+  const [filtersHydrated, setFiltersHydrated] = useState(false);
+
+  useEffect(() => {
+    const urlMode = readProviderFiltersFromUrl(searchParams).displayMode;
+    setProviderDisplayMode(urlMode ?? readProviderDisplayModePreference());
+    setDisplayModePreferenceReady(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  useEffect(() => {
+    const urlFilters = readProviderFiltersFromUrl(searchParams);
+    setSearchQuery(urlFilters.searchQuery ?? "");
+    setModelSearchQuery(urlFilters.modelSearchQuery ?? "");
+    setActiveCategory(urlFilters.category ?? null);
+    setShowFreeOnly(urlFilters.showFreeOnly ?? false);
+    setActiveServiceKind(urlFilters.mediaKind ?? null);
+    setFiltersHydrated(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!filtersHydrated || !displayModePreferenceReady) return;
+    syncProviderFiltersToUrl({
+      searchQuery,
+      modelSearchQuery,
+      displayMode: providerDisplayMode,
+      category: activeCategory,
+      showFreeOnly,
+      mediaKind: activeServiceKind,
+    });
+  }, [
+    filtersHydrated,
+    displayModePreferenceReady,
+    searchQuery,
+    modelSearchQuery,
+    providerDisplayMode,
+    activeCategory,
+    showFreeOnly,
+    activeServiceKind,
+  ]);
+
+  return { displayModePreferenceReady };
+}

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -27,10 +27,11 @@ import {
   buildCompatibleProviderGroups,
   connectionMatchesProviderCard,
   filterConfiguredProviderEntries,
+  readProviderFiltersFromUrl,
   shouldFilterProviderEntriesForDisplayMode,
   shouldShowFirstProviderHint,
   shouldShowProviderSection,
-  syncSearchToUrl,
+  syncProviderFiltersToUrl,
   upsertProviderNodeById,
   loadProviderPageData,
 } from "./providerPageUtils";
@@ -206,6 +207,10 @@ export default function ProvidersPage() {
   // #4240: media-category (serviceKind) filter — composes with activeCategory,
   // search and configured-only. null = no serviceKind filter.
   const [activeServiceKind, setActiveServiceKind] = useState<string | null>(null);
+  // URL hydration guard: the filter→URL sync effect must not write the URL
+  // before the initial URL→state read has applied, or a bookmarked view would
+  // be transiently clobbered by the default state on the first paint.
+  const [filtersHydrated, setFiltersHydrated] = useState(false);
   const notify = useNotificationStore();
   const sectionCategoryAliases: Record<string, string> = {
     cloud: "cloudagent",
@@ -229,20 +234,41 @@ export default function ProvidersPage() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    setProviderDisplayMode(readProviderDisplayModePreference());
+    const urlMode = readProviderFiltersFromUrl(searchParams).displayMode;
+    setProviderDisplayMode(urlMode ?? readProviderDisplayModePreference());
     setDisplayModePreferenceReady(true);
-  }, []);
-
-  useEffect(() => {
-    const searchFromUrl = searchParams.get("search");
-    if (searchFromUrl) {
-      setSearchQuery(searchFromUrl);
-    }
   }, [searchParams]);
 
   useEffect(() => {
-    syncSearchToUrl(searchQuery);
-  }, [searchQuery]);
+    const urlFilters = readProviderFiltersFromUrl(searchParams);
+    setSearchQuery(urlFilters.searchQuery ?? "");
+    setModelSearchQuery(urlFilters.modelSearchQuery ?? "");
+    setActiveCategory(urlFilters.category ?? null);
+    setShowFreeOnly(urlFilters.showFreeOnly ?? false);
+    setActiveServiceKind(urlFilters.mediaKind ?? null);
+    setFiltersHydrated(true);
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!filtersHydrated || !displayModePreferenceReady) return;
+    syncProviderFiltersToUrl({
+      searchQuery,
+      modelSearchQuery,
+      displayMode: providerDisplayMode,
+      category: activeCategory,
+      showFreeOnly,
+      mediaKind: activeServiceKind,
+    });
+  }, [
+    filtersHydrated,
+    displayModePreferenceReady,
+    searchQuery,
+    modelSearchQuery,
+    providerDisplayMode,
+    activeCategory,
+    showFreeOnly,
+    activeServiceKind,
+  ]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -22,22 +22,20 @@ import useEmailPrivacyStore from "@/store/emailPrivacyStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { useTranslations } from "next-intl";
 import { useSyncedModelsByProvider } from "./hooks/useSyncedModelsByProvider";
+import { useProviderUrlFilters } from "./hooks/useProviderUrlFilters";
 import {
   buildStaticProviderEntries,
   buildCompatibleProviderGroups,
   connectionMatchesProviderCard,
   filterConfiguredProviderEntries,
-  readProviderFiltersFromUrl,
   shouldFilterProviderEntriesForDisplayMode,
   shouldShowFirstProviderHint,
   shouldShowProviderSection,
-  syncProviderFiltersToUrl,
   upsertProviderNodeById,
   loadProviderPageData,
 } from "./providerPageUtils";
 import type { ProviderEntry } from "./providerPageUtils";
 import {
-  readProviderDisplayModePreference,
   shouldSyncProviderDisplayMode,
   writeProviderDisplayModePreference,
   type ProviderDisplayMode,
@@ -193,7 +191,6 @@ export default function ProvidersPage() {
   const [testingMode, setTestingMode] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<any>(null);
   const [providerDisplayMode, setProviderDisplayMode] = useState<ProviderDisplayMode>("all");
-  const [displayModePreferenceReady, setDisplayModePreferenceReady] = useState(false);
   const [oauthEnvRepairStatus, setOauthEnvRepairStatus] = useState<{
     available: boolean;
     missingCount: number;
@@ -207,10 +204,6 @@ export default function ProvidersPage() {
   // #4240: media-category (serviceKind) filter — composes with activeCategory,
   // search and configured-only. null = no serviceKind filter.
   const [activeServiceKind, setActiveServiceKind] = useState<string | null>(null);
-  // URL hydration guard: the filter→URL sync effect must not write the URL
-  // before the initial URL→state read has applied, or a bookmarked view would
-  // be transiently clobbered by the default state on the first paint.
-  const [filtersHydrated, setFiltersHydrated] = useState(false);
   const notify = useNotificationStore();
   const sectionCategoryAliases: Record<string, string> = {
     cloud: "cloudagent",
@@ -233,42 +226,21 @@ export default function ProvidersPage() {
   const addCcCompatibleLabel = t("addCcCompatible");
   const searchParams = useSearchParams();
 
-  useEffect(() => {
-    const urlMode = readProviderFiltersFromUrl(searchParams).displayMode;
-    setProviderDisplayMode(urlMode ?? readProviderDisplayModePreference());
-    setDisplayModePreferenceReady(true);
-  }, [searchParams]);
-
-  useEffect(() => {
-    const urlFilters = readProviderFiltersFromUrl(searchParams);
-    setSearchQuery(urlFilters.searchQuery ?? "");
-    setModelSearchQuery(urlFilters.modelSearchQuery ?? "");
-    setActiveCategory(urlFilters.category ?? null);
-    setShowFreeOnly(urlFilters.showFreeOnly ?? false);
-    setActiveServiceKind(urlFilters.mediaKind ?? null);
-    setFiltersHydrated(true);
-  }, [searchParams]);
-
-  useEffect(() => {
-    if (!filtersHydrated || !displayModePreferenceReady) return;
-    syncProviderFiltersToUrl({
-      searchQuery,
-      modelSearchQuery,
-      displayMode: providerDisplayMode,
-      category: activeCategory,
-      showFreeOnly,
-      mediaKind: activeServiceKind,
-    });
-  }, [
-    filtersHydrated,
-    displayModePreferenceReady,
-    searchQuery,
-    modelSearchQuery,
+  const { displayModePreferenceReady } = useProviderUrlFilters({
+    searchParams,
     providerDisplayMode,
+    setProviderDisplayMode,
+    searchQuery,
+    setSearchQuery,
+    modelSearchQuery,
+    setModelSearchQuery,
     activeCategory,
+    setActiveCategory,
     showFreeOnly,
+    setShowFreeOnly,
     activeServiceKind,
-  ]);
+    setActiveServiceKind,
+  });
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -15,7 +15,10 @@ import { getModelsByProviderId } from "@/shared/constants/models";
 import { providerHasServiceKind } from "@/lib/providers/serviceKindIndex";
 import { compareTr, matchesAnyToken, matchesSearch } from "@/shared/utils/turkishText";
 import { fetchWithTimeout } from "@/shared/utils/fetchTimeout";
-import type { ProviderDisplayMode } from "./providerPageStorage";
+import {
+  parseProviderDisplayModePreference,
+  type ProviderDisplayMode,
+} from "./providerPageStorage";
 import { getFeaturedProviderRank } from "./featuredProviders";
 
 export interface ProviderStatsSnapshot {
@@ -71,20 +74,115 @@ export function shouldShowFirstProviderHint(
 }
 
 export function syncSearchToUrl(searchQuery: string): void {
+  syncProviderFiltersToUrl({ searchQuery });
+}
+
+/** All dashboard summary-chip category keys that are valid in `?cat=`. */
+const PROVIDER_CATEGORY_URL_VALUES = new Set([
+  "oauth",
+  "ide",
+  "free",
+  "no-auth",
+  "upstream-proxy",
+  "apikey",
+  "compatible",
+  "webcookie",
+  "search",
+  "webfetch",
+  "audio",
+  "local",
+  "cloudagent",
+]);
+
+/** Media/service-kind chip keys that are valid in `?media=`. */
+const PROVIDER_SERVICE_KIND_URL_VALUES = new Set([
+  "image",
+  "video",
+  "music",
+  "tts",
+  "stt",
+  "embedding",
+]);
+
+export interface ProviderFilterUrlState {
+  searchQuery?: string;
+  modelSearchQuery?: string;
+  displayMode?: ProviderDisplayMode;
+  category?: string | null;
+  showFreeOnly?: boolean;
+  mediaKind?: string | null;
+}
+
+/**
+ * Reflect the providers dashboard filters in the URL query string via
+ * history.replaceState so a filtered view can be bookmarked/shared:
+ *
+ *   ?search=<name>  provider-name / id search (#8624)
+ *   ?model=<name>   model-name search
+ *   ?mode=all|configured|compact  display mode (All / Configured / Compact)
+ *   ?cat=<key>      active summary category (oauth, ide, free, no-auth, …)
+ *   ?media=<key>    media/service-kind filter (image, video, music, …)
+ *
+ * "Free Tier" is encoded as `?cat=free` (showFreeOnly). Params carrying no
+ * filter are removed so the URL stays canonical and shareable.
+ */
+export function syncProviderFiltersToUrl(state: ProviderFilterUrlState): void {
   if (typeof window === "undefined") return;
 
   const url = new URL(window.location.href);
-  const currentSearch = url.searchParams.get("search") || "";
+  const params = url.searchParams;
+  let changed = false;
 
-  if (searchQuery.trim()) {
-    if (currentSearch !== searchQuery) {
-      url.searchParams.set("search", searchQuery);
-      window.history.replaceState(window.history.state, "", url.toString());
-    }
-  } else if (url.searchParams.has("search")) {
-    url.searchParams.delete("search");
+  const setOrRemove = (key: string, value: string | null | undefined) => {
+    const next = value != null && value.length > 0 ? value : null;
+    const current = params.get(key);
+    if (next === current) return;
+    if (next === null) params.delete(key);
+    else params.set(key, next);
+    changed = true;
+  };
+
+  setOrRemove("search", state.searchQuery?.trim());
+  setOrRemove("model", state.modelSearchQuery?.trim());
+  setOrRemove("mode", state.displayMode && state.displayMode !== "all" ? state.displayMode : null);
+  setOrRemove("cat", state.showFreeOnly ? "free" : state.category || null);
+  setOrRemove("media", state.mediaKind || null);
+
+  if (changed) {
     window.history.replaceState(window.history.state, "", url.toString());
   }
+}
+
+/** Parse the provider dashboard filters back out of URL query params. */
+export function readProviderFiltersFromUrl(params: URLSearchParams): ProviderFilterUrlState {
+  const state: ProviderFilterUrlState = {};
+
+  const search = params.get("search");
+  if (search) state.searchQuery = search;
+
+  const model = params.get("model");
+  if (model) state.modelSearchQuery = model;
+
+  const mode = parseProviderDisplayModePreference(params.get("mode"));
+  if (mode) state.displayMode = mode;
+
+  const category = params.get("cat");
+  if (category && PROVIDER_CATEGORY_URL_VALUES.has(category)) {
+    if (category === "free") {
+      state.showFreeOnly = true;
+      state.category = null;
+    } else {
+      state.showFreeOnly = false;
+      state.category = category;
+    }
+  }
+
+  const media = params.get("media");
+  if (media && PROVIDER_SERVICE_KIND_URL_VALUES.has(media)) {
+    state.mediaKind = media;
+  }
+
+  return state;
 }
 
 export function shouldShowProviderSection(

--- a/tests/unit/provider-filters-url-sync.test.ts
+++ b/tests/unit/provider-filters-url-sync.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  readProviderFiltersFromUrl,
+  syncProviderFiltersToUrl,
+} from "../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts";
+
+type MockHistory = {
+  state: unknown;
+  replaceState(state: unknown, title: string, url: string): void;
+};
+
+type MockLocation = { href: string };
+
+type MockWindow = { history: MockHistory; location: MockLocation };
+
+const globals = globalThis as unknown as { window?: MockWindow };
+
+const originalWindow = globals.window;
+
+function mockWindow(href: string): string[] {
+  const calls: string[] = [];
+  globals.window = {
+    history: {
+      state: null,
+      replaceState(_state: unknown, _title: string, url: string) {
+        calls.push(url);
+      },
+    },
+    location: { href },
+  };
+  return calls;
+}
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    delete globals.window;
+  } else {
+    globals.window = originalWindow;
+  }
+});
+
+describe("readProviderFiltersFromUrl", () => {
+  it("parses every supported param", () => {
+    const state = readProviderFiltersFromUrl(
+      new URLSearchParams("search=openai&model=gpt&mode=compact&cat=free&media=image")
+    );
+    assert.deepEqual(state, {
+      searchQuery: "openai",
+      modelSearchQuery: "gpt",
+      displayMode: "compact",
+      showFreeOnly: true,
+      category: null,
+      mediaKind: "image",
+    });
+  });
+
+  it("reads a concrete category and the display mode", () => {
+    const state = readProviderFiltersFromUrl(new URLSearchParams("cat=oauth&mode=configured"));
+    assert.deepEqual(state, { displayMode: "configured", showFreeOnly: false, category: "oauth" });
+  });
+
+  it("ignores invalid category / media / mode values", () => {
+    const state = readProviderFiltersFromUrl(
+      new URLSearchParams("cat=bogus&mode=unknown&media=audio")
+    );
+    assert.deepEqual(state, {});
+  });
+
+  it("returns empty state for no params", () => {
+    assert.deepEqual(readProviderFiltersFromUrl(new URLSearchParams("")), {});
+  });
+});
+
+describe("syncProviderFiltersToUrl", () => {
+  it("does not throw when window is undefined (SSR environment)", () => {
+    assert.doesNotThrow(() => {
+      syncProviderFiltersToUrl({ displayMode: "compact", category: "oauth" });
+    });
+  });
+
+  it("writes all active filters via replaceState", () => {
+    const calls = mockWindow("http://localhost/dashboard/providers");
+    syncProviderFiltersToUrl({
+      searchQuery: "openai",
+      modelSearchQuery: "gpt",
+      displayMode: "compact",
+      category: "oauth",
+      showFreeOnly: false,
+      mediaKind: "image",
+    });
+    assert.equal(calls.length, 1);
+    const url = new URL(calls[0]);
+    assert.equal(url.searchParams.get("search"), "openai");
+    assert.equal(url.searchParams.get("model"), "gpt");
+    assert.equal(url.searchParams.get("mode"), "compact");
+    assert.equal(url.searchParams.get("cat"), "oauth");
+    assert.equal(url.searchParams.get("media"), "image");
+  });
+
+  it("encodes the free-tier filter as cat=free", () => {
+    const calls = mockWindow("http://localhost/dashboard/providers");
+    syncProviderFiltersToUrl({ showFreeOnly: true, category: null, displayMode: "all" });
+    assert.equal(calls.length, 1);
+    const url = new URL(calls[0]);
+    assert.equal(url.searchParams.get("cat"), "free");
+    assert.equal(url.searchParams.has("mode"), false);
+  });
+
+  it("drops the display-mode param when set back to All", () => {
+    const calls = mockWindow("http://localhost/dashboard/providers?mode=compact");
+    syncProviderFiltersToUrl({ displayMode: "all" });
+    assert.equal(calls.length, 1);
+    assert.equal(new URL(calls[0]).searchParams.has("mode"), false);
+  });
+
+  it("removes params whose filters have been cleared", () => {
+    const calls = mockWindow(
+      "http://localhost/dashboard/providers?mode=compact&cat=oauth&media=image&search=openai"
+    );
+    syncProviderFiltersToUrl({});
+    assert.equal(calls.length, 1);
+    const url = new URL(calls[0]);
+    assert.equal(url.searchParams.has("mode"), false);
+    assert.equal(url.searchParams.has("cat"), false);
+    assert.equal(url.searchParams.has("media"), false);
+    assert.equal(url.searchParams.has("search"), false);
+  });
+
+  it("preserves unrelated URL params and path", () => {
+    const calls = mockWindow("http://localhost/dashboard/providers?tab=x&mode=compact");
+    syncProviderFiltersToUrl({});
+    assert.equal(calls.length, 1);
+    const url = new URL(calls[0]);
+    assert.equal(url.pathname, "/dashboard/providers");
+    assert.equal(url.searchParams.get("tab"), "x");
+    assert.equal(url.searchParams.has("mode"), false);
+  });
+
+  it("does not replaceState when nothing changed", () => {
+    const calls = mockWindow("http://localhost/dashboard/providers?search=openai");
+    syncProviderFiltersToUrl({ searchQuery: "openai" });
+    assert.equal(calls.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Enhanced the recent change that updated the search parameters in the URL, to handle all filters on the Providers page.

The Providers dashboard filters were ephemeral — only the search term was mirrored to the URL, so a filtered view (display mode, category, media type, model search) could not be bookmarked or shared. This PR makes every filter state a first-class part of the URL query string via `history.replaceState`, so any filtered view is directly shareable/bookmarkable.

## What changed

| URL param | Filter | Example |
| --- | --- | --- |
| `?mode=` | Display mode (All / Configured / Compact) | `?mode=compact` |
| `?cat=` | Summary category chip (OAuth, Free Tier, API Key, no-auth, local, …) | `?cat=oauth`, `?cat=free` |
| `?media=` | Media/service-kind chip (image, video, music, tts, stt, embedding) | `?media=image` |
| `?model=` | Model-name search | `?model=gpt` |
| `?search=` | Provider name/id search (existing behavior, now unified) | `?search=openai` |

## How it works

- **Read on load** (`page.tsx`): URL params take precedence when seeding state; the display mode falls back to the existing `localStorage` preference when no `?mode=` is present.
- **Sync on change**: any filter change rewrites the URL with `history.replaceState`; inactive filters are removed so the URL stays canonical (e.g. All mode drops `?mode=`). Unrelated query params are preserved.
- **Free Tier** is encoded as `?cat=free` so the summary-chip state round-trips exactly.
- **Hydration guard**: the URL→state read completes before the state→URL sync runs (`filtersHydrated` + `displayModePreferenceReady`), so a bookmarked view is never transiently clobbered by first-paint defaults.
- Existing behavior kept: `?mode=configured` still degrades to "All" when there are zero connections, and display-mode persistence to `localStorage` is unchanged.

## Files changed

- `src/app/(dashboard)/dashboard/providers/providerPageUtils.ts` — `syncProviderFiltersToUrl()` / `readProviderFiltersFromUrl()` helpers; `syncSearchToUrl()` now delegates to the shared writer.
- `src/app/(dashboard)/dashboard/providers/page.tsx` — URL hydration + sync effects.

## Tests

- Added: `tests/unit/provider-filters-url-sync.test.ts` (param parsing, replaceState writes/clearing, free-tier encoding, unrelated-param preservation, SSR no-throw, no-op detection).
- Verified: `sync-search-to-url-8624.test.ts`, `providerPageStorage.test.ts`, `providers-page-utils.test.ts`, `provider-section-visibility.test.ts`, `provider-service-kind-filter-4240.test.ts` all pass; `npm run typecheck:core` and `npm run lint` are clean.

## Testing

- `node --import tsx/esm --test tests/unit/provider-filters-url-sync.test.ts`
- `npm run lint` · `npm run typecheck:core`
