### PR TITLE
fix(claude): reconcile compacted tool results

### DIFF
--- a/changelog.d/fixes/9308-claude-tool-result-pairing.md
+++ b/changelog.d/fixes/9308-claude-tool-result-pairing.md
@@ -1,0 +1,1 @@
+- **fix(claude):** reconcile compacted tool results against the preceding tool use. (thanks @ryanngit)

--- a/open-sse/translator/helpers/claudeHelper.ts
+++ b/open-sse/translator/helpers/claudeHelper.ts
@@ -153,8 +153,18 @@ export function splitMisplacedToolResults(messages: ClaudeMessage[]): ClaudeMess
 // Fix tool_use/tool_result ordering for Claude API
 // 1. Assistant message with tool_use: remove text AFTER tool_use (Claude doesn't allow)
 // 2. Merge consecutive same-role messages
+// 3. Reconcile tool_result blocks against the immediately previous tool_use message
 export function fixToolUseOrdering(messages: ClaudeMessage[]): ClaudeMessage[] {
-  if (messages.length <= 1) return messages;
+  if (messages.length === 0) return messages;
+  if (
+    messages.length === 1 &&
+    !(
+      Array.isArray(messages[0]?.content) &&
+      messages[0].content.some((block) => block.type === "tool_result")
+    )
+  ) {
+    return messages;
+  }
 
   // Pass 1: Fix assistant messages with tool_use - remove text after tool_use
   for (const msg of messages) {
@@ -216,6 +226,53 @@ export function fixToolUseOrdering(messages: ClaudeMessage[]): ClaudeMessage[] {
         : [{ type: "text", text: msg.content }];
       merged.push({ role: msg.role, content: [...content] });
     }
+  }
+
+  // Claude accepts tool_result only for a tool_use in the immediately previous
+  // assistant message. Compacted cross-model history can retain an output after
+  // dropping its call; keep that output as user text instead of sending an
+  // invalid structured reference or discarding useful context.
+  for (let i = 0; i < merged.length; i++) {
+    const msg = merged[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+
+    const previous = merged[i - 1];
+    const validIds = new Set<string>(
+      previous?.role === "assistant" && Array.isArray(previous.content)
+        ? previous.content.flatMap((block) =>
+            block.type === "tool_use" && typeof block.id === "string" && block.id ? [block.id] : []
+          )
+        : []
+    );
+    const pairedById = new Map<string, ClaudeContentBlock>();
+    const otherContent: ClaudeContentBlock[] = [];
+
+    for (const block of msg.content) {
+      if (block.type !== "tool_result") {
+        otherContent.push(block);
+        continue;
+      }
+
+      const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+      if (validIds.has(toolUseId) && !pairedById.has(toolUseId)) {
+        pairedById.set(toolUseId, block);
+        continue;
+      }
+
+      const serialized =
+        typeof block.content === "string"
+          ? block.content
+          : (JSON.stringify(block.content ?? "") ?? "");
+      otherContent.push({
+        type: "text",
+        text: `[Unpaired tool result ${toolUseId || "unknown"}]\n${serialized}`,
+      });
+    }
+
+    const pairedResults = [...validIds].map(
+      (id) => pairedById.get(id) ?? { type: "tool_result", tool_use_id: id, content: "" }
+    );
+    msg.content = [...pairedResults, ...otherContent];
   }
 
   return merged;

--- a/open-sse/translator/helpers/toolCallHelper.ts
+++ b/open-sse/translator/helpers/toolCallHelper.ts
@@ -59,8 +59,11 @@ export function ensureToolCallIds(body, options?: { use9CharId?: boolean }) {
       }
     }
 
-    // Tool responses (role "tool") follow in same order as tool_calls; set tool_call_id by index.
-    // Stop when we hit another assistant so we only link tool messages that immediately follow this one.
+    // Tool responses (role "tool") follow in the same order as tool_calls. Rewrite
+    // every id only when the provider requires generated 9-char ids; otherwise keep
+    // explicit client ids and fill only missing ones. Overwriting a compacted orphan's
+    // explicit id by position can make it impersonate a different parallel call.
+    // Stop at the next assistant so we only link responses belonging to this turn.
     if (newIdsInOrder.length > 0) {
       let idx = 0;
       for (let j = i + 1; j < body.messages.length; j++) {
@@ -68,7 +71,13 @@ export function ensureToolCallIds(body, options?: { use9CharId?: boolean }) {
         if (later.role === "assistant") break;
         if (later.role !== "tool") continue;
         if (idx < newIdsInOrder.length) {
-          later.tool_call_id = newIdsInOrder[idx];
+          if (
+            use9CharId ||
+            later.tool_call_id == null ||
+            String(later.tool_call_id).trim() === ""
+          ) {
+            later.tool_call_id = newIdsInOrder[idx];
+          }
           idx++;
         }
       }

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -224,8 +224,12 @@ export function translateRequest(
   // Fix missing tool responses (insert empty tool_result if needed)
   fixMissingToolResponses(result);
 
-  // Strip orphaned tool results (tool_result/role:tool with no matching tool_call)
-  stripOrphanedToolResults(result);
+  // Claude reconciliation preserves orphaned tool output as labelled user text.
+  // Keep the raw result carriers until the target translator can perform that
+  // lossless conversion; other target formats retain the strict orphan filter.
+  if (targetFormat !== FORMATS.CLAUDE) {
+    stripOrphanedToolResults(result);
+  }
 
   // Normalize roles: developer→system unless preserved, system→user for incompatible models.
   // This handles (1) sourceFormat openai with messages containing developer → non-openai target

--- a/open-sse/translator/request/openai-to-claude/toolResultAdjacency.ts
+++ b/open-sse/translator/request/openai-to-claude/toolResultAdjacency.ts
@@ -7,19 +7,14 @@ type ClaudeMessage = {
 // Anthropic requires each user tool_result turn to immediately follow the
 // assistant turn containing the matching tool_use. OpenAI-compatible clients can
 // send intervening user text before a later role:"tool" message, so repair the
-// ordering here and drop true orphan results.
+// ordering here while preserving unmatched output for the Claude-format pass.
 export function enforceToolResultAdjacency(messages: ClaudeMessage[]): ClaudeMessage[] {
   const assistantByToolUseId = indexAssistantToolUses(messages);
   const resultsByAssistant = new Map<ClaudeMessage, ClaudeContentBlock[]>();
   const strippedMessages: ClaudeMessage[] = [];
 
   for (const msg of messages) {
-    stripAndCollectToolResults(
-      msg,
-      assistantByToolUseId,
-      resultsByAssistant,
-      strippedMessages
-    );
+    stripAndCollectToolResults(msg, assistantByToolUseId, resultsByAssistant, strippedMessages);
   }
 
   return insertAdjacentToolResults(strippedMessages, resultsByAssistant);
@@ -53,8 +48,19 @@ function stripAndCollectToolResults(
   for (const block of msg.content) {
     if (block.type !== "tool_result") {
       remainingBlocks.push(block);
-    } else {
-      collectMatchedToolResult(block, assistantByToolUseId, resultsByAssistant);
+      continue;
+    }
+
+    if (!collectMatchedToolResult(block, assistantByToolUseId, resultsByAssistant)) {
+      const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+      const serialized =
+        typeof block.content === "string"
+          ? block.content
+          : (JSON.stringify(block.content ?? "") ?? "");
+      remainingBlocks.push({
+        type: "text",
+        text: `[Unpaired tool result ${toolUseId || "unknown"}]\n${serialized}`,
+      });
     }
   }
 
@@ -67,16 +73,17 @@ function collectMatchedToolResult(
   block: ClaudeContentBlock,
   assistantByToolUseId: Map<string, ClaudeMessage>,
   resultsByAssistant: Map<ClaudeMessage, ClaudeContentBlock[]>
-): void {
+): boolean {
   const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
   const assistant = toolUseId ? assistantByToolUseId.get(toolUseId) : undefined;
-  if (!assistant) return;
+  if (!assistant) return false;
 
   const grouped = resultsByAssistant.get(assistant) ?? [];
-  if (grouped.some((toolResult) => toolResult.tool_use_id === toolUseId)) return;
+  if (grouped.some((toolResult) => toolResult.tool_use_id === toolUseId)) return false;
 
   grouped.push(block);
   resultsByAssistant.set(assistant, grouped);
+  return true;
 }
 
 function insertAdjacentToolResults(

--- a/tests/unit/cc-bridge-tool-pair-guard.test.ts
+++ b/tests/unit/cc-bridge-tool-pair-guard.test.ts
@@ -9,9 +9,11 @@ const { fixToolPairs, stripTrailingAssistantOrphanToolUse } =
 // Regression for the Anthropic 400:
 //   `messages.N: tool_use ids were found without tool_result blocks
 //   immediately after: toolu_...`
-// The CC bridge now invokes fixToolPairs in step 5c before serialization
-// so orphan tool_use blocks from mid-tool-call truncated histories are
-// stripped before reaching Anthropic.
+// The CC bridge invokes fixToolPairs in step 5c before serialization so
+// orphan tool_use blocks from mid-tool-call truncated histories are
+// stripped before reaching Anthropic (or, since #9308, reconciled with a
+// synthetic empty tool_result earlier in step 1 when a following user
+// turn exists — see the dedicated reconciliation test below).
 
 test("fixToolPairs strips orphan tool_use blocks from non-final assistant messages", () => {
   const messages = [
@@ -64,10 +66,20 @@ test("fixToolPairs is idempotent on clean histories", () => {
   assert.deepEqual(once, twice, "idempotent on clean histories");
 });
 
-test("buildAndSignClaudeCodeRequest invokes fixToolPairs via step 5c", async () => {
+test("buildAndSignClaudeCodeRequest reconciles an orphan tool_use with a synthetic tool_result via step 1/5c", async () => {
   // Pass messages via claudeBody (BuildRequestOptions accepts sourceBody/
   // normalizedBody/claudeBody — claudeBody is the path that preserves the
   // shape we expect for an Anthropic-format upstream).
+  //
+  // Contract changed by #9308 (`fix(claude): reconcile compacted tool
+  // results`): `prepareClaudeRequest` (step 1, via `fixToolUseOrdering`)
+  // now reconciles a tool_use against the immediately following user
+  // message *before* step 5c's `fixToolPairs` ever runs, and synthesizes
+  // an empty tool_result for an unanswered tool_use instead of dropping
+  // it — Anthropic only requires a matching tool_result block, so this
+  // keeps the call visible (and the turn valid) rather than discarding
+  // it. By the time step 5c's `fixToolPairs` sees it, the tool_use is no
+  // longer "orphan" and correctly survives.
   const result = await buildAndSignClaudeCodeRequest({
     model: "claude-opus-4-7",
     apiKey: "test-key",
@@ -100,8 +112,28 @@ test("buildAndSignClaudeCodeRequest invokes fixToolPairs via step 5c", async () 
   });
 
   const body = JSON.parse(result.bodyString);
-  const text = JSON.stringify(body.messages);
-  assert.ok(!text.includes("toolu_orphan"), "orphan tool_use must be stripped before send");
+  const messages = body.messages as Array<{
+    role: string;
+    content: Array<Record<string, unknown>>;
+  }>;
+
+  const orphanTurnIndex = messages.findIndex((m) =>
+    m.content?.some((b) => b.type === "tool_use" && b.id === "toolu_orphan")
+  );
+  assert.ok(orphanTurnIndex >= 0, "toolu_orphan tool_use must survive (reconciled, not stripped)");
+
+  const followUp = messages[orphanTurnIndex + 1];
+  const syntheticResult = followUp?.content?.find(
+    (b) => b.type === "tool_result" && b.tool_use_id === "toolu_orphan"
+  );
+  assert.ok(syntheticResult, "orphan tool_use must be paired with a synthetic tool_result");
+  assert.equal(syntheticResult?.content, "", "synthetic tool_result for an orphan must be empty");
+  assert.ok(
+    followUp?.content?.some((b) => b.type === "text" && b.text === "no tool result here"),
+    "original user text must be preserved alongside the synthetic tool_result"
+  );
+
+  const text = JSON.stringify(messages);
   assert.ok(text.includes("toolu_kept"), "paired tool_use must survive");
 });
 

--- a/tests/unit/claude-tool-result-pairing.test.ts
+++ b/tests/unit/claude-tool-result-pairing.test.ts
@@ -1,0 +1,86 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+import { translateRequest } from "../../open-sse/translator/index.ts";
+import { prepareClaudeRequest } from "../../open-sse/translator/helpers/claudeHelper.ts";
+
+function translate(body: Record<string, unknown>) {
+  return translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "claude-fable-5",
+    body,
+    true,
+    null,
+    "github"
+  ) as { messages: Array<{ role: string; content: Array<Record<string, unknown>> }> };
+}
+
+describe("Claude tool result pairing", () => {
+  test("salvages orphaned results and fills missing parallel results", () => {
+    const out = translate({
+      messages: [
+        { role: "user", content: "run" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call-valid",
+              type: "function",
+              function: { name: "exec", arguments: "{}" },
+            },
+            {
+              id: "call-missing",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call-valid", content: "valid output" },
+        { role: "tool", tool_call_id: "call-orphan", content: "orphan output" },
+        { role: "user", content: "continue" },
+      ],
+    });
+
+    const assistantIndex = out.messages.findIndex(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some((block) => block.type === "tool_use" && block.id === "call-valid")
+    );
+    const resultMessage = out.messages[assistantIndex + 1];
+    assert.ok(resultMessage, "expected a user result message after the tool-use turn");
+    const structuredResults = resultMessage.content.filter((block) => block.type === "tool_result");
+
+    assert.deepEqual(
+      structuredResults.map((block) => block.tool_use_id),
+      ["call-valid", "call-missing"]
+    );
+    assert.equal(structuredResults[1].content, "");
+    assert.match(JSON.stringify(resultMessage.content), /valid output/);
+    assert.match(JSON.stringify(resultMessage.content), /orphan output/);
+  });
+
+  test("salvages an orphaned result when it is the only message", () => {
+    const out = prepareClaudeRequest(
+      {
+        model: "claude-fable-5",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "call-orphan", content: "only output" }],
+          },
+        ],
+      },
+      "github"
+    );
+
+    assert.equal(
+      out.messages?.[0]?.content instanceof Array &&
+        out.messages[0].content.some((block) => block.type === "tool_result"),
+      false
+    );
+    assert.match(JSON.stringify(out.messages?.[0]?.content), /only output/);
+  });
+});


### PR DESCRIPTION
## Summary

- pairs Claude `tool_result` blocks only with tool calls from the immediately preceding assistant turn
- synthesizes empty results for unanswered parallel tool calls and preserves orphaned or duplicate output as labelled user text
- keeps explicit client tool-call IDs intact so compacted histories cannot misassociate results by position

## Attribution

Thanks to [@ryanngit](https://github.com/ryanngit) for the original implementation.

## Changes

- extend Claude request preparation with immediate tool-result reconciliation
- preserve unmatched output through the OpenAI-to-Claude adjacency repair
- add regression coverage for parallel missing results and orphan-only histories

## Test plan

- [x] focused translator regression suite (68 tests)
- [x] `npx eslint` on all changed files
- [x] `npm run typecheck:core`
- [ ] `npm run typecheck:noimplicit:core` — pre-existing failures remain in `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`; no changed-file errors
- [x] `npm run test:vitest` (34 files, 291 tests)
- [x] `npm run check:docs-all`
- [x] `npm run check:cycles`