### PR TITLE
fix(auth): let an agy request find the connection it authorized

### DIFF
--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -927,6 +927,8 @@ export { readHeaderValue, type AuthRequestHeaders } from "./headerReader.ts";
 const PROVIDER_SEARCH_PAIRS: string[][] = [
   ["nvidia", "nvidia_nim"],
   ["kimi-coding", "kimi-coding-apikey"],
+  // The model layer canonicalizes `agy/` to `antigravity`, but the Antigravity
+  // CLI card stores its connection under `agy`. Same account, either id serves.
   ["antigravity", "agy"],
 ];
 /**

--- a/tests/unit/8779-agy-prefix-credential-lookup.test.ts
+++ b/tests/unit/8779-agy-prefix-credential-lookup.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #8779 -- an `agy/` request must find the connection the user actually
+ * authorized, which is stored under `agy`.
+ *
+ * The model layer deliberately canonicalizes the `agy/` prefix to
+ * `antigravity` (#8013 aligned the official clients and the callable catalog,
+ * and DEFAULT_MODEL_ALIAS_SEED ships `gemini-3.1-pro -> agy/gemini-pro-agent`
+ * on that assumption). The connections layer does the opposite: the Antigravity
+ * CLI card writes its row under `agy`.
+ *
+ * Those two are individually intentional and jointly broken. An operator whose
+ * only Antigravity connections came from the CLI card gets
+ * "No credentials for antigravity" on every request. A deployment that also has
+ * `antigravity` rows never sees it -- the lookup finds those instead and the
+ * `agy` rows simply go unused, which is why this survived in production.
+ *
+ * Fixed by pairing the two ids in PROVIDER_SEARCH_PAIRS, the mechanism that
+ * already exists for exactly this (nvidia/nvidia_nim, #922).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-8779-agy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+const model = await import("../../open-sse/services/model.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedOnly(provider: string) {
+  await resetStorage();
+  await providersDb.createProviderConnection({
+    provider,
+    authType: "oauth",
+    email: `${provider}@example.test`,
+    accessToken: `tok-${provider}`,
+    isActive: true,
+    testStatus: "active",
+    priority: 1,
+  });
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("the agy/ prefix still canonicalizes to antigravity (#8013 unchanged)", () => {
+  const parsed = model.parseModel("agy/gemini-3-pro");
+  assert.equal(parsed.provider, "antigravity");
+  assert.equal(parsed.providerAlias, "agy");
+});
+
+test("an agy/ request finds credentials when only agy connections exist", async () => {
+  await seedOnly("agy");
+
+  // The real path: parse the model string, then ask for the credentials of
+  // whatever provider the parse produced. Before the fix this returned null
+  // and logged "No credentials for antigravity".
+  const parsed = model.parseModel("agy/gemini-3-pro");
+  const creds = await auth.getProviderCredentials(parsed.provider as string);
+
+  assert.ok(
+    creds,
+    `no credentials for "${parsed.provider}" -- the agy row the CLI card wrote ` +
+      `is unreachable, which is #8779`
+  );
+});
+
+test("the pair works in the other direction too", async () => {
+  await seedOnly("antigravity");
+  const creds = await auth.getProviderCredentials("agy");
+  assert.ok(creds, "an antigravity row must serve an agy lookup");
+});
+
+test("each id still finds its own rows", async () => {
+  await seedOnly("agy");
+  assert.ok(await auth.getProviderCredentials("agy"));
+
+  await seedOnly("antigravity");
+  assert.ok(await auth.getProviderCredentials("antigravity"));
+});
+
+test("the pair does not make unrelated providers findable", async () => {
+  await seedOnly("agy");
+  // gemini shares the upstream vendor but not the account; it must stay empty.
+  assert.equal(await auth.getProviderCredentials("gemini"), null);
+});


### PR DESCRIPTION
Supersedes #8779, which is unreviewable: its head branch contains a
`Merge upstream/release/v3.8.49 into fix/agy-credential-lookup` commit, and
because upstream force-pushes release branches that stranded the merge-base
at `a1dc2270a` (2026-03-08). GitHub therefore diffs from five months back and
renders 11,219 files instead of the change. This PR is cut fresh from
`upstream/release/v3.8.50` and carries the same intent in 3 lines.

## The bug

The model layer canonicalizes the `agy/` prefix to the provider id
`antigravity`. That is deliberate: it is what lets the shipped default alias
`gemini-3.1-pro -> agy/gemini-pro-agent` resolve, and `getModelInfo` is
tested to canonicalize it.

The connections layer does the opposite. The Antigravity CLI card writes its
connection row under `agy`.

Each half is intentional. Together they strand the credential: an operator
whose only Antigravity connections came from the CLI card gets
`No credentials for antigravity` on every request, because the search pool
built for `antigravity` never looks at `agy` rows.

A deployment that also has `antigravity` rows never sees it -- the lookup
finds those instead and the `agy` rows silently go unused. That is why this
survived in production long enough to be reported rather than caught.

## The fix

```diff
 const PROVIDER_SEARCH_PAIRS: string[][] = [
   ["nvidia", "nvidia_nim"],
   ["kimi-coding", "kimi-coding-apikey"],
+  // The model layer canonicalizes `agy/` to `antigravity`, but the Antigravity
+  // CLI card stores its connection under `agy`. Same account, either id serves.
+  ["antigravity", "agy"],
 ];
```

`PROVIDER_SEARCH_PAIRS` already exists for exactly this shape: two separately
registered provider ids backed by one upstream account, where a credential
lookup for either must find rows stored under the other. `nvidia`/`nvidia_nim`
and `kimi-coding`/`kimi-coding-apikey` are the existing entries.

Nothing in the model layer changes, so the `agy/` prefix still canonicalizes
exactly as before and the shipped default alias is unaffected.

## Why not the generic approach

An earlier attempt expanded the alias map generically inside
`getProviderSearchPool`, adding every alias that maps to the canonical
provider. That is broader, and it broke an unrelated provider: `opencode-zen`
has `anonymousFallback: true` and shares a public endpoint with its no-auth
sibling `opencode`. The alias map (`opencode -> opencode-zen`) pulled the
sibling's connection into the search pool, which was then returned as a real
credential and silently dropped the proxy configured on the sibling's noauth
row. It needed an `anonymousFallback` special case to patch around, and
whether other alias pairs carry the same hazard was never established.

The pair entry touches two ids and nothing else.

## Verification

The pool change is additive in both directions, measured rather than argued:

| lookup | pool before | pool after | lost |
|---|---|---|---|
| `antigravity` | `["antigravity"]` | `["antigravity","agy"]` | none |
| `agy` | `["agy"]` | `["agy","antigravity"]` | none |

Both ids are built-in providers, so the pre-pair path already returned before
the `provider_nodes` expansion; the pair's early return skips nothing that was
reachable.

`tests/unit/8779-agy-prefix-credential-lookup.test.ts` covers five cases
against a real ephemeral SQLite instance and the real `parseModel` /
`getProviderCredentials` entry points, not mocks:

1. the `agy/` prefix still canonicalizes to `antigravity` (guards the model
   layer against regression from this change)
2. an `agy/` request finds credentials when only `agy` connections exist
   (the reported bug)
3. the pair resolves in the other direction too
4. each id still finds its own rows directly
5. the pair does not make unrelated providers findable

Bug-injected to confirm the tests bind to the fix: deleting the pair entry
fails cases 2 and 3 while 1, 4 and 5 still pass; restoring it returns 5/5.

A 206-file regression sweep over every test touching `agy`, `antigravity`,
credential lookup or the search pool ran 2,065 tests. The only failures were
in `tests/unit/chat-helpers.test.ts`, which fails identically on unmodified
upstream (verified across four runs, two per side), so they are pre-existing
and unrelated.

`npm run lint`, `npm run typecheck:core`, prettier and the file-size gate are
all clean on the change.

## Known adjacent issue, not fixed here

`getProviderCredentials` branches on the raw `provider` string rather than a
canonicalized id at six sites (`src/sse/services/auth.ts` lines 1109, 1237,
1255, 1666, 1732, 2059). Since `resolveProviderId("agy")` is `"agy"`, a call
arriving with `provider = "agy"` skips the Antigravity-specific quota lockout
and credits handling. Those six sites are identical in unmodified upstream and
predate this change, so fixing them belongs in its own PR -- doing it here
would widen a 3-line change into a refactor of credential selection.
