### PR TITLE
fix: resolve two macOS-only test/script failures in unit suite (#8577)

### DIFF
--- a/bin/restore-policies.sh
+++ b/bin/restore-policies.sh
@@ -39,7 +39,8 @@ snap="$(ops_find_snapshot "$ID")"
 
 # Policy definition tables present in BOTH the snapshot and the live DB. GLOB
 # keeps `_` literal; we drop usage counters / logs so accounting isn't rewound.
-readarray -t tables < <(
+tables=()
+while IFS= read -r t; do tables+=("$t"); done < <(
   sqlite3 "$snap/storage.sqlite" \
     "SELECT name FROM sqlite_master WHERE type='table' AND name GLOB 'api_key*' \
        AND name NOT GLOB '*counter*' AND name NOT GLOB '*_log*' ORDER BY name;"

--- a/changelog.d/fixes/8577-fix.plan.md
+++ b/changelog.d/fixes/8577-fix.plan.md
@@ -1,0 +1,2 @@
+- fix(tests): make machineId tests macOS-compatible by stubbing ioreg in test helper (#8577)
+- fix(scripts): replace bash 4+ readarray with compatible while-read loop in restore-policies.sh (#8577)

--- a/tests/unit/shared/machineId.test.ts
+++ b/tests/unit/shared/machineId.test.ts
@@ -38,6 +38,14 @@ function disableWindowsRegistryStrategy(): () => void {
     return origReadFileSync(filePath, encoding);
   };
 
+  const origExecSync = childProcess.execSync;
+  childProcess.execSync = ((cmd: Parameters<typeof childProcess.execSync>[0], opts: Parameters<typeof childProcess.execSync>[1]) => {
+    if (String(cmd ?? "").includes("ioreg")) {
+      throw new Error("ENOENT: mocked ioreg not available");
+    }
+    return origExecSync(cmd, opts);
+  }) as typeof childProcess.execSync;
+
   return () => {
     if (origSysRoot !== undefined) {
       process.env.SystemRoot = origSysRoot;
@@ -50,6 +58,7 @@ function disableWindowsRegistryStrategy(): () => void {
       delete process.env.windir;
     }
     fs.readFileSync = origReadFileSync;
+    childProcess.execSync = origExecSync;
   };
 }
 


### PR DESCRIPTION
Closes #8577

Two surgical fixes for macOS-only failures that never surface on Linux CI:

1. `bin/restore-policies.sh`: `readarray` is bash 4+, fails on macOS 3.2. Replaced with `while IFS= read -r` loop.

2. `tests/unit/shared/machineId.test.ts`: `disableWindowsRegistryStrategy()` did not neutralize macOS ioreg (Strategy 2), so mocked `os.hostname()` was never reached on macOS. Stubbed `execSync` to throw for ioreg commands.

`src/shared/utils/machineId.ts` is correct and unchanged — ioreg is the right strategy on macOS, the test just needs to isolate from it.

All 10 machineId tests and all 6 ops-scripts tests pass.