### PR TITLE
fix: skip synthetic Next.js standalone package.json without name field in resolveProjectRoot (#8956)

### DIFF
--- a/changelog.d/fixes/8956-fix.plan.md
+++ b/changelog.d/fixes/8956-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(auto-update): skip synthetic Next.js standalone package.json without `name` field in resolveProjectRoot (#8956)

--- a/src/lib/system/autoUpdate.ts
+++ b/src/lib/system/autoUpdate.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { closeSync, mkdirSync, openSync, existsSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, existsSync, readFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -7,15 +7,36 @@ import { homedir } from "node:os";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Check whether a directory's package.json is a valid project-root marker by
+ * requiring a non-empty `name` field.  The Next.js standalone build writes a
+ * synthetic `.build/next/package.json` = `{"type":"commonjs"}` that should not
+ * be mistaken for the real project root.
+ *
+ * Swallows read / parse errors (missing file, invalid JSON) and returns false
+ * so the walk-up continues.
+ *
+ * @internal — exported for testability.
+ */
+export function isValidPackageMarker(dir: string): boolean {
+  try {
+    const content = readFileSync(path.join(dir, "package.json"), "utf-8");
+    const pkg = JSON.parse(content);
+    return typeof pkg.name === "string" && pkg.name.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 /** @internal — exported for testability. */
 export function resolveProjectRoot(
   fallback: string,
   startDir: string = typeof __dirname !== "undefined" ? __dirname : process.cwd()
 ): string {
-  const markers = ["package.json", ".git"] as const;
   let dir = path.resolve(startDir);
   while (true) {
-    if (markers.some((m) => existsSync(path.join(dir, m)))) return dir;
+    if (existsSync(path.join(dir, ".git"))) return dir;
+    if (existsSync(path.join(dir, "package.json")) && isValidPackageMarker(dir)) return dir;
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;

--- a/tests/unit/auto-update.test.ts
+++ b/tests/unit/auto-update.test.ts
@@ -404,7 +404,7 @@ test("resolveProjectRoot walks up from start dir to nearest package.json or .git
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-root-"));
   const subDir = path.join(tempRoot, "sub", "deep");
   fs.mkdirSync(subDir, { recursive: true });
-  fs.writeFileSync(path.join(tempRoot, "package.json"), "{}");
+  fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "omniroute" }));
 
   try {
     // Walking up from a deep subdir that does not have markers must find the real root.

--- a/tests/unit/repro-8956.test.ts
+++ b/tests/unit/repro-8956.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { resolveProjectRoot } = await import("../../src/lib/system/autoUpdate.ts");
+
+test("repro-8956: resolveProjectRoot skips synthetic .build/next/package.json (no name field)", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "repro-8956-"));
+  try {
+    // Simulate a Next.js standalone build layout inside a real repo:
+    //   <tmp>/repo/.git/             (real git marker)
+    //   <tmp>/repo/package.json      (real repo root, has a "name" field)
+    //   <tmp>/repo/.build/next/package.json   (synthetic marker, {"type":"commonjs"}, no name)
+    //   <tmp>/repo/.build/next/server/chunks/ (where the bundled module lives at runtime)
+    const repoRoot = path.join(tmp, "repo");
+    const buildPkgDir = path.join(repoRoot, ".build", "next");
+    const chunksDir = path.join(buildPkgDir, "server", "chunks");
+
+    fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+    fs.mkdirSync(chunksDir, { recursive: true });
+
+    // Real root package.json with a name
+    fs.writeFileSync(path.join(repoRoot, "package.json"), JSON.stringify({ name: "omniroute" }));
+    // Synthetic Next.js standalone build marker — no "name" field
+    fs.writeFileSync(path.join(buildPkgDir, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+    // Start from the chunks dir (simulating __dirname at runtime)
+    const root = resolveProjectRoot("/fallback", chunksDir);
+
+    // Must NOT stop at .build/next — must walk up to the repo root that has .git
+    assert.equal(
+      root,
+      repoRoot,
+      `resolveProjectRoot returned ${root}, expected the repo root ${repoRoot} ` +
+        "(it stopped at the synthetic .build/next/package.json marker)"
+    );
+
+    // The resolved root must own .git so source-mode validation passes
+    assert.ok(
+      fs.existsSync(path.join(root, ".git")),
+      `PROJECT_ROOT resolved to ${root}, which lacks .git`
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repro-8956: resolveProjectRoot still finds package.json with a name field", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "repro-8956-named-"));
+  try {
+    // A normal repo root: has .git AND a named package.json
+    const repoRoot = path.join(tmp, "my-repo");
+    const subDir = path.join(repoRoot, "some", "deep", "path");
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(path.join(repoRoot, "package.json"), JSON.stringify({ name: "my-app" }));
+    fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+
+    const root = resolveProjectRoot("/fallback", subDir);
+    assert.equal(root, repoRoot);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #8956

resolveProjectRoot walks up from __dirname and stops at the first directory with package.json or .git. At runtime the module is bundled into Next.js server chunks under .build/next/, and the Next standalone build writes a synthetic .build/next/package.json = {"type":"commonjs"} (verified present). PROJECT_ROOT therefore resolves to \<repo\>/.build/next, which has no .git, so the source-mode validation emits "Not a git repository."

Fix: only accept a package.json as a project-root marker when its parsed content has a non-empty `name` field. The synthetic marker lacks `name`, so the walk-up continues to the real repo root. Keep .git as a hard marker.