### PR TITLE
fix(providers): copilot-m365-web enterprise turns send disconnectBehavior=continue (#8971)

### DIFF
--- a/changelog.d/fixes/8971-fix.plan.md
+++ b/changelog.d/fixes/8971-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(providers): copilot-m365-web enterprise turns send disconnectBehavior=continue (#8971)

--- a/open-sse/executors/copilot-m365-frames.ts
+++ b/open-sse/executors/copilot-m365-frames.ts
@@ -166,6 +166,13 @@ export interface ChatInvocationOptions {
   tone?: string;
   /** Tier-specific allowed message types; defaults to {@link ALLOWED_MESSAGE_TYPES}. */
   allowedMessageTypes?: readonly string[];
+  /**
+   * Tier-specific disconnect behavior sent in every type:4 chat invocation. The work
+   * Surface rejects any value other than exactly "continue" (#8971). Defaults to ""
+   * for individual/consumer/EDU tiers; {@link resolveChatInvocationOverrides} returns
+   * "continue" for the enterprise tier.
+   */
+  disconnectBehavior?: string;
 }
 
 /**
@@ -178,18 +185,21 @@ export function resolveChatInvocationOverrides(tier: string | undefined): {
   optionsSets: string[];
   tone: string;
   allowedMessageTypes: readonly string[];
+  disconnectBehavior: string;
 } {
   if (tier === "enterprise") {
     return {
       optionsSets: [...M365_ENTERPRISE_OPTION_SETS],
       tone: "Magic",
       allowedMessageTypes: [...ALLOWED_MESSAGE_TYPES, ...M365_ENTERPRISE_EXTRA_MESSAGE_TYPES],
+      disconnectBehavior: "continue",
     };
   }
   return {
     optionsSets: [...M365_DEFAULT_OPTION_SETS],
     tone: "",
     allowedMessageTypes: ALLOWED_MESSAGE_TYPES,
+    disconnectBehavior: "",
   };
 }
 
@@ -253,7 +263,7 @@ export function buildChatInvocation(opts: ChatInvocationOptions): Record<string,
         isSbsSupported: false,
         tone: opts.tone ?? "",
         renderReferencesBehindEOS: true,
-        disconnectBehavior: "",
+        disconnectBehavior: opts.disconnectBehavior ?? "",
       },
     ],
   };

--- a/tests/unit/copilot-m365-enterprise-invocation-7870.test.ts
+++ b/tests/unit/copilot-m365-enterprise-invocation-7870.test.ts
@@ -158,3 +158,21 @@ test("#7870: EDU-tier chat invocation payload stays byte-identical to today (una
   assert.ok(optionsSets.includes("enable_msa_user"));
   assert.equal(invocationArgs.tone, "");
 });
+
+test("#8971: enterprise-tier chat invocation must send disconnectBehavior=continue", async () => {
+  const invocationArgs = await sendChatInvocation("enterprise");
+  assert.equal(
+    invocationArgs.disconnectBehavior,
+    "continue",
+    `enterprise-tier invocation must carry disconnectBehavior="continue"; got ${JSON.stringify(invocationArgs.disconnectBehavior)}`
+  );
+});
+
+test("#8971: individual (no tier) chat invocation disconnectBehavior remains empty (byte-identical to #4042)", async () => {
+  const invocationArgs = await sendChatInvocation(undefined);
+  assert.equal(
+    invocationArgs.disconnectBehavior,
+    "",
+    `individual-tier invocation must carry disconnectBehavior=""; got ${JSON.stringify(invocationArgs.disconnectBehavior)}`
+  );
+});


### PR DESCRIPTION
Closes #8971

The enterprise-tier copilot-m365-web invocation hardcoded disconnectBehavior: "" in buildChatInvocation(). The work Surface rejects any value other than exactly "continue", returning HTTP 502 / no content on every turn.

Root cause: ChatInvocationOptions had no disconnectBehavior member, so neither resolveChatInvocationOverrides() nor any caller could override the hardcoded empty string.

Fix: added disconnectBehavior?: string to ChatInvocationOptions, return "continue" from resolveChatInvocationOverrides() for tier==="enterprise" (and "" for other tiers), and send opts.disconnectBehavior ?? "" in buildChatInvocation().

TDD: 2 new assertions (enterprise gets "continue", individual keeps "") driven through the real executor path. All 35 existing m365/copilot tests remain passing.