### PR TITLE
fix(providers): gate premium opencode-zen/opencode-go models behind an API key (#8681)

### DIFF
--- a/changelog.d/fixes/8681-fix.plan.md
+++ b/changelog.d/fixes/8681-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(providers): gate premium opencode-zen/opencode-go models behind an API key (#8681)

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -41,6 +41,31 @@ const OPENCODE_COOLDOWN_MAX_MS = 60_000;
 const EFFORT_LEVELS = ["low", "medium", "high", "max"] as const;
 
 /**
+ * Models that work WITHOUT any API key on the free/noauth opencode tier.
+ *
+ * The upstream free tier rotates frequently — when a `-free` suffix model is
+ * delisted upstream, the upstream returns "Model X is not supported" (a separate
+ * issue from this gate). The set is defined by two data sources:
+ *
+ *   1. **Known free models** — models explicitly listed in the noauth
+ *      `opencode` provider registry (`open-sse/config/providers/registry/opencode/index.ts`).
+ *      These are the canonical free models. `deepseek-v4-flash-free` appears in both
+ *      the noauth AND the zen registry (it is free on both tiers).
+ *   2. **`-free` suffix** — any model whose id ends in `-free`. This automatically
+ *      covers upstream free-tier additions without a code deploy.
+ *
+ * For `opencode-go`, there is no free tier — ALL models require an API key.
+ */
+const OPENCODE_FREE_MODELS = new Set([
+  "big-pickle",
+  "deepseek-v4-flash-free",
+  "mimo-v2.5-free",
+  "hy3-free",
+  "nemotron-3-ultra-free",
+  "north-mini-code-free",
+]);
+
+/**
  * Models on opencode-go that support effort-tier aliases. Each entry maps the
  * canonical base id to the set of effort suffixes the upstream supports.
  *
@@ -86,7 +111,31 @@ export function parseEffortLevel(model: string): { baseModel: string; effort: st
   return null;
 }
 
+/**
+ * Determine whether a model requires an API key on the given opencode provider.
+ *
+ * - `opencode-go`: ALL models require a key (no free tier).
+ * - `opencode` / `opencode-zen`: premium = any model NOT in the free set (known
+ *   free models OR ending in `-free`).
+ * - Unknown models are assumed premium (fail-safe).
+ */
+export function isPremiumOpencodeModel(model: string, provider: string): boolean {
+  // opencode-go has no free tier — every model requires a key.
+  if (provider === "opencode-go") return true;
+
+  // Models ending in `-free` are always free on the noauth/zen tier.
+  if (model.endsWith("-free")) return false;
+
+  // Check the known free model catalog.
+  return !OPENCODE_FREE_MODELS.has(model);
+}
+
 export class OpencodeExecutor extends BaseExecutor {
+  /** Delegates to `isPremiumOpencodeModel`. Exported for testability. */
+  static isPremiumModel(model: string, provider: string): boolean {
+    return isPremiumOpencodeModel(model, provider);
+  }
+
   _requestFormat: string | null = null;
 
   /**
@@ -181,6 +230,34 @@ export class OpencodeExecutor extends BaseExecutor {
 
   async execute(input: ExecuteInput) {
     this._requestFormat = getModelTargetFormat(this.provider, input.model) || "openai";
+
+    // #8681: Gate premium opencode models behind a usable API key.
+    // When the connection is keyless (no apiKey, no accessToken) and the model
+    // is a premium model (not on the free tier), return a clear 402 error
+    // instead of proxying the raw upstream 401 "Missing API key" response.
+    const creds = input.credentials;
+    const isKeyless =
+      !creds?.apiKey && !creds?.accessToken && !creds?.providerSpecificData?.extraApiKeys;
+    if (isKeyless && isPremiumOpencodeModel(input.model, this.provider)) {
+      const bodyJson = JSON.stringify({
+        error: {
+          message:
+            "This model requires an opencode API key — add one in Settings → Providers.",
+          type: "invalid_request_error",
+          code: "premium_model_requires_key",
+        },
+      });
+      return {
+        response: new Response(bodyJson, {
+          status: 402,
+          headers: { "Content-Type": "application/json" },
+        }),
+        url: "",
+        headers: {} as Record<string, string>,
+        transformedBody: null,
+      };
+    }
+
     try {
       this.syncAccountsFromCredentials(input.credentials);
 

--- a/tests/unit/7993-noauth-proxy-routing.test.ts
+++ b/tests/unit/7993-noauth-proxy-routing.test.ts
@@ -110,7 +110,7 @@ test("#7993 a canonical 'opencode/<model>' resolved combo/catalog target egresse
 
   try {
     const result = await exec.execute({
-      model: "grok-code",
+      model: "deepseek-v4-flash-free",
       body: { messages: [{ role: "user", content: "hi" }], stream: false },
       stream: false,
       signal: null,

--- a/tests/unit/opencode-premium-keyless-gate-8681.test.ts
+++ b/tests/unit/opencode-premium-keyless-gate-8681.test.ts
@@ -1,0 +1,168 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { OpencodeExecutor } = await import("../../open-sse/executors/opencode.ts");
+const { PROVIDER_MODELS } = await import("../../open-sse/config/providerModels.ts");
+
+function createInput(model, stream = true, credentials = null) {
+  return {
+    model,
+    stream,
+    credentials,
+    body: {
+      model,
+      stream,
+      messages: [{ role: "user", content: "hello" }],
+    },
+  };
+}
+
+function createMockResponse() {
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("OpencodeExecutor — premium model keyless gate (#8681)", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, _options?: RequestInit) => {
+      return createMockResponse();
+    }) as typeof globalThis.fetch;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("isPremiumModel", () => {
+    it("returns false for known free models on opencode-zen", () => {
+      // Free models from the opencode (noauth) registry
+      assert.equal(OpencodeExecutor.isPremiumModel("big-pickle", "opencode-zen"), false);
+      assert.equal(OpencodeExecutor.isPremiumModel("deepseek-v4-flash-free", "opencode-zen"), false);
+    });
+
+    it("returns false for models ending in -free on opencode-zen", () => {
+      assert.equal(OpencodeExecutor.isPremiumModel("mimo-v2.5-free", "opencode-zen"), false);
+      assert.equal(OpencodeExecutor.isPremiumModel("nemotron-3-ultra-free", "opencode-zen"), false);
+      assert.equal(OpencodeExecutor.isPremiumModel("north-mini-code-free", "opencode-zen"), false);
+      assert.equal(OpencodeExecutor.isPremiumModel("hy3-free", "opencode-zen"), false);
+    });
+
+    it("returns true for premium models on opencode-zen", () => {
+      assert.equal(OpencodeExecutor.isPremiumModel("gpt-5", "opencode-zen"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("gpt-5-nano", "opencode-zen"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("claude-sonnet-4-5", "opencode-zen"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("gemini-3-flash", "opencode-zen"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("kimi-k2.6", "opencode-zen"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("glm-5", "opencode-zen"), true);
+    });
+
+    it("returns true for ALL models on opencode-go (no free tier)", () => {
+      assert.equal(OpencodeExecutor.isPremiumModel("deepseek-v4-pro", "opencode-go"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("kimi-k2.7-code", "opencode-go"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("glm-5.2", "opencode-go"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("deepseek-v4-flash-free", "opencode-go"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("big-pickle", "opencode-go"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("mimo-v2.5-free", "opencode-go"), true);
+    });
+
+    it("returns false for free models on the opencode (noauth) provider", () => {
+      assert.equal(OpencodeExecutor.isPremiumModel("deepseek-v4-flash-free", "opencode"), false);
+      assert.equal(OpencodeExecutor.isPremiumModel("big-pickle", "opencode"), false);
+      assert.equal(OpencodeExecutor.isPremiumModel("hy3-free", "opencode"), false);
+    });
+
+    it("returns true for premium models on the opencode (noauth) provider", () => {
+      assert.equal(OpencodeExecutor.isPremiumModel("gpt-5", "opencode"), true);
+      assert.equal(OpencodeExecutor.isPremiumModel("claude-sonnet-4-5", "opencode"), true);
+    });
+
+    it("returns true for unknown models on any opencode provider", () => {
+      assert.equal(OpencodeExecutor.isPremiumModel("unknown-random-model", "opencode-zen"), true);
+    });
+  });
+
+  describe("execute with keyless credentials", () => {
+    const zenExecutor = new OpencodeExecutor("opencode-zen");
+
+    it("returns 402 for premium model gpt-5 with keyless credentials", async () => {
+      const result = await zenExecutor.execute(createInput("gpt-5", true, null));
+      const response = result instanceof Response ? result : result.response;
+      const body = await response.json() as { error: { message: string } };
+      assert.equal(response.status, 402);
+      assert.ok(
+        body.error.message.includes("API key"),
+        `Expected message to mention "API key" — got: ${body.error.message}`
+      );
+      assert.ok(
+        !body.error.message.includes("Missing API key"),
+        "Should NOT be the raw upstream 'Missing API key' message"
+      );
+    });
+
+    it("returns 402 for premium model claude-sonnet-4-5 with keyless credentials", async () => {
+      const result = await zenExecutor.execute(createInput("claude-sonnet-4-5", true, null));
+      const response = result instanceof Response ? result : result.response;
+      assert.equal(response.status, 402);
+    });
+
+    it("allows free model deepseek-v4-flash-free with keyless credentials", async () => {
+      // Should reach the upstream fetch (mock returns 200)
+      const result = await zenExecutor.execute(createInput("deepseek-v4-flash-free", true, null));
+      const response = result instanceof Response ? result : result.response;
+      // Should NOT be 402 (the premium gate); should reach the mock fetch
+      assert.notEqual(response.status, 402);
+    });
+
+    it("allows free model big-pickle with keyless credentials", async () => {
+      const result = await zenExecutor.execute(createInput("big-pickle", true, null));
+      const response = result instanceof Response ? result : result.response;
+      assert.notEqual(response.status, 402);
+    });
+  });
+
+  describe("execute with valid key credentials", () => {
+    const zenExecutor = new OpencodeExecutor("opencode-zen");
+
+    it("allows premium model gpt-5 with a valid API key", async () => {
+      // Should reach the upstream fetch (mock returns 200)
+      const result = await zenExecutor.execute(createInput("gpt-5", true, { apiKey: "valid-key" }));
+      const response = result instanceof Response ? result : result.response;
+      assert.notEqual(response.status, 402);
+    });
+
+    it("allows premium model claude-sonnet-4-5 with a valid API key", async () => {
+      const result = await zenExecutor.execute(
+        createInput("claude-sonnet-4-5", true, { apiKey: "valid-key" })
+      );
+      const response = result instanceof Response ? result : result.response;
+      assert.notEqual(response.status, 402);
+    });
+  });
+
+  describe("execute with keyless credentials on opencode-go", () => {
+    const goExecutor = new OpencodeExecutor("opencode-go");
+
+    it("returns 402 for ANY model with keyless credentials (opencode-go has no free tier)", async () => {
+      const result = await goExecutor.execute(createInput("deepseek-v4-pro", true, null));
+      const response = result instanceof Response ? result : result.response;
+      assert.equal(response.status, 402);
+    });
+  });
+
+  describe("execute with valid key on opencode-go", () => {
+    const goExecutor = new OpencodeExecutor("opencode-go");
+
+    it("allows deepseek-v4-pro with a valid API key", async () => {
+      const result = await goExecutor.execute(
+        createInput("deepseek-v4-pro", true, { apiKey: "valid-key" })
+      );
+      const response = result instanceof Response ? result : result.response;
+      assert.notEqual(response.status, 402);
+    });
+  });
+});

--- a/tests/unit/opencode-proxy-rotation-4954.test.ts
+++ b/tests/unit/opencode-proxy-rotation-4954.test.ts
@@ -117,7 +117,7 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
     installFetchStub([200]);
 
     const result = await exec.execute({
-      model: "grok-code",
+      model: "deepseek-v4-flash-free",
       body: { messages: [{ role: "user", content: "hi" }], stream: false },
       stream: false,
       signal: null,
@@ -146,7 +146,7 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
     installFetchStub([429, 200]);
 
     const result = await exec.execute({
-      model: "grok-code",
+      model: "deepseek-v4-flash-free",
       body: { messages: [{ role: "user", content: "hi" }], stream: false },
       stream: false,
       signal: null,
@@ -186,7 +186,7 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
     };
 
     await exec.execute({
-      model: "grok-code",
+      model: "deepseek-v4-flash-free",
       body: { messages: [{ role: "user", content: "hi" }], stream: false },
       stream: false,
       signal: null,
@@ -226,7 +226,7 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
     const sink: { proxy: any } = { proxy: null };
     await runWithAppliedProxyCapture(sink, () =>
       exec.execute({
-        model: "grok-code",
+        model: "deepseek-v4-flash-free",
         body: { messages: [{ role: "user", content: "hi" }], stream: false },
         stream: false,
         signal: null,


### PR DESCRIPTION
Closes #8681

Root cause: the free/noauth opencode provider (and opencode-zen/opencode-go) expose the full upstream model list including PREMIUM models (gpt-5, claude-*, gemini-*, kimi-k2.6, etc.). With a keyless connection, the executor sends no Authorization header and upstream returns 401 'Missing API key' for any premium model — which is the exact string the client shows.

Fix: add a request-time gate in OpencodeExecutor.execute() that detects keyless connections + premium models and returns a clear 402 error with message 'This model requires an opencode API key — add one in Settings → Providers.' instead of proxying the raw upstream 401.

Free models (known free catalog + `-free` suffix) continue to work keyless (deepseek-v4-flash-free, big-pickle, etc.). Users with a valid opencode API key keep premium access. opencode-go has no free tier — all models require a key.