### PR TITLE
fix(proxies): resolveProxyForConnection now returns the proxy name, so the dashboard badge shows the name instead of the hostname (#8995)

### DIFF
--- a/changelog.d/fixes/8995-fix.plan.md
+++ b/changelog.d/fixes/8995-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(proxies): resolveProxyForConnection now returns the proxy name, so the dashboard badge shows the name instead of the hostname (#8995)

--- a/src/lib/db/proxies/mappers.ts
+++ b/src/lib/db/proxies/mappers.ts
@@ -143,6 +143,7 @@ export function toRegistryProxyResolution(row: unknown, level: ProxyScope, level
       username: record.username,
       password: record.password,
       family: typeof record.family === "string" ? record.family : "auto",
+      ...(typeof record.name === "string" && record.name ? { name: record.name } : {}),
       ...(relayAuth !== undefined ? { relayAuth } : {}),
     },
     level,

--- a/src/lib/db/proxies/rotation.ts
+++ b/src/lib/db/proxies/rotation.ts
@@ -195,7 +195,7 @@ function fetchAlivePoolRows(
   matchAnyScopeId: boolean
 ): JsonRecord[] {
   const baseSelect =
-    "SELECT p.id, p.type, p.host, p.port, p.username, p.password, p.notes, p.family, a.position AS __pos, a.id AS __aid " +
+    "SELECT p.id, p.name, p.type, p.host, p.port, p.username, p.password, p.notes, p.family, a.position AS __pos, a.id AS __aid " +
     "FROM proxy_assignments a JOIN proxy_registry p ON p.id = a.proxy_id WHERE a.scope = ? ";
   const order = " ORDER BY a.position ASC, a.id ASC";
   if (matchAnyScopeId) {

--- a/tests/unit/repro-8995.test.ts
+++ b/tests/unit/repro-8995.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-repro-8995-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const proxiesDb = await import("../../src/lib/db/proxies.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+
+async function resetStorage() {
+  delete process.env.INITIAL_PASSWORD;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#8995: resolveProxyForConnection surfaces the proxy NAME for an account-level assignment", async () => {
+  await resetStorage();
+
+  // Create a named proxy
+  const created = await proxiesDb.createProxy({
+    name: "My US Proxy",
+    type: "http",
+    host: "203.0.113.10",
+    port: 3128,
+    username: "user1",
+    password: "pass1",
+  });
+  assert.ok(created?.id, "proxy must be created");
+
+  // Assign at account (connection) scope
+  await proxiesDb.assignProxyToScope("account", "conn-8995", created.id);
+
+  // Resolve — this is what the dashboard calls via /api/settings/proxy?resolve=conn-8995
+  const result = await settingsDb.resolveProxyForConnection("conn-8995");
+
+  assert.ok(result, "resolveProxyForConnection must return a result");
+  assert.ok(result.proxy, "result must have a proxy object");
+  assert.equal(
+    result.proxy.name,
+    "My US Proxy",
+    "resolveProxyForConnection must include the proxy name so the dashboard badge can show it"
+  );
+});


### PR DESCRIPTION
Closes #8995

Root cause: The data path feeding the dashboard proxy badge never delivered the proxy name. fetchAlivePoolRows() did not SELECT p.name from proxy_registry, and toRegistryProxyResolution() did not include name in the resolved proxy object. The badge render code (ConnectionRow) already had proxyName || proxyHost fallback from #7643, but proxyName was always null because the resolution API never returned it.

Fix: Two surgical changes:
- src/lib/db/proxies/rotation.ts: add p.name to the baseSelect column list
- src/lib/db/proxies/mappers.ts: include name in the resolved proxy object when present

No UI change needed — ConnectionRow already renders proxyName || proxyHost.

Regression guard: tests/unit/repro-8995.test.ts — creates a named proxy, assigns at account scope, and asserts resolveProxyForConnection returns proxy.name.
