### PR TITLE
fix(ui): normalize Free Pool API response payload to read from data.proxies (#9046)

### DIFF
--- a/changelog.d/fixes/9046-fix.md
+++ b/changelog.d/fixes/9046-fix.md
@@ -1,0 +1,1 @@
+- fix(ui): normalize Free Pool API response payload to read from data.proxies (#9046)

--- a/src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab.tsx
@@ -84,9 +84,10 @@ export default function FreePoolTab() {
         fetch("/api/settings/free-proxies/stats"),
       ]);
       if (proxiesRes.ok) {
-        const data = await proxiesRes.json();
-        setProxies(data.items || []);
-        setTotal(data.total ?? 0);
+        const body = await proxiesRes.json();
+        const payload = body?.data ?? body;
+        setProxies(payload.proxies ?? payload.items ?? []);
+        setTotal(payload.total ?? 0);
       }
       if (statsRes.ok) {
         const data = await statsRes.json();

--- a/tests/unit/free-pool-frontend-repro.test.tsx
+++ b/tests/unit/free-pool-frontend-repro.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #9046 — Free Pool proxy table stays empty despite synced stats.
+ *
+ * The API returns `{ success, data: { proxies, total, hasMore, stats, syncErrors } }`,
+ * but FreePoolTab.tsx was reading `data.items` and `data.total` from the top-level
+ * JSON — both undefined → empty table + "0 total proxies".
+ *
+ * This test verifies the payload normalization fix is present in the source code
+ * and that the correct contract keys are read by loadData().
+ *
+ * Run: node --import tsx/esm --test tests/unit/free-pool-frontend-repro.test.tsx
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const FREEPOOL_TAB_PATH = resolve(
+  import.meta.dirname,
+  "../../src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab.tsx"
+);
+
+test("FreePoolTab.loadData() reads from body.data.proxies (not data.items)", () => {
+  const src = readFileSync(FREEPOOL_TAB_PATH, "utf-8");
+
+  // The fix should use payload normalization: const payload = body?.data ?? body;
+  assert.ok(
+    src.includes("const payload = body?.data ?? body;") ||
+      src.includes("const payload = (body?.data ?? body);"),
+    "Expected payload normalization: const payload = body?.data ?? body;"
+  );
+
+  // Should read proxies from payload (not items from the top-level data)
+  assert.ok(
+    src.includes("payload.proxies ?? payload.items ?? []"),
+    "Expected setProxies to use payload.proxies with fallback to payload.items"
+  );
+
+  assert.ok(
+    src.includes("payload.total ?? 0"),
+    "Expected setTotal to use payload.total with fallback to 0"
+  );
+});
+
+test("FreePoolTab.loadData() no longer reads data.items directly from top-level JSON body", () => {
+  const src = readFileSync(FREEPOOL_TAB_PATH, "utf-8");
+
+  // Before the fix, line 88 was: setProxies(data.items || []);
+  // This pattern (reading "data.items" from the raw JSON body) should be gone.
+  const oldPattern = /setProxies\(\s*data\s*\.\s*items\s*(\|\|\s*\[\]\s*)?\)/;
+  assert.ok(
+    !oldPattern.test(src),
+    "Source must NOT contain setProxies(data.items || []) — should use payload.proxies"
+  );
+});
+
+test("FreePoolTab.loadData() no longer reads data.total directly from top-level JSON body", () => {
+  const src = readFileSync(FREEPOOL_TAB_PATH, "utf-8");
+
+  // Before the fix, line 89 was: setTotal(data.total ?? 0);
+  // This pattern should be gone.
+  const oldPattern = /setTotal\(\s*data\s*\.\s*total\s*(\?\?\s*0\s*)?\)/;
+  assert.ok(
+    !oldPattern.test(src),
+    "Source must NOT contain setTotal(data.total ?? 0) — should use payload.total"
+  );
+});
+
+// Simulate the actual API contract parsing to prove correctness
+test("Payload normalization produces correct values with real API contract shape", () => {
+  // Simulate what fetch returns:
+  const apiResponse = {
+    success: true,
+    data: {
+      proxies: [
+        { id: "p1", host: "16.163.88.228" },
+        { id: "p2", host: "203.0.113.42" },
+      ],
+      total: 254,
+    },
+  };
+
+  // THE BUG: reading from top-level body
+  const buggyProxies = (apiResponse as Record<string, unknown>).items ?? [];
+  const buggyTotal = (apiResponse as Record<string, unknown>).total ?? 0;
+  assert.equal(buggyProxies.length, 0, "BUG: data.items is undefined — should show empty table");
+  assert.equal(buggyTotal, 0, "BUG: data.total is undefined — should show 0 total");
+
+  // THE FIX: normalize through body?.data
+  const payload = (apiResponse as Record<string, unknown>)?.data ?? apiResponse;
+  const fixedProxies = (payload as Record<string, unknown>).proxies ?? (payload as Record<string, unknown>).items ?? [];
+  const fixedTotal = (payload as Record<string, unknown>).total ?? 0;
+
+  assert.equal(fixedProxies.length, 2, "FIX: payload.proxies contains 2 items");
+  assert.equal(fixedTotal, 254, "FIX: payload.total is 254");
+});
+
+// Also verify the backend contract is still correct
+test("Backend route test asserts body.data.proxies contract", () => {
+  // Verify the route test asserts data.proxies, not data.items
+  const routeTestPath = resolve(
+    import.meta.dirname,
+    "./api/free-proxies-list-route.test.ts"
+  );
+  const routeTest = readFileSync(routeTestPath, "utf-8");
+  assert.ok(
+    routeTest.includes("body.data.proxies") || routeTest.includes("body.data.total"),
+    "Route test must assert body.data.proxies and body.data.total"
+  );
+});

--- a/tests/unit/ui/free-pool-tab.test.tsx
+++ b/tests/unit/ui/free-pool-tab.test.tsx
@@ -46,7 +46,11 @@ function okJson(data: unknown) {
 function setupFetch(items: unknown[] = [], stats = defaultStats) {
   const mockFetch = vi.fn((url: string) => {
     if (String(url).includes("/stats")) return okJson({ stats });
-    return okJson({ items });
+    // Real contract: { success, data: { proxies, total, hasMore, stats, syncErrors } }
+    return okJson({
+      success: true,
+      data: { proxies: items, total: items.length, hasMore: false, stats, syncErrors: {} },
+    });
   });
   vi.stubGlobal("fetch", mockFetch);
   return mockFetch;
@@ -232,7 +236,7 @@ describe("FreePoolTab data loading", () => {
   it("disabling a source re-fetches with sources= filter", async () => {
     const mockFetch = vi.fn((url: string) => {
       if (String(url).includes("/stats")) return okJson({ stats: defaultStats });
-      return okJson({ items: [] });
+      return okJson({ success: true, data: { proxies: [], total: 0, hasMore: false, stats: defaultStats, syncErrors: {} } });
     });
     vi.stubGlobal("fetch", mockFetch);
 
@@ -285,7 +289,7 @@ describe("FreePoolTab sync error surfacing (#5595)", () => {
         });
       }
       if (String(url).includes("/stats")) return okJson({ stats: defaultStats });
-      return okJson({ items: [] });
+      return okJson({ success: true, data: { proxies: [], total: 0, hasMore: false, stats: defaultStats, syncErrors: {} } });
     });
     vi.stubGlobal("fetch", mockFetch);
 


### PR DESCRIPTION
Closes #9046

Root cause: `FreePoolTab.loadData()` reads `data.items` and `data.total` from the top-level fetch JSON, but since #6909 the route returns `{ success, data: { proxies, total, hasMore, stats, syncErrors } }`. Both `data.items` and `data.total` are `undefined` → `setProxies([])` and `setTotal(0)` → empty table + "0 total proxies". The stats render correctly (385/0/6) only because they come from the separate `/stats` endpoint whose top-level shape the frontend still parses correctly.

Fix: normalize the payload with `body?.data ?? body` and read `payload.proxies ?? payload.items ?? []` / `payload.total ?? 0` so both the current nested contract and any legacy top-level shape work.