### PR TITLE
fix(perplexity-web): update catalog to use 'copilot' mode and fix model IDs (#8989)

### DIFF
--- a/open-sse/config/providers/registry/perplexity/web/index.ts
+++ b/open-sse/config/providers/registry/perplexity/web/index.ts
@@ -15,7 +15,7 @@ export const perplexity_webProvider: RegistryEntry = {
     { id: "pplx-gpt-5.6-sol", name: "GPT-5.6 Sol (via Perplexity)", toolCalling: false },
     { id: "pplx-gemini", name: "Gemini 3.1 Pro (via Perplexity)", toolCalling: false },
     { id: "pplx-sonnet", name: "Claude Sonnet 5.0 (via Perplexity)", toolCalling: false },
-    { id: "pplx-opus", name: "Claude Opus 4.8 (via Perplexity)", toolCalling: false },
+    { id: "pplx-opus", name: "Claude Opus 5.0 (via Perplexity)", toolCalling: false },
     { id: "pplx-glm", name: "GLM-5.2 (via Perplexity)", toolCalling: false },
     { id: "pplx-kimi", name: "Kimi K2.6 (via Perplexity)", toolCalling: false },
     { id: "pplx-grok-4.5", name: "Grok 4.5 (via Perplexity)", toolCalling: false },

--- a/open-sse/executors/perplexity-web.ts
+++ b/open-sse/executors/perplexity-web.ts
@@ -388,7 +388,10 @@ export class PerplexityWebExecutor extends BaseExecutor {
     let pplxMode: string;
     let modelPref: string;
     if (thinking && THINKING_MAP[model]) {
-      pplxMode = "search";
+      // "copilot", not "search": the backend downgrades "search" to CONCISE and drops
+      // model_preference, so the thinking variant would fail the same way the catalog
+      // models do (see the note above MODEL_MAP).
+      pplxMode = "copilot";
       modelPref = THINKING_MAP[model];
       log?.info?.("PPLX-WEB", `Thinking mode → ${model} using ${modelPref}`);
     } else if (MODEL_MAP[model]) {

--- a/open-sse/executors/perplexity-web/protocol.ts
+++ b/open-sse/executors/perplexity-web/protocol.ts
@@ -51,31 +51,40 @@ export const PPLX_STREAM_EOF_SYMBOL = "event: end_of_stream";
 export const PPLX_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:148.0) Gecko/20100101 Firefox/148.0";
 
-// mode / model_preference pairs. Live www.perplexity.ai still posts mode:"copilot"
-// for the default turbo path; search mode is used for the curated catalog models.
+// mode / model_preference pairs — every entry posts mode:"copilot", like the live
+// www.perplexity.ai client does when a model is picked from the catalog.
+//
+// mode:"search" must NOT be used here. The backend now downgrades it to CONCISE and
+// drops model_preference entirely, answering with status:"FAILED" and the text
+// "Error in processing query." Verified against a paid `subscription_tier: "max"`
+// account: mode:"search" + claude50sonnet → {"mode":"CONCISE","status":"FAILED"},
+// while mode:"copilot" + the same preference → {"mode":"COPILOT",
+// "display_model":"claude50sonnet"} and a normal stream. Same for every other
+// catalog model, so "search" breaks the whole catalog, not just one entry.
 export const MODEL_MAP: Record<string, [string, string]> = {
-  // pplx-auto/pplx-sonar use "copilot" mode (was "search", which for pplx-sonar
-  // maps to "experimental" — that model no longer streams answer-text blocks
-  // for many sessions → empty content, issue #6955). The live web client uses
-  // mode:"copilot" + model_preference:"turbo" for the default turbo path.
+  // pplx-auto/pplx-sonar were already on "copilot" (with "search", pplx-sonar maps to
+  // "experimental" — that model no longer streams answer-text blocks for many
+  // sessions → empty content, issue #6955).
   "pplx-auto": ["copilot", "pplx_pro"],
   "pplx-sonar": ["copilot", "turbo"],
-  "pplx-gpt-5.6-terra": ["search", "gpt56_terra"],
-  "pplx-gpt-5.6-sol": ["search", "gpt56_sol"],
-  "pplx-gemini": ["search", "gemini31pro_high"],
-  "pplx-sonnet": ["search", "claude50sonnet"],
-  "pplx-opus": ["search", "claude48opus"],
-  "pplx-glm": ["search", "glm_5_2"],
-  "pplx-kimi": ["search", "kimik26instant"],
-  "pplx-grok-4.5": ["search", "grok45low"],
-  "pplx-nemotron": ["search", "nv_nemotron_3_ultra"],
+  "pplx-gpt-5.6-terra": ["copilot", "gpt56_terra"],
+  "pplx-gpt-5.6-sol": ["copilot", "gpt56_sol"],
+  "pplx-gemini": ["copilot", "gemini31pro_high"],
+  "pplx-sonnet": ["copilot", "claude50sonnet"],
+  // Perplexity's catalog moved Opus to 5.0; claude48opus is still accepted but
+  // answers from the older model.
+  "pplx-opus": ["copilot", "claude50opus"],
+  "pplx-glm": ["copilot", "glm_5_2"],
+  "pplx-kimi": ["copilot", "kimik26instant"],
+  "pplx-grok-4.5": ["copilot", "grok45low"],
+  "pplx-nemotron": ["copilot", "nv_nemotron_3_ultra"],
 };
 
 export const THINKING_MAP: Record<string, string> = {
   "pplx-gpt-5.6-terra": "gpt56_terra_thinking",
   "pplx-gpt-5.6-sol": "gpt56_sol_thinking",
   "pplx-sonnet": "claude50sonnetthinking",
-  "pplx-opus": "claude48opusthinking",
+  "pplx-opus": "claude50opusthinking",
   "pplx-kimi": "kimik26thinking",
   "pplx-grok-4.5": "grok45medium",
 };

--- a/tests/unit/8989-perplexity-catalog-mode-repro.test.ts
+++ b/tests/unit/8989-perplexity-catalog-mode-repro.test.ts
@@ -1,0 +1,38 @@
+// #8989 — Perplexity-web catalog models post mode:"search" which the backend
+// downgrades to CONCISE and answers with status:"FAILED" / "Error in processing query."
+// Every catalog model AND the thinking branch must use "copilot".
+//
+// Run: node --import tsx/esm --test tests/unit/8989-perplexity-catalog-mode-repro.test.ts
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-8989-repro-"));
+
+const { MODEL_MAP, THINKING_MAP } = await import(
+  "../../open-sse/executors/perplexity-web/protocol.ts"
+);
+
+// ── Guard: MODEL_MAP must use "copilot" ────────────────────────────────────
+// The backend downgrades "search" to CONCISE, drops model_preference and ends
+// the stream with status:"FAILED" ("Error in processing query.").
+
+test("MODEL_MAP catalog entries must post mode 'copilot' (#8989)", () => {
+  const offenders = Object.entries(MODEL_MAP)
+    .filter(([, [mode]]) => mode !== "copilot")
+    .map(([model, [mode]]) => `${model}=${mode}`);
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Catalog models using wrong mode: ${offenders.join(", ")}`
+  );
+});
+
+test("MODEL_MAP/THINKING_MAP: pplx-opus resolves to Claude Opus 5 (#8989)", () => {
+  assert.deepEqual(MODEL_MAP["pplx-opus"], ["copilot", "claude50opus"]);
+  assert.equal(THINKING_MAP["pplx-opus"], "claude50opusthinking");
+});

--- a/tests/unit/perplexity-web-model-mappings.test.ts
+++ b/tests/unit/perplexity-web-model-mappings.test.ts
@@ -35,9 +35,11 @@ test("Perplexity Web registers the refreshed model catalog", () => {
 test("every advertised Perplexity Web model has an explicit internal mapping", () => {
   const missing = PROVIDER_MODELS["pplx-web"].filter((model) => !MODEL_MAP[model.id]);
   assert.deepEqual(missing, []);
-  assert.deepEqual(MODEL_MAP["pplx-gpt-5.6-terra"], ["search", "gpt56_terra"]);
-  assert.deepEqual(MODEL_MAP["pplx-gpt-5.6-sol"], ["search", "gpt56_sol"]);
-  assert.deepEqual(MODEL_MAP["pplx-grok-4.5"], ["search", "grok45low"]);
+  assert.deepEqual(MODEL_MAP["pplx-gpt-5.6-terra"], ["copilot", "gpt56_terra"]);
+  assert.deepEqual(MODEL_MAP["pplx-gpt-5.6-sol"], ["copilot", "gpt56_sol"]);
+  assert.deepEqual(MODEL_MAP["pplx-grok-4.5"], ["copilot", "grok45low"]);
+  assert.deepEqual(MODEL_MAP["pplx-opus"], ["copilot", "claude50opus"]);
+  assert.equal(THINKING_MAP["pplx-opus"], "claude50opusthinking");
   assert.equal(THINKING_MAP["pplx-gpt-5.6-terra"], "gpt56_terra_thinking");
   assert.equal(THINKING_MAP["pplx-gpt-5.6-sol"], "gpt56_sol_thinking");
   assert.equal(THINKING_MAP["pplx-grok-4.5"], "grok45medium");

--- a/tests/unit/perplexity-web.test.ts
+++ b/tests/unit/perplexity-web.test.ts
@@ -814,7 +814,7 @@ test("Model mapping: GPT-5.6 Terra sends its current internal preference", async
     });
 
     assert.equal(capturedBody.params.model_preference, "gpt56_terra");
-    assert.equal(capturedBody.params.mode, "search");
+    assert.equal(capturedBody.params.mode, "copilot");
   } finally {
     globalThis.fetch = original;
   }
@@ -905,8 +905,8 @@ test("Model mapping: thinking mode uses thinking variant", async () => {
     });
 
     assert.equal(capturedBody.params.model_preference, "claude50sonnetthinking");
-    // Thinking variants still go through mode "search" (THINKING_MAP path).
-    assert.equal(capturedBody.params.mode, "search");
+    // THINKING_MAP path posts "copilot" too ("search" is downgraded to CONCISE).
+    assert.equal(capturedBody.params.mode, "copilot");
   } finally {
     globalThis.fetch = original;
   }


### PR DESCRIPTION
Closes #8989

Root cause: the MODEL_MAP in perplexity-web/protocol.ts used mode:"search" for all catalog models, but the Perplexity backend now downgrades 'search' to CONCISE and drops model_preference, returning status:FAILED with 'Error in processing query.' for every catalog model. The thinking path also used 'search', which broke thinking variants the same way.

Fix: switch all MODEL_MAP entries from 'search' to 'copilot' (matching the live www.perplexity.ai client behavior), update the thinking mode path, and update the pplx-opus model reference from claude48opus to claude50opus.

Regression test: tests/unit/perplexity-web-model-mappings.test.ts — ensures every catalog model resolves to mode:'copilot' with a valid model_preference.