### PR TITLE
fix: make antigravity and agy equivalent in credential selection (#9204)

### DIFF
--- a/changelog.d/fixes/9204-fix.plan.md
+++ b/changelog.d/fixes/9204-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(auth): make antigravity and agy equivalent in credential selection (#9204)

--- a/src/lib/oauth/utils/agyAuthImport.ts
+++ b/src/lib/oauth/utils/agyAuthImport.ts
@@ -214,6 +214,7 @@ export async function createConnectionFromAgyToken(
           resolvedEmail ||
           "Antigravity CLI (imported)",
         testStatus: "active",
+        isActive: true,
         providerSpecificData: {
           ...toRecord(existing.providerSpecificData),
           clientProfile: "cli",

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -950,6 +950,7 @@ export { fisherYatesShuffle, getNextFromDeckSync as getNextFromDeck };
 const PROVIDER_SEARCH_PAIRS: string[][] = [
   ["nvidia", "nvidia_nim"],
   ["kimi-coding", "kimi-coding-apikey"],
+  ["antigravity", "agy"],
 ];
 /**
  * Resolve provider aliases (e.g., nvidia -> nvidia_nim) for DB lookup

--- a/tests/unit/bug-9204-agy-provider-alias-credentials.test.ts
+++ b/tests/unit/bug-9204-agy-provider-alias-credentials.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-9204-agy-alias-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { createConnectionFromAgyToken } = await import(
+  "../../src/lib/oauth/utils/agyAuthImport.ts"
+);
+const { parseModel } = await import("../../open-sse/services/model.ts");
+const { getProviderCredentials } = await import("../../src/sse/services/auth.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#9204: an Antigravity CLI login is eligible for an agy model request", async () => {
+  const { connection } = await createConnectionFromAgyToken(
+    {
+      accessToken: "fresh-access-token",
+      refreshToken: "fresh-refresh-token",
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      tokenType: "Bearer",
+      authMethod: "oauth",
+      email: "reporter@example.test",
+      projectId: "project-9204",
+      tier: "free-tier",
+    },
+    { overwriteExisting: true }
+  );
+
+  assert.equal(connection.provider, "agy");
+  assert.equal(connection.isActive, true);
+  assert.equal(connection.testStatus, "active");
+
+  const parsed = parseModel("agy/gemini-2.5-flash");
+  assert.equal(parsed.provider, "antigravity");
+
+  const credentials = await getProviderCredentials(parsed.provider!, null, null, parsed.model);
+  assert.ok(credentials, "the active Antigravity CLI connection must remain selectable");
+  assert.equal(credentials.connectionId, connection.id);
+  assert.equal(credentials.accessToken, "fresh-access-token");
+});

--- a/tests/unit/bug-9204-agy-reimport-reactivates.test.ts
+++ b/tests/unit/bug-9204-agy-reimport-reactivates.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-9204-agy-reimport-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { createConnectionFromAgyToken } = await import(
+  "../../src/lib/oauth/utils/agyAuthImport.ts"
+);
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#9204: reimporting an inactive Antigravity CLI account reactivates it", async () => {
+  const existing = await providersDb.createProviderConnection({
+    provider: "agy",
+    authType: "oauth",
+    email: "reporter@example.test",
+    accessToken: "stale-access-token",
+    refreshToken: "stale-refresh-token",
+    expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    isActive: false,
+    testStatus: "expired",
+  });
+
+  await createConnectionFromAgyToken(
+    {
+      accessToken: "fresh-access-token",
+      refreshToken: "fresh-refresh-token",
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      tokenType: "Bearer",
+      authMethod: "oauth",
+      email: "reporter@example.test",
+      projectId: "project-9204",
+      tier: "free-tier",
+    },
+    { overwriteExisting: true }
+  );
+
+  const stored = await providersDb.getProviderConnectionById(existing.id);
+  assert.equal(stored?.testStatus, "active");
+  assert.equal(stored?.isActive, true, "a successful reimport must reactivate the account");
+
+  const active = await providersDb.getProviderConnections({ provider: "agy", isActive: true });
+  assert.deepEqual(active.map((connection) => connection.id), [existing.id]);
+});


### PR DESCRIPTION
Closes #9204

Antigravity CLI credentials are stored under provider `agy`, but model parsing canonicalizes `agy/...` to `antigravity`. The credential search pool in `auth.ts` had no mapping between these, so an active CLI connection was invisible to canonical `antigravity` requests, producing exactly `No active credentials for provider: antigravity`.

Two fixes:
1. Add `['antigravity', 'agy']` to `PROVIDER_SEARCH_PAIRS` so credential selection searches both identities. Requested-provider priority is preserved (antigravity first when requested, agy first when requested).
2. Add `isActive: true` to the overwrite branch in `agyAuthImport.ts` so a successful reimport/reactivation also restores the routing flag.