### PR TITLE
test(sse): expect the trailing period in the no-credentials message

### DIFF
--- a/tests/unit/vscode-token-routes.test.ts
+++ b/tests/unit/vscode-token-routes.test.ts
@@ -1161,7 +1161,7 @@ test("vscode tokenized /chat/completions route applies the path token and codex 
   // error code mapping is "model_not_found" (open-sse/config/errorConfig.ts:29).
   assert.equal(response.status, 404);
   assert.equal(body.error?.code, "model_not_found");
-  assert.equal(body.error?.message, "No active credentials for provider: codex");
+  assert.equal(body.error?.message, "No active credentials for provider: codex.");
 });
 
 test("vscode tokenized /responses route applies the path token and codex tier rewrite", async () => {
@@ -1192,7 +1192,7 @@ test("vscode tokenized /responses route applies the path token and codex tier re
   // Upstream port decolua/9router#336: see chat/completions sibling test above.
   assert.equal(response.status, 404);
   assert.equal(body.error?.code, "model_not_found");
-  assert.equal(body.error?.message, "No active credentials for provider: codex");
+  assert.equal(body.error?.message, "No active credentials for provider: codex.");
 });
 
 test("vscode tokenized api/show route preserves the selected reasoning effort for codex variants", async () => {


### PR DESCRIPTION
`release/v3.8.50` currently fails `Unit Tests fast-path` on every pull request opened against it, including the maintainer's own. This is two stale assertions, not a flake.

## What happens

`src/sse/handlers/chatHelpers.ts:660` builds the zero-active-credentials message as:

```ts
`No active credentials for provider: ${provider}.${hint}`
```

The period was added in #9275 so that the new candidate-alias hint reads as a second sentence. `tests/unit/vscode-token-routes.test.ts` still asserts the unterminated form at lines 1164 and 1195:

```
actual:   'No active credentials for provider: codex.'
expected: 'No active credentials for provider: codex'
```

## Reproduced on an unmodified base

Checked out `release/v3.8.50` at `7163081f5` with zero local changes:

```
$ node --import tsx/esm --test tests/unit/vscode-token-routes.test.ts
# tests 36
# pass 34
# fail 2
```

Same file on this branch:

```
# tests 36
# pass 36
# fail 0
```

## Why the branch never caught it

`.github/workflows/quality.yml` triggers on `pull_request` to `release/**` and on `workflow_dispatch` only, never on push. The branch therefore does not re-run `Unit Tests fast-path` after a merge, so the drift became visible only on subsequent pull requests. #9275 merged with those four shards already red.

## Scope

Two assertions, one file, no production code. The comparison stays exact rather than becoming a prefix match, since the exact form is what surfaced the drift.

This does not address the `Fast Quality Gates` failure (`check:file-size`, two frozen-ceiling violations already on the base, cleared by #9380 and #9381 together) or `dast-smoke`, which fails at `Build CLI bundle` and I have not diagnosed.
