### PR TITLE
fix(claude): remove unconditional always-mode return in claudeClassifierCompat (#9276)

### DIFF
--- a/changelog.d/fixes/9276-fix.plan.md
+++ b/changelog.d/fixes/9276-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(claude): remove unconditional "always" return in claudeClassifierCompat so normal chat requests are not swallowed (#9276)

--- a/open-sse/handlers/chatCore/claudeClassifierCompat.ts
+++ b/open-sse/handlers/chatCore/claudeClassifierCompat.ts
@@ -41,8 +41,8 @@ function extractSystemTexts(body: Record<string, unknown> | null | undefined): s
  * True when the inbound request should be default-allowed without calling upstream.
  *
  * - `mode === "off"` (default): never short-circuits.
- * - `mode === "always"`: short-circuits every Claude-format request (operator has
- *   decided every `/v1/messages` call through this route is the classifier).
+ * - `mode === "always"`: short-circuits only when the request carries the classifier's
+ *   system-prompt marker (same body-awareness as "auto").
  * - `mode === "auto"`: only short-circuits when the request carries the classifier's
  *   system-prompt marker. `</block>` in `stop_sequences` is corroborating evidence but
  *   is never sufficient alone — the marker is the strong, classifier-unique signal;
@@ -56,7 +56,6 @@ export function shouldDefaultAllowClassifier(
 ): boolean {
   if (mode !== "auto" && mode !== "always") return false;
   if (sourceFormat !== FORMATS.CLAUDE) return false;
-  if (mode === "always") return true;
 
   return extractSystemTexts(body).some((text) => text.includes(SECURITY_MONITOR_MARKER));
 }

--- a/tests/unit/claude-classifier-compat.test.ts
+++ b/tests/unit/claude-classifier-compat.test.ts
@@ -112,9 +112,25 @@ test("detector: never fires for non-Claude source formats even in always mode", 
   assert.equal(shouldDefaultAllowClassifier(FORMATS.OPENAI, CLASSIFIER_BODY, "always"), false);
 });
 
-test("detector: always fires for every Claude-format request", () => {
+test("detector: always does NOT fire for normal chat without classifier marker (#9276)", () => {
   const plain = { system: [{ type: "text", text: "hi" }], stop_sequences: [] };
-  assert.equal(shouldDefaultAllowClassifier(FORMATS.CLAUDE, plain, "always"), true);
+  assert.equal(
+    shouldDefaultAllowClassifier(FORMATS.CLAUDE, plain, "always"),
+    false,
+    "always must NOT short-circuit a normal chat (no security-monitor marker)"
+  );
+});
+
+test("detector: always fires when classifier marker is present", () => {
+  const classifier = {
+    system: [{ type: "text", text: "You are a security monitor for autonomous AI coding agents. Evaluate the following action." }],
+    stop_sequences: ["</block>"],
+  };
+  assert.equal(
+    shouldDefaultAllowClassifier(FORMATS.CLAUDE, classifier, "always"),
+    true,
+    "always must short-circuit when the classifier marker is present"
+  );
 });
 
 // ─── Pure builder: buildDefaultAllowClaudeMessage ────────────────────────────


### PR DESCRIPTION
Closes #9276

Root cause: `shouldDefaultAllowClassifier()` had `if (mode === "always") return true;` which short-circuited EVERY Claude-format request regardless of whether it carried the security-classifier marker. When set to ALWAYS on the Claude Code endpoint route, every normal chat message was swallowed by the synthetic ALLOW response.

Fix: remove the unconditional return so "always" mode requires the classifier system-prompt marker to short-circuit, matching the body-awareness that "auto" mode already has.