### PR TITLE
fix(qoder): include actionable CLI_QODER_BIN hint in connection test when qodercli is not found (#9277)

### DIFF
--- a/changelog.d/fixes/9277-fix.plan.md
+++ b/changelog.d/fixes/9277-fix.plan.md
@@ -1,0 +1,1 @@
+- fix(qoder): include actionable CLI_QODER_BIN hint in connection test when qodercli is not found (#9277)

--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -11,6 +11,7 @@ import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
 import { validateProviderApiKey } from "@/lib/providers/validation";
 import { getCliRuntimeStatus } from "@/shared/services/cliRuntime";
+import { buildQoderCliNotFoundHint } from "@omniroute/open-sse/services/qoderCliResolve.ts";
 // Use the shared open-sse token refresh with built-in dedup/race-condition cache
 import { getAccessToken } from "@omniroute/open-sse/services/tokenRefresh.ts";
 import { rotationGroupFor } from "@omniroute/open-sse/services/refreshSerializer.ts";
@@ -205,7 +206,9 @@ async function getProviderRuntimeStatus(connection: any) {
 
     const runtimeMessage = runtime.installed
       ? `Local CLI runtime is installed but not runnable (${runtime.reason || "healthcheck_failed"})`
-      : "Local CLI runtime is not installed";
+      : provider === "qoder"
+        ? buildQoderCliNotFoundHint(runtime.reason || "not_found")
+        : "Local CLI runtime is not installed";
 
     return {
       ...runtime,


### PR DESCRIPTION
Closes #9277

When the Qoder CLI (qodercli) is not detected by getCliRuntimeStatus after an OmniRoute restart (e.g. restricted launch context on Windows where APPDATA/PATH are not inherited), the connection test showed only the non-actionable 'Local CLI runtime is not installed'. Now it surfaces the same buildQoderCliNotFoundHint guidance already used in the executor path, telling the user to set CLI_QODER_BIN to the absolute path of qodercli.