### PR TITLE
fix(docs): add the missing frontmatter title to the WAF doc

### DIFF
--- a/docs/security/AGENTROUTER_WAF.md
+++ b/docs/security/AGENTROUTER_WAF.md
@@ -1,3 +1,7 @@
+---
+title: "AgentRouter WAF"
+---
+
 # agentrouter.org WAF (Web Application Firewall)
 
 The `agentrouter` upstream gateway runs a keyword-based content filter on


### PR DESCRIPTION
`dast-smoke` fails on every pull request opened against `release/v3.8.50`, at the `Build CLI bundle` step. It is not the pull requests.

## Cause

`docs/security/AGENTROUTER_WAF.md` has no frontmatter block — it starts straight at the `#` heading. `source.config.ts` lists `./security/**/*.md` in the fumadocs document set, so the file is parsed against a schema whose one required field is `title`:

```
Error: Turbopack build failed with 1 errors:
./docs/security/AGENTROUTER_WAF.md
Error: [MDX] invalid frontmatter in .../docs/security/AGENTROUTER_WAF.md:
- title: Invalid input: expected string, received undefined
```

`npm run build` stops there, and `dast-smoke` builds before it can run, so the job never gets started.

It is the only file under `docs/security/` without a title.

## Verified

Ran fumadocs' own `frontmatterSchema` against the file on both sides, unmodified base versus this branch:

```
FAIL  BEFORE (git HEAD, unmodified upstream)
      title: Invalid input: expected string, received undefined
PASS  AFTER  (with the fix)
      {"title":"AgentRouter WAF"}
```

The BEFORE message is the same string the CI build prints, so this is the same validator, not an approximation of it.

## Scope

Four added lines, one file, no prose changed. The `#` heading stays below the frontmatter, which is what the sibling documents in that directory do.

This is one of three independent reasons the branch is currently red. The other two are the frozen file-size ceilings (cleared by #9380 and #9381 together) and a set of stale routing assertions in the unit shards, of which #9392 fixes one file.
