### PR TITLE
chore(ci): stop dependabot from grouping ioredis majors with routine bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,17 @@ updates:
       # the duplication gate — migrate the gate intentionally, not via dependabot.
       - dependency-name: "jscpd"
         update-types: ["version-update:semver-major"]
+      # ioredis is a SOFT/optional dependency loaded through a dynamic import
+      # (src/lib/quota/redisQuotaStore.ts — "Redis driver requires ioredis package"),
+      # so a breaking major never fails at build or typecheck time: the only consumers
+      # are the distributed quota store (redisQuotaStore.ts, storeFactory.ts) and the
+      # `import type Redis` in src/shared/utils/rateLimiter.ts. Nothing in the unit or
+      # vitest suites exercises a live Redis connection, so a v5→v6 API break would ship
+      # green and only surface at runtime for operators running distributed quota — the
+      # exact users least able to absorb it. #9310 grouped that major with 9 harmless
+      # bumps; majors here need their own PR and a deliberate migration review.
+      - dependency-name: "ioredis"
+        update-types: ["version-update:semver-major"]
       # @huggingface/transformers is HARD-PINNED at 3.5.2 (exact, no caret) — FROZEN.
       # It is load-bearing for the LLMLingua ONNX compression engine (open-sse/services/
       # compression/engines/llmlingua/ — worker.ts pins @huggingface/transformers@3.5.2)

--- a/changelog.d/maintenance/9425-dependabot-ioredis-major.md
+++ b/changelog.d/maintenance/9425-dependabot-ioredis-major.md
@@ -1,0 +1,1 @@
+- **chore(ci):** stopped dependabot from grouping `ioredis` majors with routine production bumps — the package is resolved through a dynamic import in the distributed quota store, so a breaking major passes build, typecheck and both test suites and only surfaces at runtime for operators running Redis-backed quota ([#9425](https://github.com/diegosouzapw/OmniRoute/pull/9425))


### PR DESCRIPTION
## Why

`#9310` ("deps: bump the production group with 10 updates") carries **`ioredis` 5.10.1 → 6.0.0** — a breaking major — alongside 9 routine bumps (axios, jose, playwright, better-sqlite3, fumadocs, lucide-react, material-symbols, aws-sdk).

That combination is unusually hard to catch:

- `ioredis` is a **soft/optional dependency** resolved through a dynamic import in `src/lib/quota/redisQuotaStore.ts` (`Redis driver requires ioredis package`), so a breaking API change **cannot** fail the build or `typecheck:core`.
- Its only other consumers are `src/lib/quota/storeFactory.ts` and an `import type Redis` in `src/shared/utils/rateLimiter.ts` — types, not runtime.
- Nothing in `test:unit` or `test:vitest` opens a live Redis connection.

So a v5→v6 break ships **fully green** and surfaces only at runtime, for operators running Redis-backed distributed quota — the users least able to absorb a surprise.

## What changes

Adds `ioredis` to the existing `ignore` list for **majors only** (minors and patches keep flowing), following the same convention already used for `typescript`, `jscpd`, `next` and `@huggingface/transformers`, each with its justification inline.

Minor/patch bumps are unaffected. The ioredis 6 migration gets its own PR and its own review when we choose to do it.

## Validation

Config-only change to `.github/dependabot.yml`; no product code touched.