### PR TITLE
fix(docs): add missing title frontmatter to AGENTROUTER_WAF.md

### DIFF
--- a/docs/security/AGENTROUTER_WAF.md
+++ b/docs/security/AGENTROUTER_WAF.md
@@ -1,3 +1,6 @@
+---
+title: AGENTROUTER WAF
+---
 # agentrouter.org WAF (Web Application Firewall)
 
 The `agentrouter` upstream gateway runs a keyword-based content filter on


### PR DESCRIPTION
## What this fixes
The Docker build was failing with the error:
`[MDX] invalid frontmatter ... - title: Invalid input: expected string, received undefined`

This was caused by the `AGENTROUTER_WAF.md` file missing a `title` field.

## Changes made
- Added `title: AGENTROUTER WAF` to the frontmatter.

## Impact
Resolves the build error, allowing the Docker image to compile successfully.