### PR TITLE
fix(providers): map kimi-web/K3 to K2D5 scenario to fix resource_exhausted (#9338)

### DIFF
--- a/changelog.d/fixes/9338-kimi-web-k3-exhausted.md
+++ b/changelog.d/fixes/9338-kimi-web-k3-exhausted.md
@@ -1,0 +1,1 @@
+- fix(providers): map kimi-web/K3 to K2D5 scenario instead of OK Computer premium mode to fix resource_exhausted on non-subscriber accounts (#9338)

--- a/open-sse/config/providers/registry/kimi/web/runtime.ts
+++ b/open-sse/config/providers/registry/kimi/web/runtime.ts
@@ -12,16 +12,10 @@ export interface KimiWebModelConfig {
 
 const STATIC_MODEL_CONFIGS: Record<string, KimiWebModelConfig> = {
   k3: {
-    scenario: "SCENARIO_OK_COMPUTER",
-    kimiPlusId: "ok-computer",
-    supportedReasoningEfforts: [
-      "REASONING_EFFORT_LOW",
-      "REASONING_EFFORT_HIGH",
-      "REASONING_EFFORT_MAX",
-    ],
-    defaultReasoningEffort: "REASONING_EFFORT_MAX",
-    supportedContextLengths: ["CONTEXT_LENGTH_L", "CONTEXT_LENGTH_XL"],
-    defaultContextLength: "CONTEXT_LENGTH_L",
+    scenario: "SCENARIO_K2D5",
+    supportedReasoningEfforts: ["REASONING_EFFORT_NONE", "REASONING_EFFORT_LOW"],
+    defaultReasoningEffort: "REASONING_EFFORT_NONE",
+    supportedContextLengths: [],
   },
   k2d6: {
     scenario: "SCENARIO_K2D5",

--- a/tests/unit/executor-kimi-web.test.ts
+++ b/tests/unit/executor-kimi-web.test.ts
@@ -110,16 +110,16 @@ describe("KimiWebExecutor", () => {
         };
       };
       assert.equal(request.chat_id, "");
-      assert.equal(request.kimiplus_id, "ok-computer");
-      assert.equal(request.scenario, "SCENARIO_OK_COMPUTER");
+      assert.equal(request.kimiplus_id, undefined);
+      assert.equal(request.scenario, "SCENARIO_K2D5");
       assert.equal(request.model, undefined);
       assert.deepEqual(request.tools, []);
       assert.equal(request.message.blocks[0].text.content, "hi");
       assert.equal(request.options.system_prompt, "Be terse.");
       assert.equal(request.options.thinking, true);
       assert.equal(request.options.enable_plugin, false);
-      assert.equal(request.options.reasoning_effort, "REASONING_EFFORT_MAX");
-      assert.equal(request.options.context_length, "CONTEXT_LENGTH_L");
+      assert.equal(request.options.reasoning_effort, "REASONING_EFFORT_NONE");
+      assert.equal(request.options.context_length, undefined);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -166,19 +166,18 @@ describe("KimiWebExecutor", () => {
 describe("resolveModelConfig", () => {
   const { resolveModelConfig } = mod;
 
-  it("maps k3 to the current OK Computer route", () => {
+  it("maps k3 to the K2D5 route (same as K2.6, not premium OK Computer)", () => {
     const cfg = resolveModelConfig("k3");
     assert.ok(cfg);
-    assert.equal(cfg.scenario, "SCENARIO_OK_COMPUTER");
-    assert.equal(cfg.kimiPlusId, "ok-computer");
+    assert.equal(cfg.scenario, "SCENARIO_K2D5");
+    assert.equal(cfg.kimiPlusId, undefined);
     assert.deepEqual(cfg.supportedReasoningEfforts, [
+      "REASONING_EFFORT_NONE",
       "REASONING_EFFORT_LOW",
-      "REASONING_EFFORT_HIGH",
-      "REASONING_EFFORT_MAX",
     ]);
-    assert.equal(cfg.defaultReasoningEffort, "REASONING_EFFORT_MAX");
-    assert.deepEqual(cfg.supportedContextLengths, ["CONTEXT_LENGTH_L", "CONTEXT_LENGTH_XL"]);
-    assert.equal(cfg.defaultContextLength, "CONTEXT_LENGTH_L");
+    assert.equal(cfg.defaultReasoningEffort, "REASONING_EFFORT_NONE");
+    assert.deepEqual(cfg.supportedContextLengths, []);
+    assert.equal(cfg.defaultContextLength, undefined);
   });
 
   it("maps k2d6 to the K2D5 route and its exact effort enum", () => {


### PR DESCRIPTION
Closes #9338

## Root Cause
PR #7531 mapped kimi-web/K3 to SCENARIO_OK_COMPUTER (Agent/Kimi+ premium mode) which requires a Kimi+ subscription — causing resource_exhausted on non-subscriber accounts.

## Fix
Changed K3 scenario to SCENARIO_K2D5 (same as K2.6) and removed kimiPlusId. K3 worked fine this way before #7531.

## Gates
- [x] TDD: existing tests now pass (15/15)
- [x] lint: clean
- [x] file-size: OK (pre-existing violations in unrelated files only)
- [ ] typecheck: clean (devbox timeout — verified imports work correctly)
- [ ] complexity: OK (devbox timeout — no change to cyclomatic complexity)