### PR TITLE
fix(docs): add required MDX frontmatter to AGENTROUTER_WAF.md

### DIFF
--- a/docs/security/AGENTROUTER_WAF.md
+++ b/docs/security/AGENTROUTER_WAF.md
@@ -1,3 +1,9 @@
+---
+title: "AgentRouter WAF"
+version: 3.8.50
+lastUpdated: 2026-08-03
+---
+
 # agentrouter.org WAF (Web Application Firewall)
 
 The `agentrouter` upstream gateway runs a keyword-based content filter on


### PR DESCRIPTION
## Summary
- `docs/security/AGENTROUTER_WAF.md` (added in #9323) was missing the `title`/`version`/`lastUpdated` frontmatter block that every other `docs/security/**/*.md` file has.
- fumadocs-mdx requires a `title` on every docs file matched by `source.config.ts`, so the production build (`next build`, Turbopack) fails with `[MDX] invalid frontmatter ... title: Invalid input: expected string, received undefined`.

## Test plan
- [x] Confirmed the build fails on `release/v3.8.50` HEAD before this fix (reproduced on the `.113` build box).
- [ ] Confirm `npm run build` succeeds with this fix applied.