### PR TITLE
fix(docker): ship MITM _internal/ shims and selfsigned package in standalone bundle (#9451)

### DIFF
--- a/changelog.d/fixes/9451-selfsigned-docker-dep.md
+++ b/changelog.d/fixes/9451-selfsigned-docker-dep.md
@@ -1,0 +1,1 @@
+- fix(docker): ship MITM `_internal/` shims and `selfsigned` package in standalone bundle (#9451)

--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -117,6 +117,25 @@ const EXTRA_MODULE_ENTRIES = [
   { label: "migrations", src: ["src", "lib", "db", "migrations"], dest: ["migrations"] },
   { label: "MITM server", src: ["src", "mitm", "server.cjs"], dest: ["src", "mitm", "server.cjs"] },
   {
+    // #9451: server.cjs requires 6 shims from ./_internal/ (bypass, ingest,
+    // forwardTarget, aliasConfig, standaloneRouting, rootCaShim) which the MITM
+    // child process loads via require(). Next.js's standalone tracer never sees
+    // them (server.cjs is a separate node process, not imported by the main
+    // server), so the _internal/ directory must be copied explicitly or the MITM
+    // child crashes with MODULE_NOT_FOUND at boot.
+    label: "MITM _internal shims (#9451)",
+    src: ["src", "mitm", "_internal"],
+    dest: ["src", "mitm", "_internal"],
+  },
+  {
+    // #9451: rootCaShim.cjs does `await import("selfsigned")` for dynamic SSL
+    // certificate generation. The MITM child is not traced by Next.js, so the
+    // package is absent from the Docker standalone bundle without this entry.
+    label: "selfsigned (MITM rootCaShim dynamic import — #9451)",
+    src: ["node_modules", "selfsigned"],
+    dest: ["node_modules", "selfsigned"],
+  },
+  {
     label: "run-standalone script",
     src: ["scripts", "dev", "run-standalone.mjs"],
     dest: ["dev", "run-standalone.mjs"],

--- a/tests/unit/build/mitm-server-bundle-contents.test.ts
+++ b/tests/unit/build/mitm-server-bundle-contents.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { syncStandaloneExtraModules } from "../../../scripts/build/assembleStandalone.mjs";
+
+const repoRoot = path.resolve(new URL(".", import.meta.url).pathname, "../../..");
+
+/**
+ * Regression guard for #9451: the MITM `server.cjs` runs as a separate `node`
+ * child process in the Docker standalone bundle, so neither Next.js's
+ * file tracer nor the main server's import graph covers its dependencies.
+ * `EXTRA_MODULE_ENTRIES` must therefore ship every relative `require()` target
+ * of `server.cjs` AND every bare-specifier dynamic `import()` its `_internal/*.cjs`
+ * shims perform, or the MITM proxy crashes at boot with MODULE_NOT_FOUND.
+ */
+
+test("EXTRA_MODULE_ENTRIES ships every relative require() of MITM server.cjs (#9451)", async () => {
+  const serverSrc = fs.readFileSync(path.join(repoRoot, "src/mitm/server.cjs"), "utf8");
+  const relRequires = [...serverSrc.matchAll(/require\("\.\/([^"]+)"\)/g)].map((m) => m[1]);
+  assert.ok(
+    relRequires.length > 0,
+    "server.cjs has relative require() calls to check (sanity)"
+  );
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mitm-bundle-"));
+  try {
+    await syncStandaloneExtraModules(repoRoot, fs.promises, { log() {} }, tmp);
+    for (const rel of relRequires) {
+      assert.ok(
+        fs.existsSync(path.join(tmp, "src/mitm", rel)),
+        `server.cjs requires ./src/mitm/${rel} but EXTRA_MODULE_ENTRIES does not ship it — MITM child crashes with MODULE_NOT_FOUND`
+      );
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("EXTRA_MODULE_ENTRIES ships every dynamic import() of MITM _internal shims (#9451)", async () => {
+  const internalDir = path.join(repoRoot, "src/mitm/_internal");
+  const shimFiles = fs
+    .readdirSync(internalDir)
+    .filter((f) => f.endsWith(".cjs"));
+  assert.ok(shimFiles.length > 0, "src/mitm/_internal has shim files to check (sanity)");
+
+  // Collect bare-specifier (non-relative, non-node:) dynamic imports across all shims.
+  const bareImports = new Set<string>();
+  for (const f of shimFiles) {
+    const src = fs.readFileSync(path.join(internalDir, f), "utf8");
+    for (const m of src.matchAll(/import\("([^"]+)"\)/g)) {
+      const spec = m[1];
+      if (spec.startsWith("node:") || spec.startsWith(".") || spec.startsWith("/")) continue;
+      bareImports.add(spec);
+    }
+  }
+  assert.ok(
+    bareImports.size > 0,
+    "MITM _internal shims have bare-specifier dynamic import() calls to check (sanity)"
+  );
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mitm-bundle-imports-"));
+  try {
+    await syncStandaloneExtraModules(repoRoot, fs.promises, { log() {} }, tmp);
+    for (const spec of bareImports) {
+      // Bare specifiers resolve into node_modules/<name>; scoped packages live
+      // under node_modules/@scope/. For selfsigned (no nested subpath used at
+      // link time) it suffices to check the package directory is shipped.
+      const pkgDir = path.join(tmp, "node_modules", ...spec.split("/"));
+      assert.ok(
+        fs.existsSync(pkgDir),
+        `MITM _internal shim dynamic-imports "${spec}" but EXTRA_MODULE_ENTRIES does not ship it — MITM child crashes with MODULE_NOT_FOUND`
+      );
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #9451

## Root cause

Two defects in `scripts/build/assembleStandalone.mjs` cause the AgentBridge MITM proxy to crash at boot in the Docker standalone bundle:

1. **Missing `_internal/` shim directory** — `EXTRA_MODULE_ENTRIES` only ships `src/mitm/server.cjs` but not the `src/mitm/_internal/` directory that `server.cjs` requires at lines 138-142 and 258 (`bypass.cjs`, `ingest.cjs`, `forwardTarget.cjs`, `aliasConfig.cjs`, `standaloneRouting.cjs`, `rootCaShim.cjs`). The MITM child process crashes with MODULE_NOT_FOUND.

2. **Missing `selfsigned` package** — `src/mitm/_internal/rootCaShim.cjs` does `await import("selfsigned")` (lines 30, 46) for dynamic SSL certificate generation, but `selfsigned` is not in Next.js's standalone trace (the MITM child is a separate `node` process, not imported by the main server) and was not in `EXTRA_MODULE_ENTRIES`.

## Fix

Add two entries to `EXTRA_MODULE_ENTRIES` in `scripts/build/assembleStandalone.mjs`:
- `src/mitm/_internal` -> `src/mitm/_internal`
- `node_modules/selfsigned` -> `node_modules/selfsigned`

## Regression test (TDD, RED → GREEN)

`tests/unit/build/mitm-server-bundle-contents.test.ts` — two tests that derive the requirement from the source itself (following the same pattern as the existing `server-ws.mjs` import guard in `assemble-standalone.test.ts`):
- every relative `require()` of `server.cjs` is shipped by `EXTRA_MODULE_ENTRIES`
- every bare-specifier dynamic `import()` of the `_internal/*.cjs` shims is shipped

RED on unmodified code (both fail), GREEN after the fix.

```
✖ EXTRA_MODULE_ENTRIES ships every relative require() of MITM server.cjs (#9451)
  AssertionError: server.cjs requires ./src/mitm/_internal/bypass.cjs but EXTRA_MODULE_ENTRIES does not ship it
✖ EXTRA_MODULE_ENTRIES ships every dynamic import() of MITM _internal shims (#9451)
  AssertionError: MITM _internal shim dynamic-imports "selfsigned" but EXTRA_MODULE_ENTRIES does not ship it
```
→ after fix: pass 2, fail 0.

## Gates run green
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `npx eslint --no-config-lookup --config eslint.complexity.config.mjs scripts/build/assembleStandalone.mjs` — 0 errors
- `npx eslint --no-config-lookup --config eslint.sonarjs.config.mjs scripts/build/assembleStandalone.mjs` — 0 errors
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `node scripts/check/check-file-size.mjs` — the one ✗ (`open-sse/executors/base.ts`) is pre-existing base-red drift on a file this diff does not touch (confirmed via `git diff --name-only`)
- existing `tests/unit/build/assemble-standalone.test.ts` — 5/5 pass

## Plan file
`_tasks/pipeline/bugs/2-implementing/9451-bug-missing-selfsigned-dependency-causes-agentbridge-mitm-pr.plan.md`