### PR TITLE
fix(cli): stop the supervisor before the child so omniroute stop no longer reports success while the supervisor respawns the server (#9455)

### DIFF
--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -387,12 +387,19 @@ async function runWithSupervisor(
 
   supervisor.start();
 
+  // #9455: persist the supervisor's own PID so `omniroute stop` can SIGTERM it
+  // before the child — the supervisor's SIGTERM handler sets isShuttingDown=true,
+  // kills the child, and exits cleanly, so the child is never respawned after stop.
+  writePidFile("supervisor", process.pid);
+
   process.on("SIGINT", () => {
     killTrayIfActive();
+    cleanupPidFile("supervisor");
     supervisor.stop();
   });
   process.on("SIGTERM", () => {
     killTrayIfActive();
+    cleanupPidFile("supervisor");
     supervisor.stop();
   });
 

--- a/bin/cli/commands/stop.mjs
+++ b/bin/cli/commands/stop.mjs
@@ -24,18 +24,35 @@ export function registerStop(program) {
 
 export async function runStopCommand(opts = {}) {
   const pid = readPidFile("server");
+  // #9455: when the server was started with a supervisor (the default), killing only
+  // the child lets the supervisor respawn it immediately. The supervisor's PID is
+  // persisted separately by serve.mjs; SIGTERM it FIRST so its handler sets
+  // isShuttingDown=true and stops the child cleanly without respawning.
+  const supervisorPid = readPidFile("supervisor");
 
   if (pid && isPidRunning(pid)) {
     console.log(t("stop.stopping", { pid }));
     try {
+      if (supervisorPid && isPidRunning(supervisorPid)) {
+        try {
+          process.kill(supervisorPid, "SIGTERM");
+        } catch {}
+        // Give the supervisor a moment to cascade the shutdown to its child so we
+        // don't race the child kill against the supervisor's own child stop.
+        await sleep(300);
+      }
+
       // #8045: on win32, process.kill(pid, "SIGTERM") unconditionally force-terminates
       // the target instead of delivering an interceptable signal, racing (and beating)
       // the server's own async graceful shutdown / WAL checkpoint. stopProcessGracefully
       // skips the immediate SIGTERM on win32 and just polls before escalating to SIGKILL.
-      await stopProcessGracefully({ pid, timeoutMs: 5000, isPidRunning, sleep });
+      if (isPidRunning(pid)) {
+        await stopProcessGracefully({ pid, timeoutMs: 5000, isPidRunning, sleep });
+      }
 
       killAllSubprocesses();
       cleanupPidFile("server");
+      cleanupPidFile("supervisor");
       console.log(t("stop.stopped"));
       return 0;
     } catch (err) {
@@ -49,10 +66,24 @@ export async function runStopCommand(opts = {}) {
   const port = opts.port ? parseInt(String(opts.port), 10) : 20128;
   if (pid === null) {
     console.log(t("stop.portFallback"));
-    await killByPort(port);
+    // #9455: a stale supervisor PID file would let the port-fallback stop also
+    // leave the supervisor running and respawning. Stop it first.
+    if (supervisorPid && isPidRunning(supervisorPid)) {
+      try {
+        process.kill(supervisorPid, "SIGTERM");
+      } catch {}
+    }
+    const portFreed = await killByPort(port);
     killAllSubprocesses();
     cleanupPidFile("server");
-    console.log(t("stop.stopped"));
+    cleanupPidFile("supervisor");
+    // #9455: only report success when the port is actually free — previously stop
+    // printed "Server stopped." even when killByPort was a no-op (win32).
+    if (portFreed) {
+      console.log(t("stop.stopped"));
+    } else {
+      console.log(t("stop.notRunning"));
+    }
     return 0;
   }
 
@@ -60,31 +91,84 @@ export async function runStopCommand(opts = {}) {
   return 0;
 }
 
-async function killByPort(port) {
-  if (process.platform === "win32") return;
+/**
+ * Kill the process listening on `port`. Returns true once the port is free
+ * (or no listener was found), false if it could not be freed.
+ *
+ * #9455: previously this was a no-op on win32 (`if (win32) return;`) yet the
+ * caller still reported "Server stopped." — a lie. The win32 branch now uses
+ * `netstat -ano` to find LISTENING PIDs and `process.kill()` (SIGTERM then
+ * SIGKILL), mirroring the POSIX `lsof` path.
+ */
+export async function killByPort(port, deps = {}) {
+  const exec = deps.execFileAsync || execFileAsync;
+  const kill = deps.processKill || ((p, sig) => process.kill(p, sig));
+  const running = deps.isPidRunning || isPidRunning;
+  const wait = deps.sleep || sleep;
+  const platform = deps.platform || process.platform;
+
+  if (platform === "win32") {
+    return killByPortWin32(port, { exec, kill, running, wait });
+  }
+  return killByPortPosix(port, { exec, kill, running, wait });
+}
+
+async function killByPortPosix(port, { exec, kill, running, wait }) {
+  let pids = [];
   try {
-    const { stdout } = await execFileAsync("lsof", ["-ti", `:${port}`]);
-    const pids = stdout
+    const { stdout } = await exec("lsof", ["-ti", `:${port}`]);
+    pids = stdout
       .trim()
       .split("\n")
       .map((p) => parseInt(p, 10))
       .filter((p) => Number.isFinite(p) && p > 0);
-
-    for (const p of pids) {
-      try {
-        process.kill(p, "SIGTERM");
-      } catch {}
-    }
-
-    if (pids.length > 0) {
-      await sleep(1000);
-      for (const p of pids) {
-        try {
-          if (isPidRunning(p)) process.kill(p, "SIGKILL");
-        } catch {}
-      }
-    }
   } catch {
     // lsof not available or no process on port
   }
+  return terminatePids(pids, { kill, running, wait });
+}
+
+async function killByPortWin32(port, { exec, kill, running, wait }) {
+  let pids = [];
+  try {
+    const { stdout } = await exec("netstat", ["-ano"]);
+    pids = parseNetstatPids(stdout, port);
+  } catch {
+    // netstat not available or empty
+  }
+  return terminatePids(pids, { kill, running, wait });
+}
+
+function parseNetstatPids(stdout, port) {
+  const portCol = `:${port}`;
+  const pids = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const cols = line.trim().split(/\s+/);
+    // Expected columns: Proto LocalAddress ForeignAddress State PID
+    if (cols.length < 5) continue;
+    if (cols[0] !== "TCP" && cols[0] !== "TCPv6") continue;
+    const local = cols[1] || "";
+    if (!local.endsWith(portCol)) continue;
+    if ((cols[cols.length - 2] || "").toUpperCase() !== "LISTENING") continue;
+    const pid = parseInt(cols[cols.length - 1], 10);
+    if (Number.isFinite(pid) && pid > 0 && !pids.includes(pid)) pids.push(pid);
+  }
+  return pids;
+}
+
+async function terminatePids(pids, { kill, running, wait }) {
+  if (pids.length === 0) return true;
+  for (const p of pids) {
+    try {
+      kill(p, "SIGTERM");
+    } catch {}
+  }
+  await wait(1000);
+  for (const p of pids) {
+    try {
+      if (running(p)) kill(p, "SIGKILL");
+    } catch {}
+  }
+  // Confirm the port is free: any PID still alive means we failed.
+  return pids.every((p) => !running(p));
 }

--- a/bin/cli/utils/pid.mjs
+++ b/bin/cli/utils/pid.mjs
@@ -2,7 +2,9 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "
 import { join } from "node:path";
 import { resolveDataDir } from "../data-dir.mjs";
 
-const SERVICES = ["server", "mitm", "tunnel/cloudflared", "tunnel/tailscale"];
+// #9455: "supervisor" must be tracked so killAllSubprocesses() can stop the
+// supervisor process, not just the child server it spawned (and respawns).
+const SERVICES = ["server", "supervisor", "mitm", "tunnel/cloudflared", "tunnel/tailscale"];
 
 function getServicePidPath(service) {
   return join(resolveDataDir(), service, ".pid");

--- a/changelog.d/fixes/9455-stop-supervisor-respawn.md
+++ b/changelog.d/fixes/9455-stop-supervisor-respawn.md
@@ -1,0 +1,1 @@
+- fix(cli): stop the supervisor before the child so omniroute stop no longer reports success while the supervisor respawns the server (#9455)

--- a/tests/unit/cli-stop-supervisor-respawn-9455.test.ts
+++ b/tests/unit/cli-stop-supervisor-respawn-9455.test.ts
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Repro for #9455: omniroute stop reports success but supervisor respawns child.
+//
+// Defect 1: runStopCommand() kills the child ("server") PID but never stops the
+//   supervisor, which immediately respawns the child. The fix must have stop.mjs
+//   read the "supervisor" PID file and SIGTERM the supervisor FIRST (its handler
+//   sets isShuttingDown=true, kills the child, exits cleanly — no respawn).
+//   Plus serve.mjs must persist the supervisor PID via writePidFile("supervisor", ...).
+//
+// Defect 2: killByPort() was a no-op on win32 (`if (process.platform === "win32") return;`)
+//   yet runStopCommand still printed "Server stopped." and returned 0. The fix must
+//   implement a win32 path using netstat -ano + process.kill.
+
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_PLATFORM = process.platform;
+
+type KillByPortDeps = {
+  platform?: string;
+  execFileAsync?: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+  processKill?: (pid: number, signal: string | number) => boolean;
+  isPidRunning?: (pid: number) => boolean;
+  sleep?: (ms: number) => Promise<void>;
+};
+type KillByPortFn = (port: number, deps?: KillByPortDeps) => Promise<boolean>;
+
+function createTempDataDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-stop-sup-"));
+}
+
+function setupDataDir(dataDir: string) {
+  fs.mkdirSync(path.join(dataDir, "server"), { recursive: true });
+  fs.mkdirSync(path.join(dataDir, "supervisor"), { recursive: true });
+}
+
+function setServerPid(dataDir: string, p: number) {
+  fs.writeFileSync(path.join(dataDir, "server", ".pid"), String(p), "utf8");
+}
+function setSupervisorPid(dataDir: string, p: number) {
+  fs.writeFileSync(path.join(dataDir, "supervisor", ".pid"), String(p), "utf8");
+}
+
+async function withEnv(fn: (dataDir: string) => Promise<void>) {
+  const dataDir = createTempDataDir();
+  process.env.DATA_DIR = dataDir;
+  globalThis.fetch = (async () => {
+    throw new Error("server offline");
+  }) as typeof fetch;
+
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = () => {};
+  console.error = () => {};
+
+  try {
+    await fn(dataDir);
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+}
+
+// Track process.kill calls so the test can assert which PIDs were signalled
+// without touching real processes. PIDs >= 1000000 are treated as alive.
+function trackKills() {
+  const kills: Array<{ pid: number; signal: string | number }> = [];
+  const origKill = process.kill.bind(process);
+  type KillFn = (pid: number, signal?: NodeJS.Signals | number) => boolean;
+  const stub: KillFn = (pid, signal = 0) => {
+    if (signal === 0) {
+      return pid >= 1000000 ? true : (origKill(pid, 0), true);
+    }
+    if (pid >= 1000000) {
+      kills.push({ pid, signal: signal as string | number });
+      return true;
+    }
+    try {
+      origKill(pid, signal as NodeJS.Signals);
+      kills.push({ pid, signal: signal as string | number });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  (process as unknown as { kill: KillFn }).kill = stub;
+  return {
+    kills,
+    restore() {
+      (process as unknown as { kill: KillFn }).kill = origKill as KillFn;
+    },
+  };
+}
+
+test("Defect 1: stop must SIGTERM the supervisor BEFORE the child so it does not respawn (#9455)", async () => {
+  await withEnv(async (dataDir) => {
+    setupDataDir(dataDir);
+    const SUPERVISOR_PID = 1000123;
+    const CHILD_PID = 1000456;
+    setSupervisorPid(dataDir, SUPERVISOR_PID);
+    setServerPid(dataDir, CHILD_PID);
+
+    const tracker = trackKills();
+    try {
+      const { runStopCommand } = await import("../../bin/cli/commands/stop.mjs");
+      await runStopCommand({});
+      const signalled = tracker.kills.map((k) => k.pid);
+      assert.ok(
+        signalled.includes(SUPERVISOR_PID),
+        `supervisor PID ${SUPERVISOR_PID} must be signalled; got ${JSON.stringify(signalled)}`
+      );
+      // Supervisor must be signalled before the child (cascade order).
+      const supIdx = signalled.indexOf(SUPERVISOR_PID);
+      const childIdx = signalled.indexOf(CHILD_PID);
+      if (childIdx !== -1) {
+        assert.ok(
+          supIdx < childIdx,
+          `supervisor must be killed before child (supIdx=${supIdx} childIdx=${childIdx})`
+        );
+      }
+    } finally {
+      tracker.restore();
+    }
+  });
+});
+
+test("Defect 1b: pid.mjs SERVICES array must include supervisor so killAllSubprocesses reaches it (#9455)", async () => {
+  const tmpDir = os.tmpdir() + "/omniroute-sup-pid-" + Date.now();
+  process.env.DATA_DIR = tmpDir;
+  try {
+    const { writePidFile, readPidFile } = await import("../../bin/cli/utils/pid.mjs");
+    const ok = writePidFile("supervisor", 555555);
+    assert.equal(ok, true, "writePidFile('supervisor', ...) must succeed");
+    assert.equal(readPidFile("supervisor"), 555555);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+
+  const pidSrc = fs.readFileSync(
+    path.join(process.cwd(), "bin/cli/utils/pid.mjs"),
+    "utf8"
+  );
+  assert.ok(
+    /SERVICES\s*=\s*\[[^\]]*"supervisor"[^\]]*\]/.test(pidSrc),
+    'pid.mjs SERVICES array must include "supervisor"'
+  );
+});
+
+test("Defect 2: killByPort on win32 must actually kill the port listener via netstat -ano (#9455)", async () => {
+  const FAKE_WIN_PID = 1000789;
+  const kills: Array<{ pid: number; signal: string | number }> = [];
+  const deps = {
+    platform: "win32",
+    execFileAsync: async (cmd: string, args: string[]) => {
+      if (cmd.endsWith("netstat")) {
+        return {
+          stdout: `  TCP    0.0.0.0:20128    0.0.0.0:0    LISTENING    ${FAKE_WIN_PID}\r\n`,
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    },
+    processKill: (p: number, sig: string | number) => {
+      kills.push({ pid: p, signal: sig });
+      return true;
+    },
+    isPidRunning: (_p: number) => false, // pretend SIGTERM already killed it
+    sleep: async (_ms: number) => {},
+  };
+
+  const { killByPort } = await import("../../bin/cli/commands/stop.mjs");
+  const freed = await (killByPort as unknown as KillByPortFn)(20128, deps);
+  assert.equal(freed, true, "port must be reported free after killing the listener");
+  assert.ok(
+    kills.some((k) => k.pid === FAKE_WIN_PID),
+    `win32 killByPort must signal the netstat PID ${FAKE_WIN_PID}; got ${JSON.stringify(kills)}`
+  );
+});
+
+test("Defect 2b: killByPort on win32 with no listener returns true and signals nothing (#9455)", async () => {
+  const kills: Array<{ pid: number; signal: string | number }> = [];
+  const deps = {
+    platform: "win32",
+    execFileAsync: async (_cmd: string, _args: string[]) => ({ stdout: "", stderr: "" }),
+    processKill: (p: number, sig: string | number) => {
+      kills.push({ pid: p, signal: sig });
+      return true;
+    },
+    isPidRunning: (_p: number) => false,
+    sleep: async (_ms: number) => {},
+  };
+
+  const { killByPort } = await import("../../bin/cli/commands/stop.mjs");
+  const freed = await (killByPort as unknown as KillByPortFn)(20128, deps);
+  assert.equal(freed, true);
+  assert.equal(kills.length, 0, "no PIDs should be signalled when none are listening");
+});
+
+test("netstat parsing: only LISTENING lines matching the exact port are selected (#9455)", async () => {
+  const stdout = [
+    "  TCP    0.0.0.0:20128    0.0.0.0:0    LISTENING    111",
+    "  TCP    127.0.0.1:20128    0.0.0.0:0    LISTENING    222",
+    "  TCP    0.0.0.0:120128    0.0.0.0:0    LISTENING    333", // different port (prefix)
+    "  TCP    0.0.0.0:20128    0.0.0.0:0    TIME_WAIT    444", // not listening
+  ].join("\r\n");
+  const kills: Array<{ pid: number; signal: string | number }> = [];
+  const deps = {
+    platform: "win32",
+    execFileAsync: async (_cmd: string, _args: string[]) => ({ stdout, stderr: "" }),
+    processKill: (p: number, sig: string | number) => {
+      kills.push({ pid: p, signal: sig });
+      return true;
+    },
+    isPidRunning: (_p: number) => false,
+    sleep: async (_ms: number) => {},
+  };
+
+  const { killByPort } = await import("../../bin/cli/commands/stop.mjs");
+  await (killByPort as unknown as KillByPortFn)(20128, deps);
+  const signalled = kills.map((k) => k.pid).sort();
+  assert.deepEqual(signalled, [111, 222], "only exact-port LISTENING PIDs must be killed");
+  void ORIGINAL_PLATFORM;
+});


### PR DESCRIPTION
Closes #9455

## Root cause

Two independent defects in `omniroute stop` (`bin/cli/commands/stop.mjs`):

**Defect 1 — Supervisor respawns child after stop.** When the server runs under the default supervisor mode, `serve.mjs` spawns a `ServerSupervisor` which starts the child server. Only the **child** PID was persisted (`processSupervisor.mjs:66` writes `<dataDir>/server/.pid`). `runStopCommand()` read that PID and killed the child, but the supervisor process (a different, untracked PID) saw `isShuttingDown` still `false` and immediately restarted the child — rewriting the PID file with the new child PID. Stop printed "Server stopped." and returned 0, a lie.

**Defect 2 — `killByPort()` was a no-op on win32.** `stop.mjs:64` returned immediately on Windows, yet the caller still printed "Server stopped." and returned 0, leaving the port listener alive.

## Fix

1. `serve.mjs runWithSupervisor()` now persists the supervisor PID via `writePidFile("supervisor", process.pid)` and cleans it up on SIGINT/SIGTERM.
2. `pid.mjs` SERVICES array now includes `"supervisor"` so `killAllSubprocesses()` reaches it.
3. `stop.mjs runStopCommand()` reads the supervisor PID and SIGTERMs it **first** (its handler sets `isShuttingDown=true`, kills the child, exits cleanly — no respawn) before touching the child PID.
4. `stop.mjs killByPort()` now has a win32 path using `netstat -ano` parsing + `process.kill` (SIGTERM then SIGKILL), mirroring the POSIX `lsof` path. The port-fallback branch only prints "Server stopped." when the port is actually free.

## Regression test

`tests/unit/cli-stop-supervisor-respawn-9455.test.ts` (NEW) — RED→GREEN evidence:

RED (unmodified `origin/release/v3.8.50`):
- Defect 1: `supervisor PID 1000123 must be signalled; got [1000456,1000456,1000456]` — only the child was killed.
- Defect 1b: `pid.mjs SERVICES array must include "supervisor"` — array lacked `supervisor`.
- Defect 2: win32 `killByPort` no-op (no PID signalled).

GREEN (after fix): all 5 tests pass — supervisor is signalled before the child, SERVICES includes `supervisor`, win32 `killByPort` kills the netstat PID.

## Gates run green

- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0 (test file clean; `bin/*.mjs` are lint-ignored)
- `node scripts/check/check-file-size.mjs` — no ✗ on files this diff touches (the lone `base.ts` ✗ is pre-existing drift unrelated to this change)
- `npx eslint --config eslint.complexity.config.mjs` (cyclomatic) on changed files — 0 messages
- `npx eslint --config eslint.sonarjs.config.mjs` (cognitive) on changed files — 0 messages
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Plan file

`_tasks/pipeline/bugs/2-implementing/9455-fix-omniroute-stop-reports-success-but-supervisor-respawns-c.plan.md`
