### PR TITLE
fix(cli): re-verify running binary version after update install and warn on shadowing local install (#9475)

### DIFF
--- a/.fakebin-9475/npm
+++ b/.fakebin-9475/npm
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+if [ "$1" = "view" ]; then echo "3.8.99"; exit 0; fi
+if [ "$1" = "install" ]; then echo "added 1 package"; exit 0; fi
+exit 0

--- a/bin/cli/commands/update.mjs
+++ b/bin/cli/commands/update.mjs
@@ -181,6 +181,26 @@ export async function runUpdateCommand(opts = {}) {
     // --include=optional keeps the optionalDependencies (better-sqlite3, keytar,
     // tls-client, llmlingua SLM stack) on update so an omit=optional config can't drop them.
     execSync("npm install -g omniroute@latest --include=optional", { stdio: "inherit" });
+    // Trust-but-verify: `npm install -g` exits 0 even when a shadowing local install
+    // (e.g. ~/node_modules/omniroute ahead of the global prefix on PATH) means the
+    // binary the user actually runs was not touched. Re-read the running binary's
+    // version and warn instead of lying about success (#9475).
+    const afterVersion = await getCurrentVersion();
+    if (afterVersion && compareVersions(afterVersion, latest) < 0) {
+      printError(
+        `Global install updated to ${latest}, but the running binary still reports ${afterVersion}.`,
+      );
+      console.log(
+        "  A local `node_modules/omniroute` is likely shadowing the global install on PATH.",
+      );
+      console.log("  Diagnose with:");
+      console.log("    which -a omniroute");
+      console.log("    command -v omniroute");
+      console.log("    npm prefix -g");
+      console.log("  Then remove the shadowing local copy (e.g. `npm uninstall omniroute` from its directory)");
+      console.log("  or reorder PATH so the global bin comes first.");
+      return 1;
+    }
     printSuccess(`Updated to version ${latest}`);
     printInfo("Run `omniroute --version` to verify.");
     return 0;

--- a/changelog.d/fixes/9475-update-lies-shadowing.md
+++ b/changelog.d/fixes/9475-update-lies-shadowing.md
@@ -1,0 +1,1 @@
+- fix(cli): re-verify running binary version after `omniroute update` install and warn instead of lying about success when a local install shadows the global one (#9475)

--- a/tests/unit/cli-update-shadow-install-9475.test.ts
+++ b/tests/unit/cli-update-shadow-install-9475.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const update = await import("../../bin/cli/commands/update.mjs");
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const REAL_VERSION = JSON.parse(readFileSync(path.join(REPO_ROOT, "package.json"), "utf-8")).version;
+const FAKE_BIN = path.join(REPO_ROOT, ".fakebin-9475");
+
+test("runUpdateCommand claims success without verifying the running binary version changed (#9475)", async () => {
+  const origPath = process.env.PATH;
+  process.env.PATH = FAKE_BIN + path.delimiter + origPath;
+  const stdoutLogs: string[] = [];
+  const origLog = console.log;
+  console.log = function (...args: unknown[]) {
+    stdoutLogs.push(args.map(String).join(" "));
+  };
+  try {
+    const exitCode = await update.runUpdateCommand({ yes: true, backup: false });
+    const realVersion = await update.getCurrentVersion();
+    const claimed = stdoutLogs.some((l) => /Updated to version 3\.8\.99/i.test(l));
+    if (claimed && exitCode === 0) {
+      assert.fail(
+        "runUpdateCommand claimed Updated to version 3.8.99 (exit 0) but the running binary is still " +
+          realVersion +
+          " — the resolved/shadowing install was not actually updated. Must re-verify getCurrentVersion() after install or warn the user.",
+      );
+    }
+    assert.ok(true);
+  } finally {
+    console.log = origLog;
+    process.env.PATH = origPath;
+  }
+});


### PR DESCRIPTION
Closes #9475

## Root cause

`omniroute update` runs `npm install -g omniroute@latest` and, on exit 0, unconditionally prints `Updated to version ${latest}` and returns 0 — trusting npm's claimed install result instead of the binary the user actually runs. When a local `node_modules/omniroute` shadows the global install on PATH (the reporter's case: their `omniroute` resolves to `~/node_modules/omniroute/`, proven by the second `Loaded env from` banner line), the global copy is updated but the resolved binary stays old, so `omniroute --version` still shows the old version. The update command never re-checks `getCurrentVersion()` after the install.

The `npm warn ERESOLVE` / `install-scripts` lines in the report are warnings (downgraded by `.npmrc legacy-peer-deps=true`), not the failure — the install exited 0.

## Fix

In `bin/cli/commands/update.mjs::runUpdateCommand()`, after the `execSync("npm install -g ...")` succeeds, re-call `getCurrentVersion()` and compare to `latest`. If the running binary still reports a lower version, do NOT print the success message — instead warn the user that the resolved binary still reports the old version, list the likely cause (a local `node_modules/omniroute` shadowing the global install on PATH) and the diagnostic commands (`which -a omniroute`, `command -v omniroute`, `npm prefix -g`), and return exit 1 so scripts/CI detect the no-op update. If the versions match, print the existing success message as a verified fact.

## Regression test

`tests/unit/cli-update-shadow-install-9475.test.ts` — a fake `npm` on PATH reports `3.8.99` for `view` and "succeeds" for `install` without touching the real `package.json` (stays `3.8.50`). The test asserts the command must NOT print `Updated to version 3.8.99` with exit 0 while `getCurrentVersion()` still returns `3.8.50`.

RED (unmodified):
```
AssertionError [ERR_ASSERTION]: runUpdateCommand claimed Updated to version 3.8.99 (exit 0) but the running binary is still 3.8.50 — the resolved/shadowing install was not actually updated.
```

GREEN (after fix):
```
✔ runUpdateCommand claims success without verifying the running binary version changed (#9475) (146.146483ms)
ℹ pass 1, fail 0
```

## Gates run green

- typecheck:core — exit 0
- eslint (changed files, with suppressions) — exit 0
- check-tracked-artifacts — OK
- check-changelog-integrity — OK
- per-file complexity (eslint.complexity.config.mjs + eslint.sonarjs.config.mjs on update.mjs) — 0 violations (full-repo check-complexity/check-cognitive-complexity are ratchet/count-based; baseline 2774 with ample headroom, this change adds 0 new violations)
- sibling tests (cli-update-prefer-online-4376, cli-expanded-commands, cli-update-global-paths-3295) — all pass
- check-file-size — my touched files are NOT flagged (the lone ✗ on `open-sse/executors/base.ts` is pre-existing base-red drift on the release branch, unchanged by my diff: `git diff origin/release/v3.8.50 -- open-sse/executors/base.ts` is empty)

## Plan file

`_tasks/pipeline/bugs/2-implementing/9475-fix-update-command-lies-about-success-on-shadowing-local-install.plan.md`