### PR TITLE
fix(backend): force system MITM CA cert to 0644 on Linux regardless of umask and repair on re-install (#9442)

### DIFF
--- a/changelog.d/fixes/9442-mitm-ca-umask.md
+++ b/changelog.d/fixes/9442-mitm-ca-umask.md
@@ -1,0 +1,1 @@
+- fix(backend): force system MITM CA cert to 0644 on Linux regardless of umask and repair on re-install (#9442)

--- a/src/mitm/cert/install.ts
+++ b/src/mitm/cert/install.ts
@@ -196,6 +196,15 @@ export async function installCert(sudoPassword: string, certPath: string): Promi
 
   const isInstalled = await checkCertInstalled(certPath);
   if (isInstalled) {
+    // #9442: the fingerprint matched, but a restrictive umask at install time
+    // may have left the system cert as 0600 — unreadable by non-root TLS
+    // clients (curl, reqwest, uv, Python requests). Repair the mode before
+    // the early return so re-running install fixes a previously wrong-mode
+    // cert instead of silently skipping it.
+    if (!IS_WIN && !IS_MAC) {
+      const config = getLinuxCertConfig();
+      await ensureSystemCertMode(`${config.dir}/${LINUX_CERT_NAME}`, sudoPassword);
+    }
     console.log("✅ Certificate already installed");
     return;
   }
@@ -366,6 +375,10 @@ async function installCertLinux(sudoPassword: string, certPath: string): Promise
 
     await execFileWithPassword("sudo", ["-S", "mkdir", "-p", config.dir], sudoPassword);
     await execFileWithPassword("sudo", ["-S", "cp", certPath, destFile], sudoPassword);
+    // #9442: `cp` inherits the process umask. A restrictive umask (e.g. PM2
+    // UMask=0077) creates the system cert as 0600 root:root, unreadable by
+    // non-root TLS clients. Force the public cert to 0644 (world-readable).
+    await execFileWithPassword("sudo", ["-S", "chmod", "0644", destFile], sudoPassword);
     await execFileWithPassword("sudo", ["-S", config.cmd], sudoPassword);
 
     await updateNssDatabases(certPath, "add");
@@ -375,6 +388,29 @@ async function installCertLinux(sudoPassword: string, certPath: string): Promise
       ? "User canceled authorization"
       : "Certificate install failed";
     throw new Error(msg);
+  }
+}
+
+/**
+ * #9442 — ensure the system trust-store cert is world-readable (mode 0644).
+ *
+ * `installCertLinux()` now sets the mode explicitly after `cp`, but a cert
+ * installed by an older build (before the chmod was added) may still be 0600
+ * from a restrictive umask. `checkCertInstalledLinux()` only compares
+ * fingerprints, so {@link installCert}'s already-installed branch calls this
+ * helper to repair the mode on re-run. Best-effort: a stat/chmod failure
+ * (e.g. dest removed between the fingerprint check and here) is swallowed —
+ * the caller still reports "already installed" and a fresh install will run
+ * next time the fingerprint no longer matches.
+ */
+export async function ensureSystemCertMode(destFile: string, sudoPassword: string): Promise<void> {
+  try {
+    const mode = fs.statSync(destFile).mode & 0o777;
+    if (mode !== 0o644) {
+      await execFileWithPassword("sudo", ["-S", "chmod", "0644", destFile], sudoPassword);
+    }
+  } catch {
+    // best-effort: if stat/chmod fails, the mode repair is skipped
   }
 }
 

--- a/tests/unit/mitm-cert-install-mode-9442.test.ts
+++ b/tests/unit/mitm-cert-install-mode-9442.test.ts
@@ -1,0 +1,167 @@
+/**
+ * #9442 — Linux MITM CA install inherits umask leaving system cert unreadable.
+ *
+ * Root cause: `installCertLinux()` runs `sudo cp` to copy the cert into the
+ * system trust store but never sets the destination file mode. When the
+ * calling service has a restrictive umask (e.g. PM2 `UMask=0077`), the copied
+ * cert lands as `0600 root:root` instead of `0644`, so non-root TLS clients
+ * (curl, Rust's reqwest, uv, Python requests) scanning `/usr/lib/ssl/certs`
+ * emit repeated `Permission denied (os error 13)` warnings.
+ *
+ * Two gaps:
+ *  1. Install gap — `installCertLinux()` never calls `chmod 0644` after `cp`.
+ *  2. Repair gap — `installCert()` returns early when the cert fingerprint
+ *     already matches, so a previously wrong-mode cert is never repaired.
+ *
+ * Methodology: real stub executables on PATH capture the argv of every spawned
+ * command (`cp`, `mkdir`, `chmod`, `update-ca-certificates`), with
+ * `process.platform` forced to `linux` before the module is imported and
+ * `OMNIROUTE_NO_SUDO=1` so `sudo -S` is stripped and the underlying commands
+ * run directly (same `resolveSudoSpawn` seam tested in
+ * `mitm-systemCommands-no-sudo.test.ts`). No `child_process` mocking.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+const originalPath = process.env.PATH;
+const originalNoSudo = process.env.OMNIROUTE_NO_SUDO;
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-9442-"));
+const binDir = path.join(tmpRoot, "bin");
+fs.mkdirSync(binDir, { recursive: true });
+const captureFile = path.join(tmpRoot, "argv.log");
+
+function makeStub(name: string): string {
+  const p = path.join(binDir, name);
+  fs.writeFileSync(
+    p,
+    `#!/usr/bin/env node
+const fs = require("fs");
+fs.appendFileSync(${JSON.stringify(captureFile)}, ${JSON.stringify(name)} + "\\0" + process.argv.slice(2).join("\\0") + "\\n");
+process.exit(0);
+`,
+    { mode: 0o755 }
+  );
+  return p;
+}
+
+for (const cmd of ["cp", "mkdir", "chmod", "update-ca-certificates", "update-ca-trust"]) {
+  makeStub(cmd);
+}
+
+Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
+process.env.OMNIROUTE_NO_SUDO = "1";
+
+// Imported AFTER forcing linux + OMNIROUTE_NO_SUDO=1 so the module-level
+// IS_WIN/IS_MAC consts see `linux` and resolveSudoSpawn strips `sudo -S`.
+const { installCert, ensureSystemCertMode } = await import("../../src/mitm/cert/install.ts");
+
+test.after(() => {
+  Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  process.env.PATH = originalPath;
+  if (originalNoSudo === undefined) delete process.env.OMNIROUTE_NO_SUDO;
+  else process.env.OMNIROUTE_NO_SUDO = originalNoSudo;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function resetCaptured(): void {
+  fs.writeFileSync(captureFile, "");
+}
+
+function readCaptured(): string[][] {
+  const raw = fs.readFileSync(captureFile, "utf8");
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\0"));
+}
+
+function fakeCertFile(seed: string): string {
+  const der = crypto.createHash("sha256").update(seed).digest();
+  const pem =
+    "-----BEGIN CERTIFICATE-----\n" +
+    der.toString("base64").match(/.{1,64}/g)!.join("\n") +
+    "\n-----END CERTIFICATE-----\n";
+  const certPath = path.join(tmpRoot, `${seed}.crt`);
+  fs.writeFileSync(certPath, pem);
+  return certPath;
+}
+
+test("installCert on linux issues `chmod 0644 <destFile>` after cp (install gap)", async () => {
+  resetCaptured();
+  const certPath = fakeCertFile("install-gap-9442");
+  await installCert("", certPath);
+
+  const cmds = readCaptured();
+  const chmodCalls = cmds.filter((argv) => argv[0] === "chmod");
+  assert.ok(chmodCalls.length > 0, "installCertLinux must call chmod after cp");
+  const chmod = chmodCalls[0];
+  assert.equal(chmod[1], "0644", "mode must be 0644 (world-readable)");
+  assert.ok(
+    chmod[2].endsWith("omniroute-mitm.crt"),
+    `chmod must target the system cert, got: ${chmod[2]}`
+  );
+  // cp must precede chmod (install order: mkdir → cp → chmod → update-ca-*).
+  const cpIdx = cmds.findIndex((a) => a[0] === "cp");
+  const chmodIdx = cmds.findIndex((a) => a[0] === "chmod");
+  assert.ok(cpIdx !== -1, "cp must be issued");
+  assert.ok(chmodIdx > cpIdx, "chmod must come after cp");
+});
+
+test("ensureSystemCertMode repairs a 0600 cert to 0644 (repair gap)", async () => {
+  resetCaptured();
+  const destFile = path.join(tmpRoot, "wrong-mode-9442.crt");
+  // Create the file with the restrictive mode that a umask 0077 cp produces.
+  fs.writeFileSync(destFile, "fake-cert", { mode: 0o600 });
+  assert.equal(fs.statSync(destFile).mode & 0o777, 0o600);
+
+  await ensureSystemCertMode(destFile, "");
+
+  const cmds = readCaptured();
+  const chmodCalls = cmds.filter((a) => a[0] === "chmod");
+  assert.ok(chmodCalls.length === 1, "must chmod exactly once when mode != 0644");
+  assert.deepEqual(chmodCalls[0], ["chmod", "0644", destFile]);
+});
+
+test("ensureSystemCertMode is a no-op when the cert is already 0644", async () => {
+  resetCaptured();
+  const destFile = path.join(tmpRoot, "correct-mode-9442.crt");
+  fs.writeFileSync(destFile, "fake-cert", { mode: 0o644 });
+  assert.equal(fs.statSync(destFile).mode & 0o777, 0o644);
+
+  await ensureSystemCertMode(destFile, "");
+
+  const cmds = readCaptured();
+  const chmodCalls = cmds.filter((a) => a[0] === "chmod");
+  assert.equal(chmodCalls.length, 0, "must not chmod when mode is already 0644");
+});
+
+test("filesystem proof: cp under umask 0077 creates mode 0600 (why the fix is needed)", () => {
+  const src = path.join(tmpRoot, "umask-src.crt");
+  const dst = path.join(tmpRoot, "umask-dst.crt");
+  fs.writeFileSync(src, "cert-body", { mode: 0o644 });
+
+  const oldUmask = process.umask(0o077);
+  try {
+    // Use the real `cp` (GNU coreutils) by absolute path — the exact command
+    // installCertLinux runs — so the umask actually applies. Node's
+    // fs.copyFileSync preserves the source mode, which would mask the bug, and
+    // the bare `cp` on PATH below is a logging stub from the install tests.
+    execFileSync("/usr/bin/cp", [src, dst]);
+    const mode = fs.statSync(dst).mode & 0o777;
+    assert.equal(
+      mode,
+      0o600,
+      "cp under umask 0077 must produce 0600 — the bug this fix repairs"
+    );
+  } finally {
+    process.umask(oldUmask);
+  }
+});


### PR DESCRIPTION
Closes #9442

## Root cause

On Linux, `installCertLinux()` in `src/mitm/cert/install.ts` runs `sudo cp` to copy the MITM root CA into the system trust store but never sets the destination file mode. When the calling service has a restrictive umask (e.g. PM2 `UMask=0077`), the copied cert lands as `0600 root:root` instead of the required `0644` (world-readable). Non-root TLS clients (curl, Rust's reqwest, uv, Python requests) scanning `/usr/lib/ssl/certs` then emit repeated `Permission denied (os error 13)` warnings.

Two gaps:
1. **Install gap** — `installCertLinux()` has `cp` but no `chmod 0644` after it, so the umask wins.
2. **Repair gap** — `checkCertInstalledLinux()` only compares certificate fingerprints, and `installCert()` returns early when the fingerprint already matches, so a previously wrong-mode cert is never repaired on re-run.

## Fix

- `installCertLinux()`: add `chmod 0644 <destFile>` immediately after `cp`, before the distro CA refresh command. Idempotent and follows the same pattern as the existing `chmodSync(keyPath, 0o600)` in `rootCa.ts`.
- `installCert()`: in the already-installed early-return branch (Linux only), call a new best-effort `ensureSystemCertMode()` helper that stats the dest file and runs `chmod 0644` only when the current mode is not already 0644, so re-running install repairs a previously wrong-mode cert.

## Regression test

`tests/unit/mitm-cert-install-mode-9442.test.ts` (new file, 4 tests). Real stub executables on PATH capture the argv of every spawned command with `process.platform` forced to `linux` and `OMNIROUTE_NO_SUDO=1` (same `resolveSudoSpawn` seam tested in `mitm-systemCommands-no-sudo.test.ts`).

RED → GREEN evidence (on unmodified `origin/release/v3.8.50` vs after fix):

```
# before fix (RED — 3 of 4 fail)
✖ installCert on linux issues `chmod 0644 <destFile>` after cp (install gap)
  AssertionError: installCertLinux must call chmod after cp
  actual: false, expected: true
✖ ensureSystemCertMode repairs a 0600 cert to 0644 (repair gap)
  TypeError: ensureSystemCertMode is not a function
✖ ensureSystemCertMode is a no-op when the cert is already 0644
  TypeError: ensureSystemCertMode is not a function
✔ filesystem proof: cp under umask 0077 creates mode 0600

# after fix (GREEN — all 4 pass)
✔ installCert on linux issues `chmod 0644 <destFile>` after cp (install gap)
✔ ensureSystemCertMode repairs a 0600 cert to 0644 (repair gap)
✔ ensureSystemCertMode is a no-op when the cert is already 0644
✔ filesystem proof: cp under umask 0077 creates mode 0600
```

## Gates run green

- `npm run typecheck:core` — exit 0 (clean)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/mitm/cert/install.ts tests/unit/mitm-cert-install-mode-9442.test.ts` — exit 0
- `node scripts/check/check-file-size.mjs` — no ✗ on touched files (the only ✗ is pre-existing base-red drift on `open-sse/executors/base.ts`, not in this diff)
- targeted complexity/cognitive eslint (`eslint.complexity.config.mjs` / `eslint.sonarjs.config.mjs`) on `install.ts` — 0 violations; `installCert`/`installCertLinux` each gained one branch, well within the ≤15 limit
- `node scripts/check/check-changelog-integrity.mjs` — OK
- sibling tests touching the module (`agent-bridge-cert-install-fallback-4546`, `mitm-cert-mac-fingerprint`, `mitm-sudo-graceful-degrade`, `mitm-cert-removal-wiring`, `windows-cert-identity-7275`) — all pass (the one `system-trust-test-guard` failure is pre-existing on the clean base: it relies on the global test-runner setup which `node --test <file>` does not load, and is unrelated to this diff)

## Plan file

`_tasks/pipeline/bugs/2-implementing/9442-fix-linux-mitm-ca-install-inherits-umask-leaving-system-cert.plan.md`