### PR TITLE
fix(cli): route claude-code OAuth to the Anthropic claude browser-PKCE flow instead of the unrelated command-code provider (#9474)

### DIFF
--- a/bin/cli/commands/oauth.mjs
+++ b/bin/cli/commands/oauth.mjs
@@ -10,10 +10,27 @@ const PROVIDERS_WITH_OAUTH = [
   { id: "cursor", name: "Cursor", flow: "import" },
   { id: "zed", name: "Zed", flow: "import" },
   { id: "kiro", name: "Amazon Kiro", flow: "social" },
-  { id: "claude-code", name: "Claude Code (OAuth)", flow: "device" },
+  { id: "claude-code", name: "Claude Code (OAuth)", flow: "browser" },
   { id: "codex", name: "OpenAI Codex (OAuth)", flow: "device" },
   { id: "copilot", name: "GitHub Copilot", flow: "device" },
 ];
+
+// The user-facing provider id (the one shown by `omniroute oauth providers`)
+// is NOT always the backend OAuth provider key the server's /api/oauth/[provider]/...
+// route expects. `claude-code` is the CLI-facing alias for Anthropic's Claude
+// OAuth, which the server registers under the key `claude` (see
+// src/lib/oauth/providers/index.ts). Routing `claude-code` to the unrelated
+// `command-code` (CommandCode.ai) provider — as the previous code did — sent
+// the device-flow request to /api/providers/command-code/auth/start, which is
+// gated by requireManagementAuth and returned 401 for a fresh CLI context
+// (issue #9474). Map the alias to the real backend key instead.
+const BACKEND_OAUTH_KEY = {
+  "claude-code": "claude",
+};
+
+function resolveBackendKey(id) {
+  return BACKEND_OAUTH_KEY[id] ?? id;
+}
 
 const oauthProviderSchema = [
   { key: "id", header: "Provider ID", width: 16 },
@@ -56,32 +73,109 @@ async function pollStatus(endpoint, timeoutMs) {
 }
 
 async function runBrowserFlow(def, opts) {
-  const startRes = await apiFetch(`/api/oauth/${def.id}/start`, { method: "POST" });
+  // The user-facing id (`def.id`, e.g. "claude-code") must be translated to the
+  // backend OAuth provider key the server's /api/oauth/[provider]/... route
+  // expects (e.g. "claude"). The previous implementation called a non-existent
+  // `/api/oauth/${def.id}/start` action — no such action exists on the server
+  // (src/app/api/oauth/[provider]/[action]/route.ts), so the browser flow was
+  // broken for every browser-flow provider. Use the real `authorize` action and
+  // complete the PKCE (authorization_code / authorization_code_pkce) flow with a
+  // manual code paste, mirroring the dashboard's manual "input" step.
+  const backendKey = resolveBackendKey(def.id);
+  const redirectUri = opts.redirectUri ?? null;
+  const authorizeUrl = `/api/oauth/${backendKey}/authorize${
+    redirectUri ? `?redirect_uri=${encodeURIComponent(redirectUri)}` : ""
+  }`;
+  const startRes = await apiFetch(authorizeUrl, { method: "GET" });
   if (!startRes.ok) {
-    process.stderr.write(`Failed to start OAuth for ${def.id}: ${startRes.status}\n`);
+    const detail = await safeErrorBody(startRes);
+    process.stderr.write(`Failed to start OAuth for ${def.id}: ${startRes.status}${detail}\n`);
     process.exit(1);
   }
   const start = await startRes.json();
-  const url = start.authorizeUrl ?? start.url;
+  const url = start.authUrl ?? start.authorizeUrl ?? start.url;
+  if (!url) {
+    const hint = start.error ?? "no authUrl returned by the server";
+    process.stderr.write(`OAuth unavailable for ${def.id}: ${hint}\n`);
+    process.exit(1);
+  }
+  const { codeVerifier, state, redirectUri: returnedRedirectUri } = start;
+  const finalRedirectUri = returnedRedirectUri || redirectUri;
 
-  if (process.stdout.isTTY && opts.browser !== false) {
-    const { startOAuthTui } = await import("../tui/OAuthFlow.jsx");
-    await openBrowser(url);
-    const tuiResult = await startOAuthTui({ provider: def.name ?? def.id, url });
-    if (tuiResult.status === "cancelled") return;
-  } else {
-    process.stdout.write(`\nOpen this URL to authorize:\n  ${url}\n\n`);
-    if (opts.browser !== false) await openBrowser(url);
-    process.stderr.write("Waiting for authorization... (Ctrl+C to cancel)\n");
+  process.stdout.write(`\nOpen this URL to authorize:\n  ${url}\n\n`);
+  if (opts.browser !== false) await openBrowser(url);
+  process.stdout.write(
+    "After authorizing, paste the callback URL (or the Authentication Code\n" +
+      "shown on the confirmation page) here:\n"
+  );
+
+  const { createPrompt } = await import("../io.mjs");
+  const prompt = createPrompt();
+  const input = await prompt.ask("Callback URL or code");
+  prompt.close();
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    process.stderr.write("No authorization code provided.\n");
+    process.exit(1);
   }
 
-  const result = await pollStatus(
-    `/api/oauth/${def.id}/status?state=${encodeURIComponent(start.state ?? "")}`,
-    opts.timeout ?? 300000
-  );
+  // The Anthropic Claude confirmation page (platform.claude.com/oauth/code/callback)
+  // shows a raw "Authentication Code" like `code#state` rather than a full URL.
+  // The dashboard's manual submit (src/shared/components/OAuthModal.tsx) parses
+  // both forms; mirror that here.
+  let code = null;
+  let codeState = state || null;
+  try {
+    const cbUrl = new URL(trimmed);
+    code = cbUrl.searchParams.get("code");
+    const stateParam = cbUrl.searchParams.get("state") || cbUrl.hash.replace(/^#/, "");
+    if (stateParam) codeState = stateParam;
+  } catch {
+    const [rawCode, rawState] = trimmed.split("#", 2);
+    code = rawCode || null;
+    if (rawState) codeState = rawState;
+  }
+  if (!code) {
+    process.stderr.write(
+      "No authorization code found. Paste the callback URL or the Authentication Code.\n"
+    );
+    process.exit(1);
+  }
+
+  const exchangeRes = await apiFetch(`/api/oauth/${backendKey}/exchange`, {
+    method: "POST",
+    body: {
+      code,
+      redirectUri: finalRedirectUri,
+      codeVerifier,
+      ...(codeState ? { state: codeState } : {}),
+    },
+  });
+  if (!exchangeRes.ok) {
+    const detail = await safeErrorBody(exchangeRes);
+    process.stderr.write(`Token exchange failed: ${exchangeRes.status}${detail}\n`);
+    process.exit(1);
+  }
+  const result = await exchangeRes.json();
+  const conn = result.connection ?? {};
   process.stdout.write(
-    `Authorized: ${result.email ?? result.userId ?? result.account ?? "connected"}\n`
+    `Authorized: ${conn.email ?? conn.displayName ?? conn.id ?? "connected"}\n`
   );
+}
+
+async function safeErrorBody(res) {
+  try {
+    const data = await res.json();
+    if (data?.error) {
+      const msg = typeof data.error === "string" ? data.error : data.error?.message;
+      if (msg) return `: ${msg}`;
+    }
+    if (data?.message) return `: ${data.message}`;
+  } catch {
+    /* ignore */
+  }
+  return "";
 }
 
 async function runImportFlow(def, opts) {
@@ -124,7 +218,7 @@ async function runSocialFlow(def, opts) {
 }
 
 async function runDeviceFlow(def, opts) {
-  const providerKey = def.id === "claude-code" ? "command-code" : def.id;
+  const providerKey = resolveBackendKey(def.id);
   const startRes = await apiFetch(`/api/providers/${providerKey}/auth/start`, { method: "POST" });
   if (!startRes.ok) {
     process.stderr.write(`Failed to start device flow: ${startRes.status}\n`);

--- a/changelog.d/fixes/9474-claude-code-oauth-mismap.md
+++ b/changelog.d/fixes/9474-claude-code-oauth-mismap.md
@@ -1,0 +1,1 @@
+- fix(cli): route claude-code OAuth to the Anthropic `claude` browser-PKCE flow instead of the unrelated command-code provider (#9474)

--- a/tests/unit/9474-claude-code-oauth-mismap.test.ts
+++ b/tests/unit/9474-claude-code-oauth-mismap.test.ts
@@ -1,0 +1,109 @@
+// Repro/regression test for issue #9474
+// Claude Code OAuth device flow (`omniroute oauth start --provider claude-code`)
+// failed with 401 because the CLI mapped `claude-code` to the unrelated
+// `command-code` (CommandCode.ai) API-key provider instead of the real
+// Anthropic `claude` browser-PKCE OAuth flow.
+//
+// This test asserts the FIXED behavior:
+//  - `claude-code` is labeled `flow: "browser"` (not `"device"`)
+//  - `runDeviceFlow` no longer remaps `claude-code` to `command-code`
+//  - the CLI resolves the user-facing `claude-code` id to the backend
+//    OAuth provider key `claude` and calls the existing browser-PKCE
+//    actions (`authorize` / `exchange`), never `command-code`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+const oauthCliPath = join(repoRoot, "bin/cli/commands/oauth.mjs");
+const oauthCli = readFileSync(oauthCliPath, "utf8");
+
+test("#9474: claude-code is advertised as a browser flow (not device)", () => {
+  // The user-facing entry must be flow: "browser" — Anthropic Claude OAuth is
+  // authorization_code_pkce (browser), not a device-code flow.
+  assert.match(
+    oauthCli,
+    /\{\s*id:\s*"claude-code",\s*name:\s*"Claude Code \(OAuth\)",\s*flow:\s*"browser"\s*\}/,
+    "claude-code must be labeled flow: \"browser\" (Anthropic uses a browser PKCE flow)"
+  );
+  // And it must NOT be labeled device.
+  assert.doesNotMatch(
+    oauthCli,
+    /\{\s*id:\s*"claude-code",\s*name:\s*"Claude Code \(OAuth\)",\s*flow:\s*"device"\s*\}/,
+    "claude-code must not be labeled flow: \"device\""
+  );
+});
+
+test("#9474: runDeviceFlow no longer remaps claude-code -> command-code", () => {
+  // The mismap line must be gone entirely.
+  assert.doesNotMatch(
+    oauthCli,
+    /claude-code"\s*\?\s*"command-code"/,
+    "the claude-code -> command-code remap in runDeviceFlow must be removed"
+  );
+  // And runDeviceFlow must not call the command-code provider route via apiFetch.
+  // (Comments explaining the historical bug may mention the path; only an actual
+  // apiFetch call to it is a regression.)
+  assert.doesNotMatch(
+    oauthCli,
+    /apiFetch\(\s*`\/api\/providers\/command-code\/auth\/start/,
+    "runDeviceFlow must not apiFetch /api/providers/command-code/auth/start"
+  );
+});
+
+test("#9474: CLI resolves user-facing claude-code to backend key claude", () => {
+  // The CLI must map the user-facing id `claude-code` to the backend OAuth
+  // provider key `claude` (the key /api/oauth/[provider]/... expects).
+  // Look for a resolution helper that produces "claude" for "claude-code".
+  assert.match(
+    oauthCli,
+    /claude-code"\s*,?\s*.*?"claude"/,
+    "claude-code must resolve to backend OAuth key claude"
+  );
+});
+
+test("#9474: browser flow for claude-code targets /api/oauth/claude/authorize (not command-code, not a non-existent /start)", () => {
+  // The fixed browser flow must call the existing server action `authorize`
+  // on the resolved backend key `claude` — not the non-existent `/start`
+  // action, and not the command-code provider route.
+  // The runBrowserFlow helper must use the resolved backend key, not def.id,
+  // so claude-code routes to /api/oauth/claude/... .
+  assert.match(
+    oauthCli,
+    /\/api\/oauth\/\$\{[^}]*backendKey[^}]*\}\/authorize/,
+    "runBrowserFlow must call /api/oauth/${backendKey}/authorize using the resolved backend key"
+  );
+  assert.match(
+    oauthCli,
+    /\/api\/oauth\/\$\{[^}]*backendKey[^}]*\}\/exchange/,
+    "runBrowserFlow must call /api/oauth/${backendKey}/exchange using the resolved backend key"
+  );
+  // The old broken non-existent `/start` action must be gone from runBrowserFlow.
+  // Comments explaining the historical bug may mention the path; only an actual
+  // apiFetch call to it is a regression.
+  assert.doesNotMatch(
+    oauthCli,
+    /apiFetch\(\s*`\/api\/oauth\/\$\{def\.id\}\/start/,
+    "runBrowserFlow must not apiFetch the non-existent /api/oauth/${def.id}/start action"
+  );
+});
+
+test("#9474: real Anthropic Claude OAuth is provider `claude` with browser PKCE flow (not device)", async () => {
+  const mod = await import("../../src/lib/oauth/providers/claude.ts");
+  const claude = mod.claude;
+  assert.equal(claude.flowType, "authorization_code_pkce");
+  assert.notEqual(claude.flowType, "device_code");
+  assert.equal(claude.config.authorizeUrl, "https://claude.ai/oauth/authorize");
+});
+
+test("#9474: command-code provider is the unrelated CommandCode.ai apikey provider (unchanged, sanity)", async () => {
+  const mod = await import("../../open-sse/config/providers/registry/command-code/index.ts");
+  const commandCodeProvider = mod.command_codeProvider;
+  assert.equal(commandCodeProvider.id, "command-code");
+  assert.equal(commandCodeProvider.baseUrl, "https://api.commandcode.ai");
+  // command-code must remain distinct from the Anthropic claude provider.
+  assert.notEqual(commandCodeProvider.id, "claude");
+});


### PR DESCRIPTION
Closes #9474

## Root cause

`omniroute oauth start --provider claude-code` always failed with `Failed to start device flow: 401` because the CLI sent the request to the wrong backend provider. In `bin/cli/commands/oauth.mjs`:

- `claude-code` was advertised as `flow: "device"` and `runDeviceFlow` remapped it with `def.id === "claude-code" ? "command-code" : def.id`, so the request hit `POST /api/providers/command-code/auth/start`.
- `command-code` is the unrelated third-party service **CommandCode.ai** (`https://api.commandcode.ai`, an API-key provider), not an Anthropic/Claude Code OAuth connection.
- The `/api/providers/command-code/auth/start` route is gated by `requireManagementAuth()`; a fresh CLI context has no management credential (`contexts list` → `Auth: ✗`), so the request is rejected → `401` regardless of any `--api-key` the user passes (inference keys are not management tokens).

The real Anthropic Claude OAuth connection lives under a different provider key entirely: `claude` (`src/lib/oauth/providers/claude.ts`, `flowType: "authorization_code_pkce"`, served at `GET /api/oauth/claude/authorize` + `POST /api/oauth/claude/exchange`). There is no Anthropic device-code flow.

A secondary latent defect: `runBrowserFlow` called `POST /api/oauth/${def.id}/start` — an action that does not exist on the server (`src/app/api/oauth/[provider]/[action]/route.ts` has no `start` action, only `authorize`, `exchange`, `device-code`, `poll`, etc.), so the browser flow was broken for every browser-flow provider.

## Fix (surgical, `bin/cli/commands/oauth.mjs` only)

- Re-label `claude-code` from `flow: "device"` to `flow: "browser"` (Anthropic uses a browser PKCE flow, not device-code).
- Add a CLI-side `BACKEND_OAUTH_KEY` map resolving the user-facing id `claude-code` → backend OAuth key `claude` (the key `/api/oauth/[provider]/...` expects). Do NOT reuse `command-code`.
- Rewrite `runBrowserFlow` to use the real server PKCE flow: `GET /api/oauth/${backendKey}/authorize` → open `authUrl` → user pastes the callback URL / Authentication Code → `POST /api/oauth/${backendKey}/exchange` with `code`, `redirectUri`, `codeVerifier`, `state`. This mirrors the dashboard's manual "input" step (`src/shared/components/OAuthModal.tsx`) and parses both full callback URLs and raw `code#state` forms (the Anthropic confirmation page shows the latter).
- Remove the `def.id === "claude-code" ? "command-code" : def.id` remap in `runDeviceFlow` entirely; `runDeviceFlow` now uses the same `resolveBackendKey()` helper (so `codex`/`copilot` keep their existing `/api/providers/${id}/auth/start` path).
- Add `safeErrorBody()` helper so failed authorize/exchange responses surface the sanitized server error message instead of a bare status code.
- No server-side change required — the `claude` browser-PKCE flow already exists.

## Regression test (RED → GREEN)

`tests/unit/9474-claude-code-oauth-mismap.test.ts` asserts the fixed behavior. On unmodified `release/v3.8.50`:

```
✖ #9474: claude-code is advertised as a browser flow (not device)
✖ #9474: runDeviceFlow no longer remaps claude-code -> command-code
✖ #9474: CLI resolves user-facing claude-code to backend key claude
✖ #9474: browser flow for claude-code targets /api/oauth/claude/authorize (not command-code, not a non-existent /start)
✔ #9474: real Anthropic Claude OAuth is provider `claude` with browser PKCE flow (not device)
✔ #9474: command-code provider is the unrelated CommandCode.ai apikey provider (unchanged, sanity)
ℹ tests 6  pass 2  fail 4
```

After the fix:

```
✔ #9474: claude-code is advertised as a browser flow (not device)
✔ #9474: runDeviceFlow no longer remaps claude-code -> command-code
✔ #9474: CLI resolves user-facing claude-code to backend key claude
✔ #9474: browser flow for claude-code targets /api/oauth/claude/authorize (not command-code, not a non-existent /start)
✔ #9474: real Anthropic Claude OAuth is provider `claude` with browser PKCE flow (not device)
✔ #9474: command-code provider is the unrelated CommandCode.ai apikey provider (unchanged, sanity)
ℹ tests 6  pass 6  fail 0
```

## Gates run green

- `node --import tsx/esm --test tests/unit/9474-claude-code-oauth-mismap.test.ts` — 6/6 pass
- `node --import tsx/esm --test tests/unit/cli-oauth-commands.test.ts` — 7/7 pass (sibling OAuth CLI tests unchanged)
- `node --import tsx/esm --test tests/unit/command-code-executor.test.ts` — 14/14 pass (command-code provider unchanged)
- `npx tsc -p tsconfig.typecheck-core.json` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/9474-claude-code-oauth-mismap.test.ts` — exit 0
- complexity (`eslint.complexity.config.mjs`) + cognitive complexity (`eslint.sonarjs.config.mjs`) on `bin/cli/commands/oauth.mjs` — 0 messages
- `node scripts/check/check-file-size.mjs` — no ✗ on diff-touched files (the lone `base.ts` base-red drift is pre-existing and unrelated to this diff)
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Plan file

`_tasks/pipeline/bugs/2-implementing/9474-claude-code-oauth-mismap-command-code.plan.md`

## Notes / follow-ups

- The generic `runBrowserFlow` rework (replacing the non-existent `/start` action) now uses the real `authorize`/`exchange` PKCE flow with a manual code paste, which also unblocks the other browser-flow providers (`gemini`, `antigravity`, `windsurf`) that were equally broken by the `/start` call. `windsurf` remains `flow: "browser"` here but the server marks its PKCE flow retired (410 Gone → `import-token`); the new flow will surface that server-side `error` instead of a 404, which is the correct UX.
- `codex` is also mislabeled `flow: "device"` while using `authorization_code_pkce` on the server (same class of bug). Out of scope for this issue; file a separate follow-up if a Codex CLI flow fails the same way.