### PR TITLE
fix(translator): preserve Kimi K3 Responses reasoning

### DIFF
--- a/changelog.d/fixes/9496-kimi-k3-responses-replay.md
+++ b/changelog.d/fixes/9496-kimi-k3-responses-replay.md
@@ -1,0 +1,1 @@
+- fix(translator): preserve Kimi K3 Responses reasoning through Kimi Coding Claude-format and native Moonshot requests, keeping it on the matching assistant tool call or completed turn instead of dropping it or carrying it across a user boundary (#9496)

--- a/changelog.d/fixes/9496-kimi-k3-responses-replay.md
+++ b/changelog.d/fixes/9496-kimi-k3-responses-replay.md
@@ -1,1 +1,1 @@
-- fix(translator): preserve authentic K3 Responses reasoning by model across providers, projecting it onto the matching assistant tool call or completed turn instead of dropping it or carrying it across a user boundary (#9496)
+- fix(translator): preserve authentic K3 Responses reasoning by model across providers, keep it on the matching assistant turn, and make Kimi Coding prefer client reasoning then cached replay before its empty-marker fallback (#9496)

--- a/changelog.d/fixes/9496-kimi-k3-responses-replay.md
+++ b/changelog.d/fixes/9496-kimi-k3-responses-replay.md
@@ -1,1 +1,1 @@
-- fix(translator): preserve Kimi K3 Responses reasoning through Kimi Coding Claude-format and native Moonshot requests, keeping it on the matching assistant tool call or completed turn instead of dropping it or carrying it across a user boundary (#9496)
+- fix(translator): preserve authentic K3 Responses reasoning by model across providers, projecting it onto the matching assistant tool call or completed turn instead of dropping it or carrying it across a user boundary (#9496)

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -40,7 +40,12 @@ export async function handleResponsesCore({
   const customToolNames = collectResponsesCustomToolNames(body?.tools, inputItems);
 
   // Convert Responses API format to Chat Completions format
-  const convertedBody = convertResponsesApiFormat(body, credentials, modelInfo?.provider);
+  const convertedBody = convertResponsesApiFormat(
+    body,
+    credentials,
+    modelInfo?.provider,
+    modelInfo?.model
+  );
 
   // Ensure stream is enabled
   convertedBody.stream = true;

--- a/open-sse/services/reasoningCache.ts
+++ b/open-sse/services/reasoningCache.ts
@@ -64,6 +64,8 @@ const REASONING_REPLAY_MODEL_PATTERNS = [
 ];
 
 const DEEPSEEK_V4_MODEL_PATTERN = /deepseek[-/]v4[-.](flash|pro)/i;
+const K3_REASONING_REPLAY_MODEL_PATTERN = /(?:^|\/)(?:kimi-)?k3(?:$|-)/i;
+const NATIVE_K27_REASONING_REPLAY_MODEL_PATTERN = /(?:^|\/)kimi-k2\.7-code(?:$|-)/i;
 
 export function isDeepSeekReasoningModel(params: {
   provider: string;
@@ -93,6 +95,14 @@ export function requiresReasoningReplay(params: {
   // Explicit model signal from models.dev (preferred source of truth).
   if (normalizedInterleavedField === "reasoning_content") return true;
   if (normalizedInterleavedField === "reasoning_details") return false;
+
+  if (K3_REASONING_REPLAY_MODEL_PATTERN.test(normalizedModel)) return true;
+  if (
+    (normalizedProvider === "moonshot" || normalizedProvider === "kimi") &&
+    NATIVE_K27_REASONING_REPLAY_MODEL_PATTERN.test(normalizedModel)
+  ) {
+    return true;
+  }
 
   // DeepSeek legacy reasoner family has an inverse contract: do not replay.
   if (/deepseek-reasoner/i.test(normalizedModel) || /deepseek-r1/i.test(normalizedModel)) {

--- a/open-sse/translator/helpers/claudeHelper.ts
+++ b/open-sse/translator/helpers/claudeHelper.ts
@@ -84,6 +84,10 @@ export function hasValidContent(msg: ClaudeMessage): boolean {
     return msg.content.some(
       (block) =>
         (block.type === "text" && block.text?.trim()) ||
+        (block.type === "thinking" && block.thinking?.trim()) ||
+        (block.type === "redacted_thinking" &&
+          typeof block.data === "string" &&
+          block.data.trim()) ||
         block.type === "tool_use" ||
         block.type === "tool_result" ||
         // #7777: media-only user turns are real content — dropping them

--- a/open-sse/translator/helpers/responsesApiHelper.ts
+++ b/open-sse/translator/helpers/responsesApiHelper.ts
@@ -2,10 +2,16 @@
  * Convert OpenAI Responses API format to standard chat completions format.
  * Delegates to the canonical translator to avoid logic duplication.
  */
+import { shouldPreserveResponsesReasoningContent } from "../../utils/reasoningContentInjector.ts";
 import { openaiResponsesToOpenAIRequest } from "../request/openai-responses.ts";
 import { toRecord } from "../request/openai-responses/helpers.ts";
 
-export function convertResponsesApiFormat(body, credentials = null, provider = null) {
+export function convertResponsesApiFormat(
+  body: Record<string, unknown>,
+  credentials: unknown = null,
+  provider: unknown = null,
+  model: unknown = null
+): Record<string, unknown> {
   const bodyModel = toRecord(body).model;
   const requestedModel =
     typeof bodyModel === "string" && bodyModel.trim().length > 0
@@ -13,5 +19,21 @@ export function convertResponsesApiFormat(body, credentials = null, provider = n
         ? bodyModel
         : `${provider}/${bodyModel}`
       : provider;
-  return openaiResponsesToOpenAIRequest(requestedModel, body, null, credentials);
+  const credentialRecord =
+    credentials && typeof credentials === "object" && !Array.isArray(credentials)
+      ? (credentials as Record<string, unknown>)
+      : {};
+  const translationCredentials = shouldPreserveResponsesReasoningContent(provider, model)
+    ? { ...credentialRecord, _preserveReasoningContent: true }
+    : credentials;
+  const converted = openaiResponsesToOpenAIRequest(
+    requestedModel,
+    body,
+    null,
+    translationCredentials
+  );
+  if (!converted || typeof converted !== "object" || Array.isArray(converted)) {
+    throw new TypeError("Responses request conversion must produce an object");
+  }
+  return converted as Record<string, unknown>;
 }

--- a/open-sse/translator/helpers/responsesApiHelper.ts
+++ b/open-sse/translator/helpers/responsesApiHelper.ts
@@ -2,7 +2,7 @@
  * Convert OpenAI Responses API format to standard chat completions format.
  * Delegates to the canonical translator to avoid logic duplication.
  */
-import { shouldPreserveResponsesReasoningContent } from "../../utils/reasoningContentInjector.ts";
+import { requiresAuthenticReasoningContent } from "../../utils/reasoningContentInjector.ts";
 import { openaiResponsesToOpenAIRequest } from "../request/openai-responses.ts";
 import { toRecord } from "../request/openai-responses/helpers.ts";
 
@@ -23,7 +23,7 @@ export function convertResponsesApiFormat(
     credentials && typeof credentials === "object" && !Array.isArray(credentials)
       ? (credentials as Record<string, unknown>)
       : {};
-  const translationCredentials = shouldPreserveResponsesReasoningContent(provider, model)
+  const translationCredentials = requiresAuthenticReasoningContent(provider, model)
     ? { ...credentialRecord, _preserveReasoningContent: true }
     : credentials;
   const converted = openaiResponsesToOpenAIRequest(

--- a/open-sse/translator/helpers/responsesApiHelper.ts
+++ b/open-sse/translator/helpers/responsesApiHelper.ts
@@ -2,7 +2,7 @@
  * Convert OpenAI Responses API format to standard chat completions format.
  * Delegates to the canonical translator to avoid logic duplication.
  */
-import { requiresAuthenticReasoningContent } from "../../utils/reasoningContentInjector.ts";
+import { requiresReasoningReplay } from "../../services/reasoningCache.ts";
 import { openaiResponsesToOpenAIRequest } from "../request/openai-responses.ts";
 import { toRecord } from "../request/openai-responses/helpers.ts";
 
@@ -23,7 +23,11 @@ export function convertResponsesApiFormat(
     credentials && typeof credentials === "object" && !Array.isArray(credentials)
       ? (credentials as Record<string, unknown>)
       : {};
-  const translationCredentials = requiresAuthenticReasoningContent(provider, model)
+  const translationCredentials = requiresReasoningReplay({
+    provider: String(provider ?? ""),
+    model: String(model ?? ""),
+    allowLegacyFallback: false,
+  })
     ? { ...credentialRecord, _preserveReasoningContent: true }
     : credentials;
   const converted = openaiResponsesToOpenAIRequest(

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -13,7 +13,10 @@ import {
   providerHonorsOpenAIFormatCacheControl,
   resolveConnectionCacheOverride,
 } from "../utils/cacheControlPolicy.ts";
-import { requiresAuthenticReasoningContent } from "../utils/reasoningContentInjector.ts";
+import {
+  requiresAuthenticReasoningContent,
+  shouldPreserveResponsesReasoningContent,
+} from "../utils/reasoningContentInjector.ts";
 import { isInternalReasoningPlaceholder } from "../utils/reasoningPlaceholder.ts";
 import {
   coerceToolSchemas,
@@ -233,6 +236,17 @@ export function translateRequest(
   const connectionCacheOverride = resolveConnectionCacheOverride(
     (credentials as { providerSpecificData?: unknown } | null)?.providerSpecificData
   );
+  const normalizedProvider = String(provider ?? "");
+  const normalizedModel = String(model ?? "");
+  const isKimiCoding =
+    normalizedProvider === "kimi-coding" || normalizedProvider === "kimi-coding-apikey";
+  const requiresAuthenticReasoning = requiresAuthenticReasoningContent(
+    normalizedProvider,
+    normalizedModel
+  );
+  const preserveResponsesReasoning =
+    sourceFormat === FORMATS.OPENAI_RESPONSES &&
+    shouldPreserveResponsesReasoningContent(normalizedProvider, normalizedModel);
 
   // Phase 2: Apply thinking budget control before normalization
   result = applyThinkingBudget(result);
@@ -318,12 +332,16 @@ export function translateRequest(
             options?.preserveCacheControl === true &&
             providerHonorsOpenAIFormatCacheControl(provider, connectionCacheOverride);
           const step1Credentials =
-            options?.copilotClient || hasTargetHint || preserveCacheControl
+            options?.copilotClient ||
+            hasTargetHint ||
+            preserveCacheControl ||
+            preserveResponsesReasoning
               ? {
                   ...(credentials && typeof credentials === "object" ? credentials : {}),
                   ...(options?.copilotClient ? { _copilotClient: true } : {}),
                   ...(hasTargetHint ? { _targetFormat: targetFormat } : {}),
                   ...(preserveCacheControl ? { _preserveCacheControl: true } : {}),
+                  ...(preserveResponsesReasoning ? { _preserveReasoningContent: true } : {}),
                 }
               : credentials;
           result = toOpenAI(model, result, stream, step1Credentials);
@@ -361,14 +379,6 @@ export function translateRequest(
   // Resolve reasoning-replay status up-front: it gates both the reasoning_content
   // strip in filterToOpenAIFormat below (#4849 must NOT strip client reasoning for
   // replay providers) and the cache re-injection further down.
-  const normalizedProvider = String(provider ?? "");
-  const normalizedModel = String(model ?? "");
-  const isKimiCoding =
-    normalizedProvider === "kimi-coding" || normalizedProvider === "kimi-coding-apikey";
-  const requiresAuthenticReasoning = requiresAuthenticReasoningContent(
-    normalizedProvider,
-    normalizedModel
-  );
   const resolvedCapabilities = getResolvedModelCapabilities({
     provider: normalizedProvider,
     model: normalizedModel,

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -13,10 +13,7 @@ import {
   providerHonorsOpenAIFormatCacheControl,
   resolveConnectionCacheOverride,
 } from "../utils/cacheControlPolicy.ts";
-import {
-  requiresAuthenticReasoningContent,
-  shouldPreserveResponsesReasoningContent,
-} from "../utils/reasoningContentInjector.ts";
+import { requiresAuthenticReasoningContent } from "../utils/reasoningContentInjector.ts";
 import { isInternalReasoningPlaceholder } from "../utils/reasoningPlaceholder.ts";
 import {
   coerceToolSchemas,
@@ -245,8 +242,7 @@ export function translateRequest(
     normalizedModel
   );
   const preserveResponsesReasoning =
-    sourceFormat === FORMATS.OPENAI_RESPONSES &&
-    shouldPreserveResponsesReasoningContent(normalizedProvider, normalizedModel);
+    sourceFormat === FORMATS.OPENAI_RESPONSES && requiresAuthenticReasoning;
 
   // Phase 2: Apply thinking budget control before normalization
   result = applyThinkingBudget(result);

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -13,7 +13,6 @@ import {
   providerHonorsOpenAIFormatCacheControl,
   resolveConnectionCacheOverride,
 } from "../utils/cacheControlPolicy.ts";
-import { requiresAuthenticReasoningContent } from "../utils/reasoningContentInjector.ts";
 import { isInternalReasoningPlaceholder } from "../utils/reasoningPlaceholder.ts";
 import {
   coerceToolSchemas,
@@ -162,7 +161,11 @@ function isReasoningOnlyReplayTarget(provider: unknown, model: unknown): boolean
     /(^|\/)deepseek/i.test(normalizedModel) ||
     normalizedProvider === "xiaomi-mimo" ||
     /(^|\/)mimo/i.test(normalizedModel) ||
-    requiresAuthenticReasoningContent(normalizedProvider, normalizedModel)
+    requiresReasoningReplay({
+      provider: normalizedProvider,
+      model: normalizedModel,
+      allowLegacyFallback: false,
+    })
   );
 }
 
@@ -237,12 +240,13 @@ export function translateRequest(
   const normalizedModel = String(model ?? "");
   const isKimiCoding =
     normalizedProvider === "kimi-coding" || normalizedProvider === "kimi-coding-apikey";
-  const requiresAuthenticReasoning = requiresAuthenticReasoningContent(
-    normalizedProvider,
-    normalizedModel
-  );
+  const requiresExplicitReasoningReplay = requiresReasoningReplay({
+    provider: normalizedProvider,
+    model: normalizedModel,
+    allowLegacyFallback: false,
+  });
   const preserveResponsesReasoning =
-    sourceFormat === FORMATS.OPENAI_RESPONSES && requiresAuthenticReasoning;
+    sourceFormat === FORMATS.OPENAI_RESPONSES && requiresExplicitReasoningReplay;
 
   // Phase 2: Apply thinking budget control before normalization
   result = applyThinkingBudget(result);
@@ -379,18 +383,16 @@ export function translateRequest(
     provider: normalizedProvider,
     model: normalizedModel,
   });
-  const isReasoner =
-    requiresAuthenticReasoning ||
-    requiresReasoningReplay({
+  const isReasoner = requiresReasoningReplay({
+    provider: normalizedProvider,
+    model: normalizedModel,
+    thinkingEnabled: hasThinkingConfig(result),
+    supportsReasoning: supportsReasoning({
       provider: normalizedProvider,
       model: normalizedModel,
-      thinkingEnabled: hasThinkingConfig(result),
-      supportsReasoning: supportsReasoning({
-        provider: normalizedProvider,
-        model: normalizedModel,
-      }),
-      interleavedField: resolvedCapabilities?.interleavedField ?? null,
-    });
+    }),
+    interleavedField: resolvedCapabilities?.interleavedField ?? null,
+  });
 
   // Always normalize to clean OpenAI format when target is OpenAI
   // This handles hybrid requests (e.g., OpenAI messages + Claude tools)
@@ -461,7 +463,7 @@ export function translateRequest(
 
   if (
     targetFormat === FORMATS.OPENAI &&
-    !requiresAuthenticReasoning &&
+    !requiresExplicitReasoningReplay &&
     result.messages &&
     Array.isArray(result.messages)
   ) {
@@ -579,7 +581,7 @@ export function translateRequest(
           }
           continue;
         }
-        if (requiresAuthenticReasoning) continue;
+        if (requiresExplicitReasoningReplay) continue;
         msg.content.splice(firstToolUseIdx, 0, {
           type: "thinking",
           thinking: NON_ANTHROPIC_THINKING_PLACEHOLDER,
@@ -616,7 +618,7 @@ export function translateRequest(
       // Native Moonshot K3/K2.7 accepts only the real prior reasoning. If it
       // was not supplied and the cache missed, leave it absent so upstream can
       // enforce its contract instead of corrupting history with a placeholder.
-      if (requiresAuthenticReasoning) {
+      if (requiresExplicitReasoningReplay) {
         if (msg.reasoning_content === "") delete msg.reasoning_content;
         continue;
       }
@@ -629,7 +631,7 @@ export function translateRequest(
       // deepseek-v4-flash accepts an ABSENT reasoning_content field (the 400 is
       // specific to empty-string, and even that is endpoint-dependent). Omit
       // the field instead; providers that genuinely enforce the contract
-      // (kimi-coding, moonshot authentic-reasoning) have their own paths above.
+      // (kimi-coding, moonshot reasoning replay) have their own paths above.
       if ((hasToolCalls || shouldReplayReasoningOnly) && !msg.reasoning_content) {
         if (requiresReasoningContentPresence(normalizedProvider, normalizedModel)) {
           msg.reasoning_content = NON_ANTHROPIC_THINKING_PLACEHOLDER;

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -379,13 +379,18 @@ export function translateRequest(
     provider: normalizedProvider,
     model: normalizedModel,
   });
-  const isReasoner = requiresReasoningReplay({
-    provider: normalizedProvider,
-    model: normalizedModel,
-    thinkingEnabled: hasThinkingConfig(result),
-    supportsReasoning: supportsReasoning({ provider: normalizedProvider, model: normalizedModel }),
-    interleavedField: resolvedCapabilities?.interleavedField ?? null,
-  });
+  const isReasoner =
+    requiresAuthenticReasoning ||
+    requiresReasoningReplay({
+      provider: normalizedProvider,
+      model: normalizedModel,
+      thinkingEnabled: hasThinkingConfig(result),
+      supportsReasoning: supportsReasoning({
+        provider: normalizedProvider,
+        model: normalizedModel,
+      }),
+      interleavedField: resolvedCapabilities?.interleavedField ?? null,
+    });
 
   // Always normalize to clean OpenAI format when target is OpenAI
   // This handles hybrid requests (e.g., OpenAI messages + Claude tools)

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -481,7 +481,7 @@ export function translateRequest(
   // isReasoner / normalizedProvider / normalizedModel / resolvedCapabilities were
   // resolved up-front (before the OpenAI-format filter) so the #4849 reasoning strip
   // could honor reasoning-replay providers.
-  if (isReasoner && !isKimiCoding && result.messages && Array.isArray(result.messages)) {
+  if (isReasoner && result.messages && Array.isArray(result.messages)) {
     const canReplayReasoningOnly = isReasoningOnlyReplayTarget(normalizedProvider, normalizedModel);
 
     for (const [messageIndex, msg] of result.messages.entries()) {
@@ -530,29 +530,51 @@ export function translateRequest(
         // Has tool_use blocks but no thinking block yet.
         // Reasoning models (Kimi K2, etc.) require a thinking block before tool_use
         // on multi-turn or they regenerate the same tool call infinitely.
-        const hasThinkingBlock = msg.content.some(
+        const thinkingBlock = msg.content.find(
           (b) => b?.type === "thinking" || b?.type === "redacted_thinking"
         );
-        if (hasThinkingBlock) continue;
+        const hasNonEmptyClientThinking =
+          thinkingBlock?.type === "thinking" &&
+          typeof thinkingBlock.thinking === "string" &&
+          thinkingBlock.thinking.trim().length > 0;
+        if (thinkingBlock && (!isKimiCoding || hasNonEmptyClientThinking)) continue;
 
         const toolUseBlocks = msg.content.filter((b) => b?.type === "tool_use");
         const firstToolUseId = toolUseBlocks[0]?.id;
         const firstToolUseIdx = msg.content.findIndex((b) => b?.type === "tool_use");
 
-        // Try reasoning cache first
+        // Client reasoning wins above. Otherwise try authentic replay before
+        // retaining Kimi Code's empty protocol marker as the final fallback.
         if (firstToolUseId) {
           const cached = lookupReasoning(firstToolUseId);
           if (cached) {
-            msg.content.splice(firstToolUseIdx, 0, {
-              type: "thinking",
-              thinking: cached,
-            });
+            if (thinkingBlock) {
+              thinkingBlock.type = "thinking";
+              thinkingBlock.thinking = cached;
+              delete thinkingBlock.data;
+              delete thinkingBlock.signature;
+            } else {
+              msg.content.splice(firstToolUseIdx, 0, {
+                type: "thinking",
+                thinking: cached,
+              });
+            }
             recordReplay();
             continue;
           }
         }
+        if (isKimiCoding) {
+          if (thinkingBlock) {
+            thinkingBlock.type = "thinking";
+            thinkingBlock.thinking = "";
+            delete thinkingBlock.data;
+            delete thinkingBlock.signature;
+          } else {
+            msg.content.splice(firstToolUseIdx, 0, { type: "thinking", thinking: "" });
+          }
+          continue;
+        }
         if (requiresAuthenticReasoning) continue;
-        // Fallback: inject placeholder (must be non-empty for kimi-coding)
         msg.content.splice(firstToolUseIdx, 0, {
           type: "thinking",
           thinking: NON_ANTHROPIC_THINKING_PLACEHOLDER,

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -73,6 +73,19 @@ function toolOutputContentToString(output: unknown): string {
   return parts.join("\n");
 }
 
+function getReasoningSummaryText(item: JsonRecord): string {
+  if (!Array.isArray(item.summary)) return "";
+  return item.summary
+    .map((part) => toString(toRecord(part).text))
+    .filter((text) => text.length > 0)
+    .join("\n\n");
+}
+
+function appendReasoningContent(current: unknown, next: string): string {
+  const existing = typeof current === "string" ? current : "";
+  return existing ? `${existing}\n\n${next}` : next;
+}
+
 /**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
  */
@@ -83,13 +96,13 @@ export function openaiResponsesToOpenAIRequest(
   credentials: unknown
 ): unknown {
   void stream;
-  void credentials;
   const collapseToPlainString = requiresPlainStringContent(extractProviderHint(model));
 
   const root = toRecord(body);
   if (root.input === undefined) return body;
   const credentialRecord = toRecord(credentials);
   const storeEnabled = isOpenAIResponsesStoreEnabled(credentialRecord.providerSpecificData);
+  const preserveReasoningContent = credentialRecord._preserveReasoningContent === true;
   const rawInputItems = normalizeResponsesInputForChat(root.input);
 
   // Tools may be declared at the Responses top level or in one or more
@@ -204,6 +217,7 @@ export function openaiResponsesToOpenAIRequest(
   // Group items by conversation turn
   let currentAssistantMsg: JsonRecord | null = null;
   let pendingToolResults: JsonRecord[] = [];
+  let pendingReasoningContent = "";
 
   // Upstream providers reject messages:[] with "400: at least one message is required".
   // When the client sends input:[] (empty), inject a placeholder user message — mirrors
@@ -220,10 +234,19 @@ export function openaiResponsesToOpenAIRequest(
     const itemType = toString(item.type) || (item.role ? "message" : "");
 
     if (itemType === "message") {
+      const role = toString(item.role);
       // Flush pending assistant message with tool calls
       if (currentAssistantMsg) {
         messages.push(currentAssistantMsg);
         currentAssistantMsg = null;
+      }
+      if (role !== "assistant" && pendingReasoningContent) {
+        messages.push({
+          role: "assistant",
+          content: null,
+          reasoning_content: pendingReasoningContent,
+        });
+        pendingReasoningContent = "";
       }
 
       // Flush pending tool results
@@ -269,7 +292,12 @@ export function openaiResponsesToOpenAIRequest(
           })
         : item.content;
 
-      messages.push({ role: toString(item.role), content });
+      const message: JsonRecord = { role, content };
+      if (role === "assistant" && pendingReasoningContent) {
+        message.reasoning_content = pendingReasoningContent;
+        pendingReasoningContent = "";
+      }
+      messages.push(message);
       continue;
     }
 
@@ -294,6 +322,10 @@ export function openaiResponsesToOpenAIRequest(
           content: null,
           tool_calls: [],
         };
+        if (pendingReasoningContent) {
+          currentAssistantMsg.reasoning_content = pendingReasoningContent;
+          pendingReasoningContent = "";
+        }
       }
 
       const toolCalls = Array.isArray(currentAssistantMsg.tool_calls)
@@ -353,6 +385,10 @@ export function openaiResponsesToOpenAIRequest(
           content: null,
           tool_calls: [],
         };
+        if (pendingReasoningContent) {
+          currentAssistantMsg.reasoning_content = pendingReasoningContent;
+          pendingReasoningContent = "";
+        }
       }
       const toolCalls = Array.isArray(currentAssistantMsg.tool_calls)
         ? currentAssistantMsg.tool_calls
@@ -401,7 +437,21 @@ export function openaiResponsesToOpenAIRequest(
     }
 
     if (itemType === "reasoning") {
-      // Skip reasoning items - they are display-only metadata
+      // Responses reasoning summaries are normally display metadata. Preserve them only
+      // when the routed upstream explicitly requires prior reasoning to continue a turn.
+      if (preserveReasoningContent) {
+        const reasoning = getReasoningSummaryText(item);
+        if (reasoning) {
+          if (currentAssistantMsg) {
+            currentAssistantMsg.reasoning_content = appendReasoningContent(
+              currentAssistantMsg.reasoning_content,
+              reasoning
+            );
+          } else {
+            pendingReasoningContent = appendReasoningContent(pendingReasoningContent, reasoning);
+          }
+        }
+      }
       continue;
     }
 
@@ -429,6 +479,13 @@ export function openaiResponsesToOpenAIRequest(
   // Flush remainder
   if (currentAssistantMsg) {
     messages.push(currentAssistantMsg);
+  }
+  if (pendingReasoningContent) {
+    messages.push({
+      role: "assistant",
+      content: null,
+      reasoning_content: pendingReasoningContent,
+    });
   }
   if (pendingToolResults.length > 0) {
     for (const toolResult of pendingToolResults) {

--- a/open-sse/utils/reasoningContentInjector.ts
+++ b/open-sse/utils/reasoningContentInjector.ts
@@ -30,35 +30,24 @@ const THINKING_MODEL_PATTERNS: RegExp[] = [
   /\bmimo\b/i, // xiaomi-tokenplan mimo family (e.g. xiaomi-tokenplan/mimo-v2.5-pro)
 ];
 
-const AUTHENTIC_REASONING_MODEL_PATTERN = /(?:^|\/)kimi-k(?:3|2\.7-code)(?:$|-)/i;
+const K3_AUTHENTIC_REASONING_PATTERN = /(?:^|\/)(?:kimi-)?k3(?:$|-)/i;
+const NATIVE_K27_AUTHENTIC_REASONING_PATTERN = /(?:^|\/)kimi-k2\.7-code(?:$|-)/i;
 
 /**
- * Native Moonshot K3/K2.7 replay must use the original reasoning content.
- * A fabricated placeholder changes preserved-thinking history and is not a
- * valid substitute when the client and reasoning cache both lack the field.
+ * K3 requires authentic reasoning regardless of which provider serves it.
+ * Native Moonshot K2.7 retains the same preserved-thinking contract. Empty
+ * protocol markers remain valid only after client content and replay miss.
  */
 export function requiresAuthenticReasoningContent(provider: unknown, model: unknown): boolean {
+  const normalizedModel = String(model ?? "").trim();
+  if (K3_AUTHENTIC_REASONING_PATTERN.test(normalizedModel)) return true;
+
   const normalizedProvider = String(provider ?? "")
     .trim()
     .toLowerCase();
-  const normalizedModel = String(model ?? "").trim();
   return (
     (normalizedProvider === "moonshot" || normalizedProvider === "kimi") &&
-    AUTHENTIC_REASONING_MODEL_PATTERN.test(normalizedModel)
-  );
-}
-
-export function shouldPreserveResponsesReasoningContent(
-  provider: unknown,
-  model: unknown
-): boolean {
-  const normalizedProvider = String(provider ?? "")
-    .trim()
-    .toLowerCase();
-  return (
-    normalizedProvider === "kimi-coding" ||
-    normalizedProvider === "kimi-coding-apikey" ||
-    requiresAuthenticReasoningContent(normalizedProvider, model)
+    NATIVE_K27_AUTHENTIC_REASONING_PATTERN.test(normalizedModel)
   );
 }
 

--- a/open-sse/utils/reasoningContentInjector.ts
+++ b/open-sse/utils/reasoningContentInjector.ts
@@ -13,6 +13,8 @@
  * that proxy to thinking-mode models.
  */
 
+import { requiresReasoningReplay } from "../services/reasoningCache.ts";
+
 const PLACEHOLDER = " ";
 
 type JsonRecord = Record<string, unknown>;
@@ -30,27 +32,6 @@ const THINKING_MODEL_PATTERNS: RegExp[] = [
   /\bmimo\b/i, // xiaomi-tokenplan mimo family (e.g. xiaomi-tokenplan/mimo-v2.5-pro)
 ];
 
-const K3_AUTHENTIC_REASONING_PATTERN = /(?:^|\/)(?:kimi-)?k3(?:$|-)/i;
-const NATIVE_K27_AUTHENTIC_REASONING_PATTERN = /(?:^|\/)kimi-k2\.7-code(?:$|-)/i;
-
-/**
- * K3 requires authentic reasoning regardless of which provider serves it.
- * Native Moonshot K2.7 retains the same preserved-thinking contract. Empty
- * protocol markers remain valid only after client content and replay miss.
- */
-export function requiresAuthenticReasoningContent(provider: unknown, model: unknown): boolean {
-  const normalizedModel = String(model ?? "").trim();
-  if (K3_AUTHENTIC_REASONING_PATTERN.test(normalizedModel)) return true;
-
-  const normalizedProvider = String(provider ?? "")
-    .trim()
-    .toLowerCase();
-  return (
-    (normalizedProvider === "moonshot" || normalizedProvider === "kimi") &&
-    NATIVE_K27_AUTHENTIC_REASONING_PATTERN.test(normalizedModel)
-  );
-}
-
 export function isThinkingMessageModel(model: string | undefined | null): boolean {
   if (!model || typeof model !== "string") return false;
   return THINKING_MODEL_PATTERNS.some((re) => re.test(model));
@@ -65,7 +46,11 @@ export function shouldInjectReasoningContentPlaceholder(
     .toLowerCase();
   return (
     (normalizedProvider === "moonshot" || normalizedProvider === "kimi") &&
-    !requiresAuthenticReasoningContent(normalizedProvider, model) &&
+    !requiresReasoningReplay({
+      provider: normalizedProvider,
+      model: String(model ?? ""),
+      allowLegacyFallback: false,
+    }) &&
     isThinkingMessageModel(model)
   );
 }

--- a/open-sse/utils/reasoningContentInjector.ts
+++ b/open-sse/utils/reasoningContentInjector.ts
@@ -48,6 +48,20 @@ export function requiresAuthenticReasoningContent(provider: unknown, model: unkn
   );
 }
 
+export function shouldPreserveResponsesReasoningContent(
+  provider: unknown,
+  model: unknown
+): boolean {
+  const normalizedProvider = String(provider ?? "")
+    .trim()
+    .toLowerCase();
+  return (
+    normalizedProvider === "kimi-coding" ||
+    normalizedProvider === "kimi-coding-apikey" ||
+    requiresAuthenticReasoningContent(normalizedProvider, model)
+  );
+}
+
 export function isThinkingMessageModel(model: string | undefined | null): boolean {
   if (!model || typeof model !== "string") return false;
   return THINKING_MODEL_PATTERNS.some((re) => re.test(model));

--- a/tests/unit/kimi-coding-translator.test.ts
+++ b/tests/unit/kimi-coding-translator.test.ts
@@ -79,3 +79,165 @@ test("Kimi Anthropic preserves an explicit empty thinking block", () => {
     thinking: "",
   });
 });
+
+test("Responses history preserves Kimi reasoning before a tool call", () => {
+  const translated = translateRequest(
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.CLAUDE,
+    "k3-256k",
+    {
+      model: "k3-256k",
+      max_output_tokens: 4096,
+      reasoning: { effort: "high" },
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "Call ping, then answer DONE." }],
+        },
+        {
+          id: "rs_1",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "I should call ping first." }],
+        },
+        {
+          id: "fc_1",
+          type: "function_call",
+          call_id: "call_1",
+          name: "ping",
+          arguments: "{}",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "pong",
+        },
+      ],
+    },
+    false,
+    {},
+    "kimi-coding-apikey"
+  ) as KimiClaudeRequest;
+
+  assert.deepEqual(translated.messages[1].content[0], {
+    type: "thinking",
+    thinking: "I should call ping first.",
+  });
+  assert.deepEqual(translated.messages[1].content[1], {
+    type: "tool_use",
+    id: "call_1",
+    name: "proxy_ping",
+    input: {},
+  });
+});
+
+test("Responses history preserves Kimi reasoning on completed assistant turns", () => {
+  const translated = translateRequest(
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.CLAUDE,
+    "k3-256k",
+    {
+      model: "k3-256k",
+      max_output_tokens: 4096,
+      reasoning: { effort: "high" },
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "Remember cobalt-orchid." }],
+        },
+        {
+          id: "rs_1",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "I should retain the nonce." }],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Noted." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "What was it?" }],
+        },
+      ],
+    },
+    false,
+    {},
+    "kimi-coding-apikey"
+  ) as KimiClaudeRequest;
+
+  assert.deepEqual(translated.messages[1].content, [
+    { type: "thinking", thinking: "I should retain the nonce." },
+    { type: "text", text: "Noted." },
+  ]);
+});
+
+test("Responses history preserves Kimi reasoning before a custom tool call", () => {
+  const translated = translateRequest(
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.CLAUDE,
+    "k3-256k",
+    {
+      model: "k3-256k",
+      reasoning: { effort: "high" },
+      input: [
+        {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "I should apply the patch." }],
+        },
+        {
+          type: "custom_tool_call",
+          call_id: "call_1",
+          name: "apply_patch",
+          input: "*** Begin Patch",
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "call_1",
+          output: "Done",
+        },
+      ],
+    },
+    false,
+    {},
+    "kimi-coding-apikey"
+  ) as KimiClaudeRequest;
+
+  assert.deepEqual(translated.messages[0].content[0], {
+    type: "thinking",
+    thinking: "I should apply the patch.",
+  });
+});
+
+test("Responses history does not carry reasoning across a user boundary", () => {
+  const translated = translateRequest(
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.CLAUDE,
+    "k3-256k",
+    {
+      model: "k3-256k",
+      reasoning: { effort: "high" },
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "First turn" }],
+        },
+        {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Prior turn reasoning." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "Next turn" }],
+        },
+      ],
+    },
+    false,
+    {},
+    "kimi-coding-apikey"
+  ) as KimiClaudeRequest;
+
+  assert.deepEqual(translated.messages[1].content, [
+    { type: "thinking", thinking: "Prior turn reasoning." },
+  ]);
+  assert.deepEqual(translated.messages[2].content, [{ type: "text", text: "Next turn" }]);
+});

--- a/tests/unit/moonshot-k3.test.ts
+++ b/tests/unit/moonshot-k3.test.ts
@@ -24,12 +24,7 @@ import {
 import { translateRequest } from "../../open-sse/translator/index.ts";
 import { getResolvedModelCapabilities } from "../../src/lib/modelCapabilities.ts";
 
-const EXPECTED_MODELS = [
-  "kimi-k3",
-  "kimi-k2.7-code",
-  "kimi-k2.7-code-highspeed",
-  "kimi-k2.6",
-];
+const EXPECTED_MODELS = ["kimi-k3", "kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6"];
 
 function registryModelIds(provider: string): string[] {
   const entry = getRegistryEntry(provider);
@@ -188,6 +183,53 @@ test("Moonshot K3 participates in reasoning replay", () => {
     }),
     true
   );
+});
+
+test("Responses history preserves authentic reasoning for native Moonshot K3", () => {
+  for (const provider of ["moonshot", "kimi"]) {
+    const output = translateRequest(
+      "openai-responses",
+      "openai",
+      "kimi-k3",
+      {
+        model: "kimi-k3",
+        reasoning: { effort: "max" },
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Call search." }],
+          },
+          {
+            type: "reasoning",
+            summary: [{ type: "summary_text", text: "I should search first." }],
+          },
+          {
+            type: "function_call",
+            call_id: "call_1",
+            name: "search",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_1",
+            output: "found",
+          },
+        ],
+      },
+      false,
+      null,
+      provider
+    ) as { messages: Array<Record<string, unknown>> };
+
+    assert.equal(output.messages[1].reasoning_content, "I should search first.");
+    assert.deepEqual(output.messages[1].tool_calls, [
+      {
+        id: "call_1",
+        type: "function",
+        function: { name: "search", arguments: "{}" },
+      },
+    ]);
+  }
 });
 
 test("video_url is preserved only for Moonshot's OpenAI-compatible extension", () => {

--- a/tests/unit/responses-handler.test.ts
+++ b/tests/unit/responses-handler.test.ts
@@ -225,6 +225,44 @@ test("handleResponsesCore converts Responses API input, instructions, tools, met
   assert.equal("store" in call.body, false);
 });
 
+test("handleResponsesCore preserves Kimi K3 reasoning through provider translation", async () => {
+  const body = {
+    model: "k3-256k",
+    reasoning: { effort: "high" },
+    input: [
+      { role: "user", content: [{ type: "input_text", text: "Call search." }] },
+      {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "I should search first." }],
+      },
+      {
+        type: "function_call",
+        call_id: "call_1",
+        name: "search",
+        arguments: "{}",
+      },
+      { type: "function_call_output", call_id: "call_1", output: "found" },
+    ],
+  };
+
+  const coding = await invokeResponsesCore({
+    body,
+    provider: "kimi-coding-apikey",
+    model: "k3-256k",
+  });
+  assert.deepEqual(coding.call.body.messages?.[1]?.content?.[0], {
+    type: "thinking",
+    thinking: "I should search first.",
+  });
+
+  const native = await invokeResponsesCore({
+    body: { ...body, model: "kimi-k3", reasoning: { effort: "max" } },
+    provider: "moonshot",
+    model: "kimi-k3",
+  });
+  assert.equal(native.call.body.messages?.[1]?.reasoning_content, "I should search first.");
+});
+
 test("handleResponsesCore strips previous_response_id by default and handles empty input arrays", async () => {
   const { call, result } = await invokeResponsesCore({
     body: {

--- a/tests/unit/responses-translation-fixes.test.ts
+++ b/tests/unit/responses-translation-fixes.test.ts
@@ -57,9 +57,13 @@ test("production Responses conversion preserves Kimi K3 reasoning history", () =
   };
 
   for (const { provider, model } of [
+    { provider: "kimi-coding", model: "k3" },
     { provider: "kimi-coding-apikey", model: "k3-256k" },
     { provider: "moonshot", model: "kimi-k3" },
     { provider: "kimi", model: "kimi-k3" },
+    { provider: "some-other", model: "k3" },
+    { provider: "some-other", model: "k3-256k" },
+    { provider: "some-other", model: "kimi-k3" },
   ]) {
     const converted = convertResponsesApiFormat(body, {}, provider, model) as {
       messages: Array<Record<string, unknown>>;
@@ -67,10 +71,12 @@ test("production Responses conversion preserves Kimi K3 reasoning history", () =
     assert.equal(converted.messages[1].reasoning_content, "I should search first.");
   }
 
-  const generic = convertResponsesApiFormat(body, {}, "openai", "gpt-5") as {
-    messages: Array<Record<string, unknown>>;
-  };
-  assert.equal(Object.hasOwn(generic.messages[1], "reasoning_content"), false);
+  for (const provider of ["kimi-coding", "kimi-coding-apikey"]) {
+    const generic = convertResponsesApiFormat(body, {}, provider, "kimi-k2.6") as {
+      messages: Array<Record<string, unknown>>;
+    };
+    assert.equal(Object.hasOwn(generic.messages[1], "reasoning_content"), false, provider);
+  }
 });
 
 test("Responses→Chat: input_image converted to image_url with detail", () => {

--- a/tests/unit/responses-translation-fixes.test.ts
+++ b/tests/unit/responses-translation-fixes.test.ts
@@ -37,6 +37,42 @@ test("convertResponsesApiFormat skips function_call items with empty names", () 
   assert.equal(assistantMsgs.length, 0);
 });
 
+test("production Responses conversion preserves Kimi K3 reasoning history", () => {
+  const body = {
+    model: "kimi-k3",
+    input: [
+      { role: "user", content: [{ type: "input_text", text: "Call search." }] },
+      {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "I should search first." }],
+      },
+      {
+        type: "function_call",
+        call_id: "call_1",
+        name: "search",
+        arguments: "{}",
+      },
+      { type: "function_call_output", call_id: "call_1", output: "found" },
+    ],
+  };
+
+  for (const { provider, model } of [
+    { provider: "kimi-coding-apikey", model: "k3-256k" },
+    { provider: "moonshot", model: "kimi-k3" },
+    { provider: "kimi", model: "kimi-k3" },
+  ]) {
+    const converted = convertResponsesApiFormat(body, {}, provider, model) as {
+      messages: Array<Record<string, unknown>>;
+    };
+    assert.equal(converted.messages[1].reasoning_content, "I should search first.");
+  }
+
+  const generic = convertResponsesApiFormat(body, {}, "openai", "gpt-5") as {
+    messages: Array<Record<string, unknown>>;
+  };
+  assert.equal(Object.hasOwn(generic.messages[1], "reasoning_content"), false);
+});
+
 test("Responses→Chat: input_image converted to image_url with detail", () => {
   const body = {
     model: "gpt-4",

--- a/tests/unit/responses-translation-fixes.test.ts
+++ b/tests/unit/responses-translation-fixes.test.ts
@@ -1,3 +1,4 @@
+import { translateRequest } from "../../open-sse/translator/index.ts";
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -76,6 +77,39 @@ test("production Responses conversion preserves Kimi K3 reasoning history", () =
       messages: Array<Record<string, unknown>>;
     };
     assert.equal(Object.hasOwn(generic.messages[1], "reasoning_content"), false, provider);
+  }
+});
+
+test("Responses translation keeps authentic K3 reasoning through OpenAI cleanup", () => {
+  const body = {
+    model: "k3",
+    input: [
+      { role: "user", content: [{ type: "input_text", text: "Call search." }] },
+      {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "I should search first." }],
+      },
+      {
+        type: "function_call",
+        call_id: "call_1",
+        name: "search",
+        arguments: "{}",
+      },
+    ],
+  };
+
+  for (const provider of ["kimi-web", "some-other"]) {
+    const translated = translateRequest(
+      "openai-responses",
+      "openai",
+      "k3",
+      body,
+      false,
+      {},
+      provider
+    ) as { messages: Array<Record<string, unknown>> };
+
+    assert.equal(translated.messages[1].reasoning_content, "I should search first.", provider);
   }
 });
 

--- a/tests/unit/service-reasoning-cache.test.ts
+++ b/tests/unit/service-reasoning-cache.test.ts
@@ -66,8 +66,8 @@ describe("reasoningCache helpers", () => {
     it("returns false for reasoning_details interleaved field", () => {
       assert.equal(
         mod.requiresReasoningReplay({
-          provider: "any",
-          model: "any",
+          provider: "moonshot",
+          model: "k3",
           interleavedField: "reasoning_details",
         }),
         false
@@ -116,6 +116,9 @@ describe("reasoningCache helpers", () => {
 
     it("detects native Kimi thinking model IDs without matching unrelated aliases", () => {
       for (const model of [
+        "k3",
+        "k3-256k",
+        "kimi-k3",
         "kimi-k2",
         "kimi-k2.6",
         "kimi-k2.6-thinking",
@@ -126,8 +129,22 @@ describe("reasoningCache helpers", () => {
         assert.equal(mod.requiresReasoningReplay({ provider: "some-other", model }), true, model);
       }
 
-      for (const model of ["k3", "moonshot-v1-8k", "kimi-latest"]) {
+      for (const model of ["moonshot-v1-8k", "kimi-latest"]) {
         assert.equal(mod.requiresReasoningReplay({ provider: "some-other", model }), false, model);
+      }
+    });
+
+    it("keeps K3 and native Moonshot K2.7 replay explicit", () => {
+      for (const model of ["k3", "k3-256k", "kimi-k3", "kimi-k2.7-code"]) {
+        assert.equal(
+          mod.requiresReasoningReplay({
+            provider: "moonshot",
+            model,
+            allowLegacyFallback: false,
+          }),
+          true,
+          model
+        );
       }
     });
 

--- a/tests/unit/translator-helper-branches.test.ts
+++ b/tests/unit/translator-helper-branches.test.ts
@@ -259,6 +259,14 @@ test("openaiHelper keeps unmatched tool choices and deletes empty tools arrays",
 test("claudeHelper validates content, ordering and request preparation branches", () => {
   assert.equal(claudeHelper.hasValidContent({ content: " hello " }), true);
   assert.equal(claudeHelper.hasValidContent({ content: [{ type: "tool_use", id: "call" }] }), true);
+  assert.equal(
+    claudeHelper.hasValidContent({ content: [{ type: "thinking", thinking: "reasoning" }] }),
+    true
+  );
+  assert.equal(
+    claudeHelper.hasValidContent({ content: [{ type: "redacted_thinking", data: "opaque" }] }),
+    true
+  );
   assert.equal(claudeHelper.hasValidContent({ content: [{ type: "text", text: "   " }] }), false);
 
   assert.deepEqual(claudeHelper.fixToolUseOrdering([{ role: "user", content: "single" }]), [
@@ -690,138 +698,131 @@ test("translateRequest does not replay reasoning-only messages for non-DeepSeek 
   clearReasoningCacheAll();
 });
 
-  test("translateRequest uses Kimi Coding's empty thinking marker instead of cached replay", () => {
-    clearReasoningCacheAll();
-    cacheReasoningByKey(
-      "toolu_kimi_claude",
-      "kimi-coding",
-      "kimi-for-coding",
-      "cached thinking for Kimi tool call"
-    );
+test("translateRequest uses Kimi Coding's empty thinking marker instead of cached replay", () => {
+  clearReasoningCacheAll();
+  cacheReasoningByKey(
+    "toolu_kimi_claude",
+    "kimi-coding",
+    "kimi-for-coding",
+    "cached thinking for Kimi tool call"
+  );
 
-    // Claude-format request: assistant has tool_use in content[] but NO thinking block
-    // This simulates the scenario that causes infinite loops
-    const result = translateRequest(
-      FORMATS.OPENAI,
-      FORMATS.CLAUDE,
-      "kimi-for-coding",
-      {
-        reasoning_effort: "high",
-        messages: [
-          { role: "user", content: "read the file" },
-          {
-            role: "assistant",
-            content: [
-              {
-                type: "tool_use",
-                id: "toolu_kimi_claude",
-                name: "read_file",
-                input: { path: "test.ts" },
-              },
-            ],
-          },
-          { role: "tool", tool_call_id: "toolu_kimi_claude", content: "file data" },
-        ],
-      },
-      false,
-      null,
-      "kimi-coding"
-    );
+  // Claude-format request: assistant has tool_use in content[] but NO thinking block
+  // This simulates the scenario that causes infinite loops
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "kimi-for-coding",
+    {
+      reasoning_effort: "high",
+      messages: [
+        { role: "user", content: "read the file" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_kimi_claude",
+              name: "read_file",
+              input: { path: "test.ts" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "toolu_kimi_claude", content: "file data" },
+      ],
+    },
+    false,
+    null,
+    "kimi-coding"
+  );
 
-    const assistantMsg = result.messages.find((m) => m.role === "assistant");
-    assert.ok(assistantMsg, "assistant message should exist");
-    assert.ok(Array.isArray(assistantMsg.content), "content should be array");
+  const assistantMsg = result.messages.find((m) => m.role === "assistant");
+  assert.ok(assistantMsg, "assistant message should exist");
+  assert.ok(Array.isArray(assistantMsg.content), "content should be array");
 
-    // Kimi Code CLI 0.26 sends an explicit empty thinking marker before tool_use.
-    const thinkingBlock = assistantMsg.content.find((b) => b?.type === "thinking");
-    assert.ok(thinkingBlock, "thinking block should be injected");
-    assert.equal(thinkingBlock.thinking, "");
+  // Kimi Code CLI 0.26 sends an explicit empty thinking marker before tool_use.
+  const thinkingBlock = assistantMsg.content.find((b) => b?.type === "thinking");
+  assert.ok(thinkingBlock, "thinking block should be injected");
+  assert.equal(thinkingBlock.thinking, "");
 
-    // Thinking block should appear before tool_use
-    const thinkingIdx = assistantMsg.content.indexOf(thinkingBlock);
-    const toolUseIdx = assistantMsg.content.findIndex((b) => b?.type === "tool_use");
-    assert.ok(thinkingIdx < toolUseIdx, "thinking block should be before tool_use");
+  // Thinking block should appear before tool_use
+  const thinkingIdx = assistantMsg.content.indexOf(thinkingBlock);
+  const toolUseIdx = assistantMsg.content.findIndex((b) => b?.type === "tool_use");
+  assert.ok(thinkingIdx < toolUseIdx, "thinking block should be before tool_use");
 
-    assert.equal(getReasoningCacheServiceStats().replays, 0);
-    clearReasoningCacheAll();
-  });
+  assert.equal(getReasoningCacheServiceStats().replays, 0);
+  clearReasoningCacheAll();
+});
 
-  test("translateRequest uses an empty Kimi Coding thinking marker on cache miss", () => {
-    clearReasoningCacheAll();
+test("translateRequest uses an empty Kimi Coding thinking marker on cache miss", () => {
+  clearReasoningCacheAll();
 
-    const result = translateRequest(
-      FORMATS.OPENAI,
-      FORMATS.CLAUDE,
-      "kimi-for-coding",
-      {
-        reasoning_effort: "high",
-        messages: [
-          { role: "user", content: "do it" },
-          {
-            role: "assistant",
-            content: [
-              { type: "tool_use", id: "toolu_miss", name: "bash", input: { command: "ls" } },
-            ],
-          },
-          { role: "tool", tool_call_id: "toolu_miss", content: "output" },
-        ],
-      },
-      false,
-      null,
-      "kimi-coding"
-    );
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "kimi-for-coding",
+    {
+      reasoning_effort: "high",
+      messages: [
+        { role: "user", content: "do it" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_miss", name: "bash", input: { command: "ls" } }],
+        },
+        { role: "tool", tool_call_id: "toolu_miss", content: "output" },
+      ],
+    },
+    false,
+    null,
+    "kimi-coding"
+  );
 
-    const assistantMsg = result.messages.find((m) => m.role === "assistant");
-    assert.ok(assistantMsg, "assistant message should exist");
+  const assistantMsg = result.messages.find((m) => m.role === "assistant");
+  assert.ok(assistantMsg, "assistant message should exist");
 
-    const thinkingBlock =
-      Array.isArray(assistantMsg.content) &&
-      assistantMsg.content.find((b) => b?.type === "thinking");
-    assert.ok(thinkingBlock, "thinking block should be injected on cache miss");
-    assert.equal(thinkingBlock.thinking, "");
+  const thinkingBlock =
+    Array.isArray(assistantMsg.content) && assistantMsg.content.find((b) => b?.type === "thinking");
+  assert.ok(thinkingBlock, "thinking block should be injected on cache miss");
+  assert.equal(thinkingBlock.thinking, "");
 
-    clearReasoningCacheAll();
-  });
+  clearReasoningCacheAll();
+});
 
-  test("translateRequest does NOT inject duplicate thinking for Claude-format messages with existing thinking block", () => {
-    clearReasoningCacheAll();
+test("translateRequest does NOT inject duplicate thinking for Claude-format messages with existing thinking block", () => {
+  clearReasoningCacheAll();
 
-    const result = translateRequest(
-      FORMATS.OPENAI,
-      FORMATS.CLAUDE,
-      "kimi-for-coding",
-      {
-        messages: [
-          { role: "user", content: "hi" },
-          {
-            role: "assistant",
-            content: [
-              { type: "thinking", thinking: "I already have this" },
-              { type: "tool_use", id: "toolu_existing", name: "read", input: {} },
-            ],
-          },
-          { role: "tool", tool_call_id: "toolu_existing", content: "data" },
-        ],
-      },
-      false,
-      null,
-      "kimi-coding"
-    );
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "kimi-for-coding",
+    {
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "I already have this" },
+            { type: "tool_use", id: "toolu_existing", name: "read", input: {} },
+          ],
+        },
+        { role: "tool", tool_call_id: "toolu_existing", content: "data" },
+      ],
+    },
+    false,
+    null,
+    "kimi-coding"
+  );
 
-    const assistantMsg = result.messages.find((m) => m.role === "assistant");
-    const thinkingBlocks =
-      Array.isArray(assistantMsg.content) &&
-      assistantMsg.content.filter((b) => b?.type === "thinking");
-    assert.equal(
-      thinkingBlocks?.length,
-      1,
-      "should have exactly one thinking block (no duplicate)"
-    );
-    assert.equal(
-      thinkingBlocks[0].thinking,
-      "I already have this",
-      "original thinking should be preserved"
-    );
+  const assistantMsg = result.messages.find((m) => m.role === "assistant");
+  const thinkingBlocks =
+    Array.isArray(assistantMsg.content) &&
+    assistantMsg.content.filter((b) => b?.type === "thinking");
+  assert.equal(thinkingBlocks?.length, 1, "should have exactly one thinking block (no duplicate)");
+  assert.equal(
+    thinkingBlocks[0].thinking,
+    "I already have this",
+    "original thinking should be preserved"
+  );
 
-    clearReasoningCacheAll();
-  });
+  clearReasoningCacheAll();
+});

--- a/tests/unit/translator-helper-branches.test.ts
+++ b/tests/unit/translator-helper-branches.test.ts
@@ -698,12 +698,12 @@ test("translateRequest does not replay reasoning-only messages for non-DeepSeek 
   clearReasoningCacheAll();
 });
 
-test("translateRequest uses Kimi Coding's empty thinking marker instead of cached replay", () => {
+test("translateRequest replays cached reasoning before Kimi Coding's empty fallback", () => {
   clearReasoningCacheAll();
   cacheReasoningByKey(
     "toolu_kimi_claude",
-    "kimi-coding",
-    "kimi-for-coding",
+    "kimi-coding-apikey",
+    "k3-256k",
     "cached thinking for Kimi tool call"
   );
 
@@ -712,7 +712,7 @@ test("translateRequest uses Kimi Coding's empty thinking marker instead of cache
   const result = translateRequest(
     FORMATS.OPENAI,
     FORMATS.CLAUDE,
-    "kimi-for-coding",
+    "k3-256k",
     {
       reasoning_effort: "high",
       messages: [
@@ -733,24 +733,23 @@ test("translateRequest uses Kimi Coding's empty thinking marker instead of cache
     },
     false,
     null,
-    "kimi-coding"
+    "kimi-coding-apikey"
   );
 
   const assistantMsg = result.messages.find((m) => m.role === "assistant");
   assert.ok(assistantMsg, "assistant message should exist");
   assert.ok(Array.isArray(assistantMsg.content), "content should be array");
 
-  // Kimi Code CLI 0.26 sends an explicit empty thinking marker before tool_use.
   const thinkingBlock = assistantMsg.content.find((b) => b?.type === "thinking");
   assert.ok(thinkingBlock, "thinking block should be injected");
-  assert.equal(thinkingBlock.thinking, "");
+  assert.equal(thinkingBlock.thinking, "cached thinking for Kimi tool call");
 
   // Thinking block should appear before tool_use
   const thinkingIdx = assistantMsg.content.indexOf(thinkingBlock);
   const toolUseIdx = assistantMsg.content.findIndex((b) => b?.type === "tool_use");
   assert.ok(thinkingIdx < toolUseIdx, "thinking block should be before tool_use");
 
-  assert.equal(getReasoningCacheServiceStats().replays, 0);
+  assert.equal(getReasoningCacheServiceStats().replays, 1);
   clearReasoningCacheAll();
 });
 
@@ -760,7 +759,7 @@ test("translateRequest uses an empty Kimi Coding thinking marker on cache miss",
   const result = translateRequest(
     FORMATS.OPENAI,
     FORMATS.CLAUDE,
-    "kimi-for-coding",
+    "k3-256k",
     {
       reasoning_effort: "high",
       messages: [
@@ -774,7 +773,7 @@ test("translateRequest uses an empty Kimi Coding thinking marker on cache miss",
     },
     false,
     null,
-    "kimi-coding"
+    "kimi-coding-apikey"
   );
 
   const assistantMsg = result.messages.find((m) => m.role === "assistant");
@@ -790,11 +789,17 @@ test("translateRequest uses an empty Kimi Coding thinking marker on cache miss",
 
 test("translateRequest does NOT inject duplicate thinking for Claude-format messages with existing thinking block", () => {
   clearReasoningCacheAll();
+  cacheReasoningByKey(
+    "toolu_existing",
+    "kimi-coding-apikey",
+    "k3-256k",
+    "cached thinking must not replace client thinking"
+  );
 
   const result = translateRequest(
     FORMATS.OPENAI,
     FORMATS.CLAUDE,
-    "kimi-for-coding",
+    "k3-256k",
     {
       messages: [
         { role: "user", content: "hi" },
@@ -810,7 +815,7 @@ test("translateRequest does NOT inject duplicate thinking for Claude-format mess
     },
     false,
     null,
-    "kimi-coding"
+    "kimi-coding-apikey"
   );
 
   const assistantMsg = result.messages.find((m) => m.role === "assistant");
@@ -823,6 +828,7 @@ test("translateRequest does NOT inject duplicate thinking for Claude-format mess
     "I already have this",
     "original thinking should be preserved"
   );
+  assert.equal(getReasoningCacheServiceStats().replays, 0);
 
   clearReasoningCacheAll();
 });


### PR DESCRIPTION
## Summary

- Preserve authentic OpenAI Responses reasoning history for K3 models regardless of which provider serves `k3`, `k3-256k`, or `kimi-k3`.
- Attach reasoning to the matching assistant turn without carrying it across a user boundary; Kimi Coding receives Claude `thinking`, while native OpenAI-format routes receive `reasoning_content`.
- Keep valid thinking-only Claude assistant turns and pass the resolved model into the real `/v1/responses` conversion path.
- Use the common `requiresReasoningReplay()` policy for both production Responses conversion paths; Kimi Coding provider identity alone no longer enables preservation for unrelated models.
- Restore Kimi Coding replay precedence: non-empty client reasoning, then authentic cached reasoning, then the empty Kimi protocol marker only on cache miss.

## Related Issues

- Closes #9794
- Related to #9496, #2139, #2637, #8260

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/dev/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build also run in CI on this PR (#8329):

- [x] Change type: provider / routing
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` — changed-file ESLint passed; the repository-wide command currently fails on two unrelated `no-explicit-any` errors in `tests/unit/issue-9407-gemini-web-validation-false-positive.test.ts` and `tests/unit/v1-models-auth-leak-9320.test.ts`
- [x] Reconciled with the current active `release/v3.8.50` base; focused checks rerun afterward
- [x] Production-code changes include new or updated automated tests in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below — pending CI

Focused command:

```bash
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/reasoning-cache.test.ts tests/unit/service-reasoning-cache.test.ts tests/unit/claude-stream-reconstructed-body.test.ts tests/unit/kimi-coding-translator.test.ts tests/unit/moonshot-k3.test.ts tests/unit/responses-handler.test.ts tests/unit/responses-translation-fixes.test.ts tests/unit/translator-openai-responses-req.test.ts tests/unit/translator-helper-branches.test.ts
```

Result: 209 passed, 0 failed.

Additional checks:

```bash
npx eslint open-sse/utils/reasoningContentInjector.ts open-sse/translator/index.ts open-sse/translator/request/openai-responses.ts open-sse/translator/helpers/responsesApiHelper.ts open-sse/translator/helpers/claudeHelper.ts open-sse/handlers/responsesHandler.ts tests/unit/kimi-coding-translator.test.ts tests/unit/moonshot-k3.test.ts tests/unit/responses-translation-fixes.test.ts tests/unit/responses-handler.test.ts tests/unit/translator-helper-branches.test.ts --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json
npm run check:changelog-integrity
npm run test:coverage
```

Changed-file ESLint and changelog integrity passed. The final focused replay suite passed 86/86. Coverage was rerun with `cli-serve-stop-command.test.ts` and `cli-expanded-commands.test.ts` excluded so the gate could not signal or contact the live process on port 20128. Coverage exceeded every required 60% threshold but exited 1 on unrelated golden snapshot, ServiceSupervisor, and `wafRateLimit` failures.

## Tests Added Or Updated

- `tests/unit/kimi-coding-translator.test.ts`
- `tests/unit/moonshot-k3.test.ts`
- `tests/unit/responses-handler.test.ts`
- `tests/unit/responses-translation-fixes.test.ts`
- `tests/unit/service-reasoning-cache.test.ts`
- `tests/unit/translator-helper-branches.test.ts`

## Coverage Notes

Coverage from the earlier `npm run test:coverage` run:

- Statements: 84.50%
- Lines: 84.50%
- Functions: 88.21%
- Branches: 79.00%

The tests cover Responses reasoning placement, tool-call and completed assistant turns, user-boundary isolation, Kimi Coding Claude projection, native Moonshot projection, thinking-only assistant preservation, K3 model-driven gating across providers, non-K3 negative gating, Kimi Coding client/cache/empty replay precedence, and the actual `/v1/responses` handler path.

## Reviewer Notes

- K3 and native Moonshot/Kimi K2.7 classification now lives in `requiresReasoningReplay()`; `requiresAuthenticReasoningContent()` was removed.
- K3 preservation is model-driven: `k3`, `k3-256k`, and `kimi-k3` preserve authentic Responses reasoning across providers.
- Native `kimi-k2.7-code` retains its existing Moonshot/Kimi provider restriction.
- Kimi Coding replay now preserves non-empty client thinking, replaces empty/missing thinking with authentic cached reasoning when available, and retains the empty marker only on cache miss.
- Live external Kimi/Moonshot network behavior was not exercised in the final verification pass; the endpoint test captures and asserts the translated upstream request bodies.