### PR TITLE
[TS7] fix(types): align stream failure callback contracts

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -2778,7 +2778,7 @@ export function createSSETransformStreamWithLogger(
   body: unknown = null,
   onComplete: ((payload: StreamCompletePayload) => void) | null = null,
   apiKeyInfo: unknown = null,
-  onFailure: ((payload: StreamFailurePayload) => void | Promise<void>) | null = null,
+  onFailure: ((payload: StreamFailurePayload) => boolean | void | Promise<void>) | null = null,
   copilotCompatibleReasoning = false,
   suppressThinkClose = false,
   customToolNames: ReadonlySet<string> = new Set(),
@@ -2813,7 +2813,7 @@ export function createPassthroughStreamWithLogger(
   body: unknown = null,
   onComplete: ((payload: StreamCompletePayload) => void) | null = null,
   apiKeyInfo: unknown = null,
-  onFailure: ((payload: StreamFailurePayload) => void | Promise<void>) | null = null,
+  onFailure: ((payload: StreamFailurePayload) => boolean | void | Promise<void>) | null = null,
   clientResponseFormat: string | null = null,
   requestToolIdentityMap: Map<string, { namespace: string; name: string }> | null = null
 ) {

--- a/tests/unit/stream-failure-499-classification.test.ts
+++ b/tests/unit/stream-failure-499-classification.test.ts
@@ -48,13 +48,14 @@ test("createStreamFailureFinalizers: caller classification survives into respons
     persistFailureUsage: () => {},
   });
 
-  handleStreamFailure({
+  const handled = handleStreamFailure({
     status: 502,
     message: "Upstream stream error",
     code: "stream_pipeline_error",
     type: "stream_error",
   });
 
+  assert.equal(handled, true, "the callback contract reports that the stream failure was handled");
   const body = captured as { error: { type?: string; code?: string } };
   assert.equal(body.error.type, "stream_error");
   assert.equal(body.error.code, "stream_pipeline_error");


### PR DESCRIPTION
## Summary

- align the public stream wrapper callback signatures with the existing core stream failure contract
- preserve the boolean handled result used by chatCore failure finalizers
- add a regression assertion for the handled callback result

## TypeScript migration impact

- TS6: 82 → 79
- native TS7: 81 → 78
- normalized diff: 3 removed, 0 added

## Validation

- `node --import tsx/esm --test tests/unit/stream-failure-499-classification.test.ts`
- targeted ESLint with the repository suppression baseline
- `npm run check:file-size` (same 13 pre-existing baseline violations; no changed file is listed)

Part of #8484.