### PR TITLE
[TS7] fix(types): narrow chatCore local contracts

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -492,7 +492,7 @@ export async function handleChatCore({
     apiKeyInfo,
     log,
   });
-  if (pluginGate.blocked) {
+  if (pluginGate.blocked === true) {
     return {
       success: false,
       status: 403,
@@ -1883,7 +1883,7 @@ export async function handleChatCore({
     modelOutputCap,
     toPositiveInteger(resolveInputTokenCapForGate({ provider, model: effectiveModel }, { isCombo }))
   );
-  if (!outputBudget.ok) {
+  if (outputBudget.ok === false) {
     const exceededInputCap = outputBudget.maxInputTokens !== undefined;
     const message =
       `Input exceeds ${exceededInputCap ? "maximum input tokens" : "context window"} for ${provider}/${effectiveModel}: ` +

--- a/tests/unit/chatcore-passthrough-tool-names.test.ts
+++ b/tests/unit/chatcore-passthrough-tool-names.test.ts
@@ -38,4 +38,5 @@ test("mergeResponseToolNameMap unions base with executor _toolNameMap", () => {
   assert.equal(merged.get("a"), "1");
   assert.equal(merged.get("b"), "2");
   assert.equal(mergeResponseToolNameMap(base, {}), base);
+  assert.equal(mergeResponseToolNameMap(null, {}), null);
 });

--- a/tests/unit/chatcore-plugin-onrequest.test.ts
+++ b/tests/unit/chatcore-plugin-onrequest.test.ts
@@ -61,6 +61,7 @@ test("a body-rewriting hook → blocked:false with the new body", async () => {
   const gate = await runPluginOnRequestHook(baseArgs());
   assert.equal(gate.blocked, false);
   if (gate.blocked) return;
+  assert.equal("response" in gate, false);
   assert.deepEqual(gate.body, rewritten);
 });
 

--- a/tests/unit/output-token-budget.test.ts
+++ b/tests/unit/output-token-budget.test.ts
@@ -6,6 +6,10 @@ import { enforceOutputTokenBudget } from "../../open-sse/handlers/chatCore/outpu
 test("rejects a prompt that cannot leave one output token", () => {
   const result = enforceOutputTokenBudget({ max_tokens: 8192 }, 527_058, 128_000);
 
+  assert.equal(result.ok, false);
+  if (result.ok) assert.fail("expected the rejected output-budget branch");
+  assert.equal(result.estimatedInputTokens, 527_058);
+  assert.equal(result.contextLimit, 128_000);
   assert.deepEqual(result, {
     ok: false,
     estimatedInputTokens: 527_058,


### PR DESCRIPTION
## Summary

- import the existing response tool-name map merger used by the streaming path
- use explicit boolean discriminants for plugin and output-budget result unions
- extend the focused helper, plugin-gate, and output-budget regression coverage

## TypeScript migration impact

- TS6: 82 → 75
- native TS7: 81 → 74
- normalized diff: 7 removed, 0 added

## Validation

- `node --import tsx/esm --test tests/unit/chatcore-passthrough-tool-names.test.ts tests/unit/chatcore-plugin-onrequest.test.ts tests/unit/output-token-budget.test.ts tests/unit/output-token-budget-model-cap.test.ts`
- targeted ESLint with the repository suppression baseline
- `npm run check:file-size` (same 13 pre-existing baseline violations; no changed file is listed)

Part of #8484.