### PR TITLE
[TS7] fix(types): validate Azure OpenAI base URLs

### DIFF
--- a/open-sse/executors/azure-openai.ts
+++ b/open-sse/executors/azure-openai.ts
@@ -28,7 +28,11 @@ export class AzureOpenAIExecutor extends DefaultExecutor {
     void urlIndex;
 
     const providerSpecificData = credentials?.providerSpecificData || {};
-    const baseUrl = normalizeAzureBaseUrl(providerSpecificData.baseUrl || this.config.baseUrl);
+    const baseUrl = normalizeAzureBaseUrl(
+      typeof providerSpecificData.baseUrl === "string"
+        ? providerSpecificData.baseUrl
+        : this.config.baseUrl
+    );
     const apiVersion =
       typeof providerSpecificData.apiVersion === "string" && providerSpecificData.apiVersion.trim()
         ? providerSpecificData.apiVersion.trim()

--- a/tests/unit/azure-openai-executor.test.ts
+++ b/tests/unit/azure-openai-executor.test.ts
@@ -32,6 +32,22 @@ test("AzureOpenAIExecutor strips duplicated /openai suffixes from configured bas
   );
 });
 
+test("AzureOpenAIExecutor ignores non-string credential base URLs", () => {
+  const executor = new AzureOpenAIExecutor();
+  executor.config.baseUrl = "https://fallback-resource.openai.azure.com";
+
+  const url = executor.buildUrl("deploy-1", false, 0, {
+    providerSpecificData: {
+      baseUrl: { host: "untrusted.example.com" },
+    },
+  });
+
+  assert.equal(
+    url,
+    "https://fallback-resource.openai.azure.com/openai/deployments/deploy-1/chat/completions?api-version=2024-12-01-preview"
+  );
+});
+
 test("AzureOpenAIExecutor uses api-key auth headers instead of Bearer auth", () => {
   const executor = new AzureOpenAIExecutor();
   const headers = executor.buildHeaders({ apiKey: "azure-key-123" }, true);


### PR DESCRIPTION
## Summary

- accept a credential-specific Azure base URL only when it is a string
- fall back to the configured provider endpoint for malformed provider-specific data
- cover the non-string credential input path

## TypeScript migration impact

- TS6: 82 → 81
- native TS7: 81 → 80
- normalized diff: 1 removed, 0 added

## Validation

- `node --import tsx/esm --test tests/unit/azure-openai-executor.test.ts`
- targeted ESLint with the repository suppression baseline
- `npm run check:file-size` (same 13 pre-existing baseline violations; no changed file is listed)

Part of #8484.