### PR TITLE
[TS7] fix(types): preserve sanitized tool array contracts

### DIFF
--- a/open-sse/handlers/chatCore/sanitization.ts
+++ b/open-sse/handlers/chatCore/sanitization.ts
@@ -46,7 +46,7 @@ export function sanitizeChatRequestBody(
   }
 
   if (Array.isArray(body.tools)) {
-    body.tools = body.tools.filter((tool: Record<string, unknown>) => {
+    const tools = body.tools.filter((tool: Record<string, unknown>) => {
       const toolType = typeof tool.type === "string" ? tool.type : "";
       if (toolType && toolType !== "function" && !tool.function && tool.name === undefined) {
         return true;
@@ -56,7 +56,7 @@ export function sanitizeChatRequestBody(
       return name && String(name).trim().length > 0;
     });
 
-    body.tools = body.tools.map((tool) => sanitizeOpenAITool(tool) as (typeof body.tools)[number]);
+    body.tools = tools.map((tool) => sanitizeOpenAITool(tool));
   }
 
   return body;

--- a/tests/unit/chatcore-extracted-modules-3821.test.ts
+++ b/tests/unit/chatcore-extracted-modules-3821.test.ts
@@ -49,6 +49,7 @@ test("sanitizeChatRequestBody: strips empty message name and filters nameless to
       ],
       tools: [
         { type: "function", function: { name: "real_tool", parameters: {} } },
+        { type: "web_search_preview" },
         { type: "function", function: { name: "" } }, // dropped — empty name
         { type: "function", function: {} }, // dropped — no name
       ],
@@ -62,8 +63,9 @@ test("sanitizeChatRequestBody: strips empty message name and filters nameless to
   assert.equal(messages[1].name, "keepme", "non-empty name kept");
 
   const tools = out.tools as Array<Record<string, unknown>>;
-  assert.equal(tools.length, 1, "only the named tool survives");
+  assert.equal(tools.length, 2, "the named function and built-in tool survive");
   assert.equal((tools[0].function as Record<string, unknown>).name, "real_tool");
+  assert.deepEqual(tools[1], { type: "web_search_preview" });
 });
 
 test("checkIdempotencyCache returns { hit:null, idempotencyKey } on a miss", async () => {


### PR DESCRIPTION
## Summary

- keep the filtered tool array in a narrowed local before schema sanitization
- remove the unsafe indexed access through the reassigned unknown request field
- cover named function tools and built-in non-function tools together

## TypeScript migration impact

- TS6: 82 → 80
- native TS7: 81 → 79
- normalized diff: 2 removed, 0 added

## Validation

- `node --import tsx/esm --test tests/unit/chatcore-extracted-modules-3821.test.ts`
- targeted ESLint with the repository suppression baseline
- `npm run check:file-size` (same 13 pre-existing baseline violations; no changed file is listed)

Part of #8484.