### PR TITLE
[TS7] fix(types): validate Vision Bridge combo names

### DIFF
--- a/src/lib/guardrails/visionBridge.ts
+++ b/src/lib/guardrails/visionBridge.ts
@@ -28,6 +28,11 @@ export { isProviderConnectionUsable, hasUsableCredentialsForModel };
 
 type ComboVisionBridgeDecision = "process" | "skip" | "not-combo";
 
+export function resolveVisionComboName(mapping: Record<string, unknown>): string | null {
+  const comboName = mapping.comboName ?? mapping.name ?? null;
+  return typeof comboName === "string" && comboName.length > 0 ? comboName : null;
+}
+
 /// Check if a combo model should trigger vision bridge processing.
 /// Resolves combo targets and returns:
 /// - "process" if any target cannot be proven vision-capable
@@ -45,7 +50,7 @@ async function getComboVisionBridgeDecision(model: string): Promise<ComboVisionB
     if (!combo) {
       const mapping = await resolveComboForModel(model);
       if (!mapping) return "not-combo";
-      const comboName = mapping.comboName ?? mapping.name ?? null;
+      const comboName = resolveVisionComboName(mapping);
       if (!comboName) return "not-combo";
       combo = await getComboByName(comboName);
     }

--- a/tests/unit/guardrails/visionBridge.test.ts
+++ b/tests/unit/guardrails/visionBridge.test.ts
@@ -6,7 +6,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { VisionBridgeGuardrail } = await import("../../../src/lib/guardrails/visionBridge.ts");
+const { VisionBridgeGuardrail, resolveVisionComboName } =
+  await import("../../../src/lib/guardrails/visionBridge.ts");
 const { resetGuardrailsForTests } = await import("../../../src/lib/guardrails/registry.ts");
 const { getResolvedModelCapabilities } = await import("../../../src/lib/modelCapabilities.ts");
 import type { GuardrailContext } from "../../../src/lib/guardrails/base.ts";
@@ -93,6 +94,14 @@ test("VisionBridgeGuardrail is enabled by default", () => {
 test("VisionBridgeGuardrail can be disabled via constructor", () => {
   const guardrail = createGuardrail({ enabled: false });
   assert.strictEqual(guardrail.enabled, false);
+});
+
+test("resolveVisionComboName accepts only non-empty string mapping names", () => {
+  assert.equal(resolveVisionComboName({ comboName: "vision-fallback" }), "vision-fallback");
+  assert.equal(resolveVisionComboName({ name: "legacy-fallback" }), "legacy-fallback");
+  assert.equal(resolveVisionComboName({ comboName: { nested: true } }), null);
+  assert.equal(resolveVisionComboName({ comboName: 42 }), null);
+  assert.equal(resolveVisionComboName({ comboName: "" }), null);
 });
 
 // ── VB-S05: Vision Bridge disabled via settings ────────────────────────────


### PR DESCRIPTION
## Summary

- resolve combo mapping names through a small runtime string guard
- retain the legacy name fallback while rejecting malformed mapping values
- cover valid, legacy, empty, numeric, and object-shaped mapping names

## TypeScript migration impact

- TS6: 82 → 81
- native TS7: 81 → 80
- normalized diff: 1 removed, 0 added

## Validation

- `node --import tsx/esm --test tests/unit/guardrails/visionBridge.test.ts tests/unit/vision-bridge-preserve-on-failure-4012.test.ts`
- targeted ESLint with the repository suppression baseline
- `npm run check:file-size` (same 13 pre-existing baseline violations; no changed file is listed)

Part of #8484.