### PR TITLE
[TS7] fix(types): preserve streaming PII choice keys

### DIFF
--- a/src/lib/streamingPiiTransform.ts
+++ b/src/lib/streamingPiiTransform.ts
@@ -18,7 +18,7 @@ export function createPiiSseTransform(options?: PiiTransformOptions): TransformS
         toolArgs: "",
         partialJson: "",
       };
-      choiceBuffers.set(index, buf);
+      choiceBuffers.set(key, buf);
     }
     return buf;
   };

--- a/tests/unit/streamingPiiTransform.test.ts
+++ b/tests/unit/streamingPiiTransform.test.ts
@@ -84,6 +84,22 @@ test("createPiiSseTransform redacts PII split across chunk boundaries", async ()
   );
 });
 
+test("createPiiSseTransform isolates buffered content by choice index", async () => {
+  const transform = createPiiSseTransform({ windowSize: 10 });
+  const first =
+    'data: {"choices":[{"index":0,"delta":{"content":"alpha-user@"}},{"index":1,"delta":{"content":"beta-user@"}}]}\n\n';
+  const second =
+    'data: {"choices":[{"index":0,"delta":{"content":"example.com"}},{"index":1,"delta":{"content":"example.org"}}]}\n\n';
+  const done = "data: [DONE]\n\n";
+
+  const output = await testTransform(transform, [first, second, done]);
+
+  assert.ok(!output.includes("alpha-user@example.com"));
+  assert.ok(!output.includes("beta-user@example.org"));
+  assert.ok(output.includes('"index":0'));
+  assert.ok(output.includes('"index":1'));
+});
+
 test("createPiiSseTransform flushes final redacted content before [DONE] sentinel", async () => {
   const transform = createPiiSseTransform();
 


### PR DESCRIPTION
## Summary

- store newly-created PII buffers under the same normalized string key used for lookup
- keep per-choice buffering isolated across multi-choice SSE chunks
- add multi-choice split-PII regression coverage

## TypeScript migration impact

- TS6: 82 → 81
- native TS7: 81 → 80
- normalized diff: 1 removed, 0 added

## Validation

- `node --import tsx/esm --test tests/unit/streamingPiiTransform.test.ts`
- targeted ESLint with the repository suppression baseline
- `npm run check:file-size` (same 13 pre-existing baseline violations; no changed file is listed)

Part of #8484.