### PR TITLE
fix(sse): restore the tool-name merge import the streaming path still calls

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -223,6 +223,7 @@ import { recordCost } from "@/domain/costRules";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import {
   buildClaudePassthroughToolNameMap,
+  mergeResponseToolNameMap,
   normalizeOpenAIToolFinishReasons,
   restoreNonStreamingToolNames,
 } from "./chatCore/passthroughToolNames.ts";


### PR DESCRIPTION
Fixes #9577.

`handleChatCore` throws on the streaming path at the current tip:

```
ReferenceError: mergeResponseToolNameMap is not defined
  at handleChatCore (open-sse/handlers/chatCore.ts:4690:31)
```

The line runs after the provider has already answered and `onRequestSuccess()`
has fired, so the upstream call is spent and the request still fails.

#9236 folded `mergeResponseToolNameMap` and `restoreClaudePassthroughToolNames`
into the new `restoreNonStreamingToolNames` and swapped the import to match.
That covered the non-streaming call site at the old `:4198`. A second call site
on the streaming path at the old `:4702` still calls the name directly, and the
import no longer provides it.

### Why restore the import rather than reuse the new helper

`restoreNonStreamingToolNames(responseBody, ...)` takes a materialized
`JsonRecord` and rewrites tool names inside it. The streaming path has a stream,
not a body, and needs only the merged map to hand to the transform stream. That
is what the helper's own name says, and it is why the streaming path calls the
merge directly. Restoring the import keeps #9236's refactor exactly as written.

### Test plan

No new test. #9236 left 43 existing assertions failing across nine files, and
those are the regression guard; they were red on the base and are green with
this one line.

```
base (04683029a)   agentrouter-chatcore-protocols   3 of 6 fail, all ReferenceError
with this commit   the nine affected files          157 tests, 157 pass, 0 fail
```

Files covered: `agentrouter-chatcore-protocols`, `chat-adaptive-admission-binding`,
`chatcore-sanitization`, `chatcore-translation-paths`,
`chat-messages-validation-6402`, `chat-route-coverage`, `chat-route-edge-cases`,
`provider-request-failure-pipeline`, `responses-handler`.

`npm run typecheck:core` and `npm run lint` are both clean on this branch.

### Review record

One review round, not the three I would normally run. Re-running a review on an
unchanged one-line diff returns the cached result rather than a fresh one, so
extra rounds would add confidence I have not actually earned. Both findings that
round raised were the same claim, that the import has no usage, and both are
refuted by the call site at `:4691` and by eslint reporting no unused import.
The design question the rounds could not reach, whether the streaming path
should adopt the new helper instead, is answered from the helper's signature
above.

> [!NOTE]
> base-red inherited: #9298. A full local `npm run test:unit` on the base gives
> 94 failures; this branch removes 43 of them. The remaining 51 are unrelated and
> stay red, so `Unit Tests` will not go green on this PR alone. `Fast Quality
> Gates` fails on `check:pack-policy` over a file added by #8922, and the CodeQL
> ratchet counts alerts repository-wide rather than per diff. None of the three
> involves this file.
