### PR TITLE
fix(sse): shrink chat.ts back under the frozen file-size cap (base-red drain)

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1547,8 +1547,7 @@ async function handleSingleModelChat(
         // the next client retry select another eligible account without deleting a
         // pin that may already have moved to a healthy connection.
         const isTerminalStreamEarlyEof =
-          result.errorCode === "STREAM_EARLY_EOF" ||
-          result.errorType === "stream_early_eof";
+          result.errorCode === "STREAM_EARLY_EOF" || result.errorType === "stream_early_eof";
 
         if (isTerminalStreamEarlyEof && runtimeOptions.sessionAffinityKey) {
           try {
@@ -1769,7 +1768,8 @@ async function handleSingleModelChat(
 
         const mlSettings = resolveModelLockoutSettings(runtimeOptions.cachedSettings);
         if (mlSettings.enabled && mlSettings.errorCodes.includes(result.status)) {
-          // Lock this model on this connection until tomorrow 00:00
+          // Lock until tomorrow 00:00. Antigravity meters per exact model (#8630).
+          const lockScope = provider === "antigravity" ? "exact" : undefined;
           const lockResult = recordModelLockoutFailure(
             provider,
             credentials.connectionId,
@@ -1778,10 +1778,7 @@ async function handleSingleModelChat(
             result.status,
             0,
             providerProfile,
-            {
-              maxCooldownMs: mlSettings.maxCooldownMs,
-              scope: provider === "antigravity" ? "exact" : undefined,
-            }
+            { maxCooldownMs: mlSettings.maxCooldownMs, scope: lockScope }
           );
 
           log.info(


### PR DESCRIPTION
## Summary

`npm run check:file-size` (job `ci.yml:lint`) was red on the `release/v3.8.50` tip:

```
[file-size] 1 violação(ões):
  ✗ src/sse/handlers/chat.ts: 1880 > congelado 1877 (não pode crescer)
```

Every PR cut against that tip inherited the failure, so this drains it at the source.

## Cause

The exact-model lock scope merged with #8630 expanded an inline argument object at the
`recordModelLockoutFailure()` chokepoint from 1 line to 4:

```ts
{
  maxCooldownMs: mlSettings.maxCooldownMs,
  scope: provider === "antigravity" ? "exact" : undefined,
}
```

Net +3 on a frozen god-file that had no headroom.

## Fix — shrink, not rebaseline

Hoisted the ternary into a `lockScope` const so the object collapses back to one line, and
condensed the adjacent comment (the `#8630` rationale is preserved in it). **Behaviour is
identical** — same ternary, same argument value.

`src/sse/handlers/chat.ts`: **1880 → 1877**, exactly at the frozen cap. **No baseline entry was
added** — `config/quality/file-size-baseline.json` is untouched.

## Out-of-scope line in the diff (disclosed)

The diff also contains one Prettier normalisation at line 1547 (an `isTerminalStreamEarlyEof`
condition from #9184). That line was **already failing `prettier --check` on the base tip** —
verified with `git show origin/release/v3.8.50:src/sse/handlers/chat.ts | npx prettier --check`.
It is behaviour-neutral and leaves the file Prettier-clean.

## Validation

| Check | Result |
| --- | --- |
| `npm run check:file-size` | `OK — 124 arquivos congelados` + `OK — 44 test files congelados` |
| `npm run typecheck:core` | exit 0 |
| `npx eslint src/sse/handlers/chat.ts` (with suppressions) | exit 0, clean |
| `npx prettier --check src/sse/handlers/chat.ts` | `All matched files use Prettier code style!` |
| model-lockout + account-fallback suites | **93/93 pass** (`model-lockout-decay`, `model-lockout-max-cooldown`, `model-lockout-exact-cooldown-cap`, `repro-antigravity-404-family-cooldown-hijack`, `account-fallback-service`) |

The exact-model behaviour #8630 introduced stays covered — `Antigravity 404 Model Not Found
locks exact model ONLY, not entire family` and `Antigravity 429 Rate Limit locks whole family`
both pass.

No production behaviour changes, so no new test is added; the existing 93 assertions are the
regression guard for the wiring this touches.

Refs #8630
