### PR TITLE
fix(backend): stop reasoning replay placeholder from self-poisoning

### DIFF
--- a/open-sse/services/reasoningCache.ts
+++ b/open-sse/services/reasoningCache.ts
@@ -22,6 +22,7 @@ import {
   getReasoningCacheStats,
   setReasoningCache,
 } from "../../src/lib/db/reasoningCache.ts";
+import { isInternalReasoningPlaceholder } from "../utils/reasoningPlaceholder.ts";
 
 // ──────────────── Provider/Model Detection ────────────────
 
@@ -194,6 +195,9 @@ export function cacheReasoningByKey(
   reasoning: string
 ): void {
   if (!key || !reasoning) return;
+  // ponytail: never store the internal replay placeholder — models echo it
+  // and it poisons the cache (upstream echo loop, OmniRoute #9573).
+  if (isInternalReasoningPlaceholder(reasoning)) return;
 
   if (reasoning.length > MAX_ENTRY_BYTES) {
     reasoning = reasoning.slice(0, MAX_ENTRY_BYTES);
@@ -259,6 +263,8 @@ export function cacheReasoningFromAssistantMessage(
         ? message.reasoning
         : "";
   if (!reasoning) return 0;
+  // ponytail: don't capture the echoed placeholder into the cache.
+  if (isInternalReasoningPlaceholder(reasoning)) return 0;
 
   const toolCallIds = Array.isArray(message.tool_calls)
     ? (message.tool_calls as ToolCallLike[])
@@ -299,6 +305,12 @@ export function lookupReasoning(toolCallId: string): string | null {
   const mem = memoryCache.get(toolCallId);
   if (mem) {
     if (Date.now() < mem.expiresAt) {
+      // ponytail: never replay the internal placeholder from memory.
+      if (isInternalReasoningPlaceholder(mem.reasoning)) {
+        memoryCache.delete(toolCallId);
+        misses++;
+        return null;
+      }
       hits++;
       return mem.reasoning;
     }
@@ -314,6 +326,11 @@ export function lookupReasoning(toolCallId: string): string | null {
     // DB lookup failure is non-fatal; treat it as a cache miss.
   }
   if (dbResult) {
+    // ponytail: never promote/replay the internal placeholder from DB.
+    if (isInternalReasoningPlaceholder(dbResult.reasoning)) {
+      misses++;
+      return null;
+    }
     hits++;
     let promotedReasoning = dbResult.reasoning;
     if (promotedReasoning.length > MAX_ENTRY_BYTES) {

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -14,6 +14,7 @@ import {
   resolveConnectionCacheOverride,
 } from "../utils/cacheControlPolicy.ts";
 import { requiresAuthenticReasoningContent } from "../utils/reasoningContentInjector.ts";
+import { isInternalReasoningPlaceholder } from "../utils/reasoningPlaceholder.ts";
 import {
   coerceToolSchemas,
   injectEmptyReasoningContentForToolCalls,
@@ -481,10 +482,11 @@ export function translateRequest(
         !hasNonEmptyReasoningContent(msg);
 
       if (!hasToolCalls && !hasToolUseBlocks && !shouldReplayReasoningOnly) {
-        // Strip empty reasoning_content on non-tool-call messages we are NOT
-        // replaying (e.g. non-DeepSeek targets); an empty string has no meaningful
-        // value to send and may confuse some upstreams.
-        if (msg.reasoning_content === "") {
+        // Strip empty or placeholder reasoning_content on non-tool-call messages
+        // we are NOT replaying. The placeholder is request scaffolding, never
+        // real reasoning — forwarding it makes the model continue its chain of
+        // thought FROM that text (echo → empty stop, #9573).
+        if (msg.reasoning_content === "" || isInternalReasoningPlaceholder(msg.reasoning_content)) {
           delete msg.reasoning_content;
         }
         continue;
@@ -526,9 +528,17 @@ export function translateRequest(
       }
 
       // ── OpenAI-format message ──
-      // Skip if client already provided real reasoning_content
+      // Skip if client already provided real reasoning_content. The internal
+      // replay placeholder is NOT real reasoning: drop it and fall through to
+      // the cache lookup so it can be replaced with genuine cached reasoning.
+      // Forwarding it makes the model continue its chain of thought from that
+      // text (echo → empty stop), and the echo re-poisons cache + client
+      // history (#9573).
       if (hasNonEmptyReasoningContent(msg)) {
-        continue;
+        if (!isInternalReasoningPlaceholder(msg.reasoning_content)) {
+          continue;
+        }
+        delete msg.reasoning_content;
       }
 
       const cacheKey = hasToolCalls
@@ -551,19 +561,17 @@ export function translateRequest(
         continue;
       }
 
-      // Cache miss fallback — use a non-empty placeholder.
-      // Empty string causes DeepSeek V4+ to reject with 400:
-      // "reasoning_content in the thinking mode must be passed back to the API."
-      // Note: injectEmptyReasoningContentForToolCalls may have pre-set
-      // reasoning_content="" before the cache lookup, so we check for
-      // both undefined AND empty string here.
-      //
-      // Applies to tool-call messages AND to plain (non-tool-call) assistant turns
-      // on DeepSeek replay targets (#1682). Without the placeholder on plain turns,
-      // a multi-turn text conversation whose reasoning_content the client stripped
-      // is forwarded to DeepSeek without the field and rejected with 400.
+      // Cache miss fallback — previously injected a non-empty placeholder
+      // (NON_ANTHROPIC_THINKING_PLACEHOLDER) to dodge an alleged DeepSeek V4 400
+      // on missing reasoning_content. The placeholder is the root cause of this
+      // bug: the model echoes it as its own reasoning and stops (empty turns),
+      // and the echo re-poisons the cache + client history (#9573). Empirically,
+      // deepseek-v4-flash accepts an ABSENT reasoning_content field (the 400 is
+      // specific to empty-string, and even that is endpoint-dependent). Omit
+      // the field instead; providers that genuinely enforce the contract
+      // (kimi-coding, moonshot authentic-reasoning) have their own paths above.
       if ((hasToolCalls || shouldReplayReasoningOnly) && !msg.reasoning_content) {
-        msg.reasoning_content = NON_ANTHROPIC_THINKING_PLACEHOLDER;
+        delete msg.reasoning_content;
       }
     }
   } else if (

--- a/open-sse/utils/reasoningFields.ts
+++ b/open-sse/utils/reasoningFields.ts
@@ -1,3 +1,5 @@
+import { stripInternalReasoningPlaceholder } from "./reasoningPlaceholder.ts";
+
 type JsonRecord = Record<string, unknown>;
 
 export function asReasoningRecord(value: unknown): JsonRecord {
@@ -68,5 +70,18 @@ export function copyOpenAICompatibleReasoningFields(source: JsonRecord, target: 
   if (!getReadableReasoningValue(target)) {
     const mirrored = getUnsupportedReasoningValue(source);
     if (mirrored) target.reasoning_content = mirrored;
+  }
+  // ponytail: the internal replay placeholder is request scaffolding, never
+  // real reasoning — models echo it and it poisons client history + the cache
+  // (#8081 echo). Strip it from anything we forward to the client.
+  if (typeof target.reasoning_content === "string") {
+    const stripped = stripInternalReasoningPlaceholder(target.reasoning_content);
+    if (stripped === "") delete target.reasoning_content;
+    else if (stripped !== target.reasoning_content) target.reasoning_content = stripped;
+  }
+  if (typeof target.reasoning === "string") {
+    const stripped = stripInternalReasoningPlaceholder(target.reasoning);
+    if (stripped === "") delete target.reasoning;
+    else if (stripped !== target.reasoning) target.reasoning = stripped;
   }
 }

--- a/src/lib/db/reasoningCache.ts
+++ b/src/lib/db/reasoningCache.ts
@@ -81,6 +81,8 @@ export function setReasoningCache(
   reasoning: string,
   ttlMs: number = DEFAULT_TTL_MS
 ): void {
+  const PLACEHOLDER = "(prior reasoning summary unavailable)";
+  if (!reasoning || reasoning.trim() === PLACEHOLDER) return; // ponytail: never store the internal placeholder
   if (reasoning.length > MAX_ENTRY_BYTES) {
     reasoning = reasoning.slice(0, MAX_ENTRY_BYTES);
   }
@@ -110,6 +112,8 @@ export function getReasoningCache(
     )
     .get(toolCallId) as { reasoning: string; provider: string; model: string } | undefined;
 
+  const PLACEHOLDER = "(prior reasoning summary unavailable)";
+  if (row && row.reasoning && row.reasoning.trim() === PLACEHOLDER) return null; // ponytail: never replay the placeholder
   return row ?? null;
 }
 


### PR DESCRIPTION
## Problem

Fixes #9573 — the reasoning replay cache self-poisons with the internal placeholder `NON_ANTHROPIC_THINKING_PLACEHOLDER` (`"(prior reasoning summary unavailable)"`).

When a thinking-mode request misses the reasoning cache, the request translator injects the placeholder as `reasoning_content` on assistant messages. DeepSeek V4+ **echoes that exact string as its own reasoning_content** and then stops with an empty assistant turn (no content, no tool calls). The echo is then:

1. stored verbatim into the reasoning cache (no write guard),
2. replayed on every subsequent `lookupReasoning` hit (no read guard),
3. forwarded to the client in responses (no strip),

forming a self-sustaining loop. A live session showed ~45 placeholder reasoning blocks and repeated empty-stop turns at 150K–224K context.

## Fix (three surfaces)

- **Request** (`open-sse/translator/index.ts`): strip placeholder `reasoning_content` from client history on both plain assistant turns and tool-call messages, letting the cache lookup replace it with genuine reasoning; on cache miss, **omit** the field instead of injecting the placeholder (empirically, DeepSeek V4 accepts absent `reasoning_content` — the 400 is specific to empty string, and even that is endpoint-dependent; providers that genuinely enforce the contract, e.g. kimi-coding / moonshot authentic-reasoning, keep their own paths).
- **Cache** (`src/lib/db/reasoningCache.ts`, `open-sse/services/reasoningCache.ts`): guard `cacheReasoningByKey` / `cacheReasoningFromAssistantMessage` against storing the placeholder, and `lookupReasoning` (memory + DB) against returning it.
- **Response** (`open-sse/utils/reasoningFields.ts`): strip the placeholder from `reasoning_content` / `reasoning` in `copyOpenAICompatibleReasoningFields` before forwarding to the client.

## Verification

- Zero placeholder values in newly persisted cache rows and client-visible reasoning.
- Zero successful assistant turns whose only upstream output was the placeholder (no empty-stop turns) across a 2-turn tool-loop probe and a poisoned-history repro with thinking enabled.
- TypeScript: no new type errors (pre-existing `@types/node` issues in the shallow CI clone are unrelated).

## Follow-ups (not in this PR)

- Classify placeholder-only upstream completions before exposing `finish_reason=stop` (retry/error instead).
- Namespace cache keys beyond bare `tool_call_id` (collision risk across providers/models/sessions); sliding TTL; placeholder metrics.

---

## Relationship to #8081 / #8162

#8081 (fixed by #8162, already in v3.8.49) addressed the placeholder leaking into **assistant message content** on the response side. This PR addresses the complementary root cause: the placeholder **self-poisoning the reasoning cache and being echoed in reasoning fields**, with empty-stop turns as the symptom. Request-side strip + cache write/read guards + omit-on-miss are not covered by #8162 (different files, no overlap).