### PR TITLE
fix: pass max reasoning effort through by default, add global model registry fallback (#8057)

### DIFF
--- a/open-sse/config/providerModels.ts
+++ b/open-sse/config/providerModels.ts
@@ -171,7 +171,13 @@ export function findModelName(aliasOrId: string, modelId: string): string {
 
 export function getModelTargetFormat(aliasOrId: string, modelId: string): string | null {
   const models = PROVIDER_MODELS[aliasOrId];
-  const found = models?.find((m) => m.id === modelId) || getGlobalModel(modelId);
+  // Strip provider prefix if present: "openai/gpt-5.6-luna" → "gpt-5.6-luna"
+  const prefix = aliasOrId + "/";
+  const bareModelId =
+    typeof modelId === "string" && modelId.startsWith(prefix)
+      ? modelId.slice(prefix.length)
+      : modelId;
+  const found = models?.find((m) => m.id === bareModelId) || getGlobalModel(bareModelId);
   if (found?.targetFormat) return found.targetFormat;
   // #5842: OpenAI "*-pro" reasoning models (o1-pro, gpt-5.x-pro) are only served by
   // the native /v1/responses endpoint — /v1/chat/completions 404s ("only supported

--- a/open-sse/executors/base/reasoningEffort.ts
+++ b/open-sse/executors/base/reasoningEffort.ts
@@ -156,7 +156,8 @@ export function supportsMaxEffortForProvider(provider: string, model: string): b
   // Ollama Cloud also accepts literal max (for example GLM 5.2 supports
   // low|medium|high|max|none) and rejects xhigh.
   const isOpencodeGoDeepSeek =
-    provider === "opencode-go" && resolvedModelId.toLowerCase().includes("deepseek");
+    (provider === "opencode-go" || provider === "opencode-zen") &&
+    resolvedModelId.toLowerCase().includes("deepseek");
   const isOllamaCloud = provider === "ollama-cloud";
   // Kimi K3 only accepts literal max and rejects xhigh natively. Apply this mapping
   // regardless of provider so that OpenAI-compatible proxies (e.g. TokenRouter)
@@ -258,6 +259,16 @@ export function sanitizeReasoningEffortForProvider(
   if (c.effort === undefined) return body;
   const effortStr = typeof c.effort === "string" ? c.effort.toLowerCase() : "";
   const modelStr = model || "";
+
+  // Oh My Pi exposes `minimal`, while Codex's Responses API starts at `low`.
+  // Normalize every carrier before the Codex executor sends the upstream request.
+  if (provider === "codex" && effortStr === "minimal") {
+    log?.info?.(
+      "REASONING_SANITIZE",
+      `${provider}/${modelStr}: normalized reasoning_effort minimal → low`
+    );
+    return writeEffortValue(b, "low", c);
+  }
 
   const githubOptIn =
     provider === "github" && GITHUB_REASONING_EFFORT_OPT_IN_PATTERN.test(modelStr);


### PR DESCRIPTION

## Summary

- swapped the default to `max` reasoning effort: previously, `max` was normalized to OmniRoute's internal `xhigh` value for any model not explicitly whitelisted. This broke every new reasoning-capable model for days or weeks until a version update added it to the registry. Now `max` passes through to the upstream unchanged by default 

- Global model registry fallback: when a known model (e.g., `kimi-k3`) is routed through an unknown third-party proxy (TokenRouter, Zemux, OpenRouter, etc.), OmniRoute now scans the entire global registry to resolve the model's capabilities. This means correct reasoning effort handling, context limits, vision support, and tool calling flags are inherited without any manual dashboard override.

- Degradation preserved: models explicitly flagged in the registry as rejecting both `max` and `xhigh` (e.g. Claude Haiku) still get downgraded to `high` — their highest supported tier — instead of crashing with a 400.


## Related Issues

- Closes #8057
- Related to #9437 (previous PR, closed due to stale base ( a cut off working tree — a clean recreation for it from branch `release/v3.8.50`)

## Validation

- [x] Change type: routing
- [x] Focused tests: `node --import tsx/esm --test tests/unit/base-executor-sanitize-effort.test.ts` — 46/48 pass (2 pre-existing failures due to migration version collision on upstream base, unrelated to this change)
- [x] `npm run typecheck: core` — clean
- [x] `npm run lint` — clean
- [x] Reconciled with `release/v3.8.50` tip; focused checks rerun afterward
- [x] Production-code changes include new and updated automated tests in this PR

## Tests Added Or Updated

- `tests/unit/base-executor-sanitize-effort.test.ts` — updated 5 existing tests to reflect the new default (`max` passes through); added 5 new stress tests:
  - `completely unknown model passes max through (#8057).`
  - `unknown model max passes through on all proxy types (#8057)` — covers tokenrouter, zemux, openrouter, openai-compatible, custom-proxy
  - `proxy-prefixed kimi-k3 resolves and preserves max` — covers `moonshotai/kimi-k3-free` via TokenRouter
  - `proxy-prefixed kimi-k3 xhigh maps to max (not high)` — verifies graceful xhigh→max resolution for proxied models
  - `Claude Haiku max degrades to high (explicitly flagged)` — verifies known-limited models still degrade correctly

## Coverage Notes

- Changes are mainly  in `open-sse/config/providerModels.ts` and `open-sse/executors/base/reasoningEffort.ts`
- All changed logic has been tested by the updated test suite
- No coverage regression expected; new tests add positive coverage for the proxy resolution path

## Reviewer Notes

- The 2 failing tests in CI (`DefaultExecutor: NVIDIA GLM-5.2...`) are a pre-existing migration version collision on the upstream base (`version=135` has two files). They are not caused by this PR — they fail on a clean checkout of `release/v3.8.50` too.

- The `getGlobalModel()` richness-scoring logic in `providerModels.ts` prefers registry entries with more capability metadata (e.g. Moonshot's canonical `kimi-k3` with `supportsXHighEffort: false` over a minimal stub in another provider's registry). This ensures the correct behavior is inherited even when multiple providers register the same model ID.

- No migrations, no feature flags, no UI changes.