### PR TITLE
fix(security): anchor hostname comparison in Adobe Firefly login (#778)

### DIFF
--- a/open-sse/services/adobeFireflyBrowserLogin.ts
+++ b/open-sse/services/adobeFireflyBrowserLogin.ts
@@ -259,7 +259,14 @@ async function captureViaCdp(opts: {
       if (capturedAccessToken) return;
       const request = params.request as
         { url?: string; headers?: Record<string, string> } | undefined;
-      if (!request?.url || !request.url.includes(FIREFLY_3P_HOST_SUFFIX)) return;
+      if (!request?.url) return;
+      let host: string;
+      try {
+        host = new URL(request.url).hostname.toLowerCase();
+      } catch {
+        return;
+      }
+      if (host !== FIREFLY_3P_HOST_SUFFIX && !host.endsWith(`.${FIREFLY_3P_HOST_SUFFIX}`)) return;
       const headers = request.headers || {};
       const auth = headers.Authorization || headers.authorization || headers.AUTHORIZATION || "";
       const token = extractAdobeBearerTokenFromAuthorization(auth);


### PR DESCRIPTION
## Summary

Closes CodeQL alert #778 — `js/incomplete-url-substring-sanitization`.

**Problem:** `request.url.includes(FIREFLY_3P_HOST_SUFFIX)` matches the
substring anywhere in the URL (path, query, fragment), so an attacker
that triggers an HTTP request during the login window could inject a
lookalike URL that passes the gate and gets its Bearer token captured.

**Fix:** Parse the URL and compare `hostname` with a dot-anchored
`endsWith`, matching the idiom already used in
`docker/devin-bridge/network-guard/policy.mjs`.

**Risk:** Low — only exploitable during an operator-initiated,
time-boxed browser login (5 min default) on a temp-profile browser.

```diff
- if (!request?.url || !request.url.includes(FIREFLY_3P_HOST_SUFFIX)) return;
+ if (!request?.url) return;
+ let host: string;
+ try {
+   host = new URL(request.url).hostname.toLowerCase();
+ } catch {
+   return;
+ }
+ if (host !== FIREFLY_3P_HOST_SUFFIX && !host.endsWith(`.${FIREFLY_3P_HOST_SUFFIX}`)) return;
```

## Verification
- [x] Compiles (TypeScript)
- [x] Pre-commit hooks: docs-sync ✓, any-budget ✓, tracked-artifacts ✓
- [x] No other production code touched
