### PR TITLE
fix(model): add aq alias for amazon-q provider so parseModel resolves it instead of falling back to OpenAI (#9550)

### DIFF
--- a/changelog.d/fixes/9550-amazon-q-alias.md
+++ b/changelog.d/fixes/9550-amazon-q-alias.md
@@ -1,0 +1,1 @@
+- fix(model): add "aq" alias for amazon-q provider so parseModel resolves it instead of falling back to OpenAI (#9550)

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -54,6 +54,10 @@ ALIAS_TO_PROVIDER_ID["xiaomi"] = "xiaomi-mimo";
 ALIAS_TO_PROVIDER_ID["llamacpp"] = "llama-cpp";
 // agy/ is the short alias for antigravity provider.
 ALIAS_TO_PROVIDER_ID["agy"] = "antigravity";
+// aq/ is the user-visible prefix for the Amazon Q (AWS Builder ID) provider.
+// The canonical provider ID is "amazon-q". Register it so parseModel("aq/<model>")
+// resolves provider = "amazon-q" instead of falling through to the identity fallback.
+ALIAS_TO_PROVIDER_ID["aq"] = "amazon-q";
 
 // Provider-scoped legacy model aliases. Used to normalize provider/model inputs
 // and keep backward compatibility when upstream IDs change.

--- a/tests/unit/repro-9550-amazon-q-alias-resolution.test.ts
+++ b/tests/unit/repro-9550-amazon-q-alias-resolution.test.ts
@@ -1,0 +1,39 @@
+// repro-9550-amazon-q-alias-resolution.test.ts
+// Issue #9550: amazon-q provider silently falls back to OpenAI's endpoint
+// because the "aq" alias is never resolved to "amazon-q".
+
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { resolveProviderAlias, parseModel } from "../../open-sse/services/model.ts";
+import { getExecutor } from "../../open-sse/executors/index.ts";
+
+describe("Issue #9550 - amazon-q alias resolution", () => {
+  it("resolveProviderAlias('aq') should return 'amazon-q'", () => {
+    const provider = resolveProviderAlias("aq");
+    assert.equal(
+      provider,
+      "amazon-q",
+      `Expected "amazon-q" but got "${provider}" — ALIAS_TO_PROVIDER_ID["aq"] is missing`
+    );
+  });
+
+  it('parseModel("aq/amazon-q") should resolve provider to "amazon-q"', () => {
+    const parsed = parseModel("aq/amazon-q");
+    assert.equal(
+      parsed.provider,
+      "amazon-q",
+      `parseModel("aq/amazon-q") provider should be "amazon-q" but got "${parsed.provider}"`
+    );
+    assert.equal(parsed.model, "amazon-q");
+  });
+
+  it('getExecutor("amazon-q") should exist and be a KiroExecutor', () => {
+    const executor = getExecutor("amazon-q");
+    assert.ok(executor, "getExecutor('amazon-q') should return an executor");
+    assert.equal(
+      executor.constructor.name,
+      "KiroExecutor",
+      "amazon-q executor should be a KiroExecutor"
+    );
+  });
+});


### PR DESCRIPTION
Closes #9550

Root cause: `resolveProviderAlias("aq")` returns "aq" unchanged because `ALIAS_TO_PROVIDER_ID["aq"]` does not exist in `open-sse/services/model.ts`. The alias map is dynamically built from the registry (`PROVIDER_ID_TO_ALIAS`), and `amazon-q` has no registry entry — only `kiro` does. The manual overrides section (lines 40-55) has entries for `opencode`, `xiaomi`, `llamacpp`, and `agy`/antigravity — the exact same pattern that `aq`/amazon-q was missing.

Fix: added `ALIAS_TO_PROVIDER_ID["aq"] = "amazon-q";` to `open-sse/services/model.ts` alongside the other manual overrides.

Same bug class as #6699.

**TDD validation:**
- RED: repro test confirms 2/3 assertions fail on unfixed code (`resolveProviderAlias("aq")` returns "aq", `parseModel("aq/amazon-q")` returns provider "aq")
- GREEN: after fix, all 3 assertions pass
- 3 sibling test suites pass (model-parse, provider-alias-transitive-5918, model-alias-provider-resolution)
- ESLint clean, all quality gates pass