### PR TITLE
fix(proxy): NO_PROXY now bypasses context-level proxy in resolveProxyForRequest (#9551)

### DIFF
--- a/changelog.d/fixes/9551-proxyfetch-context-bypass.md
+++ b/changelog.d/fixes/9551-proxyfetch-context-bypass.md
@@ -1,0 +1,1 @@
+- fix(proxy): NO_PROXY now bypasses context-level proxy in resolveProxyForRequest (#9551)

--- a/open-sse/utils/proxyFetch.ts
+++ b/open-sse/utils/proxyFetch.ts
@@ -382,6 +382,10 @@ export function resolveProxyForRequest(targetUrl) {
 
   const contextProxy = proxyContext.getStore();
   if (contextProxy) {
+    // #9551: NO_PROXY must bypass context-proxy too
+    if (target && noProxyMatch(targetUrl)) {
+      return { source: "direct", proxyUrl: null };
+    }
     return { source: "context", proxyUrl: proxyConfigToUrl(contextProxy) };
   }
 

--- a/tests/unit/9551-proxyfetch-no-proxy-context-bypass.test.ts
+++ b/tests/unit/9551-proxyfetch-no-proxy-context-bypass.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runWithProxyContext, resolveProxyForRequest } from "../../open-sse/utils/proxyFetch.ts";
+
+async function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => unknown
+): Promise<unknown> {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test("[9551] BUG: context-proxy ignores NO_PROXY for non-local domains", async () => {
+  await withEnv(
+    {
+      NO_PROXY: "ark.cn-beijing.volces.com",
+      HTTP_PROXY: undefined,
+    },
+    async () => {
+      await runWithProxyContext({ type: "http", host: "127.0.0.1", port: 7897 }, () => {
+        const resolved = resolveProxyForRequest("https://ark.cn-beijing.volces.com/api/v3/models");
+        assert.equal(resolved.source, "direct", "NO_PROXY should bypass context proxy");
+      });
+    }
+  );
+});
+
+test("[9551] resolveProxyForRequest: context-proxy respects NO_PROXY=*", async () => {
+  await withEnv(
+    {
+      NO_PROXY: "*",
+      HTTP_PROXY: undefined,
+    },
+    async () => {
+      await runWithProxyContext({ type: "http", host: "127.0.0.1", port: 7897 }, () => {
+        const resolved = resolveProxyForRequest("https://api.openai.com/v1/chat/completions");
+        assert.equal(resolved.source, "direct", "NO_PROXY=* should bypass context proxy");
+      });
+    }
+  );
+});


### PR DESCRIPTION
Closes #9551

**Root cause:** `resolveProxyForRequest()` in `open-sse/utils/proxyFetch.ts` returned the AsyncLocalStorage context proxy without ever consulting `NO_PROXY`, so domains listed in `NO_PROXY` were still routed through the context proxy — effectively ignoring the user's explicit bypass directive.

**Fix:** Added a `noProxyMatch(targetUrl)` check before returning the context proxy (line 383-386). This mirrors the behavior already present in the env-proxy path (`resolveEnvProxyUrl` at line 346). The `noProxyMatch` function itself was already correct (handles exact hosts, wildcards, port-specific entries, dotted-prefix patterns) — it was simply never called from the context-proxy path.

**Regression test:** `tests/unit/9551-proxyfetch-no-proxy-context-bypass.test.ts` — 2 tests covering exact-host NO_PROXY and wildcard NO_PROXY=\\*.

**Gates:** eslint OK, complexity OK, cognitive-complexity OK, pre-commit hooks (docs-sync, any-budget, tracked-artifacts) OK.