### PR TITLE
fix(ci): include combo-matrix tests in test-integration job (#9531)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1213,8 +1213,10 @@ jobs:
           cache: npm
       - uses: ./.github/actions/npm-ci-retry
       - run: npm run check:node-runtime
-      # (tsx/esm = QW-b; o alinhamento de ESCOPO do integration com o npm script fica p/ follow-up)
-      - run: node --import tsx/esm --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 --test-shard=${{ matrix.shard }}/2 tests/integration/*.test.ts
+      - name: Integration tests (shard ${{ matrix.shard }}/2)
+        env:
+          TEST_SHARD: ${{ matrix.shard }}/2
+        run: npm run test:integration:ci
 
   test-security:
     name: Security Tests

--- a/changelog.d/fixes/9531-ci-combo-matrix.md
+++ b/changelog.d/fixes/9531-ci-combo-matrix.md
@@ -1,0 +1,1 @@
+- fix(ci): include combo-matrix tests in test-integration job (#9531)

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "backfill-aggregation": "node --import tsx src/scripts/backfillAggregation.ts",
     "env:sync": "node scripts/dev/sync-env.mjs",
     "test:integration": "cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/integration/*.test.ts \"tests/integration/combo-matrix/*.test.ts\"",
+    "test:integration:ci": "cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 --test-shard=$TEST_SHARD tests/integration/*.test.ts \"tests/integration/combo-matrix/*.test.ts\"",
     "test:combo:matrix": "cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 \"tests/integration/combo-matrix/*.test.ts\"",
     "test:combo:live": "cross-env RUN_COMBO_LIVE=1 DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 \"tests/integration/combo-live/*.live.test.ts\"",
     "test:combo:live:vps": "node scripts/test/combo-live-vps.mjs",


### PR DESCRIPTION
Closes #9531

The CI test-integration job ran an inline node command missing the
`tests/integration/combo-matrix/*.test.ts` glob (9 files covering weighted,
ordered, auto, quota-share, fusion, context-relay, etc.) and the
`setupPolyfill.ts` import, compared to the `test:integration` npm script.

**Fix**: Create a `test:integration:ci` npm script (matching the existing
`test:unit:ci:shard` pattern) as the single source of truth for the CI
command, and update `.github/workflows/ci.yml` to delegate to it instead
of an inline `node` command.

**Files changed**:
- `package.json` -- added `test:integration:ci` script with `$TEST_SHARD` env var
- `.github/workflows/ci.yml` -- replaced inline command with `npm run test:integration:ci`
- `changelog.d/fixes/9531-ci-combo-matrix.md` -- changelog fragment

**Gates verified**:
- eslint: exit 0
- check-file-size: no frozen files touched by diff
- check-changelog-integrity: fragment valid (pre-existing violation on unrelated file)
- husky pre-commit: docs-sync, any-budget, tracked-artifacts all PASS

This is a CI-configuration-only change -- no production code modified.