### PR TITLE
fix(search): mark searxng-search as fallbackOnly to prevent auto-select without instance (#9543)

### DIFF
--- a/changelog.d/fixes/9543-searxng-auto-select.md
+++ b/changelog.d/fixes/9543-searxng-auto-select.md
@@ -1,0 +1,1 @@
+- fix(search): mark searxng-search as fallbackOnly to prevent auto-select without instance (#9543)

--- a/open-sse/config/searchRegistry.ts
+++ b/open-sse/config/searchRegistry.ts
@@ -207,6 +207,7 @@ export const SEARCH_PROVIDERS: Record<string, SearchProviderConfig> = {
     maxMaxResults: 50,
     timeoutMs: 10_000,
     cacheTTLMs: 3 * 60 * 1000,
+    fallbackOnly: true,
   },
 
   "ollama-search": {

--- a/tests/unit/search-registry.test.ts
+++ b/tests/unit/search-registry.test.ts
@@ -201,7 +201,7 @@ test("selectProvider with unknown provider returns null", () => {
 test("selectProvider without argument returns cheapest provider", () => {
   const config = selectProvider();
   assert.ok(config);
-  assert.equal(config.id, "searxng-search");
+  assert.notEqual(config.id, "searxng-search");
 });
 
 test("selectProvider auto-selection never returns a fallbackOnly provider", () => {
@@ -223,7 +223,7 @@ test("selectProvider still honors an explicit fallbackOnly provider", () => {
 test("selectProvider filters by search type support", () => {
   const config = selectProvider(undefined, "news");
   assert.ok(config);
-  assert.equal(config.id, "searxng-search");
+  assert.equal(config.id, "serper-search");
   assert.equal(selectProvider("linkup-search", "news"), null);
 });
 

--- a/tests/unit/search-route.test.ts
+++ b/tests/unit/search-route.test.ts
@@ -417,7 +417,7 @@ test("v1 search POST preserves stored SearXNG baseUrl for authless providers", a
   }
 });
 
-test("v1 search POST auto-select uses authless SearXNG when no API-key providers are configured", async () => {
+test("v1 search POST returns 400 when auto-select finds no configured provider (searxng-search is now fallbackOnly)", async () => {
   const originalFetch = globalThis.fetch;
   let capturedUrl = "";
 
@@ -451,13 +451,8 @@ test("v1 search POST auto-select uses authless SearXNG when no API-key providers
     );
     const body = (await response.json()) as any;
 
-    assert.equal(response.status, 200);
-    assert.equal(
-      capturedUrl,
-      "http://localhost:8888/search?q=auto+select+self+hosted+search&format=json&categories=general"
-    );
-    assert.equal(body.provider, "searxng-search");
-    assert.equal(body.results[0].title, "Auto-selected SearXNG result");
+    assert.equal(response.status, 400);
+    assert.ok(body.error?.message || body.error);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/search-select-provider-searxng-bug-9543.test.ts
+++ b/tests/unit/search-select-provider-searxng-bug-9543.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { SEARCH_PROVIDERS, selectProvider } =
+  await import("../../open-sse/config/searchRegistry.ts");
+
+test("searxng-search has fallbackOnly: true (fix #9543)", () => {
+  const s = SEARCH_PROVIDERS["searxng-search"];
+  assert.ok(s);
+  assert.equal(s.authType, "none");
+  assert.equal(s.costPerQuery, 0);
+  assert.equal(s.fallbackOnly, true);
+});
+
+test("selectProvider does NOT auto-select searxng-search (fix #9543)", () => {
+  const auto = selectProvider();
+  assert.ok(auto);
+  assert.notEqual(auto.id, "searxng-search");
+});
+
+test("duckduckgo-free IS correctly fallbackOnly (design reference)", () => {
+  const d = SEARCH_PROVIDERS["duckduckgo-free"];
+  assert.equal(d.fallbackOnly, true);
+});
+
+test("selectProvider with explicit searxng-search still works", () => {
+  const explicit = selectProvider("searxng-search", "web");
+  assert.ok(explicit);
+  assert.equal(explicit.id, "searxng-search");
+});


### PR DESCRIPTION
Closes #9543

Root cause: selectProvider() in open-sse/config/searchRegistry.ts auto-selects the cheapest non-fallbackOnly search provider. searxng-search had costPerQuery:0 and authType:none but lacked fallbackOnly:true -- unlike duckduckgo-free which has the same cost/authType pattern and correctly IS fallbackOnly. This caused searxng-search to be auto-selected as the default provider even when no SearXNG instance was configured, producing $0.0000 results against the default localhost:8888 endpoint.

Fix: Added fallbackOnly:true to the searxng-search config entry. Explicit provider:"searxng-search" requests still work (selectProvider explicit path does not filter by fallbackOnly).

Regression test: tests/unit/search-select-provider-searxng-bug-9543.test.ts
- searxng-search has fallbackOnly:true
- selectProvider() does not auto-select searxng-search
- selectProvider with explicit searxng-search still works

Gates run green:
- 4 repro tests + 45 existing search-registry tests: all pass
- ESLint (with suppressions): clean
- Complexity/cognitive complexity: OK (no regressions)
- Typecheck: no errors in touched files (pre-existing base-red type errors in untouched files)