### PR TITLE
fix(radar): close the audit gaps — auth, merged feed fields, opt-in state, sidebar gate, size cap + daily scheduler

### DIFF
--- a/docs/frameworks/RADAR.md
+++ b/docs/frameworks/RADAR.md
@@ -1,17 +1,17 @@
 ---
 title: "Radar Free-Model Catalog"
 version: 3.8.50
-lastUpdated: 2026-08-05
+lastUpdated: 2026-08-07
 ---
 
 # Radar Free-Model Catalog
 
 > **Source of truth:** `src/lib/radar/`, `src/lib/db/radar.ts`, `src/app/api/radar/`
-> **Last updated:** 2026-08-05 — v3.8.50
+> **Last updated:** 2026-08-07 — v3.8.50
 
 Radar is an **optional add-on** that overlays a signed, freshly-curated free-model
 catalog on top of the release baseline (`FREE_MODEL_BUDGETS` in
-`open-sse/config/freeModelCatalog.ts`). It exists because the free-tier landscape moves
+`open-sse/config/freeModelCatalog.data.ts`). It exists because the free-tier landscape moves
 faster than release cadence — providers add, shrink, or discontinue free quotas between
 releases, and the baseline catalog can only be refreshed when a new version ships.
 
@@ -127,6 +127,24 @@ untouched. The cached payload is defensively re-validated again on every read
 (`getRadarCatalog()`) — a corrupted or hand-edited cache row falls back to the
 baseline rather than being served.
 
+### Response size cap (10 MB)
+
+`syncRadar()` enforces a **10 MB hard cap** on the feed response body — the signed
+feed is a KB-scale JSON document, so anything past this points at a misconfigured or
+hostile `RADAR_FEED_URL` (or an upstream serving garbage), not a legitimate catalog.
+Enforcement is two-layered:
+
+1. A `Content-Length` preflight check skips reading the body entirely when the
+   header already declares a value over the cap.
+2. A running-total check while reading the body enforces the cap even when
+   `Content-Length` is absent or understates the real size — the header is never
+   trusted on its own. Concatenating the accumulated chunks preserves the exact
+   bytes needed for the Ed25519 signature check afterward.
+
+Exceeding the cap returns `{ status: "too_large" }` and leaves the cache untouched,
+following the same non-destructive pattern as every other sync failure
+(`invalid_signature`, `invalid_schema`, `stale`).
+
 ---
 
 ## Tiers: `community` and `live`
@@ -145,6 +163,28 @@ error.** The sync path only distinguishes signature/schema/version failures (all
 recoverable, all non-fatal to the cached state) from a successful `{ status:
 "updated", version, tier }`. There is no tier-specific error path a client needs to
 handle.
+
+### The served tier comes from a response header, not the signed body
+
+The signed feed **body**'s `tier` field is always `"live"` — the feed service ships
+**one signed artifact per version**, so the body cannot carry a per-request tier
+without invalidating the Ed25519 signature (re-signing per request would defeat the
+point of a pinned, cacheable, verifiable artifact). The tier actually served for a
+given request is instead carried in the **`x-omniroute-feed-tier` response header**,
+decided server-side from the request's `Authorization` key.
+
+`syncRadar()` (`src/lib/radar/sync.ts::parseServedTierHeader()`) is the single place
+that resolves the tier a client should trust:
+
+1. Parse `x-omniroute-feed-tier` with `RadarTierSchema` (Zod) — an absent header, or
+   a value that isn't exactly `"community"` or `"live"`, is treated as **not
+   present** (never trusted into the cache/UI as-is; this also covers older feed
+   servers that predate the header).
+2. Fall back to the signed body's `tier` field (always `"live"`) only when step 1
+   yields nothing.
+3. The resolved tier is what gets cached and returned as `{ status: "updated",
+   version, tier }` — this is the value the dashboard shows, never the raw body
+   field.
 
 ---
 
@@ -183,13 +223,14 @@ Every merged entry carries an `origin` field the UI renders as a badge:
 
 ## Local surfaces — never a feed proxy
 
-Three local routes back the UI, all under `src/app/api/radar/`:
+Four local routes back the UI, all under `src/app/api/radar/`:
 
-| Route                 | Method | Purpose                                                                |
-| --------------------- | ------ | ---------------------------------------------------------------------- |
-| `/api/radar/catalog`  | GET    | Returns the merged catalog (`getRadarCatalog()`) from the local cache. |
-| `/api/radar/sync`     | POST   | Triggers `syncRadar()` server-side; returns the resulting status.      |
-| `/api/radar/settings` | POST   | Sets opt-in and/or the (encrypted) supporter key.                      |
+| Route                 | Method | Purpose                                                                                          |
+| --------------------- | ------ | -------------------------------------------------------------------------------------------------- |
+| `/api/radar/catalog`  | GET    | Returns the merged catalog (`getRadarCatalog()`) from the local cache.                            |
+| `/api/radar/sync`     | POST   | Triggers `syncRadar()` server-side; returns the resulting status.                                 |
+| `/api/radar/settings` | GET    | Returns `{ optIn, hasSupporterKey, supporterKeyMasked }` — never the raw key.                     |
+| `/api/radar/settings` | POST   | Sets opt-in and/or the (encrypted) supporter key.                                                 |
 
 **Hard rule: these routes never proxy the feed service.** The browser only ever talks
 to the local OmniRoute server; `syncRadar()` is the single module in the whole client
@@ -197,10 +238,21 @@ that touches the network for Radar (`src/lib/radar/sync.ts`), and it always runs
 server-side, never client-side. This keeps the feed URL and any supporter key
 out of client-facing network traffic entirely.
 
-All three routes return `404` when `RADAR_ENABLED` is off (see
+All four routes return `404` when `RADAR_ENABLED` is off (see
 [Flag](#flag-radar_enabled-default-off) above), and route error responses through
 `buildErrorBody()`/`sanitizeErrorMessage()` per the repo-wide error-sanitization rule
 (`docs/security/ERROR_SANITIZATION.md`).
+
+### Authentication
+
+All four routes require authentication via `isAuthenticated()`
+(`src/shared/utils/apiAuth.ts`) — a dashboard session cookie or a management-scoped
+API key, the same gate that protects the rest of `/api/settings/*`. The flag-off
+`404` check always runs **before** the auth check, so an install with `RADAR_ENABLED`
+off stays byte-identical (no auth prompt just to learn the surface doesn't exist);
+once the flag is on, an unauthenticated request gets `401` before any DB read or
+write. `GET /api/radar/settings` never returns the raw supporter key regardless of
+auth state — only the masked form and a `hasSupporterKey` boolean.
 
 ---
 

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -1281,7 +1281,7 @@ self-hosted or forked feed instead of the default OmniRoute Radar feed. See
 
 | Variable            | Default                        | Source File                   | Description                                                                                     |
 | -------------------- | ------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `RADAR_FEED_URL`    | `https://radar.omniroute.dev`  | `src/lib/radar/sync.ts`       | Base URL of the Radar feed service. Override to point at a self-hosted or forked feed.          |
+| `RADAR_FEED_URL`    | `https://radar.omniroute.online`  | `src/lib/radar/sync.ts`       | Base URL of the Radar feed service. Override to point at a self-hosted or forked feed.          |
 | `RADAR_FEED_PUBKEY` | _(pinned default key)_          | `src/lib/radar/pinnedKeys.ts` | Ed25519 public key (base64-DER SPKI or PEM) used to verify feed signatures from a custom feed.   |
 
 ---

--- a/src/app/(dashboard)/dashboard/radar/page.tsx
+++ b/src/app/(dashboard)/dashboard/radar/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Card } from "@/shared/components";
+import { shouldAutoSyncOnOpen } from "@/lib/radar/autoSync";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -183,6 +184,19 @@ export default function RadarPage() {
       setSyncing(false);
     }
   }, [t, fetchCatalog]);
+
+  // Auto-sync on open: when the operator is already opted in and the cached
+  // feed is stale (or absent), refresh it automatically once per mount so the
+  // page always shows current data without requiring the manual Sync button
+  // (spec: dados atualizados a cada abrir da página). The ref guards against
+  // re-firing when `meta` updates after the sync itself.
+  const autoSyncFiredRef = useRef(false);
+  useEffect(() => {
+    if (loading || syncing || optIn !== true || autoSyncFiredRef.current) return;
+    if (!shouldAutoSyncOnOpen(meta?.fetchedAt ?? null, Date.now())) return;
+    autoSyncFiredRef.current = true;
+    void handleSync();
+  }, [loading, syncing, optIn, meta, handleSync]);
 
   // Activate opt-in
   const handleActivate = useCallback(async () => {

--- a/src/app/(dashboard)/dashboard/radar/page.tsx
+++ b/src/app/(dashboard)/dashboard/radar/page.tsx
@@ -126,32 +126,32 @@ export default function RadarPage() {
     }
   }, [t]);
 
-  // Fetch settings to determine opt-in state
+  // Fetch settings to determine opt-in state (GET /api/radar/settings — FIX 3:
+  // previously there was no settings GET, so an already-opted-in operator saw
+  // the activation screen on every reload).
   const fetchSettings = useCallback(async () => {
     try {
-      // We don't have a GET /api/radar/settings — infer from catalog response:
-      // If catalog returns meta=null and entries are baseline-only, user hasn't opted in.
-      // A 404 means flag is off.
-      const res = await fetch("/api/radar/catalog");
-      if (res.status === 404) {
+      const settingsRes = await fetch("/api/radar/settings");
+      if (settingsRes.status === 404) {
+        // Flag off
         setOptIn(false);
         return;
       }
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      setEntries(data.entries || []);
-      setMeta(data.meta || null);
-      // If meta is null, the user hasn't synced yet (or hasn't opted in).
-      // We need to check opt-in state. Since there's no GET endpoint for settings,
-      // we infer: if flag is on and we got baseline, user may or may not be opted in.
-      // The activation flow handles this — we show the activation screen if meta is null.
-      setOptIn(null); // unknown — will determine from user action
+      if (!settingsRes.ok) throw new Error(`HTTP ${settingsRes.status}`);
+      const settingsData = await settingsRes.json();
+      setOptIn(settingsData.optIn === true);
+
+      if (settingsData.optIn === true) {
+        // Already opted in — load the catalog now so the populated/empty
+        // state renders immediately instead of waiting for a manual sync.
+        await fetchCatalog();
+      }
     } catch {
       setOptIn(null);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fetchCatalog]);
 
   useEffect(() => {
     fetchSettings();
@@ -167,7 +167,10 @@ export default function RadarPage() {
       const data = await res.json();
       if (data.status === "updated" || data.status === "stale") {
         await fetchCatalog();
-      } else if (data.status === "error") {
+      } else if (data.status === "error" || data.status === "too_large") {
+        // "too_large" reuses the generic sync-failed copy — the feed exceeded the
+        // client-side size cap (10MB), which is operationally the same as any
+        // other sync failure from the operator's point of view.
         setError(data.reason || t("syncFailed"));
       } else if (data.status === "disabled") {
         setError(t("flagDisabled"));

--- a/src/app/api/radar/catalog/route.ts
+++ b/src/app/api/radar/catalog/route.ts
@@ -4,12 +4,16 @@
  * NEVER proxies the private feed server. The browser talks only to this
  * local endpoint; sync happens server-side via POST /api/radar/sync.
  *
- * Flag off => 404 (the surface doesn't exist when disabled).
+ * Flag off => 404 (the surface doesn't exist when disabled), checked BEFORE
+ * auth so flag-off inertia stays byte-identical (no auth required to learn
+ * the surface doesn't exist). Unauthenticated access once the flag is on
+ * => 401 (management route — dashboard session or a management-scoped key).
  */
 
 import { NextResponse } from "next/server";
 import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
 import { getRadarCatalog } from "@/lib/radar";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 
@@ -20,12 +24,19 @@ export async function OPTIONS() {
   return handleCorsOptions();
 }
 
-export async function GET() {
-  // Flag gate — surface doesn't exist when disabled
+export async function GET(request: Request) {
+  // Flag gate — surface doesn't exist when disabled. MUST run before auth.
   if (!isFeatureFlagEnabled("RADAR_ENABLED")) {
     return NextResponse.json(
       buildErrorBody(404, "Not found"),
       { status: 404, headers: CORS_HEADERS },
+    );
+  }
+
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json(
+      buildErrorBody(401, "Unauthorized"),
+      { status: 401, headers: CORS_HEADERS },
     );
   }
 

--- a/src/app/api/radar/settings/route.ts
+++ b/src/app/api/radar/settings/route.ts
@@ -1,18 +1,27 @@
 /**
+ * GET /api/radar/settings — read the current Radar opt-in + supporter-key
+ * snapshot. Powers the dashboard page's "am I already opted in?" check so
+ * a reload doesn't re-show the activation screen (see FIX 3).
+ *
  * POST /api/radar/settings — set Radar opt-in and/or supporter key.
  *
  * Zod-validated body: { optIn?: boolean, supporterKey?: string|null }
  * Key shape: "omr_" + 40 hex chars.
  *
- * NEVER echoes the key back — returns a masked form instead.
- * Flag off => 404.
+ * NEVER echoes the raw key back on either verb — GET returns a masked form
+ * ("omr_****" + last 4 hex chars) and a `hasSupporterKey` boolean; POST
+ * returns the same masked form.
+ *
+ * Flag off => 404, checked BEFORE auth (byte-identical flag-off inertia).
+ * Unauthenticated access once the flag is on => 401.
  */
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
-import { setRadarOptIn, setRadarKey } from "@/lib/db/radar";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
+import { setRadarOptIn, setRadarKey, getRadarSettings } from "@/lib/db/radar";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 
 export const dynamic = "force-dynamic";
@@ -43,12 +52,54 @@ export async function OPTIONS() {
   return handleCorsOptions();
 }
 
-export async function POST(request: Request) {
-  // Flag gate
+export async function GET(request: Request) {
+  // Flag gate — MUST run before auth (byte-identical flag-off inertia).
   if (!isFeatureFlagEnabled("RADAR_ENABLED")) {
     return NextResponse.json(
       buildErrorBody(404, "Not found"),
       { status: 404, headers: CORS_HEADERS },
+    );
+  }
+
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json(
+      buildErrorBody(401, "Unauthorized"),
+      { status: 401, headers: CORS_HEADERS },
+    );
+  }
+
+  try {
+    const settings = getRadarSettings();
+    return NextResponse.json(
+      {
+        optIn: settings.optIn,
+        hasSupporterKey: settings.supporterKey !== null,
+        supporterKeyMasked: maskKey(settings.supporterKey),
+      },
+      { headers: { ...CORS_HEADERS, "Cache-Control": "no-store" } },
+    );
+  } catch (err: unknown) {
+    const { sanitizeErrorMessage } = await import("@omniroute/open-sse/utils/error");
+    return NextResponse.json(
+      buildErrorBody(500, sanitizeErrorMessage(err) || "Failed to load Radar settings"),
+      { status: 500, headers: CORS_HEADERS },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  // Flag gate — MUST run before auth (byte-identical flag-off inertia).
+  if (!isFeatureFlagEnabled("RADAR_ENABLED")) {
+    return NextResponse.json(
+      buildErrorBody(404, "Not found"),
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json(
+      buildErrorBody(401, "Unauthorized"),
+      { status: 401, headers: CORS_HEADERS },
     );
   }
 

--- a/src/app/api/radar/settings/route.ts
+++ b/src/app/api/radar/settings/route.ts
@@ -134,6 +134,17 @@ export async function POST(request: Request) {
   try {
     if (optIn !== undefined) {
       setRadarOptIn(optIn);
+      if (optIn) {
+        // Opting in is the moment the daily background sync becomes wanted —
+        // arm the scheduler lazily so a flag-off/opt-out install never even
+        // creates the timer (Radar inertia contract). Never fatal.
+        try {
+          const { ensureRadarSyncScheduler } = await import("@/lib/radar/scheduler");
+          ensureRadarSyncScheduler();
+        } catch {
+          // Scheduler is best-effort; manual sync keeps working without it.
+        }
+      }
     }
     if (supporterKey !== undefined) {
       setRadarKey(supporterKey);

--- a/src/app/api/radar/sync/route.ts
+++ b/src/app/api/radar/sync/route.ts
@@ -5,13 +5,15 @@
  * verification, schema validation, version floor). Returns the status
  * object. Never proxies the feed URL to the client.
  *
- * Flag off => 404.
+ * Flag off => 404, checked BEFORE auth (byte-identical flag-off inertia).
+ * Unauthenticated access once the flag is on => 401.
  */
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
 import { syncRadar } from "@/lib/radar/sync";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 
@@ -26,11 +28,18 @@ export async function OPTIONS() {
 }
 
 export async function POST(request: Request) {
-  // Flag gate
+  // Flag gate — MUST run before auth (byte-identical flag-off inertia).
   if (!isFeatureFlagEnabled("RADAR_ENABLED")) {
     return NextResponse.json(
       buildErrorBody(404, "Not found"),
       { status: 404, headers: CORS_HEADERS },
+    );
+  }
+
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json(
+      buildErrorBody(401, "Unauthorized"),
+      { status: 401, headers: CORS_HEADERS },
     );
   }
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -5,6 +5,7 @@ import { getRuntimePorts } from "@/lib/runtime/ports";
 import { updateSettingsSchema } from "@/shared/validation/settingsSchemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
+import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
 import { resolveModelLockoutSettings } from "@/lib/resilience/modelLockoutSettings";
 import {
   validateProxyUrl,
@@ -220,6 +221,12 @@ export async function GET(request: Request) {
         cloudConfigured: Boolean(cloudUrl),
         cloudUrl,
         machineId,
+        // Sidebar.tsx has no server-side feature-flag access (client component);
+        // this piggy-backs the RADAR_ENABLED gate onto the settings payload the
+        // sidebar already fetches on mount, so the "radar" item can hide itself
+        // without a dedicated round trip. See sidebarVisibility.ts's
+        // `isSidebarItemVisibleForFlags()`.
+        radarEnabled: isFeatureFlagEnabled("RADAR_ENABLED"),
         ...(cliproxyapiModelMapping !== null
           ? { cliproxyapi_model_mapping: cliproxyapiModelMapping }
           : {}),

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -543,6 +543,19 @@ export async function registerNodejs(): Promise<void> {
           console.warn("[STARTUP] Arena ELO sync failed to start (non-fatal):", msg);
         }),
 
+      // Radar daily feed sync: only arms itself when RADAR_ENABLED AND the user
+      // opt-in are already on (flag-off boot stays timer-free — Radar inertia
+      // contract). Non-blocking, never fatal.
+      import("@/lib/radar/scheduler")
+        .then((m) => {
+          const started = m.initRadarSyncScheduler();
+          if (started) console.log("[STARTUP] Radar sync scheduler initialized");
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn("[STARTUP] Radar sync scheduler failed to start (non-fatal):", msg);
+        }),
+
       // Pricing sync: opt-in external pricing data (self-gated by PRICING_SYNC_ENABLED inside
       // initPricingSync). Non-blocking, never fatal.
       import("@/lib/pricingSync")

--- a/src/lib/radar/applyFeed.ts
+++ b/src/lib/radar/applyFeed.ts
@@ -51,6 +51,30 @@ export interface MergedEntry {
    * Absent for entries disabled by other means or still enabled.
    */
   disabledBy?: "radar";
+  /**
+   * Context window size in tokens. Only present on entries that carry feed
+   * data (origin "radar"/"local" merged from a feed entry); undefined for
+   * baseline-only entries.
+   */
+  contextWindow?: number | null;
+  /** Capability flags reported by the feed. Undefined for baseline-only entries. */
+  capabilities?: {
+    tools: boolean;
+    vision: boolean;
+    thinking: boolean;
+  };
+  /** Rate/quota limits reported by the feed. Undefined for baseline-only entries. */
+  limits?: {
+    rpm: number | null;
+    rpd: number | null;
+    tpm: number | null;
+    tpd: number | null;
+  };
+  /** Setup guide (key URL + steps) reported by the feed. Undefined for baseline-only entries. */
+  setup?: {
+    keyUrl: string | null;
+    steps: string[];
+  } | null;
 }
 
 /**
@@ -254,6 +278,18 @@ function mergeOne(
   if (!overriddenKeys.has("creditTokens")) {
     // Feed doesn't have creditTokens; keep baseline
   }
+  if (!overriddenKeys.has("contextWindow")) {
+    result.contextWindow = feed.contextWindow;
+  }
+  if (!overriddenKeys.has("capabilities")) {
+    result.capabilities = feed.capabilities;
+  }
+  if (!overriddenKeys.has("limits")) {
+    result.limits = feed.limits;
+  }
+  if (!overriddenKeys.has("setup")) {
+    result.setup = feed.setup;
+  }
 
   // Apply local overrides (rule 1: they win)
   if (overrides) {
@@ -265,6 +301,10 @@ function mergeOne(
     if (overrides.tos !== undefined) result.tos = overrides.tos;
     if (overrides.trainsOnPrompts !== undefined) result.trainsOnPrompts = overrides.trainsOnPrompts;
     if (overrides.enabled !== undefined) result.enabled = overrides.enabled;
+    if (overrides.contextWindow !== undefined) result.contextWindow = overrides.contextWindow;
+    if (overrides.capabilities !== undefined) result.capabilities = overrides.capabilities;
+    if (overrides.limits !== undefined) result.limits = overrides.limits;
+    if (overrides.setup !== undefined) result.setup = overrides.setup;
   }
 
   // Origin: "local" if user has overrides, else "radar" (feed updated it)
@@ -292,9 +332,16 @@ function feedModelToMerged(
     trainsOnPrompts: overrides?.trainsOnPrompts ?? (feed.trainsOnPrompts ?? undefined),
     enabled: overrides?.enabled ?? feed.enabled,
     origin: overrides ? "local" : "radar",
+    contextWindow: overrides?.contextWindow ?? feed.contextWindow,
+    capabilities: overrides?.capabilities ?? feed.capabilities,
+    limits: overrides?.limits ?? feed.limits,
+    setup: overrides?.setup ?? feed.setup,
   };
 
-  if (!feed.enabled) {
+  // Rule 2 (feed disable) — but rule 1 (local override wins) takes precedence,
+  // matching mergeOne(): only force-disable when the user has NOT explicitly
+  // overridden `enabled` locally.
+  if (!feed.enabled && overrides?.enabled === undefined) {
     entry.enabled = false;
     entry.disabledBy = "radar";
   }

--- a/src/lib/radar/autoSync.ts
+++ b/src/lib/radar/autoSync.ts
@@ -1,0 +1,27 @@
+/**
+ * autoSync.ts — pure staleness rule shared by the Radar page (client) and the
+ * background scheduler (server).
+ *
+ * Kept free of any server-only import (db, sync) so the "use client" Radar
+ * page can consume it directly.
+ */
+
+/** Cache older than this triggers an automatic sync when the page opens. */
+export const AUTO_SYNC_STALE_MS = 6 * 60 * 60 * 1000; // 6h
+
+/**
+ * Whether an automatic sync should fire for a cache fetched at `fetchedAt`.
+ *
+ * Missing or unparseable timestamps count as stale — the only way to get a
+ * fresh verdict is a real, recent fetch.
+ */
+export function shouldAutoSyncOnOpen(
+  fetchedAt: string | null | undefined,
+  nowMs: number,
+  staleMs: number = AUTO_SYNC_STALE_MS
+): boolean {
+  if (!fetchedAt) return true;
+  const fetchedMs = Date.parse(fetchedAt);
+  if (!Number.isFinite(fetchedMs)) return true;
+  return nowMs - fetchedMs >= staleMs;
+}

--- a/src/lib/radar/scheduler.ts
+++ b/src/lib/radar/scheduler.ts
@@ -1,0 +1,114 @@
+/**
+ * scheduler.ts — daily background sync for the Radar feed (spec: "GET 1×/dia,
+ * só quando opt-in").
+ *
+ * Inertia contract: a flag-off boot NEVER creates a timer. The scheduler only
+ * starts from (a) `initRadarSyncScheduler()` at boot when the flag AND the
+ * user opt-in are already on, or (b) the settings route right after the user
+ * opts in. If the flag is later turned off, the next tick stops the timer —
+ * returning the process to the zero-timer state.
+ *
+ * The tick itself is cheap (one flag lookup + one DB row) and only performs a
+ * network sync when the cache is older than the daily window computed by
+ * `nextSyncTime()`. `syncRadar()` re-checks flag/opt-in internally, so a
+ * mid-flight settings change degrades to a no-op instead of an errant fetch.
+ */
+
+import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
+import { getRadarCache, getRadarSettings } from "@/lib/db/radar";
+import { nextSyncTime, syncRadar, type SyncStatus } from "./sync";
+
+/** How often the scheduler re-evaluates staleness (NOT the sync cadence). */
+export const RADAR_SCHEDULER_TICK_MS = 60 * 60 * 1000; // hourly
+
+export type RadarTickResult =
+  | { action: "stopped"; reason: "flag_off" }
+  | { action: "skipped"; reason: "opt_out" | "not_due" }
+  | { action: "synced"; result: SyncStatus };
+
+export interface RadarSchedulerDeps {
+  getFlag?: (key: string) => boolean;
+  getSettings?: () => { optIn: boolean };
+  getCache?: () => { fetchedAt: string } | null;
+  sync?: () => Promise<SyncStatus>;
+  now?: () => number;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * One scheduler evaluation. Exported for tests and for the immediate
+ * post-start tick.
+ */
+export async function radarSchedulerTick(deps: RadarSchedulerDeps = {}): Promise<RadarTickResult> {
+  const getFlag = deps.getFlag ?? isFeatureFlagEnabled;
+  if (!getFlag("RADAR_ENABLED")) {
+    stopRadarSyncScheduler(deps);
+    return { action: "stopped", reason: "flag_off" };
+  }
+
+  const settings = (deps.getSettings ?? getRadarSettings)();
+  if (!settings.optIn) return { action: "skipped", reason: "opt_out" };
+
+  const cache = (deps.getCache ?? getRadarCache)();
+  const nowMs = (deps.now ?? Date.now)();
+  if (nowMs < nextSyncTime(cache?.fetchedAt ?? null).getTime()) {
+    return { action: "skipped", reason: "not_due" };
+  }
+
+  const result = await (deps.sync ?? syncRadar)();
+  return { action: "synced", result };
+}
+
+/**
+ * Start the hourly staleness timer (idempotent). Fires one immediate,
+ * non-blocking tick so a due sync happens right away instead of waiting a
+ * full tick interval. Returns whether a new timer was created.
+ */
+export function ensureRadarSyncScheduler(deps: RadarSchedulerDeps = {}): boolean {
+  if (timer) return false;
+
+  const tick = () => {
+    radarSchedulerTick(deps).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[RADAR_SYNC] Scheduled sync tick failed (non-fatal):", msg);
+    });
+  };
+
+  timer = (deps.setIntervalFn ?? setInterval)(tick, RADAR_SCHEDULER_TICK_MS);
+  // Never keep the process alive just for this timer.
+  if (timer && typeof timer === "object" && "unref" in timer) {
+    (timer as { unref?: () => void }).unref?.();
+  }
+  tick();
+  return true;
+}
+
+/** Stop the timer (used by the flag-off self-heal and by tests). */
+export function stopRadarSyncScheduler(deps: RadarSchedulerDeps = {}): void {
+  if (timer) {
+    (deps.clearIntervalFn ?? clearInterval)(timer);
+    timer = null;
+  }
+}
+
+/**
+ * Boot-time init: only arms the scheduler when the flag AND the opt-in are
+ * already on (a flag-off install stays byte-identical — no timer, no DB
+ * polling loop). Never throws.
+ */
+export function initRadarSyncScheduler(deps: RadarSchedulerDeps = {}): boolean {
+  try {
+    const getFlag = deps.getFlag ?? isFeatureFlagEnabled;
+    if (!getFlag("RADAR_ENABLED")) return false;
+    const settings = (deps.getSettings ?? getRadarSettings)();
+    if (!settings.optIn) return false;
+    return ensureRadarSyncScheduler(deps);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("[RADAR_SYNC] Scheduler init failed (non-fatal):", msg);
+    return false;
+  }
+}

--- a/src/lib/radar/sync.ts
+++ b/src/lib/radar/sync.ts
@@ -28,6 +28,17 @@ const DEFAULT_FEED_BASE_URL = "https://radar.omniroute.online";
 
 const SYNC_TIMEOUT_MS = 30_000;
 
+/**
+ * Hard cap on the Radar feed response body. The signed feed is a small JSON
+ * document (KB-scale) — anything past this is either a misconfigured/hostile
+ * `RADAR_FEED_URL` or an upstream serving garbage. Enforced both via a
+ * `Content-Length` preflight (skip reading the body entirely when the
+ * server already declares an oversized payload) AND a running-total check
+ * while reading the body (an absent/lying Content-Length must not bypass
+ * the cap).
+ */
+const MAX_FEED_BYTES = 10 * 1024 * 1024; // 10 MB
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -38,6 +49,7 @@ export type SyncStatus =
   | { status: "invalid_signature" }
   | { status: "invalid_schema" }
   | { status: "stale" }
+  | { status: "too_large" }
   | { status: "updated"; version: string; tier: string }
   | { status: "error"; reason: string };
 
@@ -189,8 +201,54 @@ export async function syncRadar(deps: SyncDeps = {}): Promise<SyncStatus> {
       return { status: "error", reason: `Feed request failed with status ${res.status}` };
     }
 
-    // Step 4: Read exact bytes + signature header
-    const rawBytes = Buffer.from(await res.arrayBuffer());
+    // Step 3b: Content-Length preflight — skip reading an already-oversized
+    // body entirely. The header is untrusted (may be absent or wrong), so
+    // this is a fast-path only; the real enforcement is the running-total
+    // check below.
+    const contentLengthHeader = res.headers.get("content-length");
+    if (contentLengthHeader !== null) {
+      const declaredLength = Number(contentLengthHeader);
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_FEED_BYTES) {
+        return { status: "too_large" };
+      }
+    }
+
+    // Step 4: Read exact bytes + signature header, enforcing MAX_FEED_BYTES
+    // while reading so an absent/lying Content-Length cannot bypass the cap.
+    // Concatenating the accumulated chunks preserves the exact bytes needed
+    // for signature verification below.
+    let rawBytes: Buffer;
+    const body = res.body as ReadableStream<Uint8Array> | null | undefined;
+    if (body && typeof body.getReader === "function") {
+      const reader = body.getReader();
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      let tooLarge = false;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          total += value.byteLength;
+          if (total > MAX_FEED_BYTES) {
+            tooLarge = true;
+            await reader.cancel().catch(() => {});
+            break;
+          }
+          chunks.push(value);
+        }
+      }
+      if (tooLarge) {
+        return { status: "too_large" };
+      }
+      rawBytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    } else {
+      const buffered = Buffer.from(await res.arrayBuffer());
+      if (buffered.byteLength > MAX_FEED_BYTES) {
+        return { status: "too_large" };
+      }
+      rawBytes = buffered;
+    }
+
     const signature = res.headers.get("x-omniroute-feed-signature") ?? "";
 
     // Step 5: Verify signature

--- a/src/server-init.ts
+++ b/src/server-init.ts
@@ -151,6 +151,16 @@ async function startServer() {
   } catch (err) {
     startupLog.warn({ error: getErrorMessage(err) }, "Arena ELO sync could not initialize");
   }
+
+  // Radar daily feed sync: only arms itself when RADAR_ENABLED AND the user
+  // opt-in are already on (a flag-off boot stays timer-free — Radar inertia
+  // contract). Non-blocking, never fatal.
+  try {
+    const { initRadarSyncScheduler } = await import("./lib/radar/scheduler");
+    initRadarSyncScheduler();
+  } catch (err) {
+    startupLog.warn({ error: getErrorMessage(err) }, "Radar sync scheduler could not initialize");
+  }
 }
 
 // Start the server initialization

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
   applySectionOrder,
   applyItemOrder,
   getSidebarIconAccent,
+  isSidebarItemVisibleForFlags,
   type SidebarSectionId,
   type SidebarItemDefinition,
   type SidebarItemGroup,
@@ -99,6 +100,10 @@ export default function Sidebar({
   const [showDebug, setShowDebug] = useState(false);
   const [hiddenSidebarItems, setHiddenSidebarItems] = useState<string[]>([]);
   const [hiddenSidebarGroupLabels, setHiddenSidebarGroupLabels] = useState<string[]>([]);
+  // Feature-flag map for flag-gated items (e.g. "radar" -> RADAR_ENABLED).
+  // Fails open (see isSidebarItemVisibleForFlags) so a missing key never
+  // hides an unrelated item — only set once /api/settings resolves.
+  const [featureFlags, setFeatureFlags] = useState<Record<string, boolean>>({});
   const [sidebarSectionOrder, setSidebarSectionOrder] = useState<SidebarSectionId[]>([]);
   const [sidebarItemOrder, setSidebarItemOrder] = useState<SidebarItemOrder>({});
   const [customAppName, setCustomAppName] = useState<string | null>(null);
@@ -147,6 +152,9 @@ export default function Sidebar({
       );
       setCustomAppName(data?.instanceName || null);
       setCustomLogo(data?.customLogoBase64 || data?.customLogoUrl || null);
+      if (typeof data?.radarEnabled === "boolean") {
+        setFeatureFlags((prev) => ({ ...prev, RADAR_ENABLED: data.radarEnabled }));
+      }
     };
 
     fetch("/api/settings")
@@ -206,6 +214,7 @@ export default function Sidebar({
 
   const resolveItem = (item: SidebarItemDefinition, hidden: Set<string>) => {
     if (hidden.has(item.id)) return null;
+    if (!isSidebarItemVisibleForFlags(item, featureFlags)) return null;
     const subtitle = item.subtitleKey
       ? getSidebarLabel(item.subtitleKey, item.subtitleFallback ?? "")
       : item.subtitleFallback;

--- a/src/shared/constants/sidebarVisibility.ts
+++ b/src/shared/constants/sidebarVisibility.ts
@@ -126,6 +126,21 @@ export function getSidebarIconAccent(id: string): string {
   );
 }
 
+/**
+ * Decide whether a sidebar item should be shown given a resolved feature-flag
+ * map. Items without `featureFlagKey` are always visible. Fails OPEN when the
+ * flag isn't present in the map (e.g. `/api/settings` hasn't returned yet, or
+ * an older server response predates the flag) — a missing entry must never
+ * hide an unrelated item.
+ */
+export function isSidebarItemVisibleForFlags(
+  item: Pick<SidebarItemDefinition, "featureFlagKey">,
+  flags: Record<string, boolean>
+): boolean {
+  if (!item.featureFlagKey) return true;
+  return flags[item.featureFlagKey] !== false;
+}
+
 export function getSectionItems(
   section: SidebarSectionDefinition | { children: readonly SidebarSectionChild[] }
 ): readonly SidebarItemDefinition[] {

--- a/src/shared/constants/sidebarVisibility/sections.ts
+++ b/src/shared/constants/sidebarVisibility/sections.ts
@@ -469,6 +469,7 @@ const COSTS_ITEMS: readonly SidebarItemDefinition[] = [
     i18nKey: "radar",
     subtitleKey: "radarSubtitle",
     icon: "radar",
+    featureFlagKey: "RADAR_ENABLED",
   },
 ];
 

--- a/src/shared/constants/sidebarVisibility/types.ts
+++ b/src/shared/constants/sidebarVisibility/types.ts
@@ -138,6 +138,15 @@ export interface SidebarItemDefinition {
   icon: string;
   exact?: boolean;
   external?: boolean;
+  /**
+   * Opt-in feature-flag gate. When present, the item is only shown while the
+   * named flag resolves to `true` server-side. Sidebar.tsx has no built-in
+   * feature-flag awareness — the flag's resolved value is fetched once
+   * (piggy-backed on the existing `/api/settings` call) and passed through
+   * `isSidebarItemVisibleForFlags()` alongside the existing hidden-items
+   * filter. Add new flag keys to this union as new flag-gated items appear.
+   */
+  featureFlagKey?: "RADAR_ENABLED";
 }
 
 export interface SidebarItemGroup {

--- a/tests/unit/radar-api-routes.test.ts
+++ b/tests/unit/radar-api-routes.test.ts
@@ -2,9 +2,14 @@
  * tests/unit/radar-api-routes.test.ts
  *
  * TDD regression guard for the Radar API routes:
- * - GET /api/radar/catalog: flag off => 404, flag on => shape validated
- * - POST /api/radar/sync: flag off => 404, flag on => delegates to syncRadar
- * - POST /api/radar/settings: flag off => 404, never echoes clear key
+ * - GET /api/radar/catalog: flag off => 404, flag on + no auth => 401, flag on + auth => shape validated
+ * - POST /api/radar/sync: flag off => 404, flag on + no auth => 401, flag on + auth => delegates to syncRadar
+ * - POST /api/radar/settings: flag off => 404, flag on + no auth => 401, never echoes clear key
+ * - GET /api/radar/settings: flag off => 404, flag on + no auth => 401, flag on + auth => masked snapshot
+ *
+ * Auth wiring (FIX 1 / FIX 3): the flag-off 404 gate must run BEFORE the auth
+ * check (byte-identical inertia with the flag off, no auth required to learn
+ * the surface doesn't exist), auth runs AFTER it and before any DB read/write.
  *
  * Error responses must NOT leak stack traces (Hard Rule #12).
  */
@@ -14,6 +19,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { SignJWT } from "jose";
 
 // ---------------------------------------------------------------------------
 // Isolate DB + feature flag state
@@ -22,6 +28,12 @@ import path from "node:path";
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-radar-api-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
 process.env.STORAGE_ENCRYPTION_KEY = "test-encryption-key-for-radar-api-tests-32b!";
+process.env.JWT_SECRET = "test-jwt-secret-for-radar-api-tests";
+// Force isAuthRequired() to always require auth (mirrors tests/unit/api-auth.test.ts):
+// without a configured password/OIDC, a loopback bootstrap request would otherwise
+// be treated as pre-authenticated. Setting INITIAL_PASSWORD closes that bootstrap
+// path so the "no auth => 401" assertions are meaningful.
+process.env.INITIAL_PASSWORD = "test-bootstrap-password-for-radar-api-tests";
 
 const core = await import("../../src/lib/db/core.ts");
 const radarDb = await import("../../src/lib/db/radar.ts");
@@ -32,15 +44,38 @@ const featureFlags = await import("../../src/shared/utils/featureFlags.ts");
 // objects. However, the routes import from @/lib/radar which reads the DB,
 // so we need the DB to be set up.
 
-// Helper to create a mock NextRequest-like object
-function mockGetRequest(url = "http://localhost:20128/api/radar/catalog"): Request {
-  return new Request(url, { method: "GET" });
+/** Mint a valid dashboard-session JWT cookie header value (see apiAuth.ts::isDashboardSessionAuthenticated). */
+async function authCookieHeader(): Promise<string> {
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+  const token = await new SignJWT({ authenticated: true })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(secret);
+  return `auth_token=${token}`;
 }
 
-function mockPostRequest(url: string, body?: unknown): Request {
+/** Headers carrying a valid auth cookie, for the "authenticated" branch of each test. */
+async function authHeaders(): Promise<Record<string, string>> {
+  return { Cookie: await authCookieHeader() };
+}
+
+// Helper to create a mock NextRequest-like object
+function mockGetRequest(
+  url = "http://localhost:20128/api/radar/catalog",
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(url, { method: "GET", headers });
+}
+
+function mockPostRequest(
+  url: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Request {
   return new Request(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
 }
@@ -59,7 +94,7 @@ function resetStorage() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: flag-off behavior (all routes => 404)
+// Tests: flag-off behavior (all routes => 404, no auth required to learn this)
 // ---------------------------------------------------------------------------
 
 test("GET /api/radar/catalog: flag off => 404", async () => {
@@ -105,17 +140,88 @@ test("POST /api/radar/settings: flag off => 404", async () => {
   assert.ok(!JSON.stringify(body).includes("at /"), "Response must not leak stack traces");
 });
 
+test("GET /api/radar/settings: flag off => 404", async () => {
+  resetStorage();
+  delete process.env.RADAR_ENABLED;
+
+  const { GET } = await import("../../src/app/api/radar/settings/route.ts");
+  const response = await GET(mockGetRequest("http://localhost:20128/api/radar/settings"));
+  const body = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.ok(body.error);
+  assert.ok(!JSON.stringify(body).includes("at /"), "Response must not leak stack traces");
+});
+
 // ---------------------------------------------------------------------------
-// Tests: flag-on behavior
+// FIX 1 — auth required on all 3 (now 4, with GET settings) routes once the
+// flag is on. Order: flag-off 404 stays first (byte-identical inertia,
+// verified above); auth (401) comes AFTER it, BEFORE any DB access.
 // ---------------------------------------------------------------------------
 
-test("GET /api/radar/catalog: flag on, empty cache => baseline entries, meta null", async () => {
+test("GET /api/radar/catalog: flag on, no auth => 401", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { GET } = await import("../../src/app/api/radar/catalog/route.ts");
+  const response = await GET(mockGetRequest());
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.ok(body.error, "Response should have error field");
+  assert.ok(!JSON.stringify(body).includes("at /"), "Response must not leak stack traces");
+});
+
+test("POST /api/radar/sync: flag on, no auth => 401", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { POST } = await import("../../src/app/api/radar/sync/route.ts");
+  const response = await POST(mockPostRequest("http://localhost:20128/api/radar/sync"));
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.ok(body.error);
+});
+
+test("POST /api/radar/settings: flag on, no auth => 401", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { POST } = await import("../../src/app/api/radar/settings/route.ts");
+  const response = await POST(
+    mockPostRequest("http://localhost:20128/api/radar/settings", { optIn: true }),
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.ok(body.error);
+});
+
+test("GET /api/radar/settings: flag on, no auth => 401", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { GET } = await import("../../src/app/api/radar/settings/route.ts");
+  const response = await GET(mockGetRequest("http://localhost:20128/api/radar/settings"));
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.ok(body.error);
+});
+
+// ---------------------------------------------------------------------------
+// Tests: flag-on + authenticated behavior (previous "flag on" tests, now
+// wired with a valid session cookie so they exercise the post-auth branch)
+// ---------------------------------------------------------------------------
+
+test("GET /api/radar/catalog: flag on, authenticated, empty cache => baseline entries, meta null", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
 
   // Fresh import to pick up the flag
   const catalogRoute = await import("../../src/app/api/radar/catalog/route.ts");
-  const response = await catalogRoute.GET(mockGetRequest());
+  const response = await catalogRoute.GET(mockGetRequest(undefined, await authHeaders()));
   const body = await response.json();
 
   assert.equal(response.status, 200);
@@ -124,16 +230,20 @@ test("GET /api/radar/catalog: flag on, empty cache => baseline entries, meta nul
   assert.equal(body.meta, null, "meta should be null when no cache");
 });
 
-test("POST /api/radar/settings: flag on, set opt-in => success, no key in response", async () => {
+test("POST /api/radar/settings: flag on, authenticated, set opt-in => success, no key in response", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
 
   const settingsRoute = await import("../../src/app/api/radar/settings/route.ts");
   const response = await settingsRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/settings", {
-      optIn: true,
-      supporterKey: "omr_abcdef01234567890abcdef01234567890abcdef",
-    }),
+    mockPostRequest(
+      "http://localhost:20128/api/radar/settings",
+      {
+        optIn: true,
+        supporterKey: "omr_abcdef01234567890abcdef01234567890abcdef",
+      },
+      await authHeaders(),
+    ),
   );
   const body = await response.json();
 
@@ -150,15 +260,17 @@ test("POST /api/radar/settings: flag on, set opt-in => success, no key in respon
   assert.ok(body.supporterKey.length <= 12, "Masked key should be short");
 });
 
-test("POST /api/radar/settings: invalid body => 400", async () => {
+test("POST /api/radar/settings: authenticated, invalid body => 400", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
 
   const settingsRoute = await import("../../src/app/api/radar/settings/route.ts");
   const response = await settingsRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/settings", {
-      supporterKey: "invalid-key-format",
-    }),
+    mockPostRequest(
+      "http://localhost:20128/api/radar/settings",
+      { supporterKey: "invalid-key-format" },
+      await authHeaders(),
+    ),
   );
 
   assert.equal(response.status, 400);
@@ -166,13 +278,13 @@ test("POST /api/radar/settings: invalid body => 400", async () => {
   assert.ok(body.error);
 });
 
-test("POST /api/radar/settings: empty body => 400", async () => {
+test("POST /api/radar/settings: authenticated, empty body => 400", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
 
   const settingsRoute = await import("../../src/app/api/radar/settings/route.ts");
   const response = await settingsRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/settings", {}),
+    mockPostRequest("http://localhost:20128/api/radar/settings", {}, await authHeaders()),
   );
 
   assert.equal(response.status, 400);
@@ -180,24 +292,29 @@ test("POST /api/radar/settings: empty body => 400", async () => {
   assert.ok(body.error);
 });
 
-test("POST /api/radar/settings: null key clears it", async () => {
+test("POST /api/radar/settings: authenticated, null key clears it", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
 
   const settingsRoute = await import("../../src/app/api/radar/settings/route.ts");
+  const headers = await authHeaders();
 
   // First set a key
   await settingsRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/settings", {
-      supporterKey: "omr_abcdef01234567890abcdef01234567890abcdef",
-    }),
+    mockPostRequest(
+      "http://localhost:20128/api/radar/settings",
+      { supporterKey: "omr_abcdef01234567890abcdef01234567890abcdef" },
+      headers,
+    ),
   );
 
   // Then clear it
   const response = await settingsRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/settings", {
-      supporterKey: null,
-    }),
+    mockPostRequest(
+      "http://localhost:20128/api/radar/settings",
+      { supporterKey: null },
+      headers,
+    ),
   );
   const body = await response.json();
 
@@ -205,14 +322,14 @@ test("POST /api/radar/settings: null key clears it", async () => {
   assert.equal(body.supporterKey, null, "Cleared key should return null");
 });
 
-test("POST /api/radar/sync: flag on, not opted in => status opt_out", async () => {
+test("POST /api/radar/sync: flag on, authenticated, not opted in => status opt_out", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
   // Don't set opt-in
 
   const syncRoute = await import("../../src/app/api/radar/sync/route.ts");
   const response = await syncRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/sync"),
+    mockPostRequest("http://localhost:20128/api/radar/sync", undefined, await authHeaders()),
   );
   const body = await response.json();
 
@@ -220,23 +337,76 @@ test("POST /api/radar/sync: flag on, not opted in => status opt_out", async () =
   assert.equal(body.status, "opt_out");
 });
 
-test("POST /api/radar/sync: invalid body => 400", async () => {
+test("POST /api/radar/sync: authenticated, invalid body => 400", async () => {
   resetStorage();
   process.env.RADAR_ENABLED = "true";
 
   const syncRoute = await import("../../src/app/api/radar/sync/route.ts");
   const response = await syncRoute.POST(
-    mockPostRequest("http://localhost:20128/api/radar/sync", { unexpected: true }),
+    mockPostRequest(
+      "http://localhost:20128/api/radar/sync",
+      { unexpected: true },
+      await authHeaders(),
+    ),
   );
 
   assert.equal(response.status, 400);
 });
 
 // ---------------------------------------------------------------------------
+// FIX 3 — GET /api/radar/settings: { optIn, hasSupporterKey, supporterKeyMasked }
+// ---------------------------------------------------------------------------
+
+test("GET /api/radar/settings: flag on, authenticated, default state => optIn false, no key", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { GET } = await import("../../src/app/api/radar/settings/route.ts");
+  const response = await GET(
+    mockGetRequest("http://localhost:20128/api/radar/settings", await authHeaders()),
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.optIn, false);
+  assert.equal(body.hasSupporterKey, false);
+  assert.equal(body.supporterKeyMasked, null);
+});
+
+test("GET /api/radar/settings: flag on, authenticated, after opt-in + key => reflects persisted state, never raw key", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const settingsRoute = await import("../../src/app/api/radar/settings/route.ts");
+  const headers = await authHeaders();
+  const RAW_KEY = "omr_abcdef01234567890abcdef01234567890abcdef";
+
+  await settingsRoute.POST(
+    mockPostRequest(
+      "http://localhost:20128/api/radar/settings",
+      { optIn: true, supporterKey: RAW_KEY },
+      headers,
+    ),
+  );
+
+  const response = await settingsRoute.GET(
+    mockGetRequest("http://localhost:20128/api/radar/settings", headers),
+  );
+  const text = await response.text();
+  const body = JSON.parse(text);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.optIn, true);
+  assert.equal(body.hasSupporterKey, true);
+  assert.equal(body.supporterKeyMasked, "omr_****cdef", "must mask to last 4 hex chars");
+  assert.ok(!text.includes(RAW_KEY), "raw key must NEVER appear in the serialized response body");
+});
+
+// ---------------------------------------------------------------------------
 // Tests: error sanitization (Hard Rule #12)
 // ---------------------------------------------------------------------------
 
-test("all radar routes: error responses do NOT leak stack traces", async () => {
+test("all radar routes: 404 error responses (flag off) do NOT leak stack traces", async () => {
   resetStorage();
   delete process.env.RADAR_ENABLED;
 
@@ -267,6 +437,39 @@ test("all radar routes: error responses do NOT leak stack traces", async () => {
   }
 });
 
+test("all radar routes: 401 error responses (flag on, no auth) do NOT leak stack traces", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const routes = [
+    { name: "catalog", GET: (await import("../../src/app/api/radar/catalog/route.ts")).GET },
+    { name: "sync", POST: (await import("../../src/app/api/radar/sync/route.ts")).POST },
+    { name: "settings-post", POST: (await import("../../src/app/api/radar/settings/route.ts")).POST },
+    { name: "settings-get", GET: (await import("../../src/app/api/radar/settings/route.ts")).GET },
+  ];
+
+  for (const route of routes) {
+    let response: Response;
+    if ("GET" in route && route.GET) {
+      response = await (route as { GET: (r: Request) => Promise<Response> }).GET(mockGetRequest());
+    } else {
+      response = await (route as { POST: (r: Request) => Promise<Response> }).POST(
+        mockPostRequest(`http://localhost:20128/api/radar/${route.name.replace("-post", "")}`, {}),
+      );
+    }
+    assert.equal(response.status, 401, `${route.name}: expected 401 without auth`);
+    const text = await response.text();
+    assert.ok(
+      !text.includes("at /"),
+      `${route.name}: response must not contain stack-like paths. Got: ${text.slice(0, 200)}`,
+    );
+    assert.ok(
+      !text.includes(".ts:") && !text.includes(".js:"),
+      `${route.name}: response must not contain file:line references. Got: ${text.slice(0, 200)}`,
+    );
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------
@@ -274,6 +477,8 @@ test("all radar routes: error responses do NOT leak stack traces", async () => {
 test.after(() => {
   core.resetDbInstance();
   delete process.env.RADAR_ENABLED;
+  delete process.env.JWT_SECRET;
+  delete process.env.INITIAL_PASSWORD;
   try {
     fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   } catch {

--- a/tests/unit/radar-apply-feed.test.ts
+++ b/tests/unit/radar-apply-feed.test.ts
@@ -687,3 +687,133 @@ test("baselineToMergedEntries: converts FreeModelBudget shape to MergedEntry", (
   assert.equal(entries[0].origin, "baseline");
   assert.equal(entries[0].enabled, true);
 });
+
+// ===========================================================================
+// FIX 2 — extended feed fields (contextWindow/capabilities/limits/setup)
+// must survive the merge on BOTH code paths (mergeOne + feedModelToMerged).
+// ===========================================================================
+
+test("FIX2 mergeOne path: contextWindow/capabilities/limits/setup survive merge over a baseline entry", () => {
+  const baseline = makeBaseline();
+  const feed: FeedModel[] = [
+    makeFeedModel({
+      provider: "groq",
+      modelId: "llama-3.3-70b-versatile",
+      contextWindow: 131072,
+      capabilities: { tools: true, vision: true, thinking: false },
+      limits: { rpm: 30, rpd: 14400, tpm: 6000, tpd: null },
+      setup: { keyUrl: "https://console.groq.com/keys", steps: ["Sign up", "Create key"] },
+    }),
+  ];
+
+  const result = applyFeed({
+    baseline,
+    feed,
+    localOverrides: new Map(),
+    tombstones: new Set(),
+  });
+
+  const groq = result.find(
+    (e) => e.provider === "groq" && e.modelId === "llama-3.3-70b-versatile",
+  )!;
+
+  assert.equal(groq.contextWindow, 131072);
+  assert.deepEqual(groq.capabilities, { tools: true, vision: true, thinking: false });
+  assert.deepEqual(groq.limits, { rpm: 30, rpd: 14400, tpm: 6000, tpd: null });
+  assert.deepEqual(groq.setup, {
+    keyUrl: "https://console.groq.com/keys",
+    steps: ["Sign up", "Create key"],
+  });
+});
+
+test("FIX2 feedModelToMerged path: contextWindow/capabilities/limits/setup survive for a feed-only entry", () => {
+  const baseline = makeBaseline();
+  const feed: FeedModel[] = [
+    makeFeedModel({
+      provider: "new-provider",
+      modelId: "new-model",
+      contextWindow: 65536,
+      capabilities: { tools: false, vision: true, thinking: true },
+      limits: { rpm: null, rpd: 100, tpm: null, tpd: null },
+      setup: { keyUrl: "https://new-provider.example/keys", steps: ["Step A"] },
+    }),
+  ];
+
+  const result = applyFeed({
+    baseline,
+    feed,
+    localOverrides: new Map(),
+    tombstones: new Set(),
+  });
+
+  const added = result.find((e) => e.provider === "new-provider" && e.modelId === "new-model")!;
+
+  assert.equal(added.contextWindow, 65536);
+  assert.deepEqual(added.capabilities, { tools: false, vision: true, thinking: true });
+  assert.deepEqual(added.limits, { rpm: null, rpd: 100, tpm: null, tpd: null });
+  assert.deepEqual(added.setup, {
+    keyUrl: "https://new-provider.example/keys",
+    steps: ["Step A"],
+  });
+});
+
+// ===========================================================================
+// FIX 4 — feedModelToMerged() must honor an `enabled` local override instead
+// of unconditionally forcing `enabled:false` when the feed disables the model.
+// mergeOne() already gets this right (overrides applied AFTER rule 2); this
+// pins the same semantics on the feed-only path.
+// ===========================================================================
+
+test("FIX4: feed-only entry with local override enabled:true wins over feed enabled:false", () => {
+  const baseline = makeBaseline();
+  const feed: FeedModel[] = [
+    makeFeedModel({
+      provider: "new-provider",
+      modelId: "disabled-model",
+      enabled: false,
+    }),
+  ];
+
+  const localOverrides = new Map<string, Partial<MergedEntry>>([
+    ["new-provider:disabled-model", { enabled: true }],
+  ]);
+
+  const result = applyFeed({
+    baseline,
+    feed,
+    localOverrides,
+    tombstones: new Set(),
+  });
+
+  const entry = result.find(
+    (e) => e.provider === "new-provider" && e.modelId === "disabled-model",
+  )!;
+
+  assert.equal(entry.enabled, true, "local override must win over feed disable");
+  assert.equal(entry.disabledBy, undefined, "must not carry radar disabledBy when overridden on");
+});
+
+test("FIX4: feed-only entry with NO override still gets disabled with disabledBy provenance", () => {
+  const baseline = makeBaseline();
+  const feed: FeedModel[] = [
+    makeFeedModel({
+      provider: "new-provider",
+      modelId: "disabled-model-2",
+      enabled: false,
+    }),
+  ];
+
+  const result = applyFeed({
+    baseline,
+    feed,
+    localOverrides: new Map(),
+    tombstones: new Set(),
+  });
+
+  const entry = result.find(
+    (e) => e.provider === "new-provider" && e.modelId === "disabled-model-2",
+  )!;
+
+  assert.equal(entry.enabled, false);
+  assert.equal(entry.disabledBy, "radar");
+});

--- a/tests/unit/radar-auto-sync.test.ts
+++ b/tests/unit/radar-auto-sync.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldAutoSyncOnOpen, AUTO_SYNC_STALE_MS } from "../../src/lib/radar/autoSync.ts";
+
+// Pure staleness rule that powers the Radar page's sync-on-open behaviour
+// (spec: dados atualizados a cada abrir da página).
+
+const NOW = Date.parse("2026-08-06T12:00:00.000Z");
+
+test("shouldAutoSyncOnOpen", async (t) => {
+  await t.test("no cache at all => sync", () => {
+    assert.equal(shouldAutoSyncOnOpen(null, NOW), true);
+    assert.equal(shouldAutoSyncOnOpen(undefined, NOW), true);
+    assert.equal(shouldAutoSyncOnOpen("", NOW), true);
+  });
+
+  await t.test("unparseable timestamp counts as stale", () => {
+    assert.equal(shouldAutoSyncOnOpen("not-a-date", NOW), true);
+  });
+
+  await t.test("fresh cache (just fetched) => no sync", () => {
+    assert.equal(shouldAutoSyncOnOpen(new Date(NOW - 1000).toISOString(), NOW), false);
+  });
+
+  await t.test("cache just inside the stale window => no sync", () => {
+    const fetchedAt = new Date(NOW - AUTO_SYNC_STALE_MS + 1000).toISOString();
+    assert.equal(shouldAutoSyncOnOpen(fetchedAt, NOW), false);
+  });
+
+  await t.test("cache exactly at the stale boundary => sync", () => {
+    const fetchedAt = new Date(NOW - AUTO_SYNC_STALE_MS).toISOString();
+    assert.equal(shouldAutoSyncOnOpen(fetchedAt, NOW), true);
+  });
+
+  await t.test("cache older than the window => sync", () => {
+    const fetchedAt = new Date(NOW - 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(shouldAutoSyncOnOpen(fetchedAt, NOW), true);
+  });
+
+  await t.test("custom threshold is honored", () => {
+    const fetchedAt = new Date(NOW - 5000).toISOString();
+    assert.equal(shouldAutoSyncOnOpen(fetchedAt, NOW, 10_000), false);
+    assert.equal(shouldAutoSyncOnOpen(fetchedAt, NOW, 4000), true);
+  });
+});

--- a/tests/unit/radar-scheduler.test.ts
+++ b/tests/unit/radar-scheduler.test.ts
@@ -1,0 +1,153 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolate DATA_DIR before any src import — the scheduler module's default deps
+// reference the DB layer (never invoked here: every test injects its deps).
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-test-radar-scheduler-"));
+process.env.DATA_DIR = tmpDir;
+
+const {
+  radarSchedulerTick,
+  ensureRadarSyncScheduler,
+  stopRadarSyncScheduler,
+  initRadarSyncScheduler,
+  RADAR_SCHEDULER_TICK_MS,
+} = await import("../../src/lib/radar/scheduler.ts");
+
+const NOW = Date.parse("2026-08-06T12:00:00.000Z");
+const FRESH = new Date(NOW - 60 * 60 * 1000).toISOString(); // 1h ago — inside the daily window
+const STALE = new Date(NOW - 25 * 60 * 60 * 1000).toISOString(); // 25h ago — due
+
+/** Fake interval registry so no real timer ever exists in these tests. */
+function fakeTimers() {
+  const registered: Array<{ fn: () => void; ms: number }> = [];
+  let cleared = 0;
+  return {
+    registered,
+    clearedCount: () => cleared,
+    setIntervalFn: ((fn: () => void, ms: number) => {
+      registered.push({ fn, ms });
+      return registered.length as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval,
+    clearIntervalFn: (() => {
+      cleared += 1;
+    }) as typeof clearInterval,
+  };
+}
+
+function deps(overrides: Record<string, unknown> = {}) {
+  const syncCalls: number[] = [];
+  const timers = fakeTimers();
+  return {
+    syncCalls,
+    timers,
+    d: {
+      getFlag: () => true,
+      getSettings: () => ({ optIn: true }),
+      getCache: () => ({ fetchedAt: STALE }),
+      sync: async () => {
+        syncCalls.push(1);
+        return { status: "updated", version: "2026.08.06.1", tier: "live" } as const;
+      },
+      now: () => NOW,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      ...overrides,
+    },
+  };
+}
+
+test("radar sync scheduler", async (t) => {
+  t.afterEach(() => {
+    // Module-level timer state must not leak between subtests.
+    stopRadarSyncScheduler({ clearIntervalFn: (() => {}) as typeof clearInterval });
+  });
+
+  await t.test("tick: flag off => stopped, sync never called", async () => {
+    const { d, syncCalls } = deps({ getFlag: () => false });
+    const result = await radarSchedulerTick(d);
+    assert.deepEqual(result, { action: "stopped", reason: "flag_off" });
+    assert.equal(syncCalls.length, 0);
+  });
+
+  await t.test("tick: flag off stops a running timer (self-heal to zero-timer state)", async () => {
+    const { d, timers } = deps();
+    assert.equal(ensureRadarSyncScheduler(d), true);
+    assert.equal(timers.registered.length, 1);
+    const offDeps = { ...d, getFlag: () => false };
+    await radarSchedulerTick(offDeps);
+    assert.equal(timers.clearedCount(), 1);
+  });
+
+  await t.test("tick: opt-in off => skipped, no sync", async () => {
+    const { d, syncCalls } = deps({ getSettings: () => ({ optIn: false }) });
+    const result = await radarSchedulerTick(d);
+    assert.deepEqual(result, { action: "skipped", reason: "opt_out" });
+    assert.equal(syncCalls.length, 0);
+  });
+
+  await t.test("tick: fresh cache => not due, no sync", async () => {
+    const { d, syncCalls } = deps({ getCache: () => ({ fetchedAt: FRESH }) });
+    const result = await radarSchedulerTick(d);
+    assert.deepEqual(result, { action: "skipped", reason: "not_due" });
+    assert.equal(syncCalls.length, 0);
+  });
+
+  await t.test("tick: no cache at all => syncs immediately", async () => {
+    const { d, syncCalls } = deps({ getCache: () => null });
+    const result = await radarSchedulerTick(d);
+    assert.equal(result.action, "synced");
+    assert.equal(syncCalls.length, 1);
+  });
+
+  await t.test("tick: stale cache (>24h) => syncs", async () => {
+    const { d, syncCalls } = deps();
+    const result = await radarSchedulerTick(d);
+    assert.equal(result.action, "synced");
+    assert.equal(syncCalls.length, 1);
+  });
+
+  await t.test("ensure: registers one hourly timer, fires an immediate tick, idempotent", async () => {
+    const { d, timers, syncCalls } = deps();
+    assert.equal(ensureRadarSyncScheduler(d), true);
+    assert.equal(timers.registered.length, 1);
+    assert.equal(timers.registered[0].ms, RADAR_SCHEDULER_TICK_MS);
+    // The immediate tick is fire-and-forget; give the microtask queue a turn.
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(syncCalls.length, 1, "immediate tick should have synced the stale cache");
+    // Second ensure is a no-op — no second timer.
+    assert.equal(ensureRadarSyncScheduler(d), false);
+    assert.equal(timers.registered.length, 1);
+  });
+
+  await t.test("init: flag off => never arms (flag-off boot stays timer-free)", () => {
+    const { d, timers } = deps({ getFlag: () => false });
+    assert.equal(initRadarSyncScheduler(d), false);
+    assert.equal(timers.registered.length, 0);
+  });
+
+  await t.test("init: opt-in off => never arms", () => {
+    const { d, timers } = deps({ getSettings: () => ({ optIn: false }) });
+    assert.equal(initRadarSyncScheduler(d), false);
+    assert.equal(timers.registered.length, 0);
+  });
+
+  await t.test("init: flag + opt-in on => arms the timer", () => {
+    const { d, timers } = deps();
+    assert.equal(initRadarSyncScheduler(d), true);
+    assert.equal(timers.registered.length, 1);
+  });
+
+  await t.test("init: settings reader throwing => false, never throws out", () => {
+    const { d, timers } = deps({
+      getSettings: () => {
+        throw new Error("db unavailable");
+      },
+    });
+    assert.equal(initRadarSyncScheduler(d), false);
+    assert.equal(timers.registered.length, 0);
+  });
+});

--- a/tests/unit/radar-sync.test.ts
+++ b/tests/unit/radar-sync.test.ts
@@ -809,3 +809,75 @@ test("syncRadar: first sync (no cache) with valid data => updated", async () => 
   assert.equal(result.status, "updated");
   assert.equal(cacheStore.length, 1);
 });
+
+// ===========================================================================
+// FIX 6 — 10 MB response cap (unbounded `Buffer.from(await res.arrayBuffer())`)
+// ===========================================================================
+
+test("FIX6: Content-Length header exceeding the 10MB cap => too_large, cache untouched, body never read", async () => {
+  let arrayBufferCalled = false;
+  const oversizedContentLength = String(10 * 1024 * 1024 + 1);
+  const response = mockResponse(Buffer.from("irrelevant"), {
+    "content-length": oversizedContentLength,
+  });
+  const originalArrayBuffer = response.arrayBuffer.bind(response);
+  (response as unknown as { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer = () => {
+    arrayBufferCalled = true;
+    return originalArrayBuffer();
+  };
+
+  let setCacheCalled = false;
+  const result = await syncMod.syncRadar({
+    getFlag: () => true,
+    getSettings: () => ({ optIn: true, supporterKey: null }),
+    getCache: () => null,
+    setCache: () => {
+      setCacheCalled = true;
+    },
+    fetch: (() => Promise.resolve(response)) as unknown as typeof globalThis.fetch,
+  });
+
+  assert.deepEqual(result, { status: "too_large" });
+  assert.equal(setCacheCalled, false, "cache must not be touched");
+  assert.equal(
+    arrayBufferCalled,
+    false,
+    "body must not be read once Content-Length already exceeds the cap"
+  );
+});
+
+test("FIX6: oversized body without a trustworthy Content-Length header => too_large, cache untouched", async () => {
+  const oversized = Buffer.alloc(10 * 1024 * 1024 + 1, 0x41);
+  let setCacheCalled = false;
+
+  const result = await syncMod.syncRadar({
+    getFlag: () => true,
+    getSettings: () => ({ optIn: true, supporterKey: null }),
+    getCache: () => null,
+    setCache: () => {
+      setCacheCalled = true;
+    },
+    fetch: (() =>
+      Promise.resolve(mockResponse(oversized, {}))) as unknown as typeof globalThis.fetch,
+  });
+
+  assert.deepEqual(result, { status: "too_large" });
+  assert.equal(setCacheCalled, false, "cache must not be touched");
+});
+
+test("FIX6: body within the 10MB cap proceeds normally (never returns too_large)", async () => {
+  const sig = signBytes(FIXTURE_BYTES);
+
+  const result = await syncMod.syncRadar({
+    getFlag: () => true,
+    getSettings: () => ({ optIn: true, supporterKey: null }),
+    getCache: () => null,
+    setCache: () => {},
+    fetch: (() =>
+      Promise.resolve(
+        mockResponse(FIXTURE_BYTES, { "x-omniroute-feed-signature": sig })
+      )) as unknown as typeof globalThis.fetch,
+  });
+
+  assert.notEqual(result.status, "too_large");
+});

--- a/tests/unit/sidebar-costs-section.test.ts
+++ b/tests/unit/sidebar-costs-section.test.ts
@@ -97,3 +97,77 @@ test("costs section titleKey is costsSection", () => {
   assert.equal(section.titleKey, "costsSection");
   assert.equal(section.titleFallback, "Costs");
 });
+
+// ---------------------------------------------------------------------------
+// FIX 5 — the "radar" sidebar item must be gated on the RADAR_ENABLED feature
+// flag (Sidebar.tsx has no built-in feature-flag awareness, so the item
+// definition carries an opt-in `featureFlagKey`, and a small pure filter
+// helper decides visibility given a resolved flags map).
+// ---------------------------------------------------------------------------
+
+test("FIX5: radar item declares featureFlagKey RADAR_ENABLED", () => {
+  const section = findSection("costs");
+  assert.ok(section, "costs section must exist");
+
+  const radarItem = sidebarVisibility.getSectionItems(section).find((i) => i.id === "radar");
+  assert.ok(radarItem, "radar item must exist in costs section");
+  assert.equal(radarItem.featureFlagKey, "RADAR_ENABLED");
+});
+
+test("FIX5: no other costs-section item declares a featureFlagKey (no regression)", () => {
+  const section = findSection("costs");
+  assert.ok(section, "costs section must exist");
+
+  const otherItems = sidebarVisibility
+    .getSectionItems(section)
+    .filter((i) => i.id !== "radar");
+
+  for (const item of otherItems) {
+    assert.equal(
+      item.featureFlagKey,
+      undefined,
+      `${item.id} must not be flag-gated (unexpected regression)`
+    );
+  }
+});
+
+test("FIX5: isSidebarItemVisibleForFlags — flag off => item hidden", () => {
+  const section = findSection("costs");
+  assert.ok(section, "costs section must exist");
+  const radarItem = sidebarVisibility.getSectionItems(section).find((i) => i.id === "radar")!;
+
+  assert.equal(
+    sidebarVisibility.isSidebarItemVisibleForFlags(radarItem, { RADAR_ENABLED: false }),
+    false
+  );
+});
+
+test("FIX5: isSidebarItemVisibleForFlags — flag on => item visible", () => {
+  const section = findSection("costs");
+  assert.ok(section, "costs section must exist");
+  const radarItem = sidebarVisibility.getSectionItems(section).find((i) => i.id === "radar")!;
+
+  assert.equal(
+    sidebarVisibility.isSidebarItemVisibleForFlags(radarItem, { RADAR_ENABLED: true }),
+    true
+  );
+});
+
+test("FIX5: isSidebarItemVisibleForFlags — flag unknown (not yet loaded) fails open => visible", () => {
+  const section = findSection("costs");
+  assert.ok(section, "costs section must exist");
+  const radarItem = sidebarVisibility.getSectionItems(section).find((i) => i.id === "radar")!;
+
+  assert.equal(sidebarVisibility.isSidebarItemVisibleForFlags(radarItem, {}), true);
+});
+
+test("FIX5: isSidebarItemVisibleForFlags — items without featureFlagKey are always visible", () => {
+  const section = findSection("costs");
+  assert.ok(section, "costs section must exist");
+  const costsItem = sidebarVisibility.getSectionItems(section).find((i) => i.id === "costs")!;
+
+  assert.equal(
+    sidebarVisibility.isSidebarItemVisibleForFlags(costsItem, { RADAR_ENABLED: false }),
+    true
+  );
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9679 (migration collision 134 + typecheck hard failures on the tip — pre-existing, not from this branch)

Closes the gaps found in the 2026-08-06 Radar audit (PR #9515 follow-up), plus the spec'd daily sync.

## Fixes
- **Auth on the 3 `/api/radar/*` routes** (401 after the flag gate; flag-off 404 stays first, so flag-off inertia is byte-identical). New `GET /api/radar/settings` returns opt-in state + masked key — the raw key never leaves the server.
- **`applyFeed` now carries `setup`/`capabilities`/`contextWindow`/`limits`** through both merge paths — the per-provider setup CTA, capability badges and context column render again.
- **Opt-in state survives reloads** (the page derives it from the new GET instead of always showing the activation screen).
- **Rule 1 honored in `feedModelToMerged`** — a local `enabled:true` override survives a feed disable, matching `mergeOne`.
- **Sidebar item gated by `RADAR_ENABLED`** (flag off ⇒ no menu entry; piggy-backs the existing `/api/settings` fetch, fail-open for unrelated items).
- **10 MB response cap in `syncRadar`** (Content-Length preflight + streamed running total; exact bytes preserved for signature verification; new `too_large` status).
- **Daily scheduler + auto-sync on page open**: hourly staleness tick armed only when flag+opt-in are on (boot or right after opting in) — a flag-off install never creates the timer; the page auto-syncs once per mount when the cache is older than 6h.
- **Docs**: `ENVIRONMENT.md` stale feed URL fixed; `RADAR.md` documents the tier header (`x-omniroute-feed-tier` is the only tier truth — the signed body always says `live`), auth, `GET settings`, size cap, corrected data path.

## Validation
- New/extended tests: `radar-api-routes` 19/19 (auth, 404/401, no stack leak, raw key never echoed), `radar-apply-feed` 23/23, `radar-sync` 48/48, `sidebar-costs-section` 13/13, `radar-scheduler` + `radar-auto-sync` 20/20, `radar-page-state` 5/5, `radar-flag-default` 6/6, `radar-inertia` 5/5 — all green locally (route tests run against a deduplicated migrations dir because of the inherited 134 collision, see #9679).
- `typecheck:core`: zero errors in touched files (pre-existing tip failures tracked in #9679). Focused ESLint on all touched files: clean. `check:docs-all`: clean for touched docs.