### PR TITLE
fix(models): custom provider nodes lost their synced catalog after #9294

### DIFF
--- a/changelog.d/fixes/9691-custom-node-synced-catalog.md
+++ b/changelog.d/fixes/9691-custom-node-synced-catalog.md
@@ -1,0 +1,1 @@
+- **fix(models):** custom provider nodes regained their synced catalog (empty after #9294's active-connection filter — broke #7694 effort-suffix resolution and dropped thinking-effort/limit metadata for prefix-proxy nodes) ([#9691](https://github.com/diegosouzapw/OmniRoute/pull/9691))

--- a/src/lib/db/models/activeSyncedCatalog.ts
+++ b/src/lib/db/models/activeSyncedCatalog.ts
@@ -1,7 +1,7 @@
 import { providerUsesAuthoritativeLiveCatalog } from "@omniroute/open-sse/config/providerRegistry";
 import { PROVIDER_ID_TO_ALIAS } from "@omniroute/open-sse/config/providerModels.ts";
 import { getSyncedAvailableModelsByConnection, type SyncedAvailableModel } from "../models";
-import { getRawProviderConnections } from "../providers";
+import { getProviderNodeById, getRawProviderConnections } from "../providers";
 
 export type ActiveSyncedCatalog = {
   authoritative: boolean;
@@ -101,7 +101,20 @@ export async function getActiveSyncedCatalog(providerId: string): Promise<Active
       .filter((connection): connection is ProviderConnectionRef => connection !== null)
       .map((connection) => connection.id);
 
-    const models = collectModelsForConnections(modelsByConnection, activeConnectionIds);
+    let models = collectModelsForConnections(modelsByConnection, activeConnectionIds);
+
+    // Custom provider NODES (#7694 prefix proxies) live in `provider_nodes`,
+    // not `provider_connections`, and address their synced catalog by their
+    // own id (`<id>:<id>` keys) — the provider-named connection query above
+    // cannot see them, which silently emptied their catalog (and killed the
+    // #7694 effort-suffix resolution) after #9294. A node has no is_active
+    // flag: existing means active, deletion is the off switch.
+    if (models.length === 0 && (modelsByConnection[storedProviderId]?.length ?? 0) > 0) {
+      const node = await getProviderNodeById(storedProviderId);
+      if (node) {
+        models = collectModelsForConnections(modelsByConnection, [storedProviderId]);
+      }
+    }
 
     return {
       authoritative: models.length > 0 && providerUsesAuthoritativeLiveCatalog(providerId),


### PR DESCRIPTION
## Bug (produção)

O #9294 trocou a leitura do catálogo synced em `lookupModelMeta` por `getActiveSyncedCatalog`, que filtra por conexões ativas cujo campo `provider` == providerId. **Nodes custom** (#7694 — proxies com prefixo) vivem em `provider_nodes` e o campo `provider` deles carrega o TIPO (`openai-compatible`), então a query nunca casa e o catálogo do node resolve **vazio silenciosamente**. Efeitos:

- Resolução de sufixo de effort do #7694 morta (`<prefix>/<model>-high` não stripa mais para o modelo base).
- `supportedThinkingEfforts`/limites de TODO node custom somem da metadata de runtime.

## Fix

Fallback cirúrgico em `getActiveSyncedCatalog`: quando a query por provider não retorna nada mas o próprio `storedProviderId` endereça um catálogo (chaves `<id>:<id>`), usa-o se existir um provider NODE com esse id (`getProviderNodeById` — nodes não têm flag `is_active`: existir = ativo, deletar = desligar). A intenção do #9294 (excluir catálogos de conexões inativas de providers nomeados) fica intacta.

## Validação (TDD, Hard Rule #18)

`tests/unit/sync-reasoning-supported-efforts-7694.test.ts` reproduziu a quebra (2 failing: sufixo não stripado; tier list `undefined`) → **23/23** com o fix. Debug do caminho documentado: o mapa por conexão continha o catálogo, o filtro de conexões o descartava.

⚠️ Os unit shards deste PR herdam os base-reds do lote 08-06 até o #9688 mergear (migration collision + import fantasma). Refs #9294, #7694.