### PR TITLE
feat(radar): referral links — free-credits tab + default provider link (D28)

### DIFF
--- a/docs/frameworks/RADAR.md
+++ b/docs/frameworks/RADAR.md
@@ -223,14 +223,15 @@ Every merged entry carries an `origin` field the UI renders as a badge:
 
 ## Local surfaces — never a feed proxy
 
-Four local routes back the UI, all under `src/app/api/radar/`:
+Five local routes back the UI, all under `src/app/api/radar/`:
 
-| Route                 | Method | Purpose                                                                                          |
-| --------------------- | ------ | -------------------------------------------------------------------------------------------------- |
-| `/api/radar/catalog`  | GET    | Returns the merged catalog (`getRadarCatalog()`) from the local cache.                            |
-| `/api/radar/sync`     | POST   | Triggers `syncRadar()` server-side; returns the resulting status.                                 |
-| `/api/radar/settings` | GET    | Returns `{ optIn, hasSupporterKey, supporterKeyMasked }` — never the raw key.                     |
-| `/api/radar/settings` | POST   | Sets opt-in and/or the (encrypted) supporter key.                                                 |
+| Route                   | Method | Purpose                                                                                          |
+| ----------------------- | ------ | -------------------------------------------------------------------------------------------------- |
+| `/api/radar/catalog`    | GET    | Returns the merged catalog (`getRadarCatalog()`) from the local cache.                            |
+| `/api/radar/sync`       | POST   | Triggers `syncRadar()` server-side; returns the resulting status.                                 |
+| `/api/radar/settings`   | GET    | Returns `{ optIn, hasSupporterKey, supporterKeyMasked }` — never the raw key.                     |
+| `/api/radar/settings`   | POST   | Sets opt-in and/or the (encrypted) supporter key.                                                 |
+| `/api/radar/referrals`  | GET    | Returns `{ fixed, campaigns, tier }` from the local cache — see [Referral links](#referral-links-free-credits) below. |
 
 **Hard rule: these routes never proxy the feed service.** The browser only ever talks
 to the local OmniRoute server; `syncRadar()` is the single module in the whole client
@@ -238,14 +239,14 @@ that touches the network for Radar (`src/lib/radar/sync.ts`), and it always runs
 server-side, never client-side. This keeps the feed URL and any supporter key
 out of client-facing network traffic entirely.
 
-All four routes return `404` when `RADAR_ENABLED` is off (see
+All five routes return `404` when `RADAR_ENABLED` is off (see
 [Flag](#flag-radar_enabled-default-off) above), and route error responses through
 `buildErrorBody()`/`sanitizeErrorMessage()` per the repo-wide error-sanitization rule
 (`docs/security/ERROR_SANITIZATION.md`).
 
 ### Authentication
 
-All four routes require authentication via `isAuthenticated()`
+All five routes require authentication via `isAuthenticated()`
 (`src/shared/utils/apiAuth.ts`) — a dashboard session cookie or a management-scoped
 API key, the same gate that protects the rest of `/api/settings/*`. The flag-off
 `404` check always runs **before** the auth check, so an install with `RADAR_ENABLED`
@@ -253,6 +254,102 @@ off stays byte-identical (no auth prompt just to learn the surface doesn't exist
 once the flag is on, an unauthenticated request gets `401` before any DB read or
 write. `GET /api/radar/settings` never returns the raw supporter key regardless of
 auth state — only the masked form and a `hasSupporterKey` boolean.
+
+---
+
+## Referral links (free credits)
+
+The server-published feed carries a `referrals` section (server-side D28 work, already
+in production — this section documents the **client** consumption only):
+
+```ts
+referrals: {
+  fixed: RadarReferral[],      // present in EVERY tier, including community
+  campaigns: RadarReferral[],  // only populated on the live (supporter) tier;
+                                // the community artifact always publishes []
+}
+// RadarReferral = { provider, url, kind: "fixo" | "campanha", validUntil,
+//                    requiredAction, isDefault }
+```
+
+The client never decides which tier it received or which referrals belong in which
+tier — the server already publishes two artifacts (`live`/`community`) with
+`campaigns` gated server-side, same principle as the [tiers](#tiers-community-and-live)
+section above. `RadarFeedSchema` (`src/lib/radar/feedSchema.ts`) validates `referrals`
+as a whole-object `.default({fixed:[],campaigns:[]})`, and `campaigns` defaults
+independently inside it — so a feed cached before this section existed on the server
+still parses cleanly, and `campaigns` alone can also be absent without failing
+validation. Every `RadarReferral.url` must be `https://` — a `http://` url fails
+schema validation.
+
+### Accessor
+
+`src/lib/radar/index.ts` exports two read-only accessors, both never throwing (same
+defensive contract as `getRadarCatalog()` — flag off, no cache, or a corrupt/old cached
+payload all resolve to the empty shape instead of an error):
+
+- `getRadarReferrals()` → `{ fixed: RadarReferral[], campaigns: RadarReferral[] }`.
+- `getDefaultReferralFor(provider)` → the `fixed` referral with `isDefault: true` for
+  that provider, or `null`. Only looks at `fixed` — a campaign is never used as a
+  provider's "default" link.
+
+The actual "which referral is the default for a provider" rule lives in
+`findDefaultReferral()` (`src/lib/radar/referrals.ts`), a small pure function with **no
+DB import** — it is safe to import into a `"use client"` component. `getRadarReferrals`/
+`getDefaultReferralFor` (in `index.ts`) pull in `@/lib/db/radar` and therefore stay
+server-only; the providers dashboard imports `referrals.ts` directly instead of
+`index.ts` (see below) to avoid bundling `better-sqlite3` into the browser.
+
+### `GET /api/radar/referrals`
+
+Follows the exact same gate order as every other Radar route: `RADAR_ENABLED` off →
+`404` (checked first, byte-identical inertia); unauthenticated → `401`; otherwise `200`
+with `{ fixed, campaigns, tier }` — `tier` comes straight from the cache row and is
+purely informative (drives the UI's soft upsell copy below), the route does no
+gating of its own. Never proxies the feed server — same local-cache-only contract as
+`/api/radar/catalog`.
+
+### Dashboard UI — "Free credits" tab on `/dashboard/radar`
+
+Reuses the existing Radar page (`src/app/(dashboard)/dashboard/radar/page.tsx`) as a
+second tab instead of a new route — less routing/i18n surface for a feature that is a
+variation on data the page already fetches. Once opted in, the tab bar offers
+**Catalog** (existing table) and **Free credits**:
+
+- Fixed links are grouped by provider, each showing `requiredAction` (when present)
+  and a `target="_blank" rel="noopener noreferrer"` button to the referral URL.
+- Campaigns show the same, plus `validUntil` when present.
+- When `campaigns` is empty **and** the served tier is `community`, the UI shows a
+  short upsell note ("limited-time campaigns are a supporter extra") — this **never**
+  hides or gates the fixed links list, which stays fully populated for every tier. The
+  upsell is soft messaging only, never a block.
+
+### Referral link on the provider name (providers dashboard)
+
+`ProviderPageHeader` (`src/app/(dashboard)/dashboard/providers/[id]/components/`)
+already linked the provider name to `providerInfo.website` when present, with one
+precedent for a monetized link: the Kimi (Moonshot AI) partner-link note
+(`providers.kimiPartnerLinkNote` i18n key). D28 reuses that exact same discreet-note
+pattern for Radar default referrals instead of introducing a new key.
+
+Loose coupling, by design:
+
+- `resolveProviderHeaderLink()` (`src/app/(dashboard)/dashboard/providers/providerPageUtils.ts`)
+  is a **pure** function — `(staticWebsite, referralUrl) => { website, isReferralLink }`
+  — with no dependency on `@/lib/radar` or `@/lib/db/*`. `providerPageUtils.ts` as a
+  whole stays free of those imports (asserted by
+  `tests/unit/provider-header-referral-link.test.ts`).
+- `ProviderDetailPageClient.tsx` (a `"use client"` component) is the one place allowed
+  to fetch Radar data — via `fetch("/api/radar/referrals")`, the same local-route
+  pattern the Radar dashboard page itself uses — and it computes the default referral
+  client-side with `findDefaultReferral()` from the DB-free `src/lib/radar/referrals.ts`.
+- With `RADAR_ENABLED` off, the fetch 404s, `referralUrl` stays `null`, and
+  `resolveProviderHeaderLink()` returns the static catalog `website` unchanged — the
+  provider page is byte-identical to before this feature existed. Same outcome when
+  there is no cache yet or no default referral for that specific provider.
+- When a default referral does apply, `ProviderPageHeader` receives `isReferralLink`
+  and shows the same discreet note/tooltip as the Kimi partner link (reusing the
+  `providers.kimiPartnerLinkNote` key) — never a new, separate visual treatment.
 
 ---
 
@@ -283,6 +380,6 @@ feed.
 ## Related docs
 
 - [`docs/security/ERROR_SANITIZATION.md`](../security/ERROR_SANITIZATION.md) — the
-  error-response pattern the three `/api/radar/*` routes follow.
+  error-response pattern the five `/api/radar/*` routes follow.
 - [`docs/reference/ENVIRONMENT.md`](../reference/ENVIRONMENT.md#27-radar-feed-self-hosting)
   — `RADAR_FEED_URL` / `RADAR_FEED_PUBKEY` reference.

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -27,7 +27,8 @@ import { normalizeModelCatalogSource } from "@/shared/utils/modelCatalogSearch";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import useEmailPrivacyStore from "@/store/emailPrivacyStore";
 import { useNotificationStore } from "@/store/notificationStore";
-import { resolveDashboardProviderInfo } from "../providerPageUtils";
+import { resolveDashboardProviderInfo, resolveProviderHeaderLink } from "../providerPageUtils";
+import { findDefaultReferral } from "@/lib/radar/referrals";
 import { type ConnectionRowConnection } from "./components/ConnectionRow";
 import { useProviderConnections } from "./hooks/useProviderConnections";
 import { useProviderSettings } from "./hooks/useProviderSettings";
@@ -213,6 +214,39 @@ export default function ProviderDetailPageClient() {
       openAiCompatibleName: t("openaiCompatibleName"),
     },
   });
+
+  // D28 — Radar default referral link ("Pegue seus créditos grátis"). Fetched
+  // from the LOCAL /api/radar/referrals route only (never talks to the
+  // private feed server directly) — same client-fetch pattern the Radar
+  // dashboard page already uses for its own data. This keeps the providers
+  // page decoupled from @/lib/radar (DB-touching, Node-only): a 404 (flag
+  // off) or 401/network failure just leaves `referralUrl` null, and
+  // `resolveProviderHeaderLink` below then falls back to the static catalog
+  // website — byte-identical to before this feature existed.
+  const [referralUrl, setReferralUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/radar/referrals");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        const fixed = Array.isArray(data?.fixed) ? data.fixed : [];
+        const match = findDefaultReferral(fixed, providerId);
+        setReferralUrl(match?.url ?? null);
+      } catch {
+        // Best-effort only — never blocks rendering of the provider page.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId]);
+  const { website: providerHeaderWebsite, isReferralLink } = resolveProviderHeaderLink(
+    providerInfo?.website,
+    referralUrl
+  );
   const providerSupportsOAuth =
     providerInfo?.toggleAuthType === "oauth" || providerInfo?.toggleAuthType === "free";
   const subscriptionRisk = providerInfo?.subscriptionRisk === true;
@@ -463,12 +497,13 @@ export default function ProviderDetailPageClient() {
     <div className="flex flex-col gap-8">
       <ProviderPageHeader
         providerId={providerId}
-        providerInfo={providerInfo}
+        providerInfo={{ ...providerInfo, website: providerHeaderWebsite }}
         connectionsCount={connections.length}
         isOpenAICompatible={isOpenAICompatible}
         isAnthropicProtocolCompatible={isAnthropicProtocolCompatible}
         onOpenTutorial={() => setShowTutorialModal(true)}
         t={t}
+        isReferralLink={isReferralLink}
       />
 
       {providerId === "zed" && (

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPageHeader.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPageHeader.tsx
@@ -27,6 +27,14 @@ interface ProviderPageHeaderProps {
   isAnthropicProtocolCompatible: boolean;
   onOpenTutorial: () => void;
   t: ProviderMessageTranslator;
+  /**
+   * True when `providerInfo.website` was overridden with a Radar default
+   * referral link (D28 — referral links / free credits), rather than the
+   * static catalog `website`. Reuses the same discreet "Partner link" note
+   * as the pre-existing Kimi partnership link — both are the same kind of
+   * "this link supports OmniRoute" disclosure.
+   */
+  isReferralLink?: boolean;
 }
 
 export default function ProviderPageHeader({
@@ -37,6 +45,7 @@ export default function ProviderPageHeader({
   isAnthropicProtocolCompatible,
   onOpenTutorial,
   t,
+  isReferralLink = false,
 }: ProviderPageHeaderProps) {
   // Kimi (Moonshot AI) official-partnership aff links (2026-07): the header
   // website link doubles as the CTA for kimi-coding/kimi-web/moonshot's
@@ -45,6 +54,9 @@ export default function ProviderPageHeader({
   // reads as a monetized link, not just "visit provider website" like every
   // other card. UI-only — never affects routing/fallback (featuredProviders.ts).
   const isKimiPartnerLink = isKimiPartnerProviderId(providerInfo.id);
+  // D28: any Radar-driven default referral gets the exact same discreet
+  // disclosure treatment as the Kimi partner link.
+  const showPartnerNote = isKimiPartnerLink || isReferralLink;
   const kimiPartnerLinkNote = providerText(
     t,
     "kimiPartnerLinkNote",
@@ -88,9 +100,9 @@ export default function ProviderPageHeader({
               rel="noopener noreferrer"
               className="text-3xl font-semibold tracking-tight hover:underline inline-flex items-center gap-2"
               style={{ color: providerInfo.color }}
-              title={isKimiPartnerLink ? kimiPartnerLinkNote : undefined}
+              title={showPartnerNote ? kimiPartnerLinkNote : undefined}
               aria-label={
-                isKimiPartnerLink ? `${providerInfo.name} — ${kimiPartnerLinkNote}` : undefined
+                showPartnerNote ? `${providerInfo.name} — ${kimiPartnerLinkNote}` : undefined
               }
             >
               {providerInfo.name}
@@ -103,7 +115,7 @@ export default function ProviderPageHeader({
             <p className="text-text-muted">
               {t("connectionCountLabel", { count: connectionsCount })}
             </p>
-            {isKimiPartnerLink && providerInfo.website && (
+            {showPartnerNote && providerInfo.website && (
               <span className="text-[10px] font-medium uppercase tracking-wide text-text-muted/70">
                 {kimiPartnerLinkNote}
               </span>

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -511,6 +511,43 @@ export function buildCompactProviderEntries<TProvider>(
   return visibleEntries;
 }
 
+/**
+ * Result of `resolveProviderHeaderLink` — decides whether the provider name
+ * link on the detail page header (`ProviderPageHeader`) points at the
+ * static catalog `website` or at a Radar referral link.
+ */
+export interface ProviderHeaderLink {
+  /** Effective URL for the header link, or `undefined` for no link at all. */
+  website: string | undefined;
+  /** True when `website` came from a Radar default referral, not the static catalog. */
+  isReferralLink: boolean;
+}
+
+/**
+ * Pure decision function for the provider-name link (D28 — referral links).
+ * Deliberately DB-free and Radar-module-free: it takes the already-resolved
+ * referral URL (or `undefined`/`null` when none applies) as a plain string
+ * so this file — and the providers dashboard that depends on it — never has
+ * to import `@/lib/radar` (which pulls in `better-sqlite3`, Node-only) to
+ * render. The caller (`ProviderDetailPageClient`) is the one place allowed
+ * to fetch the referral, via the local `/api/radar/referrals` route — same
+ * pattern the Radar dashboard page already uses for its own data.
+ *
+ * With `RADAR_ENABLED` off, or no cache, or no default referral for the
+ * provider, `referralUrl` is `null`/`undefined` and this returns the exact
+ * same `website` the catalog already provided — byte-identical to today's
+ * behavior.
+ */
+export function resolveProviderHeaderLink(
+  staticWebsite: string | null | undefined,
+  referralUrl: string | null | undefined
+): ProviderHeaderLink {
+  if (referralUrl) {
+    return { website: referralUrl, isReferralLink: true };
+  }
+  return { website: staticWebsite ?? undefined, isReferralLink: false };
+}
+
 export function resolveDashboardProviderInfo(
   providerId: string,
   options?: {

--- a/src/app/(dashboard)/dashboard/radar/page.tsx
+++ b/src/app/(dashboard)/dashboard/radar/page.tsx
@@ -40,6 +40,24 @@ interface RadarMergedEntry {
 
 type PageState = "flag_off" | "optin_pending" | "empty" | "populated";
 
+/** D28 — referral links / free credits. Client-side mirror of RadarReferral. */
+interface RadarReferralItem {
+  provider: string;
+  url: string;
+  kind: "fixo" | "campanha";
+  validUntil: string | null;
+  requiredAction: string | null;
+  isDefault: boolean;
+}
+
+interface RadarReferralsState {
+  fixed: RadarReferralItem[];
+  campaigns: RadarReferralItem[];
+  tier: string | null;
+}
+
+type RadarTabId = "catalog" | "referrals";
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -101,6 +119,12 @@ export default function RadarPage() {
   const [optIn, setOptIn] = useState<boolean | null>(null);
   const [activating, setActivating] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [activeTab, setActiveTab] = useState<RadarTabId>("catalog");
+  const [referrals, setReferrals] = useState<RadarReferralsState>({
+    fixed: [],
+    campaigns: [],
+    tier: null,
+  });
 
   // Fetch catalog
   const fetchCatalog = useCallback(async () => {
@@ -127,6 +151,24 @@ export default function RadarPage() {
     }
   }, [t]);
 
+  // D28 — fetch the referral links section ("Pegue seus créditos grátis").
+  // Best-effort: flag off => 404, no cache => empty shape; either way this
+  // never blocks rendering of the rest of the page.
+  const fetchReferrals = useCallback(async () => {
+    try {
+      const res = await fetch("/api/radar/referrals");
+      if (!res.ok) return;
+      const data = await res.json();
+      setReferrals({
+        fixed: Array.isArray(data.fixed) ? data.fixed : [],
+        campaigns: Array.isArray(data.campaigns) ? data.campaigns : [],
+        tier: data.tier ?? null,
+      });
+    } catch {
+      // Best-effort only.
+    }
+  }, []);
+
   // Fetch settings to determine opt-in state (GET /api/radar/settings — FIX 3:
   // previously there was no settings GET, so an already-opted-in operator saw
   // the activation screen on every reload).
@@ -146,13 +188,16 @@ export default function RadarPage() {
         // Already opted in — load the catalog now so the populated/empty
         // state renders immediately instead of waiting for a manual sync.
         await fetchCatalog();
+        // D28 — load the referral links in parallel; best-effort, never
+        // blocks the catalog state above.
+        void fetchReferrals();
       }
     } catch {
       setOptIn(null);
     } finally {
       setLoading(false);
     }
-  }, [fetchCatalog]);
+  }, [fetchCatalog, fetchReferrals]);
 
   useEffect(() => {
     fetchSettings();
@@ -168,6 +213,7 @@ export default function RadarPage() {
       const data = await res.json();
       if (data.status === "updated" || data.status === "stale") {
         await fetchCatalog();
+        void fetchReferrals();
       } else if (data.status === "error" || data.status === "too_large") {
         // "too_large" reuses the generic sync-failed copy — the feed exceeded the
         // client-side size cap (10MB), which is operationally the same as any
@@ -183,7 +229,7 @@ export default function RadarPage() {
     } finally {
       setSyncing(false);
     }
-  }, [t, fetchCatalog]);
+  }, [t, fetchCatalog, fetchReferrals]);
 
   // Auto-sync on open: when the operator is already opted in and the cached
   // feed is stale (or absent), refresh it automatically once per mount so the
@@ -310,8 +356,120 @@ export default function RadarPage() {
             </Card>
           )}
 
+          {/* D28 — tab bar. Only shown once opted in (empty/populated) — the
+              activation gate above is a single full-screen step, not a tab. */}
+          {(pageState === "empty" || pageState === "populated") && (
+            <div className="flex gap-2 border-b border-border" role="tablist">
+              <button
+                role="tab"
+                aria-selected={activeTab === "catalog"}
+                onClick={() => setActiveTab("catalog")}
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === "catalog"
+                    ? "border-violet-500 text-violet-400"
+                    : "border-transparent text-text-muted hover:text-text-main"
+                }`}
+              >
+                {t("catalogTab")}
+              </button>
+              <button
+                role="tab"
+                aria-selected={activeTab === "referrals"}
+                onClick={() => setActiveTab("referrals")}
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === "referrals"
+                    ? "border-violet-500 text-violet-400"
+                    : "border-transparent text-text-muted hover:text-text-main"
+                }`}
+              >
+                {t("freeCreditsTab")}
+              </button>
+            </div>
+          )}
+
+          {/* Free credits tab (D28 — referral links) */}
+          {(pageState === "empty" || pageState === "populated") && activeTab === "referrals" && (
+            <div className="flex flex-col gap-6">
+              <p className="text-sm text-text-muted">{t("freeCreditsSubtitle")}</p>
+
+              {referrals.fixed.length === 0 ? (
+                <Card>
+                  <p className="text-text-muted text-center py-6">{t("fixedLinksEmpty")}</p>
+                </Card>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {referrals.fixed.map((referral) => (
+                    <Card key={`${referral.provider}:fixed`} padding="sm">
+                      <div className="flex flex-col gap-2">
+                        <span className="font-medium">{referral.provider}</span>
+                        {referral.requiredAction && (
+                          <p className="text-xs text-text-muted">
+                            {t("requiredActionLabel")} {referral.requiredAction}
+                          </p>
+                        )}
+                        <a
+                          href={referral.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-sm font-medium text-violet-400 hover:underline w-fit"
+                        >
+                          {t("claimButton")}
+                          <span className="material-symbols-outlined text-sm">open_in_new</span>
+                        </a>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              )}
+
+              <div>
+                <h3 className="text-lg font-semibold mb-3">{t("campaignsTitle")}</h3>
+                {referrals.campaigns.length === 0 ? (
+                  <Card>
+                    <p className="text-text-muted text-center py-6">
+                      {referrals.tier === "community"
+                        ? t("campaignsUpsellCommunity")
+                        : t("campaignsEmpty")}
+                    </p>
+                  </Card>
+                ) : (
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {referrals.campaigns.map((referral, idx) => (
+                      <Card key={`${referral.provider}:campaign:${idx}`} padding="sm">
+                        <div className="flex flex-col gap-2">
+                          <span className="font-medium">{referral.provider}</span>
+                          {referral.requiredAction && (
+                            <p className="text-xs text-text-muted">
+                              {t("requiredActionLabel")} {referral.requiredAction}
+                            </p>
+                          )}
+                          {referral.validUntil && (
+                            <p className="text-xs text-amber-400">
+                              {t("campaignsValidUntil", {
+                                date: new Date(referral.validUntil).toLocaleDateString(),
+                              })}
+                            </p>
+                          )}
+                          <a
+                            href={referral.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-sm font-medium text-violet-400 hover:underline w-fit"
+                          >
+                            {t("claimButton")}
+                            <span className="material-symbols-outlined text-sm">open_in_new</span>
+                          </a>
+                        </div>
+                      </Card>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* Empty cache — opted in but no data yet */}
-          {pageState === "empty" && (
+          {pageState === "empty" && activeTab === "catalog" && (
             <Card>
               <div className="flex flex-col items-center gap-4 py-12 text-center">
                 <p className="text-text-muted">{t("emptyState")}</p>
@@ -327,7 +485,7 @@ export default function RadarPage() {
           )}
 
           {/* Populated catalog table */}
-          {pageState === "populated" && (
+          {pageState === "populated" && activeTab === "catalog" && (
             <Card>
               <div className="overflow-x-auto">
                 <table className="w-full">

--- a/src/app/api/radar/referrals/route.ts
+++ b/src/app/api/radar/referrals/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/radar/referrals — return the referral links section ("Pegue seus
+ * créditos grátis", D28) of the locally cached Radar feed.
+ *
+ * NEVER proxies the private feed server. Like GET /api/radar/catalog, the
+ * browser talks only to this local endpoint; sync happens server-side via
+ * POST /api/radar/sync, and this route only reads the cache that sync
+ * already wrote.
+ *
+ * `fixed` referrals are present in every tier (community included, gated
+ * server-side); `campaigns` only comes populated on the `live` (supporter)
+ * tier — the community artifact publishes `campaigns: []` — so this route
+ * never needs to decide tier gating itself, it just relays what the cached
+ * feed already contains. `tier` is informative (from the cache row), used
+ * by the UI to show a soft upsell note when campaigns is empty.
+ *
+ * Flag off => 404 (the surface doesn't exist when disabled), checked BEFORE
+ * auth. Unauthenticated access once the flag is on => 401 (management route
+ * — dashboard session or a management-scoped key).
+ */
+
+import { NextResponse } from "next/server";
+import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
+import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
+import { getRadarReferrals } from "@/lib/radar";
+import { getRadarCache } from "@/lib/db/radar";
+import { buildErrorBody } from "@omniroute/open-sse/utils/error";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function OPTIONS() {
+  return handleCorsOptions();
+}
+
+export async function GET(request: Request) {
+  // Flag gate — surface doesn't exist when disabled. MUST run before auth.
+  if (!isFeatureFlagEnabled("RADAR_ENABLED")) {
+    return NextResponse.json(
+      buildErrorBody(404, "Not found"),
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json(
+      buildErrorBody(401, "Unauthorized"),
+      { status: 401, headers: CORS_HEADERS },
+    );
+  }
+
+  try {
+    const { fixed, campaigns } = getRadarReferrals();
+    const cache = getRadarCache();
+    return NextResponse.json(
+      { fixed, campaigns, tier: cache?.tier ?? null },
+      { headers: { ...CORS_HEADERS, "Cache-Control": "no-store" } },
+    );
+  } catch (err: unknown) {
+    const { sanitizeErrorMessage } = await import("@omniroute/open-sse/utils/error");
+    return NextResponse.json(
+      buildErrorBody(500, sanitizeErrorMessage(err) || "Failed to load Radar referrals"),
+      { status: 500, headers: CORS_HEADERS },
+    );
+  }
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "معطل بواسطة تغذية الرادار",
     "capTools": "الأدوات",
     "capVision": "الرؤية",
-    "capThinking": "التفكير"
+    "capThinking": "التفكير",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "إعداد المزود",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Radar axını tərəfindən deaktiv edilmişdir",
     "capTools": "Alətlər",
     "capVision": "Görmə",
-    "capThinking": "Düşünmə"
+    "capThinking": "Düşünmə",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Təchizatçı Quraşdırması",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Деактивирано от фийда на радара",
     "capTools": "Инструменти",
     "capVision": "Визия",
-    "capThinking": "Мислене"
+    "capThinking": "Мислене",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Настройка на доставчика",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "রাডার ফিড দ্বারা নিষ্ক্রিয়",
     "capTools": "টুলস",
     "capVision": "ভিশন",
-    "capThinking": "চিন্তা"
+    "capThinking": "চিন্তা",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "প্রদানকারী সেটআপ",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Zakázáno zdrojem Radar",
     "capTools": "Nástroje",
     "capVision": "Vize",
-    "capThinking": "Přemýšlení"
+    "capThinking": "Přemýšlení",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Nastavení poskytovatele",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Deaktiveret af Radar feed",
     "capTools": "Værktøjer",
     "capVision": "Vision",
-    "capThinking": "Tænkning"
+    "capThinking": "Tænkning",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Udbyder Opsætning",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Durch den Radar-Feed deaktiviert",
     "capTools": "Werkzeuge",
     "capVision": "Vision",
-    "capThinking": "Denken"
+    "capThinking": "Denken",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Anbieter-Einrichtung",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -12272,7 +12272,17 @@
     "disabledByFeed": "Disabled by Radar feed",
     "capTools": "Tools",
     "capVision": "Vision",
-    "capThinking": "Thinking"
+    "capThinking": "Thinking",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Provider Setup",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Desactivado por el feed de Radar",
     "capTools": "Herramientas",
     "capVision": "Visión",
-    "capThinking": "Pensando"
+    "capThinking": "Pensando",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Configuración del proveedor",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "غیرفعال شده توسط فید رادار",
     "capTools": "ابزارها",
     "capVision": "بینش",
-    "capThinking": "تفکر"
+    "capThinking": "تفکر",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "راه‌اندازی تأمین‌کننده",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Poissa käytöstä Radar-syötteen vuoksi",
     "capTools": "Työkalut",
     "capVision": "Näkemys",
-    "capThinking": "Ajattelu"
+    "capThinking": "Ajattelu",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Palveluntarjoajan asennus",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -12248,7 +12248,17 @@
     "disabledByFeed": "Désactivé par le flux Radar",
     "capTools": "Outils",
     "capVision": "Vision",
-    "capThinking": "Réflexion"
+    "capThinking": "Réflexion",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Configuration du fournisseur",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "રેડાર ફીડ દ્વારા અક્ષિપ્ત",
     "capTools": "સાધનો",
     "capVision": "દ્રષ્ટિ",
-    "capThinking": "વિચારવું"
+    "capThinking": "વિચારવું",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "પ્રદાતા સેટઅપ",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "מושבת על ידי פיד רדאר",
     "capTools": "כלים",
     "capVision": "חזון",
-    "capThinking": "חשיבה"
+    "capThinking": "חשיבה",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "הגדרת ספק",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "रडार फीड द्वारा अक्षम",
     "capTools": "उपकरण",
     "capVision": "दृष्टि",
-    "capThinking": "सोच"
+    "capThinking": "सोच",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "प्रदाता सेटअप",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "A Radar feed letiltotta",
     "capTools": "Eszközök",
     "capVision": "Látás",
-    "capThinking": "Gondolkodás"
+    "capThinking": "Gondolkodás",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Szolgáltató beállítása",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Dinonaktifkan oleh umpan Radar",
     "capTools": "Alat",
     "capVision": "Visi",
-    "capThinking": "Berpikir"
+    "capThinking": "Berpikir",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Pengaturan Penyedia",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "रडार फीड द्वारा अक्षम",
     "capTools": "उपकरण",
     "capVision": "दृष्टि",
-    "capThinking": "सोच"
+    "capThinking": "सोच",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "प्रदाता सेटअप",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Disabilitato dal feed Radar",
     "capTools": "Strumenti",
     "capVision": "Visione",
-    "capThinking": "Pensiero"
+    "capThinking": "Pensiero",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Configurazione del fornitore",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "レーダーフィードによって無効化されています",
     "capTools": "ツール",
     "capVision": "ビジョン",
-    "capThinking": "思考"
+    "capThinking": "思考",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "プロバイダーセットアップ",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "레이더 피드에 의해 비활성화됨",
     "capTools": "도구",
     "capVision": "비전",
-    "capThinking": "사고"
+    "capThinking": "사고",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "제공자 설정",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "रडार फीडद्वारे अक्षम",
     "capTools": "साधने",
     "capVision": "दृष्टिकोन",
-    "capThinking": "विचार"
+    "capThinking": "विचार",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "प्रदाता सेटअप",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Dilumpuhkan oleh suapan Radar",
     "capTools": "Alat",
     "capVision": "Visi",
-    "capThinking": "Berfikir"
+    "capThinking": "Berfikir",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Penyediaan Penyedia",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Uitgeschakeld door Radar-feed",
     "capTools": "Hulpmiddelen",
     "capVision": "Visie",
-    "capThinking": "Denken"
+    "capThinking": "Denken",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Leverancier Configuratie",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Deaktivert av Radar-strøm",
     "capTools": "Verktøy",
     "capVision": "Visjon",
-    "capThinking": "Tenking"
+    "capThinking": "Tenking",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Leverandøroppsett",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Disabled by Radar feed",
     "capTools": "Tools",
     "capVision": "Vision",
-    "capThinking": "Thinking"
+    "capThinking": "Thinking",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Provider Setup",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -12245,7 +12245,17 @@
     "disabledByFeed": "Wyłączone przez feed Radar",
     "capTools": "Narzędzia",
     "capVision": "Wizja",
-    "capThinking": "Myślenie"
+    "capThinking": "Myślenie",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Konfiguracja dostawcy",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -12272,7 +12272,17 @@
     "disabledByFeed": "Desativado pelo feed Radar",
     "capTools": "Ferramentas",
     "capVision": "Visão",
-    "capThinking": "Raciocínio"
+    "capThinking": "Raciocínio",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Configuração do Provedor",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Desativado pelo feed do Radar",
     "capTools": "Ferramentas",
     "capVision": "Visão",
-    "capThinking": "Pensando"
+    "capThinking": "Pensando",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Configuração do Fornecedor",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Dezactivat de feed-ul Radar",
     "capTools": "Instrumente",
     "capVision": "Viziune",
-    "capThinking": "Gândire"
+    "capThinking": "Gândire",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Configurare Furnizor",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -12317,7 +12317,17 @@
     "disabledByFeed": "Отключено лентой Радар",
     "capTools": "Инструменты",
     "capVision": "Видение",
-    "capThinking": "Мыслительный процесс"
+    "capThinking": "Мыслительный процесс",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Настройка провайдера",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Deaktivované príspevkom Radar",
     "capTools": "Nástroje",
     "capVision": "Vízia",
-    "capThinking": "Premýšľanie"
+    "capThinking": "Premýšľanie",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Nastavenie poskytovateľa",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Inaktiverad av Radar-flödet",
     "capTools": "Verktyg",
     "capVision": "Vision",
-    "capThinking": "Tänkande"
+    "capThinking": "Tänkande",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Leverantörsinstallation",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Inaktiverad av Radar-flödet",
     "capTools": "Verktyg",
     "capVision": "Vision",
-    "capThinking": "Tänkande"
+    "capThinking": "Tänkande",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Leverantörsinstallation",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "ரேடார் ஊட்டத்தால் முடக்கப்பட்டுள்ளது",
     "capTools": "கருவிகள்",
     "capVision": "பார்வை",
-    "capThinking": "சிந்தனை"
+    "capThinking": "சிந்தனை",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "வழங்குநர் அமைப்பு",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "రాడార్ ఫీడ్ ద్వారా అచ్ఛుతమైంది",
     "capTools": "సాధనాలు",
     "capVision": "దృష్టి",
-    "capThinking": "ఆలోచన"
+    "capThinking": "ఆలోచన",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "ప్రొవైడర్ సెటప్",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "ถูกปิดใช้งานโดยฟีดเรดาร์",
     "capTools": "เครื่องมือ",
     "capVision": "วิสัยทัศน์",
-    "capThinking": "การคิด"
+    "capThinking": "การคิด",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "การตั้งค่าผู้ให้บริการ",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Radar akışı tarafından devre dışı bırakıldı",
     "capTools": "Araçlar",
     "capVision": "Vizyon",
-    "capThinking": "Düşünme"
+    "capThinking": "Düşünme",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Sağlayıcı Kurulumu",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "Вимкнено через фід Радар",
     "capTools": "Інструменти",
     "capVision": "Візія",
-    "capThinking": "Мислення"
+    "capThinking": "Мислення",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Налаштування постачальника",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "ریڈار فیڈ کی وجہ سے غیر فعال",
     "capTools": "ٹولز",
     "capVision": "وژن",
-    "capThinking": "سوچنا"
+    "capThinking": "سوچنا",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "فراہم کنندہ سیٹ اپ",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -12264,7 +12264,17 @@
     "disabledByFeed": "Bị vô hiệu hóa bởi nguồn cấp dữ liệu Radar",
     "capTools": "Công cụ",
     "capVision": "Tầm nhìn",
-    "capThinking": "Suy nghĩ"
+    "capThinking": "Suy nghĩ",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "Thiết lập nhà cung cấp",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "被雷达数据源禁用",
     "capTools": "工具",
     "capVision": "视觉",
-    "capThinking": "思考"
+    "capThinking": "思考",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "提供者设置",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -12223,7 +12223,17 @@
     "disabledByFeed": "被雷達數據源禁用",
     "capTools": "工具",
     "capVision": "視覺",
-    "capThinking": "思考"
+    "capThinking": "思考",
+    "catalogTab": "Catalog",
+    "freeCreditsTab": "Free credits",
+    "freeCreditsSubtitle": "Referral links from Radar-tracked providers — using them costs you nothing extra and helps support OmniRoute.",
+    "fixedLinksEmpty": "No referral links available yet. Sync Radar to check for updates.",
+    "requiredActionLabel": "What to do:",
+    "claimButton": "Claim credits",
+    "campaignsTitle": "Limited-time campaigns",
+    "campaignsEmpty": "No active campaigns right now — check back later.",
+    "campaignsUpsellCommunity": "Limited-time campaigns are a supporter extra. Everything on this page's fixed links stays free for everyone.",
+    "campaignsValidUntil": "Valid until {date}"
   },
   "radarSetupPage": {
     "title": "提供者設置",

--- a/src/lib/radar/feedSchema.ts
+++ b/src/lib/radar/feedSchema.ts
@@ -85,6 +85,42 @@ const SetupSchema = z
   .nullable();
 
 // ---------------------------------------------------------------------------
+// Referral (D28 — referral links / free credits)
+// ---------------------------------------------------------------------------
+
+const ReferralKindEnum = z.enum(["fixo", "campanha"]);
+
+/** Referral URLs are always required to be https:// (never plain http). */
+const HttpsUrlSchema = z
+  .string()
+  .url()
+  .refine((v) => v.startsWith("https://"), { message: "Referral url must use https://" });
+
+const RadarReferralSchema = z.object({
+  provider: z.string(),
+  url: HttpsUrlSchema,
+  kind: ReferralKindEnum,
+  validUntil: z.string().nullable(),
+  requiredAction: z.string().nullable(),
+  isDefault: z.boolean(),
+});
+
+/**
+ * `referrals` is a whole-object `.default()` (not just a per-field default)
+ * so a cached feed downloaded before this section existed on the server
+ * still parses cleanly — `parsed.referrals` resolves to `{fixed:[],
+ * campaigns:[]}` instead of failing validation. `campaigns` also defaults
+ * independently so a feed that has `referrals.fixed` but omits `campaigns`
+ * (e.g. an intermediate server rollout) still parses.
+ */
+const RadarReferralsSchema = z
+  .object({
+    fixed: z.array(RadarReferralSchema).default([]),
+    campaigns: z.array(RadarReferralSchema).default([]),
+  })
+  .default({ fixed: [], campaigns: [] });
+
+// ---------------------------------------------------------------------------
 // Model
 // ---------------------------------------------------------------------------
 
@@ -156,6 +192,7 @@ export const RadarFeedSchema = z.object({
   providers: z.array(ProviderSchema),
   models: z.array(ModelSchema),
   quirks: z.array(QuirkSchema),
+  referrals: RadarReferralsSchema,
   totals: z.object({
     dedupedTokensPerMonth: z.number().int(),
     modelCount: z.number().int(),
@@ -172,3 +209,5 @@ export type RadarModel = z.infer<typeof ModelSchema>;
 export type RadarProvider = z.infer<typeof ProviderSchema>;
 export type RadarQuirk = z.infer<typeof QuirkSchema>;
 export type RadarBudget = z.infer<typeof BudgetSchema>;
+export type RadarReferral = z.infer<typeof RadarReferralSchema>;
+export type RadarReferrals = z.infer<typeof RadarReferralsSchema>;

--- a/src/lib/radar/index.ts
+++ b/src/lib/radar/index.ts
@@ -10,8 +10,9 @@
  */
 
 import { FREE_MODEL_BUDGETS } from "@omniroute/open-sse/config/freeModelCatalog";
-import { RadarFeedSchema, type RadarFeed } from "./feedSchema";
+import { RadarFeedSchema, type RadarFeed, type RadarReferral } from "./feedSchema";
 import { applyFeed, type MergedEntry, type FeedModel } from "./applyFeed";
+import { findDefaultReferral } from "./referrals";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
 import { getRadarCache } from "@/lib/db/radar";
 
@@ -130,5 +131,69 @@ export function getRadarCatalog(deps: GetRadarCatalogDeps = {}): RadarCatalogRes
   };
 }
 
+// ---------------------------------------------------------------------------
+// getRadarReferrals / getDefaultReferralFor
+// ---------------------------------------------------------------------------
+
+export interface RadarReferralsResult {
+  fixed: RadarReferral[];
+  campaigns: RadarReferral[];
+}
+
+const EMPTY_REFERRALS: RadarReferralsResult = { fixed: [], campaigns: [] };
+
+/** Injectable deps for testing — mirrors GetRadarCatalogDeps. */
+export interface GetRadarReferralsDeps {
+  getFlag?: (key: string) => boolean;
+  getCache?: () => { version: string; tier: string; payload: string; fetchedAt: string } | null;
+}
+
+/**
+ * Return the referral links section of the cached Radar feed.
+ *
+ * Never throws — returns `{fixed:[],campaigns:[]}` when: the flag is off,
+ * there is no cache yet, the cached payload fails defensive re-validation,
+ * or the cached feed predates the `referrals` section (old-feed compat —
+ * the schema's `.default()` already covers this, this is a second line of
+ * defense for a payload that fails to parse at all).
+ */
+export function getRadarReferrals(deps: GetRadarReferralsDeps = {}): RadarReferralsResult {
+  const { getFlag = isFeatureFlagEnabled, getCache: getCacheFn = getRadarCache } = deps;
+
+  if (!getFlag("RADAR_ENABLED")) {
+    return EMPTY_REFERRALS;
+  }
+
+  const cache = getCacheFn();
+  if (!cache) {
+    return EMPTY_REFERRALS;
+  }
+
+  let feed: RadarFeed;
+  try {
+    const parsed = JSON.parse(cache.payload);
+    feed = RadarFeedSchema.parse(parsed);
+  } catch {
+    return EMPTY_REFERRALS;
+  }
+
+  return feed.referrals ?? EMPTY_REFERRALS;
+}
+
+/**
+ * Return the fixed, isDefault:true referral link for `provider`, or `null`
+ * when there isn't one (flag off, no cache, or no matching default). Only
+ * looks at `fixed` referrals — see `findDefaultReferral` in `./referrals.ts`.
+ */
+export function getDefaultReferralFor(
+  provider: string,
+  deps: GetRadarReferralsDeps = {},
+): RadarReferral | null {
+  const { fixed } = getRadarReferrals(deps);
+  return findDefaultReferral(fixed, provider);
+}
+
 // Re-export merge types for convenience
 export { applyFeed, type MergedEntry, type FeedModel } from "./applyFeed";
+export { findDefaultReferral } from "./referrals";
+export type { RadarReferral } from "./feedSchema";

--- a/src/lib/radar/referrals.ts
+++ b/src/lib/radar/referrals.ts
@@ -1,0 +1,29 @@
+/**
+ * referrals.ts — pure helpers for the Radar "referral links / free credits"
+ * feature (D28).
+ *
+ * DELIBERATELY DB-FREE: this file must be safe to import from a `"use
+ * client"` component (e.g. the providers dashboard) without pulling in
+ * `@/lib/db/*` (better-sqlite3 is Node-only and cannot be bundled into the
+ * browser). The DB-touching accessors (`getRadarReferrals`,
+ * `getDefaultReferralFor`) live in `./index.ts` and delegate the actual
+ * "which referral is the default for this provider" decision back to
+ * `findDefaultReferral` here, so the logic is defined exactly once and both
+ * the server accessor and the client UI use the same rule.
+ */
+
+import type { RadarReferral } from "./feedSchema";
+
+/**
+ * Find the fixed, isDefault:true referral link for a provider.
+ *
+ * Only looks at `fixed` referrals by design — campaigns are never used as
+ * the "default" link on the provider name (they are temporary/opt-in extras
+ * surfaced separately on the Radar "free credits" tab).
+ */
+export function findDefaultReferral(
+  fixed: RadarReferral[],
+  provider: string,
+): RadarReferral | null {
+  return fixed.find((r) => r.provider === provider && r.isDefault === true) ?? null;
+}

--- a/tests/unit/provider-header-referral-link.test.ts
+++ b/tests/unit/provider-header-referral-link.test.ts
@@ -1,0 +1,84 @@
+/**
+ * tests/unit/provider-header-referral-link.test.ts
+ *
+ * TDD regression guard for the "referral link on the provider name" part of
+ * D28 (referral links / free credits). Covers the pure decision function
+ * `resolveProviderHeaderLink` used by ProviderDetailPageClient to decide
+ * whether the provider-name link (rendered by ProviderPageHeader) points at
+ * the static catalog `website` or at a Radar default referral.
+ *
+ * Loose-coupling requirements from the spec:
+ *  (a) RADAR_ENABLED off => byte-identical to today (covered indirectly:
+ *      when off, the caller never resolves a referralUrl, so this receives
+ *      null/undefined and returns the static website unchanged).
+ *  (b) No cache / no referral for the provider => same as (a).
+ *  (c) This file (providerPageUtils.ts) imports NO @/lib/radar or
+ *      @/lib/db/* symbol — asserted by source inspection so a future edit
+ *      cannot silently reintroduce a DB-touching import into a module a
+ *      "use client" component depends on.
+ *  (d) When a referral applies, isReferralLink=true (the header uses this to
+ *      show a discreet note, reusing the existing `kimiPartnerLinkNote` key).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveProviderHeaderLink } from "../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts";
+
+test("resolveProviderHeaderLink: no referral => keeps the static website, isReferralLink=false", () => {
+  const result = resolveProviderHeaderLink("https://groq.com", null);
+  assert.deepEqual(result, { website: "https://groq.com", isReferralLink: false });
+});
+
+test("resolveProviderHeaderLink: no referral, no static website => website undefined (today's no-link case)", () => {
+  const result = resolveProviderHeaderLink(undefined, null);
+  assert.deepEqual(result, { website: undefined, isReferralLink: false });
+});
+
+test("resolveProviderHeaderLink: referral present => overrides the static website, isReferralLink=true", () => {
+  const result = resolveProviderHeaderLink("https://groq.com", "https://groq.com/?ref=omniroute");
+  assert.deepEqual(result, {
+    website: "https://groq.com/?ref=omniroute",
+    isReferralLink: true,
+  });
+});
+
+test("resolveProviderHeaderLink: referral present even when catalog has no static website => still links out", () => {
+  const result = resolveProviderHeaderLink(undefined, "https://groq.com/?ref=omniroute");
+  assert.deepEqual(result, {
+    website: "https://groq.com/?ref=omniroute",
+    isReferralLink: true,
+  });
+});
+
+test("resolveProviderHeaderLink: empty-string referral is treated as absent (falsy)", () => {
+  const result = resolveProviderHeaderLink("https://groq.com", "");
+  assert.deepEqual(result, { website: "https://groq.com", isReferralLink: false });
+});
+
+// ---------------------------------------------------------------------------
+// Loose coupling — providerPageUtils.ts must not depend on the Radar/DB
+// modules to compute this (requirement (c) — see file docblock above).
+// ---------------------------------------------------------------------------
+
+test("providerPageUtils.ts does not import @/lib/radar or @/lib/db/* (loose coupling — D28)", () => {
+  const src = fs.readFileSync(
+    path.resolve(
+      process.cwd(),
+      "src/app/(dashboard)/dashboard/providers/providerPageUtils.ts"
+    ),
+    "utf-8"
+  );
+  const importLines = src
+    .split("\n")
+    .filter((line) => /^\s*import\b/.test(line));
+  assert.ok(
+    !importLines.some((line) => line.includes("@/lib/radar")),
+    "providerPageUtils.ts must not import @/lib/radar"
+  );
+  assert.ok(
+    !importLines.some((line) => line.includes("@/lib/db/")),
+    "providerPageUtils.ts must not import @/lib/db/*"
+  );
+});

--- a/tests/unit/radar-referrals-page-tab.test.ts
+++ b/tests/unit/radar-referrals-page-tab.test.ts
@@ -1,0 +1,127 @@
+/**
+ * tests/unit/radar-referrals-page-tab.test.ts
+ *
+ * Structural regression guard for the "Pegue seus créditos grátis" tab (D28)
+ * added to the existing /dashboard/radar page (no new dashboard route was
+ * created — per spec, less i18n/routing surface). Verifies:
+ *
+ *  - The page source wires a `referrals` tab fetching the LOCAL
+ *    /api/radar/referrals route only (never the private feed server).
+ *  - Every `t("...")` key the page references under the new tab exists (with
+ *    a non-empty value) in en.json — a stand-in for a full i18n-ui-coverage
+ *    run without needing to execute that whole gate here.
+ *  - No new dashboard route directory was created for this feature.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const PAGE_PATH = path.resolve(
+  process.cwd(),
+  "src/app/(dashboard)/dashboard/radar/page.tsx"
+);
+const PAGE_SRC = fs.readFileSync(PAGE_PATH, "utf-8");
+
+test("radar page: fetches referrals only from the local /api/radar/referrals route", () => {
+  assert.ok(
+    PAGE_SRC.includes('fetch("/api/radar/referrals")'),
+    "page must fetch the local referrals route"
+  );
+  // Never a direct call to an external feed-server URL from this component.
+  assert.ok(
+    !/https?:\/\/(?!localhost)/.test(PAGE_SRC.replace(/\/\*[\s\S]*?\*\//g, "")),
+    "page must never fetch an external URL directly (NEVER proxy the private feed server)"
+  );
+});
+
+test("radar page: renders a referrals tab with catalogTab/freeCreditsTab labels", () => {
+  assert.ok(PAGE_SRC.includes('t("catalogTab")'));
+  assert.ok(PAGE_SRC.includes('t("freeCreditsTab")'));
+  assert.ok(PAGE_SRC.includes('activeTab === "referrals"'));
+});
+
+test("radar page: campaigns-empty community upsell is soft (never blocks the fixed links list)", () => {
+  // The upsell only gates the campaigns section, never `referrals.fixed`.
+  assert.ok(PAGE_SRC.includes("campaignsUpsellCommunity"));
+  assert.ok(
+    !/fixed[\s\S]{0,80}tier === "community"/.test(PAGE_SRC),
+    "fixed links must never be gated on tier client-side (server already gates by artifact)"
+  );
+});
+
+test("no new dashboard route was created for the free-credits feature (spec: reuse /dashboard/radar)", () => {
+  const dashboardDir = path.resolve(process.cwd(), "src/app/(dashboard)/dashboard");
+  assert.ok(
+    !fs.existsSync(path.join(dashboardDir, "referrals")),
+    "must not create src/app/(dashboard)/dashboard/referrals/"
+  );
+  assert.ok(
+    !fs.existsSync(path.join(dashboardDir, "radar", "referrals")),
+    "must not create src/app/(dashboard)/dashboard/radar/referrals/ either — same page, new tab"
+  );
+});
+
+test("every t(\"...\") key referenced in the referrals tab section exists (non-empty) in en.json", () => {
+  const enMessages = JSON.parse(
+    fs.readFileSync(
+      path.resolve(process.cwd(), "src/i18n/messages/en.json"),
+      "utf-8"
+    )
+  );
+  const radarPage = enMessages.radarPage as Record<string, unknown>;
+  assert.ok(radarPage, "en.json must have a radarPage namespace");
+
+  const referencedKeys = [
+    "catalogTab",
+    "freeCreditsTab",
+    "freeCreditsSubtitle",
+    "fixedLinksEmpty",
+    "requiredActionLabel",
+    "claimButton",
+    "campaignsTitle",
+    "campaignsEmpty",
+    "campaignsUpsellCommunity",
+    "campaignsValidUntil",
+  ];
+
+  for (const key of referencedKeys) {
+    assert.ok(PAGE_SRC.includes(`t("${key}")` ) || PAGE_SRC.includes(`t("${key}",`), `page.tsx must reference t("${key}")`);
+    assert.equal(typeof radarPage[key], "string", `en.json radarPage.${key} must be a string`);
+    assert.ok((radarPage[key] as string).length > 0, `en.json radarPage.${key} must be non-empty`);
+  }
+});
+
+test("all 43 locale message files carry every new radarPage key with a non-empty value", () => {
+  const messagesDir = path.resolve(process.cwd(), "src/i18n/messages");
+  const files = fs.readdirSync(messagesDir).filter((f) => f.endsWith(".json"));
+  assert.ok(files.length >= 40, `expected ~43 locale files, found ${files.length}`);
+
+  const NEW_KEYS = [
+    "catalogTab",
+    "freeCreditsTab",
+    "freeCreditsSubtitle",
+    "fixedLinksEmpty",
+    "requiredActionLabel",
+    "claimButton",
+    "campaignsTitle",
+    "campaignsEmpty",
+    "campaignsUpsellCommunity",
+    "campaignsValidUntil",
+  ];
+
+  for (const file of files) {
+    const data = JSON.parse(fs.readFileSync(path.join(messagesDir, file), "utf-8"));
+    const radarPage = data.radarPage as Record<string, unknown> | undefined;
+    assert.ok(radarPage, `${file}: missing radarPage namespace`);
+    for (const key of NEW_KEYS) {
+      assert.equal(
+        typeof radarPage![key],
+        "string",
+        `${file}: radarPage.${key} must be a non-empty string`
+      );
+      assert.ok((radarPage![key] as string).length > 0, `${file}: radarPage.${key} is empty`);
+    }
+  }
+});

--- a/tests/unit/radar-referrals-route.test.ts
+++ b/tests/unit/radar-referrals-route.test.ts
@@ -1,0 +1,175 @@
+/**
+ * tests/unit/radar-referrals-route.test.ts
+ *
+ * TDD regression guard for GET /api/radar/referrals (D28 — referral links /
+ * free credits, client side). Mirrors tests/unit/radar-api-routes.test.ts:
+ *
+ *  - Flag off => 404, checked BEFORE auth (byte-identical inertia).
+ *  - Flag on, no auth => 401.
+ *  - Flag on, authenticated, no cache => 200 with { fixed: [], campaigns:
+ *    [], tier: null }.
+ *  - Flag on, authenticated, cached feed with referrals => 200 with the
+ *    cached fixed/campaigns + tier.
+ *  - Error responses never leak stack traces (Hard Rule #12).
+ *
+ * NEVER proxies the private feed server — this route only reads the local
+ * cache written by POST /api/radar/sync.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { SignJWT } from "jose";
+
+// ---------------------------------------------------------------------------
+// Isolate DB + feature flag state
+// ---------------------------------------------------------------------------
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-radar-referrals-api-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.STORAGE_ENCRYPTION_KEY = "test-encryption-key-for-radar-referrals-tests-32b!";
+process.env.JWT_SECRET = "test-jwt-secret-for-radar-referrals-tests";
+process.env.INITIAL_PASSWORD = "test-bootstrap-password-for-radar-referrals-tests";
+
+const core = await import("../../src/lib/db/core.ts");
+const radarDb = await import("../../src/lib/db/radar.ts");
+
+async function authCookieHeader(): Promise<string> {
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+  const token = await new SignJWT({ authenticated: true })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(secret);
+  return `auth_token=${token}`;
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  return { Cookie: await authCookieHeader() };
+}
+
+function mockGetRequest(
+  url = "http://localhost:20128/api/radar/referrals",
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(url, { method: "GET", headers });
+}
+
+function resetStorage() {
+  core.resetDbInstance();
+  try {
+    if (fs.existsSync(TEST_DATA_DIR)) {
+      fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    }
+  } catch {
+    // ignore
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+function baseFeed(): Record<string, unknown> {
+  return {
+    feed: "omniroute-radar",
+    schemaVersion: 1,
+    version: "2026-08-07.1",
+    generatedAt: new Date().toISOString(),
+    tier: "live",
+    counts: { providers: 0, models: 0 },
+    providers: [],
+    models: [],
+    quirks: [],
+    totals: { dedupedTokensPerMonth: 0, modelCount: 0, poolCount: 0 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("GET /api/radar/referrals: flag off => 404", async () => {
+  resetStorage();
+  delete process.env.RADAR_ENABLED;
+
+  const { GET } = await import("../../src/app/api/radar/referrals/route.ts");
+  const response = await GET(mockGetRequest());
+  const body = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.ok(body.error, "Response should have error field");
+  assert.ok(!JSON.stringify(body).includes("at /"), "Response must not leak stack traces");
+});
+
+test("GET /api/radar/referrals: flag on, no auth => 401", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { GET } = await import("../../src/app/api/radar/referrals/route.ts");
+  const response = await GET(mockGetRequest());
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.ok(body.error);
+  assert.ok(!JSON.stringify(body).includes("at /"), "Response must not leak stack traces");
+});
+
+test("GET /api/radar/referrals: flag on, authenticated, no cache => 200 empty shape", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const { GET } = await import("../../src/app/api/radar/referrals/route.ts");
+  const response = await GET(mockGetRequest(undefined, await authHeaders()));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body.fixed, []);
+  assert.deepEqual(body.campaigns, []);
+  assert.equal(body.tier, null);
+});
+
+test("GET /api/radar/referrals: flag on, authenticated, cached feed => returns fixed/campaigns/tier", async () => {
+  resetStorage();
+  process.env.RADAR_ENABLED = "true";
+
+  const feed = {
+    ...baseFeed(),
+    referrals: {
+      fixed: [
+        {
+          provider: "groq",
+          url: "https://groq.com/?ref=omniroute",
+          kind: "fixo",
+          validUntil: null,
+          requiredAction: null,
+          isDefault: true,
+        },
+      ],
+      campaigns: [],
+    },
+  };
+  radarDb.setRadarCache({
+    version: "2026-08-07.1",
+    tier: "live",
+    payload: JSON.stringify(feed),
+    signature: "test-signature",
+  });
+
+  const { GET } = await import("../../src/app/api/radar/referrals/route.ts");
+  const response = await GET(mockGetRequest(undefined, await authHeaders()));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.fixed.length, 1);
+  assert.equal(body.fixed[0].provider, "groq");
+  assert.deepEqual(body.campaigns, []);
+  assert.equal(body.tier, "live");
+});
+
+test("GET /api/radar/referrals: never proxies the private feed server (route source has no upstream fetch)", async () => {
+  const routeSrc = fs.readFileSync(
+    path.resolve(process.cwd(), "src/app/api/radar/referrals/route.ts"),
+    "utf-8",
+  );
+  assert.ok(!/fetch\(/.test(routeSrc), "referrals route must never call fetch() upstream");
+});

--- a/tests/unit/radar-referrals.test.ts
+++ b/tests/unit/radar-referrals.test.ts
@@ -1,0 +1,250 @@
+/**
+ * tests/unit/radar-referrals.test.ts
+ *
+ * TDD regression guard for the client-side "referral links / free credits"
+ * feature (D28). The server already publishes a `referrals` section on the
+ * signed feed (`{ fixed: RadarReferral[], campaigns: RadarReferral[] }`) —
+ * this suite covers the CLIENT side only:
+ *
+ *  - RadarFeedSchema: a feed WITHOUT `referrals` stays valid (compat with
+ *    old cached feeds); a feed WITH an invalid referral (non-https url) is
+ *    rejected.
+ *  - getRadarReferrals(): flag off => {fixed:[],campaigns:[]}; no cache =>
+ *    same; corrupt cache => same; feed without the section => same
+ *    (never throws).
+ *  - getDefaultReferralFor(): returns the fixed+isDefault referral for a
+ *    provider, ignores campaigns, returns null when none.
+ *  - findDefaultReferral() (pure helper, DB-free — must be importable from a
+ *    client bundle without pulling in @/lib/db/*): same contract as above,
+ *    operating directly on a `fixed` array.
+ *
+ * No DB is touched here — all DB access is injected via `deps`, matching
+ * the existing tests/unit/radar-apply-feed.test.ts convention.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RadarFeedSchema, type RadarFeed, type RadarReferral } from "../../src/lib/radar/feedSchema.ts";
+import { findDefaultReferral } from "../../src/lib/radar/referrals.ts";
+import { getRadarReferrals, getDefaultReferralFor } from "../../src/lib/radar/index.ts";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function baseFeed(): Record<string, unknown> {
+  return {
+    feed: "omniroute-radar",
+    schemaVersion: 1,
+    version: "2026-08-07.1",
+    generatedAt: new Date().toISOString(),
+    tier: "live",
+    counts: { providers: 0, models: 0 },
+    providers: [],
+    models: [],
+    quirks: [],
+    totals: { dedupedTokensPerMonth: 0, modelCount: 0, poolCount: 0 },
+  };
+}
+
+function makeReferral(overrides: Partial<RadarReferral> = {}): RadarReferral {
+  return {
+    provider: "groq",
+    url: "https://groq.com/?ref=omniroute",
+    kind: "fixo",
+    validUntil: null,
+    requiredAction: null,
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RadarFeedSchema — compat + validation
+// ---------------------------------------------------------------------------
+
+test("RadarFeedSchema: feed without `referrals` stays valid (old-feed compat)", () => {
+  const parsed = RadarFeedSchema.parse(baseFeed());
+  assert.deepEqual(parsed.referrals, { fixed: [], campaigns: [] });
+});
+
+test("RadarFeedSchema: feed with `referrals.fixed` but no `campaigns` defaults campaigns to []", () => {
+  const feed = { ...baseFeed(), referrals: { fixed: [makeReferral()] } };
+  const parsed = RadarFeedSchema.parse(feed);
+  assert.equal(parsed.referrals.fixed.length, 1);
+  assert.deepEqual(parsed.referrals.campaigns, []);
+});
+
+test("RadarFeedSchema: full referrals section round-trips", () => {
+  const feed = {
+    ...baseFeed(),
+    referrals: {
+      fixed: [makeReferral()],
+      campaigns: [
+        makeReferral({
+          provider: "openrouter",
+          kind: "campanha",
+          isDefault: false,
+          validUntil: "2026-12-31T00:00:00.000Z",
+          requiredAction: "Sign up with a credit card",
+        }),
+      ],
+    },
+  };
+  const parsed = RadarFeedSchema.parse(feed);
+  assert.equal(parsed.referrals.fixed.length, 1);
+  assert.equal(parsed.referrals.campaigns.length, 1);
+  assert.equal(parsed.referrals.campaigns[0]!.kind, "campanha");
+});
+
+test("RadarFeedSchema: rejects a referral with a non-https url", () => {
+  const feed = {
+    ...baseFeed(),
+    referrals: { fixed: [makeReferral({ url: "http://groq.com/?ref=omniroute" })], campaigns: [] },
+  };
+  assert.throws(() => RadarFeedSchema.parse(feed));
+});
+
+test("RadarFeedSchema: rejects an invalid `kind`", () => {
+  const feed = {
+    ...baseFeed(),
+    referrals: { fixed: [{ ...makeReferral(), kind: "bogus" }], campaigns: [] },
+  };
+  assert.throws(() => RadarFeedSchema.parse(feed));
+});
+
+// ---------------------------------------------------------------------------
+// findDefaultReferral — pure, DB-free helper (client-safe)
+// ---------------------------------------------------------------------------
+
+test("findDefaultReferral: returns the fixed+isDefault referral for the provider", () => {
+  const fixed = [
+    makeReferral({ provider: "groq", isDefault: true }),
+    makeReferral({ provider: "openrouter", isDefault: true }),
+  ];
+  const result = findDefaultReferral(fixed, "openrouter");
+  assert.equal(result?.provider, "openrouter");
+});
+
+test("findDefaultReferral: returns null when the provider has no default referral", () => {
+  const fixed = [makeReferral({ provider: "groq", isDefault: true })];
+  assert.equal(findDefaultReferral(fixed, "cerebras"), null);
+});
+
+test("findDefaultReferral: ignores a non-default fixed referral for the provider", () => {
+  const fixed = [makeReferral({ provider: "groq", isDefault: false })];
+  assert.equal(findDefaultReferral(fixed, "groq"), null);
+});
+
+test("findDefaultReferral: empty array => null", () => {
+  assert.equal(findDefaultReferral([], "groq"), null);
+});
+
+// ---------------------------------------------------------------------------
+// getRadarReferrals() — flag/cache gating, never throws
+// ---------------------------------------------------------------------------
+
+test("getRadarReferrals: flag off => empty, cache never read", () => {
+  let cacheReadCount = 0;
+  const result = getRadarReferrals({
+    getFlag: () => false,
+    getCache: () => {
+      cacheReadCount += 1;
+      throw new Error("cache must not be read when the flag is off");
+    },
+  });
+  assert.deepEqual(result, { fixed: [], campaigns: [] });
+  assert.equal(cacheReadCount, 0);
+});
+
+test("getRadarReferrals: flag on, no cache => empty", () => {
+  const result = getRadarReferrals({ getFlag: () => true, getCache: () => null });
+  assert.deepEqual(result, { fixed: [], campaigns: [] });
+});
+
+test("getRadarReferrals: flag on, corrupt cache payload => empty (defensive, never throws)", () => {
+  const result = getRadarReferrals({
+    getFlag: () => true,
+    getCache: () => ({
+      version: "x",
+      tier: "live",
+      payload: "{not-json",
+      fetchedAt: new Date().toISOString(),
+    }),
+  });
+  assert.deepEqual(result, { fixed: [], campaigns: [] });
+});
+
+test("getRadarReferrals: flag on, cached feed has no `referrals` section => empty", () => {
+  const result = getRadarReferrals({
+    getFlag: () => true,
+    getCache: () => ({
+      version: "x",
+      tier: "live",
+      payload: JSON.stringify(baseFeed()),
+      fetchedAt: new Date().toISOString(),
+    }),
+  });
+  assert.deepEqual(result, { fixed: [], campaigns: [] });
+});
+
+test("getRadarReferrals: flag on, cached feed has referrals => returns them", () => {
+  const feed = {
+    ...baseFeed(),
+    referrals: { fixed: [makeReferral()], campaigns: [] },
+  };
+  const result = getRadarReferrals({
+    getFlag: () => true,
+    getCache: () => ({
+      version: "x",
+      tier: "live",
+      payload: JSON.stringify(feed),
+      fetchedAt: new Date().toISOString(),
+    }),
+  });
+  assert.equal(result.fixed.length, 1);
+  assert.equal(result.fixed[0]!.provider, "groq");
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultReferralFor()
+// ---------------------------------------------------------------------------
+
+test("getDefaultReferralFor: flag off => null", () => {
+  const result = getDefaultReferralFor("groq", { getFlag: () => false, getCache: () => null });
+  assert.equal(result, null);
+});
+
+test("getDefaultReferralFor: returns the fixed default referral, ignoring campaigns", () => {
+  const feed = {
+    ...baseFeed(),
+    referrals: {
+      fixed: [makeReferral({ provider: "groq", isDefault: true })],
+      campaigns: [makeReferral({ provider: "groq", kind: "campanha", isDefault: true })],
+    },
+  };
+  const result = getDefaultReferralFor("groq", {
+    getFlag: () => true,
+    getCache: () => ({
+      version: "x",
+      tier: "live",
+      payload: JSON.stringify(feed),
+      fetchedAt: new Date().toISOString(),
+    }),
+  });
+  assert.equal(result?.kind, "fixo");
+});
+
+test("getDefaultReferralFor: provider with no default referral => null", () => {
+  const feed = { ...baseFeed(), referrals: { fixed: [], campaigns: [] } };
+  const result = getDefaultReferralFor("groq", {
+    getFlag: () => true,
+    getCache: () => ({
+      version: "x",
+      tier: "live",
+      payload: JSON.stringify(feed),
+      fetchedAt: new Date().toISOString(),
+    }),
+  });
+  assert.equal(result, null);
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9679 / #9688 (migration collision `134_ccr_blocks` × `134_proxy_logs_egress_ip` breaks every DB boot on the tip — being drained by #9688, not caused by this branch)

Client side of the referral-links feature (decision D28). The private feed server side is already implemented and deployed.

## What this adds
- **Feed schema**: `referrals: { fixed[], campaigns[] }` with `.default(...)` so pre-D28 feeds stay valid — the canonical fixture is deliberately NOT modified (it is a byte-identical mirror of the server's).
- **Accessors**: `getRadarReferrals()` / `getDefaultReferralFor()` — never throw; empty when the flag is off, no cache, or the feed predates the section. `findDefaultReferral()` lives in a DB-free module so client components can reuse the rule.
- **Route** `GET /api/radar/referrals`: 404 with the flag off (before anything else), 401 unauthenticated, then `{fixed, campaigns, tier}`. Never proxies the private server.
- **"Free credits" tab** inside `/dashboard/radar` (no new dashboard route): fixed links grouped by provider with their required action; temporary campaigns with validity; a soft supporter note only when campaigns are empty on the community tier — the free links are never gated.
- **Provider page**: the provider-name link prefers the Radar default referral when one exists. Decoupled by construction — the page fetches the local route and falls back to the static catalog website on 404/401/network error, so flag-off behaviour is byte-identical.

## Tier gating (server-side, for context)
Fixed links ship in every tier; temporary campaigns only exist in the `live` artifact. The server publishes two signed artifacts per version — the client never decides its own tier.

## Validation
58 tests green across the touched suites (`radar-referrals` 17, route 5, provider header 6, page tab 6, plus `radar-inertia` 5 and `radar-api-routes` 19 unchanged); DB-touching tests run against a deduplicated migrations dir because of the inherited 134 collision. `typecheck:core` clean for touched files; focused ESLint clean; `check:docs-all` clean for touched docs; `i18n:check-ui-coverage` PASS (10 new keys added to all 43 locales with English fallbacks).