### PR TITLE
fix(yuanbao-web): accept content field in SSE text events (upstream format change) (#8739)

### DIFF
--- a/changelog.d/fixes/8739-yuanbao-sse-parser.md
+++ b/changelog.d/fixes/8739-yuanbao-sse-parser.md
@@ -1,0 +1,1 @@
+- fix(yuanbao-web): accept `content` field in SSE text events (upstream format change) (#8739)

--- a/open-sse/executors/yuanbao-web.ts
+++ b/open-sse/executors/yuanbao-web.ts
@@ -457,9 +457,12 @@ function transformYuanbaoStream(
             if (event.type === "think" && event.content) {
               ensureRole();
               emit({ reasoning_content: event.content });
-            } else if (event.type === "text" && typeof event.msg === "string" && event.msg) {
-              ensureRole();
-              emit({ content: event.msg });
+            } else if (event.type === "text") {
+              const text = event.msg ?? event.content;
+              if (text) {
+                ensureRole();
+                emit({ content: text });
+              }
             }
           }
         }
@@ -498,7 +501,10 @@ async function collectYuanbaoResponse(
         const event = parseYuanbaoDataLine(line);
         if (!event) continue;
         if (event.type === "think" && event.content) reasoning += event.content;
-        else if (event.type === "text" && typeof event.msg === "string") content += event.msg;
+        else if (event.type === "text") {
+          const text = event.msg ?? event.content;
+          if (text) content += text;
+        }
       }
     }
   } finally {

--- a/tests/unit/providers-yuanbao-web.test.ts
+++ b/tests/unit/providers-yuanbao-web.test.ts
@@ -183,6 +183,91 @@ test("non-streaming request collects content and reasoning", async () => {
   }
 });
 
+test("streaming request handles text events with content field (upstream format change)", async () => {
+  // Upstream Yuanbao API changed text-event field from `msg` to `content`.
+  // The parser MUST handle both formats.
+  const original = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    calls.push(String(url));
+    if (String(url).includes("/conversation/create")) {
+      return new Response(JSON.stringify({ id: "conv-content" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      makeSSEBody([
+        'data: {"type":"think","content":"deep think..."}\n',
+        'data: {"type":"text","content":"New content format answer"}\n',
+        'data: {"type":"text","content":" with more"}\n',
+        'data: {"stopReason":"stop"}\n',
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    const exec = new YuanbaoWebExecutor();
+    const { response } = await exec.execute({
+      model: "deepseek-v3",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: true,
+      credentials: creds("hy_source=web; hy_user=u1; hy_token=t1"),
+      signal: null,
+    });
+    assert.equal(response.status, 200);
+    const text = await readStreamText(response);
+    assert.match(text, /"reasoning_content":"deep think\.\.\."/);
+    assert.match(text, /"content":"New content format answer"/);
+    assert.match(text, /"content":" with more"/);
+    assert.match(text, /"finish_reason":"stop"/);
+    assert.match(text, /data: \[DONE\]/);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("non-streaming request collects content from content field", async () => {
+  // Same content-field format in non-streaming path.
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    if (String(url).includes("/conversation/create")) {
+      return new Response(JSON.stringify({ id: "conv-ns-content" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      makeSSEBody([
+        'data: {"type":"think","content":"think-part"}\n',
+        'data: {"type":"text","content":"ContentFieldAnswer"}\n',
+        'data: {"stopReason":"stop"}\n',
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    const exec = new YuanbaoWebExecutor();
+    const { response } = await exec.execute({
+      model: "hunyuan-t1",
+      body: { messages: [{ role: "user", content: "q" }] },
+      stream: false,
+      credentials: creds("hy_source=web; hy_user=u1; hy_token=t1"),
+      signal: null,
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      choices: Array<{ message: { content: string; reasoning_content?: string } }>;
+    };
+    assert.equal(body.choices[0].message.content, "ContentFieldAnswer");
+    assert.equal(body.choices[0].message.reasoning_content, "think-part");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
 test("upstream 401 on conversation create surfaces an auth error (no stack leak)", async () => {
   const original = globalThis.fetch;
   globalThis.fetch = (async () =>


### PR DESCRIPTION
Closes #8739

**Root cause:** The YuanbaoWeb SSE parser only extracted text content from events matching `event.type === "text" && typeof event.msg === "string"`. The upstream Yuanbao API changed text-event format from `msg` to `content` field, so all text tokens were silently dropped -> empty response -> 502.

**Fix:** Updated both the streaming (`transformYuanbaoStream`) and non-streaming (`collectYuanbaoResponse`) paths to accept either `msg` or `content` field on text events, preferring `msg` for backward compatibility.

**Repro + verification (TDD, Hard Rule #18):**
- Wrote 2 failing tests using `content` field format (stream + non-stream) -- RED proven
- Applied fix -- both new tests and existing `msg`-format tests pass (9/9 GREEN)
- ESLint clean on both changed files
- Complexity and cognitive complexity gates pass (pre-existing baseline)
- Typecheck: only pre-existing errors in unrelated modules