### PR TITLE
fix(build): standalone bundle misses LLMLingua dist + onnxruntime native binaries

### DIFF
--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -48,10 +48,7 @@
 import fs from "node:fs/promises";
 import fsSync from "node:fs";
 import path from "node:path";
-import {
-  colocateLlmlinguaOptionals,
-  SEED_PACKAGES,
-} from "./colocateOptionals.mjs";
+import { colocateLlmlinguaOptionals, SEED_PACKAGES } from "./colocateOptionals.mjs";
 
 /**
  * Check whether a path exists (async).
@@ -78,7 +75,7 @@ async function exists(targetPath) {
  * (relative to projectRoot) and destination (relative to outDir) can be joined
  * for either path/platform. @type {{label:string, src:string[], dest:string[]}[]}
  */
-const NATIVE_ASSET_ENTRIES = [
+export const NATIVE_ASSET_ENTRIES = [
   {
     label: "wreq-js native runtime",
     src: ["node_modules", "wreq-js", "rust"],
@@ -88,6 +85,19 @@ const NATIVE_ASSET_ENTRIES = [
     label: "better-sqlite3 native binary",
     src: ["node_modules", "better-sqlite3", "build"],
     dest: ["node_modules", "better-sqlite3", "build"],
+  },
+  {
+    // onnxruntime-node's dist/binding.js dlopen()s a platform-specific
+    // libonnxruntime.so.1 shipped under bin/napi-v3/<platform>/<arch>/ — a
+    // *dynamic* native load Next.js's standalone file trace can't see (same
+    // blind spot class as the LLMLingua closure below, just for a .so instead
+    // of a JS import). Without this the standalone bundle boots with
+    // "Error: libonnxruntime.so.1: cannot open shared object file: No such
+    // file or directory" the first time transformers/llmlingua actually try
+    // to run ONNX inference.
+    label: "onnxruntime-node native binaries (libonnxruntime .so + .node addon)",
+    src: ["node_modules", "onnxruntime-node", "bin"],
+    dest: ["node_modules", "onnxruntime-node", "bin"],
   },
   {
     // TPROXY IP_TRANSPARENT addon (Fase 3 / Epic A). Built by build-tproxy-native
@@ -750,8 +760,7 @@ export function assembleStandalone({
       rootDir: projectRoot,
       targetNodeModulesDir: path.join(resolvedOutDir, "node_modules"),
       seeds: [...SEED_PACKAGES, "@huggingface/transformers"],
-      log: (message) =>
-        console.log(`[assembleStandalone] ${message.trim()}`),
+      log: (message) => console.log(`[assembleStandalone] ${message.trim()}`),
     });
   }
 

--- a/scripts/build/colocateOptionals.mjs
+++ b/scripts/build/colocateOptionals.mjs
@@ -157,9 +157,7 @@ export function colocateLlmlinguaOptionals({
   if (!existsSync(targetNm)) {
     return {
       skipped: true,
-      reason: targetNodeModulesDir
-        ? "no target node_modules"
-        : "no standalone dist/node_modules",
+      reason: targetNodeModulesDir ? "no target node_modules" : "no standalone dist/node_modules",
     };
   }
 
@@ -198,9 +196,7 @@ export function colocateLlmlinguaOptionals({
       });
       copied++;
     } catch (err) {
-      log(
-        `  ⚠️  LLMLingua optional co-location failed for ${name}: ${err.message}`
-      );
+      log(`  ⚠️  LLMLingua optional co-location failed for ${name}: ${err.message}`);
     }
   }
 

--- a/tests/unit/assemble-standalone-onnxruntime-native-asset.test.ts
+++ b/tests/unit/assemble-standalone-onnxruntime-native-asset.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test — onnxruntime-node's native libonnxruntime.so.1 was never
+ * registered in NATIVE_ASSET_ENTRIES, so the standalone bundle shipped
+ * dist/binding.js (traced by Next.js as a normal JS require) without its
+ * sibling native bin/ directory (loaded via a dynamic dlopen() Next's static
+ * file trace can't see — the same blind-spot class as the LLMLingua closure,
+ * for a .so instead of a JS import). The bundle then failed at runtime with
+ * "Error: libonnxruntime.so.1: cannot open shared object file: No such file
+ * or directory" the first time transformers/llmlingua tried to run ONNX
+ * inference — reproduced live via the Dockerfile's post-build verification
+ * step once the separate llmlingua-2 stub bug (#9653-adjacent fix) was
+ * resolved and the build progressed far enough to reach this package.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  NATIVE_ASSET_ENTRIES,
+  syncStandaloneNativeAssets,
+} from "../../scripts/build/assembleStandalone.mjs";
+
+test("NATIVE_ASSET_ENTRIES registers onnxruntime-node's native bin/ directory", () => {
+  const entry = NATIVE_ASSET_ENTRIES.find(
+    (e) => e.src.join("/") === "node_modules/onnxruntime-node/bin"
+  );
+  assert.ok(entry, "onnxruntime-node/bin must be a registered native asset entry");
+  assert.deepEqual(entry.dest, ["node_modules", "onnxruntime-node", "bin"]);
+});
+
+test("syncStandaloneNativeAssets copies onnxruntime-node's libonnxruntime.so.1 into the standalone bundle", async () => {
+  const root = mkdtempSync(join(tmpdir(), "omniroute-assemble-onnx-"));
+  try {
+    // Mirror the real package's shape: dist/binding.js (traced fine by Next)
+    // plus the platform-specific native .so under bin/napi-v3/<platform>/<arch>/.
+    const pkgDir = join(root, "node_modules", "onnxruntime-node");
+    mkdirSync(join(pkgDir, "dist"), { recursive: true });
+    writeFileSync(join(pkgDir, "dist", "binding.js"), "// native binding loader\n");
+    const soDir = join(pkgDir, "bin", "napi-v3", "linux", "x64");
+    mkdirSync(soDir, { recursive: true });
+    writeFileSync(join(soDir, "libonnxruntime.so.1"), "fake-shared-library-bytes");
+
+    const outDir = join(root, ".build", "next", "standalone");
+    mkdirSync(outDir, { recursive: true });
+
+    const changed = await syncStandaloneNativeAssets(root, undefined, { log: () => {} }, outDir);
+    assert.equal(changed, true);
+
+    const destSo = join(
+      outDir,
+      "node_modules",
+      "onnxruntime-node",
+      "bin",
+      "napi-v3",
+      "linux",
+      "x64",
+      "libonnxruntime.so.1"
+    );
+    assert.ok(existsSync(destSo), "libonnxruntime.so.1 must be copied into the standalone bundle");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/colocate-optionals.test.ts
+++ b/tests/unit/colocate-optionals.test.ts
@@ -196,6 +196,41 @@ test("colocateLlmlinguaOptionals skips when there is no standalone dist bundle",
   }
 });
 
+test("colocateLlmlinguaOptionals fills a Next-traced stub (package.json only, no dist) instead of skipping it", () => {
+  // Reproduces a real build failure: Next.js's own standalone trace can create
+  // a stub directory for a dynamically-imported optional dependency it
+  // references but can't fully bundle — just package.json, no actual code.
+  // The old skip check (`existsSync(dest)`) treated that stub as "already
+  // co-located" and never copied the real dist/ output, so
+  // require.resolve('@atjsh/llmlingua-2') found a package.json with no
+  // matching main file at runtime.
+  const root = mkdtempSync(join(tmpdir(), "omniroute-colocate-stub-"));
+  try {
+    buildRoot(root);
+    const distNm = join(root, "dist", "node_modules");
+    mkPkg(distNm, "@huggingface/transformers", { version: "3.5.2" });
+
+    // Simulate the Next-traced stub: directory exists, package.json only.
+    const stubDir = join(distNm, "@atjsh", "llmlingua-2");
+    mkdirSync(stubDir, { recursive: true });
+    writeFileSync(
+      join(stubDir, "package.json"),
+      readFileSync(join(root, "node_modules", "@atjsh", "llmlingua-2", "package.json"), "utf8")
+    );
+    assert.ok(!existsSync(join(stubDir, "dist", "index.js")), "stub must start without dist/");
+
+    const result = colocateLlmlinguaOptionals({ rootDir: root });
+    assert.equal(result.skipped, false, "must not treat the stub as already co-located");
+
+    assert.ok(
+      existsSync(join(stubDir, "dist", "index.js")),
+      "the real dist/index.js must be filled in, not left missing behind the stub"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("SEED_PACKAGES excludes transformers (it is a dist-pinned peer, not a seed)", () => {
   assert.ok(!SEED_PACKAGES.includes("@huggingface/transformers"));
   assert.deepEqual(SEED_PACKAGES, ["@atjsh/llmlingua-2", "@tensorflow/tfjs", "js-tiktoken"]);


### PR DESCRIPTION
## Summary

Two related build-tooling bugs found while debugging a Docker `runner-base` build, each the next failure once the prior one was fixed:

1. **`colocateLlmlinguaOptionals` skip-check treated a Next-traced stub as fully copied.** Next.js's own standalone trace creates a stub directory for `@atjsh/llmlingua-2` containing only `package.json` (it references the package but can't fully bundle a dynamically-imported optional dependency). The skip check (both the closure-level early return and the per-package loop) only tested `existsSync(dest)`, so that stub was indistinguishable from "already fully co-located" — the function skipped copying the real `dist/` output entirely, silently shipping a package with a manifest but no code, failing at runtime with `Cannot find module '.../dist/index.js'`.

2. **`onnxruntime-node`'s native `bin/` was never registered as a standalone asset.** `dist/binding.js` is a normal JS file Next's standalone trace bundles correctly, but it `dlopen()`s a platform-specific native library shipped under `bin/napi-v3/<platform>/<arch>/libonnxruntime.so.1` — a dynamic native load static tracing can't see (same blind-spot class as bug 1, just for a `.so` instead of a JS import). Fails at runtime with `Error: libonnxruntime.so.1: cannot open shared object file`.

## Fixes

1. `isPackageFullyCopied` originally fixed this by checking the package's declared `main` entry file. Since this branch was authored, upstream independently shipped its own fix for the same bug (`isPackageIntact`, which resolves the package via `require.resolve` from inside the target tree — a stronger check than a bare file-existence test). Rebasing picked that up; this PR's own diff now only carries the regression test coverage for the same bug.
2. Added `NATIVE_ASSET_ENTRIES` entry for `onnxruntime-node/bin`, mirroring the existing `better-sqlite3` entry.

⚠️ base-red inherited: #9737 (re-check at merge time)

## Test plan

- TDD: `tests/unit/colocate-optionals.test.ts` (+1 new case, 7/7 total) and `tests/unit/assemble-standalone-onnxruntime-native-asset.test.ts` (2/2, new file) — both confirmed failing against the pre-fix code on a clean `release/v3.8.50` checkout, passing after
- `npm run typecheck:core` — clean
- `npm run lint` — clean (scripts/ files are lint-ignored by config, as expected)
- `npm run check:file-size` — clean
- Both fixes originally confirmed against a real Docker `runner-base` build reaching further each time (Cannot find module -> libonnxruntime.so.1 missing -> build succeeds)

