### PR TITLE
fix(compression): persist enableRenderers in normalizeRtkConfig

### DIFF
--- a/src/lib/db/compression.ts
+++ b/src/lib/db/compression.ts
@@ -168,6 +168,10 @@ function normalizeRtkConfig(value: unknown): RtkConfig {
       typeof record.applyToAssistantMessages === "boolean"
         ? record.applyToAssistantMessages
         : DEFAULT_RTK_CONFIG.applyToAssistantMessages,
+    enableRenderers:
+      typeof record.enableRenderers === "boolean"
+        ? record.enableRenderers
+        : (DEFAULT_RTK_CONFIG.enableRenderers ?? false),
     enabledFilters: Array.isArray(record.enabledFilters)
       ? record.enabledFilters.filter((filter): filter is string => typeof filter === "string")
       : DEFAULT_RTK_CONFIG.enabledFilters,


### PR DESCRIPTION
## Problem

`enableRenderers` (RTK semantic renderers — git diff, test-green, structured table, terraform plan) is accepted by the API schema and persisted to the DB, but is silently dropped on every settings load.

`normalizeRtkConfig` in `src/lib/db/compression.ts` builds the config from a field whitelist: it spreads `DEFAULT_RTK_CONFIG` (where `enableRenderers: false`) and only overrides the explicitly listed keys. `enableRenderers` is not among them, so the stored value never reaches the engine. Both the dashboard API and the runtime chatCore loader (`open-sse/handlers/chatCore/compressionSettings.ts`) read through this normalizer, so renderers can never be activated via configuration.

Verified on 3.8.49 and present on `release/v3.8.50` / `main` (identical file SHA).

## Fix

Add `enableRenderers` to the normalizer whitelist, matching the existing boolean-field pattern:

```ts
enableRenderers:
  typeof record.enableRenderers === boolean
    ? record.enableRenderers
    : (DEFAULT_RTK_CONFIG.enableRenderers ?? false),
```

## Testing

- The RTK engine already consumes `config.enableRenderers` (opt-in, fail-open, default OFF — `engines/rtk/index.ts`).
- The API schema already accepts it (`compressionConfigSchemas.ts` line 78).
- The `rtkConfigSchema` / engine `getConfigSchema()` already advertise it.

## Impact

Unblocks semantic renderers for RTK (the single biggest token-savings lever on git/test/tool output for coding-agent traffic).