### PR TITLE
fix(compression): persist RTK renderer configuration

### DIFF
--- a/changelog.d/fixes/9730-persist-rtk-renderers.md
+++ b/changelog.d/fixes/9730-persist-rtk-renderers.md
@@ -1,0 +1,1 @@
+- fix(compression): persist `enableRenderers` through `normalizeRtkConfig` so RTK renderer settings survive a DB round-trip ([#9730](https://github.com/diegosouzapw/OmniRoute/pull/9730))

--- a/src/lib/db/compression.ts
+++ b/src/lib/db/compression.ts
@@ -168,6 +168,10 @@ function normalizeRtkConfig(value: unknown): RtkConfig {
       typeof record.applyToAssistantMessages === "boolean"
         ? record.applyToAssistantMessages
         : DEFAULT_RTK_CONFIG.applyToAssistantMessages,
+    enableRenderers:
+      typeof record.enableRenderers === "boolean"
+        ? record.enableRenderers
+        : (DEFAULT_RTK_CONFIG.enableRenderers ?? false),
     enabledFilters: Array.isArray(record.enabledFilters)
       ? record.enabledFilters.filter((filter): filter is string => typeof filter === "string")
       : DEFAULT_RTK_CONFIG.enabledFilters,

--- a/tests/unit/compression/rtk-renderers-config.test.ts
+++ b/tests/unit/compression/rtk-renderers-config.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, afterEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { rtkConfigSchema } from "../../../src/shared/validation/compressionConfigSchemas.ts";
+import { DEFAULT_RTK_CONFIG } from "../../../open-sse/services/compression/types.ts";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rtk-renderers-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../../src/lib/db/core.ts");
+const { getCompressionSettings, updateCompressionSettings } =
+  await import("../../../src/lib/db/compression.ts");
+
+describe("RTK renderer config persistence", () => {
+  afterEach(() => {
+    core.resetDbInstance();
+  });
+
+  after(() => {
+    core.resetDbInstance();
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  });
+
+  it("accepts enableRenderers on the strict write schema", () => {
+    assert.equal(rtkConfigSchema.safeParse({ enableRenderers: true }).success, true);
+  });
+
+  it("preserves enableRenderers through a fresh DB read", async () => {
+    const settings = await updateCompressionSettings({
+      rtkConfig: { ...DEFAULT_RTK_CONFIG, enableRenderers: true },
+    });
+    assert.equal(settings.rtkConfig.enableRenderers, true);
+
+    core.resetDbInstance();
+    const reread = await getCompressionSettings();
+    assert.equal(reread.rtkConfig.enableRenderers, true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes persistence of the RTK `enableRenderers` setting.

`enableRenderers` is already part of the RTK default config, engine config schema, and API validation schema. However, `normalizeRtkConfig()` did not read the stored field, so a configured `true` value was silently replaced by the default `false` whenever settings were loaded. This affected both the dashboard read path and runtime compression settings.

## Changes

- Preserve `enableRenderers` in `normalizeRtkConfig()`.
- Add a regression test covering schema acceptance and a fresh SQLite round-trip.

## Verification

Focused checks passed:

- `node --import tsx/esm --test tests/unit/compression/rtk-renderers-config.test.ts`
- `node --import tsx/esm --test tests/unit/compression/rtk-renderers-config.test.ts tests/unit/compression/rtk-renderers-integration.test.ts tests/unit/compression/rtk-grouping-config.test.ts`
- `npm run test:scoped -- --staged`
- Targeted ESLint for the changed source and test files
- `git diff --check`
- Commit hooks / tracked-artifacts checks

The full repository lint currently reports unrelated pre-existing errors in `open-sse/services/combo.ts` and `tests/unit/repro-9630-combo-false-503.test.ts`; the changed files pass targeted lint.

## Scope

No schema, API shape, engine behavior, or default behavior changes. The existing default remains `false`; explicitly persisted values now survive reloads.
