### PR TITLE
feat(logging): bump CHAT_LOG_ARRAY_TAIL_ITEMS default 24 -> 128

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1426,7 +1426,7 @@ APP_LOG_TO_FILE=true
 # bodies is retained in the database.
 # Used by: open-sse/handlers/chatCore.ts — cloneBoundedChatLogPayload()
 # CHAT_LOG_TEXT_LIMIT=65536                  # Max string length before truncation (default: 64 KB)
-# CHAT_LOG_ARRAY_TAIL_ITEMS=24               # Number of array items retained from tail (default: 24)
+# CHAT_LOG_ARRAY_TAIL_ITEMS=128               # Number of array items retained from tail (default: 128)
 # CHAT_LOG_MAX_DEPTH=6                       # Max nesting depth before truncation (default: 6)
 # CHAT_LOG_MAX_OBJECT_KEYS=80                # Max object keys retained (default: 80, 0 = no limit)
 

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -741,7 +741,7 @@ The logging system writes to both stdout and rotated log files. All configuratio
 | `PROXY_LOGS_TABLE_MAX_ROWS`               | `100000`                   | Max rows in the `proxy_logs` SQLite table before pruning.                         |
 | `APP_LOG_ROTATION_CHECK_INTERVAL_MS`      | `60000` (1 min)            | How often `src/lib/logRotation.ts` re-checks the active log file size.            |
 | `CHAT_LOG_TEXT_LIMIT`                     | `65536`                    | Max string length retained in chat log artifacts (default 64 KB).                 |
-| `CHAT_LOG_ARRAY_TAIL_ITEMS`               | `24`                       | Number of array items retained from the tail when truncating chat log payloads.   |
+| `CHAT_LOG_ARRAY_TAIL_ITEMS`               | `128`                      | Number of array items retained from the tail when truncating chat log payloads.   |
 | `CHAT_LOG_MAX_DEPTH`                      | `6`                        | Max nesting depth before chat log payloads are truncated.                         |
 | `CHAT_LOG_MAX_OBJECT_KEYS`                | `80`                       | Max object keys retained in chat log payloads (0 = unlimited).                    |
 | `CHAT_DEBUG_FILE`                         | `false`                    | When true, `serializeArtifactForStorage` skips size-based truncation. Debug only. |

--- a/src/lib/logEnv.ts
+++ b/src/lib/logEnv.ts
@@ -146,8 +146,19 @@ export function getChatLogTextLimit(): number {
   return parsePositiveInt(process.env.CHAT_LOG_TEXT_LIMIT, 64 * 1024);
 }
 
+/**
+ * Was a hardcoded/default 24 — real agentic CLIs with many MCP servers
+ * routinely declare 40-50+ tools in a single `tools[]` array (a live
+ * OpenClaw session logged 47), so the tail-24 default silently dropped the
+ * array's earlier entries behind an `_omniroute_truncated_array` marker —
+ * including, in one traced case, the tool actually being called
+ * (`apply_patch`), making its declared shape unrecoverable from the call
+ * log even though the call itself succeeded. Bumped to comfortably cover
+ * real large tool lists with headroom; same configurable-override pattern
+ * as the sibling CHAT_LOG_TEXT_LIMIT/CHAT_LOG_MAX_BODY_KB vars.
+ */
 export function getChatLogArrayTailItems(): number {
-  return parsePositiveInt(process.env.CHAT_LOG_ARRAY_TAIL_ITEMS, 24);
+  return parsePositiveInt(process.env.CHAT_LOG_ARRAY_TAIL_ITEMS, 128);
 }
 
 export function getChatLogMaxDepth(): number {

--- a/tests/unit/chat-log-array-tail-items-default.test.ts
+++ b/tests/unit/chat-log-array-tail-items-default.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for the CHAT_LOG_ARRAY_TAIL_ITEMS default bump 24 -> 128.
+ *
+ * Real agentic CLIs with many MCP servers routinely declare 40-50+ tools in
+ * a single request — a live OpenClaw session logged 47. The old tail-24
+ * default silently dropped the array's earlier entries behind an
+ * `_omniroute_truncated_array` marker, including (in one traced case) the
+ * tool actually being called, making its declared shape unrecoverable from
+ * the call log even though the call itself succeeded.
+ *
+ * Pins the literal default so a future edit can't silently regress it back
+ * toward the old, too-small value.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getChatLogArrayTailItems } from "@/lib/logEnv";
+
+test("getChatLogArrayTailItems defaults to 128 (not the old 24) when unset", () => {
+  const saved = process.env.CHAT_LOG_ARRAY_TAIL_ITEMS;
+  delete process.env.CHAT_LOG_ARRAY_TAIL_ITEMS;
+  try {
+    assert.equal(getChatLogArrayTailItems(), 128);
+  } finally {
+    if (saved === undefined) delete process.env.CHAT_LOG_ARRAY_TAIL_ITEMS;
+    else process.env.CHAT_LOG_ARRAY_TAIL_ITEMS = saved;
+  }
+});


### PR DESCRIPTION
## Summary

Real agentic CLIs with many MCP servers routinely declare 40-50+ tools in a single request — a live OpenClaw session logged 47. The tail-24 default silently dropped the array's earlier entries behind an `_omniroute_truncated_array` marker, so investigating why a specific tool call (`apply_patch`) behaved oddly turned up nothing: its declared shape (function vs custom type) was unrecoverable from the call log across 40 recent requests, even though the calls themselves succeeded.

Bumped the configurable default to comfortably cover real large tool lists with headroom. Updated `.env.example` and `docs/reference/ENVIRONMENT.md` to match (env-doc-sync check passes).

⚠️ base-red inherited: #9737

## Test plan

- TDD: new `tests/unit/chat-log-array-tail-items-default.test.ts` pins the literal default (24 -> 128) — confirmed failing on a clean `release/v3.8.50` checkout, passing after. (The original commit had no dedicated test; the pre-existing `chatcore-log-truncation.test.ts` derives its own expectations from `getChatLogArrayTailItems()` so it can't discriminate this specific regression.)
- `npm run typecheck:core` — clean
- `npm run lint` — clean
- `npm run check:file-size` — clean
