### PR TITLE
[TS7] test(types): use Vitest expectations in tier resolver

### DIFF
--- a/open-sse/services/__tests__/tierResolver.test.ts
+++ b/open-sse/services/__tests__/tierResolver.test.ts
@@ -199,10 +199,10 @@ describe("TierResolver", () => {
       ]);
       // Observable effect of the cache: the duplicate resolves to the same tier and only
       // ONE entry is memoized (getTierStats counts cache entries, not classify calls).
-      assert.equal(results.length, 2);
-      assert.equal(results[0].tier, results[1].tier);
+      expect(results).toHaveLength(2);
+      expect(results[0].tier).toBe(results[1].tier);
       const stats = getTierStats();
-      assert.equal(stats.free + stats.cheap + stats.premium, 1);
+      expect(stats.free + stats.cheap + stats.premium).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- replace three stray Node assert.equal calls with the Vitest expect API already imported by the test
- preserve the existing cache behavior assertions
- remove three TypeScript diagnostics without touching production code

## Validation

- /Users/backryun/OmniRoute/node_modules/.bin/vitest run open-sse/services/__tests__/tierResolver.test.ts (32 passed)
- TypeScript 6.0.3 full open-sse check: 72 -> 69, 3 removed, 0 added
- TypeScript 7.0.2 full open-sse check: 71 -> 68, 3 removed, 0 added

Tracks #8484.