### PR TITLE
[TS7] fix(translator): preserve video URL override contracts

### DIFF
--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -372,7 +372,9 @@ export function translateRequest(
       preserveReasoningContent: isReasoner,
       // Per-provider/model preserveVideoUrl flag from compat overrides.
       // Falls back to true for moonshot/kimi when unset (legacy behavior).
-      preserveVideoUrl: getModelPreserveVideoUrl(normalizedProvider, options?.model ?? "") ?? (normalizedProvider === "moonshot" || normalizedProvider === "kimi"),
+      preserveVideoUrl:
+        getModelPreserveVideoUrl(normalizedProvider, normalizedModel) ??
+        (normalizedProvider === "moonshot" || normalizedProvider === "kimi"),
     });
   }
 

--- a/src/lib/db/models/compat.ts
+++ b/src/lib/db/models/compat.ts
@@ -17,6 +17,7 @@ export { MODEL_COMPAT_PROTOCOL_KEYS, type ModelCompatProtocolKey };
 export type ModelCompatPerProtocol = {
   normalizeToolCallId?: boolean;
   preserveOpenAIDeveloperRole?: boolean;
+  preserveVideoUrl?: boolean;
   /** Merged into upstream HTTP requests for this model (after default auth headers). */
   upstreamHeaders?: Record<string, string>;
 };
@@ -76,6 +77,7 @@ export function deepMergeCompatByProtocol(
     const hasDelta =
       Object.prototype.hasOwnProperty.call(deltas, "normalizeToolCallId") ||
       Object.prototype.hasOwnProperty.call(deltas, "preserveOpenAIDeveloperRole") ||
+      Object.prototype.hasOwnProperty.call(deltas, "preserveVideoUrl") ||
       Object.prototype.hasOwnProperty.call(deltas, "upstreamHeaders");
     if (!hasDelta) continue;
     const cur: ModelCompatPerProtocol = { ...(out[key] || {}) };
@@ -84,6 +86,9 @@ export function deepMergeCompatByProtocol(
     }
     if ("preserveOpenAIDeveloperRole" in deltas) {
       cur.preserveOpenAIDeveloperRole = Boolean(deltas.preserveOpenAIDeveloperRole);
+    }
+    if ("preserveVideoUrl" in deltas) {
+      cur.preserveVideoUrl = Boolean(deltas.preserveVideoUrl);
     }
     if ("upstreamHeaders" in deltas) {
       const uh = deltas.upstreamHeaders;
@@ -105,6 +110,7 @@ export type ModelCompatOverride = {
   id: string;
   normalizeToolCallId?: boolean;
   preserveOpenAIDeveloperRole?: boolean;
+  preserveVideoUrl?: boolean;
   compatByProtocol?: CompatByProtocolMap;
   upstreamHeaders?: Record<string, string>;
   isHidden?: boolean;
@@ -159,6 +165,7 @@ export function getModelCompatOverrides(providerId: string): ModelCompatOverride
 export type ModelCompatPatch = {
   normalizeToolCallId?: boolean;
   preserveOpenAIDeveloperRole?: boolean | null;
+  preserveVideoUrl?: boolean | null;
   compatByProtocol?: CompatByProtocolMap;
   /** Replace top-level extra headers for override-only rows; omit to leave unchanged. */
   upstreamHeaders?: Record<string, string> | null;
@@ -195,6 +202,13 @@ export function mergeModelCompatOverride(
       next.preserveOpenAIDeveloperRole = Boolean(patch.preserveOpenAIDeveloperRole);
     }
   }
+  if ("preserveVideoUrl" in patch) {
+    if (patch.preserveVideoUrl === null) {
+      delete next.preserveVideoUrl;
+    } else {
+      next.preserveVideoUrl = Boolean(patch.preserveVideoUrl);
+    }
+  }
   if (patch.compatByProtocol && Object.keys(patch.compatByProtocol).length > 0) {
     const merged = deepMergeCompatByProtocol(next.compatByProtocol, patch.compatByProtocol);
     if (compatByProtocolHasEntries(merged)) next.compatByProtocol = merged;
@@ -211,6 +225,7 @@ export function mergeModelCompatOverride(
   }
   const filtered = list.filter((e) => e.id !== modelId);
   const hasPreserveFlag = Object.prototype.hasOwnProperty.call(next, "preserveOpenAIDeveloperRole");
+  const hasVideoUrlFlag = Object.prototype.hasOwnProperty.call(next, "preserveVideoUrl");
   const hasTopUpstream = next.upstreamHeaders && Object.keys(next.upstreamHeaders).length > 0;
   if ("isHidden" in patch) {
     if (patch.isHidden === null) {
@@ -231,6 +246,7 @@ export function mergeModelCompatOverride(
   if (
     next.normalizeToolCallId ||
     hasPreserveFlag ||
+    hasVideoUrlFlag ||
     hasHiddenFlag ||
     hasDeletedFlag ||
     compatByProtocolHasEntries(next.compatByProtocol) ||

--- a/tests/unit/preserve-video-url-compat.test.ts
+++ b/tests/unit/preserve-video-url-compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "node:test";
-import { ok, equal } from "node:assert/strict";
+import { deepEqual, equal, ok } from "node:assert/strict";
 
 describe("getModelPreserveVideoUrl", () => {
   it("exports getModelPreserveVideoUrl as a function", async () => {
@@ -8,8 +8,7 @@ describe("getModelPreserveVideoUrl", () => {
   });
 
   it("fallback preserves moonshot and kimi legacy behavior", () => {
-    const fallback = (provider: string) =>
-      provider === "moonshot" || provider === "kimi";
+    const fallback = (provider: string) => provider === "moonshot" || provider === "kimi";
     ok(fallback("moonshot"));
     ok(fallback("kimi"));
     equal(fallback("dashscope"), false);
@@ -27,19 +26,67 @@ describe("getModelPreserveVideoUrl", () => {
   });
 
   it("mergeModelCompatOverride accepts preserveVideoUrl", async () => {
-    const { mergeModelCompatOverride, removeModelCompatOverride } = await import("@/lib/db/models/compat");
+    const { mergeModelCompatOverride, removeModelCompatOverride } =
+      await import("@/lib/db/models/compat");
+    const { getModelPreserveVideoUrl } = await import("@/lib/db/models/modelPreserveVideoUrl");
     const PROVIDER = "test_provider_9248v3";
     const MODEL = "test_model_qwen_vl";
-    mergeModelCompatOverride(PROVIDER, MODEL, { preserveVideoUrl: true });
-    removeModelCompatOverride(PROVIDER, MODEL);
-    ok(true, "should accept preserveVideoUrl in ModelCompatPatch");
+    try {
+      mergeModelCompatOverride(PROVIDER, MODEL, { preserveVideoUrl: true });
+      equal(getModelPreserveVideoUrl(PROVIDER, MODEL), true);
+    } finally {
+      removeModelCompatOverride(PROVIDER, MODEL);
+    }
+  });
+
+  it("translateRequest resolves preserveVideoUrl with the routed model", async () => {
+    const { mergeModelCompatOverride, removeModelCompatOverride } =
+      await import("@/lib/db/models/compat");
+    const { translateRequest } = await import("@omniroute/open-sse/translator/index.ts");
+    const provider = "test-provider-video-override";
+    const model = "test-model-video-override";
+
+    mergeModelCompatOverride(provider, model, { preserveVideoUrl: true });
+    try {
+      const translated = translateRequest(
+        "openai",
+        "openai",
+        model,
+        {
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "video_url",
+                  video_url: { url: "https://cdn.example.com/input.mp4" },
+                },
+              ],
+            },
+          ],
+        },
+        false,
+        null,
+        provider
+      ) as { messages: Array<{ content: Array<{ type: string }> }> };
+
+      deepEqual(
+        translated.messages[0].content.map((part) => part.type),
+        ["video_url"]
+      );
+    } finally {
+      removeModelCompatOverride(provider, model);
+    }
   });
 
   it("deepMergeCompatByProtocol accepts preserveVideoUrl under openai protocol", async () => {
     const { deepMergeCompatByProtocol } = await import("@/lib/db/models/compat");
-    const result = deepMergeCompatByProtocol({}, {
-      openai: { preserveVideoUrl: true },
-    });
+    const result = deepMergeCompatByProtocol(
+      {},
+      {
+        openai: { preserveVideoUrl: true },
+      }
+    );
     // Valid protocol keys are 'openai', 'openai-responses', 'claude'
     equal(result.openai?.preserveVideoUrl, true);
   });


### PR DESCRIPTION
## Summary

- pass the routed model into the preserveVideoUrl compatibility lookup
- persist and merge preserveVideoUrl in top-level and per-protocol model compatibility overrides
- add regression coverage proving a non-Moonshot model keeps video_url when its override enables it

## TypeScript 7 impact

Measured against release/v3.8.50 at ee0f4298ca60340e230c2057454f810c62be63b4:

- TypeScript 6: 72 -> 71, removed 1, added 0
- TypeScript 7.0.2: 71 -> 70, removed 1, added 0
- combined with open TS7 PR #9742: 72 -> 68 and 71 -> 67, removed 4, added 0

The removed diagnostic is TS2339 in open-sse/translator/index.ts. The function already receives the routed model as its third parameter; reading options.model referenced a property that does not exist and made the compatibility lookup use an empty model id at runtime.

## Validation

- focused tests on a temporary #9745 migration-fix overlay: 26/26 passed
- npm run typecheck:core: passed
- targeted ESLint on all changed files: passed
- full TypeScript 6 and TypeScript 7 diagnostic multiset comparison: zero new diagnostics
- combined #9742 overlay: zero new diagnostics
- npm run check:file-size: touched files passed; the command still reports 12 unrelated release-base violations
- npm run typecheck:noimplicit:core: unchanged release-base failures in usageTracking.ts and cliRuntime.ts

The temporary #9745 overlay was used only to unblock DB initialization for tests and is not part of this PR.

Refs #8484