### PR TITLE
[TS7] fix(codex): preserve narrowed input arrays

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -309,6 +309,7 @@ export function stripStoredItemReferences(body: Record<string, unknown>): void {
 
 function stripOrphanedCodexFunctionCallOutputs(body: Record<string, unknown>): void {
   if (!Array.isArray(body.input)) return;
+  const input = body.input;
   // A previous_response_id delegates history resolution to the upstream
   // Responses service, so a matching function_call may legitimately live in
   // that remote response rather than in the local input array.
@@ -317,7 +318,7 @@ function stripOrphanedCodexFunctionCallOutputs(body: Record<string, unknown>): v
   const callIds = new Set<string>();
   let outputCount = 0;
 
-  for (const item of body.input) {
+  for (const item of input) {
     if (!item || typeof item !== "object" || Array.isArray(item)) continue;
     const record = item as Record<string, unknown>;
 
@@ -341,9 +342,7 @@ function stripOrphanedCodexFunctionCallOutputs(body: Record<string, unknown>): v
   }
 
   if (outputCount === 0) return;
-
-  const before = body.input.length;
-  body.input = body.input.filter((item) => {
+  const filteredInput = input.filter((item) => {
     if (!item || typeof item !== "object" || Array.isArray(item)) return true;
     const record = item as Record<string, unknown>;
     if (record.type === "function_call_output" && typeof record.call_id === "string") {
@@ -352,7 +351,8 @@ function stripOrphanedCodexFunctionCallOutputs(body: Record<string, unknown>): v
     return true;
   });
 
-  const removedCount = before - body.input.length;
+  const removedCount = input.length - filteredInput.length;
+  body.input = filteredInput;
   if (removedCount > 0) {
     console.debug(
       `[Codex] stripOrphanedCodexFunctionCallOutputs: removed ${removedCount} orphaned function_call_output item(s)`

--- a/tests/unit/codex-orphaned-tool-outputs-2928.test.ts
+++ b/tests/unit/codex-orphaned-tool-outputs-2928.test.ts
@@ -76,6 +76,7 @@ test("Codex keeps matched outputs and removes orphaned outputs from mixed input"
     { type: "function_call_output", call_id: "call_orphan", output: "orphaned" },
   ]);
 
+  assert.equal(result.length, 2);
   assert.deepEqual(toolOutputs(result), [
     { type: "function_call_output", call_id: "call_keep", output: "ok" },
   ]);


### PR DESCRIPTION
## Summary

- keep the Array.isArray-validated Codex input in a local array binding
- filter orphaned function-call outputs through that stable binding
- preserve the filtered-length contract without growing the frozen executor file

## Validation

- node --import tsx/esm --test tests/unit/codex-orphaned-tool-outputs-2928.test.ts (6/6)
- targeted ESLint PASS
- npm run typecheck:core PASS
- TypeScript 6.0.3 full open-sse diagnostics: 72 to 71, 1 removed, 0 added
- TypeScript 7.0.2 full open-sse diagnostics: 71 to 70, 1 removed, 0 added
- combined with open TS7 PRs #9742 and #9747: TS6 72 to 67, TS7 71 to 66, 5 removed and 0 added
- check:file-size: changed frozen executor no longer appears; remaining 12 failures are unchanged release-base violations
- typecheck:noimplicit:core: unchanged release-base failures remain in usageTracking.ts and cliRuntime.ts

Tracks #8484.