### PR TITLE
[TS7] fix(skills): normalize web fetch credentials

### DIFF
--- a/src/lib/skills/webFetchExecution.ts
+++ b/src/lib/skills/webFetchExecution.ts
@@ -61,11 +61,30 @@ function resolvePinnedBackend(input: ExecuteWebFetchInput): WebFetchProviderId |
   return backend ? FETCH_BACKEND_TO_PROVIDER[backend] : undefined;
 }
 
+export function normalizeWebFetchCredentials(value: unknown): WebFetchCredentials | null {
+  if (!value || typeof value !== "object") return null;
+  const credentials = value as Record<string, unknown>;
+  if (credentials.allRateLimited === true || credentials.allExpired === true) return null;
+
+  const providerSpecificData =
+    credentials.providerSpecificData &&
+    typeof credentials.providerSpecificData === "object" &&
+    !Array.isArray(credentials.providerSpecificData)
+      ? (credentials.providerSpecificData as Record<string, unknown>)
+      : undefined;
+
+  return {
+    ...(typeof credentials.apiKey === "string" && { apiKey: credentials.apiKey }),
+    ...(typeof credentials.baseUrl === "string" && { baseUrl: credentials.baseUrl }),
+    ...(providerSpecificData && { providerSpecificData }),
+  };
+}
+
 async function resolveCredentials(
   providerId: WebFetchProviderId
 ): Promise<WebFetchCredentials | null> {
   try {
-    return (await getProviderCredentialsWithQuotaPreflight(providerId)) ?? null;
+    return normalizeWebFetchCredentials(await getProviderCredentialsWithQuotaPreflight(providerId));
   } catch {
     return null;
   }

--- a/tests/unit/web-fetch-execution-credentials.test.ts
+++ b/tests/unit/web-fetch-execution-credentials.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { normalizeWebFetchCredentials } = await import("../../src/lib/skills/webFetchExecution.ts");
+
+test("web-fetch skills reject unavailable credential sentinels", () => {
+  assert.equal(
+    normalizeWebFetchCredentials({ allRateLimited: true, retryAfter: "tomorrow" }),
+    null
+  );
+  assert.equal(normalizeWebFetchCredentials({ allExpired: true, expiredCount: 2 }), null);
+});
+
+test("web-fetch skills expose only the credential fields used by fetch executors", () => {
+  assert.deepEqual(
+    normalizeWebFetchCredentials({
+      apiKey: "secret",
+      baseUrl: "https://fetch.example.test",
+      providerSpecificData: { region: "test" },
+      accessToken: "must-not-leak-through",
+    }),
+    {
+      apiKey: "secret",
+      baseUrl: "https://fetch.example.test",
+      providerSpecificData: { region: "test" },
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- reject quota/expiry sentinel objects before web-fetch skill dispatch
- normalize the broad provider credential union to the three fields fetch executors consume
- avoid forwarding unrelated access-token and connection metadata
- add focused tests for sentinel rejection and field projection

## Validation
- `node --import tsx/esm --test tests/unit/web-fetch-execution-credentials.test.ts` (2/2)
- web-fetch handler and interception tests (9/9)
- `npm run lint`
- `npm run typecheck:core`
- TypeScript 6 diagnostics: 72 -> 71, added 0
- native TypeScript 7 diagnostics: 71 -> 70, added 0

## Known base failure
The DB-backed web-fetch suites have the same 10 failures on the clean release base and this branch because migration version 135 is duplicated. The failure set and messages are unchanged.