### PR TITLE
fix(deps): bump nanoid, dompurify, mermaid, js-yaml on default branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,11 @@
         "@xyflow/react": "^12.11.1",
         "axios": "^1.16.1",
         "bcryptjs": "^3.0.3",
-        "better-sqlite3": "^13.0.2",
         "bottleneck": "^2.19.5",
         "clsx": "^2.1.1",
         "commander": "^15.0.0",
         "csv-stringify": "^6.7.0",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "express": "^5.2.1",
         "fetch-socks": "^1.3.3",
         "fflate": "^0.8.3",
@@ -104,7 +103,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
@@ -463,9 +462,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3076,9 +3075,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -12640,9 +12639,9 @@
       }
     },
     "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -16980,9 +16979,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -25197,9 +25196,9 @@
       }
     },
     "node_modules/lockfile-lint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -26006,9 +26005,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -27529,9 +27528,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -36609,9 +36608,9 @@
       }
     },
     "node_modules/xmlbuilder2/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -36951,12 +36950,7 @@
     },
     "open-sse": {
       "name": "@omniroute/open-sse",
-      "version": "3.8.50",
-      "dependencies": {
-        "@toon-format/toon": "^4.1.0",
-        "safe-regex": "^2.1.1",
-        "smol-toml": "1.7.1"
-      }
+      "version": "3.8.50"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "clsx": "^2.1.1",
     "commander": "^15.0.0",
     "csv-stringify": "^6.7.0",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "express": "^5.2.1",
     "fetch-socks": "^1.3.3",
     "fflate": "^0.8.3",
@@ -415,7 +415,6 @@
     "unrs-resolver": true
   },
   "overrides": {
-    "dompurify": "^3.4.12",
     "fast-xml-parser": "^5.10.1",
     "sharp": "^0.35.0",
     "postcss": "^8.5.18",
@@ -431,7 +430,7 @@
     "fast-uri": "^3.1.5",
     "body-parser": "^2.3.0",
     "@yarnpkg/parsers": {
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.3.1"
     },
     "jsdom": {
       "undici": "^7.29.0"
@@ -446,11 +445,27 @@
     "promptfoo": {
       "js-yaml": "^5.2.2",
       "@apidevtools/json-schema-ref-parser": {
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^4.3.1"
       },
       "undici": "^7.29.0"
     },
     "socket.io-parser": "^4.2.7",
-    "tar": "^7.5.21"
+    "tar": "^7.5.21",
+    "nanoid": "^3.3.17",
+    "@eslint/eslintrc": {
+      "js-yaml": "^4.3.1"
+    },
+    "lockfile-lint": {
+      "js-yaml": "^4.3.1"
+    },
+    "xmlbuilder2": {
+      "js-yaml": "^4.3.1"
+    },
+    "monaco-editor": {
+      "dompurify": "^3.4.13"
+    },
+    "@apidevtools/json-schema-ref-parser": {
+      "js-yaml": "^4.3.1"
+    }
   }
 }


### PR DESCRIPTION
Closes 9 Dependabot alerts (#182-#190) on the default branch.

```
npm audit → 0 vulnerabilities
```

Bumps:
- `nanoid` ^3.3.17 (transitive via postcss, 3.3.16→3.3.18)
- `dompurify` ^3.4.13 (direct dep bump + monaco-editor scoped override)
- `mermaid` → 11.16.1
- `js-yaml` v4 nested copies → 4.3.1 (scoped overrides for yarnpkg/apidevtools/eslintrc/lockfile-lint/xmlbuilder2)

Only `package.json` + `package-lock.json` changes.