### PR TITLE
fix(sse): route claude discovery aliases for catalog-only providers

### DIFF
--- a/src/lib/ccDiscoveryAliasResolve.ts
+++ b/src/lib/ccDiscoveryAliasResolve.ts
@@ -20,6 +20,7 @@ import {
 } from "@omniroute/open-sse/handlers/chatCore/ccDiscoveryAliasStrip.ts";
 import { getModelsByProviderId } from "@omniroute/open-sse/config/providerModels.ts";
 import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
+import { getProviderById, getProviderByAlias } from "@/shared/constants/providers";
 import { getCachedProviderNodes } from "@/lib/db/readCache";
 import { getComboByName } from "@/lib/db/combos";
 import {
@@ -137,6 +138,22 @@ export async function resolveCcDiscoveryAliasStripWith(
 }
 
 /**
+ * True when `prefix` names a provider the router can actually reach.
+ *
+ * Deliberately broader than the `open-sse` REGISTRY alone: enterprise-cloud
+ * providers such as `azure-ai` / `azure-openai` live only in the provider
+ * CATALOG (src/shared/constants/providers/…) yet route fine, so a registry-only
+ * check made the request path reject `claude/azure-ai/<model>` ids that the
+ * catalog had already advertised — see cc-discovery-alias-routable-prefix.test.ts.
+ */
+export function isRoutableProviderPrefix(prefix: string): boolean {
+  if (!prefix) return false;
+  if (getRegistryEntry(prefix) !== null) return true;
+  if (getProviderById(prefix) !== undefined) return true;
+  return getProviderByAlias(prefix) !== null;
+}
+
+/**
  * Production entry point: build the real lookups and resolve. Cheap-exit for any
  * id that does not start with `claude/` (the overwhelmingly common case) so a
  * normal request pays only a single `startsWith` check.
@@ -169,7 +186,7 @@ export async function resolveCcDiscoveryAliasStrip(
 
   const result = await resolveCcDiscoveryAliasStripWith(modelStr, {
     claudeModelIds,
-    isRegistryProvider: (prefix) => getRegistryEntry(prefix) !== null,
+    isRegistryProvider: (prefix) => isRoutableProviderPrefix(prefix),
     customProviderPrefixes,
     getCombo: (name) => getComboByName(name),
     gateGlobal: () => globalEnabled,

--- a/tests/unit/cc-discovery-alias-routable-prefix.test.ts
+++ b/tests/unit/cc-discovery-alias-routable-prefix.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isRoutableProviderPrefix } from "../../src/lib/ccDiscoveryAliasResolve.ts";
+
+/**
+ * Regression guard for the "listed but rejected" cc-discovery alias mismatch.
+ *
+ * The /v1/models catalog mirrors `claude/<provider>/<model>` ids based purely on
+ * the alias gate (src/app/api/v1/models/ccAliasPredicate.ts — it does NOT consult
+ * any provider registry). The request path additionally required the prefix to be
+ * an `open-sse` REGISTRY entry or an operator-defined custom node.
+ *
+ * Enterprise-cloud providers such as `azure-ai` / `azure-openai` live in the
+ * provider CATALOG (src/shared/constants/providers/apikey/enterprise-cloud.ts)
+ * and route fine directly (`azure-ai/Phi-4` → 200), but have no `open-sse`
+ * registry entry. So the catalog advertised `claude/azure-ai/<model>` while the
+ * request path refused to strip it — the id fell through with `claude` parsed as
+ * the provider, and every request was routed to the Claude provider instead.
+ *
+ * These assertions pin the predicate to "can the router actually reach it",
+ * which is the property the catalog side already assumes.
+ */
+
+test("catalog-only enterprise-cloud providers are routable (azure-ai regression)", () => {
+  assert.equal(isRoutableProviderPrefix("azure-ai"), true);
+  assert.equal(isRoutableProviderPrefix("azure-openai"), true);
+});
+
+test("open-sse registry providers stay routable", () => {
+  assert.equal(isRoutableProviderPrefix("openai"), true);
+  assert.equal(isRoutableProviderPrefix("anthropic"), true);
+});
+
+test("provider aliases resolve too", () => {
+  // `azure` is the declared alias of the `azure-openai` catalog entry.
+  assert.equal(isRoutableProviderPrefix("azure"), true);
+});
+
+test("an unknown prefix is not routable", () => {
+  assert.equal(isRoutableProviderPrefix("definitely-not-a-provider-xyz"), false);
+  assert.equal(isRoutableProviderPrefix(""), false);
+});


### PR DESCRIPTION
## Bug

Claude Code discovery aliases are advertised for providers the request path then refuses to route, so **every** such request silently goes to the Claude provider instead.

Reproduced live against an Azure AI Foundry connection:

```
POST /v1/messages  {"model":"claude/azure-ai/DeepSeek-V4-Flash"}
-> ROUTING: Provider: claude, Model: azure-ai/DeepSeek-V4-Flash
-> 404 (routed to the Claude provider, not Azure)

POST /v1/messages  {"model":"azure-ai/DeepSeek-V4-Flash"}   # direct id
-> 200 OK
```

No `CC_DISCOVERY` log line was emitted, confirming `stripped === false`.

## Root cause

The two sides of the alias disagree:

| side | predicate |
| --- | --- |
| Catalog (`ccAliasPredicate.ts`) | alias gate **only** - consults no provider registry |
| Request (`stripCcDiscoveryAlias`) | gate **plus** `isKnownProviderPrefix` |

`isKnownProviderPrefix` was built from `getRegistryEntry()` (the `open-sse` REGISTRY) plus operator-defined custom nodes. Enterprise-cloud providers such as `azure-ai` / `azure-openai` live only in the **provider catalog** (`src/shared/constants/providers/apikey/enterprise-cloud.ts`) and have no `open-sse` registry entry - `"azure-ai"` appears nowhere under `open-sse/config/`.

So the catalog advertised the mirror id, the request path declined to strip it, and the unstripped id fell through to normal resolution - which splits on the first `/` and parses `claude` as the provider.

This is exactly the hazard called out in `src/lib/ccDiscoveryAliasResolve.ts`: "they must match or an alias could be listed yet rejected."

## Fix

Extract the predicate as `isRoutableProviderPrefix()` and widen it to the provider catalog (`getProviderById` + `getProviderByAlias`) alongside the existing registry lookup, so the request path recognises exactly what the catalog can advertise.

Widening the request side (rather than narrowing the catalog) is the correct direction: these models genuinely route - the direct ids return 200.

## Tests

New `tests/unit/cc-discovery-alias-routable-prefix.test.ts`:

- `azure-ai`, `azure-openai` routable (the regression)
- `azure` alias resolves
- `openai` / `anthropic` stay routable
- unknown prefix and empty string stay non-routable

**TDD verified** - the azure and alias assertions failed against the pre-fix predicate (`false !== true`), then passed after the widening.

```
new suite                    4 pass / 0 fail
existing cc-discovery suites 70 pass / 0 fail   (6 files)
typecheck:core               clean
eslint (changed files)       exit 0
```

WARNING - base-red inherited: #9737
