### PR TITLE
fix(translator): keep Responses namespace identity across the hub-and-spoke pivot

### DIFF
--- a/changelog.d/fixes/9783-namespace-identity-pivot.md
+++ b/changelog.d/fixes/9783-namespace-identity-pivot.md
@@ -1,0 +1,1 @@
+- **Translator**: keep the Responses namespace identity map across the hub-and-spoke pivot — namespace sub-tool calls routed to non-OpenAI targets (Kiro, Cursor) no longer come back flattened (`unsupported call: functions__exec` in Codex CLI) (#9783 — thanks @VXNCXNX)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,3 +1,4 @@
+import { extractRequestToolIdentityMap } from "./chatCore/requestToolIdentity.ts";
 import { injectMemoryAndSkills } from "./chatCore/memorySkillsInjection.ts";
 import { resolveChatCoreRequestSetup } from "./chatCore/requestSetup.ts";
 import { buildFailureUsageRecord } from "./chatCore/failureUsage.ts";
@@ -2264,20 +2265,7 @@ export async function handleChatCore({
   // the latter is a Kiro/Claude passthrough alias channel with string values,
   // while namespace identities carry `{namespace, name}` for the #7936 response
   // seam. Extract first because Kiro merge may reuse `_toolNameMap` below.
-  //
-  // #9780 — prefer the dedicated channel: on a pivot the openai->claude/gemini
-  // step publishes its own alias map on `_toolNameMap`, so that property alone
-  // yields aliases here. The `_toolNameMap` read stays as the fallback for the
-  // non-pivot producers (executors/base.ts, cliproxyapi.ts, antigravity).
-  const namespaceIdentityMap = translatedBody._namespaceToolIdentityMap;
-  const requestToolIdentityMap =
-    namespaceIdentityMap instanceof Map
-      ? namespaceIdentityMap
-      : translatedBody._toolNameMap instanceof Map
-        ? translatedBody._toolNameMap
-        : null;
-  delete translatedBody._namespaceToolIdentityMap;
-  delete translatedBody._toolNameMap;
+  const requestToolIdentityMap = extractRequestToolIdentityMap(translatedBody);
 
   // Kiro: sanitize tool schemas before dispatch. Kiro returns 400 "Improperly
   // formed request" for unsupported JSON-Schema keywords (anyOf/$ref/if-then,

--- a/open-sse/handlers/chatCore/requestToolIdentity.ts
+++ b/open-sse/handlers/chatCore/requestToolIdentity.ts
@@ -1,0 +1,26 @@
+type NamespaceIdentity = { namespace: string; name: string };
+
+/**
+ * Extract the #7936 request-tool identity map from the translated body and
+ * strip both side channels before dispatch.
+ *
+ * #9780 — prefer the dedicated `_namespaceToolIdentityMap`: on a pivot the
+ * openai->claude/gemini step publishes its own alias `Map<string, string>` on
+ * `_toolNameMap`, so that property alone can yield aliases instead of
+ * identities. The `_toolNameMap` read stays as the fallback for the non-pivot
+ * producers (executors/base.ts, cliproxyapi.ts, antigravity).
+ */
+export function extractRequestToolIdentityMap(
+  translatedBody: Record<string, unknown>
+): Map<string, NamespaceIdentity> | null {
+  const namespaceIdentityMap = translatedBody._namespaceToolIdentityMap;
+  const requestToolIdentityMap =
+    namespaceIdentityMap instanceof Map
+      ? namespaceIdentityMap
+      : translatedBody._toolNameMap instanceof Map
+        ? translatedBody._toolNameMap
+        : null;
+  delete translatedBody._namespaceToolIdentityMap;
+  delete translatedBody._toolNameMap;
+  return requestToolIdentityMap as Map<string, NamespaceIdentity> | null;
+}


### PR DESCRIPTION
Fixes #9780.

## Problem

There is no direct `openai-responses` → `kiro` translator, so `translateRequest` falls back to the hub-and-spoke pivot:

- **Step 1** (`openai-responses` → `openai`) flattens each namespace sub-tool to a qualified wire name (#8295) and records the `{namespace, name}` pair, attached with `Object.defineProperty(result, "_toolNameMap", { enumerable: false })`.
- **Step 2** (`openai` → target) returns a **brand-new** object — `buildKiroPayload()` and friends never copy that property over.

`chatCore.ts` then reads `translatedBody._toolNameMap` → `null`, so `resolveRequestToolIdentity()` never fires and the flattened name reaches the client verbatim. Codex has no dispatch entry for it and answers `unsupported call: functions__exec` — the exact symptom #7936 was opened to fix, reintroduced through a different path.

Confirmed against a live gateway (`kr/gpt-5.6-luna`, UA `codex_cli_rs/0.147.0`), HTTP 200:

```
"type":"function_call","name":"functions__exec","status":"in_progress"
```

No `namespace` field, and `name` is the wire name rather than the declared `exec`.

## Why not just copy `_toolNameMap` through

That property carries **two mutually incompatible types**:

| Producer | Type | Purpose |
| --- | --- | --- |
| `openai-responses.ts` | `Map<string, {namespace, name}>` | #7936 identity seam |
| `openai-to-claude.ts`, `openai-to-gemini.ts` | `Map<string, string>` | tool-name alias remap (#1375) |

On a pivot, step 2 overwrites the identity map with an alias map for those two targets. A naive copy-through would clobber their aliases and break tool-name remapping. `chatCore.ts` already documents the distinction ("Keep the request translator's namespace identities separate from toolNameMap") — but nothing made the identity map survive step 2 in the first place.

## Fix

A dedicated `_namespaceToolIdentityMap` channel:

- `openai-responses.ts` publishes the identity map on the new key **and** keeps writing `_toolNameMap`, so the existing consumers (`executors/base.ts`, `cliproxyapi.ts`, `antigravity`) are unaffected.
- `translator/index.ts` re-attaches it after step 2 of the pivot, non-enumerably.
- `chatCore.ts` prefers the new key and falls back to `_toolNameMap` for the non-pivot producers.
- `cliproxyapi.ts` strips both keys from the wire body.

49 insertions, 6 deletions across 4 files. Nothing changes for targets that were already working.

## Verification

`tests/unit/9780-namespace-identity-pivot.test.ts`, 10 cases. On `main` without the fix: **1 pass, 9 fail**. With the fix: **10 pass**.

The end-to-end cases chain the request pivot and the response seam, i.e. what the Codex adjudicator actually receives:

| Target | Before | After |
| --- | --- | --- |
| kiro | `functions__exec`, no namespace | `exec` + `functions` |
| cursor | `functions__exec`, no namespace | `exec` + `functions` |
| claude | `functions__exec`, no namespace | `exec` + `functions` |
| gemini | `functions__exec`, no namespace | `exec` + `functions` |

The "before" column reproduces the live gateway output above.

Note `claude` / `gemini`: they carry a map even without the fix, yet still fail — it is the alias map. That is the regression guard, asserted explicitly (identity restored **and** alias values still strings).

Regression run — all `*responses*` and `*namespace*` suites, plus `chatcore-passthrough-tool-names`, `executor-kiro`, `translator-openai-to-kiro`, `8295-namespace-leaf-collision`, `translator-resp-openai-responses-namespace-identity`: **442 pass, 0 fail**.
