### PR TITLE
fix(memory): register the sqlite backend on the /api/memory/[id] route — every handler 500'd (#9737)

### DIFF
--- a/changelog.d/fixes/9737-memory-id-route-backend.md
+++ b/changelog.d/fixes/9737-memory-id-route-backend.md
@@ -1,0 +1,1 @@
+- Fixed `GET`/`PUT`/`DELETE /api/memory/[id]` always failing with a 500 (`Primary backend "sqlite" not registered`) when the route was reached before any other memory endpoint in the same process.

--- a/changelog.d/fixes/9737-route-body-validation.md
+++ b/changelog.d/fixes/9737-route-body-validation.md
@@ -1,0 +1,1 @@
+- Replaced hand-rolled body type checks with Zod validation in the plugins marketplace install route and the three Dario admin routes, restoring the `t06:route-validation` gate (Hard Rule #7).

--- a/src/app/api/memory/[id]/route.ts
+++ b/src/app/api/memory/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
-import { memoryManager } from "@/lib/memory/manager";
+// Import through the module index, NOT "@/lib/memory/manager" directly: the index's
+// import-time side effect is what calls memoryManager.register(sqliteBackend). Importing
+// the bare manager gives an EMPTY registry, so every handler here threw
+// `Primary backend "sqlite" not registered` and returned 500 (#8752).
+import { memoryManager } from "@/lib/memory";
 import { validateBody, isValidationFailure } from "@/shared/validation/helpers";
 import { MemoryUpdatePutSchema } from "@/shared/schemas/memory";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";

--- a/src/app/api/plugins/marketplace/install/route.ts
+++ b/src/app/api/plugins/marketplace/install/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 import { installMarketplacePlugin } from "@/lib/plugins/marketplace";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+
+const InstallBodySchema = z.object({
+  name: z.string().trim().min(1),
+});
 
 export async function OPTIONS() {
   return handleCorsOptions();
@@ -15,15 +20,14 @@ export async function POST(request: NextRequest) {
   const authError = await requireManagementAuth(request);
   if (authError) return authError;
   try {
-    const body = await request.json();
-    const { name } = body as { name?: string };
-    if (!name || typeof name !== "string") {
+    const parsed = InstallBodySchema.safeParse(await request.json());
+    if (!parsed.success) {
       return NextResponse.json(buildErrorBody(400, "Missing or invalid 'name' field"), {
         status: 400,
         headers: CORS_HEADERS,
       });
     }
-    const result = await installMarketplacePlugin(name);
+    const result = await installMarketplacePlugin(parsed.data.name);
     return NextResponse.json(result, { status: 201, headers: CORS_HEADERS });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : "Failed to install marketplace plugin";

--- a/src/app/api/services/dario/admin/accounts/route.ts
+++ b/src/app/api/services/dario/admin/accounts/route.ts
@@ -11,8 +11,14 @@
  * and never reaches the browser.
  */
 
+import { z } from "zod";
+
 import { forwardToDarioAdmin, requireAdminAuth } from "../_lib";
 import { createErrorResponse } from "@/lib/api/errorResponse";
+
+const DeleteAccountBodySchema = z.object({
+  alias: z.string().trim().min(1).optional(),
+});
 
 export async function GET(request: Request): Promise<Response> {
   const authResponse = await requireAdminAuth(request);
@@ -29,9 +35,9 @@ export async function DELETE(request: Request): Promise<Response> {
 
   if (!alias && request.body !== null) {
     try {
-      const parsed = await request.json();
-      if (parsed && typeof parsed === "object" && typeof (parsed as { alias?: unknown }).alias === "string") {
-        alias = (parsed as { alias: string }).alias.trim();
+      const parsed = DeleteAccountBodySchema.safeParse(await request.json());
+      if (parsed.success && parsed.data.alias) {
+        alias = parsed.data.alias;
       }
     } catch {
       /* fall through to the missing-alias error below */

--- a/src/app/api/services/dario/admin/import-from-omniroute/route.ts
+++ b/src/app/api/services/dario/admin/import-from-omniroute/route.ts
@@ -28,6 +28,7 @@
  * pickup, rather than relying on any undocumented hot-reload behavior.
  */
 
+import { z } from "zod";
 import { NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
@@ -38,6 +39,11 @@ import { getProviderConnections, getProviderConnectionById } from "@/lib/db/prov
 import { getDarioHomeDir } from "@/lib/services/installers/dario";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const ImportBodySchema = z.object({
+  connectionId: z.string().trim().min(1).optional(),
+  alias: z.string().trim().min(1).optional(),
+});
 
 const ALIAS_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_\-.]{0,63}$/;
 
@@ -82,15 +88,16 @@ export async function POST(request: Request): Promise<Response> {
   const authResponse = await requireAdminAuth(request);
   if (authResponse) return authResponse;
 
-  let body: unknown;
+  let raw: unknown;
   try {
-    body = await request.json();
+    raw = await request.json();
   } catch {
     return createErrorResponse({ status: 400, message: "Invalid JSON body" });
   }
 
-  const b = (body || {}) as Record<string, unknown>;
-  const connectionId = typeof b.connectionId === "string" ? b.connectionId : null;
+  const parsed = ImportBodySchema.safeParse(raw ?? {});
+  const b = parsed.success ? parsed.data : {};
+  const connectionId = b.connectionId ?? null;
   if (!connectionId) {
     return createErrorResponse({ status: 400, message: "connectionId is required" });
   }
@@ -112,10 +119,7 @@ export async function POST(request: Request): Promise<Response> {
     });
   }
 
-  let alias =
-    typeof b.alias === "string" && b.alias.trim()
-      ? b.alias.trim()
-      : safeAliasFromSource(conn.email as string | null, connectionId);
+  let alias = b.alias || safeAliasFromSource(conn.email as string | null, connectionId);
   if (!ALIAS_PATTERN.test(alias)) {
     alias = safeAliasFromSource(conn.email as string | null, connectionId);
   }

--- a/src/app/api/services/dario/admin/login-start/route.ts
+++ b/src/app/api/services/dario/admin/login-start/route.ts
@@ -8,23 +8,29 @@
  * posts the displayed code to /login-complete.
  */
 
+import { z } from "zod";
 import { forwardToDarioAdmin, requireAdminAuth } from "../_lib";
 import { createErrorResponse } from "@/lib/api/errorResponse";
+
+const LoginStartBodySchema = z.object({
+  alias: z.string().trim().min(1).optional(),
+});
+type LoginStartBody = z.infer<typeof LoginStartBodySchema>;
 
 export async function POST(request: Request): Promise<Response> {
   const authResponse = await requireAdminAuth(request);
   if (authResponse) return authResponse;
 
-  let body: { alias?: string } = {};
+  let body: LoginStartBody = {};
   try {
     if (request.body !== null) {
-      const parsed = await request.json();
-      if (parsed && typeof parsed === "object") body = parsed as { alias?: string };
+      const parsed = LoginStartBodySchema.safeParse(await request.json());
+      if (parsed.success) body = parsed.data;
     }
   } catch {
     return createErrorResponse({ status: 400, message: "Invalid JSON body" });
   }
 
-  const forwardBody = typeof body.alias === "string" && body.alias.trim() ? { alias: body.alias.trim() } : {};
+  const forwardBody = body.alias ? { alias: body.alias } : {};
   return forwardToDarioAdmin({ method: "POST", path: "/admin/login/start", body: forwardBody });
 }

--- a/tests/integration/combo-matrix/context-relay-codex.test.ts
+++ b/tests/integration/combo-matrix/context-relay-codex.test.ts
@@ -62,6 +62,12 @@ const { getHandoff } = await import("../../../src/lib/db/contextHandoffs.ts");
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const CODEX_COMBO_NAME = "m-relay-codex-quota";
+// The control test needs its OWN combo name. resetStorage() unlinks the DB file
+// between tests, but the previous better-sqlite3 handle survives the unlink and
+// keeps writing to the same inode, so reusing the name here failed with
+// `UNIQUE constraint failed: combos.name` — a test-isolation defect, not a
+// routing one (the assertion below does not depend on the name).
+const CONTROL_COMBO_NAME = "m-relay-openai-control";
 const SESSION_HEADER_VALUE = "relay-codex-quota-001";
 const SESSION_ID = `ext:${SESSION_HEADER_VALUE}`;
 
@@ -71,8 +77,7 @@ const CODEX_RESPONSES_HOST = "chatgpt.com/backend-api/codex/responses";
 
 // Summary JSON that parseHandoffJSON will successfully parse.
 const CODEX_SUMMARY_JSON = JSON.stringify({
-  summary:
-    "User is implementing a TypeScript context-relay codex quota-handoff test using TDD.",
+  summary: "User is implementing a TypeScript context-relay codex quota-handoff test using TDD.",
   keyDecisions: ["codex provider selected", "quota threshold at 90%"],
   taskProgress: "writing deterministic integration test for codex handoff",
   activeEntities: ["combo.ts", "codexQuotaFetcher.ts", "contextHandoff.ts"],
@@ -142,11 +147,11 @@ function buildCodexUsageBody(
 
 // ── Request builder ───────────────────────────────────────────────────────────
 
-function codexRequest(withSessionId = true) {
+function codexRequest(withSessionId = true, comboName = CODEX_COMBO_NAME) {
   return buildRequest({
     headers: withSessionId ? { "x-session-id": SESSION_HEADER_VALUE } : {},
     body: {
-      model: CODEX_COMBO_NAME,
+      model: comboName,
       stream: false,
       messages: [{ role: "user", content: "Write a TypeScript hello world." }],
     },
@@ -259,9 +264,7 @@ test("context-relay codex quota handoff: fires and expiresAt matches session-win
     name: CODEX_COMBO_NAME,
     strategy: "context-relay",
     config: { maxRetries: 0, retryDelayMs: 0, stickyRoundRobinLimit: 1 },
-    models: [
-      { id: "rc-codex-1", kind: "model", providerId: "codex", model: "gpt-5.3-codex" },
-    ],
+    models: [{ id: "rc-codex-1", kind: "model", providerId: "codex", model: "gpt-5.3-codex" }],
   });
 
   // 4. Compute quota reset times (future timestamps).
@@ -328,12 +331,10 @@ test("context-relay codex quota handoff: does NOT fire when provider is openai (
   await seedConnection("openai", { apiKey: "sk-openai-control-no-codex-block" });
 
   await combosDb.createCombo({
-    name: CODEX_COMBO_NAME,
+    name: CONTROL_COMBO_NAME,
     strategy: "context-relay",
     config: { maxRetries: 0, retryDelayMs: 0, stickyRoundRobinLimit: 1 },
-    models: [
-      { id: "rc-openai-ctrl", kind: "model", providerId: "openai", model: "gpt-4o-mini" },
-    ],
+    models: [{ id: "rc-openai-ctrl", kind: "model", providerId: "openai", model: "gpt-4o-mini" }],
   });
 
   const seenUrls: string[] = [];
@@ -342,7 +343,7 @@ test("context-relay codex quota handoff: does NOT fire when provider is openai (
     return buildOpenAIResponse("assistant reply ok");
   };
 
-  const r = await handleChat(codexRequest(true));
+  const r = await handleChat(codexRequest(true, CONTROL_COMBO_NAME));
   assert.equal(r.status, 200, "openai request must return 200");
 
   // Give setImmediate time to fire if the block were incorrectly entered.
@@ -358,7 +359,7 @@ test("context-relay codex quota handoff: does NOT fire when provider is openai (
   // No codex quota handoff record in DB.
   // (The universal handoff also does not fire because no prior model is seeded,
   // so getLastSessionModel returns null → no model switch detected.)
-  const handoff = getHandoff(SESSION_ID, CODEX_COMBO_NAME);
+  const handoff = getHandoff(SESSION_ID, CONTROL_COMBO_NAME);
   assert.equal(
     handoff,
     null,

--- a/tests/unit/route-body-validation-t06.test.ts
+++ b/tests/unit/route-body-validation-t06.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Guard for the t06:route-validation gate (Hard Rule #7 — always validate inputs
+ * with Zod schemas).
+ *
+ * The gate (scripts/check/check-route-validation.mjs) is a source scan: any
+ * `route.ts` under src/app/api that calls `request.json()` must also call
+ * `validateBody()` or `.safeParse()`. It has NO allowlist, so a route that
+ * hand-rolls `typeof x === "string"` checks passes review but fails CI — which
+ * is exactly how four routes (#9445 marketplace install, #8523's three Dario
+ * admin routes) landed on release/v3.8.50 and kept the branch out of
+ * release-green (#9737).
+ *
+ * This test runs the same rule inside the unit suite so the violation surfaces
+ * on the PR that introduces it, instead of on the next base-red sweep.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
+const API_ROOT = path.join(REPO_ROOT, "src", "app", "api");
+
+function collectRouteFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectRouteFiles(full));
+    } else if (entry.isFile() && entry.name === "route.ts") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+test("every API route reading request.json() validates it with Zod (t06)", () => {
+  const offenders: string[] = [];
+
+  for (const file of collectRouteFiles(API_ROOT)) {
+    const source = fs.readFileSync(file, "utf8");
+    if (!/request\.json\s*\(/.test(source)) continue;
+    if (/\bvalidateBody\s*\(/.test(source) || /\.safeParse\s*\(/.test(source)) continue;
+    offenders.push(path.relative(REPO_ROOT, file));
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `routes call request.json() without validateBody()/.safeParse() — hand-rolled ` +
+      `typeof checks do not satisfy Hard Rule #7 and fail the t06 CI gate:\n  ` +
+      offenders.join("\n  ")
+  );
+});


### PR DESCRIPTION
## Bug de produção

`GET`/`PUT`/`DELETE /api/memory/[id]` lançavam `Primary backend "sqlite" not registered` e retornavam **500**.

O #8752 (MemoryBackend provider pattern) ligou a rota em `@/lib/memory/manager` **direto**, mas quem popula o registro é um side-effect de import no **índice** do módulo (`src/lib/memory/index.ts:23` → `memoryManager.register(sqliteBackend)`). Importar o manager puro entrega um registry **vazio**.

### Por que passou despercebido

A falha é **ordem-dependente**: se `/api/memory` (que importa o índice) for atingida primeiro no mesmo processo, o singleton já está populado e a `[id]` funciona. Atingida primeiro — o caso comum de um cliente que edita uma memória por id — **toda request 500a**. Era o único import direto do manager em `src/`.

### Prova

```
STATUS: 500 BODY: {"error":{"message":"[MemoryManager] Primary backend \"sqlite\" not registered"}}
```
(sonda chamando o handler `PUT` real com DATA_DIR isolado, antes do fix)

O guard já existia: `tests/integration/memory-route-put.test.ts` falhava **2/5 na base** — só não aparecia porque a suíte de integração roda no CI da release-PR, não por PR. Agora **5/5**.

## Bônus: defeito de isolamento no combo-matrix

`context-relay-codex.test.ts` reusava um único nome de combo nos dois testes e o control quebrava com `UNIQUE constraint failed: combos.name` — o `resetStorage()` faz unlink do arquivo do DB, mas o handle anterior do better-sqlite3 continua escrevendo no mesmo inode. Dei nome próprio ao control e parametrizei o request builder; **a asserção não mudou** (nunca dependeu do nome). 2/2.

## Contexto do #9737 (item 6)

A suíte de integração completa neste tip rodou em **32m19s (936 testes)** — abaixo do teto de 40min que o verdict antigo reportava como estourado. O travamento era a colisão de migração 135, já corrigida.

Refs #9737