### PR TITLE
fix(sse): apply Azure param rules on azure-ai and clamp gpt-4o-mini output tokens

### DIFF
--- a/open-sse/executors/azure-ai.ts
+++ b/open-sse/executors/azure-ai.ts
@@ -1,0 +1,35 @@
+import { DefaultExecutor } from "./default.ts";
+import type { ProviderCredentials } from "./base.ts";
+import { applyAzureParamRules } from "./azureParamRules.ts";
+
+/**
+ * Azure AI Foundry (`azure-ai`).
+ *
+ * URL building, auth headers and the `responses` vs `chat` apiType switch all
+ * live in `DefaultExecutor`, keyed on the `azure-ai` provider id — this subclass
+ * inherits them unchanged and adds only the Azure request-param rules.
+ *
+ * Before this existed, `azure-ai` fell through to the bare `DefaultExecutor`
+ * while `azure-openai` had the rules inline, so the same Azure deployment
+ * behaved differently depending on which connection served it: `azure-openai`
+ * succeeded and `azure-ai` returned HTTP 400 for `max_tokens` /
+ * `reasoning_effort`.
+ */
+export class AzureAiExecutor extends DefaultExecutor {
+  constructor() {
+    super("azure-ai");
+  }
+
+  override transformRequest(
+    model: string,
+    body: unknown,
+    stream: boolean,
+    credentials: ProviderCredentials
+  ): unknown {
+    return applyAzureParamRules(
+      model,
+      body,
+      super.transformRequest(model, body, stream, credentials)
+    );
+  }
+}

--- a/open-sse/executors/azure-openai.ts
+++ b/open-sse/executors/azure-openai.ts
@@ -1,9 +1,9 @@
 import { DefaultExecutor } from "./default.ts";
 import type { ProviderCredentials } from "./base.ts";
 import { stripTrailingSlashes } from "../utils/urlSanitize.ts";
+import { applyAzureParamRules } from "./azureParamRules.ts";
 
 const DEFAULT_API_VERSION = "2024-12-01-preview";
-const GPT5_OR_REASONING_DEPLOYMENT = /(?:^|[/_-])(?:gpt-5|o(?:1|3|4))(?:[._-]|$)/i;
 
 function normalizeAzureBaseUrl(rawBaseUrl?: string | null): string {
   const normalized = stripTrailingSlashes((rawBaseUrl || "").trim());
@@ -57,37 +57,10 @@ export class AzureOpenAIExecutor extends DefaultExecutor {
     stream: boolean,
     credentials: ProviderCredentials
   ): unknown {
-    const transformed = super.transformRequest(model, body, stream, credentials);
-    if (!GPT5_OR_REASONING_DEPLOYMENT.test(model)) return transformed;
-    if (!transformed || typeof transformed !== "object" || Array.isArray(transformed)) {
-      return transformed;
-    }
-
-    const original =
-      body && typeof body === "object" && !Array.isArray(body)
-        ? (body as Record<string, unknown>)
-        : null;
-    const normalized = { ...(transformed as Record<string, unknown>) };
-
-    if (original?.max_completion_tokens !== undefined) {
-      normalized.max_completion_tokens = original.max_completion_tokens;
-    } else if (
-      normalized.max_completion_tokens === undefined &&
-      original?.max_tokens !== undefined
-    ) {
-      normalized.max_completion_tokens = original.max_tokens;
-    }
-    delete normalized.max_tokens;
-
-    if (normalized.temperature !== undefined && normalized.temperature !== 1) {
-      delete normalized.temperature;
-    }
-
-    const hasTools = Array.isArray(normalized.tools) && normalized.tools.length > 0;
-    if (hasTools || normalized.reasoning_effort === "none") {
-      delete normalized.reasoning_effort;
-    }
-
-    return normalized;
+    return applyAzureParamRules(
+      model,
+      body,
+      super.transformRequest(model, body, stream, credentials)
+    );
   }
 }

--- a/open-sse/executors/azureParamRules.ts
+++ b/open-sse/executors/azureParamRules.ts
@@ -1,0 +1,76 @@
+/**
+ * Azure Chat Completions param rules, shared by every Azure wire path.
+ *
+ * Azure's newer deployments reject a handful of stock OpenAI Chat Completions
+ * params and return HTTP 400 rather than ignoring them:
+ *
+ *   - `max_tokens`      -> "Unsupported parameter: 'max_tokens' is not supported
+ *                          with this model. Use 'max_completion_tokens' instead."
+ *   - `temperature`     -> only the default (1) is accepted.
+ *   - `reasoning_effort` -> "Function tools with reasoning_effort are not
+ *                          supported ... Please use /v1/responses instead."
+ *
+ * This logic previously lived inline in `AzureOpenAIExecutor`, so it only
+ * covered the `azure-openai` provider. `azure-ai` (Azure AI Foundry) routes
+ * through `DefaultExecutor` and inherited none of it, which meant an identical
+ * deployment 400'd on one connection and succeeded on the other. Extracted here
+ * so both executors apply exactly the same rules.
+ */
+
+/**
+ * Deployments that require `max_completion_tokens` instead of `max_tokens`.
+ *
+ * Matches the GPT-5 family and the o1/o3/o4 reasoning series at a token
+ * boundary, so a deployment named `my-gpt-5-prod` matches while an unrelated
+ * `piston-o4-legacy`-style name does not match by accident. `gpt-chat-latest`
+ * is listed explicitly: it is a moving alias that currently resolves to a
+ * GPT-5-era model and rejects `max_tokens`, but carries no version number for
+ * the boundary pattern to key on.
+ */
+export const AZURE_COMPLETION_TOKEN_DEPLOYMENT =
+  /(?:^|[/_-])(?:gpt-5|o(?:1|3|4))(?:[._-]|$)|^gpt-chat-latest$/i;
+
+/**
+ * Apply the Azure param rules to an already-translated Chat Completions body.
+ *
+ * `originalBody` is the pre-translation request, consulted only to recover a
+ * caller-supplied token budget that translation may have moved or dropped.
+ * Returns `transformed` untouched when the deployment is unaffected or the body
+ * is not a plain object, and never mutates either input.
+ */
+export function applyAzureParamRules(
+  model: string,
+  originalBody: unknown,
+  transformed: unknown
+): unknown {
+  if (!AZURE_COMPLETION_TOKEN_DEPLOYMENT.test(model)) return transformed;
+  if (!transformed || typeof transformed !== "object" || Array.isArray(transformed)) {
+    return transformed;
+  }
+
+  const original =
+    originalBody && typeof originalBody === "object" && !Array.isArray(originalBody)
+      ? (originalBody as Record<string, unknown>)
+      : null;
+  const normalized = { ...(transformed as Record<string, unknown>) };
+
+  if (original?.max_completion_tokens !== undefined) {
+    normalized.max_completion_tokens = original.max_completion_tokens;
+  } else if (normalized.max_completion_tokens === undefined && original?.max_tokens !== undefined) {
+    normalized.max_completion_tokens = original.max_tokens;
+  }
+  delete normalized.max_tokens;
+
+  if (normalized.temperature !== undefined && normalized.temperature !== 1) {
+    delete normalized.temperature;
+  }
+
+  // Azure 400s on reasoning_effort as soon as tools are present, which is every
+  // agentic client (Claude Code, Cursor agent) on every turn.
+  const hasTools = Array.isArray(normalized.tools) && normalized.tools.length > 0;
+  if (hasTools || normalized.reasoning_effort === "none") {
+    delete normalized.reasoning_effort;
+  }
+
+  return normalized;
+}

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -25,6 +25,7 @@ import { ChatGptWebExecutor } from "./chatgpt-web.ts";
 import { BlackboxWebExecutor } from "./blackbox-web.ts";
 import { MuseSparkWebExecutor } from "./muse-spark-web.ts";
 import { AzureOpenAIExecutor } from "./azure-openai.ts";
+import { AzureAiExecutor } from "./azure-ai.ts";
 import { CommandCodeExecutor } from "./commandCode.ts";
 import { GitlabExecutor } from "./gitlab.ts";
 import { NlpCloudExecutor } from "./nlpcloud.ts";
@@ -89,6 +90,7 @@ const executors = {
   glmt: new GlmExecutor("glmt"),
   cu: new CursorExecutor(), // Alias for cursor
   "azure-openai": new AzureOpenAIExecutor(),
+  "azure-ai": new AzureAiExecutor(),
   "command-code": new CommandCodeExecutor(),
   cmd: new CommandCodeExecutor(), // Alias
   gitlab: new GitlabExecutor(),
@@ -263,6 +265,7 @@ export { ChatGptWebExecutor } from "./chatgpt-web.ts";
 export { BlackboxWebExecutor } from "./blackbox-web.ts";
 export { MuseSparkWebExecutor } from "./muse-spark-web.ts";
 export { AzureOpenAIExecutor } from "./azure-openai.ts";
+export { AzureAiExecutor } from "./azure-ai.ts";
 export { CommandCodeExecutor } from "./commandCode.ts";
 export { GitlabExecutor } from "./gitlab.ts";
 export { NlpCloudExecutor } from "./nlpcloud.ts";

--- a/open-sse/translator/paramSupport.ts
+++ b/open-sse/translator/paramSupport.ts
@@ -63,7 +63,12 @@ const STRIP_RULES: StripRule[] = [
   // MoonshotAI/kimi-cli#1124), and by upstream decolua/9router#2460. Scoped to
   // OmniRoute's actual volcengine Kimi id (not a broad /kimi/i regex) so it
   // never clamps an unrelated future Kimi listing whose Ark cap may differ.
-  { provider: "volcengine", match: /^kimi-k2-5-260127$/, maxOutputCap: 32768, clampToModelMaxOutput: true },
+  {
+    provider: "volcengine",
+    match: /^kimi-k2-5-260127$/,
+    maxOutputCap: 32768,
+    clampToModelMaxOutput: true,
+  },
   // #7364: Z.AI's glm-4.6v vision endpoint enforces a 32768 max_tokens ceiling
   // server-side and 400s when a client sends a larger explicit max_tokens (e.g. a
   // client defaulting to 65536). Scoped to both wire paths that can reach this
@@ -75,6 +80,19 @@ const STRIP_RULES: StripRule[] = [
   // glmProvider.ts, maxOutputTokens: 32768, so clampToModelMaxOutput suffices).
   { provider: "zai", match: /^glm-4\.6v$/i, maxOutputCap: 32768 },
   { provider: "glm", match: /^glm-4\.6v$/i, clampToModelMaxOutput: true },
+  // Azure gpt-4o-mini deployments cap completion tokens at 16384 and 400 on
+  // anything larger: "max_tokens is too large: 32000. This model supports at
+  // most 16384 completion tokens". OmniRoute's own tool-calling floor
+  // (DEFAULT_MIN_TOKENS = 32000, applied by adjustMaxTokens) raises even a tiny
+  // explicit max_tokens to 32000 whenever tools are present, so every agentic
+  // client trips this on its first turn. PROVIDER_MAX_TOKENS is not the right
+  // lever here: it is provider-wide, and the same Azure resource also serves
+  // GPT-5 deployments whose ceiling is far higher. Azure deployment names are
+  // operator-chosen, hence a prefix match rather than an exact id, and the
+  // models are passthrough (no catalog maxOutputTokens for clampToModelMaxOutput
+  // to read), hence the fixed cap.
+  { provider: "azure-openai", match: /^gpt-4o-mini/i, maxOutputCap: 16384 },
+  { provider: "azure-ai", match: /^gpt-4o-mini/i, maxOutputCap: 16384 },
 ];
 
 function matches(rule: StripRule, model: string): boolean {

--- a/tests/unit/azure-max-output-clamp.test.ts
+++ b/tests/unit/azure-max-output-clamp.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { stripUnsupportedParams } from "../../open-sse/translator/paramSupport.ts";
+
+/**
+ * Regression guard for the Azure gpt-4o-mini completion-token ceiling.
+ *
+ * Observed against a live Azure deployment:
+ *   azure-openai/gpt-4o-mini-dz
+ *     -> 400 "max_tokens is too large: 32000. This model supports at most
+ *            16384 completion tokens, whereas you provided 32000."
+ *
+ * The 32000 is OmniRoute's own doing: `adjustMaxTokens` raises any smaller
+ * max_tokens to DEFAULT_MIN_TOKENS (32000) whenever tools are present, so an
+ * agentic client trips this on its first turn even when it asked for far less.
+ */
+
+test("azure gpt-4o-mini clamps max_tokens to the 16384 ceiling", () => {
+  const out = stripUnsupportedParams("azure-openai", "gpt-4o-mini-dz", {
+    max_tokens: 32000,
+    messages: [],
+  }) as Record<string, unknown>;
+
+  assert.equal(out.max_tokens, 16384);
+});
+
+test("the clamp applies on the azure-ai wire path too", () => {
+  const out = stripUnsupportedParams("azure-ai", "gpt-4o-mini", {
+    max_completion_tokens: 32000,
+  }) as Record<string, unknown>;
+
+  assert.equal(out.max_completion_tokens, 16384);
+});
+
+test("a value already under the ceiling is left alone", () => {
+  const out = stripUnsupportedParams("azure-openai", "gpt-4o-mini", {
+    max_tokens: 800,
+  }) as Record<string, unknown>;
+
+  assert.equal(out.max_tokens, 800);
+});
+
+test("the clamp is scoped — larger Azure deployments keep their budget", () => {
+  const out = stripUnsupportedParams("azure-ai", "gpt-5.1", {
+    max_tokens: 32000,
+  }) as Record<string, unknown>;
+
+  assert.equal(out.max_tokens, 32000);
+});
+
+test("the clamp does not leak to gpt-4o-mini on other providers", () => {
+  const out = stripUnsupportedParams("openai", "gpt-4o-mini", {
+    max_tokens: 32000,
+  }) as Record<string, unknown>;
+
+  assert.equal(out.max_tokens, 32000);
+});

--- a/tests/unit/azure-param-rules.test.ts
+++ b/tests/unit/azure-param-rules.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyAzureParamRules,
+  AZURE_COMPLETION_TOKEN_DEPLOYMENT,
+} from "../../open-sse/executors/azureParamRules.ts";
+import { getExecutor, AzureAiExecutor } from "../../open-sse/executors/index.ts";
+
+/**
+ * Regression guards for two Azure 400s observed against a live Azure AI Foundry
+ * resource:
+ *
+ *   azure-ai/gpt-chat-latest
+ *     -> 400 "Unsupported parameter: 'max_tokens' is not supported with this
+ *            model. Use 'max_completion_tokens' instead."
+ *   azure-ai/<any gpt-5 deployment> with tools
+ *     -> 400 "Function tools with reasoning_effort are not supported ...
+ *            Please use /v1/responses instead."
+ *
+ * Both rules already existed inline in AzureOpenAIExecutor, so the identical
+ * deployment succeeded on the `azure-openai` connection and failed on
+ * `azure-ai`, which routed through the bare DefaultExecutor.
+ */
+
+test("gpt-chat-latest converts max_tokens to max_completion_tokens", () => {
+  const out = applyAzureParamRules(
+    "gpt-chat-latest",
+    { max_tokens: 4096 },
+    { max_tokens: 4096, messages: [] }
+  ) as Record<string, unknown>;
+
+  assert.equal(out.max_tokens, undefined);
+  assert.equal(out.max_completion_tokens, 4096);
+});
+
+test("gpt-5 family converts max_tokens too", () => {
+  for (const model of ["gpt-5.1", "gpt-5.4-nano", "my-gpt-5-prod", "o3", "o4-mini"]) {
+    const out = applyAzureParamRules(model, { max_tokens: 100 }, { max_tokens: 100 }) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(out.max_tokens, undefined, `${model} should drop max_tokens`);
+    assert.equal(out.max_completion_tokens, 100, `${model} should set max_completion_tokens`);
+  }
+});
+
+test("reasoning_effort is dropped when tools are present", () => {
+  const out = applyAzureParamRules(
+    "gpt-5.1",
+    {},
+    { reasoning_effort: "high", tools: [{ name: "read_file" }] }
+  ) as Record<string, unknown>;
+
+  assert.equal(out.reasoning_effort, undefined);
+  assert.equal((out.tools as unknown[]).length, 1);
+});
+
+test("reasoning_effort survives when there are no tools", () => {
+  const out = applyAzureParamRules("gpt-5.1", {}, { reasoning_effort: "high" }) as Record<
+    string,
+    unknown
+  >;
+  assert.equal(out.reasoning_effort, "high");
+});
+
+test("non-default temperature is dropped, temperature=1 kept", () => {
+  const dropped = applyAzureParamRules("gpt-5.1", {}, { temperature: 0.7 }) as Record<
+    string,
+    unknown
+  >;
+  assert.equal(dropped.temperature, undefined);
+
+  const kept = applyAzureParamRules("gpt-5.1", {}, { temperature: 1 }) as Record<string, unknown>;
+  assert.equal(kept.temperature, 1);
+});
+
+test("unaffected deployments pass through untouched", () => {
+  const body = { max_tokens: 500, temperature: 0.2, reasoning_effort: "low" };
+  const out = applyAzureParamRules("Phi-4", {}, body);
+  assert.deepEqual(out, body);
+});
+
+test("the regex does not match unrelated names by accident", () => {
+  assert.equal(AZURE_COMPLETION_TOKEN_DEPLOYMENT.test("gpt-4o-mini"), false);
+  assert.equal(AZURE_COMPLETION_TOKEN_DEPLOYMENT.test("DeepSeek-V4-Flash"), false);
+  assert.equal(AZURE_COMPLETION_TOKEN_DEPLOYMENT.test("Kimi-K2.7-Code"), false);
+});
+
+test("azure-ai resolves to AzureAiExecutor, not the bare DefaultExecutor", () => {
+  const executor = getExecutor("azure-ai");
+  assert.ok(
+    executor instanceof AzureAiExecutor,
+    "azure-ai must have its own executor so it inherits the Azure param rules"
+  );
+});


### PR DESCRIPTION
Two Azure HTTP 400s found while wiring Claude Code and Cursor through OmniRoute to a live Azure AI Foundry resource. Both reproduce on any agentic client, because both trigger on the presence of `tools`.

## Bug 1 — `azure-ai` never applied the Azure param rules

```
POST /v1/messages  {"model":"azure-ai/gpt-chat-latest", ...}
-> 400 Unsupported parameter: 'max_tokens' is not supported with this model.
       Use 'max_completion_tokens' instead.

POST /v1/messages  {"model":"azure-ai/gpt-5.6-luna", ...}  # via Claude Code
-> 400 Function tools with reasoning_effort are not supported ...
```

`AzureOpenAIExecutor` already converted `max_tokens` and stripped `reasoning_effort`/`temperature`, but those rules were **inline in that class**. `azure-ai` had no entry in the executor registry and fell through to the bare `DefaultExecutor`, so the *same Azure deployment* succeeded on the `azure-openai` connection and 400'd on `azure-ai`.

**Fix:** extract the rules into `open-sse/executors/azureParamRules.ts`, add `AzureAiExecutor` (inherits `DefaultExecutor`'s `azure-ai` URL / header / `apiType` handling unchanged, adds only the rules), and register it for `azure-ai`.

Also widened the deployment pattern to cover `gpt-chat-latest` — a moving alias that resolves to a GPT-5-era model and rejects `max_tokens`, but carries no version number for the token-boundary pattern to match.

## Bug 2 — `max_tokens` floor exceeds the model ceiling

```
POST /v1/chat/completions  {"model":"azure-openai/gpt-4o-mini-dz","max_tokens":40, tools:[...]}
-> 400 max_tokens is too large: 32000. This model supports at most 16384
       completion tokens, whereas you provided 32000.
```

Note the request asked for **40**. `adjustMaxTokens` raises any smaller `max_tokens` to `DEFAULT_MIN_TOKENS` (32000) whenever tools are present, to avoid truncated tool arguments — but that floor has no upper bound, so it overshoots a model whose own ceiling is 16384.

**Fix:** scoped `maxOutputCap` rules in `paramSupport.ts` for both Azure wire paths, using the mechanism already established for the `zai` / `volcengine` endpoint caps.

`PROVIDER_MAX_TOKENS` is deliberately **not** used: it is provider-wide, and the same Azure resource also serves GPT-5 deployments whose ceiling is far higher.

## TDD

Red proven before the fix, without stashing (Hard Rule #22a) — the base regex was compared directly:

```
gpt-chat-latest    old=false  new=true      <- the 400
gpt-5.1            old=true   new=true      <- unchanged

git show origin/release/v3.8.50:open-sse/executors/index.ts | grep '"azure-ai"'
(no match - azure-ai fell through to DefaultExecutor on base)
```

## Results

```
tests/unit/azure-param-rules.test.ts       8 pass / 0 fail
tests/unit/azure-max-output-clamp.test.ts  5 pass / 0 fail
azure + param regression suites (9 files) 68 pass / 0 fail
typecheck:core                            clean
eslint (changed files)                    exit 0
```

The new suites also pin the negative cases: the regex must not match `gpt-4o-mini`, `DeepSeek-V4-Flash` or `Kimi-K2.7-Code`, the clamp must not affect `gpt-5.1`, and it must not leak to `gpt-4o-mini` on other providers.

WARNING - base-red inherited: #9737
