### PR TITLE
[TS7] fix(types): preserve Claude thinking body contracts

### DIFF
--- a/open-sse/services/claudeAdaptiveThinking.ts
+++ b/open-sse/services/claudeAdaptiveThinking.ts
@@ -54,7 +54,7 @@ export function normalizeClaudeAdaptiveThinking<T extends Record<string, unknown
   delete nextThinking.budget_tokens;
   delete nextThinking.max_tokens;
 
-  return { ...record, thinking: nextThinking } as T;
+  return { ...body, thinking: nextThinking };
 }
 
 /**
@@ -84,7 +84,7 @@ export function normalizeClaudeDisabledThinkingEffort<T extends Record<string, u
   }
 
   return {
-    ...record,
+    ...body,
     output_config: { ...outputConfig, effort: disabledEffortCap },
-  } as T;
+  };
 }

--- a/tests/unit/claude-adaptive-thinking-normalize.test.ts
+++ b/tests/unit/claude-adaptive-thinking-normalize.test.ts
@@ -55,10 +55,12 @@ test("direct Anthropic API providers clamp Opus 5 disabled thinking to high effo
     for (const effort of ["xhigh", "max"]) {
       const body = {
         model: "claude-opus-5",
+        request_marker: "preserve-me",
         thinking: { type: "disabled" },
         output_config: { effort, format: "compact" },
       };
       const result = normalizeClaudeDisabledThinkingEffort(body, "claude-opus-5", provider);
+      assert.equal(result.request_marker, "preserve-me");
       assert.deepEqual(result.thinking, { type: "disabled" });
       assert.deepEqual(result.output_config, { effort: "high", format: "compact" });
     }


### PR DESCRIPTION
## Summary

- preserve the caller-specific request body type while normalizing Claude thinking fields
- avoid erasing the generic contract through an intermediate JSON record
- retain unrelated fields when clamping disabled-thinking effort

## Validation

- `node --import tsx/esm --test tests/unit/claude-adaptive-thinking-normalize.test.ts` (15/15)
- targeted ESLint and Prettier checks
- TypeScript 6 diagnostics: 62 -> 60, removed 2, added 0
- official TypeScript 7.0.2 diagnostics: 61 -> 59, removed 2, added 0

Related to #8484.