### PR TITLE
[TS7] fix(types): normalize Gemini Business credentials

### DIFF
--- a/open-sse/executors/gemini-business.ts
+++ b/open-sse/executors/gemini-business.ts
@@ -80,16 +80,7 @@ export class GeminiBusinessExecutor extends BaseExecutor {
     // Extract cookies from credentials — check apiKey/cookie first, then
     // try each __Secure-1PSID* key in providerSpecificData individually.
     // A user with only __Secure-1PSID (no PSIDTS) is still valid.
-    const directCookie =
-      readCredentialString(credentials?.apiKey) || readCredentialString(credentials?.cookie);
-    const psid = readProviderSpecificString(credentials?.providerSpecificData, [
-      "__Secure-1PSID",
-      "cookie",
-    ]);
-    const psidts = readProviderSpecificString(credentials?.providerSpecificData, [
-      "__Secure-1PSIDTS",
-    ]);
-    const cookie = directCookie || [psid, psidts].filter(Boolean).join("; ");
+    const cookie = resolveGeminiBusinessCookie(credentials);
 
     if (!cookie) {
       return makeErrorResult(
@@ -378,6 +369,15 @@ function readProviderSpecificString(providerSpecificData: unknown, keys: string[
     if (typeof v === "string" && v.trim().length > 0) return v.trim();
   }
   return "";
+}
+
+export function resolveGeminiBusinessCookie(credentials: unknown): string {
+  if (!credentials || typeof credentials !== "object") return "";
+  const data = credentials as Record<string, unknown>;
+  const directCookie = readCredentialString(data.apiKey) || readCredentialString(data.cookie);
+  const psid = readProviderSpecificString(data.providerSpecificData, ["__Secure-1PSID", "cookie"]);
+  const psidts = readProviderSpecificString(data.providerSpecificData, ["__Secure-1PSIDTS"]);
+  return directCookie || [psid, psidts].filter(Boolean).join("; ");
 }
 
 function extractTextContent(content: unknown): string {

--- a/tests/unit/gemini-business-provider.test.ts
+++ b/tests/unit/gemini-business-provider.test.ts
@@ -6,9 +6,8 @@ const { WEB_COOKIE_PROVIDERS } = await import("../../src/shared/constants/provid
 const { WEB_SESSION_CREDENTIAL_REQUIREMENTS } = await import(
   "../../src/shared/providers/webSessionCredentials.ts"
 );
-const { GeminiBusinessExecutor, parseStreamResponse } = await import(
-  "../../open-sse/executors/gemini-business.ts"
-);
+const { GeminiBusinessExecutor, parseStreamResponse, resolveGeminiBusinessCookie } =
+  await import("../../open-sse/executors/gemini-business.ts");
 
 // ─── Provider metadata ──────────────────────────────────────────────────────
 
@@ -47,6 +46,22 @@ test("Gemini Business credential requirements use __Secure-1PSID cookies", () =>
 test("GeminiBusinessExecutor constructs with the correct provider", () => {
   const ex = new GeminiBusinessExecutor();
   assert.equal((ex as unknown as { provider: string }).provider, "gemini-business");
+});
+
+test("Gemini Business preserves supported legacy cookie credential placements", () => {
+  assert.equal(
+    resolveGeminiBusinessCookie({ cookie: "  __Secure-1PSID=legacy  " }),
+    "__Secure-1PSID=legacy"
+  );
+  assert.equal(
+    resolveGeminiBusinessCookie({
+      providerSpecificData: {
+        "__Secure-1PSID": "__Secure-1PSID=psid",
+        "__Secure-1PSIDTS": "__Secure-1PSIDTS=psidts",
+      },
+    }),
+    "__Secure-1PSID=psid; __Secure-1PSIDTS=psidts"
+  );
 });
 
 test("GeminiBusinessExecutor.execute returns 401 when no cookies are provided", async () => {


### PR DESCRIPTION
## Summary

- normalize Gemini Business cookie credentials from the supported top-level and provider-specific locations
- preserve the legacy top-level cookie fallback without widening the shared provider credential type
- add regression coverage for both credential layouts

## Validation

- `node --import tsx/esm --test tests/unit/gemini-business-provider.test.ts` (16/16)
- targeted ESLint and production-file Prettier checks
- TypeScript 6 diagnostics: 62 -> 61, removed 1, added 0
- official TypeScript 7.0.2 diagnostics: 61 -> 60, removed 1, added 0

Related to #8484.