### PR TITLE
[TS7] fix(types): preserve proxy contracts of a since-removed keyless provider

### DIFF
--- a/open-sse/executors/theoldllm.ts
+++ b/open-sse/executors/theoldllm.ts
@@ -108,13 +108,9 @@ export function mapModel(model: string): string {
 const TOKEN_SEED = "oldllm-client-2026";
 const UA_PREFIX = CHROME_UA.slice(0, 20); // "Mozilla/5.0 (Windows"
 
-type TheOldLlmProxy = {
-  type?: string;
-  host: string;
-  port: number;
-  username?: string | null;
-  password?: string | null;
-} | null;
+type TheOldLlmProxy = Awaited<
+  ReturnType<typeof import("../../src/lib/db/proxies").resolveProxyForProvider>
+>;
 
 interface TheOldLlmFetchDependencies {
   resolveProxy: () => Promise<TheOldLlmProxy>;

--- a/tests/unit/theoldllm-provider-proxy.test.ts
+++ b/tests/unit/theoldllm-provider-proxy.test.ts
@@ -10,6 +10,8 @@ test("theoldllm dispatches through its provider proxy assignment", async () => {
     port: 8080,
     username: "user",
     password: "secret",
+    family: "ipv4",
+    name: "residential-primary",
   };
   let observedProxy: unknown = null;
   let fetchCalls = 0;


### PR DESCRIPTION
Content removed on 2026-09-02 at the written request of the operator of the third-party service this change concerned. The code it introduced or modified was removed from OmniRoute in #12440. Original title and description are retained privately by the maintainer.