### PR TITLE
[TS7] fix(types): validate default executor pool config

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -61,11 +61,10 @@ import {
 } from "@/lib/providers/validation/urlHelpers";
 import { forwardOpencodeClientHeaders } from "../utils/opencodeHeaders.ts";
 import { resolveZaiUrl } from "./default/zaiFormatOverride.ts";
+import { normalizePoolConfig } from "./default/poolConfig.ts";
 import { acquireNvidiaConcurrencySlot } from "./default/nvidiaConcurrencyGate.ts";
 import { resolveAlibabaProviderBaseUrl } from "@/shared/constants/alibabaProviderRegions";
 import { usesCcWireImage } from "../services/ccWireImageBuiltins.ts";
-
-import type { PoolConfig } from "../services/sessionPool/types.ts";
 
 const NVIDIA_TOOL_CALL_ID_PATTERN = /^[A-Za-z0-9]{9}$/;
 
@@ -146,7 +145,7 @@ export class DefaultExecutor extends BaseExecutor {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
     const registryEntry = getRegistryEntry(provider);
     if (registryEntry?.poolConfig) {
-      this.poolConfig = registryEntry.poolConfig as PoolConfig;
+      this.poolConfig = normalizePoolConfig(registryEntry.poolConfig) ?? undefined;
     }
   }
 

--- a/open-sse/executors/default/poolConfig.ts
+++ b/open-sse/executors/default/poolConfig.ts
@@ -1,0 +1,33 @@
+import type { PoolConfig } from "../../services/sessionPool/types.ts";
+
+export function normalizePoolConfig(value: Record<string, unknown>): PoolConfig | null {
+  const {
+    minSessions,
+    maxSessions,
+    cooldownBase,
+    cooldownMax,
+    cooldownJitter,
+    requestTimeout,
+    requestJitter,
+  } = value;
+  if (
+    typeof minSessions !== "number" ||
+    typeof maxSessions !== "number" ||
+    typeof cooldownBase !== "number" ||
+    typeof cooldownMax !== "number" ||
+    typeof cooldownJitter !== "number" ||
+    typeof requestTimeout !== "number" ||
+    typeof requestJitter !== "number"
+  ) {
+    return null;
+  }
+  return {
+    minSessions,
+    maxSessions,
+    cooldownBase,
+    cooldownMax,
+    cooldownJitter,
+    requestTimeout,
+    requestJitter,
+  };
+}

--- a/tests/unit/default-pool-config-contract.test.ts
+++ b/tests/unit/default-pool-config-contract.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizePoolConfig } from "../../open-sse/executors/default/poolConfig.ts";
+
+test("normalizePoolConfig preserves a complete registry pool contract", () => {
+  assert.deepEqual(
+    normalizePoolConfig({
+      minSessions: 1,
+      maxSessions: 3,
+      cooldownBase: 2000,
+      cooldownMax: 5000,
+      cooldownJitter: 100,
+      requestTimeout: 30000,
+      requestJitter: 50,
+    }),
+    {
+      minSessions: 1,
+      maxSessions: 3,
+      cooldownBase: 2000,
+      cooldownMax: 5000,
+      cooldownJitter: 100,
+      requestTimeout: 30000,
+      requestJitter: 50,
+    }
+  );
+});
+
+test("normalizePoolConfig rejects incomplete registry values", () => {
+  assert.equal(normalizePoolConfig({ minSessions: 1, maxSessions: 3 }), null);
+});


### PR DESCRIPTION
## Summary
- validate registry pool configuration before assigning the DefaultExecutor contract
- preserve the complete LLM7 pool configuration without a direct incompatible cast
- keep the frozen executor and existing frozen test file within their size baselines

## Validation
- node --import tsx/esm --test tests/unit/default-pool-config-contract.test.ts
- targeted ESLint and Prettier
- TS6 diagnostics: 62 to 61; added 0
- official TypeScript 7.0.2 diagnostics: 61 to 60; added 0
- check:file-size: no new violations (two unrelated base violations remain)