### PR TITLE
[TS7] fix(types): expose SQLite transaction state

### DIFF
--- a/src/lib/db/adapters/betterSqliteAdapter.ts
+++ b/src/lib/db/adapters/betterSqliteAdapter.ts
@@ -12,6 +12,10 @@ export function createBetterSqliteAdapter(db: import("better-sqlite3").Database)
       return db.name;
     },
 
+    get inTransaction() {
+      return db.inTransaction;
+    },
+
     prepare(sql: string): PreparedStatement {
       const stmt = db.prepare(sql);
       return {

--- a/src/lib/db/adapters/types.ts
+++ b/src/lib/db/adapters/types.ts
@@ -13,6 +13,8 @@ export interface SqliteAdapter {
   readonly driver: "better-sqlite3" | "node:sqlite" | "bun:sqlite" | "sql.js";
   readonly open: boolean;
   readonly name: string;
+  /** Driver transaction state when exposed by the underlying SQLite implementation. */
+  readonly inTransaction?: boolean;
 
   prepare(sql: string): PreparedStatement;
   exec(sql: string): void;

--- a/tests/unit/db-adapters/betterSqliteAdapter.test.ts
+++ b/tests/unit/db-adapters/betterSqliteAdapter.test.ts
@@ -78,4 +78,16 @@ describe("betterSqliteAdapter", () => {
     assert.equal(count.cnt, 0, "Rollback deve ter desfeito o insert");
     adapter.close();
   });
+
+  test("expõe o estado da transação sem vazar o driver bruto", () => {
+    const adapter = tryOpenSync(":memory:");
+    if (!adapter || adapter.driver !== "better-sqlite3") return;
+
+    assert.equal(adapter.inTransaction, false);
+    const inspect = adapter.transaction(() => adapter.inTransaction);
+    assert.equal(inspect(), true);
+    assert.equal(adapter.inTransaction, false);
+
+    adapter.close();
+  });
 });


### PR DESCRIPTION
## Summary
- expose optional transaction state through the shared SQLite adapter contract
- forward better-sqlite3 transaction state without leaking its raw driver
- preserve token counter rollback detection across supported adapters

## Validation
- node --import tsx/esm --test tests/unit/db-adapters/betterSqliteAdapter.test.ts tests/unit/token-limits.test.ts (17/17)
- targeted ESLint and Prettier
- TS6 diagnostics: 62 to 61; added 0
- official TypeScript 7.0.2 diagnostics: 61 to 60; added 0
- check:file-size: no new violations (two unrelated base violations remain)