### PR TITLE
[TS7] fix(types): normalize DuckDuckGo request messages

### DIFF
--- a/open-sse/executors/duckduckgo-web.ts
+++ b/open-sse/executors/duckduckgo-web.ts
@@ -137,7 +137,22 @@ interface DuckDuckGoModelCapabilities {
   reasoningEffort: string | null;
 }
 
+type DuckDuckGoRequestMessage = Record<string, unknown> & {
+  role: string;
+  content: unknown;
+};
+
 let durablePublicKey: JsonWebKey | null = null;
+
+export function normalizeDuckDuckGoMessages(value: unknown): DuckDuckGoRequestMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((message) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) return [];
+    const record = message as Record<string, unknown>;
+    if (typeof record.role !== "string") return [];
+    return [{ ...record, role: record.role, content: record.content }];
+  });
+}
 
 function extractDuckDuckGoContent(data: unknown): string {
   if (!data || typeof data !== "object") return "";
@@ -440,14 +455,12 @@ export class DuckDuckGoWebExecutor extends BaseExecutor {
     const { model, body, stream, signal, upstreamExtraHeaders } = input;
     const upstreamModel = normalizeDuckDuckGoModel(model);
     const bodyObj = (body || {}) as Record<string, unknown>;
-    const rawMessages = Array.isArray((body as { messages?: unknown[] } | null)?.messages)
-      ? ((body as { messages: unknown[] }).messages as Array<Record<string, unknown>>)
-      : [];
+    const rawMessages = normalizeDuckDuckGoMessages(bodyObj.messages);
     const { hasTools, requestedTools, effectiveMessages } = prepareToolMessages(
       bodyObj,
       rawMessages
     );
-    const messages = effectiveMessages as Array<Record<string, unknown>>;
+    const messages = effectiveMessages;
     const isStreaming = stream !== false;
     const upstreamHeaders = upstreamExtraHeaders || {};
 

--- a/tests/unit/duckduckgo-web-executor.test.ts
+++ b/tests/unit/duckduckgo-web-executor.test.ts
@@ -4,6 +4,7 @@ import { FETCH_TIMEOUT_MS } from "../../open-sse/config/constants.ts";
 import {
   DuckDuckGoWebExecutor,
   DUCKDUCKGO_BASE,
+  normalizeDuckDuckGoMessages,
   STATUS_URL,
 } from "../../open-sse/executors/duckduckgo-web.ts";
 
@@ -38,6 +39,21 @@ describe("DuckDuckGoWebExecutor", () => {
   });
 
   describe("execute method validation", () => {
+    it("normalizes only role-bearing request messages without dropping metadata", () => {
+      assert.deepEqual(
+        normalizeDuckDuckGoMessages([
+          { role: "user", content: "hello", name: "caller" },
+          { role: "assistant", tool_calls: [{ id: "call-1" }] },
+          { content: "missing role" },
+          null,
+        ]),
+        [
+          { role: "user", content: "hello", name: "caller" },
+          { role: "assistant", content: undefined, tool_calls: [{ id: "call-1" }] },
+        ]
+      );
+    });
+
     it("should reject empty messages array", async () => {
       const executor = new DuckDuckGoWebExecutor();
 


### PR DESCRIPTION
## Summary
- normalize DuckDuckGo request messages to the shared web-tool message contract
- preserve role-bearing message metadata and explicit undefined content for tool-only messages
- discard malformed entries that cannot participate in an upstream chat request

## Validation
- node --import tsx/esm --test tests/unit/duckduckgo-web-executor.test.ts (16/16)
- targeted ESLint and Prettier
- TS6 diagnostics: 62 to 61; added 0
- official TypeScript 7.0.2 diagnostics: 61 to 60; added 0
- check:file-size: no new violations (two unrelated base violations remain)