### PR TITLE
docs(proposals): Telegram Mini App integration feasibility analysis

### DIFF
--- a/docs/proposals/TELEGRAM-MINIAPP.md
+++ b/docs/proposals/TELEGRAM-MINIAPP.md
@@ -58,7 +58,7 @@ the natural shape is:
 - **Public HTTPS required.** Telegram only delivers updates to an HTTPS
   endpoint with a valid cert. Self-hosted OmniRoute behind Tailscale/ngrok
   needs a public tunnel or Cloudflare Tunnel for the webhook path
-  (a future webhook-URL setting). The dashboard can render the current
+  (`TELEGRAM_WEBHOOK_URL`-style env). The dashboard can render the current
   public origin (`OMNIROUTE_PUBLIC_BASE_URL`) but no webhook registration
   helper exists.
 - **Encryption gate.** `webhooks/route.ts:77` already refuses telegram
@@ -102,7 +102,7 @@ the natural shape is:
 1. Add `grammy` or `telegraf` (or ~60 lines of hand-rolled HMAC + fetch).
 2. Implement `src/lib/telegram/initData.ts` — `verifyInitData(initData, botToken)`.
 3. Stand up a throwaway `POST /api/telegram/miniapp/webhook` route behind
-   a dedicated webhook secret; register via `setWebhook` once, locally.
+   `TELEGRAM_WEBHOOK_SECRET`; register via `setWebhook` once, locally.
 
 ### Phase 1 — Minimal chat slice (1–2 dev-days)
 


### PR DESCRIPTION
## Summary

Adds a feasibility analysis for integrating a **Telegram Mini App** into OmniRoute — a chat surface opened inside Telegram that proxies to OmniRoute's existing OpenAI-compatible `/v1/chat/completions` endpoint.

## What was verified (against main @ 918fba5e3)

**Already present:**
- Outbound Telegram webhook integration (`src/lib/webhooks/integrations/telegram.ts`) — event → `sendMessage`, with bot-token format validation and the DB-encryption gate (`webhooks/route.ts:77`)
- Webhook kinds `slack | telegram | discord | custom` + CRUD/test routes

**Missing (the real work):**
- Inbound Bot API listener (no `setWebhook`, no update handling — outbound only today)
- WebApp `initData` HMAC-SHA256 verification (the only trust anchor for Mini App auth)
- Telegram bot library (none in package.json)
- Mini App hosting surface + per-user API key mapping

## Verdict: FEASIBLE (2–4 dev-days for a working slice)

Key constraints identified:
1. **Public HTTPS webhook** required by Telegram (tunnel needed on self-hosted installs)
2. **No native streaming to Telegram** — must emulate with message edits
3. **initData must be verified server-side** — never trust the client
4. **Encryption gate applies** to the bot token (it becomes the HMAC secret)

Phased plan: spike (initData verification + webhook route) → minimal chat slice (/start, deep-link key mapping, chat proxy, mini app page) → hardening (streaming emulation, per-user key revocation, registration helper).

Docs-only change — no code, no env vars, no tests affected.