### PR TITLE
cherry-pick(pr-9796): [TS7] fix(types): expose SQLite transaction state

### DIFF
--- a/src/lib/db/adapters/betterSqliteAdapter.ts
+++ b/src/lib/db/adapters/betterSqliteAdapter.ts
@@ -12,6 +12,10 @@ export function createBetterSqliteAdapter(db: import("better-sqlite3").Database)
       return db.name;
     },
 
+    get inTransaction() {
+      return db.inTransaction;
+    },
+
     prepare(sql: string): PreparedStatement {
       const stmt = db.prepare(sql);
       return {

--- a/src/lib/db/adapters/types.ts
+++ b/src/lib/db/adapters/types.ts
@@ -13,6 +13,8 @@ export interface SqliteAdapter {
   readonly driver: "better-sqlite3" | "node:sqlite" | "bun:sqlite" | "sql.js";
   readonly open: boolean;
   readonly name: string;
+  /** Driver transaction state when exposed by the underlying SQLite implementation. */
+  readonly inTransaction?: boolean;
 
   prepare(sql: string): PreparedStatement;
   exec(sql: string): void;

--- a/tests/unit/db-adapters/betterSqliteAdapter.test.ts
+++ b/tests/unit/db-adapters/betterSqliteAdapter.test.ts
@@ -78,4 +78,16 @@ describe("betterSqliteAdapter", () => {
     assert.equal(count.cnt, 0, "Rollback deve ter desfeito o insert");
     adapter.close();
   });
+
+  test("expõe o estado da transação sem vazar o driver bruto", () => {
+    const adapter = tryOpenSync(":memory:");
+    if (!adapter || adapter.driver !== "better-sqlite3") return;
+
+    assert.equal(adapter.inTransaction, false);
+    const inspect = adapter.transaction(() => adapter.inTransaction);
+    assert.equal(inspect(), true);
+    assert.equal(adapter.inTransaction, false);
+
+    adapter.close();
+  });
 });


### PR DESCRIPTION
Mantainer-executed cherry-pick of the community PR #9796 from @backryun.

This branch preserves the original commits/authorship and keeps the work
available in this repository for merge without requiring author push access.