### PR TITLE
fix(antigravity): rotate image accounts on explicit quota exhaustion

### DIFF
--- a/src/sse/services/imageCredentialRetry.ts
+++ b/src/sse/services/imageCredentialRetry.ts
@@ -1,3 +1,4 @@
+import { classify429 } from "@omniroute/open-sse/services/antigravity429Engine.ts";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
 
 import { getProviderCredentialsWithQuotaPreflight } from "./auth";
@@ -48,6 +49,29 @@ function connectionIdOf(credentials: any): string | null {
 
 function isCredentialSentinel(credentials: any): boolean {
   return Boolean(credentials?.allRateLimited || credentials?.allExpired);
+}
+
+/**
+ * Image generation is non-idempotent, so account rotation stays deliberately
+ * narrower than chat failover. Antigravity's explicit exhausted-quota signal
+ * is safe to retry on another account; an ordinary 429 is not evidence that a
+ * different account helps and must not cause account rotation.
+ */
+export function isAntigravityImageQuotaExhausted(
+  provider: string,
+  result: ImageGenerationResult
+): boolean {
+  if (provider !== "antigravity" || Number(result.status) !== 429) return false;
+
+  let errorText = "";
+  try {
+    errorText =
+      typeof result.error === "string" ? result.error : JSON.stringify(result.error ?? "");
+  } catch {
+    return false;
+  }
+
+  return classify429(errorText) === "quota_exhausted";
 }
 
 async function defaultSelectNextCredentials(
@@ -110,8 +134,11 @@ export async function executeImageWithCredentialFallback({
 
     lastCredentials = currentCredentials;
     lastResult = await execute(currentCredentials);
-    const isAuthFailure = Number(lastResult.status) === 401 || lastResult.retryable === true;
-    if (lastResult.success || !isAuthFailure || !connectionId) {
+    const shouldTryAnotherAccount =
+      Number(lastResult.status) === 401 ||
+      lastResult.retryable === true ||
+      isAntigravityImageQuotaExhausted(provider, lastResult);
+    if (lastResult.success || !shouldTryAnotherAccount || !connectionId) {
       return { credentials: lastCredentials, result: lastResult };
     }
 

--- a/tests/unit/antigravity-image-credential-retry.test.ts
+++ b/tests/unit/antigravity-image-credential-retry.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isAntigravityImageQuotaExhausted } from "../../src/sse/services/imageCredentialRetry.ts";
+
+test("Antigravity image quota-exhausted 429 is the only 429 eligible for account rotation", () => {
+  assert.equal(
+    isAntigravityImageQuotaExhausted("antigravity", {
+      success: false,
+      status: 429,
+      error: { error: { message: "Individual quota reached" } },
+    }),
+    true
+  );
+});
+
+test("ordinary Hermes-shaped 429 does not create a rotation/cooldown signal", () => {
+  assert.equal(
+    isAntigravityImageQuotaExhausted("antigravity", {
+      success: false,
+      status: 429,
+      error: { error: { message: "RESOURCE_EXHAUSTED: malformed system payload" } },
+    }),
+    false
+  );
+});
+
+test("ordinary image rate-limit 429 does not create a rotation/cooldown signal", () => {
+  assert.equal(
+    isAntigravityImageQuotaExhausted("antigravity", {
+      success: false,
+      status: 429,
+      error: { error: { message: "too many requests; retry later" } },
+    }),
+    false
+  );
+});
+
+test("non-Antigravity 429 is not eligible for Antigravity account rotation", () => {
+  assert.equal(
+    isAntigravityImageQuotaExhausted("openai", {
+      success: false,
+      status: 429,
+      error: { error: { message: "Individual quota reached" } },
+    }),
+    false
+  );
+});


### PR DESCRIPTION
## Summary

- Extend the existing image credential retry coordinator so Antigravity can try another account after an explicit quota-exhaustion response.
- Keep image retries deliberately narrow: ordinary `429`, generic `RESOURCE_EXHAUSTED`, and non-Antigravity failures remain terminal.
- Preserve the existing cross-account retry behavior for `401` responses.

### Why

OmniRoute already refreshes OAuth credentials and rotates image accounts after `401`, but an Antigravity account with an explicitly exhausted image quota returns `429`. The request currently stops even when another configured Antigravity account still has quota.

Image generation may be non-idempotent, so retrying every `429` would be unsafe. This change reuses the existing Antigravity 429 classifier and permits rotation only when:

1. the provider is `antigravity`;
2. the response status is `429`; and
3. `classify429(error) === "quota_exhausted"`.

Generic rate limits, malformed/system-payload errors, and non-Antigravity responses do not rotate accounts.

## Related Issues

- Related to #9231 (existing OAuth refresh and account rotation after `401`)

## Validation

- [x] Focused tests: `node --import tsx/esm --test tests/unit/antigravity-image-credential-retry.test.ts`
- [x] `npm run lint`
- [x] Production-code changes include automated tests in this PR
- [ ] SonarQube PR analysis — pending CI

Validation was run from a clean clone on Node `v22.22.3` / npm `10.9.8`.

## Tests Added Or Updated

- `tests/unit/antigravity-image-credential-retry.test.ts`
  - rotates for an explicit Antigravity `Individual quota reached` response;
  - rejects a generic `RESOURCE_EXHAUSTED` response;
  - rejects an ordinary image rate-limit response;
  - rejects quota-shaped responses from non-Antigravity providers.

## Coverage Notes

The new focused unit file directly covers the exported retry predicate and its positive and negative classification boundaries. The retry coordinator uses the same predicate to decide whether another credential may be selected.

## Reviewer Notes

- No schema, migration, settings, or API contract changes.
- The retry remains bounded by the coordinator's existing tried-connection set and maximum-attempt limit.
- The intentionally narrow classification avoids replaying image requests for ambiguous or provider-wide rate limits.
