### PR TITLE
feat: scaffold Free Opus MVP — site & video generation endpoints

### DIFF
--- a/apps/free-opus/.github/workflows/ci.yml
+++ b/apps/free-opus/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ "tatianadug-feat-free-opus-mvp", "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: cd apps/free-opus && npm ci
+      - run: cd apps/free-opus && npm test

--- a/apps/free-opus/README.md
+++ b/apps/free-opus/README.md
@@ -7,32 +7,70 @@ Quick start (inside apps/free-opus):
 1. Install dependencies: `npm install`
 2. Run dev: `npm run dev`
 3. Open http://localhost:3000
+4. Start the background worker (separate process): `node workers/worker.js`
 
 Important notes
 - Do NOT commit API keys. Provide them via environment variables in your deployment (Vercel secrets/env).
 - This scaffold uses mocked adapters when keys are not present so the UI can demo without real provider credentials.
+- The in-memory queue is for demo only. Set REDIS_URL to use a Redis-backed queue.
 
-ENV variables (development / production):
+ENV variables (development / production)
 - OPENAI_API_KEY - (optional) OpenAI API key. If absent, the app returns mocked completions.
 - RUNWAY_API_KEY - (optional) Runway API key; runway adapter is mocked here.
-- STORAGE_S3_ENDPOINT / STORAGE_S3_KEY / STORAGE_S3_SECRET - (optional) S3-compatible storage settings for assets.
+- STORAGE_S3_ENDPOINT - (optional) S3-compatible endpoint (e.g., https://s3.amazonaws.com or MinIO).
+- STORAGE_S3_KEY - (optional) S3 access key
+- STORAGE_S3_SECRET - (optional) S3 secret key
+- STORAGE_S3_BUCKET - (optional) S3 bucket name used for presigns
+- STORAGE_S3_REGION - (optional) S3 region (default us-east-1)
 - STRIPE_SECRET_KEY - (optional) Stripe secret for billing integration.
 - AUTH_PROVIDER - (optional) e.g., clerk or auth0 - scaffolding only.
+- REDIS_URL - (optional) when set the app will use a Redis-backed queue implementation (ioredis required)
+- REDIS_QUEUE_KEY - (optional) Redis list key for jobs (default: free-opus:jobs)
+
+Local dev notes
+- With no provider keys the app still demos using mocks.
+- To demo render job processing locally: run `npm run dev` in one shell and `node workers/worker.js` in another. Use the UI to submit video jobs and poll /api/status
 
 Roadmap / TODOs
-- Replace in-memory queue with Redis-backed queue (bullmq or RSMQ)
-- Replace Runway mock with real Runway adapter and robust retry/backoff
-- Implement auth (Clerk/Auth0) and per-tenant isolation
-- Implement storage using AWS SDK and presigned URLs
-- Add Stripe billing + trial flow
-- Add CI/CD (Vercel) deployment guide and environment spec
+- Replace mock adapters with real provider integrations (Runway, ElevenLabs, OpenAI production settings)
+- Integrate auth (Clerk/Auth0) for tenant isolation
+- Integrate Stripe for trial + billing (webhooks + subscription management)
+- Harden queue with Redis and add retry/backoff with exponential policy
+- Use durable storage (S3) for assets and sign URLs server-side
+- Add rate-limiting middleware (currently basic in-memory limiter added)
+- Add unit and integration tests, coverage and CI gates
 
 API endpoints
 - POST /api/generate/site  { prompt }
 - POST /api/generate/video { prompt } -> returns jobId
 - GET  /api/status?jobId=... -> job status
+- POST /api/auth/login { email } -> mock token
+- GET  /api/auth/me (Authorization: <token>) -> mock user
+- POST /api/stripe/create-customer { email } -> mock or Stripe-backed
+- POST /api/stripe/create-subscription { customerId, priceId } -> mock or Stripe-backed
 
-Tests
-- Add unit tests under tests/ and wire a test runner.
+Tests included
+- tests/unit/runway.test.js — basic unit test for runway mock
+
+What was changed in this branch
+- Added initial scaffold: pages, API endpoints, lib adapters (openai mock, runway mock, elevenlabs mock)
+- Added queue wrapper with optional Redis adapter
+- Added S3 adapter with presign fallback (requires @aws-sdk packages to enable)
+- Added worker script to poll queue and simulate renders
+- CI (GitHub Actions) workflow and vercel.json configuration
+
+How to hand off (push-blocker)
+- This branch is committed locally as `tatianadug-feat-free-opus-mvp` but remote push returned 403 due to permissions.
+- Two options to publish code remotely:
+  1. Grant push permission for this account and push the branch: `git push -u origin tatianadug-feat-free-opus-mvp`
+  2. Apply the generated patch file in session artifacts: `git am 0001-feat-free-opus.patch` (patch placed in the Copilot session artifacts)
+
+Next steps for production hardening
+- Add real provider wiring (Runway SDK, ElevenLabs SDK, OpenAI production model selection)
+- Implement tenant-scoped DB (users, projects, job metadata)
+- Add Redis + worker autoscaling (serverless queue or background workers)
+- Add rate-limiter using Redis or API gateway level rules
+- Add Stripe webhooks and entitlement checks
+- Add Vercel environment variables and secrets, then enable automatic deployments
 
 License: MIT

--- a/apps/free-opus/README.md
+++ b/apps/free-opus/README.md
@@ -1,0 +1,38 @@
+# Free Opus — MVP (prototype)
+
+This folder contains a minimal Next.js scaffold for the Free Opus MVP (Jamstack site + AI-generated animated videos).
+
+Quick start (inside apps/free-opus):
+
+1. Install dependencies: `npm install`
+2. Run dev: `npm run dev`
+3. Open http://localhost:3000
+
+Important notes
+- Do NOT commit API keys. Provide them via environment variables in your deployment (Vercel secrets/env).
+- This scaffold uses mocked adapters when keys are not present so the UI can demo without real provider credentials.
+
+ENV variables (development / production):
+- OPENAI_API_KEY - (optional) OpenAI API key. If absent, the app returns mocked completions.
+- RUNWAY_API_KEY - (optional) Runway API key; runway adapter is mocked here.
+- STORAGE_S3_ENDPOINT / STORAGE_S3_KEY / STORAGE_S3_SECRET - (optional) S3-compatible storage settings for assets.
+- STRIPE_SECRET_KEY - (optional) Stripe secret for billing integration.
+- AUTH_PROVIDER - (optional) e.g., clerk or auth0 - scaffolding only.
+
+Roadmap / TODOs
+- Replace in-memory queue with Redis-backed queue (bullmq or RSMQ)
+- Replace Runway mock with real Runway adapter and robust retry/backoff
+- Implement auth (Clerk/Auth0) and per-tenant isolation
+- Implement storage using AWS SDK and presigned URLs
+- Add Stripe billing + trial flow
+- Add CI/CD (Vercel) deployment guide and environment spec
+
+API endpoints
+- POST /api/generate/site  { prompt }
+- POST /api/generate/video { prompt } -> returns jobId
+- GET  /api/status?jobId=... -> job status
+
+Tests
+- Add unit tests under tests/ and wire a test runner.
+
+License: MIT

--- a/apps/free-opus/lib/elevenlabs-mock.js
+++ b/apps/free-opus/lib/elevenlabs-mock.js
@@ -1,0 +1,8 @@
+// Minimal ElevenLabs TTS mock
+async function synthesize(text, opts = {}) {
+  const voice = opts.voice || "alloy";
+  // Return a mocked audio URL or buffer descriptor
+  return { url: `https://mock-storage.local/tts/${encodeURIComponent(voice)}-${Date.now()}.mp3`, size: 12345 };
+}
+
+module.exports = { synthesize };

--- a/apps/free-opus/lib/openai.js
+++ b/apps/free-opus/lib/openai.js
@@ -1,0 +1,34 @@
+// Minimal OpenAI wrapper. If OPENAI_API_KEY is not set, returns a mock completion.
+const fetch = require("node-fetch");
+
+async function complete(prompt) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    // Mock response for demo
+    return { model: "mock-openai", text: `MOCK: Generated content for prompt:\n${prompt}` };
+  }
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: 800
+    })
+  });
+
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`OpenAI error: ${res.status} ${txt}`);
+  }
+
+  const json = await res.json();
+  const text = json.choices?.[0]?.message?.content || JSON.stringify(json);
+  return { model: json.model || "openai", text };
+}
+
+module.exports = { complete };

--- a/apps/free-opus/lib/providers.js
+++ b/apps/free-opus/lib/providers.js
@@ -1,0 +1,10 @@
+// Provider abstraction layer. Exposes OpenAI, Runway, ElevenLabs via unified API.
+const openai = require("./openai");
+const runway = require("./runway-mock");
+const eleven = require("./elevenlabs-mock");
+
+module.exports = {
+  openai,
+  runway,
+  eleven
+};

--- a/apps/free-opus/lib/queue-redis.js
+++ b/apps/free-opus/lib/queue-redis.js
@@ -1,0 +1,51 @@
+// Redis-backed queue implementation (requires ioredis)
+// Uses a list key 'free-opus:jobs' to push job JSON strings.
+// NOTE: This file is optional and used when REDIS_URL is provided.
+
+const IORedis = require("ioredis");
+const { v4: uuidv4 } = require("uuid");
+
+class RedisQueue {
+  constructor() {
+    const url = process.env.REDIS_URL;
+    if (!url) throw new Error("REDIS_URL not set");
+    this.redis = new IORedis(url);
+    this.listKey = process.env.REDIS_QUEUE_KEY || "free-opus:jobs";
+  }
+
+  async enqueue(job) {
+    // ensure job has id
+    if (!job.id) job.id = uuidv4();
+    await this.redis.lpush(this.listKey, JSON.stringify(job));
+    await this.redis.hset(`free-opus:job:${job.id}`, "status", "queued", "createdAt", Date.now());
+    return job;
+  }
+
+  async dequeue() {
+    // BRPOP with timeout 1 second
+    const res = await this.redis.brpop(this.listKey, 1);
+    if (!res) return null;
+    const payload = res[1];
+    const job = JSON.parse(payload);
+    await this.redis.hset(`free-opus:job:${job.id}`, "status", "processing", "startedAt", Date.now());
+    return { id: job.id, job };
+  }
+
+  async complete(id, result) {
+    await this.redis.hset(`free-opus:job:${id}`, "status", "complete", "completedAt", Date.now());
+    if (result) await this.redis.hset(`free-opus:job:${id}`, "result", JSON.stringify(result));
+  }
+
+  async fail(id, err) {
+    await this.redis.hset(`free-opus:job:${id}`, "status", "failed", "error", String(err), "failedAt", Date.now());
+  }
+
+  async getStatus(id) {
+    const h = await this.redis.hgetall(`free-opus:job:${id}`);
+    if (!h || Object.keys(h).length === 0) return null;
+    if (h.result) try { h.result = JSON.parse(h.result); } catch (e) {}
+    return h;
+  }
+}
+
+module.exports = RedisQueue;

--- a/apps/free-opus/lib/queue.js
+++ b/apps/free-opus/lib/queue.js
@@ -1,0 +1,35 @@
+// Simple in-memory queue for demo. NOT durable — replace with Redis/queue in prod.
+const runway = require("./runway-mock");
+
+const q = [];
+const byId = new Map();
+
+function enqueue(job) {
+  const item = { id: job.id, job, enqueuedAt: Date.now(), attempts: 0 };
+  q.push(item);
+  byId.set(job.id, { status: "queued", enqueuedAt: item.enqueuedAt });
+  return item;
+}
+
+function dequeue() {
+  const item = q.shift();
+  if (!item) return null;
+  byId.set(item.id, { status: "processing", startedAt: Date.now() });
+  return item;
+}
+
+function complete(id, result) {
+  byId.set(id, { status: "complete", result, completedAt: Date.now() });
+  // also update runway mock
+  runway.setStatus(id, "complete", { url: `https://mock-storage.local/video/${id}.mp4` }).catch(() => {});
+}
+
+function fail(id, err) {
+  byId.set(id, { status: "failed", error: String(err), at: Date.now() });
+}
+
+function getStatus(id) {
+  return byId.get(id) || null;
+}
+
+module.exports = { enqueue, dequeue, complete, fail, getStatus };

--- a/apps/free-opus/lib/queue.js
+++ b/apps/free-opus/lib/queue.js
@@ -1,35 +1,60 @@
-// Simple in-memory queue for demo. NOT durable — replace with Redis/queue in prod.
-const runway = require("./runway-mock");
+// Queue wrapper: select Redis-backed queue when REDIS_URL is provided, else fall back to in-memory.
+let queueImpl = null;
 
-const q = [];
-const byId = new Map();
-
-function enqueue(job) {
-  const item = { id: job.id, job, enqueuedAt: Date.now(), attempts: 0 };
-  q.push(item);
-  byId.set(job.id, { status: "queued", enqueuedAt: item.enqueuedAt });
-  return item;
+if (process.env.REDIS_URL) {
+  try {
+    const RedisQueue = require("./queue-redis");
+    const redisQueue = new RedisQueue();
+    queueImpl = {
+      enqueue: (job) => redisQueue.enqueue(job),
+      dequeue: () => redisQueue.dequeue(),
+      complete: (id, result) => redisQueue.complete(id, result),
+      fail: (id, err) => redisQueue.fail(id, err),
+      getStatus: (id) => redisQueue.getStatus(id)
+    };
+  } catch (err) {
+    console.warn("REDIS_URL set but queue-redis load failed:", err.message);
+  }
 }
 
-function dequeue() {
-  const item = q.shift();
-  if (!item) return null;
-  byId.set(item.id, { status: "processing", startedAt: Date.now() });
-  return item;
+if (!queueImpl) {
+  // Simple in-memory queue for demo. NOT durable — replace with Redis/queue in prod.
+  const runway = require("./runway-mock");
+
+  const q = [];
+  const byId = new Map();
+
+  function enqueue(job) {
+    const id = job.id || require("uuid").v4();
+    job.id = id;
+    const item = { id: job.id, job, enqueuedAt: Date.now(), attempts: 0 };
+    q.push(item);
+    byId.set(job.id, { status: "queued", enqueuedAt: item.enqueuedAt });
+    return item;
+  }
+
+  function dequeue() {
+    const item = q.shift();
+    if (!item) return null;
+    byId.set(item.id, { status: "processing", startedAt: Date.now() });
+    return item;
+  }
+
+  function complete(id, result) {
+    byId.set(id, { status: "complete", result, completedAt: Date.now() });
+    // also update runway mock
+    runway.setStatus(id, "complete", { url: `https://mock-storage.local/video/${id}.mp4` }).catch(() => {});
+  }
+
+  function fail(id, err) {
+    byId.set(id, { status: "failed", error: String(err), at: Date.now() });
+  }
+
+  function getStatus(id) {
+    return byId.get(id) || null;
+  }
+
+  queueImpl = { enqueue, dequeue, complete, fail, getStatus };
 }
 
-function complete(id, result) {
-  byId.set(id, { status: "complete", result, completedAt: Date.now() });
-  // also update runway mock
-  runway.setStatus(id, "complete", { url: `https://mock-storage.local/video/${id}.mp4` }).catch(() => {});
-}
-
-function fail(id, err) {
-  byId.set(id, { status: "failed", error: String(err), at: Date.now() });
-}
-
-function getStatus(id) {
-  return byId.get(id) || null;
-}
-
-module.exports = { enqueue, dequeue, complete, fail, getStatus };
+module.exports = queueImpl;

--- a/apps/free-opus/lib/rateLimit.js
+++ b/apps/free-opus/lib/rateLimit.js
@@ -1,0 +1,28 @@
+// Simple in-memory rate limiter per IP. Replace with redis-backed limiter in prod.
+const WINDOW_MS = 60 * 1000; // 1 minute
+const MAX_REQ = 20;
+const map = new Map();
+
+function cleanup() {
+  const now = Date.now();
+  for (const [k, v] of map.entries()) {
+    if (v.start + WINDOW_MS < now) map.delete(k);
+  }
+}
+
+function allow(key) {
+  cleanup();
+  const now = Date.now();
+  const existing = map.get(key);
+  if (!existing) {
+    map.set(key, { start: now, count: 1 });
+    return true;
+  }
+  if (existing.count < MAX_REQ) {
+    existing.count += 1;
+    return true;
+  }
+  return false;
+}
+
+module.exports = { allow };

--- a/apps/free-opus/lib/runway-mock.js
+++ b/apps/free-opus/lib/runway-mock.js
@@ -1,0 +1,31 @@
+// Mock Runway adapter for demoing video render jobs
+const { v4: uuidv4 } = require("uuid");
+
+const jobs = new Map();
+
+async function createJob({ prompt }) {
+  const id = uuidv4();
+  const job = { id, prompt, status: "created", createdAt: Date.now() };
+  jobs.set(id, job);
+  // Simulate queued state
+  job.status = "queued";
+  return job;
+}
+
+async function getStatus(id) {
+  const job = jobs.get(id);
+  if (!job) throw new Error("not_found");
+  return job;
+}
+
+// For worker to mark complete
+async function setStatus(id, status, result) {
+  const job = jobs.get(id);
+  if (!job) throw new Error("not_found");
+  job.status = status;
+  if (result) job.result = result;
+  job.updatedAt = Date.now();
+  return job;
+}
+
+module.exports = { createJob, getStatus, setStatus, _jobs: jobs };

--- a/apps/free-opus/lib/storage-s3.js
+++ b/apps/free-opus/lib/storage-s3.js
@@ -1,0 +1,39 @@
+// Optional S3 adapter using AWS SDK v3 for presigned URLs.
+// If STORAGE_S3_ENDPOINT/KEY/SECRET not set, fall back to mock signed URLs.
+
+let s3Client = null;
+let presign = null;
+try {
+  const { S3Client, PutObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
+  const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+  if (process.env.STORAGE_S3_ENDPOINT && process.env.STORAGE_S3_KEY && process.env.STORAGE_S3_SECRET) {
+    s3Client = new S3Client({
+      endpoint: process.env.STORAGE_S3_ENDPOINT,
+      region: process.env.STORAGE_S3_REGION || "us-east-1",
+      credentials: { accessKeyId: process.env.STORAGE_S3_KEY, secretAccessKey: process.env.STORAGE_S3_SECRET }
+    });
+    presign = async (cmd) => getSignedUrl(s3Client, cmd, { expiresIn: 3600 });
+  }
+} catch (e) {
+  // aws sdk not installed; mock fallback
+}
+
+async function getSignedUploadUrl(key) {
+  if (presign) {
+    const { PutObjectCommand } = require("@aws-sdk/client-s3");
+    const cmd = new PutObjectCommand({ Bucket: process.env.STORAGE_S3_BUCKET, Key: key });
+    return { url: await presign(cmd), method: "PUT" };
+  }
+  return { url: `https://mock-storage.local/upload/${encodeURIComponent(key)}`, method: "PUT" };
+}
+
+async function getSignedDownloadUrl(key) {
+  if (presign) {
+    const { GetObjectCommand } = require("@aws-sdk/client-s3");
+    const cmd = new GetObjectCommand({ Bucket: process.env.STORAGE_S3_BUCKET, Key: key });
+    return { url: await presign(cmd), method: "GET" };
+  }
+  return { url: `https://mock-storage.local/download/${encodeURIComponent(key)}`, method: "GET" };
+}
+
+module.exports = { getSignedUploadUrl, getSignedDownloadUrl };

--- a/apps/free-opus/lib/storage.js
+++ b/apps/free-opus/lib/storage.js
@@ -1,0 +1,11 @@
+// Minimal storage helpers (S3-compatible). For demo, returns mock signed URLs.
+async function getSignedUploadUrl(key) {
+  // TODO: integrate with S3 SDK and return a real presigned URL
+  return { url: `https://mock-storage.local/upload/${encodeURIComponent(key)}`, method: "PUT" };
+}
+
+async function getSignedDownloadUrl(key) {
+  return { url: `https://mock-storage.local/download/${encodeURIComponent(key)}`, method: "GET" };
+}
+
+module.exports = { getSignedUploadUrl, getSignedDownloadUrl };

--- a/apps/free-opus/next.config.mjs
+++ b/apps/free-opus/next.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  reactStrictMode: true,
+  experimental: {
+    appDir: false
+  }
+};

--- a/apps/free-opus/package.json
+++ b/apps/free-opus/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "free-opus",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "echo \"Run linter here\"",
+    "test": "echo \"Add tests\" && exit 0"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/apps/free-opus/pages/api/auth/login.js
+++ b/apps/free-opus/pages/api/auth/login.js
@@ -1,0 +1,14 @@
+// Simple auth stub: accepts email, returns a mock token. Replace with Clerk/Auth0 integration.
+module.exports = async (req, res) => {
+  try {
+    const { email } = req.body || {};
+    if (!email) return res.status(400).json({ error: "email required" });
+
+    // In production, create user in DB and issue session cookie / JWT
+    const token = `mock-token-${Buffer.from(email).toString("hex")}`;
+    res.status(200).json({ ok: true, token, email });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/auth/me.js
+++ b/apps/free-opus/pages/api/auth/me.js
@@ -1,0 +1,16 @@
+// Simple auth/me stub: returns mocked user from token
+module.exports = async (req, res) => {
+  try {
+    const auth = req.headers.authorization || req.query.token || req.body?.token;
+    if (!auth) return res.status(401).json({ error: "unauthenticated" });
+    // token format: mock-token-<hex-email>
+    const parts = auth.split("-");
+    const hex = parts.slice(2).join("-");
+    let email = "unknown";
+    try { email = Buffer.from(hex, "hex").toString(); } catch (e) {}
+    return res.json({ ok: true, email, tenantId: "mock-tenant-1" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/generate/site.js
+++ b/apps/free-opus/pages/api/generate/site.js
@@ -1,0 +1,18 @@
+// API: /api/generate/site
+const openai = require("../../../../lib/openai");
+
+module.exports = async (req, res) => {
+  try {
+    const { prompt } = req.body || {};
+    if (!prompt) return res.status(400).json({ error: "prompt required" });
+
+    // Use OpenAI wrapper to generate site spec (mocked if no key)
+    const completion = await openai.complete(`Generate a Jamstack Next.js site from this prompt:\n${prompt}`);
+
+    // TODO: create file tree, push to GitHub/Git provider, and return deployment link
+    return res.json({ ok: true, prompt, completion });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/generate/site.js
+++ b/apps/free-opus/pages/api/generate/site.js
@@ -1,13 +1,17 @@
 // API: /api/generate/site
-const openai = require("../../../../lib/openai");
+const providers = require("../../../../lib/providers");
+const rateLimit = require("../../../../lib/rateLimit");
 
 module.exports = async (req, res) => {
   try {
+    const ip = req.headers["x-forwarded-for"] || req.socket.remoteAddress || "unknown";
+    if (!rateLimit.allow(ip)) return res.status(429).json({ error: "rate_limited" });
+
     const { prompt } = req.body || {};
     if (!prompt) return res.status(400).json({ error: "prompt required" });
 
     // Use OpenAI wrapper to generate site spec (mocked if no key)
-    const completion = await openai.complete(`Generate a Jamstack Next.js site from this prompt:\n${prompt}`);
+    const completion = await providers.openai.complete(`Generate a Jamstack Next.js site from this prompt:\n${prompt}`);
 
     // TODO: create file tree, push to GitHub/Git provider, and return deployment link
     return res.json({ ok: true, prompt, completion });

--- a/apps/free-opus/pages/api/generate/video.js
+++ b/apps/free-opus/pages/api/generate/video.js
@@ -1,14 +1,18 @@
 // API: /api/generate/video
-const runway = require("../../../../lib/runway-mock");
+const providers = require("../../../../lib/providers");
 const queue = require("../../../../lib/queue");
+const rateLimit = require("../../../../lib/rateLimit");
 
 module.exports = async (req, res) => {
   try {
+    const ip = req.headers["x-forwarded-for"] || req.socket.remoteAddress || "unknown";
+    if (!rateLimit.allow(ip)) return res.status(429).json({ error: "rate_limited" });
+
     const { prompt } = req.body || {};
     if (!prompt) return res.status(400).json({ error: "prompt required" });
 
     // Create a runway job (mock) and enqueue it for background processing
-    const job = await runway.createJob({ prompt });
+    const job = await providers.runway.createJob({ prompt });
     queue.enqueue(job);
 
     return res.json({ ok: true, jobId: job.id });

--- a/apps/free-opus/pages/api/generate/video.js
+++ b/apps/free-opus/pages/api/generate/video.js
@@ -1,0 +1,19 @@
+// API: /api/generate/video
+const runway = require("../../../../lib/runway-mock");
+const queue = require("../../../../lib/queue");
+
+module.exports = async (req, res) => {
+  try {
+    const { prompt } = req.body || {};
+    if (!prompt) return res.status(400).json({ error: "prompt required" });
+
+    // Create a runway job (mock) and enqueue it for background processing
+    const job = await runway.createJob({ prompt });
+    queue.enqueue(job);
+
+    return res.json({ ok: true, jobId: job.id });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/status.js
+++ b/apps/free-opus/pages/api/status.js
@@ -1,0 +1,19 @@
+// API: /api/status?jobId=...
+const queue = require("../lib/../lib/queue") || require("../../lib/queue");
+const runway = require("../../lib/runway-mock");
+
+module.exports = async (req, res) => {
+  try {
+    const jobId = req.query.jobId || req.body?.jobId;
+    if (!jobId) return res.status(400).json({ error: "jobId required" });
+
+    // Check in-memory queue status and runway
+    const qStatus = queue.getStatus(jobId) || null;
+    const rStatus = await runway.getStatus(jobId).catch(() => null);
+
+    return res.json({ ok: true, jobId, queue: qStatus, runway: rStatus });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/status.js
+++ b/apps/free-opus/pages/api/status.js
@@ -1,5 +1,5 @@
 // API: /api/status?jobId=...
-const queue = require("../lib/../lib/queue") || require("../../lib/queue");
+const queue = require("../../lib/queue");
 const runway = require("../../lib/runway-mock");
 
 module.exports = async (req, res) => {

--- a/apps/free-opus/pages/api/storage/download-url.js
+++ b/apps/free-opus/pages/api/storage/download-url.js
@@ -1,0 +1,14 @@
+// POST /api/storage/download-url { key }
+const s3 = require("../../../../lib/storage-s3");
+
+module.exports = async (req, res) => {
+  try {
+    const { key } = req.body || {};
+    if (!key) return res.status(400).json({ error: "key required" });
+    const presign = await s3.getSignedDownloadUrl(key);
+    return res.json({ ok: true, presign });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/storage/upload-url.js
+++ b/apps/free-opus/pages/api/storage/upload-url.js
@@ -1,0 +1,14 @@
+// POST /api/storage/upload-url { key }
+const s3 = require("../../../../lib/storage-s3");
+
+module.exports = async (req, res) => {
+  try {
+    const { key } = req.body || {};
+    if (!key) return res.status(400).json({ error: "key required" });
+    const presign = await s3.getSignedUploadUrl(key);
+    return res.json({ ok: true, presign });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/stripe/create-customer.js
+++ b/apps/free-opus/pages/api/stripe/create-customer.js
@@ -1,0 +1,16 @@
+// Stripe customer creation stub. If STRIPE_SECRET_KEY is set, integrate with stripe SDK.
+module.exports = async (req, res) => {
+  try {
+    const { email } = req.body || {};
+    if (!email) return res.status(400).json({ error: "email required" });
+    if (process.env.STRIPE_SECRET_KEY) {
+      // TODO: integrate with stripe-node
+      return res.json({ ok: true, id: "stripe-customer-id-placeholder" });
+    }
+    // Mock response
+    return res.json({ ok: true, id: `mock-customer-${Buffer.from(email).toString("hex")}` });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/api/stripe/create-subscription.js
+++ b/apps/free-opus/pages/api/stripe/create-subscription.js
@@ -1,0 +1,15 @@
+// Stripe subscription stub
+module.exports = async (req, res) => {
+  try {
+    const { customerId, priceId } = req.body || {};
+    if (!customerId || !priceId) return res.status(400).json({ error: "customerId and priceId required" });
+    if (process.env.STRIPE_SECRET_KEY) {
+      // TODO: integrate with Stripe
+      return res.json({ ok: true, subscriptionId: "stripe-sub-placeholder" });
+    }
+    return res.json({ ok: true, subscriptionId: `mock-sub-${customerId}-${priceId}` });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/apps/free-opus/pages/dashboard.js
+++ b/apps/free-opus/pages/dashboard.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function Dashboard() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Projects Dashboard</h1>
+      <p>List of user projects will appear here (multi-tenant).</p>
+      <ul>
+        <li>TODO: Integrate with auth (Clerk/Auth0)</li>
+        <li>TODO: Projects listing, status, previews</li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/free-opus/pages/deploy.js
+++ b/apps/free-opus/pages/deploy.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+export default function Deploy() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Deploy to Vercel</h1>
+      <p>
+        This page will offer a Vercel "Deploy" button and instructions. For demo
+        purposes, a guide is shown below.
+      </p>
+      <h3>Steps</h3>
+      <ol>
+        <li>Create a GitHub repo and push this project</li>
+        <li>Connect the repo in Vercel</li>
+        <li>Set required ENV variables (see README)</li>
+      </ol>
+      <p>TODO: Add Vercel button wiring (uses Vercel Git integration)</p>
+    </div>
+  );
+}

--- a/apps/free-opus/pages/index.js
+++ b/apps/free-opus/pages/index.js
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+
+export default function Home() {
+  const [prompt, setPrompt] = useState("");
+  const [status, setStatus] = useState(null);
+
+  async function generateSite(e) {
+    e.preventDefault();
+    setStatus("Submitting site job...");
+    const res = await fetch("/api/generate/site", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt })
+    });
+    const json = await res.json();
+    setStatus(JSON.stringify(json));
+  }
+
+  async function generateVideo(e) {
+    e.preventDefault();
+    setStatus("Submitting video job...");
+    const res = await fetch("/api/generate/video", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt })
+    });
+    const json = await res.json();
+    setStatus(JSON.stringify(json));
+  }
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Free Opus — Prompt-driven Jamstack & Video MVP</h1>
+      <form>
+        <label>Prompt</label>
+        <br />
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={6}
+          cols={80}
+          placeholder="Describe the site or the video you want"
+        />
+        <br />
+        <button onClick={generateSite} style={{ marginRight: 8 }}>
+          Generate Site
+        </button>
+        <button onClick={generateVideo}>Generate Video</button>
+      </form>
+      <section style={{ marginTop: 20 }}>
+        <h3>Response</h3>
+        <pre>{status ? status : "No activity yet."}</pre>
+      </section>
+      <hr />
+      <p>
+        Go to <a href="/dashboard">/dashboard</a> or <a href="/deploy">/deploy</a>
+      </p>
+    </div>
+  );
+}

--- a/apps/free-opus/tests/api.placeholder.test.js
+++ b/apps/free-opus/tests/api.placeholder.test.js
@@ -1,0 +1,4 @@
+// Placeholder tests. Replace with real unit/integration tests.
+test('placeholder', () => {
+  expect(true).toBe(true);
+});

--- a/apps/free-opus/tests/unit/runway.test.js
+++ b/apps/free-opus/tests/unit/runway.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+const runway = require('../../lib/runway-mock');
+
+test('runway mock create/get/set status', async (t) => {
+  const job = await runway.createJob({ prompt: 'hello' });
+  assert(job && job.id, 'job created');
+  const status1 = await runway.getStatus(job.id);
+  assert.equal(status1.status, 'queued');
+  await runway.setStatus(job.id, 'rendering');
+  const status2 = await runway.getStatus(job.id);
+  assert.equal(status2.status, 'rendering');
+});

--- a/apps/free-opus/vercel.json
+++ b/apps/free-opus/vercel.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@vercel/next" }
+  ],
+  "env": {
+    "OPENAI_API_KEY": "@openai_api_key",
+    "RUNWAY_API_KEY": "@runway_api_key",
+    "STORAGE_S3_ENDPOINT": "@storage_s3_endpoint",
+    "STORAGE_S3_KEY": "@storage_s3_key",
+    "STORAGE_S3_SECRET": "@storage_s3_secret",
+    "STRIPE_SECRET_KEY": "@stripe_secret_key"
+  }
+}

--- a/apps/free-opus/workers/worker.js
+++ b/apps/free-opus/workers/worker.js
@@ -1,0 +1,35 @@
+// Simple worker script for demo: poll the in-memory queue and "render" jobs.
+const queue = require("../lib/queue");
+const runway = require("../lib/runway-mock");
+
+async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function run() {
+  console.log("Worker started (demo in-memory). Polling queue...");
+  while (true) {
+    const item = queue.dequeue();
+    if (!item) {
+      await sleep(2000);
+      continue;
+    }
+
+    console.log(`Processing job ${item.id}`);
+    try {
+      // Simulate render time and progress updates
+      await sleep(3000);
+      // Mark runway mock as rendering
+      await runway.setStatus(item.id, "rendering");
+      await sleep(3000);
+      // On success write a fake result URL
+      queue.complete(item.id, { url: `https://mock-storage.local/video/${item.id}.mp4` });
+      console.log(`Job ${item.id} complete`);
+    } catch (err) {
+      console.error(`Job ${item.id} failed`, err);
+      queue.fail(item.id, err);
+    }
+  }
+}
+
+if (require.main === module) run().catch(err => { console.error(err); process.exit(1); });
+
+module.exports = { run };

--- a/apps/free-opus/workers/worker.js
+++ b/apps/free-opus/workers/worker.js
@@ -5,27 +5,55 @@ const runway = require("../lib/runway-mock");
 async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 async function run() {
-  console.log("Worker started (demo in-memory). Polling queue...");
+  console.log("Worker started (demo). Polling queue with retry/backoff...");
+  const MAX_ATTEMPTS = Number(process.env.WORKER_MAX_ATTEMPTS || 3);
+  const BASE_DELAY_MS = Number(process.env.WORKER_BASE_DELAY_MS || 2000);
+
   while (true) {
-    const item = queue.dequeue();
+    const item = await queue.dequeue();
     if (!item) {
-      await sleep(2000);
+      await sleep(1000);
       continue;
     }
 
-    console.log(`Processing job ${item.id}`);
+    const jobId = item.id || item.job?.id;
+    console.log(`Processing job ${jobId}`);
     try {
-      // Simulate render time and progress updates
+      // Update runway status to rendering
+      await runway.setStatus(jobId, "rendering");
+
+      // Simulate render work (could call providers.runway here)
       await sleep(3000);
-      // Mark runway mock as rendering
-      await runway.setStatus(item.id, "rendering");
-      await sleep(3000);
+
+      // Simulate possible transient failure
+      if (Math.random() < 0.1) throw new Error("transient_render_error");
+
       // On success write a fake result URL
-      queue.complete(item.id, { url: `https://mock-storage.local/video/${item.id}.mp4` });
-      console.log(`Job ${item.id} complete`);
+      const result = { url: `https://mock-storage.local/video/${jobId}.mp4` };
+      await queue.complete(jobId, result);
+      console.log(`Job ${jobId} complete`);
     } catch (err) {
-      console.error(`Job ${item.id} failed`, err);
-      queue.fail(item.id, err);
+      console.error(`Job ${jobId} failed`, err.message || err);
+      // Attempt retry/backoff if attempts available
+      try {
+        const status = await queue.getStatus(jobId) || {};
+        const attempts = Number(status.attempts || 0) + 1;
+        await queue.fail(jobId, err);
+        if (attempts < MAX_ATTEMPTS) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attempts - 1);
+          console.log(`Re-enqueueing job ${jobId} for retry #${attempts} after ${delay}ms`);
+          // simple delay using setTimeout then re-enqueue (for in-memory); for Redis we'd use delayed queue or scheduler
+          setTimeout(async () => {
+            try {
+              await queue.enqueue({ id: jobId, prompt: item.job?.prompt || item.prompt });
+              const meta = await queue.getStatus(jobId);
+              if (meta) meta.attempts = attempts;
+            } catch (e) { console.error('re-enqueue failed', e); }
+          }, delay);
+        } else {
+          console.log(`Job ${jobId} reached max attempts (${MAX_ATTEMPTS}) and is marked failed.`);
+        }
+      } catch (e) { console.error('retry handling failed', e); }
     }
   }
 }


### PR DESCRIPTION
Why

This PR scaffolds the Free Opus MVP: a prompt-driven Jamstack site generator and AI-animated video pipeline so the team can demo end-to-end flows and iterate on provider wiring and deployment.

What it does (approach)

- Adds a minimal Next.js app (apps/free-opus) with pages: /, /dashboard, /deploy.
- Implements serverless orchestration endpoints: POST /api/generate/site, POST /api/generate/video, GET /api/status, plus auth and Stripe stubs and storage presign endpoints.
- Introduces a provider abstraction layer (OpenAI wrapper, Runway mock, ElevenLabs mock) so real SDKs can be swapped in later.
- Adds a queue wrapper with Redis-backed implementation (when REDIS_URL is set) and an in-memory fallback for local demos.
- Adds a background worker (workers/worker.js) that polls the queue and uses retry/backoff for transient failures.
- Adds an optional S3 presign adapter (AWS SDK v3) and mock fallback for local dev.
- Adds a basic in-memory rate limiter and a CI workflow + vercel.json.

Non-obvious decisions & trade-offs

- Mocks used by default when provider keys are absent so the UI/demo works without secrets. Replace mocks with SDKs when ready.
- In-memory queue and rate limiter are intentionally simple for the MVP; recommend Redis and Redis-based rate limiter for production.
- Worker implements basic retry/backoff; for production use a durable scheduler (Redis delayed queue or cloud jobs).
- No DB yet: job metadata and multi-tenant data are currently ephemeral. Next step is to add a tenant-scoped DB and persist job records.

Files & tests

- Key locations: apps/free-opus/{pages,lib,workers,tests}
- Added unit test: tests/unit/runway.test.js (node:test)
- Changed files count: 29 (scaffold, libs, APIs, worker, README, CI)

Env vars (must set in Vercel / environment)

OPENAI_API_KEY
RUNWAY_API_KEY
STORAGE_S3_ENDPOINT, STORAGE_S3_KEY, STORAGE_S3_SECRET, STORAGE_S3_BUCKET, STORAGE_S3_REGION
STRIPE_SECRET_KEY
AUTH_PROVIDER
REDIS_URL (optional — enable Redis queue)
REDIS_QUEUE_KEY (optional)

How to run locally

cd apps/free-opus
npm install
npm run dev
In another shell: node workers/worker.js
Run unit test: node --test tests/unit/runway.test.js

What remains / next steps

- Install ioredis and AWS SDK packages when enabling Redis/S3.
- Wire Clerk/Auth0, Stripe webhooks and a tenant DB (Postgres/SQLite) for persistence.
- Replace mocks with provider SDKs and secure credentials in Vercel.
- Add integration tests, coverage gate, and production rate-limiter.

Notes about pushing

All changes are committed locally on branch `tatianadug-feat-free-opus-mvp`. Attempts to push to the upstream remote returned a 403 (permission denied). Patch files for all commits were exported to the session artifacts folder for manual application if required. If you prefer, grant push access for this repo or provide a fork remote and I will push and then update the PR.

Files changed (high-level)

- apps/free-opus/pages: index.js, dashboard.js, deploy.js, api/* (generate, auth, stripe, storage, status)
- apps/free-opus/lib: openai.js, runway-mock.js, elevenlabs-mock.js, providers.js, queue.js, queue-redis.js, storage-s3.js, storage.js, rateLimit.js
- apps/free-opus/workers/worker.js
- apps/free-opus/.github/workflows/ci.yml, vercel.json, README.md

Request for review

Focus review on: provider abstraction surface, queue fallback behavior, API shapes, and README environment list. Comments and test failures are expected as dependencies (node, ioredis, aws sdk) may not be installed in CI yet.