### PR TITLE
chore: ignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,8 @@ app.log
 deploy.sh
 docker-compose.minimal.yml
 
+# Docker Compose override (local-only, never commit)
+docker-compose.override.yml
 
 # Backup directories
 app.__qa_backup/


### PR DESCRIPTION
## Summary

Adds `docker-compose.override.yml` to `.gitignore` to prevent local override files (which are environment-specific and often contain personal paths, volumes, or env vars) from being accidentally committed to the repository.

This is a best practice for projects using Docker Compose, as each developer may have their own local overrides that should not be shared.

## Related Issues

- Closes # (not applicable – this is a trivial improvement)
- Related to # (none)

## Validation

- [x] Change type: other (chore: .gitignore update)
- [x] Focused tests and category gates from the golden path: N/A (no production code changes)
- [x] `npm run lint`: N/A (no code changes)
- [x] Reconciled with the current active release base: yes, based on `release/v3.8.50`
- [x] Production-code changes include a new or updated automated test in this PR: N/A
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below: N/A

## Tests Added Or Updated

No tests were added or modified, as this change does not affect production code.

## Coverage Notes

This PR does not touch `src/`, `open-sse/`, `electron/`, or `bin/`. Code coverage is unaffected.

## Reviewer Notes

This is a simple, low-risk change. Please verify that the added line in `.gitignore` is placed correctly and does not conflict with any existing rules.