### PR TITLE
[TS7] fix(types): stabilize skill token extraction

### DIFF
--- a/src/lib/skills/injection.ts
+++ b/src/lib/skills/injection.ts
@@ -73,7 +73,7 @@ function toLowerText(value: unknown): string {
 }
 
 function extractTokens(value: string): Set<string> {
-  const matches = value.toLowerCase().match(/[a-z0-9]+/g) || [];
+  const matches: string[] = value.toLowerCase().match(/[a-z0-9]+/g) ?? [];
   return new Set(matches.filter((t) => t.length >= TOKEN_MIN_LEN));
 }
 

--- a/tests/unit/skills-injection.test.ts
+++ b/tests/unit/skills-injection.test.ts
@@ -186,6 +186,32 @@ test("injectSkills auto mode matches message/context semantics and applies score
   });
 });
 
+test("injectSkills auto mode only scores name tokens with at least three characters", async () => {
+  for (const name of ["aiSearch", "apiSearch"]) {
+    await skillRegistry.register({
+      name,
+      version: "1.0.0",
+      description: "find",
+      schema: { input: {}, output: {} },
+      handler: `${name}-handler`,
+      enabled: true,
+      mode: "auto",
+      apiKeyId: "key-token-length",
+    });
+  }
+
+  const tools = injectSkills({
+    provider: "other",
+    apiKeyId: "key-token-length",
+    messages: [{ role: "user", content: "ai api find" }],
+  });
+
+  assert.deepEqual(
+    tools.map((tool) => (tool as { function: { name: string } }).function.name),
+    ["apiSearch@1.0.0"]
+  );
+});
+
 test("injectSkills auto mode prefers provider-matching tagged skills", async () => {
   await skillRegistry.register({
     name: "openaiDocTool",


### PR DESCRIPTION
## Summary

- give regular-expression token matches an explicit string-array contract
- preserve the existing three-character minimum for automatic skill matching
- add a regression test covering two- versus three-character name tokens

Tracked by #8484.

## Validation

- node --import tsx/esm --test tests/unit/skills-injection.test.ts (7/7)
- npm run typecheck:core
- npm run lint
- npm run test:vitest (344/344)
- TypeScript 6 open-sse diagnostics: 62 -> 61, one removed, zero added
- TypeScript 7.0.2 open-sse diagnostics: 61 -> 61, zero added
- Combined with the nine existing TS7 PRs: TS6 52 -> 51; TS7 51 -> 51; zero added
- npm run check:file-size reports the same two unrelated frozen-file failures as the clean base