### PR TITLE
feat(usage): add Command Code quota tracking

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -68,6 +68,7 @@ import { getXaiUsage } from "./usage/xai.ts";
 import { getXaiOauthUsage } from "./usage/xaiOauth.ts";
 import { getGrokCliUsage } from "./usage/grokCli.ts";
 import { getFirecrawlUsage } from "./usage/firecrawl.ts";
+import { getCommandCodeUsage } from "./usage/command-code.ts";
 
 type JsonRecord = Record<string, unknown>;
 type UsageProviderConnection = JsonRecord & {
@@ -130,6 +131,8 @@ export const USAGE_FETCHER_PROVIDERS = [
   "ha",
   // Firecrawl team credits (GET /v2/team/credit-usage)
   "firecrawl",
+  // Command Code credits + 5h/weekly windows (GET /alpha/billing/credits)
+  "command-code",
 ] as const;
 
 export type UsageFetcherProvider = (typeof USAGE_FETCHER_PROVIDERS)[number];
@@ -229,6 +232,8 @@ export async function getUsageForProvider(
       return await getHyperAgentUsage(apiKey || accessToken, providerSpecificData);
     case "firecrawl":
       return await getFirecrawlUsage(id || "", apiKey, connection);
+    case "command-code":
+      return await getCommandCodeUsage(apiKey || accessToken || "");
     default:
       return { message: `Usage API not implemented for ${provider}` };
   }
@@ -259,6 +264,7 @@ export const __testing = {
   getXaiUsage,
   getXaiOauthUsage,
   getFirecrawlUsage,
+  getCommandCodeUsage,
   getVertexUsage,
   getMiniMaxAuthErrorMessage,
   getMiniMaxErrorSummary,

--- a/open-sse/services/usage/command-code.ts
+++ b/open-sse/services/usage/command-code.ts
@@ -1,0 +1,233 @@
+/**
+ * usage/command-code.ts — Command Code (commandcode.ai) usage fetcher.
+ *
+ * Bearer `/alpha` endpoints (same surface the CLI `/usage` view uses):
+ *   GET /alpha/whoami
+ *   GET /alpha/billing/credits        → remaining pools + windowLimits
+ *   GET /alpha/billing/subscriptions  → planId + billing period (soft)
+ *   GET /alpha/usage/summary          → period spend (soft)
+ *
+ * Surfaces five_hour / weekly rolling USD windows plus a credits pool quota
+ * for Provider Limits and genericQuotaFetcher preflight.
+ */
+
+import { sanitizeErrorMessage } from "../../utils/error.ts";
+import { toNumber, toRecord } from "./scalars.ts";
+import { createQuotaFromUsage, parseResetTime, type UsageQuota } from "./quota.ts";
+
+const COMMAND_CODE_API_BASE =
+  process.env.COMMANDCODE_API_URL?.trim() || "https://api.commandcode.ai";
+const FETCH_TIMEOUT_MS = 10_000;
+
+type JsonRecord = Record<string, unknown>;
+
+const PLAN_LABELS: Record<string, string> = {
+  "individual-goat": "Command Code · GOAT",
+  "individual-go": "Command Code · Go",
+  "individual-pro": "Command Code · Pro",
+  "individual-max-10x": "Command Code · Max 10×",
+  "individual-max-20x": "Command Code · Max 20×",
+  "team-pro": "Command Code · Team Pro",
+};
+
+function withCurrency(quota: UsageQuota, displayName: string): UsageQuota {
+  return {
+    ...quota,
+    currency: "USD",
+    displayName,
+  };
+}
+
+function humanizePlanId(planId: string | undefined): string {
+  if (!planId) return "Command Code";
+  const mapped = PLAN_LABELS[planId];
+  if (mapped) return mapped;
+  const title = planId
+    .replace(/^individual-/, "")
+    .replace(/^team-/, "Team ")
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+  return `Command Code · ${title || planId}`;
+}
+
+function orgQuery(orgId: string | null | undefined): string {
+  if (!orgId) return "";
+  return `?orgId=${encodeURIComponent(orgId)}`;
+}
+
+async function fetchJson(
+  path: string,
+  apiKey: string
+): Promise<{ ok: boolean; status: number; body: JsonRecord | null }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${COMMAND_CODE_API_BASE}${path}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let body: JsonRecord | null = null;
+    if (text) {
+      try {
+        body = toRecord(JSON.parse(text));
+      } catch {
+        body = null;
+      }
+    }
+    return { ok: response.ok, status: response.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function creditRemaining(credits: JsonRecord): number {
+  return (
+    Math.max(0, toNumber(credits.monthlyCredits, 0)) +
+    Math.max(0, toNumber(credits.purchasedCredits, 0)) +
+    Math.max(0, toNumber(credits.freeCredits, 0))
+  );
+}
+
+function windowQuota(window: unknown, displayName: string): UsageQuota | null {
+  const w = toRecord(window);
+  const cap = toNumber(w.cap, 0);
+  if (!(cap > 0)) return null;
+  const used = toNumber(w.used, 0);
+  return withCurrency(createQuotaFromUsage(used, cap, w.resetAt), displayName);
+}
+
+/**
+ * Command Code Usage — monthly credit pool + 5h/weekly rolling windows.
+ */
+export async function getCommandCodeUsage(apiKey: string) {
+  if (!apiKey) {
+    return { message: "Command Code API key not available. Add a key to view usage." };
+  }
+
+  try {
+    let orgId: string | null = null;
+    try {
+      const whoami = await fetchJson("/alpha/whoami", apiKey);
+      if (whoami.status === 401 || whoami.status === 403) {
+        return {
+          message:
+            "Command Code connected. The API key was rejected — reconnect or rotate the key.",
+        };
+      }
+      if (whoami.ok && whoami.body) {
+        const org = toRecord(whoami.body.org);
+        const id = typeof org.id === "string" && org.id.trim() ? org.id.trim() : null;
+        orgId = id;
+      }
+    } catch {
+      // whoami is optional — continue without orgId
+    }
+
+    const q = orgQuery(orgId);
+    const creditsRes = await fetchJson(`/alpha/billing/credits${q}`, apiKey);
+
+    if (creditsRes.status === 401 || creditsRes.status === 403) {
+      return {
+        message: "Command Code connected. The API key was rejected — reconnect or rotate the key.",
+      };
+    }
+    if (!creditsRes.ok || !creditsRes.body) {
+      return {
+        message: `Command Code connected. /alpha/billing/credits returned HTTP ${creditsRes.status}.`,
+      };
+    }
+
+    const creditsObj = toRecord(creditsRes.body.credits);
+    const windowLimits = toRecord(creditsRes.body.windowLimits);
+    const remaining = creditRemaining(creditsObj);
+
+    let planId: string | undefined;
+    let periodStart: string | undefined;
+    let periodEnd: string | null = null;
+
+    try {
+      const subRes = await fetchJson(`/alpha/billing/subscriptions${q}`, apiKey);
+      if (subRes.ok && subRes.body) {
+        const data = toRecord(subRes.body.data);
+        if (typeof data.planId === "string" && data.planId.trim()) {
+          planId = data.planId.trim();
+        }
+        if (typeof data.currentPeriodStart === "string") {
+          periodStart = data.currentPeriodStart;
+        }
+        periodEnd = parseResetTime(data.currentPeriodEnd);
+      }
+    } catch {
+      // subscription enrichment is soft-fail
+    }
+
+    let periodUsed = 0;
+    try {
+      const sinceQ =
+        periodStart != null ? `${q ? `${q}&` : "?"}since=${encodeURIComponent(periodStart)}` : q;
+      const summaryRes = await fetchJson(`/alpha/usage/summary${sinceQ}`, apiKey);
+      if (summaryRes.ok && summaryRes.body) {
+        const cost = toNumber(summaryRes.body.totalCost, Number.NaN);
+        if (Number.isFinite(cost) && cost >= 0) {
+          periodUsed = cost;
+        } else {
+          const monthly = toNumber(summaryRes.body.totalMonthlyCredits, Number.NaN);
+          if (Number.isFinite(monthly) && monthly >= 0) periodUsed = monthly;
+        }
+      }
+    } catch {
+      // summary enrichment is soft-fail
+    }
+
+    const quotas: Record<string, UsageQuota> = {};
+
+    const fiveHour = windowQuota(windowLimits.fiveHour, "5-hour window");
+    if (fiveHour) quotas.five_hour = fiveHour;
+
+    const weekly = windowQuota(windowLimits.weekly, "Weekly window");
+    if (weekly) quotas.weekly = weekly;
+
+    const creditsTotal = periodUsed + remaining;
+    const creditsRemainingPct =
+      creditsTotal > 0
+        ? Math.round((remaining / creditsTotal) * 1000) / 10
+        : remaining > 0
+          ? 100
+          : 0;
+    quotas.credits = {
+      used: Math.max(0, periodUsed),
+      total: Math.max(0, creditsTotal),
+      remaining,
+      remainingPercentage: creditsRemainingPct,
+      resetAt: periodEnd,
+      unlimited: false,
+      currency: "USD",
+      displayName: "Credits",
+      grantedBalance: Math.max(0, toNumber(creditsObj.monthlyCredits, 0)),
+      toppedUpBalance:
+        Math.max(0, toNumber(creditsObj.purchasedCredits, 0)) +
+        Math.max(0, toNumber(creditsObj.freeCredits, 0)),
+    };
+
+    return {
+      plan: humanizePlanId(planId),
+      quotas,
+      windowExceeded: typeof windowLimits.exceeded === "string" ? windowLimits.exceeded : null,
+      limited: windowLimits.limited === true,
+    };
+  } catch (error) {
+    return {
+      message: `Command Code usage error: ${sanitizeErrorMessage(
+        error instanceof Error ? error.message : String(error)
+      )}`,
+    };
+  }
+}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/providerColumns.ts
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/providerColumns.ts
@@ -29,6 +29,7 @@ const PROVIDER_COLUMNS: Record<string, string[]> = {
   minimax: ["session"],
   "minimax-cn": ["session"],
   "kimi-coding": ["session", "weekly"],
+  "command-code": ["five_hour", "weekly", "credits"],
 };
 
 /** Hard cap for the dynamic schema (Antigravity and fallback providers). */

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -89,6 +89,8 @@ const PROVIDER_LIMITS_APIKEY_PROVIDERS = new Set([
   "hyperagent",
   "ha",
   "firecrawl",
+  // Command Code API key → /alpha/billing/credits + windowLimits
+  "command-code",
 ]);
 const DEFAULT_PROVIDER_LIMITS_SYNC_INTERVAL_MINUTES = 70;
 const PROVIDER_LIMITS_AUTO_SYNC_SETTING_KEY = "provider_limits_auto_sync_last_run";

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -463,6 +463,8 @@ export const USAGE_SUPPORTED_PROVIDERS = [
   "grok-cli",
   // Firecrawl team credits (GET /v2/team/credit-usage)
   "firecrawl",
+  // Command Code credits + 5h/weekly rolling windows
+  "command-code",
 ];
 
 // ── Zod validation at module load (Phase 7.2) ──

--- a/tests/unit/command-code-usage.test.ts
+++ b/tests/unit/command-code-usage.test.ts
@@ -1,0 +1,260 @@
+/**
+ * tests/unit/command-code-usage.test.ts
+ *
+ * Command Code usage.ts dispatch + Provider Limits allowlists for
+ * monthly credits + 5h/weekly rolling windows (Bearer /alpha APIs).
+ */
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+const { __testing, USAGE_FETCHER_PROVIDERS, getUsageForProvider } =
+  await import("../../open-sse/services/usage.ts");
+const { USAGE_SUPPORTED_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+const { isSupportedUsageConnection } = await import("../../src/lib/usage/providerLimits.ts");
+const { convertUsageToQuotaInfo } = await import("../../open-sse/services/genericQuotaFetcher.ts");
+const { getCommandCodeUsage } = __testing;
+
+const originalFetch = globalThis.fetch;
+
+type QuotaShape = {
+  used: number;
+  total: number;
+  remaining?: number;
+  remainingPercentage?: number;
+  resetAt: string | null;
+  currency?: string;
+  displayName?: string;
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const CREDITS_PAYLOAD = {
+  credits: {
+    belowThreshold: false,
+    creditThreshold: 0,
+    monthlyCredits: 34.9522404823,
+    purchasedCredits: 0.0446690956,
+    freeCredits: 0,
+  },
+  windowLimits: {
+    limited: true,
+    exceeded: "weekly",
+    fiveHour: {
+      used: 0,
+      cap: 14,
+      exceeded: false,
+      resetAt: 0,
+    },
+    weekly: {
+      used: 35.0477595177,
+      cap: 35,
+      exceeded: true,
+      resetAt: 1786575240518,
+    },
+  },
+};
+
+const WHOAMI_PERSONAL = {
+  success: true,
+  user: { id: "u1", name: "dev", email: "dev@example.com", userName: "dev" },
+  org: null,
+};
+
+const SUBSCRIPTION_GOAT = {
+  success: true,
+  data: {
+    id: "sub_1",
+    status: "active",
+    orgId: null,
+    currentPeriodStart: "2026-08-05T22:27:41.000Z",
+    currentPeriodEnd: "2026-09-05T22:27:41.000Z",
+    planId: "individual-goat",
+  },
+};
+
+const USAGE_SUMMARY = {
+  totalCount: 1260,
+  totalCost: 55.0030904221,
+  totalMonthlyCredits: 35.0477595177,
+  totalPurchasedCredits: 19.9553309044,
+  periodBasis: "billing-period",
+};
+
+function installMockFetch(handlers: Record<string, () => Response>) {
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [needle, handler] of Object.entries(handlers)) {
+      if (url.includes(needle)) return handler();
+    }
+    return jsonResponse({ error: `unhandled fetch: ${url}` }, 500);
+  };
+}
+
+describe("Command Code usage dispatch", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("registers command-code in USAGE_FETCHER_PROVIDERS and USAGE_SUPPORTED_PROVIDERS", () => {
+    assert.ok((USAGE_FETCHER_PROVIDERS as readonly string[]).includes("command-code"));
+    assert.ok((USAGE_SUPPORTED_PROVIDERS as readonly string[]).includes("command-code"));
+  });
+
+  it("isSupportedUsageConnection accepts command-code apikey connections", () => {
+    assert.equal(
+      isSupportedUsageConnection({
+        id: "c1",
+        provider: "command-code",
+        authType: "apikey",
+      }),
+      true
+    );
+  });
+
+  it("getCommandCodeUsage maps credits + windows + period spend", async () => {
+    installMockFetch({
+      "/alpha/whoami": () => jsonResponse(WHOAMI_PERSONAL),
+      "/alpha/billing/credits": () => jsonResponse(CREDITS_PAYLOAD),
+      "/alpha/billing/subscriptions": () => jsonResponse(SUBSCRIPTION_GOAT),
+      "/alpha/usage/summary": () => jsonResponse(USAGE_SUMMARY),
+    });
+
+    const r = (await getCommandCodeUsage("cc-key")) as {
+      plan?: string;
+      message?: string;
+      quotas?: {
+        five_hour?: QuotaShape;
+        weekly?: QuotaShape;
+        credits?: QuotaShape;
+      };
+    };
+
+    assert.ok(r.quotas?.five_hour, `expected five_hour, got: ${JSON.stringify(r)}`);
+    assert.ok(r.quotas?.weekly, `expected weekly, got: ${JSON.stringify(r)}`);
+    assert.ok(r.quotas?.credits, `expected credits, got: ${JSON.stringify(r)}`);
+    assert.match(r.plan || "", /GOAT/i);
+
+    assert.equal(r.quotas!.five_hour!.used, 0);
+    assert.equal(r.quotas!.five_hour!.total, 14);
+    assert.equal(r.quotas!.five_hour!.resetAt, null);
+    assert.equal(r.quotas!.five_hour!.currency, "USD");
+
+    // used clamped to total when upstream reports slight overshoot
+    assert.equal(r.quotas!.weekly!.used, 35);
+    assert.equal(r.quotas!.weekly!.total, 35);
+    assert.equal(r.quotas!.weekly!.remaining, 0);
+    assert.equal(r.quotas!.weekly!.remainingPercentage, 0);
+    assert.ok(r.quotas!.weekly!.resetAt?.startsWith("2026-"));
+
+    const remainingCredits = 34.9522404823 + 0.0446690956;
+    assert.ok(Math.abs((r.quotas!.credits!.remaining ?? 0) - remainingCredits) < 1e-9);
+    assert.equal(r.quotas!.credits!.used, USAGE_SUMMARY.totalCost);
+    assert.ok(
+      Math.abs(r.quotas!.credits!.total - (USAGE_SUMMARY.totalCost + remainingCredits)) < 1e-9
+    );
+    assert.equal(r.quotas!.credits!.resetAt, "2026-09-05T22:27:41.000Z");
+    assert.equal(r.quotas!.credits!.currency, "USD");
+  });
+
+  it("getCommandCodeUsage works for org:null without orgId query params", async () => {
+    const seen: string[] = [];
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.includes("/alpha/whoami")) return jsonResponse(WHOAMI_PERSONAL);
+      if (url.includes("/alpha/billing/credits")) return jsonResponse(CREDITS_PAYLOAD);
+      if (url.includes("/alpha/billing/subscriptions")) return jsonResponse(SUBSCRIPTION_GOAT);
+      if (url.includes("/alpha/usage/summary")) return jsonResponse(USAGE_SUMMARY);
+      return jsonResponse({ error: "unhandled" }, 500);
+    };
+
+    await getCommandCodeUsage("cc-key");
+    assert.ok(seen.some((u) => u.includes("/alpha/billing/credits")));
+    assert.ok(!seen.some((u) => /[?&]orgId=/.test(u)));
+  });
+
+  it("getCommandCodeUsage returns message when apiKey missing", async () => {
+    const r = (await getCommandCodeUsage("")) as { message?: string; quotas?: unknown };
+    assert.ok(r.message && !r.quotas);
+  });
+
+  it("getCommandCodeUsage returns message-only on 401", async () => {
+    installMockFetch({
+      "/alpha/whoami": () => jsonResponse({ success: false }, 401),
+      "/alpha/billing/credits": () =>
+        jsonResponse(
+          {
+            success: false,
+            error: { code: "UNAUTHORIZED", status: 401, message: "Invalid token" },
+          },
+          401
+        ),
+    });
+
+    const r = (await getCommandCodeUsage("bad-key")) as { message?: string; quotas?: unknown };
+    assert.ok(r.message && !r.quotas);
+  });
+
+  it("getCommandCodeUsage soft-fails when subscription/summary unavailable", async () => {
+    installMockFetch({
+      "/alpha/whoami": () => jsonResponse(WHOAMI_PERSONAL),
+      "/alpha/billing/credits": () => jsonResponse(CREDITS_PAYLOAD),
+      "/alpha/billing/subscriptions": () => jsonResponse({ success: false }, 500),
+      "/alpha/usage/summary": () => jsonResponse({ error: "boom" }, 500),
+    });
+
+    const r = (await getCommandCodeUsage("cc-key")) as {
+      plan?: string;
+      quotas?: { five_hour?: QuotaShape; weekly?: QuotaShape; credits?: QuotaShape };
+    };
+
+    assert.ok(r.quotas?.five_hour);
+    assert.ok(r.quotas?.weekly);
+    assert.ok(r.quotas?.credits);
+    // Without summary spend, used defaults to 0; remaining still from credit pools
+    assert.equal(r.quotas!.credits!.used, 0);
+    assert.ok((r.quotas!.credits!.remaining ?? 0) > 0);
+  });
+
+  it("getUsageForProvider('command-code', ...) delegates to getCommandCodeUsage", async () => {
+    installMockFetch({
+      "/alpha/whoami": () => jsonResponse(WHOAMI_PERSONAL),
+      "/alpha/billing/credits": () => jsonResponse(CREDITS_PAYLOAD),
+      "/alpha/billing/subscriptions": () => jsonResponse(SUBSCRIPTION_GOAT),
+      "/alpha/usage/summary": () => jsonResponse(USAGE_SUMMARY),
+    });
+
+    const r = (await getUsageForProvider({
+      id: "conn-cc",
+      provider: "command-code",
+      apiKey: "dispatch-key",
+    } as Parameters<typeof getUsageForProvider>[0])) as {
+      quotas?: { weekly?: QuotaShape };
+      plan?: string;
+    };
+
+    assert.match(r.plan || "", /GOAT/i);
+    assert.equal(r.quotas?.weekly?.total, 35);
+  });
+
+  it("convertUsageToQuotaInfo marks weekly-exhausted Command Code as limitReached", async () => {
+    installMockFetch({
+      "/alpha/whoami": () => jsonResponse(WHOAMI_PERSONAL),
+      "/alpha/billing/credits": () => jsonResponse(CREDITS_PAYLOAD),
+      "/alpha/billing/subscriptions": () => jsonResponse(SUBSCRIPTION_GOAT),
+      "/alpha/usage/summary": () => jsonResponse(USAGE_SUMMARY),
+    });
+
+    const usage = await getCommandCodeUsage("cc-key");
+    const info = convertUsageToQuotaInfo(usage);
+    assert.ok(info);
+    assert.equal(info!.limitReached, true);
+    assert.ok((info!.windows.weekly?.percentUsed ?? 0) >= 1 - 1e-9);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds live Command Code account quota tracking for Provider Limits and generic preflight via Bearer `/alpha` APIs (`whoami` → `billing/credits` → soft `billing/subscriptions` + `usage/summary`).
- Surfaces `five_hour`, `weekly`, and `credits` USD windows (including rolling `windowLimits`) so exhausted weekly/5h caps can skip the connection in routing.
- Registers `command-code` in `USAGE_FETCHER_PROVIDERS`, `USAGE_SUPPORTED_PROVIDERS`, `PROVIDER_LIMITS_APIKEY_PROVIDERS`, and Provider Limits column schema.

⚠️ base-red inherited: #9737

## Related Issues

- Related to #2199 (provider landed without quota tracker; FEATURES already claimed quota tracking)

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/dev/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / other (usage + Provider Limits)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base (`diegosouzapw/release/v3.8.50` @ `918647af6`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Focused validation:

```text
node --import tsx/esm --test tests/unit/command-code-usage.test.ts
# 9/9 pass

# Live smoke (local API key → leaf + Provider Limits path + HTTP on branch :20130)
# getCommandCodeUsage / fetchAndPersistProviderLimits / GET /api/usage/<id> / POST /api/usage/provider-limits
# → plan "Command Code · GOAT", five_hour/weekly/credits populated, weekly limitReached=true
```

## Tests Added Or Updated

- `tests/unit/command-code-usage.test.ts` — registration allowlists, quota mapping (`resetAt: 0` → null), org-null path, missing key, 401 message-only, soft-fail enrichment, dispatcher, `convertUsageToQuotaInfo` limitReached

## Coverage Notes

- New leaf `open-sse/services/usage/command-code.ts` plus dispatcher/allowlist wiring covered by the focused unit file above.
- Full coverage gate remains with CI.

## Reviewer Notes

- Auth is the connection API key only (no browser cookie `/internal` path). Live `/alpha/billing/credits` already returns `windowLimits.fiveHour` / `weekly`.
- Soft-fail: credits alone is enough for windows; subscription/summary enrich plan label + period spend.
- When a rolling window is exhausted, preflight can skip the connection even if monthly/purchased credits remain (matches CLI rolling-window gating). Purchased credits may still work upstream — documented risk.
- Intentionally deferred (not needed for Limits/preflight parity with ai-status/CodexBar): hourly charts, per-model `modelBreakdown`, cookie `/internal` Studio APIs.
- Base tip is currently red (#9737); do not chase inherited failures inside this PR.


Made with [Cursor](https://cursor.com)
