### PR TITLE
docs: add quickstart code examples for Python, Node.js, PHP and cURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ curl http://localhost:20128/v1/chat/completions \
 
 <sub>Prefer a specific free backend? Call it directly, e.g. `oc/…` (OpenCode Free) or `felo/…` (Felo). Then graduate to `auto` and let OmniRoute pick.</sub>
 
+<sub>📦 Copy-paste quickstart scripts for **Python, Node.js, PHP, and cURL** → [`examples/quickstart/`](examples/quickstart/)</sub>
+
 <br/>
 
 <div align="center">

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,39 @@
+# Quickstart Code Examples
+
+Simple, copy-paste scripts to get your first response from a local OmniRoute server in under a minute.
+
+## Prerequisites
+
+Start OmniRoute locally first:
+
+```bash
+npx omniroute
+# Server is now live at http://localhost:20128/v1
+```
+
+## Examples
+
+| File | Language | Dependency |
+|------|----------|------------|
+| [`python_requests.py`](python_requests.py) | Python | `pip install requests` |
+| [`nodejs_axios.js`](nodejs_axios.js) | Node.js | `npm install axios` |
+| [`curl_terminal.sh`](curl_terminal.sh) | Bash / cURL | `curl` (pre-installed on Mac/Linux) |
+| [`php_curl.php`](php_curl.php) | PHP | PHP 7.4+ with cURL |
+
+All examples use **`felo/auto`** — a keyless, zero-configuration model that works immediately with no provider sign-up required.
+
+## Key Settings (same in all examples)
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `model` | `felo/auto` | Keyless provider, works out of the box |
+| `stream` | `false` | Returns standard JSON instead of SSE stream |
+| `Authorization` | `Bearer dummy-key` | Any non-empty string satisfies the header requirement |
+
+## What to Change
+
+To use a different model, replace `felo/auto` with any model ID from:
+
+```bash
+curl http://localhost:20128/v1/models
+```

--- a/examples/quickstart/curl_terminal.sh
+++ b/examples/quickstart/curl_terminal.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# OmniRoute Quickstart — cURL (Bash / Terminal)
+# ==============================================
+# Run:  chmod +x curl_terminal.sh && ./curl_terminal.sh
+# Requires: curl (pre-installed on Mac/Linux; use Git Bash on Windows)
+
+# Your local OmniRoute server — started with: npx omniroute
+API_URL="http://localhost:20128/v1/chat/completions"
+
+curl "$API_URL" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer dummy-key" \
+  -d '{
+    "model": "felo/auto",
+    "stream": false,
+    "messages": [
+      { "role": "user", "content": "Hello! What can you do?" }
+    ]
+  }' | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])"

--- a/examples/quickstart/nodejs_axios.js
+++ b/examples/quickstart/nodejs_axios.js
@@ -1,0 +1,31 @@
+/**
+ * OmniRoute Quickstart — Node.js (axios)
+ * =======================================
+ * Run:  npm install axios
+ *       node nodejs_axios.js
+ */
+
+const axios = require('axios');
+
+// Your local OmniRoute server — started with: npx omniroute
+const API_URL = 'http://localhost:20128/v1/chat/completions';
+
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': 'Bearer dummy-key', // Any string works for free/keyless providers
+};
+
+const data = {
+  model: 'felo/auto', // Keyless, works out of the box — no sign-up needed
+  stream: false,
+  messages: [
+    { role: 'user', content: 'Hello! What can you do?' },
+  ],
+};
+
+axios.post(API_URL, data, { headers })
+  .then(res => console.log(res.data.choices[0].message.content))
+  .catch(err => {
+    console.error('Error:', err.message);
+    if (err.response) console.error('Server replied:', err.response.data);
+  });

--- a/examples/quickstart/php_curl.php
+++ b/examples/quickstart/php_curl.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * OmniRoute Quickstart — PHP (cURL)
+ * ===================================
+ * Run:  php php_curl.php
+ * Requires: PHP 7.4+ with cURL extension enabled
+ */
+
+// Your local OmniRoute server — started with: npx omniroute
+$api_url = "http://localhost:20128/v1/chat/completions";
+
+$headers = [
+    "Content-Type: application/json",
+    "Authorization: Bearer dummy-key", // Any string works for free/keyless providers
+];
+
+$data = [
+    "model"    => "felo/auto", // Keyless, works out of the box — no sign-up needed
+    "stream"   => false,
+    "messages" => [
+        ["role" => "user", "content" => "Hello! What can you do?"],
+    ],
+];
+
+$ch = curl_init($api_url);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => json_encode($data),
+    CURLOPT_HTTPHEADER     => $headers,
+]);
+
+$response  = curl_exec($ch);
+$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+if ($http_code === 200) {
+    $result = json_decode($response, true);
+    echo $result['choices'][0]['message']['content'] . PHP_EOL;
+} else {
+    echo "Error HTTP $http_code: $response" . PHP_EOL;
+}

--- a/examples/quickstart/python_requests.py
+++ b/examples/quickstart/python_requests.py
@@ -1,0 +1,28 @@
+"""
+OmniRoute Quickstart — Python (requests library)
+================================================
+Run:  pip install requests  (if not already installed)
+      python python_requests.py
+"""
+
+import requests
+
+# Your local OmniRoute server — started with: npx omniroute
+API_URL = "http://localhost:20128/v1/chat/completions"
+
+headers = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer dummy-key",  # Any string works for free/keyless providers
+}
+
+data = {
+    "model": "felo/auto",  # Keyless, works out of the box — no sign-up needed
+    "stream": False,
+    "messages": [
+        {"role": "user", "content": "Hello! What can you do?"}
+    ],
+}
+
+response = requests.post(API_URL, headers=headers, json=data)
+response.raise_for_status()
+print(response.json()["choices"][0]["message"]["content"])


### PR DESCRIPTION
Add examples/quickstart/ with minimal copy-paste scripts that let new users get a response from a local OmniRoute server in under a minute, without needing to read the full docs first.

Files added:
- examples/quickstart/python_requests.py  (requests library)
- examples/quickstart/nodejs_axios.js     (axios)
- examples/quickstart/curl_terminal.sh    (bash one-liner)
- examples/quickstart/php_curl.php        (cURL extension)
- examples/quickstart/README.md           (table + key-settings cheatsheet)

README.md: add one sub-line pointer to examples/quickstart/ below the existing zero-config curl snippet, matching the surrounding <sub> style.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/dev/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
