### PR TITLE
fix(deps): restore npm ci on release/v3.8.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -398,7 +398,7 @@
   },
   "overrides": {
     "fast-xml-parser": "^5.10.1",
-    "sharp": "^0.35.0",
+    "sharp": "$sharp",
     "postcss": "^8.5.18",
     "ip-address": "^10.3.1",
     "qs": "^6.15.2",


### PR DESCRIPTION
## Summary

- make the root sharp override reference the direct dependency specification
- prevent npm 11 from rejecting the dependency tree after the direct dependency moved to ^0.35.3
- leave package-lock.json unchanged because the resolved tree is already synchronized

## Root cause

npm ci reported the generic existing-package-lock EUSAGE message, but the npm debug log showed the underlying Arborist failure:

    Override for sharp@^0.35.3 conflicts with direct dependency

The direct dependency was ^0.35.3 while the root override remained ^0.35.0.

## Validation

Reproduced on the exact release tip 240b9b5bc436189c945dfe3027fba16c0293df58 with Node v24.16.0 and npm 11.13.0.

Before:

    npm ci --ignore-scripts --no-audit --no-fund
    npm error code EUSAGE

After:

    npm ci --ignore-scripts --no-audit --no-fund
    added 2344 packages in 5m

git diff --check also passed.
