### PR TITLE
fix(admission): prefer cgroup-scoped memory PSI

### DIFF
--- a/changelog.d/fixes/cgroup-scoped-memory-psi.md
+++ b/changelog.d/fixes/cgroup-scoped-memory-psi.md
@@ -1,0 +1,1 @@
+Prefer the process cgroup's `memory.pressure` signal over host-wide PSI for resource-pressure admission, preventing unrelated host workloads from causing false `503 resource_pressure` responses while retaining `/proc/pressure/memory` as a fallback.

--- a/open-sse/utils/resourcePressureSampler.ts
+++ b/open-sse/utils/resourcePressureSampler.ts
@@ -234,7 +234,10 @@ export async function sampleResourceSignals(
         readText(path.join(cgroupDirectory, "memory.events")),
       ])
     : [null, null, null, null];
-  const psi = await readText("/proc/pressure/memory").catch(() => null);
+  const cgroupPsi = cgroupDirectory
+    ? await readText(path.join(cgroupDirectory, "memory.pressure")).catch(() => null)
+    : null;
+  const psi = cgroupPsi ?? (await readText("/proc/pressure/memory").catch(() => null));
 
   return {
     observedAtMs: (deps.nowMs ?? Date.now)(),

--- a/tests/unit/resource-pressure-sampler.test.ts
+++ b/tests/unit/resource-pressure-sampler.test.ts
@@ -101,8 +101,12 @@ describe("sampleResourceSignals", () => {
       ["/sys/fs/cgroup/slice/service/memory.high", "966367641\n"],
       ["/sys/fs/cgroup/slice/service/memory.events", "low 1\nhigh 2\nmax 3\noom 4\noom_kill 5\n"],
       [
-        "/proc/pressure/memory",
+        "/sys/fs/cgroup/slice/service/memory.pressure",
         "some avg10=1.50 avg60=2.00 avg300=3.25 total=9\nfull avg10=0.25 avg60=0.50 avg300=0.75 total=1\n",
+      ],
+      [
+        "/proc/pressure/memory",
+        "some avg10=55.00 avg60=42.00 avg300=30.00 total=99\nfull avg10=45.00 avg60=32.00 avg300=20.00 total=88\n",
       ],
     ]);
 
@@ -132,6 +136,27 @@ describe("sampleResourceSignals", () => {
     });
     assert.equal(signals.psi?.someAvg10, 1.5);
     assert.equal(signals.psi?.fullAvg10, 0.25);
+  });
+
+  it("falls back to host PSI when the process cgroup has no memory.pressure", async () => {
+    const fs = mapFs([
+      ["/proc/self/cgroup", "0::/slice/service\n"],
+      ["/proc/self/mountinfo", "43 34 0:35 / /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"],
+      ["/sys/fs/cgroup/slice/service/memory.current", "1\n"],
+      [
+        "/proc/pressure/memory",
+        "some avg10=12.50 avg60=8.00 avg300=4.00 total=9\nfull avg10=2.50 avg60=1.50 avg300=0.75 total=1\n",
+      ],
+    ]);
+
+    const signals = await sampleResourceSignals({
+      memoryUsage: () => memoryUsage(),
+      heapStatistics: () => ({ heap_size_limit: GiB, used_heap_size: 1 }),
+      fs,
+    });
+
+    assert.equal(signals.psi?.someAvg10, 12.5);
+    assert.equal(signals.psi?.fullAvg10, 2.5);
   });
 
   it("fails open when platform reads fail or return malformed values", async () => {


### PR DESCRIPTION
## Summary

- prefer the running process cgroup's `memory.pressure` PSI over host-wide `/proc/pressure/memory`
- retain host PSI as a fallback when cgroup v2 pressure data is unavailable
- add regression coverage proving unrelated host pressure does not override a healthy service cgroup

## Problem

The adaptive resource-pressure guard introduced in #9262 samples `/proc/pressure/memory`. On a shared host, unrelated workloads can raise system-wide PSI above the critical threshold and make OmniRoute return retryable `503 resource_pressure` responses even when its own cgroup is below `memory.high`/`memory.max` and has no OOM events.

Observed on a systemd deployment running alongside an active media-indexing workload: host `some avg10` exceeded 40 while the OmniRoute cgroup remained within its configured memory bounds. The guard rejected 30 requests; one client session exhausted four complete 5-attempt retry cycles.

Cgroup v2 already exposes the scoped signal at `<resolved-cgroup>/memory.pressure`, next to the `memory.current`, `memory.high`, `memory.max`, and `memory.events` files this sampler already reads.

## Change

When the process cgroup directory is resolved:

1. read its `memory.pressure`;
2. use that PSI for admission decisions;
3. fall back to `/proc/pressure/memory` only if scoped PSI is absent/unreadable.

This keeps existing behavior for non-cgroup platforms and older kernels while preventing neighboring workloads from shedding healthy OmniRoute traffic.

## Validation

- regression test fails on the pre-fix sampler (`55 !== 1.5` because host PSI wins)
- focused sampler suite passes after the fix: **9/9**
- adjacent resource-pressure policy tests pass: **7/7**
- Prettier check passes for all changed files
- `git diff --check` passes

The broader runtime tests could not be used as a clean local gate in the production dependency tree because path-alias development dependencies are intentionally absent there; no runtime code outside the sampler changed.

## Related

- #9262
- #3052 (earlier false-positive resource-pressure threshold incident)
