### PR TITLE
fix(oauth): expose manual Codex callback entry

### DIFF
--- a/changelog.d/fixes/codex-manual-loopback-action.md
+++ b/changelog.d/fixes/codex-manual-loopback-action.md
@@ -1,0 +1,1 @@
+Add a visible manual callback-entry action to the Codex loopback warning so remote users can paste the authorization result instead of setting up an SSH tunnel.

--- a/src/shared/components/OAuthModal.tsx
+++ b/src/shared/components/OAuthModal.tsx
@@ -372,11 +372,10 @@ export default function OAuthModal({
     [provider, onSuccess, reauthConnection, t]
   );
 
-  // Start OAuth flow. `opts.grokBrowser` lets the grok-cli method tabs force a
-  // specific branch synchronously (avoids reading a just-set state value through
-  // a stale closure); when omitted, falls back to the grokBrowserMode state.
+  // Start OAuth flow. Options let method buttons select a branch synchronously
+  // instead of reading a just-set state value through a stale closure.
   const startOAuthFlow = useCallback(
-    async (opts?: { grokBrowser?: boolean }) => {
+    async (opts?: { grokBrowser?: boolean; manualLoopback?: boolean }) => {
       if (!provider) return;
       try {
         setError(null);
@@ -531,7 +530,7 @@ export default function OAuthModal({
               setPolling(false);
               forceManual = true;
             }
-          } else if (isLocalhost) {
+          } else if (isLocalhost && !opts?.manualLoopback) {
             setLoopbackHint(buildPkceLoopbackMismatchHint(provider, loopbackLocation));
             setStep("loopback-mismatch");
             return;
@@ -1124,6 +1123,7 @@ export default function OAuthModal({
           <OAuthLoopbackMismatchPanel
             providerName={providerInfo.name}
             hint={loopbackHint}
+            onManualInput={() => void startOAuthFlow({ manualLoopback: true })}
             onClose={handleClose}
           />
         )}

--- a/src/shared/components/OAuthModalPanels.tsx
+++ b/src/shared/components/OAuthModalPanels.tsx
@@ -89,6 +89,7 @@ export function OAuthDeviceCodePanel({
 type OAuthLoopbackMismatchPanelProps = {
   providerName: string;
   hint: PkceLoopbackMismatchHint;
+  onManualInput: () => void;
   onClose: () => void;
 };
 
@@ -103,6 +104,7 @@ type OAuthLoopbackMismatchPanelProps = {
 export function OAuthLoopbackMismatchPanel({
   providerName,
   hint,
+  onManualInput,
   onClose,
 }: OAuthLoopbackMismatchPanelProps) {
   const t = useTranslations("oauthModal");
@@ -194,6 +196,9 @@ export function OAuthLoopbackMismatchPanel({
         <p className="text-xs text-text-muted">{t("loopbackMismatchAlternative")}</p>
       </div>
       <div className="flex gap-2">
+        <Button onClick={onManualInput} fullWidth>
+          {t("popupBlocked")}
+        </Button>
         <Button onClick={onClose} variant="secondary" fullWidth>
           {t("cancel")}
         </Button>

--- a/tests/unit/oauth-modal-codex-lan-ip-8046.test.ts
+++ b/tests/unit/oauth-modal-codex-lan-ip-8046.test.ts
@@ -41,7 +41,7 @@ test("PKCE callback-server providers now warn (not window.open) on a LAN-IP orig
   // that surfaces the loopback mismatch instead of falling through silently.
   // The follow-up swapped the flat warning string for the structured hint that feeds
   // the dedicated panel (buildPkceLoopbackMismatchHint) — the guard itself is unchanged.
-  const arm = modal.match(/else if \(isLocalhost\) \{[\s\S]{0,300}?\n {10}\}/);
+  const arm = modal.match(/else if \(isLocalhost(?: && [^)]+)?\) \{[\s\S]{0,300}?\n {10}\}/);
   assert.ok(arm, "expected an `else if (isLocalhost)` arm inside the callback-server branch");
   assert.match(
     arm![0],
@@ -54,6 +54,29 @@ test("PKCE callback-server providers now warn (not window.open) on a LAN-IP orig
     arm![0],
     /\breturn;/,
     "the arm must stop the flow, not merely annotate it before falling through"
+  );
+});
+
+test("loopback warning offers the existing manual callback flow", () => {
+  const panels = readFileSync(
+    resolve(here, "../../src/shared/components/OAuthModalPanels.tsx"),
+    "utf8"
+  );
+
+  assert.match(
+    modal,
+    /isLocalhost && !opts\?\.manualLoopback/,
+    "the warning guard must be bypassable only through an explicit manual-flow action"
+  );
+  assert.match(
+    modal,
+    /onManualInput=\{\(\) => void startOAuthFlow\(\{ manualLoopback: true \}\)\}/,
+    "the mismatch panel action must initialize the existing authorization-code flow"
+  );
+  assert.match(
+    panels,
+    /<Button onClick=\{onManualInput\} fullWidth>/,
+    "the mismatch panel must render a visible manual-entry action next to Cancel"
   );
 });
 


### PR DESCRIPTION
## Summary

- add a visible manual-entry action beside the SSH guidance in the PKCE loopback mismatch panel
- initialize the existing authorization-code flow when the operator chooses manual entry
- keep the default tunnel guidance and all PKCE/state validation unchanged

## Problem

When OmniRoute is opened from a LAN or remote address, Codex redirects the browser to its fixed `localhost:1455` callback. The dedicated warning correctly explains the SSH tunnel, but its only action is **Cancel**, even though OmniRoute already supports pasting the callback URL or authorization code manually.

This makes the supported no-tunnel path unnecessarily difficult to discover.

## Change

The warning panel now exposes **Enter URL manually** next to **Cancel**. Choosing it:

1. explicitly bypasses the loopback-warning branch for this attempt;
2. initializes the normal OAuth authorization-code request;
3. opens the provider sign-in page;
4. shows the existing manual callback/code input.

No token parser, redirect URI, state check, callback exchange, or server-side credential handling is weakened or bypassed.

## Validation

- focused Codex LAN-loopback tests: **6/6 passed**
- Prettier check passes for all changed files
- `git diff --check` passes

## Related

- #7527
- #7725
- #8152
