### PR TITLE
fix(db): rename 139_job_registry -> 143 to avoid collision with 139_ccr_blocks

### DIFF
--- a/src/lib/db/migrations/143_job_registry.sql
+++ b/src/lib/db/migrations/143_job_registry.sql
@@ -1,4 +1,4 @@
--- Migration 139: generic job registry (jobs + job_runs tables)
+-- Migration 143: generic job registry (jobs + job_runs tables)
 -- Job registry (#8848): centralized periodic-job scheduling + run history.
 --
 -- jobs:      one row per registered job (interval or cron), with env-flag gating


### PR DESCRIPTION
## Problem

Fresh installs and existing installs crash at DB init with a migration version collision: both `139_ccr_blocks.sql` and `139_job_registry.sql` declare `version = 139`. `getMigrationFiles()` throws (`migrationRunner.ts`), the DB fails to initialize, and every API route returns 500.

The collision was introduced when the job-registry feature (#9631 / #8848) was cherry-picked into `release/v3.8.50` — its `139_job_registry.sql` collides with the `139_ccr_blocks.sql` already present on the release branch. The branch-local fix `21a3cb32f` never landed on `release/v3.8.50`.

## Fix

Rename `139_job_registry.sql` → `143_job_registry.sql` (140 is taken by `connection_runtime_state.sql`; highest existing version is 142). The SQL is idempotent (`CREATE TABLE IF NOT EXISTS` + `INSERT OR IGNORE`), and installs that already applied `139|ccr_blocks` never applied job_registry, so no retroactive guard is needed — matching the upstream fix pattern.

## Verification

- `tests/unit/db-migration-version-uniqueness.test.ts`, `migration-135-numbering-collision.test.ts`, `db-ccr-migration-renumber-134.test.ts`: 6/6 pass, including a fresh-install simulation that applies all real on-disk migrations without a version collision.
- Live: reproduced the crash with the released package (all routes 500), renamed the migration in the installed copy, restarted — server healthy (`/v1/models` 200, chat round-trip OK).