### PR TITLE
fix(db): avoid skipping pending job registry migration 146

### DIFF
--- a/src/lib/db/migrationRunner.ts
+++ b/src/lib/db/migrationRunner.ts
@@ -487,8 +487,6 @@ function isSchemaAlreadyApplied(
       // but still burn a version-tracking slot mismatch — guard it the same
       // way as the other renumbers for consistency.
       return hasTable(db, "connection_runtime_state");
-    case "146":
-      return hasTable(db, "jobs") && hasTable(db, "job_runs");
     default:
       return false;
   }

--- a/tests/unit/db-job-registry-migration-renumber-139.test.ts
+++ b/tests/unit/db-job-registry-migration-renumber-139.test.ts
@@ -15,7 +15,11 @@ fs.writeFileSync(
 );
 fs.writeFileSync(
   path.join(migrationsDir, "146_job_registry.sql"),
-  "CREATE TABLE jobs (id TEXT PRIMARY KEY); CREATE TABLE job_runs (id INTEGER PRIMARY KEY);"
+  [
+    "CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY);",
+    "CREATE TABLE IF NOT EXISTS job_runs (id INTEGER PRIMARY KEY);",
+    "CREATE TABLE job_registry_reexecuted (id INTEGER PRIMARY KEY);",
+  ].join(" ")
 );
 
 const { runMigrations } = await import("../../src/lib/db/migrationRunner.ts");
@@ -52,6 +56,54 @@ test("job registry previously applied on 139 is rehomed so CCR can claim that sl
       db
         .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ccr_blocks'")
         .get()
+    );
+    assert.equal(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'job_registry_reexecuted'"
+        )
+        .get(),
+      undefined,
+      "tracked legacy Job Registry must reconcile to 146 without replaying the migration"
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("untracked Job Registry tables do not suppress pending migration 146", () => {
+  const db = new Database(":memory:");
+  try {
+    db.exec(`
+      CREATE TABLE jobs (id TEXT PRIMARY KEY);
+      CREATE TABLE job_runs (id INTEGER PRIMARY KEY);
+      CREATE TABLE ccr_blocks (principal_id TEXT PRIMARY KEY);
+      CREATE TABLE _omniroute_migrations (
+        version TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO _omniroute_migrations (version, name)
+      VALUES ('139', 'ccr_blocks');
+    `);
+
+    assert.equal(runMigrations(db), 1);
+
+    assert.deepEqual(
+      db.prepare("SELECT version, name FROM _omniroute_migrations ORDER BY version").all(),
+      [
+        { version: "139", name: "ccr_blocks" },
+        { version: "146", name: "job_registry" },
+      ]
+    );
+
+    assert.ok(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'job_registry_reexecuted'"
+        )
+        .get(),
+      "a genuinely pending 146 migration must execute even when jobs and job_runs already exist"
     );
   } finally {
     db.close();


### PR DESCRIPTION
## Summary

- Remove the `146` Job Registry schema sentinel that treated the presence of `jobs` and `job_runs` tables as proof that migration 146 was already complete.
- Preserve the existing `139 job_registry` → `146 job_registry` compatibility mapping for correctly tracked legacy databases.
- Strengthen the Job Registry migration regression to prove both sides of the contract: tracked legacy installs reconcile without replay, while untracked physical tables do not suppress a genuinely pending 146 migration.

## Related Issues

- Related to #9945

## Validation

- [x] Change type: DB
- [x] Focused migration tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Focused validation:

- `npm run check:migration-numbering` — passed
- `npm run check:db-rules` — passed
- `npm run lint` — passed
- changed-file Prettier — passed
- Job Registry 139→146 regression — passed
- CCR 134→139 regression — passed
- migration runner regression — passed
- migration constants regression — passed
- migration version uniqueness — passed
- migration collision guard — passed
- migration 135 fresh-install regression — passed
- 43 focused tests passed, 0 failed
- docs sync — passed
- T11 explicit-any budget — passed
- tracked-artifacts gate — passed

## Tests Added Or Updated

- Updated `tests/unit/db-job-registry-migration-renumber-139.test.ts`

## Coverage Notes

The production change removes a schema-completion shortcut in `src/lib/db/migrationRunner.ts`.

The updated regression directly covers both affected paths: a tracked legacy `139 job_registry` row still reconciles to 146 without replay, while an untracked schema containing the Job Registry tables still executes the genuinely pending migration.

## Reviewer Notes

Migration 146 is idempotent and does more than create `jobs` and `job_runs`: it also creates Job Registry indexes and seeds built-in jobs.

Treating only the two table names as a completion sentinel can therefore skip missing migration side effects on an untracked or partially-created schema.

This PR intentionally leaves the existing `139 → 146` compatibility mapping and `146_job_registry.sql` unchanged. Correctly tracked legacy databases continue to avoid replay through migration-record reconciliation rather than physical-table detection.
