### PR TITLE
[TS7] fix(types): narrow combo model collections

### DIFF
--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -389,7 +389,7 @@ export async function getModelInfo(modelStr) {
 export async function getCombo(modelStr) {
   // Try exact match first (supports combos actually named "combo/ANY")
   let combo = await getComboByName(modelStr);
-  if (combo && combo.models && combo.models.length > 0) {
+  if (combo && Array.isArray(combo.models) && combo.models.length > 0) {
     return combo;
   }
 
@@ -397,7 +397,7 @@ export async function getCombo(modelStr) {
   if (modelStr.startsWith("combo/")) {
     const nameToSearch = modelStr.substring(6);
     combo = await getComboByName(nameToSearch);
-    if (combo && combo.models && combo.models.length > 0) {
+    if (combo && Array.isArray(combo.models) && combo.models.length > 0) {
       return combo;
     }
   }
@@ -409,12 +409,12 @@ export async function getCombo(modelStr) {
   // a combo named "MASTER-LIGHT"). These two fallbacks only run after the exact
   // match fails, so they never re-route a combo that already resolves today.
   combo = await getComboById(modelStr);
-  if (combo && combo.models && combo.models.length > 0) {
+  if (combo && Array.isArray(combo.models) && combo.models.length > 0) {
     return combo;
   }
 
   combo = await getComboByNameInsensitive(modelStr);
-  if (combo && combo.models && combo.models.length > 0) {
+  if (combo && Array.isArray(combo.models) && combo.models.length > 0) {
     return combo;
   }
 

--- a/tests/unit/combo-id-resolution-4446.test.ts
+++ b/tests/unit/combo-id-resolution-4446.test.ts
@@ -82,3 +82,13 @@ test("#4446 exact name match still wins and unknown slugs still return null", as
   const unknown = await sseModelService.getComboForModel("no-such-combo-xyz");
   assert.equal(unknown, null, "an unknown slug must not resolve to any combo");
 });
+
+test("getComboForModel ignores combos without a populated model array", async () => {
+  await combosDb.createCombo({
+    name: "EMPTY-COMBO",
+    models: [],
+  });
+
+  const resolved = await sseModelService.getComboForModel("EMPTY-COMBO");
+  assert.equal(resolved, null, "an empty combo must not be selected for routing");
+});


### PR DESCRIPTION
## Summary

- narrow combo model collections with Array.isArray before reading length
- preserve the existing exact-name, id, and case-insensitive resolution order
- add a regression test for empty combo collections

## TypeScript migration impact

- TypeScript 7.0.2 diagnostics: 50 -> 46
- TypeScript 6 diagnostics: 51 -> 47
- normalized diagnostic multiset: 4 removed, 0 added under both compilers
- combined with the other slices in this batch: TS7 50 -> 42, TS6 51 -> 43, 0 added

## Validation

- npm run lint
- npm run check:file-size -- --changed
- node --import tsx/esm --test tests/unit/combo-id-resolution-4446.test.ts (4/4)
- npm run test:vitest on the combined overlay (344/344)
- full unit overlay only reproduced unrelated base/environment failures; the touched suite is green

Part of #8484.