### PR TITLE
[TS7] fix(types): align Claude message contracts

### DIFF
--- a/open-sse/handlers/chatCore/claudeMessageTypes.ts
+++ b/open-sse/handlers/chatCore/claudeMessageTypes.ts
@@ -7,9 +7,19 @@
  * shapes the handler already used inline; behaviour is unchanged.
  */
 
-export type ClaudeContentBlock = Record<string, unknown>;
+export type ClaudeContentBlock = {
+  type?: string;
+  text?: string;
+  name?: string;
+  tool_use_id?: string;
+  cache_control?: unknown;
+  signature?: string;
+  thinking?: string;
+  [key: string]: unknown;
+};
 
 export type ClaudeMessage = {
-  role?: unknown;
-  content?: unknown;
+  role?: string;
+  content?: string | ClaudeContentBlock[];
+  [key: string]: unknown;
 };

--- a/tests/unit/chatcore-claude-upstream-messages.test.ts
+++ b/tests/unit/chatcore-claude-upstream-messages.test.ts
@@ -10,6 +10,7 @@ import {
   extractSystemMessagesToBody,
   normalizeClaudeUpstreamMessages,
 } from "../../open-sse/handlers/chatCore/claudeUpstreamMessages.ts";
+import type { ClaudeMessage } from "../../open-sse/handlers/chatCore/claudeMessageTypes.ts";
 
 test("extractSystemMessagesToBody lifts system/developer roles into top-level system", () => {
   const payload: Record<string, unknown> = {
@@ -51,12 +52,31 @@ test("extractSystemMessagesToBody is a no-op without system messages or a messag
 test("normalizeClaudeUpstreamMessages drops empty text blocks", () => {
   const payload: Record<string, unknown> = {
     messages: [
-      { role: "user", content: [{ type: "text", text: "" }, { type: "text", text: "keep" }] },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "" },
+          { type: "text", text: "keep" },
+        ],
+      },
     ],
   };
   normalizeClaudeUpstreamMessages(payload);
   const msg = (payload.messages as Record<string, unknown>[])[0];
   assert.deepEqual(msg.content, [{ type: "text", text: "keep" }]);
+});
+
+test("shared Claude message contract preserves structured content", () => {
+  const message: ClaudeMessage = {
+    role: "user",
+    content: [{ type: "text", text: "keep", cache_control: { type: "ephemeral" } }],
+    metadata: { source: "test" },
+  };
+  const payload: Record<string, unknown> = { messages: [message] };
+
+  normalizeClaudeUpstreamMessages(payload);
+
+  assert.deepEqual(payload.messages, [message]);
 });
 
 test("normalizeClaudeUpstreamMessages collapses tool_result to text by default", () => {


### PR DESCRIPTION
## Summary

- align the shared Claude message alias with the string role contract used by the upstream transforms
- describe the structured content fields already consumed by the handler
- retain an index signature for provider extensions
- add a regression test for structured content and metadata preservation

## TypeScript migration impact

- TypeScript 7.0.2 diagnostics: 50 -> 48
- TypeScript 6 diagnostics: 51 -> 49
- normalized diagnostic multiset: 2 removed, 0 added under both compilers
- combined with the other slices in this batch: TS7 50 -> 42, TS6 51 -> 43, 0 added

## Validation

- npm run lint
- npm run check:file-size -- --changed
- node --import tsx/esm --test tests/unit/chatcore-claude-upstream-messages.test.ts tests/unit/translator-helper-branches.test.ts (24/24)
- npm run test:vitest on the combined overlay (344/344)
- full unit overlay only reproduced unrelated base/environment failures; the touched suites are green

Part of #8484.