### PR TITLE
[TS7] fix(types): type Copilot WebSocket construction

### DIFF
--- a/open-sse/executors/copilot-web.ts
+++ b/open-sse/executors/copilot-web.ts
@@ -67,6 +67,11 @@ interface CopilotWsEvent {
   [key: string]: unknown;
 }
 
+type NodeWebSocketConstructor = new (
+  url: string | URL,
+  options?: { headers?: Record<string, string> }
+) => WebSocket;
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 export function getCopilotMode(model?: string): string {
@@ -104,6 +109,12 @@ export function extractAccessToken(credential: string): string | null {
   const bearerMatch = credential.match(/[Bb]earer\s+(.+)/);
   if (bearerMatch) return bearerMatch[1];
   return credential;
+}
+
+/* @testonly */ export function buildCopilotWebSocketHeaders(
+  accessToken: string
+): Record<string, string> {
+  return { Authorization: `Bearer ${accessToken}` };
 }
 
 /**
@@ -292,19 +303,17 @@ export class CopilotWebExecutor extends BaseExecutor {
             // Use Node.js built-in WebSocket if available, else dynamic import.
             // Pass the access token via Authorization header (not URL) to avoid
             // credential exposure in server logs.
-            let WS = globalThis.WebSocket;
-            if (!WS) {
+            const BrowserWebSocket = globalThis.WebSocket;
+            if (BrowserWebSocket) {
+              ws = new BrowserWebSocket(wsUrl);
+            } else {
               // @ts-ignore — ws module has no type declarations in this project
-              WS = (await import("ws")).default as unknown as typeof WebSocket;
-              if (accessToken) {
-                // @ts-ignore — ws module supports headers option in second arg
-                ws = new WS(wsUrl, {
-                  headers: { Authorization: `Bearer ${accessToken}` },
-                }) as WebSocket;
-              }
-            }
-            if (!ws) {
-              ws = new WS(wsUrl) as WebSocket;
+              const NodeWebSocket = (await import("ws"))
+                .default as unknown as NodeWebSocketConstructor;
+              ws = new NodeWebSocket(
+                wsUrl,
+                accessToken ? { headers: buildCopilotWebSocketHeaders(accessToken) } : undefined
+              );
             }
 
             const timeout = setTimeout(() => abort("Copilot WebSocket timeout"), FETCH_TIMEOUT_MS);

--- a/tests/unit/copilot-web-executor.test.ts
+++ b/tests/unit/copilot-web-executor.test.ts
@@ -1,8 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { getCopilotMode, extractAccessToken, sessionPoolKey, solveHashcash } =
-  await import("../../open-sse/executors/copilot-web.ts");
+const {
+  buildCopilotWebSocketHeaders,
+  getCopilotMode,
+  extractAccessToken,
+  sessionPoolKey,
+  solveHashcash,
+} = await import("../../open-sse/executors/copilot-web.ts");
 
 test("getCopilotMode maps known models to their Copilot modes", () => {
   assert.equal(getCopilotMode("copilot"), "chat");
@@ -41,6 +46,12 @@ test("extractAccessToken extracts Bearer token from Authorization header", () =>
 
 test("extractAccessToken returns null for empty input", () => {
   assert.equal(extractAccessToken(""), null);
+});
+
+test("Copilot WebSocket credentials use the Authorization header", () => {
+  assert.deepEqual(buildCopilotWebSocketHeaders("access-token"), {
+    Authorization: "Bearer access-token",
+  });
 });
 
 test("sessionPoolKey produces unique keys per token preventing session sharing", () => {


### PR DESCRIPTION
## Summary

- separate browser and Node WebSocket construction paths
- type the ws package constructor options without widening the global WebSocket type
- keep the access token in the Authorization header instead of the URL
- add a focused header contract regression test

## TypeScript migration impact

- TypeScript 7.0.2 diagnostics: 50 -> 49
- TypeScript 6 diagnostics: 51 -> 50
- normalized diagnostic multiset: 1 removed, 0 added under both compilers
- combined with the other slices in this batch: TS7 50 -> 42, TS6 51 -> 43, 0 added

## Validation

- npm run lint
- npm run check:file-size -- --changed
- node --import tsx/esm --test tests/unit/copilot-web-executor.test.ts (17/17)
- npm run test:vitest on the combined overlay (344/344)
- full unit overlay only reproduced unrelated base/environment failures; the touched suite is green

Part of #8484.