### PR TITLE
fix(i18n): escape angle brackets in denoRelayOrgDomainHint across all 43 locales

### DIFF
--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "نطاق المؤسسة مطلوب",
     "denoRelayDeployFailed": "فشل Deno Deploy",
     "denoRelayTokenHint": "رمز المؤسسة المميز (البادئة ddo_) من console.deno.com → Organization → Settings → Organization Tokens. يُستخدم مرة واحدة للنشر ولا يتم تخزينه أبدًا.",
-    "denoRelayOrgDomainHint": "النطاق الافتراضي لمؤسسة Deno Deploy الخاصة بك (مثل acme.deno.net). سيكون المرحل متاحًا على https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "النطاق الافتراضي لمؤسسة Deno Deploy الخاصة بك (مثل acme.deno.net). سيكون المرحل متاحًا على https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "التصفية حسب البروتوكول",
     "proxyFreePoolProtocol": "البروتوكول",
     "proxyFreePoolCountryPlaceholder": "البلد (مثل US)",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Təşkilat domeni tələb olunur",
     "denoRelayDeployFailed": "Deno Deploy uğursuz oldu",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens bölməsindən təşkilat tokeni (ddo_ prefiksi). Yerləşdirmə üçün bir dəfə istifadə olunur və heç vaxt saxlanılmır.",
-    "denoRelayOrgDomainHint": "Deno Deploy təşkilatınızın standart domeni (məs. acme.deno.net). Rele https://<app-name>.<org-slug>.deno.net ünvanında əlçatan olacaq.",
+    "denoRelayOrgDomainHint": "Deno Deploy təşkilatınızın standart domeni (məs. acme.deno.net). Rele https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net ünvanında əlçatan olacaq.",
     "proxyFreePoolFilterProtocol": "Protokola görə filtrləyin",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Ölkə (məs. US)",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Изисква се домейн на организацията",
     "denoRelayDeployFailed": "Неуспешно внедряване в Deno Deploy",
     "denoRelayTokenHint": "Токен на организацията (префикс ddo_) от console.deno.com → Organization → Settings → Organization Tokens. Използва се веднъж за внедряване и никога не се съхранява.",
-    "denoRelayOrgDomainHint": "Домейнът по подразбиране на вашата Deno Deploy организация (напр. acme.deno.net). Релето ще бъде достъпно на адрес https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Домейнът по подразбиране на вашата Deno Deploy организация (напр. acme.deno.net). Релето ще бъде достъпно на адрес https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Филтриране по протокол",
     "proxyFreePoolProtocol": "Протокол",
     "proxyFreePoolCountryPlaceholder": "Държава (напр. US)",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "অর্গানাইজেশন ডোমেন প্রয়োজন",
     "denoRelayDeployFailed": "Deno Deploy ব্যর্থ হয়েছে",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens থেকে অর্গানাইজেশন টোকেন (প্রিফিক্স ddo_)। ডিপ্লয়ের জন্য একবার ব্যবহার করা হয় এবং কখনই সংরক্ষণ করা হয় না।",
-    "denoRelayOrgDomainHint": "আপনার Deno Deploy অর্গানাইজেশনের ডিফল্ট ডোমেন (যেমন acme.deno.net)। রিলেটি https://<app-name>.<org-slug>.deno.net ঠিকানায় অ্যাক্সেসযোগ্য হবে।",
+    "denoRelayOrgDomainHint": "আপনার Deno Deploy অর্গানাইজেশনের ডিফল্ট ডোমেন (যেমন acme.deno.net)। রিলেটি https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net ঠিকানায় অ্যাক্সেসযোগ্য হবে।",
     "proxyFreePoolFilterProtocol": "প্রোটোকল অনুযায়ী ফিল্টার করুন",
     "proxyFreePoolProtocol": "প্রোটোকল",
     "proxyFreePoolCountryPlaceholder": "দেশ (যেমন US)",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Doména organizace je vyžadována",
     "denoRelayDeployFailed": "Deno Deploy se nezdařil",
     "denoRelayTokenHint": "Token organizace (předpona ddo_) z console.deno.com → Organization → Settings → Organization Tokens. Použije se jednou pro nasazení a nikdy se neukládá.",
-    "denoRelayOrgDomainHint": "Výchozí doména vaší organizace Deno Deploy (např. acme.deno.net). Relay bude dostupný na adrese https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Výchozí doména vaší organizace Deno Deploy (např. acme.deno.net). Relay bude dostupný na adrese https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrovat podle protokolu",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Země (např. US)",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organisationsdomæne er påkrævet",
     "denoRelayDeployFailed": "Deno Deploy mislykkedes",
     "denoRelayTokenHint": "Organisationstoken (præfiks ddo_) fra console.deno.com → Organization → Settings → Organization Tokens. Bruges én gang til udrulning og gemmes aldrig.",
-    "denoRelayOrgDomainHint": "Din Deno Deploy-organisations standarddomæne (f.eks. acme.deno.net). Relæet vil være tilgængeligt på https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Din Deno Deploy-organisations standarddomæne (f.eks. acme.deno.net). Relæet vil være tilgængeligt på https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrer efter protokol",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Land (f.eks. US)",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organisations-Domain ist erforderlich",
     "denoRelayDeployFailed": "Deno Deploy fehlgeschlagen",
     "denoRelayTokenHint": "Organisations-Token (Präfix ddo_) von console.deno.com → Organization → Settings → Organization Tokens. Wird einmal für die Bereitstellung verwendet und nie gespeichert.",
-    "denoRelayOrgDomainHint": "Die Standard-Domain Ihrer Deno Deploy-Organisation (z. B. acme.deno.net). Das Relay wird unter https://<app-name>.<org-slug>.deno.net erreichbar sein.",
+    "denoRelayOrgDomainHint": "Die Standard-Domain Ihrer Deno Deploy-Organisation (z. B. acme.deno.net). Das Relay wird unter https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net erreichbar sein.",
     "proxyFreePoolFilterProtocol": "Nach Protokoll filtern",
     "proxyFreePoolProtocol": "Protokoll",
     "proxyFreePoolCountryPlaceholder": "Land (z. B. DE)",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -6404,7 +6404,7 @@
     "denoRelayOrgDomainRequired": "Organization domain is required",
     "denoRelayDeployFailed": "Deno Deploy failed",
     "denoRelayTokenHint": "Organization token (prefix ddo_) from console.deno.com → Organization → Settings → Organization Tokens. Used once for deploy and never stored.",
-    "denoRelayOrgDomainHint": "Your Deno Deploy organization's default domain (e.g. acme.deno.net). The relay will be reachable at https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Your Deno Deploy organization's default domain (e.g. acme.deno.net). The relay will be reachable at https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filter by protocol",
     "proxyFreePoolProtocol": "Protocol",
     "proxyFreePoolCountryPlaceholder": "Country (e.g. US)",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organization domain is required",
     "denoRelayDeployFailed": "Deno Deploy failed",
     "denoRelayTokenHint": "Organization token (prefix ddo_) from console.deno.com → Organization → Settings → Organization Tokens. Used once for deploy and never stored.",
-    "denoRelayOrgDomainHint": "Your Deno Deploy organization's default domain (e.g. acme.deno.net). The relay will be reachable at https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Your Deno Deploy organization's default domain (e.g. acme.deno.net). The relay will be reachable at https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filter by protocol",
     "proxyFreePoolProtocol": "Protocol",
     "proxyFreePoolCountryPlaceholder": "Country (e.g. US)",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "دامنه سازمان الزامی است",
     "denoRelayDeployFailed": "استقرار Deno Deploy ناموفق بود",
     "denoRelayTokenHint": "توکن سازمان (با پیشوند ddo_) از console.deno.com → Organization → Settings → Organization Tokens. یک‌بار برای استقرار استفاده می‌شود و هرگز ذخیره نمی‌شود.",
-    "denoRelayOrgDomainHint": "دامنه پیش‌فرض سازمان Deno Deploy شما (مانند acme.deno.net). رله در https://<app-name>.<org-slug>.deno.net در دسترس خواهد بود.",
+    "denoRelayOrgDomainHint": "دامنه پیش‌فرض سازمان Deno Deploy شما (مانند acme.deno.net). رله در https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net در دسترس خواهد بود.",
     "proxyFreePoolFilterProtocol": "فیلتر بر اساس پروتکل",
     "proxyFreePoolProtocol": "پروتکل",
     "proxyFreePoolCountryPlaceholder": "کشور (مانند US)",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organisaation verkkotunnus vaaditaan",
     "denoRelayDeployFailed": "Deno Deploy epäonnistui",
     "denoRelayTokenHint": "Organisaation tunnus (etuliite ddo_) osoitteesta console.deno.com → Organization → Settings → Organization Tokens. Käytetään kerran käyttöönottoon, eikä sitä koskaan tallenneta.",
-    "denoRelayOrgDomainHint": "Deno Deploy -organisaatiosi oletusverkkotunnus (esim. acme.deno.net). Välityspalvelin on tavoitettavissa osoitteessa https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Deno Deploy -organisaatiosi oletusverkkotunnus (esim. acme.deno.net). Välityspalvelin on tavoitettavissa osoitteessa https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Suodata protokollan mukaan",
     "proxyFreePoolProtocol": "Protokolla",
     "proxyFreePoolCountryPlaceholder": "Maa (esim. US)",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Le domaine de l'organisation est requis",
     "denoRelayDeployFailed": "Échec de Deno Deploy",
     "denoRelayTokenHint": "Token d'organisation (préfixe ddo_) depuis console.deno.com → Organization → Settings → Organization Tokens. Utilisé une seule fois pour le déploiement et jamais stocké.",
-    "denoRelayOrgDomainHint": "Le domaine par défaut de votre organisation Deno Deploy (ex. acme.deno.net). Le relais sera accessible à l'adresse https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Le domaine par défaut de votre organisation Deno Deploy (ex. acme.deno.net). Le relais sera accessible à l'adresse https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrer par protocole",
     "proxyFreePoolProtocol": "Protocole",
     "proxyFreePoolCountryPlaceholder": "Pays (ex. US)",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "સંસ્થા ડોમેન જરૂરી છે",
     "denoRelayDeployFailed": "Deno Deploy નિષ્ફળ ગયું",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens માંથી સંસ્થા ટોકન (પ્રિફિક્સ ddo_). ડિપ્લોય માટે એકવાર ઉપયોગ થાય છે અને ક્યારેય સંગ્રહિત થતો નથી.",
-    "denoRelayOrgDomainHint": "તમારી Deno Deploy સંસ્થાનું ડિફોલ્ટ ડોમેન (દા.ત. acme.deno.net). રિલે https://<app-name>.<org-slug>.deno.net પર ઉપલબ્ધ થશે.",
+    "denoRelayOrgDomainHint": "તમારી Deno Deploy સંસ્થાનું ડિફોલ્ટ ડોમેન (દા.ત. acme.deno.net). રિલે https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net પર ઉપલબ્ધ થશે.",
     "proxyFreePoolFilterProtocol": "પ્રોટોકોલ દ્વારા ફિલ્ટર કરો",
     "proxyFreePoolProtocol": "પ્રોટોકોલ",
     "proxyFreePoolCountryPlaceholder": "દેશ (દા.ત. US)",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "נדרש דומיין של הארגון",
     "denoRelayDeployFailed": "Deno Deploy נכשל",
     "denoRelayTokenHint": "אסימון ארגון (קידומת ddo_) מתוך console.deno.com → Organization → Settings → Organization Tokens. משמש פעם אחת לפריסה ואינו נשמר לעולם.",
-    "denoRelayOrgDomainHint": "דומיין ברירת המחדל של ארגון ה-Deno Deploy שלך (למשל acme.deno.net). הממסר יהיה נגיש בכתובת https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "דומיין ברירת המחדל של ארגון ה-Deno Deploy שלך (למשל acme.deno.net). הממסר יהיה נגיש בכתובת https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "סנן לפי פרוטוקול",
     "proxyFreePoolProtocol": "פרוטוקול",
     "proxyFreePoolCountryPlaceholder": "מדינה (למשל US)",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "ऑर्गनाइज़ेशन डोमेन आवश्यक है",
     "denoRelayDeployFailed": "Deno Deploy विफल रहा",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens से ऑर्गनाइज़ेशन टोकन (प्रिफ़िक्स ddo_)। डिप्लॉय के लिए एक बार उपयोग किया जाता है और कभी संग्रहीत नहीं किया जाता।",
-    "denoRelayOrgDomainHint": "आपके Deno Deploy ऑर्गनाइज़ेशन का डिफ़ॉल्ट डोमेन (उदा. acme.deno.net)। रिले https://<app-name>.<org-slug>.deno.net पर उपलब्ध होगा।",
+    "denoRelayOrgDomainHint": "आपके Deno Deploy ऑर्गनाइज़ेशन का डिफ़ॉल्ट डोमेन (उदा. acme.deno.net)। रिले https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net पर उपलब्ध होगा।",
     "proxyFreePoolFilterProtocol": "प्रोटोकॉल के अनुसार फ़िल्टर करें",
     "proxyFreePoolProtocol": "प्रोटोकॉल",
     "proxyFreePoolCountryPlaceholder": "देश (उदा. US)",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Szervezeti tartomány megadása kötelező",
     "denoRelayDeployFailed": "A Deno Deploy sikertelen",
     "denoRelayTokenHint": "Szervezeti token (ddo_ előtaggal) a console.deno.com → Organization → Settings → Organization Tokens menüpontból. Csak egyszer használatos a telepítéshez, és soha nem tároljuk.",
-    "denoRelayOrgDomainHint": "A Deno Deploy szervezetének alapértelmezett tartománya (pl. acme.deno.net). A relay a következő címen lesz elérhető: https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "A Deno Deploy szervezetének alapértelmezett tartománya (pl. acme.deno.net). A relay a következő címen lesz elérhető: https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Szűrés protokoll szerint",
     "proxyFreePoolProtocol": "Protokoll",
     "proxyFreePoolCountryPlaceholder": "Ország (pl. US)",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Domain organisasi wajib diisi",
     "denoRelayDeployFailed": "Deno Deploy gagal",
     "denoRelayTokenHint": "Token organisasi (awalan ddo_) dari console.deno.com → Organization → Settings → Organization Tokens. Digunakan sekali untuk deploy dan tidak pernah disimpan.",
-    "denoRelayOrgDomainHint": "Domain default organisasi Deno Deploy Anda (mis. acme.deno.net). Relay akan dapat dijangkau di https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Domain default organisasi Deno Deploy Anda (mis. acme.deno.net). Relay akan dapat dijangkau di https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filter berdasarkan protokol",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Negara (mis. US)",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Domain organisasi diperlukan",
     "denoRelayDeployFailed": "Deno Deploy gagal",
     "denoRelayTokenHint": "Token organisasi (awalan ddo_) dari console.deno.com → Organization → Settings → Organization Tokens. Digunakan sekali untuk penerapan dan tidak pernah disimpan.",
-    "denoRelayOrgDomainHint": "Domain baku organisasi Deno Deploy Anda (mis. acme.deno.net). Relay akan dapat diakses di https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Domain baku organisasi Deno Deploy Anda (mis. acme.deno.net). Relay akan dapat diakses di https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Saring berdasarkan protokol",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Negara (mis. US)",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Il dominio dell'organizzazione è obbligatorio",
     "denoRelayDeployFailed": "Deno Deploy non riuscito",
     "denoRelayTokenHint": "Token dell'organizzazione (prefisso ddo_) da console.deno.com → Organization → Settings → Organization Tokens. Utilizzato una sola volta per il deploy e mai memorizzato.",
-    "denoRelayOrgDomainHint": "Il dominio predefinito della tua organizzazione Deno Deploy (es. acme.deno.net). Il relay sarà raggiungibile all'indirizzo https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Il dominio predefinito della tua organizzazione Deno Deploy (es. acme.deno.net). Il relay sarà raggiungibile all'indirizzo https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtra per protocollo",
     "proxyFreePoolProtocol": "Protocollo",
     "proxyFreePoolCountryPlaceholder": "Paese (es. US)",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "組織ドメインが必要です",
     "denoRelayDeployFailed": "Deno Deploy に失敗しました",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens から取得した組織トークン (プレフィックス ddo_)。デプロイに一度だけ使用され、保存されることはありません。",
-    "denoRelayOrgDomainHint": "Deno Deploy 組織のデフォルトドメイン (例: acme.deno.net)。リレーは https://<app-name>.<org-slug>.deno.net でアクセス可能になります。",
+    "denoRelayOrgDomainHint": "Deno Deploy 組織のデフォルトドメイン (例: acme.deno.net)。リレーは https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net でアクセス可能になります。",
     "proxyFreePoolFilterProtocol": "プロトコルでフィルター",
     "proxyFreePoolProtocol": "プロトコル",
     "proxyFreePoolCountryPlaceholder": "国 (例: US)",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "조직 도메인이 필요합니다",
     "denoRelayDeployFailed": "Deno Deploy 실패",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens에서 발급받은 조직 토큰(접두사 ddo_). 배포에 한 번만 사용되며 절대 저장되지 않습니다.",
-    "denoRelayOrgDomainHint": "Deno Deploy 조직의 기본 도메인(예: acme.deno.net). 릴레이는 https://<app-name>.<org-slug>.deno.net에서 액세스할 수 있습니다.",
+    "denoRelayOrgDomainHint": "Deno Deploy 조직의 기본 도메인(예: acme.deno.net). 릴레이는 https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net에서 액세스할 수 있습니다.",
     "proxyFreePoolFilterProtocol": "프로토콜로 필터링",
     "proxyFreePoolProtocol": "프로토콜",
     "proxyFreePoolCountryPlaceholder": "국가 (예: US)",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "ऑर्गनायझेशन डोमेन आवश्यक आहे",
     "denoRelayDeployFailed": "Deno Deploy अयशस्वी झाले",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens मधील ऑर्गनायझेशन टोकन (प्रिफिक्स ddo_). डिप्लॉयसाठी एकदाच वापरले जाते आणि कधीही स्टोअर केले जात नाही.",
-    "denoRelayOrgDomainHint": "तुमच्या Deno Deploy ऑर्गनायझेशनचे डीफॉल्ट डोमेन (उदा. acme.deno.net). रिले https://<app-name>.<org-slug>.deno.net येथे उपलब्ध असेल.",
+    "denoRelayOrgDomainHint": "तुमच्या Deno Deploy ऑर्गनायझेशनचे डीफॉल्ट डोमेन (उदा. acme.deno.net). रिले https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net येथे उपलब्ध असेल.",
     "proxyFreePoolFilterProtocol": "प्रोटोकॉलनुसार फिल्टर करा",
     "proxyFreePoolProtocol": "प्रोटोकॉल",
     "proxyFreePoolCountryPlaceholder": "देश (उदा. US)",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Domain organisasi diperlukan",
     "denoRelayDeployFailed": "Deno Deploy gagal",
     "denoRelayTokenHint": "Token organisasi (awalan ddo_) daripada console.deno.com → Organisasi → Tetapan → Token Organisasi. Digunakan sekali untuk deploy dan tidak pernah disimpan.",
-    "denoRelayOrgDomainHint": "Domain lalai organisasi Deno Deploy anda (cth. acme.deno.net). Geganti akan dapat dihubungi di https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Domain lalai organisasi Deno Deploy anda (cth. acme.deno.net). Geganti akan dapat dihubungi di https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Tapis mengikut protokol",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Negara (cth. US)",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organisatiedomein is vereist",
     "denoRelayDeployFailed": "Deno Deploy mislukt",
     "denoRelayTokenHint": "Organisatietoken (voorvoegsel ddo_) van console.deno.com → Organization → Settings → Organization Tokens. Eenmalig gebruikt voor implementatie en nooit opgeslagen.",
-    "denoRelayOrgDomainHint": "Het standaarddomein van uw Deno Deploy-organisatie (bijv. acme.deno.net). De relay is bereikbaar op https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Het standaarddomein van uw Deno Deploy-organisatie (bijv. acme.deno.net). De relay is bereikbaar op https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filteren op protocol",
     "proxyFreePoolProtocol": "Protocol",
     "proxyFreePoolCountryPlaceholder": "Land (bijv. US)",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organisasjonsdomene kreves",
     "denoRelayDeployFailed": "Deno Deploy mislyktes",
     "denoRelayTokenHint": "Organisasjonstoken (prefiks ddo_) fra console.deno.com → Organization → Settings → Organization Tokens. Brukes én gang til distribusjon og blir aldri lagret.",
-    "denoRelayOrgDomainHint": "Standarddomenet til din Deno Deploy-organisasjon (f.eks. acme.deno.net). Reléet vil være tilgjengelig på https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Standarddomenet til din Deno Deploy-organisasjon (f.eks. acme.deno.net). Reléet vil være tilgjengelig på https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrer etter protokoll",
     "proxyFreePoolProtocol": "Protokoll",
     "proxyFreePoolCountryPlaceholder": "Land (f.eks. US)",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Kinakailangan ang domain ng organisasyon",
     "denoRelayDeployFailed": "Nabigo ang Deno Deploy",
     "denoRelayTokenHint": "Token ng organisasyon (prefix na ddo_) mula sa console.deno.com → Organization → Settings → Organization Tokens. Ginamit nang isang beses para sa pag-deploy at hindi kailanman iniimbak.",
-    "denoRelayOrgDomainHint": "Ang default na domain ng iyong organisasyon sa Deno Deploy (hal. acme.deno.net). Maaabot ang relay sa https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Ang default na domain ng iyong organisasyon sa Deno Deploy (hal. acme.deno.net). Maaabot ang relay sa https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "I-filter ayon sa protocol",
     "proxyFreePoolProtocol": "Protocol",
     "proxyFreePoolCountryPlaceholder": "Bansa (hal. US)",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Domena organizacji jest wymagana",
     "denoRelayDeployFailed": "Deno Deploy nie powiodło się",
     "denoRelayTokenHint": "Token organizacji (z prefiksem ddo_) z console.deno.com → Organization → Settings → Organization Tokens. Używany jednorazowo do wdrożenia i nigdy nieprzechowywany.",
-    "denoRelayOrgDomainHint": "Domyślna domena organizacji w Deno Deploy (np. acme.deno.net). Przekaźnik będzie dostępny pod adresem https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Domyślna domena organizacji w Deno Deploy (np. acme.deno.net). Przekaźnik będzie dostępny pod adresem https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtruj według protokołu",
     "proxyFreePoolProtocol": "Protokół",
     "proxyFreePoolCountryPlaceholder": "Kraj (np. US)",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -6404,7 +6404,7 @@
     "denoRelayOrgDomainRequired": "O domínio da organização é obrigatório",
     "denoRelayDeployFailed": "Falha no Deno Deploy",
     "denoRelayTokenHint": "Token da organização (prefixo ddo_) de console.deno.com → Organization → Settings → Organization Tokens. Usado uma vez para o deploy e nunca armazenado.",
-    "denoRelayOrgDomainHint": "O domínio padrão da sua organização no Deno Deploy (ex: acme.deno.net). O relay estará acessível em https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "O domínio padrão da sua organização no Deno Deploy (ex: acme.deno.net). O relay estará acessível em https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrar por protocolo",
     "proxyFreePoolProtocol": "Protocolo",
     "proxyFreePoolCountryPlaceholder": "País (ex.: US)",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "O domínio da organização é obrigatório",
     "denoRelayDeployFailed": "Falha no Deno Deploy",
     "denoRelayTokenHint": "Token de organização (prefixo ddo_) de console.deno.com → Organização → Definições → Tokens de Organização. Usado uma vez para o deploy e nunca armazenado.",
-    "denoRelayOrgDomainHint": "O domínio predefinido da sua organização do Deno Deploy (ex. acme.deno.net). O relay estará acessível em https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "O domínio predefinido da sua organização do Deno Deploy (ex. acme.deno.net). O relay estará acessível em https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrar por protocolo",
     "proxyFreePoolProtocol": "Protocolo",
     "proxyFreePoolCountryPlaceholder": "País (ex. US)",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Domeniul organizației este obligatoriu",
     "denoRelayDeployFailed": "Deno Deploy a eșuat",
     "denoRelayTokenHint": "Tokenul organizației (prefix ddo_) de la console.deno.com → Organization → Settings → Organization Tokens. Utilizat o singură dată pentru implementare și nu este stocat niciodată.",
-    "denoRelayOrgDomainHint": "Domeniul implicit al organizației tale Deno Deploy (de ex. acme.deno.net). Releul va fi accesibil la https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Domeniul implicit al organizației tale Deno Deploy (de ex. acme.deno.net). Releul va fi accesibil la https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrează după protocol",
     "proxyFreePoolProtocol": "Protocol",
     "proxyFreePoolCountryPlaceholder": "Țară (de ex. US)",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Требуется домен организации",
     "denoRelayDeployFailed": "Развертывание Deno Deploy не удалось",
     "denoRelayTokenHint": "Токен организации (префикс ddo_) из console.deno.com → Organization → Settings → Organization Tokens. Используется один раз для развертывания и нигде не сохраняется.",
-    "denoRelayOrgDomainHint": "Домен по умолчанию вашей организации Deno Deploy (например, acme.deno.net). Релей будет доступен по адресу https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Домен по умолчанию вашей организации Deno Deploy (например, acme.deno.net). Релей будет доступен по адресу https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Фильтровать по протоколу",
     "proxyFreePoolProtocol": "Протокол",
     "proxyFreePoolCountryPlaceholder": "Страна (например, US)",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Doména organizácie je povinná",
     "denoRelayDeployFailed": "Deno Deploy zlyhalo",
     "denoRelayTokenHint": "Token organizácie (predpona ddo_) z console.deno.com → Organization → Settings → Organization Tokens. Použije sa raz na nasadenie a nikdy sa neukladá.",
-    "denoRelayOrgDomainHint": "Predvolená doména vašej organizácie Deno Deploy (napr. acme.deno.net). Relay bude dostupný na https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Predvolená doména vašej organizácie Deno Deploy (napr. acme.deno.net). Relay bude dostupný na https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrovať podľa protokolu",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Krajina (napr. US)",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organisationsdomän krävs",
     "denoRelayDeployFailed": "Deno Deploy misslyckades",
     "denoRelayTokenHint": "Organisations-token (prefix ddo_) från console.deno.com → Organization → Settings → Organization Tokens. Används en gång för deploy och sparas aldrig.",
-    "denoRelayOrgDomainHint": "Din Deno Deploy-organisations standarddomän (t.ex. acme.deno.net). Reläet kommer att vara nåbart på https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Din Deno Deploy-organisations standarddomän (t.ex. acme.deno.net). Reläet kommer att vara nåbart på https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Filtrera efter protokoll",
     "proxyFreePoolProtocol": "Protokoll",
     "proxyFreePoolCountryPlaceholder": "Land (t.ex. US)",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Kikoa cha shirika kinahitajika",
     "denoRelayDeployFailed": "Deno Deploy imeshindwa",
     "denoRelayTokenHint": "Tokeni ya shirika (kiambishi awali ddo_) kutoka console.deno.com → Organization → Settings → Organization Tokens. Inatumika mara moja kwa usambazaji na haihifadhiwi kamwe.",
-    "denoRelayOrgDomainHint": "Kikoa chaguomsingi cha shirika lako la Deno Deploy (k.m. acme.deno.net). Kiunganishi kitafikiwa kwenye https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Kikoa chaguomsingi cha shirika lako la Deno Deploy (k.m. acme.deno.net). Kiunganishi kitafikiwa kwenye https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Chuja kwa itifaki",
     "proxyFreePoolProtocol": "Itifaki",
     "proxyFreePoolCountryPlaceholder": "Nchi (k.m. US)",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "நிறுவன டொமைன் தேவை",
     "denoRelayDeployFailed": "Deno Deploy தோல்வியடைந்தது",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens இலிருந்து பெறப்படும் நிறுவன டோக்கன் (முன்னொட்டு ddo_). வரிசைப்படுத்தலுக்கு ஒரு முறை மட்டுமே பயன்படுத்தப்படும் மற்றும் ஒருபோதும் சேமிக்கப்படாது.",
-    "denoRelayOrgDomainHint": "உங்கள் Deno Deploy நிறுவனத்தின் இயல்புநிலை டொமைன் (எ.கா. acme.deno.net). ரிலேவை https://<app-name>.<org-slug>.deno.net இல் அணுக முடியும்.",
+    "denoRelayOrgDomainHint": "உங்கள் Deno Deploy நிறுவனத்தின் இயல்புநிலை டொமைன் (எ.கா. acme.deno.net). ரிலேவை https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net இல் அணுக முடியும்.",
     "proxyFreePoolFilterProtocol": "புரோட்டோகால் மூலம் வடிகட்டவும்",
     "proxyFreePoolProtocol": "புரோட்டோகால்",
     "proxyFreePoolCountryPlaceholder": "நாடு (எ.கா. US)",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "సంస్థ డొమైన్ అవసరం",
     "denoRelayDeployFailed": "Deno Deploy విఫలమైంది",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens నుండి సంస్థ టోకెన్ (ప్రిఫిక్స్ ddo_). డిప్లాయ్ కోసం ఒకసారి ఉపయోగించబడుతుంది మరియు ఎప్పటికీ నిల్వ చేయబడదు.",
-    "denoRelayOrgDomainHint": "మీ Deno Deploy సంస్థ యొక్క డిఫాల్ట్ డొమైన్ (ఉదా. acme.deno.net). రిలే https://<app-name>.<org-slug>.deno.net వద్ద అందుబాటులో ఉంటుంది.",
+    "denoRelayOrgDomainHint": "మీ Deno Deploy సంస్థ యొక్క డిఫాల్ట్ డొమైన్ (ఉదా. acme.deno.net). రిలే https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net వద్ద అందుబాటులో ఉంటుంది.",
     "proxyFreePoolFilterProtocol": "ప్రోటోకాల్ ద్వారా ఫిల్టర్ చేయండి",
     "proxyFreePoolProtocol": "ప్రోటోకాల్",
     "proxyFreePoolCountryPlaceholder": "దేశం (ఉదా. US)",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "จำเป็นต้องมีโดเมนขององค์กร",
     "denoRelayDeployFailed": "Deno Deploy ล้มเหลว",
     "denoRelayTokenHint": "โทเค็นองค์กร (คำนำหน้า ddo_) จาก console.deno.com → Organization → Settings → Organization Tokens ใช้เพียงครั้งเดียวสำหรับการปรับใช้และจะไม่ถูกจัดเก็บ",
-    "denoRelayOrgDomainHint": "โดเมนเริ่มต้นขององค์กร Deno Deploy ของคุณ (เช่น acme.deno.net) รีเลย์จะสามารถเข้าถึงได้ที่ https://<app-name>.<org-slug>.deno.net",
+    "denoRelayOrgDomainHint": "โดเมนเริ่มต้นขององค์กร Deno Deploy ของคุณ (เช่น acme.deno.net) รีเลย์จะสามารถเข้าถึงได้ที่ https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net",
     "proxyFreePoolFilterProtocol": "กรองตามโปรโตคอล",
     "proxyFreePoolProtocol": "โปรโตคอล",
     "proxyFreePoolCountryPlaceholder": "ประเทศ (เช่น US)",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Organizasyon alanı gereklidir",
     "denoRelayDeployFailed": "Deno Deploy başarısız oldu",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens adresinden alınan organizasyon belirteci (ddo_ öneki). Dağıtım için bir kez kullanılır ve asla saklanmaz.",
-    "denoRelayOrgDomainHint": "Deno Deploy organizasyonunuzun varsayılan alanı (ör. acme.deno.net). Geçişe https://<app-name>.<org-slug>.deno.net adresinden erişilebilecektir.",
+    "denoRelayOrgDomainHint": "Deno Deploy organizasyonunuzun varsayılan alanı (ör. acme.deno.net). Geçişe https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net adresinden erişilebilecektir.",
     "proxyFreePoolFilterProtocol": "Protokole göre filtrele",
     "proxyFreePoolProtocol": "Protokol",
     "proxyFreePoolCountryPlaceholder": "Ülke (ör. US)",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "Домен організації обов'язковий",
     "denoRelayDeployFailed": "Збій Deno Deploy",
     "denoRelayTokenHint": "Токен організації (префікс ddo_) з console.deno.com → Організація → Налаштування → Токени організації. Використовується один раз для розгортання і ніколи не зберігається.",
-    "denoRelayOrgDomainHint": "Домен за замовчуванням вашої організації Deno Deploy (наприклад, acme.deno.net). Релей буде доступний за адресою https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Домен за замовчуванням вашої організації Deno Deploy (наприклад, acme.deno.net). Релей буде доступний за адресою https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Фільтрувати за протоколом",
     "proxyFreePoolProtocol": "Протокол",
     "proxyFreePoolCountryPlaceholder": "Країна (наприклад, US)",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "تنظیم کا ڈومین درکار ہے",
     "denoRelayDeployFailed": "Deno Deploy ناکام ہو گیا",
     "denoRelayTokenHint": "console.deno.com → Organization → Settings → Organization Tokens سے تنظیم کا ٹوکن (سابقہ ddo_)۔ تعیناتی کے لیے ایک بار استعمال ہوتا ہے اور کبھی محفوظ نہیں کیا جاتا۔",
-    "denoRelayOrgDomainHint": "آپ کی Deno Deploy تنظیم کا ڈیفالٹ ڈومین (مثال کے طور پر acme.deno.net)۔ ریلے تک رسائی https://<app-name>.<org-slug>.deno.net پر ممکن ہوگی۔",
+    "denoRelayOrgDomainHint": "آپ کی Deno Deploy تنظیم کا ڈیفالٹ ڈومین (مثال کے طور پر acme.deno.net)۔ ریلے تک رسائی https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net پر ممکن ہوگی۔",
     "proxyFreePoolFilterProtocol": "پروٹوکول کے ذریعے فلٹر کریں",
     "proxyFreePoolProtocol": "پروٹوکول",
     "proxyFreePoolCountryPlaceholder": "ملک (مثلاً US)",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -6404,7 +6404,7 @@
     "denoRelayOrgDomainRequired": "Yêu cầu phải có tên miền tổ chức",
     "denoRelayDeployFailed": "Triển khai Deno Deploy thất bại",
     "denoRelayTokenHint": "Token tổ chức (tiền tố ddo_) lấy từ console.deno.com → Organization → Settings → Organization Tokens. Chỉ được sử dụng một lần để triển khai và không bao giờ được lưu trữ.",
-    "denoRelayOrgDomainHint": "Tên miền mặc định của tổ chức Deno Deploy của bạn (ví dụ: acme.deno.net). Dịch vụ chuyển tiếp sẽ có thể truy cập tại https://<app-name>.<org-slug>.deno.net.",
+    "denoRelayOrgDomainHint": "Tên miền mặc định của tổ chức Deno Deploy của bạn (ví dụ: acme.deno.net). Dịch vụ chuyển tiếp sẽ có thể truy cập tại https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net.",
     "proxyFreePoolFilterProtocol": "Lọc theo giao thức",
     "proxyFreePoolProtocol": "Giao thức",
     "proxyFreePoolCountryPlaceholder": "Quốc gia (ví dụ: US)",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "组织域名为必填项",
     "denoRelayDeployFailed": "Deno Deploy 失败",
     "denoRelayTokenHint": "来自 console.deno.com → Organization → Settings → Organization Tokens 的组织令牌（前缀为 ddo_）。仅用于部署一次，绝不存储。",
-    "denoRelayOrgDomainHint": "您的 Deno Deploy 组织默认域名（例如 acme.deno.net）。中继将可通过 https://<app-name>.<org-slug>.deno.net 访问。",
+    "denoRelayOrgDomainHint": "您的 Deno Deploy 组织默认域名（例如 acme.deno.net）。中继将可通过 https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net 访问。",
     "proxyFreePoolFilterProtocol": "按协议筛选",
     "proxyFreePoolProtocol": "协议",
     "proxyFreePoolCountryPlaceholder": "国家（例如 US）",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -6402,7 +6402,7 @@
     "denoRelayOrgDomainRequired": "需要組織網域",
     "denoRelayDeployFailed": "Deno Deploy 失敗",
     "denoRelayTokenHint": "來自 console.deno.com → Organization → Settings → Organization Tokens 的組織令牌（前綴 ddo_）。僅在部署時使用一次，永不儲存。",
-    "denoRelayOrgDomainHint": "您的 Deno Deploy 組織的預設網域（例如 acme.deno.net）。轉發站位於 https://<app-name>.<org-slug>.deno.net。",
+    "denoRelayOrgDomainHint": "您的 Deno Deploy 組織的預設網域（例如 acme.deno.net）。轉發站位於 https://&lt;app-name&gt;.&lt;org-slug&gt;.deno.net。",
     "proxyFreePoolFilterProtocol": "按協議篩選",
     "proxyFreePoolProtocol": "協議",
     "proxyFreePoolCountryPlaceholder": "國家（例如 US）",

--- a/tests/unit/i18n-deno-relay-unclosed-tag.test.ts
+++ b/tests/unit/i18n-deno-relay-unclosed-tag.test.ts
@@ -1,0 +1,184 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const MESSAGES_DIR = path.resolve("src/i18n/messages");
+const KEY = "denoRelayOrgDomainHint";
+const RAW_APP_NAME = /<app-name>/;
+const RAW_ORG_SLUG = /<org-slug>/;
+const ENTITY_APP_NAME = "&lt;app-name&gt;";
+const ENTITY_ORG_SLUG = "&lt;org-slug&gt;";
+
+/**
+ * Regression guard for the UNCLOSED_TAG fix (INVALID_MESSAGE: UNCLOSED_TAG in
+ * React Flight parser). The `denoRelayOrgDomainHint` translation string
+ * contained literal `<app-name>` and `<org-slug>`, which the RSC Flight
+ * protocol parser interpreted as unclosed HTML tags, corrupting the payload
+ * and breaking the DenoRelayModal render.
+ *
+ * Fix: `<` and `>` were replaced with `&lt;` / `&gt;` in all 43 locale files,
+ * and BOM inserted by PowerShell's Set-Content was stripped.
+ *
+ * This suite guards against regressions across four axes:
+ *   1. Every locale file parses as valid JSON (no BOM, no syntax errors).
+ *   2. The `denoRelayOrgDomainHint` key exists in all 43 locales.
+ *   3. No locale still carries raw `<app-name>` or `<org-slug>` literals.
+ *   4. The key uses HTML entities `&lt;app-name&gt;.&lt;org-slug&gt;` everywhere.
+ */
+
+describe("i18n — denoRelayOrgDomainHint UNCLOSED_TAG regression", () => {
+  const localeFiles = fs
+    .readdirSync(MESSAGES_DIR)
+    .filter((f) => f.endsWith(".json"));
+  const expectedCount = 43;
+
+  // --- Test 1: JSON validity (no BOM, no parse errors) ---
+  it(`all ${expectedCount} locale JSON files are valid (no BOM, no parse errors)`, () => {
+    assert.equal(
+      localeFiles.length,
+      expectedCount,
+      `Expected ${expectedCount} locale files, found ${localeFiles.length}`,
+    );
+
+    const invalid: string[] = [];
+
+    for (const file of localeFiles) {
+      const fullPath = path.join(MESSAGES_DIR, file);
+      const raw = fs.readFileSync(fullPath, "utf8");
+
+      // BOM (U+FEFF) must not be present — it breaks JSON parsers and
+      // Next.js Turbopack module resolution.
+      if (raw.charCodeAt(0) === 0xfeff) {
+        invalid.push(`${file}: starts with BOM (U+FEFF)`);
+        continue;
+      }
+
+      try {
+        JSON.parse(raw);
+      } catch (err) {
+        invalid.push(`${file}: ${(err as Error).message}`);
+      }
+    }
+
+    assert.deepEqual(
+      invalid,
+      [],
+      `${invalid.length} invalid JSON file(s). First few: ${invalid.slice(0, 5).join("; ")}`,
+    );
+  });
+
+  // --- Test 2: key existence in all locales ---
+  it(`${KEY} key exists in all ${expectedCount} locales`, () => {
+    const missingKey: string[] = [];
+
+    for (const file of localeFiles) {
+      const content = JSON.parse(
+        fs.readFileSync(path.join(MESSAGES_DIR, file), "utf8"),
+      );
+      const flat = flatten(content);
+      // The key lives in a namespace (e.g. "settings.denoRelayOrgDomainHint")
+      // — match any path that ends with the target key name.
+      const found = Object.keys(flat).some((k) => k.endsWith(`.${KEY}`));
+      if (!found) {
+        missingKey.push(file);
+      }
+    }
+
+    assert.deepEqual(
+      missingKey,
+      [],
+      `${missingKey.length} locale(s) missing key "${KEY}": ${missingKey.join(", ")}`,
+    );
+  });
+
+  // --- Test 3: no raw <app-name> or <org-slug> anywhere ---
+  it(`no locale contains raw <app-name> or <org-slug> in any value`, () => {
+    const offenders: string[] = [];
+
+    for (const file of localeFiles) {
+      const raw = fs.readFileSync(path.join(MESSAGES_DIR, file), "utf8");
+      if (RAW_APP_NAME.test(raw)) {
+        offenders.push(`${file}: raw <app-name>`);
+      }
+      if (RAW_ORG_SLUG.test(raw)) {
+        offenders.push(`${file}: raw <org-slug>`);
+      }
+    }
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `${offenders.length} file(s) still carry raw angle-bracket placeholders: ${offenders.join(", ")}`,
+    );
+  });
+
+  // --- Test 4: correct HTML entities in every locale ---
+  it(`${KEY} uses &lt;app-name&gt;.&lt;org-slug&gt; in all locales`, () => {
+    const wrong: string[] = [];
+
+    for (const file of localeFiles) {
+      const content = JSON.parse(
+        fs.readFileSync(path.join(MESSAGES_DIR, file), "utf8"),
+      );
+      const flat = flatten(content);
+
+      // Find the full dotted path (e.g. "settings.denoRelayOrgDomainHint")
+      const fullPath = Object.keys(flat).find((k) => k.endsWith(`.${KEY}`));
+      if (!fullPath) {
+        wrong.push(`${file}: key "${KEY}" not found`);
+        continue;
+      }
+
+      const value = flat[fullPath];
+
+      if (typeof value !== "string") {
+        wrong.push(`${file}: value is ${typeof value}, expected string`);
+        continue;
+      }
+
+      if (!value.includes(ENTITY_APP_NAME)) {
+        wrong.push(`${file}: missing "${ENTITY_APP_NAME}"`);
+      }
+      if (!value.includes(ENTITY_ORG_SLUG)) {
+        wrong.push(`${file}: missing "${ENTITY_ORG_SLUG}"`);
+      }
+      // Double-check: the encoded value should contain the full URL pattern
+      if (!value.includes(`${ENTITY_APP_NAME}.${ENTITY_ORG_SLUG}`)) {
+        wrong.push(
+          `${file}: missing "${ENTITY_APP_NAME}.${ENTITY_ORG_SLUG}" sequence`,
+        );
+      }
+    }
+
+    assert.deepEqual(
+      wrong,
+      [],
+      `${wrong.length} locale(s) with wrong value for "${KEY}": ${wrong.slice(0, 10).join(", ")}`,
+    );
+  });
+});
+
+// --- helpers (mirror patterns from tests/unit/i18n-pt-br.test.ts) ---
+
+/**
+ * Flatten a nested JSON object into dotted-key paths.
+ * E.g. { settings: { denoRelayOrgDomainHint: "..." } } →
+ *      { "settings.denoRelayOrgDomainHint": "..." }
+ */
+function flatten(
+  obj: Record<string, unknown>,
+  prefix = "",
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    const v = obj[k];
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      Object.assign(out, flatten(v as Record<string, unknown>, key));
+    } else {
+      out[key] = v;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Problema
- Erro de console `INVALID_MESSAGE: UNCLOSED_TAG` ao renderizar a página `/dashboard/system/proxy`
- Causa: strings de tradução com colchetes angulares literais (`<app-name>`, `<org-slug>`) interpretados como tags HTML pelo protocolo RSC (React Flight) do Next.js, corrompendo a serialização do payload

## Correção
- Substituição de `<` por `&lt;` e `>` por `&gt;` na chave `denoRelayOrgDomainHint` em **todos** os 43 arquivos de mensagens de idioma (1 linha por arquivo)

## Escopo
- **43** × `src/i18n/messages/*.json` — apenas a chave `denoRelayOrgDomainHint`
- **1** × `tests/unit/i18n-deno-relay-unclosed-tag.test.ts` — suite de regressão (novo)

## Testes
Suite `tests/unit/i18n-deno-relay-unclosed-tag.test.ts` — **4/4 passando**:
1. Todos os 43 arquivos JSON são válidos (sem BOM, sem erro de parse)
2. A chave `denoRelayOrgDomainHint` existe em todos os 43 idiomas
3. Nenhum locale contém `<app-name>` ou `<org-slug>` literal
4. A chave usa `&lt;app-name&gt;.&lt;org-slug&gt;` em todos os idiomas

## Cherry-pick (1 commit limpo, rebaseado no topo de `release/v3.8.50`)
```bash
git cherry-pick 4afa4bbb4
```

Branch: `AgnesRiber:fix/deno-relay-unclosed-tag` → `release/v3.8.50`
Diff: **43 files × 1 linha + 1 teste novo** — sem conflitos.