### PR TITLE
[TS7] fix(types): normalize stream usage before cost calculation

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -8,6 +8,7 @@ import {
   logUsage,
   addBufferToUsage,
   filterUsageForFormat,
+  normalizeUsage as normalizeTokenUsage,
 } from "./usageTracking.ts";
 import {
   parseSSELine,
@@ -1012,7 +1013,9 @@ export function createSSEStream(options: StreamOptions = {}) {
     // JSON.parse every SSE line will crash on `: x-omniroute-*` comment lines.
     if (!sseCommentsEnabled()) return;
 
-    const costUsd = finalUsage ? await calculateCost(provider, model, finalUsage) : 0;
+    const costUsd = finalUsage
+      ? await calculateCost(provider, model, normalizeTokenUsage(finalUsage))
+      : 0;
     const comment = buildOmniRouteSseMetadataComment({
       provider,
       model,

--- a/tests/unit/usage-extractor.test.ts
+++ b/tests/unit/usage-extractor.test.ts
@@ -2,7 +2,19 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { extractUsageFromResponse } = await import("../../open-sse/handlers/usageExtractor.ts");
-const { extractUsage } = await import("../../open-sse/utils/usageTracking.ts");
+const { extractUsage, normalizeUsage } = await import("../../open-sse/utils/usageTracking.ts");
+
+test("normalizeUsage keeps only finite numeric fields for stream cost calculation", () => {
+  assert.deepEqual(
+    normalizeUsage({
+      input_tokens: "12",
+      output_tokens: 3,
+      total_tokens: Number.POSITIVE_INFINITY,
+      input_tokens_details: { cached_tokens: 2 },
+    }),
+    { input_tokens: 12, output_tokens: 3 }
+  );
+});
 
 test("extractUsageFromResponse reads OpenAI chat completion usage", () => {
   const usage = extractUsageFromResponse(


### PR DESCRIPTION
## Summary\n\n- reuse the existing usage normalizer before passing streaming usage to cost calculation\n- retain finite token and provider-reported cost fields while excluding non-numeric metadata\n- remove one TS6 and one TypeScript 7 diagnostic without adding new errors\n\nTracks #8484.\n\n## Validation\n\n- [Migration] ⚠️  CRITICAL: 1 migration version(s) have been renumbered!
  Version 140: applied as "retired_provider_purge" but disk has "connection_runtime_state"
[Migration] This indicates migrations were renumbered between releases, which can cause the migration runner to skip or re-run migrations incorrectly.
[Migration] The version-only tracking will skip these (version already applied), but please report this to the OmniRoute maintainers.
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /Users/backryun/.omniroute/storage.sqlite (DATA_DIR=/Users/backryun/.omniroute, SQLITE_FILE=/Users/backryun/.omniroute/storage.sqlite)
✔ normalizeUsage keeps only finite numeric fields for stream cost calculation (0.69075ms)
✔ extractUsageFromResponse reads OpenAI chat completion usage (0.109708ms)
✔ extractUsageFromResponse reads OpenAI usage when cache/reasoning live under input/output token details (0.053166ms)
✔ extractUsageFromResponse defaults missing OpenAI token fields to zero (0.060416ms)
✔ extractUsageFromResponse reads Responses API usage from the top-level usage field (0.061458ms)
✔ extractUsageFromResponse reads Responses API usage from nested response.usage (0.047583ms)
✔ extractUsageFromResponse reads Responses API usage with prompt_tokens_details (OpenAI hybrid format) (0.046625ms)
✔ extractUsageFromResponse reads Responses API cache_read_input_tokens as cached_tokens fallback (0.041959ms)
✔ extractUsageFromResponse totals Claude prompt tokens with cache read and cache creation (0.060208ms)
✔ extractUsageFromResponse surfaces Claude thinking tokens without inflating completion (0.087625ms)
✔ extractUsageFromResponse reads Gemini usageMetadata and thinking tokens (0.055625ms)
✔ extractUsageFromResponse returns null when usage is missing (0.051041ms)
✔ extractUsageFromResponse returns null for null and undefined response bodies (0.033417ms)
✔ extractUsageFromResponse returns null for non-object response bodies (0.025583ms)
✔ extractUsage reads response.completed with prompt_tokens_details.cached_tokens (0.103041ms)
✔ extractUsage surfaces Claude message_delta thinking tokens (0.040042ms)
✔ extractUsage reads response.done with input_tokens_details and output_tokens_details (0.032333ms)
✔ extractUsage reads response.completed with cache_read_input_tokens (0.034541ms)
✔ extractUsage reads OpenAI streaming chunk with prompt_tokens_details (0.045167ms)
✔ extractUsageFromResponse reads flat cached_tokens and reasoning_tokens from OpenAI-compatible usage (0.048208ms)
✔ extractUsage reads flat cached_tokens and reasoning_tokens from streaming chunk (0.0345ms)
✔ extractUsage reads Ollama raw NDJSON final chunk (done + prompt_eval_count/eval_count) (0.050792ms)
✔ extractUsage defaults missing Ollama eval counts to zero (0.031375ms)
✔ extractUsage ignores non-final Ollama NDJSON chunks (done=false) (0.022ms)
✔ extractUsage reads top-level Gemini usageMetadata from a streaming chunk (0.031958ms)
✔ extractUsage reads Antigravity usageMetadata wrapped inside a response envelope (0.038625ms)
ℹ tests 26
ℹ suites 0
ℹ pass 26
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 335.597375\n- 
> omniroute@3.8.50 lint
> eslint . --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json\n- 
> omniroute@3.8.50 check:file-size
> node scripts/check/check-file-size.mjs

[file-size] OK — 129 arquivos congelados, cap 1000 para novos (3986 arquivos verificados)
[test-file-size] OK — 46 test files congelados, testCap 1000 para novos (4265 test files verificados)\n- TS6: 51 -> 50, removed 1, added 0\n- TypeScript 7.0.2: 50 -> 49, removed 1, added 0\n- combined eight-PR overlay: TS6 51 -> 39; TS7 50 -> 39; added 0