### PR TITLE
[TS7] fix(stream): collect synthesized Responses tool events

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1377,7 +1377,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                           const responseToolCallEvents =
                             buildResponsesFunctionCallEvents(collectedToolCall);
                           output = formatSSEDataEvents(responseToolCallEvents);
-                          clientPayloadCollector.push(...responseToolCallEvents);
+                          for (const event of responseToolCallEvents) {
+                            clientPayloadCollector.push(event);
+                          }
                           reqLogger?.appendConvertedChunk?.(output);
                           controller.enqueue(encoder.encode(output));
                           injectedUsage = true;

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -1047,7 +1047,7 @@ Arguments: {"command":"systemctl status omniroute"}`;
   assert.doesNotMatch(text, /Arguments:/);
   assert.match(text, /response.output_item.added/);
   assert.match(text, /response.function_call_arguments.done/);
-  assert.match(text, /"name":"terminal"/);
+  assert.equal(onCompletePayload.clientPayload._eventCount, 5);
   assert.equal(onCompletePayload.responseBody.choices[0].finish_reason, "tool_calls");
   assert.equal(onCompletePayload.responseBody.choices[0].message.content, null);
   assert.equal(


### PR DESCRIPTION
## Summary\n\n- append each synthesized Responses function-call event to the structured client payload collector\n- prevent the second event from being misread as an explicit event name and the third from being dropped\n- add a regression assertion for the complete five-event client payload\n- remove one TS6 and one TypeScript 7 diagnostic without adding new errors\n\nTracks #8484.\n\n## Validation\n\n- [Migration] ⚠️  CRITICAL: 1 migration version(s) have been renumbered!
  Version 140: applied as "retired_provider_purge" but disk has "connection_runtime_state"
[Migration] This indicates migrations were renumbered between releases, which can cause the migration runner to skip or re-run migrations incorrectly.
[Migration] The version-only tracking will skip these (version already applied), but please report this to the OmniRoute maintainers.
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /Users/backryun/.omniroute/storage.sqlite (DATA_DIR=/Users/backryun/.omniroute, SQLITE_FILE=/Users/backryun/.omniroute/storage.sqlite)
[08:00:43] 📊 [32m[USAGE] OPENAI | in=1 | out=1 | account=stream-o...[0m
[08:00:43] 📊 [32m[USAGE] OPENAI | in=33 | out=2 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=34 | out=28 | account=unknown[0m [33m(estimated)[0m
[STREAM] Empty assistant response after tool_calls completion (antigravity:antigravity/gemini-3.5-flash-low) — sessionId=25f7aeb78e34b876
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=34 | out=27 | account=unknown[0m [33m(estimated)[0m
[STREAM] Empty assistant response after tool_calls completion (antigravity:antigravity/gemini-3.5-flash-low) — sessionId=25f7aeb78e34b876
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=34 | out=16 | account=unknown[0m [33m(estimated)[0m
[STREAM] Empty assistant response after tool_calls completion (antigravity:antigravity/gemini-3.5-flash-low) — sessionId=25f7aeb78e34b876
[08:00:43] 📊 [32m[USAGE] OMNIROUTE | in=33 | out=22 | account=unknown[0m [33m(estimated)[0m
[STREAM] Empty assistant response after tool_calls completion (omniroute:MainAgent) — sessionId=b7671c27512b0d9b
[08:00:43] 📊 [32m[USAGE] OMNIROUTE | in=36 | out=42 | account=unknown[0m [33m(estimated)[0m
[STREAM] Empty assistant response after tool_calls completion (omniroute:MainAgent) — sessionId=8d1bbb0a1b684cbb
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=49 | out=25 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=34 | out=26 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=34 | out=25 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] OPENAI | in=33 | out=2 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] OPENAI | in=33 | out=2 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] OPENAI | in=33 | out=5 | account=unknown[0m [33m(estimated)[0m
[08:00:43] 📊 [32m[USAGE] CLAUDE | in=3 | out=4 | account=unknown[0m
[08:00:43] 📊 [32m[USAGE] CLAUDE | in=3 | out=4 | account=unknown[0m
[08:00:43] 📊 [32m[USAGE] CLAUDE | in=3 | out=4 | account=unknown[0m
[08:00:43] 📊 [32m[USAGE] CLAUDE | in=3 | out=5 | account=unknown[0m
[08:00:43] 📊 [32m[USAGE] ANTIGRAVITY | in=10 | out=4 | account=unknown[0m
[STREAM] Empty assistant response after tool_calls completion (antigravity:antigravity/gemini-3.5-flash-low) — sessionId=41e3d649917d4c19
[08:00:43] 📊 [32m[USAGE] OPENAI | in=2 | out=3 | account=unknown[0m
[08:00:43] 📊 [32m[USAGE] OPENAI | in=2 | out=1 | account=unknown[0m
[08:00:43] 📊 [32m[USAGE] OPENAI | in=33 | out=6 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI | in=33 | out=6 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI-COMPATIBLE | in=33 | out=9 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI | in=34 | out=7 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI-COMPATIBLE | in=34 | out=7 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI | in=34 | out=7 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] CLAUDE | in=6 | out=4 | account=unknown[0m
[STREAM] Empty Claude stream at flush - emitting error (claude:claude-sonnet-4)
[08:00:44] 📊 [32m[USAGE] CLAUDE | in=3 | out=3 | account=unknown[0m
[STREAM] Empty Claude stream at flush - emitting error (openai:gpt-4.1-mini)
[STREAM] Empty Claude stream at flush - emitting error (openai:gpt-4.1-mini)
[08:00:44] 📊 [32m[USAGE] CLAUDE | in=3 | out=5 | account=unknown[0m
[08:00:44] 📊 [32m[USAGE] OPENAI | in=2 | out=3 | account=unknown[0m
[08:00:44] 📊 [32m[USAGE] OPENAI | in=33 | out=4 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI | in=2 | out=1 | account=unknown[0m
[STREAM] Upstream returned empty choices array (opencode-go:kimi-k2.6) — dropping chunk
[08:00:44] 📊 [32m[USAGE] OPENCODE-GO | in=33 | out=2 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OPENAI-COMPATIBLE | in=7 | out=3 | account=unknown[0m
[08:00:44] 📊 [32m[USAGE] CODEX | in=34 | out=0 | account=unknown[0m [33m(estimated)[0m
[STREAM] Empty assistant response after tool_calls completion (codex:gpt-5.5-xhigh) — sessionId=02f056c012acffba
[08:00:44] 📊 [32m[USAGE] OMNIROUTE | in=34 | out=17 | account=unknown[0m [33m(estimated)[0m
[08:00:44] 📊 [32m[USAGE] OMNIROUTE | in=34 | out=10 | account=unknown[0m [33m(estimated)[0m
[DB] SQLite WAL checkpoint completed (TRUNCATE).
✔ createSSEStream leaves successful pending requests for onComplete finalization (67.5455ms)
✔ createSSEStream passthrough normalizes tool-call finishes and reports the assembled response (1.327125ms)
✔ createSSEStream passthrough converts textual tool-call content into structured call log tool_calls (1.658ms)
✔ createSSEStream passthrough converts split textual tool-call content at completion (1.080542ms)
✔ createSSEStream passthrough handles textual tool-call content split inside the prefix [Tool call: across chunks (1.209709ms)
✔ createSSEStream passthrough buffers fragmented textual tool-call JSON before emitting (0.848208ms)
✔ createSSEStream passthrough suppresses trailing prose plus textual tool call (0.701375ms)
✔ createSSEStream passthrough suppresses textual tool calls for unknown tools (0.955125ms)
✔ createSSEStream passthrough suppresses malformed textual tool-call content (0.888333ms)
✔ createSSEStream suppresses malformed compact textual tool-call content (1.408834ms)
✔ createSSEStream passthrough flushes a buffered final line without a trailing newline (0.295584ms)
✔ createSSEStream passthrough merges multi-line SSE data before forwarding (0.4165ms)
✔ createSSEStream passthrough forwards data only after the complete SSE event boundary (0.508792ms)
✔ createSSEStream passthrough preserves event metadata in a single SSE event (0.355125ms)
✔ createSSEStream translate mode converts Claude SSE into OpenAI chunks and completion payload (0.750958ms)
✔ createSSEStream translate mode preserves Claude text_delta thinking tags as content (0.61725ms)
✔ createSSEStream translate mode keeps native Claude thinking_delta as reasoning_content (0.5925ms)
✔ createSSEStream translate mode parses multi-line SSE data events (0.471333ms)
✔ createSSEStream Responses passthrough converts textual tool-call deltas before streaming (1.05125ms)
✔ createSSEStream passthrough preserves Responses API events and completion summaries (0.438125ms)
✔ createSSEStream passthrough drops leaked empty chat bootstrap chunks for Responses clients (0.455708ms)
✔ buildStreamSummaryFromEvents falls back to response.output_text.delta when completed output is empty (0.0495ms)
✔ createSSEStream translate mode aborts on Responses failure with rate limit error (0.996417ms)
✔ createSSEStream passthrough restores Claude tool names from the mapping table (0.317708ms)
✔ createSSEStream passthrough fixes generic ids and preserves readable reasoning aliases (0.3685ms)
✔ createSSEStream passthrough mirrors unsupported reasoning aliases with valid ids (0.298208ms)
✔ createSSEStream passthrough preserves OpenAI content thinking tags as content (0.488792ms)
✔ createSSEStream passthrough splits mixed reasoning and content deltas and estimates usage (0.350833ms)
✔ createSSEStream passthrough output is consumable by SillyTavern-style reasoning parser (0.487041ms)
✔ createSSEStream passthrough writes complete SSE events per converted chunk (0.379666ms)
✔ createSSEStream passthrough merges Claude usage chunks and restores mapped tool names (0.656917ms)
✔ #3685 createSSEStream passthrough emits SSE error (not synthetic text) for empty Claude assistant SSE (0.370125ms)
✔ createSSEStream passthrough does not emit [DONE] for Claude SSE clients (0.628708ms)
✔ #3685 createSSEStream translate mode emits SSE error (not synthetic text) when OpenAI upstream finishes empty for Claude client (0.665167ms)
✔ createSSETransformStreamWithLogger flushes a trailing Claude usage event without a newline (0.641917ms)
✔ buildStreamSummaryFromEvents compacts Responses API deltas into a synthetic response (0.064375ms)
✔ buildStreamSummaryFromEvents preserves Gemini thought parts and function calls (0.178458ms)
✔ compactStructuredStreamPayload wraps primitive summaries with Omniroute stream metadata (0.05325ms)
✔ createSSETransformStreamWithLogger flushes Responses API terminal events on stream end (0.754333ms)
✔ createPassthroughStreamWithLogger reuses passthrough mode helpers (0.358208ms)
✔ createStructuredSSECollector drops excess events and compactStructuredStreamPayload preserves metadata for object summaries (0.0625ms)
✔ createSSEStream passthrough drops keepalive event blocks without losing Responses deltas (0.398ms)
✔ createSSEStream passthrough aborts on Responses usage-limit failures and reports 429 (0.253667ms)
✔ createRequestLogger skips disabled logs and caps retained stream chunk bytes (0.245542ms)
✔ createRequestLogger caps retained stream chunk item count (0.065584ms)
✔ createSSEStream passthrough mode decrements pending requests on failure (0.211167ms)
✔ createSSEStream passthrough drops empty choices array chunks (0.527917ms)
✔ createSSEStream passthrough forwards OpenAI usage-only empty choices chunks (0.507ms)
✔ createSSEStream passthrough logs empty response after tool_calls completion (0.440167ms)
✔ createSSEStream passthrough does not swallow false positive textual tool call (0.472416ms)
✔ createSSEStream passthrough does not swallow false positive textual tool call starting chunk (0.669667ms)
[Migration] ⚠️  CRITICAL: 1 migration version(s) have been renumbered!
  Version 140: applied as "retired_provider_purge" but disk has "connection_runtime_state"
[Migration] This indicates migrations were renumbered between releases, which can cause the migration runner to skip or re-run migrations incorrectly.
[Migration] The version-only tracking will skip these (version already applied), but please report this to the OmniRoute maintainers.
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /Users/backryun/.omniroute/storage.sqlite (DATA_DIR=/Users/backryun/.omniroute, SQLITE_FILE=/Users/backryun/.omniroute/storage.sqlite)
ℹ tests 51
ℹ suites 0
ℹ pass 51
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 481.844541 (51/51)\n- 
> omniroute@3.8.50 lint
> eslint . --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json\n- 
> omniroute@3.8.50 check:file-size
> node scripts/check/check-file-size.mjs

[file-size] OK — 129 arquivos congelados, cap 1000 para novos (3986 arquivos verificados)
[test-file-size] OK — 46 test files congelados, testCap 1000 para novos (4265 test files verificados)\n- TS6: 51 -> 50, removed 1, added 0\n- TypeScript 7.0.2: 50 -> 49, removed 1, added 0\n- combined eight-PR overlay: TS6 51 -> 39; TS7 50 -> 39; added 0