### PR TITLE
[TS7] fix(types): complete Responses stream failure contract

### DIFF
--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -63,6 +63,7 @@ export async function handleResponsesCore({
     connectionId,
     userAgent: null,
     comboName: null,
+    onStreamFailure: null,
   });
 
   // handleChatCore's union includes a bare Response (early returns that never

--- a/tests/unit/responses-handler.test.ts
+++ b/tests/unit/responses-handler.test.ts
@@ -367,8 +367,8 @@ test("handleResponsesCore transforms Command Code executor SSE through Responses
   assert.match(sse, /data: \[DONE\]/);
 });
 
-test("handleResponsesCore propagates upstream failures from chatCore unchanged", async () => {
-  const { result } = await invokeResponsesCore({
+test("handleResponsesCore propagates upstream failures without retrying", async () => {
+  const { result, calls } = await invokeResponsesCore({
     body: {
       model: "gpt-4o-mini",
       input: "hello",
@@ -382,6 +382,7 @@ test("handleResponsesCore propagates upstream failures from chatCore unchanged",
 
   assert.equal(result.success, false);
   assert.equal(result.status, 401);
+  assert.equal(calls.length, 1);
 
   const payload = (await result.response.json()) as ErrorPayload;
   assert.equal(payload.error.message, "[401]: unauthorized");


### PR DESCRIPTION
## Summary\n\n- explicitly opt the Responses shim out of chatCore stream-failure callbacks\n- preserve the existing single-attempt upstream failure behavior\n- remove one TS6 and one TypeScript 7 diagnostic without adding new errors\n\nTracks #8484.\n\n## Validation\n\n- [DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[CREDENTIALS] Could not load dataPaths module, using fallback: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr
[CREDENTIALS] No external credentials file found, using defaults.
[INFO] [PLUGIN_MANAGER] manager.loadAll {"count":0}
[08:00:44] 📊 [32m[USAGE] OPENAI | in=4 | out=2 | account=unknown[0m
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:45] 🌊 [STREAM] OPENAI | gpt-4o-mini | 97ms | complete
[08:00:45] 📊 [32m[USAGE] KIMI-CODING-APIKEY | in=4 | out=2 | account=unknown[0m
[08:00:45] 🌊 [STREAM] KIMI-CODING-APIKEY | k3-256k | 6ms | error: Provider returned empty content
[08:00:45] 📊 [32m[USAGE] MOONSHOT | in=4 | out=2 | account=unknown[0m
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:45] 🌊 [STREAM] MOONSHOT | kimi-k3 | 58ms | complete
[08:00:45] 📊 [32m[USAGE] OPENAI | in=4 | out=2 | account=unknown[0m
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:45] 🌊 [STREAM] OPENAI | gpt-4o-mini | 59ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:45] 📊 [32m[USAGE] CODEX | in=4 | out=2 | account=unknown[0m
[08:00:45] 🌊 [STREAM] CODEX | gpt-5.3-codex | 60ms | error: Provider returned empty content
[08:00:45] 📊 [32m[USAGE] OPENAI | in=4 | out=2 | account=unknown[0m
[08:00:45] 🌊 [STREAM] OPENAI | gpt-4o-mini | 3ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:45] 📊 [32m[USAGE] COMMAND-CODE | in=255 | out=5 | account=unknown[0m [33m(estimated)[0m
[08:00:45] 🌊 [STREAM] COMMAND-CODE | gpt-5.4-mini | 5ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
✔ handleResponsesCore converts Responses API input, instructions, tools, metadata, and forces streaming (346.719583ms)
✔ handleResponsesCore preserves Kimi K3 reasoning through provider translation (75.327292ms)
✔ handleResponsesCore strips previous_response_id by default and handles empty input arrays (63.242541ms)
✔ handleResponsesCore preserves store for Codex responses when connection opt-in is enabled (65.281625ms)
✔ handleResponsesCore transforms upstream OpenAI SSE into Responses API SSE (12.104417ms)
✔ handleResponsesCore transforms Command Code executor SSE through Responses shim (64.511958ms)
[31m[ERROR] [401]: unauthorized[0m
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[STREAM] Empty assistant response after tool_calls completion (openai:gpt-4o-mini) — sessionId=f0330e2ef57835d2
[08:00:48] 🌊 [STREAM] OPENAI | gpt-4o-mini | 2ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[STREAM] Empty assistant response after tool_calls completion (openai:gpt-4o-mini) — sessionId=f0330e2ef57835d2
[08:00:48] 🌊 [STREAM] OPENAI | gpt-4o-mini | 3ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[STREAM] Empty assistant response after tool_calls completion (openai:gpt-4o-mini) — sessionId=301d71264310ad6f
[08:00:48] 🌊 [STREAM] OPENAI | gpt-4o-mini | 2ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:48] 📊 [32m[USAGE] OPENAI | in=4 | out=2 | account=unknown[0m
[08:00:48] 🌊 [STREAM] OPENAI | gpt-4o-mini | 3ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
[DB] Added usage_history.combo_strategy column
[DB] Added call_logs.model_pinned column
[DB] Added call_logs.session_tag column
[DB] Changing cache_size from 65536KB to 16384KB
[DB] cache_size changed to 16384KB
[DB] SQLite database ready: /var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite (DATA_DIR=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr, SQLITE_FILE=/var/folders/x8/kkjsd00s0sv14wzpgsnhjbhm0000gn/T/omniroute-responses-handler-mSWMvr/storage.sqlite)
[08:00:48] 📊 [32m[USAGE] OPENAI | in=4 | out=2 | account=unknown[0m
[08:00:48] 🌊 [STREAM] OPENAI | gpt-4o-mini | 2ms | complete
[DB] SQLite WAL checkpoint completed (TRUNCATE).
✔ handleResponsesCore propagates upstream failures without retrying (3076.275708ms)
✔ handleResponsesCore rejects invalid Responses API input that cannot be translated (2.4895ms)
✔ handleResponsesCore restores custom tools declared through additional_tools (81.233125ms)
✔ handleResponsesCore preserves top-level tool precedence for custom-name collisions (55.238334ms)
✔ handleResponsesCore restores custom tools nested in namespaces (54.855375ms)
✔ handleResponsesCore injects SSE keepalive frames for Responses streams (57.267959ms)
✔ handleResponsesCore clears heartbeat timers immediately when the request signal aborts (56.794208ms)
ℹ tests 13
ℹ suites 0
ℹ pass 13
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5169.403\n- 
> omniroute@3.8.50 lint
> eslint . --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json\n- 
> omniroute@3.8.50 check:file-size
> node scripts/check/check-file-size.mjs

[file-size] OK — 129 arquivos congelados, cap 1000 para novos (3986 arquivos verificados)
[test-file-size] OK — 46 test files congelados, testCap 1000 para novos (4265 test files verificados)\n- TS6: 51 -> 50, removed 1, added 0\n- TypeScript 7.0.2: 50 -> 49, removed 1, added 0\n- combined eight-PR overlay: TS6 51 -> 39; TS7 50 -> 39; added 0