### PR TITLE
fix(copilot-web): restore browser authentication

### DIFF
--- a/electron/lib/loginHeaderCapture.js
+++ b/electron/lib/loginHeaderCapture.js
@@ -1,0 +1,17 @@
+"use strict";
+
+function captureConfiguredHeaders(tokenSources, requestHeaders, credentials) {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(requestHeaders || {}).map(([name, value]) => [name.toLowerCase(), value])
+  );
+
+  for (const source of tokenSources || []) {
+    if (source.type !== "header" || credentials[source.name]) continue;
+    const value = normalizedHeaders[source.name.toLowerCase()];
+    if (typeof value === "string" && value.trim()) {
+      credentials[source.name] = value.trim();
+    }
+  }
+}
+
+module.exports = { captureConfiguredHeaders };

--- a/electron/loginManager.js
+++ b/electron/loginManager.js
@@ -12,6 +12,7 @@
 const { BrowserWindow, session } = require("electron");
 const { EventEmitter } = require("events");
 const path = require("path");
+const { captureConfiguredHeaders } = require("./lib/loginHeaderCapture");
 
 // In production, the tokenExtractionConfig is bundled under open-sse/services/.
 // We resolve relative to the Electron resources path.
@@ -42,6 +43,7 @@ class LoginManager extends EventEmitter {
     this.isCompleted = false;
     this.pollIntervalId = null;
     this.loginSession = null;
+    this.headerCredentials = {};
   }
 
   /**
@@ -124,6 +126,13 @@ class LoginManager extends EventEmitter {
     });
 
     const winSession = this.window.webContents.session;
+    const headerSources = config.tokenSources.filter((source) => source.type === "header");
+    if (headerSources.length > 0) {
+      winSession.webRequest.onBeforeSendHeaders((details, callback) => {
+        captureConfiguredHeaders(headerSources, details.requestHeaders, this.headerCredentials);
+        callback({ requestHeaders: details.requestHeaders });
+      });
+    }
 
     // Track navigation for success URL detection
     let navigatedToLogin = false;
@@ -235,14 +244,15 @@ class LoginManager extends EventEmitter {
           if (this.isCompleted) return;
 
           const tokenSources = config.tokenSources;
-          const credentials = {};
+          const credentials = { ...this.headerCredentials };
 
           // Collect all cookie-based sources
           const cookieSources = tokenSources.filter((s) => s.type === "cookie");
           for (const source of cookieSources) {
             const domain = source.domain || undefined;
             const matched = cookies.find(
-              (c) => c.name === source.name && (!domain || c.domain.includes(domain.replace(/^\./, "")))
+              (c) =>
+                c.name === source.name && (!domain || c.domain.includes(domain.replace(/^\./, "")))
             );
             if (matched) {
               credentials[source.name] = matched.value;
@@ -253,10 +263,12 @@ class LoginManager extends EventEmitter {
           const storageSources = tokenSources.filter(
             (s) => s.type === "localStorage" || s.type === "sessionStorage"
           );
+          const headerSources = tokenSources.filter((s) => s.type === "header");
 
           if (storageSources.length > 0 && this.window && !this.window.isDestroyed()) {
             // Execute JS to extract all localStorage/sessionStorage tokens
-            const storageType = storageSources[0].type === "localStorage" ? "localStorage" : "sessionStorage";
+            const storageType =
+              storageSources[0].type === "localStorage" ? "localStorage" : "sessionStorage";
             const keys = storageSources.map((s) => s.key);
             const js = `(() => {
               const res = {};
@@ -272,13 +284,37 @@ class LoginManager extends EventEmitter {
                 if (values && typeof values === "object") {
                   Object.assign(credentials, values);
                 }
-                this._checkCredentials(providerId, credentials, cookieSources, storageSources, poll, pollInterval);
+                this._checkCredentials(
+                  providerId,
+                  credentials,
+                  cookieSources,
+                  storageSources,
+                  headerSources,
+                  poll,
+                  pollInterval
+                );
               })
               .catch(() => {
-                this._checkCredentials(providerId, credentials, cookieSources, storageSources, poll, pollInterval);
+                this._checkCredentials(
+                  providerId,
+                  credentials,
+                  cookieSources,
+                  storageSources,
+                  headerSources,
+                  poll,
+                  pollInterval
+                );
               });
           } else {
-            this._checkCredentials(providerId, credentials, cookieSources, storageSources, poll, pollInterval);
+            this._checkCredentials(
+              providerId,
+              credentials,
+              cookieSources,
+              storageSources,
+              headerSources,
+              poll,
+              pollInterval
+            );
           }
         })
         .catch(() => {
@@ -295,23 +331,35 @@ class LoginManager extends EventEmitter {
   /**
    * Check if we have all required credentials, otherwise continue polling
    */
-  _checkCredentials(providerId, credentials, cookieSources, storageSources, poll, pollInterval) {
+  _checkCredentials(
+    providerId,
+    credentials,
+    cookieSources,
+    storageSources,
+    headerSources,
+    poll,
+    pollInterval
+  ) {
     if (this.isCompleted) return;
 
     // Collect the required source names/keys
     const requiredKeys = [
       ...cookieSources.map((s) => s.name),
       ...storageSources.map((s) => s.key),
+      ...headerSources.map((s) => s.name),
     ];
     const foundKeys = Object.keys(credentials);
     const allFound = requiredKeys.every((k) => foundKeys.includes(k));
 
     if (allFound && foundKeys.length > 0) {
       // Success — all credentials extracted
-      this._completeLogin(providerId, foundKeys.reduce((acc, k) => {
-        acc[k] = credentials[k];
-        return acc;
-      }, {}));
+      this._completeLogin(
+        providerId,
+        foundKeys.reduce((acc, k) => {
+          acc[k] = credentials[k];
+          return acc;
+        }, {})
+      );
     } else if (!this.isCompleted) {
       // Continue polling using the configured interval
       this.pollIntervalId = setTimeout(poll, pollInterval);
@@ -373,6 +421,7 @@ class LoginManager extends EventEmitter {
     }
     this.window = null;
     this.loginSession = null;
+    this.headerCredentials = {};
   }
 
   /**

--- a/open-sse/executors/copilot-web.ts
+++ b/open-sse/executors/copilot-web.ts
@@ -99,16 +99,41 @@ export function solveHashcash(parameter: string, difficulty: number): number | n
 }
 
 export function extractAccessToken(credential: string): string | null {
-  if (!credential) return null;
-  // Direct token
-  if (credential.startsWith("ey") || credential.length > 100) return credential;
-  // Try parsing as cookie string — look for _EDGE_S or similar
-  const match = credential.match(/access_token=([^;]+)/);
-  if (match) return match[1];
-  // Try HAR-extracted bearer
-  const bearerMatch = credential.match(/[Bb]earer\s+(.+)/);
+  const trimmed = credential?.trim();
+  if (!trimmed) return null;
+
+  // Parse structured input before applying the direct-token heuristic. Real
+  // DevTools cookie/HAR exports routinely exceed 100 characters.
+  const accessTokenMatch = trimmed.match(
+    /(?:^|[\s;,{"'])access_token\s*[=:]\s*["']?([^\s;,}"']+)/i
+  );
+  if (accessTokenMatch) return accessTokenMatch[1];
+
+  const bearerMatch = trimmed.match(/(?:^|[\s:{"'])bearer\s+([^\s,}"';]+)/i);
   if (bearerMatch) return bearerMatch[1];
-  return credential;
+
+  // A named cookie is not an OAuth access token. Reject it instead of sending
+  // the full cookie value as `Authorization: Bearer ...`.
+  if (/^(?:[^=;\s]+=[^;]*)(?:;|$)/.test(trimmed) || /^(?:\{|\[)/.test(trimmed)) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+export function buildCopilotWebSocketUrl(
+  accessToken?: string,
+  clientSessionId = crypto.randomUUID()
+): string {
+  const url = new URL(COPILOT_WS_URL);
+  url.searchParams.set("clientSessionId", clientSessionId);
+  if (accessToken) {
+    // Copilot's browser client authenticates the WebSocket with this query
+    // parameter. Node's browser-compatible global WebSocket cannot set custom
+    // headers, so the previous header-only fallback silently lost auth on Node 22+.
+    url.searchParams.set("accessToken", accessToken);
+  }
+  return url.toString();
 }
 
 /* @testonly */ export function buildCopilotWebSocketHeaders(
@@ -255,8 +280,7 @@ export class CopilotWebExecutor extends BaseExecutor {
     accessToken?: string,
     signal?: AbortSignal
   ): Promise<ReadableStream<Uint8Array>> {
-    // Build WebSocket URL without credentials in query string
-    const wsUrl = `${COPILOT_WS_URL}&clientSessionId=${crypto.randomUUID()}`;
+    const wsUrl = buildCopilotWebSocketUrl(accessToken);
 
     return new ReadableStream(
       {
@@ -300,9 +324,8 @@ export class CopilotWebExecutor extends BaseExecutor {
           signal?.addEventListener("abort", () => abort("Request aborted"), { once: true });
 
           try {
-            // Use Node.js built-in WebSocket if available, else dynamic import.
-            // Pass the access token via Authorization header (not URL) to avoid
-            // credential exposure in server logs.
+            // Authentication is present in wsUrl for both transports. The Node
+            // fallback also preserves the Authorization header where supported.
             const BrowserWebSocket = globalThis.WebSocket;
             if (BrowserWebSocket) {
               ws = new BrowserWebSocket(wsUrl);
@@ -534,7 +557,9 @@ export class CopilotWebExecutor extends BaseExecutor {
 
             ws.onerror = (err: Event) => {
               clearTimeout(timeout);
-              const msg = (err as ErrorEvent).message || "Copilot WebSocket error";
+              const msg = sanitizeErrorMessage(
+                (err as ErrorEvent).message || "Copilot WebSocket error"
+              );
               abort(msg);
             };
 
@@ -543,7 +568,11 @@ export class CopilotWebExecutor extends BaseExecutor {
               finish();
             };
           } catch (err) {
-            abort(err instanceof Error ? err.message : "Failed to connect to Copilot");
+            abort(
+              sanitizeErrorMessage(
+                err instanceof Error ? err.message : "Failed to connect to Copilot"
+              )
+            );
           }
         },
       },
@@ -617,7 +646,7 @@ export class CopilotWebExecutor extends BaseExecutor {
           headers: { "Content-Type": "application/json" },
         }),
         url: COPILOT_START_URL,
-        headers: accessToken ? { Authorization: `Bearer ${accessToken.slice(0, 20)}...` } : {},
+        headers: {},
         transformedBody: { conversationId: null, mode, prompt: fullPrompt.slice(0, 100) },
       };
     }

--- a/open-sse/services/inAppLoginService.ts
+++ b/open-sse/services/inAppLoginService.ts
@@ -13,7 +13,11 @@
  */
 
 import { EventEmitter } from "events";
-import { TOKEN_EXTRACTION_CONFIGS, TokenExtractionConfig, type TokenSource } from "./tokenExtractionConfig";
+import {
+  TOKEN_EXTRACTION_CONFIGS,
+  TokenExtractionConfig,
+  type TokenSource,
+} from "./tokenExtractionConfig";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -26,6 +30,20 @@ export interface LoginResult {
 interface ActiveLogin {
   providerId: string;
   aborted: boolean;
+}
+
+export function captureConfiguredHeaders(
+  tokenSources: readonly TokenSource[],
+  requestHeaders: Record<string, string>,
+  credentials: Record<string, string>
+): void {
+  for (const source of tokenSources) {
+    if (source.type !== "header" || credentials[source.name]) continue;
+    const value = requestHeaders[source.name.toLowerCase()];
+    if (typeof value === "string" && value.trim()) {
+      credentials[source.name] = value.trim();
+    }
+  }
 }
 
 // ─── Service ────────────────────────────────────────────────────────────────
@@ -46,19 +64,29 @@ export class InAppLoginService extends EventEmitter {
     }
 
     if (this.activeLogin) {
-      this.emit("status", { providerId, status: "error", message: "A login is already in progress" });
+      this.emit("status", {
+        providerId,
+        status: "error",
+        message: "A login is already in progress",
+      });
       return { success: false, error: "A login process is already in progress" };
     }
 
     this.activeLogin = { providerId, aborted: false };
-    this.emit("status", { providerId, status: "starting", message: `Opening ${config.displayName} login...` });
+    this.emit("status", {
+      providerId,
+      status: "starting",
+      message: `Opening ${config.displayName} login...`,
+    });
 
     try {
       const result = await this.runBrowserLogin(config, options?.timeout);
       this.emit("status", {
         providerId,
         status: result.success ? "complete" : "error",
-        message: result.success ? "Credentials extracted successfully" : (result.error || "Login failed"),
+        message: result.success
+          ? "Credentials extracted successfully"
+          : result.error || "Login failed",
       });
       return result;
     } catch (error) {
@@ -87,7 +115,10 @@ export class InAppLoginService extends EventEmitter {
     try {
       playwright = await import("playwright");
     } catch {
-      return { success: false, error: "Playwright is not installed. Use Electron for native login." };
+      return {
+        success: false,
+        error: "Playwright is not installed. Use Electron for native login.",
+      };
     }
 
     if (this.activeLogin?.aborted) {
@@ -106,19 +137,39 @@ export class InAppLoginService extends EventEmitter {
         locale: "en-US",
       });
       const page = await context.newPage();
+      const credentials: Record<string, string> = {};
+
+      // Playwright normalizes request header names to lowercase. Capture only
+      // explicitly configured credentials and never replace the first token
+      // observed after login.
+      page.on("request", (request: { allHeaders(): Promise<Record<string, string>> }) => {
+        void request
+          .allHeaders()
+          .then((headers) => captureConfiguredHeaders(config.tokenSources, headers, credentials))
+          .catch(() => {
+            // Some browser-internal requests do not expose their full headers.
+          });
+      });
 
       // Navigate to login URL
-      this.emit("status", { providerId, status: "navigating", message: `Loading ${config.loginUrl}` });
+      this.emit("status", {
+        providerId,
+        status: "navigating",
+        message: `Loading ${config.loginUrl}`,
+      });
       await page.goto(config.loginUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
 
       // Poll for success URL + token extraction
       const maxPolls = Math.floor(maxTimeout / pollInterval);
-      const credentials: Record<string, string> = {};
       const startTime = Date.now();
 
       for (let i = 0; i < maxPolls; i++) {
         if (this.activeLogin?.aborted) {
-          this.emit("status", { providerId, status: "cancelled", message: "Login cancelled by user" });
+          this.emit("status", {
+            providerId,
+            status: "cancelled",
+            message: "Login cancelled by user",
+          });
           return { success: false, error: "Login cancelled" };
         }
 
@@ -147,8 +198,7 @@ export class InAppLoginService extends EventEmitter {
             const domain = source.domain || undefined;
             const matched = cookies.find(
               (c: any) =>
-                c.name === source.name &&
-                (!domain || c.domain.includes(domain.replace(/^\./, "")))
+                c.name === source.name && (!domain || c.domain.includes(domain.replace(/^\./, "")))
             );
             if (matched && !credentials[source.name]) {
               credentials[source.name] = matched.value;
@@ -160,7 +210,10 @@ export class InAppLoginService extends EventEmitter {
         for (const source of tokenSources) {
           if (source.type === "localStorage" && !credentials[source.key]) {
             try {
-              const value = await page.evaluate((key: string) => localStorage.getItem(key), source.key);
+              const value = await page.evaluate(
+                (key: string) => localStorage.getItem(key),
+                source.key
+              );
               if (value && typeof value === "string") {
                 credentials[source.key] = value;
               }
@@ -170,7 +223,10 @@ export class InAppLoginService extends EventEmitter {
           }
           if (source.type === "sessionStorage" && !credentials[source.key]) {
             try {
-              const value = await page.evaluate((key: string) => sessionStorage.getItem(key), source.key);
+              const value = await page.evaluate(
+                (key: string) => sessionStorage.getItem(key),
+                source.key
+              );
               if (value && typeof value === "string") {
                 credentials[source.key] = value;
               }
@@ -182,7 +238,11 @@ export class InAppLoginService extends EventEmitter {
 
         // Check if all required tokens are found
         const requiredKeys = tokenSources.map((s) =>
-          s.type === "cookie" ? s.name : s.type === "localStorage" || s.type === "sessionStorage" ? s.key : s.name
+          s.type === "cookie"
+            ? s.name
+            : s.type === "localStorage" || s.type === "sessionStorage"
+              ? s.key
+              : s.name
         );
         const allFound = requiredKeys.every((k) => credentials[k] !== undefined);
 

--- a/open-sse/services/tokenExtractionConfig.ts
+++ b/open-sse/services/tokenExtractionConfig.ts
@@ -230,9 +230,8 @@ const RAW_CONFIGS: TokenExtractionConfig[] = [
     "Microsoft Copilot",
     "https://copilot.microsoft.com/",
     "https://copilot.microsoft.com",
-    [{ type: "cookie", name: "RPSCAuth", domain: ".microsoft.com" }],
-    "Log in with your Microsoft account at copilot.microsoft.com. The session auth cookie will be extracted.",
-    { cookieDomain: ".microsoft.com" }
+    [{ type: "header", name: "Authorization" }],
+    "Log in with your Microsoft account at copilot.microsoft.com. The bearer access token will be extracted from an authenticated request."
   ),
 
   // ── DuckDuckGo Web ────────────────────────────────────────

--- a/src/lib/providers/validation/webProvidersB.ts
+++ b/src/lib/providers/validation/webProvidersB.ts
@@ -294,7 +294,8 @@ export async function validateCopilotWebProvider({ apiKey, providerSpecificData 
     if (!raw) {
       return {
         valid: false,
-        error: "Paste your access_token from copilot.microsoft.com DevTools → Cookies",
+        error:
+          "Paste your access_token from an authenticated copilot.microsoft.com request (DevTools → Network → Authorization)",
       };
     }
 
@@ -326,7 +327,7 @@ export async function validateCopilotWebProvider({ apiKey, providerSpecificData 
       return {
         valid: false,
         error:
-          "Invalid or expired access_token — re-paste from copilot.microsoft.com DevTools → Cookies",
+          "Invalid or expired access_token — capture a fresh Authorization bearer token from copilot.microsoft.com DevTools → Network",
       };
     }
 

--- a/src/shared/constants/providers/web-cookie.ts
+++ b/src/shared/constants/providers/web-cookie.ts
@@ -125,7 +125,7 @@ export const WEB_COOKIE_PROVIDERS = {
     textIcon: "CP",
     website: "https://copilot.microsoft.com",
     authHint:
-      "Paste your access_token from copilot.microsoft.com (or export a .har file from DevTools while logged in)",
+      "Paste the access_token from an authenticated copilot.microsoft.com request (DevTools → Network → Authorization), or export a HAR while logged in",
     subscriptionRisk: true,
     riskNoticeVariant: "webCookie",
   },

--- a/tests/unit/copilot-web-executor.test.ts
+++ b/tests/unit/copilot-web-executor.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 const {
   buildCopilotWebSocketHeaders,
+  buildCopilotWebSocketUrl,
+  CopilotWebExecutor,
   getCopilotMode,
   extractAccessToken,
   sessionPoolKey,
@@ -39,6 +41,22 @@ test("extractAccessToken extracts token from cookie string", () => {
   assert.equal(extractAccessToken(`session=xyz; access_token=${token}; other=1`), token);
 });
 
+test("extractAccessToken parses access_token before classifying a long cookie string", () => {
+  const token = `eyJhbGciOiJSUzI1NiJ9.${"x".repeat(120)}`;
+  const cookie = `${"padding=value; ".repeat(12)}access_token=${token}; other=1`;
+  assert.ok(cookie.length > 100);
+  assert.equal(extractAccessToken(cookie), token);
+});
+
+test("extractAccessToken reads Authorization captured by browser login", () => {
+  const token = `eyJhbGciOiJSUzI1NiJ9.${"x".repeat(120)}`;
+  assert.equal(extractAccessToken(JSON.stringify({ Authorization: `Bearer ${token}` })), token);
+});
+
+test("extractAccessToken rejects an unrelated session cookie", () => {
+  assert.equal(extractAccessToken(`RPSCAuth=${"x".repeat(160)}`), null);
+});
+
 test("extractAccessToken extracts Bearer token from Authorization header", () => {
   const token = "my-bearer-token";
   assert.equal(extractAccessToken(`Bearer ${token}`), token);
@@ -52,6 +70,32 @@ test("Copilot WebSocket credentials use the Authorization header", () => {
   assert.deepEqual(buildCopilotWebSocketHeaders("access-token"), {
     Authorization: "Bearer access-token",
   });
+});
+
+test("buildCopilotWebSocketUrl follows Copilot's authenticated query contract", () => {
+  const url = new URL(buildCopilotWebSocketUrl("token with symbols/+", "session-id"));
+  assert.equal(url.origin, "wss://copilot.microsoft.com");
+  assert.equal(url.pathname, "/c/api/chat");
+  assert.equal(url.searchParams.get("api-version"), "2");
+  assert.equal(url.searchParams.get("clientSessionId"), "session-id");
+  assert.equal(url.searchParams.get("accessToken"), "token with symbols/+");
+});
+
+test("Copilot session failures do not return a credential-bearing header projection", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("unauthorized", { status: 401 });
+
+  try {
+    const result = await new CopilotWebExecutor().execute({
+      body: { messages: [{ role: "user", content: "hello" }] },
+      credentials: { apiKey: `ey${"x".repeat(120)}` },
+      model: "copilot",
+    });
+
+    assert.deepEqual(result.headers, {});
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("sessionPoolKey produces unique keys per token preventing session sharing", () => {

--- a/tests/unit/electron-login-header-capture.test.ts
+++ b/tests/unit/electron-login-header-capture.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { captureConfiguredHeaders } = require("../../electron/lib/loginHeaderCapture.js");
+
+test("Electron login header capture handles original-case request headers", () => {
+  const credentials: Record<string, string> = {};
+
+  captureConfiguredHeaders(
+    [{ type: "header", name: "Authorization" }],
+    { Authorization: "Bearer electron-token", Accept: "application/json" },
+    credentials
+  );
+
+  assert.deepEqual(credentials, { Authorization: "Bearer electron-token" });
+});
+
+test("Electron login header capture ignores non-header sources", () => {
+  const credentials: Record<string, string> = {};
+
+  captureConfiguredHeaders(
+    [{ type: "cookie", name: "RPSCAuth" }],
+    { Cookie: "RPSCAuth=not-an-access-token" },
+    credentials
+  );
+
+  assert.deepEqual(credentials, {});
+});

--- a/tests/unit/in-app-login-service.test.ts
+++ b/tests/unit/in-app-login-service.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { captureConfiguredHeaders } = await import("../../open-sse/services/inAppLoginService.ts");
+
+test("captureConfiguredHeaders records configured headers case-insensitively", () => {
+  const credentials: Record<string, string> = {};
+
+  captureConfiguredHeaders(
+    [{ type: "header", name: "Authorization" }],
+    { authorization: "Bearer access-token", accept: "application/json" },
+    credentials
+  );
+
+  assert.deepEqual(credentials, { Authorization: "Bearer access-token" });
+});
+
+test("captureConfiguredHeaders ignores cookies and does not replace a captured token", () => {
+  const credentials = { Authorization: "Bearer first-token" };
+
+  captureConfiguredHeaders(
+    [
+      { type: "cookie", name: "session", domain: ".example.com" },
+      { type: "header", name: "Authorization" },
+    ],
+    { authorization: "Bearer replacement-token", cookie: "session=value" },
+    credentials
+  );
+
+  assert.deepEqual(credentials, { Authorization: "Bearer first-token" });
+});

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -2574,7 +2574,7 @@ test("copilot-web validator: cookie with access_token= is extracted", async () =
 
   await validateProviderApiKey({
     provider: "copilot-web",
-    apiKey: "access_token=eyJhbGciOiJIUzI1NiJ9.payload.sig; other_cookie=foo",
+    apiKey: `${"padding=value; ".repeat(12)}access_token=eyJhbGciOiJIUzI1NiJ9.payload.sig; other_cookie=foo`,
   });
   assert.equal(capturedAuth, "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig");
 });

--- a/tests/unit/tokenExtractionConfig.test.ts
+++ b/tests/unit/tokenExtractionConfig.test.ts
@@ -8,11 +8,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-const {
-  TOKEN_EXTRACTION_CONFIGS,
-  getExtractionConfig,
-  listExtractionConfigs,
-} = await import("../../open-sse/services/tokenExtractionConfig.ts");
+const { TOKEN_EXTRACTION_CONFIGS, getExtractionConfig, listExtractionConfigs } =
+  await import("../../open-sse/services/tokenExtractionConfig.ts");
 
 describe("tokenExtractionConfig", () => {
   it("exports TOKEN_EXTRACTION_CONFIGS as a Map", () => {
@@ -101,6 +98,12 @@ describe("tokenExtractionConfig", () => {
       assert.ok(cfg !== undefined, `getExtractionConfig("${id}") returned undefined`);
       assert.equal(cfg?.providerId, id);
     }
+  });
+
+  it("captures Copilot's bearer authorization header instead of an unrelated cookie", () => {
+    const cfg = getExtractionConfig("copilot-web");
+    assert.deepEqual(cfg?.tokenSources, [{ type: "header", name: "Authorization" }]);
+    assert.doesNotMatch(cfg?.instructions || "", /RPSCAuth/i);
   });
 
   it("listExtractionConfigs returns all configs as an array", () => {


### PR DESCRIPTION
Addresses the Microsoft Copilot portion of #9980.

## Summary
- parse structured access_token and Bearer inputs before the raw-token heuristic, so long DevTools cookie or HAR exports are not sent wholesale as bearer credentials
- capture the configured Authorization header in both Playwright and Electron browser-login flows instead of extracting the unrelated RPSCAuth cookie
- authenticate the WebSocket with the accessToken query contract used by the current Copilot browser client, including the Node global WebSocket path
- sanitize WebSocket failures and stop projecting credential prefixes in failed session results

## Verification
- TDD: reproduced the long-cookie, RPSCAuth, missing browser-header, and global-WebSocket auth failures before the fix
- focused Node tests: 198 passed
- npm run test:vitest: 344 passed
- npm run lint: passed
- npm run typecheck:core: passed
- npm run check:dashboard-typecheck: passed
- npm run check:open-sse-typecheck: passed with the existing 51-error baseline and no new errors
- npm run check:file-size: passed

The full npm run test:unit sweep was also attempted, but the unrelated tests/unit/mcp-published-files-closure-3578.test.ts process remained open for more than nine minutes and the sweep was stopped. No live user credential was used, so authenticated end-to-end confirmation remains for the reporter or maintainer.