### PR TITLE
[TS7] fix(types): narrow chatCore local contracts

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -200,6 +200,7 @@ import {
 import { wrapReadableStreamWithFinalize } from "./chatCore/streamFinalize.ts";
 import { buildCacheUsageLogMeta } from "./chatCore/cacheUsageMeta.ts";
 import { buildExecutorClientHeaders } from "./chatCore/executorClientHeaders.ts";
+import { getExecutionConnectionId } from "./chatCore/executionCredentials.ts";
 import { resolveExecutionCredentials as resolveExecutionCredentialsFor } from "./chatCore/executionCredentials.ts";
 import { resolveExecutorWithProxy as resolveExecutorWithProxyFor } from "./chatCore/executorProxy.ts";
 import type { ClaudeMessage } from "./chatCore/claudeMessageTypes.ts";
@@ -231,7 +232,8 @@ import {
   normalizeOpenAIToolFinishReasons,
   restoreNonStreamingToolNames,
 } from "./chatCore/passthroughToolNames.ts";
-import { resolveCompressionSettings } from "./chatCore/compressionSettings.ts";
+import { createDisabledCompressionConfig, resolveCompressionSettings } from "./chatCore/compressionSettings.ts";
+import type { EnforceDecision } from "@/lib/quota/types";
 import { isCompressionExcluded } from "../services/compression/exclusions.ts";
 import {
   isBuiltinStackedPipeline,
@@ -1171,14 +1173,7 @@ export async function handleChatCore({
         formatCompressionAnnotation,
       } = await import("../services/compression/strategySelector.ts");
       const { trackCompressionStats } = await import("../services/compression/stats.ts");
-      let config: CompressionConfig = compressionSettings ?? {
-        enabled: false,
-        defaultMode: "off",
-        autoTriggerTokens: 0,
-        cacheMinutes: 5,
-        preserveSystemPrompt: true,
-        comboOverrides: {},
-      };
+      let config: CompressionConfig = compressionSettings ?? createDisabledCompressionConfig();
       if (compressionExcluded) config = { ...config, enabled: false };
       if (!promptCompressionEnabled || !compressionSettings) {
         log?.debug?.("COMPRESSION", "Prompt compression disabled or unavailable");
@@ -2573,7 +2568,7 @@ export async function handleChatCore({
         // router/log use. Operators configure per-(key,model) caps against THIS id.
         model: model || undefined,
         estimatedCost: {},
-      }).catch((err: unknown) => {
+      }).catch((err: unknown): EnforceDecision => {
         log?.warn?.(
           "QUOTA_SHARE",
           `enforceQuotaShare failed; fail-open: ${err instanceof Error ? err.message : String(err)}`
@@ -2738,7 +2733,8 @@ export async function handleChatCore({
               stage: "sending_to_provider",
             });
             const execCreds = getExecutionCredentials();
-            const attemptConnectionId = execCreds?.connectionId || connectionId;
+            const executionConnectionId = getExecutionConnectionId(execCreds);
+            const attemptConnectionId = executionConnectionId || connectionId;
             const accountSemaphoreMaxConcurrency = resolveAccountSemaphoreMaxConcurrency(execCreds);
             const accountSemaphoreKey = resolveAccountSemaphoreKey({
               provider,
@@ -2822,7 +2818,7 @@ export async function handleChatCore({
                 stage: "provider_response_started",
               });
 
-              if (res.response.status === 401 && execCreds?.connectionId) {
+              if (res.response.status === 401 && executionConnectionId) {
                 recordKeyHealthStatus(401, execCreds);
               }
 
@@ -2854,7 +2850,7 @@ export async function handleChatCore({
                 attempts < maxAttempts - 1
               ) {
                 const failedConnectionId =
-                  execCreds?.connectionId || credentials?.connectionId || connectionId;
+                  executionConnectionId || credentials?.connectionId || connectionId;
                 const normalizedHeaders = normalizeHeaders(res.response.headers);
                 const retryAfterHeader = normalizedHeaders["retry-after"] ?? null;
                 const retryAfterMs = retryAfterHeader

--- a/open-sse/handlers/chatCore/compressionSettings.ts
+++ b/open-sse/handlers/chatCore/compressionSettings.ts
@@ -12,6 +12,19 @@ import type { CompressionConfig } from "../../services/compression/types.ts";
 
 type LoggerLike = { warn?: (...args: unknown[]) => void } | null | undefined;
 
+export function createDisabledCompressionConfig(): CompressionConfig {
+  return {
+    enabled: false,
+    defaultMode: "off",
+    autoTriggerTokens: 0,
+    cacheMinutes: 5,
+    preserveSystemPrompt: true,
+    comboOverrides: {},
+    engines: {},
+    activeComboId: null,
+  };
+}
+
 export async function resolveCompressionSettings(log?: LoggerLike): Promise<{
   settings: CompressionConfig | null;
   enabled: boolean;

--- a/open-sse/handlers/chatCore/executionCredentials.ts
+++ b/open-sse/handlers/chatCore/executionCredentials.ts
@@ -177,3 +177,9 @@ export function resolveExecutionCredentials(opts: {
     },
   };
 }
+
+export function getExecutionConnectionId(credentials: unknown): string | null {
+  if (!credentials || typeof credentials !== "object") return null;
+  const connectionId = (credentials as Record<string, unknown>).connectionId;
+  return typeof connectionId === "string" && connectionId.trim() ? connectionId.trim() : null;
+}

--- a/tests/unit/chatcore-compression-settings.test.ts
+++ b/tests/unit/chatcore-compression-settings.test.ts
@@ -12,9 +12,8 @@ const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-comp-settings-te
 process.env.DATA_DIR = testDataDir;
 
 const coreDb = await import("../../src/lib/db/core.ts");
-const { resolveCompressionSettings } = await import(
-  "../../open-sse/handlers/chatCore/compressionSettings.ts"
-);
+const { createDisabledCompressionConfig, resolveCompressionSettings } =
+  await import("../../open-sse/handlers/chatCore/compressionSettings.ts");
 
 before(async () => {
   await coreDb.ensureDbInitialized();
@@ -32,6 +31,19 @@ after(() => {
 test("returns the settings object from the DB", async () => {
   const result = await resolveCompressionSettings();
   assert.ok(result.settings, "expected a settings object from the seeded DB");
+});
+
+test("builds a complete disabled compression fallback", () => {
+  assert.deepEqual(createDisabledCompressionConfig(), {
+    enabled: false,
+    defaultMode: "off",
+    autoTriggerTokens: 0,
+    cacheMinutes: 5,
+    preserveSystemPrompt: true,
+    comboOverrides: {},
+    engines: {},
+    activeComboId: null,
+  });
 });
 
 test("derives enabled and contextEditingEnabled from the settings", async () => {

--- a/tests/unit/chatcore-execution-credentials.test.ts
+++ b/tests/unit/chatcore-execution-credentials.test.ts
@@ -6,7 +6,10 @@
 // session-id threading.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveExecutionCredentials } from "../../open-sse/handlers/chatCore/executionCredentials.ts";
+import {
+  getExecutionConnectionId,
+  resolveExecutionCredentials,
+} from "../../open-sse/handlers/chatCore/executionCredentials.ts";
 
 const RESPONSES = "openai-responses";
 
@@ -143,6 +146,13 @@ test("missing providerSpecificData defaults to an empty object", () => {
     credentials: { connectionId: "c1" },
   }) as Record<string, unknown>;
   assert.deepEqual(out.providerSpecificData, {});
+  assert.equal(out.connectionId, "c1");
+});
+
+test("getExecutionConnectionId validates and trims the execution credential id", () => {
+  assert.equal(getExecutionConnectionId({ connectionId: "  c1  " }), "c1");
+  assert.equal(getExecutionConnectionId({ connectionId: 42 }), null);
+  assert.equal(getExecutionConnectionId(null), null);
 });
 
 test("Kimi execution credentials carry the discovered protocol and thinking policy", () => {


### PR DESCRIPTION
## Summary
- build a complete disabled compression configuration
- preserve the quota fail-open decision type
- validate execution connection ids before retry and health handling
- add local contract regression coverage

## Validation
- focused chatCore and quota suites: 36 passed
- TypeScript 6.0.3: 41 to 36 diagnostics, removed 5, added 0
- TypeScript 7.0.2: 41 to 36 diagnostics, removed 5, added 0
- combined low-risk overlay: 41 to 24 under both compilers, removed 17, added 0