### PR TITLE
[TS7] fix(types): preserve GHE Copilot executor configuration

### DIFF
--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -1,4 +1,9 @@
-import { BaseExecutor, ExecuteInput, type ProviderCredentials } from "./base.ts";
+import {
+  BaseExecutor,
+  ExecuteInput,
+  type ProviderConfig,
+  type ProviderCredentials,
+} from "./base.ts";
 import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { getModelTargetFormat } from "../config/providerModels.ts";
 import {
@@ -28,9 +33,11 @@ export interface RefreshedCopilotCredentials {
   providerSpecificData?: Record<string, unknown>;
 }
 
+type GithubExecutorConfig = ProviderConfig & Record<string, unknown>;
+
 export class GithubExecutor extends BaseExecutor {
-  constructor() {
-    super("github", PROVIDERS.github);
+  constructor(provider = "github", config?: GithubExecutorConfig) {
+    super(provider, config ?? PROVIDERS.github);
   }
 
   getCopilotToken(credentials: Record<string, any> | null | undefined) {

--- a/tests/unit/ghe-copilot.test.ts
+++ b/tests/unit/ghe-copilot.test.ts
@@ -61,8 +61,14 @@ test("buildUrl uses responses endpoint for gpt-5.4-mini and gpt-5.6-sol", () => 
   const credentials: ProviderCredentials = {
     providerSpecificData: { gheUrl: "https://ghe.company.com" },
   };
-  assert.strictEqual(executor.buildUrl("gpt-5.4-mini", true, 0, credentials), "https://ghe.company.com/responses");
-  assert.strictEqual(executor.buildUrl("ghe-copilot/gpt-5.6-sol", true, 0, credentials), "https://ghe.company.com/responses");
+  assert.strictEqual(
+    executor.buildUrl("gpt-5.4-mini", true, 0, credentials),
+    "https://ghe.company.com/responses"
+  );
+  assert.strictEqual(
+    executor.buildUrl("ghe-copilot/gpt-5.6-sol", true, 0, credentials),
+    "https://ghe.company.com/responses"
+  );
 });
 
 test("buildUrl uses chat/completions endpoint for claude and gemini models", () => {
@@ -74,8 +80,14 @@ test("buildUrl uses chat/completions endpoint for claude and gemini models", () 
   const credentials: ProviderCredentials = {
     providerSpecificData: { gheUrl: "https://ghe.company.com" },
   };
-  assert.strictEqual(executor.buildUrl("claude-opus-5", true, 0, credentials), "https://ghe.company.com/chat/completions");
-  assert.strictEqual(executor.buildUrl("gemini-3.5-flash", true, 0, credentials), "https://ghe.company.com/chat/completions");
+  assert.strictEqual(
+    executor.buildUrl("claude-opus-5", true, 0, credentials),
+    "https://ghe.company.com/chat/completions"
+  );
+  assert.strictEqual(
+    executor.buildUrl("gemini-3.5-flash", true, 0, credentials),
+    "https://ghe.company.com/chat/completions"
+  );
 });
 
 test("buildUrl handles gheUrl with trailing slash", () => {
@@ -152,6 +164,8 @@ test("executor extends GithubExecutor", () => {
     clientSecret: "test-secret",
   });
   assert.strictEqual(executor.constructor.name, "GheCopilotExecutor");
+  assert.strictEqual(executor.getProvider(), "ghe-copilot");
+  assert.strictEqual(executor.config.baseUrl, "https://api.githubcopilot.com/chat/completions");
 });
 
 test("isValidGheUrl accepts https enterprise hosts and rejects malformed or non-https input", async () => {


### PR DESCRIPTION
## Summary
- pass the GHE provider identity and provider configuration through the GitHub executor constructor
- keep the default GitHub executor behavior unchanged
- add constructor configuration coverage

## Validation
- focused GHE and GitHub executor tests: 36 passed
- TypeScript 6.0.3: 41 to 40 diagnostics, removed 1, added 0
- TypeScript 7.0.2: 41 to 40 diagnostics, removed 1, added 0
- combined low-risk overlay: 41 to 24 under both compilers, removed 17, added 0