### PR TITLE
[TS7] fix(types): validate Fal video result URLs

### DIFF
--- a/tests/unit/video-fal-grok.test.ts
+++ b/tests/unit/video-fal-grok.test.ts
@@ -97,3 +97,25 @@ test("handleVideoGeneration rejects Fal video requests without credentials", asy
   assert.equal(result.status, 401);
   assert.match(result.error, /Fal API key is required/);
 });
+
+test("handleVideoGeneration rejects malformed Fal video URL payloads", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => jsonResponse({ video: { url: { nested: "not-a-url" } } });
+
+  try {
+    const result = await handleVideoGeneration({
+      body: {
+        model: "fal-ai/xai/grok-imagine-video/text-to-video",
+        prompt: "a malformed result",
+      },
+      credentials: { apiKey: "fal-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.status, 502);
+    assert.match(result.error, /no video URL/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- narrow nested Fal video results before reading the URL
- return the existing upstream-result error for malformed URL payloads
- add a regression test for non-string nested URLs

## Validation
- focused Fal video tests: 4 passed
- TypeScript 6.0.3: 41 to 39 diagnostics, removed 2, added 0
- TypeScript 7.0.2: 41 to 39 diagnostics, removed 2, added 0
- combined low-risk overlay: 41 to 24 under both compilers, removed 17, added 0