### PR TITLE
fix(translator): restore TitleCase tool names on the Claude to Gemini path

### DIFF
--- a/changelog.d/fixes/9713-claude-gemini-tool-casing.md
+++ b/changelog.d/fixes/9713-claude-gemini-tool-casing.md
@@ -1,0 +1,1 @@
+- **fix(translator):** restore TitleCase tool names on the Claude → Gemini/Antigravity request path so Claude Code no longer fails with `No such tool available: read` ([#9713](https://github.com/diegosouzapw/OmniRoute/issues/9713))

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -12,7 +12,10 @@ import {
 } from "../../services/geminiThoughtSignatureStore.ts";
 import { capMaxOutputTokens, capThinkingBudget } from "../../../src/lib/modelCapabilities.ts";
 import { getModelSpec } from "../../../src/shared/constants/modelSpecs.ts";
-import { buildHistoricalToolResultContext } from "./openai-to-gemini/helpers.ts";
+import {
+  buildChangedToolNameMap,
+  buildHistoricalToolResultContext,
+} from "./openai-to-gemini/helpers.ts";
 
 /**
  * Direct Claude → Gemini request translator.
@@ -302,10 +305,13 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
     }
   }
 
-  // #9008: keep identity mappings so Claude Code PascalCase tool names can be
-  // restored when Gemini/Antigravity echoes a different case.
-  if (toolNameMap.size > 0) {
-    result._toolNameMap = new Map(toolNameMap);
+  // Gemini lowercases tool names in its functionCall responses, so identity
+  // entries (Read → Read) still need a lowercase alias ("read" → "Read") for
+  // gemini-to-claude to restore the casing Claude Code registered (#9568 parity
+  // — that fix landed on the openai-to-gemini path only).
+  const changedToolNameMap = buildChangedToolNameMap(toolNameMap);
+  if (changedToolNameMap) {
+    result._toolNameMap = changedToolNameMap;
   }
 
   return result;

--- a/tests/unit/probe-claude-gemini-tool-casing.test.ts
+++ b/tests/unit/probe-claude-gemini-tool-casing.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { claudeToGeminiRequest } =
+  await import("../../open-sse/translator/request/claude-to-gemini.ts");
+const { geminiToClaudeResponse } =
+  await import("../../open-sse/translator/response/gemini-to-claude.ts");
+
+// Claude Code (Anthropic Messages format) → OmniRoute → Gemini.
+//
+// Gemini always lowercases tool names in its functionCall responses, so the
+// round trip only works if the request translator publishes a lowercase alias
+// ("read" → "Read") in `_toolNameMap`. Claude Code registers its tools in
+// TitleCase and rejects anything else with "No such tool available: read".
+//
+// The identity-entry filter in claude-to-gemini.ts dropped `Read → Read`
+// (sanitized === original), so no alias reached the response translator and
+// `normalizeToolName()` — whose REVERSE_MAP is keyed by TitleCase — left the
+// lowercase name untouched. Same class as #9568, which only fixed the
+// openai-to-gemini request path.
+
+function claudeBodyWithTools(names: string[]) {
+  return {
+    messages: [{ role: "user", content: "read package.json" }],
+    tools: names.map((name) => ({
+      name,
+      description: `${name} tool`,
+      input_schema: { type: "object", properties: {} },
+    })),
+  };
+}
+
+function firstToolUseName(events) {
+  for (const event of events || []) {
+    if (event?.type === "content_block_start" && event.content_block?.type === "tool_use") {
+      return event.content_block.name;
+    }
+  }
+  return null;
+}
+
+function geminiFunctionCallChunk(name: string) {
+  return {
+    candidates: [
+      {
+        content: { parts: [{ functionCall: { name, args: { file_path: "package.json" } } }] },
+        finishReason: "STOP",
+      },
+    ],
+  };
+}
+
+test("claude-to-gemini: TitleCase tool name publishes a lowercase alias in _toolNameMap", () => {
+  const translated = claudeToGeminiRequest("gemini-2.5-pro", claudeBodyWithTools(["Read"]), false);
+
+  const map = translated._toolNameMap;
+  assert.ok(map instanceof Map, "_toolNameMap must be present so the response can be remapped");
+  assert.equal(
+    map.get("read"),
+    "Read",
+    "Gemini lowercases functionCall names — the map needs a 'read' key to restore 'Read'"
+  );
+});
+
+test("Claude Code round trip: Gemini's lowercase 'read' is restored to 'Read'", () => {
+  const translated = claudeToGeminiRequest("gemini-2.5-pro", claudeBodyWithTools(["Read"]), true);
+
+  // chatCore extracts `_toolNameMap` from the translated request body and hands
+  // it to the response translator as `state.toolNameMap`.
+  const state = { toolNameMap: translated._toolNameMap, contentBlockIndex: 0 };
+  const events = geminiToClaudeResponse(geminiFunctionCallChunk("read"), state);
+
+  assert.equal(
+    firstToolUseName(events),
+    "Read",
+    "Claude Code registers 'Read'; emitting 'read' fails with 'No such tool available: read'"
+  );
+});
+
+test("Claude Code round trip: multiple TitleCase tools survive the lowercase round trip", () => {
+  const translated = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    claudeBodyWithTools(["Read", "Bash", "WebFetch"]),
+    true
+  );
+
+  for (const [lowered, expected] of [
+    ["read", "Read"],
+    ["bash", "Bash"],
+    ["webfetch", "WebFetch"],
+  ]) {
+    const state = { toolNameMap: translated._toolNameMap, contentBlockIndex: 0 };
+    const events = geminiToClaudeResponse(geminiFunctionCallChunk(lowered), state);
+    assert.equal(firstToolUseName(events), expected, `${lowered} should restore to ${expected}`);
+  }
+});
+
+test("claude-to-gemini: names actually sanitized for Gemini keep their original mapping", () => {
+  // A tool name Gemini cannot accept verbatim must still map back to the original.
+  const translated = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    claudeBodyWithTools(["mcp__server__do-thing"]),
+    false
+  );
+
+  const map = translated._toolNameMap;
+  assert.ok(map instanceof Map, "sanitized names must still publish a map");
+  const restored = [...map.values()];
+  assert.ok(
+    restored.includes("mcp__server__do-thing"),
+    "the original (unsanitized) name must remain reachable for the response translator"
+  );
+});


### PR DESCRIPTION
Closes #9713

⚠️ base-red inherited: #9985

## Problem

Claude Code (Anthropic Messages format) against a Gemini-format provider (plain Gemini or Antigravity) fails every tool call with:

```
<tool_use_error>Error: No such tool available: read</tool_use_error>
```

Gemini lowercases tool names in its `functionCall` responses, so the request translator must publish a lowercase alias (`read` → `Read`) for `gemini-to-claude` to restore the casing Claude Code registered.

`claude-to-gemini.ts` filtered identity entries out of `_toolNameMap`:

```ts
[...toolNameMap.entries()].filter(([sanitized, original]) => sanitized !== original)
```

`Read` is a valid Gemini function name, so `Read → Read` was dropped as "unchanged" and no alias reached the response translator. `gemini-to-claude.ts` then fell back to `normalizeToolName()`, whose `REVERSE_MAP` is keyed by TitleCase (`Read → read`), leaving the lowercase name untouched — and, for clients that want lowercase, actively pointing the wrong way.

#9568 fixed exactly this class, but only on the `openai-to-gemini` request path; the `CLAUDE → GEMINI` translator registered at `claude-to-gemini.ts:323` kept the old filter.

## Fix

Reuse `buildChangedToolNameMap()` — the helper #9568 already introduced — which keeps every entry and adds a lowercase-keyed alias, including for identity entries.

## Tests

New `tests/unit/probe-claude-gemini-tool-casing.test.ts` chains the request and response translators the way `chatCore` does (`_toolNameMap` extracted from the translated body, handed to the response translator as `state.toolNameMap`):

- lowercase alias is published for a TitleCase tool name;
- full round trip restores `read` → `Read`;
- multiple tools (`Read` / `Bash` / `WebFetch`) survive the round trip;
- names that genuinely need Gemini sanitization still map back to the original.

Verified failing before the change (`'read' !== 'Read'`) and passing after.

| Check | Result |
| --- | --- |
| New test file | 4/4 pass (failed before the fix) |
| Neighboring translator tests (9568, 9575, claude-to-gemini, gemini-to-claude, toolname-map 4091, antigravity 4181, tool-choice, thought-signature t43) | 49/49 pass |
| `tsc --noEmit` on changed files | clean |
| `eslint` on changed files | clean |

Likely also covers #9743 (same class, `write`), but that report is from 3.8.49 and was not verified here, so it is not marked as closed.
