### PR TITLE
fix(kimi): apply K3 effort policy to aliases

### DIFF
--- a/open-sse/config/providers/registry/kimi/coding/runtime.ts
+++ b/open-sse/config/providers/registry/kimi/coding/runtime.ts
@@ -25,7 +25,9 @@ const KIMI_CODE_STATIC_THINKING_POLICIES: Record<string, KimiCodeThinkingPolicy>
 
 export function getKimiCodeStaticThinkingPolicy(modelId: unknown): KimiCodeThinkingPolicy | null {
   if (typeof modelId !== "string") return null;
-  return KIMI_CODE_STATIC_THINKING_POLICIES[modelId] || null;
+  const normalizedModel = modelId.trim().toLowerCase().split("/").pop() || "";
+  if (/^k3(?:$|-)/.test(normalizedModel)) return KIMI_CODE_STATIC_THINKING_POLICIES.k3;
+  return KIMI_CODE_STATIC_THINKING_POLICIES[normalizedModel] || null;
 }
 
 export type KimiCodeDeviceIdentity = {

--- a/tests/unit/responses-handler.test.ts
+++ b/tests/unit/responses-handler.test.ts
@@ -263,6 +263,22 @@ test("handleResponsesCore preserves Kimi K3 reasoning through provider translati
   assert.equal(native.call.body.messages?.[1]?.reasoning_content, "I should search first.");
 });
 
+test("handleResponsesCore maps unsupported Kimi K3 xhigh effort to max", async () => {
+  const { call, result } = await invokeResponsesCore({
+    body: {
+      model: "k3-256k",
+      reasoning: { effort: "xhigh", summary: "auto" },
+      input: "Reply with OK.",
+    },
+    provider: "kimi-coding-apikey",
+    model: "k3-256k",
+  });
+
+  assert.equal(result.success, true);
+  assert.deepEqual(call.body.thinking, { type: "enabled" });
+  assert.deepEqual(call.body.output_config, { effort: "max" });
+});
+
 test("handleResponsesCore strips previous_response_id by default and handles empty input arrays", async () => {
   const { call, result } = await invokeResponsesCore({
     body: {


### PR DESCRIPTION
Closes #10003

## Summary

- apply the existing K3 effort policy to `k3-*` aliases such as `k3-256k`
- map unsupported Responses `xhigh` requests to Kimi's native `max` on the KMCA Anthropic path

## Tests

```text
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/responses-handler.test.ts tests/unit/executor-kimi.test.ts tests/unit/chatcore-execution-credentials.test.ts
```

38 tests passed.

## Validation

A controlled live comparison before the fix returned HTTP 200 for `high` and HTTP 400 for `xhigh`. The patched deployment maps `xhigh` to `output_config.effort: "max"` and succeeds.
