### PR TITLE
feat(onboarding): add one-click free provider setup

### DIFF
--- a/changelog.d/features/9752-one-click-free-providers.md
+++ b/changelog.d/features/9752-one-click-free-providers.md
@@ -1,0 +1,4 @@
+- **Onboarding:** add an explicit, reviewable one-click setup for eligible no-auth LLM providers,
+  with per-provider caution links, selectable confirmation, idempotent creation, and safe partial
+  retries. Existing provider connections are never changed and setup completion never enables
+  providers silently. ([#9752](https://github.com/diegosouzapw/OmniRoute/issues/9752))

--- a/docs/getting-started/PROVIDERS-GUIDE.md
+++ b/docs/getting-started/PROVIDERS-GUIDE.md
@@ -30,6 +30,18 @@ See **[WEB-COOKIE-GUIDE.md](./WEB-COOKIE-GUIDE.md)** for general setup instructi
 
 ## Quick Start: Connect Your First Provider
 
+### Optional first-run free-provider setup
+
+The first-run wizard offers an explicit **Set up free providers** card. It derives the current
+eligible list from OmniRoute's no-auth provider registry, then lets you review and deselect each
+provider before confirming. OmniRoute shows the provider's caution notice and a link to its site
+so you can review third-party terms, privacy, availability, and rate limits first.
+
+This action is optional: finishing the wizard never creates free-provider connections silently.
+It creates only providers that are still missing, leaves existing customized connections
+untouched, and reports created, already-configured, and failed providers individually. You can
+safely retry only the failures after a partial result.
+
 ### Option A: Free Provider (No Credit Card)
 
 1. Open the dashboard at `http://localhost:20128`

--- a/src/app/(dashboard)/dashboard/onboarding/page.tsx
+++ b/src/app/(dashboard)/dashboard/onboarding/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useDisplayBaseUrl } from "@/shared/hooks";
+import { FreeProviderOnboardingCard } from "./steps/FreeProviderOnboardingCard";
 import { TierTour } from "./steps/TierTour";
 
 const STEP_IDS = ["welcome", "tiers", "security", "provider", "test", "done"];
@@ -357,6 +358,12 @@ export default function OnboardingWizard() {
             {currentStep.id === "provider" && (
               <div className="space-y-4">
                 <p className="text-sm text-text-muted text-center">{t("providerDesc")}</p>
+                <FreeProviderOnboardingCard />
+                <div className="flex items-center gap-3 text-[11px] text-text-muted">
+                  <span className="h-px flex-1 bg-white/10" />
+                  <span>{t("freeProviders.orUseApiKey")}</span>
+                  <span className="h-px flex-1 bg-white/10" />
+                </div>
                 <div className="grid grid-cols-3 gap-2">
                   {COMMON_PROVIDERS.map((p) => (
                     <button

--- a/src/app/(dashboard)/dashboard/onboarding/steps/FreeProviderOnboardingCard.tsx
+++ b/src/app/(dashboard)/dashboard/onboarding/steps/FreeProviderOnboardingCard.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface FreeProviderOption {
+  id: string;
+  name: string;
+  website: string;
+  caution: string;
+  defaultModel?: string;
+}
+
+interface SetupResult {
+  providerId: string;
+  status: "created" | "skipped" | "failed";
+  reason?: string;
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json().catch(() => ({}))) as Record<string, unknown>;
+}
+
+export function FreeProviderOnboardingCard() {
+  const t = useTranslations("onboarding.freeProviders");
+  const [providers, setProviders] = useState<FreeProviderOption[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [confirmed, setConfirmed] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [results, setResults] = useState<SetupResult[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    void fetch("/api/providers/free-onboarding")
+      .then(async (response) => {
+        const data = await readJson(response);
+        if (!response.ok) throw new Error("load-failed");
+        const options = Array.isArray(data.providers)
+          ? (data.providers as FreeProviderOption[])
+          : [];
+        if (!active) return;
+        setProviders(options);
+        setSelectedIds(options.map((provider) => provider.id).sort());
+      })
+      .catch(() => {
+        if (active) setError(t("loadFailed"));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [t]);
+
+  const failedIds = useMemo(
+    () => results.filter((result) => result.status === "failed").map((result) => result.providerId),
+    [results]
+  );
+
+  const toggleProvider = (providerId: string) => {
+    setSelectedIds((current) =>
+      current.includes(providerId)
+        ? current.filter((id) => id !== providerId)
+        : [...current, providerId].sort()
+    );
+    setConfirmed(false);
+  };
+
+  const submit = async (providerIds = selectedIds) => {
+    setSubmitting(true);
+    setError("");
+    try {
+      const response = await fetch("/api/providers/free-onboarding", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerIds, confirmed: true }),
+      });
+      const data = await readJson(response);
+      if (!response.ok) throw new Error("setup-failed");
+      setResults(Array.isArray(data.results) ? (data.results as SetupResult[]) : []);
+    } catch {
+      setError(t("setupFailed"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) return <p className="text-xs text-text-muted">{t("loading")}</p>;
+  if (providers.length === 0 && !error) {
+    return <p className="text-xs text-text-muted">{t("alreadyConfigured")}</p>;
+  }
+
+  return (
+    <section className="space-y-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
+      <div>
+        <h3 className="text-sm font-semibold text-text-main">{t("title")}</h3>
+        <p className="mt-1 text-xs leading-relaxed text-text-muted">{t("description")}</p>
+      </div>
+
+      <div className="max-h-48 space-y-2 overflow-y-auto pr-1">
+        {providers.map((provider) => (
+          <label
+            key={provider.id}
+            className="flex cursor-pointer items-start gap-3 rounded-lg border border-white/10 bg-white/[0.03] p-3"
+          >
+            <input
+              type="checkbox"
+              checked={selectedIds.includes(provider.id)}
+              onChange={() => toggleProvider(provider.id)}
+              className="mt-1 accent-primary"
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs font-medium text-text-main">{provider.name}</span>
+              <span className="mt-1 block text-[11px] leading-relaxed text-amber-300/90">
+                {provider.caution}
+              </span>
+              <a
+                href={provider.website}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-1 inline-block text-[11px] text-primary hover:underline"
+                onClick={(event) => event.stopPropagation()}
+              >
+                {t("reviewProviderSite")}
+              </a>
+            </span>
+          </label>
+        ))}
+      </div>
+
+      <label className="flex cursor-pointer items-start gap-2 text-xs text-text-muted">
+        <input
+          data-testid="free-provider-confirmation"
+          type="checkbox"
+          checked={confirmed}
+          onChange={(event) => setConfirmed(event.target.checked)}
+          className="mt-0.5 accent-primary"
+        />
+        <span>{t("confirmation")}</span>
+      </label>
+
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      {results.length > 0 && (
+        <ul className="space-y-1 text-xs text-text-muted">
+          {results.map((result) => (
+            <li key={result.providerId}>
+              {result.providerId}: {t(`result.${result.status}`)}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          data-testid="setup-free-providers"
+          type="button"
+          disabled={!confirmed || selectedIds.length === 0 || submitting}
+          onClick={() => void submit()}
+          className="rounded-lg bg-primary px-4 py-2 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? t("settingUp") : t("setupSelected")}
+        </button>
+        {failedIds.length > 0 && (
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => void submit(failedIds)}
+            className="rounded-lg border border-white/10 px-4 py-2 text-xs text-text-main disabled:opacity-50"
+          >
+            {t("retryFailed")}
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/api/providers/free-onboarding/route.ts
+++ b/src/app/api/providers/free-onboarding/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import { createProviderConnection, getProviderConnections } from "@/lib/db/providers";
+import {
+  getEligibleFreeOnboardingProviders,
+  selectUnconfiguredFreeOnboardingProviders,
+  setupFreeProviderConnections,
+  withFreeProviderSetupLock,
+} from "@/lib/providers/freeOnboarding";
+import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+
+const setupSchema = z.object({
+  providerIds: z.array(z.string().trim().min(1)).min(1).max(20),
+  confirmed: z.literal(true),
+});
+
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  try {
+    const candidates = getEligibleFreeOnboardingProviders();
+    const connections = await getProviderConnections();
+    return NextResponse.json({
+      providers: selectUnconfiguredFreeOnboardingProviders(candidates, connections),
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to load free providers" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = validateBody(setupSchema, rawBody);
+  if (isValidationFailure(validation)) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  try {
+    const result = await withFreeProviderSetupLock(() =>
+      setupFreeProviderConnections({
+        requestedIds: validation.data.providerIds,
+        candidates: getEligibleFreeOnboardingProviders(),
+        listExisting: () => getProviderConnections(),
+        create: (input) => createProviderConnection(input),
+      })
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Ineligible free provider IDs:")) {
+      return NextResponse.json(
+        { error: "One or more providers are not eligible" },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({ error: "Failed to set up free providers" }, { status: 500 });
+  }
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -4744,7 +4744,26 @@
       "configure": "تكوين مقدمي الخدمات"
     },
     "tierFlowDiagramAlt": "OmniRoute مخطط احتياطي ثلاثي الطبقات",
-    "apiKeyMgmt": "إدارة مفتاح واجهة برمجة التطبيقات (API)"
+    "apiKeyMgmt": "إدارة مفتاح واجهة برمجة التطبيقات (API)",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "المزودون",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -4744,7 +4744,26 @@
       "configure": "Provayderləri konfiqurasiya edin"
     },
     "tierFlowDiagramAlt": "OmniRoute 3 səviyyəli ehtiyat diaqramı",
-    "apiKeyMgmt": "API Açar İdarəetmə"
+    "apiKeyMgmt": "API Açar İdarəetmə",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -4744,7 +4744,26 @@
       "configure": "Конфигурирайте доставчици"
     },
     "tierFlowDiagramAlt": "3-степенна резервна диаграма на OmniRoute",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Доставчици",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -4744,7 +4744,26 @@
       "configure": "প্রদানকারী কনফিগার করুন"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-স্তরের ফলব্যাক ডায়াগ্রাম",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -4744,7 +4744,26 @@
       "configure": "Nakonfigurujte poskytovatele"
     },
     "tierFlowDiagramAlt": "Třívrstvý záložní diagram OmniRoute",
-    "apiKeyMgmt": "Správa API klíčů"
+    "apiKeyMgmt": "Správa API klíčů",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Poskytovatelé",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurer udbydere"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-tiers fallback diagram",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Udbydere",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -4744,7 +4744,26 @@
       "configure": "Anbieter konfigurieren"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-Stufen-Fallback-Diagramm",
-    "apiKeyMgmt": "API-Schlüsselverwaltung"
+    "apiKeyMgmt": "API-Schlüsselverwaltung",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Anbieter",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4744,7 +4744,26 @@
       "configure": "Configure providers"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-tier fallback diagram",
-    "apiKeyMgmt": "API Key Management"
+    "apiKeyMgmt": "API Key Management",
+    "freeProviders": {
+      "title": "Set up free providers",
+      "description": "Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "Loading free providers...",
+      "loadFailed": "Could not load free providers.",
+      "alreadyConfigured": "All eligible free providers are already configured.",
+      "reviewProviderSite": "Review provider site and terms",
+      "confirmation": "I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "Set up selected providers",
+      "settingUp": "Setting up...",
+      "setupFailed": "Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "Retry failed providers",
+      "orUseApiKey": "or connect with an API key",
+      "result": {
+        "created": "created",
+        "skipped": "already configured",
+        "failed": "failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -4744,7 +4744,26 @@
       "configure": "Configurar proveedores"
     },
     "tierFlowDiagramAlt": "Diagrama alternativo de 3 niveles de OmniRoute",
-    "apiKeyMgmt": "Gestión de claves API"
+    "apiKeyMgmt": "Gestión de claves API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Proveedores",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -4744,7 +4744,26 @@
       "configure": "ارائه دهندگان را پیکربندی کنید"
     },
     "tierFlowDiagramAlt": "نمودار بازگشتی 3 لایه OmniRoute",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -4744,7 +4744,26 @@
       "configure": "Määritä palveluntarjoajat"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-tasoinen varakaavio",
-    "apiKeyMgmt": "API-avainhallinta"
+    "apiKeyMgmt": "API-avainhallinta",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Palveluntarjoajat",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -4744,7 +4744,26 @@
       "configure": "Configurer les fournisseurs"
     },
     "tierFlowDiagramAlt": "Diagramme de secours OmniRoute à 3 niveaux",
-    "apiKeyMgmt": "Gestion des clés API"
+    "apiKeyMgmt": "Gestion des clés API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Fournisseurs",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -4744,7 +4744,26 @@
       "configure": "પ્રદાતાઓને ગોઠવો"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-ટાયર ફોલબેક ડાયાગ્રામ",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -4744,7 +4744,26 @@
       "configure": "הגדר ספקים"
     },
     "tierFlowDiagramAlt": "דיאגרמת OmniRoute 3-tier fallback",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "ספקים",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -4744,7 +4744,26 @@
       "configure": "प्रदाताओं को कॉन्फ़िगर करें"
     },
     "tierFlowDiagramAlt": "ओम्निरूट 3-स्तरीय फ़ॉलबैक आरेख",
-    "apiKeyMgmt": "एपीआई कुंजी प्रबंधन"
+    "apiKeyMgmt": "एपीआई कुंजी प्रबंधन",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "प्रदाता",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurálja a szolgáltatókat"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-szintű tartalék diagram",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Szolgáltatók",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurasikan penyedia"
     },
     "tierFlowDiagramAlt": "Diagram cadangan 3 tingkat OmniRoute",
-    "apiKeyMgmt": "Manajemen Kunci API"
+    "apiKeyMgmt": "Manajemen Kunci API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Penyedia",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurasikan penyedia"
     },
     "tierFlowDiagramAlt": "Diagram cadangan 3 tingkat OmniRoute",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -4744,7 +4744,26 @@
       "configure": "Configura i fornitori"
     },
     "tierFlowDiagramAlt": "Diagramma di fallback a 3 livelli di OmniRoute",
-    "apiKeyMgmt": "Gestione chiave API"
+    "apiKeyMgmt": "Gestione chiave API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Fornitori",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4744,7 +4744,26 @@
       "configure": "プロバイダーの構成"
     },
     "tierFlowDiagramAlt": "OmniRoute 3 層フォールバック図",
-    "apiKeyMgmt": "APIキー管理"
+    "apiKeyMgmt": "APIキー管理",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "プロバイダー",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4744,7 +4744,26 @@
       "configure": "공급자 구성"
     },
     "tierFlowDiagramAlt": "OmniRoute 3계층 대체 다이어그램",
-    "apiKeyMgmt": "API 키 관리"
+    "apiKeyMgmt": "API 키 관리",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "공급자",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -4744,7 +4744,26 @@
       "configure": "प्रदाते कॉन्फिगर करा"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-स्तरीय फॉलबॅक आकृती",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurasikan pembekal"
     },
     "tierFlowDiagramAlt": "Gambar rajah sandar 3 peringkat OmniRoute",
-    "apiKeyMgmt": "Mgmt Kunci API"
+    "apiKeyMgmt": "Mgmt Kunci API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Pembekal",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -4744,7 +4744,26 @@
       "configure": "Configureer aanbieders"
     },
     "tierFlowDiagramAlt": "OmniRoute fallback-diagram met 3 niveaus",
-    "apiKeyMgmt": "API-sleutelbeheer"
+    "apiKeyMgmt": "API-sleutelbeheer",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Aanbieders",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurer leverandører"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-lags reservediagram",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Leverandører",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -4744,7 +4744,26 @@
       "configure": "I-configure ang mga provider"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-tier fallback diagram",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Mga provider",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -4744,7 +4744,26 @@
       "configure": "Skonfiguruj providers"
     },
     "tierFlowDiagramAlt": "Schemat fallback 3-poziomowego OmniRoute",
-    "apiKeyMgmt": "Zarządzanie kluczami API"
+    "apiKeyMgmt": "Zarządzanie kluczami API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -4744,7 +4744,26 @@
       "configure": "Configurar provedores"
     },
     "tierFlowDiagramAlt": "Diagrama de fallback de 3 camadas do OmniRoute",
-    "apiKeyMgmt": "Ger. de Chaves API"
+    "apiKeyMgmt": "Ger. de Chaves API",
+    "freeProviders": {
+      "title": "Configurar provedores gratuitos",
+      "description": "Opcionalmente, ative provedores selecionados que não exigem cadastro. Revise o aviso e o site de cada provedor antes de continuar; disponibilidade e limites são controlados por terceiros.",
+      "loading": "Carregando provedores gratuitos...",
+      "loadFailed": "Não foi possível carregar os provedores gratuitos.",
+      "alreadyConfigured": "Todos os provedores gratuitos elegíveis já estão configurados.",
+      "reviewProviderSite": "Revisar site e termos do provedor",
+      "confirmation": "Revisei estes provedores de terceiros e quero que o OmniRoute crie as conexões selecionadas.",
+      "setupSelected": "Configurar provedores selecionados",
+      "settingUp": "Configurando...",
+      "setupFailed": "Não foi possível configurar os provedores selecionados. Nenhuma conexão existente foi alterada.",
+      "retryFailed": "Tentar novamente os provedores com falha",
+      "orUseApiKey": "ou conectar com uma chave de API",
+      "result": {
+        "created": "criado",
+        "skipped": "já configurado",
+        "failed": "falhou"
+      }
+    }
   },
   "providers": {
     "title": "Provedores",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4744,7 +4744,26 @@
       "configure": "Configurar provedores"
     },
     "tierFlowDiagramAlt": "Diagrama de fallback de 3 camadas do OmniRoute",
-    "apiKeyMgmt": "Gerenciamento de chave de API"
+    "apiKeyMgmt": "Gerenciamento de chave de API",
+    "freeProviders": {
+      "title": "Configurar fornecedores gratuitos",
+      "description": "Opcionalmente, ative fornecedores selecionados que não exigem registo. Reveja o aviso e o site de cada fornecedor antes de continuar; a disponibilidade e os limites são controlados por terceiros.",
+      "loading": "A carregar fornecedores gratuitos...",
+      "loadFailed": "Não foi possível carregar os fornecedores gratuitos.",
+      "alreadyConfigured": "Todos os fornecedores gratuitos elegíveis já estão configurados.",
+      "reviewProviderSite": "Rever site e termos do fornecedor",
+      "confirmation": "Revi estes fornecedores de terceiros e quero que o OmniRoute crie as ligações selecionadas.",
+      "setupSelected": "Configurar fornecedores selecionados",
+      "settingUp": "A configurar...",
+      "setupFailed": "Não foi possível configurar os fornecedores selecionados. Nenhuma ligação existente foi alterada.",
+      "retryFailed": "Tentar novamente os fornecedores com falha",
+      "orUseApiKey": "ou ligar com uma chave de API",
+      "result": {
+        "created": "criado",
+        "skipped": "já configurado",
+        "failed": "falhou"
+      }
+    }
   },
   "providers": {
     "title": "Provedores",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -4744,7 +4744,26 @@
       "configure": "Configurați furnizorii"
     },
     "tierFlowDiagramAlt": "Diagrama de rezervă pe 3 niveluri OmniRoute",
-    "apiKeyMgmt": "Gestiunea cheii API"
+    "apiKeyMgmt": "Gestiunea cheii API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Furnizorii",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -4744,7 +4744,26 @@
       "configure": "Настройка поставщиков"
     },
     "tierFlowDiagramAlt": "Трехуровневая резервная схема OmniRoute",
-    "apiKeyMgmt": "Управление ключами API"
+    "apiKeyMgmt": "Управление ключами API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Провайдеры",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -4744,7 +4744,26 @@
       "configure": "Nakonfigurujte poskytovateľov"
     },
     "tierFlowDiagramAlt": "3-vrstvový záložný diagram OmniRoute",
-    "apiKeyMgmt": "API kľúč Mgmt"
+    "apiKeyMgmt": "API kľúč Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Poskytovatelia",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -4744,7 +4744,26 @@
       "configure": "Konfigurera leverantörer"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-nivå reservdiagram",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Leverantörer",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -4744,7 +4744,26 @@
       "configure": "Sanidi watoa huduma"
     },
     "tierFlowDiagramAlt": "Mchoro wa kurudi nyuma wa ngazi 3 wa OmniRoute",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -4744,7 +4744,26 @@
       "configure": "வழங்குநர்களை உள்ளமைக்கவும்"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-அடுக்கு ஃபால்பேக் வரைபடம்",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -4744,7 +4744,26 @@
       "configure": "ప్రొవైడర్లను కాన్ఫిగర్ చేయండి"
     },
     "tierFlowDiagramAlt": "OmniRoute 3-టైర్ ఫాల్‌బ్యాక్ రేఖాచిత్రం",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -4744,7 +4744,26 @@
       "configure": "กำหนดค่าผู้ให้บริการ"
     },
     "tierFlowDiagramAlt": "แผนภาพทางเลือก OmniRoute 3 ระดับ",
-    "apiKeyMgmt": "การจัดการคีย์ API"
+    "apiKeyMgmt": "การจัดการคีย์ API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "ผู้ให้บริการ",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -4744,7 +4744,26 @@
       "configure": "Sağlayıcıları yapılandırma"
     },
     "tierFlowDiagramAlt": "OmniRoute 3 katmanlı geri dönüş diyagramı",
-    "apiKeyMgmt": "API Anahtarı Yönetimi"
+    "apiKeyMgmt": "API Anahtarı Yönetimi",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Sağlayıcılar",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -4744,7 +4744,26 @@
       "configure": "Налаштувати провайдерів"
     },
     "tierFlowDiagramAlt": "3-рівнева резервна схема OmniRoute",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Провайдери",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -4744,7 +4744,26 @@
       "configure": "فراہم کنندگان کو ترتیب دیں۔"
     },
     "tierFlowDiagramAlt": "OmniRoute 3 درجے کا فال بیک ڈایاگرام",
-    "apiKeyMgmt": "API Key Mgmt"
+    "apiKeyMgmt": "API Key Mgmt",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Providers",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -4744,7 +4744,26 @@
       "configure": "Cấu hình nhà cung cấp"
     },
     "tierFlowDiagramAlt": "Sơ đồ dự phòng 3 cấp của OmniRoute",
-    "apiKeyMgmt": "Quản lý khóa API"
+    "apiKeyMgmt": "Quản lý khóa API",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "Nhà cung cấp",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4744,7 +4744,26 @@
       "configure": "配置提供者"
     },
     "tierFlowDiagramAlt": "OmniRoute 3 层回退图",
-    "apiKeyMgmt": "API密钥管理"
+    "apiKeyMgmt": "API密钥管理",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "提供者",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4967,6 +4967,7 @@
     "baseUrlHint": "必填。 提供者 API 基本 URL。",
     "iconUrlLabel": "图标 URL",
     "iconUrlHint": "可选。显示为此服务商图标的图片 URL。",
+    "iconUrlInvalid": "无效的图标 URL。请使用 http(s):// 或 data:image/*;base64 URL。",
     "anthropicPrefixPlaceholder": "ac-prod",
     "openaiPrefixPlaceholder": "oc-prod",
     "anthropicBaseUrlPlaceholder": "https://api.anthropic.com/v1",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4967,7 +4967,6 @@
     "baseUrlHint": "必填。 提供者 API 基本 URL。",
     "iconUrlLabel": "图标 URL",
     "iconUrlHint": "可选。显示为此服务商图标的图片 URL。",
-    "iconUrlInvalid": "无效的图标 URL。请使用 http(s):// 或 data:image/*;base64 URL。",
     "anthropicPrefixPlaceholder": "ac-prod",
     "openaiPrefixPlaceholder": "oc-prod",
     "anthropicBaseUrlPlaceholder": "https://api.anthropic.com/v1",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -4744,7 +4744,26 @@
       "configure": "設定提供者"
     },
     "tierFlowDiagramAlt": "OmniRoute 3 層回退圖",
-    "apiKeyMgmt": "API金鑰管理"
+    "apiKeyMgmt": "API金鑰管理",
+    "freeProviders": {
+      "title": "__MISSING__:Set up free providers",
+      "description": "__MISSING__:Optionally enable selected no-signup providers. Review each provider's notice and site before continuing; availability and rate limits are controlled by third parties.",
+      "loading": "__MISSING__:Loading free providers...",
+      "loadFailed": "__MISSING__:Could not load free providers.",
+      "alreadyConfigured": "__MISSING__:All eligible free providers are already configured.",
+      "reviewProviderSite": "__MISSING__:Review provider site and terms",
+      "confirmation": "__MISSING__:I reviewed these third-party providers and want OmniRoute to create the selected connections.",
+      "setupSelected": "__MISSING__:Set up selected providers",
+      "settingUp": "__MISSING__:Setting up...",
+      "setupFailed": "__MISSING__:Could not set up the selected providers. Nothing existing was changed.",
+      "retryFailed": "__MISSING__:Retry failed providers",
+      "orUseApiKey": "__MISSING__:or connect with an API key",
+      "result": {
+        "created": "__MISSING__:created",
+        "skipped": "__MISSING__:already configured",
+        "failed": "__MISSING__:failed"
+      }
+    }
   },
   "providers": {
     "title": "提供者",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -4967,7 +4967,6 @@
     "baseUrlHint": "必填。 提供者 API 基本 URL。",
     "iconUrlLabel": "圖示網址",
     "iconUrlHint": "選用。顯示為此提供者圖示的圖片網址。",
-    "iconUrlInvalid": "無效的圖示網址。請使用 http(s):// 或 data:image/*;base64 URL。",
     "anthropicPrefixPlaceholder": "ac-prod",
     "openaiPrefixPlaceholder": "oc-prod",
     "anthropicBaseUrlPlaceholder": "https://api.anthropic.com/v1",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -4967,6 +4967,7 @@
     "baseUrlHint": "必填。 提供者 API 基本 URL。",
     "iconUrlLabel": "圖示網址",
     "iconUrlHint": "選用。顯示為此提供者圖示的圖片網址。",
+    "iconUrlInvalid": "無效的圖示網址。請使用 http(s):// 或 data:image/*;base64 URL。",
     "anthropicPrefixPlaceholder": "ac-prod",
     "openaiPrefixPlaceholder": "oc-prod",
     "anthropicBaseUrlPlaceholder": "https://api.anthropic.com/v1",

--- a/src/lib/providers/freeOnboarding.ts
+++ b/src/lib/providers/freeOnboarding.ts
@@ -1,0 +1,164 @@
+import { NOAUTH_PROVIDERS } from "@/shared/constants/providers";
+import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry";
+
+interface NoAuthOnboardingMetadata {
+  id: string;
+  name: string;
+  website?: string;
+  noAuth?: boolean;
+  hasFree?: boolean;
+  isLocalCli?: boolean;
+  serviceKinds?: string[];
+  authHint?: string;
+  freeNote?: string;
+  notice?: { text?: string };
+  deprecated?: boolean;
+  disabled?: boolean;
+  unsafe?: boolean;
+  hiddenFromDashboard?: boolean;
+}
+
+export interface FreeOnboardingProvider {
+  id: string;
+  name: string;
+  website: string;
+  caution: string;
+  defaultModel?: string;
+}
+
+export interface ExistingProviderConnection {
+  provider?: unknown;
+}
+
+export interface FreeProviderConnectionInput {
+  provider: string;
+  authType: "no-auth";
+  name: string;
+  isActive: true;
+  testStatus: "unknown";
+  defaultModel?: string;
+}
+
+export type FreeProviderSetupResult =
+  | { providerId: string; status: "created"; connectionId: string }
+  | { providerId: string; status: "skipped"; reason: "already-configured" }
+  | { providerId: string; status: "failed"; reason: "Failed to create provider" };
+
+function isEligibleProvider(provider: NoAuthOnboardingMetadata): boolean {
+  return (
+    provider.noAuth === true &&
+    provider.hasFree === true &&
+    provider.isLocalCli !== true &&
+    provider.serviceKinds?.includes("llm") === true &&
+    provider.deprecated !== true &&
+    provider.disabled !== true &&
+    provider.unsafe !== true &&
+    provider.hiddenFromDashboard !== true
+  );
+}
+
+function toOnboardingProvider(provider: NoAuthOnboardingMetadata): FreeOnboardingProvider {
+  const defaultModel = REGISTRY[provider.id]?.models?.[0]?.id;
+  return {
+    id: provider.id,
+    name: provider.name,
+    website: provider.website || "",
+    caution:
+      provider.notice?.text ||
+      provider.freeNote ||
+      provider.authHint ||
+      "This provider is operated by a third party and may enforce its own terms and limits.",
+    ...(defaultModel ? { defaultModel } : {}),
+  };
+}
+
+export function getEligibleFreeOnboardingProviders(): FreeOnboardingProvider[] {
+  return Object.values(NOAUTH_PROVIDERS as Record<string, NoAuthOnboardingMetadata>)
+    .filter(isEligibleProvider)
+    .map(toOnboardingProvider)
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function selectUnconfiguredFreeOnboardingProviders(
+  candidates: FreeOnboardingProvider[],
+  connections: ExistingProviderConnection[]
+): FreeOnboardingProvider[] {
+  const configured = new Set(
+    connections
+      .map((connection) => connection.provider)
+      .filter((provider): provider is string => typeof provider === "string")
+  );
+  return candidates.filter((candidate) => !configured.has(candidate.id));
+}
+
+interface SetupFreeProviderConnectionsOptions {
+  requestedIds: string[];
+  candidates: FreeOnboardingProvider[];
+  listExisting: () => Promise<ExistingProviderConnection[]>;
+  create: (input: FreeProviderConnectionInput) => Promise<{ id?: unknown } | null>;
+}
+
+function validateRequestedIds(
+  requestedIds: string[],
+  candidates: FreeOnboardingProvider[]
+): Map<string, FreeOnboardingProvider> {
+  const candidatesById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+  const invalidIds = [...new Set(requestedIds)]
+    .filter((providerId) => !candidatesById.has(providerId))
+    .sort((left, right) => left.localeCompare(right));
+  if (invalidIds.length > 0) {
+    throw new Error(`Ineligible free provider IDs: ${invalidIds.join(", ")}`);
+  }
+  return candidatesById;
+}
+
+export async function setupFreeProviderConnections(
+  options: SetupFreeProviderConnectionsOptions
+): Promise<{ results: FreeProviderSetupResult[] }> {
+  const candidatesById = validateRequestedIds(options.requestedIds, options.candidates);
+  const results: FreeProviderSetupResult[] = [];
+
+  for (const providerId of [...new Set(options.requestedIds)]) {
+    const existing = await options.listExisting();
+    if (existing.some((connection) => connection.provider === providerId)) {
+      results.push({ providerId, status: "skipped", reason: "already-configured" });
+      continue;
+    }
+
+    const candidate = candidatesById.get(providerId)!;
+    try {
+      const connection = await options.create({
+        provider: providerId,
+        authType: "no-auth",
+        name: candidate.name,
+        isActive: true,
+        testStatus: "unknown",
+        ...(candidate.defaultModel ? { defaultModel: candidate.defaultModel } : {}),
+      });
+      if (!connection || typeof connection.id !== "string") {
+        throw new Error("Provider connection was not persisted");
+      }
+      results.push({ providerId, status: "created", connectionId: connection.id });
+    } catch {
+      results.push({ providerId, status: "failed", reason: "Failed to create provider" });
+    }
+  }
+
+  return { results };
+}
+
+let freeProviderSetupQueue: Promise<void> = Promise.resolve();
+
+export async function withFreeProviderSetupLock<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = freeProviderSetupQueue;
+  let release: () => void = () => {};
+  freeProviderSetupQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}

--- a/tests/unit/free-provider-onboarding-selector.test.ts
+++ b/tests/unit/free-provider-onboarding-selector.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getEligibleFreeOnboardingProviders,
+  selectUnconfiguredFreeOnboardingProviders,
+} from "../../src/lib/providers/freeOnboarding.ts";
+
+test("free onboarding candidates come from the no-auth registry and exclude local/non-LLM entries", () => {
+  const providers = getEligibleFreeOnboardingProviders();
+  const ids = providers.map((provider) => provider.id);
+
+  assert.deepEqual(
+    ids,
+    [...ids].sort((a, b) => a.localeCompare(b))
+  );
+  assert.ok(ids.includes("opencode"));
+  assert.ok(ids.includes("duckduckgo-web"));
+  assert.ok(ids.includes("felo-web"));
+  assert.ok(ids.includes("theoldllm"));
+  assert.ok(ids.includes("chipotle"));
+  assert.ok(ids.includes("mimocode"));
+  assert.ok(ids.includes("aihorde"));
+  assert.ok(!ids.includes("devin-cli-agentic"));
+  assert.ok(!ids.includes("auggie"));
+  assert.ok(!ids.includes("veoaifree-web"));
+  assert.ok(providers.every((provider) => provider.caution.length > 0));
+  assert.ok(providers.every((provider) => provider.website.startsWith("https://")));
+});
+
+test("already configured providers are removed without changing registry candidates", () => {
+  const all = getEligibleFreeOnboardingProviders();
+  const available = selectUnconfiguredFreeOnboardingProviders(all, [
+    { provider: "opencode" },
+    { provider: "openai" },
+  ]);
+
+  assert.ok(!available.some((provider) => provider.id === "opencode"));
+  assert.equal(
+    all.some((provider) => provider.id === "opencode"),
+    true
+  );
+});

--- a/tests/unit/free-provider-onboarding-setup.test.ts
+++ b/tests/unit/free-provider-onboarding-setup.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getEligibleFreeOnboardingProviders,
+  setupFreeProviderConnections,
+} from "../../src/lib/providers/freeOnboarding.ts";
+
+test("batch setup creates missing providers, skips existing ones, and is retry-safe", async () => {
+  const existing = [{ provider: "opencode", name: "My customized OpenCode" }];
+  const created: Array<{ provider: string; name: string }> = [];
+  const candidates = getEligibleFreeOnboardingProviders();
+  const requestedIds = ["opencode", "mimocode"];
+
+  const first = await setupFreeProviderConnections({
+    requestedIds,
+    candidates,
+    listExisting: async () => [...existing, ...created],
+    create: async (input) => {
+      created.push({ provider: input.provider, name: input.name });
+      return { id: `created-${input.provider}` };
+    },
+  });
+  const second = await setupFreeProviderConnections({
+    requestedIds,
+    candidates,
+    listExisting: async () => [...existing, ...created],
+    create: async (input) => {
+      created.push({ provider: input.provider, name: input.name });
+      return { id: `created-${input.provider}` };
+    },
+  });
+
+  assert.deepEqual(first.results, [
+    { providerId: "opencode", status: "skipped", reason: "already-configured" },
+    { providerId: "mimocode", status: "created", connectionId: "created-mimocode" },
+  ]);
+  assert.deepEqual(second.results, [
+    { providerId: "opencode", status: "skipped", reason: "already-configured" },
+    { providerId: "mimocode", status: "skipped", reason: "already-configured" },
+  ]);
+  assert.deepEqual(existing, [{ provider: "opencode", name: "My customized OpenCode" }]);
+  assert.deepEqual(created, [{ provider: "mimocode", name: "MiMoCode (Free)" }]);
+});
+
+test("batch setup rejects unknown or ineligible IDs before creating anything", async () => {
+  let createCalls = 0;
+
+  await assert.rejects(
+    setupFreeProviderConnections({
+      requestedIds: ["openai", "missing-provider"],
+      candidates: getEligibleFreeOnboardingProviders(),
+      listExisting: async () => [],
+      create: async () => {
+        createCalls += 1;
+        return { id: "unexpected" };
+      },
+    }),
+    /Ineligible free provider IDs: missing-provider, openai/
+  );
+  assert.equal(createCalls, 0);
+});
+
+test("partial failures are reported per provider and can be retried", async () => {
+  const created = new Set<string>();
+  let mimocodeAttempts = 0;
+  const input = {
+    requestedIds: ["opencode", "mimocode"],
+    candidates: getEligibleFreeOnboardingProviders(),
+    listExisting: async () => [...created].map((provider) => ({ provider })),
+    create: async ({ provider }: { provider: string }) => {
+      if (provider === "mimocode" && mimocodeAttempts++ === 0) throw new Error("upstream detail");
+      created.add(provider);
+      return { id: `created-${provider}` };
+    },
+  };
+
+  const first = await setupFreeProviderConnections(input);
+  const retry = await setupFreeProviderConnections(input);
+
+  assert.deepEqual(first.results, [
+    { providerId: "opencode", status: "created", connectionId: "created-opencode" },
+    { providerId: "mimocode", status: "failed", reason: "Failed to create provider" },
+  ]);
+  assert.deepEqual(retry.results, [
+    { providerId: "opencode", status: "skipped", reason: "already-configured" },
+    { providerId: "mimocode", status: "created", connectionId: "created-mimocode" },
+  ]);
+});

--- a/tests/unit/ui/free-provider-onboarding.test.tsx
+++ b/tests/unit/ui/free-provider-onboarding.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const translate = (key: string) => key;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => translate,
+}));
+
+describe("FreeProviderOnboardingCard", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          providers: [
+            {
+              id: "opencode",
+              name: "OpenCode Free",
+              website: "https://opencode.ai",
+              caution: "Public endpoint. Rate limits apply.",
+              defaultModel: "big-pickle",
+            },
+          ],
+        }),
+      })
+    );
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("shows caution metadata and requires explicit confirmation before setup", async () => {
+    const { FreeProviderOnboardingCard } =
+      await import("../../../src/app/(dashboard)/dashboard/onboarding/steps/FreeProviderOnboardingCard");
+
+    await act(async () => root.render(<FreeProviderOnboardingCard />));
+    await act(async () => Promise.resolve());
+
+    expect(container.textContent).toContain("OpenCode Free");
+    expect(container.textContent).toContain("Public endpoint. Rate limits apply.");
+    expect(container.querySelector('a[href="https://opencode.ai"]')).not.toBeNull();
+
+    const setupButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="setup-free-providers"]'
+    );
+    expect(setupButton?.disabled).toBe(true);
+
+    const confirmation = container.querySelector<HTMLInputElement>(
+      '[data-testid="free-provider-confirmation"]'
+    );
+    await act(async () => confirmation?.click());
+    expect(setupButton?.disabled).toBe(false);
+  });
+
+  it("posts selected IDs only after confirmation and renders partial results for retry", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          providers: [
+            {
+              id: "opencode",
+              name: "OpenCode Free",
+              website: "https://opencode.ai",
+              caution: "Rate limits apply.",
+            },
+            {
+              id: "mimocode",
+              name: "MiMoCode",
+              website: "https://mimo.mi.com",
+              caution: "Bootstrap authentication.",
+            },
+          ],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { providerId: "opencode", status: "created", connectionId: "one" },
+            { providerId: "mimocode", status: "failed", reason: "Failed to create provider" },
+          ],
+        }),
+      } as Response);
+    const { FreeProviderOnboardingCard } =
+      await import("../../../src/app/(dashboard)/dashboard/onboarding/steps/FreeProviderOnboardingCard");
+
+    await act(async () => root.render(<FreeProviderOnboardingCard />));
+    await act(async () => Promise.resolve());
+    await act(async () =>
+      container
+        .querySelector<HTMLInputElement>('[data-testid="free-provider-confirmation"]')
+        ?.click()
+    );
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="setup-free-providers"]')?.click()
+    );
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/providers/free-onboarding",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ providerIds: ["mimocode", "opencode"], confirmed: true }),
+      })
+    );
+    expect(container.textContent).toContain("result.created");
+    expect(container.textContent).toContain("result.failed");
+    expect(container.textContent).toContain("retryFailed");
+  });
+});


### PR DESCRIPTION
## Summary

- derive eligible first-run providers directly from `NOAUTH_PROVIDERS` (free, no-auth, non-local, LLM-capable, and not disabled/deprecated/unsafe)
- add an authenticated batch endpoint that validates the server-derived allowlist, creates only missing connections, preserves existing customized connections, and reports created/skipped/failed results per provider
- add an explicit optional onboarding card with provider selection, caution/site links, confirmation, partial-result reporting, and safe retry
- document the flow and sync the new UI keys across all locale catalogs

Setup completion never creates providers silently.

## Validation

- `node --import tsx/esm --test tests/unit/free-provider-onboarding-selector.test.ts tests/unit/free-provider-onboarding-setup.test.ts` — 5 passed
- `npx vitest run tests/unit/ui/free-provider-onboarding.test.tsx` — 2 passed
- focused ESLint on all changed TypeScript/TSX and tests — passed
- `npm run typecheck:core` — passed
- `node scripts/check/check-test-discovery.mjs` — passed
- `node scripts/check/check-changelog-integrity.mjs` — passed
- locale shape audit — all 43 catalogs contain the same new key structure; PT and PT-BR are translated, other locales use the repository's `__MISSING__` marker workflow
- `npm run typecheck:noimplicit:core` — inherited failures only in untouched `open-sse/utils/usageTracking.ts` and `src/shared/services/cliRuntime.ts`
- dashboard typecheck / complexity ratchets did not complete locally under shared devbox load; CI remains authoritative

Release-green issue #9985 is open for the base branch, but lists no concrete HARD failures.

Closes #9752
