### PR TITLE
fix(search): nest Exa contents options for /search (#9914)

### DIFF
--- a/changelog.d/fixes/9914-search-exa-contents.md
+++ b/changelog.d/fixes/9914-search-exa-contents.md
@@ -1,0 +1,1 @@
+- fix(search): nest Exa contents options (text/highlights) for /search API (#9914)

--- a/open-sse/handlers/search.ts
+++ b/open-sse/handlers/search.ts
@@ -336,8 +336,10 @@ function buildExaRequest(
     query: params.query,
     numResults: params.maxResults,
     type: "auto",
-    text: true,
-    highlights: true,
+    contents: {
+      text: true,
+      highlights: true,
+    },
   };
   if (includes.length) body.includeDomains = includes;
   if (excludes.length) body.excludeDomains = excludes;

--- a/tests/unit/search-handler-extended.test.ts
+++ b/tests/unit/search-handler-extended.test.ts
@@ -123,7 +123,7 @@ test("handleSearch builds Brave news requests and normalizes favicon metadata", 
   }
 });
 
-test("handleSearch builds Exa requests with include/exclude domains and preserves rich result fields", async () => {
+test("handleSearch builds Exa requests with contents-nested options, include/exclude domains, and preserves rich result fields", async () => {
   const originalFetch = globalThis.fetch;
   let captured;
 
@@ -165,8 +165,7 @@ test("handleSearch builds Exa requests with include/exclude domains and preserve
       query: "agentic workflows",
       numResults: 5,
       type: "auto",
-      text: true,
-      highlights: true,
+      contents: { text: true, highlights: true },
       includeDomains: ["allowed.com"],
       excludeDomains: ["blocked.com"],
       category: "news",


### PR DESCRIPTION
Closes #9914

Root cause: buildExaRequest sent text/highlights at the top level of the Exa /search body, but the current Exa API requires them nested under contents. Exa returns no usable results -> empty array.

Regression test: tests/unit/search-handler-extended.test.ts (Exa test) — RED on unfixed code, GREEN after. Gates run: file-size OK (for touched files), check-complexity OK, check-cognitive-complexity OK, typecheck:core exit 0, eslint exit 0, search-area unit tests 76 pass / 0 fail.