### PR TITLE
fix(images): normalize image endpoint error format (#9981)

### DIFF
--- a/changelog.d/fixes/9981-image-error-normalization.md
+++ b/changelog.d/fixes/9981-image-error-normalization.md
@@ -1,0 +1,1 @@
+- fix(images): normalize terminal upstream errors via OpenAI-standard type/code (#9981)

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -308,10 +308,11 @@ async function postHandler(request, context) {
   }
 
   const errorPayload = toJsonErrorPayload((result as any).error, "Image generation provider error");
-  return new Response(JSON.stringify(errorPayload), {
-    status: (result as any).status,
-    headers: { "Content-Type": "application/json" },
-  });
+  const message =
+    typeof errorPayload?.error?.message === "string"
+      ? errorPayload.error.message
+      : "Image generation provider error";
+  return errorResponse((result as any).status, message);
 }
 
 export const POST = withInjectionGuard(postHandler);

--- a/src/app/api/v1/providers/[provider]/images/generations/route.ts
+++ b/src/app/api/v1/providers/[provider]/images/generations/route.ts
@@ -119,8 +119,9 @@ export async function POST(request, { params }) {
   }
 
   const errorPayload = toJsonErrorPayload((result as any).error, "Image generation provider error");
-  return new Response(JSON.stringify(errorPayload), {
-    status: (result as any).status,
-    headers: { "Content-Type": "application/json" },
-  });
+  const message =
+    typeof errorPayload?.error?.message === "string"
+      ? errorPayload.error.message
+      : "Image generation provider error";
+  return errorResponse((result as any).status, message);
 }

--- a/tests/unit/image-generation-route.test.ts
+++ b/tests/unit/image-generation-route.test.ts
@@ -701,6 +701,67 @@ test("provider-scoped image generation POST uses the shared 401 account fallback
   ]);
 });
 
+test("v1 image generation POST normalizes a terminal upstream 401 to the OpenAI-standard error shape", async () => {
+  await seedConnection("openai", { apiKey: "single-expired-image-key" });
+
+  globalThis.fetch = async (url, options: RequestInit = {}) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    const authorization = new Headers(options.headers).get("authorization") ?? "";
+    assert.equal(authorization, "Bearer single-expired-image-key");
+    return new Response(JSON.stringify({ error: { message: "expired access token" } }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/api/v1/images/generations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "openai/gpt-image-2", prompt: "normalize terminal 401" }),
+    })
+  );
+  const body = (await response.json()) as ErrorResponseBody;
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(body.error, {
+    message: "expired access token",
+    type: "authentication_error",
+    code: "invalid_api_key",
+  });
+});
+
+test("provider-scoped image generation POST normalizes a terminal upstream 401 to the OpenAI-standard error shape", async () => {
+  await seedConnection("openai", { apiKey: "provider-single-expired-key" });
+
+  globalThis.fetch = async (url, options: RequestInit = {}) => {
+    assert.equal(String(url), "https://api.openai.com/v1/images/generations");
+    const authorization = new Headers(options.headers).get("authorization") ?? "";
+    assert.equal(authorization, "Bearer provider-single-expired-key");
+    return new Response(JSON.stringify({ error: { message: "expired provider token" } }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const response = await providerImageRoute.POST(
+    new Request("http://localhost/api/v1/providers/openai/images/generations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-image-2", prompt: "normalize provider terminal 401" }),
+    }),
+    { params: Promise.resolve({ provider: "openai" }) }
+  );
+  const body = (await response.json()) as ErrorResponseBody;
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(body.error, {
+    message: "expired provider token",
+    type: "authentication_error",
+    code: "invalid_api_key",
+  });
+});
+
 test("v1 image generation POST refreshes an expired Antigravity token before dispatch", async () => {
   await seedConnection("antigravity", {
     authType: "oauth",


### PR DESCRIPTION
Closes #9981

## Root cause

`src/app/api/v1/images/generations/route.ts` (and its duplicate in `src/app/api/v1/providers/[provider]/images/generations/route.ts`) surfaced terminal upstream errors by returning `toJsonErrorPayload(result.error)` verbatim. That helper only re-wraps the upstream JSON unchanged, keeping non-standard fields (`code:'UNAUTHORIZED'`, `success`, `status`) and never applying the OpenAI-standard status->type/code mapping. Chat completions normalize the same way via `buildErrorBody`/`getErrorInfo` (401 -> `{type:'authentication_error', code:'invalid_api_key'}`), so image clients received a body shape inconsistent with the rest of the API.

## Change

- Extract a client-safe message from `result.error` (reusing `toJsonErrorPayload` for message extraction) and build the response with `errorResponse(status, message)` (which delegates to `buildErrorBody`), instead of returning the raw payload verbatim.
- Applied identically to both image-generations routes.
- HTTP status is unchanged (`getErrorInfo` still maps 400/403/404/429/5xx); only the body shape is normalized.

## Regression test

`tests/unit/image-generation-route.test.ts` — new tests where a single-account `openai` connection receives an upstream `401 {"error":{"message":"expired access token"}}` and `POST /v1/images/generations` must return `{ error: { message, type:'authentication_error', code:'invalid_api_key' } }`. Both the top-level and provider-scoped routes are covered. RED on unfixed code (no `type`/`code`), GREEN after.

## Gates

- `npm run typecheck:core` — pass
- `eslint` on changed files (suppressions flag) — pass
- `check:file-size` — changed files clean (only pre-existing base-red in untouched `open-sse/utils/proxyFetch.ts`)
- `check:complexity` + `check:cognitive-complexity` — pass
- `tests/unit/image-generation-route.test.ts` (22 tests) + `image-generation-route-auth.test.ts` (7 tests) — pass

## Tests Added Or Updated

- `tests/unit/image-generation-route.test.ts` (2 new tests)

## Reviewer Notes

Terminal-only branch normalized; success path and account-rotation behavior unchanged.