### PR TITLE
Hide health-check excluded models from /v1/models catalog

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -393,6 +393,18 @@ async function buildUnifiedModelsResponseCore(
       return collected;
     };
 
+    // Health-check exclusions (provider_specific_data.excludedModels) are enforced
+    // at request time in getProviderCredentials(); mirror the same rule in the
+    // catalog so ghost models do not appear as available. A model is hidden when
+    // the provider HAS connections but NONE of them is eligible for it.
+    const isExcludedByProviderConnections = (providerKey: string, modelId: string) => {
+      const providerId = aliasToProviderId[providerKey] || providerKey;
+      const alias = providerIdToAlias[providerId] || providerKey;
+      const providerConnections = getConnectionsForProvider(providerId, alias, providerKey);
+      if (providerConnections.length === 0) return false; // noAuth / no DB row: keep
+      return !hasEligibleConnectionForModel(providerConnections, modelId);
+    };
+
     const providerSupportsModel = (providerKey: string, modelId: string) => {
       const providerId = aliasToProviderId[providerKey] || providerKey;
       const alias = providerIdToAlias[providerId] || providerKey;
@@ -764,6 +776,7 @@ async function buildUnifiedModelsResponseCore(
         if (!providerSupportsModel(canonicalProviderId, model.id)) continue;
         const aliasId = `${alias}/${model.id}`;
         if (getModelIsHidden(canonicalProviderId, model.id)) continue;
+        if (isExcludedByProviderConnections(canonicalProviderId, model.id)) continue;
         if (shouldHidePaid(canonicalProviderId, model.id, (model as { pricing?: unknown }).pricing))
           continue;
 
@@ -857,6 +870,7 @@ async function buildUnifiedModelsResponseCore(
             continue;
           }
           if (getModelIsHidden(providerId, sm.id)) continue;
+          if (isExcludedByProviderConnections(canonicalProviderId, sm.id)) continue;
           // #6457: some upstream discovery catalogs (e.g. HuggingFace's live
           // `/v1/models`) return image/diffusion models with no modality info,
           // so `endpoints` below would default to ["chat"] and misrepresent
@@ -1233,6 +1247,7 @@ async function buildUnifiedModelsResponseCore(
           if (!modelId) continue;
           if (model.isHidden === true) continue;
           if (getModelIsHidden(canonicalProviderId, modelId)) continue;
+          if (isExcludedByProviderConnections(canonicalProviderId, modelId)) continue;
           // #6328: apply hidePaidModels to user-defined custom rows too.
           // Custom entries do not carry pricing, so shouldHidePaid() decides
           // via FREE_MODEL_IDS_BY_PROVIDER — matches synced/PROVIDER_MODELS.
@@ -1365,6 +1380,7 @@ async function buildUnifiedModelsResponseCore(
         }
 
         if (getModelIsHidden(canonicalProviderId, modelId)) continue;
+        if (isExcludedByProviderConnections(canonicalProviderId, modelId)) continue;
         // #6328: apply hidePaidModels to alias-backed rows too. Alias mappings
         // point at providerKey/modelId with no pricing, so shouldHidePaid()
         // decides via the FREE_MODEL_IDS_BY_PROVIDER catalog tier.
@@ -1437,6 +1453,7 @@ async function buildUnifiedModelsResponseCore(
         const modelId = typeof model.id === "string" ? model.id : null;
         if (!modelId) continue;
         if (getModelIsHidden(canonicalProviderId, modelId)) continue;
+        if (isExcludedByProviderConnections(canonicalProviderId, modelId)) continue;
         // #6328: apply hidePaidModels to managed-fallback rows too. Compatible
         // provider fallbacks lack pricing; shouldHidePaid() decides via the
         // FREE_MODEL_IDS_BY_PROVIDER catalog tier.


### PR DESCRIPTION
## Summary

Mirror the request-time exclusion rule in the unified catalog builder.

Health-check exclusions stored in `provider_specific_data.excludedModels` (per connection) are already enforced at request time in `getProviderCredentials()` — requests for excluded models fail fast with "No active credentials" instead of hitting dead upstream endpoints. However, the `/v1/models` catalog never consulted them, so ghost models (dead/retired/404 models from partially-working providers) still appeared as available.

## Changes

Add `isExcludedByProviderConnections()` helper: a model is hidden when its provider HAS connections but NONE of them is eligible for it (all excluded). No-auth providers with no DB rows are unaffected.

Applied across all chat-model addition paths:
- static `PROVIDER_MODELS` loop
- synced models loop
- user-defined custom models loop
- alias-backed rows
- managed-fallback rows

## Verification

- Catalog shrank from 609 → 232 models after health-check exclusions; all previously-dead models (e.g. `nvidia/codestral-22b-instruct-v0.1`, `hf/Apertus-70B-Instruct-2509`) no longer listed
- All working models (gemini, cohere, DeepSeek-V3, nemotron-3, auto/*) still listed
- Request-time behavior unchanged: excluded models fail fast, working models pass
- ESLint/prettier/t11-any-budget hooks pass