### PR TITLE
fix(responses-api): explicit function-tool declaration must win over apply_patch-is-custom fallback

### DIFF
--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -528,9 +528,21 @@ function emitToolCall(state, emit, tc) {
 
   // Custom tools are surfaced as custom_tool_call items and stream raw input instead of the
   // function_call_arguments.* events used for regular function tools. (#1007)
+  //
+  // apply_patch defaults to custom (native Codex CLI convention: the model emits it
+  // without the client ever declaring it as a tool) UNLESS the client's own request
+  // explicitly declared it with a `parameters` JSON schema — i.e. as a plain
+  // `type:"function"` tool (state.toolSchemas, populated from body.tools by
+  // extractToolSchemaMap()). Live incident: a client that registers apply_patch as a
+  // function tool and only implements function_call dispatch never recognized the
+  // custom_tool_call item this produced, so the tool call was silently never executed
+  // and no follow-up request ever carried a result back. PR #7905 already intended this
+  // precedence ("...while preserving explicit function-tool precedence") but its
+  // unconditional `toolName === "apply_patch"` OR never actually implemented the carve-out.
   const toolName = state.funcNames[tcIdx] || funcName || "";
   const isCustomTool =
-    toolName === "apply_patch" || state.customToolNames?.has?.(toolName) === true;
+    (toolName === "apply_patch" && !state.toolSchemas?.has?.(toolName)) ||
+    state.customToolNames?.has?.(toolName) === true;
 
   if (!state.funcCallIds[tcIdx] && newCallId) state.funcCallIds[tcIdx] = newCallId;
   const callId = state.funcCallIds[tcIdx];
@@ -597,8 +609,11 @@ function closeToolCall(state, emit, idx, recordAsCompleted = true) {
     const normalizedIndex = toolCallOutputIndexBase(state) + normalizeOutputIndex(idx);
     const args = state.funcArgsBuf[idx] || "{}";
     const toolName = state.funcNames[idx] || "";
+    // See emitToolCall()'s isCustomTool comment — must stay in sync (both compute the
+    // same classification independently for their respective add/close call sites).
     const isCustomTool =
-      toolName === "apply_patch" || state.customToolNames?.has?.(toolName) === true;
+      (toolName === "apply_patch" && !state.toolSchemas?.has?.(toolName)) ||
+      state.customToolNames?.has?.(toolName) === true;
 
     let funcItem;
     if (isCustomTool) {

--- a/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
+++ b/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
@@ -8,9 +8,10 @@ const { openaiToOpenAIResponsesResponse } =
 const { initState } = await import("../../open-sse/translator/index.ts");
 const { FORMATS } = await import("../../open-sse/translator/formats.ts");
 
-function collectEvents(chunks, customToolNames = new Set()) {
+function collectEvents(chunks, customToolNames = new Set(), toolSchemas = null) {
   const state = initState(FORMATS.OPENAI_RESPONSES);
   state.customToolNames = customToolNames;
+  if (toolSchemas) state.toolSchemas = toolSchemas;
   const events = [];
   for (const chunk of chunks) {
     const result = openaiToOpenAIResponsesResponse(chunk, state);
@@ -164,6 +165,130 @@ test("OpenAI -> Responses: apply_patch streams as custom_tool_call with raw inpu
   const customItem = completed.data.response.output.find((o) => o.type === "custom_tool_call");
   assert.ok(customItem, "final snapshot should carry the custom_tool_call item");
   assert.equal(customItem.input, "PATCH_BODY");
+});
+
+// Regression (live incident): a client (OpenClaw) that explicitly declares apply_patch
+// as a plain `type:"function"` tool with its own `{input:string}` JSON-schema parameters
+// must get a `function_call` item back with `arguments` as the raw JSON string it
+// registered — NOT the apply_patch-is-always-custom fallback below. PR #7905 ("Restore
+// Responses API custom tool calls") states this precedence should already hold ("...
+// while preserving explicit function-tool precedence") but its `toolName ===
+// "apply_patch"` unconditional OR never actually implemented that carve-out for
+// apply_patch specifically. Forcing custom_tool_call onto a client that registered a
+// function tool means the client's own dispatcher — which only knows how to handle
+// function_call items for a name it declared as type:"function" — never recognizes the
+// item at all: no error, no execution, no follow-up request with the tool result.
+test("OpenAI -> Responses: apply_patch streams as function_call when the client declared it as a function tool (with tool defined)", () => {
+  const toolSchemas = new Map([
+    [
+      "apply_patch",
+      {
+        type: "object",
+        properties: { input: { type: "string" } },
+        required: ["input"],
+      },
+    ],
+  ]);
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-fn-apply-patch",
+        model: "big-pickle",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "apply_patch", arguments: '{"input":"PATCH_BODY"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+      null,
+    ],
+    new Set(), // client did not declare apply_patch as type:"custom"
+    toolSchemas // ...but DID declare it as type:"function" with a parameters schema
+  );
+
+  const added = events.find((e) => e.event === "response.output_item.added");
+  assert.ok(added);
+  assert.equal(
+    added.data.item.type,
+    "function_call",
+    "explicit function-tool declaration must win over the apply_patch-is-custom fallback"
+  );
+  assert.equal(added.data.item.name, "apply_patch");
+
+  assert.ok(
+    events.some((e) => e.event === "response.function_call_arguments.delta"),
+    "expected function_call_arguments.delta events, not custom_tool_call_input.*"
+  );
+  assert.ok(!events.some((e) => e.event === "response.custom_tool_call_input.delta"));
+
+  const done = events.find(
+    (e) => e.event === "response.output_item.done" && e.data.item.type === "function_call"
+  );
+  assert.ok(done);
+  // arguments must stay the raw JSON string the model produced — NOT unwrapped to the
+  // bare patch text the way a genuine custom tool call would be.
+  assert.equal(done.data.item.arguments, '{"input":"PATCH_BODY"}');
+
+  const completed = events.find((e) => e.event === "response.completed");
+  const finalItem = completed.data.response.output.find((o) => o.name === "apply_patch");
+  assert.equal(finalItem.type, "function_call");
+  assert.equal(finalItem.arguments, '{"input":"PATCH_BODY"}');
+});
+
+// Sibling of the test above (without tool defined): when the client's request never
+// declares apply_patch as a tool at all (native Codex CLI convention — the model just
+// emits it), the original #1007 fallback behavior must be unchanged: still custom_tool_call
+// with the raw patch string unwrapped from the model's {"input":"..."} JSON.
+test("OpenAI -> Responses: apply_patch still streams as custom_tool_call when the client never declared it (without tool defined)", () => {
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-no-decl-apply-patch",
+        model: "gpt-5.3-codex",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "apply_patch", arguments: '{"input":"PATCH_BODY"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+      null,
+    ]
+    // no customToolNames, no toolSchemas — apply_patch was never declared by the client
+  );
+
+  const added = events.find((e) => e.event === "response.output_item.added");
+  assert.ok(added);
+  assert.equal(added.data.item.type, "custom_tool_call");
+  assert.equal(added.data.item.name, "apply_patch");
+  assert.ok(events.some((e) => e.event === "response.custom_tool_call_input.delta"));
+
+  const done = events.find(
+    (e) => e.event === "response.output_item.done" && e.data.item.type === "custom_tool_call"
+  );
+  assert.ok(done);
+  assert.equal(done.data.item.input, "PATCH_BODY");
 });
 
 test("OpenAI -> Responses: declared custom tools round-trip through the active translator", () => {


### PR DESCRIPTION
## Summary

`open-sse/translator/response/openai-responses.ts`'s `isCustomTool` check unconditionally treats any tool named `apply_patch` as a Codex-style custom tool:

```js
const isCustomTool =
  toolName === "apply_patch" || state.customToolNames?.has?.(toolName) === true;
```

This overrides a client's own explicit declaration whenever it registers `apply_patch` as a plain `type:"function"` tool (with its own JSON-schema `parameters`) instead of `type:"custom"`.

**Live incident**: OpenClaw (combo `default` → `opencode-zen/big-pickle`) declared `apply_patch` as `type:"function"` with `{input:string}` parameters. The model correctly produced valid JSON matching that schema (`{"input":"*** Begin Patch..."}`), but OmniRoute unwrapped it into a `custom_tool_call` with raw-text `input` instead of the `function_call`/`arguments` shape the client actually registered. OpenClaw's own dispatcher only implements `function_call` handling for a name it declared as `type:"function"`, so it silently never recognized the tool call at all — no error, no execution, no follow-up request ever carrying a result back to the model.

Traced the exact live code path (`chatCore.ts` → `createSSEStream` translate mode → `translator/index.ts`'s hub-and-spoke `openai → openai-responses` conversion) to confirm **this file** — not `transformer/responsesTransformer.ts` — is what handles combo-routed streaming for this client/provider format pair.

This bug traces back to #7905 ("Restore Responses API custom tool calls"), which already states this exact precedence should hold ("...while preserving explicit function-tool precedence") but whose unconditional `toolName === "apply_patch"` OR never actually implemented that carve-out for `apply_patch` specifically. This PR closes the gap between that PR's stated intent and its actual behavior. Linking for context: #7905.

⚠️ base-red inherited: #9985

## Fix

`state.toolSchemas` (populated from `body.tools` by `extractToolSchemaMap()`, already threaded through `stream.ts`'s translate state for a different purpose — #6951's `stripEmptyOptionalToolArgs`) only contains an entry for a tool name when the client's request declared it with a `parameters` JSON schema, i.e. as `type:"function"`. Gate the `apply_patch` fallback on **not** finding it there: `apply_patch` still defaults to custom (native Codex CLI convention — the model emits it without the client ever declaring it as a tool) unless the client explicitly registered it as a function tool, in which case that explicit declaration wins.

## Test plan

- **TDD**: two new regression tests in `tests/unit/translator-openai-responses-custom-tool-1007.test.ts`:
  - *"...with tool defined"* — client declares `apply_patch` as `type:"function"` → expects `function_call` with `arguments` staying the raw JSON string. Confirmed failing against the pre-fix code, passing after.
  - *"...without tool defined"* — client never declares `apply_patch` at all → expects unchanged `custom_tool_call` fallback (mirrors the existing #1007 coverage). Passed before and after — regression guard for the existing fallback behavior.
- Full related suite (`translator-openai-responses-custom-tool-1007`, `responses-handler`, `responses-active-stream-custom-tool`, `translator-resp-openai-responses`, `translator-resp-openai-responses-namespace-identity`, `translator-openai-responses-image-output-8459`, `responses-transformer`) — 64/64 passing, no regressions to #7905's own custom-tool coverage.
- `npx tsc --noEmit` — clean (pre-existing loose-typing errors in this test file confirmed identical on a pristine upstream checkout).
- `npm run lint` — clean.