### PR TITLE
fix(ci): repair and wire the two live-server E2E suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1254,6 +1254,63 @@ jobs:
       - run: npm run check:node-runtime
       - run: npm run test:security
 
+  # Live-server E2E. Both suites boot a real OmniRoute via their own runner and
+  # drive it over HTTP; neither needs provider credentials. They were documented in
+  # AGENTS.md's test matrix but wired to NO workflow, and had additionally been
+  # unrunnable (vitest.config.ts excluded the very files their runners passed as a
+  # positional filter) — so nothing had executed them for as long as that was true.
+  test-ecosystem:
+    name: Ecosystem E2E (live server)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # needs: changes (not build) — the runner boots its own dev server.
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
+    env:
+      JWT_SECRET: ci-test-secret-with-sufficient-length-for-validation
+      API_KEY_SECRET: ci-test-api-key-secret-long
+      DISABLE_SQLITE_AUTO_BACKUP: "true"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.CI_NODE_VERSION }}
+          cache: npm
+      - uses: ./.github/actions/npm-ci-retry
+      - run: npm run check:node-runtime
+      - run: npm run test:ecosystem
+
+  test-protocols-e2e:
+    name: Protocol Clients E2E (live server, advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
+    # ADVISORY until #10049 is resolved. Restoring this suite immediately surfaced a
+    # real discrepancy that had been invisible while it could not run: GET
+    # /api/mcp/audit answers 403 over loopback where the suite expects 200|401. That
+    # is a pre-existing contract question, not a defect introduced by wiring the job
+    # up, so it must not block every PR in the meantime. Flip to blocking (drop this
+    # continue-on-error) the moment #10049 lands.
+    continue-on-error: true
+    env:
+      JWT_SECRET: ci-test-secret-with-sufficient-length-for-validation
+      API_KEY_SECRET: ci-test-api-key-secret-long
+      DISABLE_SQLITE_AUTO_BACKUP: "true"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.CI_NODE_VERSION }}
+          cache: npm
+      - uses: ./.github/actions/npm-ci-retry
+      - run: npm run check:node-runtime
+      - run: npm run test:protocols:e2e
+
   ci-summary:
     name: CI Dashboard
     runs-on: ubuntu-latest
@@ -1276,6 +1333,8 @@ jobs:
       - test-e2e
       - test-integration
       - test-security
+      - test-ecosystem
+      - test-protocols-e2e
     steps:
       - name: Download i18n results
         continue-on-error: true
@@ -1356,6 +1415,8 @@ jobs:
           echo "| E2E | $(status '${{ needs.test-e2e.result }}') |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Integration | $(status '${{ needs.test-integration.result }}') |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Security Tests | $(status '${{ needs.test-security.result }}') |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Ecosystem E2E | $(status '${{ needs.test-ecosystem.result }}') |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Protocol Clients E2E (advisory, #10049) | $(status '${{ needs.test-protocols-e2e.result }}') |" >> "$GITHUB_STEP_SUMMARY"
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "## 🌍 Translations" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,16 +425,16 @@ For any non-trivial change, read the matching deep-dive first:
 
 ## Testing
 
-| What                    | Command                                                                     |
-| ----------------------- | --------------------------------------------------------------------------- |
-| Unit tests              | `npm run test:unit`                                                         |
-| Single file             | `node --import tsx/esm --test tests/unit/your-file.test.ts`                 |
-| Vitest (MCP, autoCombo) | `npm run test:vitest`                                                       |
-| E2E (Playwright)        | `npm run test:e2e`                                                          |
-| Protocol E2E (MCP+A2A)  | `npm run test:protocols:e2e`                                                |
-| Ecosystem               | `npm run test:ecosystem`                                                    |
-| Coverage gate           | `npm run test:coverage` (60/60/60/60 — statements/lines/functions/branches) |
-| Coverage report         | `npm run coverage:report`                                                   |
+| What                    | Command                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| Unit tests              | `npm run test:unit`                                                           |
+| Single file             | `node --import tsx/esm --test tests/unit/your-file.test.ts`                   |
+| Vitest (MCP, autoCombo) | `npm run test:vitest`                                                         |
+| E2E (Playwright)        | `npm run test:e2e`                                                            |
+| Protocol E2E (MCP+A2A)  | `npm run test:protocols:e2e` (CI job `test-protocols-e2e`, advisory — #10049) |
+| Ecosystem               | `npm run test:ecosystem` (CI job `test-ecosystem`, blocking)                  |
+| Coverage gate           | `npm run test:coverage` (60/60/60/60 — statements/lines/functions/branches)   |
+| Coverage report         | `npm run coverage:report`                                                     |
 
 **PR rule**: If you change production code in `src/`, `open-sse/`, `electron/`, or `bin/`, you must include or update tests in the same PR.
 

--- a/scripts/dev/run-ecosystem-tests.mjs
+++ b/scripts/dev/run-ecosystem-tests.mjs
@@ -74,7 +74,15 @@ async function main() {
 
   const vitestProcess = spawn(
     process.execPath,
-    ["./node_modules/vitest/vitest.mjs", "run", "tests/e2e/ecosystem.test.ts"],
+    [
+      "./node_modules/vitest/vitest.mjs",
+      "run",
+      // Without --config, Vitest loads vitest.config.ts, whose exclude list drops
+      // this file — the run then dies with "No test files found".
+      "--config",
+      "vitest.e2e-live.config.ts",
+      "tests/e2e/ecosystem.test.ts",
+    ],
     {
       stdio: "inherit",
       env: testEnv,

--- a/scripts/dev/run-protocol-clients-tests.mjs
+++ b/scripts/dev/run-protocol-clients-tests.mjs
@@ -73,8 +73,11 @@ async function main() {
     [
       "./node_modules/vitest/vitest.mjs",
       "run",
-      "--environment",
-      "node",
+      // Without --config, Vitest loads vitest.config.ts, whose exclude list drops
+      // this file — the run then dies with "No test files found". The config also
+      // sets environment: node, so the flag is no longer needed here.
+      "--config",
+      "vitest.e2e-live.config.ts",
       "tests/e2e/protocol-clients.test.ts",
     ],
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,8 +24,6 @@ export default defineConfig({
       "tests/unit/**/*.test.tsx",
       "open-sse/**/__tests__/**/*.test.ts",
       "open-sse/services/**/__tests__/**/*.test.ts",
-      "tests/e2e/ecosystem.test.ts",
-      "tests/e2e/protocol-clients.test.ts",
     ],
     exclude: [
       // Standard Vitest / tooling exclusions
@@ -35,7 +33,8 @@ export default defineConfig({
       ".idea/**",
       ".git/**",
       ".cache/**",
-      // E2E tests — run via their own scripts, not the UI vitest job
+      // Live-server E2E — these drive a real running server, so they must never run
+      // in this jsdom job. They have their own runners + vitest.e2e-live.config.ts.
       "tests/e2e/ecosystem.test.ts",
       "tests/e2e/protocol-clients.test.ts",
       // ── Pre-existing failures tracked by #8618 ───────────────────────────────

--- a/vitest.e2e-live.config.ts
+++ b/vitest.e2e-live.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+/**
+ * Live-server E2E suites (`tests/e2e/ecosystem.test.ts`,
+ * `tests/e2e/protocol-clients.test.ts`).
+ *
+ * These are the only two suites that drive a REAL running OmniRoute over HTTP
+ * rather than importing modules. Their runners — `scripts/dev/run-ecosystem-tests.mjs`
+ * and `scripts/dev/run-protocol-clients-tests.mjs` — boot a dev server, wait for
+ * `/api/monitoring/health`, then invoke Vitest with this config.
+ *
+ * They need their own config because `vitest.config.ts` deliberately EXCLUDES both
+ * files (they must not run in the jsdom UI job, which has no server). Since the
+ * runners previously invoked Vitest with no `--config`, they loaded that default
+ * config and the exclusion discarded the very file passed as the positional filter —
+ * so both scripts failed with "No test files found, exiting with code 1" and neither
+ * suite had a way to execute.
+ */
+export default defineConfig({
+  test: {
+    // Real HTTP against a running server — never jsdom.
+    environment: "node",
+    globals: true,
+    include: ["tests/e2e/ecosystem.test.ts", "tests/e2e/protocol-clients.test.ts"],
+    exclude: ["**/node_modules/**", "**/.git/**"],
+    // Both suites share ONE server instance, so files must not run concurrently.
+    fileParallelism: false,
+    // Upstream calls over the network are slower than in-process unit tests; the
+    // suites themselves also read ECOSYSTEM_*_TIMEOUT_MS for their per-case budgets.
+    testTimeout: 60000,
+    hookTimeout: 60000,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      // Mirrors tsconfig paths, same as the other two vitest configs.
+      "@omniroute/open-sse": path.resolve(__dirname, "./open-sse"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

`tests/e2e/ecosystem.test.ts` and `tests/e2e/protocol-clients.test.ts` are listed in the
`AGENTS.md` test matrix, but they ran in **no workflow** — and, more importantly, they could
not run **at all**.

Both files appear in `vitest.config.ts` under `include` **and** under `exclude`. Exclude wins.
Their runners (`scripts/dev/run-ecosystem-tests.mjs`,
`scripts/dev/run-protocol-clients-tests.mjs`) invoked Vitest with **no `--config`**, so they
loaded that same default config, whose exclusion discarded the exact file each one passed as
its positional filter:

```
$ npm run test:ecosystem
No test files found, exiting with code 1
filter: tests/e2e/ecosystem.test.ts
```

Both scripts have therefore been exiting 1 on a clean tree. The server boots fine; Vitest
simply refuses to collect the file.

## Changes

1. **`vitest.e2e-live.config.ts`** (new) — covers only these two suites. `environment: node`
   (they drive real HTTP, never jsdom) and `fileParallelism: false` (they share one server).
2. **Both runners** — pass `--config vitest.e2e-live.config.ts`. The protocol runner's
   `--environment node` flag is now redundant and drops out.
3. **`vitest.config.ts`** — remove the two `include` entries that contradicted its own
   `exclude`. The exclusions stay, with a comment saying why: these drive a live server and
   must never run in the jsdom UI job.
4. **CI** — add `test-ecosystem` (blocking) and `test-protocols-e2e` (advisory, see below),
   register both in `ci-summary`.
5. **`AGENTS.md`** — the test matrix now names the CI job backing each suite.

## Validation

Before, on this branch's base (`8fc4023f9`), no server required — collection fails first:

```
$ node ./node_modules/vitest/vitest.mjs run tests/e2e/ecosystem.test.ts
No test files found, exiting with code 1
```

After:

```
$ npm run test:ecosystem
GET /api/monitoring/health 200 in 29ms
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  8.03s
→ exit 0
```

```
$ npm run test:protocols:e2e
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

Also green: `npm run check:test-discovery` (4363 files, 31 collectors, 13 frozen orphans),
`npm run check:test-runner-api`. `npm run check:workflows` skips locally (actionlint/zizmor
not installed); CI runs it.

## Why `test-protocols-e2e` is advisory

Restoring the suite immediately surfaced a real discrepancy that was invisible while it could
not run: `GET /api/mcp/audit` answers **403** over loopback where the suite expects `200|401`.

Filed as **#10049** with the triage so far. Two candidates were ruled out: it is *not* the
missing `REQUIRE_API_KEY` (the ecosystem runner sets it, this one doesn't — adding it changes
nothing), and *not* IPv4-mapped IPv6 peer classification (`routeGuard.ts:118` already strips
`::ffff:`). The open question is whether `/api/mcp/audit` should pass
`invalidApiKeyStatus: 401` (it currently inherits `requireManagementAuth`'s 403 default) or
whether 403 is the deliberate `LOCAL_ONLY` contract and the assertion predates the route-guard
tiers work.

That is a pre-existing contract question, not something this PR introduces, so the job carries
`continue-on-error: true` rather than turning every PR red. Flip it to blocking when #10049
lands — the workflow comment says exactly that.

## Scope

No production code. Test configuration, two dev runner scripts, CI wiring, and one doc row.

⚠️ base-red inherited: #9985 (`🔴 Release branch not green: release/v3.8.50`)
