### PR TITLE
fix(zed-hosted): send the provider wire values cloud.zed.dev accepts

### DIFF
--- a/open-sse/executors/zed-hosted.ts
+++ b/open-sse/executors/zed-hosted.ts
@@ -41,11 +41,21 @@ import { openaiResponsesToOpenAIResponse } from "../translator/response/openai-r
 import { ZED_HEADERS, resolveZedModels, zedLlmFetch, type ZedCredentials } from "../shared/zedAuth.ts";
 import { resolveSuppressThinkClose, THINKING_MARKER_HEADER } from "../utils/thinkCloseMarker.ts";
 
+// Wire values for the `provider` field of POST /completions. These are NOT
+// display names: cloud.zed.dev matches them exactly, and an unrecognized value
+// fails the whole request with `500 {"message":"An internal server error
+// occurred."}` before the model is ever looked at — which is why every model id,
+// including invalid ones, produced an identical 500.
+//
+// The spellings come from Zed's own GET /models catalog, which reports
+// `anthropic`, `open_ai` and `google` (note the underscore); `x_ai` follows the
+// same convention. Feeding a catalog value back through normalizeZedProvider is
+// therefore identity, as it must be.
 const ZED_PROVIDER = {
-  anthropic: "Anthropic",
-  openai: "OpenAi",
-  google: "Google",
-  xai: "XAi",
+  anthropic: "anthropic",
+  openai: "open_ai",
+  google: "google",
+  xai: "x_ai",
 } as const;
 
 type ZedProviderName = (typeof ZED_PROVIDER)[keyof typeof ZED_PROVIDER];

--- a/tests/unit/zed-hosted-think-close-marker.test.ts
+++ b/tests/unit/zed-hosted-think-close-marker.test.ts
@@ -53,7 +53,9 @@ async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
 
 function wrapAnthropic(options?: Record<string, unknown>): Promise<string> {
   const response = new Response(buildZedAnthropicNdjson(), { status: 200 });
-  const wrapped = wrapZedCompletionStream(response, "Anthropic", "claude-test", options);
+  // "anthropic" is the wire value normalizeZedProvider now returns (and the one
+  // cloud.zed.dev accepts); the capitalized spelling 500s upstream.
+  const wrapped = wrapZedCompletionStream(response, "anthropic", "claude-test", options);
   return readAll(wrapped.body as ReadableStream<Uint8Array>);
 }
 

--- a/tests/unit/zed-provider.test.ts
+++ b/tests/unit/zed-provider.test.ts
@@ -260,22 +260,57 @@ describe("mapZedModel", () => {
 // ─── Executor: provider-family inference ────────────────────────────────────
 
 describe("normalizeZedProvider", () => {
-  test("maps explicit provider strings", () => {
-    assert.equal(normalizeZedProvider("anthropic", "any"), "Anthropic");
-    assert.equal(normalizeZedProvider("openai", "any"), "OpenAi");
-    assert.equal(normalizeZedProvider("open_ai", "any"), "OpenAi");
-    assert.equal(normalizeZedProvider("google", "any"), "Google");
-    assert.equal(normalizeZedProvider("gemini", "any"), "Google");
-    assert.equal(normalizeZedProvider("xai", "any"), "XAi");
-    assert.equal(normalizeZedProvider("x-ai", "any"), "XAi");
+  // The return value is not internal — it is serialized straight into the
+  // `provider` field of the POST /completions envelope, so it must be a wire
+  // value cloud.zed.dev accepts. Verified live against the API:
+  //
+  //   {"provider":"anthropic",...} -> 200
+  //   {"provider":"Anthropic",...} -> 500 {"message":"An internal server error occurred."}
+  //   {"provider":"open_ai",...}   -> reaches the OpenAI request parser
+  //   {"provider":"openai",...}    -> 500 (same internal error)
+  //
+  // Zed's own GET /models catalog reports exactly `anthropic`, `open_ai` and
+  // `google`, which is the authority these values follow.
+  test("returns the wire values cloud.zed.dev accepts", () => {
+    assert.equal(normalizeZedProvider("anthropic", "any"), "anthropic");
+    assert.equal(normalizeZedProvider("openai", "any"), "open_ai");
+    assert.equal(normalizeZedProvider("open_ai", "any"), "open_ai");
+    assert.equal(normalizeZedProvider("google", "any"), "google");
+    assert.equal(normalizeZedProvider("gemini", "any"), "google");
+    assert.equal(normalizeZedProvider("xai", "any"), "x_ai");
+    assert.equal(normalizeZedProvider("x-ai", "any"), "x_ai");
+  });
+
+  test("round-trips the provider values Zed's own catalog reports", () => {
+    // rawById entries carry `provider` straight from GET /models. Feeding those
+    // back must be identity — anything else corrupts a value Zed already gave us.
+    for (const wire of ["anthropic", "open_ai", "google"]) {
+      assert.equal(normalizeZedProvider(wire, "any"), wire);
+    }
   });
 
   test("infers from the model id when provider is absent", () => {
-    assert.equal(normalizeZedProvider(null, "claude-sonnet-5"), "Anthropic");
-    assert.equal(normalizeZedProvider(null, "gemini-3.1-pro"), "Google");
-    assert.equal(normalizeZedProvider(null, "grok-4"), "XAi");
-    assert.equal(normalizeZedProvider(null, "gpt-5.5"), "OpenAi");
-    assert.equal(normalizeZedProvider(null, "some-unknown-model"), "OpenAi");
+    assert.equal(normalizeZedProvider(null, "claude-sonnet-5"), "anthropic");
+    assert.equal(normalizeZedProvider(null, "gemini-3.1-pro"), "google");
+    assert.equal(normalizeZedProvider(null, "grok-4"), "x_ai");
+    assert.equal(normalizeZedProvider(null, "gpt-5.5"), "open_ai");
+    assert.equal(normalizeZedProvider(null, "some-unknown-model"), "open_ai");
+  });
+
+  test("never emits a capitalized provider — the shape that 500s upstream", () => {
+    const cases: [unknown, string][] = [
+      ["anthropic", "any"],
+      ["openai", "any"],
+      ["google", "any"],
+      ["xai", "any"],
+      [null, "claude-sonnet-5"],
+      [null, "gpt-5.5"],
+      [null, "some-unknown-model"],
+    ];
+    for (const [raw, model] of cases) {
+      const out = normalizeZedProvider(raw, model);
+      assert.equal(out, out.toLowerCase(), `${String(raw)}/${model} produced "${out}"`);
+    }
   });
 });
 
@@ -354,7 +389,7 @@ describe("ZedHostedExecutor.resolveModel + zedLlmFetch (mocked upstream)", () =>
       undefined,
       undefined
     );
-    assert.equal(result.provider, "Anthropic");
+    assert.equal(result.provider, "anthropic");
     assert.ok(calls.some((u) => u.includes("/client/llm_tokens")));
     assert.ok(calls.some((u) => u.includes("/models")));
   });
@@ -378,7 +413,7 @@ describe("ZedHostedExecutor.resolveModel + zedLlmFetch (mocked upstream)", () =>
       undefined,
       { warn: (_tag: string, msg: string) => warnCalls.push(msg) } as ExecutorLog
     );
-    assert.equal(result.provider, "Google");
+    assert.equal(result.provider, "google");
     assert.ok(warnCalls.length > 0);
   });
 });


### PR DESCRIPTION
## Summary

Every `zed-hosted` completion fails with a 500, for **every** model id — including deliberately invalid ones:

```
POST /v1/chat/completions {"model":"zed-hosted/claude-sonnet-5", ...}
-> 500 {"error":{"message":"[500]: An internal server error occurred."}}
```

`ZED_PROVIDER` held display-cased names (`"Anthropic"`, `"OpenAi"`, `"Google"`, `"XAi"`), but `normalizeZedProvider`'s return value is not internal — `execute` serializes it straight into the `provider` field of the `POST /completions` envelope. Zed matches that field exactly and rejects the request *before* resolving the model, which is exactly why the model id never mattered.

There is a second-order effect worth calling out: `normalizeZedProvider` already **accepts** Zed's correct lowercase spellings as input (`anthropic`, `open_ai`, `google`, `x_ai`) and then re-cases them into the form that 500s. So when the model catalog is available, the function takes a correct value Zed itself supplied and corrupts it. After this change it is identity on catalog values, as it should be.

## Verification

Live against `cloud.zed.dev`, requests otherwise byte-identical (same headers, same `provider_request`, same account):

| `provider` | result |
|---|---|
| `anthropic` | **200**, streams normally |
| `Anthropic` | **500** `{"message":"An internal server error occurred."}` |
| `open_ai` | reaches the OpenAI request parser (400 on a deliberately malformed body — i.e. dispatched) |
| `openai` | **500**, same internal error |
| `OpenAi` | **500**, same internal error |

The 500 body matches the reported symptom byte for byte.

The spellings follow Zed's own `GET /models` catalog, which reports exactly:

```
'anthropic'   4 models   e.g. claude-sonnet-5
'open_ai'     9 models   e.g. gpt-5.6-sol
'google'      3 models   e.g. gemini-3.1-pro-preview
```

Note `open_ai` carries an underscore. **`x_ai` follows the same convention but is not directly observed** — this account's catalog exposes no xAI models, so that one spelling is inference rather than measurement. Happy to drop it to a separate change if you'd rather not take an unverified value.

## Scope

`ZED_PROVIDER` is module-local and every branch (`initProviderState`, `convertProviderEvent`, `buildProviderRequest`) compares against the constant rather than a literal, so internal dispatch is unaffected — only the wire value changes.

## Tests

`tests/unit/zed-provider.test.ts` previously asserted the display-cased values, encoding the bug. Updated, plus four new cases: the wire-value contract, catalog round-trip identity, model-id inference, and a guard that no input can ever produce a capitalized provider. `tests/unit/zed-hosted-think-close-marker.test.ts` passed `"Anthropic"` to `wrapZedCompletionStream` directly and is updated to the value the executor now produces.

All 7 zed test files pass — 66/66:

```
tests/unit/{mitm-handler-zed,zed-docker-detect,zed-hosted-models-discovery-route,
            zed-hosted-think-close-marker,zed-import-utils,zed-oauth-provider,
            zed-provider}.test.ts
# tests 66   # pass 66   # fail 0
```

## Context

Follows #9628 (zed-hosted model discovery). That fix made the catalog load; this one makes inference actually work. Both were found running the provider against a real Zed account — #6118 shipped it tagged *"NEEDS LIVE OAUTH VALIDATION"*, and this is the second defect from that same gap.

Unrelated latent defect noticed while tracing, **not** addressed here to keep this focused: `openaiToClaudeRequest` attaches `result._toolNameMap` (a `Map`) and never deletes it before returning, so it serializes into the outbound body as `"_toolNameMap":{}` whenever the request carries tools. Zed tolerates the unknown field; a direct Anthropic call would not. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)