### PR TITLE
fix(models): memoize getModelsDevPricing (event loop / healthz)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3692,9 +3692,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3710,9 +3707,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3730,9 +3724,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3748,9 +3739,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3768,9 +3756,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3786,9 +3771,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3806,9 +3788,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3825,9 +3804,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3843,9 +3819,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3869,9 +3842,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3893,9 +3863,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3919,9 +3886,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3943,9 +3907,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3969,9 +3930,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3994,9 +3952,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4018,9 +3973,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5393,9 +5345,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5411,9 +5360,6 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5431,9 +5377,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5449,9 +5392,6 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10670,9 +10610,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10690,9 +10627,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10710,9 +10644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10730,9 +10661,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12779,9 +12707,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12795,9 +12720,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12811,9 +12733,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12827,9 +12746,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12843,9 +12759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -12859,9 +12772,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -24475,6 +24385,17 @@
       "optional": true,
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/libxmljs2/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/libxmljs2/node_modules/cacache": {

--- a/src/lib/modelsDevSync.ts
+++ b/src/lib/modelsDevSync.ts
@@ -194,9 +194,28 @@ function mapCapabilityRecord(record: Record<string, unknown>): ModelCapabilityEn
 }
 
 /**
+ * Process-local memo for models.dev pricing.
+ *
+ * `resolveCatalogPricing` used to call `getModelsDevPricing()` once per model
+ * while building `/v1/models` (~10k+ times). Each call re-ran the full SQL scan
+ * and `JSON.parse`d every pricing row, pegging the event loop for minutes
+ * (see #9685 / #10052). Memoize until the next save/clear write.
+ */
+let modelsDevPricingCache: PricingByProvider | null = null;
+
+function invalidateModelsDevPricingCache(): void {
+  modelsDevPricingCache = null;
+}
+
+/**
  * Read synced pricing from `models_dev_pricing` namespace.
+ * Results are memoized until `saveModelsDevPricing` / `clearModelsDevPricing`.
  */
 export function getModelsDevPricing(): PricingByProvider {
+  if (modelsDevPricingCache) {
+    return modelsDevPricingCache;
+  }
+
   const db = getDbInstance();
   const rows = db
     .prepare("SELECT key, value FROM key_value WHERE namespace = 'models_dev_pricing'")
@@ -213,6 +232,7 @@ export function getModelsDevPricing(): PricingByProvider {
       console.warn(`[MODELS_DEV] Corrupted pricing data for provider "${key}", skipping`);
     }
   }
+  modelsDevPricingCache = synced;
   return synced;
 }
 
@@ -233,6 +253,7 @@ export function saveModelsDevPricing(data: PricingByProvider): void {
   });
   tx();
   backupDbFile("pre-write");
+  invalidateModelsDevPricingCache();
   invalidateDbCache("pricing");
 }
 
@@ -243,6 +264,7 @@ export function clearModelsDevPricing(): void {
   const db = getDbInstance();
   db.prepare("DELETE FROM key_value WHERE namespace = 'models_dev_pricing'").run();
   backupDbFile("pre-write");
+  invalidateModelsDevPricingCache();
   invalidateDbCache("pricing");
 }
 

--- a/src/lib/modelsDevSync.ts
+++ b/src/lib/modelsDevSync.ts
@@ -20,6 +20,7 @@
 import { getDbInstance } from "./db/core";
 import { invalidateDbCache } from "./db/readCache";
 import { backupDbFile } from "./db/backup";
+import { registerDbStateResetter } from "./db/stateReset";
 
 import {
   transformModelsDevToPricing,
@@ -206,6 +207,9 @@ let modelsDevPricingCache: PricingByProvider | null = null;
 function invalidateModelsDevPricingCache(): void {
   modelsDevPricingCache = null;
 }
+
+// Register cache invalidation with DB state reset system so resetDbInstance() clears the memo.
+registerDbStateResetter(invalidateModelsDevPricingCache);
 
 /**
  * Read synced pricing from `models_dev_pricing` namespace.

--- a/tests/unit/modelsDevSync-extended.test.ts
+++ b/tests/unit/modelsDevSync-extended.test.ts
@@ -260,6 +260,33 @@ test("modelsDev pricing helpers persist records, skip corrupted rows, and clear 
   assert.deepEqual(modelsDev.getModelsDevPricing(), {});
 });
 
+test("getModelsDevPricing memoizes until save/clear (#9685)", async () => {
+  const modelsDev = await importFresh("pricing-memo");
+  const pricing = modelsDev.transformModelsDevToPricing(MOCK_MODELS_DEV_DATA);
+  modelsDev.saveModelsDevPricing(pricing);
+
+  const first = modelsDev.getModelsDevPricing();
+  const second = modelsDev.getModelsDevPricing();
+  assert.equal(first, second, "repeated reads must return the same memoized object");
+
+  // Mutating DB under the cache must not be visible until invalidation.
+  const db = core.getDbInstance();
+  db.prepare("DELETE FROM key_value WHERE namespace = 'models_dev_pricing'").run();
+  assert.equal(
+    modelsDev.getModelsDevPricing(),
+    first,
+    "raw SQL without save/clear must not bypass the memo"
+  );
+
+  modelsDev.clearModelsDevPricing();
+  assert.deepEqual(modelsDev.getModelsDevPricing(), {});
+
+  modelsDev.saveModelsDevPricing(pricing);
+  const afterSave = modelsDev.getModelsDevPricing();
+  assert.notEqual(afterSave, first, "save must invalidate the memo");
+  assert.equal(afterSave.openai["gpt-4o"].input, 2.5);
+});
+
 test("modelsDev capabilities helpers create the table, persist rows, filter by provider/model, and expose context limits", async () => {
   const modelsDev = await importFresh("capabilities-storage");
   const capabilities = modelsDev.transformModelsDevToCapabilities(MOCK_MODELS_DEV_DATA);

--- a/tests/unit/modelsDevSync-extended.test.ts
+++ b/tests/unit/modelsDevSync-extended.test.ts
@@ -285,6 +285,18 @@ test("getModelsDevPricing memoizes until save/clear (#9685)", async () => {
   const afterSave = modelsDev.getModelsDevPricing();
   assert.notEqual(afterSave, first, "save must invalidate the memo");
   assert.equal(afterSave.openai["gpt-4o"].input, 2.5);
+
+  // Copilot review: DB reset must invalidate the memo so import/restore doesn't serve stale pricing.
+  const beforeReset = modelsDev.getModelsDevPricing();
+  core.resetDbInstance();
+  const afterReset = modelsDev.getModelsDevPricing();
+  assert.notEqual(
+    afterReset,
+    beforeReset,
+    "resetDbInstance must invalidate the memo (Copilot #10055)"
+  );
+  // Data is still on disk after resetDbInstance(), but the cache was cleared and re-read from fresh DB.
+  assert.equal(afterReset.openai["gpt-4o"].input, 2.5, "DB reset re-reads from fresh connection");
 });
 
 test("modelsDev capabilities helpers create the table, persist rows, filter by provider/model, and expose context limits", async () => {


### PR DESCRIPTION
## Summary

Fixes **#9685** (primary) and materially reduces **#10052** probe timeouts when `/v1/models` is the hot path.

`resolveCatalogPricing` called `getModelsDevPricing()` **once per model** while building the unified catalog. Each call re-ran:

```sql
SELECT key, value FROM key_value WHERE namespace = 'models_dev_pricing'
```

and `JSON.parse`d every pricing row. On a large catalog that is ~10k SQL scans and multi‑GB of JSON parse work, holding the Node event loop so **all** HTTP handlers — including stock `/healthz` — stop answering.

### Change
- Process-local memo of the parsed `PricingByProvider` map
- Invalidate on `saveModelsDevPricing` / `clearModelsDevPricing` (same write path that already calls `invalidateDbCache("pricing")`)
- Unit test: same-object memo + invalidation on clear/save

### Why not a separate health server?
Same-process side channels do not help when the loop is CPU-blocked. Fixing the hog is the correct root-cause fix for both issues.

## Test plan
- [x] Unit test `getModelsDevPricing memoizes until save/clear (#9685)`
- [ ] CI unit suite
- [ ] Manual: `GET /v1/models` on a large pricing set stays under a few seconds; concurrent `GET /healthz` remains 200

## Security
No secrets or private hostnames.