### PR TITLE
fix(combo): restore HARD_COMPAT_REASONS declaration dropped by #9901 cherry-pick

### DIFF
--- a/changelog.d/fixes/combo-hard-compat-reasons.md
+++ b/changelog.d/fixes/combo-hard-compat-reasons.md
@@ -1,0 +1,1 @@
+- fix(combo): restore the HARD_COMPAT_REASONS declaration dropped by cherry-pick #9901 so capability-filtered combo requests no longer throw ReferenceError

--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -533,6 +533,14 @@ function hasKnownCompatibleContextLimit(
   return evaluateContextLimit(capabilities, requirements, target.modelStr) === true;
 }
 
+// #8494: hard capability requirements fail the combo closed when every target
+// is incompatible (tools / vision / structured_output — and output_tokens).
+// Soft failures (context_window) stay fallback-eligible. Restored verbatim:
+// cherry-pick #9901 accidentally deleted this declaration while keeping the
+// three call sites below, producing `HARD_COMPAT_REASONS is not defined` on
+// every capability-filtered combo request.
+const HARD_COMPAT_REASONS = new Set(["tools", "vision", "structured_output", "output_tokens"]);
+
 /**
  * #8332: vision is a hard requirement, not a soft preference — a target whose vision
  * support is not confirmed can never succeed on an image_url request. Callers


### PR DESCRIPTION
## Summary

Cherry-pick `2afaab52a` (#9901, merged into release/v3.8.50) deleted the only `HARD_COMPAT_REASONS` declaration in `open-sse/services/combo/comboStructure.ts` while keeping its three call sites. Every capability-filtered combo request (tools/vision/structured_output requirements — e.g. any `orchestrator` combo with tools) then throws:

```
ReferenceError: HARD_COMPAT_REASONS is not defined
```

Reproduced live on every orchestrator-combo request and in the #8488 regression suite (4 failures). This PR restores the declaration verbatim (including `output_tokens` as a hard failure), matching the pre-#9901 working state.

Note: #9621 (the earlier attempted fix) is closed; the duplicate-declaration state it targeted was resolved differently, and #9901 re-broke the file by removing the declaration entirely.

## Tests

- `8488-capability-filter-fail-closed.test.ts` — 4 failing before the fix (exact ReferenceError), 9/9 passing after. Combo + Crof focused batch: 39/39.