### PR TITLE
fix(i18n): missing key `provider.iconUrlLabel` in `pt-BR`

### DIFF
--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -4973,6 +4973,7 @@
     "baseUrlHint": "Obrigatório. URL base da API do provedor.",
     "iconUrlLabel": "URL do ícone",
     "iconUrlHint": "Opcional. URL da imagem exibida como ícone deste provedor.",
+    "iconUrlInvalid": "URL do ícone inválida. Use uma URL http(s):// ou uma URL data:image/*;base64.",
     "anthropicPrefixPlaceholder": "ac-prod",
     "openaiPrefixPlaceholder": "oc-prod",
     "anthropicBaseUrlPlaceholder": "https://api.anthropic.com/v1",


### PR DESCRIPTION
## Summary

When see latest CI red flag have missing key `provider.iconUrlLabel`

Reference : https://github.com/diegosouzapw/OmniRoute/actions/runs/31465859277/job/93698630713?pr=10072

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/dev/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
