### PR TITLE
fix(providers): kilo-gateway authType should be optional, not apikey

### DIFF
--- a/open-sse/config/providers/registry/kilo-gateway/index.ts
+++ b/open-sse/config/providers/registry/kilo-gateway/index.ts
@@ -1,5 +1,10 @@
 import type { RegistryEntry } from "../../shared.ts";
 
+/**
+ * The key is genuinely optional: probed live 2026-08-11 with no Authorization
+ * header, /chat/completions still answered 200 (kilo-auto/free routed to
+ * stepfun/step-3.7-flash) — so authType stays "optional", matching ovhcloud.
+ */
 export const kilo_gatewayProvider: RegistryEntry = {
   id: "kilo-gateway",
   alias: "kg",
@@ -7,7 +12,7 @@ export const kilo_gatewayProvider: RegistryEntry = {
   executor: "default",
   baseUrl: "https://api.kilo.ai/api/gateway/chat/completions",
   modelsUrl: "https://api.kilo.ai/api/gateway/models",
-  authType: "apikey",
+  authType: "optional",
   authHeader: "bearer",
   models: [
     { id: "kilo-auto/frontier", name: "Kilo Auto Frontier" },

--- a/tests/unit/provider-credential-requirement.test.ts
+++ b/tests/unit/provider-credential-requirement.test.ts
@@ -18,6 +18,8 @@ test("classifies each credential model from the real registries", () => {
   assert.equal(getCredentialRequirement("kilocode"), "optional");
   // Verified live 2026-07-20: answers with no Authorization header, 403s on a bad key.
   assert.equal(getCredentialRequirement("ovhcloud"), "optional");
+  // Verified live 2026-08-11: HTTP 200 with no Authorization header (#10068).
+  assert.equal(getCredentialRequirement("kilo-gateway"), "optional");
   // OAuth: nothing to paste, but the user still signs in.
   assert.equal(getCredentialRequirement("agy"), "oauth");
   // Ordinary key-gated provider.


### PR DESCRIPTION
## Summary
- Fixes #10068 — `kilo-gateway` registry entry had `authType: "apikey"`, but the endpoint answers HTTP 200 to `/chat/completions` with no `Authorization` header at all
- Changes `authType` to `"optional"` (same pattern as `ovhcloud`/`pollinations`) so keyless callers aren't blocked; a real key is still honoured and raises limits
- `freeModelCatalog.data.ts` already lists kilo-gateway models as `freeType: "recurring-uncapped"`, consistent with keyless access

## Test plan
- Added a regression assertion in `tests/unit/provider-credential-requirement.test.ts`: `getCredentialRequirement("kilo-gateway")` now equals `"optional"`
- `node --import tsx/esm --test tests/unit/provider-credential-requirement.test.ts` — 7/7 pass
- Also ran the other suites referencing kilo-gateway (free-catalog-2026-07-expansion, free-model-catalog, provider-registry-kilocode-format, nvidia-passthrough-models-6773, openrouter-passthrough-models) — 20/20 pass, none assert the old `authType`
- `eslint` on both changed files — clean
- `npm run check:any-budget:t11` — pass (unrelated to this change)