### PR TITLE
[TS7] fix(types): restore provider breaker predicate import

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -88,6 +88,7 @@ import {
 import { buildModalityBridgeHeader } from "@/lib/guardrails/modalityBridge/bridgeStats";
 import {
   isAntigravityMissingProjectError,
+  isProviderBreakerFailureStatus,
   PROVIDER_BREAKER_FAILURE_STATUSES,
   resolveStreamReadinessClassificationError,
   shouldTripProviderBreakerForResult,

--- a/tests/unit/circuit-breaker-abort-provider-trip-7907.test.ts
+++ b/tests/unit/circuit-breaker-abort-provider-trip-7907.test.ts
@@ -16,6 +16,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { shouldTripProviderBreakerForResult } from "../../src/sse/handlers/chat.ts";
+import { isProviderBreakerFailureStatus } from "../../src/sse/handlers/chatPredicates.ts";
 import { shouldRecordProviderBreakerFailure } from "../../open-sse/services/combo/comboPredicates.ts";
 
 // The exact abort shape described in the PR body / issue #7907: no upstream
@@ -25,6 +26,11 @@ const ABORT_RESULT = {
   status: 502,
   error: "request_signal_aborted",
 } as const;
+
+test("single-model breaker status guard accepts only provider-level failures", () => {
+  assert.equal(isProviderBreakerFailureStatus(502), true);
+  assert.equal(isProviderBreakerFailureStatus(429), false);
+});
 
 test("chat.ts single-model path: breaker stays CLOSED on a client abort (502 default, no errorCode)", () => {
   assert.equal(shouldTripProviderBreakerForResult(ABORT_RESULT, false, false), false);


### PR DESCRIPTION
## Summary

- restore the existing provider-breaker status predicate import in the single-model chat path
- keep 429 excluded while provider-level 5xx failures remain eligible
- add focused predicate coverage

## Validation

- `node --import tsx/esm --test tests/unit/circuit-breaker-abort-provider-trip-7907.test.ts` — 6 passed
- TypeScript 6.0.3: 52 → 51 diagnostics, removed 1, added 0
- TypeScript 7.0.2: 52 → 51 diagnostics, removed 1, added 0
- focused ESLint passed

Related to #8484.