### PR TITLE
fix: keep model wire format provider-scoped

### DIFF
--- a/open-sse/config/providerModels.ts
+++ b/open-sse/config/providerModels.ts
@@ -170,8 +170,29 @@ export function findModelName(aliasOrId: string, modelId: string): string {
 }
 
 export function getModelTargetFormat(aliasOrId: string, modelId: string): string | null {
-  const models = PROVIDER_MODELS[aliasOrId];
-  const found = models?.find((m) => m.id === modelId) || getGlobalModel(modelId);
+  const alias = PROVIDER_ID_TO_ALIAS[aliasOrId] || aliasOrId;
+  const models = PROVIDER_MODELS[alias] || PROVIDER_MODELS[aliasOrId];
+  // Wire-format metadata is provider-scoped. A model's capabilities can be
+  // shared globally, but an OpenAI registry entry's Responses target must not
+  // leak into another provider's Chat Completions connection (e.g.
+  // Nous/OpenRouter `openai/gpt-5.6-luna`).
+  // Preserve the provider-prefix normalization used before the global model
+  // fallback was added: `openai/openai/gpt-5.6-luna` is an OpenAI-local
+  // spelling, not a reason to consult another provider's metadata.
+  const prefixes = [aliasOrId, alias].filter(
+    (value, index, values) => values.indexOf(value) === index
+  );
+  const bareModelId =
+    typeof modelId === "string"
+      ? prefixes.reduce(
+          (current, prefix) =>
+            current === modelId && modelId.startsWith(`${prefix}/`)
+              ? modelId.slice(prefix.length + 1)
+              : current,
+          modelId
+        )
+      : modelId;
+  const found = models?.find((m) => m.id === bareModelId);
   if (found?.targetFormat) return found.targetFormat;
   // #5842: OpenAI "*-pro" reasoning models (o1-pro, gpt-5.x-pro) are only served by
   // the native /v1/responses endpoint — /v1/chat/completions 404s ("only supported

--- a/tests/unit/openai-gpt56-responses-routing.test.ts
+++ b/tests/unit/openai-gpt56-responses-routing.test.ts
@@ -15,8 +15,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { getModelTargetFormat } from "../../open-sse/config/providerModels.ts";
+import {
+  getModelTargetFormat,
+  getProviderModel,
+  PROVIDER_ID_TO_ALIAS,
+} from "../../open-sse/config/providerModels.ts";
 import { DefaultExecutor } from "../../open-sse/executors/default.ts";
+import { resolveChatCoreTargetFormat } from "../../open-sse/handlers/chatCore/targetFormat.ts";
 
 test("getModelTargetFormat routes the public OpenAI GPT-5.6 family through Responses", () => {
   for (const modelId of ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
@@ -42,4 +47,41 @@ test("DefaultExecutor keeps /v1/chat/completions for gpt-5.4", () => {
   const executor = new DefaultExecutor("openai");
   const url = executor.buildUrl("gpt-5.4", true, 0, null);
   assert.equal(url, "https://api.openai.com/v1/chat/completions");
+});
+
+test("cross-provider GPT-5.6 keeps the provider's Chat Completions wire format", () => {
+  for (const provider of ["nous", "openrouter"]) {
+    assert.equal(
+      getModelTargetFormat(provider, "openai/gpt-5.6-luna"),
+      null,
+      `${provider} must not inherit OpenAI's Responses target format`
+    );
+    assert.equal(
+      getModelTargetFormat(provider, "gpt-5.6-luna"),
+      null,
+      `${provider} must not inherit OpenAI's Responses target format for bare ids`
+    );
+  }
+});
+
+test("chatCore target-format resolution keeps provider defaults for cross-provider GPT-5.6", () => {
+  for (const provider of ["nous", "openrouter"]) {
+    const result = resolveChatCoreTargetFormat({
+      provider,
+      resolvedModel: "openai/gpt-5.6-luna",
+      apiFormat: undefined,
+      sourceFormat: "openai",
+      customModelTargetFormat: undefined,
+      providerSpecificData: undefined,
+    });
+    assert.equal(result.alias, PROVIDER_ID_TO_ALIAS[provider] || provider);
+    assert.equal(result.targetFormat, "openai");
+  }
+});
+
+test("global capability fallback remains available without leaking wire format", () => {
+  const metadata = getProviderModel("nous", "gpt-5.6-luna");
+  assert.equal(metadata?.supportsVision, true);
+  assert.equal(metadata?.supportsReasoning, true);
+  assert.equal(getModelTargetFormat("nous", "gpt-5.6-luna"), null);
 });


### PR DESCRIPTION
## Problem

The v3.8.50 line added a global model-registry fallback to
`getModelTargetFormat()` (upstream commit `3a66761cb`, #8057). That fallback is
useful for sharing capability metadata, but it also inherited wire-format
metadata from unrelated provider registries.

OpenAI's GPT-5.6 registry entries declare `targetFormat: "openai-responses"`.
When the same model ID was routed through the Nous or OpenRouter provider, the
fallback selected the Responses wire format even though those provider
connections dispatch to their Chat Completions endpoints. OmniRoute translated
`messages[]` into Responses `input[]`, then sent that body to
`/chat/completions`, producing:

```text
400 messages is required and must be a non-empty array
400 Input required: specify "prompt" or "messages"
```

The failure reproduced with a two-message text-only request, with and without
`reasoning_effort`; it was not caused by compression or an image.

## Change

Make `getModelTargetFormat()` provider-scoped again while retaining the useful
cross-provider global fallback for capability/model metadata:

- resolve the provider's public alias before looking up its registry models;
- preserve provider-prefix normalization for model IDs;
- use only the resolved provider's model entry for wire-format metadata;
- retain the OpenAI `*-pro` Responses heuristic;
- leave `getProviderModel()` and related capability fallback behavior unchanged.

Expected behavior:

```text
openai/gpt-5.6-luna through OpenAI      -> openai-responses
openai/gpt-5.6-luna through Nous        -> provider default: OpenAI Chat
openai/gpt-5.6-luna through OpenRouter  -> provider default: OpenAI Chat
```

## Tests

Extended `tests/unit/openai-gpt56-responses-routing.test.ts` with coverage for:

- Nous and OpenRouter GPT-5.6, bare and prefixed IDs;
- `chatCore` provider-default resolution;
- preservation of global vision/reasoning capability fallback.

Focused test results:

```text
GPT-5.6 / target-format / provider-model tests: 35 passed
Executor / reasoning / provider compatibility tests: 71 passed
Responses request translator tests: 55 passed
Total: 161 passed, 0 failed
```

## Scope

This patch changes only model wire-format resolution and its regression tests.
It does not change provider credentials, routing combo membership, compression,
Vision Bridge settings, deployment configuration, or retry policy.