### PR TITLE
fix(cli): stop swallowing non-2xx responses into benign-looking results

### DIFF
--- a/bin/cli/api.mjs
+++ b/bin/cli/api.mjs
@@ -139,6 +139,21 @@ export function shouldRetryError(err, opts = {}) {
   return false;
 }
 
+/**
+ * True when a non-2xx status means "this server does not serve this route"
+ * rather than "your request was wrong".
+ *
+ * Commands that keep a local SQLite fallback must not treat these as fatal:
+ * a CLI newer (or older) than the server it is talking to will hit routes that
+ * simply are not mounted, and aborting there strands the user with an
+ * unactionable `HTTP 404` even though the local path would have worked.
+ * Genuine client errors (400/401/403/409/422 …) stay fatal — retrying them
+ * locally would paper over a real problem.
+ */
+export function isRouteUnavailableStatus(status) {
+  return status === 404 || status === 405 || status === 501;
+}
+
 export function statusToExitCode(status) {
   if (status >= 200 && status < 300) return 0;
   if (status === 408) return 124;

--- a/bin/cli/commands/combo.mjs
+++ b/bin/cli/commands/combo.mjs
@@ -152,6 +152,7 @@ export async function runComboListCommand(opts = {}) {
     return await withRuntime(async ({ kind, api, db }) => {
       let combos = [];
       let activeCombo = null;
+      let listError = null;
 
       if (kind === "http") {
         const [listRes, activeRes] = await Promise.all([
@@ -161,6 +162,12 @@ export async function runComboListCommand(opts = {}) {
         if (listRes.ok) {
           const data = await listRes.json();
           combos = Array.isArray(data) ? data : (data.combos ?? []);
+        } else {
+          // The server answered, but not with a combo list. Falling through to
+          // an empty array here rendered "No combos configured" — which is
+          // indistinguishable from genuine emptiness and reads as real state,
+          // so a transport/auth failure looked like a wiped configuration.
+          listError = listRes.status;
         }
         if (activeRes.ok) {
           const settings = await activeRes.json();
@@ -171,11 +178,25 @@ export async function runComboListCommand(opts = {}) {
       }
 
       if (opts.json || opts.output === "json") {
-        console.log(JSON.stringify({ combos, active: activeCombo }, null, 2));
-        return 0;
+        console.log(
+          JSON.stringify(
+            { combos, active: activeCombo, error: listError && `HTTP ${listError}` },
+            null,
+            2
+          )
+        );
+        return listError ? 1 : 0;
       }
 
       printHeading(t("combo.title"));
+      if (listError) {
+        console.error(
+          t("common.error", {
+            message: `could not list combos from the server (HTTP ${listError})`,
+          })
+        );
+        return 1;
+      }
       if (combos.length === 0) {
         console.log(t("combo.noCombos"));
         return 0;

--- a/bin/cli/commands/keys.mjs
+++ b/bin/cli/commands/keys.mjs
@@ -8,7 +8,7 @@ import {
 } from "../provider-store.mjs";
 import { openOmniRouteDb } from "../sqlite.mjs";
 import { loadAvailableProviders } from "../provider-catalog.mjs";
-import { apiFetch, isServerUp } from "../api.mjs";
+import { apiFetch, isServerUp, isRouteUnavailableStatus } from "../api.mjs";
 import { t } from "../i18n.mjs";
 
 function getValidProviderIds() {
@@ -184,7 +184,10 @@ export async function runKeysAddCommand(provider, apiKey, opts = {}) {
         console.log(t("keys.added", { provider: providerLower }));
         return 0;
       }
-      if (res.status >= 400 && res.status < 500) {
+      // A missing route means this server does not implement the endpoint —
+      // fall through to the local SQLite path below rather than stranding the
+      // user. Real client errors still abort.
+      if (res.status >= 400 && res.status < 500 && !isRouteUnavailableStatus(res.status)) {
         console.error(t("common.error", { message: `HTTP ${res.status}` }));
         return 1;
       }

--- a/bin/cli/commands/providers.mjs
+++ b/bin/cli/commands/providers.mjs
@@ -129,9 +129,33 @@ function buildTestInput(connection, apiKey) {
 }
 
 async function runProviderTest(db, connection) {
+  // Only API-key connections can be probed with a stored credential. OAuth /
+  // no-auth connections have nothing for testProviderApiKey() to send, and
+  // getProviderApiKey() throws for them by design — reporting that as a FAILED
+  // test marked perfectly healthy OAuth connections as broken *and* persisted
+  // that verdict to provider_connections.test_status.
+  if (connection.authType !== "apikey") {
+    return {
+      connection: publicConnection(connection),
+      valid: false,
+      skipped: true,
+      error: `No API-key probe for ${connection.authType || "unknown"} connections`,
+    };
+  }
+
   try {
     const apiKey = getProviderApiKey(connection);
     const result = await testProviderApiKey(buildTestInput(connection, apiKey));
+    // PROVIDER_TEST_CONFIGS only knows a handful of providers; "unsupported"
+    // means the CLI has no probe recipe, not that the provider is unhealthy.
+    // Persisting it would overwrite a good test_status with a failure.
+    if (result.unsupported) {
+      return {
+        connection: publicConnection(connection),
+        ...result,
+        skipped: true,
+      };
+    }
     updateProviderTestResult(db, connection.id, result);
     return {
       connection: publicConnection(connection),

--- a/tests/unit/cli-route-unavailable-fallback-10081.test.ts
+++ b/tests/unit/cli-route-unavailable-fallback-10081.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #10081 — CLI commands swallowed a non-2xx into a benign-looking outcome:
+//   * `keys add` aborted on any 4xx, so a missing route (404) stranded the user
+//     even though the local SQLite fallback right below would have worked.
+//   * `providers test-all` reported OAuth connections as FAILED (and persisted
+//     that verdict) because getProviderApiKey() throws for them by design.
+//   * `combo list` printed "No combos configured" when the HTTP call failed,
+//     which is indistinguishable from genuine emptiness.
+
+const { isRouteUnavailableStatus } = await import("../../bin/cli/api.mjs");
+
+test("isRouteUnavailableStatus separates 'route missing' from real client errors", () => {
+  // Server does not serve this route -> the caller may fall back locally.
+  for (const status of [404, 405, 501]) {
+    assert.equal(isRouteUnavailableStatus(status), true, `${status} should be route-unavailable`);
+  }
+
+  // Genuine client errors must stay fatal — retrying locally would hide a real
+  // problem (bad credential, insufficient scope, conflict, invalid payload).
+  for (const status of [400, 401, 403, 409, 422, 429]) {
+    assert.equal(isRouteUnavailableStatus(status), false, `${status} should stay fatal`);
+  }
+
+  // Server-side failures are handled by the existing retry path, not here.
+  for (const status of [500, 502, 503]) {
+    assert.equal(isRouteUnavailableStatus(status), false, `${status} should stay fatal`);
+  }
+});
+
+test("keys add falls through to the local DB only for route-unavailable statuses", async () => {
+  const source = await import("node:fs").then((fs) =>
+    fs.readFileSync(new URL("../../bin/cli/commands/keys.mjs", import.meta.url), "utf8")
+  );
+
+  // The guard must exclude route-unavailable statuses, otherwise the
+  // openOmniRouteDb() fallback below it is unreachable while the server is up.
+  assert.match(
+    source,
+    /res\.status >= 400 && res\.status < 500 && !isRouteUnavailableStatus\(res\.status\)/,
+    "keys add should not abort on a missing route"
+  );
+});
+
+test("providers test-all skips connections it cannot probe instead of failing them", async () => {
+  const source = await import("node:fs").then((fs) =>
+    fs.readFileSync(new URL("../../bin/cli/commands/providers.mjs", import.meta.url), "utf8")
+  );
+
+  // Non-apikey connections return early as skipped, before getProviderApiKey().
+  const nonApiKeyGuard = source.indexOf('if (connection.authType !== "apikey")');
+  const getKeyCall = source.indexOf("const apiKey = getProviderApiKey(connection);");
+  assert.ok(nonApiKeyGuard > -1, "expected a non-apikey guard in runProviderTest");
+  assert.ok(
+    nonApiKeyGuard < getKeyCall,
+    "the guard must run before getProviderApiKey(), which throws for OAuth"
+  );
+
+  // An "unsupported" probe must not overwrite a good test_status with a failure.
+  assert.match(source, /if \(result\.unsupported\) \{[\s\S]*?skipped: true/);
+});
+
+test("combo list reports a transport failure instead of 'No combos configured'", async () => {
+  const source = await import("node:fs").then((fs) =>
+    fs.readFileSync(new URL("../../bin/cli/commands/combo.mjs", import.meta.url), "utf8")
+  );
+
+  assert.match(source, /listError = listRes\.status/, "a failed list must be recorded");
+  // The error branch has to be checked before the empty-list branch, otherwise
+  // the misleading "no combos" message still wins.
+  const errorBranch = source.indexOf("if (listError) {");
+  const emptyBranch = source.indexOf('console.log(t("combo.noCombos"))');
+  assert.ok(errorBranch > -1 && emptyBranch > -1);
+  assert.ok(errorBranch < emptyBranch, "listError must be handled before the empty-list message");
+});


### PR DESCRIPTION
Refs #10081.

Three commands turn a transport failure into something that reads as real state. Reproduced against a running 3.8.49 install with a valid loopback CLI token.

### 1. `keys add` — the SQLite fallback is unreachable

`/api/v1/providers/keys` is not mounted on the shipped server (`openapi.yaml` has `/api/providers`, `/api/keys` and `/api/v1/providers/{provider}/…`, not this). The 404 hits `if (res.status >= 400 && res.status < 500) return 1;` and the local path below never runs:

```console
$ omniroute keys add groq $KEY
Error: HTTP 404

$ OMNIROUTE_BASE_URL=http://127.0.0.1:1 omniroute keys add groq $KEY   # forces isServerUp() false
Key added for groq.
```

New `isRouteUnavailableStatus()` (404/405/501) lets the caller fall through. Genuine client errors — 400/401/403/409/422/429 — still abort, because retrying those locally would paper over a real problem.

I deliberately did **not** repoint the request at `POST /api/providers`: that route requires management auth, and I could not get the loopback machine-id token accepted on it, so switching would trade a 404 for a 401. Making the fallback reachable fixes the command either way.

### 2. `providers test-all` — fails every connection, and writes that to the DB

```console
$ omniroute providers test-all         # 7 healthy connections
FAIL main: Provider test not supported
FAIL amazon-q: Connection amazon-q is not an API-key provider.
FAIL kiro: Connection kiro is not an API-key provider.
…
```

Two distinct causes, neither a provider problem:

- OAuth connections reach `getProviderApiKey()`, which throws for anything not `authType === "apikey"` **by design** — and the `catch` then calls `updateProviderTestResult()`, persisting a failure onto healthy connections. They are now skipped before that call.
- API-key connections whose provider is absent from `PROVIDER_TEST_CONFIGS` (6 entries, against a ~296-provider catalog) return `unsupported: true`. That is a missing probe recipe, so it no longer overwrites a good `test_status` either.

Independently confirmed the providers were fine by routing real completions through `antigravity`, `kiro` and `qwen-cloud`.

> Note: I originally attributed the API-key half of this to the `/api/v1/providers/test` 404 in #10081. The 404 is real, but the visible `Provider test not supported` comes from the local `PROVIDER_TEST_CONFIGS` table. Broadening that table is a separate, larger change and is **not** in this PR.

### 3. `combo list` — "No combos configured" for a transport failure

Most confusing of the three, because it looks like a wiped configuration. It now reports the status and exits non-zero.

### Tests

New `tests/unit/cli-route-unavailable-fallback-10081.test.ts` (4 cases).

```
node --import tsx/esm --test tests/unit/cli-route-unavailable-fallback-10081.test.ts  -> 4 pass
node --import tsx/esm --test tests/unit/cli-providers-*.test.ts                       -> 17 pass
npx prettier --check                                                                  -> clean
```

`tests/unit/cli-combo-command.test.ts` currently fails to transform on `release/v3.8.50` for an unrelated reason — a syntax error in `src/shared/constants/providers/apikey/gateways.ts`, filed separately with a fix.