### PR TITLE
fix(providers): close the regolo entry in gateways.ts

### DIFF
--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -578,7 +578,8 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     textIcon: "DA",
     website: "https://inference.dahl.global",
     hasFree: true,
-    freeNote: "Free — MiniMax M2.7, Kimi K2.6. Click 'Add Account' to auto-generate a token, or add your own API key.",
+    freeNote:
+      "Free — MiniMax M2.7, Kimi K2.6. Click 'Add Account' to auto-generate a token, or add your own API key.",
     authHint: "Click 'Add Account' to auto-generate a token, or add a manual API key.",
     apiHint: "Auto-generate a token or paste your own API key.",
     apiKeyUrl: "https://inference.dahl.global/tokens",
@@ -1179,6 +1180,7 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     authHint: "Get your Regolo API key from regolo.ai, then paste it here as a Bearer token.",
     apiHint:
       "OpenAI-compatible endpoint at https://api.regolo.ai/v1 with dynamic model discovery (19 models).",
+  },
   "naga-ac": {
     id: "naga-ac",
     alias: "naga",
@@ -1192,8 +1194,7 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     freeNote:
       "Free models include Nemotron 3 Ultra (free) and Llama 3.3 70B Instruct (Free). Paid models require credits. Google/GitHub/Discord signup.",
     passthroughModels: true,
-    authHint:
-      "Get API key at naga.ac — Google/GitHub/Discord signup available.",
+    authHint: "Get API key at naga.ac — Google/GitHub/Discord signup available.",
   },
   chatanywhere: {
     id: "chatanywhere",
@@ -1207,7 +1208,6 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     freeNote:
       "Free tier: 5 req/day for GPT-5/4o/4.1, 30/day DeepSeek, 200/day gpt-4o-mini. Personal non-commercial use only — see chatanywhere/GPT_API_free. Requires GitHub-account-gated API key.",
     passthroughModels: true,
-    authHint:
-      "Get free API key at api.chatanywhere.tech — requires GitHub account signup.",
+    authHint: "Get free API key at api.chatanywhere.tech — requires GitHub account signup.",
   },
 };


### PR DESCRIPTION
Closes #10093.

`src/shared/constants/providers/apikey/gateways.ts` does not parse on `release/v3.8.50`. The `regolo` entry is missing its closing `},`, so `"naga-ac"` nests inside it and the object literal never closes.

```console
$ node --import tsx/esm --test tests/unit/cli-combo-command.test.ts
✖ combo switch updates active combo when server is offline
  Error: Transform failed with 1 error:
  src/shared/constants/providers/apikey/gateways.ts:1213:1: ERROR: Expected "}" but found ";"
```

TypeScript: `1213:2 ',' expected` / `1214:1 '}' expected`.

### Evidence

Parsing the literal with the TS API before the fix yields **86** entries, the last being `regolo` at line 1170 — `naga-ac` and `chatanywhere` are swallowed as its members. After the fix: **0** parse diagnostics and **88** entries, all three siblings.

### Change

- Add the missing `},`.
- Prettier could not parse the file either, so three unrelated lines had drifted out of format. Reformatted in the same pass — that is the entire rest of the diff.

### Verification

```
node --import tsx/esm --test tests/unit/cli-combo-command.test.ts       -> 5 pass (was 4 pass / 1 fail)
node --import tsx/esm --test tests/unit/morph-provider-catalog.test.ts  -> 6 pass
npx prettier --check src/shared/constants/providers/apikey/gateways.ts  -> clean
```

Suggestion for a follow-up: a CI step that parses `src/shared/constants/providers/**` would catch this class directly. Today a missing brace in a large data literal only surfaces as an unrelated test failing to transform, which is a confusing signal to debug.