### PR TITLE
feat(routing): add quota-aware provider scheduling (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2514,3 +2514,11 @@ QUOTA_STORE_DRIVER=sqlite              # sqlite | redis
 # URL the dashboard's "Support the project" button opens (payment/plans
 # page). No pricing/value lives in this repo — only the link.
 # RADAR_SUPPORTER_PLANS_URL=https://radar.omniroute.online/planos
+
+# Quota-aware provider scheduling (opt-in). When enabled, routing skips
+# connections whose configured per-window token budget (rateLimitOverrides.tpm)
+# cannot afford the estimated request cost — before dispatching — instead of
+# waiting for a 429. Fail-open: connections without a configured budget are
+# always considered affordable. Requires the provider_quota_state table
+# (migration 143).
+# OMNIROUTE_QUOTA_AWARE_ROUTING=0

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -1389,3 +1389,11 @@ Used by `src/lib/vncSession/manifest.ts` to configure Docker-based headless Chro
 | `REDIS_BIND_HOST` | `127.0.0.1` | Bind address for the embedded Redis service. |
 | `REDIS_PORT` | `6379` | Port for the embedded Redis service. |
 | `OMNIROUTE_REDIS_BIND_HOST` | – | OmniRoute-scoped override for the embedded Redis bind address. |
+
+### Quota-aware scheduling
+
+Used by `open-sse/services/combo.ts` and `src/lib/quota/quotaScheduler.ts` for pre-request token-budget checks. Opt-in — default routing behavior is unchanged when unset.
+
+| Variable                          | Default  | Source File                       | Description                                                                                                      |
+| --------------------------------- | -------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `OMNIROUTE_QUOTA_AWARE_ROUTING`   | `0`      | `open-sse/services/combo.ts`      | When `1`, skip connections whose per-window token budget (`rateLimitOverrides.tpm`, table `provider_quota_state`) cannot afford the estimated request cost before dispatch. Fail-open when no budget configured. |

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -80,7 +80,29 @@ import {
 import { selectQuotaShareTarget } from "./combo/quotaShareStrategy.ts";
 import { makeConnectionConcurrencyResolver, lookupPositiveCap } from "./combo/concurrencyCaps.ts";
 import { acquireQuotaShareConcurrencySlot } from "./combo/quotaShareConcurrency.ts";
+import { canAffordRequest } from "../../src/lib/quota/quotaScheduler.ts";
+import { getCachedProviderConnectionById } from "../../src/lib/localDb.js";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
+
+/**
+ * Resolve the configured per-connection token budget (rateLimitOverrides.tpm)
+ * for quota reservation. Returns undefined when unconfigured — the store then
+ * keeps the previously recorded limit (or 0 for a fresh row, meaning "no
+ * budget enforced").
+ */
+function resolveTargetTokenLimit(target: { connectionId?: string }): number | undefined {
+  const connectionId = target?.connectionId;
+  if (!connectionId) return undefined;
+  try {
+    const connection = getCachedProviderConnectionById(connectionId);
+    const overrides = (connection as { rateLimitOverrides?: Record<string, number> | null } | null)
+      ?.rateLimitOverrides;
+    const tpm = overrides?.tpm;
+    return typeof tpm === "number" && tpm > 0 ? tpm : undefined;
+  } catch {
+    return undefined;
+  }
+}
 import {
   applyPromptCacheAffinity,
   expandPromptCacheAffinityTargets,
@@ -981,6 +1003,27 @@ export async function handleComboChat({
             log.info(
               "COMBO",
               `Skipping ${modelStr} — quota exhaustion cutoff (${quotaCutoff.reason || "quota_exhausted"})`
+            );
+            if (i > 0) fallbackCount++;
+            return null;
+          }
+        }
+
+        // Quota-aware scheduling (opt-in, OMNIROUTE_QUOTA_AWARE_ROUTING=1):
+        // when a per-connection token budget is configured (provider_quota_state),
+        // skip targets whose remaining budget cannot afford this request —
+        // BEFORE dispatching — instead of waiting for a 429. Fails open: when
+        // no budget is configured the decision is always affordable.
+        if (process.env.OMNIROUTE_QUOTA_AWARE_ROUTING === "1" && provider && target.connectionId) {
+          const quotaDecision = canAffordRequest(
+            target.connectionId,
+            modelStr,
+            body as Record<string, unknown> | null | undefined
+          );
+          if (!quotaDecision.affordable) {
+            log.info(
+              "COMBO",
+              `Skipping ${modelStr} — quota budget ${quotaDecision.reason} (remaining ${quotaDecision.tokensRemaining ?? 0}, cost ${quotaDecision.estimatedCost ?? 0})`
             );
             if (i > 0) fallbackCount++;
             return null;
@@ -2618,6 +2661,25 @@ async function handleRoundRobinCombo({
           failoverBeforeRetry: config.failoverBeforeRetry,
         });
 
+        // Quota-aware scheduling: reserve the estimated budget for this
+        // dispatch (opt-in, same env gate as the pre-request check). Best-effort
+        // and non-blocking — recording must never break the request path.
+        if (
+          process.env.OMNIROUTE_QUOTA_AWARE_ROUTING === "1" &&
+          target.connectionId &&
+          attemptBody &&
+          typeof attemptBody === "object"
+        ) {
+          try {
+            const { reserveQuota } = await import("../../src/lib/quota/quotaScheduler.ts");
+            reserveQuota(target.connectionId, modelStr, attemptBody as Record<string, unknown>, {
+              tokenLimit: resolveTargetTokenLimit(target),
+            });
+          } catch {
+            // best-effort only
+          }
+        }
+
         // Success — validate response quality before returning
         if (result.ok) {
           let rrClone: Response;
@@ -3020,7 +3082,8 @@ async function handleRoundRobinCombo({
       return new Response(
         JSON.stringify({
           error: {
-            message: "Service temporarily unavailable: all targets were skipped by pre-dispatch filters",
+            message:
+              "Service temporarily unavailable: all targets were skipped by pre-dispatch filters",
             type: "service_unavailable",
             code: "ALL_TARGETS_SKIPPED",
           },

--- a/src/lib/db/migrations/143_provider_quota_state.sql
+++ b/src/lib/db/migrations/143_provider_quota_state.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS provider_quota_state (
+  connection_id TEXT NOT NULL,
+  model TEXT NOT NULL,
+  tokens_used INTEGER NOT NULL DEFAULT 0,
+  token_limit INTEGER NOT NULL DEFAULT 0,
+  window_start INTEGER NOT NULL,
+  window_reset INTEGER NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (connection_id, model)
+);
+CREATE INDEX IF NOT EXISTS idx_pqs_connection ON provider_quota_state(connection_id);
+CREATE INDEX IF NOT EXISTS idx_pqs_reset ON provider_quota_state(window_reset) WHERE window_reset IS NOT NULL;

--- a/src/lib/quota/providerQuotaState.ts
+++ b/src/lib/quota/providerQuotaState.ts
@@ -1,0 +1,201 @@
+/**
+ * providerQuotaState.ts — per-connection token budget ledger.
+ *
+ * Tracks tokens used against a configured per-minute (or per-window) token
+ * limit for a (connection, model) pair. The purpose is PRE-REQUEST capacity
+ * awareness: before dispatching to a provider, the scheduler can ask "does
+ * this connection have budget left?" and skip exhausted connections instead
+ * of waiting for a 429.
+ *
+ * Design notes:
+ *  - Window semantics: fixed windows keyed by `window_start` (epoch ms).
+ *    When `window_reset` passes, usage resets to 0 for the new window.
+ *  - Fail-open: reads return `{ known: false }` when the store is missing
+ *    or empty — the scheduler treats unknown budget as available (existing
+ *    routing behavior is preserved when quota tracking is not configured).
+ *  - Writes are best-effort: recording usage must never break the request
+ *    path (catch + log + return).
+ *
+ * Part of: Quota-aware provider scheduling (feat/quota-aware-scheduling).
+ */
+import { getDbInstance } from "@/lib/db/core";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("quota:provider-state");
+
+export interface ProviderQuotaRow {
+  connectionId: string;
+  model: string;
+  tokensUsed: number;
+  tokenLimit: number;
+  windowStart: number;
+  windowReset: number;
+  updatedAt: string;
+}
+
+export interface ProviderQuotaSnapshot {
+  /** true when the store has a fresh record for this window */
+  known: boolean;
+  tokensUsed: number;
+  tokenLimit: number;
+  /** remaining tokens in the current window (clamped >= 0) */
+  tokensRemaining: number;
+  /** 0..1 ratio of the window budget still available */
+  remainingRatio: number;
+  windowReset: number;
+}
+
+interface RowLike {
+  connection_id?: string;
+  model?: string;
+  tokens_used?: number;
+  token_limit?: number;
+  window_start?: number;
+  window_reset?: number;
+  updated_at?: string;
+}
+
+function normalizeRow(row: RowLike): ProviderQuotaRow {
+  return {
+    connectionId: String(row.connection_id ?? ""),
+    model: String(row.model ?? ""),
+    tokensUsed: Number(row.tokens_used ?? 0),
+    tokenLimit: Number(row.token_limit ?? 0),
+    windowStart: Number(row.window_start ?? 0),
+    windowReset: Number(row.window_reset ?? 0),
+    updatedAt: String(row.updated_at ?? ""),
+  };
+}
+
+/**
+ * Read the current quota snapshot for (connectionId, model).
+ * When the record is stale (its window expired) the caller sees
+ * `known: false` — usage for the new window is implicitly zero.
+ */
+export function getProviderQuota(
+  connectionId: string,
+  model: string
+): ProviderQuotaSnapshot | null {
+  if (!connectionId || !model) return null;
+  try {
+    const db = getDbInstance();
+    const row = db
+      .prepare("SELECT * FROM provider_quota_state WHERE connection_id = ? AND model = ?")
+      .get(connectionId, model) as RowLike | undefined;
+    if (!row) return null;
+
+    const normalized = normalizeRow(row);
+    const now = Date.now();
+    if (normalized.windowReset > 0 && now > normalized.windowReset) {
+      return {
+        known: false,
+        tokensUsed: 0,
+        tokenLimit: 0,
+        tokensRemaining: 0,
+        remainingRatio: 1,
+        windowReset: normalized.windowReset,
+      };
+    }
+
+    const tokenLimit = normalized.tokenLimit > 0 ? normalized.tokenLimit : 0;
+    const tokensUsed = Math.max(0, normalized.tokensUsed);
+    const tokensRemaining = tokenLimit > 0 ? Math.max(0, tokenLimit - tokensUsed) : 0;
+    const remainingRatio =
+      tokenLimit > 0 ? Math.min(1, Math.max(0, tokensRemaining / tokenLimit)) : 1;
+
+    return {
+      known: true,
+      tokensUsed,
+      tokenLimit,
+      tokensRemaining,
+      remainingRatio,
+      windowReset: normalized.windowReset,
+    };
+  } catch (err) {
+    log.warn(
+      { err: (err as Error)?.message, connectionId, model },
+      "getProviderQuota failed — fail-open"
+    );
+    return null;
+  }
+}
+
+/**
+ * Record token usage for (connectionId, model) in the current window.
+ *
+ * If no row exists, seeds one with the configured tokenLimit. If the window
+ * has rolled over, resets usage to the new usage. Best-effort: never throws.
+ */
+export function recordProviderQuotaUsage(
+  connectionId: string,
+  model: string,
+  tokensUsedDelta: number,
+  opts: { tokenLimit?: number; windowMs?: number } = {}
+): void {
+  if (!connectionId || !model || !(tokensUsedDelta > 0)) return;
+  try {
+    const db = getDbInstance();
+    const existing = db
+      .prepare("SELECT * FROM provider_quota_state WHERE connection_id = ? AND model = ?")
+      .get(connectionId, model) as RowLike | undefined;
+
+    const now = Date.now();
+    const windowMs = opts.windowMs ?? 60_000; // default: per-minute window
+    const windowStart = Math.floor(now / windowMs) * windowMs;
+    const windowReset = windowStart + windowMs;
+
+    if (!existing) {
+      db.prepare(
+        `INSERT OR REPLACE INTO provider_quota_state
+         (connection_id, model, tokens_used, token_limit, window_start, window_reset, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        connectionId,
+        model,
+        tokensUsedDelta,
+        opts.tokenLimit ?? 0,
+        windowStart,
+        windowReset,
+        new Date().toISOString()
+      );
+      return;
+    }
+
+    const normalized = normalizeRow(existing);
+    const windowRolledOver = normalized.windowReset > 0 && now > normalized.windowReset;
+    const nextUsed = windowRolledOver ? tokensUsedDelta : normalized.tokensUsed + tokensUsedDelta;
+    const nextLimit =
+      opts.tokenLimit && opts.tokenLimit > 0 ? opts.tokenLimit : normalized.tokenLimit;
+
+    db.prepare(
+      `UPDATE provider_quota_state
+       SET tokens_used = ?, token_limit = ?, window_start = ?, window_reset = ?, updated_at = ?
+       WHERE connection_id = ? AND model = ?`
+    ).run(
+      nextUsed,
+      nextLimit,
+      windowStart,
+      windowReset,
+      new Date().toISOString(),
+      connectionId,
+      model
+    );
+  } catch (err) {
+    log.warn(
+      { err: (err as Error)?.message, connectionId, model },
+      "recordProviderQuotaUsage failed — best-effort"
+    );
+  }
+}
+
+/** Delete all quota state for a connection (used on connection removal). */
+export function clearProviderQuota(connectionId: string): void {
+  if (!connectionId) return;
+  try {
+    getDbInstance()
+      .prepare("DELETE FROM provider_quota_state WHERE connection_id = ?")
+      .run(connectionId);
+  } catch {
+    // best-effort
+  }
+}

--- a/src/lib/quota/quotaScheduler.ts
+++ b/src/lib/quota/quotaScheduler.ts
@@ -1,0 +1,102 @@
+/**
+ * quotaScheduler.ts — pre-request capacity decision.
+ *
+ * Combines the per-connection token budget ledger (providerQuotaState) with
+ * the request cost estimate (tokenEstimator) to answer one question:
+ *
+ *   "Can this connection afford this request without exceeding its
+ *    configured per-window token budget?"
+ *
+ * The scheduler NEVER throws and NEVER blocks the request path when quota
+ * tracking is unconfigured — it fails open (returns `affordable: true`),
+ * preserving existing routing behavior. When a budget IS configured and the
+ * estimated cost exceeds the remaining budget, it returns
+ * `affordable: false` with the reason, and the caller should prefer another
+ * connection (the same failover machinery used for 429s).
+ *
+ * Part of: Quota-aware provider scheduling (feat/quota-aware-scheduling).
+ */
+import { getProviderQuota, recordProviderQuotaUsage } from "./providerQuotaState";
+import { estimateChatTokenCost } from "./tokenEstimator";
+
+export interface QuotaDecision {
+  affordable: boolean;
+  reason?: "exhausted" | "insufficient_budget" | "unconfigured";
+  /** remaining tokens in the window when known */
+  tokensRemaining?: number;
+  /** estimated cost of this request */
+  estimatedCost?: number;
+  /** 0..1 remaining ratio when known (1 when unknown) */
+  remainingRatio: number;
+}
+
+/**
+ * Decide whether (connectionId, model) can afford a request.
+ *
+ * @param connectionId provider connection id
+ * @param model model string (as routed)
+ * @param requestBody parsed chat body (used for the cost estimate)
+ * @returns a decision — always resolves, never throws
+ */
+export function canAffordRequest(
+  connectionId: string,
+  model: string,
+  requestBody: Record<string, unknown> | null | undefined
+): QuotaDecision {
+  if (!connectionId || !model) {
+    return { affordable: true, reason: "unconfigured", remainingRatio: 1 };
+  }
+
+  const snapshot = getProviderQuota(connectionId, model);
+  if (!snapshot || !snapshot.known || snapshot.tokenLimit <= 0) {
+    // No configured budget → nothing to enforce → affordable.
+    return { affordable: true, reason: "unconfigured", remainingRatio: 1 };
+  }
+
+  const cost = estimateChatTokenCost(requestBody);
+  const remaining = snapshot.tokensRemaining;
+  const remainingRatio = snapshot.remainingRatio;
+
+  if (remaining <= 0) {
+    return {
+      affordable: false,
+      reason: "exhausted",
+      tokensRemaining: 0,
+      estimatedCost: cost.totalTokens,
+      remainingRatio: 0,
+    };
+  }
+
+  if (cost.totalTokens > remaining) {
+    return {
+      affordable: false,
+      reason: "insufficient_budget",
+      tokensRemaining: remaining,
+      estimatedCost: cost.totalTokens,
+      remainingRatio,
+    };
+  }
+
+  return {
+    affordable: true,
+    tokensRemaining: remaining,
+    estimatedCost: cost.totalTokens,
+    remainingRatio,
+  };
+}
+
+/**
+ * Reserve budget for a request (call AFTER a successful dispatch decision,
+ * before/around the upstream call). Best-effort: never throws.
+ */
+export function reserveQuota(
+  connectionId: string,
+  model: string,
+  requestBody: Record<string, unknown> | null | undefined,
+  opts: { tokenLimit?: number; windowMs?: number } = {}
+): void {
+  if (!connectionId || !model) return;
+  const cost = estimateChatTokenCost(requestBody);
+  if (cost.totalTokens <= 0) return;
+  recordProviderQuotaUsage(connectionId, model, cost.totalTokens, opts);
+}

--- a/src/lib/quota/tokenEstimator.ts
+++ b/src/lib/quota/tokenEstimator.ts
@@ -1,0 +1,97 @@
+/**
+ * tokenEstimator.ts — cheap, deterministic request token-cost estimation.
+ *
+ * Estimates the token cost of a chat request (input + reserved output) so
+ * the quota scheduler can decide whether a connection has budget before
+ * dispatching. Not a model — a heuristic:
+ *   - chars / 4 approximates tokens for most latin text (OpenAI's classic
+ *     heuristic); CJK and code skew higher, so the estimate is a floor.
+ *   - max_tokens / max_completion_tokens reserves the output budget when
+ *     present; otherwise a small default output allowance is used.
+ *
+ * The estimate deliberately OVER-provisions input (×1.1) so an exhausted
+ * budget is not misjudged as available. Errors never throw — a broken
+ * estimate degrades to "unknown cost" (scheduler treats as affordable).
+ */
+
+export interface TokenCostEstimate {
+  /** estimated input tokens (may be 0 when body is unparseable) */
+  inputTokens: number;
+  /** reserved output budget (max_tokens or default) */
+  outputTokens: number;
+  /** input + output */
+  totalTokens: number;
+}
+
+const DEFAULT_OUTPUT_ALLOWANCE = 1024;
+const CHARS_PER_TOKEN = 4;
+const OVER_PROVISION = 1.1;
+
+/** Count a string's tokens by chars/4 (floor). */
+export function estimateStringTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Estimate the token cost of an OpenAI-style chat body.
+ * Accepts both `messages` (chat.completions) and `input` (Responses API).
+ */
+export function estimateChatTokenCost(
+  body: Record<string, unknown> | null | undefined
+): TokenCostEstimate {
+  if (!body || typeof body !== "object") {
+    return {
+      inputTokens: 0,
+      outputTokens: DEFAULT_OUTPUT_ALLOWANCE,
+      totalTokens: DEFAULT_OUTPUT_ALLOWANCE,
+    };
+  }
+
+  let inputTokens = 0;
+
+  const messages = body.messages;
+  if (Array.isArray(messages)) {
+    for (const msg of messages) {
+      if (!msg || typeof msg !== "object") continue;
+      const content = (msg as Record<string, unknown>).content;
+      if (typeof content === "string") {
+        inputTokens += estimateStringTokens(content);
+      } else if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part && typeof part === "object") {
+            const text = (part as Record<string, unknown>).text;
+            if (typeof text === "string") inputTokens += estimateStringTokens(text);
+          }
+        }
+      }
+    }
+  }
+
+  const input = body.input;
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      if (!item || typeof item !== "object") continue;
+      const text = (item as Record<string, unknown>).text;
+      if (typeof text === "string") inputTokens += estimateStringTokens(text);
+    }
+  }
+
+  if (typeof body.system === "string") {
+    inputTokens += estimateStringTokens(body.system);
+  }
+
+  // Reserved output budget: max_tokens / max_completion_tokens win; fall back
+  // to the default allowance.
+  const rawMax =
+    typeof body.max_tokens === "number"
+      ? body.max_tokens
+      : typeof body.max_completion_tokens === "number"
+        ? body.max_completion_tokens
+        : undefined;
+  const outputTokens =
+    typeof rawMax === "number" && rawMax > 0 ? Math.ceil(rawMax) : DEFAULT_OUTPUT_ALLOWANCE;
+
+  const totalTokens = Math.ceil(inputTokens * OVER_PROVISION) + outputTokens;
+  return { inputTokens, outputTokens, totalTokens };
+}

--- a/tests/unit/quota-scheduler.test.ts
+++ b/tests/unit/quota-scheduler.test.ts
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omni-quota-sched-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const { canAffordRequest } = await import("../../src/lib/quota/quotaScheduler");
+const { clearProviderQuota, getProviderQuota, recordProviderQuotaUsage } =
+  await import("../../src/lib/quota/providerQuotaState");
+
+async function resetStorage() {
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+const CONN = "test-conn-quota";
+const MODEL = "test-model";
+
+test("canAffordRequest: fails open when no budget configured", () => {
+  clearProviderQuota(CONN);
+  const decision = canAffordRequest(CONN, MODEL, { messages: [{ role: "user", content: "hi" }] });
+  assert.equal(decision.affordable, true);
+  assert.equal(decision.reason, "unconfigured");
+});
+
+test("canAffordRequest: skips exhausted budget", () => {
+  clearProviderQuota(CONN);
+  recordProviderQuotaUsage(CONN, MODEL, 10_000, { tokenLimit: 10_000, windowMs: 60_000 });
+  const decision = canAffordRequest(CONN, MODEL, {
+    messages: [{ role: "user", content: "hello world this is a request" }],
+  });
+  assert.equal(decision.affordable, false);
+  assert.equal(decision.reason, "exhausted");
+});
+
+test("canAffordRequest: blocks when cost exceeds remaining", () => {
+  clearProviderQuota(CONN);
+  recordProviderQuotaUsage(CONN, MODEL, 9_000, { tokenLimit: 10_000, windowMs: 60_000 });
+  const decision = canAffordRequest(CONN, MODEL, {
+    messages: [{ role: "user", content: "x".repeat(4 * 800) }], // ~800 tokens
+    max_tokens: 2000,
+  });
+  assert.equal(decision.affordable, false);
+  assert.equal(decision.reason, "insufficient_budget");
+});
+
+test("canAffordRequest: allows within budget", () => {
+  clearProviderQuota(CONN);
+  recordProviderQuotaUsage(CONN, MODEL, 1_000, { tokenLimit: 10_000, windowMs: 60_000 });
+  const decision = canAffordRequest(CONN, MODEL, { messages: [{ role: "user", content: "hi" }] });
+  assert.equal(decision.affordable, true);
+  assert.ok((decision.tokensRemaining ?? 0) > 0);
+});
+
+test("recordProviderQuotaUsage: seeds a row and accumulates", () => {
+  clearProviderQuota(CONN);
+  recordProviderQuotaUsage(CONN, MODEL, 100, { tokenLimit: 1_000, windowMs: 60_000 });
+  recordProviderQuotaUsage(CONN, MODEL, 150, { tokenLimit: 1_000, windowMs: 60_000 });
+  const snap = getProviderQuota(CONN, MODEL);
+  assert.ok(snap);
+  assert.equal(snap.tokensUsed, 250);
+  assert.equal(snap.tokenLimit, 1_000);
+  assert.equal(snap.tokensRemaining, 750);
+});
+
+test("getProviderQuota: returns null for unknown pair", () => {
+  clearProviderQuota(CONN);
+  assert.equal(getProviderQuota(CONN, "nope-model"), null);
+});
+
+test("getProviderQuota: ignores non-positive deltas", () => {
+  clearProviderQuota(CONN);
+  recordProviderQuotaUsage(CONN, MODEL, 0, { tokenLimit: 1_000 });
+  assert.equal(getProviderQuota(CONN, MODEL), null);
+});

--- a/tests/unit/quota-token-estimator.test.ts
+++ b/tests/unit/quota-token-estimator.test.ts
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { estimateChatTokenCost, estimateStringTokens } from "../../src/lib/quota/tokenEstimator";
+
+test("estimateStringTokens: chars/4 heuristic", () => {
+  assert.equal(estimateStringTokens(""), 0);
+  assert.equal(estimateStringTokens("abcd"), 1);
+  assert.equal(estimateStringTokens("abcdefgh"), 2);
+});
+
+test("estimateChatTokenCost: sums message content strings", () => {
+  const cost = estimateChatTokenCost({
+    messages: [
+      { role: "user", content: "Hello world, this is a test message" },
+      { role: "assistant", content: "A shorter reply" },
+    ],
+  });
+  assert.ok(cost.inputTokens > 0);
+  // total = input × 1.1 (over-provision) + output budget
+  assert.equal(cost.totalTokens, Math.ceil(cost.inputTokens * 1.1) + cost.outputTokens);
+});
+
+test("estimateChatTokenCost: includes system prompt", () => {
+  const withoutSystem = estimateChatTokenCost({
+    messages: [{ role: "user", content: "hi there" }],
+  });
+  const withSystem = estimateChatTokenCost({
+    system: "You are a helpful assistant with a fairly long system prompt to count",
+    messages: [{ role: "user", content: "hi there" }],
+  });
+  assert.ok(withSystem.inputTokens > withoutSystem.inputTokens);
+});
+
+test("estimateChatTokenCost: honors max_tokens as output budget", () => {
+  const cost = estimateChatTokenCost({
+    messages: [{ role: "user", content: "hi" }],
+    max_tokens: 2000,
+  });
+  assert.equal(cost.outputTokens, 2000);
+});
+
+test("estimateChatTokenCost: honors max_completion_tokens (Responses API)", () => {
+  const cost = estimateChatTokenCost({
+    messages: [{ role: "user", content: "hi" }],
+    max_completion_tokens: 500,
+  });
+  assert.equal(cost.outputTokens, 500);
+});
+
+test("estimateChatTokenCost: defaults output allowance when unset", () => {
+  const cost = estimateChatTokenCost({ messages: [{ role: "user", content: "hi" }] });
+  assert.equal(cost.outputTokens, 1024);
+});
+
+test("estimateChatTokenCost: handles multimodal content arrays", () => {
+  const cost = estimateChatTokenCost({
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,xxx" } },
+        ],
+      },
+    ],
+  });
+  assert.ok(cost.inputTokens > 0);
+});
+
+test("estimateChatTokenCost: handles Responses API input array", () => {
+  const cost = estimateChatTokenCost({
+    input: [{ role: "user", text: "What is the capital of France" }],
+  });
+  assert.ok(cost.inputTokens > 0);
+});
+
+test("estimateChatTokenCost: never throws on malformed bodies", () => {
+  for (const bad of [null, undefined, {}, { messages: "nope" }, { messages: [null, 42] }]) {
+    const cost = estimateChatTokenCost(bad as Record<string, unknown>);
+    assert.ok(cost.totalTokens >= 0);
+  }
+});


### PR DESCRIPTION
## Summary

Adds an **opt-in pre-request token-budget ledger** so routing can skip provider connections whose configured per-window token budget cannot afford the estimated request cost — **before dispatching** — instead of waiting for a 429.

## Problem

Current routing is **reactive**: a connection is only marked unavailable after the upstream returns 429 (cooldown/failover). For pools of accounts with finite per-minute token budgets, that means avoidable 429s and wasted attempts on exhausted connections.

## What's added

| Piece | Purpose |
|---|---|
| `migration 143` | `provider_quota_state` — runtime ledger (connection_id, model, tokens_used, token_limit, window_start, window_reset). No FK: best-effort writes never block on parent rows |
| `src/lib/quota/providerQuotaState.ts` | Windowed per-connection token ledger (record / get / clear), fail-open reads |
| `src/lib/quota/tokenEstimator.ts` | Deterministic chars/4 heuristic + `max_tokens`/`max_completion_tokens` output budget; input over-provisioned ×1.1 |
| `src/lib/quota/quotaScheduler.ts` | `canAffordRequest` (exhausted / insufficient_budget / unconfigured) + `reserveQuota` (best-effort) |
| `open-sse/services/combo.ts` | Opt-in gate (`OMNIROUTE_QUOTA_AWARE_ROUTING=1`) in the target-attempt loop (right after the existing quota-exhaustion cutoff): skip unaffordable connections; reserve estimated budget on dispatch. `tokenLimit` sourced from `rateLimitOverrides.tpm` |

## Behavior

- **Opt-in:** default routing is byte-for-byte unchanged when the env var is unset.
- **Fail-open:** connections without a configured budget are always considered affordable.
- **Generic:** provider-neutral — works for any connection with a `rateLimitOverrides.tpm` value (the existing per-connection TPM setting).
- **Non-blocking:** reservation is best-effort; ledger writes never break the request path.

## Example

Connection with `tpm: 10,000` and 9,800 already used in the window + a request estimating ~2,000 tokens → skipped before dispatch; the combo falls through to the next connection.

## Verification

- `quota-scheduler.test.ts` (7) + `quota-token-estimator.test.ts` (9) — **16/16 pass**
- Existing combo tests still pass (31 combined)
- `tsc --noEmit` — 0 errors in changed files
- `check-env-doc-sync` ✓ (`OMNIROUTE_QUOTA_AWARE_ROUTING` documented)
- `check-route-validation` PASS

Base: `release/v3.8.50` (per the request).