### PR TITLE
fix(providers): repair broken gateway catalog and conol-web import (base-red)

### DIFF
--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -352,21 +352,6 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     apiHint:
       "Create a ZeroLimitAI Bearer token, then use https://www.zerolimitai.com/api/v1 as the OpenAI-compatible base URL.",
   },
-  chatanywhere: {
-    id: "chatanywhere",
-    alias: "chatanywhere",
-    name: "ChatAnywhere",
-    icon: "router",
-    color: "#2563EB",
-    textIcon: "CA",
-    passthroughModels: true,
-    website: "https://chatanywhere.tech",
-    hasFree: true,
-    freeNote:
-      "Personal, educational or research use only: public documentation cites 10,000 points/day and 200 requests/day per IP/key; do not use for commercial traffic.",
-    apiHint:
-      "Create a ChatAnywhere key linked to GitHub, then use https://api.chatanywhere.org/v1 outside China. Review the non-commercial terms before enabling it.",
-  },
   helyxai: {
     id: "helyxai",
     alias: "helyxai",


### PR DESCRIPTION
## Summary

Found while rebasing 6 unrelated feature PRs — all 6 showed the identical uniform CI failure pattern (Build, Fast Quality Gates, Unit Tests fast-path ×4, No new ESLint warnings), traced to the base tip itself, not any of the PRs. Then found more while actually getting `omniroute-dev` to boot on the rebuilt combined branch — the base is unusually broken right now (multiple contributor-PR merge waves landing in quick succession).

**Note on overlap — credit where due:** item 1 below (`gateways.ts`'s missing `regolo` brace) is *also* fixed by **#10094** (@amartinawi), closing **#10093**, which was filed independently and first. That PR does not touch the `chatanywhere` duplicate-key issue (item 2) — its own parse count (88 entries) shows the duplicate survives their fix. Once #10094 merges this PR will rebase to drop the now-redundant brace hunk and keep only the dedup. Filing this as-is for the other items and so CI on the 6 PRs waiting on this doesn't stall on #10094's review cycle.

**7 independent, unrelated defects on `release/v3.8.50`:**

1. **`gateways.ts` — unclosed object literal.** The `regolo` entry (#9468) never closed its object before the next `naga-ac` key started — `TS1005`, breaks every downstream import of this file. *(Also fixed by #10094 / #10093 — see note above.)*
2. **`gateways.ts` — duplicate top-level key.** `chatanywhere` defined twice (two contributors independently adding the same gateway, #6674 among them) — `TS1117`. JS object-literal semantics mean the second definition already silently wins at runtime, so removing the first (dead, shadowed) is a pure no-op for behavior — verified via `providers-g4f-batch3.test.ts`'s `#6674 chatanywhere ...` assertions, still passing. *(Not covered by #10094.)*
3. **`conol-web/index.ts` — wrong relative import depth.** #8974 imports `conolModels.ts` with one `../` too few, resolving to a nonexistent path. Every sibling registry entry uses the same 4-level path (`hyperagent/index.ts`, `notion-web/index.ts`, `promptql/index.ts`) — this one alone used 3.
4. **`videoGeneration.ts` — duplicate import binding.** `handleFalVideoGeneration` imported from two different modules (`videoGeneration/falHandler.ts` and the newer `mediaGeneration/fal.ts`, #9982) — breaks the Turbopack build entirely via the instrumentation import chain. Kept the newer, more complete module.
5. **`tinycmsSigner.ts` — Turbopack bundles a nonexistent WASM asset.** `initTinyCmsWasm()` always calls `__wbg_init()` with a decoded `WASM_BASE64` buffer, so the `new URL('wasm_signer_bg.wasm', import.meta.url)` fallback is dead code in practice (confirmed via `provider-tinycms-web.test.ts`'s idempotency test) — but Turbopack statically bundles any `new URL('literal', import.meta.url)` regardless of reachability, and no `.wasm` file was ever checked in (#8736, tracked feature request #8734). Fixed by building the URL from a computed string instead, breaking the static-match.
6. **`conolDiscovery.ts` — wrong import path.** #8974 imports `getProviderOutboundGuard` from `@/shared/network/outboundUrlGuard` (never exported it) instead of `@/shared/network/outboundUrlGuardPolicy` (every other caller in the codebase uses the correct path). Broke `/api/providers/[id]/models` and `/api/providers/[id]/sync-models` (500), and poisoned the dev server's error state for unrelated requests until a working route recompiled.
7. **`modelSelectModalHelpers.ts` — unclosed function body.** #9011 — `isProviderModelHidden()` never closed before `PROVIDER_TEST_CHUNK_SIZE` started. Same parse-error class as #1/#7, but the failure mode is confusing: it manifests as `'import'/'export' cannot be used outside of module code` since Turbopack's parser loses track of module scope after the unclosed function. Broke every dashboard route (imported via `ModelSelectModal.tsx` → `(dashboard)/layout.tsx`).

All seven confirmed present on the pristine `release/v3.8.50` tip before this fix — not introduced by any of the 6 PRs that surfaced them.

⚠️ base-red inherited: #9985

## Note: more base-red found, not fixed here

Scoped this PR to defects that were blocking verification of my own PRs' test suites, or blocking `omniroute-dev` from booting/staying healthy. Also found (not fixed — out of scope, didn't block the above, and no existing issue found for any of these):
- `check:dashboard-typecheck`: `ProviderDetailPageClient.tsx` TS2322 regression (baseline 4→5)
- CodeQL ratchet: 2 open `js/insufficient-password-hash` alerts vs baseline 1
- `check-migration-numbering`: stale `KNOWN_GAPS` entries drifting as new migrations land (moving target — hit this repeatedly in one session as the base kept advancing)
- `open-sse/config/providers/registry/deepai/index.ts`: `Cannot find module '../shared'` (same off-by-one-`../` class as #3, but a `import type` — erased at build time, doesn't break the bundle)
- `open-sse/handlers/responseSanitizer.ts`: 2× `cached_tokens` does not exist on type `{}`
- `open-sse/handlers/search.ts`: 3× `HeadersInit` type errors
- `open-sse/utils/usageTracking.ts`: duplicate object-literal keys (same class as item 2)
- `src/lib/search/executeWebSearch.ts`: `providerConfig` possibly null

## Test plan

- `npx tsc --noEmit -p tsconfig.typecheck-core.json` — all 7 errors from these files are gone (remaining errors are the unrelated pre-existing ones listed above)
- `tests/unit/combo-routing-engine.test.ts` — 87/87 passed
- `tests/unit/providers-g4f-batch3.test.ts` — 10/10 passed, including the `chatanywhere`/`naga-ac` metadata assertions (confirms the dedup is behavior-preserving)
- `tests/unit/provider-tinycms-web.test.ts` — 15/15 passed, including the `initTinyCmsWasm` idempotency test (confirms fix #5 is behavior-preserving)
- Live-verified: rebuilt the combined staging branch for `omniroute-dev` with all fixes from this PR + 6 other rebased feature PRs, restarted the container, confirmed `/api/health/ping` returns 200 and stays healthy across multiple rechecks — twice: once after items #1-#6, and again after item #7 landed separately (a fresh contributor-PR merge wave broke it again a short time later)