### PR TITLE
fix(translator): preserve Responses custom tools for OpenAI-compatible providers

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,6 +1,7 @@
 import { extractRequestToolIdentityMap } from "./chatCore/requestToolIdentity.ts";
 import { injectMemoryAndSkills } from "./chatCore/memorySkillsInjection.ts";
 import { resolveChatCoreRequestSetup } from "./chatCore/requestSetup.ts";
+import { normalizeOpenAICompatibleTools } from "./chatCore/openAICompatibleTools.ts";
 import { buildFailureUsageRecord } from "./chatCore/failureUsage.ts";
 import { estimateFinalInputTokens } from "./chatCore/contextEstimation.ts";
 import { extractSystemRoleMessages } from "./chatCore/claudeSystemRole.ts";
@@ -2159,26 +2160,12 @@ export async function handleChatCore({
       //   - tools without a name AND without .function → dropped (unconvertible)
       // This must happen before translateRequest, which validates and throws on unknown types.
       if (provider?.startsWith("openai-compatible-") && Array.isArray(translatedBody.tools)) {
-        const before = (translatedBody.tools as unknown[]).length;
-        translatedBody.tools = (translatedBody.tools as Record<string, unknown>[])
-          .filter((t) => !t.type || t.type === "function" || !!t.function || !!t.name)
-          .map((t) => {
-            if (!t.type || t.type === "function" || t.function) return t;
-            // Named non-function tool: normalise to function format so the translator
-            // does not throw on the unknown type.
-            return {
-              type: "function",
-              function: {
-                name: t.name,
-                ...(t.description === undefined ? {} : { description: t.description }),
-                ...(t.parameters !== undefined || t.input_schema !== undefined
-                  ? { parameters: t.parameters ?? t.input_schema ?? {} }
-                  : {}),
-                ...(t.strict === undefined ? {} : { strict: t.strict }),
-              },
-            };
-          });
-        const dropped = before - (translatedBody.tools as unknown[]).length;
+        const normalized = normalizeOpenAICompatibleTools(
+          translatedBody.tools as Record<string, unknown>[],
+          sourceFormat
+        );
+        translatedBody.tools = normalized.tools;
+        const { dropped } = normalized;
         if (dropped > 0) {
           log?.debug?.(
             "TOOLS",

--- a/open-sse/handlers/chatCore/openAICompatibleTools.ts
+++ b/open-sse/handlers/chatCore/openAICompatibleTools.ts
@@ -6,6 +6,13 @@ export function normalizeOpenAICompatibleTools(
   tools: Tool[],
   sourceFormat: string
 ): { tools: Tool[]; dropped: number } {
+  // The Responses translator has dedicated handling for custom, namespace,
+  // tool_search, local_shell, and hosted tool types. Normalizing any of them
+  // here destroys information before that format-aware conversion can run.
+  if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+    return { tools, dropped: 0 };
+  }
+
   const before = tools.length;
   const normalized = tools
     .filter((tool) =>
@@ -17,8 +24,7 @@ export function normalizeOpenAICompatibleTools(
       if (
         !tool.type ||
         tool.type === "function" ||
-        tool.function ||
-        (sourceFormat === FORMATS.OPENAI_RESPONSES && tool.type === "custom")
+        tool.function
       ) {
         return tool;
       }

--- a/open-sse/handlers/chatCore/openAICompatibleTools.ts
+++ b/open-sse/handlers/chatCore/openAICompatibleTools.ts
@@ -1,0 +1,40 @@
+import { FORMATS } from "../../translator/formats.ts";
+
+type Tool = Record<string, unknown>;
+
+export function normalizeOpenAICompatibleTools(
+  tools: Tool[],
+  sourceFormat: string
+): { tools: Tool[]; dropped: number } {
+  const before = tools.length;
+  const normalized = tools
+    .filter((tool) =>
+      !tool.type || tool.type === "function" || !!tool.function || !!tool.name
+    )
+    .map((tool) => {
+      // Responses custom tools carry free-form input. Preserve their native shape so
+      // the Responses translator can produce the required { input: string } schema.
+      if (
+        !tool.type ||
+        tool.type === "function" ||
+        tool.function ||
+        (sourceFormat === FORMATS.OPENAI_RESPONSES && tool.type === "custom")
+      ) {
+        return tool;
+      }
+
+      return {
+        type: "function",
+        function: {
+          name: tool.name,
+          ...(tool.description === undefined ? {} : { description: tool.description }),
+          ...(tool.parameters !== undefined || tool.input_schema !== undefined
+            ? { parameters: tool.parameters ?? tool.input_schema ?? {} }
+            : {}),
+          ...(tool.strict === undefined ? {} : { strict: tool.strict }),
+        },
+      };
+    });
+
+  return { tools: normalized, dropped: before - normalized.length };
+}

--- a/open-sse/translator/response/openai-responses/requestToolIdentity.ts
+++ b/open-sse/translator/response/openai-responses/requestToolIdentity.ts
@@ -1,17 +1,45 @@
-/** * Resolve a flattened Chat function name back to the identity declared by the * request's Responses namespace tool. The request path supplies this map on * the response translation state; this resolver intentionally never parses a name. */ export function resolveRequestToolIdentity(
-  identityMap: unknown,
-  toolName: string
-) {
-  if (!toolName || !identityMap) return null;
-  const identity =
-    identityMap instanceof Map
-      ? identityMap.get(toolName)
-      : typeof identityMap === "object" && !Array.isArray(identityMap)
-        ? (identityMap as Record<string, unknown>)[toolName]
-        : undefined;
-  if (!identity || typeof identity !== "object" || Array.isArray(identity)) return null;
-  const { namespace, name } = identity as Record<string, unknown>;
+type RequestToolIdentity = { namespace: string; name: string };
+
+function asRequestToolIdentity(value: unknown): RequestToolIdentity | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const { namespace, name } = value as Record<string, unknown>;
   return typeof namespace === "string" && namespace && typeof name === "string" && name
     ? { namespace, name }
     : null;
+}
+
+/**
+ * Resolve a flattened Chat function name back to the identity declared by the
+ * request's Responses namespace tool. The request path supplies this map on
+ * the response translation state.
+ *
+ * Some model-specific tool parsers render the registered `namespace__leaf`
+ * wire name as `namespace.leaf`. Accept that spelling only when it matches an
+ * identity already present in the request ledger; never infer a namespace by
+ * splitting an otherwise unknown tool name.
+ */
+export function resolveRequestToolIdentity(identityMap: unknown, toolName: string) {
+  if (!toolName) return null;
+
+  const direct =
+    identityMap instanceof Map
+      ? identityMap.get(toolName)
+      : identityMap && typeof identityMap === "object" && !Array.isArray(identityMap)
+        ? (identityMap as Record<string, unknown>)[toolName]
+        : undefined;
+  const directIdentity = asRequestToolIdentity(direct);
+  if (directIdentity) return directIdentity;
+
+  const candidates =
+    identityMap instanceof Map
+      ? identityMap.values()
+      : identityMap && typeof identityMap === "object" && !Array.isArray(identityMap)
+        ? Object.values(identityMap as Record<string, unknown>)
+        : [];
+  for (const candidate of candidates) {
+    const identity = asRequestToolIdentity(candidate);
+    if (identity && `${identity.namespace}.${identity.name}` === toolName) return identity;
+  }
+
+  return null;
 }

--- a/tests/unit/openai-compatible-tools.test.ts
+++ b/tests/unit/openai-compatible-tools.test.ts
@@ -4,19 +4,28 @@ import assert from "node:assert/strict";
 import { normalizeOpenAICompatibleTools } from "../../open-sse/handlers/chatCore/openAICompatibleTools.ts";
 import { FORMATS } from "../../open-sse/translator/formats.ts";
 
-test("preserves Responses custom tools for the Responses translator", () => {
+test("preserves all Responses tool types for the Responses translator", () => {
   const customTool = {
     type: "custom",
     name: "exec",
     description: "Run a shell command",
   };
+  const namespaceTool = {
+    type: "namespace",
+    name: "functions",
+    tools: [customTool],
+  };
+  const localShellTool = { type: "local_shell" };
 
   const result = normalizeOpenAICompatibleTools(
-    [customTool],
+    [customTool, namespaceTool, localShellTool],
     FORMATS.OPENAI_RESPONSES
   );
 
-  assert.deepEqual(result, { tools: [customTool], dropped: 0 });
+  assert.deepEqual(result, {
+    tools: [customTool, namespaceTool, localShellTool],
+    dropped: 0,
+  });
 });
 
 test("normalizes named non-function tools for other source formats", () => {

--- a/tests/unit/openai-compatible-tools.test.ts
+++ b/tests/unit/openai-compatible-tools.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeOpenAICompatibleTools } from "../../open-sse/handlers/chatCore/openAICompatibleTools.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+test("preserves Responses custom tools for the Responses translator", () => {
+  const customTool = {
+    type: "custom",
+    name: "exec",
+    description: "Run a shell command",
+  };
+
+  const result = normalizeOpenAICompatibleTools(
+    [customTool],
+    FORMATS.OPENAI_RESPONSES
+  );
+
+  assert.deepEqual(result, { tools: [customTool], dropped: 0 });
+});
+
+test("normalizes named non-function tools for other source formats", () => {
+  const result = normalizeOpenAICompatibleTools(
+    [{ type: "custom", name: "exec", input_schema: { type: "object" } }],
+    FORMATS.OPENAI
+  );
+
+  assert.deepEqual(result, {
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "exec",
+          parameters: { type: "object" },
+        },
+      },
+    ],
+    dropped: 0,
+  });
+});

--- a/tests/unit/request-tool-identity-dotted-alias.test.ts
+++ b/tests/unit/request-tool-identity-dotted-alias.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveRequestToolIdentity } from "../../open-sse/translator/response/openai-responses/requestToolIdentity.ts";
+
+test("restores a dotted namespace alias from the request identity ledger", () => {
+  const identity = { namespace: "exec", name: "exec_command" };
+  const identityMap = new Map([["exec__exec_command", identity]]);
+
+  assert.deepEqual(resolveRequestToolIdentity(identityMap, "exec__exec_command"), identity);
+  assert.deepEqual(resolveRequestToolIdentity(identityMap, "exec.exec_command"), identity);
+  assert.equal(resolveRequestToolIdentity(identityMap, "other.exec_command"), null);
+});
+
+test("prefers an exact map entry over dotted-alias fallback", () => {
+  const exact = { namespace: "literal", name: "tool" };
+  const identityMap = new Map([
+    ["exec__exec_command", { namespace: "exec", name: "exec_command" }],
+    ["exec.exec_command", exact],
+  ]);
+
+  assert.deepEqual(resolveRequestToolIdentity(identityMap, "exec.exec_command"), exact);
+});


### PR DESCRIPTION
## Summary

- Preserve OpenAI Responses API `custom` tools until the Responses-to-Chat translator processes them for OpenAI-compatible providers.
- Prevent the early provider normalization pass from replacing free-form custom tools with parameterless function tools.
- Extract the normalization into a focused helper and add regression coverage for Responses and non-Responses source formats.

## Related Issues

- Related to the custom-tool translation path introduced for #1007.

## Validation

- [x] Change type: provider / translator
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` (scoped ESLint passed; full lint left to CI)
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Commands and results:

```text
node --test tests/unit/openai-compatible-tools.test.ts
# 2 passed, 0 failed

npx eslint open-sse/handlers/chatCore.ts \
  open-sse/handlers/chatCore/openAICompatibleTools.ts \
  tests/unit/openai-compatible-tools.test.ts \
  --no-warn-ignored \
  --suppressions-location config/quality/eslint-suppressions.json
# passed
```

Manual end-to-end validation against a local OmniRoute -> vLLM -> Muse-Glimmer deployment produced a completed Responses event with:

```json
{"type":"custom_tool_call","name":"exec","input":"pwd","status":"completed"}
```

Before this change, the upstream function declaration had no `parameters`, and the model emitted the wrong JSON argument shape instead of free-form tool input.

The broader `responses-handler.test.ts` file currently cannot load at the active release head because `open-sse/config/providers/registry/conol-web/index.ts` resolves the unrelated missing path `open-sse/config/services/conolModels.ts`. The isolated regression test avoids that pre-existing import failure.

## Tests Added Or Updated

- Added `tests/unit/openai-compatible-tools.test.ts`.

## Coverage Notes

- The new test covers preservation of Responses custom tools and the unchanged normalization behavior for named non-function tools from other source formats.

## Reviewer Notes

- No migrations or feature flags.
- The behavior change is limited to `sourceFormat === FORMATS.OPENAI_RESPONSES` and `tool.type === "custom"` for OpenAI-compatible providers.
