### PR TITLE
perf(compression): cap countTextTokens at 50k chars and strip base64 data URIs

### DIFF
--- a/src/shared/utils/tiktokenCounter.ts
+++ b/src/shared/utils/tiktokenCounter.ts
@@ -21,6 +21,29 @@ export function tokenizerContextFromBody(body: unknown): TokenizerContext {
 
 const encoders = new Map<TokenizerEncoding, Tiktoken>();
 
+/**
+ * Above this many characters the exact tokenizer is skipped in favor of the
+ * char-heuristic (chars/4). js-tiktoken's pure-JS encoder is near-quadratic on
+ * large inputs — a 10 MB base64 image payload can block the event loop for
+ * tens of seconds (OmniRoute worker wedge incident). Token counting is used for
+ * compression stats/estimates only, so a heuristic on oversized inputs is
+ * acceptable and keeps the loop responsive.
+ */
+const MAX_EXACT_TOKEN_COUNT_CHARS = 50_000;
+
+/**
+ * Base64 data URIs (e.g. OpenAI-style `image_url.url`) must not be tokenized:
+ * they are image payloads, not text. Matching a data URI of any `image/*`
+ * media type and stripping it keeps the count accurate (the raw bytes of an
+ * image are not meaningful "text" tokens) while avoiding the quadratic encode
+ * cost on large attachments.
+ */
+const BASE64_DATA_URI_RE = /data:image\/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+/gi;
+
+function stripBase64DataUris(text: string): string {
+  return text.replace(BASE64_DATA_URI_RE, "");
+}
+
 function normalize(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
@@ -60,12 +83,19 @@ function getEncoder(encoding: TokenizerEncoding): Tiktoken {
  * Existing callers retain cl100k_base; Codex callers may pass provider/model context
  * to use o200k_base.
  * Defensive: never throws in a counting path — falls back to a char heuristic.
+ * Oversized inputs (over 50k chars) and base64 image data URIs are never
+ * tokenized: the encoder is near-quadratic on large strings and would block the
+ * event loop (worker wedge regression).
  */
 export function countTextTokens(text: string, context?: TokenizerContext): number {
   if (!text || typeof text !== "string") return 0;
+  const stripped = stripBase64DataUris(text);
+  if (stripped.length > MAX_EXACT_TOKEN_COUNT_CHARS) {
+    return Math.ceil(stripped.length / 4);
+  }
   try {
-    return getEncoder(resolveTokenizerEncoding(context)).encode(text).length;
+    return getEncoder(resolveTokenizerEncoding(context)).encode(stripped).length;
   } catch {
-    return Math.ceil(text.length / 4);
+    return Math.ceil(stripped.length / 4);
   }
 }

--- a/tests/unit/tiktoken-counter.test.ts
+++ b/tests/unit/tiktoken-counter.test.ts
@@ -40,3 +40,34 @@ test("countTextTokens is additive-ish and monotonic for longer text", () => {
   assert.ok(long > short);
   assert.ok(short > 0);
 });
+
+test("countTextTokens fast-paths strings over 50k chars without tokenizing (worker wedge regression)", () => {
+  const big = "user: please review the attached patch\ntext: ".repeat(40_000);
+  const start = performance.now();
+  const tokens = countTextTokens(big);
+  const elapsed = performance.now() - start;
+  assert.equal(tokens, Math.ceil(big.length / 4));
+  assert.ok(elapsed < 1000, `fast path took ${elapsed.toFixed(0)}ms`);
+});
+
+test("countTextTokens strips base64 data URIs before tokenizing (images not counted as text)", () => {
+  const png =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+  const b64 = png.repeat(60);
+  const withImage = countTextTokens(
+    `{"image_url":{"url":"data:image/png;base64,${b64}"}}`,
+    { provider: "codex" }
+  );
+  const stripped = countTextTokens('{"image_url":{"url":""}}', { provider: "codex" });
+  assert.equal(withImage, stripped);
+});
+
+test("countTextTokens does not tokenize huge base64 image payloads (wedge repro)", () => {
+  const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+  const body = `{"image_url":{"url":"data:image/png;base64,${b64.repeat(14_000)}"}}`;
+  const start = performance.now();
+  const tokens = countTextTokens(body);
+  const elapsed = performance.now() - start;
+  assert.ok(tokens < 1000, `base64 payload inflates token count to ${tokens}`);
+  assert.ok(elapsed < 1000, `took ${elapsed.toFixed(0)}ms`);
+});


### PR DESCRIPTION
## Summary

Fixes #10117 — countTextTokens can block the worker event loop for tens of seconds when a Codex request carries a large base64 image payload, wedging /healthz and every concurrent request.

The compression stats estimator (stimateCompressionTokens in open-sse/services/compression/stats.ts) calls countTextTokens(JSON.stringify(body), ctx) for Codex contexts. The full body — including megabyte-scale base64 image_url data URIs — is fed synchronously to js-tiktoken's pure-JS ncode(), which is near-quadratic on large inputs (measured: 1 MB base64 → 5.9 s, 5 MB → 30.6 s, 10 MB → 58 s+; repeated-char runs are far worse).

## Changes

src/shared/utils/tiktokenCounter.ts — countTextTokens:

1. **Strip base64 data URIs** (/data:image\/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+/gi) before encoding. Image payloads are not text and are never meaningful "tokens"; stripping both fixes the count and removes the quadratic blow-up.
2. **Fast-path length guard:** if the stripped text exceeds 50 000 chars, skip ncode() and return Math.ceil(len / 4) — the same char heuristic the existing catch fallback uses.

## Also included (to make the branch build + preserve local behavior)

This branch now also carries:

- **Base-red build fixes (cherry-picked from upstream PRs #10108 / #10102, plus two manual equivalents):** conol-web/deepai registry import paths, regolo gateways syntax, tinycmsSigner computed wasm URL, fal handler duplicate import, conolDiscovery outbound-guard path, catalog dead re-exports. Without these, elease/v3.8.50 cannot produce a build at all (missing-file/module errors) — see base-red #9985.
- **Local resilience ports preserved from the deployed fork:** semantic-empty-output classification (open-sse/services/combo/comboPredicates.ts, src/sse/handlers/chatHelpers.ts) and the plugin etchTimeoutMs option (@omniroute/opencode-plugin). These are already live on the operator's deployment and would regress if omitted.

## Tests

	ests/unit/tiktoken-counter.test.ts — added 3 tests (TDD, red first):

- fast-paths 1.8 MB string in <1 s with capped count (was ~500 ms + wrong count; assertion pins the capped value)
- base64 data-URI body counts identically to stripped body
- 2 MB base64 body returns small count in <1 s (was 770 012 tokens, ~5.9 s)

Validation: 8/8 tiktoken tests; plugin suite 326/326 (3 new fetchTimeout tests); compression dir 1238 pass / 0 new failures (70 pre-existing base failures: migration-143 collision + Windows EPERM temp-dir); full 
pm run build succeeds (Turbopack, ~7 min); deployed and verified in production (worker 89-94%→~30% CPU, healthz 200 in 2-3 ms under live 227k-token prompts; 5 MB base64 probe returns in ~3 s without wedging).

> ⚠️ base-red inherited: #9985 (release/v3.8.50 has pre-existing failures: DB migration version 143 collision, Windows EPERM temp-dir cleanup, and the build blockers fixed here via #10108/#10102)