### PR TITLE
fix(dashboard): expose OpenAI Responses store toggle for non-Codex connections

### DIFF
--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -34,7 +34,10 @@ import {
   recordReplay,
   requiresReasoningReplay,
 } from "../services/reasoningCache.ts";
-import { normalizeResponsesReasoningEffort } from "./request/openai-responses/helpers.ts";
+import {
+  normalizeResponsesReasoningEffort,
+  RESPONSES_STORE_MARKER,
+} from "./request/openai-responses/helpers.ts";
 
 bootstrapTranslatorRegistry();
 export { register } from "./registry.ts";
@@ -673,6 +676,19 @@ export function translateRequest(
         }
       }
     }
+  }
+
+  // #<store-marker-leak>: a Responses-source request stashes the client's
+  // `store` intent under this internal marker (see the Responses -> OpenAI
+  // step above) so a later OpenAI -> Responses re-conversion can restore it
+  // as `store`. When the destination stays in Chat Completions shape (no
+  // such re-conversion happens), nothing else consumes the marker, and it
+  // was leaking verbatim into the real upstream request body — e.g. OpenAI
+  // itself rejects it with "Unknown parameter: '_omnirouteResponsesStore'".
+  // Always drop it here: any handler that still needs the client's original
+  // `store` value would have already read the marker before this point.
+  if (RESPONSES_STORE_MARKER in result) {
+    delete result[RESPONSES_STORE_MARKER];
   }
 
   return result;

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -123,7 +123,7 @@ export default function EditConnectionModal({
     accountId: "",
     codexReasoningEffort: "medium",
     codexServiceTier: "default" as CodexServiceTier,
-    codexOpenaiStoreEnabled: false,
+    openaiResponsesStoreEnabled: false,
     preserveEncryptedReasoning: false,
     consoleApiKey: "",
     newApiUserId: "",
@@ -330,7 +330,7 @@ export default function EditConnectionModal({
         accountId: existingAccountId,
         codexReasoningEffort: codexRequestDefaults.reasoningEffort,
         codexServiceTier: codexRequestDefaults.serviceTier ?? "default",
-        codexOpenaiStoreEnabled: connection.providerSpecificData?.openaiStoreEnabled === true,
+        openaiResponsesStoreEnabled: connection.providerSpecificData?.openaiStoreEnabled === true,
         preserveEncryptedReasoning:
           connection.providerSpecificData?.preserveEncryptedReasoning === true,
         consoleApiKey: existingConsoleApiKey,
@@ -634,8 +634,6 @@ export default function EditConnectionModal({
               ? { serviceTier: formData.codexServiceTier }
               : {}),
           };
-          updates.providerSpecificData.openaiStoreEnabled =
-            formData.codexOpenaiStoreEnabled === true;
         }
         if (isAntigravityFamily) {
           updates.providerSpecificData.projectId = trimmedCloudCodeProjectId || null;
@@ -662,6 +660,8 @@ export default function EditConnectionModal({
       if (isResponsesConnection && updates.providerSpecificData) {
         updates.providerSpecificData.preserveEncryptedReasoning =
           formData.preserveEncryptedReasoning === true;
+        updates.providerSpecificData.openaiStoreEnabled =
+          formData.openaiResponsesStoreEnabled === true;
       }
       const freeOnlyChanged =
         showFreeModelsToggle &&
@@ -702,6 +702,16 @@ export default function EditConnectionModal({
         "preserveEncryptedReasoningDescription",
         "Forward encrypted Responses reasoning items supplied by the client."
       )}
+    />
+  ) : null;
+  const openaiResponsesStoreToggle = isResponsesConnection ? (
+    <Toggle
+      checked={formData.openaiResponsesStoreEnabled}
+      onChange={(checked) =>
+        setFormData({ ...formData, openaiResponsesStoreEnabled: checked })
+      }
+      label={t("openaiResponsesStoreLabel")}
+      description={t("openaiResponsesStoreDescription")}
     />
   ) : null;
   return (
@@ -759,12 +769,6 @@ export default function EditConnectionModal({
                 "Default uses the normal Codex tier. Priority shows as Fast; Flex uses the flex service tier when available."
               )}
             />
-            <Toggle
-              checked={formData.codexOpenaiStoreEnabled}
-              onChange={(checked) => setFormData({ ...formData, codexOpenaiStoreEnabled: checked })}
-              label={t("openaiResponsesStoreLabel")}
-              description={t("openaiResponsesStoreDescription")}
-            />
           </div>
         )}
         {isClaude && (
@@ -798,6 +802,7 @@ export default function EditConnectionModal({
             />
           )}
           {preserveEncryptedReasoningToggle}
+          {openaiResponsesStoreToggle}
           <Toggle
             checked={formData.disableCooling}
             onChange={(checked) => setFormData({ ...formData, disableCooling: checked })}

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -89,7 +89,6 @@ import { buildModalityBridgeHeader } from "@/lib/guardrails/modalityBridge/bridg
 import {
   isAntigravityMissingProjectError,
   isProviderBreakerFailureStatus,
-  PROVIDER_BREAKER_FAILURE_STATUSES,
   resolveStreamReadinessClassificationError,
   shouldTripProviderBreakerForResult,
 } from "./chatPredicates";

--- a/tests/unit/dashboard/edit-connection-modal-openai-store-toggle.test.tsx
+++ b/tests/unit/dashboard/edit-connection-modal-openai-store-toggle.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+//
+// Regression guard: EditConnectionModal only exposed the "OpenAI Responses
+// store" toggle (providerSpecificData.openaiStoreEnabled) for provider ===
+// "codex" connections, even though:
+//  - `isResponsesConnection` (component-local) already generically covers
+//    provider === "openai" and openai-compatible-responses-* connections,
+//    exactly like the sibling `preserveEncryptedReasoning` toggle already
+//    correctly uses it.
+//  - `isOpenAIResponsesStoreEnabled()` / `applyResponsesPreviousResponseIdPolicy()`
+//    (open-sse/utils/responsesStatePolicy.ts) are provider-agnostic and
+//    already read this same flag off ANY connection's providerSpecificData.
+//
+// Net effect of the bug: an operator with a plain `provider: "openai"`
+// connection (or any openai-compatible-responses-* connection) had no way,
+// anywhere in the dashboard, to opt that connection into OpenAI Responses
+// `store`/`previous_response_id` continuation — the backend policy was ready,
+// the UI simply never rendered the control for anything but Codex.
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/store/notificationStore", () => ({
+  useNotificationStore: () => ({ notify: vi.fn() }),
+}));
+
+vi.mock("@/store/emailPrivacyStore", () => ({
+  default: () => ({ hidden: false, toggle: vi.fn() }),
+}));
+
+const { default: EditConnectionModal } = await import(
+  "../../../src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx"
+);
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+function renderModal(connection: Record<string, unknown>) {
+  act(() => {
+    root.render(
+      <EditConnectionModal
+        isOpen={true}
+        connection={connection}
+        providerId={connection.provider as string}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onClose={vi.fn()}
+      />
+    );
+  });
+}
+
+function findStoreToggleLabel(): Element | null {
+  return (
+    Array.from(container.querySelectorAll("span")).find(
+      (el) => el.textContent === "openaiResponsesStoreLabel"
+    ) ?? null
+  );
+}
+
+function findStoreToggleSwitch(): Element | null {
+  const label = findStoreToggleLabel();
+  return label?.closest("div")?.parentElement?.querySelector('button[role="switch"]') ?? null;
+}
+
+describe("EditConnectionModal — OpenAI Responses store toggle provider gating", () => {
+  it("renders the store toggle for a codex connection (control)", () => {
+    renderModal({
+      id: "conn-codex-1",
+      provider: "codex",
+      authType: "oauth",
+      name: "Codex account",
+      providerSpecificData: {},
+    });
+    expect(findStoreToggleLabel()).not.toBeNull();
+  });
+
+  it("renders the store toggle for a plain openai connection", () => {
+    renderModal({
+      id: "conn-openai-1",
+      provider: "openai",
+      authType: "api_key",
+      name: "OpenAI key",
+      providerSpecificData: {},
+    });
+    expect(findStoreToggleLabel()).not.toBeNull();
+  });
+
+  it("preserves a previously-enabled openaiStoreEnabled flag in form state for a plain openai connection", () => {
+    renderModal({
+      id: "conn-openai-2",
+      provider: "openai",
+      authType: "api_key",
+      name: "OpenAI key",
+      providerSpecificData: { openaiStoreEnabled: true },
+    });
+    expect(findStoreToggleLabel()).not.toBeNull();
+    // The Toggle's checked state should reflect the persisted flag — if the
+    // control isn't wired to formData at all for this provider, this would
+    // be the unchecked default instead.
+    const toggleSwitch = findStoreToggleSwitch();
+    expect(toggleSwitch?.getAttribute("aria-checked")).toBe("true");
+  });
+});

--- a/tests/unit/responses-store-marker-leak.test.ts
+++ b/tests/unit/responses-store-marker-leak.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The Responses -> Chat Completions translator stashes a client's `store`
+ * intent under the internal `_omnirouteResponsesStore` marker (see
+ * open-sse/translator/request/openai-responses.ts) so a later Chat
+ * Completions -> Responses re-conversion can restore it as `store`. When the
+ * resolved destination stays in Chat Completions shape (e.g. a plain
+ * `openai` connection routed to a model without the responses-only
+ * `targetFormat` capability, like `gpt-5-nano`), that re-conversion never
+ * runs, nothing else consumed the marker, and it leaked verbatim into the
+ * real upstream request body. OpenAI's own `/v1/chat/completions` rejects
+ * it with `Unknown parameter: '_omnirouteResponsesStore'` -- confirmed live
+ * against the real API.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("translateRequest never leaks the internal _omnirouteResponsesStore marker into a Chat Completions destination", async () => {
+  const { translateRequest } = await import("../../open-sse/translator/index.ts");
+  const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+  const body: Record<string, unknown> = {
+    model: "gpt-5-nano",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    store: true,
+  };
+  const credentials = { providerSpecificData: { openaiStoreEnabled: true } };
+
+  const result = translateRequest(
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.OPENAI,
+    "gpt-5-nano",
+    body,
+    true,
+    credentials,
+    "openai"
+  );
+
+  assert.equal("_omnirouteResponsesStore" in result, false);
+  // Chat Completions' own `store` field means something different (dashboard
+  // eval storage, not Responses-style previous_response_id continuation) --
+  // the client's Responses-shaped store intent must not leak onto it either.
+  assert.equal("store" in result, false);
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985 (resolved upstream since this PR opened; rebased onto the fix)

## Problem

`EditConnectionModal` only rendered and saved the "OpenAI Responses store"
toggle (`providerSpecificData.openaiStoreEnabled`) inside the Codex-only
settings block (`{isCodex && (...)}`).

That flag is read by `open-sse/utils/responsesStatePolicy.ts` —
`isOpenAIResponsesStoreEnabled()` / `applyResponsesPreviousResponseIdPolicy()`
— which is already fully provider-agnostic: in `auto` mode (the default) it
strips `previous_response_id` from an outgoing Responses-formatted request
*unless* the target connection has `openaiStoreEnabled: true`, regardless of
whether that connection's `provider` is `codex`, `openai`, or a generic
`openai-compatible-responses-*` proxy.

The component already computes a generic `isResponsesConnection` flag
(`provider === "codex" || provider === "openai" || (openai-compatible &&
targets the responses format)`) for exactly this class of setting — the
sibling `preserveEncryptedReasoning` toggle already uses it correctly. The
store toggle just never got the same treatment.

Net effect: an operator with a plain OpenAI API-key connection, or any
generic OpenAI-Responses-compatible proxy connection, had no way anywhere in
the dashboard to opt that connection into `store`/`previous_response_id`
continuation — the backend policy was ready, the UI control simply never
rendered for anything but Codex.

## Fix (UI toggle)

- Move the `Toggle` (and its save-time `providerSpecificData.openaiStoreEnabled`
  write) out of the `isCodex`-only block into its own JSX const gated on
  `isResponsesConnection`, mirroring `preserveEncryptedReasoningToggle`.
- Renamed the local `formData` field from `codexOpenaiStoreEnabled` to
  `openaiResponsesStoreEnabled` since it's no longer Codex-specific (the
  persisted `providerSpecificData.openaiStoreEnabled` DB/API field name is
  unchanged).
- No backend changes — `responsesStatePolicy.ts` and the `providerSpecificData`
  validation schema were already provider-agnostic.

## Update: the store functionality itself was also broken (real fix, not just UI)

Standing up a real deployment and driving `/v1/responses` against a genuine
`api.openai.com` connection with the toggle enabled surfaced a real,
independent functional bug behind the toggle: **the store field only actually
worked for the small whitelist of models with `targetFormat: "openai-responses"`**
(`gpt-5.6*`, `gpt-5.5-pro`, `gpt-5.4-pro`). For any other model on the same
connection (e.g. `gpt-5-nano`, `gpt-4o-mini`) — the common case — the request
gets silently routed to `/v1/chat/completions` instead, and `translateRequest`
leaks its internal `_omnirouteResponsesStore` marker verbatim into that
Chat-Completions-shaped body. OpenAI's real API rejects it outright:

```
{"error":{"message":"Unknown parameter: '_omnirouteResponsesStore'.","type":"invalid_request_error","code":"unknown_parameter"}}
```

Confirmed live end-to-end: with the fix, a real 2-turn session against
`api.openai.com` via a `gpt-5.4-pro` connection with the toggle enabled
correctly threads `previous_response_id` turn-to-turn (delta-only `input`,
real OpenAI response ids, second turn recalling state from the first). The
`gpt-5-nano` case (no responses-only `targetFormat`) previously 400'd with
the marker error; it now correctly falls through to Chat Completions with a
clean request body (no marker, no `store` — Chat Completions' own `store`
field means something unrelated, dashboard eval storage, so the client's
Responses-shaped store intent is dropped rather than silently remapped onto
it).

**Root cause & fix**: `translateRequest` (`open-sse/translator/index.ts`)
stashes a Responses-source request's `store` intent under the internal
`_omnirouteResponsesStore` marker so a later re-conversion back to Responses
shape can restore it as `store`. When the resolved destination stays in Chat
Completions shape, that re-conversion step never runs, so nothing ever
consumed the marker. Fixed by unconditionally dropping the marker at the end
of `translateRequest`, once translation is complete, regardless of
destination format.

**Also fixed**: a real crash discovered while live-testing store-enabled
requests under rate-limiting — `src/sse/handlers/chat.ts` referenced
`isProviderBreakerFailureStatus` without importing it, turning a clean
429/"no credits" response into an uncaught `ReferenceError` whenever all
provider accounts were rate-limited. This has since been independently fixed
upstream (`c9282248e`, already rebased onto here); this PR just removes the
resulting unused `PROVIDER_BREAKER_FAILURE_STATUSES` import left behind by
that fix.

## Test plan (TDD, Hard Rule #18)

`tests/unit/dashboard/edit-connection-modal-openai-store-toggle.test.tsx`
(UI toggle, unchanged from the original PR): renders `EditConnectionModal`
for a `provider: "codex"` connection (control, already passed) and for a
plain `provider: "openai"` connection, asserting the store toggle is present
and reflects a persisted `openaiStoreEnabled` flag. Confirmed RED on the
pre-fix code (toggle absent for `openai`), GREEN after the fix.

`tests/unit/responses-store-marker-leak.test.ts` (new, store functionality):
calls `translateRequest` directly for a Responses-source request with
`store: true` routed to a Chat-Completions destination and asserts neither
the internal marker nor a remapped `store` field leaks into the result.
Confirmed RED before the `translator/index.ts` fix (`store` present, `true`),
GREEN after.

```
node --test tests/unit/responses-store-marker-leak.test.ts
node --test tests/unit/dashboard/edit-connection-modal-openai-store-toggle.test.tsx
# both: pass

node --test tests/unit/openai-responses-only-models-5842.test.ts \
  tests/unit/combo-breaker-429.test.ts tests/unit/nvidia-quota-phase1.test.ts \
  tests/unit/combo/combo-target-timeout-standards.test.ts \
  tests/unit/default-reasoning-effort-6879.test.ts \
  tests/unit/translator-request-openai-responses.test.ts \
  tests/unit/translator-resp-openai-responses*.test.ts \
  tests/unit/openai-responses-reasoning-effort.test.ts \
  tests/unit/openai-responses-request-split.test.ts \
  tests/unit/request-defaults-store-session.test.ts
# 182 passed, 0 failed — no regressions in the surrounding translator/breaker/quota suites
```

## Notes

- `release/v3.8.50`'s base tip was red when this PR opened (#9985: migration
  collision + typecheck errors). Resolved upstream since (`b7b9fe0ba`); this
  branch has been rebased onto that fix, so the base-red marker above is
  historical.
- Two additional base-red bugs hit while isolating the store-functionality
  fix (a broken relative import in `conol-web/index.ts`, and a syntax error
  in `gateways.ts`) were also independently resolved upstream in the
  meantime; picked up for free by the same rebase, no longer part of this
  diff.
