### PR TITLE
fix(release): opens the missing 3.8.50 changelog cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
-### Fixed
+---
+
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
 
 - **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
 

--- a/docs/i18n/ar/CHANGELOG.md
+++ b/docs/i18n/ar/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/az/CHANGELOG.md
+++ b/docs/i18n/az/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/bg/CHANGELOG.md
+++ b/docs/i18n/bg/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/bn/CHANGELOG.md
+++ b/docs/i18n/bn/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/cs/CHANGELOG.md
+++ b/docs/i18n/cs/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/da/CHANGELOG.md
+++ b/docs/i18n/da/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/de/CHANGELOG.md
+++ b/docs/i18n/de/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/es/CHANGELOG.md
+++ b/docs/i18n/es/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/fa/CHANGELOG.md
+++ b/docs/i18n/fa/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/fi/CHANGELOG.md
+++ b/docs/i18n/fi/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/fr/CHANGELOG.md
+++ b/docs/i18n/fr/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/gu/CHANGELOG.md
+++ b/docs/i18n/gu/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/he/CHANGELOG.md
+++ b/docs/i18n/he/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/hi/CHANGELOG.md
+++ b/docs/i18n/hi/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/hu/CHANGELOG.md
+++ b/docs/i18n/hu/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/id/CHANGELOG.md
+++ b/docs/i18n/id/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/in/CHANGELOG.md
+++ b/docs/i18n/in/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/it/CHANGELOG.md
+++ b/docs/i18n/it/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ja/CHANGELOG.md
+++ b/docs/i18n/ja/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ko/CHANGELOG.md
+++ b/docs/i18n/ko/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/mr/CHANGELOG.md
+++ b/docs/i18n/mr/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ms/CHANGELOG.md
+++ b/docs/i18n/ms/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/nl/CHANGELOG.md
+++ b/docs/i18n/nl/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/no/CHANGELOG.md
+++ b/docs/i18n/no/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/phi/CHANGELOG.md
+++ b/docs/i18n/phi/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/pl/CHANGELOG.md
+++ b/docs/i18n/pl/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ---
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/pt-BR/CHANGELOG.md
+++ b/docs/i18n/pt-BR/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/pt/CHANGELOG.md
+++ b/docs/i18n/pt/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ro/CHANGELOG.md
+++ b/docs/i18n/ro/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ru/CHANGELOG.md
+++ b/docs/i18n/ru/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/sk/CHANGELOG.md
+++ b/docs/i18n/sk/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/sv/CHANGELOG.md
+++ b/docs/i18n/sv/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/sw/CHANGELOG.md
+++ b/docs/i18n/sw/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ta/CHANGELOG.md
+++ b/docs/i18n/ta/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/te/CHANGELOG.md
+++ b/docs/i18n/te/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/th/CHANGELOG.md
+++ b/docs/i18n/th/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/tr/CHANGELOG.md
+++ b/docs/i18n/tr/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/uk-UA/CHANGELOG.md
+++ b/docs/i18n/uk-UA/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/ur/CHANGELOG.md
+++ b/docs/i18n/ur/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/vi/CHANGELOG.md
+++ b/docs/i18n/vi/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/zh-CN/CHANGELOG.md
+++ b/docs/i18n/zh-CN/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._

--- a/docs/i18n/zh-TW/CHANGELOG.md
+++ b/docs/i18n/zh-TW/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [3.8.31] — 2026-06-20
 
+## [3.8.50] — 2026-07-28
+
+_Living section — opened when the v3.8.50 development cycle started. Finalized at the v3.8.50 release._
+
+### 🐛 Bug Fixes
+
+- **executors**: fix internal timeout misclassified as client disconnect (499) for 7 niche executors — pass TimeoutError reason to controller.abort() (#8197 side-finding)
+
+---
+
+
 ## [3.8.49] — 2026-07-28
 
 _Living section — regenerated 2026-07-19 from all 306 cycle commits (bump 2c62333b0 → tip). Bullets carry the merged PR and its author; direct pushes listed separately. Finalized at the v3.8.49 release._


### PR DESCRIPTION
## Summary
- `release/v3.8.50`'s `package.json` was bumped to `3.8.50` when the cycle opened (2026-07-28, commit `ed2db6cb1`), but `CHANGELOG.md`'s `## [Unreleased]` header was never renamed to `## [3.8.50]` — matching the precedent already visible in `## [3.8.49]`'s own "Living section — opened when the cycle started" pattern.
- This mismatch fails `check:docs-sync`'s "latest changelog release matches package.json" gate unconditionally, currently blocking `Docs Gates (fast-path)` CI on every open PR targeting this base (observed directly on #9173, #9006, #8909).
- Minimal fix: renames the header, restores an empty `## [Unreleased]` above it, and mirrors the new section into all 42 `docs/i18n/*/CHANGELOG.md` locale files via the existing `sync-changelog-i18n.mjs` tool (no content invented — verified `check:docs-sync` and `check:docs-all`'s changelog checks pass, plus the 16 existing changelog unit tests).