### PR TITLE
fix(routing): fallback to default model alias seeds when unmapped in database

### DIFF
--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -26,7 +26,7 @@ import {
   readCompressionRequestHeader,
   withCompressionHeaderEcho,
 } from "@/shared/utils/compressionHeaderEcho";
-import { resolveModelAliasOnBody } from "@/lib/modelAliasResolver";
+import { resolveModelAliasWithSeedFallbackOnBody } from "@/lib/modelAliasResolver";
 
 let initPromise = null;
 
@@ -161,7 +161,7 @@ export async function POST(request) {
 
         // Resolve model alias before forwarding to handleChat
         if (parsedBody && typeof parsedBody === "object") {
-          await resolveModelAliasOnBody(parsedBody).catch(() => {
+          await resolveModelAliasWithSeedFallbackOnBody(parsedBody).catch(() => {
             /* swallow — fall through with original model */
           });
         }

--- a/src/app/api/v1/models/catalogHelpers.ts
+++ b/src/app/api/v1/models/catalogHelpers.ts
@@ -16,6 +16,7 @@ export interface CustomModelEntry {
   apiFormat?: string;
   supportedEndpoints?: string[];
   inputTokenLimit?: number;
+  outputTokenLimit?: number;
   isHidden?: boolean;
   // User-set "vision-capable" flag (persisted by addCustomModel / replaceCustomModels
   // in src/lib/db/models.ts). Surfaced into `/v1/models` via

--- a/src/lib/modelAliasResolver.ts
+++ b/src/lib/modelAliasResolver.ts
@@ -9,6 +9,7 @@
  * `src/lib/modelAliasSeed.ts`.
  */
 import { getModelAliases } from "@/lib/db/models/aliases";
+import { DEFAULT_MODEL_ALIAS_SEED } from "@/lib/modelAliasSeed";
 
 let cachedAliases: Record<string, unknown> | null = null;
 let lastFetch = 0;
@@ -35,7 +36,7 @@ export async function resolveModelAlias(
   if (!model) return model;
 
   const aliases = await loadAliases();
-  const target = aliases[model];
+  const target = aliases[model] ?? (DEFAULT_MODEL_ALIAS_SEED as Record<string, unknown>)[model];
 
   if (target === undefined) return model;
 

--- a/src/lib/modelAliasResolver.ts
+++ b/src/lib/modelAliasResolver.ts
@@ -26,11 +26,16 @@ async function loadAliases(): Promise<Record<string, unknown>> {
 }
 
 /**
- * Resolve a model alias to its target provider model ID.
+ * Resolve a model alias to its target provider model ID, falling back to the
+ * static DEFAULT_MODEL_ALIAS_SEED when the alias is not in the database.
  * If the alias maps to an array, returns the first element.
  * If no alias is found, returns the original model name unchanged.
+ *
+ * Named distinctly from `resolveModelAlias` (modelDeprecation.ts /
+ * modelSpecs.ts, sync string→string) to avoid export collisions when both
+ * modules are imported together.
  */
-export async function resolveModelAlias(
+export async function resolveModelAliasWithSeedFallback(
   model: string | null | undefined
 ): Promise<string | null | undefined> {
   if (!model) return model;
@@ -59,11 +64,11 @@ export async function resolveModelAlias(
  * Resolve model alias on a parsed request body in-place.
  * Mutates `body.model` if an alias is found.
  */
-export async function resolveModelAliasOnBody(
+export async function resolveModelAliasWithSeedFallbackOnBody(
   body: Record<string, unknown> | null | undefined
 ): Promise<void> {
   if (!body || typeof body !== "object") return;
-  body.model = await resolveModelAlias(body.model as string | null | undefined);
+  body.model = await resolveModelAliasWithSeedFallback(body.model as string | null | undefined);
 }
 
 /**

--- a/src/lib/modelAliasSeed.ts
+++ b/src/lib/modelAliasSeed.ts
@@ -3,6 +3,9 @@ import { deleteModelAlias, getModelAliases, setModelAlias } from "@/lib/db/model
 export const DEFAULT_MODEL_ALIAS_SEED = Object.freeze({
   "gemini-3.1-pro": "agy/gemini-pro-agent",
   "gemini-3.1-flash-lite-preview": "gemini/gemini-3.1-flash-lite",
+  "claude-sonnet-4-6": "agy/claude-sonnet-4-6",
+  "claude-opus-4-6-thinking": "agy/claude-opus-4-6-thinking",
+  "gemini-3.6-flash-low": "agy/gemini-3.6-flash-low",
 });
 
 // Remove only aliases that still match a default value previously shipped by OmniRoute.

--- a/tests/unit/model-alias-seed-fallback.test.ts
+++ b/tests/unit/model-alias-seed-fallback.test.ts
@@ -1,0 +1,14 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveModelAlias } from "../../src/lib/modelAliasResolver";
+
+test("resolveModelAlias: falls back to DEFAULT_MODEL_ALIAS_SEED for unmapped models", async () => {
+  const opus = await resolveModelAlias("claude-opus-4-6-thinking");
+  assert.equal(opus, "agy/claude-opus-4-6-thinking");
+
+  const flash = await resolveModelAlias("gemini-3.6-flash-low");
+  assert.equal(flash, "agy/gemini-3.6-flash-low");
+
+  const unknown = await resolveModelAlias("unknown-custom-model-999");
+  assert.equal(unknown, "unknown-custom-model-999");
+});

--- a/tests/unit/model-alias-seed-fallback.test.ts
+++ b/tests/unit/model-alias-seed-fallback.test.ts
@@ -1,14 +1,66 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveModelAlias } from "../../src/lib/modelAliasResolver";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveModelAliasWithSeedFallback } from "../../src/lib/modelAliasResolver";
 
-test("resolveModelAlias: falls back to DEFAULT_MODEL_ALIAS_SEED for unmapped models", async () => {
-  const opus = await resolveModelAlias("claude-opus-4-6-thinking");
-  assert.equal(opus, "agy/claude-opus-4-6-thinking");
+// Hermetic test: isolate DATA_DIR so the alias lookup reads an EMPTY
+// modelAliases namespace (fresh install state) instead of the operator's live
+// DB. This is the exact scenario the 401 fix targets — aliases unmapped in
+// the DB must fall back to the static seed.
+async function withEmptyAliasDb(fn: () => Promise<void>) {
+  const prevDataDir = process.env.DATA_DIR;
+  const prevKey = process.env.STORAGE_ENCRYPTION_KEY;
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "alias-seed-fallback-"));
+  process.env.DATA_DIR = dataDir;
+  delete process.env.STORAGE_ENCRYPTION_KEY;
 
-  const flash = await resolveModelAlias("gemini-3.6-flash-low");
-  assert.equal(flash, "agy/gemini-3.6-flash-low");
+  try {
+    // Reset the module-level DB singleton so it binds to the temp dir.
+    const { resetDbInstance } = await import("../../src/lib/db/core");
+    resetDbInstance?.();
+    await fn();
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    const { resetDbInstance } = await import("../../src/lib/db/core");
+    resetDbInstance?.();
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
+    if (prevKey === undefined) delete process.env.STORAGE_ENCRYPTION_KEY;
+    else process.env.STORAGE_ENCRYPTION_KEY = prevKey;
+  }
+}
 
-  const unknown = await resolveModelAlias("unknown-custom-model-999");
-  assert.equal(unknown, "unknown-custom-model-999");
+test("resolveModelAliasWithSeedFallback: falls back to DEFAULT_MODEL_ALIAS_SEED for unmapped models", async () => {
+  await withEmptyAliasDb(async () => {
+    const opus = await resolveModelAliasWithSeedFallback("claude-opus-4-6-thinking");
+    assert.equal(opus, "agy/claude-opus-4-6-thinking");
+
+    const flash = await resolveModelAliasWithSeedFallback("gemini-3.6-flash-low");
+    assert.equal(flash, "agy/gemini-3.6-flash-low");
+
+    const unknown = await resolveModelAliasWithSeedFallback("unknown-custom-model-999");
+    assert.equal(unknown, "unknown-custom-model-999");
+  });
+});
+
+// Regression for the 401 the PR fixes: a client sends a model alias that is
+// NOT in the database alias table (empty modelAliases namespace = fresh
+// install / wiped aliases) but IS in the static seed. Before the fix the
+// alias resolved to itself → upstream rejects with 401 "no such model"; after
+// the fix it maps to the seed target (agy/...), which routes to a real model.
+test("resolveModelAliasWithSeedFallback: unmapped-but-seeded alias resolves (401 regression)", async () => {
+  await withEmptyAliasDb(async () => {
+    const resolved = await resolveModelAliasWithSeedFallback("claude-opus-4-6-thinking");
+    assert.equal(resolved, "agy/claude-opus-4-6-thinking");
+  });
+});
+
+// The exported name must not collide with the sync resolveModelAlias in
+// modelDeprecation.ts / modelSpecs.ts (maintainer review note on PR #10124).
+test("resolveModelAliasWithSeedFallback: export name is distinct from the sync resolveModelAlias", async () => {
+  const mod = await import("../../src/lib/modelAliasResolver");
+  assert.equal(typeof mod.resolveModelAliasWithSeedFallback, "function");
+  assert.equal(mod.resolveModelAlias, undefined, "must not export the colliding sync name");
 });


### PR DESCRIPTION
## Summary
Resolves an issue where bare OpenAI-compatible API model names (such as `claude-sonnet-4-6`, `claude-opus-4-6-thinking`, `gemini-3.6-flash-low`) failed with a `401: Missing API key` when unmapped in database aliases.

## Changes
1. Updated `resolveModelAlias()` in `src/lib/modelAliasResolver.ts` to fall back to `DEFAULT_MODEL_ALIAS_SEED` when unmapped in DB cache.
2. Added default alias seeds for `claude-sonnet-4-6`, `claude-opus-4-6-thinking`, and `gemini-3.6-flash-low` in `src/lib/modelAliasSeed.ts`.
3. Fixed syntax and import errors on release/v3.8.50 base.
4. Added unit tests in `tests/unit/model-alias-seed-fallback.test.ts`.