### PR TITLE
fix(streaming): honor body stream intent for early heartbeats

### DIFF
--- a/changelog.d/fixes/10127-early-sse-heartbeat.md
+++ b/changelog.d/fixes/10127-early-sse-heartbeat.md
@@ -1,0 +1,1 @@
+- **fix(streaming):** start early SSE heartbeats when Responses or Messages requests opt into streaming through the request body (#10127)

--- a/src/app/api/v1/messages/route.ts
+++ b/src/app/api/v1/messages/route.ts
@@ -7,6 +7,7 @@ import {
   ANTHROPIC_PING_FRAME,
 } from "@omniroute/open-sse/utils/earlyStreamKeepalive";
 import { resolveKeepaliveThreshold } from "@omniroute/open-sse/utils/keepaliveThreshold";
+import { resolveStreamFlag } from "@omniroute/open-sse/utils/aiSdkCompat";
 
 let initialized = false;
 
@@ -54,22 +55,27 @@ async function postHandler(request: any, context: any, preParsedBody: any = null
   // /v1/responses (#2544). Anthropic clients ignore SSE comments for their watchdog, so
   // emit a real `event: ping` (ANTHROPIC_PING_FRAME). Non-streaming callers keep the
   // verbatim path.
-  const accept = String(request.headers?.get?.("accept") || "").toLowerCase();
-  if (accept.includes("text/event-stream")) {
-    let model;
+  let body = preParsedBody;
+  if (body == null) {
     try {
-      const body = preParsedBody ?? (await request.clone().json().catch(() => null));
-      model = body?.model;
+      body = await request
+        .clone()
+        .json()
+        .catch(() => null);
     } catch {
-      // body unavailable / non-JSON — fall back to the default keepalive threshold
+      // body unavailable / non-JSON — handleChat will return its normal validation error
     }
-    return await withEarlyStreamKeepalive(handleChat(request, null, preParsedBody), {
+  }
+  const accept = String(request.headers?.get?.("accept") || "");
+  const wantsStreaming = resolveStreamFlag(body?.stream, accept, "claude");
+  if (wantsStreaming) {
+    return await withEarlyStreamKeepalive(handleChat(request, null, body), {
       signal: request.signal,
-      thresholdMs: resolveKeepaliveThreshold(model),
+      thresholdMs: resolveKeepaliveThreshold(body?.model),
       keepaliveFrame: ANTHROPIC_PING_FRAME,
     });
   }
-  return await handleChat(request, null, preParsedBody);
+  return await handleChat(request, null, body);
 }
 
 export const POST = withInjectionGuard(postHandler);

--- a/src/app/api/v1/responses/route.ts
+++ b/src/app/api/v1/responses/route.ts
@@ -9,6 +9,7 @@ import { resolveResponsesApiModel } from "@/app/api/internal/codex-responses-ws/
 import { getModelInfo } from "@/sse/services/model";
 import { getComboByName } from "@/lib/db/combos";
 import { resolveKeepaliveThreshold } from "@omniroute/open-sse/utils/keepaliveThreshold";
+import { resolveStreamFlag } from "@omniroute/open-sse/utils/aiSdkCompat";
 
 // NOTE: We do NOT call initTranslators() here — the translator registry is
 // bootstrapped at module level inside open-sse/translator/index.ts when it
@@ -92,8 +93,9 @@ async function postHandler(request: any, context: any, preParsedBody: any = null
     request,
     preParsedBody
   );
-  const accept = String(request.headers?.get?.("accept") || "").toLowerCase();
-  if (accept.includes("text/event-stream")) {
+  const accept = String(request.headers?.get?.("accept") || "");
+  const wantsStreaming = resolveStreamFlag(resolvedBody?.stream, accept, "openai-responses");
+  if (wantsStreaming) {
     // Adaptive threshold: web-session and anonymous-fallback providers are slower
     // to produce the first byte, so use a longer keepalive threshold (15s vs 2s).
     // Reuse resolvedBody.model — no extra clone/parse needed (#4041).

--- a/tests/unit/early-sse-route-intent.test.ts
+++ b/tests/unit/early-sse-route-intent.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { resolveStreamFlag } from "../../open-sse/utils/aiSdkCompat.ts";
+
+const ROUTES = [
+  {
+    name: "responses",
+    sourceFormat: "openai-responses",
+    bodyExpression: "resolvedBody?.stream",
+    source: fs.readFileSync(path.join("src", "app", "api", "v1", "responses", "route.ts"), "utf8"),
+  },
+  {
+    name: "messages",
+    sourceFormat: "claude",
+    bodyExpression: "body?.stream",
+    source: fs.readFileSync(path.join("src", "app", "api", "v1", "messages", "route.ts"), "utf8"),
+  },
+] as const;
+
+for (const route of ROUTES) {
+  test(`${route.name} early-heartbeat gate uses the real stream resolver`, () => {
+    const escapedBodyExpression = route.bodyExpression.replace(/[?.]/g, "\\$&");
+    assert.match(
+      route.source,
+      new RegExp(
+        `resolveStreamFlag\\(\\s*${escapedBodyExpression},\\s*accept,\\s*"${route.sourceFormat}"\\s*\\)`
+      )
+    );
+    assert.match(route.source, /if \(wantsStreaming\) \{[\s\S]*withEarlyStreamKeepalive\(/);
+    assert.doesNotMatch(route.source, /accept\.includes\(["']text\/event-stream["']\)/);
+  });
+
+  test(`${route.name} stream intent covers body and Accept without overriding stream:false`, () => {
+    assert.equal(resolveStreamFlag(true, "application/json", route.sourceFormat), true);
+    assert.equal(resolveStreamFlag(false, "text/event-stream", route.sourceFormat), false);
+    assert.equal(resolveStreamFlag(undefined, "text/event-stream", route.sourceFormat), true);
+    assert.equal(resolveStreamFlag(undefined, "application/json", route.sourceFormat), false);
+  });
+}


### PR DESCRIPTION
## Summary

- start the existing early SSE keepalive wrapper for Responses and Messages requests that opt into streaming with body `stream: true`, even when `Accept` is JSON, wildcard, or absent
- use `resolveStreamFlag` with the real `openai-responses` / `claude` source formats so explicit `stream: false` still wins over an SSE `Accept` header
- reuse the already parsed request body and existing startup, ping, error, threshold, cancellation, and non-stream response paths

## Related Issues

- Related to first-byte timeouts for streaming Responses and Messages clients.

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/dev/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: backend / bug fix
- [x] Focused tests and category gates from the golden path
- [x] Changed-route and new-test ESLint passed with no diagnostics
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below — pending CI

Commands/results:

- `node --import tsx/esm --test --test-concurrency=1 tests/unit/early-sse-route-intent.test.ts tests/unit/t26-ai-sdk-accept-header-compat.test.ts tests/unit/early-stream-keepalive.test.ts tests/unit/keepalive-cleanup-8140.test.ts` — 38 passed
- `npx eslint --no-warn-ignored src/app/api/v1/responses/route.ts src/app/api/v1/messages/route.ts tests/unit/early-sse-route-intent.test.ts` — passed
- `npm run check:build-scope` — passed
- `npm run check:changelog-integrity` — this PR's `10127` fragment is valid; the gate still reports inherited invalid feature fragments `9239` and `9490`
- `git diff --check` — passed

The active release base has unrelated Conol registry import/syntax, migration-collision, and changelog-integrity failures. This PR does not modify those files.

## Tests Added Or Updated

- `tests/unit/early-sse-route-intent.test.ts`

## Coverage Notes

- pins both route gates to `resolveStreamFlag` with their real source format instead of an ad-hoc `Accept` substring check
- covers body `stream: true` with JSON Accept, body `stream: false` with SSE Accept, omitted stream with SSE Accept, and omitted stream with JSON Accept for Responses and Messages
- existing keepalive tests continue to verify immediate startup/ping frames, delayed keepalives, sanitized errors, cancellation, and interval cleanup

## Reviewer Notes

- Chat Completions already has a body-aware early-heartbeat gate and is intentionally unchanged
- `withEarlyStreamKeepalive` internals and wire frames are intentionally unchanged
- the injection guard normally supplies `preParsedBody`; Messages only clone-parses as a fallback for direct/internal invocation and threads the result to `handleChat`
- a heavier local chat-pipeline harness run was attempted but the shared local `node_modules` lacks declared dependency `turndown`; the focused dependency-free route contract and keepalive suites are green, and no dependency change is included
- no request body, prompt, credential, header value, or user content is newly logged
- independent review approved the candidate; the remaining validation item is first-byte smoke testing against the final integrated image
