### PR TITLE
fix(combo): isolate session stickiness by combo

### DIFF
--- a/changelog.d/fixes/10136-combo-scoped-session-stickiness.md
+++ b/changelog.d/fixes/10136-combo-scoped-session-stickiness.md
@@ -1,0 +1,1 @@
+- **fix(combo):** scope session-stickiness bindings to their owning Combo so identical first messages cannot carry a successful target into another priority chain and bypass its configured order (fixes #10136)

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2626,7 +2626,8 @@ async function handleRoundRobinCombo({
         filteredTargets,
         // #7270: normalize both wire shapes (.messages / Responses-API .input) so RR
         // stickiness engages on the /v1/responses surface, not just Chat Completions.
-        normalizeStickinessMessages(body as { messages?: unknown; input?: unknown })
+        normalizeStickinessMessages(body as { messages?: unknown; input?: unknown }),
+        combo.name
       );
   const rrAffinity = applyPromptCacheAffinity(
     filteredTargets,

--- a/open-sse/services/combo/sessionStickiness.ts
+++ b/open-sse/services/combo/sessionStickiness.ts
@@ -8,7 +8,8 @@
  *
  * Design
  * ──────
- * • Hash key: SHA-256 of the FIRST user message → first 16 hex chars.
+ * • Hash key: SHA-256 of the FIRST user message, namespaced by Combo identity
+ *   at production call sites → first 16 hex chars.
  *   Using only the first message gives a stable key that does not change as
  *   the conversation grows, yet still identifies the conversation reliably.
  * • Headroom gate: before reusing the sticky connection we re-check that its
@@ -317,6 +318,23 @@ export function deriveMessageHash(
   return createHash("sha256").update(text).digest("hex").slice(0, 16);
 }
 
+/**
+ * Keep one conversation's prompt-cache affinity local to the Combo that learned
+ * it. Without this namespace, two different Combos receiving the same first
+ * user message share a binding and can silently reorder each other's targets.
+ * The unscoped form remains available for direct callers and backwards-compatible
+ * unit seams; production dispatchers always provide their Combo name.
+ */
+function scopeMessageHash(messageHash: string, namespace?: string): string {
+  if (!namespace) return messageHash;
+  return createHash("sha256")
+    .update(namespace)
+    .update("\0")
+    .update(messageHash)
+    .digest("hex")
+    .slice(0, 16);
+}
+
 /** Evict expired entries and enforce the hard cap. */
 function evict(): void {
   const now = Date.now();
@@ -424,19 +442,22 @@ export interface ApplyStickinessResult {
  *
  * @param orderedTargets  Targets already ordered by the combo strategy.
  * @param messages        Request body.messages.
+ * @param namespace       Combo identity that owns this sticky binding.
  * @returns               Result with (possibly reordered) targets.
  */
 export async function applySessionStickiness(
   orderedTargets: ResolvedComboTarget[],
-  messages: Array<{ role?: string; content?: unknown }> | null | undefined
+  messages: Array<{ role?: string; content?: unknown }> | null | undefined,
+  namespace?: string
 ): Promise<ApplyStickinessResult> {
   const noOp: ApplyStickinessResult = { targets: orderedTargets, messageHash: null, stuck: false };
 
   try {
     if (orderedTargets.length <= 1) return noOp;
 
-    const messageHash = deriveMessageHash(messages);
-    if (!messageHash) return noOp;
+    const rawMessageHash = deriveMessageHash(messages);
+    if (!rawMessageHash) return noOp;
+    const messageHash = scopeMessageHash(rawMessageHash, namespace);
 
     const existing = stickyMap.get(messageHash);
     if (!existing) return { targets: orderedTargets, messageHash, stuck: false };

--- a/open-sse/services/combo/targetResolution.ts
+++ b/open-sse/services/combo/targetResolution.ts
@@ -498,7 +498,8 @@ async function applyContinuityFilters(
         initialOrderedTargets,
         // #7270: normalize both wire shapes (.messages / Responses-API .input) so the
         // stickiness key is derivable on the /v1/responses surface, not just Chat Completions.
-        normalizeStickinessMessages(body as { messages?: unknown; input?: unknown })
+        normalizeStickinessMessages(body as { messages?: unknown; input?: unknown }),
+        combo.name
       );
   let orderedTargets = sticky.targets;
   if (!cacheStrategyAffinityApplied) {

--- a/tests/unit/combo-session-stickiness.test.ts
+++ b/tests/unit/combo-session-stickiness.test.ts
@@ -214,6 +214,36 @@ test("different message hashes can map to different connections", async () => {
   assert.equal(r2.targets[0].connectionId, "conn-Y");
 });
 
+test("identical first messages do not leak sticky targets across combos", async () => {
+  injectSat({ util5h: 0.0, util7d: 0.0 });
+  const messages = [{ role: "user", content: "Shared control prompt" }];
+  const targets = [
+    makeTarget("conn-primary"),
+    makeTarget("conn-intermediate"),
+    makeTarget("conn-last"),
+  ];
+
+  const firstCombo = await applySessionStickiness(targets, messages, "combo-with-last-success");
+  assert.ok(firstCombo.messageHash);
+  recordStickyBinding(firstCombo.messageHash, "conn-last");
+
+  const repeatedFirstCombo = await applySessionStickiness(
+    targets,
+    messages,
+    "combo-with-last-success"
+  );
+  assert.equal(repeatedFirstCombo.stuck, true);
+  assert.equal(repeatedFirstCombo.targets[0].connectionId, "conn-last");
+
+  const secondCombo = await applySessionStickiness(targets, messages, "fresh-priority-combo");
+  assert.equal(secondCombo.stuck, false);
+  assert.deepEqual(
+    secondCombo.targets.map((target) => target.connectionId),
+    ["conn-primary", "conn-intermediate", "conn-last"],
+    "a binding learned by another combo must not reorder this combo's configured priority"
+  );
+});
+
 test("saturation fetch error → fail-open (original order, no crash)", async () => {
   __setStickinessHeadroomFetcherForTests(async (_id: string) => {
     throw new Error("network failure");


### PR DESCRIPTION
## Summary

- keep session-stickiness bindings local to the Combo that learned them
- preserve same-Combo prompt-cache affinity while preventing identical first messages from reordering another priority chain
- apply the same namespace on standard and round-robin dispatch paths

## Related Issues

- Fixes #10136

## Validation

- [x] Change type: routing
- [x] Focused tests and category gates from the golden path
- [x] Targeted ESLint on all changed TypeScript files
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include an updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Focused validation:

- `node --import tsx/esm --test tests/unit/combo-session-stickiness.test.ts tests/unit/combo-disable-session-stickiness.test.ts` — 34 passed
- `npx eslint open-sse/services/combo.ts open-sse/services/combo/sessionStickiness.ts open-sse/services/combo/targetResolution.ts tests/unit/combo-session-stickiness.test.ts --no-cache --suppressions-location config/quality/eslint-suppressions.json` — passed
- `npm run check:complexity` — passed
- `git diff HEAD^ HEAD --check` — passed

## Tests Added Or Updated

- `tests/unit/combo-session-stickiness.test.ts`
  - proves bindings remain reusable within one Combo
  - proves the same first message cannot carry that binding into a different Combo

## Coverage Notes

The focused regression exercises the new namespace at the session-stickiness boundary and verifies both isolation and retained same-Combo reuse. The two production callers pass the existing Combo name into that boundary; no routing branch or failure-handling path was removed.

## Reviewer Notes

The active release head currently has unrelated baseline failures: core typecheck stops at malformed syntax in `src/shared/constants/providers/apikey/gateways.ts`; file-size reports six untouched files; changelog integrity reports two untouched feature fragments. The changed files pass targeted ESLint, focused tests, complexity, and diff checks.
