### PR TITLE
fix(discovery): parse reasoning tiers nested under metadata.reasoning.supported_efforts (neuralwatt shape)

### DIFF
--- a/changelog.d/fixes/discovery-metadata-effort-tiers.md
+++ b/changelog.d/fixes/discovery-metadata-effort-tiers.md
@@ -1,0 +1,1 @@
+- fix(discovery): parse upstream reasoning tiers nested under metadata.reasoning.supported_efforts (neuralwatt /v1/models shape) so synced openai-compatible models advertise effort aliases

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -145,6 +145,27 @@ export function detectSupportedThinkingEfforts(record: JsonRecord): string[] | u
     }
   }
 
+  // neuralwatt-style upstreams wrap the same tier data one level deeper under
+  // `metadata.reasoning.supported_efforts` (their /v1/models nests capabilities
+  // and reasoning under a `metadata` object). Same semantics and validation as
+  // the top-level #7694 shape; placed right after it so a top-level declaration
+  // still wins when both are present.
+  const metadataRecord = asRecord(record.metadata);
+  const metadataParsed = reasoningSupportedEffortsSchema.safeParse(metadataRecord.reasoning);
+  if (metadataParsed.success && metadataParsed.data) {
+    const rawEfforts = metadataParsed.data.supported_efforts;
+    if (Array.isArray(rawEfforts)) {
+      const efforts = Array.from(
+        new Set(
+          rawEfforts
+            .filter((effort): effort is string => typeof effort === "string" && effort.length > 0)
+            .map(normalizeSupportedEffort)
+        )
+      );
+      if (efforts.length > 0) return efforts;
+    }
+  }
+
   // #9160: fall back to `capabilities.effort_tiers` before the legacy fields.
   // OmniRoute's own catalog surfaces effort tiers inside `capabilities.effort_tiers`,
   // which the existing `parseEffortList` already handles (string arrays).

--- a/tests/unit/model-discovery-reasoning-levels.test.ts
+++ b/tests/unit/model-discovery-reasoning-levels.test.ts
@@ -127,3 +127,40 @@ test("client_version opt-in without an explicit version still defaults off (no g
   });
   assert.ok(!url.includes("client_version"));
 });
+
+test("metadata.reasoning.supported_efforts (neuralwatt shape) is parsed into supportedThinkingEfforts", () => {
+  const [model] = normalizeDiscoveredModels([
+    {
+      id: "neuralwatt/glm-5.2",
+      metadata: {
+        reasoning: { supported_efforts: ["max", "high", "none"] },
+        capabilities: { reasoning_effort: true },
+      },
+    },
+  ]);
+  // max canonicalizes to xhigh through the shared discovery normalization,
+  // matching every other tier-array source.
+  assert.deepEqual(model.supportedThinkingEfforts, ["xhigh", "high", "none"]);
+});
+
+test("metadata.reasoning.supported_efforts does not override a top-level declared tier list", () => {
+  const [model] = normalizeDiscoveredModels([
+    {
+      id: "both-shapes",
+      reasoning: { supported_efforts: ["medium"] },
+      metadata: { reasoning: { supported_efforts: ["max", "none"] } },
+    },
+  ]);
+  assert.deepEqual(model.supportedThinkingEfforts, ["medium"]);
+});
+
+test("malformed metadata.reasoning shape degrades to undefined, does not throw", () => {
+  const models = normalizeDiscoveredModels([
+    { id: "bad-metadata-1", metadata: { reasoning: { supported_efforts: "not-an-array" } } },
+    { id: "bad-metadata-2", metadata: { reasoning: 42 } },
+    { id: "bad-metadata-3", metadata: null },
+  ]);
+  for (const model of models) {
+    assert.equal("supportedThinkingEfforts" in model, false);
+  }
+});


### PR DESCRIPTION
## Summary

neuralwatt's `/v1/models` wraps capabilities and reasoning under a `metadata` object — `metadata.reasoning.supported_efforts` (e.g. `["max","high","none"]`) and `metadata.capabilities.reasoning_effort` — one level deeper than the shapes `detectSupportedThinkingEfforts` recognized (top-level `reasoning.supported_efforts`, `capabilities.effort_tiers`, `supported_reasoning_levels`, `thinking.levels`). Synced openai-compatible rows therefore carried no `supportedThinkingEfforts`, so the catalog/Combo Builder advertised no effort aliases for neuralwatt models.

- Recognize `metadata.reasoning.supported_efforts` with the same Zod schema and validation as the top-level #7694 shape (Hard Rule #7: a malformed entry degrades, never throws).
- Placed right after the top-level `reasoning.supported_efforts` in precedence, so a top-level declaration still wins when both are present.
- `max` normalizes to `xhigh` through the shared discovery vocabulary, matching every other tier-array source (neuralwatt accepts `xhigh` and aliases it to `max` upstream).

## Tests

- `model-discovery-reasoning-levels.test.ts` — 3 new: neuralwatt shape parsed; top-level declaration not overridden; malformed `metadata.reasoning` degrades without throwing. Suite 16/16 pass.

## Related

- **#10147** — catalog-side publish gap: `/v1/models` still shows no `-<tier>` variants for openai-compatible node providers because the synced loop drops all node models (providerSupportsModel connection resolution). This PR fixes the discovery-side capture; #10147 tracks the catalog-side fix.

## Base-red (pre-existing, not from this PR)

- `conol-web` registry import path error (#10102, open) and `gateways.ts` syntax error (#10093, fixed by #10102) block registry import; locally worked around for the test run.
- Docs-sync version drift (package.json 3.8.49 vs CHANGELOG 3.8.50).
- Migration version collision 143 (fresh-DB/DB-backed tests) — fixed by #10063.
