### PR TITLE
fix(auto-combo): scope concurrency to provider account

### DIFF
--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -1,0 +1,209 @@
+import { z } from "zod";
+import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
+import { callCloudWithMachineId } from "@/shared/utils/cloud";
+import { handleChat } from "@/sse/handlers/chat";
+import { generateRequestId } from "@/shared/utils/requestId";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
+import { createInjectionGuard } from "@/middleware/promptInjectionGuard";
+import { acceptHeaderForcesStream } from "@omniroute/open-sse/utils/aiSdkCompat.ts";
+import {
+  OPENAI_CHAT_ERROR_FRAME,
+  OPENAI_KEEPALIVE_FRAME,
+  OPENAI_STARTUP_FRAME,
+  withEarlyStreamKeepalive,
+} from "@omniroute/open-sse/utils/earlyStreamKeepalive";
+import { resolveKeepaliveThreshold } from "@omniroute/open-sse/utils/keepaliveThreshold";
+import {
+  admitChatRequest,
+  admitChatStructure,
+} from "@/shared/middleware/chatBodyAdmission";
+import {
+  readCompressionRequestHeader,
+  withCompressionHeaderEcho,
+} from "@/shared/utils/compressionHeaderEcho";
+import { resolveModelAliasOnBody } from "@/lib/modelAliasResolver";
+
+let initPromise = null;
+
+// Singleton injection guard instance
+const injectionGuard = createInjectionGuard();
+
+/**
+ * Initialize translators once (Promise-based singleton — no race condition)
+ */
+function ensureInitialized() {
+  if (!initPromise) {
+    initPromise = Promise.resolve(initTranslators()).then(() => {
+      console.log("[SSE] Translators initialized");
+    });
+  }
+  return initPromise;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Minimal request-shape validation (Rule #7 / T06 gate). This is the hottest path in the
+// proxy, and the body is already parsed exactly once above into `parsedBody` (see the
+// #4380/#7862 comment on the single `request.json()` call) — so this only runs `.safeParse()`
+// over that already-parsed object, it does NOT read the body again.
+//
+// Deliberately permissive: `src/sse/handlers/chat.ts` (deeper in `handleChat`) owns the real
+// validation of this payload — messages/model/temperature/top_p/max_tokens/n — and accepts
+// shapes this schema must not newly reject, e.g. a `model` that is entirely absent (resolved
+// later via `input`/antigravity) or `null`, and message `role`s such as `"developer"` (see
+// `open-sse/services/roleNormalizer.ts`) that a stricter enum would exclude. `.passthrough()`
+// keeps every other field (stream, tools, reasoning, provider-specific extras, ...) intact.
+// This schema only asserts what the route already assumes before handing `parsedBody` to
+// `handleChat`: a non-null object, `model` a nullable string when present, `messages` an
+// array when present — so `.safeParse()` failing here is always a shape the deep validation
+// would already have rejected with its own 400, never a new rejection.
+const chatCompletionsRouteShapeSchema = z
+  .object({
+    model: z.string().nullable().optional(),
+    messages: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+
+/**
+ * Handle CORS preflight
+ */
+export async function OPTIONS() {
+  return handleCorsOptions();
+}
+
+export async function POST(request) {
+  await ensureInitialized();
+
+  // Content-Type guard (#6414) — reject non-JSON POST bodies with 415 per RFC 7231.
+  // OpenAI/Anthropic reject `text/plain` or missing Content-Type at the edge; matching
+  // that behavior prevents a text/plain body from silently reaching provider lookup.
+  const contentType = request.headers.get("content-type") ?? "";
+  const requestContentLengthHeader = request.headers.get("content-length");
+  if (!contentType.toLowerCase().split(";")[0].trim().startsWith("application/json")) {
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: "Content-Type must be application/json",
+          type: "invalid_request_error",
+          code: "unsupported_media_type",
+        },
+      }),
+      { status: 415, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } }
+    );
+  }
+
+  // Ingest the body with a hard byte bound BEFORE JSON parsing. Missing or dishonest
+  // Content-Length values cannot bypass the actual-byte limit. Heavyweight admission
+  // is now handled by provider/account-scoped semaphores in the open-sse layer.
+  const admissionResult = await admitChatRequest(request);
+  if (admissionResult.admit === false) return admissionResult.response;
+  request = admissionResult.request;
+
+  try {
+    // One-line marker for diagnosing 413 / Server-Action interceptions.
+    // Logs only when Content-Length is present so debug noise stays low for
+    // typical chat payloads. Opt-in via OMNIROUTE_LOG_REQUEST_SHAPE=1.
+    if (process.env.OMNIROUTE_LOG_REQUEST_SHAPE === "1") {
+      const ct = contentType;
+      const cl = requestContentLengthHeader;
+      if (cl && Number(cl) > 256 * 1024) {
+        console.error(`[CHAT-ROUTE] large body content-type="${ct}" content-length=${cl}`);
+      }
+    }
+
+    // Prompt injection guard — inspect body before forwarding. Parse the body ONCE here
+    // and thread it to handleChat so the handler does not JSON-parse the (often 270-550 KB)
+    // coding-agent payload a second time — the double parse doubled the body's heap
+    // residency on the hot path and fed the OOM crash-loop (#4380). #7862 parse-once over
+    // the admission-rebuilt request: the bytes are already buffered in memory by
+    // admitChatRequest(), so json() parses them directly — no clone(), no second stream read.
+    let parsedBody = null;
+    try {
+      parsedBody = await request.json().catch(() => null);
+      if (parsedBody) {
+        // Route-level shape gate (T06) — validates the object already parsed above; it
+        // never reads the request body a second time. See chatCompletionsRouteShapeSchema
+        // for why this stays scoped to record-shaped bodies and deliberately permissive.
+        if (isRecord(parsedBody)) {
+          const shapeCheck = chatCompletionsRouteShapeSchema.safeParse(parsedBody);
+          if (!shapeCheck.success) {
+            const issue = shapeCheck.error.issues[0];
+            const field = issue?.path?.length ? issue.path.join(".") : "body";
+            return errorResponse(400, `${field}: ${issue?.message ?? "Invalid request"}`);
+          }
+        }
+
+        const structuralAdmission = await admitChatStructure(parsedBody);
+        if (structuralAdmission.admit === false) {
+          return structuralAdmission.response;
+        }
+
+        // Resolve model alias before forwarding to handleChat
+        if (parsedBody && typeof parsedBody === "object") {
+          await resolveModelAliasOnBody(parsedBody).catch(() => {
+            /* swallow — fall through with original model */
+          });
+        }
+
+        const { blocked, result } = injectionGuard(parsedBody);
+        if (blocked) {
+          return new Response(
+            JSON.stringify({
+              error: {
+                message: "Request blocked: potential prompt injection detected",
+                type: "injection_detected",
+                code: "SECURITY_001",
+                detections: result.detections.length,
+              },
+            }),
+            { status: 400, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } }
+          );
+        }
+      }
+    } catch (error) {
+      console.error("[SECURITY] Prompt injection guard failed:", error);
+    }
+
+    // Gate the early SSE keepalive wrapper: only wrap when the client explicitly
+    // asks for streaming (body `stream: true`) or the Accept header forces SSE.
+    // The parsed body is passed through UNTOUCHED — the actual stream/JSON framing
+    // stays decided by chatCore/resolveStreamFlag (legacy streaming default and the
+    // per-key `streamDefaultMode: "json"` opt-in are preserved).
+    const parsedBodyIsRecord = isRecord(parsedBody);
+    const acceptHeader = request.headers.get("accept") || "";
+    const acceptForcesStream =
+      parsedBodyIsRecord && acceptHeaderForcesStream(acceptHeader, parsedBody.stream);
+    const wantsStreaming = (parsedBodyIsRecord && parsedBody.stream === true) || acceptForcesStream;
+
+    // #6422 — capture the compression request header once so we can echo it back
+    // on the response when internal early-returns (idempotency cache, some combo
+    // paths) drop the meta the docs promise.
+    const compressionRequestHeader = readCompressionRequestHeader(request);
+
+    if (wantsStreaming) {
+      const reqId = generateRequestId();
+      const streamedResponse = await withEarlyStreamKeepalive(
+        handleChat(request, null, parsedBody, reqId),
+        {
+          signal: request.signal,
+          thresholdMs: resolveKeepaliveThreshold(parsedBody?.model),
+          keepaliveFrame: OPENAI_KEEPALIVE_FRAME,
+          startupFrame: OPENAI_STARTUP_FRAME,
+          errorFrame: OPENAI_CHAT_ERROR_FRAME,
+          extraHeaders: { "X-Correlation-Id": reqId },
+        }
+      );
+      return withCompressionHeaderEcho(streamedResponse, compressionRequestHeader);
+    }
+
+    return withCompressionHeaderEcho(
+      await handleChat(request, null, parsedBody),
+      compressionRequestHeader
+    );
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/shared/middleware/chatBodyAdmission.ts
+++ b/src/shared/middleware/chatBodyAdmission.ts
@@ -1,0 +1,278 @@
+/**
+ * Body ingestion for POST /v1/chat/completions.
+ *
+ * Large chat bodies amplify into multiple transient representations while they are parsed,
+ * translated, compressed, and dispatched. This module enforces hard byte limits against actual
+ * bytes read, not an untrusted Content-Length header.
+ *
+ * Heavyweight admission has moved to provider/account-scoped semaphores in the open-sse layer,
+ * so requests reach normal provider/account routing first. Session affinity keeps one session
+ * on its pinned account; independent sessions can select independent accounts.
+ */
+
+import { CORS_HEADERS } from "../utils/cors";
+import { createHash } from "crypto";
+
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export const CHAT_LARGE_BODY_BYTES = parsePositiveInt(
+  process.env.OMNIROUTE_CHAT_LARGE_BODY_BYTES,
+  256 * 1024
+);
+
+export const CHAT_HARD_MAX_BODY_BYTES = parsePositiveInt(
+  process.env.OMNIROUTE_CHAT_HARD_MAX_BODY_BYTES,
+  50 * 1024 * 1024
+);
+
+export const CHAT_HEAVY_MESSAGE_COUNT = parsePositiveInt(
+  process.env.OMNIROUTE_CHAT_HEAVY_MESSAGE_COUNT,
+  200
+);
+export const CHAT_HEAVY_TOOL_COUNT = parsePositiveInt(
+  process.env.OMNIROUTE_CHAT_HEAVY_TOOL_COUNT,
+  64
+);
+export const CHAT_HEAVY_ESTIMATED_TOKENS = parsePositiveInt(
+  process.env.OMNIROUTE_CHAT_HEAVY_ESTIMATED_TOKENS,
+  32_000
+);
+
+/**
+ * Optional per-deployment history cap. `0` (the default) disables it.
+ *
+ * A fixed message count is a *deployment policy*, not a universal property of a chat request:
+ * the same 900-message conversation is trivial on a 16 GB host and fatal in a 1 GB container.
+ * Enforcing one here rejected conversations before OmniRoute's own compression pipeline — the
+ * component that exists precisely to make them servable — ever ran, and returned a terminal 413
+ * that no client can retry its way out of. Message count is also not an input the caller fully
+ * controls: translation from other protocols expands a single turn into several `messages[]`
+ * entries, so the metric an operator caps is partly manufactured by OmniRoute itself.
+ */
+export const CHAT_HARD_MAX_MESSAGES = parsePositiveInt(
+  process.env.OMNIROUTE_CHAT_HARD_MAX_MESSAGES,
+  0
+);
+
+function rejectionResponse(status: 413 | 503, hardMaxBytes: number): Response {
+  const isPayload = status === 413;
+  const headers: Record<string, string> = {
+    ...CORS_HEADERS,
+    "Content-Type": "application/json",
+  };
+  if (!isPayload) headers["Retry-After"] = "2";
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: isPayload
+          ? `Request body too large for chat completions (max ${Math.floor(
+              hardMaxBytes / (1024 * 1024)
+            )} MB).`
+          : "Chat admission capacity is temporarily unavailable. Retry shortly.",
+        type: isPayload ? "payload_too_large" : "server_error",
+        code: isPayload ? "PAYLOAD_TOO_LARGE" : "chat_admission_busy",
+      },
+    }),
+    { status, headers }
+  );
+}
+
+function structuralRejectionResponse(status: 413 | 503, maxMessages: number): Response {
+  const historyLimit = status === 413;
+  const headers: Record<string, string> = {
+    ...CORS_HEADERS,
+    "Content-Type": "application/json",
+  };
+  if (!historyLimit) headers["Retry-After"] = "1";
+
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: historyLimit
+          ? `Chat history exceeds the ${maxMessages}-message limit; compact the conversation and retry.`
+          : "Structurally heavy chat request capacity is busy; retry shortly.",
+        type: historyLimit ? "payload_too_large" : "server_error",
+        code: historyLimit ? "chat_history_too_large" : "chat_admission_busy",
+        reason: historyLimit ? "message_limit" : "structure_limit",
+      },
+    }),
+    { status, headers }
+  );
+}
+
+type TokenEstimate = { tokens: number; exhausted: boolean };
+
+function conservativeStringTokens(value: string, remaining: number): number {
+  let tokens = 0;
+  for (const character of value) {
+    tokens += character.codePointAt(0)! < 0x80 ? 0.25 : 1;
+    if (tokens >= remaining) return remaining;
+  }
+  return tokens;
+}
+
+function estimateStructureTokens(value: unknown, limit: number): TokenEstimate {
+  let tokens = 0;
+  let visited = 0;
+  const maxNodes = 10_000;
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  while (stack.length > 0 && tokens < limit && visited < maxNodes) {
+    const current = stack.pop();
+    if (!current) break;
+    visited += 1;
+    if (typeof current.value === "string") {
+      tokens += conservativeStringTokens(current.value, limit - tokens);
+      continue;
+    }
+    if (!current.value || typeof current.value !== "object") continue;
+    if (current.depth >= 12) return { tokens, exhausted: true };
+
+    const remainingNodes = maxNodes - visited - stack.length;
+    if (Array.isArray(current.value)) {
+      if (current.value.length > remainingNodes) return { tokens, exhausted: true };
+      for (const child of current.value) stack.push({ value: child, depth: current.depth + 1 });
+      continue;
+    }
+
+    let children = 0;
+    for (const key in current.value) {
+      if (!Object.hasOwn(current.value, key)) continue;
+      children += 1;
+      if (children > remainingNodes) return { tokens, exhausted: true };
+      tokens += conservativeStringTokens(key, limit - tokens);
+      if (tokens >= limit) return { tokens: limit, exhausted: false };
+      stack.push({
+        value: (current.value as Record<string, unknown>)[key],
+        depth: current.depth + 1,
+      });
+    }
+  }
+  return { tokens, exhausted: stack.length > 0 && tokens < limit };
+}
+
+export type ChatStructureAdmission =
+  { admit: true } | { admit: false; response: Response };
+
+export async function admitChatStructure(
+  body: unknown,
+  options: {
+    maxMessages?: number;
+    heavyMessages?: number;
+    heavyTools?: number;
+    heavyTokens?: number;
+  } = {}
+): Promise<ChatStructureAdmission> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return { admit: true };
+
+  const record = body as Record<string, unknown>;
+  const messages = Array.isArray(record.messages) ? record.messages : [];
+  const tools = Array.isArray(record.tools) ? record.tools : [];
+  const maxMessages = options.maxMessages ?? CHAT_HARD_MAX_MESSAGES;
+  // Opt-in only: `0`/unset means no history cap, so oversized conversations reach the
+  // compression pipeline instead of a terminal 413.
+  if (maxMessages > 0 && messages.length > maxMessages) {
+    return { admit: false, response: structuralRejectionResponse(413, maxMessages) };
+  }
+
+  const heavyMessages = options.heavyMessages ?? CHAT_HEAVY_MESSAGE_COUNT;
+  const heavyTools = options.heavyTools ?? CHAT_HEAVY_TOOL_COUNT;
+  const heavyTokens = options.heavyTokens ?? CHAT_HEAVY_ESTIMATED_TOKENS;
+  const countHeavy = messages.length >= heavyMessages || tools.length >= heavyTools;
+  if (!countHeavy) return { admit: true };
+
+  const messageEstimate = estimateStructureTokens(messages, heavyTokens);
+  const toolEstimate = messageEstimate.exhausted
+    ? { tokens: 0, exhausted: true }
+    : estimateStructureTokens(tools, heavyTokens - messageEstimate.tokens);
+  const estimatedTokens = Math.min(heavyTokens, messageEstimate.tokens + toolEstimate.tokens);
+  const heavy =
+    countHeavy ||
+    messageEstimate.exhausted ||
+    toolEstimate.exhausted ||
+    estimatedTokens >= heavyTokens;
+
+  // Heavy admission is now handled by provider/account-scoped semaphores in open-sse,
+  // not by a process-wide lease. Just return structural analysis.
+  return { admit: true };
+}
+
+function parseContentLength(header: string | null): number | null {
+  if (header === null || !/^(0|[1-9]\d*)$/.test(header.trim())) return null;
+  const parsed = Number(header);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function rebuildRequest(request: Request, body: Uint8Array): Request {
+  const headers = new Headers(request.headers);
+  // The inbound value may be absent or dishonest. Let the runtime derive the correct value.
+  headers.delete("content-length");
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body,
+    signal: request.signal,
+    duplex: "half",
+  } as RequestInit & { duplex: "half" });
+}
+
+export type ChatRequestAdmission =
+  | { admit: true; request: Request }
+  | { admit: false; response: Response };
+
+/**
+ * Ingest the request body with a hard byte bound before JSON parsing.
+ * Missing/invalid Content-Length is sniffed; enforcement is against actual bytes read.
+ *
+ * Heavyweight capacity management has moved to the open-sse layer's account-scoped
+ * semaphores, so this module only enforces hard byte limits.
+ */
+export async function admitChatRequest(
+  request: Request,
+  options: {
+    hardMaxBytes?: number;
+  } = {}
+): Promise<ChatRequestAdmission> {
+  const hardMaxBytes = options.hardMaxBytes ?? CHAT_HARD_MAX_BODY_BYTES;
+  const contentLength = parseContentLength(request.headers.get("content-length"));
+
+  if (contentLength !== null && contentLength > hardMaxBytes) {
+    return { admit: false, response: rejectionResponse(413, hardMaxBytes) };
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) return { admit: true, request };
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > hardMaxBytes) {
+        await reader.cancel("chat request exceeds hard body limit").catch(() => undefined);
+        return { admit: false, response: rejectionResponse(413, hardMaxBytes) };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { admit: true, request: rebuildRequest(request, body) };
+}

--- a/tests/unit/account-semaphore-account-scope.test.ts
+++ b/tests/unit/account-semaphore-account-scope.test.ts
@@ -1,0 +1,26 @@
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { acquire, getStats, resetAll } from "../../open-sse/services/accountSemaphore.ts";
+
+afterEach(() => resetAll());
+
+test("account semaphore isolates providers and accounts but serializes one account", async () => {
+  const codexA = "codex:account-a";
+  const clineA = "clinepass:account-a";
+
+  const releaseCodex = await acquire(codexA, { maxConcurrency: 1 });
+  const releaseCline = await acquire(clineA, { maxConcurrency: 1 });
+  assert.equal(getStats()[codexA].running, 1);
+  assert.equal(getStats()[clineA].running, 1);
+
+  const waitingCodex = acquire(codexA, { maxConcurrency: 1 });
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(getStats()[codexA].queued, 1);
+  assert.equal(getStats()[clineA].queued, 0);
+
+  releaseCodex();
+  const releaseWaitingCodex = await waitingCodex;
+  releaseWaitingCodex();
+  releaseCline();
+});


### PR DESCRIPTION
## Summary
Move heavyweight chat admission out of the pre-route global lease. The request reaches normal provider/account routing first, so existing session affinity keeps one session on its pinned account; independent sessions can select independent accounts.

The account semaphore key is `provider:account`, so each selected account remains serialized by its own configured cap.

## Minimal diff
- `src/shared/middleware/chatBodyAdmission.ts` — removes the process-wide pre-parse capacity lease.
- `src/app/api/v1/chat/completions/route.ts` — removes lease lifecycle handling.
- `tests/unit/account-semaphore-account-scope.test.ts` — proves separate accounts/providers do not contend while one account serializes.

## Validation
- account semaphore regression
- generic session-affinity regression
- Codex session-affinity vs forced target regression
- Result: 24 passed, 0 failed.
- ESLint passed for the three changed files.

No combo-config override, new parser, migration, dashboard/API surface, task card, or roadmap change is included.