### PR TITLE
fix(responses): preserve case-insensitive combo names before Codex rewrite

### DIFF
--- a/src/app/api/v1/responses/route.ts
+++ b/src/app/api/v1/responses/route.ts
@@ -6,8 +6,7 @@ import {
 } from "@omniroute/open-sse/utils/earlyStreamKeepalive";
 import { withInjectionGuard } from "@/middleware/promptInjectionGuard";
 import { resolveResponsesApiModel } from "@/app/api/internal/codex-responses-ws/modelResolution";
-import { getModelInfo } from "@/sse/services/model";
-import { getComboByName } from "@/lib/db/combos";
+import { getModelInfo, getComboForModel } from "@/sse/services/model";
 import { resolveKeepaliveThreshold } from "@omniroute/open-sse/utils/keepaliveThreshold";
 
 // NOTE: We do NOT call initTranslators() here — the translator registry is
@@ -57,7 +56,7 @@ export async function withCodexPreferredModel(
     const { model, changed } = await resolveResponsesApiModel(
       body.model,
       getModelInfo,
-      async (name) => !!(await getComboByName(name))
+      async (name) => !!(await getComboForModel(name))
     );
     if (!changed) return { request, body };
 

--- a/tests/unit/responses-case-insensitive-combo-guard.test.ts
+++ b/tests/unit/responses-case-insensitive-combo-guard.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { readFileSync } from "node:fs";
 
 import { resolveResponsesApiModel } from "../../src/app/api/internal/codex-responses-ws/modelResolution.ts";
@@ -21,13 +24,77 @@ test("case-insensitive combo match prevents Codex rewrite on /v1/responses", asy
   assert.equal(result.model, "gpt-5.6-sol");
 });
 
+test("bare codex model is still rewritten when not a combo (Codex preference preserved)", async () => {
+  const isCombo = async () => false;
+
+  const result = await resolveResponsesApiModel("gpt-5.5", resolver, isCombo);
+
+  assert.equal(result.changed, true);
+  assert.equal(result.model, "codex/gpt-5.5");
+});
+
+test("provider-prefixed models pass through unchanged", async () => {
+  const isCombo = async () => false;
+
+  for (const model of ["anthropic/claude-opus-4-8", "codex/gpt-5.5", "combo/my-combo"]) {
+    const result = await resolveResponsesApiModel(model, resolver, isCombo);
+    assert.equal(result.changed, false, `${model} must not be marked as changed`);
+    assert.equal(result.model, model, `${model} must pass through unchanged`);
+  }
+});
+
 test("Responses route uses the downstream combo resolver for the Codex rewrite guard", () => {
   const source = readFileSync(
     new URL("../../src/app/api/v1/responses/route.ts", import.meta.url),
     "utf8"
   );
 
-  assert.match(source, /import \{ getModelInfo, getComboForModel \} from "@\/sse\/services\/model"/);
+  assert.match(
+    source,
+    /import \{ getModelInfo, getComboForModel \} from "@\/sse\/services\/model"/
+  );
   assert.match(source, /async \(name\) => !!\(await getComboForModel\(name\)\)/);
   assert.doesNotMatch(source, /getComboByName\(name\)/);
+});
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-responses-ci-" + Date.now())
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const sseModelService = await import("../../src/sse/services/model.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("getComboForModel resolves a stored combo by a case-insensitive request name", async () => {
+  core.resetDbInstance();
+
+  await combosDb.createCombo({
+    name: "GPT-5.6-SOL",
+    models: [{ provider: "openrouter", model: "gpt-5.6" }],
+  });
+
+  const resolved = await sseModelService.getComboForModel("gpt-5.6-sol");
+  assert.ok(resolved, "expected lowercased request to resolve to the stored GPT-5.6-SOL combo");
+  assert.equal((resolved as { name: string }).name, "GPT-5.6-SOL");
+});
+
+test("real getComboForModel predicate prevents the Codex rewrite on /v1/responses", async () => {
+  core.resetDbInstance();
+
+  await combosDb.createCombo({
+    name: "Archon-Gate-9",
+    models: [{ provider: "openrouter", model: "gpt-5.6" }],
+  });
+
+  const isCombo = async (name: string) => !!(await sseModelService.getComboForModel(name));
+
+  const result = await resolveResponsesApiModel("archon-gate-9", resolver, isCombo);
+  assert.equal(result.changed, false);
+  assert.equal(result.model, "archon-gate-9");
 });

--- a/tests/unit/responses-case-insensitive-combo-guard.test.ts
+++ b/tests/unit/responses-case-insensitive-combo-guard.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { resolveResponsesApiModel } from "../../src/app/api/internal/codex-responses-ws/modelResolution.ts";
+
+const resolver = async (modelStr: string) => {
+  if (modelStr.startsWith("codex/")) {
+    return { provider: "codex", model: modelStr.slice("codex/".length) };
+  }
+  return { provider: "openrouter", model: modelStr };
+};
+
+test("case-insensitive combo match prevents Codex rewrite on /v1/responses", async () => {
+  const storedComboName = "GPT-5.6-SOL";
+  const isCombo = async (name: string) => name.toLowerCase() === storedComboName.toLowerCase();
+
+  const result = await resolveResponsesApiModel("gpt-5.6-sol", resolver, isCombo);
+
+  assert.equal(result.changed, false);
+  assert.equal(result.model, "gpt-5.6-sol");
+});
+
+test("Responses route uses the downstream combo resolver for the Codex rewrite guard", () => {
+  const source = readFileSync(
+    new URL("../../src/app/api/v1/responses/route.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(source, /import \{ getModelInfo, getComboForModel \} from "@\/sse\/services\/model"/);
+  assert.match(source, /async \(name\) => !!\(await getComboForModel\(name\)\)/);
+  assert.doesNotMatch(source, /getComboByName\(name\)/);
+});


### PR DESCRIPTION
## Summary

Fixes #10176. `/v1/responses` previously guarded the Codex-preference rewrite with a **case-sensitive** `getComboByName()` check, so a mixed-case stored combo (`GPT-5.6-SOL`) was missed when the client sent a lowercase model id (`gpt-5.6-sol`). The bare id was then rewritten to `codex/gpt-5.6-sol` and `changed=true`, shadowing the combo and causing fast upstream 404s with zero tokens.

This PR reuses the downstream combo resolver (`getComboForModel`) for the guard, so pre-rewrite semantics and downstream combo resolution stay aligned. Minimal diff, no behavior change on non-`/v1/responses` paths.

## Root cause

- `getComboByName()` → SQLite `WHERE name = ?` (case-sensitive).
- Downstream `getComboForModel()` → `getCombo()` chain: exact name → `combo/` prefix → combo ID → case-insensitive name (`getComboByNameInsensitive()`, `COLLATE NOCASE`) → model-to-combo mapping.
- Pre-rewrite guard and downstream resolver had divergent semantics; the case-insensitive fallback lived only downstream.

## Changes

`src/app/api/v1/responses/route.ts`
- Import `getComboForModel` from `@/sse/services/model` (drop the `getComboByName` import from `@/lib/db/combos`).
- Predicate: `async (name) => !!(await getComboByName(name))` → `async (name) => !!(await getComboForModel(name))`.

No changes to `modelResolution.ts`, `model.ts`, or `combos.ts` — this reuses the existing downstream path (including its guarded `try/catch`, `auto` handling, `combo/<name>` handling, combo-ID handling, and malformed-DB/migration fallback).

## Regression

Stored combo `GPT-5.6-SOL`, request model `gpt-5.6-sol` over `/v1/responses`:
- **Before:** rewritten to `codex/gpt-5.6-sol`, `changed=true` → combo shadowed, fast 404.
- **After:** `gpt-5.6-sol`, `changed=false` → downstream combo routing applies `GPT-5.6-SOL`.

Guard still rewrites genuine bare codex models: `gpt-5.5` (no combo) → `codex/gpt-5.5`, `changed=true`. Provider-prefixed ids (`anthropic/...`, `codex/...`, `combo/...`) pass through unchanged.

## Validation

- Added `tests/unit/responses-case-insensitive-combo-guard.test.ts`:
  - case-insensitive combo prevents the Codex rewrite (`GPT-5.6-SOL` stored, `gpt-5.6-sol` requested);
  - bare `gpt-5.5` still rewritten to `codex/gpt-5.5` when not a combo;
  - slash / provider-prefixed models (`anthropic/...`, `codex/...`, `combo/...`) unchanged;
  - source guard asserting the route uses `getComboForModel` (not `getComboByName`);
  - **SQLite-backed** tests: a real stored `GPT-5.6-SOL` combo resolved via `getComboForModel("gpt-5.6-sol")`, and the real predicate prevents the rewrite.
- Existing `tests/unit/combo-name-codex-responses-rewrite.test.ts` (`paid-premium`, `n8n-text`, bare rewrite, slash passthrough) still passes.
- `tests/unit/responses-combo-resolution-3227.test.ts` still passes.

Ran (locally):
- `node --import tsx/esm --test` on `tests/unit/combo-name-codex-responses-rewrite.test.ts`, `tests/unit/responses-case-insensitive-combo-guard.test.ts`, `tests/unit/responses-combo-resolution-3227.test.ts` → **15/15 pass**.
- `npm run typecheck:core` → clean.
- `eslint` on the two changed files → clean (0 errors).
- `prettier --check` on changed files → clean.

⚠️ base-red inherited: #9985 (`🔴 Release branch not green: release/v3.8.50`). The full-repo `eslint .` run surfaces 14 pre-existing errors in files untouched by this PR (`providerModelsConfig.ts`, `modelSelectModalHelpers.ts`, `combo/image-combo.test.ts`, `driverFactory.test.ts`); `typecheck:core` is clean. These are unrelated to this change and are left for the existing base-red tracking.

## Notes for reviewers

The SQLite-backed integration coverage (case E) was feasible in repo-standard unit-test fixtures and is included rather than deferred. No real API keys, tokens, or session ids anywhere in this PR.