### PR TITLE
fix(combo): preserve OpenCode Free oc/ prefix for configured connections

### DIFF
--- a/src/lib/combos/builderOptions.ts
+++ b/src/lib/combos/builderOptions.ts
@@ -556,6 +556,17 @@ function buildModelOptions(
   return modelMap;
 }
 
+function rewriteQualifiedModelPrefix(
+  modelMap: Map<string, ComboBuilderModelOption>,
+  providerId: string,
+  routingPrefix: string
+): void {
+  if (routingPrefix === providerId) return;
+  for (const option of modelMap.values()) {
+    option.qualifiedModel = `${routingPrefix}/${option.id}`;
+  }
+}
+
 /**
  * #6957: some providers' own catalogs assign the identical display `name` to
  * several distinct model ids (e.g. Mistral's "codestral-latest" alias renders
@@ -684,6 +695,12 @@ export async function getComboBuilderOptions(): Promise<ComboBuilderOptionsPaylo
       customModels
     );
 
+    // #2901 follow-up: a configured OpenCode connection shadows the no-auth
+    // entry below, so it must receive the same `oc/` routing prefix. The raw
+    // `opencode/` prefix is reserved by model parsing for the api-key tier.
+    const routingPrefix = providerId === "opencode" ? providerVisual.alias : providerId;
+    rewriteQualifiedModelPrefix(modelMap, providerId, routingPrefix);
+
     const normalizedConnections =
       expandConnectionOptions(providerConnections).sort(compareConnections);
 
@@ -749,11 +766,7 @@ export async function getComboBuilderOptions(): Promise<ComboBuilderOptionsPaylo
     // (manual ALIAS_TO_PROVIDER_ID override), while "oc/<model>" resolves to the
     // no-auth "opencode" provider. Rewrite qualifiedModel to the alias prefix.
     const routingPrefix = noAuthProvider.alias || providerId;
-    if (routingPrefix !== providerId) {
-      for (const opt of modelMap.values()) {
-        opt.qualifiedModel = `${routingPrefix}/${opt.id}`;
-      }
-    }
+    rewriteQualifiedModelPrefix(modelMap, providerId, routingPrefix);
 
     const displayName = (providerEntryName(providerId) ||
       getProviderDisplayName(providerId, null) ||

--- a/tests/unit/combo-builder-opencode-prefix.test.ts
+++ b/tests/unit/combo-builder-opencode-prefix.test.ts
@@ -22,6 +22,7 @@ const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-pre
 process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
 const { getComboBuilderOptions } = await import("../../src/lib/combos/builderOptions.ts");
 const { parseModel } = await import("../../open-sse/services/model.ts");
 
@@ -50,6 +51,29 @@ test("#2901 no-auth OpenCode combo models use the oc/ prefix (not opencode/)", a
       `qualifiedModel '${m.qualifiedModel}' must start with 'oc/' (got id-prefix instead)`
     );
   }
+});
+
+test("#2901 configured OpenCode connections also use the oc/ prefix", async () => {
+  await providersDb.createProviderConnection({
+    provider: "opencode",
+    authType: "apikey",
+    name: "OpenCode Free test connection",
+    apiKey: "test-key",
+  });
+
+  const payload = await getComboBuilderOptions();
+  const opencode = payload.providers.find(
+    (provider) => provider.providerId === "opencode" && provider.connectionCount > 0
+  );
+  assert.ok(opencode, "configured OpenCode provider must appear in the combo builder");
+
+  const bigPickle = opencode.models.find((model) => model.id === "big-pickle");
+  assert.ok(bigPickle, "big-pickle must be listed under the configured opencode provider");
+  assert.equal(
+    bigPickle.qualifiedModel,
+    "oc/big-pickle",
+    "configured opencode combo entries must use the 'oc/' routing alias"
+  );
 });
 
 test("#2901 the oc/ prefix actually resolves back to the no-auth opencode provider", () => {


### PR DESCRIPTION
## Summary

- Preserve the `oc/` routing alias for configured OpenCode Free connections in the Combo builder.
- Add a regression test covering configured OpenCode connections.

Fixes #10181. This is the configured-connection follow-up to #2901, which fixed the no-auth branch.

## Root cause

OpenCode Free uses provider id `opencode` and routing alias `oc`. The no-auth Combo path already emitted `oc/<model>`, but the configured-connection path built `qualifiedModel` from the provider id and emitted `opencode/<model>`. The `opencode/` prefix is parsed as a different OpenCode tier, so this can route to the wrong backend when OpenCode Free and OpenCode Go are both configured.

## Test plan

- `DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/unit/combo-builder-opencode-prefix.test.ts`
- Result: 3 passed, 0 failed.
