### PR TITLE
fix(sse): apply free-tier filter to auto/best-free on chat path

### DIFF
--- a/src/sse/handlers/autoRouting.ts
+++ b/src/sse/handlers/autoRouting.ts
@@ -32,7 +32,12 @@ function classifyAutoModel(
   const recognizedBuiltInAuto =
     model === "auto" || Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, model);
   if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, model)) {
-    return { variant: AUTO_TEMPLATE_VARIANTS[model], recognizedBuiltInAuto: true };
+    // auto/best-free must carry spec.tier="free" so virtualFactory applies the
+    // free-tier candidate filter (excludes paid backends). Mirrors the
+    // hardcoded spec in builtinCatalog.ts:createBuiltinAutoCombo. Without this,
+    // chat.ts routes auto/best-free as plain auto/cheap (no tier filter).
+    const spec = model === "auto/best-free" ? { tier: "free" as const } : undefined;
+    return { variant: AUTO_TEMPLATE_VARIANTS[model], spec, recognizedBuiltInAuto: true };
   }
   if (!model.startsWith("auto/")) return { recognizedBuiltInAuto };
 

--- a/tests/unit/auto-best-free-tier-filter.test.ts
+++ b/tests/unit/auto-best-free-tier-filter.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression: `auto/best-free` must carry `spec.tier = "free"` so the
+ * virtualFactory candidate filter (buildAutoCandidateFilter) excludes paid
+ * backends from the pool.
+ *
+ * Root cause: `classifyAutoModel` in `src/sse/handlers/autoRouting.ts` returns
+ * only `{ variant: "cheap" }` for `auto/best-free` (via AUTO_TEMPLATE_VARIANTS),
+ * WITHOUT setting `spec.tier = "free"`. The sibling path `createBuiltinAutoCombo`
+ * in `open-sse/services/autoCombo/builtinCatalog.ts` has a hardcoded special case
+ * `modelStr === "auto/best-free" ? { tier: "free" as const } : undefined`, but
+ * `chat.ts` routes through `resolveAutoRoutingState` → `createVirtualAutoCombo`
+ * (autoRouting.ts), NOT through `createBuiltinAutoCombo`. So the chat path
+ * skipped the tier filter entirely and `auto/best-free` behaved as plain
+ * `auto/cheap`, allowing paid models (e.g. antigravity/gemini-3.6-flash-high)
+ * to be selected from the full pool.
+ *
+ * classifyAutoModel() is module-private, so this exercises it through the public
+ * resolveAutoRoutingState() — same pattern as auto-family-classification-8866.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveAutoRoutingState } from "../../src/sse/handlers/autoRouting.ts";
+
+test("auto/best-free carries spec.tier='free' so the candidate filter excludes paid backends", async () => {
+  const state = await resolveAutoRoutingState("auto/best-free");
+  assert.equal(state.recognizedBuiltInAuto, true);
+  assert.equal(state.variant, "cheap");
+  assert.equal(
+    state.spec?.tier,
+    "free",
+    "auto/best-free must carry spec.tier='free' to trigger the free-tier candidate filter in virtualFactory"
+  );
+});
+
+test("auto/best-coding does NOT carry a free tier spec (only auto/best-free is free-tier)", async () => {
+  const state = await resolveAutoRoutingState("auto/best-coding");
+  assert.equal(state.recognizedBuiltInAuto, true);
+  assert.equal(state.variant, "coding");
+  assert.notEqual(state.spec?.tier, "free");
+});


### PR DESCRIPTION
## Problem

`auto/best-free` was routing to paid backends (e.g. `antigravity/gemini-3.6-flash-high`) instead of restricting to the free-tier candidate pool.

## Root cause

There are two code paths that materialize a virtual auto-combo:

| Path | Entry | Sets `spec.tier="free"` for `auto/best-free`? |
|---|---|---|
| `chatHelpers.ts` → `createBuiltinAutoCombo` | `builtinCatalog.ts:120` hardcodes `spec = { tier: "free" }` | Yes |
| `chat.ts` → `resolveAutoRoutingState` → `createVirtualAutoCombo` (actual chat path) | `autoRouting.ts:34-36` `classifyAutoModel` returns only `{ variant: "cheap" }`, **no spec** | **No** |

The chat handler (`chat.ts:654/675`) routes through `resolveAutoRoutingState` (autoRouting.ts), **not** through `createBuiltinAutoCombo` (chatHelpers.ts). So `auto/best-free` was materialized as plain `auto/cheap` with no tier filter — the full candidate pool (including paid backends) entered cheap-variant scoring, and paid models could be selected.

`classifyAutoModel` was missing the hardcoded special case that `builtinCatalog.ts:createBuiltinAutoCombo` already had for `auto/best-free`.

## Fix

Mirror the hardcoded `spec = { tier: "free" }` from `builtinCatalog.ts:120` into `classifyAutoModel` (`autoRouting.ts`), so both paths apply the free-tier candidate filter consistently.

```diff
   if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, model)) {
-    return { variant: AUTO_TEMPLATE_VARIANTS[model], recognizedBuiltInAuto: true };
+    const spec = model === "auto/best-free" ? { tier: "free" as const } : undefined;
+    return { variant: AUTO_TEMPLATE_VARIANTS[model], spec, recognizedBuiltInAuto: true };
   }
```

## Testing (TDD)

- `tests/unit/auto-best-free-tier-filter.test.ts` — RED: `auto/best-free` `spec.tier` was `undefined` before fix; GREEN: `"free"` after fix.
- All 19 related auto-routing tests pass (including `auto-family-classification-8866`, `verify-17-auto-combos`, `auto-combos-suffixes-4235`).
- No new typecheck/lint regressions.

## Files changed

- `src/sse/handlers/autoRouting.ts` (+6 -1)
- `tests/unit/auto-best-free-tier-filter.test.ts` (new, 40 lines)