### PR TITLE
fix(dashboard): retarget Kimi promo CTA to the API platform aff link

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ curl http://localhost:20128/v1/chat/completions \
 </div>
 
 <p align="center">
-  <a href="https://www.kimi.com/code?aff=omniroute">
+  <a href="https://platform.kimi.ai?aff=omniroute">
     <img src="public/sponsors/kimi-k3-banner.png" width="100%" alt="Kimi K3 — Open Frontier Intelligence · 2.8T parameters · 1M-token context"/>
   </a>
 </p>
@@ -228,7 +228,7 @@ curl http://localhost:20128/v1/chat/completions \
 <table>
   <tr>
     <td align="center" width="150">
-      <a href="https://www.kimi.com/code?aff=omniroute">
+      <a href="https://platform.kimi.ai?aff=omniroute">
         <picture>
           <source media="(prefers-color-scheme: dark)" srcset="public/providers/kimi-logomark-dark.svg">
           <img src="public/providers/kimi-logomark-light.svg" width="64" alt="Kimi (Moonshot AI)"/>

--- a/src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx
+++ b/src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx
@@ -7,14 +7,18 @@ import { APP_CONFIG } from "@/shared/constants/appConfig";
 import { shouldShowKimiSponsorBanner } from "./kimiSponsorBannerGate";
 
 // Official Kimi partnership tracking link — keep in sync with README.md's
-// Sponsors section and the aff links wired in the providers onboarding UI
-// (ProviderPageHeader.tsx).
-const KIMI_CODING_AFF_URL = "https://www.kimi.com/code?aff=omniroute";
+// Open Source Friends section and the aff links wired in the providers
+// onboarding UI (ProviderPageHeader.tsx). Retargeted 2026-08 from the coding
+// plan (kimi.com/code) to the API platform at Moonshot's request: coding plan
+// subscriptions are closed to most new users, so that traffic could not
+// convert.
+const KIMI_PLATFORM_AFF_URL = "https://platform.kimi.ai?aff=omniroute";
 
-// Versioned dismissal key — bump the suffix (e.g. `-v2`) if the banner's
+// Versioned dismissal key — bump the suffix (e.g. `-v3`) if the banner's
 // offer/copy ever changes materially enough to warrant re-showing it to
-// users who already dismissed the previous version.
-const DISMISS_STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v1";
+// users who already dismissed the previous version. `-v2` = the 2026-08 CTA
+// retarget to the API platform (new destination + new copy).
+const DISMISS_STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v2";
 // Same-tab signal for the dismiss button, since writing localStorage doesn't
 // fire a "storage" event in the tab that wrote it.
 const DISMISS_EVENT = "omniroute:kimi-sponsor-banner-dismissed";
@@ -69,7 +73,7 @@ export default function KimiSponsorBanner() {
   return (
     <div
       role="complementary"
-      aria-label={t("title")}
+      aria-label={t("foundingFriendTitle")}
       className="mb-4 flex flex-col gap-3 rounded-lg border border-[#1783FF]/30 bg-[#1783FF]/5 px-4 py-3 dark:bg-[#1783FF]/10 sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="flex min-w-0 items-start gap-3">
@@ -77,7 +81,7 @@ export default function KimiSponsorBanner() {
           <ProviderIcon providerId="moonshot" size={24} type="color" />
         </div>
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-text-main">{t("title")}</p>
+          <p className="text-sm font-semibold text-text-main">{t("foundingFriendTitle")}</p>
           <p className="mt-0.5 text-xs text-text-muted">{t("description")}</p>
         </div>
       </div>
@@ -85,7 +89,7 @@ export default function KimiSponsorBanner() {
       <div className="flex shrink-0 items-center gap-3 self-end sm:self-auto">
         <div className="flex flex-col items-end gap-0.5">
           <a
-            href={KIMI_CODING_AFF_URL}
+            href={KIMI_PLATFORM_AFF_URL}
             target="_blank"
             rel="noopener noreferrer"
             title={t("partnerLinkNote")}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "لا توجد تجاوزات — سيشارك جميع المزودين النشطين بنماذجهم الافتراضية"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) هو الصديق المؤسس للمصادر المفتوحة لـ OmniRoute",
-    "description": "يوفر Kimi K3 نافذة سياق بحجم 1M-token وأداء برمجة رائدًا لـ OmniRoute بجزء بسيط من التكلفة.",
-    "cta": "احصل على Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) هو صديق المصدر المفتوح المؤسس لـ OmniRoute",
+    "description": "استخدم Kimi K3 في OmniRoute عبر واجهة Kimi API الرسمية. استمتع بذكاء متقدم بتكلفة أقل.",
+    "cta": "احصل على مفتاح Kimi API",
     "partnerLinkNote": "رابط شريك",
     "dismissAriaLabel": "تجاهل"
   },

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Əvəzetmə yoxdur — bütün aktiv provayderlər standart modelləri ilə iştirak edəcək"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) OmniRoute-un təsisçi Açıq Mənbə Dostudur",
-    "description": "Kimi K3, OmniRoute-a 1M-token kontekst pəncərəsi və qabaqcıl kodlaşdırma performansı gətirir, həm də xərclərin kiçik bir hissəsinə.",
-    "cta": "Kimi Code əldə et",
+    "foundingFriendTitle": "Kimi (Moonshot AI) OmniRoute-un təsisçi Açıq Mənbə Dostudur",
+    "description": "Kimi K3-ü OmniRoute-da rəsmi Kimi API vasitəsilə istifadə edin. Daha az xərclə qabaqcıl intellektdən yararlanın.",
+    "cta": "Kimi API açarı əldə edin",
     "partnerLinkNote": "Tərəfdaş linki",
     "dismissAriaLabel": "Bağla"
   },

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Без предефинирания — всички активни доставчици ще участват с моделите си по подразбиране"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) е основаващият приятел на отворения код на OmniRoute",
-    "description": "Kimi K3 осигурява контекстен прозорец от 1M-token и водеща производителност при програмиране за OmniRoute на малка част от цената.",
-    "cta": "Вземете Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) е основополагащият приятел на отворения код на OmniRoute",
+    "description": "Използвайте Kimi K3 в OmniRoute чрез официалния Kimi API. Насладете се на върхов интелект на по-ниска цена.",
+    "cta": "Вземете Kimi API ключ",
     "partnerLinkNote": "Партньорска връзка",
     "dismissAriaLabel": "Затваряне"
   },

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "কোনো ওভাররাইড নেই — সমস্ত সক্রিয় প্রোভাইডার তাদের ডিফল্ট মডেল নিয়ে অংশগ্রহণ করবে"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) হল OmniRoute-এর প্রতিষ্ঠাতা ওপেন সোর্স বন্ধু",
-    "description": "Kimi K3 খরচের একটি সামান্য অংশেই OmniRoute-এ একটি 1M-token কনটেক্সট উইন্ডো এবং ফ্রন্টিয়ার কোডিং পারফরম্যান্স নিয়ে আসে।",
-    "cta": "Kimi Code পান",
+    "foundingFriendTitle": "Kimi (Moonshot AI) হল OmniRoute-এর প্রতিষ্ঠাতা ওপেন সোর্স বন্ধু",
+    "description": "অফিসিয়াল Kimi API-এর মাধ্যমে OmniRoute-এ Kimi K3 ব্যবহার করুন। কম খরচে অত্যাধুনিক বুদ্ধিমত্তা উপভোগ করুন।",
+    "cta": "Kimi API কী নিন",
     "partnerLinkNote": "পার্টনার লিঙ্ক",
     "dismissAriaLabel": "খারিজ করুন"
   },

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Žádná přepsání — všichni aktivní poskytovatelé se zapojí se svými výchozími modely"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) je zakládající open source přítel OmniRoute",
-    "description": "Kimi K3 přináší do OmniRoute kontextové okno s kapacitou 1M-token a špičkový výkon při kódování za zlomek ceny.",
-    "cta": "Získat Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) je zakládající open source přítel OmniRoute",
+    "description": "Používejte Kimi K3 v OmniRoute přes oficiální Kimi API. Užijte si špičkovou inteligenci za méně peněz.",
+    "cta": "Získat Kimi API klíč",
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavřít"
   },

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Ingen tilsidesættelser — alle aktive udbydere vil deltage med deres standardmodeller"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) er OmniRoutes grundlæggende open source-ven",
-    "description": "Kimi K3 bringer et 1M-token kontekstvindue og banebrydende kodningsydelse til OmniRoute til en brøkdel af prisen.",
-    "cta": "Hent Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) er OmniRoutes stiftende open source-ven",
+    "description": "Brug Kimi K3 i OmniRoute via det officielle Kimi API. Nyd banebrydende intelligens til en lavere pris.",
+    "cta": "Få en Kimi API-nøgle",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Afvis"
   },

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -12395,9 +12395,9 @@
     "noProviderOverrides": "Keine Überschreibungen — alle aktiven Anbieter nehmen mit ihren Standardmodellen teil"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) ist OmniRoutes Gründungs-Open-Source-Freund",
-    "description": "Kimi K3 bringt ein 1M-token-Kontextfenster und erstklassige Coding-Leistung zu einem Bruchteil der Kosten zu OmniRoute.",
-    "cta": "Kimi Code holen",
+    "foundingFriendTitle": "Kimi (Moonshot AI) ist OmniRoutes Open-Source-Gründungsfreund",
+    "description": "Nutze Kimi K3 in OmniRoute über die offizielle Kimi API. Genieße Spitzenintelligenz bei geringeren Kosten.",
+    "cta": "Kimi API-Schlüssel holen",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Schließen"
   },

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -13024,9 +13024,9 @@
     "testFailed": "Test failed"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) is now an official sponsor of OmniRoute",
-    "description": "Kimi K3 brings a 1M-token context window and frontier coding performance to OmniRoute at a fraction of the cost.",
-    "cta": "Get Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) is OmniRoute's founding Open Source Friend",
+    "description": "Use Kimi K3 in OmniRoute through the official Kimi API. Enjoy frontier intelligence while spending less.",
+    "cta": "Get a Kimi API Key",
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
   },

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Sin ajustes específicos: todos los proveedores activos participarán con sus modelos predeterminados"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) is now an official sponsor of OmniRoute",
-    "description": "Kimi K3 aporta una ventana de contexto de 1M de tokens y un rendimiento de código de vanguardia a OmniRoute por una fracción del coste.",
-    "cta": "Obtener Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) es el amigo fundador del código abierto de OmniRoute",
+    "description": "Usa Kimi K3 en OmniRoute a través de la API oficial de Kimi. Disfruta de inteligencia de frontera gastando menos.",
+    "cta": "Obtener una clave de API de Kimi",
     "partnerLinkNote": "Enlace de socio",
     "dismissAriaLabel": "Descartar"
   },

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "بدون جایگزینی — همه ارائه‌دهندگان فعال با مدل‌های پیش‌فرض خود مشارکت خواهند کرد"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) دوست بنیان‌گذار متن‌باز OmniRoute است",
-    "description": "مدل Kimi K3 پنجره زمینه 1M-token و عملکرد برنامه‌نویسی پیشرو را با کسری از هزینه به OmniRoute می‌آورد.",
-    "cta": "دریافت Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) دوست متن‌باز بنیان‌گذار OmniRoute است",
+    "description": "از Kimi K3 در OmniRoute از طریق API رسمی Kimi استفاده کنید. از هوش پیشرفته با هزینه کمتر لذت ببرید.",
+    "cta": "دریافت کلید Kimi API",
     "partnerLinkNote": "لینک همکاری",
     "dismissAriaLabel": "بستن"
   },

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Ei ohituksia — kaikki aktiiviset tarjoajat osallistuvat oletusmalleillaan"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) on OmniRouten perustajan avoimen lähdekoodin ystävä",
-    "description": "Kimi K3 tuo 1M-tokenin konteksti-ikkunan ja huippuluokan koodaussuorituskyvyn OmniRouteen murto-osalla kustannuksista.",
-    "cta": "Hanki Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) on OmniRouten perustava avoimen lähdekoodin ystävä",
+    "description": "Käytä Kimi K3:a OmniRoutessa virallisen Kimi API:n kautta. Nauti huippuälystä pienemmillä kustannuksilla.",
+    "cta": "Hanki Kimi API-avain",
     "partnerLinkNote": "Kumppanilinkki",
     "dismissAriaLabel": "Sulje"
   },

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -13019,9 +13019,9 @@
     "testFailed": "Échec du test"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) est l'ami open source fondateur d'OmniRoute",
-    "description": "Kimi K3 apporte une fenêtre de contexte de 1M de tokens et des performances de codage de pointe à OmniRoute pour une fraction du coût.",
-    "cta": "Obtenir Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) est l'ami open source fondateur d'OmniRoute",
+    "description": "Utilisez Kimi K3 dans OmniRoute via l'API officielle Kimi. Profitez d'une intelligence de pointe en dépensant moins.",
+    "cta": "Obtenir une clé API Kimi",
     "partnerLinkNote": "Lien partenaire",
     "dismissAriaLabel": "Ignorer"
   },

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "કોઈ ઓવરરાઇડ્સ નથી — બધા સક્રિય પ્રોવાઇડર્સ તેમના ડિફૉલ્ટ મોડેલ્સ સાથે ભાગ લેશે"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) એ OmniRoute નો સ્થાપક ઓપન સોર્સ મિત્ર છે",
-    "description": "Kimi K3 ખર્ચના એક નાના ભાગમાં OmniRoute માં 1M-token કોન્ટેક્સ્ટ વિન્ડો અને અદ્યતન કોડિંગ પર્ફોર્મન્સ લાવે છે.",
-    "cta": "Kimi Code મેળવો",
+    "foundingFriendTitle": "Kimi (Moonshot AI) એ OmniRoute નો સ્થાપક ઓપન સોર્સ મિત્ર છે",
+    "description": "સત્તાવાર Kimi API દ્વારા OmniRoute માં Kimi K3 વાપરો. ઓછા ખર્ચે અદ્યતન બુદ્ધિમત્તાનો આનંદ લો.",
+    "cta": "Kimi API કી મેળવો",
     "partnerLinkNote": "પાર્ટનર લિંક",
     "dismissAriaLabel": "બંધ કરો"
   },

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "אין דריסות — כל הספקים הפעילים ישתתפו עם מודלי ברירת המחדל שלהם"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) הוא חבר הקוד הפתוח המייסד של OmniRoute",
-    "description": "Kimi K3 מביא חלון הקשר של 1M-token וביצועי קידוד מובילים ל-OmniRoute בחלק קטן מהעלות.",
-    "cta": "קבל את Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) הוא חבר הקוד הפתוח המייסד של OmniRoute",
+    "description": "השתמשו ב-Kimi K3 ב-OmniRoute דרך ה-API הרשמי של Kimi. תיהנו מאינטליגנציה חדשנית בעלות נמוכה יותר.",
+    "cta": "קבלו מפתח Kimi API",
     "partnerLinkNote": "קישור שותף",
     "dismissAriaLabel": "התעלם"
   },

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "कोई ओवरराइड नहीं — सभी सक्रिय प्रदाता अपने डिफ़ॉल्ट मॉडल के साथ भाग लेंगे"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI), OmniRoute का संस्थापक ओपन सोर्स मित्र है",
-    "description": "Kimi K3 लागत के एक अंश पर OmniRoute में 1M-टोकन संदर्भ विंडो और अत्याधुनिक कोडिंग प्रदर्शन लाता है।",
-    "cta": "Kimi Code प्राप्त करें",
+    "foundingFriendTitle": "Kimi (Moonshot AI) OmniRoute का संस्थापक ओपन सोर्स मित्र है",
+    "description": "आधिकारिक Kimi API के ज़रिए OmniRoute में Kimi K3 इस्तेमाल करें। कम खर्च में अत्याधुनिक बुद्धिमत्ता का आनंद लें।",
+    "cta": "Kimi API कुंजी प्राप्त करें",
     "partnerLinkNote": "पार्टनर लिंक",
     "dismissAriaLabel": "खारिज करें"
   },

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Nincsenek felülbírálások — minden aktív szolgáltató az alapértelmezett modelljével vesz részt"
   },
   "kimiSponsorBanner": {
-    "title": "A Kimi (Moonshot AI) az OmniRoute alapító nyílt forráskódú barátja",
-    "description": "A Kimi K3 1M-tokenes kontextusablakot és élvonalbeli kódolási teljesítményt hoz az OmniRoute-ba, a költségek töredékéért.",
-    "cta": "Kimi Code beszerzése",
+    "foundingFriendTitle": "A Kimi (Moonshot AI) az OmniRoute alapító nyílt forráskódú barátja",
+    "description": "Használd a Kimi K3-at az OmniRoute-ban a hivatalos Kimi API-n keresztül. Élvezd az élvonalbeli intelligenciát kevesebb költséggel.",
+    "cta": "Kimi API-kulcs beszerzése",
     "partnerLinkNote": "Partnerhivatkozás",
     "dismissAriaLabel": "Elvetés"
   },

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Tidak ada override — semua penyedia aktif akan berpartisipasi dengan model default mereka"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) adalah sahabat open source pendiri OmniRoute",
-    "description": "Kimi K3 menghadirkan konteks window 1M-token dan performa coding mutakhir ke OmniRoute dengan biaya yang jauh lebih murah.",
-    "cta": "Dapatkan Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) adalah Sahabat Open Source pendiri OmniRoute",
+    "description": "Gunakan Kimi K3 di OmniRoute melalui Kimi API resmi. Nikmati kecerdasan terdepan dengan biaya lebih hemat.",
+    "cta": "Dapatkan Kunci API Kimi",
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"
   },

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Tidak ada penimpaan — semua penyedia aktif akan berpartisipasi dengan model default mereka"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) adalah sahabat open source pendiri OmniRoute",
-    "description": "Kimi K3 menghadirkan konteks window 1M-token dan performa coding mutakhir ke OmniRoute dengan biaya yang jauh lebih murah.",
-    "cta": "Dapatkan Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) adalah Sahabat Open Source pendiri OmniRoute",
+    "description": "Gunakan Kimi K3 di OmniRoute melalui Kimi API resmi. Nikmati kecerdasan terdepan dengan biaya lebih hemat.",
+    "cta": "Dapatkan Kunci API Kimi",
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"
   },

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Nessun override — tutti i provider attivi parteciperanno con i loro modelli predefiniti"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) è l'amico open source fondatore di OmniRoute",
-    "description": "Kimi K3 porta una finestra di contesto da 1M di token e prestazioni di codifica all'avanguardia su OmniRoute a una frazione del costo.",
-    "cta": "Ottieni Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) è l'amico open source fondatore di OmniRoute",
+    "description": "Usa Kimi K3 in OmniRoute tramite l'API ufficiale di Kimi. Goditi un'intelligenza di frontiera spendendo meno.",
+    "cta": "Ottieni una chiave API Kimi",
     "partnerLinkNote": "Link partner",
     "dismissAriaLabel": "Ignora"
   },

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "オーバーライドなし — すべてのアクティブなプロバイダーがデフォルトモデルで参加します"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi（Moonshot AI）は OmniRoute の創設オープンソースフレンドです",
-    "description": "Kimi K3 は、わずかなコストで 1M トークンのコンテキストウィンドウと最先端のコーディングパフォーマンスを OmniRoute に提供します。",
-    "cta": "Kimi Code を取得",
+    "foundingFriendTitle": "Kimi（Moonshot AI）はOmniRouteの創設オープンソースフレンドです",
+    "description": "公式Kimi APIを通じてOmniRouteでKimi K3を使えます。最先端の知能をより低コストで。",
+    "cta": "Kimi APIキーを取得",
     "partnerLinkNote": "パートナーリンク",
     "dismissAriaLabel": "閉じる"
   },

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "재정의 없음 — 모든 활성 프로바이더가 기본 모델로 참여합니다"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi(Moonshot AI)는 OmniRoute의 창립 오픈소스 프렌드입니다",
-    "description": "Kimi K3는 적은 비용으로 1M 토큰 컨텍스트 창과 최첨단 코딩 성능을 OmniRoute에 제공합니다.",
-    "cta": "Kimi Code 가져오기",
+    "foundingFriendTitle": "Kimi(Moonshot AI)는 OmniRoute의 창립 오픈소스 친구입니다",
+    "description": "공식 Kimi API를 통해 OmniRoute에서 Kimi K3를 사용하세요. 더 적은 비용으로 최첨단 지능을 누리세요.",
+    "cta": "Kimi API 키 받기",
     "partnerLinkNote": "파트너 링크",
     "dismissAriaLabel": "닫기"
   },

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "कोणतेही ओव्हरराइड नाहीत — सर्व सक्रिय प्रोव्हायडर्स त्यांच्या डीफॉल्ट मॉडेल्ससह सहभागी होतील"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) हा OmniRoute चा संस्थापक ओपन सोर्स मित्र आहे",
-    "description": "Kimi K3 अगदी कमी खर्चात OmniRoute साठी 1M-टोकन कॉन्टेक्स्ट विंडो आणि अग्रगण्य कोडिंग कार्यक्षमता आणते.",
-    "cta": "Kimi Code मिळवा",
+    "foundingFriendTitle": "Kimi (Moonshot AI) हा OmniRoute चा संस्थापक ओपन सोर्स मित्र आहे",
+    "description": "अधिकृत Kimi API द्वारे OmniRoute मध्ये Kimi K3 वापरा. कमी खर्चात अत्याधुनिक बुद्धिमत्तेचा आनंद घ्या.",
+    "cta": "Kimi API की मिळवा",
     "partnerLinkNote": "भागीदार लिंक",
     "dismissAriaLabel": "बंद करा"
   },

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Tiada penggantian — semua penyedia aktif akan mengambil bahagian dengan model lalai mereka"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) ialah rakan sumber terbuka pengasas OmniRoute",
-    "description": "Kimi K3 membawakan tetingkap konteks 1M-token dan prestasi pengekodan termaju ke OmniRoute pada sebahagian kecil daripada kos.",
-    "cta": "Dapatkan Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) ialah Rakan Sumber Terbuka pengasas OmniRoute",
+    "description": "Gunakan Kimi K3 dalam OmniRoute melalui Kimi API rasmi. Nikmati kecerdasan terkehadapan dengan perbelanjaan lebih rendah.",
+    "cta": "Dapatkan Kunci API Kimi",
     "partnerLinkNote": "Pautan rakan kongsi",
     "dismissAriaLabel": "Tutup"
   },

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Geen overschrijvingen — alle actieve providers nemen deel met hun standaardmodellen"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) is OmniRoute's oprichtende open source-vriend",
-    "description": "Kimi K3 brengt een contextvenster van 1M tokens en toonaangevende codeerprestaties naar OmniRoute tegen een fractie van de kosten.",
-    "cta": "Kimi Code ophalen",
+    "foundingFriendTitle": "Kimi (Moonshot AI) is OmniRoutes oprichtende open source-vriend",
+    "description": "Gebruik Kimi K3 in OmniRoute via de officiële Kimi API. Geniet van grensverleggende intelligentie voor minder geld.",
+    "cta": "Kimi API-sleutel ophalen",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Sluiten"
   },

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Ingen overstyringer — alle aktive leverandører vil delta med sine standardmodeller"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) er OmniRoutes grunnleggende åpen kildekode-venn",
-    "description": "Kimi K3 bringer et 1M-token kontekstvindu og banebrytende kodeytelse til OmniRoute til en brøkdel av kostnaden.",
-    "cta": "Hent Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) er OmniRoutes grunnleggende open source-venn",
+    "description": "Bruk Kimi K3 i OmniRoute via det offisielle Kimi API-et. Nyt banebrytende intelligens til en lavere kostnad.",
+    "cta": "Få en Kimi API-nøkkel",
     "partnerLinkNote": "Partnerlenke",
     "dismissAriaLabel": "Avvis"
   },

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Walang mga override — lahat ng aktibong provider ay lalahok gamit ang kanilang mga default na modelo"
   },
   "kimiSponsorBanner": {
-    "title": "Ang Kimi (Moonshot AI) ang tagapagtatag na open source na kaibigan ng OmniRoute",
-    "description": "Nagdadala ang Kimi K3 ng 1M-token context window at makabagong performance sa pag-code sa OmniRoute sa mas mababang halaga.",
-    "cta": "Kumuha ng Kimi Code",
+    "foundingFriendTitle": "Ang Kimi (Moonshot AI) ang founding Open Source Friend ng OmniRoute",
+    "description": "Gamitin ang Kimi K3 sa OmniRoute sa pamamagitan ng opisyal na Kimi API. Tamasahin ang frontier intelligence nang mas matipid.",
+    "cta": "Kumuha ng Kimi API Key",
     "partnerLinkNote": "Link ng kasosyo",
     "dismissAriaLabel": "I-dismiss"
   },

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Brak nadpisań — wszyscy aktywni dostawcy będą uczestniczyć ze swoimi domyślnymi modelami"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) jest przyjacielem-założycielem open source OmniRoute",
-    "description": "Kimi K3 zapewnia okno kontekstowe o rozmiarze 1M tokenów i najwyższą wydajność kodowania w OmniRoute za ułamek ceny.",
-    "cta": "Uzyskaj Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) to założycielski przyjaciel open source OmniRoute",
+    "description": "Używaj Kimi K3 w OmniRoute przez oficjalne Kimi API. Ciesz się najnowocześniejszą inteligencją, wydając mniej.",
+    "cta": "Zdobądź klucz Kimi API",
     "partnerLinkNote": "Link partnerski",
     "dismissAriaLabel": "Odrzuć"
   },

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -13008,9 +13008,9 @@
     "testFailed": "__MISSING__:Test failed"
   },
   "kimiSponsorBanner": {
-    "title": "A Kimi (Moonshot AI) agora é patrocinadora oficial do OmniRoute",
-    "description": "A Kimi K3 traz uma janela de contexto de 1M de tokens e desempenho de ponta em programação ao OmniRoute por uma fração do custo.",
-    "cta": "Obter Kimi Code",
+    "foundingFriendTitle": "A Kimi (Moonshot AI) é a Amiga do Código Aberto fundadora do OmniRoute",
+    "description": "Use o Kimi K3 no OmniRoute pela API oficial da Kimi. Aproveite inteligência de fronteira gastando menos.",
+    "cta": "Obter uma chave de API da Kimi",
     "partnerLinkNote": "Link de parceria",
     "dismissAriaLabel": "Dispensar"
   },

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Sem substituições — todos os fornecedores ativos participarão com os seus modelos predefinidos"
   },
   "kimiSponsorBanner": {
-    "title": "A Kimi (Moonshot AI) é a amiga fundadora de código aberto do OmniRoute",
-    "description": "O Kimi K3 traz uma janela de contexto de 1M de tokens e desempenho de codificação de ponta para o OmniRoute por uma fração do custo.",
-    "cta": "Obter Kimi Code",
+    "foundingFriendTitle": "A Kimi (Moonshot AI) é a Amiga do Código Aberto fundadora do OmniRoute",
+    "description": "Use o Kimi K3 no OmniRoute através da API oficial da Kimi. Desfrute de inteligência de fronteira gastando menos.",
+    "cta": "Obter uma chave de API da Kimi",
     "partnerLinkNote": "Link de parceiro",
     "dismissAriaLabel": "Dispensar"
   },

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Fără suprascrieri — toți furnizorii activi vor participa cu modelele lor implicite"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) este prietenul fondator open source al OmniRoute",
-    "description": "Kimi K3 aduce o fereastră de context de 1M de tokeni și performanță de vârf în codificare pentru OmniRoute la o fracțiune din cost.",
-    "cta": "Obține Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) este prietenul open source fondator al OmniRoute",
+    "description": "Folosește Kimi K3 în OmniRoute prin API-ul oficial Kimi. Bucură-te de inteligență de frontieră cheltuind mai puțin.",
+    "cta": "Obține o cheie API Kimi",
     "partnerLinkNote": "Link de partener",
     "dismissAriaLabel": "Închide"
   },

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Без переопределений — все активные провайдеры будут участвовать со своими моделями по умолчанию"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) — друг-основатель открытого кода OmniRoute",
-    "description": "Kimi K3 предлагает контекстное окно в 1M токенов и передовую производительность кодирования в OmniRoute за долю стоимости.",
-    "cta": "Получить Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) — друг-основатель открытого кода OmniRoute",
+    "description": "Используйте Kimi K3 в OmniRoute через официальный Kimi API. Наслаждайтесь передовым интеллектом, тратя меньше.",
+    "cta": "Получить ключ Kimi API",
     "partnerLinkNote": "Партнерская ссылка",
     "dismissAriaLabel": "Закрыть"
   },

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Žiadne prepísania — všetci aktívni poskytovatelia sa zapoja so svojimi predvolenými modelmi"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) je zakladajúci open source priateľ OmniRoute",
-    "description": "Kimi K3 prináša kontextové okno s veľkosťou 1M tokenov a špičkový výkon pri kódovaní do OmniRoute za zlomok ceny.",
-    "cta": "Získať Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) je zakladajúci open source priateľ OmniRoute",
+    "description": "Používajte Kimi K3 v OmniRoute cez oficiálne Kimi API. Užite si špičkovú inteligenciu za menej peňazí.",
+    "cta": "Získať Kimi API kľúč",
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavrieť"
   },

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Inga åsidosättningar — alla aktiva leverantörer kommer att delta med sina standardmodeller"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) är OmniRoutes grundande öppen källkod-vän",
-    "description": "Kimi K3 ger ett kontextfönster på 1M token och ledande kodningsprestanda till OmniRoute till en bråkdel av kostnaden.",
-    "cta": "Hämta Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) är OmniRoutes grundande open source-vän",
+    "description": "Använd Kimi K3 i OmniRoute via det officiella Kimi API:et. Njut av banbrytande intelligens till en lägre kostnad.",
+    "cta": "Skaffa en Kimi API-nyckel",
     "partnerLinkNote": "Partnerlänk",
     "dismissAriaLabel": "Avvisa"
   },

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Hakuna ubatilishaji — watoa huduma wote wanaotumika watashiriki na miundo yao chaguomsingi"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) ni rafiki mwanzilishi wa chanzo huria wa OmniRoute",
-    "description": "Kimi K3 inaleta dirisha la muktadha la tokeni 1M na utendaji wa kiwango cha juu wa uandishi wa nambari kwenye OmniRoute kwa gharama nafuu sana.",
-    "cta": "Pata Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) ni Rafiki Mwanzilishi wa Open Source wa OmniRoute",
+    "description": "Tumia Kimi K3 kwenye OmniRoute kupitia Kimi API rasmi. Furahia akili ya kisasa kwa gharama ndogo.",
+    "cta": "Pata Ufunguo wa Kimi API",
     "partnerLinkNote": "Kiungo cha mshirika",
     "dismissAriaLabel": "Ondoa"
   },

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "மேலெழுதல்கள் இல்லை — அனைத்து செயலில் உள்ள வழங்குநர்களும் தங்களின் இயல்புநிலை மாடல்களுடன் பங்கேற்பார்கள்"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) என்பது OmniRoute இன் நிறுவன திறந்த மூல நண்பர் ஆகும்",
-    "description": "Kimi K3 ஆனது 1M-டோக்கன் சூழல் சாளரத்தையும், மிகக் குறைந்த செலவில் OmniRoute க்கான அதிநவீன குறியீட்டு செயல்திறனையும் வழங்குகிறது.",
-    "cta": "Kimi Code-ஐப் பெறுங்கள்",
+    "foundingFriendTitle": "Kimi (Moonshot AI) என்பது OmniRoute-இன் நிறுவனர் ஓப்பன் சோர்ஸ் நண்பர்",
+    "description": "அதிகாரப்பூர்வ Kimi API வழியாக OmniRoute-இல் Kimi K3-ஐப் பயன்படுத்துங்கள். குறைந்த செலவில் முன்னணி நுண்ணறிவை அனுபவியுங்கள்.",
+    "cta": "Kimi API விசையைப் பெறுங்கள்",
     "partnerLinkNote": "பங்குதாரர் இணைப்பு",
     "dismissAriaLabel": "நிராகரி"
   },

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "ఓవర్‌రైడ్‌లు లేవు — యాక్టివ్‌గా ఉన్న అన్ని ప్రొవైడర్‌లు వాటి డిఫాల్ట్ మోడల్‌లతో పాల్గొంటాయి"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) అనేది OmniRoute యొక్క వ్యవస్థాపక ఓపెన్ సోర్స్ మిత్రుడు",
-    "description": "Kimi K3 చాలా తక్కువ ఖర్చుతో OmniRouteకు 1M-టోకెన్ కాంటెక్స్ట్ విండోను మరియు అత్యుత్తమ కోడింగ్ పనితీరును అందిస్తుంది.",
-    "cta": "Kimi Code పొందండి",
+    "foundingFriendTitle": "Kimi (Moonshot AI) అనేది OmniRoute యొక్క వ్యవస్థాపక ఓపెన్ సోర్స్ మిత్రుడు",
+    "description": "అధికారిక Kimi API ద్వారా OmniRouteలో Kimi K3ని ఉపయోగించండి. తక్కువ ఖర్చుతో అత్యాధునిక మేధస్సును ఆస్వాదించండి.",
+    "cta": "Kimi API కీ పొందండి",
     "partnerLinkNote": "భాగస్వామి లింక్",
     "dismissAriaLabel": "తీసివేయి"
   },

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "ไม่มีการเขียนทับ — ผู้ให้บริการที่เปิดใช้งานทั้งหมดจะเข้าร่วมด้วยโมเดลเริ่มต้นของตน"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) คือเพื่อนโอเพนซอร์สผู้ก่อตั้งของ OmniRoute",
-    "description": "Kimi K3 มอบหน้าต่างบริบทขนาด 1M โทเค็นและประสิทธิภาพการเขียนโค้ดระดับแนวหน้าให้กับ OmniRoute ในราคาเพียงเศษเสี้ยว",
-    "cta": "รับ Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) คือเพื่อนโอเพนซอร์สผู้ก่อตั้งของ OmniRoute",
+    "description": "ใช้ Kimi K3 ใน OmniRoute ผ่าน Kimi API อย่างเป็นทางการ เพลิดเพลินกับปัญญาระดับแนวหน้าในราคาที่ถูกลง",
+    "cta": "รับคีย์ Kimi API",
     "partnerLinkNote": "ลิงก์พันธมิตร",
     "dismissAriaLabel": "ปิด"
   },

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Geçersiz kılma yok — tüm etkin sağlayıcılar varsayılan modelleriyle katılacaktır"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI), OmniRoute'un kurucu açık kaynak dostu",
-    "description": "Kimi K3, maliyetin çok küçük bir kısmıyla OmniRoute'a 1M tokenlik bir bağlam penceresi ve öncü kodlama performansı getiriyor.",
-    "cta": "Kimi Code Edin",
+    "foundingFriendTitle": "Kimi (Moonshot AI), OmniRoute'un kurucu Açık Kaynak Dostudur",
+    "description": "Resmî Kimi API üzerinden OmniRoute'ta Kimi K3 kullanın. Daha az harcayarak öncü zekânın keyfini çıkarın.",
+    "cta": "Kimi API Anahtarı Alın",
     "partnerLinkNote": "Ortaklık bağlantısı",
     "dismissAriaLabel": "Kapat"
   },

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "Без перевизначень — усі активні провайдери братимуть участь зі своїми моделями за замовчуванням"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) — друг-засновник відкритого коду OmniRoute",
-    "description": "Kimi K3 забезпечує контекстне вікно розміром 1M токенів та передову продуктивність кодування для OmniRoute за незначну частку вартості.",
-    "cta": "Отримати Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) — друг-засновник відкритого коду OmniRoute",
+    "description": "Використовуйте Kimi K3 в OmniRoute через офіційний Kimi API. Насолоджуйтесь передовим інтелектом, витрачаючи менше.",
+    "cta": "Отримати ключ Kimi API",
     "partnerLinkNote": "Партнерське посилання",
     "dismissAriaLabel": "Закрити"
   },

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -12394,9 +12394,9 @@
     "noProviderOverrides": "کوئی اوور رائیڈز نہیں — تمام فعال فراہم کنندگان اپنے ڈیفالٹ ماڈلز کے ساتھ حصہ لیں گے"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) OmniRoute کا بانی اوپن سورس دوست ہے",
-    "description": "Kimi K3 لاگت کے ایک معمولی حصے میں OmniRoute کے لیے 1M-ٹوکن سیاق و سباق کی ونڈو اور جدید ترین کوڈنگ کارکردگی لاتا ہے۔",
-    "cta": "Kimi Code حاصل کریں",
+    "foundingFriendTitle": "Kimi (Moonshot AI) OmniRoute کا بانی اوپن سورس دوست ہے",
+    "description": "سرکاری Kimi API کے ذریعے OmniRoute میں Kimi K3 استعمال کریں۔ کم خرچ میں جدید ترین ذہانت سے لطف اٹھائیں۔",
+    "cta": "Kimi API کلید حاصل کریں",
     "partnerLinkNote": "پارٹنر لنک",
     "dismissAriaLabel": "خارج کریں"
   },

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -13018,9 +13018,9 @@
     "testFailed": "Kiểm thử thất bại"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi (Moonshot AI) là người bạn mã nguồn mở sáng lập của OmniRoute",
-    "description": "Kimi K3 brings a 1M-token context window and frontier coding performance to OmniRoute at a fraction of the cost.",
-    "cta": "Get Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) là người bạn mã nguồn mở sáng lập của OmniRoute",
+    "description": "Dùng Kimi K3 trong OmniRoute qua Kimi API chính thức. Tận hưởng trí tuệ tiên phong với chi phí thấp hơn.",
+    "cta": "Nhận khóa Kimi API",
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
   },

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -12473,9 +12473,9 @@
     "noProviderOverrides": "无覆盖 — 所有活跃提供者都将使用其默认模型参与"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi（Moonshot AI）是 OmniRoute 的创始开源好友",
-    "description": "Kimi K3 为 OmniRoute 带来了 1M token 的上下文窗口和前沿的编码性能，而成本仅为极小一部分。",
-    "cta": "获取 Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) 是 OmniRoute 的创始开源好友",
+    "description": "通过官方 Kimi API 在 OmniRoute 中使用 Kimi K3。以更低的花费享受前沿智能。",
+    "cta": "获取 Kimi API 密钥",
     "partnerLinkNote": "合作伙伴链接",
     "dismissAriaLabel": "关闭"
   },

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -12395,9 +12395,9 @@
     "noProviderOverrides": "無覆寫——所有啟用的提供者將使用其預設模型參與"
   },
   "kimiSponsorBanner": {
-    "title": "Kimi（Moonshot AI）是 OmniRoute 的創始開源好友",
-    "description": "Kimi K3 提供 100 萬 Token 的上下文視窗與頂尖程式碼效能，但只需同類產品的一小部分成本。",
-    "cta": "取得 Kimi Code",
+    "foundingFriendTitle": "Kimi (Moonshot AI) 是 OmniRoute 的創始開源好友",
+    "description": "透過官方 Kimi API 在 OmniRoute 中使用 Kimi K3。以更低的花費享受前沿智慧。",
+    "cta": "取得 Kimi API 金鑰",
     "partnerLinkNote": "合作夥伴連結",
     "dismissAriaLabel": "關閉"
   },

--- a/tests/unit/ui/kimiSponsorBanner.test.tsx
+++ b/tests/unit/ui/kimiSponsorBanner.test.tsx
@@ -10,8 +10,9 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v1";
-const KIMI_CODING_AFF_URL = "https://www.kimi.com/code?aff=omniroute";
+const STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v2";
+const LEGACY_V1_STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v1";
+const KIMI_PLATFORM_AFF_URL = "https://platform.kimi.ai?aff=omniroute";
 
 vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
 vi.mock("@/shared/components/ProviderIcon", () => ({ default: () => null }));
@@ -21,9 +22,8 @@ async function renderBanner(version: string): Promise<HTMLDivElement> {
   vi.doMock("@/shared/constants/appConfig", () => ({
     APP_CONFIG: { name: "OmniRoute", description: "AI Gateway", version },
   }));
-  const { default: KimiSponsorBanner } = await import(
-    "../../../src/app/(dashboard)/dashboard/KimiSponsorBanner"
-  );
+  const { default: KimiSponsorBanner } =
+    await import("../../../src/app/(dashboard)/dashboard/KimiSponsorBanner");
 
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -48,13 +48,13 @@ describe("KimiSponsorBanner", () => {
     vi.doUnmock("@/shared/constants/appConfig");
   });
 
-  it("renders with the CTA pointing at the Kimi Coding aff link inside the version window", async () => {
+  it("renders with the CTA pointing at the Kimi API Platform aff link inside the version window", async () => {
     const container = await renderBanner("3.8.49");
-    expect(container.textContent).toContain("title");
+    expect(container.textContent).toContain("foundingFriendTitle");
     expect(container.textContent).toContain("cta");
     const link = container.querySelector("a[href]");
     expect(link).not.toBeNull();
-    expect(link?.getAttribute("href")).toBe(KIMI_CODING_AFF_URL);
+    expect(link?.getAttribute("href")).toBe(KIMI_PLATFORM_AFF_URL);
     expect(link?.getAttribute("target")).toBe("_blank");
     expect(link?.getAttribute("rel")).toContain("noopener");
   });
@@ -97,5 +97,14 @@ describe("KimiSponsorBanner", () => {
     localStorage.setItem(STORAGE_KEY, "true");
     const container = await renderBanner("3.8.49");
     expect(container.querySelector("[role='complementary']")).toBeNull();
+  });
+
+  it("re-shows the retargeted banner to users who dismissed the v1 (Get Kimi Code) version", async () => {
+    // 2026-08 CTA retarget (coding plan -> API platform) bumped the dismissal
+    // key to -v2 so the whole install base gets one fresh impression.
+    localStorage.setItem(LEGACY_V1_STORAGE_KEY, "true");
+    const container = await renderBanner("3.8.50");
+    expect(container.querySelector("[role='complementary']")).not.toBeNull();
+    localStorage.removeItem(LEGACY_V1_STORAGE_KEY);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,7 +40,6 @@ export default defineConfig({
       "tests/e2e/protocol-clients.test.ts",
       // ── Pre-existing failures tracked by #8618 ───────────────────────────────
       "open-sse/services/autoCombo/__tests__/providerDiversity.test.ts", // #8618 — pre-existing failure; remove this exclusion when fixed
-      "tests/unit/ui/kimiSponsorBanner.test.tsx", // #8618 — pre-existing failure; remove this exclusion when fixed
       "tests/unit/ui/compareView.test.tsx", // #8618 — pre-existing failure; remove this exclusion when fixed
       "tests/unit/ui/model-select-modal-keep-open.test.tsx", // #8618 — pre-existing failure; remove this exclusion when fixed
       "tests/unit/ui/model-select-field-6540.test.tsx", // #8618 — pre-existing failure; remove this exclusion when fixed


### PR DESCRIPTION
## Summary

Retargets the Kimi (Moonshot AI) promotional traffic from the coding plan (`kimi.com/code`) to the API platform (`platform.kimi.ai?aff=omniroute`), at Moonshot's request: coding plan subscriptions are currently closed to most new users, so that traffic could not convert. Partner-reported result of the current placements: ~12.8K unique visits in the two weeks after v3.8.49.

### Changes

- **Dashboard banner** (`KimiSponsorBanner.tsx`): CTA link now points at the API platform aff link. Dismissal key bumped to `-v2` (materially new copy + new destination), so users who dismissed the old banner see the retargeted one once.
- **Banner copy** (all 43 locales): CTA "Get Kimi Code" → "Get a Kimi API Key"; description replaced by the partner-approved copy ("Use Kimi K3 in OmniRoute through the official Kimi API. Enjoy frontier intelligence while spending less."). Title finally aligned in-app to the "founding Open Source Friend" framing agreed in July (it had landed in the README but never in the app). The title key was renamed `title` → `foundingFriendTitle` following the i18n value-drift gate's documented rename rule: 14 locales already carried the Friends wording from a previous translation run, so an in-place edit would read as stale there.
- **README**: the two promotional Kimi links (K3 banner art + logomark card in the Open Source Friends section) now point at the platform aff link. The Kimi Code provider pages inside the product intentionally keep `kimi.com/code` — they are a settings surface for existing coding plan subscribers, not a promotional one.
- **vitest.config.ts**: removed the stale `tests/unit/ui/kimiSponsorBanner.test.tsx` exclusion (#8618 is closed; the test is fixed and green in this PR).

### Tests

- `tests/unit/ui/kimiSponsorBanner.test.tsx` (vitest, now un-excluded): CTA asserts the platform aff URL, dismissal asserts the `-v2` key, and a new case proves a `-v1` dismissal no longer hides the retargeted banner. 7/7 green.
- `tests/unit/kimi-sponsor-banner-version-gate.test.ts` + `tests/unit/kimi-partner-aff-links.test.ts` + `tests/unit/i18n-ui-value-drift.test.ts`: 27/27 green (provider `website` fields untouched by design).
- Gates run locally: `check-ui-value-drift` PASS (base `origin/release/v3.8.50`), `check-ui-keys-coverage` PASS (42 locales ≥ 80%), `typecheck:core` clean.
- `i18n-vi-completeness` reds are inherited (25 `__MISSING__` placeholders already on the base tip, unrelated namespaces).

⚠️ base-red inherited: #9985

Refs the Kimi partnership placement work from #8028/#8039/#8117.
