### PR TITLE
docs(readme): cycle-evolution section — 291→338 providers + v3.8.51 teaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@
 
 <br/>
 
+## 📈 The Gateway Keeps Growing
+
+<div align="center">
+
+|                      | v3.8.49 | **v3.8.50** |                           |
+| -------------------- | :-----: | :---------: | ------------------------- |
+| 🌐 Providers         |   291   |   **338**   | **+47 in a single cycle** |
+| 🧠 Documented models |  500+   |  **1200+**  | catalog more than doubled |
+
+**Next stop `v3.8.51+`** — Modality Bridge (vision & video everywhere) · Radar free-model catalog · quota-aware scheduling · new providers queued (Tencent AI Studio & more) → [Roadmap](ROADMAP.md)
+
+</div>
+
+<br/>
+
 ## 🧩 Available
 
 [![npm version](https://img.shields.io/npm/v/omniroute?color=cb3837&logo=npm)](https://www.npmjs.com/package/omniroute)


### PR DESCRIPTION
Adds a compact evolution section right before **🧩 Available**: a v3.8.49 → v3.8.50 mini-table (291 → 338 providers, +47 in one cycle; documented models 500+ → 1200+) and a one-line teaser of the in-flight work for v3.8.51+ (Modality Bridge #9759/#9760, Radar, quota-aware scheduling #10126, Tencent AI Studio #10174), linking to the root ROADMAP.md.

Owner-approved layout (option B of three mockups). Docs-only.

⚠️ base-red inherited: #9985