### PR TITLE
docs(readme): expand v3.8.51 teaser — in-flight feature grid + queued-provider numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@
 | 🌐 Providers         |   291   |   **338**   | **+47 in a single cycle** |
 | 🧠 Documented models |  500+   |  **1200+**  | catalog more than doubled |
 
-**Next stop `v3.8.51+`** — Modality Bridge (vision & video everywhere) · Radar free-model catalog · quota-aware scheduling · new providers queued (Tencent AI Studio & more) → [Roadmap](ROADMAP.md)
+**🔭 Next stop `v3.8.51+` — already in flight:**
+
+| 🖼️ **Modality Bridge** — vision landed in v3.8.50; video next                                    | 📡 **Radar** — live free-model catalog overlay               |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| ⚖️ **Quota-aware scheduling** — route by remaining quota                                         | 📊 **Quota telemetry** — adaptive routing + status inventory |
+| 🤝 **338 providers → more queued** — 3 PRs open: Tencent AI Studio, ZCode & a free-gateway batch | 🗺️ [Roadmap](ROADMAP.md) → riding the rail to **v3.9.0 LTS** |
 
 </div>
 


### PR DESCRIPTION
Expands the one-line teaser in **📈 The Gateway Keeps Growing** into a compact 2-column grid of verified in-flight work: Modality Bridge (vision merged in #9759, video next), Radar, quota-aware scheduling (#10126/#10098), quota telemetry (#10148), and **3 open provider PRs** (Tencent AI Studio #10174, ZCode #10184, free-gateway batch #9210) pushing past 338 — plus the Roadmap link to the v3.9.0 LTS rail. Owner-approved layout (grid option with provider numbers).

⚠️ base-red inherited: #9985