### PR TITLE
docs(readme): add olud.ai directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 [![Stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social)](https://github.com/diegosouzapw/OmniRoute)
 <a href="https://trendshift.io/repositories/23589" target="_blank"><img src="https://trendshift.io/api/badge/repositories/23589" alt="diegosouzapw%2FOmniRoute | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 [![Star History Rank](https://api.star-history.com/badge?repo=diegosouzapw/OmniRoute&theme=dark)](https://www.star-history.com/diegosouzapw/omniroute)
+[![olud.ai](https://olud.ai/badge.php?tool=diegosouzapw-omniroute)](https://olud.ai/project/diegosouzapw-omniroute.html)
 
 ### 💬 Join the community
 


### PR DESCRIPTION
## Summary

olud.ai (independent AI hub tracking 10,000+ open-source projects) featured OmniRoute with its own daily-rebuilt page and offered a dynamic badge. This adds the badge next to the other ranking badges (Trendshift, Star History) in the README header.

Verified before adding: the project page https://olud.ai/project/diegosouzapw-omniroute.html is live with real repo data, and the badge endpoint serves a cached SVG (`image/svg+xml` via Cloudflare, 1h cache). The badge is dynamic (live star count + directory rank), so it never goes stale. GitHub proxies README images through camo, so no visitor data reaches the third party.

One-line README change, no production code.

⚠️ base-red inherited: #9985 (also: `check-docs-sync` prints an advisory FAIL for the CHANGELOG `[Unreleased]` section — pre-existing cycle state on the base tip, exit code is 0)