### PR TITLE
fix(dashboard): close isProviderModelHidden's function body

### DIFF
--- a/src/shared/components/modelSelectModalHelpers.ts
+++ b/src/shared/components/modelSelectModalHelpers.ts
@@ -139,6 +139,8 @@ export function isProviderModelHidden(
     return false;
   }
   return hiddenModelsByProvider.get(providerId)?.has(modelId) ?? false;
+}
+
 /** Matches the provider-page "Test All Models" concurrency (#chunks of 3). */
 export const PROVIDER_TEST_CHUNK_SIZE = 3;
 


### PR DESCRIPTION
## What Problem This Solves

`isProviderModelHidden` in `src/shared/components/modelSelectModalHelpers.ts` is missing its closing brace. Every declaration after it in the file (`PROVIDER_TEST_CHUNK_SIZE`, `ProviderConnectionLike`, `ProviderTestModelLike`, `ProviderTestTarget`, `resolveConnectionIdForProvider`, ...) gets parsed as part of that function's body instead -- a hard syntax error.

## Why This Change Was Made

Found while typechecking an unrelated branch against `tsconfig.typecheck-dashboard.json` -- the parse error here is where it first surfaces (`error TS1005: '}' expected` at EOF), but the missing brace is the real, exact defect. This is a one-line, fully self-contained fix; no other file references this function's internals in a way that depends on the broken parse.

## User Impact

Restores `tsconfig.typecheck-dashboard.json` past this file. (The lane still has other pre-existing, unrelated type errors elsewhere -- Electron API typings, resilience env typing, a couple of schema-call signature mismatches -- out of scope for this fix.)

## Evidence

Confirmed the missing brace on a clean `release/v3.8.50` checkout directly (not just my branch):

```
  return hiddenModelsByProvider.get(providerId)?.has(modelId) ?? false;
/** Matches the provider-page "Test All Models" concurrency (#chunks of 3). */
export const PROVIDER_TEST_CHUNK_SIZE = 3;
```

## Test plan

- [x] `npx tsc --pretty false -p tsconfig.typecheck-dashboard.json` no longer reports the parse error in this file (remaining errors are pre-existing and unrelated, in other files)