### PR TITLE
fix(deepseek-web): classify business auth rejection as 401

### DIFF
--- a/src/lib/providers/validation/webProvidersA.ts
+++ b/src/lib/providers/validation/webProvidersA.ts
@@ -116,6 +116,7 @@ export async function validateDeepSeekWebProvider({ apiKey }: any) {
       return {
         valid: false,
         error: "userToken is invalid or expired — get a fresh one from localStorage",
+        statusCode: resp.status,
       };
     }
     if (!resp.ok) {
@@ -123,6 +124,20 @@ export async function validateDeepSeekWebProvider({ apiKey }: any) {
     }
     const json = await resp.json();
     const bizData = json?.data?.biz_data || json?.biz_data;
+
+    // DeepSeek's web endpoint can report auth rejection as HTTP 200 with an
+    // application-level error envelope. Code 40003 is the observed
+    // "Authorization Failed" signal. Preserve the real HTTP behavior while
+    // returning an auth-classifiable status to OmniRoute's connection-test
+    // layer so it is not collapsed into a generic upstream_error.
+    if (Number(json?.code) === 40003) {
+      return {
+        valid: false,
+        error: "userToken is invalid or expired — get a fresh one from localStorage",
+        statusCode: 401,
+      };
+    }
+
     if (!bizData?.token) {
       return {
         valid: false,

--- a/tests/unit/deepseek-web-auth-semantics.test.ts
+++ b/tests/unit/deepseek-web-auth-semantics.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { validateDeepSeekWebProvider } = await import(
+  "../../src/lib/providers/validation/webProvidersA.ts"
+);
+const { classifyFailure } = await import(
+  "../../src/app/api/providers/[id]/test/route.ts"
+);
+
+const SYNTHETIC_INVALID_TOKEN = "omniroute-auth-keeper-invalid-session-deepseek";
+
+type DeepSeekValidationResult = Awaited<ReturnType<typeof validateDeepSeekWebProvider>>;
+
+function statusCodeOf(result: DeepSeekValidationResult): number | undefined {
+  if ("statusCode" in result && typeof result.statusCode === "number") {
+    return result.statusCode;
+  }
+  return undefined;
+}
+
+async function withFetchResponse(body: unknown, status: number, fn: () => Promise<void>) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("DeepSeek HTTP 200 code 40003 is surfaced as auth-classifiable 401", async () => {
+  await withFetchResponse(
+    {
+      code: 40003,
+      msg: "Authorization Failed",
+      data: { biz_data: null },
+    },
+    200,
+    async () => {
+      const result = await validateDeepSeekWebProvider({
+        apiKey: SYNTHETIC_INVALID_TOKEN,
+      });
+      const statusCode = statusCodeOf(result);
+
+      assert.equal(result.valid, false);
+      assert.equal(statusCode, 401);
+      assert.match(String(result.error ?? ""), /invalid or expired/i);
+      assert.doesNotMatch(String(result.error ?? ""), new RegExp(SYNTHETIC_INVALID_TOKEN));
+
+      const diagnosis = classifyFailure({
+        error: result.error,
+        statusCode,
+        provider: "deepseek-web",
+      });
+      assert.equal(diagnosis.type, "upstream_auth_error");
+      assert.equal(diagnosis.code, "401");
+    }
+  );
+});
+
+test("DeepSeek unknown HTTP 200 business failure is not synthesized into 401", async () => {
+  await withFetchResponse(
+    {
+      code: 49999,
+      msg: "Temporary provider condition",
+      data: { biz_data: null },
+    },
+    200,
+    async () => {
+      const result = await validateDeepSeekWebProvider({
+        apiKey: SYNTHETIC_INVALID_TOKEN,
+      });
+      const statusCode = statusCodeOf(result);
+
+      assert.equal(result.valid, false);
+      assert.equal(statusCode, undefined);
+
+      const diagnosis = classifyFailure({
+        error: result.error,
+        statusCode,
+        provider: "deepseek-web",
+      });
+      assert.equal(diagnosis.type, "upstream_error");
+      assert.equal(diagnosis.code, "upstream_error");
+    }
+  );
+});
+
+test("DeepSeek literal 401 and 403 preserve their HTTP auth status", async () => {
+  for (const status of [401, 403]) {
+    await withFetchResponse({}, status, async () => {
+      const result = await validateDeepSeekWebProvider({
+        apiKey: SYNTHETIC_INVALID_TOKEN,
+      });
+      const statusCode = statusCodeOf(result);
+
+      assert.equal(result.valid, false);
+      assert.equal(statusCode, status);
+
+      const diagnosis = classifyFailure({
+        error: result.error,
+        statusCode,
+        provider: "deepseek-web",
+      });
+      assert.equal(diagnosis.type, "upstream_auth_error");
+      assert.equal(diagnosis.code, String(status));
+    });
+  }
+});
+
+test("DeepSeek valid HTTP 200 response with derived token remains healthy", async () => {
+  await withFetchResponse(
+    {
+      code: 0,
+      msg: "",
+      data: { biz_data: { token: "synthetic-derived-access-token" } },
+    },
+    200,
+    async () => {
+      const result = await validateDeepSeekWebProvider({
+        apiKey: "synthetic-valid-user-token",
+      });
+      assert.deepEqual(result, { valid: true, error: null });
+    }
+  );
+});


### PR DESCRIPTION
## What changed

- Preserve literal DeepSeek `401` / `403` status codes from `validateDeepSeekWebProvider` so the connection-test classifier can distinguish authentication failures from generic upstream errors.
- Treat DeepSeek application-level business code `40003` (`Authorization Failed`) returned under HTTP 200 as an auth-classifiable `statusCode: 401`.
- Keep all other HTTP-200 / missing-token business failures generic; they are **not** synthesized into credential failures.
- Add focused regressions for HTTP 200 + 40003, unknown business codes, literal 401/403, and the healthy derived-token response.

## Root cause

DeepSeek can represent authentication rejection under HTTP 200. The validator previously rejected the missing-token response without returning a `statusCode`, so the connection-test classifier fell through to `upstream_error`. A controlled Auth Keeper integration test reproduced `diagnosis=upstream_error`, `code=upstream_error`, `statusCode=null` for a fixed synthetic invalid DeepSeek session and then safely auto-restored the good credential.

A direct synthetic request from the same host subsequently confirmed the provider semantics without using or printing any real credential:

```text
httpStatus=200
businessCode=40003
messageClass=AUTHORIZATION_FAILED
accessTokenPresent=false
rawBodyPrinted=false
credentialPrinted=false
credentialType=FIXED_SYNTHETIC_ONLY
```

DeepSeek integration issue `deepseek-ai/awesome-deepseek-integration#654` independently documents the same HTTP-200 `{ "code": 40003, "msg": "Authorization Failed" }` pattern.

## Safety

This is intentionally narrow:

- arbitrary nonzero business codes remain generic and are not synthesized into credential failures;
- tests and live characterization use fixed synthetic credentials only;
- no Auth Keeper recovery policy was broadened;
- no real credential or raw DeepSeek response body is included in logs or test output.

## Validation

- Final commit: `e2e8ca09d73e9892749ed36b07afb3d52464418b`.
- Direct parent/current upstream `release/v3.8.50`: `f1eb0b835722ca744692834c84661f1bc8d564a6`.
- Focused regression: **4 passed, 0 failed**.
- Scoped ESLint for the validator and regression file: **PASS, 0 findings**.
- Semgrep on the earlier equivalent functional diff: **PASS**.
- `npm ci`: **0 vulnerabilities** reported.
- Scope: **one production validator file + one focused regression file**.

The final checkout used `--depth 1`, so the final `git diff f1eb0b8..HEAD` display command could not resolve the parent object locally. This was a shallow-clone inspection limitation only; the final branch is independently verified on GitHub as one commit directly ahead of `f1eb0b8` with exactly the two intended files.