### PR TITLE
fix(translator): resolve the Claude thinking output cap with the routed provider

### DIFF
--- a/changelog.d/fixes/10139-thinking-output-cap-provider-scope.md
+++ b/changelog.d/fixes/10139-thinking-output-cap-provider-scope.md
@@ -1,0 +1,1 @@
+- **fix(translator):** resolve the Claude thinking output cap with the routed provider so a provider-scoped-only `max_output_tokens` override is no longer invisible to `fitThinkingToMaxTokens()`, which previously let the synthesized `max_tokens` (caller room + thinking budget) go out unbounded and 400 upstream ([#10139](https://github.com/diegosouzapw/OmniRoute/issues/10139))

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -240,7 +240,12 @@ export function openaiToClaudeRequest(model, body, stream, credentials = null) {
   // could exceed model caps (e.g. Opus 4.7's 128000 ceiling) and trigger
   // HTTP 400 from Anthropic.
   if (!isKimiCoding) {
-    const fitted = fitThinkingToMaxTokens(model, Number(result.max_tokens) || 0, result.thinking);
+    const fitted = fitThinkingToMaxTokens(
+      model,
+      Number(result.max_tokens) || 0,
+      result.thinking,
+      routedProvider
+    );
     result.max_tokens = fitted.maxTokens;
     if (fitted.thinking === undefined) {
       delete result.thinking;

--- a/open-sse/translator/request/openai-to-claude/thinkingBudget.ts
+++ b/open-sse/translator/request/openai-to-claude/thinkingBudget.ts
@@ -7,9 +7,9 @@ import { capMaxOutputTokens } from "../../../../src/lib/modelCapabilities.ts";
 const MIN_CLAUDE_THINKING_BUDGET = 1024;
 const MIN_RESPONSE_ROOM = 1024;
 
-function safeCapMaxOutputTokens(model: string): number | null {
+function safeCapMaxOutputTokens(model: string, provider?: string | null): number | null {
   try {
-    const cap = capMaxOutputTokens(model);
+    const cap = capMaxOutputTokens(provider ? { provider, model } : model);
     return typeof cap === "number" && cap > 0 ? cap : null;
   } catch {
     return null;
@@ -31,6 +31,12 @@ function safeCapMaxOutputTokens(model: string): number | null {
  *     responseRoom shrunk to MIN_RESPONSE_ROOM; if still below MIN, disable
  *     thinking entirely (cap too tight for any reasoning).
  *
+ * `provider` scopes the cap lookup to a provider-specific override (e.g. a
+ * dashboard-set `max_output_tokens` for `opencode-go/qwen3.7-plus`) when the
+ * model-only entry has no cap of its own. Without it, a model whose real
+ * ceiling is only known per-provider resolves to no cap at all and the
+ * synthesized `max_tokens` goes out unbounded (#10139).
+ *
  * Worked example (real-world Opus 4.7 case that previously 400'd):
  *   caller max_tokens = 32000, reasoning_effort=high → budget = 131072,
  *   model cap = 128000.
@@ -42,9 +48,10 @@ function safeCapMaxOutputTokens(model: string): number | null {
 export function fitThinkingToMaxTokens(
   model: string,
   callerMaxTokens: number,
-  thinking: Record<string, unknown> | undefined
+  thinking: Record<string, unknown> | undefined,
+  provider?: string | null
 ): { maxTokens: number; thinking: Record<string, unknown> | undefined } {
-  const modelCap = safeCapMaxOutputTokens(model);
+  const modelCap = safeCapMaxOutputTokens(model, provider);
   const requestedBudget = Number(thinking?.budget_tokens) || 0;
 
   // No budgeted thinking — just cap max_tokens to the model output ceiling.

--- a/tests/unit/repro-10139-claude-thinking-output-cap.test.ts
+++ b/tests/unit/repro-10139-claude-thinking-output-cap.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for issue #10139 (follow-up to #6637).
+ *
+ * Reporter observed: for a model whose real output ceiling is only known via a
+ * provider-scoped override (e.g. an operator-set `max_output_tokens` for
+ * `opencode-go/qwen3.7-plus`, written through the dashboard's
+ * `PUT /api/provider-models`), `fitThinkingToMaxTokens()` resolved the cap by
+ * model name alone. The provider-scoped override was invisible to that lookup,
+ * so the cap resolved to `null` and the synthesized `max_tokens` (caller's
+ * `max_tokens` + the `reasoning_effort` thinking budget) went out unbounded —
+ * `64000 + 131072 = 195072`, which the upstream provider rejected with a bare
+ * `400 {"model":"qwen3.7-plus"}`.
+ *
+ * Root cause (confirmed by reading `fitThinkingToMaxTokens` and its caller in
+ * `openai-to-claude.ts`): the caller already has `routedProvider` in scope
+ * (used two lines earlier for the Kimi-coding check) but never passed it
+ * through, so `safeCapMaxOutputTokens()` always resolved the model-only
+ * capability entry and missed any provider-scoped override.
+ *
+ * Fix: `fitThinkingToMaxTokens()` takes an optional `provider` argument and
+ * forwards it to `capMaxOutputTokens({ provider, model })`, which already
+ * supports provider-scoped resolution; the caller now passes `routedProvider`.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-repro-10139-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { setModelCapabilityOverride, removeModelCapabilityOverride } =
+  await import("../../src/lib/db/modelCapabilityOverrides.ts");
+const { fitThinkingToMaxTokens } =
+  await import("../../open-sse/translator/request/openai-to-claude/thinkingBudget.ts");
+
+const PROVIDER = "opencode-go";
+const MODEL = "qwen3.7-plus";
+const TARGET = `${PROVIDER}/${MODEL}`;
+const REAL_UPSTREAM_OUTPUT_CAP = 131072; // per reporter's boundary test (131072 -> 200, 131073 -> 400)
+const CALLER_MAX_TOKENS = 64000; // DEFAULT_MAX_TOKENS when the client sends none
+const THINKING_BUDGET = 131072; // effortBudgetMap.high
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#10139: a provider-scoped-only output cap is invisible without a provider argument", () => {
+  assert.ok(
+    setModelCapabilityOverride(TARGET, "max_output_tokens", REAL_UPSTREAM_OUTPUT_CAP),
+    "expected the max_output_tokens override to be written"
+  );
+  try {
+    // Reproduces the pre-fix call shape: no provider passed.
+    const result = fitThinkingToMaxTokens(MODEL, CALLER_MAX_TOKENS, {
+      type: "enabled",
+      budget_tokens: THINKING_BUDGET,
+    });
+    // This is the defect: with no provider, the override is invisible and the
+    // synthesized max_tokens goes out unbounded (64000 + 131072 = 195072).
+    assert.equal(
+      result.maxTokens,
+      CALLER_MAX_TOKENS + THINKING_BUDGET,
+      "documents the pre-fix behavior: uncapped when provider is omitted"
+    );
+  } finally {
+    removeModelCapabilityOverride(TARGET, "max_output_tokens");
+  }
+});
+
+test("#10139: passing the routed provider resolves the override and clamps max_tokens", () => {
+  assert.ok(
+    setModelCapabilityOverride(TARGET, "max_output_tokens", REAL_UPSTREAM_OUTPUT_CAP),
+    "expected the max_output_tokens override to be written"
+  );
+  try {
+    const result = fitThinkingToMaxTokens(
+      MODEL,
+      CALLER_MAX_TOKENS,
+      { type: "enabled", budget_tokens: THINKING_BUDGET },
+      PROVIDER
+    );
+    assert.ok(
+      result.maxTokens <= REAL_UPSTREAM_OUTPUT_CAP,
+      `expected max_tokens to stay <= ${REAL_UPSTREAM_OUTPUT_CAP}, got ${result.maxTokens} ` +
+        `(reproduces the reported 195072, upstream then 400s)`
+    );
+    assert.equal(result.maxTokens, REAL_UPSTREAM_OUTPUT_CAP);
+    assert.equal(result.thinking?.budget_tokens, REAL_UPSTREAM_OUTPUT_CAP - CALLER_MAX_TOKENS);
+  } finally {
+    removeModelCapabilityOverride(TARGET, "max_output_tokens");
+  }
+});
+
+test("#10139: no override present, provider argument is a no-op (unchanged behavior)", () => {
+  const withoutProvider = fitThinkingToMaxTokens(MODEL, CALLER_MAX_TOKENS, {
+    type: "enabled",
+    budget_tokens: THINKING_BUDGET,
+  });
+  const withProvider = fitThinkingToMaxTokens(
+    MODEL,
+    CALLER_MAX_TOKENS,
+    { type: "enabled", budget_tokens: THINKING_BUDGET },
+    PROVIDER
+  );
+  assert.deepEqual(withProvider, withoutProvider);
+});


### PR DESCRIPTION
## Problem

`fitThinkingToMaxTokens()` (`open-sse/translator/request/openai-to-claude/thinkingBudget.ts`) clamps the synthesized `max_tokens` to the model's output cap, but resolves that cap from a bare model id:

```ts
const modelCap = safeCapMaxOutputTokens(model);   // -> capMaxOutputTokens(model)
```

A cap that is only known **per provider** — an operator `max_output_tokens` override set via the dashboard, a synced catalog `limit_output`, or a registry entry scoped to one connection — is invisible to a bare-model lookup. `capMaxOutputTokens()` already accepts a `{ provider, model }` object and resolves provider-scoped data when given one (`resolveCapabilityInput()`), but this call site never passes it, so `modelCap` comes back `null` and the unbounded branch runs:

```ts
target = modelCap === null ? responseRoom + requestedBudget : Math.min(responseRoom + requestedBudget, modelCap);
```

Concretely: a client that sends no max-token field at all gets `DEFAULT_MAX_TOKENS` (64000) as `responseRoom`, and `reasoning_effort: "high"` supplies a 131072 thinking budget. With no cap resolved, `target = 195072`. For `opencode-go/qwen3.7-plus`, the real upstream ceiling (per boundary testing: `131072` → 200, `131073` → 400) is only registered as a provider-scoped override — so every such request went out as `max_tokens: 195072` and was rejected upstream with a bare `400 {"model":"qwen3.7-plus"}`.

The caller in `openai-to-claude.ts` already has the routed provider in scope two lines earlier (used immediately after for the Kimi-coding check) — it just never threads it into this call:

```ts
const routedProvider = credentials?._provider;
const isKimiCoding = routedProvider === "kimi-coding" || ...;
...
const fitted = fitThinkingToMaxTokens(model, Number(result.max_tokens) || 0, result.thinking);  // no provider
```

Follow-up to #6637, whose token-budgeting half was never addressed — #6893 fixed only the combo fallback classification, not the translation-time cap resolution.

## Fix

`fitThinkingToMaxTokens()` takes an optional 4th argument `provider`, forwarded into `capMaxOutputTokens({ provider, model })` — no new lookup path, this object shape is already supported. The caller now passes the already-in-scope `routedProvider`. Omitting the argument (any other existing caller) keeps the exact prior behavior — verified below.

This is the same provider-aware read path #6524 aligned the reasoning-token-buffer clamp onto.

## Verification

New regression test `tests/unit/repro-10139-claude-thinking-output-cap.test.ts`, modeled on this repo's own `repro-6524.test.ts` DB-fixture pattern, against a real `opencode-go/qwen3.7-plus` `max_output_tokens` override:

```
without provider (documents the pre-fix defect): maxTokens = 195072 (uncapped)
with provider:                                    maxTokens = 131072, thinking.budget_tokens = 67072
no override present:                              behavior identical with/without provider argument
```

Red→green, same tree, only the fix commit toggled:

```
git stash (fix only)   -> tests/unit/repro-10139-claude-thinking-output-cap.test.ts: not ok 2, # pass 2 # fail 1
git stash pop           -> # pass 3 # fail 0
```

No regressions in the surrounding suites:

```
tests/unit/translator-openai-to-claude.test.ts             17/17
tests/unit/openai-to-claude-thinking-budget-split.test.ts   3/3   (leaf/host split-guard, unaffected)
tests/unit/repro-6524.test.ts                                2/2
tests/unit/minimax-m3-maxtokens.test.ts                      5/5
tests/unit/output-token-budget-model-cap.test.ts            12/12
```

`npm run check:changelog-integrity` passes; a `changelog.d/fixes/` fragment is included. Commit went through the full pre-commit hook (`docs-sync`, `check:any-budget:t11`, lint-staged) with no `--no-verify` needed.

## Note

Rebased onto the `openai-to-claude/thinkingBudget.ts` extraction that landed in the recent provider-registry reorg — the defect and fix are unchanged in substance from the original patch written against the inline code, only the file location moved.

Closes #10139
