### PR TITLE
feat(dashboard): Kimi 15% first-top-up campaign — tracked link + discount-first copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ curl http://localhost:20128/v1/chat/completions \
 </div>
 
 <p align="center">
-  <a href="https://platform.kimi.ai?aff=omniroute">
+  <a href="https://platform.kimi.ai?track_id=track-8197581fdd7d4139a0f562e4a03c3798&aff=omniroute">
     <img src="public/sponsors/kimi-k3-banner.png" width="100%" alt="Kimi K3 — Open Frontier Intelligence · 2.8T parameters · 1M-token context"/>
   </a>
 </p>
@@ -248,7 +248,7 @@ curl http://localhost:20128/v1/chat/completions \
 <table>
   <tr>
     <td align="center" width="150">
-      <a href="https://platform.kimi.ai?aff=omniroute">
+      <a href="https://platform.kimi.ai?track_id=track-8197581fdd7d4139a0f562e4a03c3798&aff=omniroute">
         <picture>
           <source media="(prefers-color-scheme: dark)" srcset="public/providers/kimi-logomark-dark.svg">
           <img src="public/providers/kimi-logomark-light.svg" width="64" alt="Kimi (Moonshot AI)"/>
@@ -260,7 +260,7 @@ curl http://localhost:20128/v1/chat/completions \
     <td>
       Thanks to <b>Kimi (Moonshot AI)</b>, our founding Open Source Friend, for backing this project! Kimi is the AI lab behind the open-weight K2 and K3 model families — <b>Kimi K3</b> delivers a 1M-token context window, native vision and frontier-level coding at a fraction of closed-model prices, and works out of the box with Claude Code, Codex and every coding tool OmniRoute serves.
       <br/><br/>
-      <b>What Kimi's support powers:</b> Kimi's API credits power OmniRoute's AI-validated release pipeline — the <i>merge validation powered by Kimi K3</i> stage that reviews every pull request before it ships — plus day-to-day feature development. First-class Kimi support ships on both rails: the direct <a href="https://platform.kimi.ai?aff=omniroute">Kimi API</a> (<code>kimi-k3</code>) and the <a href="https://www.kimi.com/code?aff=omniroute">Kimi Code coding plan</a> (OAuth and API key). OmniRoute is also the first Brazilian open-source project in Kimi's support program. <a href="https://platform.kimi.ai?aff=omniroute"><b>Get a Kimi API key →</b></a>
+      <b>What Kimi's support powers:</b> Kimi's API credits power OmniRoute's AI-validated release pipeline — the <i>merge validation powered by Kimi K3</i> stage that reviews every pull request before it ships — plus day-to-day feature development. First-class Kimi support ships on both rails: the direct <a href="https://platform.kimi.ai?track_id=track-8197581fdd7d4139a0f562e4a03c3798&aff=omniroute">Kimi API</a> (<code>kimi-k3</code>) and the <a href="https://www.kimi.com/code?aff=omniroute">Kimi Code coding plan</a> (OAuth and API key). OmniRoute is also the first Brazilian open-source project in Kimi's support program. <a href="https://platform.kimi.ai?track_id=track-8197581fdd7d4139a0f562e4a03c3798&aff=omniroute"><b>Get a Kimi API key with 15% extra credits →</b></a>
     </td>
   </tr>
   <tr>

--- a/src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx
+++ b/src/app/(dashboard)/dashboard/KimiSponsorBanner.tsx
@@ -12,7 +12,11 @@ import { shouldShowKimiSponsorBanner } from "./kimiSponsorBannerGate";
 // plan (kimi.com/code) to the API platform at Moonshot's request: coding plan
 // subscriptions are closed to most new users, so that traffic could not
 // convert.
-const KIMI_PLATFORM_AFF_URL = "https://platform.kimi.ai?aff=omniroute";
+// Dedicated tracked link issued by Moonshot 2026-08 for the 15% first-top-up
+// bonus campaign (offer valid through 2026-09-30 — revisit the 15% copy in the
+// i18n `kimiSponsorBanner.description` strings after that date if not renewed).
+const KIMI_PLATFORM_AFF_URL =
+  "https://platform.kimi.ai?track_id=track-8197581fdd7d4139a0f562e4a03c3798&aff=omniroute";
 
 // Versioned dismissal key — bump the suffix (e.g. `-v3`) if the banner's
 // offer/copy ever changes materially enough to warrant re-showing it to

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) هو صديق المصدر المفتوح المؤسس لـ OmniRoute",
-    "description": "استخدم Kimi K3 في OmniRoute عبر واجهة Kimi API الرسمية. استمتع بذكاء متقدم بتكلفة أقل.",
+    "description": "المستخدمون الجدد يحصلون على 15% رصيد API إضافي عند أول شحن. استخدم Kimi K3 في OmniRoute عبر واجهة Kimi API الرسمية.",
     "cta": "احصل على مفتاح Kimi API",
     "partnerLinkNote": "رابط شريك",
     "dismissAriaLabel": "تجاهل"

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) OmniRoute-un təsisçi Açıq Mənbə Dostudur",
-    "description": "Kimi K3-ü OmniRoute-da rəsmi Kimi API vasitəsilə istifadə edin. Daha az xərclə qabaqcıl intellektdən yararlanın.",
+    "description": "Yeni istifadəçilər ilk balans artırmada 15% əlavə API krediti qazanır. Kimi K3-ü OmniRoute-da rəsmi Kimi API vasitəsilə istifadə edin.",
     "cta": "Kimi API açarı əldə edin",
     "partnerLinkNote": "Tərəfdaş linki",
     "dismissAriaLabel": "Bağla"

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) е основополагащият приятел на отворения код на OmniRoute",
-    "description": "Използвайте Kimi K3 в OmniRoute чрез официалния Kimi API. Насладете се на върхов интелект на по-ниска цена.",
+    "description": "Новите потребители получават 15% допълнителен API кредит при първото зареждане. Използвайте Kimi K3 в OmniRoute чрез официалния Kimi API.",
     "cta": "Вземете Kimi API ключ",
     "partnerLinkNote": "Партньорска връзка",
     "dismissAriaLabel": "Затваряне"

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) হল OmniRoute-এর প্রতিষ্ঠাতা ওপেন সোর্স বন্ধু",
-    "description": "অফিসিয়াল Kimi API-এর মাধ্যমে OmniRoute-এ Kimi K3 ব্যবহার করুন। কম খরচে অত্যাধুনিক বুদ্ধিমত্তা উপভোগ করুন।",
+    "description": "নতুন ব্যবহারকারীরা প্রথম রিচার্জে 15% অতিরিক্ত API ক্রেডিট পান। অফিসিয়াল Kimi API-এর মাধ্যমে OmniRoute-এ Kimi K3 ব্যবহার করুন।",
     "cta": "Kimi API কী নিন",
     "partnerLinkNote": "পার্টনার লিঙ্ক",
     "dismissAriaLabel": "খারিজ করুন"

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) je zakládající open source přítel OmniRoute",
-    "description": "Používejte Kimi K3 v OmniRoute přes oficiální Kimi API. Užijte si špičkovou inteligenci za méně peněz.",
+    "description": "Noví uživatelé získají 15% API kreditu navíc při prvním dobití. Používejte Kimi K3 v OmniRoute přes oficiální Kimi API.",
     "cta": "Získat Kimi API klíč",
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavřít"

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) er OmniRoutes stiftende open source-ven",
-    "description": "Brug Kimi K3 i OmniRoute via det officielle Kimi API. Nyd banebrydende intelligens til en lavere pris.",
+    "description": "Nye brugere får 15% ekstra API-kredit ved første optankning. Brug Kimi K3 i OmniRoute via det officielle Kimi API.",
     "cta": "Få en Kimi API-nøgle",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Afvis"

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) ist OmniRoutes Open-Source-Gründungsfreund",
-    "description": "Nutze Kimi K3 in OmniRoute über die offizielle Kimi API. Genieße Spitzenintelligenz bei geringeren Kosten.",
+    "description": "Neue Nutzer erhalten 15% extra API-Guthaben bei der ersten Aufladung. Nutze Kimi K3 in OmniRoute über die offizielle Kimi API.",
     "cta": "Kimi API-Schlüssel holen",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Schließen"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) is OmniRoute's founding Open Source Friend",
-    "description": "Use Kimi K3 in OmniRoute through the official Kimi API. Enjoy frontier intelligence while spending less.",
+    "description": "New users get 15% extra API credits on their first top-up. Use Kimi K3 in OmniRoute through the official Kimi API.",
     "cta": "Get a Kimi API Key",
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) es el amigo fundador del código abierto de OmniRoute",
-    "description": "Usa Kimi K3 en OmniRoute a través de la API oficial de Kimi. Disfruta de inteligencia de frontera gastando menos.",
+    "description": "Los usuarios nuevos reciben un 15% de crédito de API extra en su primera recarga. Usa Kimi K3 en OmniRoute a través de la API oficial de Kimi.",
     "cta": "Obtener una clave de API de Kimi",
     "partnerLinkNote": "Enlace de socio",
     "dismissAriaLabel": "Descartar"

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) دوست متن‌باز بنیان‌گذار OmniRoute است",
-    "description": "از Kimi K3 در OmniRoute از طریق API رسمی Kimi استفاده کنید. از هوش پیشرفته با هزینه کمتر لذت ببرید.",
+    "description": "کاربران جدید در اولین شارژ حساب 15% اعتبار API اضافی دریافت می‌کنند. از Kimi K3 در OmniRoute از طریق API رسمی Kimi استفاده کنید.",
     "cta": "دریافت کلید Kimi API",
     "partnerLinkNote": "لینک همکاری",
     "dismissAriaLabel": "بستن"

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) on OmniRouten perustava avoimen lähdekoodin ystävä",
-    "description": "Käytä Kimi K3:a OmniRoutessa virallisen Kimi API:n kautta. Nauti huippuälystä pienemmillä kustannuksilla.",
+    "description": "Uudet käyttäjät saavat 15% lisää API-saldoa ensimmäisestä latauksesta. Käytä Kimi K3:a OmniRoutessa virallisen Kimi API:n kautta.",
     "cta": "Hanki Kimi API-avain",
     "partnerLinkNote": "Kumppanilinkki",
     "dismissAriaLabel": "Sulje"

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) est l'ami open source fondateur d'OmniRoute",
-    "description": "Utilisez Kimi K3 dans OmniRoute via l'API officielle Kimi. Profitez d'une intelligence de pointe en dépensant moins.",
+    "description": "Les nouveaux utilisateurs reçoivent 15% de crédits API en plus sur leur premier rechargement. Utilisez Kimi K3 dans OmniRoute via l'API officielle Kimi.",
     "cta": "Obtenir une clé API Kimi",
     "partnerLinkNote": "Lien partenaire",
     "dismissAriaLabel": "Ignorer"

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) એ OmniRoute નો સ્થાપક ઓપન સોર્સ મિત્ર છે",
-    "description": "સત્તાવાર Kimi API દ્વારા OmniRoute માં Kimi K3 વાપરો. ઓછા ખર્ચે અદ્યતન બુદ્ધિમત્તાનો આનંદ લો.",
+    "description": "નવા વપરાશકર્તાઓને પ્રથમ ટોપ-અપ પર 15% વધારાની API ક્રેડિટ મળે છે. સત્તાવાર Kimi API દ્વારા OmniRoute માં Kimi K3 વાપરો.",
     "cta": "Kimi API કી મેળવો",
     "partnerLinkNote": "પાર્ટનર લિંક",
     "dismissAriaLabel": "બંધ કરો"

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) הוא חבר הקוד הפתוח המייסד של OmniRoute",
-    "description": "השתמשו ב-Kimi K3 ב-OmniRoute דרך ה-API הרשמי של Kimi. תיהנו מאינטליגנציה חדשנית בעלות נמוכה יותר.",
+    "description": "משתמשים חדשים מקבלים 15% קרדיט API נוסף בטעינה הראשונה. השתמשו ב-Kimi K3 ב-OmniRoute דרך ה-API הרשמי של Kimi.",
     "cta": "קבלו מפתח Kimi API",
     "partnerLinkNote": "קישור שותף",
     "dismissAriaLabel": "התעלם"

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) OmniRoute का संस्थापक ओपन सोर्स मित्र है",
-    "description": "आधिकारिक Kimi API के ज़रिए OmniRoute में Kimi K3 इस्तेमाल करें। कम खर्च में अत्याधुनिक बुद्धिमत्ता का आनंद लें।",
+    "description": "नए उपयोगकर्ताओं को पहले टॉप-अप पर 15% अतिरिक्त API क्रेडिट मिलता है। आधिकारिक Kimi API के ज़रिए OmniRoute में Kimi K3 इस्तेमाल करें।",
     "cta": "Kimi API कुंजी प्राप्त करें",
     "partnerLinkNote": "पार्टनर लिंक",
     "dismissAriaLabel": "खारिज करें"

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "A Kimi (Moonshot AI) az OmniRoute alapító nyílt forráskódú barátja",
-    "description": "Használd a Kimi K3-at az OmniRoute-ban a hivatalos Kimi API-n keresztül. Élvezd az élvonalbeli intelligenciát kevesebb költséggel.",
+    "description": "Az új felhasználók 15% extra API-keretet kapnak az első feltöltéskor. Használd a Kimi K3-at az OmniRoute-ban a hivatalos Kimi API-n keresztül.",
     "cta": "Kimi API-kulcs beszerzése",
     "partnerLinkNote": "Partnerhivatkozás",
     "dismissAriaLabel": "Elvetés"

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) adalah Sahabat Open Source pendiri OmniRoute",
-    "description": "Gunakan Kimi K3 di OmniRoute melalui Kimi API resmi. Nikmati kecerdasan terdepan dengan biaya lebih hemat.",
+    "description": "Pengguna baru mendapat 15% kredit API ekstra pada isi ulang pertama. Gunakan Kimi K3 di OmniRoute melalui Kimi API resmi.",
     "cta": "Dapatkan Kunci API Kimi",
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) adalah Sahabat Open Source pendiri OmniRoute",
-    "description": "Gunakan Kimi K3 di OmniRoute melalui Kimi API resmi. Nikmati kecerdasan terdepan dengan biaya lebih hemat.",
+    "description": "Pengguna baru mendapat 15% kredit API ekstra pada isi ulang pertama. Gunakan Kimi K3 di OmniRoute melalui Kimi API resmi.",
     "cta": "Dapatkan Kunci API Kimi",
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) è l'amico open source fondatore di OmniRoute",
-    "description": "Usa Kimi K3 in OmniRoute tramite l'API ufficiale di Kimi. Goditi un'intelligenza di frontiera spendendo meno.",
+    "description": "I nuovi utenti ricevono il 15% di crediti API extra sulla prima ricarica. Usa Kimi K3 in OmniRoute tramite l'API ufficiale di Kimi.",
     "cta": "Ottieni una chiave API Kimi",
     "partnerLinkNote": "Link partner",
     "dismissAriaLabel": "Ignora"

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi（Moonshot AI）はOmniRouteの創設オープンソースフレンドです",
-    "description": "公式Kimi APIを通じてOmniRouteでKimi K3を使えます。最先端の知能をより低コストで。",
+    "description": "新規ユーザーは初回チャージでAPIクレジットが15%増量。公式Kimi APIを通じてOmniRouteでKimi K3を使えます。",
     "cta": "Kimi APIキーを取得",
     "partnerLinkNote": "パートナーリンク",
     "dismissAriaLabel": "閉じる"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi(Moonshot AI)는 OmniRoute의 창립 오픈소스 친구입니다",
-    "description": "공식 Kimi API를 통해 OmniRoute에서 Kimi K3를 사용하세요. 더 적은 비용으로 최첨단 지능을 누리세요.",
+    "description": "신규 사용자는 첫 충전 시 API 크레딧을 15% 추가로 받습니다. 공식 Kimi API를 통해 OmniRoute에서 Kimi K3를 사용하세요.",
     "cta": "Kimi API 키 받기",
     "partnerLinkNote": "파트너 링크",
     "dismissAriaLabel": "닫기"

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) हा OmniRoute चा संस्थापक ओपन सोर्स मित्र आहे",
-    "description": "अधिकृत Kimi API द्वारे OmniRoute मध्ये Kimi K3 वापरा. कमी खर्चात अत्याधुनिक बुद्धिमत्तेचा आनंद घ्या.",
+    "description": "नवीन वापरकर्त्यांना पहिल्या टॉप-अपवर 15% अतिरिक्त API क्रेडिट मिळते. अधिकृत Kimi API द्वारे OmniRoute मध्ये Kimi K3 वापरा.",
     "cta": "Kimi API की मिळवा",
     "partnerLinkNote": "भागीदार लिंक",
     "dismissAriaLabel": "बंद करा"

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) ialah Rakan Sumber Terbuka pengasas OmniRoute",
-    "description": "Gunakan Kimi K3 dalam OmniRoute melalui Kimi API rasmi. Nikmati kecerdasan terkehadapan dengan perbelanjaan lebih rendah.",
+    "description": "Pengguna baharu mendapat 15% kredit API tambahan pada tambah nilai pertama. Gunakan Kimi K3 dalam OmniRoute melalui Kimi API rasmi.",
     "cta": "Dapatkan Kunci API Kimi",
     "partnerLinkNote": "Pautan rakan kongsi",
     "dismissAriaLabel": "Tutup"

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) is OmniRoutes oprichtende open source-vriend",
-    "description": "Gebruik Kimi K3 in OmniRoute via de officiële Kimi API. Geniet van grensverleggende intelligentie voor minder geld.",
+    "description": "Nieuwe gebruikers krijgen 15% extra API-tegoed bij hun eerste storting. Gebruik Kimi K3 in OmniRoute via de officiële Kimi API.",
     "cta": "Kimi API-sleutel ophalen",
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Sluiten"

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) er OmniRoutes grunnleggende open source-venn",
-    "description": "Bruk Kimi K3 i OmniRoute via det offisielle Kimi API-et. Nyt banebrytende intelligens til en lavere kostnad.",
+    "description": "Nye brukere får 15% ekstra API-kreditt ved første påfylling. Bruk Kimi K3 i OmniRoute via det offisielle Kimi API-et.",
     "cta": "Få en Kimi API-nøkkel",
     "partnerLinkNote": "Partnerlenke",
     "dismissAriaLabel": "Avvis"

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Ang Kimi (Moonshot AI) ang founding Open Source Friend ng OmniRoute",
-    "description": "Gamitin ang Kimi K3 sa OmniRoute sa pamamagitan ng opisyal na Kimi API. Tamasahin ang frontier intelligence nang mas matipid.",
+    "description": "Ang mga bagong user ay makakakuha ng 15% dagdag na API credits sa unang top-up. Gamitin ang Kimi K3 sa OmniRoute sa pamamagitan ng opisyal na Kimi API.",
     "cta": "Kumuha ng Kimi API Key",
     "partnerLinkNote": "Link ng kasosyo",
     "dismissAriaLabel": "I-dismiss"

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) to założycielski przyjaciel open source OmniRoute",
-    "description": "Używaj Kimi K3 w OmniRoute przez oficjalne Kimi API. Ciesz się najnowocześniejszą inteligencją, wydając mniej.",
+    "description": "Nowi użytkownicy otrzymują 15% dodatkowych środków API przy pierwszym doładowaniu. Używaj Kimi K3 w OmniRoute przez oficjalne Kimi API.",
     "cta": "Zdobądź klucz Kimi API",
     "partnerLinkNote": "Link partnerski",
     "dismissAriaLabel": "Odrzuć"

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "A Kimi (Moonshot AI) é a Amiga do Código Aberto fundadora do OmniRoute",
-    "description": "Use o Kimi K3 no OmniRoute pela API oficial da Kimi. Aproveite inteligência de fronteira gastando menos.",
+    "description": "Usuários novos ganham 15% de créditos de API extras na primeira recarga. Use o Kimi K3 no OmniRoute pela API oficial da Kimi.",
     "cta": "Obter uma chave de API da Kimi",
     "partnerLinkNote": "Link de parceria",
     "dismissAriaLabel": "Dispensar"

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "A Kimi (Moonshot AI) é a Amiga do Código Aberto fundadora do OmniRoute",
-    "description": "Use o Kimi K3 no OmniRoute através da API oficial da Kimi. Desfrute de inteligência de fronteira gastando menos.",
+    "description": "Os novos utilizadores ganham 15% de créditos de API extra no primeiro carregamento. Use o Kimi K3 no OmniRoute através da API oficial da Kimi.",
     "cta": "Obter uma chave de API da Kimi",
     "partnerLinkNote": "Link de parceiro",
     "dismissAriaLabel": "Dispensar"

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) este prietenul open source fondator al OmniRoute",
-    "description": "Folosește Kimi K3 în OmniRoute prin API-ul oficial Kimi. Bucură-te de inteligență de frontieră cheltuind mai puțin.",
+    "description": "Utilizatorii noi primesc 15% credite API în plus la prima alimentare. Folosește Kimi K3 în OmniRoute prin API-ul oficial Kimi.",
     "cta": "Obține o cheie API Kimi",
     "partnerLinkNote": "Link de partener",
     "dismissAriaLabel": "Închide"

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) — друг-основатель открытого кода OmniRoute",
-    "description": "Используйте Kimi K3 в OmniRoute через официальный Kimi API. Наслаждайтесь передовым интеллектом, тратя меньше.",
+    "description": "Новые пользователи получают 15% дополнительных API-кредитов при первом пополнении. Используйте Kimi K3 в OmniRoute через официальный Kimi API.",
     "cta": "Получить ключ Kimi API",
     "partnerLinkNote": "Партнерская ссылка",
     "dismissAriaLabel": "Закрыть"

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) je zakladajúci open source priateľ OmniRoute",
-    "description": "Používajte Kimi K3 v OmniRoute cez oficiálne Kimi API. Užite si špičkovú inteligenciu za menej peňazí.",
+    "description": "Noví používatelia získajú 15% API kreditu navyše pri prvom dobití. Používajte Kimi K3 v OmniRoute cez oficiálne Kimi API.",
     "cta": "Získať Kimi API kľúč",
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavrieť"

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) är OmniRoutes grundande open source-vän",
-    "description": "Använd Kimi K3 i OmniRoute via det officiella Kimi API:et. Njut av banbrytande intelligens till en lägre kostnad.",
+    "description": "Nya användare får 15% extra API-kredit vid första påfyllningen. Använd Kimi K3 i OmniRoute via det officiella Kimi API:et.",
     "cta": "Skaffa en Kimi API-nyckel",
     "partnerLinkNote": "Partnerlänk",
     "dismissAriaLabel": "Avvisa"

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) ni Rafiki Mwanzilishi wa Open Source wa OmniRoute",
-    "description": "Tumia Kimi K3 kwenye OmniRoute kupitia Kimi API rasmi. Furahia akili ya kisasa kwa gharama ndogo.",
+    "description": "Watumiaji wapya wanapata 15% ya salio la ziada la API kwenye malipo yao ya kwanza. Tumia Kimi K3 kwenye OmniRoute kupitia Kimi API rasmi.",
     "cta": "Pata Ufunguo wa Kimi API",
     "partnerLinkNote": "Kiungo cha mshirika",
     "dismissAriaLabel": "Ondoa"

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) என்பது OmniRoute-இன் நிறுவனர் ஓப்பன் சோர்ஸ் நண்பர்",
-    "description": "அதிகாரப்பூர்வ Kimi API வழியாக OmniRoute-இல் Kimi K3-ஐப் பயன்படுத்துங்கள். குறைந்த செலவில் முன்னணி நுண்ணறிவை அனுபவியுங்கள்.",
+    "description": "புதிய பயனர்கள் முதல் டாப்-அப்பில் 15% கூடுதல் API கிரெடிட் பெறுவார்கள். அதிகாரப்பூர்வ Kimi API வழியாக OmniRoute-இல் Kimi K3-ஐப் பயன்படுத்துங்கள்.",
     "cta": "Kimi API விசையைப் பெறுங்கள்",
     "partnerLinkNote": "பங்குதாரர் இணைப்பு",
     "dismissAriaLabel": "நிராகரி"

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) అనేది OmniRoute యొక్క వ్యవస్థాపక ఓపెన్ సోర్స్ మిత్రుడు",
-    "description": "అధికారిక Kimi API ద్వారా OmniRouteలో Kimi K3ని ఉపయోగించండి. తక్కువ ఖర్చుతో అత్యాధునిక మేధస్సును ఆస్వాదించండి.",
+    "description": "కొత్త వినియోగదారులు మొదటి టాప్-అప్‌లో 15% అదనపు API క్రెడిట్ పొందుతారు. అధికారిక Kimi API ద్వారా OmniRouteలో Kimi K3ని ఉపయోగించండి.",
     "cta": "Kimi API కీ పొందండి",
     "partnerLinkNote": "భాగస్వామి లింక్",
     "dismissAriaLabel": "తీసివేయి"

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) คือเพื่อนโอเพนซอร์สผู้ก่อตั้งของ OmniRoute",
-    "description": "ใช้ Kimi K3 ใน OmniRoute ผ่าน Kimi API อย่างเป็นทางการ เพลิดเพลินกับปัญญาระดับแนวหน้าในราคาที่ถูกลง",
+    "description": "ผู้ใช้ใหม่รับเครดิต API เพิ่ม 15% เมื่อเติมเงินครั้งแรก ใช้ Kimi K3 ใน OmniRoute ผ่าน Kimi API อย่างเป็นทางการ",
     "cta": "รับคีย์ Kimi API",
     "partnerLinkNote": "ลิงก์พันธมิตร",
     "dismissAriaLabel": "ปิด"

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI), OmniRoute'un kurucu Açık Kaynak Dostudur",
-    "description": "Resmî Kimi API üzerinden OmniRoute'ta Kimi K3 kullanın. Daha az harcayarak öncü zekânın keyfini çıkarın.",
+    "description": "Yeni kullanıcılar ilk bakiye yüklemesinde %15 ekstra API kredisi kazanır. Resmî Kimi API üzerinden OmniRoute'ta Kimi K3 kullanın.",
     "cta": "Kimi API Anahtarı Alın",
     "partnerLinkNote": "Ortaklık bağlantısı",
     "dismissAriaLabel": "Kapat"

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) — друг-засновник відкритого коду OmniRoute",
-    "description": "Використовуйте Kimi K3 в OmniRoute через офіційний Kimi API. Насолоджуйтесь передовим інтелектом, витрачаючи менше.",
+    "description": "Нові користувачі отримують 15% додаткових API-кредитів при першому поповненні. Використовуйте Kimi K3 в OmniRoute через офіційний Kimi API.",
     "cta": "Отримати ключ Kimi API",
     "partnerLinkNote": "Партнерське посилання",
     "dismissAriaLabel": "Закрити"

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) OmniRoute کا بانی اوپن سورس دوست ہے",
-    "description": "سرکاری Kimi API کے ذریعے OmniRoute میں Kimi K3 استعمال کریں۔ کم خرچ میں جدید ترین ذہانت سے لطف اٹھائیں۔",
+    "description": "نئے صارفین کو پہلی ٹاپ اپ پر 15% اضافی API کریڈٹ ملتا ہے۔ سرکاری Kimi API کے ذریعے OmniRoute میں Kimi K3 استعمال کریں۔",
     "cta": "Kimi API کلید حاصل کریں",
     "partnerLinkNote": "پارٹنر لنک",
     "dismissAriaLabel": "خارج کریں"

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) là người bạn mã nguồn mở sáng lập của OmniRoute",
-    "description": "Dùng Kimi K3 trong OmniRoute qua Kimi API chính thức. Tận hưởng trí tuệ tiên phong với chi phí thấp hơn.",
+    "description": "Người dùng mới nhận thêm 15% tín dụng API cho lần nạp đầu tiên. Dùng Kimi K3 trong OmniRoute qua Kimi API chính thức.",
     "cta": "Nhận khóa Kimi API",
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) 是 OmniRoute 的创始开源好友",
-    "description": "通过官方 Kimi API 在 OmniRoute 中使用 Kimi K3。以更低的花费享受前沿智能。",
+    "description": "新用户首次充值可获得 15% 额外 API 额度。通过官方 Kimi API 在 OmniRoute 中使用 Kimi K3。",
     "cta": "获取 Kimi API 密钥",
     "partnerLinkNote": "合作伙伴链接",
     "dismissAriaLabel": "关闭"

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -13055,7 +13055,7 @@
   },
   "kimiSponsorBanner": {
     "foundingFriendTitle": "Kimi (Moonshot AI) 是 OmniRoute 的創始開源好友",
-    "description": "透過官方 Kimi API 在 OmniRoute 中使用 Kimi K3。以更低的花費享受前沿智慧。",
+    "description": "新用戶首次儲值可獲得 15% 額外 API 額度。透過官方 Kimi API 在 OmniRoute 中使用 Kimi K3。",
     "cta": "取得 Kimi API 金鑰",
     "partnerLinkNote": "合作夥伴連結",
     "dismissAriaLabel": "關閉"

--- a/tests/unit/ui/kimiSponsorBanner.test.tsx
+++ b/tests/unit/ui/kimiSponsorBanner.test.tsx
@@ -12,7 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v2";
 const LEGACY_V1_STORAGE_KEY = "omniroute-kimi-sponsor-banner-dismissed-v1";
-const KIMI_PLATFORM_AFF_URL = "https://platform.kimi.ai?aff=omniroute";
+const KIMI_PLATFORM_AFF_URL =
+  "https://platform.kimi.ai?track_id=track-8197581fdd7d4139a0f562e4a03c3798&aff=omniroute";
 
 vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
 vi.mock("@/shared/components/ProviderIcon", () => ({ default: () => null }));


### PR DESCRIPTION
## Summary

Moonshot approved a 15% extra-API-credits offer for new users' first top-up, tied to a dedicated tracked link issued specifically for OmniRoute (valid through **2026-09-30**). This wires it in:

- **Dashboard banner** (`KimiSponsorBanner.tsx`): link → the dedicated `track_id=track-8197581...&aff=omniroute` URL. Dismissal key stays `-v2` — the retargeted banner from #10200 has not shipped in any release yet, so this amends the same unshipped campaign.
- **Banner description, all 43 locales**: now leads with the discount — "New users get 15% extra API credits on their first top-up. Use Kimi K3 in OmniRoute through the official Kimi API."
- **README**: the 3 API platform links now use the tracked URL; the CTA reads "Get a Kimi API key with 15% extra credits →".
- A code comment marks the 15% strings for revisit after 2026-09-30 if the offer is not renewed.

## Tests / gates (all local, green)

- `tests/unit/ui/kimiSponsorBanner.test.tsx` — TDD red→green on the new URL, 7/7.
- `check-ui-value-drift` PASS (base `origin/release/v3.8.50`), `check-ui-keys-coverage` PASS (42 locales), `typecheck:core` clean, Prettier clean.

⚠️ base-red inherited: #9985

Follow-up to #10200.