### PR TITLE
[TS7] fix(types): remove duplicate SSE comment import

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -74,7 +74,6 @@ import {
   hasUnsupportedReasoningSignal,
 } from "./reasoningFields.ts";
 import { applyThinkTag, flushThink, initThinkState } from "./thinkTagParser.ts";
-import { sseCommentsEnabled } from "./sseHeartbeat.ts";
 import {
   caseInsensitiveToolNameLookup,
   restoreOpenAIToolNames,


### PR DESCRIPTION
## Summary

- remove the duplicate `sseCommentsEnabled` import introduced while the original import remained in `open-sse/utils/stream.ts`
- clear both TS2300 diagnostics without changing runtime behavior

## Root cause

The same binding was imported twice from `sseHeartbeat.ts`, so both TypeScript 6 and the official TypeScript 7.0.2 compiler reported two duplicate-identifier diagnostics.

## Validation

- full `open-sse/tsconfig.json`: TS6 28 → 26, added 0
- full `open-sse/tsconfig.json`: TypeScript 7.0.2 28 → 26, added 0
- `node --import tsx/esm --test tests/unit/sse-comments-optout-9305.test.ts tests/unit/sseHeartbeat.test.ts` (10/10)
- `npm exec eslint -- open-sse/utils/stream.ts`
- `npm run check:file-size`

Refs #8484