### PR TITLE
[TS7] fix(types): narrow combo credential preflight

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -787,7 +787,7 @@ async function handleChatImplementation(
           ...(bypassProviderQuotaPolicy ? { bypassQuotaPolicy: true } : {}),
         }
       );
-      if (!creds || creds.allRateLimited) return false;
+      if (!creds || !("authType" in creds)) return false;
 
       // OAuth selection must happen atomically with occupancy reservation in the
       // actual dispatch. Availability preflight may finish well before a combo

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -654,6 +654,7 @@ type AnonymousFallbackProviderDefinition = {
   noAuth?: boolean;
 };
 function buildSyntheticNoAuthCredentials(providerSpecificData: JsonRecord = {}): {
+  authType: "none";
   apiKey: null;
   accessToken: null;
   refreshToken: null;
@@ -676,6 +677,7 @@ function buildSyntheticNoAuthCredentials(providerSpecificData: JsonRecord = {}):
   retryAfterHuman?: never;
 } {
   return {
+    authType: "none",
     apiKey: null,
     accessToken: null,
     refreshToken: null,

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -117,6 +117,13 @@ test("extractApiKey parses bearer headers and isValidApiKey validates persisted 
   assert.equal(await auth.isValidApiKey(""), false);
 });
 
+test("getProviderCredentials identifies synthetic no-auth credentials", async () => {
+  const credentials = await auth.getProviderCredentials("opencode");
+
+  assert.equal(credentials?.connectionId, "noauth");
+  assert.equal(credentials?.authType, "none");
+});
+
 test("getProviderCredentials reports rate limiting when only inactive suppressed records remain", async () => {
   const retryAfter = futureIso();
   await seedConnection("openai", {


### PR DESCRIPTION
## Summary

- give synthetic no-auth credentials the same explicit `authType` discriminator used by normal credentials
- reject non-credential preflight sentinels before combo credential caching
- preserve caching for API-key and no-auth credentials while continuing to defer OAuth selection to dispatch

## Root cause

`getProviderCredentialsWithQuotaPreflight()` returns both usable credentials and failure sentinels. The combo availability preflight checked only `allRateLimited`, then accessed `authType` on the unresolved union. Synthetic no-auth credentials also omitted the discriminator even though their provider contract is explicitly no-auth.

## Validation

- full `open-sse/tsconfig.json`: TS6 28 → 27, removed 1, added 0
- full `open-sse/tsconfig.json`: TypeScript 7.0.2 28 → 27, removed 1, added 0
- `node --import tsx/esm --test tests/unit/sse-auth.test.ts` (64/64)
- targeted ESLint with repository suppressions
- Prettier check on all changed files
- `npm run check:file-size`

The repository-wide lint command remains base-red on unrelated existing parser and `no-new-func` diagnostics; neither file is touched here.

Refs #8484