### PR TITLE
[TS7] fix(types): align Responses stream options

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -5045,6 +5045,8 @@ export async function handleChatCore({
       apiKeyInfo,
       handleStreamFailure,
       copilotCompatibleReasoning,
+      false,
+      customToolNames,
       // openai-responses → openai translation still wants the namespace identity
       // map for #7936-style round-trip closure when the client also speaks
       // Responses (Codex CLI).

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -528,6 +528,43 @@ test("chatCore honors providerSpecificData.apiType for legacy openai-compatible 
   assert.equal("messages" in call.body, false);
   assert.equal(payload.choices[0].message.content, "ok");
 });
+test("chatCore translates a streaming Responses upstream for a Chat client", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openai-compatible-sp-openai",
+    model: "gpt-5.4",
+    endpoint: "/v1/chat/completions",
+    accept: "text/event-stream",
+    credentials: {
+      apiKey: "sk-test",
+      providerSpecificData: {
+        apiType: "responses",
+        baseUrl: "https://proxy.example.com/v1",
+        prefix: "sp-openai",
+      },
+    },
+    body: {
+      model: "gpt-5.4",
+      stream: true,
+      messages: [{ role: "user", content: "Reply with OK only." }],
+    },
+    responseFactory: () =>
+      new Response(
+        [
+          'data: {"type":"response.output_text.delta","delta":"ok"}',
+          "",
+          'data: {"type":"response.completed","response":{"id":"resp_stream","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}',
+          "",
+        ].join("\n"),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } }
+      ),
+  });
+
+  assert.equal(result.success, true);
+  assert.match(call.url, /\/responses$/);
+  const streamed = await result.response.text();
+  assert.match(streamed, /"content":"ok"/);
+  assert.match(streamed, /data: \[DONE\]/);
+});
 test("chatCore applies Responses input policy to openai-compatible targets", async () => {
   const reasoningItems = [
     { id: "rs_valid", type: "reasoning", encrypted_content: "encrypted-blob" },


### PR DESCRIPTION
## Summary

- pass the missing `suppressThinkClose` and `customToolNames` arguments before the namespace identity map
- keep the Responses-upstream → Chat-client stream path aligned with `createSSETransformStreamWithLogger()`
- cover the real streaming translation path through `handleChatCore()`

## Root cause

`createSSETransformStreamWithLogger()` gained two positional options, but the Responses-to-Chat call site still passed `requestToolIdentityMap` immediately after `copilotCompatibleReasoning`. That put a `Map` in the boolean `suppressThinkClose` slot and omitted the final options.

## Validation

- full `open-sse/tsconfig.json`: TS6 28 → 27, removed 1, added 0
- full `open-sse/tsconfig.json`: TypeScript 7.0.2 28 → 27, removed 1, added 0
- focused Responses→Chat streaming integration test (1/1)
- targeted ESLint with repository suppressions
- `npm run check:file-size`

The repository copy of `chatCore.ts` is already Prettier-red before this change; this PR deliberately avoids a whole-file formatting rewrite.

Refs #8484