### PR TITLE
[TS7] fix(types): narrow refresh token rotation inputs

### DIFF
--- a/open-sse/services/refreshSerializer.ts
+++ b/open-sse/services/refreshSerializer.ts
@@ -112,8 +112,8 @@ export async function serializeRefresh<T>(provider: string, fn: () => Promise<T>
  * and codex-lb's replica race-detection.
  */
 export function wasRefreshTokenRotated(
-  attemptedRefreshToken: string | null | undefined,
-  latestRefreshToken: string | null | undefined
+  attemptedRefreshToken: unknown,
+  latestRefreshToken: unknown
 ): boolean {
   return (
     typeof attemptedRefreshToken === "string" &&

--- a/tests/unit/refresh-serializer.test.ts
+++ b/tests/unit/refresh-serializer.test.ts
@@ -109,4 +109,6 @@ test("wasRefreshTokenRotated: true only when the DB token changed to a non-empty
   assert.equal(wasRefreshTokenRotated("rt-old", ""), false, "empty DB token = deactivate");
   assert.equal(wasRefreshTokenRotated(null, "rt-new"), false, "unknown attempted = deactivate");
   assert.equal(wasRefreshTokenRotated(undefined, undefined), false);
+  assert.equal(wasRefreshTokenRotated("rt-old", { token: "rt-new" }), false);
+  assert.equal(wasRefreshTokenRotated(42, "rt-new"), false);
 });


### PR DESCRIPTION
## Summary
- align the refresh-token rotation guard with the unknown values returned by the DB boundary
- preserve the existing fail-closed runtime checks for non-string token values
- cover malformed token values in the existing serializer test

## TS7 impact
- TypeScript 6: 28 -> 27 diagnostics (1 removed, 0 added)
- TypeScript 7.0.2: 28 -> 27 diagnostics (1 removed, 0 added)

## Validation
- node --import tsx/esm --test tests/unit/refresh-serializer.test.ts (6/6)
- targeted ESLint
- npm run check:file-size
- git diff --check