### PR TITLE
fix(quality): register visionBridge-responses-9597 covering test in stryker tap.testFiles

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -232,6 +232,7 @@
       "tests/unit/gemini-web-missing-browser-3516.test.ts",
       "tests/unit/grok-cli-oauth.test.ts",
       "tests/unit/guardrails-api-3496.test.ts",
+      "tests/unit/guardrails/visionBridge-responses-9597.test.ts",
       "tests/unit/headroom-codex-quota-snapshot-6379.test.ts",
       "tests/unit/headroom-proxy-lifecycle.test.ts",
       "tests/unit/idempotency-fusion-collision.test.ts",


### PR DESCRIPTION
## Summary

- Registers `tests/unit/guardrails/visionBridge-responses-9597.test.ts` in `stryker.conf.json`'s `tap.testFiles` — it covers `open-sse/services/combo/comboStructure.ts` but was missing from the list, so its mutant kills weren't counted.

## Root cause

`check-mutation-test-coverage.mjs --strict` (the `mutation-test-coverage` gate in Fast Quality Gates) scans all unit test files for ones that exercise a mutated module and asserts every one of them is registered in `tap.testFiles`. This one covering test drifted out of sync — currently failing this gate on every open PR against `release/v3.8.50`, unrelated to whatever else the PR touches. Reproduced on the pure tip (`6143da70d1`) before this fix.

## Validation

- [x] `node scripts/check/check-mutation-test-coverage.mjs --strict` — clean (was failing before)
- [x] `node --import tsx --test tests/unit/guardrails/visionBridge-responses-9597.test.ts` — 5/5 pass
- [x] `python3 -c "import json; json.load(open('stryker.conf.json'))"` — valid JSON

## Tests Added Or Updated

- None — this registers an existing test, no behavior change.

## Coverage Notes

- N/A, config-only change.

## Reviewer Notes

- Found while investigating base-red failures on diegosouzapw/OmniRoute#10262 and #10263 — this was the only one of four failing gates with no existing tracking issue or PR (the others are covered by #9985 (dead-code, tracked as expected ratchet drift), and #10252/#10260 (open-sse-typecheck stream.ts TS2300, poolside catalog test)).
