### PR TITLE
fix(providers): preserve connection test status codes

### DIFF
--- a/changelog.d/fixes/10272-provider-test-statuscode-propagation.md
+++ b/changelog.d/fixes/10272-provider-test-statuscode-propagation.md
@@ -1,0 +1,1 @@
+- **fix(providers):** preserve validator HTTP status codes in API-key and web connection-test results so callers can distinguish authentication, rate-limit, and upstream failures ([#10272](https://github.com/diegosouzapw/OmniRoute/pull/10272)) — thanks @Zartharas

--- a/src/app/api/providers/[id]/test/apiKeyTestResult.ts
+++ b/src/app/api/providers/[id]/test/apiKeyTestResult.ts
@@ -1,0 +1,28 @@
+export interface ApiKeyValidationResult {
+  valid: boolean;
+  warning?: string | null;
+  statusCode?: number | null;
+  deployments?: unknown;
+}
+
+export interface ApiKeyTestDiagnosis {
+  type: string;
+  source: string;
+  message: string | null;
+  code: string | null;
+}
+
+export function buildApiKeyConnectionTestResult(
+  result: ApiKeyValidationResult,
+  error: string | null,
+  diagnosis: ApiKeyTestDiagnosis
+) {
+  return {
+    valid: !!result.valid,
+    error,
+    warning: result.warning || null,
+    statusCode: result.valid ? null : (result.statusCode ?? null),
+    diagnosis,
+    ...(Array.isArray(result.deployments) ? { deployments: result.deployments } : {}),
+  };
+}

--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -23,6 +23,7 @@ import { isGitLabDirectAccessDisabled } from "@/lib/oauth/gitlab";
 import { providerAllowsOptionalApiKey } from "@/shared/constants/providers";
 import { removeConnectionHealth } from "@omniroute/open-sse/services/apiKeyRotator.ts";
 import { classifyAmbiguousOrAuthError, type ClassifyFailureArgs } from "./mistralAmbiguousAuth";
+import { buildApiKeyConnectionTestResult } from "./apiKeyTestResult";
 import { OAUTH_TEST_CONFIG } from "./oauthTestConfig";
 
 // Bound the OAuth probe so a hung upstream can't block the connection-test queue
@@ -614,15 +615,7 @@ async function testApiKeyConnection(connection: any) {
     ? makeDiagnosis("ok", "upstream", null, null)
     : classifyFailure({ error, statusCode: result.statusCode, provider: connection.provider });
 
-  return {
-    valid: !!result.valid,
-    error,
-    warning: result.warning || null,
-    diagnosis,
-    ...(Array.isArray((result as any).deployments)
-      ? { deployments: (result as any).deployments }
-      : {}),
-  };
+  return buildApiKeyConnectionTestResult(result, error, diagnosis);
 }
 
 /**
@@ -709,7 +702,8 @@ export async function testSingleConnection(connectionId: string, validationModel
   // failures a short cooldown so the lazy-recovery path retries them.
   const terminalTestStatuses = new Set(["banned", "expired", "credits_exhausted"]);
   const isTerminalFailure =
-    !result.valid && terminalTestStatuses.has(String(diagnosis.code ?? diagnosis.type ?? "").toLowerCase());
+    !result.valid &&
+    terminalTestStatuses.has(String(diagnosis.code ?? diagnosis.type ?? "").toLowerCase());
   const testFailureCooldownMs = result.valid ? 0 : 30_000; // 30s retry window
 
   const updateData: Record<string, any> = {

--- a/tests/unit/provider-test-statuscode-propagation.test.ts
+++ b/tests/unit/provider-test-statuscode-propagation.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildApiKeyConnectionTestResult } =
+  await import("../../src/app/api/providers/[id]/test/apiKeyTestResult.ts");
+
+const FAILURE_DIAGNOSIS = {
+  type: "synthetic_failure",
+  source: "test",
+  message: "Synthetic validator failure",
+  code: "synthetic",
+};
+
+test("API-key connection tests preserve validator failure status codes", () => {
+  for (const statusCode of [401, 403, 429, 503]) {
+    const result = buildApiKeyConnectionTestResult(
+      {
+        valid: false,
+        warning: null,
+        statusCode,
+      },
+      `Synthetic validator failure ${statusCode}`,
+      FAILURE_DIAGNOSIS
+    );
+
+    assert.equal(result.valid, false);
+    assert.equal(result.statusCode, statusCode);
+    assert.deepEqual(result.diagnosis, FAILURE_DIAGNOSIS);
+  }
+});
+
+test("status-less semantic failures remain status-less", () => {
+  const result = buildApiKeyConnectionTestResult(
+    {
+      valid: false,
+      warning: null,
+    },
+    "Synthetic semantic failure",
+    FAILURE_DIAGNOSIS
+  );
+
+  assert.equal(result.valid, false);
+  assert.equal(result.statusCode, null);
+  assert.deepEqual(result.diagnosis, FAILURE_DIAGNOSIS);
+});
+
+test("successful validation does not synthesize an HTTP status", () => {
+  const diagnosis = {
+    type: "ok",
+    source: "upstream",
+    message: null,
+    code: null,
+  };
+
+  const result = buildApiKeyConnectionTestResult(
+    {
+      valid: true,
+      warning: null,
+      statusCode: 200,
+    },
+    null,
+    diagnosis
+  );
+
+  assert.equal(result.valid, true);
+  assert.equal(result.statusCode, null);
+  assert.deepEqual(result.diagnosis, diagnosis);
+});


### PR DESCRIPTION
## Summary

Preserve validator HTTP failure status metadata through the API-key / web-session connection-test path.

## Root cause

`testApiKeyConnection()` already passes `result.statusCode` into `classifyFailure()`, but the API-key connection-test result omitted that field.

Downstream consumers could therefore lose exact status metadata even when the validator knew the upstream response class.

This could cause:

- the connection-test response to expose `statusCode: null`;
- call-log handling to fall back to `401` for unrelated 403/429/5xx failures;
- downstream tooling to lose the distinction between authentication, rate-limit, and upstream failures.

## Fix

- Extract a small pure connection-test result builder.
- Preserve validator failure `statusCode`.
- Keep successful validation status-less.
- Keep status-less semantic failures status-less.
- Preserve warning, diagnosis, and deployment behavior.
- Add focused regression coverage for 401, 403, 429, 503, status-less failures, and success.
- Add the canonical `changelog.d` fragment for #10272.

## Safety

This does not broaden authentication classification or automatic recovery behavior.

It only preserves status metadata already produced by the validator. Unknown/status-less failures remain status-less.

This complements #10218, which is merged and narrowly classifies DeepSeek business code `40003` as auth status `401`.

## Validation

Final reconciliation was completed against the active `release/v3.8.50` tip before review:

- Focused regression: **3 passed, 0 failed**
- Scoped ESLint: **PASS**
- Route validation: **PASS**
- Core typecheck: **PASS**
- Explicit-any budget: **PASS**
- Cycle check: **PASS**
- File-size gate: **PASS**
- Docs-sync: **PASS**
- Changelog integrity: **PASS**
- Tracked-artifact check: **PASS**
- Normal Husky pre-commit hook: **PASS**
- `npm ci`: **0 vulnerabilities**
- Final branch: **1 commit** directly parented to the reconciled release tip

Repository-wide `npm run lint` is currently base-red from unrelated upstream files:

- `@omniroute/opencode-plugin/src/index.ts`
- `tests/unit/cli-env-inline-comment-10100.test.ts`

The changed files pass scoped ESLint, and the observed full-lint failure remains limited to those two unrelated upstream errors.

## Tests Added Or Updated

- `tests/unit/provider-test-statuscode-propagation.test.ts`

## Reviewer Notes

The connection-test route stays small; result normalization is isolated in a sibling pure helper.

No recovery policy, OAuth behavior, or database schema is changed.
