### PR TITLE
fix(cline): preserve only client-supplied task IDs

### DIFF
--- a/changelog.d/fixes/cline-task-id-passthrough.md
+++ b/changelog.d/fixes/cline-task-id-passthrough.md
@@ -1,0 +1,1 @@
+- **fix(cline):** Preserve client-supplied Cline task IDs and omit the header when clients provide none, preventing request-scoped proxy IDs from being reported as tasks.

--- a/src/shared/utils/clineAuth.ts
+++ b/src/shared/utils/clineAuth.ts
@@ -8,8 +8,6 @@
  * must route its headers through `buildClineHeaders()`.
  */
 
-import { randomUUID } from "node:crypto";
-
 import { APP_CONFIG } from "../constants/appConfig";
 
 const APP_VERSION = APP_CONFIG.version;
@@ -41,9 +39,11 @@ function getHeaderCaseInsensitive(
   return key ? cleanHeaderValue(headers?.[key]) : undefined;
 }
 
-/** Keep an inbound Cline task id when supplied; otherwise create one per request. */
-export function resolveClineTaskId(clientHeaders?: Record<string, string> | null): string {
-  return getHeaderCaseInsensitive(clientHeaders, "x-task-id") ?? randomUUID();
+/** Keep an inbound Cline task id when supplied; never invent task identity at the proxy layer. */
+export function resolveClineTaskId(
+  clientHeaders?: Record<string, string> | null
+): string | undefined {
+  return getHeaderCaseInsensitive(clientHeaders, "x-task-id");
 }
 
 function resolveClineClientType(clientHeaders?: Record<string, string> | null): string | undefined {
@@ -53,18 +53,15 @@ function resolveClineClientType(clientHeaders?: Record<string, string> | null): 
 }
 
 /**
- * Apply the required Cline billing headers with case-insensitive replacement.
- * These fields are authoritative in the official client and must win over
- * stored/configured header layers.
+ * Apply Cline billing headers with case-insensitive replacement. Task identity
+ * is optional and may only come from the request context; stored/configured
+ * header layers must not fabricate or override it.
  */
 export function applyClineProtocolHeaders(
   headers: Record<string, string>,
   context: ClineHeaderContext = {}
 ): Record<string, string> {
-  const taskId =
-    cleanHeaderValue(context.taskId) ??
-    getHeaderCaseInsensitive(headers, "x-task-id") ??
-    randomUUID();
+  const taskId = cleanHeaderValue(context.taskId);
   const clientVersion = cleanHeaderValue(context.clientVersion) ?? APP_VERSION;
   const existingClientType = getHeaderCaseInsensitive(headers, "x-client-type");
   const clientType =
@@ -82,8 +79,12 @@ export function applyClineProtocolHeaders(
     "X-PLATFORM": cleanHeaderValue(context.platform) ?? process.platform ?? "unknown",
     "X-PLATFORM-VERSION": cleanHeaderValue(context.platformVersion) ?? process.version ?? "unknown",
     "X-CORE-VERSION": cleanHeaderValue(context.coreVersion) ?? APP_VERSION,
-    "X-Task-ID": taskId,
   };
+
+  for (const existing of Object.keys(headers)) {
+    if (existing.toLowerCase() === "x-task-id") delete headers[existing];
+  }
+  if (taskId) required["X-Task-ID"] = taskId;
 
   for (const [name, value] of Object.entries(required)) {
     for (const existing of Object.keys(headers)) {

--- a/tests/integration/cline-task-id-propagation.test.ts
+++ b/tests/integration/cline-task-id-propagation.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createChatPipelineHarness } from "./_chatPipelineHarness.ts";
+
+const harness = await createChatPipelineHarness("cline-task-id-propagation");
+const { buildRequest, cleanup, handleChat, seedConnection } = harness;
+
+function plainHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  return Object.fromEntries(new Headers(headers).entries());
+}
+
+function upstreamStream(text: string): Response {
+  return new Response(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_repro",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: { role: "assistant", content: text } }],
+      })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n"),
+    { status: 200, headers: { "Content-Type": "text/event-stream" } }
+  );
+}
+
+test.after(async () => {
+  await cleanup();
+});
+
+test("full chat pipeline omits absent task ids and preserves inbound ids", async () => {
+  await seedConnection("clinepass", { apiKey: "sk-clinepass-repro" });
+  const upstreamHeaders: Record<string, string>[] = [];
+
+  globalThis.fetch = async (_url, init = {}) => {
+    upstreamHeaders.push(plainHeaders(init.headers));
+    return upstreamStream("ok");
+  };
+
+  const send = async (headers: Record<string, string> = {}) => {
+    const response = await handleChat(
+      buildRequest({
+        headers,
+        body: {
+          model: "cp/cline-pass/glm-5.2",
+          stream: false,
+          messages: [{ role: "user", content: "task id reproduction" }],
+        },
+      })
+    );
+    await response.text();
+    assert.equal(response.status, 200);
+  };
+
+  await send();
+  await send();
+  await send({ "X-Task-ID": "client-task-123" });
+
+  assert.equal(upstreamHeaders.length, 3);
+  assert.equal(upstreamHeaders[0]["x-client-type"], "omniroute");
+  assert.equal(upstreamHeaders[1]["x-client-type"], "omniroute");
+  assert.ok(!("x-task-id" in upstreamHeaders[0]));
+  assert.ok(!("x-task-id" in upstreamHeaders[1]));
+  assert.equal(upstreamHeaders[2]["x-task-id"], "client-task-123");
+});

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -1083,7 +1083,6 @@
         "X-IS-MULTIROOT": "false",
         "X-PLATFORM": "<PLATFORM>",
         "X-PLATFORM-VERSION": "<NODE>",
-        "X-Task-ID": "<UUID>",
         "X-Title": "Cline"
       },
       "nonStream": {
@@ -1097,7 +1096,6 @@
         "X-IS-MULTIROOT": "false",
         "X-PLATFORM": "<PLATFORM>",
         "X-PLATFORM-VERSION": "<NODE>",
-        "X-Task-ID": "<UUID>",
         "X-Title": "Cline"
       },
       "oauth": {
@@ -1112,7 +1110,6 @@
         "X-IS-MULTIROOT": "false",
         "X-PLATFORM": "<PLATFORM>",
         "X-PLATFORM-VERSION": "<NODE>",
-        "X-Task-ID": "<UUID>",
         "X-Title": "Cline"
       }
     },
@@ -2141,29 +2138,6 @@
       "stream": "https://api.freeaiapikey.com/v1/chat/completions"
     }
   },
-  "freeinference": {
-    "format": "openai",
-    "headers": {
-      "apiKey": {
-        "Accept": "text/event-stream",
-        "Authorization": "Bearer <TOK>",
-        "Content-Type": "application/json"
-      },
-      "nonStream": {
-        "Authorization": "Bearer <TOK>",
-        "Content-Type": "application/json"
-      },
-      "oauth": {
-        "Accept": "text/event-stream",
-        "Authorization": "Bearer <TOK>",
-        "Content-Type": "application/json"
-      }
-    },
-    "url": {
-      "nonStream": "https://freeinference.org/v1/chat/completions",
-      "stream": "https://freeinference.org/v1/chat/completions"
-    }
-  },
   "freebuff": {
     "format": "openai",
     "headers": {
@@ -2185,6 +2159,29 @@
     "url": {
       "nonStream": "https://www.codebuff.com/api/v1",
       "stream": "https://www.codebuff.com/api/v1"
+    }
+  },
+  "freeinference": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://freeinference.org/v1/chat/completions",
+      "stream": "https://freeinference.org/v1/chat/completions"
     }
   },
   "freemodel-dev": {

--- a/tests/unit/cline-workos-auth-token-shape.test.ts
+++ b/tests/unit/cline-workos-auth-token-shape.test.ts
@@ -7,6 +7,7 @@ import {
   buildClinepassHeaders,
   getClineAccessToken,
   getClineAuthorizationHeader,
+  resolveClineTaskId,
 } from "../../src/shared/utils/clineAuth.ts";
 import { buildProviderHeaders } from "../../open-sse/services/provider.ts";
 import { DefaultExecutor } from "../../open-sse/executors/default.ts";
@@ -46,11 +47,22 @@ test("buildClineHeaders emits the full cline client header set", () => {
 });
 
 test("buildClineHeaders merges extra headers and omits Authorization with no token", () => {
-  const headers = buildClineHeaders("", { Accept: "application/json" });
+  const headers = buildClineHeaders("", {
+    Accept: "application/json",
+    "x-task-id": "configured-task-must-not-leak",
+  });
   assert.equal(headers.Accept, "application/json");
   assert.ok(!("Authorization" in headers));
+  assert.ok(!("X-Task-ID" in headers));
+  assert.ok(!("x-task-id" in headers));
   // Client-identification headers are still present even without a token.
   assert.equal(headers["X-CLIENT-TYPE"], "omniroute");
+});
+
+test("resolveClineTaskId forwards client task identity but does not invent one", () => {
+  assert.equal(resolveClineTaskId({ "x-task-id": "client-task-123" }), "client-task-123");
+  assert.equal(resolveClineTaskId({}), undefined);
+  assert.equal(resolveClineTaskId(null), undefined);
 });
 
 test("required Cline protocol headers override conflicting configured casing", () => {
@@ -109,6 +121,9 @@ test("DefaultExecutor.buildHeaders uses the cline workos auth token shape", () =
   assert.equal(headers["X-CLIENT-TYPE"], "omniroute");
   assert.equal(headers["X-Title"], "Cline");
   assert.equal(headers["X-Task-ID"], "task-from-client");
+
+  const withoutTaskId = executor.buildHeaders({ apiKey: "tok-abc" }, true, {});
+  assert.ok(!("X-Task-ID" in withoutTaskId));
 });
 
 test("DefaultExecutor labels internal health checks separately from user traffic", () => {


### PR DESCRIPTION
## What changed

- forward a sanitized inbound `X-Task-ID` for Cline and ClinePass requests
- omit `X-Task-ID` when the client did not supply one
- remove configured/stored task headers so proxy configuration cannot invent task identity
- add unit coverage for passthrough, omission, and configured-header removal
- add a full chat-pipeline regression test covering ClinePass routing and upstream headers

## Why

OmniRoute currently falls back to `randomUUID()` when a client does not send `X-Task-ID`. Because the fallback is generated once per upstream request, downstream systems can mistake independent requests for durable client tasks.

The proxy cannot infer a real task boundary for arbitrary clients. Preserving a client-provided ID and otherwise omitting the optional header keeps task identity truthful.

## Impact

- clients that provide a task ID keep the existing behavior
- clients without a task ID no longer emit fabricated request-scoped task identities
- Cline/ClinePass authentication and the remaining protocol headers are unchanged

## Validation

- pre-fix controlled pipeline reproduction: two requests without an inbound task ID emitted different UUIDs; an inbound `client-task-123` value was preserved
- post-fix focused unit + full-pipeline tests: 13/13 unit tests and 1/1 integration test passed
- `npm run typecheck:core`
- focused ESLint on all changed TypeScript files
- `npm run check:changelog-integrity`

The integration test exercises the complete request handler, provider routing, authentication-header construction, executor, and mocked upstream boundary without using a live account or incurring model usage.

### Base status

⚠️ base-red inherited: [#9985](https://github.com/diegosouzapw/OmniRoute/issues/9985)

Full-repository `npm run lint` also reaches two unrelated errors already present outside this diff (`@omniroute/opencode-plugin/src/index.ts:5481` and `tests/unit/cli-env-inline-comment-10100.test.ts:35`). Focused lint for every changed TypeScript file passes.

## Test files

- `tests/unit/cline-workos-auth-token-shape.test.ts`
- `tests/integration/cline-task-id-propagation.test.ts`
