### PR TITLE
fix(settings): default debugMode to false

### DIFF
--- a/changelog.d/fixes/debugmode-default-false.md
+++ b/changelog.d/fixes/debugmode-default-false.md
@@ -1,0 +1,1 @@
+- **fix(settings):** default `debugMode` to false so installs without a persisted key are not in debug (`src/lib/db/settings.ts`)

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -212,7 +212,7 @@ export async function getSettings() {
     idempotencyWindowMs: 5000,
     wsAuth: false,
     maxBodySizeMb: requestBodyLimitMbFromEnv(process.env.MAX_BODY_SIZE_BYTES),
-    debugMode: true,
+    debugMode: false,
     // Opt-in diagnostic: when true, the chat handler emits a `log.debug("TOOLS", …)`
     // line per request summarizing tool count + MCP/hosted/client source breakdown.
     logToolSources: false,

--- a/tests/unit/debugmode-default-false.test.ts
+++ b/tests/unit/debugmode-default-false.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-debugmode-default-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const settings = await import("../../src/lib/db/settings.ts");
+
+test.after(() => {
+  try {
+    core.closeDbInstance();
+  } catch {}
+  core.resetDbInstance();
+});
+
+test("getSettings defaults debugMode to false", async () => {
+  core.resetDbInstance();
+  core.getDbInstance();
+  const result = await settings.getSettings();
+  assert.strictEqual(result.debugMode, false);
+});
+
+test("getSettings debugMode default persists across reads", async () => {
+  core.resetDbInstance();
+  core.getDbInstance();
+  const first = await settings.getSettings();
+  const second = await settings.getSettings();
+  assert.strictEqual(first.debugMode, false);
+  assert.strictEqual(second.debugMode, false);
+});


### PR DESCRIPTION
## Summary

- `getSettings()` seeds `debugMode: true` before overlaying sqlite. A missing key means **production debug logging is on**.
- CONTRIBUTING documents Debug Mode as an Advanced **opt-in** toggle.
- Default is now `false`. Persisted `true` is unchanged.

## Validation

- [x] Docs-only change (no production code) — N/A (one-line default + changelog)
- Existing settings tests that PATCH `debugMode: true` still apply.

## Reviewer Notes

No secrets. Behavior change only for installs that never persisted the key.
