### PR TITLE
fix(i18n): unflatten dotted namespace keys in resilienceConnections and capabilityFilter

### DIFF
--- a/scripts/ad-hoc/find-dotted-i18n-keys.mjs
+++ b/scripts/ad-hoc/find-dotted-i18n-keys.mjs
@@ -1,0 +1,34 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const dir = "src/i18n/messages";
+const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+
+const patterns = new Map();
+
+for (const file of files) {
+  const full = path.join(dir, file);
+  const data = JSON.parse(readFileSync(full, "utf8"));
+
+  function walk(obj, prefix) {
+    if (obj === null || typeof obj !== "object") return;
+    for (const key of Object.keys(obj)) {
+      if (key.includes(".")) {
+        const full = prefix ? `${prefix}.${key}` : key;
+        if (!patterns.has(full)) patterns.set(full, new Set());
+        patterns.get(full).add(file);
+      }
+      const val = obj[key];
+      if (val !== null && typeof val === "object") {
+        walk(val, prefix ? `${prefix}.${key}` : key);
+      }
+    }
+  }
+  walk(data, "");
+}
+
+console.log(`Files scanned: ${files.length}`);
+console.log(`Distinct dotted-key paths found: ${patterns.size}\n`);
+for (const [key, fileSet] of [...patterns.entries()].sort()) {
+  console.log(`${key}  (in ${fileSet.size} files)`);
+}

--- a/scripts/ad-hoc/fix-dotted-i18n-keys.mjs
+++ b/scripts/ad-hoc/fix-dotted-i18n-keys.mjs
@@ -1,0 +1,87 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const dir = "src/i18n/messages";
+const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+
+const CAP_KEYS = [
+  "visionMismatch",
+  "toolsMismatch",
+  "structuredOutputMismatch",
+  "contextWindowMismatch",
+];
+const DEGRADED_SOURCE_KEYS = ["database", "circuitBreaker", "modelLockouts", "count"];
+
+function fixTopLevelCapabilityFilter(root) {
+  const prefix = "capabilityFilter.";
+  const entries = Object.entries(root);
+  const hasDotted = entries.some(([k]) => k.startsWith(prefix));
+  if (!hasDotted) return root;
+
+  const out = {};
+  let inserted = false;
+  for (const [key, value] of entries) {
+    if (key.startsWith(prefix)) {
+      if (!inserted) {
+        const nested = {};
+        for (const sub of CAP_KEYS) {
+          const full = prefix + sub;
+          if (full in root) nested[sub] = root[full];
+        }
+        out.capabilityFilter = nested;
+        inserted = true;
+      }
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function fixResilienceDegradedSource(root) {
+  const rc = root.resilienceConnections;
+  if (!rc || typeof rc !== "object") return root;
+
+  const prefix = "degraded.source.";
+  const entries = Object.entries(rc);
+  const hasDotted = entries.some(([k]) => k.startsWith(prefix));
+  if (!hasDotted) return root;
+
+  const out = {};
+  let inserted = false;
+  for (const [key, value] of entries) {
+    if (key.startsWith(prefix)) {
+      if (!inserted) {
+        const nested = {};
+        for (const sub of DEGRADED_SOURCE_KEYS) {
+          const full = prefix + sub;
+          if (full in rc) nested[sub] = rc[full];
+        }
+        out.degradedSource = nested;
+        inserted = true;
+      }
+      continue;
+    }
+    out[key] = value;
+  }
+
+  return { ...root, resilienceConnections: out };
+}
+
+let changedCount = 0;
+for (const file of files) {
+  const full = path.join(dir, file);
+  const raw = readFileSync(full, "utf8");
+  const data = JSON.parse(raw);
+
+  let next = fixTopLevelCapabilityFilter(data);
+  next = fixResilienceDegradedSource(next);
+
+  const serialized = JSON.stringify(next, null, 2);
+  if (serialized !== JSON.stringify(data, null, 2)) {
+    writeFileSync(full, serialized, "utf8");
+    changedCount += 1;
+  }
+}
+
+console.log(`Fixed ${changedCount}/${files.length} locale files.`);

--- a/scripts/ad-hoc/validate-locale-json.mjs
+++ b/scripts/ad-hoc/validate-locale-json.mjs
@@ -1,0 +1,18 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const dir = "src/i18n/messages";
+const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+let invalid = 0;
+
+for (const file of files) {
+  const full = path.join(dir, file);
+  try {
+    JSON.parse(readFileSync(full, "utf8"));
+  } catch (e) {
+    invalid += 1;
+    console.log(`INVALID: ${file}: ${e.message}`);
+  }
+}
+
+console.log(`${files.length - invalid}/${files.length} valid`);

--- a/src/app/(dashboard)/dashboard/resilience/connections/components/ResilienceConnectionsClient.tsx
+++ b/src/app/(dashboard)/dashboard/resilience/connections/components/ResilienceConnectionsClient.tsx
@@ -186,7 +186,7 @@ export default function ResilienceConnectionsClient() {
           }}
         >
           {t("degraded", {
-            sources: data.meta.degraded.map((s) => t(`degraded.source.${s}`)).join(", "),
+            sources: data.meta.degraded.map((s) => t(`degradedSource.${s}`)).join(", "),
           })}
         </div>
       )}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "توقف الاستطلاع: رفض الخادم الطلب (404/403).",
     "pollErrorTransient": "خطأ في جلب البيانات: إعادة المحاولة تلقائيًا.",
     "degraded": "بيانات جزئية: مصادر غير متاحة: {sources}",
-    "degraded.source.database": "قاعدة البيانات",
-    "degraded.source.circuitBreaker": "قاطع الدائرة",
-    "degraded.source.modelLockouts": "حظر النماذج",
-    "degraded.source.count": "عدد الاتصالات"
+    "degradedSource": {
+      "database": "قاعدة البيانات",
+      "circuitBreaker": "قاطع الدائرة",
+      "modelLockouts": "حظر النماذج",
+      "count": "عدد الاتصالات"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "رفض الطلبات قبل الإرسال عندما يفتقر النموذج المستهدف إلى القدرات المطلوبة (الرؤية، الأدوات، المخرجات المنظمة، نافذة السياق). يحمي الطلبات المباشرة من مزود واحد التي تتجاوز فلتر توافق الطبقة المجمعة.",
-  "capabilityFilter.visionMismatch": "المزود لا يدعم الرؤية لطلب الصورة هذا",
-  "capabilityFilter.toolsMismatch": "المزود لا يدعم استدعاء الأداة",
-  "capabilityFilter.structuredOutputMismatch": "المزود لا يدعم الإخراج المنظم",
-  "capabilityFilter.contextWindowMismatch": "تجاوز الطلب نافذة سياق المزود",
+  "capabilityFilter": {
+    "visionMismatch": "المزود لا يدعم الرؤية لطلب الصورة هذا",
+    "toolsMismatch": "المزود لا يدعم استدعاء الأداة",
+    "structuredOutputMismatch": "المزود لا يدعم الإخراج المنظم",
+    "contextWindowMismatch": "تجاوز الطلب نافذة سياق المزود"
+  },
   "publicSystem": {
     "notFound": {
       "title": "الصفحة غير موجودة",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Sorğu dayandırıldı: server sorğunu rədd etdi (404/403).",
     "pollErrorTransient": "Məlumat alarkən xəta: avtomatik yenidən cəhd edilir.",
     "degraded": "Qismən məlumat: əlçatmaz mənbələr: {sources}",
-    "degraded.source.database": "Verilənlər Bazası",
-    "degraded.source.circuitBreaker": "Dövrə Açarı",
-    "degraded.source.modelLockouts": "Model Blokları",
-    "degraded.source.count": "Bağlantı Sayı"
+    "degradedSource": {
+      "database": "Verilənlər Bazası",
+      "circuitBreaker": "Dövrə Açarı",
+      "modelLockouts": "Model Blokları",
+      "count": "Bağlantı Sayı"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Tələb olunan imkanlar (görmə, alətlər, strukturlaşdırılmış çıxış, kontekst pəncərəsi) olmayan hədəf modelində göndərilmədən əvvəl tələbləri rədd edin. Kombinasiya qatının uyğunluq filtrini keçən birbaşa tək təminatçı tələblərini qoruyur.",
-  "capabilityFilter.visionMismatch": "Təchizatçı bu şəkil tələbi üçün görünüşü dəstəkləmir",
-  "capabilityFilter.toolsMismatch": "Təchizatçı alət çağırışını dəstəkləmir",
-  "capabilityFilter.structuredOutputMismatch": "Təchizatçı strukturlaşdırılmış çıxışı dəstəkləmir",
-  "capabilityFilter.contextWindowMismatch": "Sorğu təminatçının kontekst pəncərəsini aşır",
+  "capabilityFilter": {
+    "visionMismatch": "Təchizatçı bu şəkil tələbi üçün görünüşü dəstəkləmir",
+    "toolsMismatch": "Təchizatçı alət çağırışını dəstəkləmir",
+    "structuredOutputMismatch": "Təchizatçı strukturlaşdırılmış çıxışı dəstəkləmir",
+    "contextWindowMismatch": "Sorğu təminatçının kontekst pəncərəsini aşır"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Səhifə tapılmadı",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Запитването е спряно: сървърът отхвърли заявката (404/403).",
     "pollErrorTransient": "Грешка при извличане на данни: автоматичен повторен опит.",
     "degraded": "Частични данни: недостъпни източници: {sources}",
-    "degraded.source.database": "База Данни",
-    "degraded.source.circuitBreaker": "Прекъсвач",
-    "degraded.source.modelLockouts": "Заключвания на Модел",
-    "degraded.source.count": "Брой Връзки"
+    "degradedSource": {
+      "database": "База Данни",
+      "circuitBreaker": "Прекъсвач",
+      "modelLockouts": "Заключвания на Модел",
+      "count": "Брой Връзки"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Отхвърлете заявките преди изпращане, когато целевият модел няма необходимите възможности (визия, инструменти, структурирани изходи, контекстен прозорец). Защитава директните заявки от един доставчик, които заобикалят филтъра за съвместимост на комбинирания слой.",
-  "capabilityFilter.visionMismatch": "Доставчикът не поддържа визуализация за тази заявка за изображение",
-  "capabilityFilter.toolsMismatch": "Доставчикът не поддържа извикване на инструменти",
-  "capabilityFilter.structuredOutputMismatch": "Доставчикът не поддържа структурирано изходно съдържание",
-  "capabilityFilter.contextWindowMismatch": "Заявката надвишава контекстния прозорец на доставчика",
+  "capabilityFilter": {
+    "visionMismatch": "Доставчикът не поддържа визуализация за тази заявка за изображение",
+    "toolsMismatch": "Доставчикът не поддържа извикване на инструменти",
+    "structuredOutputMismatch": "Доставчикът не поддържа структурирано изходно съдържание",
+    "contextWindowMismatch": "Заявката надвишава контекстния прозорец на доставчика"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Страницата не е намерена",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "পোলিং বন্ধ: সার্ভার অনুরোধ প্রত্যাখ্যান করেছে (404/403)।",
     "pollErrorTransient": "ডেটা আনতে ত্রুটি: স্বয়ংক্রিয়ভাবে পুনরায় চেষ্টা করা হচ্ছে।",
     "degraded": "আংশিক ডেটা: অনুপলব্ধ উৎস: {sources}",
-    "degraded.source.database": "ডাটাবেস",
-    "degraded.source.circuitBreaker": "সার্কিট ব্রেকার",
-    "degraded.source.modelLockouts": "মডেল লকআউট",
-    "degraded.source.count": "সংযোগ সংখ্যা"
+    "degradedSource": {
+      "database": "ডাটাবেস",
+      "circuitBreaker": "সার্কিট ব্রেকার",
+      "modelLockouts": "মডেল লকআউট",
+      "count": "সংযোগ সংখ্যা"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "লক্ষ্য মডেলের প্রয়োজনীয় সক্ষমতা (দৃষ্টি, সরঞ্জাম, কাঠামোবদ্ধ আউটপুট, প্রসঙ্গ উইন্ডো) অনুপস্থিত থাকলে প্রেরণের আগে অনুরোধগুলি প্রত্যাখ্যান করুন। এটি কম্বো-লেয়ার সামঞ্জস্য ফিল্টারকে বাইপাস করা সরাসরি একক-প্রদানকারী অনুরোধগুলি রক্ষা করে।",
-  "capabilityFilter.visionMismatch": "এই চিত্রের অনুরোধের জন্য প্রদানকারী ভিশন সমর্থন করে না",
-  "capabilityFilter.toolsMismatch": "প্রদানকারী টুল কলিং সমর্থন করে না",
-  "capabilityFilter.structuredOutputMismatch": "প্রোভাইডার স্ট্রাকচারড আউটপুট সমর্থন করে না",
-  "capabilityFilter.contextWindowMismatch": "অনুরোধটি প্রদানকারীর প্রসঙ্গ উইন্ডো অতিক্রম করেছে",
+  "capabilityFilter": {
+    "visionMismatch": "এই চিত্রের অনুরোধের জন্য প্রদানকারী ভিশন সমর্থন করে না",
+    "toolsMismatch": "প্রদানকারী টুল কলিং সমর্থন করে না",
+    "structuredOutputMismatch": "প্রোভাইডার স্ট্রাকচারড আউটপুট সমর্থন করে না",
+    "contextWindowMismatch": "অনুরোধটি প্রদানকারীর প্রসঙ্গ উইন্ডো অতিক্রম করেছে"
+  },
   "publicSystem": {
     "notFound": {
       "title": "পৃষ্ঠা পাওয়া যায়নি",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Dotazování zastaveno: server odmítl požadavek (404/403).",
     "pollErrorTransient": "Chyba při načítání dat: automatické opakování.",
     "degraded": "Částečná data: nedostupné zdroje: {sources}",
-    "degraded.source.database": "Databáze",
-    "degraded.source.circuitBreaker": "Jistič",
-    "degraded.source.modelLockouts": "Uzamčení Modelu",
-    "degraded.source.count": "Počet Připojení"
+    "degradedSource": {
+      "database": "Databáze",
+      "circuitBreaker": "Jistič",
+      "modelLockouts": "Uzamčení Modelu",
+      "count": "Počet Připojení"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Odmítnout požadavky před odesláním, když cílový model postrádá požadované schopnosti (vidění, nástroje, strukturovaný výstup, kontextové okno). Chrání přímé požadavky od jednotlivých poskytovatelů, které obcházejí filtr kompatibility kombinované vrstvy.",
-  "capabilityFilter.visionMismatch": "Poskytovatel nepodporuje zobrazení pro tento požadavek na obrázek",
-  "capabilityFilter.toolsMismatch": "Poskytovatel nepodporuje volání nástroje",
-  "capabilityFilter.structuredOutputMismatch": "Poskytovatel nepodporuje strukturovaný výstup",
-  "capabilityFilter.contextWindowMismatch": "Žádost překračuje kontextové okno poskytovatele",
+  "capabilityFilter": {
+    "visionMismatch": "Poskytovatel nepodporuje zobrazení pro tento požadavek na obrázek",
+    "toolsMismatch": "Poskytovatel nepodporuje volání nástroje",
+    "structuredOutputMismatch": "Poskytovatel nepodporuje strukturovaný výstup",
+    "contextWindowMismatch": "Žádost překračuje kontextové okno poskytovatele"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Stránka nebyla nalezena",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling stoppet: serveren afviste anmodningen (404/403).",
     "pollErrorTransient": "Fejl ved hentning af data: forsøger automatisk igen.",
     "degraded": "Delvise data: utilgængelige kilder: {sources}",
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Afbryder",
-    "degraded.source.modelLockouts": "Modellåsninger",
-    "degraded.source.count": "Antal Forbindelser"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Afbryder",
+      "modelLockouts": "Modellåsninger",
+      "count": "Antal Forbindelser"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Afvis anmodninger før afsendelse, når målmodellen mangler de nødvendige funktioner (vision, værktøjer, struktureret output, kontekstvindue). Beskytter direkte anmodninger fra en enkelt udbyder, der omgår kombinationslagets kompatibilitetsfilter.",
-  "capabilityFilter.visionMismatch": "Udbyderen understøtter ikke vision for denne billedanmodning",
-  "capabilityFilter.toolsMismatch": "Udbyderen understøtter ikke værktøjsopkald.",
-  "capabilityFilter.structuredOutputMismatch": "Udbyderen understøtter ikke struktureret output",
-  "capabilityFilter.contextWindowMismatch": "Anmodningen overskrider udbyderens kontekstvindue",
+  "capabilityFilter": {
+    "visionMismatch": "Udbyderen understøtter ikke vision for denne billedanmodning",
+    "toolsMismatch": "Udbyderen understøtter ikke værktøjsopkald.",
+    "structuredOutputMismatch": "Udbyderen understøtter ikke struktureret output",
+    "contextWindowMismatch": "Anmodningen overskrider udbyderens kontekstvindue"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Siden blev ikke fundet",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Abfrage gestoppt: Der Server hat die Anfrage abgelehnt (404/403).",
     "pollErrorTransient": "Fehler beim Abrufen der Daten: automatischer erneuter Versuch.",
     "degraded": "Teildaten: nicht verfügbare Quellen: {sources}",
-    "degraded.source.database": "Datenbank",
-    "degraded.source.circuitBreaker": "Leistungsschalter",
-    "degraded.source.modelLockouts": "Modellsperren",
-    "degraded.source.count": "Verbindungsanzahl"
+    "degradedSource": {
+      "database": "Datenbank",
+      "circuitBreaker": "Leistungsschalter",
+      "modelLockouts": "Modellsperren",
+      "count": "Verbindungsanzahl"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Lehnen Sie Anfragen ab, bevor sie versendet werden, wenn das Zielmodell über die erforderlichen Funktionen (Vision, Werkzeuge, strukturierte Ausgabe, Kontextfenster) nicht verfügt. Schützt direkte Einzelanbieteranfragen, die den Kombo-Schicht-Kompatibilitätsfilter umgehen.",
-  "capabilityFilter.visionMismatch": "Der Anbieter unterstützt die Vision für diese Bildanfrage nicht",
-  "capabilityFilter.toolsMismatch": "Der Anbieter unterstützt keinen Toolaufruf",
-  "capabilityFilter.structuredOutputMismatch": "Der Anbieter unterstützt keine strukturierten Ausgaben",
-  "capabilityFilter.contextWindowMismatch": "Anfrage überschreitet das Kontextfenster des Anbieters",
+  "capabilityFilter": {
+    "visionMismatch": "Der Anbieter unterstützt die Vision für diese Bildanfrage nicht",
+    "toolsMismatch": "Der Anbieter unterstützt keinen Toolaufruf",
+    "structuredOutputMismatch": "Der Anbieter unterstützt keine strukturierten Ausgaben",
+    "contextWindowMismatch": "Anfrage überschreitet das Kontextfenster des Anbieters"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Seite nicht gefunden",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling stopped: the server rejected the request (404/403).",
     "pollErrorTransient": "Error fetching data: retrying automatically.",
     "degraded": "Partial data: unavailable sources: {sources}",
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Model Lockouts",
-    "degraded.source.count": "Connection Count"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Model Lockouts",
+      "count": "Connection Count"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Reject requests before dispatch when the target model lacks required capabilities (vision, tools, structured output, context window). Protects direct single-provider requests that bypass the combo-layer compatibility filter.",
-  "capabilityFilter.visionMismatch": "Provider does not support vision for this image request",
-  "capabilityFilter.toolsMismatch": "Provider does not support tool calling",
-  "capabilityFilter.structuredOutputMismatch": "Provider does not support structured output",
-  "capabilityFilter.contextWindowMismatch": "Request exceeds provider context window",
+  "capabilityFilter": {
+    "visionMismatch": "Provider does not support vision for this image request",
+    "toolsMismatch": "Provider does not support tool calling",
+    "structuredOutputMismatch": "Provider does not support structured output",
+    "contextWindowMismatch": "Request exceeds provider context window"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Page not found",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Sondeo detenido: el servidor rechazó la solicitud (404/403).",
     "pollErrorTransient": "Error al obtener datos: reintentando automáticamente.",
     "degraded": "Datos parciales: fuentes no disponibles: {sources}",
-    "degraded.source.database": "Base de Datos",
-    "degraded.source.circuitBreaker": "Disyuntor",
-    "degraded.source.modelLockouts": "Bloqueos de Modelo",
-    "degraded.source.count": "Cantidad de Conexiones"
+    "degradedSource": {
+      "database": "Base de Datos",
+      "circuitBreaker": "Disyuntor",
+      "modelLockouts": "Bloqueos de Modelo",
+      "count": "Cantidad de Conexiones"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Rechazar solicitudes antes del despacho cuando el modelo objetivo carece de capacidades requeridas (visión, herramientas, salida estructurada, ventana de contexto). Protege las solicitudes directas de un solo proveedor que eluden el filtro de compatibilidad de la capa combinada.",
-  "capabilityFilter.visionMismatch": "El proveedor no admite visión para esta solicitud de imagen",
-  "capabilityFilter.toolsMismatch": "El proveedor no admite la llamada a la herramienta",
-  "capabilityFilter.structuredOutputMismatch": "El proveedor no admite salida estructurada",
-  "capabilityFilter.contextWindowMismatch": "La solicitud excede la ventana de contexto del proveedor",
+  "capabilityFilter": {
+    "visionMismatch": "El proveedor no admite visión para esta solicitud de imagen",
+    "toolsMismatch": "El proveedor no admite la llamada a la herramienta",
+    "structuredOutputMismatch": "El proveedor no admite salida estructurada",
+    "contextWindowMismatch": "La solicitud excede la ventana de contexto del proveedor"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Página no encontrada",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "نظرسنجی متوقف شد: سرور درخواست را رد کرد (404/403).",
     "pollErrorTransient": "خطا در دریافت داده: تلاش مجدد خودکار.",
     "degraded": "داده ناقص: منابع در دسترس نیست: {sources}",
-    "degraded.source.database": "پایگاه داده",
-    "degraded.source.circuitBreaker": "قطع‌کننده مدار",
-    "degraded.source.modelLockouts": "قفل‌های مدل",
-    "degraded.source.count": "تعداد اتصالات"
+    "degradedSource": {
+      "database": "پایگاه داده",
+      "circuitBreaker": "قطع‌کننده مدار",
+      "modelLockouts": "قفل‌های مدل",
+      "count": "تعداد اتصالات"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "درخواست‌ها را قبل از ارسال رد کنید زمانی که مدل هدف قابلیت‌های مورد نیاز (بینایی، ابزارها، خروجی ساختاریافته، پنجره زمینه) را ندارد. از درخواست‌های مستقیم تک‌تأمین‌کننده که فیلتر سازگاری لایه ترکیبی را دور می‌زنند، محافظت می‌کند.",
-  "capabilityFilter.visionMismatch": "ارائه‌دهنده برای این درخواست تصویر از بینایی پشتیبانی نمی‌کند",
-  "capabilityFilter.toolsMismatch": "ارائه‌دهنده از فراخوانی ابزار پشتیبانی نمی‌کند",
-  "capabilityFilter.structuredOutputMismatch": "ارائه‌دهنده خروجی ساختاریافته را پشتیبانی نمی‌کند",
-  "capabilityFilter.contextWindowMismatch": "درخواست از حد مجاز پنجره زمینه ارائه‌دهنده فراتر می‌رود",
+  "capabilityFilter": {
+    "visionMismatch": "ارائه‌دهنده برای این درخواست تصویر از بینایی پشتیبانی نمی‌کند",
+    "toolsMismatch": "ارائه‌دهنده از فراخوانی ابزار پشتیبانی نمی‌کند",
+    "structuredOutputMismatch": "ارائه‌دهنده خروجی ساختاریافته را پشتیبانی نمی‌کند",
+    "contextWindowMismatch": "درخواست از حد مجاز پنجره زمینه ارائه‌دهنده فراتر می‌رود"
+  },
   "publicSystem": {
     "notFound": {
       "title": "صفحه پیدا نشد",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Kysely pysäytetty: palvelin hylkäsi pyynnön (404/403).",
     "pollErrorTransient": "Virhe tietojen haussa: yritetään automaattisesti uudelleen.",
     "degraded": "Osittaiset tiedot: käyttökelvottomat lähteet: {sources}",
-    "degraded.source.database": "Tietokanta",
-    "degraded.source.circuitBreaker": "Piirikatkaisija",
-    "degraded.source.modelLockouts": "Mallilukitukset",
-    "degraded.source.count": "Yhteyksien Määrä"
+    "degradedSource": {
+      "database": "Tietokanta",
+      "circuitBreaker": "Piirikatkaisija",
+      "modelLockouts": "Mallilukitukset",
+      "count": "Yhteyksien Määrä"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Hylkää pyynnöt ennen lähettämistä, kun kohdemallilta puuttuu vaadittuja ominaisuuksia (näkö, työkalut, jäsennelty ulostulo, kontekstikkelu). Suojaa suorat yhden tarjoajan pyynnöt, jotka ohittavat yhdistelmäkerroksen yhteensopivuussuodattimen.",
-  "capabilityFilter.visionMismatch": "Palveluntarjoaja ei tue näkymää tälle kuvapyynnölle",
-  "capabilityFilter.toolsMismatch": "Toimittaja ei tue työkalun kutsumista",
-  "capabilityFilter.structuredOutputMismatch": "Palveluntarjoaja ei tue jäsenneltyä tulostusta",
-  "capabilityFilter.contextWindowMismatch": "Pyyntö ylittää tarjoajan kontekstin ikkunan",
+  "capabilityFilter": {
+    "visionMismatch": "Palveluntarjoaja ei tue näkymää tälle kuvapyynnölle",
+    "toolsMismatch": "Toimittaja ei tue työkalun kutsumista",
+    "structuredOutputMismatch": "Palveluntarjoaja ei tue jäsenneltyä tulostusta",
+    "contextWindowMismatch": "Pyyntö ylittää tarjoajan kontekstin ikkunan"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Sivua ei löytynyt",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Sondage arrêté : le serveur a rejeté la requête (404/403).",
     "pollErrorTransient": "Erreur lors de la récupération des données : nouvelle tentative automatique.",
     "degraded": "Données partielles : sources indisponibles : {sources}",
-    "degraded.source.database": "Base de Données",
-    "degraded.source.circuitBreaker": "Disjoncteur",
-    "degraded.source.modelLockouts": "Blocages de Modèle",
-    "degraded.source.count": "Nombre de Connexions"
+    "degradedSource": {
+      "database": "Base de Données",
+      "circuitBreaker": "Disjoncteur",
+      "modelLockouts": "Blocages de Modèle",
+      "count": "Nombre de Connexions"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Rejeter les demandes avant l'expédition lorsque le modèle cible manque des capacités requises (vision, outils, sortie structurée, fenêtre de contexte). Protège les demandes directes à un seul fournisseur qui contournent le filtre de compatibilité de la couche combo.",
-  "capabilityFilter.visionMismatch": "Le fournisseur ne prend pas en charge la vision pour cette demande d'image",
-  "capabilityFilter.toolsMismatch": "Le fournisseur ne prend pas en charge l'appel d'outils",
-  "capabilityFilter.structuredOutputMismatch": "Le fournisseur ne prend pas en charge la sortie structurée",
-  "capabilityFilter.contextWindowMismatch": "La demande dépasse la fenêtre de contexte du fournisseur",
+  "capabilityFilter": {
+    "visionMismatch": "Le fournisseur ne prend pas en charge la vision pour cette demande d'image",
+    "toolsMismatch": "Le fournisseur ne prend pas en charge l'appel d'outils",
+    "structuredOutputMismatch": "Le fournisseur ne prend pas en charge la sortie structurée",
+    "contextWindowMismatch": "La demande dépasse la fenêtre de contexte du fournisseur"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Page introuvable",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "પોલિંગ બંધ: સર્વરે વિનંતી નકારી (404/403).",
     "pollErrorTransient": "ડેટા મેળવવામાં ભૂલ: આપમેળે ફરી પ્રયાસ કરી રહ્યાં છીએ.",
     "degraded": "આંશિક ડેટા: અનુપલબ્ધ સ્રોત: {sources}",
-    "degraded.source.database": "ડેટાબેઝ",
-    "degraded.source.circuitBreaker": "સર્કિટ બ્રેકર",
-    "degraded.source.modelLockouts": "મોડેલ લોકઆઉટ",
-    "degraded.source.count": "કનેક્શન ગણતરી"
+    "degradedSource": {
+      "database": "ડેટાબેઝ",
+      "circuitBreaker": "સર્કિટ બ્રેકર",
+      "modelLockouts": "મોડેલ લોકઆઉટ",
+      "count": "કનેક્શન ગણતરી"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "જ્યારે લક્ષ્ય મોડેલમાં જરૂરી ક્ષમતાઓ (દૃષ્ટિ, સાધનો, રચિત આઉટપુટ, સંદર્ભ વિન્ડો) નથી ત્યારે વિતરણ પહેલાં વિનંતીઓને નકારી નાખો. કોમ્બો-લેયર સુસંગતતા ફિલ્ટરને બાયપાસ કરતી સીધી એકલ-પ્રદાતા વિનંતિઓને સુરક્ષિત કરે છે.",
-  "capabilityFilter.visionMismatch": "આ છબીની વિનંતી માટે પ્રદાતા દ્રષ્ટિનું સમર્થન નથી આપતું",
-  "capabilityFilter.toolsMismatch": "પ્રદાતા ટૂલ કોલિંગને સપોર્ટ કરતો નથી",
-  "capabilityFilter.structuredOutputMismatch": "પ્રદાતા સંરચિત આઉટપુટને સમર્થન આપતો નથી",
-  "capabilityFilter.contextWindowMismatch": "વિનંતી પ્રદાતા સંદર્ભ વિન્ડોને પાર કરે છે",
+  "capabilityFilter": {
+    "visionMismatch": "આ છબીની વિનંતી માટે પ્રદાતા દ્રષ્ટિનું સમર્થન નથી આપતું",
+    "toolsMismatch": "પ્રદાતા ટૂલ કોલિંગને સપોર્ટ કરતો નથી",
+    "structuredOutputMismatch": "પ્રદાતા સંરચિત આઉટપુટને સમર્થન આપતો નથી",
+    "contextWindowMismatch": "વિનંતી પ્રદાતા સંદર્ભ વિન્ડોને પાર કરે છે"
+  },
   "publicSystem": {
     "notFound": {
       "title": "પૃષ્ઠ મળ્યું નથી",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "הסקר הופסק: השרת דחה את הבקשה (404/403).",
     "pollErrorTransient": "שגיאה באחזור נתונים: ניסיון חוזר אוטומטי.",
     "degraded": "נתונים חלקיים: מקורות לא זמינים: {sources}",
-    "degraded.source.database": "מסד נתונים",
-    "degraded.source.circuitBreaker": "נתיק מעגל",
-    "degraded.source.modelLockouts": "נעילות מודל",
-    "degraded.source.count": "מספר חיבורים"
+    "degradedSource": {
+      "database": "מסד נתונים",
+      "circuitBreaker": "נתיק מעגל",
+      "modelLockouts": "נעילות מודל",
+      "count": "מספר חיבורים"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "דחה בקשות לפני שליחה כאשר המודל המטרה חסר יכולות נדרשות (חזון, כלים, פלט מובנה, חלון הקשר). מגן על בקשות ישירות מספק אחד שעוקפות את מסנן ההתאמה של שכבת הקומבו.",
-  "capabilityFilter.visionMismatch": "הספק אינו תומך בראייה עבור בקשה זו של תמונה",
-  "capabilityFilter.toolsMismatch": "הספק אינו תומך בקריאת כלים",
-  "capabilityFilter.structuredOutputMismatch": "הספק אינו תומך בפלט מובנה",
-  "capabilityFilter.contextWindowMismatch": "הבקשה חורגת מגבול ההקשר של הספק",
+  "capabilityFilter": {
+    "visionMismatch": "הספק אינו תומך בראייה עבור בקשה זו של תמונה",
+    "toolsMismatch": "הספק אינו תומך בקריאת כלים",
+    "structuredOutputMismatch": "הספק אינו תומך בפלט מובנה",
+    "contextWindowMismatch": "הבקשה חורגת מגבול ההקשר של הספק"
+  },
   "publicSystem": {
     "notFound": {
       "title": "העמוד לא נמצא",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "पोलिंग रुकी: सर्वर ने अनुरोध अस्वीकार किया (404/403)।",
     "pollErrorTransient": "डेटा प्राप्त करने में त्रुटि: स्वतः पुनः प्रयास।",
     "degraded": "आंशिक डेटा: अनुपलब्ध स्रोत: {sources}",
-    "degraded.source.database": "डेटाबेस",
-    "degraded.source.circuitBreaker": "सर्किट ब्रेकर",
-    "degraded.source.modelLockouts": "मॉडल लॉकआउट",
-    "degraded.source.count": "कनेक्शन गणना"
+    "degradedSource": {
+      "database": "डेटाबेस",
+      "circuitBreaker": "सर्किट ब्रेकर",
+      "modelLockouts": "मॉडल लॉकआउट",
+      "count": "कनेक्शन गणना"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "डिस्पैच से पहले अनुरोधों को अस्वीकार करें जब लक्षित मॉडल आवश्यक क्षमताओं (दृष्टि, उपकरण, संरचित आउटपुट, संदर्भ विंडो) से रहित हो। यह सीधे एकल-प्रदाता अनुरोधों की रक्षा करता है जो कॉम्बो-लेयर संगतता फ़िल्टर को बायपास करते हैं।",
-  "capabilityFilter.visionMismatch": "प्रदाता इस छवि अनुरोध के लिए दृष्टि का समर्थन नहीं करता",
-  "capabilityFilter.toolsMismatch": "प्रदाता टूल कॉलिंग का समर्थन नहीं करता",
-  "capabilityFilter.structuredOutputMismatch": "प्रदाता संरचित आउटपुट का समर्थन नहीं करता",
-  "capabilityFilter.contextWindowMismatch": "अनुरोध प्रदाता संदर्भ विंडो से अधिक है",
+  "capabilityFilter": {
+    "visionMismatch": "प्रदाता इस छवि अनुरोध के लिए दृष्टि का समर्थन नहीं करता",
+    "toolsMismatch": "प्रदाता टूल कॉलिंग का समर्थन नहीं करता",
+    "structuredOutputMismatch": "प्रदाता संरचित आउटपुट का समर्थन नहीं करता",
+    "contextWindowMismatch": "अनुरोध प्रदाता संदर्भ विंडो से अधिक है"
+  },
   "publicSystem": {
     "notFound": {
       "title": "पृष्ठ नहीं मिला",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Lekérdezés leállítva: a szerver elutasította a kérést (404/403).",
     "pollErrorTransient": "Hiba az adatok lekérésekor: automatikus újrapróbálkozás.",
     "degraded": "Részleges adatok: nem elérhető források: {sources}",
-    "degraded.source.database": "Adatbázis",
-    "degraded.source.circuitBreaker": "Megszakító",
-    "degraded.source.modelLockouts": "Modell Zárolások",
-    "degraded.source.count": "Kapcsolatok Száma"
+    "degradedSource": {
+      "database": "Adatbázis",
+      "circuitBreaker": "Megszakító",
+      "modelLockouts": "Modell Zárolások",
+      "count": "Kapcsolatok Száma"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Elutasítja a kéréseket a kiszállítás előtt, amikor a célmodell hiányzik a szükséges képességekből (látás, eszközök, strukturált kimenet, kontextusablak). Védi a közvetlen, egy szolgáltatótól érkező kéréseket, amelyek megkerülik a kombinált réteg kompatibilitási szűrőt.",
-  "capabilityFilter.visionMismatch": "A szolgáltató nem támogatja a látást ehhez a képkéréshez",
-  "capabilityFilter.toolsMismatch": "A szolgáltató nem támogatja az eszközhívást",
-  "capabilityFilter.structuredOutputMismatch": "A szolgáltató nem támogatja a strukturált kimenetet",
-  "capabilityFilter.contextWindowMismatch": "A kérés meghaladja a szolgáltató kontextusablakát",
+  "capabilityFilter": {
+    "visionMismatch": "A szolgáltató nem támogatja a látást ehhez a képkéréshez",
+    "toolsMismatch": "A szolgáltató nem támogatja az eszközhívást",
+    "structuredOutputMismatch": "A szolgáltató nem támogatja a strukturált kimenetet",
+    "contextWindowMismatch": "A kérés meghaladja a szolgáltató kontextusablakát"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Az oldal nem található",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling dihentikan: server menolak permintaan (404/403).",
     "pollErrorTransient": "Kesalahan mengambil data: mencoba lagi secara otomatis.",
     "degraded": "Data sebagian: sumber tidak tersedia: {sources}",
-    "degraded.source.database": "Basis Data",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Penguncian Model",
-    "degraded.source.count": "Jumlah Koneksi"
+    "degradedSource": {
+      "database": "Basis Data",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Penguncian Model",
+      "count": "Jumlah Koneksi"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Tolak permintaan sebelum pengiriman ketika model target tidak memiliki kemampuan yang diperlukan (visi, alat, output terstruktur, jendela konteks). Melindungi permintaan penyedia tunggal langsung yang melewati filter kompatibilitas lapisan kombinasi.",
-  "capabilityFilter.visionMismatch": "Penyedia tidak mendukung visi untuk permintaan gambar ini",
-  "capabilityFilter.toolsMismatch": "Penyedia tidak mendukung pemanggilan alat",
-  "capabilityFilter.structuredOutputMismatch": "Penyedia tidak mendukung keluaran terstruktur",
-  "capabilityFilter.contextWindowMismatch": "Permintaan melebihi jendela konteks penyedia",
+  "capabilityFilter": {
+    "visionMismatch": "Penyedia tidak mendukung visi untuk permintaan gambar ini",
+    "toolsMismatch": "Penyedia tidak mendukung pemanggilan alat",
+    "structuredOutputMismatch": "Penyedia tidak mendukung keluaran terstruktur",
+    "contextWindowMismatch": "Permintaan melebihi jendela konteks penyedia"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Halaman tidak ditemukan",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling dihentikan: server menolak permintaan (404/403).",
     "pollErrorTransient": "Kesalahan mengambil data: mencoba lagi secara otomatis.",
     "degraded": "Data sebagian: sumber tidak tersedia: {sources}",
-    "degraded.source.database": "Basis Data",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Penguncian Model",
-    "degraded.source.count": "Jumlah Koneksi"
+    "degradedSource": {
+      "database": "Basis Data",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Penguncian Model",
+      "count": "Jumlah Koneksi"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Tolak permintaan sebelum pengiriman ketika model target tidak memiliki kemampuan yang diperlukan (visi, alat, output terstruktur, jendela konteks). Melindungi permintaan penyedia tunggal langsung yang melewati filter kompatibilitas lapisan kombinasi.",
-  "capabilityFilter.visionMismatch": "Penyedia tidak mendukung visi untuk permintaan gambar ini",
-  "capabilityFilter.toolsMismatch": "Penyedia tidak mendukung pemanggilan alat",
-  "capabilityFilter.structuredOutputMismatch": "Penyedia tidak mendukung keluaran terstruktur",
-  "capabilityFilter.contextWindowMismatch": "Permintaan melebihi jendela konteks penyedia",
+  "capabilityFilter": {
+    "visionMismatch": "Penyedia tidak mendukung visi untuk permintaan gambar ini",
+    "toolsMismatch": "Penyedia tidak mendukung pemanggilan alat",
+    "structuredOutputMismatch": "Penyedia tidak mendukung keluaran terstruktur",
+    "contextWindowMismatch": "Permintaan melebihi jendela konteks penyedia"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Halaman tidak ditemukan",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Sondaggio interrotto: il server ha rifiutato la richiesta (404/403).",
     "pollErrorTransient": "Errore nel recupero dei dati: nuovo tentativo automatico.",
     "degraded": "Dati parziali: fonti non disponibili: {sources}",
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Interruttore",
-    "degraded.source.modelLockouts": "Blocchi Modello",
-    "degraded.source.count": "Conteggio Connessioni"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Interruttore",
+      "modelLockouts": "Blocchi Modello",
+      "count": "Conteggio Connessioni"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Rifiuta le richieste prima della spedizione quando il modello di destinazione manca delle capacità richieste (visione, strumenti, output strutturato, finestra di contesto). Protegge le richieste dirette a singolo fornitore che bypassano il filtro di compatibilità del livello combinato.",
-  "capabilityFilter.visionMismatch": "Il fornitore non supporta la visione per questa richiesta di immagine",
-  "capabilityFilter.toolsMismatch": "Il provider non supporta la chiamata degli strumenti",
-  "capabilityFilter.structuredOutputMismatch": "Il provider non supporta l'output strutturato",
-  "capabilityFilter.contextWindowMismatch": "La richiesta supera la finestra di contesto del fornitore",
+  "capabilityFilter": {
+    "visionMismatch": "Il fornitore non supporta la visione per questa richiesta di immagine",
+    "toolsMismatch": "Il provider non supporta la chiamata degli strumenti",
+    "structuredOutputMismatch": "Il provider non supporta l'output strutturato",
+    "contextWindowMismatch": "La richiesta supera la finestra di contesto del fornitore"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Pagina non trovata",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "ポーリング停止:サーバーがリクエストを拒否しました(404/403)。",
     "pollErrorTransient": "データ取得エラー:自動的に再試行します。",
     "degraded": "部分データ:利用できないソース: {sources}",
-    "degraded.source.database": "データベース",
-    "degraded.source.circuitBreaker": "サーキットブレーカー",
-    "degraded.source.modelLockouts": "モデルロックアウト",
-    "degraded.source.count": "接続数"
+    "degradedSource": {
+      "database": "データベース",
+      "circuitBreaker": "サーキットブレーカー",
+      "modelLockouts": "モデルロックアウト",
+      "count": "接続数"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "ディスパッチ前にリクエストを拒否します。ターゲットモデルに必要な機能（ビジョン、ツール、構造化出力、コンテキストウィンドウ）が欠けている場合。コンボレイヤーの互換性フィルターをバイパスする直接の単一プロバイダーリクエストを保護します。",
-  "capabilityFilter.visionMismatch": "プロバイダーはこの画像リクエストのビジョンをサポートしていません",
-  "capabilityFilter.toolsMismatch": "プロバイダーはツール呼び出しをサポートしていません",
-  "capabilityFilter.structuredOutputMismatch": "プロバイダーは構造化出力をサポートしていません",
-  "capabilityFilter.contextWindowMismatch": "リクエストがプロバイダーのコンテキストウィンドウを超えています",
+  "capabilityFilter": {
+    "visionMismatch": "プロバイダーはこの画像リクエストのビジョンをサポートしていません",
+    "toolsMismatch": "プロバイダーはツール呼び出しをサポートしていません",
+    "structuredOutputMismatch": "プロバイダーは構造化出力をサポートしていません",
+    "contextWindowMismatch": "リクエストがプロバイダーのコンテキストウィンドウを超えています"
+  },
   "publicSystem": {
     "notFound": {
       "title": "ページが見つかりません",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "폴링 중지됨: 서버가 요청을 거부했습니다(404/403).",
     "pollErrorTransient": "데이터 가져오기 오류: 자동으로 재시도합니다.",
     "degraded": "부분 데이터: 사용할 수 없는 소스: {sources}",
-    "degraded.source.database": "데이터베이스",
-    "degraded.source.circuitBreaker": "회로 차단기",
-    "degraded.source.modelLockouts": "모델 잠금",
-    "degraded.source.count": "연결 수"
+    "degradedSource": {
+      "database": "데이터베이스",
+      "circuitBreaker": "회로 차단기",
+      "modelLockouts": "모델 잠금",
+      "count": "연결 수"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "대상 모델에 필수 기능(비전, 도구, 구조화된 출력, 컨텍스트 창)이 부족할 경우 요청을 발송 전에 거부합니다. 콤보 레이어 호환성 필터를 우회하는 직접 단일 공급자 요청을 보호합니다.",
-  "capabilityFilter.visionMismatch": "제공자가 이 이미지 요청에 대한 비전을 지원하지 않습니다.",
-  "capabilityFilter.toolsMismatch": "공급자가 도구 호출을 지원하지 않습니다.",
-  "capabilityFilter.structuredOutputMismatch": "제공자가 구조화된 출력을 지원하지 않습니다",
-  "capabilityFilter.contextWindowMismatch": "요청이 공급자 컨텍스트 창을 초과했습니다",
+  "capabilityFilter": {
+    "visionMismatch": "제공자가 이 이미지 요청에 대한 비전을 지원하지 않습니다.",
+    "toolsMismatch": "공급자가 도구 호출을 지원하지 않습니다.",
+    "structuredOutputMismatch": "제공자가 구조화된 출력을 지원하지 않습니다",
+    "contextWindowMismatch": "요청이 공급자 컨텍스트 창을 초과했습니다"
+  },
   "publicSystem": {
     "notFound": {
       "title": "페이지를 찾을 수 없습니다",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "पोलिंग थांबले: सर्व्हरने विनंती नाकारली (404/403).",
     "pollErrorTransient": "डेटा आणण्यात त्रुटी: आपोआप पुन्हा प्रयत्न करत आहे.",
     "degraded": "आंशिक डेटा: अनुपलब्ध स्रोत: {sources}",
-    "degraded.source.database": "डेटाबेस",
-    "degraded.source.circuitBreaker": "सर्किट ब्रेकर",
-    "degraded.source.modelLockouts": "मॉडेल लॉकआउट",
-    "degraded.source.count": "कनेक्शन संख्या"
+    "degradedSource": {
+      "database": "डेटाबेस",
+      "circuitBreaker": "सर्किट ब्रेकर",
+      "modelLockouts": "मॉडेल लॉकआउट",
+      "count": "कनेक्शन संख्या"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "डिस्पॅच करण्यापूर्वी विनंत्या नाकारल्या जातात जेव्हा लक्ष्य मॉडेल आवश्यक क्षमतांचा अभाव असतो (दृष्टी, साधने, संरचित आउटपुट, संदर्भ विंडो). कॉम्बो-लेयर सुसंगतता फिल्टरला बायपास करणाऱ्या थेट एकल-प्रदात्याच्या विनंत्यांचे संरक्षण करते.",
-  "capabilityFilter.visionMismatch": "या प्रतिमेच्या विनंतीसाठी प्रदाता दृश्याचे समर्थन करत नाही",
-  "capabilityFilter.toolsMismatch": "प्रदायक साधन कॉलिंगला समर्थन करत नाही",
-  "capabilityFilter.structuredOutputMismatch": "प्रदायक संरचित आउटपुटला समर्थन करत नाही",
-  "capabilityFilter.contextWindowMismatch": "विनंती प्रदाता संदर्भ विंडो ओलांडते",
+  "capabilityFilter": {
+    "visionMismatch": "या प्रतिमेच्या विनंतीसाठी प्रदाता दृश्याचे समर्थन करत नाही",
+    "toolsMismatch": "प्रदायक साधन कॉलिंगला समर्थन करत नाही",
+    "structuredOutputMismatch": "प्रदायक संरचित आउटपुटला समर्थन करत नाही",
+    "contextWindowMismatch": "विनंती प्रदाता संदर्भ विंडो ओलांडते"
+  },
   "publicSystem": {
     "notFound": {
       "title": "पृष्ठ सापडले नाही",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling dihentikan: pelayan menolak permintaan (404/403).",
     "pollErrorTransient": "Ralat mengambil data: cuba semula secara automatik.",
     "degraded": "Data separa: sumber tidak tersedia: {sources}",
-    "degraded.source.database": "Pangkalan Data",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Penguncian Model",
-    "degraded.source.count": "Bilangan Sambungan"
+    "degradedSource": {
+      "database": "Pangkalan Data",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Penguncian Model",
+      "count": "Bilangan Sambungan"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Tolak permintaan sebelum penghantaran apabila model sasaran tidak mempunyai keupayaan yang diperlukan (penglihatan, alat, output terstruktur, tetingkap konteks). Melindungi permintaan penyedia tunggal secara langsung yang mengabaikan penapis keserasian lapisan gabungan.",
-  "capabilityFilter.visionMismatch": "Penyedia tidak menyokong penglihatan untuk permintaan imej ini",
-  "capabilityFilter.toolsMismatch": "Penyedia tidak menyokong panggilan alat",
-  "capabilityFilter.structuredOutputMismatch": "Penyedia tidak menyokong output berstruktur",
-  "capabilityFilter.contextWindowMismatch": "Permintaan melebihi tetingkap konteks penyedia",
+  "capabilityFilter": {
+    "visionMismatch": "Penyedia tidak menyokong penglihatan untuk permintaan imej ini",
+    "toolsMismatch": "Penyedia tidak menyokong panggilan alat",
+    "structuredOutputMismatch": "Penyedia tidak menyokong output berstruktur",
+    "contextWindowMismatch": "Permintaan melebihi tetingkap konteks penyedia"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Halaman tidak ditemui",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling gestopt: de server heeft het verzoek geweigerd (404/403).",
     "pollErrorTransient": "Fout bij ophalen van gegevens: automatisch opnieuw proberen.",
     "degraded": "Gedeeltelijke gegevens: niet-beschikbare bronnen: {sources}",
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Modelvergrendelingen",
-    "degraded.source.count": "Aantal Verbindingen"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Modelvergrendelingen",
+      "count": "Aantal Verbindingen"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Weiger verzoeken vóór verzending wanneer het doellmodel ontbrekende vereiste mogelijkheden heeft (zicht, tools, gestructureerde output, contextvenster). Beschermt directe verzoeken van een enkele aanbieder die de compatibiliteitsfilter van de comb-laag omzeilen.",
-  "capabilityFilter.visionMismatch": "Provider ondersteunt geen visie voor dit afbeeldingsverzoek",
-  "capabilityFilter.toolsMismatch": "Provider ondersteunt het aanroepen van tools niet",
-  "capabilityFilter.structuredOutputMismatch": "Provider ondersteunt geen gestructureerde uitvoer",
-  "capabilityFilter.contextWindowMismatch": "Verzoek overschrijdt de contextvenster van de provider",
+  "capabilityFilter": {
+    "visionMismatch": "Provider ondersteunt geen visie voor dit afbeeldingsverzoek",
+    "toolsMismatch": "Provider ondersteunt het aanroepen van tools niet",
+    "structuredOutputMismatch": "Provider ondersteunt geen gestructureerde uitvoer",
+    "contextWindowMismatch": "Verzoek overschrijdt de contextvenster van de provider"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Pagina niet gevonden",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Polling stoppet: serveren avviste forespørselen (404/403).",
     "pollErrorTransient": "Feil ved henting av data: prøver automatisk igjen.",
     "degraded": "Delvise data: utilgjengelige kilder: {sources}",
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Kretsbryter",
-    "degraded.source.modelLockouts": "Modelllåsinger",
-    "degraded.source.count": "Antall Tilkoblinger"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Kretsbryter",
+      "modelLockouts": "Modelllåsinger",
+      "count": "Antall Tilkoblinger"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Avvis forespørselene før utsendelse når målmodellen mangler nødvendige funksjoner (visjon, verktøy, strukturert utdata, kontekstvindu). Beskytter direkte forespørseler fra enkeltleverandører som omgår kombinasjonslagets kompatibilitetsfilter.",
-  "capabilityFilter.visionMismatch": "Leverandøren støtter ikke visjon for denne bildeforespørselen",
-  "capabilityFilter.toolsMismatch": "Leverandøren støtter ikke verktøykall.",
-  "capabilityFilter.structuredOutputMismatch": "Leverandøren støtter ikke strukturert utdata",
-  "capabilityFilter.contextWindowMismatch": "Forespørselen overskrider leverandørens kontekstvindu",
+  "capabilityFilter": {
+    "visionMismatch": "Leverandøren støtter ikke visjon for denne bildeforespørselen",
+    "toolsMismatch": "Leverandøren støtter ikke verktøykall.",
+    "structuredOutputMismatch": "Leverandøren støtter ikke strukturert utdata",
+    "contextWindowMismatch": "Forespørselen overskrider leverandørens kontekstvindu"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Siden ble ikke funnet",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Huminto ang polling: tinanggihan ng server ang kahilingan (404/403).",
     "pollErrorTransient": "Error sa pagkuha ng data: awtomatikong sinusubukan muli.",
     "degraded": "Bahagyang data: hindi available na pinagmulan: {sources}",
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Mga Lockout ng Modelo",
-    "degraded.source.count": "Bilang ng Koneksyon"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Mga Lockout ng Modelo",
+      "count": "Bilang ng Koneksyon"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Tanggihan ang mga kahilingan bago ang pagpapadala kapag ang target na modelo ay kulang sa mga kinakailangang kakayahan (paningin, mga tool, nakabalangkas na output, bintana ng konteksto). Pinoprotektahan ang mga direktang kahilingan mula sa isang tagapagbigay na lumalampas sa filter ng pagiging tugma ng combo-layer.",
-  "capabilityFilter.visionMismatch": "Hindi sinusuportahan ng provider ang vision para sa kahilingang ito ng larawan",
-  "capabilityFilter.toolsMismatch": "Hindi sinusuportahan ng provider ang pagtawag sa tool",
-  "capabilityFilter.structuredOutputMismatch": "Hindi sinusuportahan ng provider ang nakabalangkas na output",
-  "capabilityFilter.contextWindowMismatch": "Lumampas ang kahilingan sa konteksto ng tagapagbigay",
+  "capabilityFilter": {
+    "visionMismatch": "Hindi sinusuportahan ng provider ang vision para sa kahilingang ito ng larawan",
+    "toolsMismatch": "Hindi sinusuportahan ng provider ang pagtawag sa tool",
+    "structuredOutputMismatch": "Hindi sinusuportahan ng provider ang nakabalangkas na output",
+    "contextWindowMismatch": "Lumampas ang kahilingan sa konteksto ng tagapagbigay"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Hindi matagpuan ang pahina",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Odpytywanie zatrzymane: serwer odrzucił żądanie (404/403).",
     "pollErrorTransient": "Błąd pobierania danych: automatyczne ponowienie.",
     "degraded": "Dane częściowe: niedostępne źródła: {sources}",
-    "degraded.source.database": "Baza Danych",
-    "degraded.source.circuitBreaker": "Wyłącznik",
-    "degraded.source.modelLockouts": "Blokady Modelu",
-    "degraded.source.count": "Liczba Połączeń"
+    "degradedSource": {
+      "database": "Baza Danych",
+      "circuitBreaker": "Wyłącznik",
+      "modelLockouts": "Blokady Modelu",
+      "count": "Liczba Połączeń"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Odrzuć żądania przed wysyłką, gdy docelowy model nie ma wymaganych możliwości (wizja, narzędzia, strukturalne wyjście, okno kontekstowe). Chroni bezpośrednie żądania od pojedynczego dostawcy, które omijają filtr zgodności warstwy kombinacyjnej.",
-  "capabilityFilter.visionMismatch": "Dostawca nie obsługuje wizji dla tego żądania obrazu",
-  "capabilityFilter.toolsMismatch": "Dostawca nie obsługuje wywoływania narzędzi",
-  "capabilityFilter.structuredOutputMismatch": "Dostawca nie obsługuje strukturalnego wyjścia",
-  "capabilityFilter.contextWindowMismatch": "Żądanie przekracza okno kontekstu dostawcy",
+  "capabilityFilter": {
+    "visionMismatch": "Dostawca nie obsługuje wizji dla tego żądania obrazu",
+    "toolsMismatch": "Dostawca nie obsługuje wywoływania narzędzi",
+    "structuredOutputMismatch": "Dostawca nie obsługuje strukturalnego wyjścia",
+    "contextWindowMismatch": "Żądanie przekracza okno kontekstu dostawcy"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Nie znaleziono strony",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Sondagem interrompida: o servidor rejeitou a requisição (404/403).",
     "pollErrorTransient": "Erro ao buscar dados: repetindo automaticamente.",
     "degraded": "Dados parciais: fontes indisponíveis: {sources}",
-    "degraded.source.database": "Banco de Dados",
-    "degraded.source.circuitBreaker": "Disjuntor",
-    "degraded.source.modelLockouts": "Bloqueios de Modelo",
-    "degraded.source.count": "Contagem de Conexões"
+    "degradedSource": {
+      "database": "Banco de Dados",
+      "circuitBreaker": "Disjuntor",
+      "modelLockouts": "Bloqueios de Modelo",
+      "count": "Contagem de Conexões"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Rejeitar requisições antes do despacho quando o modelo alvo nao possui as capacidades necessarias (visao, ferramentas, saída estruturada, janela de contexto). Protege requisições diretas que ignoram o filtro de compatibilidade do combo.",
-  "capabilityFilter.visionMismatch": "O provedor nao suporta visao para esta requisicao de imagem",
-  "capabilityFilter.toolsMismatch": "O provedor nao suporta chamada de ferramentas",
-  "capabilityFilter.structuredOutputMismatch": "O provedor nao suporta saida estruturada",
-  "capabilityFilter.contextWindowMismatch": "A requisicao excede a janela de contexto do provedor",
+  "capabilityFilter": {
+    "visionMismatch": "O provedor nao suporta visao para esta requisicao de imagem",
+    "toolsMismatch": "O provedor nao suporta chamada de ferramentas",
+    "structuredOutputMismatch": "O provedor nao suporta saida estruturada",
+    "contextWindowMismatch": "A requisicao excede a janela de contexto do provedor"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Página não encontrada",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -13319,16 +13319,20 @@
         "count": "Contagem de Ligações"
       }
     },
-    "degraded.source.database": "Database",
-    "degraded.source.circuitBreaker": "Circuit Breaker",
-    "degraded.source.modelLockouts": "Model Lockouts",
-    "degraded.source.count": "Connection Count"
+    "degradedSource": {
+      "database": "Database",
+      "circuitBreaker": "Circuit Breaker",
+      "modelLockouts": "Model Lockouts",
+      "count": "Connection Count"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Rejeitar pedidos antes do envio quando o modelo de destino não tiver as capacidades necessárias (visão, ferramentas, saída estruturada, janela de contexto). Protege pedidos diretos de um único fornecedor que contornam o filtro de compatibilidade da camada combinada.",
-  "capabilityFilter.visionMismatch": "Provider does not support vision for this image request",
-  "capabilityFilter.toolsMismatch": "Provider does not support tool calling",
-  "capabilityFilter.structuredOutputMismatch": "Provider does not support structured output",
-  "capabilityFilter.contextWindowMismatch": "Request exceeds provider context window",
+  "capabilityFilter": {
+    "visionMismatch": "O fornecedor não suporta visão para este pedido de imagem",
+    "toolsMismatch": "O fornecedor não suporta a chamada de ferramentas",
+    "structuredOutputMismatch": "O fornecedor não suporta saída estruturada",
+    "contextWindowMismatch": "A solicitação excede a janela de contexto do fornecedor"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Página não encontrada",
@@ -13703,11 +13707,5 @@
     "hint": "Quando ativado, os modelos descobertos aparecem nas seleções do provedor em todo o OmniRoute.",
     "updateFailed": "Falha ao atualizar (HTTP {status})",
     "networkError": "Erro de rede — não foi possível atualizar a configuração de exposição do fornecedor"
-  },
-  "capabilityFilter": {
-    "visionMismatch": "O fornecedor não suporta visão para este pedido de imagem",
-    "toolsMismatch": "O fornecedor não suporta a chamada de ferramentas",
-    "structuredOutputMismatch": "O fornecedor não suporta saída estruturada",
-    "contextWindowMismatch": "A solicitação excede a janela de contexto do fornecedor"
   }
 }

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Interogare oprită: serverul a respins cererea (404/403).",
     "pollErrorTransient": "Eroare la preluarea datelor: reîncercare automată.",
     "degraded": "Date parțiale: surse indisponibile: {sources}",
-    "degraded.source.database": "Bază de Date",
-    "degraded.source.circuitBreaker": "Întrerupător de Circuit",
-    "degraded.source.modelLockouts": "Blocaje Model",
-    "degraded.source.count": "Număr de Conexiuni"
+    "degradedSource": {
+      "database": "Bază de Date",
+      "circuitBreaker": "Întrerupător de Circuit",
+      "modelLockouts": "Blocaje Model",
+      "count": "Număr de Conexiuni"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Respinge cererile înainte de expediere atunci când modelul țintă nu are capabilitățile necesare (viziune, instrumente, ieșire structurată, fereastră de context). Protejează cererile directe de un singur furnizor care ocolesc filtrul de compatibilitate al stratului combinat.",
-  "capabilityFilter.visionMismatch": "Furnizorul nu suportă viziunea pentru această cerere de imagine",
-  "capabilityFilter.toolsMismatch": "Furnizorul nu suportă apelarea instrumentului",
-  "capabilityFilter.structuredOutputMismatch": "Furnizorul nu suportă ieșirea structurată",
-  "capabilityFilter.contextWindowMismatch": "Cererea depășește fereastra de context a furnizorului",
+  "capabilityFilter": {
+    "visionMismatch": "Furnizorul nu suportă viziunea pentru această cerere de imagine",
+    "toolsMismatch": "Furnizorul nu suportă apelarea instrumentului",
+    "structuredOutputMismatch": "Furnizorul nu suportă ieșirea structurată",
+    "contextWindowMismatch": "Cererea depășește fereastra de context a furnizorului"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Pagina nu a fost găsită",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Опрос остановлен: сервер отклонил запрос (404/403).",
     "pollErrorTransient": "Ошибка получения данных: автоматический повтор.",
     "degraded": "Частичные данные: недоступные источники: {sources}",
-    "degraded.source.database": "База Данных",
-    "degraded.source.circuitBreaker": "Автомат Защиты",
-    "degraded.source.modelLockouts": "Блокировки Модели",
-    "degraded.source.count": "Количество Соединений"
+    "degradedSource": {
+      "database": "База Данных",
+      "circuitBreaker": "Автомат Защиты",
+      "modelLockouts": "Блокировки Модели",
+      "count": "Количество Соединений"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Отклонять запросы перед отправкой, когда целевая модель не имеет необходимых возможностей (визуализация, инструменты, структурированный вывод, контекстное окно). Защищает прямые запросы от единственного поставщика, которые обходят фильтр совместимости комбинированного слоя.",
-  "capabilityFilter.visionMismatch": "Поставщик не поддерживает визуализацию для этого запроса изображения",
-  "capabilityFilter.toolsMismatch": "Провайдер не поддерживает вызов инструмента",
-  "capabilityFilter.structuredOutputMismatch": "Поставщик не поддерживает структурированный вывод",
-  "capabilityFilter.contextWindowMismatch": "Запрос превышает контекстное окно провайдера",
+  "capabilityFilter": {
+    "visionMismatch": "Поставщик не поддерживает визуализацию для этого запроса изображения",
+    "toolsMismatch": "Провайдер не поддерживает вызов инструмента",
+    "structuredOutputMismatch": "Поставщик не поддерживает структурированный вывод",
+    "contextWindowMismatch": "Запрос превышает контекстное окно провайдера"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Страница не найдена",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Dopytovanie zastavené: server odmietol požiadavku (404/403).",
     "pollErrorTransient": "Chyba pri načítaní dát: automatické opakovanie.",
     "degraded": "Čiastočné dáta: nedostupné zdroje: {sources}",
-    "degraded.source.database": "Databáza",
-    "degraded.source.circuitBreaker": "Istič",
-    "degraded.source.modelLockouts": "Uzamknutia Modelu",
-    "degraded.source.count": "Počet Pripojení"
+    "degradedSource": {
+      "database": "Databáza",
+      "circuitBreaker": "Istič",
+      "modelLockouts": "Uzamknutia Modelu",
+      "count": "Počet Pripojení"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Zamietnuť požiadavky pred odoslaním, keď cieľový model postráda požadované schopnosti (vízia, nástroje, štruktúrovaný výstup, kontextové okno). Chráni priamu požiadavku od jedného poskytovateľa, ktorá obchádza filter kompatibility kombinovanej vrstvy.",
-  "capabilityFilter.visionMismatch": "Poskytovateľ nepodporuje víziu pre tento požiadavku na obrázok",
-  "capabilityFilter.toolsMismatch": "Poskytovateľ nepodporuje volanie nástroja",
-  "capabilityFilter.structuredOutputMismatch": "Poskytovateľ nepodporuje štruktúrovaný výstup",
-  "capabilityFilter.contextWindowMismatch": "Žiadosť presahuje kontextové okno poskytovateľa",
+  "capabilityFilter": {
+    "visionMismatch": "Poskytovateľ nepodporuje víziu pre tento požiadavku na obrázok",
+    "toolsMismatch": "Poskytovateľ nepodporuje volanie nástroja",
+    "structuredOutputMismatch": "Poskytovateľ nepodporuje štruktúrovaný výstup",
+    "contextWindowMismatch": "Žiadosť presahuje kontextové okno poskytovateľa"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Stránka nenájdená",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Pollning stoppad: servern avvisade förfrågan (404/403).",
     "pollErrorTransient": "Fel vid hämtning av data: försöker automatiskt igen.",
     "degraded": "Partiell data: otillgängliga källor: {sources}",
-    "degraded.source.database": "Databas",
-    "degraded.source.circuitBreaker": "Kretsbrytare",
-    "degraded.source.modelLockouts": "Modellåsningar",
-    "degraded.source.count": "Antal Anslutningar"
+    "degradedSource": {
+      "database": "Databas",
+      "circuitBreaker": "Kretsbrytare",
+      "modelLockouts": "Modellåsningar",
+      "count": "Antal Anslutningar"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Avvisa förfrågningar innan de skickas när målmodellen saknar nödvändiga funktioner (vision, verktyg, strukturerad utdata, kontextfönster). Skyddar direkta förfrågningar från en enda leverantör som kringgår kompatibilitetsfiltret för kombinationslager.",
-  "capabilityFilter.visionMismatch": "Leverantören stöder inte vision för denna bildförfrågan",
-  "capabilityFilter.toolsMismatch": "Leverantören stöder inte verktygsanrop.",
-  "capabilityFilter.structuredOutputMismatch": "Leverantören stöder inte strukturerad utdata",
-  "capabilityFilter.contextWindowMismatch": "Begäran överskrider leverantörens kontextfönster",
+  "capabilityFilter": {
+    "visionMismatch": "Leverantören stöder inte vision för denna bildförfrågan",
+    "toolsMismatch": "Leverantören stöder inte verktygsanrop.",
+    "structuredOutputMismatch": "Leverantören stöder inte strukturerad utdata",
+    "contextWindowMismatch": "Begäran överskrider leverantörens kontextfönster"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Sidan kunde inte hittas",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Uchunguzi umesimamishwa: seva ilikataa ombi (404/403).",
     "pollErrorTransient": "Hitilafu katika kupata data: inajaribu tena kiotomatiki.",
     "degraded": "Data isiyokamilika: vyanzo visivyopatikana: {sources}",
-    "degraded.source.database": "Hifadhidata",
-    "degraded.source.circuitBreaker": "Kivunja Mzunguko",
-    "degraded.source.modelLockouts": "Kufuli za Mfano",
-    "degraded.source.count": "Idadi ya Miunganisho"
+    "degradedSource": {
+      "database": "Hifadhidata",
+      "circuitBreaker": "Kivunja Mzunguko",
+      "modelLockouts": "Kufuli za Mfano",
+      "count": "Idadi ya Miunganisho"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "kataa maombi kabla ya kutuma wakati mfano wa lengo hauna uwezo unaohitajika (maono, zana, matokeo yaliyoandikwa, dirisha la muktadha). Inalinda maombi ya moja kwa moja kutoka kwa mtoa huduma mmoja ambayo yanapita chujio cha ulinganifu wa safu ya mchanganyiko.",
-  "capabilityFilter.visionMismatch": "Mtoa huduma haitoi msaada wa kuona kwa ombi hili la picha",
-  "capabilityFilter.toolsMismatch": "Mtoa huduma haitoi msaada wa kuita zana",
-  "capabilityFilter.structuredOutputMismatch": "Mtoa huduma haitoi matokeo yaliyoandikwa kwa muundo",
-  "capabilityFilter.contextWindowMismatch": "Omba inazidi dirisha la muktadha wa mtoa huduma",
+  "capabilityFilter": {
+    "visionMismatch": "Mtoa huduma haitoi msaada wa kuona kwa ombi hili la picha",
+    "toolsMismatch": "Mtoa huduma haitoi msaada wa kuita zana",
+    "structuredOutputMismatch": "Mtoa huduma haitoi matokeo yaliyoandikwa kwa muundo",
+    "contextWindowMismatch": "Omba inazidi dirisha la muktadha wa mtoa huduma"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Ukurasa haukupatikana",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "வாக்கெடுப்பு நிறுத்தப்பட்டது: சேவையகம் கோரிக்கையை நிராகரித்தது (404/403).",
     "pollErrorTransient": "தரவைப் பெறுவதில் பிழை: தானாக மீண்டும் முயற்சிக்கிறது.",
     "degraded": "பகுதி தரவு: கிடைக்காத மூலங்கள்: {sources}",
-    "degraded.source.database": "தரவுத்தளம்",
-    "degraded.source.circuitBreaker": "சுற்று பிரேக்கர்",
-    "degraded.source.modelLockouts": "மாதிரி பூட்டுகள்",
-    "degraded.source.count": "இணைப்புகளின் எண்ணிக்கை"
+    "degradedSource": {
+      "database": "தரவுத்தளம்",
+      "circuitBreaker": "சுற்று பிரேக்கர்",
+      "modelLockouts": "மாதிரி பூட்டுகள்",
+      "count": "இணைப்புகளின் எண்ணிக்கை"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "விருப்பமான மாதிரி தேவையான திறன்களை (காணல், கருவிகள், கட்டமைக்கப்பட்ட வெளியீடு, சூழல் ஜன்னல்) இன்றி இருந்தால், அனுப்புவதற்கு முன் கோரிக்கைகளை நிராகரிக்கவும். கம்போ-லேயர் ஒத்திசைவு வடிகட்டியை தவிர்க்கும் நேரடி ஒற்றை வழங்குநர் கோரிக்கைகளை பாதுகாக்கிறது.",
-  "capabilityFilter.visionMismatch": "இந்த படக் கோரிக்கைக்கு வழங்குநர் கண்ணோட்டத்தை ஆதரிக்கவில்லை",
-  "capabilityFilter.toolsMismatch": "சேவையாளர் கருவி அழைப்பை ஆதரிக்கவில்லை",
-  "capabilityFilter.structuredOutputMismatch": "சேவையாளர் கட்டமைக்கப்பட்ட வெளியீட்டை ஆதரிக்கவில்லை",
-  "capabilityFilter.contextWindowMismatch": "விண்ணப்பம் வழங்குநர் சூழல் ஜன்னலை மீறுகிறது",
+  "capabilityFilter": {
+    "visionMismatch": "இந்த படக் கோரிக்கைக்கு வழங்குநர் கண்ணோட்டத்தை ஆதரிக்கவில்லை",
+    "toolsMismatch": "சேவையாளர் கருவி அழைப்பை ஆதரிக்கவில்லை",
+    "structuredOutputMismatch": "சேவையாளர் கட்டமைக்கப்பட்ட வெளியீட்டை ஆதரிக்கவில்லை",
+    "contextWindowMismatch": "விண்ணப்பம் வழங்குநர் சூழல் ஜன்னலை மீறுகிறது"
+  },
   "publicSystem": {
     "notFound": {
       "title": "பக்கம் கிடைக்கவில்லை",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "పోలింగ్ ఆగింది: సర్వర్ అభ్యర్థనను తిరస్కరించింది (404/403).",
     "pollErrorTransient": "డేటాను పొందడంలో లోపం: స్వయంచాలకంగా మళ్లీ ప్రయత్నిస్తోంది.",
     "degraded": "పాక్షిక డేటా: అందుబాటులో లేని మూలాలు: {sources}",
-    "degraded.source.database": "డేటాబేస్",
-    "degraded.source.circuitBreaker": "సర్క్యూట్ బ్రేకర్",
-    "degraded.source.modelLockouts": "మోడల్ లాక్‌అవుట్‌లు",
-    "degraded.source.count": "కనెక్షన్ల సంఖ్య"
+    "degradedSource": {
+      "database": "డేటాబేస్",
+      "circuitBreaker": "సర్క్యూట్ బ్రేకర్",
+      "modelLockouts": "మోడల్ లాక్‌అవుట్‌లు",
+      "count": "కనెక్షన్ల సంఖ్య"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "ప్రయోజనాలు అవసరమైన సామర్థ్యాలు (దృష్టి, సాధనాలు, నిర్మిత అవుట్‌పుట్, సందర్భం విండో) లేని లక్ష్య మోడల్ ముందు పంపిణీకి అభ్యర్థనలను తిరస్కరించండి. కాంబో-లేయర్ అనుకూలత ఫిల్టర్‌ను దాటించే ప్రత్యక్ష సింగిల్-ప్రొవైడర్ అభ్యర్థనలను రక్షిస్తుంది.",
-  "capabilityFilter.visionMismatch": "ఈ చిత్రం అభ్యర్థనకు ప్రొవైడర్ దృష్టిని మద్దతు ఇవ్వడం లేదు",
-  "capabilityFilter.toolsMismatch": "ప్రొవైడర్ టూల్ కాలింగ్‌ను మద్దతు ఇవ్వదు",
-  "capabilityFilter.structuredOutputMismatch": "ప్రొవైడర్ నిర్మిత అవుట్‌పుట్‌ను మద్దతు ఇవ్వదు",
-  "capabilityFilter.contextWindowMismatch": "అనువర్తన ప్రదాత యొక్క సందర్భం కిటికీని మించు కోరింపు",
+  "capabilityFilter": {
+    "visionMismatch": "ఈ చిత్రం అభ్యర్థనకు ప్రొవైడర్ దృష్టిని మద్దతు ఇవ్వడం లేదు",
+    "toolsMismatch": "ప్రొవైడర్ టూల్ కాలింగ్‌ను మద్దతు ఇవ్వదు",
+    "structuredOutputMismatch": "ప్రొవైడర్ నిర్మిత అవుట్‌పుట్‌ను మద్దతు ఇవ్వదు",
+    "contextWindowMismatch": "అనువర్తన ప్రదాత యొక్క సందర్భం కిటికీని మించు కోరింపు"
+  },
   "publicSystem": {
     "notFound": {
       "title": "పేజీ కనుగొనబడలేదు",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "หยุดการสำรวจ: เซิร์ฟเวอร์ปฏิเสธคำขอ (404/403)",
     "pollErrorTransient": "เกิดข้อผิดพลาดในการดึงข้อมูล: กำลังลองใหม่โดยอัตโนมัติ",
     "degraded": "ข้อมูลบางส่วน: แหล่งข้อมูลที่ไม่พร้อมใช้งาน: {sources}",
-    "degraded.source.database": "ฐานข้อมูล",
-    "degraded.source.circuitBreaker": "เซอร์กิตเบรกเกอร์",
-    "degraded.source.modelLockouts": "การล็อกเอาต์โมเดล",
-    "degraded.source.count": "จำนวนการเชื่อมต่อ"
+    "degradedSource": {
+      "database": "ฐานข้อมูล",
+      "circuitBreaker": "เซอร์กิตเบรกเกอร์",
+      "modelLockouts": "การล็อกเอาต์โมเดล",
+      "count": "จำนวนการเชื่อมต่อ"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "ปฏิเสธคำขอก่อนการส่งเมื่อโมเดลเป้าหมายขาดความสามารถที่จำเป็น (วิสัยทัศน์, เครื่องมือ, ผลลัพธ์ที่มีโครงสร้าง, หน้าต่างบริบท) ป้องกันคำขอจากผู้ให้บริการเดียวที่ข้ามตัวกรองความเข้ากันได้ของเลเยอร์รวม",
-  "capabilityFilter.visionMismatch": "ผู้ให้บริการไม่รองรับการมองเห็นสำหรับคำขอภาพนี้",
-  "capabilityFilter.toolsMismatch": "ผู้ให้บริการไม่รองรับการเรียกเครื่องมือ",
-  "capabilityFilter.structuredOutputMismatch": "ผู้ให้บริการไม่รองรับการส่งออกแบบมีโครงสร้าง",
-  "capabilityFilter.contextWindowMismatch": "คำขอเกินขอบเขตบริบทของผู้ให้บริการ",
+  "capabilityFilter": {
+    "visionMismatch": "ผู้ให้บริการไม่รองรับการมองเห็นสำหรับคำขอภาพนี้",
+    "toolsMismatch": "ผู้ให้บริการไม่รองรับการเรียกเครื่องมือ",
+    "structuredOutputMismatch": "ผู้ให้บริการไม่รองรับการส่งออกแบบมีโครงสร้าง",
+    "contextWindowMismatch": "คำขอเกินขอบเขตบริบทของผู้ให้บริการ"
+  },
   "publicSystem": {
     "notFound": {
       "title": "ไม่พบหน้า",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Yoklama durduruldu: sunucu isteği reddetti (404/403).",
     "pollErrorTransient": "Veri alınırken hata: otomatik olarak yeniden deneniyor.",
     "degraded": "Kısmi veri: kullanılamayan kaynaklar: {sources}",
-    "degraded.source.database": "Veritabanı",
-    "degraded.source.circuitBreaker": "Devre Kesici",
-    "degraded.source.modelLockouts": "Model Kilitleri",
-    "degraded.source.count": "Bağlantı Sayısı"
+    "degradedSource": {
+      "database": "Veritabanı",
+      "circuitBreaker": "Devre Kesici",
+      "modelLockouts": "Model Kilitleri",
+      "count": "Bağlantı Sayısı"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Hedef model gerekli yeteneklere (görüş, araçlar, yapılandırılmış çıktı, bağlam penceresi) sahip olmadığında, gönderimden önce istekleri reddedin. Kombinasyon katmanı uyumluluk filtresini atlayan doğrudan tek sağlayıcı isteklerini korur.",
-  "capabilityFilter.visionMismatch": "Sağlayıcı, bu görüntü isteği için görsel desteği sağlamıyor.",
-  "capabilityFilter.toolsMismatch": "Sağlayıcı araç çağrısını desteklemiyor",
-  "capabilityFilter.structuredOutputMismatch": "Sağlayıcı yapılandırılmış çıktıyı desteklemiyor",
-  "capabilityFilter.contextWindowMismatch": "Talep sağlayıcı bağlam penceresini aşıyor",
+  "capabilityFilter": {
+    "visionMismatch": "Sağlayıcı, bu görüntü isteği için görsel desteği sağlamıyor.",
+    "toolsMismatch": "Sağlayıcı araç çağrısını desteklemiyor",
+    "structuredOutputMismatch": "Sağlayıcı yapılandırılmış çıktıyı desteklemiyor",
+    "contextWindowMismatch": "Talep sağlayıcı bağlam penceresini aşıyor"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Sayfa bulunamadı",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Опитування зупинено: сервер відхилив запит (404/403).",
     "pollErrorTransient": "Помилка отримання даних: автоматичний повтор.",
     "degraded": "Часткові дані: недоступні джерела: {sources}",
-    "degraded.source.database": "База Даних",
-    "degraded.source.circuitBreaker": "Автоматичний Вимикач",
-    "degraded.source.modelLockouts": "Блокування Моделі",
-    "degraded.source.count": "Кількість З'єднань"
+    "degradedSource": {
+      "database": "База Даних",
+      "circuitBreaker": "Автоматичний Вимикач",
+      "modelLockouts": "Блокування Моделі",
+      "count": "Кількість З'єднань"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Відхиляйте запити перед відправкою, коли цільова модель не має необхідних можливостей (зір, інструменти, структурований вихід, контекстне вікно). Захищає прямі запити від одного постачальника, які обходять фільтр сумісності комбінаційного шару.",
-  "capabilityFilter.visionMismatch": "Постачальник не підтримує візуалізацію для цього запиту зображення",
-  "capabilityFilter.toolsMismatch": "Постачальник не підтримує виклик інструментів",
-  "capabilityFilter.structuredOutputMismatch": "Постачальник не підтримує структурований вивід",
-  "capabilityFilter.contextWindowMismatch": "Запит перевищує контекстне вікно постачальника",
+  "capabilityFilter": {
+    "visionMismatch": "Постачальник не підтримує візуалізацію для цього запиту зображення",
+    "toolsMismatch": "Постачальник не підтримує виклик інструментів",
+    "structuredOutputMismatch": "Постачальник не підтримує структурований вивід",
+    "contextWindowMismatch": "Запит перевищує контекстне вікно постачальника"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Сторінку не знайдено",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "پولنگ روک دی گئی: سرور نے درخواست مسترد کر دی (404/403)۔",
     "pollErrorTransient": "ڈیٹا حاصل کرنے میں خرابی: خودکار طور پر دوبارہ کوشش کی جا رہی ہے۔",
     "degraded": "جزوی ڈیٹا: غیر دستیاب ذرائع: {sources}",
-    "degraded.source.database": "ڈیٹا بیس",
-    "degraded.source.circuitBreaker": "سرکٹ بریکر",
-    "degraded.source.modelLockouts": "ماڈل لاک آؤٹس",
-    "degraded.source.count": "کنکشنز کی تعداد"
+    "degradedSource": {
+      "database": "ڈیٹا بیس",
+      "circuitBreaker": "سرکٹ بریکر",
+      "modelLockouts": "ماڈل لاک آؤٹس",
+      "count": "کنکشنز کی تعداد"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "جب ہدف ماڈل میں ضروری صلاحیتیں (نظریات، ٹولز، منظم آؤٹ پٹ، سیاق و سباق کی کھڑکی) نہیں ہوتیں تو بھیجنے سے پہلے درخواستوں کو مسترد کریں۔ یہ براہ راست واحد فراہم کنندہ کی درخواستوں کی حفاظت کرتا ہے جو کمبو-لیئر کی ہم آہنگی کے فلٹر کو نظر انداز کرتی ہیں۔",
-  "capabilityFilter.visionMismatch": "فراہم کنندہ اس تصویر کی درخواست کے لیے بصیرت کی حمایت نہیں کرتا",
-  "capabilityFilter.toolsMismatch": "فراہم کنندہ ٹول کالنگ کی حمایت نہیں کرتا",
-  "capabilityFilter.structuredOutputMismatch": "پرووائیڈر ساختی آؤٹ پٹ کی حمایت نہیں کرتا",
-  "capabilityFilter.contextWindowMismatch": "درخواست فراہم کنندہ کے سیاق و سباق کی ونڈو سے تجاوز کر گئی ہے",
+  "capabilityFilter": {
+    "visionMismatch": "فراہم کنندہ اس تصویر کی درخواست کے لیے بصیرت کی حمایت نہیں کرتا",
+    "toolsMismatch": "فراہم کنندہ ٹول کالنگ کی حمایت نہیں کرتا",
+    "structuredOutputMismatch": "پرووائیڈر ساختی آؤٹ پٹ کی حمایت نہیں کرتا",
+    "contextWindowMismatch": "درخواست فراہم کنندہ کے سیاق و سباق کی ونڈو سے تجاوز کر گئی ہے"
+  },
   "publicSystem": {
     "notFound": {
       "title": "صفحہ نہیں ملا",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "Đã dừng thăm dò: máy chủ đã từ chối yêu cầu (404/403).",
     "pollErrorTransient": "Lỗi khi lấy dữ liệu: tự động thử lại.",
     "degraded": "Dữ liệu một phần: nguồn không khả dụng: {sources}",
-    "degraded.source.database": "Cơ Sở Dữ Liệu",
-    "degraded.source.circuitBreaker": "Cầu Dao Mạch",
-    "degraded.source.modelLockouts": "Khóa Mô Hình",
-    "degraded.source.count": "Số Lượng Kết Nối"
+    "degradedSource": {
+      "database": "Cơ Sở Dữ Liệu",
+      "circuitBreaker": "Cầu Dao Mạch",
+      "modelLockouts": "Khóa Mô Hình",
+      "count": "Số Lượng Kết Nối"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "Từ chối yêu cầu trước khi gửi đi khi mô hình đích thiếu các khả năng bắt buộc (thị giác, công cụ, đầu ra có cấu trúc, cửa sổ ngữ cảnh). Bảo vệ các yêu cầu trực tiếp đến một nhà cung cấp khi chúng bỏ qua bộ lọc tương thích của combo.",
-  "capabilityFilter.visionMismatch": "Nhà cung cấp không hỗ trợ thị giác cho yêu cầu hình ảnh này",
-  "capabilityFilter.toolsMismatch": "Nhà cung cấp không hỗ trợ gọi công cụ",
-  "capabilityFilter.structuredOutputMismatch": "Nhà cung cấp không hỗ trợ đầu ra có cấu trúc",
-  "capabilityFilter.contextWindowMismatch": "Yêu cầu vượt quá cửa sổ ngữ cảnh của nhà cung cấp",
+  "capabilityFilter": {
+    "visionMismatch": "Nhà cung cấp không hỗ trợ thị giác cho yêu cầu hình ảnh này",
+    "toolsMismatch": "Nhà cung cấp không hỗ trợ gọi công cụ",
+    "structuredOutputMismatch": "Nhà cung cấp không hỗ trợ đầu ra có cấu trúc",
+    "contextWindowMismatch": "Yêu cầu vượt quá cửa sổ ngữ cảnh của nhà cung cấp"
+  },
   "publicSystem": {
     "notFound": {
       "title": "Không tìm thấy trang",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "轮询已停止:服务器拒绝了请求 (404/403)。",
     "pollErrorTransient": "获取数据出错:将自动重试。",
     "degraded": "部分数据:不可用的数据源: {sources}",
-    "degraded.source.database": "数据库",
-    "degraded.source.circuitBreaker": "断路器",
-    "degraded.source.modelLockouts": "模型锁定",
-    "degraded.source.count": "连接数"
+    "degradedSource": {
+      "database": "数据库",
+      "circuitBreaker": "断路器",
+      "modelLockouts": "模型锁定",
+      "count": "连接数"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "在目标模型缺少所需能力（视觉、工具、结构化输出、上下文窗口）时，拒绝调度前的请求。保护绕过组合层兼容性过滤器的直接单一提供者请求。",
-  "capabilityFilter.visionMismatch": "提供者不支持此图像请求的视觉效果",
-  "capabilityFilter.toolsMismatch": "提供者不支持工具调用",
-  "capabilityFilter.structuredOutputMismatch": "提供者不支持结构化输出",
-  "capabilityFilter.contextWindowMismatch": "请求超出提供者上下文窗口",
+  "capabilityFilter": {
+    "visionMismatch": "提供者不支持此图像请求的视觉效果",
+    "toolsMismatch": "提供者不支持工具调用",
+    "structuredOutputMismatch": "提供者不支持结构化输出",
+    "contextWindowMismatch": "请求超出提供者上下文窗口"
+  },
   "publicSystem": {
     "notFound": {
       "title": "页面未找到",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -13240,16 +13240,20 @@
     "pollErrorStopped": "輪詢已停止:伺服器拒絕了請求 (404/403)。",
     "pollErrorTransient": "取得資料時發生錯誤:將自動重試。",
     "degraded": "部分資料:無法使用的來源: {sources}",
-    "degraded.source.database": "資料庫",
-    "degraded.source.circuitBreaker": "斷路器",
-    "degraded.source.modelLockouts": "模型鎖定",
-    "degraded.source.count": "連線數"
+    "degradedSource": {
+      "database": "資料庫",
+      "circuitBreaker": "斷路器",
+      "modelLockouts": "模型鎖定",
+      "count": "連線數"
+    }
   },
   "featureFlagCapabilityFilterEnabledDescription": "在目標模型缺乏所需功能（視覺、工具、結構化輸出、上下文窗口）時，拒絕發送前的請求。保護繞過組合層兼容性過濾器的直接單一提供者請求。",
-  "capabilityFilter.visionMismatch": "提供者不支援此影像請求的視覺效果",
-  "capabilityFilter.toolsMismatch": "提供者不支援工具呼叫",
-  "capabilityFilter.structuredOutputMismatch": "提供者不支援結構化輸出",
-  "capabilityFilter.contextWindowMismatch": "請求超出提供者上下文窗口",
+  "capabilityFilter": {
+    "visionMismatch": "提供者不支援此影像請求的視覺效果",
+    "toolsMismatch": "提供者不支援工具呼叫",
+    "structuredOutputMismatch": "提供者不支援結構化輸出",
+    "contextWindowMismatch": "請求超出提供者上下文窗口"
+  },
   "publicSystem": {
     "notFound": {
       "title": "找不到頁面",

--- a/tests/unit/ui/resilience-connections.test.tsx
+++ b/tests/unit/ui/resilience-connections.test.tsx
@@ -213,7 +213,7 @@ describe("ResilienceConnectionsClient", () => {
     });
     // The degraded banner is the only caller passing a `sources` option, so the
     // interpolated JSON is a distinctive marker that the banner rendered.
-    await waitFor(() => el!.textContent?.includes('"sources":"degraded.source.circuitBreaker"'));
+    await waitFor(() => el!.textContent?.includes('"sources":"degradedSource.circuitBreaker"'));
   });
 
   it("degradation banner hidden when meta.degraded is empty", async () => {


### PR DESCRIPTION
## Summary

- `next-intl` rejects message keys containing a literal `.` (reserved for expressing nesting). This broke every dashboard page load (`RootLayout` → `getMessages()`) with an `INVALID_KEY` error across all 43 locale files.
- Only `compliance.eventTypes.*` had a runtime normalizer for this pattern (`normalizeComplianceEventTypes` in `src/i18n/request.ts`). `capabilityFilter.*` and `resilienceConnections.degraded.source.*` did not, and threw on every request.
- Restructured both into proper nested objects across all 43 locale files:
  - `"capabilityFilter.visionMismatch"` → `capabilityFilter: { visionMismatch: ... }` (and 3 siblings)
  - `"degraded.source.database"` → `resilienceConnections.degradedSource: { database: ... }` (and 3 siblings) — kept as a **sibling** key rather than nested under `degraded`, since `degraded` is also used as a plain string message (`t("degraded", {...})`) in the same component and can't be both a string and an object.
- Updated the one call site in `ResilienceConnectionsClient.tsx` from `t(\`degraded.source.${s}\`)` to `t(\`degradedSource.${s}\`)`.
- Updated the matching assertion in `tests/unit/ui/resilience-connections.test.tsx`.

⚠️ base-red inherited: #9985

## Test plan

- [x] All 43 locale JSON files still parse (`scripts/ad-hoc/validate-locale-json.mjs`)
- [x] `node scripts/i18n/check-ui-keys-coverage.mjs` — PASS, all 42 non-EN locales at 99.9–100% coverage
- [x] `npx tsc --pretty false -p tsconfig.typecheck-core.json` — clean
- [x] `npx vitest run --config vitest.config.ts tests/unit/ui/resilience-connections.test.tsx` — 17/17 passing
- [ ] Live browser re-verification of `/login` was attempted but blocked by an environment memory constraint (Turbopack dev server OOM-killed twice on this box independent of this change); static verification above was used instead