### PR TITLE
fix(vision): preserve high detail for inline images

### DIFF
--- a/open-sse/handlers/chatCore/upstreamBody.ts
+++ b/open-sse/handlers/chatCore/upstreamBody.ts
@@ -87,6 +87,71 @@ function truncateToolList(
   return bodyToSend;
 }
 
+// OpenCode's AI SDK file-part serializer omits `image_url.detail`, which makes
+// wide, text-dense screenshots fall back to low-detail vision sampling upstream.
+function defaultImageDetail(bodyToSend: Body): Body {
+  let nextBody = bodyToSend;
+
+  if (Array.isArray(bodyToSend.messages)) {
+    const messages = bodyToSend.messages.map((message) => {
+      if (!message || typeof message !== "object" || Array.isArray(message)) return message;
+      const messageRecord = message as Record<string, unknown>;
+      if (!Array.isArray(messageRecord.content)) return message;
+
+      let changed = false;
+      const content = messageRecord.content.map((part) => {
+        if (!part || typeof part !== "object" || Array.isArray(part)) return part;
+        const partRecord = part as Record<string, unknown>;
+        const imageUrl = partRecord.image_url;
+        if (
+          partRecord.type !== "image_url" ||
+          !imageUrl ||
+          typeof imageUrl !== "object" ||
+          Array.isArray(imageUrl)
+        ) {
+          return part;
+        }
+
+        const imageUrlRecord = imageUrl as Record<string, unknown>;
+        if (imageUrlRecord.detail !== undefined) return part;
+        changed = true;
+        return { ...partRecord, image_url: { ...imageUrlRecord, detail: "high" } };
+      });
+
+      return changed ? { ...messageRecord, content } : message;
+    });
+
+    if (messages.some((message, index) => message !== bodyToSend.messages?.[index])) {
+      nextBody = { ...nextBody, messages };
+    }
+  }
+
+  if (Array.isArray(bodyToSend.input)) {
+    const input = bodyToSend.input.map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return item;
+      const itemRecord = item as Record<string, unknown>;
+      if (!Array.isArray(itemRecord.content)) return item;
+
+      let changed = false;
+      const content = itemRecord.content.map((part) => {
+        if (!part || typeof part !== "object" || Array.isArray(part)) return part;
+        const partRecord = part as Record<string, unknown>;
+        if (partRecord.type !== "input_image" || partRecord.detail !== undefined) return part;
+        changed = true;
+        return { ...partRecord, detail: "high" };
+      });
+
+      return changed ? { ...itemRecord, content } : item;
+    });
+
+    if (input.some((item, index) => item !== bodyToSend.input?.[index])) {
+      nextBody = { ...nextBody, input };
+    }
+  }
+
+  return nextBody;
+}
+
 // Inject prompt_cache_key only for providers that support it.
 async function injectPromptCacheKey(
   bodyToSend: Body,
@@ -157,6 +222,7 @@ export async function prepareUpstreamBody(opts: {
     model: payloadRuleModel,
     log,
   });
+  bodyToSend = defaultImageDetail(bodyToSend);
   bodyToSend = truncateToolList(bodyToSend, provider, bypassDefaultToolLimit ?? false, log);
   const connectionCacheOverride = resolveConnectionCacheOverride(credentials?.providerSpecificData);
   bodyToSend = await injectPromptCacheKey(

--- a/src/lib/guardrails/visionBridgeHelpers.ts
+++ b/src/lib/guardrails/visionBridgeHelpers.ts
@@ -605,7 +605,7 @@ async function callVisionModelSingle(
                   type: "image_url",
                   image_url: {
                     url: normalizedImageInput,
-                    detail: "low",
+                    detail: "high",
                   },
                 },
                 { type: "text", text: config.prompt },

--- a/tests/unit/chatcore-upstream-body.test.ts
+++ b/tests/unit/chatcore-upstream-body.test.ts
@@ -50,6 +50,58 @@ test("leaves the model untouched when it already matches", async () => {
   assert.equal(out.model, "model-a");
 });
 
+test("defaults OpenAI image inputs to high detail without overriding explicit detail", async () => {
+  const out = await prepareUpstreamBody({
+    translatedBody: {
+      model: "model-a",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Read this screenshot" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,test" } },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,test", detail: "low" },
+            },
+          ],
+        },
+      ],
+    },
+    modelToCall: "model-a",
+    provider: "opencode-zen",
+    targetFormat: FORMATS.OPENAI,
+    credentials: null,
+  });
+
+  const content = (
+    out.messages as Array<{ content: Array<{ image_url?: { detail?: string } }> }>
+  )[0].content;
+  assert.equal(content[1].image_url?.detail, "high");
+  assert.equal(content[2].image_url?.detail, "low");
+});
+
+test("defaults Responses input images to high detail", async () => {
+  const out = await prepareUpstreamBody({
+    translatedBody: {
+      model: "model-a",
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_image", image_url: "data:image/png;base64,test" }],
+        },
+      ],
+    },
+    modelToCall: "model-a",
+    provider: "opencode-zen",
+    targetFormat: FORMATS.OPENAI_RESPONSES,
+    credentials: null,
+  });
+
+  const content = (out.input as Array<{ content: Array<{ detail?: string }> }>)[0].content;
+  assert.equal(content[0].detail, "high");
+});
+
 test("strips Codex GPT-5 verbosity after routing resolves to opencode-go/GLM", async () => {
   const translatedBody = {
     model: "glm-5.2",

--- a/tests/unit/guardrails/visionBridgeHelpers.callVisionModel.test.ts
+++ b/tests/unit/guardrails/visionBridgeHelpers.callVisionModel.test.ts
@@ -277,7 +277,7 @@ test("callVisionModel uses correct request body format", async () => {
     };
     assert.strictEqual(imagePart.type, "image_url");
     assert.strictEqual(imagePart.image_url.url, imageUri);
-    assert.strictEqual(imagePart.image_url.detail, "low");
+    assert.strictEqual(imagePart.image_url.detail, "high");
 
     // Second content is text prompt
     const textPart = message.content[1] as { type: string; text: string };


### PR DESCRIPTION
## Summary

OpenCode serializes pasted image file parts as OpenAI `image_url` content without a `detail` field. OmniRoute then forwards the provider default, which is low-detail sampling. That makes wide, text-dense screenshots unreadable even though the original image bytes are intact.

This change:

- Defaults missing `image_url.detail` to `high` for OpenAI chat messages.
- Defaults missing `detail` to `high` for Responses `input_image` parts.
- Preserves explicit client values such as `low`, `auto`, and `high`.
- Uses high detail for the internal OpenAI-compatible vision bridge.

## Verification

- `tests/unit/chatcore-upstream-body.test.ts`
- `tests/unit/guardrails/visionBridgeHelpers.callVisionModel.test.ts`
- Targeted ESLint passed.
- The regression fails before the change and passes after it.