### PR TITLE
fix(providers): validate Z.ai web auth semantics

### DIFF
--- a/changelog.d/fixes/10329-zai-web-auth-semantics.md
+++ b/changelog.d/fixes/10329-zai-web-auth-semantics.md
@@ -1,0 +1,1 @@
+- **fix(providers):** validate Z.ai web Local Storage sessions against the authenticated user-settings endpoint and preserve exact upstream status codes ([#10329](https://github.com/diegosouzapw/OmniRoute/pull/10329)) — thanks @Zartharas

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -81,6 +81,7 @@ import {
   validatePoeProvider,
 } from "./validation/audioMiscProviders";
 import { validateChatGptWebCodexProvider } from "./validation/chatgptWebCodex";
+import { validateZaiWebProvider } from "./validation/zaiWeb";
 import { validateSearchProvider, SEARCH_VALIDATOR_CONFIGS } from "./validation/searchProviders";
 import {
   validateClarifaiProvider,
@@ -227,7 +228,7 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
           error:
             "Modal requires a Base URL pointing to your OpenAI-compatible Modal app " +
             "(e.g. https://<workspace>--<app>.modal.run/v1). " +
-            "Fill in the \"Base URL override\" field.",
+            'Fill in the "Base URL override" field.',
         };
       }
       return validateOpenAILikeProvider({
@@ -249,6 +250,7 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     snowflake: validateSnowflakeProvider,
     gigachat: validateGigachatProvider,
     "deepseek-web": validateDeepSeekWebProvider,
+    "zai-web": validateZaiWebProvider,
     "grok-web": validateGrokWebProvider,
     "qwen-web": validateQwenWebProvider,
     "kimi-web": validateKimiWebProvider,

--- a/src/lib/providers/validation/zaiWeb.ts
+++ b/src/lib/providers/validation/zaiWeb.ts
@@ -1,0 +1,52 @@
+import { extractZaiToken } from "@omniroute/open-sse/services/zaiWebCredentials.ts";
+import { toValidationErrorResult, validationRead } from "./transport";
+
+const ZAI_SESSION_PROBE_URL = "https://chat.z.ai/api/v1/users/user/settings";
+
+export async function validateZaiWebProvider({ apiKey }: { apiKey?: string }) {
+  const token = extractZaiToken(String(apiKey || ""));
+
+  if (!token) {
+    return {
+      valid: false,
+      error:
+        'Invalid Z.ai web-session credential — copy the "token" value from chat.z.ai Local Storage.',
+    };
+  }
+
+  try {
+    const response = await validationRead(ZAI_SESSION_PROBE_URL, {
+      method: "GET",
+      headers: {
+        Accept: "application/json, text/plain, */*",
+        Authorization: `Bearer ${token}`,
+        Origin: "https://chat.z.ai",
+        Referer: "https://chat.z.ai/",
+      },
+    });
+
+    if (response.status >= 200 && response.status < 300) {
+      return {
+        valid: true,
+        error: null,
+      };
+    }
+
+    if (response.status === 401) {
+      return {
+        valid: false,
+        error:
+          'Invalid or expired Z.ai web-session credential — copy a fresh "token" value from chat.z.ai Local Storage.',
+        statusCode: 401,
+      };
+    }
+
+    return {
+      valid: false,
+      error: `Z.ai session validation returned HTTP ${response.status}`,
+      statusCode: response.status,
+    };
+  } catch (error: unknown) {
+    return toValidationErrorResult(error);
+  }
+}

--- a/tests/unit/zai-web-auth-semantics.test.ts
+++ b/tests/unit/zai-web-auth-semantics.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const originalFetch = globalThis.fetch;
+
+const { validateProviderApiKey } = await import("../../src/lib/providers/validation.ts");
+
+let nextStatus = 200;
+let lastRequest: {
+  url: string;
+  method: string;
+  authorization: string;
+  cookie: string;
+} | null = null;
+
+let lastResponse: Response | null = null;
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const headers = new Headers(init?.headers);
+
+  lastRequest = {
+    url: String(input),
+    method: String(init?.method || "GET"),
+    authorization: headers.get("authorization") || "",
+    cookie: headers.get("cookie") || "",
+  };
+
+  lastResponse = new Response(
+    JSON.stringify({
+      secret: "response-body-must-not-be-consumed",
+    }),
+    {
+      status: nextStatus,
+      headers: {
+        "content-type": "application/json",
+      },
+    }
+  );
+
+  return lastResponse;
+}) as typeof fetch;
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function validate(status: number) {
+  nextStatus = status;
+  lastRequest = null;
+  lastResponse = null;
+
+  return validateProviderApiKey({
+    provider: "zai-web",
+    apiKey: "synthetic-zai-token",
+    providerSpecificData: {},
+  });
+}
+
+test("zai-web uses the token-only authenticated user-settings GET", async () => {
+  const result = await validate(200);
+
+  assert.equal(result.valid, true);
+
+  assert.equal(lastRequest?.url, "https://chat.z.ai/api/v1/users/user/settings");
+
+  assert.equal(lastRequest?.method, "GET");
+
+  assert.equal(lastRequest?.authorization, "Bearer synthetic-zai-token");
+
+  assert.equal(lastRequest?.cookie, "");
+
+  assert.equal(lastResponse?.bodyUsed, false);
+});
+
+test("zai-web preserves exact 401 as credential rejection", async () => {
+  const result = await validate(401);
+
+  assert.equal(result.valid, false);
+  assert.equal(result.statusCode, 401);
+
+  assert.match(result.error, /invalid or expired/i);
+
+  assert.equal(lastResponse?.bodyUsed, false);
+});
+
+test("zai-web preserves 403 without calling it expired", async () => {
+  const result = await validate(403);
+
+  assert.equal(result.valid, false);
+  assert.equal(result.statusCode, 403);
+
+  assert.doesNotMatch(result.error, /invalid or expired/i);
+
+  assert.equal(lastResponse?.bodyUsed, false);
+});
+
+test("zai-web preserves rate-limit and server statuses", async () => {
+  for (const status of [429, 503]) {
+    const result = await validate(status);
+
+    assert.equal(result.valid, false);
+    assert.equal(result.statusCode, status);
+
+    assert.doesNotMatch(result.error, /invalid or expired/i);
+
+    assert.equal(lastResponse?.bodyUsed, false);
+  }
+});


### PR DESCRIPTION
## Summary

Fix Z.ai web connection testing so it validates the Local Storage session token against Z.ai's authenticated user-settings endpoint instead of relying on the generic `/api/models` web-session probe.

The dedicated validator preserves literal upstream status codes so callers can distinguish an exact authentication rejection from rate limits, server errors, and other upstream failures.

## Root cause

`zai-web` previously fell through to the generic web-cookie validator.

That path probes `/api/models`, which is primarily a model-catalog endpoint rather than a dedicated authenticated-session endpoint. It also uses the generic `AUTH_007` handling instead of returning the precise upstream status needed by connection-test failure classification.

Z.ai's current OmniRoute credential contract stores only the Local Storage `token`, so the validator needs to test the same token-only authentication shape used by the provider.

## Fix

Added a dedicated `validateZaiWebProvider()` that:

- extracts the existing Z.ai Local Storage token using `extractZaiToken()`
- sends `GET /api/v1/users/user/settings`
- authenticates using only `Authorization: Bearer <token>`
- does not require or send a Cookie header
- treats 2xx as valid
- preserves exact HTTP 401 as invalid/expired credentials
- preserves 403 without labeling it as an expired session
- preserves 429 and 5xx status codes for downstream classification
- does not consume the upstream response body

The specialty validator is registered ahead of the generic web-session fallback.

## Live semantic verification

A read-only control was performed before implementation:

- valid current Z.ai Local Storage token → HTTP 200
- fixed synthetic invalid token → HTTP 401
- Cookie header sent → no
- response body read → no
- provider mutation → none
- OmniRoute mutation → none

This confirmed that `/api/v1/users/user/settings` provides a reliable token-only authentication signal for the credential format OmniRoute actually stores.

## Validation

Focused new regression:

- `tests/unit/zai-web-auth-semantics.test.ts` — 4/4 passed

Existing web-validation regressions:

- `provider-validation-web-cookie-auth007.test.ts`
- `web-cookie-validation-proxy-7058.test.ts`
- 6/6 passed

Existing Z.ai executor suite:

- `executor-zai-web.test.ts`
- 28/28 passed

Additional gates:

- focused ESLint — passed
- `npm run typecheck:core` — passed
- `git diff --check` — passed

No live OmniRoute stack was modified during implementation.
