### PR TITLE
fix(sse): clear release/v3.8.50 base reds — dup import, stale suppressions, skill sync, stryker testFiles

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1701,11 +1701,6 @@
       "count": 43
     }
   },
-  "tests/unit/call-log-file-rotation.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 5
-    }
-  },
   "tests/unit/call-log-startup.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -74,7 +74,6 @@ import {
   hasUnsupportedReasoningSignal,
 } from "./reasoningFields.ts";
 import { applyThinkTag, flushThink, initThinkState } from "./thinkTagParser.ts";
-import { sseCommentsEnabled } from "./sseHeartbeat.ts";
 import {
   caseInsensitiveToolNameLookup,
   restoreOpenAIToolNames,

--- a/skills/omni-settings/SKILL.md
+++ b/skills/omni-settings/SKILL.md
@@ -319,15 +319,7 @@ curl -X PUT https://localhost:20128/api/settings/system-prompt \
 
 Get thinking budget configuration
 
-Returns proxy-level thinking/reasoning **request rewrite** settings:
-
-| Field | Meaning |
-|-------|---------|
-| `mode` | `passthrough` (leave client reasoning alone — **required for Codex visible thinking**), `auto` (**strips** all client thinking fields), `custom`, `adaptive` |
-| `customBudget` | Fixed budget when `mode=custom` |
-| `effortLevel` | Base effort when `mode=adaptive` |
-
-**Not** compression and **not** “decrypt encrypted reasoning”. Full guide: `docs/guides/THINKING_BUDGET.md`.
+Returns the current thinking/reasoning budget settings for AI models.
 
 ```bash
 curl https://localhost:20128/api/settings/thinking-budget \
@@ -338,16 +330,12 @@ curl https://localhost:20128/api/settings/thinking-budget \
 
 Update thinking budget configuration
 
-Example — keep client-controlled reasoning (Codex/Desktop):
-
 ```bash
 curl -X PUT https://localhost:20128/api/settings/thinking-budget \
-  -H "Authorization: Bearer $OMNIROUTE_TOKEN" \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
   -H "Content-Type: application/json" \
-  -d '{"mode":"passthrough","customBudget":10240,"effortLevel":"medium"}'
+  -d '{}'
 ```
-
-Warning: `mode=auto` deletes `reasoning` / `reasoning_effort` / Claude `thinking` from the outbound body before upstream. That can empty thinking panels even when the client requested Ultra + summary.
 
 ### GET /api/tags
 

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -232,6 +232,7 @@
       "tests/unit/gemini-web-missing-browser-3516.test.ts",
       "tests/unit/grok-cli-oauth.test.ts",
       "tests/unit/guardrails-api-3496.test.ts",
+      "tests/unit/guardrails/visionBridge-responses-9597.test.ts",
       "tests/unit/headroom-codex-quota-snapshot-6379.test.ts",
       "tests/unit/headroom-proxy-lifecycle.test.ts",
       "tests/unit/idempotency-fusion-collision.test.ts",


### PR DESCRIPTION
## O que
Drena os base-reds determinísticos do tip de `release/v3.8.50` (`266e39d36d`) — round 5. Refs #9985.

| Fix | Arquivo | Gate que valida (antes → depois, rodado local) |
| --- | --- | --- |
| Remove import duplicado de `sseCommentsEnabled` (linha 77, clobber de merge do #9378) | `open-sse/utils/stream.ts` | `check:open-sse-typecheck`: TS2300 ×2 → **OK** (26 pré-existentes no baseline). Desbloqueia também Fast Production Build / dast-smoke / Build advisory (Turbopack "Ecmascript file had an error" apontava este arquivo) |
| Prune de 5 suppressions ESLint obsoletas (0 adições) | `config/quality/eslint-suppressions.json` | `npm run lint:json -- --max-warnings 0`: exit 2 ("suppressions left that do not occur anymore") → **exit 0** |
| Regen do SKILL.md gerado de `omni-settings` | `skills/omni-settings/SKILL.md` | `check:agent-skills-sync`: exit 2 (GENERATED: + omni-settings) → **✓ 46 unchanged** |
| Registra `tests/unit/guardrails/visionBridge-responses-9597.test.ts` (do #10202) em `tap.testFiles` | `stryker.conf.json` | `check:mutation-test-coverage --strict`: 1 missing → **✓ no drift** |

## Fora de escopo (reds da base que permanecem)
- Falhas de unit shards (combo/priority retry, i18n `denoRelayOrgDomainHint`, signal-abort, poolside) — precisam de diagnóstico próprio (/sweep-reds).
- Drift de ratchet `dead-code` (409 > 248) — rebaseline na release, por política.

⚠️ base-red inherited: #9985 (este PR é o fix de parte desses reds; os gates corrigidos devem passar já na rodada de CI deste PR, pois o CI roda contra o merge-ref base+PR).