### PR TITLE
[TS7] fix(types): restore custom model output limit contract

### DIFF
--- a/src/app/api/v1/models/catalogHelpers.ts
+++ b/src/app/api/v1/models/catalogHelpers.ts
@@ -16,6 +16,7 @@ export interface CustomModelEntry {
   apiFormat?: string;
   supportedEndpoints?: string[];
   inputTokenLimit?: number;
+  outputTokenLimit?: number;
   isHidden?: boolean;
   // User-set "vision-capable" flag (persisted by addCustomModel / replaceCustomModels
   // in src/lib/db/models.ts). Surfaced into `/v1/models` via

--- a/tests/unit/model-token-limit-catalog.test.ts
+++ b/tests/unit/model-token-limit-catalog.test.ts
@@ -251,6 +251,11 @@ test("v1 model catalog overlays same-id custom metadata before final overrides",
     { outputTokenLimit: 32000 },
     false
   );
+
+  const customProjected = await getModel(`${prefix}/${modelId}`);
+  assert.ok(customProjected);
+  assert.equal(customProjected.max_output_tokens, 32000);
+
   assert.equal(
     capabilityOverrides.setModelCapabilityOverride(
       `${prefix}/${modelId}`,


### PR DESCRIPTION
## Summary

- restore the persisted `outputTokenLimit` field on the custom-model catalog contract
- verify that a custom model's output limit is projected as `max_output_tokens` before final capability overrides
- remove the final two TypeScript 6 and official TypeScript 7.0.2 diagnostics on `release/v3.8.50`

## Root cause

PR #10248 began reading `CustomModelEntry.outputTokenLimit` while the local interface still declared only `inputTokenLimit`. The field is already persisted and consumed elsewhere; only this catalog boundary contract was incomplete.

## Validation

- `node --import tsx/esm --test tests/unit/model-token-limit-catalog.test.ts` (5 passed)
- `./node_modules/.bin/tsc --pretty false -p open-sse/tsconfig.json` (0 diagnostics)
- `npm exec --yes --package=typescript@7.0.2 -- tsc --pretty false -p open-sse/tsconfig.json` (0 diagnostics)
- `npm run test:vitest` (357 passed)
- `npm run check:file-size`
- targeted ESLint on both changed files

Closes the final remaining diagnostics tracked by #8484.
