### PR TITLE
fix(auto): rate-limit empty-pool AUTO warnings

### DIFF
--- a/changelog.d/fixes/auto-empty-pool-log-once.md
+++ b/changelog.d/fixes/auto-empty-pool-log-once.md
@@ -1,0 +1,1 @@
+- **fix(auto):** rate-limit `auto/<family> matched no connected models` warnings to once per minute per label (`open-sse/services/autoCombo/virtualFactory.ts`)

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -44,6 +44,23 @@ export interface AutoComboSpec {
   family?: ModelFamily;
 }
 
+/** Rate-limit empty-pool AUTO warns (same label can be resolved many times/min). */
+const emptyPoolWarnAt = new Map<string, number>();
+export const EMPTY_POOL_WARN_INTERVAL_MS = 60_000;
+
+export function warnEmptyAutoPoolOnce(label: string, message: string, now = Date.now()): boolean {
+  const last = emptyPoolWarnAt.get(label) ?? 0;
+  if (now - last < EMPTY_POOL_WARN_INTERVAL_MS) return false;
+  emptyPoolWarnAt.set(label, now);
+  log.warn("AUTO", message);
+  return true;
+}
+
+/** Test-only: reset the debounce map. */
+export function resetEmptyAutoPoolWarnStateForTests(): void {
+  emptyPoolWarnAt.clear();
+}
+
 /** Minimal connection shape needed for virtual auto-combo factory */
 interface VirtualFactoryConn extends ConnectionFields {
   id: string;
@@ -692,8 +709,8 @@ export async function createVirtualAutoComboFromPrepared(
       // Family combos always degrade to an empty pool when unavailable — a family
       // is a hard identity constraint, not a soft optimization bias, so there is
       // no sensible "fall back to the full pool" behavior for it.
-      log.warn(
-        "AUTO",
+      warnEmptyAutoPoolOnce(
+        label,
         `${label} matched no connected models; returning an empty pool.${spec?.family ? "" : ' Set OMNIROUTE_AUTO_FREE_FALLBACK_TO_FULL_POOL=true to restore the legacy "use full pool" behavior.'}`
       );
       effectivePool = [];

--- a/tests/unit/auto-empty-pool-warn-once.test.ts
+++ b/tests/unit/auto-empty-pool-warn-once.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  EMPTY_POOL_WARN_INTERVAL_MS,
+  resetEmptyAutoPoolWarnStateForTests,
+  warnEmptyAutoPoolOnce,
+} from "../../open-sse/services/autoCombo/virtualFactory.ts";
+
+test("warnEmptyAutoPoolOnce emits at most once per label per interval", () => {
+  resetEmptyAutoPoolWarnStateForTests();
+  const t0 = 1_000_000;
+  assert.equal(warnEmptyAutoPoolOnce("auto/zai", "empty", t0), true);
+  assert.equal(warnEmptyAutoPoolOnce("auto/zai", "empty", t0 + 1), false);
+  assert.equal(warnEmptyAutoPoolOnce("auto/zai", "empty", t0 + EMPTY_POOL_WARN_INTERVAL_MS - 1), false);
+  assert.equal(warnEmptyAutoPoolOnce("auto/other", "empty", t0 + 1), true);
+  assert.equal(warnEmptyAutoPoolOnce("auto/zai", "empty", t0 + EMPTY_POOL_WARN_INTERVAL_MS), true);
+});


### PR DESCRIPTION
## Summary

- `virtualFactory` `log.warn`s `auto/<family> matched no connected models; returning an empty pool` **on every resolve**.
- Observed on 3.8.49: that line ~once per 1–2 minutes continuously when a family (e.g. a virtual `auto/<family>`) has zero connected models — including when nothing user-facing needs that family (suspicion: health/catalog tick).
- Behavior unchanged (still empty pool). Warn is rate-limited to **once per label per 60s**.
- Unit test for the debounce helper.

## Related Issues

- Empty-pool AUTO log-storm issue filed in this batch
- Related to #10052 only as extra main-thread logging under load

## Validation

- [x] Production-code changes include a new or updated automated test in this PR

```text
node --import tsx --test tests/unit/auto-empty-pool-warn-once.test.ts
```

No secrets or private hostnames.
