### PR TITLE
feat(sse): add GLM-5.3 models and effort tiers

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,411 @@
+<!-- refreshed: 2026-08-14 -->
+# Architecture
+
+**Analysis Date:** 2026-08-14
+
+## System Overview
+
+OmniRoute is a unified AI proxy/router with 7 architectural layers that process client requests through format translation, intelligent routing, and upstream execution:
+
+```text
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                         API Routes (Entry Points)                             │
+│                         src/app/api/v1/*/route.ts                             │
+│  ┌─CORS → Zod Validation → Auth → Policy → Prompt Injection Guard─────────┐  │
+└──┼─────────────────────────────────────────────────────────────────────────┼──┘
+   │
+   ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                    Request Handling Layer                                     │
+│         open-sse/handlers/{chatCore,embeddings,images}.ts                    │
+│  ┌─Memory Injection → Request Setup → Tool Normalization────────────────┐   │
+│  │─Cache Check → Rate Limit → Semantic Cache → Idempotency──────────┐  │   │
+│  │─Client Buffers → Guardrails → Lifecycle Checks────────────────┐  │  │   │
+└──┼────────────────────────────────────────────────────────────────┼──┼──┼───┘
+   │                                                                │  │  │
+   ▼                                                                │  │  │
+┌──────────────────────────────────────────────────────────────────┼──┼──────┐
+│                    Routing & Resilience Layer                    │  │      │
+│      open-sse/services/{combo,accountFallback}.ts                │  │      │
+│  ┌─Combo Strategy Selection → Target Candidate Building──────┐  │  │      │
+│  │─Quota Evaluation → Credential Gate → Session Affinity──┐  │  │  │      │
+│  │─Circuit Breaker Check → Account Semaphore → Model Lock─┤  │  │  │      │
+└──┼──────────────────────────────────────────────────────────┼──┼──┼───────┘
+   │  (19 combo strategies: priority/weighted/round-robin/    │  │  │
+   │   cost-optimized/fusion/auto/... See AUTO-COMBO.md)      │  │  │
+   │                                                            │  │  │
+   ▼                                                            │  │  │
+┌──────────────────────────────────────────────────────────────┼──┼────────┐
+│                   Format Translation Layer                    │  │        │
+│    open-sse/translator/{index,request,response}/*.ts         │  │        │
+│  ┌─Request Normalization → Format Conversion────────────┐   │  │        │
+│  │─Tool Translation → Schema Coercion → Reasoning Setup ├───┼──┼────┐   │
+│  │─Response Translation → Result Synthesis             │   │  │    │   │
+└──┼─────────────────────────────────────────────────────┼───┼──┼────┼───┘
+   │  (OpenAI ↔ Claude ↔ Gemini ↔ Responses formats)     │   │  │    │
+   │                                                      │   │  │    │
+   ▼                                                      │   │  │    │
+┌────────────────────────────────────────────────────────┼───┼──┼────┼────┐
+│              Provider Execution Layer                   │   │  │    │    │
+│       open-sse/executors/base.ts + provider-specific   │   │  │    │    │
+│  ┌─Request Transformation → Credential Inject────────┐ │   │  │    │    │
+│  │─HTTP Dispatch w/ Retry/Backoff → Stream Setup─────┤─┼───┼──┼────┼──┐ │
+│  │─Error Classification → Fallback Signaling       │ │ │   │  │    │  │ │
+└──┼───────────────────────────────────────────────────┼─┼───┼──┼────┼──┼─┘
+   │  (124+ provider executors: OpenAI, Claude,        │ │   │  │    │  │
+   │   Anthropic, Gemini, local, etc)                  │ │   │  │    │  │
+   │                                                    │ │   │  │    │  │
+   ▼                                                    │ │   │  │    │  │
+┌───────────────────────────────────────────────────────┼─┼───┼──┼────┼──┼──┐
+│              Upstream HTTP & Resilience               │ │   │  │    │  │  │
+│    fetch() w/ Retry Policy → Connection Cooldown     │ │   │  │    │  │  │
+│    Provider Circuit Breaker → Model Lockout          │ │   │  │    │  │  │
+│    Account Semaphore → Rate Limit Tracking           │ │   │  │    │  │  │
+└───────────────────────────────────────────────────────┼─┼───┼──┼────┼──┼──┘
+   │                                                    │ │   │  │    │  │
+   ├──(Success Path)───────────────────────────────────┘ │   │  │    │  │
+   │                                                      │   │  │    │  │
+   ▼                                                      │   │  │    │  │
+┌─────────────────────────────────────────────────────────┼───┼──┼────┼──┼──┐
+│           Response & Stream Processing                  │   │  │    │  │  │
+│  Response Format Detection → Transform Stream Setup     │   │  │    │  │  │
+│  SSE/JSON Output → Semantic Cache Store → Usage Track  │   │  │    │  │  │
+└─────────────────────────────────────────────────────────┼───┼──┼────┼──┼──┘
+   │                                                      │   │  │    │  │
+   │   (Failure Path: checkFallbackError) ◄──────────────┘   │  │    │  │
+   │   (Retries per combo strategy)      ◄──────────────────┘  │    │  │
+   │   (Fall back to next target)        ◄──────────────────────┘    │  │
+   │   (Final error response)            ◄──────────────────────────┘  │
+   │                                                                    │
+   ▼                                                                    │
+┌──────────────────────────────────────────────────────────────────────┼──┐
+│           Persistence & Support Services                              │  │
+│  Database (src/lib/db/): SQLite 145+ migrations, 30+ domain modules  │  │
+│  Memory (src/lib/memory/): FTS5 + Qdrant vector search               │  │
+│  Cache (open-sse/services/): Semantic, idempotency, combo context    │  │
+│  Webhooks (src/lib/webhookDispatcher.ts): Request/response events    │  │
+│  MCP Server (open-sse/mcp-server/): 105 tools, 31 scopes             │  │
+│  A2A (src/lib/a2a/): JSON-RPC 2.0 agent protocol, 5 skills          │  │
+│  Skills (src/lib/skills/): Extensible sandboxed skill framework      │  │
+│  Cloud Agents (src/lib/cloudAgent/): Integration with external AI    │  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Responsibilities
+
+| Component | Responsibility | File |
+|-----------|----------------|------|
+| **API Routes** | HTTP entry points, CORS, validation, auth, delegation | `src/app/api/v1/*/route.ts` |
+| **Request Handlers** | Cache/rate-limit checks, guardrails, memory injection, lifecycle | `open-sse/handlers/chatCore.ts` |
+| **Combo Router** | Multi-target selection, strategy execution, target orchestration | `open-sse/services/combo.ts` |
+| **Account Fallback** | Credential selection, circuit breaker, connection cooldown, model lockout | `open-sse/services/accountFallback.ts` |
+| **Request Translator** | OpenAI/Claude/Gemini/Responses format interop | `open-sse/translator/index.ts` |
+| **Provider Executors** | HTTP dispatch, credential injection, error classification | `open-sse/executors/base.ts` |
+| **Stream Processor** | SSE/JSON output, chunking, error finalization | `open-sse/utils/stream.ts` |
+| **Database** | Persistence of credentials, combos, settings, migrations | `src/lib/db/core.ts` |
+| **Domain Policy** | Cost rules, fallback logic, quota enforcement | `src/domain/` |
+| **Guardrails** | PII masking, prompt injection, vision safety | `src/lib/guardrails/` |
+| **MCP Server** | 105 tools across 31 scopes (stdio/SSE/HTTP) | `open-sse/mcp-server/` |
+| **A2A Server** | JSON-RPC 2.0 agent protocol, 5 skills | `src/lib/a2a/` |
+
+## Pattern Overview
+
+**Overall:** Streaming-first request pipeline with pluggable executors and multi-target failover.
+
+**Key Characteristics:**
+- **Stateless HTTP handlers** per route; state stored in SQLite or transient cache
+- **Promise-based async flow** with no blocking I/O; all persistence via async DB calls
+- **Per-request logging context** (traceId) for correlation across layers
+- **Lazy resilience recovery** — circuit breaker and connection cooldown checked on read, not background task
+- **Hot-path optimization** — route shape validation minimal; deep validation in handler; formatted requests cached
+- **Error classification pattern** — each layer catches and classifies failures (account error vs. provider error vs. upstream error) before deciding retry/fallback
+
+## Layers
+
+**API Routes (Entry):**
+- Purpose: HTTP binding, OPTIONS/POST handling, headers normalization, body parsing
+- Location: `src/app/api/v1/*/route.ts` (40+ routes)
+- Contains: Route handlers following Next.js App Router pattern
+- Depends on: Zod (validation), `open-sse/handlers/*` (delegation)
+- Used by: HTTP clients (OpenAI-compatible endpoints)
+
+**Request Handlers (Processing):**
+- Purpose: Manage request lifecycle — cache checks, rate limits, guardrails, memory injection, model lifecycle
+- Location: `open-sse/handlers/` (32 modules)
+- Contains: `chatCore.ts` (main), `embeddings.ts`, `images.ts`, and 30+ context modules for isolated concerns
+- Depends on: `open-sse/services/` (combo, cache, rate limit), `open-sse/translator/`, guardrails, DB
+- Used by: API routes, combo service (per-target wrapper)
+
+**Routing & Resilience (Orchestration):**
+- Purpose: Multi-target selection, execution strategy, circuit breaker, account semaphore, model lockout
+- Location: `open-sse/services/{combo.ts, accountFallback.ts, ...}`
+- Contains: 19 combo strategies (priority/weighted/round-robin/fusion/cost/context-optimized/etc.), quota evaluation, credential gate
+- Depends on: Credentials DB, circuit breaker state, model lockout DB, quota cache
+- Used by: `handleChat`, combo endpoints, MCP tools
+
+**Format Translation (Interop):**
+- Purpose: Convert between OpenAI, Claude, Gemini, Responses, and other API formats
+- Location: `open-sse/translator/{index.ts, request/*, response/*}`
+- Contains: Request normalization, tool translation, schema coercion, response synthesis
+- Depends on: Format registry, model capabilities DB, provider config
+- Used by: Request handlers (before executor), response processors (after upstream)
+
+**Provider Execution (HTTP Dispatch):**
+- Purpose: Provider-specific HTTP dispatch, credential injection, error classification, retry policy
+- Location: `open-sse/executors/base.ts` (72KB base class), 124+ provider-specific executors
+- Contains: Base executor pattern, OAuth token refresh, API key rotation, fingerprinting, header management
+- Depends on: HTTP client (`fetch`), executor registry, provider config
+- Used by: Combo service per target (wrapped in `handleSingleModel`)
+
+**Stream & Response (Output):**
+- Purpose: SSE/JSON stream assembly, chunking, semantic cache storage, response cleanup
+- Location: `open-sse/utils/{stream.ts, sseHeartbeat.ts}`, `open-sse/transformer/`
+- Contains: TransformStream builders, event serialization, keepalive frames, error finalization
+- Depends on: Stream controller, response format, usage tracking
+- Used by: Response assembly phase in handlers
+
+**Persistence & Support:**
+- **Database**: `src/lib/db/{core.ts, [130 modules]}` — SQLite, 145 migrations, domain modules for credentials/combos/settings
+- **Memory**: `src/lib/memory/` — FTS5 full-text search + Qdrant vector for semantic recall
+- **Cache**: `open-sse/services/{semanticCache.ts, idempotencyCache.ts, comboContextCache.ts}`
+- **MCP**: `open-sse/mcp-server/{tools/*, transports/*}` — 105 tools, 31 scopes, 3 transports
+- **A2A**: `src/lib/a2a/` — JSON-RPC 2.0 agent protocol, 5 skills
+- **Webhooks**: `src/lib/webhookDispatcher.ts` — request/response lifecycle events
+
+## Data Flow
+
+### Primary Request Path
+
+1. **HTTP Entry** (`src/app/api/v1/chat/completions/route.ts:81-300`)
+   - Parse request body once (no body re-reads)
+   - Validate Content-Type (application/json)
+   - Extract headers (compression, streaming hints)
+   - Initialize translators (singleton, Promise-based)
+
+2. **Admission & Validation** (`src/app/api/v1/chat/completions/route.ts:100-200`)
+   - Chat admission queue (max wait: CHAT_ADMISSION_QUEUE_MAX_MS)
+   - Zod shape validation (minimal; deep validation downstream)
+   - Prompt injection guard check
+   - Extract API key, policy enforcement
+
+3. **Handler Delegation** (`src/app/api/v1/chat/completions/route.ts:200+`)
+   - Call `handleChat()` from `src/sse/handlers/chat.ts`
+   - Pass: body, credentials, API key info, correlation ID, session affinity
+   - Chain response through compression echo, SSE keepalive, early stream keepalive
+
+4. **Request Processing** (`open-sse/handlers/chatCore.ts:426-850`)
+   - Extract model info, create trace ID
+   - Inject system prompt, custom system prompt
+   - Run plugin onRequest hook
+   - Resolve request format (OpenAI vs. Responses vs. Claude)
+   - Check semantic cache (full match)
+   - Check idempotency cache
+   - Normalize messages, resolve lifecycle (model deprecation policy)
+   - Validate tool calling support
+   - Resolve memory & skills context
+   - Apply client usage buffers
+   - Build guardrail context
+
+5. **Routing Decision** (`open-sse/handlers/chatCore.ts:850-1000`)
+   - Parse combo name (if multi-target)
+   - Resolve combo strategy (19 options)
+   - Build combo context (targets, quota info, credential gates)
+   - If single-target: proceed to translation
+   - If multi-target: invoke `handleCombo()` (orchestrates per-target `handleSingleModel()`)
+
+6. **Format Translation** (`open-sse/handlers/chatCore.ts:1000-1200`)
+   - Call `translateRequest()` (returns translated body + metadata)
+   - Resolve target format per provider/model
+   - Normalize OpenAI↔Claude↔Gemini↔Responses
+   - Translate tools (tool schema coercion, optional enum omission)
+   - Strip unsupported params per provider
+   - Apply reasoning/thinking budget
+
+7. **Executor Resolution & Dispatch** (`open-sse/handlers/chatCore.ts:1200-1400`)
+   - Call `getExecutor(provider, model)` (returns appropriate executor class)
+   - Instantiate with credentials
+   - Call `executor.execute({translatedBody, ...})`
+   - Executor handles: credential injection, header merging, OAuth token refresh, retry policy
+   - Executor dispatches: `fetch()` to upstream with retry loop (backoff on 5xx/408)
+
+8. **Error Classification & Fallback** (`open-sse/handlers/chatCore.ts:1400-1500`)
+   - Catch upstream error
+   - Call `checkFallbackError()` (classify: account error / provider error / context overflow / quota / etc.)
+   - Decide: retry same target, fall back to next combo target, or final error
+   - If fallback eligible: record model lockout, mark connection cooldown, loop to step 5 (next target)
+   - If no fallback: build error response
+
+9. **Response Processing** (`open-sse/handlers/chatCore.ts:1500-1700`)
+   - Detect response format (streaming vs. JSON)
+   - If streaming: set up SSE stream, apply keepalive, semantic cache store
+   - If JSON: extract usage, convert to client format, apply Responses semantics
+   - Store semantic cache (if hit eligible)
+   - Emit request.completed event
+   - Return response with correct headers (CORS, content-type, usage)
+
+### Combo Routing Flow (Multi-Target)
+
+1. **Combo Setup** (`open-sse/services/combo.ts:100-300`)
+   - Resolve combo config from DB
+   - Build target candidates (providers + models)
+   - Evaluate quota per candidate
+   - Check credential gate (available accounts)
+   - Apply session affinity (sticky connection)
+   - Order by strategy (priority/cost/round-robin/etc.)
+
+2. **Per-Target Execution** (`open-sse/services/combo.ts:300-600`)
+   - For each target in order:
+     - Check circuit breaker (CLOSED/OPEN/HALF_OPEN)
+     - Check model lockout (per target)
+     - Try to acquire account semaphore slot
+     - Call `handleSingleModel()` (wraps `handleChatCore()`)
+     - Catch response/error
+
+3. **Fallback Decision** (`open-sse/services/combo.ts:600-800`)
+   - Classify error: recoverable vs. terminal
+   - If recoverable: mark connection cooldown, increment failure count, try next target
+   - If terminal (account banned / expired / invalid key): skip, try next
+   - If quota hit per target: skip, try next
+   - If all targets exhausted: return combo error with diagnostics
+
+4. **Fusion Strategy Exception** (`open-sse/services/fusion.ts`)
+   - Fan out to a panel of models in parallel
+   - Judge model synthesizes one final answer
+   - Return judge response
+
+### Cache Paths
+
+- **Semantic Cache Hit** (`open-sse/handlers/chatCore/semanticCache.ts`): Compare request hash + key embeddings, return cached response directly
+- **Idempotency Hit** (`open-sse/handlers/chatCore/idempotency.ts`): Match idempotency key, return cached response
+- **Combo Context Cache** (`open-sse/handlers/chatCore/comboContextCache.ts`): Avoid re-fetching combo metadata per request batch
+
+## Key Abstractions
+
+**Executor Pattern:**
+- Purpose: Encapsulate provider-specific HTTP behavior
+- Examples: `open-sse/executors/{openai.ts, claude-web.ts, bedrock.ts, antigravity.ts}`
+- Pattern: Extends `BaseExecutor`, overrides: request prep, error classification, response parsing
+- Interface: `execute({translatedBody, credentials, ...}): Promise<Response>`
+
+**TransformStream (SSE Output):**
+- Purpose: Compose streaming response pipelines
+- Examples: `open-sse/utils/createSSETransformStreamWithLogger()`, heartbeat, semanticCacheStore
+- Pattern: Chainable `.pipe()` operators; each wraps input readable stream
+- Usage: `response.body.pipe(sseTransform).pipe(heartbeatTransform).pipe(cacheStoreTransform)`
+
+**Account Semaphore:**
+- Purpose: Limit concurrent requests per connection
+- Pattern: Acquire slot before executor dispatch; release on error or response complete
+- Tuneable: Per-account concurrency cap in DB
+- Usage: Prevents thundering herd against OAuth-backed providers
+
+**Circuit Breaker (Lazy Recovery):**
+- Purpose: Disable whole provider on repeated failures
+- States: CLOSED (normal) → OPEN (blocked) → HALF_OPEN (test probe)
+- Recovery: Lazy — checked on read; if timeout elapsed, refresh to HALF_OPEN
+- Usage: Prevents slow provider from cascading to all combo targets
+
+**Model Lockout:**
+- Purpose: Disable one model per connection when only that model fails
+- Pattern: Per-model failure count + timestamp in accountFallback context
+- Usage: Allows same connection to serve other models while one is unavailable
+
+**Combo Strategy Registries:**
+- Purpose: Select per-request routing algorithm (19 strategies)
+- Examples: `priority` (use first candidate), `cost-optimized` (lowest $/token), `fusion` (parallel judge)
+- Tuneable: Strategy name + params in DB combo record
+- Usage: `resolveComboConfig()` returns strategy enum; combo loop respects it
+
+**Provider Executor Registry:**
+- Purpose: Map provider ID → executor class
+- Pattern: Lazy loading; cached after first instantiation
+- Usage: `getExecutor(provider, model)` returns executor instance
+
+## Entry Points
+
+**HTTP Routes:**
+- Location: `src/app/api/v1/chat/completions`, `embeddings`, `images`, `audio/transcriptions`, etc.
+- Triggers: HTTP POST (or OPTIONS for CORS)
+- Responsibilities: Parse request, apply CORS, delegate to handler
+
+**MCP Tools:**
+- Location: `open-sse/mcp-server/tools/` (105 tools across 31 scopes)
+- Triggers: Tool invocation from client (Claude, Copilot, etc.)
+- Responsibilities: Tool input validation, DB/API access, result formatting
+
+**A2A Skills:**
+- Location: `src/lib/a2a/skills/` (smart-routing, quota-management, provider-discovery, etc.)
+- Triggers: Task execution from agent runtime
+- Responsibilities: Task planning, execution, result synthesis
+
+**Webhooks:**
+- Location: `src/lib/webhookDispatcher.ts`
+- Triggers: Request start, response complete, error events
+- Responsibilities: Dispatch to configured endpoints
+
+## Architectural Constraints
+
+- **Threading:** Single-threaded event loop (Node.js). No worker threads for main request path. Account semaphore + circuit breaker use in-process atomics (no distributed coordination).
+- **Global state:** 
+  - Circuit breaker state: `src/shared/utils/circuitBreaker.ts` (in-memory + DB fallback)
+  - Combo failure tracker: `open-sse/services/combo/failureTracker.ts` (in-memory, reset per request)
+  - Connection cooldown: `open-sse/services/accountFallback.ts` (in-memory + DB)
+  - Model lockout: `open-sse/services/accountFallback.ts` (in-memory + DB)
+- **Circular imports:** None detected in core pipeline (`src/app/api → open-sse/handlers → open-sse/services`). Domain modules (`src/domain`) have weak circular coupling (mitigated by lazy imports).
+- **Database transactions:** SQLite WAL mode; migrations idempotent and transactional. Concurrent writes to shared connections may cause lock contention (unobserved in practice at <1000 req/s).
+
+## Anti-Patterns
+
+### Swallowing Errors in Streams
+
+**What happens:** A stream error (e.g., network failure mid-response) is caught but not propagated. Client sees incomplete SSE frame.
+**Why it's wrong:** Client hangs waiting for response completion; dashboards show "pending" forever.
+**Do this instead:** Always emit error frame before stream close. Use `streamFailure.finalize()` from `open-sse/utils/streamFailureFinalization.ts` to emit standardized error on abort.
+
+### Re-validating Already-Parsed Bodies
+
+**What happens:** Request body is parsed in route, then re-validated deeply in handler. Two separate Zod schema runs.
+**Why it's wrong:** Duplicates CPU work on hot path; slow requests.
+**Do this instead:** Route does minimal shape check (non-null object, model is string). Handler owns the deep validation (`messages`, `tools`, `parameters`). See `src/app/api/v1/chat/completions/route.ts:55-72` (intentionally permissive schema).
+
+### String-Interpolating API Paths
+
+**What happens:** Custom API path built via string interpolation: `const url = \`${baseUrl}/${customPath}\`.
+**Why it's wrong:** Path traversal risk; user-supplied path can escape to parent directories.
+**Do this instead:** Sanitize path with `sanitizePath()` from `open-sse/executors/base.ts:126-133` — validate starts with `/`, no `..`, no null bytes, reasonable length.
+
+### Blocking Executor Instantiation
+
+**What happens:** Executor class instantiated inside a loop with full initialization (credential refresh, OAuth fetch).
+**Why it's wrong:** Blocks combo loop; if one target has slow OAuth, whole combo stalls.
+**Do this instead:** Executor initialization is async and happens inside `executor.execute()`, outside the critical path. Combo loop only decides targets; executors handle their own setup.
+
+## Error Handling
+
+**Strategy:** Classify errors into account/provider/context categories. Try fallback within combo if available; else return typed error response.
+
+**Patterns:**
+- **Try/catch at handler boundary**: Each handler catches sync + async errors, logs with traceId, returns typed error response
+- **Error classification before fallback**: `checkFallbackError()` analyzes HTTP status + error message to decide retry/fallback/terminal
+- **Account errors (401/403 w/ specific keywords)**: Mark connection cooldown, skip next time, try another credential
+- **Provider errors (5xx/502/503/504)**: Increment provider circuit breaker, may open if threshold exceeded
+- **Context overflow (context length exceeded)**: Mark model lockout, try another model
+- **Terminal errors (banned / expired / invalid)**: Set account status to unavailable; manual fix required
+- **SSE stream errors**: Emit error frame with message, close stream cleanly
+- **Timeout errors**: Classify as network (connection level) vs. application (request level); retry with backoff
+
+## Cross-Cutting Concerns
+
+**Logging:** Request logger with pino context. Per-request traceId for correlation. Stage trace (stageTrace) marks checkpoint timing. Executor request logging optional (gated by OMNIROUTE_DEBUG).
+
+**Validation:** Zod schemas guard HTTP body shape (route level, minimal) and message/tool structure (handler level, deep). Provider registry validates model names on startup.
+
+**Authentication:** Optional API key validation (`isValidApiKey()` from auth module). JWT extraction + policy enforcement (rate limits, quota). Provider credentials resolved via DB module (`src/sse/services/auth.ts`).
+
+**Memory & Skills Injection:** Request handler injects memory context (similar messages) and available skills (callable tools) into system prompt or tool list before translation.
+
+**Guardrails:** PII masking (opt-in), prompt injection guard, vision safety checks. Applied to request body before handler or to response after upstream.
+
+---
+
+*Architecture analysis: 2026-08-14*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,195 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-08-14
+
+## Tech Debt
+
+**TypeScript 7 Migration (ESLint any-budget frozen debt):**
+- Issue: Large number of `no-explicit-any` violations allowlisted in `config/quality/eslint-suppressions.json`. Suppressions frozen at migration baseline; new violations are treated as errors but pre-existing ones are suppressed.
+- Files: `open-sse/executors/` (deepseek-web.ts: 12, github.ts: 14, t3-chat-web.ts: 11, etc.), `open-sse/handlers/search.ts: 33 suppressions`
+- Impact: Code in executors and search handler lacks type safety. New developers cannot see the actual type errors (hidden by suppressions). Refactoring these areas is risky without proper typing.
+- Fix approach: Incrementally fix violations in the suppression list. The `npm run lint` applies suppressions; fix genuine violations one file at a time and remove from `eslint-suppressions.json`. Priority: high-traffic executors first (github, deepseek-web).
+
+**Database Schema Evolution (145 migrations):**
+- Issue: 145 migrations indicate significant schema churn. Risk of migration ordering issues, late schema corrections, or abandoned schema columns.
+- Files: `src/lib/db/migrations/*.sql` (includes DROPs, ALTERs, renames like migration 025 renaming `call_logs` to `call_logs_v1_legacy`)
+- Impact: Complex migration history increases risk of (a) rollback failures, (b) production schema drift if migrations run out-of-order, (c) orphaned columns/indexes from dropped tables.
+- Fix approach: Audit old migrations (< 2026-01) for abandoned columns still being written to. Consider consolidating old schema into a single "baseline" migration in a future release cycle. Use `npm run db:audit` (if available) to detect unused columns.
+
+**Codex Input Cap Values Unconfirmed (#6191):**
+- Issue: Multiple TODO comments indicating unconfirmed input token limits for Codex models.
+- Files: `open-sse/config/providers/registry/codex/index.ts:152, 161, 172, 183, 192`
+- Impact: If caps are wrong, requests may exceed Codex's actual limits → upstream failures, poor routing decisions in combo strategies. Caps are used for cost estimation and request feasibility checks.
+- Fix approach: Pull exact limits from Codex provider documentation or API docs. Verify against live requests in staging. Add regression test asserting caps match upstream docs. Reference issue #6191 for context.
+
+**Large File Complexity (Performance & Maintainability Risk):**
+- Issue: Several core files exceed 3000 lines, indicating high cyclomatic complexity and mutation risk.
+- Files: `open-sse/handlers/chatCore.ts (5162 lines)`, `open-sse/services/combo.ts (3353 lines)`, `open-sse/executors/chatgpt-web.ts (3239 lines)`, `open-sse/handlers/imageGeneration.ts (3144 lines)`
+- Impact: High risk of regressions on edits. Difficult to onboard contributors. Testing coverage struggles to keep pace (e.g., chatCore at 72.45% line coverage, below 80.8% baseline).
+- Fix approach: Extract cohesive submodules from chatCore (e.g., semantic cache logic → separate handler; idempotency cache → separate module). Combo strategies could be split into individual strategy files. This is a medium-priority refactor — tackle during slower release cycles.
+
+## Known Bugs
+
+**SSE Snapshot Duplication in Responses API (Documented Learning):**
+- Symptoms: When parsing Responses API streaming chunks with final snapshots, text may appear duplicated at the end of the stream if snapshot is processed through rolling delta buffers.
+- Files: `open-sse/utils/stream.ts`, `open-sse/handlers/responseSanitizer.ts` (streaming PII transform)
+- Trigger: Responses API with `done` or `completed` event containing a final snapshot; PII sanitization or semantic cache storage enabled.
+- Workaround: Always parse snapshot text directly (standalone), bypassing delta buffers. This is documented in AGENTS.md § PII & Stream Sanitization Learnings.
+
+**Database Handle Cleanup in Tests:**
+- Symptoms: Node.js test runner hangs indefinitely after tests that trigger SQLite migrations or establish connections.
+- Files: `tests/unit/*` (any test using `resetDbInstance()`)
+- Trigger: Test calls `resetDbInstance()` or opens a DB connection without closing in a `test.after(...)` hook.
+- Workaround: Always include `test.after(...)` that calls `resetDbInstance()` and/or closes DB handles. Documented in AGENTS.md § PII & Stream Sanitization Learnings.
+
+## Security Considerations
+
+**ReDoS Risk in PII Pattern Matching (Documented Learning):**
+- Risk: Regex patterns matching variable-length strings (IPv6, credit cards, SSNs) can cause catastrophic backtracking on malicious/long inputs when processing untrusted request/response payloads.
+- Files: `src/lib/piiSanitizer.ts`, `src/lib/guardrails/piiMasker.ts`, `src/lib/streamingPiiTransform.ts`
+- Current mitigation: Patterns must use strictly bounded, non-overlapping sequences (e.g., `{1,7}` limits on repetition) to prevent exponential backtracking. This is a documented convention in AGENTS.md.
+- Recommendations: (1) Audit all regex in pii*.ts files for unbounded quantifiers (e.g., `.*`, `+`, `*` without explicit limits). (2) Add ReDoS-specific linting (e.g., `safe-regex` or `eslint-plugin-security`). (3) Test with pathologically long inputs (100KB+ strings) in `tests/unit/pii-*.test.ts`.
+
+**Unsanitized HTML in Docs Route (Properly Mitigated):**
+- Risk: `src/app/docs/[...slug]/page.tsx:90` uses `dangerouslySetInnerHTML` to render translated markdown.
+- Files: `src/app/docs/[...slug]/page.tsx:67` (sanitizeDocsHtml), `src/lib/docsSanitizer.ts`
+- Current mitigation: (a) Path traversal prevention via `resolveSafeI18nSectionDir` (validates locale and slug segments). (b) XSS prevention via `sanitizeDocsHtml()` (DOMPurify on parsed markdown). Guards are present and tested.
+- Recommendations: Ensure `sanitizeDocsHtml()` remains strict (allowlist-based). Test with injected script tags in i18n markdown files.
+
+**PII Data Mutation Default (Properly Guarded):**
+- Risk: PII redaction/sanitization flags (`PII_REDACTION_ENABLED`, `PII_RESPONSE_SANITIZATION`) could accidentally default to `true`, silently corrupting legitimate operator data in self-hosted deployments.
+- Files: `src/shared/constants/featureFlagDefinitions.ts:51, 62`, `tests/unit/pii-opt-in-default.test.ts`
+- Current mitigation: Hard Rule #20 requires both flags default to `"false"`. Regression guard test (`pii-opt-in-default.test.ts`) asserts definition defaults + runtime behavior. Any change to defaults requires explicit operator approval.
+- Recommendations: Maintain regression guard test. Before any flag default change, announce in release notes + require operator sign-off. The opt-in model is intentional — do not "improve" by enabling by default.
+
+## Performance Bottlenecks
+
+**Chat Handler Streaming Complexity (5162 lines, 72.45% coverage):**
+- Problem: `open-sse/handlers/chatCore.ts` orchestrates the entire request pipeline — translation, caching, routing, streaming, error handling — in one module.
+- Files: `open-sse/handlers/chatCore.ts`, submodules `open-sse/handlers/chatCore/*.ts`
+- Cause: Monolithic handler design simplifies top-level flow but concentrates mutation risk and testing burden.
+- Improvement path: Extract cohesive submodules (semantic cache, idempotency, streaming pipeline) into separate handlers. Improve coverage via targeted unit tests on isolated modules. Target coverage improvement from 72.45% to 80%+ via incremental extraction.
+
+**Model Catalog Building & Caching (1707 lines):**
+- Problem: `src/app/api/v1/models/catalog.ts` rebuilds the entire provider catalog on request, with caching that uses `setImmediate(resolve)` to defer computation (`line 138`).
+- Files: `src/app/api/v1/models/catalog.ts:138`
+- Cause: Deferring catalog builds to next event loop tick can cause thundering herd on high concurrency (multiple requests queue up, all build in parallel).
+- Improvement path: Switch from `setImmediate` to a proper semaphore-based lock. Pre-compute catalog on startup (if feasible) or use a request-deduplicating promise cache (`Promise.race([outstanding, new Promise(...))`).
+
+**Streaming Error Handling Complexity:**
+- Problem: `open-sse/utils/stream.ts` (2921 lines) contains intricate SSE parsing, error translation, and PII sanitization. A single malformed upstream response can trigger multiple error handling paths.
+- Files: `open-sse/utils/stream.ts`, `open-sse/handlers/responseSanitizer.ts`, `open-sse/handlers/responseTranslator.ts`
+- Cause: Multiple translation layers (format → OpenAI → Responses API) each with error recovery logic that can overlap.
+- Improvement path: Consolidate error handling into a single error taxonomy. Add performance monitoring (metrics) on error recovery paths. Profile with upstream 4xx/5xx injection tests.
+
+## Fragile Areas
+
+**Streaming SSE Parser (Multiple Transports: stdio, SSE, HTTP):**
+- Files: `open-sse/handlers/sseParser.ts`, `open-sse/services/*/streamHandler.ts` implementations
+- Why fragile: SSE parsing must handle incomplete chunks, malformed JSON, encoding edge cases, and EOF detection differently per transport (stdio vs HTTP vs Streamable HTTP). Off-by-one errors in chunk buffering can cause message loss.
+- Safe modification: (1) Add integration tests with real upstream providers (GitHub, DeepSeek, Pollinations). (2) Fuzz test SSE parser with pathological inputs (truncated JSON, mixed encodings, duplicate event IDs). (3) Never change SSE line parsing logic without running `npm run test:e2e` against staging upstreams.
+- Test coverage: SSE parser has pre-existing suppressions (no-restricted-syntax). Coverage of edge cases (EOF, incomplete chunks) is likely incomplete. Recommend focused integration tests before any refactoring.
+
+**Combo Routing Strategy Selection (19 strategies, 3353 lines):**
+- Files: `open-sse/services/combo.ts`, strategy implementations
+- Why fragile: 19 routing strategies (priority, weighted, round-robin, fusion, pipeline, etc.) share mutable state (request log, provider health). A regression in one strategy's cost/health calculations affects all others.
+- Safe modification: (1) Extract each strategy into a separate file with isolated unit tests. (2) Verify Auto-Combo scoring logic against expected weights (14 factors in `docs/routing/AUTO-COMBO.md`). (3) Run `npm run test:vitest` (covers autoCombo) before touching strategy selection. (4) Use feature flags to A/B test strategy changes on subset of traffic.
+- Test coverage: autoCombo coverage at 85.42% (above baseline), but individual strategy coverage gaps exist. Before adding a new strategy, require unit tests demonstrating it handles missing provider health data gracefully.
+
+**Connection Cooldown & Circuit Breaker Interaction (3 layers):**
+- Files: `open-sse/services/accountFallback.ts (2066 lines)`, `src/shared/utils/circuitBreaker.ts`, `src/sse/services/auth.ts`
+- Why fragile: Three distinct failure mechanisms (provider circuit breaker, connection cooldown, model lockout) must stay separate. A connection that hits multiple layers (e.g., circuit breaker AND cooldown) can create state inconsistencies or missed retry windows.
+- Safe modification: (1) Never merge cooldown state into circuit breaker — keep scopes separate per AGENTS.md Resilience Runtime State. (2) Read lazily (use `getStatus()` which refreshes expired state) rather than raw state columns. (3) Add integration tests proving a provider that opens circuit breaker correctly recovers per reset timeout without being stuck in cooldown. (4) Document state transitions in comments (CLOSED → OPEN → HALF_OPEN, separate from rateLimitedUntil timeline).
+- Test coverage: accountFallback.ts has high coverage (96.78% lines), but circuit breaker interaction under concurrent failures is likely undertested. Recommend chaos tests: rapid failures on same key while another key recovers.
+
+## Scaling Limits
+
+**SQLite Database Concurrency (Single Writer):**
+- Current capacity: OmniRoute uses SQLite (WAL mode) with single-writer semantics. Call logs, usage tracking, and quota state are persisted to SQLite.
+- Limit: Under high concurrency (1000+ concurrent /v1/chat/completions requests), SQLite's write queue can become a bottleneck. WAL allows multiple readers + one writer, but a bursty write pattern (e.g., usage updates on every request) will serialize.
+- Scaling path: (1) Batch usage updates (flush every N seconds or M requests). (2) Consider a queue-based architecture (write usage to an in-memory queue, flush asynchronously). (3) For production deployments, migrate to PostgreSQL. For now, monitor `database_lock_wait_ms` metrics in call logs.
+
+**MCP Tool Registry Growth (105 tools across 31 scopes):**
+- Current capacity: MCP server exposes 105 tools (43 base + plugins). Tool execution is synchronous and runs in a single process thread.
+- Limit: Adding many long-running tools (e.g., file I/O, external API calls) can cause timeout/hang if a single tool blocks the event loop. Tool execution is not parallelized.
+- Scaling path: (1) Profile tool latency (`npm run test:vitest` includes tool timing). (2) For long-running tools, implement async generators (streaming response). (3) Consider worker-thread isolation for blocking tools. (4) Add execution timeouts per tool (e.g., 30s max).
+
+**Memory (Streaming Buffers & Session State):**
+- Current capacity: Long-lived SSE streams and session state (memory vectors, combo execution logs) are kept in process memory. No explicit memory bounds.
+- Limit: A single multi-hour SSE stream can accumulate unlimited response chunks in a buffer if the client is slow to consume. Session vectors are not evicted.
+- Scaling path: (1) Implement max buffer size per stream (e.g., 10MB). Return 413 Payload Too Large if exceeded. (2) Evict old session vectors from memory (LRU, TTL). (3) Use a separate Redis/in-memory store for session state if scaling beyond single node.
+
+**Catalog Query Complexity (339 providers, dynamic capability overlays):**
+- Current capacity: Model catalog (`src/app/api/v1/models/catalog.ts`) joins 339 providers × models with dynamic overlays (radar, custom registry, free-model catalog). Catalog build is O(providers × models).
+- Limit: At >10k total models across 339 providers, catalog build time will exceed request SLA (target <500ms). Caching mitigates, but cache invalidation is implicit and adds latency.
+- Scaling path: (1) Pre-compute and cache catalog at startup. (2) Lazy-load provider subsets on request (e.g., only populate capability overlays for requested provider). (3) Add metrics tracking catalog build time per provider. (4) Consider splitting catalog into provider-specific endpoints (e.g., `/v1/models?provider=openai`).
+
+## Dependencies at Risk
+
+**better-sqlite3 (SQLite driver) vs Bun:sqlite compatibility:**
+- Risk: OmniRoute uses `better-sqlite3` as the authoritative driver for Node.js. A best-effort `bun:sqlite` compatibility path exists (see AGENTS.md) but is not officially supported. Future Bun versions may diverge.
+- Impact: If Bun gains significant adoption in the wild, the fallback path may become unmaintained. If better-sqlite3 is deprecated, migration is forced.
+- Migration plan: Document the precise Bun:sqlite driver adapter (`src/lib/db/driver.ts` or equivalent) and keep it in sync with bun releases. Alternatively, migrate to `libsql` (open-source, driver-agnostic). For now, the Node.js driver is stable; Bun support is optional.
+
+**marked (Markdown parser) in docs rendering:**
+- Risk: `src/app/docs/[...slug]/page.ts` uses `marked` for server-side rendering of i18n markdown. No version pinning guard.
+- Impact: Major `marked` version upgrades (e.g., v10 → v11) can change HTML output, breaking docs rendering or introducing unexpected tags.
+- Migration plan: Pin `marked` to a major version. Test rendering on version upgrade before merging. Use `sanitizeDocsHtml()` as a defense-in-depth: even if `marked` adds unexpected HTML, sanitizer catches it.
+
+**Open-source LLM Provider SDKs (SDK sprawl):**
+- Risk: `open-sse/executors/` implements 30+ provider SDKs manually (not via official SDK; hand-rolled HTTP + format translation). If a provider changes API, executor breaks.
+- Impact: Rapid provider churn → executor maintenance burden. Missing features (e.g., new tool calling format) → manual implementation debt.
+- Migration plan: Prioritize providers with stable APIs (OpenAI, Anthropic) and maintain hand-rolled versions. For high-churn providers (DeepSeek, T3Chat, local models), use official SDKs if available. For experimental providers, accept higher brittleness; mark as "best-effort."
+
+## Missing Critical Features
+
+**Provider Health Dashboard (Metrics only, no visual feedback):**
+- Problem: Operator can query provider health via `/api/monitoring/health`, but dashboard does not surface real-time provider status, circuit breaker state, or connection cooldown timeline.
+- Blocks: Operators cannot quickly diagnose why traffic is routing away from a provider without logs. Circuit breaker state is internal (not visible in UI).
+- Priority: Medium. Implement a status panel in the dashboard (`src/app/(dashboard)/dashboard/providers/...`) showing: (a) Circuit breaker state per provider. (b) Active cooldowns per connection. (c) Last failure timestamp + error.
+
+**Semantic Similarity Search in Memory (Vector store not fully integrated):**
+- Problem: Memory system supports Qdrant for semantic search, but integration is incomplete. Search may require fallback to keyword matching.
+- Blocks: Memory recall for high-context tasks is less effective if semantic search is unavailable.
+- Priority: Medium. Complete Qdrant integration (`src/lib/memory/`); add fallback behavior if Qdrant is unreachable.
+
+**Rate Limit Header Parsing Standardization (RFC 6585 compliance):**
+- Problem: Different providers use different rate-limit headers (`RateLimit-Remaining`, `X-RateLimit-Remaining`, `Retry-After`, provider-specific reset times). Parsing is inconsistent across executors.
+- Blocks: Quota-aware routing and retry logic cannot reliably estimate reset times.
+- Priority: Medium-High. Standardize rate-limit parsing in `open-sse/utils/rateLimitHeaders.ts` (if exists) or create one. Add tests for each provider's header format.
+
+## Test Coverage Gaps
+
+**chatCore Handler (72.45% line coverage, below 80.8% baseline):**
+- What's not tested: Cache validation logic (idempotency, semantic cache), streaming error recovery, composite scenarios (cache hit + streaming + PII sanitization).
+- Files: `open-sse/handlers/chatCore.ts`, `open-sse/handlers/chatCore/*.ts` submodules
+- Risk: High. chatCore is the critical path for all requests. A regression in error handling or cache logic propagates to all clients.
+- Priority: High. Extract and unit-test cache submodules separately. Add integration tests for chatCore → upstream provider → response → streaming flow. Target 85%+ coverage.
+
+**Streaming Parser Edge Cases (SSE + HTTP + Responses API):**
+- What's not tested: Truncated JSON in middle of chunk, multiple events in one chunk, UTF-8 encoding errors, missing newlines, empty chunks, upstream connection reset mid-stream.
+- Files: `open-sse/handlers/sseParser.ts`, `open-sse/utils/stream.ts`
+- Risk: Medium. SSE parser is used for all streaming responses; malformed upstream responses can hang the stream or lose messages.
+- Priority: High. Fuzz test SSE parser with pathological inputs. Upstream mutation tests (deliberately break upstream responses) in CI.
+
+**Combo Routing Strategies (Individual strategy tests missing):**
+- What's not tested: Fusion strategy with unequal latencies, round-robin fairness under bursty traffic, weighted strategy with zero-weight providers, pipeline strategy with cascading failures.
+- Files: `open-sse/services/combo.ts`, individual strategy implementations
+- Risk: Medium. A broken strategy silently routes traffic incorrectly; operator may not notice until metrics degrade.
+- Priority: Medium. Add unit tests per strategy in `tests/unit/combo/` (e.g., `fusion.test.ts`, `weighted.test.ts`). Use mock providers with controllable latency/failure.
+
+**Connection Cooldown Under Concurrent Failures:**
+- What's not tested: (a) Two concurrent requests on same bad connection → cooldown increment (should not double-increment). (b) Anti-thundering-herd guard. (c) Terminal states (banned, expired, credits_exhausted) not overwritten by transient cooldown.
+- Files: `open-sse/services/accountFallback.ts`, `src/sse/services/auth.ts::markAccountUnavailable`
+- Risk: Medium. Cooldown state corruption could leave a working connection permanently cooldown'd or skip a necessary cooldown.
+- Priority: Medium. Add chaos tests simulating 100 concurrent requests on same bad key. Verify cooldown behavior.
+
+**PII Sanitization Regex Patterns (ReDoS injection):**
+- What's not tested: Long (1MB+) strings with repeating patterns (e.g., repeated "a" to trigger `.*` backtracking). Patterns that could be malicious (e.g., crafted emails designed to match SSN regex).
+- Files: `src/lib/piiSanitizer.ts` regex patterns, `src/lib/streamingPiiTransform.ts`
+- Risk: Low-Medium. ReDoS can cause CPU spike on malicious requests. Rare if PII sanitization is opt-in (Hard Rule #20), but high-impact if enabled.
+- Priority: Medium. Add property-based tests (e.g., `fast-check`) generating long strings. Profile regex execution time. Add ReDoS-specific linting.
+
+---
+
+*Concerns audit: 2026-08-14*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,181 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-08-14
+
+## Naming Patterns
+
+**Files:**
+- Utilities and non-component modules: camelCase (e.g., `numeric.ts`, `logger.ts`, `errorConfig.ts`)
+- Kebab-case used for some path segments (e.g., `provider-models`, `api-manager`)
+- API routes: `route.ts` by convention in Next.js app directory
+- Test files: `*.test.ts`, `*.test.tsx`, or `*.test.mjs`
+
+**Functions:**
+- camelCase for all functions (e.g., `sanitizeErrorMessage`, `normalizeRequestedModelIds`, `toNumber`, `createLogger`)
+- Public API functions are exported as named exports
+- Helper/utility functions use clear, descriptive names
+
+**Variables:**
+- camelCase for all variable names (e.g., `firstLine`, `singleModelId`, `transportConfig`)
+- Constants: UPPER_SNAKE (e.g., `MAX_ERROR_LEN`, `SOURCE_EXT`, `BLOCKED_KEYS`, `SIDEBAR_ICON_ACCENTS`)
+- Boolean variables/functions start with `is` or `has` (e.g., `isPosix`, `isWindows`, `isAuthenticated`)
+
+**Types:**
+- PascalCase for TypeScript types and interfaces (e.g., `ErrorResponseBody`, `LoggerOptions`, `ModelCompatPatch`)
+- Generic type parameters: single uppercase letter or descriptive PascalCase (e.g., `T`, `TRecord`)
+- Enum values: UPPER_SNAKE
+
+**Components:**
+- React components: PascalCase function names (e.g., `InitPage`, `ApiManagerPageClient`, `EndpointPageClient`)
+- Custom hooks: camelCase prefixed with `use` (e.g., `useLocalStorage`, `useIsAuth`)
+
+## Code Style
+
+**Formatting:**
+- Tool: Prettier (enforced via lint-staged on pre-commit)
+- Indent: 2 spaces
+- Semicolons: true (required)
+- Quotes: double quotes (e.g., `"use strict"`, not `'use strict'`)
+- Print width: 100 characters
+- Trailing commas: es5 (trailing commas in arrays/objects, but not in function parameters)
+
+**Linting:**
+- Tool: ESLint with flat config (`eslint.config.mjs`)
+- Zero-warning policy: all new violations are errors
+- Pre-existing violations frozen in `config/quality/eslint-suppressions.json` (ESLint native bulk suppressions)
+- Critical rules (always error):
+  - `no-eval`: forbidden everywhere (never use `eval()`)
+  - `no-implied-eval`: forbidden everywhere (never use `setTimeout("code")` style)
+  - `no-new-func`: forbidden everywhere (never use `new Function()`)
+  - `no-explicit-any`: error in `open-sse/` and `tests/` (incremental adoption)
+  - `import/no-anonymous-default-export`: error in `src/`
+  - `react-hooks/exhaustive-deps`: error in React code
+  - `@next/next/no-img-element`: error (use `Image` component)
+- Import boundary restrictions: no direct imports of executor implementations or localDb barrel
+
+## Import Organization
+
+**Order:**
+1. External packages (e.g., `import axios from "axios"`, `import pino from "pino"`)
+2. Node.js built-ins (e.g., `import fs from "node:fs"`, `import path from "node:path"`)
+3. Internal `@/` imports from src (e.g., `import { logger } from "@/shared/utils/logger"`)
+4. `@omniroute/open-sse` imports (monorepo workspace)
+5. Relative imports (e.g., `import { util } from "../utils"`)
+
+**Path Aliases:**
+- `@/*` → `src/` (primary alias for source files)
+- `@omniroute/open-sse` → `open-sse/` (workspace root)
+- `@omniroute/open-sse/*` → `open-sse/*` (internal workspace imports)
+
+**Database imports:**
+- Prefer importing from domain modules under `src/lib/db/` (e.g., `src/lib/db/modelContextOverrides.ts`)
+- Avoid direct imports from `src/lib/localDb.ts` (compatibility barrel only; use owning domain modules instead)
+- Exception: `src/lib/db/` internals may use the compatibility barrel during decomposition
+
+## Error Handling
+
+**Patterns:**
+- All HTTP/SSE error responses route through `buildErrorBody()` or `sanitizeErrorMessage()` from `open-sse/utils/error.ts`
+- Never expose raw `err.stack` or `err.message` in responses (stack traces and paths are redacted)
+- Error response structure:
+  ```typescript
+  {
+    error: {
+      message: string;        // sanitized message
+      type?: string;          // error category (e.g., "invalid_api_key")
+      code?: string;          // error code
+    };
+    upstream_details?: Record<string, unknown> | null;  // sanitized upstream response
+  }
+  ```
+- HTTP status codes follow REST conventions: 400 (bad request), 401 (auth), 403 (forbidden), 429 (rate limit), 500+ (server errors)
+- Proper error context: include relevant identifiers (model, provider, account) but never credentials
+- Logging: errors logged with pino using `log.error({ err, model, provider }, "message")`
+
+## Logging
+
+**Framework:** Pino (structured JSON logger)
+
+**Patterns:**
+- Create a child logger with context: `const log = logger.child({ module: "proxy", requestId: "..." })`
+- Log with structured data: `log.info({ model: "gpt-4o" }, "Request received")`
+- Error logging includes error object: `log.error({ err }, "Connection failed")`
+- Log levels: `debug`, `info`, `warn`, `error` (set via `APP_LOG_LEVEL` env var, defaults to `debug` in dev, `info` in prod)
+- Sensitive data (API keys, tokens, passwords) is automatically redacted via `redactLogArgs()` in logger hooks
+- File rotation: logs written to `~/.omniroute/logs/` with automatic daily rotation
+- Dev mode: pretty-printed to console via pino-pretty; production: JSON lines for log aggregation
+
+## Comments
+
+**When to Comment:**
+- Non-obvious business rules that code structure alone cannot express
+- Workarounds for external library bugs or platform limitations
+- Complex regex patterns or mathematical formulas
+- Critical warnings about side effects or non-obvious constraints
+- Issue/PR numbers in code comments (e.g., `// #7879: explanation of workaround`)
+
+**DO NOT use comments for:**
+- Explanatory comments describing WHAT code does (code must be self-documenting via naming)
+- Inline comments inside function bodies, loops, or conditionals
+- Redundant docstrings/JSDoc (unless it's a public API or the project has an established convention)
+- Section dividers or "helper" markers
+- TODO/FIXME/HACK comments (unless explicitly requested and tracking an issue number)
+
+**Comment style (when allowed):**
+- One line, concise
+- Explain WHY, never WHAT
+- Must add information not derivable from code itself
+- Example: `// Literal path so Webpack emits the chunk (computed string breaks dev: MODULE_NOT_FOUND)`
+
+## Function Design
+
+**Size:**
+- Functions should be focused (single responsibility)
+- Helper functions extracted when logic is repeated or becomes unreadable
+- Average function length: 20-50 lines (not a hard rule, but a signal)
+
+**Parameters:**
+- Descriptive parameter names (e.g., `normalizeRequestedModelIds(searchParams, body)` not `normalize(a, b)`)
+- Use object parameters for functions with many arguments (destructuring in signature)
+- Type all parameters explicitly in TypeScript (no implicit `any`)
+
+**Return Values:**
+- Functions return single, well-typed values (not tuples unless semantically meaningful)
+- Async functions return Promises
+- Errors thrown, not returned as error objects (try/catch at boundaries)
+- Null/undefined only when explicitly semantically meaningful (prefer typed unions like `Result<T>`)
+
+## Module Design
+
+**Exports:**
+- Named exports preferred (allows tree-shaking and refactoring)
+- Default exports used for page components in Next.js `page.tsx` and `layout.tsx`
+- Barrel files (index.ts with re-exports) used for module boundaries only, not for convenience
+
+**Barrel Files:**
+- `src/lib/localDb.ts` is a read-only re-export layer during decomposition
+- Real logic lives in domain modules under `src/lib/db/`
+- Barrel imports discouraged outside of boundary modules
+
+**Monorepo Workspace:**
+- `open-sse/` is a separate workspace with its own package.json, tsconfig, and lint rules
+- Import from `@omniroute/open-sse` or relative paths when crossing workspace boundary
+- `src/` can import from `open-sse/` but not vice versa
+
+## Type System
+
+**Configuration:**
+- TypeScript strict mode: OFF (`strict: false` in tsconfig.json)
+- Incremental adoption of strictness in `open-sse/` (error boundaries, type safety for streaming)
+- No implicit `any` in `open-sse/` and `tests/`
+- Target: ES2022, Module: esnext, Resolution: bundler
+
+**Practice:**
+- All function parameters and return types should be explicit
+- Use `unknown` for unconstrained inputs; narrow with `typeof` checks
+- Use type guards (type predicates) for complex narrowing
+- Avoid casting; prefer runtime validation with Zod schemas
+
+---
+
+*Convention analysis: 2026-08-14*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,274 @@
+# External Integrations
+
+**Analysis Date:** 2026-08-14
+
+## APIs & External Services
+
+**LLM Providers (339 total):**
+- OpenAI (ChatGPT, GPT-4, o1) - SDK via HTTP, API key auth
+  - Routes: `src/app/api/v1/chat/completions`, `src/app/api/v1/embeddings`
+  - Executor: `open-sse/executors/openai.ts`
+  - Translator: `open-sse/translator/openai.ts`
+- Anthropic (Claude family) - HTTP protocol, API key auth
+  - Executor: `open-sse/executors/anthropic.ts`
+  - OAuth support: `src/lib/oauth/providers/claude.ts`
+- Google Gemini - HTTP protocol, API key + OAuth
+  - Executor: `open-sse/executors/gemini.ts`
+  - OAuth: `src/lib/oauth/providers/ghe-copilot.ts`
+- AWS Bedrock - @aws-sdk/client-bedrock-runtime 3.1073.0
+  - Region-aware HTTP dispatch
+  - Config: `open-sse/config/bedrock.ts`
+  - Executor: `open-sse/executors/bedrock.ts`
+- Grok (xAI) - OAuth + API key flows
+  - OAuth: `src/lib/oauth/providers/grok-cli-oauth.ts`, `src/lib/oauth/providers/grok-cli.ts`
+- 334+ more providers (Hugging Face, LLaMA, Mistral, etc.)
+  - Registry: `open-sse/config/providerRegistry.ts`
+  - Provider definitions: `src/shared/constants/providers.ts`
+
+**OAuth Providers (20+):**
+- GitHub - `src/lib/oauth/providers/github.ts`
+- GitLab Duo - `src/lib/oauth/providers/gitlab-duo.ts`
+- GitHub Enterprise Copilot - `src/lib/oauth/providers/ghe-copilot.ts`
+- Claude (Anthropic) - `src/lib/oauth/providers/claude.ts`
+- Codex (Cursor IDE) - `src/lib/oauth/providers/codex.ts`
+- Cline (VS Code) - `src/lib/oauth/providers/cline.ts`
+- Cursor - `src/lib/oauth/providers/cursor.ts`
+- Grok CLI OAuth - `src/lib/oauth/providers/grok-cli-oauth.ts`
+- Grok CLI - `src/lib/oauth/providers/grok-cli.ts`
+- Zed - `src/lib/oauth/providers/zed.ts`, `src/lib/oauth/providers/zed-hosted.ts`
+- Zed Keychain Reader - `src/lib/zed-oauth/keychain-reader.ts` (system keychain via Keytar 7.9.0)
+- Raycast - `src/lib/oauth/providers/raycast.ts`
+- Kimo Coding - `src/lib/oauth/providers/kimi-coding.ts`
+- Antigravity - `src/lib/oauth/providers/antigravity.ts`
+- Codebuddy CN - `src/lib/oauth/providers/codebuddy-cn.ts`
+- Devin Desktop - `src/lib/oauth/providers/devin-desktop.ts`
+- Kilocode - `src/lib/oauth/providers/kilocode.ts`
+- Trae - `src/lib/oauth/providers/trae.ts`
+- Kiro - `src/lib/oauth/providers/kiro.ts`
+- OpenFérence - `src/lib/oauth/providers/openference.ts`
+- Qoder - `src/lib/oauth/providers/qoder.ts`
+- AGY - `src/lib/oauth/providers/agy.ts`
+
+**Tunneling & Networking:**
+- Ngrok (@ngrok/ngrok 1.7.0) - Tunnel public URLs for webhooks/callbacks
+  - Routes: `src/app/api/tunnels/ngrok/`
+- Cloudflare Tunnels - Zero Trust network access
+  - Config/auth: `src/app/api/settings/proxy/cloudflare-deploy/`
+
+**WebSocket & Real-time:**
+- ws 8.18.0 - WebSocket server/client
+  - A2A protocol streaming: `src/lib/a2a/streaming.ts`
+  - Live dashboard WS: `src/app/api/v1/streams/` routes
+  - Chat completion SSE: `open-sse/handlers/chatCore.ts` (SSE streams)
+
+**Code Editor Integrations:**
+- Cursor IDE - Built-in Cursor support via `src/lib/oauth/providers/cursor.ts`
+- Cline (VS Code extension) - OAuth flow via `src/lib/oauth/providers/cline.ts`
+- Codex - Custom protocol integration
+- Zed - Full OAuth + token management
+- Raycast - Script command integration
+
+**Cloud Agent Platforms:**
+- Devin (cloud AI engineer) - `src/lib/cloudAgent/agents/devin.ts`
+- Codex Cloud - `src/lib/cloudAgent/agents/codex-cloud.ts`
+- Jules (research agent) - `src/lib/cloudAgent/agents/jules.ts`
+  - Registry: `src/lib/cloudAgent/registry.ts`
+  - Task execution: `src/lib/a2a/taskExecution.ts`
+
+## Data Storage
+
+**Databases:**
+- SQLite 3
+  - Primary storage: `~/.omniroute/storage.sqlite` (or `DATA_DIR/storage.sqlite`)
+  - Driver adapters: `src/lib/db/adapters/` (better-sqlite3 or sql.js fallback)
+  - 145+ migrations: `src/lib/db/migrations/`
+  - WAL mode enabled for concurrency
+  - FTS5 extension for full-text search (memory corpus, local corpus)
+  - Encryption: AES-256-GCM via `src/lib/db/encryption.ts` (optional `STORAGE_ENCRYPTION_KEY`)
+  - Domain modules: `src/lib/db/` (proxyLogs, apiKeys, webhooks, providers, circuitBreakers, featureFlags, etc.)
+
+**Redis (Optional):**
+- ioredis 5.10.1 (optional dependency)
+  - Connection: `REDIS_URL` env var (e.g., `redis://localhost:6379`)
+  - Purpose: Distributed rate limiting, session/auth cache, quota management
+  - Fallback: In-memory store if `REDIS_URL` unset (single-instance deployments work out-of-box)
+  - Local Redis container: `src/app/api/local/redis/` routes (Docker-based)
+  - Store factory: `src/lib/quota/storeFactory.ts`
+
+**Vector Database (Optional):**
+- Qdrant - Semantic memory & vector search
+  - Connection: `QDRANT_HOST`, `QDRANT_PORT`, `QDRANT_API_KEY` env vars
+  - Collection: `QDRANT_COLLECTION` (default: "memories")
+  - Config: `src/lib/memory/qdrant.ts`
+  - Vector size: `QDRANT_VECTOR_SIZE` (default: 1536)
+  - HNSW settings: `QDRANT_HNSW_EF_CONSTRUCT` (default: 128)
+  - Health check: `checkQdrantHealth()`
+  - Operations: upsert, delete, search semantic memory
+
+**File Storage:**
+- Local filesystem only (no S3/GCS integration)
+  - Logs directory: `DATA_DIR/logs/`
+  - Database backups: `DATA_DIR/db_backups/`
+  - Data serialization: `src/lib/usage/callLogArtifacts.ts`
+- Sharp 0.35.3 - Image processing (thumbnails, AVIF conversion)
+
+**Caching:**
+- SQLite FTS5 - Full-text search cache for memory retrieval
+- In-memory: Lowdb 7.0.1 (JSON file store)
+- Circuit breaker state: `domain_circuit_breakers` SQLite table
+- Rate limiter: Redis (if configured) or in-memory LRU
+
+## Authentication & Identity
+
+**JWT-based (Custom):**
+- Implementation: `src/lib/jwt.ts`, `jose 6.2.3`
+- Issued on: First setup (admin), API key generation
+- Stored: Secure HTTP-only cookies (dashboard), bearer tokens (API)
+- Validation: Every route via `extractApiKey()` and `isValidApiKey()`
+- Secret: `JWT_SECRET` env var (required, generated on setup)
+
+**API Key Management:**
+- Hash: bcryptjs 3.0.3 (Bcrypt hashing)
+- Storage: `api_keys` SQLite table with encryption
+- Secret key for HMAC: `API_KEY_SECRET` env var
+- Validation: `src/sse/services/auth.ts::getProviderCredentials()`
+- Policy enforcement: `src/server/authz/routeGuard.ts`
+
+**OAuth (20+ providers):**
+- Directory: `src/lib/oauth/providers/`
+- Config: `src/lib/oauth/constants/oauth.ts`
+- Flow: Authorization Code (standard OIDC/OAuth2)
+- Storage: `provider_connections` SQLite table (encrypted credentials, refresh tokens)
+- Keychain fallback: Zed keychain via `keytar 7.9.0` (macOS/Windows credential manager)
+
+**Password-based (Admin setup):**
+- Initial password: `INITIAL_PASSWORD` env var
+- Hash: bcryptjs 3.0.3
+- Change endpoint: `/api/v1/auth/change-password`
+
+## Monitoring & Observability
+
+**Logging:**
+- Framework: Pino 10.3.1 (structured JSON logging)
+- Output: `pino-pretty` for dev, raw JSON for production
+- Level: Controlled by `APP_LOG_LEVEL` env var (default: info)
+- Context: `src/shared/utils/logger.ts`
+- Audit log: `mcp_audit` SQLite table (MCP tool invocations)
+
+**Health Checks:**
+- Endpoint: `src/app/api/monitoring/health/route.ts`
+- Status: Provider circuit breakers, upstream availability, cache health
+- Database health: `src/lib/db/healthCheck.ts`
+- Qdrant health: `src/lib/memory/qdrant.ts::checkQdrantHealth()`
+- Redis health: Connection test on demand
+
+**Error Tracking:**
+- None (no Sentry/DataDog integration)
+- Error logging: Via Pino (structured, queryable in logs)
+- Error sanitization: `src/open-sse/utils/error.ts::buildErrorBody()` (no stack traces in responses)
+
+**Metrics:**
+- Provider metrics: `src/app/api/provider-metrics/route.ts`
+- Health matrix: `src/app/api/providers/health-matrix/route.ts`
+- Coverage/usage: `src/lib/usage/` modules
+- Circuit breaker state: Runtime status API
+
+## CI/CD & Deployment
+
+**Hosting Options:**
+- Self-hosted (Node.js, Docker, systemd)
+- Docker (multi-stage: base + runner-web with Playwright)
+- Fly.io (Node.js buildpack, `fly.toml` config)
+- Vercel (Next.js serverless)
+- Electron desktop app (macOS, Windows, Linux)
+- Cloudflare Workers (relay via proxy)
+- Deno Deploy (relay via proxy)
+
+**CI Pipeline:**
+- GitHub Actions (.github/workflows/)
+- Jobs: `lint`, `quality-gate`, `quality-extended`, `test-unit`, `test-vitest`, `test-ecosystem`, `test-e2e`
+- Nightly: `nightly-release-green`, `nightly-mutation`, `nightly-resilience`, `nightly-llm-security`
+- Publish: `npm-publish` (npm registry), `docker-publish` (Docker Hub, ghcr.io)
+- Deploy: `deploy-vps.yml` (VPS 192.168.0.15 for live testing)
+
+**Build Artifacts:**
+- npm package: `omniroute` CLI + embedded server
+- Docker image: Node.js 22 Alpine base + Playwright browser stack
+- Electron: Native macOS .dmg, Windows .exe, Linux .AppImage
+- Standalone: `dist/` directory with bundled assets
+
+## Environment Configuration
+
+**Required env vars (Production):**
+- `JWT_SECRET` - Secret for JWT signing (openssl rand -base64 48)
+- `API_KEY_SECRET` - Secret for API key hashing (openssl rand -hex 32)
+- `INITIAL_PASSWORD` - Admin password on first setup (min 8 chars)
+- `NODE_ENV` - "production" or "development"
+- `PORT` - HTTP server port (default: 20128)
+
+**Optional env vars (Performance/Features):**
+- `REDIS_URL` - Redis connection string (redis://localhost:6379). If unset, in-memory fallback.
+- `QUOTA_STORE_REDIS_URL` - Separate Redis URL for quota management
+- `QDRANT_HOST` - Qdrant server hostname (e.g., localhost, qdrant.example.com)
+- `QDRANT_PORT` - Qdrant port (default: 6333)
+- `QDRANT_API_KEY` - Qdrant API key (if protected)
+- `QDRANT_COLLECTION` - Vector collection name (default: "memories")
+- `QDRANT_EMBEDDING_MODEL` - Embedding model selector (default via provider config)
+- `QDRANT_VECTOR_SIZE` - Embedding dimension (default: 1536)
+- `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID for Worker deployments
+- `CLOUDFLARE_API_BASE` - Cloudflare API base URL (default: https://api.cloudflare.com/client/v4)
+- `OMNIROUTE_REDIS_CONTAINER_NAME` - Docker container name for local Redis (default: omniroute-redis)
+- `OMNIROUTE_REDIS_HOST_PORT` - Host port binding for local Redis (default: 6379)
+- `OMNIROUTE_REDIS_IMAGE` - Docker image for Redis (default: docker.io/redis:7-alpine)
+- `STORAGE_ENCRYPTION_KEY` - AES-256-GCM key for encrypting credentials at rest (hex-encoded)
+- `APP_LOG_LEVEL` - Pino log level (trace, debug, info, warn, error, fatal)
+- `REQUIRE_API_KEY` - Enforce API key for all requests (true/false, optional)
+- `DISABLE_SQLITE_AUTO_BACKUP` - Disable automatic SQLite backups (set in test suite)
+- `OMNIROUTE_NO_SUDO` - Disable sudo for MITM cert install in rootless environments
+
+**Secrets location:**
+- Credentials: Encrypted in SQLite `provider_connections` table (AES-256-GCM if `STORAGE_ENCRYPTION_KEY` set)
+- Env-based: `.env` file (git-ignored, loaded via Node.js dotenv pattern or Next.js auto)
+- Secure stores: macOS Keychain / Windows Credential Manager via `keytar 7.9.0` (Zed OAuth tokens)
+
+## Webhooks & Callbacks
+
+**Incoming Webhooks:**
+- Directory: `src/app/api/v1/webhooks/`
+- Types: `provider-status`, `usage-alert`, `circuit-breaker`, custom events
+- Handlers: `src/lib/webhooks/integrations/` (Slack, Discord, Telegram, HTTP)
+- Verification: HMAC-SHA256 signature validation
+- Retry: Exponential backoff (configurable)
+- Database: `webhooks` and `webhook_deliveries` SQLite tables
+
+**Webhook Integrations:**
+- Slack - Message notifications via webhook URL
+  - Formatter: `src/lib/webhooks/integrations/slack.ts::buildSlackPayload()`
+- Discord - Embed-based notifications
+  - Formatter: `src/lib/webhooks/integrations/discord.ts::buildDiscordPayload()`
+- Telegram - Chat notifications via bot token
+  - Formatter: `src/lib/webhooks/integrations/telegram.ts`
+- HTTP Custom - Generic POST to webhook URL (JSON payload)
+
+**Outgoing Webhooks:**
+- Events: Provider status changes, usage milestones, circuit breaker state, quota alerts
+- Dispatcher: `src/lib/webhookDispatcher.ts::dispatchEvent()`
+- Event types: `src/lib/webhooks/eventDescriptions.ts`
+
+**MCP Protocol (Model Context Protocol):**
+- SDK: @modelcontextprotocol/sdk 1.29.0
+- Server: `open-sse/mcp-server/`
+- 105 tools across 3 transports (stdio, SSE, Streamable HTTP)
+- 31 scopes (base, memory, skill, agentSkill, pool, notion, obsidian, gamification, plugin, etc.)
+- Audit: `mcp_audit` SQLite table
+
+**A2A Protocol (Agent-to-Agent):**
+- Format: JSON-RPC 2.0
+- Transports: WebSocket, HTTP Server-Sent Events
+- Implementation: `src/lib/a2a/` (taskExecution, streaming, skills)
+- Skills: smart-routing, quota-management, provider-discovery, cost-analysis, health-report
+- Agent Card: `.well-known/agent.json` endpoint
+
+---
+
+*Integration audit: 2026-08-14*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,227 @@
+# Technology Stack
+
+<!-- refreshed: 2026-08-14 -->
+
+**Analysis Date:** 2026-08-14
+
+## Languages
+
+**Primary:**
+- TypeScript 6.0.3 - Core application logic, Next.js App Router, open-sse handlers
+- JavaScript (ES Modules) - Build scripts, CLI utilities, Node.js runtime
+- JSX/TSX - React component definitions in `src/app/(dashboard)` and shared UI components
+
+**Secondary:**
+- HTML5/CSS3 - Templated via React/Next.js
+- SQL - SQLite migrations in `src/lib/db/migrations/`
+- TOML - Configuration parsing with `smol-toml`
+
+## Runtime
+
+**Environment:**
+- Node.js `>=22.22.2 <23 || >=24.0.0 <27` (mandatory, specified in `package.json::engines`)
+- ES Module resolution (`"type": "module"` in `package.json`)
+- Runtime features: async/await, Promise, native test runner (`node:test`)
+- Optional: Bun 1.3.14 (dev-only for gate/generator scripts; not the published runtime)
+
+**Package Manager:**
+- npm (npm install, npm ci, npm run)
+- Lockfile: `package-lock.json` (present)
+- Workspaces: `open-sse/`, `packages/browser-pool` (npm workspaces in `package.json`)
+
+## Frameworks
+
+**Core:**
+- Next.js 16.2.11 (App Router) - Main web framework, API routes under `src/app/api/`, Dashboard UI in `src/app/(dashboard)/`
+- React 19.2.8 - UI component library
+- React DOM 19.2.8 - React DOM rendering for Next.js SSR
+- Express 5.2.1 - Lightweight server utilities (HTTP middleware)
+
+**Styling & UI:**
+- Tailwind CSS 4.3.0 - Utility-first CSS framework (configured in `next.config.mjs`)
+- tailwind-merge 3.6.0 - Merge Tailwind class names with conflict resolution
+- PostCSS 8.5.18 - CSS processing pipeline
+- Material Symbols - Icon library reference (material-symbols 0.45.2)
+- Lucide React 1.21.0 - Icon component library
+
+**Documentation & Content:**
+- Fumadocs Core 16.10.5 - Documentation framework
+- Fumadocs UI 16.10.5 - Pre-built documentation UI components
+- Fumadocs MDX 15.2.2 - MDX support for docs
+- Mermaid 11.15.0 - Diagram rendering (ASCII/SVG)
+- Marked 18.0.4 - Markdown parser
+- Marked Terminal 7.3.0 - Terminal markdown rendering
+- React Markdown 10.1.0 - React markdown renderer component
+
+**Internationalization:**
+- next-intl 4.12.0 - Multi-language support with i18n routing (`src/i18n/`)
+
+**Themes:**
+- next-themes 0.4.6 - Dark/light mode toggle
+
+**State Management & Data:**
+- Zustand 5.0.13 - Lightweight state management (`src/shared/hooks/`)
+- React Query - Via Zustand (not directly visible in dependencies)
+- Lowdb 7.0.1 - JSON file database for local storage
+
+**Logging & Diagnostics:**
+- Pino 10.3.1 - Fast structured JSON logging
+- Pino Abstract Transport 3.0.0 - Pino transport abstraction layer
+- Pino Pretty 13.1.3 - Pretty-printed Pino output for development
+- Ora 9.4.1 - CLI spinner/loading indicator
+- WTFNode 0.10.1 - Debug tool for finding event listener leaks
+
+**Analytics & Visualization:**
+- Recharts 3.8.1 - React charting library for dashboard metrics
+- XYFlow React 12.11.1 - React node/edge graph visualization
+
+**UI/Dialog Components:**
+- ink 7.0.3 - React for terminal UIs (CLI interface)
+- ink-spinner 5.0.0 - Terminal spinner
+- ink-text-input 6.0.0 - Terminal text input
+- Monaco Editor 0.56.0 - Code editor component (VS Code editor)
+- @monaco-editor/react 4.7.0 - React wrapper for Monaco Editor
+
+**Data Processing & Formatting:**
+- DOMPurify 3.4.13 - XSS prevention (HTML sanitization)
+- csv-stringify 6.7.0 - CSV format generation
+- turndown 7.2.0 - HTML to Markdown converter
+- turndown-plugin-gfm 1.0.2 - GitHub Flavored Markdown extension for Turndown
+- js-yaml 5.2.2 - YAML parsing and serialization
+- jsonc-parser 3.3.1 - JSON with comments parser
+- Parse5 8.0.1 - HTML parser (DOM-compatible)
+
+**Compression & Performance:**
+- fflate 0.8.3 - Fast deflate compression
+- xxhash-wasm 1.1.0 - Fast non-crypto hashing
+- Yazl 3.3.1 - ZIP file creation
+
+## Testing
+
+**Framework:**
+- Node.js native test runner (`node --test`) - Unit tests in `tests/unit/`
+- Vitest 4.1.7 - Component and specialized testing (MCP, autoCombo, cache) (`npm run test:vitest`)
+- @vitejs/plugin-react 6.0.5 - React support for Vitest
+
+**Browser/E2E:**
+- Playwright 1.62.0 - Browser automation and E2E testing
+- @playwright/test 1.62.1 - Playwright testing framework
+- playwright-ctrf-json-reporter 0.0.29 - Test result reporting
+
+**Coverage & Quality:**
+- c8 12.0.0 - Code coverage measurement (60% statements/lines/functions/branches floor)
+- @testing-library/react 16.3.2 - React component testing utilities
+- @testing-library/jest-dom 7.0.0 - Custom Jest matchers for DOM testing
+- fast-check 4.8.0 - Property-based testing
+- @axe-core/playwright 4.11.3 - Accessibility testing (WCAG/a11y)
+
+**Mutation Testing:**
+- @stryker-mutator/core 9.6.1 - Mutation testing framework
+- @stryker-mutator/tap-runner 9.6.1 - TAP runner for Stryker
+
+**Mocking & Test Utilities:**
+- jsdom 30.0.1 - DOM implementation for Node.js tests
+
+## Key Dependencies
+
+**Critical (Production):**
+- @modelcontextprotocol/sdk 1.29.0 - MCP server framework (105 tools across 3 transports)
+- better-sqlite3 13.0.2 (optional) - Synchronous SQLite driver (blocks required for `npm install`)
+- ioredis 5.10.1 - Redis client (optional, for rate limiting and quota caching)
+- @aws-sdk/client-bedrock-runtime 3.1073.0 - AWS Bedrock API client
+- undici 8.10.0 - HTTP client (replaces fetch in Node.js 18-)
+- ws 8.18.0 - WebSocket server/client (A2A protocol streaming, Live WS dashboard)
+- axios 1.16.1 - HTTP client with retries
+
+**Infrastructure & Auth:**
+- jose 6.2.3 - JWT handling (bearer token auth)
+- bcryptjs 3.0.3 - Password hashing
+- keytar 7.9.0 (optional) - System keychain access (Zed OAuth credential import)
+- selfsigned 5.5.0 - Self-signed certificate generation (MITM proxy certs)
+- @ngrok/ngrok 1.7.0 - Ngrok tunneling client
+
+**Network & Proxy:**
+- http-proxy-middleware 4.0.0 - HTTP proxy middleware
+- https-proxy-agent 9.0.0 - HTTPS agent with proxy support
+- fetch-socks 1.3.3 - SOCKS proxy support for fetch
+- socks 2.8.7 - SOCKS5 client
+
+**CLI & Terminal UI:**
+- commander 15.0.0 - Command-line argument parsing
+- update-notifier 7.3.1 - Notify users of package updates
+- open 11.0.0 - Open URLs/files in default applications
+- cron-parser 5.6.2 - Cron expression parsing
+
+**ML/AI Integration:**
+- @huggingface/transformers 4.2.0 - Transformer models (optional)
+- onnxruntime-node 1.24.3 - ONNX runtime for inference
+- js-tiktoken 1.0.20 (optional) - Token counting for OpenAI models
+- @atjsh/llmlingua-2 2.0.3 (optional) - Prompt compression
+
+**Utilities:**
+- uuid 14.0.0 - UUID generation
+- clsx 2.1.1 - Conditional className utility
+- sharp 0.35.3 - Image processing (thumbnails, AVIF conversion)
+- dompurify 3.4.13 - XSS prevention (HTML sanitization)
+- bottleneck 2.19.5 - Rate limiting (queue/throttle)
+- sql.js 1.14.1 - SQL.js database adapter (browser/Bun fallback)
+
+## Configuration
+
+**TypeScript:**
+- `tsconfig.json` - Main TypeScript configuration (target: ES2022, module: esnext)
+- `tsconfig.typecheck-core.json` - Core type-checking scope
+- `tsconfig.typecheck-noimplicit-core.json` - Strict type-checking (no implicit any)
+- Path aliases: `@/*` → `src/`, `@omniroute/open-sse` → `open-sse/`, `@omniroute/open-sse/*` → `open-sse/*`
+
+**Next.js:**
+- `next.config.mjs` - App configuration (CSP headers, MDX support, i18n plugin, CORS, query timeout)
+- `next-env.d.ts` - Auto-generated Next.js types
+
+**Build Tools:**
+- `eslint.config.mjs` - ESLint configuration (ES2022, Node.js CommonJS modules)
+- `.prettierrc` - Prettier formatter config (2-space, semicolons, 100-char width, trailing commas)
+- `postcss.config.mjs` - PostCSS pipeline (Tailwind, Autoprefixer)
+- `vitest.config.ts` - Vitest config (jsdom, React plugin, FTS5 setup)
+- `vitest.mcp.config.ts` - Vitest MCP-specific config
+- `playwright.config.ts` - Playwright E2E config
+
+**Database:**
+- `src/lib/db/migrations/` - 145+ idempotent SQLite migration files
+- SQLite WAL mode enabled by default
+- FTS5 (full-text search) extension for memory/corpus tables
+
+**Environment:**
+- `.env.example` (forbidden to read, but referenced in docs)
+- Key vars: `PORT`, `JWT_SECRET`, `API_KEY_SECRET`, `INITIAL_PASSWORD`, `REQUIRE_API_KEY`, `APP_LOG_LEVEL`, `REDIS_URL`, `QDRANT_*`, `CLOUDFLARE_*`, `NODE_ENV`
+- Data directory: `DATA_DIR` env or `~/.omniroute/` default
+
+## Platform Requirements
+
+**Development:**
+- Node.js 22.22.2+ or 24.0.0+
+- npm 9+ (for workspaces)
+- SQLite3 development headers (for better-sqlite3 build)
+- Python 3.8+ (optional, for some build scripts)
+- Playwright dependencies (Chromium, Firefox, WebKit)
+
+**Production:**
+- Node.js 22.22.2+ or 24.0.0+
+- SQLite3 (bundled; better-sqlite3 prebuilt binary or sql.js fallback)
+- Redis server (optional, for distributed rate limiting; in-memory fallback if missing)
+- Qdrant server (optional, for semantic memory; disabled if not configured)
+- 512 MB+ RAM minimum (1 GB+ recommended)
+- Disk space: ~200 MB base + variable for SQLite data (`~/.omniroute/`)
+
+**Deployment Targets:**
+- Docker (multi-stage: base, runner-web with Playwright)
+- Fly.io (Node.js buildpack, custom `fly.toml`)
+- Vercel (Next.js serverless)
+- Self-hosted Linux/macOS (systemd, Docker, VM)
+- Cloudflare Workers (via relay proxy)
+- Deno Deploy (via relay proxy)
+- Electron (desktop app in `electron/` subdirectory)
+
+---
+
+*Stack analysis: 2026-08-14*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,462 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-08-14
+
+## Directory Layout
+
+```
+OmniRoute/
+├── src/                           # Next.js 16 application
+│   ├── app/                       # Next.js App Router
+│   │   ├── api/v1/                # OpenAI-compatible API endpoints (40+ routes)
+│   │   │   ├── chat/completions/
+│   │   │   ├── embeddings/
+│   │   │   ├── images/
+│   │   │   ├── audio/
+│   │   │   ├── models/
+│   │   │   ├── combos/
+│   │   │   ├── batches/
+│   │   │   ├── agents/
+│   │   │   ├── _shared/           # Shared middleware + helpers
+│   │   │   └── [...omnirouteCatchAll]/
+│   │   ├── (dashboard)/           # User dashboard UI
+│   │   ├── a2a/                   # Agent-to-Agent protocol
+│   │   ├── api/monitoring/        # Health, status, metrics
+│   │   ├── auth/                  # OAuth callbacks
+│   │   ├── docs/                  # OpenAPI, provider catalog
+│   │   └── [error codes]/         # 400, 401, 403, 408, 429, 500, 502, 503
+│   ├── lib/                       # Core business logic (130+ modules)
+│   │   ├── db/                    # SQLite domain modules (145 migrations)
+│   │   │   ├── core.ts            # DB singleton + transaction handling
+│   │   │   ├── migrations/        # Idempotent SQL migrations
+│   │   │   ├── apiKeys.ts         # Credential management
+│   │   │   ├── combos.ts          # Multi-target routing configs
+│   │   │   ├── settings.ts        # Global + per-account settings
+│   │   │   ├── circuitBreakers.ts # Provider breaker state
+│   │   │   └── [100+ other modules]
+│   │   ├── a2a/                   # Agent-to-Agent protocol
+│   │   │   ├── skills/            # 5 agent skills
+│   │   │   ├── taskExecution.ts
+│   │   │   └── protocols.ts
+│   │   ├── memory/                # Persistent conversational memory
+│   │   │   ├── fts5/              # Full-text search
+│   │   │   ├── qdrant/            # Vector embeddings
+│   │   │   └── retrieval.ts
+│   │   ├── skills/                # Sandboxed skill framework
+│   │   │   ├── executor.ts
+│   │   │   ├── sandbox.ts
+│   │   │   └── registry.ts
+│   │   ├── guardrails/            # Security: PII, injection, vision
+│   │   │   ├── piiMasker.ts
+│   │   │   ├── promptInjectionGuard.ts
+│   │   │   └── visionSafety.ts
+│   │   ├── oauth/                 # OAuth2 provider integrations
+│   │   │   ├── providers/         # 20+ OAuth providers
+│   │   │   └── tokenRefresh.ts
+│   │   ├── cloudAgent/            # Cloud agent integrations (Codex, Devin, Jules)
+│   │   ├── evals/                 # Evaluation framework
+│   │   ├── compliance/            # Audit + legal compliance
+│   │   ├── cacheLayer.ts          # Redis/in-memory cache abstraction
+│   │   ├── webhookDispatcher.ts   # Event webhooks
+│   │   └── [100+ other modules]
+│   ├── domain/                    # Policy engine
+│   │   ├── models/                # Model registry + capabilities
+│   │   ├── providers/             # Provider configuration
+│   │   ├── fallback/              # Fallback routing logic
+│   │   └── cost/                  # Cost calculation rules
+│   ├── sse/                       # Server-sent events / streaming
+│   │   ├── handlers/              # Request processing
+│   │   │   ├── chat.ts
+│   │   │   ├── embeddings.ts
+│   │   │   └── [2+ other handlers]
+│   │   └── services/              # Streaming-specific services
+│   ├── shared/                    # Shared utilities (external & internal)
+│   │   ├── constants/             # providers.ts, upstreamHeaders.ts, etc.
+│   │   ├── utils/                 # cors.ts, requestId.ts, error.ts, etc.
+│   │   ├── middleware/            # chatBodyAdmission.ts, etc.
+│   │   └── resilience/            # Circuit breaker, rate limit base
+│   ├── server/                    # Backend infrastructure
+│   │   └── authz/                 # Route guard, authorization checks
+│   ├── types/                     # Global TypeScript types
+│   ├── models/                    # TypeScript model definitions
+│   ├── store/                     # Client-side state (dashboard)
+│   ├── hooks/                     # React hooks (dashboard)
+│   ├── mitm/                      # Man-in-the-middle proxy (tunnel mode)
+│   │   ├── cert/                  # Certificate generation + installation
+│   │   └── proxy.ts
+│   ├── middleware.ts              # Next.js middleware
+│   ├── scripts/                   # Server startup scripts
+│   └── i18n/                      # Internationalization
+│
+├── open-sse/                      # Streaming engine workspace
+│   ├── handlers/                  # Request processing (32 modules)
+│   │   ├── chatCore.ts            # Main chat handler (5000+ lines)
+│   │   ├── chatCore/              # Modular concerns (30+ modules)
+│   │   │   ├── requestSetup.ts
+│   │   │   ├── semanticCache.ts
+│   │   │   ├── idempotency.ts
+│   │   │   ├── memorySkillsInjection.ts
+│   │   │   ├── guardrailContext.ts
+│   │   │   ├── responseHeaders.ts
+│   │   │   └── [25+ other modules]
+│   │   ├── embeddings.ts
+│   │   ├── images.ts
+│   │   └── [5+ other handlers]
+│   ├── executors/                 # Provider HTTP dispatch (124+ files)
+│   │   ├── base.ts                # Base executor pattern (72KB)
+│   │   ├── base/                  # Base concerns (headers, reasoning, etc.)
+│   │   ├── openai.ts, claude-web.ts, bedrock.ts, ...
+│   │   └── [120+ provider-specific executors]
+│   ├── translator/                # Format conversion (OpenAI ↔ Claude ↔ Gemini)
+│   │   ├── index.ts               # Main translation hub
+│   │   ├── request/               # Request normalization
+│   │   │   ├── openai/
+│   │   │   ├── claude/
+│   │   │   ├── gemini/
+│   │   │   └── openai-responses/
+│   │   ├── response/              # Response synthesis
+│   │   ├── helpers/               # schemaCoercion, toolCall, claude, etc.
+│   │   └── registry.ts            # Translator lookup
+│   ├── services/                  # Business logic (226 modules)
+│   │   ├── combo.ts               # Multi-target orchestration
+│   │   ├── combo/                 # Combo concerns (15+ modules)
+│   │   │   ├── context.ts
+│   │   │   ├── comboSetup.ts
+│   │   │   ├── sessionStickiness.ts
+│   │   │   ├── quotaShareConcurrency.ts
+│   │   │   ├── promptCacheAffinity.ts
+│   │   │   └── [10+ other modules]
+│   │   ├── accountFallback.ts      # Credential selection + resilience (81KB)
+│   │   ├── accountFallback/       # Fallback concerns
+│   │   ├── autoCombo/             # 14-factor auto-combo scoring (26 modules)
+│   │   ├── sessionPool/           # OAuth session pooling
+│   │   ├── apiKeyRotator.ts       # Rotating API keys
+│   │   ├── accountSemaphore.ts    # Per-connection concurrency
+│   │   ├── rateLimitSemaphore.ts  # Global rate limiting
+│   │   ├── quotaPreflight.ts      # Quota evaluation
+│   │   ├── provider.ts            # Provider capability queries
+│   │   ├── [200+ other services]
+│   │   └── __tests__/             # Shared service tests
+│   ├── transformer/               # Responses API ↔ Chat Completions adapter
+│   │   ├── responsesTransformer.ts
+│   │   └── toResponses.ts
+│   ├── utils/                     # Utilities (98 modules)
+│   │   ├── stream.ts              # Stream composition
+│   │   ├── error.ts               # Error building + sanitization
+│   │   ├── cors.ts                # CORS headers
+│   │   ├── headers.ts             # Header normalization
+│   │   ├── usageTracking.ts       # Token usage
+│   │   ├── requestLogger.ts       # Structured logging
+│   │   ├── [90+ other utils]
+│   ├── config/                    # Configuration (56 modules)
+│   │   ├── constants.ts           # HTTP status, timeout, thresholds
+│   │   ├── providerRegistry.ts    # Model registry + capabilities
+│   │   ├── providers/             # Per-provider configs
+│   │   ├── anthropicHeaders.ts
+│   │   ├── [50+ other configs]
+│   ├── mcp-server/                # MCP protocol server (105 tools, 31 scopes)
+│   │   ├── tools/                 # 43 base tools + modular tools
+│   │   │   ├── memory/
+│   │   │   ├── skill/
+│   │   │   ├── agentSkill/
+│   │   │   ├── pool/
+│   │   │   ├── notion/
+│   │   │   ├── obsidian/
+│   │   │   ├── gamification/
+│   │   │   ├── plugin/
+│   │   │   └── [base tools]
+│   │   ├── transports/            # stdio, SSE, HTTP
+│   │   ├── schema.ts              # Tool schema validation
+│   │   └── server.ts              # Server entry point
+│   ├── lib/                       # Shared libraries
+│   │   ├── baseExecutor.ts
+│   │   └── [other lib modules]
+│   ├── shared/                    # Shared in open-sse
+│   └── vendor/                    # Vendored dependencies
+│
+├── electron/                      # Desktop application
+│   ├── src/
+│   ├── main/
+│   └── preload/
+│
+├── tests/                         # Test files (all tests here, NEVER in src/)
+│   ├── unit/                      # Unit tests (Node.js test runner)
+│   │   ├── services/
+│   │   ├── executors/
+│   │   ├── translators/
+│   │   └── [organized by feature]
+│   ├── integration/               # Integration tests (multi-module DB state)
+│   ├── e2e/                       # End-to-end (Playwright, UI workflows)
+│   └── protocols/                 # MCP + A2A protocol tests
+│
+├── scripts/                       # Maintenance & build scripts (NEVER at repo root)
+│   ├── build/                     # Build helpers
+│   ├── check/                     # Quality gates (lint, type, test, cycle detection)
+│   ├── dev/                       # Development helpers
+│   ├── docs/                      # Documentation generators
+│   ├── release/                   # Release workflow
+│   ├── ci/                        # CI helpers
+│   ├── quality/                   # Quality checks
+│   ├── ad-hoc/                    # One-off experimental scripts
+│   ├── perf/                      # Performance benchmarks
+│   ├── ops/                       # Operations (Docker, deployment)
+│   └── [15+ other categories]
+│
+├── docs/                          # Project documentation
+│   ├── architecture/              # ARCHITECTURE.md, RESILIENCE_GUIDE.md, etc.
+│   ├── frameworks/                # MCP-SERVER.md, A2A-SERVER.md, etc.
+│   ├── routing/                   # AUTO-COMBO.md, REASONING_REPLAY.md
+│   ├── security/                  # GUARDRAILS.md, PUBLIC_CREDS.md, etc.
+│   ├── reference/                 # API_REFERENCE.md, PROVIDER_REFERENCE.md
+│   ├── ops/                       # Operations guides
+│   ├── guides/                    # ELECTRON_GUIDE.md, etc.
+│   └── diagrams/                  # Mermaid + SVG diagrams
+│
+├── public/                        # Static assets
+├── config/                        # Configuration files
+│   ├── quality/                   # ESLint suppressions, etc.
+│   └── [other config]
+│
+├── skills/                        # Skill marketplace
+│   └── [skill definitions]
+│
+├── .planning/                     # GSD planning artifacts (gitignored)
+│   ├── codebase/                  # Codebase map (ARCHITECTURE.md, STRUCTURE.md, etc.)
+│   └── graphs/                    # Code knowledge graphs
+│
+├── bin/                           # CLI entry point
+│   ├── omniroute.ts               # CLI main
+│   └── [CLI sub-commands]
+│
+├── .github/                       # GitHub workflows + CI/CD
+│   └── workflows/
+│
+├── changelog.d/                   # Changelog fragments (tool-managed)
+├── AGENTS.md                      # Project rules (MANDATORY reference)
+├── CLAUDE.md                      # Claude Code specifics
+├── package.json                   # Root dependencies
+├── next.config.mjs                # Next.js configuration
+├── tsconfig.json                  # TypeScript configuration
+├── eslint.config.mjs              # ESLint rules
+└── .env.example                   # Environment template
+```
+
+## Directory Purposes
+
+**src/app/api/v1/:**
+- Purpose: OpenAI-compatible HTTP endpoints
+- Contains: 40+ route handlers following Next.js App Router pattern
+- Key files: `route.ts` per endpoint, `_shared/` for shared middleware
+- Pattern: Each endpoint has POST handler; some have OPTIONS for CORS preflight
+
+**open-sse/handlers/:**
+- Purpose: Request processing logic (cache, rate limit, guardrails, routing)
+- Contains: 32 modules; `chatCore.ts` is the central orchestrator
+- Key files: `chatCore.ts` (5000+ lines split into 30+ concerns), `embeddings.ts`, `images.ts`
+- Pattern: Each handler delegates to `open-sse/services/` and `open-sse/translator/`
+
+**open-sse/executors/:**
+- Purpose: Provider-specific HTTP dispatch
+- Contains: 124+ executor files (one per provider or provider family)
+- Key files: `base.ts` (72KB base class), provider-specific files
+- Pattern: Extends `BaseExecutor`, overrides request prep + error classification
+
+**open-sse/translator/:**
+- Purpose: Format conversion between OpenAI, Claude, Gemini, Responses
+- Contains: Request + response translation pipelines
+- Key files: `index.ts` (main hub), `request/` and `response/` subdirs per format
+- Pattern: Hub-and-spoke — all formats normalize to internal schema, then to target format
+
+**open-sse/services/:**
+- Purpose: Business logic — combo routing, resilience, quota, auth, caching
+- Contains: 226 modules covering 15+ cross-cutting concerns
+- Key files: `combo.ts` (orchestration), `accountFallback.ts` (resilience), `autoCombo/` (scoring)
+- Pattern: Services are stateless functions + in-memory caches; state in DB or transient cache
+
+**src/lib/db/:**
+- Purpose: SQLite persistence
+- Contains: 130+ domain modules, 145 migrations
+- Key files: `core.ts` (DB singleton), per-domain modules like `apiKeys.ts`, `combos.ts`
+- Pattern: Each module exports CRUD functions; no raw SQL in routes
+
+**open-sse/mcp-server/:**
+- Purpose: MCP protocol server (105 tools, 31 scopes)
+- Contains: Tool definitions, transports (stdio, SSE, HTTP)
+- Key files: `tools/` (tool implementations), `transports/` (protocol handling)
+- Pattern: Tool registered with Zod input schema + async handler
+
+**src/lib/a2a/:**
+- Purpose: Agent-to-Agent protocol (JSON-RPC 2.0)
+- Contains: 5 agent skills, task execution
+- Key files: `skills/`, `taskExecution.ts`, `protocols.ts`
+- Pattern: Skill receives task context, returns structured result
+
+## Key File Locations
+
+**Entry Points:**
+- `src/app/api/v1/chat/completions/route.ts`: Chat completion endpoint (POST)
+- `src/app/api/v1/embeddings/route.ts`: Embeddings endpoint
+- `src/app/api/v1/images/generations/route.ts`: Image generation endpoint
+- `src/app/api/v1/audio/transcriptions/route.ts`: Audio transcription endpoint
+- `bin/omniroute.ts`: CLI entry point
+- `open-sse/mcp-server/server.ts`: MCP server bootstrap
+
+**Configuration:**
+- `open-sse/config/providerRegistry.ts`: Model + provider registry
+- `open-sse/config/constants.ts`: Timeouts, thresholds, HTTP status codes
+- `src/lib/db/core.ts`: Database singleton + connection setup
+- `src/shared/constants/providers.ts`: Provider ID definitions
+- `next.config.mjs`: Next.js build configuration
+- `tsconfig.json`: TypeScript configuration
+
+**Core Logic:**
+- `open-sse/handlers/chatCore.ts`: Main request orchestrator (5000+ lines)
+- `open-sse/services/combo.ts`: Multi-target routing (1000+ lines)
+- `open-sse/services/accountFallback.ts`: Credential selection + resilience (81KB)
+- `open-sse/executors/base.ts`: Base executor pattern (72KB)
+- `open-sse/translator/index.ts`: Format translation hub (1000+ lines)
+- `src/lib/guardrails/piiMasker.ts`: PII redaction logic
+- `src/lib/guardrails/promptInjectionGuard.ts`: Prompt injection detection
+
+**Testing:**
+- `tests/unit/`: Unit tests (Node.js native test runner)
+- `tests/integration/`: Integration tests (DB state, multi-module)
+- `tests/e2e/`: End-to-end tests (Playwright, UI workflows)
+- `tests/protocols/`: MCP + A2A protocol tests
+
+## Naming Conventions
+
+**Files:**
+- **camelCase with meaningful suffix**: `chatCore.ts`, `accountFallback.ts`, `promptInjectionGuard.ts`
+- **Directory-based organization**: Group related files in subdirs (e.g., `chatCore/` for concerns, `combo/` for strategy)
+- **Modular concerns**: Break large files at 1500-2000 lines into `fileName/` + `fileName/concern.ts` pattern
+- **Tests**: `*.test.ts` or `*.spec.ts` suffix; always in `tests/` directory
+
+**Directories:**
+- **kebab-case for route paths**: `/api/v1/chat/completions` (not `/chat-completions/`)
+- **camelCase for business logic dirs**: `open-sse/handlers/`, `src/lib/db/`
+- **UPPERCASE for global config**: `public/`, `scripts/`, `docs/`
+- **Grouped by concern**: `open-sse/services/combo/`, `open-sse/handlers/chatCore/`
+
+**Functions:**
+- **camelCase verbs**: `handleChat`, `translateRequest`, `getExecutor`, `checkFallbackError`
+- **Booleans prefixed with is/should/has**: `isModelScope`, `shouldUseFusion`, `hasThinkingConfig`
+- **Async prefixed with get/fetch/resolve**: `getExecutor`, `fetchCodexQuota`, `resolveComboConfig`
+
+**Types/Constants:**
+- **PascalCase for types**: `ProviderConfig`, `ComboContext`, `ComboDiagnostics`
+- **UPPER_SNAKE for constants**: `HTTP_STATUS`, `FETCH_TIMEOUT_MS`, `COMBO_FAILURE_THRESHOLD`
+- **Descriptive enum names**: `ComboStrategy`, `ErrorClassification`, `ModelLockoutReason`
+
+## Where to Add New Code
+
+**New LLM Provider Support:**
+1. **Provider executor**: Create `open-sse/executors/yourprovider.ts` extending `BaseExecutor`
+   - Override: `async execute()`, error classification logic
+   - Export as default: `export default class YourProviderExecutor extends BaseExecutor { }`
+2. **Optional translator**: If format is non-OpenAI, create `open-sse/translator/request/yourformat/*.ts` + `response/yourformat/*.ts`
+3. **Provider config**: Add entry to `open-sse/config/providerRegistry.ts` with model list
+4. **Tests**: Add unit tests in `tests/unit/executors/yourprovider.test.ts`
+
+**New API Endpoint (Chat-like):**
+1. **Route handler**: Create `src/app/api/v1/yourfeature/route.ts`
+   - Pattern: CORS preflight → Zod body validation → optional auth → delegate to `open-sse/handlers/`
+   - Export: `export async function OPTIONS()` + `export async function POST(request)`
+2. **Handler**: If new, create `open-sse/handlers/yourfeature.ts`
+   - Signature: `export async function handleYourFeature({body, credentials, ...})`
+   - Depends on: `open-sse/services/combo`, `open-sse/translator/`, `open-sse/executors/`
+3. **Tests**: Add in `tests/unit/endpoints/yourfeature.test.ts`
+
+**New MCP Tool:**
+1. **Tool module**: Create `open-sse/mcp-server/tools/yourmodule/yourTool.ts`
+   - Define: Input schema (Zod), handler function (async)
+   - Export: `export const yourTool = { name, description, inputSchema, handler }`
+2. **Registration**: Add to tool registry in tool set creation (tool wiring)
+3. **Scope assignment**: Assign scope(s) in registry (e.g., `SCOPE_BASE`, `SCOPE_ADMIN`)
+4. **Tests**: Add in `tests/unit/mcp-server/tools/yourmodule.test.ts`
+
+**New Database Module:**
+1. **Domain module**: Create `src/lib/db/yourmodule.ts`
+   - Import: `getDbInstance()` from `./core.ts`
+   - Export: CRUD functions (`insert`, `getBy*`, `update`, `delete`)
+   - Use: Transactions for multi-step operations
+2. **Migration** (if new table): Create in `src/lib/db/migrations/001_yourmodule.sql` (idempotent)
+3. **Re-export**: Add to `src/lib/localDb.ts` export list
+4. **Tests**: Add in `tests/unit/db/yourmodule.test.ts`
+
+**New Combo Strategy:**
+1. **Strategy function**: Create in `open-sse/services/combo/yourStrategy.ts`
+   - Signature: `export function resolveYourStrategyOrder(candidates: ProviderCandidate[], context: ComboContext): ProviderCandidate[]`
+   - Return: Ordered list of candidates to try
+2. **Registration**: Add to strategy enum + registry in `open-sse/services/comboConfig.ts`
+3. **Tests**: Add in `tests/unit/services/combo/yourStrategy.test.ts`
+
+**New Guardrail:**
+1. **Guardrail module**: Create `src/lib/guardrails/yourGuardrail.ts`
+   - Export: `export function buildYourGuardrailContext(body, credentials, ...): GuardrailContext`
+   - Or: `export function applyYourGuardrail(body, request, settings): Promise<Body | GuardrailResponse>`
+2. **Wiring**: Add call site in request handler or response processor
+3. **Feature flag**: If opt-in, add boolean flag in `src/shared/constants/featureFlagDefinitions.ts`
+4. **Tests**: Add in `tests/unit/guardrails/yourGuardrail.test.ts`
+
+**Utilities & Helpers:**
+- **Shared helpers**: `src/shared/utils/yourHelper.ts` (used across src/, open-sse/)
+- **Stream utils**: `open-sse/utils/yourStreamHelper.ts` (SSE/response composition)
+- **Service helpers**: `open-sse/services/yourHelper.ts` (business logic)
+- **Test fixtures**: `tests/unit/fixtures/yourFixture.ts` (data builders, mocks)
+
+**Configuration & Constants:**
+- **Provider-specific**: `open-sse/config/providers/yourprovider.ts`
+- **Global constants**: `open-sse/config/constants.ts` or `src/shared/constants/`
+- **Feature flags**: `src/shared/constants/featureFlagDefinitions.ts`
+- **Type definitions**: `src/types/` or domain-specific `*.ts` in context
+
+## Special Directories
+
+**scripts/:**
+- Purpose: Build, test, check, and utility scripts (NEVER in repo root)
+- Generated: No (all hand-maintained)
+- Committed: Yes (production use)
+- Subdirs: `build/`, `check/`, `dev/`, `docs/`, `release/`, `ci/`, `quality/`, `ad-hoc/`, `perf/`, `ops/`, etc.
+- Rule: One-off or experimental scripts go in `scripts/ad-hoc/`; production scripts in appropriate category
+
+**tests/:**
+- Purpose: ALL tests (unit, integration, e2e, protocol)
+- Generated: No (hand-written + test fixtures)
+- Committed: Yes (blocking CI)
+- Structure: `tests/unit/`, `tests/integration/`, `tests/e2e/`, `tests/protocols/`
+- Rule: NEVER create test files in `src/` root or elsewhere; always `tests/`
+
+**.planning/codebase/:**
+- Purpose: Codebase map documents (ARCHITECTURE.md, STRUCTURE.md, CONVENTIONS.md, TESTING.md, CONCERNS.md)
+- Generated: Yes (by `/gsd-map-codebase` agent)
+- Committed: No (gitignored)
+- Use: Input to `/gsd-plan-phase` and `/gsd-execute-phase` for planning context
+
+**_tasks/:**
+- Purpose: Separate git repo for planning artifacts (plans, specs, research, hand-offs)
+- Generated: Yes (by superpowers skills)
+- Committed: Yes (to `_tasks/` remote, not main repo)
+- Rule: NEVER tracked in main repo; always under `.gitignore` anchor `/_*/`
+
+**public/:**
+- Purpose: Static assets served directly (images, fonts, favicon)
+- Generated: No (design assets)
+- Committed: Yes
+- Served: At root (e.g., `/favicon.ico`)
+
+**docs/:**
+- Purpose: Project documentation (architecture, frameworks, security, ops, guides)
+- Generated: Partially (provider reference auto-generated)
+- Committed: Yes
+- Accuracy rule: Only describe verified behavior (run commands, check source before documenting)
+
+**config/:**
+- Purpose: Build + ESLint configuration
+- Generated: No (hand-maintained)
+- Committed: Yes
+- Subdir: `config/quality/` contains ESLint suppressions (`eslint-suppressions.json`)
+
+---
+
+*Structure analysis: 2026-08-14*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,439 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-08-14
+
+## Test Framework
+
+**Runners:**
+- **Node.js native test runner** (`node:test`) - default for ~95% of unit tests
+  - Import: `import test from "node:test"` or `import { describe, it, before, after, beforeEach, afterEach, mock } from "node:test"`
+  - Assertion: `import assert from "node:assert/strict"`
+  - Config: built-in (no config file needed, but respects NODE_OPTIONS)
+  
+- **Vitest** - for MCP server, autoCombo routing, cache tests, and browser-based tests
+  - Config: `vitest.config.ts`
+  - Import: `import { describe, it, beforeEach, afterEach, expect, vi } from "vitest"`
+  - Environment: jsdom (for React/UI component tests)
+  - Execution: `npm run test:vitest` (MCP, autoCombo, cache) and `npm run test:vitest:ui` (UI tests)
+
+- **Playwright** - for end-to-end browser tests
+  - Config: `playwright.config.ts`
+  - Tests: `tests/e2e/*.spec.ts`
+  - Execution: `npm run test:e2e`
+
+**Run Commands:**
+```bash
+npm run test:unit                  # Run all unit tests (Node.js native)
+npm run test:vitest               # Run vitest suite (MCP, autoCombo, cache)
+npm run test:vitest:ui            # Run vitest UI tests (React components)
+npm run test:integration          # Integration tests (multi-module, DB state)
+npm run test:e2e                  # Playwright end-to-end tests
+npm run test:coverage             # Coverage gate (60/60/60/60: statements/lines/functions/branches)
+npm run test:all                  # All test suites (unit + vitest + vitest:ui + ecosystem + e2e)
+npm run test:scoped               # Run tests for changed files only (pre-commit)
+npm run test:property             # Property-based tests (fast-check)
+npm run test:mutation             # Mutation testing (Stryker)
+```
+
+## Test File Organization
+
+**Location:**
+- **Primary**: `tests/unit/` directory (most unit tests)
+- **Integration**: `tests/integration/` (multi-module tests, combo matrix, live tests)
+- **E2E**: `tests/e2e/` (Playwright browser tests)
+- **Co-located**: `src/**/__tests__/` or `src/**/__tests__/*.test.ts` (module-specific tests, especially MCP tools)
+- **Serial tests**: `tests/unit/serial/` (tests that cannot run in parallel)
+
+**Naming:**
+- `*.test.ts` - Node.js test files (native runner)
+- `*.test.tsx` - React component tests (vitest)
+- `*.test.mjs` - ESM module tests
+- `*.spec.ts` - Playwright tests (`tests/e2e/*.spec.ts`)
+- `*.live.test.ts` - Live integration tests (require running server)
+- `*.property.test.ts` - Property-based tests
+
+## Test Structure
+
+**Node.js native runner pattern:**
+```typescript
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("feature works correctly", () => {
+  const result = calculateSomething();
+  assert.equal(result, expectedValue);
+});
+
+test("async operation completes", async () => {
+  const result = await asyncFunction();
+  assert.ok(result);
+});
+```
+
+**Describe/It pattern:**
+```typescript
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+describe("Feature name", () => {
+  let fixture: SomeType;
+
+  before(() => {
+    // Runs once before all tests in this describe
+    setupGlobalState();
+  });
+
+  after(() => {
+    // Runs once after all tests in this describe
+    cleanupGlobalState();
+  });
+
+  beforeEach(() => {
+    // Runs before each test
+    fixture = createFixture();
+  });
+
+  afterEach(() => {
+    // Runs after each test
+    if (fixture) fixture.cleanup();
+  });
+
+  it("should do something", () => {
+    const result = fixture.doSomething();
+    assert.equal(result, expected);
+  });
+
+  it("should handle errors", async () => {
+    await assert.rejects(() => fixture.failingOperation(), Error);
+  });
+});
+```
+
+**Vitest pattern (for MCP, autoCombo, React):**
+```typescript
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+
+describe("MCP Tool", () => {
+  let mockDb: MockDatabase;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should invoke the tool correctly", async () => {
+    const result = await toolFunction(mockDb);
+    expect(result).toEqual(expectedValue);
+    expect(mockDb.query).toHaveBeenCalledWith("SELECT * FROM table");
+  });
+
+  it("timeout override for slow tests", async () => {
+    // ... slow test code ...
+  }, 30000); // 30 second timeout instead of default 5000ms
+});
+```
+
+## Mocking
+
+**Node.js native test framework:**
+```typescript
+import { mock } from "node:test";
+
+describe("Mocking with node:test", () => {
+  it("mocks database prepare calls", () => {
+    const db = getDbInstance();
+    const prepareSpy = mock.method(db, "prepare");
+    
+    callFunctionThatUsesPrepare();
+    
+    assert.equal(prepareSpy.mock.calls.length, 1);
+    const callArgs = prepareSpy.mock.calls[0].arguments;
+    prepareSpy.mock.restore();
+  });
+
+  it("mocks a function's return value", () => {
+    const fn = mock.fn(() => "mocked value");
+    const result = fn();
+    assert.equal(result, "mocked value");
+    assert.equal(fn.mock.calls.length, 1);
+  });
+});
+```
+
+**Vitest mocking:**
+```typescript
+import { vi } from "vitest";
+
+describe("Mocking with vitest", () => {
+  it("mocks functions", () => {
+    const mockFn = vi.fn(() => "result");
+    expect(mockFn()).toBe("result");
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("spies on module methods", () => {
+    const module = getModule();
+    const spy = vi.spyOn(module, "method");
+    
+    module.method("arg");
+    
+    expect(spy).toHaveBeenCalledWith("arg");
+    spy.mockRestore();
+  });
+
+  it("mocks entire modules", async () => {
+    vi.doMock("./module", () => ({
+      default: { fn: vi.fn(() => "mocked") },
+    }));
+    const mod = await import("./module");
+    expect(mod.default.fn()).toBe("mocked");
+    vi.resetModules();
+  });
+});
+```
+
+**What to Mock:**
+- External API calls (HTTP, database backends not in scope)
+- File system operations (use temp directories instead where possible)
+- Time-dependent functions (use `vi.useFakeTimers()`)
+- Complex dependencies when testing units in isolation
+
+**What NOT to Mock:**
+- The code under test (never mock what you're testing)
+- Built-in modules like `node:fs` (use real temp files or abstraction patterns)
+- Database queries when testing database modules (use real SQLite in-memory)
+- HTTP client libraries in integration tests (use nock or msw for stubbing)
+
+## Fixtures and Factories
+
+**Test Data:**
+```typescript
+// tests/unit/fixtures/userFactory.ts
+export function createTestUser(overrides?: Partial<User>): User {
+  return {
+    id: "user-123",
+    email: "test@example.com",
+    role: "user",
+    ...overrides,
+  };
+}
+
+// In test:
+import { createTestUser } from "../fixtures/userFactory";
+
+it("calculates user quota", () => {
+  const user = createTestUser({ role: "premium" });
+  const quota = calculateQuota(user);
+  assert.equal(quota, 10000);
+});
+```
+
+**Database fixtures:**
+```typescript
+// tests/_setup/dbFixtures.ts
+export async function seedTestDatabase() {
+  const db = getDbInstance();
+  db.prepare("INSERT INTO providers (id, name) VALUES (?, ?)").run("gpt4", "GPT-4");
+  return db;
+}
+
+// In test:
+before(async () => {
+  await seedTestDatabase();
+});
+```
+
+**Location:**
+- `tests/_setup/` - global setup, fixtures, utilities
+- `tests/fixtures/` - test data factories
+- `src/**/__tests__/fixtures/` - module-specific fixtures (for co-located tests)
+
+## Coverage
+
+**Requirements:** 60/60/60 threshold for statements, lines, functions, and branches
+- Enforced via `npm run test:coverage`
+- Pre-existing coverage frozen in `quality-baseline.json`
+- Ratchet policy: coverage must not regress; update baseline via `npm run quality:ratchet -- --update` when coverage genuinely improves
+- Report: HTML report at `coverage/index.html`
+
+**View Coverage:**
+```bash
+npm run test:coverage               # Run tests with coverage check
+npm run coverage:report             # Generate HTML report (after test:coverage)
+open coverage/index.html            # View report in browser
+```
+
+## Test Types
+
+**Unit Tests:**
+- Scope: single function or module in isolation
+- Location: `tests/unit/` (primary) or `src/**/__tests__/`
+- Mocking: external dependencies
+- Examples: `pricing-sync-memoization.test.ts`, `sidebar-icon-accents-3812.test.ts`
+- Command: `npm run test:unit`
+
+**Integration Tests:**
+- Scope: multiple modules working together, database interactions
+- Location: `tests/integration/` or `tests/integration/combo-matrix/`
+- Database: real SQLite (in isolated temp directory per test)
+- Examples: combo routing matrix tests, heap growth tests
+- Command: `npm run test:integration`
+
+**E2E Tests:**
+- Scope: complete user workflows through browser or HTTP client
+- Location: `tests/e2e/`
+- Framework: Playwright
+- Examples: login flow, dashboard navigation, API responses
+- Command: `npm run test:e2e`
+
+**Live Tests:**
+- Scope: behavior with real upstream providers or servers
+- Location: `tests/integration/combo-live/*.live.test.ts` or `tests/boundary/*.live.test.ts`
+- Command: `npm run test:combo:live` (requires RUN_COMBO_LIVE=1)
+- Execution: manual, on-demand, or CI with real credentials
+
+## Common Patterns
+
+**Async Testing:**
+```typescript
+// Node.js native — promise rejection
+it("rejects on error", async () => {
+  await assert.rejects(
+    () => asyncFunction(),
+    (err: Error) => err.message.includes("expected text")
+  );
+});
+
+// Vitest — expect.rejects
+it("throws on bad input", async () => {
+  await expect(() => asyncFunction("bad")).rejects.toThrow("expected");
+});
+
+// With timeout for slow operations
+it("handles slow network", async () => {
+  const result = await slowNetworkCall();
+  assert.ok(result);
+}, 10000); // 10 second timeout
+```
+
+**Error Testing:**
+```typescript
+// Node.js native
+it("validates input", () => {
+  assert.throws(
+    () => validateSchema(invalidData),
+    { message: /required field/ }
+  );
+});
+
+// Vitest
+it("rejects invalid schema", () => {
+  expect(() => validateSchema(invalidData)).toThrow(/required field/);
+});
+```
+
+**Database Testing:**
+```typescript
+import { getDbInstance } from "@/lib/db/core";
+
+it("inserts and retrieves data", () => {
+  const db = getDbInstance();
+  
+  // Insert
+  const result = db.prepare("INSERT INTO models (id, name) VALUES (?, ?)").run("m1", "Model 1");
+  
+  // Retrieve
+  const model = db.prepare("SELECT * FROM models WHERE id = ?").get("m1");
+  assert.equal(model.name, "Model 1");
+});
+```
+
+**Memoization/Cache Testing:**
+```typescript
+it("returns same reference for repeated reads within cache version", () => {
+  const first = getCachedValue();
+  const second = getCachedValue();
+  assert.equal(second, first); // Same object reference, not just deep equality
+});
+
+it("invalidates cache after write", () => {
+  const before = getCachedValue();
+  writeValue(newData);
+  const after = getCachedValue();
+  assert.notEqual(after, before); // Different reference = cache invalidated
+});
+```
+
+**Mock Database Pattern:**
+```typescript
+import { mock } from "node:test";
+
+it("tracks database calls", () => {
+  const db = getDbInstance();
+  const prepareSpy = mock.method(db, "prepare");
+  const callsBefore = prepareSpy.mock.calls.length;
+
+  // Code under test
+  doSomethingWithDb();
+
+  const callsAfter = prepareSpy.mock.calls.length;
+  prepareSpy.mock.restore();
+  
+  assert.ok(callsAfter - callsBefore <= 1, "should only query once (memoized)");
+});
+```
+
+**Setup/Teardown with Cleanup:**
+```typescript
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+it("works with temporary files", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-"));
+  
+  try {
+    const filePath = path.join(tempDir, "test.txt");
+    fs.writeFileSync(filePath, "content");
+    
+    const content = fs.readFileSync(filePath, "utf8");
+    assert.equal(content, "content");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+```
+
+## Database Handle Cleanup (Critical for Node.js test runner)
+
+**IMPORTANT:** Any test that triggers database migrations or establishes SQLite connections MUST call `resetDbInstance()` in a test.after() hook.
+
+```typescript
+import test from "node:test";
+import { getDbInstance, resetDbInstance } from "@/lib/db/core";
+
+test.describe("Database operations", () => {
+  test.afterEach(async () => {
+    try {
+      resetDbInstance(); // Close handle; prevents indefinite hang
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test("initializes database", () => {
+    const db = getDbInstance();
+    // ... test code ...
+  });
+});
+```
+
+Failure to release handles causes Node's native test runner to hang indefinitely.
+
+---
+
+*Testing analysis: 2026-08-14*

--- a/docs/reference/PROVIDER_REFERENCE.md
+++ b/docs/reference/PROVIDER_REFERENCE.md
@@ -1,14 +1,14 @@
 ---
 title: "Provider Reference"
 version: 3.8.50
-lastUpdated: 2026-08-12
+lastUpdated: 2026-08-14
 ---
 
 # Provider Reference
 
 > **Auto-generated** from `src/shared/constants/providers.ts` — do not edit by hand.
 > Regenerate with: `npm run gen:provider-reference`
-> **Last generated:** 2026-08-12
+> **Last generated:** 2026-08-14
 
 Total providers: **339**. See category breakdown below.
 

--- a/open-sse/config/glmProvider.ts
+++ b/open-sse/config/glmProvider.ts
@@ -19,6 +19,35 @@ export const GLM_ANTHROPIC_DEFAULT_BASE_URLS = Object.freeze({
 
 export const GLM_SHARED_MODELS = Object.freeze([
   {
+    // GLM-5.3 (2026-08-14): one upstream id; effort is the reasoning_effort
+    // param (low|high|max, default max) — the -high/-low entries below are
+    // OmniRoute aliases resolved by GlmExecutor::parseGlmEffortTier.
+    // Default context window not yet published by Z.ai; 1M mirrored from
+    // GLM-5.2 (same base model). https://z.ai/blog/glm-5.3
+    id: "glm-5.3",
+    name: "GLM 5.3",
+    contextLength: 1000000,
+    maxOutputTokens: 131072,
+    toolCalling: true,
+    supportsReasoning: true,
+  },
+  {
+    id: "glm-5.3-high",
+    name: "GLM 5.3 High",
+    contextLength: 1000000,
+    maxOutputTokens: 131072,
+    toolCalling: true,
+    supportsReasoning: true,
+  },
+  {
+    id: "glm-5.3-low",
+    name: "GLM 5.3 Low",
+    contextLength: 1000000,
+    maxOutputTokens: 131072,
+    toolCalling: true,
+    supportsReasoning: true,
+  },
+  {
     id: "glm-5.2",
     name: "GLM 5.2",
     contextLength: 1000000,

--- a/open-sse/config/glmProvider.ts
+++ b/open-sse/config/glmProvider.ts
@@ -48,6 +48,16 @@ export const GLM_SHARED_MODELS = Object.freeze([
     supportsReasoning: true,
   },
   {
+    // Explicit alias for the upstream default (max) — pins reasoning_effort so
+    // the tier survives an upstream default change, and mirrors glm-5.2-max UX.
+    id: "glm-5.3-max",
+    name: "GLM 5.3 Max",
+    contextLength: 1000000,
+    maxOutputTokens: 131072,
+    toolCalling: true,
+    supportsReasoning: true,
+  },
+  {
     id: "glm-5.2",
     name: "GLM 5.2",
     contextLength: 1000000,

--- a/open-sse/config/providers/registry/zai/index.ts
+++ b/open-sse/config/providers/registry/zai/index.ts
@@ -11,13 +11,15 @@ export const zaiProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "x-api-key",
   headers: getAnthropicCompatHeaders(),
-  // Real upstream model IDs only. The effort tiers (glm-5.2-high / glm-5.2-max)
-  // are intentionally NOT listed here: they are OmniRoute aliases resolved by the
-  // GlmExecutor (parseGlm52Effort → base "glm-5.2" + effort field). This provider
-  // uses the DefaultExecutor, which sends the model ID verbatim, so the aliases
-  // would reach z.ai's Anthropic endpoint as unknown IDs. Use the `glm` provider
-  // for effort tiers. Vision models are likewise omitted (handled elsewhere).
+  // Real upstream model IDs only. The effort tiers (glm-5.2-high/-max,
+  // glm-5.3-high/-low) are intentionally NOT listed here: they are OmniRoute
+  // aliases resolved by the GlmExecutor (parseGlmEffortTier → base model +
+  // effort selector). This provider uses the DefaultExecutor, which sends the
+  // model ID verbatim, so the aliases would reach z.ai's Anthropic endpoint as
+  // unknown IDs. Use the `glm` provider for effort tiers. Vision models are
+  // likewise omitted (handled elsewhere).
   models: [
+    { id: "glm-5.3", name: "GLM 5.3" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "glm-5.1", name: "GLM 5.1" },
     { id: "glm-5", name: "GLM 5" },

--- a/open-sse/executors/glm.ts
+++ b/open-sse/executors/glm.ts
@@ -52,17 +52,41 @@ function getEffectiveKey(credentials: ProviderCredentials): string {
   return credentials.apiKey || credentials.accessToken || "";
 }
 
+export type GlmEffortLevel = "low" | "high" | "max";
+
+type GlmEffortTier = {
+  baseModel: string;
+  effort: GlmEffortLevel;
+  /** Transport where the upstream honors the effort selector for this family. */
+  transport: GlmTransport;
+};
+
 /**
- * GLM-5.2 effort tiers route exclusively through the Anthropic transport,
- * where Zhipu maps Claude Code effort selectors (high/max) to reasoning
- * intensity. The base model ID sent upstream is always "glm-5.2".
+ * GLM-5.2 effort tiers (glm-5.2-high/-max) route exclusively through the
+ * Anthropic transport, where Zhipu maps Claude Code effort selectors (high/max)
+ * to reasoning intensity. The base model ID sent upstream is always "glm-5.2".
+ *
+ * GLM-5.3 replaced tier endpoints with a documented `reasoning_effort` request
+ * parameter (low|high|max, default max) on the coding chat/completions endpoint,
+ * so its tiers stay on the OpenAI transport and inject `reasoning_effort` +
+ * `thinking.type=enabled` (5.3 no longer accepts thinking disabled).
  *
  * https://docs.z.ai/devpack/latest-model
+ * https://z.ai/blog/glm-5.3
  */
-function parseGlm52Effort(model: string): { baseModel: string; effort: "high" | "max" } | null {
-  if (model === "glm-5.2-high") return { baseModel: "glm-5.2", effort: "high" };
-  if (model === "glm-5.2-max") return { baseModel: "glm-5.2", effort: "max" };
-  return null;
+function parseGlmEffortTier(model: string): GlmEffortTier | null {
+  switch (model) {
+    case "glm-5.2-high":
+      return { baseModel: "glm-5.2", effort: "high", transport: "anthropic" };
+    case "glm-5.2-max":
+      return { baseModel: "glm-5.2", effort: "max", transport: "anthropic" };
+    case "glm-5.3-high":
+      return { baseModel: "glm-5.3", effort: "high", transport: "openai" };
+    case "glm-5.3-low":
+      return { baseModel: "glm-5.3", effort: "low", transport: "openai" };
+    default:
+      return null;
+  }
 }
 
 /**
@@ -278,7 +302,7 @@ export class GlmExecutor extends DefaultExecutor {
     credentials: ProviderCredentials,
     transport: GlmTransport
   ) {
-    const effortTier = parseGlm52Effort(model);
+    const effortTier = parseGlmEffortTier(model);
     const effectiveModel = effortTier ? effortTier.baseModel : model;
 
     const transformed = this.transformRequest(effectiveModel, body, stream, credentials);
@@ -313,6 +337,14 @@ export class GlmExecutor extends DefaultExecutor {
     }
 
     if (transport === "openai") {
+      // GLM-5.3 effort tiers: inject the documented `reasoning_effort` param and
+      // force thinking on — 5.3 rejects thinking.type "disabled", and an effort
+      // tier without thinking would silently drop the selector upstream.
+      if (record && effortTier && effortTier.transport === "openai") {
+        const existingThinking = asRecord(record.thinking);
+        record.thinking = { ...existingThinking, type: "enabled" };
+        record.reasoning_effort = effortTier.effort;
+      }
       if (record && stream && hasTools(record) && record.tool_stream === undefined) {
         return { ...record, tool_stream: true };
       }
@@ -446,7 +478,12 @@ export class GlmExecutor extends DefaultExecutor {
    */
   private async finalizeAnthropicTransportResult(
     input: ExecuteInput,
-    result: { response: Response; url: string; headers: Record<string, string>; transformedBody: unknown }
+    result: {
+      response: Response;
+      url: string;
+      headers: Record<string, string>;
+      transformedBody: unknown;
+    }
   ): Promise<GlmExecuteResult> {
     const { response: rawResponse, url, headers, transformedBody } = result;
     const clientHeaders = input.clientHeaders ?? {};
@@ -475,13 +512,14 @@ export class GlmExecutor extends DefaultExecutor {
   }
 
   async execute(input: ExecuteInput): Promise<GlmExecuteResult> {
-    const effortTier = parseGlm52Effort(input.model);
+    const effortTier = parseGlmEffortTier(input.model);
 
-    // GLM-5.2 effort tiers route directly through Anthropic transport (no fallback).
-    // Zhipu only graduates effort on the Anthropic endpoint via the
-    // effort-2025-11-24 beta header included in GLM_ANTHROPIC_BETA.
+    // Effort tiers route directly through their family's transport (no fallback):
+    // GLM-5.2 → Anthropic (Zhipu only graduates effort there, via the
+    // effort-2025-11-24 beta header in GLM_ANTHROPIC_BETA); GLM-5.3 → OpenAI
+    // coding endpoint (`reasoning_effort` param). See parseGlmEffortTier.
     if (effortTier) {
-      return this.executeTransport(input, "anthropic");
+      return this.executeTransport(input, effortTier.transport);
     }
 
     const primaryTransport = getGlmTransport(

--- a/open-sse/executors/glm.ts
+++ b/open-sse/executors/glm.ts
@@ -84,6 +84,8 @@ function parseGlmEffortTier(model: string): GlmEffortTier | null {
       return { baseModel: "glm-5.3", effort: "high", transport: "openai" };
     case "glm-5.3-low":
       return { baseModel: "glm-5.3", effort: "low", transport: "openai" };
+    case "glm-5.3-max":
+      return { baseModel: "glm-5.3", effort: "max", transport: "openai" };
     default:
       return null;
   }

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -65,7 +65,14 @@ const BEDROCK_CLAUDE_ALIASES = (...modelIds: string[]) => [
 // Provider discovery/sync sources can under-report GLM-5.2 IDs as 128K.
 // Keep native/bare Z.AI GLM-5.2 context authoritative, but do not blindly apply
 // it to every provider-wrapped alias: hosted providers can and do cap lower.
-const AUTHORITATIVE_CONTEXT_WINDOW_MODEL_IDS = new Set(["glm-5.2", "glm-5.2-high", "glm-5.2-max"]);
+const AUTHORITATIVE_CONTEXT_WINDOW_MODEL_IDS = new Set([
+  "glm-5.3",
+  "glm-5.3-high",
+  "glm-5.3-low",
+  "glm-5.2",
+  "glm-5.2-high",
+  "glm-5.2-max",
+]);
 const AUTHORITATIVE_PROVIDER_CONTEXT_WINDOWS = new Map<string, number>([
   ["cloudflare-ai/@cf/zai-org/glm-5.2", 262144],
   // Hugging Face Router has 1M-capable backends, but bare routing can select
@@ -505,6 +512,30 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
   "mimo-v2-flash": {
     maxOutputTokens: 65536,
     contextWindow: 262144,
+    supportsTools: true,
+  },
+
+  // ── Z.AI GLM-5.3 (1M context mirrored from 5.2 — same base model; 128K max
+  // output; effort via reasoning_effort param, tiers are OmniRoute aliases) ──
+  "glm-5.3": {
+    maxOutputTokens: 131072,
+    contextWindow: 1000000,
+    thinkingBudgetCap: 38912,
+    supportsThinking: true,
+    supportsTools: true,
+  },
+  "glm-5.3-high": {
+    maxOutputTokens: 131072,
+    contextWindow: 1000000,
+    thinkingBudgetCap: 38912,
+    supportsThinking: true,
+    supportsTools: true,
+  },
+  "glm-5.3-low": {
+    maxOutputTokens: 131072,
+    contextWindow: 1000000,
+    thinkingBudgetCap: 38912,
+    supportsThinking: true,
     supportsTools: true,
   },
 

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -69,6 +69,7 @@ const AUTHORITATIVE_CONTEXT_WINDOW_MODEL_IDS = new Set([
   "glm-5.3",
   "glm-5.3-high",
   "glm-5.3-low",
+  "glm-5.3-max",
   "glm-5.2",
   "glm-5.2-high",
   "glm-5.2-max",
@@ -532,6 +533,13 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     supportsTools: true,
   },
   "glm-5.3-low": {
+    maxOutputTokens: 131072,
+    contextWindow: 1000000,
+    thinkingBudgetCap: 38912,
+    supportsThinking: true,
+    supportsTools: true,
+  },
+  "glm-5.3-max": {
     maxOutputTokens: 131072,
     contextWindow: 1000000,
     thinkingBudgetCap: 38912,

--- a/src/shared/constants/pricing/shared-tiers.ts
+++ b/src/shared/constants/pricing/shared-tiers.ts
@@ -100,6 +100,30 @@ export const CLAUDE_SONNET_5_PRICING = {
 };
 
 export const GLM_PRICING = {
+  // GLM-5.3 (2026-08-14): Z.ai hasn't published 5.3 rates yet — mirrored from
+  // GLM-5.2 (same base model; 5.1 and 5.2 also share identical rates).
+  // Correct when https://docs.z.ai/guides/overview/pricing lists glm-5.3.
+  "glm-5.3": {
+    input: 1.2,
+    output: 5,
+    cached: 0.3,
+    reasoning: 5,
+    cache_creation: 1.2,
+  },
+  "glm-5.3-high": {
+    input: 1.2,
+    output: 5,
+    cached: 0.3,
+    reasoning: 5,
+    cache_creation: 1.2,
+  },
+  "glm-5.3-low": {
+    input: 1.2,
+    output: 5,
+    cached: 0.3,
+    reasoning: 5,
+    cache_creation: 1.2,
+  },
   "glm-5.2": {
     input: 1.2,
     output: 5,

--- a/src/shared/constants/pricing/shared-tiers.ts
+++ b/src/shared/constants/pricing/shared-tiers.ts
@@ -124,6 +124,13 @@ export const GLM_PRICING = {
     reasoning: 5,
     cache_creation: 1.2,
   },
+  "glm-5.3-max": {
+    input: 1.2,
+    output: 5,
+    cached: 0.3,
+    reasoning: 5,
+    cache_creation: 1.2,
+  },
   "glm-5.2": {
     input: 1.2,
     output: 5,

--- a/tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts
+++ b/tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts
@@ -1,0 +1,180 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// GLM-5.3 support (released 2026-08-14, https://z.ai/blog/glm-5.3).
+//
+// Upstream ships ONE model id (`glm-5.3`) — effort is a request parameter
+// (`reasoning_effort`: low|high|max, default max) on the coding chat/completions
+// endpoint, and `thinking.type: "disabled"` is rejected (converted to low by the
+// coding endpoint). OmniRoute keeps the GLM-5.2 tier UX: `glm-5.3-high` /
+// `glm-5.3-low` pseudo-ids resolved by the GlmExecutor only. Base `glm-5.3` uses
+// the upstream default (max). Unlike the 5.2 tiers (Anthropic-transport effort
+// beta header), the 5.3 tiers use the documented `reasoning_effort` param on the
+// OpenAI coding transport.
+//
+// Spec caveat: Z.ai has not yet published the default context window — 1M is
+// mirrored from GLM-5.2 (same base model) per operator decision; correct when
+// the official spec lands.
+
+const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
+const { GlmExecutor } = await import("../../open-sse/executors/glm.ts");
+const { MODEL_SPECS } = await import("../../src/shared/constants/modelSpecs.ts");
+const { GLM_PRICING } = await import("../../src/shared/constants/pricing/shared-tiers.ts");
+
+const GLM_5_3_IDS = ["glm-5.3", "glm-5.3-high", "glm-5.3-low"] as const;
+
+// transformForTransport returns an opaque body; surface only the fields asserted below.
+type TransformedRequest = {
+  model?: string;
+  reasoning_effort?: string;
+  thinking?: { type?: string } | null;
+  max_tokens?: number;
+  effort?: string;
+};
+
+function modelIds(provider: string): string[] {
+  const entry = getRegistryEntry(provider);
+  assert.ok(entry, `provider "${provider}" should be registered`);
+  return (entry.models ?? []).map((m) => m.id);
+}
+
+for (const provider of ["glm", "glm-cn", "glmt"]) {
+  test(`${provider} advertises the GLM-5.3 base model and effort tiers (GLM_SHARED_MODELS)`, () => {
+    const ids = modelIds(provider);
+    for (const id of GLM_5_3_IDS) {
+      assert.ok(ids.includes(id), `${provider} should expose ${id}; got ${ids.join(", ")}`);
+    }
+  });
+
+  test(`${provider} GLM-5.3 entries mirror the GLM-5.2 shape (1M ctx, 128K out)`, () => {
+    const models = getRegistryEntry(provider)!.models ?? [];
+    const base = models.find((m) => m.id === "glm-5.3");
+    assert.ok(base, "glm-5.3 entry missing");
+    assert.equal(base.contextLength, 1_000_000);
+    assert.equal(base.maxOutputTokens, 131_072);
+    assert.equal(base.toolCalling, true);
+    assert.equal(base.supportsReasoning, true);
+  });
+}
+
+test("zai advertises the GLM-5.3 base model only (DefaultExecutor sends ids verbatim)", () => {
+  const ids = modelIds("zai");
+  assert.ok(ids.includes("glm-5.3"), `zai should advertise glm-5.3; got ${ids.join(", ")}`);
+  for (const alias of ["glm-5.3-high", "glm-5.3-low"]) {
+    assert.ok(
+      !ids.includes(alias),
+      `zai must not list ${alias}: GlmExecutor-only alias, unknown upstream on the Anthropic endpoint`
+    );
+  }
+});
+
+test("modelSpecs carries 1M/128K specs for all GLM-5.3 ids", () => {
+  for (const id of GLM_5_3_IDS) {
+    const spec = MODEL_SPECS[id];
+    assert.ok(spec, `MODEL_SPECS should include ${id}`);
+    assert.equal(spec.contextWindow, 1_000_000);
+    assert.equal(spec.maxOutputTokens, 131_072);
+    assert.equal(spec.supportsThinking, true);
+  }
+});
+
+test("GLM_PRICING covers the GLM-5.3 ids with GLM-5.2-parity rates", () => {
+  const reference = GLM_PRICING["glm-5.2"];
+  assert.ok(reference, "glm-5.2 pricing reference missing");
+  for (const id of GLM_5_3_IDS) {
+    const pricing = GLM_PRICING[id];
+    assert.ok(pricing, `GLM_PRICING should include ${id}`);
+    assert.deepEqual(pricing, reference);
+  }
+});
+
+test("GlmExecutor resolves glm-5.3-high to reasoning_effort=high on the OpenAI coding transport", () => {
+  const executor = new GlmExecutor("glm");
+  const transformed = executor.transformForTransport(
+    "glm-5.3-high",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as TransformedRequest;
+
+  assert.equal(transformed.model, "glm-5.3", "upstream must receive the base model id");
+  assert.equal(transformed.reasoning_effort, "high");
+  assert.equal(transformed.thinking?.type, "enabled");
+});
+
+test("GlmExecutor resolves glm-5.3-low to reasoning_effort=low with thinking enabled", () => {
+  const executor = new GlmExecutor("glm");
+  const transformed = executor.transformForTransport(
+    "glm-5.3-low",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as TransformedRequest;
+
+  assert.equal(transformed.model, "glm-5.3");
+  assert.equal(transformed.reasoning_effort, "low");
+  assert.equal(transformed.thinking?.type, "enabled");
+});
+
+test("GlmExecutor leaves base glm-5.3 without an injected reasoning_effort (upstream default = max)", () => {
+  const executor = new GlmExecutor("glm");
+  const transformed = executor.transformForTransport(
+    "glm-5.3",
+    { model: "glm-5.3", messages: [{ role: "user", content: "hi" }] },
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as TransformedRequest;
+
+  assert.equal(transformed.model, "glm-5.3");
+  assert.equal(transformed.reasoning_effort, undefined);
+  // Thinking-model max_tokens default applies to 5.3 (GLM_THINKING_MODEL_PATTERN)
+  assert.equal(transformed.max_tokens, 131_072);
+});
+
+test("GLM-5.3 effort tiers execute on the OpenAI coding transport (no Anthropic-only pinning)", async () => {
+  const executor = new GlmExecutor("glm");
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    return new Response(
+      'data: {"id":"chatcmpl-glm53","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"}}]}\n\ndata: [DONE]\n\n',
+      { headers: { "Content-Type": "text/event-stream" } }
+    );
+  };
+
+  try {
+    await executor.execute({
+      model: "glm-5.3-high",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: true,
+      credentials: {
+        apiKey: "glm-key",
+        providerSpecificData: { baseUrl: "https://api.z.ai/api/coding/paas/v4" },
+      },
+    });
+
+    assert.deepEqual(calls, ["https://api.z.ai/api/coding/paas/v4/chat/completions"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("GLM-5.2 effort tiers still pin the Anthropic transport (effort beta header) — regression guard", () => {
+  const executor = new GlmExecutor("glm");
+  const transformed = executor.transformForTransport(
+    "glm-5.2-max",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    { apiKey: "glm-key" },
+    "anthropic"
+  ) as TransformedRequest;
+
+  assert.equal(transformed.model, "glm-5.2");
+  assert.equal(transformed.effort, "max");
+  assert.equal(transformed.thinking?.type, "enabled");
+});

--- a/tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts
+++ b/tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts
@@ -21,7 +21,7 @@ const { GlmExecutor } = await import("../../open-sse/executors/glm.ts");
 const { MODEL_SPECS } = await import("../../src/shared/constants/modelSpecs.ts");
 const { GLM_PRICING } = await import("../../src/shared/constants/pricing/shared-tiers.ts");
 
-const GLM_5_3_IDS = ["glm-5.3", "glm-5.3-high", "glm-5.3-low"] as const;
+const GLM_5_3_IDS = ["glm-5.3", "glm-5.3-high", "glm-5.3-low", "glm-5.3-max"] as const;
 
 // transformForTransport returns an opaque body; surface only the fields asserted below.
 type TransformedRequest = {
@@ -60,7 +60,7 @@ for (const provider of ["glm", "glm-cn", "glmt"]) {
 test("zai advertises the GLM-5.3 base model only (DefaultExecutor sends ids verbatim)", () => {
   const ids = modelIds("zai");
   assert.ok(ids.includes("glm-5.3"), `zai should advertise glm-5.3; got ${ids.join(", ")}`);
-  for (const alias of ["glm-5.3-high", "glm-5.3-low"]) {
+  for (const alias of ["glm-5.3-high", "glm-5.3-low", "glm-5.3-max"]) {
     assert.ok(
       !ids.includes(alias),
       `zai must not list ${alias}: GlmExecutor-only alias, unknown upstream on the Anthropic endpoint`
@@ -115,6 +115,21 @@ test("GlmExecutor resolves glm-5.3-low to reasoning_effort=low with thinking ena
 
   assert.equal(transformed.model, "glm-5.3");
   assert.equal(transformed.reasoning_effort, "low");
+  assert.equal(transformed.thinking?.type, "enabled");
+});
+
+test("GlmExecutor resolves glm-5.3-max to an explicit reasoning_effort=max (pins the tier even if the upstream default changes)", () => {
+  const executor = new GlmExecutor("glm");
+  const transformed = executor.transformForTransport(
+    "glm-5.3-max",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as TransformedRequest;
+
+  assert.equal(transformed.model, "glm-5.3");
+  assert.equal(transformed.reasoning_effort, "max");
   assert.equal(transformed.thinking?.type, "enabled");
 });
 

--- a/tests/unit/zai-catalog-glm52.test.ts
+++ b/tests/unit/zai-catalog-glm52.test.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 //
 // The `zai` provider uses the DefaultExecutor, which sends the requested model ID
 // verbatim. The effort tiers `glm-5.2-high` / `glm-5.2-max` are OmniRoute aliases
-// that only the GlmExecutor knows how to resolve (parseGlm52Effort → base model
+// that only the GlmExecutor knows how to resolve (parseGlmEffortTier → base model
 // "glm-5.2" + `effort` field + effort-2025-11-24 beta header). Listing them under
 // `zai` would send unknown model IDs to z.ai's Anthropic endpoint, so they belong
 // to the `glm` provider only.


### PR DESCRIPTION
## What

Adds GLM-5.3 support (released 2026-08-14, https://z.ai/blog/glm-5.3) across the z.ai first-party providers.

Upstream ships **one** model id `glm-5.3` — effort is now a request parameter (`reasoning_effort`: `low|high|max`, default `max`) on the coding chat/completions endpoint, and `thinking.type: "disabled"` is no longer accepted. Per operator decision, OmniRoute keeps the 5.2 tier UX with `glm-5.3-high` / `glm-5.3-low` aliases (base id = upstream default `max`).

## Changes

- `open-sse/config/glmProvider.ts` — `glm-5.3`, `glm-5.3-high`, `glm-5.3-low` in `GLM_SHARED_MODELS` (→ glm / glm-cn / glmt)
- `open-sse/config/providers/registry/zai/index.ts` — base `glm-5.3` only (tiers are GlmExecutor aliases; `zai` sends ids verbatim)
- `open-sse/executors/glm.ts` — `parseGlm52Effort` generalized to `parseGlmEffortTier`: 5.2 tiers keep the Anthropic-transport effort beta path (unchanged); 5.3 tiers stay on the OpenAI coding transport and inject `reasoning_effort` + `thinking.type=enabled`
- `src/shared/constants/modelSpecs.ts` — specs for the 3 ids + `AUTHORITATIVE_CONTEXT_WINDOW_MODEL_IDS`
- `src/shared/constants/pricing/shared-tiers.ts` — `GLM_PRICING` entries for the 3 ids
- `docs/reference/PROVIDER_REFERENCE.md` — regenerated (`npm run gen:provider-reference`)

## Spec caveats (unpublished upstream)

- **Context window**: Z.ai documents a `glm-5.3[1m]` suffix for 1M but not the default; **1M mirrored from GLM-5.2** (same base model) per operator decision — correct when the official spec lands.
- **Pricing**: not yet on https://docs.z.ai/guides/overview/pricing; mirrored from GLM-5.2 (5.1 and 5.2 share identical rates).

## Tests

- New: `tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts` (14 tests) — catalog presence on glm/glm-cn/glmt/zai, spec + pricing entries, executor tier resolution (`reasoning_effort` high/low + thinking enabled), base-id passthrough, 5.2 Anthropic-tier regression guard. Written failing-first, then implemented.
- Ran green: the 14 new + 228 tests across glm/zai/modelSpecs/pricing suites (`node --import tsx/esm --test`), `npm run lint` (0 errors), `npm run typecheck:core`, `npm run check:provider-consistency`.

⚠️ base-red inherited: #9985

## Sources

- https://z.ai/blog/glm-5.3 (release + API changes)
- https://docs.z.ai/devpack/latest-model (model ids, effort mapping)