### PR TITLE
perf(electron): prune authoring docs from desktop packages (5/8)

### DIFF
--- a/scripts/build/electronRuntimeDocs.mjs
+++ b/scripts/build/electronRuntimeDocs.mjs
@@ -1,0 +1,65 @@
+import { existsSync, lstatSync, readdirSync, rmSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+
+export const ELECTRON_RUNTIME_DOC_PRUNE_RULES = Object.freeze({
+  localeRootFiles: Object.freeze(["CHANGELOG.md"]),
+  authoringDirectories: Object.freeze(["docs/research", "docs/superpowers"]),
+});
+
+function payloadSize(targetPath) {
+  const stat = lstatSync(targetPath);
+  if (!stat.isDirectory()) {
+    return { files: 1, bytes: stat.size };
+  }
+
+  return readdirSync(targetPath).reduce(
+    (total, entry) => {
+      const payload = payloadSize(join(targetPath, entry));
+      total.files += payload.files;
+      total.bytes += payload.bytes;
+      return total;
+    },
+    { files: 0, bytes: 0 }
+  );
+}
+
+function removePayload(bundleRoot, relativePath, summary) {
+  const root = resolve(bundleRoot);
+  const targetPath = resolve(root, relativePath);
+  if (targetPath !== root && !targetPath.startsWith(`${root}${sep}`)) {
+    throw new Error(`[electron-docs] refusing to prune outside bundle root: ${relativePath}`);
+  }
+  if (!existsSync(targetPath)) return;
+
+  const payload = payloadSize(targetPath);
+  rmSync(targetPath, { recursive: true, force: true });
+  summary.removedFiles += payload.files;
+  summary.removedBytes += payload.bytes;
+  summary.removedPaths.push(relative(root, targetPath).split(sep).join("/"));
+}
+
+/**
+ * Remove docs that are useful while authoring OmniRoute but are never read by
+ * the packaged desktop runtime. Canonical docs remain untouched; bundleRoot is
+ * the disposable Electron staging directory.
+ */
+export function pruneElectronRuntimeDocs(bundleRoot) {
+  const summary = { removedFiles: 0, removedBytes: 0, removedPaths: [] };
+  const localesRoot = join(bundleRoot, "docs", "i18n");
+
+  if (existsSync(localesRoot)) {
+    for (const locale of readdirSync(localesRoot, { withFileTypes: true })) {
+      if (!locale.isDirectory()) continue;
+      for (const fileName of ELECTRON_RUNTIME_DOC_PRUNE_RULES.localeRootFiles) {
+        removePayload(bundleRoot, join("docs", "i18n", locale.name, fileName), summary);
+      }
+    }
+  }
+
+  for (const relativePath of ELECTRON_RUNTIME_DOC_PRUNE_RULES.authoringDirectories) {
+    removePayload(bundleRoot, relativePath, summary);
+  }
+
+  summary.removedPaths.sort();
+  return summary;
+}

--- a/scripts/build/prepare-electron-standalone.mjs
+++ b/scripts/build/prepare-electron-standalone.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { assembleStandalone } from "./assembleStandalone.mjs";
 import { buildRebuildSpawnPlan } from "./electronRebuildPlan.mjs";
+import { pruneElectronRuntimeDocs } from "./electronRuntimeDocs.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -204,6 +205,14 @@ assembleStandalone({
   // app they would point at the build machine's absolute paths and break on install.
   materializeSymlinks: true,
 });
+
+const docsPrune = pruneElectronRuntimeDocs(ELECTRON_STANDALONE_DIR);
+if (docsPrune.removedFiles > 0) {
+  console.log(
+    `[electron] pruned ${docsPrune.removedFiles} authoring doc file(s) ` +
+      `(${docsPrune.removedBytes} bytes) from the staging bundle`
+  );
+}
 
 // Electron-UNIQUE post-assembly steps
 removeGeneratedElectronArtifacts();

--- a/tests/unit/electron-packaging.test.ts
+++ b/tests/unit/electron-packaging.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { pruneElectronRuntimeDocs } from "../../scripts/build/electronRuntimeDocs.mjs";
 
 const ROOT = join(import.meta.dirname, "..", "..");
 
@@ -35,5 +37,71 @@ test("electron standalone assembly normalizes Turbopack hashed external imports"
     prepareScript,
     /assembleStandalone\(\{[\s\S]*?patchTurbopackChunks:\s*true,[\s\S]*?\}\);/,
     "Electron packages must strip Turbopack's hashed external package names before bundling"
+  );
+});
+
+test("electron docs manifest prunes authoring payloads without removing runtime docs", () => {
+  const bundleRoot = mkdtempSync(join(tmpdir(), "omniroute-electron-docs-"));
+  const files = new Map([
+    ["docs/openapi.yaml", "openapi: 3.1.0"],
+    ["docs/guides/CODEX-CLI-CONFIGURATION.md", "# Codex CLI"],
+    ["docs/i18n/ko/docs/guides/ELECTRON_GUIDE.md", "# Electron"],
+    ["docs/i18n/ko/CHANGELOG.md", "translated release history"],
+    ["docs/i18n/fr/CHANGELOG.md", "historique traduit"],
+    ["docs/research/desktop-notes.md", "authoring notes"],
+    ["docs/superpowers/plans/desktop-plan.md", "implementation plan"],
+  ]);
+
+  try {
+    for (const [relativePath, content] of files) {
+      const absolutePath = join(bundleRoot, relativePath);
+      mkdirSync(join(absolutePath, ".."), { recursive: true });
+      writeFileSync(absolutePath, content);
+    }
+
+    const result = pruneElectronRuntimeDocs(bundleRoot);
+
+    assert.deepEqual(result.removedPaths, [
+      "docs/i18n/fr/CHANGELOG.md",
+      "docs/i18n/ko/CHANGELOG.md",
+      "docs/research",
+      "docs/superpowers",
+    ]);
+    assert.equal(result.removedFiles, 4);
+    assert.equal(
+      result.removedBytes,
+      Buffer.byteLength("translated release history") +
+        Buffer.byteLength("historique traduit") +
+        Buffer.byteLength("authoring notes") +
+        Buffer.byteLength("implementation plan")
+    );
+
+    assert.equal(existsSync(join(bundleRoot, "docs/openapi.yaml")), true);
+    assert.equal(existsSync(join(bundleRoot, "docs/guides/CODEX-CLI-CONFIGURATION.md")), true);
+    assert.equal(existsSync(join(bundleRoot, "docs/i18n/ko/docs/guides/ELECTRON_GUIDE.md")), true);
+    assert.equal(existsSync(join(bundleRoot, "docs/i18n/ko/CHANGELOG.md")), false);
+    assert.equal(existsSync(join(bundleRoot, "docs/research")), false);
+    assert.equal(existsSync(join(bundleRoot, "docs/superpowers")), false);
+
+    assert.deepEqual(pruneElectronRuntimeDocs(bundleRoot), {
+      removedFiles: 0,
+      removedBytes: 0,
+      removedPaths: [],
+    });
+  } finally {
+    rmSync(bundleRoot, { recursive: true, force: true });
+  }
+});
+
+test("electron bundle preparation applies the runtime docs manifest to its staging tree", () => {
+  const prepareScript = readFileSync(
+    join(ROOT, "scripts", "build", "prepare-electron-standalone.mjs"),
+    "utf8"
+  );
+
+  assert.match(
+    prepareScript,
+    /pruneElectronRuntimeDocs\(ELECTRON_STANDALONE_DIR\)/,
+    "Electron staging must prune authoring docs before electron-builder copies the bundle"
   );
 });


### PR DESCRIPTION
## Summary

- prune Electron-only staging payloads that the packaged runtime never reads
- exclude 42 translated changelogs plus future `docs/research` and `docs/superpowers` authoring trees
- preserve canonical OpenAPI, Codex CLI documentation, and translated runtime guides
- report removed file and byte totals during Electron standalone preparation

## Related Issues

- Related to #10321 (Stage 5)

## Validation

- [x] Change type: build-deploy
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Commands and results:

- `node --import tsx/esm --test tests/unit/electron-packaging.test.ts tests/unit/electron-main.test.ts` — 39 passed
- `npm run test:vitest` — 39 files / 357 tests passed
- `npm run lint` — passed
- `npm run check:file-size` — passed
- `npm run build` — passed
- `node scripts/build/prepare-electron-standalone.mjs` — passed; removed 42 files / 74,455,753 raw bytes
- macOS arm64 `electron-builder` package before and after the staging prune — both passed

Measured DMG result from the same build and packaging configuration:

- before: 629,843,776 bytes
- after: 608,247,523 bytes
- reduction: 21,596,253 bytes (3.43%)

The packaged app retained:

- `Resources/app/docs/openapi.yaml`
- `Resources/app/docs/guides/CODEX-CLI-CONFIGURATION.md`
- `Resources/app/docs/i18n/ko/docs/guides/USER_GUIDE.md`

## Tests Added Or Updated

- `tests/unit/electron-packaging.test.ts`
  - exercises the manifest against a real temporary docs tree
  - verifies required runtime docs remain
  - verifies pruning is idempotent
  - verifies Electron standalone preparation invokes the manifest

## Coverage Notes

- No `src/`, `open-sse/`, `electron/`, or `bin/` runtime source changed.
- The new build helper is covered directly by the updated Electron packaging unit test.

## Reviewer Notes

- Canonical repository docs are never mutated; pruning is limited to the disposable `.build/electron-standalone` staging tree.
- `npm run test:unit` encountered the pre-existing `#8510 v1 image edit POST rejects more than 4 Adobe Firefly reference images` cleanup race (`ENOTEMPTY`). The same isolated failure reproduces on the clean `release/v3.8.50` checkout and is unrelated to these three changed files.
- `npm run electron:smoke:packaged` safely refused to launch because the user's existing OmniRoute server already owned port 20128. The existing process was not stopped; both DMG builds and packaged-file checks passed.
