### PR TITLE
fix(image): support OpenRouter reference-image edits (#10197)

### DIFF
--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -1309,6 +1309,107 @@ export async function handleOpenAIImageEdit({
   return result;
 }
 
+/**
+ * Handle OpenRouter's unified Image API reference-image flow.
+ *
+ * OpenRouter does not expose `/images/edits`; image-to-image requests use
+ * `POST /api/v1/images` with `input_references` containing data-URL images.
+ * Keep this separate from the generic multipart `/images/edits` forwarder,
+ * whose contract is used by custom OpenAI-compatible nodes (#10197).
+ */
+export async function handleOpenRouterImageEdit({
+  model,
+  provider,
+  baseUrl,
+  credentials,
+  prompt,
+  imageBytes,
+  imageMime,
+  size,
+  n = 1,
+  log,
+}: {
+  model: string;
+  provider: string;
+  baseUrl: string;
+  credentials:
+    | {
+        apiKey?: string;
+        accessToken?: string;
+      }
+    | null
+    | undefined;
+  prompt: string;
+  imageBytes: Buffer;
+  imageMime?: string | null;
+  size?: string | null;
+  n?: number;
+  log?: { info: (tag: string, message: string) => void } | null;
+}) {
+  const startTime = Date.now();
+  let url = baseUrl.trim();
+  while (url.endsWith("/")) url = url.slice(0, -1);
+  if (url.endsWith("/images/generations")) {
+    url = url.slice(0, -"/images/generations".length) + "/images";
+  } else if (!url.endsWith("/images")) {
+    url += "/images";
+  }
+
+  const mime = imageMime || "image/png";
+  const upstreamBody: Record<string, unknown> = {
+    model,
+    prompt,
+    input_references: [
+      {
+        type: "image_url",
+        image_url: {
+          url: `data:${mime};base64,${imageBytes.toString("base64")}`,
+        },
+      },
+    ],
+    n: n || 1,
+  };
+  if (size) upstreamBody.size = size;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const token = credentials?.apiKey || credentials?.accessToken;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  log?.info(
+    "IMAGE",
+    `${provider}/${model} (reference edit) | prompt: "${prompt.slice(0, 60)}..." -> ${url}`
+  );
+
+  const result = await fetchImageEndpoint(
+    url,
+    headers,
+    JSON.stringify(upstreamBody),
+    provider,
+    log
+  );
+
+  saveCallLog({
+    method: "POST",
+    path: "/v1/images/edits",
+    status: result.status || (result.success ? 200 : 502),
+    model: `${provider}/${model}`,
+    provider,
+    duration: Date.now() - startTime,
+    tokens: { prompt_tokens: 0, completion_tokens: 0 },
+    error: result.success
+      ? null
+      : typeof result.error === "string"
+        ? result.error.slice(0, 500)
+        : null,
+    requestBody: { model, prompt: prompt.slice(0, 200), size: size || "default", n: n || 1 },
+    responseBody: result.success ? { images_count: result.data?.data?.length || 0 } : null,
+  }).catch(() => {});
+
+  return result;
+}
+
 export async function handleImageEdit({
   provider,
   model,

--- a/src/app/api/v1/images/edits/route.ts
+++ b/src/app/api/v1/images/edits/route.ts
@@ -3,6 +3,7 @@ import {
   handleCodexImageEdit,
   handleImageEdit,
   handleOpenAIImageEdit,
+  handleOpenRouterImageEdit,
 } from "@omniroute/open-sse/handlers/imageGeneration.ts";
 import {
   handleFalAIImageEdit,
@@ -583,6 +584,55 @@ async function postHandler(request: Request, _context?: unknown) {
       imageBytes,
       imageMime,
     });
+  }
+
+  // Built-in OpenRouter uses its unified Image API for reference-image
+  // edits: POST /api/v1/images with input_references. Forward through the
+  // provider-specific adapter (#10197), rather than the multipart
+  // /images/edits path used by custom OpenAI-compatible nodes.
+  if (providerConfig?.id === "openrouter") {
+    const credentials = await getProviderCredentialsWithQuotaPreflight(
+      parsed.provider,
+      null,
+      allowedConnections,
+      resolvedModel
+    );
+    if (!credentials) {
+      return errorResponse(
+        HTTP_STATUS.UNAUTHORIZED,
+        `No credentials for provider: ${parsed.provider}`
+      );
+    }
+    if (credentials.allRateLimited) {
+      return unavailableResponse(
+        HTTP_STATUS.RATE_LIMITED,
+        `[${parsed.provider}] All accounts rate limited`,
+        credentials.retryAfter,
+        credentials.retryAfterHuman
+      );
+    }
+
+    const result = await handleOpenRouterImageEdit({
+      provider: parsed.provider,
+      model: parsed.model,
+      baseUrl: providerConfig.baseUrl,
+      credentials,
+      prompt,
+      imageBytes,
+      imageMime,
+      size: size ?? undefined,
+      n: 1,
+      log,
+    });
+
+    if (result.success) {
+      await clearRecoveredProviderState(credentials);
+      return jsonResponse(result.data);
+    }
+    return jsonResponse(
+      toJsonErrorPayload(result.error, "Image edit provider error"),
+      result.status
+    );
   }
 
   // Other built-in providers do not expose an OpenAI-compatible edit endpoint.

--- a/tests/unit/10197-openrouter-image-edits-route.test.ts
+++ b/tests/unit/10197-openrouter-image-edits-route.test.ts
@@ -1,0 +1,185 @@
+// #10197 (tiangao88): route-level coverage for the built-in OpenRouter branch
+// that /v1/images/edits gained in this PR. Exercises the actual POST(request)
+// handler so the credentials / rate-limit / unified-Image-API forwarding branches
+// added to route.ts itself are proven, not just the downstream service call.
+//
+// Before this change: POST /v1/images/edits rejected the built-in `openrouter`
+// provider ("Image edit is not supported for built-in provider"), so image
+// Combos routing through OpenRouter could generate but never edit. OpenRouter's
+// current reference-image contract is POST /api/v1/images with input_references.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-openrouter-edits-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "openrouter-edits-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const imageEditRoute = await import("../../src/app/api/v1/images/edits/route.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+interface ErrorResponseBody {
+  error: { message: string; code?: string };
+}
+
+interface ImageResponseBody {
+  data: Array<{ b64_json?: string; url?: string }>;
+}
+
+const originalFetch = globalThis.fetch;
+
+async function resetStorage() {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  v1ModelsCatalog.__resetCatalogBuilderRunsForTest();
+}
+
+function seedOpenRouterConnection(overrides: { rateLimitedUntil?: string | null } = {}) {
+  return providersDb.createProviderConnection({
+    provider: "openrouter",
+    authType: "apikey",
+    name: "openrouter-test",
+    apiKey: "sk-or-test-openrouter-edits",
+    isActive: true,
+    testStatus: "active",
+    rateLimitedUntil: overrides.rateLimitedUntil ?? null,
+  });
+}
+
+function dataUrlPng(bytes: number[]): string {
+  return `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+const REF_A = dataUrlPng([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1]);
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#10197 v1 image edit POST forwards built-in openrouter edits to the unified Image API", async () => {
+  await seedOpenRouterConnection();
+
+  let hitUrl: string | null = null;
+  let hitAuth: string | null = null;
+  let hitBody = "";
+
+  globalThis.fetch = async (url, init: RequestInit = {}) => {
+    hitUrl = String(url);
+    const headers = init.headers;
+    hitAuth =
+      headers instanceof Headers
+        ? String(headers.get("authorization") || "")
+        : String(
+            (headers as Record<string, string> | undefined)?.authorization ||
+              (headers as Record<string, string> | undefined)?.Authorization ||
+              ""
+          );
+    // The OpenRouter adapter sends JSON with input_references, not multipart.
+    const raw = init.body;
+    if (typeof raw === "string") hitBody = raw;
+    else if (raw instanceof Uint8Array) hitBody = Buffer.from(raw).toString("utf8");
+    else if (raw instanceof ArrayBuffer) hitBody = Buffer.from(raw).toString("utf8");
+    else if (raw && typeof (raw as { arrayBuffer?: unknown }).arrayBuffer === "function") {
+      hitBody = Buffer.from(await (raw as { arrayBuffer(): Promise<ArrayBuffer> }).arrayBuffer()).toString("utf8");
+    }
+    return new Response(
+      JSON.stringify({ data: [{ b64_json: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64") }] }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const response = await imageEditRoute.POST(
+    new Request("http://localhost/api/v1/images/edits", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "openrouter/google/gemini-3.1-flash-image-preview",
+        prompt: "add a red hat",
+        images: [REF_A],
+      }),
+    })
+  );
+  const body = (await response.json()) as ImageResponseBody;
+
+  assert.equal(response.status, 200);
+  assert.ok(body.data[0].b64_json, "edit must return an image payload");
+
+  // OpenRouter's current image-to-image endpoint is the unified Image API.
+  assert.equal(hitUrl, "https://openrouter.ai/api/v1/images");
+  // Must carry the OpenRouter connection key as a Bearer token.
+  assert.equal(hitAuth, "Bearer sk-or-test-openrouter-edits");
+  assert.ok(hitBody, "JSON body must be captured");
+  const forwarded = JSON.parse(hitBody) as {
+    model?: string;
+    prompt?: string;
+    input_references?: Array<{ image_url?: { url?: string } }>;
+  };
+  assert.equal(forwarded.model, "google/gemini-3.1-flash-image-preview");
+  assert.equal(forwarded.prompt, "add a red hat");
+  assert.equal(forwarded.input_references?.length, 1);
+  assert.match(forwarded.input_references?.[0]?.image_url?.url || "", /^data:image\/png;base64,/);
+});
+
+test("#10197 v1 image edit POST surfaces missing openrouter credentials", async () => {
+  // No openrouter connection seeded at all.
+  globalThis.fetch = async () => {
+    throw new Error("Missing-credentials path must not reach upstream");
+  };
+
+  const response = await imageEditRoute.POST(
+    new Request("http://localhost/api/v1/images/edits", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "openrouter/openai/gpt-5-image-mini",
+        prompt: "edit this",
+        images: [REF_A],
+      }),
+    })
+  );
+  const body = (await response.json()) as ErrorResponseBody;
+
+  assert.equal(response.status, 401);
+  assert.match(body.error.message, /No credentials for provider: openrouter/);
+  // Hard Rule #12 — error responses must never leak a raw stack trace.
+  assert.ok(!body.error.message.includes("at /"));
+});
+
+test("#10197 v1 image edit POST surfaces openrouter rate-limit sentinel", async () => {
+  await seedOpenRouterConnection({ rateLimitedUntil: new Date(Date.now() + 60_000).toISOString() });
+  globalThis.fetch = async () => {
+    throw new Error("Rate-limited path must not reach upstream");
+  };
+
+  const response = await imageEditRoute.POST(
+    new Request("http://localhost/api/v1/images/edits", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "openrouter/openai/gpt-5.4-image-2",
+        prompt: "edit this",
+        images: [REF_A],
+      }),
+    })
+  );
+  const body = (await response.json()) as ErrorResponseBody;
+
+  assert.equal(response.status, 429);
+  assert.match(body.error.message, /All accounts rate limited/);
+  assert.ok(!body.error.message.includes("at /"));
+});


### PR DESCRIPTION
### Problem / use case

`POST /v1/images/edits` currently rejects the built-in `openrouter` provider:

> Image edit is not supported for built-in provider "openrouter". Use
> adobe-firefly, chatgpt-web, codex, or a custom OpenAI-compatible image
> provider.

OpenRouter supports image-to-image/reference-image generation through its
unified Image API. Clients that route image generation through OpenRouter —
including image Combos — currently have to move edits to another provider
transport.

### Proposed change

Add a built-in OpenRouter branch to `POST /v1/images/edits`:

1. Resolve the OpenRouter connection with the existing credential and quota
   preflight logic.
2. Preserve the public OmniRoute edit route and input formats (multipart or
   JSON/data-URL image input).
3. Translate the source image into OpenRouter's documented reference-image
   format and call:

   ```text
   POST https://openrouter.ai/api/v1/images
   ```

   with an `input_references` entry containing a base64 data URL.
4. Strip the OmniRoute provider prefix before forwarding the model, e.g.:

   ```text
   openrouter/google/gemini-3.1-flash-image-preview
   → google/gemini-3.1-flash-image-preview
   ```
5. Keep the existing multipart `/images/edits` forwarder unchanged for custom
   OpenAI-compatible providers.

OpenRouter does **not** expose `/api/v1/images/edits`; direct verification
returns 404. The unified `/api/v1/images` + `input_references` contract returns
HTTP 200 with a real edited image.

### Files changed

- `src/app/api/v1/images/edits/route.ts`
  - add the built-in `openrouter` dispatch branch;
  - preserve missing-credential and rate-limit responses;
  - call the provider-specific adapter.
- `open-sse/handlers/imageGeneration.ts`
  - add `handleOpenRouterImageEdit`;
  - normalize the registry base URL to `/api/v1/images`;
  - encode the incoming image as a data URL;
  - normalize the upstream response to the existing OpenAI image response shape.
- `tests/unit/10197-openrouter-image-edits-route.test.ts`
  - successful forwarding and JSON contract;
  - provider-prefix stripping;
  - Bearer credential forwarding;
  - missing-credential 401;
  - rate-limit 429.

### Verification

- `git diff --check`: clean.
- Direct OpenRouter control: `/api/v1/images` with `input_references` returned
  HTTP 200 and a real JPEG edit.
- Fork image CI: successful production build run `31630860913`.
- Deployed fork image: live and healthy; edit through
  `a deployed fork of the gateway` returned HTTP 200 in 8.2 seconds with a complete edited
  JPEG. Visual verification confirmed the requested red party hat edit.
- Local route test execution was unavailable in the preparation environment
  because the native `better-sqlite3` module was not installed; the test is
  included for CI/upstream execution.

### Scope / non-goals

- No changes to other built-in image providers.
- No changes to Hermes configuration or the Hermes image-generation module.
- This enables the OmniRoute image-edit API; Hermes-side native routing remains
  a separate plugin task.
- Combo fallback strategy is not redesigned by this change.

### Related issues/history

- #3214 — custom OpenAI-compatible image providers and `/v1/images/edits`
- #8100 — Codex reference-image editing
- #8510 — Adobe Firefly reference-image support
- #9239 — image-generation Combo execution/fallback
- #9933 — FAL reference-image edits