### PR TITLE
test(models): align catalog dedup test with #10248 custom-overlay contract

### DIFF
--- a/tests/unit/models-catalog-route.test.ts
+++ b/tests/unit/models-catalog-route.test.ts
@@ -1399,7 +1399,11 @@ test("v1 models catalog skips duplicate built-ins and custom models from inactiv
 
   assert.equal(response.status, 200);
   assert.equal(duplicateBuiltins.length, 1);
-  assert.equal(duplicateBuiltins[0].custom === true, false);
+  // #10248: a custom row sharing a built-in id is the operator-owned overlay —
+  // the catalog keeps one deduped entry, flags it custom, and applies the
+  // custom row's explicitly-stored fields (here: the display name).
+  assert.equal(duplicateBuiltins[0].custom, true);
+  assert.equal(duplicateBuiltins[0].name, "Duplicate Builtin");
   assert.equal(
     body.data.some((item) => item.id === "cl/inactive-only" || item.id === "cline/inactive-only"),
     false


### PR DESCRIPTION
## Problem

The release/v3.8.50 Node 24/26 compat shards are red with exactly one failing test (1/7782):

`tests/unit/models-catalog-route.test.ts` → **"v1 models catalog skips duplicate built-ins and custom models from inactive providers"** — `AssertionError: true !== false` at the `custom` flag assertion.

## Cause

#10248 (merged 2026-08-14) deliberately changed the /v1/models dedup semantics in `src/app/api/v1/models/catalog.ts`: when a custom row shares an id with a built-in entry, the catalog now treats the custom row as the **operator-owned overlay** — one deduped entry, flagged `custom: true`, with the custom row's explicitly-stored fields applied. #10248 rewrote the sibling suites (`synced-model-delete-*`, `provider-models-custom-merge-6247`, …) but missed this assertion, which still encoded the pre-#10248 contract ("built-in wins, no custom flag").

## Fix

Test-only change (5 lines): assert the new contract —

- dedup still yields exactly **one** `openai/gpt-4o-2024-11-20` entry (unchanged)
- the merged entry now carries `custom: true`
- the custom row's display name ("Duplicate Builtin") is applied (new coverage for the overlay)
- inactive-provider custom models remain excluded (unchanged)

## Validation

TDD per repo protocol: reproduced the exact CI failure locally in an isolated worktree cut from `release/v3.8.50` (43 pass / 1 fail), applied the change, now **44/44 pass**:

```
node --import tsx/esm --test tests/unit/models-catalog-route.test.ts
# tests 44 / pass 44 / fail 0
```

No production code touched. Unblocks the Node compat gate for the v3.8.50 release.