### PR TITLE
fix(services): use CLIProxy executable on Windows

### DIFF
--- a/src/lib/services/installers/cliproxy.ts
+++ b/src/lib/services/installers/cliproxy.ts
@@ -101,7 +101,8 @@ export async function update(): Promise<InstallResult> {
  * async file I/O is not available here.
  */
 export function resolveSpawnArgs(port: number): SpawnArgs {
-  const symlinkPath = path.join(BIN_DIR, "cliproxyapi");
+  const executableName = process.platform === "win32" ? "cliproxyapi.exe" : "cliproxyapi";
+  const symlinkPath = path.join(BIN_DIR, executableName);
 
   fs.mkdirSync(CONFIG_DIR, { recursive: true });
   const configPath = path.join(CONFIG_DIR, "config.yaml");

--- a/src/lib/versionManager/binaryManager.ts
+++ b/src/lib/versionManager/binaryManager.ts
@@ -97,6 +97,10 @@ async function verifyChecksum(filePath: string, expectedSha256: string): Promise
   return hash.digest("hex").toLowerCase() === expectedSha256.toLowerCase();
 }
 
+function managedBinaryName(): string {
+  return process.platform === "win32" ? "cliproxyapi.exe" : "cliproxyapi";
+}
+
 function findBinaryInDir(dir: string): string | null {
   const candidates = ["cli-proxy-api", "cli-proxy-api.exe", "CLIProxyAPI", "CLIProxyAPI.exe"];
   for (const name of candidates) {
@@ -161,7 +165,7 @@ export async function installVersion(version: string, dataDir?: string): Promise
 
   const binary = await downloadRelease(version, binDir);
 
-  const symlinkPath = path.join(binDir, "cliproxyapi");
+  const symlinkPath = path.join(binDir, managedBinaryName());
   try {
     await fs.unlink(symlinkPath);
   } catch {}
@@ -176,7 +180,7 @@ export async function installVersion(version: string, dataDir?: string): Promise
 
 export async function getCurrentBinaryPath(dataDir?: string): Promise<string | null> {
   const dir = dataDir || DEFAULT_DATA_DIR;
-  const symlinkPath = path.join(dir, "bin", "cliproxyapi");
+  const symlinkPath = path.join(dir, "bin", managedBinaryName());
   try {
     const real = await fs.realpath(symlinkPath);
     return fsSync.existsSync(/* turbopackIgnore: true */ real) ? real : null;
@@ -215,7 +219,7 @@ export async function rollbackVersion(dataDir?: string): Promise<string | null> 
   const oldBinary = findBinaryInDir(path.join(binDir, `cliproxyapi-${previous}`));
   if (!oldBinary) return null;
 
-  const symlinkPath = path.join(binDir, "cliproxyapi");
+  const symlinkPath = path.join(binDir, managedBinaryName());
   try {
     await fs.unlink(symlinkPath);
   } catch {}

--- a/tests/unit/binaryManager.test.ts
+++ b/tests/unit/binaryManager.test.ts
@@ -139,6 +139,32 @@ describe("binaryManager", () => {
         assert.ok(real.includes("1.0.0"));
       }
     });
+
+    it("writes the Windows rollback artifact at the CLIProxy spawn path", async () => {
+      const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+      try {
+        const binDir = path.join(tmpDir, "bin");
+        for (const ver of ["1.0.0", "2.0.0"]) {
+          const versionDir = path.join(binDir, `cliproxyapi-${ver}`);
+          fs.mkdirSync(versionDir, { recursive: true });
+          fs.writeFileSync(path.join(versionDir, "cli-proxy-api"), `bin-${ver}`);
+        }
+
+        assert.equal(await mod.rollbackVersion(tmpDir), "1.0.0");
+        const { resolveSpawnArgs } = await import("../../src/lib/services/installers/cliproxy.ts");
+        const spawn = resolveSpawnArgs(8317);
+
+        assert.equal(spawn.command, path.join(binDir, "cliproxyapi.exe"));
+        assert.equal(fs.existsSync(spawn.command), true);
+        assert.equal(await mod.getCurrentBinaryPath(tmpDir), spawn.command);
+      } finally {
+        if (originalPlatformDescriptor) {
+          Object.defineProperty(process, "platform", originalPlatformDescriptor);
+        }
+      }
+    });
   });
 
   describe("removeVersion", () => {

--- a/tests/unit/services/installers/cliproxy-resolve-spawn-args-6877.test.ts
+++ b/tests/unit/services/installers/cliproxy-resolve-spawn-args-6877.test.ts
@@ -51,9 +51,8 @@ describe("resolveSpawnArgs (#6877 — real filesystem)", () => {
   });
 
   it("uses the --config long flag and never the -c short flag", async () => {
-    const { resolveSpawnArgs } = await import(
-      "../../../../src/lib/services/installers/cliproxy.ts"
-    );
+    const { resolveSpawnArgs } =
+      await import("../../../../src/lib/services/installers/cliproxy.ts");
 
     const port = 8317;
     const result = resolveSpawnArgs(port);
@@ -61,13 +60,33 @@ describe("resolveSpawnArgs (#6877 — real filesystem)", () => {
     const configPath = path.join(dataDir, "services", "cliproxy", "config.yaml");
 
     assert.deepEqual(result.args, ["--config", configPath]);
+    assert.equal(
+      result.command,
+      path.join(dataDir, "bin", process.platform === "win32" ? "cliproxyapi.exe" : "cliproxyapi")
+    );
     assert.ok(!result.args.includes("-c"), "args must never contain the short -c flag");
   });
 
+  it("uses the .exe command name on Windows", async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      const { resolveSpawnArgs } =
+        await import("../../../../src/lib/services/installers/cliproxy.ts");
+      const result = resolveSpawnArgs(8317);
+
+      assert.equal(result.command, path.join(dataDir, "bin", "cliproxyapi.exe"));
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+    }
+  });
+
   it("writes the default config.yaml template when none exists yet", async () => {
-    const { resolveSpawnArgs } = await import(
-      "../../../../src/lib/services/installers/cliproxy.ts"
-    );
+    const { resolveSpawnArgs } =
+      await import("../../../../src/lib/services/installers/cliproxy.ts");
 
     const port = 9123;
     const result = resolveSpawnArgs(port);
@@ -81,9 +100,8 @@ describe("resolveSpawnArgs (#6877 — real filesystem)", () => {
   });
 
   it("preserves a pre-existing config.yaml byte-for-byte instead of overwriting it", async () => {
-    const { resolveSpawnArgs } = await import(
-      "../../../../src/lib/services/installers/cliproxy.ts"
-    );
+    const { resolveSpawnArgs } =
+      await import("../../../../src/lib/services/installers/cliproxy.ts");
 
     const configDir = path.join(dataDir, "services", "cliproxy");
     fs.mkdirSync(configDir, { recursive: true });


### PR DESCRIPTION
## Summary

Select `cliproxyapi.exe` when the embedded CLIProxy service is started on Windows while retaining the existing extensionless command on other platforms. The change is limited to the installer’s spawn-argument resolver; service-supervisor lifecycle handling remains unchanged.

Closes #10245.

## Validation

- Added deterministic Windows platform coverage using the repository’s established platform-mocking pattern.
- Preserved and asserted the native-platform command name and existing configuration-file behavior.
- Verified the focused resolver suite passes.
- Verified core TypeScript checking and focused lint pass.
- Verified `npm run quality:scan:fast` passes all 18 gates.
