### PR TITLE
fix(db): default debugMode to false in getSettings() defaults

### DIFF
--- a/changelog.d/fixes/10372-debug-mode-default-false.md
+++ b/changelog.d/fixes/10372-debug-mode-default-false.md
@@ -1,0 +1,1 @@
+- **fix(db):** `getSettings()` defaults `debugMode` to `false` — fresh installs no longer run in debug mode (persisted `debugMode: true` is preserved) ([#10372](https://github.com/diegosouzapw/OmniRoute/pull/10372) — thanks @lamchun1110)

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -212,7 +212,9 @@ export async function getSettings() {
     idempotencyWindowMs: 5000,
     wsAuth: false,
     maxBodySizeMb: requestBodyLimitMbFromEnv(process.env.MAX_BODY_SIZE_BYTES),
-    debugMode: true,
+    // #10312: opt-in only — a fresh install (or one missing the persisted key)
+    // must not run in debug mode; installs that persisted `true` keep it.
+    debugMode: false,
     // Opt-in diagnostic: when true, the chat handler emits a `log.debug("TOOLS", …)`
     // line per request summarizing tool count + MCP/hosted/client source breakdown.
     logToolSources: false,

--- a/tests/unit/db-settings-debug-mode-default-10312.test.ts
+++ b/tests/unit/db-settings-debug-mode-default-10312.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-settings-debug-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const settings = await import("../../src/lib/db/settings.ts");
+
+async function resetStorage() {
+  const globalDb = (globalThis as { __omnirouteDb?: { open: boolean; close(): void } })
+    .__omnirouteDb;
+  try {
+    if (globalDb?.open) {
+      globalDb.close();
+    }
+  } catch {}
+  delete (globalThis as { __omnirouteDb?: unknown }).__omnirouteDb;
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+await resetStorage();
+
+test("#10312: empty store defaults debugMode to false (fresh install is not in debug)", async () => {
+  await resetStorage();
+  const result = await settings.getSettings();
+  assert.equal(result.debugMode, false);
+});
+
+test("#10312: persisted debugMode=true is preserved after the default flip", async () => {
+  await resetStorage();
+  await settings.updateSettings({ debugMode: true });
+  const result = await settings.getSettings();
+  assert.equal(result.debugMode, true);
+});
+
+test("#10312: persisted debugMode=false stays false after the default flip", async () => {
+  await resetStorage();
+  await settings.updateSettings({ debugMode: false });
+  const result = await settings.getSettings();
+  assert.equal(result.debugMode, false);
+});


### PR DESCRIPTION
## What

Fixes #10312.

`getSettings()` in `src/lib/db/settings.ts` set `debugMode: true` in the defaults object, so any fresh install (or one missing the persisted `debugMode` key) ran in debug mode — contradicting the docs, which describe Debug Mode as an Advanced, opt-in toggle. This flooded new production installs with debug-level logs and buried real warnings.

## Change

- Flip the default from `true` to `false` in the `getSettings()` defaults object (neighbor opt-in flag `logToolSources` already defaults to `false`).
- No migration needed: installs that already persisted `debugMode: true` keep it — only the missing-key path changes.

## Tests

Added `tests/unit/db-settings-debug-mode-default-10312.test.ts`:

1. Empty store → `debugMode === false` (fresh install is not in debug)
2. Persisted `debugMode: true` is preserved after the default flip
3. Persisted `debugMode: false` stays `false`

Verified locally: new test file passes (3/3), existing settings test files pass (`db-settings-extended`, `db-settings-split`, `settings-api`, `check-pack-boot` — 79/79), and `npm run lint` is clean.

## Changelog fragment

Added under `changelog.d/fixes/` with this PR's number.