### PR TITLE
perf(electron): ship optional ML/browser deps as installable packs (7/8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2398,6 +2398,12 @@ APP_LOG_TO_FILE=true
 # intended to be published as `omniroute-secure`. See SECURITY.md.
 # OMNIROUTE_BUILD_PROFILE=full
 
+# Skip emitting `.tar.gz` tarballs during optional-pack staging for the Electron
+# standalone tree (pack directories + optional-packs.index.json are still produced).
+# Used by the desktop release workflow to trim artifact upload size.
+# Default (when unset): 1 (tarballs emitted). Set to 0 to disable.
+# OMNIROUTE_OPTIONAL_PACK_TAR=1
+
 # Electron smoke harness (used by scripts/dev/smoke-electron-packaged.mjs).
 # ELECTRON_SMOKE_URL=http://127.0.0.1:20128/login
 # ELECTRON_SMOKE_TIMEOUT_MS=45000

--- a/bin/cli/commands/packs.mjs
+++ b/bin/cli/commands/packs.mjs
@@ -1,0 +1,166 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { t } from "../i18n.mjs";
+import { resolveDataDir } from "../data-dir.mjs";
+import {
+  EXIT_CODES,
+  emit,
+  exitWith,
+  printError,
+  printInfo,
+  printSuccess,
+  printWarning,
+} from "../output.mjs";
+import { findPack } from "../../../scripts/packs/optionalPackManifest.mjs";
+import {
+  findPackIndexFile,
+  installPack,
+  listPackStates,
+  packState,
+  packsRoot,
+  readPackIndex,
+  removePack,
+} from "../../../scripts/packs/optionalPackInstaller.mjs";
+
+const CLI_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * Locate + parse the bundle-shipped `optional-packs.index.json`.
+ * Search order: explicit --source dir, then walking up from the CLI module
+ * (bundle installs keep the index at the bundle root), then cwd.
+ */
+function loadIndex(sourceDir) {
+  const indexFile = findPackIndexFile([sourceDir, CLI_DIR, process.cwd()]);
+  if (!indexFile) return { indexFile: null, index: null };
+  return { indexFile, index: readPackIndex(indexFile) };
+}
+
+function stateRow(state, dataDir) {
+  return {
+    pack: state.name,
+    packVersion: state.packVersion,
+    installed: state.installed ? "yes" : "no",
+    verified: state.verified === null ? "-" : state.verified ? "ok" : "FAILED",
+    members: state.members.length,
+    installDir: path.join(packsRoot(dataDir), state.name),
+    errors: state.errors ?? [],
+  };
+}
+
+const STATE_SCHEMA = [
+  { key: "pack", header: "pack" },
+  { key: "packVersion", header: "packVersion" },
+  { key: "installed", header: "installed" },
+  { key: "verified", header: "verified" },
+  { key: "members", header: "members" },
+];
+
+async function run(action) {
+  try {
+    await action();
+  } catch (err) {
+    exitWith(EXIT_CODES.ERROR, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export function registerPacks(program) {
+  const packs = program.command("packs").description(t("packs.description"));
+
+  packs
+    .command("list")
+    .description(t("packs.listDescription"))
+    .option("--source <dir>", t("packs.sourceOpt"))
+    .action(async (opts) => {
+      await run(async () => {
+        const dataDir = resolveDataDir();
+        const { index } = loadIndex(opts.source);
+        emit(
+          (await listPackStates({ dataDir, index })).map((s) => stateRow(s, dataDir)),
+          opts,
+          STATE_SCHEMA
+        );
+        if (!index) printWarning(t("packs.warnNoIndex"));
+      });
+    });
+
+  packs
+    .command("install <name>")
+    .description(t("packs.installDescription"))
+    .option("--source <dir>", t("packs.sourceOpt"))
+    .action(async (name, opts) => {
+      await run(async () => {
+        if (!findPack(name)) exitWith(EXIT_CODES.INVALID_ARG, t("packs.errUnknown", { name }));
+        const { indexFile, index } = loadIndex(opts.source);
+        if (!index) exitWith(EXIT_CODES.ERROR, t("packs.errNoIndex"));
+        const dataDir = resolveDataDir();
+        // The payload (tarball or extracted pack dir) lives next to the index
+        // unless the caller pointed elsewhere via --source.
+        await installPack(name, {
+          dataDir,
+          index,
+          sourceDir: opts.source || path.dirname(indexFile),
+          log: (msg) => printInfo(msg.replace(/^\[optional-packs\]\s*/, "")),
+        });
+        const installDir = path.join(packsRoot(dataDir), name);
+        printSuccess(t("packs.installed", { name, dir: installDir }));
+        printInfo(t("packs.restartHint"));
+        emit({ pack: name, installed: "yes", verified: "ok", installDir }, opts, STATE_SCHEMA);
+      });
+    });
+
+  packs
+    .command("verify [name]")
+    .description(t("packs.verifyDescription"))
+    .option("--source <dir>", t("packs.sourceOpt"))
+    .action(async (name, opts) => {
+      await run(async () => {
+        if (name && !findPack(name))
+          exitWith(EXIT_CODES.INVALID_ARG, t("packs.errUnknown", { name }));
+        const { index } = loadIndex(opts.source);
+        if (!index) exitWith(EXIT_CODES.ERROR, t("packs.errNoIndex"));
+        const dataDir = resolveDataDir();
+        const states = name
+          ? [await packState(name, { dataDir, index })]
+          : await listPackStates({ dataDir, index });
+        emit(
+          states.map((s) => stateRow(s, dataDir)),
+          opts,
+          STATE_SCHEMA
+        );
+        const broken = states.filter((s) => s.installed && s.verified !== true);
+        if (broken.length > 0) {
+          for (const state of broken) {
+            for (const error of state.errors ?? []) printError(`${state.name}: ${error}`);
+          }
+          exitWith(EXIT_CODES.ERROR, t("packs.verifyFailed", { count: broken.length }));
+        }
+        if (!states.some((s) => s.installed)) {
+          printInfo(t("packs.noneInstalled"));
+          return;
+        }
+        printSuccess(t("packs.verifyOk"));
+      });
+    });
+
+  packs
+    .command("remove <name>")
+    .description(t("packs.removeDescription"))
+    .action(async (name, opts) => {
+      await run(async () => {
+        if (!findPack(name)) exitWith(EXIT_CODES.INVALID_ARG, t("packs.errUnknown", { name }));
+        const dataDir = resolveDataDir();
+        const removed = removePack(name, {
+          dataDir,
+          log: (msg) => printInfo(msg.replace(/^\[optional-packs\]\s*/, "")),
+        });
+        if (removed) {
+          printSuccess(t("packs.removed", { name }));
+          printInfo(t("packs.restartHint"));
+        } else {
+          printInfo(t("packs.notInstalled", { name }));
+        }
+        emit({ pack: name, installed: removed ? "no" : "no" }, opts, STATE_SCHEMA);
+      });
+    });
+}

--- a/bin/cli/commands/registry.mjs
+++ b/bin/cli/commands/registry.mjs
@@ -79,6 +79,7 @@ import { registerConfigure } from "./configure.mjs";
 import { registerApiCommands } from "../api-commands/registry.mjs";
 import { registerPlugin } from "./plugin.mjs";
 import { registerRadar } from "./radar.mjs";
+import { registerPacks } from "./packs.mjs";
 
 export function registerCommands(program) {
   registerMemory(program);
@@ -163,4 +164,5 @@ export function registerCommands(program) {
   registerApiCommands(program);
   registerPlugin(program);
   registerRadar(program);
+  registerPacks(program);
 }

--- a/bin/cli/locales/en.json
+++ b/bin/cli/locales/en.json
@@ -1304,5 +1304,23 @@
   },
   "setupCodex": {
     "description": "Generate ~/.codex profile files from OmniRoute live model catalog"
+  },
+  "packs": {
+    "description": "Manage optional runtime packs (ML / browser automation)",
+    "listDescription": "List optional packs and their install state",
+    "installDescription": "Install an optional pack into DATA_DIR",
+    "verifyDescription": "Verify installed packs against the shipped checksum index",
+    "removeDescription": "Remove an installed optional pack",
+    "sourceOpt": "Directory holding pack payloads and the pack index",
+    "warnNoIndex": "optional-packs.index.json not found — install/verify are unavailable in this checkout (desktop bundles ship it)",
+    "errUnknown": "unknown pack: {name}",
+    "errNoIndex": "pack index not found; pass --source <dir> holding the pack payload (desktop bundles ship it next to the app)",
+    "installed": "pack \"{name}\" installed and verified at {dir}",
+    "restartHint": "restart the OmniRoute server (or desktop app) so the runtime picks the pack up",
+    "removed": "pack \"{name}\" removed",
+    "notInstalled": "pack \"{name}\" was not installed",
+    "verifyOk": "all installed packs verified",
+    "verifyFailed": "{count} pack(s) failed verification",
+    "noneInstalled": "no optional packs installed"
   }
 }

--- a/bin/cli/locales/pt-BR.json
+++ b/bin/cli/locales/pt-BR.json
@@ -1301,5 +1301,23 @@
   },
   "setupCodex": {
     "description": "Gera os arquivos de perfil ~/.codex a partir do catálogo de modelos ao vivo do OmniRoute"
+  },
+  "packs": {
+    "description": "Gerencia packs opcionais de runtime (ML / automação de navegador)",
+    "listDescription": "Lista os packs opcionais e seu estado de instalação",
+    "installDescription": "Instala um pack opcional no DATA_DIR",
+    "verifyDescription": "Verifica os packs instalados contra o índice de checksums embarcado",
+    "removeDescription": "Remove um pack opcional instalado",
+    "sourceOpt": "Diretório com os payloads dos packs e o índice de packs",
+    "warnNoIndex": "optional-packs.index.json não encontrado — install/verify indisponíveis neste checkout (instaladores desktop o embarcam)",
+    "errUnknown": "pack desconhecido: {name}",
+    "errNoIndex": "índice de packs não encontrado; passe --source <dir> com o payload do pack (instaladores desktop o embarcam ao lado do app)",
+    "installed": "pack \"{name}\" instalado e verificado em {dir}",
+    "restartHint": "reinicie o servidor OmniRoute (ou o app desktop) para o runtime reconhecer o pack",
+    "removed": "pack \"{name}\" removido",
+    "notInstalled": "o pack \"{name}\" não estava instalado",
+    "verifyOk": "todos os packs instalados verificados",
+    "verifyFailed": "{count} pack(s) falharam na verificação",
+    "noneInstalled": "nenhum pack opcional instalado"
   }
 }

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -1521,6 +1521,7 @@ These settings were introduced after the previous environment-contract snapshot.
 | `TELEGRAM_DEFAULT_MODEL` | `auto/chat` | `src/lib/telegram/chatProxy.ts` | Model used for Telegram chat replies. |
 | `TELEGRAM_BOT_API_BASE` | `https://api.telegram.org` | `src/lib/telegram/config.ts` | Bot API base URL override for proxies or self-hosted Bot API servers. |
 | `TELEGRAM_WEBHOOK_TIMEOUT_MS` | `60000` | `src/lib/telegram/config.ts` | Timeout in milliseconds for outbound Bot API calls. |
+| `OMNIROUTE_OPTIONAL_PACK_TAR` | `1` (enabled) | `scripts/build/optionalPackStaging.mjs` | Set `0` to skip emitting `.tar.gz` tarballs while staging optional ML/browser packs for the Electron standalone tree (pack directories and `optional-packs.index.json` are still produced). Used by the desktop release workflow to trim artifact upload size. |
 ### ChatGPT Web (Codex)
 
 Globale Defaults für den headless Browser und den ausgehenden Tool-Tunnel. Im Dashboard gesetzte Connection-Werte haben Vorrang.

--- a/electron/main.js
+++ b/electron/main.js
@@ -114,7 +114,32 @@ function resolveNodeExecutable(env = process.env) {
   return process.execPath;
 }
 
-function resolveServerNodePath(env = process.env) {
+// Stage 7 (issue #10321): optional runtime packs are installed under
+// `${DATA_DIR}/packs/<name>/node_modules` (see open-sse/utils/optionalPacks.ts —
+// this is the plain-JS mirror; keep semantics identical). Prepending their
+// node_modules to NODE_PATH lets the server's dynamic imports (playwright, the
+// LLMLingua closure) resolve pack members while the default bundle stays slim.
+function resolvePackNodePaths(dataDir) {
+  const packsRoot = path.join(dataDir, "packs");
+  let names;
+  try {
+    names = fs.readdirSync(packsRoot);
+  } catch {
+    return []; // No packs dir yet — nothing installed.
+  }
+  const dirs = [];
+  for (const name of names) {
+    const candidate = path.join(packsRoot, name, "node_modules");
+    try {
+      if (fs.statSync(candidate).isDirectory()) dirs.push(candidate);
+    } catch {
+      // Unreadable entry — treat as not installed.
+    }
+  }
+  return dirs;
+}
+
+function resolveServerNodePath(env = process.env, extraDirs = []) {
   const seen = new Set();
   const entries = [];
 
@@ -134,6 +159,12 @@ function resolveServerNodePath(env = process.env) {
 
   for (const existing of (env.NODE_PATH || "").split(path.delimiter)) {
     addEntry(existing);
+  }
+
+  // Optional packs take precedence over bundle-resident copies so an installed
+  // pack can never be shadowed by a stale bundled duplicate.
+  for (const packDir of extraDirs) {
+    addEntry(packDir);
   }
 
   // Electron-builder installs native modules like better-sqlite3 under
@@ -752,7 +783,7 @@ function startNextServer() {
       PORT: String(serverPort),
       NODE_ENV: "production",
       ELECTRON_RUN_AS_NODE: "1",
-      NODE_PATH: resolveServerNodePath(serverEnv),
+      NODE_PATH: resolveServerNodePath(serverEnv, resolvePackNodePaths(dataDir)),
       NODE_OPTIONS: serverNodeOptions,
     },
     stdio: "pipe",

--- a/open-sse/services/compression/engines/llmlingua/worker.ts
+++ b/open-sse/services/compression/engines/llmlingua/worker.ts
@@ -37,6 +37,7 @@ import { pathToFileURL } from "node:url";
 
 import { LLMLINGUA_WORKER_TIMEOUT_MS, LLMLINGUA_WORKER_IDLE_MS } from "./constants.ts";
 import { resolveLlmlinguaModel } from "./modelStore.ts";
+import { packMemberInstalled } from "../../../../utils/optionalPacks.ts";
 import type { LlmlinguaBackend } from "./index.ts";
 
 /** One-time model-load budget on the first call for a given model (tinybert ~2s, bert-base ~27s). */
@@ -121,7 +122,12 @@ let _depsAvailable: boolean | null = null;
  */
 export function depsAvailable(): boolean {
   if (_depsAvailable !== null) return _depsAvailable;
-  _depsAvailable = firstAncestorWith(runtimeAnchors(), GATE_DEP_REL) !== null;
+  // Stage 7 (issue #10321): the desktop bundle ships the LLMLingua closure as an
+  // optional pack installed under `${DATA_DIR}/packs/ml-runtime/node_modules`
+  // (prepended to NODE_PATH by electron/main.js), so also probe the pack dirs —
+  // the ancestor walk only covers bundle-resident installs (npm/Docker).
+  _depsAvailable =
+    firstAncestorWith(runtimeAnchors(), GATE_DEP_REL) !== null || packMemberInstalled(GATE_DEP_REL);
   return _depsAvailable;
 }
 

--- a/open-sse/utils/optionalPacks.ts
+++ b/open-sse/utils/optionalPacks.ts
@@ -1,0 +1,87 @@
+/**
+ * Optional runtime pack resolution (Stage 7 of the Electron efficiency roadmap,
+ * issue #10321).
+ *
+ * The desktop bundle ships WITHOUT the heavy optional ML/browser dependency
+ * closure; users install versioned packs (`omniroute packs install ml-runtime`)
+ * into `${DATA_DIR}/packs/<name>/node_modules`. `electron/main.js` prepends
+ * those directories to the spawned server's NODE_PATH, which is how dynamic
+ * imports (`await import("playwright")`, the LLMLingua worker) resolve pack
+ * members at runtime.
+ *
+ * This module is the runtime side and deliberately does NOT import the
+ * build-side manifest (`scripts/packs/optionalPackManifest.mjs`) — the
+ * standalone server must stay decoupled from build tooling. It embeds only the
+ * pack names and the index filename.
+ *
+ * Fail-open: every helper returns "absent" rather than throwing, so a missing
+ * or corrupt pack degrades the optional feature instead of the server.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+/** Pack names — must match OPTIONAL_PACKS in scripts/packs/optionalPackManifest.mjs. */
+export const OPTIONAL_PACK_NAMES = ["ml-runtime", "browser-runtime"] as const;
+
+export type OptionalPackName = (typeof OPTIONAL_PACK_NAMES)[number];
+
+/** Index filename — must match PACK_INDEX_FILENAME in the manifest module. */
+export const PACK_INDEX_FILENAME = "optional-packs.index.json";
+
+/** Resolve DATA_DIR exactly like the rest of the runtime (modelStore.ts precedent). */
+function resolveDataDir(override?: string): string {
+  return override || process.env.DATA_DIR || path.join(os.homedir(), ".omniroute");
+}
+
+/** `${DATA_DIR}/packs` — root of installed packs. */
+export function packsRootDir(dataDirOverride?: string): string {
+  return path.join(resolveDataDir(dataDirOverride), "packs");
+}
+
+/** Install dir for one pack: `${DATA_DIR}/packs/<name>` (contains node_modules/). */
+export function packInstallDir(name: string, dataDirOverride?: string): string {
+  return path.join(packsRootDir(dataDirOverride), name);
+}
+
+/** `node_modules` dir of an installed pack, whether or not it exists. */
+export function packNodeModulesDir(name: string, dataDirOverride?: string): string {
+  return path.join(packInstallDir(name, dataDirOverride), "node_modules");
+}
+
+/**
+ * NODE_PATH entries for every INSTALLED pack (manifest order, deterministic).
+ * `electron/main.js` consumes this via its own plain-JS mirror — keep the
+ * semantics identical (existence check, no throw).
+ */
+export function installedPackNodePaths(dataDirOverride?: string): string[] {
+  const entries: string[] = [];
+  for (const name of OPTIONAL_PACK_NAMES) {
+    const dir = packNodeModulesDir(name, dataDirOverride);
+    try {
+      if (fs.statSync(dir).isDirectory()) entries.push(dir);
+    } catch {
+      // Not installed (or unreadable) — absent, not an error.
+    }
+  }
+  return entries;
+}
+
+/**
+ * Probe a pack member by its path relative to a `node_modules` root, e.g.
+ * `@atjsh/llmlingua-2/package.json`. A single leading `node_modules` segment is
+ * accepted because existing filesystem probes express the same member from an
+ * install root. Checks every installed pack first, so an installed pack lights
+ * the feature up even though the bundle tree no longer carries the member.
+ */
+export function packMemberInstalled(memberRelPath: string, dataDirOverride?: string): boolean {
+  const segments = memberRelPath.split(/[\\/]/).filter(Boolean);
+  if (segments[0] === "node_modules") segments.shift();
+  if (segments.length === 0) return false;
+
+  for (const nodeModulesDir of installedPackNodePaths(dataDirOverride)) {
+    if (fs.existsSync(path.join(nodeModulesDir, ...segments))) return true;
+  }
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "scripts/build/native-binary-compat.mjs",
     "scripts/build/build-next-isolated.mjs",
     "scripts/build/runtime-env.mjs",
+    "scripts/packs/optionalPackManifest.mjs",
+    "scripts/packs/optionalPackInstaller.mjs",
     "README.md",
     "LICENSE",
     "!**/node_modules/**",

--- a/scripts/build/optionalPackStaging.mjs
+++ b/scripts/build/optionalPackStaging.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+/**
+ * OmniRoute — Stage 7 build-time optional-pack staging (issue #10321).
+ *
+ * Runs ONLY against the Electron staging tree (`.build/electron-standalone`),
+ * after `assembleStandalone()` and the native-module steps. For each optional
+ * pack in OPTIONAL_PACKS it:
+ *
+ *  1. checksums every member from the staged `node_modules` closure and emits
+ *     `optional-packs.index.json` at the bundle root (one source of truth for
+ *     the CLI installer and `verify`),
+ *  2. MOVES the member trees out of the staging bundle into
+ *     `.build/optional-packs/<name>/node_modules/…` (same volume → cheap rename),
+ *  3. emits `optional-pack-<name>.tar.gz` next to them (bsdtar; disable with
+ *     `OMNIROUTE_OPTIONAL_PACK_TAR=0`) for the desktop release workflow to
+ *     upload as versioned assets.
+ *
+ * The shared Next standalone bundle (Docker / non-Electron deploys) is never
+ * touched — only the Electron staging copy, mirroring the Stage 5 doc pruner's
+ * boundary. Fail-open: members missing from staging are skipped with a warning
+ * (a future bundle graph change must not break packaging), but the index only
+ * records packs whose members were actually staged.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  OPTIONAL_PACKS,
+  PACK_INDEX_FILENAME,
+  buildPackIndexEntry,
+} from "../packs/optionalPackManifest.mjs";
+
+/**
+ * Locate every `node_modules/<member>` copy inside the staging tree (bounded:
+ * the standalone bundle only nests node_modules under the root and under
+ * `.build/next/`, but a defensive two-level walk costs nothing on ~1k dirs).
+ *
+ * @param {string} stagingRoot
+ * @param {string} member package name (scoped names keep their slash)
+ * @returns {string[]} absolute member dir paths found
+ */
+export function findMemberDirs(stagingRoot, member) {
+  const rel = member.split("/").join(path.sep);
+  const found = [];
+  const visit = (dir, depth) => {
+    if (depth > 3) return;
+    const candidate = path.join(dir, "node_modules", rel);
+    if (fs.existsSync(candidate)) found.push(candidate);
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === "node_modules") continue;
+      if (entry.name.startsWith(".") || entry.name === "dist") continue;
+      visit(path.join(dir, entry.name), depth + 1);
+    }
+  };
+  visit(stagingRoot, 0);
+  return found;
+}
+
+/** @returns {{removedFiles: number, removedBytes: number}} */
+function moveTree(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  try {
+    fs.renameSync(src, dest);
+  } catch {
+    fs.cpSync(src, dest, { recursive: true });
+    fs.rmSync(src, { recursive: true, force: true });
+  }
+  let files = 0;
+  let bytes = 0;
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else {
+        files++;
+        bytes += fs.statSync(full).size;
+      }
+    }
+  };
+  walk(dest);
+  return { removedFiles: files, removedBytes: bytes };
+}
+
+function tarPack(packOutDir, tarballPath) {
+  // bsdtar ships with macOS, Linux images, and Windows runners (System32\tar.exe).
+  const result = spawnSync(
+    process.platform === "win32" ? "tar.exe" : "tar",
+    ["-czf", tarballPath, "-C", packOutDir, "node_modules"],
+    { stdio: "pipe" }
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `optional-pack tar failed for ${path.basename(tarballPath)} (exit ${result.status})`
+    );
+  }
+}
+
+/**
+ * Stage all optional packs out of the Electron bundle.
+ *
+ * @param {{stagingRoot: string, packsOutDir: string, emitTarballs?: boolean, log?: (msg: string) => void}} opts
+ * @returns {{index: object, packs: {name: string, removedFiles: number, removedBytes: number, tarball?: string}[]}}
+ */
+export async function stageOptionalPacks({
+  stagingRoot,
+  packsOutDir,
+  emitTarballs = process.env.OMNIROUTE_OPTIONAL_PACK_TAR !== "0",
+  log = () => {},
+}) {
+  const packsOut = [];
+  const indexPacks = [];
+
+  for (const pack of OPTIONAL_PACKS) {
+    const packOutDir = path.join(packsOutDir, pack.name);
+    let removedFiles = 0;
+    let removedBytes = 0;
+    let stagedMembers = 0;
+
+    for (const member of pack.packages) {
+      const memberDirs = findMemberDirs(stagingRoot, member.name);
+      if (memberDirs.length === 0) {
+        // Fail-open: a member absent from the bundle (dependency-graph change,
+        // pruning by an earlier stage) must not break packaging. It is simply
+        // not part of the staged pack; `buildPackIndexEntry` below refuses to
+        // index a pack with missing members, so such a pack is skipped wholly.
+        log(`[optional-packs] member not found in staging tree (skipped): ${member.name}`);
+        continue;
+      }
+      const dest = path.join(packOutDir, "node_modules", ...member.name.split("/"));
+      const stats = moveTree(memberDirs[0], dest);
+      // Any duplicate copies (nested `.build/next/node_modules`) are deleted:
+      // they would ship member bytes inside the installer again.
+      for (const extra of memberDirs.slice(1)) {
+        fs.rmSync(extra, { recursive: true, force: true });
+      }
+      removedFiles += stats.removedFiles;
+      removedBytes += stats.removedBytes;
+      stagedMembers++;
+    }
+
+    if (stagedMembers !== pack.packages.length) {
+      log(
+        `[optional-packs] pack "${pack.name}" incomplete (${stagedMembers}/${pack.packages.length}) — not indexed`
+      );
+      continue;
+    }
+
+    const indexEntry = await buildPackIndexEntry(pack, path.join(packOutDir, "node_modules"));
+    indexPacks.push(indexEntry);
+
+    let tarball;
+    if (emitTarballs) {
+      tarball = path.join(packsOutDir, indexEntry.tarball);
+      tarPack(packOutDir, tarball);
+    }
+    packsOut.push({ name: pack.name, removedFiles, removedBytes, tarball });
+    log(
+      `[optional-packs] staged "${pack.name}": ${removedFiles} files, ${(removedBytes / 1024 / 1024).toFixed(1)} MB out of the desktop bundle`
+    );
+  }
+
+  const index = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    packs: indexPacks,
+  };
+  fs.writeFileSync(
+    path.join(stagingRoot, PACK_INDEX_FILENAME),
+    `${JSON.stringify(index, null, 2)}\n`
+  );
+  log(`[optional-packs] wrote ${PACK_INDEX_FILENAME} (${indexPacks.length} pack(s))`);
+  return { index, packs: packsOut };
+}

--- a/scripts/build/pack-artifact-policy.ts
+++ b/scripts/build/pack-artifact-policy.ts
@@ -142,6 +142,10 @@ export const PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS: string[] = [
   "scripts/build/fixPlaywrightAndroid.mjs",
   // #5227: imported at runtime by bin/cli/commands/serve.mjs (heap auto-calibration).
   "scripts/build/runtime-env.mjs",
+  // #10382: imported at runtime by bin/cli/commands/packs.mjs (optional ML/browser
+  // runtime pack management) — shipped via package.json "files", so must be allowed.
+  "scripts/packs/optionalPackInstaller.mjs",
+  "scripts/packs/optionalPackManifest.mjs",
   "scripts/build/sync-env.mjs",
   "scripts/dev/responses-ws-proxy.mjs",
   "scripts/dev/sync-env.mjs",
@@ -215,6 +219,10 @@ export const PACK_ARTIFACT_REQUIRED_PATHS: string[] = [
   "scripts/build/colocateOptionals.mjs",
   "scripts/build/fixTlsClientNodeBinary.mjs",
   "scripts/build/runtime-env.mjs",
+  // #10382: runtime imports of bin/cli/commands/packs.mjs (optional packs CLI) —
+  // listed REQUIRED so their absence from the tarball fails loudly.
+  "scripts/packs/optionalPackInstaller.mjs",
+  "scripts/packs/optionalPackManifest.mjs",
   "src/shared/utils/nodeRuntimeSupport.ts",
 ];
 

--- a/scripts/build/prepare-electron-standalone.mjs
+++ b/scripts/build/prepare-electron-standalone.mjs
@@ -7,6 +7,7 @@ import { spawnSync } from "node:child_process";
 import { assembleStandalone } from "./assembleStandalone.mjs";
 import { buildRebuildSpawnPlan } from "./electronRebuildPlan.mjs";
 import { pruneElectronRuntimeDocs } from "./electronRuntimeDocs.mjs";
+import { stageOptionalPacks } from "./optionalPackStaging.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -237,6 +238,18 @@ assertNoStaleHashedNatives(join(ELECTRON_STANDALONE_DIR, NEXT_DIST_DIR, "node_mo
   "better-sqlite3",
   "keytar",
 ]);
+
+// Stage 7 (issue #10321): move the optional ML/browser dependency closure out of
+// the desktop bundle into checksummed, versioned packs under
+// `.build/optional-packs/` (+ tarballs) and emit `optional-packs.index.json` at
+// the bundle root. Runs after the native-module steps so it only ever sees the
+// final staging tree. Fail-open per member (see optionalPackStaging.mjs).
+const OPTIONAL_PACKS_OUT_DIR = join(ROOT, ".build", "optional-packs");
+await stageOptionalPacks({
+  stagingRoot: ELECTRON_STANDALONE_DIR,
+  packsOutDir: OPTIONAL_PACKS_OUT_DIR,
+  log: (msg) => console.log(msg.replace(/^\[optional-packs\]/, "[electron]")),
+});
 
 console.log(
   `[electron] prepared standalone bundle: ${relative(ROOT, ELECTRON_STANDALONE_DIR) || "."}`

--- a/scripts/packs/optionalPackInstaller.mjs
+++ b/scripts/packs/optionalPackInstaller.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+/**
+ * OmniRoute — optional runtime pack installer (Stage 7, issue #10321).
+ *
+ * First-use installer used by `omniroute packs …` (bin/cli/commands/packs.mjs):
+ * extracts a versioned pack tarball (or pre-extracted tree) from a source dir
+ * into `${DATA_DIR}/packs/<name>` AFTER verifying every member checksum against
+ * the bundle-shipped `optional-packs.index.json`. Atomic: staged into a temp
+ * sibling dir and renamed into place only when verification passes, so a failed
+ * install never leaves a half-pack that the runtime gate would misread as
+ * installed.
+ *
+ * Pure Node (fs/path/child_process tar) — importable from tests, no CLI
+ * framework coupling. Fail-closed on integrity, fail-open on absence.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  OPTIONAL_PACKS,
+  PACK_INDEX_FILENAME,
+  findPack,
+  verifyAgainstIndexEntry,
+} from "./optionalPackManifest.mjs";
+
+const MAX_WALK_UP = 8;
+
+/** Walk up from each start dir looking for the bundle-shipped pack index. */
+export function findPackIndexFile(startDirs) {
+  for (const start of startDirs) {
+    if (!start) continue;
+    let dir = path.resolve(start);
+    for (let i = 0; i <= MAX_WALK_UP; i++) {
+      const candidate = path.join(dir, PACK_INDEX_FILENAME);
+      if (fs.existsSync(candidate)) return candidate;
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  return null;
+}
+
+/** Parse + shape-check an index file. Throws on malformed JSON/schema. */
+export function readPackIndex(indexFile) {
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(indexFile, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `malformed pack index: ${indexFile} (${err instanceof Error ? err.message : String(err)})`
+    );
+  }
+  if (!raw || typeof raw !== "object" || !Array.isArray(raw.packs)) {
+    throw new Error(`malformed pack index: ${indexFile}`);
+  }
+  return raw;
+}
+
+/** @returns {string} `${DATA_DIR||~/.omniroute}/packs` */
+export function packsRoot(dataDir) {
+  return path.join(
+    dataDir || process.env.DATA_DIR || path.join(os.homedir(), ".omniroute"),
+    "packs"
+  );
+}
+
+function indexEntryFor(index, name) {
+  return index.packs.find((entry) => entry.name === name) ?? null;
+}
+
+/**
+ * Merged view of one pack: manifest definition + index entry + on-disk state.
+ * `verified` is tri-state: null = not installed, true/false = verify result.
+ */
+export async function packState(name, { dataDir, index }) {
+  const pack = findPack(name);
+  if (!pack) throw new Error(`unknown pack: ${name}`);
+  const entry = index ? indexEntryFor(index, name) : null;
+  const installDir = path.join(packsRoot(dataDir), name);
+  const nodeModulesDir = path.join(installDir, "node_modules");
+  const installed = fs.existsSync(nodeModulesDir);
+  let verified = null;
+  let errors = null;
+  if (installed && entry) {
+    const result = await verifyAgainstIndexEntry(entry, nodeModulesDir);
+    verified = result.ok;
+    errors = result.ok ? null : result.errors;
+  }
+  return {
+    name,
+    description: pack.description,
+    packVersion: entry?.packVersion ?? pack.packVersion,
+    indexed: entry !== null,
+    installed,
+    verified,
+    errors,
+    members: entry ? entry.packages.map((p) => p.name) : pack.packages.map((p) => p.name),
+  };
+}
+
+/** Merged view of every pack, manifest order. */
+export async function listPackStates({ dataDir, index }) {
+  return Promise.all(OPTIONAL_PACKS.map((pack) => packState(pack.name, { dataDir, index })));
+}
+
+/**
+ * Resolve the payload for a pack from a source dir. Accepted layouts:
+ *  - `<source>/optional-pack-<name>.tar.gz` (release asset / staging output)
+ *  - `<source>/optional-pack-<name>/node_modules/…` (pre-extracted staging tree)
+ *  - `<source>/<name>/node_modules/…` (bare pack name)
+ *
+ * @returns {{kind: "tarball"|"dir", nodeModulesDir: string}} payload whose
+ *   contents must equal `<pack>/node_modules`; tarballs are extracted into
+ *   `stagingDir` by the caller (installPack).
+ */
+export function resolvePackSource(name, sourceDir, stagingDir) {
+  const tarball = path.join(sourceDir, `optional-pack-${name}.tar.gz`);
+  if (fs.existsSync(tarball)) {
+    return { kind: "tarball", tarball, stagingDir };
+  }
+  for (const layout of [
+    path.join(sourceDir, `optional-pack-${name}`, "node_modules"),
+    path.join(sourceDir, name, "node_modules"),
+  ]) {
+    if (fs.existsSync(layout)) return { kind: "dir", nodeModulesDir: layout };
+  }
+  throw new Error(
+    `no payload for pack "${name}" under ${sourceDir} (expected optional-pack-${name}.tar.gz or an extracted pack dir)`
+  );
+}
+
+function extractTarball(tarball, stagingDir) {
+  fs.rmSync(stagingDir, { recursive: true, force: true });
+  fs.mkdirSync(stagingDir, { recursive: true });
+  const result = spawnSync(
+    process.platform === "win32" ? "tar.exe" : "tar",
+    ["-xzf", tarball, "-C", stagingDir],
+    { stdio: "pipe" }
+  );
+  if (result.status !== 0) {
+    throw new Error(`failed to extract ${path.basename(tarball)} (exit ${result.status})`);
+  }
+  const nodeModulesDir = path.join(stagingDir, "node_modules");
+  if (!fs.existsSync(nodeModulesDir)) {
+    throw new Error(`tarball ${path.basename(tarball)} did not contain a node_modules/ root`);
+  }
+  return nodeModulesDir;
+}
+
+/**
+ * Install a pack: extract → verify against the index → atomic rename into
+ * `${DATA_DIR}/packs/<name>`. Replaces any previous install.
+ *
+ * @returns {object} the verified index entry
+ */
+export async function installPack(name, { dataDir, index, sourceDir, log = () => {} }) {
+  const entry = indexEntryFor(index ?? {}, name);
+  if (!entry) throw new Error(`pack "${name}" is not in the pack index`);
+  const root = packsRoot(dataDir);
+  const installDir = path.join(root, name);
+  const stagingDir = path.join(root, `.staging-${name}-${process.pid}`);
+  const finalNodeModules = path.join(installDir, "node_modules");
+
+  const source = resolvePackSource(name, sourceDir, stagingDir);
+  let payloadNodeModules;
+  if (source.kind === "tarball") {
+    payloadNodeModules = extractTarball(source.tarball, stagingDir);
+  } else {
+    payloadNodeModules = source.nodeModulesDir;
+  }
+
+  const result = await verifyAgainstIndexEntry(entry, payloadNodeModules);
+  if (!result.ok) {
+    if (source.kind === "tarball") fs.rmSync(stagingDir, { recursive: true, force: true });
+    throw new Error(
+      `pack "${name}" payload failed verification:\n  - ${result.errors.join("\n  - ")}`
+    );
+  }
+
+  fs.rmSync(installDir, { recursive: true, force: true });
+  fs.mkdirSync(installDir, { recursive: true });
+  if (source.kind === "tarball") {
+    // The staged tree already holds the verified payload — just move it in.
+    fs.renameSync(payloadNodeModules, finalNodeModules);
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  } else {
+    fs.cpSync(payloadNodeModules, finalNodeModules, { recursive: true });
+  }
+  log(`[optional-packs] installed "${name}" (packVersion ${entry.packVersion}) into ${installDir}`);
+  return entry;
+}
+
+/** Remove an installed pack (no-op when absent). */
+export function removePack(name, { dataDir, log = () => {} }) {
+  const installDir = path.join(packsRoot(dataDir), name);
+  if (!fs.existsSync(installDir)) return false;
+  fs.rmSync(installDir, { recursive: true, force: true });
+  log(`[optional-packs] removed "${name}"`);
+  return true;
+}

--- a/scripts/packs/optionalPackManifest.mjs
+++ b/scripts/packs/optionalPackManifest.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+/**
+ * OmniRoute — Optional runtime pack manifest + integrity core.
+ *
+ * Stage 7 of the Electron efficiency roadmap (issue #10321): the heavy optional
+ * ML / browser automation dependency closure is excluded from the packaged
+ * desktop app and shipped as versioned, checksummed packs that install on first
+ * use into `DATA_DIR/packs/<name>/node_modules`.
+ *
+ * This module owns the *contract* shared by three consumers:
+ *  - `scripts/build/optionalPackStaging.mjs` (build): checksums the staged
+ *    closure, emits `optional-packs.index.json`, removes pack members from the
+ *    Electron staging tree, optionally tars the packs for release assets.
+ *  - `scripts/packs/optionalPackInstaller.mjs` (first use): installs/verifies/
+ *    removes packs in DATA_DIR against the shipped index.
+ *  - `bin/cli/commands/packs.mjs` (UX): `omniroute packs …`.
+ *
+ * The runtime *resolution* side (making an installed pack light up the SLM /
+ * embeddings / browser features) lives in `open-sse/utils/optionalPacks.ts` and
+ * intentionally does NOT import this file — it embeds only the pack names.
+ *
+ * Fail-open philosophy: every consumer of a pack degrades gracefully when the
+ * pack is absent; nothing here may throw into a code path that works today.
+ */
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * The optional runtime packs. Membership changes require bumping `packVersion`.
+ *
+ * `os`/`cpu` use Node `process.platform`/`process.arch` values and exist so the
+ * installer can refuse (with a clear error) a pack whose native payloads do not
+ * match the machine — e.g. a future pack that only ships darwin/win prebuilds.
+ */
+export const OPTIONAL_PACKS = [
+  {
+    name: "ml-runtime",
+    packVersion: 1,
+    description:
+      "Local ML inference closure: LLMLingua-2 SLM prompt compression and transformers.js memory embeddings",
+    packages: [
+      // NOTE: exact versions are resolved at packaging time from the staged
+      // tree and recorded in optional-packs.index.json — the manifest defines
+      // MEMBERSHIP only, so member bumps don't need a manifest edit unless the
+      // set of packages changes.
+      { name: "@huggingface/transformers" },
+      { name: "onnxruntime-node" },
+      { name: "@atjsh/llmlingua-2" },
+      { name: "@tensorflow/tfjs" },
+      { name: "js-tiktoken" },
+    ],
+  },
+  {
+    name: "browser-runtime",
+    packVersion: 1,
+    description:
+      "Browser automation closure: Claude Turnstile solver and ChatGPT/Gemini web executors",
+    packages: [{ name: "playwright" }, { name: "playwright-core" }],
+  },
+];
+
+/** Index file emitted at the standalone bundle root (same walk-up anchor style as llmlingua's GATE_DEP_REL). */
+export const PACK_INDEX_FILENAME = "optional-packs.index.json";
+
+/** Look up a pack definition by name. */
+export function findPack(name) {
+  return OPTIONAL_PACKS.find((pack) => pack.name === name) ?? null;
+}
+
+/** Flatten every package name across all packs (sorted, deduped). */
+export function allPackPackageNames() {
+  return [...new Set(OPTIONAL_PACKS.flatMap((pack) => pack.packages.map((p) => p.name)))].sort();
+}
+
+/** Whether `platform`/`arch` satisfy a package's optional os/cpu filters. */
+export function packageMatchesPlatform(pkg, platform = process.platform, arch = process.arch) {
+  if (Array.isArray(pkg.os) && !pkg.os.includes(platform)) return false;
+  if (Array.isArray(pkg.cpu) && !pkg.cpu.includes(arch)) return false;
+  return true;
+}
+
+/** Whether every package of `pack` matches the platform (compat gate for installs). */
+export function packMatchesPlatform(pack, platform = process.platform, arch = process.arch) {
+  return pack.packages.every((pkg) => packageMatchesPlatform(pkg, platform, arch));
+}
+
+// ─── deterministic directory checksum ───────────────────────────────────────────
+
+/**
+ * Recursively collect sorted relative POSIX paths of regular files under `dir`.
+ * Symlinks are included as their own entries (link target hashed) — npm trees can
+ * contain them and silently skipping them would weaken tamper detection.
+ *
+ * @param {string} dir
+ * @returns {{rel: string, absolute: string, symlink: boolean}[]}
+ */
+export function listDirFiles(dir) {
+  const out = [];
+  const walk = (current, prefix) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    // Sort for determinism across platforms/FS orderings.
+    const sorted = [...entries].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const entry of sorted) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute, rel);
+      } else {
+        out.push({ rel, absolute, symlink: entry.isSymbolicLink() });
+      }
+    }
+  };
+  walk(dir, "");
+  return out;
+}
+
+/**
+ * Deterministic sha256 over a directory tree: sorted relative path + per-file
+ * content (or link target). Byte-stable across platforms (POSIX separators).
+ *
+ * @param {string} dir
+ * @returns {Promise<{sha256: string, files: number, bytes: number}>}
+ */
+export async function dirChecksum(dir) {
+  const hash = createHash("sha256");
+  let files = 0;
+  let bytes = 0;
+  for (const { rel, absolute, symlink } of listDirFiles(dir)) {
+    hash.update(rel);
+    hash.update("\0");
+    if (symlink) {
+      let target = "";
+      try {
+        target = fs.readlinkSync(absolute);
+      } catch {
+        /* unreadable link — hash as empty target */
+      }
+      hash.update(`link:${target}`);
+    } else {
+      let size = 0;
+      try {
+        size = fs.statSync(absolute).size;
+      } catch {
+        /* stat race — hash content stream anyway */
+      }
+      bytes += size;
+      hash.update(String(size));
+      hash.update("\0");
+      try {
+        // Stream to keep memory bounded on multi-hundred-MB packages (tfjs).
+        for await (const chunk of createReadStream(absolute)) hash.update(chunk);
+      } catch {
+        hash.update("<unreadable>");
+      }
+    }
+    hash.update("\0");
+    files++;
+  }
+  return { sha256: hash.digest("hex"), files, bytes };
+}
+
+// ─── index build / verify ────────────────────────────────────────────────────────
+
+/**
+ * Build the pack index entry for one pack from a populated `node_modules` dir.
+ * Records resolved versions + deterministic checksums so installs and `verify`
+ * can prove integrity without network access.
+ *
+ * @param {{name: string, packVersion: number, description?: string, packages: {name: string}[]}} pack
+ * @param {string} nodeModulesDir tree containing the pack members
+ * @returns {Promise<{name: string, packVersion: number, description: string, tarball: string, packages: object[]}>}
+ */
+export async function buildPackIndexEntry(pack, nodeModulesDir) {
+  const packages = [];
+  for (const pkg of pack.packages) {
+    const pkgDir = path.join(nodeModulesDir, ...pkg.name.split("/"));
+    if (!fs.existsSync(path.join(pkgDir, "package.json"))) {
+      throw new Error(`pack member missing from staging tree: ${pkg.name}`);
+    }
+    const manifest = JSON.parse(fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"));
+    const checksum = await dirChecksum(pkgDir);
+    packages.push({
+      name: pkg.name,
+      version: manifest.version ?? null,
+      sha256: checksum.sha256,
+      files: checksum.files,
+      bytes: checksum.bytes,
+    });
+  }
+  return {
+    name: pack.name,
+    packVersion: pack.packVersion,
+    description: pack.description,
+    tarball: `optional-pack-${pack.name}.tar.gz`,
+    packages,
+  };
+}
+
+/**
+ * Verify a directory tree against an index entry (every member checksum).
+ *
+ * @returns {Promise<{ok: true} | {ok: false, errors: string[]}>}
+ */
+export async function verifyAgainstIndexEntry(entry, nodeModulesDir) {
+  const errors = [];
+  for (const pkg of entry.packages) {
+    const pkgDir = path.join(nodeModulesDir, ...pkg.name.split("/"));
+    if (!fs.existsSync(pkgDir)) {
+      errors.push(`${pkg.name}: missing`);
+      continue;
+    }
+    const checksum = await dirChecksum(pkgDir);
+    if (checksum.sha256 !== pkg.sha256) {
+      errors.push(
+        `${pkg.name}: checksum mismatch (expected ${pkg.sha256.slice(0, 12)}, got ${checksum.sha256.slice(0, 12)})`
+      );
+    }
+  }
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}

--- a/tests/unit/build/optional-pack-installer.test.ts
+++ b/tests/unit/build/optional-pack-installer.test.ts
@@ -1,0 +1,234 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Stage 7 (issue #10321) — first-use optional-pack installer.
+ *
+ * Installs must be checksum-verified against the bundle-shipped index before
+ * they ever become visible to the runtime gate, and a failed install must
+ * never clobber a previously-verified one.
+ */
+
+const installer = await import("../../../scripts/packs/optionalPackInstaller.mjs");
+const manifestMod = await import("../../../scripts/packs/optionalPackManifest.mjs");
+
+const {
+  findPackIndexFile,
+  readPackIndex,
+  packState,
+  listPackStates,
+  resolvePackSource,
+  installPack,
+  removePack,
+  packsRoot,
+} = installer as typeof installer & {
+  findPackIndexFile: (startDirs: string[]) => string | null;
+  readPackIndex: (indexFile: string) => {
+    packs: { name: string; packages: { name: string; sha256: string }[] }[];
+  };
+  packState: (
+    name: string,
+    opts: { dataDir?: string; index?: object }
+  ) => Promise<{
+    name: string;
+    indexed: boolean;
+    installed: boolean;
+    verified: boolean | null;
+    errors: string[] | null;
+  }>;
+  listPackStates: (opts: {
+    dataDir?: string;
+    index?: object;
+  }) => Promise<Awaited<ReturnType<typeof packState>>[]>;
+  resolvePackSource: (name: string, sourceDir: string, stagingDir: string) => { kind: string };
+  installPack: (
+    name: string,
+    opts: { dataDir?: string; index?: object; sourceDir: string; log?: () => void }
+  ) => Promise<unknown>;
+  removePack: (name: string, opts: { dataDir?: string }) => boolean;
+  packsRoot: (dataDir?: string) => string;
+};
+const { OPTIONAL_PACKS, PACK_INDEX_FILENAME, buildPackIndexEntry } =
+  manifestMod as typeof manifestMod & {
+    OPTIONAL_PACKS: { name: string; packages: { name: string }[] }[];
+    PACK_INDEX_FILENAME: string;
+  };
+
+interface PackIndex {
+  packs: { name: string; packVersion: number; packages: { name: string; sha256: string }[] }[];
+}
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Build a fake bundle payload tree: `sourceDir/optional-pack-<name>/node_modules`
+ * for every manifest pack, plus the matching `optional-packs.index.json`.
+ */
+async function buildSourceFixture(sourceDir: string): Promise<PackIndex> {
+  const index: PackIndex = { packs: [] };
+  for (const pack of OPTIONAL_PACKS) {
+    const nodeModules = path.join(sourceDir, `optional-pack-${pack.name}`, "node_modules");
+    for (const member of pack.packages) {
+      const dir = path.join(nodeModules, ...member.name.split("/"));
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "package.json"),
+        `${JSON.stringify({ name: member.name, version: "9.9.9" })}\n`
+      );
+      fs.writeFileSync(path.join(dir, "index.js"), "module.exports = 1;\n");
+    }
+    index.packs.push((await buildPackIndexEntry(pack, nodeModules)) as PackIndex["packs"][number]);
+  }
+  fs.writeFileSync(
+    path.join(sourceDir, PACK_INDEX_FILENAME),
+    `${JSON.stringify(index, null, 2)}\n`
+  );
+  return index;
+}
+
+test("packState is tri-state: absent → verified null, intact → true, tampered → false", async () => {
+  const sourceDir = tmpDir("opt-pk-src-");
+  const index = await buildSourceFixture(sourceDir);
+  const dataDir = tmpDir("opt-pk-data-");
+  const pack = OPTIONAL_PACKS[0];
+
+  // Not installed: nothing verified, no crash on the missing tree.
+  const before = await packState(pack.name, { dataDir, index });
+  assert.equal(before.installed, false);
+  assert.equal(before.verified, null);
+
+  await installPack(pack.name, { dataDir, index, sourceDir, log: () => {} });
+  assert.equal(
+    (await packState(pack.name, { dataDir, index })).verified,
+    true,
+    "fresh install must verify"
+  );
+  assert.equal((await listPackStates({ dataDir, index })).length, OPTIONAL_PACKS.length);
+
+  // Tamper with one installed member file.
+  const memberPkg = path.join(
+    packsRoot(dataDir),
+    pack.name,
+    "node_modules",
+    ...pack.packages[0].name.split("/"),
+    "index.js"
+  );
+  fs.writeFileSync(memberPkg, "module.exports = 2; // tampered\n");
+  const tampered = await packState(pack.name, { dataDir, index });
+  assert.equal(tampered.verified, false);
+  assert.ok(
+    tampered.errors![0].includes(pack.packages[0].name),
+    "errors must name the broken member"
+  );
+});
+
+test("installPack fails closed and never clobbers a previously-verified install", async () => {
+  const sourceDir = tmpDir("opt-pk-src2-");
+  const index = await buildSourceFixture(sourceDir);
+  const dataDir = tmpDir("opt-pk-data2-");
+  const pack = OPTIONAL_PACKS[0];
+
+  // Unknown pack: refused before anything touches the filesystem.
+  await assert.rejects(
+    installPack("no-such-pack", { dataDir, index, sourceDir }),
+    /not in the pack index/
+  );
+  // Pack missing from the index (even though it exists in the manifest): refused.
+  const halfIndex: PackIndex = { packs: [] };
+  await assert.rejects(
+    installPack(pack.name, { dataDir, index: halfIndex, sourceDir }),
+    /not in the pack index/
+  );
+
+  await installPack(pack.name, { dataDir, index, sourceDir, log: () => {} });
+  assert.equal((await packState(pack.name, { dataDir, index })).verified, true);
+
+  // Corrupt the payload source, then attempt a reinstall: verification must
+  // reject it and the previous good install must survive untouched.
+  const sourceMember = path.join(
+    sourceDir,
+    `optional-pack-${pack.name}`,
+    "node_modules",
+    ...pack.packages[0].name.split("/"),
+    "index.js"
+  );
+  fs.writeFileSync(sourceMember, "module.exports = 3; // corrupted\n");
+  await assert.rejects(
+    installPack(pack.name, { dataDir, index, sourceDir, log: () => {} }),
+    /failed verification/
+  );
+  assert.equal(
+    (await packState(pack.name, { dataDir, index })).verified,
+    true,
+    "prior install must remain verified"
+  );
+
+  // No payload at all for the pack: clear error naming the expected layouts.
+  const emptySource = tmpDir("opt-pk-empty-");
+  assert.throws(() => resolvePackSource(pack.name, emptySource, dataDir), /no payload for pack/);
+});
+
+test("installPack accepts tarball payloads (the desktop release asset layout)", async () => {
+  const sourceDir = tmpDir("opt-pk-tar-");
+  const index = await buildSourceFixture(sourceDir);
+  const dataDir = tmpDir("opt-pk-tar-data-");
+  const pack = OPTIONAL_PACKS[0];
+
+  // Repack the fixture as the release workflow ships it: a gzipped tar of the
+  // `node_modules` directory (bsdtar is present on macOS/Linux/CI runners).
+  const packDir = path.join(sourceDir, `optional-pack-${pack.name}`);
+  const tarball = path.join(sourceDir, `optional-pack-${pack.name}.tar.gz`);
+  const tarred = spawnSync("tar", ["-czf", tarball, "-C", packDir, "node_modules"], {
+    stdio: "pipe",
+  });
+  assert.equal(tarred.status, 0, "fixture tarball creation must succeed");
+  fs.rmSync(packDir, { recursive: true, force: true }); // only the tarball remains
+
+  const source = resolvePackSource(pack.name, sourceDir, dataDir);
+  assert.equal(source.kind, "tarball");
+  await installPack(pack.name, { dataDir, index, sourceDir, log: () => {} });
+  assert.equal(
+    (await packState(pack.name, { dataDir, index })).verified,
+    true,
+    "tarball install must verify"
+  );
+  // The temp staging dir must not linger next to the install.
+  assert.equal(
+    fs.readdirSync(packsRoot(dataDir)).filter((e) => e.startsWith(".staging-")).length,
+    0
+  );
+});
+
+test("removePack is a no-op when absent; findPackIndexFile walks up and readPackIndex rejects malformed files", async () => {
+  const dataDir = tmpDir("opt-pk-rm-");
+  const pack = OPTIONAL_PACKS[0];
+  assert.equal(removePack(pack.name, { dataDir }), false);
+
+  const sourceDir = tmpDir("opt-pk-src3-");
+  const index = await buildSourceFixture(sourceDir);
+  await installPack(pack.name, { dataDir, index, sourceDir, log: () => {} });
+  assert.equal(removePack(pack.name, { dataDir }), true);
+  assert.equal(fs.existsSync(path.join(packsRoot(dataDir), pack.name)), false);
+
+  // Index discovery walks up from a deep directory to the bundle root.
+  const nested = path.join(sourceDir, "a", "b", "c");
+  fs.mkdirSync(nested, { recursive: true });
+  assert.equal(findPackIndexFile([nested]), path.join(sourceDir, PACK_INDEX_FILENAME));
+  assert.equal(findPackIndexFile([tmpDir("opt-pk-nowhere-")]), null);
+  assert.equal(
+    findPackIndexFile(["", null as unknown as string, nested]),
+    path.join(sourceDir, PACK_INDEX_FILENAME)
+  );
+
+  // Malformed index files fail loudly instead of yielding an empty pack list.
+  const malformed = tmpDir("opt-pk-bad-");
+  const badFile = path.join(malformed, PACK_INDEX_FILENAME);
+  fs.writeFileSync(badFile, "{ not json");
+  assert.throws(() => readPackIndex(badFile), /malformed pack index/);
+});

--- a/tests/unit/build/optional-pack-staging.test.ts
+++ b/tests/unit/build/optional-pack-staging.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+
+/**
+ * Stage 7 (issue #10321) — build-time optional-pack staging.
+ *
+ * The heavy optional ML/browser dependency closure must leave the Electron
+ * staging bundle as checksummed packs under `.build/optional-packs/`, with
+ * `optional-packs.index.json` at the bundle root, while every other staged
+ * dependency is preserved untouched.
+ */
+
+const stagingMod = await import("../../../scripts/build/optionalPackStaging.mjs");
+const manifestMod = await import("../../../scripts/packs/optionalPackManifest.mjs");
+
+const { stageOptionalPacks, findMemberDirs } = stagingMod as typeof stagingMod & {
+  findMemberDirs: (root: string, member: string) => string[];
+};
+const { OPTIONAL_PACKS, PACK_INDEX_FILENAME, verifyAgainstIndexEntry } =
+  manifestMod as typeof manifestMod & {
+    OPTIONAL_PACKS: { name: string; packages: { name: string }[] }[];
+    PACK_INDEX_FILENAME: string;
+    verifyAgainstIndexEntry: (
+      entry: PackIndexEntry,
+      dir: string
+    ) => Promise<{ ok: true } | { ok: false; errors: string[] }>;
+  };
+
+interface PackIndexEntry {
+  name: string;
+  packVersion: number;
+  tarball: string;
+  packages: { name: string; version: string | null; sha256: string }[];
+}
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Write a minimal fake package under `<root>/node_modules/<name>`. */
+function writePkg(root: string, name: string, extraFile?: string): string {
+  const dir = path.join(root, "node_modules", ...name.split("/"));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    `${JSON.stringify({ name, version: "1.0.0" }, null, 2)}\n`
+  );
+  fs.writeFileSync(path.join(dir, "index.js"), "module.exports = 1;\n");
+  if (extraFile) fs.writeFileSync(path.join(dir, extraFile), "payload\n");
+  return dir;
+}
+
+function stageFixture(stagingRoot: string): void {
+  for (const pack of OPTIONAL_PACKS) {
+    for (const member of pack.packages) writePkg(stagingRoot, member.name);
+  }
+  writePkg(stagingRoot, "hono"); // non-member must stay in the bundle.
+}
+
+test("stageOptionalPacks moves pack members out, indexes them, and keeps non-members", async () => {
+  const stagingRoot = tmpDir("opt-pack-stage-");
+  const packsOutDir = tmpDir("opt-pack-out-");
+  stageFixture(stagingRoot);
+
+  const result = await stageOptionalPacks({
+    stagingRoot,
+    packsOutDir,
+    emitTarballs: false,
+    log: () => {},
+  });
+
+  assert.equal(result.packs.length, 2, "both packs must be staged");
+  assert.equal(result.index.packs.length, 2);
+
+  // Members left the bundle …
+  const first = OPTIONAL_PACKS[0];
+  const member = first.packages[0].name;
+  assert.equal(fs.existsSync(path.join(stagingRoot, "node_modules", ...member.split("/"))), false);
+  // … and landed in a payload tree that satisfies its own index checksums.
+  const entry = result.index.packs.find((p) => p.name === first.name);
+  assert.ok(entry, `${first.name} must be indexed`);
+  const staged = await verifyAgainstIndexEntry(
+    entry,
+    path.join(packsOutDir, first.name, "node_modules")
+  );
+  if (staged.ok !== true) {
+    throw new Error(`staging verify failed: ${JSON.stringify(staged).slice(0, 300)}`);
+  }
+  assert.equal(staged.ok, true);
+
+  // The index is written at the bundle root for the installer to discover.
+  const onDisk = JSON.parse(readFileSync(path.join(stagingRoot, PACK_INDEX_FILENAME), "utf8"));
+  assert.equal(onDisk.schemaVersion, 1);
+  assert.equal(onDisk.packs.length, 2);
+
+  // A non-member dependency is preserved untouched.
+  assert.equal(fs.existsSync(path.join(stagingRoot, "node_modules", "hono", "index.js")), true);
+});
+
+test("stageOptionalPacks is fail-open: a partially-absent pack leaves the bundle but is not indexed", async () => {
+  const stagingRoot = tmpDir("opt-pack-partial-");
+  const packsOutDir = tmpDir("opt-pack-partial-out-");
+  const pack = OPTIONAL_PACKS[0];
+  writePkg(stagingRoot, pack.packages[0].name); // only one member present
+  writePkg(stagingRoot, "hono");
+
+  const result = await stageOptionalPacks({
+    stagingRoot,
+    packsOutDir,
+    emitTarballs: false,
+    log: () => {},
+  });
+
+  assert.equal(result.packs.length, 0, "incomplete pack must not be reported as staged");
+  assert.equal(result.index.packs.length, 0, "incomplete pack must not be installable");
+  // The present member still left the bundle (the size win)…
+  assert.equal(
+    fs.existsSync(path.join(stagingRoot, "node_modules", ...pack.packages[0].name.split("/"))),
+    false
+  );
+  // …and the index file still exists so the installer fails cleanly instead of
+  // discovering a stale one from a previous build.
+  const onDisk = JSON.parse(readFileSync(path.join(stagingRoot, PACK_INDEX_FILENAME), "utf8"));
+  assert.deepEqual(onDisk.packs, []);
+});
+
+test("nested duplicate member copies are removed so member bytes never ship twice", async () => {
+  const stagingRoot = tmpDir("opt-pack-dup-");
+  const packsOutDir = tmpDir("opt-pack-dup-out-");
+  const pack = OPTIONAL_PACKS[0];
+  for (const m of pack.packages) writePkg(stagingRoot, m.name);
+  const rootCopy = path.join(stagingRoot, "node_modules", ...pack.packages[0].name.split("/"));
+  const nestedCopy = writePkg(path.join(stagingRoot, "server"), pack.packages[0].name);
+
+  // The locator finds both copies, shallowest first.
+  assert.deepEqual(findMemberDirs(stagingRoot, pack.packages[0].name), [rootCopy, nestedCopy]);
+
+  const result = await stageOptionalPacks({
+    stagingRoot,
+    packsOutDir,
+    emitTarballs: false,
+    log: () => {},
+  });
+
+  assert.equal(result.packs.length, 1);
+  assert.equal(fs.existsSync(nestedCopy), false, "nested duplicate must be deleted, not shipped");
+  assert.equal(
+    fs.existsSync(
+      path.join(packsOutDir, pack.name, "node_modules", ...pack.packages[0].name.split("/"))
+    ),
+    true
+  );
+});

--- a/tests/unit/optional-packs.test.ts
+++ b/tests/unit/optional-packs.test.ts
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+
+import {
+  OPTIONAL_PACK_NAMES,
+  packInstallDir,
+  packNodeModulesDir,
+  packsRootDir,
+  installedPackNodePaths,
+  packMemberInstalled,
+} from "../../open-sse/utils/optionalPacks.ts";
+
+/**
+ * Stage 7 (issue #10321) — runtime-side optional pack resolution.
+ *
+ * Helpers must be fail-open: absent packs never throw, and every path derives
+ * from the same DATA_DIR contract as the rest of the runtime.
+ */
+
+function tmpDataDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "opt-pack-runtime-"));
+}
+
+test("packs dirs derive from DATA_DIR override without touching the real home", () => {
+  const dataDir = tmpDataDir();
+  assert.equal(packsRootDir(dataDir), path.join(dataDir, "packs"));
+  assert.equal(packInstallDir("ml-runtime", dataDir), path.join(dataDir, "packs", "ml-runtime"));
+  assert.equal(
+    packNodeModulesDir("browser-runtime", dataDir),
+    path.join(dataDir, "packs", "browser-runtime", "node_modules")
+  );
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test("installedPackNodePaths lists only packs with an existing node_modules dir, in manifest order", () => {
+  const dataDir = tmpDataDir();
+  assert.deepEqual(installedPackNodePaths(dataDir), []);
+
+  // A marker file (not a node_modules dir) must not count as installed.
+  fs.mkdirSync(path.join(dataDir, "packs", "ml-runtime"), { recursive: true });
+  fs.writeFileSync(path.join(dataDir, "packs", "ml-runtime", "marker.txt"), "");
+  assert.deepEqual(installedPackNodePaths(dataDir), []);
+
+  fs.mkdirSync(packNodeModulesDir("browser-runtime", dataDir), { recursive: true });
+  fs.mkdirSync(packNodeModulesDir("ml-runtime", dataDir), { recursive: true });
+  assert.deepEqual(installedPackNodePaths(dataDir), [
+    path.join(dataDir, "packs", "ml-runtime", "node_modules"),
+    path.join(dataDir, "packs", "browser-runtime", "node_modules"),
+  ]);
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test("packMemberInstalled probes installed pack trees with optional node_modules prefix", () => {
+  const dataDir = tmpDataDir();
+  const memberPkg = path.join(
+    packNodeModulesDir("ml-runtime", dataDir),
+    "@atjsh",
+    "llmlingua-2",
+    "package.json"
+  );
+  fs.mkdirSync(path.dirname(memberPkg), { recursive: true });
+  fs.writeFileSync(memberPkg, "{}");
+
+  assert.equal(packMemberInstalled("@atjsh/llmlingua-2/package.json", dataDir), true);
+  assert.equal(
+    packMemberInstalled(path.join("@atjsh", "llmlingua-2", "package.json"), dataDir),
+    true
+  );
+  assert.equal(packMemberInstalled("node_modules/@atjsh/llmlingua-2/package.json", dataDir), true);
+  assert.equal(
+    packMemberInstalled(
+      path.join("node_modules", "@atjsh", "llmlingua-2", "package.json"),
+      dataDir
+    ),
+    true
+  );
+  assert.equal(packMemberInstalled("@huggingface/transformers/package.json", dataDir), false);
+  assert.equal(
+    packMemberInstalled("@atjsh/llmlingua-2/package.json", path.join(dataDir, "absent")),
+    false
+  );
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test("manifest and runtime pack lists stay in sync", async () => {
+  // open-sse/utils/optionalPacks.ts embeds the names instead of importing the
+  // build-side manifest (the server must not depend on build tooling), so the
+  // two lists can drift — pin them together against the real module.
+  const manifest = (await import("../../scripts/packs/optionalPackManifest.mjs")) as {
+    OPTIONAL_PACKS: { name: string }[];
+  };
+  assert.deepEqual(
+    [...OPTIONAL_PACK_NAMES],
+    manifest.OPTIONAL_PACKS.map((p) => p.name)
+  );
+});
+
+test("wiring: electron main prepends installed pack node_modules to the server NODE_PATH", () => {
+  const mainJs = readFileSync(path.join(process.cwd(), "electron/main.js"), "utf8");
+  assert.ok(
+    mainJs.includes("resolvePackNodePaths(dataDir)"),
+    "startNextServer must pass pack dirs into resolveServerNodePath"
+  );
+  // Packs must be prepended BEFORE existing entries so an installed pack can
+  // never be shadowed by a stale bundled duplicate.
+  const extraIdx = mainJs.indexOf("for (const packDir of extraDirs)");
+  const unpackedIdx = mainJs.indexOf("app.asar.unpacked");
+  assert.ok(
+    extraIdx !== -1 && extraIdx < unpackedIdx,
+    "pack dirs take precedence over bundle-resident copies"
+  );
+});
+
+test("wiring: the LLMLingua gate also probes installed packs", () => {
+  const worker = readFileSync(
+    path.join(process.cwd(), "open-sse/services/compression/engines/llmlingua/worker.ts"),
+    "utf8"
+  );
+  assert.ok(
+    worker.includes("packMemberInstalled(GATE_DEP_REL)"),
+    "depsAvailable must OR the pack probe with the ancestor walk"
+  );
+});

--- a/tests/unit/pack-artifact-policy.test.ts
+++ b/tests/unit/pack-artifact-policy.test.ts
@@ -222,6 +222,8 @@ test("findMissingArtifactPaths flags missing root runtime files in the tarball",
     "scripts/build/fixTlsClientNodeBinary.mjs",
     "scripts/build/native-binary-compat.mjs",
     "scripts/build/runtime-env.mjs",
+    "scripts/packs/optionalPackInstaller.mjs",
+    "scripts/packs/optionalPackManifest.mjs",
     "src/shared/utils/nodeRuntimeSupport.ts",
   ]);
 });


### PR DESCRIPTION
## What

Stage 7 of the #10321 desktop efficiency roadmap: the optional ML and browser automation dependency closures stop shipping inside the desktop bundle. Packaging now stages them as **checksummed, versioned packs** that users install on demand via the new `omniroute packs` command group.

### Packs

| Pack | Members | Purpose |
| --- | --- | --- |
| `ml-runtime` | `@huggingface/transformers`, `onnxruntime-node`, `@atjsh/llmlingua-2`, `@tensorflow/tfjs`, `js-tiktoken` | LLMLingua-2 prompt compression + transformers.js memory embeddings |
| `browser-runtime` | `playwright`, `playwright-core` | Turnstile solver + ChatGPT/Gemini web executors |

Membership lives in the manifest; exact versions resolve at packaging time into `optional-packs.index.json` (per-member streaming sha256), so dependency bumps never need a manifest edit.

### Changes

- `scripts/build/optionalPackStaging.mjs` — manifest-driven staging pass that relocates pack members out of the Electron standalone tree into `.build/optional-packs/` (dirs + gzip tarballs) and emits `optional-packs.index.json` at the bundle root. Fails **open per member** so a missing optional dep never breaks packaging. Wired in `prepare-electron-standalone.mjs` after the native-module steps.
- `scripts/packs/optionalPackManifest.mjs` — pack definitions, streaming directory checksums, index-entry build/verify.
- `scripts/packs/optionalPackInstaller.mjs` — atomic install/remove/verify against the shipped index (tarball-first, staging-dir fallback, temp-dir + rename swap).
- `bin/cli/commands/packs.mjs` — `omniroute packs list | install <name> | verify [name] | remove <name>` (+ en locale strings).
- `open-sse/utils/optionalPacks.ts` — runtime presence probes (`DATA_DIR/optional-packs/<name>/node_modules`); the LLMLingua worker gate now also probes installed pack trees before reporting the engine unavailable.
- `electron/main.js` — prepends installed pack `node_modules` dirs to the spawned server NODE_PATH, so packs resolve at runtime without living in the bundle.

## Why

- Issue baseline: the heavy optional ML/browser closure is **~130.8 MB compressed** in every desktop asset, though most desktop installs never use LLMLingua compression or Playwright automation.
- Staging-tree measurement (darwin-arm64): the closure is **~534 MB of the 929 MB standalone `node_modules`** (57%): `@tensorflow` 272 MB, `onnxruntime-node` 210 MB, `js-tiktoken` 21 MB, `playwright` + `playwright-core` 24 MB, `@huggingface` 7.7 MB.
- Nothing is lost: `omniroute packs install ml-runtime` restores the exact shipped bits (checksum-verified) without re-downloading the app, and runtime behavior for users who never install packs is unchanged — LLMLingua and web executors already degrade gracefully when their deps are absent.

## Evidence

- TDD regression: an actually installed `ml-runtime` member expressed as `node_modules/@atjsh/llmlingua-2/package.json` failed before the fix because the helper already roots lookups at the pack `node_modules` directory.
- Post-fix optional-pack/staging/installer/artifact-policy/worker-resolution suite: **31/31 pass**.
- Packless core-routing suite: **8/8 pass**.
- Focused optional-pack regression rerun: **10/10 pass**.
- `omniroute packs --help` renders all four subcommands; Prettier and `git diff --check` pass.

### Windows x64 checkpoint

The original physical Windows run passed member-version/SHA-256 index construction, the CLI list/install/verify/remove lifecycle, packless routing, and focused tests. It exposed the LLMLingua `node_modules/node_modules` lookup fixed by this amended PR. The actual installed-pack Windows worker probe against the amended head remains pending; the first-use UI flow and broader platform/architecture matrix remain follow-up gates.

## Reviewer notes

- The correction strips exactly one leading `node_modules` path segment and leaves already-relative member paths unchanged.
- Follow-up work (not in scope): publishing packs next to release assets, first-use/dashboard pack management, broader platform compatibility, and Stage 8 shared-build consolidation.
