### PR TITLE
test(api): align duplicate-builtin catalog expectation with the #10248 overlay contract

### DIFF
--- a/tests/unit/models-catalog-route.test.ts
+++ b/tests/unit/models-catalog-route.test.ts
@@ -1398,8 +1398,15 @@ test("v1 models catalog skips duplicate built-ins and custom models from inactiv
   const duplicateBuiltins = body.data.filter((item) => item.id === "openai/gpt-4o-2024-11-20");
 
   assert.equal(response.status, 200);
+  // Still exactly one entry: the custom row overlays the built-in, it does not duplicate it.
   assert.equal(duplicateBuiltins.length, 1);
-  assert.equal(duplicateBuiltins[0].custom === true, false);
+  // #10248 changed the contract: a custom row for an id that already exists is the
+  // operator-owned overlay for that model (catalog.ts:1330) — its explicitly stored
+  // fields win over the discovered metadata, and the merged entry is flagged `custom`.
+  // Before #10248 the duplicate was skipped outright, so this asserted `false`.
+  assert.equal(duplicateBuiltins[0].custom, true);
+  // The overlay must keep the catalog identity rather than becoming a detached entry.
+  assert.equal(duplicateBuiltins[0].id, "openai/gpt-4o-2024-11-20");
   assert.equal(
     body.data.some((item) => item.id === "cl/inactive-only" || item.id === "cline/inactive-only"),
     false


### PR DESCRIPTION
## O que

Alinha `tests/unit/models-catalog-route.test.ts` ao contrato que o #10248 estabeleceu. Este é o **último base-red** do `Unit Tests fast-path (3/4)`.

## Por que (discriminação: teste desatualizado, não regressão)

O #10248 (`876cc42089`, "make custom model overrides work consistently", @jackjinke) mudou 62 linhas de `src/app/api/v1/models/catalog.ts` e atualizou 11 arquivos de teste — mas **não** este, que cobre exatamente esse arquivo.

O contrato mudou de forma **intencional e documentada**:

- Antes: um custom row com o mesmo id de um built-in era simplesmente **pulado** (o comentário removido dizia `Skip if already added as built-in`).
- Agora (`catalog.ts:1330`): *"A custom row is the operator-owned overlay for the same provider/model. Preserve catalog identity and discovered metadata, but let every field explicitly stored on the custom row determine the effective metadata"* — e a entrada resultante é marcada `custom: true`.
- O changelog do #10248 confirma: *"custom model metadata … now take precedence over discovered metadata"*.

O teste ainda afirmava `custom === false`, escrito para o comportamento antigo. Falhava em `models-catalog-route.test.ts:1402` com `actual: true, expected: false`.

## O que mudou no teste

Nenhuma asserção foi removida ou enfraquecida — a expectativa desatualizada foi **corrigida** e uma asserção **nova** foi adicionada:

- `duplicateBuiltins.length === 1` — mantido (o overlay não duplica a entrada)
- `custom === false` → `custom === true` — reflete o overlay do operador, com comentário citando #10248 e a linha do contrato
- **novo:** `id === "openai/gpt-4o-2024-11-20"` — garante que o overlay preserva a identidade do catálogo em vez de virar uma entrada solta

## Validação

`node --import tsx/esm --test tests/unit/models-catalog-route.test.ts` → **44 pass, 0 fail** (era 43 pass / 1 fail no tip `f06d5f20ed`, que já inclui #10373 e #10339).