### PR TITLE
fix(models): stop flagging built-in models as custom in /v1/models (base-red)

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -1363,7 +1363,18 @@ async function buildUnifiedModelsResponseCore(
                 ? { max_output_tokens: model.outputTokenLimit }
                 : {}),
               ...(visionFields || {}),
-              custom: true,
+              // #10248 regressed this to unconditionally stamp `custom: true` on the
+              // merge, even when `existingIndex !== -1` means the custom row is just a
+              // metadata overlay on top of an entry that already exists in the catalog
+              // (a built-in PROVIDER_MODELS row, a synced/discovered model, or an
+              // earlier custom row for the same id). That mislabeled a duplicate custom
+              // row for an operator's already-active built-in model (e.g. a token-limit
+              // override on openai/gpt-4o) as "custom: true" in the public catalog, even
+              // though the model is the standard built-in one. Omit `custom` from the
+              // overlay so `mergeCustomModelMetadata` preserves `existing.custom`
+              // instead: an entry that already owed its existence to a custom row keeps
+              // `custom: true`, and a built-in/synced entry merely overlaid with custom
+              // metadata stays classified as non-custom.
             });
             continue;
           }


### PR DESCRIPTION
## Summary

Base-red fix for `release/v3.8.50` (#9985): `tests/unit/models-catalog-route.test.ts` has been failing on the release tip, taking down the **Unit Tests fast-path** shard of every open PR — including third-party ones.

**Root cause:** #10248 rewrote the custom-model overlay merge in `src/app/api/v1/models/catalog.ts` to always write `custom: true`. That is correct when the custom row *is* the model, but wrong when it is only a metadata overlay on a model already present as built-in/synced (e.g. a token-limit override on `openai/gpt-4o-2024-11-20`) — those got reported as operator-defined in the public `/v1/models` response.

**Fix:** drop the hardcoded `custom: true` from the overlay object so `existing.custom` survives the merge. A row that already was custom stays custom; a built-in merely overlaid with custom metadata stays built-in. One file, ~12 lines including the explanatory comment.

## Validation

- `tests/unit/models-catalog-route.test.ts` — 44/44 (was 43/44 red on the tip).
- Sibling sweep: all 66 test files touching `getUnifiedModelsResponse` / `addCustomModel` — 388/388.
- `check-open-sse-typecheck.mjs` OK · `typecheck:core` exit 0 · prettier/eslint clean on the touched file.

The originating investigation started from a different hypothesis (inactive-provider leakage); instrumentation proved the `activeAliases` gate already works and pointed at the `custom` flag instead.

Refs #9985, #10248
