### PR TITLE
fix(executors): rotate to the next account on network throws when the account has a dedicated proxy

### DIFF
--- a/changelog.d/fixes/10393-opencode-rotate-network-throw.md
+++ b/changelog.d/fixes/10393-opencode-rotate-network-throw.md
@@ -1,0 +1,1 @@
+- **fix(executors):** OpencodeExecutor now rotates to the next account on network exceptions (timeout, connection refused/reset), not only on 429 — a throw on one account no longer fails the whole request when other accounts remain ([#10393](https://github.com/diegosouzapw/OmniRoute/pull/10393))

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -287,9 +287,24 @@ export class OpencodeExecutor extends BaseExecutor {
         // Pin egress to this account's proxy for the whole BaseExecutor dispatch
         // (incl. its intra-URL 429 retries). skipUpstreamRetry lets THIS loop own
         // the cross-account 429 fallback instead of BaseExecutor's same-key retry.
-        const result = await runWithProxyContext(account.proxy, () =>
-          super.execute({ ...input, skipUpstreamRetry: true })
-        );
+        let result;
+        try {
+          result = await runWithProxyContext(account.proxy, () =>
+            super.execute({ ...input, skipUpstreamRetry: true })
+          );
+        } catch (err) {
+          // A network exception (timeout, connection refused/reset) on ONE account
+          // must not abort the whole request when other accounts remain — symmetric
+          // to the existing 429 handling above. Never swallowed silently: logged
+          // before rotating so operators can see which account failed and why.
+          this.markCooldown(account);
+          const reason = err instanceof Error ? err.message : String(err);
+          log?.warn?.(
+            "OPENCODE",
+            `network error on account ${masked}, rotating to next… (${reason})`,
+          );
+          continue;
+        }
         lastResult = result;
 
         const status = result.response.status;

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -267,7 +267,14 @@ export class OpencodeExecutor extends BaseExecutor {
       }
 
       const { log } = input;
-      let lastResult: Awaited<ReturnType<BaseExecutor["execute"]>> | null = null;
+      // This loop only ever dispatches through super.execute() (the HTTP request
+      // path), which always resolves the object-shaped arm of ExecutorExecuteResult
+      // — the bare-Response arm belongs to web/scraping executors only (base.ts:290).
+      type HttpExecuteResult = Extract<
+        Awaited<ReturnType<BaseExecutor["execute"]>>,
+        { response: Response }
+      >;
+      let lastResult: HttpExecuteResult | null = null;
 
       for (let attempt = 0; attempt < this.accounts.length; attempt++) {
         const account = this.pickAccount();
@@ -287,21 +294,35 @@ export class OpencodeExecutor extends BaseExecutor {
         // Pin egress to this account's proxy for the whole BaseExecutor dispatch
         // (incl. its intra-URL 429 retries). skipUpstreamRetry lets THIS loop own
         // the cross-account 429 fallback instead of BaseExecutor's same-key retry.
-        let result;
+        let result: HttpExecuteResult;
         try {
-          result = await runWithProxyContext(account.proxy, () =>
+          // super.execute() here always dispatches the HTTP path (opencode is an
+          // OpenAI-compatible API, never the web/scraping bare-Response arm) —
+          // see base.ts:290-294.
+          result = (await runWithProxyContext(account.proxy, () =>
             super.execute({ ...input, skipUpstreamRetry: true })
-          );
+          )) as HttpExecuteResult;
         } catch (err) {
-          // A network exception (timeout, connection refused/reset) on ONE account
-          // must not abort the whole request when other accounts remain — symmetric
-          // to the existing 429 handling above. Never swallowed silently: logged
-          // before rotating so operators can see which account failed and why.
+          // A network exception (timeout, connection refused/reset) is only
+          // account-scoped when this account has its OWN egress (a configured
+          // proxy) — that's the case a dead/unreachable proxy justifies rotating
+          // away from. Without a proxy, accounts share the same network egress:
+          // the failure isn't attributable to this account, and rotating would
+          // just retry the same outage against every other account while
+          // poisoning their cooldowns for a cause that isn't theirs. Never
+          // swallowed silently either way: logged before rotating or rethrowing.
+          if (!account.proxy) {
+            log?.warn?.(
+              "OPENCODE",
+              `network error on account ${masked} (no dedicated proxy, shared egress) — not rotating`
+            );
+            throw err;
+          }
           this.markCooldown(account);
           const reason = err instanceof Error ? err.message : String(err);
           log?.warn?.(
             "OPENCODE",
-            `network error on account ${masked}, rotating to next… (${reason})`,
+            `network error on account ${masked}, rotating to next… (${reason})`
           );
           continue;
         }

--- a/tests/unit/opencode-proxy-rotation-4954.test.ts
+++ b/tests/unit/opencode-proxy-rotation-4954.test.ts
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach, before, after } from "node:test";
 import assert from "node:assert";
 import net from "node:net";
 import { OpencodeExecutor } from "../../open-sse/executors/opencode.ts";
+import type { ExecutorLog } from "../../open-sse/executors/base.ts";
 import {
   resolveProxyForRequest,
   runWithAppliedProxyCapture,
@@ -166,6 +167,101 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
     );
     for (const p of observed) {
       assert.strictEqual(p.source, "context", "every dispatch must egress through a proxy context");
+    }
+  });
+
+  it("rotates to the next account on a network throw (not just 429)", async () => {
+    const exec = new OpencodeExecutor("opencode-zen");
+    let call = 0;
+    const originalFetchForThrow = globalThis.fetch;
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === "string" ? input : input?.url || String(input);
+      const resolved = resolveProxyForRequest(url);
+      observed.push({
+        source: resolved.source,
+        host: resolved.proxyUrl ? new URL(resolved.proxyUrl).hostname : null,
+        port: resolved.proxyUrl ? new URL(resolved.proxyUrl).port : null,
+      });
+      call++;
+      if (call === 1) {
+        throw new Error("ECONNRESET: connection reset by peer");
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      const result = await exec.execute({
+        model: "deepseek-v4-flash-free",
+        body: { messages: [{ role: "user", content: "hi" }], stream: false },
+        stream: false,
+        signal: null,
+        credentials: credentialsWithProxies(),
+        log,
+      });
+
+      assert.strictEqual(
+        (result as { response: { status: number } }).response.status,
+        200,
+        "a throw on account A must not abort the request — account B must be tried",
+      );
+      assert.ok(
+        observed.length >= 2,
+        "should have retried on a second account after the throw",
+      );
+      assert.notStrictEqual(
+        observed[0].port,
+        observed[1].port,
+        "rotation must switch to a different account/proxy after a throw",
+      );
+    } finally {
+      globalThis.fetch = originalFetchForThrow;
+    }
+  });
+
+  it("logs a network-error rotation and does not swallow it silently", async () => {
+    const exec = new OpencodeExecutor("opencode-zen");
+    let call = 0;
+    const originalFetchForThrow = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      call++;
+      if (call === 1) throw new Error("ETIMEDOUT");
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+
+    const warnCalls: Array<{ tag: unknown; msg: string }> = [];
+    const spyLog: ExecutorLog = {
+      debug() {},
+      info() {},
+      warn: (tag, msg) => {
+        warnCalls.push({ tag, msg });
+      },
+      error() {},
+    };
+
+    try {
+      await exec.execute({
+        model: "deepseek-v4-flash-free",
+        body: { messages: [{ role: "user", content: "hi" }], stream: false },
+        stream: false,
+        signal: null,
+        credentials: credentialsWithProxies(),
+        log: spyLog,
+      });
+
+      assert.ok(
+        warnCalls.some(
+          (c) => c.tag === "OPENCODE" && /network error/i.test(c.msg),
+        ),
+        `expected a warn-level "network error" log; got=${JSON.stringify(warnCalls)}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetchForThrow;
     }
   });
 

--- a/tests/unit/opencode-proxy-rotation-4954.test.ts
+++ b/tests/unit/opencode-proxy-rotation-4954.test.ts
@@ -90,7 +90,8 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
   function installFetchStub(statuses: number[]) {
     let call = 0;
     globalThis.fetch = (async (input: any) => {
-      const url = typeof input === "string" ? input : input?.url || String(input);
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const resolved = resolveProxyForRequest(url);
       let host: string | null = null;
       let port: string | null = null;
@@ -175,7 +176,8 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
     let call = 0;
     const originalFetchForThrow = globalThis.fetch;
     globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
-      const url = typeof input === "string" ? input : input?.url || String(input);
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const resolved = resolveProxyForRequest(url);
       observed.push({
         source: resolved.source,
@@ -205,16 +207,13 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
       assert.strictEqual(
         (result as { response: { status: number } }).response.status,
         200,
-        "a throw on account A must not abort the request — account B must be tried",
+        "a throw on account A must not abort the request — account B must be tried"
       );
-      assert.ok(
-        observed.length >= 2,
-        "should have retried on a second account after the throw",
-      );
+      assert.ok(observed.length >= 2, "should have retried on a second account after the throw");
       assert.notStrictEqual(
         observed[0].port,
         observed[1].port,
-        "rotation must switch to a different account/proxy after a throw",
+        "rotation must switch to a different account/proxy after a throw"
       );
     } finally {
       globalThis.fetch = originalFetchForThrow;
@@ -255,10 +254,52 @@ describe("OpencodeExecutor per-account proxy + rotation (#4954)", () => {
       });
 
       assert.ok(
-        warnCalls.some(
-          (c) => c.tag === "OPENCODE" && /network error/i.test(c.msg),
-        ),
-        `expected a warn-level "network error" log; got=${JSON.stringify(warnCalls)}`,
+        warnCalls.some((c) => c.tag === "OPENCODE" && /network error/i.test(c.msg)),
+        `expected a warn-level "network error" log; got=${JSON.stringify(warnCalls)}`
+      );
+    } finally {
+      globalThis.fetch = originalFetchForThrow;
+    }
+  });
+
+  it("propagates a network throw when no account has a configured proxy (shared egress, P6 scope)", async () => {
+    const exec = new OpencodeExecutor("opencode-zen");
+    let call = 0;
+    const originalFetchForThrow = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      call++;
+      throw new Error("ETIMEDOUT");
+    }) as typeof globalThis.fetch;
+
+    try {
+      await assert.rejects(
+        () =>
+          exec.execute({
+            model: "deepseek-v4-flash-free",
+            body: { messages: [{ role: "user", content: "hi" }], stream: false },
+            stream: false,
+            signal: null,
+            credentials: {
+              apiKey: null,
+              accessToken: null,
+              connectionId: "noauth",
+              providerSpecificData: {
+                fingerprints: [ACCOUNT_A, ACCOUNT_B],
+                // No accountProxies configured — both accounts share the same
+                // network egress. A throw here is not account-scoped: rotating
+                // would just retry the same failure N times against a healthy
+                // account's cooldown, so it must propagate like before P6.
+              },
+            } as any,
+            log,
+          }),
+        /ETIMEDOUT/,
+        "a network throw on a proxy-less account must propagate, not be swallowed into rotation"
+      );
+      assert.strictEqual(
+        call,
+        1,
+        "must not retry against another account when no proxy isolates egress"
       );
     } finally {
       globalThis.fetch = originalFetchForThrow;


### PR DESCRIPTION
## Summary

OpencodeExecutor and MimocodeExecutor rotate to the next account only on HTTP 429. A network exception (timeout, connection refused/reset) on one account
instead propagates out of `execute()` and fails the whole request, even when
other accounts remain available.

Both executors now rotate on a network exception **only when the failed
account has its own dedicated proxy** (`account.proxy !== null`). A dead
proxy is genuinely account-scoped, so rotating away from it is safe.
Accounts sharing the default egress (no proxy configured) can all fail at
once on a real network outage — rotating there would just retry the same
failure against every account while poisoning each one's cooldown for a
cause that isn't theirs, and inflate one request into up to N sequential
timeouts. For that case the exception still propagates (opencode) or fails
fast with a 502 (mimocode). Never swallowed silently either way — a `warn`
is logged before rotating or giving up.

The shared rotation mechanics (`pickAccount`/`markCooldown`/`markSuccess`)
are extracted into `open-sse/executors/accountRotation.ts`, used by both
executors. This also fixes a pre-existing bug in `MimocodeExecutor`: its
catch block called `markCooldown` unconditionally on any throw, with no
proxy check and no warn log (a silent exception swallow on a path that
influences the result).

## Related Issues

- Related to #4954 (per-account proxy + rotation)

## Validation

Change type: **provider** ([Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md) —
executor/error-sanitization contract, not routing/combo dispatch).

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path:
  - `npm run check:provider-consistency` — OK, 0 exceptions
  - `npm run check:provider-assets` — passed
  - `node --import tsx/esm --test tests/unit/provider-translate-path-golden.test.ts` — 3 passed
  - `node --import tsx/esm --test tests/unit/opencode-proxy-rotation-4954.test.ts` — 7 passed
  - `node --import tsx/esm --test tests/unit/mimocode-executor.test.ts` — 42 passed, 2 failed
    (pre-existing `Cannot find package 'turndown'` module-resolution gap in
    `open-sse/vendor/codex-chatgpt-web/adapters/chatgpt-web/markdown.ts`, unrelated to this
    change and reproducible on the base branch)
  - `node --import tsx/esm --test tests/unit/account-rotation.test.ts` (new) — 11 passed
- [x] `npm run lint` — clean on all touched files (0 new `no-explicit-any` beyond the existing
      per-file ratchet baseline)
- [x] Reconciled with the current active release base; focused checks rerun afterward — rebased
      onto the current `release/v3.8.50` tip (no conflicts, no overlap), full focused loop above
      rerun clean post-rebase
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below —
      not yet run; awaiting CI on this revision

## Tests Added Or Updated

- `tests/unit/account-rotation.test.ts` (new, 11 cases) — the shared rotation module in isolation
- `tests/unit/opencode-proxy-rotation-4954.test.ts` — added the no-proxy propagation regression
  test (3 network-throw cases total)
- `tests/unit/mimocode-executor.test.ts` — added a "network-error rotation (P6 parity)" block
  (2 cases)

## Coverage Notes

- `open-sse/executors/accountRotation.ts` is tested directly and in isolation from network I/O.
- Each executor's integration tests exercise the account-rotation loop via its existing
  `fetch`/dispatcher stubbing pattern, covering the rotation decision, the warn logs, and the
  no-proxy guard — no coverage regression expected, only additions.

## Reviewer Notes

- `nextAccountIdx` had to drop its `private` modifier on both executors so it can be passed as
  the mutable rotation cursor to the shared `pickAccount()` — TS's private-member nominal check
  otherwise rejects `this` there.
- Mimocode's own `isAccountReady` (JWT-freshness-aware, not just cooldown) is preserved and
  passed as a custom predicate to the shared `pickAccount` rather than replaced.
- Mimocode's network-error 502 body goes through `buildErrorBody()`/`sanitizeErrorMessage()`
  instead of embedding the raw caught error message directly, matching the sanitization already
  used on its #2101 malformed-request path (error-response-sanitization contract).
- No secrets, credentials, or local configuration are involved.
