### PR TITLE
fix(chat): guard search providers from OpenAI fallback

### DIFF
--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -1,3 +1,4 @@
+import { SEARCH_PROVIDERS } from "../config/searchRegistry.ts";
 import { AntigravityExecutor } from "./antigravity.ts";
 import { GithubExecutor } from "./github.ts";
 import { GheCopilotExecutor } from "./ghe-copilot.ts";
@@ -227,11 +228,29 @@ const defaultCache = new Map();
 // follow-up once their own chat-routing behavior is confirmed.
 const CHAT_UNSUPPORTED_CLOUD_AGENT_PROVIDERS = new Set(["jules"]);
 
+// #10274 — providers that exist ONLY as /v1/search endpoint entries
+// (SEARCH_PROVIDERS in open-sse/config/searchRegistry.ts) and have no chat-completions
+// REGISTRY entry anywhere in open-sse/. Without this guard, getExecutor() silently falls
+// through to DefaultExecutor's `PROVIDERS[provider] || PROVIDERS.openai` fallback, sending
+// the user's real search API key (e.g. a Tavily `tvly-...` key) to OpenAI's endpoint and
+// surfacing OpenAI's own "Incorrect API key provided" error for a provider the user believes
+// is the search provider. The set is DERIVED from SEARCH_PROVIDERS so adding a new search
+// provider without updating this guard fails the regression test automatically. Search
+// providers must be executed through /v1/search, never the chat-completions path.
+const CHAT_UNSUPPORTED_SEARCH_PROVIDERS = new Set(Object.keys(SEARCH_PROVIDERS));
+
 export function getExecutor(provider) {
   if (executors[provider]) return executors[provider];
   if (CHAT_UNSUPPORTED_CLOUD_AGENT_PROVIDERS.has(provider)) {
     const err = new Error(
       `Provider "${provider}" is a cloud-agent provider and does not support direct chat completions; use the Cloud Agents task API instead.`
+    );
+    (err as Error & { status?: number }).status = 400;
+    throw err;
+  }
+  if (CHAT_UNSUPPORTED_SEARCH_PROVIDERS.has(provider)) {
+    const err = new Error(
+      `Provider "${provider}" is a search provider and does not support chat completions; use the /v1/search endpoint instead.`
     );
     (err as Error & { status?: number }).status = 400;
     throw err;

--- a/tests/unit/search-providers-chat-guard.test.ts
+++ b/tests/unit/search-providers-chat-guard.test.ts
@@ -1,0 +1,55 @@
+// Probe for issue #10274 -- "Search providers (tavily/exa/firecrawl) leak API keys to
+// api.openai.com when used as chat/combo targets".
+//
+// Search-only providers (tavily-search, exa-search, firecrawl, serper-search, ...) exist
+// ONLY in SEARCH_PROVIDERS (open-sse/config/searchRegistry.ts) + the /v1/search catalog;
+// they have no chat REGISTRY entry and no specialized executor. Routing one of them as a
+// chat-completions target (e.g. a round-robin combo with targets "tavily-search/web")
+// therefore fell through to DefaultExecutor's `PROVIDERS[provider] || PROVIDERS.openai`
+// fallback, which forwarded the user's real search API key to https://api.openai.com
+// (observed as `[401] Incorrect API key provided: tvly-...` from OpenAI, not from Tavily).
+// This probe proves the executor-level root cause directly and pins the guard: getExecutor()
+// must throw a clear, sanitized 400 for every search provider instead of silently inheriting
+// OpenAI's base URL/config. The guard set is DERIVED from SEARCH_PROVIDERS so adding a new
+// search provider without updating the guard fails this test.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getExecutor, hasSpecializedExecutor } from "../../open-sse/executors/index.ts";
+import { SEARCH_PROVIDERS } from "../../open-sse/config/searchRegistry.ts";
+
+const SEARCH_PROVIDER_IDS = Object.keys(SEARCH_PROVIDERS);
+
+test("#10274: no search provider has a specialized chat executor", () => {
+  for (const id of SEARCH_PROVIDER_IDS) {
+    assert.equal(
+      hasSpecializedExecutor(id),
+      false,
+      `search provider '${id}' must not have a specialized chat executor`
+    );
+  }
+});
+
+test("#10274: a chat-completion request routed to a search provider must not silently hit OpenAI's endpoint", () => {
+  // Desired behavior: search providers (registered only in SEARCH_PROVIDERS, never in the
+  // chat REGISTRY) must not silently resolve to OpenAI's chat/completions endpoint when
+  // routed through the normal chat-completions executor path. getExecutor() must throw a
+  // clear, sanitized error for this set instead of falling through to DefaultExecutor's
+  // `PROVIDERS.openai` fallback (which produced the "Incorrect API key provided: tvly-..."
+  // OpenAI error the reporter saw for genuine Tavily/Exa/Firecrawl keys). Before the fix,
+  // getExecutor("tavily-search") returned a working executor whose buildUrl() resolved to
+  // OpenAI's endpoint -- this assertion FAILS on unfixed release/v3.8.50 code because no
+  // error is thrown at all.
+  for (const id of SEARCH_PROVIDER_IDS) {
+    assert.throws(
+      () => getExecutor(id),
+      (err) => {
+        assert.match(err.message, /search provider/i);
+        assert.match(err.message, /does not support chat completions/i);
+        assert.match(err.message, /\/v1\/search/i);
+        assert.equal(err.status, 400);
+        return true;
+      },
+      `search provider '${id}' must raise a clear error instead of inheriting OpenAI's base URL/config`
+    );
+  }
+});


### PR DESCRIPTION
## PR Description — Issue #10274

### 1. Problem
Search-only providers (`tavily-search`, `exa-search`, `firecrawl`, and 11 others) used as chat-completions targets (e.g. a round-robin combo with `tavily-search/web`) silently forwarded the user's real search API key to `https://api.openai.com/v1/chat/completions`, surfacing OpenAI's own `[401] Incorrect API key provided: tvly-...` error. Users believed they were talking to the search provider; their key was being sent to OpenAI instead.

### 2. Root cause
Search providers exist only in `SEARCH_PROVIDERS` (`open-sse/config/searchRegistry.ts`) and the `/v1/search` catalog — they have no chat `REGISTRY` entry and no specialized executor. `getExecutor()` in `open-sse/executors/index.ts` therefore fell through to `DefaultExecutor`'s `PROVIDERS[provider] || PROVIDERS.openai` fallback, which resolves the base URL/config to OpenAI's endpoint. Credentials were found in the chat path (same `getProviderSearchPool` lookup `/v1/search` uses), so the request was attempted — against the wrong host. Structural gap identical to the previously-fixed `jules` cloud-agent case (#6699).

### 3. Fix
`open-sse/executors/index.ts`: added `CHAT_UNSUPPORTED_SEARCH_PROVIDERS = new Set(Object.keys(SEARCH_PROVIDERS))` and a guard in `getExecutor()` that throws a sanitized status-400 error **before** the `DefaultExecutor` fallback — stating the provider is a search provider, does not support chat completions, and directing to `/v1/search`. The set is **derived** from `SEARCH_PROVIDERS`, so adding a new search provider without updating the guard fails the regression test automatically. Mirrors the `#6699` jules pattern.

### 4. Security impact
Search-provider API keys can no longer reach `api.openai.com`. The throw occurs before `DefaultExecutor` construction, so the `PROVIDERS.openai` fallback path is unreachable for all `SEARCH_PROVIDERS` ids. `/v1/search` uses its own dispatch (`open-sse/handlers/search.ts`) and never calls `getExecutor` — unaffected. Error is sanitized (no stack traces, per `docs/security/ERROR_SANITIZATION.md`).

### 5. Tests/verification
- **Focused regression (TDD)**: `tests/unit/search-providers-chat-guard.test.ts` — RED before fix (`Missing expected exception`), GREEN after; 2/2 PASS, covers all 14 search providers.
- **Targeted suites** exercising the `getExecutor` path: **386 tests PASS** (chatcore-executor-proxy, chatcore-target-format, blackbox/claude/chatgpt-web, adobe-firefly, combo-strategies, search-provider-validation, probe-6699, firecrawl, search-handler, route-edge-coverage, chat-helpers, 8200-perplexity-cooldown).
- `npm run test:vitest`: **PASS** (39 files / 357 tests).
- `npm run typecheck:core`: **PASS**. `npm run check:cycles`: **PASS**. Changed-file ESLint: **PASS** (exit 0).
- Runtime spot-check: `tavily-search`, `exa-search`, `firecrawl` → `status 400` with clear message.

### 6. Known pre-existing/environment blockers
- `combo-routing-e2e.test.ts`: **FAIL — PRE-EXISTING** (openai step-ordering assertion; reproduced identically on base `266e39d36`). Unrelated to search providers.
- Full `npm run lint`: **FAIL — PRE-EXISTING** (2 errors in untouched files — `@omniroute/opencode-plugin/src/index.ts` parse error, `tests/unit/cli-env-inline-comment-10100.test.ts` no-new-func; identical on base).
- Full `npm run test:unit`: **BLOCKED — ENVIRONMENT** — machine OOM-kills the run partway; no #10274-specific failure identified. Requires a CI-capable runner for the complete unit gate.
- No #10274-specific test regression identified.

**Scope**: commit `1c13badde` contains only `open-sse/executors/index.ts` (+19) and `tests/unit/search-providers-chat-guard.test.ts` (+55). `package-lock.json`, openrouter registry, freeModelCatalog, `/v1/search`, and database/migrations untouched. Shared checkout clean. `.sandbox/` (test artifact) untracked, not in commit.

Fixes #10274
