### PR TITLE
fix(cli): remove orphaned resolveOpencodeConfigDir re-export (base-red #9985)

### DIFF
--- a/changelog.d/fixes/basered-deadcode-opencode-config-dir.md
+++ b/changelog.d/fixes/basered-deadcode-opencode-config-dir.md
@@ -1,0 +1,1 @@
+- fix(cli): drop the orphaned `resolveOpencodeConfigDir` re-export from `cliRuntime` — it lost its last consumer in #10246 and diverged from the canonical resolver by one directory level (#9985)

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -9,10 +9,7 @@ import { withSettingsFallback } from "./cliInstallFallback";
 import { GROK_BUILD_RUNTIME_ENTRY, AMP_RUNTIME_ENTRY } from "./cliRuntimeGrokBuild";
 import { isLocationTrusted, findKnownPathMatch } from "./cliRuntimeKnownPath";
 import { buildHealthcheckPath } from "./cliRuntimeHealthcheckPath";
-import {
-  resolveOpencodeConfigDir as resolveOpenCodeConfigDir,
-  resolveOpencodeConfigPath as resolveOpenCodeConfigPath,
-} from "./opencodeConfigPath";
+import { resolveOpencodeConfigPath as resolveOpenCodeConfigPath } from "./opencodeConfigPath";
 const VALID_RUNTIME_MODES = new Set(["auto", "host", "container"]);
 const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
 
@@ -971,19 +968,6 @@ export const getCliConfigHome = () => {
   }
 
   return normalized;
-};
-
-export const resolveOpencodeConfigDir = (
-  _platform = process.platform,
-  env: NodeJS.ProcessEnv = process.env,
-  homeDir = os.homedir()
-) => {
-  // #3330: OpenCode reads its config from XDG `~/.config/opencode/` on ALL
-  // platforms — including Windows, where it uses `%USERPROFILE%\.config`, NOT
-  // `%APPDATA%`. Writing to %APPDATA% on Windows put the file where OpenCode
-  // never looks, so dashboard-saved config silently had no effect. `_platform`
-  // is kept in the signature for call-site/test compatibility.
-  return path.dirname(resolveOpenCodeConfigDir(env, homeDir));
 };
 
 export const resolveOpencodeConfigPath = (

--- a/tests/unit/opencode-config-dir-single-source.test.ts
+++ b/tests/unit/opencode-config-dir-single-source.test.ts
@@ -1,0 +1,57 @@
+// Regression guard for the #10246 follow-up: `resolveOpencodeConfigDir` has exactly ONE
+// implementation, in `src/shared/services/opencodeConfigPath.ts`.
+//
+// #10246 moved the canonical resolvers into `opencodeConfigPath.ts` and left a thin wrapper
+// `resolveOpencodeConfigDir` behind in `cliRuntime.ts`. That wrapper lost its last consumer in
+// the same commit and became a dead export — which is what pushed the `check:dead-code` ratchet
+// to 410 (baseline 409) and made every PR on `release/v3.8.50` born red on that gate.
+//
+// Worse than the ratchet: the wrapper returned `path.dirname()` of the canonical value, i.e.
+// `~/.config` instead of `~/.config/opencode`. Two same-named exports with DIFFERENT return
+// values is a live foot-gun — a future caller importing from `cliRuntime` instead of
+// `opencodeConfigPath` would silently write the OpenCode config one directory too high.
+//
+// This test pins both halves: the canonical resolver's contract, and the absence of the
+// divergent re-export.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { resolveOpencodeConfigDir } from "@/shared/services/opencodeConfigPath";
+import * as cliRuntime from "@/shared/services/cliRuntime";
+
+test("#10246 canonical resolveOpencodeConfigDir returns the XDG opencode directory", () => {
+  assert.equal(
+    resolveOpencodeConfigDir({ XDG_CONFIG_HOME: "/xdg" }, "/home/u"),
+    path.join("/xdg", "opencode")
+  );
+  // No XDG_CONFIG_HOME → `<home>/.config/opencode` on every platform (#3330: OpenCode reads
+  // XDG even on Windows, where it uses %USERPROFILE%\.config and never %APPDATA%).
+  assert.equal(
+    resolveOpencodeConfigDir({}, "/home/u"),
+    path.join("/home/u", ".config", "opencode")
+  );
+  // A blank/whitespace XDG_CONFIG_HOME must fall back, not produce a relative path.
+  assert.equal(
+    resolveOpencodeConfigDir({ XDG_CONFIG_HOME: "   " }, "/home/u"),
+    path.join("/home/u", ".config", "opencode")
+  );
+});
+
+test("#10246 cliRuntime does NOT re-export a divergent resolveOpencodeConfigDir", () => {
+  assert.equal(
+    (cliRuntime as Record<string, unknown>).resolveOpencodeConfigDir,
+    undefined,
+    "cliRuntime must not re-export resolveOpencodeConfigDir — the wrapper returned the PARENT " +
+      "directory (path.dirname of the canonical value), so importing it by name would write the " +
+      "OpenCode config one level too high. Import it from opencodeConfigPath instead."
+  );
+});
+
+test("#10246 cliRuntime still exposes the config PATH helpers it owns", () => {
+  // The path helpers legitimately stay on cliRuntime (they have live consumers) — this guard
+  // must not be read as "cliRuntime should stop exporting OpenCode helpers entirely".
+  assert.equal(typeof cliRuntime.resolveOpencodeConfigPath, "function");
+  assert.equal(typeof cliRuntime.getOpenCodeConfigPath, "function");
+});


### PR DESCRIPTION
Refs #9985

## The base is red and every PR inherits it

`check:dead-code` reports **410 dead symbols against a 409 baseline on the pristine
`release/v3.8.50` tip** — no PR content involved. Confirmed by running the gate on a clean
`origin/release/v3.8.50` checkout with a fresh `npm ci`:

```
DEAD_EXPORTS=332
DEAD_FILES=78
DEAD_TOTAL=410
[dead-code] REGRESSÃO — 410 símbolos mortos > baseline 409
```

Every open PR on the branch fails this gate today: #10386, #10393, #10390, #10388, #10382.

## Isolating the +1

Diffed the knip 6.32 JSON reports between the commit where the 409 baseline was measured
(`97aac6ac6c`, #10260) and the current tip:

```
=== dead only at the tip ===
  + src/shared/services/cliRuntime.ts::exports::resolveOpencodeConfigDir
=== disappeared ===
  (none)
```

Exactly one symbol. `git log -S` pins the orphaning commit: `ed48328c7c` — **#10246**, which
moved the canonical resolvers into `src/shared/services/opencodeConfigPath.ts` and left a thin
wrapper behind in `cliRuntime.ts`, removing its last consumer in the same change. An exhaustive
sweep (including dynamic string access) confirms zero consumers anywhere in the repo.

> ⚠️ Measuring this locally requires **knip 6.32**. A stale `node_modules` on 6.27 reports 170
> dead exports instead of 332 and the gate reads green — the 6.27→6.32 bump (#10043) is exactly
> what the 248→409 rebaseline note in `quality-baseline.json` describes.

## Why removal, not a rebaseline

The metric **regressed**, so the ratchet policy calls for removing the dead export, not raising
the bar. And the wrapper was not merely unused — it was **divergent**:

```ts
// cliRuntime.ts (removed)
return path.dirname(resolveOpenCodeConfigDir(env, homeDir));   // → ~/.config
// opencodeConfigPath.ts (canonical, kept)
return path.join(xdgConfigHome || path.join(homeDir, ".config"), "opencode");   // → ~/.config/opencode
```

Two same-named exports returning values one directory apart is a live foot-gun: a future caller
importing from `cliRuntime` instead of `opencodeConfigPath` would silently write the OpenCode
config to `~/.config/opencode.json` instead of `~/.config/opencode/opencode.json`.

## Validation

New guard `tests/unit/opencode-config-dir-single-source.test.ts` pins the canonical resolver's
contract (XDG set, XDG unset, XDG blank) and asserts the divergent re-export stays gone.
**Mutation-validated** — re-adding the wrapper flips it red:

```
--- wrapper reintroduced ---   ℹ pass 2   ℹ fail 1
--- restored ---               ℹ pass 3   ℹ fail 0
```

```
check:dead-code            → DEAD_TOTAL=409, OK — 409 símbolos mortos (baseline 409)
cliRuntime/opencode suites → 51 pass, 0 fail (10 files)
new guard                  → 3 pass, 0 fail
lint / typecheck:core      → exit 0
file-size / complexity-ratchets / test-discovery → green
```

No baseline file is touched.