### PR TITLE
fix(providers): refresh the translate-path golden for the bailian Token Plan endpoint

### DIFF
--- a/docs/providers/ALIBABA-QWEN-PROVIDER-FAMILIES.md
+++ b/docs/providers/ALIBABA-QWEN-PROVIDER-FAMILIES.md
@@ -32,7 +32,7 @@ different endpoint families, so all four products remain separate provider IDs.
 | Provider family         | `global-sg`                                                              | `china-beijing`                                                      | Wire format |
 | ----------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------- | ----------- |
 | `alibaba`               | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`                 | `https://dashscope.aliyuncs.com/compatible-mode/v1`                  | OpenAI      |
-| `bailian-coding-plan`   | `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1`           | `https://coding.dashscope.aliyuncs.com/apps/anthropic/v1`            | Anthropic   |
+| `bailian-coding-plan`   | `https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1` | `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic/v1`  | Anthropic   |
 | `qwen-cloud`            | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`                 | `https://dashscope.aliyuncs.com/compatible-mode/v1`                  | OpenAI      |
 | `qwen-cloud-token-plan` | `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | OpenAI      |
 

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -565,8 +565,8 @@
       }
     },
     "url": {
-      "nonStream": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
-      "stream": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1"
+      "nonStream": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1",
+      "stream": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1"
     }
   },
   "baseten": {


### PR DESCRIPTION
## Problema (base vermelha)

O #10290 trocou o `bailian-coding-plan` do host do Coding Plan para o do Token Plan (documentado), mas o golden `tests/snapshots/provider/translate-path.json` ainda fixava `coding-intl.dashscope.aliyuncs.com` — então `tests/unit/provider-translate-path-golden.test.ts` falha no tip da release (shard `Unit Tests fast-path (4/4)`).

Assumo o erro: mergeei o #10290 antes do CI fechar, a pedido, e esse golden só roda no shard de unit — nem os testes focados nem o typecheck o executam. Por isso a regressão passou.

## Fix

- Golden regenerado com `UPDATE_GOLDEN=1`. **Diff auditado**: exatamente as 2 linhas do `bailian-coding-plan` (nonStream/stream); todos os demais providers byte-idênticos.
- `docs/providers/ALIBABA-QWEN-PROVIDER-FAMILIES.md`: a matriz de endpoints também apontava o host antigo — atualizada para `token-plan.{ap-southeast-1,cn-beijing}.maas.aliyuncs.com/apps/anthropic/v1`.

## Validação

- `provider-translate-path-golden`: RED no tip → **3/3 GREEN** após regenerar.
- `check:docs-all` executado sobre a doc alterada.

Refs #9603