### PR TITLE
fix(sse): buffer '<think' partial so split open tags don't leak into content

### DIFF
--- a/open-sse/utils/thinkTagParser.ts
+++ b/open-sse/utils/thinkTagParser.ts
@@ -22,6 +22,15 @@ const THINK_OPEN = "<think>";
 const THINK_CLOSE = "</think>";
 
 /**
+ * Every proper prefix of `<think>` ("<", "<t", ... "<think"), derived from the
+ * tag itself so the list cannot drift out of sync with it.
+ */
+const THINK_OPEN_PARTIALS: readonly string[] = Array.from(
+  { length: THINK_OPEN.length - 1 },
+  (_, i) => THINK_OPEN.slice(0, i + 1)
+);
+
+/**
  * Create the mutable streaming-parse context for one SSE stream.
  * `enabled` decides whether the caller should attempt think-tag parsing at
  * all for this stream (passthrough mode + a provider/model that is known to
@@ -52,10 +61,7 @@ export function initThinkState(isPassthroughMode: boolean, provider?: unknown, m
  * @returns {boolean}
  */
 export function containsOrMayEndWithThinkOpenTag(value: string): boolean {
-  return (
-    value.includes(THINK_OPEN) ||
-    ["<", "<t", "<th", "<thi", "<thin"].some((suffix) => value.endsWith(suffix))
-  );
+  return value.includes(THINK_OPEN) || THINK_OPEN_PARTIALS.some((suffix) => value.endsWith(suffix));
 }
 
 /**

--- a/tests/unit/think-tag-parser.test.ts
+++ b/tests/unit/think-tag-parser.test.ts
@@ -1,8 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { hasThinkTags, extractThinkTags, processStreamingThinkDelta, flushThinkBuffer } =
-  await import("../../open-sse/utils/thinkTagParser.ts");
+const {
+  hasThinkTags,
+  extractThinkTags,
+  processStreamingThinkDelta,
+  flushThinkBuffer,
+  containsOrMayEndWithThinkOpenTag,
+  applyThinkTag,
+} = await import("../../open-sse/utils/thinkTagParser.ts");
 
 test("hasThinkTags detects opening tags and ignores empty input", () => {
   assert.equal(hasThinkTags("before <think>plan</think> after"), true);
@@ -57,6 +63,33 @@ test("processStreamingThinkDelta extracts content and reasoning across split tag
   assert.deepEqual(flushed, {
     reasoningDelta: null,
     contentDelta: " world",
+  });
+});
+
+test("containsOrMayEndWithThinkOpenTag flags a chunk ending on any partial open tag", () => {
+  for (const partial of ["<", "<t", "<th", "<thi", "<thin", "<think"]) {
+    assert.equal(containsOrMayEndWithThinkOpenTag(`answer ${partial}`), true, partial);
+  }
+  assert.equal(containsOrMayEndWithThinkOpenTag("plain answer"), false);
+});
+
+test("applyThinkTag buffers an open tag split as '<think' + '>' across deltas", () => {
+  const ctx = { enabled: true, active: false, insideThink: false, buffer: "" };
+
+  const opening: { content: unknown; reasoning_content?: string } = { content: "<think" };
+  assert.equal(applyThinkTag(ctx, opening), true);
+  assert.equal(opening.content, "");
+
+  const rest: { content: unknown; reasoning_content?: string } = {
+    content: ">plan</think>answer",
+  };
+  assert.equal(applyThinkTag(ctx, rest), true);
+  assert.equal(rest.reasoning_content, "plan");
+  assert.equal(rest.content, "");
+
+  assert.deepEqual(flushThinkBuffer(ctx), {
+    reasoningDelta: null,
+    contentDelta: "answer",
   });
 });
 


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

Fixes an SSE streaming bug where an open `<think` tag split across two deltas could leak into assistant content instead of being parsed as reasoning.

The fix makes the parser derive all valid partial prefixes directly from `THINK_OPEN`, including `<think`.

## Tests

- think-tag parser tests: 8/8 pass
- 12 related think-tag/stream suites: 159/159 pass
- typecheck: clean
- ESLint: clean
- pre-commit gates: pass

## Related Issues

Related to #723.

No migrations, feature flags, or configuration changes.