### PR TITLE
fix(dashboard): media mini-playgrounds send masked API key as Bearer (401 under REQUIRE_API_KEY)

### DIFF
--- a/changelog.d/fixes/9935-media-playground-masked-bearer.md
+++ b/changelog.d/fixes/9935-media-playground-masked-bearer.md
@@ -1,0 +1,1 @@
+- fix(dashboard): media mini-playgrounds authenticate via session instead of sending the masked API key as Bearer, fixing 401s under REQUIRE_API_KEY (#9935)

--- a/src/app/(dashboard)/dashboard/media-providers/components/EmbeddingExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/EmbeddingExampleCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -24,7 +25,7 @@ function extractError(data: unknown): string | null {
 
 export function EmbeddingExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
 
   const firstModel = models[0]?.id ?? "";
@@ -43,7 +44,7 @@ export function EmbeddingExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -55,13 +56,18 @@ export function EmbeddingExampleCard({ providerId }: Props) {
     setResult(undefined);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/media-providers/components/ImageExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/ImageExampleCard.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface SuggestedHfModel {
@@ -101,7 +102,7 @@ function ImageResultRenderer(data: unknown, altText: string) {
 export function ImageExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
   const tMedia = useTranslations("media");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
   const suggestedModels = useHfSuggestedImageModels(providerId);
 
@@ -121,7 +122,7 @@ export function ImageExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -133,13 +134,18 @@ export function ImageExampleCard({ providerId }: Props) {
     setResult(undefined);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/media-providers/components/MusicExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/MusicExampleCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -24,7 +25,7 @@ function extractError(data: unknown): string | null {
 
 export function MusicExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
 
   const firstModel = models[0]?.id ?? "";
@@ -45,7 +46,7 @@ export function MusicExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -58,13 +59,18 @@ export function MusicExampleCard({ providerId }: Props) {
     setAudioUrl(null);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const elapsed = performance.now() - t0;

--- a/src/app/(dashboard)/dashboard/media-providers/components/OcrExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/OcrExampleCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -25,7 +26,7 @@ function extractError(data: unknown): string | null {
 
 export function OcrExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
 
   const firstModel = models[0]?.id ?? "";
@@ -47,7 +48,7 @@ export function OcrExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -59,13 +60,18 @@ export function OcrExampleCard({ providerId }: Props) {
     setResult(undefined);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/media-providers/components/SttExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/SttExampleCard.tsx
@@ -6,6 +6,7 @@ import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { PlaygroundCard } from "./PlaygroundCard";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 
 interface Props {
   providerId: string;
@@ -39,7 +40,7 @@ function SttResultRenderer(data: unknown) {
 
 export function SttExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
 
   // Show only speech-to-text models. Providers like OpenRouter expose a large
@@ -72,7 +73,7 @@ export function SttExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
     },
     body: {
       model: qualify(effectiveModel),
@@ -105,12 +106,15 @@ export function SttExampleCard({ providerId }: Props) {
       formData.append("model", qualify(effectiveModel));
       formData.append("file", file);
 
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = { "x-connection-id": providerId };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: formData,
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/media-providers/components/TtsExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/TtsExampleCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -26,7 +27,7 @@ function extractError(data: unknown): string | null {
 
 export function TtsExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
 
   const firstModel = models[0]?.id ?? "tts-1";
@@ -54,7 +55,7 @@ export function TtsExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -69,13 +70,18 @@ export function TtsExampleCard({ providerId }: Props) {
     }
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const elapsed = performance.now() - t0;

--- a/src/app/(dashboard)/dashboard/media-providers/components/VideoExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/VideoExampleCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { useProviderModels } from "../../providers/hooks/useProviderModels";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -48,7 +49,7 @@ function VideoResultRenderer(data: unknown, unsupportedText: string) {
 
 export function VideoExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
 
   const firstModel = models[0]?.id ?? "";
@@ -66,7 +67,7 @@ export function VideoExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -78,13 +79,18 @@ export function VideoExampleCard({ providerId }: Props) {
     setResult(undefined);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/media-providers/components/WebFetchExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/WebFetchExampleCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -34,7 +35,7 @@ function extractError(data: unknown): string | null {
 
 export function WebFetchExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
 
   const [url, setUrl] = useState<string>("https://example.com");
   const [format, setFormat] = useState<FetchFormat>("markdown");
@@ -50,7 +51,7 @@ export function WebFetchExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -62,13 +63,18 @@ export function WebFetchExampleCard({ providerId }: Props) {
     setResult(undefined);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/media-providers/components/WebSearchExampleCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/WebSearchExampleCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { useApiKey } from "../../providers/hooks/useApiKey";
 import { buildCurl } from "../../providers/utils/buildCurl";
+import { PLAYGROUND_KEY_ID_HEADER, resolvePlaygroundKeyId } from "../../providers/utils/playgroundAuth";
 import { PlaygroundCard } from "./PlaygroundCard";
 
 interface Props {
@@ -64,7 +65,7 @@ function SearchResultRenderer(data: unknown, fallbackTitle: (number: number) => 
 
 export function WebSearchExampleCard({ providerId }: Props) {
   const t = useTranslations("miniPlayground");
-  const { apiKey } = useApiKey();
+  const { apiKey, keys } = useApiKey();
 
   const [query, setQuery] = useState<string>(() => t("webSearchSample"));
   const [numResults, setNumResults] = useState<number>(5);
@@ -79,7 +80,7 @@ export function WebSearchExampleCard({ providerId }: Props) {
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:20128") +
       ENDPOINT_PATH,
     headers: {
-      Authorization: `Bearer ${apiKey || "<your-api-key>"}`,
+      Authorization: "Bearer <your-api-key>",
       "Content-Type": "application/json",
     },
     body: buildBody(),
@@ -91,13 +92,18 @@ export function WebSearchExampleCard({ providerId }: Props) {
     setResult(undefined);
     const t0 = performance.now();
     try {
+      // Authenticate via the dashboard session cookie — never send the masked
+      // apiKey as a Bearer token (it is not a real credential; see #9935).
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-connection-id": providerId,
+      };
+      const playgroundKeyId = resolvePlaygroundKeyId(apiKey, keys);
+      if (playgroundKeyId) headers[PLAYGROUND_KEY_ID_HEADER] = playgroundKeyId;
       const res = await fetch(ENDPOINT_PATH, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "x-connection-id": providerId,
-        },
+        credentials: "same-origin",
+        headers,
         body: JSON.stringify(buildBody()),
       });
       const data: unknown = await res.json();

--- a/src/app/(dashboard)/dashboard/providers/utils/playgroundAuth.ts
+++ b/src/app/(dashboard)/dashboard/providers/utils/playgroundAuth.ts
@@ -1,0 +1,34 @@
+/**
+ * playgroundAuth — shared helpers so the dashboard mini-playgrounds authenticate
+ * upstream requests via the dashboard session instead of a raw Bearer token.
+ *
+ * `/api/keys` only ever exposes MASKED key values (sk-xxxx****yyyy — see
+ * `maskStoredApiKey` in `src/lib/apiKeyExposure.ts`). Sending that masked
+ * string as `Authorization: Bearer` is never a valid credential and 401s
+ * under `REQUIRE_API_KEY` (#9935). The fix mirrors `LlmChatCard.tsx` (#3503):
+ * requests go out with `credentials: "same-origin"` and no Bearer header: the
+ * gateway falls through to the dashboard session. When a specific key is
+ * selected we forward only its id via `PLAYGROUND_KEY_ID_HEADER` so the
+ * gateway can still apply that key's policy (allowed_models, etc.)
+ * server-side — the secret itself never reaches the browser.
+ */
+
+/** Header used to test a specific API key's policy from the dashboard playground
+ *  without exposing the key secret to the browser — the gateway resolves the key
+ *  by id server-side (see enforceApiKeyPolicy). */
+export const PLAYGROUND_KEY_ID_HEADER = "x-omniroute-playground-key-id";
+
+/**
+ * Map the playground's masked key selection (sk-xxxx****yyyy, as returned by
+ * `/api/keys`) back to its key id. The id — never the secret — is sent to the
+ * gateway so it can apply that key's policy (allowed_models, etc.) server-side.
+ * Returns null when there is no match, which falls through to the dashboard
+ * session (full access, any model).
+ */
+export function resolvePlaygroundKeyId(
+  selectedMaskedKey: string,
+  keys: { id: string; key: string }[]
+): string | null {
+  if (!selectedMaskedKey) return null;
+  return keys.find((k) => k.key === selectedMaskedKey)?.id ?? null;
+}

--- a/tests/unit/bug-9935-masked-bearer.test.ts
+++ b/tests/unit/bug-9935-masked-bearer.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { maskStoredApiKey } from "../../src/lib/apiKeyExposure";
+
+const COMPONENT_DIR = resolve("src/app/(dashboard)/dashboard/media-providers/components");
+const EXAMPLE_CARDS = [
+  "WebSearchExampleCard.tsx",
+  "WebFetchExampleCard.tsx",
+  "ImageExampleCard.tsx",
+  "TtsExampleCard.tsx",
+  "SttExampleCard.tsx",
+  "OcrExampleCard.tsx",
+  "MusicExampleCard.tsx",
+  "EmbeddingExampleCard.tsx",
+  "VideoExampleCard.tsx",
+];
+const FIXED_REFERENCE = "LlmChatCard.tsx";
+const MASKED_BEARER = /\bBearer\s*\$?\{?\s*apiKey/;
+
+test("every media ExampleCard avoids sending a masked apiKey as Bearer (#9935)", () => {
+  for (const file of [...EXAMPLE_CARDS, FIXED_REFERENCE]) {
+    const src = readFileSync(resolve(COMPONENT_DIR, file), "utf8");
+    assert.ok(
+      !MASKED_BEARER.test(src),
+      `${file} still sends the (masked) apiKey as an Authorization: Bearer token — will 401 under REQUIRE_API_KEY`
+    );
+  }
+});
+
+test("masked value is never a real API key (repro of the 401 trigger)", () => {
+  const real = "sk-abcdef0123456789wxyz";
+  const masked = maskStoredApiKey(real);
+  assert.notEqual(masked, real);
+});


### PR DESCRIPTION
Refs #9935

## Root cause

`useApiKey()` (`src/app/(dashboard)/dashboard/providers/hooks/useApiKey.ts`) fetches gateway
keys from `GET /api/keys`, which returns the **masked** value
(`maskStoredApiKey()` → `sk-xxxx****yyyy`, `src/lib/apiKeyExposure.ts`). The 9 media
mini-playground `*ExampleCard` components under
`src/app/(dashboard)/dashboard/media-providers/components/` sent that masked string as a real
`Authorization: Bearer` header on Run. A masked string is never a valid credential, so the
gateway returns `AUTH_002 Invalid API key` under `REQUIRE_API_KEY=true` — and because a Bearer
header is present, the request never falls through to dashboard session auth.

`LlmChatCard.tsx` (#3503) already got this right: authenticate via the dashboard session
(`credentials: "same-origin"`, no Bearer) and, when a specific key is selected, forward only
its id via `x-omniroute-playground-key-id` so the gateway applies that key's policy
server-side without the secret touching the wire.

## Fix

Mirror the `LlmChatCard` pattern in all 9 affected cards (WebSearch, WebFetch, Image, TTS,
STT, OCR, Music, Embedding, Video):

- Drop the `Authorization: Bearer ${apiKey}` header from the `fetch()` call; add
  `credentials: "same-origin"` so the dashboard session cookie authenticates the request.
- Add a shared helper, `resolvePlaygroundKeyId()` /
  `PLAYGROUND_KEY_ID_HEADER` in
  `src/app/(dashboard)/dashboard/providers/utils/playgroundAuth.ts` (mirrors the private
  helper already inlined in `LlmChatCard.tsx`), and send
  `x-omniroute-playground-key-id: <id>` when a specific key is selected.
- Update the `buildCurl` snippet in each card to show `Authorization: Bearer <your-api-key>`
  (a placeholder) instead of the masked value.

## Regression test

`tests/unit/bug-9935-masked-bearer.test.ts` — asserts none of the 9 `*ExampleCard` components
(nor the reference `LlmChatCard.tsx`) embed `apiKey` in a raw `Authorization: Bearer` header.

```
node --import tsx/esm --test tests/unit/bug-9935-masked-bearer.test.ts
✔ every media ExampleCard avoids sending a masked apiKey as Bearer (#9935)
✔ masked value is never a real API key (repro of the 401 trigger)
ℹ pass 2, fail 0
```

Fail→pass evidence: on the unfixed tree (`git show origin/release/v3.8.50:...`) the
`WebSearchExampleCard.tsx` (and the other 8 cards) still contain
`` Authorization: `Bearer ${apiKey}` `` — the regression test's `MASKED_BEARER` regex matches
and the test fails RED; after the fix it is green.

## Gates run

- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-file-size.mjs` — no new violations on touched files
- `node scripts/check/check-complexity.mjs` — OK (2456 vs baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1104 vs baseline 1223)
- `node scripts/check/check-test-discovery.mjs` — OK, new test discovered
- `npm run test:unit` — started locally; the shared devbox is running many concurrent
  full-suite jobs from parallel sessions and the run did not finish within this session's
  window (progressing normally, no failures observed in the portion that completed). This
  PR's change is frontend-only (9 React components + one pure TS helper, no DB/server code),
  so CI's `test-unit` job is the authoritative full-suite gate here.

## Scope

Touched only the 9 `*ExampleCard` components, the new shared
`src/app/(dashboard)/dashboard/providers/utils/playgroundAuth.ts` helper, and the regression
test. No changes to `LlmChatCard.tsx` (already correct) or `buildCurl.ts` (generic
string-builder, unaffected).

⚠️ base-red inherited: #9985 — ESLint errors (2) from #10250 (unrelated i18n PT-PT commit on
the release tip; not touched by this PR).

Note: issue #9935 shows as already CLOSED on GitHub (closed 2026-08-14, no linked PR/commit),
but the bug is still present in `origin/release/v3.8.50` HEAD — verified via
`git show origin/release/v3.8.50:.../WebSearchExampleCard.tsx`, which still sends the masked
key as Bearer. This PR lands the actual fix regardless of the issue's closed state.
