### PR TITLE
fix(sse): mark gemini-3.5-flash as thinking-capable

### DIFF
--- a/changelog.d/fixes/10286-gemini-3-5-flash-thinking.md
+++ b/changelog.d/fixes/10286-gemini-3-5-flash-thinking.md
@@ -1,0 +1,1 @@
+- fix(sse): mark gemini-3.5-flash as thinking-capable so reasoning_effort is no longer rejected with a spurious 400 (#10286)

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -226,8 +226,16 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
   },
 
   // ── Gemini 3.5 Flash ─────────────────────────────────────────────
+  // #10286: the base Google AI Studio model DOES support reasoning (it has
+  // an effort-tier alias gemini-3.5-flash-high) — override the shared spec's
+  // supportsThinking:false here only. Do NOT flip GEMINI_35_FLASH_MODEL_SPEC
+  // itself: it is also spread into the Antigravity flash-tier aliases
+  // (gemini-3.5-flash-low/-extra-low, gemini-3-flash-agent, gemini-3.6-flash-*)
+  // which reject client-supplied thinking params because the model id itself
+  // selects the reasoning tier upstream.
   "gemini-3.5-flash": {
     ...GEMINI_35_FLASH_MODEL_SPEC,
+    supportsThinking: true,
     aliases: ["gemini-3.5-flash-high"],
   },
 

--- a/tests/unit/gemini-3-5-flash-thinking.test.ts
+++ b/tests/unit/gemini-3-5-flash-thinking.test.ts
@@ -1,0 +1,76 @@
+// Regression test for #10286: gemini-3.5-flash was incorrectly marked
+// supportsThinking:false, causing a spurious pre-provider HTTP 400 for any
+// request with reasoning_effort set, even though the base Google AI Studio
+// model supports reasoning (it has an effort-tier alias gemini-3.5-flash-high).
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-repro-10286-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "test-repro-10286-secret";
+
+const caps = await import("../../src/lib/modelCapabilities.ts");
+const core = await import("../../src/lib/db/core.ts");
+const rulesDb = await import("../../src/lib/db/reasoningRoutingRules.ts");
+const policy = await import("../../src/lib/reasoningRouting/policy.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  rulesDb.invalidateReasoningRoutingRuleCache();
+}
+
+function ruleInput(patch: Record<string, unknown> = {}) {
+  return {
+    name: "Enable thinking on gemini-3.5-flash",
+    description: "",
+    scope: "global",
+    apiKeyId: null,
+    comboId: null,
+    connectionId: null,
+    modelPattern: "gemini-3.5-flash",
+    sourceEffort: "any",
+    requestTags: [],
+    tagMatchMode: "any",
+    effortMode: "inherit",
+    targetEffort: null,
+    targetKind: "keep",
+    targetModel: null,
+    targetComboId: null,
+    budgetAction: "preserve",
+    budgetTokens: null,
+    priority: 0,
+    enabled: true,
+    ...patch,
+  };
+}
+
+test.beforeEach(resetStorage);
+test.after(async () => {
+  await resetStorage();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("gemini-3.5-flash (AI Studio provider) resolves as thinking-capable", () => {
+  const resolved = caps.getResolvedModelCapabilities({
+    provider: "gemini",
+    model: "gemini-3.5-flash",
+  });
+  assert.equal(resolved.supportsThinking, true);
+});
+
+test("reasoning_effort 'high' on gemini-3.5-flash is NOT rejected by routing policy", async () => {
+  await rulesDb.createReasoningRoutingRule(ruleInput());
+  const decision = await policy.resolveReasoningRoutingRule({
+    sourceModel: "gemini/gemini-3.5-flash",
+    sourceModelAliases: ["gemini-3.5-flash"],
+    sourceEffort: "high",
+    hasReasoningSignal: true,
+  });
+  assert.ok(decision, "a matching rule must produce a decision");
+  assert.equal(decision.capability, "supported");
+});


### PR DESCRIPTION
Closes #10286

## Root cause

`src/shared/constants/modelSpecs.ts` declares the shared `GEMINI_35_FLASH_MODEL_SPEC`
constant with `supportsThinking: false`. The base `"gemini-3.5-flash"` entry spreads
that spec, so `getResolvedModelCapabilities()` reports the base Google AI Studio model
as thinking-incapable, which makes `capabilityFor()`
(`src/lib/reasoningRouting/policy.ts`) resolve to `"unsupported"` for any
`reasoning_effort`, and `applyDecision()` (`src/sse/handlers/reasoningRouting.ts`)
turns that into a pre-provider HTTP 400 — even though the base model supports
reasoning (it has an effort-tier alias `gemini-3.5-flash-high`, and the reporter
independently verified flipping the flag to `true` works end-to-end).

The same shared `GEMINI_35_FLASH_MODEL_SPEC` constant is also spread into several
Antigravity flash-tier aliases (`gemini-3.5-flash-low`, `gemini-3.5-flash-extra-low`,
`gemini-3-flash-agent`, `gemini-3.6-flash-*`), and those tier ids are documented as
rejecting client-supplied thinking params (the model id itself selects the reasoning
tier upstream). So the fix does **not** flip the shared constant — it sets
`supportsThinking: true` as an explicit override on the base `"gemini-3.5-flash"`
entry only, leaving `GEMINI_35_FLASH_MODEL_SPEC` and all the Antigravity tier aliases
unchanged (still `false`).

## Fix

`src/shared/constants/modelSpecs.ts`: added `supportsThinking: true` override on the
base `"gemini-3.5-flash"` entry (after the `...GEMINI_35_FLASH_MODEL_SPEC` spread).

## Regression test

`tests/unit/gemini-3-5-flash-thinking.test.ts` — TDD, fails on unfixed code
(`AssertionError: false !== true` / decision.capability `'unsupported'` vs
`'supported'`), passes after the fix:

```
✔ gemini-3.5-flash (AI Studio provider) resolves as thinking-capable
✔ reasoning_effort 'high' on gemini-3.5-flash is NOT rejected by routing policy
```

Asserts both:
1. `getResolvedModelCapabilities({provider:"gemini", model:"gemini-3.5-flash"}).supportsThinking === true`
2. reasoning-routing policy resolves `reasoning_effort:"high"` on `gemini-3.5-flash` to
   capability `"supported"` (not the pre-provider 400).

## Gates run

- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `node scripts/check/check-file-size.mjs` — no new violation on `modelSpecs.ts`
- `node scripts/check/check-complexity.mjs` — OK (2456 violations, baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1104 violations, baseline 1223)
- `node scripts/check/check-test-discovery.mjs` — OK, new test file discovered
- `npm run test:unit` — started full suite; 614/4565 test files completed with 0
  failures before the run stalled to near-zero throughput under severe 13-way
  parallel devbox contention (13 concurrent fan-out agents running the identical
  full suite on shared hardware — not specific to this change). No regression
  signal in the portion that ran. CI runs on isolated runners and is the
  authoritative full-suite gate for this PR.

⚠️ base-red inherited: #9985 — ESLint errors (2) from #10250
