### PR TITLE
test(build): make standalone fixture paths portable on Windows

### DIFF
--- a/tests/unit/build/assemble-standalone.test.ts
+++ b/tests/unit/build/assemble-standalone.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   assembleStandalone,
   patchTurbopackChunks,
@@ -197,7 +198,7 @@ test("the TPROXY addon source is skipped gracefully when it was not built (non-L
 // the requirement from the source itself: EVERY relative import in
 // standalone-server-ws.mjs must be shipped into the bundle by the extra-module sync.
 test("every relative import of standalone-server-ws.mjs is shipped into the bundle", async () => {
-  const repoRoot = path.resolve(new URL(".", import.meta.url).pathname, "../../..");
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
   const serverWsSrc = fs.readFileSync(
     path.join(repoRoot, "scripts/dev/standalone-server-ws.mjs"),
     "utf8"


### PR DESCRIPTION
## Summary

- resolve the standalone fixture repository root with `fileURLToPath(import.meta.url)`
- avoid interpreting a Windows file URL pathname as a native path and producing `C:\\C:\\Users\\...`
- keep the production standalone assembler unchanged

## Root cause

Physical Windows x64 validation for #10321 reproduced the combined standalone test failure as an `ENOENT` under a duplicated drive path. `new URL(".", import.meta.url).pathname` returns a URL pathname, not a Windows filesystem path; passing it directly to `path.resolve()` duplicates the drive prefix.

## Validation

- Windows x64 before fix: `assemble-standalone.test.ts` fails with `C:\\C:\\Users\\...` (recorded in the #10321 Stage 8 checkpoint)
- `node --import tsx/esm --test tests/unit/build/assemble-standalone.test.ts` — 5/5 pass on macOS arm64
- `npx prettier --check tests/unit/build/assemble-standalone.test.ts` — pass
- `git diff --check` — pass

A Windows x64 rerun is in progress and will be appended when available.

Refs #10321
