### PR TITLE
fix(ci): clean up Windows packaged smoke process trees

### DIFF
--- a/scripts/dev/smoke-electron-packaged.mjs
+++ b/scripts/dev/smoke-electron-packaged.mjs
@@ -255,20 +255,33 @@ async function signalProcessTree(child, signal) {
   }
 }
 
-async function stopApp(child) {
+export async function stopApp(
+  child,
+  {
+    currentPlatform = platform(),
+    signalProcessTreeFn = signalProcessTree,
+    waitForProcessTreeExitFn = waitForProcessTreeExit,
+  } = {}
+) {
   if (!child.pid) return;
 
-  await signalProcessTree(child, "SIGTERM");
-  await waitForProcessTreeExit(child, 5_000);
+  // On Windows, terminating only the direct Electron process can orphan the
+  // packaged server when the parent exits before the follow-up liveness check.
+  // Kill the process tree in one operation while the root PID is still valid.
+  if (currentPlatform === "win32") {
+    await signalProcessTreeFn(child, "SIGKILL");
+    await waitForProcessTreeExitFn(child, 2_000);
+    return;
+  }
 
-  const isStillRunning =
-    platform() === "win32"
-      ? child.exitCode === null && child.signalCode === null
-      : isProcessGroupAlive(child.pid);
+  await signalProcessTreeFn(child, "SIGTERM");
+  await waitForProcessTreeExitFn(child, 5_000);
+
+  const isStillRunning = isProcessGroupAlive(child.pid);
 
   if (isStillRunning) {
-    await signalProcessTree(child, "SIGKILL");
-    await waitForProcessTreeExit(child, 2_000);
+    await signalProcessTreeFn(child, "SIGKILL");
+    await waitForProcessTreeExitFn(child, 2_000);
   }
 }
 

--- a/tests/unit/electron-smoke-script.test.ts
+++ b/tests/unit/electron-smoke-script.test.ts
@@ -5,6 +5,7 @@ import {
   buildSmokeEnv,
   FATAL_LOG_PATTERNS,
   LINUX_EXECUTABLE_NAMES,
+  stopApp,
 } from "../../scripts/dev/smoke-electron-packaged.mjs";
 
 test("electron smoke discovers the default Linux executable name", () => {
@@ -46,4 +47,27 @@ test("electron smoke treats Electron process errors as fatal startup logs", () =
       `${log} should match a fatal log pattern`
     );
   }
+});
+
+test("electron smoke force-terminates the Windows process tree before the parent can exit", async () => {
+  const signals: string[] = [];
+  const waits: number[] = [];
+  const child = {
+    pid: 4242,
+    exitCode: 0,
+    signalCode: null,
+  };
+
+  await stopApp(child, {
+    currentPlatform: "win32",
+    signalProcessTreeFn: async (_child, signal) => {
+      signals.push(signal);
+    },
+    waitForProcessTreeExitFn: async (_child, timeoutMs) => {
+      waits.push(timeoutMs);
+    },
+  });
+
+  assert.deepEqual(signals, ["SIGKILL"]);
+  assert.deepEqual(waits, [2_000]);
 });


### PR DESCRIPTION
## Summary

- terminate the Windows packaged Electron smoke process tree in one `taskkill /T /F` operation while the root PID is still valid
- prevent a crashed Electron parent from orphaning its embedded server and contaminating later smoke runs
- make the cleanup path dependency-injectable for a focused regression test

## Root cause

The Windows cleanup path first sent a signal only to the direct Electron process. If that parent exited before the liveness check, `stopApp()` considered cleanup complete and skipped the existing tree-kill path, leaving server descendants and port 20128 behind.

This PR fixes the cleanup defect only. It does not claim to resolve the separate Windows `EXCEPTION_BREAKPOINT` or `/login` readiness failure tracked in #10321.

## Validation

- TDD: the new regression initially failed because the Windows tree-safe cleanup contract did not exist
- `node --import .../tsx/dist/esm/index.mjs --test tests/unit/electron-smoke-script.test.ts tests/unit/electron-packaging.test.ts` — 6/6 pass
- `npx prettier --check scripts/dev/smoke-electron-packaged.mjs tests/unit/electron-smoke-script.test.ts` — pass
- `git diff --check` — pass

Refs #10321