### PR TITLE
fix(sse): flag OpenAI streams that close with content but no terminal marker

### DIFF
--- a/open-sse/utils/streamHandler.ts
+++ b/open-sse/utils/streamHandler.ts
@@ -210,6 +210,14 @@ function hasClientTerminalSseMarker(text: string, clientResponseFormat?: string 
     );
   }
 
+  // OpenAI chat completions: some providers omit `data: [DONE]` (already
+  // matched above) and terminate with a finish_reason chunk instead. A
+  // non-null finish_reason value is that terminal signal — a bare
+  // `finish_reason: null` delta chunk must NOT count (#10443).
+  if (clientResponseFormat === FORMATS.OPENAI) {
+    return /"finish_reason"\s*:\s*"[^"]+"/.test(text);
+  }
+
   return false;
 }
 
@@ -516,8 +524,22 @@ function resolveSilentCloseReason(input: {
 }): string | null {
   if (!input.bytesWereForwarded) return null;
 
-  if (!input.clientTerminalSeen && input.clientResponseFormat === FORMATS.CLAUDE) {
-    return "Upstream stream ended without a terminal marker";
+  if (!input.clientTerminalSeen) {
+    if (input.clientResponseFormat === FORMATS.CLAUDE) {
+      return "Upstream stream ended without a terminal marker";
+    }
+    // #10443: every known path that produces OpenAI chat chunks emits a
+    // terminal — the response translators (gemini/claude/kiro/cursor-to-openai)
+    // all emit a finish_reason chunk, the non-standard executors (kiro, cursor,
+    // nlpcloud, poe-web, copilot-m365-web, chatgpt-web, chipotle, gitlab)
+    // enqueue `data: [DONE]` themselves, and standard OpenAI-compatible
+    // upstreams end with finish_reason + [DONE] per spec. So a close that
+    // forwarded content but no terminal marker is an upstream drop, not a
+    // legitimate end. Guard on sawContent() so the #8649 empty-content
+    // verdict below keeps its more precise shape for content-free closes.
+    if (input.clientResponseFormat === FORMATS.OPENAI && input.contentWatcher.sawContent()) {
+      return "Upstream stream ended without a terminal marker";
+    }
   }
 
   const watcher = input.contentWatcher;

--- a/tests/unit/silent-sse-close-openai-10443.test.ts
+++ b/tests/unit/silent-sse-close-openai-10443.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression test for #10443 — silent SSE truncation on OpenAI chat completions.
+ *
+ * The reporter's symptom: HTTP 200, a few content chunks forwarded, then the
+ * upstream (antigravity/Gemini) drops the stream without a terminal marker —
+ * no finish_reason chunk, no `data: [DONE]`. OmniRoute used to close the stream
+ * silently, so OpenAI-compatible clients (Hermes) see a truncated stream with
+ * no finish_reason at all.
+ *
+ * #7699 fixed this shape for Claude-format clients only; the resolver
+ * deliberately returned null for every other format because "many formats have
+ * no [DONE] equivalent". That reasoning does not hold for OpenAI chat
+ * completions: a healthy OpenAI stream ALWAYS carries either a finish_reason
+ * chunk (translator/upstream) or `data: [DONE]`. So a close that forwarded
+ * content but no terminal marker is a failure there too, and must surface a
+ * synthetic error chunk instead of a silent close.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { createDisconnectAwareStream, createStreamController } =
+  await import("../../open-sse/utils/streamHandler.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+function createNoopAbortWritableStream(): { getWriter: () => { abort: () => Promise<void> } } {
+  return { getWriter: () => ({ abort: () => Promise.resolve() }) };
+}
+
+async function drainStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const parts: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  return new TextDecoder().decode(
+    parts.reduce((acc, c) => {
+      const merged = new Uint8Array(acc.length + c.length);
+      merged.set(acc, 0);
+      merged.set(c, acc.length);
+      return merged;
+    }, new Uint8Array(0))
+  );
+}
+
+/**
+ * Wire a synthetic upstream byte stream (already in client format) through
+ * createDisconnectAwareStream with the given clientResponseFormat and return
+ * everything the client would receive.
+ */
+async function runClientStream(
+  upstreamChunks: string[],
+  clientResponseFormat: string | null
+): Promise<string> {
+  const upstream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of upstreamChunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+
+  const transform = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+    },
+  });
+  const transformedBody = upstream.pipeThrough(transform);
+
+  const sc = createStreamController({
+    provider: "antigravity",
+    model: "gemini-3.6-flash-medium",
+    clientResponseFormat,
+  });
+
+  const wrapped = createDisconnectAwareStream(
+    { readable: transformedBody, writable: createNoopAbortWritableStream() },
+    sc
+  );
+
+  return drainStream(wrapped);
+}
+
+test("#10443 OpenAI format: content then bare close emits synthetic error, not a silent truncation", async () => {
+  const text = await runClientStream(
+    ['data: {"choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}\n\n'],
+    FORMATS.OPENAI
+  );
+
+  // The forwarded content survives...
+  assert.match(text, /partial/);
+  // ...and the close must be flagged, OpenAI style: error chunk + [DONE].
+  assert.match(text, /"finish_reason":\s*"error"/);
+  assert.match(text, /data: \[DONE\]/);
+  assert.match(text, /Upstream stream ended without a terminal marker/);
+});
+
+test("#10443 OpenAI format: finish_reason chunk counts as terminal, no synthetic error", async () => {
+  // Upstream that legitimately closes WITHOUT `data: [DONE]` but WITH a
+  // finish_reason chunk (some OpenAI-compatible providers do exactly this).
+  const text = await runClientStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+    ],
+    FORMATS.OPENAI
+  );
+
+  assert.match(text, /partial/);
+  assert.doesNotMatch(text, /Upstream stream ended without a terminal marker/);
+  assert.doesNotMatch(text, /"finish_reason":\s*"error"/);
+});
+
+test("#10443 OpenAI format: data: [DONE] close is unchanged, no synthetic error", async () => {
+  const text = await runClientStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}\n\n',
+      "data: [DONE]\n\n",
+    ],
+    FORMATS.OPENAI
+  );
+
+  assert.match(text, /partial/);
+  assert.doesNotMatch(text, /Upstream stream ended without a terminal marker/);
+  assert.doesNotMatch(text, /"finish_reason":\s*"error"/);
+});
+
+test("#10443 OpenAI format: content-free close keeps the #8649 empty-content verdict", async () => {
+  // An SSE frame with no content forwarded: the #8649 empty-content rule must
+  // keep its verdict (the no-marker rule only applies when content was forwarded).
+  const text = await runClientStream(
+    ['data: {"choices":[{"index":0,"delta":{},"finish_reason":null}]}\n\n'],
+    FORMATS.OPENAI
+  );
+
+  assert.match(text, /Provider returned empty content/);
+  assert.doesNotMatch(text, /Upstream stream ended without a terminal marker/);
+});
+
+test("#10443 OpenAI format: literal finish_reason text inside model content does not count as a terminal marker", async () => {
+  // The model itself outputs a JSON snippet containing `"finish_reason": "stop"`.
+  // JSON.stringify escapes the inner quotes, so the raw SSE bytes carry
+  // `\"finish_reason\": \"stop\"` inside delta.content — the terminal-marker
+  // regex requires an unescaped field and must NOT match it. If it did, the
+  // clientTerminalSeen flag would trip early and a real mid-stream drop after
+  // such content would be misread as a clean completion.
+  const text = await runClientStream(
+    [
+      'data: {"choices":[{"index":0,"delta":{"content":"a stream ends with \\"finish_reason\\": \\"stop\\""},"finish_reason":null}]}\n\n',
+    ],
+    FORMATS.OPENAI
+  );
+
+  // No real terminal marker was forwarded, so the close is still flagged.
+  assert.match(text, /Upstream stream ended without a terminal marker/);
+  assert.match(text, /"finish_reason":\s*"error"/);
+});


### PR DESCRIPTION
## Problem

Issue #10443 (antigravity via OmniRoute unusable): when the upstream kills an SSE
stream mid-generation without a terminal marker, OmniRoute closed the stream
silently for OpenAI chat-completions clients. The client saw HTTP 200, a few
content chunks, then a bare close with no `finish_reason` — Hermes reports it as
`EmptyStreamError` and the turn returns nothing.

The silent close was deliberate: `resolveSilentCloseReason()` (#7699) only flags
a close-without-terminal-marker for Claude-format clients, because "many formats
have no `[DONE]` equivalent". That reasoning does not hold for OpenAI chat
completions — a healthy OpenAI stream always ends with either a `finish_reason`
chunk (translator/upstream) or `data: [DONE]`. A close that forwarded content
but neither marker is an upstream drop there too.

Concretely for antigravity/Gemini: the executor is a pure byte passthrough and
the `gemini-to-openai` translator emits the final `finish_reason` chunk only
when the upstream `finishReason` event arrives. When Gemini kills the stream
(e.g. its own rate enforcement) the forwarded bytes contain zero terminal
marker, and the disconnect-aware layer closed the stream silently.

## Fix

`open-sse/utils/streamHandler.ts`, two small changes:

1. `hasClientTerminalSseMarker()`: for `FORMATS.OPENAI`, a non-null
   `finish_reason` value now counts as a terminal marker (some providers
   legitimately omit `data: [DONE]`). A bare `finish_reason: null` delta chunk
   still does NOT count.
2. `resolveSilentCloseReason()`: the "ended without a terminal marker" verdict
   now also fires for `FORMATS.OPENAI` when content was forwarded
   (`sawContent()` guard, so the #8649 empty-content verdict keeps its more
   precise shape for content-free closes).

On the drop, the existing in-band error path emits an OpenAI error chunk
(`finish_reason: "error"`) plus `data: [DONE]` — the same machinery #7699
built; nothing new is synthesized.

## Verification

- TDD: new `tests/unit/silent-sse-close-openai-10443.test.ts` — the core case
  (content then bare close) was RED before the fix and is GREEN after. Four
  guard cases pin the boundaries: a `finish_reason` chunk counts as terminal,
  `data: [DONE]` closes stay unchanged, content-free closes keep the #8649
  empty-content verdict, and a literal `"finish_reason": "stop"` inside model
  output text does NOT trip the marker (JSON escaping keeps the raw bytes from
  matching the unescaped-field regex).
- Bug-injection at each fix site: deleting the resolver's OpenAI branch turns
  the core case RED; deleting the marker detection turns the
  `finish_reason`-counts-as-terminal case RED. Both restored → GREEN.
- Regression: 72/72 across the stream-handler suites (`silent-sse-close-7699`,
  `empty-stream-no-content-8649`, `stream-handler*`,
  `chatcore-streaming-pipeline`, and the new file). `npm run typecheck:core`
  clean; Prettier clean.

⚠️ base-red inherited: #9985
