### PR TITLE
fix(sse): stop ZWJ-obfuscating the substring hermes in user messages (#10484)

### DIFF
--- a/changelog.d/fixes/10484-hermes-obfuscate-zwj.md
+++ b/changelog.d/fixes/10484-hermes-obfuscate-zwj.md
@@ -1,0 +1,1 @@
+- fix(sse): stop ZWJ-obfuscating the substring "hermes" in user messages and hostnames (#10484)

--- a/open-sse/services/systemTransforms.ts
+++ b/open-sse/services/systemTransforms.ts
@@ -96,9 +96,10 @@ export const DEFAULT_OBFUSCATE_WORDS = [
   // Open WebUI additions
   "openwebui",
   "open-webui",
-  // Hermes additions (#8350)
-  "hermes-agent",
-  "hermes",
+  // Do not add "hermes" / "hermes-agent" here. #8350 is handled by
+  // HERMES_PARAGRAPH_ANCHORS + HERMES_IDENTITY_PREFIXES (system-prompt
+  // drops only). ZWJ on the short substring "hermes" rewrites user
+  // messages and hostnames (#10484).
 ];
 
 /**

--- a/src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx
@@ -81,8 +81,6 @@ const DEFAULT_OBFUSCATE_WORDS = [
   "codecompanion",
   "openwebui",
   "open-webui",
-  "hermes-agent",
-  "hermes",
 ];
 
 // Mirror of DEFAULT_SYSTEM_TRANSFORMS_CONFIG from open-sse/services/systemTransforms.ts.

--- a/tests/unit/8350-hermes-oauth-usage-400.test.ts
+++ b/tests/unit/8350-hermes-oauth-usage-400.test.ts
@@ -68,3 +68,34 @@ test("non-Hermes system prompt passes through byte-identical through the claude 
     "a normal operator system prompt with no third-party-agent anchors must pass through untouched"
   );
 });
+
+// #10484 — #8358 added "hermes" to DEFAULT_OBFUSCATE_WORDS. The ZWJ op
+// targets user messages with a case-insensitive, no-word-boundary regex, so
+// hostnames and ordinary mentions of the OmniRoute hermes CLI tool were
+// rewritten. System-prompt identity drops (#8350) must stay; user text must not
+// be mutated.
+test("user message containing hermes hostname stays byte-identical (#10484)", () => {
+  const body = {
+    system: [
+      {
+        type: "text",
+        text: "You are a helpful operator-configured assistant. Follow company policy X and always answer in English.",
+      },
+    ],
+    messages: [
+      {
+        role: "user",
+        content: "1. hermes\n2. hermes.example.ts.net\n3. Hermes on agent-001\n4. hermeS",
+      },
+    ],
+  };
+  const before = JSON.stringify(body);
+  applySystemTransformPipeline(PROVIDER_CLAUDE, body, DEFAULT_SYSTEM_TRANSFORMS_CONFIG);
+  assert.equal(
+    JSON.stringify(body),
+    before,
+    "user text containing the substring hermes must not receive ZWJ obfuscation"
+  );
+  const content = (body.messages[0] as { content: string }).content;
+  assert.equal(content.includes("\u200d"), false, "no zero-width joiner in user text");
+});

--- a/tests/unit/system-transforms.test.ts
+++ b/tests/unit/system-transforms.test.ts
@@ -502,8 +502,6 @@ const UI_DEFAULTS_SNAPSHOT = {
             "codecompanion",
             "openwebui",
             "open-webui",
-            "hermes-agent",
-            "hermes",
           ],
           targets: ["system", "messages", "tools"],
         },


### PR DESCRIPTION
## Summary

- `#8358` correctly dropped Hermes Agent **system-prompt** identity paragraphs so Anthropic does not return `[400] Third-party apps now draw from extra usage`.
- The same PR also added `"hermes"` / `"hermes-agent"` to `DEFAULT_OBFUSCATE_WORDS`. That ZWJ op targets user messages with a case-insensitive, no-word-boundary regex, so hostnames and ordinary mentions of the OmniRoute `hermes` CLI tool were rewritten (`h` + U+200D + `ermes`).
- This PR keeps the `#8350` paragraph/identity drops and removes those two words from the factory obfuscate list (server + Settings UI mirror + snapshot).

## Related Issues

- Closes #10484
- Related to #8350
- Related to #8358

## Validation

- [x] `npx tsx --test tests/unit/8350-hermes-oauth-usage-400.test.ts tests/unit/system-transforms.test.ts` (29/29 pass)
- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

RED before the list change: user text `hermes` / `hermes.<tailscale-host>` / `Hermes` / `hermeS` was rewritten with ZWJ. GREEN after.

## Tests Added Or Updated

- `tests/unit/8350-hermes-oauth-usage-400.test.ts` — new assertion that a user message containing `hermes` / a hostname stays byte-identical
- `tests/unit/system-transforms.test.ts` — UI-defaults snapshot no longer lists `hermes` / `hermes-agent` as obfuscate words

## Coverage Notes

- Production change is the factory word list in `open-sse/services/systemTransforms.ts` plus the Settings UI mirror. Covered by the new `#10484` unit test and the existing `#8350` identity-drop test (still required to pass).

## Reviewer Notes

- Operators who already saved a custom `systemTransforms` config still have `hermes` in that persisted list until they remove it or reset defaults after this ships.
- Reset-to-defaults after this merge is the durable fix; emptying `obfuscate_words.words` on `claude` / `anthropic-compatible-cc` is the live workaround today.
- Hardcoded `claudeCodeObfuscation.ts` `DEFAULT_SENSITIVE_WORDS` never included `hermes`; no change there.