### PR TITLE
fix(compression): add i18n support for less-code and terse-prose

### DIFF
--- a/docs/compression/COMPRESSION_GUIDE.md
+++ b/docs/compression/COMPRESSION_GUIDE.md
@@ -182,6 +182,22 @@ With Stacked:        10K-2.5K tokens sent     (78-95% eligible RTK+Caveman range
 
 ---
 
+## Output Styles
+
+Output styles inject a system prompt instruction to steer the model's writing style. They are defined in the output style catalog and support multiple languages and intensity levels (`lite`, `full`, `ultra`). 
+
+| Style | Description | Supported Languages | Levels |
+| --- | --- | --- | --- |
+| `terse-prose` | Drop filler/articles/hedging; keep technical substance exact. | `en`, `pt-BR`, `ja`, `id`, `vi` | `lite`, `full`, `ultra` |
+| `less-code` | YAGNI ladder: smallest working change, no unrequested abstractions. | `en`, `pt-BR`, `vi`, `ja`, `id` | `lite`, `full`, `ultra` |
+| `ponytail` | Lazy senior-dev discipline: climb the YAGNI ladder, fix root cause, smallest working diff. | `en`, `pt-BR`, `vi`, `ja`, `id` | `lite`, `full`, `ultra` |
+| `i-have-adhd` | Action-first output: next action leads, steps numbered, one concrete next step, no preamble. | `en`, `pt-BR`, `vi`, `ja`, `id` | `lite`, `full`, `ultra` |
+| `terse-cjk` | Classical-Chinese ultra-terse style (locale-gated to zh). | `zh` | `lite`, `full`, `ultra` |
+
+Each level appends a shared boundary clause ensuring that code blocks, URLs, file paths, commands, and identifiers remain verbatim.
+
+---
+
 ## Configuration
 
 ### Dashboard

--- a/open-sse/services/compression/outputMode.ts
+++ b/open-sse/services/compression/outputMode.ts
@@ -64,6 +64,11 @@ export const CAVEMAN_INSTRUCTION_BY_LANGUAGE = {
     full: `Jawab sangat singkat ala caveman pintar. Hapus kata pengisi (hanya/sangat/sebenarnya), salam sopan santun. Kalimat pendek/tidak lengkap OK. Gunakan sinonim pendek. Pertahankan semua substansi teknis, kode, error, URL, & identifier secara persis. ${SHARED_BOUNDARIES}`,
     ultra: `Jawab ultra singkat. Kompresi maksimal. Gunakan singkatan umum (DB/auth/config/req/res/fn/impl), hilangkan kata hubung, gunakan panah untuk kausalitas (X → Y). Satu kata jika cukup. Jangan singkat simbol kode, nama API, string error, URL, atau identifier. ${SHARED_BOUNDARIES}`,
   },
+  vi: {
+    lite: `Trả lời súc tích. Bỏ từ đệm, sáo rỗng, rào đón. Giữ nguyên câu hoàn chỉnh, thuật ngữ kỹ thuật, code, lỗi, URL và định danh. ${SHARED_BOUNDARIES}`,
+    full: `Trả lời cộc lốc như người tối cổ thông minh. Bỏ mạo từ, từ đệm, sáo rỗng, rào đón. Chấp nhận câu rút gọn. Dùng từ đồng nghĩa ngắn. Giữ nguyên mọi nội dung kỹ thuật, code, lỗi, URL và định danh. ${SHARED_BOUNDARIES}`,
+    ultra: `Trả lời cực kỳ cộc lốc. Nén tối đa. Như điện tín. Viết tắt (DB/auth/config/req/res/fn/impl), bỏ liên từ, dùng mũi tên cho quan hệ nhân quả (X → Y). Một từ nếu một từ là đủ. Không bao giờ viết tắt ký hiệu code, tên API, chuỗi lỗi, URL hoặc định danh. ${SHARED_BOUNDARIES}`,
+  },
 } as const;
 
 const CAVEMAN_OUTPUT_MARKER = "[OmniRoute Caveman Output Mode]";

--- a/open-sse/services/compression/outputStyles/catalog.ts
+++ b/open-sse/services/compression/outputStyles/catalog.ts
@@ -41,6 +41,7 @@ export const OUTPUT_STYLE_CATALOG: Record<string, OutputStyle> = {
       "pt-BR": CAVEMAN_INSTRUCTION_BY_LANGUAGE["pt-BR"],
       ja: CAVEMAN_INSTRUCTION_BY_LANGUAGE.ja,
       id: CAVEMAN_INSTRUCTION_BY_LANGUAGE.id,
+      vi: CAVEMAN_INSTRUCTION_BY_LANGUAGE.vi,
     },
   },
   "less-code": {
@@ -52,6 +53,28 @@ export const OUTPUT_STYLE_CATALOG: Record<string, OutputStyle> = {
       lite: `Write the smallest change that satisfies the request. Skip speculative abstractions. ${SHARED_BOUNDARIES}`,
       full: `Act like a lazy senior dev applying YAGNI. Smallest working change only. No unrequested abstractions, no premature generalization, no extra layers, no defensive scaffolding the request did not ask for. Reuse existing code over adding new code. ${SHARED_BOUNDARIES}`,
       ultra: `Minimal diff discipline. Touch the fewest lines that make it work. Zero new files, classes, or config unless strictly required. Inline over abstract. No "while we're here" extras. ${SHARED_BOUNDARIES}`,
+    },
+    i18n: {
+      "pt-BR": {
+        lite: `Escreva a menor alteração que satisfaça o pedido. Pule abstrações especulativas. ${SHARED_BOUNDARIES}`,
+        full: `Aja como um dev sênior preguiçoso aplicando YAGNI. Apenas a menor alteração funcional. Nenhuma abstração não solicitada, generalização prematura, camadas extras ou estrutura defensiva não pedida. Reutilize código existente em vez de adicionar novo. ${SHARED_BOUNDARIES}`,
+        ultra: `Disciplina de diff mínimo. Toque no menor número de linhas para funcionar. Zero arquivos, classes ou configs novos a menos que estritamente necessário. Inline em vez de abstrair. Sem extras "já que estamos aqui". ${SHARED_BOUNDARIES}`,
+      },
+      vi: {
+        lite: `Viết thay đổi nhỏ nhất đáp ứng yêu cầu. Bỏ qua các abstraction suy đoán. ${SHARED_BOUNDARIES}`,
+        full: `Hành động như một senior dev lười biếng áp dụng YAGNI. Chỉ làm thay đổi nhỏ nhất chạy được. Không abstraction không được yêu cầu, không tổng quát hóa sớm, không thêm layer, không dàn giáo phòng thủ mà yêu cầu không hỏi. Dùng lại code có sẵn thay vì thêm code mới. ${SHARED_BOUNDARIES}`,
+        ultra: `Kỷ luật diff tối thiểu. Chạm ít dòng nhất để chạy được. Không file, class hay config mới trừ khi bắt buộc. Inline thay vì abstract. Không thêm thắt kiểu "tiện tay làm luôn". ${SHARED_BOUNDARIES}`,
+      },
+      ja: {
+        lite: `要求を満たす最小の変更を書け。推測に基づく抽象化はスキップ。${SHARED_BOUNDARIES}`,
+        full: `YAGNIを適用する怠惰なシニア開発者のように振る舞え。動く最小の変更のみ。要求されていない抽象化、時期尚早な汎用化、余分なレイヤー、要求されていない防御的足場は禁止。新規コード追加より既存コードの再利用。${SHARED_BOUNDARIES}`,
+        ultra: `最小diffの規律。動くようにするための変更行数を最小に。厳密に必要でない限り、新規ファイル、クラス、設定はゼロ。抽象化よりインライン。ついでに行う余分な変更は禁止。${SHARED_BOUNDARIES}`,
+      },
+      id: {
+        lite: `Tulis perubahan terkecil yang memenuhi permintaan. Lewati abstraksi spekulatif. ${SHARED_BOUNDARIES}`,
+        full: `Bertindak seperti dev senior malas yang menerapkan YAGNI. Hanya perubahan terkecil yang berfungsi. Tanpa abstraksi yang tidak diminta, generalisasi prematur, lapisan ekstra, atau scaffolding defensif yang tidak diminta. Pakai ulang kode yang ada daripada menambah kode baru. ${SHARED_BOUNDARIES}`,
+        ultra: `Disiplin diff minimal. Sentuh baris sesedikit mungkin yang membuatnya berfungsi. Nol file, kelas, atau config baru kecuali sangat diperlukan. Inline daripada abstract. Tanpa tambahan "mumpung di sini". ${SHARED_BOUNDARIES}`,
+      },
     },
   },
   // Ponytail (lazy-senior-dev mode) — integrated into the output-style registry

--- a/tests/unit/compression/output-styles-i18n-matrix.test.ts
+++ b/tests/unit/compression/output-styles-i18n-matrix.test.ts
@@ -30,9 +30,6 @@ const REQUIRED_LANGUAGES = ["pt-BR"];
  * Do NOT add entries here without an issue — fix the coverage instead.
  */
 const KNOWN_ENGLISH_ONLY: Record<string, string> = {
-  // 9router port that never got translated. Tracked in the compression i18n
-  // backlog; the fix is mechanical (same shape as ponytail/i-have-adhd).
-  "less-code": "pre-existing gap — English-only since the 9router port",
 };
 
 /**
@@ -41,9 +38,9 @@ const KNOWN_ENGLISH_ONLY: Record<string, string> = {
  */
 const BASELINE_LANGUAGES: Record<string, string[]> = {
   // terse-prose reuses CAVEMAN_INSTRUCTION_BY_LANGUAGE (outputMode.ts), which
-  // localizes to pt-BR/ja/id — keep the two in sync when adding a language.
-  "terse-prose": ["pt-BR", "ja", "id"],
-  "less-code": [],
+  // localizes to pt-BR/ja/id/vi — keep the two in sync when adding a language.
+  "terse-prose": ["pt-BR", "ja", "id", "vi"],
+  "less-code": ["pt-BR", "vi", "ja", "id"],
   ponytail: ["pt-BR", "vi", "ja", "id"],
   "i-have-adhd": ["pt-BR", "vi", "ja", "id"],
   // locale-gated to zh: the single-language instruction IS the feature.


### PR DESCRIPTION
Translates less-code output style to pt-BR, vi, ja, and id. Adds missing vi translation to terse-prose caveman mode. Removes less-code from English-only allowlist and updates matrix tests.%0A%0AFixes #10426