### PR TITLE
fix(combo): actionable recovery hint for the all_targets_skipped terminal reason (#9303)

### DIFF
--- a/changelog.d/fixes/9303-recovery-hint-all-targets-skipped.md
+++ b/changelog.d/fixes/9303-recovery-hint-all-targets-skipped.md
@@ -1,0 +1,1 @@
+- fix(combo): recovery hint for all_targets_skipped now points at provider quota/availability instead of 'transient, just retry' (#9303)

--- a/open-sse/services/combo/pinRecovery.ts
+++ b/open-sse/services/combo/pinRecovery.ts
@@ -53,6 +53,12 @@ export function buildRecoveryHint(
         next_step:
           "Strict context requirements removed every target (known context windows are below minContextWindow). Lower minContextWindow, switch contextFilterMode to lenient, or add larger-context models.",
       };
+    case "all_targets_skipped":
+      return {
+        action: "switch-combo",
+        next_step:
+          "Every target was skipped before dispatch (capability pre-filter narrowed the pool and the remaining targets were all quota-exhausted/unavailable). Check the provider's quota in /dashboard/providers, reconnect or top up the account, or switch to a combo/model that has a healthy capability-matching target.",
+      };
     default:
       return {
         action: "retry",

--- a/tests/unit/9303-recovery-hint-all-targets-skipped.test.ts
+++ b/tests/unit/9303-recovery-hint-all-targets-skipped.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildRecoveryHint } = await import("../../open-sse/services/combo/pinRecovery.ts");
+
+test(
+  "#9303: buildRecoveryHint('all_targets_skipped') must return an actionable " +
+    "hint, not the generic 'transient, just retry' default",
+  () => {
+    const hint = buildRecoveryHint("all_targets_skipped");
+
+    assert.notEqual(
+      hint.action,
+      "retry",
+      "the pre-dispatch full-exhaustion terminal reason must not be classified as a " +
+        "generically 'retry'-able transient failure — the reporter's log shows the " +
+        "identical exhaustion recurring across ~9 consecutive requests with no recovery"
+    );
+    assert.doesNotMatch(
+      hint.next_step,
+      /failed transiently/i,
+      "must not tell the client this was transient when the whole target pool was " +
+        "pre-filtered/quota-exhausted before a single dispatch attempt was made"
+    );
+    assert.match(
+      hint.next_step,
+      /quota|availability|provider/s,
+      "the hint must point at the provider quota/availability as the actionable next step"
+    );
+  }
+);


### PR DESCRIPTION
Closes #9303

The 503 ALL_TARGETS_SKIPPED response itself is correct, already-tested combo routing (a vision hard-requirement narrowed the pool to the reporter's quota-exhausted antigravity connection — covered by #8332/#8488 tests). The real defect: `buildRecoveryHint()` had no `case "all_targets_skipped"`, so it fell to the generic default `action: "retry" / "The combo failed transiently…"` — misleading the client (and plugin tooling) into retrying a non-transient, whole-session quota exhaustion.

**Root cause:** `open-sse/services/combo/pinRecovery.ts::buildRecoveryHint()` is a pure switch over `terminalReason` with actionable branches for every sibling reason (`all_accounts_inactive`, `no_executable_targets`, …) but no case for `all_targets_skipped`, the sole reason stamped by `combo.ts:2257`. The hint is mirrored into `recovery_hint` + `x-omniroute-recovery-*` headers.

**Fix:** add `case "all_targets_skipped":` (action switch-combo) pointing at provider quota/availability — reconnect or top up the quota-exhausted account, or switch to a combo/model with a healthy capability-matching target. No status-code/dispatch/auth change.

**Regression test (RED→GREEN):** `tests/unit/9303-recovery-hint-all-targets-skipped.test.ts` — asserts action != retry, no 'failed transiently' wording, and the hint references quota/availability. Existing `8332` / `8488` vision fail-closed tests re-run green (12 tests total).

**Gates:** typecheck exit 0 · eslint exit 0 · check-file-size OK · check-complexity OK · check-cognitive-complexity OK · check-changelog-integrity OK · tests 12/12 GREEN.

⚠️ base-red inherited: #9985