### PR TITLE
fix(providers): strip uniqueItems from Gemini tool schemas to avoid upstream 400 (#9617)

### DIFF
--- a/changelog.d/fixes/9617-gemini-uniqueitems-strip.md
+++ b/changelog.d/fixes/9617-gemini-uniqueitems-strip.md
@@ -1,0 +1,1 @@
+- fix(providers): strip uniqueItems from Gemini tool schemas (Gemini rejects it with 400 'Unknown name uniqueItems') (#9617)

--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -58,6 +58,11 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   "contains",
   "minContains",
   "maxContains",
+  // #9617: array uniqueness keyword — agentic-CLI tool schemas (JSON-Schema
+  // generators) set this routinely and Gemini's schema parser has no field for
+  // it, rejecting the whole request with "Unknown name \"uniqueItems\"".
+  // Upstream 9router already strips it alongside `contains` for the same error.
+  "uniqueItems",
   // Complex schema keywords (handled by flattenAnyOfOneOf/mergeAllOf)
   "anyOf",
   "oneOf",

--- a/tests/unit/9617-gemini-uniqueitems.test.ts
+++ b/tests/unit/9617-gemini-uniqueitems.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildGeminiTools } from "../../open-sse/translator/helpers/geminiToolsSanitizer.ts";
+
+// Issue #9617: Gemini rejects `uniqueItems` in function_declarations parameter schemas
+// with HTTP 400 "Unknown name \"uniqueItems\" ... Cannot find field" (Gemini's protobuf-JSON
+// schema parser only accepts a subset of JSON Schema/OpenAPI 3.0 — the same class of error
+// already fixed for `multipleOf`, `minItems`, `maxItems`, `strict`, `encrypted` in
+// GEMINI_UNSUPPORTED_SCHEMA_KEYS, open-sse/translator/helpers/geminiHelper.ts).
+test("buildGeminiTools strips uniqueItems from array schemas (issue #9617)", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "exit_worktree",
+        description: "test tool with an array-of-objects parameter",
+        parameters: {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              uniqueItems: true,
+              items: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  action: { type: "string" },
+                },
+                required: ["name", "action"],
+              },
+            },
+          },
+          required: ["items"],
+        },
+      },
+    },
+  ];
+
+  const geminiTools = buildGeminiTools(tools);
+  const serialized = JSON.stringify(geminiTools);
+
+  assert.ok(geminiTools, "expected buildGeminiTools to return a tools array");
+  assert.equal(
+    serialized.includes("uniqueItems"),
+    false,
+    `uniqueItems leaked into the Gemini payload (would trigger upstream 400 "Unknown name \\"uniqueItems\\""): ${serialized}`
+  );
+});
+
+// Companion: a top-level (non-nested) array property with uniqueItems is also stripped —
+// matches the reporter's deeply-nested case with extra path coverage.
+test("buildGeminiTools strips uniqueItems from a top-level array parameter schema (issue #9617)", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "list_worktrees",
+        description: "test tool with a top-level array parameter",
+        parameters: {
+          type: "object",
+          properties: {
+            paths: {
+              type: "array",
+              uniqueItems: true,
+              items: { type: "string" },
+            },
+          },
+          required: ["paths"],
+        },
+      },
+    },
+  ];
+
+  const serialized = JSON.stringify(buildGeminiTools(tools));
+  assert.equal(serialized.includes("uniqueItems"), false);
+});


### PR DESCRIPTION
Closes #9617

Gemini rejects any tool schema carrying `uniqueItems` with HTTP 400 "Unknown name uniqueItems ... Cannot find field" because its protobuf-JSON schema parser has no field for it. Agentic-CLI tool definitions (JSON-Schema generators) set this routinely, so 25-tool requests with one array-of-objects param fail wholesale.

**Root cause:** `GEMINI_UNSUPPORTED_SCHEMA_KEYS` (`open-sse/translator/helpers/geminiHelper.ts`) already strips the sibling keywords for the identical class of failure (`minItems`, `maxItems`, `multipleOf`, `strict`, `encrypted`, `contains`) — but `uniqueItems` was never added. `buildGeminiTools` → `cleanJSONSchemaForAntigravity` → `removeUnsupportedKeywords` therefore passed it through to the upstream `function_declarations`. Upstream 9router already strips `uniqueItems` alongside `contains` with the same rationale.

**Fix:** one-line addition of `"uniqueItems"` to the strip-list (array-keyword block, with #9617 + upstream-precedent comment). No code-path change.

**Regression tests (RED→GREEN):** `tests/unit/9617-gemini-uniqueitems.test.ts` — nested array-of-objects with `uniqueItems` + a top-level array param both assert no `uniqueItems` survives `buildGeminiTools` (2/2). Existing Gemini/sanitizer area tests re-run green (25 tests).

**Gates:** typecheck exit 0 · eslint exit 0 · check-file-size OK · check-complexity OK · check-cognitive-complexity OK · check-changelog-integrity OK · tests 27/27 GREEN.

⚠️ base-red inherited: #9985