### PR TITLE
fix(providers): update token-backed web sessions

### DIFF
--- a/changelog.d/fixes/10518-token-backed-web-session-update.md
+++ b/changelog.d/fixes/10518-token-backed-web-session-update.md
@@ -1,0 +1,1 @@
+- **fix(providers):** allow token-backed web sessions stored with `authType: "cookie"` to refresh their token through the provider update API ([#10518](https://github.com/diegosouzapw/OmniRoute/pull/10518)) — thanks @Zartharas

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -25,6 +25,7 @@ import {
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { isApiKeyRevealEnabled, maskStoredApiKey } from "@/lib/apiKeyExposure";
 import { cleanupProviderModelsAfterConnectionDelete } from "@/lib/db/models";
+import { canUpdateProviderApiKey } from "@/shared/providers/webSessionCredentials";
 import {
   refreshConnectionRateLimits,
   enableRateLimitProtection,
@@ -161,7 +162,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     if (globalPriority !== undefined) updateData.globalPriority = globalPriority;
     if (defaultModel !== undefined) updateData.defaultModel = defaultModel;
     if (isActive !== undefined) updateData.isActive = isActive;
-    if (apiKey && existing.authType === "apikey") {
+    if (apiKey && canUpdateProviderApiKey(existing.authType, existing.provider)) {
       if (existing.provider === "chatgpt-web-codex") {
         const validationId =
           incomingPsd && typeof incomingPsd.validationId === "string"

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -375,6 +375,12 @@ export function getWebSessionCredentialRequirement(
   );
 }
 
+export function canUpdateProviderApiKey(authType: unknown, providerId: unknown): boolean {
+  if (authType === "apikey") return true;
+  if (authType !== "cookie") return false;
+  return getWebSessionCredentialRequirement(providerId)?.kind === "token";
+}
+
 export function requiresWebSessionCredential(providerId: unknown): boolean {
   const requirement = getWebSessionCredentialRequirement(providerId);
   return !!requirement && requirement.kind !== "none";

--- a/tests/unit/bulk-web-session-import.test.ts
+++ b/tests/unit/bulk-web-session-import.test.ts
@@ -10,6 +10,7 @@ import { bulkWebSessionImportSchema } from "../../src/shared/validation/schemas.
 import {
   requiresWebSessionCredential,
   getWebSessionCredentialRequirement,
+  canUpdateProviderApiKey,
   hasUsableWebSessionCredential,
   resolveWebSessionImportApiKey,
 } from "../../src/shared/providers/webSessionCredentials.ts";
@@ -157,6 +158,27 @@ describe("web-session credential helpers", () => {
   it("hasUsableWebSessionCredential validates token data correctly", () => {
     assert.equal(hasUsableWebSessionCredential("deepseek-web", { token: "my-token" }), true);
     assert.equal(hasUsableWebSessionCredential("deepseek-web", { token: "   " }), false);
+  });
+});
+
+describe("canUpdateProviderApiKey", () => {
+  it("preserves normal API-key credential updates", () => {
+    assert.equal(canUpdateProviderApiKey("apikey", "openai"), true);
+  });
+
+  it("allows token-kind web sessions stored with cookie authType", () => {
+    assert.equal(canUpdateProviderApiKey("cookie", "deepseek-web"), true);
+    assert.equal(canUpdateProviderApiKey("cookie", "zai-web"), true);
+  });
+
+  it("does not allow cookie-kind web sessions to update apiKey", () => {
+    assert.equal(canUpdateProviderApiKey("cookie", "chatgpt-web"), false);
+    assert.equal(canUpdateProviderApiKey("cookie", "claude-web"), false);
+  });
+
+  it("does not broaden non-cookie auth types", () => {
+    assert.equal(canUpdateProviderApiKey("oauth", "deepseek-web"), false);
+    assert.equal(canUpdateProviderApiKey(null, "deepseek-web"), false);
   });
 });
 


### PR DESCRIPTION
## Summary

Allow token-kind web-session connections stored with `authType: "cookie"` to update their token through the existing provider PUT API.

## Root cause

Bulk web-session import stores token-kind providers such as DeepSeek and Z.AI with cookie auth type while their token lives in `apiKey`. The provider PUT route previously accepted `apiKey` updates only for `authType: "apikey"`, so a later credential refresh could not persist the new token.

## Fix

Centralize update eligibility in `canUpdateProviderApiKey()`. Normal API-key updates remain unchanged. Cookie-auth connections may update `apiKey` only when the centralized web-session requirement is `kind: "token"`. Cookie-kind web sessions and other auth types remain excluded.

## Validation

- focused regression: 25/25 passed
- scoped ESLint: PASS
- `npm run typecheck:core`: PASS
- `git diff --check`: PASS
- one commit directly parented to the current release branch tip

The same behavior was also live-validated with a disposable DeepSeek token-backed cookie-auth row: the credential PUT succeeded, `apiKey` was applied, `authType` remained `cookie`, and cleanup returned provider inventory to baseline.

No raw credential values are included in the PR or validation output.