### PR TITLE
feat(dashboard): VS Code Copilot Chat home banner, remove Provider Quota home card

### DIFF
--- a/src/app/(dashboard)/dashboard/HomePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/HomePageClient.tsx
@@ -2,8 +2,7 @@
 
 import { useTranslations } from "next-intl";
 
-import { useState, useEffect, useMemo, useCallback, useRef, Suspense } from "react";
-import dynamic from "next/dynamic";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Card, CardSkeleton, Button, Modal } from "@/shared/components";
@@ -20,8 +19,6 @@ import { getProviderDisplayLabel } from "@/shared/utils/providerDisplayLabel";
 import { useIsElectron, useOpenExternal } from "@/shared/hooks/useElectron";
 import { HomeProviderTopologySection } from "./HomeProviderTopologySection";
 import { shouldShowProviderTopologyOnHome } from "./homeAppearance";
-
-const ProviderQuotaWidget = dynamic(() => import("../home/ProviderQuotaWidget"), { ssr: false });
 
 type UpdateStep = {
   step: string;
@@ -202,13 +199,10 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
   const [updatePhase, setUpdatePhase] = useState<"idle" | "running" | "done" | "failed">("idle");
 
   // Appearance settings for home page pinning
-  const [pinProviderQuotaToHome, setPinProviderQuotaToHome] = useState(false);
   const [showQuickStartOnHome, setShowQuickStartOnHome] = useState(true); // default on
   // #4596: default hidden until appearance settings load, so the live-WS
   // topology connection is never opened before we know the user wants it.
   const [showProviderTopologyOnHome, setShowProviderTopologyOnHome] = useState(false);
-  const [autoRefreshProviderQuota, setAutoRefreshProviderQuota] = useState(false);
-  const [autoRefreshProviderQuotaInterval, setAutoRefreshProviderQuotaInterval] = useState(180);
   const [appearanceSettingsLoaded, setAppearanceSettingsLoaded] = useState(false);
 
   useEffect(() => {
@@ -217,9 +211,6 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
       .then((r) => (r.ok ? r.json() : {}))
       .then((data) => {
         if (data) {
-          if (typeof data.pinProviderQuotaToHome === "boolean") {
-            setPinProviderQuotaToHome(data.pinProviderQuotaToHome);
-          }
           if (typeof data.showQuickStartOnHome === "boolean") {
             setShowQuickStartOnHome(data.showQuickStartOnHome);
           }
@@ -232,12 +223,6 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
           setShowProviderTopologyOnHome(
             shouldShowProviderTopologyOnHome(data.showProviderTopologyOnHome)
           );
-          if (typeof data.autoRefreshProviderQuota === "boolean") {
-            setAutoRefreshProviderQuota(data.autoRefreshProviderQuota);
-          }
-          if (typeof data.autoRefreshProviderQuotaInterval === "number") {
-            setAutoRefreshProviderQuotaInterval(data.autoRefreshProviderQuotaInterval);
-          }
         }
       })
       .catch(() => {
@@ -1046,15 +1031,6 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
               )}
           </div>
         </div>
-      )}
-
-      {/* Pinned Provider Quota Limits */}
-      {pinProviderQuotaToHome && (
-        <Suspense fallback={<CardSkeleton />}>
-          <ProviderQuotaWidget
-            autoRefreshInterval={autoRefreshProviderQuota ? autoRefreshProviderQuotaInterval : 0}
-          />
-        </Suspense>
       )}
 
       {/* Quick Start (controlled by Appearance setting, default on) */}

--- a/src/app/(dashboard)/dashboard/VscodeCopilotBanner.tsx
+++ b/src/app/(dashboard)/dashboard/VscodeCopilotBanner.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { useTranslations } from "next-intl";
+
+// Marketplace listing is the primary CTA; Open VSX (Cursor/Windsurf/VSCodium/etc.)
+// is called out via secondaryNote instead of a second button, to keep this banner
+// the same size as KimiSponsorBanner.
+const MARKETPLACE_URL = "https://marketplace.visualstudio.com/items?itemName=diegosouzapw.omnicopilot";
+
+const DISMISS_STORAGE_KEY = "omniroute-vscode-copilot-banner-dismissed-v1";
+// Same-tab signal for the dismiss button, since writing localStorage doesn't
+// fire a "storage" event in the tab that wrote it.
+const DISMISS_EVENT = "omniroute:vscode-copilot-banner-dismissed";
+
+function isNotDismissed(): boolean {
+  try {
+    return !localStorage.getItem(DISMISS_STORAGE_KEY);
+  } catch {
+    return true;
+  }
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(DISMISS_EVENT, callback);
+  return () => window.removeEventListener(DISMISS_EVENT, callback);
+}
+
+// SSR has no localStorage, so the server always renders the banner visible;
+// useSyncExternalStore reconciles that against the real client-side value
+// right after hydration, mirroring KimiSponsorBanner's pattern.
+function getServerSnapshot() {
+  return true;
+}
+
+/**
+ * Dismissable banner announcing the OmniCopilot VS Code extension on the
+ * dashboard home page — same size/shape as KimiSponsorBanner, no version gate
+ * (durable feature announcement, not a time-boxed sponsor deal).
+ */
+export default function VscodeCopilotBanner() {
+  const t = useTranslations("vscodeCopilotBanner");
+  const visible = useSyncExternalStore(subscribe, isNotDismissed, getServerSnapshot);
+
+  if (!visible) {
+    return null;
+  }
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_STORAGE_KEY, "true");
+    } catch {
+      // ignore — worst case the banner reappears next visit
+    }
+    window.dispatchEvent(new Event(DISMISS_EVENT));
+  };
+
+  return (
+    <div
+      role="complementary"
+      aria-label={t("title")}
+      className="mb-4 flex flex-col gap-3 rounded-lg border border-[#007ACC]/30 bg-[#007ACC]/5 px-4 py-3 dark:bg-[#007ACC]/10 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-[#007ACC]/10">
+          <span className="material-symbols-outlined text-[22px] text-[#007ACC]" aria-hidden="true">
+            extension
+          </span>
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-text-main">{t("title")}</p>
+          <p className="mt-0.5 text-xs text-text-muted">{t("description")}</p>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-3 self-end sm:self-auto">
+        <div className="flex flex-col items-end gap-0.5">
+          <a
+            href={MARKETPLACE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg bg-[#007ACC] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:brightness-110"
+          >
+            {t("cta")}
+            <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
+              open_in_new
+            </span>
+          </a>
+          <span className="text-[9px] text-text-muted/70">{t("secondaryNote")}</span>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label={t("dismissAriaLabel")}
+          className="text-text-muted transition-colors hover:text-text-main"
+        >
+          <span className="material-symbols-outlined text-[18px]">close</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/settings/components/AppearanceTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/AppearanceTab.tsx
@@ -12,7 +12,6 @@ import {
   normalizeComboConfigMode,
   type ComboConfigMode,
 } from "@/shared/constants/comboConfigMode";
-import { PIN_PROVIDER_QUOTA_TO_HOME_KEY } from "@/shared/constants/homeWidgets";
 import AccountEmailVisibilitySetting from "./AccountEmailVisibilitySetting";
 
 export default function AppearanceTab() {
@@ -38,7 +37,6 @@ export default function AppearanceTab() {
   const isValidHex = /^#([0-9a-fA-F]{6})$/.test(
     customThemeColor.startsWith("#") ? customThemeColor : `#${customThemeColor}`
   );
-  const pinProviderQuotaToHome = settings.pinProviderQuotaToHome === true;
   const showQuickStartOnHome = settings.showQuickStartOnHome !== false;
   const showProviderTopologyOnHome = settings.showProviderTopologyOnHome !== false;
   const autoRefreshProviderQuota = settings.autoRefreshProviderQuota === true;
@@ -197,27 +195,6 @@ export default function AppearanceTab() {
 
           <div className="rounded-lg border border-border bg-surface/40 overflow-hidden">
             <div className="divide-y divide-border/70">
-              <div className="flex items-start justify-between gap-4 px-4 py-3">
-                <div>
-                  <p className="font-medium">
-                    {getSettingsLabel("homeProviderQuotaLimits", "Provider Quota Limits")}
-                  </p>
-                  <p className="text-sm text-text-muted">
-                    {getSettingsLabel(
-                      "homeProviderQuotaLimitsDesc",
-                      "Pin the Provider Quota status container (with Refresh All button) to the top of the Home page."
-                    )}
-                  </p>
-                </div>
-                <Toggle
-                  checked={pinProviderQuotaToHome}
-                  onChange={async (checked) => {
-                    await updateSetting(PIN_PROVIDER_QUOTA_TO_HOME_KEY, checked);
-                  }}
-                  disabled={loading}
-                />
-              </div>
-
               <div className="flex items-start justify-between gap-4 px-4 py-3">
                 <div>
                   <p className="font-medium">{getSettingsLabel("homeQuickStart", "Quick Start")}</p>

--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -4,6 +4,7 @@ import { getSettings } from "@/lib/localDb";
 import HomePageClient from "../dashboard/HomePageClient";
 import BootstrapBanner from "../dashboard/BootstrapBanner";
 import KimiSponsorBanner from "../dashboard/KimiSponsorBanner";
+import VscodeCopilotBanner from "../dashboard/VscodeCopilotBanner";
 import NewsBanner from "../dashboard/NewsBanner";
 
 export const dynamic = "force-dynamic";
@@ -19,6 +20,7 @@ export default async function HomePage() {
     <>
       {isBootstrapped && <BootstrapBanner />}
       <KimiSponsorBanner />
+      <VscodeCopilotBanner />
       <NewsBanner />
       <HomePageClient machineId={machineId} />
     </>

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "رابط شريك",
     "dismissAriaLabel": "تجاهل"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute يعمل الآن داخل VS Code Copilot Chat",
+    "description": "ثبّت امتداد OmniCopilot المجاني وستظهر جميع نماذج OmniRoute مباشرة في منتقي النماذج في Copilot Chat الذي تستخدمه بالفعل.",
+    "cta": "احصل على الامتداد",
+    "secondaryNote": "متوفر أيضًا على Open VSX (Cursor، Windsurf، VSCodium…)",
+    "dismissAriaLabel": "تجاهل"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "قم بالإعلان عن معرفات المرايا <gateway-alias>/<model> على /v1/models للنماذج التي ليس لديها مالك قانوني لديه بيانات اعتماد نشطة ولكن بوابة تمرير مع بيانات اعتماد نشطة توجهها. تحذير: يضيف إدخالات الكتالوج لجميع العملاء عند تمكينه عالميًا.",
   "radarPage": {
     "title": "كتالوج الرادار",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Tərəfdaş linki",
     "dismissAriaLabel": "Bağla"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute artıq VS Code Copilot Chat daxilində işləyir",
+    "description": "Pulsuz OmniCopilot əlavəsini quraşdırın və bütün OmniRoute modelləri artıq istifadə etdiyiniz Copilot Chat model seçicisində görünsün.",
+    "cta": "Əlavəni əldə edin",
+    "secondaryNote": "Həmçinin Open VSX-də (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Bağla"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> güzgü ID-lərini /v1/models-da reklam edin, əgər modelin kanonik sahibi aktiv etibarnaməyə malik deyilsə, lakin bir keçid qapısı aktiv etibarnamə ilə onları yönləndirirsə. Xəbərdarlıq: qlobal olaraq aktiv edildikdə bütün müştərilər üçün kataloq qeydləri əlavə edir.",
   "radarPage": {
     "title": "Radar Kataloqu",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Партньорска връзка",
     "dismissAriaLabel": "Затваряне"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute вече работи във VS Code Copilot Chat",
+    "description": "Инсталирайте безплатното разширение OmniCopilot и всички модели на OmniRoute ще се появят направо в избора на модели на Copilot Chat, който вече използвате.",
+    "cta": "Вземете разширението",
+    "secondaryNote": "Налично и в Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Затваряне"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Рекламирайте <gateway-alias>/<model> mirror ids на /v1/models за модели, чийто каноничен собственик няма активна идентификация, но пасивен шлюз с активна идентификация ги маршрутизира. Внимание: добавя записи в каталога за всички клиенти, когато е активирано глобално.",
   "radarPage": {
     "title": "Каталог на радара",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "পার্টনার লিঙ্ক",
     "dismissAriaLabel": "খারিজ করুন"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute এখন VS Code Copilot Chat-এর ভেতরে চলে",
+    "description": "বিনামূল্যের OmniCopilot এক্সটেনশন ইনস্টল করুন এবং আপনার ইতিমধ্যে ব্যবহৃত Copilot Chat মডেল পিকারেই সব OmniRoute মডেল দেখা যাবে।",
+    "cta": "এক্সটেনশনটি নিন",
+    "secondaryNote": "Open VSX-এও পাওয়া যায় (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "খারিজ করুন"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> মিরর আইডি গুলি /v1/models এ বিজ্ঞাপন দিন তাদের জন্য মডেল যাদের ক্যানোনিকাল মালিকের কোনো সক্রিয় শংসাপত্র নেই কিন্তু একটি পাসথ্রু গেটওয়ে তাদের সক্রিয় শংসাপত্র দ্বারা রাউট করে। সতর্কতা: এটি বিশ্বব্যাপী সক্ষম হলে সমস্ত ক্লায়েন্টের জন্য ক্যাটালগ এন্ট্রি যোগ করে।",
   "radarPage": {
     "title": "রাডার ক্যাটালগ",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavřít"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute nyní běží přímo ve VS Code Copilot Chat",
+    "description": "Nainstalujte si bezplatné rozšíření OmniCopilot a všechny modely OmniRoute se objeví přímo ve výběru modelů Copilot Chat, který už používáte.",
+    "cta": "Získat rozšíření",
+    "secondaryNote": "Také na Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Zavřít"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Inzerujte <gateway-alias>/<model> zrcadlové ID na /v1/models pro modely, jejichž kanonický vlastník nemá aktivní pověření, ale passtrhough brána s aktivním pověřením je směruje. Upozornění: při globálním povolení přidává katalogové položky pro všechny klienty.",
   "radarPage": {
     "title": "Radar katalog",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Afvis"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute kører nu inde i VS Code Copilot Chat",
+    "description": "Installer den gratis OmniCopilot-udvidelse, og alle OmniRoute-modeller vises direkte i den Copilot Chat-modelvælger, du allerede bruger.",
+    "cta": "Hent udvidelsen",
+    "secondaryNote": "Også på Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Afvis"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Reklamer <gateway-alias>/<model> spejl-id'er på /v1/models for modeller, hvis kanoniske ejer ikke har nogen aktiv legitimationsoplysninger, men en passthrough gateway med aktive legitimationsoplysninger ruter dem. Advarsel: tilføjer katalogposter for alle klienter, når det er aktiveret globalt.",
   "radarPage": {
     "title": "Radar Katalog",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Schließen"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute läuft jetzt direkt in VS Code Copilot Chat",
+    "description": "Installiere die kostenlose OmniCopilot-Erweiterung, und jedes OmniRoute-Modell erscheint direkt in der Copilot-Chat-Modellauswahl, die du bereits nutzt.",
+    "cta": "Erweiterung holen",
+    "secondaryNote": "Auch auf Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Schließen"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Bewerben Sie <gateway-alias>/<model> Spiegel-IDs auf /v1/models für Modelle, deren kanonischer Eigentümer keine aktiven Anmeldeinformationen hat, aber ein Durchgangsgateway mit aktiven Anmeldeinformationen sie weiterleitet. Warnung: Fügt Katalogeinträge für alle Clients hinzu, wenn global aktiviert.",
   "radarPage": {
     "title": "Radar-Katalog",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -13088,6 +13088,13 @@
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute now runs inside VS Code Copilot Chat",
+    "description": "Install the free OmniCopilot extension and every OmniRoute model shows up right in the Copilot Chat model picker you already use.",
+    "cta": "Get the Extension",
+    "secondaryNote": "Also on Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Dismiss"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Advertise <gateway-alias>/<model> mirror ids on /v1/models for models whose canonical owner has no active credential but a passthrough gateway with an active credential routes them. Warning: adds catalog entries for all clients when enabled globally.",
   "radarPage": {
     "title": "Radar Catalog",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Enlace de socio",
     "dismissAriaLabel": "Descartar"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute ahora funciona dentro de VS Code Copilot Chat",
+    "description": "Instala la extensión gratuita OmniCopilot y todos los modelos de OmniRoute aparecerán directamente en el selector de modelos de Copilot Chat que ya usas.",
+    "cta": "Obtener la extensión",
+    "secondaryNote": "También en Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Descartar"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Anunciar los IDs de espejo <gateway-alias>/<model> en /v1/models para modelos cuyo propietario canónico no tiene credenciales activas, pero un gateway de paso con credenciales activas los enruta. Advertencia: añade entradas de catálogo para todos los clientes cuando se habilita globalmente.",
   "radarPage": {
     "title": "Catálogo de Radar",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "لینک همکاری",
     "dismissAriaLabel": "بستن"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute اکنون درون VS Code Copilot Chat اجرا می‌شود",
+    "description": "افزونه رایگان OmniCopilot را نصب کنید تا همه مدل‌های OmniRoute مستقیماً در انتخابگر مدل Copilot Chat که از قبل استفاده می‌کنید نمایش داده شوند.",
+    "cta": "دریافت افزونه",
+    "secondaryNote": "همچنین در Open VSX (Cursor، Windsurf، VSCodium…)",
+    "dismissAriaLabel": "بستن"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "آگهی <gateway-alias>/<model> شناسه‌های آینه‌ای در /v1/models برای مدل‌هایی که مالک قانونی آن‌ها هیچ اعتبار فعالی ندارد اما یک دروازه عبوری با اعتبار فعال آن‌ها را مسیریابی می‌کند. هشدار: در صورت فعال‌سازی جهانی، ورودی‌های کاتالوگ را برای تمام مشتریان اضافه می‌کند.",
   "radarPage": {
     "title": "کاتالوگ رادار",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Kumppanilinkki",
     "dismissAriaLabel": "Sulje"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute toimii nyt suoraan VS Code Copilot Chatissa",
+    "description": "Asenna ilmainen OmniCopilot-laajennus, niin kaikki OmniRoute-mallit näkyvät suoraan siinä Copilot Chatin mallivalitsimessa, jota jo käytät.",
+    "cta": "Hanki laajennus",
+    "secondaryNote": "Myös Open VSX:ssä (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Sulje"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Mainosta <gateway-alias>/<model> peilid tunnuksia /v1/models -osoitteessa malleille, joiden kanoninen omistaja ei omaa aktiivista tunnistetta, mutta ohjaa niitä aktiivisella tunnisteella varustettu ohitusportti. Varoitus: lisää luettelo-merkintöjä kaikille asiakkaille, kun se on otettu käyttöön globaalisti.",
   "radarPage": {
     "title": "Radar-katalogi",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Lien partenaire",
     "dismissAriaLabel": "Ignorer"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute fonctionne désormais directement dans VS Code Copilot Chat",
+    "description": "Installez l'extension gratuite OmniCopilot et tous les modèles OmniRoute apparaissent directement dans le sélecteur de modèles de Copilot Chat que vous utilisez déjà.",
+    "cta": "Obtenir l'extension",
+    "secondaryNote": "Aussi sur Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Ignorer"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Annoncez les identifiants de miroir <gateway-alias>/<model> sur /v1/models pour les modèles dont le propriétaire canonique n'a pas de crédentiel actif mais un passerelle de contournement avec un crédentiel actif les achemine. Avertissement : ajoute des entrées de catalogue pour tous les clients lorsqu'il est activé globalement.",
   "radarPage": {
     "title": "Catalogue Radar",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "પાર્ટનર લિંક",
     "dismissAriaLabel": "બંધ કરો"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute હવે VS Code Copilot Chat અંદર ચાલે છે",
+    "description": "મફત OmniCopilot એક્સટેન્શન ઇન્સ્ટોલ કરો અને તમે પહેલેથી ઉપયોગ કરો છો તે Copilot Chat મોડલ પિકરમાં જ બધા OmniRoute મોડલ દેખાશે.",
+    "cta": "એક્સટેન્શન મેળવો",
+    "secondaryNote": "Open VSX પર પણ ઉપલબ્ધ (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "બંધ કરો"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> મિરર આઈડીઓને /v1/models પર જાહેરાત આપો તે મોડલ્સ માટે જેમના કૅનોનિકલ માલિક પાસે કોઈ સક્રિય પ્રમાણપત્ર નથી પરંતુ એક પાસથ્રૂ ગેટવે સાથે સક્રિય પ્રમાણપત્ર તેમને માર્ગદર્શિત કરે છે. ચેતવણી: વૈશ્વિક રીતે સક્રિય કરવામાં આવે ત્યારે તમામ ક્લાયન્ટ્સ માટે કૅટલોગ એન્ટ્રીઓ ઉમેરે છે.",
   "radarPage": {
     "title": "રેડાર કેટલોગ",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "קישור שותף",
     "dismissAriaLabel": "התעלם"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute פועל כעת ישירות בתוך VS Code Copilot Chat",
+    "description": "התקינו את התוסף החינמי OmniCopilot וכל מודלי OmniRoute יופיעו ישירות בבורר המודלים של Copilot Chat שאתם כבר משתמשים בו.",
+    "cta": "קבלו את התוסף",
+    "secondaryNote": "זמין גם ב-Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "התעלם"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "פרסם את מזהי המראה של <gateway-alias>/<model> ב-/v1/models עבור מודלים שבעליהם הקנוניים אין להם אישור פעיל אך שער העברת נתונים עם אישור פעיל מנתב אותם. אזהרה: מוסיף רשומות קטלוג לכל הלקוחות כאשר זה מופעל באופן גלובלי.",
   "radarPage": {
     "title": "קטלוג רדאר",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "पार्टनर लिंक",
     "dismissAriaLabel": "खारिज करें"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute अब VS Code Copilot Chat के अंदर चलता है",
+    "description": "मुफ़्त OmniCopilot एक्सटेंशन इंस्टॉल करें और सभी OmniRoute मॉडल सीधे उसी Copilot Chat मॉडल पिकर में दिखेंगे जिसे आप पहले से इस्तेमाल करते हैं।",
+    "cta": "एक्सटेंशन प्राप्त करें",
+    "secondaryNote": "Open VSX पर भी उपलब्ध (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "खारिज करें"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> मिरर आईडी को /v1/models पर विज्ञापित करें उन मॉडलों के लिए जिनके कैनोनिकल मालिक के पास कोई सक्रिय क्रेडेंशियल नहीं है लेकिन एक पासथ्रू गेटवे के साथ सक्रिय क्रेडेंशियल उन्हें रूट करता है। चेतावनी: जब वैश्विक रूप से सक्षम किया जाता है तो सभी क्लाइंट्स के लिए कैटलॉग प्रविष्टियाँ जोड़ता है।",
   "radarPage": {
     "title": "रडार कैटलॉग",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerhivatkozás",
     "dismissAriaLabel": "Elvetés"
   },
+  "vscodeCopilotBanner": {
+    "title": "Az OmniRoute mostantól fut a VS Code Copilot Chatben",
+    "description": "Telepítsd az ingyenes OmniCopilot bővítményt, és minden OmniRoute modell megjelenik a Copilot Chat modellválasztójában, amit már használsz.",
+    "cta": "Bővítmény letöltése",
+    "secondaryNote": "Elérhető az Open VSX-en is (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Elvetés"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Hirdesse a <gateway-alias>/<model> tükör azonosítókat a /v1/models-on olyan modellekhez, amelyek kanonikus tulajdonosa nem rendelkezik aktív hitelesítő adatokkal, de egy átjáró, amelynek aktív hitelesítő adatai vannak, irányítja őket. Figyelmeztetés: globális engedélyezés esetén a katalógus bejegyzéseket ad hozzá az összes klienshez.",
   "radarPage": {
     "title": "Radar Katalógus",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute kini berjalan di dalam VS Code Copilot Chat",
+    "description": "Instal ekstensi OmniCopilot gratis dan setiap model OmniRoute akan muncul langsung di pemilih model Copilot Chat yang sudah kamu gunakan.",
+    "cta": "Dapatkan Ekstensi",
+    "secondaryNote": "Juga tersedia di Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Tutup"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Iklankan <gateway-alias>/<model> ID cermin di /v1/models untuk model yang pemilik kanoniknya tidak memiliki kredensial aktif tetapi gateway passthrough dengan kredensial aktif mengarahkannya. Peringatan: menambahkan entri katalog untuk semua klien saat diaktifkan secara global.",
   "radarPage": {
     "title": "Katalog Radar",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Tautan mitra",
     "dismissAriaLabel": "Tutup"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute kini berjalan di dalam VS Code Copilot Chat",
+    "description": "Instal ekstensi OmniCopilot gratis dan setiap model OmniRoute akan muncul langsung di pemilih model Copilot Chat yang sudah kamu gunakan.",
+    "cta": "Dapatkan Ekstensi",
+    "secondaryNote": "Juga tersedia di Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Tutup"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Iklankan id cermin <gateway-alias>/<model> di /v1/models untuk model yang pemilik kanoniknya tidak memiliki kredensial aktif tetapi gateway passthrough dengan kredensial aktif mengarahkannya. Peringatan: menambahkan entri katalog untuk semua klien saat diaktifkan secara global.",
   "radarPage": {
     "title": "रडार कैटलॉग",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Link partner",
     "dismissAriaLabel": "Ignora"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute ora funziona dentro VS Code Copilot Chat",
+    "description": "Installa l'estensione gratuita OmniCopilot e ogni modello OmniRoute comparirà direttamente nel selettore di modelli di Copilot Chat che già usi.",
+    "cta": "Ottieni l'estensione",
+    "secondaryNote": "Disponibile anche su Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Ignora"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Mostra gli id specchio <gateway-alias>/<model> su /v1/models per i modelli il cui proprietario canonico non ha credenziali attive ma un gateway di transito con una credenziale attiva li instrada. Attenzione: aggiunge voci nel catalogo per tutti i client quando abilitato globalmente.",
   "radarPage": {
     "title": "Catalogo Radar",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "パートナーリンク",
     "dismissAriaLabel": "閉じる"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRouteがVS Code Copilot Chat内で動作するようになりました",
+    "description": "無料のOmniCopilot拡張機能をインストールすると、すでに使っているCopilot Chatのモデル選択画面にすべてのOmniRouteモデルが表示されます。",
+    "cta": "拡張機能を入手",
+    "secondaryNote": "Open VSXでも利用可能（Cursor、Windsurf、VSCodiumなど）",
+    "dismissAriaLabel": "閉じる"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "<gateway-alias>/<model> ミラー ID を /v1/models で広告します。これは、正規の所有者にアクティブな資格情報がないが、パススルーゲートウェイがアクティブな資格情報でルーティングされるモデルに適用されます。警告: グローバルに有効にすると、すべてのクライアントにカタログエントリが追加されます。",
   "radarPage": {
     "title": "レーダーカタログ",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "파트너 링크",
     "dismissAriaLabel": "닫기"
   },
+  "vscodeCopilotBanner": {
+    "title": "이제 OmniRoute가 VS Code Copilot Chat 안에서 실행됩니다",
+    "description": "무료 OmniCopilot 확장 프로그램을 설치하면 이미 사용 중인 Copilot Chat 모델 선택기에 모든 OmniRoute 모델이 바로 나타납니다.",
+    "cta": "확장 프로그램 받기",
+    "secondaryNote": "Open VSX(Cursor, Windsurf, VSCodium 등)에서도 이용 가능",
+    "dismissAriaLabel": "닫기"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "<gateway-alias>/<model> 미러 ID를 /v1/models에서 광고합니다. 이는 정식 소유자가 활성 자격 증명이 없지만 패스스루 게이트웨이가 활성 자격 증명으로 라우팅하는 모델에 해당합니다. 경고: 전역적으로 활성화되면 모든 클라이언트에 대한 카탈로그 항목이 추가됩니다.",
   "radarPage": {
     "title": "레이더 카탈로그",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "भागीदार लिंक",
     "dismissAriaLabel": "बंद करा"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute आता VS Code Copilot Chat मध्ये चालते",
+    "description": "मोफत OmniCopilot विस्तार स्थापित करा आणि तुम्ही आधीच वापरत असलेल्या Copilot Chat मॉडेल निवडकात प्रत्येक OmniRoute मॉडेल दिसेल.",
+    "cta": "विस्तार मिळवा",
+    "secondaryNote": "Open VSX वर देखील उपलब्ध (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "बंद करा"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "<gateway-alias>/<model> मिरर आयडीज /v1/models वर जाहिरात करा त्या मॉडेलसाठी ज्यांचे कॅनॉनिकल मालकाकडे सक्रिय क्रेडेन्शियल नाही परंतु एक पासथ्रू गेटवे ज्यामध्ये सक्रिय क्रेडेन्शियल आहे त्यांना रूट करते. चेतावणी: जागतिक स्तरावर सक्षम केल्यास सर्व क्लायंटसाठी कॅटलॉग नोंदी जोडते.",
   "radarPage": {
     "title": "रडार कॅटलॉग",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Pautan rakan kongsi",
     "dismissAriaLabel": "Tutup"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute kini berfungsi dalam VS Code Copilot Chat",
+    "description": "Pasang sambungan OmniCopilot percuma dan setiap model OmniRoute akan muncul terus dalam pemilih model Copilot Chat yang anda sudah gunakan.",
+    "cta": "Dapatkan Sambungan",
+    "secondaryNote": "Juga di Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Tutup"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Iklankan <gateway-alias>/<model> mirror ids pada /v1/models untuk model yang pemilik kanoniknya tiada kelayakan aktif tetapi gateway passthrough dengan kelayakan aktif mengarahkannya. Amaran: menambah entri katalog untuk semua klien apabila diaktifkan secara global.",
   "radarPage": {
     "title": "Katalog Radar",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerlink",
     "dismissAriaLabel": "Sluiten"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute draait nu binnen VS Code Copilot Chat",
+    "description": "Installeer de gratis OmniCopilot-extensie en elk OmniRoute-model verschijnt direct in de Copilot Chat-modelkiezer die je al gebruikt.",
+    "cta": "Extensie downloaden",
+    "secondaryNote": "Ook op Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Sluiten"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Adverteer <gateway-alias>/<model> mirror-id's op /v1/models voor modellen waarvan de canonieke eigenaar geen actieve referentie heeft, maar een passthrough-gateway met een actieve referentie ze doorstuurt. Waarschuwing: voegt catalogusvermeldingen toe voor alle klanten wanneer wereldwijd ingeschakeld.",
   "radarPage": {
     "title": "Radar Catalogus",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerlenke",
     "dismissAriaLabel": "Avvis"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute kjører nå inne i VS Code Copilot Chat",
+    "description": "Installer den gratis OmniCopilot-utvidelsen, så vises hver OmniRoute-modell rett i Copilot Chat-modellvelgeren du allerede bruker.",
+    "cta": "Last ned utvidelsen",
+    "secondaryNote": "Også på Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Avvis"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Reklamer <gateway-alias>/<model> speil-id-er på /v1/models for modeller hvis kanoniske eier ikke har aktive legitimasjoner, men en passthrough-gateway med aktive legitimasjoner ruter dem. Advarsel: legger til katalogoppføringer for alle klienter når det er aktivert globalt.",
   "radarPage": {
     "title": "Radar Katalog",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Link ng kasosyo",
     "dismissAriaLabel": "I-dismiss"
   },
+  "vscodeCopilotBanner": {
+    "title": "Ang OmniRoute ay gumagana na ngayon sa loob ng VS Code Copilot Chat",
+    "description": "I-install ang libreng OmniCopilot extension at lalabas ang bawat OmniRoute model diretso sa Copilot Chat model picker na ginagamit mo na.",
+    "cta": "Kunin ang Extension",
+    "secondaryNote": "Nasa Open VSX din (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "I-dismiss"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "I-anunsyo ang <gateway-alias>/<model> mirror ids sa /v1/models para sa mga modelong ang canonical owner ay walang aktibong credential ngunit may passthrough gateway na may aktibong credential na nagruruta sa kanila. Babala: nagdadagdag ng mga entry sa katalogo para sa lahat ng kliyente kapag pinagana nang globally.",
   "radarPage": {
     "title": "Radar Catalog",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Link partnerski",
     "dismissAriaLabel": "Odrzuć"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute działa teraz w VS Code Copilot Chat",
+    "description": "Zainstaluj darmowe rozszerzenie OmniCopilot, a każdy model OmniRoute pojawi się od razu w selektorze modeli Copilot Chat, którego już używasz.",
+    "cta": "Pobierz rozszerzenie",
+    "secondaryNote": "Dostępne również na Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Odrzuć"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Reklamuj identyfikatory luster <gateway-alias>/<model> na /v1/models dla modeli, których kanoniczny właściciel nie ma aktywnego poświadczenia, ale brama passthrough z aktywnym poświadczeniem je kieruje. Uwaga: dodaje wpisy katalogu dla wszystkich klientów, gdy jest włączone globalnie.",
   "radarPage": {
     "title": "Katalog Radar",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -13088,6 +13088,13 @@
     "partnerLinkNote": "Link de parceria",
     "dismissAriaLabel": "Dispensar"
   },
+  "vscodeCopilotBanner": {
+    "title": "O OmniRoute agora funciona dentro do VS Code Copilot Chat",
+    "description": "Instale a extensão gratuita OmniCopilot e cada modelo do OmniRoute aparece direto no seletor de modelos do Copilot Chat que você já usa.",
+    "cta": "Baixar a Extensão",
+    "secondaryNote": "Também disponível na Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Dispensar"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Anuncie os IDs de espelho <gateway-alias>/<model> em /v1/models para modelos cujo proprietário canônico não possui credenciais ativas, mas um gateway de passagem com credenciais ativas os roteia. Aviso: adiciona entradas de catálogo para todos os clientes quando ativado globalmente.",
   "radarPage": {
     "title": "Catálogo Radar",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Link de parceiro",
     "dismissAriaLabel": "Dispensar"
   },
+  "vscodeCopilotBanner": {
+    "title": "O OmniRoute agora funciona dentro do VS Code Copilot Chat",
+    "description": "Instale a extensão gratuita OmniCopilot e cada modelo do OmniRoute surge diretamente no seletor de modelos do Copilot Chat que já utiliza.",
+    "cta": "Obter a Extensão",
+    "secondaryNote": "Também disponível na Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Dispensar"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Anuncie <gateway-alias>/<model> IDs de espelho em /v1/models para modelos cujo proprietário canónico não tem credenciais ativas, mas um gateway de passagem com credenciais ativas os encaminha. Aviso: adiciona entradas de catálogo para todos os clientes quando ativado globalmente.",
   "radarPage": {
     "title": "Catálogo Radar",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Link de partener",
     "dismissAriaLabel": "Închide"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute rulează acum în VS Code Copilot Chat",
+    "description": "Instalează extensia gratuită OmniCopilot și fiecare model OmniRoute apare direct în selectorul de modele din Copilot Chat pe care îl folosești deja.",
+    "cta": "Obține extensia",
+    "secondaryNote": "Disponibil și pe Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Închide"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Publica ID-urile oglinzii <gateway-alias>/<model> pe /v1/models pentru modelele al căror proprietar canonical nu are un acreditiv activ, dar un gateway passthrough cu un acreditiv activ le rotește. Atenție: adaugă intrări în catalog pentru toți clienții când este activat global.",
   "radarPage": {
     "title": "Catalog Radar",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Партнерская ссылка",
     "dismissAriaLabel": "Закрыть"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute теперь работает внутри VS Code Copilot Chat",
+    "description": "Установите бесплатное расширение OmniCopilot, и каждая модель OmniRoute появится прямо в выборе моделей Copilot Chat, которым вы уже пользуетесь.",
+    "cta": "Получить расширение",
+    "secondaryNote": "Также доступно на Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Закрыть"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Рекламируйте <gateway-alias>/<model> идентификаторы зеркал на /v1/models для моделей, у которых канонический владелец не имеет активной учетной записи, но шлюз с пропуском с активной учетной записью маршрутизирует их. Внимание: добавляет записи каталога для всех клиентов при глобальном включении.",
   "radarPage": {
     "title": "Каталог Радар",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerský odkaz",
     "dismissAriaLabel": "Zavrieť"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute teraz beží priamo v VS Code Copilot Chat",
+    "description": "Nainštalujte si bezplatné rozšírenie OmniCopilot a každý model OmniRoute sa zobrazí priamo vo výbere modelov Copilot Chat, ktorý už používate.",
+    "cta": "Získať rozšírenie",
+    "secondaryNote": "Dostupné aj na Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Zavrieť"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Inzerujte <gateway-alias>/<model> zrkadlové ID na /v1/models pre modely, ktorých kanonický vlastník nemá aktívnu certifikáciu, ale pasívny gateway s aktívnou certifikáciou ich smeruje. Upozornenie: pri globálnom povolení pridáva záznamy do katalógu pre všetkých klientov.",
   "radarPage": {
     "title": "Radar katalóg",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Partnerlänk",
     "dismissAriaLabel": "Avvisa"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute körs nu inuti VS Code Copilot Chat",
+    "description": "Installera det kostnadsfria tillägget OmniCopilot så visas alla OmniRoute-modeller direkt i den modellväljare i Copilot Chat som du redan använder.",
+    "cta": "Hämta tillägget",
+    "secondaryNote": "Finns även på Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Avvisa"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Annonsera <gateway-alias>/<model> spegel-id på /v1/models för modeller vars kanoniska ägare inte har någon aktiv legitimation men en passthrough-gateway med en aktiv legitimation dirigerar dem. Varning: lägger till katalogposter för alla klienter när det är aktiverat globalt.",
   "radarPage": {
     "title": "Radar Katalog",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Kiungo cha mshirika",
     "dismissAriaLabel": "Ondoa"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute sasa inafanya kazi ndani ya VS Code Copilot Chat",
+    "description": "Sakinisha kiendelezi cha bure cha OmniCopilot na kila mfano wa OmniRoute utaonekana moja kwa moja kwenye kichagua-mfano cha Copilot Chat unachotumia tayari.",
+    "cta": "Pata Kiendelezi",
+    "secondaryNote": "Pia kwenye Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Ondoa"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Tangaza <gateway-alias>/<model> vitambulisho vya kioo kwenye /v1/models kwa ajili ya mifano ambayo mmiliki wake wa kanuni hana akreditivu hai lakini lango la kupitisha lenye akreditivu hai linaelekeza kwao. Onyo: inaongeza orodha za katalogi kwa wateja wote inapowezeshwa kimataifa.",
   "radarPage": {
     "title": "Radar Katalog",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "பங்குதாரர் இணைப்பு",
     "dismissAriaLabel": "நிராகரி"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute இப்போது VS Code Copilot Chat-க்குள் இயங்குகிறது",
+    "description": "இலவச OmniCopilot நீட்டிப்பை நிறுவவும், நீங்கள் ஏற்கெனவே பயன்படுத்தும் Copilot Chat மாடல் தேர்வியில் ஒவ்வொரு OmniRoute மாடலும் நேரடியாகத் தோன்றும்.",
+    "cta": "நீட்டிப்பைப் பெறுங்கள்",
+    "secondaryNote": "Open VSX (Cursor, Windsurf, VSCodium…) இலும் கிடைக்கிறது",
+    "dismissAriaLabel": "நிராகரி"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> மின்னூட்ட அடையாளங்களை /v1/models இல் விளம்பரம் செய்கிறது, அதன் கானோனிக்கல் உரிமையாளருக்கு செயல்பாட்டில் உள்ள சான்றிதழ் இல்லை ஆனால் ஒரு பாஸ்த்ரூ கேட்வே செயல்பாட்டில் உள்ள சான்றிதழ் அவற்றை வழிநடத்துகிறது. எச்சரிக்கை: உலகளாவியமாக செயல்படுத்தப்படும் போது அனைத்து கிளையன்டுகளுக்கான பட்டியல் பதிவுகளைச் சேர்க்கிறது.",
   "radarPage": {
     "title": "ரேடார் பட்டியல்",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "భాగస్వామి లింక్",
     "dismissAriaLabel": "తీసివేయి"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute ఇప్పుడు VS Code Copilot Chatలో నడుస్తుంది",
+    "description": "ఉచిత OmniCopilot పొడిగింపును ఇన్‌స్టాల్ చేయండి, మీరు ఇప్పటికే ఉపయోగిస్తున్న Copilot Chat మోడల్ పికర్‌లో ప్రతి OmniRoute మోడల్ నేరుగా కనిపిస్తుంది.",
+    "cta": "పొడిగింపును పొందండి",
+    "secondaryNote": "Open VSX (Cursor, Windsurf, VSCodium…)లో కూడా అందుబాటులో ఉంది",
+    "dismissAriaLabel": "తీసివేయి"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> మిర్రర్ ఐడీలను /v1/models లో ప్రచారం చేయండి, కానోనికల్ యజమాని యాక్టివ్ క్రెడెన్షియల్ లేకపోతే కానీ యాక్టివ్ క్రెడెన్షియల్ రూట్ చేసే పాస్త్రూ గేట్వే ఉన్న మోడల్స్ కోసం. హెచ్చరిక: ఇది గ్లోబల్‌గా ఎనేబుల్ చేసినప్పుడు అన్ని క్లయింట్ల కోసం కాటలాగ్ ఎంట్రీలను జోడిస్తుంది.",
   "radarPage": {
     "title": "రాడార్ కాటలాగ్",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "ลิงก์พันธมิตร",
     "dismissAriaLabel": "ปิด"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute ทำงานภายใน VS Code Copilot Chat แล้ว",
+    "description": "ติดตั้งส่วนขยาย OmniCopilot ฟรี แล้วทุกโมเดลของ OmniRoute จะปรากฏในตัวเลือกโมเดลของ Copilot Chat ที่คุณใช้อยู่แล้วทันที",
+    "cta": "รับส่วนขยาย",
+    "secondaryNote": "มีให้ใช้งานบน Open VSX ด้วย (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "ปิด"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "โฆษณา <gateway-alias>/<model> รหัสกระจกบน /v1/models สำหรับโมเดลที่เจ้าของตามกฎหมายไม่มีข้อมูลรับรองที่ใช้งานอยู่ แต่มีเกตเวย์แบบผ่านที่มีข้อมูลรับรองที่ใช้งานอยู่ทำการส่งต่อพวกเขา เตือน: จะเพิ่มรายการในแคตตาล็อกสำหรับลูกค้าทั้งหมดเมื่อเปิดใช้งานทั่วโลก.",
   "radarPage": {
     "title": "แคตตาล็อกเรดาร์",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Ortaklık bağlantısı",
     "dismissAriaLabel": "Kapat"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute artık VS Code Copilot Chat içinde çalışıyor",
+    "description": "Ücretsiz OmniCopilot uzantısını yükleyin ve zaten kullandığınız Copilot Chat model seçicisinde her OmniRoute modeli görünsün.",
+    "cta": "Uzantıyı Al",
+    "secondaryNote": "Open VSX'te de mevcut (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Kapat"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "<gateway-alias>/<model> ayna kimliklerini /v1/models üzerinde, kanonik sahibi aktif bir kimliğe sahip olmayan ancak aktif bir kimliğe sahip bir geçiş geçidi tarafından yönlendirilen modeller için tanıtın. Uyarı: Küresel olarak etkinleştirildiğinde tüm istemciler için katalog girişleri ekler.",
   "radarPage": {
     "title": "Radar Kataloğu",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "Партнерське посилання",
     "dismissAriaLabel": "Закрити"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute тепер працює всередині VS Code Copilot Chat",
+    "description": "Встановіть безкоштовне розширення OmniCopilot, і кожна модель OmniRoute з'явиться прямо в переліку моделей Copilot Chat, яким ви вже користуєтесь.",
+    "cta": "Отримати розширення",
+    "secondaryNote": "Також доступно на Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Закрити"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Рекламуйте <gateway-alias>/<model> ідентифікатори дзеркал на /v1/models для моделей, власник яких не має активних облікових даних, але шлюз з пропуском з активними обліковими даними їх маршрутизує. Увага: додає записи каталогу для всіх клієнтів, коли увімкнено глобально.",
   "radarPage": {
     "title": "Каталог Радар",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "پارٹنر لنک",
     "dismissAriaLabel": "خارج کریں"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute اب VS Code Copilot Chat کے اندر چلتا ہے",
+    "description": "مفت OmniCopilot ایکسٹینشن انسٹال کریں اور ہر OmniRoute ماڈل اسی Copilot Chat ماڈل پکر میں نظر آئے گا جسے آپ پہلے سے استعمال کرتے ہیں۔",
+    "cta": "ایکسٹینشن حاصل کریں",
+    "secondaryNote": "Open VSX پر بھی دستیاب ہے (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "خارج کریں"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "/gateway-alias/<model> کی عکاسی کے IDs کو /v1/models پر اشتہار دیں ان ماڈلز کے لیے جن کے حقیقی مالک کے پاس کوئی فعال سند نہیں ہے لیکن ایک پاس تھرو گیٹ وے جس کے پاس ایک فعال سند ہے انہیں روٹ کرتا ہے۔ انتباہ: جب عالمی طور پر فعال کیا جائے تو یہ تمام کلائنٹس کے لیے کیٹلاگ کی اندراجات شامل کرتا ہے۔",
   "radarPage": {
     "title": "ریڈار کیٹلاگ",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -13088,6 +13088,13 @@
     "partnerLinkNote": "Partner link",
     "dismissAriaLabel": "Dismiss"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute giờ đây chạy ngay trong VS Code Copilot Chat",
+    "description": "Cài đặt tiện ích mở rộng OmniCopilot miễn phí và mọi mô hình OmniRoute sẽ xuất hiện ngay trong bộ chọn mô hình Copilot Chat mà bạn đang dùng.",
+    "cta": "Nhận tiện ích mở rộng",
+    "secondaryNote": "Cũng có trên Open VSX (Cursor, Windsurf, VSCodium…)",
+    "dismissAriaLabel": "Đóng"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "Công bố các id phản chiếu &lt;gateway-alias&gt;/&lt;model&gt; trên /v1/models cho các mô hình có chủ sở hữu chuẩn không có thông tin xác thực hoạt động nhưng một cổng chuyển tiếp có thông tin xác thực hoạt động định tuyến được chúng. Cảnh báo: khi bật, số mục trong danh mục tăng lên với mọi client.",
   "radarPage": {
     "title": "Danh mục Radar",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "合作伙伴链接",
     "dismissAriaLabel": "关闭"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute 现已可在 VS Code Copilot Chat 中运行",
+    "description": "安装免费的 OmniCopilot 扩展，每个 OmniRoute 模型都会直接出现在你已经在用的 Copilot Chat 模型选择器中。",
+    "cta": "获取扩展",
+    "secondaryNote": "同样支持 Open VSX（Cursor、Windsurf、VSCodium…）",
+    "dismissAriaLabel": "关闭"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "在/v1/models上为那些规范所有者没有活动凭证但通过一个具有活动凭证的通道网关路由的模型宣传<gateway-alias>/<model>镜像ID。警告：当全局启用时，会为所有客户端添加目录条目。",
   "radarPage": {
     "title": "雷达目录",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -13081,6 +13081,13 @@
     "partnerLinkNote": "合作夥伴連結",
     "dismissAriaLabel": "關閉"
   },
+  "vscodeCopilotBanner": {
+    "title": "OmniRoute 現已可在 VS Code Copilot Chat 中運作",
+    "description": "安裝免費的 OmniCopilot 擴充功能，每個 OmniRoute 模型都會直接出現在你已經在用的 Copilot Chat 模型選擇器中。",
+    "cta": "取得擴充功能",
+    "secondaryNote": "同樣支援 Open VSX（Cursor、Windsurf、VSCodium…）",
+    "dismissAriaLabel": "關閉"
+  },
   "featureFlagExposeFunctionalGatewayMirrorsDescription": "在 /v1/models 上廣告 <gateway-alias>/<model> 鏡像 ID，針對那些其正規擁有者沒有有效憑證但有一個通過網關且有有效憑證路由它們的模型。警告：當全域啟用時，會為所有客戶端添加目錄條目。",
   "radarPage": {
     "title": "雷達目錄",

--- a/src/shared/constants/homeWidgets.ts
+++ b/src/shared/constants/homeWidgets.ts
@@ -1,5 +1,0 @@
-/**
- * Settings keys for widgets that can be pinned / shown from Appearance settings.
- */
-
-export const PIN_PROVIDER_QUOTA_TO_HOME_KEY = "pinProviderQuotaToHome";

--- a/tests/unit/ui/vscodeCopilotBanner.test.tsx
+++ b/tests/unit/ui/vscodeCopilotBanner.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+/**
+ * VscodeCopilotBanner — dismissible home-page banner announcing the OmniCopilot
+ * VS Code extension. No version gate (durable feature announcement), mirrors
+ * KimiSponsorBanner's render/dismiss/persistence contract (see
+ * tests/unit/ui/kimiSponsorBanner.test.tsx).
+ */
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "omniroute-vscode-copilot-banner-dismissed-v1";
+const MARKETPLACE_URL = "https://marketplace.visualstudio.com/items?itemName=diegosouzapw.omnicopilot";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
+
+async function renderBanner(): Promise<HTMLDivElement> {
+  const { default: VscodeCopilotBanner } = await import(
+    "../../../src/app/(dashboard)/dashboard/VscodeCopilotBanner"
+  );
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<VscodeCopilotBanner />);
+  });
+  return container;
+}
+
+describe("VscodeCopilotBanner", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("renders with the CTA pointing at the VS Code Marketplace listing", async () => {
+    const container = await renderBanner();
+    expect(container.querySelector("[role='complementary']")).not.toBeNull();
+    expect(container.textContent).toContain("title");
+    expect(container.textContent).toContain("cta");
+    const link = container.querySelector("a[href]");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe(MARKETPLACE_URL);
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("shows the Open VSX secondary note near the CTA", async () => {
+    const container = await renderBanner();
+    expect(container.textContent).toContain("secondaryNote");
+  });
+
+  it("dismiss button hides the banner and persists the dismissal to localStorage", async () => {
+    const container = await renderBanner();
+    expect(container.querySelector("[role='complementary']")).not.toBeNull();
+
+    const dismissButton = container.querySelector("button");
+    expect(dismissButton).not.toBeNull();
+    act(() => {
+      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector("[role='complementary']")).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("stays hidden across a fresh render once dismissed (localStorage persistence)", async () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    const container = await renderBanner();
+    expect(container.querySelector("[role='complementary']")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `VscodeCopilotBanner` — a dismissible banner on the dashboard home page announcing the
  OmniCopilot VS Code extension, rendered right below `KimiSponsorBanner` with the same
  size/shape/CSS pattern (no version-window gate — durable feature announcement, not a
  time-boxed sponsor deal). CTA links to the VS Code Marketplace listing; a secondary note
  points to Open VSX (Cursor, Windsurf, VSCodium…).
- Removes the "Provider Quota" card that could be pinned to the dashboard home page
  (`ProviderQuotaWidget` render call + `pinProviderQuotaToHome` state/settings-fetch in
  `HomePageClient.tsx`), and the now-dead "Pin Provider Quota Limits to Home" toggle in
  Settings → Appearance.
- **Not touched**: `ProviderQuotaWidget.tsx` itself (still a valid, independently tested
  component — just no longer mounted anywhere), its component-level tests, the standalone
  `/dashboard/quota` page, and the "Provider Quota auto refresh" toggle + interval setting in
  Appearance — that auto-refresh setting is shared with `/dashboard/quota`, confirmed via
  `src/app/(dashboard)/dashboard/quota/page.tsx` reading the same `autoRefreshProviderQuota`/
  `autoRefreshProviderQuotaInterval` keys, so removing it would have broken that page.
- Localized in all 43 locales (`vscodeCopilotBanner` namespace, 5 keys × 42 non-English
  locales, purely additive — no pre-existing `__MISSING__` debt touched).

⚠️ base-red inherited: #9985

## Test plan
- [x] `npm run typecheck:core` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run check:dead-code` — 250 symbols (baseline 415, no regression)
- [x] `npm run i18n:check-ui-coverage` — PASS, all 42 locales ≥80% (99.7–100%)
- [x] `npm run check:docs-sync` — PASS
- [x] New `tests/unit/ui/vscodeCopilotBanner.test.tsx` (4 tests: CTA link, secondary note,
      dismiss + localStorage persistence) — passing
- [x] Existing `ProviderQuotaWidget`/quota-grid/appearance/home-client sibling tests re-run —
      all still passing (confirms the removal didn't regress the widget itself or the shared
      auto-refresh setting)