### PR TITLE
fix(compliance): redact extra provider API keys

### DIFF
--- a/changelog.d/fixes/10521-audit-extra-api-keys-redaction.md
+++ b/changelog.d/fixes/10521-audit-extra-api-keys-redaction.md
@@ -1,0 +1,1 @@
+- **fix(compliance):** redact additional provider API keys from audit-log payloads ([#10521](https://github.com/diegosouzapw/OmniRoute/pull/10521)) — thanks @Zartharas

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -111,6 +111,7 @@ const AUDIT_LOG_REQUIRED_COLUMNS: Record<string, string> = {
 
 const SENSITIVE_AUDIT_KEYS = new Set([
   "apikey",
+  "extraapikeys",
   "accesstoken",
   "refreshtoken",
   "idtoken",

--- a/tests/unit/compliance-index.test.ts
+++ b/tests/unit/compliance-index.test.ts
@@ -92,6 +92,12 @@ test("compliance audit log supports structured filters, totals and secret redact
       nested: {
         refreshToken: "refresh-secret",
       },
+      providerSpecificData: {
+        extraApiKeys: ["sk-extra-1", "sk-extra-2"],
+        token: "token-secret",
+        userToken: "user-token-secret",
+        cookie: "cookie-secret",
+      },
       changedFields: ["defaultModel"],
     },
     ipAddress: "10.0.0.4",
@@ -132,6 +138,12 @@ test("compliance audit log supports structured filters, totals and secret redact
     apiKey: "[redacted]",
     nested: {
       refreshToken: "[redacted]",
+    },
+    providerSpecificData: {
+      extraApiKeys: "[redacted]",
+      token: "[redacted]",
+      userToken: "[redacted]",
+      cookie: "[redacted]",
     },
     changedFields: ["defaultModel"],
   });


### PR DESCRIPTION
## Summary

Redact `providerSpecificData.extraApiKeys` before provider credential audit metadata is serialized.

## Root cause

Audit serialization already recursively redacts sensitive keys such as `apiKey`, `token`, `userToken`, `cookie`, secrets, and passwords. However, the normalized key for `extraApiKeys` is `extraapikeys`, which did not match the existing singular `apiKey` rules. As a result, an array of additional provider API keys could survive audit serialization unchanged.

## Fix

Add the exact normalized `extraapikeys` key to the existing audit sensitive-key allowlist. This keeps the change narrow and avoids overly broad plural matching that could redact unrelated telemetry fields.

Extend the existing compliance audit regression to verify redaction of `extraApiKeys` alongside the already-covered token and cookie credential forms.

## Validation

- compliance audit regression: 5/5 passed
- source scoped ESLint: PASS
- base/current test lint debt parity: 5 pre-existing `no-explicit-any` findings in both
- `npm run typecheck:core`: PASS
- `git diff --check`: PASS

No production credential values are included in the change or validation output.