### PR TITLE
fix(embeddings): cool down account on hard errors (402/401/5xx)

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1083,11 +1083,6 @@
       "count": 1
     }
   },
-  "src/lib/embeddings/service.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/lib/evals/runtime.ts": {
     "no-restricted-imports": {
       "count": 1

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -10,13 +10,14 @@ import { errorResponse, unavailableResponse } from "@omniroute/open-sse/utils/er
 import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
-import { getProviderCredentials, clearRecoveredProviderState } from "@/sse/services/auth";
 import {
-  getCachedProviderNodes,
-  getComboByName,
-  getCombos,
-  getDatabaseSettings,
-} from "@/lib/localDb";
+  getProviderCredentials,
+  clearRecoveredProviderState,
+  markAccountUnavailable,
+} from "@/sse/services/auth";
+import { getCachedProviderNodes } from "@/lib/db/readCache";
+import { getComboByName, getCombos } from "@/lib/db/combos";
+import { getDatabaseSettings } from "@/lib/db/databaseSettings";
 import { resolveProxyForConnection } from "@/lib/db/settings";
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
@@ -309,7 +310,7 @@ export async function createEmbeddingResponse(
       // #10347 — thread the selected connection id so handleEmbedding can cool the
       // account on a hard upstream failure (previously always null on /v1/embeddings).
       connectionId:
-        ((credentials as { connectionId?: string } | null)?.connectionId) ||
+        (credentials as { connectionId?: string } | null)?.connectionId ||
         options.connectionId ||
         connectionIdForProxy ||
         null,
@@ -337,6 +338,33 @@ export async function createEmbeddingResponse(
     return new Response(JSON.stringify(result.data), {
       status: result.status,
       headers: responseHeaders,
+    });
+  }
+
+  // #10347: cool down the account on hard errors (402 subscription expired,
+  // 401 revoked, 403 forbidden, 404 model gone, 429 rate limit, 5xx server
+  // errors) so the next embedding request skips this account. Mirrors chat.ts
+  // behavior.
+  // Skip for 400 (bad request) — the account is fine, the request was wrong.
+  // Best-effort: don't block the error response on the DB write.
+  const HARD_ERROR_STATUSES = new Set([401, 402, 403, 404, 429, 500, 502, 503, 504]);
+  if (
+    credentials &&
+    "connectionId" in credentials &&
+    typeof credentials.connectionId === "string" &&
+    HARD_ERROR_STATUSES.has(result.status)
+  ) {
+    markAccountUnavailable(
+      credentials.connectionId,
+      result.status,
+      result.error || "Embedding provider error",
+      provider,
+      resolvedModel || null
+    ).catch((err) => {
+      log.debug(
+        "EMBED",
+        `Cooldown write failed for ${provider}/${credentials.connectionId?.slice(0, 8)}: ${err}`
+      );
     });
   }
 

--- a/tests/unit/embedding-account-cooldown-10347.test.ts
+++ b/tests/unit/embedding-account-cooldown-10347.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-embed-cooldown-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "embed-cooldown-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedConnection(provider: string): Promise<string> {
+  const conn = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    apiKey: `${provider}-key`,
+    isActive: true,
+    testStatus: "active",
+  });
+  return (conn as Record<string, unknown>).id as string;
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#10347: markAccountUnavailable triggers cooldown on embedding 402", async () => {
+  await resetStorage();
+  const connId = await seedConnection("mistral");
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    402,
+    "Check your subscription on https://admin.mistral.ai/subscription",
+    "mistral",
+    "mistral-embed"
+  );
+
+  assert.strictEqual(result.shouldFallback, true, "402 must trigger account cooldown");
+
+  // Verify the connection was marked — 402 is terminal (credits_exhausted),
+  // which sets testStatus but not rateLimitedUntil
+  const conn = await providersDb.getProviderConnectionById(connId);
+  assert.strictEqual(
+    conn.testStatus,
+    "credits_exhausted",
+    "402 must mark connection credits_exhausted"
+  );
+});
+
+test("#10347: markAccountUnavailable triggers cooldown on embedding 500", async () => {
+  await resetStorage();
+  const connId = await seedConnection("mistral");
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    500,
+    "Internal server error",
+    "mistral",
+    "mistral-embed"
+  );
+
+  assert.strictEqual(result.shouldFallback, true, "500 must trigger account cooldown");
+  const conn = await providersDb.getProviderConnectionById(connId);
+  assert.strictEqual(conn.testStatus, "unavailable", "500 must mark connection unavailable");
+});
+
+test("#10347: embedding 400 (bad request) does NOT trigger account cooldown", async () => {
+  await resetStorage();
+  const connId = await seedConnection("mistral");
+
+  // 400 bad request is a client error, not an account issue — should not cool down
+  const result = await auth.markAccountUnavailable(
+    connId,
+    400,
+    "Invalid embedding input format",
+    "mistral",
+    "mistral-embed"
+  );
+
+  // Generic 400 returns shouldFallback:false (not account-fallback-worthy)
+  assert.strictEqual(result.shouldFallback, false, "400 bad request must not trigger cooldown");
+  const conn = await providersDb.getProviderConnectionById(connId);
+  assert.strictEqual(conn.testStatus, "active", "400 must keep connection active");
+});

--- a/tests/unit/embedding-cooldown-integration-10347.test.ts
+++ b/tests/unit/embedding-cooldown-integration-10347.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// #10347 integration: exercise createEmbeddingResponse end-to-end with a
+// mocked upstream that returns 402, then verify the connection gets cooled
+// down. This proves the production code path actually calls
+// markAccountUnavailable — the direct-call tests in
+// embedding-account-cooldown-10347.test.ts would pass even if the
+// production block were removed.
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-embed-int-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "embed-int-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+
+function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedConnection(
+  provider: string,
+  overrides: Record<string, unknown> = {}
+): Promise<string> {
+  const conn = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    apiKey: `${provider}-key`,
+    isActive: true,
+    testStatus: "active",
+    ...overrides,
+  });
+  return (conn as Record<string, unknown>).id as string;
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("createEmbeddingResponse marks connection on upstream 402", async () => {
+  resetStorage();
+  const connId = await seedConnection("mistral");
+
+  // Mock upstream to return 402 (subscription expired).
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({ error: "Check your subscription on https://admin.mistral.ai/subscription" }),
+      { status: 402, headers: { "Content-Type": "application/json" } }
+    )) as typeof globalThis.fetch;
+
+  try {
+    // Import the service AFTER seeding the DB so its module-level caches
+    // see the seeded connection.
+    const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+
+    // Call the production path — this must exercise the markAccountUnavailable
+    // block we added in #10347.
+    const res = await createEmbeddingResponse(
+      { model: "mistral-embed", input: "hello" },
+      { connectionId: connId }
+    );
+
+    assert.equal(res.status, 402, "must return upstream status");
+
+    // Give the fire-and-forget markAccountUnavailable call time to settle.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    // Verify the connection was actually marked — this is the assertion
+    // that would FAIL if the production block were removed.
+    const conn = await providersDb.getProviderConnectionById(connId);
+    assert.equal(
+      conn.testStatus,
+      "credits_exhausted",
+      "402 must mark connection credits_exhausted via production code path"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("createEmbeddingResponse skips 400 (bad request) — no cooldown", async () => {
+  resetStorage();
+  const connId = await seedConnection("mistral");
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ error: "Invalid embedding input format" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof globalThis.fetch;
+
+  try {
+    const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+
+    const res = await createEmbeddingResponse(
+      { model: "mistral-embed", input: "hello" },
+      { connectionId: connId }
+    );
+
+    assert.equal(res.status, 400, "must return upstream status");
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    const conn = await providersDb.getProviderConnectionById(connId);
+    assert.equal(
+      conn.testStatus,
+      "active",
+      "400 must NOT mark connection — account is fine, request was wrong"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/unit/embedding-cooldown-integration-10347.test.ts
+++ b/tests/unit/embedding-cooldown-integration-10347.test.ts
@@ -88,6 +88,66 @@ test("createEmbeddingResponse marks connection on upstream 402", async () => {
   }
 });
 
+test("cooled account is skipped on next request — second connection selected", async () => {
+  resetStorage();
+  const conn1 = await seedConnection("mistral", { apiKey: "mistral-key-1" });
+  const conn2 = await seedConnection("mistral", { apiKey: "mistral-key-2" });
+
+  const originalFetch = globalThis.fetch;
+  let fetchCallCount = 0;
+
+  try {
+    const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+
+    // First request: upstream returns 402 → conn1 gets cooled.
+    globalThis.fetch = (async () => {
+      fetchCallCount++;
+      return new Response(JSON.stringify({ error: "subscription expired" }), {
+        status: 402,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+
+    const res1 = await createEmbeddingResponse(
+      { model: "mistral-embed", input: "hello" },
+      { connectionId: conn1 }
+    );
+    assert.equal(res1.status, 402);
+
+    // Wait for fire-and-forget cooldown write.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    // Verify conn1 is cooled.
+    const conn1After = await providersDb.getProviderConnectionById(conn1);
+    assert.equal(conn1After.testStatus, "credits_exhausted", "conn1 must be cooled");
+
+    // Second request: upstream returns 200.
+    globalThis.fetch = (async () => {
+      fetchCallCount++;
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: [0.1, 0.2], index: 0 }],
+          model: "mistral-embed",
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof globalThis.fetch;
+
+    // Call without specifying connectionId — credential selection should
+    // skip conn1 (credits_exhausted) and pick conn2.
+    const res2 = await createEmbeddingResponse({ model: "mistral-embed", input: "world" }, {});
+    assert.equal(res2.status, 200, "second request must succeed via conn2");
+
+    // Verify conn2 is still healthy.
+    const conn2After = await providersDb.getProviderConnectionById(conn2);
+    assert.equal(conn2After.testStatus, "active", "conn2 must remain active");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("createEmbeddingResponse skips 400 (bad request) — no cooldown", async () => {
   resetStorage();
   const connId = await seedConnection("mistral");


### PR DESCRIPTION
**Problem**: Issue #10347 — embedding path does not cool down accounts on hard errors (402 subscription expired, 401 revoked, 403 forbidden, 5xx server errors). A dead Mistral subscription is retried on every embedding request instead of being cooled down and skipped.

Root cause: `src/lib/embeddings/service.ts` calls `handleEmbedding()` but does NOT call `markAccountUnavailable()` on error. The chat path does this in `src/sse/handlers/chat.ts:1942`.

**Fix**: Added `markAccountUnavailable` call in `createEmbeddingResponse()` after `handleEmbedding` returns an error. Only triggers on hard error statuses (401/402/403/404/429/5xx) — skips 400 (bad request) since the account is fine. Best-effort design (fire-and-forget with `.catch` debug logging) mirrors chat.ts behavior.

**Changes**:
- `src/lib/embeddings/service.ts`: import `markAccountUnavailable`, add cooldown call on hard errors, replace `@/lib/localDb` barrel import with direct `@/lib/db/` imports
- `tests/unit/embedding-account-cooldown-10347.test.ts`: 3 tests (402→credits_exhausted, 500→unavailable, 400→no cooldown)

**Verification**:
- 3/3 tests pass
- `npm run typecheck:core` clean
- Forge review R1-R3: all CONFIRMED findings are by-design (fire-and-forget pattern matches chat.ts) or already handled (anti-thundering-herd guard in markAccountUnavailable)

⚠️ base-red inherited: #9985
