### PR TITLE
refresh opencode provider

### DIFF
--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -13,145 +13,48 @@ export const opencode_goProvider: RegistryEntry = {
   authPrefix: "Bearer",
   defaultContextLength: 200000,
   models: [
-    // Port from decolua/9router 8efacc11: align with official Go endpoints —
-    // glm-5.2 is now advertised and Kimi chat traffic must route through
-    // `kimi-k2.7-code` (the live API rejects the plain `kimi-k2.7` alias for
-    // `/chat/completions`, even though the docs config example uses it).
-    // GLM-5.2 — base model + effort-tier aliases (#6922).
-    // OpencodeExecutor rewrites the alias to the canonical id and injects
-    // reasoning_effort, mirroring the deepseek-v4-pro-* pattern.
+    { id: "glm-5.3", name: "GLM-5.3", supportsReasoning: true },
+    { id: "glm-5.2-max", name: "GLM-5.2 (max)", supportsReasoning: true },
+    { id: "glm-5.2-high", name: "GLM-5.2 (high)", supportsReasoning: true },
     { id: "glm-5.2", name: "GLM-5.2", supportsReasoning: true },
-    { id: "glm-5.2-high", name: "GLM-5.2 (high effort)", supportsReasoning: true },
-    { id: "glm-5.2-max", name: "GLM-5.2 (max effort)", supportsReasoning: true },
-    { id: "glm-5.1", name: "GLM-5.1" },
-    { id: "glm-5", name: "GLM-5" },
-    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
-    { id: "kimi-k2.6", name: "Kimi K2.6" },
-    { id: "kimi-k2.5", name: "Kimi K2.5" },
-    // #8353: Kimi K3 base + max-effort alias from the OpenCode Go registry.
+    // OpenAI
+    { id: "gpt-5.6-luna", name: "GPT 5.6 Luna", contextLength: 1048576, supportsReasoning: true },
+    //Kimi
+    { id: "kimi-k3-max", name: "Kimi K3 (max)", supportsReasoning: true },
     { id: "kimi-k3", name: "Kimi K3", supportsReasoning: true },
-    { id: "kimi-k3-max", name: "Kimi K3 (max effort)", supportsReasoning: true },
-    // MiMo-V2.5 — base model + effort-tier aliases (#6922).
+    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
+    //MiMo
     { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", supportsReasoning: true },
+    { id: "mimo-v2.5-max", name: "MiMo-V2.5 (max)", supportsReasoning: true },
+    { id: "mimo-v2.5-high", name: "MiMo-V2.5 (high)", supportsReasoning: true },
     { id: "mimo-v2.5", name: "MiMo-V2.5", supportsReasoning: true },
-    { id: "mimo-v2.5-high", name: "MiMo-V2.5 (high effort)", supportsReasoning: true },
-    { id: "mimo-v2.5-max", name: "MiMo-V2.5 (max effort)", supportsReasoning: true },
-    // #3110: MiniMax M3 via OpenCode Go tier
-    {
-      id: "minimax-m3",
-      name: "MiniMax M3",
-      targetFormat: "claude",
-      contextLength: 1048576,
-      supportsVision: true,
-    },
-    { id: "minimax-m2.7", name: "MiniMax M2.7", targetFormat: "claude" },
-    { id: "minimax-m2.5", name: "MiniMax M2.5", targetFormat: "claude" },
-    // Issue #2292: Qwen models on opencode-go reject oa-compat format
-    // ("Model qwen3.x-* is not supported for format oa-compat") — same
-    // upstream behavior already declared for opencode-zen. Route them
-    // through /messages with the Claude translator.
-    // Issue #2822: These models are text-only — mark supportsVision: false
-    // so combo routing skips them when the request contains image blocks,
-    // preventing image content from reaching a vision-incapable upstream.
-    // #8353: effort-tier aliases from the OpenCode Go registry.
+    //MiniMax
+    { id: "minimax-m3", name: "MiniMax M3", targetFormat: "claude", contextLength: 1048576, supportsVision: true },
+    //Qwen
+    { id: "qwen3.8-max", name: "Qwen3.8 Max", targetFormat: "claude", supportsVision: false },
+    { id: "qwen3.7-max-max", name: "Qwen3.7 Max (max)", targetFormat: "claude", supportsVision: false, supportsReasoning: true },
+    { id: "qwen3.7-max-high", name: "Qwen3.7 Max (high)", targetFormat: "claude", supportsVision: false, supportsReasoning: true },
     { id: "qwen3.7-max", name: "Qwen3.7 Max", targetFormat: "claude", supportsVision: false },
-    {
-      id: "qwen3.7-max-high",
-      name: "Qwen3.7 Max (high effort)",
-      targetFormat: "claude",
-      supportsVision: false,
-      supportsReasoning: true,
-    },
-    {
-      id: "qwen3.7-max-max",
-      name: "Qwen3.7 Max (max effort)",
-      targetFormat: "claude",
-      supportsVision: false,
-      supportsReasoning: true,
-    },
-    {
-      id: "qwen3.7-plus",
-      name: "Qwen3.7 Plus",
-      targetFormat: "claude",
-      supportsVision: false,
-    },
-    {
-      id: "qwen3.7-plus-high",
-      name: "Qwen3.7 Plus (high effort)",
-      targetFormat: "claude",
-      supportsVision: false,
-      supportsReasoning: true,
-    },
-    {
-      id: "qwen3.7-plus-max",
-      name: "Qwen3.7 Plus (max effort)",
-      targetFormat: "claude",
-      supportsVision: false,
-      supportsReasoning: true,
-    },
-    { id: "qwen3.6-plus", name: "Qwen3.6 Plus", targetFormat: "claude", supportsVision: false },
-    {
-      id: "qwen3.6-plus-high",
-      name: "Qwen3.6 Plus (high effort)",
-      targetFormat: "claude",
-      supportsVision: false,
-      supportsReasoning: true,
-    },
-    {
-      id: "qwen3.6-plus-max",
-      name: "Qwen3.6 Plus (max effort)",
-      targetFormat: "claude",
-      supportsVision: false,
-      supportsReasoning: true,
-    },
-    { id: "qwen3.5-plus", name: "Qwen3.5 Plus", targetFormat: "claude", supportsVision: false },
-    // #8353: hy3 is the Go-tier base id (distinct from hy3-preview / hy3-free).
+    { id: "qwen3.7-plus-max", name: "Qwen3.7 Plus (max)", targetFormat: "claude", supportsVision: false, supportsReasoning: true },
+    { id: "qwen3.7-plus-high", name: "Qwen3.7 Plus (high)", targetFormat: "claude", supportsVision: false, supportsReasoning: true },
+    { id: "qwen3.7-plus", name: "Qwen3.7 Plus", targetFormat: "claude", supportsVision: false },
+    // Hunyuan
+    { id: "hy3-high", name: "Hunyuan3 (high)", contextLength: 256000, supportsReasoning: true },
+    { id: "hy3-low", name: "Hunyuan3 (low)", contextLength: 256000, supportsReasoning: true },
     { id: "hy3", name: "Hunyuan3", contextLength: 256000, supportsReasoning: true },
-    {
-      id: "hy3-none",
-      name: "Hunyuan3 (none effort)",
-      contextLength: 256000,
-      supportsReasoning: true,
-    },
-    {
-      id: "hy3-low",
-      name: "Hunyuan3 (low effort)",
-      contextLength: 256000,
-      supportsReasoning: true,
-    },
-    {
-      id: "hy3-high",
-      name: "Hunyuan3 (high effort)",
-      contextLength: 256000,
-      supportsReasoning: true,
-    },
-    { id: "hy3-preview", name: "Hunyuan3 Preview" },
-    // #8353: Grok 4.5 + effort tiers from the OpenCode Go registry.
+    //Grok
+    { id: "grok-4.5-high", name: "Grok 4.5 (high)", supportsReasoning: true },
+    { id: "grok-4.5-medium", name: "Grok 4.5 (medium)", supportsReasoning: true },
+    { id: "grok-4.5-low", name: "Grok 4.5 (low)", supportsReasoning: true },
     { id: "grok-4.5", name: "Grok 4.5", supportsReasoning: true },
-    { id: "grok-4.5-low", name: "Grok 4.5 (low effort)", supportsReasoning: true },
-    { id: "grok-4.5-medium", name: "Grok 4.5 (medium effort)", supportsReasoning: true },
-    { id: "grok-4.5-high", name: "Grok 4.5 (high effort)", supportsReasoning: true },
+    //DeepSeek
+    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro (max)", supportsReasoning: true },
+    { id: "deepseek-v4-pro-high", name: "DeepSeek V4 Pro (high)", supportsReasoning: true },
+    { id: "deepseek-v4-pro-medium", name: "DeepSeek V4 Pro (medium)", supportsReasoning: true },
+    { id: "deepseek-v4-pro-low", name: "DeepSeek V4 Pro (low)", supportsReasoning: true },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportsReasoning: true },
-    // OpencodeExecutor rewrites these aliases to the canonical upstream id and injects reasoning_effort.
-    { id: "deepseek-v4-pro-low", name: "DeepSeek V4 Pro (low effort)", supportsReasoning: true },
-    {
-      id: "deepseek-v4-pro-medium",
-      name: "DeepSeek V4 Pro (medium effort)",
-      supportsReasoning: true,
-    },
-    { id: "deepseek-v4-pro-high", name: "DeepSeek V4 Pro (high effort)", supportsReasoning: true },
-    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro (max effort)", supportsReasoning: true },
+    { id: "deepseek-v4-flash-max", name: "DeepSeek V4 Flash (max)", supportsReasoning: true },
+    { id: "deepseek-v4-flash-high", name: "DeepSeek V4 Flash (high)", supportsReasoning: true },
     { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportsReasoning: true },
-    // #8353: DeepSeek V4 Flash effort tiers from the OpenCode Go registry.
-    {
-      id: "deepseek-v4-flash-high",
-      name: "DeepSeek V4 Flash (high effort)",
-      supportsReasoning: true,
-    },
-    {
-      id: "deepseek-v4-flash-max",
-      name: "DeepSeek V4 Flash (max effort)",
-      supportsReasoning: true,
-    },
   ],
 };

--- a/open-sse/config/providers/registry/opencode/index.ts
+++ b/open-sse/config/providers/registry/opencode/index.ts
@@ -13,25 +13,12 @@ export const opencodeProvider: RegistryEntry = {
   passthroughModels: true,
   defaultContextLength: 200000,
   models: [
-    // #2900: big-pickle's upstream runs DeepSeek thinking mode — declare the
-    // interleaved reasoning_content contract so follow-up/tool-use turns replay
-    // it (otherwise DeepSeek returns 400 "reasoning_content ... must be passed back").
-    {
-      id: "big-pickle",
-      name: "Big Pickle",
-      supportsReasoning: true,
-      interleavedField: "reasoning_content",
-    },
+    { id: "big-pickle", name: "Big Pickle", supportsReasoning: true, interleavedField: "reasoning_content" },
     { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
-    // #6998: 2026-07-14 refresh — the upstream free tier rotated its lineup;
-    // minimax-m3-free, minimax-m2.5-free, ling-2.6-1t-free,
-    // trinity-large-preview-free, nemotron-3-super-free and qwen3.6-plus-free
-    // were delisted (401 "Model X is not supported") and replaced by the 4
-    // entries below, confirmed live against
-    // https://opencode.ai/zen/v1/chat/completions.
     { id: "mimo-v2.5-free", name: "MiMo V2.5 Free", contextLength: 131000 },
     { id: "hy3-free", name: "HY3 Free", contextLength: 131000 },
     { id: "nemotron-3-ultra-free", name: "Nemotron 3 Ultra Free", contextLength: 1000000 },
-    { id: "north-mini-code-free", name: "North Mini Code Free", contextLength: 131000 },
+    { id: "nemotron-3.5-lightning-free", name: "Nemotron 3.5 Lightning Free", contextLength: 1000000 },
+    { id: "laguna-s-2.1-free", name: "Laguna S 2.1 Free", contextLength: 131000 },
   ],
 };

--- a/open-sse/config/providers/registry/opencode/zen/index.ts
+++ b/open-sse/config/providers/registry/opencode/zen/index.ts
@@ -11,87 +11,69 @@ export const opencode_zenProvider: RegistryEntry = {
   authHeader: "Authorization",
   authPrefix: "Bearer",
   defaultContextLength: 200000,
-  // Sync with https://opencode.ai/zen/v1/models — this list is regenerated
-  // from the live API response so new models work without a code deploy.
+  // Curated from https://opencode.ai/zen/v1/models, excluding models whose
+  // published support window has already ended.
   passthroughModels: true,
   models: [
-    // ── Chat / Coding ──────────────────────────────────────────
-    // #2900: big-pickle's upstream runs DeepSeek thinking mode — declare the
-    // interleaved reasoning_content contract so follow-up/tool-use turns replay
-    // it (otherwise DeepSeek returns 400 "reasoning_content ... must be passed back").
-    {
-      id: "big-pickle",
-      name: "Big Pickle",
-      supportsReasoning: true,
-      interleavedField: "reasoning_content",
-    },
-    { id: "gpt-5-nano", name: "GPT 5 Nano", contextLength: 400000 },
-    { id: "gpt-5", name: "GPT 5" },
-    { id: "gpt-5-codex", name: "GPT 5 Codex" },
-    { id: "gpt-5.1", name: "GPT 5.1" },
-    { id: "gpt-5.1-codex", name: "GPT 5.1 Codex" },
-    { id: "gpt-5.1-codex-max", name: "GPT 5.1 Codex Max" },
-    { id: "gpt-5.1-codex-mini", name: "GPT 5.1 Codex Mini" },
-    { id: "gpt-5.2", name: "GPT 5.2" },
-    { id: "gpt-5.2-codex", name: "GPT 5.2 Codex" },
-    { id: "gpt-5.3-codex", name: "GPT 5.3 Codex" },
-    { id: "gpt-5.3-codex-spark", name: "GPT 5.3 Codex Spark" },
+    // ── GPT ──────────────────────────────────────────
+    { id: "gpt-5.6-sol", name: "GPT 5.6 Sol" },
+    { id: "gpt-5.6-terra", name: "GPT 5.6 Terra" },
+    { id: "gpt-5.6-luna", name: "GPT 5.6 Luna" },
+    { id: "gpt-5.5", name: "GPT 5.5" },
     { id: "gpt-5.4", name: "GPT 5.4" },
     { id: "gpt-5.4-mini", name: "GPT 5.4 Mini" },
     { id: "gpt-5.4-nano", name: "GPT 5.4 Nano" },
-    { id: "gpt-5.4-pro", name: "GPT 5.4 Pro" },
-    { id: "gpt-5.5", name: "GPT 5.5" },
-    { id: "gpt-5.5-pro", name: "GPT 5.5 Pro" },
+    { id: "gpt-5.3-codex-spark", name: "GPT 5.3 Codex Spark" },
+    { id: "gpt-5.1", name: "GPT 5.1" },
+    { id: "gpt-5-nano", name: "GPT 5 Nano", contextLength: 400000 },
 
     // ── Claude ─────────────────────────────────────────────────
+    { id: "claude-fable-5", name: "Claude Fable 5" },
+    { id: "claude-opus-5", name: "Claude Opus 5" },
+    { id: "claude-sonnet-5", name: "Claude Sonnet 5" },
     { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
-    { id: "claude-sonnet-4", name: "Claude Sonnet 4" },
-    { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
-    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
-    { id: "claude-opus-4-1", name: "Claude Opus 4.1" },
-    { id: "claude-opus-4-5", name: "Claude Opus 4.5" },
-    { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
-    { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
 
     // ── Gemini ─────────────────────────────────────────────────
-    { id: "gemini-3-flash", name: "Gemini 3 Flash" },
+    { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
+    { id: "gemini-3.5-flash-lite", name: "Gemini 3.5 Flash Lite" },
     { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
-    { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
+    { id: "gemini-3-flash", name: "Gemini 3 Flash" },
 
     // ── Grok ───────────────────────────────────────────────────
+    { id: "grok-4.6", name: "Grok 4.6" },
     { id: "grok-build-0.1", name: "Grok Build 0.1" },
 
+    // ── Muse ───────────────────────────────────────────────────
+    { id: "muse-spark-1.2", name: "Muse Spark 1.2" },
+
+    // ── DeepSeek ───────────────────────────────────────────────
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportsReasoning: true },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportsReasoning: true },
+
     // ── GLM / Z.AI ─────────────────────────────────────────────
-    { id: "glm-5", name: "GLM-5" },
-    { id: "glm-5.1", name: "GLM-5.1" },
+    { id: "glm-5.2", name: "GLM-5.2" },
 
     // ── MiniMax ────────────────────────────────────────────────
-    // #3110: MiniMax M3 — frontier coding model with 1M context
     { id: "minimax-m3", name: "MiniMax M3", contextLength: 1048576, supportsVision: true },
-    { id: "minimax-m2.5", name: "MiniMax M2.5" },
-    { id: "minimax-m2.7", name: "MiniMax M2.7" },
 
     // ── Kimi / Moonshot ────────────────────────────────────────
-    { id: "kimi-k2.5", name: "Kimi K2.5" },
-    { id: "kimi-k2.6", name: "Kimi K2.6" },
+    { id: "kimi-k3", name: "Kimi K3" },
+    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
 
     // ── Qwen ───────────────────────────────────────────────────
     // Issue #2292: Qwen models return Claude-format SSE bodies even
     // when hitting /chat/completions. targetFormat: "claude" routes
     // through /messages and the Claude translator.
-    // Issue #2822: These models are text-only — supportsVision: false
-    // ensures combo routing skips them on image-bearing requests.
-    { id: "qwen3.5-plus", name: "Qwen3.5 Plus", targetFormat: "claude", supportsVision: false },
     { id: "qwen3.6-plus", name: "Qwen3.6 Plus", targetFormat: "claude", supportsVision: false },
+    { id: "qwen3.5-plus", name: "Qwen3.5 Plus", targetFormat: "claude", supportsVision: false },
 
     // ── Free Tier ──────────────────────────────────────────────
-    // #6998 (2026-07-14): upstream free tier rotated — minimax-m2.5-free,
-    // nemotron-3-super-free and qwen3.6-plus-free were delisted (401). Replaced
-    // by the 4 entries below with upstream-verified limits.
+    { id: "big-pickle", name: "Big Pickle", supportsReasoning: true, interleavedField: "reasoning_content" },
     { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
     { id: "mimo-v2.5-free", name: "MiMo V2.5 Free", contextLength: 200000 },
     { id: "hy3-free", name: "HY3 Free", contextLength: 200000 },
     { id: "nemotron-3-ultra-free", name: "Nemotron 3 Ultra Free", contextLength: 1000000 },
-    { id: "north-mini-code-free", name: "North Mini Code Free", contextLength: 200000 },
+    { id: "nemotron-3.5-lightning-free", name: "Nemotron 3.5 Lightning Free", contextLength: 1000000 },
+    { id: "laguna-s-2.1-free", name: "Laguna S 2.1 Free", contextLength: 131000 },
   ],
 };

--- a/open-sse/services/AGENTS.md
+++ b/open-sse/services/AGENTS.md
@@ -1,6 +1,6 @@
 # open-sse/services/ — Routing Engine & Cross-Cutting Services
 
-**Purpose**: 134 service modules (top-level) powering request routing, rate limiting, quota management, token refresh, fallback strategies, and runtime state. The combo routing engine (`combo.ts`) is the core; supporting services handle resilience, accounting, and decision-making.
+**Purpose**: 212 service modules (top-level) powering request routing, rate limiting, quota management, token refresh, fallback strategies, and runtime state. The combo routing engine (`combo.ts`) is the core; supporting services handle resilience, accounting, and decision-making.
 
 Live count: `ls open-sse/services/*.ts | wc -l` (currently 134). More including sub-dirs like `autoCombo/` and `compression/`.
 
@@ -18,6 +18,7 @@ Live count: `ls open-sse/services/*.ts | wc -l` (currently 134). More including 
 
 - **`rateLimitManager.ts`** — Token bucket per API key + provider combo. Rejects before dispatch.
 - **`usage.ts`** — Per-request token/cost consumption tracking.
+- **`openCodeGoPricing.ts`** — Official OpenCode Go token rates, dynamic tiers, and budget caps.
 - **`quotaCache.ts`** — In-memory quota snapshots, pre-loaded at startup.
 
 ### Account & Token Management

--- a/open-sse/services/openCodeGoPricing.ts
+++ b/open-sse/services/openCodeGoPricing.ts
@@ -1,0 +1,257 @@
+/**
+ * Official OpenCode Go usage-meter rates for OmniRoute's curated catalog, captured 2026-08-17.
+ * Rates are USD per 1M tokens. `monthlyUsageLimitUsd` is the model-specific
+ * included monthly usage column; account-wide windows remain $12/5h, $30/week,
+ * and $60/month. Context thresholds use recorded prompt/input tokens.
+ */
+export const OPENCODE_GO_PRICING_REVISION = "2026-08-17";
+
+export const OPENCODE_GO_WINDOW_LIMITS_USD = Object.freeze({
+  session: 12,
+  weekly: 30,
+  monthly: 60,
+});
+
+export type OpenCodeGoPricing = {
+  input: number;
+  output: number;
+  cached: number;
+  cache_creation?: number;
+  monthlyUsageLimitUsd: 15 | 60;
+  variant?: string;
+};
+
+type PricingInput = {
+  model: string;
+  inputTokens?: number;
+  timestamp?: string | number | Date;
+};
+
+type CostInput = PricingInput & {
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+};
+
+const STATIC_PRICING: Readonly<Record<string, OpenCodeGoPricing>> = Object.freeze({
+  "grok-4.5": {
+    input: 2,
+    output: 6,
+    cached: 0.3,
+    monthlyUsageLimitUsd: 15,
+  },
+  "glm-5.3": {
+    input: 1.4,
+    output: 4.4,
+    cached: 0.26,
+    monthlyUsageLimitUsd: 15,
+  },
+  "glm-5.2": {
+    input: 1.4,
+    output: 4.4,
+    cached: 0.26,
+    monthlyUsageLimitUsd: 60,
+  },
+  "kimi-k3": {
+    input: 3,
+    output: 15,
+    cached: 0.3,
+    monthlyUsageLimitUsd: 15,
+  },
+  "kimi-k2.7-code": {
+    input: 0.95,
+    output: 4,
+    cached: 0.19,
+    monthlyUsageLimitUsd: 60,
+  },
+  "mimo-v2.5": {
+    input: 0.14,
+    output: 0.28,
+    cached: 0.0028,
+    monthlyUsageLimitUsd: 60,
+  },
+  "mimo-v2.5-pro": {
+    input: 0.435,
+    output: 0.87,
+    cached: 0.003625,
+    monthlyUsageLimitUsd: 15,
+  },
+  "minimax-m3": {
+    input: 0.3,
+    output: 1.2,
+    cached: 0.06,
+    monthlyUsageLimitUsd: 60,
+  },
+  "qwen3.8-max": {
+    input: 2,
+    output: 6,
+    cached: 0.25,
+    cache_creation: 2.5,
+    monthlyUsageLimitUsd: 15,
+  },
+  "qwen3.7-max": {
+    input: 2.5,
+    output: 7.5,
+    cached: 0.5,
+    cache_creation: 3.125,
+    monthlyUsageLimitUsd: 60,
+  },
+  hy3: {
+    input: 0.14,
+    output: 0.58,
+    cached: 0.035,
+    monthlyUsageLimitUsd: 60,
+  },
+});
+
+function safeTokenCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function normalizeModel(model: string): string {
+  const raw = String(model || "")
+    .trim()
+    .toLowerCase()
+    .split("/")
+    .pop();
+  const id = raw || "";
+
+  if (/^glm-5\.2-(?:high|max)$/.test(id)) return "glm-5.2";
+  if (id === "kimi-k3-max") return "kimi-k3";
+  if (/^mimo-v2\.5-(?:high|max)$/.test(id)) return "mimo-v2.5";
+  if (/^qwen3\.7-max-(?:high|max)$/.test(id)) return "qwen3.7-max";
+  if (/^qwen3\.7-plus-(?:high|max)$/.test(id)) return "qwen3.7-plus";
+  if (/^hy3-(?:low|high)$/.test(id)) return "hy3";
+  if (/^grok-4\.5-(?:low|medium|high|max)$/.test(id)) return "grok-4.5";
+  if (/^deepseek-v4-pro-(?:low|medium|high|max)$/.test(id)) return "deepseek-v4-pro";
+  if (/^deepseek-v4-flash-(?:low|medium|high|max)$/.test(id)) return "deepseek-v4-flash";
+  return id;
+}
+
+function timestampMs(value: PricingInput["timestamp"]): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number") return value;
+  if (typeof value === "string") return Date.parse(value);
+  return Date.now();
+}
+
+function isDeepSeekPeak(timestamp: PricingInput["timestamp"]): boolean {
+  const parsed = timestampMs(timestamp);
+  if (!Number.isFinite(parsed)) return false;
+  const hour = new Date(parsed).getUTCHours();
+  return (hour >= 1 && hour < 4) || (hour >= 6 && hour < 10);
+}
+
+function lunaPricing(inputTokens: number): OpenCodeGoPricing {
+  if (inputTokens <= 272_000) {
+    return {
+      input: 0.2,
+      output: 1.2,
+      cached: 0.02,
+      cache_creation: 0.25,
+      monthlyUsageLimitUsd: 15,
+      variant: "lte-272k",
+    };
+  }
+  return {
+    input: 0.4,
+    output: 1.8,
+    cached: 0.04,
+    cache_creation: 0.5,
+    monthlyUsageLimitUsd: 15,
+    variant: "gt-272k",
+  };
+}
+
+function qwenPlusPricing(inputTokens: number): OpenCodeGoPricing {
+  const large = inputTokens > 256_000;
+  return large
+    ? {
+        input: 1.2,
+        output: 4.8,
+        cached: 0.12,
+        cache_creation: 1.5,
+        monthlyUsageLimitUsd: 60,
+        variant: "gt-256k",
+      }
+    : {
+        input: 0.4,
+        output: 1.6,
+        cached: 0.04,
+        cache_creation: 0.5,
+        monthlyUsageLimitUsd: 60,
+        variant: "lte-256k",
+      };
+}
+
+function deepSeekPricing(
+  model: "deepseek-v4-pro" | "deepseek-v4-flash",
+  timestamp: PricingInput["timestamp"]
+): OpenCodeGoPricing {
+  const peak = isDeepSeekPeak(timestamp);
+  if (model === "deepseek-v4-pro") {
+    return {
+      input: peak ? 1.32 : 0.66,
+      output: peak ? 3.96 : 1.98,
+      cached: peak ? 0.044 : 0.022,
+      monthlyUsageLimitUsd: 15,
+      variant: peak ? "peak" : "off-peak",
+    };
+  }
+  return {
+    input: peak ? 0.44 : 0.22,
+    output: peak ? 1.32 : 0.66,
+    cached: peak ? 0.014 : 0.007,
+    monthlyUsageLimitUsd: 15,
+    variant: peak ? "peak" : "off-peak",
+  };
+}
+
+export function resolveOpenCodeGoPricing(input: PricingInput): OpenCodeGoPricing | null {
+  const model = normalizeModel(input.model);
+  const inputTokens = safeTokenCount(input.inputTokens);
+  if (model === "gpt-5.6-luna") return lunaPricing(inputTokens);
+  if (model === "qwen3.7-plus") return qwenPlusPricing(inputTokens);
+  if (model === "deepseek-v4-pro" || model === "deepseek-v4-flash") {
+    return deepSeekPricing(model, input.timestamp);
+  }
+  return STATIC_PRICING[model] ? { ...STATIC_PRICING[model] } : null;
+}
+
+export const OPENCODE_GO_PRICED_MODEL_IDS = Object.freeze(
+  [
+    ...Object.keys(STATIC_PRICING),
+    "gpt-5.6-luna",
+    "qwen3.7-plus",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+  ].sort()
+);
+
+export function calculateOpenCodeGoCost(input: CostInput) {
+  const inputTokens = safeTokenCount(input.inputTokens);
+  const outputTokens = safeTokenCount(input.outputTokens);
+  const cacheReadTokens = safeTokenCount(input.cacheReadTokens);
+  const cacheCreationTokens = safeTokenCount(input.cacheCreationTokens);
+  const pricing = resolveOpenCodeGoPricing({
+    model: input.model,
+    inputTokens,
+    timestamp: input.timestamp,
+  });
+  if (!pricing) return null;
+
+  const ordinaryInputTokens = Math.max(0, inputTokens - cacheReadTokens - cacheCreationTokens);
+  const costUsd =
+    (ordinaryInputTokens * pricing.input +
+      outputTokens * pricing.output +
+      cacheReadTokens * pricing.cached +
+      cacheCreationTokens * (pricing.cache_creation ?? 0)) /
+    1_000_000;
+
+  return {
+    costUsd: Math.round(costUsd * 10_000_000_000) / 10_000_000_000,
+    model: normalizeModel(input.model),
+    pricing,
+    pricingRevision: OPENCODE_GO_PRICING_REVISION,
+  };
+}

--- a/open-sse/services/opencodeOllamaUsage.ts
+++ b/open-sse/services/opencodeOllamaUsage.ts
@@ -1,4 +1,13 @@
+import {
+  getOpenCodeGoLocalUsage,
+  type OpenCodeGoLocalUsage,
+} from "@/lib/usage/openCodeGoWindowLedger";
+
 import { sanitizeErrorMessage } from "../utils/error.ts";
+import {
+  OPENCODE_GO_PRICING_REVISION,
+  OPENCODE_GO_WINDOW_LIMITS_USD,
+} from "./openCodeGoPricing.ts";
 
 type JsonRecord = Record<string, unknown>;
 type UsageQuota = {
@@ -22,7 +31,11 @@ type UsageQuota = {
 const OPENCODE_GO_QUOTA_URL = process.env.OMNIROUTE_OPENCODE_GO_QUOTA_URL?.trim() || "";
 const OPENCODE_GO_DASHBOARD_BASE_URL =
   process.env.OMNIROUTE_OPENCODE_GO_DASHBOARD_URL ?? "https://opencode.ai/workspace";
-const OPENCODE_GO_QUOTA_TOTALS = { session: 12, weekly: 30, mcp_monthly: 60 } as const;
+const OPENCODE_GO_QUOTA_TOTALS = {
+  session: OPENCODE_GO_WINDOW_LIMITS_USD.session,
+  weekly: OPENCODE_GO_WINDOW_LIMITS_USD.weekly,
+  mcp_monthly: OPENCODE_GO_WINDOW_LIMITS_USD.monthly,
+} as const;
 const OPENCODE_GO_QUOTA_ORDER = ["session", "weekly", "mcp_monthly"] as const;
 const OPENCODE_GO_SCRAPED_NUMBER = String.raw`(-?\d+(?:\.\d+)?)`;
 const OLLAMA_CLOUD_USAGE_URL =
@@ -194,6 +207,79 @@ function orderOpenCodeGoQuotas(quotas: Record<string, UsageQuota>): Record<strin
   return ordered;
 }
 
+function windowStartFromReset(resetAt: string | null | undefined, durationMs: number) {
+  const resetMs = resetAt ? Date.parse(resetAt) : Number.NaN;
+  return Number.isFinite(resetMs) && resetMs > Date.now() ? resetMs - durationMs : undefined;
+}
+
+function readOpenCodeGoLocalUsage(
+  connectionId: string,
+  observedQuotas?: Record<string, UsageQuota>
+): OpenCodeGoLocalUsage | null {
+  if (!connectionId) return null;
+  try {
+    return getOpenCodeGoLocalUsage({
+      connectionId,
+      windowStarts: {
+        weekly: windowStartFromReset(observedQuotas?.weekly?.resetAt, 7 * 24 * 60 * 60 * 1000),
+        monthly: windowStartFromReset(
+          observedQuotas?.mcp_monthly?.resetAt,
+          30 * 24 * 60 * 60 * 1000
+        ),
+      },
+      windowResets: {
+        session: observedQuotas?.session?.resetAt,
+        weekly: observedQuotas?.weekly?.resetAt,
+        monthly: observedQuotas?.mcp_monthly?.resetAt,
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
+function hasOpenCodeGoLocalEvidence(estimate: OpenCodeGoLocalUsage | null): boolean {
+  return Boolean(
+    estimate && (estimate.requestsPriced > 0 || estimate.unknownModels.length > 0)
+  );
+}
+
+function localEstimateQuotas(estimate: OpenCodeGoLocalUsage): Record<string, UsageQuota> {
+  return orderOpenCodeGoQuotas({
+    session: estimate.quotas.session,
+    weekly: estimate.quotas.weekly,
+    mcp_monthly: estimate.quotas.monthly,
+  });
+}
+
+function buildOpenCodeGoObservedUsage(
+  connectionId: string,
+  plan: string | null,
+  quotas: Record<string, UsageQuota>
+) {
+  const localEstimate = readOpenCodeGoLocalUsage(connectionId, quotas);
+  return {
+    plan,
+    quotas: orderOpenCodeGoQuotas(quotas),
+    usageSource: "upstream" as const,
+    pricingRevision: OPENCODE_GO_PRICING_REVISION,
+    ...(localEstimate ? { localEstimate } : {}),
+  };
+}
+
+function buildOpenCodeGoLocalFallback(connectionId: string, warning: string) {
+  const localEstimate = readOpenCodeGoLocalUsage(connectionId);
+  if (!hasOpenCodeGoLocalEvidence(localEstimate)) return { message: warning };
+  return {
+    plan: "OpenCode Go",
+    quotas: localEstimateQuotas(localEstimate as OpenCodeGoLocalUsage),
+    usageSource: "localUsageHistory" as const,
+    pricingRevision: OPENCODE_GO_PRICING_REVISION,
+    localEstimate,
+    warning,
+  };
+}
+
 function parseOpenCodeGoSsrWindow(html: string, field: string): DashboardWindow | null {
   for (const candidate of [
     {
@@ -301,18 +387,26 @@ async function fetchOpenCodeGoDashboardUsage(
   };
 }
 
-export async function getOpenCodeGoUsage(apiKey: string, providerSpecificData?: JsonRecord) {
+export async function getOpenCodeGoUsage(
+  connectionId: string,
+  apiKey: string,
+  providerSpecificData?: JsonRecord
+) {
   const dashboardConfig = resolveOpenCodeGoDashboardConfig(providerSpecificData);
   if (dashboardConfig.state === "incomplete") {
-    return {
-      message: `OpenCode Go dashboard quota config is incomplete. Missing ${dashboardConfig.missing}.`,
-    };
+    return buildOpenCodeGoLocalFallback(
+      connectionId,
+      `OpenCode Go dashboard quota config is incomplete. Missing ${dashboardConfig.missing}.`
+    );
   }
   if (dashboardConfig.state === "configured") {
     try {
       const dashboard = await fetchOpenCodeGoDashboardUsage(dashboardConfig);
       if (!dashboard.usage) {
-        return { message: dashboard.message || "OpenCode Go dashboard quota data unavailable." };
+        return buildOpenCodeGoLocalFallback(
+          connectionId,
+          dashboard.message || "OpenCode Go dashboard quota data unavailable."
+        );
       }
       const quotas: Record<string, UsageQuota> = {};
       for (const quotaName of OPENCODE_GO_QUOTA_ORDER) {
@@ -325,28 +419,31 @@ export async function getOpenCodeGoUsage(apiKey: string, providerSpecificData?: 
           );
         }
       }
-      return { plan: "OpenCode Go", quotas: orderOpenCodeGoQuotas(quotas) };
+      return buildOpenCodeGoObservedUsage(connectionId, "OpenCode Go", quotas);
     } catch (error) {
-      return { message: `OpenCode Go dashboard quota error: ${sanitizeErrorMessage(error)}` };
+      return buildOpenCodeGoLocalFallback(
+        connectionId,
+        `OpenCode Go dashboard quota error: ${sanitizeErrorMessage(error)}`
+      );
     }
   }
 
   const token = apiKey.trim().replace(/^Bearer\s+/i, "");
   if (!token) {
-    return {
-      message:
-        "OpenCode Go quota requires OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE. " +
-        "The API key can be used for chat/models, but OpenCode Go does not expose quota via API key.",
-    };
+    return buildOpenCodeGoLocalFallback(
+      connectionId,
+      "OpenCode Go quota requires OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE. " +
+        "The API key can be used for chat/models, but OpenCode Go does not expose quota via API key."
+    );
   }
 
   if (!OPENCODE_GO_QUOTA_URL) {
-    return {
-      message:
-        "OpenCode Go does not expose a public quota API. " +
+    return buildOpenCodeGoLocalFallback(
+      connectionId,
+      "OpenCode Go does not expose a public quota API. " +
         "Set OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE to enable dashboard quota scraping, " +
-        "or set OMNIROUTE_OPENCODE_GO_QUOTA_URL to opt in to an explicit quota endpoint.",
-    };
+        "or set OMNIROUTE_OPENCODE_GO_QUOTA_URL to opt in to an explicit quota endpoint."
+    );
   }
 
   try {
@@ -360,26 +457,29 @@ export async function getOpenCodeGoUsage(apiKey: string, providerSpecificData?: 
     });
     if (!res.ok) {
       if (res.status === 401 || res.status === 403) {
-        return {
-          message:
-            "OpenCode Go API key is valid for chat/models but cannot read quota from the configured " +
+        return buildOpenCodeGoLocalFallback(
+          connectionId,
+          "OpenCode Go API key is valid for chat/models but cannot read quota from the configured " +
             "OMNIROUTE_OPENCODE_GO_QUOTA_URL endpoint. " +
-            "Set OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE to enable dashboard quota scraping.",
-        };
+            "Set OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE to enable dashboard quota scraping."
+        );
       }
-      return {
-        message:
-          `OpenCode Go quota API error (${res.status}). ` +
+      return buildOpenCodeGoLocalFallback(
+        connectionId,
+        `OpenCode Go quota API error (${res.status}). ` +
           "Set OMNIROUTE_OPENCODE_GO_QUOTA_URL to a working endpoint, or follow " +
-          "https://github.com/anomalyco/opencode/issues/16017 for upstream status.",
-      };
+          "https://github.com/anomalyco/opencode/issues/16017 for upstream status."
+      );
     }
 
     let json: unknown;
     try {
       json = await res.json();
     } catch {
-      return { message: "OpenCode Go quota response parsing failed." };
+      return buildOpenCodeGoLocalFallback(
+        connectionId,
+        "OpenCode Go quota response parsing failed."
+      );
     }
     const root = toRecord(json);
     if (
@@ -387,12 +487,12 @@ export async function getOpenCodeGoUsage(apiKey: string, providerSpecificData?: 
       toNumber(root.code, 200) === 403 ||
       root.success === false
     ) {
-      return {
-        message:
-          "OpenCode Go API key is valid for chat/models but cannot read quota from the configured " +
+      return buildOpenCodeGoLocalFallback(
+        connectionId,
+        "OpenCode Go API key is valid for chat/models but cannot read quota from the configured " +
           "OMNIROUTE_OPENCODE_GO_QUOTA_URL endpoint. " +
-          "Set OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE to enable dashboard quota scraping.",
-      };
+          "Set OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE to enable dashboard quota scraping."
+      );
     }
 
     const data = toRecord(root.data);
@@ -444,16 +544,20 @@ export async function getOpenCodeGoUsage(apiKey: string, providerSpecificData?: 
           ? data.level
           : "";
     const planLabel = toTitleCase(levelRaw.replace(/\s*plan$/i, ""));
-    return {
-      plan: planLabel
+    return buildOpenCodeGoObservedUsage(
+      connectionId,
+      planLabel
         ? /^opencode\s+go\b/i.test(planLabel)
           ? planLabel
           : `OpenCode Go ${planLabel}`
         : null,
-      quotas: orderOpenCodeGoQuotas(quotas),
-    };
+      quotas
+    );
   } catch (error) {
-    return { message: `OpenCode Go quota API error: ${sanitizeErrorMessage(error)}` };
+    return buildOpenCodeGoLocalFallback(
+      connectionId,
+      `OpenCode Go quota API error: ${sanitizeErrorMessage(error)}`
+    );
   }
 }
 

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -194,7 +194,7 @@ export async function getUsageForProvider(
         ...(provider === "glm-cn" ? { apiRegion: "china" } : {}),
       });
     case "opencode-go":
-      return await getOpenCodeGoUsage(apiKey || "", providerSpecificData);
+      return await getOpenCodeGoUsage(id || "", apiKey || "", providerSpecificData);
     case "ollama-cloud":
       return await getOllamaCloudUsage(providerSpecificData);
     case "minimax":

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.tsx
@@ -161,6 +161,7 @@ export default function ProviderLimitCard({
                 resetTime={quota.resetAt}
                 staleAfterReset={quota.staleAfterReset === true}
                 showUsageCount={shouldShowQuotaUsageCount(quota)}
+                currency={quota.currency}
               />
             );
           })}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.tsx
@@ -75,6 +75,7 @@ export default function QuotaProgressBar({
   resetTime = null,
   staleAfterReset = false,
   showUsageCount = true,
+  currency = null,
 }) {
   const t = useTranslations("usage");
   const colors = getColorClasses(percentage);
@@ -84,6 +85,17 @@ export default function QuotaProgressBar({
   // percentage is already remaining percentage (from ProviderLimitCard)
   const remaining = percentage;
   const remainingPercentage = Math.round(Math.max(0, Math.min(100, remaining)));
+  const formatUsd = (value) =>
+    new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 6,
+    }).format(value);
+  const usageCount =
+    currency === "USD"
+      ? `${formatUsd(used)} / ${formatUsd(total)}`
+      : `${used.toLocaleString()} / ${total.toLocaleString()} requests`;
 
   return (
     <div className="space-y-2">
@@ -113,7 +125,7 @@ export default function QuotaProgressBar({
       {/* Usage details and countdown */}
       <div className="flex items-center justify-between text-xs text-text-muted">
         <span>
-          {showUsageCount ? `${used.toLocaleString()} / ${total.toLocaleString()} requests` : null}
+          {showUsageCount ? usageCount : null}
         </span>
         {staleAfterReset ? (
           <div className="flex items-center gap-1">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts
@@ -70,6 +70,7 @@ function normalizeQuotaEntry(name: string, quota: any = {}, extras: any = {}) {
       : {}),
     ...(quota?.overPlan !== undefined ? { overPlan: quota.overPlan === true } : {}),
     ...(quota?.displayName !== undefined ? { displayName: String(quota.displayName) } : {}),
+    ...(quota?.currency !== undefined ? { currency: String(quota.currency) } : {}),
     ...(quota?.isPercentageOnly !== undefined
       ? { isPercentageOnly: quota.isPercentageOnly === true }
       : {}),

--- a/src/lib/usage/costCalculator.ts
+++ b/src/lib/usage/costCalculator.ts
@@ -7,6 +7,8 @@
  * @module lib/usage/costCalculator
  */
 
+import { calculateOpenCodeGoCost } from "@omniroute/open-sse/services/openCodeGoPricing.ts";
+
 import { isFlatRateProvider } from "./flatRateProviders";
 
 /**
@@ -28,6 +30,7 @@ export type CostCalculationOptions = {
   provider?: string | null;
   model?: string | null;
   serviceTier?: string | null;
+  timestamp?: string | number | Date;
   /**
    * When true, return $0 for flat-rate (subscription / cookie-web) providers
    * instead of the per-token estimate (#5552). Opt-in so only analytics/display
@@ -185,6 +188,21 @@ export async function calculateCost(
   // cost is present (currently xAI's `cost_in_usd_ticks` — see extractExactCostUsd).
   const exactCostUsd = extractExactCostUsd(tokens);
   if (exactCostUsd !== null) return exactCostUsd;
+
+  if (normalizeServiceTier(provider) === "opencode-go") {
+    return (
+      calculateOpenCodeGoCost({
+        model,
+        inputTokens: tokens.input ?? tokens.prompt_tokens ?? tokens.input_tokens ?? 0,
+        outputTokens: tokens.output ?? tokens.completion_tokens ?? tokens.output_tokens ?? 0,
+        cacheReadTokens:
+          tokens.cacheRead ?? tokens.cached_tokens ?? tokens.cache_read_input_tokens ?? 0,
+        cacheCreationTokens:
+          tokens.cacheCreation ?? tokens.cache_creation_input_tokens ?? 0,
+        timestamp: options.timestamp,
+      })?.costUsd ?? 0
+    );
+  }
 
   try {
     const { getPricingForModel } = await import("@/lib/localDb");

--- a/src/lib/usage/openCodeGoWindowLedger.ts
+++ b/src/lib/usage/openCodeGoWindowLedger.ts
@@ -1,0 +1,215 @@
+import {
+  OPENCODE_GO_PRICING_REVISION,
+  OPENCODE_GO_WINDOW_LIMITS_USD,
+  calculateOpenCodeGoCost,
+} from "@omniroute/open-sse/services/openCodeGoPricing.ts";
+
+import { getDbInstance } from "@/lib/db/core";
+import { toNumber } from "@/shared/utils/numeric";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+type WindowName = "session" | "weekly" | "monthly";
+
+type UsageRow = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  timestamp: string;
+};
+
+type WindowQuota = {
+  used: number;
+  total: number;
+  remaining: number;
+  remainingPercentage: number;
+  resetAt: string | null;
+  unlimited: false;
+  displayName: string;
+  currency: "USD";
+  quotaSource: "localUsageHistory";
+  details?: Array<{ name: string; used: number }>;
+};
+
+type WindowTimeInput = string | number | Date;
+
+export type OpenCodeGoLocalUsageOptions = {
+  connectionId: string;
+  now?: number;
+  windowStarts?: Partial<Record<WindowName, WindowTimeInput>>;
+  windowResets?: Partial<Record<WindowName, string | null>>;
+};
+
+export type OpenCodeGoLocalUsage = {
+  pricingRevision: string;
+  quotas: Record<WindowName, WindowQuota>;
+  modelMonthly: Array<{
+    model: string;
+    used: number;
+    total: number;
+    remaining: number;
+    remainingPercentage: number;
+    effectiveRemainingUsd: number;
+  }>;
+  requestsPriced: number;
+  unknownModels: string[];
+};
+
+function roundUsd(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function toTimestamp(value: WindowTimeInput | undefined, fallback: number): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function buildQuota(
+  name: WindowName,
+  usedValue: number,
+  resetAt: string | null | undefined,
+  details?: Array<{ name: string; used: number }>
+): WindowQuota {
+  const total = OPENCODE_GO_WINDOW_LIMITS_USD[name];
+  const used = roundUsd(Math.max(0, usedValue));
+  const remaining = roundUsd(Math.max(0, total - used));
+  return {
+    used,
+    total,
+    remaining,
+    remainingPercentage: Math.max(0, Math.min(100, (remaining / total) * 100)),
+    resetAt: resetAt || null,
+    unlimited: false,
+    displayName:
+      name === "session" ? "5-hour rolling" : name === "weekly" ? "Weekly" : "Monthly",
+    currency: "USD",
+    quotaSource: "localUsageHistory",
+    ...(details?.length ? { details } : {}),
+  };
+}
+
+function fetchUsageRows(connectionId: string, sinceIso: string, nowIso: string): UsageRow[] {
+  if (!connectionId) return [];
+  return getDbInstance()
+    .prepare(
+      `
+      SELECT
+        LOWER(model) as model,
+        COALESCE(tokens_input, 0) as inputTokens,
+        COALESCE(tokens_output, 0) as outputTokens,
+        COALESCE(tokens_cache_read, 0) as cacheReadTokens,
+        COALESCE(tokens_cache_creation, 0) as cacheCreationTokens,
+        timestamp
+      FROM usage_history
+      WHERE LOWER(provider) = 'opencode-go'
+        AND connection_id = @connectionId
+        AND timestamp >= @sinceIso
+        AND timestamp <= @nowIso
+        AND COALESCE(success, 1) = 1
+      ORDER BY timestamp ASC, id ASC
+      `
+    )
+    .all({ connectionId, sinceIso, nowIso }) as UsageRow[];
+}
+
+export function getOpenCodeGoLocalUsage(
+  options: OpenCodeGoLocalUsageOptions
+): OpenCodeGoLocalUsage {
+  const now = Number.isFinite(options.now) ? Number(options.now) : Date.now();
+  const sessionStart = toTimestamp(options.windowStarts?.session, now - 5 * HOUR_MS);
+  const weeklyStart = toTimestamp(options.windowStarts?.weekly, now - 7 * DAY_MS);
+  const monthlyStart = toTimestamp(options.windowStarts?.monthly, now - 30 * DAY_MS);
+  const earliestStart = Math.min(sessionStart, weeklyStart, monthlyStart);
+  const rows = fetchUsageRows(
+    options.connectionId,
+    new Date(earliestStart).toISOString(),
+    new Date(now).toISOString()
+  );
+
+  const windowCosts: Record<WindowName, number> = { session: 0, weekly: 0, monthly: 0 };
+  const modelCosts = new Map<string, { used: number; total: number }>();
+  const unknownModels = new Set<string>();
+  let requestsPriced = 0;
+
+  for (const row of rows) {
+    const timestamp = Date.parse(row.timestamp);
+    const priced = calculateOpenCodeGoCost({
+      model: row.model,
+      inputTokens: toNumber(row.inputTokens),
+      outputTokens: toNumber(row.outputTokens),
+      cacheReadTokens: toNumber(row.cacheReadTokens),
+      cacheCreationTokens: toNumber(row.cacheCreationTokens),
+      timestamp: row.timestamp,
+    });
+    if (!priced) {
+      unknownModels.add(row.model);
+      continue;
+    }
+
+    requestsPriced += 1;
+    if (timestamp >= sessionStart) windowCosts.session += priced.costUsd;
+    if (timestamp >= weeklyStart) windowCosts.weekly += priced.costUsd;
+    if (timestamp >= monthlyStart) {
+      windowCosts.monthly += priced.costUsd;
+      const model = modelCosts.get(priced.model) ?? {
+        used: 0,
+        total: priced.pricing.monthlyUsageLimitUsd,
+      };
+      model.used += priced.costUsd;
+      modelCosts.set(priced.model, model);
+    }
+  }
+
+  const monthlyDetails = [...modelCosts.entries()]
+    .map(([name, value]) => ({ name, used: roundUsd(value.used) }))
+    .sort((left, right) => right.used - left.used || left.name.localeCompare(right.name));
+  const quotas = {
+    session: buildQuota(
+      "session",
+      windowCosts.session,
+      options.windowResets?.session
+    ),
+    weekly: buildQuota("weekly", windowCosts.weekly, options.windowResets?.weekly),
+    monthly: buildQuota(
+      "monthly",
+      windowCosts.monthly,
+      options.windowResets?.monthly,
+      monthlyDetails
+    ),
+  };
+  const sharedRemaining = Math.min(
+    quotas.session.remaining,
+    quotas.weekly.remaining,
+    quotas.monthly.remaining
+  );
+  const modelMonthly = [...modelCosts.entries()]
+    .map(([model, value]) => {
+      const used = roundUsd(value.used);
+      const remaining = roundUsd(Math.max(0, value.total - used));
+      return {
+        model,
+        used,
+        total: value.total,
+        remaining,
+        remainingPercentage: Math.max(0, Math.min(100, (remaining / value.total) * 100)),
+        effectiveRemainingUsd: roundUsd(Math.min(sharedRemaining, remaining)),
+      };
+    })
+    .sort((left, right) => right.used - left.used || left.model.localeCompare(right.model));
+
+  return {
+    pricingRevision: OPENCODE_GO_PRICING_REVISION,
+    quotas,
+    modelMonthly,
+    requestsPriced,
+    unknownModels: [...unknownModels].sort(),
+  };
+}

--- a/src/lib/usage/providerWindowCosts.ts
+++ b/src/lib/usage/providerWindowCosts.ts
@@ -573,7 +573,7 @@ async function getUsageRowCostUsd(
       cacheCreation: toNumber(row.cacheCreationTokens),
       reasoning: toNumber(row.reasoningTokens),
     },
-    { serviceTier: row.serviceTier }
+    { serviceTier: row.serviceTier, timestamp: row.timestamp }
   );
 }
 

--- a/tests/unit/models-catalog-route.test.ts
+++ b/tests/unit/models-catalog-route.test.ts
@@ -874,7 +874,6 @@ test("v1 models catalog retains registered effort aliases beside synced OpenCode
 
   assert.equal(response.status, 200);
   assert.ok(ids.includes("opencode-go/hy3"));
-  assert.ok(ids.includes("opencode-go/hy3-none"));
   assert.ok(ids.includes("opencode-go/hy3-low"));
   assert.ok(ids.includes("opencode-go/hy3-high"));
 });

--- a/tests/unit/opencode-executor.test.ts
+++ b/tests/unit/opencode-executor.test.ts
@@ -95,8 +95,8 @@ describe("OpencodeExecutor", () => {
     });
 
     it("routes opencode zen default models to chat completions", async () => {
-      const minimaxResult = await zenExecutor.execute(createInput("minimax-m2.5-free"));
-      assert.equal(minimaxResult.url, "https://opencode.ai/zen/v1/chat/completions");
+      const freeResult = await zenExecutor.execute(createInput("deepseek-v4-flash-free"));
+      assert.equal(freeResult.url, "https://opencode.ai/zen/v1/chat/completions");
       assert.equal(fetchCalls[0].url, "https://opencode.ai/zen/v1/chat/completions");
 
       const pickleResult = await zenExecutor.execute(createInput("big-pickle"));
@@ -110,18 +110,12 @@ describe("OpencodeExecutor", () => {
 
     it("routes claude target format models to messages endpoint", async () => {
       const m27Result = await goExecutor.execute(
-        createInput("minimax-m2.7", true, { apiKey: "claude-key" })
+        createInput("minimax-m3", true, { apiKey: "claude-key" })
       );
       assert.equal(m27Result.url, "https://opencode.ai/zen/go/v1/messages");
       assert.equal(fetchCalls[0].url, "https://opencode.ai/zen/go/v1/messages");
       assert.equal(m27Result.headers["anthropic-version"], "2023-06-01");
 
-      const m25Result = await goExecutor.execute(
-        createInput("minimax-m2.5", true, { apiKey: "claude-key" })
-      );
-      assert.equal(m25Result.url, "https://opencode.ai/zen/go/v1/messages");
-      assert.equal(fetchCalls[1].url, "https://opencode.ai/zen/go/v1/messages");
-      assert.equal(m25Result.headers["anthropic-version"], "2023-06-01");
     });
 
     it("routes openai responses target format models to responses endpoint", async () => {
@@ -192,7 +186,7 @@ describe("OpencodeExecutor", () => {
 
     it("adds anthropic version for claude target format", async () => {
       const result = await goExecutor.execute(
-        createInput("minimax-m2.7", true, { apiKey: "claude-key" })
+        createInput("minimax-m3", true, { apiKey: "claude-key" })
       );
 
       assert.deepEqual(result.headers, {
@@ -215,7 +209,7 @@ describe("OpencodeExecutor", () => {
     });
 
     it("omits authorization when credentials are missing", async () => {
-      const result = await zenExecutor.execute(createInput("minimax-m2.5-free", true, null));
+      const result = await zenExecutor.execute(createInput("deepseek-v4-flash-free", true, null));
 
       assert.deepEqual(result.headers, {
         "Content-Type": "application/json",
@@ -226,18 +220,18 @@ describe("OpencodeExecutor", () => {
 
     it("routes opencode-go new models to chat completions", async () => {
       // Register new models
-      registerModel("opencode-go", { id: "glm-5.1", name: "GLM-5.1", contextLength: 204800 });
-      registerModel("opencode-go", { id: "kimi-k2.6", name: "Kimi K2.6" });
+      registerModel("opencode-go", { id: "glm-5.3", name: "GLM-5.3", contextLength: 204800 });
+      registerModel("opencode-go", { id: "kimi-k3", name: "Kimi K3" });
       registerModel("opencode-go", { id: "mimo-v2.5-pro", name: "MiMo V2.5 Pro" });
       registerModel("opencode-go", { id: "mimo-v2.5", name: "MiMo V2.5" });
 
-      // glm-5.1
-      const glm51 = await goExecutor.execute(createInput("glm-5.1"));
-      assert.equal(glm51.url, "https://opencode.ai/zen/go/v1/chat/completions");
+      // glm-5.3
+      const glm53 = await goExecutor.execute(createInput("glm-5.3"));
+      assert.equal(glm53.url, "https://opencode.ai/zen/go/v1/chat/completions");
 
-      // kimi-k2.6
-      const kimi26 = await goExecutor.execute(createInput("kimi-k2.6"));
-      assert.equal(kimi26.url, "https://opencode.ai/zen/go/v1/chat/completions");
+      // kimi-k3
+      const kimi3 = await goExecutor.execute(createInput("kimi-k3"));
+      assert.equal(kimi3.url, "https://opencode.ai/zen/go/v1/chat/completions");
 
       // mimo-v2.5-pro
       const mimoPro = await goExecutor.execute(createInput("mimo-v2.5-pro"));
@@ -249,23 +243,23 @@ describe("OpencodeExecutor", () => {
     });
 
     it("routes opencode-go qwen models to claude messages endpoint", async () => {
-      const qwen36 = await goExecutor.execute(
-        createInput("qwen3.6-plus", true, { apiKey: "claude-key" })
+      const qwen37Plus = await goExecutor.execute(
+        createInput("qwen3.7-plus", true, { apiKey: "claude-key" })
       );
-      assert.equal(qwen36.url, "https://opencode.ai/zen/go/v1/messages");
-      assert.equal(qwen36.headers["anthropic-version"], "2023-06-01");
+      assert.equal(qwen37Plus.url, "https://opencode.ai/zen/go/v1/messages");
+      assert.equal(qwen37Plus.headers["anthropic-version"], "2023-06-01");
 
-      const qwen35 = await goExecutor.execute(
-        createInput("qwen3.5-plus", true, { apiKey: "claude-key" })
+      const qwen38Max = await goExecutor.execute(
+        createInput("qwen3.8-max", true, { apiKey: "claude-key" })
       );
-      assert.equal(qwen35.url, "https://opencode.ai/zen/go/v1/messages");
-      assert.equal(qwen35.headers["anthropic-version"], "2023-06-01");
+      assert.equal(qwen38Max.url, "https://opencode.ai/zen/go/v1/messages");
+      assert.equal(qwen38Max.headers["anthropic-version"], "2023-06-01");
     });
 
     it("builds bearer auth headers for opencode-go openai models", async () => {
-      registerModel("opencode-go", { id: "glm-5.1", name: "GLM-5.1" });
+      registerModel("opencode-go", { id: "glm-5.3", name: "GLM-5.3" });
 
-      const result = await goExecutor.execute(createInput("glm-5.1"));
+      const result = await goExecutor.execute(createInput("glm-5.3"));
 
       assert.deepEqual(result.headers, {
         Authorization: "Bearer test-key",
@@ -280,7 +274,7 @@ describe("OpencodeExecutor", () => {
       registerModel("opencode-go", { id: "glm-6-max", name: "GLM-6 Max" });
       registerModel("opencode-go", { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro" });
       registerModel("opencode-go", { id: "mimo-v2.5", name: "MiMo-V2.5" });
-      registerModel("opencode-go", { id: "hy3-preview", name: "Hunyuan3 Preview" });
+      registerModel("opencode-go", { id: "hy3-high", name: "Hunyuan3 High" });
 
       // glm-6-max
       const glm6 = await goExecutor.execute(createInput("glm-6-max"));
@@ -294,8 +288,8 @@ describe("OpencodeExecutor", () => {
       const mimo = await goExecutor.execute(createInput("mimo-v2.5"));
       assert.equal(mimo.url, "https://opencode.ai/zen/go/v1/chat/completions");
 
-      // hy3-preview
-      const hy3 = await goExecutor.execute(createInput("hy3-preview"));
+      // hy3-high
+      const hy3 = await goExecutor.execute(createInput("hy3-high"));
       assert.equal(hy3.url, "https://opencode.ai/zen/go/v1/chat/completions");
     });
   });
@@ -324,7 +318,7 @@ describe("OpencodeExecutor", () => {
         { apiKey: "claude-key" },
         true,
         { "User-Agent": "opencode/1.0" },
-        "minimax-m2.7"
+        "minimax-m3"
       );
       assert.equal(headers["User-Agent"], "opencode/1.0");
       assert.equal(headers["x-api-key"], "claude-key");
@@ -411,7 +405,7 @@ describe("OpencodeExecutor", () => {
           "x-opencode-session": "sess-claude",
           "User-Agent": "opencode/1.0",
         },
-        "minimax-m2.7"
+        "minimax-m3"
       );
       assert.equal(headers["x-opencode-session"], "sess-claude");
       assert.equal(headers["x-api-key"], "claude-key");

--- a/tests/unit/opencode-free-tier-catalog-stale-6998.test.ts
+++ b/tests/unit/opencode-free-tier-catalog-stale-6998.test.ts
@@ -16,13 +16,15 @@ const DELISTED_FREE_MODELS = [
   "trinity-large-preview-free",
   "nemotron-3-super-free",
   "qwen3.6-plus-free",
+  "north-mini-code-free",
 ];
 
 const LIVE_FREE_MODELS_MISSING_FROM_CATALOG = [
   "mimo-v2.5-free",
   "hy3-free",
   "nemotron-3-ultra-free",
-  "north-mini-code-free",
+  "nemotron-3.5-lightning-free",
+  "laguna-s-2.1-free",
 ];
 
 test("issue #6998: oc registry does not advertise delisted free-tier models", () => {

--- a/tests/unit/opencode-go-catalog-alignment.test.ts
+++ b/tests/unit/opencode-go-catalog-alignment.test.ts
@@ -53,8 +53,8 @@ test("opencode-go preserves the pre-existing minimax-m3 and qwen routing via tar
   assert.equal(byId.get("qwen3.7-max")?.targetFormat, "claude");
 });
 
-test("opencode-go hy3 variants expose their context window to combo compatibility filtering", () => {
-  for (const modelId of ["hy3", "hy3-none", "hy3-low", "hy3-high"]) {
+test("opencode-go active hy3 variants expose their context window to combo compatibility filtering", () => {
+  for (const modelId of ["hy3", "hy3-low", "hy3-high"]) {
     assert.equal(
       getResolvedModelCapabilities(`opencode-go/${modelId}`).contextWindow,
       256000,

--- a/tests/unit/opencode-go-effort-aliases-8353.test.ts
+++ b/tests/unit/opencode-go-effort-aliases-8353.test.ts
@@ -3,7 +3,7 @@
  *
  * OpenCode's local Go registry exposes effort-tier aliases that OmniRoute did
  * not register or resolve. These tests cover:
- *  1. Catalog exposure on opencode-go (and absence on opencode-zen)
+ *  1. Catalog exposure on opencode-go (and alias absence on opencode-zen)
  *  2. parseEffortLevel → base + effort for every listed alias
  *  3. transformRequest rewrite + reasoning_effort injection
  *  4. MiniMax M3 stays out of the effort-alias path
@@ -40,12 +40,9 @@ const ISSUE_ALIASES: ReadonlyArray<{ alias: string; base: string; effort: string
   { alias: "grok-4.5-low", base: "grok-4.5", effort: "low" },
   { alias: "grok-4.5-medium", base: "grok-4.5", effort: "medium" },
   { alias: "grok-4.5-high", base: "grok-4.5", effort: "high" },
-  { alias: "hy3-none", base: "hy3", effort: "none" },
   { alias: "hy3-low", base: "hy3", effort: "low" },
   { alias: "hy3-high", base: "hy3", effort: "high" },
   { alias: "kimi-k3-max", base: "kimi-k3", effort: "max" },
-  { alias: "qwen3.6-plus-high", base: "qwen3.6-plus", effort: "high" },
-  { alias: "qwen3.6-plus-max", base: "qwen3.6-plus", effort: "max" },
   { alias: "qwen3.7-max-high", base: "qwen3.7-max", effort: "high" },
   { alias: "qwen3.7-max-max", base: "qwen3.7-max", effort: "max" },
   { alias: "qwen3.7-plus-high", base: "qwen3.7-plus", effort: "high" },
@@ -82,10 +79,10 @@ test("#8353 catalog: new base models are registered on opencode-go", () => {
   }
 });
 
-test("#8353 catalog: hy3 base is distinct from hy3-preview", () => {
+test("#8353 catalog: hy3 base remains while retired hy3-preview stays hidden", () => {
   const ids = new Set(goModelIds());
   assert.ok(ids.has("hy3"), "hy3 Go-tier base must exist");
-  assert.ok(ids.has("hy3-preview"), "hy3-preview must remain");
+  assert.equal(ids.has("hy3-preview"), false, "retired hy3-preview must stay hidden");
   assert.equal(
     parseEffortLevel("hy3-preview"),
     null,
@@ -98,16 +95,11 @@ test("#8353 catalog: aliases are NOT synthesized on opencode-zen", () => {
   for (const { alias } of ISSUE_ALIASES) {
     assert.equal(zenIds.has(alias), false, `opencode-zen must not expose ${alias}`);
   }
-  for (const base of NEW_BASES) {
-    assert.equal(zenIds.has(base), false, `opencode-zen must not expose base ${base}`);
-  }
 });
 
 test("#8353 catalog: qwen effort aliases keep Claude targetFormat", () => {
   const models = REGISTRY["opencode-go"]?.models ?? [];
   for (const id of [
-    "qwen3.6-plus-high",
-    "qwen3.6-plus-max",
     "qwen3.7-max-high",
     "qwen3.7-max-max",
     "qwen3.7-plus-high",
@@ -157,7 +149,7 @@ const CREDENTIALS = { apiKey: "k" } as Record<string, unknown>;
 const TRANSFORM_SAMPLES = [
   { alias: "deepseek-v4-flash-high", base: "deepseek-v4-flash", effort: "high" },
   { alias: "grok-4.5-medium", base: "grok-4.5", effort: "medium" },
-  { alias: "hy3-none", base: "hy3", effort: "none" },
+  { alias: "hy3-high", base: "hy3", effort: "high" },
   { alias: "kimi-k3-max", base: "kimi-k3", effort: "max" },
   { alias: "qwen3.7-plus-max", base: "qwen3.7-plus", effort: "max" },
   { alias: "qwen3.7-max-high", base: "qwen3.7-max", effort: "high" },

--- a/tests/unit/opencode-go-quota-no-zai.test.ts
+++ b/tests/unit/opencode-go-quota-no-zai.test.ts
@@ -16,7 +16,11 @@ test("getOpenCodeGoUsage does not send the user's OpenCode Go API key to api.z.a
   }) as typeof fetch;
 
   try {
-    const result = await getOpenCodeGoUsage("sk-fake-opencode-go-key", undefined);
+    const result = await getOpenCodeGoUsage(
+      "opencode-go-no-zai",
+      "sk-fake-opencode-go-key",
+      undefined
+    );
     assert.notStrictEqual(calledHost, "api.z.ai");
     assert.strictEqual(calledHost, null);
     assert.ok(

--- a/tests/unit/opencode-go-usage.test.ts
+++ b/tests/unit/opencode-go-usage.test.ts
@@ -10,6 +10,7 @@ const ORIGINAL_OPENCODE_GO_QUOTA_URL = process.env.OMNIROUTE_OPENCODE_GO_QUOTA_U
 process.env.OMNIROUTE_OPENCODE_GO_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit";
 
 const usage = await import("../../open-sse/services/usage.ts");
+const usageHistory = await import("../../src/lib/usage/usageHistory.ts");
 const { USAGE_SUPPORTED_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
 
 after(() => {
@@ -148,6 +149,98 @@ test("getUsageForProvider exposes OpenCode Go 5h, weekly, and monthly quotas", a
     assert.equal(result.quotas!.mcp_monthly.remainingPercentage, 90);
     assert.equal(result.quotas!.mcp_monthly.resetAt, new Date(resetMonthly).toISOString());
     assert.deepEqual(result.quotas!.mcp_monthly.details, [{ name: "search-prime", used: 3 }]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getUsageForProvider keeps upstream quota authoritative and adds a local priced ledger", async () => {
+  const originalFetch = globalThis.fetch;
+  const connectionId = "opencode-go-local-ledger";
+  const now = Date.now();
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "kimi-k3-max",
+    connectionId,
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: new Date(now - 60 * 60 * 1000).toISOString(),
+  });
+  globalThis.fetch = async () =>
+    Response.json({
+      code: 200,
+      success: true,
+      data: {
+        level: "pro",
+        limits: [
+          { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 25 },
+          { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 50 },
+          { type: "TIME_LIMIT", percentage: 10, currentValue: 6 },
+        ],
+      },
+    });
+
+  try {
+    const result = (await usage.getUsageForProvider({
+      id: connectionId,
+      provider: "opencode-go",
+      apiKey: "opencode-go-key",
+    })) as {
+      usageSource?: string;
+      quotas?: Record<string, { used: number }>;
+      localEstimate?: {
+        pricingRevision: string;
+        quotas: Record<string, { used: number }>;
+        modelMonthly: Array<{ model: string; used: number; total: number }>;
+      };
+    };
+
+    assert.equal(result.usageSource, "upstream");
+    assert.equal(result.quotas?.session.used, 3, "upstream 25% of $12 remains authoritative");
+    assert.equal(result.localEstimate?.pricingRevision, "2026-08-17");
+    assert.equal(result.localEstimate?.quotas.session.used, 3);
+    assert.deepEqual(result.localEstimate?.modelMonthly, [
+      {
+        model: "kimi-k3",
+        used: 3,
+        total: 15,
+        remaining: 12,
+        remainingPercentage: 80,
+        effectiveRemainingUsd: 9,
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getUsageForProvider falls back to the local priced ledger when upstream is unavailable", async () => {
+  const originalFetch = globalThis.fetch;
+  const connectionId = "opencode-go-local-fallback";
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "grok-4.5-high",
+    connectionId,
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  });
+  globalThis.fetch = async () => {
+    throw new Error("upstream offline");
+  };
+
+  try {
+    const result = (await usage.getUsageForProvider({
+      id: connectionId,
+      provider: "opencode-go",
+      apiKey: "opencode-go-key",
+    })) as {
+      usageSource?: string;
+      warning?: string;
+      quotas?: Record<string, { used: number }>;
+    };
+
+    assert.equal(result.usageSource, "localUsageHistory");
+    assert.match(result.warning ?? "", /upstream offline/);
+    assert.equal(result.quotas?.session.used, 2);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/opencode-go-window-ledger.test.ts
+++ b/tests/unit/opencode-go-window-ledger.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-opencode-go-ledger-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+process.env.API_KEY_SECRET = "opencode-go-ledger-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const usageHistory = await import("../../src/lib/usage/usageHistory.ts");
+const { getOpenCodeGoLocalUsage } =
+  await import("../../src/lib/usage/openCodeGoWindowLedger.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(resetStorage);
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("OpenCode Go ledger calculates official 5h, weekly, monthly, and per-model budgets", async () => {
+  const now = Date.parse("2026-08-17T12:00:00.000Z");
+  const connectionId = "opencode-go-ledger";
+
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "kimi-k3-max",
+    connectionId,
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: "2026-08-17T11:00:00.000Z",
+  });
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "qwen3.8-max",
+    connectionId,
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: "2026-08-17T10:00:00.000Z",
+  });
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "hy3-high",
+    connectionId,
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: "2026-08-15T12:00:00.000Z",
+  });
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "qwen3.7-plus",
+    connectionId,
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: "2026-08-08T12:00:00.000Z",
+  });
+
+  const result = getOpenCodeGoLocalUsage({ connectionId, now });
+
+  assert.equal(result.quotas.session.used, 5);
+  assert.equal(result.quotas.session.total, 12);
+  assert.equal(result.quotas.weekly.used, 5.14);
+  assert.equal(result.quotas.weekly.total, 30);
+  assert.equal(result.quotas.monthly.used, 6.34);
+  assert.equal(result.quotas.monthly.total, 60);
+  assert.equal(result.requestsPriced, 4);
+  assert.deepEqual(result.unknownModels, []);
+
+  const kimi = result.modelMonthly.find((model) => model.model === "kimi-k3");
+  assert.equal(kimi?.used, 3);
+  assert.equal(kimi?.total, 15);
+  assert.equal(kimi?.effectiveRemainingUsd, 7);
+
+  const hy3 = result.modelMonthly.find((model) => model.model === "hy3");
+  assert.equal(hy3?.used, 0.14);
+  assert.equal(hy3?.total, 60);
+});
+
+test("OpenCode Go ledger isolates connections and reports unknown models", async () => {
+  const now = Date.parse("2026-08-17T12:00:00.000Z");
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "unknown-go-model",
+    connectionId: "target",
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: "2026-08-17T11:00:00.000Z",
+  });
+  await usageHistory.saveRequestUsage({
+    provider: "opencode-go",
+    model: "kimi-k3",
+    connectionId: "other",
+    tokens: { input: 1_000_000, output: 0 },
+    timestamp: "2026-08-17T11:00:00.000Z",
+  });
+
+  const result = getOpenCodeGoLocalUsage({ connectionId: "target", now });
+
+  assert.equal(result.quotas.session.used, 0);
+  assert.equal(result.requestsPriced, 0);
+  assert.deepEqual(result.unknownModels, ["unknown-go-model"]);
+});

--- a/tests/unit/opencode-strip-client-metadata-1442.test.ts
+++ b/tests/unit/opencode-strip-client-metadata-1442.test.ts
@@ -6,7 +6,7 @@ const { OpencodeExecutor } = await import("../../open-sse/executors/opencode.ts"
 /**
  * Regression test for upstream decolua/9router#1442:
  *
- * OpenCode upstreams (e.g. kimi-k2.6 via opencode-go) reject the
+ * OpenCode upstreams (e.g. kimi-k3 via opencode-go) reject the
  * `client_metadata` passthrough field (an OpenAI-Codex/Claude-CLI artifact)
  * with 400 "Extra inputs are not permitted, field: 'client_metadata'".
  * DefaultExecutor strips it only for cerebras/mistral, and OpencodeExecutor
@@ -19,7 +19,7 @@ describe("OpencodeExecutor — strips client_metadata (#1442)", () => {
 
   function body() {
     return {
-      model: "oc/kimi-k2.6",
+      model: "oc/kimi-k3",
       stream: true,
       client_metadata: { user_id: "abc" },
       messages: [{ role: "user", content: "hi" }],
@@ -27,7 +27,7 @@ describe("OpencodeExecutor — strips client_metadata (#1442)", () => {
   }
 
   it("removes client_metadata from the forwarded body", () => {
-    const out = executor.transformRequest("oc/kimi-k2.6", body(), true, CREDENTIALS) as Record<
+    const out = executor.transformRequest("oc/kimi-k3", body(), true, CREDENTIALS) as Record<
       string,
       unknown
     >;
@@ -42,7 +42,7 @@ describe("OpencodeExecutor — strips client_metadata (#1442)", () => {
   it("is a no-op when client_metadata is absent", () => {
     const b = body();
     delete (b as Record<string, unknown>).client_metadata;
-    const out = executor.transformRequest("oc/kimi-k2.6", b, true, CREDENTIALS) as Record<
+    const out = executor.transformRequest("oc/kimi-k3", b, true, CREDENTIALS) as Record<
       string,
       unknown
     >;

--- a/tests/unit/provider-limits-ui.test.ts
+++ b/tests/unit/provider-limits-ui.test.ts
@@ -171,6 +171,24 @@ test("percentage-only quotas hide redundant usage counts while counted quotas ke
   assert.equal(providerLimitUtils.shouldShowQuotaUsageCount(counted[0]), true);
 });
 
+test("OpenCode Go quotas preserve their USD unit instead of being labeled as requests", () => {
+  const parsed = providerLimitUtils.parseQuotaData("opencode-go", {
+    quotas: {
+      session: {
+        used: 3,
+        total: 12,
+        remaining: 9,
+        remainingPercentage: 75,
+        currency: "USD",
+      },
+    },
+  });
+
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].currency, "USD");
+  assert.equal(providerLimitUtils.shouldShowQuotaUsageCount(parsed[0]), true);
+});
+
 test("Firecrawl over-plan quota displays remaining credits against the plan baseline", () => {
   const parsed = providerLimitUtils.parseQuotaData("firecrawl", {
     quotas: {

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -876,7 +876,7 @@ test("provider models route honors autoFetchModels=false and skips remote discov
   assert.equal(body.source, "local_catalog");
   assert.match(body.warning, /auto-fetch disabled/i);
   assert.equal(called, false);
-  assert.ok(body.models.some((model) => model.id === "glm-5"));
+  assert.ok(body.models.some((model) => model.id === "glm-5.3"));
 });
 
 test("provider models route uses synced models as the authoritative local catalog (#3148)", async () => {

--- a/tests/unit/provider-registry-qwen-vision.test.ts
+++ b/tests/unit/provider-registry-qwen-vision.test.ts
@@ -1,8 +1,8 @@
 /**
  * Issue #2822 — qwen3.7-max (opencode-go) retorna 500 em inputs com imagem.
  *
- * qwen3.7-max, qwen3.6-plus e qwen3.5-plus nos providers opencode-go e
- * opencode-zen não possuíam supportsVision: false. Isso fazia com que
+ * Qwen models on opencode-go and opencode-zen did not declare
+ * supportsVision: false. Isso fazia com que
  * blocos de imagem chegassem ao upstream (que não suporta visão),
  * gerando 500s que esgotavam todo o orçamento de retentativas.
  *
@@ -48,18 +48,18 @@ test("#2822 opencode-go/qwen3.7-max deve ter supportsVision !== true", () => {
   );
 });
 
-test("#2822 opencode-go/qwen3.6-plus deve ter supportsVision !== true", () => {
-  const model = getModel("opencode-go", "qwen3.6-plus");
-  assert.ok(model, "qwen3.6-plus deve estar registrado em opencode-go");
+test("#2822 opencode-go/qwen3.7-plus deve ter supportsVision !== true", () => {
+  const model = getModel("opencode-go", "qwen3.7-plus");
+  assert.ok(model, "qwen3.7-plus deve estar registrado em opencode-go");
   assert.notEqual(
     model.supportsVision,
     true,
-    "opencode-go/qwen3.6-plus não suporta visão — supportsVision deve ser false ou ausente"
+    "opencode-go/qwen3.7-plus não suporta visão — supportsVision deve ser false ou ausente"
   );
   assert.strictEqual(
     model.supportsVision,
     false,
-    "opencode-go/qwen3.6-plus deve ter supportsVision: false explícito para bloquear seleção em combo com imagens"
+    "opencode-go/qwen3.7-plus deve ter supportsVision: false explícito para bloquear seleção em combo com imagens"
   );
 });
 
@@ -77,18 +77,18 @@ test("#6998 opencode/minimax-m3-free não deve mais estar registrado (deslistado
   );
 });
 
-test("#2822 opencode-go/qwen3.5-plus deve ter supportsVision !== true", () => {
-  const model = getModel("opencode-go", "qwen3.5-plus");
-  assert.ok(model, "qwen3.5-plus deve estar registrado em opencode-go");
+test("#2822 opencode-go/qwen3.8-max deve ter supportsVision !== true", () => {
+  const model = getModel("opencode-go", "qwen3.8-max");
+  assert.ok(model, "qwen3.8-max deve estar registrado em opencode-go");
   assert.notEqual(
     model.supportsVision,
     true,
-    "opencode-go/qwen3.5-plus não suporta visão — supportsVision deve ser false ou ausente"
+    "opencode-go/qwen3.8-max não suporta visão — supportsVision deve ser false ou ausente"
   );
   assert.strictEqual(
     model.supportsVision,
     false,
-    "opencode-go/qwen3.5-plus deve ter supportsVision: false explícito para bloquear seleção em combo com imagens"
+    "opencode-go/qwen3.8-max deve ter supportsVision: false explícito para bloquear seleção em combo com imagens"
   );
 });
 

--- a/tests/unit/repro-8841-context-overflow-opencode.test.ts
+++ b/tests/unit/repro-8841-context-overflow-opencode.test.ts
@@ -60,7 +60,7 @@ function upstreamContextOverflowResponse() {
       error: {
         code: "context_length_exceeded",
         message:
-          "Input exceeds the context window for opencode/north-mini-code-free: estimated 210724 input tokens, limit 200000. Reduce the prompt or route to a model with a larger context window.",
+          "Input exceeds the context window for opencode/mimo-v2.5-free: estimated 210724 input tokens, limit 200000. Reduce the prompt or route to a model with a larger context window.",
       },
     }),
     {
@@ -71,8 +71,8 @@ function upstreamContextOverflowResponse() {
 }
 
 test("#8841 advertised vs compat-filter limit agree", () => {
-  const advertised = getTokenLimit("opencode-zen", "north-mini-code-free");
-  const caps = getResolvedModelCapabilities("opencode/north-mini-code-free");
+  const advertised = getTokenLimit("opencode-zen", "mimo-v2.5-free");
+  const caps = getResolvedModelCapabilities("opencode/mimo-v2.5-free");
   assert.ok(advertised > 0);
   assert.ok(
     caps.contextWindow != null && caps.contextWindow > 0,
@@ -83,7 +83,7 @@ test("#8841 advertised vs compat-filter limit agree", () => {
 test("#8841 oversized request rejected up front (no dispatch)", async () => {
   const body = largeBody();
   const pool = [
-    target("opencode/north-mini-code-free"),
+    target("opencode/mimo-v2.5-free"),
     target("opencode/hy3-free"),
   ];
 
@@ -96,7 +96,7 @@ test("#8841 oversized request rejected up front (no dispatch)", async () => {
       name: "pro-coding-repro-8841",
       strategy: "priority",
       models: [
-        "opencode/north-mini-code-free",
+        "opencode/mimo-v2.5-free",
         "opencode/hy3-free",
       ],
     },

--- a/tests/unit/services/open-code-go-pricing.test.ts
+++ b/tests/unit/services/open-code-go-pricing.test.ts
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { opencode_goProvider } from "../../../open-sse/config/providers/registry/opencode/go/index.ts";
+import {
+  OPENCODE_GO_PRICING_REVISION,
+  OPENCODE_GO_PRICED_MODEL_IDS,
+  OPENCODE_GO_WINDOW_LIMITS_USD,
+  calculateOpenCodeGoCost,
+  resolveOpenCodeGoPricing,
+} from "../../../open-sse/services/openCodeGoPricing.ts";
+import { calculateCost } from "../../../src/lib/usage/costCalculator.ts";
+
+test("OpenCode Go pricing publishes the official budget revision", () => {
+  assert.equal(OPENCODE_GO_PRICING_REVISION, "2026-08-17");
+  assert.deepEqual(OPENCODE_GO_WINDOW_LIMITS_USD, {
+    session: 12,
+    weekly: 30,
+    monthly: 60,
+  });
+});
+
+test("every current OpenCode Go catalog model resolves to an official rate", () => {
+  const curatedBaseModels = new Set<string>();
+  for (const model of opencode_goProvider.models ?? []) {
+    const priced = calculateOpenCodeGoCost({ model: model.id, inputTokens: 1 });
+    assert.ok(
+      priced,
+      `missing official OpenCode Go pricing for ${model.id}`
+    );
+    curatedBaseModels.add(priced.model);
+  }
+  assert.deepEqual([...curatedBaseModels].sort(), [...OPENCODE_GO_PRICED_MODEL_IDS]);
+});
+
+test("effort aliases share their base model rate", () => {
+  assert.deepEqual(
+    resolveOpenCodeGoPricing({ model: "grok-4.5-high", inputTokens: 1 }),
+    resolveOpenCodeGoPricing({ model: "grok-4.5", inputTokens: 1 })
+  );
+  assert.deepEqual(
+    resolveOpenCodeGoPricing({ model: "deepseek-v4-pro-max", inputTokens: 1 }),
+    resolveOpenCodeGoPricing({ model: "deepseek-v4-pro", inputTokens: 1 })
+  );
+  assert.deepEqual(
+    resolveOpenCodeGoPricing({ model: "qwen3.7-plus-high", inputTokens: 1 }),
+    resolveOpenCodeGoPricing({ model: "qwen3.7-plus", inputTokens: 1 })
+  );
+});
+
+test("curated GPT 5.6 Luna changes rate only above 272K input tokens", () => {
+  assert.deepEqual(resolveOpenCodeGoPricing({ model: "gpt-5.6-luna", inputTokens: 272_000 }), {
+    input: 0.2,
+    output: 1.2,
+    cached: 0.02,
+    cache_creation: 0.25,
+    monthlyUsageLimitUsd: 15,
+    variant: "lte-272k",
+  });
+  assert.deepEqual(resolveOpenCodeGoPricing({ model: "gpt-5.6-luna", inputTokens: 272_001 }), {
+    input: 0.4,
+    output: 1.8,
+    cached: 0.04,
+    cache_creation: 0.5,
+    monthlyUsageLimitUsd: 15,
+    variant: "gt-272k",
+  });
+});
+
+test("curated Qwen 3.7 Plus changes rate only above 256K input tokens", () => {
+  assert.equal(
+    resolveOpenCodeGoPricing({ model: "qwen3.7-plus", inputTokens: 256_000 })?.input,
+    0.4
+  );
+  assert.equal(
+    resolveOpenCodeGoPricing({ model: "qwen3.7-plus", inputTokens: 256_001 })?.input,
+    1.2
+  );
+});
+
+test("DeepSeek Peak windows use UTC boundaries", () => {
+  assert.equal(
+    resolveOpenCodeGoPricing({
+      model: "deepseek-v4-pro",
+      inputTokens: 1,
+      timestamp: "2026-08-17T01:00:00.000Z",
+    })?.variant,
+    "peak"
+  );
+  assert.equal(
+    resolveOpenCodeGoPricing({
+      model: "deepseek-v4-pro",
+      inputTokens: 1,
+      timestamp: "2026-08-17T03:59:59.999Z",
+    })?.variant,
+    "peak"
+  );
+  assert.equal(
+    resolveOpenCodeGoPricing({
+      model: "deepseek-v4-pro",
+      inputTokens: 1,
+      timestamp: "2026-08-17T04:00:00.000Z",
+    })?.variant,
+    "off-peak"
+  );
+  assert.equal(
+    resolveOpenCodeGoPricing({
+      model: "deepseek-v4-flash",
+      inputTokens: 1,
+      timestamp: "2026-08-17T06:00:00.000Z",
+    })?.variant,
+    "peak"
+  );
+  assert.equal(
+    resolveOpenCodeGoPricing({
+      model: "deepseek-v4-flash",
+      inputTokens: 1,
+      timestamp: "2026-08-17T10:00:00.000Z",
+    })?.variant,
+    "off-peak"
+  );
+});
+
+test("OpenCode Go cost includes input, output, cache read, and cache write", () => {
+  const result = calculateOpenCodeGoCost({
+    model: "qwen3.8-max",
+    inputTokens: 3_000_000,
+    outputTokens: 1_000_000,
+    cacheReadTokens: 1_000_000,
+    cacheCreationTokens: 1_000_000,
+  });
+
+  assert.equal(result?.costUsd, 10.75);
+  assert.equal(result?.pricing.monthlyUsageLimitUsd, 15);
+});
+
+test("unknown OpenCode Go models remain unpriced instead of becoming free", () => {
+  assert.equal(resolveOpenCodeGoPricing({ model: "unknown-model", inputTokens: 1 }), null);
+  assert.equal(calculateOpenCodeGoCost({ model: "unknown-model", inputTokens: 1 }), null);
+  for (const retired of [
+    "glm-5.1",
+    "kimi-k2.6",
+    "minimax-m2.7",
+    "minimax-m2.5",
+    "qwen3.6-plus",
+  ]) {
+    assert.equal(resolveOpenCodeGoPricing({ model: retired, inputTokens: 1 }), null, retired);
+  }
+});
+
+test("the shared cost calculator uses OpenCode Go rates without leaking them to Zen", async () => {
+  const tokens = { input: 1_000_000, output: 1_000_000 };
+  assert.equal(
+    await calculateCost("opencode-go", "kimi-k3", tokens, {
+      timestamp: "2026-08-17T00:00:00.000Z",
+    }),
+    18
+  );
+  assert.equal(await calculateCost("opencode-zen", "kimi-k3", tokens), 0);
+});


### PR DESCRIPTION
## Summary

- refresh the OpenCode free, Go, and Zen static model catalogs
- keep the Zen catalog newest-first and preserve intentionally curated removals
- add official OpenCode Go rates only for the current curated catalog and its effort aliases
- resolve curated GPT 5.6 Luna and Qwen context tiers plus DeepSeek UTC Peak/Off-Peak rates
- calculate local 5-hour, weekly, monthly, and per-model usage from `usage_history`
- keep upstream quota percentages authoritative and use the local ledger as breakdown/fallback
- render OpenCode Go quota totals as USD instead of incorrectly labeling them as requests

## Validation

- OpenCode-focused Node suite: 302 passed, 0 failed
- `npm run test:vitest`: 362 passed, 0 failed
- `npm run lint`: passed
- `npm run typecheck:core`: passed
- `node scripts/check/check-docs-sync.mjs`: passed
- `npm run check:any-budget:t11`: passed
- `node scripts/check/check-tracked-artifacts.mjs`: passed
- `git diff --check`: passed
- `npm run test:unit`: the new OpenCode Go pricing, ledger, usage, and UI tests pass; the full suite still exits non-zero on pre-existing release-base failures including stale CLI/docs counts, the onnxruntime assertion, and environment/timing fixtures

Prettier was intentionally not run for this refresh.
