### PR TITLE
fix(sse): include prompt cache usage fields on message_stop fallback path

### DIFF
--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -298,6 +298,8 @@ export function claudeToOpenAIResponse(chunk, state) {
       if (!state.finishReasonSent) {
         const finishReason =
           state.finishReason || (state.toolCalls?.size > 0 ? "tool_calls" : "stop");
+        const cachedTokens = state.usage?.cache_read_input_tokens || 0;
+        const cacheCreationTokens = state.usage?.cache_creation_input_tokens || 0;
         const usageObj =
           state.usage && typeof state.usage === "object"
             ? {
@@ -310,6 +312,16 @@ export function claudeToOpenAIResponse(chunk, state) {
                         reasoning_tokens: state.usage.reasoning_tokens,
                         completion_tokens_details: {
                           reasoning_tokens: state.usage.reasoning_tokens,
+                        },
+                      }
+                    : {}),
+                  ...(cachedTokens > 0 || cacheCreationTokens > 0
+                    ? {
+                        prompt_tokens_details: {
+                          ...(cachedTokens > 0 ? { cached_tokens: cachedTokens } : {}),
+                          ...(cacheCreationTokens > 0
+                            ? { cache_creation_tokens: cacheCreationTokens }
+                            : {}),
                         },
                       }
                     : {}),

--- a/tests/unit/translator-resp-claude-to-openai.test.ts
+++ b/tests/unit/translator-resp-claude-to-openai.test.ts
@@ -403,6 +403,40 @@ test("Claude stream: message_stop falls back to tool_calls when tool use already
   assert.equal(result[0].choices[0].finish_reason, "tool_calls");
 });
 
+test("Claude stream: message_stop includes prompt_tokens_details when usage arrived on an earlier message_delta without stop_reason (#10535)", () => {
+  const state = createState();
+  claudeToOpenAIResponse(
+    { type: "message_start", message: { id: "msg1", model: "claude-sonnet-4-6" } },
+    state
+  );
+
+  // Usage lands on a message_delta that carries no stop_reason (e.g. an
+  // upstream that reports usage and the finish signal in separate events),
+  // so the finalChunk branch in the message_delta case never runs and
+  // finishReasonSent stays false.
+  const deltaResult = claudeToOpenAIResponse(
+    {
+      type: "message_delta",
+      delta: {},
+      usage: {
+        input_tokens: 8,
+        output_tokens: 5,
+        cache_read_input_tokens: 2000,
+        cache_creation_input_tokens: 0,
+      },
+    },
+    state
+  );
+  assert.equal(deltaResult, null);
+
+  const result = claudeToOpenAIResponse({ type: "message_stop" }, state);
+
+  assert.equal(result[0].usage.prompt_tokens, 2008);
+  assert.equal(result[0].usage.completion_tokens, 5);
+  assert.equal(result[0].usage.total_tokens, 2013);
+  assert.equal(result[0].usage.prompt_tokens_details.cached_tokens, 2000);
+});
+
 test("Claude stream: unsupported events return null", () => {
   assert.equal(claudeToOpenAIResponse({ type: "error" }, createState()), null);
 });


### PR DESCRIPTION
## Summary
- `claude-to-openai.ts` built the final OpenAI-format `usage` payload in two places: the `message_delta` finish path (already mapped `cache_read`/`cache_creation` into `prompt_tokens_details`) and a `message_stop` fallback used when the finish signal arrives without usage on the same event.
- The fallback never copied the cache fields, so OpenAI-compatible clients saw "0% cache hit" even though the data was present in `state.usage` (matches the report: Claude-format responses had the counters, OpenAI-format ones didn't).
- Mirrored the existing `prompt_tokens_details` mapping from the `message_delta` path into the `message_stop` fallback.

Fixes #10535

## Test plan
- [x] New regression test: "Claude stream: message_stop includes prompt_tokens_details when usage arrived on an earlier message_delta without stop_reason (#10535)" — fails before the fix, passes after.
- [x] `node --import tsx/esm --test tests/unit/translator-resp-claude-to-openai.test.ts` — 16/16 passing.
- [x] `npm run typecheck:core` — clean.
- [x] `npm run lint` (suppressions applied) — no new violations on the two changed files.

⚠️ base-red inherited: #9985 (the two failing jobs on the latest schedule run — "Validate main branch" and "Bank ratchet shrinks" — are unrelated to this change; "Validate active release branch" passed on the current tip).
