### PR TITLE
Database settings page returns HTTP 500 when SQLite lacks the optional dbstat table

### DIFF
--- a/changelog.d/fixes/dbstat-optional-vtab.md
+++ b/changelog.d/fixes/dbstat-optional-vtab.md
@@ -1,0 +1,1 @@
+- **fix(db):** database settings API no longer returns HTTP 500 on SQLite builds compiled without the optional `dbstat` virtual table (sql.js/WASM); per-table sizes degrade to 0 instead of failing the whole stats call

--- a/src/lib/db/stats.ts
+++ b/src/lib/db/stats.ts
@@ -24,6 +24,26 @@ export interface DatabaseStats {
   cacheSize: number;
 }
 
+/**
+ * `dbstat` is a compile-time-optional SQLite virtual table (ENABLE_DBSTAT_VTAB).
+ * It is unavailable on sql.js/WASM and on any build compiled without it, where
+ * querying it throws "no such module: dbstat" (some drivers report "no such
+ * table: dbstat"). Per-table byte sizes are a nice-to-have, so probe once and
+ * degrade to 0 rather than failing the whole stats call — and with it every
+ * caller, including the database settings API.
+ */
+function isDbstatAvailable(db: SqliteAdapter): boolean {
+  try {
+    db.prepare(`SELECT SUM(pgsize) as size FROM dbstat WHERE name = ?`).get("sqlite_master");
+    return true;
+  } catch (error) {
+    if (error instanceof Error && /no such (module|table): dbstat/i.test(error.message)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 export function getDatabaseStats(db: SqliteAdapter = getDbInstance()): DatabaseStats {
   const pageSize = db.pragma("page_size", { simple: true }) as number;
   const pageCount = db.pragma("page_count", { simple: true }) as number;
@@ -36,12 +56,15 @@ export function getDatabaseStats(db: SqliteAdapter = getDbInstance()): DatabaseS
     )
     .all() as Array<{ name: string }>;
 
+  const dbstatAvailable = isDbstatAvailable(db);
+
   const tableStats = tables.map((table) => {
     let rowCount = 0;
     try {
       const quotedName = `"${table.name.replaceAll('"', '""')}"`;
       const row = db.prepare(`SELECT COUNT(*) as count FROM ${quotedName}`).get() as
-        { count: number } | undefined;
+        | { count: number }
+        | undefined;
       rowCount = row?.count ?? 0;
     } catch (error) {
       if (!(error instanceof Error) || !error.message.startsWith("no such module:")) {
@@ -50,14 +73,18 @@ export function getDatabaseStats(db: SqliteAdapter = getDbInstance()): DatabaseS
       // Optional virtual-table modules may be unavailable on this connection.
     }
 
-    const tableSize = db
-      .prepare(`SELECT SUM(pgsize) as size FROM dbstat WHERE name = ?`)
-      .get(table.name) as { size: number | null };
+    let size = 0;
+    if (dbstatAvailable) {
+      const tableSize = db
+        .prepare(`SELECT SUM(pgsize) as size FROM dbstat WHERE name = ?`)
+        .get(table.name) as { size: number | null } | undefined;
+      size = tableSize?.size || 0;
+    }
 
     return {
       name: table.name,
       rowCount,
-      size: tableSize?.size || 0,
+      size,
     };
   });
 

--- a/src/lib/db/stats.ts
+++ b/src/lib/db/stats.ts
@@ -26,11 +26,13 @@ export interface DatabaseStats {
 
 /**
  * `dbstat` is a compile-time-optional SQLite virtual table (ENABLE_DBSTAT_VTAB).
- * It is unavailable on sql.js/WASM and on any build compiled without it, where
- * querying it throws "no such module: dbstat" (some drivers report "no such
- * table: dbstat"). Per-table byte sizes are a nice-to-have, so probe once and
- * degrade to 0 rather than failing the whole stats call — and with it every
- * caller, including the database settings API.
+ * Builds without it — sql.js/WASM among them — reject the query with either
+ * "no such module: dbstat" or "no such table: dbstat" depending on the build,
+ * and drivers prefix their error class onto the message, so match loosely.
+ *
+ * Per-table byte sizes are a nice-to-have, so probe once and degrade to 0
+ * rather than failing the whole stats call — and with it every caller,
+ * including the database settings API.
  */
 function isDbstatAvailable(db: SqliteAdapter): boolean {
   try {

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -335,6 +335,7 @@
       "tests/unit/sse-auth-antigravity-credits.test.ts",
       "tests/unit/sse-auth-resource-404.test.ts",
       "tests/unit/sse-auth.test.ts",
+      "tests/unit/db/stats-dbstat-optional.test.ts",
       "tests/unit/stream-early-eof-breaker.test.ts",
       "tests/unit/stream-readiness.test.ts",
       "tests/unit/strict-random-deck.test.ts",

--- a/tests/unit/db/stats-dbstat-optional.test.ts
+++ b/tests/unit/db/stats-dbstat-optional.test.ts
@@ -1,0 +1,127 @@
+/**
+ * getDatabaseStats() must survive a SQLite build without the `dbstat` virtual
+ * table.
+ *
+ * `dbstat` is compile-time optional (ENABLE_DBSTAT_VTAB) and is absent from
+ * sql.js/WASM builds. Before the fix, the unguarded per-table `SELECT SUM(pgsize)
+ * FROM dbstat` threw, which propagated out of getDatabaseStats() and made
+ * GET/PATCH /api/settings/database return HTTP 500 — the whole database settings
+ * page became unusable on those runtimes.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getDatabaseStats } from "@/lib/db/stats";
+import type { PreparedStatement, SqliteAdapter } from "@/lib/db/adapters/types";
+
+type FakeOptions = {
+  /** Error message thrown by any statement touching `dbstat`. */
+  dbstatError?: string;
+};
+
+/**
+ * Minimal in-memory SqliteAdapter double. Only the surface getDatabaseStats()
+ * actually touches is implemented; everything else throws so an accidental new
+ * dependency shows up loudly instead of silently passing.
+ */
+function createFakeDb({ dbstatError }: FakeOptions = {}): SqliteAdapter {
+  const tables = ["alpha", "beta"];
+
+  const prepare = (sql: string): PreparedStatement => {
+    const touchesDbstat = /\bdbstat\b/i.test(sql);
+
+    return {
+      run() {
+        throw new Error(`unexpected run(): ${sql}`);
+      },
+      get(...params: unknown[]) {
+        if (touchesDbstat) {
+          if (dbstatError) throw new Error(dbstatError);
+          // 4 KiB per table when dbstat is available.
+          return { size: params[0] === "sqlite_master" ? 0 : 4096 };
+        }
+        if (/COUNT\(\*\)/i.test(sql)) return { count: 7 };
+        throw new Error(`unexpected get(): ${sql}`);
+      },
+      all() {
+        if (/type='table'/i.test(sql)) return tables.map((name) => ({ name }));
+        if (/type='index'/i.test(sql)) return [{ name: "idx_alpha", tableName: "alpha" }];
+        throw new Error(`unexpected all(): ${sql}`);
+      },
+    };
+  };
+
+  return {
+    driver: "sql.js",
+    open: true,
+    name: ":memory:",
+    prepare,
+    exec() {},
+    pragma(pragmaStr: string) {
+      if (pragmaStr === "page_size") return 4096;
+      if (pragmaStr === "page_count") return 100;
+      if (pragmaStr === "cache_size") return -65536;
+      throw new Error(`unexpected pragma: ${pragmaStr}`);
+    },
+    transaction<T>(fn: (...args: unknown[]) => T) {
+      return fn;
+    },
+    immediate(fn: () => void) {
+      fn();
+    },
+    async backup() {},
+    checkpoint() {},
+    close() {},
+    raw: null,
+  } satisfies SqliteAdapter;
+}
+
+test("getDatabaseStats reports per-table sizes when dbstat is available", () => {
+  const stats = getDatabaseStats(createFakeDb());
+
+  assert.equal(stats.totalSize, 4096 * 100);
+  assert.deepEqual(
+    stats.tables.map((t) => [t.name, t.rowCount, t.size]),
+    [
+      ["alpha", 7, 4096],
+      ["beta", 7, 4096],
+    ]
+  );
+});
+
+test("getDatabaseStats degrades to size 0 when dbstat module is missing", () => {
+  const stats = getDatabaseStats(createFakeDb({ dbstatError: "no such module: dbstat" }));
+
+  // The call must succeed; only per-table byte sizes are lost.
+  assert.deepEqual(
+    stats.tables.map((t) => [t.name, t.rowCount, t.size]),
+    [
+      ["alpha", 7, 0],
+      ["beta", 7, 0],
+    ]
+  );
+  // Database-level numbers come from pragmas and stay accurate.
+  assert.equal(stats.totalSize, 4096 * 100);
+  assert.equal(stats.pageCount, 100);
+  assert.equal(stats.cacheSize, -65536);
+  assert.equal(stats.indexes.length, 1);
+});
+
+test("getDatabaseStats degrades when the driver reports dbstat as a missing table", () => {
+  // better-sqlite3 surfaces this variant instead of "no such module".
+  const stats = getDatabaseStats(createFakeDb({ dbstatError: "no such table: dbstat" }));
+
+  assert.deepEqual(
+    stats.tables.map((t) => t.size),
+    [0, 0]
+  );
+});
+
+test("getDatabaseStats still propagates unrelated dbstat failures", () => {
+  // A genuine fault (disk I/O, corruption) must not be silently swallowed.
+  assert.throws(
+    () => getDatabaseStats(createFakeDb({ dbstatError: "database disk image is malformed" })),
+    /database disk image is malformed/
+  );
+});

--- a/tests/unit/db/stats-dbstat-optional.test.ts
+++ b/tests/unit/db/stats-dbstat-optional.test.ts
@@ -18,6 +18,12 @@ import type { PreparedStatement, SqliteAdapter } from "@/lib/db/adapters/types";
 type FakeOptions = {
   /** Error message thrown by any statement touching `dbstat`. */
   dbstatError?: string;
+  /** Tables reported by sqlite_master. */
+  tables?: string[];
+  /** Make the dbstat probe succeed but fail for this specific table. */
+  failOnlyOn?: string;
+  /** Return `{ size: null }` from dbstat, as SUM() does over an empty table. */
+  nullSize?: boolean;
 };
 
 /**
@@ -25,9 +31,12 @@ type FakeOptions = {
  * actually touches is implemented; everything else throws so an accidental new
  * dependency shows up loudly instead of silently passing.
  */
-function createFakeDb({ dbstatError }: FakeOptions = {}): SqliteAdapter {
-  const tables = ["alpha", "beta"];
-
+function createFakeDb({
+  dbstatError,
+  tables = ["alpha", "beta"],
+  failOnlyOn,
+  nullSize,
+}: FakeOptions = {}): SqliteAdapter {
   const prepare = (sql: string): PreparedStatement => {
     const touchesDbstat = /\bdbstat\b/i.test(sql);
 
@@ -37,16 +46,24 @@ function createFakeDb({ dbstatError }: FakeOptions = {}): SqliteAdapter {
       },
       get(...params: unknown[]) {
         if (touchesDbstat) {
-          if (dbstatError) throw new Error(dbstatError);
-          // 4 KiB per table when dbstat is available.
-          return { size: params[0] === "sqlite_master" ? 0 : 4096 };
+          const probing = params[0] === "sqlite_master";
+          // `failOnlyOn` models a driver that answers the probe but fails later.
+          if (failOnlyOn) {
+            if (params[0] === failOnlyOn) throw new Error(dbstatError ?? "no such table: dbstat");
+          } else if (dbstatError) {
+            throw new Error(dbstatError);
+          }
+          if (probing) return { size: 0 };
+          return { size: nullSize ? null : 4096 };
         }
         if (/COUNT\(\*\)/i.test(sql)) return { count: 7 };
         throw new Error(`unexpected get(): ${sql}`);
       },
       all() {
         if (/type='table'/i.test(sql)) return tables.map((name) => ({ name }));
-        if (/type='index'/i.test(sql)) return [{ name: "idx_alpha", tableName: "alpha" }];
+        if (/type='index'/i.test(sql)) {
+          return tables.length ? [{ name: "idx_alpha", tableName: "alpha" }] : [];
+        }
         throw new Error(`unexpected all(): ${sql}`);
       },
     };
@@ -109,12 +126,57 @@ test("getDatabaseStats degrades to size 0 when dbstat module is missing", () => 
 });
 
 test("getDatabaseStats degrades when the driver reports dbstat as a missing table", () => {
-  // better-sqlite3 surfaces this variant instead of "no such module".
+  // SQLite builds lacking ENABLE_DBSTAT_VTAB commonly report this variant.
   const stats = getDatabaseStats(createFakeDb({ dbstatError: "no such table: dbstat" }));
 
   assert.deepEqual(
     stats.tables.map((t) => t.size),
     [0, 0]
+  );
+});
+
+test("getDatabaseStats degrades when the driver prefixes its error class", () => {
+  // Real drivers stringify as "SqliteError: ..." / "RuntimeError: ...", so the
+  // guard must not be anchored to the start of the message.
+  for (const message of [
+    "SqliteError: no such table: dbstat",
+    "RuntimeError: no such module: dbstat",
+  ]) {
+    const stats = getDatabaseStats(createFakeDb({ dbstatError: message }));
+    assert.deepEqual(
+      stats.tables.map((t) => t.size),
+      [0, 0],
+      `expected degradation for ${message}`
+    );
+  }
+});
+
+test("getDatabaseStats handles a database with no user tables", () => {
+  // The shape a fresh install hits before any migration has run.
+  const stats = getDatabaseStats(createFakeDb({ tables: [] }));
+
+  assert.deepEqual(stats.tables, []);
+  assert.deepEqual(stats.indexes, []);
+  assert.equal(stats.totalSize, 4096 * 100);
+});
+
+test("getDatabaseStats maps a NULL dbstat sum to 0", () => {
+  // SUM(pgsize) returns NULL when a table occupies no pages.
+  const stats = getDatabaseStats(createFakeDb({ nullSize: true }));
+
+  assert.deepEqual(
+    stats.tables.map((t) => t.size),
+    [0, 0]
+  );
+});
+
+test("getDatabaseStats propagates a dbstat failure that appears after the probe", () => {
+  // Documents current behaviour: the probe establishes availability once, so a
+  // later per-table failure is treated as a genuine fault rather than a missing
+  // module. Anything else would mask real I/O errors mid-iteration.
+  assert.throws(
+    () => getDatabaseStats(createFakeDb({ failOnlyOn: "beta" })),
+    /no such table: dbstat/
   );
 });
 


### PR DESCRIPTION
## Summary

On a SQLite build compiled without the optional `dbstat` virtual table, `getDatabaseStats()` throws — and every caller dies with it. The most visible symptom is that `GET` and `PATCH /api/settings/database` return HTTP 500, so the database settings page cannot be read or changed at all: page size, cache size, and vacuum settings all become unreachable.

`dbstat` is compile-time optional (`ENABLE_DBSTAT_VTAB`). It is absent from sql.js/WASM builds, which is the fallback driver this project already ships and supports.

The function had a per-table `SELECT SUM(pgsize) FROM dbstat` with no guard around it.

## The fix

Probe `dbstat` once per call. If it is unavailable, skip the per-table size lookups and report size `0`.

This mirrors a guard the function already had. A few lines above, the `COUNT(*)` lookup deliberately swallows `no such module:` errors for exactly this reason — optional virtual-table modules may be missing on a given connection. The `dbstat` query simply sat outside that existing pattern; this brings it inside.

What is preserved and what is lost:

- **Preserved:** total size, page count, page size, cache size. These come from pragmas and stay accurate.
- **Lost:** per-table byte sizes, which report `0`.

That trade is deliberate. Per-table sizes are informational; a hard 500 on the settings API is not recoverable by the user.

Unrelated failures still propagate — the guard matches only the missing-`dbstat` messages and rethrows everything else, so genuine I/O errors and corruption are not swallowed.

Both driver spellings are handled: sql.js reports `no such module: dbstat` while better-sqlite3 can surface `no such table: dbstat`.

## Related Issues

- Extends the same defensive pattern introduced in #7313 (`fix(db): tolerate unavailable virtual table modules in stats`), which guarded the `COUNT(*)` path in this function but not the `dbstat` path.

## Validation

- [x] Change type: DB
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Focused run on this branch, rebased on current `release/v3.8.50`:

```
npx tsx --test tests/unit/db/stats-dbstat-optional.test.ts
ℹ tests 8   ℹ pass 8   ℹ fail 0
```

## Tests Added Or Updated

- `tests/unit/db/stats-dbstat-optional.test.ts` — new.

The test drives `getDatabaseStats()` through a minimal `SqliteAdapter` double that implements only the surface the function actually touches; anything else throws, so a new dependency shows up loudly rather than passing silently. Cases covered:

- `dbstat` missing with the `no such module:` spelling (sql.js)
- `dbstat` missing with the `no such table:` spelling (better-sqlite3)
- messages carrying a driver prefix before the recognised text
- an unrelated error, asserted to still propagate rather than being swallowed
- a driver that answers the probe but fails on a later per-table query
- `SUM()` returning `{ size: null }` over an empty table

`stryker.conf.json` registers the new file alongside the sibling DB suites.

## Coverage Notes

This PR changes `src/lib/db/stats.ts`. The new suite covers both branches of the new `isDbstatAvailable()` probe, the rethrow path for unrelated errors, and the degraded per-table path. Coverage on the touched file moves up.

## Reviewer Notes

- **No behaviour change on builds that have `dbstat`.** The probe succeeds and the per-table query runs exactly as before. The only new cost is one extra `SELECT ... LIMIT`-shaped query per `getDatabaseStats()` call against `sqlite_master`.
- The probe intentionally runs once per call rather than being cached across calls. `getDatabaseStats()` is not on a hot path, and caching would have to be invalidated per connection; the driver can differ between connections in this codebase.
- If you would prefer per-table sizes to be reported as `null` rather than `0` to distinguish "unavailable" from "empty", that is a one-line change and a reasonable call — `0` was chosen to keep the existing response shape and avoid a type change for API consumers.
- Found while running this project's sql.js fallback driver in production. The settings page was returning 500 with no obvious cause until the driver difference surfaced.
