### PR TITLE
fix(api): name working OpenRouter ids when Gemini embed creds are missing

### DIFF
--- a/changelog.d/fixes/embed-gemini-missing-creds-hint.md
+++ b/changelog.d/fixes/embed-gemini-missing-creds-hint.md
@@ -1,0 +1,1 @@
+- **fix(api):** `/v1/embeddings` 400s for native `gemini-embedding-2` now name the working OpenRouter ids (`openrouter/google/gemini-embedding-2` and the preview alias) instead of only `No credentials for embedding provider: gemini` — thanks @RaviTharuma

--- a/src/lib/embeddings/errors.ts
+++ b/src/lib/embeddings/errors.ts
@@ -1,0 +1,50 @@
+/**
+ * Operator-facing embedding credential / provider errors.
+ *
+ * Native `gemini-embedding-2` is registered, but a host without a `gemini`
+ * Google AI Studio key still 400s. OpenRouter already serves the same model
+ * under `openrouter/google/gemini-embedding-2` (live default 3072-d). Name
+ * that working id in the 400 so Hindsight / Memorix operators are not stuck
+ * on a dead native id.
+ */
+
+export const OPENROUTER_GEMINI_EMBEDDING_2 = "openrouter/google/gemini-embedding-2";
+export const OPENROUTER_GEMINI_EMBEDDING_2_PREVIEW =
+  "openrouter/google/gemini-embedding-2-preview";
+export const NATIVE_GEMINI_EMBEDDING_2 = "gemini/gemini-embedding-2";
+
+const OPENROUTER_HINT =
+  `use \`${OPENROUTER_GEMINI_EMBEDDING_2}\` or \`${OPENROUTER_GEMINI_EMBEDDING_2_PREVIEW}\` ` +
+  "when OpenRouter is configured";
+
+/**
+ * 400 body when the resolved embedding provider has no usable credentials.
+ */
+export function formatMissingEmbeddingCredentialsError(provider: string): string {
+  const base = `No credentials for embedding provider: ${provider}`;
+  if (provider === "gemini") {
+    return (
+      `${base}. Native Gemini embeddings require a Google AI Studio API key on the \`gemini\` ` +
+      `provider. Without that key, ${OPENROUTER_HINT}.`
+    );
+  }
+  return base;
+}
+
+/**
+ * 400 body when the first path segment is not a known embedding provider.
+ */
+export function formatUnknownEmbeddingProviderError(
+  provider: string,
+  model: string | null = null
+): string {
+  const base =
+    `Unknown embedding provider: ${provider}. No matching hardcoded or local provider found.`;
+  const looksLikeGeminiEmbedding2 =
+    provider === "google" || (typeof model === "string" && model.includes("gemini-embedding-2"));
+  if (!looksLikeGeminiEmbedding2) return base;
+  return (
+    `${base} For Gemini Embedding 2, ${OPENROUTER_HINT}, or call \`${NATIVE_GEMINI_EMBEDDING_2}\` ` +
+    "after adding a Google AI Studio key on the `gemini` provider."
+  );
+}

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -22,6 +22,10 @@ import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
 import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
 import { findEmbeddingComboDimensionConflict } from "./familyGuard";
+import {
+  formatMissingEmbeddingCredentialsError,
+  formatUnknownEmbeddingProviderError,
+} from "./errors";
 import { isPrivateHost, isCloudMetadataHost } from "@/shared/network/outboundUrlGuard";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
@@ -217,7 +221,7 @@ export async function createEmbeddingResponse(
   if (!providerConfig) {
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,
-      `Unknown embedding provider: ${provider}. No matching hardcoded or local provider found.`
+      formatUnknownEmbeddingProviderError(provider, resolvedModel)
     );
   }
 
@@ -227,7 +231,7 @@ export async function createEmbeddingResponse(
     if (!credentials) {
       return errorResponse(
         HTTP_STATUS.BAD_REQUEST,
-        `No credentials for embedding provider: ${provider}`
+        formatMissingEmbeddingCredentialsError(provider)
       );
     }
     if ("allRateLimited" in credentials && credentials.allRateLimited) {

--- a/tests/unit/embeddings-gemini-creds-hint.test.ts
+++ b/tests/unit/embeddings-gemini-creds-hint.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatMissingEmbeddingCredentialsError,
+  formatUnknownEmbeddingProviderError,
+  OPENROUTER_GEMINI_EMBEDDING_2,
+  OPENROUTER_GEMINI_EMBEDDING_2_PREVIEW,
+  NATIVE_GEMINI_EMBEDDING_2,
+} from "../../src/lib/embeddings/errors.ts";
+
+test("missing gemini embed credentials name the working OpenRouter ids", () => {
+  const message = formatMissingEmbeddingCredentialsError("gemini");
+  assert.match(message, /^No credentials for embedding provider: gemini/);
+  assert.match(message, new RegExp(OPENROUTER_GEMINI_EMBEDDING_2));
+  assert.match(message, new RegExp(OPENROUTER_GEMINI_EMBEDDING_2_PREVIEW));
+  assert.match(message, /Google AI Studio/);
+});
+
+test("missing credentials for other providers stay a short 400", () => {
+  assert.equal(
+    formatMissingEmbeddingCredentialsError("openai"),
+    "No credentials for embedding provider: openai"
+  );
+});
+
+test("unknown google provider names Gemini Embedding 2 workarounds", () => {
+  const message = formatUnknownEmbeddingProviderError("google", "gemini-embedding-2");
+  assert.match(message, /^Unknown embedding provider: google/);
+  assert.match(message, new RegExp(OPENROUTER_GEMINI_EMBEDDING_2));
+  assert.match(message, new RegExp(NATIVE_GEMINI_EMBEDDING_2));
+});
+
+test("unknown unrelated providers stay a short 400", () => {
+  assert.equal(
+    formatUnknownEmbeddingProviderError("not-a-provider", "text-embedding-3-small"),
+    "Unknown embedding provider: not-a-provider. No matching hardcoded or local provider found."
+  );
+});


### PR DESCRIPTION
## Summary

Native `gemini-embedding-2` is registered in OmniRoute, but a host without a Google AI Studio key on the `gemini` provider returns a dead-end 400. OpenRouter already serves the same model. This PR only improves that 400 (and the unknown-`google` 400) so operators are told the working ids.

This does **not** add a Gemini API key. Native `gemini-embedding-2` still needs a `gemini` connection (secrets-only / dashboard). See the secrets note at the bottom.

## Live evidence (re-verified 2026-08-17, OmniRoute 3.8.49)

Endpoint: `https://<omniroute-host>/v1/embeddings`  
Clients that break: **Hindsight 0.9.1** and **Memorix 1.6.0** if they are pointed at bare `gemini-embedding-2` / `gemini/gemini-embedding-2`.

### Actual — native id

Request:

```json
{ "model": "gemini-embedding-2", "input": ["alpha", "beta"] }
```

HTTP **400**

```json
{
  "error": {
    "message": "No credentials for embedding provider: gemini",
    "type": "invalid_request_error",
    "code": "bad_request"
  }
}
```

`gemini/gemini-embedding-2` is the same 400.

`google/gemini-embedding-2` is HTTP **400**:

```json
{
  "error": {
    "message": "Unknown embedding provider: google. No matching hardcoded or local provider found.",
    "type": "invalid_request_error",
    "code": "bad_request"
  }
}
```

### Actual — working OpenRouter ids (same host, OpenRouter configured)

`openrouter/google/gemini-embedding-2` → HTTP **200**, 2 vectors, **3072-d**, batch 2→2.  
`openrouter/google/gemini-embedding-2-preview` → HTTP **200**, 2 vectors, **3072-d**.

### Expected after this PR

Same HTTP 400, but the message names:

- `openrouter/google/gemini-embedding-2`
- `openrouter/google/gemini-embedding-2-preview`
- and that a Google AI Studio key on the `gemini` provider is required for `gemini/gemini-embedding-2`

Unrelated providers keep the short message (existing `route-edge-coverage` regex still matches).

### Repro (redact the bearer)

```bash
curl -sS https://omniroute.example/v1/embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"gemini-embedding-2","input":["alpha","beta"]}'

curl -sS https://omniroute.example/v1/embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"openrouter/google/gemini-embedding-2","input":["alpha","beta"]}'
```

## Secrets-only (cannot ship in this PR)

Making native `gemini-embedding-2` return 200 requires a Google AI Studio key stored as a `gemini` provider connection (dashboard or imported `GEMINI_API_KEY`). That secret is not in git. Homelab `omniroute-secrets` currently injects `JINA_AI_API_KEY`, not a Gemini embed key.

## Related Issues

- Related to #7956 / #7978 (multimodal embeddings already landed; this is the credential 400)
- Sibling PRs: catalog registration of the OpenRouter ids; embeddings client runbook

## Validation

- [x] `node --import tsx/esm --test tests/unit/embeddings-gemini-creds-hint.test.ts` (4 pass)
- [x] `node --import tsx/esm --test tests/unit/route-edge-coverage.test.ts` (16 pass)

## Tests Added Or Updated

- `tests/unit/embeddings-gemini-creds-hint.test.ts`

## Coverage Notes

- New helper `src/lib/embeddings/errors.ts` is fully covered by the new unit file.
- `src/lib/embeddings/service.ts` now calls those helpers on the existing 400 paths; `route-edge-coverage` still exercises missing-credentials / unknown-provider.

## Reviewer Notes

- No credential fallback / silent OpenRouter rewrite. Operators must change the model id or add a Gemini key.
- `google` is **not** aliased to `gemini` globally — a custom provider_node with prefix `google` already exists in tests (`auth-clear-provider-routes`).

Made with [Cursor](https://cursor.com)