### PR TITLE
fix(providers): catalog OpenRouter Gemini Embedding 2 ids

### DIFF
--- a/changelog.d/fixes/catalog-openrouter-gemini-embedding-2.md
+++ b/changelog.d/fixes/catalog-openrouter-gemini-embedding-2.md
@@ -1,0 +1,1 @@
+- **fix(providers):** register live OpenRouter Gemini Embedding 2 ids (`google/gemini-embedding-2` and `google/gemini-embedding-2-preview`, 3072-d) in the curated embeddings catalog so `GET /v1/models` and `GET /v1/embeddings` list the ids that already serve — thanks @RaviTharuma

--- a/open-sse/config/embeddingRegistry.ts
+++ b/open-sse/config/embeddingRegistry.ts
@@ -241,6 +241,16 @@ export const EMBEDDING_PROVIDERS: Record<string, EmbeddingProvider> = {
         name: "Gemini Embedding 001 (OpenRouter)",
         dimensions: 768,
       },
+      {
+        id: "google/gemini-embedding-2",
+        name: "Gemini Embedding 2 (OpenRouter)",
+        dimensions: 3072,
+      },
+      {
+        id: "google/gemini-embedding-2-preview",
+        name: "Gemini Embedding 2 Preview (OpenRouter)",
+        dimensions: 3072,
+      },
     ],
   },
 

--- a/tests/unit/openrouter-embeddings-catalog-6976.test.ts
+++ b/tests/unit/openrouter-embeddings-catalog-6976.test.ts
@@ -68,11 +68,21 @@ test("embeddingRegistry curated openrouter catalog carries the refreshed lineup 
     "baai/bge-m3",
     "mistralai/mistral-embed-2312",
     "google/gemini-embedding-001",
+    "google/gemini-embedding-2",
+    "google/gemini-embedding-2-preview",
   ]) {
     assert.ok(ids.includes(expected), `expected curated id ${expected}; got ${ids.join(", ")}`);
     const dim = config!.models.find((m) => m.id === expected)?.dimensions;
     assert.equal(typeof dim, "number", `${expected} must carry a dimensions value`);
   }
+  assert.equal(
+    config!.models.find((m) => m.id === "google/gemini-embedding-2")?.dimensions,
+    3072
+  );
+  assert.equal(
+    config!.models.find((m) => m.id === "google/gemini-embedding-2-preview")?.dimensions,
+    3072
+  );
 });
 
 test("getStaticModelsForProvider(openrouter) folds the curated embeddings into the specialty catalog (#6976)", () => {


### PR DESCRIPTION
## Summary

`POST /v1/embeddings` already serves `openrouter/google/gemini-embedding-2` (passthrough), but the curated OpenRouter embedding catalog only listed `google/gemini-embedding-001`. `GET /v1/models` and `GET /v1/embeddings` therefore hide the id that actually works.

This PR only registers the live OpenRouter ids (and the preview alias) with the measured default dimension **3072**.

## Live evidence (re-verified 2026-08-17, OmniRoute 3.8.49)

Endpoint: `https://<omniroute-host>/v1`  
Clients: **Hindsight 0.9.1** and **Memorix 1.6.0** discover models via catalog / configured id. If they only offer listed embedding ids, Gemini Embedding 2 is invisible even though it serves.

### Catalog (actual)

`GET /v1/embeddings` → HTTP **200**, 29 models. Hits included:

- `openrouter/google/gemini-embedding-001` (listed)
- **not** `openrouter/google/gemini-embedding-2`
- **not** `openrouter/google/gemini-embedding-2-preview`
- **not** native `gemini-embedding-2` (no `gemini` credentials on this host)

`GET /v1/models` → HTTP **200**, 2811 models. Same Gemini Embedding 2 gap.

### Serve path (actual, unlisted id)

Request:

```json
{ "model": "openrouter/google/gemini-embedding-2", "input": ["alpha", "beta"] }
```

HTTP **200**, `n=2`, dims `[3072, 3072]`, `usage.prompt_tokens=2`.

Preview alias:

```json
{ "model": "openrouter/google/gemini-embedding-2-preview", "input": ["alpha", "beta"] }
```

HTTP **200**, `n=2`, dims `[3072, 3072]`.

### Expected after this PR

`GET /v1/models` and `GET /v1/embeddings` list:

- `openrouter/google/gemini-embedding-2` (3072)
- `openrouter/google/gemini-embedding-2-preview` (3072)

when OpenRouter is an active provider. Serve behavior is unchanged.

### Repro (redact the bearer)

```bash
curl -sS https://omniroute.example/v1/embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" | jq '.data[].id | select(test("gemini-embedding"))'

curl -sS https://omniroute.example/v1/embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"openrouter/google/gemini-embedding-2","input":["alpha","beta"]}'
```

## Related Issues

- Related to #6976 (OpenRouter embeddings catalog)
- Sibling: better 400 for native `gemini-embedding-2` when no Gemini key exists

## Validation

- [x] `node --import tsx/esm --test tests/unit/openrouter-embeddings-catalog-6976.test.ts tests/unit/openrouter-registry.test.ts` (11 pass)

## Tests Added Or Updated

- `tests/unit/openrouter-embeddings-catalog-6976.test.ts` — asserts the two new ids and 3072-d

## Coverage Notes

- Catalog data in `open-sse/config/embeddingRegistry.ts`; covered by the existing #6976 registry + discovery tests.

## Reviewer Notes

- Did **not** change native `gemini` registry dimensions (still 768 in-tree). That is a separate concern; this host cannot exercise native Gemini embed without a secret.
- Did **not** change `google/gemini-embedding-001`'s curated 768. Live OpenRouter 001 also returned 3072 on this host; leaving 001 alone keeps this PR one concern.

Made with [Cursor](https://cursor.com)