### PR TITLE
fix(api): accept Jina native {image: data:url} embedding input

### DIFF
--- a/changelog.d/fixes/embed-jina-native-image-input.md
+++ b/changelog.d/fixes/embed-jina-native-image-input.md
@@ -1,0 +1,1 @@
+- **fix(api):** accept Jina/Memorix native multimodal embedding items (`{image: "data:..."}`, `{text}`, `{pdf}`) on `POST /v1/embeddings` and normalize them to the canonical `{type,source}` contract — thanks @RaviTharuma

--- a/src/shared/validation/jinaNativeEmbeddingInput.ts
+++ b/src/shared/validation/jinaNativeEmbeddingInput.ts
@@ -1,0 +1,83 @@
+/**
+ * Normalize Jina / Memorix native multimodal embedding items into OmniRoute's
+ * canonical `{ type, source }` contract before Zod validation.
+ *
+ * Jina's `/v1/embeddings` and Memorix 1.6.0 send `{ image: "data:image/..." }`
+ * (and `{ text }`, `{ audio }`, `{ video }`, `{ pdf }`). OmniRoute previously
+ * accepted only `{ type: "image", source: { type: "base64"|"url", ... } }`, so
+ * those clients received a generic HTTP 400 `Invalid request`.
+ */
+
+const JINA_MEDIA_KEYS = ["text", "image", "audio", "video", "pdf"] as const;
+type JinaMediaKey = (typeof JINA_MEDIA_KEYS)[number];
+
+const DEFAULT_MEDIA_TYPE: Record<Exclude<JinaMediaKey, "text">, string> = {
+  image: "image/png",
+  audio: "audio/mpeg",
+  video: "video/mp4",
+  pdf: "application/pdf",
+};
+
+const DATA_URI_RE = /^data:([^;,]+);base64,(.+)$/i;
+
+export function isJinaNativeEmbeddingItem(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if ("type" in record && "source" in record) return false;
+  const present = JINA_MEDIA_KEYS.filter((key) => key in record);
+  if (present.length !== 1) return false;
+  return typeof record[present[0]] === "string" && String(record[present[0]]).trim().length > 0;
+}
+
+function mediaStringToSource(media: string, fallbackMediaType: string) {
+  const trimmed = media.trim();
+  const dataUri = DATA_URI_RE.exec(trimmed);
+  if (dataUri) {
+    return {
+      type: "base64" as const,
+      data: dataUri[2],
+      media_type: dataUri[1],
+    };
+  }
+  if (/^https:\/\//i.test(trimmed)) {
+    return { type: "url" as const, url: trimmed };
+  }
+  return {
+    type: "base64" as const,
+    data: trimmed,
+    media_type: fallbackMediaType,
+  };
+}
+
+export function jinaNativeItemToCanonical(value: Record<string, unknown>) {
+  if (typeof value.text === "string") {
+    return { type: "text" as const, text: value.text };
+  }
+  for (const key of ["image", "audio", "video", "pdf"] as const) {
+    if (typeof value[key] !== "string") continue;
+    const type = key === "pdf" ? ("document" as const) : key;
+    return {
+      type,
+      source: mediaStringToSource(value[key], DEFAULT_MEDIA_TYPE[key]),
+    };
+  }
+  return value;
+}
+
+/**
+ * If the input array contains any Jina-native items, convert those (and bare
+ * strings in the same batch) to canonical multimodal items. Other shapes are
+ * left untouched so existing OpenAI string/token and OmniRoute structured
+ * inputs keep their current Zod path.
+ */
+export function normalizeJinaNativeEmbeddingInput(input: unknown): unknown {
+  if (!Array.isArray(input)) return input;
+  if (!input.some(isJinaNativeEmbeddingItem)) return input;
+  return input.map((item) => {
+    if (typeof item === "string") return { type: "text", text: item };
+    if (isJinaNativeEmbeddingItem(item)) {
+      return jinaNativeItemToCanonical(item as Record<string, unknown>);
+    }
+    return item;
+  });
+}

--- a/src/shared/validation/schemas/apiV1.ts
+++ b/src/shared/validation/schemas/apiV1.ts
@@ -20,6 +20,7 @@ import {
 } from "@/shared/reasoning/effortStandardization";
 
 import { modelIdSchema, nonEmptyStringSchema } from "./misc.ts";
+import { normalizeJinaNativeEmbeddingInput } from "../jinaNativeEmbeddingInput.ts";
 
 export const embeddingTokenArraySchema = z
   .array(z.number().int().min(0))
@@ -127,13 +128,16 @@ const embeddingMultimodalInputSchema = z
     }
   });
 
-export const embeddingInputSchema = z.union([
-  nonEmptyStringSchema,
-  z.array(nonEmptyStringSchema).min(1, "input must contain at least one item"),
-  embeddingTokenArraySchema,
-  z.array(embeddingTokenArraySchema).min(1, "input must contain at least one item"),
-  embeddingMultimodalInputSchema,
-]);
+export const embeddingInputSchema = z.preprocess(
+  normalizeJinaNativeEmbeddingInput,
+  z.union([
+    nonEmptyStringSchema,
+    z.array(nonEmptyStringSchema).min(1, "input must contain at least one item"),
+    embeddingTokenArraySchema,
+    z.array(embeddingTokenArraySchema).min(1, "input must contain at least one item"),
+    embeddingMultimodalInputSchema,
+  ])
+);
 
 export type EmbeddingMultimodalItem = z.infer<typeof embeddingMultimodalItemSchema>;
 

--- a/tests/unit/embeddings-jina-native-input.test.ts
+++ b/tests/unit/embeddings-jina-native-input.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { v1EmbeddingsSchema } from "../../src/shared/validation/schemas/apiV1.ts";
+import {
+  isJinaNativeEmbeddingItem,
+  jinaNativeItemToCanonical,
+  normalizeJinaNativeEmbeddingInput,
+} from "../../src/shared/validation/jinaNativeEmbeddingInput.ts";
+
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const DATA_URL = `data:image/png;base64,${PNG_B64}`;
+
+test("detects Jina/Memorix native items and ignores OmniRoute canonical items", () => {
+  assert.equal(isJinaNativeEmbeddingItem({ image: DATA_URL }), true);
+  assert.equal(isJinaNativeEmbeddingItem({ text: "caption" }), true);
+  assert.equal(isJinaNativeEmbeddingItem({ pdf: "data:application/pdf;base64,cA==" }), true);
+  assert.equal(
+    isJinaNativeEmbeddingItem({
+      type: "image",
+      source: { type: "base64", data: PNG_B64, media_type: "image/png" },
+    }),
+    false
+  );
+  assert.equal(isJinaNativeEmbeddingItem({ image: DATA_URL, text: "nope" }), false);
+});
+
+test("translates Jina native image/text/pdf items to canonical source objects", () => {
+  assert.deepEqual(jinaNativeItemToCanonical({ text: "caption" }), {
+    type: "text",
+    text: "caption",
+  });
+  assert.deepEqual(jinaNativeItemToCanonical({ image: DATA_URL }), {
+    type: "image",
+    source: { type: "base64", data: PNG_B64, media_type: "image/png" },
+  });
+  assert.deepEqual(jinaNativeItemToCanonical({ image: "https://example.com/bike.png" }), {
+    type: "image",
+    source: { type: "url", url: "https://example.com/bike.png" },
+  });
+  assert.deepEqual(jinaNativeItemToCanonical({ pdf: "data:application/pdf;base64,cA==" }), {
+    type: "document",
+    source: { type: "base64", data: "cA==", media_type: "application/pdf" },
+  });
+});
+
+test("v1 embeddings schema accepts Memorix {image: data:url} and mixed text+image", () => {
+  const imageOnly = v1EmbeddingsSchema.safeParse({
+    model: "jina-ai/jina-embeddings-v5-omni-small",
+    input: [{ image: DATA_URL }],
+  });
+  assert.equal(imageOnly.success, true);
+  if (imageOnly.success) {
+    assert.deepEqual(imageOnly.data.input, [
+      {
+        type: "image",
+        source: { type: "base64", data: PNG_B64, media_type: "image/png" },
+      },
+    ]);
+  }
+
+  const mixed = v1EmbeddingsSchema.safeParse({
+    model: "jina-ai/jina-embeddings-v5-omni-small",
+    input: ["a red bicycle", { image: DATA_URL }],
+  });
+  assert.equal(mixed.success, true);
+  if (mixed.success) {
+    assert.deepEqual(mixed.data.input, [
+      { type: "text", text: "a red bicycle" },
+      {
+        type: "image",
+        source: { type: "base64", data: PNG_B64, media_type: "image/png" },
+      },
+    ]);
+  }
+});
+
+test("legacy string/token and OmniRoute {type,source} inputs are unchanged", () => {
+  assert.equal(
+    v1EmbeddingsSchema.safeParse({
+      model: "jina-ai/jina-embeddings-v5-omni-small",
+      input: ["alpha", "beta"],
+    }).success,
+    true
+  );
+  const canonical = {
+    type: "image" as const,
+    source: { type: "base64" as const, data: PNG_B64, media_type: "image/png" },
+  };
+  const parsed = v1EmbeddingsSchema.safeParse({
+    model: "jina-ai/jina-embeddings-v5-omni-small",
+    input: [canonical],
+  });
+  assert.equal(parsed.success, true);
+  if (parsed.success) assert.deepEqual(parsed.data.input, [canonical]);
+  assert.deepEqual(normalizeJinaNativeEmbeddingInput(["alpha", "beta"]), ["alpha", "beta"]);
+});
+
+test("still rejects unsafe remote image URLs after Jina-native normalize", () => {
+  const parsed = v1EmbeddingsSchema.safeParse({
+    model: "jina-ai/jina-embeddings-v5-omni-small",
+    input: [{ image: "http://127.0.0.1/image.png" }],
+  });
+  assert.equal(parsed.success, false);
+});


### PR DESCRIPTION
## Summary

`POST /v1/embeddings` already accepts OmniRoute canonical multimodal items (`{type:"image", source:{type:"base64",...}}`) and forwards them to Jina as `{image: "data:..."}`. Jina-compatible clients (Memorix 1.6.0, Jina SDKs) send that native shape **inbound**. Zod rejects it as `Invalid request` before the handler runs.

This PR normalizes Jina/Memorix items (`{image}`, `{text}`, `{audio}`, `{video}`, `{pdf}`) to the canonical `{type,source}` contract, then reuses the existing URL/base64 bounds from #7978.

## Live evidence (re-verified 2026-08-17, OmniRoute 3.8.49)

Endpoint: `https://<omniroute-host>/v1/embeddings`  
Model: `jina-ai/jina-embeddings-v5-omni-small`  
Clients: **Memorix 1.6.0** (Jina media body). **Hindsight 0.9.1** is text-only and is not blocked by this 400.

### Actual — OmniRoute canonical image (works)

28×28 PNG (784 pixels; Jina rejects 1×1 with “Image too small … Minimum required: 784 pixels”):

```json
{
  "model": "jina-ai/jina-embeddings-v5-omni-small",
  "input": [
    {
      "type": "image",
      "source": {
        "type": "base64",
        "data": "<base64-png>",
        "media_type": "image/png"
      }
    }
  ]
}
```

HTTP **200**, 1 vector, **1024-d**.

### Actual — Memorix / Jina native shape (broken)

```json
{
  "model": "jina-ai/jina-embeddings-v5-omni-small",
  "input": [{ "image": "data:image/png;base64,<base64-png>" }]
}
```

HTTP **400**

```json
{
  "error": {
    "message": "Invalid request",
    "type": "invalid_request_error",
    "code": "bad_request"
  }
}
```

Mixed `{text}` + `{image: data:url}` is the same 400.

### Expected after this PR

The Memorix/Jina body parses as the canonical image item and follows the same Jina translator as #7978. Unsafe `http://` / loopback image URLs still 400.

### Repro (redact the bearer)

```bash
# works today
curl -sS https://omniroute.example/v1/embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"jina-ai/jina-embeddings-v5-omni-small","input":[{"type":"image","source":{"type":"base64","data":"<png-b64>","media_type":"image/png"}}]}'

# 400 today — this PR
curl -sS https://omniroute.example/v1/embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"jina-ai/jina-embeddings-v5-omni-small","input":[{"image":"data:image/png;base64,<png-b64>"}]}'
```

## Memorix client note (out of scope, still true)

Memorix 1.6.0 only treats `baseUrl` matching `/jina\.ai/i` as native media. An OmniRoute URL stays text-only on the client. That gate is Memorix. OmniRoute still has to accept the Jina body so any Jina-compatible client (or a future Memorix gate change) works.

## Related Issues

- Related to #7956 / #7978 (canonical multimodal items)
- Sibling: `/v1/multimodal-embeddings` alias (path 404, separate PR)

## Validation

- [x] `node --import tsx/esm --test tests/unit/embeddings-jina-native-input.test.ts tests/unit/embeddings-multimodal-7956.test.ts` (12 pass)

## Tests Added Or Updated

- `tests/unit/embeddings-jina-native-input.test.ts`
- existing `tests/unit/embeddings-multimodal-7956.test.ts` still green

## Coverage Notes

- New `src/shared/validation/jinaNativeEmbeddingInput.ts` is covered by the new unit file.
- `v1EmbeddingsSchema` preprocess is covered by both the new file and #7956 schema tests.

## Reviewer Notes

- Canonical `{type,source}` items are detected and left untouched.
- Remote URLs still go through `parseAndValidatePublicUrl` (HTTPS, no loopback/metadata).

Made with [Cursor](https://cursor.com)