### PR TITLE
feat(api): alias /v1/multimodal-embeddings to /v1/embeddings

### DIFF
--- a/changelog.d/features/multimodal-embeddings-alias.md
+++ b/changelog.d/features/multimodal-embeddings-alias.md
@@ -1,0 +1,1 @@
+- **feat(api):** add `GET`/`POST` `/v1/multimodal-embeddings` as an alias of `/v1/embeddings` so Jina-compatible clients do not receive HTTP 404 `unknown_route` — thanks @RaviTharuma

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1371,6 +1371,38 @@ paths:
             cost is computed per modality when pricing is available, otherwise
             `0` (fail-open).
 
+  /api/v1/multimodal-embeddings:
+    post:
+      tags: [Embeddings]
+      summary: Create embeddings (Jina multimodal-embeddings alias)
+      description: >-
+        Same handler as `POST /api/v1/embeddings`. Provided so Jina-compatible
+        clients that call `/v1/multimodal-embeddings` do not receive HTTP 404
+        `unknown_route`.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [input, model]
+              additionalProperties: true
+      responses:
+        "200":
+          description: Embedding vectors (same contract as POST /api/v1/embeddings).
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    get:
+      tags: [Embeddings]
+      summary: List embedding models (Jina multimodal-embeddings alias)
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Embedding model catalog (same as GET /api/v1/embeddings).
+
   /api/v1/providers/{provider}/embeddings:
     post:
       tags: [Embeddings]

--- a/src/app/api/v1/multimodal-embeddings/route.ts
+++ b/src/app/api/v1/multimodal-embeddings/route.ts
@@ -1,0 +1,5 @@
+/**
+ * Alias of `/v1/embeddings` for clients that call Jina's
+ * `/v1/multimodal-embeddings` path. Same handler, same catalog GET.
+ */
+export { GET, POST, OPTIONS } from "../embeddings/route";

--- a/src/shared/constants/endpointCategories.ts
+++ b/src/shared/constants/endpointCategories.ts
@@ -34,7 +34,7 @@ export const ENDPOINT_CATEGORIES: readonly EndpointCategory[] = [
     id: "embeddings",
     label: "Embeddings",
     description: "Text embeddings generation",
-    prefixes: ["/v1/embeddings"],
+    prefixes: ["/v1/embeddings", "/v1/multimodal-embeddings"],
   },
   {
     id: "images",

--- a/tests/unit/endpoint-categories.test.ts
+++ b/tests/unit/endpoint-categories.test.ts
@@ -44,6 +44,10 @@ test("resolveEndpointCategory: maps /v1/embeddings to 'embeddings'", () => {
   assert.equal(resolveEndpointCategory("/v1/embeddings"), "embeddings");
 });
 
+test("resolveEndpointCategory: maps /v1/multimodal-embeddings to 'embeddings'", () => {
+  assert.equal(resolveEndpointCategory("/v1/multimodal-embeddings"), "embeddings");
+});
+
 test("resolveEndpointCategory: maps /v1/images/generations to 'images'", () => {
   assert.equal(resolveEndpointCategory("/v1/images/generations"), "images");
 });

--- a/tests/unit/multimodal-embeddings-alias.test.ts
+++ b/tests/unit/multimodal-embeddings-alias.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-mm-embed-alias-"));
+
+const embeddings = await import("../../src/app/api/v1/embeddings/route.ts");
+const multimodal = await import("../../src/app/api/v1/multimodal-embeddings/route.ts");
+
+test("POST/GET/OPTIONS /v1/multimodal-embeddings are the embeddings handlers", () => {
+  assert.equal(multimodal.POST, embeddings.POST);
+  assert.equal(multimodal.GET, embeddings.GET);
+  assert.equal(multimodal.OPTIONS, embeddings.OPTIONS);
+});


### PR DESCRIPTION
## Summary

Jina documents `/v1/multimodal-embeddings`. OmniRoute only implements `/v1/embeddings`. Clients that POST the Jina path hit the #6405 catch-all and get JSON 404 `unknown_route`.

This PR adds `GET`/`POST`/`OPTIONS` `/v1/multimodal-embeddings` as the **same handlers** as `/v1/embeddings` (not a 308). API-key endpoint category `embeddings` includes the new prefix so a embeddings-only key is not blocked.

## Live evidence (re-verified 2026-08-17, OmniRoute 3.8.49)

Endpoint: `https://<omniroute-host>/v1/multimodal-embeddings`  
Clients: **Memorix 1.6.0** / any Jina SDK that uses the multimodal path. **Hindsight 0.9.1** uses `/v1/embeddings` and is not blocked by this 404.

### Actual

Request (same body that works on `/v1/embeddings`):

```json
{ "model": "jina-ai/jina-embeddings-v5-omni-small", "input": ["alpha"] }
```

HTTP **404**

```json
{
  "error": {
    "message": "Unknown API route: /v1/multimodal-embeddings",
    "type": "not_found",
    "code": "unknown_route",
    "path": "/v1/multimodal-embeddings"
  }
}
```

Same body on `POST /v1/embeddings` → HTTP **200**, 1024-d.

### Expected after this PR

`POST /v1/multimodal-embeddings` is the embeddings handler (200 for the text case above). `GET` lists embedding models. No redirect, so POST clients that do not follow 308 still work.

### Repro (redact the bearer)

```bash
curl -sS -D- https://omniroute.example/v1/multimodal-embeddings \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"jina-ai/jina-embeddings-v5-omni-small","input":["alpha"]}'
```

## Related Issues

- Related to #6405 (JSON 404 catch-all)
- Related to #7956 / #7978
- Sibling: accept Jina `{image: data:url}` on the embeddings body (this PR is path-only)

## Validation

- [x] `node --import tsx/esm --test tests/unit/multimodal-embeddings-alias.test.ts tests/unit/endpoint-categories.test.ts` (27 pass)

## Tests Added Or Updated

- `tests/unit/multimodal-embeddings-alias.test.ts` — same function references as `/v1/embeddings`
- `tests/unit/endpoint-categories.test.ts` — category map

## Coverage Notes

- New route is a re-export (`src/app/api/v1/multimodal-embeddings/route.ts`).
- `docs/openapi.yaml` documents the alias so OpenAPI coverage does not drop below the 35.9% floor.

## Reviewer Notes

- Did not regenerate `openapi.generated.ts` (full regen also pulled unrelated stale explorer entries). `prebuild:docs` will pick the new path up.

Made with [Cursor](https://cursor.com)