### PR TITLE
fix(mcp): make GitHub skill tools discoverable through omniroute_tool_search

### DIFF
--- a/changelog.d/fixes/10575-mcp-github-tool-search.md
+++ b/changelog.d/fixes/10575-mcp-github-tool-search.md
@@ -1,0 +1,1 @@
+- **fix(mcp):** make GitHub skill tools discoverable through `omniroute_tool_search`

--- a/open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { getAllToolDefinitions } from "../toolSearch/catalog.ts";
 
+const GITHUB_SKILL_TOOL_NAMES = [
+  "omniroute_github_skills_search",
+  "omniroute_github_skills_scan",
+  "omniroute_github_skills_install",
+] as const;
+
 describe("getAllToolDefinitions", () => {
   const all = getAllToolDefinitions();
   it("aggregates many tools across collections", () => {
@@ -17,6 +23,12 @@ describe("getAllToolDefinitions", () => {
   it("no duplicate names", () => {
     const names = all.map((t) => t.name);
     expect(new Set(names).size).toBe(names.length);
+  });
+  it("includes all GitHub skill tools", () => {
+    const names = new Set(all.map((tool) => tool.name));
+    for (const name of GITHUB_SKILL_TOOL_NAMES) {
+      expect(names.has(name)).toBe(true);
+    }
   });
   it("includes every canonical CCR lifecycle tool", () => {
     for (const name of ["store", "retrieve", "inspect", "list", "delete", "stats"]) {

--- a/open-sse/mcp-server/__tests__/toolSearch.tool.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.tool.test.ts
@@ -29,11 +29,28 @@ describe("omniroute_tool_search", () => {
   });
 
   it("returns relevant tool with a signature, not itself", async () => {
-    const res = await client.callTool({ name: "omniroute_tool_search", arguments: { query: "health" } });
+    const res = await client.callTool({
+      name: "omniroute_tool_search",
+      arguments: { query: "health" },
+    });
     const text = (res.content as Array<{ text: string }>)[0].text;
     const parsed = JSON.parse(text);
     expect(parsed.tools.some((t: any) => t.name === "omniroute_get_health")).toBe(true);
     expect(parsed.tools.every((t: any) => t.name !== "omniroute_tool_search")).toBe(true);
     expect(typeof parsed.tools[0].signature).toBe("string");
+  });
+
+  it("discovers all GitHub skill tools", async () => {
+    const res = await client.callTool({
+      name: "omniroute_tool_search",
+      arguments: { query: "GitHub skills", limit: 25 },
+    });
+    const text = (res.content as Array<{ text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    const names = new Set(parsed.tools.map((tool: { name: string }) => tool.name));
+
+    expect(names.has("omniroute_github_skills_search")).toBe(true);
+    expect(names.has("omniroute_github_skills_scan")).toBe(true);
+    expect(names.has("omniroute_github_skills_install")).toBe(true);
   });
 });

--- a/open-sse/mcp-server/toolSearch/catalog.ts
+++ b/open-sse/mcp-server/toolSearch/catalog.ts
@@ -2,8 +2,9 @@
  * getAllToolDefinitions — unified catalog of all MCP tool definitions.
  *
  * Aggregates the same collections referenced by TOTAL_MCP_TOOL_COUNT in server.ts:
- *   MCP_TOOLS + memoryTools + skillTools + agentSkillTools + poolTools +
- *   gamificationTools + pluginTools + notionTools + obsidianTools
+ *   MCP_TOOLS + memoryTools + skillTools + agentSkillTools + githubSkillTools +
+ *   poolTools + gamificationTools + pluginTools + notionTools + obsidianTools +
+ *   localCorpusTools + compressionTools
  *
  * Tolerates both Array and Record shapes. Deduplicates by name (first wins).
  */
@@ -12,6 +13,7 @@ import { MCP_TOOLS } from "../schemas/tools.ts";
 import { memoryTools } from "../tools/memoryTools.ts";
 import { skillTools } from "../tools/skillTools.ts";
 import { agentSkillTools } from "../tools/agentSkillTools.ts";
+import { githubSkillTools } from "../tools/githubSkillTools.ts";
 import { poolTools } from "../tools/poolTools.ts";
 import { gamificationTools } from "../tools/gamificationTools.ts";
 import { pluginTools } from "../tools/pluginTools.ts";
@@ -72,6 +74,7 @@ export function getAllToolDefinitions(): ToolCatalogEntry[] {
     memoryTools,
     skillTools,
     agentSkillTools,
+    githubSkillTools,
     poolTools,
     gamificationTools,
     pluginTools,


### PR DESCRIPTION
# fix(mcp): make GitHub skill tools discoverable through `omniroute_tool_search`

## Summary

The MCP server registers three GitHub skill tools (`omniroute_github_skills_search`, `omniroute_github_skills_scan`, `omniroute_github_skills_install`), and `TOTAL_MCP_TOOL_COUNT` already counts them — but `getAllToolDefinitions()` did not include the `githubSkillTools` collection. As a result, a client that already knew an exact tool name could call it, but a client relying on `omniroute_tool_search` could not discover it.

This PR adds `githubSkillTools` to the search catalog and adds regression coverage at both layers: catalog construction and the client-visible MCP search path.

## Why this matters

This is a focused instance of a recurring MCP contract-drift pattern:

- [#6854](https://github.com/diegosouzapw/OmniRoute/issues/6854) — MCP tool-count / collection drift
- [#7579](https://github.com/diegosouzapw/OmniRoute/issues/7579) — client-visible missing tools
- [#10159](https://github.com/diegosouzapw/OmniRoute/issues/10159) — MCP search-provider schema drift
- [#10209](https://github.com/diegosouzapw/OmniRoute/pull/10209) — existing provider-enum fix, which this PR complements rather than duplicates

This PR fixes only the tool-search catalog omission. The linked issues describe related discovery and contract-parity layers; the REST catalog and observability layers should be handled separately.

## Changes

- Add `githubSkillTools` to `getAllToolDefinitions()` (one import + one collection entry, matching the existing pattern for `memoryTools`, `skillTools`, `agentSkillTools`, etc.).
- Catalog test: assert all three GitHub skill tools are present in `getAllToolDefinitions()`.
- Client test: assert an in-memory MCP client can discover all three through `omniroute_tool_search`.
- Changelog fragment under `changelog.d/fixes/`.

## Scope boundaries

This PR does **not** change:

- MCP server registration or tool handlers;
- provider schemas or provider visibility;
- `/api/mcp/tools` behavior;
- MCP transport or stateless-session behavior;
- startup, OAuth, or admission control;
- observability or MCP status/doctor endpoints.

## Validation

Focused tests and gates, run under Node 24.19.0:

```bash
npm run check:node-runtime
npm run test:vitest -- \
  open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts \
  open-sse/mcp-server/__tests__/toolSearch.tool.test.ts
npm run check:open-sse-typecheck
npm run check:test-discovery
npm run check:changelog-integrity
npm run lint
```

Results:

- Focused MCP tests: **2 files, 8 tests passed** (hermetic temp `DATA_DIR`, no writes to the developer's `~/.omniroute`).
- Open SSE typecheck: passed (only pre-existing frozen baseline errors remain).
- Test discovery / changelog integrity: passed.
- Full repository lint: passed (0 errors, 0 warnings across 8,310 files).
- `git diff --check`: passed.

## Review notes

> Every tool in the searchable static MCP collection must be discoverable through `omniroute_tool_search`; this PR adds the previously omitted GitHub skill collection.

This change is deliberately narrow: it does not claim every MCP projection must have an identical inventory, nor that it resolves the entire historical MCP visibility issue cluster.
