### PR TITLE
fix(audio): fall back nested STT models when the prefix provider has no credentials

### DIFF
--- a/changelog.d/fixes/10583-stt-nested-model-credential-fallback.md
+++ b/changelog.d/fixes/10583-stt-nested-model-credential-fallback.md
@@ -1,0 +1,1 @@
+- **fix(audio):** when a prefix-matched STT provider has no credentials, retry gateways that list the same nested model id (e.g. `deepgram/nova-3` → `openrouter/deepgram/nova-3`) and mention those ids in the 400; stop documenting bare `deepgram/nova-3` as the default example ([#10583](https://github.com/diegosouzapw/OmniRoute/issues/10583))

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -478,7 +478,7 @@ If a provider repeatedly enters OPEN state:
 
 ### "Unsupported model" error
 
-- Ensure you're using the correct prefix: `deepgram/nova-3` or `assemblyai/best`
+- Use a model id whose first segment is a provider you have credentials for (`openai/whisper-1`, `openrouter/deepgram/nova-3`). Bare `deepgram/nova-3` requires a native Deepgram key.
 - Verify the provider is connected in **Dashboard → Providers**
 
 ### Transcription returns empty or fails

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -948,8 +948,11 @@ Content-Type: multipart/form-data
 curl -X POST http://localhost:20128/v1/audio/transcriptions \
   -H "Authorization: Bearer your-api-key" \
   -F "file=@audio.mp3" \
-  -F "model=deepgram/nova-3"
+  -F "model=openai/whisper-1"
 ```
+
+`deepgram/nova-3` is the native Deepgram route and needs a Deepgram API key.
+If only OpenRouter is configured, use `openrouter/deepgram/nova-3`.
 
 **Speech-to-Text (transcription)** providers:
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -808,7 +808,10 @@ Authorization: Bearer your-api-key
 Content-Type: multipart/form-data
 ```
 
-Transcribe audio files using Deepgram or AssemblyAI.
+Transcribe audio files using any configured STT provider. The first path
+segment selects the native provider (`openai/…`, `deepgram/…`). Gateways that
+re-export another vendor's model use a qualified id
+(`openrouter/deepgram/nova-3`).
 
 **Request:**
 
@@ -816,7 +819,7 @@ Transcribe audio files using Deepgram or AssemblyAI.
 curl -X POST http://localhost:20128/v1/audio/transcriptions \
   -H "Authorization: Bearer your-api-key" \
   -F "file=@recording.mp3" \
-  -F "model=deepgram/nova-3"
+  -F "model=openai/whisper-1"
 ```
 
 **Response:**
@@ -830,7 +833,10 @@ curl -X POST http://localhost:20128/v1/audio/transcriptions \
 }
 ```
 
-**Supported providers:** `deepgram/nova-3`, `assemblyai/best`.
+**Example model ids:** `openai/whisper-1` (requires an OpenAI key),
+`openrouter/deepgram/nova-3` (requires an OpenRouter key),
+`deepgram/nova-3` (requires a native Deepgram key). A bare
+`deepgram/nova-3` request does **not** use OpenRouter.
 
 **Supported formats:** `mp3`, `wav`, `m4a`, `flac`, `ogg`, `webm`.
 

--- a/open-sse/config/audioRegistry.ts
+++ b/open-sse/config/audioRegistry.ts
@@ -711,6 +711,85 @@ export function parseTranslationModel(modelStr: string | null, dynamicProviders?
   return parseAudioModel(modelStr, AUDIO_TRANSLATION_PROVIDERS, dynamicProviders);
 }
 
+export interface AudioProviderMatch {
+  provider: string;
+  model: string;
+  config: AudioProvider;
+}
+
+/**
+ * Candidate model ids to try when the prefix-matched provider has no credentials.
+ * Includes the raw request string (a gateway may list `deepgram/nova-3` as its
+ * own model id) plus the parsed native id and `provider/model`.
+ */
+export function audioModelAliasCandidates(
+  originalModel: string,
+  failedProvider: string,
+  resolvedModel: string | null
+): string[] {
+  const candidates = [originalModel];
+  if (resolvedModel) {
+    candidates.push(resolvedModel);
+    candidates.push(`${failedProvider}/${resolvedModel}`);
+  }
+  return [...new Set(candidates.filter(Boolean))];
+}
+
+/**
+ * Find another registry provider that lists one of the candidate model ids.
+ * Used when `deepgram/nova-3` prefix-matches native Deepgram but only a
+ * gateway such as OpenRouter has credentials for that model id.
+ */
+export function findAlternateAudioProvider(
+  registry: Record<string, AudioProvider>,
+  failedProvider: string,
+  candidates: string[]
+): AudioProviderMatch | null {
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    for (const [providerId, config] of Object.entries(registry)) {
+      if (providerId === failedProvider) continue;
+      if (config.models.some((m) => m.id === candidate)) {
+        return { provider: providerId, model: candidate, config };
+      }
+    }
+  }
+  return null;
+}
+
+/** Qualified catalog ids (`gateway/model`) that list the same nested model. */
+export function listAlternateAudioModelIds(
+  registry: Record<string, AudioProvider>,
+  failedProvider: string,
+  candidates: string[]
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    for (const [providerId, config] of Object.entries(registry)) {
+      if (providerId === failedProvider) continue;
+      if (!config.models.some((m) => m.id === candidate)) continue;
+      const id = `${providerId}/${candidate}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+export function missingAudioProviderCredentialsMessage(
+  provider: string,
+  alternateIds: string[] = []
+): string {
+  const base = `No credentials for provider: ${provider}`;
+  if (alternateIds.length === 0) return base;
+  return `${base}. The catalog also lists this model as ${alternateIds.join(", ")}`;
+}
+
 /**
  * Get all audio models as a flat list
  */

--- a/src/app/api/v1/audio/transcriptions/route.ts
+++ b/src/app/api/v1/audio/transcriptions/route.ts
@@ -8,6 +8,11 @@ import {
 import {
   parseTranscriptionModel,
   getTranscriptionProvider,
+  audioModelAliasCandidates,
+  findAlternateAudioProvider,
+  listAlternateAudioModelIds,
+  missingAudioProviderCredentialsMessage,
+  AUDIO_TRANSCRIPTION_PROVIDERS,
 } from "@omniroute/open-sse/config/audioRegistry.ts";
 import { resolveDynamicAudioProviders } from "@/app/api/v1/_shared/audioProviderNodes";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
@@ -66,7 +71,9 @@ async function transcribeWithModel(
     "audio-transcriptions"
   );
 
-  const { provider, model: resolvedModel } = parseTranscriptionModel(modelStr, dynamicProviders);
+  const parsed = parseTranscriptionModel(modelStr, dynamicProviders);
+  let provider = parsed.provider;
+  let resolvedModel = parsed.model;
   if (!provider) {
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,
@@ -75,7 +82,7 @@ async function transcribeWithModel(
   }
 
   // Check provider config — hardcoded first, then dynamic
-  const providerConfig =
+  let providerConfig =
     getTranscriptionProvider(provider) || dynamicProviders.find((dp) => dp.id === provider) || null;
 
   // Get credentials — skip for local providers (authType: "none").
@@ -87,8 +94,37 @@ async function transcribeWithModel(
     // NOTE: the 2nd arg of this helper is `excludeConnectionId`, not "use this
     // connection" — a combo target's connectionId must never be passed here.
     credentials = await getProviderCredentialsWithQuotaPreflight(credentialKey);
+    // Prefix match wins (`deepgram/nova-3` → native Deepgram). If that
+    // provider has no credentials, retry gateways that list the same nested
+    // model id (e.g. OpenRouter's `deepgram/nova-3`).
     if (!credentials) {
-      return errorResponse(HTTP_STATUS.BAD_REQUEST, `No credentials for provider: ${provider}`);
+      const candidates = audioModelAliasCandidates(modelStr, provider, resolvedModel);
+      const alternate = findAlternateAudioProvider(
+        AUDIO_TRANSCRIPTION_PROVIDERS,
+        provider,
+        candidates
+      );
+      if (alternate) {
+        const alternateCredentials = await getProviderCredentialsWithQuotaPreflight(
+          alternate.provider
+        );
+        if (alternateCredentials && !isAllRateLimitedCredentials(alternateCredentials)) {
+          provider = alternate.provider;
+          resolvedModel = alternate.model;
+          providerConfig = alternate.config;
+          credentials = alternateCredentials;
+        }
+      }
+    }
+    if (!credentials) {
+      const candidates = audioModelAliasCandidates(modelStr, provider, resolvedModel);
+      return errorResponse(
+        HTTP_STATUS.BAD_REQUEST,
+        missingAudioProviderCredentialsMessage(
+          provider,
+          listAlternateAudioModelIds(AUDIO_TRANSCRIPTION_PROVIDERS, provider, candidates)
+        )
+      );
     }
     if (isAllRateLimitedCredentials(credentials)) {
       return rateLimitedProviderResponse(provider, credentials);

--- a/tests/unit/audio-nested-model-credential-fallback.test.ts
+++ b/tests/unit/audio-nested-model-credential-fallback.test.ts
@@ -37,8 +37,17 @@ test("findAlternateAudioProvider maps native Deepgram nova-3 to OpenRouter", () 
 });
 
 test("findAlternateAudioProvider maps bare whisper-1 to OpenRouter when OpenAI has no creds", () => {
+  // Scoped to a 2-provider registry (rather than the live, growing
+  // AUDIO_TRANSCRIPTION_PROVIDERS) so this stays a deterministic test of the
+  // *qualified*-alias fallback branch (`${failedProvider}/${resolvedModel}`)
+  // regardless of future providers that also list a bare "whisper-1" id
+  // (e.g. nanogpt) and would otherwise intercept on the first candidate.
+  const scopedRegistry = {
+    openai: AUDIO_TRANSCRIPTION_PROVIDERS.openai,
+    openrouter: AUDIO_TRANSCRIPTION_PROVIDERS.openrouter,
+  };
   const candidates = audioModelAliasCandidates("whisper-1", "openai", "whisper-1");
-  const alternate = findAlternateAudioProvider(AUDIO_TRANSCRIPTION_PROVIDERS, "openai", candidates);
+  const alternate = findAlternateAudioProvider(scopedRegistry, "openai", candidates);
   assert.ok(alternate);
   assert.equal(alternate?.provider, "openrouter");
   assert.equal(alternate?.model, "openai/whisper-1");

--- a/tests/unit/audio-nested-model-credential-fallback.test.ts
+++ b/tests/unit/audio-nested-model-credential-fallback.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  parseTranscriptionModel,
+  AUDIO_TRANSCRIPTION_PROVIDERS,
+  audioModelAliasCandidates,
+  findAlternateAudioProvider,
+  listAlternateAudioModelIds,
+  missingAudioProviderCredentialsMessage,
+} = await import("../../open-sse/config/audioRegistry.ts");
+
+test("parseTranscriptionModel prefix-matches native Deepgram for deepgram/nova-3", () => {
+  assert.deepEqual(parseTranscriptionModel("deepgram/nova-3"), {
+    provider: "deepgram",
+    model: "nova-3",
+  });
+});
+
+test("parseTranscriptionModel keeps OpenRouter when the id is qualified", () => {
+  assert.deepEqual(parseTranscriptionModel("openrouter/deepgram/nova-3"), {
+    provider: "openrouter",
+    model: "deepgram/nova-3",
+  });
+});
+
+test("findAlternateAudioProvider maps native Deepgram nova-3 to OpenRouter", () => {
+  const candidates = audioModelAliasCandidates("deepgram/nova-3", "deepgram", "nova-3");
+  const alternate = findAlternateAudioProvider(
+    AUDIO_TRANSCRIPTION_PROVIDERS,
+    "deepgram",
+    candidates
+  );
+  assert.ok(alternate);
+  assert.equal(alternate?.provider, "openrouter");
+  assert.equal(alternate?.model, "deepgram/nova-3");
+});
+
+test("findAlternateAudioProvider maps bare whisper-1 to OpenRouter when OpenAI has no creds", () => {
+  const candidates = audioModelAliasCandidates("whisper-1", "openai", "whisper-1");
+  const alternate = findAlternateAudioProvider(AUDIO_TRANSCRIPTION_PROVIDERS, "openai", candidates);
+  assert.ok(alternate);
+  assert.equal(alternate?.provider, "openrouter");
+  assert.equal(alternate?.model, "openai/whisper-1");
+});
+
+test("findAlternateAudioProvider returns null when no other provider lists the model", () => {
+  const alternate = findAlternateAudioProvider(AUDIO_TRANSCRIPTION_PROVIDERS, "assemblyai", [
+    "universal-3-pro",
+    "assemblyai/universal-3-pro",
+  ]);
+  assert.equal(alternate, null);
+});
+
+test("missing-credential error lists qualified catalog aliases", () => {
+  const candidates = audioModelAliasCandidates("deepgram/nova-3", "deepgram", "nova-3");
+  const ids = listAlternateAudioModelIds(AUDIO_TRANSCRIPTION_PROVIDERS, "deepgram", candidates);
+  assert.ok(ids.includes("openrouter/deepgram/nova-3"));
+  assert.match(
+    missingAudioProviderCredentialsMessage("deepgram", ids),
+    /No credentials for provider: deepgram.*openrouter\/deepgram\/nova-3/
+  );
+});


### PR DESCRIPTION
## Summary

- `POST /v1/audio/transcriptions` prefix-matches `deepgram/nova-3` to native Deepgram. With no Deepgram key that is HTTP 400 `No credentials for provider: deepgram`, even when OpenRouter lists the same nested id.
- If the prefix-matched provider has no credentials, retry other registry providers that list the original model id (OpenRouter → `deepgram/nova-3`). Native Deepgram still wins when it is configured.
- The 400 now mentions qualified catalog ids. Docs no longer present bare `deepgram/nova-3` as the default example.

## Related Issues

- Closes #10583
- Related to #7860

## Validation

- [x] Focused tests: `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/audio-nested-model-credential-fallback.test.ts` (6 pass)
- [ ] `npm run lint` (CI)
- [x] Production-code changes include a new automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `tests/unit/audio-nested-model-credential-fallback.test.ts`

## Coverage Notes

- New helpers in `open-sse/config/audioRegistry.ts` and the transcription route fallback are covered by the new unit file (parse, alias candidates, OpenRouter fallback, hint message).

## Reviewer Notes

- Fallback only runs after the prefix-matched provider returns no credentials. It does not change routing when native Deepgram (or any other prefix provider) is configured.
- English docs only; i18n copies still show the old example until the next translation sync.