### PR TITLE
fix(cli): let setup --api-key reach the provider setup path

### DIFF
--- a/bin/cli/commands/setup.mjs
+++ b/bin/cli/commands/setup.mjs
@@ -133,6 +133,29 @@ async function setupProvider(db, opts, prompt, nonInteractive) {
   return connection;
 }
 
+/**
+ * Merge the `setup` subcommand options with the program-level ones.
+ *
+ * The program declares a global `--api-key` (the OmniRoute *server* key, see
+ * bin/cli/program.mjs) and `setup` declares its own `--api-key` (the *provider*
+ * key). Commander binds the value to the program-level option, so the
+ * subcommand's `opts.apiKey` is always `undefined` and `--add-provider` failed
+ * with "Provider API key is required" even when `--api-key` was passed. Falling
+ * back to the global value also makes `OMNIROUTE_API_KEY` work, which the error
+ * message already told users to use.
+ *
+ * @param {Record<string, unknown>} opts Subcommand options.
+ * @param {Record<string, unknown>} globalOpts Result of `cmd.optsWithGlobals()`.
+ * @returns {Record<string, unknown>} Options to hand to `runSetupCommand`.
+ */
+export function mergeSetupOptions(opts, globalOpts) {
+  return {
+    ...opts,
+    apiKey: opts.apiKey ?? globalOpts.apiKey,
+    output: globalOpts.output,
+  };
+}
+
 export function registerSetup(program) {
   program
     .command("setup")
@@ -149,7 +172,7 @@ export function registerSetup(program) {
     .option("--list", "List all supported CLI tools")
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
-      const exitCode = await runSetupCommand({ ...opts, output: globalOpts.output });
+      const exitCode = await runSetupCommand(mergeSetupOptions(opts, globalOpts));
       if (exitCode !== 0) process.exit(exitCode);
     });
 

--- a/changelog.d/fixes/10612-setup-provider-api-key-collision.md
+++ b/changelog.d/fixes/10612-setup-provider-api-key-collision.md
@@ -1,1 +1,0 @@
-- **fix(cli):** `omniroute setup --add-provider --api-key <key>` no longer aborts with "Provider API key is required" — Commander bound the value to the program-level `--api-key` (the OmniRoute server key), leaving the subcommand's own option undefined; `OMNIROUTE_API_KEY` now works as the error message advertised ([#10612](https://github.com/diegosouzapw/OmniRoute/pull/10612))

--- a/changelog.d/fixes/10612-setup-provider-api-key-collision.md
+++ b/changelog.d/fixes/10612-setup-provider-api-key-collision.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `omniroute setup --add-provider --api-key <key>` no longer aborts with "Provider API key is required" — Commander bound the value to the program-level `--api-key` (the OmniRoute server key), leaving the subcommand's own option undefined; `OMNIROUTE_API_KEY` now works as the error message advertised ([#10612](https://github.com/diegosouzapw/OmniRoute/pull/10612))

--- a/changelog.d/fixes/10613-setup-provider-api-key-collision.md
+++ b/changelog.d/fixes/10613-setup-provider-api-key-collision.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `omniroute setup --add-provider --api-key <key>` no longer aborts with "Provider API key is required" — Commander bound the value to the program-level `--api-key` (the OmniRoute server key), leaving the subcommand's own option undefined; `OMNIROUTE_API_KEY` now works as the error message advertised ([#10613](https://github.com/diegosouzapw/OmniRoute/pull/10613))

--- a/tests/unit/cli/setup-provider-api-key.test.ts
+++ b/tests/unit/cli/setup-provider-api-key.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Command, Option } from "commander";
+
+import { mergeSetupOptions } from "../../../bin/cli/commands/setup.mjs";
+
+/**
+ * Reproduces the flag shape of the real CLI: bin/cli/program.mjs declares a
+ * program-level `--api-key` (OmniRoute server key) and bin/cli/commands/setup.mjs
+ * declares its own `--api-key` (provider key).
+ */
+function parseSetupArgv(argv: string[]) {
+  const program = new Command();
+  program.exitOverride();
+  program.addOption(new Option("--api-key <key>", "server key").env("OMNIROUTE_API_KEY"));
+  program.addOption(new Option("--output <format>", "output").default("table"));
+
+  let captured: Record<string, unknown> | null = null;
+  program
+    .command("setup")
+    .exitOverride()
+    .option("--api-key <value>", "Provider API key")
+    .option("--add-provider", "Add an API-key provider connection")
+    .option("--provider <id>", "Provider id")
+    .option("--non-interactive", "Read all inputs from flags")
+    .action((opts, cmd) => {
+      captured = mergeSetupOptions(opts, cmd.optsWithGlobals());
+    });
+
+  program.parse(["node", "omniroute", ...argv]);
+  return captured as unknown as Record<string, unknown>;
+}
+
+test("setup --api-key reaches runSetupCommand despite the program-level --api-key", () => {
+  const merged = parseSetupArgv([
+    "setup",
+    "--non-interactive",
+    "--add-provider",
+    "--provider",
+    "openrouter",
+    "--api-key",
+    "sk-or-v1-example",
+  ]);
+
+  // Regression: Commander binds the value to the program-level option, so the
+  // subcommand's own opts.apiKey is undefined and setup aborted with
+  // "Provider API key is required" even though --api-key was supplied.
+  assert.equal(merged.apiKey, "sk-or-v1-example");
+  assert.equal(merged.provider, "openrouter");
+  assert.equal(merged.addProvider, true);
+});
+
+test("OMNIROUTE_API_KEY satisfies the provider key the error message advertises", () => {
+  const original = process.env.OMNIROUTE_API_KEY;
+  process.env.OMNIROUTE_API_KEY = "sk-from-env";
+  try {
+    const merged = parseSetupArgv(["setup", "--non-interactive", "--add-provider"]);
+    assert.equal(merged.apiKey, "sk-from-env");
+  } finally {
+    if (original === undefined) delete process.env.OMNIROUTE_API_KEY;
+    else process.env.OMNIROUTE_API_KEY = original;
+  }
+});
+
+test("an explicit subcommand value wins over the program-level one", () => {
+  const merged = mergeSetupOptions(
+    { apiKey: "subcommand-value" },
+    { apiKey: "global-value", output: "json" }
+  );
+  assert.equal(merged.apiKey, "subcommand-value");
+  assert.equal(merged.output, "json");
+});
+
+test("output still comes from the program-level options", () => {
+  const merged = mergeSetupOptions({}, { output: "json" });
+  assert.equal(merged.output, "json");
+  assert.equal(merged.apiKey, undefined);
+});


### PR DESCRIPTION
## Problem

`bin/cli/program.mjs:26` declares a program-level `--api-key` (the OmniRoute *server* key) and `bin/cli/commands/setup.mjs:144` declares its own `--api-key` (the *provider* key). Commander binds the value to the program-level option, so the subcommand's `opts.apiKey` is always `undefined`.

The documented headless setup path is therefore unusable — it rejects the very flag that was just passed:

```
$ omniroute setup --non-interactive --add-provider \
    --provider openrouter --api-key sk-or-v1-...

OmniRoute Setup
✔ Admin password configured
✖ Provider API key is required. Pass --api-key or OMNIROUTE_API_KEY.
```

`OMNIROUTE_API_KEY` does not help either: it feeds the same program-level option, so it never reaches `resolveProviderInput()` at `setup.mjs:71`.

Minimal reproduction of the flag shape:

```js
const p = new Command();
p.addOption(new Option("--api-key <key>", "global").env("OMNIROUTE_API_KEY"));
p.command("setup").option("--api-key <value>", "Provider API key")
 .action((opts, cmd) => {
   console.log(opts.apiKey);                    // undefined
   console.log(cmd.optsWithGlobals().apiKey);   // "SECRET123"
 });
p.parse(["node", "x", "setup", "--api-key", "SECRET123"]);
```

Until this is fixed the only way to add a provider from a script is `omniroute keys add <provider> <key>`.

## Fix

Fall back to the program-level value in a small exported helper, `mergeSetupOptions()`. An explicit subcommand value still wins. This also makes `OMNIROUTE_API_KEY` satisfy the provider key — which the error message already promised.

## Verification

Against a throwaway `DATA_DIR`, the previously failing command now completes:

```
✔ Admin password configured
✔ Provider configured: OpenRouter
✔ Setup complete
Provider: openrouter (OpenRouter)
```

and the row lands in `provider_connections`.

## Tests

New `tests/unit/cli/setup-provider-api-key.test.ts` (4 tests) covers the real Commander flag shape, the `OMNIROUTE_API_KEY` path, subcommand-wins precedence, and that `output` still comes from the program level. All pass; `npm run lint` clean on the changed files.
