### PR TITLE
fix(oauth): treat Kiro social poll status as alias of error for pending states

### DIFF
--- a/src/lib/oauth/kiroSocialPoll.ts
+++ b/src/lib/oauth/kiroSocialPoll.ts
@@ -1,5 +1,7 @@
 export type KiroSocialPollData = {
   error?: unknown;
+  /** Kiro reports poll progress here (e.g. "authorization_pending"), not in `error`. */
+  status?: unknown;
   accessToken?: unknown;
   refreshToken?: unknown;
 };
@@ -26,8 +28,9 @@ export function classifyKiroSocialPoll(
   responseStatus: number,
   data: KiroSocialPollData
 ): KiroSocialPollOutcome {
-  if (data.error === "authorization_pending" || data.error === "slow_down") {
-    return { kind: "pending", error: data.error };
+  const progress = data.error ?? data.status;
+  if (progress === "authorization_pending" || progress === "slow_down") {
+    return { kind: "pending", error: progress as "authorization_pending" | "slow_down" };
   }
 
   if (!responseOk || data.error) {

--- a/tests/unit/kiro-social-poll.test.ts
+++ b/tests/unit/kiro-social-poll.test.ts
@@ -21,6 +21,26 @@ test("classifyKiroSocialPoll keeps only documented pending states retryable", ()
   });
 });
 
+test("classifyKiroSocialPoll treats status as alias of error for pending states", () => {
+  // Kiro upstream returns progress in `status`, not `error`
+  assert.deepEqual(classifyKiroSocialPoll(true, 200, { status: "authorization_pending" }), {
+    kind: "pending",
+    error: "authorization_pending",
+  });
+  assert.deepEqual(classifyKiroSocialPoll(true, 200, { status: "slow_down" }), {
+    kind: "pending",
+    error: "slow_down",
+  });
+  // error takes precedence over status if both present
+  assert.deepEqual(
+    classifyKiroSocialPoll(true, 200, { error: "slow_down", status: "authorization_pending" }),
+    {
+      kind: "pending",
+      error: "slow_down",
+    }
+  );
+});
+
 test("classifyKiroSocialPoll stops on denied, expired and malformed responses", () => {
   assert.deepEqual(classifyKiroSocialPoll(false, 403, { error: "access_denied" }), {
     kind: "error",


### PR DESCRIPTION
## Summary

Fixes #10618 — Kiro/Amazon Q social login always fails with invalid_token_response (pending state unreachable).

## Problem

Kiro's device poll endpoint reports progress in a `status` field (e.g. `authorization_pending`), but `classifyKiroSocialPoll()` only inspected `data.error`. This caused every pre-authorization poll to fall through to the terminal `invalid_token_response` error, making social login impossible for Kiro AI and Amazon Q via Google/GitHub.

**Upstream response (while user has not yet authorized):**
```json
HTTP/2 200
{"accessToken":null,"identityProvider":null,"profileArn":null,"refreshToken":null,"status":"authorization_pending"}
```

Because `data.error` is `undefined`, the response is `200 OK`, and both tokens are `null`, control reached the terminal error branch.

## Solution

- Add `status` field to `KiroSocialPollData` type
- Update `classifyKiroSocialPoll()` to check `data.status` as fallback for `data.error` when detecting pending states (`authorization_pending` | `slow_down`)
- `error` takes precedence over `status` if both present

## Changes

- `src/lib/oauth/kiroSocialPoll.ts`: Add `status` field and update `classifyKiroSocialPoll()`
- `tests/unit/kiro-social-poll.test.ts`: Add tests for `status`-based pending detection and precedence

## Testing

- All existing unit tests pass (5/5)
- New test added: `classifyKiroSocialPoll treats status as alias of error for pending states`
- TypeScript typecheck passes
- ESLint passes