### PR TITLE
fix(sse): route bare qwen3.8-max to the canonical -preview id

### DIFF
--- a/open-sse/services/modelDeprecation.ts
+++ b/open-sse/services/modelDeprecation.ts
@@ -40,6 +40,13 @@ const BUILT_IN_ALIASES: Record<string, string> = {
   "fireworks/accounts/fireworks/models/kimi-k2": "moonshotai/Kimi-K2",
   "kimi-k2": "moonshotai/Kimi-K2",
 
+  // Qwen — the model ships only under the `-preview` id (bailian-coding-plan, qoder,
+  // qwen-cloud-token-plan, qwen-web). Without this, the bare id missed MODEL_SPECS and
+  // the context preflight fell back to contextManager's `default: 128000`, rejecting
+  // prompts the model's real 1M window accepts. Drop this line if Alibaba ever ships a
+  // distinct GA `qwen3.8-max` — it would no longer be the same model.
+  "qwen3.8-max": "qwen3.8-max-preview",
+
   // Mistral short aliases
   "mistral-large": "mistral-large-latest",
   "mistral-small": "mistral-small-latest",

--- a/tests/unit/qwen38-max-bare-id-alias.test.ts
+++ b/tests/unit/qwen38-max-bare-id-alias.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { MODEL_SPECS } from "../../src/shared/constants/modelSpecs.ts";
+import { resolveModelAlias } from "../../open-sse/services/modelDeprecation.ts";
+import { resolveLifecycle } from "../../open-sse/handlers/chatCore/modelLifecyclePolicy.ts";
+
+/**
+ * Bare `qwen3.8-max` was an unroutable id: the model ships everywhere as
+ * `qwen3.8-max-preview` (bailian-coding-plan, qoder, qwen-cloud-token-plan, qwen-web),
+ * and nothing in the repo declared the short form. A client sending it therefore
+ *
+ *   1. missed MODEL_SPECS, so `getModelContextLimit()` fell through to the
+ *      `default: 128000` in open-sse/services/contextManager.ts, and the chatCore
+ *      preflight rejected any prompt above 128k with `context_length_exceeded`
+ *      ("Input exceeds context window ... limit 128000") even though the real
+ *      window is 1M; and
+ *   2. would have been dispatched verbatim to the upstream, which only knows the
+ *      `-preview` id.
+ *
+ * Both symptoms have one cause — the missing id — so the fix belongs in the
+ * deprecation/rename alias map (`BUILT_IN_ALIASES`), which `resolveLifecycle()`
+ * applies at open-sse/handlers/chatCore.ts:755, well before both the context
+ * preflight and the upstream dispatch. A MODEL_SPECS `aliases` entry would have
+ * fixed only (1): spec aliases resolve capabilities, never the dispatched id.
+ */
+
+const BARE = "qwen3.8-max";
+const CANONICAL = "qwen3.8-max-preview";
+
+test("bare qwen3.8-max resolves to the canonical -preview id", () => {
+  assert.equal(resolveModelAlias(BARE), CANONICAL);
+});
+
+test("the canonical id is a no-op through the alias map (no double rewrite)", () => {
+  assert.equal(resolveModelAlias(CANONICAL), CANONICAL);
+});
+
+test("the alias target carries the real 1M window, not the 128k fallback", () => {
+  const spec = MODEL_SPECS[CANONICAL];
+  assert.ok(spec, `MODEL_SPECS is missing ${CANONICAL}`);
+  assert.equal(spec.contextWindow, 1_000_000);
+  // The bare id must NOT gain its own spec entry — a second source of truth for the
+  // same model is what lets the two ids drift apart again.
+  assert.equal(MODEL_SPECS[BARE], undefined);
+});
+
+test("chatCore lifecycle resolution rewrites the model before dispatch", () => {
+  for (const provider of ["qwen-cloud-token-plan", "qoder", "bailian-coding-plan", "qwen-web"]) {
+    const [resolvedModel, effectiveModel, lifecycleError] = resolveLifecycle(provider, BARE);
+    assert.equal(resolvedModel, CANONICAL, `resolvedModel for ${provider}`);
+    assert.equal(effectiveModel, CANONICAL, `effectiveModel for ${provider}`);
+    assert.equal(lifecycleError, null, `unexpected lifecycle rejection for ${provider}`);
+  }
+});


### PR DESCRIPTION
## Problem

Sending `qwen3.8-max` (without `-preview`) was rejected by the chatCore preflight:

```
API Error: 400 Input exceeds context window for qwen-cloud-token-plan/qwen3.8-max:
estimated 129106 input tokens, limit 128000.
```

The `128000` is not a stale catalog value — it is the `default: 128000` fallback in
`open-sse/services/contextManager.ts:26`, reached because the bare id resolves to
nothing. Every provider that serves this model registers it as `qwen3.8-max-preview`
(bailian-coding-plan, qoder, qwen-cloud-token-plan, qwen-web), declared with a real
**1M** window in `src/shared/constants/modelSpecs.ts`. Nothing declared the short form.

The same missing id also means the request would have been dispatched to the upstream
verbatim, under an id the upstream does not know.

## Fix

One line in `BUILT_IN_ALIASES` (`open-sse/services/modelDeprecation.ts`), the map
`resolveLifecycle()` applies at `open-sse/handlers/chatCore.ts:755` — before the context
preflight *and* before dispatch, so both symptoms clear at once.

A `MODEL_SPECS.aliases` entry would have fixed only the window: spec aliases resolve
capabilities, never the dispatched model id.

The comment on the entry records the removal condition — if Alibaba ships a distinct GA
`qwen3.8-max`, it is no longer the same model and the alias must go.

## Validation (TDD)

`tests/unit/qwen38-max-bare-id-alias.test.ts` — written first, confirmed failing on the
base (`actual: 'qwen3.8-max'`), green after the fix. It covers the alias, the canonical
id staying a no-op (no double rewrite), the 1M target window, the absence of a competing
`MODEL_SPECS` entry for the bare id, and `resolveLifecycle()` across all four providers.

Sibling sweep: 10 alias/deprecation/model-spec test files, **79 tests green**.
`npx eslint` clean on both files; `check-mutation-test-coverage` reports no drift.

⚠️ base-red inherited: #9985 — `typecheck:core` fails on
`open-sse/services/compression/engines/omniglyphAdapter.ts(126,54)`, a file this PR does
not touch (diff is 1 source file + 1 new test).
