### PR TITLE
fix(pricing): DeepSeek V4 static defaults stale by 4 days, off by ~1.6-2.4x

### DIFF
--- a/src/shared/constants/pricing/frontier-labs.ts
+++ b/src/shared/constants/pricing/frontier-labs.ts
@@ -315,20 +315,28 @@ export const DEFAULT_PRICING_FRONTIER = {
       reasoning: 2.19,
       cache_creation: 0.55,
     },
-    // DeepSeek official API list prices, checked 2026-08-13.
+    // DeepSeek official API list prices, checked 2026-08-18. Superseded the
+    // prior 2026-08-13 flat prices below: DeepSeek switched v4-pro/v4-flash to
+    // peak/off-peak dynamic pricing on 2026-08-17 (peak = exactly 2x off-peak;
+    // peak hours 01:00-04:00 and 06:00-10:00 UTC — see
+    // https://api-docs.deepseek.com/quick_start/pricing/). This static table has
+    // no time-of-day dimension, so these are the OFF-PEAK (lower-bound) prices —
+    // a deliberate, documented undercount during the two peak windows, never an
+    // overcount. True peak-awareness would need a time dimension threaded through
+    // getPricingForModel() and every call site; out of scope for this fix.
     "deepseek-v4-pro": {
-      input: 0.435,
-      output: 0.87,
-      cached: 0.003625,
-      reasoning: 0.87,
-      cache_creation: 0.435,
+      input: 0.66,
+      output: 1.98,
+      cached: 0.022,
+      reasoning: 1.98,
+      cache_creation: 0.66,
     },
     "deepseek-v4-flash": {
-      input: 0.14,
-      output: 0.28,
-      cached: 0.0028,
-      reasoning: 0.28,
-      cache_creation: 0.14,
+      input: 0.22,
+      output: 0.66,
+      cached: 0.007,
+      reasoning: 0.66,
+      cache_creation: 0.22,
     },
   },
   blackbox: {

--- a/tests/unit/pricing-deepseek-v4-static-regression.test.ts
+++ b/tests/unit/pricing-deepseek-v4-static-regression.test.ts
@@ -1,0 +1,44 @@
+// Regression guard for the corrected DeepSeek V4 static pricing defaults (#10635): DeepSeek
+// switched deepseek-v4-pro/deepseek-v4-flash to peak/off-peak dynamic pricing on 2026-08-17;
+// the static table carries the off-peak (lower-bound) values. Asserts the exact corrected
+// figures and the documented output=3x-input / peak=2x-off-peak internal consistency so a
+// future accidental revert to the stale 2026-08-13 numbers is caught by CI.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { DEFAULT_PRICING_FRONTIER } = await import(
+  "../../src/shared/constants/pricing/frontier-labs.ts"
+);
+
+test("deepseek-v4-pro carries the corrected off-peak static prices", () => {
+  const entry = (DEFAULT_PRICING_FRONTIER as Record<string, Record<string, Record<string, number>>>)
+    .deepseek["deepseek-v4-pro"];
+  assert.ok(entry, "deepseek-v4-pro entry must exist under DEFAULT_PRICING_FRONTIER.deepseek");
+  assert.equal(entry.input, 0.66);
+  assert.equal(entry.output, 1.98);
+  assert.equal(entry.cached, 0.022);
+  assert.equal(entry.reasoning, 1.98);
+  assert.equal(entry.cache_creation, 0.66);
+});
+
+test("deepseek-v4-flash carries the corrected off-peak static prices", () => {
+  const entry = (DEFAULT_PRICING_FRONTIER as Record<string, Record<string, Record<string, number>>>)
+    .deepseek["deepseek-v4-flash"];
+  assert.ok(entry, "deepseek-v4-flash entry must exist under DEFAULT_PRICING_FRONTIER.deepseek");
+  assert.equal(entry.input, 0.22);
+  assert.equal(entry.output, 0.66);
+  assert.equal(entry.cached, 0.007);
+  assert.equal(entry.reasoning, 0.66);
+  assert.equal(entry.cache_creation, 0.22);
+});
+
+test("deepseek-v4 entries keep DeepSeek's documented output=3x-input ratio", () => {
+  const deepseek = (DEFAULT_PRICING_FRONTIER as Record<string, Record<string, Record<string, number>>>)
+    .deepseek;
+  for (const model of ["deepseek-v4-pro", "deepseek-v4-flash"]) {
+    const entry = deepseek[model];
+    assert.equal(entry.output, entry.input * 3, `${model}: output should be 3x input`);
+    assert.equal(entry.reasoning, entry.output, `${model}: reasoning should match output`);
+    assert.ok(entry.cached < entry.input, `${model}: cached must be cheaper than input`);
+  }
+});


### PR DESCRIPTION
## Description

DeepSeek switched `deepseek-v4-pro`/`deepseek-v4-flash` to peak/off-peak dynamic pricing on 2026-08-17 (off-peak = exactly half of peak; peak hours 01:00-04:00 and 06:00-10:00 UTC — [pricing page](https://api-docs.deepseek.com/quick_start/pricing/)). `DEFAULT_PRICING_FRONTIER.deepseek` in `frontier-labs.ts` is dated `checked 2026-08-13`, four days before the change, and was never updated — the compiled-in numbers are now stale by ~1.6-2.4x depending on token type.

I hit this from the consumer side (a local cost-reconciliation pipeline reading `/api/pricing/defaults`) and confirmed `POST /api/pricing` still returns non-2xx on this build — the table really is compiled-in, matching the existing pattern in `sync_gateway`-style write attempts. Fixing the static default is the only lever available.

## Scope

Uses the **off-peak** values (the documented lower bound) since `getPricingForModel(provider, model)` has no time-of-day dimension anywhere in its resolution chain. Adding real peak-awareness would mean threading a `ts`/hour parameter through the resolver and every call site — a real feature, not a bugfix — so deliberately out of scope here. Off-peak-only is a strict undercount confined to the two peak windows, never wrong-direction, and is still a ~1.6-2.4x correction over what's there now.

## Validation

- Confirmed live consumers of this table: `src/shared/utils/costEstimator.ts`, `src/lib/batches/costEstimator.ts`.
- Re-ran their test suites plus every `pricing-*`/`catalog-pricing-*` unit test (68 tests across 11 files, including `tests/unit/lib/batches/costEstimator.test.ts`) — all pass unchanged; none assert the specific stale values, so nothing needed updating on the test side.
- Live-verified the new numbers against the current DeepSeek pricing page directly (not just the changelog text) before writing them in.
