### PR TITLE
fix(pricing): 3 dead entries in LITELLM_PROVIDER_MAP silently drop synced pricing

### DIFF
--- a/src/lib/pricingSync.ts
+++ b/src/lib/pricingSync.ts
@@ -105,10 +105,22 @@ const LITELLM_PROVIDER_MAP: Record<string, string[]> = {
   vertex_ai: ["gemini"],
   "vertex_ai-anthropic_models": ["anthropic"],
   google: ["gemini"],
-  deepseek: ["if"],
+  // Registry ALIAS, not registry id — pricingSync writes/reads are keyed by
+  // alias everywhere else (see getPricingForModel(provider, model) callers).
+  // Four of these previously used the provider's `id` string, which is not a
+  // valid pricing-lookup key for that provider and, worse, for `deepseek` a
+  // real (but wrong) alias existed under that string — silently routing
+  // DeepSeek's synced pricing onto Qoder (open-sse/config/providers/registry/
+  // qoder/index.ts, alias "if", an unrelated third-party API) instead of
+  // DeepSeek (alias "ds"). `bedrock`/`bedrock_converse` and `cloudflare`
+  // pointed at their provider's `id` ("kiro", "cloudflare-ai") rather than
+  // its `alias` ("kr", "cf") — not wrong-provider, just a dead key nothing
+  // downstream ever looks up, so those two providers silently never received
+  // synced pricing at all.
+  deepseek: ["ds"],
   groq: ["groq"],
   together_ai: ["openrouter"],
-  bedrock: ["kiro"],
+  bedrock: ["kr"],
   fireworks_ai: ["fireworks"],
   cerebras: ["cerebras"],
   nvidia_nim: ["nvidia"],
@@ -116,8 +128,11 @@ const LITELLM_PROVIDER_MAP: Record<string, string[]> = {
   "vertex_ai-language_models": ["gemini"],
   "vertex_ai-mistral_models": ["mistral"],
   gemini: ["gemini"],
-  bedrock_converse: ["kiro"],
-  cloudflare: ["cloudflare-ai"],
+  bedrock_converse: ["kr"],
+  cloudflare: ["cf"],
+  // stability-ai has no chat-completions registry entry (image-only:
+  // open-sse/config/providers/registry/stability-ai/imageModels.ts) — left
+  // as-is rather than guessed at; not the same bug shape as the three above.
   stability: ["stability-ai"],
 };
 

--- a/tests/unit/pricing-sync.test.ts
+++ b/tests/unit/pricing-sync.test.ts
@@ -138,9 +138,14 @@ describe("transformToOmniRoute", () => {
 
     const result = transformToOmniRoute(raw);
 
-    // deepseek maps to "if" alias
-    assert.ok(result.if, "Should map deepseek to if alias");
-    assert.ok(result.if["deepseek-chat"]);
+    // deepseek maps to "ds" (its real registry alias — open-sse/config/providers/
+    // registry/deepseek/index.ts). Previously mapped to "if" (Qoder's alias, an
+    // unrelated provider) — fixed alongside the other dead LITELLM_PROVIDER_MAP
+    // entries (bedrock/bedrock_converse/cloudflare) that pointed at a provider's
+    // `id` instead of its `alias`.
+    assert.ok(result.ds, "Should map deepseek to its real ds alias");
+    assert.ok(result.ds["deepseek-chat"]);
+    assert.ok(!result.if, "Must not route deepseek pricing onto Qoder's if alias");
   });
 
   test("skips entries without input cost", () => {


### PR DESCRIPTION
## Description

`LITELLM_PROVIDER_MAP` in `pricingSync.ts` maps a LiteLLM provider key to the OmniRoute provider it should sync pricing onto. Every downstream consumer of synced pricing (`getPricingForModel(provider, model)` and its callers) looks a provider up by its registry **alias** — but 4 of the ~20 map entries used the wrong string, so those providers have silently never received synced pricing:

| LiteLLM key | map had | real problem | should be |
|---|---|---|---|
| `deepseek` | `"if"` | `if` **is** a real alias — just Qoder's ([`registry/qoder/index.ts`](../blob/release/v3.8.50/open-sse/config/providers/registry/qoder/index.ts)), an unrelated third-party API. Every sync has been silently writing DeepSeek pricing onto Qoder's slot instead. | `"ds"` |
| `bedrock` / `bedrock_converse` | `"kiro"` | that's the provider's registry `id`, not its `alias` (`"kr"`) — dead key, nothing downstream reads it | `"kr"` |
| `cloudflare` | `"cloudflare-ai"` | same shape — `id` not `alias` (`"cf"`) | `"cf"` |

I found the `deepseek` one investigating a separate DeepSeek pricing issue and audited the rest of the table programmatically (all ~250 real registry aliases cross-checked against every map target) rather than assume it was the only one — the other two are the identical bug shape.

**Left alone, on purpose:** `stability: ["stability-ai"]` looks similar but `stability-ai` has no chat-completions registry entry at all (image-only — [`imageModels.ts`](../blob/release/v3.8.50/open-sse/config/providers/registry/stability-ai/imageModels.ts)). That's a different, ambiguous question (does image pricing belong in this table at all?), not the same "typo'd the key" bug — didn't want to guess at it here.

## Validation

- `tests/unit/pricing-sync.test.ts`'s `deepseek` case was asserting the *buggy* `if` mapping as expected output (`// deepseek maps to "if" alias`) — updated to assert `ds` and explicitly check pricing is **not** routed onto `if`.
- Ran the full pricing-sync test surface (`pricing-sync`, `pricing-sync-extended`, `pricing-sync-cross-instance`, `pricing-sync-memoization`, `model-pricing-litellm-gap-9364` — 25 tests) — all pass.
