### PR TITLE
feat(db): report the SQLite driver and its durability on the DB health check

### DIFF
--- a/docs/ops/DATABASE_GUIDE.md
+++ b/docs/ops/DATABASE_GUIDE.md
@@ -453,26 +453,47 @@ Run monthly during low-traffic windows. (WAL mode reduces the need, but doesn't 
 
 `src/lib/db/healthCheck.ts` provides **DB-level health diagnostics**:
 
-````bash
-GET /api/db/health
+Both verbs require authentication (`401` otherwise). `GET` diagnoses only; `POST` runs the
+same check with `autoRepair` enabled.
 
-Returns:
+```bash
+GET  /api/db/health   # diagnose
+POST /api/db/health   # diagnose + repair
+```
+
+The response is the `DbHealthCheckResult` produced by `runDbHealthCheck()`
+(`src/lib/db/healthCheck.ts`):
 
 ```json
 {
-  "status": "healthy",
-  "checks": {
-    "writable": { "status": "pass" },
-    "integrity": { "status": "pass", "result": "ok" },
-    "foreign_keys": { "status": "pass", "violations": 0 },
-    "orphaned_artifacts": { "status": "warn", "count": 12 },
-    "table_sizes": {
-      "usage_history": { "rows": 12345, "size_mb": 12.3 },
-      "call_logs": { "rows": 567, "size_mb": 2.1 }
+  "isHealthy": false,
+  "issues": [
+    {
+      "type": "broken_reference",
+      "table": "domain_budgets",
+      "description": "Domain budgets referenced API keys that no longer exist.",
+      "count": 2
     }
-  }
+  ],
+  "repairedCount": 0,
+  "backupCreated": false,
+  "autoRepair": false,
+  "checkedAt": "2026-08-18T09:00:00.000Z",
+  "driver": { "name": "better-sqlite3", "degraded": false }
 }
-````
+```
+
+| Field             | Meaning                                                                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isHealthy`       | `true` when `issues` is empty. `driver` never influences it.                                                                                   |
+| `issues[].type`   | One of `integrity_check_failed`, `broken_reference`, `stale_snapshot`, `invalid_state`.                                                        |
+| `repairedCount`   | Rows repaired during this run; always `0` when `autoRepair` is false.                                                                          |
+| `backupCreated`   | Whether a backup was taken before repairing.                                                                                                   |
+| `checkedAt`       | ISO timestamp shared by the run and by any repair note it writes.                                                                              |
+| `driver.name`     | SQLite driver serving the checked database.                                                                                                    |
+| `driver.degraded` | `true` when writes are not durably backed by the database file — the `sql.js` WASM fallback (whole-file persistence) or an in-memory database. |
+
+The same payload is returned by the `omniroute_db_health_check` MCP tool.
 
 Run `PRAGMA integrity_check` to detect corruption:
 

--- a/scripts/check/check-fabricated-docs.mjs
+++ b/scripts/check/check-fabricated-docs.mjs
@@ -314,6 +314,7 @@ const ENV_VAR_DENYLIST = new Set([
   "AUTHZ_NOT_INITIALIZED", // AuthzAssertionError code (AUTHZ_GUIDE.md)
   "MODULE_NOT_FOUND", // Node runtime error code watched by service supervisor (ELECTRON_GUIDE.md)
   "ERR_DLOPEN_FAILED", // Node native-module load error code (ELECTRON_GUIDE.md)
+  "SQLITE_FULL", // SQLite result code returned when the disk is full (DATABASE_GUIDE.md)
   // ── Code-symbol / naming-convention examples documented in prose ─────────────
   "UPPER_SNAKE", // the literal naming-convention token in the style guide (CODEBASE_DOCUMENTATION.md)
   "DEFAULT_TIMEOUT", // example constant name in the UPPER_SNAKE convention row (AGENTS.md)

--- a/src/lib/db/healthCheck.ts
+++ b/src/lib/db/healthCheck.ts
@@ -5,16 +5,27 @@ type SqliteDatabase = SqliteAdapter;
 type JsonRecord = Record<string, unknown>;
 
 export type DbHealthIssueType =
-  | "integrity_check_failed"
-  | "broken_reference"
-  | "stale_snapshot"
-  | "invalid_state";
+  "integrity_check_failed" | "broken_reference" | "stale_snapshot" | "invalid_state";
 
 export interface DbHealthIssue {
   type: DbHealthIssueType;
   table: string;
   description: string;
   count: number;
+}
+
+/** Derived from the adapter contract so a new driver cannot drift out of sync here. */
+export type DbDriverName = SqliteAdapter["driver"];
+
+export interface DbDriverHealth {
+  name: DbDriverName;
+  /**
+   * True when writes are not durably backed by the database file: the `sql.js` WASM
+   * fallback, or an in-memory database — which the cloud/build path opens through the
+   * NATIVE cascade, so the driver name alone would read as healthy.
+   * Informative only; `isHealthy` stays defined by `issues`.
+   */
+  degraded: boolean;
 }
 
 export interface DbHealthCheckResult {
@@ -24,6 +35,17 @@ export interface DbHealthCheckResult {
   backupCreated: boolean;
   autoRepair: boolean;
   checkedAt: string;
+  driver: DbDriverHealth;
+}
+
+const IN_MEMORY_DB_NAME = ":memory:";
+
+/** PURE: describe the driver serving `db`, and whether its writes survive a crash. */
+export function describeDbDriver(db: Pick<SqliteAdapter, "driver" | "name">): DbDriverHealth {
+  return {
+    name: db.driver,
+    degraded: db.driver === "sql.js" || db.name === IN_MEMORY_DB_NAME,
+  };
 }
 
 interface RunDbHealthCheckOptions {
@@ -383,8 +405,7 @@ function repairInvalidJsonRows(
 function getSchemaVersionIssueCount(db: SqliteDatabase, expectedSchemaVersion: string): number {
   if (!hasRows(db, "db_meta")) return 0;
   const row = db.prepare("SELECT value FROM db_meta WHERE key = 'schema_version'").get() as
-    | { value?: string | null }
-    | undefined;
+    { value?: string | null } | undefined;
   const current = typeof row?.value === "string" ? row.value : null;
   return current === expectedSchemaVersion ? 0 : 1;
 }
@@ -561,5 +582,6 @@ export function runDbHealthCheck(
     backupCreated,
     autoRepair,
     checkedAt,
+    driver: describeDbDriver(db),
   };
 }

--- a/tests/unit/db-health-driver.test.ts
+++ b/tests/unit/db-health-driver.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-health-driver-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "db-health-driver-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const healthCheckDb = await import("../../src/lib/db/healthCheck.ts");
+const driverFactory = await import("../../src/lib/db/adapters/driverFactory.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// ─── describeDbDriver: pure decision ───────────────────
+
+test("the sql.js WASM fallback is reported degraded", () => {
+  assert.deepEqual(
+    healthCheckDb.describeDbDriver({ driver: "sql.js", name: "/data/storage.sqlite" }),
+    {
+      name: "sql.js",
+      degraded: true,
+    }
+  );
+});
+
+test("a native driver backed by a real file is not degraded", () => {
+  for (const driver of ["better-sqlite3", "node:sqlite", "bun:sqlite"] as const) {
+    assert.deepEqual(healthCheckDb.describeDbDriver({ driver, name: "/data/storage.sqlite" }), {
+      name: driver,
+      degraded: false,
+    });
+  }
+});
+
+test("an in-memory database is degraded even on a native driver", () => {
+  for (const driver of ["better-sqlite3", "node:sqlite", "bun:sqlite", "sql.js"] as const) {
+    assert.deepEqual(healthCheckDb.describeDbDriver({ driver, name: ":memory:" }), {
+      name: driver,
+      degraded: true,
+    });
+  }
+});
+
+// ─── runDbHealthCheck: wiring against ground truth ─────
+
+test("the health check reports the driver of the database it actually ran against", () => {
+  const db = core.getDbInstance();
+  const result = healthCheckDb.runDbHealthCheck(db, { autoRepair: false });
+
+  assert.equal(result.driver.name, db.driver);
+
+  // Precondition: the fixture is file-backed, so `degraded` is asserted as a literal
+  // rather than re-derived from the implementation's own condition.
+  assert.ok(db.name.endsWith(".sqlite"), `expected a file-backed fixture, got ${db.name}`);
+  assert.equal(result.driver.degraded, false);
+});
+
+test("an in-memory database opened through the real cascade is reported degraded", () => {
+  // Same tryOpenSync() the cloud/build path reaches through openSqliteDatabase(), so the
+  // `:memory:` name is observed from the adapter rather than assumed.
+  const memoryAdapter = driverFactory.tryOpenSync(":memory:");
+  assert.ok(memoryAdapter, "expected the native cascade to open an in-memory database");
+  try {
+    assert.equal(memoryAdapter.name, ":memory:");
+    assert.equal(healthCheckDb.describeDbDriver(memoryAdapter).degraded, true);
+  } finally {
+    memoryAdapter.close();
+  }
+});


### PR DESCRIPTION
## Summary

- `DbHealthCheckResult` now reports which SQLite driver served the checked database, and whether
  that database's writes are durable: `"driver": { "name": "sql.js", "degraded": true }`.
- That was not answerable at runtime. `driverFactory` logs the chosen driver **once** at startup;
  `omniroute doctor` checks whether the better-sqlite3 native binary loads **on disk, from its own
  process**; and the payload of the endpoint whose job is DB health carried no driver field.
  Per #10552, a standalone bundle can rewrite the runtime `require` so the native driver fails to
  resolve **inside** the server while a fresh CLI resolves it fine — the server then runs on the
  sql.js WASM fallback while `doctor` reports green.
- `degraded` has exactly one meaning: writes are not durably backed by the database file. Two
  cases qualify — the sql.js WASM fallback, and an in-memory database, which `getDbInstance()`
  opens in cloud/build mode through the **native** cascade, so the driver name alone would read
  as healthy while nothing is persisted.
- Informative only: `isHealthy` stays defined by `issues`, so no existing check changes verdict.
- The field is read from the adapter the check ran against, so it cannot report a different
  database than the one inspected.

Also corrects the `DATABASE_GUIDE` health-check section, which documented a
`{status, checks: {...}}` payload this endpoint has never returned (`orphaned_artifacts` and
`table_sizes` have no source match in the repository). Its unterminated code fence left every
fabricated-docs claim below it unscanned; closing it surfaced `SQLITE_FULL` — a SQLite **result
code** quoted in prose, read by the gate as an env var — now allowlisted next to the other
prose-documented error codes.

## Related Issues

- Related to #10552 (fixes the cause this makes observable)
- Related to #7592, #8707, #7132 (silent sql.js fallback and its consequences)

## Validation

- [x] Change type: DB / observability (+ docs)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

```
$ node --import tsx/esm --test tests/unit/db-health-driver.test.ts
# tests 5   # pass 5   # fail 0

$ node --import tsx/esm --test tests/unit/db-health-check.test.ts     # pass 10  # fail 0
$ node --import tsx/esm --test tests/unit/db-core.test.ts             # pass 40  # fail 0
$ node --import tsx/esm --test tests/unit/db-core-extended.test.ts    # pass 27  # fail 0

$ npx vitest run --config vitest.mcp.config.ts \
    open-sse/mcp-server/__tests__/dbHealthTool.test.ts
Test Files  1 passed (1)      Tests  3 passed (3)

$ npm run typecheck:core 2>&1 | grep "error TS"
open-sse/services/compression/engines/omniglyphAdapter.ts(126,54): error TS2339: ...   # 1, pre-existing on base

$ npx eslint src/lib/db/healthCheck.ts tests/unit/db-health-driver.test.ts
0 errors

$ for g in check:docs-sync check:fabricated-docs check:docs-symbols check:doc-links; do
    npm run "$g" --silent >/dev/null 2>&1; echo "$g => rc=$?"; done
check:docs-sync => rc=0
check:fabricated-docs => rc=0
check:docs-symbols => rc=0
check:doc-links => rc=0
```

The single typecheck error is already tracked on the base and lives in a file this PR does not
touch.

⚠️ base-red inherited: #9985

## Tests Added Or Updated

- `tests/unit/db-health-driver.test.ts` (new, 5 tests): `describeDbDriver` flags sql.js as
  degraded, flags every driver as degraded for `:memory:`, and leaves the three native drivers
  undegraded on a file-backed database; `runDbHealthCheck` against a real database reports a
  driver **equal to** the adapter's own `db.driver`; and an in-memory database opened through the
  same `tryOpenSync` cascade the cloud/build path uses really reports `name === ":memory:"`.

## Coverage Notes

- Touched `src/`: `describeDbDriver()` (pure, all branches covered) and the single construction
  site of `DbHealthCheckResult`, covered by the real-database test above.
- No coverage moved down; the production change is additive.

## Reviewer Notes

- No migration, no feature flag, no change to request handling.
- `DbHealthCheckResult` gains one required field. It has a single producer, and both consumers
  (`/api/db/health`, `omniroute_db_health_check`) serialize the whole result, so no further
  wiring is needed.
- `driver` is nested rather than two flat fields so the two facts stay grouped and a later
  `persistence` refinement needs no third root field — happy to flatten it for consistency with
  the surrounding style.
- Deliberately not folded into `isHealthy`: a database on sql.js still works, and turning working
  installations red would change an existing check's verdict inside an observability change.
- `getDriverInfo()` / `setDriverInfo()` in `src/lib/db/core.ts` answer a different question — how
  better-sqlite3 was _resolved_, not which driver is serving — and have no production caller.
  Left untouched; removing or reviving them belongs in its own PR.
- The `check-fabricated-docs` allowlist entry is a pre-existing false positive that the broken
  fence had been hiding, not a new violation: the unmodified file passes the gate, and the same
  file with only the missing fence closed fails on `SQLITE_FULL`.
- Two unrelated formatting hunks in `healthCheck.ts` come from the repository's own
  `lint-staged` Prettier pass — the committed file predates the current formatting on those
  lines.
