### PR TITLE
fix(api): classify OAuth probe timeout as network_error

### DIFF
--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -153,6 +153,7 @@ export function classifyFailure({
     normalized.includes("fetch failed") ||
     normalized.includes("network") ||
     normalized.includes("timeout") ||
+    normalized.includes("timed out") ||
     normalized.includes("econn") ||
     normalized.includes("enotfound") ||
     normalized.includes("socket")

--- a/tests/unit/connection-test-timed-out-network-error.test.ts
+++ b/tests/unit/connection-test-timed-out-network-error.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { classifyFailure } = await import("../../src/app/api/providers/[id]/test/route.ts");
+
+// The OAuth probe's own abort message is "Test timed out after Xs" (route.ts's
+// AbortSignal.timeout handling), which contains "timed out" but not "timeout" —
+// classifyFailure must classify it as network_error, not the generic upstream_error
+// fallback, so a transient probe timeout doesn't paint the connection permanently red.
+test("classifyFailure maps an OAuth-probe 'timed out' message to network_error", () => {
+  const diagnosis = classifyFailure({
+    error: "Test timed out after 30s",
+    statusCode: null,
+    provider: "some-oauth-provider",
+  });
+
+  assert.equal(diagnosis.type, "network_error");
+  assert.equal(diagnosis.code, "network_error");
+});
+
+test("classifyFailure still maps the existing 'timeout' substring to network_error", () => {
+  const diagnosis = classifyFailure({
+    error: "connect ETIMEDOUT — timeout while probing upstream",
+    statusCode: null,
+    provider: "some-oauth-provider",
+  });
+
+  assert.equal(diagnosis.type, "network_error");
+});


### PR DESCRIPTION
## Summary

The OAuth probe reports its own abort as "Test timed out after 30s", but `classifyFailure` only matched `timeout`, not `timed out`. A hung probe was diagnosed as a generic upstream error and marked the connection broken.

Add `timed out` to the network error pattern so transient probe failures don't paint connections permanently red.

Complements the existing #9623 fix (30s cooldown for non-terminal failures) by correctly classifying the OAuth probe timeout as a network error.

Fixes #9623

## Test plan

- `node --import tsx/esm --test tests/unit/connection-test-timed-out-network-error.test.ts` (new regression test, added during review)
