### PR TITLE
fix(cli): stop hardcoding codex.cmd in launch-codex Windows spawn

### DIFF
--- a/bin/cli/commands/launch-codex.mjs
+++ b/bin/cli/commands/launch-codex.mjs
@@ -20,12 +20,16 @@ const STRIPPED_CODEX_ENV_KEYS = [
 /** Placeholder so codex's `env_key` is always satisfied when the backend is open. */
 const NO_AUTH_SENTINEL = "omniroute-no-auth";
 
-// On Windows the `codex` binary is an npm `.cmd` shim that `spawn` cannot resolve
-// without a shell (bare "codex" → ENOENT). Mirror the qodercli Windows fix (#6263):
-// spawn `codex.cmd` through a shell on win32, and the bare binary elsewhere.
+// On Windows an npm-installed `codex` is a `.cmd` shim that `spawn` cannot
+// resolve without a shell (bare "codex" -> ENOENT when shell is undefined).
+// A native/standalone Codex CLI install instead places a bare `codex.exe` on
+// PATH with no `.cmd` shim at all, so the command must NOT be hardcoded to
+// "codex.cmd" -- shell: true lets cmd.exe's normal PATHEXT resolution find
+// whichever one is actually installed. Mirrors the same fix applied to
+// resolveClaudeSpawn() for the same reason (see bin/cli/commands/launch.mjs).
 export function resolveCodexSpawn(platform) {
   if (platform === "win32") {
-    return { command: "codex.cmd", shell: true };
+    return { command: "codex", shell: true };
   }
   return { command: "codex", shell: undefined };
 }

--- a/tests/unit/cli/launch-codex-windows-spawn-args.test.ts
+++ b/tests/unit/cli/launch-codex-windows-spawn-args.test.ts
@@ -13,9 +13,15 @@ import {
 
 const isWindows = process.platform === "win32";
 
-test("resolveCodexSpawn: win32 spawns codex.cmd through a shell", () => {
+// Regression guard: on Windows an npm-installed `codex` is a `.cmd` shim that
+// spawn() cannot resolve without a shell (bare "codex" -> ENOENT when shell is
+// undefined). A native/standalone Codex CLI install instead places a bare
+// `codex.exe` on PATH with no `.cmd` shim at all, so the command must NOT be
+// hardcoded to "codex.cmd" -- shell: true lets cmd.exe's normal PATHEXT
+// resolution find whichever one is actually installed.
+test("resolveCodexSpawn: win32 spawns bare codex through a shell (PATHEXT resolves .cmd or .exe)", () => {
   const { command, shell } = resolveCodexSpawn("win32");
-  assert.equal(command, "codex.cmd");
+  assert.equal(command, "codex");
   assert.equal(shell, true);
 });
 


### PR DESCRIPTION
## Summary
- `resolveCodexSpawn()` in `bin/cli/commands/launch-codex.mjs` hardcoded `"codex.cmd"` on win32, assuming an npm-shim install of the Codex CLI
- A native/standalone Codex CLI install places a bare `codex.exe` on PATH with no `.cmd` shim, so `omniroute launch-codex` failed with `'codex.cmd' is not recognized as an internal or external command`
- Fix mirrors the identical fix already applied to `resolveClaudeSpawn()` (`bin/cli/commands/launch.mjs`, commit d83801f): pass bare `"codex"` through `shell: true` and let cmd.exe's own PATHEXT resolution find whichever binary is actually installed — `.cmd` shim or `.exe` native

## Test plan
- [x] Reproduced the failure directly: `cmd.exe /c "codex.cmd --version"` → `'codex.cmd' is not recognized...`
- [x] Confirmed bare `codex` resolves via PATHEXT: `cmd.exe /c "codex --version"` → `codex-cli 0.147.0`
- [x] Updated the regression test (`tests/unit/cli/launch-codex-windows-spawn-args.test.ts`) to assert the bare-command shape, mirroring the existing `launch-windows-spawn-args.test.ts` pattern for Claude
- [x] `node --import tsx/esm --test tests/unit/cli/launch-codex-windows-spawn-args.test.ts` — 7/7 pass
- [x] `node --import tsx/esm --test tests/unit/cli/launch-codex.test.ts tests/unit/cli/setup-codex.test.ts` — 9/9 pass (no other codex CLI tests touch the spawn shape)