### PR TITLE
fix(files): validate the list limit query parameter

### DIFF
--- a/src/app/api/v1/files/route.ts
+++ b/src/app/api/v1/files/route.ts
@@ -7,6 +7,61 @@ export async function OPTIONS() {
   return handleCorsOptions();
 }
 
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 10000;
+
+export function parseFilesListQuery(searchParams: URLSearchParams):
+  | {
+      ok: true;
+      limit: number;
+      after: string | undefined;
+      order: "asc" | "desc";
+      purpose: string | undefined;
+    }
+  | { ok: false; response: Response } {
+  const rawLimit = searchParams.get("limit");
+  let limit = DEFAULT_LIST_LIMIT;
+
+  if (rawLimit !== null) {
+    if (!/^\d+$/.test(rawLimit)) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: { message: "limit must be a positive integer", type: "invalid_request_error" } },
+          { status: 400, headers: CORS_HEADERS }
+        ),
+      };
+    }
+
+    limit = Number.parseInt(rawLimit, 10);
+    if (limit < 1 || limit > MAX_LIST_LIMIT) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            error: {
+              message: `limit must be between 1 and ${MAX_LIST_LIMIT}`,
+              type: "invalid_request_error",
+            },
+          },
+          { status: 400, headers: CORS_HEADERS }
+        ),
+      };
+    }
+  }
+
+  const orderParam = searchParams.get("order");
+  const order = orderParam === "asc" ? "asc" : "desc";
+
+  return {
+    ok: true,
+    limit,
+    after: searchParams.get("after") || undefined,
+    order,
+    purpose: searchParams.get("purpose") || undefined,
+  };
+}
+
 export async function POST(request: Request) {
   const scope = await getApiKeyRequestScope(request);
   if (scope.rejection) return scope.rejection;
@@ -78,10 +133,9 @@ export async function GET(request: Request) {
   const apiKeyId = scope.apiKeyId;
 
   const { searchParams } = new URL(request.url);
-  const limit = Math.min(Number.parseInt(searchParams.get("limit") || "20") || 20, 10000);
-  const after = searchParams.get("after") || undefined;
-  const order = (searchParams.get("order") as "asc" | "desc") || "desc";
-  const purpose = searchParams.get("purpose") || undefined;
+  const parsed = parseFilesListQuery(searchParams);
+  if (!parsed.ok) return parsed.response;
+  const { limit, after, order, purpose } = parsed;
 
   // We fetch limit + 1 to check if there are more items
   const files = listFiles({

--- a/tests/integration/files-api-limit-validation.test.ts
+++ b/tests/integration/files-api-limit-validation.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { createFile, deleteFile } from "@/lib/db/files";
+import { GET, parseFilesListQuery } from "@/app/api/v1/files/route";
+
+describe("GET /v1/files limit validation", () => {
+  it("parses an explicit positive integer limit", () => {
+    const parsed = parseFilesListQuery(new URLSearchParams("limit=2&order=asc&purpose=batch"));
+
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.limit, 2);
+    assert.equal(parsed.order, "asc");
+    assert.equal(parsed.purpose, "batch");
+  });
+
+  it("rejects non-integer, zero, and oversized limits", async () => {
+    for (const rawLimit of ["abc", "1.5", "-1", "0", "10001"]) {
+      const parsed = parseFilesListQuery(
+        new URLSearchParams(`limit=${encodeURIComponent(rawLimit)}`)
+      );
+      assert.equal(parsed.ok, false, `limit=${rawLimit} should be rejected`);
+      if (parsed.ok) continue;
+      assert.equal(parsed.response.status, 400);
+      const body = await parsed.response.json();
+      assert.equal(body.error.type, "invalid_request_error");
+    }
+  });
+
+  it("returns only the requested number of files over HTTP", async () => {
+    const created = [
+      createFile({
+        bytes: 1,
+        filename: "test-files-limit-http-a.txt",
+        purpose: "assistants",
+        content: Buffer.from("a"),
+        mimeType: "text/plain",
+      }),
+      createFile({
+        bytes: 1,
+        filename: "test-files-limit-http-b.txt",
+        purpose: "assistants",
+        content: Buffer.from("b"),
+        mimeType: "text/plain",
+      }),
+    ];
+
+    try {
+      const response = await GET(
+        new Request("http://localhost/v1/files?limit=1&purpose=assistants")
+      );
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.object, "list");
+      assert.equal(body.data.length, 1);
+      assert.equal(body.has_more, true);
+    } finally {
+      for (const file of created) deleteFile(file.id);
+    }
+  });
+
+  it("returns 400 over HTTP for an invalid limit instead of listing files", async () => {
+    const response = await GET(new Request("http://localhost/v1/files?limit=-1"));
+
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error.type, "invalid_request_error");
+  });
+});

--- a/tests/integration/files-api-limit-validation.test.ts
+++ b/tests/integration/files-api-limit-validation.test.ts
@@ -4,6 +4,14 @@ import { createFile, deleteFile } from "@/lib/db/files";
 import { GET, parseFilesListQuery } from "@/app/api/v1/files/route";
 
 describe("GET /v1/files limit validation", () => {
+  it("defaults to 20 when limit is absent", () => {
+    const parsed = parseFilesListQuery(new URLSearchParams("order=asc"));
+
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.limit, 20);
+  });
+
   it("parses an explicit positive integer limit", () => {
     const parsed = parseFilesListQuery(new URLSearchParams("limit=2&order=asc&purpose=batch"));
 


### PR DESCRIPTION
## Summary

- Validate the `limit` query parameter accepted by `GET /v1/files`.
- Return a structured `400 invalid_request_error` response for non-integer, zero, negative, or oversized values.
- Preserve the existing default limit of 20 and maximum of 10,000.

## Related Issues

- No linked issue.

## Validation

CI will run the repository gates on this PR.

- [x] Change type: other — Files API validation
- [x] Focused tests and category gates from the golden path
- [x] ESLint and Prettier checks on the changed files
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new automated test in this PR

Focused validation:

```text
tests 38
pass 38
fail 0
```

The focused run covered:

- `tests/integration/files-api-limit-validation.test.ts`
- `tests/integration/files-api.test.ts`
- `tests/unit/batch_api.test.ts`

## Tests Added Or Updated

- Added `tests/integration/files-api-limit-validation.test.ts`.

The test covers valid parsing, invalid limits, HTTP pagination behavior, and the HTTP 400 response.

## Coverage Notes

The new integration test exercises both the query parser and the `GET /v1/files` route. The existing Files API and batch API suites also pass against this change.

## Reviewer Notes

- No database migrations or feature flags.
- The maximum accepted value remains 10,000.