### PR TITLE
test(aihorde): guard client browser bundles

### DIFF
--- a/tests/unit/media-page-client-browser-bundle.test.ts
+++ b/tests/unit/media-page-client-browser-bundle.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+async function assertBrowserBundleSafe(relativePath: string) {
+  await assert.doesNotReject(
+    build({
+      absWorkingDir: REPO_ROOT,
+      entryPoints: [fileURLToPath(new URL(relativePath, import.meta.url))],
+      bundle: true,
+      format: "esm",
+      logLevel: "silent",
+      platform: "browser",
+      tsconfig: "tsconfig.json",
+      write: false,
+    })
+  );
+}
+
+test("media page client entry stays browser-bundle safe", async () => {
+  await assertBrowserBundleSafe(
+    "../../src/app/(dashboard)/dashboard/cache/media/MediaPageClient.tsx"
+  );
+});
+
+test("provider detail client entry stays browser-bundle safe", async () => {
+  await assertBrowserBundleSafe(
+    "../../src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx"
+  );
+});


### PR DESCRIPTION
CI note: `Docs Gates` currently inherits the release-base `BOT_TOKEN` / `BOT_URL` env-doc failure. the same base-red appears on unrelated #10780; this diff does not touch those variables.

`release/v3.8.50` now contains the browser-safe AI Horde registry implementation. this PR keeps the focused regression test requested in review.

## what it covers

- bundle the media cache client for the browser
- bundle the provider detail client for the browser
- fail if either entry pulls database, filesystem, or other server-only code into the client graph

The broader client-entry guard on the release branch covers the same class of bug. this test keeps the two original failure paths explicit.

## how to test

```sh
npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=4096 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/unit/media-page-client-browser-bundle.test.ts
npx eslint tests/unit/media-page-client-browser-bundle.test.ts
```

Both commands pass after rebasing onto the current `release/v3.8.50` tip.
