### PR TITLE
test(chatcore): wait for queued call log writes

### DIFF
--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -36,7 +36,8 @@ const {
   setBackgroundDegradationConfig,
   resetStats: resetBackgroundStats,
 } = await import("../../open-sse/services/backgroundTaskDetector.ts");
-const { getCallLogs, getCallLogById } = await import("../../src/lib/usage/callLogs.ts");
+const { getCallLogs, getCallLogById, waitForCallLogSaves } =
+  await import("../../src/lib/usage/callLogs.ts");
 const {
   handleChatCore,
   shouldUseNativeCodexPassthrough,
@@ -286,6 +287,7 @@ async function flushAsyncSideEffects() {
 }
 
 async function getLatestCallLog() {
+  await waitForCallLogSaves(5000);
   const rows = await getCallLogs({ limit: 5 });
   if (!Array.isArray(rows) || rows.length === 0) return null;
   return getCallLogById(rows[0].id);


### PR DESCRIPTION
CI note: `Docs Gates` currently inherits the release-base `BOT_TOKEN` / `BOT_URL` env-doc failure. the same base-red appears on unrelated #10780; this diff does not touch those variables.

The chatcore translation suite could read `call_logs` before queued writes finished. latest-record assertions then saw stale rows.

This PR only changes test timing. production behavior stays the same.

The shared helper now waits for `waitForCallLogSaves(5000)` before reading the latest call log. `release/v3.8.50` owns the SSE comment behavior updated in #10726, so this branch leaves those assertions unchanged.

## how to test

```sh
npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=4096 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/unit/chatcore-translation-paths.test.ts
```

The focused file passes after rebasing onto the current release tip. direct-file ESLint still reports 31 `no-explicit-any` findings present on the release base; this three-line diff adds none.
