### PR TITLE
fix(analytics): read auto routing usage from call logs

### DIFF
--- a/src/app/api/analytics/auto-routing/route.ts
+++ b/src/app/api/analytics/auto-routing/route.ts
@@ -16,7 +16,6 @@ export async function GET(request: Request) {
   const authError = await requireManagementAuth(request);
   if (authError) return authError;
   try {
-    // Query usage_logs for auto/ prefix requests
     const totalRequests = getAutoRoutingTotalCount();
 
     // Variant breakdown

--- a/src/lib/db/usageLogs.ts
+++ b/src/lib/db/usageLogs.ts
@@ -1,11 +1,6 @@
 /**
- * db/usageLogs.ts — Read-only aggregation queries over `usage_logs`
- * extracted from the /api/analytics/auto-routing route handler.
- *
- * Hard Rule #5: routes must not embed raw SQL — these queries live here so the
- * /api/analytics/auto-routing route can delegate.
- *
- * Sliced out of #3500 (usage_logs cluster, slice 4).
+ * Read-only auto-routing aggregations over `call_logs`.
+ * `requested_model` keeps the client auto/* id after routing resolves a target.
  */
 
 import { getDbInstance } from "./core";
@@ -19,8 +14,7 @@ export interface AutoRoutingTotalResult {
 }
 
 /**
- * Returns the total number of requests routed through auto/ prefix models.
- * Matches model = 'auto' OR model LIKE 'auto/%'.
+ * Returns the number of call-log rows requested through auto/ prefix models.
  */
 export function getAutoRoutingTotalCount(): AutoRoutingTotalResult {
   const db = getDbInstance();
@@ -28,8 +22,8 @@ export function getAutoRoutingTotalCount(): AutoRoutingTotalResult {
     .prepare(
       `
       SELECT COUNT(*) as count
-      FROM usage_logs
-      WHERE model = 'auto' OR model LIKE 'auto/%'
+      FROM call_logs
+      WHERE requested_model = 'auto' OR requested_model LIKE 'auto/%'
     `
     )
     .get() as AutoRoutingTotalResult | undefined;
@@ -42,11 +36,7 @@ export interface AutoRoutingVariantRow {
 }
 
 /**
- * Returns per-variant request counts for auto/ prefix models.
- * Variant is derived from the model name:
- *   'auto'      → 'default'
- *   'auto/X'    → 'X'
- *   other       → 'other' (should not occur given the WHERE clause)
+ * Returns per-variant request counts from the client-requested model id.
  */
 export function getAutoRoutingVariantBreakdown(): AutoRoutingVariantRow[] {
   const db = getDbInstance();
@@ -55,13 +45,13 @@ export function getAutoRoutingVariantBreakdown(): AutoRoutingVariantRow[] {
       `
       SELECT
         CASE
-          WHEN model = 'auto' THEN 'default'
-          WHEN model LIKE 'auto/%' THEN SUBSTR(model, 6)
+          WHEN requested_model = 'auto' THEN 'default'
+          WHEN requested_model LIKE 'auto/%' THEN SUBSTR(requested_model, 6)
           ELSE 'other'
         END as variant,
         COUNT(*) as count
-      FROM usage_logs
-      WHERE model = 'auto' OR model LIKE 'auto/%'
+      FROM call_logs
+      WHERE requested_model = 'auto' OR requested_model LIKE 'auto/%'
       GROUP BY variant
       ORDER BY count DESC
     `
@@ -75,7 +65,7 @@ export interface AutoRoutingTopProviderRow {
 }
 
 /**
- * Returns the top 10 providers used for auto/ prefix model requests.
+ * Returns the top 10 providers used for auto/ prefix requests.
  */
 export function getAutoRoutingTopProviders(): AutoRoutingTopProviderRow[] {
   const db = getDbInstance();
@@ -83,8 +73,10 @@ export function getAutoRoutingTopProviders(): AutoRoutingTopProviderRow[] {
     .prepare(
       `
       SELECT provider, COUNT(*) as count
-      FROM usage_logs
-      WHERE model = 'auto' OR model LIKE 'auto/%'
+      FROM call_logs
+      WHERE (requested_model = 'auto' OR requested_model LIKE 'auto/%')
+        AND provider IS NOT NULL
+        AND TRIM(provider) != ''
       GROUP BY provider
       ORDER BY count DESC
       LIMIT 10

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -771,7 +771,7 @@ export type {
 } from "./db/usageAnalytics";
 
 // ---------------------------------------------------------------------------
-// usage_logs — auto-routing analytics (#3500 slice 4)
+// call_logs auto-routing analytics (#3500 slice 4)
 // ---------------------------------------------------------------------------
 export {
   getAutoRoutingTotalCount,

--- a/tests/unit/auto-routing-analytics-db.test.ts
+++ b/tests/unit/auto-routing-analytics-db.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const originalDataDir = process.env.DATA_DIR;
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-auto-routing-analytics-"));
+process.env.DATA_DIR = testDataDir;
+
+const core = await import("../../src/lib/db/core.ts");
+const usageLogs = await import("../../src/lib/db/usageLogs.ts");
+
+test.before(() => {
+  core.resetDbInstance();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(testDataDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+});
+
+test("auto-routing analytics use requested models from the runtime schema", () => {
+  const db = core.getDbInstance();
+  const insert = db.prepare(
+    `INSERT INTO call_logs (id, model, requested_model, provider, timestamp)
+     VALUES (?, ?, ?, ?, ?)`
+  );
+  const timestamp = new Date().toISOString();
+
+  insert.run("auto-default", "claude-opus-5", "auto", "anthropic", timestamp);
+  insert.run("auto-fast-1", "gpt-5.6-luna", "auto/fast", "openai", timestamp);
+  insert.run("auto-fast-2", "gpt-5.6-terra", "auto/fast", "openai", timestamp);
+  insert.run("direct", "gpt-4", "gpt-4", "openai", timestamp);
+
+  assert.deepEqual(usageLogs.getAutoRoutingTotalCount(), { count: 3 });
+  assert.deepEqual(usageLogs.getAutoRoutingVariantBreakdown(), [
+    { variant: "fast", count: 2 },
+    { variant: "default", count: 1 },
+  ]);
+  assert.deepEqual(usageLogs.getAutoRoutingTopProviders(), [
+    { provider: "openai", count: 2 },
+    { provider: "anthropic", count: 1 },
+  ]);
+});

--- a/tests/unit/db-logs-cache-3500.test.ts
+++ b/tests/unit/db-logs-cache-3500.test.ts
@@ -1,5 +1,5 @@
 /**
- * #3500 — usage_logs / semantic_cache / proxy_logs SQL extracted into db modules
+ * #3500: semantic_cache / proxy_logs SQL extracted into db modules
  * (Hard Rule #5, slice 4).
  *
  * Seeds an in-memory temp SQLite DB for each table and asserts each new db
@@ -17,34 +17,8 @@ const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omni-db-logs-cache-
 process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
-const usageLogs = await import("../../src/lib/db/usageLogs.ts");
 const semanticCache = await import("../../src/lib/db/semanticCache.ts");
 const proxyLogs = await import("../../src/lib/db/proxyLogs.ts");
-
-// ---------------------------------------------------------------------------
-// Helpers — usage_logs seeding
-// usage_logs is NOT in the core.ts schema; create it as a lightweight table
-// mirroring the columns used by the auto-routing queries (model, provider).
-// ---------------------------------------------------------------------------
-
-function ensureUsageLogsTable() {
-  const db = core.getDbInstance();
-  db.prepare(
-    `CREATE TABLE IF NOT EXISTS usage_logs (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      model TEXT NOT NULL,
-      provider TEXT NOT NULL,
-      timestamp TEXT NOT NULL
-    )`
-  ).run();
-}
-
-function insertUsageLog(row: { model: string; provider: string }) {
-  const db = core.getDbInstance();
-  db.prepare(
-    `INSERT INTO usage_logs (model, provider, timestamp) VALUES (?, ?, ?)`
-  ).run(row.model, row.provider, new Date().toISOString());
-}
 
 // ---------------------------------------------------------------------------
 // Helpers — semantic_cache seeding
@@ -70,7 +44,7 @@ function insertSemanticCache(row: {
     "hash_" + row.id,
     "{}",
     row.tokens_saved ?? 0,
-    row.hit_count ?? 0,
+    row.hit_count ?? 0
   );
 }
 
@@ -91,67 +65,11 @@ function insertProxyLog(row: { id: string; timestamp: string; provider?: string 
 
 test.before(() => {
   core.resetDbInstance();
-  ensureUsageLogsTable();
 });
 
 test.after(() => {
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
-});
-
-// ===========================================================================
-// usageLogs — getAutoRoutingTotalCount
-// ===========================================================================
-
-test("#3500 getAutoRoutingTotalCount — returns 0 when no rows", () => {
-  const result = usageLogs.getAutoRoutingTotalCount();
-  assert.equal(result.count, 0);
-});
-
-test("#3500 getAutoRoutingTotalCount — counts auto and auto/* models", () => {
-  insertUsageLog({ model: "auto", provider: "openai" });
-  insertUsageLog({ model: "auto/fast", provider: "anthropic" });
-  insertUsageLog({ model: "gpt-4", provider: "openai" }); // must NOT be counted
-
-  const result = usageLogs.getAutoRoutingTotalCount();
-  assert.ok(result.count >= 2, `expected >= 2, got ${result.count}`);
-});
-
-// ===========================================================================
-// usageLogs — getAutoRoutingVariantBreakdown
-// ===========================================================================
-
-test("#3500 getAutoRoutingVariantBreakdown — maps auto → default, auto/X → X", () => {
-  // Insert another auto and auto/fast to have stable counts
-  insertUsageLog({ model: "auto", provider: "openai" });
-  insertUsageLog({ model: "auto/fast", provider: "anthropic" });
-
-  const rows = usageLogs.getAutoRoutingVariantBreakdown();
-  const byVariant: Record<string, number> = {};
-  for (const r of rows) byVariant[r.variant] = r.count;
-
-  assert.ok("default" in byVariant, "should have a 'default' variant for bare 'auto'");
-  assert.ok("fast" in byVariant, "should have a 'fast' variant for 'auto/fast'");
-  assert.ok(byVariant["default"] >= 1, "default count >= 1");
-  assert.ok(byVariant["fast"] >= 1, "fast count >= 1");
-});
-
-// ===========================================================================
-// usageLogs — getAutoRoutingTopProviders
-// ===========================================================================
-
-test("#3500 getAutoRoutingTopProviders — returns top providers for auto/* models", () => {
-  const rows = usageLogs.getAutoRoutingTopProviders();
-  assert.ok(Array.isArray(rows), "result is array");
-  assert.ok(rows.length > 0, "at least one provider row");
-  for (const r of rows) {
-    assert.equal(typeof r.provider, "string");
-    assert.equal(typeof r.count, "number");
-  }
-  // Should be ordered descending by count (first row has highest count)
-  if (rows.length > 1) {
-    assert.ok(rows[0].count >= rows[1].count, "ordered descending by count");
-  }
 });
 
 // ===========================================================================
@@ -316,8 +234,16 @@ test("#3500 exportProxyLogsSince — returns rows with timestamp >= since", () =
   const base = new Date("2025-01-15T10:00:00.000Z");
   const old = new Date("2025-01-14T10:00:00.000Z");
 
-  insertProxyLog({ id: "pl-new-1", timestamp: new Date("2025-01-15T11:00:00.000Z").toISOString(), provider: "openai" });
-  insertProxyLog({ id: "pl-new-2", timestamp: new Date("2025-01-15T12:00:00.000Z").toISOString(), provider: "anthropic" });
+  insertProxyLog({
+    id: "pl-new-1",
+    timestamp: new Date("2025-01-15T11:00:00.000Z").toISOString(),
+    provider: "openai",
+  });
+  insertProxyLog({
+    id: "pl-new-2",
+    timestamp: new Date("2025-01-15T12:00:00.000Z").toISOString(),
+    provider: "anthropic",
+  });
   insertProxyLog({ id: "pl-old-1", timestamp: old.toISOString(), provider: "openai" }); // outside window
 
   const rows = proxyLogs.exportProxyLogsSince(base.toISOString());


### PR DESCRIPTION
CI note: `Docs Gates` currently inherits the release-base `BOT_TOKEN` / `BOT_URL` env-doc failure. the same base-red appears on unrelated #10780; this diff does not touch those variables.

The auto-routing analytics endpoint queried `usage_logs`, but the runtime does not create or write that table. the caught SQLite error made the endpoint return empty metrics.

`call_logs.requested_model` already records `auto` and `auto-fast`, along with the provider used for each call.

## what changed

- read auto-routing counts and provider totals from `call_logs`
- use `requested_model` to separate `auto` from `auto-fast`
- remove tests that created an application-owned schema that does not exist
- test against the real core schema with different requested and resolved models
- restore `DATA_DIR` after the database regression test

No migration is needed. the branch contains five changed files and does not carry the combo patch.

## how to test

```sh
npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=4096 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/unit/auto-routing-analytics-db.test.ts tests/unit/db-logs-cache-3500.test.ts
npx eslint src/app/api/analytics/auto-routing/route.ts src/lib/db/usageLogs.ts src/lib/localDb.ts tests/unit/auto-routing-analytics-db.test.ts tests/unit/db-logs-cache-3500.test.ts
```

Both commands pass after rebasing onto the current `release/v3.8.50` tip.
