### PR TITLE
fix(combo): use .ts extension for localDb import to fix Turbopack dev-boot resolution

### DIFF
--- a/open-sse/config/providers/registry/aihorde/imageModels.ts
+++ b/open-sse/config/providers/registry/aihorde/imageModels.ts
@@ -5,8 +5,32 @@
  * async API (`/v2/generate/async`). `models` is a live getter so
  * imageRegistry stays under the file-size cap and zero-worker names are
  * never advertised.
+ *
+ * NOTE: this module must NOT statically import the live catalog service
+ * (open-sse/services/aihordeImageCatalog.ts). That service pulls in the
+ * network/DB stack (safeOutboundFetch → featureFlags → db/core →
+ * better-sqlite3), which would drag server-only code into the client bundle
+ * and fail the production build. Instead, the server-side Horde poller pushes
+ * refreshed snapshots in through `setAiHordeImageCatalogEntries()`.
  */
-import { getCachedAiHordeImageCatalogEntries } from "../../../../services/aihordeImageCatalog.ts";
+
+export interface AiHordeRegistryModelEntry {
+  id: string;
+  name: string;
+  provider: string;
+  supportedSizes: string[];
+  inputModalities: string[];
+  description?: string;
+}
+
+// Snapshot of the live AI Horde catalog. Empty until the server-side poller
+// pushes a refresh. (The client bundle never populates it — same as before,
+// when the client always read an empty in-memory cache.)
+let aiHordeCatalogEntries: AiHordeRegistryModelEntry[] = [];
+
+export function setAiHordeImageCatalogEntries(entries: AiHordeRegistryModelEntry[]): void {
+  aiHordeCatalogEntries = entries;
+}
 
 export const AI_HORDE_IMAGE_PROVIDER = {
   id: "aihorde",
@@ -16,7 +40,7 @@ export const AI_HORDE_IMAGE_PROVIDER = {
   authHeader: "apikey",
   format: "aihorde",
   get models() {
-    return getCachedAiHordeImageCatalogEntries().map((entry) => ({
+    return aiHordeCatalogEntries.map((entry) => ({
       id: entry.id.startsWith("aihorde/") ? entry.id.slice("aihorde/".length) : entry.id,
       name: entry.name,
       inputModalities: entry.inputModalities,

--- a/open-sse/services/aihordeImageCatalog.ts
+++ b/open-sse/services/aihordeImageCatalog.ts
@@ -8,6 +8,10 @@
  */
 
 import { safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
+import {
+  setAiHordeImageCatalogEntries,
+  type AiHordeRegistryModelEntry,
+} from "../config/providers/registry/aihorde/imageModels.ts";
 
 export const AI_HORDE_API_BASE = "https://aihorde.net/api";
 export const AI_HORDE_ANONYMOUS_KEY = "0000000000";
@@ -143,6 +147,7 @@ export class HordeImageCatalog {
     } else {
       this.lastError = error;
     }
+    syncRegistrySnapshot(this);
   }
 
   /** Drop the snapshot so the next `ensureFresh` must hit Horde. */
@@ -150,6 +155,7 @@ export class HordeImageCatalog {
     this.models = new Map();
     this.updatedAt = null;
     this.lastError = null;
+    syncRegistrySnapshot(this);
   }
 
   setFetch(fetchImpl: HordeFetch): void {
@@ -174,7 +180,9 @@ export class HordeImageCatalog {
     await this.refresh(options);
   }
 
-  private async refreshOnce(options: { timeoutMs?: number; signal?: AbortSignal } = {}): Promise<void> {
+  private async refreshOnce(
+    options: { timeoutMs?: number; signal?: AbortSignal } = {}
+  ): Promise<void> {
     try {
       const url = `${AI_HORDE_API_BASE}/v2/status/models?type=image`;
       const response = await this.fetchImpl(url, {
@@ -197,19 +205,13 @@ export class HordeImageCatalog {
 
 export const aiHordeImageCatalog = new HordeImageCatalog();
 
-export function resetAiHordeImageCatalog(): void {
-  aiHordeImageCatalog.clear();
-}
-
-export function getCachedAiHordeImageCatalogEntries(): Array<{
-  id: string;
-  name: string;
-  provider: string;
-  supportedSizes: string[];
-  inputModalities: string[];
-  description?: string;
-}> {
-  return aiHordeImageCatalog.listModels().map((model) => ({
+/**
+ * Map a catalog snapshot to the registry entry shape and push it into
+ * `AI_HORDE_IMAGE_PROVIDER` (see imageModels.ts). Only the module-level
+ * singleton drives the registry — injected test instances are ignored.
+ */
+function registryEntriesFrom(models: HordeImageCatalogModel[]): AiHordeRegistryModelEntry[] {
+  return models.map((model) => ({
     id: `aihorde/${model.name}`,
     name: `${model.name} (AI Horde)`,
     provider: "aihorde",
@@ -217,4 +219,17 @@ export function getCachedAiHordeImageCatalogEntries(): Array<{
     inputModalities: ["text", "image"],
     description: `${model.count} worker${model.count === 1 ? "" : "s"} online`,
   }));
+}
+
+function syncRegistrySnapshot(from: HordeImageCatalog): void {
+  if (from !== aiHordeImageCatalog) return;
+  setAiHordeImageCatalogEntries(registryEntriesFrom(from.listModels()));
+}
+
+export function resetAiHordeImageCatalog(): void {
+  aiHordeImageCatalog.clear();
+}
+
+export function getCachedAiHordeImageCatalogEntries(): AiHordeRegistryModelEntry[] {
+  return registryEntriesFrom(aiHordeImageCatalog.listModels());
 }

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -87,7 +87,7 @@ import { selectQuotaShareTarget } from "./combo/quotaShareStrategy.ts";
 import { makeConnectionConcurrencyResolver, lookupPositiveCap } from "./combo/concurrencyCaps.ts";
 import { acquireQuotaShareConcurrencySlot } from "./combo/quotaShareConcurrency.ts";
 import { canAffordRequest } from "../../src/lib/quota/quotaScheduler.ts";
-import { getCachedProviderConnectionById } from "../../src/lib/localDb.js";
+import { getCachedProviderConnectionById } from "../../src/lib/localDb.ts";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
 
 /**
@@ -1190,7 +1190,6 @@ export async function handleComboChat({
             if (i > 0) fallbackCount++;
             return stopProtectedPriorityTarget(`Connection capacity reached for ${modelStr}`);
           }
-
         }
 
         // #9654 Wave 2: per-target lane-aware admission probe. With virtual


### PR DESCRIPTION
## Summary

- `open-sse/services/combo.ts:90` imported `localDb` with an explicit `.js` extension, unlike every sibling static import in the same file (`.ts` or no extension). That `.js` suffix stopped resolving under Turbopack's dev-instrumentation path after the dependency bump in #10647, so `npm ci && npm run dev` on the current tip dies during boot before serving anything:

  ```
  [STARTUP] Fatal: instrumentation hook failed during boot: Cannot find module '../../src/lib/localDb.js'
  ```

  One-line fix: use `.ts`, matching the sibling import one line above it.

- **Update (second commit):** fixes the dev-boot bug above but doesn't fix `npm run build`, which was still red for a separate reason — thanks @jonlwheat2-gif for the full diagnosis and verified fix in the review comments. `open-sse/config/providers/registry/aihorde/imageModels.ts` statically imports `open-sse/services/aihordeImageCatalog.ts`, which pulls in `safeOutboundFetch -> featureFlags -> db/core -> better-sqlite3`. `imageRegistry.ts` (which imports `imageModels.ts`) is reachable from the `"use client"` `ProviderDetailPageClient.tsx` dashboard page via `mediaServiceKinds.ts -> serviceKindIndex.ts`, so the whole server DB/network stack was getting dragged into the browser bundle — Turbopack reported 28 `Module not found` errors (`fs`/`net`/`tls`/...) across the reachable server graph. `imageModels.ts` no longer imports the catalog service directly; it holds a module-level snapshot that the server-side Horde poller pushes into via a new `setAiHordeImageCatalogEntries()` setter, called from `replace()`/`clear()` after every snapshot change. No behavior change — server-side the registry still reflects the live catalog, client-side the model list was always empty before this too (the browser can neither poll Horde nor reach the DB).

## Related Issues

- Closes #10674

## Validation

- Change type: build-deploy (dev-server boot resolution + client-bundle isolation; no runtime logic changed)
- `npx eslint` on all touched files: clean
- lint-staged pre-commit (prettier + eslint --fix + docs-sync + t11 any-budget): passed
- Reconciled with `release/v3.8.50` tip (`df9059141`)
- `npm run build`: before the second commit, `Turbopack build failed with 28 errors` (reproduced against a pristine checkout + fresh `npm ci`, matching @jonlwheat2-gif's report exactly). After: `✓ Compiled successfully`, 0 errors.
- `tests/unit/aihorde-*.test.ts` (5 files, the full AI Horde suite): 29/29 pass via `node --test`.

## Tests Added Or Updated

- None new. The `imageModels.ts` / `aihordeImageCatalog.ts` refactor is a wiring change (push instead of pull) with identical runtime behavior on both ends; the existing `tests/unit/aihorde-image-catalog.test.ts` and `tests/unit/aihorde-image-generation.test.ts` already cover `getCachedAiHordeImageCatalogEntries()` and the registry entry shape, and both pass unmodified against the refactor.

## Coverage Notes

- No coverage impact for the first (import-extension) commit — file content and exports are otherwise unchanged.
- Second commit is a pure indirection change (setter/getter instead of direct call) behind the same existing test coverage; no new branches introduced.

## Reviewer Notes

- Live-verified against a fresh `npm ci` + `npm run dev` on `release/v3.8.50` tip (`df9059141`): before this change, boot failed with the `Cannot find module` error above; after, the dev server listens and `GET /api/health/ping` returns `200 {"status":"ok",...}`.
- #10674's own A/B table already isolates the dev-boot issue to the dependency lockfile change in #10647 rather than any code regression, so the first commit is purely a resolver-compatibility fix, not a workaround for changed application behavior.
- The second commit's diagnosis and fix were authored by @jonlwheat2-gif in the PR review comments; this commit re-verifies the repro and diff against the current tree (28 -> 0 build errors, confirmed directly) before applying it, rather than taking the comment on faith.

