### PR TITLE
test(mcp): declara a precondição de env dos testes de principal do CCR/MCP

### DIFF
--- a/tests/unit/compression/ccr-mcp-integration.test.ts
+++ b/tests/unit/compression/ccr-mcp-integration.test.ts
@@ -1,10 +1,28 @@
-import { describe, it, beforeEach } from "node:test";
+import { describe, it, beforeEach, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-ccr-mcp-"));
+
+// `resolveCcrPrincipal` dá precedência a `resolveMcpCallerApiKeyId()`, que cai em
+// `OMNIROUTE_API_KEY`/`ROUTER_API_KEY` no transporte stdio. Estes testes gravam blocos
+// com um principal LITERAL ("tenant-a") e leem pelos handlers MCP: com a env presente no
+// shell, o handler resolve um principal diferente e todo bloco vira "not found" — red
+// fantasma que não reproduz no CI, onde a env não existe. A precondição era implícita;
+// aqui ela passa a ser declarada. Mesmo idioma de api-key-lifecycle e cli-remote-mode.
+const ORIGINAL_OMNIROUTE_API_KEY = process.env.OMNIROUTE_API_KEY;
+const ORIGINAL_ROUTER_API_KEY = process.env.ROUTER_API_KEY;
+delete process.env.OMNIROUTE_API_KEY;
+delete process.env.ROUTER_API_KEY;
+
+after(() => {
+  if (ORIGINAL_OMNIROUTE_API_KEY === undefined) delete process.env.OMNIROUTE_API_KEY;
+  else process.env.OMNIROUTE_API_KEY = ORIGINAL_OMNIROUTE_API_KEY;
+  if (ORIGINAL_ROUTER_API_KEY === undefined) delete process.env.ROUTER_API_KEY;
+  else process.env.ROUTER_API_KEY = ORIGINAL_ROUTER_API_KEY;
+});
 
 const ccr = await import("../../../open-sse/services/compression/engines/ccr/index.ts");
 const tools = await import("../../../open-sse/mcp-server/tools/compressionTools.ts");

--- a/tests/unit/mcp-extra-forward-6178.test.ts
+++ b/tests/unit/mcp-extra-forward-6178.test.ts
@@ -18,6 +18,22 @@ import assert from "node:assert/strict";
 // call. If `extra` is dropped, the caller resolves to "anonymous", the store key
 // misses, and retrieval errors out.
 
+// A precondição deste teste é que NÃO exista um principal de API key resolvível: ele
+// prova que o `extra` chega ao handler comparando o principal derivado de `clientId`. Com
+// `OMNIROUTE_API_KEY` no shell, `resolveMcpCallerApiKeyId()` resolve primeiro e mascara
+// exatamente o que o teste mede — red fantasma local que não reproduz no CI.
+const ORIGINAL_OMNIROUTE_API_KEY = process.env.OMNIROUTE_API_KEY;
+const ORIGINAL_ROUTER_API_KEY = process.env.ROUTER_API_KEY;
+delete process.env.OMNIROUTE_API_KEY;
+delete process.env.ROUTER_API_KEY;
+
+test.after(() => {
+  if (ORIGINAL_OMNIROUTE_API_KEY === undefined) delete process.env.OMNIROUTE_API_KEY;
+  else process.env.OMNIROUTE_API_KEY = ORIGINAL_OMNIROUTE_API_KEY;
+  if (ORIGINAL_ROUTER_API_KEY === undefined) delete process.env.ROUTER_API_KEY;
+  else process.env.ROUTER_API_KEY = ORIGINAL_ROUTER_API_KEY;
+});
+
 const { createMcpServer } = await import("../../open-sse/mcp-server/server.ts");
 const { storeBlock, resetCcrStore } = await import(
   "../../open-sse/services/compression/engines/ccr/index.ts"


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## O `ccr-mcp-integration` não era um vermelho da base

Ele foi reportado no #10655 como o terceiro base-red pendente. **Estava errado.** A
investigação levou a um vazamento de ambiente, não a um defeito do repositório — e a
correção é declarar a precondição que os testes já assumiam em silêncio.

## Causa

`resolveCcrPrincipal` (`open-sse/mcp-server/tools/compressionTools.ts`) dá precedência a
`resolveMcpCallerApiKeyId()` sobre o `clientId` do `extra`. No transporte stdio essa função
cai em `resolvePrincipalFromEnv()`, que lê `OMNIROUTE_API_KEY` / `ROUTER_API_KEY`.

Dois testes gravam blocos CCR com um principal **literal** e leem pelos handlers MCP:

- `tests/unit/compression/ccr-mcp-integration.test.ts` — `tryStoreBlock(content, "tenant-a")`
  seguido de `handleCcrRetrieveTool({hash}, {authInfo:{clientId:"tenant-a"}})`;
- `tests/unit/mcp-extra-forward-6178.test.ts` — guarda de regressão que prova que o `extra`
  chega ao handler, comparando justamente o principal derivado de `clientId`.

Com a variável presente no shell, o handler resolve **outro** principal, o lookup erra o
bucket e todo bloco vira `found: false`. O `mcp-extra-forward-6178` é ainda mais irônico: a
env mascara exatamente aquilo que ele mede.

## Por que passa no CI e falha localmente

O runner não tem `OMNIROUTE_API_KEY`; o devbox tem. Por isso este vermelho **nunca apareceu
em nenhuma execução de CI** — inclusive na do #10655, onde eu o havia listado como pendente.
É um red que só existe na máquina do desenvolvedor, e que consumiu uma investigação inteira
antes de a causa aparecer.

## Correção

Nenhum código de produção mudou — não havia defeito de produção. A precondição já existia;
agora está escrita, no mesmo idioma já usado em `api-key-lifecycle.test.ts`,
`cli-remote-mode.test.ts` e no irmão `ccr-mcp-principal-5649.test.ts` (que aprendeu a mesma
lição no #7883): salvar o valor, remover no topo do arquivo, restaurar no `after`.

## Validação

Executado no worktree cortado de `origin/release/v3.8.50` (`df905914`):

| Cenário | Antes | Depois |
| --- | --- | --- |
| Os 3 arquivos de principal CCR/MCP, **com** a env no shell | 1 falha | 23/23 |
| Os mesmos, **sem** a env (como o CI) | 23/23 | 23/23 |
| `tests/unit/compression/*.test.ts` num shell com a env | 1408/1410 | **1433/1433** |
| ESLint nos arquivos alterados | — | PASS |

Passar nos dois ambientes é o ponto: a mudança declara a precondição, não afrouxa a
asserção.

## Nota de processo

Vale como precedente registrado: ao investigar um vermelho local que o CI não reproduz,
comparar antes de tudo com `env -u OMNIROUTE_API_KEY -u ROUTER_API_KEY`. Um teste que
depende da ausência de uma variável de ambiente e não declara isso vira red fantasma para
qualquer pessoa cujo shell a exporte.


## Vermelhos do CI deste PR — todos herdados

O tip da base (`df905914`) entrou em storm depois que este PR foi aberto. Os PRs abertos no
mesmo período mostram o mesmo padrão:

| PR | Falhas | Sucessos |
| --- | --- | --- |
| #10683 | 10 | 5 |
| #10684 | 10 | 5 |
| #10685 | 10 | 5 |
| #10686 | 10 | 5 |
| #10687 | 11 | 4 |
| **#10689 (este)** | **11** | **8** |

Nenhum dos arquivos alterados aqui aparece em qualquer log de falha (verificado por varredura
sobre os logs dos dois runs vermelhos: zero ocorrências de `ccr-mcp-integration` e
`mcp-extra-forward-6178`). Os testes que caem são `antigravity-model-aliases`,
`glm-provider-model-import-route`, `cc-compatible-provider`, `chatcore-translation-paths`,
`chat-messages-validation-6402`, `executor-qwen-web`, `check-docs-counts-sync`,
`check-env-doc-sync` e `check-fabricated-docs`, além dos gates `error-helper`,
`mutation-test-coverage`, `dead-code` e `open-sse-typecheck`.

Localmente, na base `df905914` e com a env vazada presente, os arquivos deste PR fecham
23/23 e a pasta `tests/unit/compression` fecha 1433/1433.
