### PR TITLE
fix(sse): import localDb through its real .ts extension (#10674)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -87,7 +87,7 @@ import { selectQuotaShareTarget } from "./combo/quotaShareStrategy.ts";
 import { makeConnectionConcurrencyResolver, lookupPositiveCap } from "./combo/concurrencyCaps.ts";
 import { acquireQuotaShareConcurrencySlot } from "./combo/quotaShareConcurrency.ts";
 import { canAffordRequest } from "../../src/lib/quota/quotaScheduler.ts";
-import { getCachedProviderConnectionById } from "../../src/lib/localDb.js";
+import { getCachedProviderConnectionById } from "../../src/lib/localDb.ts";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
 
 /**
@@ -1190,7 +1190,6 @@ export async function handleComboChat({
             if (i > 0) fallbackCount++;
             return stopProtectedPriorityTarget(`Connection capacity reached for ${modelStr}`);
           }
-
         }
 
         // #9654 Wave 2: per-target lane-aware admission probe. With virtual

--- a/src/lib/usage/usageLedger.ts
+++ b/src/lib/usage/usageLedger.ts
@@ -1,4 +1,4 @@
-import type { ModelPricingRegistry } from "./modelPricingRegistry.js";
+import type { ModelPricingRegistry } from "./modelPricingRegistry.ts";
 
 export type UsageStatus = "success" | "failed" | "rate_limited" | "timeout" | "cancelled";
 

--- a/tests/unit/no-js-extension-on-repo-imports-10674.test.ts
+++ b/tests/unit/no-js-extension-on-repo-imports-10674.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * #10674: `open-sse/services/combo.ts` imported `"../../src/lib/localDb.js"` — a
+ * `.js` suffix on a file that only exists as `.ts`. Turbopack used to resolve it
+ * anyway; after the dependency-tree change in #10647 it stopped, and the
+ * instrumentation hook died at boot with MODULE_NOT_FOUND, taking down `npm run dev`
+ * and the production build (60 consecutive red `Build App` runs).
+ *
+ * A `.js` specifier is legitimate for npm packages that publish ESM that way
+ * (e.g. `@modelcontextprotocol/sdk/client/index.js`) — this guard only rejects
+ * RELATIVE specifiers, which always point at first-party TypeScript here.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function relativeJsImports(): string[] {
+  let out = "";
+  try {
+    out = execFileSync(
+      "git",
+      ["grep", "-n", "-E", 'from "\\.{1,2}/[^"]*\\.js"', "--", "open-sse/**/*.ts", "src/**/*.ts"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    );
+  } catch (err) {
+    // git grep exits 1 with no output when nothing matches — that is the clean state.
+    if ((err as { status?: number }).status === 1) return [];
+    throw err;
+  }
+  return out.split("\n").filter((line) => line.trim().length > 0);
+}
+
+test("no first-party TypeScript module is imported through a .js specifier", () => {
+  const offenders = relativeJsImports();
+  assert.deepEqual(
+    offenders,
+    [],
+    `Relative imports must use the real .ts extension — a .js suffix resolves only by ` +
+      `bundler accident and breaks boot when the toolchain changes (#10674):\n${offenders.join("\n")}`
+  );
+});


### PR DESCRIPTION
Closes #10674.

## Root cause

`open-sse/services/combo.ts:90` imported `"../../src/lib/localDb.js"` — a `.js` suffix on a
module that only ever existed as `.ts`. Turbopack resolved it by accident; the dependency-tree
change in #10647 stopped doing so, and the instrumentation hook then died at boot with
`MODULE_NOT_FOUND`.

Every sibling import in that same file already uses `.ts`, so this was a one-off slip, not a
convention.

## Impact this was causing

- `npm run dev` on the tip could not boot at all (the symptom #10674 reports).
- **`Build App` has been red for 60 consecutive runs** on `release/v3.8.50` — every run
  available through the API, none green. The failure cascades: once `combo.ts` fails to
  resolve, Next reports 29 `Module not found` errors, including Node builtins
  (`child_process`, `dns`, `fs`, `tls`, `net`, `module`) pulled into the Middleware/Instrumentation
  graphs. All 29 come from this single unresolved import.
- `Deploy to VPS` has been skipping as a consequence.

## Validation

Before/after on the tip (`df90591415`), fresh `npm ci`, `.build/next/dev` cache cleared:

| | result |
| --- | --- |
| before | `Fatal: instrumentation hook failed during boot: Cannot find module '../../src/lib/localDb.js'` |
| after | boots fully — migrations, schedulers, proxy-health all start; **0** `Module not found` |

`typecheck:core` clean, `eslint` clean on all three files.

## Second offender found by the guard

`src/lib/usage/usageLedger.ts:1` had the same `.js`-on-a-`.ts` pattern. It never broke because
it is an `import type`, erased before resolution — a latent copy of the same bug, fixed here.

## Guard

`tests/unit/no-js-extension-on-repo-imports-10674.test.ts` rejects **relative** `.js` specifiers
across `open-sse/` and `src/`. Package specifiers stay allowed on purpose: publishing ESM under
`.js` is correct for real packages (`@modelcontextprotocol/sdk/client/index.js` and 25 others
in-tree). Proven to discriminate — re-introducing the `.js` suffix makes it fail, naming the
exact file and line.
