### PR TITLE
test(ci): clear release gate regressions

### DIFF
--- a/tests/unit/autoCombo/provider-family-combos.test.ts
+++ b/tests/unit/autoCombo/provider-family-combos.test.ts
@@ -144,7 +144,16 @@ describe("auto/<family> materialization (#6453)", () => {
     // `zcode` joined for the same documented reason too — #10184 added the local
     // ZCode app-server backend whose registry (registry/zcode) advertises the
     // full GLM_SHARED_MODELS line-up, so it genuinely serves the family.
-    assert.deepEqual(providerIds, ["auggie", "devin-cli-agentic", "glm", "zai", "zcode"]);
+    // cloudflare-playground advertises zai-org/glm-* models, so its no-auth
+    // catalog belongs in auto/glm too.
+    assert.deepEqual(providerIds, [
+      "auggie",
+      "cloudflare-playground",
+      "devin-cli-agentic",
+      "glm",
+      "zai",
+      "zcode",
+    ]);
     // Every candidate must be a glm-family model (the Cartesian pool now surfaces
     // each backend's full glm line-up, not only the glm-5.2 default), and the
     // connected openai/gpt-4o-mini backend must be excluded — same family

--- a/tests/unit/cli-oauth-commands.test.ts
+++ b/tests/unit/cli-oauth-commands.test.ts
@@ -100,11 +100,13 @@ test("runOAuthStatus consumes the connections envelope", async () => {
   globalThis.fetch = ((url: string) => {
     assert.ok(url.includes("/api/providers"));
     return Promise.resolve(makeResp({ connections: CONNECTIONS }));
-  }) as any;
+  }) as typeof fetch;
 
   try {
     const { runOAuthStatus } = await import("../../bin/cli/commands/oauth.mjs");
-    const out = await captureStdout(() => runOAuthStatus({}, makeCmd() as any));
+    const out = await captureStdout(() =>
+      runOAuthStatus({}, makeCmd() as Parameters<typeof runOAuthStatus>[1])
+    );
     const parsed = JSON.parse(out);
     assert.deepEqual(
       parsed.map((connection: { id: string }) => connection.id),

--- a/tests/unit/executor-gitlab.test.ts
+++ b/tests/unit/executor-gitlab.test.ts
@@ -305,7 +305,10 @@ test("GitlabExecutor falls back to the public Code Suggestions endpoint when dir
       "https://gitlab.example.com/api/v4/code_suggestions/completions",
     ]);
 
-    const body = (await result.response.json()) as any;
+    const body = (await result.response.json()) as {
+      model: string;
+      choices: Array<{ message: { content: string } }>;
+    };
     assert.equal(body.model, "code-gecko");
     assert.match(body.choices[0].message.content, /monolith fallback works/i);
   } finally {


### PR DESCRIPTION
Two unrelated changes landed on `release/v3.8.50` with their regression tests, but left the shared CI branch red:

- `cloudflare-playground` began advertising two GLM models while the exact `auto/glm` provider assertion still expected the old five-provider pool
- the new CLI OAuth and GitLab fallback tests added three `any` casts, pushing both files past their frozen ESLint suppression counts and exposing all 25 violations in the lint report

This PR keeps those release-branch repairs out of #10682 through #10686.

## what changed

- include `cloudflare-playground` in the exact `auto/glm` provider set
- replace only the three newly introduced `any` casts with inferred or structural types
- leave production code and the existing ESLint suppression baseline unchanged

## how to test

```sh
npm run test:vitest -- tests/unit/autoCombo/provider-family-combos.test.ts
node --import tsx --test-name-pattern='runOAuthStatus consumes the connections envelope' tests/unit/cli-oauth-commands.test.ts
node --import tsx --test-name-pattern='direct_access returns 401' tests/unit/executor-gitlab.test.ts
npm run lint:json -- --max-warnings 0
```

The focused tests pass, the full Vitest suite passes `368/368`, and the repository-wide no-new-warnings gate passes locally.

## current release-branch blockers

The fresh GitHub run confirms this branch's build, Vitest, ESLint, metrics collection, and quality-ratchet phases pass. The workflow is still red on release-wide state outside these three files:

- the final step of the job named `No new ESLint warnings` sees 13 open CodeQL alerts against a baseline of 9
- all four native-test shards fail on unrelated Antigravity, Qwen, i18n, SSE, model-sync, OpenRouter, and usage-history tests
- `Fast Quality Gates` reports inherited `error-helper`, mutation-coverage, dead-code, and open-sse typecheck failures

The same failures are present on the sibling PRs based on this release tip. None of #10693's three touched tests appears in the failed native-test lists.
