### PR TITLE
fix(skills): regenerate the CLI skills the quota subcommands left stale

### DIFF
--- a/skills/cli-resilience/SKILL.md
+++ b/skills/cli-resilience/SKILL.md
@@ -30,6 +30,40 @@ omniroute --version
 omniroute quota
 ```
 
+### `quota status`
+
+Show truthful OmniRoute gateway, quota, pool, and circuit state
+
+**Example:**
+
+```bash
+omniroute quota status
+```
+
+### `quota preview`
+
+Preview allocation enforcement without an upstream request
+
+**Flags:**
+
+- `--tokens <n>`
+
+**Example:**
+
+```bash
+omniroute quota preview
+```
+
+### `quota ensure <json>`
+
+Idempotently create or update a quota pool from a JSON object
+
+**Example:**
+
+```bash
+omniroute quota ensure <json>
+```
+
 ### `resilience`
 
 **Example:**

--- a/skills/omni-inference/SKILL.md
+++ b/skills/omni-inference/SKILL.md
@@ -14,6 +14,24 @@ All requests require a valid Bearer token or session cookie. Obtain a token via 
 
 ## Endpoints
 
+### POST /api/v1/session-leases
+
+Acquire, renew, or release an exclusive managed connection lease
+
+Requires an API key with `lease:exclusive` and an explicit non-empty
+`allowedConnections` policy. The opaque owner is bound to the authenticated API key;
+the lease owns an eligible connection, not a provider or model. Managed inference
+requests present the owner and exact generation headers. Temporary foreign occupancy
+returns 429 `WAITING_FOR_CAPACITY` with `Retry-After`.
+
+
+```bash
+curl -X POST https://localhost:20128/api/v1/session-leases \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 ### POST /api/v1/chat/completions
 
 Create chat completion
@@ -107,6 +125,28 @@ Create embeddings
 
 ```bash
 curl -X POST https://localhost:20128/api/v1/embeddings \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### GET /api/v1/multimodal-embeddings
+
+List embedding models (Jina multimodal-embeddings alias)
+
+```bash
+curl https://localhost:20128/api/v1/multimodal-embeddings \
+  -H "Authorization: Bearer $OMNIROUTE_TOKEN"
+```
+
+### POST /api/v1/multimodal-embeddings
+
+Create embeddings (Jina multimodal-embeddings alias)
+
+Same handler as `POST /api/v1/embeddings`. Provided so Jina-compatible clients that call `/v1/multimodal-embeddings` do not receive HTTP 404 `unknown_route`.
+
+```bash
+curl -X POST https://localhost:20128/api/v1/multimodal-embeddings \
   -H "Authorization: Bearer $OMNIROUTE_TOKEN"
   -H "Content-Type: application/json" \
   -d '{}'


### PR DESCRIPTION
## Base-red, not a branch defect

`Merge integrity (changelog + generated skills)` → `check:agent-skills-sync` fails on the
release tip itself. Reproduced on a **pristine checkout of `22b89a273b`** with zero local
changes:

```
Generated: 2 · Unchanged: 44 · Pruned: 0 · Orphans: 0 · Errors: 0
  GENERATED:
    + omni-inference
    + cli-resilience
```

Exit code 2 = "dry-run detected changes", so every PR cut from this branch inherits the red.

## Cause

`quota status`, `quota preview` and `quota ensure` were added to the CLI catalog without
re-running the generator, so the committed `SKILL.md` files drifted from it.

## Change

`node --import tsx/esm scripts/skills/generate-agent-skills.mjs --apply` — generated output,
no hand edits. Purely additive: the three subcommands gain their sections, nothing is removed
or reworded.

## Verification

`npm run check:agent-skills-sync` → `Generated: 0 · Unchanged: 46` after the change.

Separate from the OmniGlyph base-red tracked in #9985.