### PR TITLE
fix(cline): label OmniRoute health checks as internal

### DIFF
--- a/src/shared/utils/clineAuth.ts
+++ b/src/shared/utils/clineAuth.ts
@@ -13,6 +13,8 @@ import { randomUUID } from "node:crypto";
 import { APP_CONFIG } from "../constants/appConfig";
 
 const APP_VERSION = APP_CONFIG.version;
+const DEFAULT_CLINE_CLIENT_TYPE = "omniroute";
+const INTERNAL_HEALTH_CHECK_CLIENT_TYPE = "omniroute-internal-health-check";
 
 export interface ClineHeaderContext {
   taskId?: string;
@@ -44,6 +46,12 @@ export function resolveClineTaskId(clientHeaders?: Record<string, string> | null
   return getHeaderCaseInsensitive(clientHeaders, "x-task-id") ?? randomUUID();
 }
 
+function resolveClineClientType(clientHeaders?: Record<string, string> | null): string | undefined {
+  return getHeaderCaseInsensitive(clientHeaders, "x-internal-test") === "combo-health-check"
+    ? INTERNAL_HEALTH_CHECK_CLIENT_TYPE
+    : undefined;
+}
+
 /**
  * Apply the required Cline billing headers with case-insensitive replacement.
  * These fields are authoritative in the official client and must win over
@@ -58,12 +66,18 @@ export function applyClineProtocolHeaders(
     getHeaderCaseInsensitive(headers, "x-task-id") ??
     randomUUID();
   const clientVersion = cleanHeaderValue(context.clientVersion) ?? APP_VERSION;
+  const existingClientType = getHeaderCaseInsensitive(headers, "x-client-type");
+  const clientType =
+    cleanHeaderValue(context.clientType) ??
+    (existingClientType === INTERNAL_HEALTH_CHECK_CLIENT_TYPE
+      ? INTERNAL_HEALTH_CHECK_CLIENT_TYPE
+      : DEFAULT_CLINE_CLIENT_TYPE);
   const required: Record<string, string> = {
     "HTTP-Referer": "https://cline.bot",
     "X-Title": "Cline",
     "User-Agent": `Cline/${clientVersion}`,
     "X-IS-MULTIROOT": context.isMultiRoot === true ? "true" : "false",
-    "X-CLIENT-TYPE": cleanHeaderValue(context.clientType) ?? "omniroute",
+    "X-CLIENT-TYPE": clientType,
     "X-CLIENT-VERSION": clientVersion,
     "X-PLATFORM": cleanHeaderValue(context.platform) ?? process.platform ?? "unknown",
     "X-PLATFORM-VERSION": cleanHeaderValue(context.platformVersion) ?? process.version ?? "unknown",
@@ -159,7 +173,10 @@ export function applyClineAuthHeaders(
   clientHeaders: Record<string, string> | null | undefined,
   isClinepass: boolean
 ): Record<string, string> {
-  const context: ClineHeaderContext = { taskId: resolveClineTaskId(clientHeaders) };
+  const context: ClineHeaderContext = {
+    taskId: resolveClineTaskId(clientHeaders),
+    clientType: resolveClineClientType(clientHeaders),
+  };
   const built = isClinepass
     ? buildClinepassHeaders(credentials, effectiveKey, context)
     : buildClineHeaders(effectiveKey || credentials?.accessToken, {}, context);

--- a/tests/unit/cline-workos-auth-token-shape.test.ts
+++ b/tests/unit/cline-workos-auth-token-shape.test.ts
@@ -110,3 +110,16 @@ test("DefaultExecutor.buildHeaders uses the cline workos auth token shape", () =
   assert.equal(headers["X-Title"], "Cline");
   assert.equal(headers["X-Task-ID"], "task-from-client");
 });
+
+test("DefaultExecutor labels internal health checks separately from user traffic", () => {
+  const executor = new DefaultExecutor("cline");
+  const headers = executor.buildHeaders({ apiKey: "tok-abc" }, true, {
+    "X-Internal-Test": "combo-health-check",
+  });
+
+  assert.equal(headers["X-CLIENT-TYPE"], "omniroute-internal-health-check");
+
+  // BaseExecutor reapplies the required protocol headers immediately before dispatch.
+  applyClineProtocolHeaders(headers, { taskId: headers["X-Task-ID"] });
+  assert.equal(headers["X-CLIENT-TYPE"], "omniroute-internal-health-check");
+});


### PR DESCRIPTION
## Problema

As verificações de integridade de modelos e combos do OmniRoute já se identificam com:

```http
X-Internal-Test: combo-health-check
```

Quando uma dessas verificações é encaminhada pelo Cline, o construtor de headers do Cline atualmente a identifica com o mesmo valor `X-CLIENT-TYPE: omniroute` usado pelo tráfego normal de usuários. Por isso, a telemetria downstream não consegue distinguir as verificações internas do OmniRoute das requisições de usuários.

## Alteração

- mapeia o marcador existente `combo-health-check` para `X-CLIENT-TYPE: omniroute-internal-health-check`
- mantém o tráfego normal do Cline/ClinePass inalterado como `X-CLIENT-TYPE: omniroute`
- preserva a identificação interna quando o executor reaplica os headers obrigatórios do Cline imediatamente antes do envio

Esta alteração não adiciona nenhum header ou campo no banco de dados e não modifica o corpo das requisições, o roteamento, a autenticação, o faturamento ou os IDs de tarefa.

## Teste

```bash
node --import tsx/esm --test tests/unit/cline-workos-auth-token-shape.test.ts
```

O teste de regressão falhava antes da implementação (`omniroute` em vez de `omniroute-internal-health-check`) e passou depois dela (12/12).

Também passaram:

```bash
npm run typecheck:core
npx prettier --check src/shared/utils/clineAuth.ts tests/unit/cline-workos-auth-token-shape.test.ts
npx eslint src/shared/utils/clineAuth.ts tests/unit/cline-workos-auth-token-shape.test.ts --suppressions-location config/quality/eslint-suppressions.json
```

⚠️ Estado `base-red` herdado: #9985. A suíte ampla de testes unitários não é usada como evidência neste PR; caminhos não relacionados da branch base falharam localmente, enquanto o teste de regressão focado e as verificações principais acima estão passando.
