### PR TITLE
fix(agent-bridge): make the regenerate-cert endpoint actually mint a new cert (#10467)

### DIFF
--- a/src/app/api/tools/agent-bridge/cert/regenerate/route.ts
+++ b/src/app/api/tools/agent-bridge/cert/regenerate/route.ts
@@ -9,11 +9,10 @@ import { createErrorResponse } from "@/lib/api/errorResponse";
 
 export async function POST(): Promise<Response> {
   try {
-    // generateCert checks for existing files — force-regenerate by deleting first
-    // is not in scope; the function is idempotent (returns existing paths). If a
-    // caller needs a fresh cert they must delete the old one manually. We expose
-    // whatever generateCert decides.
-    const result = await generateCert();
+    // #10467: generateCert() returns the existing paths untouched when a cert is already
+    // on disk, which made this endpoint a no-op — the download still served the old file.
+    // This route is the one caller that must always mint a fresh cert.
+    const result = await generateCert({ force: true });
     return Response.json({ ok: true, certPath: result.cert, keyPath: result.key });
   } catch (err) {
     const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));

--- a/src/mitm/cert/generate.ts
+++ b/src/mitm/cert/generate.ts
@@ -16,12 +16,17 @@ const TARGET_HOST = TARGET_HOSTS[0];
 /**
  * Generate self-signed SSL certificate using selfsigned (pure JS, no openssl needed)
  */
-export async function generateCert(): Promise<{ key: string; cert: string }> {
+export async function generateCert(options?: {
+  force?: boolean;
+}): Promise<{ key: string; cert: string }> {
   const certDir = path.join(resolveMitmDataDir(), "mitm");
   const keyPath = path.join(certDir, "server.key");
   const certPath = path.join(certDir, "server.crt");
 
-  if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+  // #10467: callers that only need a cert to exist keep the existing one, but the
+  // regenerate endpoint has to actually mint a new one — otherwise a cert missing the
+  // SANs added in #6494 can never be replaced from the UI.
+  if (!options?.force && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
     console.log("✅ SSL certificate already exists");
     return { key: keyPath, cert: certPath };
   }

--- a/tests/unit/agent-bridge-cert-regenerate-force-10467.test.ts
+++ b/tests/unit/agent-bridge-cert-regenerate-force-10467.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { X509Certificate } from "node:crypto";
+
+// #10467: POST /api/tools/agent-bridge/cert/regenerate called generateCert() with no
+// arguments. generateCert() short-circuits when server.key and server.crt already exist,
+// so the endpoint was a no-op on every machine that had ever started the bridge — the
+// download route kept serving the old file, with the same md5 and, for anyone whose cert
+// predates #6494, still missing the extra SANs. generateCert now takes { force } and the
+// regenerate route is the one caller that passes it.
+
+const certModule = "../../src/mitm/cert/generate.ts";
+
+async function withTempDataDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-cert-10467-"));
+  const previous = process.env.DATA_DIR;
+  process.env.DATA_DIR = dir;
+  try {
+    return await fn(dir);
+  } finally {
+    if (previous === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const read = (p: string) => fs.readFileSync(p, "utf8");
+
+test("generateCert() keeps the existing certificate when it is already on disk", async () => {
+  await withTempDataDir(async () => {
+    const { generateCert } = await import(certModule);
+
+    const first = await generateCert();
+    const certBefore = read(first.cert);
+    const keyBefore = read(first.key);
+
+    const second = await generateCert();
+
+    assert.equal(second.cert, first.cert, "path should be stable");
+    assert.equal(read(second.cert), certBefore, "certificate should not be replaced");
+    assert.equal(read(second.key), keyBefore, "key should not be replaced");
+  });
+});
+
+test("generateCert({ force: true }) mints a new certificate over the existing one", async () => {
+  await withTempDataDir(async () => {
+    const { generateCert } = await import(certModule);
+
+    const first = await generateCert();
+    const certBefore = read(first.cert);
+    const keyBefore = read(first.key);
+
+    const forced = await generateCert({ force: true });
+
+    assert.equal(forced.cert, first.cert, "path should be stable");
+    assert.notEqual(read(forced.cert), certBefore, "certificate should be replaced");
+    assert.notEqual(read(forced.key), keyBefore, "key should be replaced");
+  });
+});
+
+test("the forced certificate is still valid and carries every antigravity SAN", async () => {
+  await withTempDataDir(async () => {
+    const { generateCert } = await import(certModule);
+    const { ANTIGRAVITY_TARGET } = await import("../../src/mitm/targets/antigravity.ts");
+
+    await generateCert();
+    const forced = await generateCert({ force: true });
+
+    const x509 = new X509Certificate(fs.readFileSync(forced.cert));
+    const sans = (x509.subjectAltName ?? "")
+      .split(",")
+      .map((entry) => entry.trim().replace(/^DNS:/, ""))
+      .filter(Boolean);
+
+    for (const host of ANTIGRAVITY_TARGET.hosts) {
+      assert.ok(sans.includes(host), `forced cert is missing SAN for ${host}`);
+    }
+  });
+});
+
+test("generateCert({ force: true }) creates the certificate when none exists yet", async () => {
+  await withTempDataDir(async () => {
+    const { generateCert } = await import(certModule);
+
+    const result = await generateCert({ force: true });
+
+    assert.ok(fs.existsSync(result.cert), "certificate should exist");
+    assert.ok(fs.existsSync(result.key), "key should exist");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #10467 — "Regenerate Cert does not regenerate the cert".

`POST /api/tools/agent-bridge/cert/regenerate` called `generateCert()` with no arguments, and `generateCert()` short-circuits whenever both files already exist:

```ts
if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
  console.log("✅ SSL certificate already exists");
  return { key: keyPath, cert: certPath };
}
```

So on any machine that had already started the bridge the endpoint was a no-op. It still answered `{ ok: true }` with the two paths, which is why the UI reported success while `/cert/download` kept serving the identical file — matching the reporter's observation that the md5 never changed and the SANs added in #6494 never appeared.

The route's own comment documented this as intentional ("the function is idempotent … If a caller needs a fresh cert they must delete the old one manually"), but that leaves the regenerate button with nothing to do, and there is no other UI path to delete the cert.

## Change

`generateCert` takes an opt-in `{ force }`, and the regenerate route is the one caller that passes it.

The other three callers only need a certificate to *exist* — `src/app/api/settings/mitm/route.ts`, `src/app/api/tools/agent-bridge/server/route.ts` and `src/mitm/manager.ts` — so they keep the existing short-circuit and are untouched. Nothing regenerates a cert that used to be reused.

## Tests

New file `tests/unit/agent-bridge-cert-regenerate-force-10467.test.ts`, 4 cases, `node:test` to match the sibling `agent-bridge-cert-*` tests. Each case runs against its own temp `DATA_DIR`, so no test touches the real cert store.

| Case | Asserts |
|---|---|
| `generateCert()` with a cert on disk | file contents unchanged — the reuse path is preserved |
| `generateCert({ force: true })` with a cert on disk | both cert and key contents differ — the actual fix |
| forced cert is well-formed | parses as `X509Certificate` and carries a SAN for every `ANTIGRAVITY_TARGET.hosts` entry, so a forced cert can't silently regress #6494 |
| `generateCert({ force: true })` with nothing on disk | still creates both files |

The suite pins the bug rather than describing the fix — against the unpatched `generate.ts`, exactly the one case that targets it fails:

```
ℹ tests 4
ℹ pass 3
ℹ fail 1
  AssertionError [ERR_ASSERTION]: certificate should be replaced
```

With the patch: `pass 4, fail 0`.

## Commands run

```
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts \
     --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit \
     tests/unit/agent-bridge-cert-regenerate-force-10467.test.ts
  → tests 4, pass 4, fail 0

# regression over every cert/mitm unit test, same machine
tests/unit/*cert*.test.ts + tests/unit/*mitm*.test.ts
  before: tests 311, pass 300, fail 10
  after:  tests 315, pass 304, fail 10   (+4 tests, +4 pass, same 10 failures)

npx eslint <the 3 changed files>   → clean
npm run typecheck:core             → clean
npm run check:test-discovery       → OK
npm run check:route-validation:t06 → PASS
npm run check:test-runner-api      → OK
```

The 10 pre-existing failures in that set are environment-bound, not related to this change — they assert POSIX behaviour (`chmod 0644` after `cp`, `umask 0077`, `/etc/hosts` writes, `sudo` fallback) plus two Windows cert-store lookups. The set is identical before and after; only the 4 new tests moved the counts.

I could not run `npm run test:coverage` end to end on this machine — the full runner needs far more than a Windows dev box will finish in reasonable time. The changed production lines are covered by the new tests: the `force` branch and the preserved reuse branch are each asserted directly, and the route's single changed line is the call site.

## Changed files

- `src/mitm/cert/generate.ts` — `{ force }` option
- `src/app/api/tools/agent-bridge/cert/regenerate/route.ts` — pass `{ force: true }`
- `tests/unit/agent-bridge-cert-regenerate-force-10467.test.ts` — new
