### PR TITLE
feat(settings): add reasoning effort model overrides

### DIFF
--- a/changelog.d/features/reasoning-efforts-model-override.md
+++ b/changelog.d/features/reasoning-efforts-model-override.md
@@ -1,0 +1,1 @@
+- **feat(settings):** add a strict comma-separated `reasoning_efforts` Model Override that preserves native `max` and `ultra` tiers across direct and combo catalog metadata (fixes #10563).

--- a/src/app/(dashboard)/dashboard/settings/components/ModelCapabilityOverridesTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ModelCapabilityOverridesTab.tsx
@@ -9,7 +9,9 @@ import {
   type PricingCatalogProvider,
 } from "@/lib/modelCapabilityOverrideTargets";
 
-type ModelOverrideKey = "context_length" | "max_input_tokens" | "max_output_tokens";
+type ModelOverrideKey =
+  "context_length" | "max_input_tokens" | "max_output_tokens" | "reasoning_efforts";
+type ModelOverrideValue = number | string[];
 type StatusTone = "success" | "error" | "info";
 
 type ModelOverrideTarget = import("@/lib/modelCapabilityOverrideTargets").ModelOverrideTarget;
@@ -22,7 +24,7 @@ interface PricingCatalogModel {
 interface ModelCapabilityOverride {
   target: string;
   key: ModelOverrideKey;
-  value: number;
+  value: ModelOverrideValue;
 }
 
 interface StatusMessage {
@@ -70,7 +72,7 @@ function useModelCapabilityOverridesData() {
   }, [showStatus, t]);
 
   const saveOverride = useCallback(
-    async (target: string, key: ModelOverrideKey, value: number) => {
+    async (target: string, key: ModelOverrideKey, value: number | string) => {
       try {
         const response = await fetch("/api/model-capability-overrides", {
           method: "PATCH",
@@ -150,7 +152,7 @@ function ModelCapabilityOverridesPanel({
 }: {
   targets: ModelOverrideTarget[];
   overrides: ModelCapabilityOverride[];
-  onSave: (target: string, key: ModelOverrideKey, value: number) => void;
+  onSave: (target: string, key: ModelOverrideKey, value: number | string) => void;
   onRemove: (target: string, key: ModelOverrideKey) => void;
 }) {
   const [selectedTarget, setSelectedTarget] = useState("");
@@ -294,7 +296,7 @@ function ModelOverrideEditor({
   activeOverrides: ModelCapabilityOverride[];
   activeTarget: string;
   onRemove: (target: string, key: ModelOverrideKey) => void;
-  onSave: (target: string, key: ModelOverrideKey, value: number) => void;
+  onSave: (target: string, key: ModelOverrideKey, value: number | string) => void;
 }) {
   const t = useTranslations("settings");
   return (
@@ -316,13 +318,18 @@ function ModelOverrideForm({
   onSave,
 }: {
   activeTarget: string;
-  onSave: (target: string, key: ModelOverrideKey, value: number) => void;
+  onSave: (target: string, key: ModelOverrideKey, value: number | string) => void;
 }) {
   const t = useTranslations("settings");
   const [key, setKey] = useState<ModelOverrideKey>("context_length");
   const [value, setValue] = useState("");
+  const isReasoningEfforts = key === "reasoning_efforts";
   const numericValue = Number(value);
-  const saveDisabled = !activeTarget || !Number.isInteger(numericValue) || numericValue <= 0;
+  const saveDisabled =
+    !activeTarget ||
+    (isReasoningEfforts
+      ? value.length === 0
+      : !Number.isInteger(numericValue) || numericValue <= 0);
 
   return (
     <div className="flex flex-col sm:flex-row gap-2">
@@ -334,14 +341,19 @@ function ModelOverrideForm({
         <option value="context_length">context_length</option>
         <option value="max_input_tokens">max_input_tokens</option>
         <option value="max_output_tokens">max_output_tokens</option>
+        <option value="reasoning_efforts">reasoning_efforts</option>
       </select>
       <input
-        type="number"
-        min="1"
-        step="1"
+        type={isReasoningEfforts ? "text" : "number"}
+        min={isReasoningEfforts ? undefined : "1"}
+        step={isReasoningEfforts ? undefined : "1"}
         value={value}
         onChange={(event) => setValue(event.target.value)}
-        placeholder={t("modelOverrideValuePlaceholder")}
+        placeholder={t(
+          isReasoningEfforts
+            ? "modelOverrideReasoningEffortsPlaceholder"
+            : "modelOverrideValuePlaceholder"
+        )}
         className="flex-1 px-3 py-2 text-xs bg-bg-base border border-border rounded-md focus:outline-none focus:border-primary"
       />
       <Button
@@ -349,7 +361,7 @@ function ModelOverrideForm({
         size="sm"
         disabled={saveDisabled}
         onClick={() => {
-          onSave(activeTarget, key, numericValue);
+          onSave(activeTarget, key, isReasoningEfforts ? value : numericValue);
           setValue("");
         }}
       >
@@ -398,7 +410,9 @@ function ModelOverrideRow({
     <div className="px-3 py-2 flex items-center justify-between gap-2 text-xs">
       <div className="flex items-center gap-2 min-w-0">
         <span className="font-mono px-1.5 py-0.5 rounded bg-bg-subtle">{override.key}</span>
-        <span className="font-semibold tabular-nums">{override.value}</span>
+        <span className="font-semibold tabular-nums">
+          {Array.isArray(override.value) ? override.value.join(", ") : override.value}
+        </span>
       </div>
       <button
         type="button"

--- a/src/app/api/model-capability-overrides/route.ts
+++ b/src/app/api/model-capability-overrides/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { resolveProviderAlias } from "@omniroute/open-sse/services/model.ts";
+import { parseReasoningEffortsOverride } from "@/shared/reasoning/reasoningEffortsOverride";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import {
   listModelCapabilityOverrides,
@@ -16,9 +17,21 @@ import {
 } from "@/lib/db/modelContextOverrides";
 import { getProviderPrefixIndex, type ProviderPrefixEntry } from "@/lib/providerNodePrefixes";
 
-const overrideKeySchema = z.enum(["context_length", "max_input_tokens", "max_output_tokens"]);
+const overrideKeySchema = z.enum([
+  "context_length",
+  "max_input_tokens",
+  "max_output_tokens",
+  "reasoning_efforts",
+]);
 type PublicOverrideKey = z.infer<typeof overrideKeySchema>;
-type PublicOverride = Omit<ModelCapabilityOverride, "key"> & { key: PublicOverrideKey };
+type PublicOverride = {
+  provider: string;
+  modelId: string;
+  target: string;
+  key: PublicOverrideKey;
+  value: number | string[];
+  refreshedAt: string;
+};
 
 /**
  * One-time per-request snapshot of the provider-node prefix index. Loaded once
@@ -79,11 +92,27 @@ async function listPublicOverrides(
     .sort((left, right) => right.refreshedAt.localeCompare(left.refreshedAt));
 }
 
-const upsertOverrideSchema = z.object({
-  target: z.string().min(3),
-  key: overrideKeySchema,
-  value: z.coerce.number().int().positive(),
+const reasoningEffortsValueSchema = z.string().transform((value, context) => {
+  const parsed = parseReasoningEffortsOverride(value);
+  if (!parsed.ok) {
+    context.addIssue({ code: "custom", message: parsed.error });
+    return z.NEVER;
+  }
+  return parsed.efforts;
 });
+
+const upsertOverrideSchema = z.discriminatedUnion("key", [
+  z.object({
+    target: z.string().min(3),
+    key: z.enum(["context_length", "max_input_tokens", "max_output_tokens"]),
+    value: z.coerce.number().int().positive(),
+  }),
+  z.object({
+    target: z.string().min(3),
+    key: z.literal("reasoning_efforts"),
+    value: reasoningEffortsValueSchema,
+  }),
+]);
 
 /**
  * Canonicalize a public `<prefix>/<model>` target to `<internalNodeId>/<model>`

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -58,9 +58,11 @@ import {
   getCatalogDiagnosticsHeaders,
   type CatalogEnrichmentSnapshot,
 } from "@/lib/modelMetadataRegistry";
+import { createModelCapabilityResolutionSnapshot } from "@/lib/modelCapabilityResolutionSnapshot";
 import { getModelsDevPricing, getSyncedCapability } from "@/lib/modelsDevSync";
 import { getModelSpec } from "@/shared/constants/modelSpecs";
 import { getModelsCatalogPrefixMode } from "@/shared/utils/featureFlags";
+import { buildReservedPrefixes, selectCompatibleNodeForPrefix } from "@/lib/providerNodePrefixes";
 import { applyCatalogPostFilters, finalizeCatalogResponse } from "./catalogResponse";
 import {
   isNoAuthProviderBlocked,
@@ -271,6 +273,7 @@ async function buildUnifiedModelsResponseCore(
     // #9147: yield after auth check before DB initialization prologue
     await yieldCatalogBuildTurn();
 
+    const capabilityResolutionSnapshot = createModelCapabilityResolutionSnapshot();
     const { aliasToProviderId, providerIdToAlias } = buildAliasMaps();
     const _qp = new URL(request.url).searchParams.get("prefix");
     const prefixMode =
@@ -323,6 +326,7 @@ async function buildUnifiedModelsResponseCore(
 
     // Build map of provider node ID to prefix and type for compatible providers
     const providerIdToPrefix: Record<string, string> = {};
+    const providerNodeIdByPrefix: Record<string, string> = {};
     const nodeIdToProviderType: Record<string, string> = {};
     for (const node of providerNodes) {
       const resolvedPrefix =
@@ -339,6 +343,12 @@ async function buildUnifiedModelsResponseCore(
       if (node.type) {
         nodeIdToProviderType[node.id] = node.type;
       }
+    }
+    const reservedProviderPrefixes = buildReservedPrefixes();
+    for (const prefix of new Set(Object.values(providerIdToPrefix))) {
+      if (reservedProviderPrefixes.has(prefix)) continue;
+      const winner = selectCompatibleNodeForPrefix(providerNodes, prefix);
+      if (winner?.id) providerNodeIdByPrefix[prefix] = winner.id;
     }
 
     // #8327: `resolveCanonicalProviderId`/`canonicalProviderId` only know the static
@@ -450,8 +460,12 @@ async function buildUnifiedModelsResponseCore(
     const getProviderPrefixes = (providerId: string, rawProvider: string) =>
       getProviderPrefixesFromMaps(aliasMaps, providerId, rawProvider);
 
-    const getComboTargetModelId = (target: ComboCatalogTarget) =>
-      getComboTargetModelIdFromMaps(aliasMaps, target);
+    const getComboTargetModelId = (target: ComboCatalogTarget) => {
+      const resolved = getComboTargetModelIdFromMaps(aliasMaps, target);
+      if (!resolved) return null;
+      const nodeId = providerNodeIdByPrefix[resolved.providerId];
+      return nodeId ? { ...resolved, providerId: nodeId } : resolved;
+    };
 
     const getComboTargetCatalogMetadata = (
       target: ComboCatalogTarget
@@ -462,11 +476,19 @@ async function buildUnifiedModelsResponseCore(
       const canonical = getCanonicalModelMetadata({
         provider: targetModel.providerId,
         model: targetModel.modelId,
+        snapshot: capabilityResolutionSnapshot,
       });
       if (!canonical) return null;
 
       const source = canonical.metadata.source;
-      if (!source.providerRegistry && !source.staticSpec && !source.syncedCapability) return null;
+      if (
+        !source.providerRegistry &&
+        !source.staticSpec &&
+        !source.syncedCapability &&
+        !source.reasoningEffortsOverride
+      ) {
+        return null;
+      }
 
       const providerId = canonical.provider || targetModel.providerId;
       const modelId = canonical.model || targetModel.modelId;
@@ -539,7 +561,7 @@ async function buildUnifiedModelsResponseCore(
           providerId,
           modelId,
           canonical.capabilities.supportsThinking,
-          registryModel?.supportedThinkingEfforts
+          canonical.capabilities.supportedThinkingEfforts ?? registryModel?.supportedThinkingEfforts
         )
       );
 
@@ -1740,9 +1762,8 @@ async function buildUnifiedModelsResponseCore(
       }
       enrichmentSnapshot = {
         modelsDevPricing,
-        providerNodeIdsByPrefix: Object.fromEntries(
-          Object.entries(providerIdToPrefix).map(([providerId, prefix]) => [prefix, providerId])
-        ),
+        capabilityResolutionSnapshot,
+        providerNodeIdsByPrefix: providerNodeIdByPrefix,
       };
       // The production profile identified pricing snapshot construction as the last
       // dominant synchronous stage. Let already-queued health checks run before the

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -7189,6 +7189,7 @@
     "configured": "configured",
     "none": "None",
     "modelOverrideValuePlaceholder": "Numeric value",
+    "modelOverrideReasoningEffortsPlaceholder": "English comma-separated, e.g. low, medium, high",
     "addKeyValue": "Add key value",
     "noModelOverrides": "No overrides configured for this model.",
     "modelOverrideLoadFailed": "Failed to load model overrides",

--- a/src/lib/db/modelCapabilityOverrides.ts
+++ b/src/lib/db/modelCapabilityOverrides.ts
@@ -1,16 +1,31 @@
+import {
+  parseReasoningEffortsOverride,
+  REASONING_EFFORT_OVERRIDE_VALUES,
+  type ReasoningEffortOverrideValue,
+} from "@/shared/reasoning/reasoningEffortsOverride";
 import { getDbInstance } from "./core";
 import { invalidateDbCache } from "./readCache";
 
-export type ModelCapabilityOverrideKey = "max_input_tokens" | "max_output_tokens" | "max_token";
+export type NumericModelCapabilityOverrideKey =
+  "max_input_tokens" | "max_output_tokens" | "max_token";
+export type ModelCapabilityOverrideKey = NumericModelCapabilityOverrideKey | "reasoning_efforts";
 
-export interface ModelCapabilityOverride {
+interface ModelCapabilityOverrideBase {
   provider: string;
   modelId: string;
   target: string;
-  key: ModelCapabilityOverrideKey;
-  value: number;
   refreshedAt: string;
 }
+
+export type ModelCapabilityOverride =
+  | (ModelCapabilityOverrideBase & {
+      key: NumericModelCapabilityOverrideKey;
+      value: number;
+    })
+  | (ModelCapabilityOverrideBase & {
+      key: "reasoning_efforts";
+      value: ReasoningEffortOverrideValue[];
+    });
 
 interface OverrideRow {
   provider: string;
@@ -20,12 +35,25 @@ interface OverrideRow {
   refreshed_at: string;
 }
 
-function isSupportedKey(value: unknown): value is ModelCapabilityOverrideKey {
+function isNumericKey(value: unknown): value is NumericModelCapabilityOverrideKey {
   return value === "max_input_tokens" || value === "max_output_tokens" || value === "max_token";
+}
+
+function isSupportedKey(value: unknown): value is ModelCapabilityOverrideKey {
+  return isNumericKey(value) || value === "reasoning_efforts";
 }
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isReasoningEfforts(value: unknown): value is ReasoningEffortOverrideValue[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  const allowed = new Set<string>(REASONING_EFFORT_OVERRIDE_VALUES);
+  return (
+    value.every((entry) => typeof entry === "string" && allowed.has(entry)) &&
+    new Set(value).size === value.length
+  );
 }
 
 export function parseModelOverrideTarget(
@@ -51,33 +79,35 @@ function toOverride(row: OverrideRow): ModelCapabilityOverride | null {
     return null;
   }
 
-  if (!isPositiveInteger(parsedValue)) return null;
-
-  return {
+  const base: ModelCapabilityOverrideBase = {
     provider: row.provider,
     modelId: row.model_id,
     target: `${row.provider}/${row.model_id}`,
-    key: row.override_key,
-    value: parsedValue,
     refreshedAt: row.refreshed_at,
   };
+  if (row.override_key === "reasoning_efforts") {
+    return isReasoningEfforts(parsedValue)
+      ? { ...base, key: row.override_key, value: parsedValue }
+      : null;
+  }
+  return isPositiveInteger(parsedValue)
+    ? { ...base, key: row.override_key, value: parsedValue }
+    : null;
 }
 
-/** Nested provider → model → max_token map used by build-local snapshots. */
+/** Nested provider → model → numeric override map used by build-local snapshots. */
 export type NestedMaxTokenOverrideMap = ReadonlyMap<string, ReadonlyMap<string, number>>;
 
 export function getModelCapabilityOverride(
   provider: string | null | undefined,
   modelId: string | null | undefined,
-  key: ModelCapabilityOverrideKey,
+  key: NumericModelCapabilityOverrideKey,
   bulkMaxTokenOverrides?: NestedMaxTokenOverrideMap | null
 ): number | null {
   const target = parseModelOverrideTarget(`${provider || ""}/${modelId || ""}`);
-  if (!target || !isSupportedKey(key)) return null;
+  if (!target || !isNumericKey(key)) return null;
 
   if (bulkMaxTokenOverrides) {
-    // The caller pairs the bulk map with the key it was built for
-    // (max_output_tokens or max_input_tokens in the #9199 snapshot).
     return bulkMaxTokenOverrides.get(target.provider)?.get(target.modelId) ?? null;
   }
 
@@ -89,7 +119,30 @@ export function getModelCapabilityOverride(
       )
       .get(target.provider, target.modelId, key) as OverrideRow | undefined;
     const override = row ? toOverride(row) : null;
-    return override?.value ?? null;
+    return override && override.key !== "reasoning_efforts" ? override.value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getReasoningEffortsOverride(
+  provider: string | null | undefined,
+  modelId: string | null | undefined,
+  bulk?: ReadonlyMap<string, ReadonlyMap<string, readonly ReasoningEffortOverrideValue[]>> | null
+): readonly ReasoningEffortOverrideValue[] | null {
+  const target = parseModelOverrideTarget(`${provider || ""}/${modelId || ""}`);
+  if (!target) return null;
+  if (bulk) return bulk.get(target.provider)?.get(target.modelId) ?? null;
+
+  try {
+    const row = getDbInstance()
+      .prepare(
+        "SELECT provider, model_id, override_key, override_value, refreshed_at " +
+          "FROM model_capability_overrides WHERE provider = ? AND model_id = ? AND override_key = 'reasoning_efforts'"
+      )
+      .get(target.provider, target.modelId) as OverrideRow | undefined;
+    const override = row ? toOverride(row) : null;
+    return override?.key === "reasoning_efforts" ? override.value : null;
   } catch {
     return null;
   }
@@ -98,10 +151,22 @@ export function getModelCapabilityOverride(
 export function setModelCapabilityOverride(
   target: string,
   key: ModelCapabilityOverrideKey,
-  value: number
+  value: number | string | readonly string[]
 ): boolean {
   const parsedTarget = parseModelOverrideTarget(target);
-  if (!parsedTarget || !isSupportedKey(key) || !isPositiveInteger(value)) return false;
+  if (!parsedTarget || !isSupportedKey(key)) return false;
+
+  let normalizedValue: number | ReasoningEffortOverrideValue[];
+  if (key === "reasoning_efforts") {
+    const parsed = Array.isArray(value)
+      ? parseReasoningEffortsOverride(value.join(","))
+      : parseReasoningEffortsOverride(value);
+    if (!parsed.ok) return false;
+    normalizedValue = parsed.efforts;
+  } else {
+    if (!isPositiveInteger(value)) return false;
+    normalizedValue = value;
+  }
 
   getDbInstance()
     .prepare(
@@ -109,7 +174,7 @@ export function setModelCapabilityOverride(
         "(provider, model_id, override_key, override_value, refreshed_at) " +
         "VALUES (?, ?, ?, ?, datetime('now'))"
     )
-    .run(parsedTarget.provider, parsedTarget.modelId, key, JSON.stringify(value));
+    .run(parsedTarget.provider, parsedTarget.modelId, key, JSON.stringify(normalizedValue));
   invalidateDbCache("model-capabilities");
   return true;
 }

--- a/src/lib/modelCapabilities.ts
+++ b/src/lib/modelCapabilities.ts
@@ -13,7 +13,10 @@ import {
 import { getSyncedCapability } from "@/lib/modelsDevSync";
 import { MODELS_DEV_PROVIDER_MAP } from "@/lib/modelsDevSync/transform";
 import { getModelContextOverride } from "@/lib/db/modelContextOverrides";
-import { getModelCapabilityOverride } from "@/lib/db/modelCapabilityOverrides";
+import {
+  getModelCapabilityOverride,
+  getReasoningEffortsOverride,
+} from "@/lib/db/modelCapabilityOverrides";
 import { getCustomModelVisionOverride } from "@/lib/db/models";
 import type { ModelCapabilityResolutionSnapshot } from "@/lib/modelCapabilityResolutionSnapshot";
 import { resolveAudioCapability, resolveVideoCapability } from "@/lib/modelCapabilityModalities";
@@ -117,6 +120,8 @@ export interface ResolvedModelCapabilities {
   toolCalling: boolean;
   reasoning: boolean;
   supportsThinking: boolean | null;
+  supportedThinkingEfforts: readonly string[] | null;
+  reasoningEffortsOverride: boolean;
   supportsTools: boolean | null;
   supportsVision: boolean | null;
   supportsAudio: boolean | null;
@@ -613,10 +618,25 @@ function getMaxTokenCapabilityOverride(
   );
 }
 
-/**
- * Bulk-load friendly max_input_tokens override lookup (#9199): resolves from the
- * snapshot's preloaded map instead of a per-model SQLite read.
- */
+/** Resolve an exact reasoning-effort vocabulary from the build-local snapshot
+ * when present, otherwise from the on-demand persisted override lookup. */
+function getReasoningEffortsCapabilityOverride(
+  resolved: {
+    provider: string | null;
+    model: string | null;
+    rawModel: string | null;
+  },
+  snapshot?: ModelCapabilityResolutionSnapshot | null
+): readonly string[] | null {
+  const bulk = snapshot?.reasoningEffortsOverrides ?? null;
+  return (
+    getReasoningEffortsOverride(resolved.provider, resolved.model, bulk) ??
+    (resolved.rawModel && resolved.rawModel !== resolved.model
+      ? getReasoningEffortsOverride(resolved.provider, resolved.rawModel, bulk)
+      : null)
+  );
+}
+
 function getMaxInputTokenCapabilityOverride(
   resolved: {
     provider: string | null;
@@ -705,13 +725,18 @@ export function getResolvedModelCapabilities(
     (typeof spec?.supportsTools === "boolean" ? spec.supportsTools : null) ??
     (providerDeniesTools ? false : null);
 
-  const supportsThinking = reasoningDenied
-    ? false
-    : (synced?.reasoning ??
-      (typeof registryModel?.supportsReasoning === "boolean"
-        ? registryModel.supportsReasoning
-        : null) ??
-      (typeof spec?.supportsThinking === "boolean" ? spec.supportsThinking : null));
+  const reasoningEffortsOverride = usePersistedOverrides
+    ? getReasoningEffortsCapabilityOverride(resolved, snapshot)
+    : null;
+  const supportsThinking = reasoningEffortsOverride
+    ? true
+    : reasoningDenied
+      ? false
+      : (synced?.reasoning ??
+        (typeof registryModel?.supportsReasoning === "boolean"
+          ? registryModel.supportsReasoning
+          : null) ??
+        (typeof spec?.supportsThinking === "boolean" ? spec.supportsThinking : null));
 
   const authoritativeContextWindow = getAuthoritativeStaticContextWindow(
     resolved.provider,
@@ -785,6 +810,9 @@ export function getResolvedModelCapabilities(
     toolCalling: supportsTools ?? heuristicToolCalling(lookupKey),
     reasoning: supportsThinking ?? heuristicReasoning(lookupKey),
     supportsThinking,
+    supportedThinkingEfforts:
+      reasoningEffortsOverride ?? registryModel?.supportedThinkingEfforts ?? null,
+    reasoningEffortsOverride: reasoningEffortsOverride !== null,
     supportsTools,
     supportsVision,
     supportsAudio,

--- a/src/lib/modelCapabilityResolutionSnapshot.ts
+++ b/src/lib/modelCapabilityResolutionSnapshot.ts
@@ -9,6 +9,7 @@
  * collide via delimiter composition.
  */
 import { listModelCapabilityOverrides } from "@/lib/db/modelCapabilityOverrides";
+import type { ReasoningEffortOverrideValue } from "@/shared/reasoning/reasoningEffortsOverride";
 import { listModelContextOverrides } from "@/lib/db/modelContextOverrides";
 import {
   listCustomModelVisionOverrides,
@@ -22,11 +23,16 @@ import {
 
 /** Nested provider → model → numeric override map (collision-free). */
 export type NestedOverrideMap = ReadonlyMap<string, ReadonlyMap<string, number>>;
+export type NestedReasoningEffortsOverrideMap = ReadonlyMap<
+  string,
+  ReadonlyMap<string, readonly ReasoningEffortOverrideValue[]>
+>;
 
 export interface ModelCapabilityResolutionSnapshot {
   readonly synced: CapabilitiesByProvider;
   readonly maxTokenOverrides: NestedOverrideMap;
   readonly maxInputTokenOverrides: NestedOverrideMap;
+  readonly reasoningEffortsOverrides: NestedReasoningEffortsOverrideMap;
   readonly contextOverrides: NestedOverrideMap;
   readonly customVisionOverrides: CustomModelVisionOverrideMap;
 }
@@ -61,11 +67,22 @@ export function createModelCapabilityResolutionSnapshot(
 
   const maxTokenOverrides = new Map<string, Map<string, number>>();
   const maxInputTokenOverrides = new Map<string, Map<string, number>>();
+  const reasoningEffortsOverrides = new Map<
+    string,
+    Map<string, readonly ReasoningEffortOverrideValue[]>
+  >();
   for (const entry of listModelCapabilityOverrides()) {
     if (entry.key === "max_output_tokens") {
       setNestedOverride(maxTokenOverrides, entry.provider, entry.modelId, entry.value);
     } else if (entry.key === "max_input_tokens") {
       setNestedOverride(maxInputTokenOverrides, entry.provider, entry.modelId, entry.value);
+    } else if (entry.key === "reasoning_efforts") {
+      let byModel = reasoningEffortsOverrides.get(entry.provider);
+      if (!byModel) {
+        byModel = new Map();
+        reasoningEffortsOverrides.set(entry.provider, byModel);
+      }
+      byModel.set(entry.modelId, entry.value);
     }
   }
 
@@ -78,6 +95,7 @@ export function createModelCapabilityResolutionSnapshot(
     synced,
     maxTokenOverrides,
     maxInputTokenOverrides,
+    reasoningEffortsOverrides,
     contextOverrides,
     customVisionOverrides: listCustomModelVisionOverrides(options.customModelVision),
   };

--- a/src/lib/modelMetadataRegistry.ts
+++ b/src/lib/modelMetadataRegistry.ts
@@ -8,6 +8,7 @@ import {
   isNonChatCatalogSurface,
 } from "@/lib/modelCapabilities";
 import { getModelCapabilityOverride } from "@/lib/db/modelCapabilityOverrides";
+import type { ModelCapabilityResolutionSnapshot } from "@/lib/modelCapabilityResolutionSnapshot";
 import {
   getAuthoritativeContextWindow,
   getAuthoritativeProviderContextWindow,
@@ -40,6 +41,7 @@ type JsonRecord = Record<string, unknown>;
 
 export interface CatalogEnrichmentSnapshot {
   modelsDevPricing: PricingByProvider | null;
+  capabilityResolution?: ModelCapabilityResolutionSnapshot;
   providerNodeIdsByPrefix?: Readonly<Record<string, string>>;
   /** #9147: build-local bulk load of synced capabilities + token/context overrides
    * so per-entry enrichment never hits SQLite again (see catalogResponse.ts). */
@@ -64,6 +66,7 @@ export interface CanonicalModelMetadata {
     toolCalling: boolean;
     reasoning: boolean;
     supportsThinking: boolean | null;
+    supportedThinkingEfforts: readonly string[] | null;
     supportsTools: boolean | null;
     vision: boolean | null;
     attachment: boolean | null;
@@ -90,6 +93,7 @@ export interface CanonicalModelMetadata {
       providerRegistry: boolean;
       staticSpec: boolean;
       syncedCapability: boolean;
+      reasoningEffortsOverride: boolean;
     };
   };
   modalities: {
@@ -249,6 +253,7 @@ export function getCanonicalModelMetadata(input: {
       toolCalling: resolved.toolCalling,
       reasoning: resolved.reasoning,
       supportsThinking: resolved.supportsThinking,
+      supportedThinkingEfforts: resolved.supportedThinkingEfforts,
       supportsTools: resolved.supportsTools,
       vision: resolved.supportsVision,
       attachment: resolved.attachment,
@@ -275,6 +280,7 @@ export function getCanonicalModelMetadata(input: {
         providerRegistry: Boolean(registryModel),
         staticSpec: Boolean(staticSpec),
         syncedCapability: Boolean(syncedCapability),
+        reasoningEffortsOverride: resolved.reasoningEffortsOverride,
       },
     },
     modalities: {
@@ -437,10 +443,6 @@ export function enrichCatalogModelEntry<T extends JsonRecord>(
     snapshot: snapshot?.capabilityResolutionSnapshot ?? null,
   });
   if (!metadata) return entry;
-  const registryModel = getRegistryModel(
-    metadata.providerAlias || metadata.provider,
-    metadata.model
-  );
 
   const nextEntry: JsonRecord = { ...entry };
   const existingName = asNonEmptyString(entry.name);
@@ -484,9 +486,9 @@ export function enrichCatalogModelEntry<T extends JsonRecord>(
           ...(metadata.capabilities.supportsThinking
             ? {
                 effort_tiers:
-                  registryModel?.supportedThinkingEfforts &&
-                  registryModel.supportedThinkingEfforts.length > 0
-                    ? [...registryModel.supportedThinkingEfforts]
+                  metadata.capabilities.supportedThinkingEfforts &&
+                  metadata.capabilities.supportedThinkingEfforts.length > 0
+                    ? [...metadata.capabilities.supportedThinkingEfforts]
                     : extendCodexGpt56EffortValues(
                         metadata.provider,
                         metadata.model,

--- a/src/shared/reasoning/reasoningEffortsOverride.ts
+++ b/src/shared/reasoning/reasoningEffortsOverride.ts
@@ -1,0 +1,57 @@
+export const REASONING_EFFORT_OVERRIDE_VALUES = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+] as const;
+
+export type ReasoningEffortOverrideValue = (typeof REASONING_EFFORT_OVERRIDE_VALUES)[number];
+
+const REASONING_EFFORT_OVERRIDE_SET = new Set<string>(REASONING_EFFORT_OVERRIDE_VALUES);
+const EDGE_INVISIBLE_PATTERN =
+  /^[\p{White_Space}\p{Separator}\p{Control}\p{Format}]+|[\p{White_Space}\p{Separator}\p{Control}\p{Format}]+$/gu;
+const NON_ASCII_COMMA_PATTERN = /[\u060c\u3001\ufe10\ufe11\ufe50\ufe51\uff0c\uff64]/u;
+
+export type ReasoningEffortsOverrideParseResult =
+  { ok: true; efforts: ReasoningEffortOverrideValue[] } | { ok: false; error: string };
+
+function stripInvisibleEdges(value: string): string {
+  return value.replace(EDGE_INVISIBLE_PATTERN, "");
+}
+
+/** Parse one ASCII-comma-separated native reasoning-effort vocabulary. */
+export function parseReasoningEffortsOverride(value: unknown): ReasoningEffortsOverrideParseResult {
+  if (typeof value !== "string") {
+    return { ok: false, error: "reasoning_efforts must be a string" };
+  }
+  if (NON_ASCII_COMMA_PATTERN.test(value)) {
+    return { ok: false, error: "reasoning_efforts must use English commas" };
+  }
+
+  const segments = value.split(",");
+  if (segments.length === 0) {
+    return { ok: false, error: "reasoning_efforts must not be empty" };
+  }
+
+  const efforts: ReasoningEffortOverrideValue[] = [];
+  const seen = new Set<string>();
+  for (const segment of segments) {
+    const effort = stripInvisibleEdges(segment).toLowerCase();
+    if (!effort) {
+      return { ok: false, error: "reasoning_efforts contains an empty item" };
+    }
+    if (!REASONING_EFFORT_OVERRIDE_SET.has(effort)) {
+      return { ok: false, error: `Unsupported reasoning effort: ${effort}` };
+    }
+    if (seen.has(effort)) {
+      return { ok: false, error: `Duplicate reasoning effort: ${effort}` };
+    }
+    seen.add(effort);
+    efforts.push(effort as ReasoningEffortOverrideValue);
+  }
+
+  return { ok: true, efforts };
+}

--- a/tests/unit/model-capability-overrides.test.ts
+++ b/tests/unit/model-capability-overrides.test.ts
@@ -193,6 +193,60 @@ describe("model capability overrides", () => {
     assert.equal(rejectedDelete.status, 400);
   });
 
+  it("stores exact reasoning_efforts through the API and preserves native max/ultra", async () => {
+    const before = caps.getResolvedModelCapabilities("codex/gpt-5.6");
+    const accepted = await patchOverride(
+      "reasoning_efforts",
+      "\ufeff\u200b low\r\n, medium, max\u200d, ultra\u2060"
+    );
+    assert.equal(accepted.status, 200);
+
+    const payload = (await accepted.json()) as {
+      overrides: Array<{ target: string; key: string; value: number | string[] }>;
+    };
+    const listed = payload.overrides.find((override) => override.key === "reasoning_efforts");
+    assert.ok(listed);
+    assert.equal(listed.target, "codex/gpt-5.6");
+    assert.deepEqual(listed.value, ["low", "medium", "max", "ultra"]);
+    assert.deepEqual(overrides.getReasoningEffortsOverride("codex", "gpt-5.6"), [
+      "low",
+      "medium",
+      "max",
+      "ultra",
+    ]);
+
+    const resolved = caps.getResolvedModelCapabilities("codex/gpt-5.6");
+    assert.equal(resolved.supportsThinking, true);
+    assert.equal(resolved.reasoningEffortsOverride, true);
+    assert.deepEqual(resolved.supportedThinkingEfforts, ["low", "medium", "max", "ultra"]);
+
+    for (const invalid of [
+      "",
+      "low,",
+      "low,,high",
+      "low, LOW",
+      "minimal,low",
+      "low,unknown",
+      "low，high",
+    ]) {
+      assert.equal((await patchOverride("reasoning_efforts", invalid)).status, 400, invalid);
+    }
+    assert.equal((await patchOverride("reasoning_efforts", ["low", "high"])).status, 400);
+    assert.equal((await patchOverride("reasoning_efforts", 123)).status, 400);
+
+    const removed = await route.DELETE(
+      new Request(
+        "http://localhost/api/model-capability-overrides?target=codex/gpt-5.6&key=reasoning_efforts",
+        { method: "DELETE" }
+      )
+    );
+    assert.equal(removed.status, 200);
+    assert.equal(overrides.getReasoningEffortsOverride("codex", "gpt-5.6"), null);
+    const after = caps.getResolvedModelCapabilities("codex/gpt-5.6");
+    assert.equal(after.reasoningEffortsOverride, false);
+    assert.deepEqual(after.supportedThinkingEfforts, before.supportedThinkingEfforts);
+  });
+
   it("rejects invalid targets and non-positive values", () => {
     assert.equal(overrides.setModelCapabilityOverride("gpt-4o", "max_output_tokens", 1000), false);
     assert.equal(

--- a/tests/unit/model-catalog-runtime-invalidation.test.ts
+++ b/tests/unit/model-catalog-runtime-invalidation.test.ts
@@ -153,6 +153,22 @@ test("#9199 capability data writes advance the model-catalog generation", () => 
       true
     );
   });
+  expectGenerationAdvance("set reasoning_efforts override", () => {
+    assert.equal(
+      capabilityOverrides.setModelCapabilityOverride(
+        "openai/gpt-5.4-mini",
+        "reasoning_efforts",
+        "low,max,ultra"
+      ),
+      true
+    );
+  });
+  expectGenerationAdvance("remove reasoning_efforts override", () => {
+    assert.equal(
+      capabilityOverrides.removeModelCapabilityOverride("openai/gpt-5.4-mini", "reasoning_efforts"),
+      true
+    );
+  });
   expectGenerationAdvance("setModelContextOverride", () => {
     assert.equal(contextOverrides.setModelContextOverride("openai", "gpt-5.4-mini", 400000), true);
   });

--- a/tests/unit/models-catalog-combo-metadata.test.ts
+++ b/tests/unit/models-catalog-combo-metadata.test.ts
@@ -11,7 +11,10 @@ process.env.API_KEY_SECRET ||= "combo-metadata-test-secret";
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const combosDb = await import("../../src/lib/db/combos.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
 const contextOverrides = await import("../../src/lib/db/modelContextOverrides.ts");
+const capabilityOverrides = await import("../../src/lib/db/modelCapabilityOverrides.ts");
+const overrideRoute = await import("../../src/app/api/model-capability-overrides/route.ts");
 const catalog = await import("../../src/app/api/v1/models/catalog.ts");
 
 test.after(() => {
@@ -123,6 +126,140 @@ test("single-target combo respects registry reasoning overrides before specs", a
   assert.equal(capabilities.thinking, false);
   assert.equal(capabilities.supportsThinking, false);
   assert.equal(Object.hasOwn(capabilities, "effort_tiers"), false);
+});
+
+test("reasoning_efforts overrides project exact native tiers to direct models and combo intersections", async () => {
+  const openaiTarget = "openai/gpt-4o";
+  const anthropicTarget = "anthropic/claude-sonnet-4-5";
+  assert.equal(
+    capabilityOverrides.setModelCapabilityOverride(
+      openaiTarget,
+      "reasoning_efforts",
+      "low,max,ultra"
+    ),
+    true
+  );
+  assert.equal(
+    capabilityOverrides.setModelCapabilityOverride(
+      anthropicTarget,
+      "reasoning_efforts",
+      "medium,max,ultra"
+    ),
+    true
+  );
+
+  try {
+    await providersDb.createProviderConnection({
+      provider: "openai",
+      authType: "apikey",
+      name: "reasoning-efforts-openai-combo",
+      apiKey: "openai-test-key",
+      isActive: true,
+      testStatus: "active",
+    });
+    await providersDb.createProviderConnection({
+      provider: "anthropic",
+      authType: "apikey",
+      name: "reasoning-efforts-anthropic-combo",
+      apiKey: "anthropic-test-key",
+      isActive: true,
+      testStatus: "active",
+    });
+    await combosDb.createCombo({
+      name: "reasoning-efforts-override-combo",
+      strategy: "auto",
+      models: [openaiTarget, anthropicTarget],
+    });
+
+    const response = await catalog.getUnifiedModelsResponse(
+      new Request("http://localhost/api/v1/models")
+    );
+    const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+    const direct = body.data.find((item) => item.id === openaiTarget);
+    const combo = body.data.find((item) => item.id === "reasoning-efforts-override-combo");
+
+    assert.equal(response.status, 200);
+    assert.ok(direct);
+    assert.ok(combo);
+    assert.deepEqual((direct.capabilities as Record<string, unknown>).effort_tiers, [
+      "low",
+      "max",
+      "ultra",
+    ]);
+    assert.deepEqual((combo.capabilities as Record<string, unknown>).effort_tiers, [
+      "max",
+      "ultra",
+    ]);
+  } finally {
+    capabilityOverrides.removeModelCapabilityOverride(openaiTarget, "reasoning_efforts");
+    capabilityOverrides.removeModelCapabilityOverride(anthropicTarget, "reasoning_efforts");
+  }
+});
+
+test("compatible provider-node override reaches direct and combo metadata through its public prefix", async () => {
+  const nodeId = "openai-compatible-chat-reasoning-override";
+  const prefix = "reasoning-override";
+  const modelId = "native-reasoning-model";
+  await providersDb.createProviderNode({
+    id: nodeId,
+    type: "openai-compatible",
+    prefix,
+    name: "Reasoning Override",
+    apiType: "chat",
+    baseUrl: "https://example.com/v1",
+  });
+  const connection = await providersDb.createProviderConnection({
+    provider: nodeId,
+    authType: "api_key",
+    name: "reasoning-override-connection",
+    apiKey: "sk-test",
+    isActive: true,
+    testStatus: "active",
+  });
+  await modelsDb.replaceSyncedAvailableModelsForConnection(nodeId, connection.id, [
+    { id: modelId, name: "Native Reasoning Model" },
+  ]);
+
+  const patch = await overrideRoute.PATCH(
+    new Request("http://localhost/api/model-capability-overrides", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        target: `${prefix}/${modelId}`,
+        key: "reasoning_efforts",
+        value: "low,max,ultra",
+      }),
+    })
+  );
+  assert.equal(patch.status, 200);
+  assert.deepEqual(capabilityOverrides.getReasoningEffortsOverride(nodeId, modelId), [
+    "low",
+    "max",
+    "ultra",
+  ]);
+
+  await combosDb.createCombo({
+    name: "provider-node-reasoning-override-combo",
+    strategy: "auto",
+    models: [`${prefix}/${modelId}`],
+  });
+  const response = await catalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const direct = body.data.find((item) => item.id === `${prefix}/${modelId}`);
+  const combo = body.data.find((item) => item.id === "provider-node-reasoning-override-combo");
+
+  assert.equal(response.status, 200);
+  assert.ok(direct);
+  assert.ok(combo);
+  for (const item of [direct, combo]) {
+    assert.deepEqual((item.capabilities as Record<string, unknown>).effort_tiers, [
+      "low",
+      "max",
+      "ultra",
+    ]);
+  }
 });
 
 test("single-target combo reflects unblocked Antigravity Gemini reasoning", async () => {

--- a/tests/unit/reasoning-efforts-override-parser.test.ts
+++ b/tests/unit/reasoning-efforts-override-parser.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { parseReasoningEffortsOverride } =
+  await import("../../src/shared/reasoning/reasoningEffortsOverride.ts");
+
+test("parses native reasoning efforts using only ASCII commas", () => {
+  assert.deepEqual(parseReasoningEffortsOverride("none, low,medium, high, xhigh,max,ultra"), {
+    ok: true,
+    efforts: ["none", "low", "medium", "high", "xhigh", "max", "ultra"],
+  });
+});
+
+test("strips whitespace, CR/LF, NBSP, BOM, and zero-width edge characters", () => {
+  assert.deepEqual(
+    parseReasoningEffortsOverride("\ufeff\u200b low\r\n,\u00a0max\u200d , ultra\u2060"),
+    { ok: true, efforts: ["low", "max", "ultra"] }
+  );
+});
+
+test("rejects empty, duplicate, unknown, and non-ASCII-comma input", () => {
+  for (const input of [
+    "",
+    "low,",
+    ",low",
+    "low,,high",
+    "low, low",
+    "LOW, low",
+    "minimal,low",
+    "low,unknown",
+    "low，high",
+    "low、high",
+  ]) {
+    const parsed = parseReasoningEffortsOverride(input);
+    assert.equal(parsed.ok, false, input);
+  }
+});
+
+test("does not strip invisible characters from the middle of an effort", () => {
+  assert.equal(parseReasoningEffortsOverride("l\u200bow,high").ok, false);
+});

--- a/tests/unit/ui/model-capability-overrides-tab-9557.test.tsx
+++ b/tests/unit/ui/model-capability-overrides-tab-9557.test.tsx
@@ -56,6 +56,82 @@ afterEach(() => {
 });
 
 describe("ModelCapabilityOverridesTab (issue #9557)", () => {
+  it("uses a text input and sends the raw comma-separated reasoning_efforts string", async () => {
+    const catalog = {
+      codex: {
+        id: "codex",
+        alias: "codex",
+        displayPrefix: "codex",
+        name: "Codex",
+        authType: "oauth",
+        format: "openai",
+        models: [{ id: "gpt-5.6", name: "GPT 5.6" }],
+      },
+    };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation((input: any, init: RequestInit | undefined) => {
+      const url = String(input);
+      if (url.includes("/api/pricing/models")) return Promise.resolve(jsonResponse(catalog));
+      if (url.includes("/api/model-capability-overrides")) {
+        return Promise.resolve(
+          jsonResponse({
+            overrides:
+              init?.method === "PATCH"
+                ? [
+                    {
+                      target: "codex/gpt-5.6",
+                      key: "reasoning_efforts",
+                      value: ["low", "max", "ultra"],
+                    },
+                  ]
+                : [],
+          })
+        );
+      }
+      return Promise.resolve(jsonResponse({ error: "unexpected" }, { ok: false }));
+    });
+
+    render();
+    await act(async () => flush());
+
+    const select = document.querySelector("select") as HTMLSelectElement;
+    act(() => {
+      select.value = "reasoning_efforts";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    const valueInput = document.querySelector(
+      'input[placeholder*="English comma-separated"]'
+    ) as HTMLInputElement;
+    expect(valueInput).toBeTruthy();
+    expect(valueInput.type).toBe("text");
+
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(valueInput, " low, max, ultra ");
+      valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const addButton = Array.from(document.querySelectorAll("button")).find((button) =>
+      (button.textContent ?? "").includes("Add key value")
+    );
+    await act(async () => {
+      addButton!.click();
+      await flush();
+    });
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([input, init]) =>
+        String(input).includes("/api/model-capability-overrides") &&
+        (init as RequestInit | undefined)?.method === "PATCH"
+    );
+    expect(patchCall).toBeTruthy();
+    expect(JSON.parse(String(patchCall![1].body))).toEqual({
+      target: "codex/gpt-5.6",
+      key: "reasoning_efforts",
+      value: " low, max, ultra ",
+    });
+    expect(document.body.textContent).toContain("low, max, ultra");
+  });
+
   it("renders the public prefix, never the node UUID, and PATCH/DELETE use prefix/model", async () => {
     const catalog = {
       [NODE_ID]: {


### PR DESCRIPTION
## Summary

- Add `reasoning_efforts` to Dashboard Settings > AI > Model Overrides as one English-comma-separated string input.
- Parse and persist the exact native vocabulary `none, low, medium, high, xhigh, max, ultra`; preserve `max` and `ultra` without mapping either to `xhigh`.
- Reject empty items, trailing/repeated commas, normalized duplicates, unknown values, non-string API payloads, and non-ASCII/full-width commas. Strip edge whitespace plus CR/LF, NBSP, BOM, zero-width and other Unicode control/format/separator noise.
- Feed the override through the build-local capability snapshot and canonical metadata so direct models and combos share one source and combo tiers intersect. Compatible provider-node public prefixes resolve to the same runtime winner for API persistence, direct catalog enrichment, and combo metadata.

## Related Issues

- Related to #10563

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: UI / i18n / API / DB
- [x] Focused tests and category gates from the golden path
  - `node --import tsx --test tests/unit/reasoning-efforts-override-parser.test.ts tests/unit/model-capability-overrides.test.ts tests/unit/models-catalog-combo-metadata.test.ts tests/unit/model-catalog-runtime-invalidation.test.ts`
  - Post-commit result: 23/23 passed
  - Extended snapshot/prefix/effort regression run: 59/59 passed
  - `npx vitest run tests/unit/ui/model-capability-overrides-tab-9557.test.tsx` (2/2 passed)
  - `npm run typecheck:core`
  - `npm run typecheck:noimplicit:core`
  - `npm run check:dashboard-typecheck`
  - `npm run i18n:check-ui-coverage`
  - `npm run i18n:check-value-drift`
  - `npm run check:changelog-integrity`
  - Changed-file ESLint and `git diff --check`
  - Commit hooks: Prettier, changed-file ESLint, docs sync, explicit-any budget, tracked-artifacts
- [ ] `npm run lint`
  - The changed files pass ESLint. The repo-wide command is blocked only by 25 pre-existing `@typescript-eslint/no-explicit-any` errors in `tests/unit/cli-oauth-commands.test.ts` and `tests/unit/executor-gitlab.test.ts`.
- [x] Reconciled with the current active release base; focused checks rerun afterward
  - HTTPS fetch confirmed `origin/release/v3.8.50@b754e44e260ba888035b8ec077b4da8ea4483e48`; this branch is one commit directly on that base.
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Additional baseline note: `npm run check:open-sse-typecheck` reports `open-sse/executors/index.ts(239,27) TS2345` for the pre-existing `GlmExecutor.buildHeaders` signature mismatch. The exact diagnostic reproduces in a detached clean worktree at `origin/release/v3.8.50`; this PR does not modify that path.

## Tests Added Or Updated

- `tests/unit/reasoning-efforts-override-parser.test.ts`
- `tests/unit/model-capability-overrides.test.ts`
- `tests/unit/model-catalog-runtime-invalidation.test.ts`
- `tests/unit/models-catalog-combo-metadata.test.ts`
- `tests/unit/ui/model-capability-overrides-tab-9557.test.tsx`

## Coverage Notes

- Parser tests cover ASCII commas, edge Unicode normalization, empty/duplicate/unknown values, full-width commas, and interior zero-width rejection.
- API/DB tests cover discriminated value types, CRUD, native `max`/`ultra` preservation, exact provider/model isolation, and token-override compatibility.
- Catalog tests cover direct projection, multi-target combo intersections, compatible provider-node public-prefix persistence and projection, and cache-generation invalidation.
- The real dashboard component test verifies the control switches to a text input, sends the raw string to the server, and renders the normalized array.

## Reviewer Notes

- No migration: the existing `override_value` JSON TEXT column stores the normalized string array.
- No feature flag.
- English UI copy is in `src/i18n/messages/en.json`; no user-facing string is hard-coded.
- The build-local snapshot avoids per-model SQLite queries.
- A read-only reviewer found and the implementation fixed a compatible provider-node combo gap; delta review confirmed the High finding and duplicate-prefix residual are closed, with no remaining blockers.
