### PR TITLE
fix(oauth): keep the Kiro profileArn on IAM Identity Center logins

### DIFF
--- a/src/shared/components/OAuthModal.tsx
+++ b/src/shared/components/OAuthModal.tsx
@@ -430,13 +430,17 @@ export default function OAuthModal({
           const verifyUrl = data.verification_uri_complete || data.verification_uri;
           if (typeof verifyUrl === "string" && verifyUrl) window.open(verifyUrl, "oauth_verify");
 
-          // Start polling - pass extraData for Kiro (contains _clientId, _clientSecret)
+          // Start polling - pass extraData for Kiro (contains _clientId, _clientSecret).
+          // _authMethod must be forwarded too: pollToken falls back to "builder-id" without it,
+          // which makes postExchange skip the Q Developer profile lookup. An IdC connection then
+          // gets persisted with no profileArn and every usage call returns 403.
           const extraData =
             provider === "kiro" || provider === "amazon-q"
               ? {
                   _clientId: data._clientId,
                   _clientSecret: data._clientSecret,
                   _region: data._region,
+                  _authMethod: data._authMethod,
                 }
               : provider === "ghe-copilot" && gheUrl.trim()
                 ? { gheUrl: gheUrl.trim() }

--- a/tests/unit/kiro-idc-profilearn-extradata.test.ts
+++ b/tests/unit/kiro-idc-profilearn-extradata.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Source-level contract tests for the IdC (IAM Identity Center) Kiro login path.
+//
+// A Kiro connection added through "Your organization (AWS IAM Identity Center)" must end up
+// with a `profileArn` in providerSpecificData. Without it every CodeWhisperer usage call is
+// made unbound to the Q Developer profile and AWS answers 403 "User is not authorized to make
+// this call", so the quota card shows "Kiro quota API rejected the current token" while chat
+// keeps working.
+//
+// The value is only discovered when `_authMethod` survives the device-code round trip:
+//
+//   requestDeviceCode  -> _authMethod: "idc"        (startUrl present)
+//   OAuthModal         -> forwards extraData to the poll request   <- the link that broke
+//   pollToken          -> extraData?._authMethod || "builder-id"
+//   postExchange       -> returns early for "builder-id" (no profile lookup)
+//   mapTokens          -> persists authMethod + profileArn
+//
+// The modal used to copy only _clientId/_clientSecret/_region, so an IdC login was persisted as
+// a Builder ID one and the profile lookup never ran.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const modalSource = readFileSync(join(here, "../../src/shared/components/OAuthModal.tsx"), "utf8");
+const kiroProviderSource = readFileSync(
+  join(here, "../../src/lib/oauth/providers/kiro.ts"),
+  "utf8"
+);
+
+test("OAuthModal forwards _authMethod to the poll request for Kiro device code", () => {
+  const extraDataBlock = modalSource.match(
+    /provider === "kiro" \|\| provider === "amazon-q"\s*\?\s*\{[\s\S]*?\}/
+  );
+  assert.ok(extraDataBlock, "Kiro extraData block not found in OAuthModal");
+
+  const block = extraDataBlock[0];
+  assert.match(block, /_clientId: data\._clientId/);
+  assert.match(block, /_clientSecret: data\._clientSecret/);
+  assert.match(block, /_region: data\._region/);
+  // The regression: dropping this line silently downgrades an IdC login to Builder ID.
+  assert.match(
+    block,
+    /_authMethod: data\._authMethod/,
+    "OAuthModal must forward _authMethod so pollToken does not fall back to builder-id"
+  );
+});
+
+test("requestDeviceCode marks IdC logins so the profile lookup can run", () => {
+  assert.match(
+    kiroProviderSource,
+    /_authMethod: config\.skipIssuerUrlForRegistration \? "idc" : "builder-id"/
+  );
+});
+
+test("pollToken keeps the device-code _authMethod when the caller forwards it", () => {
+  assert.match(kiroProviderSource, /_authMethod: extraData\?\._authMethod \|\| "builder-id"/);
+});
+
+test("postExchange skips the profile lookup only for Builder ID logins", () => {
+  assert.match(kiroProviderSource, /if \(tokenData\?\._authMethod === "builder-id"\) return null;/);
+  assert.match(
+    kiroProviderSource,
+    /discoverKiroProfileArnAcrossRegions\(accessToken, storedRegion\)/
+  );
+});
+
+test("mapTokens persists profileArn when the exchange discovered one", () => {
+  assert.match(
+    kiroProviderSource,
+    /\.\.\.\(extra\?\.profileArn \? \{ profileArn: extra\.profileArn \} : \{\}\)/
+  );
+});


### PR DESCRIPTION
A Kiro connection added through **"Your organization (AWS IAM Identity Center)"** now keeps its Q Developer `profileArn`. Before this it was persisted as a Builder ID connection with no ARN, and every usage lookup for it returned 403.

## The symptom

On an instance with 8 Kiro connections, only the ones added through the IdC flow failed:

- The connection tests fine and shows **Connected**; chat requests work normally.
- The quota card shows the plan as **Unknown** with no credit bar.
- `GET /api/usage/<id>` returns `{"message":"Kiro quota API rejected the current token. Chat may still work.","quotas":{}}`.

Connections added through AWS Builder ID on the same instance returned `plan: "KIRO POWER"` with credits, so the failure looked account-specific rather than flow-specific. It is not: subscription tier, plan source, IdC application assignment and user attributes were all identical to the working accounts.

## Why it happens

Checked directly against CodeWhisperer with the account's own SSO token:

| Call | Result |
| --- | --- |
| `ListAvailableProfiles` | **200** — returns the organization's profile ARN |
| `GetUsageLimits` without `profileArn` | **403** `AccessDeniedException: User is not authorized to make this call.` |
| `GetUsageLimits` with `profileArn` | **200** — `subscriptionTitle: "KIRO POWER"` |

An IdC token has to be bound to the Q Developer profile; a Builder ID token does not need one. That is why only IdC connections break, and why the failure surfaces at the quota call rather than at login — the profile lookup itself succeeds without an ARN, so registration looks healthy.

The ARN was never stored because `_authMethod` was dropped between the device-code request and the poll:

1. `requestDeviceCode` marks the login `_authMethod: "idc"` when a `startUrl` is present.
2. `OAuthModal` forwarded only `_clientId` / `_clientSecret` / `_region` into the poll request.
3. `pollToken` fell back to `"builder-id"`.
4. `postExchange` returns early for `"builder-id"`, so `ListAvailableProfiles` never ran.
5. `mapTokens` stored the connection with the wrong `authMethod` and no `profileArn`.

## The fix

Forward `_authMethod` alongside the other device-code fields. Builder ID logins are unaffected — they have no profile and the lookup is still skipped, so no extra region probes are added for them.

| | Before | After |
| --- | --- | --- |
| Connection added via IdC | stored as `authMethod: "builder-id"`, no `profileArn` | stored as `authMethod: "idc"` with the discovered `profileArn` |
| Its quota card | plan **Unknown**, no credits | plan and credits shown |
| Connection added via Builder ID | unchanged | unchanged |

## Verification

**TDD** — `tests/unit/kiro-idc-profilearn-extradata.test.ts` fails on the base commit with

```
OAuthModal must forward _authMethod so pollToken does not fall back to builder-id
```

and passes with the fix (5/5). It pins the whole chain, so a future edit that drops any link in it fails the suite rather than silently downgrading IdC logins again.

**Real environment** — reproduced on a running instance, then confirmed the mechanism by writing the ARN into the affected connection by hand:

```
PUT /api/providers/<id>  {"providerSpecificData":{"profileArn":"<org profile arn>"}}
GET /api/usage/<id>      -> {"plan":"KIRO POWER","quotas":{"credit":{...}}}
```

**Checks run**

| Command | Result |
| --- | --- |
| `node --import tsx/esm --test tests/unit/kiro-idc-profilearn-extradata.test.ts` | 5 passed |
| `oauth-modal-typescript-regressions` + `oauth-modal-grok-cli-paste-7610` + `kiro-iam-profilearn-usage` | 13 passed |
| `npx eslint` on the changed files | clean |
| `npm run typecheck:core` | 9 pre-existing errors, all in `open-sse/services/compression/**` (`omniglyph` exports), none in the changed files |

## Note for reviewers

⚠️ base-red inherited: #9985 — `release/v3.8.50` was already red when this branch was cut.
