### PR TITLE
fix(sensenova): clamp unsupported max reasoning effort to xhigh

### DIFF
--- a/open-sse/config/providers/registry/sensenova/index.ts
+++ b/open-sse/config/providers/registry/sensenova/index.ts
@@ -27,6 +27,8 @@ export const sensenovaProvider: RegistryEntry = {
       contextLength: 1048576,
       maxOutputTokens: 65536,
       supportsReasoning: true,
+      supportedThinkingEfforts: ["none", "low", "medium", "high", "xhigh"],
+      supportsXHighEffort: true,
       interleavedField: "reasoning_content",
     },
     {

--- a/open-sse/executors/base/reasoningEffort.ts
+++ b/open-sse/executors/base/reasoningEffort.ts
@@ -6,6 +6,7 @@ import {
   supportsClaudeMaxEffort,
   supportsXHighEffort,
   getProviderModel,
+  getProviderModels,
 } from "../../config/providerModels.ts";
 
 /**
@@ -351,6 +352,31 @@ export function sanitizeReasoningEffortForProvider(
   // new models from being unusable for weeks until they're whitelisted (#8057).
   if (effortStr === "max") {
     if (supportsMax) return body; // explicitly known to accept max
+
+    // A model that explicitly advertises its accepted tiers is safe to normalize.
+    // Keep the default pass-through for absent metadata: an unlisted model might
+    // support literal `max`, and #8057 deliberately avoids blocking such models.
+    const providerModelId = modelStr.startsWith(`${provider}/`)
+      ? modelStr.slice(provider.length + 1)
+      : modelStr;
+    // Do not fall back to a globally registered model here. Identical ids can
+    // have different upstream contracts across providers (for example, OpenCode
+    // and SenseNova both expose deepseek-v4-flash with different max support).
+    const explicitEfforts = getProviderModels(provider).find(
+      (entry) => entry.id === providerModelId || entry.aliases?.includes(providerModelId)
+    )?.supportedThinkingEfforts;
+    const maxFallback =
+      Array.isArray(explicitEfforts) && !explicitEfforts.includes("max")
+        ? ["xhigh", "high", "medium", "low"].find((tier) => explicitEfforts.includes(tier))
+        : undefined;
+    if (maxFallback) {
+      log?.info?.(
+        "REASONING_SANITIZE",
+        `${provider}/${modelStr}: downgraded reasoning_effort max → ${maxFallback} (explicit model capability)`
+      );
+      return writeEffortValue(b, maxFallback, c);
+    }
+
     if (!supportsXHigh) {
       // Model is explicitly flagged as rejecting xhigh (and not in supportsMax) —
       // it likely only accepts standard tiers. Degrade to its highest: high.
@@ -360,7 +386,6 @@ export function sanitizeReasoningEffortForProvider(
       );
       return writeEffortValue(b, "high", c);
     }
-    // Default: pass max through unchanged — trust the upstream
     return body;
   }
 

--- a/tests/unit/sensenova-reasoning-effort.test.ts
+++ b/tests/unit/sensenova-reasoning-effort.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sanitizeReasoningEffortForProvider } from "../../open-sse/executors/base/reasoningEffort.ts";
+
+test("sensenova/deepseek-v4-flash maps max to its explicit xhigh ceiling", () => {
+  const result = sanitizeReasoningEffortForProvider(
+    { reasoning_effort: "max", messages: [] },
+    "sensenova",
+    "deepseek-v4-flash"
+  );
+
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "xhigh");
+});
+
+test("sensenova models without an explicit effort list keep max unchanged", () => {
+  const result = sanitizeReasoningEffortForProvider(
+    { reasoning_effort: "max", messages: [] },
+    "sensenova",
+    "glm-5.2"
+  );
+
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "max");
+});


### PR DESCRIPTION
## Summary

- Normalize `reasoning_effort: "max"` to `xhigh` for SenseNova's `deepseek-v4-flash`, whose upstream contract explicitly accepts up to `xhigh` but rejects `max`.
- Preserve literal `max` passthrough for models without explicit per-model effort metadata and avoid cross-provider capability lookup for same-ID models.
- Add a regression test for the SenseNova capability ceiling.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
  - `node --import tsx/esm --test tests/unit/base-reasoning-effort-split.test.ts tests/unit/sensenova-reasoning-effort.test.ts tests/unit/opencode-zen-reasoning-effort.test.ts`
  - Result: 12 passed, 0 failed.
  - Manual live validation: input `max` was normalized to `xhigh`; `sensenova/deepseek-v4-flash` returned HTTP 200 with a non-empty reply.
- [ ] `npm run lint`
  - The full local ESLint process hung without diagnostics and was stopped. Targeted ESLint for all changed files exited successfully with code 0.
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- Added `tests/unit/sensenova-reasoning-effort.test.ts`.

## Coverage Notes

- `tests/unit/sensenova-reasoning-effort.test.ts` covers the explicit SenseNova `max` to `xhigh` normalization and verifies that a SenseNova model without explicit effort metadata continues to preserve `max`.
- `tests/unit/opencode-zen-reasoning-effort.test.ts` confirms same-ID OpenCode models retain their existing `max` passthrough behavior.
- `tests/unit/base-reasoning-effort-split.test.ts` confirms both supported import paths resolve to the same sanitizer.
- No known coverage decrease in touched files.

## Reviewer Notes

- No migrations or feature flags.
- The capability lookup intentionally stays scoped to the current provider because providers can expose the same model ID with different upstream reasoning-effort contracts.
- The change only affects models that explicitly declare supported reasoning efforts and omit `max`; models with absent metadata keep the existing passthrough behavior.