### PR TITLE
fix: resolve audio provider short-alias prefix in parseAudioModel (#10586)

### DIFF
--- a/changelog.d/fixes/10586-audio-alias-prefix-gap.md
+++ b/changelog.d/fixes/10586-audio-alias-prefix-gap.md
@@ -1,0 +1,1 @@
+- fix(sse): resolve the short provider-alias prefix (e.g. `el/`) advertised by GET /v1/models for audio speech, transcription and translation model ids (#10586)

--- a/open-sse/config/audioRegistry.ts
+++ b/open-sse/config/audioRegistry.ts
@@ -7,6 +7,8 @@
  * - /v1/audio/speech (TTS API)
  */
 
+import { getProviderAlias } from "@/shared/constants/providers";
+
 interface AudioModel {
   id: string;
   name: string;
@@ -674,6 +676,16 @@ function parseAudioModel(
   for (const [providerId] of Object.entries(registry)) {
     if (modelStr.startsWith(providerId + "/")) {
       return { provider: providerId, model: modelStr.slice(providerId.length + 1) };
+    }
+  }
+
+  // Phase 1.5: prefix match against the short provider alias the catalog itself
+  // advertises (e.g. "el/eleven_multilingual_v2" for elevenlabs) when it differs
+  // from the canonical registry key already tried in Phase 1.
+  for (const [providerId] of Object.entries(registry)) {
+    const alias = getProviderAlias(providerId);
+    if (alias && alias !== providerId && modelStr.startsWith(alias + "/")) {
+      return { provider: providerId, model: modelStr.slice(alias.length + 1) };
     }
   }
 

--- a/tests/unit/audio-alias-prefix-10586.test.ts
+++ b/tests/unit/audio-alias-prefix-10586.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("parseSpeechModel resolves the elevenlabs short-alias prefix advertised by /v1/models", async () => {
+  const { parseSpeechModel } = await import("../../open-sse/config/audioRegistry.ts");
+
+  const canonical = parseSpeechModel("elevenlabs/eleven_multilingual_v2");
+  assert.deepEqual(canonical, { provider: "elevenlabs", model: "eleven_multilingual_v2" });
+
+  // This is the id /v1/models actually advertises in default "dual" prefix mode
+  // (REGISTRY["elevenlabs"].alias === "el"). It currently fails to parse.
+  const aliased = parseSpeechModel("el/eleven_multilingual_v2");
+  assert.deepEqual(
+    aliased,
+    { provider: "elevenlabs", model: "eleven_multilingual_v2" },
+    `expected "el/eleven_multilingual_v2" to resolve to the elevenlabs provider like its canonical twin does, but got ${JSON.stringify(aliased)}`
+  );
+});
+
+test("parseSpeechModel resolves every alias registered for an AUDIO_SPEECH_PROVIDERS entry", async () => {
+  const { parseSpeechModel, AUDIO_SPEECH_PROVIDERS } = await import(
+    "../../open-sse/config/audioRegistry.ts"
+  );
+  const { getProviderAlias } = await import("../../src/shared/constants/providers.ts");
+
+  for (const providerId of Object.keys(AUDIO_SPEECH_PROVIDERS)) {
+    const alias = getProviderAlias(providerId);
+    if (!alias || alias === providerId) continue;
+    const canonical = parseSpeechModel(`${providerId}/sample-model`);
+    assert.deepEqual(canonical, { provider: providerId, model: "sample-model" });
+    const aliased = parseSpeechModel(`${alias}/sample-model`);
+    assert.deepEqual(
+      aliased,
+      { provider: providerId, model: "sample-model" },
+      `expected "${alias}/sample-model" to resolve to ${providerId} but got ${JSON.stringify(aliased)}`
+    );
+  }
+});
+
+test("parseTranscriptionModel resolves every alias registered for an AUDIO_TRANSCRIPTION_PROVIDERS entry", async () => {
+  const { parseTranscriptionModel, AUDIO_TRANSCRIPTION_PROVIDERS } = await import(
+    "../../open-sse/config/audioRegistry.ts"
+  );
+  const { getProviderAlias } = await import("../../src/shared/constants/providers.ts");
+
+  for (const providerId of Object.keys(AUDIO_TRANSCRIPTION_PROVIDERS)) {
+    const alias = getProviderAlias(providerId);
+    if (!alias || alias === providerId) continue;
+    const canonical = parseTranscriptionModel(`${providerId}/sample-model`);
+    assert.deepEqual(canonical, { provider: providerId, model: "sample-model" });
+    const aliased = parseTranscriptionModel(`${alias}/sample-model`);
+    assert.deepEqual(
+      aliased,
+      { provider: providerId, model: "sample-model" },
+      `expected "${alias}/sample-model" to resolve to ${providerId} but got ${JSON.stringify(aliased)}`
+    );
+  }
+});
+
+test("parseTranslationModel resolves every alias registered for an AUDIO_TRANSLATION_PROVIDERS entry", async () => {
+  const { parseTranslationModel, AUDIO_TRANSLATION_PROVIDERS } = await import(
+    "../../open-sse/config/audioRegistry.ts"
+  );
+  const { getProviderAlias } = await import("../../src/shared/constants/providers.ts");
+
+  for (const providerId of Object.keys(AUDIO_TRANSLATION_PROVIDERS)) {
+    const alias = getProviderAlias(providerId);
+    if (!alias || alias === providerId) continue;
+    const canonical = parseTranslationModel(`${providerId}/sample-model`);
+    assert.deepEqual(canonical, { provider: providerId, model: "sample-model" });
+    const aliased = parseTranslationModel(`${alias}/sample-model`);
+    assert.deepEqual(
+      aliased,
+      { provider: providerId, model: "sample-model" },
+      `expected "${alias}/sample-model" to resolve to ${providerId} but got ${JSON.stringify(aliased)}`
+    );
+  }
+});


### PR DESCRIPTION
Closes #10586

## Root cause

GET /v1/models advertises both the short provider-alias id and the canonical
provider id for every model (default `MODELS_CATALOG_PREFIX_MODE="dual"`), e.g.
`el/eleven_multilingual_v2` (alias `el` for `elevenlabs`) alongside
`elevenlabs/eleven_multilingual_v2`. `parseAudioModel()` in
`open-sse/config/audioRegistry.ts` only prefix-matched against the
`AUDIO_SPEECH_PROVIDERS` / `AUDIO_TRANSCRIPTION_PROVIDERS` / `AUDIO_TRANSLATION_PROVIDERS`
canonical registry keys, never against the short alias each provider is
registered under (`src/shared/constants/providers/audio.ts`) — so the
alias-prefixed id the catalog itself just advertised 400ed with "Invalid speech
model" when sent back to `/v1/audio/speech` or `/v1/audio/transcriptions`.

## Fix

Added a Phase 1.5 prefix-match in `parseAudioModel()` that additionally tries
`getProviderAlias(providerId)` (from `src/shared/constants/providers.ts` —
covers `AUDIO_ONLY_PROVIDERS`, unlike the chat-only `PROVIDER_ID_TO_ALIAS` map)
for every registry entry, resolving to the same canonical `providerId` a
request already reaches via the long-form id. This only widens what parses; it
cannot change routing for any currently-working id. Verified there is no alias
string that collides with another provider's canonical id across the speech,
transcription, and translation registries.

## Regression test

`tests/unit/audio-alias-prefix-10586.test.ts` — proven RED before the fix
(`el/eleven_multilingual_v2` resolved to `{provider: null, ...}`), GREEN after.
Also adds enumeration tests covering every provider with a registered short
alias in `AUDIO_SPEECH_PROVIDERS`, `AUDIO_TRANSCRIPTION_PROVIDERS`, and
`AUDIO_TRANSLATION_PROVIDERS` (elevenlabs/`el`, deepgram/`dg`, soniox/`sx`,
assemblyai/`aai`, etc.) so both the alias-prefixed and canonical-prefixed
catalog ids resolve to the same provider.

## Scope

Out of scope per the plan-file (tracked separately under the parent tracker
#10591): the missing `/v1/realtime` route, the
`mistral/voxtral-mini-transcribe-2507` vs nested-openrouter-model mismatch, and
the `google/gemini-2.5-flash-preview-tts` vs vertex-only registry gap.

## Gates run

- `node --import tsx/esm --test tests/unit/audio-alias-prefix-10586.test.ts` — 4/4 pass
- Full existing audio-module test suite (speech/transcription/translation handlers, provider-node selection, soniox, fishaudio, openrouter nested models, combo resolution) — 94/94 pass
- `node scripts/check/check-file-size.mjs` (changed files) — OK
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — OK
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` (changed files) — clean
- `node scripts/check/check-complexity.mjs` / `check-cognitive-complexity.mjs` — these are whole-repo ratchets (ignore file args); attempted twice but did not finish within the session due to severe devbox CPU saturation from many concurrent parallel sessions running the same full-repo scan simultaneously (confirmed via `ps`, not specific to this change). The diff is a ~10-line addition mirroring the pre-existing Phase-1 prefix-match loop in the same function, so complexity risk is minimal.

⚠️ base-red inherited: #9985