### PR TITLE
fix(dashboard): List Models card must not hardcode models={null} (#10553)

### DIFF
--- a/changelog.d/fixes/10553-list-models-card-hardcoded-null.md
+++ b/changelog.d/fixes/10553-list-models-card-hardcoded-null.md
@@ -1,0 +1,1 @@
+- fix(dashboard): show the real model count on the "List Models" endpoint card instead of a permanent "—" (#10553)

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -2069,7 +2069,8 @@ export default function APIPageClient({ machineId }: Readonly<APIPageClientProps
               iconBg="bg-teal-500/10"
               title={t("listModels")}
               path="/v1/models"
-              models={null}
+              models={allModels}
+              modelsLoading={modelsLoading}
               copy={copy}
               copied={copied}
               baseUrl={currentEndpoint}

--- a/tests/unit/dashboard/endpoint-list-models-card-10553.test.ts
+++ b/tests/unit/dashboard/endpoint-list-models-card-10553.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+// Regression guard for #10553: the "List Models" EndpointCard on the
+// Endpoints dashboard tab (path "/v1/models") was hardcoded with
+// `models={null}`, so it could never show the total model count, unlike
+// every other EndpointCard fed a real models array or the full `allModels`
+// catalog state.
+
+const cwd = process.cwd();
+const filePath = resolve(
+  join(cwd, "src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx")
+);
+const source = readFileSync(filePath, "utf-8");
+
+test("issue #10553: List Models card must not hardcode models={null}", () => {
+  const cardMatch = source.match(
+    /title=\{t\("listModels"\)\}[\s\S]{0,200}?models=\{([^}]*)\}/
+  );
+  assert.ok(cardMatch, "List Models EndpointCard not found");
+  assert.notStrictEqual(cardMatch[1].trim(), "null", "List Models card must not hardcode models={null}");
+});
+
+test("issue #10553: List Models card passes modelsLoading", () => {
+  const cardMatch = source.match(
+    /title=\{t\("listModels"\)\}[\s\S]{0,250}?(modelsLoading=\{[^}]*\})/
+  );
+  assert.ok(cardMatch, "List Models card missing modelsLoading prop");
+});


### PR DESCRIPTION
Closes #10553

Root cause: the "List Models" EndpointCard (path `/v1/models`) on the Endpoints dashboard tab was hardcoded with `models={null}`, so EndpointCard's render logic (`models === null ? "—" : ...`) permanently took the "—" branch. Every sibling card that maps to an actual model-list endpoint is fed a real array + `modelsLoading`; fixed List Models to use `models={allModels}` + `modelsLoading={modelsLoading}`, matching the existing pattern.

Regression test: tests/unit/dashboard/endpoint-list-models-card-10553.test.ts.

⚠️ Note: `npx eslint` on the touched file reports 3 pre-existing errors (temporal-dead-zone lint findings at lines 310/315/316, unrelated to this change) — confirmed present on `origin/release/v3.8.50` tip before this PR (base-red drift, not introduced here).