### PR TITLE
fix(cli): readiness poll must target 127.0.0.1, not localhost (#10508)

### DIFF
--- a/bin/cli/utils/pid.mjs
+++ b/bin/cli/utils/pid.mjs
@@ -102,7 +102,7 @@ export async function waitForServer(port, timeout = 60000) {
 // - "not-listening": nothing is accepting connections on the port at all.
 async function pollHealthOnce(port) {
   try {
-    const res = await fetch(`http://localhost:${port}/api/monitoring/health`, {
+    const res = await fetch(`http://127.0.0.1:${port}/api/monitoring/health`, {
       signal: AbortSignal.timeout(2000),
     });
     return res.ok ? "ready" : "fast-reject";

--- a/changelog.d/fixes/10508-cli-readiness-localhost-dns-delay.md
+++ b/changelog.d/fixes/10508-cli-readiness-localhost-dns-delay.md
@@ -1,0 +1,1 @@
+- fix(cli): use 127.0.0.1 for the readiness health-check poll instead of localhost, avoiding Windows DNS-resolution delays that made a healthy server report as never-ready (#10508)

--- a/tests/unit/cli-readiness-127-0-0-1-10508.test.ts
+++ b/tests/unit/cli-readiness-127-0-0-1-10508.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+// Regression guard for #10508: pollHealthOnce() used "localhost" (forcing DNS
+// resolution) while the sibling isPortListening() already hard-codes 127.0.0.1
+// for exactly this reason. A slow "localhost" DNS lookup (Windows VPN
+// split-DNS/search-suffix probing, corporate resolvers, DNS-filtering
+// security software) can exceed the 2s per-poll timeout and make
+// waitForServer() report "hanging" forever even though the server is healthy.
+
+const filePath = resolve(join(process.cwd(), "bin/cli/utils/pid.mjs"));
+const source = readFileSync(filePath, "utf-8");
+
+test("issue #10508: pollHealthOnce must target 127.0.0.1, not localhost", () => {
+  const match = source.match(/fetch\(`http:\/\/([^:$]+):\$\{port\}\/api\/monitoring\/health`/);
+  assert.ok(match, "pollHealthOnce fetch call not found");
+  assert.equal(match[1], "127.0.0.1", "readiness poll must use the literal 127.0.0.1, not localhost");
+});


### PR DESCRIPTION
Closes #10508

Root cause: the CLI's readiness poll (`pollHealthOnce` in `bin/cli/utils/pid.mjs`) fetched `http://localhost:${port}/...`, forcing a DNS/getaddrinfo lookup for "localhost" — a well-documented source of multi-second delays on Windows (VPN split-DNS, corporate resolvers, DNS-filtering security software). The sibling `isPortListening()` helper in the same file already hard-codes the literal `127.0.0.1` for exactly this reason. A resolution delay past the 2s per-poll timeout makes every poll report "hanging", which never arms the fast-reject grace window, so `waitForServer()` times out even though the server booted successfully.

Fix: target the literal `127.0.0.1`, matching the existing sibling helper.

Regression test: tests/unit/cli-readiness-127-0-0-1-10508.test.ts.