### PR TITLE
fix(cli): npmInstallRuntime must allow-scripts for its own runtime deps (#10713)

### DIFF
--- a/bin/cli/runtime/nativeDeps.mjs
+++ b/bin/cli/runtime/nativeDeps.mjs
@@ -118,6 +118,11 @@ export function npmInstallRuntime(pkgs, opts = {}) {
   // install of a sibling runtime dep (e.g. systray2 from trayRuntime.ts, which writes to the
   // same runtime dir) does not prune this package as "extraneous" — that pruning otherwise
   // reproduces "No SQLite driver available" after a tray install removes better-sqlite3.
+  // npm 12+ defaults `allowScripts` to off, silently skipping lifecycle/install
+  // scripts (e.g. better-sqlite3's node-gyp/prebuild-install rebuild) unless the
+  // package has a matching `allowScripts` entry — and still exits 0, masking the
+  // failure (#10713). The runtime dir is a CLI-owned, non-user package.json, so
+  // explicitly allowing scripts for the packages we are installing here is safe.
   const npmArgs = [
     "install",
     ...pkgs,
@@ -125,6 +130,7 @@ export function npmInstallRuntime(pkgs, opts = {}) {
     "--no-fund",
     "--prefer-online",
     "--save-exact",
+    ...pkgs.map((pkg) => `--allow-scripts=${pkg}`),
   ];
   // On Windows .cmd files cannot be executed without a shell; use cmd.exe /c explicitly
   // so we never set shell:true (which would propagate env and enable injection).

--- a/changelog.d/fixes/10713-runtime-repair-npm12-allow-scripts.md
+++ b/changelog.d/fixes/10713-runtime-repair-npm12-allow-scripts.md
@@ -1,0 +1,1 @@
+- fix(cli): pass --allow-scripts for the runtime's own npm-installed dependencies, so npm 12+'s default install-scripts block no longer silently skips better-sqlite3's native build (#10713)

--- a/tests/unit/cli-npm-install-runtime-allow-scripts-10713.test.ts
+++ b/tests/unit/cli-npm-install-runtime-allow-scripts-10713.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { npmInstallRuntime } from "../../bin/cli/runtime/nativeDeps.mjs";
+
+test("issue #10713: npmInstallRuntime requests --allow-scripts for its own fully-controlled runtime dependency", () => {
+  const fakeBinDir = mkdtempSync(join(tmpdir(), "omniroute-fakenpm-"));
+  const argvLog = join(fakeBinDir, "argv.log");
+  const npmScript = join(fakeBinDir, "npm");
+  writeFileSync(npmScript, `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${argvLog}"\nexit 0\n`);
+  chmodSync(npmScript, 0o755);
+
+  const originalPath = process.env.PATH;
+  const originalDataDir = process.env.DATA_DIR;
+  const fakeDataDir = mkdtempSync(join(tmpdir(), "omniroute-fakedata-"));
+  try {
+    process.env.PATH = `${fakeBinDir}:${originalPath}`;
+    process.env.DATA_DIR = fakeDataDir;
+
+    const ok = npmInstallRuntime(["better-sqlite3@12.10.1"], { silent: true });
+
+    assert.equal(ok, true, "npm 12 exits 0 even when it silently skipped install scripts");
+    assert.ok(existsSync(argvLog), "fake npm should have been invoked");
+
+    const argv = readFileSync(argvLog, "utf8");
+
+    assert.ok(
+      argv.includes("--allow-scripts=better-sqlite3@12.10.1"),
+      "npm must be told to allow-scripts for its own runtime dep. argv was:\n" + argv
+    );
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = originalDataDir;
+    rmSync(fakeBinDir, { recursive: true, force: true });
+    rmSync(fakeDataDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #10713

Root cause: npm 12+ (July 2026) defaults `allowScripts` to off, silently skipping lifecycle/install scripts — including better-sqlite3's implicit node-gyp/prebuild-install rebuild — for any package without a matching `allowScripts` entry, and still exits 0 (a warning, not a failure). `npmInstallRuntime()` in `bin/cli/runtime/nativeDeps.mjs` never requested `--allow-scripts`, so on npm 12+ the CLI's self-heal/runtime-repair path has no reliable automatic way to succeed.

Fix: pass `--allow-scripts=<pkg>` per package being installed. The runtime dir is a CLI-owned, non-user `package.json` (`~/.omniroute/runtime`), so explicitly allowing scripts for exactly the packages this call installs is safe and matches the reporter's own suggested fix.

Regression test: tests/unit/cli-npm-install-runtime-allow-scripts-10713.test.ts (adapted from the plan-file's proven repro with a fake npm shim — reproduces RED on current tip, GREEN after the fix). Verified no regression against 21 existing tests in cli-runtime.test.ts, runtime-deps-save-exact-no-prune.test.ts, sqlite-repair-discoverability-3476.test.ts, runtime/sqliteRuntime-node26-compat.test.ts.