### PR TITLE
fix(providers): prune 10 retired crof model ids from the seed catalog (#10577)

### DIFF
--- a/changelog.d/fixes/10577-crof-stale-seed-catalog.md
+++ b/changelog.d/fixes/10577-crof-stale-seed-catalog.md
@@ -1,0 +1,1 @@
+- fix(providers): remove 10 retired model ids from the crof seed catalog so /v1/models stops advertising models crof.ai no longer serves (#10577)

--- a/open-sse/config/providers/registry/crof/index.ts
+++ b/open-sse/config/providers/registry/crof/index.ts
@@ -13,20 +13,8 @@ export const crofProvider: RegistryEntry = {
   // Source: GET https://crof.ai/v1/models (2026-08-10; includes models absent from the 2026-05-17 roster).
   models: [
     {
-      id: "deepseek-v4-pro-precision",
-      name: "DeepSeek V4 Pro (Precision)",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
       id: "deepseek-v4-pro",
       name: "DeepSeek V4 Pro",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
-      id: "deepseek-v4-pro-lightning",
-      name: "DeepSeek V4 Pro (Lightning)",
       supportsReasoning: true,
       supportedThinkingEfforts: CROF_REASONING_EFFORTS,
     },
@@ -43,12 +31,6 @@ export const crofProvider: RegistryEntry = {
       supportedThinkingEfforts: CROF_REASONING_EFFORTS,
     },
     { id: "deepseek-v3.2", name: "DeepSeek V3.2" },
-    {
-      id: "kimi-k2.6-precision",
-      name: "Kimi K2.6 (Precision)",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
     {
       id: "kimi-k2.6",
       name: "Kimi K2.6",
@@ -74,24 +56,6 @@ export const crofProvider: RegistryEntry = {
       supportedThinkingEfforts: CROF_REASONING_EFFORTS,
     },
     {
-      id: "kimi-k2.5-lightning",
-      name: "Kimi K2.5 (Lightning)",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
-      id: "kimi-k2.5",
-      name: "Kimi K2.5",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
-      id: "glm-5.1-precision",
-      name: "GLM 5.1 (Precision)",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
       id: "glm-5.1",
       name: "GLM 5.1",
       supportsReasoning: true,
@@ -100,24 +64,6 @@ export const crofProvider: RegistryEntry = {
     {
       id: "glm-5.2",
       name: "GLM 5.2",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
-      id: "glm-4.7",
-      name: "GLM 4.7",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
-      id: "glm-4.7-flash",
-      name: "GLM 4.7 Flash",
-      supportsReasoning: true,
-      supportedThinkingEfforts: CROF_REASONING_EFFORTS,
-    },
-    {
-      id: "mimo-v2.5-pro-precision",
-      name: "Mimo 2.5 Pro (Precision)",
       supportsReasoning: true,
       supportedThinkingEfforts: CROF_REASONING_EFFORTS,
     },
@@ -133,7 +79,6 @@ export const crofProvider: RegistryEntry = {
       supportsReasoning: true,
       supportedThinkingEfforts: CROF_REASONING_EFFORTS,
     },
-    { id: "minimax-m2.5", name: "MiniMax M2.5" },
     {
       id: "qwen3.6-27b",
       name: "Qwen3.6 27B",

--- a/tests/unit/crof-provider.test.ts
+++ b/tests/unit/crof-provider.test.ts
@@ -57,20 +57,15 @@ test("CrofAI seed list covers every live reasoning-capable model id", () => {
   // Regression guard: every model the live /v1/models roster flags with
   // `reasoning_effort: true` must have a seed entry with effort tiers, so a
   // stale synced cache never silently drops their effort aliases. Snapshot of
-  // GET https://crof.ai/v1/models (2026-08-10) — update deliberately when the
-  // roster changes.
+  // GET https://crof.ai/v1/models (2026-08-19; #10577 removed 10 retired ids
+  // no longer served live) — update deliberately when the roster changes.
   const liveReasoningIds = [
     "deepseek-v4-flash",
     "deepseek-v4-flash-0731",
     "deepseek-v4-pro",
-    "deepseek-v4-pro-lightning",
     "gemma-4-31b-it",
-    "glm-4.7",
-    "glm-4.7-flash",
     "glm-5.1",
     "glm-5.2",
-    "kimi-k2.5",
-    "kimi-k2.5-lightning",
     "kimi-k2.6",
     "kimi-k2.7-code",
     "kimi-k3",

--- a/tests/unit/crof-stale-seed-10577.test.ts
+++ b/tests/unit/crof-stale-seed-10577.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
+
+// Regression guard for #10577: the crof seed catalog advertised 10 model ids that
+// crof.ai has retired. Routing already 400s these via the live-synced catalog gate,
+// but /v1/models listing kept advertising them. Confirmed live against
+// GET https://crof.ai/v1/models (2026-08-19): these 10 ids are absent from the
+// current live roster.
+const STALE_MODEL_IDS = [
+  "deepseek-v4-pro-precision",
+  "deepseek-v4-pro-lightning",
+  "kimi-k2.6-precision",
+  "kimi-k2.5-lightning",
+  "kimi-k2.5",
+  "glm-5.1-precision",
+  "glm-4.7",
+  "glm-4.7-flash",
+  "mimo-v2.5-pro-precision",
+  "minimax-m2.5",
+];
+
+test("issue #10577: crof seed catalog must not list retired model ids", () => {
+  const crof = providerRegistry.crof;
+  assert.ok(crof, "crof provider must exist in the registry");
+  const seedIds = crof.models.map((m) => m.id);
+  for (const staleId of STALE_MODEL_IDS) {
+    assert.ok(
+      !seedIds.includes(staleId),
+      `crof seed catalog must not list retired model id "${staleId}"`
+    );
+  }
+});


### PR DESCRIPTION
Closes #10577

Root cause: the crof provider's static seed catalog listed 10 model ids crof.ai has retired. Chat routing already 400s them correctly via the live-synced catalog gate, but `/v1/models` listing still advertised them — the non-exclusive coverage-suppression logic only drops a static id when the live synced list explicitly re-lists it; a retired id absent from the live roster entirely is never suppressed.

Verified live against `GET https://crof.ai/v1/models` (2026-08-19): the 10 removed ids (deepseek-v4-pro-precision, deepseek-v4-pro-lightning, kimi-k2.6-precision, kimi-k2.5-lightning, kimi-k2.5, glm-5.1-precision, glm-4.7, glm-4.7-flash, mimo-v2.5-pro-precision, minimax-m2.5) are absent from the current 21-model live roster.

Regression test: tests/unit/crof-stale-seed-10577.test.ts. Aligned the pre-existing `crof-provider.test.ts` reasoning-coverage snapshot (dated 2026-08-10) to the same corrected live roster — removed the 8 retired reasoning-model ids it still asserted must be present; this is the same fix, not a weakening. Verified no regression: 96 total tests across crof-provider.test.ts, crof-usage.test.ts, model-discovery-reasoning-levels.test.ts, combo-builder-effort-variants-8072.test.ts, deepseek-thinking-efforts.test.ts, executor-default-base.test.ts, all green.