### PR TITLE
fix(mitm): forward passthrough traffic to the real requested host (#10479)

### DIFF
--- a/changelog.d/fixes/10479-mitm-passthrough-misroutes-unknown-hosts.md
+++ b/changelog.d/fixes/10479-mitm-passthrough-misroutes-unknown-hosts.md
@@ -1,0 +1,1 @@
+- fix(mitm): forward passthrough traffic to the actual requested Host instead of misrouting every non-TARGET_HOSTS request to the hardcoded Antigravity sandbox host (#10479)

--- a/src/mitm/server.cjs
+++ b/src/mitm/server.cjs
@@ -318,7 +318,14 @@ function getTargetHost(req) {
   const host = String(req.headers.host || "")
     .split(":")[0]
     .toLowerCase();
-  return TARGET_HOSTS.has(host) ? host : "daily-cloudcode-pa.sandbox.googleapis.com";
+  // #10479: the non-TARGET_HOSTS branch used to hardcode a fallback host — in
+  // the original Antigravity DNS-spoof flow, req.headers.host is always a
+  // TARGET_HOSTS member, so it was dead code. The passthrough() call path
+  // added for transparent-redirect/HTTP-proxy clients can reach ANY internet
+  // host, so the real requested Host header must always be forwarded, never
+  // a hardcoded default (which silently misrouted every non-TARGET_HOSTS
+  // request to an unrelated backend).
+  return host;
 }
 
 async function resolveTargetIP(targetHost) {

--- a/tests/unit/mitm-passthrough-real-host-10479.test.ts
+++ b/tests/unit/mitm-passthrough-real-host-10479.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const serverPath = path.resolve(here, "../../src/mitm/server.cjs");
+const src = fs.readFileSync(serverPath, "utf-8");
+
+test("issue #10479: getTargetHost() must not reroute unknown/passthrough hosts to the hardcoded Antigravity default", () => {
+  const fnMatch = src.match(/function getTargetHost\(req\) \{[\s\S]*?\n\}/);
+  assert.ok(fnMatch, "getTargetHost() must exist in server.cjs");
+  const fnBody = fnMatch[0];
+  assert.doesNotMatch(
+    fnBody,
+    /:\s*"daily-cloudcode-pa\.sandbox\.googleapis\.com"/,
+    "getTargetHost() must not hardcode the Antigravity sandbox host as the " +
+      "fallback target for hosts outside TARGET_HOSTS — passthrough traffic " +
+      "for e.g. example.org must be forwarded to example.org, not to Google's " +
+      "Cloud Code API (issue #10479)"
+  );
+});


### PR DESCRIPTION
Closes #10479

Root cause: AgentBridge's standalone MITM proxy (`src/mitm/server.cjs`) misrouted passthrough traffic for any host outside `TARGET_HOSTS`. `getTargetHost()`'s fallback branch hardcoded `"daily-cloudcode-pa.sandbox.googleapis.com"` instead of the real requested Host header — dead code in the original Antigravity DNS-spoof flow (where the Host header is guaranteed to be a TARGET_HOSTS member), but the new transparent-redirect/HTTP-proxy `passthrough()` call path lets clients reach arbitrary internet hosts through the same function, so any host NOT in TARGET_HOSTS was silently forwarded to Google's Cloud Code API instead of the actual requested destination.

Fix: `getTargetHost()` now always returns the real requested Host header.

Regression test: tests/unit/mitm-passthrough-real-host-10479.test.ts. Verified no regression against 36 existing tests in mitm-server-connect.test.ts, mitm-manager-bypass-json.test.ts, agentbridge-antigravity-cert-hosts-6494.test.ts.