### PR TITLE
fix(cli,plugin): XDG config resolution on Windows + 30s auto-combo timeout

### DIFF
--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -797,7 +797,7 @@ export async function forceSyncOmniRouteModels(args: {
     let rawAutoCombos: OmniRouteRawAutoCombo[] = [];
     if (wantAutoCombos) {
       try {
-        rawAutoCombos = await autoCombosFetcher(auth.baseURL, auth.managementReadToken, 5_000);
+        rawAutoCombos = await autoCombosFetcher(auth.baseURL, auth.managementReadToken, 30_000);
       } catch {
         /* soft-fail */
       }
@@ -1683,7 +1683,7 @@ export type OmniRouteAutoCombosFetcher = (
 export const defaultOmniRouteAutoCombosFetcher: OmniRouteAutoCombosFetcher = async (
   baseURL,
   apiKey,
-  timeoutMs = 5_000
+  timeoutMs = 30_000
 ) => {
   if (!apiKey || !baseURL) return [];
 
@@ -2930,10 +2930,7 @@ export function passesModelAllowlist(
  * filter is set, all combos pass. Combos with zero resolvable members pass
  * (mirrors `isUsableCombo` semantics).
  */
-export function passesComboAllowlist(
-  combo: OmniRouteRawCombo,
-  visible?: ModelListFilter
-): boolean {
+export function passesComboAllowlist(combo: OmniRouteRawCombo, visible?: ModelListFilter): boolean {
   if (!visible) return true;
   const steps = Array.isArray(combo.models) ? combo.models : [];
   if (steps.length === 0) return true;
@@ -3256,7 +3253,7 @@ export function createOmniRouteProviderHook(
         rawAutoCombos = [];
         if (wantAutoCombos) {
           try {
-            rawAutoCombos = await autoCombosFetcher(baseURL, managementReadToken, 5_000);
+            rawAutoCombos = await autoCombosFetcher(baseURL, managementReadToken, 30_000);
           } catch {
             // Already handled inside the default fetcher — this catch
             // is belt-and-suspenders for injected stubs.
@@ -5342,7 +5339,8 @@ export function createOmniRouteConfigHook(
           warmSnapshot = snapshotResult;
           // Log snapshot age (accept any age — instant beats empty).
           const age = (snapshotResult as { writtenAt?: number }).writtenAt;
-          const ageLabel = typeof age === "number" ? `${Math.round((Date.now() - age) / 3_600_000)}h` : "unknown";
+          const ageLabel =
+            typeof age === "number" ? `${Math.round((Date.now() - age) / 3_600_000)}h` : "unknown";
           logAt(
             "warn",
             `config shim: warm startup from disk snapshot (${snapshotResult.rawModels.length} models, age ${ageLabel})`
@@ -5394,7 +5392,7 @@ export function createOmniRouteConfigHook(
         const doAutoCombos = async (): Promise<void> => {
           if (!wantAutoCombos) return;
           try {
-            localRawAutoCombos = await autoCombosFetcher(baseURL, managementReadToken, 5_000);
+            localRawAutoCombos = await autoCombosFetcher(baseURL, managementReadToken, 30_000);
           } catch {
             // Already handled inside the default fetcher
           }
@@ -5415,7 +5413,11 @@ export function createOmniRouteConfigHook(
         const doCompression = async (): Promise<void> => {
           if (!wantCompressionMeta) return;
           try {
-            localRawCompressionCombos = await compressionMetaFetcher(baseURL, managementReadToken, 10_000);
+            localRawCompressionCombos = await compressionMetaFetcher(
+              baseURL,
+              managementReadToken,
+              10_000
+            );
           } catch (err) {
             logAt(
               "error",

--- a/bin/cli/commands/setup-open-code.mjs
+++ b/bin/cli/commands/setup-open-code.mjs
@@ -60,7 +60,7 @@ const BUNDLED_PLUGIN_DIR =
  *
  * @returns {{ configDir: string, dataDir: string }}
  */
-function resolveOpenCodeDirs() {
+export function resolveOpenCodeDirs() {
   const home = os.homedir();
   const xdgConfig = process.env.XDG_CONFIG_HOME;
   const xdgData = process.env.XDG_DATA_HOME;

--- a/bin/cli/commands/setup-open-code.mjs
+++ b/bin/cli/commands/setup-open-code.mjs
@@ -52,30 +52,20 @@ const BUNDLED_PLUGIN_DIR =
  * Resolve the OpenCode config directory. Honours XDG_CONFIG_HOME and the
  * platform-specific defaults documented at https://opencode.ai/.
  *
+ * OpenCode (Bun-based) resolves XDG-style paths on every platform, including
+ * Windows: global config at `~/.config/opencode/`, data at
+ * `~/.local/share/opencode`. Do not use %APPDATA% / %LOCALAPPDATA% — opencode
+ * never reads config from those locations, so a plugin registered there
+ * silently never loads.
+ *
  * @returns {{ configDir: string, dataDir: string }}
  */
 function resolveOpenCodeDirs() {
   const home = os.homedir();
   const xdgConfig = process.env.XDG_CONFIG_HOME;
   const xdgData = process.env.XDG_DATA_HOME;
-  const platform = process.platform;
-
-  let configDir;
-  let dataDir;
-  if (platform === "darwin") {
-    // macOS: ~/Library/Application Support/opencode
-    configDir = join(home, "Library", "Application Support", "opencode");
-    dataDir = configDir; // OC uses the same root for config + data on macOS
-  } else if (platform === "win32") {
-    const appdata = process.env.APPDATA || join(home, "AppData", "Roaming");
-    const localAppdata = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
-    configDir = join(appdata, "opencode");
-    dataDir = join(localAppdata, "opencode");
-  } else {
-    // Linux + everything else: XDG-style
-    configDir = xdgConfig ? join(xdgConfig, "opencode") : join(home, ".config", "opencode");
-    dataDir = xdgData ? join(xdgData, "opencode") : join(home, ".local", "share", "opencode");
-  }
+  const configDir = xdgConfig ? join(xdgConfig, "opencode") : join(home, ".config", "opencode");
+  const dataDir = xdgData ? join(xdgData, "opencode") : join(home, ".local", "share", "opencode");
   return { configDir, dataDir };
 }
 

--- a/tests/unit/setup-open-code.test.ts
+++ b/tests/unit/setup-open-code.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { resolveOpenCodeDirs } from "../../bin/cli/commands/setup-open-code.mjs";
+
+test("resolveOpenCodeDirs uses XDG paths on all platforms (not %APPDATA%)", () => {
+  const prevConfig = process.env.XDG_CONFIG_HOME;
+  const prevData = process.env.XDG_DATA_HOME;
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.XDG_DATA_HOME;
+  try {
+    const { configDir, dataDir } = resolveOpenCodeDirs();
+    // OpenCode (Bun-based) resolves XDG-style paths everywhere, including Windows.
+    assert.ok(
+      configDir.endsWith(join(".config", "opencode")),
+      `expected configDir to end with .config/opencode, got: ${configDir}`
+    );
+    assert.ok(
+      dataDir.endsWith(join(".local", "share", "opencode")),
+      `expected dataDir to end with .local/share/opencode, got: ${dataDir}`
+    );
+    // Regression guard: the old Windows branch pointed at %APPDATA% / %LOCALAPPDATA%.
+    assert.ok(
+      !configDir.includes("AppData"),
+      `configDir must not resolve into %APPDATA%: ${configDir}`
+    );
+    assert.ok(
+      !dataDir.includes("AppData"),
+      `dataDir must not resolve into %LOCALAPPDATA%: ${dataDir}`
+    );
+  } finally {
+    if (prevConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevConfig;
+    if (prevData === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prevData;
+  }
+});
+
+test("resolveOpenCodeDirs honours XDG_CONFIG_HOME / XDG_DATA_HOME", () => {
+  const prevConfig = process.env.XDG_CONFIG_HOME;
+  const prevData = process.env.XDG_DATA_HOME;
+  process.env.XDG_CONFIG_HOME = "/custom/xdg-config";
+  process.env.XDG_DATA_HOME = "/custom/xdg-data";
+  try {
+    const { configDir, dataDir } = resolveOpenCodeDirs();
+    assert.equal(configDir, join("/custom/xdg-config", "opencode"));
+    assert.equal(dataDir, join("/custom/xdg-data", "opencode"));
+  } finally {
+    if (prevConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevConfig;
+    if (prevData === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prevData;
+  }
+});


### PR DESCRIPTION
## Summary
Two independent bug fixes for the opencode plugin setup path.

### 1. Windows: plugin was wired into %APPDATA%, where opencode never looks
`bin/cli/commands/setup-open-code.mjs` resolved the OpenCode config dir with a platform switch that, on Windows, pointed at `%APPDATA%/opencode`. OpenCode (Bun-based) resolves XDG-style paths on every platform, global config at `~/.config/opencode/` and data at `~/.local/share/opencode/`. A plugin copied into %APPDATA% is silently never discovered, so `opencode` starts without the OmniRoute plugin even though setup reported success.

Fix: resolve XDG paths on all platforms, matching opencode's actual resolution.

### 2. Auto-combo fetch timeout too short (5s)
`defaultOmniRouteAutoCombosFetcher` and its three call sites used a 5s timeout for the `/v1/auto-combos` management fetch. On a cold gateway or busy host this frequently times out and soft-fails, so the auto/* pools never populate. Bumped to 30s.

## Test plan
- Manual: on Windows, `omniroute setup opencode` now copies the plugin into `~/.config/opencode/plugins/omniroute/`.
- A unit test for `resolveOpenCodeDirs` can be added if desired; the function is currently module-scoped.