### PR TITLE
fix(analytics): treat Claude Code (`claude`/`cc`) as a flat-rate subscription provider (#10773)

### DIFF
--- a/changelog.d/fixes/10774-claude-code-flat-rate.md
+++ b/changelog.d/fixes/10774-claude-code-flat-rate.md
@@ -1,0 +1,1 @@
+- **fix(analytics):** Claude Code (`claude`/`cc`) is a flat-rate subscription, so cost analytics reports `$0` for it instead of estimating Anthropic list prices — the metered `anthropic` API keeps its real cost, and budget/quota/routing still estimate as before ([#10774](https://github.com/diegosouzapw/OmniRoute/pull/10774)) — thanks @electrumguy

--- a/src/lib/usage/flatRateProviders.ts
+++ b/src/lib/usage/flatRateProviders.ts
@@ -31,8 +31,9 @@ import { WEB_COOKIE_PROVIDERS } from "@/shared/constants/providers/web-cookie";
  * its analytics cost is intentional, not an artifact), `byteplus` (BytePlus
  * ModelArk is a metered inference host, billed per token — zeroing it would hide
  * real cost), `minimax-cn` (the metered Minimax China API, distinct from the
- * `minimax` "Minimax Coding" plan), and `glm-thinking` (metered tier, distinct
- * from the `glm` Coding plan).
+ * `minimax` "Minimax Coding" plan), `glm-thinking` (metered tier, distinct
+ * from the `glm` Coding plan), and `anthropic` (the metered Anthropic API,
+ * distinct from the `claude`/`cc` Claude Code plan below).
  */
 const FLAT_RATE_SUBSCRIPTION_PROVIDER_IDS: ReadonlySet<string> = new Set([
   "minimax", // "Minimax Coding" plan
@@ -43,6 +44,8 @@ const FLAT_RATE_SUBSCRIPTION_PROVIDER_IDS: ReadonlySet<string> = new Set([
   "qwen-cloud-token-plan", // Qwen Cloud Token Plan
   "glm", // GLM Coding plan
   "glm-cn", // GLM Coding (China) plan
+  "claude", // Claude Code plan (OAuth-only — a Claude Pro/Max subscription)
+  "cc", // Claude Code plan (alias id — same connection, shares the `cc` pricing rows)
 ]);
 
 /**

--- a/tests/unit/flat-rate-cost-5552.test.ts
+++ b/tests/unit/flat-rate-cost-5552.test.ts
@@ -23,6 +23,8 @@ test("isFlatRateProvider: dedicated subscription / coding-plan providers are fla
     "qwen-cloud-token-plan",
     "glm",
     "glm-cn",
+    "claude",
+    "cc",
   ]) {
     assert.equal(isFlatRateProvider(id), true, `${id} should be flat-rate`);
   }
@@ -36,7 +38,8 @@ test("isFlatRateProvider: case-insensitive + trimmed", () => {
 test("isFlatRateProvider: metered / cost-tracked providers are NOT flat-rate (no hidden cost)", () => {
   // codex/cx = OmniRoute actively tracks Codex token cost (Fast-tier multipliers,
   // GPT-5.x pricing) and Codex can be a metered account; byteplus = metered ModelArk;
-  // minimax-cn = metered China API; glm-thinking = metered tier.
+  // minimax-cn = metered China API; glm-thinking = metered tier; anthropic = the
+  // metered Anthropic API, distinct from the `claude`/`cc` Claude Code plan.
   for (const id of [
     "openai",
     "anthropic",
@@ -68,6 +71,11 @@ test("computeCostFromPricing: flat-rate provider with flatRateAsZero → $0", ()
     computeCostFromPricing(PRICING, TOKENS, { provider: "minimax", flatRateAsZero: true }),
     0
   );
+  // Claude Code is billed by the Pro/Max subscription, never per token.
+  assert.equal(
+    computeCostFromPricing(PRICING, TOKENS, { provider: "claude", flatRateAsZero: true }),
+    0
+  );
 });
 
 test("computeCostFromPricing: opt-in only — flat-rate provider WITHOUT the flag still estimates", () => {
@@ -83,6 +91,11 @@ test("computeCostFromPricing: metered provider with the flag still estimates", (
   // byteplus is metered despite being a subscription-ish gateway — must NOT be zeroed.
   assert.equal(
     computeCostFromPricing(PRICING, TOKENS, { provider: "byteplus", flatRateAsZero: true }),
+    3
+  );
+  // The metered Anthropic API keeps its real cost — only the Claude Code plan is flat-rate.
+  assert.equal(
+    computeCostFromPricing(PRICING, TOKENS, { provider: "anthropic", flatRateAsZero: true }),
     3
   );
 });


### PR DESCRIPTION
## Summary

Cost analytics priced **Claude Code** (`claude`, alias `cc`) at Anthropic list rates, even though that connection is an OAuth Pro/Max **subscription** — a flat monthly fee with no per-token billing. This adds `claude` / `cc` to `FLAT_RATE_SUBSCRIPTION_PROVIDER_IDS`, so the existing `flatRateAsZero` path (#5552 / #5704) reports `$0` for it like every other subscription / coding-plan provider.

Display-only, unchanged semantics: `flatRateAsZero` is opt-in and passed only by the four analytics surfaces, so budget, quota, spend recording and routing keep estimating exactly as before.

Measured on a live 3.8.49 instance: 13 Claude Code requests (6.3k input / 726 output / 59.5k cache-creation) accrued **≈ $0.78** of reported cost at the default `cc` rows (`claude-fable-5` = 10 / 50 / 1.0 / 12.5 per 1M). Cache-creation tokens dominate, so the inflation grows with agentic usage. On the same instance `zai-web` already reports `$0` — only because it happens to be a cookie/web provider.

**Why this is not the `codex` case.** The set deliberately excludes `codex`/`cx` because Codex can also be a metered API account. Claude Code cannot: metered Anthropic is a separate provider id (`anthropic`), so zeroing `claude`/`cc` hides no real spend. This is the same split the file already documents for `minimax` vs `minimax-cn` and `glm` vs `glm-thinking`. `anthropic` is now named in the "deliberately EXCLUDED" comment, and a test asserts it still estimates.

`cc` is included alongside `claude` for the same reason `getCodexFastCostMultiplier` handles both `codex` and `cx` — the alias is what keys the pricing rows.

Scope note: other `subscriptionRisk: true` OAuth providers (`antigravity`, `copilot`, `kiro`, …) look like the same class, but I only have a Claude Code connection to verify against, so they are deliberately left out rather than guessed at.

## Related Issues

- Closes #10773
- Related to #5552, #5704

## Validation

- [x] Change type: other (cost analytics classification — pure data + display)
- [x] Focused tests: `node --import tsx/esm --test tests/unit/flat-rate-cost-5552.test.ts` → **8/8 pass**. Red-then-green checked: with the two set entries reverted, the same file fails 2/8 (`isFlatRateProvider: dedicated subscription / coding-plan providers` and `computeCostFromPricing: flat-rate provider with flatRateAsZero → $0`), so the new assertions do bite.
- [x] `prettier --check` clean on both touched files
- [x] Reconciled with the current active release base (`release/v3.8.50`)
- [x] Production-code change ships updated automated tests in this PR

## Tests Added Or Updated

- `tests/unit/flat-rate-cost-5552.test.ts` — `claude` / `cc` added to the flat-rate id list; `computeCostFromPricing` asserted `$0` for `claude` with the flag; `anthropic` asserted to still estimate at full rate with the flag set.

## Coverage Notes

The change is two entries in an existing `Set` plus a doc comment in `src/lib/usage/flatRateProviders.ts`; both new branches (flat-rate hit for `claude`, metered miss for `anthropic`) are covered by the updated test file, which is the dedicated suite for this module.

## Reviewer Notes

- No migration, no flag, no config surface. Historical rows are re-costed on read, so the Costs dashboard drops the Claude Code line to `$0` retroactively on the next analytics load — worth calling out in the changelog since a user's total will visibly fall.
- If you would rather derive this from the catalog (`subscriptionRisk: true`) than keep an explicit list, say so and I will rework it — I kept the explicit-set style the file argues for.
