### PR TITLE
chore(security): drop the unused enforceSecrets() duplicate

### DIFF
--- a/changelog.d/maintenance/10775-remove-dead-enforce-secrets.md
+++ b/changelog.d/maintenance/10775-remove-dead-enforce-secrets.md
@@ -1,0 +1,1 @@
+- chore(security): remove the unused `enforceSecrets()` duplicate of the boot secret check and pin the live `enforceWebRuntimeEnv()` wiring with a regression test (#10775)

--- a/src/server-init.ts
+++ b/src/server-init.ts
@@ -1,7 +1,6 @@
 // Server startup script
 import initializeCloudSync from "./shared/services/initializeCloudSync";
 import { enforceWebRuntimeEnv } from "./lib/env/runtimeEnv";
-import { enforceSecrets } from "./shared/utils/secretsValidator";
 import { initAuditLog, cleanupExpiredLogs, logAuditEvent } from "./lib/compliance/index";
 import { initConsoleInterceptor } from "./lib/consoleInterceptor";
 import { registerBudgetResetJob } from "./lib/jobs/budgetResetJob";
@@ -33,8 +32,7 @@ async function startServer() {
   // Console interceptor: capture all console output to log file (must be first)
   initConsoleInterceptor();
 
-  // FASE-01: Validate required secrets before anything else (fail-fast)
-  enforceSecrets();
+  // FASE-01: Validate required secrets and runtime env before anything else (fail-fast)
   enforceWebRuntimeEnv();
 
   // Compliance: Initialize audit_log table

--- a/src/shared/utils/secretsValidator.ts
+++ b/src/shared/utils/secretsValidator.ts
@@ -101,35 +101,3 @@ export function validateSecrets(env = process.env) {
     warnings,
   };
 }
-
-/**
- * Validate secrets and terminate process if critical ones are missing.
- * Should be called during server initialization (fail-fast).
- * @param {object} [logger] - Optional logger (defaults to console)
- */
-export function enforceSecrets(logger = console, env = process.env) {
-  const result = validateSecrets(env);
-
-  // Print warnings (non-fatal)
-  for (const w of result.warnings) {
-    logger.warn(`⚠️  [SECURITY] ${w.issue}`);
-  }
-
-  // If there are errors, print them and exit
-  if (!result.valid) {
-    logger.error("");
-    logger.error("═══════════════════════════════════════════════════");
-    logger.error("  ❌  SECURITY: Missing required secrets");
-    logger.error("═══════════════════════════════════════════════════");
-    for (const e of result.errors) {
-      logger.error(`  • ${e.issue}`);
-      logger.error(`    → ${e.hint}`);
-    }
-    logger.error("");
-    logger.error("  Set these in your .env file or environment.");
-    logger.error("  See .env.example for reference.");
-    logger.error("═══════════════════════════════════════════════════");
-    logger.error("");
-    process.exit(1);
-  }
-}

--- a/tests/integration/integration-wiring.test.ts
+++ b/tests/integration/integration-wiring.test.ts
@@ -59,10 +59,6 @@ describe("Pipeline Wiring — server-init.ts", () => {
     assert.match(src, /cleanupExpiredLogs/);
   });
 
-  it("should enforce secrets before startup", () => {
-    assert.match(src, /enforceSecrets/);
-  });
-
   it("should enforce web runtime env before startup", () => {
     assert.match(src, /enforceWebRuntimeEnv/);
   });

--- a/tests/integration/security-hardening.test.ts
+++ b/tests/integration/security-hardening.test.ts
@@ -144,12 +144,6 @@ test("chat handler wires guardrail pre-call validation", () => {
   );
 });
 
-test("server-init.ts calls enforceSecrets", () => {
-  const content = readIfExists("src/server-init.ts");
-  assert.ok(content, "src/server-init.ts should exist");
-  assert.ok(content.includes("enforceSecrets"), "server-init.ts should call enforceSecrets");
-});
-
 test("instrumentation-node.ts validates runtime env after restoring secrets", () => {
   const content = readIfExists("src/instrumentation-node.ts");
   assert.ok(content, "src/instrumentation-node.ts should exist");

--- a/tests/unit/secrets-boot-guard.test.ts
+++ b/tests/unit/secrets-boot-guard.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The boot-time secret check runs through enforceWebRuntimeEnv() (src/lib/env/runtimeEnv.ts),
+ * which feeds validateSecrets() errors into the same exit path as the schema errors. Nothing
+ * pinned that wiring, so unplugging it would silently let a server boot with a too-short
+ * API_KEY_SECRET.
+ *
+ * secretsValidator.ts also exported enforceSecrets(), a second entry point around the same
+ * validateSecrets() call. It had no live caller and duplicated a guard that was already
+ * running — removed here, and asserted gone so it does not come back.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { validateSecrets } from "../../src/shared/utils/secretsValidator.ts";
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.resolve(import.meta.dirname, "../..", relativePath), "utf-8");
+}
+
+// ── validateSecrets rules ────────────────────────────────────────────────────
+
+test("validateSecrets: a strong API_KEY_SECRET and unset JWT_SECRET is valid", () => {
+  const result = validateSecrets({ API_KEY_SECRET: "a".repeat(32) });
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test("validateSecrets: a missing API_KEY_SECRET is an error (the only required rule)", () => {
+  const result = validateSecrets({});
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.name === "API_KEY_SECRET"));
+});
+
+test("validateSecrets: an API_KEY_SECRET shorter than 16 chars is an error", () => {
+  const result = validateSecrets({ API_KEY_SECRET: "short" });
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.name === "API_KEY_SECRET"));
+});
+
+test("validateSecrets: a known-weak but long-enough API_KEY_SECRET is a warning, not an error", () => {
+  // "endpoint-proxy-api-key-secret" is 30 chars — long enough to reach the
+  // known-weak check specifically, not the length check.
+  const result = validateSecrets({ API_KEY_SECRET: "endpoint-proxy-api-key-secret" });
+  assert.equal(result.valid, true, "known-weak values are a warning, not a hard error");
+  assert.ok(result.warnings.some((w) => w.name === "API_KEY_SECRET"));
+});
+
+test("validateSecrets: JWT_SECRET is optional — a missing one is not an error", () => {
+  const result = validateSecrets({ API_KEY_SECRET: "a".repeat(32) });
+  assert.equal(result.valid, true);
+  assert.equal(
+    result.errors.some((e) => e.name === "JWT_SECRET"),
+    false
+  );
+});
+
+// ── The live guard: validateSecrets errors must stay fatal at boot ───────────
+
+test("enforceWebRuntimeEnv exits the process on a secret error", () => {
+  const source = readSource("src/lib/env/runtimeEnv.ts");
+  assert.match(
+    source,
+    /const secretValidation = validateSecrets\(env\)/,
+    "validateWebRuntimeEnv must run validateSecrets"
+  );
+  assert.match(
+    source,
+    /const errors = \[\.\.\.secretValidation\.errors\]/,
+    "secret errors must be merged into the fatal error list, not just warned about"
+  );
+  assert.match(source, /process\.exit\(1\)/, "enforceWebRuntimeEnv must exit on an invalid env");
+});
+
+test("registerNodejs calls enforceWebRuntimeEnv, after ensureSecrets", () => {
+  const source = readSource("src/instrumentation-node.ts");
+  const ensure = source.indexOf("await ensureSecrets();");
+  const enforce = source.indexOf("enforceWebRuntimeEnv()");
+
+  assert.notEqual(ensure, -1, "ensureSecrets() call not found");
+  assert.notEqual(enforce, -1, "enforceWebRuntimeEnv() call not found — the boot guard is unwired");
+  assert.ok(
+    ensure < enforce,
+    "enforceWebRuntimeEnv() must run after ensureSecrets(), which generates the secrets a " +
+      "fresh install does not have yet"
+  );
+});
+
+test("secretsValidator exports no second enforce entry point", () => {
+  const source = readSource("src/shared/utils/secretsValidator.ts");
+  assert.doesNotMatch(
+    source,
+    /export function enforceSecrets/,
+    "enforceSecrets() duplicated the enforceWebRuntimeEnv() guard with no caller"
+  );
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

- `enforceSecrets()` in `src/shared/utils/secretsValidator.ts` validates the secrets and exits on
  error, and its only caller is `src/server-init.ts` — a module nothing imports. It reads like a
  guard that never runs.
- It is not one. `enforceWebRuntimeEnv()` (`src/lib/env/runtimeEnv.ts`) is called unconditionally
  from `registerNodejs()` and runs the same `validateSecrets()`; its errors are merged into the
  list that triggers `process.exit(1)`. A missing or too-short `API_KEY_SECRET` already refuses to
  boot, and has since v3.6.6. `enforceSecrets()` is a strict subset of that check, so giving it a
  caller would refuse nothing the server does not already refuse.
- The duplicate goes instead. `validateSecrets()` — the logic both went through — is untouched.

## Related Issues

- None filed upstream; found while auditing `src/server-init.ts` as dead code. #10780 removes that
  module.

## Validation

- [x] Change type: other (dead-code removal + regression test)
- [x] Focused tests and category gates from the golden path: `tests/unit/secrets-boot-guard.test.ts`
      (8/8) and the two integration files that asserted on the removed function (87 pass, 4 skipped)
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- `tests/unit/secrets-boot-guard.test.ts` (new, replaces `tests/unit/enforce-secrets-boot-wiring.test.ts`)
- `tests/integration/integration-wiring.test.ts`
- `tests/integration/security-hardening.test.ts`

The new file keeps the `validateSecrets` rule coverage and adds what nothing covered before: that
`enforceWebRuntimeEnv()` still runs after `ensureSecrets()` at boot, that secret errors stay in the
fatal list, and that no second `enforce*` entry point comes back.

## Coverage Notes

- `src/shared/utils/secretsValidator.ts` loses a function and its branches; the remaining
  `validateSecrets()` keeps its direct coverage. `src/server-init.ts` loses an import and a call.
  No production code is added.

## Reviewer Notes

- No behavior change: nothing that booted before is refused now, and nothing refused before boots.
- `src/server-init.ts` is touched only to drop the import and the call. #10780 removes that module
  outright; whichever lands second needs a trivial rebase.
- The branch name (`fix/wire-enforce-secrets`) predates the change of approach — this PR removes
  the function rather than wiring it.
