### PR TITLE
fix(catalog): exclude generic 128k default from combo context min() (#10734)

### DIFF
--- a/changelog.d/fixes/10734-combo-context-generic-default.md
+++ b/changelog.d/fixes/10734-combo-context-generic-default.md
@@ -1,0 +1,1 @@
+- **fix(catalog):** stop counting `getTokenLimit()`'s generic 128k catch-all as a known combo window, so `/v1/models` advertises the min of sourced member contexts instead of collapsing a 500k combo to 128k ([#10734](https://github.com/diegosouzapw/OmniRoute/issues/10734))

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -282,6 +282,29 @@ export function getTokenLimit(
 }
 
 /**
+ * Context window from a known source only: an explicit canonical window, or a
+ * provider/model-specific `resolveTokenLimit` result. The generic 128000
+ * catch-all (`specific: false`) is treated as unknown so combo `min()` does
+ * not advertise 128k when every real member is larger (#10734).
+ */
+export function getSourcedTokenLimit(
+  provider: string,
+  model: string | null = null,
+  canonicalWindow?: unknown,
+  snapshot?: ModelCapabilityResolutionSnapshot | null
+): number | undefined {
+  if (
+    typeof canonicalWindow === "number" &&
+    Number.isFinite(canonicalWindow) &&
+    canonicalWindow > 0
+  ) {
+    return canonicalWindow;
+  }
+  const resolved = resolveTokenLimit(provider, model, snapshot);
+  return resolved.specific ? resolved.limit : undefined;
+}
+
+/**
  * Resolve a combo target's token limit without crashing when `parseModel(modelStr)`
  * returns `provider: null` (model id with no `provider/` prefix).
  *
@@ -315,7 +338,7 @@ export function getComboTargetTokenLimit(options: {
  * name heuristic, curated per-provider default) or only from the generic
  * catch-all default.
  */
-function resolveTokenLimit(
+export function resolveTokenLimit(
   provider: string,
   model: string | null = null,
   snapshot?: ModelCapabilityResolutionSnapshot | null

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -68,7 +68,7 @@ import {
   isNoAuthRawProviderPrefix,
   normalizeBlockedProviderSet,
 } from "@/shared/utils/noAuthProviders";
-import { getTokenLimit } from "@omniroute/open-sse/services/contextManager";
+import { getSourcedTokenLimit, getTokenLimit } from "@omniroute/open-sse/services/contextManager";
 import { extractApiKey } from "@/sse/services/auth";
 import type { ComboModelStep } from "@/lib/combos/steps";
 import {
@@ -396,7 +396,10 @@ async function buildUnifiedModelsResponseCore(
     // single-stretch event-loop budget this file's own yield mechanism is meant to protect.
     const connectionsForProviderCache = new Map<string, typeof connections>();
     const getConnectionsForProvider = (...keys: Array<string | null | undefined>) => {
-      const cacheKey = keys.filter((k): k is string => Boolean(k)).sort().join(" ");
+      const cacheKey = keys
+        .filter((k): k is string => Boolean(k))
+        .sort()
+        .join(" ");
       const cached = connectionsForProviderCache.get(cacheKey);
       if (cached) return cached;
       const seen = new Set<string>();
@@ -476,9 +479,11 @@ async function buildUnifiedModelsResponseCore(
       const syncedInputModalities = parseJsonStringArray(synced?.modalities_input);
       const syncedOutputModalities = parseJsonStringArray(synced?.modalities_output);
 
-      const contextLength = isPositiveFiniteNumber(canonical.limits.contextWindow)
-        ? canonical.limits.contextWindow
-        : getTokenLimit(providerId, modelId) || undefined;
+      const contextLength = getSourcedTokenLimit(
+        providerId,
+        modelId,
+        canonical.limits.contextWindow
+      );
       const maxInputTokens = isPositiveFiniteNumber(canonical.limits.maxInputTokens)
         ? canonical.limits.maxInputTokens
         : contextLength;

--- a/src/lib/combos/comboContext.ts
+++ b/src/lib/combos/comboContext.ts
@@ -11,7 +11,7 @@
 
 import { resolveNestedComboTargets } from "@omniroute/open-sse/services/combo";
 import { getCanonicalModelMetadata } from "@/lib/modelMetadataRegistry";
-import { getTokenLimit } from "@omniroute/open-sse/services/contextManager";
+import { getSourcedTokenLimit } from "@omniroute/open-sse/services/contextManager";
 import { buildAliasMaps, getComboTargetModelId } from "@/app/api/v1/models/catalogProviderMaps";
 
 /* ─── helpers ───────────────────────────────────────────────── */
@@ -96,10 +96,7 @@ export function computeComboContextLength(
     const providerId = canonicalMeta.provider || resolvedTarget.providerId;
     const modelId = canonicalMeta.model || resolvedTarget.modelId;
 
-    const targetCtx =
-      (isPositiveFiniteNumber(canonicalMeta.limits.contextWindow)
-        ? canonicalMeta.limits.contextWindow
-        : undefined) ?? getTokenLimit(providerId, modelId);
+    const targetCtx = getSourcedTokenLimit(providerId, modelId, canonicalMeta.limits.contextWindow);
 
     if (isPositiveFiniteNumber(targetCtx)) {
       contextValues.push(targetCtx);

--- a/tests/unit/combo-context-generic-default-10734.test.ts
+++ b/tests/unit/combo-context-generic-default-10734.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-10734-combo-ctx-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET ||= "combo-context-10734-secret";
+
+const { getSourcedTokenLimit, resolveTokenLimit, getTokenLimit } =
+  await import("../../open-sse/services/contextManager.ts");
+const { computeComboContextLength } = await import("../../src/lib/combos/comboContext.ts");
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const contextOverrides = await import("../../src/lib/db/modelContextOverrides.ts");
+const catalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#10734: resolveTokenLimit marks the generic 128k catch-all as specific:false", () => {
+  const resolved = resolveTokenLimit("not-a-real-provider", "no-such-model");
+  assert.equal(resolved.limit, 128000);
+  assert.equal(resolved.specific, false);
+});
+
+test("#10734: getSourcedTokenLimit omits the generic 128k catch-all", () => {
+  assert.equal(getSourcedTokenLimit("not-a-real-provider", "no-such-model"), undefined);
+  assert.equal(getTokenLimit("not-a-real-provider", "no-such-model"), 128000);
+});
+
+test("#10734: getSourcedTokenLimit keeps an explicit canonical window", () => {
+  assert.equal(getSourcedTokenLimit("not-a-real-provider", "no-such-model", 500000), 500000);
+});
+
+test("#10734: getSourcedTokenLimit keeps provider-specific defaults (claude)", () => {
+  const sourced = getSourcedTokenLimit("claude", "claude-sonnet-4");
+  assert.equal(typeof sourced, "number");
+  assert.ok(sourced && sourced > 128000);
+  assert.equal(resolveTokenLimit("claude", "claude-sonnet-4").specific, true);
+});
+
+test("#10734: combo min() ignores unsourced members instead of advertising 128k", () => {
+  const combo = {
+    name: "large-plus-unknown",
+    models: ["glm/glm-5.2", "not-a-real-provider/no-such-model"],
+  };
+  const result = computeComboContextLength(combo, []);
+  assert.equal(
+    result,
+    1000000,
+    "glm-5.2 is a sourced 1M window; the generic-default member must not pull min() to 128k"
+  );
+});
+
+test("#10734: nested combo-ref inherits sourced min(), not 128k", () => {
+  const inner = {
+    name: "inner-large",
+    models: ["glm/glm-5.2", "not-a-real-provider/no-such-model"],
+  };
+  const wrapper = {
+    name: "wrapper-large",
+    models: [{ kind: "combo-ref", comboName: "inner-large" }],
+  };
+  const result = computeComboContextLength(wrapper, [inner, wrapper]);
+  assert.equal(result, 1000000);
+});
+
+test("#10734: GET /v1/models does not advertise 128k for a 500k combo plus an unsourced member", async () => {
+  const modelId = "gpt-5.6-terra";
+  assert.equal(contextOverrides.setModelContextOverride("codex", modelId, 500000), true);
+
+  await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "codex-10734-large-window",
+    accessToken: "codex-test-token",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {},
+  });
+  await combosDb.createCombo({
+    name: "large-context-combo-10734",
+    strategy: "priority",
+    models: [`codex/${modelId}`, "not-a-real-provider/no-such-model"],
+  });
+
+  const response = await catalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const combo = body.data.find((item) => item.id === "large-context-combo-10734");
+
+  assert.equal(response.status, 200);
+  assert.ok(combo, "combo should be published in /v1/models");
+  assert.notEqual(
+    combo.context_length,
+    128000,
+    "generic 128k must not win min() over the 500k sourced member"
+  );
+  assert.equal(combo.context_length, 500000);
+});


### PR DESCRIPTION
## Summary
- Combo `context_length` in `/v1/models` is the min of *sourced* member windows only (canonical window or a provider/model-specific token limit).
- `getTokenLimit()`'s generic 128000 catch-all (`specific: false`) is no longer treated as a known window, so a 500k combo is not advertised as 128k because an unsourced or generic-default member entered `min()`.
- Explicit combo `context_length` overrides still win. Nested combo-refs inherit the same sourced-min rule.

Closes #10734

⚠️ base-red inherited: #9985

## Test plan
- [x] `node --import tsx/esm --test tests/unit/combo-context-generic-default-10734.test.ts`
- [x] `node --import tsx/esm --test tests/unit/combo-context-prefix-resolution.test.ts`
- [x] `node --import tsx/esm --test tests/unit/models-catalog-combo-metadata.test.ts`
- [x] `node --import tsx/esm --test tests/unit/resolveComboContextLimit.test.ts`
- [ ] `GET /v1/models` for a combo whose catalogued members are 500k (plus an unsourced member) advertises 500000, not 128000