### PR TITLE
fix(sse): re-run strict system hoist after format translation

### DIFF
--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -701,6 +701,19 @@ export function translateRequest(
     delete result[RESPONSES_STORE_MARKER];
   }
 
+  // #7293 follow-up: the pre-translation hoist above normalizes the *source*
+  // message array, which a target translator can then undo. `claudeToOpenAI`
+  // pushes `body.system` as a fresh leading system message before appending the
+  // converted messages, so an already-hoisted system lands at index 1 again;
+  // a Responses-source request has no `messages` at all until translation, so
+  // the earlier call is a no-op for it. Re-run on the final outbound array —
+  // it is the only shape the upstream actually sees. Idempotent: same array
+  // reference for non-strict providers and already-compliant requests, so
+  // prompt-cache prefixes stay stable.
+  if (targetFormat === FORMATS.OPENAI && result.messages && Array.isArray(result.messages)) {
+    result.messages = hoistLeadingSystemMessage(result.messages, provider);
+  }
+
   return result;
 }
 

--- a/tests/unit/probe-7293-strict-system-hoist.test.ts
+++ b/tests/unit/probe-7293-strict-system-hoist.test.ts
@@ -142,3 +142,39 @@ test("#7293: already-compliant strict-provider request is a no-op (prompt-cache 
 
   assert.deepEqual(result.messages, messages);
 });
+
+test("#7293: Claude-source request keeps a single leading system message after claudeToOpenAI re-adds body.system", () => {
+  // Claude Code's real shape: a top-level `system` field AND a system-role
+  // message inside `messages`. claudeToOpenAI pushes body.system as the leading
+  // system message and then appends the converted messages, so hoisting before
+  // translation is not enough — the offender reappears at index 1.
+  const body = {
+    model: "mimo-v2.5",
+    system: [{ type: "text", text: "You are a coding assistant." }],
+    messages: [
+      { role: "user", content: "hi" },
+      { role: "system", content: "deferred tools list" },
+      { role: "user", content: "go" },
+    ],
+  };
+
+  const result = translateRequest(
+    FORMATS.CLAUDE,
+    FORMATS.OPENAI,
+    "mimo-v2.5",
+    body,
+    false,
+    null,
+    "xiaomi-mimo"
+  );
+
+  const outMessages = result.messages as Array<{ role: string; content: string }>;
+  const systemIndices = outMessages
+    .map((m, i) => (m.role === "system" ? i : -1))
+    .filter((i) => i >= 0);
+
+  assert.deepEqual(systemIndices, [0]);
+  // Merge, never drop: both the top-level system and the offender survive.
+  assert.match(outMessages[0].content, /You are a coding assistant\./);
+  assert.match(outMessages[0].content, /deferred tools list/);
+});


### PR DESCRIPTION
Setting `OMNIROUTE_STRICT_SYSTEM_PROVIDERS` wasn't enough to get Claude Code talking to a strict upstream, and the reason turned out to be ordering rather than configuration — the hoist runs before the target translator, and `claudeToOpenAI` puts a system message back in front of the one it just hoisted.

My setup: a vLLM endpoint serving Qwen3.8-27B, registered as a `vllm` connection, with `OMNIROUTE_STRICT_SYSTEM_PROVIDERS=vllm`. Qwen3's chat template rejects anything but a single system message at index 0 — same constraint `xiaomi-mimo` already has in `BUILTIN_PROVIDERS_SYSTEM_MUST_BE_FIRST`:

```
{"error":{"message":"System message must be at the beginning.","type":"BadRequestError","code":400}}
```

Claude Code sends a top-level `system` field *and* a `role: "system"` message inside `messages` (its deferred-tools/agents block, ~6.5KB, present on every request — it isn't a hook or a plugin, so there's no way to turn it off client-side). That's the shape that breaks:

- `hoistLeadingSystemMessage` at `open-sse/translator/index.ts:321` runs on the source array and correctly folds the offender onto index 0
- then `claudeToOpenAI` (`open-sse/translator/request/claude-to-openai.ts:161`) pushes `body.system` as a fresh leading system message and appends the converted messages after it
- the hoisted system is back at index 1, and the upstream 400s

A Responses-source request never gets that far — `result.messages` doesn't exist yet at line 321 (only `input` does), so the call is a plain no-op and Codex CLI hits the same wall through `developer` → `system` normalization.

The fix re-runs the same helper on the final outbound array, at the single `return` of `translateRequest`, which is the only shape the upstream actually sees. It's the existing helper with no behaviour change: still merge-never-drop, still returns the same array reference for non-strict providers and already-compliant requests, so prompt-cache prefixes are unaffected.

Confirmed against the live endpoint — the array `claudeToOpenAI` emits today is rejected, and the array the helper produces from it is accepted with both texts preserved:

| messages sent upstream | result |
| --- | --- |
| `[system, user, system, user]` (current) | 400 `System message must be at the beginning.` |
| `[system, user, user]` (after the fix) | 200, system content `"You are a coding assistant.\ndeferred tools list"` |

Added a case to `tests/unit/probe-7293-strict-system-hoist.test.ts` covering the Claude → OpenAI path with both a top-level `system` and a mid-array one, asserting a single system at index 0 with both texts merged. Stashing the `index.ts` change and re-running gives 5 pass / 1 fail with only the new case failing, so it does pin the regression rather than pass vacuously. `memory-system-first-6135`, `claude-system-role-cache-boundary` and `memory-cache-safe-injection` are green too (33 assertions), and ESLint is clean on both files.

Worth a look at whether the pre-translation call at line 321 is still needed once this one exists — I left it alone to keep the diff small, but the later call may well subsume it.
