### PR TITLE
fix(zed-hosted): add connection test support for Zed Hosted Models

### DIFF
--- a/src/app/api/providers/[id]/test/oauthTestConfig.ts
+++ b/src/app/api/providers/[id]/test/oauthTestConfig.ts
@@ -176,6 +176,12 @@ export const OAUTH_TEST_CONFIG: Record<string, OAuthTestConfigEntry> = {
     // Test Connection persists testStatus="error" on a healthy account (#8408).
     checkExpiry: true,
   },
+  "zed-hosted": {
+    // Zed Hosted Models uses a long-lived native-app access token with no
+    // expiry or refresh token. Validate presence here; real connectivity is
+    // exercised by chat requests through the ZedHostedExecutor.
+    checkExpiry: true,
+  },
   cline: CLINE_OAUTH_TEST_CONFIG,
   // ClinePass reuses the same WorkOS OAuth flow and token lifecycle as Cline.
   clinepass: CLINE_OAUTH_TEST_CONFIG,


### PR DESCRIPTION
Adds Zed Hosted Models to OAUTH_TEST_CONFIG so the dashboard connection test no longer reports "Provider test not supported". Other zed-hosted fixes (OAuth paste, executor request format, model discovery) are already present on this branch/upstream.