### PR TITLE
fix(opencode-plugin): keep bare combo ids unprefixed

### DIFF
--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -1294,10 +1294,15 @@ export function mapRawModelToModelV2(
     // `(providerID, modelID)`. If the raw id is already provider-prefixed
     // (e.g. `cc/claude-opus-4-7` from the `cc` Claude Code alias, or
     // `nvidia/llama-3-70b` from a provider that ships prefixed ids), leave
-    // it as-is — double-prefixing breaks OC's lookup. Otherwise prefix with
-    // the resolved `providerId` so a bare key like `claude-opus-4` parses as
-    // `(omniroute, claude-opus-4)` and the credentials resolve correctly.
-    id: raw.id.includes("/") ? raw.id : `${ctx.providerId}/${raw.id}`,
+    // it as-is — double-prefixing breaks OC's lookup. Bare **combo** ids
+    // (`owned_by: "combo"`, e.g. `gpt-5.6-sol`) must also stay unprefixed:
+    // OpenCode looks up `-m <plugin>/<combo>` as model id `<combo>` under
+    // the plugin provider (#10345). Other bare ids still prefix with
+    // `providerId` so credentials resolve as `(omniroute, model)`.
+    id:
+      raw.id.includes("/") || raw.owned_by === "combo"
+        ? raw.id
+        : `${ctx.providerId}/${raw.id}`,
     /**
      * Display name. Falls back to raw.id when no enrichment is available;
      * the caller (`createOmniRouteProviderHook`) overlays

--- a/@omniroute/opencode-plugin/tests/bare-combo-ids-10345.test.ts
+++ b/@omniroute/opencode-plugin/tests/bare-combo-ids-10345.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mapRawModelToModelV2 } from "../src/index.ts";
+
+test("mapRawModelToModelV2: bare combo ids stay unprefixed (#10345)", () => {
+  const combo = mapRawModelToModelV2(
+    {
+      id: "gpt-5.6-sol",
+      owned_by: "combo",
+      context_length: 272000,
+      max_output_tokens: 8192,
+    },
+    { providerId: "omniroute", baseURL: "https://or.example.com/v1" }
+  );
+  assert.equal(combo.id, "gpt-5.6-sol");
+  assert.equal(combo.providerID, "omniroute");
+
+  const slashed = mapRawModelToModelV2(
+    {
+      id: "cx/gpt-5.6-sol",
+      owned_by: "combo",
+      context_length: 272000,
+    },
+    { providerId: "omniroute", baseURL: "https://or.example.com/v1" }
+  );
+  assert.equal(slashed.id, "cx/gpt-5.6-sol");
+
+  const ordinary = mapRawModelToModelV2(
+    { id: "claude-primary", context_length: 200000 },
+    { providerId: "omniroute", baseURL: "https://or.example.com/v1" }
+  );
+  assert.equal(ordinary.id, "omniroute/claude-primary");
+});

--- a/changelog.d/fixes/10345-bare-combo-opencode-ids.md
+++ b/changelog.d/fixes/10345-bare-combo-opencode-ids.md
@@ -1,0 +1,1 @@
+- **fix(opencode-plugin):** publish bare combo model ids without the plugin provider prefix so OpenCode can select them ([#10345](https://github.com/diegosouzapw/OmniRoute/issues/10345))


### PR DESCRIPTION
## Summary
- `/v1/models` combo rows (`owned_by: combo`) with a bare id such as `gpt-5.6-sol` were published as `omniroute/gpt-5.6-sol`.
- OpenCode looks up `-m <plugin>/<combo>` as model id `<combo>` under the plugin provider, so the prefixed id never matched.
- Slashed siblings (`cx/gpt-5.6-sol`) and ordinary non-combo ids are unchanged.

## Related Issues
- Closes #10345

## Validation
- [x] Change type: other (OpenCode plugin catalog)
- [x] Focused tests: `@omniroute/opencode-plugin/tests/bare-combo-ids-10345.test.ts` (1 pass)
- [ ] `npm run lint`
- [x] Reconciled with `release/v3.8.50`
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated
- `@omniroute/opencode-plugin/tests/bare-combo-ids-10345.test.ts`

## Coverage Notes
- `mapRawModelToModelV2` id assignment is covered by the new unit file.

## Reviewer Notes
- Combo entries already discovered via `/api/combos` used the bare `combo.id` in `mapComboToModelV2`. This aligns the `/v1/models` combo rows with that.
