### PR TITLE
feat(speech): accept response_format=ogg as an opus alias

### DIFF
--- a/changelog.d/features/10587-ogg-speech-alias.md
+++ b/changelog.d/features/10587-ogg-speech-alias.md
@@ -1,0 +1,1 @@
+- **feat(providers):** accept `response_format=ogg` on `/v1/audio/speech` as an alias for the existing Opus/Ogg encoder ([#10587](https://github.com/diegosouzapw/OmniRoute/issues/10587))

--- a/open-sse/handlers/audioSpeech.ts
+++ b/open-sse/handlers/audioSpeech.ts
@@ -230,6 +230,16 @@ async function handleDeepgramSpeech(providerConfig, body, modelId, token) {
 }
 
 /**
+ * Voice-note clients send response_format=ogg. OpenAI TTS documents opus, not ogg.
+ * OmniRoute already returns Ogg/Opus bytes for opus — alias ogg → opus (#10587).
+ */
+export function normalizeSpeechResponseFormat(fmt) {
+  if (typeof fmt !== "string" || !fmt) return "mp3";
+  const lower = fmt.toLowerCase();
+  return lower === "ogg" ? "opus" : lower;
+}
+
+/**
  * Handle Soniox TTS (OpenAI speech shape → Soniox /tts, returns raw audio bytes)
  */
 async function handleSonioxSpeech(providerConfig, body, modelId, token) {
@@ -963,7 +973,7 @@ export async function handleAudioSpeech({
         model: modelId,
         input: body.input,
         voice: body.voice || "alloy",
-        response_format: body.response_format || "mp3",
+        response_format: normalizeSpeechResponseFormat(body.response_format),
         speed: body.speed || 1.0,
       }),
     });

--- a/tests/unit/audio-speech-ogg-alias-10587.test.ts
+++ b/tests/unit/audio-speech-ogg-alias-10587.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { normalizeSpeechResponseFormat, handleAudioSpeech } = await import(
+  "../../open-sse/handlers/audioSpeech.ts"
+);
+
+test("normalizeSpeechResponseFormat aliases ogg to opus (#10587)", () => {
+  assert.equal(normalizeSpeechResponseFormat("ogg"), "opus");
+  assert.equal(normalizeSpeechResponseFormat("OGG"), "opus");
+  assert.equal(normalizeSpeechResponseFormat("opus"), "opus");
+  assert.equal(normalizeSpeechResponseFormat("mp3"), "mp3");
+  assert.equal(normalizeSpeechResponseFormat(undefined), "mp3");
+});
+
+test("OpenAI-compat speech path remaps ogg to opus before upstream", async () => {
+  const originalFetch = globalThis.fetch;
+  let captured;
+  globalThis.fetch = async (_url, options = {}) => {
+    captured = JSON.parse(String(options.body || "{}"));
+    return new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+      headers: { "content-type": "audio/opus" },
+    });
+  };
+  try {
+    const response = await handleAudioSpeech({
+      body: {
+        model: "openai/tts-1",
+        input: "format check",
+        voice: "alloy",
+        response_format: "ogg",
+      },
+      credentials: { apiKey: "openai-key" },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(captured.response_format, "opus");
+    assert.equal(captured.model, "tts-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- `POST /v1/audio/speech` with `response_format=ogg` was forwarded to OpenAI TTS and returned 400 `Invalid response_format`.
- OmniRoute already returns Ogg/Opus bytes for `opus`. Map `ogg` → `opus` on the OpenAI-compat path.
- Other formats unchanged.

## Related Issues
- Closes #10587

## Validation
- [x] Change type: provider
- [x] Focused tests: `tests/unit/audio-speech-ogg-alias-10587.test.ts` (2 pass)
- [ ] `npm run lint`
- [x] Reconciled with `release/v3.8.50`
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated
- `tests/unit/audio-speech-ogg-alias-10587.test.ts`

## Coverage Notes
- `normalizeSpeechResponseFormat` and the default OpenAI-compat JSON body are covered by the new unit file.

## Reviewer Notes
- Content-Type remains whatever the upstream returns for opus (typically `audio/opus`).
