### PR TITLE
docs(backend): document memory/skills/token-refresh event-loop cost

### DIFF
--- a/changelog.d/maintenance/10349-optional-work-event-loop.md
+++ b/changelog.d/maintenance/10349-optional-work-event-loop.md
@@ -1,0 +1,1 @@
+- **docs(backend):** document that memory extraction, skills injection, and token refresh share the request event loop, plus dashboard kill switches ([#10349](https://github.com/diegosouzapw/OmniRoute/issues/10349))

--- a/docs/ops/MONITORING_GUIDE.md
+++ b/docs/ops/MONITORING_GUIDE.md
@@ -197,6 +197,11 @@ livenessProbe:
 
 Related: [#10052](https://github.com/diegosouzapw/OmniRoute/issues/10052) (probes while the event loop is busy), [#9685](https://github.com/diegosouzapw/OmniRoute/issues/9685) / [#10055](https://github.com/diegosouzapw/OmniRoute/pull/10055) (catalog pricing hog), [#10117](https://github.com/diegosouzapw/OmniRoute/issues/10117) (compression token-count hog).
 
+
+### Optional request-path work (memory, skills, token refresh)
+
+Memory extraction, skills injection, and OAuth token refresh share the **main Node event loop** with `/healthz`. They are dashboard-toggle features (`memoryEnabled`, `skillsEnabled`), not a worker pool. See [Environment — event-loop cost](../reference/ENVIRONMENT.md#event-loop-cost-of-memory-skills-and-token-refresh-10349).
+
 ### Provider Health
 
 > **No REST endpoint.** Provider health data is available via the MCP tool `observability_snapshot` or the dashboard `/dashboard/providers` page.

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -862,6 +862,19 @@ The logging system writes to both stdout and rotated log files. All configuratio
 
 ### Memory Engine (plan 21)
 
+### Event-loop cost of memory, skills, and token refresh (#10349)
+
+OmniRoute is a **single Node process**. Memory extraction/retrieval, skills injection, and provider token refresh run on that **same event loop** as `GET /healthz` and the dashboard. They are not a worker thread.
+
+| Work | Code | Default | Operator control |
+| --- | --- | --- | --- |
+| Memory extraction / retrieval | `src/lib/memory/` | Dashboard **memoryEnabled** (default on) | Turn off **Settings → Memory**. There is no separate env kill switch beyond disabling the feature in settings. |
+| Skills injection | `src/lib/skills/injection.ts` | Dashboard **skillsEnabled** (default on) | Turn off **Settings → Memory/Skills** (`skillsEnabled`). Sandbox knobs below only bound execution after injection is already on. |
+| Token refresh | `src/sse/services/tokenRefresh.ts` | On for connected OAuth/web providers | Disconnect the provider or let tokens stay valid; there is no `TOKEN_REFRESH=0` env today. |
+
+If `/healthz` is slow on a quiet box, disable memory + skills first, then check catalog/compression load (#10303, #9685). These features yield at `await` points but still compete for the one thread.
+
+
 Embedding layer, vector store and reranking knobs for the persistent memory subsystem (`src/lib/memory/`).
 
 | Variable                        | Default                    | Description                                                                                                |


### PR DESCRIPTION
## Summary
- Confirm the thread model: memory extraction, skills injection, and token refresh run on the **same Node event loop** as `/healthz`.
- Kill switches: dashboard `memoryEnabled` / `skillsEnabled`. Token refresh has no env kill switch today (disconnect the provider).
- Point operators at those toggles when `/healthz` is slow on a quiet box.

## Related Issues
- Closes #10349
- Related to #10303

## Validation
- [x] Change type: other (docs)
- [x] Focused tests: docs-only
- [ ] `npm run lint`
- [x] Reconciled with `release/v3.8.50`

## Tests Added Or Updated
- None. Documentation of existing thread model; no off-thread rewrite in this slice.

## Coverage Notes
- No production code.

## Reviewer Notes
- Moving extraction/injection off the request path is follow-on work. This PR is the document-and-control slice.
