### PR TITLE
fix(cli): prevent DEP0190 child process spawn deprecation on Windows

### DIFF
--- a/src/lib/cli-helper/tool-detector.ts
+++ b/src/lib/cli-helper/tool-detector.ts
@@ -104,7 +104,8 @@ async function detectBinaryWindows(
     const { stdout } = await execFileImpl(located.commandPath, ["--version"], {
       timeout: 5000,
       env,
-      ...(useShell ? { shell: true } : {}),
+      windowsHide: true,
+      ...(useShell ? { shell: true, windowsVerbatimArguments: true } : {}),
     });
     return { installed: true, version: stdout.trim().replace(/^v/, "") };
   } catch {


### PR DESCRIPTION
## Summary

Adds `windowsVerbatimArguments: true` and `windowsHide: true` to `execFileImpl` when probing tool versions with `shell: true` on Windows in `src/lib/cli-helper/tool-detector.ts`.

### Problem & Motivation

On Windows environments running Node.js 22+, executing child processes with `shell: true` alongside array arguments triggers:
```
(node:XXXXX) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

In `detectBinaryWindows()`, CLI tool version probes (`--version`) invoke `.cmd`/`.bat` wrappers via `shell: true`. Passing `windowsVerbatimArguments: true` informs Node that arguments are explicitly intended for the Windows shell wrapper without relying on unsafe legacy argument stringification, silencing the deprecation cleanly.

### Verification

- Confirmed `tool-detector.ts` typechecks cleanly under `npm run typecheck:core`.
- Verified on Windows host running Node.js v24.19.0.
