### PR TITLE
fix(build): ensure standalone package.json declares module type for Node 24 worker compatibility

### DIFF
--- a/scripts/build/colocate-standalone.mjs
+++ b/scripts/build/colocate-standalone.mjs
@@ -13,7 +13,7 @@
  *
  * Run manually after a build, or automatically via the `postbuild` npm hook.
  */
-import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -107,3 +107,22 @@ for (const pkg of closure) {
 console.log(
   `[colocate-standalone] ✅ optional-dep closure: ${closure.length} packages (copied ${copied})`
 );
+
+// 3) Ensure standalone package.json declares "type": "module" so Node 24 runs ESM worker bundles without warning
+const standalonePkgPath = join(STANDALONE, "package.json");
+if (existsSync(standalonePkgPath)) {
+  try {
+    const rawPkg = readFileSync(standalonePkgPath, "utf8");
+    const pkgJson = JSON.parse(rawPkg);
+    if (!pkgJson.type) {
+      pkgJson.type = "module";
+      writeFileSync(standalonePkgPath, JSON.stringify(pkgJson, null, 2) + "\n", "utf8");
+      console.log("[colocate-standalone] ✅ standalone package.json configured with type: module");
+    }
+  } catch (err) {
+    console.warn(
+      "[colocate-standalone] ⚠️  could not update standalone package.json:",
+      err.message
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Updates `scripts/build/colocate-standalone.mjs` to ensure the generated Next.js standalone `package.json` declares `"type": "module"`.

### Problem & Motivation

When OmniRoute is built with standalone output and run under Node.js 24, colocated worker threads (such as `callLogArtifactWorker.js` or `onnxWorker.js`) are bundled in ESM format (`--format=esm`). Because Next.js's default standalone tracer produces a `package.json` without an explicit module type, Node.js 24 emits:
```
(node:XXXXX) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of .../callLogArtifactWorker.js is not specified and it doesn't parse as CommonJS. Reparsing as ES module because module syntax was detected.
```
This forces a runtime parsing retry for every newly spawned worker thread and emits repetitive warnings in production logs.

### Solution

In the standalone post-build co-location step (`colocate-standalone.mjs`), check the generated `standalone/package.json` and set `"type": "module"` if absent.

### Verification

- Confirmed `colocate-standalone.mjs` executes and writes `"type": "module"` to `package.json`.
- Tested worker thread spawn under Node.js v24.19.0: workers boot instantaneously without reparsing warnings.
