### PR TITLE
fix(images): route bare dall-e-3 to OpenAI

### DIFF
--- a/changelog.d/fixes/10832-unprefixed-dalle3.md
+++ b/changelog.d/fixes/10832-unprefixed-dalle3.md
@@ -1,0 +1,1 @@
+- **fix(images):** register OpenAI `dall-e-3` in the image registry so unprefixed `dall-e-3` (and `openai/dall-e-3`) route to OpenAI Images instead of Microsoft Designer Web, and so the chat catalog no longer lists `openai/dall-e-3` as a 128k chat model ([#10832](https://github.com/diegosouzapw/OmniRoute/issues/10832))

--- a/open-sse/config/imageRegistry.ts
+++ b/open-sse/config/imageRegistry.ts
@@ -210,6 +210,7 @@ export const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
     authHeader: "bearer",
     format: "openai", // native OpenAI format
     models: [
+      { id: "dall-e-3", name: "DALL·E 3" },
       { id: "gpt-image-2", name: "GPT Image 2" },
       { id: "gpt-image-1.5", name: "GPT Image 1.5" },
       { id: "gpt-image-1-mini", name: "GPT Image 1 Mini" },

--- a/tests/unit/unprefixed-dalle3-10832.test.ts
+++ b/tests/unit/unprefixed-dalle3-10832.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  IMAGE_PROVIDERS,
+  parseImageModel,
+  getAllImageModels,
+  isRegisteredImageModel,
+} from "../../open-sse/config/imageRegistry.ts";
+
+test("#10832 unprefixed dall-e-3 routes to OpenAI, not Microsoft Designer Web", () => {
+  assert.deepEqual(parseImageModel("dall-e-3"), {
+    provider: "openai",
+    model: "dall-e-3",
+  });
+  assert.deepEqual(parseImageModel("openai/dall-e-3"), {
+    provider: "openai",
+    model: "dall-e-3",
+  });
+  assert.deepEqual(parseImageModel("microsoft-designer-web/dall-e-3"), {
+    provider: "microsoft-designer-web",
+    model: "dall-e-3",
+  });
+  assert.deepEqual(parseImageModel("msdesigner/dall-e-3"), {
+    provider: "microsoft-designer-web",
+    model: "dall-e-3",
+  });
+
+  assert.equal(isRegisteredImageModel("openai", "dall-e-3"), true);
+  assert.equal(isRegisteredImageModel("microsoft-designer-web", "dall-e-3"), true);
+
+  const openai = IMAGE_PROVIDERS.openai;
+  assert.ok(openai.models.some((model) => model.id === "dall-e-3"));
+
+  const catalog = getAllImageModels();
+  assert.ok(catalog.some((model) => model.id === "openai/dall-e-3" && model.provider === "openai"));
+  assert.ok(
+    catalog.some(
+      (model) =>
+        model.id === "microsoft-designer-web/dall-e-3" &&
+        model.provider === "microsoft-designer-web"
+    )
+  );
+});


### PR DESCRIPTION
## Summary

- Register OpenAI `dall-e-3` in `IMAGE_PROVIDERS.openai.models` so the unprefixed `parseImageModel()` scan resolves `dall-e-3` to OpenAI Images instead of Microsoft Designer Web.
- Prefixed `microsoft-designer-web/dall-e-3` and `msdesigner/dall-e-3` stay on Designer Web.
- Because `#6457` skips registered image models from the chat catalog, `openai/dall-e-3` no longer appears as a 128k chat model.

## Related Issues

- Closes #10832

## Validation

- [x] Change type: provider / routing
- [x] Focused tests and category gates from the golden path
- [x] `npx eslint` on the two TypeScript files in this PR
- [x] Reconciled with the current active release base (`release/v3.8.50`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Local gates (this host does not run the full unit suite or production build):

- `npm run check:file-size` — OK (registry did not grow past the freeze)
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/unprefixed-dalle3-10832.test.ts tests/unit/cheaperinference-image-models.test.ts` — 5 pass

## Tests Added Or Updated

- `tests/unit/unprefixed-dalle3-10832.test.ts` (new; frozen `image-generation-handler.test.ts` left untouched)

## Coverage Notes

- `open-sse/config/imageRegistry.ts`: `parseImageModel("dall-e-3")` now returns `{ provider: "openai", model: "dall-e-3" }`; `isRegisteredImageModel("openai", "dall-e-3")` is true; `getAllImageModels()` includes `openai/dall-e-3`.
- Coverage on the frozen handler test file is unchanged.

## Reviewer Notes

- Designer Web still owns the **prefixed** `dall-e-3` id. Only the unprefixed scan changes, via OpenAI being listed first in `IMAGE_PROVIDERS`.
- No credential, hostname, or operator combo names in this PR.
