### PR TITLE
fix(catalog): stop advertising auto/* when auto routing is disabled

### DIFF
--- a/changelog.d/fixes/10857-hide-auto-models-when-routing-disabled.md
+++ b/changelog.d/fixes/10857-hide-auto-models-when-routing-disabled.md
@@ -1,0 +1,1 @@
+- **fix(catalog):** `/v1/models` no longer advertises the built-in `auto/*` ids while auto routing is disabled — they were listed but rejected at request time with `Auto routing is disabled` ([#10831](https://github.com/diegosouzapw/OmniRoute/issues/10831), [#10857](https://github.com/diegosouzapw/OmniRoute/pull/10857)) — thanks @ntdat812

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -181,7 +181,11 @@ export async function getUnifiedModelsResponse(
       { corsHeaders, diagnosticHeaders },
       buildCatalogPayload,
       {
-        hideAutoCombos: settingsForAuth?.hideAutoCombos === true,
+        // #10831: a disabled router hides auto/* just as hideAutoCombos does, so
+        // the two collapse into one cache dimension — the resulting catalogs are
+        // identical and do not need separate entries.
+        hideAutoCombos:
+          settingsForAuth?.hideAutoCombos === true || settingsForAuth?.autoRoutingEnabled === false,
         hideNoThinkVariants: settingsForAuth?.hideNoThinkVariants === true,
       }
     );
@@ -292,7 +296,11 @@ async function buildUnifiedModelsResponseCore(
     // #9418: Opt-in filter — skip the entire auto/* synthesis loop when the operator
     // does not want built-in virtual combos advertised in the catalog. User-defined
     // combos are unaffected; routing still works for ids sent explicitly.
-    const hideAuto = settings.hideAutoCombos === true;
+    // #10831: also drop them when auto routing is switched off. Unlike
+    // hideAutoCombos — which only unadvertises ids that still route when sent
+    // explicitly — a disabled router rejects every auto/* id with a 400, so
+    // listing them offers the client a choice that cannot succeed.
+    const hideAuto = settings.hideAutoCombos === true || settings.autoRoutingEnabled === false;
     const shouldHidePaid = (providerKey: string, modelId: string, pricing?: unknown): boolean => {
       if (!hidePaid) return false;
       const provider = aliasToProviderId[providerKey] || providerKey;

--- a/tests/unit/catalog-auto-routing-disabled-10831.test.ts
+++ b/tests/unit/catalog-auto-routing-disabled-10831.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #10831 — when auto routing is switched off, `auto/*` ids must not be
+ * advertised in `/v1/models`.
+ *
+ * Unlike `hideAutoCombos` (#9418), which only unadvertises ids that still route
+ * when a client sends them explicitly, `autoRoutingEnabled: false` makes the
+ * router reject every `auto/*` id with
+ * "Auto routing is disabled. Enable it in Settings > Routing." (see
+ * src/sse/handlers/autoRouting.ts). Listing them therefore offers the picker a
+ * choice that can only fail.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-auto-routing-10831-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+async function fetchCatalog(): Promise<Array<{ id: string }>> {
+  const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models", { method: "GET" })
+  );
+  if (res.status !== 200) {
+    const body = await res.text();
+    assert.fail(`Expected 200, got ${res.status}: ${body.slice(0, 500)}`);
+  }
+  const body = (await res.json()) as { data: Array<{ id: string }> };
+  return body.data;
+}
+
+const isAutoId = (m: { id: string }) => m.id.startsWith("auto/");
+
+test.after(() => {
+  core.resetDbInstance();
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+test("autoRoutingEnabled=false removes auto/* ids from /v1/models", async () => {
+  await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "openai-main",
+    apiKey: "sk-test",
+    isActive: true,
+  });
+
+  // Baseline: routing on, ids advertised.
+  await settingsDb.updateSettings({ autoRoutingEnabled: true, hideAutoCombos: false });
+  const on = await fetchCatalog();
+  const autoWhenOn = on.filter(isAutoId).map((m) => m.id);
+  assert.equal(
+    autoWhenOn.length > 0,
+    true,
+    `expected auto/* ids while auto routing is enabled, got ${autoWhenOn.length}`
+  );
+
+  // Routing off: none may remain.
+  await settingsDb.updateSettings({ autoRoutingEnabled: false, hideAutoCombos: false });
+  const off = await fetchCatalog();
+  const leaked = off.filter(isAutoId).map((m) => m.id);
+  assert.deepEqual(
+    leaked,
+    [],
+    `auto/* ids leaked while auto routing is disabled: ${leaked.join(", ")}`
+  );
+
+  // Everything else must survive — this is a filter, not a catalog wipe.
+  const hasProviderModel = off.some((m) => m.id.startsWith("openai/") || m.id.startsWith("oa/"));
+  assert.equal(hasProviderModel, true, "provider models must remain when auto routing is disabled");
+});
+
+test("re-enabling auto routing brings auto/* ids back (cache key varies on the flag)", async () => {
+  await settingsDb.updateSettings({ autoRoutingEnabled: false, hideAutoCombos: false });
+  const off = await fetchCatalog();
+  assert.deepEqual(
+    off.filter(isAutoId).map((m) => m.id),
+    []
+  );
+
+  await settingsDb.updateSettings({ autoRoutingEnabled: true, hideAutoCombos: false });
+  const back = await fetchCatalog();
+  assert.equal(
+    back.filter(isAutoId).length > 0,
+    true,
+    "auto/* ids must return once auto routing is re-enabled — a stale cached catalog would fail here"
+  );
+});


### PR DESCRIPTION
## Summary

Closes #10831.

With `autoRoutingEnabled: false`, `/v1/models` still advertised every built-in `auto/*` id, but the
router rejects all of them at request time:

```
Error: OmniRoute request failed (HTTP 400): Auto routing is disabled. Enable it in Settings > Routing.
```

(`src/sse/handlers/autoRouting.ts`). A picker built from `/v1/models` therefore offered 38 choices
that could only fail. Verified count from the failing test on `release/v3.8.50`:

```
auto/best-coding, auto/best-reasoning, auto/best-fast, auto/best-vision, auto/best-chat,
auto/best-coding-fast, auto/pro-coding, … auto/glm, auto/minimax, auto/mimo, auto/zai,
auto/gemma, auto/llama, auto/gemini      (38 ids)
```

`auto/best-coding` is the one named in the report.

## Why `hideAutoCombos` did not already cover it

They mean different things, and the distinction is worth preserving:

- `hideAutoCombos` (#9418) **unadvertises** ids that remain routable when a client sends them
  explicitly — an opt-in catalog-noise filter.
- `autoRoutingEnabled: false` makes them **unroutable**. Listing them is not noise, it is a wrong
  answer.

So this does not change what `hideAutoCombos` means; it adds the second reason to hide.

## Fix

One decision point, in `catalog.ts`:

```ts
const hideAuto =
  settings.hideAutoCombos === true || settings.autoRoutingEnabled === false;
```

and the same disjunction in the value handed to the catalog cache dimension.

**On the cache:** my first attempt added `autoRoutingDisabled` as a seventh cache-key field. That was
wrong twice over — it broke `10313-catalog-cache-key-hashing.test.ts`, which pins the key at six
pipe-delimited fields, and it was unnecessary: both flags produce an *identical* catalog (no `auto/*`
entries), so they need one shared bit, not two dimensions. Collapsing them keeps the key format
untouched and `#10313` green.

## Tests

`tests/unit/catalog-auto-routing-disabled-10831.test.ts` (new, 2 cases), modelled on the existing
`catalog-hide-auto-no-think.test.ts`:

1. `autoRoutingEnabled=false` removes every `auto/*` id while provider models survive — a filter, not
   a catalog wipe.
2. Re-enabling brings them back. This one exists specifically to catch a stale cached catalog: if the
   flag did not participate in the cache dimension, the second fetch would still serve the filtered
   payload and the test would fail.

```
npx tsx --test tests/unit/catalog-auto-routing-disabled-10831.test.ts     2/2 pass
+ catalog-hide-auto-no-think, 10313-catalog-cache-key-hashing,
  9147-catalog-eventloop-yield                                            9/9 pass (4 files)
npx eslint <changed files>                                                clean
```

The new test fails **2/2 on `release/v3.8.50`**, listing all 38 leaked ids, and passes here.

`src/app/api/v1/models/catalog.ts` reports one pre-existing ESLint error (`'@/lib/localDb' import is
restricted`, line 3) — identical on a clean checkout, untouched by this PR.

## Compatibility

No change for the default configuration (`autoRoutingEnabled` unset or true) or for anyone already
using `hideAutoCombos`. Explicitly-sent `auto/*` ids are unaffected by this PR — they were already
being rejected by the router, which is the behaviour the issue reports.
