### PR TITLE
feat(vision-bridge): honor configured vision model + support custom model input & all active providers (#10808, #10809)

### DIFF
--- a/open-sse/executors/commandCode.ts
+++ b/open-sse/executors/commandCode.ts
@@ -387,6 +387,38 @@ const COMMAND_CODE_PASSTHROUGH_FIELDS = [
   "extra_body",
 ] as const;
 
+/**
+ * Command Code's /alpha/generate endpoint serves most models under a
+ * vendor-prefixed wire id (e.g. `xiaomi/mimo-v2.5`, `deepseek/deepseek-v4-pro`,
+ * `moonshotai/Kimi-K2.6`) and defaults an unprefixed id to the `anthropic:`
+ * provider, which 403s with "Model/provider not recognized: anthropic:<id>".
+ * The command-code registry ids already carry the vendor prefix, so a bare id
+ * reaching the executor is an operator-set custom model (e.g. the Vision Bridge
+ * picker, #10809). Map the small set of documented bare ids to their
+ * vendor-prefixed wire form; anything with an explicit `/` (or already wired)
+ * passes through untouched. Kept minimal and doc-backed, mirroring the
+ * `CC_VISION_MODEL_PATTERNS` philosophy.
+ */
+const COMMAND_CODE_BARE_MODEL_VENDOR_PREFIX: Readonly<Record<string, string>> = {
+  // Xiaomi MiMo V2.5 — the only CC-served vision model not in the registry.
+  "mimo-v2.5": "xiaomi/mimo-v2.5",
+  "mimo-v2.5-pro": "xiaomi/mimo-v2.5-pro",
+};
+
+/**
+ * Normalize an incoming model id to the wire form Command Code's upstream
+ * accepts. Strips a leading provider prefix (`command-code/` / `cmd/`) that the
+ * pipeline may have resolved, then maps known bare ids to their
+ * vendor-prefixed form (see above).
+ */
+function normalizeCommandCodeWireModel(model: string): string {
+  const trimmed = String(model || "").trim();
+  if (!trimmed) return trimmed;
+  const bare = trimmed.replace(/^(?:command-code|cmd)\//, "");
+  if (bare.includes("/")) return bare;
+  return COMMAND_CODE_BARE_MODEL_VENDOR_PREFIX[bare] ?? bare;
+}
+
 function buildCommandCodeBody(
   model: string,
   body: unknown,
@@ -398,8 +430,10 @@ function buildCommandCodeBody(
   // Payload rules may rewrite `body.model` (e.g. deepseek-v4-pro-max →
   // deepseek/deepseek-v4-pro for the command-code provider). Prefer the
   // rewritten value if present; fall back to the resolved combo model arg.
-  const resolvedModel =
-    typeof input.model === "string" && input.model.trim().length > 0 ? input.model : model;
+  // Normalize to the vendor-prefixed wire id the upstream requires (#10809).
+  const resolvedModel = normalizeCommandCodeWireModel(
+    typeof input.model === "string" && input.model.trim().length > 0 ? input.model : model
+  );
 
   const converted = convertMessages(input.messages, resolvedModel, toolNameMap);
   const explicitSystem = typeof input.system === "string" ? input.system : "";

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -28,13 +28,17 @@ export function isEmptyContentResponse(responseBody: unknown): boolean {
 
     const content = message?.content ?? delta?.content;
     const reasoningContent = message?.reasoning_content ?? delta?.reasoning_content;
+    // opencode-routed gateways (e.g. opencode/mimo-v2.5-free) name the reasoning
+    // field `reasoning` instead of `reasoning_content` (#6623).
+    const reasoningAlt = message?.reasoning ?? delta?.reasoning;
     const hasToolCalls =
       (Array.isArray(message?.tool_calls) && (message.tool_calls as unknown[]).length > 0) ||
       (Array.isArray(delta?.tool_calls) && (delta.tool_calls as unknown[]).length > 0);
 
     const hasContent = content !== null && content !== undefined && content !== "";
     const hasReasoning =
-      reasoningContent !== null && reasoningContent !== undefined && reasoningContent !== "";
+      (reasoningContent !== null && reasoningContent !== undefined && reasoningContent !== "") ||
+      (reasoningAlt !== null && reasoningAlt !== undefined && reasoningAlt !== "");
 
     // A response truncated at the token limit (finish_reason "length") is a valid,
     // successful completion even with empty text — do not flag it as a fake success.

--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -299,8 +299,15 @@ export function detectMalformedNonStream(resp: unknown): MalformedReason | null 
     )
       return true;
     if (Array.isArray(msg?.tool_calls) && (msg.tool_calls as unknown[]).length > 0) return true;
+    // Reasoning-only completions are real output: a reasoning model that
+    // exhausts max_tokens on chain-of-thought returns `content: null` with the
+    // analysis in a reasoning field. Some OpenAI-compatible upstreams (e.g.
+    // opencode/mimo-v2.5-free via the OpenCode gateway) name it `reasoning`
+    // rather than `reasoning_content` — missing either variant falsely flagged
+    // these as empty_choices → 502 (#6623).
     if (typeof msg?.reasoning_content === "string" && (msg.reasoning_content as string).length > 0)
       return true;
+    if (typeof msg?.reasoning === "string" && (msg.reasoning as string).length > 0) return true;
     return false;
   });
 

--- a/src/app/(dashboard)/dashboard/settings/components/modalityBridge/ModalityBridgeVisionTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/modalityBridge/ModalityBridgeVisionTab.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { Card, ModelSelectField, Toggle } from "@/shared/components";
-import type { ApiModel } from "@/shared/components/ModelSelectField";
 import {
   MODALITY_BRIDGE_DEFAULTS,
   resolveVisionBridgeRuntimeSettings,
@@ -56,7 +55,6 @@ function clampNumber(raw: string, min: number, max: number, fallback: number): n
 export default function ModalityBridgeVisionTab() {
   const t = useTranslations("settings");
   const [settings, setSettings] = useState<VisionState | null>(null);
-  const isVisionModel = useCallback((model: ApiModel) => model.supportsVision === true, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -174,9 +172,20 @@ export default function ModalityBridgeVisionTab() {
           value={settings.modalityBridgeVisionModel}
           placeholder={t("modalityBridgeVisionModelAuto")}
           allowEmpty
+          // #10809: read the unified catalog (all configured providers +
+          // user-added custom models — matching the Audio tab's modelSource)
+          // so active upstream vision models are never missed. #10703: the
+          // filter still lists only vision-capable models, so text-only code
+          // models (cmd/gpt-5.3-codex, cmd/deepseek/deepseek-v4-pro, …) never
+          // appear as Vision Bridge candidates. allowCustomInput keeps an
+          // editable text field so operators can type a self-hosted / unlisted
+          // vision model.
+          modelSource="catalog"
+          modelFilter={(model) => model.supportsVision === true}
+          allowCustomInput
+          testId="modality-bridge-vision-model"
           onChange={(value) => void update({ modalityBridgeVisionModel: value })}
           className="text-sm"
-          modelFilter={isVisionModel}
         />
 
         <Toggle

--- a/src/lib/guardrails/visionBridge.ts
+++ b/src/lib/guardrails/visionBridge.ts
@@ -419,12 +419,25 @@ export class VisionBridgeGuardrail extends BaseGuardrail {
     // callVisionModel may fall back internally to another vision model, and
     // keying by attempt would fragment the cache and leak router state into the
     // key. Intentional and stable — do not "fix" this to key per attempt.
+    //
+    // The prompt component is the BASE prompt (`config.prompt`), deliberately
+    // NOT the task-aware composed prompt (`composedPrompt`): the composed
+    // prompt appends the LAST user text, which changes on every conversation
+    // turn. Zoo Code / Claude Code clients resend the FULL transcript each
+    // turn, so a text-only follow-up still carries the turn-1 image in the
+    // history — the bridge re-enters the describe path — but if the key
+    // changed with each new turn it would miss the cache and re-call the
+    // vision model (e.g. mimo-v2.5) for byte-identical images. Keying on the
+    // stable base prompt makes an unchanged history image reuse the cached
+    // description; a genuinely NEW image has a different contentRef and still
+    // misses. The task-aware prompt is what the vision model actually receives
+    // on the first describe, so no description quality is lost.
     const cache = runtime.cacheEnabled ? getSharedBridgeCacheFor(runtime) : null;
 
     // Process all images in parallel using Promise.allSettled for fail-partial behavior
     const results = await Promise.allSettled(
       limitedParts.map(async (imagePart, i) => {
-        const key = cache ? bridgeCacheKey(imagePart.imageUrl, composedPrompt, config.model) : null;
+        const key = cache ? bridgeCacheKey(imagePart.imageUrl, config.prompt, config.model) : null;
         const cached = key && cache ? cache.get(key) : undefined;
         const description = cached ?? (await callVision(imagePart.imageUrl, describeConfig));
         if (cached === undefined && key && cache) cache.set(key, description);

--- a/src/lib/guardrails/visionBridgeCredentials.ts
+++ b/src/lib/guardrails/visionBridgeCredentials.ts
@@ -5,6 +5,9 @@
  * (visionBridge.ts already imports getBestVisionModel from visionBridgeRouter.ts).
  */
 
+import { resolveProviderId } from "@/shared/constants/providers";
+import { isNoAuthProviderKey } from "@/shared/utils/noAuthProviders";
+
 /**
  * True when a provider connection can actually authenticate upstream.
  * `noauth` with no real API key is NOT usable (opencode-zen free tier often
@@ -36,9 +39,14 @@ function hasOAuthCredential(connection: ProviderConnectionLike): boolean {
   );
 }
 
-export function isProviderConnectionUsable(connection: ProviderConnectionLike): boolean {
+/** True when the connection row carries a terminal status (disabled/banned/expired). */
+export function hasTerminalConnectionStatus(connection: ProviderConnectionLike): boolean {
   const status = String(connection.testStatus || "").toLowerCase();
-  if (TERMINAL_CONNECTION_STATUSES.has(status)) {
+  return TERMINAL_CONNECTION_STATUSES.has(status);
+}
+
+export function isProviderConnectionUsable(connection: ProviderConnectionLike): boolean {
+  if (hasTerminalConnectionStatus(connection)) {
     return false;
   }
 
@@ -78,22 +86,34 @@ function loadProvidersModule(): Promise<typeof import("@/lib/db/providers")> {
 /**
  * Resolve whether `provider/model` has at least one usable active connection.
  * Returns `null` when the credential store is unavailable (unit tests / early boot).
+ *
+ * The provider prefix is resolved alias→canonical id before querying
+ * `provider_connections` (the column stores the id, e.g. "opencode" for the
+ * "oc" alias — #10702: an alias-keyed query returned zero rows and excluded
+ * every candidate). No-auth providers (NOAUTH_PROVIDERS) need no stored API
+ * key: their effective credential is the synthetic "noauth" connection, so
+ * an empty active set is usable for them (unlike keyed providers). A stored
+ * row with a terminal status (disabled/banned/expired) still blocks the
+ * provider; any other row is treated as usable (the key requirement does not
+ * apply — a noauth row carries no API key by design).
  */
 export async function hasUsableCredentialsForModel(model: string): Promise<boolean | null> {
-  const rawPrefix = typeof model === "string" ? model.split("/")[0]?.trim() : "";
-  if (!rawPrefix) return null;
+  const rawProvider = typeof model === "string" ? model.split("/")[0]?.trim() : "";
+  if (!rawProvider) return null;
+  const provider = resolveProviderId(rawProvider);
+  const isNoAuth = isNoAuthProviderKey(rawProvider, provider);
   try {
     const { getProviderConnections } = await loadProvidersModule();
-    // The model ids this module receives use the PUBLIC ALIAS (PROVIDER_MODELS keys,
-    // e.g. "cmd" for command-code), but provider_connections.provider is always
-    // persisted under the raw registry id — resolve the alias first, matching every
-    // other credential-check path (open-sse/services/model.ts, sse/services/auth.ts).
-    const { resolveProviderId } = await import("@/shared/constants/providers");
-    const provider = resolveProviderId(rawPrefix);
     const connections = await getProviderConnections({ provider, isActive: true });
     if (!Array.isArray(connections)) return null;
-    // Empty active set is a definitive "no" only when the table is readable.
-    if (connections.length === 0) return false;
+    // Empty active set: keyed providers are definitively unusable; no-auth
+    // providers still work through the synthetic "noauth" connection.
+    if (connections.length === 0) return isNoAuth;
+    // No-auth rows store no API key (authType "noauth" + empty apiKey would
+    // fail the generic key check) — only a terminal status blocks them.
+    if (isNoAuth) {
+      return !connections.some((c: any) => hasTerminalConnectionStatus(c));
+    }
     return connections.some((c: any) => isProviderConnectionUsable(c));
   } catch {
     return null;

--- a/src/lib/guardrails/visionBridgeHelpers.ts
+++ b/src/lib/guardrails/visionBridgeHelpers.ts
@@ -526,6 +526,11 @@ function parseSseVisionBody(rawBody: string): unknown {
     if (typeof delta?.reasoning_content === "string" && delta.reasoning_content.length > 0) {
       reasoningParts.push(delta.reasoning_content);
     }
+    // opencode-routed gateways (e.g. mimo-v2.5-free) stream chain-of-thought in
+    // `delta.reasoning` instead of `reasoning_content` (#6623).
+    if (typeof delta?.reasoning === "string" && delta.reasoning.length > 0) {
+      reasoningParts.push(delta.reasoning);
+    }
 
     // Some providers put a full message (not a delta) in the final chunk.
     const message = choice?.message as Record<string, unknown> | undefined;
@@ -534,6 +539,9 @@ function parseSseVisionBody(rawBody: string): unknown {
     }
     if (typeof message?.reasoning_content === "string" && message.reasoning_content.length > 0) {
       reasoningParts.push(message.reasoning_content);
+    }
+    if (typeof message?.reasoning === "string" && message.reasoning.length > 0) {
+      reasoningParts.push(message.reasoning);
     }
 
     // Anthropic-style streaming: `content_block_delta` with `delta.text`.
@@ -602,13 +610,17 @@ async function readVisionResponseBody(response: Response): Promise<unknown> {
 
 /**
  * Extract the description text from an OpenAI-compatible vision response.
- * Falls back to `reasoning_content` when `content` is empty — reasoning models
- * (e.g. xiaomi/mimo-v2.5) can exhaust `max_tokens` on chain-of-thought and
- * return `content: null` with a complete analysis in `reasoning_content`.
+ * Falls back to `reasoning_content` then `reasoning` when `content` is empty —
+ * reasoning models (e.g. xiaomi/mimo-v2.5, opencode/mimo-v2.5-free) can exhaust
+ * `max_tokens` on chain-of-thought and return `content: null` with a complete
+ * analysis in a reasoning field. opencode-routed gateways name that field
+ * `reasoning` rather than `reasoning_content` (#6623 / #10809).
  */
 function extractOpenAICompatibleContent(data: unknown): string {
   const record = data as {
-    choices?: Array<{ message?: { content?: unknown; reasoning_content?: unknown } }>;
+    choices?: Array<{
+      message?: { content?: unknown; reasoning_content?: unknown; reasoning?: unknown };
+    }>;
     error?: { message?: string };
   } | null;
 
@@ -625,7 +637,11 @@ function extractOpenAICompatibleContent(data: unknown): string {
   if (content) return content;
 
   const reasoning =
-    typeof message?.reasoning_content === "string" ? message.reasoning_content.trim() : "";
+    typeof message?.reasoning_content === "string"
+      ? message.reasoning_content.trim()
+      : typeof message?.reasoning === "string"
+        ? message.reasoning.trim()
+        : "";
   if (reasoning) return reasoning;
 
   throw new Error("Vision API returned empty or invalid response");

--- a/src/lib/modelCapabilities.ts
+++ b/src/lib/modelCapabilities.ts
@@ -434,10 +434,19 @@ export function modelIdLikelyVision(modelId: string | null | undefined): boolean
  * models are text-only (mimo.mi.com .../image-understanding; hermes-agent#18884).
  * Anchored to the full id (`$`) and tolerant of a `provider/` prefix so `mimo-v2.5-pro`
  * never matches the multimodal `mimo-v2.5`, and `mimo-v2-pro` never matches `mimo-v2-omni`.
+ *
+ * Command Code `cmd/gpt-5.3-codex*` (#10703): the Command Code registry marks
+ * `gpt-5.3-codex` as `supportsVision: true`, but the gateway actually exposes
+ * it as a text-only code model — selecting it as a Vision Bridge candidate
+ * failed every image describe call (#10703, CONTRIBUTOR-reported). Scoped to
+ * the command-code alias/id so only the Command-Code-gateway Codex variants
+ * are overridden; genuine multimodal `gpt-5.x` chat models (e.g. `gpt-5.5`,
+ * `gpt-5.4-mini`, real OpenAI `openai/gpt-5.3-codex`) keep their vision verdict.
  */
 const KNOWN_TEXT_ONLY_DESPITE_SYNC: readonly RegExp[] = [
   /(?:^|\/)mimo-v2\.5-pro$/i,
   /(?:^|\/)mimo-v2-pro$/i,
+  /^(?:cmd|command-code)\/gpt-5\.3-codex(?:-|$)/i,
 ];
 
 function isKnownTextOnlyDespiteSync(modelId: string | null | undefined): boolean {
@@ -571,7 +580,10 @@ function getContextOverride(
  * `snapshot` is the #9147 build-local bulk load; when supplied the on-demand
  * SQLite read is skipped and the preloaded nested map is used instead.
  */
-export function getResolvedModelContextOverride(input: CapabilityInput, snapshot?: ModelCapabilityResolutionSnapshot | null): number | null {
+export function getResolvedModelContextOverride(
+  input: CapabilityInput,
+  snapshot?: ModelCapabilityResolutionSnapshot | null
+): number | null {
   return getContextOverride(resolveCapabilityInput(input), snapshot);
 }
 

--- a/src/shared/components/ModelSelectField.tsx
+++ b/src/shared/components/ModelSelectField.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import Select from "./Select";
 import Input from "./Input";
+import { cn } from "@/shared/utils/cn";
+import { isVisionModelId } from "@/shared/constants/visionModels";
 
 export interface ApiModel {
   provider: string;
@@ -29,6 +31,15 @@ export interface ModelSelectFieldProps {
   modelFilter?: (model: ApiModel) => boolean;
   /** Model API to read. The unified catalog includes specialty audio/video surfaces. */
   modelSource?: "available" | "catalog";
+  /**
+   * Render an editable text input (with a <datalist> of catalog suggestions)
+   * instead of a plain <select>. Lets operators type a custom/self-hosted
+   * model id that is not (or not yet) in the catalog — e.g. an Ollama/vLLM
+   * vision model for the Modality Bridge Vision picker (#10703).
+   */
+  allowCustomInput?: boolean;
+  /** Optional test id forwarded to the underlying control. */
+  testId?: string;
   className?: string;
 }
 
@@ -41,11 +52,48 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
 }
 
-function readCatalogModels(value: unknown): ApiModel[] {
+/** @internal exported for unit tests (node --test imports the module directly). */
+export function readCatalogModels(value: unknown): ApiModel[] {
   const catalog = asRecord(asRecord(value)?.catalog);
   if (!catalog) return [];
 
   const models: ApiModel[] = [];
+
+  /**
+   * Derive the vision verdict from the unified catalog entry (#10809). The
+   * unified catalog serializes capability/modality metadata (not a top-level
+   * `supportsVision`), so a Vision-picker filter of `supportsVision === true`
+   * would otherwise drop every catalog model. Resolution order: explicit
+   * `capabilities.vision` wins, then input modalities. The conservative id
+   * heuristic is ONLY applied to user-added custom models (operator chose that
+   * model — no authoritative metadata exists) — registry-backed entries must
+   * carry explicit capability/modality data, which the shared resolver already
+   * neutralizes for text-only overrides like `cmd/gpt-5.3-codex` (#10703).
+   * Only confirmed-vision models are flagged; `undefined` (unknown/text-only)
+   * keeps them out of a strict `=== true` filter (#10703).
+   */
+  const resolvesVisible: (
+    model: Record<string, unknown>,
+    fullId: string,
+    isCustom: boolean
+  ) => boolean | undefined = (model, fullId, isCustom) => {
+    const capabilities = asRecord(model.capabilities);
+    if (capabilities && typeof capabilities.vision === "boolean") {
+      return capabilities.vision || undefined;
+    }
+    const inputs = Array.isArray(model.input_modalities) ? model.input_modalities : [];
+    if (inputs.length > 0) {
+      return (
+        inputs.some((entry) => {
+          const value = String(entry).toLowerCase();
+          return value.includes("image") || value.includes("video");
+        }) || undefined
+      );
+    }
+    if (isCustom) return isVisionModelId(fullId) ? true : undefined;
+    return undefined;
+  };
+
   for (const [provider, rawBucket] of Object.entries(catalog)) {
     const bucket = asRecord(rawBucket);
     if (!Array.isArray(bucket?.models)) continue;
@@ -54,12 +102,14 @@ function readCatalogModels(value: unknown): ApiModel[] {
       const id = typeof model?.id === "string" ? model.id : "";
       if (!id) continue;
       const providerPrefix = `${provider}/`;
+      const fullId = id.startsWith(providerPrefix) ? id : `${providerPrefix}${id}`;
       models.push({
         provider,
         model: id.startsWith(providerPrefix) ? id.slice(providerPrefix.length) : id,
-        fullModel: id.startsWith(providerPrefix) ? id : `${providerPrefix}${id}`,
+        fullModel: fullId,
         type: typeof model?.type === "string" ? model.type : undefined,
         subtype: typeof model?.subtype === "string" ? model.subtype : undefined,
+        supportsVision: resolvesVisible(model, fullId, model.custom === true),
       });
     }
   }
@@ -85,6 +135,8 @@ export default function ModelSelectField({
   allowEmpty = false,
   modelFilter,
   modelSource = "available",
+  allowCustomInput = false,
+  testId,
   className,
 }: ModelSelectFieldProps) {
   const t = useTranslations("common");
@@ -137,6 +189,50 @@ export default function ModelSelectField({
     !hasKnownValue && allowCustom
       ? [{ value, label: `${value} (${t("custom")})` }, ...state.options]
       : state.options;
+
+  // Editable custom-input mode (#10703): an operator may need a vision model
+  // that is not (yet) in the catalog (self-hosted Ollama/vLLM, unlisted
+  // provider). Keep the filtered <select> for the known catalog AND add a
+  // free-text input below so a custom/unlisted id can be typed directly. The
+  // select keeps `label`/`allowEmpty` semantics (existing UI tests query the
+  // model label's parent for the <select>), while the custom field's
+  // `onChange` lets operators save any string.
+  if (allowCustomInput && state.status === "ready") {
+    const customInputId = `${testId ?? "model-select-field"}-custom-input`;
+    // Known means either the empty placeholder, a catalog option, or the
+    // injected "(custom)" entry — so an off-catalog saved value stays visible
+    // as the selected option instead of falling back to the placeholder.
+    const knownValue = value === "" || options.some((o) => o.value === value);
+    return (
+      <div className={cn("flex flex-col gap-2", className)}>
+        <Select
+          label={label}
+          value={knownValue ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          options={options}
+          placeholder={placeholder || t("selectAModel")}
+          placeholderDisabled={!allowEmpty}
+          disabled={disabled}
+          aria-label={ariaLabel}
+        />
+        <div className="flex flex-col gap-1">
+          <label htmlFor={customInputId} className="text-xs font-medium text-text-muted">
+            {t("custom")}
+          </label>
+          <input
+            id={customInputId}
+            data-testid={testId ? `${testId}-custom-input` : undefined}
+            value={value}
+            disabled={disabled}
+            placeholder={placeholder || t("selectAModel")}
+            aria-label={ariaLabel}
+            onChange={(e) => onChange(e.target.value)}
+            className="w-full py-2 px-3 text-sm text-text-main bg-surface border border-black/10 dark:border-white/10 rounded-control focus:ring-1 focus:ring-accent/30 focus:border-accent/50 focus:outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed text-[16px] sm:text-sm"
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Select

--- a/tests/unit/command-code-registry-vision.test.ts
+++ b/tests/unit/command-code-registry-vision.test.ts
@@ -7,9 +7,15 @@
  * which had no registry flag and no heuristic match, returning `null`/`false`.
  * This caused the Vision Bridge to incorrectly reroute to opencode-zen (401).
  *
- * After the fix: the registry declares `supportsVision: true` for all CC
+ * After the fix: the registry declares `supportsVision: true` for CC
  * vision-capable models, so the guardrail sees native vision support and
- * passes through unmodified.
+ * passes through unmodified — EXCEPT the text-only codex variant
+ * (`gpt-5.3-codex` via the Command Code gateway), which issue #10703 confirms
+ * cannot see images and was previously mis-flagged as vision in the registry.
+ * It follows the same `KNOWN_TEXT_ONLY_DESPITE_SYNC` hard-override path as
+ * `mimo-v2.5-pro`. `gpt-5.4-mini` is intentionally left as vision-capable —
+ * it's a real OpenAI multimodal model and the Command Code gateway forwards
+ * images correctly for it.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -25,7 +31,6 @@ const CC_VISION: [string, string][] = [
   ["Claude Haiku 4.5 (CC)", "command-code/claude-haiku-4-5-20251001"],
   ["GPT-5.5 (CC)", "command-code/gpt-5.5"],
   ["GPT-5.4 (CC)", "command-code/gpt-5.4"],
-  ["GPT-5.3 Codex (CC)", "command-code/gpt-5.3-codex"],
   ["GPT-5.4 Mini (CC)", "command-code/gpt-5.4-mini"],
   ["Kimi K2.6 (CC)", "command-code/moonshotai/Kimi-K2.6"],
   ["Kimi K2.5 (CC)", "command-code/moonshotai/Kimi-K2.5"],
@@ -35,6 +40,7 @@ const CC_VISION: [string, string][] = [
 // ── Models that MUST NOT claim vision (text-only) ──────────────────────────
 
 const CC_TEXT_ONLY: [string, string][] = [
+  ["GPT-5.3 Codex (CC)", "command-code/gpt-5.3-codex"],
   ["DeepSeek V4 Pro (CC)", "command-code/deepseek/deepseek-v4-pro"],
   ["DeepSeek V4 Flash (CC)", "command-code/deepseek/deepseek-v4-flash"],
   ["GLM-5.1 (CC)", "command-code/zai-org/GLM-5.1"],

--- a/tests/unit/command-code-vision.test.ts
+++ b/tests/unit/command-code-vision.test.ts
@@ -57,6 +57,64 @@ function userContent(calls: FetchCall[]): unknown {
   )[0].content;
 }
 
+// ── wire model normalization (#10809) ────────────────────────────────
+//
+// Command Code's /alpha/generate endpoint serves most models under a
+// vendor-prefixed wire id and defaults an unprefixed id to the `anthropic:`
+// provider (403 "Model/provider not recognized: anthropic:<id>"). A bare id
+// reaches the executor when an operator sets a custom vision model in the
+// Vision Bridge picker (e.g. `command-code/mimo-v2.5`). The executor must
+// normalize to the documented vendor-prefixed wire form.
+
+function wireModel(calls: FetchCall[]): string {
+  return (calls[0].body.params as Record<string, unknown>).model as string;
+}
+
+test("#10809: command-code/mimo-v2.5 wire model is normalized to xiaomi/mimo-v2.5", async () => {
+  const calls = captureFetch(
+    commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+  );
+  await getExecutor("command-code").execute({
+    model: "command-code/mimo-v2.5",
+    stream: false,
+    credentials: { apiKey: "cc_test_key" },
+    body: {
+      model: "command-code/mimo-v2.5",
+      messages: [{ role: "user", content: "hi" }],
+    },
+  });
+  assert.equal(wireModel(calls), "xiaomi/mimo-v2.5");
+});
+
+test("#10809: cmd/mimo-v2.5 (alias prefix) is also normalized", async () => {
+  const calls = captureFetch(
+    commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+  );
+  await getExecutor("command-code").execute({
+    model: "cmd/mimo-v2.5",
+    stream: false,
+    credentials: { apiKey: "cc_test_key" },
+    body: { model: "cmd/mimo-v2.5", messages: [{ role: "user", content: "hi" }] },
+  });
+  assert.equal(wireModel(calls), "xiaomi/mimo-v2.5");
+});
+
+test("#10809: already vendor-prefixed wire ids pass through unchanged", async () => {
+  const calls = captureFetch(
+    commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+  );
+  await getExecutor("command-code").execute({
+    model: "command-code/deepseek/deepseek-v4-pro",
+    stream: false,
+    credentials: { apiKey: "cc_test_key" },
+    body: {
+      model: "command-code/deepseek/deepseek-v4-pro",
+      messages: [{ role: "user", content: "hi" }],
+    },
+  });
+  assert.equal(wireModel(calls), "deepseek/deepseek-v4-pro");
+});
+
 // ── vision models: image parts preserved in CC CLI format ─────────────
 
 test("vision model minimax-m3 preserves image_url part as CC CLI {type:image}", async () => {
@@ -628,10 +686,11 @@ test("text-only model deepseek-v4-flash strips Anthropic source.base64 image blo
 //
 // These two ids stay INSIDE the `/gpt-5/` vision family: both accept image
 // input on the OpenAI API, and there is no verified Command Code backend data
-// marking them text-only. These tests pin that conservative behavior so a
-// future "narrow the regex" change cannot silently strip images from models
-// that can see them (the #4071 regression class). Revisit ONLY with per-model
-// CC registry capability data proving they are text-only.
+// marking them text-only. These tests pin that conservative executor behavior
+// so a future "narrow the regex" change cannot silently strip images from models
+// that can see them (the #4071 regression class). The #10703 Vision Bridge
+// candidate-list fix lives in the shared capability resolution
+// (KNOWN_TEXT_ONLY_DESPITE_SYNC), NOT in the executor's wire transform.
 
 test("gpt-5.4-mini keeps image parts (conservative vision family lock)", async () => {
   const calls = captureFetch(

--- a/tests/unit/guardrails/vision-bridge-cache-key.test.ts
+++ b/tests/unit/guardrails/vision-bridge-cache-key.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression: the Vision Bridge describe cache must be keyed on the BASE
+ * prompt (`config.prompt`), not the task-aware composed prompt.
+ *
+ * Zoo Code (Claude Code protocol) resends the FULL transcript on every turn.
+ * A text-only follow-up turn still carries the turn-1 image inside the
+ * history, so `extractImageParts` keeps finding it and the bridge re-enters
+ * the describe path. When the cache key embeds the composed prompt — which
+ * appends the LAST user text via `composeVisionPrompt` — every new turn
+ * produces a different key, missing the shared cache and re-calling the
+ * vision model (e.g. mimo-v2.5) even though the image bytes are identical.
+ *
+ * Fix: key the cache on the stable base prompt so an unchanged image in the
+ * history reuses the cached description. The task-aware composed prompt is
+ * still what the vision model receives on the first describe.
+ *
+ * Run: node --import tsx/esm --test tests/unit/guardrails/vision-bridge-cache-key.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { VisionBridgeGuardrail } = await import("../../../src/lib/guardrails/visionBridge.ts");
+const { resetGuardrailsForTests } = await import("../../../src/lib/guardrails/registry.ts");
+const { getResolvedModelCapabilities } = await import("../../../src/lib/modelCapabilities.ts");
+import type { GuardrailContext } from "../../../src/lib/guardrails/base.ts";
+import type { VisionModelConfig } from "../../../src/lib/guardrails/visionBridgeHelpers.ts";
+
+const TEXT_ONLY_MODEL = "command-code/deepseek/deepseek-v4-pro";
+
+// Unique data-URI images per test → no cross-test cache pollution (the shared
+// describe cache is a process-wide singleton). These are 1x1 PNGs; the
+// describe path never fetches them over the network.
+const IMAGE_A =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+const IMAGE_B =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+const IMAGE_C = "https://example.com/third.png";
+
+let mockSettings: Record<string, unknown>;
+let visionCallCount = 0;
+let capturedPrompts: string[] = [];
+
+function createGuardrail() {
+  return new VisionBridgeGuardrail({
+    deps: {
+      getSettings: async () => mockSettings,
+      callVisionModel: async (_img: string, config: VisionModelConfig) => {
+        visionCallCount++;
+        capturedPrompts.push(config.prompt);
+        return "A black labrador puppy on a wooden floor";
+      },
+      // Fail-open (null): no credential DB in this unit test.
+      hasUsableCredentials: async () => null,
+    },
+  });
+}
+
+test.beforeEach(() => {
+  resetGuardrailsForTests({ registerDefaults: false });
+  visionCallCount = 0;
+  capturedPrompts = [];
+  mockSettings = {
+    // New modalityBridge* keys (PR-1). Mode forced to "describe" so the
+    // whole-request reroute block is skipped and only the describe path runs.
+    modalityBridgeVisionMode: "describe",
+    modalityBridgeVisionModel: "openai/gpt-4o-mini",
+    modalityBridgeVisionPrompt: "VB-CACHE-KEY: Describe this image concisely.",
+    modalityBridgeVisionTimeout: 30000,
+    modalityBridgeVisionMaxImages: 10,
+    modalityBridgeCacheEnabled: true,
+    modalityBridgeCacheTtlMinutes: 60,
+    modalityBridgeCacheMaxEntries: 200,
+  };
+});
+
+function createContext(overrides: Partial<GuardrailContext> = {}): GuardrailContext {
+  return { model: TEXT_ONLY_MODEL, log: console, ...overrides };
+}
+
+// Fail loudly if the static capability drift makes the fixture invalid: the
+// describe path only runs for non-vision models.
+test("VB-CACHE-FIXTURE: text-only model resolves without vision support", () => {
+  assert.notEqual(
+    getResolvedModelCapabilities(TEXT_ONLY_MODEL).supportsVision,
+    true,
+    `${TEXT_ONLY_MODEL} must be text-only for this regression`
+  );
+});
+
+function turn1Payload(imageUri: string) {
+  return {
+    model: TEXT_ONLY_MODEL,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What's in this image?" },
+          { type: "image_url", image_url: { url: imageUri } },
+        ],
+      },
+    ],
+  };
+}
+
+// Zoo Code resends the FULL transcript: turn-1 user message (with the image),
+// the assistant reply, and the new text-only follow-up.
+function turn2Payload(imageUri: string) {
+  return {
+    model: TEXT_ONLY_MODEL,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What's in this image?" },
+          { type: "image_url", image_url: { url: imageUri } },
+        ],
+      },
+      { role: "assistant", content: "A black labrador puppy on a wooden floor." },
+      { role: "user", content: "Now what is 2+2?" },
+    ],
+  };
+}
+
+test("VB-CACHE-01: same image in history reuses the cached description across turns", async () => {
+  const guardrail = createGuardrail();
+
+  // Turn 1: image present → describe once.
+  const first = await guardrail.preCall(turn1Payload(IMAGE_A), createContext());
+  assert.strictEqual(first.block, false);
+  assert.ok(first.modifiedPayload, "turn 1 must describe the image");
+  assert.strictEqual(visionCallCount, 1, "turn 1 must call the vision model once");
+  // Task-aware prompt must reach the vision model on the first describe.
+  assert.ok(
+    capturedPrompts[0].includes("What's in this image?"),
+    "task-aware composed prompt must be used for the first describe"
+  );
+
+  // Turn 2: full transcript resent; image unchanged in history, only the last
+  // user text changed. The cached description must be reused → NO new call.
+  const second = await guardrail.preCall(turn2Payload(IMAGE_A), createContext());
+  assert.strictEqual(second.block, false);
+  assert.ok(second.modifiedPayload, "turn 2 must still splice the description");
+  assert.strictEqual(
+    visionCallCount,
+    1,
+    "an unchanged image in the history must hit the cache, not re-describe"
+  );
+});
+
+test("VB-CACHE-02: a NEW image still forces a fresh vision call", async () => {
+  const guardrail = createGuardrail();
+
+  // Turn 1 with a unique image (IMAGE_B — never used by VB-CACHE-01).
+  await guardrail.preCall(turn1Payload(IMAGE_B), createContext());
+  assert.strictEqual(visionCallCount, 1, "first describe of IMAGE_B must call once");
+
+  // Turn 2 with a DIFFERENT image URL (IMAGE_C) → new contentRef → miss → call.
+  const second = await guardrail.preCall(
+    {
+      model: TEXT_ONLY_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What about this one?" },
+            { type: "image_url", image_url: { url: IMAGE_C } },
+          ],
+        },
+      ],
+    },
+    createContext()
+  );
+  assert.strictEqual(second.block, false);
+  assert.strictEqual(visionCallCount, 2, "a different image must be re-described");
+});

--- a/tests/unit/guardrails/vision-bridge-sse-and-reasoning.test.ts
+++ b/tests/unit/guardrails/vision-bridge-sse-and-reasoning.test.ts
@@ -143,6 +143,37 @@ test("vision-bridge: falls back to reasoning_content when content is null", asyn
   }
 });
 
+test("vision-bridge: falls back to plain `reasoning` when content is null (opencode gateway)", async () => {
+  // opencode-routed gateways name the reasoning field `reasoning` (not
+  // `reasoning_content`) — e.g. opencode/mimo-v2.5-free (#6623 / #10809).
+  // extractOpenAICompatibleContent must use it as the description.
+  const reasoningText =
+    "The image shows a young black Labrador puppy with golden-brown eyes sitting on weathered wooden planks.";
+  const mockResponse = {
+    ok: true,
+    json: async () => ({
+      choices: [
+        {
+          finish_reason: "length",
+          message: {
+            content: null,
+            reasoning: reasoningText,
+          },
+        },
+      ],
+    }),
+  };
+
+  globalThis.fetch = async () => mockResponse as unknown as Response;
+
+  try {
+    const result = await callVisionModel(TINY_PNG, baseConfig());
+    assert.strictEqual(result, reasoningText);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("vision-bridge: parses SSE reasoning_content deltas when content is empty", async () => {
   const reasoningPart1 = "The user wants a concise description of an image. ";
   const reasoningPart2 = "A black Labrador puppy gazes up at the camera.";

--- a/tests/unit/guardrails/visionBridgeCredentials.test.ts
+++ b/tests/unit/guardrails/visionBridgeCredentials.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Vision Bridge credential checks — #10702 regression tests.
+ *
+ * `hasUsableCredentialsForModel()` gates which vision-capable catalog
+ * candidates the bridge may use. Before the fix:
+ *
+ *   1. The provider prefix was used verbatim against `provider_connections`
+ *      (an exact SQL `provider = ?` match), so alias-keyed model ids like
+ *      `oc/mimo-v2.5-free` queried `provider = "oc"` — but the row is stored
+ *      under the canonical id `opencode` — returning zero rows and excluding
+ *      every candidate, which surfaced as
+ *      "No vision-capable provider connected, cannot process image request".
+ *
+ *   2. No-auth providers (`oc`/`opencode`, `ddgw`/`duckduckgo-web`, ...) were
+ *      judged by the same "must have a usable stored API key" bar as keyed
+ *      providers, even though their effective credential is the synthetic
+ *      "noauth" connection (src/sse/services/auth.ts) and they carry no key.
+ *
+ * This suite exercises the real DB-backed path (createProviderConnection +
+ * getProviderConnections) — same pattern as
+ * tests/unit/8779-agy-prefix-credential-lookup.test.ts. Isolated DATA_DIR per
+ * PII learnings §3: resetDbInstance() + cleanup in test.after so the node:test
+ * runner doesn't hang on open handles.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-vb-cred-"));
+
+// Set before any db import so getDbInstance() picks the temp dir.
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../../src/lib/db/core.ts");
+const providersDb = await import("../../../src/lib/db/providers.ts");
+const { hasUsableCredentialsForModel, hasTerminalConnectionStatus } =
+  await import("../../../src/lib/guardrails/visionBridgeCredentials.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// ── alias → canonical id resolution (#10702) ────────────────────────────────
+
+test("alias-keyed model finds a row stored under the canonical provider id (#10702)", async () => {
+  await resetStorage();
+  // The connection is stored under the canonical id "command-code".
+  await providersDb.createProviderConnection({
+    provider: "command-code",
+    authType: "apikey",
+    apiKey: "cc-real-key",
+    isActive: true,
+    testStatus: "active",
+  });
+
+  // The model id uses the public alias prefix "cmd" — before the fix this
+  // queried provider = "cmd", found no row, and returned false.
+  const usable = await hasUsableCredentialsForModel("cmd/deepseek-v4-flash");
+  assert.equal(usable, true, "alias prefix must resolve to the canonical provider id");
+});
+
+test("alias-keyed noauth model is usable with NO stored row (#10702)", async () => {
+  await resetStorage();
+  // No `provider_connections` row at all — the noauth provider is served by
+  // the synthetic "noauth" connection, so it must still be usable.
+  const usable = await hasUsableCredentialsForModel("oc/mimo-v2.5-free");
+  assert.equal(usable, true, "noauth provider must not require a stored connection row");
+});
+
+test("canonical-id noauth model is usable with NO stored row", async () => {
+  await resetStorage();
+  const usable = await hasUsableCredentialsForModel("opencode/mimo-v2.5-free");
+  assert.equal(usable, true);
+});
+
+// ── noauth terminal-status blocking ─────────────────────────────────────────
+
+test("noauth provider is NOT usable when a row carries a terminal status", async () => {
+  await resetStorage();
+  await providersDb.createProviderConnection({
+    provider: "opencode",
+    authType: "no-auth",
+    name: "opencode-account",
+    isActive: true,
+    testStatus: "banned",
+  });
+  const usable = await hasUsableCredentialsForModel("oc/mimo-v2.5-free");
+  assert.equal(usable, false, "a banned noauth row must block the provider");
+});
+
+test("noauth provider with a healthy row is usable", async () => {
+  await resetStorage();
+  await providersDb.createProviderConnection({
+    provider: "opencode",
+    authType: "no-auth",
+    name: "opencode-account",
+    isActive: true,
+    testStatus: "active",
+  });
+  const usable = await hasUsableCredentialsForModel("oc/mimo-v2.5-free");
+  assert.equal(usable, true);
+});
+
+// ── keyed providers keep the original gate ──────────────────────────────────
+
+test("keyed provider with no active connection is NOT usable", async () => {
+  await resetStorage();
+  const usable = await hasUsableCredentialsForModel("openai/gpt-4o-mini");
+  assert.equal(usable, false, "no openai row seeded → definitively unusable");
+});
+
+test("keyed provider with a usable active connection is usable", async () => {
+  await resetStorage();
+  await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    apiKey: "sk-real-key",
+    isActive: true,
+    testStatus: "active",
+  });
+  const usable = await hasUsableCredentialsForModel("openai/gpt-4o-mini");
+  assert.equal(usable, true);
+});
+
+test("keyed provider with only a banned connection is NOT usable", async () => {
+  await resetStorage();
+  await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    apiKey: "sk-dead-key",
+    isActive: true,
+    testStatus: "banned",
+  });
+  const usable = await hasUsableCredentialsForModel("openai/gpt-4o-mini");
+  assert.equal(usable, false);
+});
+
+test("non-existent provider returns false (definitive, table readable)", async () => {
+  await resetStorage();
+  const usable = await hasUsableCredentialsForModel("no-such-provider/model");
+  assert.equal(usable, false);
+});
+
+// ── helper: hasTerminalConnectionStatus ─────────────────────────────────────
+
+test("hasTerminalConnectionStatus recognizes terminal statuses", () => {
+  assert.equal(hasTerminalConnectionStatus({ testStatus: "disabled" }), true);
+  assert.equal(hasTerminalConnectionStatus({ testStatus: "banned" }), true);
+  assert.equal(hasTerminalConnectionStatus({ testStatus: "expired" }), true);
+  assert.equal(hasTerminalConnectionStatus({ testStatus: "active" }), false);
+  assert.equal(hasTerminalConnectionStatus({ testStatus: null }), false);
+  assert.equal(hasTerminalConnectionStatus({}), false);
+});

--- a/tests/unit/issue-6623-opencode-mimo-reasoning-details-nonstream.test.ts
+++ b/tests/unit/issue-6623-opencode-mimo-reasoning-details-nonstream.test.ts
@@ -20,7 +20,12 @@ const mimoOpenRouterStyleResponse = {
         refusal: null,
         reasoning: "Hmm, the user just said hi",
         reasoning_details: [
-          { type: "reasoning.text", text: "Hmm, the user just said hi", format: "unknown", index: 0 },
+          {
+            type: "reasoning.text",
+            text: "Hmm, the user just said hi",
+            format: "unknown",
+            index: 0,
+          },
         ],
       },
     },
@@ -33,12 +38,40 @@ test("#6623 raw responseBody is not flagged empty by isEmptyContentResponse", ()
 });
 
 test("#6623 /v1/messages non-stream translation of an OpenRouter reasoning-only turn is flagged malformed (502) - RED", () => {
-  const translated = translateNonStreamingResponse(mimoOpenRouterStyleResponse, "openai", "claude", null);
+  const translated = translateNonStreamingResponse(
+    mimoOpenRouterStyleResponse,
+    "openai",
+    "claude",
+    null
+  );
   const malformedReason = detectMalformedNonStream(translated);
   assert.equal(malformedReason, null);
 });
 
 test("#6623 /v1/chat/completions (openai->openai, no translation) is unaffected", () => {
-  const passthrough = translateNonStreamingResponse(mimoOpenRouterStyleResponse, "openai", "openai", null);
+  const passthrough = translateNonStreamingResponse(
+    mimoOpenRouterStyleResponse,
+    "openai",
+    "openai",
+    null
+  );
   assert.equal(passthrough, mimoOpenRouterStyleResponse);
+});
+
+test("#6623 raw OpenAI passthrough with only message.reasoning is NOT flagged malformed", () => {
+  // The opencode gateway names the reasoning field `reasoning` (not
+  // `reasoning_content`). A reasoning-only completion must be treated as real
+  // output on the raw /v1/chat/completions path, not empty_choices → 502.
+  assert.equal(detectMalformedNonStream(mimoOpenRouterStyleResponse), null);
+});
+
+test("#6623 isEmptyContentResponse honours a plain `reasoning` field (stop reason)", () => {
+  // Same reasoning-only body but with finish_reason "stop" — the empty-content
+  // pre-translation check must not classify it as a fake-success empty body
+  // (which would trigger fallback / cooldown on a perfectly usable completion).
+  const stopReasoningOnly = {
+    ...mimoOpenRouterStyleResponse,
+    choices: [{ ...mimoOpenRouterStyleResponse.choices[0], finish_reason: "stop" }],
+  };
+  assert.equal(isEmptyContentResponse(stopReasoningOnly), false);
 });

--- a/tests/unit/model-capabilities-command-code-codex-textonly-10703.test.ts
+++ b/tests/unit/model-capabilities-command-code-codex-textonly-10703.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #10703 — Command Code `gpt-5.3-codex` model ids must NOT resolve as
+ * vision-capable through the shared capability resolver.
+ *
+ * The Command Code gateway registry declared `supportsVision: true` for
+ * `gpt-5.3-codex`, so the Modality Bridge Vision dropdown (which reads
+ * `/api/models` → `getResolvedModelCapabilities`) listed it as a Vision Bridge
+ * candidate. Selecting it as the Vision model failed image describe calls
+ * (#10703, CONTRIBUTOR). The fix adds the id family to the existing
+ * `KNOWN_TEXT_ONLY_DESPITE_SYNC` hard-override — the same mechanism that keeps
+ * `mimo-v2.5-pro` text-only — so the shared verdict is `false` everywhere
+ * (dropdown, Vision Bridge auto-router, `/v1/models`, compression).
+ *
+ * Scope discipline: only the Command Code gateway's `cmd/` / `command-code/`
+ * codex variants are overridden. Genuine multimodal OpenAI codex ids
+ * (`openai/gpt-5.3-codex`) and the `gpt-5.x` chat family (`gpt-5.4`,
+ * `gpt-5.4-mini`, `gpt-5.5`) must keep `supportsVision: true`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getResolvedModelCapabilities } from "../../src/lib/modelCapabilities.ts";
+
+// ── Overridden: Command Code gateway codex ids are text-only (#10703) ────────
+
+const CC_TEXT_ONLY_CODEX: [string, string][] = [
+  ["alias prefix", "cmd/gpt-5.3-codex"],
+  ["raw provider id", "command-code/gpt-5.3-codex"],
+  ["spark variant", "cmd/gpt-5.3-codex-spark"],
+  ["effort variant", "cmd/gpt-5.3-codex-high"],
+  ["preview variant", "cmd/gpt-5.3-codex-spark-preview"],
+];
+
+for (const [desc, modelId] of CC_TEXT_ONLY_CODEX) {
+  test(`#10703: ${desc} ${modelId} → supportsVision=false`, () => {
+    const caps = getResolvedModelCapabilities(modelId);
+    assert.equal(caps.supportsVision, false, `${modelId} is text-only via Command Code (#10703)`);
+  });
+}
+
+// ── NOT overridden: known multimodal / non-CC ids keep their vision verdict ──
+
+const MUST_STAY_VISION: [string, string][] = [
+  ["real OpenAI codex", "openai/gpt-5.3-codex"],
+  ["multimodal gpt-5.5", "cmd/gpt-5.5"],
+  ["multimodal gpt-5.4", "cmd/gpt-5.4"],
+  ["multimodal gpt-5.4-mini", "cmd/gpt-5.4-mini"],
+  ["claude opus 4.7 (CC)", "cmd/claude-opus-4-7"],
+  ["kimi k2.6 (CC)", "cmd/moonshotai/Kimi-K2.6"],
+];
+
+for (const [desc, modelId] of MUST_STAY_VISION) {
+  test(`#10703 scope guard: ${desc} ${modelId} stays supportsVision=true`, () => {
+    const caps = getResolvedModelCapabilities(modelId);
+    assert.equal(caps.supportsVision, true, `${modelId} must not be overridden (#10703 scope)`);
+  });
+}
+
+// ── The override must also beat a wrong synced attachment/modalit
+//    (the #4071 failure mode), mirroring the mimo-v2.5-pro guard tests. ──────
+
+test("#10703: override still wins when synced capability wrongly claims vision-support", () => {
+  // No DB/synced fan-in in this repo for command-code static ids (they are
+  // registry-driven), so a plain resolution is the authoritative check — a
+  // registry `supportsVision: true` must be neutralized even without synced
+  // data present.
+  const caps = getResolvedModelCapabilities("cmd/gpt-5.3-codex");
+  assert.equal(caps.supportsVision, false);
+  assert.equal(caps.provider, "command-code");
+});

--- a/tests/unit/model-select-field-catalog-vision-10809.test.ts
+++ b/tests/unit/model-select-field-catalog-vision-10809.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #10809 — `readCatalogModels` derives `supportsVision` from the unified
+ * catalog shape so the Modality Bridge Vision picker can use `modelSource
+ * "catalog"` (all configured providers + user-added custom models) while still
+ * applying the strict `supportsVision === true` filter (#10703).
+ *
+ * The unified catalog serializes capability/modality metadata — `capabilities.
+ * vision`, `input_modalities` — NOT a top-level `supportsVision` flag, so a
+ * naive `model.supportsVision === true` filter would silently drop every
+ * catalog model. This module pins the derivation:
+ *
+ *  1. explicit `capabilities.vision` (boolean) wins — registry/synced-backed
+ *     entries, where the shared resolver has already neutralized text-only
+ *     overrides like `cmd/gpt-5.3-codex` (#10703);
+ *  2. input modalities declaring image/video;
+ *  3. the conservative id heuristic ONLY for user-added `custom` models
+ *     (no authoritative metadata exists — the operator chose that id);
+ *     registry-backed entries without capability data are treated as unknown.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { readCatalogModels } from "../../src/shared/components/ModelSelectField.tsx";
+
+function catalogShape(bucket: Record<string, unknown>): unknown {
+  return { catalog: { provider: bucket } };
+}
+
+test("#10809: capabilities.vision=true entries are flagged vision-capable", () => {
+  const models = readCatalogModels(
+    catalogShape({
+      models: [
+        { id: "gpt-4o", capabilities: { vision: true } },
+        { id: "gemini-2.5-flash", capabilities: { vision: true, reasoning: true } },
+      ],
+    })
+  );
+  assert.equal(models.length, 2);
+  for (const model of models) {
+    assert.equal(model.supportsVision, true, `${model.fullModel} must be vision`);
+  }
+});
+
+test("#10809: capabilities.vision=false entries are NOT flagged vision-capable", () => {
+  const models = readCatalogModels(
+    catalogShape({
+      models: [{ id: "gpt-5.3-codex", capabilities: { vision: false } }],
+    })
+  );
+  assert.equal(models.length, 1);
+  assert.equal(models[0].supportsVision, undefined, "vision:false must not be flagged");
+});
+
+test("#10809: input_modalities declaring image/video are flagged vision-capable", () => {
+  const models = readCatalogModels(
+    catalogShape({
+      models: [
+        {
+          id: "claude-4.5-sonnet",
+          input_modalities: ["text", "image"],
+          output_modalities: ["text"],
+        },
+        { id: "qwen3-vl", input_modalities: ["image"] },
+      ],
+    })
+  );
+  assert.equal(models.length, 2);
+  for (const model of models) {
+    assert.equal(model.supportsVision, true, `${model.fullModel} modality-derived vision`);
+  }
+});
+
+test("#10809: text-only input_modalities are NOT flagged vision-capable", () => {
+  const models = readCatalogModels(
+    catalogShape({
+      models: [{ id: "deepseek-v4-pro", input_modalities: ["text"] }],
+    })
+  );
+  assert.equal(models.length, 1);
+  assert.equal(models[0].supportsVision, undefined, "text-only modalities must not be flagged");
+});
+
+test("registry-backed entries without capability/modality data stay unknown (not heuristic)", () => {
+  // No `capabilities`/`input_modalities` and NOT `custom` — must NOT fall back
+  // to the id heuristic (which would wrongly flag `gpt-5.3-codex` via `gpt-5`).
+  const models = readCatalogModels(
+    catalogShape({
+      models: [{ id: "gpt-5.3-codex" }],
+    })
+  );
+  assert.equal(models.length, 1);
+  assert.equal(models[0].supportsVision, undefined, "bare registry id must stay unknown");
+});
+
+test("#10809: user-added custom models fall back to the conservative id heuristic", () => {
+  const models = readCatalogModels(
+    catalogShape({
+      models: [
+        { id: "ollama/llava:13b", custom: true },
+        { id: "selfhost/qwen3-vl", custom: true },
+        { id: "selfhost/plain-model", custom: true },
+      ],
+    })
+  );
+  const byId = Object.fromEntries(models.map((m) => [m.fullModel, m]));
+  assert.equal(byId["provider/ollama/llava:13b"].supportsVision, true, "llava is vision");
+  assert.equal(byId["provider/selfhost/qwen3-vl"].supportsVision, true, "qwen3-vl is vision");
+  assert.equal(
+    byId["provider/selfhost/plain-model"].supportsVision,
+    undefined,
+    "plain stays unknown"
+  );
+});
+
+test("#10809: custom+vision true and custom text-only verbatim entries are respected", () => {
+  const models = readCatalogModels(
+    catalogShape({
+      models: [
+        { id: "vllm/my-vision-model", custom: true, capabilities: { vision: true } },
+        { id: "vllm/my-text-model", custom: true, capabilities: { vision: false } },
+      ],
+    })
+  );
+  const byId = Object.fromEntries(models.map((m) => [m.fullModel, m]));
+  assert.equal(byId["provider/vllm/my-vision-model"].supportsVision, true);
+  assert.equal(byId["provider/vllm/my-text-model"].supportsVision, undefined);
+});

--- a/tests/unit/ui/modality-bridge-vision-tab.test.tsx
+++ b/tests/unit/ui/modality-bridge-vision-tab.test.tsx
@@ -32,9 +32,17 @@ describe("ModalityBridgeVisionTab", () => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      // The Vision picker now reads the unified catalog (modelSource="catalog",
+      // #10809), which returns `{ catalog: { provider: { models: [...] } } }`.
       if (url.includes("/api/models")) {
         return new Response(
-          JSON.stringify({ models: [{ provider: "openai", model: "gpt-4o-mini" }] }),
+          JSON.stringify({
+            catalog: {
+              openai: {
+                models: [{ id: "gpt-4o-mini", capabilities: { vision: true } }],
+              },
+            },
+          }),
           { status: 200 }
         );
       }
@@ -249,5 +257,92 @@ describe("ModalityBridgeVisionTab", () => {
       "prompt-injection",
       "credential-masker",
     ]);
+  });
+
+  it("#10703: filters the model dropdown to vision-capable models only", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/models")) {
+        return new Response(
+          JSON.stringify({
+            catalog: {
+              openai: {
+                models: [
+                  { id: "gpt-4o-mini", capabilities: { vision: true } },
+                  { id: "gpt-4o", capabilities: { vision: true } },
+                ],
+              },
+              cmd: {
+                models: [
+                  { id: "gpt-5.3-codex", capabilities: { vision: false } },
+                  { id: "deepseek/deepseek-v4-pro", input_modalities: ["text"] },
+                ],
+              },
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes("/api/settings")) {
+        if (init?.method === "PATCH") return new Response("{}", { status: 200 });
+        return new Response(
+          JSON.stringify({ visionBridgeModel: "openai/gpt-4o-mini", visionBridgeEnabled: true }),
+          { status: 200 }
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const el = await render();
+    await waitFor(
+      () => el.querySelector('[data-testid="modality-bridge-vision-model-custom-input"]') !== null,
+      "vision model picker to load"
+    );
+
+    // The filtered <select> must list vision-capable models only (empty placeholder excluded).
+    const modelLabel = Array.from(el.querySelectorAll("label")).find((label) =>
+      label.textContent?.includes("modalityBridgeVisionModel")
+    );
+    const modelSelect =
+      (modelLabel?.parentElement?.querySelector("select") as HTMLSelectElement | null) ?? null;
+    const optionValues = Array.from(modelSelect?.options ?? [])
+      .map((o) => o.value)
+      .filter(Boolean);
+    expect(optionValues).toContain("openai/gpt-4o-mini");
+    expect(optionValues).toContain("openai/gpt-4o");
+    expect(optionValues).not.toContain("cmd/gpt-5.3-codex");
+    expect(optionValues).not.toContain("cmd/deepseek/deepseek-v4-pro");
+  });
+
+  it("#10703: the custom model input lets operators type an unlisted vision model", async () => {
+    const el = await render();
+    await waitFor(
+      () => el.querySelector('[data-testid="modality-bridge-vision-model-custom-input"]') !== null,
+      "vision model picker to load"
+    );
+
+    const input = el.querySelector(
+      '[data-testid="modality-bridge-vision-model-custom-input"]'
+    ) as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value"
+      )?.set;
+      setter?.call(input, "ollama/llava:13b");
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await waitFor(
+      () =>
+        fetchMock.mock.calls.some(([, init]) => {
+          if ((init as RequestInit | undefined)?.method !== "PATCH") return false;
+          const body = JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>;
+          return body.modalityBridgeVisionModel === "ollama/llava:13b";
+        }),
+      "custom vision model PATCH"
+    );
   });
 });

--- a/tests/unit/vision-bridge-cc-no-reroute.test.ts
+++ b/tests/unit/vision-bridge-cc-no-reroute.test.ts
@@ -86,11 +86,10 @@ function imagePayload(model: string) {
 
 // ── Sanity: capabilities must resolve first ─────────────────────────────────
 
-test("CC-VB-SANITY: getResolvedModelCapabilities reports vision for CC models", () => {
+test("CC-VB-SANITY: getResolvedModelCapabilities reports vision for CC vision models", () => {
   for (const modelId of [
     "command-code/gpt-5.5",
     "command-code/gpt-5.4",
-    "command-code/gpt-5.3-codex",
     "command-code/gpt-5.4-mini",
     "command-code/claude-opus-4-7",
     "command-code/claude-sonnet-4-6",
@@ -102,6 +101,15 @@ test("CC-VB-SANITY: getResolvedModelCapabilities reports vision for CC models", 
     const caps = getResolvedModelCapabilities(modelId);
     assert.equal(caps.supportsVision, true, `${modelId} must have supportsVision: true`);
   }
+});
+
+test("CC-VB-SANITY: text-only cmd/gpt-5.3-codex resolves as non-vision (#10703)", () => {
+  const caps = getResolvedModelCapabilities("command-code/gpt-5.3-codex");
+  assert.equal(
+    caps.supportsVision,
+    false,
+    "command-code/gpt-5.3-codex is text-only — must NOT have supportsVision: true"
+  );
 });
 
 // ── THE FIX: CC vision models pass through, no reroute ──────────────────────
@@ -171,7 +179,6 @@ test("CC-VB-06: all CC vision models pass through unmodified (loop)", async () =
   const models = [
     "command-code/gpt-5.5",
     "command-code/gpt-5.4",
-    "command-code/gpt-5.3-codex",
     "command-code/gpt-5.4-mini",
     "command-code/claude-opus-4-7",
     "command-code/claude-opus-4-6",
@@ -191,6 +198,31 @@ test("CC-VB-06: all CC vision models pass through unmodified (loop)", async () =
     assert.strictEqual(visionCallCount, 0, `${model}: must not call vision API`);
     assert.strictEqual(result.modifiedPayload, undefined, `${model}: must not reroute`);
   }
+});
+
+// ── #10703: text-only cmd/gpt-5.3-codex must NOT be treated as vision ──────────
+// The command-code registry declared `supportsVision: true` on gpt-5.3-codex,
+// but issue #10703 confirms it cannot see images through that gateway. It
+// follows the same KNOWN_TEXT_ONLY_DESPITE_SYNC hard-override as mimo-v2.5-pro,
+// so an image request must be rerouted (or described) rather than passed
+// through blind. gpt-5.4-mini is intentionally left as vision-capable — it's a
+// real OpenAI multimodal model that the Command Code gateway forwards correctly.
+
+test("CC-VB-07: cmd/gpt-5.3-codex reroutes instead of passing through (#10703)", async () => {
+  const guardrail = createGuardrail();
+  const model = "command-code/gpt-5.3-codex";
+
+  visionCallCount = 0;
+  const payload = imagePayload(model);
+  const result = await guardrail.preCall(payload, createContext({ model }));
+
+  assert.strictEqual(result.block, false, `${model}: must not block`);
+  const caps = getResolvedModelCapabilities(model);
+  assert.equal(caps.supportsVision, false, `${model}: must be flagged text-only (#10703)`);
+  assert.ok(
+    result.modifiedPayload !== undefined || visionCallCount > 0,
+    `${model}: image request must be rerouted/described, not passed through blind`
+  );
 });
 
 // ── Regression: text-only CC models still handled correctly ─────────────────


### PR DESCRIPTION
## Summary

- **Bug (#10808)** — the Vision Bridge ignored the operator-configured vision
  model (e.g. `oc/mimo-v2.5-free`) and fell back to `command-code/claude-opus-4-7`,
  producing repeated `403 MODEL_NOT_IN_PLAN` failures. Root cause: the bridge
  credential gate queried `provider_connections` with the public alias (`oc`)
  instead of the canonical registry id (`opencode`), returning zero rows and
  excluding every candidate; no-auth providers were also judged by the
  "must have a stored API key" bar even though they authenticate through the
  synthetic `noauth` connection.
- **Feature (#10809)** — the Vision Bridge model picker was limited to a
  hardcoded `available` subset. It now reads the unified catalog (all
  configured providers + user-added custom models, matching the Audio tab),
  derives `supportsVision` from catalog capability/modality metadata, and adds
  an editable custom-input field so operators can type self-hosted/unlisted
  vision model ids (Ollama/vLLM, …).
- Supporting fixes in the same commit: `reasoning` field fallback for
  opencode-routed gateways (SSE + non-stream parsing, empty-choices
  misclassification), Command Code wire-model normalization for bare ids
  (`mimo-v2.5` → `xiaomi/mimo-v2.5`), stable Vision Bridge describe cache key
  (base prompt, not task-composed prompt), and `cmd/gpt-5.3-codex*` marked
  text-only in capability resolution.

## Related Issues

- Closes #10808
- Closes #10809
- Related to #10702 (alias resolution), #10703 (catalog vision filter), #6623 (opencode reasoning field)

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other — **provider + routing + UI**
- [x] Focused tests and category gates from the golden path:
  - `node --import tsx/esm --test tests/unit/guardrails/visionBridgeCredentials.test.ts`
  - `node --import tsx/esm --test tests/unit/guardrails/vision-bridge-cache-key.test.ts`
  - `node --import tsx/esm --test tests/unit/model-select-field-catalog-vision-10809.test.ts`
  - `node --import tsx/esm --test tests/unit/model-capabilities-command-code-codex-textonly-10703.test.ts`
  - `node --import tsx/esm --test tests/unit/command-code-vision.test.ts`
  - `node --import tsx/esm --test tests/unit/command-code-registry-vision.test.ts`
  - `node --import tsx/esm --test tests/unit/guardrails/vision-bridge-sse-and-reasoning.test.ts`
  - `node --import tsx/esm --test tests/unit/issue-6623-opencode-mimo-reasoning-details-nonstream.test.ts`
  - `node --import tsx/esm --test tests/unit/vision-bridge-cc-no-reroute.test.ts`
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- `tests/unit/guardrails/visionBridgeCredentials.test.ts` (new) — #10702
  regression: alias resolution + no-auth provider handling against the real
  DB-backed path (isolated `DATA_DIR`, `resetDbInstance()` cleanup).
- `tests/unit/guardrails/vision-bridge-cache-key.test.ts` (new) — describe
  cache reuse across full-transcript turns; new images still force a fresh call.
- `tests/unit/model-select-field-catalog-vision-10809.test.ts` (new) —
  `readCatalogModels` vision verdict derivation (capabilities / input
  modalities / conservative heuristic for `custom` models only).
- `tests/unit/model-capabilities-command-code-codex-textonly-10703.test.ts`
  (new) — `cmd/gpt-5.3-codex` text-only override.
- `tests/unit/command-code-vision.test.ts` — wire-model normalization
  (`command-code/mimo-v2.5` → `xiaomi/mimo-v2.5`, aliased `cmd/`, prefixed
  passthrough); conservative vision-family lock kept for `gpt-5.4-mini`.
- `tests/unit/command-code-registry-vision.test.ts` — registry verdict moves
  `gpt-5.3-codex` from vision → text-only list.
- `tests/unit/guardrails/vision-bridge-sse-and-reasoning.test.ts` — plain
  `reasoning` field fallback (opencode gateway) for non-stream responses.
- `tests/unit/issue-6623-opencode-mimo-reasoning-details-nonstream.test.ts` —
  reasoning-only non-stream completions no longer flagged empty.
- `tests/unit/ui/modality-bridge-vision-tab.test.tsx` — Vision tab with
  catalog model source + custom input.
- `tests/unit/vision-bridge-cc-no-reroute.test.ts` — no-reroute expectations
  for native-vision CC models.

## Coverage Notes

- Production changes span `src/lib/guardrails/` (vision bridge), `src/lib/
  modelCapabilities.ts`, `src/shared/components/ModelSelectField.tsx`,
  `src/app/(dashboard)/dashboard/settings/components/modalityBridge/`, and
  `open-sse/` (commandCode executor, errorClassifier, diagnostics).
- Coverage: new tests directly exercise the changed code paths — credential
  resolution (real DB-backed), cache keying, catalog vision derivation, wire
  model normalization, and reasoning-field parsing. UI change (Vision tab
  props) is covered by the updated `modality-bridge-vision-tab.test.tsx`.
- No coverage regression expected in touched files; the new test files add
  statement/branch coverage to previously untested branches (no-auth provider
  path in `visionBridgeCredentials.ts`, `reasoning` fallback branches).

## Reviewer Notes

- **No feature flags or DB migrations** — all changes are in-memory/resolution
  logic; no schema change, no new env vars.
- **Intentional behavior change**: `hasUsableCredentialsForModel` now treats an
  empty active connection set as usable for no-auth providers (`oc`/`opencode`,
  `ddgw`/`duckduckgo-web`, …). Terminal statuses (`disabled`/`banned`/`expired`)
  still block. This is what lets `oc/mimo-v2.5-free` pass the credential gate.
- **Cache key change** (`visionBridge.ts`): keying switched from the
  task-aware composed prompt to the base prompt. Intentional and stable — the
  composed prompt appends the last user text and changes every turn, defeating
  the cache for full-transcript clients. A genuinely new image has a different
  `contentRef` and still misses.
- **Wire-model normalization** (`commandCode.ts`) is a minimal, doc-backed
  allowlist (`mimo-v2.5`, `mimo-v2.5-pro`); ids containing `/` pass through
  untouched. Verify against Command Code's `/alpha/generate` when testing.
- **`reasoning` field fallback** relies on OpenAI-compatible upstreams naming
  chain-of-thought `reasoning` (opencode gateway). `reasoning_content` remains
  the primary fallback.
- Manual validation worth doing: configure `oc/mimo-v2.5-free` as the Vision
  Bridge model with a text-only target, send an image payload, and confirm the
  describe call goes to `oc/mimo-v2.5-free` (no fallback to claude-opus-4-7).
