### PR TITLE
fix(api): guard combo updates against emptying, and fix copilot combo targets

### DIFF
--- a/changelog.d/fixes/10866-combo-empty-models.md
+++ b/changelog.d/fixes/10866-combo-empty-models.md
@@ -1,0 +1,1 @@
+- fix(api): reject a combo update that removes every model, and store the copilot's combo targets where the router reads them (#10866)

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -121,11 +121,7 @@ export const COPILOT_TOOLS: CopilotTool[] = [
       let output = `**${combos.length} combo(s) configured**\n\n`;
       for (const c of combos as any[]) {
         const active = c.isActive ? "✅" : "⛔";
-        const targets = c.targets
-          ? typeof c.targets === "string"
-            ? JSON.parse(c.targets).length
-            : c.targets.length
-          : 0;
+        const targets = Array.isArray(c.models) ? c.models.length : 0;
         output += `${active} **${c.name}** — strategy: \`${c.strategy}\` — ${targets} target(s)\n`;
       }
       return output;
@@ -165,7 +161,7 @@ export const COPILOT_TOOLS: CopilotTool[] = [
       const combo = await createCombo({
         name,
         strategy,
-        targets: JSON.stringify(targets),
+        models: targets,
         isActive: true,
       });
       const anyCombo = combo as any;

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -379,7 +379,12 @@ export const updateComboSchema = z
   .object({
     name: comboNameSchema.optional(),
     description: z.string().max(2000).optional().nullable(),
-    models: z.array(comboModelEntry).optional(),
+    // Creation may leave `models` empty (`omniroute combo create` drafts one
+    // that way); an update may not, or a working combo loses every target.
+    models: z
+      .array(comboModelEntry)
+      .min(1, "an update cannot remove every model from a combo")
+      .optional(),
     strategy: comboStrategySchema.optional(),
     config: comboRuntimeConfigSchema.optional(),
     isActive: z.boolean().optional(),

--- a/tests/unit/combo-empty-models.test.ts
+++ b/tests/unit/combo-empty-models.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-empty-models-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { createComboSchema, updateComboSchema } =
+  await import("../../src/shared/validation/schemas/combo.ts");
+const { getCopilotTool } = await import("../../src/lib/copilot/tools.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const core = await import("../../src/lib/db/core.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("an update cannot remove every model from a combo", () => {
+  assert.equal(updateComboSchema.safeParse({ models: [] }).success, false);
+  assert.equal(updateComboSchema.safeParse({ models: ["openai/gpt-4o-mini"] }).success, true);
+  assert.equal(updateComboSchema.safeParse({ name: "renamed" }).success, true);
+});
+
+test("creating a combo with no model stays allowed — the CLI does it on purpose", () => {
+  assert.equal(createComboSchema.safeParse({ name: "drafted", models: [] }).success, true);
+  assert.equal(createComboSchema.safeParse({ name: "drafted" }).success, true);
+});
+
+test("the copilot createCombo tool stores targets where the router looks for them", async () => {
+  const tool = getCopilotTool("createCombo");
+  assert.ok(tool);
+
+  await tool.handler({
+    name: "copilot-stored",
+    strategy: "priority",
+    targets: JSON.stringify([{ provider: "openai", model: "gpt-4o-mini", weight: 100 }]),
+  });
+
+  const stored = (await combosDb.getComboByName("copilot-stored")) as { models?: unknown[] } | null;
+  assert.ok(stored, "the combo should exist");
+  assert.equal(stored.models?.length, 1);
+});
+
+test("the copilot combo list counts the targets the router will use", async () => {
+  const list = getCopilotTool("listCombos");
+  assert.ok(list);
+
+  await combosDb.createCombo({
+    name: "dashboard-made",
+    strategy: "priority",
+    models: ["openai/gpt-4o-mini", "openai/gpt-4o"],
+  });
+
+  const output = await list.handler({});
+  assert.match(output, /\*\*dashboard-made\*\* — strategy: `priority` — 2 target\(s\)/);
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

Send `PUT /api/combos/<id>` with `{"models": []}` and the API answers 200 with every target gone. Ask that same combo for a completion a second later and you get a 404, `Combo has no executable targets`. Nothing warns you in between, and there's no undo.

This PR makes an update refuse an empty `models` array.

Creation is deliberately left alone. `omniroute combo create` builds an empty combo on purpose and expects you to fill it in from the dashboard (`bin/cli/commands/combo.mjs:290`), so requiring a model at creation would break a shipped CLI command. An empty combo is a legitimate draft; silently turning a working one into a draft isn't.

The invariant itself isn't new. "A combo has at least one model" is already re-checked by about nine consumers downstream — `open-sse/services/combo.ts:869`, `fusion.ts:282`, `pipeline.ts:169`, `chaosEngine.ts:392`, `src/domain/comboResolver.ts:30`, `src/app/api/combos/test/route.ts:165`, and the catalog skips the combo entirely (`catalog.ts:684`). The dashboard blocks the save too (`page.tsx:2185`, `:2808`). The write path was the only place that didn't look.

**Second bug, same family.** The OmniRoute Copilot's `createCombo` tool wrote its targets into a `targets` field (`src/lib/copilot/tools.ts:165`). The router reads `models`, and nothing reads `targets`, so every combo built through the copilot reported "created with N target(s)" and routed to none. `listCombos` read that same `targets` field back, so the two tools agreed with each other while disagreeing with the product. Both now use `models`.

## Related Issues

- None found. Searching issues and PRs for an empty-combo guard returns nothing in any state.

## Validation

- [x] Change type: routing / CLI
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/combo-empty-models.test.ts` (new) — four cases: an update with an empty `models` is rejected, an update that omits `models` still goes through, creation with no model stays allowed, and the two copilot tools round-trip through `models`.

Run: `node --import tsx/esm --test tests/unit/combo-empty-models.test.ts` — 4/4. Every `tests/unit/combo*` and `tests/unit/combo/*` file: 1213 tests, 1208 pass, 5 inherited failures (see below). `npm run test:vitest`: 368/368. `npm run lint`: clean.

## Coverage Notes

Both touched production files are covered by the new test: the schema change through `updateComboSchema.safeParse`, and both copilot tools through their real handlers against a temp SQLite database. No mocks.

## Reviewer Notes

- The base tip is red (#9985). The 5 failures in `tests/unit/combo-context-overflow-compression-probe.test.ts` are inherited: same 5, same names, with this branch's two production files reverted to the base commit.
- No migration, no feature flag. Existing empty combos keep working exactly as before — you can still rename, disable or delete one, and an update that adds models repairs it.
- The one behavior change a client could notice: a `PUT` sending `"models": []` now gets a 400 (`COMBO_002`) instead of a 200. I couldn't find any first-party caller that does this. The CLI only sends an empty `models` on create, never on update.
