### PR TITLE
feat(api): accept PATCH on /api/combos/[id]

### DIFF
--- a/changelog.d/features/10869-combo-patch-verb.md
+++ b/changelog.d/features/10869-combo-patch-verb.md
@@ -1,0 +1,1 @@
+- feat(api): accept PATCH on /api/combos/[id], the verb the OpenAPI spec already documents (#10869)

--- a/src/app/api/combos/[id]/route.ts
+++ b/src/app/api/combos/[id]/route.ts
@@ -265,6 +265,12 @@ export async function PUT(request, { params }) {
   }
 }
 
+// PATCH /api/combos/[id] - partial update. PUT merges the body onto the stored
+// combo, so both verbs share one handler (same shape as /api/providers/[id]).
+export async function PATCH(request, ctx) {
+  return PUT(request, ctx);
+}
+
 // DELETE /api/combos/[id] - Delete combo
 export async function DELETE(request, { params }) {
   const authError = await requireManagementAuth(request);

--- a/tests/unit/combo-patch-verb.test.ts
+++ b/tests/unit/combo-patch-verb.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-patch-verb-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const comboRoute = await import("../../src/app/api/combos/[id]/route.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function patch(id: string, body: Record<string, unknown>) {
+  return new Request(`http://localhost/api/combos/${id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("PATCH changes one field and leaves the rest of the combo alone", async () => {
+  const combo = await combosDb.createCombo({
+    name: "patchable",
+    strategy: "priority",
+    models: [{ provider: "openai", model: "gpt-4o" }],
+    system_message: "keep me",
+  });
+
+  const response = await comboRoute.PATCH(patch(combo.id, { strategy: "round-robin" }), {
+    params: Promise.resolve({ id: combo.id }),
+  });
+  assert.equal(response.status, 200);
+
+  const stored = (await combosDb.getComboById(combo.id)) as {
+    strategy?: string;
+    system_message?: string;
+    models?: unknown[];
+  };
+  assert.equal(stored.strategy, "round-robin");
+  assert.equal(stored.system_message, "keep me");
+  assert.equal(stored.models?.length, 1);
+});
+
+test("PATCH on an unknown combo answers 404, like PUT", async () => {
+  const response = await comboRoute.PATCH(patch("does-not-exist", { strategy: "priority" }), {
+    params: Promise.resolve({ id: "does-not-exist" }),
+  });
+  assert.equal(response.status, 404);
+
+  const body = (await response.json()) as { error?: { code?: string } };
+  assert.equal(body.error?.code, "COMBO_007");
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

`docs/openapi.yaml` describes `/api/combos/{id}` as `patch` and `delete` (`:2071`). The route exports `GET`, `PUT` and `DELETE` (`src/app/api/combos/[id]/route.ts:77,97,269`) — no `PATCH`. So a client generated from the published spec calls the documented verb and gets a 405 from the App Router, before any handler runs.

This adds the missing export. It's four lines, because the behavior is already there:

```ts
export async function PATCH(request, ctx) {
  return PUT(request, ctx);
}
```

`PUT` merges the body onto the stored combo (`sqliteComboRepository.updateCombo` builds `{...current, ...data}`) and `updateComboSchema` is entirely optional with a "No valid fields to update" refinement. That's PATCH semantics under a PUT name. `/api/providers/[id]:384` resolved the same situation with the same one-line delegation, and 25 routes under `/api/**` already export a `PATCH` — including the combo's closest neighbours: `keys/[id]`, `quota/pools/[id]`, `quota/groups/[id]`, `relay/tokens/[id]`, `settings/reasoning-routing-rules/[id]`.

Nothing about `PUT` changes. Existing clients keep working.

## Related Issues

- None. No issue or PR mentions a combo `PATCH`, in any state.

## Validation

- [x] Change type: routing
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/combo-patch-verb.test.ts` (new) — a `PATCH` that changes `strategy` alone leaves `system_message` and `models` untouched, and a `PATCH` on an unknown id answers 404 `COMBO_007` exactly like `PUT`. Both call the exported handler against a temp SQLite database.

Run: `node --import tsx/esm --test tests/unit/combo-patch-verb.test.ts` — 2/2, and both fail with `comboRoute.PATCH is not a function` before the change. Every `tests/unit/combo*` and `tests/unit/combo/*` file: 1211 tests, 1206 pass, 5 inherited failures. `npm run test:vitest`: 368/368. `npm run lint`: clean. The four OpenAPI gates (`check:openapi-coverage`, `-routes`, `-security-tiers`, `-breaking`) all pass.

## Coverage Notes

The only production change is the new export, and both new tests go through it. Nothing else in `src/` is touched, so no file loses coverage.

## Reviewer Notes

- The base tip is red (#9985). The 5 failures in `tests/unit/combo-context-overflow-compression-probe.test.ts` are inherited — they reproduce with this branch's route file reverted to the base commit.
- **Arrays replace, they don't merge.** Sending `"models": [...]` in a `PATCH` swaps the whole list, same as today's `PUT`. That's standard, but worth stating because a combo's `models` is the field people patch most.
- I did not touch the OpenAPI entry. It's now accurate for `patch`, but it still omits `get` and `put` for this path — a separate documentation gap, and fixing it here would widen a four-line change.
- Auth, validation, name-collision, DAG and quota-share checks are unchanged: they all live in `PUT`, and `PATCH` is that same function.
