### PR TITLE
fix(cli): report .env lines that never take effect

### DIFF
--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -119,6 +119,9 @@ function loadEnvFile() {
     addEnvPath(join(ROOT, ".env"));
   }
 
+  const keyOrigin = new Map();
+  const shadowed = new Map();
+
   for (const envPath of envPaths) {
     try {
       if (existsSync(envPath)) {
@@ -131,18 +134,30 @@ function loadEnvFile() {
             const key = trimmed.slice(0, eqIdx).trim();
             if (process.env[key] === undefined) {
               process.env[key] = parseEnvValue(trimmed.slice(eqIdx + 1));
+              keyOrigin.set(key, envPath);
+            } else if (!shadowed.has(key)) {
+              // The line is inert: something set this key first. Report it once
+              // per key, whether the winner was an earlier file or the process
+              // environment (#6194: a shell's own HOSTNAME beat the .env and the
+              // server bound to the wrong address in silence).
+              shadowed.set(key, { winner: keyOrigin.get(key) ?? null, loser: envPath });
             }
           }
         }
         loadedEnvPaths.push(envPath);
       }
-    } catch {
-      // Ignore errors reading env files.
+    } catch (err) {
+      console.warn(`  \x1b[33m⚠ Could not read ${envPath}: ${err?.message ?? err}\x1b[0m`);
     }
   }
 
   for (const envPath of loadedEnvPaths) {
     console.log(`  \x1b[2m📋 Loaded env from ${envPath}\x1b[0m`);
+  }
+
+  for (const [key, { winner, loser }] of shadowed) {
+    const setter = winner ? winner : "the environment";
+    console.warn(`  \x1b[33m⚠ ${key} in ${loser} is ignored, ${setter} set it first\x1b[0m`);
   }
 }
 

--- a/changelog.d/fixes/10870-cli-env-collision.md
+++ b/changelog.d/fixes/10870-cli-env-collision.md
@@ -1,0 +1,1 @@
+- fix(cli): warn when a .env line never takes effect, and stop swallowing an unreadable .env (#10870)

--- a/tests/unit/cli-env-collision.test.ts
+++ b/tests/unit/cli-env-collision.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = path.join(ROOT, "bin", "omniroute.mjs");
+
+function layout() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-cli-env-collision-"));
+  const home = path.join(tmp, "home");
+  const dataDir = path.join(tmp, "data");
+  const cwd = path.join(tmp, "cwd");
+  const appDataDir =
+    process.platform === "win32"
+      ? path.join(tmp, "appdata", "omniroute")
+      : path.join(home, ".omniroute");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(appDataDir, { recursive: true });
+  fs.mkdirSync(cwd, { recursive: true });
+  return { tmp, home, dataDir, cwd };
+}
+
+function runCli(
+  { tmp, home, dataDir, cwd }: ReturnType<typeof layout>,
+  extraEnv: Record<string, string> = {}
+) {
+  const cleanEnv = { ...process.env };
+  for (const key of ["OMNIROUTE_BASE_URL", "PORT", "STORAGE_ENCRYPTION_KEY"]) {
+    delete cleanEnv[key];
+  }
+  return spawnSync("node", [BIN, "env", "show", "--json"], {
+    cwd,
+    env: {
+      ...cleanEnv,
+      DATA_DIR: dataDir,
+      HOME: home,
+      USERPROFILE: home,
+      APPDATA: path.join(tmp, "appdata"),
+      CI: "1",
+      OMNIROUTE_CLI_SKIP_REPO_ENV: "1",
+      OMNIROUTE_NO_UPDATE_NOTIFIER: "1",
+      ...extraEnv,
+    },
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+}
+
+test("a key masked by an earlier .env is named, with both files and without its value", () => {
+  const dirs = layout();
+  try {
+    fs.writeFileSync(
+      path.join(dirs.dataDir, ".env"),
+      "OMNIROUTE_BASE_URL=https://data.example/v1\n"
+    );
+    fs.writeFileSync(path.join(dirs.cwd, ".env"), "OMNIROUTE_BASE_URL=https://cwd.example/v1\n");
+
+    const stderr = runCli(dirs).stderr ?? "";
+
+    assert.match(stderr, /OMNIROUTE_BASE_URL/);
+    assert.ok(stderr.includes(path.join(dirs.cwd, ".env")), `ignored file named: ${stderr}`);
+    assert.ok(stderr.includes(path.join(dirs.dataDir, ".env")), `winning file named: ${stderr}`);
+    assert.ok(!stderr.includes("cwd.example"), "the ignored value must never be printed");
+    assert.ok(!stderr.includes("data.example"), "the winning value must never be printed");
+  } finally {
+    fs.rmSync(dirs.tmp, { recursive: true, force: true });
+  }
+});
+
+test("a key each file declares once says nothing", () => {
+  const dirs = layout();
+  try {
+    fs.writeFileSync(
+      path.join(dirs.dataDir, ".env"),
+      "OMNIROUTE_BASE_URL=https://data.example/v1\n"
+    );
+    fs.writeFileSync(path.join(dirs.cwd, ".env"), "PORT=34567\n");
+
+    const stderr = runCli(dirs).stderr ?? "";
+    assert.ok(!/OMNIROUTE_BASE_URL|PORT/.test(stderr), `nothing to report: ${stderr}`);
+  } finally {
+    fs.rmSync(dirs.tmp, { recursive: true, force: true });
+  }
+});
+
+test("a key the environment already set is reported too — that is #6194", () => {
+  const dirs = layout();
+  try {
+    fs.writeFileSync(
+      path.join(dirs.dataDir, ".env"),
+      "OMNIROUTE_BASE_URL=https://data.example/v1\n"
+    );
+
+    const stderr = runCli(dirs, { OMNIROUTE_BASE_URL: "https://shell.example/v1" }).stderr ?? "";
+
+    assert.match(stderr, /OMNIROUTE_BASE_URL/);
+    assert.ok(stderr.includes(path.join(dirs.dataDir, ".env")), `inert file named: ${stderr}`);
+    assert.match(stderr, /environment/);
+    assert.ok(!stderr.includes("shell.example"), "the winning value must never be printed");
+    assert.ok(!stderr.includes("data.example"), "the ignored value must never be printed");
+  } finally {
+    fs.rmSync(dirs.tmp, { recursive: true, force: true });
+  }
+});
+
+test("an unreadable .env is reported instead of being swallowed", () => {
+  const dirs = layout();
+  try {
+    // A directory named `.env` passes existsSync and makes readFileSync throw
+    // EISDIR for any user, root included — unlike chmod 000.
+    fs.mkdirSync(path.join(dirs.cwd, ".env"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dirs.dataDir, ".env"),
+      "OMNIROUTE_BASE_URL=https://data.example/v1\n"
+    );
+
+    const result = runCli(dirs);
+    assert.equal(result.status, 0, "an unreadable .env must stay non-fatal");
+    assert.ok(
+      (result.stderr ?? "").includes(path.join(dirs.cwd, ".env")),
+      `the unreadable file should be named: ${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(dirs.tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

#6194 is the story this PR is about. A user put `HOSTNAME=0.0.0.0` in their `.env`; the shell had already exported `HOSTNAME`, so the line did nothing, the server bound to the machine name, `localhost` stopped answering, and ModelSync and health checks failed with `ECONNREFUSED`. The loader knew the `.env` line was inert. It didn't say so.

That's the defect: `loadEnvFile()` (`bin/omniroute.mjs:97-127`) stacks up to four `.env` files — `$DATA_DIR/.env`, the default data dir, `$PWD/.env`, then the repo checkout — and keeps the first value it finds. First-wins is correct and unchanged here. What was missing is a word about the lines that lose. Now each one gets a line on stderr:

```
⚠ HOSTNAME in /home/me/.omniroute/.env is ignored, the environment set it first
⚠ PORT in /home/me/project/.env is ignored, /home/me/.omniroute/.env set it first
```

The key and the two sources, never the value — a `.env` holds secrets and the name is enough to act on. One line per key, not per file, so layering three `.env` files in a container doesn't turn the boot log into a wall.

The second fix sits one character away. The read was wrapped in `catch {}` under an "Ignore errors reading env files" comment, so a `.env` you can't read — wrong permissions, a stray directory with that name, a bad mount — meant the server booted without its configuration in complete silence. It's a warning now, and startup carries on. Refusing to boot would trade one bad failure mode for a worse one.

## Related Issues

- Related to #6194 (a `.env` line silently beaten by the shell, with the whole cascade it caused)
- #10100 → #10101 fixed a different defect in this same parser

## Validation

- [x] Change type: CLI
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/cli-env-collision.test.ts` (new) — four cases, each spawning the real CLI against a temp `HOME`/`DATA_DIR`/cwd: a key masked by an earlier file is named with both paths and neither value; a key the environment already holds is reported the same way (the #6194 shape); a key declared once says nothing; an unreadable `.env` warns and still exits 0.

Three of the four fail on the base. The one that passes before and after is the guard against a chatty warning — it would catch a regression that starts complaining about keys nobody masked.

Run: `node --import tsx/esm --test tests/unit/cli-env-collision.test.ts` — 4/4. The neighbouring CLI env tests (`cli-data-dir-env-loading`, `cli-env-inline-comment-10100`, `cli-data-dir-env`, `cli-entrypoint`, `cli-electron-to-cli-migration-server-env-7302`, `cli-storage-key-bootstrap`) are untouched and green: 14/14. `npm run test:vitest`: 368/368. `npm run lint`: clean.

## Coverage Notes

`bin/omniroute.mjs` is the only production file touched. The new test drives it through `spawnSync` rather than importing a helper, so both new branches — an inert key, a failed read — run inside a real CLI startup. `tests/unit/cli-data-dir-env-loading.test.ts` already covered precedence itself and still passes unmodified, which is the evidence that resolution didn't move.

## Reviewer Notes

- The base tip is red (#9985).
- **On noise, since that's the obvious objection.** The warning only fires when a `.env` declares a key something else already set. On a real 13-key `.env` on a long-running install, that's zero lines. It does mean a deployment that passes env vars _and_ mounts a `.env` with the same keys will see one line per overlapping key at boot — which is arguably the information you want, since those `.env` lines do nothing. If you'd rather keep it strictly to file-vs-file collisions, that's a one-line change: keep the `keyOrigin.has(key)` guard in the `else if`. I went the other way because #6194 is the environment case, and it's the one that cost a real diagnosis.
- Warnings go to stderr, so `omniroute env show --json` and anything else parsing stdout is unaffected.
- The unreadable-file test uses a **directory** named `.env` instead of `chmod 000`: a container running as root can read a 000 file, and the test would quietly stop testing anything.
- Precedence, parsing and the existing "Loaded env from" lines are untouched. The only new output is warnings.
