### PR TITLE
fix(opencode): route Muse Spark 1.2 models to OpenAI Responses API

### DIFF
--- a/open-sse/config/providers/registry/opencode/index.ts
+++ b/open-sse/config/providers/registry/opencode/index.ts
@@ -22,6 +22,26 @@ export const opencodeProvider: RegistryEntry = {
       supportsReasoning: true,
       interleavedField: "reasoning_content",
     },
+    // #MUSE_SPARK: Muse Spark is served by OpenCode Zen ONLY on the OpenAI
+    // Responses API (https://opencode.ai/zen/v1/responses), not /chat/completions
+    // (confirmed in the official OpenCode Zen docs: https://opencode.ai/docs/zen/).
+    // Without targetFormat:"openai-responses" these models fall through to the
+    // default chat/completions pass-through and the upstream returns null/empty
+    // content (see issue #10867). The opencode provider is passthrough, so
+    // declaring them here only sets the wire format / capability flags — the
+    // live upstream model list already advertises both ids.
+    {
+      id: "muse-spark-1.2",
+      name: "Muse Spark 1.2",
+      supportsReasoning: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.2-contributor-free",
+      name: "Muse Spark 1.2 Contributor Free",
+      supportsReasoning: true,
+      targetFormat: "openai-responses",
+    },
     { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
     // #6998: 2026-07-14 refresh — the upstream free tier rotated its lineup;
     // minimax-m3-free, minimax-m2.5-free, ling-2.6-1t-free,

--- a/tests/unit/opencode-muse-spark-responses-10867.test.ts
+++ b/tests/unit/opencode-muse-spark-responses-10867.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { opencodeProvider } from "../../open-sse/config/providers/registry/opencode/index.ts";
+
+// #10867: Muse Spark is served by OpenCode Zen only on the OpenAI Responses API
+// (/responses), not /chat/completions. Without targetFormat:"openai-responses"
+// these models fall through to the default chat/completions pass-through and the
+// upstream returns null/empty content.
+test("muse-spark-1.2 and muse-spark-1.2-contributor-free route to the Responses API", () => {
+  for (const id of ["muse-spark-1.2", "muse-spark-1.2-contributor-free"]) {
+    const model = opencodeProvider.models.find((m) => m.id === id);
+    assert.ok(model, `${id} should be registered in the opencode provider`);
+    assert.equal(
+      model?.targetFormat,
+      "openai-responses",
+      `${id} must target the Responses API, not the default chat/completions pass-through`
+    );
+    assert.equal(model?.supportsReasoning, true);
+  }
+});


### PR DESCRIPTION
## Summary
OpenCode Zen serves `muse-spark-1.2` and `muse-spark-1.2-contributor-free` **only** on the OpenAI Responses API endpoint (`https://opencode.ai/zen/v1/responses`), not `/chat/completions`. This is confirmed in the official OpenCode Zen docs (https://opencode.ai/docs/zen/ — both model ids list `https://opencode.ai/zen/v1/responses` as their endpoint).

Without `targetFormat: "openai-responses"` these models fall through to the default chat/completions pass-through and the upstream returns `null`/empty `content` (reported in #10867).

## Change
Declared both models in `open-sse/config/providers/registry/opencode/index.ts` with:
- `targetFormat: "openai-responses"` (route to `/responses`)
- `supportsReasoning: true` (forward `reasoning_effort`)

The `opencode` provider is `passthroughModels: true`, so this only sets the wire format and capability flags — the live upstream model list already advertises both ids.

## Behavior notes
- After the fix, `oc/muse-spark-1.2-contributor-free` resolves to the `/responses` endpoint and returns real `output_text` instead of `null`.
- The model's thinking is internal/hidden (closed-source Meta model); it does **not** emit a separate `reasoning` item for display. That is expected behavior, not a bug — this PR only fixes the endpoint routing so content is returned at all.

## Test plan
- [ ] Restart OmniRoute
- [ ] `curl .../v1/models | grep muse-spark` lists `oc/muse-spark-1.2` and `oc/muse-spark-1.2-contributor-free`
- [ ] Send a request to `/v1/chat/completions` with `oc/muse-spark-1.2-contributor-free` → non-null content returned

Closes #10867 (root-cause fix; the issue also discusses the hidden-thinking nuance).
