### PR TITLE
fix(provider-health): keep unsupported validation probes neutral

### DIFF
--- a/changelog.d/fixes/10878-unsupported-validation-probes-neutral.md
+++ b/changelog.d/fixes/10878-unsupported-validation-probes-neutral.md
@@ -1,0 +1,1 @@
+- **fix(provider-health):** Keep unsupported 404/405 validation probes neutral so they do not poison stored credential health or scheduler failure state, while still honoring per-connection health-check pacing ([#10878](https://github.com/diegosouzapw/OmniRoute/pull/10878)) — thanks @Zartharas

--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -704,6 +704,7 @@ async function testApiKeyConnection(connection: any) {
     const error = "Provider test not supported";
     return {
       valid: false,
+      skipped: true,
       error,
       diagnosis: classifyFailure({ error, unsupported: true, provider: connection.provider }),
     };
@@ -795,6 +796,18 @@ export async function testSingleConnection(connectionId: string, validationModel
   }
 
   const latencyMs = Date.now() - startTime;
+
+  // Unsupported validation capability is neutral: the probe established that
+  // this provider cannot be verified through the generic test surface, not
+  // that its credential is invalid. Do not mutate persisted credential health.
+  if (result.skipped === true) {
+    return {
+      ...result,
+      latencyMs,
+      runtime: runtime || null,
+      testedAt: null,
+    };
+  }
 
   // Build update data
   const now = new Date().toISOString();

--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -130,8 +130,20 @@ async function testConnection(
   try {
     const result = await testSingleConnection(connectionId);
 
-    // A deliberate lease skip must not rewrite the health cache.
-    if (result.skipped === true) return;
+    // Deliberate skips never rewrite credential health or failure state.
+    // Unsupported validation capability is stable enough to honor the
+    // connection's configured interval; an exclusive-lease skip intentionally
+    // remains due on the next global sweep so recovery is not delayed.
+    if (result.skipped === true) {
+      const diagnosis = result.diagnosis as { code?: string } | undefined;
+      if (diagnosis?.code === "unsupported") {
+        getSchedulerState().perConnTiming.set(connectionId, {
+          lastAttemptAt: startTime,
+          nextAttemptAt: startTime + intervalMs,
+        });
+      }
+      return;
+    }
 
     const latencyMs = Date.now() - startTime;
     const state = getSchedulerState();

--- a/src/lib/providers/validation/openaiFormat.ts
+++ b/src/lib/providers/validation/openaiFormat.ts
@@ -163,7 +163,11 @@ export async function validateOpenAILikeProvider({
     }
 
     if (chatRes.status === 404 || chatRes.status === 405) {
-      return { valid: false, error: "Provider validation endpoint not supported" };
+      return {
+        valid: false,
+        error: "Provider validation endpoint not supported",
+        unsupported: true,
+      };
     }
 
     if (chatRes.status >= 500) {

--- a/tests/unit/provider-validation-unsupported-neutral.test.ts
+++ b/tests/unit/provider-validation-unsupported-neutral.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-unsupported-probe-neutral-")
+);
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+process.env.OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK = "true";
+
+const originalFetch = globalThis.fetch;
+
+const core = await import("../../src/lib/db/core.ts");
+
+const { validateOpenAILikeProvider } =
+  await import("../../src/lib/providers/validation/openaiFormat.ts");
+
+const { testSingleConnection } = await import("../../src/app/api/providers/[id]/test/route.ts");
+
+const credentialHealthScheduler = await import("../../src/lib/credentialHealth/scheduler.ts");
+
+function mockUnsupportedValidationSurface() {
+  let calls = 0;
+
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    calls += 1;
+
+    const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+
+    if (href.includes("/models")) {
+      return new Response("not found", {
+        status: 404,
+      });
+    }
+
+    return new Response("method not allowed", {
+      status: 405,
+    });
+  }) as typeof fetch;
+
+  return () => calls;
+}
+
+test.after(() => {
+  credentialHealthScheduler.stopCredentialHealthCheck();
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+
+  fs.rmSync(TEST_DATA_DIR, {
+    recursive: true,
+    force: true,
+  });
+});
+
+test("404/405 OpenAI-like probe surface is explicitly unsupported, not an auth failure", async () => {
+  const getCalls = mockUnsupportedValidationSurface();
+
+  const result = (await validateOpenAILikeProvider({
+    provider: "openai",
+    apiKey: "synthetic-test-key",
+    baseUrl: "https://api.openai.com/v1",
+    modelId: "gpt-4.1-mini",
+    providerSpecificData: {},
+  })) as {
+    valid: boolean;
+    error: string | null;
+    unsupported?: boolean;
+  };
+
+  assert.equal(getCalls(), 2, "expected /models then chat/completions validation probes");
+
+  assert.equal(result.valid, false);
+
+  assert.equal(result.unsupported, true, "404/405 validation surface must carry unsupported:true");
+
+  assert.match(String(result.error), /validation endpoint not supported/i);
+});
+
+test("unsupported provider verification is neutral and does not poison stored connection health", async () => {
+  const getCalls = mockUnsupportedValidationSurface();
+
+  const db = core.getDbInstance();
+
+  db.prepare(
+    `INSERT INTO provider_connections
+       (
+         id,
+         provider,
+         auth_type,
+         name,
+         api_key,
+         is_active,
+         test_status,
+         health_check_interval,
+         created_at,
+         updated_at
+       )
+     VALUES
+       (?, ?, 'apikey', ?, ?, 1, 'active', 60, ?, ?)`
+  ).run(
+    "unsupported-probe-test",
+    "openai",
+    "unsupported probe test",
+    "synthetic-test-key",
+    new Date().toISOString(),
+    new Date().toISOString()
+  );
+
+  const before = db
+    .prepare(
+      `SELECT
+         test_status,
+         last_tested,
+         last_error,
+         last_error_at,
+         error_code
+       FROM provider_connections
+       WHERE id = ?`
+    )
+    .get("unsupported-probe-test") as {
+    test_status: string;
+    last_tested: string | null;
+    last_error: string | null;
+    last_error_at: string | null;
+    error_code: string | null;
+  };
+
+  assert.equal(before.test_status, "active");
+  assert.equal(before.last_tested, null);
+  assert.equal(before.last_error, null);
+  assert.equal(before.last_error_at, null);
+  assert.equal(before.error_code, null);
+
+  const result = await testSingleConnection("unsupported-probe-test");
+
+  assert.equal(
+    getCalls(),
+    2,
+    "expected actual validator execution before capability was classified unsupported"
+  );
+
+  assert.equal(result.valid, false);
+
+  assert.equal(result.skipped, true, "unsupported verification must be returned as a neutral skip");
+
+  assert.equal(result.diagnosis?.code, "unsupported");
+
+  const after = db
+    .prepare(
+      `SELECT
+         test_status,
+         last_tested,
+         last_error,
+         last_error_at,
+         error_code
+       FROM provider_connections
+       WHERE id = ?`
+    )
+    .get("unsupported-probe-test") as {
+    test_status: string;
+    last_tested: string | null;
+    last_error: string | null;
+    last_error_at: string | null;
+    error_code: string | null;
+  };
+
+  assert.deepEqual(
+    after,
+    before,
+    "unsupported capability detection must not mutate persisted credential health"
+  );
+
+  await credentialHealthScheduler.forceSweep();
+
+  const timing = globalThis.__omnirouteCredentialHC?.perConnTiming.get("unsupported-probe-test");
+
+  assert.ok(timing, "unsupported scheduler skip must still establish per-connection pacing");
+
+  assert.equal(
+    timing.nextAttemptAt - timing.lastAttemptAt,
+    60 * 60_000,
+    "unsupported validation must honor the connection's 60-minute health-check interval"
+  );
+
+  const afterSweep = db
+    .prepare(
+      `SELECT
+         test_status,
+         last_tested,
+         last_error,
+         last_error_at,
+         error_code
+       FROM provider_connections
+       WHERE id = ?`
+    )
+    .get("unsupported-probe-test");
+
+  assert.deepEqual(
+    afterSweep,
+    before,
+    "scheduler handling of unsupported validation must remain health-state neutral"
+  );
+
+  credentialHealthScheduler.stopCredentialHealthCheck();
+});


### PR DESCRIPTION
## Summary

Generic OpenAI-like connection validation currently treats a chat-probe 404/405 as a normal failed credential test.

That is not sufficient evidence that the credential is invalid: it can mean the provider simply does not expose the generic validation surface.

This PR makes that capability result neutral end-to-end.

## Behavior

For an OpenAI-like validation flow where the fallback chat probe returns 404/405:

- validator returns `valid: false` with `unsupported: true`
- connection test returns `skipped: true`
- persisted provider health is not rewritten
- CredentialHealth cache/failure state is not poisoned
- unsupported scheduler skips still honor the connection's configured `healthCheckInterval`
- exclusive-lease skips retain their existing immediate-retry semantics

Existing behavior remains unchanged for:

- 401/403 authentication failures
- 429 accepted-but-rate-limited responses
- 5xx upstream failures
- successful validation

## Scope

- `src/lib/providers/validation/openaiFormat.ts`
- `src/app/api/providers/[id]/test/route.ts`
- `src/lib/credentialHealth/scheduler.ts`
- `tests/unit/provider-validation-unsupported-neutral.test.ts`
- `changelog.d/fixes/10878-unsupported-validation-probes-neutral.md`

No provider-specific exception and no MiMoCode runtime behavior is introduced.

## Validation

- RED: unsupported 404/405 lacked `unsupported:true`
- RED: unsupported result mutated stored connection health
- RED: unsupported scheduler skip failed to establish per-connection pacing
- GREEN: unsupported validator classification
- GREEN: persisted-health non-mutation
- GREEN: configured health-check pacing
- GREEN: exclusive-lease skip regression
- GREEN: existing 403 behavior
- GREEN: existing 429 behavior
- GREEN: OpenAI-format export regression
- `npm run typecheck:core` — PASS
- `npm run lint` — PASS
- file-size gate — PASS
- complexity gate — PASS
- cognitive-complexity gate — PASS
- `npm run check:any-budget:t11` — PASS
- tracked-artifacts gate — PASS
- upstream base was unchanged throughout implementation

## Design note

This does not label unsupported validation as healthy.

The result remains `valid: false`; the neutral `skipped` state means only that the generic validation surface produced no reliable credential-validity evidence.

The scheduler therefore avoids error/backoff poisoning while still pacing future unsupported probes according to the configured connection interval.
