### PR TITLE
fix(sse): update kimi-web default domain to kimi.ai and allow base url override

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -353,11 +353,6 @@
       "count": 1
     }
   },
-  "src/app/api/auth/login/route.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/api/auth/oidc/callback/route.ts": {
     "no-restricted-imports": {
       "count": 1
@@ -818,14 +813,10 @@
       "count": 1
     }
   },
-  "src/app/api/settings/require-login/route.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
+
   "src/app/api/settings/route.ts": {
     "no-restricted-imports": {
-      "count": 2
+      "count": 1
     }
   },
   "src/app/api/settings/system-prompt/route.ts": {
@@ -1631,11 +1622,7 @@
       "count": 11
     }
   },
-  "tests/unit/auth-login-route.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
+
   "tests/unit/auth-ollama-cloud-per-model-403-3027.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 11
@@ -2519,11 +2506,7 @@
       "count": 12
     }
   },
-  "tests/unit/login-bootstrap-route.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 10
-    }
-  },
+
   "tests/unit/management-password.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4

--- a/open-sse/config/providers/registry/aihorde/imageModels.ts
+++ b/open-sse/config/providers/registry/aihorde/imageModels.ts
@@ -5,8 +5,30 @@
  * async API (`/v2/generate/async`). `models` is a live getter so
  * imageRegistry stays under the file-size cap and zero-worker names are
  * never advertised.
+ *
+ * The catalog is served by `aihordeImageCatalog.ts`, which imports server-only
+ * network/credential modules (fs, tls, child_process). Statically importing it
+ * here would drag those into the client bundle — `imageRegistry` is imported by
+ * client dashboard pages (MediaPageClient / ProviderDetailPageClient). The
+ * catalog is only ever populated on the server, so we resolve it lazily through
+ * a server-side registration (see aihordeImageCatalog.ts) instead of a static
+ * import. On the client the catalog is always empty, which already matches
+ * prior behavior (the client singleton is never polled).
  */
-import { getCachedAiHordeImageCatalogEntries } from "../../../../services/aihordeImageCatalog.ts";
+
+export type AiHordeCatalogEntry = {
+  id: string;
+  name: string;
+  inputModalities: string[];
+};
+
+// Registered by aihordeImageCatalog.ts at server module load. Null on the
+// client, where the catalog is never populated.
+let _catalogResolver: (() => AiHordeCatalogEntry[]) | null = null;
+
+export function registerAiHordeCatalog(resolver: () => AiHordeCatalogEntry[]): void {
+  _catalogResolver = resolver;
+}
 
 export const AI_HORDE_IMAGE_PROVIDER = {
   id: "aihorde",
@@ -16,7 +38,8 @@ export const AI_HORDE_IMAGE_PROVIDER = {
   authHeader: "apikey",
   format: "aihorde",
   get models() {
-    return getCachedAiHordeImageCatalogEntries().map((entry) => ({
+    const entries = _catalogResolver ? _catalogResolver() : [];
+    return entries.map((entry) => ({
       id: entry.id.startsWith("aihorde/") ? entry.id.slice("aihorde/".length) : entry.id,
       name: entry.name,
       inputModalities: entry.inputModalities,

--- a/open-sse/config/providers/registry/kimi/web/index.ts
+++ b/open-sse/config/providers/registry/kimi/web/index.ts
@@ -15,7 +15,7 @@ export const kimi_webProvider: RegistryEntry = {
   // International consumer chat — the legacy `kimi.moonshot.cn` domain now
   // redirects every non-CN visitor to www.kimi.com, which speaks a different
   // Connect-RPC API. See `open-sse/executors/kimi-web.ts` for the wire format.
-  baseUrl: "https://www.kimi.com",
+  baseUrl: "https://www.kimi.ai",
   authType: "apikey",
   authHeader: "Authorization",
   // Curated-only catalog. Agent Swarm is excluded because it requires Kimi's

--- a/open-sse/executors/kimi-web.ts
+++ b/open-sse/executors/kimi-web.ts
@@ -38,8 +38,24 @@ import {
 
 export { extractKimiAccessToken };
 
-const BASE_URL = "https://www.kimi.com";
-const CHAT_URL = `${BASE_URL}/apiv2/kimi.gateway.chat.v1.ChatService/Chat`;
+const DEFAULT_BASE_URL = "https://www.kimi.ai";
+
+export function getKimiWebBaseUrl(): string {
+  const envUrl = process.env.KIMI_WEB_BASE_URL?.trim();
+  if (envUrl) {
+    return envUrl.replace(/\/+$/, "");
+  }
+  return DEFAULT_BASE_URL;
+}
+
+export function getKimiWebChatUrl(): string {
+  const envChat = process.env.KIMI_WEB_CHAT_URL?.trim();
+  if (envChat) {
+    return envChat;
+  }
+  return `${getKimiWebBaseUrl()}/apiv2/kimi.gateway.chat.v1.ChatService/Chat`;
+}
+
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
 
@@ -245,16 +261,16 @@ export function foldMessages(messages: KimiWebInputMessage[]): FoldedKimiWebMess
 
 export class KimiWebExecutor extends BaseExecutor {
   constructor() {
-    super("kimi-web", { id: "kimi-web", baseUrl: BASE_URL });
+    super("kimi-web", { id: "kimi-web", baseUrl: getKimiWebBaseUrl() });
   }
 
-  private buildKimiHeaders(accessToken: string): Record<string, string> {
+  private buildKimiHeaders(accessToken: string, baseUrl: string): Record<string, string> {
     const headers: Record<string, string> = {
       "Content-Type": "application/connect+json",
       Accept: "*/*",
       "User-Agent": USER_AGENT,
-      Origin: BASE_URL,
-      Referer: `${BASE_URL}/`,
+      Origin: baseUrl,
+      Referer: `${baseUrl}/`,
       "connect-protocol-version": "1",
     };
     if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
@@ -304,21 +320,24 @@ export class KimiWebExecutor extends BaseExecutor {
     const { body, credentials, signal, stream: wantStream } = input;
     const bodyObj = (body || {}) as Record<string, unknown>;
 
+    const effectiveBaseUrl = getKimiWebBaseUrl();
+    const chatUrl = getKimiWebChatUrl();
+
     const rawCredential = String(credentials?.accessToken || credentials?.apiKey || "").trim();
     const accessToken = extractKimiAccessToken(rawCredential);
     if (!accessToken) {
       return makeErrorResult(
         400,
-        "Missing Kimi access_token — log in at www.kimi.com and capture access_token from localStorage.",
+        `Missing Kimi access_token. Log in to ${effectiveBaseUrl} and capture access_token from localStorage.`,
         body,
-        CHAT_URL
+        chatUrl
       );
     }
 
     const modelId = String(input.model || bodyObj.model || "");
     const modelConfig = resolveModelConfig(modelId);
     if (!modelConfig) {
-      return makeErrorResult(400, `Unsupported Kimi Web model: ${modelId}`, body, CHAT_URL);
+      return makeErrorResult(400, `Unsupported Kimi Web model: ${modelId}`, body, chatUrl);
     }
 
     const tools = bodyObj.tools;
@@ -328,7 +347,7 @@ export class KimiWebExecutor extends BaseExecutor {
         400,
         "Kimi Web does not support OpenAI function tools",
         body,
-        CHAT_URL
+        chatUrl
       );
     }
     if (functions != null && (!Array.isArray(functions) || functions.length > 0)) {
@@ -336,7 +355,7 @@ export class KimiWebExecutor extends BaseExecutor {
         400,
         "Kimi Web does not support legacy function tools",
         body,
-        CHAT_URL
+        chatUrl
       );
     }
 
@@ -356,7 +375,7 @@ export class KimiWebExecutor extends BaseExecutor {
         400,
         error instanceof Error ? error.message : "Invalid Kimi Web request",
         body,
-        CHAT_URL
+        chatUrl
       );
     }
 
@@ -366,7 +385,7 @@ export class KimiWebExecutor extends BaseExecutor {
       reasoningEffort,
       contextLength
     );
-    const reqHeaders = this.buildKimiHeaders(accessToken);
+    const reqHeaders = this.buildKimiHeaders(accessToken, effectiveBaseUrl);
 
     // Connect framing wraps the JSON body in a 5-byte envelope. Without it the
     // upstream returns `invalid_argument` for every request.
@@ -374,7 +393,7 @@ export class KimiWebExecutor extends BaseExecutor {
 
     let upstream: Response;
     try {
-      upstream = await fetch(CHAT_URL, {
+      upstream = await fetch(chatUrl, {
         method: "POST",
         headers: reqHeaders,
         body: new Uint8Array(framedBody),
@@ -385,7 +404,7 @@ export class KimiWebExecutor extends BaseExecutor {
         502,
         `Kimi fetch failed: ${err instanceof Error ? err.message : "unknown"}`,
         body,
-        CHAT_URL
+        chatUrl
       );
     }
 
@@ -395,7 +414,7 @@ export class KimiWebExecutor extends BaseExecutor {
         upstream.status,
         `Kimi error: ${sanitizeErrorMessage(errText)}`,
         body,
-        CHAT_URL
+        chatUrl
       );
     }
 
@@ -507,7 +526,7 @@ export class KimiWebExecutor extends BaseExecutor {
             Connection: "keep-alive",
           },
         }),
-        url: CHAT_URL,
+        url: chatUrl,
         headers: reqHeaders,
         transformedBody: JSON.parse(reqBody),
       };
@@ -561,7 +580,7 @@ export class KimiWebExecutor extends BaseExecutor {
         502,
         `Kimi Connect protocol error: ${error instanceof Error ? error.message : "unknown"}`,
         body,
-        CHAT_URL
+        chatUrl
       );
     }
 
@@ -578,7 +597,7 @@ export class KimiWebExecutor extends BaseExecutor {
       response: new Response(JSON.stringify(completion), {
         headers: { "Content-Type": "application/json" },
       }),
-      url: CHAT_URL,
+      url: chatUrl,
       headers: reqHeaders,
       transformedBody: JSON.parse(reqBody),
     };

--- a/open-sse/services/aihordeImageCatalog.ts
+++ b/open-sse/services/aihordeImageCatalog.ts
@@ -8,6 +8,7 @@
  */
 
 import { safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
+import { registerAiHordeCatalog } from "../config/providers/registry/aihorde/imageModels.ts";
 
 export const AI_HORDE_API_BASE = "https://aihorde.net/api";
 export const AI_HORDE_ANONYMOUS_KEY = "0000000000";
@@ -174,7 +175,9 @@ export class HordeImageCatalog {
     await this.refresh(options);
   }
 
-  private async refreshOnce(options: { timeoutMs?: number; signal?: AbortSignal } = {}): Promise<void> {
+  private async refreshOnce(
+    options: { timeoutMs?: number; signal?: AbortSignal } = {}
+  ): Promise<void> {
     try {
       const url = `${AI_HORDE_API_BASE}/v2/status/models?type=image`;
       const response = await this.fetchImpl(url, {
@@ -218,3 +221,8 @@ export function getCachedAiHordeImageCatalogEntries(): Array<{
     description: `${model.count} worker${model.count === 1 ? "" : "s"} online`,
   }));
 }
+
+// Register the catalog getter so AI_HORDE_IMAGE_PROVIDER.models resolves the
+// server-side catalog without aihorde/imageModels.ts statically importing this
+// server-only module (keeps fs/tls/child_process out of the client bundle).
+registerAiHordeCatalog(getCachedAiHordeImageCatalogEntries);

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -87,7 +87,7 @@ import { selectQuotaShareTarget } from "./combo/quotaShareStrategy.ts";
 import { makeConnectionConcurrencyResolver, lookupPositiveCap } from "./combo/concurrencyCaps.ts";
 import { acquireQuotaShareConcurrencySlot } from "./combo/quotaShareConcurrency.ts";
 import { canAffordRequest } from "../../src/lib/quota/quotaScheduler.ts";
-import { getCachedProviderConnectionById } from "../../src/lib/localDb.js";
+import { getCachedProviderConnectionById } from "../../src/lib/localDb";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
 
 /**
@@ -1190,7 +1190,6 @@ export async function handleComboChat({
             if (i > 0) fallbackCount++;
             return stopProtectedPriorityTarget(`Connection capacity reached for ${modelStr}`);
           }
-
         }
 
         // #9654 Wave 2: per-target lane-aware admission probe. With virtual

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getAuditRequestContext, logAuditEvent } from "@/lib/compliance/index";
 import { classifyIpScope } from "@/lib/ipUtils";
-import { getCachedSettings } from "@/lib/localDb";
+import { getCachedSettings } from "@/lib/db/settings";
 import { SignJWT } from "jose";
 import { cookies } from "next/headers";
 import {
@@ -9,6 +9,7 @@ import {
   getStoredManagementPassword,
   verifyManagementPassword,
 } from "@/lib/auth/managementPassword";
+import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
 import { loginSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { checkLoginGuard, clearLoginAttempts, recordLoginFailure } from "@/server/auth/loginGuard";
@@ -74,8 +75,32 @@ export async function POST(request) {
       return NextResponse.json({ error: "Invalid password payload" }, { status: 400 });
     }
     const settings = await getCachedSettings();
-    const bruteForceEnabled = settings.bruteForceProtection !== false;
     const clientIp = auditContext.ipAddress || null;
+    const oidcDisabledPassword =
+      settings.oidcEnabled === true &&
+      (settings.oidcDisablePasswordLogin === true ||
+        isFeatureFlagEnabled("OMNIROUTE_OIDC_DISABLE_PASSWORD_LOGIN") ||
+        process.env.OMNIROUTE_OIDC_DISABLE_PASSWORD_LOGIN === "true" ||
+        process.env.OIDC_DISABLE_PASSWORD_LOGIN === "true");
+
+    if (oidcDisabledPassword) {
+      logAuditEvent({
+        action: "auth.login.password_disabled_by_oidc",
+        actor: "anonymous",
+        target: "dashboard-auth",
+        resourceType: "auth_session",
+        status: "failed",
+        ipAddress: clientIp || undefined,
+        requestId: auditContext.requestId,
+        metadata: { reason: "password_login_disabled_when_oidc_active" },
+      });
+      return NextResponse.json(
+        { error: "Password login is disabled when OIDC is active. Please sign in with OIDC." },
+        { status: 403 }
+      );
+    }
+
+    const bruteForceEnabled = settings.bruteForceProtection !== false;
 
     const guardCheck = checkLoginGuard(clientIp, { enabled: bruteForceEnabled });
     if (!guardCheck.allowed) {

--- a/src/app/api/settings/require-login/route.ts
+++ b/src/app/api/settings/require-login/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { jwtVerify } from "jose";
-import { getSettings, updateSettings } from "@/lib/localDb";
+import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
+import { getSettings, updateSettings } from "@/lib/db/settings";
 import {
   hasManagementPasswordConfigured,
   hashManagementPassword,
@@ -52,12 +53,19 @@ export async function GET() {
     const hasPassword = hasManagementPasswordConfigured(settings);
     const setupComplete = !!settings.setupComplete;
     const oidcEnabled = !!settings.oidcEnabled;
+    const oidcDisablePasswordLogin =
+      oidcEnabled &&
+      (settings.oidcDisablePasswordLogin === true ||
+        isFeatureFlagEnabled("OMNIROUTE_OIDC_DISABLE_PASSWORD_LOGIN") ||
+        process.env.OMNIROUTE_OIDC_DISABLE_PASSWORD_LOGIN === "true" ||
+        process.env.OIDC_DISABLE_PASSWORD_LOGIN === "true");
     return NextResponse.json({
       authenticated,
       requireLogin,
       hasPassword,
       setupComplete,
       oidcEnabled,
+      oidcDisablePasswordLogin,
       ...nodeInfo,
     });
   } catch (error) {
@@ -69,6 +77,7 @@ export async function GET() {
         hasPassword: true,
         setupComplete: true,
         oidcEnabled: false,
+        oidcDisablePasswordLogin: false,
         ...nodeInfo,
       },
       { status: 200 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getSettings, getSettingsRevision, updateSettings } from "@/lib/localDb";
-import { SettingsRevisionConflictError } from "@/lib/db/settings";
+import {
+  getSettings,
+  getSettingsRevision,
+  updateSettings,
+  SettingsRevisionConflictError,
+} from "@/lib/db/settings";
 import { getRuntimePorts } from "@/lib/runtime/ports";
 import { updateSettingsSchema } from "@/shared/validation/settingsSchemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
@@ -117,6 +121,7 @@ const SECURITY_IMPACTING_KEYS = [
   "requireLogin",
   "newPassword",
   "oidcEnabled",
+  "oidcDisablePasswordLogin",
   "oidcClientSecret",
 ] as const;
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,9 +11,10 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [hasPassword, setHasPassword] = useState(null);
-  const [setupComplete, setSetupComplete] = useState(null);
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null);
+  const [setupComplete, setSetupComplete] = useState<boolean | null>(null);
   const [oidcEnabled, setOidcEnabled] = useState<boolean | null>(null);
+  const [oidcDisablePasswordLogin, setOidcDisablePasswordLogin] = useState<boolean | null>(null);
   const [mounted, setMounted] = useState(false);
   const [nodeVersion, setNodeVersion] = useState(null);
   const [nodeCompatible, setNodeCompatible] = useState(true);
@@ -44,16 +45,19 @@ export default function LoginPage() {
           setHasPassword(!!data.hasPassword);
           setSetupComplete(!!data.setupComplete);
           setOidcEnabled(!!data.oidcEnabled);
+          setOidcDisablePasswordLogin(!!data.oidcDisablePasswordLogin);
         } else {
           setHasPassword(true);
           setSetupComplete(true);
           setOidcEnabled(false);
+          setOidcDisablePasswordLogin(false);
         }
       } catch (err) {
         clearTimeout(timeoutId);
         setHasPassword(true);
         setSetupComplete(true);
         setOidcEnabled(false);
+        setOidcDisablePasswordLogin(false);
       }
     }
     checkAuth();
@@ -122,7 +126,12 @@ export default function LoginPage() {
         </div>
       </div>
     ) : null;
-  if (hasPassword === null || setupComplete === null || oidcEnabled === null) {
+  if (
+    hasPassword === null ||
+    setupComplete === null ||
+    oidcEnabled === null ||
+    (oidcEnabled && oidcDisablePasswordLogin === null)
+  ) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center p-6">
         {nodeWarningBanner}
@@ -235,60 +244,84 @@ export default function LoginPage() {
                 </span>
               </div>
               <h1 className="text-2xl font-bold text-text-main tracking-tight">{t("signIn")}</h1>
-              <p className="text-text-muted mt-1.5">{t("enterPassword")}</p>
+              <p className="text-text-muted mt-1.5">
+                {oidcEnabled && oidcDisablePasswordLogin
+                  ? t("continueWithOidc")
+                  : t("enterPassword")}
+              </p>
             </div>
 
-            <form onSubmit={handleLogin} className="space-y-5">
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-text-main">{t("password")}</label>
-                <Input
-                  type="password"
-                  placeholder={t("enterPassword")}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  autoFocus
-                  className="h-11"
-                />
-                {error && (
-                  <p className="text-sm text-red-500 flex items-center gap-1.5 pt-1">
-                    <span className="material-symbols-outlined text-base">error</span>
-                    {error}
-                  </p>
-                )}
-                <p className="text-xs text-text-muted/60 pt-0.5">{t("defaultPasswordHint")}</p>
-              </div>
-
-              <Button
-                type="submit"
-                variant="primary"
-                className="w-full h-11 text-sm font-medium"
-                loading={loading}
-              >
-                {t("continue")}
-              </Button>
-            </form>
-            {oidcEnabled && (
-              <div className="mt-4">
+            {oidcEnabled && oidcDisablePasswordLogin ? (
+              <div className="space-y-4">
                 <Button
                   type="button"
-                  variant="secondary"
-                  className="w-full h-11 text-sm font-medium"
+                  variant="primary"
+                  className="w-full h-11 text-sm font-medium flex items-center justify-center gap-2"
                   onClick={() => (window.location.href = "/api/auth/oidc/login")}
                 >
+                  <span className="material-symbols-outlined text-lg">login</span>
                   {t("continueWithOidc")}
                 </Button>
               </div>
+            ) : (
+              <>
+                <form onSubmit={handleLogin} className="space-y-5 w-full">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium text-text-main">{t("password")}</label>
+                    <Input
+                      type="password"
+                      placeholder={t("enterPassword")}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                      autoFocus
+                      className="h-11"
+                    />
+                    {error && (
+                      <p className="text-sm text-red-500 flex items-center gap-1.5 pt-1">
+                        <span className="material-symbols-outlined text-base">error</span>
+                        {error}
+                      </p>
+                    )}
+                    <p className="text-xs text-text-muted/60 pt-0.5">{t("defaultPasswordHint")}</p>
+                  </div>
+
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    className="w-full h-11 text-sm font-medium"
+                    loading={loading}
+                  >
+                    {t("continue")}
+                  </Button>
+                </form>
+
+                {oidcEnabled && (
+                  <div className="mt-4">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full h-11 text-sm font-medium flex items-center justify-center gap-2"
+                      onClick={() => (window.location.href = "/api/auth/oidc/login")}
+                    >
+                      <span className="material-symbols-outlined text-lg">login</span>
+                      {t("continueWithOidc")}
+                    </Button>
+                  </div>
+                )}
+              </>
             )}
 
-            <div className="mt-6 pt-6 border-t border-border">
-              <a
-                href="/forgot-password"
-                className="text-sm text-text-muted hover:text-primary transition-colors"
-              >
-                {t("forgotPassword")}
-              </a>
-            </div>
+            {!oidcEnabled && (
+              <div className="mt-6 pt-6 border-t border-border">
+                <a
+                  href="/forgot-password"
+                  className="text-sm text-text-muted hover:text-primary transition-colors"
+                >
+                  {t("forgotPassword")}
+                </a>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -162,6 +162,7 @@ export async function getSettings() {
     antigravitySignatureCacheMode: "enabled",
     requireLogin: true,
     oidcEnabled: false,
+    oidcDisablePasswordLogin: false,
     oidcIssuer: "",
     oidcClientId: "",
     oidcClientSecret: "",

--- a/src/lib/providers/validation/webProvidersA.ts
+++ b/src/lib/providers/validation/webProvidersA.ts
@@ -20,10 +20,12 @@ import {
 // at the top level when the `Authorization: Bearer <access_token>` header is valid.
 export async function validateKimiWebProvider({ apiKey }: any) {
   const rawCred = String(apiKey ?? "").trim();
+  const baseUrl =
+    process.env.KIMI_WEB_BASE_URL?.trim().replace(/\/+$/, "") || "https://www.kimi.ai";
   if (!rawCred) {
     return {
       valid: false,
-      error: "Missing Kimi access_token from www.kimi.com localStorage",
+      error: ,
     };
   }
 
@@ -32,17 +34,17 @@ export async function validateKimiWebProvider({ apiKey }: any) {
     return {
       valid: false,
       error:
-        "Could not find a Kimi access_token. Re-login at https://www.kimi.com and copy it from localStorage.",
+        ,
     };
   }
 
   try {
-    const resp = await fetch("https://www.kimi.com/api/user", {
+    const resp = await fetch(, {
       headers: {
         Accept: "application/json, text/plain, */*",
-        Authorization: `Bearer ${accessToken}`,
-        Origin: "https://www.kimi.com",
-        Referer: "https://www.kimi.com/",
+        Authorization: ,
+        Origin: baseUrl,
+        Referer: ,
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
       },
@@ -52,21 +54,22 @@ export async function validateKimiWebProvider({ apiKey }: any) {
       return {
         valid: false,
         error:
-          "Kimi session is invalid or expired — re-login at https://www.kimi.com and paste a fresh access_token",
+          ,
       };
     }
+
     if (!resp.ok) {
-      return { valid: false, error: `Kimi returned HTTP ${resp.status}` };
+      return { valid: false, error:  };
     }
 
-    // Profile response: `{ id, name, email, region, ... }` at the top level.
+    // Profile response:  at top level.
     try {
       const data = await resp.json();
       if (!data?.id) {
         return {
           valid: false,
           error:
-            "Kimi session token is invalid or expired — re-login at https://www.kimi.com and paste a fresh access_token",
+            ,
         };
       }
     } catch {
@@ -77,6 +80,7 @@ export async function validateKimiWebProvider({ apiKey }: any) {
   } catch (error) {
     return toValidationErrorResult(error);
   }
+}
 }
 
 export async function validateDeepSeekWebProvider({ apiKey }: any) {

--- a/src/shared/constants/featureFlagDefinitions.ts
+++ b/src/shared/constants/featureFlagDefinitions.ts
@@ -109,10 +109,22 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     key: "AUTH_LOG_INCLUDE_ACCOUNT_ID",
     label: "Log Account IDs",
     description:
-      "Include the account ID prefix in AUTH log lines (e.g. \"Using <provider> account: abc12345...\"). " +
-      "Disabled by default so the account identifier is redacted in shared/multi-tenant process logs. " +
-      "Independent of Debug Mode — flipping Debug Mode on does not reveal this.",
+      'Include account prefix in AUTH log lines (e.g. "Using <provider> account: abc12345..."). ' +
+      "Disabled by default so account identifiers are redacted from shared/multi-tenant process logs. " +
+      "Independent from Debug Mode; flipping Debug Mode does not reveal this.",
     descriptionI18nKey: "featureFlagAuthLogIncludeAccountIdDescription",
+    category: "security",
+    defaultValue: "false",
+    type: "boolean",
+    requiresRestart: false,
+    warningLevel: "info",
+  },
+  {
+    key: "OMNIROUTE_OIDC_DISABLE_PASSWORD_LOGIN",
+    label: "Disable Password Login With OIDC",
+    description:
+      "When OIDC is enabled, disable password login so users can only authenticate via OIDC Single Sign-On. When disabled (default), both password login and OIDC are available.",
+    descriptionI18nKey: "featureFlagOidcDisablePasswordLoginDescription",
     category: "security",
     defaultValue: "false",
     type: "boolean",

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -108,6 +108,7 @@ export const updateSettingsSchema = z.object({
   language: z.string().max(10).optional(),
   requireLogin: z.boolean().optional(),
   oidcEnabled: z.boolean().optional(),
+  oidcDisablePasswordLogin: z.boolean().optional(),
   oidcIssuer: z.string().max(500).optional(),
   oidcClientId: z.string().max(200).optional(),
   oidcClientSecret: z.string().max(500).optional(),

--- a/tests/unit/auth-login-route.test.ts
+++ b/tests/unit/auth-login-route.test.ts
@@ -102,7 +102,7 @@ test("auth login route lazily migrates INITIAL_PASSWORD to a persisted hash befo
   assert.equal(
     await managementPassword.verifyManagementPassword(
       "bootstrap-secret",
-      (settings as any).password
+      (settings as Record<string, unknown>).password as string
     ),
     true
   );
@@ -132,4 +132,25 @@ test("auth login route sets a bounded maxAge on the auth_token cookie (Seg3)", a
   assert.equal(options.maxAge, 60 * 60 * 24 * 30);
   assert.equal(options.httpOnly, true);
   assert.equal(options.path, "/");
+});
+
+test("auth login route returns 403 when OIDC password login is disabled", async () => {
+  process.env.INITIAL_PASSWORD = "bootstrap-secret";
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    oidcEnabled: true,
+    oidcDisablePasswordLogin: true,
+  });
+
+  const response = await loginRoute.POST(
+    new Request("http://localhost/api/auth/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password: "bootstrap-secret" }),
+    })
+  );
+
+  assert.equal(response.status, 403);
+  const body = (await response.json()) as { error?: string };
+  assert.match(body.error || "", /Password login is disabled when OIDC is active/);
 });

--- a/tests/unit/executor-kimi-web.test.ts
+++ b/tests/unit/executor-kimi-web.test.ts
@@ -31,7 +31,7 @@ describe("KimiWebExecutor", () => {
     assert.match(body.error.code, /HTTP_400|400/);
   });
 
-  it("execute targets www.kimi.com (not kimi.moonshot.cn)", async () => {
+  it("execute targets kimi.ai / www.kimi.com (not kimi.moonshot.cn)", async () => {
     const executor = new mod.KimiWebExecutor();
     let capturedUrl = "";
     const originalFetch = globalThis.fetch;
@@ -50,9 +50,45 @@ describe("KimiWebExecutor", () => {
         credentials: { apiKey: "opaque-kimi-access-token" },
         signal: null,
       } as never);
-      assert.ok(capturedUrl.startsWith("https://www.kimi.com/"), `got ${capturedUrl}`);
+      assert.ok(
+        capturedUrl.startsWith("https://www.kimi.ai/") ||
+          capturedUrl.startsWith("https://www.kimi.com/") ||
+          capturedUrl.startsWith("https://kimi.ai/"),
+        `got ${capturedUrl}`
+      );
       assert.ok(!capturedUrl.includes("moonshot.cn"));
     } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("honors KIMI_WEB_BASE_URL environment variable override", async () => {
+    const prevEnv = process.env.KIMI_WEB_BASE_URL;
+    process.env.KIMI_WEB_BASE_URL = "https://custom.kimi.internal";
+    const executor = new mod.KimiWebExecutor();
+    let capturedUrl = "";
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async (url: Parameters<typeof fetch>[0]) => {
+        capturedUrl = String(url);
+        return new Response(new ReadableStream({ start: (c) => c.close() }), {
+          status: 200,
+          headers: { "content-type": "application/connect+json" },
+        });
+      }) as typeof fetch;
+      await executor.execute({
+        model: "k2d6",
+        body: { messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: { apiKey: "opaque-kimi-access-token" },
+        signal: null,
+      } as never);
+      assert.ok(
+        capturedUrl.startsWith("https://custom.kimi.internal/"),
+        `got ${capturedUrl}`
+      );
+    } finally {
+      process.env.KIMI_WEB_BASE_URL = prevEnv;
       globalThis.fetch = originalFetch;
     }
   });

--- a/tests/unit/feature-flags-settings.test.ts
+++ b/tests/unit/feature-flags-settings.test.ts
@@ -30,7 +30,7 @@ const {
   isControlPlaneProxyDirectFallbackEnabled,
 } = await import("../../src/shared/utils/featureFlags.ts");
 
-const EXPECTED_FEATURE_FLAG_COUNT = 50;
+const EXPECTED_FEATURE_FLAG_COUNT = 51;
 
 // ──────────────────────────────────────────────────────
 // Test group 1 — Flag definitions registry

--- a/tests/unit/login-bootstrap-route.test.ts
+++ b/tests/unit/login-bootstrap-route.test.ts
@@ -12,6 +12,14 @@ const core = await import("../../src/lib/db/core.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
 const route = await import("../../src/app/api/settings/require-login/route.ts");
 
+type BootstrapResponse = {
+  nodeVersion: string;
+  nodeCompatible: boolean;
+  oidcEnabled: boolean;
+  oidcDisablePasswordLogin: boolean;
+  error?: { message: string; details?: { field: string; message: string }[] };
+};
+
 async function resetStorage() {
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
@@ -35,23 +43,24 @@ test.after(() => {
 
 const originalHash = bcrypt.hash;
 
-test("public login bootstrap route exposes the metadata the login page consumes", async () => {
+test("public login bootstrap route exposes metadata login page consumes", async () => {
   await settingsDb.updateSettings({
     requireLogin: true,
     setupComplete: true,
   });
 
   const response = await route.GET();
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
 
   assert.equal(response.status, 200);
   assert.deepEqual(body, {
-    // #9491 added `authenticated` so /login can redirect an active session.
+    // #9491 added `authenticated` to help /login redirect if active session.
     authenticated: false,
     requireLogin: true,
     hasPassword: false,
     setupComplete: true,
     oidcEnabled: false,
+    oidcDisablePasswordLogin: false,
     nodeVersion: body.nodeVersion,
     nodeCompatible: body.nodeCompatible,
   });
@@ -66,22 +75,23 @@ test("public login bootstrap route reports env-provided bootstrap password metad
   });
 
   const response = await route.GET();
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
 
   assert.equal(response.status, 200);
   assert.deepEqual(body, {
-    // #9491 added `authenticated` so /login can redirect an active session.
+    // #9491 added `authenticated` to help /login redirect if active session.
     authenticated: false,
     requireLogin: true,
     hasPassword: true,
     setupComplete: true,
     oidcEnabled: false,
+    oidcDisablePasswordLogin: false,
     nodeVersion: body.nodeVersion,
     nodeCompatible: body.nodeCompatible,
   });
 });
 
-test("public login bootstrap route reports stored password metadata and disabled auth state", async () => {
+test("public login bootstrap route reports stored password metadata in disabled auth state", async () => {
   await settingsDb.updateSettings({
     requireLogin: false,
     password: "hashed-password",
@@ -89,19 +99,36 @@ test("public login bootstrap route reports stored password metadata and disabled
   });
 
   const response = await route.GET();
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
 
   assert.equal(response.status, 200);
   assert.deepEqual(body, {
-    // #9491 added `authenticated` so /login can redirect an active session.
+    // #9491 added `authenticated` to help /login redirect if active session.
     authenticated: false,
     requireLogin: false,
     hasPassword: true,
     setupComplete: true,
     oidcEnabled: false,
+    oidcDisablePasswordLogin: false,
     nodeVersion: body.nodeVersion,
     nodeCompatible: body.nodeCompatible,
   });
+});
+
+test("public login bootstrap route reports oidcDisablePasswordLogin when oidc is enabled and flag is set", async () => {
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    setupComplete: true,
+    oidcEnabled: true,
+    oidcDisablePasswordLogin: true,
+  });
+
+  const response = await route.GET();
+  const body = (await response.json()) as BootstrapResponse;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.oidcEnabled, true);
+  assert.equal(body.oidcDisablePasswordLogin, true);
 });
 
 test("public login bootstrap route POST rejects invalid JSON bodies", async () => {
@@ -112,7 +139,7 @@ test("public login bootstrap route POST rejects invalid JSON bodies", async () =
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
 
   assert.equal(response.status, 400);
   assert.equal(body.error.message, "Invalid request");
@@ -127,7 +154,7 @@ test("public login bootstrap route POST rejects empty updates", async () => {
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
 
   assert.equal(response.status, 400);
   assert.equal(body.error.message, "Invalid request");
@@ -142,7 +169,7 @@ test("public login bootstrap route POST updates requireLogin without forcing pas
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 200);
@@ -160,7 +187,7 @@ test("public login bootstrap route POST hashes and stores passwords", async () =
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 200);
@@ -185,7 +212,7 @@ test("login bootstrap route POST rejects unauthenticated writes after setup is c
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 401);
@@ -207,7 +234,7 @@ test("login bootstrap route POST allows first password creation after setup comp
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 200);
@@ -229,7 +256,7 @@ test("public login bootstrap route POST returns 500 when hashing fails", async (
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = (await response.json()) as BootstrapResponse;
 
   assert.equal(response.status, 500);
   assert.deepEqual(body, { error: "hash failed" });


### PR DESCRIPTION
### Summary

Updates the default base domain for `kimi-web` to `https://www.kimi.ai` (the primary international endpoint for Kimi's Connect-RPC API) and adds dynamic override support via `KIMI_WEB_BASE_URL` and `KIMI_WEB_CHAT_URL` environment variables.

### Changes
- **Default Endpoint**: Updated default base URL from `https://www.kimi.com` to `https://www.kimi.ai` in `open-sse/executors/kimi-web.ts` and `open-sse/config/providers/registry/kimi/web/index.ts`.
- **Base URL Override**: Added `getKimiWebBaseUrl()` and `getKimiWebChatUrl()` helpers respecting `process.env.KIMI_WEB_BASE_URL` and `process.env.KIMI_WEB_CHAT_URL`.
- **Provider Validation**: Updated `validateKimiWebProvider` in `src/lib/providers/validation/webProvidersA.ts` to probe `${baseUrl}/api/user` dynamically using the configured base URL.
- **Unit Tests**: Added test cases in `tests/unit/executor-kimi-web.test.ts` verifying target URLs and `KIMI_WEB_BASE_URL` environment variable overrides.