### PR TITLE
fix: route Playground ChatTab Send to the selected endpoint (#10592)

### DIFF
--- a/changelog.d/fixes/10592-playground-chattab-endpoint-routing.md
+++ b/changelog.d/fixes/10592-playground-chattab-endpoint-routing.md
@@ -1,0 +1,1 @@
+- fix(dashboard): route the Playground's ChatTab "Send" through the endpoint actually selected in StudioConfigPane (`search`, `web.fetch`, etc.) instead of always POSTing to `/api/v1/chat/completions`, fixing the false "No active credentials for provider" 404 when testing search-only providers (#10592)

--- a/src/app/(dashboard)/dashboard/playground/components/tabs/ChatTab.tsx
+++ b/src/app/(dashboard)/dashboard/playground/components/tabs/ChatTab.tsx
@@ -11,6 +11,13 @@ import { getModelPricing } from "@/lib/playground/types";
 import type { ConfigState } from "../StudioConfigPane";
 import type { StreamMetrics } from "@/shared/schemas/playground";
 import { buildReasoningRequestFields } from "../reasoningControlUtils";
+import {
+  buildNonChatRequestBody,
+  formatNonChatResponse,
+  isChatCompletionsEndpoint,
+  lastUserContent,
+  resolveChatTabRequestPath,
+} from "./chatTabEndpointRequest";
 
 interface Message {
   role: "system" | "user" | "assistant";
@@ -127,11 +134,19 @@ export default function ChatTab({ configState, onMetricsUpdate }: ChatTabProps) 
 
     try {
       const fetchHeaders: Record<string, string> = { "Content-Type": "application/json" };
+      const chatEndpoint = isChatCompletionsEndpoint(configState.endpoint);
+      const requestBody = chatEndpoint
+        ? buildRequestBody(chatMessages)
+        : buildNonChatRequestBody(
+            configState.endpoint,
+            lastUserContent(chatMessages),
+            configState.model
+          );
 
-      const res = await fetch("/api/v1/chat/completions", {
+      const res = await fetch(resolveChatTabRequestPath(configState.endpoint), {
         method: "POST",
         headers: fetchHeaders,
-        body: JSON.stringify(buildRequestBody(chatMessages)),
+        body: JSON.stringify(requestBody),
         signal: controller.signal,
       });
 
@@ -146,6 +161,20 @@ export default function ChatTab({ configState, onMetricsUpdate }: ChatTabProps) 
         setMessages((prev) => prev.slice(0, targetIndex));
         setLoading(false);
         setResponseDuration(Date.now() - startTime);
+        streamMetrics.reset();
+        return;
+      }
+
+      if (!chatEndpoint) {
+        const rawText = await res.text();
+        setMessages((prev) => {
+          const next = [...prev];
+          const idx = appendIndex !== undefined ? appendIndex : next.length - 1;
+          next[idx] = { ...next[idx], content: formatNonChatResponse(rawText) };
+          return next;
+        });
+        setResponseDuration(Date.now() - startTime);
+        setLoading(false);
         streamMetrics.reset();
         return;
       }

--- a/src/app/(dashboard)/dashboard/playground/components/tabs/chatTabEndpointRequest.ts
+++ b/src/app/(dashboard)/dashboard/playground/components/tabs/chatTabEndpointRequest.ts
@@ -1,0 +1,59 @@
+// src/app/(dashboard)/dashboard/playground/components/tabs/chatTabEndpointRequest.ts
+//
+// #10592 — ChatTab.tsx hardcoded every "Send" click to POST /api/v1/chat/completions,
+// ignoring configState.endpoint entirely. Selecting a search-only provider (exa-search,
+// tavily-search, serper-search) in the Endpoint selector still sent a chat.completions
+// request, which has no notion of search-provider credentials and 404s.
+//
+// This module gives ChatTab a small, testable seam for routing non-chat endpoints
+// (currently "search" and "web.fetch") to their real path with a query-shaped body,
+// instead of the chat.completions messages/SSE shape.
+
+import { endpointToPath, type PlaygroundEndpoint } from "@/lib/playground/codeExport";
+
+/** Chat-shaped endpoints keep the existing messages[] + SSE-delta request/response flow. */
+export function isChatCompletionsEndpoint(endpoint: PlaygroundEndpoint | undefined): boolean {
+  return !endpoint || endpoint === "chat.completions";
+}
+
+/** Resolves the fetch path (mounted under `/api`) for the selected Playground endpoint. */
+export function resolveChatTabRequestPath(endpoint: PlaygroundEndpoint | undefined): string {
+  return `/api${endpointToPath(endpoint ?? "chat.completions")}`;
+}
+
+/**
+ * Builds the request body for a non-chat endpoint from the user's free-text query.
+ * "search" and "web.fetch" both take a single string field instead of a messages array.
+ */
+export function buildNonChatRequestBody(
+  endpoint: PlaygroundEndpoint | undefined,
+  query: string,
+  model: string
+): Record<string, unknown> {
+  if (endpoint === "web.fetch") {
+    return { url: query };
+  }
+  const body: Record<string, unknown> = { query };
+  if (model) body.model = model;
+  return body;
+}
+
+/** Renders a non-chat endpoint's raw response text as a chat-bubble-friendly string. */
+export function formatNonChatResponse(rawText: string): string {
+  try {
+    const parsed = JSON.parse(rawText) as unknown;
+    return "```json\n" + JSON.stringify(parsed, null, 2) + "\n```";
+  } catch {
+    return rawText;
+  }
+}
+
+/** Finds the most recent user-authored message content to use as a non-chat query. */
+export function lastUserContent(
+  chatMessages: Array<{ role: string; content: string }>
+): string {
+  for (let i = chatMessages.length - 1; i >= 0; i--) {
+    if (chatMessages[i].role === "user") return chatMessages[i].content;
+  }
+  return "";
+}

--- a/tests/unit/ui/playground-chat-tab-search-endpoint-10592.test.tsx
+++ b/tests/unit/ui/playground-chat-tab-search-endpoint-10592.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/playground/types", () => ({ getModelPricing: () => null }));
+vi.mock("@/lib/playground/streamMetrics", () => ({
+  computeMetrics: () => ({ ttftMs: 100, totalMs: 500, tokensIn: 10, tokensOut: 20, tps: 40, costUsd: 0.001 }),
+}));
+vi.mock("remark-gfm", () => ({ default: () => {} }));
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="markdown-content">{children}</div>,
+}));
+if (typeof Element.prototype.scrollIntoView === "undefined") {
+  Object.defineProperty(Element.prototype, "scrollIntoView", { value: () => {}, writable: true, configurable: true });
+}
+function setInputValue(el: HTMLTextAreaElement | HTMLInputElement, value: string): void {
+  const nativeSetter =
+    el instanceof HTMLTextAreaElement
+      ? Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set
+      : Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  nativeSetter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+}
+const { DEFAULT_PARAMS } = await import("../../../src/app/(dashboard)/dashboard/playground/components/ParamSliders");
+const { default: ChatTab } = await import("../../../src/app/(dashboard)/dashboard/playground/components/tabs/ChatTab");
+function makeSearchProviderConfig() {
+  return {
+    endpoint: "search" as const,
+    baseUrl: "http://localhost:20128",
+    model: "exa-search/web",
+    provider: "exa-search",
+    systemPrompt: "",
+    params: { ...DEFAULT_PARAMS },
+  };
+}
+const containers: Array<{ root: ReturnType<typeof createRoot>; el: HTMLDivElement }> = [];
+function renderChatTab(config: ReturnType<typeof makeSearchProviderConfig>): HTMLDivElement {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  act(() => {
+    root.render(<ChatTab configState={config} />);
+  });
+  containers.push({ root, el });
+  return el;
+}
+async function waitFor(fn: () => boolean, timeout = 3000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+describe("ChatTab — search-provider endpoint routing (#10592)", () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+  afterEach(() => {
+    for (const { root, el } of containers.splice(0)) {
+      act(() => root.unmount());
+      el.remove();
+    }
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+  it("routes to /api/v1/search (not /api/v1/chat/completions) when configState.endpoint is 'search'", async () => {
+    let capturedUrl: string | null = null;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      capturedUrl = String(url);
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } }
+      );
+    });
+    const el = renderChatTab(makeSearchProviderConfig());
+    const textarea = el.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setInputValue(textarea, "latest news India");
+    });
+    const sendBtn = Array.from(el.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Send")
+    ) as HTMLButtonElement | undefined;
+    await act(async () => {
+      sendBtn?.click();
+    });
+    await waitFor(() => capturedUrl !== null);
+    expect(capturedUrl).toBe("/api/v1/search");
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #10592

## Root cause

`ChatTab.tsx` (the "Send"-style chat UI in the main Playground) hardcoded every
request to `POST /api/v1/chat/completions` and never read `configState.endpoint`,
even though `StudioConfigPane`'s "Endpoint" selector exposes 13 real API endpoints
(`chat.completions`, `search`, `web.fetch`, etc. via `ENDPOINT_OPTIONS` /
`endpointToPath()` in `src/lib/playground/codeExport.ts`). Search providers
(`exa-search`, `tavily-search`, `serper-search`) have no chat-model catalog entries,
so `StudioConfigPane` falls back to a free-text model field, letting a user type
`exa-search/web` and hit "Send" — which still POSTed to chat.completions and 404'd
with `No active credentials for provider: exa-search`, because chat credential
resolution has no notion of search-provider credentials.

## Fix

`ChatTab.tsx` now resolves the request path from `configState.endpoint` via the
existing `endpointToPath()` helper, and for non-chat-shaped endpoints (currently
`search` and `web.fetch`) builds a query/url-based request body instead of the
`messages[]` shape, then renders the raw (JSON-pretty-printed when possible)
response instead of assuming an SSE chat-completions delta stream. The
`chat.completions` path (the default/most common case) is untouched — same
request body builder, same SSE decode loop.

New module: `src/app/(dashboard)/dashboard/playground/components/tabs/chatTabEndpointRequest.ts`
(kept ChatTab.tsx's diff minimal and gives the endpoint-routing logic its own
testable seam).

## Regression test (TDD)

`tests/unit/ui/playground-chat-tab-search-endpoint-10592.test.tsx` — renders
`ChatTab` with `configState.endpoint: "search"`, types a query, clicks Send, and
asserts the captured `fetch()` URL is `/api/v1/search` (not
`/api/v1/chat/completions`).

- RED on `origin/release/v3.8.50` (confirmed in the analysis pass and re-confirmed
  on this fresh worktree before the fix): `AssertionError: expected
  '/api/v1/chat/completions' to be '/api/v1/search'`.
- GREEN after the fix: `npx vitest run --config vitest.config.ts tests/unit/ui/playground-chat-tab-search-endpoint-10592.test.tsx` → 1 passed.

## Gates run

- `npx vitest run --config vitest.config.ts tests/unit/ui/playground-chat-tab-search-endpoint-10592.test.tsx` → pass
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → clean
- `node scripts/check/check-file-size.mjs` → OK
- `node scripts/check/check-complexity.mjs` → OK (2573 violations vs baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1157 violations vs baseline 1223)
- `node scripts/check/check-changelog-integrity.mjs` → OK

## Scope note

`CompareTab.tsx` has an independent hardcoded `fetch(`${configState.baseUrl}/v1/chat/completions`, ...)` call with the same class of issue, but it's a separate component/test surface — out of scope for this fix and left for a follow-up issue rather than widening this PR's diff.