### PR TITLE
fix(config): exclude cookie-auth image bridges from unprefixed model scan (#10848)

### DIFF
--- a/changelog.d/fixes/10848-image-scan-cookie-bridge.md
+++ b/changelog.d/fixes/10848-image-scan-cookie-bridge.md
@@ -1,0 +1,1 @@
+- fix(config): exclude cookie-auth image bridges (chatgpt-web, gemini-web) from the unprefixed model scan so a bare id never silently binds to an unofficial web bridge (#10848)

--- a/open-sse/config/imageRegistry.ts
+++ b/open-sse/config/imageRegistry.ts
@@ -918,9 +918,9 @@ export function parseImageModel(modelStr) {
     }
   }
 
-  // No provider prefix — try to find the model in every provider
+  // No provider prefix — try to find the model in every provider, excluding cookie-auth (web) bridges
   for (const [providerId, config] of Object.entries(IMAGE_PROVIDERS)) {
-    if (config.routingAliases?.includes(modelStr) || config.models.some((m) => m.id === modelStr)) {
+    if (config.authHeader !== "cookie" && (config.routingAliases?.includes(modelStr) || config.models.some((m) => m.id === modelStr))) {
       return { provider: providerId, model: modelStr };
     }
   }

--- a/tests/unit/unprefixed-scan-web-cookie-10848.test.ts
+++ b/tests/unit/unprefixed-scan-web-cookie-10848.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { IMAGE_PROVIDERS, parseImageModel } from "../../open-sse/config/imageRegistry.ts";
+
+test("#10848 bare id that only exists on a cookie-auth web bridge should not silently resolve to it", () => {
+  const chatgptWeb = IMAGE_PROVIDERS["chatgpt-web"];
+  assert.equal(chatgptWeb.authHeader, "cookie");
+  const otherProvidersWithSameId = Object.entries(IMAGE_PROVIDERS).filter(
+    ([providerId, config]) =>
+      providerId !== "chatgpt-web" && config.models.some((m) => m.id === "gpt-5.5")
+  );
+  assert.deepEqual(
+    otherProvidersWithSameId,
+    [],
+    "expected only chatgpt-web (cookie) to register gpt-5.5"
+  );
+
+  const resolved = parseImageModel("gpt-5.5");
+
+  assert.notDeepEqual(
+    resolved,
+    { provider: "chatgpt-web", model: "gpt-5.5" },
+    "bare 'gpt-5.5' must not silently bind to the cookie-auth chatgpt-web bridge"
+  );
+
+  assert.deepEqual(parseImageModel("chatgpt-web/gpt-5.5"), {
+    provider: "chatgpt-web",
+    model: "gpt-5.5",
+  });
+  assert.deepEqual(parseImageModel("cgpt-web/gpt-5.5"), {
+    provider: "chatgpt-web",
+    model: "gpt-5.5",
+  });
+});


### PR DESCRIPTION
Closes #10848

## Root cause
`parseImageModel()`'s unprefixed fallback loop in `open-sse/config/imageRegistry.ts` (lines ~918-923) walked every entry in `IMAGE_PROVIDERS` in insertion order with zero check on `config.authHeader`, so a bare model id that only exists on a cookie-auth "web bridge" provider (`chatgpt-web`, `gemini-web`, and one `cloudflare` entry) silently resolved to that unofficial bridge. PR #10847 (closing #10832) only special-cased `dall-e-3` by registering it on OpenAI and relying on insertion order — it added no general parser guard.

Example: bare `"gpt-5.5"` (registered only on `chatgpt-web`, `authHeader: "cookie"`) resolved to `{ provider: "chatgpt-web", model: "gpt-5.5" }` even though no official provider ever contested it.

## Fix
Skip providers with `authHeader === "cookie"` in the unprefixed fallback loop only. The prefixed-scan loop is untouched, so explicit prefixes (`chatgpt-web/gpt-5.5`, `cgpt-web/gpt-5.5`, `gweb/nano-banana-web`, `msdesigner/dall-e-3`) keep resolving normally — this only removes the *silent* bare-id fallback to unofficial bridges.

Kept the change line-neutral in `open-sse/config/imageRegistry.ts` (frozen at 1034 lines per `config/quality/file-size-baseline.json`) by folding the guard into the existing condition instead of adding new lines.

## Regression test
`tests/unit/unprefixed-scan-web-cookie-10848.test.ts` (TDD):
- confirmed RED on `origin/release/v3.8.50`: bare `"gpt-5.5"` resolved to `{ provider: "chatgpt-web", model: "gpt-5.5" }`
- GREEN after the fix: bare `"gpt-5.5"` no longer silently binds to the cookie-auth bridge, while `chatgpt-web/gpt-5.5` and `cgpt-web/gpt-5.5` (explicit prefixes) still resolve correctly

## Verification
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/unprefixed-scan-web-cookie-10848.test.ts` → pass
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/unprefixed-dalle3-10832.test.ts tests/unit/image-model-not-in-chat-catalog-6457.test.ts tests/unit/chatgpt-web.test.ts tests/unit/gemini-web-image-generation-10466.test.ts tests/unit/microsoft-designer-web-6672.test.ts tests/unit/image-registry-gpt56.test.ts` → 118/118 pass (no regression to #10832/#10847 dall-e-3 fix, #6457 chat-catalog exclusion, or web-bridge image generation)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/config/imageRegistry.ts tests/unit/unprefixed-scan-web-cookie-10848.test.ts` → clean
- `node scripts/check/check-file-size.mjs` → OK (no growth past frozen baseline)
- `node scripts/check/check-complexity.mjs` → OK
- `node scripts/check/check-cognitive-complexity.mjs` → OK
- `node scripts/check/check-changelog-integrity.mjs` → OK