### PR TITLE
fix: skip expensive RTK compression stats computation on no-op runs (#10765)

### DIFF
--- a/changelog.d/fixes/10765-rtk-unconditional-stats-cpu.md
+++ b/changelog.d/fixes/10765-rtk-unconditional-stats-cpu.md
@@ -1,0 +1,1 @@
+- fix(compression): skip the expensive `createCompressionStats()` pass in RTK when no message was actually compressed, matching every sibling stacked engine (#10765)

--- a/open-sse/services/compression/engines/rtk/index.ts
+++ b/open-sse/services/compression/engines/rtk/index.ts
@@ -656,6 +656,18 @@ export function applyRtkCompression(
     };
   });
 
+  // Mirror the sibling stacked engines (headroom, session-dedup, ccr, relevance,
+  // ionizer, readLifecycle): skip the expensive createCompressionStats() pass
+  // (full JSON.stringify + tokenizer over the whole body, twice) when nothing
+  // actually changed. Untouched messages keep their original reference above,
+  // so a reference-identity scan is enough to detect the no-op case (#10765).
+  const anyMessageChanged = compressedMessages.some(
+    (message, index) => message !== messages[index]
+  );
+  if (!anyMessageChanged) {
+    return { body, compressed: false, stats: null };
+  }
+
   const compressedBody = { ...adapter.body, messages: compressedMessages };
   const stats = createCompressionStats(
     adapter.body,

--- a/tests/unit/compression/rtk-engine.test.ts
+++ b/tests/unit/compression/rtk-engine.test.ts
@@ -70,7 +70,8 @@ describe("RTK compression engine", () => {
     assert.equal(rtkEngine.validateConfig({ intensity: "invalid" }).valid, false);
     assert.equal(rtkEngine.validateConfig({ rawOutputRetention: "always" }).valid, true);
 
-    const body = { messages: [{ role: "tool", content: "same\nsame\nsame\nsame" }] };
+    const repeated = Array.from({ length: 20 }, () => "same").join("\n");
+    const body = { messages: [{ role: "tool", content: repeated }] };
     assert.equal(
       rtkEngine.apply(body, { config: { rtkConfig: { enabled: true } } }).stats?.engine,
       "rtk"

--- a/tests/unit/probe-10765-rtk-noop-stats.test.ts
+++ b/tests/unit/probe-10765-rtk-noop-stats.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyRtkCompression } from "../../open-sse/services/compression/engines/rtk/index.ts";
+
+// Issue #10765: enabling RTK causes ~100% CPU even when the engine finds nothing to
+// compress ("It also occurs when the engine does not modify the request and reports
+// no token savings."). Root cause: applyRtkCompression() unconditionally calls
+// createCompressionStats() at the end of the function — which does a full
+// JSON.stringify() (+ tiktoken tokenize for Codex bodies) of the ENTIRE request body,
+// TWICE (original + compressed) — even when zero messages were touched.
+//
+// Every sibling stacked engine (headroom, session-dedup, ccr, relevance, ionizer,
+// readLifecycle) returns `stats: null` early when nothing changed, skipping this
+// expensive computation entirely. RTK is the outlier: it always pays the cost.
+test("RTK no-op run should skip the expensive stats computation (like sibling engines)", () => {
+  const body = {
+    model: "codex/gpt-5",
+    provider: "codex",
+    messages: [
+      { role: "user", content: "hello, this is a simple message with nothing to compress" },
+    ],
+  };
+
+  const result = applyRtkCompression(body, { config: { enabled: true } });
+
+  assert.equal(result.compressed, false, "RTK made no changes");
+  assert.equal(
+    result.stats,
+    null,
+    "RTK should return stats: null on a no-op run, like every sibling stacked engine"
+  );
+});


### PR DESCRIPTION
Closes #10765

## Root cause
`applyRtkCompression()` (`open-sse/services/compression/engines/rtk/index.ts`) unconditionally
called `createCompressionStats()` at the end of every run, even when zero messages matched any
RTK filter. Every sibling stacked engine (headroom, session-dedup, ccr, relevance, ionizer,
readLifecycle) already returns `{ body, compressed: false, stats: null }` early when nothing
changed — RTK was the outlier. `createCompressionStats()` runs two full `JSON.stringify()` +
tiktoken-tokenize passes over the entire request body, so every RTK invocation paid this CPU
cost regardless of whether anything was compressed, which explains the reported near-100% CPU /
tens-of-seconds-in-compression-stage symptoms, worsened under concurrent large Codex sessions
whose bodies sit near the ~50k-char exact-tokenizer cutoff.

## Fix
Added an early-return guard mirroring the sibling engines: after building `compressedMessages`,
detect whether any message actually changed via reference-identity comparison against the
original `messages` array (untouched messages keep their original object reference through the
existing `.map()`), and skip `createCompressionStats()` entirely when nothing changed.
`rtkRawOutputPointers` accounting was verified safe — pointers are only ever pushed on the
already-compressed branch (`compressedTokens < originalTokens`), so the guard cannot suppress a
non-empty pointer list.

Scope note: `finalizeStackedResult()` in `strategySelector.ts` has the same architectural gap for
`mode:"stacked"` aggregate stats (explains why toggling headroom/session-dedup/ccr alone also
reproduces the symptom) — intentionally left out of this PR per the plan-file's risk assessment;
recommend filing a follow-up issue for that larger, separate change.

## Regression test (TDD)
`tests/unit/probe-10765-rtk-noop-stats.test.ts` — RED before the fix (`stats` was a non-null
object on a guaranteed no-op body), GREEN after
(`node --import tsx/esm --test tests/unit/probe-10765-rtk-noop-stats.test.ts`).

`tests/unit/compression/rtk-engine.test.ts` — one existing assertion
(`exposes RTK engine schema, validation, apply and compress contracts`) relied on the old
always-non-null stats shape on a body that never actually got compressed by the full pipeline
(4 repeated lines is below the dedup threshold used through `applyRtkCompression`, even though
`processRtkText` alone would trigger on 20+). Updated the fixture to a body that genuinely gets
compressed (20 repeated lines, matching the sibling "applies to chat tool messages" test), so the
assertion now exercises the corrected contract rather than the bug. Line-neutral otherwise.

## Verification
- `node --import tsx/esm --test tests/unit/probe-10765-rtk-noop-stats.test.ts` → GREEN
- `node --import tsx/esm --test tests/unit/compression/rtk-*.test.ts tests/unit/rtk-*.test.ts tests/unit/api/compression/rtk-*.test.ts` → 181 tests, only 3 pre-existing/environmental failures unrelated to this diff (see below)
- `npm run typecheck:core` → clean (exit 0)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → clean
- `node scripts/check/check-complexity.mjs` → OK (2573 vs baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1157 vs baseline 1223)
- `node scripts/check/check-file-size.mjs` → no violation on touched files
- `node scripts/check/check-changelog-integrity.mjs` → OK

## Known pre-existing / unrelated failures observed during verification
- `tests/unit/rtk-enable-renderers-6703.test.ts` (2 tests, "unrecognized_keys: rawOutputMaxFiles,
  rawOutputMaxAgeDays") — confirmed via `git diff origin/release/v3.8.50` that neither this test
  file nor the RTK config schema it exercises is touched by this branch; fails identically before
  this change.
- `tests/unit/compression/rtk-discover-redos.test.ts` — a wall-clock ReDoS-timing assertion
  (`< 1000ms`) that flaked once at 1280ms under the load of running all 34 RTK suites
  concurrently; passes in isolation (129ms). Not touched by this diff.

⚠️ base-red inherited: #9985 (`release/v3.8.50` currently reports 🔴 not-green; unrelated to this
change).