### PR TITLE
fix: log upstream error body in COMBO per-target failure warnings (#10597)

### DIFF
--- a/changelog.d/fixes/10597-combo-log-error-body.md
+++ b/changelog.d/fixes/10597-combo-log-error-body.md
@@ -1,0 +1,1 @@
+- **fix(sse):** Include the redacted upstream error body in the per-target COMBO failure log (`Model X failed, trying next`) so operators can triage a 400/500 without reproducing the request ([#10597](https://github.com/diegosouzapw/OmniRoute/issues/10597))

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2275,7 +2275,10 @@ async function handleComboChatInner({
               );
             }
           }
-          log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status: result.status });
+          log.warn("COMBO", `Model ${modelStr} failed, trying next`, {
+            status: result.status,
+            errorBody: redactConnectionLabel(errorText),
+          });
 
           // #5976: per-model-quota providers (Gemini, GitHub, etc.) multiplex models
           // behind one connection. A model-level 500 or 429 (RPM) must NOT cool down
@@ -3460,7 +3463,10 @@ async function handleRoundRobinCombo({
           kind: classifyComboOutcome(result.status, errorText),
         });
         if (offset > 0) fallbackCount++;
-        log.warn("COMBO-RR", `${modelStr} failed, trying next model`, { status: result.status });
+        log.warn("COMBO-RR", `${modelStr} failed, trying next model`, {
+          status: result.status,
+          errorBody: redactConnectionLabel(errorText),
+        });
 
         if (
           resilienceSettings.providerCooldown.enabled &&

--- a/tests/unit/combo-10597-error-body-logging.test.ts
+++ b/tests/unit/combo-10597-error-body-logging.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #10597 — When a combo target fails with a non-2xx status, the per-target
+ * "Model X failed, trying next" COMBO log line only carries `{ status }` —
+ * the upstream error BODY (e.g. Anthropic's "prompt is too long" or a
+ * tool_use/tool_result pairing 400) is captured in `errorText` but never
+ * logged, so operators cannot distinguish failure causes from server logs
+ * without reproducing the request.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-10597-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "combo-10597-test-secret";
+
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+
+const DISTINCTIVE_ERROR_TEXT =
+  "messages.450: `tool_use` ids were found without `tool_result` blocks immediately after";
+
+type WarnCall = { tag: string; msg: string; meta: unknown };
+const warnCalls: WarnCall[] = [];
+const log = {
+  info: () => {},
+  debug: () => {},
+  error: () => {},
+  warn: (tag: string, msg: string, meta?: unknown) => {
+    warnCalls.push({ tag, msg, meta });
+  },
+};
+
+function failing400() {
+  return new Response(
+    JSON.stringify({
+      type: "error",
+      error: { type: "invalid_request_error", message: DISTINCTIVE_ERROR_TEXT },
+    }),
+    { status: 400, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function healthy200(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: "ok",
+      object: "chat.completion",
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content: "hello from " + model }, finish_reason: "stop" }],
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function makeCombo(models: string[]) {
+  return { name: "test-combo-10597", strategy: "priority", models: models.map((m) => ({ model: m })) };
+}
+
+test("#10597 COMBO failure log must surface the upstream error body, not just the status code", async () => {
+  const modelsCalled: string[] = [];
+  const handleSingleModel = async (_body: unknown, modelStr: string) => {
+    modelsCalled.push(modelStr);
+    if (modelsCalled.length === 1) return failing400();
+    return healthy200(modelStr);
+  };
+
+  const result = await handleComboChat({
+    body: { model: "test", messages: [{ role: "user", content: "hi" }] },
+    combo: makeCombo(["claude/claude-opus-4-8", "openai/gpt-4o-mini"]),
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [],
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(modelsCalled.length, 2);
+
+  const failureLog = warnCalls.find(
+    (c) => typeof c.msg === "string" && c.msg.includes("claude/claude-opus-4-8") && c.msg.includes("failed")
+  );
+  assert.ok(failureLog, "expected a COMBO warn log for the failing leg");
+
+  const serialized = JSON.stringify(failureLog);
+  assert.ok(
+    serialized.includes("tool_use") || serialized.includes(DISTINCTIVE_ERROR_TEXT),
+    `expected the upstream error body to appear in the COMBO failure log, but got: ${serialized}`
+  );
+});


### PR DESCRIPTION
Closes #10597

## Root cause
The per-target combo failure log line (`log.warn("COMBO", "Model X failed, trying next", { status })`) discarded the upstream error body even though it was already captured in `errorText` a few lines earlier (`open-sse/services/combo.ts`). This is the reporter's Problem #1 ("upstream 400 body is not logged") — operators could not distinguish a context-overflow 400 from a tool_use/tool_result pairing 400 from an auth 400 without reproducing the failing request.

## Fix
Added a redacted `errorBody` field (via the already-imported `redactConnectionLabel`, reusing the existing 500-char truncation on `errorText`) to:
- the main per-target COMBO failure log (`open-sse/services/combo.ts`, `handleComboChatInner`)
- the COMBO-RR mirror log (`handleRoundRobinCombo`)

Purely additive to log metadata — no control-flow change.

Scope note: the last-resort compat-fallback debug log (`open-sse/services/combo/comboCompatFallback.ts`) does not currently capture an error body at all (it only has `result.status`), so enriching it would require reading the response body there for the first time — out of scope for this surgical fix; left as a follow-up if operators need it too.

## Regression test (TDD)
`tests/unit/combo-10597-error-body-logging.test.ts` — fails on unfixed code (log meta was `{"status":400}` only) and passes after the fix (the upstream error text now appears in the COMBO warn log).

```
node --import tsx/esm --test tests/unit/combo-10597-error-body-logging.test.ts
```
RED before → GREEN after.

## Gates run
- `node --import tsx/esm --test tests/unit/combo-10597-error-body-logging.test.ts` — GREEN
- `node --import tsx/esm --test tests/unit/combo-failure-log-message.test.ts` — GREEN (pre-existing sibling test on the same log line, unaffected)
- `node --import tsx/esm --test tests/unit/combo-quota-share-cooldown-wait.test.ts` (isolated) — 7/7 GREEN (two of these flaked under full-suite CPU contention on this shared devbox during the batch `combo-*.test.ts` run — confirmed unrelated to this diff by re-running in isolation)
- `node scripts/check/check-complexity.mjs` — OK (2573 violations, baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1157 violations, baseline 1223)
- `node scripts/check/check-file-size.mjs` — no new violations
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/combo.ts tests/unit/combo-10597-error-body-logging.test.ts` — clean
- `npm run typecheck:core` — exit 0, clean

## Notes for the reporter
The revised hypothesis (compression pipeline breaking tool_use/tool_result pairing → Anthropic 400) remains unconfirmed and out of scope here — `MALFORMED_REQUEST_PATTERNS` in `open-sse/services/accountFallback.ts` has no entry for "tool_use ids were found without tool_result" yet. Once this ships, please share the newly-logged `errorBody` from the next production failure so we can confirm/refute that theory before scoping further work.