### PR TITLE
fix(cli): repair hollow externalized package dirs in nested distDir node_modules (#7346)

### DIFF
--- a/changelog.d/fixes/7346-electron-hollow-nested-package-repair.md
+++ b/changelog.d/fixes/7346-electron-hollow-nested-package-repair.md
@@ -1,0 +1,1 @@
+- fix(cli): repair hollow externalized package dirs in the nested `<distDir>/node_modules` bundle location too, not just the top-level one, fixing macOS/Linux Electron `ERR_MODULE_NOT_FOUND` on Turbopack-externalized packages (#7346)

--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -628,12 +628,11 @@ function copyNativeAssetsAndExtraModules(projectRoot, resolvedOutDir) {
  * This keeps the fix narrowly scoped to packages the standalone already expects.
  *
  * @param {string} projectRoot
- * @param {string} resolvedOutDir
+ * @param {string} bundleNodeModules
  * @returns {{repaired: number, packages: string[]}}
  */
-function repairEmptyExternalPackageDirs(projectRoot, resolvedOutDir) {
+function repairEmptyExternalPackageDirs(projectRoot, bundleNodeModules) {
   const summary = { repaired: 0, packages: [] };
-  const bundleNodeModules = path.join(resolvedOutDir, "node_modules");
   const sourceNodeModules = path.join(projectRoot, "node_modules");
   if (!fsSync.existsSync(bundleNodeModules) || !fsSync.existsSync(sourceNodeModules)) {
     return summary;
@@ -899,12 +898,23 @@ export function assembleStandalone({
   // 6. Optionally copy native assets + extra modules (synchronous)
   if (copyNatives) {
     copyNativeAssetsAndExtraModules(projectRoot, resolvedOutDir);
-    const emptyPkgRepair = repairEmptyExternalPackageDirs(projectRoot, resolvedOutDir);
-    if (emptyPkgRepair.repaired > 0) {
-      console.log(
-        `[assembleStandalone] Repaired ${emptyPkgRepair.repaired} hollow external package dir(s): ` +
-          emptyPkgRepair.packages.join(", ")
-      );
+    // Repair hollow externalized package dirs in BOTH locations Turbopack's standalone
+    // tracer can populate: the top-level bundle node_modules, and — for projects with a
+    // custom distDir (see next.config.mjs) — the nested <relDistDir>/node_modules mirrored
+    // alongside the traced server chunks. materializeBundledSymlinks (step 7 below) already
+    // treats these as two distinct targets; #9913 only covered the top-level one, which left
+    // the nested location's hollow dirs unrepaired (#7346).
+    for (const bundleNodeModules of [
+      path.join(resolvedOutDir, "node_modules"),
+      path.join(resolvedOutDir, relDistDir, "node_modules"),
+    ]) {
+      const emptyPkgRepair = repairEmptyExternalPackageDirs(projectRoot, bundleNodeModules);
+      if (emptyPkgRepair.repaired > 0) {
+        console.log(
+          `[assembleStandalone] Repaired ${emptyPkgRepair.repaired} hollow external package dir(s) in ` +
+            `${path.relative(resolvedOutDir, bundleNodeModules) || "."}: ${emptyPkgRepair.packages.join(", ")}`
+        );
+      }
     }
 
     // #9166: dynamically imported LLMLingua packages are not reliably traced

--- a/tests/unit/build/repair-empty-external-package-dirs-nested.test.ts
+++ b/tests/unit/build/repair-empty-external-package-dirs-nested.test.ts
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { assembleStandalone } from "../../../scripts/build/assembleStandalone.mjs";
+
+// #7346: on macOS (and Linux AppImage) Electron builds, Turbopack's standalone tracer can leave
+// a hollow (directory exists, contains zero files) externalized-package directory behind. #9913
+// added `repairEmptyExternalPackageDirs` to overlay the real source package on top of a hollow
+// bundle dir — but it only scans the TOP-LEVEL `<outDir>/node_modules`. This project builds with
+// a custom, non-default `distDir` (".build/next", see next.config.mjs), and Next's standalone
+// tracer also emits a SECOND, nested `node_modules` under `<outDir>/<relDistDir>/node_modules`
+// (the same location `materializeBundledSymlinks` already treats as a distinct target — see
+// assembleStandalone() step 7). A hollow externalized package dir landing in that nested
+// location is never repaired, which reproduces the exact ERR_MODULE_NOT_FOUND class reported on
+// #7346 even after #6794/#7353/#9913 all landed.
+test("assembleStandalone repairs a hollow externalized package dir in the nested <distDir> node_modules, not just the top-level one", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "repair-nested-empty-pkg-"));
+  const projectRoot = path.join(tmp, "project");
+  const relDistDir = ".build/next";
+  const distDir = path.join(projectRoot, relDistDir);
+  const outDir = path.join(tmp, "dist");
+
+  // Real source package the repair should copy from.
+  const sourcePkgDir = path.join(projectRoot, "node_modules", "some-nested-pkg");
+  fs.mkdirSync(sourcePkgDir, { recursive: true });
+  fs.writeFileSync(path.join(sourcePkgDir, "package.json"), '{"name":"some-nested-pkg"}');
+  fs.writeFileSync(path.join(sourcePkgDir, "index.js"), "module.exports = {};");
+
+  // Fake standalone tree with a hollow externalized package dir under the NESTED
+  // <relDistDir>/node_modules (directory exists but contains zero files — the exact
+  // "hollow" shape repairEmptyExternalPackageDirs already repairs at the top level).
+  const standaloneDir = path.join(distDir, "standalone");
+  fs.mkdirSync(standaloneDir, { recursive: true });
+  fs.writeFileSync(path.join(standaloneDir, "server.js"), "// server");
+  const hollowNestedPkgDir = path.join(standaloneDir, relDistDir, "node_modules", "some-nested-pkg");
+  fs.mkdirSync(hollowNestedPkgDir, { recursive: true });
+
+  assembleStandalone({
+    distDir,
+    outDir,
+    projectRoot,
+    copyNatives: true,
+  });
+
+  const repairedIndexPath = path.join(outDir, relDistDir, "node_modules", "some-nested-pkg", "index.js");
+  assert.ok(
+    fs.existsSync(repairedIndexPath),
+    "hollow nested externalized package dir must be repaired with the real source package (index.js present)"
+  );
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
Refs #7346

⚠️ base-red inherited: #9985 (release/v3.8.50 tip is currently red per the continuous release-green check; unrelated to this change).

## Root cause

macOS (and Linux AppImage) Electron builds have been crashing at startup with `ERR_MODULE_NOT_FOUND` for Turbopack-externalized packages. Three fixes already landed for this issue class: #6794 (materialize hashed-module symlinks), #7353 (patch hashed `require()` calls), and #9913 (repair hollow/empty externalized package dirs, incl. a `ws` full-source overlay). Despite all three being on tip, a field report on 3.8.49 confirmed the error still occurred, and #7346 stayed open pending real validation.

This project builds Next.js with a **custom, non-default `distDir`** (`.build/next`, see `next.config.mjs`). Next's standalone tracer, in that configuration, emits **two separate `node_modules` locations** inside the assembled bundle:

1. `<outDir>/node_modules` (top-level)
2. `<outDir>/<relDistDir>/node_modules` (nested, alongside the traced server chunks)

`materializeBundledSymlinks` (the symlink-dereferencing pass) already iterates over **both** locations (`scripts/build/assembleStandalone.mjs`, step 7). But `repairEmptyExternalPackageDirs` — the function #9913 added to overlay a real source package on top of a hollow (zero-file) externalized package directory — only ever scanned the **top-level** `node_modules`. A hollow externalized package dir landing in the nested location was never repaired, reproducing the exact `ERR_MODULE_NOT_FOUND` class reported in #7346 even with #6794/#7353/#9913 all merged.

## Fix

`repairEmptyExternalPackageDirs` now takes the target `node_modules` directory directly (instead of deriving only the top-level one from `resolvedOutDir`), and `assembleStandalone()` invokes it for **both** the top-level and the nested `<relDistDir>/node_modules` locations — mirroring the existing dual-location pattern already used by `materializeBundledSymlinks`.

## Regression test (TDD, Hard Rule #18)

New test: `tests/unit/build/repair-empty-external-package-dirs-nested.test.ts`

- Builds a synthetic standalone tree (custom `distDir`, matching this project's real config) containing a hollow (zero-file) externalized package directory under the **nested** `<relDistDir>/node_modules`.
- **RED on the pre-fix code** (verified by temporarily reverting the production change and re-running the test — confirmed failure): the nested hollow dir is left untouched.
- **GREEN after the fix**: the nested hollow dir gets the real source package copied in.

Ran together with the existing suite for this module — all pass:
```
node --import tsx/esm --test \
  tests/unit/build/repair-empty-external-package-dirs-nested.test.ts \
  tests/unit/build/assemble-standalone.test.ts \
  tests/unit/materialize-bundled-symlinks.test.ts \
  tests/unit/electron-packaging.test.ts \
  tests/unit/build/standalone-bundle.test.ts
# tests 27, pass 27, fail 0
```

## Validation scope / what's NOT covered

This closes the specific coverage gap identified by the prior triage pass (`_tasks/pipeline/bugs/2-implementing/7346-macos-electron-err-module-not-found.plan.md`, verdict `needs-vps`): `repairEmptyExternalPackageDirs` had zero direct unit coverage, and only handled one of the two node_modules locations Turbopack's tracer can populate for this project's custom `distDir`. It is **not** an end-to-end confirmation on a real packaged macOS/Linux Electron build (that requires `electron:build:mac`/`electron:build:linux` + `electron:smoke:packaged` on real hardware, which was not available in this sandbox) — hence `Refs #7346` rather than `Closes #7346`. The earlier "should already be fixed" claim on this issue (2026-07-26) was disproven by a live field report, so we're deliberately not claiming full closure from unit-test evidence alone this time either.

## Gates run

- `node --import tsx/esm --test <touched + sibling tests>` — 27/27 pass
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2573 vs baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1157 vs baseline 1223)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — 0 errors