### PR TITLE
fix(executor): respect apiType="chat" in forceResponsesUpstream (#5483 regression)

### DIFF
--- a/open-sse/executors/forceResponsesUpstream.ts
+++ b/open-sse/executors/forceResponsesUpstream.ts
@@ -28,6 +28,17 @@ export function shouldForceResponsesUpstream(
   const providerSpecificData = credentials?.providerSpecificData ?? null;
   if (providerSpecificData?._omnirouteForceResponsesUpstream === true) return true;
   if (getOpenAICompatibleType(provider, providerSpecificData) === "responses") return false;
+  // apiType="chat" means the operator explicitly chose the chat/completions
+  // wire. Don't second-guess that choice by forcing /responses just because the
+  // body carries namespace tools — the standard namespace→flatten path
+  // (openai-responses.ts) handles those correctly for chat backends.
+  if (
+    providerSpecificData &&
+    typeof providerSpecificData.apiType === "string" &&
+    providerSpecificData.apiType === "chat"
+  ) {
+    return false;
+  }
 
   const hasResponsesShape =
     body.input !== undefined ||

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -9,6 +9,7 @@ import {
   mergeUpstreamExtraHeaders,
   setUserAgentHeader,
 } from "../../open-sse/executors/base.ts";
+import { shouldForceResponsesUpstream } from "../../open-sse/executors/forceResponsesUpstream.ts";
 import { DefaultExecutor } from "../../open-sse/executors/default.ts";
 import { PROVIDERS } from "../../open-sse/config/constants.ts";
 import {
@@ -1577,4 +1578,54 @@ test("DefaultExecutor.execute does not produce duplicate anthropic-version heade
     sentBody.system?.[0]?.text ?? "",
     /^x-anthropic-billing-header: cc_version=2\.1\.220\.1f2; cc_entrypoint=cli; cch=[0-9a-f]{5};$/
   );
+});
+
+test('shouldForceResponsesUpstream respects explicit apiType="chat" even when namespace tools are present', () => {
+  const body = {
+    input: "hi",
+    tools: [
+      {
+        type: "namespace",
+        name: "collaboration",
+        tools: [
+          {
+            name: "spawn_agent",
+            description: "Spawn an agent",
+            parameters: { type: "object", properties: { task: { type: "string" } } },
+          },
+        ],
+      },
+    ],
+  };
+  const credentials = {
+    providerSpecificData: {
+      baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      apiType: "chat",
+    },
+  };
+  assert.equal(
+    shouldForceResponsesUpstream("openai-compatible-responses-demo", body, credentials),
+    false
+  );
+});
+
+test("shouldForceResponsesUpstream still forces /responses for untyped OpenAI-compatible providers with namespace tools", () => {
+  const body = {
+    input: "hi",
+    tools: [
+      {
+        type: "namespace",
+        name: "collaboration",
+        tools: [
+          { name: "spawn_agent", description: "Spawn an agent", parameters: { type: "object" } },
+        ],
+      },
+    ],
+  };
+  const credentials = {
+    providerSpecificData: {
+      baseUrl: "https://proxy.example/v1",
+    },
+  };
+  assert.equal(shouldForceResponsesUpstream("openai-compatible-test", body, credentials), true);
 });


### PR DESCRIPTION
## Summary

Regression fix for #5483. The executor-level `forceResponsesUpstream` guard routes Responses-API-shaped requests that carry MCP `namespace` or `tool_search*` tools to the upstream `/responses` endpoint. That is correct for Responses-capable OpenAI-compatible backends, but currently even providers explicitly configured with `apiType="chat"` are forced onto `/responses`, skipping the standard namespace flatten path.

For chat-only backends (e.g. Volcengine Ark codingplan) the `/responses` endpoint does not support the `namespace` tool type. The request is sent to the wrong wire, the collaboration namespace collapses to an empty-schema function, and Codex clients fail with `unsupported call: collaboration` (or `functions.collaboration.spawn_agent`).

## Fix

Honor the operator's explicit wire choice: if `providerSpecificData.apiType === "chat"`, return `false` from `shouldForceResponsesUpstream` before the Responses-shape/tool sniffing runs. The existing namespace→flatten path in `openai-responses.ts` then handles chat backends correctly.

This only changes providers where the user explicitly configured `apiType="chat"`. Untyped OpenAI-compatible providers still keep the #5483 behavior and are forced to `/responses` when appropriate.

## Tests

Added two regression cases to `tests/unit/executor-default-base.test.ts`:

- explicit `apiType="chat"` + namespace tools → not forced to /responses
- untyped OpenAI-compatible provider + namespace tools → still forced to /responses (preserves #5483)

## Validation

```bash
npm run typecheck:core
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/executor-default-base.test.ts
```

Both pass locally (51 tests, 0 failures).