### PR TITLE
fix(catalog): preserve provider effort tiers

### DIFF
--- a/changelog.d/fixes/10953-preserve-provider-effort-tiers.md
+++ b/changelog.d/fixes/10953-preserve-provider-effort-tiers.md
@@ -1,0 +1,1 @@
+- **fix(catalog):** preserve provider-declared reasoning effort tiers instead of replacing them with generic defaults ([#10953](https://github.com/diegosouzapw/OmniRoute/pull/10953)) — thanks @xz-dev

--- a/src/lib/modelMetadataRegistry.ts
+++ b/src/lib/modelMetadataRegistry.ts
@@ -457,6 +457,31 @@ export function enrichCatalogModelEntry<T extends JsonRecord>(
     { provider, model },
     capabilitySnapshot
   );
+  const existingCapabilities =
+    entry.capabilities && typeof entry.capabilities === "object"
+      ? (entry.capabilities as JsonRecord)
+      : {};
+  const declaredEffortTiers = Array.isArray(existingCapabilities.effort_tiers)
+    ? existingCapabilities.effort_tiers.filter(
+        (effort): effort is string => typeof effort === "string" && effort.length > 0
+      )
+    : [];
+  const sourceDeclaresThinking =
+    typeof existingCapabilities.thinking === "boolean" ||
+    typeof existingCapabilities.supportsThinking === "boolean";
+  const effortTiers =
+    metadata.capabilities.supportedThinkingEfforts &&
+    metadata.capabilities.supportedThinkingEfforts.length > 0
+      ? [...metadata.capabilities.supportedThinkingEfforts]
+      : declaredEffortTiers.length > 0
+        ? declaredEffortTiers
+        : sourceDeclaresThinking
+          ? undefined
+          : extendCodexGpt56EffortValues(
+              metadata.provider,
+              metadata.model,
+              CANONICAL_EFFORT_VALUES
+            );
   const capabilityFields = {
     ...(typeof metadata.capabilities.vision === "boolean"
       ? { vision: metadata.capabilities.vision }
@@ -482,18 +507,8 @@ export function enrichCatalogModelEntry<T extends JsonRecord>(
       ? {
           thinking: metadata.capabilities.supportsThinking,
           supportsThinking: metadata.capabilities.supportsThinking,
-          ...(metadata.capabilities.supportsThinking
-            ? {
-                effort_tiers:
-                  metadata.capabilities.supportedThinkingEfforts &&
-                  metadata.capabilities.supportedThinkingEfforts.length > 0
-                    ? [...metadata.capabilities.supportedThinkingEfforts]
-                    : extendCodexGpt56EffortValues(
-                        metadata.provider,
-                        metadata.model,
-                        CANONICAL_EFFORT_VALUES
-                      ),
-              }
+          ...(metadata.capabilities.supportsThinking && effortTiers
+            ? { effort_tiers: effortTiers }
             : {}),
         }
       : {}),
@@ -509,9 +524,7 @@ export function enrichCatalogModelEntry<T extends JsonRecord>(
   };
 
   nextEntry.capabilities = {
-    ...(entry.capabilities && typeof entry.capabilities === "object"
-      ? (entry.capabilities as JsonRecord)
-      : {}),
+    ...existingCapabilities,
     ...capabilityFields,
   };
 

--- a/tests/unit/effort-thinking-standardization-6241.test.ts
+++ b/tests/unit/effort-thinking-standardization-6241.test.ts
@@ -179,6 +179,36 @@ test("enrichCatalogModelEntry exposes supportsThinking + effort_tiers for a thin
   assert.equal(caps.reasoning, true);
 });
 
+test("enrichCatalogModelEntry preserves Kimi's provider-declared effort contract", () => {
+  for (const model of ["k3", "k3-256k"]) {
+    const entry = registry.enrichCatalogModelEntry({
+      id: `kmc/${model}`,
+      object: "model",
+      owned_by: "kimi-coding",
+      root: model,
+      capabilities: {
+        thinking: true,
+        supportsThinking: true,
+        effort_tiers: ["low", "high", "max"],
+      },
+    }) as Record<string, unknown>;
+    assert.deepEqual(
+      (entry.capabilities as Record<string, unknown>).effort_tiers,
+      ["low", "high", "max"],
+      model
+    );
+  }
+
+  const k27 = registry.enrichCatalogModelEntry({
+    id: "kmc/kimi-for-coding",
+    object: "model",
+    owned_by: "kimi-coding",
+    root: "kimi-for-coding",
+    capabilities: { thinking: true, supportsThinking: true },
+  }) as Record<string, unknown>;
+  assert.equal("effort_tiers" in (k27.capabilities as Record<string, unknown>), false);
+});
+
 test("enrichCatalogModelEntry exposes Max for Kiro GPT-5.6 Luna", () => {
   const enriched = registry.enrichCatalogModelEntry({
     id: "kr/gpt-5.6-luna",


### PR DESCRIPTION
## Summary

- Preserve provider/source-declared `capabilities.effort_tiers` during final model-catalog enrichment instead of replacing them with OmniRoute's generic canonical tier list.
- Keep explicit canonical/operator `supportedThinkingEfforts` authoritative.
- Avoid inventing tiers when a source explicitly declares thinking support without a tier contract.
- Keep the legacy canonical fallback for entries that do not declare thinking metadata, including existing Codex GPT-5.6 behavior.

This keeps Kimi Coding `k3` and `k3-256k` on their provider contract: `low`, `high`, `max`.

## Related Issues

- Related to #10788
- Related to #6241

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: other — model catalog metadata
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Focused validation:

```bash
node --import tsx/esm --test --test-concurrency=1 \
  tests/unit/effort-thinking-standardization-6241.test.ts \
  tests/unit/model-capabilities-specialty-8016.test.ts \
  tests/unit/catalog-pricing-surface-8018.test.ts \
  tests/unit/models-catalog-route.test.ts
npm run typecheck:core
npm run lint
git diff --check origin/release/v3.8.50...HEAD
```

## Tests Added Or Updated

- `tests/unit/effort-thinking-standardization-6241.test.ts`
  - preserves Kimi Coding `k3` / `k3-256k` as exactly `low`, `high`, `max`
  - verifies an explicitly thinking-capable source with no tiers does not receive fabricated tiers
  - retains the existing canonical fallback assertion for legacy entries

## Coverage Notes

- The updated unit test directly exercises the changed `enrichCatalogModelEntry()` precedence and merge behavior.
- CI remains responsible for the full unit shards, Vitest, coverage gate, and production build.

## Reviewer Notes

- No migration, feature flag, dependency, or request-routing change.
- GLM-CN is intentionally out of scope: its live OpenAI and Anthropic model-list endpoints currently return model IDs without effort metadata, so its provider-specific tier contract and routing require a separate follow-up.
- Independent final review found no blockers.
