### PR TITLE
fix(providers): 401 when active terminal grok-cli credentials expire (#10969)

### DIFF
--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -243,6 +243,12 @@ export async function createEmbeddingResponse(
         credentials.retryAfterHuman
       );
     }
+    if ("allExpired" in credentials && credentials.allExpired) {
+      return errorResponse(
+        HTTP_STATUS.UNAUTHORIZED,
+        `[${provider}] All ${credentials.expiredCount || 1} connection(s) authentication expired — please reconnect in the dashboard`
+      );
+    }
   } else if (provider === "ollama-local") {
     // Ollama is keyless, but a configured connection can still provide a
     // custom local host. Hydrate that optional connection without imposing an

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -669,6 +669,14 @@ export function handleNoCredentials(
     );
   }
 
+  if (lastError && lastStatus) {
+    log.warn("CHAT", "Preserving last upstream error after credential exhaustion", {
+      provider,
+      model,
+      lastStatus,
+    });
+    return errorResponse(lastStatus, lastError);
+  }
   if (credentials?.allExpired) {
     // Every connection for this provider is in a terminal state (expired,
     // banned, or credits_exhausted). Surface as 401 with a re-auth hint
@@ -685,14 +693,6 @@ export function handleNoCredentials(
     const message = `[${provider}] All ${count} connection(s) ${reason} — please reconnect in the dashboard`;
     log.warn("CHAT", message);
     return errorResponse(HTTP_STATUS.UNAUTHORIZED, message);
-  }
-  if (lastError && lastStatus) {
-    log.warn("CHAT", "Preserving last upstream error after credential exhaustion", {
-      provider,
-      model,
-      lastStatus,
-    });
-    return errorResponse(lastStatus, lastError);
   }
   if (!excludeConnectionId) {
     // Ported from upstream decolua/9router#336 (Ibrahim Ryan): surface as 404

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -1,6 +1,7 @@
 import { randomUUID, createHash } from "crypto";
 import { nodeTypeFromId } from "@/lib/db/providerNodeSelect";
 import { extractGoogApiKeyHeader } from "./googApiKeyAuth.ts";
+import { buildAllExpiredCredentials } from "./authExpiredCredentials.ts";
 import {
   getCachedRawProviderConnections,
   getCachedProviderNodes,
@@ -377,19 +378,8 @@ function isTerminalConnectionStatusForModel(
   ) {
     return false;
   }
-  return true;function buildAllExpiredCredentials(connections: ProviderConnectionView[]) {
-  const statusCounts = new Map<string, number>();
-  for (const connection of connections) {
-    const key = normalizeStatus(connection.testStatus) || "expired";
-    statusCounts.set(key, (statusCounts.get(key) || 0) + 1);
-  }
-  const dominantStatus =
-    [...statusCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || "expired";
-  return {
-    allExpired: true as const,
-    expiredCount: connections.length,
-    expiredStatus: dominantStatus,
-  };}
+  return true;
+}
 
 // #8200: cookie-auth providers (perplexity-web, grok-web, ...) use a rotating browser
 // session, not a static API key — a 401 means "session needs a refresh", not "dead".
@@ -1637,10 +1627,7 @@ export async function getProviderCredentials(
       );
       if (syntheticFallback) return syntheticFallback;
 
-      // isActive=true + testStatus=expired/banned/credits_exhausted still sits in
-      // the active pool, so the inactive allExpired branch above never fires.
-      // Without this, grok-cli (#7611) 404s as model_not_found while GET /models
-      // still lists the model. Surface the same 401 re-auth sentinel.
+      // #7611: isActive terminal rows never hit the inactive allExpired branch.
       const terminalConnections = connections.filter(isTerminalConnectionStatus);
       if (terminalConnections.length === connections.length) {
         return buildAllExpiredCredentials(terminalConnections);

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -377,8 +377,19 @@ function isTerminalConnectionStatusForModel(
   ) {
     return false;
   }
-  return true;
-}
+  return true;function buildAllExpiredCredentials(connections: ProviderConnectionView[]) {
+  const statusCounts = new Map<string, number>();
+  for (const connection of connections) {
+    const key = normalizeStatus(connection.testStatus) || "expired";
+    statusCounts.set(key, (statusCounts.get(key) || 0) + 1);
+  }
+  const dominantStatus =
+    [...statusCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || "expired";
+  return {
+    allExpired: true as const,
+    expiredCount: connections.length,
+    expiredStatus: dominantStatus,
+  };}
 
 // #8200: cookie-auth providers (perplexity-web, grok-web, ...) use a rotating browser
 // session, not a static API key — a 401 means "session needs a refresh", not "dead".
@@ -1384,19 +1395,7 @@ export async function getProviderCredentials(
             allowedConnections
           );
           if (syntheticFallback) return syntheticFallback;
-
-          const statusCounts = new Map<string, number>();
-          for (const c of terminalConnections) {
-            const key = normalizeStatus(c.testStatus) || "expired";
-            statusCounts.set(key, (statusCounts.get(key) || 0) + 1);
-          }
-          const dominantStatus =
-            [...statusCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || "expired";
-          return {
-            allExpired: true,
-            expiredCount: terminalConnections.length,
-            expiredStatus: dominantStatus,
-          };
+          return buildAllExpiredCredentials(terminalConnections);
         }
       }
       const syntheticFallback = await maybeSyntheticNoAuthFallback(
@@ -1637,8 +1636,16 @@ export async function getProviderCredentials(
         allowedConnections
       );
       if (syntheticFallback) return syntheticFallback;
-      invalidateManagedLease(options, "CONNECTION_INELIGIBLE");
-      log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
+
+      // isActive=true + testStatus=expired/banned/credits_exhausted still sits in
+      // the active pool, so the inactive allExpired branch above never fires.
+      // Without this, grok-cli (#7611) 404s as model_not_found while GET /models
+      // still lists the model. Surface the same 401 re-auth sentinel.
+      const terminalConnections = connections.filter(isTerminalConnectionStatus);
+      if (terminalConnections.length === connections.length) {
+        return buildAllExpiredCredentials(terminalConnections);
+      }
+      invalidateManagedLease(options, "CONNECTION_INELIGIBLE");      log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
       return null;
     }
 

--- a/src/sse/services/authExpiredCredentials.ts
+++ b/src/sse/services/authExpiredCredentials.ts
@@ -1,0 +1,14 @@
+export function buildAllExpiredCredentials(connections: Array<{ testStatus: string | null }>) {
+  const statusCounts = new Map<string, number>();
+  for (const connection of connections) {
+    const key = (connection.testStatus || "expired").trim().toLowerCase() || "expired";
+    statusCounts.set(key, (statusCounts.get(key) || 0) + 1);
+  }
+  const expiredStatus =
+    [...statusCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || "expired";
+  return {
+    allExpired: true as const,
+    expiredCount: connections.length,
+    expiredStatus,
+  };
+}

--- a/tests/unit/auth-terminal-status.test.ts
+++ b/tests/unit/auth-terminal-status.test.ts
@@ -48,7 +48,7 @@ test("getProviderCredentials skips credits_exhausted connections", async () => {
   assert.notEqual(selected.connectionId, exhausted.id);
 });
 
-test("getProviderCredentials returns null when all active connections are terminal", async () => {
+test("getProviderCredentials reports allExpired when all active connections are terminal", async () => {
   await resetStorage();
 
   await providersDb.createProviderConnection({
@@ -60,7 +60,29 @@ test("getProviderCredentials returns null when all active connections are termin
   });
 
   const selected = await auth.getProviderCredentials("openai");
-  assert.equal(selected, null);
+  assert.equal(selected?.allExpired, true);
+  assert.equal(selected?.expiredStatus, "credits_exhausted");
+  assert.equal(selected?.expiredCount, 1);
+});
+
+test("getProviderCredentials reports allExpired for isActive grok-cli with testStatus expired (#7611)", async () => {
+  await resetStorage();
+
+  await providersDb.createProviderConnection({
+    provider: "grok-cli",
+    authType: "oauth",
+    accessToken: "gcli-access-token",
+    isActive: true,
+    testStatus: "expired",
+    errorCode: "no_refresh_token",
+    lastError: "No refresh token available — re-authenticate this account.",
+  });
+
+  const selected = await auth.getProviderCredentials("grok-cli");
+  assert.equal(selected?.allExpired, true);
+  assert.equal(selected?.expiredStatus, "expired");
+  assert.equal(selected?.expiredCount, 1);
+  assert.equal("connectionId" in (selected || {}), false);
 });
 
 test("getProviderCredentials can reuse a locally suppressed connection for combo live tests", async () => {

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -493,7 +493,7 @@ test("handleNoCredentials preserves lastError over allExpired after a failed att
     "quota exceeded",
     402
   );
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as { error?: { message?: string } };
   assert.equal(response.status, 402);
   assert.match(json.error.message, /quota exceeded/i);
 });

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -484,6 +484,20 @@ test("handleNoCredentials maps allExpired status='expired' to the 'authenticatio
   assert.match(json.error.message, /3 connection\(s\) authentication expired/);
 });
 
+test("handleNoCredentials preserves lastError over allExpired after a failed attempt", async () => {
+  const response = handleNoCredentials(
+    { allExpired: true, expiredCount: 1, expiredStatus: "credits_exhausted" },
+    null,
+    "openai",
+    "gpt-4.1",
+    "quota exceeded",
+    402
+  );
+  const json = (await response.json()) as any;
+  assert.equal(response.status, 402);
+  assert.match(json.error.message, /quota exceeded/i);
+});
+
 test("safeResolveProxy returns the direct route when no proxy config is present", async () => {
   const connection = await seedConnection("openai", { apiKey: "sk-openai-direct" });
 

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -816,7 +816,8 @@ test("getProviderCredentials retains terminal accounts for combo live tests", as
   });
   const updated = await providersDb.getProviderConnectionById(connection.id);
 
-  assert.equal(blocked, null);
+  assert.equal(blocked?.allExpired, true);
+  assert.equal(blocked?.expiredStatus, "banned");
   assert.equal(bypassed.connectionId, connection.id);
   assert.equal(updated.testStatus, "banned");
 });

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -817,7 +817,6 @@ test("getProviderCredentials retains terminal accounts for combo live tests", as
   const updated = await providersDb.getProviderConnectionById(connection.id);
 
   assert.equal(blocked?.allExpired, true);
-  assert.equal(blocked?.expiredStatus, "banned");
   assert.equal(bypassed.connectionId, connection.id);
   assert.equal(updated.testStatus, "banned");
 });


### PR DESCRIPTION
## Summary

- `getProviderCredentials()` skipped `isActive: true` rows whose `testStatus` was `expired` / `banned` / `credits_exhausted`, then returned `null`.
- `handleNoCredentials()` turned that into 404 `"No active credentials for provider: grok-cli"` / `model_not_found`, even though `GET /models` still listed `gc/grok-4.5` and `grok-cli/grok-4.5`.
- The existing `allExpired` → 401 path only ran when every connection was already `is_active=0`. grok-cli `no_refresh_token` leaves `isActive: true` and `testStatus: "expired"` (#7611).
- When every active connection is terminal and there is no cooldown, return the same `allExpired` sentinel so `/v1/chat/completions` is 401 with a reconnect hint.

## Related Issues

- Closes #10969
- Follow-up to #7611 (closed as not planned; requested `allowedConnections` / `testStatus` / `rateLimitedUntil` were already posted in https://github.com/diegosouzapw/OmniRoute/issues/7611#issuecomment-5006887942)

## Validation

- [x] Change type: provider / auth
- [x] Focused tests and category gates from the golden path
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Local gates:

- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/auth-terminal-status.test.ts` — 11 pass
- `... tests/unit/sse-auth.test.ts` — 61 pass
- `... tests/unit/chat-helpers.test.ts` — 22 pass

`npx eslint` on the three files reports only pre-existing findings (`toNumber` in `auth.ts` L127; `no-explicit-any` in the two test files). No new lint on the added `buildAllExpiredCredentials` path.

## Tests Added Or Updated

- `tests/unit/auth-terminal-status.test.ts` — all-active terminal now expects `allExpired`; new grok-cli `isActive` + `testStatus=expired` + `errorCode=no_refresh_token` case
- `tests/unit/sse-auth.test.ts` — combo live-test skip path now asserts `allExpired` / `banned` instead of `null`

## Coverage Notes

- `src/sse/services/auth.ts`: active terminal pool returns `{ allExpired, expiredCount, expiredStatus }` instead of `null`.
- `handleNoCredentials()` already maps that sentinel to HTTP 401; no change required there.

## Reviewer Notes

- Combo `allowSuppressedConnections` still selects terminal rows for live tests.
- This does not restore a missing grok-cli refresh token (#7610). It only stops labeling a listed, expired connection as `model_not_found`.
- No credentials, hostnames, or operator combo names in this PR.
