### PR TITLE
fix(providers): remove dead existingConnections lookups on connection creation

### DIFF
--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -174,7 +174,6 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "OpenAI Compatible node not found" }, { status: 404 });
       }
 
-      const existingConnections = await getProviderConnections({ provider });
       // Allow multiple connections for compatible nodes exactly like first-party providers
 
       providerSpecificData = {
@@ -200,7 +199,6 @@ export async function POST(request: Request) {
         );
       }
 
-      const existingConnections = await getProviderConnections({ provider });
       // Allow multiple connections for compatible nodes exactly like first-party providers
 
       providerSpecificData = {


### PR DESCRIPTION
## Summary

`route.ts` declares `existingConnections` right before creating an OpenAI-Compatible or
Anthropic-Compatible connection, but never reads it. Traced the history: commit
`5b5e21a99` (`fix: resolve v3.7.0 stabilization issues`, closing #1566 — "OpenAI
Compatible node: support multiple connections") deliberately removed the
single-connection guard that used to read this variable, replacing it with the comment
still there today: "Allow multiple connections for compatible nodes exactly like
first-party providers". The variable declaration itself was left behind. Removed both
(one per branch), keeping the comment that explains the intentional behavior.

⚠️ base-red inherited: #9985

## Related Issues

Cleans up dead code left over from #1566 (already resolved by `5b5e21a99`). No new issue.

## Validation

- [x] Change type: other (dead-code removal, zero behavior change)
- [x] Focused tests: `providers-route-managed-catalog`, `providers-route-patch-method`,
      `provider-route-schemas`, `provider-connections-pagination-2998` — 14/14 pass, same
      as before the change
- [x] `npm run lint`
- [x] No behavior changed, so no new test — the existing suites are the regression guard

## Tests Added Or Updated

None. The removed variables were never read, so there's nothing new to cover.

## Coverage Notes

No impact — the removed lines were dead code, never on a covered path.

## Reviewer Notes

Just the two `getProviderConnections({ provider })` calls, one per branch. Nothing else
touched. See #10974 for the sibling cleanup — the guard condition these fed into
(`allowMultipleCompatibleConnections`) was removed by the same `5b5e21a99` commit and is
also dead, but that's a separate PR since it also touches the flag's Settings UI surface.
