### PR TITLE
fix(db): pause call-log rotate on SQLITE_CORRUPT

### DIFF
--- a/changelog.d/fixes/10736-corrupt-rotate-fence.md
+++ b/changelog.d/fixes/10736-corrupt-rotate-fence.md
@@ -1,0 +1,1 @@
+- **fix(db):** pause call-log rotation and record SQLITE_CORRUPT on `/api/db/health` instead of retrying writes against a malformed pager ([#10736](https://github.com/diegosouzapw/OmniRoute/issues/10736))

--- a/src/lib/db/healthCheck.ts
+++ b/src/lib/db/healthCheck.ts
@@ -26,6 +26,53 @@ export interface DbHealthCheckResult {
   checkedAt: string;
 }
 
+export interface PagerCorruptionNote {
+  source: string;
+  message: string;
+  at: string;
+}
+
+let pagerCorruption: PagerCorruptionNote | null = null;
+
+function pagerErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message?: unknown }).message ?? "");
+  }
+  return String(error ?? "unknown");
+}
+
+export function isSqlitePagerCorruptError(error: unknown): boolean {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code || "")
+      : "";
+  const message = pagerErrorMessage(error);
+  return (
+    code === "SQLITE_CORRUPT" ||
+    code === "SQLITE_NOTADB" ||
+    code === "SQLITE_IOERR" ||
+    /malformed|SQLITE_CORRUPT|SQLITE_NOTADB|SQLITE_IOERR/i.test(message)
+  );
+}
+
+export function notePagerCorruption(source: string, error: unknown): void {
+  const message = pagerErrorMessage(error) || "unknown";
+  pagerCorruption = {
+    source,
+    message,
+    at: new Date().toISOString(),
+  };
+}
+
+export function getPagerCorruption(): PagerCorruptionNote | null {
+  return pagerCorruption;
+}
+
+export function resetPagerCorruption(): void {
+  pagerCorruption = null;
+}
+
 interface RunDbHealthCheckOptions {
   autoRepair?: boolean;
   createBackupBeforeRepair?: () => boolean;
@@ -404,6 +451,14 @@ export function runDbHealthCheck(
   const expectedSchemaVersion = options.expectedSchemaVersion || "1";
   const checkedAt = new Date().toISOString();
   const issues: DbHealthIssue[] = [];
+  if (pagerCorruption) {
+    issues.push({
+      type: "integrity_check_failed",
+      table: "sqlite",
+      description: `Pager reported SQLITE_CORRUPT during ${pagerCorruption.source}: ${pagerCorruption.message}`,
+      count: 1,
+    });
+  }
   let repairedCount = 0;
   let backupCreated = false;
   let backupAttempted = false;

--- a/src/lib/usage/callLogRotation.ts
+++ b/src/lib/usage/callLogRotation.ts
@@ -20,6 +20,7 @@ import {
   type CallLogDetailState,
 } from "./callLogArtifacts";
 import { getCallLogMaxEntries, getCallLogRetentionDays, getCallLogsTableMaxRows } from "../logEnv";
+import { isSqlitePagerCorruptError, notePagerCorruption } from "../db/healthCheck";
 
 const CALL_LOG_ROTATE_THROTTLE_MS = 60_000;
 const CALL_LOG_ROTATE_BATCH_SIZE = 100;
@@ -308,7 +309,29 @@ export function trimCallLogsToMaxRows(
   return { deletedRows, deletedArtifacts };
 }
 
+let callLogRotatePaused = false;
+
+export function isCallLogRotatePaused(): boolean {
+  return callLogRotatePaused;
+}
+
+export function resetCallLogRotateFence(): void {
+  callLogRotatePaused = false;
+}
+
+export function handleCallLogRotateError(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error("[callLogs] Failed to rotate request artifacts:", message);
+  if (!isSqlitePagerCorruptError(error)) return;
+  callLogRotatePaused = true;
+  notePagerCorruption("call-log-rotate", error);
+  console.error(
+    "[callLogs] SQLITE_CORRUPT during rotation; pausing further rotate writes. Check /api/db/health."
+  );
+}
+
 export function rotateCallLogs() {
+  if (callLogRotatePaused) return;
   try {
     if (!CALL_LOGS_DIR || !fs.existsSync(CALL_LOGS_DIR)) return;
 
@@ -324,7 +347,7 @@ export function rotateCallLogs() {
       minAgeMs: CALL_LOG_ORPHAN_MIN_AGE_MS,
     });
   } catch (error) {
-    console.error("[callLogs] Failed to rotate request artifacts:", (error as Error).message);
+    handleCallLogRotateError(error);
   }
 }
 
@@ -335,7 +358,7 @@ function runScheduledCallLogRotation() {
     try {
       rotateCallLogs();
     } catch (error) {
-      console.error("[callLogs] Failed to rotate request artifacts:", (error as Error).message);
+      handleCallLogRotateError(error);
     } finally {
       callLogRotateInFlight = false;
     }

--- a/tests/unit/call-log-rotate-corrupt.test.ts
+++ b/tests/unit/call-log-rotate-corrupt.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getPagerCorruption,
+  isSqlitePagerCorruptError,
+  notePagerCorruption,
+  resetPagerCorruption,
+} from "../../src/lib/db/healthCheck.ts";
+import {
+  handleCallLogRotateError,
+  isCallLogRotatePaused,
+  resetCallLogRotateFence,
+} from "../../src/lib/usage/callLogRotation.ts";
+
+test("isSqlitePagerCorruptError matches SQLITE_CORRUPT and malformed pager errors", () => {
+  assert.equal(isSqlitePagerCorruptError({ code: "SQLITE_CORRUPT", message: "x" }), true);
+  assert.equal(
+    isSqlitePagerCorruptError(new Error("database disk image is malformed")),
+    true
+  );
+  assert.equal(isSqlitePagerCorruptError(new Error("SQLITE_IOERR")), true);
+  assert.equal(isSqlitePagerCorruptError(new Error("simulated opendir failure")), false);
+});
+
+test("notePagerCorruption surfaces on the next health check snapshot", () => {
+  resetPagerCorruption();
+  notePagerCorruption("call-log-rotate", { code: "SQLITE_CORRUPT", message: "malformed" });
+  const noted = getPagerCorruption();
+  assert.ok(noted);
+  assert.equal(noted.source, "call-log-rotate");
+  assert.match(noted.message, /malformed|SQLITE_CORRUPT/);
+  resetPagerCorruption();
+  assert.equal(getPagerCorruption(), null);
+});
+
+test("handleCallLogRotateError fences further rotation on SQLITE_CORRUPT", () => {
+  resetCallLogRotateFence();
+  resetPagerCorruption();
+  const corrupt = Object.assign(new Error("database disk image is malformed"), {
+    code: "SQLITE_CORRUPT",
+  });
+  handleCallLogRotateError(corrupt);
+  assert.equal(isCallLogRotatePaused(), true);
+  assert.ok(getPagerCorruption());
+  resetCallLogRotateFence();
+  resetPagerCorruption();
+});
+
+test("handleCallLogRotateError does not fence ordinary filesystem errors", () => {
+  resetCallLogRotateFence();
+  resetPagerCorruption();
+  handleCallLogRotateError(new Error("simulated opendir failure"));
+  assert.equal(isCallLogRotatePaused(), false);
+  assert.equal(getPagerCorruption(), null);
+});


### PR DESCRIPTION
## Summary

- On `SQLITE_CORRUPT` / malformed pager / `SQLITE_IOERR` during call-log rotation, **pause further rotate writes** instead of retrying DELETEs against a broken file.
- Record the failure so `/api/db/health` reports `integrity_check_failed` (`Pager reported SQLITE_CORRUPT during call-log-rotate: …`).
- Ordinary filesystem errors still log and do **not** pause rotation.

Does **not** auto-`REINDEX`. That remains unsafe on a live single-writer file.

## Related Issues

- Closes the fail-closed gap in #10736 (owner already scoped this as the narrow safe fix)
- Related to #10817 (single-replica SQLite HA limits)

## Validation

- [x] Change type: DB
- [x] Focused tests: `node --import tsx/esm --test tests/unit/call-log-rotate-corrupt.test.ts` (4/4)
- [x] `tests/unit/call-log-file-rotation.test.ts` swallow-filesystem case still passes
- [ ] `npm run lint` (CI)
- [x] Branched from `origin/release/v3.8.50` (`266e39d36`)
- [x] New automated test in this PR

## Tests Added Or Updated

- `tests/unit/call-log-rotate-corrupt.test.ts`

## Coverage Notes

- `src/lib/db/healthCheck.ts` pager-note helpers + `src/lib/usage/callLogRotation.ts` fence covered by the new file.
- One existing orphan-cleanup assertion in `call-log-file-rotation.test.ts` failed on this machine because `better-sqlite3` is built for NODE_MODULE_VERSION 137 vs local 147 (sql.js fallback). Unrelated to this fence; CI image has a matching native module.

## Reviewer Notes

- Public `/healthz` stays process-lifecycle only (by design). Degraded DB is `/api/db/health`.
- Production evidence for #10736 (real `integrity_check`, Longhorn block PVC) is on the issue.
