### PR TITLE
fix(db): add missing @/lib/db/connections module breaking dashboard build

### DIFF
--- a/src/app/api/usage/utilization/route.ts
+++ b/src/app/api/usage/utilization/route.ts
@@ -71,7 +71,9 @@ export async function GET(request: Request) {
         connectionMeta[cid] = {
           email: conn?.email ?? null,
           name: conn?.name ?? null,
-          displayName: conn?.displayName ?? null,
+          // provider_connections has no display-name column; the UI falls back
+          // to name/email via getAccountDisplayName.
+          displayName: null,
         };
       }
     }

--- a/src/lib/db/connections.ts
+++ b/src/lib/db/connections.ts
@@ -1,0 +1,21 @@
+import { getDbInstance } from "./core";
+
+export interface ProviderConnectionRef {
+  id: string;
+  provider: string;
+  name: string | null;
+  email: string | null;
+}
+
+/**
+ * Look up a single provider connection by id. Backs dashboard surfaces that
+ * need human-readable account metadata (email/name) for a connection id,
+ * e.g. the utilization Account Split cards.
+ */
+export function getConnection(connectionId: string): ProviderConnectionRef | null {
+  const db = getDbInstance();
+  const row = db
+    .prepare("SELECT id, provider, name, email FROM provider_connections WHERE id = ?")
+    .get(connectionId) as ProviderConnectionRef | undefined;
+  return row ?? null;
+}


### PR DESCRIPTION
## Problem

#10939 added this import to `src/app/api/usage/utilization/route.ts`:

```ts
import { getConnection } from "@/lib/db/connections";
```

…but no such module exists anywhere in the repo, so the dashboard build fails on current HEAD:

```
Error: Turbopack build failed with 1 error:
./src/app/api/usage/utilization/route.ts:3:1
Error: Module not found: Can't resolve '@/lib/db/connections'
```

(The PR's description notes CI was already red via base-red #9985, which is why this slipped through.)

## Fix

Add `src/lib/db/connections.ts` following the existing db-helper pattern (`getDbInstance` + prepared statement, cf. `connectionRuntimeState.ts`):

```ts
getConnection(connectionId): { id, provider, name, email } | null
```

— exactly the email/name metadata the route maps into `ConnectionMetaEntry`.

Also replace the route's `conn?.displayName ?? null` with a literal `null`: `provider_connections` has no display-name column, and the Account Split card already falls back through `getAccountDisplayName` (displayName → name → email), so behavior for that field is unchanged while types stay honest.

## Verification

```
npm run build
# before: Error: Module not found: Can't resolve '@/lib/db/connections'
# after:  ⚡ Done — standalone tree written
```

Remaining `tsc --noEmit` findings are pre-existing base-red items in unrelated files (#9985); none touch the files changed here.