### PR TITLE
fix(opencode): guard the provider block when merging an existing config

### DIFF
--- a/changelog.d/fixes/opencode-merge-provider-guard.md
+++ b/changelog.d/fixes/opencode-merge-provider-guard.md
@@ -1,0 +1,1 @@
+- **OpenCode config merge:** stop `mergeOpenCodeConfig` splaying a malformed `provider` block into index keys. The root was already guarded against a non-object; the `provider` branch it spreads one level down was not, so an existing `"provider": ["a", "b"]` merged to `{"0": "a", "1": "b", …}`. Its sibling `mergeOpenCodeConfigText` already refuses the same input.

--- a/src/shared/services/opencodeConfig.ts
+++ b/src/shared/services/opencodeConfig.ts
@@ -91,11 +91,23 @@ export const mergeOpenCodeConfig = (
       ? existingConfig
       : {};
 
+  // Same guard as the root above, one level down. Spreading a non-object here
+  // does not throw, it splays the value into index keys: an existing
+  // `"provider": ["a", "b"]` merged to `{"0": "a", "1": "b", omniroute: ... }`
+  // and a string was exploded one character per key. mergeOpenCodeConfigText
+  // refuses the same input outright, so the two disagreed on what to do with a
+  // malformed config.
+  const existingProvider = (safeConfig as Record<string, unknown>).provider;
+  const safeProvider =
+    existingProvider && typeof existingProvider === "object" && !Array.isArray(existingProvider)
+      ? (existingProvider as Record<string, unknown>)
+      : {};
+
   return {
     ...safeConfig,
     $schema: safeConfig.$schema || "https://opencode.ai/config.json",
     provider: {
-      ...((safeConfig as any).provider || {}),
+      ...safeProvider,
       omniroute: buildOpenCodeProviderConfig(input),
     },
   };

--- a/tests/unit/opencode-merge-provider-guard.test.ts
+++ b/tests/unit/opencode-merge-provider-guard.test.ts
@@ -1,0 +1,68 @@
+// `mergeOpenCodeConfig` guarded the root against a non-object but not the
+// `provider` branch it spreads one level down. Spreading a non-object does not
+// throw, it splays the value into index keys, so an existing config with a
+// malformed `provider` was rewritten into nonsense instead of being rejected:
+//
+//   provider: ["a", "b"]  ->  { "0": "a", "1": "b", omniroute: {...} }
+//   provider: "oops"      ->  { "0": "o", "1": "o", "2": "p", "3": "s", ... }
+//
+// Its sibling `mergeOpenCodeConfigText` throws on the same input
+// ("Can not add index to parent of type array"), so the two disagreed on what a
+// malformed config means.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { mergeOpenCodeConfig, mergeOpenCodeConfigText } =
+  await import("../../src/shared/services/opencodeConfig.ts");
+
+const INPUT = {
+  baseUrl: "http://localhost:20128/v1",
+  apiKey: "sk_test_opencode",
+  model: "claude-sonnet-4-5-thinking",
+};
+
+for (const [label, provider] of [
+  ["an array", ["a", "b"]],
+  ["a string", "oops"],
+  ["a number", 7],
+  ["null", null],
+] as const) {
+  test(`mergeOpenCodeConfig drops a provider block that is ${label}`, () => {
+    const merged = mergeOpenCodeConfig({ provider } as never, INPUT);
+
+    assert.deepEqual(
+      Object.keys(merged.provider),
+      ["omniroute"],
+      `a provider block that is ${label} must not be splayed into index keys`
+    );
+    assert.equal(merged.provider.omniroute.options.baseURL, "http://localhost:20128/v1");
+  });
+}
+
+test("mergeOpenCodeConfig still preserves sibling providers", () => {
+  // The guard must only reject non-objects, never a legitimate provider map.
+  const merged = mergeOpenCodeConfig(
+    { provider: { custom: { name: "Custom Provider" }, other: { name: "Other" } } } as never,
+    INPUT
+  );
+
+  assert.deepEqual(Object.keys(merged.provider).sort(), ["custom", "omniroute", "other"]);
+  assert.equal(merged.provider.custom.name, "Custom Provider");
+});
+
+test("mergeOpenCodeConfig still guards the root itself", () => {
+  for (const existing of [["a"], "oops", 7, null, undefined]) {
+    const merged = mergeOpenCodeConfig(existing as never, INPUT);
+    assert.deepEqual(Object.keys(merged.provider), ["omniroute"]);
+    assert.equal(merged.$schema, "https://opencode.ai/config.json");
+  }
+});
+
+test("mergeOpenCodeConfigText keeps refusing the same malformed input", () => {
+  // Pinning the sibling's behaviour: the object variant now drops the bad
+  // block, the text variant still refuses to touch the file. Both are safe;
+  // neither corrupts.
+  for (const text of ['{"provider": ["a","b"]}', '{"provider": "oops"}']) {
+    assert.throws(() => mergeOpenCodeConfigText(text, INPUT));
+  }
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Problem

`mergeOpenCodeConfig` guards the **root** against a non-object, then spreads `safeConfig.provider` one level down with no guard at all:

```ts
const safeConfig =
  existingConfig && typeof existingConfig === "object" && !Array.isArray(existingConfig)
    ? existingConfig
    : {};

return {
  ...safeConfig,
  provider: {
    ...((safeConfig as any).provider || {}),   // <-- unguarded
    omniroute: buildOpenCodeProviderConfig(input),
  },
};
```

Spreading a non-object into an object literal does not throw — it splays the value into index keys. Measured on the current branch base:

| existing `provider` | `Object.keys(merged.provider)` before | after |
| --- | --- | --- |
| `{ other: {...} }` | `["other", "omniroute"]` | `["other", "omniroute"]` |
| `["a", "b"]` | `["0", "1", "omniroute"]` | `["omniroute"]` |
| `"oops"` | `["0", "1", "2", "3", "omniroute"]` | `["omniroute"]` |
| `7` | `["omniroute"]` | `["omniroute"]` |

A string is exploded one character per key. The result is a config that is structurally valid JSON and silently wrong.

The sibling merge refuses the same input outright:

```
mergeOpenCodeConfigText('{"provider": ["a","b"]}')  ->  throws
    "Can not add index to parent of type array"
```

So the two functions that exist to do the same job disagreed about what a malformed config means: one refuses to touch it, the other rewrites it into nonsense.

## Scope of impact — stated accurately

**No user's file is being corrupted today.** The API write path (`src/app/api/cli-tools/guide-settings/[toolId]/route.ts:220`) uses `mergeOpenCodeConfigText`, the variant that throws. `mergeOpenCodeConfig` is an exported helper used by tests and available to callers, so this is a latent defect in the public surface rather than a live data-loss bug. I would rather say that than imply an impact the code path does not have.

## Change

The `provider` branch now applies the same object/array check the root already applies, so a malformed block is dropped instead of splayed. Six lines plus a comment explaining why a bare spread is not safe here.

I kept "drop and replace" rather than "throw", to match the precedent the root guard already sets in this same function. If you would rather both variants throw so a malformed config is never silently discarded, say so and I will make them consistent that way instead — it is a one-line change either way, but it alters the contract for existing callers, so it is your call rather than mine.

## Verification

`tests/unit/opencode-merge-provider-guard.test.ts` (new, 7 cases): the four malformed shapes, a positive case proving a legitimate provider map with two siblings is untouched, the root guard itself, and a case pinning that `mergeOpenCodeConfigText` still refuses the same input — so the two cannot silently converge on the wrong behaviour later.

Reverting only `src/shared/services/opencodeConfig.ts`: **2 failed, 5 passed** (the array and string cases). All 7 pass with the change.

Related suites — `t40-opencode-cli-tools-integration`, `opencode-config-dir-single-source`, and the new file: **19 passed, 0 failed**. `npm run typecheck:core` exit 0, `eslint` clean on both files, `check:changelog-integrity` OK.
