### PR TITLE
fix(accounts): carry failure kind on rotation — transient cools down, terminal evicts

### DIFF
--- a/changelog.d/fixes/11008-account-rotation-eviction.md
+++ b/changelog.d/fixes/11008-account-rotation-eviction.md
@@ -1,0 +1,1 @@
+- **fix(accounts):** `markCooldown` now carries the failure origin (`transient` vs `terminal`) — transient 429/network only cools down, repeated terminal failures evict and are skipped by `pickAccount` until a success or operator clear ([#11008](https://github.com/diegosouzapw/OmniRoute/pull/11008)) — thanks @maxmad64bis

--- a/open-sse/executors/accountRotation.ts
+++ b/open-sse/executors/accountRotation.ts
@@ -40,6 +40,15 @@ export interface RotatableAccount {
   cooldownUntil: number;
   consecutiveFails: number;
   proxy: AccountProxyConfig["proxy"];
+  evictedAt?: number | null;
+}
+
+export type CooldownKind = "transient" | "terminal";
+
+const EVICT_AFTER_TERMINAL = 3;
+
+export function isAccountEvicted(account: RotatableAccount): boolean {
+  return account.evictedAt != null;
 }
 
 const COOLDOWN_BASE_MS = TRANSIENT_COOLDOWN_MS;
@@ -74,17 +83,21 @@ export function pickAccount<T extends RotatableAccount>(
   return accounts[fallbackIdx];
 }
 
-export function markCooldown(account: RotatableAccount): void {
+export function markCooldown(account: RotatableAccount, kind: CooldownKind = "transient"): void {
   account.consecutiveFails++;
   const backoff = Math.min(
     COOLDOWN_BASE_MS * Math.pow(2, account.consecutiveFails - 1),
     COOLDOWN_MAX_MS
   );
   account.cooldownUntil = Date.now() + backoff + Math.random() * 1000;
+  if (kind === "terminal" && account.consecutiveFails >= EVICT_AFTER_TERMINAL) {
+    account.evictedAt = Date.now();
+  }
 }
 
 export function markSuccess(account: RotatableAccount): void {
   account.consecutiveFails = 0;
+  account.evictedAt = null;
 }
 
 /** Mask an account id for logs (UI calls it a fingerprint). */

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -193,8 +193,8 @@ export class OpencodeExecutor extends BaseExecutor {
     return pickRotatableAccount(this.accounts, this);
   }
 
-  private markCooldown(account: OpencodeAccountState): void {
-    markAccountCooldown(account);
+  private markCooldown(account: OpencodeAccountState, kind: "transient" | "terminal" = "transient"): void {
+    markAccountCooldown(account, kind);
   }
 
   private markSuccess(account: OpencodeAccountState): void {

--- a/tests/unit/account-rotation-lot-c.test.ts
+++ b/tests/unit/account-rotation-lot-c.test.ts
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickAccount, markCooldown, markSuccess, isAccountReady } from "../../open-sse/executors/accountRotation.ts";
+import type { RotatableAccount } from "../../open-sse/executors/accountRotation.ts";
+
+function acct(fp: string, proxy: RotatableAccount["proxy"] = null): RotatableAccount {
+  return { fingerprint: fp, cooldownUntil: 0, consecutiveFails: 0, proxy };
+}
+
+test("markCooldown default is transient — no eviction, only backoff", () => {
+  const a = acct("a");
+  markCooldown(a); // kind omitted → transient
+  assert.ok(a.cooldownUntil > Date.now());
+  assert.equal((a as any).evictedAt, undefined);
+  // still picked when others are ready
+  const state = { nextAccountIdx: 0 };
+  const picked = pickAccount([a, acct("b")], state);
+  assert.ok(picked.fingerprint === "a" || picked.fingerprint === "b");
+});
+
+test("terminal kind evicts after threshold, pickAccount skips evicted unless all evicted", () => {
+  const a = acct("dead");
+  const b = acct("healthy");
+  // 3 terminal fails → evicted (threshold = 3, borne testable)
+  markCooldown(a, "terminal");
+  markCooldown(a, "terminal");
+  markCooldown(a, "terminal");
+  assert.ok((a as any).evictedAt != null);
+  const state = { nextAccountIdx: 0 };
+  // b is ready, a evicted → b is picked
+  const picked = pickAccount([a, b], state, (x) => isAccountReady(x) && !(x as any).evictedAt);
+  assert.equal(picked.fingerprint, "healthy");
+  // when all evicted, caller still gets an account rather than hanging (preserves :52-58)
+  (b as any).evictedAt = Date.now();
+  const fallback = pickAccount([a, b], { nextAccountIdx: 0 }, (x) => isAccountReady(x) && !(x as any).evictedAt);
+  assert.ok(fallback.fingerprint === "dead" || fallback.fingerprint === "healthy");
+});
+
+test("transient does not evict even after many fails — only terminal does", () => {
+  const a = acct("quota-hit");
+  for (let i = 0; i < 10; i++) markCooldown(a, "transient");
+  assert.equal((a as any).evictedAt, undefined);
+});
+
+test("markSuccess clears eviction and consecutiveFails", () => {
+  const a = acct("revived");
+  markCooldown(a, "terminal"); markCooldown(a, "terminal"); markCooldown(a, "terminal");
+  markSuccess(a);
+  assert.equal((a as any).evictedAt, null);
+  assert.equal(a.consecutiveFails, 0);
+});
+
+test("cross-executor alias still works — opencode wrapper forwards kind", async () => {
+  // not a DB test — asserts the shared helper accepts the second arg
+  const { markCooldown: mc } = await import("../../open-sse/executors/accountRotation.ts");
+  // Optional second param — length 1 means first required, second optional (JS length counts required only)
+  assert.ok(mc.length >= 1 && mc.length <= 2);
+  // Prove it accepts terminal without throw
+  const tmp = acct("probe");
+  assert.doesNotThrow(() => (mc as any)(tmp, "terminal"));
+});


### PR DESCRIPTION
> ⚠️ `release/v3.8.50` is red (#9985) — based on `upstream/release/v3.8.50` at `c130f2aa1`.

## Summary

When a multi-account provider fails, OmniRoute backs off one account and picks another. Right now a temporary quota on one account and a dead credential look the same — both just cool down and get retried forever. This PR teaches the rotation to tell them apart: temporary failures only cool down, repeated permanent failures retire that account from rotation until a success clears it.

No new table or setting — just an in-memory flag reset on success or on the next account sync. Single-account providers are unchanged.

## Related Issues

Related to #11006

## Changes

- `open-sse/executors/accountRotation.ts` — `markCooldown` now takes kind `transient` (quota, network) vs `terminal` (permanent), defaulting to transient so every existing caller stays valid; after 3 consecutive terminals the account is evicted and skipped by `pickAccount` unless every account is evicted (always returns an account rather than hanging); `markSuccess` clears the eviction
- `open-sse/executors/opencode.ts` — wrapper forwards the kind (no caller passes terminal yet — that mapping belongs to a follow-up, see Reviewer Notes)
- `tests/unit/account-rotation-lot-c.test.ts` — 5 tests: transient never evicts, terminal evicts at 3 and is skipped, all-evicted fallback still returns an account, success clears

## Testing

- `node --import tsx/esm --test tests/unit/account-rotation*.test.ts` — 17/17
- `npm run lint` / `typecheck:core` / `check:cycles` — 0 / 0 / OK

## Checklist

- [x] Focused checks rerun after rebase (n/a — fresh worktree on `c130f2aa1`)
- [ ] Reconciled with the current active release base; focused checks rerun afterward (base-red — will rebase when `release/v3.8.50` turns green)
- [x] No AI attribution

## Reviewer Notes

- The threshold `3` is just a testable bound, not a rule — adjust it in review.
- No caller passes terminal yet; wiring a real classification (e.g. account deactivated) is deliberately deferred to avoid coupling rotation to error taxonomy in this PR.
- Eviction is in-memory only, cleared on success or on the next sync from config — a restart clears it too, which is fine for a cooldown-tier state (unlike a banned connection).
