### PR TITLE
fix(cli): generated combo PATCH sends literal {id} — resolve $ref params + requestBody (#10955)

### DIFF
--- a/bin/cli/api-commands/combos.mjs
+++ b/bin/cli/api-commands/combos.mjs
@@ -30,20 +30,60 @@ export function register_combos(parent) {
       const data = res.ok ? await res.json() : await res.text();
       emit(data, gOpts);
     });
-  tag.command("patch-api-combos-id-")
-    .description("Update combo")
+  tag.command("get-api-combos-id-")
+    .description("Get combo by ID")
+    .requiredOption("--id <id>", "")
     .action(async (opts, cmd) => {
       const gOpts = cmd.optsWithGlobals();
       let url = "/api/combos/{id}";
-      const res = await apiFetch(url, { method: "PATCH", baseUrl: gOpts.baseUrl, apiKey: gOpts.apiKey });
+      url = url.replace("{id}", encodeURIComponent(opts.id ?? ""));
+      const res = await apiFetch(url, { method: "GET", baseUrl: gOpts.baseUrl, apiKey: gOpts.apiKey });
+      const data = res.ok ? await res.json() : await res.text();
+      emit(data, gOpts);
+    });
+  tag.command("put-api-combos-id-")
+    .description("Update combo")
+    .requiredOption("--id <id>", "")
+    .option("--body <jsonOrPath>", "JSON body or @path/to/file.json")
+    .action(async (opts, cmd) => {
+      const gOpts = cmd.optsWithGlobals();
+      let url = "/api/combos/{id}";
+      url = url.replace("{id}", encodeURIComponent(opts.id ?? ""));
+      let body;
+      if (opts.body) {
+        body = opts.body.startsWith("@")
+          ? JSON.parse(readFileSync(opts.body.slice(1), "utf8"))
+          : JSON.parse(opts.body);
+      }
+      const res = await apiFetch(url, { method: "PUT", body, baseUrl: gOpts.baseUrl, apiKey: gOpts.apiKey });
+      const data = res.ok ? await res.json() : await res.text();
+      emit(data, gOpts);
+    });
+  tag.command("patch-api-combos-id-")
+    .description("Update combo")
+    .requiredOption("--id <id>", "")
+    .option("--body <jsonOrPath>", "JSON body or @path/to/file.json")
+    .action(async (opts, cmd) => {
+      const gOpts = cmd.optsWithGlobals();
+      let url = "/api/combos/{id}";
+      url = url.replace("{id}", encodeURIComponent(opts.id ?? ""));
+      let body;
+      if (opts.body) {
+        body = opts.body.startsWith("@")
+          ? JSON.parse(readFileSync(opts.body.slice(1), "utf8"))
+          : JSON.parse(opts.body);
+      }
+      const res = await apiFetch(url, { method: "PATCH", body, baseUrl: gOpts.baseUrl, apiKey: gOpts.apiKey });
       const data = res.ok ? await res.json() : await res.text();
       emit(data, gOpts);
     });
   tag.command("delete-api-combos-id-")
     .description("Delete combo")
+    .requiredOption("--id <id>", "")
     .action(async (opts, cmd) => {
       const gOpts = cmd.optsWithGlobals();
       let url = "/api/combos/{id}";
+      url = url.replace("{id}", encodeURIComponent(opts.id ?? ""));
       const res = await apiFetch(url, { method: "DELETE", baseUrl: gOpts.baseUrl, apiKey: gOpts.apiKey });
       const data = res.ok ? await res.json() : await res.text();
       emit(data, gOpts);

--- a/changelog.d/fixes/10955-cli-ref-params.md
+++ b/changelog.d/fixes/10955-cli-ref-params.md
@@ -1,0 +1,1 @@
+- fix(cli): resolve $ref path params and add PATCH combos requestBody in generated API commands (#10955)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2105,11 +2105,26 @@ paths:
     patch:
       tags: [Combos]
       summary: Update combo
+      description: >-
+        Partial update: the body is merged onto the stored combo, so a field left out keeps
+        its current value. An array that IS sent replaces the stored one outright.
       parameters:
         - $ref: "#/components/parameters/ResourceId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
       responses:
         "200":
           description: Updated combo
+        "400":
+          description: Invalid body, or the resulting combo fails validation
+        "404":
+          description: Combo not found
+        "409":
+          description: Name already taken, or the combo is quota-share managed
     delete:
       tags: [Combos]
       summary: Delete combo

--- a/scripts/check/check-env-doc-sync.mjs
+++ b/scripts/check/check-env-doc-sync.mjs
@@ -156,8 +156,11 @@ const IGNORE_FROM_CODE = new Set([
   // X11/Wayland display server vars used by tray heuristic (isTraySupported).
   "DISPLAY",
   "WAYLAND_DISPLAY",
-  // Build-time override for OpenAPI spec path used by generate-api-commands.mjs.
+  // Build-time overrides for generate-api-commands.mjs (spec input / commands output dir).
+  // OPENAPI_OUT_DIR exists so tests/unit/cli-api-generator-ref-params.test.ts can regenerate
+  // into a scratch dir instead of the real bin/cli/api-commands/ tree.
   "OPENAPI_SPEC",
+  "OPENAPI_OUT_DIR",
   // Aliases for documented vars handled via fallback ordering.
   "API_KEY",
   "APP_URL",

--- a/scripts/cli/generate-api-commands.mjs
+++ b/scripts/cli/generate-api-commands.mjs
@@ -11,7 +11,7 @@ import * as yaml from "js-yaml";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..");
 const SPEC_PATH = process.env.OPENAPI_SPEC || join(ROOT, "docs/openapi.yaml");
-const OUT_DIR = join(ROOT, "bin/cli/api-commands");
+const OUT_DIR = process.env.OPENAPI_OUT_DIR || join(ROOT, "bin/cli/api-commands");
 
 // Operations already covered by hand-crafted commands — skip in generated output.
 const IGNORED_OP_IDS = new Set([
@@ -51,6 +51,29 @@ if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
 
 const spec = yaml.load(readFileSync(SPEC_PATH, "utf8"));
 
+// Minimal, scoped $ref resolver — only follows refs into components/parameters.
+// This is not a generic dereferencer (no cycle handling, no cross-file refs):
+// OpenAPI `parameters` entries in this spec only ever $ref a component parameter
+// (see docs/openapi.yaml → components/parameters/ResourceId), so a full
+// dereferencer would be scope creep. Without this, `p.in === "path"` silently
+// drops every $ref'd path parameter (a bare `{ $ref }` object has no `.in`),
+// which is what let generated PATCH/DELETE combo commands lose --id (#10955).
+const PARAM_REF_PREFIX = "#/components/parameters/";
+function resolveParam(p) {
+  if (p && typeof p === "object" && typeof p.$ref === "string") {
+    if (!p.$ref.startsWith(PARAM_REF_PREFIX)) {
+      throw new Error(`Unsupported parameter $ref (only ${PARAM_REF_PREFIX}* is resolved): ${p.$ref}`);
+    }
+    const name = p.$ref.slice(PARAM_REF_PREFIX.length);
+    const resolved = spec.components?.parameters?.[name];
+    if (!resolved) {
+      throw new Error(`Unresolvable parameter $ref: ${p.$ref}`);
+    }
+    return resolved;
+  }
+  return p;
+}
+
 /** @type {Record<string, Array<{path: string, method: string, opId: string, op: object}>>} */
 const byTag = {};
 
@@ -89,7 +112,7 @@ for (const [tag, ops] of Object.entries(byTag)) {
 
   for (const { path, method, opId, op } of ops) {
     const cmdName = kebab(opId);
-    const params = op.parameters || [];
+    const params = (op.parameters || []).map(resolveParam);
     const pathParams = params.filter((p) => p.in === "path");
     const queryParams = params.filter((p) => p.in === "query");
     const hasBody = !!op.requestBody;

--- a/skills/omni-combos-routing/SKILL.md
+++ b/skills/omni-combos-routing/SKILL.md
@@ -60,6 +60,8 @@ curl -X PUT https://localhost:20128/api/combos/{id} \
 
 Update combo
 
+Partial update: the body is merged onto the stored combo, so a field left out keeps its current value. An array that IS sent replaces the stored one outright.
+
 ```bash
 curl -X PATCH https://localhost:20128/api/combos/{id} \
   -H "Authorization: Bearer $OMNIROUTE_TOKEN" \

--- a/tests/unit/cli-api-generator-ref-params.test.ts
+++ b/tests/unit/cli-api-generator-ref-params.test.ts
@@ -1,0 +1,150 @@
+// Regression test for #10955: generated `combos patch-*` CLI command sent a
+// literal PATCH /api/combos/{id} to the server (405) because the generator
+// dropped $ref'd path parameters (a bare `{ $ref }` object has no `.in`, so
+// the `p.in === "path"` filter silently excluded it) and never emitted
+// --body for the requestBody-less PATCH spec entry.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const GENERATOR = join(ROOT, "scripts", "cli", "generate-api-commands.mjs");
+const REAL_COMBOS = join(ROOT, "bin", "cli", "api-commands", "combos.mjs");
+
+// Minimal fixture spec reproducing the exact shape that broke: a path
+// parameter declared via $ref to a components/parameters entry, on a PATCH
+// operation that also carries a requestBody.
+const FIXTURE_SPEC = `
+openapi: 3.0.3
+info:
+  title: fixture
+  version: "1"
+paths:
+  /api/widgets/{id}:
+    patch:
+      tags: [Widgets]
+      summary: Update widget
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Updated widget
+components:
+  parameters:
+    ResourceId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+`;
+
+function runGenerator(specPath, outDir) {
+  execFileSync(process.execPath, ["--import", "tsx/esm", GENERATOR], {
+    cwd: ROOT,
+    env: { ...process.env, OPENAPI_SPEC: specPath, OPENAPI_OUT_DIR: outDir },
+    stdio: "pipe",
+  });
+}
+
+test("generator resolves a $ref path parameter into --id and substitutes {id} in the URL", () => {
+  const workDir = mkdtempSync(join(tmpdir(), "cli-api-gen-ref-"));
+  const specPath = join(workDir, "fixture.yaml");
+  const outDir = join(workDir, "out");
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(specPath, FIXTURE_SPEC);
+
+  try {
+    runGenerator(specPath, outDir);
+    const generated = readFileSync(join(outDir, "widgets.mjs"), "utf8");
+
+    // The $ref'd path param must have produced a required --id flag.
+    assert.match(
+      generated,
+      /\.requiredOption\("--id <id>"/,
+      "generated command must declare --id from the resolved $ref path parameter"
+    );
+    // The URL must be built with {id} substitution, not sent literally.
+    assert.match(
+      generated,
+      /url = url\.replace\("\{id\}", encodeURIComponent\(opts\.id/,
+      "generated command must substitute {id} in the URL"
+    );
+    assert.doesNotMatch(generated, /url = "\/api\/widgets\/\{id\}";\s*\n\s*const res/);
+
+    // requestBody presence must still produce --body.
+    assert.match(
+      generated,
+      /\.option\("--body <jsonOrPath>"/,
+      "generated command must declare --body for the requestBody"
+    );
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("generator rejects an unsupported $ref target instead of silently dropping the parameter", () => {
+  const workDir = mkdtempSync(join(tmpdir(), "cli-api-gen-ref-bad-"));
+  const specPath = join(workDir, "fixture.yaml");
+  const outDir = join(workDir, "out");
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(
+    specPath,
+    `
+openapi: 3.0.3
+info:
+  title: fixture
+  version: "1"
+paths:
+  /api/widgets/{id}:
+    get:
+      tags: [Widgets]
+      summary: Get widget
+      parameters:
+        - $ref: "#/components/schemas/NotAParameter"
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    NotAParameter:
+      type: object
+`
+  );
+
+  try {
+    assert.throws(() => runGenerator(specPath, outDir));
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("real generated bin/cli/api-commands/combos.mjs has --id and --body on the PATCH combo command (#10955)", () => {
+  const src = readFileSync(REAL_COMBOS, "utf8");
+  const patchBlockMatch = src.match(/ {2}tag\.command\("patch-[^"]*"\)[\s\S]*?\n {2}(?=tag\.command\(|\})/);
+  assert.ok(patchBlockMatch, "combos.mjs must have a generated patch-* command block");
+  const patchBlock = patchBlockMatch[0];
+
+  assert.match(patchBlock, /\.requiredOption\("--id <id>"/, "PATCH combo command must require --id");
+  assert.match(
+    patchBlock,
+    /\.option\("--body <jsonOrPath>"/,
+    "PATCH combo command must accept --body"
+  );
+  assert.match(
+    patchBlock,
+    /url = url\.replace\("\{id\}", encodeURIComponent\(opts\.id/,
+    "PATCH combo command must substitute {id} in the URL, not send it literally"
+  );
+});


### PR DESCRIPTION
Closes #10955

## Root cause

`scripts/cli/generate-api-commands.mjs` loads `docs/openapi.yaml` with `yaml.load` and never resolves `$ref`. The spec declares the combo path parameter via:

```yaml
parameters:
  - $ref: "#/components/parameters/ResourceId"
```

The generator's `p.in === "path"` filter silently drops any `$ref`'d parameter — a bare `{ $ref }` object has no `.in` — so every generated command on a `$ref`'d path param lost its `--id` flag and its `{id}` → real-id URL substitution. On top of that, `PATCH /api/combos/{id}` had no `requestBody` in the spec, so no `--body` was ever emitted. The result: `omniroute api combos patch-api-combos-id-` sent a literal `PATCH /api/combos/{id}` with no body → 405/mismatch upstream.

This is a pre-existing spec-wide bug, not combo-specific: `#/components/parameters/ResourceId` is `$ref`'d 20 times across the spec (providers, combos, api-keys, settings, etc.).

## Fix

1. **`scripts/cli/generate-api-commands.mjs`** — added a minimal, scoped `resolveParam()` that only follows `#/components/parameters/*` refs (not a generic dereferencer — this spec never uses any other parameter-level `$ref` target, and a full dereferencer would be scope creep). Unsupported/unresolvable refs now throw at generation time instead of being silently dropped.
2. **`docs/openapi.yaml`** — added the missing `requestBody` to `PATCH /api/combos/{id}`, mirroring `PUT`'s shape exactly (verified against `src/app/api/combos/[id]/route.ts` — `PATCH` delegates straight to `PUT`, same partial-update/merge semantics).
3. **`bin/cli/api-commands/combos.mjs`** — regenerated with the fixed generator. Diff is wiring-only: `--id`/`--body`/URL-substitution added to `get`/`put`/`patch`/`delete` combo-by-id commands (`get`/`put` were entirely missing before — same underlying bug, not new scope). No other `api-commands/*.mjs` file is touched in this PR; the same `$ref` fix will apply the next time the full `build:cli-api` regen runs, but that pulls in unrelated spec drift on ~15 other files that's out of scope for this issue.
4. `OPENAPI_OUT_DIR` env override added to the generator (mirrors the existing `OPENAPI_SPEC` override) purely so the new test can regenerate into a scratch directory instead of the real `bin/cli/api-commands/` tree; added to the `check-env-doc-sync.mjs` internal-tooling allowlist next to `OPENAPI_SPEC`.

## Tests (TDD)

`tests/unit/cli-api-generator-ref-params.test.ts` — RED on the untouched code, GREEN after the fix:
- generator resolves a `$ref` path parameter into `--id` and substitutes `{id}` in the URL (fixture spec reproducing the exact broken shape)
- generator throws on an unsupported `$ref` target instead of silently dropping the parameter
- the real generated `bin/cli/api-commands/combos.mjs` has `--id` and `--body` on the PATCH combo command

Sibling suites: `tests/unit/cli-openapi-codegen.test.ts`, `tests/unit/cli-combo-command.test.ts` — all green.

## Gates run

- `check-file-size.mjs` — OK
- `check-complexity.mjs` — OK (2615 vs baseline 2774)
- `check-cognitive-complexity.mjs` — OK (1175 vs baseline 1223)
- `npm run typecheck:core` — clean
- `eslint --suppressions-location config/quality/eslint-suppressions.json` — clean on changed files (generated `.mjs`/scripts are gitignore-pattern excluded from lint, as expected)
- `check-changelog-integrity.mjs` — OK
- `npm run check:docs-all`:
  - `check:docs-sync` — PASS
  - `check:docs-counts` — 5 STRICT drifts, **all pre-existing and untouched by this diff**: `docs/reference/PROVIDER_REFERENCE.md` (346 vs 347) + 4 SVGs — this is the inherited #9985 base-red (`gh issue`/nightly-release-green), not introduced here (`git diff origin/release/v3.8.50 -- docs/reference/PROVIDER_REFERENCE.md docs/diagrams/` is empty)
  - `check:env-doc-sync` — OPENAPI_OUT_DIR resolved via allowlist; remaining 6 missing-vars are pre-existing, untouched production code (`OMNIROUTE_STANDALONE_DIR`, `KIMI_WEB_*`, `OIDC_DISABLE_PASSWORD_LOGIN`, etc.)
  - `check:deprecated-versions` — advisory (exit 0), 66 pre-existing drifts across unrelated docs
  - `check:doc-links` — PASS
  - `check:fabricated-docs` — PASS

⚠️ base-red inherited: #9985 — public-creds(copilot-m365-web), docs-sync(PROVIDER_REFERENCE)