### PR TITLE
fix(startup): log when credential health check is disabled

### DIFF
--- a/changelog.d/fixes/11016-cred-health-disable-log.md
+++ b/changelog.d/fixes/11016-cred-health-disable-log.md
@@ -1,0 +1,1 @@
+- **fix(startup):** log `Credential health scheduler disabled` when `OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK` is set instead of lying with `started` ([#11016](https://github.com/diegosouzapw/OmniRoute/issues/11016)) — thanks @RaviTharuma

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -471,8 +471,12 @@ export async function registerNodejs(): Promise<void> {
   // instrumentation startup), NOT in the unused src/server-init.ts.
   try {
     const { initCredentialHealthCheck } = await import("@/lib/credentialHealth/scheduler");
-    initCredentialHealthCheck();
-    console.log("[STARTUP] Credential health scheduler started");
+    const started = initCredentialHealthCheck();
+    console.log(
+      started
+        ? "[STARTUP] Credential health scheduler started"
+        : "[STARTUP] Credential health scheduler disabled"
+    );
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn("[STARTUP] Could not start credential health scheduler:", msg);

--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -349,10 +349,13 @@ function scheduleSweep(): void {
 
 /**
  * Start the credential health check scheduler (idempotent).
+ * Returns whether the sweep is armed. False when
+ * OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK is set (#11016).
  */
-export function initCredentialHealthCheck(): void {
+export function initCredentialHealthCheck(): boolean {
   const state = getSchedulerState();
-  if (state.initialized || isCredentialHealthCheckDisabled()) return;
+  if (isCredentialHealthCheckDisabled()) return false;
+  if (state.initialized) return true;
   state.initialized = true;
   initCredentialCache();
 
@@ -364,6 +367,7 @@ export function initCredentialHealthCheck(): void {
   state.sweepTimer = setTimeout(() => {
     sweep().catch((err) => console.error(LOG_PREFIX, "Initial sweep failed:", err));
   }, INITIAL_DELAY_MS);
+  return true;
 }
 
 /**

--- a/tests/unit/credential-health-boot-wiring.test.ts
+++ b/tests/unit/credential-health-boot-wiring.test.ts
@@ -31,6 +31,11 @@ test("credential health scheduler is started from the real Next.js instrumentati
     /\[STARTUP\] Credential health scheduler started/,
     "a [STARTUP] log line proves the boot wiring ran (grep-able in app.log)"
   );
+  assert.match(
+    instrumentation,
+    /\[STARTUP\] Credential health scheduler disabled/,
+    "#11016: disable env must log disabled, not lie with started"
+  );
 });
 
 test("the wiring is NOT placed in the dead src/server-init.ts (the #7432 no-op)", () => {

--- a/tests/unit/credential-health-disable-return.test.ts
+++ b/tests/unit/credential-health-disable-return.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #11016: OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK must be observable.
+// Set the kill-switch BEFORE importing the scheduler — the module auto-inits
+// on first import.
+process.env.OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK = "true";
+
+test("initCredentialHealthCheck returns false when the disable env is set", async () => {
+  const { initCredentialHealthCheck } = await import(
+    "../../src/lib/credentialHealth/scheduler.ts"
+  );
+  assert.equal(initCredentialHealthCheck(), false);
+});


### PR DESCRIPTION
## Summary

- `initCredentialHealthCheck()` now returns whether the sweep is armed.
- Boot logs `Credential health scheduler disabled` when `OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK` is set, instead of always printing `started`.

## Related Issues

- Closes #11016

## Validation

- [x] Focused tests: `node --import tsx/esm --test tests/unit/credential-health-boot-wiring.test.ts tests/unit/credential-health-disable-return.test.ts` (3 pass)
- [ ] `npm run lint`
- [x] Production-code changes include a new or updated automated test in this PR
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `tests/unit/credential-health-disable-return.test.ts`
- `tests/unit/credential-health-boot-wiring.test.ts` — source must contain the disabled log line.

## Coverage Notes

- `src/lib/credentialHealth/scheduler.ts` return contract + `src/instrumentation-node.ts` boot log.

## Reviewer Notes

- Sweep behaviour unchanged. Log + return value only.
