### PR TITLE
fix: strip unsupported message metadata for Groq

### DIFF
--- a/open-sse/config/providerFieldStrips.ts
+++ b/open-sse/config/providerFieldStrips.ts
@@ -56,12 +56,21 @@ export function stripGroqUnsupportedFields<T extends Record<string, unknown>>(bo
   delete next.top_logprobs;
   if (Array.isArray(next.messages)) {
     next.messages = next.messages.map((m) => {
-      if (m && typeof m === "object" && "name" in m) {
-        const { name: _name, ...rest } = m as Record<string, unknown>;
+      if (m && typeof m === "object") {
+        const {
+          name: _name,
+          model: _model,
+          messageId: _msgId,
+          sender: _sender,
+          ...rest
+        } = m as Record<string, unknown>;
+
         return rest;
       }
+
       return m;
     });
   }
   return next as T;
 }
+

--- a/tests/unit/provider-field-strips.test.ts
+++ b/tests/unit/provider-field-strips.test.ts
@@ -53,3 +53,27 @@ test("stripGroqUnsupportedFields is immutable (does not mutate input)", () => {
   assert.equal(input.messages[0].name, "bob");
   assert.equal(input.logprobs, true);
 });
+
+test("stripGroqUnsupportedFields drops unsupported messages[].model and other metadata while keeping role and content", () => {
+  const out = stripGroqUnsupportedFields({
+    messages: [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: "hello!",
+        model: "groq/openai/gpt-oss-20b",
+        messageId: "msg_123",
+        sender: "assistant",
+      },
+    ],
+  });
+  assert.equal(out.messages.length, 2);
+  assert.equal(out.messages[0].role, "user");
+  assert.equal(out.messages[0].content, "hello");
+  assert.equal(out.messages[1].role, "assistant");
+  assert.equal(out.messages[1].content, "hello!");
+  assert.equal("model" in out.messages[1], false);
+  assert.equal("messageId" in out.messages[1], false);
+  assert.equal("sender" in out.messages[1], false);
+});
+


### PR DESCRIPTION
# Fix Groq Multi-Turn Chat Unsupported Metadata Sanitization

## Summary

Groq rejects multi-turn chat requests when assistant messages contain unsupported metadata such as `model`.

OmniRoute's Groq-specific request sanitizer previously removed `name` but preserved unsupported message-level metadata.

This patch sanitizes each message in `messages[]` by removing:
- `model`
- `name`
- `messageId`
- `sender`

Standard message fields such as `role`, `content`, and `tool_calls` are preserved.

---

## Root Cause

On multi-turn conversations, assistant history may contain:

```json
{
  "role": "assistant",
  "content": "...",
  "model": "groq/openai/gpt-oss-20b"
}