### PR TITLE
fix(credentialHealth): log correct scheduler state on boot

### DIFF
--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -450,8 +450,12 @@ export async function registerNodejs(): Promise<void> {
   // instrumentation startup), NOT in the unused src/server-init.ts.
   try {
     const { initCredentialHealthCheck } = await import("@/lib/credentialHealth/scheduler");
-    initCredentialHealthCheck();
-    console.log("[STARTUP] Credential health scheduler started");
+    const started = initCredentialHealthCheck();
+    if (started) {
+      console.log("[STARTUP] Credential health scheduler started");
+    } else {
+      console.log("[STARTUP] Credential health scheduler disabled");
+    }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn("[STARTUP] Could not start credential health scheduler:", msg);
@@ -562,7 +566,10 @@ export async function registerNodejs(): Promise<void> {
         })
         .catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
-          console.warn("[STARTUP] OpenRouter provider stats sync failed to start (non-fatal):", msg);
+          console.warn(
+            "[STARTUP] OpenRouter provider stats sync failed to start (non-fatal):",
+            msg
+          );
         }),
 
       // models.dev capability sync: opt-in via Settings > AI (self-gated by

--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -67,7 +67,6 @@ function isBuildProcess(): boolean {
   return typeof process !== "undefined" && process.env.NEXT_PHASE === "phase-production-build";
 }
 
-
 function isCredentialHealthCheckDisabled(): boolean {
   if (isBuildProcess() || isAutomatedTestProcess()) return true;
   const val = process.env.OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK;
@@ -281,9 +280,10 @@ function scheduleSweep(): void {
 /**
  * Start the credential health check scheduler (idempotent).
  */
-export function initCredentialHealthCheck(): void {
+export function initCredentialHealthCheck(): boolean {
   const state = getSchedulerState();
-  if (state.initialized || isCredentialHealthCheckDisabled()) return;
+  if (isCredentialHealthCheckDisabled()) return false;
+  if (state.initialized) return true;
   state.initialized = true;
   initCredentialCache();
 
@@ -295,6 +295,8 @@ export function initCredentialHealthCheck(): void {
   state.sweepTimer = setTimeout(() => {
     sweep().catch((err) => console.error(LOG_PREFIX, "Initial sweep failed:", err));
   }, INITIAL_DELAY_MS);
+
+  return true;
 }
 
 /**

--- a/tests/unit/credential-health-boot-wiring.test.ts
+++ b/tests/unit/credential-health-boot-wiring.test.ts
@@ -10,8 +10,7 @@ import { fileURLToPath } from "node:url";
 // (src/instrumentation-node.ts) and NOT in the unused src/server-init.ts — the exact
 // mistake that made the earlier attempt (closed PR #7432) a no-op.
 
-const read = (rel: string) =>
-  readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
 
 const instrumentation = read("../../src/instrumentation-node.ts");
 
@@ -28,9 +27,47 @@ test("credential health scheduler is started from the real Next.js instrumentati
   );
   assert.match(
     instrumentation,
-    /\[STARTUP\] Credential health scheduler started/,
+    /\[STARTUP\] Credential health scheduler (started|disabled)/,
     "a [STARTUP] log line proves the boot wiring ran (grep-able in app.log)"
   );
+});
+
+import * as testProcess from "../../src/shared/utils/testProcess";
+import { mock } from "node:test";
+
+test("initCredentialHealthCheck returns correct boolean based on env var", async () => {
+  const oldNodeEnv = process.env.NODE_ENV;
+  const oldVitest = process.env.VITEST;
+  const oldArgv = process.argv;
+  const oldExecArgv = process.execArgv;
+
+  process.env.NODE_ENV = "development";
+  delete process.env.VITEST;
+  process.argv = ["node", "script.js"];
+  process.execArgv = [];
+
+  const { initCredentialHealthCheck, stopCredentialHealthCheck } =
+    await import("../../src/lib/credentialHealth/scheduler");
+
+  // Cleanup any previous state
+  stopCredentialHealthCheck();
+
+  // Test disabled state
+  process.env.OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK = "1";
+  assert.equal(initCredentialHealthCheck(), false, "Should return false when disabled");
+
+  // Cleanup and test enabled state
+  stopCredentialHealthCheck();
+  delete process.env.OMNIROUTE_DISABLE_CREDENTIAL_HEALTH_CHECK;
+  assert.equal(initCredentialHealthCheck(), true, "Should return true when enabled");
+
+  // Cleanup
+  stopCredentialHealthCheck();
+
+  process.env.NODE_ENV = oldNodeEnv;
+  if (oldVitest !== undefined) process.env.VITEST = oldVitest;
+  process.argv = oldArgv;
+  process.execArgv = oldExecArgv;
 });
 
 test("the wiring is NOT placed in the dead src/server-init.ts (the #7432 no-op)", () => {


### PR DESCRIPTION
Fixes #11016

### What this PR does
- Modifies `initCredentialHealthCheck` to return a boolean indicating whether the scheduler was actually started or if it was disabled via the environment variable.
- Updates the boot wiring in `src/instrumentation-node.ts` to log either `[STARTUP] Credential health scheduler started` or `[STARTUP] Credential health scheduler disabled` based on the returned boolean.
- Updates `tests/unit/credential-health-boot-wiring.test.ts` to allow both log lines and validates the return behavior of the `initCredentialHealthCheck` function.
