### PR TITLE
fix(combo): accept SSE comment lines (e.g. OpenRouter keep-alives) in response quality validation

### DIFF
--- a/open-sse/services/combo/validateQuality.ts
+++ b/open-sse/services/combo/validateQuality.ts
@@ -617,7 +617,22 @@ export async function validateResponseQuality(
   try {
     json = JSON.parse(text);
   } catch {
-    if (text.startsWith("data:") || text.startsWith("event:")) return { valid: true };
+    // An SSE stream body is expected for streamed upstreams. Besides `data:` and
+    // `event:` frames, the SSE spec also allows comment lines that begin with a
+    // colon (`:`), which providers use for keep-alives while the model is still
+    // generating — e.g. OpenRouter emits `: OPENROUTER PROCESSING` on slower /
+    // reasoning responses. A stream that opens with such a comment (or with
+    // leading whitespace/newlines) is still a valid stream, not malformed JSON,
+    // so trim and recognize the comment prefix before rejecting. Without this,
+    // otherwise-good streamed completions get failed as "not valid JSON".
+    const trimmed = text.trimStart();
+    if (
+      trimmed.startsWith("data:") ||
+      trimmed.startsWith("event:") ||
+      trimmed.startsWith(":")
+    ) {
+      return { valid: true };
+    }
     return { valid: false, reason: "response is not valid JSON" };
   }
 

--- a/open-sse/services/combo/validateQuality.ts
+++ b/open-sse/services/combo/validateQuality.ts
@@ -626,11 +626,7 @@ export async function validateResponseQuality(
     // so trim and recognize the comment prefix before rejecting. Without this,
     // otherwise-good streamed completions get failed as "not valid JSON".
     const trimmed = text.trimStart();
-    if (
-      trimmed.startsWith("data:") ||
-      trimmed.startsWith("event:") ||
-      trimmed.startsWith(":")
-    ) {
+    if (trimmed.startsWith("data:") || trimmed.startsWith("event:") || trimmed.startsWith(":")) {
       return { valid: true };
     }
     return { valid: false, reason: "response is not valid JSON" };

--- a/tests/unit/validate-response-quality.test.ts
+++ b/tests/unit/validate-response-quality.test.ts
@@ -24,6 +24,20 @@ test("returns valid=true for SSE with 'data:' lines", async () => {
   assert.strictEqual(res.valid, true);
 });
 
+test("returns valid=true for SSE opening with a ':' comment line (e.g. OpenRouter keep-alive)", async () => {
+  const res = await validateResponseQuality(
+    makeResponse(': OPENROUTER PROCESSING\n\ndata: {"foo":"bar"}\n\n'),
+    false,
+    {}
+  );
+  assert.strictEqual(res.valid, true);
+});
+
+test("returns valid=true for an SSE stream with leading whitespace before the first frame", async () => {
+  const res = await validateResponseQuality(makeResponse('\n\ndata: {"foo":"bar"}\n\n'), false, {});
+  assert.strictEqual(res.valid, true);
+});
+
 test("returns valid=false for non-JSON non-SSE text", async () => {
   const res = await validateResponseQuality(makeResponse("Hello world"), false, {});
   assert.strictEqual(res.valid, false);


### PR DESCRIPTION
## Problem

The combo response quality gate fails a streamed **HTTP 200** completion as
`response is not valid JSON` whenever the SSE body opens with a **comment line**
(a line beginning with `:`) or with leading whitespace/newlines.

In `validateResponseQuality` (`open-sse/services/combo/validateQuality.ts`), when
`JSON.parse(text)` fails on a streamed body, the fallback only treats it as a valid
stream if it `startsWith("data:")` or `startsWith("event:")`:

```ts
try {
  json = JSON.parse(text);
} catch {
  if (text.startsWith("data:") || text.startsWith("event:")) return { valid: true };
  return { valid: false, reason: "response is not valid JSON" };
}
```

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation),
lines starting with `:` are **comments**, which providers use as keep-alives while the
model is still generating. **OpenRouter emits `: OPENROUTER PROCESSING`** at the start of
the stream on slower / reasoning responses. Such a stream is perfectly valid, but because
its first bytes are `:` (not `data:`/`event:`), the gate rejects it — and since every
member of a combo returns the same shape, the whole combo cascades to a **502**.

It presents as **intermittent**: fast replies stream `data:` immediately and pass; slower
ones get the keep-alive comment first and fail. The rejected responses contain real, valid
content and reconstruct to valid JSON downstream — only the raw-stream sniff is wrong.

## Fix

Trim leading whitespace and accept the `:` (SSE comment) prefix before rejecting:

```ts
const trimmed = text.trimStart();
if (trimmed.startsWith("data:") || trimmed.startsWith("event:") || trimmed.startsWith(":")) {
  return { valid: true };
}
return { valid: false, reason: "response is not valid JSON" };
```

## Tests

Added two regression cases to `tests/unit/validate-response-quality.test.ts`:
- SSE stream opening with a `: OPENROUTER PROCESSING` comment → `valid: true`
- SSE stream with leading whitespace before the first frame → `valid: true`

Full file passes (14/14), existing cases unchanged:

```
# tests 14
# pass 14
# fail 0
```
