### PR TITLE
fix(sse): resolve OpencodeExecutor target format through the provider alias

### DIFF
--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -1,6 +1,6 @@
 import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
 import { PROVIDERS } from "../config/constants.ts";
-import { getModelTargetFormat } from "../config/providerModels.ts";
+import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
 import {
   injectReasoningContentForThinkingModel,
   isThinkingMessageModel,
@@ -125,6 +125,24 @@ export function isPremiumOpencodeModel(model: string, provider: string): boolean
   return !OPENCODE_FREE_MODELS.has(model);
 }
 
+/**
+ * Resolves the registry `targetFormat` for a model, aliasing `provider` first.
+ *
+ * `PROVIDER_MODELS` is keyed by the provider's public ALIAS (e.g. `"oc"`), not its
+ * raw registry id (e.g. `"opencode"`) — mirrors `resolveChatCoreTargetFormat()`
+ * (`handlers/chatCore/targetFormat.ts`), which already aliases before calling
+ * `getModelTargetFormat()`. Calling it with the raw id here made every entry miss
+ * silently (fell through to `"openai"`), while chatCore's own request-body
+ * translation (correctly aliased) still switched to the Responses API shape for
+ * `targetFormat:"openai-responses"` models — sending a Responses-shaped body to
+ * the `/chat/completions` URL this executor's own `buildUrl()` kept selecting.
+ * Exported for testability.
+ */
+export function resolveOpencodeTargetFormat(provider: string, model: string): string {
+  const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
+  return getModelTargetFormat(alias, model) || "openai";
+}
+
 export class OpencodeExecutor extends BaseExecutor {
   /** Delegates to `isPremiumOpencodeModel`. Exported for testability. */
   static isPremiumModel(model: string, provider: string): boolean {
@@ -193,7 +211,10 @@ export class OpencodeExecutor extends BaseExecutor {
     return pickRotatableAccount(this.accounts, this);
   }
 
-  private markCooldown(account: OpencodeAccountState, kind: "transient" | "terminal" = "transient"): void {
+  private markCooldown(
+    account: OpencodeAccountState,
+    kind: "transient" | "terminal" = "transient"
+  ): void {
     markAccountCooldown(account, kind);
   }
 
@@ -202,7 +223,7 @@ export class OpencodeExecutor extends BaseExecutor {
   }
 
   async execute(input: ExecuteInput) {
-    this._requestFormat = getModelTargetFormat(this.provider, input.model) || "openai";
+    this._requestFormat = resolveOpencodeTargetFormat(this.provider, input.model);
 
     // #8681: Gate premium opencode models behind a usable API key.
     // When the connection is keyless (no apiKey, no accessToken) and the model

--- a/tests/unit/opencode-target-format-alias-11045.test.ts
+++ b/tests/unit/opencode-target-format-alias-11045.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  OpencodeExecutor,
+  resolveOpencodeTargetFormat,
+} from "../../open-sse/executors/opencode.ts";
+
+// oc/muse-spark-1.2-contributor-free returns HTTP 400 with an empty assistant
+// message right after `targetFormat:"openai-responses"` was added to its registry
+// entry (#10874). Root cause: `PROVIDER_MODELS` is keyed by the provider's public
+// ALIAS ("oc"), not its raw registry id ("opencode") — resolving the target format
+// with the raw id missed the registry entry entirely, so `buildUrl()` kept picking
+// `/chat/completions` while chatCore's own (correctly aliased) request translation
+// had already switched the request BODY to the Responses API shape (`input:[...]`).
+// Upstream received a Responses-shaped body at the Chat Completions endpoint and
+// returned a degenerate empty response.
+
+test("resolveOpencodeTargetFormat resolves the registry entry via the provider alias, not the raw id", () => {
+  assert.equal(
+    resolveOpencodeTargetFormat("opencode", "muse-spark-1.2-contributor-free"),
+    "openai-responses"
+  );
+  assert.equal(resolveOpencodeTargetFormat("opencode", "muse-spark-1.2"), "openai-responses");
+});
+
+test("resolveOpencodeTargetFormat falls back to 'openai' for a model with no registry targetFormat", () => {
+  assert.equal(resolveOpencodeTargetFormat("opencode", "hy3-free"), "openai");
+});
+
+test("resolveOpencodeTargetFormat falls back to 'openai' for an unknown provider (no alias, no direct match)", () => {
+  assert.equal(resolveOpencodeTargetFormat("not-a-real-provider", "muse-spark-1.2"), "openai");
+});
+
+test("OpencodeExecutor.buildUrl uses /responses once _requestFormat is resolved through the alias (live-bug repro)", () => {
+  const executor = new OpencodeExecutor("opencode");
+  // Mirrors the first line of execute() — see #11045.
+  (executor as unknown as { _requestFormat: string })._requestFormat = resolveOpencodeTargetFormat(
+    "opencode",
+    "muse-spark-1.2-contributor-free"
+  );
+  const url = executor.buildUrl("muse-spark-1.2-contributor-free", true);
+  assert.ok(url.endsWith("/responses"), `expected URL to end with /responses, got: ${url}`);
+});


### PR DESCRIPTION
## Summary

#10874 added `targetFormat: "openai-responses"` to the Muse Spark entries in the `opencode` provider registry. That broke every request to those models: HTTP 400, empty message, `finish_reason: null`.

Turns out `PROVIDER_MODELS` is keyed by a provider's public alias (`"oc"` for this one), not its raw registry id (`"opencode"`). `OpencodeExecutor.execute()` looks up the target format with the raw id, misses the registry entry, and falls back to `"openai"` — so `buildUrl()` keeps pointing at `/chat/completions`. Meanwhile `chatCore`'s own resolution (which does alias correctly) already switched the request **body** to the Responses API shape. Result: a Responses-shaped body lands on the Chat Completions URL, and upstream has nothing sane to answer with.

This never showed up before because no model in this registry had ever used `targetFormat` — the alias bug was just sitting there, never exercised.

Fix: pulled the alias-resolving lookup into its own function (`resolveOpencodeTargetFormat`), same pattern `chatCore/targetFormat.ts` already uses, and pointed `execute()` at it instead of the raw call.

## Related Issues

- Closes #11046

## Validation

- [x] Change type: routing (`open-sse/executors/opencode.ts`)
- [x] `node --import tsx/esm --test tests/unit/opencode-target-format-alias-11045.test.ts` — 4/4
- [x] Related opencode-executor suites re-run too (noauth-proxy-routing, session-fingerprint-headers, cli-headers-synthesis, proxy-rotation, muse-spark-responses) — 32/32
- [x] `npm run lint` clean — the 2 pre-existing `no-explicit-any` in this file are untouched
- [x] `tsc --noEmit` — no new errors
- [x] Branched from current `release/v3.8.50` tip
- [x] Test written first against the actual bug (raw id → wrong format), confirmed failing, then fixed

⚠️ base-red inherited: #9985

## Tests Added Or Updated

`tests/unit/opencode-target-format-alias-11045.test.ts`:
- `resolveOpencodeTargetFormat` resolves the muse-spark entries via the alias
- Falls back to `"openai"` for a model with no registry `targetFormat`
- Falls back to `"openai"` for a provider with no alias mapping
- `OpencodeExecutor.buildUrl` actually returns `/responses` once `_requestFormat` is resolved through the alias (live-bug repro)

## Coverage Notes

Only touches `open-sse/executors/opencode.ts`, covered by the new tests plus the full existing executor suite for this file.

## Reviewer Notes

Same pattern other executors already use (`github.ts`, `default.ts` hardcode their alias as a literal since it's a fixed 1:1 mapping for those providers). This one resolves it dynamically via `PROVIDER_ID_TO_ALIAS` instead of hardcoding `"oc"`, so it keeps working if the alias ever changes.