### PR TITLE
fix(providers): route Muse Spark to the Responses API on opencode-zen and opencode-go too

### DIFF
--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -138,6 +138,7 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVision: true,
       supportsAudio: true,
       supportsVideo: true,
+      targetFormat: "openai-responses",
     },
     {
       id: "muse-spark-1.2-contributor-minimal",
@@ -148,6 +149,7 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVision: true,
       supportsAudio: true,
       supportsVideo: true,
+      targetFormat: "openai-responses",
     },
     {
       id: "muse-spark-1.2-contributor-low",
@@ -158,6 +160,7 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVision: true,
       supportsAudio: true,
       supportsVideo: true,
+      targetFormat: "openai-responses",
     },
     {
       id: "muse-spark-1.2-contributor-medium",
@@ -168,6 +171,7 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVision: true,
       supportsAudio: true,
       supportsVideo: true,
+      targetFormat: "openai-responses",
     },
     {
       id: "muse-spark-1.2-contributor-high",
@@ -178,6 +182,7 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVision: true,
       supportsAudio: true,
       supportsVideo: true,
+      targetFormat: "openai-responses",
     },
     {
       id: "muse-spark-1.2-contributor-xhigh",
@@ -188,6 +193,7 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVision: true,
       supportsAudio: true,
       supportsVideo: true,
+      targetFormat: "openai-responses",
     },
     // #8353: Grok 4.5 + effort tiers from the OpenCode Go registry.
     { id: "grok-4.5", name: "Grok 4.5", supportsReasoning: true },

--- a/open-sse/config/providers/registry/opencode/zen/index.ts
+++ b/open-sse/config/providers/registry/opencode/zen/index.ts
@@ -51,7 +51,25 @@ export const opencode_zenProvider: RegistryEntry = {
     { id: "grok-4.6", name: "Grok 4.6" },
 
     // ── Muse ───────────────────────────────────────────────────
-    { id: "muse-spark-1.2", name: "Muse Spark 1.2" },
+    // Muse Spark is served by OpenCode Zen only on the OpenAI Responses API
+    // endpoint, not /chat/completions (see the opencode provider's own
+    // muse-spark entries, #10874/#10867) — this provider is a separate
+    // registry entry for the same upstream and never got the same
+    // targetFormat declaration, so requests routed here still hit
+    // /chat/completions with a mismatched or unanswerable body and the
+    // upstream returns an empty message.
+    {
+      id: "muse-spark-1.2",
+      name: "Muse Spark 1.2",
+      supportsReasoning: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.2-contributor-free",
+      name: "Muse Spark 1.2 Contributor Free",
+      supportsReasoning: true,
+      targetFormat: "openai-responses",
+    },
 
     // ── DeepSeek ────────────────────────────────────────────────
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },

--- a/tests/unit/opencode-zen-muse-spark-targetformat-11046.test.ts
+++ b/tests/unit/opencode-zen-muse-spark-targetformat-11046.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { opencode_zenProvider } from "../../open-sse/config/providers/registry/opencode/zen/index.ts";
+import { opencode_goProvider } from "../../open-sse/config/providers/registry/opencode/go/index.ts";
+
+// opencode-zen and opencode-go both serve the same upstream family
+// (opencode.ai/zen/*) as the opencode provider for Muse Spark, but neither
+// got the targetFormat:"openai-responses" declaration that #10874 added to
+// the opencode provider's entries — so requests routed to either still hit
+// /chat/completions and the upstream returns an empty message.
+test("muse-spark-1.2 and muse-spark-1.2-contributor-free route to the Responses API on opencode-zen too", () => {
+  for (const id of ["muse-spark-1.2", "muse-spark-1.2-contributor-free"]) {
+    const model = opencode_zenProvider.models.find((m) => m.id === id);
+    assert.ok(model, `${id} should be registered in the opencode-zen provider`);
+    assert.equal(
+      model?.targetFormat,
+      "openai-responses",
+      `${id} must target the Responses API, not the default chat/completions pass-through`
+    );
+    assert.equal(model?.supportsReasoning, true);
+  }
+});
+
+test("all muse-spark-1.2-contributor effort-tier entries route to the Responses API on opencode-go too", () => {
+  const ids = [
+    "muse-spark-1.2-contributor",
+    "muse-spark-1.2-contributor-minimal",
+    "muse-spark-1.2-contributor-low",
+    "muse-spark-1.2-contributor-medium",
+    "muse-spark-1.2-contributor-high",
+    "muse-spark-1.2-contributor-xhigh",
+  ];
+  for (const id of ids) {
+    const model = opencode_goProvider.models.find((m) => m.id === id);
+    assert.ok(model, `${id} should be registered in the opencode-go provider`);
+    assert.equal(
+      model?.targetFormat,
+      "openai-responses",
+      `${id} must target the Responses API, not the default chat/completions pass-through`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

#10874 fixed Muse Spark on the `opencode` provider by declaring `targetFormat: "openai-responses"` on its registry entries — the model only answers on the Responses API, not `/chat/completions`. Same upstream family, two more provider registries never got the memo:

- `opencode-zen` — `muse-spark-1.2` had no `targetFormat`; `muse-spark-1.2-contributor-free` wasn't even declared.
- `opencode-go` — all 6 `muse-spark-1.2-contributor*` effort-tier entries had no `targetFormat`.

Both share the same executor (`opencode`) and the same upstream family (`opencode.ai/zen/*`) as the provider #10874 already fixed, so it's the same bug, just three separate copies of the same registry data drifting independently. Mirrored the same declaration onto both.

Left `freebuff`'s `meta/muse-spark-1.2-contributor` alone — **verified**: distinct backend (`codebuff.com`, dedicated `freebuff` executor posting to `/chat/completions`, no Responses API), so the same fix doesn't apply there.

## Related Issues

- Closes #11048

## Validation

- [x] Change type: routing (provider registry — `open-sse/config/providers/registry/opencode/{zen,go}/index.ts`)
- [x] `node --import tsx/esm --test tests/unit/opencode-zen-muse-spark-targetformat-11046.test.ts` — 2/2
- [x] Existing suites for these two registries re-run too (`opencode-zen-reasoning-effort`, `opencode-zen-alias-combo-e2e`, `auth-opencode-zen-noauth-fallback`) — 18/18 total
- [x] `npm run lint` clean
- [x] Branched from current `release/v3.8.50` tip
- [x] Test written first against the real registry data, confirmed failing, then fixed

⚠️ base-red inherited: #9985

## Tests Added Or Updated

`tests/unit/opencode-zen-muse-spark-targetformat-11046.test.ts`:
- `opencode-zen`'s `muse-spark-1.2` and `muse-spark-1.2-contributor-free` both resolve to `targetFormat: "openai-responses"`
- All 6 `opencode-go` muse-spark effort-tier entries do too

## Coverage Notes

Registry data only — no logic changes, covered by the assertions above plus the full existing test suite for both registries.

## Reviewer Notes

Didn't touch `freebuff` — **verified** it's a genuinely different backend (`codebuff.com` `/chat/completions`, dedicated executor, no Responses API involved), so the same fix doesn't apply; not a guess.

This is the second copy of this exact bug found in two days (see #11046/#11047) — same upstream registered under 3 provider entries with no shared source of truth for per-model capability flags, so a fix to one silently doesn't cover the others. Follow-up de-duplication opened as #11051 (extracts the entries that were already byte-identical across `opencode-zen`/`opencode-go` into a shared array).