### PR TITLE
fix: isolate probeBeforeSpawn adoption tests on distinct ports to stop order-dependent flake (#10523)

### DIFF
--- a/changelog.d/fixes/10523-servicesupervisor-port-flake.md
+++ b/changelog.d/fixes/10523-servicesupervisor-port-flake.md
@@ -1,0 +1,1 @@
+- fix(services): isolate probeBeforeSpawn adoption tests on distinct ports to stop the order-dependent flake (#10523)

--- a/tests/unit/services/ServiceSupervisor.test.ts
+++ b/tests/unit/services/ServiceSupervisor.test.ts
@@ -244,8 +244,16 @@ test("#6205: probeBeforeSpawn adopts a healthy existing instance (no spawn)", as
 // healthy, running service as untrustworthy/stale. This asserts the resolved
 // pid on adoption matches the real process actually holding the port.
 test("adopted service resolves and records the real pid of the process holding the port", async () => {
-  const healthServer = startHealthServer(29996);
-  const cfg = { ...tickConfig("test-adopt", 29996), probeBeforeSpawn: true };
+  // Use a distinct port from the other probeBeforeSpawn adoption test above.
+  // Both originally shared 29996, and Node's undici fetch() keep-alive pool
+  // (used by isHealthy() in portProbe.ts) caches a socket keyed only by
+  // host:port, so the second test's fetch could be replayed over a stale
+  // connection from the first test's health server instance, failing the
+  // probe and flipping the adoption into a spurious "error" state. A separate
+  // port keeps each probe isolated from the other test's pooled connection
+  // (#10523).
+  const healthServer = startHealthServer(29995);
+  const cfg = { ...tickConfig("test-adopt", 29995), probeBeforeSpawn: true };
   const sup = new ServiceSupervisor(cfg);
 
   try {


### PR DESCRIPTION
Closes #10523

**Root cause:** tests/unit/services/ServiceSupervisor.test.ts has two probeBeforeSpawn adoption tests (#6205 probeBeforeSpawn adopts at line 215, and 'adopted service resolves' at line 246) that both start a fresh health http.Server on the SAME fixed port 29996 in the same process. When the second runs after the first, Node's undici global `fetch()` used by portProbe.ts::isHealthy() pools/keeps-alive a TCP connection keyed only by host:port, so the second test's health probe can be replayed over a stale/half-closed connection from the first test's now-closed server. The probe fails while the raw TCP `isPortInUse()` probe succeeds against the live new server, so decidePreSpawn() returns the "held but unhealthy" → state 'error' branch, spilling 'running'.

This is an order-dependent test flake only — no production behavior change.

**Repro (RED → GREEN):** on origin/release/v3.8.50, the ordered run fails deterministically:
`node --import tsx/esm --test --test-name-pattern="probeBeforeSpawn adopts|adopted service resolves" tests/unit/services/ServiceSupervisor.test.ts`
→ `AssertionError: 'error' !== 'running'` (confirmed across consecutive runs).

**Fix:** give the second adoption test its own distinct port (29995) so each probe is isolated from the other test's pooled connection — the plan's preferred, zero-risk option. The regression guard is the ordered test pattern above, confirmed GREEN 3x consecutively after the change; the full ServiceSupervisor.test.ts file passes 7/7.

**Gates:** file-size OK (only pre-existing base-red on src/lib/modelCapabilities.ts, untouched); complexity OK + cognitive-complexity OK (both baseline 0 deltas); changelog-integrity OK; lint OK; typecheck:core exit 0; sibling tests (serviceSupervisorSpawnError.test.ts, portProbePid.test.ts) pass 11/11.
