### PR TITLE
fix(dashboard): treat UncloseAI as a no-auth provider so the connect form no longer forces a fake API key (#8864)

### DIFF
--- a/changelog.d/fixes/8864-uncloseai-noauth.md
+++ b/changelog.d/fixes/8864-uncloseai-noauth.md
@@ -1,0 +1,1 @@
+- fix(dashboard): treat UncloseAI as a no-auth provider so the connect form no longer forces a fake API key (#8864)

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -639,20 +639,6 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
       text: "Dahl auto-generates tokens via https://inference.dahl.global/tokens. No signup needed. Rate limits apply. You can also add your own API key.",
     },
   },
-  uncloseai: {
-    id: "uncloseai",
-    alias: "unc",
-    name: "UncloseAI",
-    icon: "auto_awesome",
-    color: "#8B5CF6",
-    textIcon: "UN",
-    website: "https://uncloseai.com",
-    hasFree: true,
-    freeNote: "Free forever — no signup, no credit card. OpenAI-compatible endpoints.",
-    passthroughModels: true,
-    authHint:
-      "No auth required. API accepts any non-empty string as key for identification. If older built-in models return 404, use Available Models → Import from /models or Auto-Sync; verified live model: solidrust/Hermes-3-Llama-3.1-8B-AWQ.",
-  },
   hackclub: {
     id: "hackclub",
     alias: "hc",

--- a/src/shared/constants/providers/noauth.ts
+++ b/src/shared/constants/providers/noauth.ts
@@ -175,6 +175,25 @@ export const NOAUTH_PROVIDERS = {
       text: "ZCode runs locally through its native app-server. OmniRoute never receives or stores the Z.ai credential.",
     },
   },
+  uncloseai: {
+    id: "uncloseai",
+    alias: "unc",
+    name: "UncloseAI",
+    icon: "auto_awesome",
+    color: "#8B5CF6",
+    textIcon: "UN",
+    website: "https://uncloseai.com",
+    noAuth: true,
+    hasFree: true,
+    passthroughModels: true,
+    serviceKinds: ["llm"],
+    authHint:
+      "No auth required. API accepts any non-empty string as key for identification. If older built-in models return 404, use Available Models → Import from /models or Auto-Sync; verified live model: solidrust/Hermes-3-Llama-3.1-8B-AWQ.",
+    freeNote: "Free forever — no signup, no credit card. OpenAI-compatible endpoints.",
+    notice: {
+      text: "UncloseAI needs no API key. API accepts any non-empty string as key for identification. If older built-in models return 404, use Available Models → Import from /models or Auto-Sync.",
+    },
+  },
   aihorde: {
     id: "aihorde",
     alias: "horde",

--- a/tests/unit/providers-constants-split.test.ts
+++ b/tests/unit/providers-constants-split.test.ts
@@ -24,7 +24,8 @@
 // (base-reds round 3, #9985) are both included in that measurement; Cursor API (specialty-media,
 // #10729) brings it to 229; Token Kiosk (gateways, #10722) — merged in the same
 // merge-train batch — independently bumped the gateways family too, landing at 231; Freebuff
-// (gateways, #10531) brings it to 232.
+// (gateways, #10531) brings it to 232. #8864 moves uncloseai (gateways family) into
+// NOAUTH_PROVIDERS, dropping the APIKEY_PROVIDERS count to 231.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -53,12 +54,12 @@ test("barrel still exports every catalog + key helpers", () => {
   }
 });
 
-test("APIKEY_PROVIDERS merges the 6 family files into 232 entries (no loss / no dup)", async () => {
+test("APIKEY_PROVIDERS merges the 6 family files into 231 entries (no loss / no dup)", async () => {
   const keys = Object.keys((P as Record<string, object>).APIKEY_PROVIDERS);
-  assert.equal(keys.length, 232);
-  assert.equal(new Set(keys).size, 232, "duplicate keys after spread-merge");
+  assert.equal(keys.length, 231);
+  assert.equal(new Set(keys).size, 231, "duplicate keys after spread-merge");
   // the merged object's entry-count equals the sum of the 6 semantic family files; families are a
-  // strict partition (every provider in exactly one), so the sum must be exactly 232.
+  // strict partition (every provider in exactly one), so the sum must be exactly 231.
   const families: [string, string][] = [
     ["gateways", "APIKEY_PROVIDERS_GATEWAYS"],
     ["frontier-labs", "APIKEY_PROVIDERS_FRONTIER"],
@@ -78,7 +79,7 @@ test("APIKEY_PROVIDERS merges the 6 family files into 232 entries (no loss / no 
       seen.add(k);
     }
   }
-  assert.equal(famTotal, 232, "families must partition all 232 providers");
+  assert.equal(famTotal, 231, "families must partition all 231 providers");
 });
 
 test("AI_PROVIDERS Proxy aggregates all sections; lookups resolve", () => {

--- a/tests/unit/providers/uncloseai-noauth.test.ts
+++ b/tests/unit/providers/uncloseai-noauth.test.ts
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { NOAUTH_PROVIDERS, providerAllowsOptionalApiKey } from "@/shared/constants/providers";
+
+test("uncloseai should be treated as a no-auth provider", () => {
+  const isNoAuthRegistered = Object.prototype.hasOwnProperty.call(NOAUTH_PROVIDERS, "uncloseai");
+  const allowsOptionalKey = providerAllowsOptionalApiKey("uncloseai");
+
+  assert.equal(
+    isNoAuthRegistered || allowsOptionalKey,
+    true,
+    "uncloseai must be registered in NOAUTH_PROVIDERS or allow an optional API key " +
+      "so the dashboard doesn't force users to enter a key for a no-auth provider"
+  );
+  assert.equal(
+    isNoAuthRegistered,
+    true,
+    "uncloseai must be registered in NOAUTH_PROVIDERS (not just allow an optional key) " +
+      "so the dashboard renders the NoAuthProviderControls flow"
+  );
+});


### PR DESCRIPTION
Closes #8864

## Root cause
UncloseAI's dashboard metadata lived in the API-key-provider registry (`src/shared/constants/providers/apikey/gateways.ts`) instead of the no-auth registry (`src/shared/constants/providers/noauth.ts`), even though its executor entry (`open-sse/config/providers/registry/uncloseai/index.ts`) already declares `authType: "optional"` — the backend genuinely needs no key. Because `providerAllowsOptionalApiKey()` and the dashboard's `isFreeNoAuth` gate (`ProviderDetailPageClient.tsx`) only recognize providers in `NOAUTH_PROVIDERS` or the explicit optional-key allow-list, the Add/Edit-connection UI forced users through the API-key flow for a provider that needs none — exactly the reporter's complaint.

## Fix
Moved the `uncloseai` entry from `gateways.ts` to `NOAUTH_PROVIDERS` in `noauth.ts` (modeled after `aihorde`: `noAuth: true`, `hasFree`, `passthroughModels`, `serviceKinds: ['llm']`, keeping the original `freeNote`/prose). `ProviderDetailPageClient` now renders `NoAuthProviderControls` instead of the API-key form for uncloseai, matching `aihorde`/`opencode`. No provider-id collision — every consumer keys off the id `uncloseai`, which migrated cleanly; existing users who stored a dummy key keep working since the executor is `authType: "optional"` regardless of registry placement. Consumers verified: combos/builderOptions, freeOnboarding, freeProviderRankings, catalog, ModelSelectModal, noAuthProviders, providerCredentialRequirement.

## Regression test
`tests/unit/providers/uncloseai-noauth.test.ts` (was RED on base, now GREEN). Aligned `tests/unit/providers-constants-split.test.ts` APIKEY_PROVIDERS count 232→231 (uncloseai migrated to NOAUTH — a legit contract change, not a weakened assertion).

## Gates
- repro test: RED → GREEN
- focused + related no-auth/provider tests: 53 pass
- `npm run typecheck:core`: clean
- eslint (changed files, suppressions flag): clean
- complexity + cognitive-complexity ratchets: OK
- file-size: no ✗ on touched files (pre-existing base-red on `src/lib/modelCapabilities.ts` only)
- changelog-integrity: OK (fragment `changelog.d/fixes/8864-uncloseai-noauth.md`)

⚠️ base-red inherited: #9985. A local full-suite run on the heavily-loaded devbox (load avg 43-50) showed only inherited/environmental failures — none on files touched by this diff (only provider metadata in `gateways.ts`/`noauth.ts`): #9147 event-loop timing test, chatcore attempt-logging / call-log DB tests (load timeouts), and cli-setup-opencode / setup-qwen setup tests (reproduced identically on the clean base tip).