### PR TITLE
fix: add static model catalog for v0-vercel-web web-cookie provider (#10990)

### DIFF
--- a/changelog.d/fixes/10990-v0-vercel-web-static-catalog.md
+++ b/changelog.d/fixes/10990-v0-vercel-web-static-catalog.md
@@ -1,0 +1,1 @@
+- **Static model catalog for v0-vercel-web:** seed a static catalog for the v0-vercel-web web-cookie provider (v0-1.0-md, v0-1.5-lg, v0-1.5-md) so its dashboard "Available Models" / "Import from /models" UI serves a usable list instead of falling through to the route's 400 "does not support models listing" ([#10990](https://github.com/diegosouzapw/OmniRoute/issues/10990)).

--- a/src/lib/providers/staticModels.ts
+++ b/src/lib/providers/staticModels.ts
@@ -99,6 +99,15 @@ const STATIC_MODEL_PROVIDERS: Record<string, () => Array<{ id: string; name: str
     { id: "google_scholar", name: "Google Scholar" },
     { id: "duckduckgo", name: "DuckDuckGo" },
   ],
+  "v0-vercel-web": () => [
+    // v0-vercel-web web-cookie codegen provider — no upstream /v1/models endpoint,
+    // no registry `models` and no discovery config, so seed the current v0 lineup
+    // as a static catalog mirroring the v0-vercel API provider (shared.ts) so the
+    // model-import UI serves a list instead of the tail 400 (#10990).
+    { id: "v0-1.0-md", name: "V0 1.0 MD" },
+    { id: "v0-1.5-lg", name: "V0 1.5 LG" },
+    { id: "v0-1.5-md", name: "V0 1.5 MD" },
+  ],
   "venice-web": () => [
     // Venice.ai web-cookie provider — no upstream /v1/models endpoint, so seed the
     // current lineup as a static catalog (#6269). Venice rotates its catalog; keep

--- a/tests/unit/repro-10990-v0-vercel-web-static-models.test.ts
+++ b/tests/unit/repro-10990-v0-vercel-web-static-models.test.ts
@@ -1,0 +1,25 @@
+/**
+ * #10990 — v0-vercel-web (a web-cookie codegen provider) shipped a web-cookie
+ * executor but no registry `models`, no discovery config, and no static-catalog
+ * entry, so its "Import from /models" fell through to the models route's tail 400
+ * ("Provider v0-vercel-web does not support models listing"). Adding a
+ * `v0-vercel-web` entry to STATIC_MODEL_PROVIDERS gives the models route a local
+ * catalog to serve (same class as the #6269 venice-web / #7820 amazon-q fix).
+ *
+ * Kept as a standalone unit against the pure `getStaticModelsForProvider` resolver
+ * rather than extending the frozen `provider-models-route.test.ts` god-file.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getStaticModelsForProvider } from "../../src/lib/providers/staticModels.ts";
+
+test("#10990 v0-vercel-web resolves a non-empty static local catalog", () => {
+  const models = getStaticModelsForProvider("v0-vercel-web");
+  assert.ok(models && models.length > 0, "v0-vercel-web should expose a static catalog");
+  const ids = models.map((m) => m.id);
+  assert.ok(
+    ids.includes("v0-1.5-lg"),
+    `expected v0-1.5-lg in [${ids.join(", ")}]`
+  );
+});


### PR DESCRIPTION
Closes #10990

## Root cause
v0-vercel-web (a web-cookie codegen provider registered in src/shared/constants/providers/web-cookie.ts:301, executor open-sse/executors/v0-vercel-web.ts) has no registry `models`, no discovery config (no PROVIDER_MODELS_CONFIG entry, no discoverable /v1/models URL), and no entry in STATIC_MODEL_PROVIDERS. On the models route (src/app/api/providers/[id]/models/route.ts) both `registryCatalogModels` (getModelsByProviderId -> []) and `specialtyCatalogModels` (getStaticModelsForProvider -> undefined) are empty, so localCatalog stays empty and the route's `if (!config)` tail branch returns the hard 400 "Provider v0-vercel-web does not support models listing". "Import from /models" in the dashboard therefore fails.

## Fix
Seed a static catalog for v0-vercel-web in STATIC_MODEL_PROVIDERS (src/lib/providers/staticModels.ts), mirroring the established precedent for web-cookie/codegen providers with no /v1/models endpoint (venice-web #6269, amazon-q #7820, jules #5569). The lineup (v0-1.0-md, v0-1.5-lg, v0-1.5-md) mirrors the v0-vercel API provider list in open-sse/config/providers/shared.ts:377. The v0-vercel-web executor forwards any model id (default "v0-default") to https://v0.dev/api/chat, so an unknown listed id still attempts a request rather than hard-failing.

Note: I did NOT use the providerLacksModelListing gate suggested by the reporter — that gate only covers tool-only providers and returns false for this LLM provider; the static catalog is the correct fix.

## Regression test
- TDD: RED first (actual: undefined) then GREEN after the fix on `tests/unit/repro-10990-v0-vercel-web-static-models.test.ts` (asserts a non-empty catalog containing v0-1.5-lg).
- Sibling static-catalog tests pass (venice-web #6269, amazon-q #7820, devin #6142, search-providers #7529).
- provider-models-route.test.ts: 59/59 pass.

## Gates
file-size (my diff only touches staticModels.ts + new test), complexity (OK 2618 ≤ 2774), cognitive-complexity (OK 1179 ≤ 1223), changelog-integrity (OK), typecheck:core (exit 0), eslint (0) — all green on my diff.

⚠️ base-red inherited: #9985 (release/v3.8.50 base tip not green). Pre-existing, reproduced on origin/release/v3.8.50, NOT touched by this diff: file-size gate flags src/lib/modelCapabilities.ts (1072 > frozen 1016, already ~1071 lines on the clean base tip). Other shared base-red drifts (docs-sync i18n, agent-skills-sync, open-sse-typecheck, public-creds, secrets, mutation coverage, i18nUiCoverage) known from #9985.