### PR TITLE
fix(cli): scoping android instrumentation-hook diagnosis to real platform signal (#10028)

### DIFF
--- a/bin/cli/utils/ensureAndroidCacheDir.mjs
+++ b/bin/cli/utils/ensureAndroidCacheDir.mjs
@@ -94,10 +94,15 @@ export function ensureAndroidCacheDir(options = {}) {
  */
 export function isFatalInstrumentationHookFailure(text) {
   if (!text) return false;
-  return (
-    /Unsupported platform:\s*android/i.test(text) ||
-    /error occurred while loading instrumentation hook/i.test(text)
-  );
+  // Next.js wraps ANY throw inside instrumentation.register() with the generic
+  // "An error occurred while loading instrumentation hook:" prefix, on every
+  // platform (node_modules/next/dist/server/web/globals.js). That prefix alone
+  // therefore cannot identify the Android/Termux cache-probe failure — a bare
+  // generic instrumentation error on win32/desktop would be misreported as the
+  // Android bug and hide the real cause. Only match when the text actually
+  // carries the Android platform marker that Next's getCacheDirectory() emits.
+  // #10028
+  return /Unsupported platform:\s*android/i.test(text);
 }
 
 /**

--- a/changelog.d/fixes/10028-windows-instrumentation-hook.md
+++ b/changelog.d/fixes/10028-windows-instrumentation-hook.md
@@ -1,0 +1,1 @@
+- fix(cli): stop diagnosing every Next.js instrumentation-hook failure as the Android/Termux cache bug — only the Android "Unsupported platform: android" signal now triggers the Android hint, so a win32/desktop instrumentation error surfaces its real cause instead of a useless `mkdir -p ~/.cache` (#10028)

--- a/tests/unit/termux-android-cache-dir.test.ts
+++ b/tests/unit/termux-android-cache-dir.test.ts
@@ -166,6 +166,19 @@ test("isFatalInstrumentationHookFailure: matches Next.js android + hook errors",
   assert.equal(isFatalInstrumentationHookFailure(""), false);
 });
 
+test("isFatalInstrumentationHookFailure: BUG #10028 — generic non-Android instrumentation failure is not Android/Termux", () => {
+  // Next.js wraps ANY throw inside instrumentation.register() with the generic
+  // "An error occurred while loading instrumentation hook:" prefix, on every
+  // platform. Without an actual Android/"Unsupported platform:" signal, that
+  // generic wrapper must NOT be diagnosed as the Android/Termux cache-dir bug,
+  // or a plain win32/desktop failure gets a useless `mkdir -p ~/.cache` hint
+  // and the real cause is hidden.
+  const genericWindowsFailure =
+    "Error: An error occurred while loading instrumentation hook: " +
+    "Cannot find module 'C:\\Users\\dev\\.omniroute\\config.json'";
+  assert.equal(isFatalInstrumentationHookFailure(genericWindowsFailure), false);
+});
+
 test("formatAndroidInstrumentationFailureHint: names the cache dir and TERMUX_GUIDE", () => {
   const hint = formatAndroidInstrumentationFailureHint("/data/home/.cache");
   assert.match(hint, /\/data\/home\/\.cache/);


### PR DESCRIPTION
Closes #10028

## Root cause
`isFatalInstrumentationHookFailure()` in `bin/cli/utils/ensureAndroidCacheDir.mjs` OR'd two regexes:
1. `/Unsupported platform:\s*android/i` — correctly Android-specific.
2. `/error occurred while loading instrumentation hook/i` — matches Next.js's *generic* error wrapper, which fires for ANY exception thrown inside `instrumentation.register()`, on ANY platform (`node_modules/next/dist/server/web/globals.js` prepends `An error occurred while loading instrumentation hook: ` to every `err.message`).

So on Windows (or any desktop OS), if the instrumentation hook throws for any unrelated reason (missing config, path resolution, permissions), the CLI confidently diagnosed it as the Android/Termux cache-dir bug and printed a hopeless `mkdir -p ~/.cache` / TERMUX_GUIDE hint — hiding the real underlying error. Introduced whole in PR #8593 (fixing #8519) and never scoped to an actual Android signal.

#8519/#7265 are genuine Android/Termux cache-dir probe failures; win32 is not hit by that path. This is a separate defect in OmniRoute's own diagnostic code.

## Fix
`isFatalInstrumentationHookFailure()` now matches only the actual Android platform marker that Next's `getCacheDirectory()` emits (`Unsupported platform: android`). The generic instrumentation-hook prefix alone no longer triggers the Android/Termux hint. The real underlying error text is still surfaced to the operator via `process.stderr.write/`stdout.write` before the check — unchanged.

## Regression test (TDD)
RED → GREEN in `tests/unit/termux-android-cache-dir.test.ts`:
- New test: a generic non-Android instrumentation-hook failure (`Error: An error occurred while loading instrumentation hook: Cannot find module 'C:\Users\dev\.omniroute\config.json'`) must NOT be diagnosed as Android/Termux (returns `false`).
- Existing true-positive Android/Termux cases in the same file keep passing.

## Gates
- termux-android-cache-dir.test.ts: 17/17 pass (incl. new regression)
- serve/supervisor sibling tests: 36/36 pass
- complexidade + cognitive-complexity: OK (below frozen baselines)
- typecheck:core exit 0
- eslint (suppressions flag): exit 0
- changelog-integrity: OK
- file-size: no touched file flagged

⚠️ base-red inherited: #9985 — pre-existing file-size drift on `src/lib/modelCapabilities.ts` (not touched by this diff) shows on the base tip.