### PR TITLE
fix(providers): deprecate blackbox provider since api.blackbox.ai returns 404 (#10997)

### DIFF
--- a/changelog.d/fixes/10997-blackbox-deprecation.md
+++ b/changelog.d/fixes/10997-blackbox-deprecation.md
@@ -1,0 +1,1 @@
+- fix(providers): mark the blackbox provider deprecated — api.blackbox.ai returns HTTP 404 on every path variant (sweep 2026-08-21), so the public inference surface is dead and the catalog entry now carries a deprecation notice. ([#10997](https://github.com/diegosouzapw/OmniRoute/issues/10997))

--- a/open-sse/config/providers/registry/blackbox/index.ts
+++ b/open-sse/config/providers/registry/blackbox/index.ts
@@ -5,6 +5,12 @@ export const blackboxProvider: RegistryEntry = {
   alias: "bb",
   format: "openai",
   executor: "default",
+  // NOTE: api.blackbox.ai returns HTTP 404 on /v1/chat/completions and /v1/models
+  // (empty body, all path variants) since sweep 2026-08-21; the public inference
+  // surface has moved to the gated enterprise.blackbox.ai/v1 endpoint. The provider
+  // is marked deprecated in src/shared/constants/providers/apikey/frontier-labs.ts —
+  // this registry entry is kept intact (registration/execution unaffected), so
+  // existing configured keys keep working if a restored/enterprise host is reachable.
   baseUrl: "https://api.blackbox.ai/v1/chat/completions",
   modelsUrl: "https://api.blackbox.ai/v1/models",
   authType: "apikey",

--- a/src/shared/constants/providers/apikey/frontier-labs.ts
+++ b/src/shared/constants/providers/apikey/frontier-labs.ts
@@ -91,6 +91,11 @@ export const APIKEY_PROVIDERS_FRONTIER = {
     hasFree: true,
     freeNote:
       "Limited free access is available through Blackbox; model availability and account limits apply",
+    subscriptionRisk: true,
+    riskNoticeVariant: "deprecated",
+    deprecated: true,
+    deprecationReason:
+      "api.blackbox.ai returns HTTP 404 on every path variant (sweep 2026-08-21); the public inference surface has moved to the gated enterprise.blackbox.ai/v1 endpoint.",
   },
   xai: {
     id: "xai",

--- a/tests/unit/blackbox-deprecation-probe.test.ts
+++ b/tests/unit/blackbox-deprecation-probe.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const blackboxRegistryPath = join(
+  __dirname,
+  "../../open-sse/config/providers/registry/blackbox/index.ts",
+);
+const blackboxMetaPath = join(
+  __dirname,
+  "../../src/shared/constants/providers/apikey/frontier-labs.ts",
+);
+
+test("probe: blackbox runtime registry still points at api.blackbox.ai (bug present)", () => {
+  const src = readFileSync(blackboxRegistryPath, "utf8");
+  assert.match(src, /api\.blackbox\.ai\/v1\/chat\/completions/);
+  assert.match(src, /api\.blackbox\.ai\/v1\/models/);
+});
+
+test("guard: blackbox metadata is marked deprecated because api.blackbox.ai is dead", () => {
+  const meta = readFileSync(blackboxMetaPath, "utf8");
+  const block = meta.split(/\n\s*blackbox:\s*\{/)[1]?.split(/\n\s*\w+:\s*\{/)[0] ?? "";
+  assert.ok(block.includes("deprecated: true"));
+  assert.ok(block.includes('riskNoticeVariant: "deprecated"'));
+  assert.ok(block.includes("deprecationReason"));
+});


### PR DESCRIPTION
Closes #10997

The `blackbox` provider's upstream `api.blackbox.ai` now returns HTTP 404 (empty body) on every path variant — `GET /v1/models`, `POST /v1/chat/completions` with both bare (`gpt-5.5`) and `blackboxai/openai/gpt-5.5` model ids (curl-verified against the resolved host 35.241.5.35). `enterprise.blackbox.ai` is live but gated (403), `www.blackbox.ai` is the marketing site. The public inference surface has pivoted away from `api.blackbox.ai`.

Fix mirrors the `galadriel` precedent: mark the blackbox metadata entry `deprecated: true` + `riskNoticeVariant: "deprecated"` + `subscriptionRisk` + a `deprecationReason` (display/sort flag only — never blocks registration or execution, so existing configured keys are functionally unaffected). Registry entry untouched beyond a code comment.

TDD regression guard: `tests/unit/blackbox-deprecation-probe.test.ts` asserts blackbox is now marked deprecated.

Gates: typecheck:core exit 0; eslint clean; changelog-integrity OK; 171 sibling catalog/provider tests pass; curl 404 evidence above.

⚠️ base-red inherited: #9985