### PR TITLE
fix(resilience): honor shared passthrough providers

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -31,7 +31,7 @@ import {
   looksLikeQuotaExhausted,
   type FailureKind,
 } from "../../src/shared/utils/classify429";
-import { resolveProviderId } from "../../src/shared/constants/providers";
+import { getProviderById, resolveProviderId } from "../../src/shared/constants/providers";
 import { resolveUseUpstream429BreakerHints } from "../../src/shared/utils/providerHints";
 import { getCodexModelScope } from "../config/codexQuotaScopes.ts";
 import { getQuotaScopedModelForProvider } from "./antigravityQuotaFamily.ts";
@@ -711,6 +711,8 @@ export function hasPerModelQuota(
   if (getCanonicalLockProvider(provider) === "codex") return true;
   if (provider === "gemini" || provider === "github") return true;
   if (getPassthroughProviders().has(provider)) return true;
+  const sharedProvider = getProviderById(resolveProviderId(provider));
+  if (sharedProvider?.passthroughModels === true) return true;
   if (isCompatibleProvider(provider)) return true;
   return false;
 }

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -435,6 +435,13 @@ test("hasPerModelQuota returns true for GitHub Copilot provider (#1624)", () => 
   assert.equal(hasPerModelQuota("github", "gpt-5-mini"), true);
 });
 
+test("hasPerModelQuota honors shared passthrough provider metadata (#11071)", () => {
+  assert.equal(hasPerModelQuota("ollama-local"), true);
+  assert.equal(hasPerModelQuota("lm-studio"), true);
+  assert.equal(hasPerModelQuota("vllm"), true);
+  assert.equal(hasPerModelQuota("mlx-gemma"), false);
+});
+
 test("Codex Spark 429s are scoped away from normal Codex models", () => {
   const connectionId = `codex-${Date.now()}`;
   clearModelLock("codex", connectionId, "gpt-5.3-codex-spark");


### PR DESCRIPTION
## Summary
- Resolve passthrough-model metadata from the shared provider registry when deciding whether failures are model-scoped.
- Keep Ollama, LM Studio, vLLM, and other shared passthrough providers from turning a missing model into a connection-wide cooldown.
- Add a focused regression test covering passthrough and non-passthrough local providers.

## Root cause
`hasPerModelQuota()` only consulted the Open-SSE registry and compatible-provider rules. Local providers such as `ollama-local` define `passthroughModels: true` in the shared registry, so their model-not-found failures fell through to connection-wide cooldown handling.

## Verification
- `node --import tsx/esm --test tests/unit/account-fallback-service.test.ts` — 78 passed
- Regression sabotage run — new test fails without the production change and passes with it
- `npm run test:vitest` — 34 files, 291 tests passed
- `npm run typecheck:core` — passed
- `npm run lint` — passed with 6 pre-existing warnings and 0 errors

## Local limitations
- `npm run test:unit` exceeded the local 420-second tool limit; CI should complete the full suite.
- `npm run build` exited during the Turbopack compile phase without a diagnostic; typecheck and focused tests passed, so CI build remains the authoritative result.

## Risk
Low. The change only broadens existing model-lockout classification to providers already declaring `passthroughModels: true`; explicit connection-level overrides still take precedence.

Closes #11071
