### PR TITLE
fix(ratelimit): keep operator minTime floor when relaxing limiter on headroom (#9763)

### DIFF
--- a/changelog.d/fixes/9763-ratelimit-mintime-floor.md
+++ b/changelog.d/fixes/9763-ratelimit-mintime-floor.md
@@ -1,0 +1,1 @@
+- **fix(ratelimit):** respect operator `minTimeBetweenRequestsMs` floor when relaxing the limiter on headroom — the adaptive rate-limit learning no longer silently erases a configured minimum gap between requests when the upstream reports plenty of remaining capacity ([#9763](https://github.com/diegosouzapw/OmniRoute/issues/9763)).

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -756,7 +756,7 @@ export function updateFromHeaders(provider, connectionId, headers, status, model
         );
       } else if (remaining > limit * 0.5) {
         // Plenty of headroom — relax the limiter
-        updates.minTime = 0;
+        updates.minTime = resolveMinTime(currentRequestQueueSettings.minTimeBetweenRequestsMs);
         updates.reservoir = null;
         updates.reservoirRefreshAmount = null;
         updates.reservoirRefreshInterval = null;

--- a/tests/unit/rateLimitManager-mintime-floor-9763.test.ts
+++ b/tests/unit/rateLimitManager-mintime-floor-9763.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const rlm = await import("../../open-sse/services/rateLimitManager.ts");
+const {
+  enableRateLimitProtection,
+  withRateLimit,
+  updateFromHeaders,
+  applyRequestQueueSettings,
+  __setLimiterFactoryForTests,
+  __resetRateLimitManagerForTests,
+} = rlm;
+
+test.beforeEach(async () => {
+  await __resetRateLimitManagerForTests();
+});
+
+test("headroom relaxation respects operator minTimeBetweenRequestsMs floor (#9763)", async () => {
+  // Apply an operator-configured minTime floor of 200ms
+  await applyRequestQueueSettings({
+    minTimeBetweenRequestsMs: 200,
+    concurrentRequests: 0,
+    requestsPerMinute: 0,
+    maxWaitMs: 30000,
+    autoEnableApiKeyProvider: false,
+  });
+
+  let capturedMinTime: number | undefined;
+
+  // Inject a fake limiter whose updateSettings captures the minTime.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const noop = (): any => undefined;
+
+  __setLimiterFactoryForTests(() => {
+    const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+    const fake = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateSettings(updates: Record<string, any>) {
+        capturedMinTime = typeof updates.minTime === "number" ? updates.minTime : undefined;
+        return fake;
+      },
+      on(event: string, fn: (...args: unknown[]) => void) {
+        (listeners[event] ??= []).push(fn);
+        return fake;
+      },
+      schedule(arg0: unknown, arg1?: unknown) {
+        const fn = typeof arg1 === "function" ? arg1 : typeof arg0 === "function" ? arg0 : noop;
+        return fn();
+      },
+      disconnect() {
+        return Promise.resolve();
+      },
+      chain() {
+        return fake;
+      },
+      counts() {
+        return { RECEIVED: 0, QUEUED: 0, RUNNING: 0, EXECUTING: 0 };
+      },
+      currentReservoir() {
+        return Promise.resolve(null);
+      },
+      stop() {
+        return Promise.resolve();
+      },
+    };
+    return fake;
+  });
+
+  enableRateLimitProtection("test-mintime-floor");
+
+  // Materialize the limiter with a dummy request
+  await withRateLimit("openai", "test-mintime-floor", "gpt-4", async () => "ok");
+
+  // Simulate a response with plenty of headroom: remaining=80 > limit*0.5=50
+  const headers = new Headers({
+    "x-ratelimit-limit-requests": "100",
+    "x-ratelimit-remaining-requests": "80",
+  });
+  updateFromHeaders("openai", "test-mintime-floor", headers, 200, "gpt-4");
+
+  // The operator configured minTime=200, so headroom relaxation MUST NOT
+  // override it to 0. Before the fix, capturedMinTime === 0 (RED).
+  assert.strictEqual(
+    capturedMinTime,
+    200,
+    `Expected minTime=200 (operator floor), got ${capturedMinTime}`
+  );
+});


### PR DESCRIPTION
Fixes #9763.

### What

`updateFromHeaders` in `open-sse/services/rateLimitManager.ts` learns rate limits from upstream `x-ratelimit-*` headers. In the "plenty of headroom" branch (`remaining > limit * 0.5`) it relaxed the limiter by setting `updates.minTime = 0` unconditionally:

```ts
} else if (remaining > limit * 0.5) {
  // Plenty of headroom — relax the limiter
  updates.minTime = 0;   // <-- overrides the operator's configured floor
  updates.reservoir = null;
  ...
}
```

That `0` overwrites `resilienceSettings.requestQueue.minTimeBetweenRequestsMs` — the minimum gap an operator explicitly configures (for example, to protect a sensitive self-hosted upstream). The override happens silently and persists for the life of the limiter, so a single well-provisioned response effectively disables the operator's throttle until the next restart. That is the behavior reported in #9763.

Notably the module already resolves that floor everywhere else through `resolveMinTime(...)` — `buildLimiterDefaults()` uses `resolveMinTime(currentRequestQueueSettings.minTimeBetweenRequestsMs)`, and the RPM-derived assignment a few lines above already clamps with `Math.max(0, ...)`. Only this headroom branch bypassed the floor.

### Fix

Relax toward the configured floor instead of a hard `0`:

```ts
updates.minTime = resolveMinTime(currentRequestQueueSettings.minTimeBetweenRequestsMs);
```

`resolveMinTime` returns `0` when no floor is configured, so the default (no operator throttle) behavior is unchanged. When a floor is set, headroom still lifts learned throttling down to — but never below — the operator's minimum spacing. Reservoir relaxation is untouched.

### Test

New `tests/unit/rateLimitManager-mintime-floor-9763.test.ts` sets an operator floor of 200ms via `applyRequestQueueSettings`, injects a spy limiter through the existing `__setLimiterFactoryForTests` hook, drives a headroom response (`limit=100, remaining=80`) through `updateFromHeaders`, and asserts the limiter's `minTime` stays at 200. It fails on the current base (observed `got 0`) and passes with this change. The three existing tests in `rateLimitManager-update-sequencing.test.ts` only exercise the retry-after path, so this branch was previously uncovered.

Verified on the `release/v3.8.50` base:
- new + sequencing + headers-split: 11/11 pass
- broader ratelimit sweep (idle-eviction, queue-timeout, reservoir-refresh, headers-split): 18/18 pass
- RED without the fix, GREEN with it.

### Changelog

Adds `changelog.d/fixes/9763-ratelimit-mintime-floor.md`.
