### PR TITLE
fix(sse): classify RFC1918 and .local hosts as local providers

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -10,6 +10,7 @@ export {
 } from "./providers/registry/alibaba/index.ts";
 export { REGISTRY } from "./providers/index.ts";
 import { REGISTRY } from "./providers/index.ts";
+import { isPrivateHost } from "@/shared/network/outboundUrlGuard";
 import {
   RegistryModel,
   REASONING_UNSUPPORTED,
@@ -126,17 +127,31 @@ const LOCAL_HOSTNAMES = new Set([
  *
  * Operators can extend via LOCAL_HOSTNAMES env var (comma-separated) for Docker
  * hostnames (e.g., LOCAL_HOSTNAMES=omlx,mlx-audio).
+ *
+ * #11091 — this previously matched only `localhost`, `127.0.0.1` and 172.16.0.0/12,
+ * which misses most of the address space a self-hosted LLM box actually lives on
+ * (192.168/16, 10/8, CGNAT/Tailscale 100.64/10, and `.local` mDNS names). A LAN
+ * Ollama/LM Studio host therefore failed this check and a 404 for one missing model
+ * cooled the WHOLE connection instead of locking out just that model — the exact
+ * opposite of what a multi-host setup needs. Delegate to `isPrivateHost`, which is
+ * this codebase's existing definition of a private host, instead of maintaining a
+ * second narrower one.
+ *
+ * Deliberately NOT an SSRF control: the sole caller is the 404 model-lockout branch
+ * in `src/sse/services/auth.ts`, which gates no outbound request. `isPrivateHost`
+ * fails CLOSED (empty host ⇒ private) because it guards egress; this helper must
+ * fail OPEN, so an unparseable URL or empty hostname still returns false.
+ *
+ * Custom LAN suffixes that are not IP literals and not `.local`/`.internal`
+ * (e.g. `studio.lan`) still need LOCAL_HOSTNAMES — they are indistinguishable
+ * from public hostnames without resolving them.
  */
 export function isLocalProvider(baseUrl?: string | null): boolean {
   if (!baseUrl) return false;
   try {
-    const url = new URL(baseUrl);
-    const hostname = url.hostname;
-    // Strictly matching 172.16.0.0/12 (Docker/local) and explicitly blocking ::1 per SSRF hardening
-    return (
-      LOCAL_HOSTNAMES.has(hostname) ||
-      /^172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(hostname)
-    );
+    const hostname = new URL(baseUrl).hostname;
+    if (!hostname) return false;
+    return LOCAL_HOSTNAMES.has(hostname) || isPrivateHost(hostname);
   } catch {
     return false;
   }

--- a/tests/unit/local-provider-lan-detection-11091.test.ts
+++ b/tests/unit/local-provider-lan-detection-11091.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isLocalProvider } from "../../open-sse/config/providerRegistry.ts";
+
+// #11091 — isLocalProvider() gates the 404 model-only lockout in
+// src/sse/services/auth.ts. It used to match only localhost / 127.0.0.1 /
+// 172.16.0.0/12, so a self-hosted backend on a normal LAN was classified as
+// remote and one missing model cooled the entire connection.
+
+test("classifies RFC1918 LAN hosts as local", () => {
+  for (const host of [
+    "http://192.168.1.50:11434/v1",
+    "http://192.168.0.15:11434/v1",
+    "http://10.10.0.181:11434/v1",
+    "http://10.0.0.1:1234/v1",
+    "http://172.16.0.1:11434/v1",
+    "http://172.31.255.254:11434/v1",
+  ]) {
+    assert.equal(isLocalProvider(host), true, `expected local: ${host}`);
+  }
+});
+
+test("classifies CGNAT/Tailscale and link-local hosts as local", () => {
+  assert.equal(isLocalProvider("http://100.64.0.1:11434/v1"), true);
+  assert.equal(isLocalProvider("http://100.127.255.254:11434/v1"), true);
+  assert.equal(isLocalProvider("http://169.254.1.1:11434/v1"), true);
+});
+
+test("classifies mDNS and reserved private suffixes as local", () => {
+  assert.equal(isLocalProvider("http://studio.local:11434/v1"), true);
+  assert.equal(isLocalProvider("http://box.internal:11434/v1"), true);
+  assert.equal(isLocalProvider("http://dev.localhost:11434/v1"), true);
+});
+
+test("keeps the previously supported loopback forms local", () => {
+  assert.equal(isLocalProvider("http://localhost:11434/v1"), true);
+  assert.equal(isLocalProvider("http://127.0.0.1:11434/v1"), true);
+  assert.equal(isLocalProvider("http://[::1]:11434/v1"), true);
+});
+
+test("classifies IPv6 unique-local and link-local hosts as local", () => {
+  assert.equal(isLocalProvider("http://[fd00::1]:11434/v1"), true);
+  assert.equal(isLocalProvider("http://[fe80::1]:11434/v1"), true);
+});
+
+test("does NOT classify public hosts as local", () => {
+  for (const host of [
+    "https://api.openai.com/v1",
+    "https://generativelanguage.googleapis.com/v1beta",
+    "http://8.8.8.8:11434/v1",
+    "http://172.15.0.1:11434/v1", // just below the 172.16/12 range
+    "http://172.32.0.1:11434/v1", // just above the 172.16/12 range
+    "http://100.63.255.255:11434/v1", // just below the 100.64/10 range
+    "http://192.169.1.1:11434/v1", // just outside 192.168/16
+  ]) {
+    assert.equal(isLocalProvider(host), false, `expected non-local: ${host}`);
+  }
+});
+
+test("fails open on missing or unparseable input", () => {
+  // isPrivateHost() fails CLOSED (empty host => private) because it guards
+  // egress. isLocalProvider() must fail OPEN — it only widens a lockout scope.
+  assert.equal(isLocalProvider(null), false);
+  assert.equal(isLocalProvider(undefined), false);
+  assert.equal(isLocalProvider(""), false);
+  assert.equal(isLocalProvider("not a url"), false);
+  assert.equal(isLocalProvider("file:///models"), false);
+});


### PR DESCRIPTION
Fixes #11091

## Problem

`isLocalProvider()` (`open-sse/config/providerRegistry.ts`) matched only
`localhost`, `127.0.0.1` and `172.16.0.0/12` — missing most of the address space a
self-hosted LLM box actually lives on.

Its **sole caller** is the 404 model-lockout branch at `src/sse/services/auth.ts:2955`:

```ts
if (isLocalProvider(connBaseUrl) && status === 404 && provider && model) {
  // model-only lockout — connection stays active
```

So a LAN-hosted Ollama/LM Studio/vLLM connection failed the check and a 404 for one
missing model cooled the **entire connection** rather than locking out just that model.
On a multi-host setup where each host deliberately holds a different model subset, the
missing-model 404 is the *expected* case — one lookup took a whole host offline.

## Fix

Delegate to `isPrivateHost()` (`src/shared/network/outboundUrlGuard.ts`) — this
codebase's existing definition of a private host — instead of maintaining a second,
narrower one. `LOCAL_HOSTNAMES` stays as an additive escape hatch.

Now correctly classified as local: `192.168/16`, `10/8`, `100.64/10` (CGNAT/Tailscale),
`169.254/16`, IPv6 ULA/link-local/`::1`, and `.local` / `.internal` / `.localhost` names.

Two deliberate asymmetries, both covered by tests:

- `isPrivateHost()` fails **closed** (empty host ⇒ private) because it guards egress.
  `isLocalProvider()` must fail **open** — it only widens a lockout scope and gates no
  outbound request — so an empty or unparseable hostname still returns `false`.
- Custom LAN suffixes that are neither IP literals nor `.local`/`.internal`
  (e.g. `studio.lan`) still need `LOCAL_HOSTNAMES`; they are indistinguishable from
  public hostnames without resolving them.

## Blast radius

There are two different `isLocalProvider` functions in the tree. The **`providerId`**
variant (`src/shared/constants/providers.ts`) is untouched — it has three callers
(`providerHints.ts`, `validation.ts`, `validation/webCookie.ts`) and existing coverage in
`ollama-local-provider.test.ts` / `provider-validation-specialty.test.ts`.

This PR changes only the **`baseUrl`** variant, whose full caller set is the single
`auth.ts:2955` line above. The function's doc comment also claimed use for "health check
targets"; that is stale — no such caller exists.

## Validation

TDD per Hard Rule #18. The 7 new cases in
`tests/unit/local-provider-lan-detection-11091.test.ts` were checked against the old
predicate first — it misclassified **9/9** local hosts as remote (`192.168.1.50`,
`10.10.0.181`, `10.0.0.1`, `100.64.0.1`, `169.254.1.1`, `studio.local`, `box.internal`,
`[::1]`, `[fd00::1]`), and all pass after the change. Boundary cases are asserted in both
directions (`172.15`/`172.32`, `100.63`, `192.169` stay non-local).

- `node --import tsx/esm --test tests/unit/local-provider-lan-detection-11091.test.ts` — 7 passed
- `node --import tsx/esm --test tests/unit/ollama-local-provider.test.ts tests/unit/provider-validation-specialty.test.ts` — 126 passed
- `node --import tsx/esm --test tests/unit/account-fallback-lockout-eviction.test.ts tests/unit/domain-lockout-policy.test.ts tests/unit/model-lockout-decay.test.ts tests/unit/auth-ollama-cloud-per-model-403-3027.test.ts` — 16 passed
- `npm run typecheck:core` — clean
- `npm run check:cycles` — clean
- `npm run check:file-size` — clean
- `npx eslint` on both changed files — clean

---

## ⚠️ base-red inherited: #9985

Every failing check on this PR reproduces on the unmodified base tip
(`release/v3.8.50`) and none of them touch the two files in this diff
(`open-sse/config/providerRegistry.ts`, `tests/unit/local-provider-lan-detection-11091.test.ts`).

The failing set here is byte-identical to unrelated PRs opened against the same base
(e.g. #11135, which shares no files with this one):

```
Fast Quality Gates
Merge integrity (changelog + generated skills)
No new ESLint warnings
Unit Tests fast-path (1/4 … 4/4)
```

**Unit Tests fast-path** — failures are in unrelated suites: Vietnamese locale key parity /
ICU placeholders, `getTokenLimit` hyperagent model ids, provider-detail browser-bundle
safety, `probeBeforeSpawn` (#6205), systemd-notify handshake, and `buildSlackPayload`.
No assertion in the failing set calls `isLocalProvider()`.

**Merge integrity** — `check:changelog-integrity` passes (`OK — no base bullets lost`).
The job exits 2 on `check:agent-skills-sync`, which regenerates one stale generated file
on the base:

```
Generated: 1 · Unchanged: 45 · Pruned: 0 · Orphans: 0 · Errors: 0
  GENERATED:
    + omni-webhooks
```

`skills/omni-webhooks/SKILL.md` is out of sync in the base tree, not in this branch.

Local verification of the changed code is in the Validation section above — the new test
file passes 7/7 and `npx eslint` is clean on both changed files.
