### PR TITLE
fix(search): fall back to duckduckgo-free when no search provider is configured

### DIFF
--- a/src/app/api/v1/search/route.ts
+++ b/src/app/api/v1/search/route.ts
@@ -56,7 +56,7 @@ export async function OPTIONS() {
  * GET /v1/search — list available search providers
  */
 export async function GET() {
-  const settings = await getSettings().catch(() => ({} as any));
+  const settings = await getSettings().catch(() => ({}) as any);
   const blockedProviders = settings?.blockedProviders || [];
   const providers = getAllSearchProviders().filter(
     (p) => !isProviderBlockedByIdOrAlias(p.id, blockedProviders)
@@ -141,7 +141,7 @@ async function postHandler(request: Request, context: unknown) {
   const policy = await enforceApiKeyPolicy(request, "search");
   if (policy.rejection) return policy.rejection;
 
-  const settings = await getSettings().catch(() => ({} as any));
+  const settings = await getSettings().catch(() => ({}) as any);
   const blockedProviders = settings?.blockedProviders || [];
 
   // Resolve provider and credentials
@@ -244,6 +244,34 @@ async function postHandler(request: Request, context: unknown) {
         if (altConfig && altCreds) {
           providerConfig = altConfig;
           credentials = altCreds;
+          break;
+        }
+      }
+    }
+
+    // Last resort before failing: promote a fallback-only free provider (e.g.
+    // duckduckgo-free) to the primary pick so out-of-the-box search works when
+    // no credentialed provider is configured at all.
+    if (!credentials) {
+      const fallbackProviders = Object.values(SEARCH_PROVIDERS)
+        .filter(
+          (provider) =>
+            provider.fallbackOnly &&
+            supportsSearchType(provider, body.search_type) &&
+            !isProviderBlockedByIdOrAlias(provider.id, blockedProviders)
+        )
+        .sort((a, b) => a.costPerQuery - b.costPerQuery);
+
+      for (const fallbackProvider of fallbackProviders) {
+        providerConfig = fallbackProvider;
+        if (fallbackProvider.id === "duckduckgo-free") {
+          credentials = {};
+          break;
+        }
+        const fallbackCreds = await resolveSearchCredentials(fallbackProvider.id);
+        if (isAllRateLimitedCredentials(fallbackCreds)) continue;
+        if (fallbackCreds) {
+          credentials = fallbackCreds;
           break;
         }
       }

--- a/src/shared/components/OmniRouteLogo.tsx
+++ b/src/shared/components/OmniRouteLogo.tsx
@@ -16,6 +16,7 @@ export default function OmniRouteLogo({ size = 20, className = "" }: OmniRouteLo
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
+      suppressHydrationWarning
     >
       {/* Central node */}
       <circle cx="16" cy="16" r="3" fill="currentColor" />


### PR DESCRIPTION
## Problem

Out of the box (zero search provider credentials configured), `POST /v1/search` always failed with:

```
OmniRoute API error [400]: {"error":{"message":"No credentials configured for any search provider. Add an API key for a search provider (serper-search, brave-search, ...) in the dashboard.","type":"invalid_request_error","code":"bad_request"}}
```

even though the registry ships a free no-key provider (`duckduckgo-free`) exactly for this case.

## Root cause

In the auto-select path of `src/app/api/v1/search/route.ts`, fallback-only providers (`duckduckgo-free`, `searxng-search`) were only ever promoted to the **alternate** slot (the last-resort failover block). When **no** credentialed provider was found, the 400 error was returned *before* that block could run — so the last-resort path was dead code in the zero-credentials case.

The lib variant `src/lib/search/executeWebSearch.ts` already handles this correctly (it promotes `duckduckgo-free` with empty credentials), so the two paths disagreed.

## Fix

Promote a fallback-only provider to the **primary** pick as a last resort before failing, mirroring `executeWebSearch()`:

- `duckduckgo-free` runs with empty credentials (HTML scraping path, no key needed)
- `searxng-search` is used only when it has explicitly configured credentials
- honors `blockedProviders` and rate-limit state like the rest of the selection logic