### PR TITLE
fix(memory): treat TokenRouter as system-must-be-first (live HTTP 400 confirmed)

### DIFF
--- a/src/lib/memory/injection.ts
+++ b/src/lib/memory/injection.ts
@@ -65,7 +65,11 @@ export function providerSupportsSystemMessage(provider: string | null | undefine
  *
  * Populated with the Xiaomi MiMo endpoint (provider id `xiaomi-mimo`, registry
  * alias `mimo`, serving mimo-v2.5) confirmed live to 400 on a non-first system
- * message. Add other providers here only when they are documented as strict.
+ * message, and the TokenRouter gateway (provider id `tokenrouter`), confirmed
+ * live on 2026-08-22 to reject mid-array system messages — including the
+ * compression notice spliced by purifyHistory() before that splice was fixed to
+ * merge into the leading system message. Add other providers here only when
+ * they are documented as strict.
  *
  * Self-hosted deployments can extend this list without a source change via
  * OMNIROUTE_STRICT_SYSTEM_PROVIDERS (comma-separated provider ids,
@@ -73,7 +77,7 @@ export function providerSupportsSystemMessage(provider: string | null | undefine
  * self-hosted Qwen3.5+/3.6 model, whose chat template enforces the same
  * single-leading-system-message constraint as xiaomi-mimo.
  */
-const BUILTIN_PROVIDERS_SYSTEM_MUST_BE_FIRST = new Set(["xiaomi-mimo", "mimo"]);
+const BUILTIN_PROVIDERS_SYSTEM_MUST_BE_FIRST = new Set(["xiaomi-mimo", "mimo", "tokenrouter"]);
 
 /**
  * Parses OMNIROUTE_STRICT_SYSTEM_PROVIDERS into a normalized id list.

--- a/tests/unit/memory-system-first-6135.test.ts
+++ b/tests/unit/memory-system-first-6135.test.ts
@@ -49,6 +49,11 @@ describe("injectMemory system-must-be-first (#6135)", () => {
   it("flags xiaomi-mimo (and alias mimo) as system-must-be-first", () => {
     assert.equal(systemMessageMustBeFirst("xiaomi-mimo"), true);
     assert.equal(systemMessageMustBeFirst("mimo"), true);
+    // tokenrouter: confirmed live 2026-08-22 — mid-array system message
+    // (e.g. the purifyHistory compression notice) -> HTTP 400
+    // "System message must be at the beginning".
+    assert.equal(systemMessageMustBeFirst("tokenrouter"), true);
+    assert.equal(systemMessageMustBeFirst("TokenRouter"), true); // case-insensitive
     // default: unlisted providers keep current (non-first-constrained) behavior
     assert.equal(systemMessageMustBeFirst("anthropic"), false);
     assert.equal(systemMessageMustBeFirst(null), false);


### PR DESCRIPTION
## Summary

- Adds `tokenrouter` to `BUILTIN_PROVIDERS_SYSTEM_MUST_BE_FIRST` in `src/lib/memory/injection.ts`.
- TokenRouter (a built-in gateway, `src/shared/constants/providers/apikey/gateways.ts`) rejects any `system` message at a non-zero index with HTTP 400 `System message must be at the beginning`. Confirmed live on 2026-08-22: ten call logs from one day show combo-routed `qwen3.8-max-free` requests failing right after the context compressor spliced a second system-role message mid-array (the `purifyHistory()` compression notice). The per-provider circuit breaker then flapped the combo onto the next target, which is why the failures looked intermittent.
- With this flag set, both consumers of the list do the right thing for TokenRouter: cache-safe memory injection keeps its message at index 0 (#6135), and the strict-system hoist (#7293) folds any residual mid-array system messages — including ones coming from client histories OmniRoute cannot control — into the leading system block.
- Self-hosters can already work around this via `OMNIROUTE_STRICT_SYSTEM_PROVIDERS=tokenrouter`; this PR makes the built-in default safe.

## Related Issues

- Related to #6135 and #7293 (same mechanism, new provider).
- Companion PR fixes the producer side: purifyHistory() no longer emits a mid-array system message at all.

## Validation

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base (`release/v3.8.50`)
- [x] Production-code changes include a new or updated automated test in this PR

Focused run:

```
tests/unit/memory-system-first-6135.test.ts     14/14 pass (extended)
tests/unit/probe-7293-strict-system-hoist.test.ts  pass
```

## Tests Added Or Updated

- **Updated** `tests/unit/memory-system-first-6135.test.ts` — the flag test now also asserts `systemMessageMustBeFirst("tokenrouter") === true` (plus case-insensitive "TokenRouter"), with a comment citing the live evidence.

## Coverage Notes

- Changes `src/`: covered by the updated flag test plus the full injection/hoist suites above, which exercise both consumers of the list end-to-end.

## Reviewer Notes

- One-line behavioral change; no migrations or feature flags. Providers not in the list are unaffected.