### PR TITLE
fix(resilience): include RFC1918, CGNAT, and mDNS hosts in isLocalProvider (#11091)

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -133,6 +133,7 @@ export function isLocalProvider(baseUrl?: string | null): boolean {
   try {
     const url = new URL(baseUrl);
     const hostname = url.hostname;
+    if (!hostname) return false;
     return LOCAL_HOSTNAMES.has(hostname) || isPrivateHost(hostname);
   } catch {
     return false;

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -10,6 +10,7 @@ export {
 } from "./providers/registry/alibaba/index.ts";
 export { REGISTRY } from "./providers/index.ts";
 import { REGISTRY } from "./providers/index.ts";
+import { isPrivateHost } from "@/shared/network/outboundUrlGuard";
 import {
   RegistryModel,
   REASONING_UNSUPPORTED,
@@ -132,11 +133,7 @@ export function isLocalProvider(baseUrl?: string | null): boolean {
   try {
     const url = new URL(baseUrl);
     const hostname = url.hostname;
-    // Strictly matching 172.16.0.0/12 (Docker/local) and explicitly blocking ::1 per SSRF hardening
-    return (
-      LOCAL_HOSTNAMES.has(hostname) ||
-      /^172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(hostname)
-    );
+    return LOCAL_HOSTNAMES.has(hostname) || isPrivateHost(hostname);
   } catch {
     return false;
   }

--- a/tests/unit/is-local-provider-11091.test.ts
+++ b/tests/unit/is-local-provider-11091.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isLocalProvider } from "../../open-sse/config/providerRegistry.ts";
+
+test("isLocalProvider detects RFC1918, CGNAT/Tailscale, and mDNS private hosts", () => {
+  // Local / loopback
+  assert.equal(isLocalProvider("http://localhost:11434/v1"), true);
+  assert.equal(isLocalProvider("http://127.0.0.1:11434/v1"), true);
+
+  // Docker 172.16/12
+  assert.equal(isLocalProvider("http://172.18.0.2:11434/v1"), true);
+
+  // RFC1918 LAN hosts (Issue #11091)
+  assert.equal(isLocalProvider("http://192.168.1.50:11434/v1"), true);
+  assert.equal(isLocalProvider("http://10.0.0.5:11434/v1"), true);
+
+  // Tailscale / CGNAT (100.64/10)
+  assert.equal(isLocalProvider("http://100.64.1.2:11434/v1"), true);
+
+  // Link-local (169.254/16)
+  assert.equal(isLocalProvider("http://169.254.1.1:11434/v1"), true);
+
+  // mDNS / private suffixes
+  assert.equal(isLocalProvider("http://studio.local:11434/v1"), true);
+  assert.equal(isLocalProvider("http://mybox.internal:11434/v1"), true);
+
+  // Public hosts (should be false)
+  assert.equal(isLocalProvider("https://api.openai.com/v1"), false);
+  assert.equal(isLocalProvider("https://api.anthropic.com/v1"), false);
+  assert.equal(isLocalProvider("http://8.8.8.8:8080/v1"), false);
+});

--- a/tests/unit/is-local-provider-11091.test.ts
+++ b/tests/unit/is-local-provider-11091.test.ts
@@ -28,4 +28,11 @@ test("isLocalProvider detects RFC1918, CGNAT/Tailscale, and mDNS private hosts",
   assert.equal(isLocalProvider("https://api.openai.com/v1"), false);
   assert.equal(isLocalProvider("https://api.anthropic.com/v1"), false);
   assert.equal(isLocalProvider("http://8.8.8.8:8080/v1"), false);
+
+  // Fails open on missing or unparseable input (Issue #11091 review finding)
+  assert.equal(isLocalProvider(null), false);
+  assert.equal(isLocalProvider(undefined), false);
+  assert.equal(isLocalProvider(""), false);
+  assert.equal(isLocalProvider("not a url"), false);
+  assert.equal(isLocalProvider("file:///models"), false);
 });


### PR DESCRIPTION
Fixes #11091.

### Root Cause
`isLocalProvider(baseUrl)` in `open-sse/config/providerRegistry.ts` matched only `localhost`, `127.0.0.1`, `172.16.0.0/12`, and `LOCAL_HOSTNAMES`. It missed `192.168.0.0/16`, `10.0.0.0/8`, `100.64.0.0/10` (Tailscale/CGNAT), `169.254.0.0/16`, and `.local` / `.internal` hostnames. As a result, 404 responses from self-hosted LAN/Tailscale LLMs misclassified the host as non-local and triggered a whole-connection cooldown instead of a model-only lockout.

### Fix
Updated `isLocalProvider(baseUrl)` to delegate hostname evaluation to `isPrivateHost(hostname)` from `@/shared/network/outboundUrlGuard`, which already covers all RFC1918, CGNAT/Tailscale, link-local, and mDNS private domain suffixes.

### Test Coverage
Added unit test `tests/unit/is-local-provider-11091.test.ts` asserting that LAN (`192.168.1.50`, `10.0.0.5`), Tailscale (`100.64.1.2`), link-local (`169.254.1.1`), mDNS (`studio.local`, `mybox.internal`), and Docker (`172.18.0.2`) hosts resolve to `true`, while public hosts (`api.openai.com`, `8.8.8.8`) resolve to `false`.