### PR TITLE
fix(search): enforce blockedProviders setting on search endpoint (#11100)

### DIFF
--- a/open-sse/config/searchRegistry.ts
+++ b/open-sse/config/searchRegistry.ts
@@ -10,6 +10,8 @@
  * perplexity-search reuses credentials from the "perplexity" chat provider.
  */
 
+import { isProviderBlockedByIdOrAlias } from "@/shared/utils/noAuthProviders";
+
 export interface SearchProviderConfig {
   id: string;
   name: string;
@@ -394,16 +396,18 @@ export function supportsSearchType(
 /**
  * Get all search providers as a flat list
  */
-export function getAllSearchProviders(): Array<{
+export function getAllSearchProviders(blockedProviders: string[] = []): Array<{
   id: string;
   name: string;
   searchTypes: string[];
 }> {
-  return Object.values(SEARCH_PROVIDERS).map((p) => ({
-    id: p.id,
-    name: p.name,
-    searchTypes: p.searchTypes,
-  }));
+  return Object.values(SEARCH_PROVIDERS)
+    .filter((p) => !(p as any).disabled && !isProviderBlockedByIdOrAlias(p.id, blockedProviders))
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      searchTypes: p.searchTypes,
+    }));
 }
 
 /**

--- a/open-sse/config/searchRegistry.ts
+++ b/open-sse/config/searchRegistry.ts
@@ -402,7 +402,7 @@ export function getAllSearchProviders(blockedProviders: string[] = []): Array<{
   searchTypes: string[];
 }> {
   return Object.values(SEARCH_PROVIDERS)
-    .filter((p) => !(p as any).disabled && !isProviderBlockedByIdOrAlias(p.id, blockedProviders))
+    .filter((p) => !p.disabled && !isProviderBlockedByIdOrAlias(p.id, blockedProviders))
     .map((p) => ({
       id: p.id,
       name: p.name,

--- a/src/app/api/v1/search/route.ts
+++ b/src/app/api/v1/search/route.ts
@@ -58,9 +58,7 @@ export async function OPTIONS() {
 export async function GET() {
   const settings = await getSettings().catch(() => ({} as any));
   const blockedProviders = settings?.blockedProviders || [];
-  const providers = getAllSearchProviders().filter(
-    (p) => !isProviderBlockedByIdOrAlias(p.id, blockedProviders)
-  );
+  const providers = getAllSearchProviders(blockedProviders);
   const timestamp = Math.floor(Date.now() / 1000);
 
   const data = providers.map((p) => ({

--- a/tests/unit/search-blocked-providers-11100.test.ts
+++ b/tests/unit/search-blocked-providers-11100.test.ts
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getAllSearchProviders } from "../../open-sse/config/searchRegistry.ts";
+
+test("getAllSearchProviders filters out blocked providers", () => {
+  const all = getAllSearchProviders();
+  assert.ok(all.some((p) => p.id === "serper-search"));
+
+  const filtered = getAllSearchProviders(["serper-search"]);
+  assert.equal(filtered.some((p) => p.id === "serper-search"), false);
+});


### PR DESCRIPTION
Fixes #11100.

### Root Cause
`getAllSearchProviders()` in `open-sse/config/searchRegistry.ts` returned all search providers without filtering out those present in `blockedProviders` settings.

### Fix
- Updated `getAllSearchProviders(blockedProviders: string[] = [])` in `open-sse/config/searchRegistry.ts` to filter out disabled providers and any provider matching `isProviderBlockedByIdOrAlias(p.id, blockedProviders)`.
- Updated `GET /v1/search` in `src/app/api/v1/search/route.ts` to pass `blockedProviders` from settings to `getAllSearchProviders(blockedProviders)`.

### Test Coverage
Added unit test `tests/unit/search-blocked-providers-11100.test.ts` verifying `getAllSearchProviders` filters out blocked providers.