### PR TITLE
fix(sse): default summary on freshly-built Chat->Responses reasoning items

### DIFF
--- a/open-sse/translator/request/openai-responses/toResponses.ts
+++ b/open-sse/translator/request/openai-responses/toResponses.ts
@@ -201,6 +201,14 @@ export function openaiToOpenAIResponsesRequest(
         input.push({
           type: "reasoning",
           content: [{ type: "reasoning_text", text: reasoning }],
+          // Strict Responses-API upstreams (e.g. opencode/zen) require `summary`
+          // on every `input[]` item of type "reasoning", plaintext or opaque —
+          // omitting it rejects the request with `input[N] missing required
+          // field summary`. This item is always freshly built from a chat
+          // client's plaintext reasoning, so there is no source summary to
+          // preserve; default to an empty array like the replay sanitizer does
+          // for opaque items in reasoningInputPolicy.ts (#11108).
+          summary: [],
         });
       }
 

--- a/tests/unit/reasoning-cache.test.ts
+++ b/tests/unit/reasoning-cache.test.ts
@@ -664,6 +664,7 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
       {
         type: "reasoning",
         content: [{ type: "reasoning_text", text: "Cached Chat continuation reasoning" }],
+        summary: [],
       }
     );
   });

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -475,6 +475,7 @@ test("Chat -> Responses defaults unannotated targets to plaintext reasoning", ()
     {
       type: "reasoning",
       content: [{ type: "reasoning_text", text: "Inspect the repository first" }],
+      summary: [],
     },
     {
       type: "function_call",
@@ -513,6 +514,7 @@ test("Chat -> DeepSeek Responses accepts the plaintext reasoning alias", () => {
   assert.deepEqual(result.input[0], {
     type: "reasoning",
     content: [{ type: "reasoning_text", text: "Alias plaintext reasoning" }],
+    summary: [],
   });
 });
 


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

`openaiToOpenAIResponsesRequest()` (`open-sse/translator/request/openai-responses/toResponses.ts`) builds a Responses-API `input[]` reasoning item from a Chat-format assistant message's readable reasoning text, but never included a `summary` field. Strict Responses-API upstreams (observed: `opencode/muse-spark-1.2-contributor-free` via `opencode`/zen) require `summary` on every `input[]` item of type `"reasoning"`, plaintext or opaque — the request is rejected on the very first continuation turn:

```
[400] invalid_request_error: `input[N]` missing required field `summary`
```

This is a **distinct construction site** from the replay-sanitizer fixed in #11108 (`reasoningInputPolicy.ts::sanitizeResponsesInput()`), which only guards items already present in an *incoming* Responses-format `input[]` array (client-native Responses format, e.g. Codex). This function instead **freshly builds** a reasoning item from a Chat-format client's plaintext reasoning text on every request that needs Chat→Responses translation (e.g. opencode CLI talking to a Responses-only upstream) — no source `summary` exists to preserve, so it must default to an empty array unconditionally, mirroring `reasoningInputPolicy.ts`'s opaque-item default from #11108.

Confirmed against a live production call log: the failing `input[]` item was exactly `{type:"reasoning", content:[...]}` — no `summary`, no `id` — matching this construction site precisely.

## Change

- `openaiToOpenAIResponsesRequest()`: default `summary: []` on the reasoning item built from a Chat client's plaintext reasoning.
- Updated two now-outdated legacy assertions (`tests/unit/translator-openai-responses-req.test.ts`, `tests/unit/reasoning-cache.test.ts`) that locked in the old byte-verbatim shape (no `summary`) to the corrected contract.

## Test Plan

```bash
node --import tsx/esm --test tests/unit/translator-openai-responses-req.test.ts
# 57 pass, 0 fail

npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 \
  tests/unit/reasoning-cache.test.ts \
  tests/unit/strip-reasoning-blobs-agentic-context-1599.test.ts \
  tests/unit/translator-resp-openai-responses.test.ts \
  tests/unit/translator-openai-responses-req.test.ts \
  tests/unit/encrypted-reasoning-summary-7243.test.ts \
  tests/unit/openai-responses-request-split.test.ts \
  tests/unit/empty-tool-name-loop.test.ts \
  tests/unit/executor-codex-gpt56.test.ts \
  tests/unit/headroom-responses-format.test.ts \
  tests/unit/openai-responses-reasoning-effort.test.ts \
  tests/unit/openai-responses-verbosity.test.ts \
  tests/unit/orphaned-tool-filter.test.ts \
  tests/unit/repro-7023.test.ts \
  tests/unit/responses-input-item-status-8083.test.ts \
  tests/unit/responses-translation-fixes.test.ts \
  tests/unit/stream-helpers.test.ts
# every reasoning/translator/Responses-format consumer of this function, 0 fail
```

`npx eslint open-sse/translator/request/openai-responses/toResponses.ts tests/unit/translator-openai-responses-req.test.ts tests/unit/reasoning-cache.test.ts --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json` — clean.

`npx tsc --pretty false -p tsconfig.typecheck-core.json` — no errors on the touched files.