### PR TITLE
fix(webhooks): followup ghost-event dispatcher + vi i18n (#11050)

### DIFF
--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -12207,7 +12207,7 @@
       },
       "omni-webhooks": {
         "name": "Webhook",
-        "description": "__MISSING__:Register, list, test, and remove webhook endpoints. Configure event subscriptions (request.completed, request.failed, quota.exceeded, etc.) and manage delivery retries."
+        "description": "Đăng ký, liệt kê, kiểm thử và xoá các endpoint webhook. Cấu hình đăng ký sự kiện (request.completed, request.failed, quota.exceeded, v.v.) và quản lý thử lại giao hàng."
       },
       "omni-mcp": {
         "name": "Máy chủ MCP",

--- a/tests/unit/webhook-discord-dispatcher.test.ts
+++ b/tests/unit/webhook-discord-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { WEBHOOK_EVENT_VALUES } from "../../src/lib/webhooks/eventDescriptions.ts";
 
 const { buildDiscordPayload } = await import("../../src/lib/webhooks/integrations/discord.ts");
 
@@ -14,15 +15,7 @@ test("buildDiscordPayload — request.failed produces embed with model", () => {
 });
 
 test("buildDiscordPayload — all WEBHOOK_EVENTS return object with content or embeds", () => {
-  const events = [
-    "request.completed",
-    "request.failed",
-    "provider.error",
-    "provider.recovered",
-    "quota.exceeded",
-    "combo.switched",
-    "test.ping",
-  ] as const;
+  const events = WEBHOOK_EVENT_VALUES;
   for (const event of events) {
     const payload = buildDiscordPayload(event, {});
     assert.ok(
@@ -33,7 +26,7 @@ test("buildDiscordPayload — all WEBHOOK_EVENTS return object with content or e
 });
 
 test("buildDiscordPayload — embeds have title and color fields", () => {
-  const payload = buildDiscordPayload("provider.error", { provider: "openai" });
+  const payload = buildDiscordPayload("request.failed", { provider: "openai" });
   assert.ok(Array.isArray(payload.embeds) && payload.embeds.length > 0, "should have embeds");
   const embed = payload.embeds![0];
   assert.ok(typeof embed.title === "string" && embed.title.length > 0, "embed must have title");

--- a/tests/unit/webhook-slack-dispatcher.test.ts
+++ b/tests/unit/webhook-slack-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { WEBHOOK_EVENT_VALUES } from "../../src/lib/webhooks/eventDescriptions.ts";
 
 const { buildSlackPayload } = await import("../../src/lib/webhooks/integrations/slack.ts");
 
@@ -30,8 +31,8 @@ test("buildSlackPayload — test.ping produces a ping/test message", () => {
   );
 });
 
-test("buildSlackPayload — provider.error includes provider context", () => {
-  const payload = buildSlackPayload("provider.error", { provider: "openai", model: "gpt-4" });
+test("buildSlackPayload — request.failed includes provider context", () => {
+  const payload = buildSlackPayload("request.failed", { provider: "openai" });
   const combined = JSON.stringify(payload);
   assert.ok(
     combined.includes("Provider") ||
@@ -43,15 +44,7 @@ test("buildSlackPayload — provider.error includes provider context", () => {
 });
 
 test("buildSlackPayload — all WEBHOOK_EVENTS produce valid payloads with text field", () => {
-  const events = [
-    "request.completed",
-    "request.failed",
-    "provider.error",
-    "provider.recovered",
-    "quota.exceeded",
-    "combo.switched",
-    "test.ping",
-  ] as const;
+  const events = WEBHOOK_EVENT_VALUES;
   for (const event of events) {
     const payload = buildSlackPayload(event, {});
     assert.ok(

--- a/tests/unit/webhook-telegram-dispatcher.test.ts
+++ b/tests/unit/webhook-telegram-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { WEBHOOK_EVENT_VALUES } from "../../src/lib/webhooks/eventDescriptions.ts";
 
 const { buildTelegramPayload, buildTelegramUrl } =
   await import("../../src/lib/webhooks/integrations/telegram.ts");
@@ -77,15 +78,7 @@ test("buildTelegramPayload — chat_id matches provided value for groups", () =>
 });
 
 test("buildTelegramPayload — all WEBHOOK_EVENTS produce valid payloads with chat_id", () => {
-  const events = [
-    "request.completed",
-    "request.failed",
-    "provider.error",
-    "provider.recovered",
-    "quota.exceeded",
-    "combo.switched",
-    "test.ping",
-  ] as const;
+  const events = WEBHOOK_EVENT_VALUES;
   for (const event of events) {
     const payload = buildTelegramPayload(event, {}, "99999");
     assert.equal(payload.chat_id, "99999");

--- a/tests/unit/webhooks-ghost-events.test.ts
+++ b/tests/unit/webhooks-ghost-events.test.ts
@@ -30,4 +30,16 @@ describe("webhook catalogue", () => {
     const { notifyWebhookEvent } = await import("../../src/lib/webhookDispatcher.ts");
     assert.equal(typeof notifyWebhookEvent, "function");
   });
+
+  it("every builder accepts every value in WEBHOOK_EVENT_VALUES without throwing", async () => {
+    const { buildDiscordPayload } = await import("../../src/lib/webhooks/integrations/discord.ts");
+    const { buildSlackPayload } = await import("../../src/lib/webhooks/integrations/slack.ts");
+    const { buildTelegramPayload } =
+      await import("../../src/lib/webhooks/integrations/telegram.ts");
+    for (const event of WEBHOOK_EVENT_VALUES) {
+      assert.doesNotThrow(() => buildDiscordPayload(event, {}));
+      assert.doesNotThrow(() => buildSlackPayload(event, {}));
+      assert.doesNotThrow(() => buildTelegramPayload(event, {}, "99999"));
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the already-merged #11050: closes the two blockers the owner flagged.
- Dispatcher tests (`webhook-discord/slack/telegram-dispatcher.test.ts`) still iterated/called the removed events `provider.error`/`provider.recovered`/`combo.switched`, throwing `TypeError: Cannot read properties of undefined` at runtime (`EVENT_DESCRIPTIONS[event]`). Replaced the hand-copied catalogs with `WEBHOOK_EVENT_VALUES` and retargeted the standalone `discord:36` / `slack:41` calls to `request.failed` with `{ provider }` shape.
- `vi.json` carried `__MISSING__:` on `omni-webhooks.description`, which `tests/unit/i18n-vi-completeness.test.ts` bans for `vi` only. Translated it to Vietnamese. The other 41 locales keep the marker by design (the `sync-ui-keys.mjs` convention; `i18n-ui-value-drift` treats `__MISSING__:` as the legitimate staleness signal).
- Added a runtime smoke test asserting the three builders accept every value in `WEBHOOK_EVENT_VALUES`. The negative ghost-string assertions in `webhooks-ghost-events.test.ts` are kept (they prove the removal).

## Related Issues

- Related to #11050 (already merged; this PR fixes its two blockers)

## Validation

Change type: i18n / other (test-only + one i18n value)

- [x] Focused tests rerun: `webhook-discord/slack/telegram-dispatcher.test.ts`, `i18n-vi-completeness.test.ts`, `i18n-ui-value-drift.test.ts`, `webhooks-ghost-events.test.ts` all pass
- [x] `npm run lint` (pre-commit hooks ran on commit)
- [x] Reconciled with current active release base `upstream/release/v3.8.50`
- [x] Production-code change (`vi.json`) includes an automated test in this PR (`i18n-vi-compat`/completeness)

## Tests Added Or Updated

- `tests/unit/webhooks-ghost-events.test.ts` — new positive smoke test over `WEBHOOK_EVENT_VALUES`
- `tests/unit/webhook-discord-dispatcher.test.ts`, `webhook-slack-dispatcher.test.ts`, `webhook-telegram-dispatcher.test.ts` — catalogs now derive from `WEBHOOK_EVENT_VALUES`; slack test name updated

## Coverage Notes

- No `src/`/`open-sse/`/`electron/`/`bin/` production logic changed (only a test file and one i18n value). The `vi.json` value change is covered by the existing `i18n-vi-completeness` gate.

## Reviewer Notes

- `eventDescriptions.ts` is intentionally NOT touched (it was already correct in #11050).
- The smoke test is a runtime check, not a static source-scan gate; a future hand-copied literal in a dispatcher test would not be caught by this PR alone. Filed as a known follow-up.
