### PR TITLE
fix(cline): use valid modelType/model format for Cline provider models (#11099)

### DIFF
--- a/open-sse/config/providers/registry/cline/index.ts
+++ b/open-sse/config/providers/registry/cline/index.ts
@@ -27,7 +27,7 @@ export const clineProvider: RegistryEntry = {
   // the official free bucket and text-output models advertised as zero-cost.
   models: [
     {
-      id: "zai/glm-5.2",
+      id: "z-ai/glm-5.2",
       name: "GLM 5.2",
       toolCalling: true,
       supportsReasoning: true,

--- a/tests/unit/cline-model-format-11099.test.ts
+++ b/tests/unit/cline-model-format-11099.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getModelsByProviderId } from "../../open-sse/config/providerModels.ts";
+import { parseClineRecommendedModels } from "../../open-sse/services/clinepassModels.ts";
+
+test("#11099: Cline provider catalog model IDs use valid modelType/model format", () => {
+  const models = getModelsByProviderId("cline");
+  assert.ok(models.length > 0, "cline provider must expose models");
+
+  for (const model of models) {
+    assert.match(
+      model.id,
+      /^[a-z0-9-]+-?[a-z0-9-]*\/[a-z0-9._:-]+$/i,
+      `Model ID '${model.id}' must follow provider/model format`
+    );
+    assert.notEqual(
+      model.id.split("/")[0],
+      "zai",
+      "Model ID must use 'z-ai' instead of invalid 'zai'"
+    );
+  }
+});
+
+test("#11099: parseClineRecommendedModels correctly extracts recommended/free models", () => {
+  const mockPayload = {
+    recommended: [
+      { id: "moonshotai/kimi-k3", name: "kimi-k3" },
+      { id: "x-ai/grok-4.5", name: "grok-4.5" },
+    ],
+    free: [{ id: "deepseek/deepseek-v4-flash", name: "deepseek-v4-flash" }],
+  };
+
+  const parsed = parseClineRecommendedModels(mockPayload);
+  assert.equal(parsed.length, 3);
+  assert.equal(parsed[0].id, "moonshotai/kimi-k3");
+  assert.equal(parsed[1].id, "x-ai/grok-4.5");
+  assert.equal(parsed[2].id, "deepseek/deepseek-v4-flash");
+});


### PR DESCRIPTION
### Summary
Fixes #11099 where Cline models returned 400 invalid model format. Expected format: modelType/model.

### Root Cause
`open-sse/config/providers/registry/cline/index.ts` contained `zai/glm-5.2` instead of `z-ai/glm-5.2` (missing hyphen in namespace).

### Validation
- Unit test `tests/unit/cline-model-format-11099.test.ts` passed TAP version 13.
- `check:dashboard-typecheck` passed clean.