### PR TITLE
fix(registry): restore models[0] default + guards; note muse-spark overlay (#11051/#11049)

### DIFF
--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -14,8 +14,6 @@ export const opencode_goProvider: RegistryEntry = {
   authPrefix: "Bearer",
   defaultContextLength: 200000,
   models: [
-    ...OPENCODE_ZEN_GO_SHARED_MODELS,
-
     // Port from decolua/9router 8efacc11: align with official Go endpoints —
     // glm-5.2 is now advertised and Kimi chat traffic must route through
     // `kimi-k2.7-code` (the live API rejects the plain `kimi-k2.7` alias for
@@ -26,6 +24,10 @@ export const opencode_goProvider: RegistryEntry = {
     { id: "glm-5.2", name: "GLM-5.2", supportsReasoning: true },
     { id: "glm-5.2-high", name: "GLM-5.2 (high effort)", supportsReasoning: true },
     { id: "glm-5.2-max", name: "GLM-5.2 (max effort)", supportsReasoning: true },
+
+    ...OPENCODE_ZEN_GO_SHARED_MODELS,
+    // models[0] (glm-5.2) is the dashboard default (LlmChatCard/ProviderTestSlideOver take models[0]).
+
     { id: "glm-5.1", name: "GLM-5.1" },
     { id: "glm-5", name: "GLM-5" },
     // kimi-k2.7-code declared identically on opencode-zen — see OPENCODE_ZEN_GO_SHARED_MODELS.

--- a/open-sse/config/providers/registry/opencode/zen/index.ts
+++ b/open-sse/config/providers/registry/opencode/zen/index.ts
@@ -16,8 +16,6 @@ export const opencode_zenProvider: RegistryEntry = {
   // from the live API response so new models work without a code deploy.
   passthroughModels: true,
   models: [
-    ...OPENCODE_ZEN_GO_SHARED_MODELS,
-
     // ── Chat / Coding ──────────────────────────────────────────
     // #2900: big-pickle's upstream runs DeepSeek thinking mode — declare the
     // interleaved reasoning_content contract so follow-up/tool-use turns replay
@@ -28,6 +26,10 @@ export const opencode_zenProvider: RegistryEntry = {
       supportsReasoning: true,
       interleavedField: "reasoning_content",
     },
+
+    ...OPENCODE_ZEN_GO_SHARED_MODELS,
+    // models[0] (big-pickle) is the dashboard default; SHARED spread kept after it.
+
     { id: "gpt-5.6-sol", name: "GPT 5.6 Sol" },
     { id: "gpt-5.6-terra", name: "GPT 5.6 Terra" },
     { id: "gpt-5.6-luna", name: "GPT 5.6 Luna" },
@@ -67,6 +69,8 @@ export const opencode_zenProvider: RegistryEntry = {
       supportsReasoning: true,
       targetFormat: "openai-responses",
     },
+    // Explicit wire-format overlay of the base opencode provider's muse-spark entry
+    // (targetFormat: openai-responses). Keep in sync with base on catalog syncs.
     {
       id: "muse-spark-1.2-contributor-free",
       name: "Muse Spark 1.2 Contributor Free",

--- a/tests/unit/opencode-zen-go-shared-models.test.ts
+++ b/tests/unit/opencode-zen-go-shared-models.test.ts
@@ -24,3 +24,16 @@ test("every OPENCODE_ZEN_GO_SHARED_MODELS entry is present, unmodified, exactly 
 test("OPENCODE_ZEN_GO_SHARED_MODELS is frozen (no accidental cross-registry mutation)", () => {
   assert.ok(Object.isFrozen(OPENCODE_ZEN_GO_SHARED_MODELS));
 });
+
+test("referenced non-shared model ids remain present", () => {
+  const goIds = new Set(opencode_goProvider.models.map((m) => m.id));
+  const zenIds = new Set(opencode_zenProvider.models.map((m) => m.id));
+  for (const id of ["minimax-m3", "glm-5.1"]) {
+    assert.ok(goIds.has(id) || zenIds.has(id), `expected ${id} in go or zen`);
+  }
+});
+
+test("models[0] is the intended dashboard default", () => {
+  assert.equal(opencode_goProvider.models[0].id, "glm-5.2");
+  assert.equal(opencode_zenProvider.models[0].id, "big-pickle");
+});


### PR DESCRIPTION
## Summary

Follow-up to the already-merged #11051 and #11049.

- **#11051 (silent default-model change):** #11051 placed the `OPENCODE_ZEN_GO_SHARED_MODELS` spread at `models[0]`, so the dashboard default became `kimi-k2.7-code` for both `opencode-go` and `opencode-zen` (the dashboard picks `models[0]`, e.g. `LlmChatCard.tsx:178`, `ProviderTestSlideOver.tsx:63`). Moved the spread after `glm-5.2` (go) / `big-pickle` (zen) to restore the original `models[0]`. Exact pre-#11051 interleaving is not restorable with a single spread and is not required.
- **#11051 (golden list nit):** added narrowed guards instead of a frozen full catalog — assert referenced non-shared ids (`minimax-m3`, `glm-5.1`) remain present, and `models[0].id` is `glm-5.2` / `big-pickle`. A full snapshot would red on every legitimate catalog sync (`passthroughModels: true`, live-regenerated).
- **#11049 (overlay drift):** one-line comment marking `zen muse-spark-1.2-contributor-free` as an explicit wire-format overlay of the base provider (avoid catalog-sync drift).

## Related Issues

- Related to #11051 and #11049 (both already merged; this PR addresses the owner's nits)

## Validation

Change type: provider / other (registry + tests)

- [x] Focused tests rerun: `opencode-zen-go-shared-models.test.ts`, `check:provider-consistency` (267/0), `opencode-muse-spark-responses-10867`, `opencode-zen-muse-spark-targetformat-11046`, `opencode-go-catalog-alignment`
- [x] `npm run lint` (pre-commit hooks ran on commit)
- [x] Reconciled with current active release base `upstream/release/v3.8.50`
- [x] Production-code change (registry) includes an automated test in this PR

## Tests Added Or Updated

- `tests/unit/opencode-zen-go-shared-models.test.ts` — two new narrow guards (non-shared id presence + models[0] default)

## Coverage Notes

- Registry `open-sse/config/providers/registry/opencode/{go,zen}/index.ts` changes are covered by the new `opencode-zen-go-shared-models` guards plus the existing `check:provider-consistency` (267 entries).

## Reviewer Notes

- No change to `eventDescriptions.ts` or any webhook code.
- The previous #11051 reply mixed up the landed order; this PR measures against `upstream/release/v3.8.50` where the spread is correctly at index 0.
