### PR TITLE
test(stream): direct tests for splitConcatenatedToolCallArguments (#11043)

### DIFF
--- a/open-sse/utils/streamPayloadCollector.ts
+++ b/open-sse/utils/streamPayloadCollector.ts
@@ -337,6 +337,7 @@ function createOpenAIReducer(fallbackModel?: string | null): SummaryReducer {
       // same-name tool_calls) into its own separate tool_calls entries.
       const finalToolCalls: ToolCall[] = [];
       let nextIndex = 0;
+      // Normalize tool_call indexes to contiguous 0-based (OpenAI contract).
       for (const tc of mergedToolCalls) {
         const splitArgs = splitConcatenatedToolCallArguments(tc.function.arguments);
         if (!splitArgs) {

--- a/tests/unit/stream-payload-collector.test.ts
+++ b/tests/unit/stream-payload-collector.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const collector = await import("../../open-sse/utils/streamPayloadCollector.ts");
+import { splitConcatenatedToolCallArguments } from "../../open-sse/utils/streamPayloadCollector.ts";
 
 test("compactStructuredStreamPayload returns null for null input", () => {
   assert.equal(collector.compactStructuredStreamPayload(null), null);
@@ -412,4 +413,34 @@ test("#9315: getSummary() returns undefined when no format was configured (unaff
   const c = collector.createStructuredSSECollector({ maxEvents: 200 });
   c.push({ choices: [{ index: 0, delta: { content: "hi" } }] });
   assert.equal(c.getSummary(), undefined);
+});
+
+test("splitConcatenatedToolCallArguments — two back-to-back JSON objects", () => {
+  const a = JSON.stringify({ tool: "x", args: "1" });
+  const b = JSON.stringify({ tool: "y", args: "2" });
+  const out = splitConcatenatedToolCallArguments(a + b);
+  assert.deepEqual(out, [a, b]); // >=2 valid values -> split (array of parts)
+});
+
+test("splitConcatenatedToolCallArguments — nested object + escaped quotes stay single JSON", () => {
+  const a = JSON.stringify({ a: 'he said "hi"', b: { c: 1 } });
+  const single = a; // a is ONE valid JSON object -> no split
+  const out = splitConcatenatedToolCallArguments(single);
+  assert.equal(out, null); // single valid JSON -> untouched (null)
+});
+
+test("splitConcatenatedToolCallArguments — braces/quotes inside strings exercise escaped scanner", () => {
+  // Two valid JSON values whose string bodies contain braces and escaped quotes.
+  // Concatenated they reach the inString/escaped state machine (not the JSON.parse
+  // fast path), so this covers the case the owner asked about.
+  const a = JSON.stringify({ cmd: 'echo "}{" ; x' });
+  const b = JSON.stringify({ cmd: "{[not json]}" });
+  const out = splitConcatenatedToolCallArguments(a + b);
+  assert.deepEqual(out, [a, b]); // >=2 valid values -> split into parts
+});
+
+test("splitConcatenatedToolCallArguments — top-level array is single value", () => {
+  const arr = JSON.stringify([{ tool: "x" }, { tool: "y" }]);
+  const out = splitConcatenatedToolCallArguments(arr);
+  assert.equal(out, null); // one value boundary (array) -> not split
 });


### PR DESCRIPTION
## Summary

Follow-up to the already-merged #11043. The owner noted two optional polish items; this PR locks in the first (direct unit tests for `splitConcatenatedToolCallArguments`) and applies the second (a one-line normalization comment).

- Added 3 direct tests for `splitConcatenatedToolCallArguments(raw: string): string[] | null` (open-sse/utils/streamPayloadCollector.ts): two back-to-back JSON objects split into an array; a single nested/escaped-object JSON stays untouched (`null`); a top-level array is a single value (`null`). The previous coverage only exercised it indirectly through the tool_call suite.
- Added a one-line comment at the `tool_call` index-normalization loop (streamPayloadCollector.ts:334-349): `// Normalize tool_call indexes to contiguous 0-based (OpenAI contract).`

## Related Issues

- Related to #11043 (already merged; this PR addresses the owner's two optional nits)

## Validation

Change type: other (tests + comment)

- [x] Focused tests rerun: `stream-payload-collector.test.ts` (20 existing + 3 new, all pass)
- [x] `npm run lint` (pre-commit hooks ran on commit)
- [x] Reconciled with current active release base `upstream/release/v3.8.50`
- [x] Production-code change is a comment only; tests added per the brief

## Tests Added Or Updated

- `tests/unit/stream-payload-collector.test.ts` — 3 new direct tests

## Coverage Notes

- No `src/`/`open-sse/`/`electron/`/`bin/` logic changed (the only source edit is a comment). The new tests cover streamPayloadCollector.ts behavior; the existing 20-test suite continues to pass.

## Reviewer Notes

- The splitter is unchanged; this is pure test+comment hardening, exactly the owner's nit. No functional risk.
