### PR TITLE
test(services): align adoption tests with the opt-in contract from #11040

### DIFF
--- a/tests/unit/services/ServiceSupervisor.test.ts
+++ b/tests/unit/services/ServiceSupervisor.test.ts
@@ -40,6 +40,10 @@ db.prepare(
   `INSERT OR IGNORE INTO version_manager (tool, status, port, auto_start, auto_update, provider_expose)
    VALUES ('test-adopt', 'stopped', 29996, 0, 0, 0)`
 ).run();
+db.prepare(
+  `INSERT OR IGNORE INTO version_manager (tool, status, port, auto_start, auto_update, provider_expose)
+   VALUES ('test-adopt-deny', 'stopped', 29994, 0, 0, 0)`
+).run();
 
 const { ServiceSupervisor } = await import("../../../src/lib/services/ServiceSupervisor.ts");
 
@@ -213,6 +217,10 @@ test("does NOT auto-restart on crash", async () => {
 // the port, the supervisor ADOPTS it (marks running, no child spawned) instead
 // of spawning a duplicate that would die with EADDRINUSE.
 test("#6205: probeBeforeSpawn adopts a healthy existing instance (no spawn)", async () => {
+  // GHSA-wg9p-6m2g-4v27: adoption of an already-healthy listener is opt-in
+  // (a squatter can answer 2xx), so this adoption-path test opts in explicitly.
+  const prevAdopt = process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE;
+  process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE = "1";
   const healthServer = startHealthServer(29996);
   const cfg = { ...tickConfig("test-adopt", 29996), probeBeforeSpawn: true };
   const sup = new ServiceSupervisor(cfg);
@@ -232,6 +240,8 @@ test("#6205: probeBeforeSpawn adopts a healthy existing instance (no spawn)", as
   } finally {
     await sup.stop();
     healthServer.close();
+    if (prevAdopt === undefined) delete process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE;
+    else process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE = prevAdopt;
   }
 });
 
@@ -254,6 +264,9 @@ test("adopted service resolves and records the real pid of the process holding t
   // (#10523).
   const healthServer = startHealthServer(29995);
   const cfg = { ...tickConfig("test-adopt", 29995), probeBeforeSpawn: true };
+  // Same opt-in as the adoption test above (GHSA-wg9p-6m2g-4v27).
+  const prevAdopt = process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE;
+  process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE = "1";
   const sup = new ServiceSupervisor(cfg);
 
   try {
@@ -268,5 +281,33 @@ test("adopted service resolves and records the real pid of the process holding t
   } finally {
     await sup.stop();
     healthServer.close();
+    if (prevAdopt === undefined) delete process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE;
+    else process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE = prevAdopt;
+  }
+});
+
+// GHSA-wg9p-6m2g-4v27: a healthy 2xx on the probed port no longer proves the
+// listener is this service — a local squatter can answer 200 and get adopted,
+// receiving the injected service API key. Without the operator opt-in the
+// supervisor must surface the actionable error instead of adopting.
+test("probeBeforeSpawn does NOT adopt a healthy listener without the opt-in", async () => {
+  const healthServer = startHealthServer(29994);
+  const cfg = { ...tickConfig("test-adopt-deny", 29994), probeBeforeSpawn: true };
+  const prevAdopt = process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE;
+  delete process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE;
+  const sup = new ServiceSupervisor(cfg);
+
+  try {
+    const status = await sup.start();
+    assert.equal(status.state, "error", "a healthy listener is not adopted by default");
+    assert.match(
+      status.lastError ?? "",
+      /OMNIROUTE_ADOPT_EXISTING_SERVICE/,
+      "the error names the opt-in escape hatch"
+    );
+  } finally {
+    await sup.stop();
+    healthServer.close();
+    if (prevAdopt !== undefined) process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE = prevAdopt;
   }
 });


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

Follow-up to #11040 (already merged): the security fix for GHSA-wg9p-6m2g-4v27 changed
`decidePreSpawn()` so adopting an already-healthy listener is **opt-in** (`OMNIROUTE_ADOPT_EXISTING_SERVICE=1`) —
a 2xx on the probed port cannot prove the listener is this service. The two integration tests in
`ServiceSupervisor.test.ts` still asserted adopt-by-default and have been red on the release tip since the merge:

- `#6205: probeBeforeSpawn adopts a healthy existing instance (no spawn)`
- `adopted service resolves and records the real pid of the process holding the port`

## Change (tests only — no production code touched)

- Both adoption tests now set `OMNIROUTE_ADOPT_EXISTING_SERVICE=1` explicitly (restored in `finally`), keeping the adoption path they exercise covered under the new contract.
- New default-deny case: without the flag, a healthy listener is **not** adopted and the surfaced error names the opt-in escape hatch — permanent regression guard for the advisory behavior.

## Validation

- Discrimination vs base: ran both `eb4fd74b^...` (pre-merge) and `eb4fd74b` — only these 2 failures were introduced by #11040; the other red unit files on the tip (hard-session-lease-bypass-inventory, sse-auth-codex-account-pool, openrouter-free-model-credits-exhausted, combo-quota-exhaustion-only-fallback) already failed **before** the merge and are separate basered debt.
- `ServiceSupervisor.test.ts`: 8/8 green · `ninerouter-embed-port-6205.test.ts`: 9/9 green (sibling sweep found no other consumer of the old contract)
- ESLint + Prettier clean on the touched file