### PR TITLE
fix(api): refuse creating a routing combo without any model

### DIFF
--- a/bin/cli/commands/combo.mjs
+++ b/bin/cli/commands/combo.mjs
@@ -307,6 +307,12 @@ export async function runComboCreateCommand(name, strategy = "priority", opts = 
   }
 
   const models = Array.isArray(opts.models) ? opts.models : [];
+  if (!models.length) {
+    console.error(
+      "combo create requires at least one target. Pass --models <provider/model,...> and/or repeat --model <provider/model>."
+    );
+    return 1;
+  }
 
   try {
     return await withRuntime(async ({ kind, api, db }) => {

--- a/changelog.d/fixes/11162-combo-create-requires-model.md
+++ b/changelog.d/fixes/11162-combo-create-requires-model.md
@@ -1,0 +1,1 @@
+- **Combo create:** creating a routing combo without any model is now refused (`400`) — the CLI requires `--models`/`--model` on `combo create`, matching the dashboard which already rejected empty combos.

--- a/config/quality/quality-baseline.json
+++ b/config/quality/quality-baseline.json
@@ -197,10 +197,11 @@
       "_rebaseline_2026_08_09_v3850_release_close": "7666 -> 8045 (+379 gzip bytes, +4.9%). Release v3.8.50 close reconciliation measured twice with the real size-limit + @size-limit/file path on tip e0ce95c592. Per-entry measurements remain below their absolute budgets: omniroute.mjs 4380/15000, mcp-server.mjs 1195/5000, nodeRuntimeSupport.mjs 887/8000, reset-password.mjs 1583/6000. The growth accumulated through legitimate CLI/runtime work in this cycle, including global-install ESM alias resolution, Termux cache preparation, and MCP stdio startup hardening; no entrypoint is near its absolute ceiling. The direction:down ratchet stays blocking from this exact measured tip."
     },
     "openapiBreaking": {
-      "value": 0,
+      "value": 4,
       "direction": "down",
       "dedicatedGate": true,
-      "_note": "oasdiff breaking-change gate (Fase 9 Onda 0). Blocks any breaking change vs base spec."
+      "_note": "oasdiff breaking-change gate (Fase 9 Onda 0). Blocks any breaking change vs base spec.",
+      "_rebaseline_2026_08_22_combo_create_min1": "0 -> 4, split 3 own + 1 inherited. Docs-only alignment of components.schemas.ComboCreate with the request contract already enforced by the API since 638fc5fbd (combo create refuses an empty model list) and d5034ea52: `model`/`nodes` were phantom properties the server never accepted, and `models` (array, minItems 1) is the real required field. OWN findings (3, caused by this commit): removed `model`, removed `nodes`, added required `models` on POST /api/combos — spec-vs-server drift, not client-facing breakage, no working client could have relied on the removed shapes. INHERITED finding (1, NOT caused by this PR's code changes — pre-existing drift already present at parent d5034ea52): PATCH /api/combos/{id} request-body-added-required; that route's patch operation declares its own inline requestBody (required: true, bare object schema, docs/openapi.yaml ~2107-2118) and does not reference ComboCreate, so this finding exists independently of the ComboCreate alignment (same own-growth vs inherited-drift convention as _rebaseline_2026_07_20_aliasresolver_hook_split_7808). No code change in this PR; follow-up tracking = this change's PR description."
     },
     "mutationScore.src/sse/services/auth.ts": {
       "value": 52.57,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8893,12 +8893,20 @@ components:
 
     ComboCreate:
       type: object
-      required: [name, model]
+      required: [name, models]
       properties:
         name:
           type: string
-        model:
-          type: string
+        models:
+          type: array
+          minItems: 1
+          items:
+            oneOf:
+              - type: string
+                description: "provider/model reference"
+              - type: object
+                description: "structured combo step (provider, model, weight, ...)"
+                additionalProperties: true
         strategy:
           type: string
           enum:
@@ -8920,14 +8928,3 @@ components:
             - context-optimized
             - fusion
           default: priority
-        nodes:
-          type: array
-          items:
-            type: object
-            properties:
-              connectionId:
-                type: string
-              weight:
-                type: integer
-              priority:
-                type: integer

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -321,7 +321,7 @@ export const createComboSchema = z
   .object({
     name: comboNameSchema,
     description: z.string().max(2000).optional(),
-    models: z.array(comboModelEntry).optional().default([]),
+    models: z.array(comboModelEntry).min(1, "a combo requires at least one model"),
     strategy: comboStrategySchema.optional().default("priority"),
     config: comboRuntimeConfigSchema.optional(),
     allowedProviders: z.array(z.string().trim().min(1).max(200)).max(100).optional(),
@@ -380,8 +380,9 @@ export const updateComboSchema = z
   .object({
     name: comboNameSchema.optional(),
     description: z.string().max(2000).optional().nullable(),
-    // Creation may leave `models` empty (`omniroute combo create` drafts one
-    // that way); an update may not, or a working combo loses every target.
+    // An update may not remove every model from a combo, or a working combo
+    // loses every target. Creation refuses an empty list too: since the CLI
+    // gained --models (#10954), an empty draft has no remaining legitimate path.
     models: z
       .array(comboModelEntry)
       .min(1, "an update cannot remove every model from a combo")

--- a/tests/unit/cli-combo-create-models-10954.test.ts
+++ b/tests/unit/cli-combo-create-models-10954.test.ts
@@ -90,7 +90,15 @@ test("combo create — parses --models without throwing (Commander option regist
   });
 
   await prog.parseAsync(
-    ["node", "x", "combo", "create", "my-combo", "--models", "openai/gpt-4o,anthropic/claude-3-opus"],
+    [
+      "node",
+      "x",
+      "combo",
+      "create",
+      "my-combo",
+      "--models",
+      "openai/gpt-4o,anthropic/claude-3-opus",
+    ],
     { from: "node" }
   );
 
@@ -221,4 +229,27 @@ test("combo create (HTTP) — POST /api/combos body carries the parsed models", 
     if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
     else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
   }
+});
+
+// Regression for the follow-up of #11011: with --models available, creating
+// an empty combo is no longer a legitimate path on either transport.
+test("combo create without any model is refused before reaching a transport", async () => {
+  await withComboEnv(async () => {
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (msg?: unknown) => {
+      errors.push(String(msg));
+    };
+    try {
+      const mod = await import("../../bin/cli/commands/combo.mjs");
+      const rc = await mod.runComboCreateCommand("guard-test");
+      assert.equal(rc, 1);
+    } finally {
+      console.error = originalError;
+    }
+    assert.ok(
+      errors.some((m) => m.includes("--models")),
+      `stderr should name --models, got: ${errors.join(" | ")}`
+    );
+  });
 });

--- a/tests/unit/combo-bracket-names.test.ts
+++ b/tests/unit/combo-bracket-names.test.ts
@@ -30,6 +30,7 @@ test.after(() => {
 test("combo schemas accept names with spaces and square brackets", () => {
   const createResult = schemas.createComboSchema.safeParse({
     name: "Claude [1m]",
+    models: ["anthropic/claude-3-opus"],
   });
   const updateResult = schemas.updateComboSchema.safeParse({
     name: "Claude [1m]",

--- a/tests/unit/combo-context-length.test.ts
+++ b/tests/unit/combo-context-length.test.ts
@@ -46,6 +46,7 @@ test.after(async () => {
 test("createComboSchema accepts valid context_length", () => {
   const result = schemas.createComboSchema.safeParse({
     name: "TestCombo",
+    models: ["openai/gpt-4o-mini"],
     context_length: 128000,
   });
   assert.equal(result.success, true);
@@ -54,6 +55,7 @@ test("createComboSchema accepts valid context_length", () => {
 test("createComboSchema rejects context_length below minimum (1000)", () => {
   const result = schemas.createComboSchema.safeParse({
     name: "TestCombo",
+    models: ["openai/gpt-4o-mini"],
     context_length: 999,
   });
   assert.equal(result.success, false);
@@ -62,6 +64,7 @@ test("createComboSchema rejects context_length below minimum (1000)", () => {
 test("createComboSchema rejects context_length above maximum (2000000)", () => {
   const result = schemas.createComboSchema.safeParse({
     name: "TestCombo",
+    models: ["openai/gpt-4o-mini"],
     context_length: 2000001,
   });
   assert.equal(result.success, false);
@@ -70,12 +73,14 @@ test("createComboSchema rejects context_length above maximum (2000000)", () => {
 test("createComboSchema accepts context_length at exact boundaries", () => {
   const min = schemas.createComboSchema.safeParse({
     name: "MinCombo",
+    models: ["openai/gpt-4o-mini"],
     context_length: 1000,
   });
   assert.equal(min.success, true);
 
   const max = schemas.createComboSchema.safeParse({
     name: "MaxCombo",
+    models: ["openai/gpt-4o-mini"],
     context_length: 2000000,
   });
   assert.equal(max.success, true);
@@ -84,6 +89,7 @@ test("createComboSchema accepts context_length at exact boundaries", () => {
 test("createComboSchema rejects non-integer context_length", () => {
   const result = schemas.createComboSchema.safeParse({
     name: "TestCombo",
+    models: ["openai/gpt-4o-mini"],
     context_length: 128000.5,
   });
   assert.equal(result.success, false);
@@ -92,6 +98,7 @@ test("createComboSchema rejects non-integer context_length", () => {
 test("createComboSchema accepts omitted context_length", () => {
   const result = schemas.createComboSchema.safeParse({
     name: "TestCombo",
+    models: ["openai/gpt-4o-mini"],
   });
   assert.equal(result.success, true);
 });

--- a/tests/unit/combo-empty-models.test.ts
+++ b/tests/unit/combo-empty-models.test.ts
@@ -24,9 +24,9 @@ test("an update cannot remove every model from a combo", () => {
   assert.equal(updateComboSchema.safeParse({ name: "renamed" }).success, true);
 });
 
-test("creating a combo with no model stays allowed — the CLI does it on purpose", () => {
-  assert.equal(createComboSchema.safeParse({ name: "drafted", models: [] }).success, true);
-  assert.equal(createComboSchema.safeParse({ name: "drafted" }).success, true);
+test("creating a combo without a model is refused at the boundary", () => {
+  assert.equal(createComboSchema.safeParse({ name: "drafted", models: [] }).success, false);
+  assert.equal(createComboSchema.safeParse({ name: "drafted" }).success, false);
 });
 
 test("the copilot createCombo tool stores targets where the router looks for them", async () => {


### PR DESCRIPTION
## Summary

- Creating a routing combo without any model is now refused at the boundary: `createComboSchema` requires a non-empty `models` list, so `POST /api/combos` returns 400 for a missing or empty list.
- `omniroute combo create` requires `--models <provider/model,...>` and/or repeated `--model`, instead of silently writing `models: []`.
- `docs/openapi.yaml`: `ComboCreate` aligned with the actual request contract (`required: [name, models]`, union `string | structured entry`, phantom properties `model`/`nodes` removed).

## Related Issues

- Closes #10954
- Related to #11011, #8494, #6546

## Validation

- [x] Change type: routing / CLI
- [x] Focused tests: `node --import tsx/esm --test tests/unit/combo-empty-models.test.ts tests/unit/combo-context-length.test.ts tests/unit/combo-bracket-names.test.ts tests/unit/cli-combo-create-models-10954.test.ts` (and the full `tests/unit/combo-*` / `combos-*` set) — all green
- [x] `npm run lint` — no new findings from this PR's files (pre-existing failures elsewhere are unchanged; see Reviewer Notes)
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include updated automated tests in this PR

Manual loop on a live server: `POST /api/combos` without `models` → 400; with one model → 201; `combo create` without `--models` → stderr message naming the flags, exit code 1.

## Tests Added Or Updated

- `tests/unit/combo-empty-models.test.ts` — invariant inverted: creating without a model is refused at the boundary (was: asserted allowed).
- `tests/unit/cli-combo-create-models-10954.test.ts` — new regression: the guard fires before reaching either transport (HTTP body or local-db fallback).
- `tests/unit/combo-context-length.test.ts`, `tests/unit/combo-bracket-names.test.ts` — fixtures updated for the now-required `models` (8 call sites total).

## Coverage Notes

Production change is confined to `src/shared/validation/schemas/combo.ts` (one line + comment) and `bin/cli/commands/combo.mjs` (guard). Covered by `tests/unit/combo-empty-models.test.ts` and `tests/unit/cli-combo-create-models-10954.test.ts` respectively. No coverage moved down in touched files.

## Reviewer Notes

- **Consistency, not new policy**: the dashboard already rejected empty combos client-side ("Add at least one model."), `/api/combos/duplicate` already returns 400 for an empty list (#11011 made populated creation the normal CLI path), six downstream consumers reject the empty object, and fail-closed is the established behavior for empty pools (#8494, #6546). Since #10954 framed always-empty creation as a bug and #11011 removed the last legitimate use of an empty draft, this closes the remaining hole. **Intended consequence**: a legacy combo stored empty in the database can no longer be duplicated from the dashboard (duplicate re-posts through `POST /api/combos`) — consistent with the duplicate route already refusing empties.
- **OpenAPI breaking-change gate**: rebaseline entry `_rebaseline_2026_08_22_combo_create_min1` documents **3 own findings** (removed `model`, removed `nodes`, added required `models` on POST /api/combos — spec-vs-server drift, not client-facing breakage) + **1 inherited finding** (`PATCH /api/combos/{id} request-body-added-required`), which is pre-existing drift already present at this PR's base commit — that route declares its own inline requestBody schema and does not reference `ComboCreate`. A dedicated tracking issue can be filed if preferred; happy to reference it here.
- **Pre-existing CI failures** (reproduced identically at the base commit, untouched by this PR): one quota-classifier unit test, lint failures tracked by #10906, dashboard typecheck errors TS2554 ×188.
