### PR TITLE
fix(bun): update Dockerfile.bun entrypoint and native bun:sqlite instantiation (#11039)

### DIFF
--- a/Dockerfile.bun
+++ b/Dockerfile.bun
@@ -86,4 +86,4 @@ EXPOSE 20128
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD bun healthcheck.mjs || exit 1
 
-ENTRYPOINT ["bun", "bin/omniroute.mjs", "serve", "--no-open"]
+ENTRYPOINT ["bun", "dev/run-standalone.mjs"]

--- a/src/lib/db/adapters/driverFactory.ts
+++ b/src/lib/db/adapters/driverFactory.ts
@@ -224,7 +224,10 @@ export function createSyncDriverFactory(load: DriverLoader, betterSqliteProbe?: 
         const bunOptions: Record<string, unknown> = {};
         if (options?.readonly === true) bunOptions.readonly = true;
         if (options?.create === false && filePath !== ":memory:") bunOptions.create = false;
-        const db = new Database(filePath, bunOptions);
+        const db =
+          Object.keys(bunOptions).length > 0
+            ? new Database(filePath, bunOptions)
+            : new Database(filePath);
         return createBunSqliteAdapter(db, filePath);
       } catch (err) {
         logSwallowedDriverError("bun:sqlite", err);


### PR DESCRIPTION
### Summary

Follow-up fixes for the Bun backend support PR (#11039):

1. **`Dockerfile.bun` ENTRYPOINT**:
   Updated `ENTRYPOINT` from `["bun", "bin/omniroute.mjs", "serve", "--no-open"]` (which targeted a non-standalone CLI script) to `ENTRYPOINT ["bun", "dev/run-standalone.mjs"]` (matching Node Dockerfile and shipped inside Next.js standalone output).

2. **Native `bun:sqlite` Instantiation**:
   Updated `src/lib/db/adapters/driverFactory.ts` so `new Database(filePath)` is called without an empty options object when options are default (prevents `bad parameter or other API misuse` throw on Bun 1.3.14).

### Verification
- `./node_modules/.bin/bun test tests/unit/db-adapters/` under Bun 1.3.14 (35/35 tests passed; driver resolves to native `bun:sqlite`).
- `npm run typecheck:core` (0 errors)
- `npx eslint src/lib/db/adapters/driverFactory.ts` (0 issues)
