### PR TITLE
feat(cli-tools): add Prime Agent to the CLI agents catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ the current catalog at **[radar.omniroute.online/planos](https://radar.omniroute
 <b>＋ also works with</b> · Kiro · Command Code · Antigravity · Windsurf · AMP · <b>any OpenAI-compatible tool</b>
 </div>
 
-<sub>📖 Per-tool setup for all 34 tools (26 CLI Code's + 8 CLI Agents) → [`docs/reference/CLI-TOOLS.md`](docs/reference/CLI-TOOLS.md) · 🧩 OpenCode plugin → [`@omniroute/opencode-provider`](https://www.npmjs.com/package/@omniroute/opencode-provider)</sub>
+<sub>📖 Per-tool setup for all 35 tools (26 CLI Code's + 9 CLI Agents) → [`docs/reference/CLI-TOOLS.md`](docs/reference/CLI-TOOLS.md) · 🧩 OpenCode plugin → [`@omniroute/opencode-provider`](https://www.npmjs.com/package/@omniroute/opencode-provider)</sub>
 
 </div>
 

--- a/docs/reference/CLI-TOOLS.md
+++ b/docs/reference/CLI-TOOLS.md
@@ -176,7 +176,7 @@ All tools that appear in `/dashboard/cli-code`. Those with `baseUrlSupport: none
 Tools with `baseUrlSupport: "partial"` show a badge "⚠ Base URL parcial" in the dashboard card.
 ---
 
-## 2. CLI Agents Catalog (8 tools)
+## 2. CLI Agents Catalog (9 tools)
 
 Autonomous agents that appear in `/dashboard/cli-agents`:
 
@@ -190,6 +190,7 @@ Autonomous agents that appear in `/dashboard/cli-agents`:
 | agent-deck   | Agent Deck       | asheshgoplani (OSS)      | full           | false        |
 | omp          | Oh My Pi         | OSS                      | full           | true         |
 | letta        | Letta CLI        | Letta                    | full           | false        |
+| prime-agent  | Prime Agent      | Prime Intellect (OSS)    | full           | false        |
 
 ---
 

--- a/src/shared/constants/cliTools.ts
+++ b/src/shared/constants/cliTools.ts
@@ -593,6 +593,31 @@ aider --openai-api-base "{{baseUrl}}" --model "{{model}}"`,
   },
 
   /**
+   * ★ Added 2026-08-22 — Prime Agent (PrimeIntellect-ai/prime-agent).
+   * A self-improving RLM coding harness (TypeScript) whose LLM toolkit
+   * (prime-agent-ai) supports "any OpenAI-compatible API" + a dedicated
+   * "OpenAI Codex (ChatGPT Plus/Pro OAuth)" provider, so it can point at
+   * OmniRoute's OpenAI-compatible base URL like codex/forge. Installed via
+   * `curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh`;
+   * provider chosen at first run via `/login`.
+   */
+  "prime-agent": {
+    id: "prime-agent",
+    name: "Prime Agent",
+    icon: "terminal",
+    color: "#6366F1",
+    description:
+      "Prime Agent — self-improving RLM coding harness with OpenAI-compatible provider support",
+    docsUrl: "https://github.com/PrimeIntellect-ai/prime-agent",
+    configType: "custom",
+    category: "agent",
+    vendor: "Prime Intellect (OSS)",
+    acpSpawnable: false,
+    baseUrlSupport: "full",
+    defaultCommand: "prime-agent",
+  },
+
+  /**
    * ★ Added by plan 14 (CLI Pages Redesign) — 2026-05-27
    * Kept as a legacy/dual entry after CodeWhale (see below) took over as the
    * actively-maintained successor. Existing users who still have DeepSeek

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -245,6 +245,15 @@ const CLI_TOOLS: Record<string, any> = {
       config: ".jcode/config.json",
     },
   },
+  "prime-agent": {
+    defaultCommand: "prime-agent",
+    envBinKey: "CLI_PRIME_AGENT_BIN",
+    requiresBinary: true,
+    healthcheckTimeoutMs: 8000,
+    paths: {
+      config: ".prime-agent/config.json",
+    },
+  },
   "grok-build": GROK_BUILD_RUNTIME_ENTRY,
   "deepseek-tui": {
     defaultCommand: "deepseek-tui",


### PR DESCRIPTION
## Summary

Adds **Prime Agent** ([PrimeIntellect-ai/prime-agent](https://github.com/PrimeIntellect-ai/prime-agent)) to the CLI agents catalog. Prime Agent is a self-improving RLM coding harness (MIT, TypeScript) whose LLM toolkit (`prime-agent-ai`) supports "any OpenAI-compatible API" plus a dedicated OpenAI Codex provider, so it can point at OmniRoute's OpenAI-compatible base URL exactly like `codex`/`forge` do.

## What's in it

- `src/shared/constants/cliTools.ts`: new `prime-agent` catalog entry (category `agent`, `configType: custom`, `baseUrlSupport: full`, `acpSpawnable: false`, `defaultCommand: prime-agent`).
- `src/shared/services/cliRuntime.ts`: matching runtime entry (`envBinKey: CLI_PRIME_AGENT_BIN`, config `.prime-agent/config.json`).
- Doc-count sync: `README.md` (34 → 35 tools) and `docs/reference/CLI-TOOLS.md` (CLI Agents 8 → 9, plus the table row), so the `check-docs-counts-sync` STRICT gate stays green.

## Verification

- `node scripts/check/check-docs-counts-sync.mjs`: CLI tools count matches (35).
- `tests/unit/cli-catalog-acpspawnable.test.ts`: 26/26 pass.
- open-sse typecheck gate: no new errors (frozen baseline).

Install for users: `curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh`, then pick a provider at first run via `/login` and point it at the OmniRoute base URL.