### PR TITLE
fix(cli): resolve blank device code and undefined verification URL in oauth start (#11164)

### DIFF
--- a/bin/cli/commands/oauth.mjs
+++ b/bin/cli/commands/oauth.mjs
@@ -228,20 +228,38 @@ async function runSocialFlow(def, opts) {
 
 async function runDeviceFlow(def, opts) {
   const providerKey = resolveBackendKey(def.id);
-  const startRes = await apiFetch(`/api/providers/${providerKey}/auth/start`, {
-    ...targetApiOptions(opts),
-    method: "POST",
-  });
+  let startRes = await apiFetch(`/api/oauth/${providerKey}/device-code`, targetApiOptions(opts));
+  if (!startRes.ok) {
+    startRes = await apiFetch(`/api/providers/${providerKey}/auth/start`, {
+      ...targetApiOptions(opts),
+      method: "POST",
+    });
+  }
   if (!startRes.ok) {
     process.stderr.write(`Failed to start device flow: ${startRes.status}\n`);
     process.exit(1);
   }
   const start = await startRes.json();
-  process.stdout.write(
-    `\nDevice code: ${start.userCode ?? start.user_code ?? ""}\nVisit: ${start.verificationUri ?? start.verification_uri}\n\n`
-  );
-  if (opts.browser !== false)
-    await openBrowser(start.verificationUri ?? start.verification_uri ?? "");
+  const userCode = start.userCode ?? start.user_code ?? "";
+  const verificationUri =
+    start.verificationUriComplete ??
+    start.verification_uri_complete ??
+    start.verificationUri ??
+    start.verification_uri ??
+    start.authUrl ??
+    start.url ??
+    "";
+
+  if (userCode) {
+    process.stdout.write(`\nDevice code: ${userCode}\nVisit: ${verificationUri}\n\n`);
+  } else if (verificationUri) {
+    process.stdout.write(`\nVisit: ${verificationUri}\n\n`);
+  } else {
+    process.stdout.write(`\nAuthorization URL not available\n\n`);
+  }
+
+  if (opts.browser !== false && verificationUri)
+    await openBrowser(verificationUri);
   process.stderr.write("Waiting for device authorization...\n");
   const deadline = Date.now() + (opts.timeout ?? 300000);
   const intervalMs = (start.intervalMs ?? start.interval ?? 5) * 1000;

--- a/tests/unit/oauth-device-flow-11164.test.ts
+++ b/tests/unit/oauth-device-flow-11164.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("device code normalization handles camelCase, snake_case, and authUrl without returning undefined", () => {
+  const cases = [
+    {
+      input: { userCode: "ABCD-1234", verificationUri: "https://auth.example.com" },
+      expectedCode: "ABCD-1234",
+      expectedUri: "https://auth.example.com",
+    },
+    {
+      input: { user_code: "EFGH-5678", verification_uri: "https://auth.example.com/device" },
+      expectedCode: "EFGH-5678",
+      expectedUri: "https://auth.example.com/device",
+    },
+    {
+      input: { authUrl: "https://studio.example.com/auth" },
+      expectedCode: "",
+      expectedUri: "https://studio.example.com/auth",
+    },
+  ];
+
+  for (const c of cases) {
+    const userCode = c.input.userCode ?? c.input.user_code ?? "";
+    const verificationUri =
+      c.input.verificationUriComplete ??
+      c.input.verification_uri_complete ??
+      c.input.verificationUri ??
+      c.input.verification_uri ??
+      c.input.authUrl ??
+      c.input.url ??
+      "";
+
+    assert.equal(userCode, c.expectedCode);
+    assert.equal(verificationUri, c.expectedUri);
+    assert.notEqual(verificationUri, "undefined");
+  }
+});


### PR DESCRIPTION
### Summary

Resolves #11164 where `omniroute oauth start --provider claude-code --no-browser` (and other device-flow CLI OAuth commands) printed a blank device code and `Visit: undefined`:

1. **Endpoint Resolution**:
   Updated `runDeviceFlow` in `bin/cli/commands/oauth.mjs` to try `/api/oauth/${providerKey}/device-code` before falling back to `/api/providers/${providerKey}/auth/start`.

2. **Property Normalization**:
   Extracted property fallbacks for both camelCase and snake_case response payloads:
   - `userCode`: `start.userCode ?? start.user_code ?? ""`
   - `verificationUri`: `start.verificationUriComplete ?? start.verification_uri_complete ?? start.verificationUri ?? start.verification_uri ?? start.authUrl ?? start.url ?? ""`

3. **Output Formatting**:
   Surfaces `Device code: ...` only when a user code is present; avoids printing `undefined` URLs or empty labels.

### Verification
- `node --import tsx/esm --test tests/unit/oauth-device-flow-11164.test.ts` (PASS)
- `npm run typecheck:core` (0 errors)
- `npm run check:docs-all` (PASS)
