### PR TITLE
fix(sse): stop keyless pollinations 401s from poisoning the noauth pool (#9827)

### DIFF
--- a/open-sse/executors/pollinations.ts
+++ b/open-sse/executors/pollinations.ts
@@ -3,6 +3,29 @@ import { PROVIDERS } from "../config/constants.ts";
 import { DEFAULT_POOL_CONFIG } from "../services/sessionPool/types.ts";
 import type { ExecuteInput } from "./base.ts";
 
+/** Premium Pollinations models — upstream answers 401 UNAUTHORIZED without a key. */
+const PREMIUM_MODELS = new Set([
+  "claude",
+  "claude-fast",
+  "claude-large",
+  "gemini",
+  "gemini-fast",
+  "midijourney",
+  "midijourney-large",
+]);
+
+/** Build the actionable 401 error shown when a premium model is used without a key. */
+function premiumModelRequiresKeyError(model: string): Error {
+  const enhanced = new Error(
+    `Pollinations model "${model}" requires an API key. ` +
+      `Free keyless models: openai, openai-fast, openai-large, qwen-coder, mistral, deepseek, grok, gemini-flash-lite-3.1, perplexity-fast, perplexity-reasoning. ` +
+      `Get a Pollinations API key at https://enter.pollinations.ai and add it in Settings → API Keys.`
+  );
+  (enhanced as any).status = 401;
+  (enhanced as any).type = "authentication_error";
+  return enhanced;
+}
+
 export class PollinationsExecutor extends BaseExecutor {
   constructor() {
     super("pollinations", PROVIDERS["pollinations"] || { format: "openai" });
@@ -11,9 +34,7 @@ export class PollinationsExecutor extends BaseExecutor {
 
   buildUrl(_model: string, _stream: boolean, urlIndex = 0, _credentials = null): string {
     const baseUrls = this.getBaseUrls();
-    return (
-      baseUrls[urlIndex] || baseUrls[0] || "https://gen.pollinations.ai/v1/chat/completions"
-    );
+    return baseUrls[urlIndex] || baseUrls[0] || "https://gen.pollinations.ai/v1/chat/completions";
   }
 
   buildHeaders(credentials: any, stream = true): Record<string, string> {
@@ -54,6 +75,15 @@ export class PollinationsExecutor extends BaseExecutor {
 
     if (!isAnonymous) {
       return super.execute(input);
+    }
+
+    // #9827 — premium models require a key upstream (verified: 401 UNAUTHORIZED).
+    // Fail fast with guidance instead of dispatching an anonymous request whose
+    // 401 would be recorded against the keyless connection's health and flip the
+    // anonymous pool to "all accounts unavailable".
+    const requestedModel = input.model || "";
+    if (PREMIUM_MODELS.has(requestedModel)) {
+      throw premiumModelRequiresKeyError(requestedModel);
     }
 
     const pool = this.getPool();
@@ -98,17 +128,9 @@ export class PollinationsExecutor extends BaseExecutor {
       }
       // Enhance 401 errors with actionable guidance
       if (err?.status === 401 || err?.statusCode === 401) {
-        const premiumModels = ["claude", "claude-fast", "claude-large", "gemini", "gemini-fast", "midijourney", "midijourney-large"];
         const model = input.model || "";
-        if (premiumModels.includes(model)) {
-          const enhanced = new Error(
-            `Pollinations model "${model}" requires an API key. ` +
-            `Free keyless models: openai, openai-fast, openai-large, qwen-coder, mistral, deepseek, grok, gemini-flash-lite-3.1, perplexity-fast, perplexity-reasoning. ` +
-            `Get a Pollinations API key at https://enter.pollinations.ai and add it in Settings → API Keys.`
-          );
-          (enhanced as any).status = 401;
-          (enhanced as any).type = "authentication_error";
-          throw enhanced;
+        if (PREMIUM_MODELS.has(model)) {
+          throw premiumModelRequiresKeyError(model);
         }
       }
       throw err;

--- a/open-sse/handlers/chatCore/keyHealth.ts
+++ b/open-sse/handlers/chatCore/keyHealth.ts
@@ -41,6 +41,13 @@ export function recordKeyHealthStatus(
   const connId = creds?.connectionId as string | undefined;
   if (!connId) return;
 
+  // #9827: a keyless (noauth) connection has no key to fail. Upstream 401s on
+  // the anonymous path (e.g. Pollinations premium models that require a key)
+  // must not poison the connection's key-health state — doing so flips the whole
+  // anonymous pool to "all accounts unavailable". Mirrors the cliproxyapi guard
+  // above: there is nothing to record when no key material exists.
+  if (!creds?.apiKey && !creds?.accessToken) return;
+
   const psd = creds.providerSpecificData as Record<string, unknown> | undefined;
   const extraKeys = (psd?.extraApiKeys as string[] | undefined) ?? [];
   const health = psd?.apiKeyHealth as Record<string, KeyHealth> | undefined;

--- a/tests/unit/chatcore-key-health.test.ts
+++ b/tests/unit/chatcore-key-health.test.ts
@@ -15,7 +15,10 @@ const touched: string[] = [];
 
 function creds(connectionId: string, psd: Record<string, unknown> = {}) {
   touched.push(connectionId);
-  return { connectionId, providerSpecificData: psd };
+  // Key health only applies to connections that actually carry key material —
+  // the synthetic noauth connection (apiKey/accessToken null) is covered by the
+  // dedicated #9827 no-op test below.
+  return { connectionId, apiKey: "kh-test-key", accessToken: null, providerSpecificData: psd };
 }
 
 afterEach(() => {
@@ -67,6 +70,17 @@ test("non-401 / non-2xx status does not touch key health", () => {
   const conn = "kh-5xx-noop";
   recordKeyHealthStatus(500, creds(conn), noopLog);
   assert.equal(getAllKeyHealth()[`${conn}:primary`], undefined);
+});
+
+test("401 on a keyless connection is a no-op — no key to fail (#9827)", () => {
+  const before = Object.keys(getAllKeyHealth()).length;
+  // Synthetic noauth credentials (authType "none") carry no key material.
+  recordKeyHealthStatus(
+    401,
+    { connectionId: "noauth", apiKey: null, accessToken: null, providerSpecificData: {} },
+    noopLog
+  );
+  assert.equal(Object.keys(getAllKeyHealth()).length, before);
 });
 
 test("CPA pool failures do not poison the selected native connection key", () => {

--- a/tests/unit/executor-pollinations.test.ts
+++ b/tests/unit/executor-pollinations.test.ts
@@ -47,7 +47,9 @@ test("PollinationsExecutor enhances 401 errors for premium models with actionabl
   // Mock super.execute (BaseExecutor.prototype.execute) to throw a 401
   const origBaseExec = Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute;
   Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute = async function () {
-    const err = new Error("Authentication required. Please provide an API key via Authorization header (Bearer token) or ?key= query parameter.");
+    const err = new Error(
+      "Authentication required. Please provide an API key via Authorization header (Bearer token) or ?key= query parameter."
+    );
     (err as any).status = 401;
     throw err;
   };
@@ -65,6 +67,38 @@ test("PollinationsExecutor enhances 401 errors for premium models with actionabl
     assert.match(err.message, /Pollinations model "claude" requires an API key/);
     assert.match(err.message, /enter\.pollinations\.ai/);
     assert.match(err.message, /Free keyless models/);
+  } finally {
+    Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute = origBaseExec;
+  }
+});
+
+test("anonymous premium model fails fast with guidance and never dispatches upstream (#9827)", async () => {
+  const executor = new PollinationsExecutor();
+  let dispatched = false;
+
+  const origBaseExec = Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute;
+  Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute = async function () {
+    dispatched = true;
+    return new Response("ok", { status: 200 });
+  };
+
+  try {
+    await executor.execute({
+      model: "gemini",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: {},
+    });
+    assert.fail("Should have thrown");
+  } catch (err) {
+    assert.equal(err.status, 401);
+    assert.match(err.message, /Pollinations model "gemini" requires an API key/);
+    assert.match(err.message, /Free keyless models/);
+    assert.equal(
+      dispatched,
+      false,
+      "upstream must not be called for premium models on the anonymous path"
+    );
   } finally {
     Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute = origBaseExec;
   }


### PR DESCRIPTION
> ⚠️ **base-red inherited: #9985** — the `release/v3.8.50` base is not green (open "Release branch not green" report). The failing checks here (Fast Quality Gates, No new ESLint warnings, Unit Tests fast-path ×4) fail on the base itself, in files untouched by this PR (`combos/page.tsx` TS2554×188, `HarImportButton.tsx`, chatCore-reasoning/config-generator/quota-classifier/live-sweep unit tests). This PR's own checks pass: Build, Vitest, Docs Gates, semgrep, dast-smoke, Change Classification, Merge integrity — and both new tests pass inside the unit suites.

Closes #9827.

## Problem

Anonymous Pollinations requests keep returning 401 and, worse, poison the whole keyless pool:

```
AUTH | Using pollinations account: noauth...
AUTH | 401 on connection noauth - key marked as failed (failure #7)
AUTH | pollinations | all 1 accounts unavailable
```

Root cause (replicated live): the upstream only 401s **premium** models on the anonymous path (`claude`, `gemini`, `midijourney`, …). The poison chain is:

1. A premium model is requested anonymously → upstream legitimately answers `401 UNAUTHORIZED`
2. `chatCore` sees the 401 → `recordKeyHealthStatus(401, execCreds)` (`open-sse/handlers/chatCore/keyHealth.ts`)
3. `keyHealth` marks the **keyless synthetic `noauth` connection's "key" as failed** — a noauth connection has no `apiKey`/`accessToken`, so there is nothing to fail, but it flips the anonymous pool to `all 1 accounts unavailable`
4. Free anonymous models (`openai`, `qwen-coder`, …) then die with the pool

## Fix (4 files)

**`open-sse/handlers/chatCore/keyHealth.ts`** — new guard in `recordKeyHealthStatus()`:

```ts
if (!creds?.apiKey && !creds?.accessToken) return;
```

A keyless connection has no key material to fail; upstream 401s on the anonymous path are now a no-op and can no longer disable the pool (mirrors the existing `cliproxyapi` guard). Keyed connections are unaffected.

**`open-sse/executors/pollinations.ts`** — premium-model list + error builder hoisted to module scope; anonymous **premium** requests now **fail fast with guidance** ("Pollinations model X requires an API key. Free keyless models: openai, … Get a key at https://enter.pollinations.ai") *before* any upstream dispatch, so the 401 that starts the poison chain never happens.

**Tests** — `tests/unit/chatcore-key-health.test.ts` (401 on a keyless connection is a no-op) and `tests/unit/executor-pollinations.test.ts` (anonymous premium fails fast, never dispatches upstream).

## Verification

- ✅ 15/15 targeted unit tests pass (executor + key-health suites, incl. the 2 new #9827 tests)
- ✅ `typecheck:core` clean; prettier/eslint/any-budget/docs-sync pre-commit gates pass
- ✅ Bug confirmed present at the pristine `release/v3.8.50` tip — the guard only covered `cliproxyapi` + missing `connectionId`
- ✅ Live reproduction + fix verification on the same scenario (see comments on this PR)

## Live upstream probe results (2026-08-22, UTC timestamps 2026-08-23T01:17Z)

Direct probes against `gen.pollinations.ai` from this machine, to reconcile with #11117 (which makes the Pollinations key fully required based on reports that upstream now 401s ALL anonymous traffic):

| # | Request | Result |
|---|---------|--------|
| 1 | Anonymous chat, model `openai` (no auth header) | **200** — real completion |
| 2 | Anonymous chat, model `claude` (premium) | **401** `{"code":"UNAUTHORIZED","message":"A valid API key is required"}` |
| 3 | Keyed chat, model `openai` (`Bearer sk_…`) | **200** — real completion |
| 4 | Keyed chat, model `claude` (premium) | **402** `PAYMENT_REQUIRED` "Insufficient balance" (key authenticates; balance 0) |
| 5 | Anonymous image gen, model `flux` | **401** `UNAUTHORIZED` — image generation now requires a key |
| 6 | Keyed image gen, model `flux` | **402** `PAYMENT_REQUIRED` (key authenticates; balance 0) |

Keyed end-to-end through the running app: `POST /v1/chat/completions` `pollinations/openai` → **200** with a real completion via the keyed connection.

### Reconciliation note for #11117

As of 2026-08-22, upstream does **not** 401 *all* anonymous traffic: anonymous **text chat** on the free models returns **200** (probe 1), which is why this PR keeps the keyless path alive rather than removing it. The 401s that motivated #11117 are real but narrower:

- anonymous **premium models** → 401 (probe 2)
- anonymous **image generation** → 401 (probe 5)

Both fixes are complementary: #11117 hard-requires a key at the connection/UI level, while this PR stops keyless 401s from poisoning the pool and gives anonymous users a clear "premium requires a key" error for the models that do demand one.
