### PR TITLE
fix(ci): green the release/v3.8.50 base (#9985)

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -853,11 +853,6 @@
       "count": 1
     }
   },
-  "src/app/api/usage/call-logs/route.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/api/usage/quota/route.ts": {
     "no-restricted-imports": {
       "count": 1
@@ -949,11 +944,6 @@
     }
   },
   "src/app/api/v1/models/catalog.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/api/v1/rerank/route.ts": {
     "no-restricted-imports": {
       "count": 1
     }

--- a/tests/unit/cli-combo-command.test.ts
+++ b/tests/unit/cli-combo-command.test.ts
@@ -37,7 +37,11 @@ async function withComboEnv(fn: (dataDir: string) => Promise<void>) {
 test("combo create inserts a new combo via db module", async () => {
   await withComboEnv(async () => {
     const { runComboCreateCommand } = await import("../../bin/cli/commands/combo.mjs");
-    const result = await runComboCreateCommand("my-combo", "priority", {});
+    // #11162: combo create refuses combos without any model — pass a model
+    // like the sibling tests updated in that commit.
+    const result = await runComboCreateCommand("my-combo", "priority", {
+      models: ["openai/gpt-4o-mini"],
+    });
     assert.equal(result, 0);
 
     // Verify via the same db module
@@ -53,10 +57,12 @@ test("combo create fails if combo already exists", async () => {
   await withComboEnv(async () => {
     const { runComboCreateCommand } = await import("../../bin/cli/commands/combo.mjs");
 
-    await runComboCreateCommand("dup-combo", "auto", {});
+    await runComboCreateCommand("dup-combo", "auto", { models: ["openai/gpt-4o-mini"] });
     const originalError = console.error;
     console.error = () => {};
-    const result = await runComboCreateCommand("dup-combo", "auto", {});
+    const result = await runComboCreateCommand("dup-combo", "auto", {
+      models: ["openai/gpt-4o-mini"],
+    });
     console.error = originalError;
 
     assert.equal(result, 1);
@@ -68,7 +74,7 @@ test("combo delete removes the combo", async () => {
     const { runComboCreateCommand, runComboDeleteCommand } =
       await import("../../bin/cli/commands/combo.mjs");
 
-    await runComboCreateCommand("to-delete", "weighted", {});
+    await runComboCreateCommand("to-delete", "weighted", { models: ["openai/gpt-4o-mini"] });
     const result = await runComboDeleteCommand("to-delete", { yes: true });
     assert.equal(result, 0);
 
@@ -91,7 +97,7 @@ test("combo switch updates active combo when server is offline", async () => {
     const { runComboCreateCommand, runComboSwitchCommand } =
       await import("../../bin/cli/commands/combo.mjs");
 
-    await runComboCreateCommand("my-switch", "round-robin", {});
+    await runComboCreateCommand("my-switch", "round-robin", { models: ["openai/gpt-4o-mini"] });
     const result = await runComboSwitchCommand("my-switch", {});
     assert.equal(result, 0);
 

--- a/tests/unit/clinepass-provider.test.ts
+++ b/tests/unit/clinepass-provider.test.ts
@@ -87,7 +87,7 @@ test("ClinePass fallback is the official subscription-only catalog", () => {
 test("Cline fallback owns recommended/free models and excludes the ClinePass namespace", () => {
   const ids = providerRegistry.cline.models.map((model: { id: string }) => model.id);
   assert.deepEqual(ids, [
-    "zai/glm-5.2",
+    "z-ai/glm-5.2",
     "x-ai/grok-4.5",
     "openai/gpt-5.6-sol",
     "moonshotai/kimi-k3",

--- a/tests/unit/guide-settings-route.test.ts
+++ b/tests/unit/guide-settings-route.test.ts
@@ -127,7 +127,11 @@ test("guide-settings POST writes OpenCode config with current schema and multi-m
     "cc/claude-sonnet-4-20250514",
     "gg/gemini-2.5-pro",
   ]);
-  assert.equal(content.providers, undefined);
+  // The v2 provider schema is dual-written alongside the v1 block: the v2
+  // entry lives under `providers.omniroute` with `package`/`settings`.
+  assert.equal(content.providers.omniroute.package, "@opencode-ai/ai/providers/openai-compatible");
+  assert.equal(content.providers.omniroute.settings.baseURL, "http://my-omni/v1");
+  assert.ok(content.providers.omniroute.settings.apiKey.startsWith("sk-"));
 });
 
 test("guide-settings POST preserves existing OpenCode config fields while only updating provider.omniroute", async () => {

--- a/tests/unit/provider-alias-uniqueness.test.ts
+++ b/tests/unit/provider-alias-uniqueness.test.ts
@@ -47,21 +47,18 @@ test("primary providers keep the short alias; web variants use their own id", ()
   assert.equal(PROVIDER_ID_TO_ALIAS["qwen-web"], "qwen-web");
   assert.equal(PROVIDER_ID_TO_ALIAS.kimi, "kimi");
   assert.equal(PROVIDER_ID_TO_ALIAS["kimi-web"], "kimi-web");
-  assert.equal(PROVIDER_ID_TO_ALIAS.hackclub, "hc");
   assert.equal(PROVIDER_ID_TO_ALIAS.huggingchat, "huggingchat");
 });
 
 test("src/shared providers map resolves the same aliases unambiguously", () => {
   // alias → id
   assert.equal(resolveProviderId("kimi"), "kimi");
-  assert.equal(resolveProviderId("hc"), "hackclub");
   // id used as alias for the secondary variants
   assert.equal(resolveProviderId("qwen-web"), "qwen-web");
   assert.equal(resolveProviderId("kimi-web"), "kimi-web");
   assert.equal(resolveProviderId("huggingchat"), "huggingchat");
   // id → alias
   assert.equal(getProviderAlias("kimi"), "kimi");
-  assert.equal(getProviderAlias("hackclub"), "hc");
 });
 
 // #6673: hailuo-web must not collide with the paid API-key minimax/minimax-cn

--- a/tests/unit/t40-opencode-cli-tools-integration.test.ts
+++ b/tests/unit/t40-opencode-cli-tools-integration.test.ts
@@ -110,7 +110,11 @@ test("T40: OpenCode config document uses current provider schema", () => {
     configDocument.provider.omniroute.models["gg/gemini-2.5-pro"].name,
     "Gemini 2.5 Pro"
   );
-  assert.equal(configDocument.providers, undefined);
+  // v2 provider schema is dual-written alongside the v1 block.
+  assert.equal(
+    configDocument.providers.omniroute.package,
+    "@opencode-ai/ai/providers/openai-compatible"
+  );
 });
 
 test("T40: OpenCode explicit multi-model selection overrides fallback defaults", () => {


### PR DESCRIPTION
## What

Finishes greening the `release/v3.8.50` base (#9985). **Rebuilt on the current base (`79c5bdf68`)** — the owner's #10964 already fixed the first 7 failures, so this PR now carries only the remaining base-red failures:

| File | Issue | Fix |
|---|---|---|
| `tests/unit/guide-settings-route.test.ts` | v2 OpenCode dual-write — #10964 updated the model-limit blocks but missed the stale `content.providers === undefined` assert (line 130) | Assert the v2 `providers.omniroute.package/settings` shape |
| `tests/unit/t40-opencode-cli-tools-integration.test.ts` | stale v1-only assertion | Assert v2 `providers.omniroute.package` |
| `tests/unit/clinepass-provider.test.ts` | `zai/glm-5.2` stale id | Use `z-ai/glm-5.2` vendor prefix (#6108) |
| `tests/unit/provider-alias-uniqueness.test.ts` | 3 stale hackclub assertions | Remove — Hack Club AI removed (#11118) |
| `config/quality/eslint-suppressions.json` | 2 stale suppressions | Prune (`call-logs`, `rerank`) |
| `tests/unit/cli-combo-command.test.ts` | **#11162 made combo create refuse no-model combos; this file was missed** (reported as #11203) | Pass `models: ["openai/gpt-4o-mini"]` to the create calls, mirroring #11162's sibling-test fix |

## Verification (Linux, Docker, Node 24.19.0)

- guide-settings: **4/4** · t40: **9/9** · clinepass: **21/21** · provider-alias: **6/6** · cli-combo: **5/5** (pristine was 2/5)
- ESLint gate clean (pruned suppressions, no "stale suppressions" warning)
- `check:dashboard-typecheck`: 0 regressions vs frozen baseline (owner's #10964 already fixed combos/HarImport)
- Typecheck, docs-sync, any-budget, tracked-artifacts: green locally

## Note

The 7 originally-listed fixes (combos TS2554, HarImport TS2339, aihorde SSRF guard, config-generator 128K, quota 403, openrouter allExpired, pt-BR keys) are **no longer in this PR** — the owner's #10964 landed equivalent fixes in the base. Thanks to the reviewer for flagging cli-combo-command (#11203).

Closes the remaining base-red tail of #9985 so #11194 and other dependent PRs get a green base.