### PR TITLE
docs(i18n): clarify embedded services purpose for beginners

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1012,7 +1012,7 @@
     "apiManager": "API Keys",
     "apiManagerSubtitle": "Manage API keys and access",
     "embeddedServices": "Embedded Services",
-    "embeddedServicesSubtitle": "Manage local proxy services",
+    "embeddedServicesSubtitle": "Optional local services",
     "logs": "Logs",
     "webhooks": "Webhooks",
     "webhooksSubtitle": "Get notified of events",
@@ -8677,7 +8677,7 @@
   },
   "embeddedServices": {
     "title": "Embedded Services",
-    "description": "Local engines managed on demand — CLIProxyAPI, 9Router, Mux, and Bifrost. Accessible on loopback only.",
+    "description": "Optional helpers that run on your machine. Most users can start without them — install one only when an integration needs it.",
     "stateRunning": "Running",
     "stateStopped": "Stopped",
     "stateStarting": "Starting",


### PR DESCRIPTION
## What

Reframes the **Embedded Services** dashboard copy so beginners understand these are **optional local helpers**, not required infrastructure they must set up.

Two English string changes in `src/i18n/messages/en.json`:

| Key                            | Before                                                                                                   | After                                                                                                                           |
| ------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| `nav.embeddedServicesSubtitle` | "Manage local proxy services"                                                                            | "Optional local services"                                                                                                       |
| `embeddedServices.description` | "Local engines managed on demand — CLIProxyAPI, 9Router, Mux, and Bifrost. Accessible on loopback only." | "Optional helpers that run on your machine. Most users can start without them — install one only when an integration needs it." |

## Why

Part of a beginner-UX communication pass (tracking: #11197). The current copy leads with jargon ("proxy services", "local engines managed on demand") and lists product names before explaining **whether a new user needs any of this**. The page sits in the sidebar at the same visual weight as core setup, so beginners often assume it's a required step. The new copy leads with the user's decision — _most people can skip this_ — and defers the how to the moment an integration actually needs it.

No behavior, routing, or component logic changes — English microcopy only.

## Scope

- 1 file, 2 lines changed (`src/i18n/messages/en.json`).
- Other 41 locales intentionally untouched: the repo's `i18n:sync-ui` pass adds `__MISSING__` markers for the whole backlog of pending keys across every locale, which would balloon this into a 43-file diff of unrelated churn. Leaving them lets the normal translation workflow pick up the two new English values. English is the source-of-truth fallback, so all locales render the improved copy until translated.

## Testing

- `npm run lint` — passes (pre-existing `prune-suppressions` notice on the base branch is unrelated).
- Prettier-clean (`npx prettier --check src/i18n/messages/en.json`).
- No `.ts`/`.tsx` touched, so typecheck surface is unaffected.

## Related

- Tracking issue: #11197
- Wayfinder map: #11167
