### PR TITLE
fix(i18n): complete vi parity for cheaperInferenceSponsorBanner

### DIFF
--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -13869,5 +13869,12 @@
     "toolsMismatch": "Nhà cung cấp không hỗ trợ gọi công cụ",
     "structuredOutputMismatch": "Nhà cung cấp không hỗ trợ đầu ra có cấu trúc",
     "contextWindowMismatch": "Yêu cầu vượt quá cửa sổ ngữ cảnh của nhà cung cấp"
+  },
+  "cheaperInferenceSponsorBanner": {
+    "title": "Cheaper Inference là Đối tác Mã nguồn Mở của OmniRoute",
+    "description": "Một cổng xếp hạng theo chi phí, bán lại hàng chục mô hình tiên phong sau một endpoint tương thích OpenAI — định tuyến mỗi yêu cầu đến nhà cung cấp đủ điều kiện rẻ nhất, không bao giờ vượt giá niêm yết.",
+    "cta": "Lấy khóa API",
+    "partnerLinkNote": "Liên kết đối tác",
+    "dismissAriaLabel": "Đóng"
   }
 }


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## Summary

The sponsor banner (`cheaperInferenceSponsorBanner`) landed in `en.json`/`pt.json` without the Vietnamese copy, breaking the **strict vi parity gate** — 3 failing tests in `tests/unit/i18n-vi-completeness.test.ts` (key parity, ICU placeholder parity, ICU parse regression), red on every release-branch CI run since.

Adds the 5 missing `vi.json` translations (`title`, `description`, `cta`, `partnerLinkNote`, `dismissAriaLabel`), inserted at the same relative position as `en.json` (after `capabilityFilter`).

Note: the `fix/release-v3.8.50-basereds-sse-vi` worktree that owned this debt has been idle for 4 days (last commit 2026-08-18), so this drains the orphaned item. That worktree is untouched.

## Validation

- `i18n-vi-completeness.test.ts`: **5/5** (was 2/5 on the base tip)
- `npm run i18n:check-ui-coverage`: PASS — vi now **100.0%** (12802/12802)
- `npm run i18n:check-value-drift`: PASS
- Prettier clean; JSON parses (the completeness test itself parses it)