### PR TITLE
pricing: DeepSeek peak is Monday to Friday, not every day (comment only)

### DIFF
--- a/src/shared/constants/pricing/frontier-labs.ts
+++ b/src/shared/constants/pricing/frontier-labs.ts
@@ -317,15 +317,21 @@ export const DEFAULT_PRICING_FRONTIER = {
       reasoning: 2.19,
       cache_creation: 0.55,
     },
-    // DeepSeek official API list prices, checked 2026-08-18. Superseded the
+    // DeepSeek official API list prices, checked 2026-08-23. Superseded the
     // prior 2026-08-13 flat prices below: DeepSeek switched v4-pro/v4-flash to
     // peak/off-peak dynamic pricing on 2026-08-17 (peak = exactly 2x off-peak;
-    // peak hours 01:00-04:00 and 06:00-10:00 UTC — see
-    // https://api-docs.deepseek.com/quick_start/pricing/). This static table has
+    // peak hours 01:00-04:00 and 06:00-10:00 UTC, Monday through Friday — the
+    // whole weekend is off-peak, see
+    // https://api-docs.deepseek.com/quick_start/pricing/). That weekday clause
+    // is easy to miss: the Chinese page states it in Beijing time
+    // (「高峰时段为北京时间周一至周五 9:00 - 12:00、14:00 - 18:00」) while the English
+    // one attaches UTC to the hours and leaves the weekday unqualified. Peak is
+    // therefore 35 hours a week, not 49. This static table has
     // no time-of-day dimension, so these are the OFF-PEAK (lower-bound) prices —
-    // a deliberate, documented undercount during the two peak windows, never an
-    // overcount. True peak-awareness would need a time dimension threaded through
-    // getPricingForModel() and every call site; out of scope for this fix.
+    // a deliberate, documented undercount, never an overcount, and it now applies
+    // to 21% of the week rather than 29%. True peak-awareness would need a time
+    // dimension threaded through getPricingForModel() and every call site; out of
+    // scope for this fix.
     "deepseek-v4-pro": {
       input: 0.66,
       output: 1.98,


### PR DESCRIPTION
## Summary

Comment-only correction in `src/shared/constants/pricing/frontier-labs.ts`. The DeepSeek block describes peak as `01:00-04:00 and 06:00-10:00 UTC` with no day restriction; the vendor restricts those windows to weekdays.

DeepSeek's pricing page:

> Peak hours are 01:00 - 04:00 and 06:00 - 10:00 UTC, **Monday through Friday** (all other hours are off-peak).

The Chinese version of the same footnote pins the timezone rather than the hours: 「高峰时段为北京时间**周一至周五** 9:00 - 12:00、14:00 - 18:00」. Reading only the English one, the weekday clause is easy to drop, which is what happened here.

The prices themselves are correct and unchanged — I re-read the page today and `deepseek-v4-pro` 0.66 / 1.98 / 0.022 and `deepseek-v4-flash` 0.22 / 0.66 / 0.007 are still the off-peak rates. Only the `checked` date and the description of the window move.

This makes the existing decision look better rather than worse: because peak is 35 hours a week and not 49, the documented undercount applies to 21% of the week, not 29%. I did not touch the "out of scope for this fix" conclusion — the static table is still the right call at this size.

## Related Issues

- None.

## Validation

- [x] Change type: other (comment only)
- [x] No production code changed, so no focused tests apply
- [ ] `npm run lint` — not run locally; the file is comment-only and CI covers it

## Tests Added Or Updated

- None. No production code changed.

## Coverage Notes

- `src/shared/constants/pricing/frontier-labs.ts` changes are inside a comment block; no executable line is affected.
