### PR TITLE
fix(kie): map the Nano Banana 2 Market id to its KIE upstream id (#11225)

### DIFF
--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -91,6 +91,14 @@ interface KieImageOptions {
   } | null;
 }
 
+export const KIE_MARKET_UPSTREAM_MODEL_IDS: ReadonlyMap<string, string> = new Map([
+  ["google-imagen/nano-banana-2", "nano-banana-2"],
+]);
+
+export function resolveKieMarketUpstreamModelId(publicModelId: string): string {
+  return KIE_MARKET_UPSTREAM_MODEL_IDS.get(publicModelId) ?? publicModelId;
+}
+
 const OPENAI_IMAGE_TO_IMAGE_MODELS = new Set([
   "black-forest-labs/FLUX.2-max",
   "black-forest-labs/FLUX.2-pro",
@@ -205,7 +213,9 @@ function isCodexChatGptModelAccessError(status: number, errorText: string, model
       if (typeof nested === "string") detail = nested;
     }
   }
-  return detail === `The '${model}' model is not supported when using Codex with a ChatGPT account.`;
+  return (
+    detail === `The '${model}' model is not supported when using Codex with a ChatGPT account.`
+  );
 }
 
 const BFL_MODEL_ENDPOINTS = {
@@ -773,7 +783,7 @@ async function handleKieImageGeneration({
       input.image_url = imageUrl;
     }
     payload = {
-      model,
+      model: resolveKieMarketUpstreamModelId(model),
       input,
     };
   } else {

--- a/tests/unit/kie-market-upstream-model-id-11225.test.ts
+++ b/tests/unit/kie-market-upstream-model-id-11225.test.ts
@@ -6,7 +6,10 @@ import { join } from "node:path";
 
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-kie-11225-"));
 
-const { handleImageGeneration } = await import("../../open-sse/handlers/imageGeneration.ts");
+const { KIE_IMAGE_MODELS } =
+  await import("../../open-sse/config/providers/registry/kie/imageModels.ts");
+const { handleImageGeneration, KIE_MARKET_UPSTREAM_MODEL_IDS, resolveKieMarketUpstreamModelId } =
+  await import("../../open-sse/handlers/imageGeneration.ts");
 
 /**
  * Issue #11225 — KIE Market public model IDs are namespaced for the OmniRoute
@@ -28,9 +31,16 @@ interface CapturedCreate {
   body: Record<string, unknown>;
 }
 
-async function runKieMarketGeneration(publicModel: string): Promise<CapturedCreate> {
+interface CapturedMarketGeneration {
+  create: CapturedCreate;
+  pollUrl: string;
+  result: Awaited<ReturnType<typeof handleImageGeneration>>;
+}
+
+async function runKieMarketGeneration(publicModel: string): Promise<CapturedMarketGeneration> {
   const originalFetch = globalThis.fetch;
   let captured: CapturedCreate | undefined;
+  let pollUrl = "";
 
   globalThis.fetch = (async (url: unknown, options: { body?: unknown } = {}) => {
     const stringUrl = String(url);
@@ -47,6 +57,7 @@ async function runKieMarketGeneration(publicModel: string): Promise<CapturedCrea
     }
 
     if (stringUrl.startsWith("https://api.kie.ai/api/v1/jobs/recordInfo")) {
+      pollUrl = stringUrl;
       return new Response(
         JSON.stringify({
           code: 200,
@@ -77,38 +88,144 @@ async function runKieMarketGeneration(publicModel: string): Promise<CapturedCrea
     });
 
     assert.equal(result.success, true, "KIE Market generation should succeed against the stub");
+    assert.ok(captured, "expected a createTask request to be captured");
+    assert.ok(pollUrl, "expected recordInfo polling to be captured");
+    return { create: captured, pollUrl, result };
   } finally {
     globalThis.fetch = originalFetch;
   }
-
-  assert.ok(captured, "expected a createTask request to be captured");
-  return captured;
 }
+
+function resolveLiveKieMarketCatalog() {
+  return KIE_IMAGE_MODELS.filter(({ isMarket }) => isMarket).map(({ id }) => ({
+    publicModelId: id,
+    upstreamModelId: resolveKieMarketUpstreamModelId(id),
+  }));
+}
+
+test("KIE Market resolver changes exactly one id in the live market catalog", () => {
+  const roundTrips = resolveLiveKieMarketCatalog();
+  const changed = roundTrips.filter(({ publicModelId, upstreamModelId }) => {
+    return upstreamModelId !== publicModelId;
+  });
+
+  assert.deepEqual(changed, [
+    {
+      publicModelId: "google-imagen/nano-banana-2",
+      upstreamModelId: "nano-banana-2",
+    },
+  ]);
+});
+
+test("KIE Market resolver preserves every other live market catalog id byte-identically", () => {
+  for (const { publicModelId, upstreamModelId } of resolveLiveKieMarketCatalog()) {
+    if (publicModelId !== "google-imagen/nano-banana-2") {
+      assert.equal(
+        upstreamModelId,
+        publicModelId,
+        `${publicModelId} must round-trip byte-identically`
+      );
+    }
+  }
+});
+
+test("KIE Market resolver keeps exactly one explicit upstream id mapping", () => {
+  assert.equal(KIE_MARKET_UPSTREAM_MODEL_IDS.size, 1);
+});
+
+test("KIE Market resolver passes an unknown namespaced id through byte-identically", () => {
+  const unknownModelId = "kie/foo/bar";
+  let resolvedModelId = "";
+
+  assert.doesNotThrow(() => {
+    resolvedModelId = resolveKieMarketUpstreamModelId(unknownModelId);
+  });
+  assert.equal(resolvedModelId, unknownModelId);
+});
 
 test("KIE Market createTask sends the bare upstream model id for Nano Banana 2 (#11225)", async () => {
   const captured = await runKieMarketGeneration("kie/google-imagen/nano-banana-2");
 
   assert.equal(
-    captured.body.model,
+    captured.create.body.model,
     "nano-banana-2",
     "KIE Market createTask must send the upstream model id, not the namespaced catalog id"
   );
 
-  const input = captured.body.input as Record<string, unknown>;
+  const input = captured.create.body.input as Record<string, unknown>;
   assert.equal(input.prompt, "a calm harbour at sunrise");
   assert.equal(input.aspect_ratio, "1:1");
+  assert.equal(new URL(captured.pollUrl).searchParams.get("taskId"), "kie-market-task-1");
+  assert.ok("data" in captured.result, "successful KIE generation must return image data");
+  assert.equal(captured.result.data.data[0].url, "https://example.com/kie-market-image.png");
 });
 
 test("KIE Market createTask leaves genuinely namespaced upstream ids untouched (#11225 control)", async () => {
   const captured = await runKieMarketGeneration("kie/seedream/4.5-text-to-image");
 
   assert.equal(
-    captured.body.model,
+    captured.create.body.model,
     "seedream/4.5-text-to-image",
     "seedream/4.5-text-to-image IS the upstream id and must not be stripped"
   );
 
-  const input = captured.body.input as Record<string, unknown>;
+  const input = captured.create.body.input as Record<string, unknown>;
   assert.equal(input.prompt, "a calm harbour at sunrise");
   assert.equal(input.aspect_ratio, "1:1");
+});
+
+test("KIE direct image routing keeps the gpt4o-image endpoint and payload shape", async () => {
+  const originalFetch = globalThis.fetch;
+  let createUrl = "";
+  let createBody: Record<string, unknown> | undefined;
+
+  globalThis.fetch = (async (url: unknown, options: { body?: unknown } = {}) => {
+    const stringUrl = String(url);
+    if (stringUrl === "https://api.kie.ai/api/v1/gpt4o-image/generate") {
+      createUrl = stringUrl;
+      createBody = JSON.parse(String(options.body ?? "{}")) as Record<string, unknown>;
+      return new Response(JSON.stringify({ code: 200, data: { taskId: "kie-direct-task-1" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (stringUrl.startsWith("https://api.kie.ai/api/v1/gpt4o-image/record-info")) {
+      return new Response(
+        JSON.stringify({
+          code: 200,
+          data: {
+            status: "SUCCESS",
+            response: { resultUrls: ["https://example.com/kie-direct-image.png"] },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  }) as typeof globalThis.fetch;
+
+  try {
+    const result = await handleImageGeneration({
+      body: {
+        model: "kie/gpt4o-image",
+        prompt: "a direct-path control",
+        size: "1024x1024",
+        n: 2,
+      },
+      credentials: { apiKey: "test-kie-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(createUrl, "https://api.kie.ai/api/v1/gpt4o-image/generate");
+    assert.deepEqual(createBody, {
+      prompt: "a direct-path control",
+      size: "1:1",
+      nVariants: 2,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/tests/unit/kie-market-upstream-model-id-11225.test.ts
+++ b/tests/unit/kie-market-upstream-model-id-11225.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-kie-11225-"));
+
+const { handleImageGeneration } = await import("../../open-sse/handlers/imageGeneration.ts");
+
+/**
+ * Issue #11225 — KIE Market public model IDs are namespaced for the OmniRoute
+ * catalog (`kie/google-imagen/nano-banana-2`), but the KIE Market createTask
+ * API expects the bare upstream model ID `nano-banana-2`. Sending the
+ * namespaced id makes upstream reject the task.
+ *
+ * The mapping must be an explicit seam: other KIE Market ids such as
+ * `seedream/4.5-text-to-image` ARE the real upstream ids and must pass through
+ * unchanged, so a generic "strip everything before the slash" is wrong.
+ *
+ * These tests drive the real public `handleImageGeneration` entrypoint and
+ * capture the payload at the final executor boundary (`fetch` to
+ * `/api/v1/jobs/createTask`). No credentials, no network, no production data.
+ */
+
+interface CapturedCreate {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+async function runKieMarketGeneration(publicModel: string): Promise<CapturedCreate> {
+  const originalFetch = globalThis.fetch;
+  let captured: CapturedCreate | undefined;
+
+  globalThis.fetch = (async (url: unknown, options: { body?: unknown } = {}) => {
+    const stringUrl = String(url);
+
+    if (stringUrl === "https://api.kie.ai/api/v1/jobs/createTask") {
+      captured = {
+        url: stringUrl,
+        body: JSON.parse(String(options.body ?? "{}")) as Record<string, unknown>,
+      };
+      return new Response(JSON.stringify({ code: 200, data: { taskId: "kie-market-task-1" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (stringUrl.startsWith("https://api.kie.ai/api/v1/jobs/recordInfo")) {
+      return new Response(
+        JSON.stringify({
+          code: 200,
+          data: {
+            state: "success",
+            resultJson: JSON.stringify({
+              resultUrls: ["https://example.com/kie-market-image.png"],
+            }),
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  }) as typeof globalThis.fetch;
+
+  try {
+    const result = await handleImageGeneration({
+      body: {
+        model: publicModel,
+        prompt: "a calm harbour at sunrise",
+        size: "1024x1024",
+        n: 1,
+      },
+      credentials: { apiKey: "test-kie-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true, "KIE Market generation should succeed against the stub");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.ok(captured, "expected a createTask request to be captured");
+  return captured;
+}
+
+test("KIE Market createTask sends the bare upstream model id for Nano Banana 2 (#11225)", async () => {
+  const captured = await runKieMarketGeneration("kie/google-imagen/nano-banana-2");
+
+  assert.equal(
+    captured.body.model,
+    "nano-banana-2",
+    "KIE Market createTask must send the upstream model id, not the namespaced catalog id"
+  );
+
+  const input = captured.body.input as Record<string, unknown>;
+  assert.equal(input.prompt, "a calm harbour at sunrise");
+  assert.equal(input.aspect_ratio, "1:1");
+});
+
+test("KIE Market createTask leaves genuinely namespaced upstream ids untouched (#11225 control)", async () => {
+  const captured = await runKieMarketGeneration("kie/seedream/4.5-text-to-image");
+
+  assert.equal(
+    captured.body.model,
+    "seedream/4.5-text-to-image",
+    "seedream/4.5-text-to-image IS the upstream id and must not be stripped"
+  );
+
+  const input = captured.body.input as Record<string, unknown>;
+  assert.equal(input.prompt, "a calm harbour at sunrise");
+  assert.equal(input.aspect_ratio, "1:1");
+});


### PR DESCRIPTION
## Summary

KIE Market image requests were sent to KIE with the OmniRoute-advertised model id instead of the
id KIE actually accepts, so `kie/google-imagen/nano-banana-2` failed upstream.

This PR maps exactly one advertised Market id to its KIE upstream id at the `createTask` seam:

- `google-imagen/nano-banana-2` → `nano-banana-2`

**Contract, stated precisely:**

- Only `google-imagen/nano-banana-2` is rewritten. Every other Market catalog id is forwarded
  **byte-identically**, including genuinely namespaced ids that KIE expects with their namespace.
- This is **not** generic namespace stripping. An unknown namespaced id passes through unchanged
  rather than being blindly truncated at the `/`.
- The direct `kie/gpt4o-image` path is untouched — same endpoint, same payload shape.
- `taskId` polling and result URL normalization are unchanged.

Base: `release/v3.8.50` @ `1f6e781c4fdc9c78997ec638f6c4773cbcb5c971` (the live tip at the time of
writing; this branch is a clean 3-commit fast-forward from it, 0 behind).

Head commit: `7f5c63872e6c3044382cf3397d37dc4ae2975700`
Tree: `877b4746e37f715d01d9280ef9b0fab3767fb96f`

## Related Issues

- Related to #11225

Deliberately **not** using a closing keyword: #11225 reports the general class of KIE advertised-vs-upstream
id mismatches. This PR fixes the one occurrence that is reproducible today and freezes the seam with
regression tests. A maintainer should decide whether the issue closes here or stays open for other
catalog entries.

## Validation

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint` (ESLint on changed files, exit 0)
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Focused suite (6 files, Node 24 = `CI_NODE_VERSION`):

```
tests/unit/kie-market-upstream-model-id-11225.test.ts
tests/unit/image-generation-handler.test.ts
tests/unit/kie-task-helpers.test.ts
tests/unit/kie-executor-routing.test.ts
tests/unit/kie-audio-transcription-result.test.ts
tests/unit/image-generation-route.test.ts
```

→ **86/86 pass, exit 0**, re-run on the frozen tree after reconciling against the live base.

Other gates on this exact tree:

- Prettier `--check` on both changed files: exit 0
- ESLint on both changed files: exit 0
- `git diff --check`: exit 0
- Full-tree `tsc --noEmit`, sibling-snapshot attribution against the base commit:
  baseline **4645** diagnostics, candidate **4645**, **candidate-only delta 0**.
  `--listFiles` confirms the new test file is inside the tsc program, so the zero delta is real
  coverage rather than exclusion.

Mutation evidence — the following 8 mutations of the production seam were each independently
confirmed to make the suite **fail**, so the tests are load-bearing rather than decorative:
generic namespace strip, widened map, removed map, throw-on-unknown-id, direct-path seam leak,
direct-path payload drift, wrong poll `taskId`, and removal of URL normalization.

Additional adversarial probes also fail as expected: removing `isMarket` from the catalog,
renaming `nano-banana-2` in the catalog, dropping aspect ratio, and — importantly — an
**empty-catalog vacuity probe**: emptying the catalog makes the suite fail rather than pass
vacuously, so the assertions are genuinely catalog-driven.

Hermeticity: no real network, no real credentials, `DATA_DIR` redirected to a temp dir before
imports, `finally` restoration of `globalThis.fetch` proven to hold under a thrown assertion, and
no leaked handles (the focused run self-exits cleanly without `--test-force-exit`).

## Tests Added Or Updated

- `tests/unit/kie-market-upstream-model-id-11225.test.ts` (new, +231): 7 tests covering the
  catalog-wide invariant (exactly one id changes, all others byte-identical, exactly one explicit
  mapping, unknown namespaced ids pass through), the Market `createTask` body, the namespaced
  control case, and the untouched direct `kie/gpt4o-image` route.

## Coverage Notes

`open-sse/handlers/imageGeneration.ts` (+12/-2) is covered by the new test file, which asserts on
the intercepted `createTask` request body through the real `handleImageGeneration` entrypoint
rather than on an extracted helper. No touched file lost coverage.

**Known adjacent gap, disclosed honestly:** deleting the KIE **market** `image_url` assignment
(`open-sse/handlers/imageGeneration.ts:782-784`) survives not only this focused suite but a broad
39-file / 395-test run (395/395, exit 0) — KIE-market image-to-image input is untested repo-wide.
That block is **byte-identical to the base tree and untouched by this PR**, so it is a pre-existing
coverage gap rather than a regression introduced here. I have deliberately not widened this PR's
scope to fix it; happy to open a separate follow-up issue if that matches your preference.

## Reviewer Notes

- No DB migration, no schema change, no security surface, no core routing rewrite.
- 2 files total across the 3 commits: `open-sse/handlers/imageGeneration.ts` +12/-2 and one new
  test file +231/-0.
- The chain is RED → GREEN → hardened tests: `c27a73aa0` adds failing coverage, `5951cba9b` is the
  production fix, `7f5c63872` extends the regression cover.
- Opened as **Draft** pending your call on two things: (1) whether #11225 should be closed by this
  bounded fix or kept open for the wider catalog, and (2) whether the `image_url` coverage gap
  above should become its own issue.
- Merge-train eligibility: this is small and mechanically low-risk, but it is a provider behavior
  change at a request seam, so I have not assumed it qualifies for batch handling — your call.
