### PR TITLE
fix(dashboard): restore ProviderModelsModal map broken by #11228 (base-red #9985)

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -2360,19 +2360,7 @@ function ProviderModelsModal({
         <div className="flex flex-col gap-1">
           {groupModels.map((m) => {
             const copyKey = `modal-${m.id}`;
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2 mb-2">
-        <h1 className="text-2xl font-bold">{t("endpoint.title")}</h1>
-        <p className="text-text-muted">{t("endpoint.subtitle")}</p>
-        <div className="flex items-center gap-3 mt-2">
-          <code className="text-sm bg-card-subtle px-3 py-1 rounded-md text-text-main font-mono">{useDisplayBaseUrl()}/v1</code>
-          <a href="#test" className="text-sm text-action font-medium hover:underline">{t("endpoint.testEndpoint")}</a>
-        </div>
-      </div>
-      <div className="flex items-center gap-2 text-xs text-text-muted">
-        <span>{t("endpoint.advancedProtocols")}</span>
-      </div>
+            return (
               <div
                 key={m.id}
                 className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-surface/60 group"


### PR DESCRIPTION
## What

The squash merge of #11228 (8a42aeebb8, 2026-08-23 09:47) applied its endpoint-header hunk **inside `ProviderModelsModal`**, replacing the `groupModels.map` callback's `return (` with the page-level guided-header JSX. The file stopped parsing:

- Turbopack: `3 errors at EndpointPageClient.tsx:2397` — every Build App / Publish to Docker Hub run red since (runs 32641477569, 32641695716, 32642031466)
- release-green reported the same defect as "1 ESLint error" (run 32632606002) — the parser error, one defect, two symptoms

## Fix

Surgical revert of that single hunk — the file is now **byte-identical to its pre-#11228 state** (verified: `diff` vs 968fa961 is empty). Nothing else from #11228 is touched: the health-page verdict header, the resilience reassurance block and the new i18n keys all parse fine and stay.

## Validation (TDD, HR#18)

- **RED**: `prettier --check` on the base-tip file → `SyntaxError: Unexpected token (2397:11)`; the pre-existing jsdom render suite `EndpointPageClient.test.tsx` imports the component, so it reds on the broken base too.
- **GREEN**: after the revert — 4/4 passing, prettier clean, eslint clean.

## Follow-up (not in this PR)

The guided endpoint connection header that #11228 intended never actually existed (the injected JSX was unreachable and uncompilable). It needs a fresh PR applying the header to the page-level component (`EndpointPageClient` main return), not the modal. Will note on #11228.

Refs #9985