### PR TITLE
fix(resilience): honor dashboard quota snapshots in opencode-go preflight (#11234)

### DIFF
--- a/open-sse/services/opencodeOllamaUsage.ts
+++ b/open-sse/services/opencodeOllamaUsage.ts
@@ -103,7 +103,7 @@ function getProviderSpecificString(data: JsonRecord | undefined, keys: string[])
   return "";
 }
 
-function resolveOpenCodeGoDashboardConfig(
+export function resolveOpenCodeGoDashboardConfig(
   providerSpecificData?: JsonRecord
 ): OpenCodeGoDashboardConfig {
   const workspaceId =

--- a/open-sse/services/opencodeQuotaFetcher.ts
+++ b/open-sse/services/opencodeQuotaFetcher.ts
@@ -48,6 +48,7 @@
 import { registerQuotaFetcher, registerQuotaWindows, type QuotaInfo } from "./quotaPreflight.ts";
 import { registerMonitorFetcher } from "./quotaMonitor.ts";
 import { throttleQuotaFetch } from "./quotaFetchThrottle.ts";
+import { resolveOpenCodeGoDashboardConfig } from "./opencodeOllamaUsage.ts";
 
 // OpenCode quota endpoint — same key works across opencode, opencode-go, opencode-zen
 // Default points at /zen/go/v1/quota which returns 404 today (no public quota API yet,
@@ -227,6 +228,114 @@ function parseOpencodeQuotaResponse(data: unknown): OpencodeTripleWindowQuota | 
 
 // ─── Core Fetcher ─────────────────────────────────────────────────────────────
 
+// ─── Dashboard Snapshot Bridge (#11234) ───────────────────────────────────────
+//
+// The live endpoint above has no public quota API today (404 — see module
+// JSDoc), so without this bridge every preflight evaluated `null` and
+// proceeded (fail-open) even when the dashboard already showed a drained
+// window. The dashboard scrape (`getOpenCodeGoUsage` in
+// opencodeOllamaUsage.ts) persists per-window snapshots through
+// `src/domain/quotaCache.ts::setQuotaCache` under the window keys
+// session / weekly / mcp_monthly; this bridge synthesizes the same
+// OpencodeTripleWindowQuota shape from those cached snapshots so the quota
+// cutoff sees them.
+//
+// Read-only: accessors only, never SQL, never a re-scrape on the hot path.
+// Fail-open is preserved — no snapshots means `null`, exactly as before.
+
+// Dashboard snapshot key → fetcher/preflight window key.
+const DASHBOARD_SNAPSHOT_WINDOW_MAP: ReadonlyArray<readonly [string, string]> = [
+  ["session", OPENCODE_WINDOW_5H],
+  ["weekly", OPENCODE_WINDOW_WEEKLY],
+  ["mcp_monthly", OPENCODE_WINDOW_MONTHLY],
+];
+
+function hasDashboardQuotaConfig(connection?: Record<string, unknown>): boolean {
+  // Snapshots can only exist when the operator configured the dashboard
+  // scrape for this connection (or globally via env). Gating on it keeps the
+  // snapshot read (and its cold-start DB hydration) off connections that
+  // could never have produced one.
+  const psd = connection?.providerSpecificData as Record<string, unknown> | undefined;
+  return resolveOpenCodeGoDashboardConfig(psd).state !== "none";
+}
+
+async function synthesizeQuotaFromDashboardSnapshots(
+  connectionId: string
+): Promise<OpencodeTripleWindowQuota | null> {
+  let quotaCacheDomain: typeof import("../../src/domain/quotaCache.ts");
+  try {
+    // Dynamic import: a static edge would close an initialization cycle
+    // (opencodeQuotaFetcher → quotaCache → usage.ts → usage/opencode.ts →
+    // opencodeQuotaFetcher).
+    quotaCacheDomain = await import("../../src/domain/quotaCache.ts");
+  } catch {
+    return null;
+  }
+
+  // Hydrate the in-memory cache from persisted snapshots when cold (the
+  // accessor does this internally), then read the raw per-window rows.
+  quotaCacheDomain.getQuotaWindowStatus(connectionId, DASHBOARD_SNAPSHOT_WINDOW_MAP[0][0]);
+  const entry = quotaCacheDomain.getQuotaCache(connectionId);
+  const quotas = entry?.quotas;
+  if (!quotas || typeof quotas !== "object") return null;
+
+  const now = Date.now();
+  const windows: Record<string, { percentUsed: number; resetAt: string | null }> = {};
+
+  for (const [snapshotKey, windowKey] of DASHBOARD_SNAPSHOT_WINDOW_MAP) {
+    const raw = quotas[snapshotKey];
+    if (!raw || typeof raw.remainingPercentage !== "number") continue;
+    // #10095 mirror: a window whose fraction upstream never reported is
+    // "unknown", not 0% — it must not count as exhausted.
+    if (raw.fractionReported === false) continue;
+    const resetAt = typeof raw.resetAt === "string" && raw.resetAt ? raw.resetAt : null;
+    if (resetAt) {
+      const resetMs = Date.parse(resetAt);
+      // Mirror getQuotaWindowStatus (quotaCache.ts): an expired resetAt means
+      // the window has rolled into a fresh period — the cached percentage is
+      // stale and must not count as exhausted.
+      if (Number.isFinite(resetMs) && resetMs <= now) continue;
+    }
+    const remaining = Math.max(0, Math.min(100, raw.remainingPercentage));
+    windows[windowKey] = { percentUsed: 1 - remaining / 100, resetAt };
+  }
+
+  if (Object.keys(windows).length === 0) return null;
+
+  const window5h = windows[OPENCODE_WINDOW_5H] ?? { percentUsed: 0, resetAt: null };
+  const windowWeekly = windows[OPENCODE_WINDOW_WEEKLY] ?? { percentUsed: 0, resetAt: null };
+  const windowMonthly = windows[OPENCODE_WINDOW_MONTHLY] ?? { percentUsed: 0, resetAt: null };
+
+  const worstPercent = Math.max(
+    window5h.percentUsed,
+    windowWeekly.percentUsed,
+    windowMonthly.percentUsed
+  );
+
+  // Dominant reset: pick the window with the worst usage (same policy as the
+  // live-response parser above).
+  let dominantResetAt: string | null = null;
+  if (worstPercent === window5h.percentUsed) {
+    dominantResetAt = window5h.resetAt ?? windowWeekly.resetAt ?? windowMonthly.resetAt;
+  } else if (worstPercent === windowWeekly.percentUsed) {
+    dominantResetAt = windowWeekly.resetAt ?? window5h.resetAt ?? windowMonthly.resetAt;
+  } else {
+    dominantResetAt = windowMonthly.resetAt ?? windowWeekly.resetAt ?? window5h.resetAt;
+  }
+
+  return {
+    used: worstPercent * 100,
+    total: 100,
+    percentUsed: worstPercent,
+    resetAt: dominantResetAt,
+    windows,
+    window5h,
+    windowWeekly,
+    windowMonthly,
+    limitReached: worstPercent >= 1,
+  };
+}
+
 /**
  * Fetch current quota for an OpenCode connection.
  * Returns percentUsed = max(5h%, weekly%, monthly%) — worst-case across all windows.
@@ -242,18 +351,37 @@ export async function fetchOpencodeQuota(
   connectionId: string,
   connection?: Record<string, unknown>
 ): Promise<OpencodeTripleWindowQuota | null> {
+  // Snapshots can only exist when the dashboard scrape is configured for this
+  // connection (or globally via env); without it the bridge stays off and the
+  // fetcher never touches the snapshot store.
+  const dashboardConfigured = hasDashboardQuotaConfig(connection);
+
   // Check cache first
   const cached = quotaCache.get(connectionId);
   if (cached) {
     // 404 sentinel — use longer TTL to avoid hammering a non-existent endpoint
     if (cached.noEndpoint && Date.now() - cached.fetchedAt < NO_ENDPOINT_TTL_MS) {
-      return null;
+      // The live endpoint is known-absent — serve dashboard snapshots if the
+      // operator configured the scrape (#11234).
+      return dashboardConfigured ? synthesizeQuotaFromDashboardSnapshots(connectionId) : null;
     }
     if (cached.quota !== null && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       return cached.quota;
     }
   }
 
+  const live = await fetchLiveOpencodeQuota(connectionId, connection);
+  if (live) return live;
+
+  // #11234 — the live endpoint has no public quota API (404) or failed:
+  // fall back to the operator-configured dashboard snapshots, read-only.
+  return dashboardConfigured ? synthesizeQuotaFromDashboardSnapshots(connectionId) : null;
+}
+
+async function fetchLiveOpencodeQuota(
+  connectionId: string,
+  connection?: Record<string, unknown>
+): Promise<OpencodeTripleWindowQuota | null> {
   // Extract API key from connection
   const apiKey =
     typeof connection?.apiKey === "string" && connection.apiKey.trim().length > 0

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -2274,6 +2274,11 @@ export async function getProviderCredentialsWithQuotaPreflight(
     //   • a per-connection override on this row
     //   • a per-(provider, window) default in resilience settings
     //   • the legacy `quotaPreflightEnabled` flag in providerSpecificData
+    //   • the operator-enabled quota cutoff (resilience.quotaPreflight.enabled /
+    //     QUOTA_PREFLIGHT_CUTOFF_ENABLED) — #11234: it previously only armed the
+    //     auto-strategy candidate builder and the per-target cutoff for pinned
+    //     connections, so priority combos over sibling connections (no pinned
+    //     connectionId) never filtered an exhausted sister
     //   • the global default is stricter than the factory no-op level
     //     (factory = 2% remaining, basically "right before 429" — anything
     //     stricter means the operator wants enforcement everywhere)
@@ -2295,10 +2300,12 @@ export async function getProviderCredentialsWithQuotaPreflight(
 
     const hasConnectionOverrides = Object.keys(perConnectionWindowOverrides).length > 0;
     const legacyForceEnable = isQuotaPreflightEnabled(credentials as Record<string, unknown>);
+    const globalCutoffEnabled = resilience.quotaPreflight.enabled === true;
     if (
       !hasConnectionOverrides &&
       !providerHasDefaults &&
       !legacyForceEnable &&
+      !globalCutoffEnabled &&
       !globalDefaultIsRestrictive
     ) {
       const committed = await commitLease();

--- a/tests/unit/quota-exhaustion-cutoff-opencode.test.ts
+++ b/tests/unit/quota-exhaustion-cutoff-opencode.test.ts
@@ -1,0 +1,303 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * #11234 — opencode-go quota preflight ignored the dashboard quota snapshots.
+ *
+ * Root cause (two gaps):
+ *
+ *  A) `fetchOpencodeQuota` (open-sse/services/opencodeQuotaFetcher.ts) only
+ *     consulted the live upstream endpoint, which has no public quota API
+ *     (404 — see module JSDoc). It never read the quota snapshots the
+ *     dashboard scrape (`getOpenCodeGoUsage`, keyed session/weekly/mcp_monthly)
+ *     persists through `src/domain/quotaCache.ts`. Every preflight therefore
+ *     evaluated `null` and proceeded (fail-open), even with a sister
+ *     connection sitting at 0% weekly remaining in plain sight on the
+ *     dashboard.
+ *
+ *  B) The sibling-selection latency gate in
+ *     `src/sse/services/auth.ts::getProviderCredentialsWithQuotaPreflight`
+ *     never consulted `resilience.quotaPreflight.enabled`
+ *     (QUOTA_PREFLIGHT_CUTOFF_ENABLED). That flag only armed the auto-strategy
+ *     candidate builder and the per-target cutoff for pinned connections, so
+ *     a priority combo over sibling opencode-go connections (connectionId
+ *     null at combo level) skipped preflight entirely.
+ *
+ * Fix:
+ *  A) The fetcher now synthesizes its triple-window quota from the cached
+ *     dashboard snapshots (read-only, accessors only, no re-scrape on the hot
+ *     path) when the live endpoint yields nothing — mapping
+ *     session→window_5h, weekly→window_weekly, mcp_monthly→window_monthly and
+ *     mirroring `getQuotaWindowStatus` semantics (expired resetAt = window has
+ *     rolled over = must not count as exhausted).
+ *  B) `resilience.quotaPreflight.enabled === true` now arms the
+ *     sibling-selection latency gate as well.
+ *
+ * These tests are the regression guards: fetcher-level for (A), selector-level
+ * for (B).
+ */
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omni-quota-11234-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+// Part (B): the operator flag must be ON before the resilience settings module
+// is first imported (its defaults are computed at module load).
+process.env.QUOTA_PREFLIGHT_CUTOFF_ENABLED = "true";
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "quota-11234-secret";
+
+const originalFetch = globalThis.fetch;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const quotaSnapshotsDb = await import("../../src/lib/db/quotaSnapshots.ts");
+const quotaCache = await import("../../src/domain/quotaCache.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const { fetchOpencodeQuota, invalidateOpencodeQuotaCache } = await import(
+  "../../open-sse/services/opencodeQuotaFetcher.ts"
+);
+const { evaluateQuotaCutoff, registerQuotaFetcher } = await import(
+  "../../open-sse/services/quotaPreflight.ts"
+);
+const { buildAutoQuotaThresholds } = await import(
+  "../../open-sse/services/combo/quotaExhaustionCutoff.ts"
+);
+const { resolveResilienceSettings } = await import("../../src/lib/resilience/settings.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+
+const PROVIDER = "opencode-go";
+// Dashboard scrape window keys (opencodeOllamaUsage.ts::OPENCODE_GO_QUOTA_ORDER)
+const DASH_SESSION = "session";
+const DASH_WEEKLY = "weekly";
+// Fetcher/preflight window keys (opencodeQuotaFetcher.ts registry)
+const WINDOW_5H = "window_5h";
+const WINDOW_WEEKLY = "window_weekly";
+
+function seedSnapshot(
+  connectionId: string,
+  windowKey: string,
+  remainingPercentage: number,
+  nextResetAt: string | null
+) {
+  quotaSnapshotsDb.saveQuotaSnapshot({
+    provider: PROVIDER,
+    connection_id: connectionId,
+    window_key: windowKey,
+    remaining_percentage: remainingPercentage,
+    is_exhausted: remainingPercentage <= 0 ? 1 : 0,
+    next_reset_at: nextResetAt,
+    window_duration_ms: null,
+    raw_data: null,
+  });
+}
+
+function dashboardConfiguredConnection(apiKey: string): Record<string, unknown> {
+  // Mirrors the operator-configured dashboard scrape
+  // (opencodeOllamaUsage.ts::resolveOpenCodeGoDashboardConfig).
+  return {
+    apiKey,
+    providerSpecificData: {
+      openCodeGoWorkspaceId: "ws-11234",
+      openCodeGoAuthCookie: "auth-cookie-11234",
+    },
+  };
+}
+
+function hoursFromNow(hours: number): string {
+  return new Date(Date.now() + hours * 3_600_000).toISOString();
+}
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  coreDb.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  quotaCache.__clearForTests();
+});
+
+// ─── (A) fetcher bridge: dashboard snapshots → QuotaInfo ────────────────────
+
+test("#11234 dashboard snapshots feed the quota cutoff when the live endpoint has no quota API", async () => {
+  const connectionId = `oc-11234-block-${Date.now()}`;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return new Response(null, { status: 404 });
+  };
+
+  // Dashboard shows: weekly fully drained (0% remaining, reset in 3 days),
+  // session healthy (80% remaining).
+  seedSnapshot(connectionId, DASH_WEEKLY, 0, hoursFromNow(72));
+  seedSnapshot(connectionId, DASH_SESSION, 80, hoursFromNow(2));
+
+  const quota = await fetchOpencodeQuota(connectionId, dashboardConfiguredConnection("sk-test"));
+
+  assert.ok(quota, "fetcher must synthesize quota from dashboard snapshots when the live endpoint 404s");
+  assert.equal(fetchCalls, 1, "snapshot bridge must be read-only — no re-scrape on the hot path");
+
+  // Key mapping: weekly → window_weekly (0% remaining = 100% used),
+  // session → window_5h (80% remaining = 20% used).
+  assert.equal(quota.windows?.[WINDOW_WEEKLY]?.percentUsed, 1);
+  assert.ok(
+    Math.abs((quota.windows?.[WINDOW_5H]?.percentUsed ?? 0) - 0.2) < 1e-9,
+    `window_5h percentUsed should be ~0.2, got ${quota.windows?.[WINDOW_5H]?.percentUsed}`
+  );
+
+  const decision = evaluateQuotaCutoff(
+    quota,
+    buildAutoQuotaThresholds(PROVIDER, undefined, null)
+  );
+  assert.equal(decision.proceed, false, "weekly at 0% remaining must block the connection");
+  assert.equal(decision.reason, "quota_exhausted");
+
+  invalidateOpencodeQuotaCache(connectionId);
+});
+
+test("#11234 a snapshot whose reset already passed must not count as exhausted", async () => {
+  const connectionId = `oc-11234-expired-${Date.now()}`;
+  globalThis.fetch = async () => new Response(null, { status: 404 });
+
+  // Weekly hit 0% but its reset is 1h in the PAST — the window rolled into a
+  // fresh period, so the stale 0% must not block (mirrors
+  // getQuotaWindowStatus: expired resetAt → reachedThreshold = false).
+  seedSnapshot(connectionId, DASH_WEEKLY, 0, hoursFromNow(-1));
+  seedSnapshot(connectionId, DASH_SESSION, 80, hoursFromNow(2));
+
+  const quota = await fetchOpencodeQuota(connectionId, dashboardConfiguredConnection("sk-test"));
+
+  assert.ok(quota, "the healthy session snapshot should still synthesize");
+  assert.equal(
+    quota.windows?.[WINDOW_WEEKLY],
+    undefined,
+    "an expired weekly window must be dropped from the synthesized quota"
+  );
+
+  const decision = evaluateQuotaCutoff(
+    quota,
+    buildAutoQuotaThresholds(PROVIDER, undefined, null)
+  );
+  assert.equal(decision.proceed, true, "an expired weekly window must not block the connection");
+
+  invalidateOpencodeQuotaCache(connectionId);
+});
+
+test("#11234 per-window threshold overrides apply to the mapped window_weekly key", async () => {
+  const connectionId = `oc-11234-threshold-${Date.now()}`;
+  globalThis.fetch = async () => new Response(null, { status: 404 });
+
+  // Weekly at 40% remaining — above the factory 2% cutoff (would proceed),
+  // but below an operator override of 50% min-remaining for window_weekly.
+  seedSnapshot(connectionId, DASH_WEEKLY, 40, hoursFromNow(72));
+  seedSnapshot(connectionId, DASH_SESSION, 90, hoursFromNow(2));
+
+  const quota = await fetchOpencodeQuota(connectionId, dashboardConfiguredConnection("sk-test"));
+  assert.ok(quota);
+
+  const factoryDecision = evaluateQuotaCutoff(
+    quota,
+    buildAutoQuotaThresholds(PROVIDER, undefined, null)
+  );
+  assert.equal(
+    factoryDecision.proceed,
+    true,
+    "factory 2% cutoff must not block a window at 40% remaining"
+  );
+
+  const settings = resolveResilienceSettings({
+    resilienceSettings: {
+      quotaPreflight: {
+        enabled: true,
+        providerWindowDefaults: { [PROVIDER]: { [WINDOW_WEEKLY]: 50 } },
+      },
+    },
+  });
+  const overrideDecision = evaluateQuotaCutoff(
+    quota,
+    buildAutoQuotaThresholds(PROVIDER, undefined, settings)
+  );
+  assert.equal(
+    overrideDecision.proceed,
+    false,
+    "a 50% window_weekly override must block at 40% remaining — the override resolves against the mapped key"
+  );
+
+  invalidateOpencodeQuotaCache(connectionId);
+});
+
+test("#11234 fail-open preserved: configured dashboard with no snapshots still returns null", async () => {
+  const connectionId = `oc-11234-failopen-${Date.now()}`;
+  globalThis.fetch = async () => new Response(null, { status: 404 });
+
+  const quota = await fetchOpencodeQuota(connectionId, dashboardConfiguredConnection("sk-test"));
+  assert.equal(quota, null, "no snapshots → fail-open (null), exactly as before");
+
+  invalidateOpencodeQuotaCache(connectionId);
+});
+
+// ─── (B) flag scope: sibling-selection latency gate ─────────────────────────
+
+test("#11234 quotaPreflight.enabled arms sibling selection: the exhausted sister is skipped for the healthy one", async () => {
+  const tag = Date.now();
+
+  const exhausted = await providersDb.createProviderConnection({
+    provider: PROVIDER,
+    authType: "apikey",
+    name: `oc-11234-exhausted-${tag}`,
+    apiKey: "sk-oc-11234-exhausted",
+    priority: 1,
+    isActive: true,
+    testStatus: "active",
+  });
+  const healthy = await providersDb.createProviderConnection({
+    provider: PROVIDER,
+    authType: "apikey",
+    name: `oc-11234-healthy-${tag}`,
+    apiKey: "sk-oc-11234-healthy",
+    priority: 2,
+    isActive: true,
+    testStatus: "active",
+  });
+
+  // Stub the upstream quota signal: the priority-1 sister is fully drained,
+  // the priority-2 sister is healthy. No per-connection overrides, no
+  // per-(provider, window) defaults, no legacy quotaPreflightEnabled flag,
+  // factory 2% global threshold — so TODAY the latency gate skips preflight
+  // entirely and the selector returns the exhausted sister. With
+  // resilience.quotaPreflight.enabled arming the gate, preflight must run and
+  // skip her.
+  registerQuotaFetcher(PROVIDER, async (connectionId: string) => {
+    if (connectionId === exhausted.id) {
+      return {
+        used: 100,
+        total: 100,
+        percentUsed: 1.0,
+        resetAt: hoursFromNow(1),
+      };
+    }
+    return { used: 0, total: 100, percentUsed: 0, resetAt: null };
+  });
+
+  try {
+    const selection = await auth.getProviderCredentialsWithQuotaPreflight(
+      PROVIDER,
+      null,
+      null,
+      null
+    );
+    const result = selection as { connectionId?: string } | null;
+
+    assert.equal(
+      result?.connectionId,
+      healthy.id,
+      "with quotaPreflight.enabled the selector must skip the exhausted priority-1 sister and pick the healthy one"
+    );
+  } finally {
+    await providersDb.deleteProviderConnection(exhausted.id);
+    await providersDb.deleteProviderConnection(healthy.id);
+  }
+});


### PR DESCRIPTION
Closes #11234

## Problem

The opencode-go quota preflight ignored the dashboard quota snapshots, so priority combos (e.g. `opencode-go/deepseek-v4-pro`) kept selecting sibling connections whose weekly window was already drained — the data was visible on the dashboard but never reached routing. Two independent gaps:

**Gap A — fetcher never read the snapshots.** `fetchOpencodeQuota` only consulted the live upstream endpoint, which has no public quota API (404 — the module JSDoc already admits this). Every preflight evaluated `null` → `evaluateQuotaCutoff(null)` → proceed (fail-open), even with a connection at 0% weekly remaining persisted by the dashboard scrape. Window keys also differed: the fetcher registry uses `window_5h`/`window_weekly`/`window_monthly` while the dashboard snapshots use `session`/`weekly`/`mcp_monthly`.

**Gap B — the operator flag never armed sibling selection.** `QUOTA_PREFLIGHT_CUTOFF_ENABLED` (`resilience.quotaPreflight.enabled`) was only read by the auto-strategy candidate builder and by the per-target cutoff that requires a pinned connectionId. The sibling-selection latency gate in `getProviderCredentialsWithQuotaPreflight` never consulted it, so priority combos (connectionId null at combo level) skipped preflight entirely.

## Fix

**A) Snapshot bridge in the fetcher** (`open-sse/services/opencodeQuotaFetcher.ts`). When the live endpoint yields nothing and the connection has dashboard scrape config, the fetcher synthesizes its triple-window `QuotaInfo` from the cached snapshots — `session→window_5h`, `weekly→window_weekly`, `mcp_monthly→window_monthly`, `percentUsed = 1 − remainingPercentage/100` — mirroring `getQuotaWindowStatus` semantics: an expired `resetAt` means the window rolled over and must not count as exhausted; `fractionReported === false` (#10095) is "unknown", never exhaustion. Read-only via `src/domain/quotaCache.ts` accessors (never SQL, never a re-scrape on the hot path), gated on scrape config so unconfigured connections never touch the snapshot store. Fail-open preserved: no snapshots → `null`, exactly as before. The quotaCache import is dynamic because a static edge would close an initialization cycle (`fetcher → quotaCache → usage.ts → usage/opencode.ts → fetcher`).

**B) Flag scope** (`src/sse/services/auth.ts`). `resilience.quotaPreflight.enabled === true` now also arms the sibling-selection latency gate, so priority combos filter exhausted sisters. Default unchanged (flag off = today's behavior).

Gap 3 from the issue analysis (`isExhausted()` requiring ALL windows at zero) was deliberately **not** touched — inverting it globally risks over-blocking providers with alternative windows.

## Validation (TDD, Hard Rule #18)

New `tests/unit/quota-exhaustion-cutoff-opencode.test.ts` (5 tests, all RED→GREEN except the fail-open guard):

| Test | Before | After |
| --- | --- | --- |
| fetcher 404 + snapshots weekly=0%/session=80% → `blocked` | RED (quota `null`) | GREEN |
| weekly 0% with `next_reset_at` in the past → not blocked | RED | GREEN |
| per-window threshold override on mapped `window_weekly` key | RED | GREEN |
| configured dashboard, no snapshots → `null` (fail-open) | GREEN (guard) | GREEN |
| flag on, two sisters, priority-1 exhausted → picks healthy | RED (picked exhausted) | GREEN |

Sibling suites green (~500 tests): `opencode-quota-fetcher` (18, 404-latch unchanged), `quota-preflight`, `combo-priority-quota-exhaustion-cutoff-5923`, `combo-quota-exhaustion-only-fallback`, `issue-6686`, `8431-multiwindow`, `quota-fetch-throttle-6911`, `sse-auth*` (4 files), all quota fetchers (codex/bailian/deepseek/generic/agentrouter/grok/firecrawl/freemodel), combo strategies, snapshot/hydration tests. `npx eslint` (with suppressions) and `npm run typecheck:core` clean on all touched files.