### PR TITLE
fix(live-ws, dashboard): allow 0.0.0.0 dashboard origin and stop non-square SVG image warnings

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-code/components/DefaultToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/DefaultToolCard.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Card, Button, ModelSelectModal } from "@/shared/components";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { copyToClipboard } from "@/shared/utils/clipboard";
 import { buildOpenCodeConfigDocument } from "@/shared/services/opencodeConfig";
@@ -643,38 +642,32 @@ export default function DefaultToolCard({
   };
 
   const renderIcon = () => {
+    // Tool SVGs are non-square (e.g. opencode is 234×42, cursor is 467×532).
+    // next/image's dev check warns whenever the rendered aspect-ratio size
+    // differs from the square width/height attributes, so these render as a
+    // plain <img> capped at 32px on both axes — true ratio, no dev noise.
+    const renderImg = (src: string) => (
+      // eslint-disable-next-line @next/next/no-img-element -- local static SVG asset
+      <img
+        src={src}
+        alt={tool.name}
+        width={32}
+        height={32}
+        className="size-8 object-contain rounded-lg"
+        style={{ width: "auto", height: "auto", maxWidth: 32, maxHeight: 32 }}
+        onError={(e) => {
+          (e.currentTarget as HTMLElement).style.display = "none";
+        }}
+      />
+    );
     if (tool.image) {
-      return (
-        <Image
-          src={tool.image}
-          alt={tool.name}
-          width={32}
-          height={32}
-          className="size-8 object-contain rounded-lg"
-          sizes="32px"
-          onError={(e) => {
-            (e.currentTarget as HTMLElement).style.display = "none";
-          }}
-        />
-      );
+      return renderImg(tool.image);
     }
     if (tool.imageLight || tool.imageDark) {
       const themedSrc = isDark
         ? tool.imageDark || tool.imageLight
         : tool.imageLight || tool.imageDark;
-      return (
-        <Image
-          src={themedSrc}
-          alt={tool.name}
-          width={32}
-          height={32}
-          className="size-8 object-contain rounded-lg"
-          sizes="32px"
-          onError={(e) => {
-            (e.currentTarget as HTMLElement).style.display = "none";
-          }}
-        />
-      );
+      return renderImg(themedSrc);
     }
     if (tool.icon) {
       return (

--- a/src/server/ws/liveServerAllowList.ts
+++ b/src/server/ws/liveServerAllowList.ts
@@ -20,6 +20,11 @@ export const DEFAULT_ALLOWED_ORIGINS: readonly string[] = Object.freeze([
   "http://127.0.0.1:20128",
   "http://localhost:20128",
   "http://[::1]:20128",
+  // 0.0.0.0 is the "unspecified" address but browsers treat it as loopback
+  // when the user pastes it into the address bar; the dashboard is reachable
+  // at http://0.0.0.0:20128 and its WS Origin is exactly that string. Same
+  // local-only posture as the entries above — it never refers to a LAN host.
+  "http://0.0.0.0:20128",
 ]);
 
 /**

--- a/src/shared/components/ProviderIcon.tsx
+++ b/src/shared/components/ProviderIcon.tsx
@@ -399,34 +399,56 @@ const ProviderIcon = memo(function ProviderIcon({
         className={className}
         style={{ display: "inline-flex", alignItems: "center", ...style }}
       >
-        <Image
+        {/* eslint-disable-next-line @next/next/no-img-element -- themed local SVG asset; see the Tier 2 comment for why these use a plain <img> */}
+        <img
           src={themedSrc}
           alt={providerId}
           width={size}
           height={size}
-          style={{ objectFit: "contain" }}
+          style={{
+            objectFit: "contain",
+            flex: "none",
+            width: "auto",
+            height: "auto",
+            maxWidth: size,
+            maxHeight: size,
+          }}
           onError={() => setFailedAssets((current) => ({ ...current, [themedKey]: true }))}
-          unoptimized
         />
       </span>
     );
   }
 
-  // Tier 2: Local SVG — fastest, cached separately from the JS bundle
+  // Tier 2: Local SVG — fastest, cached separately from the JS bundle.
+  // Rendered as a plain <img> (not next/image): provider SVGs carry their own
+  // intrinsic aspect ratio (e.g. opencode.svg is 234×42), and next/image's
+  // dev-mode check warns whenever the layout size differs from the square
+  // width/height attributes — a false positive for non-square logos rendered
+  // at fixed icon sizes. We keep `width/height` attributes for layout reserve
+  // but let the intrinsic ratio win on both axes (`width/height: "auto"`) so
+  // wide logos like opencode render at their true aspect ratio instead of
+  // being letterboxed into a 1:1 box.
   if (hasSvg && !svgFailed) {
     return (
       <span
         className={className}
         style={{ display: "inline-flex", alignItems: "center", ...style }}
       >
-        <Image
+        {/* eslint-disable-next-line @next/next/no-img-element -- local static SVG asset, see comment above */}
+        <img
           src={`/providers/${localSvgId}.svg`}
           alt={providerId}
           width={size}
           height={size}
-          style={{ objectFit: "contain" }}
+          style={{
+            objectFit: "contain",
+            flex: "none",
+            width: "auto",
+            height: "auto",
+            maxWidth: size,
+            maxHeight: size,
+          }}
           onError={() => setFailedAssets((current) => ({ ...current, [svgKey]: true }))}
-          unoptimized
         />
       </span>
     );

--- a/src/shared/components/cli/CliToolCard.tsx
+++ b/src/shared/components/cli/CliToolCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import type { CliCatalogEntry } from "@/shared/schemas/cliCatalog";
 import type { ToolBatchStatus } from "@/shared/types/cliBatchStatus";
@@ -38,12 +37,18 @@ export default function CliToolCard({
     <div className="flex items-center gap-2.5">
       {/* Icon / image */}
       {imageSrc ? (
-        <Image
+        // Plain <img> (not next/image): tool SVGs are non-square (opencode
+        // 234×42, cursor 467×532) and next/image's dev check warns whenever the
+        // rendered aspect-ratio size differs from the square width/height
+        // attributes. object-contain + max caps keep the logo at its true ratio.
+        // eslint-disable-next-line @next/next/no-img-element -- local static SVG asset
+        <img
           src={imageSrc}
           alt={tool.name}
           width={32}
           height={32}
           className="rounded-md object-contain flex-shrink-0"
+          style={{ width: "auto", height: "auto", maxWidth: 32, maxHeight: 32 }}
         />
       ) : (
         <span

--- a/tests/unit/security/live-server-allowlist.test.ts
+++ b/tests/unit/security/live-server-allowlist.test.ts
@@ -130,6 +130,9 @@ describe("isOriginAllowed", () => {
     assert.equal(isOriginAllowed("http://127.0.0.1:20128", EMPTY_ENV), true);
     assert.equal(isOriginAllowed("http://localhost:20128", EMPTY_ENV), true);
     assert.equal(isOriginAllowed("http://[::1]:20128", EMPTY_ENV), true);
+    // 0.0.0.0 is loopback-equivalent in the browser; the dashboard is often
+    // opened at http://0.0.0.0:20128, which sends exactly that Origin on WS.
+    assert.equal(isOriginAllowed("http://0.0.0.0:20128", EMPTY_ENV), true);
   });
 
   it("accepts an Origin matching LIVE_WS_ALLOWED_ORIGINS", () => {


### PR DESCRIPTION
## Summary

Two console errors flood the browser when the OmniRoute dashboard is opened at `http://0.0.0.0:20128` — the exact address the Next.js dev server prints on startup:

1. **`[LiveWS] Server error: FORBIDDEN_ORIGIN Origin not allowed`** — an infinite reconnect loop on every dashboard page.
2. **`Image with src "http://0.0.0.0:20128/providers/opencode.svg" has either width or height modified, but not the other`** — a Next.js dev-mode warning for non-square provider logos.

This PR fixes both.

---

## Problem 1: LiveWS `FORBIDDEN_ORIGIN`

### Root cause
The live dashboard WebSocket server (`src/server/ws/liveServer.ts`, port `20132`) validates the browser's `Origin` header against an allow-list (`src/server/ws/liveServerAllowList.ts`). The defaults only covered:

```
http://127.0.0.1:20128
http://localhost:20128
http://[::1]:20128
```

The Next.js dev server binds to `0.0.0.0` (visible in the startup log: `[Next] dev server listening on http://0.0.0.0:20128`). When a user opens that URL in a browser, the browser sends `Origin: http://0.0.0.0:20128` verbatim on the WebSocket upgrade — which was **not** in the allow-list. The server rejects it, the hook (`useLiveDashboard.ts`) logs the error, closes, and auto-reconnects → the error floods the console in a tight loop.

### Fix
Added `http://0.0.0.0:20128` to `DEFAULT_ALLOWED_ORIGINS`. This is safe: `0.0.0.0` is the *unspecified* address and is loopback-equivalent when used as an Origin in a browser — it can never refer to a LAN host, so the "local-only by default" security posture is unchanged. The same equivalence already appears elsewhere in the codebase (`src/lib/headroom/detect.ts`, `src/shared/network/outboundUrlGuard.ts` treat `0.0.0.0` as loopback).

Security note: LAN/Tailscale exposure still requires the explicit `LIVE_WS_HOST=0.0.0.0` + `LIVE_WS_ALLOWED_ORIGINS` opt-in — unchanged.

---

## Problem 2: Next.js "width or height modified, but not the other" image warning

### Root cause
Provider logos are rendered at fixed square icon sizes through `next/image`. Several provider SVGs are **not square**:

| Asset | Intrinsic size | Ratio |
|---|---|---|
| `opencode.svg` / `opencode-light.svg` / `opencode-dark.svg` | 234×42 | ~5.6:1 |
| `cursor.svg` | 466.73×532.09 | ~0.88:1 |
| `arena-light.svg` | 121.75×91.97 | ~1.3:1 |
| `omp.png` | 256×171 | ~1.5:1 |

Tailwind v4's preflight CSS applies `img { height: auto }` globally. Combined with the SVG's own intrinsic dimensions, the rendered height never matches the square `width`/`height` attributes `next/image` writes — so Next's dev-mode check (`img.height !== height attribute`) fires on **every dashboard page** that shows these logos.

### Fix
Render local provider SVGs and CLI tool logos with a plain `<img>` (the same pattern already used for operator-supplied remote icon URLs) that:
- keeps `object-fit: contain`,
- sets `width: auto; height: auto` so the intrinsic aspect ratio is honored,
- caps both axes at the requested icon size (`maxWidth`/`maxHeight`).

Square logos (OpenAI, Anthropic, etc.) render **identically** to before — the cap makes them exactly `size × size`. Wide logos like opencode now render at their true 5.6:1 ratio instead of being letterboxed into a 1:1 box. And the dev-mode warning is gone.

### Files changed
- `src/server/ws/liveServerAllowList.ts` — allow `http://0.0.0.0:20128` origin
- `src/shared/components/ProviderIcon.tsx` — Tier 1 (themed) + Tier 2 (local SVG) → plain `<img>` with aspect-ratio-preserving styles
- `src/shared/components/cli/CliToolCard.tsx` — same treatment for CLI tool logos
- `src/app/(dashboard)/dashboard/cli-code/components/DefaultToolCard.tsx` — same treatment for the tool detail card
- `tests/unit/security/live-server-allowlist.test.ts` — pins the new `0.0.0.0` origin as allowed

---

## Verification

- **Unit test**: `live-server-allowlist.test.ts` — 24/24 pass, including the new `http://0.0.0.0:20128` assertion.
- **Headless browser (Playwright/Chromium)**, logged in against the dev server:
  - Loaded every dashboard page (`/dashboard`, `/dashboard/providers`, `/dashboard/cli-code`, `/dashboard/cli-agents`, `/dashboard/runtime`, `/dashboard/combos`, `/dashboard/usage`, `/dashboard/health`, `/`, `/login`) — **0** image warnings.
  - Opened the dashboard at `http://0.0.0.0:20128` — WebSocket connects successfully (`[LiveWS] Client connected`), **0** `FORBIDDEN_ORIGIN` errors.
- `eslint` on all changed files: clean.
- `tsc --noEmit` (core + dashboard tsconfigs): no errors in changed files.
- Pre-commit hooks (lint-staged, docs-sync, any-budget, tracked-artifacts): all pass.

## Test plan for reviewers
1. `npm run dev`, open `http://0.0.0.0:20128` (or the printed URL if it's 0.0.0.0).
2. Confirm no `FORBIDDEN_ORIGIN` spam in the console.
3. Visit `/dashboard/providers`, `/dashboard/cli-code` — confirm no image aspect-ratio warnings and that wide logos (OpenCode) render at their true ratio.
