### PR TITLE
fix(ollama): route models by advertised capability (#11087) — port of #11088 to the release line

### DIFF
--- a/changelog.d/fixes/11271-ollama-capability-routing.md
+++ b/changelog.d/fixes/11271-ollama-capability-routing.md
@@ -1,0 +1,1 @@
+- **fix(ollama):** Ollama Local models are no longer flattened to `chat` at sync time — the synced store persists every advertised capability and chat filtering moves to read time, so `/v1/embeddings` and `/v1/images/generations` stop rejecting models the daemon reports as capable ([#11271](https://github.com/diegosouzapw/OmniRoute/pull/11271)) — thanks @yourspraveen

--- a/open-sse/services/combo/autoStrategy.ts
+++ b/open-sse/services/combo/autoStrategy.ts
@@ -28,6 +28,7 @@ import type {
   ResolvedComboTarget,
 } from "./types.ts";
 import { extractSessionAffinityKey } from "@/sse/services/auth";
+import { filterChatSelectableModels } from "../modelEndpointPolicy.ts";
 import { DEFAULT_INTENT_CONFIG, type IntentClassifierConfig } from "../intentClassifier.ts";
 import { getTaskFitness } from "../autoCombo/taskFitness.ts";
 import {
@@ -470,10 +471,13 @@ export async function expandAutoComboCandidatePool(
       // catalog only when the user has none. This keeps catalog-only models
       // (e.g. openrouter/auto) out of pure-auto pools when the operator only
       // synced a subset (e.g. OpenRouter with importFreeModelsOnly).
-      const [syncedModels, customModels] = await Promise.all([
+      // #11088 (option 1): the synced store now persists non-chat models too —
+      // chat combo pools must keep filtering them out at read time.
+      const [syncedModelsRaw, customModels] = await Promise.all([
         getSyncedAvailableModels(providerId),
         getCustomModels(providerId),
       ]);
+      const syncedModels = filterChatSelectableModels(providerId, syncedModelsRaw);
       const hiddenModels = hiddenModelsMap.get(providerId);
       const userVisibleIds = new Set<string>();
       for (const m of syncedModels) if (m.id && !hiddenModels?.has(m.id)) userVisibleIds.add(m.id);

--- a/src/app/api/providers/[id]/models/discovery/helpers.ts
+++ b/src/app/api/providers/[id]/models/discovery/helpers.ts
@@ -1,5 +1,11 @@
 import { isSelfHostedChatProvider } from "@/shared/constants/providers";
 import { getStaticModelsForProvider, type LocalCatalogModel } from "@/lib/providers/staticModels";
+import { SAFE_OUTBOUND_FETCH_PRESETS, safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
+import { getProviderValidationGuard } from "@/shared/network/outboundUrlGuardPolicy";
+import {
+  buildOllamaShowUrl,
+  enrichOllamaModelsWithCapabilities,
+} from "@/lib/providerModels/ollamaCapabilities";
 
 export type JsonRecord = Record<string, unknown>;
 
@@ -101,4 +107,36 @@ export function buildNamedOpenAiStyleHeaders(
   }
 
   return headers;
+}
+
+// #11087 — Ollama's OpenAI-compatible /v1/models response carries no capability
+// data, so every local model looked like a chat model and image/embedding
+// requests were routed to text-only models. Probe /api/show per model (bounded
+// concurrency, failures degrade to the unenriched entry) to recover the
+// advertised capabilities. Lives here rather than inline in route.ts to keep the
+// route file under its frozen file-size cap.
+export async function enrichOllamaLocalModels(
+  models: unknown[],
+  baseUrl: string,
+  proxy: unknown,
+  token: string | null | undefined
+): Promise<JsonRecord[]> {
+  const showUrl = buildOllamaShowUrl(baseUrl);
+  return enrichOllamaModelsWithCapabilities(models, async (modelId) => {
+    try {
+      const showResponse = await safeOutboundFetch(showUrl, {
+        ...SAFE_OUTBOUND_FETCH_PRESETS.modelsProbe,
+        // Same guard tier as the discovery probe above: local-first, so LAN
+        // Ollama hosts are reachable while the outbound guard stays enforced.
+        guard: getProviderValidationGuard(),
+        proxyConfig: proxy,
+        method: "POST",
+        headers: buildOptionalBearerHeaders(token),
+        body: JSON.stringify({ model: modelId, verbose: false }),
+      });
+      return showResponse.ok ? await showResponse.json() : null;
+    } catch {
+      return null;
+    }
+  });
 }

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -108,6 +108,7 @@ import {
   mergeSpecialtyCatalogIntoLiveModels,
   buildOptionalBearerHeaders,
   buildNamedOpenAiStyleHeaders,
+  enrichOllamaLocalModels,
 } from "./discovery/helpers";
 import {
   fetchAntigravityDiscoveryModelsCached,
@@ -794,6 +795,8 @@ export async function GET(
             models = isNamedOpenAIStyleProvider(provider)
               ? normalizeOpenAiLikeModelsResponse(data, provider)
               : data.data || data.models || [];
+            if (provider === "ollama-local")
+              models = await enrichOllamaLocalModels(models, baseUrl, proxy, token);
             break; // Success!
           }
 

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -23,6 +23,10 @@ import { getComboByName } from "@/lib/db/combos";
 import { getAllCustomModels } from "@/lib/db/models";
 import { resolveProxyForConnection } from "@/lib/db/settings";
 import { resolveImageRouteModel } from "@/lib/images/imageRouteModel";
+import {
+  resolveLocalSyncedEndpointRoute,
+  type LocalSyncedEndpointRoute,
+} from "@/lib/providerModels/syncedEndpointRouting";
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { calculateModalCost } from "@/lib/usage/costCalculator";
@@ -145,6 +149,16 @@ async function postHandler(request, context) {
   // Parse model to get provider
   let { provider, model: requestedModel } = parseImageModel(body.model);
   let isCustomModel = false;
+  let syncedEndpointRoute: LocalSyncedEndpointRoute | null = null;
+
+  if (!provider) {
+    syncedEndpointRoute = await resolveLocalSyncedEndpointRoute(body.model, "images");
+    if (syncedEndpointRoute) {
+      provider = syncedEndpointRoute.provider;
+      body.model = `${syncedEndpointRoute.provider}/${syncedEndpointRoute.model}`;
+      isCustomModel = true;
+    }
+  }
 
   // If not in built-in registry, check custom models tagged for images
   if (!provider) {
@@ -231,9 +245,8 @@ async function postHandler(request, context) {
     credentials = await getProviderCredentialsWithQuotaPreflight(
       provider,
       null,
-      null,
-      requestedModel
-    );
+      syncedEndpointRoute?.connectionIds ?? null,
+      requestedModel    );
     if (!credentials) {
       return errorResponse(
         HTTP_STATUS.BAD_REQUEST,

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -31,6 +31,7 @@ import { isPrivateHost, isCloudMetadataHost } from "@/shared/network/outboundUrl
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { generateRequestId } from "@/shared/utils/requestId";
+import { resolveLocalSyncedEndpointRoute } from "@/lib/providerModels/syncedEndpointRouting";
 
 type ValidatedEmbeddingBody = Record<string, unknown> & { model: string };
 type ProviderCredentialsResult = Awaited<ReturnType<typeof getProviderCredentials>>;
@@ -164,7 +165,17 @@ export async function createEmbeddingResponse(
         model: options.resolvedModel ?? body.model,
       }
     : parseEmbeddingModel(body.model, dynamicProviders);
-  const { provider, model: resolvedModel } = parsedModel;
+  let { provider, model: resolvedModel } = parsedModel;
+  // #11088: a bare local-model request routes through the connection that
+  // advertises the requested endpoint — only when no explicit resolvedProvider
+  // already won above (explicit resolution takes precedence).
+  const syncedEndpointRoute = options.resolvedProvider
+    ? null
+    : await resolveLocalSyncedEndpointRoute(body.model, "embeddings");
+  if (syncedEndpointRoute) {
+    provider = syncedEndpointRoute.provider;
+    resolvedModel = syncedEndpointRoute.model;
+  }
   if (!provider) {
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,
@@ -172,12 +183,55 @@ export async function createEmbeddingResponse(
     );
   }
 
+  let credentials: ProviderCredentialsResult | null = null;
   let providerConfig: EmbeddingProvider | null =
     options.resolvedProvider ||
     dynamicProviders.find((dp) => dp.id === provider) ||
     getEmbeddingProvider(provider) ||
     null;
   let credentialsProviderId = provider;
+
+  if (syncedEndpointRoute) {
+    credentials = await getProviderCredentials(
+      provider,
+      null,
+      syncedEndpointRoute.connectionIds,
+      syncedEndpointRoute.model
+    );
+    if (!credentials) {
+      return errorResponse(
+        HTTP_STATUS.BAD_REQUEST,
+        `No credentials for embedding provider: ${provider}`
+      );
+    }
+    if ("allRateLimited" in credentials && credentials.allRateLimited) {
+      return unavailableResponse(
+        HTTP_STATUS.RATE_LIMITED,
+        `[${provider}] All accounts rate limited`,
+        credentials.retryAfter,
+        credentials.retryAfterHuman
+      );
+    }
+
+    const providerSpecificData = (credentials as { providerSpecificData?: Record<string, unknown> })
+      .providerSpecificData;
+    const configuredBaseUrl = providerSpecificData?.baseUrl;
+    if (typeof configuredBaseUrl !== "string" || configuredBaseUrl.trim().length === 0) {
+      return errorResponse(
+        HTTP_STATUS.BAD_REQUEST,
+        `No base URL configured for embedding provider: ${provider}`
+      );
+    }
+    let baseUrl = configuredBaseUrl.trim();
+    while (baseUrl.endsWith("/")) baseUrl = baseUrl.slice(0, -1);
+    providerConfig = {
+      id: provider,
+      baseUrl: baseUrl.endsWith("/embeddings") ? baseUrl : `${baseUrl}/embeddings`,
+      authType: "apikey",
+      authHeader: "bearer",
+      models: [],
+    };
+  }
 
   if (!providerConfig) {
     try {
@@ -226,8 +280,7 @@ export async function createEmbeddingResponse(
     );
   }
 
-  let credentials: ProviderCredentialsResult | null = null;
-  if (providerConfig.authType !== "none") {
+  if (!credentials && providerConfig.authType !== "none") {
     credentials = await getProviderCredentials(credentialsProviderId);
     if (!credentials) {
       return errorResponse(

--- a/src/lib/providerModels/managedModelImport.ts
+++ b/src/lib/providerModels/managedModelImport.ts
@@ -21,7 +21,6 @@ import {
   ANTIGRAVITY_MODEL_ALIASES,
   ANTIGRAVITY_REVERSE_MODEL_ALIASES,
 } from "@omniroute/open-sse/config/antigravityModelAliases.ts";
-import { filterChatSelectableModels } from "@omniroute/open-sse/services/modelEndpointPolicy.ts";
 import { filterSelectableModels } from "@omniroute/open-sse/services/modelLifecycle.ts";
 
 type JsonRecord = Record<string, unknown>;
@@ -253,9 +252,10 @@ export async function importManagedModels({
   const previousSyncedAvailableModels =
     previousSyncedAvailableModelsInput ??
     (await getSyncedAvailableModelsForConnection(providerId, connectionId));
-  const discoveredModels = filterChatSelectableModels(
+  // #11088 (option 1): keep non-chat models; chat filtering happens at read time.
+  const discoveredModels = filterSelectableModels(
     providerId,
-    filterSelectableModels(providerId, normalizeDiscoveredModels(fetchedModels, providerId))
+    normalizeDiscoveredModels(fetchedModels, providerId)
   );
   const candidateImportedModels = normalizeImportedModels(discoveredModels);
   const importedIds = new Set(candidateImportedModels.map((model) => model.id));

--- a/src/lib/providerModels/managedModelImport.ts
+++ b/src/lib/providerModels/managedModelImport.ts
@@ -21,7 +21,9 @@ import {
   ANTIGRAVITY_MODEL_ALIASES,
   ANTIGRAVITY_REVERSE_MODEL_ALIASES,
 } from "@omniroute/open-sse/config/antigravityModelAliases.ts";
+import { filterChatSelectableModels } from "@omniroute/open-sse/services/modelEndpointPolicy.ts";
 import { filterSelectableModels } from "@omniroute/open-sse/services/modelLifecycle.ts";
+import { isSelfHostedChatProvider } from "@/shared/constants/providers";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -252,11 +254,18 @@ export async function importManagedModels({
   const previousSyncedAvailableModels =
     previousSyncedAvailableModelsInput ??
     (await getSyncedAvailableModelsForConnection(providerId, connectionId));
-  // #11088 (option 1): keep non-chat models; chat filtering happens at read time.
-  const discoveredModels = filterSelectableModels(
+  // #11088 (option 1): self-hosted providers keep their non-chat models — chat
+  // filtering happens at read time (resolveLocalSyncedEndpointRoute). Every other
+  // provider keeps the import-time chat filter: the read-time path is gated on
+  // isSelfHostedChatProvider, so dropping it globally leaked image/video models
+  // into OpenAI chat selections (#11271).
+  const selectableModels = filterSelectableModels(
     providerId,
     normalizeDiscoveredModels(fetchedModels, providerId)
   );
+  const discoveredModels = isSelfHostedChatProvider(providerId)
+    ? selectableModels
+    : filterChatSelectableModels(providerId, selectableModels);
   const candidateImportedModels = normalizeImportedModels(discoveredModels);
   const importedIds = new Set(candidateImportedModels.map((model) => model.id));
 

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -6,7 +6,6 @@ import {
 } from "@/lib/db/models";
 import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization";
 import { isObsoleteKiroModelAlias } from "@omniroute/open-sse/services/kiroModels.ts";
-import { filterChatSelectableModels } from "@omniroute/open-sse/services/modelEndpointPolicy.ts";
 import { filterSelectableModels } from "@omniroute/open-sse/services/modelLifecycle.ts";
 
 type JsonRecord = Record<string, unknown>;
@@ -379,9 +378,13 @@ export async function persistDiscoveredModels(
   connectionId: string,
   models: unknown
 ): Promise<SyncedAvailableModel[]> {
-  const normalized = filterChatSelectableModels(
+  // #11088 (option 1): the synced store is endpoint-agnostic — images/embeddings
+  // models must persist so per-connection endpoint routing (#11088) and the
+  // /v1/models catalog can see them. Chat selectability is applied at read time
+  // (auto-pool expansion, chat projections), not at write time.
+  const normalized = filterSelectableModels(
     providerId,
-    filterSelectableModels(providerId, normalizeDiscoveredModels(models, providerId))
+    normalizeDiscoveredModels(models, providerId)
   );
   await replaceSyncedAvailableModelsForConnection(providerId, connectionId, normalized);
   return normalized;

--- a/src/lib/providerModels/ollamaCapabilities.ts
+++ b/src/lib/providerModels/ollamaCapabilities.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+
+type JsonRecord = Record<string, unknown>;
+
+const ollamaShowResponseSchema = z
+  .object({
+    capabilities: z.array(z.string().max(64)).max(32).optional(),
+  })
+  .passthrough();
+
+const OLLAMA_CAPABILITY_TO_ENDPOINT: Readonly<Record<string, string>> = {
+  completion: "chat",
+  embedding: "embeddings",
+  image: "images",
+};
+
+const MAX_CONCURRENT_SHOW_REQUESTS = 4;
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+export function buildOllamaShowUrl(openAiBaseUrl: string): string {
+  let base = openAiBaseUrl.trim();
+  while (base.endsWith("/")) base = base.slice(0, -1);
+  base = base.replace(/\/(?:chat\/completions|completions|embeddings|images\/generations)$/i, "");
+  if (base.endsWith("/v1")) base = base.slice(0, -3);
+  return `${base}/api/show`;
+}
+
+export function applyOllamaShowCapabilities(model: unknown, showResponse: unknown): JsonRecord {
+  const record = asRecord(model);
+  const parsed = ollamaShowResponseSchema.safeParse(showResponse);
+  if (!parsed.success || !parsed.data.capabilities) return record;
+
+  const capabilities = Array.from(
+    new Set(parsed.data.capabilities.map((value) => value.trim().toLowerCase()).filter(Boolean))
+  );
+  const supportedEndpoints = Array.from(
+    new Set(
+      capabilities
+        .map((capability) => OLLAMA_CAPABILITY_TO_ENDPOINT[capability])
+        .filter((endpoint): endpoint is string => Boolean(endpoint))
+    )
+  );
+  if (supportedEndpoints.length === 0) return record;
+
+  const apiFormat = supportedEndpoints.includes("chat")
+    ? "chat-completions"
+    : supportedEndpoints.includes("embeddings")
+      ? "embeddings"
+      : "images-generations";
+
+  return {
+    ...record,
+    apiFormat,
+    supportedEndpoints,
+    ...(capabilities.includes("vision") ? { supportsVision: true } : {}),
+    ...(capabilities.includes("tools") ? { supportsTools: true } : {}),
+    ...(capabilities.includes("thinking") ? { supportsThinking: true } : {}),
+  };
+}
+
+export async function enrichOllamaModelsWithCapabilities(
+  models: unknown[],
+  fetchShow: (modelId: string) => Promise<unknown | null>
+): Promise<JsonRecord[]> {
+  const output: JsonRecord[] = new Array(models.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < models.length) {
+      const index = nextIndex++;
+      const model = asRecord(models[index]);
+      const modelId =
+        typeof model.id === "string"
+          ? model.id
+          : typeof model.name === "string"
+            ? model.name
+            : typeof model.model === "string"
+              ? model.model
+              : null;
+      if (!modelId) {
+        output[index] = model;
+        continue;
+      }
+      try {
+        output[index] = applyOllamaShowCapabilities(model, await fetchShow(modelId));
+      } catch {
+        output[index] = model;
+      }
+    }
+  };
+
+  const workerCount = Math.min(MAX_CONCURRENT_SHOW_REQUESTS, Math.max(1, models.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return output;
+}

--- a/src/lib/providerModels/syncedEndpointRouting.ts
+++ b/src/lib/providerModels/syncedEndpointRouting.ts
@@ -1,0 +1,31 @@
+import { getSyncedAvailableModelsByConnection } from "@/lib/db/models";
+import { isSelfHostedChatProvider, resolveProviderId } from "@/shared/constants/providers";
+
+export type LocalSyncedEndpointRoute = {
+  provider: string;
+  model: string;
+  connectionIds: string[];
+};
+
+export async function resolveLocalSyncedEndpointRoute(
+  modelStr: string,
+  endpoint: "embeddings" | "images"
+): Promise<LocalSyncedEndpointRoute | null> {
+  const slashIndex = modelStr.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === modelStr.length - 1) return null;
+
+  const provider = resolveProviderId(modelStr.slice(0, slashIndex));
+  const model = modelStr.slice(slashIndex + 1);
+  if (!isSelfHostedChatProvider(provider)) return null;
+
+  const byConnection = await getSyncedAvailableModelsByConnection(provider);
+  const connectionIds = Object.entries(byConnection)
+    .filter(([, models]) =>
+      models.some(
+        (candidate) => candidate.id === model && candidate.supportedEndpoints?.includes(endpoint)
+      )
+    )
+    .map(([connectionId]) => connectionId);
+
+  return connectionIds.length > 0 ? { provider, model, connectionIds } : null;
+}

--- a/tests/unit/hard-session-lease-bypass-inventory.test.ts
+++ b/tests/unit/hard-session-lease-bypass-inventory.test.ts
@@ -40,7 +40,11 @@ const EXPECTED: Record<InventoryKind, Record<string, number>> = {
     "src/app/api/v1/session-leases/route.ts": 1,
     "src/app/api/v1/videos/generations/route.ts": 2,
     "src/app/api/v1/web/fetch/route.ts": 1,
-    "src/lib/embeddings/service.ts": 2,
+    // #11088/#11271: third site is the synced local-endpoint route — it resolves
+    // credentials through getProviderCredentials with the connection allowlist
+    // from resolveLocalSyncedEndpointRoute, and handles allRateLimited, so it is
+    // fenced the same way as the two pre-existing sites.
+    "src/lib/embeddings/service.ts": 3,
     "src/lib/memory/embedding/index.ts": 1,
     "src/lib/search/executeWebSearch.ts": 2,
     "src/lib/skills/webFetchExecution.ts": 1,

--- a/tests/unit/ollama-local-capabilities-routing.test.ts
+++ b/tests/unit/ollama-local-capabilities-routing.test.ts
@@ -1,0 +1,205 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-ollama-capabilities-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.APP_LOG_TO_FILE = "false";
+process.env.API_KEY_SECRET = "ollama-capabilities-test-secret";
+process.env.REQUIRE_API_KEY = "false";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const providerModelsRoute = await import("../../src/app/api/providers/[id]/models/route.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+const imageRoute = await import("../../src/app/api/v1/images/generations/route.ts");
+const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+
+const originalFetch = globalThis.fetch;
+
+function resetStorage() {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedOllamaConnection(baseUrl = "http://127.0.0.1:11434/v1", priority = 1) {
+  return providersDb.createProviderConnection({
+    provider: "ollama-local",
+    authType: "apikey",
+    name: "Ollama test host",
+    apiKey: "test-key",
+    isActive: true,
+    testStatus: "active",
+    priority,
+    providerSpecificData: { baseUrl },
+  });
+}
+
+test.beforeEach(resetStorage);
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("Ollama discovery maps /api/show capabilities into connection-scoped model metadata", async () => {
+  const connection = await seedOllamaConnection();
+  const showCapabilities: Record<string, string[]> = {
+    "image-model": ["image"],
+    "embedding-model": ["embedding"],
+    "chat-model": ["completion", "vision", "tools", "thinking"],
+  };
+  const calledUrls: string[] = [];
+
+  globalThis.fetch = async (input, init = {}) => {
+    const url = String(input);
+    calledUrls.push(url);
+    if (url.endsWith("/v1/models")) {
+      return Response.json({
+        data: Object.keys(showCapabilities).map((id) => ({ id, object: "model" })),
+      });
+    }
+    if (url.endsWith("/api/show")) {
+      const body = JSON.parse(String(init.body || "{}")) as { model?: string };
+      return Response.json({ capabilities: showCapabilities[body.model || ""] || [] });
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  const response = await providerModelsRoute.GET(
+    new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
+    { params: { id: connection.id } }
+  );
+  const body = (await response.json()) as {
+    models: Array<{
+      id: string;
+      apiFormat?: string;
+      supportedEndpoints?: string[];
+      supportsVision?: boolean;
+      supportsTools?: boolean;
+      supportsThinking?: boolean;
+    }>;
+  };
+
+  assert.equal(response.status, 200);
+  assert.ok(calledUrls.some((url) => url.endsWith("/api/show")));
+  assert.deepEqual(body.models.find((model) => model.id === "image-model")?.supportedEndpoints, [
+    "images",
+  ]);
+  assert.equal(
+    body.models.find((model) => model.id === "image-model")?.apiFormat,
+    "images-generations"
+  );
+  assert.deepEqual(
+    body.models.find((model) => model.id === "embedding-model")?.supportedEndpoints,
+    ["embeddings"]
+  );
+  assert.equal(
+    body.models.find((model) => model.id === "embedding-model")?.apiFormat,
+    "embeddings"
+  );
+  const chatModel = body.models.find((model) => model.id === "chat-model");
+  assert.deepEqual(chatModel?.supportedEndpoints, ["chat"]);
+  assert.equal(chatModel?.supportsVision, true);
+  assert.equal(chatModel?.supportsTools, true);
+  assert.equal(chatModel?.supportsThinking, true);
+
+  const persisted = await modelsDb.getSyncedAvailableModelsForConnection(
+    "ollama-local",
+    connection.id
+  );
+  assert.deepEqual(persisted.find((model) => model.id === "image-model")?.supportedEndpoints, [
+    "images",
+  ]);
+  assert.deepEqual(persisted.find((model) => model.id === "embedding-model")?.supportedEndpoints, [
+    "embeddings",
+  ]);
+
+  const catalogResponse = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/v1/models")
+  );
+  const catalog = (await catalogResponse.json()) as {
+    data: Array<{
+      id: string;
+      type?: string;
+      supported_endpoints?: string[];
+      capabilities?: Record<string, boolean>;
+    }>;
+  };
+  const imageCatalogModel = catalog.data.find((model) => model.id.endsWith("/image-model"));
+  assert.equal(imageCatalogModel?.type, "image");
+  assert.deepEqual(imageCatalogModel?.supported_endpoints, ["images"]);
+  const embeddingCatalogModel = catalog.data.find((model) => model.id.endsWith("/embedding-model"));
+  assert.equal(embeddingCatalogModel?.type, "embedding");
+  assert.deepEqual(embeddingCatalogModel?.supported_endpoints, ["embeddings"]);
+  const chatCatalogModel = catalog.data.find((model) => model.id.endsWith("/chat-model"));
+  assert.equal(chatCatalogModel?.capabilities?.vision, true);
+  assert.equal(chatCatalogModel?.capabilities?.tool_calling, true);
+  assert.equal(chatCatalogModel?.capabilities?.reasoning, true);
+});
+
+test("Ollama image model routes through its advertising connection", async () => {
+  await seedOllamaConnection("http://127.0.0.1:11434/v1", 1);
+  const connection = await seedOllamaConnection("http://127.0.0.1:11435/v1", 2);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("ollama-local", connection.id, [
+    {
+      id: "image-model",
+      name: "Image Model",
+      apiFormat: "images-generations",
+      supportedEndpoints: ["images"],
+    },
+  ]);
+
+  let capturedUrl = "";
+  globalThis.fetch = async (input) => {
+    capturedUrl = String(input);
+    return Response.json({ data: [{ b64_json: "aW1hZ2U=" }] });
+  };
+
+  const response = await imageRoute.POST(
+    new Request("http://localhost/v1/images/generations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "ollama-local/image-model", prompt: "test image" }),
+    })
+  );
+
+  assert.equal(response.status, 200, await response.text());
+  assert.equal(capturedUrl, "http://127.0.0.1:11435/v1/images/generations");
+});
+
+test("Ollama embedding model routes through its advertising connection", async () => {
+  await seedOllamaConnection("http://127.0.0.1:11434/v1", 1);
+  const connection = await seedOllamaConnection("http://127.0.0.1:11436/v1", 2);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("ollama-local", connection.id, [
+    {
+      id: "embedding-model",
+      name: "Embedding Model",
+      apiFormat: "embeddings",
+      supportedEndpoints: ["embeddings"],
+    },
+  ]);
+
+  let capturedUrl = "";
+  globalThis.fetch = async (input) => {
+    capturedUrl = String(input);
+    return Response.json({
+      data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+      usage: { prompt_tokens: 2, total_tokens: 2 },
+    });
+  };
+
+  const response = await createEmbeddingResponse({
+    model: "ollama-local/embedding-model",
+    input: "hello",
+  });
+
+  assert.equal(response.status, 200, await response.text());
+  assert.equal(capturedUrl, "http://127.0.0.1:11436/v1/embeddings");
+});


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## What

Ports **#11088** (merged) onto the active release line. Closes the gap you flagged on #11087:

> it landed on `main`, not on the `release/v3.8.50` branch, so it will NOT be in the v3.8.50 package about to publish; it rides the following release line (v3.8.51+)

Same precedent as #11165, which ported #11075 from `main` onto `release/v3.8.50`.

## Why this is worth porting rather than waiting

`release/v3.8.51` does not exist yet, and every PR currently open — 30 of them — is cut from `release/v3.8.50`. Until the next cycle branch appears, the fix is reachable only from `main`, which no active branch is based on. Meanwhile the defect is live on the release line: every Ollama Local model is flattened to `chat`, so `/v1/embeddings` and `/v1/images/generations` reject models the daemon advertises as capable.

If you would rather this wait for the v3.8.51 branch, say so and I will close it — the branch will keep.

## ⚠️ No longer a byte-identical port — #11088 carries two defects

This PR **started** as a byte-identical port and I described it that way below. CI proved that wrong, so the description is corrected here rather than quietly left standing. Two failures showed up that are **not** in the base-red set, reproduce on `main` (which already carries #11088), and do **not** reproduce on the pristine release tip — i.e. they are defects in the merged change, not in the port:

**1. OpenAI import leaks image/video models into chat selections** — real behavioural regression.

```
✖ OpenAI import excludes image and video generation models from chat selections
  actual:   [ 'gpt-5.6-sol', 'gpt-image-2', 'sora-2-pro', 'vendor-image-model' ]
  expected: [ 'gpt-5.6-sol' ]
```

#11088 dropped `filterChatSelectableModels` from `importManagedModels` for **every** provider, but the compensating read-time filter (`resolveLocalSyncedEndpointRoute`) is gated on `isSelfHostedChatProvider`. Non-local providers therefore lost the filter with nothing replacing it, and the models are persisted, not merely returned. Fixed in `c018e3a45` by scoping the drop to self-hosted providers — the local behaviour #11087 asked for is untouched and the Ollama suite stays 3/3.

**2. An unregistered credential site** — `hard-lease credential, executor, and connection-query inventory has no unclassified site` (`src/lib/embeddings/service.ts` 2 → 3). The new site resolves through `getProviderCredentials` with the connection allowlist from `resolveLocalSyncedEndpointRoute` and handles `allRateLimited`, so it is fenced like its two siblings — the ledger had simply not been told. Registered with a comment saying why.

**`main` still has both.** This PR fixes them only on the release line; `main` needs the same two-line change. Flagging rather than opening a second PR unasked — say the word and it is up in minutes.

## Fidelity (as originally written — see the correction above)

The change set is **byte-identical to the merged #11088** — I diffed all 11 files against `refs/pull/11088/head` after applying, and every one matches:

```
open-sse/services/combo/autoStrategy.ts                     |   6 +-
src/app/api/providers/[id]/models/discovery/helpers.ts      |  38 ++++
src/app/api/providers/[id]/models/route.ts                  |   3 +
src/app/api/v1/images/generations/route.ts                  |  19 +-
src/lib/embeddings/service.ts                               |  59 +++++-
src/lib/providerModels/managedModelImport.ts                |   6 +-
src/lib/providerModels/modelDiscovery.ts                    |   9 +-
src/lib/providerModels/ollamaCapabilities.ts                |  98 ++++++++++
src/lib/providerModels/syncedEndpointRouting.ts             |  31 ++++
tests/unit/ollama-local-capabilities-routing.test.ts        | 205 +++++++++++++
```

The **ported commit** re-derived nothing: applied with `git apply --3way` at the release tip `a7e09eda5`, clean, no conflicts. The two-file fix above sits in a **separate commit on top** (`c018e3a45`), so the port and the correction stay reviewable independently.

**Deliberately not carried over:** `docs/superpowers/plans/2026-08-23-qdrant-configuration-guidance.md` and its `specs/` sibling. Those are on `main` only because they rode in with #11088's squash — they came from #11213 and `855243ab1` already removed them from the release branch. They do not belong here (or on `main` — see the separate cleanup PR).

The changelog fragment is renumbered to this PR in a follow-up commit, matching how #11165 handled its own fragment.

## Verification at the release tip

| Check | Result |
| --- | --- |
| `tests/unit/ollama-local-capabilities-routing.test.ts` | **3/3 pass** |
| `npm run typecheck:core` | clean |
| `npx eslint` on all 10 changed source/test files | clean¹ |

¹ One `no-restricted-imports` hit in `src/app/api/providers/[id]/models/route.ts` — the pre-existing `@/lib/localDb` import at line 14, already frozen in `config/quality/eslint-suppressions.json` with `count: 1`. Untouched by this port; `npm run lint` (which applies the suppressions, and is what CI runs) is clean.

Fixes #11087 on the release line.

