### PR TITLE
fix(security): clear new CodeQL code-scanning alerts (round 4)

### DIFF
--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 import {
   BaseExecutor,
   ExecuteInput,
@@ -12,6 +14,11 @@ import {
 } from "../config/providerHeaderProfiles.ts";
 import { sanitizeResponsesInputItems } from "../services/responsesInputSanitizer.ts";
 import { stripUnsupportedParams } from "../translator/paramSupport.ts";
+
+/** Correlation-id fallback for runtimes without crypto.randomUUID — still CSPRNG-backed. */
+function randomIdFallback(): string {
+  return `${Date.now()}-${randomBytes(9).toString("hex")}`;
+}
 
 /**
  * What a Copilot credential refresh resolves to.
@@ -329,7 +336,7 @@ export class GithubExecutor extends BaseExecutor {
       ...getGitHubCopilotChatHeaders(stream ? "text/event-stream" : "application/json", initiator),
       Authorization: `Bearer ${token}`,
       "x-request-id":
-        crypto.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        crypto.randomUUID?.() || randomIdFallback(),
     };
 
     // Per-call / per-conversation / per-turn correlation ids the @github/copilot
@@ -338,7 +345,7 @@ export class GithubExecutor extends BaseExecutor {
     // fresh uuids. A Copilot-aware client may pin the session/task ids across a
     // conversation via its own headers — honor those when present, else mint.
     const genId = () =>
-      crypto.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      crypto.randomUUID?.() || randomIdFallback();
     headers["x-interaction-id"] = this.readClientHeader(clientHeaders, "x-interaction-id") || genId();
     headers["x-client-session-id"] =
       this.readClientHeader(clientHeaders, "x-client-session-id") || genId();

--- a/tests/unit/cli/_helpers/shellArgs.mjs
+++ b/tests/unit/cli/_helpers/shellArgs.mjs
@@ -23,8 +23,11 @@ export function unescapeWindowsShellArg(arg) {
   s = s.replace(/\^(.)/g, "$1").replace(/\^(.)/g, "$1");
   // 2. drop the wrapping quotes added by the CRT argv layer
   if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) s = s.slice(1, -1);
-  // 3. undo the doubled backslashes and the escaped embedded quotes
-  s = s.replace(/\\\\/g, "\\").replace(/\\"/g, '"');
+  // 3. undo the doubled backslashes and the escaped embedded quotes in a single
+  // left-to-right pass — two sequential global replaces would let the first
+  // pass's output feed the second (e.g. an escaped-backslash-then-quote
+  // sequence could be misread), which is exactly what js/double-escaping flags.
+  s = s.replace(/\\\\|\\"/g, (m) => (m === "\\\\" ? "\\" : '"'));
   return s;
 }
 


### PR DESCRIPTION
## Summary
Closes the 2 new CodeQL code-scanning alerts:

- **js/insecure-randomness** — `open-sse/executors/github.ts:344`: the Copilot correlation-id generators (`x-request-id`, `x-interaction-id`, `x-client-session-id`, `x-agent-task-id`) fell back to `Math.random()` when `crypto.randomUUID` is unavailable. Replaced with a CSPRNG-backed `randomIdFallback()` (`node:crypto` `randomBytes`) — no behavior change, `crypto.randomUUID` stays the primary path.
- **js/double-escaping** — `tests/unit/cli/_helpers/shellArgs.mjs:27`: `unescapeWindowsShellArg()` chained two sequential global `.replace()` unescape passes, which lets the first pass's output feed the second — the exact double-(un)escaping bug pattern the query flags (an escaped-backslash-then-quote sequence could be misread depending on pass order). Collapsed into a single left-to-right regex replace with alternation.

## Test plan
- [x] `node --import tsx/esm --test tests/unit/cli/run-command.test.ts` — 12/12 pass
- [x] `node --import tsx/esm --test tests/unit/executor-github.test.ts tests/unit/8951-github-gpt56-responses.test.ts tests/unit/github-copilot-custom-model-target-format.test.ts tests/unit/github-copilot-claude-native-messages.test.ts tests/unit/executor-github-prefill-sanitize.test.ts tests/unit/copilot-claude-always-v1-messages.test.ts tests/unit/copilot-gemini-claude-route-no-responses.test.ts tests/unit/t27-github-copilot-response-format.test.ts` — 62/62 pass
- [x] `npx eslint` on changed files — no new errors (pre-existing `no-explicit-any` violations in github.ts are frozen/suppressed, unrelated to this change)

⚠️ base-red inherited: #9985