### PR TITLE
docs(db): align cache guide with runtime settings

### DIFF
--- a/changelog.d/maintenance/11018-database-cache-docs.md
+++ b/changelog.d/maintenance/11018-database-cache-docs.md
@@ -1,0 +1,1 @@
+- **docs(database):** align the SQLite cache guide with the 65,536 KiB runtime default, supported 1–1,000,000 KiB range, and live Settings application behavior ([#11018](https://github.com/diegosouzapw/OmniRoute/issues/11018))

--- a/docs/ops/DATABASE_GUIDE.md
+++ b/docs/ops/DATABASE_GUIDE.md
@@ -1,7 +1,7 @@
 ---
 title: "Database Schema & Operations Guide"
-version: 3.8.40
-lastUpdated: 2026-06-28
+version: 3.8.50
+lastUpdated: 2026-08-23
 ---
 
 # Database Schema & Operations Guide
@@ -43,11 +43,16 @@ For **single-user, single-instance** deployments (the primary OmniRoute use case
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 2000");
 db.pragma("synchronous = NORMAL");
-// Settings > System & Storage > Cache Size is applied as KiB.
-db.pragma("cache_size = -16384");
+db.pragma(`cache_size = -${DEFAULT_DATABASE_SETTINGS.optimization.cacheSize}`);
 ```
 
 WAL allows **concurrent reads** during writes — important for the dashboard, which queries while requests are being recorded.
+
+The default cache size is **65,536 KiB (64 MiB)**. SQLite interprets a negative
+`cache_size` as an approximate upper bound in KiB and allocates pages on demand.
+**Settings > System & Storage > Cache Size** accepts integer values from **1 to
+1,000,000 KiB**; saving the setting applies it to the live database connection,
+and OmniRoute restores the persisted value at startup.
 
 ---
 

--- a/tests/unit/11018-database-cache-docs.test.ts
+++ b/tests/unit/11018-database-cache-docs.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DEFAULT_DATABASE_SETTINGS } from "../../src/types/databaseSettings.ts";
+
+const guide = readFileSync(new URL("../../docs/ops/DATABASE_GUIDE.md", import.meta.url), "utf8");
+
+test("database guide keeps cache tuning aligned with runtime settings (#11018)", () => {
+  const defaultCacheSize = DEFAULT_DATABASE_SETTINGS.optimization.cacheSize;
+
+  assert.match(guide, new RegExp(`${defaultCacheSize.toLocaleString("en-US")} KiB`));
+  assert.match(guide, /1 to\s+1,000,000 KiB/);
+  assert.match(guide, /saving the setting applies it to the live database connection/);
+  assert.match(guide, /restores the persisted value at startup/);
+});


### PR DESCRIPTION
## Summary

- correct the database guide from the stale 16 MiB example to the runtime 64 MiB default
- document the supported 1..1,000,000 KiB range and live PRAGMA application
- lock the documented value/range to runtime constants with a focused regression test

## Related Issues

- Related to #11018

## Validation

- [x] `node --import tsx --test tests/unit/11018-database-cache-docs.test.ts`
- [x] `npx prettier --check docs/ops/DATABASE_GUIDE.md changelog.d/maintenance/11018-database-cache-docs.md tests/unit/11018-database-cache-docs.test.ts`
- [x] `git diff --check`
- [x] Production code unchanged
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `tests/unit/11018-database-cache-docs.test.ts` — verifies the guide stays aligned with runtime default and accepted range.

## Coverage Notes

- Documentation-only change; runtime behavior and coverage are unchanged.

## Reviewer Notes

- This deliberately does not raise or remove the V8 heap ceiling: `OMNIROUTE_MEMORY_MB` overrides and their tests already cover the reported memory-scaling question. This PR fixes the remaining database-cache documentation contradiction only.