### PR TITLE
fix(translator): preserve omitted OpenCode subagent session IDs

### DIFF
--- a/changelog.d/fixes/11297-opencode-subagent-sessionid.md
+++ b/changelog.d/fixes/11297-opencode-subagent-sessionid.md
@@ -1,0 +1,1 @@
+- **fix(translator):** preserve omitted OpenCode `subagent.sessionID` values — optional default-less plain strings now use the Responses `null = omit` sentinel and are stripped before the client sees the tool call, so Codex/Responses no longer invent filler session IDs ([#11297](https://github.com/diegosouzapw/OmniRoute/pull/11297)) — thanks @ofonseca-pyming

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -379,6 +379,7 @@ import { isCompactResponsesEndpoint } from "../executors/codex.ts";
 import { persistCodexChildQuotaResponse } from "../services/codexAccount/index.ts";
 import { invalidateCodexQuotaCache } from "../services/codexQuotaFetcher.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
+import { extractToolSchemaMap } from "../translator/response/openai-responses/toolSchemas.ts";
 import { unwrapClineNonStreamingEnvelope } from "./chatCore/clineResponseEnvelope.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
 import {
@@ -4905,12 +4906,14 @@ export async function handleChatCore({
 
     // Translate response to client's expected format (usually OpenAI)
     // Pass toolNameMap so Claude OAuth proxy_ prefix is stripped in tool_use blocks (#605)
+    const responseToolSchemas = extractToolSchemaMap(finalBody || translatedBody || body);
     let translatedResponse = needsTranslation(responsePayloadFormat, clientResponseFormat)
       ? translateNonStreamingResponse(
           responseBody,
           responsePayloadFormat,
           clientResponseFormat,
-          responseToolNameMap
+          responseToolNameMap,
+          responseToolSchemas
         )
       : responseBody;
     const memoryExtractionResponse = translatedResponse;
@@ -4937,7 +4940,8 @@ export async function handleChatCore({
               responseBody,
               responsePayloadFormat,
               FORMATS.OPENAI,
-              responseToolNameMap
+              responseToolNameMap,
+              responseToolSchemas
             )
           : responseBody;
       const firstChoice = cacheResponse?.choices?.[0];
@@ -5460,7 +5464,8 @@ export async function handleChatCore({
                 streamBody,
                 clientResponseFormat,
                 FORMATS.OPENAI,
-                responseToolNameMap
+                responseToolNameMap,
+                extractToolSchemaMap(finalBody || translatedBody || body)
               ) as Record<string, unknown>)
             : streamBody;
         const choices = cacheStreamBody.choices as

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -13,6 +13,7 @@ import {
 import { restoreClaudeToolName } from "../services/claudeCodeToolRemapper.ts";
 import { extractReplayableResponsesReasoningText } from "../services/reasoningInputPolicy.ts";
 import { sanitizeToolId } from "../translator/helpers/schemaCoercion.ts";
+import { stripEmptyOptionalToolArgs } from "../translator/response/openai-responses/pureHelpers.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -135,24 +136,28 @@ function findBestMessageText(output: unknown[]): {
  * Handles different provider response formats (Gemini, Claude, etc.)
  *
  * @param toolNameMap - Optional Map<prefixedName, originalName> for Claude OAuth tool name stripping
+ * @param toolSchemas - Optional Map<toolName, parametersSchema> for schema-aware optional-arg cleanup
  */
 export function translateNonStreamingResponse(
   responseBody: JsonRecord,
   targetFormat: string,
   sourceFormat: string,
-  toolNameMap?: Map<string, string> | null
+  toolNameMap?: Map<string, string> | null,
+  toolSchemas?: Map<string, JsonRecord> | null
 ): JsonRecord;
 export function translateNonStreamingResponse(
   responseBody: unknown,
   targetFormat: string,
   sourceFormat: string,
-  toolNameMap?: Map<string, string> | null
+  toolNameMap?: Map<string, string> | null,
+  toolSchemas?: Map<string, JsonRecord> | null
 ): unknown;
 export function translateNonStreamingResponse(
   responseBody: unknown,
   targetFormat: string,
   sourceFormat: string,
-  toolNameMap?: Map<string, string> | null
+  toolNameMap?: Map<string, string> | null,
+  toolSchemas?: Map<string, JsonRecord> | null
 ): unknown {
   // If already in source format, return as-is
   if (targetFormat === sourceFormat) {
@@ -219,6 +224,11 @@ export function translateNonStreamingResponse(
           toString(itemObj.id) ||
           `call_${Date.now()}_${toolCalls.length}`;
         let argsToEmit = itemObj.arguments;
+        const rawName = toString(itemObj.name);
+        const toolSchema = toolSchemas?.get(rawName);
+        if (toolSchema) {
+          argsToEmit = stripEmptyOptionalToolArgs(argsToEmit, rawName, toolSchema);
+        }
         if (argsToEmit != null && typeof argsToEmit === "object" && !Array.isArray(argsToEmit)) {
           const cleaned: JsonRecord = { ...(argsToEmit as JsonRecord) };
           for (const [k, v] of Object.entries(cleaned)) {
@@ -229,7 +239,6 @@ export function translateNonStreamingResponse(
 
         const fnArgs =
           typeof argsToEmit === "string" ? argsToEmit : JSON.stringify(argsToEmit || {});
-        const rawName = toString(itemObj.name);
         // Strip Claude OAuth proxy_ prefix using toolNameMap
         const resolvedName = caseInsensitiveToolNameLookup(rawName, toolNameMap) ?? rawName;
         toolCalls.push({

--- a/open-sse/translator/helpers/schemaCoercion.ts
+++ b/open-sse/translator/helpers/schemaCoercion.ts
@@ -290,6 +290,31 @@ export function coerceToolSchemas(tools: unknown): unknown {
   });
 }
 
+const NULL_OMISSION_NOTE = "null = omit this parameter";
+
+function schemaTypeIncludes(type: unknown, wanted: string): boolean {
+  return type === wanted || (Array.isArray(type) && type.includes(wanted));
+}
+
+function isPlainStringType(type: unknown): boolean {
+  return type === "string" || (Array.isArray(type) && type.length === 1 && type[0] === "string");
+}
+
+function appendNullOmissionMarker(description: unknown): string {
+  if (typeof description === "string" && description.length > 0) {
+    return description.includes(NULL_OMISSION_NOTE)
+      ? description
+      : `${description} (${NULL_OMISSION_NOTE})`;
+  }
+  return NULL_OMISSION_NOTE;
+}
+
+function widenTypeWithNull(type: unknown): unknown {
+  if (typeof type === "string") return [type, "null"];
+  if (Array.isArray(type) && !type.includes("null")) return [...type, "null"];
+  return type;
+}
+
 // #7023 — Responses API strict mode forces every "optional" tool property into
 // `required`, so a model that intends to OMIT an optional enum property (no declared
 // `default`) must still emit a concrete value (e.g. Agent.isolation:"remote"). Neither
@@ -299,7 +324,11 @@ export function coerceToolSchemas(tools: unknown): unknown {
 // `null` (see pureHelpers.ts::isDroppableNullEntry). Scope: top-level
 // `properties[key].enum` only — does not recurse into `items`/`anyOf`/`oneOf` branches
 // (no real-world case beyond Agent.isolation is documented; extend with a concrete repro).
-function shouldInjectNullOmission(key: string, propSchema: unknown, required: Set<string>): boolean {
+function shouldInjectNullOmission(
+  key: string,
+  propSchema: unknown,
+  required: Set<string>
+): boolean {
   return (
     isPlainObject(propSchema) &&
     Array.isArray(propSchema.enum) &&
@@ -312,17 +341,36 @@ function widenPropertyForNullOmission(propSchema: JsonRecord): JsonRecord {
   const widened: JsonRecord = { ...propSchema };
   const enumValues = propSchema.enum as unknown[];
   widened.enum = enumValues.includes(null) ? enumValues : [...enumValues, null];
-  if (typeof propSchema.type === "string") {
-    widened.type = [propSchema.type, "null"];
-  } else if (Array.isArray(propSchema.type) && !propSchema.type.includes("null")) {
-    widened.type = [...propSchema.type, "null"];
-  }
-  const note = "null = omit this parameter";
-  widened.description =
-    typeof propSchema.description === "string" && propSchema.description.length > 0
-      ? `${propSchema.description} (${note})`
-      : note;
+  widened.type = widenTypeWithNull(propSchema.type);
+  widened.description = appendNullOmissionMarker(propSchema.description);
   return widened;
+}
+
+// OpenCode `subagent.sessionID` (and any other optional default-less plain string) has
+// the same strict-mode omission problem as #7023 enums, but no enum to widen. Inject
+// the same nullable-union sentinel on top-level `properties[key]` only — do not recurse
+// into `items`/`anyOf`/`$defs`, and do not touch enums (owned by the helper above).
+function shouldInjectStringNullOmission(
+  key: string,
+  propSchema: unknown,
+  required: Set<string>
+): boolean {
+  return (
+    isPlainObject(propSchema) &&
+    !Array.isArray(propSchema.enum) &&
+    isPlainStringType(propSchema.type) &&
+    !schemaTypeIncludes(propSchema.type, "null") &&
+    !required.has(key) &&
+    !hasOwn(propSchema, "default")
+  );
+}
+
+function widenStringPropertyForNullOmission(propSchema: JsonRecord): JsonRecord {
+  return {
+    ...propSchema,
+    type: widenTypeWithNull(propSchema.type),
+    description: appendNullOmissionMarker(propSchema.description),
+  };
 }
 
 export function injectOptionalEnumOmissionSentinel(schema: unknown): unknown {
@@ -351,6 +399,43 @@ export function injectOptionalEnumOmissionForTools(tools: unknown): unknown {
     const result: JsonRecord = { ...tool };
     if ("parameters" in result && !isPlainObject(result.function)) {
       result.parameters = injectOptionalEnumOmissionSentinel(result.parameters);
+    }
+    return result;
+  });
+}
+
+export function injectOptionalStringOmissionSentinel(schema: unknown): unknown {
+  if (!isPlainObject(schema) || !isPlainObject(schema.properties)) return schema;
+
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  let changed = false;
+  const nextProperties: JsonRecord = { ...schema.properties };
+
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
+    if (!shouldInjectStringNullOmission(key, propSchema, required)) continue;
+    nextProperties[key] = widenStringPropertyForNullOmission(propSchema as JsonRecord);
+    changed = true;
+  }
+
+  if (!changed) return schema;
+  return { ...schema, properties: nextProperties };
+}
+
+export function injectOptionalStringOmissionForTools(tools: unknown): unknown {
+  if (!Array.isArray(tools)) return tools;
+
+  return tools.map((tool) => {
+    if (!isPlainObject(tool)) return tool;
+
+    const result: JsonRecord = { ...tool };
+    if (isPlainObject(result.function) && "parameters" in result.function) {
+      result.function = {
+        ...result.function,
+        parameters: injectOptionalStringOmissionSentinel(result.function.parameters),
+      };
+    }
+    if ("parameters" in result && !isPlainObject(result.function)) {
+      result.parameters = injectOptionalStringOmissionSentinel(result.parameters);
     }
     return result;
   });

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -18,6 +18,7 @@ import {
   coerceToolSchemas,
   injectEmptyReasoningContentForToolCalls,
   injectOptionalEnumOmissionForTools,
+  injectOptionalStringOmissionForTools,
   sanitizeToolDescriptions,
 } from "./helpers/schemaCoercion.ts";
 import { getRequestTranslator, getResponseTranslator } from "./registry.ts";
@@ -595,6 +596,12 @@ export function translateRequest(
   }
 
   if (result.tools !== undefined) {
+    // Plain-string omission must run before coerceToolSchemas() strips `default`,
+    // so defaulted optional strings stay unsentinelled. Enum injection stays after
+    // coercion to preserve the #7023 pipeline.
+    if (targetFormat === FORMATS.OPENAI_RESPONSES) {
+      result.tools = injectOptionalStringOmissionForTools(result.tools);
+    }
     result.tools = coerceToolSchemas(result.tools);
     result.tools = sanitizeToolDescriptions(result.tools);
     if (targetFormat === FORMATS.OPENAI_RESPONSES) {

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -866,13 +866,13 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
 function openaiResponsesToOpenAIResponseStream(chunk, state) {
   if (!chunk) {
-    // Iterate every still-open call needing schema-aware normalization, not just a
-    // single one — multiple parallel calls can each be pending here if the stream
-    // ends before their output_item.done arrives.
+    // Iterate every still-open call with a buffered argument payload — argument
+    // deltas are buffered for every tool, so an incomplete stream must flush every
+    // buffered call, not only the historical uppercase Agent path.
     const pendingNormalized: Array<{ index: number; argsStr: string }> = [];
     if (state.toolCallByCallId instanceof Map) {
       for (const entry of state.toolCallByCallId.values()) {
-        if (entry.needsNormalization && entry.argsBuffer) {
+        if (entry.argsBuffer) {
           const toolSchema = state.toolSchemas?.get(entry.name);
           const argsToEmit = stripEmptyOptionalToolArgs(entry.argsBuffer, entry.name, toolSchema);
           pendingNormalized.push({

--- a/open-sse/translator/response/openai-responses/pureHelpers.ts
+++ b/open-sse/translator/response/openai-responses/pureHelpers.ts
@@ -56,21 +56,35 @@ function isDroppableEmptyEntry(entry, propSchema, required, key, allowlisted) {
   return allowlisted || (propSchema != null && !required.has(key));
 }
 
-// #7023 — the request-side counterpart (injectOptionalEnumOmissionSentinel) widens
-// no-default optional enum properties to accept `null`, meaning "omitted" (OpenAI's own
-// nullable-union idiom for Responses-API strict mode). Drop the key when the model
-// follows that idiom for a non-required, schema-declared property.
+function schemaTypeIncludes(type, wanted) {
+  return type === wanted || (Array.isArray(type) && type.includes(wanted));
+}
+
+function hasOmissionSentinel(propSchema) {
+  if (!propSchema || typeof propSchema !== "object") return false;
+  if (
+    typeof propSchema.description !== "string" ||
+    !propSchema.description.includes("null = omit this parameter")
+  ) {
+    return false;
+  }
+  return (
+    schemaTypeIncludes(propSchema.type, "null") ||
+    (Array.isArray(propSchema.enum) && propSchema.enum.includes(null))
+  );
+}
+
+// #7023 — the request-side counterpart widens no-default optional properties to accept
+// `null`, meaning "omitted" (OpenAI's own nullable-union idiom for Responses-API strict
+// mode). Enums use injectOptionalEnumOmissionSentinel; plain strings use
+// injectOptionalStringOmissionSentinel. Drop the key when the model follows that idiom
+// for a non-required, schema-declared property, or when OmniRoute's marker is present
+// even after an upstream strictifies the field into `required`.
 function isDroppableNullEntry(entry, propSchema, required, key, toolName) {
   if (entry !== null) return false;
   if (toolName === "Agent") return true;
   if (propSchema == null) return false;
-  const omissionSentinel =
-    typeof propSchema === "object" &&
-    Array.isArray(propSchema.enum) &&
-    propSchema.enum.includes(null) &&
-    typeof propSchema.description === "string" &&
-    propSchema.description.includes("null = omit this parameter");
-  return !required.has(key) || omissionSentinel;
+  return !required.has(key) || hasOmissionSentinel(propSchema);
 }
 
 function stripEmptyOptionalToolArgsObject(value, toolName, schema) {
@@ -110,7 +124,11 @@ export function stripEmptyOptionalToolArgs(value, toolName, schema) {
     // supplied (schema-aware normalization is not restricted to the allowlist).
     // "Agent" also passes without a schema: isDroppableNullEntry drops its null
     // omission sentinels even when the strict schema snapshot is unavailable (#9423).
-    if (!hasUsableSchema(schema) && !STRIPPABLE_EMPTY_ARG_TOOLS.has(toolName) && toolName !== "Agent") {
+    if (
+      !hasUsableSchema(schema) &&
+      !STRIPPABLE_EMPTY_ARG_TOOLS.has(toolName) &&
+      toolName !== "Agent"
+    ) {
       return value;
     }
     try {

--- a/tests/unit/openai-responses-opencode-subagent-sessionid.test.ts
+++ b/tests/unit/openai-responses-opencode-subagent-sessionid.test.ts
@@ -1,0 +1,515 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// OpenCode `subagent.sessionID` is an optional plain string. Absence means "spawn a
+// new child". Responses/Codex strict mode forces every declared property into
+// `required`, so models invent fillers (`ses_`, `ses_new`, parent IDs) unless
+// OmniRoute offers `null` as the omission sentinel and strips it before the client
+// sees the tool call. This is the string counterpart of the #7023 enum sentinel.
+
+const { injectOptionalStringOmissionSentinel, injectOptionalStringOmissionForTools } =
+  await import("../../open-sse/translator/helpers/schemaCoercion.ts");
+const { stripEmptyOptionalToolArgs } =
+  await import("../../open-sse/translator/response/openai-responses/pureHelpers.ts");
+const { openaiResponsesToOpenAIResponse } =
+  await import("../../open-sse/translator/response/openai-responses.ts");
+const { translateRequest } = await import("../../open-sse/translator/index.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+const { translateNonStreamingResponse } =
+  await import("../../open-sse/handlers/responseTranslator.ts");
+const { extractToolSchemaMap } =
+  await import("../../open-sse/translator/response/openai-responses/toolSchemas.ts");
+
+const OMISSION_MARKER = "null = omit this parameter";
+
+const OPENCODE_SUBAGENT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    agent: { type: "string" },
+    description: { type: "string" },
+    prompt: { type: "string" },
+    sessionID: {
+      type: "string",
+      description: "Continue a specific previous subagent conversation",
+    },
+    background: { type: "boolean" },
+  },
+  required: ["agent", "description", "prompt"],
+};
+
+const SUBAGENT_TOOL_CHAT = {
+  type: "function",
+  function: {
+    name: "subagent",
+    parameters: structuredClone(OPENCODE_SUBAGENT_SCHEMA),
+  },
+};
+
+const SUBAGENT_TOOL_RESPONSES = {
+  type: "function",
+  name: "subagent",
+  parameters: structuredClone(OPENCODE_SUBAGENT_SCHEMA),
+};
+
+const NATIVE_CUSTOM_TOOL = {
+  type: "custom",
+  name: "apply_patch",
+  format: { type: "grammar", syntax: "lark", definition: "start: /.+/ " },
+};
+
+function findTool(tools, name) {
+  return tools.find((t) => t?.name === name || t?.function?.name === name);
+}
+
+function toolParameters(tool) {
+  return tool.parameters ?? tool.function?.parameters ?? tool.input_schema;
+}
+
+function sessionIdSchema(params) {
+  return params.properties.sessionID;
+}
+
+function assertOmissionSentinel(prop) {
+  assert.deepEqual(prop.type, ["string", "null"]);
+  assert.match(
+    prop.description,
+    new RegExp(OMISSION_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  );
+  assert.equal(Array.isArray(prop.enum), false);
+}
+
+function collectArgs(chunks) {
+  const list = Array.isArray(chunks) ? chunks : chunks ? [chunks] : [];
+  let raw = "";
+  let finishReason = null;
+  for (const chunk of list) {
+    const choice = chunk?.choices?.[0];
+    if (!choice) continue;
+    const args = choice.delta?.tool_calls?.[0]?.function?.arguments;
+    if (typeof args === "string") raw += args;
+    if (choice.finish_reason) finishReason = choice.finish_reason;
+  }
+  return { raw, finishReason, parsed: raw ? JSON.parse(raw) : null };
+}
+
+test("RED: translateRequest OpenAI→Responses widens optional default-less sessionID", () => {
+  const body = {
+    model: "gpt-5.1-codex",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [structuredClone(SUBAGENT_TOOL_CHAT)],
+  };
+
+  const toResponses = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI_RESPONSES,
+    "gpt-5.1-codex",
+    structuredClone(body)
+  );
+  const tool = findTool(toResponses.tools, "subagent");
+  const params = toolParameters(tool);
+  assertOmissionSentinel(sessionIdSchema(params));
+  assert.equal(params.properties.agent.type, "string");
+  assert.equal(params.properties.background.type, "boolean");
+  assert.deepEqual(params.required, ["agent", "description", "prompt"]);
+});
+
+test("RED: same-format Responses applies string omission without flattening native tools", () => {
+  const body = {
+    model: "gpt-5.1-codex",
+    input: [{ role: "user", content: "hi" }],
+    tools: [structuredClone(SUBAGENT_TOOL_RESPONSES), structuredClone(NATIVE_CUSTOM_TOOL)],
+  };
+
+  const sameFormat = translateRequest(
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.OPENAI_RESPONSES,
+    "gpt-5.1-codex",
+    structuredClone(body)
+  );
+  const functionTool = findTool(sameFormat.tools, "subagent");
+  assertOmissionSentinel(sessionIdSchema(toolParameters(functionTool)));
+
+  const custom = sameFormat.tools.find((t) => t.name === "apply_patch");
+  assert.equal(custom.type, "custom");
+  assert.deepEqual(custom.format, NATIVE_CUSTOM_TOOL.format);
+  assert.equal(custom.parameters, undefined);
+});
+
+test("characterization: non-Responses target leaves sessionID unchanged", () => {
+  const body = {
+    model: "claude-3-7-sonnet",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [structuredClone(SUBAGENT_TOOL_CHAT)],
+  };
+  const toClaude = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "claude-3-7-sonnet",
+    structuredClone(body)
+  );
+  const tool = toClaude.tools.find((t) => String(t.name).includes("subagent"));
+  const schema = toolParameters(tool);
+  assert.equal(schema.properties.sessionID.type, "string");
+  assert.equal(
+    String(schema.properties.sessionID.description || "").includes(OMISSION_MARKER),
+    false
+  );
+});
+
+test("characterization: required string stays non-nullable; unmarked required null is kept", () => {
+  const requiredOnly = injectOptionalStringOmissionSentinel({
+    type: "object",
+    properties: { sessionID: { type: "string" } },
+    required: ["sessionID"],
+  });
+  assert.equal(requiredOnly.properties.sessionID.type, "string");
+
+  const requiredNull = stripEmptyOptionalToolArgs(
+    { sessionID: null, agent: "explore" },
+    "subagent",
+    {
+      type: "object",
+      properties: { sessionID: { type: "string" }, agent: { type: "string" } },
+      required: ["sessionID", "agent"],
+    }
+  );
+  assert.equal(Object.prototype.hasOwnProperty.call(requiredNull, "sessionID"), true);
+  assert.equal(requiredNull.sessionID, null);
+});
+
+test("characterization: optional string with default stays unsentinelled through translateRequest", () => {
+  const body = {
+    model: "gpt-5.1-codex",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "subagent",
+          parameters: {
+            type: "object",
+            properties: {
+              agent: { type: "string" },
+              sessionID: { type: "string", default: "" },
+            },
+            required: ["agent"],
+          },
+        },
+      },
+    ],
+  };
+  const toResponses = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI_RESPONSES,
+    "gpt-5.1-codex",
+    structuredClone(body)
+  );
+  const params = toolParameters(findTool(toResponses.tools, "subagent"));
+  assert.equal(params.properties.sessionID.type, "string");
+  assert.equal(
+    String(params.properties.sessionID.description || "").includes(OMISSION_MARKER),
+    false
+  );
+});
+
+test("characterization: optional unmarked null is already stripped; real IDs are kept", () => {
+  const optionalSchema = structuredClone(OPENCODE_SUBAGENT_SCHEMA);
+  const stripped = stripEmptyOptionalToolArgs(
+    {
+      agent: "explore",
+      description: "spawn",
+      prompt: "do work",
+      sessionID: null,
+    },
+    "subagent",
+    optionalSchema
+  );
+  assert.equal(Object.prototype.hasOwnProperty.call(stripped, "sessionID"), false);
+
+  const kept = stripEmptyOptionalToolArgs(
+    {
+      agent: "explore",
+      description: "continue",
+      prompt: "do work",
+      sessionID: "ses_valid_child",
+    },
+    "subagent",
+    optionalSchema
+  );
+  assert.equal(kept.sessionID, "ses_valid_child");
+});
+
+test("RED: strictified required sessionID with OmniRoute marker still drops null", () => {
+  const strictified = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      agent: { type: "string" },
+      description: { type: "string" },
+      prompt: { type: "string" },
+      sessionID: {
+        type: ["string", "null"],
+        description: `Continue a specific previous subagent conversation (${OMISSION_MARKER})`,
+      },
+      background: { type: "boolean" },
+    },
+    required: ["agent", "description", "prompt", "sessionID", "background"],
+  };
+  const stripped = stripEmptyOptionalToolArgs(
+    {
+      agent: "explore",
+      description: "spawn",
+      prompt: "do work",
+      sessionID: null,
+    },
+    "subagent",
+    strictified
+  );
+  assert.equal(Object.prototype.hasOwnProperty.call(stripped, "sessionID"), false);
+  assert.equal(stripped.agent, "explore");
+});
+
+test("characterization: empty sessionID is stripped; nested optional strings are not widened", () => {
+  const emptyStripped = stripEmptyOptionalToolArgs(
+    {
+      agent: "explore",
+      description: "spawn",
+      prompt: "do work",
+      sessionID: "",
+    },
+    "subagent",
+    OPENCODE_SUBAGENT_SCHEMA
+  );
+  assert.equal(Object.prototype.hasOwnProperty.call(emptyStripped, "sessionID"), false);
+
+  const nested = injectOptionalStringOmissionSentinel({
+    type: "object",
+    properties: {
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { sessionID: { type: "string" } },
+          required: [],
+        },
+      },
+      wrapper: {
+        anyOf: [{ type: "object", properties: { sessionID: { type: "string" } } }],
+      },
+      $defs: {
+        child: { type: "object", properties: { sessionID: { type: "string" } } },
+      },
+    },
+    required: [],
+  });
+  assert.equal(nested.properties.items.items.properties.sessionID.type, "string");
+  assert.equal(nested.properties.wrapper.anyOf[0].properties.sessionID.type, "string");
+  assert.equal(nested.properties.$defs.child.properties.sessionID.type, "string");
+
+  const mixedUnion = injectOptionalStringOmissionSentinel({
+    type: "object",
+    properties: { value: { type: ["string", "number"] } },
+    required: [],
+  });
+  assert.deepEqual(mixedUnion.properties.value.type, ["string", "number"]);
+});
+
+test("characterization: string omission injection is idempotent", () => {
+  const once = injectOptionalStringOmissionSentinel(structuredClone(OPENCODE_SUBAGENT_SCHEMA));
+  const twice = injectOptionalStringOmissionSentinel(once);
+  assertOmissionSentinel(sessionIdSchema(twice));
+  assert.equal(twice.properties.sessionID.description.split(OMISSION_MARKER).length - 1, 1);
+  const toolsOnce = injectOptionalStringOmissionForTools([
+    structuredClone(SUBAGENT_TOOL_RESPONSES),
+  ]);
+  const toolsTwice = injectOptionalStringOmissionForTools(toolsOnce);
+  assertOmissionSentinel(toolParameters(toolsTwice[0]).properties.sessionID);
+});
+
+test("characterization: fragmented deltas + output_item.done emit cleaned lowercase subagent args", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      agent: { type: "string" },
+      description: { type: "string" },
+      prompt: { type: "string" },
+      sessionID: {
+        type: ["string", "null"],
+        description: `Continue a specific previous subagent conversation (${OMISSION_MARKER})`,
+      },
+    },
+    required: ["agent", "description", "prompt"],
+  };
+  const state = { toolSchemas: new Map([["subagent", schema]]) };
+  openaiResponsesToOpenAIResponse(
+    {
+      type: "response.output_item.added",
+      item: { type: "function_call", call_id: "call_1", name: "subagent" },
+    },
+    state
+  );
+  const raw = JSON.stringify({
+    agent: "explore",
+    description: "spawn",
+    prompt: "do work",
+    sessionID: null,
+  });
+  const firstDelta = openaiResponsesToOpenAIResponse(
+    { type: "response.function_call_arguments.delta", delta: raw.slice(0, 40) },
+    state
+  );
+  const secondDelta = openaiResponsesToOpenAIResponse(
+    { type: "response.function_call_arguments.delta", delta: raw.slice(40) },
+    state
+  );
+  const done = openaiResponsesToOpenAIResponse(
+    {
+      type: "response.output_item.done",
+      item: { type: "function_call", call_id: "call_1", name: "subagent", arguments: raw },
+    },
+    state
+  );
+
+  assert.equal(firstDelta, null);
+  assert.equal(secondDelta, null);
+  const args = JSON.parse(done.choices[0].delta.tool_calls[0].function.arguments);
+  assert.equal(Object.prototype.hasOwnProperty.call(args, "sessionID"), false);
+  assert.equal(args.agent, "explore");
+  assert.equal(args.prompt, "do work");
+});
+
+test("RED: incomplete-stream flush emits cleaned lowercase subagent arguments", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      agent: { type: "string" },
+      description: { type: "string" },
+      prompt: { type: "string" },
+      sessionID: {
+        type: ["string", "null"],
+        description: `Continue a specific previous subagent conversation (${OMISSION_MARKER})`,
+      },
+    },
+    required: ["agent", "description", "prompt"],
+  };
+  const state = { toolSchemas: new Map([["subagent", schema]]) };
+  openaiResponsesToOpenAIResponse(
+    {
+      type: "response.output_item.added",
+      item: { type: "function_call", call_id: "call_1", name: "subagent" },
+    },
+    state
+  );
+  const raw = JSON.stringify({
+    agent: "explore",
+    description: "spawn",
+    prompt: "do work",
+    sessionID: null,
+  });
+  openaiResponsesToOpenAIResponse(
+    { type: "response.function_call_arguments.delta", delta: raw },
+    state
+  );
+  const flushed = openaiResponsesToOpenAIResponse(null, state);
+  const { parsed, finishReason } = collectArgs(flushed);
+  assert.ok(parsed);
+  assert.equal(Object.prototype.hasOwnProperty.call(parsed, "sessionID"), false);
+  assert.equal(parsed.agent, "explore");
+  assert.equal(finishReason, "tool_calls");
+});
+
+test("RED: non-streaming Responses translation drops sessionID null when given the schema", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      agent: { type: "string" },
+      description: { type: "string" },
+      prompt: { type: "string" },
+      sessionID: {
+        type: ["string", "null"],
+        description: `Continue a specific previous subagent conversation (${OMISSION_MARKER})`,
+      },
+    },
+    required: ["agent", "description", "prompt", "sessionID"],
+  };
+  const responseBody = {
+    id: "resp_1",
+    object: "response",
+    output: [
+      {
+        type: "function_call",
+        call_id: "call_1",
+        name: "subagent",
+        arguments: JSON.stringify({
+          agent: "explore",
+          description: "spawn",
+          prompt: "do work",
+          sessionID: null,
+        }),
+      },
+    ],
+  };
+  const translated = translateNonStreamingResponse(
+    responseBody,
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.OPENAI,
+    null,
+    new Map([["subagent", schema]])
+  );
+  const args = JSON.parse(translated.choices[0].message.tool_calls[0].function.arguments);
+  assert.equal(Object.prototype.hasOwnProperty.call(args, "sessionID"), false);
+  assert.equal(args.agent, "explore");
+});
+
+test("characterization: non-streaming keeps a real sessionID and legacy empty cleanup without schema", () => {
+  const withId = translateNonStreamingResponse(
+    {
+      id: "resp_2",
+      object: "response",
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_2",
+          name: "subagent",
+          arguments: JSON.stringify({
+            agent: "explore",
+            description: "continue",
+            prompt: "do work",
+            sessionID: "ses_valid_child",
+          }),
+        },
+      ],
+    },
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.OPENAI
+  );
+  const kept = JSON.parse(withId.choices[0].message.tool_calls[0].function.arguments);
+  assert.equal(kept.sessionID, "ses_valid_child");
+
+  const noSchema = translateNonStreamingResponse(
+    {
+      id: "resp_3",
+      object: "response",
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_3",
+          name: "other",
+          arguments: { note: "", tags: [] },
+        },
+      ],
+    },
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.OPENAI
+  );
+  const cleaned = JSON.parse(noSchema.choices[0].message.tool_calls[0].function.arguments);
+  assert.equal(Object.prototype.hasOwnProperty.call(cleaned, "note"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(cleaned, "tags"), false);
+});
+
+test("characterization: extractToolSchemaMap still keys OpenCode subagent by lowercase name", () => {
+  const map = extractToolSchemaMap({ tools: [structuredClone(SUBAGENT_TOOL_RESPONSES)] });
+  assert.ok(map?.has("subagent"));
+  assert.equal(map.get("subagent").properties.sessionID.type, "string");
+});


### PR DESCRIPTION
## Summary

- OpenCode `subagent.sessionID` is an optional default-less string: omit it to spawn a new child, pass a real child ID to continue.
- Responses/Codex strict mode required every declared property, so models invented fillers (`ses_`, `ses_new`, parent IDs) instead of omitting the field.
- Offer `null` as the omission sentinel for optional default-less plain strings (`null = omit this parameter`), then strip that `null` before OpenCode sees the tool call. Real child session IDs stay unchanged.

## Related Issues

- Related to #6951 / #7023 (prior enum omission-sentinel mechanism). Those issues are not reopened by this PR.
- No dedicated bug issue yet.

⚠️ base-red inherited: #9985

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: routing / translator (other)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint` — this PR's files are clean with CI suppressions. Full-repo lint is `✖ 47 problems (47 errors, 0 warnings)` on untouched dashboard/CLI/test files (`FirstRunReadinessCard`, `EndpointPageClient`, `CommandPalette`, CLI tests). Inherited from #9985; not repaired here.
- [x] `npm run check:open-sse-typecheck` — `OK — 5 pre-existing error(s), all within frozen baseline`
- [x] Reconciled with the current active release base (`origin/release/v3.8.50` @ `92f58603f`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.
- Vitest, sharded unit suite, 60% coverage ratchet, and production build: CI-owned.

### Evidence

Node 24.19.0 (repo engines: `>=22.22.2 <23 || >=24.0.0 <27`). Rebased onto `origin/release/v3.8.50`, then:

```
$ node -v
v24.19.0

$ node --import tsx/esm --test tests/unit/openai-responses-opencode-subagent-sessionid.test.ts
✔ RED: translateRequest OpenAI→Responses widens optional default-less sessionID
✔ RED: same-format Responses applies string omission without flattening native tools
✔ characterization: non-Responses target leaves sessionID unchanged
✔ characterization: required string stays non-nullable; unmarked required null is kept
✔ characterization: optional string with default stays unsentinelled through translateRequest
✔ characterization: optional unmarked null is already stripped; real IDs are kept
✔ RED: strictified required sessionID with OmniRoute marker still drops null
✔ characterization: empty sessionID is stripped; nested optional strings are not widened
✔ characterization: string omission injection is idempotent
✔ characterization: fragmented deltas + output_item.done emit cleaned lowercase subagent args
✔ RED: incomplete-stream flush emits cleaned lowercase subagent arguments
✔ RED: non-streaming Responses translation drops sessionID null when given the schema
✔ characterization: non-streaming keeps a real sessionID and legacy empty cleanup without schema
✔ characterization: extractToolSchemaMap still keys OpenCode subagent by lowercase name
ℹ tests 14
ℹ pass 14
ℹ fail 0

$ node --import tsx/esm --test tests/unit/schema-coercion.test.ts
ℹ tests 19
ℹ pass 19
ℹ fail 0

$ node --import tsx/esm --test tests/unit/openai-responses-subagent-strip-2446.test.ts
ℹ tests 3
ℹ pass 3
ℹ fail 0

$ node --import tsx/esm --test tests/unit/response-openai-responses-purehelpers-split.test.ts
ℹ tests 3
ℹ pass 3
ℹ fail 0

$ npm run check:open-sse-typecheck
[open-sse-typecheck] OK — 5 pre-existing error(s), all within frozen baseline.

$ npm run lint
✖ 47 problems (47 errors, 0 warnings)
# none in this PR's files; inherited #9985 files only
```

## Tests Added Or Updated

- `tests/unit/openai-responses-opencode-subagent-sessionid.test.ts` (new, 14 cases)

Unchanged related guards rerun:

- `tests/unit/schema-coercion.test.ts`
- `tests/unit/openai-responses-subagent-strip-2446.test.ts`
- `tests/unit/response-openai-responses-purehelpers-split.test.ts`

## Coverage Notes

- Request injection: `injectOptionalStringOmissionForTools` / `injectOptionalStringOmissionSentinel` — covered by the widening, idempotency, required/default/nested characterization tests.
- Null stripping: marker-aware `isDroppableNullEntry()` in `pureHelpers.ts` — covered by unmarked-null vs marker-null vs real-ID cases.
- Stream flush: incomplete-stream flush of every buffered tool call — covered by the fragmented-delta and incomplete-stream tests.
- Non-streaming path: `translateNonStreamingResponse(..., toolSchemaMap)` from `chatCore.ts` — covered by the schema-aware drop + legacy empty-cleanup tests.
- No coverage regression expected on the new test file; CI owns the 60% ratchet.

## Reviewer Notes

Suggested review order (one commit, 8 files):

1. `open-sse/translator/helpers/schemaCoercion.ts` + `open-sse/translator/index.ts` — request-side sentinel
2. `open-sse/translator/response/openai-responses/pureHelpers.ts` — response-side strip
3. `open-sse/translator/response/openai-responses.ts` — incomplete-stream flush
4. `open-sse/handlers/responseTranslator.ts` + `open-sse/handlers/chatCore.ts` — non-streaming schema threading
5. `tests/unit/openai-responses-opencode-subagent-sessionid.test.ts` — contract

- Global growth (intentional, same as #7023): every top-level optional default-less plain string in a Responses-bound tool schema gets `type: ["string", "null"]` and `null = omit this parameter`. Nested `items` / `anyOf` / `$defs` are not widened. Enums stay on the existing helper. For OpenCode `subagent`, only `sessionID` qualifies (`agent` / `description` / `prompt` are required; `background` is boolean).
- String vs enum helpers stay split. String sentinel runs **before** `coerceToolSchemas()` so optional strings with `default` stay unsentinelled (`coerceToolSchemas` strips `default`, #1782). Enum injection stays **after** coercion to preserve the #7023 pipeline.
- Incomplete-stream flush is now generic (every buffered tool call), not Agent-only. Previously `needsNormalization` was set only for uppercase `Agent`, so a lowercase `subagent` abort dropped the call. Truncated JSON is passed through (`JSON.parse` catch). Clients that depended on aborted non-Agent tool calls being silently dropped will now see them. That is the intended trade.
- Non-streaming `translateNonStreamingResponse` takes an optional 5th schema-map argument. Existing four-arg callers keep the legacy empty-string/array cleanup when no schema is supplied.
- Residual, out of scope: if Codex ignores the sentinel and still emits a plausible filler (`ses_new`, parent `ses_…`), OmniRoute forwards it. This is a protocol omit-token, not a session-ID validator. OpenCode will still reject a fake ID.
- Schema lookup is exact-name (`extractToolSchemaMap` pre-existing). Tests key `subagent` lowercase, matching OpenCode. A `Subagent` vs `subagent` mismatch would skip schema-aware strip; not changed here.
- No migration, feature flag, or public API change.
- Changelog fragment: `changelog.d/fixes/11297-opencode-subagent-sessionid.md`.
