### PR TITLE
fix(opencode-plugin): track active release branch in CI + align combo-id fixture

### DIFF
--- a/.github/workflows/opencode-plugin-ci.yml
+++ b/.github/workflows/opencode-plugin-ci.yml
@@ -2,11 +2,11 @@ name: opencode-plugin CI
 
 on:
   push:
-    branches: [main, release/v3.8.2]
+    branches: [main, "release/**"]
     paths:
       - "@omniroute/opencode-plugin/**"
   pull_request:
-    branches: [main, release/v3.8.2]
+    branches: [main, "release/**"]
     paths:
       - "@omniroute/opencode-plugin/**"
     types: [opened, synchronize, reopened, ready_for_review]

--- a/@omniroute/opencode-plugin/tests/provider.test.ts
+++ b/@omniroute/opencode-plugin/tests/provider.test.ts
@@ -104,7 +104,10 @@ test("models: extracts apiKey from ctx.auth (type=api) and calls fetcher with it
   // #6859: dynamic-hook catalog keys use the unprefixed omnirouteProviderId
   // ("omniroute"), not the OC-gate-prefixed hook.id ("opencode-omniroute") —
   // that prefix must never leak into anything OmniRoute's server parses.
-  assert.ok(out["omniroute/claude-primary"]);
+  // #10345/#10821: bare combo ids (owned_by: "combo") stay unprefixed —
+  // OpenCode looks up `-m <plugin>/<combo>` as model id `<combo>` under the
+  // plugin provider, so `claude-primary` here carries no provider prefix.
+  assert.ok(out["claude-primary"]);
 });
 
 test("models: returns {} when ctx.auth is null/undefined/wrong-type/empty-key", async () => {
@@ -159,11 +162,15 @@ test("models: maps a sample /v1/models entry to ModelV2 (sanity)", async () => {
   // omnirouteProviderId ("omniroute") — the OC-gate prefix ("opencode-")
   // must stay OC-internal (hook.id / AuthHook.provider) and never leak into
   // anything OmniRoute's own server parses for credential lookup.
-  const claude = out["omniroute/claude-primary"];
+  // #10345/#10821: bare **combo** ids (owned_by: "combo", e.g.
+  // "claude-primary") must also stay unprefixed — OpenCode looks up
+  // `-m <plugin>/<combo>` as model id `<combo>` under the plugin provider.
+  const claude = out["claude-primary"];
   assert.ok(claude, "claude-primary present");
-  // `mapRawModelToModelV2` stamps the provider prefix on the id so OC's
-  // static-catalog reader resolves `(providerID, modelID)` from the key.
-  assert.equal(claude.id, "omniroute/claude-primary");
+  // `mapRawModelToModelV2` leaves bare combo ids unprefixed (see
+  // src/index.ts mapRawModelToModelV2) so OC's `-m <plugin>/<combo>` lookup
+  // resolves the combo id directly.
+  assert.equal(claude.id, "claude-primary");
   assert.equal(claude.name, "claude-primary");
   assert.equal(claude.providerID, "omniroute");
   assert.equal(claude.api.id, "openai-compatible");


### PR DESCRIPTION
## Summary

- **#11291** — `opencode-plugin-ci.yml` push/pull_request branch triggers were pinned to `release/v3.8.2` since the workflow's creation. The active release line has since moved on (`release/v3.8.50`), so the workflow never fired mid-cycle. Switched both `branches:` filters to `[main, "release/**"]`, matching the pattern already used by `semgrep.yml`, `quality.yml`, `nightly-release-green.yml`, and `dast-smoke.yml`. The `paths:` filter scoping to `@omniroute/opencode-plugin/**` was already correct and is unchanged.
- **#11292** — `tests/provider.test.ts` had two stale assertions expecting the combo id `claude-primary` (fixture `owned_by: "combo"`) to come back key-prefixed as `omniroute/claude-primary`. Since #10821 (`mapRawModelToModelV2`, `src/index.ts`), bare combo ids are left unprefixed so OpenCode's `-m <plugin>/<combo>` lookup resolves the combo id directly (per #10345). Updated the assertions to `out["claude-primary"]` / `claude.id === "claude-primary"` and refreshed the stale comment to reference the real contract. The `gemini-3-flash` (`owned_by: "google"`) assertions were untouched.

## Test plan

- [x] `node --import tsx/esm --test tests/provider.test.ts` — RED before fix: 11/13 pass, 2 failures at lines 107 and 163 (exactly the stale assertions). GREEN after fix: 13/13.
- [x] `npm run build && npm test` (full `@omniroute/opencode-plugin` suite) — 343/343 pass.
- [x] YAML syntax of `opencode-plugin-ci.yml` validated with `python3 -c "import yaml; yaml.safe_load(open(...))"`.
- [ ] No way to validate the trigger firing live from this environment (requires an actual push/PR event against `release/v3.8.50`); the branch-filter change follows the exact pattern already proven working in the other workflows listed above.

⚠️ base-red inherited: #9985