### PR TITLE
fix(api): honor model-hidden overrides across provider key variants (#11300)

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -9,6 +9,7 @@ import {
   getModelAliases,
   getDatabaseSettings,
   getHiddenModelsByProvider,
+  isModelHiddenInBulkMap,
 } from "@/lib/localDb";
 import { createLazyConnectionView } from "@/lib/db/providers/lazyConnectionView";
 import { extractAliasBackedModels } from "./aliasBackedModels";
@@ -265,10 +266,17 @@ async function buildUnifiedModelsResponseCore(
     // try would let a crash here propagate as an unhandled rejection instead
     // (catalogCache.ts's in-flight coalescing does not fully consume rejections).
     const hiddenModelsByProvider = getHiddenModelsByProvider();
-    const isModelHiddenBulk = (providerId: string, modelId: string): boolean => {
-      const hiddenSet = hiddenModelsByProvider.get(providerId);
-      return hiddenSet ? hiddenSet.has(modelId) : false;
-    };
+    // #11300: overrides are stored under whatever key the dashboard route carried
+    // (node UUID, alias like cc/gh/xao, canonical id). `isModelHiddenInBulkMap`
+    // resolves the equivalence set [key, canonical, alias-of-canonical] plus the
+    // caller extras below (this loop's own alias + node prefix). The alias/prefix
+    // maps are declared further down but only READ here at call time (first call
+    // site is ~L850), so the closure reference is safe.
+    const isModelHiddenBulk = (providerId: string, modelId: string): boolean =>
+      isModelHiddenInBulkMap(hiddenModelsByProvider, providerId, modelId, [
+        providerIdToAlias[providerId],
+        providerIdToPrefix[providerId],
+      ]);
     let settings: Record<string, any> = {};
     try {
       settings = await getSettings();
@@ -1018,7 +1026,10 @@ async function buildUnifiedModelsResponseCore(
 
     for (const modelId of CODEX_NATIVE_UNPREFIXED_MODELS) {
       if (!providerSupportsModel("codex", modelId)) continue;
-      if (isModelHiddenBulk("codex", modelId)) continue;
+      // #11300: a codex-native model hidden under the `openai` family page (or the
+      // `cx` alias, resolved inside isModelHiddenBulk) must not stay published here.
+      if (isModelHiddenBulk("codex", modelId) || isModelHiddenBulk("openai", modelId))
+        continue;
 
       const alias = providerIdToAlias.codex || "cx";
       const aliasId = `${alias}/${modelId}`;

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -5,6 +5,11 @@
  */
 
 import { isRetiredGitHubCopilotModelId } from "@omniroute/open-sse/config/providers/registry/github/retiredModels.ts";
+import {
+  getProviderAlias,
+  getProviderConnectionFamilyIds,
+  resolveProviderId,
+} from "@/shared/constants/providers";
 
 import type { SqliteAdapter } from "./adapters/types";
 import { getDbInstance } from "./core";
@@ -959,12 +964,67 @@ export function getModelPreserveOpenAIDeveloperRole(
  * Check if the model is flagged as hidden from the public catalog.
  */
 export function getModelIsHidden(providerId: string, modelId: string): boolean {
-  const m = getCustomModelRow(providerId, modelId);
-  if (m && Object.prototype.hasOwnProperty.call(m, "isHidden")) {
-    return Boolean(m.isHidden);
+  // #11300: overrides are stored under whatever key the dashboard route carried
+  // (node UUID, alias like cc/gh/xao, or canonical id). Try the equivalence set
+  // instead of one exact key; first definitive answer wins.
+  for (const key of providerKeysToCheck(providerId)) {
+    const m = getCustomModelRow(key, modelId);
+    if (m && Object.prototype.hasOwnProperty.call(m, "isHidden")) {
+      return Boolean(m.isHidden);
+    }
+    const co = readCompatList(key).find((e) => e.id === modelId);
+    if (co && Object.prototype.hasOwnProperty.call(co, "isHidden")) {
+      return Boolean(co.isHidden);
+    }
   }
-  const co = readCompatList(providerId).find((e) => e.id === modelId);
-  return Boolean(co?.isHidden);
+  return false;
+}
+
+/**
+ * #11300: visibility overrides are persisted under whatever provider key the
+ * dashboard route carried (node UUID, route alias like `cc`/`gh`/`xao`, or the
+ * canonical id). Readers must try the whole equivalence set: the original key,
+ * its canonical id, that canonical's registered alias — plus any caller-supplied
+ * extras (catalog passes node prefixes here).
+ */
+export function providerKeysToCheck(
+  providerId: string,
+  extraKeys?: Array<string | null | undefined>
+): string[] {
+  const canonical = resolveProviderId(providerId);
+  return [
+    ...new Set(
+      [
+        providerId,
+        canonical,
+        getProviderAlias(canonical),
+        // Connection-family aliases (e.g. xai ↔ xai-oauth/xao, magnific ↔ freepik):
+        // hides saved on a family-alias page must be honored family-wide.
+        ...getProviderConnectionFamilyIds(canonical),
+        ...(extraKeys ?? []),
+      ].filter((k): k is string => Boolean(k))
+    ),
+  ];
+}
+
+/**
+ * Bulk-map variant of the #11300 multi-key check, used by the /v1/models catalog
+ * builder (`buildUnifiedModelsResponseCore`) against the single bulk query result
+ * of `getHiddenModelsByProvider()` — keeps the build O(1) per model (no per-call
+ * SQLite reads, preserving the #9147 guarantee).
+ */
+export function isModelHiddenInBulkMap(
+  hiddenByProvider: Map<string, Set<string>>,
+  providerId: string,
+  modelId: string,
+  extraKeys?: Array<string | null | undefined>
+): boolean {
+  if (!providerId || !modelId) return false;
+  for (const key of providerKeysToCheck(providerId, extraKeys)) {
+    const set = hiddenByProvider.get(key);
+    if (set?.has(modelId)) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -65,6 +65,8 @@ export {
   getModelIsHidden,
   setModelIsHidden,
   getHiddenModelsByProvider,
+  isModelHiddenInBulkMap,
+  providerKeysToCheck,
   // Synced Available Models
   getSyncedAvailableModels,
   getAllSyncedAvailableModels,

--- a/tests/unit/model-hide-multikey-11300.test.ts
+++ b/tests/unit/model-hide-multikey-11300.test.ts
@@ -1,0 +1,109 @@
+/**
+ * #11300 — Models toggled "Hidden" on Provider pages are still listed in GET /v1/models.
+ *
+ * Root cause: PATCH /api/provider-models persists {isHidden} under whatever key the
+ * dashboard route carried (node UUID, alias like cc/gh/xao, or canonical claude/github),
+ * while every catalog lookup queries ONE key (canonical, raw connection id, or a
+ * hardcoded "codex"). Any key mismatch leaks the hidden model back into /v1/models.
+ *
+ * This suite pins the multi-key contract:
+ *   - hide saved under an ALIAS is honored when querying CANONICAL (and vice versa)
+ *   - hide saved under a NODE-PREFIX/UUID-style key is honored from any equivalent key
+ *   - the bulk map helper used by buildUnifiedModelsResponseCore resolves all of them
+ */
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+// Hermetic DB (see synced-model-hide-persist-3782.test.ts): isolate DATA_DIR before
+// any import opens the SQLite handle, release the handle afterwards.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-test-hide-multikey-"));
+process.env.DATA_DIR = tmpDir;
+
+const {
+  setModelIsHidden,
+  getModelIsHidden,
+  getHiddenModelsByProvider,
+} = await import("../../src/lib/localDb.ts");
+const { resetDbInstance } = await import("../../src/lib/db/core.ts");
+const { isModelHiddenInBulkMap, providerKeysToCheck } = await import(
+  "../../src/lib/db/models.ts"
+);
+
+before(() => {
+  resetDbInstance();
+});
+
+after(() => {
+  resetDbInstance();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("hide saved under ALIAS key is honored when querying CANONICAL (issue case 2)", () => {
+  // Dashboard page /dashboard/providers/cc toggles gpt-4o hidden → stored under "cc".
+  setModelIsHidden("cc", "gpt-4o", true);
+
+  assert.equal(getModelIsHidden("cc", "gpt-4o"), true, "exact alias key must match");
+  assert.equal(
+    getModelIsHidden("claude", "gpt-4o"),
+    true,
+    "canonical lookup must find alias-stored hide (#11300)"
+  );
+});
+
+test("hide saved under CANONICAL key is honored when queried via ALIAS", () => {
+  setModelIsHidden("github", "gpt-4o-mini", true);
+
+  assert.equal(getModelIsHidden("gh", "gpt-4o-mini"), true);
+  assert.equal(getModelIsHidden("github", "gpt-4o-mini"), true);
+});
+
+test("hide saved under xAI alias xao is honored when querying xai (issue case 2)", () => {
+  setModelIsHidden("xao", "grok-4", true);
+
+  assert.equal(getModelIsHidden("xai", "grok-4"), true);
+});
+
+test("bulk map helper resolves alias/canonical/prefix variants (catalog seam)", () => {
+  // Simulates what getHiddenModelsByProvider() returns when the operator hid models
+  // from three different dashboard surfaces.
+  const map = new Map<string, Set<string>>([
+    ["cc", new Set(["gpt-4o"])], // hidden from alias page
+    ["github", new Set(["gpt-4o-mini"])], // hidden from canonical page
+    ["openai-compatible-chat-ea7d9940", new Set(["deepseek-v4-flash-0731"])], // node UUID page
+  ]);
+
+  // Static loop queries canonicalProviderId…
+  assert.equal(isModelHiddenInBulkMap(map, "claude", "gpt-4o"), true);
+  // Synced loop queries raw connection id (node UUID)…
+  assert.equal(isModelHiddenInBulkMap(map, "openai-compatible-chat-ea7d9940", "deepseek-v4-flash-0731"), true);
+  // Alias loop queries the alias…
+  assert.equal(isModelHiddenInBulkMap(map, "gh", "gpt-4o-mini"), true);
+  // …and unrelated providers stay untouched.
+  assert.equal(isModelHiddenInBulkMap(map, "anthropic", "gpt-4o"), false);
+  assert.equal(isModelHiddenInBulkMap(map, "claude", "gpt-4o-mini"), false);
+});
+
+test("codex-native unprefixed check finds hides stored under cx alias (issue case 4)", () => {
+  setModelIsHidden("cx", "gpt-5-codex", true);
+
+  // The codex-native loop calls isModelHiddenBulk("codex", …); multi-key resolution
+  // must reach the alias-stored entry.
+  assert.equal(getModelIsHidden("codex", "gpt-5-codex"), true);
+});
+
+test("providerKeysToCheck dedupes and keeps unknown ids intact", () => {
+  assert.deepEqual(providerKeysToCheck("unknown-provider"), ["unknown-provider"]);
+  const keys = providerKeysToCheck("cc");
+  assert.ok(keys.includes("cc"), "original key preserved");
+  assert.ok(keys.includes("claude"), "canonical included");
+});
+
+test("hidden flag stays scoped to the hidden model only", () => {
+  setModelIsHidden("mistral", "mistral-large", true);
+
+  assert.equal(getModelIsHidden("mistral", "mistral-small"), false);
+  assert.equal(getModelIsHidden("mistral", "mistral-large"), true);
+});

--- a/tests/unit/model-hide-multikey-11300.test.ts
+++ b/tests/unit/model-hide-multikey-11300.test.ts
@@ -25,7 +25,6 @@ process.env.DATA_DIR = tmpDir;
 const {
   setModelIsHidden,
   getModelIsHidden,
-  getHiddenModelsByProvider,
 } = await import("../../src/lib/localDb.ts");
 const { resetDbInstance } = await import("../../src/lib/db/core.ts");
 const { isModelHiddenInBulkMap, providerKeysToCheck } = await import(


### PR DESCRIPTION
Fixes #11300

## Summary

Models toggled **Hidden** on provider pages kept appearing in `GET /v1/models` whenever the storage key differed from the key a catalog loop queried. Root cause verified line-by-line at base `527da6565`: the write path persists `{isHidden:true}` under **whatever provider key the dashboard route carried** — node UUID (`openai-compatible-chat-<uuid>`), route alias (`cc`/`gh`/`cx`/`xao`), or canonical id (`claude`/`github`/`xai`) — while every read path used exactly one key.

## Before → After (precise)

| Site | Before (base) | After (this branch) |
|---|---|---|
| Bulk-map closure, `catalog.ts` | single-key exact lookup, :267-271 | delegates to multi-key helper, **:275-279**, extras `[providerIdToAlias[key], providerIdToPrefix[key]]`; all 16 call sites unchanged |
| Codex-native loop, `catalog.ts` | hardcoded `"codex"` only, :1020-1021 | also consults the `openai` family page, **:1030-1031** |
| `getModelIsHidden`, `db/models.ts` | exact-key reads only, :961-968 | equivalence-set walk across both namespaces, **:966-981** |
| New: `providerKeysToCheck()` | — | **models.ts:990-1009**: `[key, canonical=resolveProviderId(key), getProviderAlias(canonical), …getProviderConnectionFamilyIds(canonical), …extras]` — family ids cover `xai ↔ xao/xai-oauth`, `magnific ↔ freepik` |
| New: `isModelHiddenInBulkMap()` | — | **models.ts:1016-1033**: O(1)-per-model bulk check, preserves the #9147 one-query-per-build guarantee |
| Re-export, `localDb.ts` | — | lines 68-69 |

Loop-key mismatch table being fixed (base line numbers): static loop queried canonical (:958) missing alias/UUID-stored hides; synced loop queried raw connection id (:1082); custom loop canonical (:1501/:1685/:1759); media loops `model.provider` (:1336-1455). Secondary blast radius closed: per-key public filtering (`apiKeys.ts:1541`) uses `getModelIsHidden`.

## TDD evidence (hard rule #18)

New suite `tests/unit/model-hide-multikey-11300.test.ts`:

**RED against unfixed base** — pass 4 / fail 3:
```
✖ hide saved under xAI alias xao is honored when querying xai   (family aliases never resolved)
✖ bulk map helper resolves alias/canonical/prefix variants       (catalog seam missing entirely)
✖ providerKeysToCheck dedupes and keeps unknown ids intact       (helper did not exist)
```
Honest note: two cases passed pre-fix because `readCompatList()` internally resolves *some* aliases via open-sse's `resolveProviderAlias` — but the `customModels` namespace, connection-family aliases (`xao`), and the entire catalog bulk map did not. That patchwork is why existing tests (which only cover same-key hides) never caught it.

**GREEN post-fix:** 7/7.

**Regression sweep** — issue-named tests + full `/v1/models` family (`synced-model-hide-persist-3782`, `model-catalog-policy-invalidation-8728`, `aliases-included`, `auth-leak-9320`, `catalog-generation-race`, `catalog-ttl`, `concurrent-6408`, `discovery-conformance`): **39 pass / 0 fail**; re-run green after rebase onto current tip. Independently reproduced in a detached clean worktree (no caches): same results.

**Gates:** `npm run typecheck:core` clean. ⚠️ Inherited: repo-wide lint reports 34 pre-existing errors in files this PR does not touch (present at base; tracked by the base-red cluster #9985).

## Scope boundary (matches the reporter's own proposal)

Cross-family bridging with no alias/family/prefix relationship (e.g. bare UUID vs unrelated canonical) would require a reverse node-family index; every combination reachable via canonical resolution, registered aliases, connection-family ids, and node prefixes — i.e., all four cases enumerated in the issue — is covered.

Diff: 4 files changed, +191/−10.
