### PR TITLE
fix(db): escape regex metacharacters in group model patterns

### DIFF
--- a/changelog.d/fixes/11311-group-model-pattern-regex-escape.md
+++ b/changelog.d/fixes/11311-group-model-pattern-regex-escape.md
@@ -1,0 +1,1 @@
+- **fix(db):** group model patterns escape regex metacharacters, so `gpt-4.1*` no longer matches `gpt-4o1-preview` and a pattern like `gpt-4(*` no longer throws `SyntaxError` out of the completion and `/v1/models` paths ([#11311](https://github.com/diegosouzapw/OmniRoute/pull/11311))

--- a/src/lib/db/apiKeyGroups.ts
+++ b/src/lib/db/apiKeyGroups.ts
@@ -304,11 +304,35 @@ export function checkKeyModelAccess(
   return { allowed: false, matchedRules: permissions, deniedBy: null };
 }
 
+/**
+ * Compile a group model pattern.
+ *
+ * `*` is the only wildcard this syntax has, so every other regex
+ * metacharacter must be escaped before the pattern is compiled. Interpolating
+ * it raw made an operator's pattern behave as a regex in two ways:
+ *
+ *   - `gpt-4.1*` matched `gpt-4o1-preview`, because `.` is "any character".
+ *     On a deny rule that blocks unrelated models; on an allow rule it grants
+ *     models the pattern was never meant to cover.
+ *   - `gpt-4(*`, `claude-3[*` and `*+*` threw `SyntaxError` (unterminated
+ *     group / unterminated character class / nothing to repeat) out of
+ *     `checkKeyModelAccess()`, which runs on the completion and /v1/models
+ *     paths — one malformed pattern broke every request for keys in that
+ *     group.
+ *
+ * Escaping keeps the semantics this function already had (case-sensitive,
+ * `*`-only) and matches how the rest of the repo compiles operator patterns
+ * (`globToRegex`, `matchesWildcardPattern`).
+ */
+function modelPatternToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\?]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
 function matchesModelPattern(pattern: string, model: string): boolean {
   if (pattern === "*") return true;
   if (pattern.includes("*")) {
-    const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$");
-    return regex.test(model);
+    return modelPatternToRegex(pattern).test(model);
   }
   return pattern === model;
 }

--- a/tests/unit/group-model-pattern-regex-escape.test.ts
+++ b/tests/unit/group-model-pattern-regex-escape.test.ts
@@ -1,0 +1,156 @@
+// A group model pattern is operator text, but `matchesModelPattern()` compiled
+// it into a RegExp with only `*` substituted, so every other metacharacter kept
+// its regex meaning. Measured on the pre-fix build, through the real
+// `checkKeyModelAccess()` (deny rule, key in the group):
+//
+//   "gpt-4.1*"   vs "gpt-4o1-preview" -> DENIED   ('.' matched 'o')
+//   "gpt-4(*"    vs "gpt-4o"          -> THROW SyntaxError: Unterminated group
+//   "claude-3[*" vs "claude-3-opus"   -> THROW SyntaxError: Unterminated character class
+//   "*+*"        vs "anything"        -> THROW SyntaxError: Nothing to repeat
+//
+// The throw is not contained: `isModelAllowedForKey()` calls this helper with no
+// try/catch, and that runs on the completion path (`src/sse/handlers/chat.ts`)
+// and on the /v1/models catalog, so one malformed pattern breaks every request
+// for keys in that group.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.API_KEY_SECRET = "test-secret-key-for-unit-tests-123456789";
+
+import * as apiKeys from "../../src/lib/db/apiKeys";
+import * as apiKeyGroups from "../../src/lib/db/apiKeyGroups";
+
+let counter = 0;
+
+/**
+ * A fresh key in a fresh group carrying the rule under test.
+ *
+ * A deny rule is paired with `allow *`, because group membership alone is
+ * deny-by-default: with no matching allow rule `checkKeyModelAccess()` returns
+ * false for everything, which would hide whether the deny pattern matched.
+ */
+async function keyWithRule(pattern: string, accessType: "allow" | "deny"): Promise<string> {
+  const label = `pattern-escape-${counter++}`;
+  const key = await apiKeys.createApiKey(label, `machine-${label}`);
+  assert.ok(key, "test key must be created");
+  const group = apiKeyGroups.createKeyGroup(label);
+  apiKeyGroups.addKeyToGroup(key.id, group.id);
+  apiKeyGroups.addGroupPermission(group.id, pattern, accessType);
+  if (accessType === "deny") {
+    apiKeyGroups.addGroupPermission(group.id, "*", "allow");
+  }
+  return key.id;
+}
+
+test("a deny pattern's '.' is a literal, not any-character", async () => {
+  const keyId = await keyWithRule("gpt-4.1*", "deny");
+
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "gpt-4.1-mini").allowed,
+    false,
+    "the model the operator meant to deny must still be denied"
+  );
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "gpt-4o1-preview").allowed,
+    true,
+    "'.' must not match 'o' — an unrelated model was being denied"
+  );
+});
+
+test("an allow pattern's '.' does not widen the grant", async () => {
+  // Same defect in the direction that matters more: an allow rule that matches
+  // more models than it names hands out access the operator never granted.
+  const keyId = await keyWithRule("claude-3.5*", "allow");
+
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "claude-3.5-sonnet").allowed,
+    true,
+    "the model the operator meant to allow must still be allowed"
+  );
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "claude-3x5-internal").allowed,
+    false,
+    "'.' must not match 'x' — an unnamed model was being granted"
+  );
+});
+
+test("patterns that are not valid regexes no longer throw", async () => {
+  // Each of these threw SyntaxError out of the request path before the fix.
+  for (const pattern of ["gpt-4(*", "claude-3[*", "*+*", "a{2*", "gpt-4\\*"]) {
+    const keyId = await keyWithRule(pattern, "deny");
+    assert.doesNotThrow(
+      () => apiKeyGroups.checkKeyModelAccess(keyId, "gpt-4o"),
+      `pattern ${JSON.stringify(pattern)} must not throw`
+    );
+  }
+});
+
+test("the throw also escaped through isModelAllowedForKey", async () => {
+  // The end-to-end path: this is the helper the completion handler and the
+  // /v1/models catalog call, and it has no try/catch around the group check.
+  const label = `pattern-escape-e2e-${counter++}`;
+  const key = await apiKeys.createApiKey(label, `machine-${label}`);
+  assert.ok(key);
+  const group = apiKeyGroups.createKeyGroup(label);
+  apiKeyGroups.addKeyToGroup(key.id, group.id);
+  apiKeyGroups.addGroupPermission(group.id, "gpt-4(*", "deny");
+  apiKeyGroups.addGroupPermission(group.id, "*", "allow");
+
+  const allowed = await apiKeys.isModelAllowedForKey(key.key, "openai/gpt-4o");
+  assert.equal(
+    allowed,
+    true,
+    "a malformed pattern must not deny — and must not throw — on the request path"
+  );
+});
+
+test("literal metacharacters in a pattern match themselves", async () => {
+  // Model ids do carry dots and plus signs, so the escape has to make the
+  // literal reading work, not merely stop the throw.
+  const keyId = await keyWithRule("qwen2.5+vl*", "deny");
+
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "qwen2.5+vl-7b").allowed,
+    false,
+    "the literal pattern must match the literal model id"
+  );
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "qwen2X5vvl-7b").allowed,
+    true,
+    "and must not match the regex reading of itself"
+  );
+});
+
+test("plain wildcard semantics are unchanged", async () => {
+  const keyId = await keyWithRule("gpt-4*", "deny");
+
+  for (const model of ["gpt-4", "gpt-4o", "gpt-4-turbo"]) {
+    assert.equal(
+      apiKeyGroups.checkKeyModelAccess(keyId, model).allowed,
+      false,
+      `${model} must still be denied by gpt-4*`
+    );
+  }
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(keyId, "gpt-3.5-turbo").allowed,
+    true,
+    "an unrelated model must still be allowed"
+  );
+});
+
+test("'*' and exact matches keep their fast paths", async () => {
+  const denyAll = await keyWithRule("*", "deny");
+  assert.equal(apiKeyGroups.checkKeyModelAccess(denyAll, "anything/at-all").allowed, false);
+
+  const exact = await keyWithRule("gpt-4.1-mini", "deny");
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(exact, "gpt-4.1-mini").allowed,
+    false,
+    "an exact pattern still matches exactly"
+  );
+  assert.equal(
+    apiKeyGroups.checkKeyModelAccess(exact, "gpt-4X1-mini").allowed,
+    true,
+    "an exact pattern was never a regex and must stay literal"
+  );
+});


### PR DESCRIPTION
## The bug

`matchesModelPattern()` in `src/lib/db/apiKeyGroups.ts` compiled an operator's group pattern into a RegExp with only `*` substituted:

```ts
const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$");
```

Every other metacharacter kept its regex meaning. Measured on `release/v3.8.50` (`3192eb88d`) through the real `checkKeyModelAccess()`, with a deny rule and the key in the group:

| pattern | model | result |
| --- | --- | --- |
| `gpt-4.1*` | `gpt-4o1-preview` | **DENIED** — `.` matched `o` |
| `gpt-4(*` | `gpt-4o` | **THROW** `SyntaxError: Invalid regular expression: /^gpt-4(.*$/: Unterminated group` |
| `claude-3[*` | `claude-3-opus` | **THROW** `Unterminated character class` |
| `*+*` | `anything` | **THROW** `Nothing to repeat` |

`modelPattern` reaches the DB as free text — `POST /api/keys/groups/[id]/permissions` validates it as `z.string().trim().min(1)` and nothing narrows it afterwards.

## Why the throw matters

It is not contained. `isModelAllowedForKey()` (`src/lib/db/apiKeys.ts:1563`) calls the group check with no try/catch, and that helper runs on the completion path (`src/sse/handlers/chat.ts:942`) and on the `/v1/models` catalog (`src/app/api/v1/models/catalogResponse.ts:209`). Confirmed end to end:

```
deny  "gpt-4(*" -> THROW Invalid regular expression: /^gpt-4(.*$/: Unterminated group
allow "gpt-4(*" -> THROW Invalid regular expression: /^gpt-4(.*$/: Unterminated group
```

So one malformed pattern breaks every request for keys in that group, not just the rule that carries it.

The over-match is quieter but worse in one direction: on a **deny** rule it blocks unrelated models, on an **allow** rule it grants models the operator never named.

## The fix

Escape the metacharacters before substituting `*`. This keeps the semantics the function already had — case-sensitive, `*`-only, no `?` wildcard — so no existing pattern changes meaning except the ones that were being read as regexes. It also brings this call site in line with how the rest of the repo compiles operator patterns (`globToRegex` in `src/shared/utils/globPattern.ts`, `matchesWildcardPattern` in `src/lib/db/apiKeys/modelPermissions.ts`); this was the last unescaped one.

I deliberately did **not** switch to `globToRegex`: it is case-insensitive and treats `?` as a wildcard, which would silently widen existing allow rules.

## Tests

`tests/unit/group-model-pattern-regex-escape.test.ts` — 7 tests through the real `checkKeyModelAccess()` and `isModelAllowedForKey()`, no mocks.

They are load-bearing, not decorative. Removing the escape (keeping the rest of the fix) fails 5 of the 7:

```
not ok 1 - a deny pattern's '.' is a literal, not any-character
not ok 2 - an allow pattern's '.' does not widen the grant
not ok 3 - patterns that are not valid regexes no longer throw
not ok 4 - the throw also escaped through isModelAllowedForKey
not ok 5 - literal metacharacters in a pattern match themselves
ok 6 - plain wildcard semantics are unchanged
ok 7 - '*' and exact matches keep their fast paths
# pass 2  # fail 5
```

The two that still pass are the ones pinning unchanged behaviour, which is what they are for.

## Verification

- New file: **7 passed, 0 failed**.
- Neighbours (`db-api-key-groups`, `group-provider-permission`, `model-catalog-policy-invalidation-8728`, `api-key-policy`, `api-key-scope-validation`, `api-key-lifecycle`): **83 tests, 82 pass**. The one failure is `api-key-lifecycle` — `EBUSY: resource busy or locked, unlink '…\storage.sqlite'` during teardown on Windows; all 11 of its assertions pass. It fails identically with `src/lib/db/apiKeyGroups.ts` restored from `HEAD`, so it is pre-existing and environment-specific, not this change.
- `npm run typecheck:core`: clean. `eslint` on both files: clean.
- `prettier --check` reports the same pre-existing formatting drift on `apiKeyGroups.ts` before and after this change (the file uses trailing commas the config would strip), so I left the rest of the file alone rather than shipping a whole-file reformat.

Found by audit while looking for unescaped dynamic `RegExp` construction, not from a reported incident — no user report is attached to it.


---

⚠️ base-red inherited: #9985 — `No new ESLint warnings` fails on this PR with

```
There are suppressions left that do not occur anymore.
Consider re-running the command with `--prune-suppressions`.
```

That is a stale entry in `config/quality/eslint-suppressions.json`, not a warning introduced here: `config/quality/eslint-suppressions.json` has no entry for `src/lib/db/apiKeyGroups.ts`, `eslint` on both changed files is clean locally, and the same job is red on the other open PRs against this base (#11307, #11308, #11309 — including the maintainer's own). Left alone rather than pruned from a contributor branch.
