### PR TITLE
fix(usage): honor active rateLimitedUntil cooldown on provider-limits sync

### DIFF
--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -459,12 +459,29 @@ function windowStillExhaustedAfterRealReset(value: unknown, nowMs: number): bool
   return resetMs > nowMs;
 }
 
+// An explicitly persisted cooldown is still in force when it parses to a
+// timestamp in the future. Fail OPEN on an unparseable/corrupt value: a bad
+// timestamp must never be able to pin a connection offline forever.
+export function hasActiveCooldown(
+  connection: ProviderConnectionLike,
+  nowMs: number = Date.now()
+): boolean {
+  const raw = connection.rateLimitedUntil;
+  if (!raw) return false;
+  const untilMs = new Date(raw).getTime();
+  if (!Number.isFinite(untilMs)) return false;
+  return untilMs > nowMs;
+}
+
 export async function maybeClearRecoveredQuotaState(
   connection: ProviderConnectionLike,
   usage: JsonRecord
 ): Promise<ProviderConnectionLike> {
   if (!hasUsableQuota(usage)) return connection;
   if (isTerminalStatusForQuotaRecovery(connection.testStatus)) return connection;
+  const nowMs = Date.now();
+  const cooldownActive = hasActiveCooldown(connection, nowMs);
+
   if (connection.lastErrorType === "quota_exhausted") {
     if (
       connection.lastErrorSource === CLAUDE_EXTRA_USAGE_ERROR_SOURCE &&
@@ -479,7 +496,16 @@ export async function maybeClearRecoveredQuotaState(
       // below must not release it just because some quota window looks fresh.
       return connection;
     }
+  }
 
+  // An active cooldown must be honoured regardless of `lastErrorType`.
+  // `lastErrorType` is not normalized across writers: the provider test route
+  // persists diagnosis vocabulary (`upstream_rate_limited`, `network_error`, ...)
+  // that never equals "quota_exhausted", while still persisting a real
+  // `rateLimitedUntil`. Gating these guards on `quota_exhausted` alone let every
+  // other error type fall straight through to the clear, wiping multi-day
+  // cooldowns on each provider-limits sync (issue #11277).
+  if (cooldownActive || connection.lastErrorType === "quota_exhausted") {
     const quotas = usage?.quotas;
     if (isRecord(quotas)) {
       // Honor the REAL per-window resetAt from the freshly fetched quota
@@ -488,13 +514,10 @@ export async function maybeClearRecoveredQuotaState(
       // reset was parseable). Only stay locked if some window that governs
       // this connection's quota is still demonstrably exhausted.
       const anyStillBlocking = Object.values(quotas).some((value) =>
-        windowStillExhaustedAfterRealReset(value, Date.now())
+        windowStillExhaustedAfterRealReset(value, nowMs)
       );
       if (anyStillBlocking) return connection;
-    } else if (
-      connection.rateLimitedUntil &&
-      new Date(connection.rateLimitedUntil).getTime() > Date.now()
-    ) {
+    } else if (cooldownActive) {
       // No quota object at all (degraded/failed fetch shape) — fall back to
       // the previous synthetic-cooldown guard.
       return connection;

--- a/tests/unit/provider-limits-recovery.test.ts
+++ b/tests/unit/provider-limits-recovery.test.ts
@@ -530,3 +530,110 @@ test("Claude extra-usage block stays locked through the real sync chain when rec
     "extra_usage marker must survive the general recovery-clearing logic"
   );
 });
+
+// --- issue #11277: active cooldown wiped on every provider-limits sync ---------
+// `lastErrorType` is not normalized across writers. src/app/api/providers/[id]/test/route.ts
+// persists `diagnosis.type` ("upstream_rate_limited", "network_error", ...), which never
+// equals "quota_exhausted", while still persisting a real `rateLimitedUntil`. Because all
+// the defensive guards lived inside `if (lastErrorType === "quota_exhausted")`, any other
+// error type fell straight through to clearRecoveredProviderState.
+
+async function createConnectionWithCooldown(rateLimitedUntil: string | null) {
+  const created = await providersDb.createProviderConnection({
+    provider: "glm",
+    authType: "apikey",
+    name: `GLM 11277 ${Date.now()}-${Math.random()}`,
+    apiKey: "glm-test-key",
+    testStatus: "unavailable",
+    isActive: true,
+    lastError: "429 weekly quota exhausted",
+    lastErrorType: "upstream_rate_limited",
+    lastErrorSource: "executor",
+    errorCode: 429,
+    rateLimitedUntil,
+    backoffLevel: 2,
+  });
+  const connectionId = (created as { id: string }).id;
+  return {
+    connectionId,
+    connection: await providersDb.getProviderConnectionById(connectionId),
+  };
+}
+
+// Mirrors production: a 5h window with quota left next to the weekly window that
+// actually governs the block sitting at zero. hasUsableQuota() returns true on the
+// first non-zero window, so the connection looks "recovered".
+const MIXED_QUOTAS = {
+  quotas: {
+    "session (5h)": { remaining: 500, remainingPercentage: 42 },
+    "weekly (7d)": { remaining: 0, remainingPercentage: 0 },
+  },
+};
+
+test("active cooldown survives a quota sync even when lastErrorType is not quota_exhausted (#11277)", async () => {
+  const cooldown = new Date(Date.now() + 146 * 60 * 60 * 1000).toISOString();
+  const { connectionId, connection } = await createConnectionWithCooldown(cooldown);
+
+  const result = await providerLimits.maybeClearRecoveredQuotaState(connection, MIXED_QUOTAS);
+
+  assert.equal(result.rateLimitedUntil, cooldown, "146h cooldown must not be wiped");
+  assert.equal(result.testStatus, "unavailable", "connection must stay unavailable");
+  assert.equal(result.lastErrorType, "upstream_rate_limited");
+
+  const after = await providersDb.getProviderConnectionById(connectionId);
+  assert.equal(after.rateLimitedUntil, cooldown, "persisted cooldown must survive the sync");
+  assert.equal(after.testStatus, "unavailable");
+  assert.equal(Number(after.errorCode), 429, "error code must survive the sync");
+});
+
+test("expired cooldown still clears transient state (no-regression, #11277)", async () => {
+  const expired = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const { connectionId, connection } = await createConnectionWithCooldown(expired);
+
+  const result = await providerLimits.maybeClearRecoveredQuotaState(connection, MIXED_QUOTAS);
+
+  assert.equal(result.testStatus, "active", "expired cooldown must not block recovery");
+  assert.equal(result.rateLimitedUntil, null);
+
+  const after = await providersDb.getProviderConnectionById(connectionId);
+  assert.equal(after.testStatus, "active");
+  assert.equal(after.rateLimitedUntil, undefined);
+  assert.equal(after.lastErrorType, undefined);
+  assert.equal(after.backoffLevel, 0);
+});
+
+test("corrupt rateLimitedUntil fails OPEN and does not pin the connection (#11277)", async () => {
+  const { connectionId, connection } = await createConnectionWithCooldown("not-a-timestamp");
+
+  const result = await providerLimits.maybeClearRecoveredQuotaState(connection, MIXED_QUOTAS);
+
+  assert.equal(result.testStatus, "active", "unparseable cooldown must not lock the connection");
+
+  const after = await providersDb.getProviderConnectionById(connectionId);
+  assert.equal(after.testStatus, "active");
+  assert.equal(after.rateLimitedUntil, undefined);
+});
+
+test("hasActiveCooldown fails open on unparseable and absent timestamps (#11277)", () => {
+  const now = Date.now();
+  assert.equal(providerLimits.hasActiveCooldown({ rateLimitedUntil: null } as never, now), false);
+  assert.equal(
+    providerLimits.hasActiveCooldown({ rateLimitedUntil: "garbage" } as never, now),
+    false,
+    "corrupt value must fail open"
+  );
+  assert.equal(
+    providerLimits.hasActiveCooldown(
+      { rateLimitedUntil: new Date(now + 60_000).toISOString() } as never,
+      now
+    ),
+    true
+  );
+  assert.equal(
+    providerLimits.hasActiveCooldown(
+      { rateLimitedUntil: new Date(now - 60_000).toISOString() } as never,
+      now
+    ),
+    false
+  );
+});


### PR DESCRIPTION
Fixes #11277

## Problem

`maybeClearRecoveredQuotaState()` gated every defensive guard behind `lastErrorType === "quota_exhausted"`. Any other `lastErrorType` fell straight through to `clearRecoveredProviderState` and wiped a still-active `rateLimitedUntil` without ever consulting it.

`lastErrorType` is not normalized across writers. The provider test route persists `diagnosis.type` (`upstream_rate_limited`, `network_error`, ...), which never equals `"quota_exhausted"`, while persisting a real `rateLimitedUntil`. Combined with `hasUsableQuota()` returning true on the first non-zero window — so a connection with a 5h window and a weekly window looks recovered while the weekly one is still at zero — a multi-day cooldown was cleared on every 5-10 minute sync, burning a real upstream call, taking the same 429, and cooling down again. That is the loop the reporter observed with a 146-hour cooldown.

## Fix

Adds an exported `hasActiveCooldown()` and hoists the quota-window guards out of the `lastErrorType` branch so they apply whenever a cooldown is still in force, regardless of which writer set it.

`hasActiveCooldown` deliberately fails **open** on an unparseable timestamp: a corrupt value must never be able to pin a connection offline forever.

The change is additive — the `quota_exhausted` refinements keep their exact previous behaviour for the case where the cooldown has already expired.

## Test

Added to the existing `tests/unit/provider-limits-recovery.test.ts`.

Verified failing on the base commit, 2 of 17:

```
✖ active cooldown survives a quota sync even when lastErrorType is not quota_exhausted (#11277)
✖ hasActiveCooldown fails open on unparseable and absent timestamps (#11277)
ℹ pass 15
ℹ fail 2
```

With the fix, 17/17 pass:

```
ℹ tests 17
ℹ pass 17
ℹ fail 0
```

Run with the repository's own unit runner (`node --test` via the `test:unit` script), not vitest — `tests/unit/*.test.ts` is covered by the former.

Branch is up to date with `release/v3.8.50`.
