### PR TITLE
fix(i18n): add the 3 missing pt-BR CLI keys that break locale parity

### DIFF
--- a/bin/cli/locales/pt-BR.json
+++ b/bin/cli/locales/pt-BR.json
@@ -26,7 +26,8 @@
     "testFailed": "Teste do provedor falhou: {error}",
     "loginEnabled": "Login: habilitado (senha atualizada)",
     "loginDisabled": "Login: desabilitado",
-    "providerInfo": "Provedor: {info}"
+    "providerInfo": "Provedor: {info}",
+    "opencode": "Instala e configura o plugin @omniroute/opencode-plugin incluído para o OpenCode"
   },
   "doctor": {
     "title": "OmniRoute Doctor",
@@ -254,7 +255,9 @@
     "no_recovery": "Desabilitar reinício automático em crash (modo debug)",
     "max_restarts": "Máximo de reinícios em 30s antes de desistir (padrão: 2)",
     "tray": "Mostrar ícone na bandeja do sistema (apenas desktop, opt-in)",
-    "no_tray": "Desabilitar ícone na bandeja do sistema"
+    "no_tray": "Desabilitar ícone na bandeja do sistema",
+    "tls_cert": "Caminho para um certificado TLS (PEM) para servir HTTPS (também OMNIROUTE_TLS_CERT)",
+    "tls_key": "Caminho para a chave privada TLS (PEM) para servir HTTPS (também OMNIROUTE_TLS_KEY)"
   },
   "backup": {
     "title": "Backup",


### PR DESCRIPTION
## What

`tests/unit/i18n-pt-br.test.ts` asserts key parity between `bin/cli/locales/en.json` and `pt-BR.json`. Three keys present in `en.json` are missing from `pt-BR.json`, so the test fails on `release/v3.8.50`:

```
pt-BR.json is missing 3 keys present in en.json. Sample: setup.opencode, serve.tls_cert, serve.tls_key
```

(en 823 keys, pt-BR 820.)

## Fix

Added the three, translated in the register of the surrounding `serve.*` and `setup.*` entries:

- `setup.opencode`
- `serve.tls_cert`
- `serve.tls_key`

Parity restored — `en` and `pt-BR` both 823 keys — and `i18n-pt-br` goes 3/3.

Nothing else touched.
