### PR TITLE
fix(security): refuse proxy-authorization and proxy-authenticate upstream

### DIFF
--- a/changelog.d/fixes/11328-upstream-headers-proxy-auth.md
+++ b/changelog.d/fixes/11328-upstream-headers-proxy-auth.md
@@ -1,0 +1,1 @@
+- **fix(security):** `proxy-authorization` and `proxy-authenticate` are refused as upstream/custom headers, so a proxy credential is no longer forwarded to the model provider — the canonical denylist now matches the RFC 7230 §6.1 set the rest of the codebase already strips ([#11328](https://github.com/diegosouzapw/OmniRoute/pull/11328))

--- a/src/shared/constants/upstreamHeaders.ts
+++ b/src/shared/constants/upstreamHeaders.ts
@@ -10,6 +10,16 @@ const FORBIDDEN = new Set(
     "content-length",
     "keep-alive",
     "proxy-connection",
+    // The two RFC 7230 §6.1 hop-by-hop names this list was missing. They belong
+    // to the connection between the client and OmniRoute (or its upstream
+    // proxy), never to the request OmniRoute makes to the model provider —
+    // forwarding `proxy-authorization` hands that proxy credential to the
+    // provider. `src/lib/services/reverseProxy.ts` (HOP_BY_HOP),
+    // `src/mitm/sanitizeHeaders.ts`, `src/mitm/inspector/httpProxyServer.ts`,
+    // `src/mitm/tproxy/tlsCapture.ts` and `src/app/api/openapi/try/route.ts`
+    // all already strip them; this list, the canonical one, did not.
+    "proxy-authenticate",
+    "proxy-authorization",
     "transfer-encoding",
     "te",
     "trailer",

--- a/tests/unit/upstream-headers-proxy-auth.test.ts
+++ b/tests/unit/upstream-headers-proxy-auth.test.ts
@@ -1,0 +1,66 @@
+// `FORBIDDEN` in src/shared/constants/upstreamHeaders.ts is documented as the
+// hop-by-hop / Host / framing denylist, and it was missing two of the RFC 7230
+// §6.1 names. Measured before the fix:
+//
+//   proxy-authorization   upstream=allow  custom=allow
+//   proxy-authenticate    upstream=allow  custom=allow
+//   proxy-connection      upstream=BLOCK  custom=BLOCK
+//
+// `proxy-authorization` is the one that costs something: it authenticates the
+// hop to the operator's own proxy, so forwarding it hands that credential to
+// the model provider. Five other modules in this repo already strip it
+// (reverseProxy HOP_BY_HOP, mitm/sanitizeHeaders, inspector/httpProxyServer,
+// tproxy/tlsCapture, openapi/try) — the canonical list did not.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isForbiddenUpstreamHeaderName,
+  isForbiddenCustomHeaderName,
+} from "../../src/shared/constants/upstreamHeaders.ts";
+import { HOP_BY_HOP } from "../../src/lib/services/reverseProxy.ts";
+import { sanitizeUpstreamHeadersMap } from "../../src/lib/db/models.ts";
+
+test("proxy-authorization and proxy-authenticate are refused", () => {
+  for (const name of ["proxy-authorization", "proxy-authenticate"]) {
+    assert.equal(isForbiddenUpstreamHeaderName(name), true, name);
+    assert.equal(isForbiddenCustomHeaderName(name), true, name);
+  }
+});
+
+test("the refusal is case-insensitive, like every other name in the list", () => {
+  for (const name of ["Proxy-Authorization", "PROXY-AUTHENTICATE", "  Proxy-Authorization  "]) {
+    assert.equal(isForbiddenUpstreamHeaderName(name), true, name);
+  }
+});
+
+test("sanitizeUpstreamHeadersMap drops them and keeps the rest", () => {
+  const out = sanitizeUpstreamHeadersMap({
+    "Proxy-Authorization": "Basic c2VjcmV0",
+    "Proxy-Authenticate": "Basic realm=x",
+    "X-Custom": "ok",
+  });
+
+  assert.deepEqual(out, { "X-Custom": "ok" });
+});
+
+test("the canonical list now covers every hop-by-hop name reverseProxy strips", () => {
+  // `reverseProxy.HOP_BY_HOP` is the repo's own RFC 7230 §6.1 list. The two
+  // lists drifting apart is what this fix repairs, so compare them directly —
+  // `trailers` is the TE token, spelled `trailer` as a header name.
+  const missing = [...HOP_BY_HOP]
+    .map((name) => (name === "trailers" ? "trailer" : name))
+    .filter((name) => !isForbiddenUpstreamHeaderName(name));
+
+  assert.deepEqual(missing, []);
+});
+
+test("ordinary headers are still allowed", () => {
+  for (const name of ["x-custom", "x-forwarded-for", "user-agent", "accept"]) {
+    assert.equal(isForbiddenUpstreamHeaderName(name), false, name);
+  }
+  // Auth headers stay allowed as *upstream* headers (the credential layer owns
+  // them) while remaining forbidden as operator-supplied custom headers.
+  assert.equal(isForbiddenUpstreamHeaderName("authorization"), false);
+  assert.equal(isForbiddenCustomHeaderName("authorization"), true);
+});


### PR DESCRIPTION
## The gap

`FORBIDDEN` in `src/shared/constants/upstreamHeaders.ts` is the canonical denylist — its own docstring calls it "names we never forward (Host / hop-by-hop / framing)". It was missing two of the RFC 7230 §6.1 hop-by-hop names. Measured on `release/v3.8.50`:

```
proxy-connection      upstream=BLOCK  custom=BLOCK
proxy-authorization   upstream=allow  custom=allow
proxy-authenticate    upstream=allow  custom=allow
```

`proxy-authorization` is the one that costs something: it authenticates the hop to the operator's **own** proxy. Forwarded to the model provider, it hands that credential to a third party — the same reason `authorization` is refused for operator-supplied custom headers.

## Why this reads as drift rather than a judgement call

Five other modules in this repo already strip both:

| module | list |
| --- | --- |
| `src/lib/services/reverseProxy.ts` | `HOP_BY_HOP` — the full RFC set, both names present |
| `src/mitm/sanitizeHeaders.ts` | secret-masking set |
| `src/mitm/inspector/httpProxyServer.ts` | explicit `lower === "proxy-authorization"` |
| `src/mitm/tproxy/tlsCapture.ts` | same |
| `src/app/api/openapi/try/route.ts` | request denylist |

And `mitm/sanitizeHeaders.ts` decides what to drop by **calling `isForbiddenUpstreamHeaderName()`**, so the gap propagated from the canonical list into the inspector's own stripping (the value was still masked there, so the leak was to the log shape, not the log content).

## The change

Two names added to `FORBIDDEN`. Nothing else moves: `isForbiddenCustomHeaderName()` already ORs this set with the auth set, and the Zod `upstreamHeaderNameSchema` + record refine already call it, so validation, sanitization and the executor pick it up from the one place AGENTS.md asks to keep in sync.

## Tests

`tests/unit/upstream-headers-proxy-auth.test.ts` — 5 tests: both names refused for upstream and custom headers, case/whitespace variants, `sanitizeUpstreamHeadersMap()` dropping them while keeping unrelated headers, and a check that ordinary headers are still allowed and `authorization` keeps its asymmetry (allowed upstream where the credential layer owns it, refused as an operator-supplied custom header).

The fourth test compares the two lists directly rather than restating a constant: every name in `reverseProxy.HOP_BY_HOP` must be refused by `isForbiddenUpstreamHeaderName()`. That is the invariant whose breach caused this, so it now fails if the two drift again.

Against `release/v3.8.50` with only `upstreamHeaders.ts` reverted: **4 failed, 1 passed** — the one that passes on both is the "ordinary headers still allowed" guard.

With the change: **18 passed** across this file plus `upstream-headers-sanitize` and `connection-level-upstream-headers`. `npm run typecheck:core` clean, `eslint` clean.

---

⚠️ base-red inherited: #9985 — `No new ESLint warnings` and `dast-smoke` fail on every open PR against this base, including your own.
