### PR TITLE
fix(dashboard): route the Adapta tutorial CTA through the branded shortener

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/AdaptaTutorialModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/AdaptaTutorialModal.tsx
@@ -7,6 +7,10 @@ type AdaptaTutorialModalProps = {
   onClose: () => void;
 };
 
+// The Adapta CTA href points at https://link.omniroute.online/adapta (our own
+// shortener, the `adapta` slug) so the click lands in our Kutt metrics. The visible
+// link text intentionally stays the real domain (agent.adapta.one/agentic-chat) so
+// users still see where they are going.
 export function AdaptaTutorialModal({ isOpen, onClose }: AdaptaTutorialModalProps) {
   const t = useTranslations("providers.adaptaTutorial");
 
@@ -29,7 +33,7 @@ export function AdaptaTutorialModal({ isOpen, onClose }: AdaptaTutorialModalProp
               <p className="text-text-muted mt-0.5">
                 {t("step1DescPrefix")}{" "}
                 <a
-                  href="https://agent.adapta.one/agentic-chat"
+                  href="https://link.omniroute.online/adapta"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline text-primary"


### PR DESCRIPTION
⚠️ base-red inherited: #9985

## What

The Adapta tutorial modal's CTA linked straight at `agent.adapta.one/agentic-chat`,
so those clicks never reached our metrics. This points the `href` at
`https://link.omniroute.online/adapta` — the `adapta` slug on our own shortener,
which redirects to the same destination.

The **visible link text stays the real domain** (`agent.adapta.one/agentic-chat`)
so users still see where they are going; only the `href` changed.

Completes the shortener rollout started in #11196 — that PR created the `adapta`
slug but did not wire this callsite.

## Scope

One line, one file. Provider `baseUrl` configs that also mention `agent.adapta.one`
(`webProvidersB.ts`, `web-cookie.ts`, `webSessionCredentials.ts`) are **API endpoints**
and are deliberately untouched.

## Verified

- TSX parses clean (esbuild)
- `eslint --max-warnings 0` on the changed file: clean
- `tests/unit/executor-adapta-web.test.ts`: 5/5 pass
- Slug verified live: `link.omniroute.online/adapta` → 302 → `agent.adapta.one/agentic-chat`