### PR TITLE
fix(cli): spawn npm with shell on win32 in update command (#11335)

### DIFF
--- a/bin/cli/commands/update.mjs
+++ b/bin/cli/commands/update.mjs
@@ -29,10 +29,14 @@ export async function getCurrentVersion() {
 // Without it `npm view` can return a stale cached version (e.g. report 3.8.30 as
 // "latest" after 3.8.31 was published), so the updater told users on an old build
 // they were already on the latest version (#4376). `execFn` is injectable for tests.
-export async function getLatestVersion(execFn = execFileAsync) {
+export async function getLatestVersion(execFn = execFileAsync, platform = process.platform) {
   try {
     const { stdout } = await execFn("npm", ["view", "omniroute", "version", "--prefer-online"], {
       timeout: 15000,
+      // On Windows npm is npm.cmd; Node ≥24 refuses to execFile a .cmd without
+      // a shell (nodejs/node#52554 — spawn EINVAL / ENOENT, see #5379), so enable
+      // the shell on win32 only. Mirror the CLI fix from #7913/#6263/#6304.
+      shell: platform === "win32",
     });
     return stdout.trim();
   } catch {
@@ -116,6 +120,8 @@ export async function runUpdateCommand(opts = {}) {
     try {
       const { stdout } = await execFileAsync("npm", ["view", "omniroute", "changelog"], {
         timeout: 10000,
+        // Same win32 shell requirement as getLatestVersion (nodejs/node#52554).
+        shell: process.platform === "win32",
       });
       if (stdout.trim()) {
         console.log(stdout.trim());

--- a/tests/unit/cli-update-npm-shell-win32-11335.test.ts
+++ b/tests/unit/cli-update-npm-shell-win32-11335.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const update = await import("../../bin/cli/commands/update.mjs");
+
+// #11335: `omniroute update` failed on Windows with "Could not check latest
+// version. Is npm available?" even though npm worked fine. getLatestVersion()
+// ran execFile("npm", ...) without a shell; on Node ≥24 spawning npm.cmd
+// without a shell throws EINVAL/ENOENT (nodejs/node#52554, see #5379). The
+// fix enables the shell on win32 only, mirroring the CLI fixes from
+// #7913/#6263/#6304.
+test("getLatestVersion enables the shell on win32 (#11335)", async () => {
+  let captured = null;
+  const fakeExec = async (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    captured = { cmd, args, opts };
+    return { stdout: "3.8.49\n" };
+  };
+  const latest = await update.getLatestVersion(fakeExec, "win32");
+  assert.equal(latest, "3.8.49");
+  assert.ok(captured, "exec must be invoked");
+  assert.equal(captured.cmd, "npm");
+  assert.ok(
+    captured.args.includes("--prefer-online"),
+    `expected --prefer-online in npm args, got: ${JSON.stringify(captured.args)}`
+  );
+  assert.equal(
+    captured.opts.shell,
+    true,
+    "win32 must enable the shell so npm.cmd resolves (no EINVAL/ENOENT)"
+  );
+  assert.equal(captured.opts.timeout, 15000);
+});
+
+test("getLatestVersion leaves the shell disabled off win32 (#11335)", async () => {
+  let captured = null;
+  const fakeExec = async (_cmd: string, _args: string[], opts: Record<string, unknown>) => {
+    captured = { opts };
+    return { stdout: "3.8.49\n" };
+  };
+  await update.getLatestVersion(fakeExec, "linux");
+  assert.ok(captured, "exec must be invoked");
+  assert.notEqual(captured.opts.shell, true, "non-win32 must not enable the shell");
+});
+
+test("#11335 both npm lookups in update.mjs wire the win32 shell", () => {
+  const src = fs.readFileSync(
+    new URL("../../bin/cli/commands/update.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.ok(
+    src.includes('shell: platform === "win32"'),
+    "getLatestVersion must enable the shell on win32"
+  );
+  assert.ok(
+    src.includes('shell: process.platform === "win32"'),
+    "changelog lookup must enable the shell on win32"
+  );
+});


### PR DESCRIPTION
## Summary

`omniroute update` fails on Windows with **"✖ Could not check latest version. Is npm available?"** even when npm is installed and working. Fixes #11335.

## Root cause

`bin/cli/commands/update.mjs` → `getLatestVersion()` runs:

```js
execFile("npm", ["view", "omniroute", "version", "--prefer-online"], { timeout: 15000 })
```

without a shell. On Windows npm is `npm.cmd`, and Node ≥24 refuses to `execFile` a `.cmd` without a shell (nodejs/node#52554 hardening, see #5379). Two failure modes observed on Windows 11 + Node v26.5.1:

| Call | Error |
|---|---|
| `execFile("npm", ...)` bare name | `ENOENT` (an extensionless `npm` shim from another Node install shadows the path) |
| `execFile("npm.cmd", ...)` | `EINVAL` (thrown synchronously) |

Both land in the `catch {}` and surface as the misleading "Is npm available?" message. The `--changelog` lookup in the same file has the identical pattern.

## Fix

Enable the shell on **win32 only** in both npm lookups, mirroring the established CLI fixes from #7913/#6263/#6304 (spawn `.cmd` shims with `shell: true` on win32). The version lookup's exec options are passed through a `platform` parameter (defaults to `process.platform`) so the behavior stays unit-testable; args are static (no user input), so there is no shell-injection surface (Hard Rule #13).

## Tests

Added `tests/unit/cli-update-npm-shell-win32-11335.test.ts` following the style of `cli-update-prefer-online-4376.test.ts`:

- win32 → `opts.shell === true` (+ `--prefer-online` still passed, timeout preserved)
- non-win32 → shell not enabled
- source-level assertion that both npm lookups in `update.mjs` wire the win32 shell

Local verification (Node v26.5.1, Windows 11):

```
$ node --test <harness>     # 4/4 pass against bin/cli/commands/update.mjs
$ omniroute update          # (patched installed copy) → "You are running the latest version!"
```

## References

- Fixes #11335
- Same root cause previously fixed in other code paths: #5379 (embedded services), #5542 (in-app auto-update), #7913/#6263/#6304 (CLI spawns)
- nodejs/node#52554
