### PR TITLE
fix(release): count sweep-stale matches by their real category in the summary

### DIFF
--- a/scripts/release/sweep-stale-fragments.mjs
+++ b/scripts/release/sweep-stale-fragments.mjs
@@ -111,6 +111,18 @@ export function classifyFragments({ fragments = [], changelog = "" }) {
   return { stale, keep };
 }
 
+/**
+ * Count a stale list by how each entry was matched, for the human report line.
+ * classifyFragments only ever sets matchedBy to "pr-number" (the filename convention) or
+ * "text" (the normalized-bullet fallback); the summary must bucket under those exact values.
+ * Pure - the two counts always add up to stale.length and never mislabel a category.
+ */
+export function summarizeStale(stale) {
+  const byPrNumber = (stale || []).filter((s) => s.matchedBy === "pr-number").length;
+  const byText = (stale || []).filter((s) => s.matchedBy === "text").length;
+  return { byPrNumber, byText };
+}
+
 export function readFragments(root) {
   const out = [];
   for (const sub of FRAGMENT_DIRS) {
@@ -141,9 +153,8 @@ function main(argv) {
     return 0;
   }
 
-  const byRef = stale.filter((s) => s.matchedBy === "ref").length;
-  const byText = stale.length - byRef;
-  process.stdout.write(`  matched by ref: ${byRef} · by text: ${byText}\n`);
+  const { byPrNumber, byText } = summarizeStale(stale);
+  process.stdout.write(`  matched by pr-number: ${byPrNumber} · by text: ${byText}\n`);
   for (const s of stale) process.stdout.write(`  ${apply ? "removed" : "stale"}: ${s.rel} — ${s.reason}\n`);
 
   if (!apply) {

--- a/tests/unit/sweep-stale-fragments.test.ts
+++ b/tests/unit/sweep-stale-fragments.test.ts
@@ -19,6 +19,7 @@ import {
   classifyFragments,
   normalizeBullet,
   refsIn,
+  summarizeStale,
 } from "../../scripts/release/sweep-stale-fragments.mjs";
 
 const CHANGELOG = `# Changelog
@@ -150,4 +151,25 @@ test("refsIn finds every number and nothing else", () => {
   assert.deepEqual(refsIn("closes #12, refs #345 and v3.8.49"), [12, 345]);
   assert.deepEqual(refsIn(""), []);
   assert.deepEqual(refsIn(undefined), []);
+});
+
+// The report line "matched by … : N · by text: M" must count every stale entry under the
+// category it was actually matched by. The summary used to compare against a `matchedBy`
+// value ("ref") that classifyFragments never emits — it emits "pr-number" — so the
+// pr-number bucket was permanently 0 and every filename-matched fragment was mis-tallied
+// as a text match. summarizeStale is the pure counter the report line uses.
+test("summarizeStale tallies pr-number and text matches under their real categories", () => {
+  const stale = [
+    { matchedBy: "pr-number" },
+    { matchedBy: "pr-number" },
+    { matchedBy: "text" },
+  ];
+  assert.deepEqual(summarizeStale(stale), { byPrNumber: 2, byText: 1 });
+});
+
+test("summarizeStale never leaks a category into the wrong bucket", () => {
+  const stale = [{ matchedBy: "pr-number" }, { matchedBy: "pr-number" }];
+  const { byPrNumber, byText } = summarizeStale(stale);
+  assert.equal(byPrNumber, 2, "both filename matches count as pr-number");
+  assert.equal(byText, 0, "no filename match may be reported as a text match");
 });


### PR DESCRIPTION
`scripts/release/sweep-stale-fragments.mjs` printed `matched by ref: N · by text: M`, computing `byRef` from `matchedBy === "ref"`. But `classifyFragments` only ever sets `matchedBy` to `"pr-number"` (the `<PR>-<slug>.md` filename convention) or `"text"` (the normalized-bullet fallback) — `"ref"` is a value it never produces. So the pr-number bucket was permanently 0 and every filename-matched stale fragment was mis-tallied as a text match in the release captain's report.

Fix: extract a pure `summarizeStale(stale)` (matching this file's established pure/unit-tested pattern) that buckets under the categories `classifyFragments` actually emits, and relabel the line to `matched by pr-number`.

**Evidence** (`node --test tests/unit/sweep-stale-fragments.test.ts`):
- Before: `does not provide an export named summarizeStale` → pass 0 / fail 1
- After: tests 13 / pass 13 / fail 0

Same class as #11321 (release-script miscount), different file.