### PR TITLE
fix(i18n): complete zh-CN/zh-TW CLI locales and guard their parity

### DIFF
--- a/bin/cli/locales/zh-CN.json
+++ b/bin/cli/locales/zh-CN.json
@@ -38,7 +38,8 @@
     "testFailed": "提供者测试失败：{error}",
     "loginEnabled": "登录：已启用（密码已更新）",
     "loginDisabled": "登录：已禁用",
-    "providerInfo": "提供者：{info}"
+    "providerInfo": "提供者：{info}",
+    "opencode": "安装并配置随附的 @omniroute/opencode-plugin 以用于 OpenCode"
   },
   "doctor": {
     "title": "OmniRoute 诊断",
@@ -252,7 +253,9 @@
     "no_recovery": "禁用崩溃自动重启（调试模式）",
     "max_restarts": "30 秒内的最大崩溃重启次数（默认：2）",
     "tray": "显示系统托盘图标（仅桌面，选择加入）",
-    "no_tray": "禁用系统托盘图标"
+    "no_tray": "禁用系统托盘图标",
+    "tls_cert": "用于提供 HTTPS 服务的 TLS 证书（PEM）路径（也可用 OMNIROUTE_TLS_CERT）",
+    "tls_key": "用于提供 HTTPS 服务的 TLS 私钥（PEM）路径（也可用 OMNIROUTE_TLS_KEY）"
   },
   "backup": {
     "title": "备份",
@@ -1258,5 +1261,69 @@
     "search": "搜索 npm 注册表中的可用插件",
     "update": "更新已安装的插件",
     "scaffold": "搭建新的插件模板"
+  },
+  "authExport": {
+    "description": "导出已解密的提供者凭据（仅限本地，明文输出）",
+    "idOpt": "仅导出与此 id/名称/提供者匹配的连接",
+    "formatOpt": "输出格式：json 或 env",
+    "outOpt": "将输出写入文件而非标准输出（以 0600 权限写入）",
+    "forceOpt": "确认你了解此操作会打印/写入明文密钥",
+    "warning": "⚠ 此操作会打印/写入已解密的明文 API 密钥和 OAuth 令牌。请确保你的屏幕、shell 历史记录以及任何输出文件保持私密。",
+    "confirmHeading": "⚠ 警告：此操作会以明文导出已解密的提供者凭据",
+    "confirmBody": "此命令会为所选连接解密并打印/写入 apiKey、accessToken、refreshToken 和\nidToken。请将输出视为机密。",
+    "confirmFooter": "如需确认，请运行：\n  omniroute auth export --force",
+    "missingKey": "导出凭据需要 STORAGE_ENCRYPTION_KEY。",
+    "notFound": "未找到连接：{id}",
+    "invalidFormat": "无效格式：{format}。请使用 json 或 env。"
+  },
+  "radar": {
+    "description": "检查并同步本地 Radar 目录订阅源",
+    "status": "显示本地 Radar 设置和订阅源缓存状态",
+    "sync": "通过本地服务器同步目录、推荐、优惠和 Intel"
+  },
+  "launch": {
+    "description": "启动指向 OmniRoute 的 Claude Code（本地或远程，使用 --profile）",
+    "token": "Claude 客户端应发送的令牌（ANTHROPIC_AUTH_TOKEN）",
+    "notRunning": "无法在 {port} 访问 OmniRoute。请使用 “omniroute serve” 启动它。",
+    "notFound": "在 PATH 中未找到 “claude” CLI。"
+  },
+  "run": {
+    "description": "通过 OmniRoute 启动受支持的 CLI 目标"
+  },
+  "setupClaude": {
+    "description": "从 OmniRoute 模型目录生成 ~/.claude/profiles 的 Claude Code 配置文件"
+  },
+  "connect": {
+    "description": "连接到远程 OmniRoute 服务器并进入远程模式"
+  },
+  "tokens": {
+    "description": "管理限定范围的 CLI 访问令牌（远程模式）"
+  },
+  "configure": {
+    "description": "从活动服务器选择提供者+模型并配置受支持的本地 CLI"
+  },
+  "launchCodex": {
+    "description": "启动指向 OmniRoute 的 Codex CLI（本地或远程 VPS）"
+  },
+  "setupCodex": {
+    "description": "从 OmniRoute 实时模型目录生成 ~/.codex 配置文件"
+  },
+  "packs": {
+    "description": "管理可选的运行时包（ML / 浏览器自动化）",
+    "listDescription": "列出可选包及其安装状态",
+    "installDescription": "将可选包安装到 DATA_DIR",
+    "verifyDescription": "根据随附的校验和索引验证已安装的包",
+    "removeDescription": "移除已安装的可选包",
+    "sourceOpt": "存放包负载和包索引的目录",
+    "warnNoIndex": "未找到 optional-packs.index.json —— 此检出无法进行安装/验证（桌面捆绑包会附带它）",
+    "errUnknown": "未知的包：{name}",
+    "errNoIndex": "未找到包索引；请通过 --source <dir> 传入存放包负载的目录（桌面捆绑包会将其附带在应用旁）",
+    "installed": "包 “{name}” 已安装并在 {dir} 验证通过",
+    "restartHint": "请重启 OmniRoute 服务器（或桌面应用），以便运行时加载该包",
+    "removed": "包 “{name}” 已移除",
+    "notInstalled": "包 “{name}” 未安装",
+    "verifyOk": "所有已安装的包均已验证通过",
+    "verifyFailed": "{count} 个包验证失败",
+    "noneInstalled": "未安装可选包"
   }
 }

--- a/bin/cli/locales/zh-TW.json
+++ b/bin/cli/locales/zh-TW.json
@@ -38,7 +38,8 @@
     "testFailed": "提供者測試失敗：{error}",
     "loginEnabled": "登入：已啟用（密碼已更新）",
     "loginDisabled": "登入：已停用",
-    "providerInfo": "提供者：{info}"
+    "providerInfo": "提供者：{info}",
+    "opencode": "安裝並配置隨附的 @omniroute/opencode-plugin 以用於 OpenCode"
   },
   "doctor": {
     "title": "OmniRoute 診斷",
@@ -252,7 +253,9 @@
     "no_recovery": "停用崩潰自動重啟（除錯模式）",
     "max_restarts": "30 秒內的最大崩潰重啟次數（預設：2）",
     "tray": "顯示系統托盤圖示（僅桌面，選擇加入）",
-    "no_tray": "停用系統托盤圖示"
+    "no_tray": "停用系統托盤圖示",
+    "tls_cert": "用於提供 HTTPS 服務的 TLS 憑證（PEM）路徑（也可用 OMNIROUTE_TLS_CERT）",
+    "tls_key": "用於提供 HTTPS 服務的 TLS 私鑰（PEM）路徑（也可用 OMNIROUTE_TLS_KEY）"
   },
   "backup": {
     "title": "備份",
@@ -1258,5 +1261,69 @@
     "search": "搜尋 npm 登錄檔中的可用外掛",
     "update": "更新已安裝的外掛",
     "scaffold": "搭建新的外掛模板"
+  },
+  "authExport": {
+    "description": "匯出已解密的提供者憑據（僅限本機，明文輸出）",
+    "idOpt": "僅匯出與此 id/名稱/提供者相符的連線",
+    "formatOpt": "輸出格式：json 或 env",
+    "outOpt": "將輸出寫入檔案而非標準輸出（以 0600 權限寫入）",
+    "forceOpt": "確認你了解此操作會列印/寫入明文密鑰",
+    "warning": "⚠ 此操作會列印/寫入已解密的明文 API 金鑰和 OAuth 令牌。請確保你的螢幕、shell 歷史記錄以及任何輸出檔案保持私密。",
+    "confirmHeading": "⚠ 警告：此操作會以明文匯出已解密的提供者憑據",
+    "confirmBody": "此命令會為所選連線解密並列印/寫入 apiKey、accessToken、refreshToken 和\nidToken。請將輸出視為機密。",
+    "confirmFooter": "如需確認，請執行：\n  omniroute auth export --force",
+    "missingKey": "匯出憑據需要 STORAGE_ENCRYPTION_KEY。",
+    "notFound": "找不到連線：{id}",
+    "invalidFormat": "無效格式：{format}。請使用 json 或 env。"
+  },
+  "radar": {
+    "description": "檢查並同步本機 Radar 目錄訂閱來源",
+    "status": "顯示本機 Radar 設定和訂閱來源快取狀態",
+    "sync": "透過本機伺服器同步目錄、推薦、優惠和 Intel"
+  },
+  "launch": {
+    "description": "啟動指向 OmniRoute 的 Claude Code（本機或遠端，使用 --profile）",
+    "token": "Claude 用戶端應傳送的令牌（ANTHROPIC_AUTH_TOKEN）",
+    "notRunning": "無法在 {port} 存取 OmniRoute。請使用「omniroute serve」啟動它。",
+    "notFound": "在 PATH 中找不到「claude」CLI。"
+  },
+  "run": {
+    "description": "透過 OmniRoute 啟動受支援的 CLI 目標"
+  },
+  "setupClaude": {
+    "description": "從 OmniRoute 模型目錄產生 ~/.claude/profiles 的 Claude Code 配置檔"
+  },
+  "connect": {
+    "description": "連線到遠端 OmniRoute 伺服器並進入遠端模式"
+  },
+  "tokens": {
+    "description": "管理限定範圍的 CLI 存取令牌（遠端模式）"
+  },
+  "configure": {
+    "description": "從使用中的伺服器選擇提供者+模型並配置受支援的本機 CLI"
+  },
+  "launchCodex": {
+    "description": "啟動指向 OmniRoute 的 Codex CLI（本機或遠端 VPS）"
+  },
+  "setupCodex": {
+    "description": "從 OmniRoute 即時模型目錄產生 ~/.codex 配置檔"
+  },
+  "packs": {
+    "description": "管理可選的執行階段套件（ML / 瀏覽器自動化）",
+    "listDescription": "列出可選套件及其安裝狀態",
+    "installDescription": "將可選套件安裝到 DATA_DIR",
+    "verifyDescription": "根據隨附的總和檢查碼索引驗證已安裝的套件",
+    "removeDescription": "移除已安裝的可選套件",
+    "sourceOpt": "存放套件負載和套件索引的目錄",
+    "warnNoIndex": "找不到 optional-packs.index.json —— 此檢出無法進行安裝/驗證（桌面套件會隨附它）",
+    "errUnknown": "未知的套件：{name}",
+    "errNoIndex": "找不到套件索引；請透過 --source <dir> 傳入存放套件負載的目錄（桌面套件會將其隨附在應用程式旁）",
+    "installed": "套件「{name}」已安裝並在 {dir} 驗證通過",
+    "restartHint": "請重新啟動 OmniRoute 伺服器（或桌面應用程式），以便執行階段載入該套件",
+    "removed": "套件「{name}」已移除",
+    "notInstalled": "套件「{name}」未安裝",
+    "verifyOk": "所有已安裝的套件均已驗證通過",
+    "verifyFailed": "{count} 個套件驗證失敗",
+    "noneInstalled": "未安裝可選套件"
   }
 }

--- a/scripts/check/check-cli-i18n.mjs
+++ b/scripts/check/check-cli-i18n.mjs
@@ -69,6 +69,7 @@ const files = walk(COMMANDS_DIR);
 const usedKeys = collectTKeys(files);
 const en = loadJson(join(LOCALES_DIR, "en.json"));
 const ptBR = loadJson(join(LOCALES_DIR, "pt-BR.json"));
+const zhLocales = ["zh-CN", "zh-TW"].map((n) => [n, loadJson(join(LOCALES_DIR, `${n}.json`))]);
 const enKeys = flattenKeys(en);
 
 let errors = 0;
@@ -93,6 +94,19 @@ if (missingTopLevel.length > 0) {
   errors += missingTopLevel.length;
 } else {
   console.log(`[cli-i18n] ✓ pt-BR.json has all ${enTopLevel.length} top-level sections`);
+}
+
+// Check 3: zh-CN and zh-TW have full key parity with en.json
+for (const [name, cat] of zhLocales) {
+  const catKeys = flattenKeys(cat);
+  const missingKeys = [...enKeys].filter((k) => !catKeys.has(k));
+  if (missingKeys.length > 0) {
+    console.error(`[cli-i18n] Keys in en.json missing from ${name}.json:`);
+    for (const k of missingKeys) console.error(`  ✗ ${k}`);
+    errors += missingKeys.length;
+  } else {
+    console.log(`[cli-i18n] ✓ ${name}.json has full parity (${enKeys.size} keys)`);
+  }
 }
 
 if (errors > 0) {

--- a/tests/unit/cli-i18n-catalog.test.ts
+++ b/tests/unit/cli-i18n-catalog.test.ts
@@ -10,6 +10,8 @@ const ROOT = join(__dirname, "..", "..");
 const require = createRequire(import.meta.url);
 const en = require("../../bin/cli/locales/en.json");
 const ptBR = require("../../bin/cli/locales/pt-BR.json");
+const zhCN = require("../../bin/cli/locales/zh-CN.json");
+const zhTW = require("../../bin/cli/locales/zh-TW.json");
 
 function flattenKeys(obj: Record<string, unknown>, prefix = ""): Set<string> {
   const keys = new Set<string>();
@@ -71,6 +73,14 @@ test("pt-BR.json tem todas as seções top-level de en.json", () => {
   const missing = enTop.filter((k) => !ptTop.has(k));
   assert.deepEqual(missing, [], `Seções top-level faltando em pt-BR.json: ${missing.join(", ")}`);
 });
+
+for (const [name, cat] of [["zh-CN", zhCN], ["zh-TW", zhTW]] as const) {
+  test(name + ".json tem paridade total de chaves com en.json", () => {
+    const catKeys = flattenKeys(cat as Record<string, unknown>);
+    const missing = [...enKeys].filter((k) => !catKeys.has(k));
+    assert.deepEqual(missing, [], name + ".json chaves faltando: " + missing.join(", "));
+  });
+}
 
 test("i18n.mjs detecta locale por OMNIROUTE_LANG", async () => {
   const { resetForTests, detectLocale } = await import("../../bin/cli/i18n.mjs");


### PR DESCRIPTION
The zh-CN and zh-TW CLI catalogs were each missing the same 45 keys present in `en.json`: `setup.opencode`, the full `authExport.*` credential-export command, `serve.tls_cert`/`serve.tls_key`, `radar.*`, `launch.*`, the `.description` for `run`/`setupClaude`/`connect`/`tokens`/`configure`/`launchCodex`/`setupCodex`, and the complete `packs.*` runtime-pack command.

All 45 are translated into Simplified (zh-CN) and Traditional (zh-TW) Chinese, reusing the terminology already established in each catalog (provider, model, server, API key, credentials, profile) and preserving every `{placeholder}`.

The CLI i18n guard previously only checked pt-BR top-level sections. It now demands **full key parity with `en`** for zh-CN and zh-TW in both the `node:test` catalog test and `scripts/check/check-cli-i18n.mjs`, so the same gap cannot silently reappear.

RED (guard extended, keys absent): `pass 7 / fail 2`. GREEN (keys added): `pass 9 / fail 0`. Same class as the merged pt-BR completion #11322.