### PR TITLE
feat(providers): publish web-session credential contract

### DIFF
--- a/changelog.d/features/11340-web-session-contract.md
+++ b/changelog.d/features/11340-web-session-contract.md
@@ -1,0 +1,1 @@
+- **feat(providers):** publish a management-authenticated versioned web-session credential contract from OmniRoute's canonical browser credential metadata ([#11340](https://github.com/diegosouzapw/OmniRoute/pull/11340)) — thanks @Zartharas

--- a/src/app/api/providers/web-session-contract/route.ts
+++ b/src/app/api/providers/web-session-contract/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import { buildWebSessionContract } from "@/lib/providers/webSessionContract";
+
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  return NextResponse.json(buildWebSessionContract());
+}

--- a/src/lib/providers/webSessionContract.ts
+++ b/src/lib/providers/webSessionContract.ts
@@ -1,8 +1,8 @@
 import {
   listExtractionConfigs,
   type TokenSource,
-} from "../../../open-sse/services/tokenExtractionConfig.ts";
-import { getWebSessionCredentialRequirement } from "../../shared/providers/webSessionCredentials.ts";
+} from "@omniroute/open-sse/services/tokenExtractionConfig.ts";
+import { getWebSessionCredentialRequirement } from "@/shared/providers/webSessionCredentials";
 
 export const WEB_SESSION_CONTRACT_VERSION = 1;
 

--- a/src/lib/providers/webSessionContract.ts
+++ b/src/lib/providers/webSessionContract.ts
@@ -1,0 +1,58 @@
+import {
+  listExtractionConfigs,
+  type TokenSource,
+} from "../../../open-sse/services/tokenExtractionConfig.ts";
+import { getWebSessionCredentialRequirement } from "../../shared/providers/webSessionCredentials.ts";
+
+export const WEB_SESSION_CONTRACT_VERSION = 1;
+
+export interface WebSessionContractProvider {
+  providerId: string;
+  displayName: string;
+  loginUrl: string;
+  homeUrl: string;
+  tokenSources: TokenSource[];
+  credential: {
+    kind: "cookie" | "token";
+    storageKeys: string[];
+    acceptsFullCookieHeader: boolean;
+  };
+}
+
+export interface WebSessionContract {
+  version: typeof WEB_SESSION_CONTRACT_VERSION;
+  providers: WebSessionContractProvider[];
+}
+
+/**
+ * Publish only the canonical, non-secret metadata needed by external
+ * credential brokers to capture credentials in the same shape OmniRoute
+ * accepts. Provider instructions, polling state, and credential values are
+ * intentionally excluded.
+ */
+export function buildWebSessionContract(): WebSessionContract {
+  const providers = listExtractionConfigs().flatMap<WebSessionContractProvider>((config) => {
+    const requirement = getWebSessionCredentialRequirement(config.providerId);
+    if (!requirement || requirement.kind === "none") return [];
+
+    return [
+      {
+        providerId: config.providerId,
+        displayName: config.displayName,
+        loginUrl: config.loginUrl,
+        homeUrl: config.homeUrl,
+        tokenSources: config.tokenSources.map((source) => ({ ...source })),
+        credential: {
+          kind: requirement.kind,
+          storageKeys: [...requirement.storageKeys],
+          acceptsFullCookieHeader: requirement.acceptsFullCookieHeader,
+        },
+      },
+    ];
+  });
+
+  return {
+    version: WEB_SESSION_CONTRACT_VERSION,
+    providers,
+  };
+}

--- a/tests/unit/web-session-contract.test.ts
+++ b/tests/unit/web-session-contract.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { listExtractionConfigs } from "../../open-sse/services/tokenExtractionConfig.ts";
+import {
+  buildWebSessionContract,
+  WEB_SESSION_CONTRACT_VERSION,
+} from "../../src/lib/providers/webSessionContract.ts";
+import { getWebSessionCredentialRequirement } from "../../src/shared/providers/webSessionCredentials.ts";
+
+test("web-session contract mirrors canonical extraction and credential metadata", () => {
+  const contract = buildWebSessionContract();
+  assert.equal(contract.version, WEB_SESSION_CONTRACT_VERSION);
+
+  const expected = listExtractionConfigs().flatMap((config) => {
+    const requirement = getWebSessionCredentialRequirement(config.providerId);
+    return requirement && requirement.kind !== "none" ? [{ config, requirement }] : [];
+  });
+
+  assert.equal(contract.providers.length, expected.length);
+  assert.equal(new Set(contract.providers.map((provider) => provider.providerId)).size, expected.length);
+
+  for (const { config, requirement } of expected) {
+    const published = contract.providers.find((provider) => provider.providerId === config.providerId);
+    assert.ok(published, `${config.providerId} must be published`);
+    assert.equal(published.displayName, config.displayName);
+    assert.equal(published.loginUrl, config.loginUrl);
+    assert.equal(published.homeUrl, config.homeUrl);
+    assert.deepEqual(published.tokenSources, config.tokenSources);
+    assert.equal(published.credential.kind, requirement.kind);
+    assert.deepEqual(published.credential.storageKeys, [...requirement.storageKeys]);
+    assert.equal(
+      published.credential.acceptsFullCookieHeader,
+      requirement.acceptsFullCookieHeader
+    );
+  }
+});
+
+test("web-session contract preserves representative token and cookie semantics", () => {
+  const providers = new Map(
+    buildWebSessionContract().providers.map((provider) => [provider.providerId, provider])
+  );
+
+  assert.equal(providers.get("deepseek-web")?.credential.kind, "token");
+  assert.equal(providers.get("zai-web")?.credential.kind, "token");
+  assert.equal(providers.get("gemini-web")?.credential.kind, "cookie");
+  assert.equal(providers.get("qwen-web")?.credential.kind, "cookie");
+
+  assert.ok(
+    providers
+      .get("deepseek-web")
+      ?.tokenSources.some((source) => source.type === "localStorage" && source.key === "userToken")
+  );
+  assert.ok(
+    providers
+      .get("gemini-web")
+      ?.tokenSources.some(
+        (source) =>
+          source.type === "cookie" && source.name === "__Secure-1PSID" && source.domain === ".google.com"
+      )
+  );
+});
+
+test("web-session contract excludes credential values and operator-only guidance", () => {
+  const serialized = JSON.stringify(buildWebSessionContract());
+
+  for (const forbidden of [
+    "placeholder",
+    "instructions",
+    "pollingConfig",
+    "credentialName",
+    "guideSteps",
+    "guideNote",
+  ]) {
+    assert.equal(serialized.includes(`\"${forbidden}\"`), false, `${forbidden} must not be published`);
+  }
+});
+
+test("web-session contract route remains management-authenticated", () => {
+  const source = readFileSync(
+    new URL("../../src/app/api/providers/web-session-contract/route.ts", import.meta.url),
+    "utf8"
+  );
+
+  const authCall = source.indexOf("requireManagementAuth(request)");
+  const responseCall = source.indexOf("NextResponse.json(buildWebSessionContract())");
+
+  assert.ok(authCall >= 0, "route must require management authentication");
+  assert.ok(responseCall > authCall, "authentication must run before contract publication");
+});

--- a/tests/unit/web-session-contract.test.ts
+++ b/tests/unit/web-session-contract.test.ts
@@ -19,10 +19,15 @@ test("web-session contract mirrors canonical extraction and credential metadata"
   });
 
   assert.equal(contract.providers.length, expected.length);
-  assert.equal(new Set(contract.providers.map((provider) => provider.providerId)).size, expected.length);
+  assert.equal(
+    new Set(contract.providers.map((provider) => provider.providerId)).size,
+    expected.length
+  );
 
   for (const { config, requirement } of expected) {
-    const published = contract.providers.find((provider) => provider.providerId === config.providerId);
+    const published = contract.providers.find(
+      (provider) => provider.providerId === config.providerId
+    );
     assert.ok(published, `${config.providerId} must be published`);
     assert.equal(published.displayName, config.displayName);
     assert.equal(published.loginUrl, config.loginUrl);
@@ -30,10 +35,7 @@ test("web-session contract mirrors canonical extraction and credential metadata"
     assert.deepEqual(published.tokenSources, config.tokenSources);
     assert.equal(published.credential.kind, requirement.kind);
     assert.deepEqual(published.credential.storageKeys, [...requirement.storageKeys]);
-    assert.equal(
-      published.credential.acceptsFullCookieHeader,
-      requirement.acceptsFullCookieHeader
-    );
+    assert.equal(published.credential.acceptsFullCookieHeader, requirement.acceptsFullCookieHeader);
   }
 });
 
@@ -57,7 +59,9 @@ test("web-session contract preserves representative token and cookie semantics",
       .get("gemini-web")
       ?.tokenSources.some(
         (source) =>
-          source.type === "cookie" && source.name === "__Secure-1PSID" && source.domain === ".google.com"
+          source.type === "cookie" &&
+          source.name === "__Secure-1PSID" &&
+          source.domain === ".google.com"
       )
   );
 });
@@ -73,7 +77,11 @@ test("web-session contract excludes credential values and operator-only guidance
     "guideSteps",
     "guideNote",
   ]) {
-    assert.equal(serialized.includes(`\"${forbidden}\"`), false, `${forbidden} must not be published`);
+    assert.equal(
+      serialized.includes(`\"${forbidden}\"`),
+      false,
+      `${forbidden} must not be published`
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

Publish a management-authenticated, versioned web-session credential contract at `/api/providers/web-session-contract`.

The contract is derived from OmniRoute's canonical browser-session metadata:

- `listExtractionConfigs()`
- `getWebSessionCredentialRequirement()`

Only non-secret metadata is returned. Credential values, placeholders, instructions, polling configuration, and operator-only guidance are excluded.

## Why

External credential brokers otherwise need to duplicate OmniRoute's browser-session credential schema and can drift as provider requirements change.

This is the narrow upstream-suitable contract-publication portion remaining after aggregate Auth Keeper integration work was separated into independent upstream fixes.

## Scope

- `src/lib/providers/webSessionContract.ts`
- `src/app/api/providers/web-session-contract/route.ts`
- `tests/unit/web-session-contract.test.ts`

No executor, routing, inference, scheduler, recovery, database, provider-asset, dashboard, CLI, or credential-value behavior changes.

## Validation

Against active `release/v3.8.51` base `3192eb88d5550de4c3fd9985564f6b5641e9d681`:

- contract/canonical regression: **22/22 PASS**
- post-format contract regression: **4/4 PASS**
- formatter-only correction: **byte-for-byte Prettier proof PASS**
- provider consistency: **PASS**
- translate-path golden regression: **PASS**
- Prettier contract surface: **PASS**
- scoped ESLint on all changed TS files: **PASS**
- core typecheck: **PASS**
- explicit-any budget: **PASS**
- tracked-artifact policy: **PASS**
- diff whitespace validation: **PASS**
- release reconciliation: **PASS**

### Existing base-red full-repository lint

The active release base currently reports the known 22-error lint set across:

- FirstRunReadinessCard.tsx
- EndpointPageClient.tsx
- CommandPalette.tsx
- cli-mcp-call-commands.test.ts
- cli-resilience-commands.test.ts
- cli-skills-commands.test.ts

plus the existing stale-directive warning in EditConnectionModal.tsx.

All seven source blobs and the lint configuration are identical between the active release base and this PR head. This patch changes none of those files.

The exact 22-error set is the same release baseline tracked and fixed independently by merged upstream PR #11317.

### Existing base-red provider asset gate

`npm run check:provider-assets` reports:

```
freebuff.png: 512x512 exceeds 256px max dimension
```

This is also inherited from the release base:

- pristine base reproduces exactly this single asset failure;
- base and PR head contain the same `freebuff.png` blob;
- base and PR head contain the same asset-checker blob;
- this PR changes no provider asset.

Broad PR CI remains authoritative for the repository-wide matrix.
