### PR TITLE
test(db): make exclusive-connection-lease uniqueness test self-contained

### DIFF
--- a/tests/unit/exclusive-connection-leases.test.ts
+++ b/tests/unit/exclusive-connection-leases.test.ts
@@ -61,6 +61,19 @@ test("uses the live next-free migration slot without runner compatibility specia
 });
 
 test("enforces global active owner and connection uniqueness", () => {
+  // Establish the OWNER_A/conn-a lease this test reuses, rather than depending
+  // on a lease left behind by an earlier test in the file. The DB instance is
+  // shared across tests (reset only in test.after), so relying on prior state
+  // makes this test order-dependent: run in isolation the re-acquire below
+  // returns ACQUIRED instead of REUSED.
+  leases.acquireExclusiveConnectionLease({
+    leaseOwnerId: OWNER_A,
+    apiKeyId: "key-a",
+    provider: "codex",
+    connectionId: "conn-a",
+    now: at(0),
+  });
+
   const ownerA = leases.acquireExclusiveConnectionLease({
     leaseOwnerId: OWNER_A,
     apiKeyId: "key-a",


### PR DESCRIPTION
The `"enforces global active owner and connection uniqueness"` test asserted that re-acquiring `OWNER_A` on `conn-a` returns `REUSED`, but that lease was only created by the earlier `"hashes canonical owners"` test. The DB instance is shared across the file (reset only in `test.after`), so the assertion silently depended on test execution order — run in isolation the re-acquire returns `ACQUIRED` and the test fails.

Fix establishes the lease inside the test itself. No production code change.

RED (isolated, `--test-name-pattern`): `fail 1` (`ACQUIRED` != `REUSED`). GREEN: isolated pass, full file 11/11. Same class as #11327 (test isolation), different file.