### PR TITLE
fix(deps): keep unused pnpm peers out of production

### DIFF
--- a/changelog.d/maintenance/11342-pnpm-optional-peers-license-policy.md
+++ b/changelog.d/maintenance/11342-pnpm-optional-peers-license-policy.md
@@ -1,3 +1,3 @@
 - **fix(deps):** prevent pnpm from auto-installing the unused `@lobehub/ui` peer subtree of
   `@lobehub/icons`, keeping six unneeded packages with incompatible or unverifiable license
-  metadata out of production installs.
+  metadata out of production installs ([#11342](https://github.com/diegosouzapw/OmniRoute/pull/11342)).

--- a/changelog.d/maintenance/pending-pnpm-optional-peers-license-policy.md
+++ b/changelog.d/maintenance/pending-pnpm-optional-peers-license-policy.md
@@ -1,0 +1,3 @@
+- **fix(deps):** prevent pnpm from auto-installing the unused `@lobehub/ui` peer subtree of
+  `@lobehub/icons`, keeping six unneeded packages with incompatible or unverifiable license
+  metadata out of production installs.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - "packages/*"
   - "open-sse"
+# Match `.npmrc`'s legacy-peer-deps posture. OmniRoute imports only the deep
+# icon modules from @lobehub/icons; auto-installing its unused @lobehub/ui peer
+# pulls a large UI subtree (including packages without distributable licenses).
+autoInstallPeers: false
 allowBuilds:
   "@parcel/watcher": true
   "@swc/core": true

--- a/tests/unit/build/check-licenses.test.ts
+++ b/tests/unit/build/check-licenses.test.ts
@@ -8,6 +8,7 @@
 //   - stripVersion()     — strips @version suffix from package keys
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 // @ts-expect-error — .mjs helper has no type declarations; runtime shape is known.
 import {
   classifyLicense,
@@ -15,15 +16,19 @@ import {
   loadAllowlist,
 } from "../../../scripts/check/check-licenses.mjs";
 
+const PNPM_WORKSPACE_URL = new URL("../../../pnpm-workspace.yaml", import.meta.url);
+
 // ---------------------------------------------------------------------------
 // Helpers — synthetic allowlists for testing classifyLicense in isolation
 // ---------------------------------------------------------------------------
 
-function makeAllowlist(overrides: Partial<{
-  allowed: string[];
-  allowedExpressions: string[];
-  exceptions: Record<string, { license: string; justification: string; risk: string }>;
-}> = {}) {
+function makeAllowlist(
+  overrides: Partial<{
+    allowed: string[];
+    allowedExpressions: string[];
+    exceptions: Record<string, { license: string; justification: string; risk: string }>;
+  }> = {}
+) {
   return {
     allowed: ["MIT", "Apache-2.0", "BSD-3-Clause", "ISC", "0BSD"],
     allowedExpressions: ["(MIT OR Apache-2.0)", "MIT AND ISC", "MIT*"],
@@ -31,6 +36,15 @@ function makeAllowlist(overrides: Partial<{
     ...overrides,
   };
 }
+
+test("pnpm does not auto-install the unused @lobehub/ui peer subtree", () => {
+  const workspace = fs.readFileSync(PNPM_WORKSPACE_URL, "utf8");
+  assert.match(
+    workspace,
+    /^autoInstallPeers:\s*false\s*$/m,
+    "pnpm must match npm's legacy-peer-deps posture; @lobehub/ui is not a runtime dependency"
+  );
+});
 
 // ---------------------------------------------------------------------------
 // stripVersion
@@ -53,7 +67,10 @@ test("stripVersion: handles scoped package without version", () => {
 });
 
 test("stripVersion: handles nested scope-like name with version", () => {
-  assert.equal(stripVersion("@aws-sdk/client-bedrock-runtime@3.1063.0"), "@aws-sdk/client-bedrock-runtime");
+  assert.equal(
+    stripVersion("@aws-sdk/client-bedrock-runtime@3.1063.0"),
+    "@aws-sdk/client-bedrock-runtime"
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -150,7 +167,10 @@ test("classifyLicense: LGPL package with registered exception returns 'exception
   });
   const result = classifyLicense("lgpl-native-pkg@1.2.3", "LGPL-3.0-or-later", allowlist);
   assert.equal(result.status, "exception");
-  assert.ok(result.reason.includes("exception"), `reason should mention exception: ${result.reason}`);
+  assert.ok(
+    result.reason.includes("exception"),
+    `reason should mention exception: ${result.reason}`
+  );
 });
 
 test("classifyLicense: scoped package with exception: version is stripped for lookup", () => {


### PR DESCRIPTION
## Summary

- Stop pnpm from auto-installing the unused `@lobehub/ui` peer subtree declared by `@lobehub/icons`.
- Keep six unneeded packages with incompatible or unverifiable license metadata out of production installs without adding policy exceptions.
- Add a regression test that keeps pnpm aligned with the repository's existing npm `legacy-peer-deps` posture.

The affected subtree was not present in `package-lock.json`, was not imported by OmniRoute, and existed only because pnpm automatically installed an optional UI peer. With `autoInstallPeers: false`, a freshly generated temporary pnpm lock contains zero resolutions for `@giscus/react`, `@pierre/diffs`, `@pierre/theming`, `@splinetool/runtime`, `chroma-js`, or `elkjs`.

## Related Issues

- Related to #9985 (release-green tracking; no failure from this change is being attributed to that issue)

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: build-deploy / dependency policy
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` — focused ESLint passed; full lint remains delegated to CI
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Exact post-rebase evidence against `release/v3.8.50` at `9b14896a6cb61f2eda1c091a219a8558d10e5fb4`:

- `node --import tsx/esm --test tests/unit/build/check-licenses.test.ts` — **37/37 PASS**
- `npm run check:licenses` — **PASS**, 951 production packages, 0 policy violations
- temporary pnpm lock regeneration — all six unwanted package resolutions absent; lock removed afterward
- `CHANGELOG_BASE_REF=refs/remotes/origin/release/v3.8.50 npm run check:changelog-integrity` — **PASS**
- Prettier on all three changed paths — **PASS**
- `git diff --check` — **PASS**

⚠️ The continuous base-red tracker #9985 remains open. Its current report is independently being repaired; inherited release-level results must be compared against this PR's exact merge candidate rather than assigned to this dependency-policy change.

## Tests Added Or Updated

- `tests/unit/build/check-licenses.test.ts`
  - proves `pnpm-workspace.yaml` disables peer auto-installation;
  - retains the existing license classifier and allowlist contract tests.

## Coverage Notes

- No `src/`, `open-sse/`, `electron/`, or `bin/` production code changed.
- The behavior is a package-manager policy contract and is exercised directly by the updated Node unit test plus the full production dependency license scan.

## Reviewer Notes

- This deliberately removes the unused dependency subtree instead of adding six license exceptions.
- No `pnpm-lock.yaml` is tracked by this PR. A temporary lock was generated only as validation and then deleted.
- Existing approved exceptions for Sharp's dynamically linked libvips packages, `caniuse-lite`, and `tls-client-node` are unchanged.
- The changelog fragment is named for and links directly to this PR.
