### PR TITLE
fix(compression): use pathToFileURL for workerUrl to prevent bundler resolution failure

### DIFF
--- a/changelog.d/fixes/compression-worker-bundler-resolve.md
+++ b/changelog.d/fixes/compression-worker-bundler-resolve.md
@@ -1,0 +1,1 @@
+- **fix(compression):** use `pathToFileURL` in `compressionWorkerPool` so bundlers (Webpack / Turbopack) do not attempt static asset resolution of missing `compressionWorker.js` during build

--- a/open-sse/services/compression/compressionWorkerPool.ts
+++ b/open-sse/services/compression/compressionWorkerPool.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import type { CompressionResult } from "./types.ts";
 import type { StackedCompressionStep } from "./strategySelector.ts";
@@ -17,9 +17,10 @@ function positiveInteger(value: string | undefined, fallback: number): number {
 function workerUrl(): URL {
   const dir = dirname(fileURLToPath(import.meta.url));
   for (const name of ["compressionWorker.js", "compressionWorker.ts"]) {
-    if (existsSync(join(dir, name))) return new URL(name, import.meta.url);
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return pathToFileURL(candidate);
   }
-  return new URL("compressionWorker.js", import.meta.url);
+  return pathToFileURL(join(dir, "compressionWorker.js"));
 }
 function unchanged(body: Record<string, unknown>): CompressionResult {
   return { body, compressed: false, stats: null };


### PR DESCRIPTION
## Summary

- Use `pathToFileURL(join(dir, ...))` instead of `new URL(..., import.meta.url)` in `open-sse/services/compression/compressionWorkerPool.ts`.
- Fixes `Module not found: Can't resolve 'compressionWorker.js'` during Webpack / Next.js production builds (`next build` / Docker builder).

### Background
When Webpack and Turbopack statically scan source files during `next build`, `new URL("compressionWorker.js", import.meta.url)` is treated as a static asset/worker import. Since `compressionWorker.js` does not exist during Next build (only the `.ts` source exists), both bundlers fail resolution. Constructing the file URL dynamically via `pathToFileURL` prevents the static bundler interception while preserving the correct runtime `URL` resolution for Node.js Worker threads.

## Validation
- Change type: bug fix
- Reconciled with `upstream/release/v3.8.50`
- Tested with Next build / Webpack bundling
