### PR TITLE
fix(translator): preserve functionCall id in Gemini to OpenAI request translation

### DIFF
--- a/open-sse/translator/request/gemini-to-openai.ts
+++ b/open-sse/translator/request/gemini-to-openai.ts
@@ -137,7 +137,7 @@ function convertGeminiContent(content) {
 
     if (part.functionCall) {
       toolCalls.push({
-        id: `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        id: part.functionCall.id || `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
         type: "function",
         function: {
           name: part.functionCall.name,

--- a/tests/unit/translator-gemini-to-openai.test.ts
+++ b/tests/unit/translator-gemini-to-openai.test.ts
@@ -100,10 +100,7 @@ test("Gemini -> OpenAI maps a thought:true part to reasoning_content instead of 
       contents: [
         {
           role: "model",
-          parts: [
-            { thought: true, text: "internal reasoning" },
-            { text: "final answer" },
-          ],
+          parts: [{ thought: true, text: "internal reasoning" }, { text: "final answer" }],
         },
       ],
     },
@@ -116,9 +113,7 @@ test("Gemini -> OpenAI maps a thought:true part to reasoning_content instead of 
   assert.equal(assistant.reasoning_content, "internal reasoning");
   // The visible content must not contain the thought text.
   const visibleText =
-    typeof assistant.content === "string"
-      ? assistant.content
-      : JSON.stringify(assistant.content);
+    typeof assistant.content === "string" ? assistant.content : JSON.stringify(assistant.content);
   assert.doesNotMatch(visibleText, /internal reasoning/);
   assert.match(visibleText, /final answer/);
 });
@@ -171,4 +166,74 @@ test("Gemini -> OpenAI converts function responses into tool messages", () => {
       content: '{"temp":20}',
     },
   ]);
+});
+
+test("Gemini -> OpenAI preserves functionCall id when present", () => {
+  const result = geminiToOpenAIRequest(
+    "gpt-4o",
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "call_custom_id_999",
+                name: "get_weather",
+                args: { city: "Tokyo" },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    false
+  );
+
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "assistant");
+  assert.equal(result.messages[0].tool_calls[0].id, "call_custom_id_999");
+  assert.equal(result.messages[0].tool_calls[0].function.name, "get_weather");
+});
+
+test("Gemini -> OpenAI maintains matching IDs across multi-turn tool call and response", () => {
+  const result = geminiToOpenAIRequest(
+    "gpt-4o",
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "call_calc_456",
+                name: "calculator",
+                args: { expr: "2 + 2" },
+              },
+            },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call_calc_456",
+                name: "calculator",
+                response: { result: 4 },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    false
+  );
+
+  assert.equal(result.messages.length, 2);
+  const assistantCallId = result.messages[0].tool_calls[0].id;
+  const toolResponseCallId = result.messages[1].tool_call_id;
+  assert.equal(assistantCallId, "call_calc_456");
+  assert.equal(toolResponseCallId, "call_calc_456");
+  assert.equal(assistantCallId, toolResponseCallId);
 });


### PR DESCRIPTION
## Summary

Fixes an issue in `geminiToOpenAIRequest` where `part.functionCall.id` was discarded in favor of an unconditionally generated random ID (`call_${Date.now()}_...`).

In multi-turn conversations with tool calls, the subsequent `functionResponse` preserves `tool_call_id: part.functionResponse.id`. Discarding `functionCall.id` on the assistant turn caused a mismatch between the assistant's `tool_calls[i].id` and the user's `tool_call_id`, which caused OpenAI-compatible upstreams to reject the request with HTTP `400 Bad Request`.

## Changes

- In `open-sse/translator/request/gemini-to-openai.ts`: prefer `part.functionCall.id` when present, falling back to random generation only if omitted (matching sibling behavior in `antigravity-to-openai.ts:290`).
- In `tests/unit/translator-gemini-to-openai.test.ts`: added regression tests for ID preservation and multi-turn tool call/response ID parity.

## Validation

- [x] Focused tests: `node --import tsx/esm --test tests/unit/translator-gemini-to-openai.test.ts` (8/8 passing)
- [x] Linter: `npm run lint` (0 errors)
- [x] Base branch: `release/v3.8.50`
- [x] Automated regression tests included

## Tests Added

- `tests/unit/translator-gemini-to-openai.test.ts`
