### PR TITLE
fix(db): keep tokenExpiresAt when a connection is created

### DIFF
--- a/changelog.d/fixes/11368-create-connection-tokenexpiresat.md
+++ b/changelog.d/fixes/11368-create-connection-tokenexpiresat.md
@@ -1,0 +1,1 @@
+- **Provider connections:** keep `tokenExpiresAt` when a connection is created. The create-path allowlist omitted it, so every insert stored NULL and the dashboard token badge could read a fresh connection as expired until its first background refresh ([#11368](https://github.com/diegosouzapw/OmniRoute/pull/11368)).

--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -625,6 +625,10 @@ export async function createProviderConnection(data: JsonRecord) {
     "accessToken",
     "refreshToken",
     "expiresAt",
+    // #5326's payload sets this and _insertConnectionRow binds it, but it was
+    // missing from this allowlist — so every created row stored NULL however good
+    // the payload was. The update path already carries it (`data.tokenExpiresAt`).
+    "tokenExpiresAt",
     "tokenType",
     "scope",
     "idToken",

--- a/tests/unit/oauth-connection-tokenexpiresat-5326.test.ts
+++ b/tests/unit/oauth-connection-tokenexpiresat-5326.test.ts
@@ -1,7 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { buildOAuthConnectionCreatePayload } from "../../src/lib/oauth/connectionPersistence.ts";
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-tokenexpiresat-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "tokenexpiresat-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { buildOAuthConnectionCreatePayload } =
+  await import("../../src/lib/oauth/connectionPersistence.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
 
 // Regression for #5326: a freshly created OAuth connection (e.g. antigravity) used
 // to persist only `expiresAt`, leaving `tokenExpiresAt` null. The dashboard token
@@ -32,12 +47,39 @@ test("buildOAuthConnectionCreatePayload mirrors expiresAt into tokenExpiresAt (#
 });
 
 test("buildOAuthConnectionCreatePayload keeps tokenExpiresAt null when expiry is unknown", () => {
-  const payload = buildOAuthConnectionCreatePayload(
-    "antigravity",
-    { accessToken: "at-456" },
-    null
-  );
+  const payload = buildOAuthConnectionCreatePayload("antigravity", { accessToken: "at-456" }, null);
 
   assert.equal(payload.expiresAt, null);
   assert.equal(payload.tokenExpiresAt, null);
+});
+
+// The two cases above assert the payload object only, which is why the create path
+// could drop the field for as long as it did. `createProviderConnection` copies
+// optional fields through an allowlist, and `tokenExpiresAt` was not on it, so the
+// insert bound NULL however good the payload was. Persist and read it back.
+test("a created connection keeps tokenExpiresAt through the database", async () => {
+  core.resetDbInstance();
+  const expiresAt = new Date(Date.now() + 3600 * 1000).toISOString();
+  const payload = buildOAuthConnectionCreatePayload(
+    "antigravity",
+    {
+      accessToken: "at-789",
+      refreshToken: "rt-789",
+      email: "roundtrip@example.com",
+      expiresIn: 3600,
+    },
+    expiresAt
+  );
+  assert.equal(payload.tokenExpiresAt, expiresAt, "precondition: the payload carries it");
+
+  const created = await providersDb.createProviderConnection(payload);
+  const readBack = (await providersDb.getProviderConnections({})).find(
+    (c: { id: string }) => c.id === created.id
+  );
+
+  assert.ok(readBack, "the connection was persisted");
+  assert.equal(readBack.expiresAt, expiresAt);
+  // The dashboard badge and tokenHealthCheck both prefer tokenExpiresAt and fall back
+  // to expiresAt only when it is null, so a NULL here is a false "Token Expired".
+  assert.equal(readBack.tokenExpiresAt, expiresAt);
 });


### PR DESCRIPTION
## Summary

`createProviderConnection` copies optional fields onto the row through an allowlist (`src/lib/db/providers.ts:583`). `tokenExpiresAt` is not on it, and the initial object at `:568` does not set it either — so `_insertConnectionRow` always binds

```ts
tokenExpiresAt: conn.tokenExpiresAt || null,   // providers.ts:707
```

as **NULL on every insert**, however good the payload was.

That makes #5326 a no-op end to end. `buildOAuthConnectionCreatePayload` mirrors the computed expiry into `tokenExpiresAt` (`connectionPersistence.ts:105`) precisely so the dashboard badge does not flash "Token Expired" before the first background refresh — and the value is discarded one layer down. The update path already carries it (`providers.ts:762`), so a connection only gained the field after its first refresh.

One string on the allowlist.

## Related Issues

- Related to #5326 (whose fix this restores end to end)

## Validation

- [x] Change type: DB
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint` — **0 net new** on the changed file (4 pre-existing `no-unused-vars`, same before and after)
- [x] Reconciled with the current active release base (`release/v3.8.50`, `dafb4ae80`)
- [x] Production-code changes include a new or updated automated test in this PR

```
tests/unit/oauth-connection-tokenexpiresat-5326.test.ts   3 pass, 0 fail
  + oauth-refresh-connection-dedup-8059                   7 pass, 0 fail
```

**Written test-first**: the new case fails on the base with `tokenExpiresAt: null`, and passes with the one-string change. **Mutation-checked**, after confirming the edit applied — removing the string again gives 2 pass / 1 fail, exactly the new case.

## Tests Added Or Updated

- `tests/unit/oauth-connection-tokenexpiresat-5326.test.ts` — one case that persists the payload with `createProviderConnection` and reads it back through `getProviderConnections`.

The two existing cases are unchanged. Worth noting *why* they did not catch this: both assert the payload object and neither touches the database, so the create path could drop the field for as long as it did with the regression test green. The file now covers both halves.

## Coverage Notes

`src/lib/db/providers.ts` — the added allowlist entry is exercised by the round-trip case, and the mutation confirms it is the line under test rather than incidental.

## Reviewer Notes

- One-string change to a create-path allowlist; no schema change, no migration. The column and its binding already existed.
- I did **not** touch the re-auth path. `connectionPersistence.ts:146` and the four route sites spread `...tokenData` + `expiresAt` but omit `tokenExpiresAt`, which looks like the same omission on update — but both consumers prefer `tokenExpiresAt` and the create path is now correct, so I would rather that be judged separately than widened into this PR.
