### PR TITLE
fix(dashboard): align sync interval slider ticks via magnetic checkpoints

### DIFF
--- a/changelog.d/fixes/11394-modelsdev-interval-slider.md
+++ b/changelog.d/fixes/11394-modelsdev-interval-slider.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** Model Database sync interval slider ticks now match the thumb position — checkpoint-space slider with magnetic snap on release ([#11394](https://github.com/diegosouzapw/OmniRoute/pull/11394)) — thanks @An0nym0us92

--- a/src/app/(dashboard)/dashboard/settings/components/ModelsDevSyncTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ModelsDevSyncTab.tsx
@@ -24,6 +24,46 @@ interface SyncResult {
   error?: string;
 }
 
+// Slider works in "checkpoint space": position p ∈ [0, 3] maps linearly onto
+// these hour values, so the evenly spaced tick labels always match the thumb.
+const INTERVAL_CHECKPOINTS = [1, 6, 24, 168];
+const SNAP_THRESHOLD = 0.15;
+
+function positionToHours(pos: number): number {
+  const p = Math.min(INTERVAL_CHECKPOINTS.length - 1, Math.max(0, pos));
+  const lower = Math.floor(p);
+  const upper = Math.ceil(p);
+  if (lower === upper) return INTERVAL_CHECKPOINTS[lower];
+  const t = p - lower;
+  return Math.round(
+    INTERVAL_CHECKPOINTS[lower] + (INTERVAL_CHECKPOINTS[upper] - INTERVAL_CHECKPOINTS[lower]) * t
+  );
+}
+
+function hoursToPosition(hours: number): number {
+  const cps = INTERVAL_CHECKPOINTS;
+  if (hours <= cps[0]) return 0;
+  for (let i = 0; i < cps.length - 1; i++) {
+    if (hours <= cps[i + 1]) {
+      return i + (hours - cps[i]) / (cps[i + 1] - cps[i]);
+    }
+  }
+  return cps.length - 1;
+}
+
+// Magnetic checkpoints: snap to a reference point when released nearby,
+// otherwise keep the freely chosen position.
+function snapPosition(pos: number): number {
+  for (let i = 0; i < INTERVAL_CHECKPOINTS.length; i++) {
+    if (Math.abs(pos - i) <= SNAP_THRESHOLD) return i;
+  }
+  return pos;
+}
+
+function formatInterval(hours: number): string {
+  return hours === 168 ? "7d" : `${hours}h`;
+}
+
 export default function ModelsDevSyncTab() {
   const t = useTranslations("settings");
   const [status, setStatus] = useState<ModelsDevStatus | null>(null);
@@ -32,7 +72,7 @@ export default function ModelsDevSyncTab() {
   const [saving, setSaving] = useState(false);
   const [enabled, setEnabled] = useState(false);
   const [intervalHours, setIntervalHours] = useState(24);
-  const [draftIntervalHours, setDraftIntervalHours] = useState(24);
+  const [draftPos, setDraftPos] = useState(2);
   const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(
     null
   );
@@ -58,7 +98,7 @@ export default function ModelsDevSyncTab() {
           const intervalMs = settingsData.modelsDevSyncInterval || 86400000;
           const hours = Math.round(intervalMs / 3600000);
           setIntervalHours(hours);
-          setDraftIntervalHours(hours);
+          setDraftPos(hoursToPosition(hours));
         }
       })
       .catch((err) => {
@@ -126,7 +166,7 @@ export default function ModelsDevSyncTab() {
   const updateInterval = async (hours: number) => {
     const oldInterval = intervalHours;
     setIntervalHours(hours);
-    setDraftIntervalHours(hours);
+    setDraftPos(hoursToPosition(hours));
     try {
       const res = await fetch("/api/settings", {
         method: "PATCH",
@@ -135,18 +175,25 @@ export default function ModelsDevSyncTab() {
       });
       if (!res.ok) {
         setIntervalHours(oldInterval);
-        setDraftIntervalHours(oldInterval);
+        setDraftPos(hoursToPosition(oldInterval));
         setFeedback({ type: "error", message: t("enableSyncError") });
       } else {
         setFeedback({ type: "success", message: "Interval updated" });
       }
     } catch {
       setIntervalHours(oldInterval);
-      setDraftIntervalHours(oldInterval);
+      setDraftPos(hoursToPosition(oldInterval));
       setFeedback({ type: "error", message: "Network error" });
     } finally {
       setTimeout(() => setFeedback(null), 3000);
     }
+  };
+
+  // Commit on release: snap to a checkpoint when near one, else keep free value.
+  const commitDraftInterval = () => {
+    const snapped = snapPosition(draftPos);
+    if (snapped !== draftPos) setDraftPos(snapped);
+    updateInterval(positionToHours(snapped));
   };
 
   if (loading) {
@@ -238,18 +285,20 @@ export default function ModelsDevSyncTab() {
             <div className="flex items-center justify-between mb-3">
               <p className="text-sm font-medium">{t("modelsDevInterval")}</p>
               <span className="text-sm font-mono tabular-nums text-blue-400">
-                {draftIntervalHours}h
+                {formatInterval(positionToHours(draftPos))}
               </span>
             </div>
             <input
               type="range"
-              min="1"
-              max="168"
-              step="1"
-              value={draftIntervalHours}
-              onChange={(e) => setDraftIntervalHours(parseInt(e.target.value))}
-              onMouseUp={(e) => updateInterval(parseInt((e.target as HTMLInputElement).value))}
-              onBlur={(e) => updateInterval(parseInt(e.target.value))}
+              min="0"
+              max={INTERVAL_CHECKPOINTS.length - 1}
+              step="any"
+              value={draftPos}
+              onChange={(e) => setDraftPos(parseFloat(e.target.value))}
+              onMouseUp={commitDraftInterval}
+              onTouchEnd={commitDraftInterval}
+              onBlur={commitDraftInterval}
+              aria-label={t("modelsDevInterval")}
               className="w-full accent-blue-500"
             />
             <div className="flex justify-between text-xs text-text-muted mt-1">

--- a/tests/unit/ui/models-dev-sync-interval-slider-checkpoints.test.tsx
+++ b/tests/unit/ui/models-dev-sync-interval-slider-checkpoints.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelsDevSyncTab from "@/app/(dashboard)/dashboard/settings/components/ModelsDevSyncTab";
+
+// Regression coverage for the Model Database sync interval slider
+// (Settings > AI > Model Database): the reference ticks (1h/6h/24h/7d) used
+// to be laid out evenly with flex justify-between while the underlying
+// <input type=range> ran a linear 1-168 hour scale, so the thumb position
+// never matched the labels (59h landed visually on top of "6h").
+//
+// The slider now works in checkpoint space: position p in [0,3] maps linearly
+// onto [1,6,24,168] hours. It slides freely (step=any) and on release snaps
+// magnetically onto a checkpoint when dropped within threshold of one,
+// otherwise keeps the freely chosen (interpolated) hour value.
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const roots: Array<{ root: Root; el: HTMLDivElement }> = [];
+
+async function render(): Promise<HTMLDivElement> {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  await act(async () => {
+    root.render(<ModelsDevSyncTab />);
+  });
+  roots.push({ root, el });
+  return el;
+}
+
+function getSlider(container: HTMLDivElement): HTMLInputElement {
+  const input = container.querySelector('input[type="range"]');
+  if (!input) throw new Error("sync interval slider not found");
+  return input as HTMLInputElement;
+}
+
+function getLabel(container: HTMLDivElement): string {
+  const span = container.querySelector("span.text-blue-400");
+  if (!span?.textContent) throw new Error("interval label not found");
+  return span.textContent;
+}
+
+async function setSliderValue(container: HTMLDivElement, value: string) {
+  const input = getSlider(container);
+  // NOTE: synchronous act() on purpose — wrapping this in async act() lets the
+  // commit flush late, so the change handler would read the pre-dispatch value.
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function releaseSlider(container: HTMLDivElement) {
+  act(() => {
+    getSlider(container).dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  });
+}
+
+async function waitFor(predicate: () => boolean, label: string) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > 2000) {
+      throw new Error(`Timed out waiting for: ${label}`);
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+}
+
+describe("ModelsDevSyncTab interval slider checkpoints", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/settings/models-dev")) {
+        return new Response(
+          JSON.stringify({
+            enabled: true,
+            lastSync: null,
+            lastSyncModelCount: 0,
+            lastSyncCapabilityCount: 0,
+            nextSync: null,
+            intervalMs: 86400000,
+            providerCount: 1,
+            modelCount: 1,
+            capabilityCount: 1,
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes("/api/settings")) {
+        if (init?.method === "PATCH") {
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }
+        return new Response(
+          JSON.stringify({ modelsDevSyncEnabled: true, modelsDevSyncInterval: 86400000 }),
+          { status: 200 }
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    for (const { root, el } of roots.splice(0)) {
+      act(() => root.unmount());
+      el.remove();
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("maps the saved 24h interval onto checkpoint position 2", async () => {
+    const container = await render();
+    await waitFor(() => getSlider(container).value === "2", "saved interval to load");
+
+    expect(getLabel(container)).toBe("24h");
+  });
+
+  it("shows interpolated hours while dragging between checkpoints", async () => {
+    const container = await render();
+    await waitFor(() => getSlider(container).value === "2", "saved interval to load");
+
+    // midpoint of the 6h..24h segment -> 15h
+    await setSliderValue(container, "1.5");
+
+    expect(getLabel(container)).toBe("15h");
+    const patch = fetchMock.mock.calls.find((call) => call[1]?.method === "PATCH");
+    expect(patch).toBeUndefined(); // dragging alone must not save
+  });
+
+  it("snaps onto 6h when released near that checkpoint", async () => {
+    const container = await render();
+    await waitFor(() => getSlider(container).value === "2", "saved interval to load");
+
+    await setSliderValue(container, "0.9"); // within snap threshold of checkpoint 1
+    releaseSlider(container);
+
+    await waitFor(() => {
+      return Boolean(fetchMock.mock.calls.find((call) => call[1]?.method === "PATCH"));
+    }, "PATCH request to be issued");
+
+    const patch = fetchMock.mock.calls.find((call) => call[1]?.method === "PATCH");
+    expect(JSON.parse(String(patch?.[1]?.body))).toEqual({ modelsDevSyncInterval: 21600000 });
+    expect(getSlider(container).value).toBe("1");
+    expect(getLabel(container)).toBe("6h");
+  });
+
+  it("keeps the free value when released away from any checkpoint", async () => {
+    const container = await render();
+    await waitFor(() => getSlider(container).value === "2", "saved interval to load");
+
+    await setSliderValue(container, "1.5"); // mid-segment, no snap
+    releaseSlider(container);
+
+    await waitFor(() => {
+      return Boolean(fetchMock.mock.calls.find((call) => call[1]?.method === "PATCH"));
+    }, "PATCH request to be issued");
+
+    const patch = fetchMock.mock.calls.find((call) => call[1]?.method === "PATCH");
+    expect(JSON.parse(String(patch?.[1]?.body))).toEqual({ modelsDevSyncInterval: 54000000 });
+    expect(getSlider(container).value).toBe("1.5");
+    expect(getLabel(container)).toBe("15h");
+  });
+});


### PR DESCRIPTION
## Summary

The Model Database sync interval slider (Settings → AI Settings → Model Database) rendered its `1h/6h/24h/7d` reference labels evenly spaced with `flex justify-between` while the input ran a linear 1–168 hour scale — two coordinate systems that can never agree. A value of 59h landed visually on top of "6h" (measured: thumb ≈34.7% vs label ≈33% of track width).

Fix: move the slider into **checkpoint space**. Position `p ∈ [0,3]` maps linearly onto `[1,6,24,168]` hours, so the evenly spaced ticks and the thumb share one coordinate system by construction:

- thumb slides freely anywhere on the track (`step="any"`) — free sliding is preserved
- on release it **magnetically snaps** onto a checkpoint only when dropped within ~5% of one; otherwise the freely chosen value is kept
- live label shows interpolated hours mid-drag (midpoint of 6h–24h = `15h`); saved values roundtrip losslessly through `hoursToPosition()`

No new UI components, no copy changes, no i18n additions.

### Behavior table

| Release position | Result |
|---|---|
| within ~5% of a tick | snaps exactly onto 1h / 6h / 24h / 7d |
| anywhere else | keeps free value (interpolated hours, e.g. pos 1.5 = `15h`) |
| value saved by an older version (e.g. 59h) | roundtrips losslessly, thumb at proportional spot |

## Related Issues

- Closes #11393

## Validation

- [x] Change type: UI (dashboard settings component)
- [x] Focused tests from the golden path (see Tests section below)
- [x] `npm run lint` — `eslint --max-warnings 0` clean on both changed files
- [x] Reconciled with the current active release base (`release/v3.8.50` @ dafb4ae); focused checks rerun after reconcile
- [x] Production-code change includes a new automated test in this PR

⚠️ base-red inherited: #9985

## Tests Added Or Updated

- `tests/unit/ui/models-dev-sync-interval-slider-checkpoints.test.tsx` (new, vitest + jsdom):
  - saved 24h maps onto checkpoint position 2 with label `24h`
  - mid-drag shows interpolated `15h` and issues **no** PATCH while dragging
  - release near a checkpoint snaps to it (PATCH `{ modelsDevSyncInterval: 21600000 }`, label `6h`)
  - release away from checkpoints keeps the free value (PATCH `{ modelsDevSyncInterval: 54000000 }`, label stays `15h`)

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Coverage Notes

All new logic lives in module-scope pure helpers (`positionToHours`, `hoursToPosition`, `snapPosition`, `formatInterval`) plus the commit path in `ModelsDevSyncTab`; the new test exercises all four behaviors through the rendered component (jsdom + controlled-input dispatch pattern matching `cache-settings-tab-bounds-8219.test.tsx`). No existing tests covered this component before, so nothing moved down.

## Reviewer Notes

- Free sliding is intentionally preserved; snapping is magnetic-on-release only (threshold ±0.15 checkpoint units), never forced while dragging.
- `onBlur` also commits (pre-existing pattern kept), so keyboard users get the same snap semantics; arrow-key granularity under `step="any"` is browser-defined (~1% of range per keypress).
- Changelog fragment `changelog.d/fixes/<PR#>-modelsdev-interval-slider.md` follows immediately once this PR has its number (fragments are numbered by PR).
