### PR TITLE
fix(sse): preserve auto-selected first target

### DIFF
--- a/open-sse/services/combo/promptCacheAffinity.ts
+++ b/open-sse/services/combo/promptCacheAffinity.ts
@@ -290,6 +290,7 @@ export function shouldProtectOriginalFirst(
   return (
     stickyStuck ||
     autoUsedExplicitRouter ||
+    strategy === "auto" ||
     strategy === "quota-share" ||
     strategy === "weighted" ||
     strategy === "priority" ||

--- a/tests/unit/8370-priority-affinity-reorder.test.ts
+++ b/tests/unit/8370-priority-affinity-reorder.test.ts
@@ -139,8 +139,8 @@ test("BUG #8370: priority combo keeps its declared model-1-first order despite c
   );
 });
 
-test("shouldProtectOriginalFirst covers priority, fill-first, and lkgp", () => {
-  for (const strategy of ["priority", "fill-first", "lkgp"]) {
+test("shouldProtectOriginalFirst covers auto, priority, fill-first, and lkgp", () => {
+  for (const strategy of ["auto", "priority", "fill-first", "lkgp"]) {
     assert.equal(
       shouldProtectOriginalFirst(false, false, strategy),
       true,


### PR DESCRIPTION
## Problem

Auto routing selects and ranks a first target, but prompt-cache affinity could subsequently replace it. That made the dispatched target differ from the result produced by auto scoring.

## Summary

- Prevent prompt-cache affinity post-processing from replacing the first target selected by auto routing.
- Auto routing has already produced its ranked order at this stage, so the existing original-first guard now protects `auto`.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: routing
- [x] Focused regression test passed
- [ ] Focused category gates from the Contribution Golden Path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

This is a draft. Final category-gate and lint results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/8370-priority-affinity-reorder.test.ts`

## Coverage Notes

- The updated regression verifies that prompt-cache-affinity post-processing preserves the auto-selected first target.
- No known touched-file coverage decrease.

## Reviewer Notes

- Only the existing original-first guard changes; affinity behavior for other strategies is unchanged.
