### PR TITLE
fix(sse): preserve auto scoring order

### DIFF
--- a/open-sse/services/taskAwareRouting.ts
+++ b/open-sse/services/taskAwareRouting.ts
@@ -64,7 +64,7 @@ const MAX_CONVERSATION_AFFINITY_ENTRIES = 1000;
  * Task routing is additive: other strategies are wholly unaffected.
  */
 export function isTaskRoutingStrategy(strategy: unknown): boolean {
-  return ["smart", "task", "task-aware", "task_aware", "auto"].includes(
+  return ["smart", "task", "task-aware", "task_aware"].includes(
     String(strategy ?? "").toLowerCase()
   );
 }

--- a/tests/unit/combo-task-aware.test.ts
+++ b/tests/unit/combo-task-aware.test.ts
@@ -255,9 +255,10 @@ describe("reorderByTaskWeight", () => {
 
 describe("isTaskRoutingStrategy", () => {
   it("returns true for task-aware strategy names", () => {
-    for (const name of ["smart", "task", "task-aware", "task_aware", "auto"]) {
+    for (const name of ["smart", "task", "task-aware", "task_aware"]) {
       assert.ok(isTaskRoutingStrategy(name), `Expected ${name} to be task-routing`);
     }
+    assert.ok(!isTaskRoutingStrategy("auto"), "auto scoring must not be reordered by task routing");
   });
 
   it("is case-insensitive", () => {


### PR DESCRIPTION
## Problem

Auto routing already includes task fitness as one of its scoring criteria. Running the separate generic task-aware reorder afterward scored task fit a second time and could overwrite the final order produced by the full auto score.

## Summary

- Stop generic task-aware post-processing from reordering targets after auto routing has completed scoring.
- The task-routing predicate no longer classifies `auto` as a generic task strategy; explicit task strategies retain their behavior.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: routing
- [x] Focused regression test passed
- [ ] Focused category gates from the Contribution Golden Path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

This is a draft. Final category-gate and lint results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/combo-task-aware.test.ts`

## Coverage Notes

- The updated regression verifies that auto bypasses generic task reordering while explicit task strategies remain eligible.
- No known touched-file coverage decrease.

## Reviewer Notes

- Task fitness is not removed: it remains part of auto candidate scoring.
- Explicit task-aware strategies retain their existing post-processing behavior.
- The optional `taskFit=0` defense is excluded because it would broaden semantics without a demonstrated regression.
