### PR TITLE
fix(dashboard): normalize explicit auto weights

### DIFF
--- a/src/lib/usage/comboScoringInspector.ts
+++ b/src/lib/usage/comboScoringInspector.ts
@@ -12,6 +12,7 @@ import {
   calculateFactors,
   calculateScore,
   DEFAULT_WEIGHTS,
+  normalizeScoringWeights,
   type ProviderCandidate,
   type ScoringFactors,
   type ScoringWeights,
@@ -122,8 +123,11 @@ function resolveModePackName(config: Record<string, unknown>): string | null {
 
 /** Resolves an explicit, validated `weights` object from the config, if present. */
 function resolveExplicitWeights(config: Record<string, unknown>): ScoringWeights | undefined {
-  const explicitWeights = isRecord(config.weights) ? (config.weights as ScoringWeights) : undefined;
-  return explicitWeights && validateWeights(explicitWeights) ? explicitWeights : undefined;
+  if (!isRecord(config.weights)) return undefined;
+  const explicitWeights = config.weights as ScoringWeights;
+  if (validateWeights(explicitWeights)) return explicitWeights;
+  const normalized = normalizeScoringWeights(config.weights as Partial<ScoringWeights>);
+  return validateWeights(normalized) ? normalized : undefined;
 }
 
 function resolveInspectorWeights(combo: ComboRecord | undefined): InspectorWeights {

--- a/tests/unit/combo-scoring-inspector.test.ts
+++ b/tests/unit/combo-scoring-inspector.test.ts
@@ -27,7 +27,8 @@ const { normalizeComboStep } = await import("../../src/lib/combos/steps.ts");
 const { lockModel, clearAllModelLockouts } =
   await import("../../open-sse/services/accountFallback.ts");
 const { resetAllCircuitBreakers } = await import("../../src/shared/utils/circuitBreaker.ts");
-const { DEFAULT_WEIGHTS } = await import("../../open-sse/services/autoCombo/scoring.ts");
+const { DEFAULT_WEIGHTS, normalizeScoringWeights } =
+  await import("../../open-sse/services/autoCombo/scoring.ts");
 const { MODE_PACKS } = await import("../../open-sse/services/autoCombo/modePacks.ts");
 
 async function resetStorage() {
@@ -242,6 +243,32 @@ test("scoring inspector reports valid explicit auto weights", async () => {
   assert.equal(response.combos[0].weightSource, "explicit");
   assert.equal(response.combos[0].modePack, null);
   assert.deepEqual(response.combos[0].weights, explicitWeights);
+});
+test("scoring inspector normalizes partial explicit auto weights like runtime", async () => {
+  const explicitWeights = {
+    quota: 0.3,
+    health: 0.25,
+    costInv: 0.1,
+    latencyInv: 0.1,
+  };
+  const combo = await combosDb.createCombo({
+    name: "combo-scoring-partial-explicit-weights",
+    strategy: "auto",
+    models: ["openai/gpt-4o-mini"],
+    autoConfig: { weights: explicitWeights },
+  });
+
+  const response = await inspector.buildComboScoringInspectorResponse({
+    range: "24h",
+    horizon: "7d",
+    comboId: String(combo.id),
+    combos: [combo],
+    skipAutopilot: true,
+  });
+
+  assert.equal(response.combos[0].weightSource, "explicit");
+  assert.deepEqual(response.combos[0].weights, normalizeScoringWeights(explicitWeights));
+  assert.equal(response.combos[0].warnings.length, 0);
 });
 
 test("scoring inspector marks non-auto combos as explanatory recompute", async () => {


### PR DESCRIPTION
## Problem

The scoring inspector rejected or misreported partial and non-unit explicit weights even though runtime auto routing normalizes those same values. Operators could therefore see diagnostics that disagreed with actual routing behavior.

## Summary

- Normalize partial or non-unit explicit weights before the combo scoring inspector validates them.
- Use the runtime normalizer so diagnostics remain consistent while exact valid weights are preserved unchanged.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: UI
- [x] Focused regression test passed
- [ ] Focused category gates from the Contribution Golden Path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

This is a draft. Final category-gate and lint results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/combo-scoring-inspector.test.ts`

## Coverage Notes

- The updated regression covers incomplete and non-unit weights, exact valid weights, and invalid fallback behavior.
- No known touched-file coverage decrease.

## Reviewer Notes

- Negative and non-finite values remain invalid.
