### PR TITLE
fix(sse): preserve opencode parser identity

### DIFF
--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -41,8 +41,6 @@ for (const [id, alias] of Object.entries(PROVIDER_ID_TO_ALIAS)) {
 // Manual alias overrides — maps slug-style prefixes to canonical provider IDs.
 // These live outside the registry because they represent multiple providers
 // or backward-compatible slug changes, not a single provider's display name.
-// opencode/ → opencode-zen (the main free/open tier; opencode-go is a separate paid tier)
-ALIAS_TO_PROVIDER_ID["opencode"] = "opencode-zen";
 // xiaomi/ is the user-visible prefix for MiMo models; register it so
 // parseModel("xiaomi/mimo-v2-flash") resolves provider = "xiaomi-mimo" instead
 // of falling through to the identity fallback ("xiaomi").
@@ -187,10 +185,7 @@ export function resolveProviderAlias(aliasOrId: string | null | undefined): stri
   if (typeof aliasOrId !== "string") return null;
   // Follow the alias chain transitively so intermediate alias-only hops resolve
   // to the final target, but STOP as soon as a hop lands on a registered
-  // provider id (#2901): "oc" must resolve to the no-auth "opencode" provider,
-  // NOT continue through the manual "opencode" → "opencode-zen" slug override —
-  // that override is for user-typed `opencode/` prefixes only. Without this
-  // boundary the no-auth provider becomes unreachable by any prefix.
+  // provider id (#2901): "oc" must resolve to the no-auth "opencode" provider.
   // Guarded against infinite loops with both a depth limit and a seen-set.
   let current = aliasOrId;
   const seen = new Set<string>();
@@ -645,17 +640,8 @@ async function resolveModelByProviderInference(modelId: string, extendedContext:
     }
   }
 
-  // Opencode free-tier models always route to opencode when active — prevents
-  // prefix inference from misrouting -free names to other providers when the
-  // live catalog is temporarily unreachable.
-  //
-  // A literal `activeProviders?.has("opencode")` check is unreachable in
-  // practice: `getActiveProviderSet()` canonicalizes every connection's
-  // provider id through `resolveProviderAlias()`, and the manual override
-  // above (`ALIAS_TO_PROVIDER_ID["opencode"] = "opencode-zen"`) rewrites any
-  // "opencode" id to "opencode-zen" before it ever reaches the active set —
-  // so an active no-auth opencode connection never appears as "opencode".
-  // Check both opencode-family canonical ids that catalog this model id.
+  // Opencode free-tier models route to an active opencode-family provider — prevents
+  // prefix inference from misrouting -free names when the live catalog is unavailable.
   if (modelId === "big-pickle" || modelId.endsWith("-free")) {
     const candidates = MODEL_TO_PROVIDERS.get(modelId) || [];
     const activeOpencodeCandidate = candidates.find(

--- a/tests/unit/combo-builder-opencode-prefix.test.ts
+++ b/tests/unit/combo-builder-opencode-prefix.test.ts
@@ -2,12 +2,9 @@
  * Issue #2901 — OpenCode Free combo entries use the `opencode/` prefix instead
  * of `oc/`.
  *
- * The no-auth OpenCode provider has id "opencode" and alias "oc". The combo
- * builder built `qualifiedModel` from the provider *id* (`opencode/big-pickle`),
- * but `parseModel("opencode/...")` resolves to the **opencode-zen** provider
- * (an api-key tier) via a manual ALIAS_TO_PROVIDER_ID override — not the no-auth
- * "opencode" provider. The user-facing routing alias `oc/` resolves correctly
- * (`oc/big-pickle` → provider "opencode").
+ * The no-auth OpenCode provider has id "opencode" and alias "oc". Its combo
+ * entries use the shorter `oc/` alias, while either explicit prefix must resolve
+ * to the same provider identity.
  *
  * This test drives the real builder against a fresh DB and asserts that no-auth
  * OpenCode models carry the `oc/` prefix.
@@ -76,8 +73,9 @@ test("#2901 configured OpenCode connections also use the oc/ prefix", async () =
   );
 });
 
-test("#2901 the oc/ prefix actually resolves back to the no-auth opencode provider", () => {
-  // Guards the premise: opencode/ misroutes to opencode-zen, oc/ is correct.
+test("OpenCode provider prefixes preserve their distinct identities", () => {
   assert.equal(parseModel("oc/big-pickle").provider, "opencode");
-  assert.equal(parseModel("opencode/big-pickle").provider, "opencode-zen");
+  assert.equal(parseModel("opencode/big-pickle").provider, "opencode");
+  assert.equal(parseModel("opencode-zen/big-pickle").provider, "opencode-zen");
+  assert.equal(parseModel("opencode-go/big-pickle").provider, "opencode-go");
 });

--- a/tests/unit/provider-alias-transitive-5918.test.ts
+++ b/tests/unit/provider-alias-transitive-5918.test.ts
@@ -2,25 +2,15 @@
  * Regression tests for #5918: resolveProviderAlias must follow the alias chain
  * transitively.
  *
- * Root cause: resolveProviderAlias() did a single-hop lookup
- * (`ALIAS_TO_PROVIDER_ID[alias] || alias`). The registry has genuine two-hop chains:
- * the parent OpenCode provider registers `id: "opencode", alias: "oc"` (so
- * `oc -> opencode`), and a manual override maps `opencode -> opencode-zen` (the
- * main free tier). With single-hop, `resolveProviderAlias("oc")` returned the
- * intermediate `"opencode"` instead of the final `"opencode-zen"`, so `oc/<model>`
- * resolved to the wrong provider.
+ * The OpenCode provider registers `id: "opencode", alias: "oc"`. Both its alias
+ * and canonical id must resolve to the no-auth provider without drifting into a
+ * separate OpenCode tier.
  *
  * Fix: resolve transitively with a depth limit AND a seen-set so cycles cannot loop.
  * These assertions FAIL on the old single-hop implementation and pass on the fix.
  *
- * RECONCILED at v3.8.44 with the #2901 contract: the chain STOPS as soon as a hop
- * lands on a REGISTERED provider id. "oc" is the registry alias of the no-auth
- * "opencode" provider, so `oc/<model>` must resolve to it — continuing through the
- * manual "opencode" → "opencode-zen" slug override (which exists only for
- * user-typed `opencode/` prefixes) would leave the no-auth provider unreachable by
- * any prefix and misroute its combo entries (see combo-builder-opencode-prefix
- * test #2901). Transitivity still applies across alias-only hops, and the
- * loop/depth guards from #5918 are retained.
+ * The chain stops as soon as a hop lands on a registered provider id. Transitivity
+ * still applies across alias-only hops, and the loop/depth guards are retained.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -34,8 +24,8 @@ test("resolveProviderAlias stops the oc chain at the registered no-auth opencode
   assert.equal(resolveProviderAlias("oc"), "opencode");
 });
 
-test("resolveProviderAlias resolves a direct one-hop alias", () => {
-  assert.equal(resolveProviderAlias("opencode"), "opencode-zen");
+test("resolveProviderAlias preserves the registered opencode provider id", () => {
+  assert.equal(resolveProviderAlias("opencode"), "opencode");
 });
 
 test("resolveProviderAlias returns a terminal id unchanged (id === alias)", () => {


### PR DESCRIPTION
## Problem

Explicit `opencode/...` model IDs were rewritten to `opencode-zen`, so models addressed through the distinct OpenCode Free provider were parsed as belonging to the Zen tier.

## Summary

- Stop rewriting explicitly qualified `opencode/...` model IDs to `opencode-zen`.
- Normal identity fallback handles OpenCode Free (`opencode`); the `oc` alias remains supported and Free, Zen, and Go remain distinct.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: provider
- [x] Focused regression test passed
- [ ] Focused category gates from the Contribution Golden Path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

This is a draft. Final category-gate and lint results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/combo-builder-opencode-prefix.test.ts`
- `tests/unit/provider-alias-transitive-5918.test.ts`

## Coverage Notes

- The updated regressions cover base OpenCode prefixes, the retained `oc` alias, transitive aliases, and tier separation.
- No known touched-file coverage decrease.

## Reviewer Notes

- OpenCode Free is a distinct provider entry, not another name for OpenCode Zen.
- This removes only the erroneous parser alias.
