### PR TITLE
fix(sse): honor explicit combo target timeout

### DIFF
--- a/open-sse/services/comboConfig.ts
+++ b/open-sse/services/comboConfig.ts
@@ -22,7 +22,7 @@ export const PRE_SCREEN_CONCURRENCY = 5;
  * the whole combo for up to 10 minutes before falling through to the next model
  * (escalated cmqlrhd7c). For STREAMING requests this only bounds the time-to-first-headers
  * — token generation streams after the response resolves, so it is NOT cut short. Operators
- * can still raise it per-combo via `targetTimeoutMs` (capped at the upstream ceiling), or set
+ * can still raise it per-combo via `targetTimeoutMs`, or set
  * a longer value for slow non-streaming reasoning combos.
  */
 export const DEFAULT_COMBO_TARGET_TIMEOUT_MS = 120_000;
@@ -250,11 +250,8 @@ export function resolveComboTargetTimeoutMs(
     ? normalizePositiveTimeoutMs(config.targetTimeoutMs)
     : 0;
 
-  // Explicit per-combo config: honour it, but never extend past the upstream ceiling.
-  if (configuredTimeoutMs > 0) {
-    if (ceilingTimeoutMs <= 0) return configuredTimeoutMs;
-    return Math.min(configuredTimeoutMs, ceilingTimeoutMs);
-  }
+  // Explicit per-combo config overrides the upstream/default timeout.
+  if (configuredTimeoutMs > 0) return configuredTimeoutMs;
 
   // Unset config: fall back to the saner combo default (when provided) so a hung target
   // fails over fast instead of inheriting the full upstream timeout. Never exceed the

--- a/tests/unit/combo-config.test.ts
+++ b/tests/unit/combo-config.test.ts
@@ -292,10 +292,10 @@ test("combo config schema allows zero-latency tuning fields when subfeatures sta
   assert.equal(parsed.config.predictiveTtftMs, 0);
 });
 
-test("resolveComboTargetTimeoutMs inherits the upstream timeout and only shortens it", () => {
+test("resolveComboTargetTimeoutMs inherits upstream timeout unless explicitly overridden", () => {
   assert.equal(resolveComboTargetTimeoutMs({}, 600000), 600000);
   assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 30000 }, 600000), 30000);
-  assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 900000 }, 600000), 600000);
+  assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 900000 }, 600000), 900000);
   assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 0 }, 600000), 600000);
   assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 30000 }, 0), 30000);
   assert.equal(resolveComboTargetTimeoutMs({}, 0), 0);
@@ -314,14 +314,17 @@ test("resolveComboTargetTimeoutMs falls back to the saner combo default when uns
   assert.equal(resolveComboTargetTimeoutMs({}, 600000, 120000), 120000);
   // Operators can still extend beyond the default, up to the ceiling.
   assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 300000 }, 600000, 120000), 300000);
-  // Explicit config above the ceiling is still capped at the ceiling.
-  assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 900000 }, 600000, 120000), 600000);
+  // Explicit config remains authoritative even when it exceeds the upstream default.
+  assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 900000 }, 600000, 120000), 900000);
   // A default larger than the ceiling is clamped to the ceiling.
   assert.equal(resolveComboTargetTimeoutMs({}, 100000, 120000), 100000);
   // Backward-compat: omitting the default arg keeps the legacy inherit-the-ceiling behavior.
   assert.equal(resolveComboTargetTimeoutMs({}, 600000), 600000);
   // Disabled upstream timeout (0 = unbounded) stays unbounded even with a default present.
   assert.equal(resolveComboTargetTimeoutMs({}, 0, 120000), 0);
+});
+test("resolveComboTargetTimeoutMs honors a 300s combo override over a 120s upstream default", () => {
+  assert.equal(resolveComboTargetTimeoutMs({ targetTimeoutMs: 300000 }, 120000, 120000), 300000);
 });
 
 // #7360 / #7301: any strategy with comboCooldownWait enabled waits out cooldowns for up


### PR DESCRIPTION
## Problem

A combo could specify a longer `targetTimeoutMs`, but the resolver silently capped it at the default fetch timeout. The configured override therefore had no effect for the cases that needed extra time.

## Summary

- Honor a valid explicit combo `targetTimeoutMs` instead of capping it by the default fetch timeout.
- Fallback behavior remains unchanged when no valid override exists.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: routing
- [x] Focused regression test passed
- [ ] Focused category gates from the Contribution Golden Path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

This is a draft. Final category-gate and lint results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/combo-config.test.ts`

## Coverage Notes

- The updated regression covers explicit overrides and absent or invalid fallback behavior.
- No known touched-file coverage decrease.

## Reviewer Notes

- Large explicit values can now run for their configured duration.
