### PR TITLE
fix(dashboard): expose custom mode-pack option

### DIFF
--- a/src/lib/combos/intelligentRouting.ts
+++ b/src/lib/combos/intelligentRouting.ts
@@ -58,6 +58,7 @@ export const DEFAULT_INTELLIGENT_WEIGHTS: IntelligentRoutingWeights = {
 };
 
 export const MODE_PACK_OPTIONS = [
+  { id: "custom", label: "Custom / None (Use Sliders)", emoji: "tune" },
   { id: "ship-fast", label: "Ship Fast", emoji: "rocket_launch" },
   { id: "cost-saver", label: "Cost Saver", emoji: "savings" },
   { id: "quality-first", label: "Quality First", emoji: "target" },

--- a/tests/unit/autocombo-unification.test.ts
+++ b/tests/unit/autocombo-unification.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const intelligentRouting = await import("../../src/lib/combos/intelligentRouting.ts");
+const { getModePack } = await import("../../open-sse/services/autoCombo/modePacks.ts");
 
 test("getStrategyCategory classifies intelligent and deterministic strategies correctly", () => {
   assert.equal(intelligentRouting.getStrategyCategory("auto"), "intelligent");
@@ -153,6 +154,19 @@ test("sidebar visibility excludes the removed auto-combo item", async () => {
   assert.deepEqual(sidebarVisibility.normalizeHiddenSidebarItems(["auto-combo" as any, "home"]), [
     "home",
   ]);
+});
+
+test("custom mode-pack selection preserves explicit slider intent", () => {
+  assert.deepEqual(intelligentRouting.MODE_PACK_OPTIONS[0], {
+    id: "custom",
+    label: "Custom / None (Use Sliders)",
+    emoji: "tune",
+  });
+  assert.equal(
+    intelligentRouting.normalizeIntelligentRoutingConfig({ modePack: "custom" }).modePack,
+    "custom"
+  );
+  assert.equal(getModePack("custom"), undefined);
 });
 
 test("intelligent routing helpers normalize config and build provider scores", () => {


### PR DESCRIPTION
## Problem

Operators could tune custom slider weights, but the mode-pack selector exposed only named presets. Choosing a preset overwrote those weights and there was no visible way to select the runtime's existing custom mode.

## Summary

- Expose the existing `custom` sentinel in the shared mode-pack selector so operators can retain slider weights.
- Both UI flows consume the shared list, and runtime already leaves weights unchanged when `custom` resolves no preset.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: UI
- [x] Focused regression test passed
- [ ] Focused category gates from the Contribution Golden Path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

This is a draft. Final category-gate and lint results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/autocombo-unification.test.ts`

## Coverage Notes

- The updated regression verifies the option, normalization, and absence of a named custom preset.
- No known touched-file coverage decrease.

## Reviewer Notes

- Absent mode packs still default to `ship-fast`; no migration is included.
