### PR TITLE
fix(build): gate better-sqlite3 build stub to avoid bundling stub at runtime (#11343)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,7 @@ import { createMDX } from "fumadocs-mdx/next";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mitmManagerAliasFor } from "./scripts/build/mitm-stub-flag.mjs";
+import { betterSqlite3AliasFor } from "./scripts/build/better-sqlite3-stub-flag.mjs";
 import { normalizeBasePath } from "./scripts/build/normalizeBasePath.mjs";
 import {
   buildSecurityHeaderRules,
@@ -138,10 +139,14 @@ const nextConfig = {
       // the stub to every npm/Electron/VPS artifact and broke Agent Bridge
       // start for all non-Docker users (#6344). See scripts/build/mitm-stub-flag.mjs.
       ...mitmManagerAliasFor(process.env),
-      // Build-time stub so the bundler never traces the native better-sqlite3
-      // addon into a build worker (SIGABRT at worker teardown). Runtime still
-      // uses the real package via serverExternalPackages. (#10060)
-      "better-sqlite3": "./src/lib/db/better-sqlite3.stub.js",
+      // Better-sqlite3 never gets bundled: during the production build the
+      // native addon must stay out of build workers (SIGABRT at teardown,
+      // #10060) so the bundler resolves it to the no-op build stub; at
+      // runtime the alias is empty and serverExternalPackages keeps the
+      // real package external (#11343 — the previous UNCONDITIONAL alias
+      // shipped the stub into the standalone server and every DB op 500ed).
+      // See scripts/build/better-sqlite3-stub-flag.mjs.
+      ...betterSqlite3AliasFor(process.env),
       ...minimalBuildAliases,
     },
     // src/lib/agentSkills/generator.ts builds its fs base path from a runtime

--- a/scripts/build/better-sqlite3-stub-flag.mjs
+++ b/scripts/build/better-sqlite3-stub-flag.mjs
@@ -1,0 +1,38 @@
+/**
+ * Decide whether the Turbopack/Next.js bundler should alias better-sqlite3 to
+ * the no-op build stub (src/lib/db/better-sqlite3.stub.js).
+ *
+ * History (#11343): the alias used to be UNCONDITIONAL in next.config.mjs,
+ * which made the bundler resolve every `require("better-sqlite3")` to the
+ * stub AHEAD of serverExternalPackages — the stub was then bundled into the
+ * standalone server and the real native addon never loaded at runtime, so
+ * every DB operation threw a 500 (`r(...) is not a constructor`) in the
+ * v3.8.50 release artifact.
+ *
+ * The stub exists ONLY to keep the native addon out of build workers during
+ * the production build (its Statement destructor SIGABRTs at worker teardown —
+ * #10060). At runtime the real package must win via serverExternalPackages,
+ * so the alias is gated on the same explicit build signals the in-process
+ * stub gate uses (src/lib/buildPhase.ts::isNextBuildPhase):
+ *   - OMNIROUTE_BUILDING === "1": set by scripts/build/build-next-isolated.mjs
+ *     and inherited by every spawned build worker; the reliable signal
+ *     because Next.js workers sometimes drop NEXT_PHASE (#10060).
+ *   - NEXT_PHASE === "phase-production-build": set by Next.js on the main
+ *     build process when `next build` runs directly.
+ *   - npm_lifecycle_event === "build": backstop for invocations launched via
+ *     `npm run build`.
+ */
+export function shouldStubBetterSqlite3(env = process.env) {
+  return (
+    env.OMNIROUTE_BUILDING === "1" ||
+    env.NEXT_PHASE === "phase-production-build" ||
+    env.npm_lifecycle_event === "build"
+  );
+}
+
+/** Turbopack resolveAlias fragment for better-sqlite3, derived from the env. */
+export function betterSqlite3AliasFor(env = process.env) {
+  return shouldStubBetterSqlite3(env)
+    ? { "better-sqlite3": "./src/lib/db/better-sqlite3.stub.js" }
+    : {};
+}

--- a/tests/unit/build/better-sqlite3-stub-flag-11343.test.mjs
+++ b/tests/unit/build/better-sqlite3-stub-flag-11343.test.mjs
@@ -1,0 +1,88 @@
+// Regression test for #11343 — the better-sqlite3 alias in next.config.mjs was
+// UNCONDITIONAL: the bundler resolved every `require("better-sqlite3")` to the
+// no-op build stub ahead of serverExternalPackages, so the stub was bundled
+// into the standalone server and the real native addon never loaded at
+// runtime — every DB operation then threw a 500 (`r(...) is not a
+// constructor`). The alias must be gated on the same explicit build signals the
+// in-process stub gate uses (src/lib/buildPhase.ts); a default production
+// build / runtime must bundle the REAL package via serverExternalPackages.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const { shouldStubBetterSqlite3, betterSqlite3AliasFor } = await import(
+  "../../../scripts/build/better-sqlite3-stub-flag.mjs"
+);
+
+const STUB_ALIAS = { "better-sqlite3": "./src/lib/db/better-sqlite3.stub.js" };
+
+describe("better-sqlite3 build-stub alias (#11343)", () => {
+  it("default env does NOT stub better-sqlite3 (npm/Electron/VPS runtime gets the real addon)", () => {
+    assert.equal(shouldStubBetterSqlite3({}), false);
+    assert.deepEqual(betterSqlite3AliasFor({}), {});
+  });
+
+  it("OMNIROUTE_BUILDING=1 stubs (isolated build script signal, inherited by build workers)", () => {
+    assert.equal(shouldStubBetterSqlite3({ OMNIROUTE_BUILDING: "1" }), true);
+    assert.deepEqual(betterSqlite3AliasFor({ OMNIROUTE_BUILDING: "1" }), STUB_ALIAS);
+  });
+
+  it("NEXT_PHASE=phase-production-build stubs (direct `next build` signal)", () => {
+    assert.equal(shouldStubBetterSqlite3({ NEXT_PHASE: "phase-production-build" }), true);
+    assert.deepEqual(
+      betterSqlite3AliasFor({ NEXT_PHASE: "phase-production-build" }),
+      STUB_ALIAS
+    );
+  });
+
+  it("npm_lifecycle_event=build backstop stubs (parity with src/lib/buildPhase.ts)", () => {
+    assert.equal(shouldStubBetterSqlite3({ npm_lifecycle_event: "build" }), true);
+    assert.deepEqual(
+      betterSqlite3AliasFor({ npm_lifecycle_event: "build" }),
+      STUB_ALIAS
+    );
+  });
+
+  it("explicit OMNIROUTE_BUILDING=0 does NOT stub (off wins over the backstop)", () => {
+    assert.equal(shouldStubBetterSqlite3({ OMNIROUTE_BUILDING: "0" }), false);
+    assert.deepEqual(betterSqlite3AliasFor({ OMNIROUTE_BUILDING: "0" }), {});
+  });
+
+  it("NEXT_PHASE=phase-production-start does NOT stub (runtime phase)", () => {
+    assert.equal(shouldStubBetterSqlite3({ NEXT_PHASE: "phase-production-start" }), false);
+    assert.deepEqual(betterSqlite3AliasFor({ NEXT_PHASE: "phase-production-start" }), {});
+  });
+
+  it("stub wins when both build and non-build signals are mixed", () => {
+    assert.equal(
+      shouldStubBetterSqlite3({
+        OMNIROUTE_BUILDING: "1",
+        NEXT_PHASE: "phase-production-start",
+      }),
+      true
+    );
+  });
+
+  it("next.config.mjs derives the turbopack alias from the flag (no unconditional stub)", () => {
+    const config = readFileSync(new URL("../../../next.config.mjs", import.meta.url), "utf8");
+    assert.match(
+      config,
+      /betterSqlite3AliasFor/,
+      "next.config.mjs must use betterSqlite3AliasFor()"
+    );
+    assert.doesNotMatch(
+      config,
+      /^\s*"better-sqlite3":\s*"\.\/src\/lib\/db\/better-sqlite3\.stub\.js",?\s*$/m,
+      "next.config.mjs must not hardcode the better-sqlite3 stub alias"
+    );
+  });
+
+  it("serverExternalPackages keeps better-sqlite3 external for the runtime (real addon)", () => {
+    const config = readFileSync(new URL("../../../next.config.mjs", import.meta.url), "utf8");
+    assert.match(
+      config,
+      /serverExternalPackages:\s*\[[\s\S]*"better-sqlite3"/,
+      "better-sqlite3 must stay in serverExternalPackages so runtime uses the real addon"
+    );
+  });
+});

--- a/tests/unit/termux-android-cache-dir.test.ts
+++ b/tests/unit/termux-android-cache-dir.test.ts
@@ -179,6 +179,23 @@ test("isFatalInstrumentationHookFailure: BUG #10028 — generic non-Android inst
   assert.equal(isFatalInstrumentationHookFailure(genericWindowsFailure), false);
 });
 
+test("isFatalInstrumentationHookFailure: DB runtime error is not misreported as Android cache bug (#11343)", () => {
+  // #11343 runtime symptom: better-sqlite3 got bundled as the no-op stub and
+  // every DB op threw a minified constructor error. That must NOT trip the
+  // Android/Termux cache hint on desktop — the real cause is the driver, not
+  // `~/.cache`.
+  assert.equal(
+    isFatalInstrumentationHookFailure("TypeError: r(...) is not a constructor"),
+    false
+  );
+  assert.equal(
+    isFatalInstrumentationHookFailure(
+      "Error: An error occurred while loading instrumentation hook: TypeError: r(...) is not a constructor"
+    ),
+    false
+  );
+});
+
 test("formatAndroidInstrumentationFailureHint: names the cache dir and TERMUX_GUIDE", () => {
   const hint = formatAndroidInstrumentationFailureHint("/data/home/.cache");
   assert.match(hint, /\/data\/home\/\.cache/);


### PR DESCRIPTION
## Summary
- Fixes #11343: Next.js / Turbopack build unconditionally aliased `better-sqlite3` to `./src/lib/db/better-sqlite3.stub.js`, which caused the no-op stub to be bundled into the standalone production build and threw 500 errors (`r(...) is not a constructor`) on every database operation at runtime.
- Adds `scripts/build/better-sqlite3-stub-flag.mjs` mirroring the `mitm-stub-flag.mjs` pattern, gating the build-stub alias on explicit build signals (`OMNIROUTE_BUILDING=1`, `NEXT_PHASE=phase-production-build`, `npm_lifecycle_event=build`).
- At runtime, the alias is empty and `serverExternalPackages` keeps the real native addon external.
- Adds regression unit tests in `tests/unit/build/better-sqlite3-stub-flag-11343.test.mjs` and prevents DB runtime errors from being misreported as Android cache issues in `tests/unit/termux-android-cache-dir.test.ts`.

## Verification
- `node --test tests/unit/build/better-sqlite3-stub-flag-11343.test.mjs` (9/9 pass)
- `node --test tests/unit/termux-android-cache-dir.test.ts` (18/18 pass)
- Code-forge review: 2 consecutive clean cycles (PASS).
- ⚠️ base-red inherited: #9985