### PR TITLE
fix(sse): skip locked models in stored auto combos

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -630,7 +630,18 @@ export async function buildAutoCandidates(
   // Filter out candidates whose model is hidden by the user in the dashboard
   return candidates.filter((c) => {
     const hiddenModels = hiddenModelsMap.get(c.provider);
-    return !hiddenModels?.has(c.model);
+    if (hiddenModels?.has(c.model)) return false;
+
+    if (c.connectionId) {
+      return !isModelLocked(c.provider, c.connectionId, c.model);
+    }
+
+    const providerConnections = connectionsByProvider.get(c.provider) ?? [];
+    if (providerConnections.length === 0) return true;
+
+    return providerConnections.some((connection) =>
+      !isModelLocked(c.provider, String(connection.id ?? ""), c.model)
+    );
   });
 }
 

--- a/tests/unit/combo-account-allowlist-3266.test.ts
+++ b/tests/unit/combo-account-allowlist-3266.test.ts
@@ -26,6 +26,7 @@ const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const { buildAutoCandidates, handleComboChat } = await import("../../open-sse/services/combo.ts");
 const { getProviderCredentials } = await import("../../src/sse/services/auth.ts");
+const accountFallback = await import("../../open-sse/services/accountFallback.ts");
 const { normalizeComboStep } = await import("../../src/lib/combos/steps.ts");
 const { buildPrecisionComboModelStep } = await import("../../src/lib/combos/builderDraft.ts");
 
@@ -58,6 +59,7 @@ async function seedConn(name: string, tags?: string[]) {
 }
 
 test.beforeEach(async () => {
+  accountFallback.clearAllModelLockouts();
   await resetStorage();
 });
 
@@ -185,6 +187,57 @@ test("buildAutoCandidates expands dynamic auto steps only within allowedConnecti
   assert.deepEqual([...connectionIds].sort(), [foo1.id, foo2.id].sort());
   assert.ok(connectionIds.every((connectionId) => allowed.has(connectionId!)));
   assert.ok(connectionIds.every((connectionId) => !forbidden.has(connectionId!)));
+});
+
+test("buildAutoCandidates excludes active model lockouts from stored auto combos", async () => {
+  const locked = await seedConn("locked");
+  const available = await seedConn("available");
+  accountFallback.lockModel("openai", locked.id, "gpt-4o-mini", "rate_limited", 60_000);
+
+  const candidates = await buildAutoCandidates(
+    [
+      {
+        kind: "model",
+        stepId: "openai/gpt-4o-mini",
+        executionKey: "openai/gpt-4o-mini",
+        modelStr: "openai/gpt-4o-mini",
+        provider: "openai",
+        providerId: "openai",
+        connectionId: null,
+        weight: 1,
+        label: null,
+      },
+    ],
+    "auto-lockout"
+  );
+
+  assert.ok(candidates.some((candidate) => candidate.connectionId === available.id));
+  assert.ok(candidates.every((candidate) => candidate.connectionId !== locked.id));
+});
+
+test("buildAutoCandidates removes provider-level candidates only when every connection is locked", async () => {
+  const first = await seedConn("first");
+  const second = await seedConn("second");
+  accountFallback.lockModel("openai", first.id, "gpt-4o-mini", "rate_limited", 60_000);
+
+  const target = {
+    kind: "model" as const,
+    stepId: "openai/gpt-4o-mini",
+    executionKey: "openai/gpt-4o-mini",
+    modelStr: "openai/gpt-4o-mini",
+    provider: "openai",
+    providerId: "openai",
+    connectionId: null,
+    weight: 1,
+    label: null,
+  };
+
+  const partiallyAvailable = await buildAutoCandidates([target], "auto-partial-lockout");
+  assert.ok(partiallyAvailable.length > 0);
+
+  accountFallback.lockModel("openai", second.id, "gpt-4o-mini", "rate_limited", 60_000);
+  const fullyLocked = await buildAutoCandidates([target], "auto-full-lockout");
+  assert.deepEqual(fullyLocked, []);
 });
 
 // ── 3. Acceptance: the credential selector never escapes the allowlist ───────


### PR DESCRIPTION
## Problem

After a stored auto combo received a 429, its locked model could immediately score first again because stored-combo candidate construction did not consult active model lockouts. That caused tight retries against a model already known to be unavailable.

## Summary

- Exclude active per-connection model lockouts while scoring candidates for stored auto combos.
- Keep a provider-level candidate while any active provider connection is unlocked, and fail open when no active connections are enumerated.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: routing
- [x] Focused regression tests passed
- [x] `npm run check:known-symbols`
- [ ] `npm run lint`
- [x] Based on the current active release tip when created
- [x] Production-code changes include a new or updated automated test

- Focused candidate and hidden-model suites: 14 passed
- `npm run check:known-symbols`: passed
- Changed test file ESLint: passed

This remains a draft. Final repository lint/category results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/combo-account-allowlist-3266.test.ts`

## Coverage Notes

- Regression coverage exercises the reported failure and its availability/release boundary.
- No known touched-file coverage decrease.

## Reviewer Notes

- Uses the existing `isModelLocked` import and `connectionsByProvider` map; no additional query or dependency is introduced.
