### PR TITLE
fix(sse): enforce Retry-After limiter pauses

### DIFF
--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -100,6 +100,7 @@ export const ZAI_WEB_REQUEST_QUEUE_MAX_WAIT_MS = 60_000;
 
 const limiterEffectiveSettings = new WeakMap<Bottleneck, Bottleneck.ConstructorOptions>();
 const preservedReplacementSettings = new Map<string, Bottleneck.ConstructorOptions>();
+const limiterPauseTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const limiterWatchdog = new LimiterWedgeWatchdog({
   limiters,
   limiterLastUsed,
@@ -205,6 +206,56 @@ function updateAllLimiterSettings() {
   }
 }
 
+function clearLimiterPauseTimer(key: string): void {
+  const timer = limiterPauseTimers.get(key);
+  if (!timer) return;
+  clearTimeout(timer);
+  limiterPauseTimers.delete(key);
+}
+
+function clearLimiterPauseTimers(connectionId?: string): void {
+  for (const key of Array.from(limiterPauseTimers.keys())) {
+    if (connectionId === undefined || key.includes(connectionId)) {
+      clearLimiterPauseTimer(key);
+    }
+  }
+}
+
+function pauseLimiterUntil(
+  provider: string,
+  connectionId: string,
+  model: string | null,
+  limiter: Bottleneck,
+  retryAfterMs: number
+): void {
+  const key = getLimiterKey(provider, connectionId, model);
+  clearLimiterPauseTimer(key);
+  updateLimiterSettings(limiter, {
+    reservoir: 0,
+    reservoirRefreshAmount: null,
+    reservoirRefreshInterval: null,
+  });
+
+  const releaseTimer = setTimeout(() => {
+    limiterPauseTimers.delete(key);
+    if (limiters.get(key) !== limiter) return;
+
+    const defaults = buildLimiterDefaults();
+    const overrides = connectionRateLimitOverrides.get(connectionId);
+    const resumeRpm = resolveRpm(overrides?.rpm ?? defaults.reservoir);
+    const release = limiter.incrementReservoir(resumeRpm).then(() => {
+      if (limiters.get(key) !== limiter) return;
+      updateLimiterSettings(limiter, {
+        reservoirRefreshAmount: resumeRpm,
+        reservoirRefreshInterval: 60 * 1000,
+      });
+    });
+    trackAsyncOperation(release);
+  }, retryAfterMs);
+  releaseTimer.unref?.();
+  limiterPauseTimers.set(key, releaseTimer);
+}
+
 function clearPreservedReplacementSettings(connectionId: string): void {
   for (const key of preservedReplacementSettings.keys()) {
     if (key.includes(connectionId)) preservedReplacementSettings.delete(key);
@@ -302,6 +353,7 @@ function shutdownLimiters(): void {
   limiters.clear();
   limiterLastUsed.clear();
   preservedReplacementSettings.clear();
+  clearLimiterPauseTimers();
 }
 
 // Only register shutdown handlers when there are active limiters to shut down.
@@ -407,6 +459,7 @@ export function enableRateLimitProtection(connectionId) {
 export function disableRateLimitProtection(connectionId) {
   enabledConnections.delete(connectionId);
   clearPreservedReplacementSettings(connectionId);
+  clearLimiterPauseTimers(connectionId);
   // Ordinary administrative eviction uses disconnect(), not stop(), so
   // in-flight requests can finish. Wedge recovery is the deliberate exception:
   // it removes the limiter from the cache first, then stops it to settle jobs
@@ -445,6 +498,7 @@ export function refreshConnectionRateLimits(connectionId, overrides) {
     connectionRateLimitOverrides.set(connectionId, overrides);
   }
   clearPreservedReplacementSettings(connectionId);
+  clearLimiterPauseTimers(connectionId);
   // Evict limiters referencing this connection so they get recreated on next use
   for (const [key, limiter] of Array.from(limiters)) {
     if (key.includes(connectionId)) {
@@ -733,7 +787,11 @@ export function updateFromHeaders(provider, connectionId, headers, status, model
     limiterWatchdog.forget(limiter);
     limiterLastUsed.delete(limiterKey);
     preservedReplacementSettings.delete(limiterKey);
+    clearLimiterPauseTimer(limiterKey);
     trackAsyncOperation(limiter.disconnect());
+
+    const blockedLimiter = getLimiter(provider, connectionId, model);
+    pauseLimiterUntil(provider, connectionId, model, blockedLimiter, retryAfterMs);
     return;
   }
 
@@ -915,6 +973,7 @@ export async function __resetRateLimitManagerForTests() {
   initialized = false;
   limiterLastUsed.clear();
   preservedReplacementSettings.clear();
+  clearLimiterPauseTimers();
   limiterFactory = defaultLimiterFactory;
   limiterWatchdog.reset();
   shutdownHandlersRegistered = false;
@@ -1023,10 +1082,6 @@ export function updateFromResponseBody(provider, connectionId, responseBody, sta
       `🚫 [RATE-LIMIT] ${provider}:${connectionId.slice(0, 8)} — body-parsed retry: ${Math.ceil(retryAfterMs / 1000)}s (${reason})`
     );
 
-    updateLimiterSettings(limiter, {
-      reservoir: 0,
-      reservoirRefreshAmount: 60,
-      reservoirRefreshInterval: retryAfterMs,
-    });
+    pauseLimiterUntil(provider, connectionId, model, limiter, retryAfterMs);
   }
 }

--- a/tests/unit/rate-limit-manager.test.ts
+++ b/tests/unit/rate-limit-manager.test.ts
@@ -766,12 +766,71 @@ test("rate limit manager handles soft over-limit warnings and normal header lear
   assert.ok(allStatuses["claude:conn-high-remaining"]);
 });
 
+test("header-derived Retry-After blocks dispatch until the deadline", async () => {
+  const connectionId = "conn-header-pause";
+  rateLimitManager.enableRateLimitProtection(connectionId);
+  rateLimitManager.updateFromHeaders(
+    "openai",
+    connectionId,
+    { "retry-after": "100ms" },
+    429,
+    "gpt-4o"
+  );
+
+  let dispatched = false;
+  const pending = rateLimitManager.withRateLimit(
+    "openai",
+    connectionId,
+    "gpt-4o",
+    async () => {
+      dispatched = true;
+      return "released";
+    }
+  );
+
+  await wait(30);
+  assert.equal(dispatched, false);
+  assert.equal(await Promise.race([pending, wait(300).then(() => "timed-out")]), "released");
+});
+
+test("body-derived retry hints block dispatch until the deadline", async () => {
+  const connectionId = "conn-body-pause";
+  rateLimitManager.enableRateLimitProtection(connectionId);
+  rateLimitManager.updateFromResponseBody(
+    "openai",
+    connectionId,
+    { error: { details: [{ retryDelay: "100ms" }] } },
+    429,
+    "gpt-4o"
+  );
+
+  let dispatched = false;
+  const pending = rateLimitManager.withRateLimit(
+    "openai",
+    connectionId,
+    "gpt-4o",
+    async () => {
+      dispatched = true;
+      return "released";
+    }
+  );
+
+  await wait(30);
+  assert.equal(dispatched, false);
+  assert.equal(await Promise.race([pending, wait(300).then(() => "timed-out")]), "released");
+});
+
 test("rate limit manager handles 429 limiter teardown and disable cleanup", async () => {
   rateLimitManager.enableRateLimitProtection("conn-429");
   rateLimitManager.updateFromHeaders("openai", "conn-429", { "retry-after": "1s" }, 429, "gpt-4o");
   await wait(25);
 
-  assert.equal(rateLimitManager.getRateLimitStatus("openai", "conn-429").active, false);
+  const pausedState = await rateLimitManager.__getLimiterStateForTests(
+    "openai",
+    "conn-429",
+    "gpt-4o"
+  );
+  assert.equal(pausedState?.reservoir, 0);
 
   rateLimitManager.enableRateLimitProtection("conn-disable");
   rateLimitManager.updateFromHeaders(


### PR DESCRIPTION
## Problem

The 429 header path logged a Retry-After pause but only evicted its limiter. The next request created a fresh limiter with full capacity and could dispatch immediately; body-derived pauses could also wedge when relying on a dynamically installed refresh heartbeat.

## Summary

- Block replacement limiters for the full Retry-After window after a 429.
- Use the same explicit, identity-guarded release timer for header- and body-derived hints, restoring configured capacity at the deadline.

## Related Issues

- Related to #9985 (inherited `release/v3.8.50` base status; not caused by this patch)

## Validation

- [x] Change type: routing
- [x] Focused regression tests passed
- [x] `npm run check:known-symbols`
- [ ] `npm run lint`
- [x] Based on the current active release tip when created
- [x] Production-code changes include a new or updated automated test

- Focused rate-limit suites: 32 passed
- `npm run check:known-symbols`: passed
- `git diff --check`: passed

This remains a draft. Final repository lint/category results will be recorded before review.

## Tests Added Or Updated

- `tests/unit/rate-limit-manager.test.ts`

## Coverage Notes

- Regression coverage exercises the reported failure and its availability/release boundary.
- No known touched-file coverage decrease.

## Reviewer Notes

- Pause timers are cleared during shutdown, disable, connection refresh, and test reset; stale timers cannot modify a replaced limiter.
