### PR TITLE
feat(sse): add glm-5.3-max explicit effort tier

### DIFF
--- a/open-sse/config/glmProvider.ts
+++ b/open-sse/config/glmProvider.ts
@@ -49,6 +49,17 @@ export const GLM_SHARED_MODELS = Object.freeze([
     supportedThinkingEfforts: ["low"],
   },
   {
+    // Explicit alias for the upstream default (max) — pins reasoning_effort so
+    // the tier survives an upstream default change, and mirrors glm-5.2-max UX.
+    id: "glm-5.3-max",
+    name: "GLM 5.3 Max",
+    contextLength: 1000000,
+    maxOutputTokens: 131072,
+    toolCalling: true,
+    supportsReasoning: true,
+    supportedThinkingEfforts: ["max"],
+  },
+  {
     // GLM-5.2 has two positive effective tiers: low/medium map to high and xhigh
     // maps to max; disabling thinking remains the separate thinking toggle.
     // https://docs.z.ai/guides/capabilities/thinking

--- a/open-sse/executors/glm.ts
+++ b/open-sse/executors/glm.ts
@@ -85,6 +85,8 @@ function parseGlmEffortTier(model: string): GlmEffortTier | null {
       return { baseModel: "glm-5.3", effort: "high", transport: "openai" };
     case "glm-5.3-low":
       return { baseModel: "glm-5.3", effort: "low", transport: "openai" };
+    case "glm-5.3-max":
+      return { baseModel: "glm-5.3", effort: "max", transport: "openai" };
     default:
       return null;
   }

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -70,6 +70,7 @@ const AUTHORITATIVE_CONTEXT_WINDOW_MODEL_IDS = new Set([
   "glm-5.3",
   "glm-5.3-high",
   "glm-5.3-low",
+  "glm-5.3-max",
   "glm-5.2",
   "glm-5.2-high",
   "glm-5.2-max",
@@ -567,6 +568,13 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     supportsTools: true,
   },
   "glm-5.3-low": {
+    maxOutputTokens: 131072,
+    contextWindow: 1000000,
+    thinkingBudgetCap: 38912,
+    supportsThinking: true,
+    supportsTools: true,
+  },
+  "glm-5.3-max": {
     maxOutputTokens: 131072,
     contextWindow: 1000000,
     thinkingBudgetCap: 38912,

--- a/src/shared/constants/pricing/shared-tiers.ts
+++ b/src/shared/constants/pricing/shared-tiers.ts
@@ -135,6 +135,13 @@ export const GLM_PRICING = {
     reasoning: 5,
     cache_creation: 1.2,
   },
+  "glm-5.3-max": {
+    input: 1.2,
+    output: 5,
+    cached: 0.3,
+    reasoning: 5,
+    cache_creation: 1.2,
+  },
   "glm-5.2": {
     input: 1.2,
     output: 5,

--- a/tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts
+++ b/tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts
@@ -22,7 +22,7 @@ const metadataRegistry = await import("../../src/lib/modelMetadataRegistry.ts");
 const { shouldExposeSyncedEffortVariants, SYNCED_EFFORT_SKIP_PROVIDERS } =
   await import("../../open-sse/utils/syncedEffortVariants.ts");
 
-const GLM_5_3_IDS = ["glm-5.3", "glm-5.3-high", "glm-5.3-low"] as const;
+const GLM_5_3_IDS = ["glm-5.3", "glm-5.3-high", "glm-5.3-low", "glm-5.3-max"] as const;
 
 // transformForTransport returns an opaque body; surface only the fields asserted below.
 type TransformedRequest = {
@@ -99,6 +99,7 @@ test("catalog exposes only GLM effort tiers that each provider can route", () =>
     ["glm-5.3", ["low", "high", "max"]],
     ["glm-5.3-high", ["high"]],
     ["glm-5.3-low", ["low"]],
+    ["glm-5.3-max", ["max"]],
     ["glm-5.2", ["high", "max"]],
     ["glm-5.2-high", ["high"]],
     ["glm-5.2-max", ["max"]],
@@ -119,7 +120,6 @@ test("catalog exposes only GLM effort tiers that each provider can route", () =>
     }
   }
 });
-
 for (const provider of ["glm", "glm-cn", "glmt"]) {
   test(`${provider} advertises the GLM-5.3 base model and effort tiers (GLM_SHARED_MODELS)`, () => {
     const ids = modelIds(provider);
@@ -142,7 +142,7 @@ for (const provider of ["glm", "glm-cn", "glmt"]) {
 test("zai advertises the GLM-5.3 base model only (DefaultExecutor sends ids verbatim)", () => {
   const ids = modelIds("zai");
   assert.ok(ids.includes("glm-5.3"), `zai should advertise glm-5.3; got ${ids.join(", ")}`);
-  for (const alias of ["glm-5.3-high", "glm-5.3-low"]) {
+  for (const alias of ["glm-5.3-high", "glm-5.3-low", "glm-5.3-max"]) {
     assert.ok(
       !ids.includes(alias),
       `zai must not list ${alias}: GlmExecutor-only alias, unknown upstream on the Anthropic endpoint`
@@ -200,6 +200,20 @@ test("GlmExecutor resolves glm-5.3-low to reasoning_effort=low with thinking ena
   assert.equal(transformed.thinking?.type, "enabled");
 });
 
+test("GlmExecutor resolves glm-5.3-max to an explicit reasoning_effort=max (pins the tier even if the upstream default changes)", () => {
+  const executor = new GlmExecutor("glm");
+  const transformed = executor.transformForTransport(
+    "glm-5.3-max",
+    { messages: [{ role: "user", content: "hi" }] },
+    false,
+    { apiKey: "glm-key" },
+    "openai"
+  ) as TransformedRequest;
+
+  assert.equal(transformed.model, "glm-5.3");
+  assert.equal(transformed.reasoning_effort, "max");
+  assert.equal(transformed.thinking?.type, "enabled");
+});
 test("GlmExecutor leaves base glm-5.3 without an injected reasoning_effort (upstream default = max)", () => {
   const executor = new GlmExecutor("glm");
   const transformed = executor.transformForTransport(


### PR DESCRIPTION
## What

Adds an explicit `glm-5.3-max` model alias for GLM-5.3, mirroring the existing `glm-5.2-max` UX.

## Why

GLM-5.3's `reasoning_effort` accepts `low|high|max` (upstream default `max`), but only `-high`/`-low` had OmniRoute aliases — base `glm-5.3` silently depended on the upstream default staying `max`. `glm-5.3-max` pins the tier explicitly so it survives an upstream default change and lets clients request max deliberately.

## Changes

- `open-sse/config/glmProvider.ts` — `glm-5.3-max` entry in `GLM_SHARED_MODELS` (1M ctx / 128K out / `supportedThinkingEfforts: ["max"]`)
- `open-sse/executors/glm.ts` — `parseGlmEffortTier` resolves `glm-5.3-max` → `reasoning_effort: "max"` on the OpenAI coding transport
- `src/shared/constants/modelSpecs.ts` — spec entry + `AUTHORITATIVE_CONTEXT_WINDOW_MODEL_IDS` membership
- `src/shared/constants/pricing/shared-tiers.ts` — glm-5.2-parity rates
- `tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts` — catalog/pricing/specs coverage, zai verbatim-id guard, executor transform test; upstream `routedTiers` fixture extended with `["max"]`

## Test evidence

- `tests/unit/glm-5.3-catalog-and-effort-tiers.test.ts` + `tests/unit/zai-catalog-glm52.test.ts`: 23/23 pass
- Coverage gate (`npm run test:coverage`): running — result will be posted in a comment
