### PR TITLE
fix(sse): limit exploitation to equivalent candidates

### DIFF
--- a/changelog.d/fixes/11420-auto-equivalent-rotation.md
+++ b/changelog.d/fixes/11420-auto-equivalent-rotation.md
@@ -1,0 +1,1 @@
+- **fix(sse):** Keep normal Auto-Combo exploitation within the highest-score equivalence tier while preserving load balancing across equivalent candidates ([#11420](https://github.com/diegosouzapw/OmniRoute/pull/11420)) — thanks @jacobsparts

--- a/open-sse/services/autoCombo/engine.ts
+++ b/open-sse/services/autoCombo/engine.ts
@@ -93,6 +93,8 @@ function tierPreferencesForName(name: string): Record<TierName, number> {
 }
 
 const SCORE_EPSILON = 1e-4;
+// Keep load balancing for candidates whose normalized scores differ by at most one point.
+const EXPLOITATION_EQUIVALENCE_THRESHOLD = 0.01;
 const CLEAR_WINNER_THRESHOLD = 0.1;
 
 class ScoreTierRotator {
@@ -301,8 +303,12 @@ export function selectProvider(
     const idx = Math.floor(Math.random() * candidates_.length);
     selected = candidates_[idx];
   } else {
+    const bestScore = candidates_[0].score;
+    const equivalentCandidates = candidates_.filter(
+      (candidate) => bestScore - candidate.score <= EXPLOITATION_EQUIVALENCE_THRESHOLD
+    );
     const rotator = getRotator(config.name);
-    selected = rotator.pick(candidates_);
+    selected = rotator.pick(equivalentCandidates);
   }
 
   // Budget cap enforcement

--- a/tests/unit/autoCombo/tieredRotation.test.ts
+++ b/tests/unit/autoCombo/tieredRotation.test.ts
@@ -123,24 +123,60 @@ describe("Tiered Rotation in selectProvider", () => {
     expect(seen.has("openai/gpt-4o") || seen.has("anthropic/claude-opus")).toBe(true);
   });
 
-  it("cheap combo pulls from rest tier (lower scores) more often than smart", () => {
-    const top = makeCandidate({ provider: "openai", model: "gpt-4o", quotaRemaining: 100 });
-    const rest = makeCandidate({
-      provider: "cheap-provider",
-      model: "cheap-model",
+  it("zero-exploration selection never leaves the highest-score equivalence tier", () => {
+    const top = makeCandidate({
+      provider: "openai",
+      model: "gpt-4o",
       quotaRemaining: 100,
-      costPer1MTokens: 0,
-      p95LatencyMs: 5000,
+      p95LatencyMs: 900,
     });
-    const pool = [top, rest];
+    const lower = makeCandidate({
+      provider: "mistral",
+      model: "mistral-large",
+      quotaRemaining: 97,
+      p95LatencyMs: 1000,
+    });
+    const pool = [top, lower];
+    const scored = scorePool(pool, "coding", DEFAULT_WEIGHTS, getTaskFitness);
+    expect(scored[0].score).toBeGreaterThan(scored[1].score);
+    expect(scored[0].score - scored[1].score).toBeLessThan(0.1);
 
     const config = makeConfig("cheap");
-    const counts: Record<string, number> = {};
-    for (let i = 0; i < 200; i++) {
-      const result = selectProvider(config, pool, "coding");
-      counts[result.provider] = (counts[result.provider] ?? 0) + 1;
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
+    try {
+      for (let i = 0; i < 20; i++) {
+        const result = selectProvider(config, pool, "coding");
+        expect(result.isExploration).toBe(false);
+        expect(result.provider).toBe(scored[0].provider);
+        expect(result.model).toBe(scored[0].model);
+      }
+    } finally {
+      randomSpy.mockRestore();
     }
-    expect(counts["cheap-provider"]).toBeGreaterThan(0);
+  });
+
+  it("explicit exploration can still select a lower-scored candidate", () => {
+    const top = makeCandidate({
+      provider: "openai",
+      model: "gpt-4o",
+      quotaRemaining: 100,
+      p95LatencyMs: 900,
+    });
+    const lower = makeCandidate({
+      provider: "mistral",
+      model: "mistral-large",
+      quotaRemaining: 97,
+      p95LatencyMs: 1000,
+    });
+    const config = { ...makeConfig("cheap"), explorationRate: 1 };
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.99);
+    try {
+      const result = selectProvider(config, [top, lower], "coding");
+      expect(result.isExploration).toBe(true);
+      expect(result.provider).toBe("mistral");
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it("single-candidate pool always returns the same candidate", () => {


### PR DESCRIPTION
## Problem

With exploration disabled, Auto-Combo could still rotate from the highest-scored candidate into a materially lower-scored tier. In simple terms, the scoring engine identified the better target and ordinary exploitation then discarded that result.

This is a narrower replacement for #11406. It does **not** remove `ScoreTierRotator` or concentrate all traffic on one connection. Candidates whose normalized scores are within one point (`0.01`) of the winner remain in the rotation pool, preserving load balancing across equivalent providers and connection IDs.

## Summary

- restrict non-exploratory rotation to candidates within `0.01` of the best score
- preserve round-robin across tied and near-equivalent connections
- leave explicit exploration able to select lower-scored candidates
- leave budget-cap fallback behavior unchanged

The boundary is evidence-based in the regression fixtures: the existing intended smart rotation spans a `0.005621` score gap, while the reproduced incorrect lower-tier choice has a `0.027147` gap.

## Tests

- [x] Regression failed against unmodified `release/v3.8.50`
- [x] `npx vitest run --config vitest.mcp.config.ts tests/unit/autoCombo/tieredRotation.test.ts` — 12 passed
- [x] `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/auto-combo-engine.test.ts` — 4 passed
- [x] focused suppression-aware ESLint — passed
- [x] `git diff --check` — passed
- [x] `npm run check:known-symbols` — passed

Repository-wide lint is currently blocked by inherited base-red issue #9985; the changed files pass the repository's suppression-aware focused lint.

## Scope

Production code changes are limited to `open-sse/services/autoCombo/engine.ts`; the focused regression is in `tests/unit/autoCombo/tieredRotation.test.ts`.

⚠️ base-red inherited: #9985
