### PR TITLE
fix(quality): drain the two Fast Quality Gates base-reds (lockfile + mutation coverage)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25590,7 +25590,7 @@
     },
     "node_modules/libxmljs2/node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -325,6 +325,8 @@
       "tests/unit/repro-9486.test.ts",
       "tests/unit/repro-9630-combo-false-503.test.ts",
       "tests/unit/repro-antigravity-404-family-cooldown-hijack.test.ts",
+      "tests/unit/repro-combo-persisted-cooldown-preskip.test.ts",
+      "tests/unit/repro-glm-iso-reset-24h-cap.test.ts",
       "tests/unit/resilience-connections.test.ts",
       "tests/unit/responses-handler.test.ts",
       "tests/unit/responses-passthrough-openai-compatible.test.ts",


### PR DESCRIPTION
Drains the two gates that have been failing `Fast Quality Gates` on **every** open PR against `release/v3.8.50`:

```
2 gate(s) failed: mutation-test-coverage lockfile
```

Neither belongs to any feature branch, so per the base-red doctrine they are fixed here rather than inside someone's PR.

## `check:lockfile`

```
detected invalid host(s) for package: brace-expansion@2.1.4
    expected: registry.npmjs.org
    actual:   registry.npmmirror.com
```

A transitive **dev + optional** entry (`libxmljs2` → `brace-expansion@2.1.4`) landed with a `resolved` URL pointing at the npmmirror registry, which `lockfile-lint` rejects as a supply-chain policy violation.

**Checked before touching it** — the recorded `integrity` is byte-identical to the official npmjs tarball's:

```
sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
```

So the package *content* is the same one npmjs serves. This is a provenance slip — an install that ran behind the mirror registry, and the lockfile carried the URL back — not a tampered package. Repointed the URL; `integrity` untouched.

It was the only non-npmjs host in the file (2690 `registry.npmjs.org` entries, 1 mirror).

## `check:mutation-test-coverage`

Two covering unit tests were missing from `stryker.conf.json`'s `tap.testFiles`, so their mutant kills did not count:

| Mutated module | Missing test |
| --- | --- |
| `open-sse/services/accountFallback.ts` | `tests/unit/repro-glm-iso-reset-24h-cap.test.ts` |
| `open-sse/services/combo/comboPredicates.ts` | `tests/unit/repro-combo-persisted-cooldown-preskip.test.ts` |

Inserted in place.

## Validation

- `check:lockfile` — `✔ No issues detected`
- `check:mutation-test-coverage --strict` — `✓ No drift — every covering unit test is listed in tap.testFiles`
- `check:tracked-artifacts`, `prettier --check` — PASS

The whole diff is **three lines**. A first attempt re-serialized `stryker.conf.json` through a JSON round-trip and the sort silently reordered ~10 curated entries that were already out of alphabetical order; that was thrown away and redone as an in-place insert. Worth knowing if you ever automate edits to that file.

## Not fixed here

`stryker.conf.json` has a pre-existing duplicate entry (`tests/unit/aihorde-optional-api-key.test.ts` appears twice). Harmless and out of scope for a base-red drain — flagging it rather than folding it in.

The other `release/v3.8.50` base-reds are untouched by this PR: openapi-coverage ratchet, `route-body-validation-t06` (volcengine-plan routes), the "350 providers" doc-count drift, ESLint stale suppressions, and the unit-shard failures tracked under #9985.
