### PR TITLE
fix(providers): send Responses API payload during OpenAI-compatible validation

### DIFF
--- a/src/lib/providers/validation/openaiFormat.ts
+++ b/src/lib/providers/validation/openaiFormat.ts
@@ -410,16 +410,24 @@ export async function validateOpenAICompatibleProvider({ apiKey, providerSpecifi
   const chatSuffix = apiType === "responses" ? "/responses" : "/chat/completions";
   const chatUrl = `${baseUrl}${chatSuffix}`;
   const testModelId = validationModelId;
+  const testBody =
+    apiType === "responses"
+      ? {
+          model: testModelId,
+          input: [{ role: "user", content: "test" }],
+          max_output_tokens: 1,
+        }
+      : {
+          model: testModelId,
+          messages: [{ role: "user", content: "test" }],
+          max_tokens: 1,
+        };
 
   try {
     const chatRes = await validationWrite(chatUrl, {
       method: "POST",
       headers: buildBearerHeaders(apiKey, providerSpecificData),
-      body: JSON.stringify({
-        model: testModelId,
-        messages: [{ role: "user", content: "test" }],
-        max_tokens: 1,
-      }),
+      body: JSON.stringify(testBody),
     });
 
     if (chatRes.ok) {

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -16,7 +16,6 @@ const { __setTlsFetchOverrideForTesting: __setPplxTlsFetchOverride } =
 const { __setTlsFetchOverrideForTesting: __setGrokTlsFetchOverride } =
   await import("../../open-sse/services/grokTlsClient.ts");
 
-
 const originalFetch = globalThis.fetch;
 
 test.afterEach(() => {
@@ -1232,9 +1231,13 @@ test("local OpenAI-style providers validate without sending Authorization when a
 });
 
 test("OpenAI-compatible validator covers /responses mode and final ping fallback", async () => {
-  const calls = [];
+  const calls: Array<{ url: string; method: string; body: string | undefined }> = [];
   globalThis.fetch = async (url, init = {}) => {
-    calls.push({ url: String(url), method: init.method || "GET" });
+    calls.push({
+      url: String(url),
+      method: init.method || "GET",
+      body: typeof init.body === "string" ? init.body : undefined,
+    });
     if (String(url).endsWith("/models")) {
       return new Response(JSON.stringify({ error: "no models" }), { status: 500 });
     }
@@ -1282,6 +1285,11 @@ test("OpenAI-compatible validator covers /responses mode and final ping fallback
     calls.map((call) => call.url),
     ["https://openai-like.example.com/v1/models", "https://openai-like.example.com/v1/responses"]
   );
+  const responsesBody = JSON.parse(calls[1].body || "{}");
+  assert.deepEqual(responsesBody.input, [{ role: "user", content: "test" }]);
+  assert.equal(responsesBody.max_output_tokens, 1);
+  assert.equal(responsesBody.messages, undefined);
+  assert.equal(responsesBody.max_tokens, undefined);
   assert.equal(pingFallback.valid, true);
   assert.equal(pingFallback.error, null);
 });


### PR DESCRIPTION
## Summary
- Fixes the OpenAI-compatible **Test Connection** probe for Responses API: it posted Chat Completions fields (`messages`, `max_tokens`) to `/responses`.
- Sends `input` and `max_output_tokens` when `apiType === "responses"`. Chat Completions mode is unchanged.
- Adds regression assertions on the `/responses` probe body.

Fixes #11453

⚠️ base-red inherited: #11449

Target is `release/v3.8.51` (active development branch). Freeze #11439 applies to `release/v3.8.50` only.

## Test plan
- [x] `node --import tsx/esm --test tests/unit/provider-validation-specialty.test.ts` (123 passed)
- [x] Dashboard: Providers → OpenAI Compatible Details → API type Responses → Test Connection succeeds without `Unsupported parameter: 'messages'`
- [x] Chat Completions API type still validates with `messages` / `max_tokens`