### PR TITLE
fix(ui): wrap quota card footer action buttons to prevent clipping Refresh button on narrow cards

### DIFF
--- a/changelog.d/fixes/quota-card-footer-flex-wrap.md
+++ b/changelog.d/fixes/quota-card-footer-flex-wrap.md
@@ -1,0 +1,1 @@
+- fix(ui): wrap quota card footer action buttons to prevent clipping Refresh button on narrow cards — when extra action buttons such as `View credits` are present on Codex cards, allow the footer row to flex-wrap with `shrink-0` buttons so `Refresh now` remains visible and clickable across all responsive card widths

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx
@@ -418,10 +418,10 @@ export default function QuotaCardExpanded({
         </button>
       )}
 
-      <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-border/40">
+      <div className="flex flex-wrap items-center justify-between gap-1.5 pt-1.5 border-t border-border/40">
         {refreshedLabel && (
           <span
-            className={`text-[10px] tabular-nums ${
+            className={`text-[10px] tabular-nums shrink-0 ${
               hasStaleData ? "text-amber-500" : "text-text-muted"
             }`}
             title={
@@ -433,7 +433,7 @@ export default function QuotaCardExpanded({
             {tr("updatedShort", "Updated")} {refreshedLabel}
           </span>
         )}
-        <div className="flex items-center gap-1.5 ml-auto">
+        <div className="flex flex-wrap items-center justify-end gap-1.5 ml-auto">
           {canRedeemResetCredit && (
             <button
               type="button"
@@ -442,7 +442,7 @@ export default function QuotaCardExpanded({
                 e.stopPropagation();
                 onOpenResetCredits?.();
               }}
-              className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-primary/40 text-primary bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+              className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-primary/40 text-primary bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
             >
               <span
                 className={`material-symbols-outlined text-[12px] ${
@@ -461,7 +461,7 @@ export default function QuotaCardExpanded({
               e.stopPropagation();
               onOpenCutoff();
             }}
-            className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer ${
+            className={`inline-flex shrink-0 items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer ${
               hasCutoffOverrides ? "border-primary/40 text-primary" : "border-border"
             }`}
           >
@@ -474,7 +474,7 @@ export default function QuotaCardExpanded({
               e.stopPropagation();
               onOpenCost();
             }}
-            className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] cursor-pointer"
+            className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] cursor-pointer"
           >
             <span className="material-symbols-outlined text-[12px]">bar_chart</span>
             {t("usdCost")}
@@ -486,7 +486,7 @@ export default function QuotaCardExpanded({
               e.stopPropagation();
               onRefresh();
             }}
-            className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
           >
             <span
               className={`material-symbols-outlined text-[12px] ${loading ? "animate-spin" : ""}`}

--- a/tests/unit/quota-card-expanded-footer-flex-wrap.test.ts
+++ b/tests/unit/quota-card-expanded-footer-flex-wrap.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const COMPONENT_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx"
+);
+
+test("QuotaCardExpanded footer enables flex-wrap to prevent action button clipping", () => {
+  const content = fs.readFileSync(COMPONENT_PATH, "utf8");
+
+  // Assert footer container has flex-wrap and border-t
+  assert.match(
+    content,
+    /className="[^"]*flex\s+flex-wrap[^"]*border-t[^"]*"/,
+    "Footer container must include flex-wrap to allow wrapping on narrow cards"
+  );
+
+  // Assert buttons container has flex-wrap
+  assert.match(
+    content,
+    /className="[^"]*flex\s+flex-wrap[^"]*ml-auto[^"]*"/,
+    "Action buttons container must include flex-wrap to prevent pushing Refresh now button off-screen"
+  );
+
+  // Assert Refresh now button has shrink-0
+  assert.ok(
+    content.includes("inline-flex shrink-0 items-center gap-1 text-[11px] font-medium") &&
+      content.includes('tr("forceRefresh", "Refresh now")'),
+    "Action buttons must include shrink-0 to prevent compression"
+  );
+});


### PR DESCRIPTION
### Summary

Resolves an issue where the `Refresh now` button in `QuotaCardExpanded` becomes clipped and invisible on narrow card layouts (e.g. 4–5 cards per row on wider viewports or compact grids) when an account has reset credits available (`canRedeemResetCredit === true`).

#### 1. Root Cause
- When an account (e.g. OpenAI Codex) has reset credits enabled, an extra `View credits` button is rendered in the card footer alongside `Edit cutoffs`, `USD Cost`, and `Refresh now`.
- The footer row container and button wrapper lacked `flex-wrap`, causing the 4-button group plus the timestamp label to exceed the card width (~240px) and overflow past the right boundary.
- Because the outer `<Card>` component specifies `overflow-hidden`, the trailing `Refresh now` action button was pushed off-screen and clipped.

#### 2. Fix
- Added `flex-wrap` and `justify-between` / `justify-end` to the footer container and action button group in `src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx`.
- Added `shrink-0` to all action buttons to prevent button text distortion.
- Ensures all action buttons wrap cleanly onto an additional row on narrow cards so `Refresh now` remains 100% visible and clickable.

### Verification
- `npx tsx --test tests/unit/quota-card-expanded-footer-flex-wrap.test.ts` (PASS)
- `npx tsx --test tests/unit/quota-card-expanded-sort-collapse.test.ts` (PASS)
- `npx tsx --test tests/unit/quota-card-grid-mobile-7072.test.ts` (PASS)
