### PR TITLE
fix(bun): use native bun:sqlite during startup to avoid N-API crash

### DIFF
--- a/bin/cli/runtime/sqliteRuntime.mjs
+++ b/bin/cli/runtime/sqliteRuntime.mjs
@@ -26,6 +26,17 @@ let resolvedCached = null;
 export async function loadSqliteRuntime() {
   if (resolvedCached) return resolvedCached;
 
+  if (process.versions.bun) {
+    try {
+      const bunSqlite = await import("bun:sqlite");
+      resolvedCached = {
+        driver: { kind: "bun-sqlite", Database: bunSqlite.Database },
+        source: "bun-sqlite",
+      };
+      return resolvedCached;
+    } catch {}
+  }
+
   const bundled = await tryLoadBundled();
   if (bundled) {
     resolvedCached = { driver: bundled, source: "bundled" };

--- a/changelog.d/fixes/11440-bun-sqlite-startup.md
+++ b/changelog.d/fixes/11440-bun-sqlite-startup.md
@@ -1,0 +1,1 @@
+- **fix(bun):** use native `bun:sqlite` in `bootstrap-env` and `sync-env` to avoid loading `better-sqlite3` N-API addon during Bun startup ([#11440](https://github.com/diegosouzapw/OmniRoute/pull/11440)) — thanks @TheDemonTuan

--- a/changelog.d/fixes/11440-bun-sqlite-startup.md
+++ b/changelog.d/fixes/11440-bun-sqlite-startup.md
@@ -1,1 +1,0 @@
-- **fix(bun):** use native `bun:sqlite` in `bootstrap-env` and `sync-env` to avoid loading `better-sqlite3` N-API addon during Bun startup ([#11440](https://github.com/diegosouzapw/OmniRoute/pull/11440)) — thanks @TheDemonTuan

--- a/changelog.d/fixes/11468-bun-sqlite-startup.md
+++ b/changelog.d/fixes/11468-bun-sqlite-startup.md
@@ -1,0 +1,1 @@
+- **fix(bun):** use native `bun:sqlite` in `bootstrap-env` and `sync-env` to avoid loading `better-sqlite3` N-API addon during Bun startup ([#11468](https://github.com/diegosouzapw/OmniRoute/pull/11468)) — thanks @TheDemonTuan

--- a/scripts/build/bootstrap-env.mjs
+++ b/scripts/build/bootstrap-env.mjs
@@ -82,6 +82,32 @@ function hasEncryptedCredentials(dataDir) {
   const dbPath = join(dataDir, "storage.sqlite");
   if (!existsSync(dbPath)) return false;
 
+  if (process.versions.bun) {
+    try {
+      const { Database } = require("bun:sqlite");
+      const db = new Database(dbPath, { readonly: true, create: false });
+      try {
+        const row = db
+          .query(
+            `SELECT 1
+               FROM provider_connections
+              WHERE access_token LIKE 'enc:v1:%'
+                 OR refresh_token LIKE 'enc:v1:%'
+                 OR api_key LIKE 'enc:v1:%'
+                 OR id_token LIKE 'enc:v1:%'
+              LIMIT 1`
+          )
+          .get();
+        return !!row;
+      } finally {
+        db.close();
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Unable to inspect existing database at ${dbPath}: ${message}`);
+    }
+  }
+
   try {
     const Database = require("better-sqlite3");
     const db = new Database(dbPath, { readonly: true, fileMustExist: true });

--- a/scripts/dev/sync-env.mjs
+++ b/scripts/dev/sync-env.mjs
@@ -93,12 +93,38 @@ function hasEncryptedCredentials(dataDir) {
   const dbPath = join(dataDir, "storage.sqlite");
   if (!existsSync(dbPath)) return false;
 
+  const require = createRequire(import.meta.url);
+
+  if (process.versions.bun) {
+    try {
+      const { Database } = require("bun:sqlite");
+      const db = new Database(dbPath, { readonly: true, create: false });
+      try {
+        const row = db
+          .query(
+            `SELECT 1
+               FROM provider_connections
+              WHERE access_token LIKE 'enc:v1:%'
+                 OR refresh_token LIKE 'enc:v1:%'
+                 OR api_key LIKE 'enc:v1:%'
+                 OR id_token LIKE 'enc:v1:%'
+              LIMIT 1`
+          )
+          .get();
+        return !!row;
+      } finally {
+        db.close();
+      }
+    } catch {
+      return false;
+    }
+  }
+
   try {
     // Resolve `require` lazily here (not at module top-level): when this file is
     // bundled into a standalone route, a top-level `createRequire(import.meta.url)`
     // throws during module evaluation and 500s the whole route (#5006). Inside this
     // guarded block, any failure simply returns false (the safe default below).
-    const require = createRequire(import.meta.url);
     const Database = require("better-sqlite3");
     const db = new Database(dbPath, { readonly: true, fileMustExist: true });
     try {

--- a/tests/unit/db-adapters/bunSqliteAdapter.test.ts
+++ b/tests/unit/db-adapters/bunSqliteAdapter.test.ts
@@ -81,3 +81,15 @@ test("bun:sqlite adapter backs up on-disk databases without serializing them", a
   assert.deepEqual(execCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
   assert.equal(fs.readFileSync(destinationPath, "utf8"), sourceContents);
 });
+
+test("loadSqliteRuntime prioritizes bun:sqlite under Bun without loading better-sqlite3", async (t) => {
+  if (!process.versions.bun) {
+    t.skip("bun:sqlite is only available under Bun");
+    return;
+  }
+
+  const { loadSqliteRuntime } = await import("../../../bin/cli/runtime/sqliteRuntime.mjs");
+  const runtime = await loadSqliteRuntime();
+  assert.equal(runtime.driver.kind, "bun-sqlite");
+  assert.equal(runtime.source, "bun-sqlite");
+});


### PR DESCRIPTION
## Summary

Avoids loading the `better-sqlite3` native Node-API `.node` binary during Bun startup in `bootstrap-env.mjs`, `sync-env.mjs`, and `sqliteRuntime.mjs`. When running under Bun (`process.versions.bun`), these pre-server bootstrap paths now use the native `bun:sqlite` built-in driver directly.

## Root Cause & Motivation

When running under Bun on Linux ARM64 (e.g. `bun dev/run-standalone.mjs`), `hasEncryptedCredentials` in `bootstrap-env.mjs` ran before OmniRoute's main database driver initialized. Calling `require("better-sqlite3")` triggered a native Node-API crash:

```text
Panic: NAPI FATAL ERROR: Error::New napi_get_last_error_info
Bun has crashed
Aborted (core dumped)
Exit code 134
```

Because native aborts cannot be trapped by JavaScript `try/catch`, this crashed the process before server boot.

OmniRoute already supports and prefers `bun:sqlite` when running under Bun (`driverFactory.ts`). This fix aligns the bootstrap and environment utilities with that existing design.

## Key Changes

1. **`scripts/build/bootstrap-env.mjs`**: When `process.versions.bun` is detected, use `require("bun:sqlite").Database` with synchronous `.query(...).get()` instead of requiring `better-sqlite3`.
2. **`scripts/dev/sync-env.mjs`**: Same guard added to `hasEncryptedCredentials`.
3. **`bin/cli/runtime/sqliteRuntime.mjs`**: Prioritizes `bun-sqlite` when `process.versions.bun` is true.
4. **`tests/unit/db-adapters/bunSqliteAdapter.test.ts`**: Added regression test verifying `loadSqliteRuntime` prioritizes `bun:sqlite` under Bun without loading `better-sqlite3`.
5. **Node.js behavior**: 100% unchanged (`better-sqlite3` is still used under Node.js).

## Validation

- Tested with `bun test tests/unit/db-adapters/bunSqliteAdapter.test.ts`: **3 pass, 0 fail**.