### PR TITLE
build(bun): allow Turbopack bundler flag on Bun 1.4+ with configurable Webpack fallback

### DIFF
--- a/Dockerfile.bun
+++ b/Dockerfile.bun
@@ -41,8 +41,9 @@ RUN bun -e "import { Database } from 'bun:sqlite'; const db = new Database(':mem
 
 COPY . .
 
-# Disable Turbopack for Bun builder stage (Turbopack V8 internal worker bindings require Node)
-ENV OMNIROUTE_USE_TURBOPACK=0
+# Turbopack is supported on Bun 1.4 + Next 16.3; override via --build-arg OMNIROUTE_USE_TURBOPACK=0 if needed
+ARG OMNIROUTE_USE_TURBOPACK=1
+ENV OMNIROUTE_USE_TURBOPACK=${OMNIROUTE_USE_TURBOPACK}
 
 ARG OMNIROUTE_BASE_PATH=""
 ENV OMNIROUTE_BASE_PATH=$OMNIROUTE_BASE_PATH

--- a/changelog.d/features/11471-bun-turbopack.md
+++ b/changelog.d/features/11471-bun-turbopack.md
@@ -1,0 +1,1 @@
+- **build(bun):** allow Turbopack bundler flag on Bun 1.4+ with configurable Webpack fallback ([#11471](https://github.com/diegosouzapw/OmniRoute/pull/11471)) — thanks @TheDemonTuan

--- a/scripts/build/build-next-isolated.mjs
+++ b/scripts/build/build-next-isolated.mjs
@@ -131,9 +131,9 @@ function runNextBuild() {
 }
 
 export function resolveNextBuildBundlerFlag(baseEnv = process.env) {
-  // Turbopack is the default on Node.js; on Bun or when explicitly disabled (=0),
-  // use Webpack (--webpack) to avoid Turbopack V8 internal worker API mismatches.
-  if (process.versions.bun || baseEnv.OMNIROUTE_USE_TURBOPACK === "0") {
+  // Turbopack is the default (on Node.js and Bun 1.4+).
+  // When explicitly disabled (OMNIROUTE_USE_TURBOPACK=0), use Webpack (--webpack) as fallback.
+  if (baseEnv.OMNIROUTE_USE_TURBOPACK === "0") {
     return "--webpack";
   }
   return "--turbopack";

--- a/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
+++ b/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveNextBuildBundlerFlag } from "../../../scripts/build/build-next-isolated.mjs";
+
+test("resolveNextBuildBundlerFlag returns --turbopack by default", () => {
+  const flag = resolveNextBuildBundlerFlag({});
+  assert.equal(flag, "--turbopack");
+});
+
+test("resolveNextBuildBundlerFlag returns --webpack when OMNIROUTE_USE_TURBOPACK is '0'", () => {
+  const flag = resolveNextBuildBundlerFlag({ OMNIROUTE_USE_TURBOPACK: "0" });
+  assert.equal(flag, "--webpack");
+});
+
+test("resolveNextBuildBundlerFlag returns --turbopack when OMNIROUTE_USE_TURBOPACK is '1'", () => {
+  const flag = resolveNextBuildBundlerFlag({ OMNIROUTE_USE_TURBOPACK: "1" });
+  assert.equal(flag, "--turbopack");
+});


### PR DESCRIPTION
## Summary

Allows Next.js 16.3 Turbopack build flag on Bun 1.4+ while keeping `OMNIROUTE_USE_TURBOPACK=0` as the explicit Webpack fallback.

## Context & Motivation

Previously, `resolveNextBuildBundlerFlag` unconditionally forced `--webpack` whenever `process.versions.bun` was true due to historical V8 worker binding mismatches in earlier Bun versions.

With Bun 1.4+ adding extensive Node.js compatibility improvements and officially supporting Next.js 16.3 + Turbopack, this change:
1. Removes the hardcoded Bun check from `resolveNextBuildBundlerFlag` so that `OMNIROUTE_USE_TURBOPACK=1` (or unset) delegates to `--turbopack`.
2. Preserves `OMNIROUTE_USE_TURBOPACK=0` as the reliable fallback for `--webpack`.
3. Makes `Dockerfile.bun` support `--build-arg OMNIROUTE_USE_TURBOPACK=0` as an escape hatch.

## Key Changes

- **`scripts/build/build-next-isolated.mjs`**: `resolveNextBuildBundlerFlag` evaluates `baseEnv.OMNIROUTE_USE_TURBOPACK === "0"` to return `--webpack`, otherwise defaults to `--turbopack`.
- **`Dockerfile.bun`**: Replaces hardcoded `ENV OMNIROUTE_USE_TURBOPACK=0` with `ARG OMNIROUTE_USE_TURBOPACK=1` and `ENV OMNIROUTE_USE_TURBOPACK=${OMNIROUTE_USE_TURBOPACK}`.
- **`tests/unit/build/resolve-next-build-bundler-flag.test.mjs`**: Added unit tests covering default behavior and explicit `OMNIROUTE_USE_TURBOPACK=0` fallback.

## Validation

- Tested with `node --test tests/unit/build/resolve-next-build-bundler-flag.test.mjs`: **3 pass, 0 fail**.
- Tested with `bun test tests/unit/build/resolve-next-build-bundler-flag.test.mjs`: **3 pass, 0 fail**.