### PR TITLE
fix(responses-continuation): fail closed on a log-truncated stored input/output array

### DIFF
--- a/src/lib/db/responsesContinuationStore.ts
+++ b/src/lib/db/responsesContinuationStore.ts
@@ -30,6 +30,23 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+// Both array-bounding implementations that clip a stored artifact's payload
+// for log-storage size (cloneBoundedChatLogPayload in
+// open-sse/handlers/chatCore/logTruncation.ts, and cloneBoundedForLog in
+// open-sse/utils/requestLogger.ts) prepend this sentinel in place of the
+// items they dropped once an array exceeds their tail-item cap -- so a real,
+// ordinary-length conversation resolves fine, but any conversation whose
+// input/output grew past that cap gets this object silently standing in for
+// real history. Reading it back as a genuine Responses-API item sent a
+// malformed reconstructed request upstream (translator 400:
+// "input item type 'missing' cannot be represented..."), which is worse than
+// the plain cache-miss this function is otherwise designed to fail into.
+const TRUNCATED_ARRAY_MARKER = "_omniroute_truncated_array";
+
+function containsTruncatedArrayMarker(items: readonly unknown[]): boolean {
+  return items.some((item) => isPlainRecord(item) && item[TRUNCATED_ARRAY_MARKER] === true);
+}
+
 /**
  * Resolve the full input + output a prior Responses API call produced, so
  * the caller can reconstruct `full_input = stored.input + stored.output +
@@ -88,6 +105,7 @@ export function resolvePreviousResponseState(
     ? clientResponse.output
     : clientResponse?.summary?.output;
   if (!Array.isArray(input) || !Array.isArray(output)) return null;
+  if (containsTruncatedArrayMarker(input) || containsTruncatedArrayMarker(output)) return null;
 
   return { input, output };
 }

--- a/tests/unit/responses-continuation-store.test.ts
+++ b/tests/unit/responses-continuation-store.test.ts
@@ -223,6 +223,44 @@ test("resolvePreviousResponseState resolves input from clientRawRequest when pro
   });
 });
 
+test("resolvePreviousResponseState fails closed when the stored input array was log-truncated", () => {
+  // Real production shape: cloneBoundedChatLogPayload (chatCore/logTruncation.ts)
+  // and cloneBoundedForLog (utils/requestLogger.ts) both prepend an
+  // `_omniroute_truncated_array` sentinel in place of the items they dropped
+  // once a logged array exceeds their tail-item cap (~24 items) -- routine
+  // for any conversation that's been going a while, not an edge case. Reading
+  // that sentinel back as a real Responses-API item and forwarding it upstream
+  // produced a live 400: "input item type 'missing' cannot be represented in
+  // Chat Completions" -- worse than the plain cache-miss this function is
+  // otherwise designed to fail into.
+  insertCallLog({
+    id: "log-7",
+    responseId: "resp_gen-truncated-history",
+    apiKeyId: "key-1",
+    detailState: "ready",
+    artifactRelPath: "2026-01-01/log-7.json",
+  });
+  writeArtifact("2026-01-01/log-7.json", {
+    clientRawRequest: {
+      body: {
+        input: [
+          { _omniroute_truncated_array: true, originalLength: 26, retainedTailItems: 24 },
+          { type: "function_call_output", call_id: "call_1", output: "ok" },
+        ],
+      },
+    },
+    providerRequest: { body: { input: [] } },
+    clientResponse: {
+      summary: {
+        id: "resp_gen-truncated-history",
+        output: [{ type: "message", role: "assistant", content: "hello" }],
+      },
+    },
+  });
+
+  assert.equal(store.resolvePreviousResponseState("resp_gen-truncated-history", "key-1"), null);
+});
+
 test("resolvePreviousResponseState returns null when detail logging was never captured for this row", () => {
   insertCallLog({
     id: "log-5",


### PR DESCRIPTION
## What Problem This Solves
`previous_response_id` continuation went from "doesn't help" to "actively breaks the turn" once a real conversation's logged history grew past ~24 items: the client sent a valid `previous_response_id`, OmniRoute accepted it, reconstructed the request server-side, and forwarded a genuinely malformed body upstream — a live 400: `Unsupported Responses API feature: input item type 'missing' cannot be represented in Chat Completions`. Confirmed live on a real gateway's production traffic.

## Why This Change Was Made
`resolvePreviousResponseState` (added in #11434, building on the continuation-virtualization work in #10262) reads a stored call-log artifact's `input`/`output` arrays back as if they were always the complete, untruncated conversation. But both array-bounding implementations that clip a stored artifact for log-storage size — `cloneBoundedChatLogPayload` (`open-sse/handlers/chatCore/logTruncation.ts`) and `cloneBoundedForLog` (`open-sse/utils/requestLogger.ts`) — prepend an `_omniroute_truncated_array` sentinel object in place of the items they drop once an array exceeds their tail-item cap (`MAX_LOG_ARRAY_ITEMS = 24`). That's routine for any conversation that's been running a while, not an edge case.

Reading that sentinel back as a real Responses-API item and forwarding the reconstructed request upstream produced the malformed-input 400 above. This function already fails closed (returns `null`, forcing a full-history resend) for a size-limit-omitted payload — this extends the same treatment to a truncated-array sentinel in either the cached `input` or `output`.

## User Impact
Any client relying on `previous_response_id` continuation now correctly falls back to resending full history once its conversation's logged arrays exceed the tail-item cap, instead of getting a corrupted reconstruction and a hard 400 on that turn.

## Evidence
- New regression test (`resolvePreviousResponseState fails closed when the stored input array was log-truncated`) reproduces the exact sentinel shape and asserts `null`. Confirmed it fails on pre-fix code (returns the corrupted `{input, output}` including the sentinel object) and passes post-fix.
- Full `tests/unit/responses-continuation-store.test.ts` suite green (9/9) on both the branch this was developed against and `release/v3.8.51`.
- Live-verified directly against the exact `response_id` that produced the real 400 in production (`resp_gen-1787640505-UFPwZTrkLcHJY4O3CRmA`): `resolvePreviousResponseState` now returns `null` for it instead of the malformed reconstruction that broke the turn.
