### PR TITLE
fix(docker-bun): strip Node SQLite addon from runtime

### DIFF
--- a/Dockerfile.bun
+++ b/Dockerfile.bun
@@ -84,7 +84,18 @@ ENV DATA_DIR=/app/data
 RUN mkdir -p /app/data
 
 COPY --from=builder /app/.build/next/standalone ./
+
+ENV OMNIROUTE_MIGRATIONS_DIR=/app/migrations
+
 COPY --from=builder /app/scripts/dev/healthcheck.mjs ./healthcheck.mjs
+
+# Bun uses bun:sqlite. Remove every standalone/vendor copy of the Node-only
+# addon so no traced chunk can dlopen it and abort the process before fallback.
+RUN find /app \
+      -path '*/node_modules/better-sqlite3' \
+      -prune \
+      -exec rm -rf '{}' + \
+  && test -z "$(find /app -type f -name 'better_sqlite3.node' -print -quit)"
 
 RUN chown -R bun:bun /app /app/data
 

--- a/changelog.d/fixes/11482-bun-runtime-native-addon.md
+++ b/changelog.d/fixes/11482-bun-runtime-native-addon.md
@@ -1,0 +1,1 @@
+- **fix(docker-bun):** remove every vendored `better-sqlite3` native addon from the Bun runtime image so startup cannot abort before the `bun:sqlite` fallback ([#11482](https://github.com/diegosouzapw/OmniRoute/pull/11482)) — thanks @TheDemonTuan

--- a/tests/unit/build/bun-runtime-native-addon.test.mjs
+++ b/tests/unit/build/bun-runtime-native-addon.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const dockerfile = readFileSync(new URL("../../../Dockerfile.bun", import.meta.url), "utf8");
+
+test("Bun runner excludes every better-sqlite3 native addon", () => {
+  assert.doesNotMatch(
+    dockerfile,
+    /COPY --from=builder \/app\/node_modules\/better-sqlite3/
+  );
+  assert.match(
+    dockerfile,
+    /find \/app[\s\S]*-path '\*\/node_modules\/better-sqlite3'[\s\S]*-prune[\s\S]*-exec rm -rf '\{\}' \+/
+  );
+  assert.match(
+    dockerfile,
+    /test -z "\$\(find \/app -type f -name 'better_sqlite3\.node' -print -quit\)"/
+  );
+});


### PR DESCRIPTION
## Summary
- stop copying the top-level `better-sqlite3` package into the Bun runner
- remove every traced or vendored `better-sqlite3` copy after standalone assembly
- fail the image build if any `better_sqlite3.node` binary remains
- add a focused regression test

## Root cause
An ARM64 Bun container reached `bun:sqlite`, then aborted during startup with `NAPI FATAL ERROR: Error::New napi_get_last_error_info`. Isolated probes against the exact failed image showed only `better-sqlite3` reproduced the native abort; `keytar`, `onnxruntime-node`, `sqlite-vec`, `tls-client-node`, `wreq-js`, and `sharp` all imported successfully. A JavaScript `try/catch` cannot recover from this process-level abort.

This PR is intentionally Bun-only. It does not change Node source compatibility or unrelated deployment/Caddy automation. It complements #11468 and #11470 by ensuring no additional standalone copy can still be loaded after the Bun-native SQLite startup path is selected.

## Validation
- failing before the fix, passing after: `node --test tests/unit/build/bun-runtime-native-addon.test.mjs`
- production ARM64 evidence from the fork: final image booted, `/healthz` passed, and blue/green deployment completed without `NAPI FATAL ERROR`

⚠️ base-red inherited: #11449
