### PR TITLE
feat(providers): verify-only health sweep for web-cookie connections (#11488)

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -30,6 +30,10 @@ import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 import { refreshGithubCopilotSubTokenIfNeeded } from "@/lib/tokenHealthCheckCopilot";
 import { checkCursorConnectionIfNeeded } from "@/lib/tokenHealthCheckCursor";
 import { checkKimiWebConnectionIfNeeded } from "@/lib/tokenHealthCheckKimi";
+import {
+  checkWebCookieConnectionIfNeeded,
+  isWebCookieHealthProbeCandidate,
+} from "@/lib/tokenHealthCheckWebCookie";
 
 const LOG_PREFIX = "[HealthCheck]";
 const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
@@ -442,7 +446,12 @@ export async function sweep(): Promise<number> {
   }
   state.sweeping = true;
   try {
-    const connections = await getProviderConnections({ authType: "oauth" });
+    const connections = [
+      ...(await getProviderConnections({ authType: "oauth" })),
+      // #11488: web-cookie rows (auth_type 'cookie') were never swept — a dead
+      // cookie stayed "active" until a live request failed against it.
+      ...(await getProviderConnections({ authType: "cookie" })),
+    ];
 
     if (!connections || connections.length === 0) return 0;
 
@@ -614,6 +623,22 @@ export async function checkConnection(conn) {
       log,
       logWarn,
       logError,
+      getConnectionLogLabel,
+      logPrefix: LOG_PREFIX,
+    });
+    return;
+  }
+
+  // Generic web-cookie verify-only probe (#11488): every catalogued cookie
+  // provider without its own bespoke leaf above. Kimi-web already returned.
+  if (isWebCookieHealthProbeCandidate(conn.provider)) {
+    const now = new Date().toISOString();
+    await checkWebCookieConnectionIfNeeded({
+      conn,
+      now,
+      intervalMin,
+      log,
+      logWarn,
       getConnectionLogLabel,
       logPrefix: LOG_PREFIX,
     });

--- a/src/lib/tokenHealthCheckWebCookie.ts
+++ b/src/lib/tokenHealthCheckWebCookie.ts
@@ -1,0 +1,133 @@
+import { WEB_COOKIE_PROVIDERS } from "@/shared/constants/providers";
+import { validateWebCookieProvider } from "@/lib/providers/validation/webCookie";
+import { updateProviderConnection } from "@/lib/db/providers";
+
+/**
+ * Verify-only background probe for web-cookie connections (#11488).
+ *
+ * The token health-check sweep historically iterated ONLY `auth_type = 'oauth'`
+ * rows, and even for those a missing refresh-token short-circuits into a no-op.
+ * Web-cookie connections (`auth_type = 'cookie'`) therefore kept
+ * `testStatus = "active"` forever — a dead cookie surfaced only when a live
+ * user request failed with 401/403.
+ *
+ * This leaf mirrors `tokenHealthCheckKimi.ts` / `tokenHealthCheckCursor.ts`:
+ * pure decision + persistence, with every side-effecting function injectable
+ * so tests can drive outcomes without network or DB.
+ *
+ * Probe semantics reuse `validateWebCookieProvider` — the same generic
+ * session-ping the dashboard Test button falls back to — because its result
+ * contract is deterministic: 401/403 → `{ error: "SESSION_EXPIRED",
+ * errorCode: "AUTH_007" }`, registry-less providers → `unsupported: true`.
+ * The richer per-provider specialty validators are deliberately NOT used here:
+ * a background sweep that can terminal-state a connection must only act on an
+ * unambiguous signal, and must treat every ambiguous failure (network blip,
+ * SSRF-guard block, 5xx) as "unknown" — stamp the tick, change nothing.
+ */
+
+/** Minimal structural view of a connection row this prober reads. */
+export interface WebCookieProbeConnection {
+  id: string;
+  provider?: string | null;
+  apiKey?: string | null;
+  providerSpecificData?: unknown;
+  lastHealthCheckAt?: string | null;
+}
+
+type LogFn = (...msg: unknown[]) => void;
+
+/** True when `provider` is a catalogued web-cookie provider this module can probe. */
+export function isWebCookieHealthProbeCandidate(provider: unknown): boolean {
+  const key = String(provider || "").toLowerCase();
+  return Boolean((WEB_COOKIE_PROVIDERS as Record<string, unknown>)[key]);
+}
+
+function readCredential(conn: WebCookieProbeConnection): string {
+  const direct = typeof conn.apiKey === "string" ? conn.apiKey.trim() : "";
+  if (direct) return direct;
+  const psd = conn.providerSpecificData;
+  if (psd && typeof psd === "object" && !Array.isArray(psd)) {
+    const cookie = (psd as Record<string, unknown>).cookie;
+    return typeof cookie === "string" ? cookie.trim() : "";
+  }
+  return "";
+}
+
+function isSessionExpiredResult(result: {
+  valid: boolean;
+  error?: string | null;
+  errorCode?: string | null;
+}): boolean {
+  return (
+    result.valid === false &&
+    (result.errorCode === "AUTH_007" ||
+      String(result.error || "").toUpperCase().includes("SESSION_EXPIRED"))
+  );
+}
+
+export async function checkWebCookieConnectionIfNeeded(params: {
+  conn: WebCookieProbeConnection;
+  now: string;
+  /** Sweep-computed interval in minutes; 0 already filtered by the caller. */
+  intervalMin: number;
+  log: LogFn;
+  logWarn: LogFn;
+  getConnectionLogLabel: (conn: { name?: string | null; email?: string | null; id?: string | null }) => string;
+  logPrefix: string;
+  probeFn?: typeof validateWebCookieProvider;
+  persistFn?: typeof updateProviderConnection;
+}): Promise<boolean> {
+  const { conn, now, intervalMin, logWarn, getConnectionLogLabel, logPrefix } = params;
+  if (!isWebCookieHealthProbeCandidate(conn?.provider)) return false;
+
+  // Interval gate FIRST so steady-state ticks cost one date comparison, not a probe.
+  const lastCheckMs = conn.lastHealthCheckAt ? new Date(conn.lastHealthCheckAt).getTime() : 0;
+  if (lastCheckMs > 0 && Date.now() - lastCheckMs < intervalMin * 60 * 1000) return true;
+
+  const persist = params.persistFn || updateProviderConnection;
+  const probe = params.probeFn || validateWebCookieProvider;
+  const label = `${String(conn.provider)}/${getConnectionLogLabel(conn)}`;
+
+  const credential = readCredential(conn);
+  if (!credential) {
+    await persist(conn.id, { lastHealthCheckAt: now });
+    return true;
+  }
+
+  const result = await probe({ provider: String(conn.provider), apiKey: credential });
+
+  if (result.valid) {
+    // Steady state: silent stamp only (per-tick chatter would emit ~1440 lines/day).
+    await persist(conn.id, { lastHealthCheckAt: now });
+    return true;
+  }
+
+  if (result.unsupported) {
+    // No honest probe exists for this provider (registry-less / no /models API):
+    // keep the row untouched except for the cadence stamp.
+    await persist(conn.id, { lastHealthCheckAt: now });
+    return true;
+  }
+
+  if (isSessionExpiredResult(result)) {
+    logWarn(
+      `${logPrefix} ${label} cookie rejected by upstream (401/403); marking expired — re-paste the cookie to reactivate`
+    );
+    await persist(conn.id, {
+      testStatus: "expired",
+      lastHealthCheckAt: now,
+      lastError: "Session cookie expired or was revoked by the upstream site.",
+      lastErrorAt: now,
+      lastErrorType: "session_expired",
+      lastErrorSource: "webcookie",
+      errorCode: "session_expired",
+    });
+    return true;
+  }
+
+  // Ambiguous failure (network error, guard block, unexpected status): never flip
+  // state on it — a transient blip must not terminal-state a healthy cookie.
+  logWarn(`${logPrefix} ${label} probe inconclusive (${result.error}); will retry next interval`);
+  await persist(conn.id, { lastHealthCheckAt: now });
+  return true;
+}

--- a/src/lib/tokenHealthCheckWebCookie.ts
+++ b/src/lib/tokenHealthCheckWebCookie.ts
@@ -61,7 +61,9 @@ function isSessionExpiredResult(result: {
   return (
     result.valid === false &&
     (result.errorCode === "AUTH_007" ||
-      String(result.error || "").toUpperCase().includes("SESSION_EXPIRED"))
+      String(result.error || "")
+        .toUpperCase()
+        .includes("SESSION_EXPIRED"))
   );
 }
 
@@ -72,7 +74,11 @@ export async function checkWebCookieConnectionIfNeeded(params: {
   intervalMin: number;
   log: LogFn;
   logWarn: LogFn;
-  getConnectionLogLabel: (conn: { name?: string | null; email?: string | null; id?: string | null }) => string;
+  getConnectionLogLabel: (conn: {
+    name?: string | null;
+    email?: string | null;
+    id?: string | null;
+  }) => string;
   logPrefix: string;
   probeFn?: typeof validateWebCookieProvider;
   persistFn?: typeof updateProviderConnection;
@@ -82,7 +88,8 @@ export async function checkWebCookieConnectionIfNeeded(params: {
 
   // Interval gate FIRST so steady-state ticks cost one date comparison, not a probe.
   const lastCheckMs = conn.lastHealthCheckAt ? new Date(conn.lastHealthCheckAt).getTime() : 0;
-  if (lastCheckMs > 0 && Date.now() - lastCheckMs < intervalMin * 60 * 1000) return true;
+  if (lastCheckMs > 0 && new Date(now).getTime() - lastCheckMs < intervalMin * 60 * 1000)
+    return true;
 
   const persist = params.persistFn || updateProviderConnection;
   const probe = params.probeFn || validateWebCookieProvider;

--- a/tests/unit/token-health-check-webcookie.test.ts
+++ b/tests/unit/token-health-check-webcookie.test.ts
@@ -1,0 +1,199 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  checkWebCookieConnectionIfNeeded,
+  isWebCookieHealthProbeCandidate,
+} from "../../src/lib/tokenHealthCheckWebCookie.ts";
+
+const NOW = "2026-08-25T12:00:00.000Z";
+
+type ProbeParams = Parameters<typeof checkWebCookieConnectionIfNeeded>[0];
+
+function baseParams(over: Partial<ProbeParams> = {}): ProbeParams {
+  const base: ProbeParams = {
+    conn: {
+      id: "conn-1",
+      provider: "claude-web",
+      apiKey: "sessionKey=sk-ant-sid01-x",
+      lastHealthCheckAt: null,
+    },
+    now: NOW,
+    intervalMin: 60,
+    log: () => {},
+    logWarn: () => {},
+    getConnectionLogLabel: () => "claude-1",
+    logPrefix: "[Test]",
+  };
+  return { ...base, ...over };
+}
+describe("web-cookie health probe (#11488)", () => {
+  it("candidate detection matches catalogued cookie providers only", () => {
+    assert.equal(isWebCookieHealthProbeCandidate("claude-web"), true);
+    assert.equal(isWebCookieHealthProbeCandidate("chatgpt-web"), true);
+    assert.equal(isWebCookieHealthProbeCandidate("openai"), false);
+    assert.equal(isWebCookieHealthProbeCandidate(undefined), false);
+    assert.equal(isWebCookieHealthProbeCandidate(""), false);
+  });
+
+  it("returns handled=false for non-cookie providers", async () => {
+    let probed = false;
+    const handled = await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        conn: { id: "c1", provider: "openai" },
+        probeFn: async () => {
+          probed = true;
+          return { valid: true, error: null, unsupported: false };
+        },
+      })
+    );
+    assert.equal(handled, false);
+    assert.equal(probed, false);
+  });
+
+  it("valid probe stamps lastHealthCheckAt and keeps the row active", async () => {
+    let persisted: Record<string, unknown> | null = null;
+    const handled = await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        probeFn: async () => ({ valid: true, error: null, unsupported: false }),
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.equal(handled, true);
+    assert.deepEqual(persisted, { lastHealthCheckAt: NOW });
+  });
+
+  it("AUTH_007 / SESSION_EXPIRED flips the connection to terminal expired", async () => {
+    let persisted: Record<string, unknown> | null = null;
+    await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        probeFn: async () => ({
+          valid: false,
+          error: "SESSION_EXPIRED",
+          errorCode: "AUTH_007",
+          unsupported: false,
+        }),
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.ok(persisted);
+    assert.equal(persisted!.testStatus, "expired");
+    assert.equal(persisted!.errorCode, "session_expired");
+    assert.equal(persisted!.lastErrorType, "session_expired");
+    assert.equal(persisted!.lastErrorSource, "webcookie");
+  });
+
+  it("unsupported providers are stamped without any state flip", async () => {
+    let persisted: Record<string, unknown> | null = null;
+    await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        conn: {
+          id: "c1",
+          provider: "poe-web",
+          apiKey: "key",
+        },
+        probeFn: async () => ({
+          valid: false,
+          error: "Provider validation not supported",
+          unsupported: true,
+        }),
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.deepEqual(persisted, { lastHealthCheckAt: NOW });
+  });
+
+  it("ambiguous failures never terminal-state the connection", async () => {
+    let persisted: Record<string, unknown> | null = null;
+    await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        probeFn: async () => ({
+          valid: false,
+          error: "validation network error: ECONNRESET",
+          unsupported: false,
+        }),
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.deepEqual(persisted, { lastHealthCheckAt: NOW });
+  });
+
+  it("honors the interval gate — recently checked rows are skipped silently", async () => {
+    let probed = false;
+    let persisted: Record<string, unknown> | null = null;
+    const handled = await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        conn: {
+          id: "c1",
+          provider: "claude-web",
+          apiKey: "cookie",
+          // Checked 5 minutes ago against a 60-minute interval.
+          lastHealthCheckAt: new Date(new Date(NOW).getTime() - 5 * 60 * 1000).toISOString(),
+        },
+        probeFn: async () => {
+          probed = true;
+          return { valid: true, error: null, unsupported: false };
+        },
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.equal(handled, true);
+    assert.equal(probed, false);
+    assert.equal(persisted, null);
+  });
+
+  it("rows without any credential are stamped without probing", async () => {
+    let probed = false;
+    let persisted: Record<string, unknown> | null = null;
+    const handled = await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        conn: { id: "c1", provider: "grok-web", apiKey: "" },
+        probeFn: async () => {
+          probed = true;
+          return { valid: true, error: null, unsupported: false };
+        },
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.equal(handled, true);
+    assert.equal(probed, false);
+    assert.deepEqual(persisted, { lastHealthCheckAt: NOW });
+  });
+
+  it("falls back to providerSpecificData.cookie when apiKey is empty", async () => {
+    let seenKey: string | null = null;
+    await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        conn: {
+          id: "c1",
+          provider: "qwen-web",
+          apiKey: "",
+          providerSpecificData: { cookie: "token=abc" },
+        },
+        probeFn: async ({ apiKey }) => {
+          seenKey = apiKey ?? null;
+          return { valid: true, error: null, unsupported: false };
+        },
+        persistFn: async () => ({}),
+      })
+    );
+    assert.equal(seenKey, "token=abc");
+  });
+});

--- a/tests/unit/token-health-check-webcookie.test.ts
+++ b/tests/unit/token-health-check-webcookie.test.ts
@@ -156,6 +156,33 @@ describe("web-cookie health probe (#11488)", () => {
     assert.equal(persisted, null);
   });
 
+  it("stale rows are re-probed once the interval has elapsed", async () => {
+    let probes = 0;
+    let persisted: Record<string, unknown> | null = null;
+    const handled = await checkWebCookieConnectionIfNeeded(
+      baseParams({
+        conn: {
+          id: "c1",
+          provider: "claude-web",
+          apiKey: "cookie",
+          // Checked 61 minutes ago against a 60-minute interval — gate must open.
+          lastHealthCheckAt: new Date(new Date(NOW).getTime() - 61 * 60 * 1000).toISOString(),
+        },
+        probeFn: async () => {
+          probes++;
+          return { valid: true, error: null, unsupported: false };
+        },
+        persistFn: async (_id, data) => {
+          persisted = data as Record<string, unknown>;
+          return {};
+        },
+      })
+    );
+    assert.equal(handled, true);
+    assert.equal(probes, 1);
+    assert.deepEqual(persisted, { lastHealthCheckAt: NOW });
+  });
+
   it("rows without any credential are stamped without probing", async () => {
     let probed = false;
     let persisted: Record<string, unknown> | null = null;


### PR DESCRIPTION
Closes #11488.

## What

The token health-check scheduler only iterated `auth_type = 'oauth'` rows, and its no-refresh-token branch no-opped anyway (`tokenHealthCheck.ts` :649/:770) — so every web-cookie connection (chatgpt-web, claude-web, grok-web, qwen-web, gemini-web, …) stayed `testStatus: "active"` until a live user request failed with 401/403.

This PR adds a **verify-only** path to the existing sweep:

- `sweep()` now also fetches `{ authType: "cookie" }` rows.
- New leaf `src/lib/tokenHealthCheckWebCookie.ts` (same injectable-DI pattern as `tokenHealthCheckKimi.ts` / `tokenHealthCheckCursor.ts`) probes catalogued cookie providers via `validateWebCookieProvider` — the generic session-ping the dashboard Test button falls back to, proxy-fallback transport included.
- Result mapping is deliberately conservative:
  - valid → silent `lastHealthCheckAt` stamp (no per-tick log noise);
  - unambiguous `AUTH_007 / SESSION_EXPIRED` → terminal `expired` with `errorCode: session_expired`, `lastErrorSource: webcookie`;
  - network / guard-block / 5xx / `unsupported` → stamp only, **never** a state flip.
- Per-connection `healthCheckInterval` honored (default 60 min, 0 = off). `kimi-web` keeps its bespoke refresh leaf with precedence; no behavior change for OAuth rows.

The richer per-provider specialty validators are intentionally not used here: a background sweep that can terminal-state a connection must act only on an unambiguous signal.

## Verification

- New unit suite `tests/unit/token-health-check-webcookie.test.ts`: **9/9 pass** (`npx tsx --test --test-force-exit tests/unit/token-health-check-webcookie.test.ts`) covering all branches — candidate detection, non-cookie passthrough, valid-stamp, expired-flip field mapping, unsupported/inconclusive stamp-only, interval gate, missing credential, providerSpecificData.cookie fallback.
- Regression: `tests/unit/token-health-check-kimi.test.ts` 4/4 pass.
- `npx tsc --noEmit -p tsconfig.json`: zero diagnostics in the three touched files.
- `npm run check:file-size`: OK.
- ESLint: both new files clean. One pre-existing error remains in `src/lib/tokenHealthCheck.ts` (`@/lib/localDb` restricted-import barrel) — reproduced on the pristine base commit before my change, untouched here.

## Changed files

- `src/lib/tokenHealthCheckWebCookie.ts` (new)
- `src/lib/tokenHealthCheck.ts` (+20 wiring lines)
- `tests/unit/token-health-check-webcookie.test.ts` (new)