### PR TITLE
fix(providers): remove executor-level tool truncation in OpencodeExecutor

### DIFF
--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -887,12 +887,6 @@ export class OpencodeExecutor extends BaseExecutor {
     }
     if (modifiedBody && typeof modifiedBody === "object" && !Array.isArray(modifiedBody)) {
       const mb = modifiedBody as Record<string, unknown>;
-      if (Array.isArray(mb.tools) && mb.tools.length > 128) {
-        mb.tools = mb.tools.slice(0, 128);
-      }
-    }
-    if (modifiedBody && typeof modifiedBody === "object" && !Array.isArray(modifiedBody)) {
-      const mb = modifiedBody as Record<string, unknown>;
       const parsed = parseEffortLevel(model);
       if (parsed) {
         mb.model = parsed.baseModel;

--- a/tests/unit/opencode-executor-no-tool-truncation.test.ts
+++ b/tests/unit/opencode-executor-no-tool-truncation.test.ts
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { OpencodeExecutor } from "../../open-sse/executors/opencode.ts";
+
+test("OpencodeExecutor.transformRequest does not truncate tools beyond 128 (#11444)", () => {
+  const executor = new OpencodeExecutor();
+  const toolCount = 160;
+  const tools = Array.from({ length: toolCount }, (_, i) => ({
+    type: "function",
+    function: { name: `tool_${i}`, description: `Tool ${i}`, parameters: {} },
+  }));
+
+  const body = {
+    model: "deepseek-chat",
+    messages: [{ role: "user", content: "hello" }],
+    tools,
+  };
+
+  const result = executor.transformRequest(
+    "deepseek-chat",
+    body,
+    false,
+    { apiKey: "test-key" }
+  );
+
+  assert.equal(
+    result.tools.length,
+    toolCount,
+    `Expected all ${toolCount} tools to pass through, but got ${result.tools.length}`
+  );
+});
+
+test("OpencodeExecutor.transformRequest preserves tools at exactly 128", () => {
+  const executor = new OpencodeExecutor();
+  const tools = Array.from({ length: 128 }, (_, i) => ({
+    type: "function",
+    function: { name: `tool_${i}`, description: `Tool ${i}`, parameters: {} },
+  }));
+
+  const body = {
+    model: "deepseek-chat",
+    messages: [{ role: "user", content: "hello" }],
+    tools,
+  };
+
+  const result = executor.transformRequest(
+    "deepseek-chat",
+    body,
+    false,
+    { apiKey: "test-key" }
+  );
+
+  assert.equal(result.tools.length, 128);
+});
+
+test("OpencodeExecutor.transformRequest preserves tools well above 128 (#9132)", () => {
+  const executor = new OpencodeExecutor();
+  const toolCount = 250;
+  const tools = Array.from({ length: toolCount }, (_, i) => ({
+    type: "function",
+    function: { name: `tool_${String(i).padStart(3, "0")}`, description: `T${i}`, parameters: {} },
+  }));
+
+  const body = {
+    model: "qwen-coder-plus",
+    messages: [{ role: "user", content: "test" }],
+    tools,
+  };
+
+  const result = executor.transformRequest(
+    "qwen-coder-plus",
+    body,
+    true,
+    { apiKey: "test-key" }
+  );
+
+  assert.equal(
+    result.tools.length,
+    toolCount,
+    "Executor must not truncate — centralized truncateToolList() handles limits"
+  );
+});


### PR DESCRIPTION
Fixes #11444

## What this PR does

Removes the unconditional `tools.slice(0, 128)` in `OpencodeExecutor.transformRequest` (introduced in a16e47c59, #1699, v3.7.2). This executor-level cap silently dropped every tool past index 128, making late-alphabetical tools — including `read`, `skill`, `task`, `task_cancel`, `task_message`, `task_result`, `task_revive`, `todowrite`, `wait_for_user`, `webfetch`, `write` — unreachable on all `oc/*` routes. Since opencode sends tools alphabetically, subagent spawning (`task`) was completely broken.

## Why

PR #6193 fixed the **chatCore layer** truncation by adding a `bypassDefaultToolLimit` flag, but it did not touch the **executor layer**. The centralized `truncateToolList()` in `chatCore/upstreamBody.ts` already handles per-provider tool limits (via `toolLimitDetector.ts`) with proper bypass detection for opencode clients. The executor-level slice was both redundant and unreachable by the bypass flag — a second cap that undid #6193's fix for any request routed through `OpencodeExecutor`.

## Changes

- `open-sse/executors/opencode.ts`: removed the 6-line block that unconditionally truncated `mb.tools` to 128 entries

## Test plan

- [x] Regression test `tests/unit/opencode-executor-no-tool-truncation.test.ts` — 3 assertions:
  - 160 tools pass through without truncation
  - 128 tools preserved exactly (boundary)
  - 250 tools pass through (stress, simulating real opencode sessions)
- [x] All 3 tests pass after rebase onto current `release/v3.8.51` tip

## Reproduction (from issue)

```bash
# Send 150+ tools to an oc/* model via OmniRoute — tools at index ≥128 are absent from upstream
curl -X POST http://localhost:20128/v1/chat/completions   -H "Content-Type: application/json"   -d '{"model":"oc/deepseek-chat","messages":[{"role":"user","content":"hi"}],"tools":[...150+ tools...]}'
# With this fix: all tools reach upstream intact
```

⚠️ base-red inherited: #11449