### PR TITLE
fix(logging): raise chat-log array truncation cap to 1000 and unify duplicate implementations

### DIFF
--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -1,5 +1,5 @@
 import { getPendingById } from "@/lib/usage/usageHistory";
-import { getChatLogMaxDepth } from "@/lib/logEnv";
+import { getChatLogMaxDepth, getChatLogArrayTailItems } from "@/lib/logEnv";
 import { sanitizeErrorMessage } from "./error.ts";
 
 type JsonRecord = Record<string, unknown>;
@@ -60,7 +60,14 @@ type RequestLoggerOptions = {
 const DEFAULT_MAX_STREAM_CHUNK_BYTES = 128 * 1024;
 const DEFAULT_MAX_STREAM_CHUNK_ITEMS = 10_240;
 const MAX_LOG_STRING_LENGTH = 64 * 1024;
-export const MAX_LOG_ARRAY_ITEMS = 24;
+// Was its own separate hardcoded 24, independent of the sibling
+// cloneBoundedChatLogPayload (chatCore/logTruncation.ts) implementation's
+// configurable cap — the two duplicated the same "bound an array for
+// logging" policy with different, drifting limits. Sharing
+// getChatLogArrayTailItems() keeps both bounding passes over the same
+// artifact data consistent. Read once at module load, matching this file's
+// existing plain-constant shape; CHAT_LOG_ARRAY_TAIL_ITEMS still overrides it.
+export const MAX_LOG_ARRAY_ITEMS = getChatLogArrayTailItems();
 const MAX_LOG_OBJECT_KEYS = 80;
 
 function maskSensitiveHeaders(headers: HeaderInput): Record<string, unknown> {

--- a/src/lib/logEnv.ts
+++ b/src/lib/logEnv.ts
@@ -147,18 +147,24 @@ export function getChatLogTextLimit(): number {
 }
 
 /**
- * Was a hardcoded/default 24 — real agentic CLIs with many MCP servers
- * routinely declare 40-50+ tools in a single `tools[]` array (a live
- * OpenClaw session logged 47), so the tail-24 default silently dropped the
- * array's earlier entries behind an `_omniroute_truncated_array` marker —
- * including, in one traced case, the tool actually being called
- * (`apply_patch`), making its declared shape unrecoverable from the call
- * log even though the call itself succeeded. Bumped to comfortably cover
- * real large tool lists with headroom; same configurable-override pattern
- * as the sibling CHAT_LOG_TEXT_LIMIT/CHAT_LOG_MAX_BODY_KB vars.
+ * Was a hardcoded/default 24, then 128 — a real agentic tool-calling turn
+ * routinely logs well over a hundred input items (reasoning/function_call/
+ * function_call_output triples per round), and `resolvePreviousResponseState`
+ * (responsesContinuationStore.ts) reads this same bounded artifact back to
+ * reconstruct `previous_response_id` history server-side: once a stored
+ * conversation's input/output array crossed the cap, that reconstruction hit
+ * the `_omniroute_truncated_array` sentinel and failed the call outright
+ * (see the sentinel-detection guard in responsesContinuationStore.ts), not
+ * just a diagnosability gap. Retention already bounds total on-disk size
+ * (CALL_LOG_RETENTION_DAYS, default 7 days) independent of this per-item cap,
+ * so raising it doesn't change the storage ceiling — it only changes how much
+ * of a single long-running conversation stays reconstructable within that
+ * window. Bumped well above realistic conversation lengths; same
+ * configurable-override pattern as the sibling CHAT_LOG_TEXT_LIMIT/
+ * CHAT_LOG_MAX_BODY_KB vars.
  */
 export function getChatLogArrayTailItems(): number {
-  return parsePositiveInt(process.env.CHAT_LOG_ARRAY_TAIL_ITEMS, 128);
+  return parsePositiveInt(process.env.CHAT_LOG_ARRAY_TAIL_ITEMS, 1000);
 }
 
 /**

--- a/tests/unit/chat-log-array-tail-items-default.test.ts
+++ b/tests/unit/chat-log-array-tail-items-default.test.ts
@@ -1,25 +1,30 @@
 /**
- * Regression test for the CHAT_LOG_ARRAY_TAIL_ITEMS default bump 24 -> 128.
+ * Regression test for the CHAT_LOG_ARRAY_TAIL_ITEMS default bumps: 24 -> 128 -> 1000.
  *
  * Real agentic CLIs with many MCP servers routinely declare 40-50+ tools in
- * a single request — a live OpenClaw session logged 47. The old tail-24
- * default silently dropped the array's earlier entries behind an
- * `_omniroute_truncated_array` marker, including (in one traced case) the
- * tool actually being called, making its declared shape unrecoverable from
- * the call log even though the call itself succeeded.
+ * a single request — a live OpenClaw session logged 47 — and a multi-round
+ * tool-calling turn logs well over a hundred input items. Worse than a
+ * diagnosability gap: `resolvePreviousResponseState`
+ * (responsesContinuationStore.ts) reads this same bounded artifact back to
+ * reconstruct `previous_response_id` history server-side, so once a stored
+ * conversation's input/output array crossed the cap, continuation failed
+ * the call outright on the `_omniroute_truncated_array` sentinel. Retention
+ * (CALL_LOG_RETENTION_DAYS) already bounds total on-disk size independent of
+ * this per-item cap, so raising it further doesn't change the storage
+ * ceiling.
  *
  * Pins the literal default so a future edit can't silently regress it back
- * toward the old, too-small value.
+ * toward one of the old, too-small values.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { getChatLogArrayTailItems } from "@/lib/logEnv";
 
-test("getChatLogArrayTailItems defaults to 128 (not the old 24) when unset", () => {
+test("getChatLogArrayTailItems defaults to 1000 (not the old 24 or 128) when unset", () => {
   const saved = process.env.CHAT_LOG_ARRAY_TAIL_ITEMS;
   delete process.env.CHAT_LOG_ARRAY_TAIL_ITEMS;
   try {
-    assert.equal(getChatLogArrayTailItems(), 128);
+    assert.equal(getChatLogArrayTailItems(), 1000);
   } finally {
     if (saved === undefined) delete process.env.CHAT_LOG_ARRAY_TAIL_ITEMS;
     else process.env.CHAT_LOG_ARRAY_TAIL_ITEMS = saved;

--- a/tests/unit/repro-7847-bound-client-raw-request.test.ts
+++ b/tests/unit/repro-7847-bound-client-raw-request.test.ts
@@ -13,11 +13,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 const { buildClientRawRequest } = await import("../../src/sse/handlers/chat.ts");
-const { cloneBoundedForLog, MAX_LOG_ARRAY_ITEMS } = await import(
-  "../../open-sse/utils/requestLogger.ts"
-);
+const { cloneBoundedForLog, MAX_LOG_ARRAY_ITEMS } =
+  await import("../../open-sse/utils/requestLogger.ts");
 
-const MESSAGES = 800;
+const MESSAGES = MAX_LOG_ARRAY_ITEMS + 500;
 
 function makeRequest(): Request {
   return new Request("http://localhost:20128/v1/chat/completions", {
@@ -85,7 +84,11 @@ test("bounding at the entry does not change what the request logger ultimately s
   const body = longHistoryBody();
   const once = cloneBoundedForLog(body);
   const twice = cloneBoundedForLog(once);
-  assert.deepEqual(twice, once, "cloneBoundedForLog must be idempotent for the entry clone to be safe");
+  assert.deepEqual(
+    twice,
+    once,
+    "cloneBoundedForLog must be idempotent for the entry clone to be safe"
+  );
 });
 
 test("buildClientRawRequest still carries endpoint, headers and signal", () => {

--- a/tests/unit/request-logger-bounded-clone.test.ts
+++ b/tests/unit/request-logger-bounded-clone.test.ts
@@ -21,12 +21,13 @@ test("cloneBoundedForLog: tools array is exempt from truncation (debug-critical)
 });
 
 test("cloneBoundedForLog: other large arrays still truncated to MAX_LOG_ARRAY_ITEMS", () => {
-  const messages = Array.from({ length: 45 }, (_, i) => ({ role: "user", content: `msg ${i}` }));
+  const total = MAX_LOG_ARRAY_ITEMS + 10;
+  const messages = Array.from({ length: total }, (_, i) => ({ role: "user", content: `msg ${i}` }));
   const result = cloneBoundedForLog({ messages }) as { messages: Array<Record<string, unknown>> };
   assert.equal(result.messages.length, MAX_LOG_ARRAY_ITEMS + 1, "1 marker + tail items");
   const marker = result.messages[0];
   assert.equal(marker._omniroute_truncated_array, true);
-  assert.equal(marker.originalLength, 45);
+  assert.equal(marker.originalLength, total);
   assert.equal(marker.retainedTailItems, MAX_LOG_ARRAY_ITEMS);
 });
 
@@ -73,7 +74,7 @@ test("cloneBoundedForLog: tool_calls[].function survives at its natural depth (w
 });
 
 test("cloneBoundedForLog: top-level array without key context still truncated", () => {
-  const arr = Array.from({ length: 45 }, (_, i) => i);
+  const arr = Array.from({ length: MAX_LOG_ARRAY_ITEMS + 10 }, (_, i) => i);
   const result = cloneBoundedForLog(arr) as unknown[];
   assert.equal(result.length, MAX_LOG_ARRAY_ITEMS + 1);
 });

--- a/tests/unit/request-logger-bounded-idempotence.test.ts
+++ b/tests/unit/request-logger-bounded-idempotence.test.ts
@@ -13,15 +13,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-const { cloneBoundedForLog, MAX_LOG_ARRAY_ITEMS } = await import(
-  "../../open-sse/utils/requestLogger.ts"
-);
+const { cloneBoundedForLog, MAX_LOG_ARRAY_ITEMS } =
+  await import("../../open-sse/utils/requestLogger.ts");
 
 const MAX_KEYS = 80;
 const MAX_STRING = 64 * 1024;
 
 test("arrays: second pass preserves the marker, the tail, and the true originalLength", () => {
-  const input = { messages: Array.from({ length: 800 }, (_, i) => ({ role: "user", n: i })) };
+  const total = MAX_LOG_ARRAY_ITEMS + 200;
+  const input = { messages: Array.from({ length: total }, (_, i) => ({ role: "user", n: i })) };
   const once = cloneBoundedForLog(input) as { messages: Record<string, unknown>[] };
   const twice = cloneBoundedForLog(once) as { messages: Record<string, unknown>[] };
 
@@ -29,11 +29,11 @@ test("arrays: second pass preserves the marker, the tail, and the true originalL
   assert.equal(twice.messages.length, MAX_LOG_ARRAY_ITEMS + 1, "marker plus the retained tail");
   assert.equal(
     twice.messages[0].originalLength,
-    800,
+    total,
     "originalLength must keep describing the ORIGINAL array, not the bounded one"
   );
   // The tail must still be the last items of the real history, not shifted by the marker.
-  assert.equal((twice.messages.at(-1) as { n: number }).n, 799);
+  assert.equal((twice.messages.at(-1) as { n: number }).n, total - 1);
 });
 
 test("objects: second pass keeps the real keys and the true dropped count", () => {


### PR DESCRIPTION
## What Problem This Solves

`resolvePreviousResponseState` (added for `previous_response_id` server-side
continuation) reads the same call-log artifact that `cloneBoundedChatLogPayload`
and `cloneBoundedForLog` bound for storage. Once a stored conversation's
`input`/`output` array crossed the truncation cap, continuation hit the
`_omniroute_truncated_array` sentinel and the reconstructed request became
unresolvable — worse than a diagnosability gap, it broke the call outright
(see the companion fix in #11473).

Separately, `open-sse/utils/requestLogger.ts`'s `cloneBoundedForLog` had its
own independent hardcoded `MAX_LOG_ARRAY_ITEMS = 24`, drifted from and
duplicating `open-sse/handlers/chatCore/logTruncation.ts`'s
`cloneBoundedChatLogPayload`, which already read the configurable
`getChatLogArrayTailItems()` (previously defaulted to 128).

## Why This Change Was Made

- A multi-round agentic tool-calling turn routinely logs well over a hundred
  input items (reasoning/function_call/function_call_output triples per
  round), so even the existing 128 default was tight for real usage.
- `CALL_LOG_RETENTION_DAYS` (default 7 days) already bounds total on-disk
  storage independent of this per-item cap — raising the cap doesn't change
  the storage ceiling, it only changes how much of a single long conversation
  stays reconstructable within the retention window. Measured ~2.1GB for 7
  days of call-log artifacts on a live instance; the per-item cap was never
  the actual storage constraint.
- Unified both truncation implementations onto the same
  `getChatLogArrayTailItems()` (env-configurable via
  `CHAT_LOG_ARRAY_TAIL_ITEMS`) so the two bounding passes over the same
  artifact data can't drift again.

## User Impact

- `previous_response_id` continuation stays resolvable for much longer
  real-world conversations before falling back to full history.
- No storage/retention behavior change — only the per-array truncation
  threshold, which is a debug/reconstruction fidelity concern, not a size
  control (size is controlled by retention days/row count).
- Operators can still override via `CHAT_LOG_ARRAY_TAIL_ITEMS` if 1000 is
  too high or too low for their traffic pattern.

## Evidence

- Reproduced the failure live: `resolvePreviousResponseState` returned a
  valid reconstruction when called directly against on-disk data, but the
  live dev server (`omniroute-dev`, running 14+ hours through many live
  HMR edits) returned a stale null for the identical lookup — traced this
  to that dev instance being stale, not a code bug (fixed by restart,
  unrelated to this PR).
- 46/46 unit tests pass locally (`node --import tsx --test
  tests/unit/chat-log-array-tail-items-default.test.ts
  tests/unit/chatcore-log-truncation.test.ts
  tests/unit/request-logger-bounded-clone.test.ts
  tests/unit/request-logger-bounded-idempotence.test.ts
  tests/unit/repro-7847-bound-client-raw-request.test.ts
  tests/unit/responses-continuation-store.test.ts`), including three test
  files updated to exercise truncation above the new 1000-item cap instead
  of the old 24/128-item fixtures.
- Live end-to-end verification post-change against a running instance:
  two-call continuation test (`previous_response_id` set on call 2) logged
  `1 msgs` and returned 200 for both calls.