### PR TITLE
fix: restore live websocket URL helpers

### DIFF
--- a/src/shared/utils/wsPath.ts
+++ b/src/shared/utils/wsPath.ts
@@ -53,3 +53,61 @@ export function resolveLiveWsPublicUrl(env: NodeJS.ProcessEnv = process.env): st
 export function getLiveWsPath(): string {
   return deriveLiveWsPath(resolveLiveWsPublicUrl() ?? undefined);
 }
+
+/** A port the handshake may report, or null when it is not usable. */
+export function sanitizeLiveWsPort(port: unknown): number | null {
+  const value = typeof port === "string" ? Number(port) : port;
+  if (typeof value !== "number" || !Number.isInteger(value)) return null;
+  return value > 0 && value < 65536 ? value : null;
+}
+
+export interface LiveWsUrlParts {
+  /** Explicit `wsUrl` passed by the caller - always wins. */
+  explicit?: string | null;
+  /** `live.publicUrl` from the handshake - a complete URL, used as-is. */
+  handshakeUrl?: string | null;
+  /** `live.port` from the handshake, i.e. the running LIVE_WS_PORT. */
+  handshakePort?: number | null;
+  /** `live.path` from the handshake. */
+  handshakePath?: string | null;
+  /** The compiled-in default, used for everything the handshake does not say. */
+  defaultUrl: string;
+}
+
+/**
+ * Resolve the live dashboard WebSocket URL.
+ *
+ * The handshake reports the port the live server is actually listening on, but
+ * the client read only `publicUrl` and `path` from it. An operator who moved
+ * the server with `LIVE_WS_PORT` still got the compiled-in 20132, and the
+ * dashboard sat on "Live disabled - WebSocket disconnected" with no way to
+ * correct it short of rebuilding the image (#11331).
+ *
+ * Precedence: an explicit `wsUrl` wins, then a complete `publicUrl` from the
+ * handshake, then the default URL with whatever port and path the handshake
+ * reported applied to it.
+ */
+export function resolveLiveWsUrl({
+  explicit,
+  handshakeUrl,
+  handshakePort,
+  handshakePath,
+  defaultUrl,
+}: LiveWsUrlParts): string {
+  if (explicit) return explicit;
+  if (handshakeUrl) return handshakeUrl;
+
+  const port = sanitizeLiveWsPort(handshakePort);
+  const path =
+    typeof handshakePath === "string" && handshakePath.startsWith("/") ? handshakePath : null;
+  if (port === null && path === null) return defaultUrl;
+
+  try {
+    const url = new URL(defaultUrl);
+    if (port !== null) url.port = String(port);
+    if (path !== null) url.pathname = path;
+    return url.toString();
+  } catch {
+    return defaultUrl;
+  }
+}


### PR DESCRIPTION
## Summary

- restores sanitizeLiveWsPort and resolveLiveWsUrl, omitted when the changes from #11388 were squashed
- fixes the Turbopack import failures currently blocking the v3.8.51 release pipeline
- keeps the patch identical to the original implementation covered by the existing regression test

## Validation

- live-ws-url-11331: 11/11 passing
- Prettier check: passing
- ESLint for wsPath.ts: passing
- typecheck:core: passing
- full production build deferred to CI because the local machine ran out of resources