### PR TITLE
fix(kiro): add runtime.us-east-1.kiro.dev as first-attempt endpoint

### DIFF
--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -244,6 +244,14 @@ export function resolveKiroRegion(
 export { kiroRuntimeHost };
 
 /**
+ * Status codes for which trying the next candidate endpoint may succeed where the
+ * current one failed (auth/profile mismatch, not a payload problem). Mirrors
+ * 9router's KIRO_ENDPOINT_FALLBACK_STATUSES — a 400 (malformed body) is deliberately
+ * excluded since resending the same body to another host cannot fix it.
+ */
+const KIRO_ENDPOINT_FALLBACK_STATUSES = new Set([401, 403, 404]);
+
+/**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
  * Uses AWS CodeWhisperer streaming API with AWS EventStream binary format
  */
@@ -334,17 +342,47 @@ export class KiroExecutor extends BaseExecutor {
     // Center accounts (e.g. eu-central-1) are rejected by the default us-east-1 host; only the
     // regional endpoint accepts the region-bound token + profileArn.
     const region = resolveKiroRegion(credentials);
-    const url = `${kiroRuntimeHost(region)}/generateAssistantResponse`;
+    const regionalUrl = `${kiroRuntimeHost(region)}/generateAssistantResponse`;
+
+    // The Kiro IDE's own branded gateway (runtime.*.kiro.dev) only exists for
+    // us-east-1 and only accepts Kiro OIDC/social tokens — it rejects
+    // TokenType=API_KEY and external-IdP/IdC SSO tokens outright (403 "bearer
+    // token invalid"), so those auth methods go straight to the region-resolved
+    // CodeWhisperer/Amazon Q surface (mirrors 9router's getOrderedBaseUrls in
+    // open-sse/executors/kiro.js). For everything else, try the branded gateway
+    // first — it is the surface the native Kiro IDE itself talks to — and fall
+    // back to the raw AWS host on an auth/profile-shaped failure.
+    const authMethod =
+      typeof credentials.providerSpecificData?.authMethod === "string"
+        ? credentials.providerSpecificData.authMethod
+        : undefined;
+    const isCodeWhispererOnly =
+      authMethod === "api_key" || authMethod === "idc" || isExternalIdpAuthMethod(authMethod);
+    const candidateUrls =
+      region === "us-east-1" && !isCodeWhispererOnly
+        ? ["https://runtime.us-east-1.kiro.dev/generateAssistantResponse", regionalUrl]
+        : [regionalUrl];
+
     const headers = this.buildHeaders(credentials, stream);
     mergeUpstreamExtraHeaders(headers, upstreamExtraHeaders);
     const transformedBody = await this.transformRequest(model, body, stream, credentials);
+    const requestBody = JSON.stringify(transformedBody);
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(transformedBody),
-      signal,
-    });
+    let response!: Response;
+    let url = candidateUrls[0];
+    for (let i = 0; i < candidateUrls.length; i++) {
+      url = candidateUrls[i];
+      response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: requestBody,
+        signal,
+      });
+      const hasFallback = i + 1 < candidateUrls.length;
+      if (response.ok || !hasFallback || !KIRO_ENDPOINT_FALLBACK_STATUSES.has(response.status)) {
+        break;
+      }
+    }
 
     if (!response.ok) {
       return { response, url, headers, transformedBody };

--- a/tests/unit/kiro-runtime-gateway-fallback.test.ts
+++ b/tests/unit/kiro-runtime-gateway-fallback.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { KiroExecutor } from "../../open-sse/executors/kiro.ts";
+
+// #<issue>: the executor only ever called the region-resolved CodeWhisperer/
+// Amazon Q surface directly. The native Kiro IDE talks to a branded gateway
+// (runtime.us-east-1.kiro.dev) first — this covers the new candidate-url
+// ordering, fallback-on-auth-failure behavior, and the auth-method gate that
+// keeps API-key/IdC/external-IdP connections off the gateway entirely (it
+// rejects those token types outright).
+
+test("KiroExecutor.execute tries runtime.us-east-1.kiro.dev before the regional CodeWhisperer host for OAuth accounts", async () => {
+  const executor = new KiroExecutor();
+  const originalFetch = globalThis.fetch;
+  const calledUrls: string[] = [];
+
+  globalThis.fetch = (async (url: string) => {
+    calledUrls.push(String(url));
+    return new Response("ok", {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.amazon.eventstream" },
+    });
+  }) as typeof fetch;
+
+  try {
+    executor.transformEventStreamToSSE = (() =>
+      new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })) as typeof executor.transformEventStreamToSSE;
+
+    await executor.execute({
+      model: "claude-sonnet-4.5",
+      body: { conversationState: {} },
+      stream: true,
+      credentials: { accessToken: "kiro-token", providerSpecificData: { authMethod: "social" } },
+    });
+
+    assert.equal(calledUrls.length, 1);
+    assert.match(
+      calledUrls[0],
+      /^https:\/\/runtime\.us-east-1\.kiro\.dev\/generateAssistantResponse/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("KiroExecutor.execute falls back to the regional CodeWhisperer host when the gateway rejects the token", async () => {
+  const executor = new KiroExecutor();
+  const originalFetch = globalThis.fetch;
+  const calledUrls: string[] = [];
+
+  globalThis.fetch = (async (url: string) => {
+    calledUrls.push(String(url));
+    if (calledUrls.length === 1) {
+      return new Response("bearer token invalid", { status: 403 });
+    }
+    return new Response("ok", {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.amazon.eventstream" },
+    });
+  }) as typeof fetch;
+
+  try {
+    executor.transformEventStreamToSSE = (() =>
+      new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })) as typeof executor.transformEventStreamToSSE;
+
+    const result = await executor.execute({
+      model: "claude-sonnet-4.5",
+      body: { conversationState: {} },
+      stream: true,
+      credentials: { accessToken: "kiro-token", providerSpecificData: { authMethod: "social" } },
+    });
+
+    assert.equal(calledUrls.length, 2);
+    assert.match(calledUrls[0], /^https:\/\/runtime\.us-east-1\.kiro\.dev/);
+    assert.match(calledUrls[1], /^https:\/\/codewhisperer\.us-east-1\.amazonaws\.com/);
+    assert.equal((result.response as Response).status, 200);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("KiroExecutor.execute never tries the gateway for api_key/idc/external_idp auth methods", async () => {
+  const executor = new KiroExecutor();
+  const originalFetch = globalThis.fetch;
+
+  for (const authMethod of ["api_key", "idc", "external_idp"]) {
+    const calledUrls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calledUrls.push(String(url));
+      return new Response("ok", {
+        status: 200,
+        headers: { "Content-Type": "application/vnd.amazon.eventstream" },
+      });
+    }) as typeof fetch;
+
+    try {
+      executor.transformEventStreamToSSE = (() =>
+        new Response("data: [DONE]\n\n", {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })) as typeof executor.transformEventStreamToSSE;
+
+      await executor.execute({
+        model: "claude-sonnet-4.5",
+        body: { conversationState: {} },
+        stream: true,
+        credentials: { accessToken: "kiro-token", providerSpecificData: { authMethod } },
+      });
+
+      assert.equal(calledUrls.length, 1, `expected exactly one call for authMethod=${authMethod}`);
+      assert.doesNotMatch(
+        calledUrls[0],
+        /kiro\.dev/,
+        `${authMethod} must never hit the branded gateway`
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+});
+
+test("KiroExecutor.execute does not retry a malformed-body 400 across endpoints", async () => {
+  const executor = new KiroExecutor();
+  const originalFetch = globalThis.fetch;
+  const calledUrls: string[] = [];
+
+  globalThis.fetch = (async (url: string) => {
+    calledUrls.push(String(url));
+    return new Response("REQUEST_BODY_INVALID", { status: 400 });
+  }) as typeof fetch;
+
+  try {
+    const result = await executor.execute({
+      model: "claude-sonnet-4.5",
+      body: { conversationState: {} },
+      stream: true,
+      credentials: { accessToken: "kiro-token", providerSpecificData: { authMethod: "social" } },
+    });
+
+    assert.equal(calledUrls.length, 1);
+    assert.equal((result.response as Response).status, 400);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

The Kiro executor only ever calls the region-resolved CodeWhisperer/Amazon Q
surface directly (`codewhisperer.us-east-1.amazonaws.com` or
`q.{region}.amazonaws.com`). The native Kiro IDE itself talks to a branded
gateway (`runtime.us-east-1.kiro.dev`) first.

#8229 already proposed aligning with the native IDE endpoints; it was closed
not because that direction was rejected, but because it also (unintentionally)
reverted the #6170 VPS-verified model catalog fix. @diegosouzapw noted then
that the endpoint-alignment direction was "genuinely interesting" and welcomed
a focused follow-up that leaves the catalog alone. This PR is that follow-up —
it touches only `open-sse/executors/kiro.ts`, no model catalog or header
changes.

## What changed

For auth methods the branded gateway actually accepts — i.e. **not**
`api_key`/`idc`/`external_idp`, which the gateway rejects outright with 403
"bearer token invalid" — and only when the resolved runtime region is
`us-east-1` (the gateway isn't regional), `KiroExecutor.execute()` now tries
`runtime.us-east-1.kiro.dev` first and falls back to the region-resolved AWS
host on an auth/profile-shaped failure (401/403/404 — mirrors 9router's
`KIRO_ENDPOINT_FALLBACK_STATUSES`, a sibling project this repo was originally
rebranded from). A malformed-body 400 stays terminal, since resending the
same body to a different host can't fix it.

## Why

- Matches what the native Kiro IDE itself does — trying the branded surface
  first before the raw AWS backend.
- `api_key`/`idc`/`external_idp` accounts are explicitly excluded from the
  gateway attempt since it's documented (and empirically observed by prior
  work) to reject those token types.

## Validation

- New regression tests: `tests/unit/kiro-runtime-gateway-fallback.test.ts`
  (gateway-first ordering, fallback on 401/403/404, auth-method gate,
  400 stays terminal — 4/4 passing).
- Full existing Kiro suite unaffected: `executor-kiro.test.ts` (20/20),
  `kiro-region-ssrf-guard`, `kiro-idc-cross-region`, `kiro-iam-region`,
  `kiro-iam-profilearn-usage`, `kiro-external-idp`, `kiro-api-key-route-helpers`,
  `oauth-kiro`, `oauth-kiro-idc` (all passing, 143 tests total across the
  Kiro-related suite).
- `npx tsc --noEmit -p tsconfig.typecheck-core.json`: 0 errors.

I have not been able to validate live against the production VPS (no access) —
happy to have that step done by a maintainer/CI before merge, per the
bug-fix triage protocol in AGENTS.md.

⚠️ base-red inherited: #11449