### PR TITLE
fix(ci): skip stale release Docker publishes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,6 +68,16 @@ jobs:
             "$EVENT_NAME" "$REF_TYPE" "$REF_NAME" "$INPUT_VERSION" "$DEFAULT_BRANCH")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+          # Frozen release branches keep receiving coordination commits after the
+          # next cycle becomes the default branch. They must not overwrite :next,
+          # but that expected no-op is not a workflow failure.
+          if [ "$VERSION" = "skip" ]; then
+            echo "promote_latest=false" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping Docker publish from non-default release branch: $REF_NAME"
+            exit 0
+          fi
+
           # 2) Decide whether to promote :latest. Floating channels are never
           # eligible, and the helper independently fails closed for non-semver.
           PROMOTE="false"

--- a/changelog.d/fixes/11523-stale-release-docker-skip.md
+++ b/changelog.d/fixes/11523-stale-release-docker-skip.md
@@ -1,0 +1,1 @@
+- Treat Docker publishing from a non-default release branch as an expected skip instead of a failed workflow, while preserving the guard that prevents it from overwriting the `next` channel.

--- a/scripts/ci/resolve-docker-publish-version.sh
+++ b/scripts/ci/resolve-docker-publish-version.sh
@@ -32,10 +32,10 @@ case "$EVENT_NAME" in
           ;;
         release/v*)
           if [ -z "$DEFAULT_BRANCH" ] || [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
-            echo "Refusing to publish next from non-default release branch: $REF_NAME" >&2
-            exit 1
+            VERSION="skip"
+          else
+            VERSION="next"
           fi
-          VERSION="next"
           ;;
         *)
           echo "Unsupported Docker publish branch: $REF_NAME" >&2

--- a/tests/unit/build/docker-next-channel-8576.test.ts
+++ b/tests/unit/build/docker-next-channel-8576.test.ts
@@ -72,18 +72,19 @@ test("the current default release branch resolves to next", () => {
   );
 });
 
-test("a stale release branch cannot overwrite next", () => {
-  assert.throws(
-    () =>
-      resolveVersion(
-        "push",
-        "branch",
-        "release/v3.8.49",
-        "",
-        "release/v3.8.50",
-      ),
-    /Refusing to publish next from non-default release branch/,
+test("a stale release branch skips without overwriting next", () => {
+  assert.equal(
+    resolveVersion(
+      "push",
+      "branch",
+      "release/v3.8.49",
+      "",
+      "release/v3.8.50",
+    ),
+    "skip",
   );
+  assert.match(WORKFLOW, /\[ "\$VERSION" = "skip" \]/);
+  assert.match(WORKFLOW, /echo "skip=true" >> "\$GITHUB_OUTPUT"/);
 });
 
 test("existing main, tag, dispatch, and release behavior is preserved", () => {


### PR DESCRIPTION
Fixes #11523. Treats Docker publishing from non-default frozen release branches as an expected no-op while preserving the guard against overwriting the next channel. Focused tests: 7/7 pass; build-scope check pass; focused ESLint pass; diff check clean. ⚠️ base-red inherited: #11449 (full lint reproduces 275 pre-existing errors outside this diff).