### PR TITLE
fix(responses): preserve json_object response format

### DIFF
--- a/changelog.d/fixes/oss026-chat-responses-json-object.md
+++ b/changelog.d/fixes/oss026-chat-responses-json-object.md
@@ -1,0 +1,1 @@
+- Preserve Chat Completions JSON-object response formats when translating requests to the Responses API.

--- a/open-sse/translator/request/openai-responses/toResponses.ts
+++ b/open-sse/translator/request/openai-responses/toResponses.ts
@@ -29,11 +29,15 @@ import {
 const DEFAULT_RESPONSES_REASONING_SUMMARY = "auto";
 const RESPONSES_REASONING_ENCRYPTED_CONTENT_INCLUDE = "reasoning.encrypted_content";
 
-// Chat Completions `response_format: { type: "json_schema" }` → Responses API `text.format`.
+// Chat Completions JSON `response_format` → Responses API `text.format`.
 // Merges into any existing `result.text` (e.g. verbosity) so structured-output schemas from
 // Chat clients survive the translation to the Responses/Codex upstream (#5933).
 function mapChatResponseFormatToResponsesText(body: JsonRecord, result: JsonRecord): void {
   const responseFormat = toRecord(body.response_format);
+  if (responseFormat.type === "json_object") {
+    result.text = { ...toRecord(result.text), format: { type: "json_object" } };
+    return;
+  }
   if (responseFormat.type !== "json_schema") return;
 
   const jsonSchema = toRecord(responseFormat.json_schema);

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -683,6 +683,25 @@ test("Chat -> Responses converts json_schema response_format to text.format", ()
   assert.equal(result.response_format, undefined);
 });
 
+test("Chat -> Responses converts json_object response_format to text.format", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.2-codex",
+    {
+      messages: [{ role: "user", content: "Return the answer as JSON" }],
+      response_format: { type: "json_object" },
+    },
+    false,
+    null
+  ) as { text?: unknown; response_format?: unknown };
+
+  assert.deepEqual(result.text, {
+    format: {
+      type: "json_object",
+    },
+  });
+  assert.equal(result.response_format, undefined);
+});
+
 test("Chat -> Responses uses response_format over nonstandard chat text.format", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-5.2-codex",


### PR DESCRIPTION
Preserves Chat Completions response_format type json_object when translating to Responses text.format, restoring symmetry with the reverse translator. Tests: 58/58 focused pass; focused ESLint, build-scope and diff checks pass. ⚠️ base-red inherited: #11449.