### PR TITLE
fix(dashboard): restore the return( clobbered by the #11088 merge

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -2360,19 +2360,7 @@ function ProviderModelsModal({
         <div className="flex flex-col gap-1">
           {groupModels.map((m) => {
             const copyKey = `modal-${m.id}`;
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2 mb-2">
-        <h1 className="text-2xl font-bold">{t("endpoint.title")}</h1>
-        <p className="text-text-muted">{t("endpoint.subtitle")}</p>
-        <div className="flex items-center gap-3 mt-2">
-          <code className="text-sm bg-card-subtle px-3 py-1 rounded-md text-text-main font-mono">{useDisplayBaseUrl()}/v1</code>
-          <a href="#test" className="text-sm text-action font-medium hover:underline">{t("endpoint.testEndpoint")}</a>
-        </div>
-      </div>
-      <div className="flex items-center gap-2 text-xs text-text-muted">
-        <span>{t("endpoint.advancedProtocols")}</span>
-      </div>
+            return (
               <div
                 key={m.id}
                 className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-surface/60 group"

--- a/tests/unit/app-router-tsx-syntax.test.ts
+++ b/tests/unit/app-router-tsx-syntax.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// A botched merge resolution can splice a stray fragment into the middle of a
+// component and leave the file syntactically invalid. Until now the only gate
+// catching that was `npm run build` inside the Docker publish job — so a broken
+// merge landed on main (#11088) and silently blocked every image push for two
+// days while the parse error sat in a single .tsx file.
+//
+// Parsing (no type-checking) the App Router tree costs well under a second and
+// moves that feedback into the unit suite, where it lands on the PR instead of
+// on the release pipeline.
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const APP_DIR = path.join(REPO_ROOT, "src/app");
+
+function collectTsxFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectTsxFiles(full, found);
+    } else if (entry.name.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+test("every App Router .tsx file parses without syntax errors", () => {
+  const files = collectTsxFiles(APP_DIR);
+  assert.ok(files.length > 0, "expected to find .tsx files under src/app");
+
+  const broken: string[] = [];
+  for (const file of files) {
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, "utf8"),
+      ts.ScriptTarget.ES2022,
+      /* setParentNodes */ false,
+      ts.ScriptKind.TSX
+    );
+
+    // parseDiagnostics is internal but stable, and it is the only way to read
+    // syntax errors without standing up a full Program (which would pull in
+    // type-checking and turn a sub-second parse into a multi-minute run).
+    const diagnostics = (source as unknown as { parseDiagnostics?: ts.Diagnostic[] })
+      .parseDiagnostics;
+
+    for (const diagnostic of diagnostics ?? []) {
+      const { line } = source.getLineAndCharacterOfPosition(diagnostic.start ?? 0);
+      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+      broken.push(`${path.relative(REPO_ROOT, file)}:${line + 1} — ${message}`);
+    }
+  }
+
+  assert.deepEqual(broken, [], `Syntax errors in App Router files:\n${broken.join("\n")}`);
+});


### PR DESCRIPTION
## Sintoma

`Build App` e `Publish to Docker Hub` falham em **todo push para `main` desde 2026-08-23**. Consequência: a tag flutuante `diegosouzapw/omniroute:main` não é republicada desde **2026-08-22 01:27**, e toda instalação que a acompanha (Watchtower/compose apontando para `:main`) está presa naquela imagem — o Watchtower loga `Scanned=1 Updated=0` corretamente, porque de fato não há nada novo no registry.

```
./src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx:2397:11
Error: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
Error: Turbopack build failed with 3 errors
```

## Causa-raiz

A resolução de merge em `65e81158a` (#11088) substituiu o `return (` de dentro do callback `groupModels.map()` em `renderModelGroup` por um fragmento de 13 linhas vindo de **outra parte do arquivo** — o `return` de topo do componente, incluindo uma chamada do hook `useDisplayBaseUrl()` dentro de um `.map()` e chaves `t("endpoint.title" | "endpoint.subtitle" | "endpoint.testEndpoint" | "endpoint.advancedProtocols")`.

Essas chaves não existem nem em `release/v3.8.51` nem no commit pai `c68cda7df`: o fragmento é conteúdo morto ressuscitado por merge, não código válido que se perdeu.

## Correção

Remover o fragmento e restaurar `return (`. Depois disso, `renderModelGroup` fica **byte-idêntico** ao de `release/v3.8.51`, que nunca carregou a corrupção:

```
diff <(git show origin/release/v3.8.51:<file> | sed -n '/const renderModelGroup/,/^  };/p') \
     <(sed -n '/const renderModelGroup/,/^  };/p' <file>)   # sem diferenças
```

Nenhuma outra branch está afetada — `release/v3.8.50` e `release/v3.8.51` têm o bloco íntegro.

## Validação (Hard Rule #18 — failing-then-passing)

Novo guard `tests/unit/app-router-tsx-syntax.test.ts`: faz o parse dos 723 `.tsx` de `src/app` via `ts.createSourceFile` e exige zero diagnósticos de sintaxe. Não faz type-checking, então roda em ~0,35s.

| Alvo | Resultado |
| --- | --- |
| `EndpointPageClient.tsx` em `origin/main` (pré-fix) | **FAIL** — 35 diagnósticos, o primeiro em `:2397 — Unexpected token. Did you mean {'}'} or &rbrace;?` |
| Árvore corrigida (`src/app`, 723 arquivos) | **PASS** — 0 diagnósticos |

A mensagem e a linha batem exatamente com o que o Turbopack reportou, ou seja, o teste cobre a falha real e não um proxy dela.

Varredura adicional: os **3738** arquivos `.ts`/`.tsx` tocados por `65e81158a` foram submetidos ao parser — a corrupção estava isolada neste único arquivo.

Por que o teste existe: até agora o único gate que pegava essa classe de erro era o `npm run build` dentro do job de Docker. Isso empurra o feedback para o PR, e não para o pipeline de release.

## Observações

- **base-red herdado (não corrigido aqui, por política):** `check:tracked-artifacts` falha em `main` porque o mesmo commit `65e81158a` voltou a rastrear `docs/superpowers/plans/2026-08-23-qdrant-configuration-guidance.md` e `docs/superpowers/specs/2026-08-23-qdrant-configuration-guidance-design.md`. Isso **não** bloqueia a publicação da imagem (o `docker-publish.yml` não roda esse gate), mas deixa `main` vermelha. Correção é `git rm --cached` nos dois — merece PR próprio.
- Independente disto, `Publish to Docker Hub` também falha nas branches de release: `release/v3.8.50` por `Refusing to publish next from non-default release branch` (já rastreado em #11523) e `release/v3.8.51` por `Export resolveLiveWsUrl doesn't exist in target module`.
- Gates rodados localmente: `prettier --check` (PASS nos 2 arquivos), `check-docs-sync` (PASS), `check:any-budget:t11` (PASS). `eslint` não pôde rodar neste ambiente (sem `node_modules`); fica para o CI.
