### PR TITLE
fix: accept Gemini Web cookie exports

### DIFF
--- a/open-sse/executors/gemini-web.ts
+++ b/open-sse/executors/gemini-web.ts
@@ -15,6 +15,7 @@
 
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
 import { buildErrorBody, sanitizeErrorMessage } from "../utils/error.ts";
+import { normalizeGeminiCookieInput } from "../utils/geminiCookies.ts";
 import { prepareToolMessages } from "../translator/webTools.ts";
 import { buildToolModeResponse } from "./chatgptWebTools.ts";
 import {
@@ -385,12 +386,6 @@ export function mergeRotatedGeminiCookies(
   }
 
   return merged.map(({ name, value }) => `${name}=${value}`).join("; ");
-}
-
-function normalizeGeminiCookieInput(raw: string, cookieName = "__Secure-1PSID"): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return "";
-  return trimmed.includes("=") ? trimmed : `${cookieName}=${trimmed}`;
 }
 
 function resolveGeminiWebCookie(credentials: ExecuteInput["credentials"]): string {

--- a/open-sse/utils/geminiCookies.ts
+++ b/open-sse/utils/geminiCookies.ts
@@ -1,0 +1,26 @@
+type CookieRecord = Record<string, unknown>;
+
+function cookiePairsFromJson(raw: string): string[] {
+  if (!raw.startsWith("{")) return [];
+  try {
+    const parsed = JSON.parse(raw) as CookieRecord;
+    const cookies =
+      parsed.cookies && typeof parsed.cookies === "object" && !Array.isArray(parsed.cookies)
+        ? (parsed.cookies as CookieRecord)
+        : parsed;
+    return Object.entries(cookies)
+      .filter(([, value]) => typeof value === "string" && value.trim().length > 0)
+      .map(([name, value]) => `${name}=${String(value).trim()}`);
+  } catch {
+    return [];
+  }
+}
+
+/** Normalize a pasted Gemini cookie header, bare PSID, or browser-export JSON. */
+export function normalizeGeminiCookieInput(raw: string, cookieName = "__Secure-1PSID"): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  const jsonPairs = cookiePairsFromJson(trimmed);
+  if (jsonPairs.length > 0) return jsonPairs.join("; ");
+  return trimmed.includes("=") ? trimmed : `${cookieName}=${trimmed}`;
+}

--- a/src/lib/providers/validation/webProvidersB.ts
+++ b/src/lib/providers/validation/webProvidersB.ts
@@ -11,6 +11,7 @@ import {
 } from "./transport";
 import { SafeOutboundFetchError } from "@/shared/network/safeOutboundFetch";
 import { normalizeSessionCookieHeader } from "@/lib/providers/webCookieAuth";
+import { normalizeGeminiCookieInput } from "@omniroute/open-sse/utils/geminiCookies.ts";
 import { buildJulesApiUrl } from "@/lib/cloudAgent/julesApi.ts";
 import {
   META_AI_ASBD_ID,
@@ -213,11 +214,8 @@ export async function validateGeminiWebProvider({ apiKey, providerSpecificData =
       return { valid: false, error: "Paste your __Secure-1PSID cookie from gemini.google.com" };
     }
 
-    // Accept full cookie blob or bare value
-    let cookieHeader = raw;
-    if (!raw.includes("=")) {
-      cookieHeader = `__Secure-1PSID=${raw}`;
-    }
+    // Accept full cookie blob, bare value, or browser-export JSON.
+    const cookieHeader = normalizeGeminiCookieInput(raw);
 
     const response = await validationRead("https://gemini.google.com/app", {
       headers: applyCustomUserAgent(

--- a/src/shared/constants/providers/web-cookie.ts
+++ b/src/shared/constants/providers/web-cookie.ts
@@ -52,7 +52,7 @@ export const WEB_COOKIE_PROVIDERS = {
     textIcon: "GWeb",
     website: "https://gemini.google.com",
     authHint:
-      "Paste your __Secure-1PSID cookie value from gemini.google.com. Optionally add __Secure-1PSIDTS separated by semicolon.",
+      "Paste the full cookie header, the __Secure-1PSID value, or the JSON export containing cookies from gemini.google.com. Include __Secure-1PSIDTS and __Secure-1PSIDCC when available.",
     subscriptionRisk: true,
     riskNoticeVariant: "webCookie",
     // #7286 Level 2: tools[] is prompt-emulated via webTools.ts (parseToolCallsFromText).

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -82,6 +82,9 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     kind: "cookie",
     credentialName: "__Secure-1PSID (optional: __Secure-1PSIDTS)",
     placeholder: "__Secure-1PSID=...; __Secure-1PSIDTS=...",
+    hintKey: "geminiWebCookieHint",
+    hintFallback:
+      'Accepted formats: full Cookie header without the "Cookie:" prefix, a single __Secure-1PSID value, or browser-export JSON such as {"cookies":{"__Secure-1PSID":"...","__Secure-1PSIDTS":"...","__Secure-1PSIDCC":"..."}}.',
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie", "__Secure-1PSID", "__Secure-1PSIDTS"],
   },
@@ -356,8 +359,7 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
   "conol-web": {
     kind: "cookie",
     credentialName: "__Secure-better-auth.session_token",
-    placeholder:
-      "__Secure-better-auth.session_token=... or full Cookie header from conol.ai",
+    placeholder: "__Secure-better-auth.session_token=... or full Cookie header from conol.ai",
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie", "__Secure-better-auth.session_token"],
   },

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -2576,6 +2576,29 @@ test("gemini-web validator: bare value gets __Secure-1PSID prefix", async () => 
   assert.equal(capturedCookie, "__Secure-1PSID=eyJbarevalue");
 });
 
+test("gemini-web validator: accepts cookies JSON exported by browser tools", async () => {
+  let capturedCookie = "";
+  globalThis.fetch = async (url, init = {}) => {
+    if (String(url).includes("gemini.google.com")) {
+      capturedCookie = ((init.headers as Record<string, string>) || {}).Cookie || "";
+      return new Response("ok", { status: 200 });
+    }
+    throw new Error(`unexpected fetch: ${String(url)}`);
+  };
+
+  await validateProviderApiKey({
+    provider: "gemini-web",
+    apiKey: JSON.stringify({
+      cookies: {
+        "__Secure-1PSID": "psid-json",
+        "__Secure-1PSIDTS": "psidts-json",
+      },
+    }),
+  });
+
+  assert.equal(capturedCookie, "__Secure-1PSID=psid-json; __Secure-1PSIDTS=psidts-json");
+});
+
 test("gemini-web validator: 401 → invalid cookie", async () => {
   globalThis.fetch = async () => new Response("unauthorized", { status: 401 });
 


### PR DESCRIPTION
Accept full cookie headers, bare PSID values, and browser-exported JSON cookie objects. Normalize the same input for validation and Playwright execution, and document the accepted formats. Tests: Gemini executor 14/14, provider validation 124/124, typecheck core passed.