### PR TITLE
fix(search): prefer credentialed providers over duckduckgo-free fallback (#11524)

### DIFF
--- a/changelog.d/fixes/11524-search-credentialed-over-fallback.md
+++ b/changelog.d/fixes/11524-search-credentialed-over-fallback.md
@@ -1,0 +1,1 @@
+- fix(search): prefer credentialed providers over duckduckgo-free fallback (#11524) — the fallback-only loop ran before the credentialed-providers loop in `executeWebSearch`, making configured providers unreachable when `duckduckgo-free` was available.

--- a/src/lib/search/executeWebSearch.ts
+++ b/src/lib/search/executeWebSearch.ts
@@ -186,6 +186,28 @@ export async function executeWebSearch(
     credentials = await resolveSearchCredentials(providerConfig.id);
 
     if (!credentials) {
+      // 1. Try credentialed providers first, sorted by cost. Fallback-only
+      // providers are reached only if no configured provider is available.
+      const sortedIds = Object.values(SEARCH_PROVIDERS)
+        .filter((provider) => !provider.fallbackOnly && supportsSearchType(provider, searchType))
+        .sort((a, b) => a.costPerQuery - b.costPerQuery)
+        .map((provider) => provider.id);
+
+      for (const providerId of sortedIds) {
+        if (providerId === providerConfig.id) continue;
+        const altConfig = getSearchProvider(providerId);
+        const altCreds = await resolveSearchCredentials(providerId);
+        if (altConfig && altCreds) {
+          providerConfig = altConfig;
+          credentials = altCreds;
+          break;
+        }
+      }
+    }
+
+    if (!credentials) {
+      // 2. Last resort: fallback-only providers so out-of-the-box search
+      // still works when no credentialed provider is configured.
       const fallbackProviders = Object.values(SEARCH_PROVIDERS)
         .filter((provider) => provider.fallbackOnly && supportsSearchType(provider, searchType))
         .sort((a, b) => a.costPerQuery - b.costPerQuery);
@@ -205,24 +227,6 @@ export async function executeWebSearch(
     }
 
     if (!credentials) {
-      const sortedIds = Object.values(SEARCH_PROVIDERS)
-        .filter((provider) => supportsSearchType(provider, searchType))
-        .sort((a, b) => a.costPerQuery - b.costPerQuery)
-        .map((provider) => provider.id);
-
-      for (const providerId of sortedIds) {
-        if (providerId === providerConfig.id) continue;
-        const altConfig = getSearchProvider(providerId);
-        const altCreds = await resolveSearchCredentials(providerId);
-        if (altConfig && altCreds) {
-          providerConfig = altConfig;
-          credentials = altCreds;
-          break;
-        }
-      }
-    }
-
-    if (!credentials) {
       throw new WebSearchExecutionError(
         `No credentials configured for any search provider. Add an API key for a search provider (${Object.keys(
           SEARCH_PROVIDERS
@@ -231,8 +235,10 @@ export async function executeWebSearch(
       );
     }
 
+    // Exclude fallback-only providers from execution-time alternates.
+    // They are reserved for last-resort primary selection.
     const otherIds = Object.values(SEARCH_PROVIDERS)
-      .filter((provider) => supportsSearchType(provider, searchType))
+      .filter((provider) => !provider.fallbackOnly && supportsSearchType(provider, searchType))
       .sort((a, b) => a.costPerQuery - b.costPerQuery)
       .map((provider) => provider.id)
       .filter((providerId) => providerId !== providerConfig!.id);

--- a/tests/unit/execute-web-search-fallback-11524.test.ts
+++ b/tests/unit/execute-web-search-fallback-11524.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-execute-web-search-fallback-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { executeWebSearch } = await import("../../src/lib/search/executeWebSearch.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedConnection(
+  provider: string,
+  overrides: {
+    apiKey?: string | null;
+    authType?: string;
+    providerSpecificData?: Record<string, unknown>;
+  } = {}
+) {
+  return providersDb.createProviderConnection({
+    provider,
+    authType: overrides.authType || "apikey",
+    name: `${provider}-${Math.random().toString(16).slice(2, 8)}`,
+    apiKey: overrides.apiKey ?? "test-key",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: overrides.providerSpecificData || {},
+  });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// Regression test for #11524 — executeWebSearch must prefer a credentialed
+// provider over duckduckgo-free when the initially selected provider has no credentials.
+test("auto-selects credentialed provider before duckduckgo-free fallback (#11524)", async () => {
+  await seedConnection("brave-search", { apiKey: "brave-key" });
+
+  const originalFetch = globalThis.fetch;
+  const fetchCalls: string[] = [];
+
+  globalThis.fetch = async (url, _init = {}) => {
+    const urlStr = String(url);
+    fetchCalls.push(urlStr);
+
+    if (urlStr.includes("api.search.brave.com")) {
+      return new Response(
+        JSON.stringify({
+          web: {
+            results: [
+              {
+                title: "Brave result",
+                url: "https://example.com/brave",
+                description: "Brave search result",
+              },
+            ],
+            totalCount: 1,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+
+    throw new Error(`Unexpected fetch to ${urlStr} in auto-select path`);
+  };
+
+  try {
+    const result = await executeWebSearch({ query: "latest omniroute roadmap" });
+
+    assert.equal(
+      result.data.provider,
+      "brave-search",
+      "must use the configured credentialed provider, not duckduckgo-free"
+    );
+    assert.ok(
+      fetchCalls.some((url) => url.includes("api.search.brave.com")),
+      "must call the Brave Search endpoint"
+    );
+    assert.ok(
+      !fetchCalls.some((url) => url.includes("duckduckgo.com")),
+      "duckduckgo-free must NOT be invoked when a credentialed provider is available (#11524)"
+    );
+    assert.equal(result.data.results.length, 1);
+    assert.equal(result.data.results[0].title, "Brave result");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

When `executeWebSearch` auto-selects a search provider, it could choose
`duckduckgo-free` before checking whether another configured provider had
credentials available.

This meant that a configured provider such as `brave-search` could be
available but would only be reached through the fallback path after the
DuckDuckGo request failed.

This change makes credentialed non-fallback providers take priority, while
keeping `duckduckgo-free` as the last-resort option for zero-config setups.

## Related Issues

- Closes #11524 

## Validation

- [x] Change type: routing
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Production-code changes include a new automated test in this PR

## Tests Added Or Updated

- `tests/unit/execute-web-search-fallback-11524.test.ts`
  - Adds a regression test with `brave-search` credentials configured.
  - Verifies that `brave-search` is selected.
  - Verifies that `duckduckgo-free` is never invoked.

Focused search tests were also rerun and passed.

## Coverage Notes

`src/lib/search/executeWebSearch.ts` is covered by the new regression test.

The change is limited to provider selection and execution-time alternate
selection. No database schema, migrations, dependencies, or API contracts
were changed.

## Reviewer Notes

The fix changes the auto-selection order so configured credentialed
non-fallback providers are checked before fallback-only providers.

Zero-config behavior remains unchanged: when no credentialed provider is
available, `duckduckgo-free` can still be selected as the fallback.

Explicit provider selection is unchanged.

The regression test was first run against the original implementation and
failed because `duckduckgo-free` was actually invoked. After the production
change, the same test passed.

The broader `skills-pipeline` integration test was also compared against the
original implementation; its remaining skill-injection/context failures are
pre-existing and unrelated to this change.