### PR TITLE
fix(sse): explicit types for openai-responses pureHelpers — clears last failing core typecheck gate

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -159,11 +159,6 @@
       "count": 1
     }
   },
-  "open-sse/executors/index.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "open-sse/executors/kiro.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 3
@@ -472,11 +467,6 @@
     }
   },
   "open-sse/services/autoCombo/pipelineRouter.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 2
-    }
-  },
-  "open-sse/services/autoCombo/routerStrategy.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 2
     }

--- a/open-sse/translator/response/openai-responses/pureHelpers.ts
+++ b/open-sse/translator/response/openai-responses/pureHelpers.ts
@@ -1,7 +1,20 @@
 // Pure, stateless helpers for the OpenAI Responses <-> Chat response translator.
 // Extracted verbatim from response/openai-responses.ts (no host imports, no stream state).
 
-export function normalizeToolName(value) {
+// Minimal structural view of the tool JSON-Schema subset this module inspects. Values
+// arrive straight from request payloads, so fields stay `unknown` and every access site
+// narrows them with runtime guards — the guards below remain the source of truth.
+interface ToolArgSchema {
+  description?: unknown;
+  type?: unknown;
+  enum?: unknown;
+  properties?: Record<string, ToolArgSchema>;
+  required?: unknown;
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+export function normalizeToolName(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
@@ -14,7 +27,7 @@ const STRIPPABLE_EMPTY_ARG_TOOLS = new Set(["Read", "Subagent"]);
 
 // Deep-equal for JSON-shaped values (schema `default` comparison). Cheap and safe:
 // tool args are always JSON-serializable, so a stringify comparison is exact.
-function jsonValuesEqual(a, b) {
+function jsonValuesEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   try {
@@ -24,43 +37,52 @@ function jsonValuesEqual(a, b) {
   }
 }
 
-function hasUsableSchema(schema) {
+function hasUsableSchema(schema: unknown): schema is ToolArgSchema {
   return !!(schema && typeof schema === "object" && !Array.isArray(schema));
 }
 
-function schemaProperties(schema) {
-  return hasUsableSchema(schema) && schema.properties && typeof schema.properties === "object"
-    ? schema.properties
-    : null;
+function schemaProperties(schema: unknown): Record<string, ToolArgSchema> | null {
+  if (!hasUsableSchema(schema)) return null;
+  return schema.properties && typeof schema.properties === "object" ? schema.properties : null;
 }
 
-function schemaRequiredSet(schema) {
-  return new Set(hasUsableSchema(schema) && Array.isArray(schema.required) ? schema.required : []);
+function schemaRequiredSet(schema: unknown): Set<unknown> {
+  const required = hasUsableSchema(schema) ? schema.required : null;
+  return new Set(Array.isArray(required) ? required : []);
 }
 
-function isEmptyToolArgValue(entry) {
+function isEmptyToolArgValue(entry: unknown): boolean {
   return entry === "" || (Array.isArray(entry) && entry.length === 0);
 }
 
 // True when `entry` strictly equals the property's declared JSON Schema `default` — an
 // emitted value indistinguishable from omission, safe to drop for any tool.
-function matchesSchemaDefault(propSchema, entry) {
+function matchesSchemaDefault(
+  propSchema: ToolArgSchema | null | undefined,
+  entry: unknown
+): boolean {
   if (!propSchema || !Object.prototype.hasOwnProperty.call(propSchema, "default")) return false;
   return jsonValuesEqual(entry, propSchema.default);
 }
 
 // True when `entry` is empty and either the tool is on the legacy allowlist, or the
 // schema declares this property but does not mark it `required` (generalized #6951 rule).
-function isDroppableEmptyEntry(entry, propSchema, required, key, allowlisted) {
+function isDroppableEmptyEntry(
+  entry: unknown,
+  propSchema: ToolArgSchema | null | undefined,
+  required: Set<unknown>,
+  key: string,
+  allowlisted: boolean
+): boolean {
   if (!isEmptyToolArgValue(entry)) return false;
   return allowlisted || (propSchema != null && !required.has(key));
 }
 
-function schemaTypeIncludes(type, wanted) {
+function schemaTypeIncludes(type: unknown, wanted: string): boolean {
   return type === wanted || (Array.isArray(type) && type.includes(wanted));
 }
 
-function hasOmissionSentinel(propSchema) {
+function hasOmissionSentinel(propSchema: ToolArgSchema | null | undefined): boolean {
   if (!propSchema || typeof propSchema !== "object") return false;
   if (
     typeof propSchema.description !== "string" ||
@@ -80,14 +102,24 @@ function hasOmissionSentinel(propSchema) {
 // injectOptionalStringOmissionSentinel. Drop the key when the model follows that idiom
 // for a non-required, schema-declared property, or when OmniRoute's marker is present
 // even after an upstream strictifies the field into `required`.
-function isDroppableNullEntry(entry, propSchema, required, key, toolName) {
+function isDroppableNullEntry(
+  entry: unknown,
+  propSchema: ToolArgSchema | null | undefined,
+  required: Set<unknown>,
+  key: string,
+  toolName: string
+): boolean {
   if (entry !== null) return false;
   if (toolName === "Agent") return true;
   if (propSchema == null) return false;
   return !required.has(key) || hasOmissionSentinel(propSchema);
 }
 
-function stripEmptyOptionalToolArgsObject(value, toolName, schema) {
+function stripEmptyOptionalToolArgsObject(
+  value: Record<string, unknown>,
+  toolName: string,
+  schema: unknown
+): Record<string, unknown> {
   const properties = schemaProperties(schema);
   const required = schemaRequiredSet(schema);
   const allowlisted = STRIPPABLE_EMPTY_ARG_TOOLS.has(toolName);
@@ -116,7 +148,11 @@ function stripEmptyOptionalToolArgsObject(value, toolName, schema) {
 //     Read/Subagent allowlist above.
 // Without a schema, behavior is unchanged (allowlist + empty-only), preserving existing
 // callers that only pass (value, toolName).
-export function stripEmptyOptionalToolArgs(value, toolName, schema) {
+export function stripEmptyOptionalToolArgs(
+  value: unknown,
+  toolName: string,
+  schema: unknown
+): unknown {
   if (value == null) return value;
 
   if (typeof value === "string") {
@@ -143,29 +179,33 @@ export function stripEmptyOptionalToolArgs(value, toolName, schema) {
 
   if (Array.isArray(value) || typeof value !== "object") return value;
 
-  return stripEmptyOptionalToolArgsObject(value, toolName, schema);
+  return stripEmptyOptionalToolArgsObject(value as Record<string, unknown>, toolName, schema);
 }
 
-export function normalizeOutputIndex(outputIndex) {
+export function normalizeOutputIndex(outputIndex: unknown): number {
   const normalized = Number(outputIndex);
   return Number.isInteger(normalized) && normalized >= 0 ? normalized : 0;
 }
 
-export function normalizeUpstreamFailure(data, fallbackType = "server_error") {
-  const response = data?.response && typeof data.response === "object" ? data.response : null;
+export function normalizeUpstreamFailure(data: unknown, fallbackType = "server_error") {
+  const root = (data && typeof data === "object" ? data : {}) as Record<string, unknown>;
+  const response =
+    root.response && typeof root.response === "object"
+      ? (root.response as Record<string, unknown>)
+      : null;
   const error =
     response?.error && typeof response.error === "object"
-      ? response.error
-      : data?.error && typeof data.error === "object"
-        ? data.error
+      ? (response.error as Record<string, unknown>)
+      : root.error && typeof root.error === "object"
+        ? (root.error as Record<string, unknown>)
         : null;
 
   const code = typeof error?.code === "string" ? error.code : "";
   const message =
     typeof error?.message === "string"
       ? error.message
-      : typeof data?.message === "string"
-        ? data.message
+      : typeof root.message === "string"
+        ? root.message
         : "Upstream failure";
 
   // Preserve upstream error semantics:
@@ -195,15 +235,17 @@ export function normalizeUpstreamFailure(data, fallbackType = "server_error") {
   };
 }
 
-export function extractResponsesReasoningSummaryText(item) {
-  if (!item || !Array.isArray(item.summary)) return "";
+export function extractResponsesReasoningSummaryText(item: unknown): string {
+  const summary = item && typeof item === "object" ? (item as { summary?: unknown }).summary : null;
+  if (!Array.isArray(summary)) return "";
   // #9500 — reasoning summary parts are discrete segments; join with "\n\n"
   // (matches extractThinkingFromContent convention). Filter empties so an
   // empty summary_text element does not produce a dangling separator.
-  return item.summary
-    .map((part) =>
-      part && typeof part === "object" && typeof part.text === "string" ? part.text : ""
-    )
+  return summary
+    .map((part) => {
+      const p = part as { text?: unknown } | null;
+      return p && typeof p === "object" && typeof p.text === "string" ? p.text : "";
+    })
     .filter((text) => text.length > 0)
     .join("\n\n");
 }
@@ -221,6 +263,6 @@ export function extractResponsesReasoningSummaryText(item) {
 //     would display it as if it were real reasoning. Return empty so synthetic
 //     summary events are suppressed; the reasoning item (with `encrypted_content`)
 //     still arrives on `response.output_item.done`.
-export function getVisibleResponsesReasoningSummaryText(item) {
+export function getVisibleResponsesReasoningSummaryText(item: unknown): string {
   return extractResponsesReasoningSummaryText(item);
 }


### PR DESCRIPTION
⚠️ base-red inherited: #11449 — `release/v3.8.51` was already failing before this branch. None of those failures are touched here.

## Summary

Follow-up to audit `2026-08-25_bash-code-audit-v2.md` §0 ("this checkout cannot verify itself"). Two commits, three distinct problems: one environmental (fixed with no code change), two real and fixed in code/config. The PR's theme throughout: make the verification gates verifiable again.

| Commit | File(s) | Nature |
|---|---|---|
| `9305a316a` | `open-sse/translator/response/openai-responses/pureHelpers.ts` | type annotations only (75+/33−) |
| `7ca179f4f` | `config/quality/eslint-suppressions.json` | prune 2 stale entries (10 deletions) |

## What was broken

**1. Environment — checkout had no dependencies installed (root cause of §0)**

- `node_modules` was **completely empty (0 packages)** — the audit guessed "incomplete/stale install"; reality: never installed in this checkout.
- Result: ~21 files with TS2307 `Cannot find module 'zod'`, plus a ~400+ error cascade of TS2591/TS2503/TS2304 (`process`, `Buffer`, `NodeJS`, `setImmediate`) from unresolved `@types/node`.

**2. Code — 36 genuine implicit-any errors hidden under that noise**

- After the env restore, `typecheck:noimplicit:core` still failed (exit 2) with 36 × TS7006, all in one file: `open-sse/translator/response/openai-responses/pureHelpers.ts`.
- Cause: helpers were "extracted verbatim" from the host translator without parameter annotations. Not environment-related, not zod-related.

**3. Config — `lint:json --max-warnings 0` exits 2 on stale suppression enforcement**

- ESLint reports suppressions whose violations no longer occur anywhere; its staleness enforcement fails the gate.
- **Verified inherited, not introduced here**: reproduced exit 2 on a clean detached worktree at pristine `origin/release/v3.8.51` tip (`107802255`), which this branch is cut from. Per-file lint results are independent, and neither affected file is touched by commit 1.
- Stale entries: `open-sse/executors/index.ts` (`@typescript-eslint/no-unused-vars`, count 1) and `open-sse/services/autoCombo/routerStrategy.ts` (same rule, count 2).

## What was fixed

### Fix 1 — Environment restore (no commit)

`npm install` → 2,425 packages restored (`zod@4.4.3`, `@types/node`, etc.), 0 vulnerabilities.
`npm run typecheck:core`: hundreds of errors → **exit 0**.

### Audit §0's six "possibly phantom" errors — confirmed PHANTOM

All six were inference cascades from zod resolving to `{}` and vanished with the install, exactly as the audit predicted. Zero code changes made to these files:

| Reported | Location |
|---|---|
| TS2339 `compositeTiers` | `open-sse/services/combo.ts:372` |
| TS18046 `rules`/`total` | `settingsSchemas.ts:317–318` |
| TS2322 null-vs-undefined | `modelSyncScheduler.ts:126,128` |
| TS2322 null-vs-undefined | `cliRuntime.ts:567` |

### Fix 2 — explicit types in `pureHelpers.ts` (commit `9305a316a`)

Type-only, behavior-preserving, no `any` (ESLint `no-explicit-any` is an error in `open-sse/`). All upstream call sites were checked first: every consumer uses `typeof x === "string" ? x : JSON.stringify(x)` patterns, so `unknown` returns are safe.

Edits in `open-sse/translator/response/openai-responses/pureHelpers.ts` (line numbers are post-edit):

| Lines | Change |
|---|---|
| :7 | New `interface ToolArgSchema` — minimal structural view of the tool JSON-Schema subset; fields stay `unknown`, runtime guards remain the source of truth |
| :17–:147 | Explicit signatures on internal helpers: `normalizeToolName` (:17), `jsonValuesEqual` (:30), `hasUsableSchema` (:40, now a type predicate), `schemaProperties` (:44), `schemaRequiredSet` (:49), `isEmptyToolArgValue` (:54), `matchesSchemaDefault` (:60), `isDroppableEmptyEntry` (:70), `schemaTypeIncludes` (:81), `hasOmissionSentinel` (:85), `isDroppableNullEntry` (:105), `stripEmptyOptionalToolArgsObject` (:118) |
| :151, :185, :190, :238, :266 | Exported functions annotated: `stripEmptyOptionalToolArgs`, `normalizeOutputIndex`, `normalizeUpstreamFailure`, `extractResponsesReasoningSummaryText`, `getVisibleResponsesReasoningSummaryText` |

Two bodies restructured for type narrowing with identical runtime semantics:

- `normalizeUpstreamFailure` (:190): `data?.response/error/message` → one `Record<string, unknown>` cast of `data` + `root.*` accesses. Same short-circuit outcomes for null/primitives/arrays.
- `extractResponsesReasoningSummaryText` (:238): `item.summary` extracted through a cast before the existing `Array.isArray` guard. Same `""` result for non-object input.

No logic, ordering, or guard conditions changed anywhere else.

### Fix 3 — prune the 2 stale suppressions (commit `7ca179f4f`)

Mechanical `--prune-suppressions` run; nothing hand-edited beyond restoring the trailing newline. No allowlist semantics weakened — each removed entry suppressed a violation ESLint confirms no longer exists. This complies with the repo's own stale-enforcement policy (AGENTS.md → Quality Gates → Allowlist policy).

## Verification (all run this session)

| Check | Before | After |
|---|---|---|
| `npm run typecheck:core` | ❌ hundreds of errors | ✅ exit 0 |
| `npm run typecheck:noimplicit:core` | ❌ exit 2 (36 × TS7006) | ✅ exit 0 |
| `npm run lint:json -- --max-warnings 0` | ❌ exit 2 (stale suppressions) | ✅ exit 0 |
| `npm run lint` (CI blocking variant) | — | ✅ exit 0 |
| Unit tests covering the pureHelpers leaf (7 files) | — | ✅ 51/51 pass |
| ESLint + Prettier on changed files | — | ✅ clean |
| Pre-commit hooks (lint-staged, docs-sync, any-budget, tracked-artifacts) | — | ✅ all green on both commits |

Inheritance proof for Fix 3: detached worktree at `origin/release/v3.8.51` (`107802255`) + junctioned `node_modules` → `npm run lint:json -- --max-warnings 0` = **exit 2**, same message. Worktree torn down after.

Test files for Fix 2: `repro-6951`, `repro-7023`, `repro-9500-reasoning-separator`, `encrypted-reasoning-summary-7243`, `openai-responses-opencode-subagent-sessionid`, `openai-responses-subagent-strip-2446`, `response-openai-responses-purehelpers-split`.

## Not tested / honest caveats

- **No new tests added**: both changes are mechanical (annotations with intended zero behavioral delta; config pruning enforced by ESLint itself). The existing suite directly exercises every exported function of the pureHelpers leaf. If reviewers want a compile-time regression guard, a follow-up adding it to a `noImplicitAny` CI job would do it — happy to add.
- No live streaming/E2E against real upstreams (annotations are compile-time; the 51 unit tests cover the runtime paths).
- Full `test:unit` / `test:vitest` / e2e suites were not run in this session — out of scope for §0.
- `npm install` prunes one optional nested entry under `libxmljs2` in `package-lock.json` on every fresh install here; that diff was reverted twice and is **not** part of this PR.
- Audit items N1–N8 are untouched; N1 (http→https one-word fix) remains next priority per the audit's own order.
