### PR TITLE
fix(cache): expire a semantic-cache row on its TTL, not at UTC midnight (#11559)

### DIFF
--- a/changelog.d/fixes/11573-semantic-cache-ttl.md
+++ b/changelog.d/fixes/11573-semantic-cache-ttl.md
@@ -1,0 +1,1 @@
+- **fix(cache):** a semantic-cache entry now expires on its TTL instead of surviving until the next UTC midnight, and `dbEntries` stops counting expired rows ([#11573](https://github.com/diegosouzapw/OmniRoute/pull/11573))

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -31,6 +31,20 @@ function toNumber(value: unknown, fallback = 0): number {
   return fallback;
 }
 
+/**
+ * Current time in the same format `expires_at` and `created_at` are written in.
+ *
+ * `expires_at` is a TEXT column holding an ISO-8601 string ("2026-08-26T14:00:00.000Z"),
+ * so it has to be compared against another ISO-8601 string. Comparing it to SQLite's
+ * `datetime('now')` ("2026-08-26 14:00:00") is a lexicographic comparison that diverges
+ * at index 10, where the stored value has 'T' (0x54) and `datetime('now')` has ' ' (0x20).
+ * 'T' sorts after ' ', so every row whose UTC calendar date was today compared as
+ * unexpired regardless of its real time-of-day TTL.
+ */
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
 function ensureCacheMetricsTable() {
   try {
     const db = getDbInstance();
@@ -203,9 +217,9 @@ export function getCachedResponse(signature) {
     const db = getDbInstance();
     const row = db
       .prepare(
-        "SELECT response, tokens_saved FROM semantic_cache WHERE signature = ? AND expires_at > datetime('now')"
+        "SELECT response, tokens_saved FROM semantic_cache WHERE signature = ? AND expires_at > ?"
       )
-      .get(signature);
+      .get(signature, isoNow());
 
     if (row) {
       const record = asRecord(row);
@@ -342,8 +356,8 @@ export function getCacheStats() {
   try {
     const db = getDbInstance();
     const row = db
-      .prepare("SELECT COUNT(*) as count FROM semantic_cache WHERE expires_at > datetime('now')")
-      .get();
+      .prepare("SELECT COUNT(*) as count FROM semantic_cache WHERE expires_at > ?")
+      .get(isoNow());
     dbSize = toNumber(asRecord(row).count, 0);
   } catch {
     // DB not available

--- a/tests/unit/11559-semantic-cache-ttl-expiry.test.ts
+++ b/tests/unit/11559-semantic-cache-ttl-expiry.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #11559 — the semantic cache never expired an entry whose `expires_at` fell on the
+ * current UTC calendar day.
+ *
+ * `expires_at` is written as an ISO-8601 string ("2026-08-26T14:00:00.000Z") but was read
+ * back with `expires_at > datetime('now')`, and `datetime('now')` renders as
+ * "2026-08-26 14:00:00". Both are TEXT, so SQLite compares them lexicographically and they
+ * diverge at index 10, where the stored value has 'T' (0x54) and `datetime('now')` has
+ * ' ' (0x20). 'T' sorts after ' ', so any row whose date part equalled today's date looked
+ * unexpired no matter what its time-of-day TTL said — up to ~24h of staleness, and it
+ * survived restarts because `getCachedResponse` promotes DB rows back into the LRU.
+ */
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  clearCache,
+  clearMemoryCache,
+  getCachedResponse,
+  getCacheStats,
+  setCachedResponse,
+} from "../../src/lib/semanticCache.ts";
+import { getDbInstance } from "../../src/lib/db/core.ts";
+
+function ensureSemanticCacheTable(db) {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS semantic_cache (
+      id TEXT PRIMARY KEY,
+      signature TEXT NOT NULL UNIQUE,
+      model TEXT NOT NULL,
+      prompt_hash TEXT NOT NULL,
+      response TEXT NOT NULL,
+      tokens_saved INTEGER DEFAULT 0,
+      hit_count INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL
+    )`
+  ).run();
+}
+
+/** Midnight of the UTC day SQLite itself considers "today" — always <= `datetime('now')`. */
+function startOfSqliteToday(db): string {
+  const row = db.prepare("SELECT datetime('now') AS now").get();
+  return `${String(row.now).slice(0, 10)}T00:00:00.000Z`;
+}
+
+function insertRow(db, signature: string, expiresAt: string, response: unknown) {
+  db.prepare(
+    `INSERT OR REPLACE INTO semantic_cache
+       (id, signature, model, prompt_hash, response, tokens_saved, hit_count, created_at, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`
+  ).run(
+    `id-${signature}`,
+    signature,
+    "gpt-4o",
+    signature.slice(0, 16),
+    JSON.stringify(response),
+    7,
+    new Date(Date.now() - 60_000).toISOString(),
+    expiresAt
+  );
+}
+
+describe("#11559 semantic cache TTL expiry", () => {
+  let db;
+
+  before(() => {
+    db = getDbInstance();
+    ensureSemanticCacheTable(db);
+  });
+
+  beforeEach(() => {
+    clearCache();
+  });
+
+  it("misses a row that expired earlier today (UTC)", () => {
+    // Expired at 00:00 UTC today: same calendar date as `datetime('now')`, so the old
+    // `expires_at > datetime('now')` predicate answered true on the 'T' vs ' ' byte alone.
+    insertRow(db, "sig-expired-today", startOfSqliteToday(db), { choices: ["stale"] });
+    clearMemoryCache();
+
+    assert.equal(
+      getCachedResponse("sig-expired-today"),
+      null,
+      "an entry whose TTL lapsed earlier today must not be served"
+    );
+  });
+
+  it("does not count a row that expired earlier today in dbEntries", () => {
+    insertRow(db, "sig-stats-expired", startOfSqliteToday(db), { choices: ["stale"] });
+    clearMemoryCache();
+
+    assert.equal(getCacheStats().dbEntries, 0);
+  });
+
+  it("still serves a row whose TTL has not lapsed", () => {
+    const response = { choices: [{ message: { content: "fresh" } }] };
+    insertRow(db, "sig-live", new Date(Date.now() + 3_600_000).toISOString(), response);
+    clearMemoryCache();
+
+    assert.deepEqual(getCachedResponse("sig-live"), response);
+    assert.equal(getCacheStats().dbEntries, 1);
+  });
+
+  it("survives a memory eviction on a normally written entry", () => {
+    const response = { choices: [{ message: { content: "written" } }] };
+    setCachedResponse("sig-roundtrip", "gpt-4o", response, 12, 3_600_000);
+    clearMemoryCache();
+
+    assert.deepEqual(
+      getCachedResponse("sig-roundtrip"),
+      response,
+      "the read predicate must still match the ISO format setCachedResponse writes"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #11559.

## The bug

`semanticCache.ts` writes `expires_at` as an ISO-8601 string:

```ts
const expiresAt = new Date(Date.now() + ttl).toISOString();  // "2026-08-26T14:00:00.000Z"
```

but read it back with

```sql
WHERE signature = ? AND expires_at > datetime('now')          -- "2026-08-26 14:00:00"
```

`expires_at` is a TEXT column, so that is a lexicographic comparison, and the two
renderings diverge at index 10 — the stored value has `T` (0x54) where `datetime('now')`
has a space (0x20). `'T' > ' '`, so **any row whose UTC calendar date equals today's
compares greater than `datetime('now')` no matter what its time-of-day TTL says**.

Consequences:

- an entry stayed servable until 00:00 UTC of the *next* day — up to ~24h past its TTL;
- `getCachedResponse` promotes a DB hit back into the in-memory LRU, so the staleness
  survived LRU eviction and process restarts;
- `getCacheStats().dbEntries` counted the same expired rows as live.

Rows whose `expires_at` date is strictly older than today *were* evicted correctly
(the date prefix decides the comparison), which is why this reads as "TTL sort of
works" rather than "the cache never expires".

## The fix

Compare against a JS-generated ISO timestamp, so both sides of the predicate use the
format the writer produces. Applied to both call sites (`getCachedResponse`,
`getCacheStats`). No schema change, no migration — the stored format is unchanged and
already ISO.

The other date comparisons in the file were already consistent-format
(`invalidateStale` compares `created_at` against an ISO cutoff); only the two
`expires_at vs datetime('now')` pairs mismatched.

## Tests

`tests/unit/11559-semantic-cache-ttl-expiry.test.ts` — 4 cases:

| case | asserts |
|---|---|
| row expired at 00:00 UTC today | `getCachedResponse` misses |
| same row | `getCacheStats().dbEntries === 0` |
| row expiring in 1h | still served, counted once |
| `setCachedResponse` → `clearMemoryCache` → read | round-trip still hits (guards against "fixing" this by changing the write format) |

The expired row's `expires_at` is derived from SQLite's own `datetime('now')` date part,
so the test targets today's UTC date exactly rather than hoping a `now - 1min` timestamp
does not straddle midnight.

Red/green on the two expiry cases:

```
# with src/lib/semanticCache.ts reverted
✖ misses a row that expired earlier today (UTC)
✖ does not count a row that expired earlier today in dbEntries
✔ still serves a row whose TTL has not lapsed
✔ survives a memory eviction on a normally written entry
ℹ pass 2   ℹ fail 2

# with the fix
ℹ tests 4  ℹ pass 4  ℹ fail 0
```

## Commands run

```
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts \
     --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit \
     tests/unit/11559-semantic-cache-ttl-expiry.test.ts
#  tests 4 | pass 4 | fail 0

# related suites, unchanged:
#  semantic-cache, cache-stats-reports-semantic-cache, chatcore-semantic-cache,
#  chatcore-semantic-cache-store, cache-metrics, cache-sweeps
#  tests 74 | pass 74 | fail 0

npx eslint src/lib/semanticCache.ts tests/unit/11559-semantic-cache-ttl-expiry.test.ts   # clean
npx prettier --check <both files>                                                        # clean
```

Changed test files: `tests/unit/11559-semantic-cache-ttl-expiry.test.ts` (new).
