### PR TITLE
test(authz): pin the GET-exemption set by membership, not by count (#11531)

### DIFF
--- a/changelog.d/maintenance/11580-get-exemption-membership-pin.md
+++ b/changelog.d/maintenance/11580-get-exemption-membership-pin.md
@@ -1,0 +1,1 @@
+- **test(authz):** pin `LOCAL_ONLY_API_GET_EXEMPTIONS` by exact membership instead of by entry count, so the guard names the offending path and also catches a substitution ([#11580](https://github.com/diegosouzapw/OmniRoute/pull/11580))

--- a/tests/unit/authz/route-guard-version-get-exemption.test.ts
+++ b/tests/unit/authz/route-guard-version-get-exemption.test.ts
@@ -85,13 +85,27 @@ describe("isLocalOnlyPath — GET exemption for /api/system/version (#5083)", ()
     assert.equal(isLocalOnlyPath("/api/db-backups/exportAll", "GET"), true);
   });
 
-  // ── EXEMPTION SET IS EXPORTED AND CONTAINS EXACTLY /api/system/version ───
+  // ── EXEMPTION SET IS EXPORTED AND HOLDS EXACTLY THE REVIEWED PATHS ───────
 
   test("LOCAL_ONLY_API_GET_EXEMPTIONS contains /api/system/version", () => {
     assert.ok(LOCAL_ONLY_API_GET_EXEMPTIONS.has("/api/system/version"));
   });
 
-  test("LOCAL_ONLY_API_GET_EXEMPTIONS has exactly 1 entry", () => {
-    assert.equal(LOCAL_ONLY_API_GET_EXEMPTIONS.size, 1);
+  // Every entry here opens a local-only path to LAN/remote GET, so the set must
+  // never grow by accident. Pinned by membership rather than by `size`: a count
+  // cannot say WHICH path appeared, and it cannot see a substitution at all —
+  // swapping /api/system/version for some other route keeps size at 1 and passes.
+  // Adding a path is still meant to fail here; the fix is to add it to this list
+  // in the same change, with the reason it is safe for a read-only method.
+  //
+  //   /api/system/version    — GET only reads package.json + the npm registry (#5083)
+  //   /api/tunnels/cloudflared — GET is tunnel status; POST still spawns cloudflared
+  //                              and stays local-only (#11531, and see
+  //                              route-guard-tunnel-processes-local-only.test.ts)
+  test("LOCAL_ONLY_API_GET_EXEMPTIONS holds exactly the reviewed paths", () => {
+    assert.deepEqual([...LOCAL_ONLY_API_GET_EXEMPTIONS].sort(), [
+      "/api/system/version",
+      "/api/tunnels/cloudflared",
+    ]);
   });
 });


### PR DESCRIPTION
## The red test

`Unit Tests fast-path` fails on every branch:

```
✖ LOCAL_ONLY_API_GET_EXEMPTIONS has exactly 1 entry
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    actual: 2, expected: 1
```

[#11531](https://github.com/diegosouzapw/OmniRoute/pull/11531) (`e48ffd38d`, yesterday)
added `/api/tunnels/cloudflared` to `LOCAL_ONLY_API_GET_EXEMPTIONS` and shipped
`tests/unit/authz/route-guard-tunnel-processes-local-only.test.ts` alongside it. What it
did not touch was the #5083 sibling four directories over, which pins the set's
**cardinality** at 1.

## This is the test that is wrong, not the code

Worth stating plainly, because "align the assertion to current behaviour" is usually how
a real defect gets buried. Here the production change is the reviewed one:

- `GET /api/tunnels/cloudflared` is tunnel **status** — no spawn.
- `POST` on the same path still spawns cloudflared and stays local-only.

`route-guard-tunnel-processes-local-only.test.ts` asserts both, and it passes today. The
exemption was deliberate; only the count in the older file rotted.

## Why membership instead of a bigger number

Bumping `1` to `2` would go green, but it would keep a guard that cannot do its job. A
`size` assertion:

- **cannot say which path appeared.** `actual: 2, expected: 1` sends the next author
  hunting for a diff the test already had in hand.
- **cannot see a substitution at all.** Swap `/api/system/version` for a spawn-capable
  route and the size stays 1 — a security-relevant edit passes silently.

Pinning the exact membership keeps the "must not grow by accident" property, fails just
as loudly on an addition, additionally catches the swap, and prints the offending path.
Both entries are now listed with the reason each is safe for a read-only method, so the
next person to add one is told what the bar is.

## Verification

Three states, same file:

```
# base branch, unmodified
✖ LOCAL_ONLY_API_GET_EXEMPTIONS has exactly 1 entry     actual: 2, expected: 1
ℹ pass 18  ℹ fail 1     (with the tunnel sibling: 19 tests)

# with this change
✔ LOCAL_ONLY_API_GET_EXEMPTIONS holds exactly the reviewed paths
ℹ pass 15  ℹ fail 0

# guard still bites — a third entry added to the set by hand
✖ LOCAL_ONLY_API_GET_EXEMPTIONS holds exactly the reviewed paths
  + actual - expected
    [
  +   '/api/db-backups/exportAll',
        '/api/system/version',
        '/api/tunnels/cloudflared'
    ]
  ✖ GET /api/db-backups/exportAll still local-only (spawns tar)     ← also fires
ℹ pass 13  ℹ fail 2

# guard catches a swap, which `size` could not — cloudflared replaced by exportAll
✖ LOCAL_ONLY_API_GET_EXEMPTIONS holds exactly the reviewed paths
  + actual - expected
  +   '/api/db-backups/exportAll',
        '/api/system/version',
  -   '/api/tunnels/cloudflared'
```

Whole directory, after the change:

```
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts \
     --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit \
     --test-concurrency=4 "tests/unit/authz/*.test.ts"
# tests 250 | pass 248 | fail 2
```

The two remaining failures are `client-api-policy-fallback` and `management-policy`,
both failing in their `test.after` `rmSync` of a tmp `DATA_DIR` with `EPERM` on this
Windows host — identical on the unmodified base branch, unrelated to this change.

```
npx eslint <file>      # No issues found
npx prettier --check   # clean
```

Test-only; no production code touched.
