### PR TITLE
test(claude-web): assert which class the registry entry builds, not one spelling of it (#11421)

### DIFF
--- a/changelog.d/maintenance/11586-claude-web-registry-guard.md
+++ b/changelog.d/maintenance/11586-claude-web-registry-guard.md
@@ -1,0 +1,1 @@
+- **test(claude-web):** the Turnstile-solver guard asserts which class the `claude-web`/`cw-web` registry entries build instead of pinning the pre-lazy `new ClaudeWebExecutor()` spelling ([#11586](https://github.com/diegosouzapw/OmniRoute/pull/11586))

--- a/tests/unit/claude-web-transport.test.ts
+++ b/tests/unit/claude-web-transport.test.ts
@@ -407,7 +407,17 @@ describe("Claude Web executor transport orchestration", () => {
     assert.match(executorSource, /export class ClaudeWebExecutor extends BaseExecutor/);
     assert.doesNotMatch(executorSource, /claudeTurnstileSolver|getCfClearanceToken|tryBackedChat/);
     assert.doesNotMatch(indexSource, /ClaudeWebWithAutoRefresh/);
-    assert.match(indexSource, /"claude-web": new ClaudeWebExecutor\(\)/);
-    assert.match(indexSource, /"cw-web": new ClaudeWebExecutor\(\)/);
+
+    // What this guards is WHICH class each alias constructs — the plain executor, not a
+    // wrapper that would drag the standalone solver back in. Read the entry and assert
+    // on the class it names, rather than on one spelling of the registry: #11421 made
+    // every entry a lazy `() => import(...).then((m) => new m.X())` thunk, and a pinned
+    // `new ClaudeWebExecutor()` literal went red on a refactor that never touched this
+    // property.
+    for (const alias of ["claude-web", "cw-web"]) {
+      const entry = indexSource.match(new RegExp(`"${alias}":\\s*(.+)`));
+      assert.ok(entry, `"${alias}" must still be registered in executors/index.ts`);
+      assert.match(entry[1], /\bClaudeWebExecutor\(\)/);
+    }
   });
 });


### PR DESCRIPTION
## The red test

`Unit Tests fast-path` fails on every branch:

```
✖ has no execution-time dependency on the standalone Turnstile solver
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression
  /"claude-web": new ClaudeWebExecutor\(\)/
```

## Cause

[#11421](https://github.com/diegosouzapw/OmniRoute/pull/11421) made the executor
registry lazy, so every entry in `open-sse/executors/index.ts` became a thunk:

```ts
"claude-web": () => import("./claude-web.ts").then((m) => new m.ClaudeWebExecutor()),
"cw-web":     () => import("./claude-web.ts").then((m) => new m.ClaudeWebExecutor()), // Alias
```

The property this test exists to guard is unchanged: each alias builds the **plain**
`ClaudeWebExecutor`, not a `ClaudeWebWithAutoRefresh` wrapper that would pull the
standalone Turnstile solver back into the execution path. Only the spelling of the
registry moved, and the pinned literal went red on a refactor that never touched what it
was protecting.

## The fix

Read the registry entry for each alias and assert on the **class it names**, instead of
pinning one syntactic form of the map:

```ts
for (const alias of ["claude-web", "cw-web"]) {
  const entry = indexSource.match(new RegExp(`"${alias}":\s*(.+)`));
  assert.ok(entry, `"${alias}" must still be registered in executors/index.ts`);
  assert.match(entry[1], /\bClaudeWebExecutor\(\)/);
}
```

This survives the eager→lazy change and the next reshaping, and the `assert.ok` keeps
the guard from silently going vacuous if an alias is dropped from the registry
altogether — the old regex would just have failed with "did not match" either way,
without distinguishing "renamed" from "gone". The `ClaudeWebWithAutoRefresh` negative
guard and the `ClaudeWebExecutor extends BaseExecutor` module anchor are untouched.

## Verification

```
# base branch
✖ has no execution-time dependency on the standalone Turnstile solver
ℹ tests 9  ℹ pass 8  ℹ fail 1

# with this change
ℹ tests 9  ℹ pass 9  ℹ fail 0
```

**The guard still bites.** I pointed the `claude-web` entry at the forbidden wrapper by
hand:

```
"claude-web": () => import("./claude-web.ts").then((m) => new m.ClaudeWebWithAutoRefresh()),

✖ has no execution-time dependency on the standalone Turnstile solver
  The input was expected to not match the regular expression /ClaudeWebWithAutoRefresh/
ℹ pass 8  ℹ fail 1
```

```
npx eslint tests/unit/claude-web-transport.test.ts   # 0 errors
```

`prettier --check` reports this file as non-conformant both before and after the change
(pre-existing on the base branch), so I left the formatting alone rather than mixing an
unrelated reformat into the diff.

Test-only; no production code touched.

---

Third stale artifact of #11421 that I have run into in the checks — the other two are
[#11582](https://github.com/diegosouzapw/OmniRoute/pull/11582) (the `known-symbols`
executor gate still calling the now-async `getExecutor()` synchronously, reporting all
142 aliases dead) and the `extractExecutorAliases` fixture folded into that same PR.
Each is independent; merge in any order.
