### PR TITLE
chore(lint): prune two stale bulk-suppression entries

### DIFF
--- a/changelog.d/maintenance/11587-prune-stale-eslint-suppressions.md
+++ b/changelog.d/maintenance/11587-prune-stale-eslint-suppressions.md
@@ -1,0 +1,1 @@
+- **chore(lint):** prune two stale entries from `eslint-suppressions.json` so the bulk-suppression check stops exiting non-zero on every branch ([#11587](https://github.com/diegosouzapw/OmniRoute/pull/11587))

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -159,11 +159,6 @@
       "count": 1
     }
   },
-  "open-sse/executors/index.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "open-sse/executors/kiro.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 3
@@ -472,11 +467,6 @@
     }
   },
   "open-sse/services/autoCombo/pipelineRouter.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 2
-    }
-  },
-  "open-sse/services/autoCombo/routerStrategy.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 2
     }


### PR DESCRIPTION
## It is not reporting new warnings

`No new ESLint warnings` fails on every branch, and the job prints **nothing** — exit
code 2 with no diagnostics, and the summary step then reports
`cat: .artifacts/quality-ratchet.md: No such file or directory`. That silence is why it
reads like ordinary ratchet drift, which the release-green issues correctly describe as
a non-contributor concern.

It isn't. Run locally, `npm run lint:json -- --max-warnings 0` prints one line:

```
There are suppressions left that do not occur anymore.
Consider re-running the command with `--prune-suppressions`.
```

ESLint's bulk-suppressions feature exits non-zero when the suppressions file claims
problems that no longer occur. No warning count is over budget — the file is simply out
of sync with the code.

## The two stale entries

```diff
-  "open-sse/executors/index.ts": {
-    "@typescript-eslint/no-unused-vars": { "count": 1 }
-  },
-  "open-sse/services/autoCombo/routerStrategy.ts": {
-    "@typescript-eslint/no-unused-vars": { "count": 2 }
-  },
```

Linting those two files directly:

```
index.ts           errors 0  warnings 0  rules []
routerStrategy.ts  errors 0  warnings 0  rules []
```

Zero problems of **any** rule, not just of the suppressed one — so the entries are dead
weight, not a Windows-local artifact. (`open-sse/executors/index.ts` losing an
unused-var is the expected consequence of #11421 replacing its eager class imports with
lazy thunks.)

## What this does not do

This is not a ratchet rebaseline. `--prune-suppressions` only removes entries that no
longer match any reported problem; it cannot add or relax one. The remaining 1247 files
and 5501 suppressed problems are untouched — the diff is 10 deleted lines and nothing
else.

I restored the trailing newline that ESLint's writer drops, so the diff stays on the two
removed blocks instead of also touching the last line of a 162 KB file.

## Verification

```
# base branch
node scripts/quality/run-eslint-json.mjs --max-warnings 0
EXIT=2
There are suppressions left that do not occur anymore. …

# with this change
node scripts/quality/run-eslint-json.mjs --max-warnings 0
EXIT=0   (no output)
```

One caveat worth stating: I pruned on a Windows host. If CI's ESLint reports a problem
for either file that mine does not, the prune would be one entry too aggressive and the
job would turn from "stale suppressions" into a real lint error — visible, not silent,
and a one-line revert. `@typescript-eslint/no-unused-vars` has no path or platform
dependency and both files lint completely clean here, so I do not expect that, but the
CI run on this PR is the real check.

Config-only: no code, no tests.
