### PR TITLE
i18n(vi): translate the five reliability-column strings

### DIFF
--- a/changelog.d/fixes/11589-i18n-vi-reliability.md
+++ b/changelog.d/fixes/11589-i18n-vi-reliability.md
@@ -1,0 +1,1 @@
+- **i18n(vi):** translate the five reliability-column strings on the free-provider rankings page, which rendered as `__MISSING__:` markers in the Vietnamese UI ([#11589](https://github.com/diegosouzapw/OmniRoute/pull/11589))

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -12488,11 +12488,11 @@
     "sortTypeFirst": "Dễ thiết lập trước",
     "sortTypeFirstHelp": "Nhóm theo mức độ thiết lập (Không cần đăng ký → Đăng nhập OAuth → Khóa API), đồng thời giữ thứ tự chất lượng trong từng nhóm",
     "typeLegend": "Không cần đăng ký = không cần thiết lập · Đăng nhập OAuth = đăng nhập bằng tài khoản của bạn · Khóa API = dùng khóa riêng hoặc gói miễn phí của nhà cung cấp",
-    "colReliability": "__MISSING__:Reliability",
-    "colReliabilityHelp": "__MISSING__:Share of calls this provider actually answered over the last 24 hours. A dash means it served too little traffic to state a rate.",
-    "reliabilitySample": "__MISSING__:{successes} of {requests} calls succeeded in the last {hours}h",
-    "reliabilityTooFew": "__MISSING__:Only {requests} calls in the last {hours}h — too few to state a rate",
-    "reliabilityNoTraffic": "__MISSING__:No calls recorded in the last 24h"
+    "colReliability": "Độ tin cậy",
+    "colReliabilityHelp": "Tỷ lệ lệnh gọi mà nhà cung cấp này thực sự trả lời trong 24 giờ qua. Dấu gạch ngang nghĩa là lưu lượng quá ít để đưa ra tỷ lệ.",
+    "reliabilitySample": "{successes} trong {requests} lệnh gọi thành công trong {hours}h qua",
+    "reliabilityTooFew": "Chỉ có {requests} lệnh gọi trong {hours}h qua — quá ít để đưa ra tỷ lệ",
+    "reliabilityNoTraffic": "Không ghi nhận lệnh gọi nào trong 24h qua"
   },
   "discovery": {
     "title": "Khám phá nhà cung cấp",


### PR DESCRIPTION
Part of the "every gate is red on every branch" cleanup — one of six independent unit-test failures on `release/v3.8.51`.

## The red test

```
✖ Vietnamese locale has no internal missing markers or empty fallbacks
```

`src/i18n/messages/vi.json` carries five `__MISSING__:` placeholders, all from the
reliability column added to the free-provider rankings page:

| key | English |
| --- | --- |
| `freeProviderRankingsPage.colReliability` | Reliability |
| `freeProviderRankingsPage.colReliabilityHelp` | Share of calls this provider actually answered over the last 24 hours… |
| `freeProviderRankingsPage.reliabilitySample` | `{successes}` of `{requests}` calls succeeded in the last `{hours}`h |
| `freeProviderRankingsPage.reliabilityTooFew` | Only `{requests}` calls in the last `{hours}`h — too few to state a rate |
| `freeProviderRankingsPage.reliabilityNoTraffic` | No calls recorded in the last 24h |

A `__MISSING__:` marker is not a silent gap — it renders **in the UI**, so a Vietnamese
operator currently sees `__MISSING__:Reliability` as a column header.

## The translation

Vietnamese is my first language. I matched the terminology already established in this
file rather than inventing new terms — `nhà cung cấp` for provider, `hạn ngạch` for
quota, the same register as the neighbouring `colConfigured` / `filterAvailableOnlyHelp`
strings.

```json
"colReliability": "Độ tin cậy",
"colReliabilityHelp": "Tỷ lệ lệnh gọi mà nhà cung cấp này thực sự trả lời trong 24 giờ qua. Dấu gạch ngang nghĩa là lưu lượng quá ít để đưa ra tỷ lệ.",
"reliabilitySample": "{successes} trong {requests} lệnh gọi thành công trong {hours}h qua",
"reliabilityTooFew": "Chỉ có {requests} lệnh gọi trong {hours}h qua — quá ít để đưa ra tỷ lệ",
"reliabilityNoTraffic": "Không ghi nhận lệnh gọi nào trong 24h qua"
```

Every ICU placeholder is preserved verbatim — `{successes}`, `{requests}`, `{hours}` —
which the placeholder-parity and ICU-parse cases in the same suite check independently.

## Verification

```
# base branch
✖ Vietnamese locale has no internal missing markers or empty fallbacks
ℹ tests 5  ℹ pass 4  ℹ fail 1

# with this change — the whole vi suite
✔ Vietnamese locale has complete key parity with English
✔ Vietnamese locale has no internal missing markers or empty fallbacks
✔ Vietnamese locale preserves every ICU placeholder name
✔ Vietnamese locale introduces no ICU parse regression
✔ no-auth provider controls keep locale translators unambiguous
ℹ tests 5  ℹ pass 5  ℹ fail 0

# every i18n suite in the repo
node … --test-concurrency=4 "tests/unit/i18n-*.test.ts"
ℹ tests 134  ℹ pass 134  ℹ fail 0
```

Locale-only; no code, no other locale touched.
