### PR TITLE
test(models): pin qwen3.8-max resolution per provider, not across all four

### DIFF
--- a/changelog.d/maintenance/11590-qwen38-provider-aware-alias.md
+++ b/changelog.d/maintenance/11590-qwen38-provider-aware-alias.md
@@ -1,0 +1,1 @@
+- **test(models):** pin `qwen3.8-max` resolution per provider — two of the four catalogs now serve the bare id and no longer carry `-preview` ([#11590](https://github.com/diegosouzapw/OmniRoute/pull/11590))

--- a/tests/unit/qwen38-max-bare-id-alias.test.ts
+++ b/tests/unit/qwen38-max-bare-id-alias.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { MODEL_SPECS } from "../../src/shared/constants/modelSpecs.ts";
 import { resolveModelAlias } from "../../open-sse/services/modelDeprecation.ts";
 import { resolveLifecycle } from "../../open-sse/handlers/chatCore/modelLifecyclePolicy.ts";
+import { hasKnownProviderModel } from "../../open-sse/services/model.ts";
 
 /**
  * Bare `qwen3.8-max` was an unroutable id: the model ships everywhere as
@@ -22,6 +23,13 @@ import { resolveLifecycle } from "../../open-sse/handlers/chatCore/modelLifecycl
  * applies at open-sse/handlers/chatCore.ts:755, well before both the context
  * preflight and the upstream dispatch. A MODEL_SPECS `aliases` entry would have
  * fixed only (1): spec aliases resolve capabilities, never the dispatched id.
+ *
+ * SINCE THEN the premise has half-expired: `qwen-cloud-token-plan` and `qwen-web`
+ * now list the BARE id and no longer carry `-preview` at all, so the rewrite that
+ * rescues `qoder`/`bailian-coding-plan` would break those two. `resolveModelAlias`
+ * already handles this — `hasKnownProviderModel` short-circuits the built-in alias
+ * when the provider serves the id itself — which is why the alias map keeps the
+ * entry rather than dropping it. The assertions below pin BOTH halves.
  */
 
 const BARE = "qwen3.8-max";
@@ -44,11 +52,40 @@ test("the alias target carries the real 1M window, not the 128k fallback", () =>
   assert.equal(MODEL_SPECS[BARE], undefined);
 });
 
-test("chatCore lifecycle resolution rewrites the model before dispatch", () => {
-  for (const provider of ["qwen-cloud-token-plan", "qoder", "bailian-coding-plan", "qwen-web"]) {
+// The catalogs have since split. `qwen-cloud-token-plan` and `qwen-web` now list the
+// BARE id and no longer carry `-preview`, so `resolveModelAlias`'s
+// `hasKnownProviderModel` short-circuit deliberately leaves the id alone there —
+// rewriting it to `-preview` would dispatch an id those two no longer serve. The
+// rewrite still has to happen on the providers that only know `-preview`.
+const SERVES_BARE = ["qwen-cloud-token-plan", "qwen-web"];
+const SERVES_PREVIEW = ["qoder", "bailian-coding-plan"];
+
+// Pin the premise, not just the outcome: if a catalog flips, this fails first and says
+// which provider moved, instead of leaving the lifecycle assertions below unexplained.
+test("the catalog split the two ids across providers", () => {
+  for (const provider of SERVES_BARE) {
+    assert.equal(hasKnownProviderModel(provider, BARE), true, `${provider} must serve ${BARE}`);
+  }
+  for (const provider of SERVES_PREVIEW) {
+    assert.equal(
+      hasKnownProviderModel(provider, BARE),
+      false,
+      `${provider} must NOT serve ${BARE} — the rewrite below depends on it`
+    );
+  }
+});
+
+test("chatCore lifecycle rewrites the model only where the provider needs it", () => {
+  for (const provider of SERVES_PREVIEW) {
     const [resolvedModel, effectiveModel, lifecycleError] = resolveLifecycle(provider, BARE);
     assert.equal(resolvedModel, CANONICAL, `resolvedModel for ${provider}`);
     assert.equal(effectiveModel, CANONICAL, `effectiveModel for ${provider}`);
+    assert.equal(lifecycleError, null, `unexpected lifecycle rejection for ${provider}`);
+  }
+  for (const provider of SERVES_BARE) {
+    const [resolvedModel, effectiveModel, lifecycleError] = resolveLifecycle(provider, BARE);
+    assert.equal(resolvedModel, BARE, `resolvedModel for ${provider}`);
+    assert.equal(effectiveModel, BARE, `effectiveModel for ${provider}`);
     assert.equal(lifecycleError, null, `unexpected lifecycle rejection for ${provider}`);
   }
 });


### PR DESCRIPTION
Part of the "every gate is red on every branch" cleanup — one of six independent unit-test failures on `release/v3.8.51`.

## The red test

```
✖ chatCore lifecycle resolution rewrites the model before dispatch
  AssertionError: resolvedModel for qwen-cloud-token-plan
  actual: 'qwen3.8-max', expected: 'qwen3.8-max-preview'
```

## The test's premise expired halfway

Its docblock states the model "ships everywhere as `qwen3.8-max-preview`
(bailian-coding-plan, qoder, qwen-cloud-token-plan, qwen-web)". Probed against the live
catalogs and `hasKnownProviderModel`:

| provider | catalog ids matching `qwen3.8-max` | serves the bare id? | `resolveModelAlias(bare, provider)` |
| --- | --- | --- | --- |
| `qwen-cloud-token-plan` | `["qwen3.8-max"]` | **true** | `qwen3.8-max` |
| `qwen-web` | `["qwen3.8-max"]` | **true** | `qwen3.8-max` |
| `qoder` | `["qwen3.8-max-preview"]` | false | `qwen3.8-max-preview` |
| `bailian-coding-plan` | `["qwen3.8-max-preview"]` | false | `qwen3.8-max-preview` |

Two of the four now list the **bare** id and no longer carry `-preview` at all.

## The code is right

`resolveModelAlias` short-circuits the built-in alias when the provider serves the id
itself:

```ts
// The provider serves this id itself — nothing is deprecated from its point of view.
if (provider && hasKnownProviderModel(provider, modelId)) return modelId;
```

Rewriting `qwen3.8-max` → `-preview` on those two would dispatch an id they no longer
serve — the mirror image of the 404 the original fix prevented. That short-circuit is
also why the `BUILT_IN_ALIASES` entry correctly **stays** rather than being dropped: the
other two still need it, and the alias map's own comment anticipated exactly this split
("Drop this line if Alibaba ever ships a distinct GA `qwen3.8-max`").

## What changed

The loop asserted one outcome for all four providers, which the split made impossible to
express. It now asserts both directions, and adds a case pinning the **catalog premise**
itself:

```ts
const SERVES_BARE    = ["qwen-cloud-token-plan", "qwen-web"];
const SERVES_PREVIEW = ["qoder", "bailian-coding-plan"];
```

So if a catalog flips again, the premise case fails first and names the provider that
moved, instead of leaving the lifecycle assertions failing with no explanation. The
docblock records the half-expiry rather than pretending the original premise still holds.

## Verification

```
# base branch
✖ chatCore lifecycle resolution rewrites the model before dispatch
ℹ tests 4  ℹ pass 3  ℹ fail 1

# with this change
✔ bare qwen3.8-max resolves to the canonical -preview id
✔ the canonical id is a no-op through the alias map (no double rewrite)
✔ the alias target carries the real 1M window, not the 128k fallback
✔ the catalog split the two ids across providers
✔ chatCore lifecycle rewrites the model only where the provider needs it
ℹ tests 5  ℹ pass 5  ℹ fail 0
```

Test-only; no production code touched.
