### PR TITLE
test(executors): drop the tool-truncation assertion #11444 removed the code for

### DIFF
--- a/changelog.d/maintenance/11591-ts7-stale-tool-truncation.md
+++ b/changelog.d/maintenance/11591-ts7-stale-tool-truncation.md
@@ -1,0 +1,1 @@
+- **test(executors):** drop the stale 128-tool truncation assertion that contradicted the #11444 pass-through contract ([#11591](https://github.com/diegosouzapw/OmniRoute/pull/11591))

--- a/tests/unit/ts7-executor-shared-shapes.test.ts
+++ b/tests/unit/ts7-executor-shared-shapes.test.ts
@@ -14,7 +14,7 @@ const { OpencodeExecutor } = await import("../../open-sse/executors/opencode.ts"
  * that failed to type-check — no duplicate added here.
  */
 
-describe("OpencodeExecutor — tools truncation survives the narrowing fix", () => {
+describe("OpencodeExecutor — the tools array survives the narrowing fix", () => {
   const executor = new OpencodeExecutor("opencode-go");
   const CREDENTIALS = { apiKey: "k" } as Record<string, unknown>;
 
@@ -33,15 +33,25 @@ describe("OpencodeExecutor — tools truncation survives the narrowing fix", () 
     };
   }
 
-  it("truncates an over-long tools array to 128 entries", () => {
+  // #11444 removed the executor's own `tools.slice(0, 128)`: it dropped every tool past
+  // the 128th (task, skill, write, read…) and left subagent runs paralyzed. Limiting is
+  // the chatCore layer's job now — `upstreamBody.truncateToolList()`, which reads a
+  // per-provider limit from `toolLimitDetector` instead of a hardcoded 128, so
+  // grok-cli (200) and nvidia (1536) are not cut at someone else's ceiling.
+  //
+  // This case used to assert the truncation and directly contradicted
+  // `opencode-tools-no-truncation.test.ts`, which owns the pass-through contract. It now
+  // pins the same direction from this file's angle — the narrowing fix must not let the
+  // cap creep back in here — so the two agree instead of racing.
+  it("forwards an over-long tools array intact, leaving the limit to chatCore (#11444)", () => {
     const out = executor.transformRequest("oc/kimi-k2.6", bodyWith(200), true, CREDENTIALS) as {
       tools: unknown[];
     };
-    assert.equal(out.tools.length, 128, "upstream rejects more than 128 tools");
-    assert.deepEqual(
-      (out.tools[127] as { function: { name: string } }).function.name,
-      "tool_127",
-      "truncation keeps the first 128 in order, not an arbitrary slice"
+    assert.equal(out.tools.length, 200, "the executor must not impose a tool cap");
+    assert.equal(
+      (out.tools[199] as { function: { name: string } }).function.name,
+      "tool_199",
+      "order and tail preserved — nothing sliced off"
     );
   });
 


### PR DESCRIPTION
Part of the "every gate is red on every branch" cleanup — one of six independent unit-test failures on `release/v3.8.51`.

## The red test

```
✖ truncates an over-long tools array to 128 entries
  AssertionError: upstream rejects more than 128 tools
  200 !== 128
```

## Two tests asserted opposite contracts for the same call

`tests/unit/opencode-tools-no-truncation.test.ts` exists specifically to pin the
opposite, and it passes today:

> `OpencodeExecutor.transformRequest` contained a second hardcoded tool-list truncation
> (`mb.tools.slice(0, 128)`)… When a client (opencode/claude-code) sends >128 tools, the
> opencode executor silently dropped every tool after the 128th (e.g. task, skill,
> write, read), leaving subagent tasks **paralyzed**.
>
> Tool-list limiting is the chatCore `upstreamBody.truncateToolList()`'s job
> (per-provider known/effective limits via `toolLimitDetector`), NOT the executor's.

So the removal was deliberate and fixed a real user-facing bug (#11444). This file still
asserted the truncation that fix removed.

## Why the behaviour is better where it moved

`upstreamBody.truncateToolList()` reads a **per-provider** limit
(`getKnownToolLimit` → `PROVIDER_TOOL_LIMITS`) rather than a hardcoded 128, so
`grok-cli` (200) and `nvidia` (1536) are no longer cut at someone else's ceiling, and
`bypassDefaultToolLimit` gives callers an escape the executor-level slice never had.

## What changed

I did not delete the case. It now pins the same direction from this file's angle — the
TS 7 narrowing fix (#8484) must not let the cap creep back in here — so the two files
agree instead of racing:

```ts
it("forwards an over-long tools array intact, leaving the limit to chatCore (#11444)", () => {
  assert.equal(out.tools.length, 200, "the executor must not impose a tool cap");
  assert.equal(out.tools[199].function.name, "tool_199", "order and tail preserved");
});
```

The describe title lost the word "truncation" for the same reason.

## Verification

Both files, run together:

```
# base branch
✖ truncates an over-long tools array to 128 entries    200 !== 128

# with this change
✔ preserves all 150 tools (no slice(0,128))
✔ preserves all 300 tools (well beyond the old hardcoded 128 cap)
✔ preserves tool order (first AND last tool intact)
✔ preserves empty tools array intact
✔ preserves tool objects content exactly without mutation
✔ is a no-op when tools is absent
✔ OpencodeExecutor — no hardcoded 128-tool truncation (#11444)
✔ forwards an over-long tools array intact, leaving the limit to chatCore (#11444)
✔ leaves a within-limit tools array untouched
✔ is a no-op when the body carries no tools
✔ leaves an array-shaped body alone (pins the !Array.isArray guard)
ℹ tests 10  ℹ pass 10  ℹ fail 0
```

Test-only; no production code touched.
