### PR TITLE
test(token-health): pin the real terminal-skip boundary, not the pre-exemption one

### DIFF
--- a/changelog.d/maintenance/11592-token-health-retry-budget.md
+++ b/changelog.d/maintenance/11592-token-health-retry-budget.md
@@ -1,0 +1,1 @@
+- **test(token-health):** pin the current terminal-skip boundary — expired with retry budget is probed, `account_deactivated` stays skipped ([#11592](https://github.com/diegosouzapw/OmniRoute/pull/11592))

--- a/tests/unit/token-health-no-refresh-token-expired-5326.test.ts
+++ b/tests/unit/token-health-no-refresh-token-expired-5326.test.ts
@@ -201,19 +201,64 @@ test("checkConnection clears stale no_refresh_token state for usable GitHub Copi
   }
 });
 
-// Boundary regression for #8182 vs #5326: the terminal-skip guard added by #8182
-// must keep skipping a GitHub Copilot connection that is "expired" for a DIFFERENT
-// reason than the recoverable no_refresh_token self-heal above (e.g. a manually
-// banned/invalidated account). Only the EXACT no_refresh_token shape is exempted
-// from the terminal skip — this proves the #5326 fix did not reopen #8182's
-// wasted-probe fix for every "expired" GitHub connection.
-test("checkConnection still skips a GitHub Copilot connection expired for a non-no_refresh_token reason (#8182 boundary)", async () => {
+// Boundary between #8182's terminal-skip and the retry-budget exemption that later
+// widened it (`isRecoverableExpiredWithRetryBudget` in tokenHealthCheck.ts).
+//
+// #8182 skipped every "expired" connection to stop wasting a probe per sweep on rows
+// that can never self-heal. That was too wide: a transient OAuth failure parks a healthy
+// connection at "expired" and it could then never come back. The current guard therefore
+// exempts an expired connection while it still has retry budget AND is not
+// `account_deactivated`, so only genuinely dead accounts stay unprobed.
+//
+// This case used to assert the pre-exemption behaviour — that ANY non-`no_refresh_token`
+// expired GitHub connection is skipped — which is no longer the policy. Both halves of
+// the real boundary are pinned below instead, so the wasted-probe protection is still
+// covered where it actually applies.
+test("checkConnection probes an expired GitHub connection that still has retry budget", async () => {
+  await resetStorage();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ message: "Bad credentials" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  try {
+    const connection = await providersDb.createProviderConnection({
+      provider: "github",
+      authType: "oauth",
+      name: "GitHub Transiently Expired Account",
+      accessToken: "github-access-token",
+      refreshToken: null,
+      providerSpecificData: {
+        copilotToken: "copilot-token",
+        copilotTokenExpiresAt: Math.floor((Date.now() + 60 * 60 * 1000) / 1000),
+      },
+      testStatus: "expired",
+      errorCode: "invalid_grant",
+      lastError: "Manually invalidated by operator.",
+      isActive: true,
+    });
+
+    await tokenHealthCheck.checkConnection(connection);
+
+    const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
+    assert.ok(
+      updated?.lastHealthCheckAt,
+      "retry budget remaining — the sweep must probe so a transient failure can self-heal"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("checkConnection still skips an expired GitHub connection whose account is deactivated (#8182)", async () => {
   await resetStorage();
 
   const connection = await providersDb.createProviderConnection({
     provider: "github",
     authType: "oauth",
-    name: "GitHub Genuinely Expired Account",
+    name: "GitHub Deactivated Account",
     accessToken: "github-access-token",
     refreshToken: null,
     providerSpecificData: {
@@ -222,18 +267,15 @@ test("checkConnection still skips a GitHub Copilot connection expired for a non-
     },
     testStatus: "expired",
     errorCode: "invalid_grant",
-    lastError: "Manually invalidated by operator.",
+    lastErrorType: "account_deactivated",
+    lastError: "Account deactivated upstream.",
     isActive: true,
   });
 
   await tokenHealthCheck.checkConnection(connection);
 
   const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
-  assert.equal(
-    updated?.testStatus,
-    "expired",
-    "terminal-skip must still apply outside the exact no_refresh_token shape"
-  );
+  assert.equal(updated?.testStatus, "expired", "a dead account must stay terminal");
   assert.equal(updated?.errorCode, "invalid_grant");
   assert.equal(
     updated?.lastHealthCheckAt ?? null,


### PR DESCRIPTION
Part of the "every gate is red on every branch" cleanup — one of six independent unit-test failures on `release/v3.8.51`.

## The red test

```
✖ checkConnection still skips a GitHub Copilot connection expired for a
  non-no_refresh_token reason (#8182 boundary)
  actual: 'github_access_token_invalid', expected: 'invalid_grant'
```

The row was written, so `checkConnection` did not return early — the terminal skip the
assertion describes no longer applies to that fixture.

## The policy moved on purpose

#8182 skipped every `"expired"` connection so a sweep would not waste a probe per cycle
on rows that can never self-heal. That turned out too wide: a transient OAuth failure
parks a healthy connection at `"expired"` and it could then never come back.
`tokenHealthCheck.ts` therefore grew a third exemption alongside the GitHub-Copilot and
Cursor ones:

```ts
const isRecoverableExpiredWithRetryBudget =
  conn.testStatus === "expired" &&
  conn.lastErrorType !== "account_deactivated" &&
  getExpiredRetryCount(conn) < EXPIRED_RETRY_MAX;
```

with the intent stated inline: *"allow expired connections with retry budget remaining
to pass through so transient OAuth failures can self-heal instead of being permanently
skipped. Exhausted retries stay terminal."*

The test's fixture has retry count 0 and no `lastErrorType`, so under the current guard
it is **deliberately** probed. The assertion described the pre-exemption policy.

## What changed

Deleting the case would have left #8182's wasted-probe protection unguarded, so it is
replaced by the two halves of the boundary that exists now:

- **retry budget remaining → probed.** `lastHealthCheckAt` gets written, so a transient
  failure can self-heal.
- **`lastErrorType: "account_deactivated"` → still skipped.** Status stays `expired`,
  `errorCode` untouched, `lastHealthCheckAt` still null — `checkConnection` returns
  early without touching the row, which is the property #8182 was protecting.

The probe case stubs `globalThis.fetch` with a 401, matching how the sibling tests in
this file isolate themselves, so it stays hermetic and does not reach the network.

## Verification

```
# base branch
✖ checkConnection still skips a GitHub Copilot connection expired for a non-no_refresh_token reason
ℹ tests 6  ℹ pass 5  ℹ fail 1

# with this change
✔ checkConnection marks refresh-capable provider with no refresh token as expired (#5326)
✔ checkConnection leaves a connection WITH a refresh token untouched (#5326)
✔ checkConnection leaves a non-refresh provider with no refresh token untouched (#5326)
✔ checkConnection keeps GitHub Copilot access-token-only connections active
✔ checkConnection clears stale no_refresh_token state for usable GitHub Copilot connections
✔ checkConnection probes an expired GitHub connection that still has retry budget
✔ checkConnection still skips an expired GitHub connection whose account is deactivated (#8182)
ℹ tests 7  ℹ pass 7  ℹ fail 0
```

Test-only; no production code touched.

One thing I did **not** cover and would rather flag than guess at: the third terminal
path, `getExpiredRetryCount(conn) >= EXPIRED_RETRY_MAX`. Seeding a connection at the
retry ceiling means writing `providerSpecificData.expiredRetry.count`, and I could not
tell from the code whether that shape is a supported fixture or an internal detail I
would be freezing by asserting on it. Happy to add the case if you confirm which.
