### PR TITLE
test(models): follow #11503's Gemini -high alias retarget

### DIFF
--- a/changelog.d/maintenance/11593-gemini-alias-target.md
+++ b/changelog.d/maintenance/11593-gemini-alias-target.md
@@ -1,0 +1,1 @@
+- **test(models):** follow #11503's retarget of the `gemini-3-pro-high` alias to the hyphenated catalog id ([#11593](https://github.com/diegosouzapw/OmniRoute/pull/11593))

--- a/tests/unit/t31-t33-t34-t38-model-specs.test.ts
+++ b/tests/unit/t31-t33-t34-t38-model-specs.test.ts
@@ -32,8 +32,12 @@ test("T31: antigravity static catalog exposes client-visible Gemini preview IDs"
   assert.ok(!staticIds.includes("gemini-claude-opus-4-5-thinking"));
 });
 
+// #11503 retargeted the -high alias from the dotted id to the hyphenated one, on the
+// grounds that the catalog spells it that way and the dotted form is not routable.
+// The two rungs therefore no longer share a spelling — pinned separately so a future
+// re-unification is a deliberate edit here rather than a silent drift.
 test("T31: legacy Gemini aliases resolve to Gemini 3.1 IDs", () => {
-  assert.equal(resolveDeprecatedAlias("gemini-3-pro-high"), "gemini-3.1-pro-high");
+  assert.equal(resolveDeprecatedAlias("gemini-3-pro-high"), "gemini-3-1-pro-high");
   assert.equal(resolveDeprecatedAlias("gemini-3-pro-low"), "gemini-3.1-pro-low");
 });
 


### PR DESCRIPTION
Part of the "every gate is red on every branch" cleanup — the last of six independent unit-test failures on `release/v3.8.51`.

## The red test

```
✖ T31: legacy Gemini aliases resolve to Gemini 3.1 IDs
  actual:   'gemini-3-1-pro-high'
  expected: 'gemini-3.1-pro-high'
```

## Cause

[#11503](https://github.com/diegosouzapw/OmniRoute/pull/11503) (`ae7a843e8`, today —
catalog hygiene) retargeted the `-high` alias, with the reason recorded inline in
`modelDeprecation.ts`:

```ts
// #11503: the catalog spells this one with hyphens ("gemini-3-1-pro-high"); the
// dotted form is not a routable id, so the rewrite used to guarantee a 404.
"gemini-3-pro-high": "gemini-3-1-pro-high",
"gemini-3-pro-low": "gemini-3.1-pro-low",
```

The T31 assertion still pinned the old target. The two rungs no longer share a spelling,
so they are now pinned separately, with a note that re-unifying them should be a
deliberate edit here rather than silent drift.

## One thing I want to raise rather than quietly follow

I am taking #11503 at its word here — it is same-day, reasoned, and the failing
assertion is unambiguously the stale side. But while checking it I noticed the two
spellings are not evenly distributed, and it may be worth a second look:

| spelling | where it appears |
| --- | --- |
| `gemini-3.1-pro-high` (dotted) | `antigravityModelAliases.ts`, `modelFamilyFallback.ts`, `backgroundTaskDetector.ts`, and the shipped `@omniroute/opencode-provider` |
| `gemini-3-1-pro-high` (hyphens) | `open-sse/config/providers/registry/devin/catalog.ts` only |

`BUILT_IN_ALIASES` is global — it applies whatever provider the request targets — so if
the hyphenated id is Devin's spelling specifically, the rewrite may now 404 on the
Antigravity/opencode surfaces where the dotted form is what exists. I could not settle
that from the repo alone (neither spelling is in `getStaticModelsForProvider("antigravity")`;
only `gemini-3.1-pro-low` is), so I have **not** changed the alias — this PR only makes
the test agree with the shipped behaviour. If the hyphenated target was meant to be
Devin-scoped rather than global, that is a separate fix and I am glad to open it.

## Verification

```
# base branch
✖ T31: legacy Gemini aliases resolve to Gemini 3.1 IDs
ℹ tests 8  ℹ pass 7  ℹ fail 1

# with this change
ℹ tests 8  ℹ pass 8  ℹ fail 0
```

Test-only; no production code touched.
