### PR TITLE
chore(quality): prune stale eslint-suppressions entries

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -159,11 +159,6 @@
       "count": 1
     }
   },
-  "open-sse/executors/index.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "open-sse/executors/kiro.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 3
@@ -472,11 +467,6 @@
     }
   },
   "open-sse/services/autoCombo/pipelineRouter.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 2
-    }
-  },
-  "open-sse/services/autoCombo/routerStrategy.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 2
     }


### PR DESCRIPTION
## Summary

Two entries in `config/quality/eslint-suppressions.json` no longer match the current
violation counts:

- `open-sse/executors/index.ts` — the unused-var suppression is stale after #11421's
  lazy-executor refactor removed the code that triggered it.
- `open-sse/services/autoCombo/routerStrategy.ts` — stale after #11555's docs cleanup
  removed the hardcoded description string.

## Why this matters

The suppression mechanism's count-mismatch check is all-or-nothing per run: when
*any* file's recorded count no longer matches, the tool surfaces every other file's
suppressed violations as apparent errors too, not just the mismatched one. That is
why the same ~228 dashboard `react-hooks/*` findings kept appearing as "pre-existing,
unrelated" noise across several unrelated PRs merged today — they were already
correctly suppressed; the two stale entries above were breaking that shielding
globally.

## Separate, real infra issue (not fixed here)

While investigating, found the **shared main checkout's** `node_modules/eslint-config-next`
is itself incomplete (`package.json` only, no `dist/` files) — likely a stale/partial
install. That means every worktree hard-linked from it (`cp -al`) inherits a broken
Next.js ESLint config, which independently produces phantom findings. A `npm install`
in the main checkout resolves it; not done here since it's a shared resource other
sessions may be using concurrently — flagging for the operator to run at a convenient
moment.

## Validation

- Verified in an isolated worktree off a fresh, complete `npm install`: full-repo
  `npm run lint` — `0 errors` after this prune (was `228 problems` before, purely
  from the stale-suppression cascade — confirmed by diffing the eslint output before/after
  with nothing else changed).
- `check:tracked-artifacts` and `check:any-budget:t11` pre-commit hooks passed.