### PR TITLE
fix(dashboard): restore focus after closing modals

### DIFF
--- a/changelog.d/fixes/11607-modal-focus-restoration.md
+++ b/changelog.d/fixes/11607-modal-focus-restoration.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** Restore keyboard focus after shared modals close and cancel delayed autofocus during cleanup ([#11607](https://github.com/diegosouzapw/OmniRoute/pull/11607)) — thanks @pacocartones

--- a/src/shared/components/Modal.tsx
+++ b/src/shared/components/Modal.tsx
@@ -56,6 +56,7 @@ export default function Modal({
   const t = useTranslations("common");
   const titleId = useId();
   const dialogRef = useRef(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   const sizes = {
     sm: "max-w-sm",
@@ -88,6 +89,22 @@ export default function Modal({
     return () => document.removeEventListener("keydown", handleEscape);
   }, [isOpen, onClose]);
 
+  // Return keyboard users to the control that opened the dialog.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const activeElement = document.activeElement;
+    previouslyFocusedRef.current = activeElement instanceof HTMLElement ? activeElement : null;
+
+    return () => {
+      const previouslyFocused = previouslyFocusedRef.current;
+      previouslyFocusedRef.current = null;
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [isOpen]);
+
   // Focus trap
   useEffect(() => {
     if (!isOpen || !dialogRef.current) return;
@@ -98,9 +115,9 @@ export default function Modal({
 
     // Focus first focusable element
     const firstFocusable = dialog.querySelector(focusableSelector);
-    if (firstFocusable) {
-      setTimeout(() => firstFocusable.focus(), 50);
-    }
+    const focusTimer = firstFocusable
+      ? window.setTimeout(() => firstFocusable.focus(), 50)
+      : undefined;
 
     const handleTab = (e) => {
       if (e.key !== "Tab") return;
@@ -121,7 +138,10 @@ export default function Modal({
     };
 
     dialog.addEventListener("keydown", handleTab);
-    return () => dialog.removeEventListener("keydown", handleTab);
+    return () => {
+      if (focusTimer !== undefined) window.clearTimeout(focusTimer);
+      dialog.removeEventListener("keydown", handleTab);
+    };
   }, [isOpen]);
 
   if (!isOpen) return null;

--- a/tests/unit/ui/modal-focus-restoration.test.tsx
+++ b/tests/unit/ui/modal-focus-restoration.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import React, { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const { default: Modal } = await import("../../../src/shared/components/Modal");
+
+const cleanups: Array<() => void> = [];
+
+function Harness() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Open details
+      </button>
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} title="Details">
+        Modal body
+      </Modal>
+    </>
+  );
+}
+
+function renderHarness() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Harness />));
+  cleanups.push(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+  return container;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("shared Modal focus restoration", () => {
+  it("returns focus to the trigger after Escape closes the dialog", () => {
+    const container = renderHarness();
+    const trigger = container.querySelector<HTMLButtonElement>("button")!;
+
+    act(() => {
+      trigger.focus();
+      trigger.click();
+    });
+
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(dialog).not.toBeNull();
+    act(() => {
+      dialog.querySelector<HTMLButtonElement>("button")!.focus();
+    });
+    expect(document.activeElement).not.toBe(trigger);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("returns focus after the close button dismisses the dialog", () => {
+    const container = renderHarness();
+    const trigger = container.querySelector<HTMLButtonElement>("button")!;
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+
+    act(() => {
+      trigger.focus();
+      trigger.click();
+    });
+    const focusTimerIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 50);
+    expect(focusTimerIndex).toBeGreaterThanOrEqual(0);
+    const focusTimer = setTimeoutSpy.mock.results[focusTimerIndex]!.value;
+
+    const closeButton = container.querySelector<HTMLButtonElement>('[role="dialog"] button')!;
+    act(() => {
+      closeButton.focus();
+      closeButton.click();
+    });
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(focusTimer);
+    expect(document.activeElement).toBe(trigger);
+    act(() => vi.runAllTimers());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does not try to focus an opener that was removed while the dialog was open", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const focusSpy = vi.spyOn(trigger, "focus");
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let isOpen = true;
+    const renderModal = () => {
+      root.render(
+        <Modal
+          isOpen={isOpen}
+          onClose={() => {
+            isOpen = false;
+            renderModal();
+          }}
+          title="Details"
+        >
+          Modal body
+        </Modal>
+      );
+    };
+
+    act(renderModal);
+    focusSpy.mockClear();
+    trigger.remove();
+
+    expect(() => {
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      });
+    }).not.toThrow();
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(focusSpy).not.toHaveBeenCalled();
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary

- restore keyboard focus to the control that opened the shared modal when it closes
- skip restoration when that opener has been removed from the document
- cancel the delayed initial-focus timer during cleanup so a closed dialog cannot steal focus later

## Why

The shared modal moved focus into its close button and trapped Tab correctly, but closing it left `document.body` focused. Keyboard users therefore lost their place after Escape or the close button. Profile badge details and the many existing shared-modal consumers need a complete focus lifecycle before further modal migrations.

## TDD evidence

RED on the unmodified base:

```text
expected <body ...> to be <button type="button">Open details</button>
```

GREEN:

- restores focus after Escape
- restores focus after the close button
- explicitly verifies the 50 ms autofocus timer is cancelled
- does not call `focus()` for a detached opener

```text
tests/unit/ui/modal-focus-restoration.test.tsx (3 tests) PASS
```

## Validation

- focused Vitest: 3/3 PASS
- changed-file ESLint with zero warnings: PASS
- core TypeScript check: PASS
- Prettier and `git diff --check`: PASS
- independent review: PASS after requesting explicit detached-opener and timer-cleanup coverage

## Scope

This PR changes only the shared modal focus lifecycle and its regression test. It does not migrate Profile or alter any individual modal layout.

## Base status

`release/v3.8.51` has unrelated known red gates tracked in #11449. This diff does not touch the documented env, executor, dependency, alias or baseline failures.
