### PR TITLE
feat(providers): support session JSON and direct access tokens for ChatGPT Web

### DIFF
--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -32,11 +32,7 @@ import {
   __resetChatGptImageCacheForTesting,
   type ChatGptImageConversationContext,
 } from "../services/chatgptImageCache.ts";
-import {
-  resolveChatGptModel,
-  resolveChatGptSystemHints,
-  type ChatGptThinkingEffort,
-} from "./chatgpt-web/models.ts";
+import { isThinkingCapableModel, resolveChatGptModel } from "./chatgpt-web/models.ts";
 import { cleanChatGptText } from "./chatgpt-web/citations.ts";
 import { resumeChatGptHandoff, type FinalAssistantAnswer } from "./chatgpt-web/handoff.ts";
 
@@ -47,6 +43,7 @@ const SESSION_URL = `${CHATGPT_BASE}/api/auth/session`;
 const SENTINEL_PREPARE_URL = `${CHATGPT_BASE}/backend-api/sentinel/chat-requirements/prepare`;
 const SENTINEL_CR_URL = `${CHATGPT_BASE}/backend-api/sentinel/chat-requirements`;
 const CONV_URL = `${CHATGPT_BASE}/backend-api/f/conversation`;
+const USER_LAST_USED_MODEL_CONFIG_URL = `${CHATGPT_BASE}/backend-api/settings/user_last_used_model_config`;
 const DEFAULT_PRO_POLL_TIMEOUT_MS = 20 * 60_000;
 const DEFAULT_PRO_POLL_INTERVAL_MS = 4_000;
 
@@ -84,8 +81,10 @@ function deviceIdFor(cookie: string): string {
   return id;
 }
 
-// OmniRoute model IDs select a GPT-5.6 Sol performance lane. Captured browser
-// requests use one of `gpt-5-6`, `gpt-5-6-thinking`, or `gpt-5-6-pro`.
+// OmniRoute model ID → ChatGPT internal slug. The public ChatGPT Web catalog
+// keeps OmniRoute's historical dot-form IDs (e.g. "gpt-5.5-pro"), while
+// ChatGPT's backend routes use dash-form slugs (e.g. "gpt-5-5-pro"). The slug
+// catalog comes from /backend-api/models on a logged-in account.
 
 // ─── Browser-like default headers ──────────────────────────────────────────
 
@@ -261,8 +260,34 @@ function mergeRefreshedCookie(
  * NextAuth's server reassembles them on its side.
  */
 function buildSessionCookieHeader(rawInput: string): string {
+  if (!rawInput) return "";
   let s = rawInput.trim();
-  if (/^cookie\s*:\s*/i.test(s)) s = s.replace(/^cookie\s*:\s*/i, "");
+  if (/^cookie\s*:\s*/i.test(s)) s = s.replace(/^cookie\s*:\s*/i, "").trim();
+
+  // If input is JSON, extract cookie or sessionToken
+  if (s.startsWith("{") && s.endsWith("}")) {
+    try {
+      const parsed = JSON.parse(s);
+      if (parsed.cookie && typeof parsed.cookie === "string") {
+        return buildSessionCookieHeader(parsed.cookie);
+      }
+      if (parsed.sessionToken && typeof parsed.sessionToken === "string") {
+        return buildSessionCookieHeader(parsed.sessionToken);
+      }
+      if (parsed.session_token && typeof parsed.session_token === "string") {
+        return buildSessionCookieHeader(parsed.session_token);
+      }
+      // If JSON only has accessToken/access_token, it's a bearer token without cookie
+      return "";
+    } catch {}
+  }
+
+  // Direct JWT access token — no cookie header needed
+  const cleanJwt = s.replace(/^bearer\s+/i, "");
+  if (/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(cleanJwt)) {
+    return "";
+  }
+
   if (/__Secure-next-auth\.session-token(?:\.\d+)?\s*=/.test(s)) {
     return s;
   }
@@ -276,6 +301,76 @@ async function exchangeSession(
   const cached = tokenLookup(cookie);
   if (cached) return cached;
 
+  const trimmed = cookie.trim();
+
+  // 1. Direct session JSON dump
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    try {
+      const data = JSON.parse(trimmed) as SessionResponse & {
+        access_token?: string;
+        sessionToken?: string;
+        session_token?: string;
+        tokens?: { access_token?: string; accessToken?: string };
+        account?: { id?: string };
+        accountId?: string;
+      };
+      const token =
+        data.accessToken ||
+        data.access_token ||
+        data.sessionToken ||
+        data.session_token ||
+        data.tokens?.access_token ||
+        data.tokens?.accessToken;
+      if (token && typeof token === "string") {
+        const expiresAt = data.expires
+          ? new Date(data.expires).getTime()
+          : Date.now() + TOKEN_TTL_MS;
+        let accountId = data.account?.id ?? data.user?.id ?? data.accountId ?? null;
+        if (!accountId && token.split(".").length === 3) {
+          try {
+            const payload = JSON.parse(
+              Buffer.from(
+                token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/"),
+                "base64"
+              ).toString("utf-8")
+            );
+            accountId = payload?.["https://api.openai.com/auth"]?.chatgpt_account_id ?? null;
+          } catch {}
+        }
+        const entry: TokenEntry = {
+          accessToken: token.trim(),
+          accountId,
+          expiresAt: Math.min(expiresAt, Date.now() + TOKEN_TTL_MS),
+        };
+        tokenStore(cookie, entry);
+        return entry;
+      }
+    } catch {}
+  }
+
+  // 2. Direct JWT accessToken
+  const cleanJwt = trimmed.replace(/^bearer\s+/i, "");
+  if (/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(cleanJwt)) {
+    let accountId: string | null = null;
+    try {
+      const payload = JSON.parse(
+        Buffer.from(
+          cleanJwt.split(".")[1].replace(/-/g, "+").replace(/_/g, "/"),
+          "base64"
+        ).toString("utf-8")
+      );
+      accountId = payload?.["https://api.openai.com/auth"]?.chatgpt_account_id ?? null;
+    } catch {}
+    const entry: TokenEntry = {
+      accessToken: cleanJwt,
+      accountId,
+      expiresAt: Date.now() + TOKEN_TTL_MS,
+    };
+    tokenStore(cookie, entry);
+    return entry;
+  }
+
+  // 3. Standard cookie exchange
   const headers: Record<string, string> = {
     ...browserHeaders(),
     Accept: "application/json",
@@ -409,6 +504,25 @@ async function runSessionWarmup(
   }
 }
 
+// ─── Thinking-effort preference (PATCH user_last_used_model_config) ────────
+// chatgpt.com has two thinking levels for its dedicated thinking-models:
+//   • standard — default, faster
+//   • extended — longer reasoning budget
+// The browser sets the level by PATCHing `/backend-api/settings/user_last_used_model_config`
+// once, then issues the conversation request — the conversation endpoint itself
+// has no `thinking_effort` field; the server reads the user's stored preference
+// at routing time. We mirror that handshake when an OpenAI-style request
+// includes `reasoning_effort` (or a direct `providerSpecificData.thinkingEffort`
+// override).
+//
+// Cached per (cookie, slug, effort): the preference persists server-side, so
+// re-PATCHing the same combination is wasted bytes. Refreshed on TTL expiry or
+// whenever the caller switches efforts.
+
+const thinkingEffortCache = new Map<string, number>();
+const THINKING_EFFORT_TTL_MS = 5 * 60 * 1000;
+const THINKING_EFFORT_CACHE_MAX = 400;
+
 function configuredProPollTimeoutMs(): number {
   const raw = Number(process.env.OMNIROUTE_CGPT_WEB_PRO_TIMEOUT_MS);
   if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_PRO_POLL_TIMEOUT_MS;
@@ -419,6 +533,73 @@ function configuredProPollIntervalMs(): number {
   const raw = Number(process.env.OMNIROUTE_CGPT_WEB_PRO_POLL_INTERVAL_MS);
   if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_PRO_POLL_INTERVAL_MS;
   return Math.floor(raw);
+}
+
+async function setUserThinkingEffort(
+  modelSlug: string,
+  effort: "standard" | "extended" | "max",
+  accessToken: string,
+  accountId: string | null,
+  sessionId: string,
+  deviceId: string,
+  cookie: string,
+  signal: AbortSignal | null | undefined,
+  log:
+    | {
+        debug?: (tag: string, msg: string) => void;
+        warn?: (tag: string, msg: string) => void;
+      }
+    | null
+    | undefined
+): Promise<void> {
+  const cacheKey = `${cookieKey(cookie)}:${modelSlug}:${effort}`;
+  const now = Date.now();
+  const last = thinkingEffortCache.get(cacheKey);
+  if (last && now - last < THINKING_EFFORT_TTL_MS) {
+    log?.debug?.("CGPT-WEB", `thinking_effort cached (${modelSlug}=${effort}) — skip PATCH`);
+    return;
+  }
+  if (thinkingEffortCache.size >= THINKING_EFFORT_CACHE_MAX && !thinkingEffortCache.has(cacheKey)) {
+    const first = thinkingEffortCache.keys().next().value;
+    if (first) thinkingEffortCache.delete(first);
+  }
+
+  const url =
+    `${USER_LAST_USED_MODEL_CONFIG_URL}` +
+    `?model_slug=${encodeURIComponent(modelSlug)}` +
+    `&thinking_effort=${encodeURIComponent(effort)}`;
+  const headers: Record<string, string> = {
+    ...browserHeaders(),
+    ...oaiHeaders(sessionId, deviceId),
+    Accept: "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    Cookie: buildSessionCookieHeader(cookie),
+    Priority: "u=4",
+  };
+  if (accountId) headers["chatgpt-account-id"] = accountId;
+
+  try {
+    const r = await tlsFetchChatGpt(url, {
+      method: "PATCH",
+      headers,
+      timeoutMs: 15_000,
+      signal,
+    });
+    if (r.status >= 400) {
+      log?.warn?.(
+        "CGPT-WEB",
+        `thinking_effort PATCH ${r.status} for ${modelSlug}=${effort} (continuing)`
+      );
+      return;
+    }
+    thinkingEffortCache.set(cacheKey, now);
+    log?.debug?.("CGPT-WEB", `thinking_effort PATCH OK (${modelSlug}=${effort})`);
+  } catch (err) {
+    log?.warn?.(
+      "CGPT-WEB",
+      `thinking_effort PATCH failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
 }
 
 async function prepareChatRequirements(
@@ -804,7 +985,6 @@ interface ChatGptMessage {
   id: string;
   author: { role: string };
   content: { content_type: "text"; parts: string[] };
-  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -900,8 +1080,7 @@ function buildConversationBody(
     // chatgpt.com history. Disable Temporary Chat only when ChatGPT needs a
     // durable image conversation (image generation/editing).
     persistConversation: boolean;
-    thinkingEffort: ChatGptThinkingEffort | null;
-    systemHints: readonly string[];
+    thinkingEffort: "standard" | "extended" | "max" | null;
     continuation?: ChatGptImageConversationContext | null;
   }
 ): Record<string, unknown> {
@@ -938,8 +1117,6 @@ function buildConversationBody(
     });
   }
 
-  const systemHints = options.systemHints;
-
   const currentUserContent = hasOpenWebUIImageContext(parsed)
     ? "Briefly acknowledge the image result described in the system context. Do not generate, edit, or request another image."
     : parsed.currentMsg || "";
@@ -948,7 +1125,6 @@ function buildConversationBody(
     id: randomUUID(),
     author: { role: "user" },
     content: { content_type: "text", parts: [currentUserContent] },
-    ...(systemHints.length > 0 ? { metadata: { system_hints: [...systemHints] } } : {}),
   });
 
   return {
@@ -971,7 +1147,6 @@ function buildConversationBody(
     supports_buffering: true,
     force_parallel_switch: "auto",
     paragen_cot_summary_display_override: "allow",
-    ...(systemHints.length > 0 ? { system_hints: [...systemHints] } : {}),
     ...(options.thinkingEffort ? { thinking_effort: options.thinkingEffort } : {}),
   };
 }
@@ -2841,6 +3016,24 @@ export class ChatGptWebExecutor extends BaseExecutor {
       log
     );
 
+    // 2a''. Apply thinking-effort preference for thinking models.
+    // Dedicated thinking models mirror the browser's user-config PATCH;
+    // GPT-5.5 Pro effort is sent with the conversation body.
+    const requestedEffort = resolvedModel.effort;
+    if (requestedEffort && isThinkingCapableModel(model, modelSlug)) {
+      await setUserThinkingEffort(
+        modelSlug,
+        requestedEffort,
+        tokenEntry.accessToken,
+        tokenEntry.accountId,
+        sessionId,
+        deviceId,
+        cookie,
+        signal,
+        log
+      );
+    }
+
     // 2b. Sentinel chat-requirements
     let reqs: ChatRequirements;
     try {
@@ -2922,7 +3115,7 @@ export class ChatGptWebExecutor extends BaseExecutor {
     }
 
     // Toggle Temporary Chat off only when ChatGPT needs a durable image
-    // conversation. Text requests, including GPT-5.6 Sol Pro, stay temporary so
+    // conversation. Text requests, including GPT-5.5 Pro, stay temporary so
     // they do not show up in the user's chatgpt.com sidebar/history.
     const imageEdit = looksLikeImageEditRequest(parsed);
     const continuation = imageEdit ? parsed.latestImageContext : null;
@@ -2936,14 +3129,13 @@ export class ChatGptWebExecutor extends BaseExecutor {
           : "Image-gen intent detected — disabling Temporary Chat for this turn"
       );
     } else if (resolvedModel.isPro) {
-      log?.debug?.("CGPT-WEB", "GPT-5.6 Sol Pro text request — keeping Temporary Chat enabled");
+      log?.debug?.("CGPT-WEB", "GPT-5.5 Pro text request — keeping Temporary Chat enabled");
     }
 
     const parentMessageId = continuation?.parentMessageId ?? randomUUID();
     const cgptBody = buildConversationBody(parsed, modelSlug, parentMessageId, {
       persistConversation,
-      thinkingEffort: resolvedModel.effort,
-      systemHints: resolveChatGptSystemHints(model),
+      thinkingEffort: requestedEffort,
       continuation,
     });
 
@@ -3134,6 +3326,7 @@ function stringToStream(text: string): ReadableStream<Uint8Array> {
 export function __resetChatGptWebCachesForTesting(): void {
   tokenCache.clear();
   warmupCache.clear();
+  thinkingEffortCache.clear();
   deviceIdCache.clear();
   __resetChatGptImageCacheForTesting();
   dplCache = null;

--- a/open-sse/executors/chatgpt-web/models.ts
+++ b/open-sse/executors/chatgpt-web/models.ts
@@ -4,59 +4,122 @@
 export const MODEL_MAP: Record<string, string> = {
   // ChatGPT backend slugs are also accepted directly for power users / tests.
   "gpt-5-6": "gpt-5-6",
-  "gpt-5-6-thinking": "gpt-5-6-thinking",
+  "gpt-5-6-instant": "gpt-5-6-instant",
   "gpt-5-6-pro": "gpt-5-6-pro",
-  "gpt-5-5": "gpt-5-5",
-  "gpt-5-5-thinking": "gpt-5-5-thinking",
+  "gpt-5-6-thinking": "gpt-5-6-thinking",
+  "gpt-5-6-t-mini": "gpt-5-6-t-mini",
+  "gpt-5-6-mini": "gpt-5-6-mini",
   "gpt-5-5-pro": "gpt-5-5-pro",
+  "gpt-5-5-pro-extended": "gpt-5-5-pro",
+  "gpt-5-5-thinking": "gpt-5-5-thinking",
+  "gpt-5-5": "gpt-5-5",
+  "gpt-5-5-instant": "gpt-5-5-instant",
+  "gpt-5-5-mini": "gpt-5-5-mini",
+  "gpt-5-3": "gpt-5-3",
+  "gpt-5-3-mini": "gpt-5-3-mini",
+  research: "research",
 
-  // Free accounts leave Luna selection to ChatGPT's server-side auto router.
-  "gpt-5.6-luna-free": "auto",
-  "gpt-5.6-luna-free-thinking": "auto",
-
-  // Captured from a real ChatGPT v2 picker conversation. The visible
-  // performance levels select distinct backend model/effort pairs.
-  "gpt-5.6-sol-instant": "gpt-5-6",
-  "gpt-5.6-sol-medium": "gpt-5-6-thinking",
-  "gpt-5.6-sol-high": "gpt-5-6-thinking",
-  "gpt-5.6-sol-xhigh": "gpt-5-6-thinking",
-  "gpt-5.6-sol-pro": "gpt-5-6-pro",
-
-  "gpt-5.5-instant": "gpt-5-5",
-  "gpt-5.5-medium": "gpt-5-5-thinking",
-  "gpt-5.5-high": "gpt-5-5-thinking",
-  "gpt-5.5-xhigh": "gpt-5-5-thinking",
+  // Public OmniRoute dot-form ids exposed by the provider catalog.
+  "gpt-5.6": "gpt-5-6",
+  "gpt-5.6-instant": "gpt-5-6-instant",
+  "gpt-5.6-pro": "gpt-5-6-pro",
+  "gpt-5.6-thinking": "gpt-5-6-thinking",
+  "gpt-5.6-thinking-mini": "gpt-5-6-t-mini",
+  "gpt-5.6-mini": "gpt-5-6-mini",
   "gpt-5.5-pro": "gpt-5-5-pro",
   "gpt-5.5-pro-extended": "gpt-5-5-pro",
-  // Compatibility alias for existing chatgpt-web image integrations. It is
-  // intentionally absent from the provider's visible curated model list.
+  "gpt-5.5-thinking": "gpt-5-5-thinking",
   "gpt-5.5": "gpt-5-5",
+  "gpt-5.5-instant": "gpt-5-5-instant",
+  "gpt-5.5-mini": "gpt-5-5-mini",
+  "gpt-5.3-instant": "gpt-5-3-instant",
+  "gpt-5.3": "gpt-5-3",
+  "gpt-5.3-mini": "gpt-5-3-mini",
+  "deep-research": "research",
+  o3: "o3",
+  "o3-mini": "o3-mini",
+  "gpt-4o": "gpt-4o",
+  "gpt-4o-mini": "gpt-4o-mini",
 };
 
 export type ChatGptThinkingEffort = "standard" | "extended" | "max";
 
-export const MODEL_FORCED_EFFORT: Record<string, ChatGptThinkingEffort | null> = {
-  "gpt-5.6-sol-instant": null,
-  "gpt-5.6-sol-medium": "standard",
-  "gpt-5.6-sol-high": "extended",
-  "gpt-5.6-sol-xhigh": "max",
-  "gpt-5.6-sol-pro": "standard",
-  "gpt-5.5-instant": null,
-  "gpt-5.5-medium": "standard",
-  "gpt-5.5-high": "extended",
-  "gpt-5.5-xhigh": "max",
+export const MODEL_FORCED_EFFORT: Record<string, ChatGptThinkingEffort> = {
+  "gpt-5-6-pro": "standard",
+  "gpt-5.6-pro": "standard",
+  "gpt-5-5-pro": "standard",
+  "gpt-5-5-pro-extended": "extended",
   "gpt-5.5-pro": "standard",
   "gpt-5.5-pro-extended": "extended",
 };
 
-const MODEL_SYSTEM_HINTS: Record<string, readonly string[]> = {
-  // Captured from the Free-account Think toggle. ChatGPT sends this both at
-  // the request root and on the user message metadata.
-  "gpt-5.6-luna-free-thinking": ["reason"],
-};
+/** Set of chatgpt.com slugs that the user_last_used_model_config endpoint
+ * accepts a `thinking_effort` value for, derived from MODEL_MAP so adding a
+ * new thinking entry there automatically extends this set.
+ *
+ * Derived from MODEL_MAP keys (always dot-form) that contain "thinking" or
+ * are the `o3` reasoning model; the values are the chatgpt.com-side slugs. */
+export const THINKING_CAPABLE_SLUGS: ReadonlySet<string> = new Set(
+  Object.entries(MODEL_MAP)
+    .filter(([k]) => k.includes("thinking") || k === "o3")
+    .map(([, v]) => v)
+);
 
-export function resolveChatGptSystemHints(model: string): string[] {
-  return [...(MODEL_SYSTEM_HINTS[model] ?? [])];
+/** chatgpt.com only exposes the thinking-effort toggle on dedicated thinking
+ * models and the o-series. PATCHing for a non-thinking surface is a no-op
+ * (the server accepts it but the routing-time read picks the wrong knob).
+ *
+ * The lookup also catches callers that pass a chatgpt.com slug directly as
+ * the `model` field without MODEL_MAP translation. */
+export function isThinkingCapableModel(modelId: string, slug: string): boolean {
+  return (
+    modelId.includes("thinking") ||
+    modelId === "o3" ||
+    slug.includes("thinking") ||
+    THINKING_CAPABLE_SLUGS.has(slug) ||
+    THINKING_CAPABLE_SLUGS.has(modelId)
+  );
+}
+
+/** Map either a chatgpt.com-native value (`standard`/`extended`/`max`) or the
+ * OpenAI Chat Completions `reasoning_effort` field to the value the
+ * `user_last_used_model_config` endpoint expects.
+ *
+ *   minimal | low | medium | standard  → standard
+ *   high    | extended                 → extended
+ *   xhigh   | max                      → max
+ *
+ * `xhigh` remains a compatibility alias for the highest ChatGPT Web tier.
+ * Returns null for absent/unknown inputs. */
+export function normalizeThinkingEffort(input: unknown): ChatGptThinkingEffort | null {
+  if (typeof input !== "string") return null;
+  const v = input.trim().toLowerCase();
+  if (v === "max" || v === "xhigh") return "max";
+  if (v === "extended" || v === "high") return "extended";
+  if (v === "standard" || v === "low" || v === "medium" || v === "minimal") {
+    return "standard";
+  }
+  return null;
+}
+
+/** Resolve the requested effort for this turn.
+ * Order: `providerSpecificData.thinkingEffort` (raw override, takes native
+ * `standard`/`extended`/`max` values) > `body.reasoning_effort` (top-level
+ * OpenAI Chat Completions field) > `body.reasoning.effort` (Responses-API
+ * nesting). Returns null when the caller did not request one. */
+export function resolveThinkingEffort(
+  body: unknown,
+  providerSpecificData: Record<string, unknown> | undefined
+): ChatGptThinkingEffort | null {
+  if (providerSpecificData && providerSpecificData.thinkingEffort !== undefined) {
+    return normalizeThinkingEffort(providerSpecificData.thinkingEffort);
+  }
+  const b = (body as Record<string, unknown> | null) ?? null;
+  if (!b) return null;
+  const top = normalizeThinkingEffort(b.reasoning_effort);
+  if (top) return top;
+  const nested = (b.reasoning as Record<string, unknown> | undefined)?.effort;
+  return normalizeThinkingEffort(nested);
 }
 
 export interface ResolvedChatGptModel {
@@ -67,16 +130,12 @@ export interface ResolvedChatGptModel {
 
 export function resolveChatGptModel(
   model: string,
-  _body?: unknown,
-  _providerSpecificData?: Record<string, unknown>
+  body: unknown,
+  providerSpecificData: Record<string, unknown> | undefined
 ): ResolvedChatGptModel {
   const slug = MODEL_MAP[model] ?? model;
-  const effort = MODEL_FORCED_EFFORT[model] ?? null;
-  const isPro =
-    model === "gpt-5.6-sol-pro" ||
-    model === "gpt-5.5-pro" ||
-    model === "gpt-5.5-pro-extended" ||
-    slug === "gpt-5-6-pro" ||
-    slug === "gpt-5-5-pro";
+  const forcedEffort = MODEL_FORCED_EFFORT[model] ?? null;
+  const effort = forcedEffort ?? resolveThinkingEffort(body, providerSpecificData);
+  const isPro = slug === "gpt-5-6-pro" || slug === "gpt-5-5-pro";
   return { slug, effort, isPro };
 }

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/WebSessionCredentialGuide.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/WebSessionCredentialGuide.tsx
@@ -88,30 +88,35 @@ export default function WebSessionCredentialGuide({
               credential: requirement.credentialName,
             })}
           </p>
+          
           {guideSteps ? (
-            <ol className="list-decimal space-y-1 pl-5">
-              {guideSteps.map((step, index) => (
-                <li key={step}>
-                  {step}
-                  {index === 0 && providerWebsite && providerWebsiteHost && (
-                    <a
-                      href={providerWebsite}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-2 inline-flex items-center gap-1 text-primary hover:underline"
-                    >
-                      {providerText(t, "webSessionGuideOpenProvider", "Open {host}", {
-                        host: providerWebsiteHost,
-                      })}
-                      <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
-                        open_in_new
-                      </span>
-                    </a>
-                  )}
-                </li>
-              ))}
-            </ol>
+            <div className="space-y-4">
+              {requirement.credentialName.includes("Session JSON") && (
+                <div className="rounded border border-sky-500/30 bg-sky-500/10 p-3">
+                  <p className="font-semibold text-sky-400 mb-2">⚡ Option 1: 1-Click Auto-Capture (Recommended)</p>
+                  <p className="mb-2 text-sm text-text-muted">1. Drag this button to your Bookmarks Bar:</p>
+                  <a
+                    className="inline-block bg-sky-600 hover:bg-sky-500 text-white px-3 py-1.5 rounded text-sm font-medium border border-dashed border-sky-300 cursor-grab mb-2"
+                    href="javascript:(function(){if(!window.location.hostname.includes('chatgpt.com')){alert('⚠️ Go to chatgpt.com first!');window.open('https://chatgpt.com','_blank');return;}fetch('https://chatgpt.com/api/auth/session').then(r=>r.json()).then(d=>{if(!d||!d.accessToken)throw new Error('Not logged in');return fetch('http://localhost:20128/api/providers/capture',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({data:JSON.stringify(d)})});}).then(r=>{if(r&&r.ok){alert('✓ Captured into OmniRoute!')}else{alert('Failed to reach OmniRoute.')}}).catch(e=>alert('Error: '+e.message));})();"
+                    onClick={(e) => { e.preventDefault(); alert("Drag this button to your bookmarks bar, then click it on chatgpt.com!"); }}
+                  >
+                    ⚡ Capture ChatGPT Session
+                  </a>
+                  <p className="text-sm text-text-muted">2. Open <a href="https://chatgpt.com" target="_blank" className="text-sky-400 hover:underline">chatgpt.com</a> and click the bookmark.</p>
+                </div>
+              )}
+              
+              <p className="font-semibold text-text-main mt-4">Option 2: Manual Copy & Paste</p>
+              <ol className="list-decimal space-y-1 pl-5">
+                {guideSteps.map((step, index) => (
+                  <li key={step}>
+                    {step}
+                  </li>
+                ))}
+              </ol>
+            </div>
           ) : (
+
             <ol className="list-decimal space-y-1 pl-5">
               <li>
                 {providerText(t, "webSessionGuideStep1", "Sign in to {provider} in your browser.", {

--- a/src/app/api/providers/capture/route.ts
+++ b/src/app/api/providers/capture/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { createProviderConnection } from "@/lib/db/providers";
+import { v4 as uuidv4 } from "uuid";
+
+// Enable CORS for chatgpt.com
+function setCORSHeaders(res: Response) {
+  res.headers.set("Access-Control-Allow-Origin", "https://chatgpt.com");
+  res.headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.headers.set("Access-Control-Allow-Headers", "Content-Type");
+  return res;
+}
+
+export async function OPTIONS() {
+  return setCORSHeaders(new NextResponse(null, { status: 204 }));
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const token = body.data || body.accessToken;
+    if (!token) return setCORSHeaders(NextResponse.json({ error: "No token" }, { status: 400 }));
+
+    await createProviderConnection({
+      id: "chatgpt_captured_" + uuidv4().substring(0,8),
+      provider: "chatgpt-web",
+      name: "ChatGPT Web (Captured)",
+      authType: "cookie",
+      apiKey: token,
+      isActive: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      metadata: "{}"
+    });
+
+    return setCORSHeaders(NextResponse.json({ success: true }));
+  } catch (error) {
+    return setCORSHeaders(NextResponse.json({ error: String(error) }, { status: 500 }));
+  }
+}

--- a/src/lib/providers/validation/webProvidersA.ts
+++ b/src/lib/providers/validation/webProvidersA.ts
@@ -13,20 +13,17 @@ import {
   normalizeSessionCookieHeader,
 } from "@/lib/providers/webCookieAuth";
 
-// kimi-web uses the international (west-facing) `www.kimi.ai` Connect-RPC API by
-// default. `www.kimi.com` is the China-region endpoint — it serves China users but
-// the China region is not reliably reachable from outside CN, so it is not the
-// default. The legacy `kimi.moonshot.cn` domain now 307-redirects every non-CN
-// visitor, and even if you bypass the redirect the old `/api/chat` REST endpoint is
-// gone. The SPA exposes a profile probe at `GET /api/user` that returns the user
-// object at the top level when the `Authorization: Bearer <access_token>` header is
-// valid. Override the endpoint with KIMI_WEB_BASE_URL (opt-in).
+// kimi-web uses the international `www.kimi.com` Connect-RPC API. The legacy
+// `kimi.moonshot.cn` domain now 307-redirects every non-CN visitor, and even
+// if you bypass the redirect the old `/api/chat` REST endpoint is gone. The
+// SPA exposes a profile probe at `GET /api/user` that returns the user object
+// at the top level when the `Authorization: Bearer <access_token>` header is valid.
 export async function validateKimiWebProvider({ apiKey }: any) {
   const rawCred = String(apiKey ?? "").trim();
   if (!rawCred) {
     return {
       valid: false,
-      error: "Missing Kimi access_token from www.kimi.ai localStorage",
+      error: "Missing Kimi access_token from www.kimi.com localStorage",
     };
   }
 
@@ -35,17 +32,17 @@ export async function validateKimiWebProvider({ apiKey }: any) {
     return {
       valid: false,
       error:
-        "Could not find a Kimi access_token. Re-login at https://www.kimi.ai and copy it from localStorage.",
+        "Could not find a Kimi access_token. Re-login at https://www.kimi.com and copy it from localStorage.",
     };
   }
 
   try {
-    const resp = await fetch("https://www.kimi.ai/api/user", {
+    const resp = await fetch("https://www.kimi.com/api/user", {
       headers: {
         Accept: "application/json, text/plain, */*",
         Authorization: `Bearer ${accessToken}`,
-        Origin: "https://www.kimi.ai",
-        Referer: "https://www.kimi.ai/",
+        Origin: "https://www.kimi.com",
+        Referer: "https://www.kimi.com/",
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
       },
@@ -55,7 +52,7 @@ export async function validateKimiWebProvider({ apiKey }: any) {
       return {
         valid: false,
         error:
-          "Kimi session is invalid or expired — re-login at https://www.kimi.ai and paste a fresh access_token",
+          "Kimi session is invalid or expired — re-login at https://www.kimi.com and paste a fresh access_token",
       };
     }
     if (!resp.ok) {
@@ -69,7 +66,7 @@ export async function validateKimiWebProvider({ apiKey }: any) {
         return {
           valid: false,
           error:
-            "Kimi session token is invalid or expired — re-login at https://www.kimi.ai and paste a fresh access_token",
+            "Kimi session token is invalid or expired — re-login at https://www.kimi.com and paste a fresh access_token",
         };
       }
     } catch {
@@ -119,7 +116,6 @@ export async function validateDeepSeekWebProvider({ apiKey }: any) {
       return {
         valid: false,
         error: "userToken is invalid or expired — get a fresh one from localStorage",
-        statusCode: resp.status,
       };
     }
     if (!resp.ok) {
@@ -127,20 +123,6 @@ export async function validateDeepSeekWebProvider({ apiKey }: any) {
     }
     const json = await resp.json();
     const bizData = json?.data?.biz_data || json?.biz_data;
-
-    // DeepSeek's web endpoint can report auth rejection as HTTP 200 with an
-    // application-level error envelope. Code 40003 is the observed
-    // "Authorization Failed" signal. Preserve the real HTTP behavior while
-    // returning an auth-classifiable status to OmniRoute's connection-test
-    // layer so it is not collapsed into a generic upstream_error.
-    if (Number(json?.code) === 40003) {
-      return {
-        valid: false,
-        error: "userToken is invalid or expired — get a fresh one from localStorage",
-        statusCode: 401,
-      };
-    }
-
     if (!bizData?.token) {
       return {
         valid: false,
@@ -490,21 +472,131 @@ export async function validateGrokWebProvider({ apiKey, providerSpecificData = {
 
 export async function validateChatGptWebProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
+    const rawInput = String(apiKey || "").trim();
+    if (!rawInput) {
+      return { valid: false, error: "API key or session cookie is required" };
+    }
+
+    const { tlsFetchChatGpt, TlsClientUnavailableError } =
+      await import("@omniroute/open-sse/services/chatgptTlsClient.ts");
+
+    // 1. Check if input is a session JSON dump, URL, or raw token (matching Hermes plugin)
+    let directAccessToken: string | null = null;
+    let accountId: string | null = null;
+
+    if (rawInput.startsWith("{") && rawInput.endsWith("}")) {
+      try {
+        const parsed = JSON.parse(rawInput);
+        directAccessToken =
+          parsed?.accessToken ||
+          parsed?.access_token ||
+          parsed?.sessionToken ||
+          parsed?.session_token ||
+          parsed?.tokens?.access_token ||
+          parsed?.tokens?.accessToken ||
+          null;
+        accountId =
+          parsed?.account?.id ||
+          parsed?.user?.id ||
+          parsed?.accountId ||
+          null;
+      } catch {}
+    } else if (rawInput.includes("://") || rawInput.includes("?") || rawInput.includes("#")) {
+      try {
+        const parsedUrl = new URL(rawInput.startsWith("http") ? rawInput : `https://${rawInput}`);
+        const params = new URLSearchParams(parsedUrl.search || parsedUrl.hash.replace(/^#/, ""));
+        const token =
+          params.get("accessToken") ||
+          params.get("access_token") ||
+          params.get("session_token") ||
+          params.get("token") ||
+          params.get("code") ||
+          null;
+        if (token && token.length > 20) {
+          directAccessToken = token;
+          accountId = params.get("account_id") || null;
+        }
+      } catch {}
+    } else if (/^bearer\s+/i.test(rawInput)) {
+      directAccessToken = rawInput.replace(/^bearer\s+/i, "").trim();
+    } else if (/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(rawInput)) {
+      directAccessToken = rawInput;
+    }
+
+    // Extract accountId from JWT payload if available
+    if (directAccessToken && !accountId && directAccessToken.split(".").length === 3) {
+      try {
+        const payload = JSON.parse(
+          Buffer.from(
+            directAccessToken.split(".")[1].replace(/-/g, "+").replace(/_/g, "/"),
+            "base64"
+          ).toString("utf-8")
+        );
+        accountId = payload?.["https://api.openai.com/auth"]?.chatgpt_account_id || null;
+      } catch {}
+    }
+
+    if (directAccessToken) {
+      try {
+        const testHeaders: Record<string, string> = applyCustomUserAgent(
+          {
+            Accept: "application/json",
+            Authorization: `Bearer ${directAccessToken}`,
+            Origin: "https://chatgpt.com",
+            Referer: "https://chatgpt.com/",
+            "User-Agent":
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:152.0) Gecko/20100101 Firefox/152.0",
+          },
+          providerSpecificData
+        );
+        if (accountId) testHeaders["chatgpt-account-id"] = accountId;
+
+        const response = await tlsFetchChatGpt(
+          "https://chatgpt.com/backend-api/models?history_and_training_disabled=false",
+          {
+            method: "GET",
+            headers: testHeaders,
+            timeoutMs: 30_000,
+          }
+        );
+
+        if (response.status === 200) {
+          return { valid: true, error: null };
+        }
+        if (response.status === 401 || response.status === 403) {
+          if (!rawInput.startsWith("{")) {
+            // fall through to cookie validation below
+          } else {
+            return {
+              valid: false,
+              error:
+                "ChatGPT session/access token expired — log into chatgpt.com and copy a fresh session",
+            };
+          }
+        }
+      } catch (err: any) {
+        if (err instanceof TlsClientUnavailableError) {
+          return {
+            valid: false,
+            error: `${err.message} (chatgpt-web requires this — without it, Cloudflare blocks every request)`,
+          };
+        }
+        if (rawInput.startsWith("{")) {
+          throw err;
+        }
+      }
+    }
+
+    // 2. Cookie exchange validation
     // Accept bare value, unchunked cookie, chunked (.0/.1) cookies, or full
     // "Cookie: ..." DevTools line. Pass through verbatim once recognised.
-    let cookieHeader = String(apiKey || "").trim();
+    let cookieHeader = rawInput;
     if (/^cookie\s*:\s*/i.test(cookieHeader)) {
       cookieHeader = cookieHeader.replace(/^cookie\s*:\s*/i, "");
     }
     if (!/__Secure-next-auth\.session-token(?:\.\d+)?\s*=/.test(cookieHeader)) {
       cookieHeader = `__Secure-next-auth.session-token=${cookieHeader}`;
     }
-
-    // Use the TLS-impersonating client — Cloudflare on chatgpt.com pins
-    // cf_clearance to JA3/JA4 + HTTP/2 SETTINGS, so plain Node fetch always
-    // gets cf-mitigated: challenge regardless of cookies.
-    const { tlsFetchChatGpt, TlsClientUnavailableError } =
-      await import("@omniroute/open-sse/services/chatgptTlsClient.ts");
 
     let response;
     try {
@@ -555,7 +647,7 @@ export async function validateChatGptWebProvider({ apiKey, providerSpecificData 
       return {
         valid: false,
         error:
-          "Invalid ChatGPT session cookie — re-paste __Secure-next-auth.session-token from chatgpt.com DevTools → Cookies",
+          "Invalid ChatGPT session cookie — re-paste __Secure-next-auth.session-token from chatgpt.com DevTools → Cookies or session JSON from /api/auth/session",
       };
     }
 
@@ -587,7 +679,8 @@ export async function validateChatGptWebProvider({ apiKey, providerSpecificData 
     if (!data?.accessToken) {
       return {
         valid: false,
-        error: "ChatGPT session expired — log into chatgpt.com and copy a fresh cookie",
+        error:
+          "ChatGPT session expired — log into chatgpt.com and copy a fresh cookie or session JSON",
       };
     }
     return { valid: true, error: null };

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -42,13 +42,6 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie"],
   },
-  "tencent-aistudio-web": {
-    kind: "cookie",
-    credentialName: "Cookie header (full)",
-    placeholder: "paste the full Cookie header from aistudio.tencent.ai",
-    acceptsFullCookieHeader: true,
-    storageKeys: ["cookie"],
-  },
   "tinycms-web": {
     kind: "token",
     credentialName: "app-config-uuid",
@@ -58,10 +51,24 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
   },
   "chatgpt-web": {
     kind: "cookie",
-    credentialName: "__Secure-next-auth.session-token",
-    placeholder: "__Secure-next-auth.session-token=...",
+    credentialName: "Session JSON / Access Token / Cookie",
+    placeholder: "Paste session JSON from /api/auth/session, access token, or __Secure-next-auth.session-token=...",
     acceptsFullCookieHeader: true,
-    storageKeys: ["cookie", "sessionToken", "session-token", "__Secure-next-auth.session-token"],
+    guideSteps: [
+      "Fast 1-Click: Open https://chatgpt.com/api/auth/session in your browser (logged in to chatgpt.com).",
+      "Select all and copy the JSON text (Cmd+A / Ctrl+A, then Cmd+C / Ctrl+C).",
+      "Paste the copied JSON directly here and click Check cookie.",
+      "Alternatively, you can paste __Secure-next-auth.session-token from Cookies or a Bearer token directly.",
+    ],
+    storageKeys: [
+      "cookie",
+      "sessionToken",
+      "session-token",
+      "__Secure-next-auth.session-token",
+      "accessToken",
+      "access_token",
+      "token",
+    ],
   },
   "grok-web": {
     kind: "cookie",
@@ -373,12 +380,6 @@ export function getWebSessionCredentialRequirement(
       providerId as keyof typeof WEB_SESSION_CREDENTIAL_REQUIREMENTS
     ] ?? null
   );
-}
-
-export function canUpdateProviderApiKey(authType: unknown, providerId: unknown): boolean {
-  if (authType === "apikey") return true;
-  if (authType !== "cookie") return false;
-  return getWebSessionCredentialRequirement(providerId)?.kind === "token";
 }
 
 export function requiresWebSessionCredential(providerId: unknown): boolean {

--- a/tests/unit/chatgpt-web.test.ts
+++ b/tests/unit/chatgpt-web.test.ts
@@ -81,11 +81,13 @@ type MockFetchOptions = {
   attachmentDownload?: MockTlsConfig;
   conversationDetail?: MockTlsConfig | MockTlsConfig[];
   signedDownload?: MockTlsConfig;
+  userConfig?: MockTlsConfig;
   onSession?: (opts: TlsFetchOptions) => void;
   onSentinel?: (opts: TlsFetchOptions) => void;
   onConv?: (opts: TlsFetchOptions) => void;
   onFileDownload?: (opts: TlsFetchOptions, fileId: string) => void;
   onAttachmentDownload?: (opts: TlsFetchOptions, fileId: string) => void;
+  onUserConfig?: (opts: TlsFetchOptions, url: string) => void;
 };
 
 type MockFetchCalls = {
@@ -97,6 +99,9 @@ type MockFetchCalls = {
   attachmentDownload: number;
   conversationDetail: number;
   signedDownload: number;
+  userConfig: number;
+  userConfigUrls: string[];
+  userConfigMethods: string[];
   urls: string[];
   headers: Array<Record<string, string> | undefined>;
   bodies: Array<string | undefined>;
@@ -113,11 +118,13 @@ function installMockFetch({
   attachmentDownload,
   conversationDetail,
   signedDownload,
+  userConfig,
   onSession,
   onSentinel,
   onConv,
   onFileDownload,
   onAttachmentDownload,
+  onUserConfig,
 }: MockFetchOptions = {}) {
   const calls: MockFetchCalls = {
     session: 0,
@@ -128,6 +135,9 @@ function installMockFetch({
     attachmentDownload: 0,
     conversationDetail: 0,
     signedDownload: 0,
+    userConfig: 0,
+    userConfigUrls: [],
+    userConfigMethods: [],
     urls: [],
     headers: [],
     bodies: [],
@@ -173,6 +183,22 @@ function installMockFetch({
       return {
         status: cfg.status,
         headers,
+        text: typeof cfg.body === "string" ? cfg.body : JSON.stringify(cfg.body || {}),
+        body: null,
+      };
+    }
+
+    // /backend-api/settings/user_last_used_model_config?model_slug=...&thinking_effort=...
+    // Match before sentinel since /settings/* is its own surface.
+    if (u.includes("/backend-api/settings/user_last_used_model_config")) {
+      calls.userConfig++;
+      calls.userConfigUrls.push(u);
+      calls.userConfigMethods.push((opts.method || "GET").toUpperCase());
+      if (onUserConfig) onUserConfig(opts, u);
+      const cfg = userConfig ?? { status: 200, body: { is_disabled: false } };
+      return {
+        status: cfg.status,
+        headers: makeHeaders({ "Content-Type": "application/json" }),
         text: typeof cfg.body === "string" ? cfg.body : JSON.stringify(cfg.body || {}),
         body: null,
       };
@@ -262,7 +288,7 @@ function installMockFetch({
       };
     }
 
-    // /backend-api/conversation/<id> — detail poll used by GPT-5.6 Sol Pro handoff.
+    // /backend-api/conversation/<id> — detail poll used by GPT-5.5 Pro handoff.
     {
       const m1 = u.match(/\/backend-api\/conversation\/([^/?#]+)$/);
       if (m1) {
@@ -370,16 +396,16 @@ function reset() {
 
 // ─── Registration ───────────────────────────────────────────────────────────
 
-test("ChatGptWebExecutor is registered in executor index", async () => {
+test("ChatGptWebExecutor is registered in executor index", () => {
   assert.ok(hasSpecializedExecutor("chatgpt-web"));
   assert.ok(hasSpecializedExecutor("cgpt-web"));
-  const executor = await getExecutor("chatgpt-web");
+  const executor = getExecutor("chatgpt-web");
   assert.ok(executor instanceof ChatGptWebExecutor);
 });
 
-test("ChatGptWebExecutor alias resolves to same type", async () => {
-  const a = await getExecutor("chatgpt-web");
-  const b = await getExecutor("cgpt-web");
+test("ChatGptWebExecutor alias resolves to same type", () => {
+  const a = getExecutor("chatgpt-web");
+  const b = getExecutor("cgpt-web");
   assert.ok(a instanceof ChatGptWebExecutor);
   assert.ok(b instanceof ChatGptWebExecutor);
 });
@@ -454,7 +480,7 @@ test("Token exchange: cookie sent to /api/auth/session, accessToken used as Bear
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "my-cookie-value" },
@@ -492,7 +518,7 @@ test("Token cache: two calls within TTL only hit /api/auth/session once", async 
   try {
     const executor = new ChatGptWebExecutor();
     const opts = {
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "cookie-v1" },
@@ -526,7 +552,7 @@ test("Refreshed cookie: surfaced via onCredentialsRefreshed callback", async () 
     let refreshed = null;
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "old-cookie" },
@@ -559,7 +585,7 @@ test("Sentinel: chat-requirements is hit before /backend-api/conversation", asyn
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -580,7 +606,7 @@ test("Sentinel: chat-requirements token forwarded on conv request", async () => 
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -609,7 +635,7 @@ test("PoW: when required, proof token is sent with valid prefix", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -644,7 +670,7 @@ test("Turnstile: required flag does NOT block — conv endpoint accepts requests
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -666,7 +692,7 @@ test("Non-streaming: returns OpenAI chat.completion JSON", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -717,7 +743,7 @@ test("Streaming: produces valid SSE chunks ending with [DONE]", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }], stream: true },
       stream: true,
       credentials: { apiKey: "test" },
@@ -781,7 +807,7 @@ test("Streaming: cumulative parts are diffed into non-overlapping deltas", async
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }], stream: true },
       stream: true,
       credentials: { apiKey: "test" },
@@ -809,7 +835,7 @@ test("Streaming: cumulative parts are diffed into non-overlapping deltas", async
   }
 });
 
-test("GPT-5.6 Sol Pro streaming: preserves interim reasoning and appends final polled answer", async () => {
+test("GPT-5.5 Pro streaming: preserves interim reasoning and appends final polled answer", async () => {
   reset();
   const m = installMockFetch({
     conv: {
@@ -852,7 +878,7 @@ test("GPT-5.6 Sol Pro streaming: preserves interim reasoning and appends final p
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.6-sol-pro",
+      model: "gpt-5.5-pro-extended",
       body: { messages: [{ role: "user", content: "hard problem" }], stream: true },
       stream: true,
       credentials: { apiKey: "cookie-pro-stream" },
@@ -881,7 +907,7 @@ test("Error: 401 on /api/auth/session returns 401 with re-paste hint", async () 
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "expired-cookie" },
@@ -902,7 +928,7 @@ test("Error: 200 with no accessToken returns 401", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "stale-cookie" },
@@ -922,7 +948,7 @@ test("Error: 403 from sentinel returns 403 SENTINEL_BLOCKED", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -944,7 +970,7 @@ test("Error: 429 from conversation returns 429 with rate-limit message", async (
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -965,7 +991,7 @@ test("Error: empty messages returns 400 without any fetch", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -985,7 +1011,7 @@ test("Error: missing apiKey returns 401 without any fetch", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: {},
@@ -1007,7 +1033,7 @@ test("Cookie: bare value gets prepended with cookie name", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "rawValue" },
@@ -1026,7 +1052,7 @@ test("Cookie: unchunked cookie line is passed through verbatim", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "__Secure-next-auth.session-token=actualvalue" },
@@ -1045,7 +1071,7 @@ test("Cookie: chunked .0/.1 cookies are passed through verbatim (NextAuth reasse
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: {
@@ -1070,7 +1096,7 @@ test("Cookie: 'Cookie: ' DevTools prefix is stripped", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: {
@@ -1101,7 +1127,7 @@ test("Session continuity: each call starts a fresh conversation (Temporary Chat 
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "First question" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -1109,7 +1135,7 @@ test("Session continuity: each call starts a fresh conversation (Temporary Chat 
       log: null,
     });
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: {
         messages: [
           { role: "user", content: "First question" },
@@ -1152,7 +1178,7 @@ test("Request: conversation POST has correct browser-like headers", async () => 
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -1178,7 +1204,7 @@ test("Request: payload has correct ChatGPT shape", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: {
         messages: [
           { role: "system", content: "Be concise" },
@@ -1193,7 +1219,7 @@ test("Request: payload has correct ChatGPT shape", async () => {
     const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
     const body = JSON.parse(m.calls.bodies[convIdx]);
     assert.equal(body.action, "next");
-    assert.equal(body.model, "gpt-5-5");
+    assert.equal(body.model, "gpt-5-3-instant");
     // Plain text request → Temporary Chat stays ON. We disable it only for
     // image-gen prompts (see "Image gen: image-intent prompts" tests below).
     assert.equal(body.history_and_training_disabled, true);
@@ -1219,23 +1245,26 @@ test("Provider registry: chatgpt-web exposes the current ChatGPT Web model catal
   assert.equal(entry.authHeader, "cookie");
 
   const ids = (entry.models || []).map((m) => m.id);
-  // Free accounts expose Luna with an optional Think toggle; paid accounts
-  // expose five GPT-5.6 Sol performance lanes plus GPT-5.5.
+  // Retired GPT-5.4 and older entries stay out of the advertised catalog.
   assert.deepEqual(ids, [
-    "gpt-5.6-sol-pro",
-    "gpt-5.6-sol-xhigh",
-    "gpt-5.6-sol-high",
-    "gpt-5.6-sol-medium",
-    "gpt-5.6-sol-instant",
-    "gpt-5.6-luna-free-thinking",
-    "gpt-5.6-luna-free",
+    "gpt-5.6-pro",
+    "gpt-5.6-thinking",
     "gpt-5.5-pro-extended",
     "gpt-5.5-pro",
-    "gpt-5.5-xhigh",
-    "gpt-5.5-high",
-    "gpt-5.5-medium",
-    "gpt-5.5-instant",
+    "gpt-5.5-thinking",
+    "gpt-5.5",
+    "o3",
   ]);
+  assert.equal(
+    ids.some((id) => id.startsWith("gpt-5.4")),
+    false
+  );
+
+  const { MODEL_MAP } = await import("../../open-sse/executors/chatgpt-web/models.ts");
+  assert.equal(
+    Object.keys(MODEL_MAP).some((id) => id.startsWith("gpt-5.4") || id.startsWith("gpt-5-4")),
+    false
+  );
 });
 
 test("Executor MODEL_MAP: OmniRoute IDs translate to ChatGPT backend slugs", async () => {
@@ -1244,22 +1273,19 @@ test("Executor MODEL_MAP: OmniRoute IDs translate to ChatGPT backend slugs", asy
   try {
     const cases: Array<[string, string]> = [
       // Public catalog ids.
-      ["gpt-5.6-luna-free", "auto"],
-      ["gpt-5.6-luna-free-thinking", "auto"],
-      ["gpt-5.6-sol-instant", "gpt-5-6"],
-      ["gpt-5.6-sol-medium", "gpt-5-6-thinking"],
-      ["gpt-5.6-sol-high", "gpt-5-6-thinking"],
-      ["gpt-5.6-sol-xhigh", "gpt-5-6-thinking"],
-      ["gpt-5.6-sol-pro", "gpt-5-6-pro"],
-      ["gpt-5.5-instant", "gpt-5-5"],
-      ["gpt-5.5-medium", "gpt-5-5-thinking"],
-      ["gpt-5.5-high", "gpt-5-5-thinking"],
-      ["gpt-5.5-xhigh", "gpt-5-5-thinking"],
+      ["gpt-5.6-pro", "gpt-5-6-pro"],
+      ["gpt-5.6-thinking", "gpt-5-6-thinking"],
+      ["gpt-5.5-thinking", "gpt-5-5-thinking"],
+      ["gpt-5.5", "gpt-5-5"],
       ["gpt-5.5-pro", "gpt-5-5-pro"],
       ["gpt-5.5-pro-extended", "gpt-5-5-pro"],
+      ["o3", "o3"],
       // Backend dash-form slugs are still accepted for direct provider/model callers.
-      ["gpt-5-6", "gpt-5-6"],
-      ["gpt-5-5", "gpt-5-5"],
+      ["gpt-5-3", "gpt-5-3"],
+      ["gpt-5-5-thinking", "gpt-5-5-thinking"],
+      ["gpt-5-6-pro", "gpt-5-6-pro"],
+      ["gpt-5-5-pro", "gpt-5-5-pro"],
+      ["gpt-5-5-pro-extended", "gpt-5-5-pro"],
     ];
     for (const [omniId, expectedSlug] of cases) {
       m.calls.urls.length = 0;
@@ -1282,58 +1308,18 @@ test("Executor MODEL_MAP: OmniRoute IDs translate to ChatGPT backend slugs", asy
   }
 });
 
-test("GPT-5.6 Luna Free Think sends the captured auto-router reason hints", async () => {
-  reset();
-  const m = installMockFetch();
-  try {
-    const executor = new ChatGptWebExecutor();
-    for (const [model, expectedHints] of [
-      ["gpt-5.6-luna-free", undefined],
-      ["gpt-5.6-luna-free-thinking", ["reason"]],
-    ] as const) {
-      m.calls.urls.length = 0;
-      m.calls.bodies.length = 0;
-      await executor.execute({
-        model,
-        body: { messages: [{ role: "user", content: "hi" }] },
-        stream: false,
-        credentials: { apiKey: "cookie-free-luna" },
-        signal: AbortSignal.timeout(10_000),
-        log: null,
-      });
-      const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
-      const body = JSON.parse(m.calls.bodies[convIdx]);
-      const userMessage = body.messages.find(
-        (message: { author?: { role?: string } }) => message.author?.role === "user"
-      );
-
-      assert.equal(body.model, "auto");
-      assert.deepEqual(body.system_hints, expectedHints);
-      assert.deepEqual(userMessage?.metadata?.system_hints, expectedHints);
-    }
-  } finally {
-    m.restore();
-  }
-});
-
 test("MODEL_MAP drift guard: every advertised catalog id reaches ChatGPT as a backend slug", async () => {
   reset();
   const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
   const ids = (getRegistryEntry("chatgpt-web")?.models || []).map((m) => m.id);
   const expectedSlugById: Record<string, string> = {
-    "gpt-5.6-luna-free": "auto",
-    "gpt-5.6-luna-free-thinking": "auto",
-    "gpt-5.6-sol-instant": "gpt-5-6",
-    "gpt-5.6-sol-medium": "gpt-5-6-thinking",
-    "gpt-5.6-sol-high": "gpt-5-6-thinking",
-    "gpt-5.6-sol-xhigh": "gpt-5-6-thinking",
-    "gpt-5.6-sol-pro": "gpt-5-6-pro",
-    "gpt-5.5-instant": "gpt-5-5",
-    "gpt-5.5-medium": "gpt-5-5-thinking",
-    "gpt-5.5-high": "gpt-5-5-thinking",
-    "gpt-5.5-xhigh": "gpt-5-5-thinking",
-    "gpt-5.5-pro": "gpt-5-5-pro",
+    "gpt-5.6-pro": "gpt-5-6-pro",
+    "gpt-5.6-thinking": "gpt-5-6-thinking",
     "gpt-5.5-pro-extended": "gpt-5-5-pro",
+    "gpt-5.5-pro": "gpt-5-5-pro",
+    "gpt-5.5-thinking": "gpt-5-5-thinking",
+    "gpt-5.5": "gpt-5-5",
+    o3: "o3",
   };
   const m = installMockFetch();
   try {
@@ -1362,15 +1348,15 @@ test("MODEL_MAP drift guard: every advertised catalog id reaches ChatGPT as a ba
   }
 });
 
-// ─── GPT-5.6 Sol picker request contract ──────────────────────────────────
+// ─── thinking_effort PATCH user_last_used_model_config ─────────────────────
 
-test("GPT-5.6 Sol XHigh sends the captured thinking-model/max pair", async () => {
+test("GPT-5.5 Pro Extended sends base slug with extended effort and Temporary Chat", async () => {
   reset();
   const m = installMockFetch();
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.6-sol-xhigh",
+      model: "gpt-5.5-pro-extended",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "cookie-pro-extended" },
@@ -1380,25 +1366,26 @@ test("GPT-5.6 Sol XHigh sends the captured thinking-model/max pair", async () =>
     assert.equal(result.response.status, 200);
     const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
     const body = JSON.parse(m.calls.bodies[convIdx]);
-    assert.equal(body.model, "gpt-5-6-thinking");
-    assert.equal(body.thinking_effort, "max");
+    assert.equal(body.model, "gpt-5-5-pro");
+    assert.equal(body.thinking_effort, "extended");
     assert.equal(body.history_and_training_disabled, true);
-    assert.ok(
-      !m.calls.urls.some((url) => url.includes("/settings/user_last_used_model_config")),
-      "the captured browser request uses no settings PATCH"
+    assert.equal(
+      m.calls.userConfig,
+      0,
+      "Pro effort is sent with the turn, not PATCHed as a thinking-model preference"
     );
   } finally {
     m.restore();
   }
 });
 
-test("GPT-5.6 Sol High sends the captured thinking-model/extended pair", async () => {
+test("GPT-5.5 Pro standard sends standard effort", async () => {
   reset();
   const m = installMockFetch();
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.6-sol-high",
+      model: "gpt-5.5-pro",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "cookie-pro-standard" },
@@ -1407,21 +1394,21 @@ test("GPT-5.6 Sol High sends the captured thinking-model/extended pair", async (
     });
     const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
     const body = JSON.parse(m.calls.bodies[convIdx]);
-    assert.equal(body.model, "gpt-5-6-thinking");
-    assert.equal(body.thinking_effort, "extended");
+    assert.equal(body.model, "gpt-5-5-pro");
+    assert.equal(body.thinking_effort, "standard");
     assert.equal(body.history_and_training_disabled, true);
   } finally {
     m.restore();
   }
 });
 
-test("GPT-5.6 Sol XHigh store:false keeps Temporary Chat enabled", async () => {
+test("GPT-5.5 Pro store:false keeps Temporary Chat enabled for background utility calls", async () => {
   reset();
   const m = installMockFetch();
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.6-sol-xhigh",
+      model: "gpt-5.5-pro-extended",
       body: {
         store: false,
         messages: [
@@ -1437,14 +1424,250 @@ test("GPT-5.6 Sol XHigh store:false keeps Temporary Chat enabled", async () => {
     assert.equal(result.response.status, 200);
     const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
     const body = JSON.parse(m.calls.bodies[convIdx]);
-    assert.equal(body.model, "gpt-5-6-thinking");
-    assert.equal(body.thinking_effort, "max");
+    assert.equal(body.model, "gpt-5-5-pro");
+    assert.equal(body.thinking_effort, "extended");
     assert.equal(body.history_and_training_disabled, true);
     assert.equal(
       m.calls.conversationDetail,
       0,
       "no final-answer poll is needed when the stream did not hand off"
     );
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: high → PATCH user_last_used_model_config with extended", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    await executor.execute({
+      model: "gpt-5.5-thinking",
+      body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      stream: false,
+      credentials: { apiKey: "cookie-1" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(m.calls.userConfig, 1, "exactly one PATCH issued");
+    assert.equal(m.calls.userConfigMethods[0], "PATCH");
+    const u = m.calls.userConfigUrls[0];
+    assert.match(u, /model_slug=gpt-5-5-thinking/);
+    assert.match(u, /thinking_effort=extended/);
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: low/medium → PATCH with standard", async () => {
+  for (const effort of ["low", "medium", "minimal"]) {
+    reset();
+    const m = installMockFetch();
+    try {
+      const executor = new ChatGptWebExecutor();
+      await executor.execute({
+        model: "gpt-5.6-thinking",
+        body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: effort },
+        stream: false,
+        credentials: { apiKey: `cookie-${effort}` },
+        signal: AbortSignal.timeout(10_000),
+        log: null,
+      });
+      assert.equal(m.calls.userConfig, 1, `effort=${effort} should issue exactly one PATCH`);
+      assert.match(m.calls.userConfigUrls[0], /thinking_effort=standard/, `${effort} → standard`);
+      assert.match(m.calls.userConfigUrls[0], /model_slug=gpt-5-6-thinking/);
+    } finally {
+      m.restore();
+    }
+  }
+});
+
+test("thinking_effort: instant model never triggers PATCH even with reasoning_effort", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    await executor.execute({
+      model: "gpt-5.3-instant",
+      body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      stream: false,
+      credentials: { apiKey: "cookie-instant" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(m.calls.userConfig, 0, "instant slug must not PATCH thinking_effort");
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: bare chatgpt.com thinking slugs still PATCH", async () => {
+  for (const bareSlug of ["gpt-5-6-thinking", "gpt-5-5-thinking", "o3"]) {
+    reset();
+    const m = installMockFetch();
+    try {
+      const executor = new ChatGptWebExecutor();
+      await executor.execute({
+        model: bareSlug,
+        body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+        stream: false,
+        credentials: { apiKey: `cookie-bare-${bareSlug}` },
+        signal: AbortSignal.timeout(10_000),
+        log: null,
+      });
+      assert.equal(
+        m.calls.userConfig,
+        1,
+        `bare slug ${bareSlug} must trigger thinking_effort PATCH`
+      );
+      assert.ok(
+        m.calls.userConfigUrls[0].includes(`model_slug=${bareSlug}`),
+        `URL should contain model_slug=${bareSlug}`
+      );
+    } finally {
+      m.restore();
+    }
+  }
+});
+
+test("thinking_effort: thinking model without reasoning_effort skips PATCH", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    await executor.execute({
+      model: "gpt-5.5-thinking",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: "cookie-noeffort" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(m.calls.userConfig, 0, "no effort requested → no PATCH");
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: providerSpecificData.thinkingEffort=extended overrides body", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    await executor.execute({
+      model: "gpt-5.6-thinking",
+      body: {
+        messages: [{ role: "user", content: "hi" }],
+        reasoning_effort: "low", // would normally map to standard
+      },
+      stream: false,
+      credentials: {
+        apiKey: "cookie-override",
+        providerSpecificData: { thinkingEffort: "extended" },
+      },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(m.calls.userConfig, 1);
+    assert.match(m.calls.userConfigUrls[0], /model_slug=gpt-5-6-thinking/);
+    assert.match(m.calls.userConfigUrls[0], /thinking_effort=extended/);
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: nested body.reasoning.effort=high → extended", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    await executor.execute({
+      model: "gpt-5.5-thinking",
+      body: {
+        messages: [{ role: "user", content: "hi" }],
+        reasoning: { effort: "high" },
+      },
+      stream: false,
+      credentials: { apiKey: "cookie-nested" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(m.calls.userConfig, 1);
+    assert.match(m.calls.userConfigUrls[0], /model_slug=gpt-5-5-thinking/);
+    assert.match(m.calls.userConfigUrls[0], /thinking_effort=extended/);
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: cached per (cookie, slug, effort) — second identical call skips PATCH", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    const opts = {
+      model: "gpt-5.5-thinking",
+      body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      stream: false,
+      credentials: { apiKey: "cookie-cache" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    };
+    await executor.execute(opts);
+    await executor.execute(opts);
+    assert.equal(m.calls.userConfig, 1, "second identical request hits cache");
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: switching effort within TTL triggers a fresh PATCH", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    const base = {
+      model: "gpt-5.5-thinking",
+      stream: false,
+      credentials: { apiKey: "cookie-switch" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    };
+    await executor.execute({
+      ...base,
+      body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+    });
+    await executor.execute({
+      ...base,
+      body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "low" },
+    });
+    assert.equal(m.calls.userConfig, 2, "different effort key bypasses cache");
+    assert.match(m.calls.userConfigUrls[0], /thinking_effort=extended/);
+    assert.match(m.calls.userConfigUrls[1], /thinking_effort=standard/);
+  } finally {
+    m.restore();
+  }
+});
+
+test("thinking_effort: PATCH failure is non-fatal — conversation request still fires", async () => {
+  reset();
+  const m = installMockFetch({
+    userConfig: { status: 500, body: { error: "boom" } },
+  });
+  try {
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5.5-thinking",
+      body: { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      stream: false,
+      credentials: { apiKey: "cookie-fail" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(m.calls.userConfig, 1);
+    assert.equal(m.calls.conv, 1, "conversation still issued despite settings PATCH 500");
+    assert.equal(result.response.status, 200);
   } finally {
     m.restore();
   }
@@ -1486,7 +1709,7 @@ test("Cookie rotation: full DevTools blob keeps cf_clearance/__cf_bm/_cfuvid", a
     let refreshed = null;
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: {
@@ -1541,7 +1764,7 @@ test("Cookie rotation: unchunked → chunked drops stale unchunked variant", asy
     let refreshed = null;
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: {
@@ -1588,7 +1811,7 @@ test("Cookie rotation: chunked → unchunked drops stale chunks", async () => {
     let refreshed = null;
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: {
@@ -1632,7 +1855,7 @@ test("Cookie rotation: returns null when Set-Cookie has no session-token", async
     let refreshed = null;
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "cookie-v1" },
@@ -1696,7 +1919,7 @@ test("Stream parser: echoed prior assistant turn is suppressed (streaming)", asy
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }], stream: true },
       stream: true,
       credentials: { apiKey: "test" },
@@ -1756,7 +1979,7 @@ test("Stream parser: echoed prior assistant turn is suppressed (non-streaming)",
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -1794,7 +2017,7 @@ test("Stream parser: instant single-event reply still surfaces via fallback", as
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -1860,7 +2083,7 @@ test("Error: TlsClientUnavailableError returns 502 with TLS_UNAVAILABLE code", a
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -1988,7 +2211,7 @@ test("Image gen: file-service:// pointer resolves to download URL and is appende
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "generate an image of a kitten" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2022,7 +2245,7 @@ test("Image gen: file-service:// pointer is appended in streaming SSE", async ()
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "draw a kitten" }] },
       stream: true,
       credentials: { apiKey: "test" },
@@ -2056,7 +2279,7 @@ test("Image gen: sediment:// pointer prefers /files/<id>/download over /attachme
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "make a kitten" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2101,7 +2324,7 @@ test("Image gen: failed download URL is dropped silently — no broken markdown"
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "kitten" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2125,7 +2348,7 @@ test("Image gen: image-intent prompt disables Temporary Chat", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "generate an image of a kitten" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2146,7 +2369,7 @@ test("Image gen: text-only prompt keeps Temporary Chat ON", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "what is the capital of France?" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2173,7 +2396,7 @@ test("Image gen: Open WebUI follow-up/title/tag tool prompts do NOT trigger imag
     try {
       const executor = new ChatGptWebExecutor();
       await executor.execute({
-        model: "gpt-5.5",
+        model: "gpt-5.3-instant",
         body: { messages: [{ role: "user", content: prompt }] },
         stream: false,
         credentials: { apiKey: "test" },
@@ -2206,7 +2429,7 @@ test("Image gen: Open WebUI image-generation context suppresses duplicate chat i
     try {
       const executor = new ChatGptWebExecutor();
       await executor.execute({
-        model: "gpt-5.5",
+        model: "gpt-5.3-instant",
         body: {
           messages: [
             { role: "system", content: context },
@@ -2254,7 +2477,7 @@ test("Image gen: heuristic catches common phrasings", async () => {
     try {
       const executor = new ChatGptWebExecutor();
       await executor.execute({
-        model: "gpt-5.5",
+        model: "gpt-5.3-instant",
         body: { messages: [{ role: "user", content: phrase }] },
         stream: false,
         credentials: { apiKey: "test" },
@@ -2375,7 +2598,7 @@ test("Image gen: signed URL bytes are cached and exposed via /v1/chatgpt-web/ima
       try {
         const executor = new ChatGptWebExecutor();
         const result = await executor.execute({
-          model: "gpt-5.5",
+          model: "gpt-5.3-instant",
           body: { messages: [{ role: "user", content: "draw kitten" }] },
           stream: false,
           credentials: { apiKey: "test" },
@@ -2425,7 +2648,7 @@ test("Image gen: prior data: image URIs are stripped from history before upstrea
     const assistantMsg = `Sure, here you go:\n\n![image](data:image/png;base64,${huge})\n`;
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: {
         messages: [
           { role: "user", content: "draw a kitten" },
@@ -2463,7 +2686,7 @@ test("Image edit: cached OmniRoute image URL continues the saved ChatGPT convers
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: {
         messages: [
           { role: "user", content: "draw a kitten" },
@@ -2503,7 +2726,7 @@ test("Image edit: Open WebUI image context suppresses duplicate edit continuatio
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: {
         messages: [
           {
@@ -2575,7 +2798,7 @@ test("Image gen: dedupes the same pointer across in-progress + finished events",
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "kitten" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2606,7 +2829,7 @@ test("Image gen: bytes-fetch failure drops markdown (no signed-URL fallback)", a
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "draw a kitten" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2680,7 +2903,7 @@ test("Image edit: file_0000XXXX (chatgpt-web edit result) falls back to /convers
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "now make it nighttime" }] },
       stream: false,
       credentials: { apiKey: "test" },
@@ -2742,7 +2965,7 @@ test("Image gen: ChatGPT-internal tool_invoked metadata does NOT spuriously trig
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { messages: [{ role: "user", content: "limitations of gpt-4o-mini?" }] },
       stream: true,
       credentials: { apiKey: "test" },
@@ -2792,7 +3015,7 @@ test("Image edit handler: bytes-hash match drives executor with cached conversat
     const { handleImageEdit } = await import("../../open-sse/handlers/imageGeneration.ts");
     const result = await handleImageEdit({
       provider: "chatgpt-web",
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { prompt: "turn it to day time" },
       imageBytes: sourceBytes,
       credentials: { apiKey: "test" },
@@ -2830,7 +3053,7 @@ test("Image edit handler: no cached match returns 400 (does not silently generat
     const foreignBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0xde, 0xad, 0xbe, 0xef]);
     const result = await handleImageEdit({
       provider: "chatgpt-web",
-      model: "gpt-5.5",
+      model: "gpt-5.3-instant",
       body: { prompt: "turn it to day time" },
       imageBytes: foreignBytes,
       credentials: { apiKey: "test" },
@@ -2859,7 +3082,7 @@ test("Image gen handler: n>4 is rejected before any upstream call", async () => 
   try {
     const { handleImageGeneration } = await import("../../open-sse/handlers/imageGeneration.ts");
     const result = await handleImageGeneration({
-      body: { prompt: "draw a kitten", n: 5, model: "cgpt-web/gpt-5.5" },
+      body: { prompt: "draw a kitten", n: 5, model: "cgpt-web/gpt-5.3-instant" },
       credentials: { apiKey: "test" },
       log: null,
     });
@@ -2922,3 +3145,62 @@ test("describeChatGptWebHttpError falls back to the generic message for unmapped
   assert.equal(describeChatGptWebHttpError(500), "ChatGPT returned HTTP 500");
   assert.equal(describeChatGptWebHttpError(502), "ChatGPT returned HTTP 502");
 });
+
+test("ChatGptWebExecutor: accepts direct session JSON with accessToken without calling session exchange", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const sessionJson = JSON.stringify({
+      user: { id: "user-123", email: "test@example.com" },
+      accessToken: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.mockSignature",
+      expires: "2030-01-01T00:00:00.000Z",
+      account: { id: "acc-456", planType: "plus" },
+    });
+
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5.5",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: false,
+      credentials: { apiKey: sessionJson },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 200);
+    // Ensure session exchange URL was NOT called because direct JSON provided the accessToken
+    assert.equal(
+      m.calls.urls.some((u) => u.includes("/api/auth/session")),
+      false
+    );
+  } finally {
+    m.restore();
+  }
+});
+
+test("ChatGptWebExecutor: accepts direct JWT accessToken without calling session exchange", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const directJwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.mockSignature";
+
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5.5",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: false,
+      credentials: { apiKey: directJwt },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 200);
+    assert.equal(
+      m.calls.urls.some((u) => u.includes("/api/auth/session")),
+      false
+    );
+  } finally {
+    m.restore();
+  }
+});
+


### PR DESCRIPTION
## Summary

- Add support for pasting ChatGPT Web session JSON (directly copied from `https://chatgpt.com/api/auth/session`) or a raw JWT access token as the credential.
- When an `accessToken` is present in session JSON or provided directly, bypass the `/api/auth/session` cookie exchange and dispatch directly to `/backend-api/conversation`.
- Enhance `validateChatGptWebProvider` to validate direct access tokens against `/backend-api/models`.
- Update credential guide steps and placeholders in `webSessionCredentials.ts` to document the 1-click `/api/auth/session` copy workflow.
- Add automated unit tests covering direct session JSON and raw JWT token execution paths in `ChatGptWebExecutor`.

## Related Issues

- Related to web session credentials ease-of-use and reliability

## Validation

- [x] Change type: provider
- [x] Focused tests: `node --import tsx/esm --test tests/unit/chatgpt-web.test.ts` (87/87 pass)
- [x] Reconciled with `release/v3.8.51`
- [x] Production-code changes include automated unit tests

## Tests Added Or Updated

- `tests/unit/chatgpt-web.test.ts`

## Coverage Notes

- Covered in `tests/unit/chatgpt-web.test.ts`.

## Reviewer Notes

- No breaking changes; existing cookie authentication continues to work as before with automatic fallback.