### PR TITLE
fix: remove Brave Search from free tier

### DIFF
--- a/src/shared/constants/providers/search.ts
+++ b/src/shared/constants/providers/search.ts
@@ -33,7 +33,7 @@ export const SEARCH_PROVIDERS = {
     color: "#FB542B",
     textIcon: "BR",
     website: "https://brave.com/search/api",
-    hasFree: true,
+    hasFree: false,
     authHint: "Subscription token from Brave Search API dashboard",
   },
   "exa-search": {


### PR DESCRIPTION
Brave Search API no longer has a free tier that does not require a paid/metered subscription.