### PR TITLE
fix(providers): Brave Search no longer has a free tier

### DIFF
--- a/src/shared/constants/providers/search.ts
+++ b/src/shared/constants/providers/search.ts
@@ -33,7 +33,7 @@ export const SEARCH_PROVIDERS = {
     color: "#FB542B",
     textIcon: "BR",
     website: "https://brave.com/search/api",
-    hasFree: true,
+    hasFree: false,
     authHint: "Subscription token from Brave Search API dashboard",
   },
   "exa-search": {


### PR DESCRIPTION
Brave Search API no longer has a free tier that does not require a paid/metered subscription.

Sources:

- [https://www.implicator.ai/brave-drops-free-search-api-tier-puts-all-developers-on-metered-billing/](https://www.implicator.ai/brave-drops-free-search-api-tier-puts-all-developers-on-metered-billing/)
- [https://scavio.dev/blog/brave-search-api-killed-free-tier-what-now-2026](https://scavio.dev/blog/brave-search-api-killed-free-tier-what-now-2026)