### PR TITLE
fix: pass tool result content through as string in OpenAI/Claude -> Gemini translation

### DIFF
--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -2,7 +2,6 @@ import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import {
   DEFAULT_SAFETY_SETTINGS,
-  tryParseJSON,
   cleanJSONSchemaForAntigravity,
 } from "../helpers/geminiHelper.ts";
 import { buildGeminiTools, sanitizeGeminiToolName } from "../helpers/geminiToolsSanitizer.ts";
@@ -186,13 +185,6 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
                   .map((c) => (c.type === "text" ? c.text : JSON.stringify(c)))
                   .join("\n");
               }
-              let parsedContent = tryParseJSON(content);
-              if (parsedContent === null) {
-                parsedContent = { result: content };
-              } else if (typeof parsedContent !== "object") {
-                parsedContent = { result: parsedContent };
-              }
-
               const toolUseId = block.tool_use_id;
               const name = toolUseNames[toolUseId] || "unknown";
 
@@ -210,7 +202,7 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
                 functionResponse: {
                   ...(stripFunctionCallId ? {} : { id: toolUseId }),
                   name,
-                  response: { result: parsedContent },
+                  response: { result: content },
                 },
               });
               break;

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -511,18 +511,12 @@ function openaiToGeminiBase(
               name = sanitizeToolName(name);
 
               const resp = toolResponses[fid];
-              let parsedResp = tryParseJSON(resp);
-              if (parsedResp === null) {
-                parsedResp = { result: resp };
-              } else if (typeof parsedResp !== "object") {
-                parsedResp = { result: parsedResp };
-              }
 
               toolParts.push({
                 functionResponse: {
                   ...(toolNameOptions.stripFunctionCallId ? {} : { id: fid }),
                   name: name,
-                  response: { result: parsedResp },
+                  response: { result: resp },
                 },
               });
             }

--- a/tests/unit/translator-claude-to-gemini.test.ts
+++ b/tests/unit/translator-claude-to-gemini.test.ts
@@ -103,7 +103,7 @@ test("Claude -> Gemini maps system, thinking, tool use, tool result and tools", 
     functionResponse: {
       id: "tu_1",
       name: "weather",
-      response: { result: { result: "20C" } },
+      response: { result: "20C" },
     },
   });
   assert.equal(result.generationConfig.maxOutputTokens, 256);

--- a/tests/unit/translator-openai-to-gemini.test.ts
+++ b/tests/unit/translator-openai-to-gemini.test.ts
@@ -289,7 +289,7 @@ test("OpenAI -> Gemini request maps messages, merged system instructions, tools 
   assert.deepEqual(getFunctionResponse(toolResponseTurn.parts[0]), {
     id: "call_1",
     name: "weather",
-    response: { result: { temp: 20 } },
+    response: { result: '{"temp":20}' },
   });
 
   const generationConfig = (result as GeminiRequestWithConfig).generationConfig;
@@ -550,7 +550,7 @@ test("OpenAI -> Cloud Code Gemini emits native functionResponse result", () => {
   assert.deepEqual(getFunctionResponse(toolTurn.parts[0]), {
     id: "read_file_123_0",
     name: "read_file",
-    response: { result: { result: "The answer is capybara-4729." } },
+    response: { result: "The answer is capybara-4729." },
   });
 });
 
@@ -956,7 +956,7 @@ test("OpenAI -> Antigravity Claude path sanitizes tool names for Gemini schema",
   const toolResultBlock = getFunctionResponse(toolTurn.parts[0]);
   assert.equal(toolResultBlock.id, "call_long_2");
   assert.equal(toolResultBlock.name, sanitizedToolName);
-  assert.deepEqual(toolResultBlock.response, { result: { ok: true } });
+  assert.deepEqual(toolResultBlock.response, { result: '{"ok":true}' });
 });
 
 test("OpenAI -> Antigravity Claude path applies output cap and strips thinkingConfig", () => {

--- a/tests/unit/translator-tool-result-json-passthrough.test.ts
+++ b/tests/unit/translator-tool-result-json-passthrough.test.ts
@@ -1,0 +1,203 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiToGeminiRequest, openaiToAntigravityRequest } =
+  await import("../../open-sse/translator/request/openai-to-gemini.ts");
+const { claudeToGeminiRequest } =
+  await import("../../open-sse/translator/request/claude-to-gemini.ts");
+const {
+  buildGeminiThoughtSignatureKey,
+  storeGeminiThoughtSignature,
+  clearGeminiThoughtSignatures,
+} = await import("../../open-sse/services/geminiThoughtSignatureStore.ts");
+
+test.beforeEach(() => {
+  clearGeminiThoughtSignatures();
+});
+
+type UnknownRecord = Record<string, unknown>;
+
+function getFunctionResponse(part: unknown) {
+  assert.ok(part && typeof part === "object", "expected Gemini part");
+  const functionResponse = (part as UnknownRecord).functionResponse;
+  assert.ok(functionResponse && typeof functionResponse === "object", "expected functionResponse");
+  return functionResponse as { id?: string; name: string; response?: unknown };
+}
+
+// A tool result whose payload is itself valid JSON (e.g. a WebFetch result
+// `{"title": ..., "summary": ...}`). It must be passed through to Gemini /
+// Antigravity as the raw string — it must NOT be JSON.parse'd into a nested
+// object, which made Antigravity reject the request with HTTP 400 "upstream
+// error" (upstream translator used tryParseJSON on tool result content).
+const JSON_TOOL_RESULT = '{"title":"Example","summary":"antigravity 400 repro"}';
+
+test("OpenAI -> Gemini keeps a JSON-string tool result as a raw string", () => {
+  const result = openaiToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [
+        { role: "user", content: "fetch it" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_json_1",
+              type: "function",
+              function: { name: "web_fetch", arguments: '{"url":"https://example.com"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_json_1", content: JSON_TOOL_RESULT },
+      ],
+    },
+    false
+  );
+
+  const toolTurn = (result as { contents: Array<UnknownRecord> }).contents.find(
+    (c) => c.role === "user" && c.parts.some((part) => (part as UnknownRecord).functionResponse)
+  );
+  assert.ok(toolTurn, "expected a tool response turn");
+  assert.deepEqual(getFunctionResponse((toolTurn.parts as unknown[])[0]).response, {
+    result: JSON_TOOL_RESULT,
+  });
+});
+
+test("OpenAI -> Gemini keeps a plain-text tool result as a raw string (no double wrap)", () => {
+  const result = openaiToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [
+        { role: "user", content: "read it" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_txt_1",
+              type: "function",
+              function: { name: "read_file", arguments: '{"path":"a.txt"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_txt_1", content: "plain text output" },
+      ],
+    },
+    false
+  );
+
+  const toolTurn = (result as { contents: Array<UnknownRecord> }).contents.find(
+    (c) => c.role === "user" && c.parts.some((part) => (part as UnknownRecord).functionResponse)
+  );
+  assert.ok(toolTurn, "expected a tool response turn");
+  assert.deepEqual(getFunctionResponse((toolTurn.parts as unknown[])[0]).response, {
+    result: "plain text output",
+  });
+});
+
+test("OpenAI -> Antigravity keeps a JSON-string tool result as a raw string", () => {
+  const result = openaiToAntigravityRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [
+        { role: "user", content: "fetch it" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_json_2",
+              type: "function",
+              function: { name: "web_fetch", arguments: '{"url":"https://example.com"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_json_2", content: JSON_TOOL_RESULT },
+      ],
+    },
+    false,
+    { projectId: "proj-json-passthrough" } as never
+  );
+
+  const request = (result as unknown as { request: { contents: Array<UnknownRecord> } }).request;
+  const toolTurn = request.contents.find(
+    (c) => c.role === "user" && c.parts.some((part) => (part as UnknownRecord).functionResponse)
+  );
+  assert.ok(toolTurn, "expected an Antigravity tool response turn");
+  assert.deepEqual(getFunctionResponse((toolTurn.parts as unknown[])[0]).response, {
+    result: JSON_TOOL_RESULT,
+  });
+});
+
+test("Claude -> Gemini keeps a JSON-string tool_result as a raw string", () => {
+  // Native functionResponse requires a cached thoughtSignature for the tool use.
+  const ns = "conn-tool-result-json";
+  storeGeminiThoughtSignature(buildGeminiThoughtSignatureKey(ns, "tu_json_1"), "SIG_JSON_1");
+
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "fetch it" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "need tool" },
+            {
+              type: "tool_use",
+              id: "tu_json_1",
+              name: "web_fetch",
+              input: { url: "https://example.com" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu_json_1", content: JSON_TOOL_RESULT }],
+        },
+      ],
+    },
+    false,
+    { _signatureNamespace: ns } as never
+  );
+
+  const toolTurn = (result as { contents: Array<UnknownRecord> }).contents.find(
+    (c) => c.role === "user" && c.parts.some((part) => (part as UnknownRecord).functionResponse)
+  );
+  assert.ok(toolTurn, "expected a tool response turn");
+  assert.deepEqual(getFunctionResponse((toolTurn.parts as unknown[])[0]).response, {
+    result: JSON_TOOL_RESULT,
+  });
+});
+
+test("Claude -> Gemini keeps a plain-text tool_result as a raw string (no double wrap)", () => {
+  const ns = "conn-tool-result-txt";
+  storeGeminiThoughtSignature(buildGeminiThoughtSignatureKey(ns, "tu_txt_1"), "SIG_TXT_1");
+
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "read it" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "need tool" },
+            { type: "tool_use", id: "tu_txt_1", name: "read_file", input: { path: "a.txt" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu_txt_1", content: "plain text output" }],
+        },
+      ],
+    },
+    false,
+    { _signatureNamespace: ns } as never
+  );
+
+  const toolTurn = (result as { contents: Array<UnknownRecord> }).contents.find(
+    (c) => c.role === "user" && c.parts.some((part) => (part as UnknownRecord).functionResponse)
+  );
+  assert.ok(toolTurn, "expected a tool response turn");
+  assert.deepEqual(getFunctionResponse((toolTurn.parts as unknown[])[0]).response, {
+    result: "plain text output",
+  });
+});


### PR DESCRIPTION
## Summary

Tool results that are themselves valid JSON (e.g. a WebFetch payload `{"title": ..., "summary": ...}`) were `JSON.parse`'d and nested into `functionResponse.response.result` as a structured object by both Gemini request translators. Antigravity rejects that shape with HTTP 400 "upstream error".

This change stops parsing tool result content entirely: the raw string is passed through unchanged as `response.result`, and plain-text results are no longer double-wrapped as `{ result: { result: ... } }`.

- `open-sse/translator/request/openai-to-gemini.ts` — drop the `tryParseJSON` dance on tool result content; emit `response: { result: resp }`.
- `open-sse/translator/request/claude-to-gemini.ts` — same for `tool_result` content; remove the now-unused `tryParseJSON` import.
- `openai-to-gemini.ts` keeps parsing `function` call **arguments** (`fn.arguments`) — that path is untouched.

## Related Issues

- No issue was filed for this regression; reported directly with a local reproduction.

## Validation

Change type: other (request-translator conversion)

- [x] Change type: other (request-translator conversion)
- [x] Focused tests and category gates from the golden path — translator unit suites + new regression suite below
- [ ] `npm run lint` — full lint runs in CI; the changed files are eslint-clean (`--max-warnings 0`, exit 0)
- [x] Reconciled with the current active release base: branch cut from `release/v3.8.51` tip `e0ea3f9`; focused checks rerun after the change
- [x] Production-code changes include a new or updated automated test in this PR

Evidence — translator suites (includes the new regression tests):

```
ℹ tests 68
ℹ pass 68
ℹ fail 0
✔ OpenAI -> Gemini keeps a JSON-string tool result as a raw string
✔ OpenAI -> Gemini keeps a plain-text tool result as a raw string (no double wrap)
✔ OpenAI -> Antigravity keeps a JSON-string tool result as a raw string
✔ Claude -> Gemini keeps a JSON-string tool_result as a raw string
✔ Claude -> Gemini keeps a plain-text tool_result as a raw string (no double wrap)
```

Evidence — open-sse typecheck gate and test discovery (the local runner is Windows 24 where `npx.cmd` spawnSync is EINVAL — same class of issue the repo's Windows build scripts already accommodate — so `tsc` was invoked directly with identical flags and the same baseline diff):

```
LIVE-ERRORS=5
NO-REGRESSIONS (all live errors within frozen baseline)
[test-discovery] OK — 5182 arquivos de teste, 31 collectors, 13 órfão(s) congelado(s)
```

## Tests Added Or Updated

- `tests/unit/translator-tool-result-json-passthrough.test.ts` (new): JSON-string and plain-text tool results stay raw strings through OpenAI→Gemini, OpenAI→Antigravity (Cloud Code envelope) and Claude→Gemini request translation.
- `tests/unit/translator-openai-to-gemini.test.ts`: 3 expectations updated to the new shape (`{"temp":20}` stays a string; `"The answer is capybara-4729."` is no longer double-wrapped; `'{"ok":true}'` stays a string).
- `tests/unit/translator-claude-to-gemini.test.ts`: 1 expectation updated (`"20C"` is no longer double-wrapped).

## Coverage Notes

- The change is confined to `open-sse/translator/request/` conversion. The two translator suites plus the new passthrough suite assert the exact emitted `functionResponse.response` shape on both the OpenAI and Claude input paths, including the Cloud Code envelope used for Antigravity.
- The deleted parse branches were removed, not replaced — no coverage regression.
- The emitted `response: { result: <string> }` shape is exactly what the response-direction translators already consume (`gemini-to-openai-function-response.test.ts` uses `response: { result: "b done" }`), so round-trips are consistent.

## Reviewer Notes

- Observable behavior change: `functionResponse.response.result` is always the raw string now — for JSON-looking and plain-text tool results alike, on both translators.
- The double-wrap of plain-text results (`{ result: { result: "20C" } }` → `{ result: "20C" }`) is removed intentionally; the outer `{ result: ... }` wrapper stays because Gemini's `FunctionResponse.response` is an object.
- **Inherited base-red note:** on the current `release/v3.8.51` tip (`e0ea3f9`, dependabot #11428, 2026-08-26) the `known-symbols` and `mutation-test-coverage` gates in Fast Quality Gates fail for ANY PR cut from this base: both reproduce identically on a pristine `e0ea3f9` checkout (verified locally, zero PR changes applied). This PR touches neither executors/providers (known-symbols) nor `routeGuard`/combo-quota modules (stryker testFiles); the failures are the inherited base-reds tracked by #11608, #11609 (merge-ready, all green) and #11626. The unit-shard and docs-gates flakes on the first CI run are also environmental (missing `better_sqlite3.node` native binary on the runner; docs gates pass locally on the identical tree).