### PR TITLE
test(autoCombo): port models_dev_tier #11508 guard from node:test to vitest

### DIFF
--- a/tests/unit/autoCombo/models-dev-tier-11508.test.ts
+++ b/tests/unit/autoCombo/models-dev-tier-11508.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, before } from "node:test";
+import { describe, it, beforeAll } from "vitest";
 import assert from "node:assert/strict";
 
 import { getDbInstance } from "../../../src/lib/db/core.ts";
@@ -51,7 +51,7 @@ function seed(provider: string, modelId: string, caps: {
   ).run(provider, modelId, caps.tool_call ?? null, caps.reasoning ?? null, caps.limit_context ?? null);
 }
 
-before(() => {
+beforeAll(() => {
   ensureTable();
   // Force both module caches to re-read after our seeds.
   invalidateCapabilitiesCache();


### PR DESCRIPTION
Fixes the **Vitest (fast-path)** base-red on `release/v3.8.51` (tracked under #11449; surfaced on PR #11633's run).

## Root cause

`tests/unit/autoCombo/models-dev-tier-11508.test.ts` imports `describe` / `it` / `before` from **`node:test`**, but the directory is collected exclusively by vitest:

- `vitest.mcp.config.ts` includes `"tests/unit/autoCombo/**/*.test.ts"`.
- The Node-native runner (`test:unit`) only globs `tests/unit/*.test.ts`, `tests/unit/dashboard/**`, and `tests/unit/**/*.test.mjs` — it never sees this file.
- Every sibling in `tests/unit/autoCombo/` imports from `"vitest"`.

Result: vitest collects the file, registers zero suites, and fails the whole job with `No test suite found in file ... models-dev-tier-11508.test.ts`, while the node:test callbacks leak their own spec output into the vitest log. The suite has effectively never been counted by either runner.

## Fix

Port the imports to vitest — `before` → `beforeAll`; keep `node:assert/strict` (runner-agnostic). No assertion or seeding logic changed. 2-line diff.

## Verification

```
# pristine origin/release/v3.8.51 (broken):
Test Files  1 failed | 48 passed (49)
Tests       452 passed

# this branch:
Test Files  49 passed (49)
Tests       457 passed   # +5: this file's tests now actually register
```

Note: the other failing fast-path job on that run (Docs Gates — provider-count 353→354 drift) is a separate concern and needs its own docs-sync fix.
