### PR TITLE
fix(security): redact NVIDIA_API_KEY at the log sink in the ad-hoc diag script

### DIFF
--- a/scripts/ad-hoc/nvidia-startswith-diag.ts
+++ b/scripts/ad-hoc/nvidia-startswith-diag.ts
@@ -19,12 +19,20 @@
  */
 
 const KEY = process.env.NVIDIA_API_KEY ?? "";
-const BASE_URL = process.env.NVIDIA_BASE_URL || "https://integrate.api.nvidia.com/v1/chat/completions";
+const BASE_URL =
+  process.env.NVIDIA_BASE_URL || "https://integrate.api.nvidia.com/v1/chat/completions";
 const MODEL = process.env.NVIDIA_MODEL || "openai/gpt-oss-120b";
 
 // Neutralize CR/LF before logging so env-derived values (NVIDIA_MODEL, etc.)
-// cannot forge extra log lines (S5145 log injection).
-const line = (s = "") => console.log(String(s).replace(/[\r\n]+/g, " "));
+// cannot forge extra log lines (S5145 log injection). Also strip any raw
+// occurrence of the API key so an upstream error/response that echoes it
+// back (e.g. inside err.stack or a validation result) never reaches the
+// terminal in clear text (js/clear-text-logging, CWE-312/532).
+const line = (s = "") => {
+  let out = String(s).replace(/[\r\n]+/g, " ");
+  if (KEY) out = out.split(KEY).join("[REDACTED]");
+  console.log(out);
+};
 const hr = () => line("─".repeat(72));
 
 function show(label: string, value: unknown) {
@@ -52,8 +60,13 @@ async function partA() {
     });
     line("  ✅ validateProviderApiKey retornou (sem crash):");
     show("resultado", result);
-    if (typeof (result as any)?.error === "string" && (result as any).error.includes("startsWith")) {
-      line("  ⚠️  A mensagem de erro contém 'startsWith' → crash CAPTURADO dentro do try/catch da validação.");
+    if (
+      typeof (result as any)?.error === "string" &&
+      (result as any).error.includes("startsWith")
+    ) {
+      line(
+        "  ⚠️  A mensagem de erro contém 'startsWith' → crash CAPTURADO dentro do try/catch da validação."
+      );
     }
   } catch (err: any) {
     line("  ❌ validateProviderApiKey LANÇOU (crash não tratado):");


### PR DESCRIPTION
## Resumo

CodeQL alert [#866](https://github.com/diegosouzapw/OmniRoute/security/code-scanning/866) (`js/clear-text-logging`, severity high) flagged `scripts/ad-hoc/nvidia-startswith-diag.ts:27` — the `line()` console.log wrapper — attributing the tainted source to `NOAUTH_IDS` in `tests/unit/executor-web-cookie-sweep.test.ts:159`.

That specific attribution is a CodeQL artifact: `NOAUTH_IDS` is a local `const` (list of provider IDs like `duckduckgo-web`) defined and used only inside that one test file, with zero import or dataflow relationship to the diagnostic script. The "AUTH" substring in the identifier is almost certainly what the heuristic source-matcher latched onto.

That said, the script has a real, independent clear-text-logging risk worth closing: `partA()`/`partB()` log `result` from `validateProviderApiKey()`, `err.message`, and `err.stack` verbatim. If an upstream response or the validation library ever echoes the raw `NVIDIA_API_KEY` back inside an error message or stack, it would print in clear text to the operator's terminal (CWE-312/532).

## Fix

`line()` — the single console.log sink used by every log call in the script — now strips any literal occurrence of the real `NVIDIA_API_KEY` value before printing, regardless of which code path produced the string. This closes the risk class at the sink, independent of the exact (and here, seemingly incorrect) taint path CodeQL reported.

No behavior change for non-key content; CR/LF neutralization (existing S5145 mitigation) is preserved.

## Validation

- `npx prettier --check` clean on the changed file.
- `scripts/ad-hoc/` is outside ESLint's scanned paths (ad-hoc scripts are ignored by config) — confirmed via `npx eslint`.
- This is a standalone, non-imported ad-hoc CLI script (no test suite exercises it); TDD per Hard Rule #18 does not apply — same validation category as prior CodeQL-alert rounds in this repo (source-level fix, no dismissal).

⚠️ base-red inherited: #11449