### PR TITLE
fix(types): clear the two type regressions red on release/v3.8.51

### DIFF
--- a/open-sse/executors/zai-web.ts
+++ b/open-sse/executors/zai-web.ts
@@ -90,13 +90,19 @@ async function resolveZaiBrowserAttachments(
 > {
   try {
     // Browser-page upload: keep the original bytes/mimeType (no Cursor wire prep).
+    // EncodedImage.mimeType is optional on the wire type, but every producer
+    // reachable here (decodeDataUrl / fetchImageBytes) validates an image/*
+    // string before pushing; the fallback only satisfies the attachment type.
     const images = await resolveCursorImages(imageUrls, { prepareForWire: false });
     return {
-      attachments: images.map((image, index) => ({
-        name: zaiImageFileName(image.mimeType, index),
-        mimeType: image.mimeType,
-        buffer: image.data,
-      })),
+      attachments: images.map((image, index) => {
+        const mimeType = image.mimeType ?? "image/jpeg";
+        return {
+          name: zaiImageFileName(mimeType, index),
+          mimeType,
+          buffer: image.data,
+        };
+      }),
     };
   } catch (error) {
     const message =

--- a/open-sse/utils/error.ts
+++ b/open-sse/utils/error.ts
@@ -15,6 +15,7 @@ interface ErrorResponseBody {
     message: string;
     type?: string;
     code?: string;
+    reason?: string;
   };
   upstream_details?: Record<string, unknown> | null; // sanitized upstream provider body
 }
@@ -108,6 +109,7 @@ export function sanitizeUpstreamDetails(value: unknown, depth = 0): unknown {
 export type ErrorBodyClassification = {
   type?: string;
   code?: string;
+  reason?: string;
 };
 
 /**
@@ -132,6 +134,7 @@ export function buildErrorBody(
       message: safeMessage,
       type: classification?.type ?? errorInfo.type,
       code: classification?.code ?? errorInfo.code,
+      reason: classification?.reason,
     },
   };
 

--- a/src/shared/middleware/chatAdmissionResponses.ts
+++ b/src/shared/middleware/chatAdmissionResponses.ts
@@ -66,8 +66,8 @@ export function structuralRejectionResponse(status: 413 | 503, maxMessages: numb
     {
       type: historyLimit ? "payload_too_large" : "server_error",
       code: historyLimit ? "chat_history_too_large" : "chat_admission_busy",
+      reason: historyLimit ? "message_limit" : "structure_limit",
     }
   );
-  body.error.reason = historyLimit ? "message_limit" : "structure_limit";
   return new Response(JSON.stringify(body), { status, headers });
 }

--- a/tests/unit/chat-admission-rejection-reason.test.ts
+++ b/tests/unit/chat-admission-rejection-reason.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  structuralRejectionResponse,
+} from "../../src/shared/middleware/chatAdmissionResponses.ts";
+
+// Pins the machine-readable error.reason contract of the chat admission
+// structural rejections (#TS2339 regression guard): buildErrorBody now owns
+// the reason field via ErrorBodyClassification, so the response bodies keep
+// carrying it without post-construction mutation of an untyped field.
+test("structuralRejectionResponse 413 carries reason=message_limit classification", () => {
+  const res = structuralRejectionResponse(413, 40);
+  assert.equal(res.status, 413);
+  assert.ok(!res.headers.has("Retry-After"), "413 is not retryable-by-header");
+  return res.text().then((raw) => {
+    const body = JSON.parse(raw);
+    assert.equal(body.error.reason, "message_limit");
+    assert.equal(body.error.type, "payload_too_large");
+    assert.equal(body.error.code, "chat_history_too_large");
+    assert.ok(!body.error.message.includes("at /"), "must not leak stack traces");
+  });
+});
+
+test("structuralRejectionResponse 503 carries reason=structure_limit and Retry-After", () => {
+  const res = structuralRejectionResponse(503, 40);
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get("Retry-After"), "1");
+  return res.text().then((raw) => {
+    const body = JSON.parse(raw);
+    assert.equal(body.error.reason, "structure_limit");
+    assert.equal(body.error.type, "server_error");
+    assert.equal(body.error.code, "chat_admission_busy");
+  });
+});

--- a/tests/unit/zai-web-attachment-mime-contract.test.ts
+++ b/tests/unit/zai-web-attachment-mime-contract.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveCursorImages } from "../../open-sse/utils/cursorImages.ts";
+
+// zai-web maps resolveCursorImages() output into browser-upload attachments
+// whose mimeType is REQUIRED. EncodedImage.mimeType is optional on the wire
+// type, so zai-web carries an `?? "image/jpeg"` fallback — this test pins the
+// producer contract that makes the fallback dead code in practice: every
+// image that reaches a browser upload must arrive with a concrete image/*
+// mime string (decodeDataUrl / fetchImageBytes validate it before pushing).
+const PIXEL_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+test("resolveCursorImages (prepareForWire:false) always yields a concrete image/* mimeType", async () => {
+  const images = await resolveCursorImages([PIXEL_PNG], { prepareForWire: false });
+  assert.equal(images.length, 1);
+  assert.equal(typeof images[0]!.mimeType, "string");
+  assert.match(images[0]!.mimeType as string, /^image\//);
+});


### PR DESCRIPTION
Fixes the **typecheck:core** and **check:open-sse-typecheck** gate failures that are red on pristine `release/v3.8.51` (base-red #11449; visible on the Fast Quality Gates job of [run 32967268206](https://github.com/diegosouzapw/OmniRoute/actions/runs/32967268206/job/98174119181) and every other PR against `.51`).

## What failed (both reproduce on unfixed tip)

**1. `open-sse/executors/zai-web.ts(95,7)` TS2322 + `(96,32)` TS2345**

`resolveCursorImages()` returns `EncodedImage[]` whose `mimeType` is optional (`mimeType?: string` in `cursorAgentProtobuf/imageEncoding.ts`), but zai-web mapped it straight into browser-upload attachments whose type requires `mimeType: string`, and into `zaiImageFileName(mimeType: string, ...)`.

Runtime is unchanged by the fix: every producer reachable with `prepareForWire: false` (`decodeDataUrl` / `fetchImageBytes`) validates an `image/*` string before pushing, so the coercion is dead code kept only to satisfy the attachment contract. New test pins that producer contract.

**2. `src/shared/middleware/chatAdmissionResponses.ts(71,14)` TS2339**

`structuralRejectionResponse()` assigned `body.error.reason = ...` after `buildErrorBody()`, but `ErrorResponseBody.error` declared no `reason` field. Fix adds optional `reason?: string` to `ErrorBodyClassification` and threads it through `buildErrorBody()`, so the field is typed end-to-end and set at construction. Wire bodies are byte-identical to before.

## Changes

- `open-sse/utils/error.ts` — `reason?: string` on `ErrorBodyClassification` + `ErrorResponseBody.error`, emitted from classification
- `src/shared/middleware/chatAdmissionResponses.ts` — pass `reason` via classification; drop post-construction mutation
- `open-sse/executors/zai-web.ts` — coerce `image.mimeType ?? "image/jpeg"` once per attachment
- `tests/unit/chat-admission-rejection-reason.test.ts` — 413/503 reason/type/code + Retry-After pins
- `tests/unit/zai-web-attachment-mime-contract.test.ts` — producer always yields a concrete `image/*` mime

## Verification

```
npx tsc --noEmit -p tsconfig.typecheck-core.json        # exit 0 (was: 2 errors)
npx tsc --noEmit -p open-sse/tsconfig.json              # only the 5 videoBridgeHelpers
                                                        # errors frozen in the baseline remain
node --import tsx/esm --test <2 new test files>         # 3/3 pass
executor-zai-web + zai-validator suites                 # 36/36 pass
```

Note: the third failing gate on that job (`test-runner-api` — `models-dev-tier-11508.test.ts` importing `node:test` in a vitest-only dir) is fixed separately by #11635.
