### PR TITLE
fix(build): resolve workspace: protocol dependencies to concrete semver versions during prepublish (#11540)

### DIFF
--- a/scripts/build/prepublish.ts
+++ b/scripts/build/prepublish.ts
@@ -23,7 +23,7 @@ import {
   statSync,
   chmodSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { assembleStandalone } from "./assembleStandalone.mjs";
@@ -35,6 +35,12 @@ import {
   APP_STAGING_REMOVAL_PATHS,
   findUnexpectedArtifactPaths,
 } from "./pack-artifact-policy.ts";
+import {
+  collectWorkspaceVersions,
+  findPackageJsonFiles,
+  hasWorkspaceProtocol,
+  resolvePackageJsonWorkspaceProtocols,
+} from "./resolveWorkspaceProtocols.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -705,6 +711,33 @@ if (remainingUnexpectedFiles.length > 0) {
     console.error(`     - dist/${violation}`)
   );
   process.exit(1);
+}
+
+// -- Step 11: Resolve workspace: protocol dependencies -----------------
+// npm/pnpm workspace protocol specifiers (workspace:*, workspace:^, ...)
+// are meaningless to the npm registry and make `npm install -g omniroute`
+// fail with EUNSUPPORTEDPROTOCOL. Rewrite any that leaked into published
+// package.json files to the concrete workspace package version.
+// Only touch files inside the staged dist/ tree; workspace member source
+// package.json files must never be mutated by the publish step.
+const workspaceVersions = collectWorkspaceVersions(ROOT);
+const publishablePackageJsonDirs = [DIST_DIR];
+const publishablePackageJsonPaths = publishablePackageJsonDirs
+  .flatMap((dir) => (existsSync(dir) ? findPackageJsonFiles(dir) : []))
+  .filter((filePath) => existsSync(filePath));
+
+for (const pkgJsonPath of publishablePackageJsonPaths) {
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    continue;
+  }
+  if (!hasWorkspaceProtocol(pkg)) continue;
+
+  const resolved = resolvePackageJsonWorkspaceProtocols(pkg, workspaceVersions);
+  writeFileSync(pkgJsonPath, JSON.stringify(resolved, null, 2) + "\n");
+  console.log(`  [resolved] Resolved workspace: protocols in ${relative(ROOT, pkgJsonPath)}`);
 }
 
 // ── Done ───────────────────────────────────────────────────

--- a/scripts/build/resolveWorkspaceProtocols.ts
+++ b/scripts/build/resolveWorkspaceProtocols.ts
@@ -1,0 +1,228 @@
+/**
+ * Resolve pnpm/npm workspace protocol dependencies to concrete semver versions.
+ *
+ * The npm registry clients cannot parse `workspace:` specifiers. During prepublish
+ * we rewrite any `workspace:*`, `workspace:^`, `workspace:~` (or explicit
+ * `workspace:<range>`) dependency declarations to the matching workspace package's
+ * actual version before npm pack/publish sees them.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import * as yaml from "js-yaml";
+
+const WORKSPACE_PROTOCOL_RE = /^workspace:/;
+
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+/**
+ * Parse a simple workspace glob entry into concrete directories relative to a root.
+ * Supports entries like "packages/*" and literal directory names like "open-sse".
+ */
+function expandWorkspaceEntry(root: string, entry: string): string[] {
+  const trimmed = entry.trim();
+  if (!trimmed) return [];
+  if (!trimmed.endsWith("/*")) {
+    const dir = join(root, trimmed);
+    try {
+      return statSync(dir).isDirectory() ? [dir] : [];
+    } catch {
+      return [];
+    }
+  }
+  const parent = join(root, trimmed.slice(0, -2));
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(parent);
+  } catch {
+    return [];
+  }
+  return entries
+    .map((name) => join(parent, name))
+    .filter((dir) => {
+      try {
+        return statSync(dir).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+}
+
+/**
+ * Read the root package.json and, if present, pnpm-workspace.yaml to discover
+ * workspace member directories. Returns a map of package name -> version.
+ */
+export function collectWorkspaceVersions(projectRoot: string): Map<string, string> {
+  const versions = new Map<string, string>();
+
+  const rootPkgPath = join(projectRoot, "package.json");
+  let workspaceEntries: string[] = [];
+  try {
+    const rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf8")) as {
+      workspaces?: string[];
+    };
+    if (Array.isArray(rootPkg.workspaces)) {
+      workspaceEntries.push(...rootPkg.workspaces);
+    }
+  } catch {
+    // ignore unreadable root package.json
+  }
+
+  const pnpmWorkspacePath = join(projectRoot, "pnpm-workspace.yaml");
+  try {
+    const yamlContent = readFileSync(pnpmWorkspacePath, "utf8");
+    const doc = yaml.load(yamlContent) as { packages?: unknown } | null | undefined;
+    if (doc && Array.isArray(doc.packages)) {
+      for (const entry of doc.packages) {
+        if (typeof entry === "string" && entry) {
+          workspaceEntries.push(entry);
+        }
+      }
+    }
+  } catch {
+    // ignore missing or malformed pnpm-workspace.yaml
+  }
+
+  const seenDirs = new Set<string>();
+  for (const entry of workspaceEntries) {
+    for (const dir of expandWorkspaceEntry(projectRoot, entry)) {
+      if (seenDirs.has(dir)) continue;
+      seenDirs.add(dir);
+      try {
+        const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+          name?: string;
+          version?: string;
+        };
+        if (pkg.name && pkg.version) {
+          versions.set(pkg.name, pkg.version);
+        }
+      } catch {
+        // skip unreadable workspace member package.json
+      }
+    }
+  }
+
+  return versions;
+}
+
+/**
+ * Resolve workspace protocol dependencies inside a package.json object.
+ *
+ * Replaces `workspace:*`, `workspace:^`, `workspace:~`, `workspace:<range>`,
+ * and `workspace:<packageName>` with the concrete version of the referenced
+ * workspace package. Throws if a workspace specifier cannot be resolved.
+ */
+export function resolvePackageJsonWorkspaceProtocols(
+  pkg: Record<string, unknown>,
+  workspaceVersions: Map<string, string>
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = { ...pkg };
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = pkg[field];
+    if (!deps || typeof deps !== "object" || Array.isArray(deps)) continue;
+
+    const resolvedDeps: Record<string, string> = {};
+    let changed = false;
+    for (const [depName, versionSpec] of Object.entries(deps as Record<string, unknown>)) {
+      if (typeof versionSpec !== "string") {
+        resolvedDeps[depName] = String(versionSpec ?? "");
+        continue;
+      }
+      if (!WORKSPACE_PROTOCOL_RE.test(versionSpec)) {
+        resolvedDeps[depName] = versionSpec;
+        continue;
+      }
+
+      const body = versionSpec.slice("workspace:".length);
+      let concrete: string | undefined;
+
+      if (body === "*") {
+        concrete = workspaceVersions.get(depName);
+      } else if (body === "^") {
+        const version = workspaceVersions.get(depName);
+        concrete = version ? `^${version}` : undefined;
+      } else if (body === "~") {
+        const version = workspaceVersions.get(depName);
+        concrete = version ? `~${version}` : undefined;
+      } else if (body.startsWith("^") || body.startsWith("~") || /^[\d<>=]/.test(body)) {
+        // Explicit range inside workspace: protocol - strip the protocol prefix.
+        concrete = body;
+      } else {
+        // workspace:<packageName> - resolve to that package's version.
+        concrete = workspaceVersions.get(body);
+      }
+
+      if (concrete) {
+        resolvedDeps[depName] = concrete;
+        changed = true;
+      } else {
+        throw new Error(
+          `Cannot resolve workspace protocol "${versionSpec}" for dependency "${depName}". ` +
+            "Make sure the referenced package is a declared workspace member with a version."
+        );
+      }
+    }
+
+    if (changed) {
+      resolved[field] = resolvedDeps;
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Return true if any dependency field in the package contains a workspace: specifier.
+ */
+export function hasWorkspaceProtocol(pkg: Record<string, unknown>): boolean {
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = pkg[field];
+    if (!deps || typeof deps !== "object" || Array.isArray(deps)) continue;
+    for (const versionSpec of Object.values(deps as Record<string, unknown>)) {
+      if (typeof versionSpec === "string" && WORKSPACE_PROTOCOL_RE.test(versionSpec)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Recursively walk a directory and return every package.json path found.
+ * Stops descending after maxDepth to avoid runaway recursion on deep trees.
+ */
+export function findPackageJsonFiles(dir: string, maxDepth = 10): string[] {
+  const results: string[] = [];
+  if (maxDepth < 0) return results;
+
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry === "node_modules") continue;
+    const fullPath = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      results.push(...findPackageJsonFiles(fullPath, maxDepth - 1));
+    } else if (entry === "package.json") {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}

--- a/tests/unit/build/pack-no-workspace-protocol.test.ts
+++ b/tests/unit/build/pack-no-workspace-protocol.test.ts
@@ -1,0 +1,269 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  collectWorkspaceVersions,
+  resolvePackageJsonWorkspaceProtocols,
+  hasWorkspaceProtocol,
+  findPackageJsonFiles,
+} from "../../../scripts/build/resolveWorkspaceProtocols.ts";
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as Record<string, unknown>;
+}
+
+test("resolvePackageJsonWorkspaceProtocols replaces workspace:*, workspace:^, workspace:~", () => {
+  const versions = new Map([
+    ["@omniroute/open-sse", "3.8.51"],
+    ["@omniroute/shared", "1.2.3"],
+  ]);
+
+  const resolved = resolvePackageJsonWorkspaceProtocols(
+    {
+      name: "omniroute",
+      version: "3.8.51",
+      dependencies: {
+        "@omniroute/open-sse": "workspace:^",
+        "@omniroute/shared": "workspace:*",
+        lodash: "^4.17.0",
+      },
+      devDependencies: {
+        "@omniroute/open-sse": "workspace:~",
+      },
+      peerDependencies: {
+        "@omniroute/shared": "workspace:1.2.3",
+      },
+      optionalDependencies: {
+        "@omniroute/open-sse": "workspace:>=3.0.0",
+      },
+    },
+    versions
+  );
+
+  assert.equal((resolved.dependencies as Record<string, string>)["@omniroute/open-sse"], "^3.8.51");
+  assert.equal((resolved.dependencies as Record<string, string>)["@omniroute/shared"], "1.2.3");
+  assert.equal((resolved.dependencies as Record<string, string>).lodash, "^4.17.0");
+  assert.equal(
+    (resolved.devDependencies as Record<string, string>)["@omniroute/open-sse"],
+    "~3.8.51"
+  );
+  assert.equal((resolved.peerDependencies as Record<string, string>)["@omniroute/shared"], "1.2.3");
+  assert.equal(
+    (resolved.optionalDependencies as Record<string, string>)["@omniroute/open-sse"],
+    ">=3.0.0"
+  );
+});
+
+test("resolvePackageJsonWorkspaceProtocols leaves non-workspace specs untouched", () => {
+  const resolved = resolvePackageJsonWorkspaceProtocols(
+    {
+      name: "x",
+      dependencies: {
+        a: "^1.0.0",
+        b: "file:../b",
+        c: "npm:alias@1.0.0",
+      },
+    },
+    new Map()
+  );
+
+  assert.equal((resolved.dependencies as Record<string, string>).a, "^1.0.0");
+  assert.equal((resolved.dependencies as Record<string, string>).b, "file:../b");
+  assert.equal((resolved.dependencies as Record<string, string>).c, "npm:alias@1.0.0");
+  assert.equal(hasWorkspaceProtocol(resolved), false);
+});
+
+test("resolvePackageJsonWorkspaceProtocols throws for unresolvable workspace protocol", () => {
+  assert.throws(
+    () =>
+      resolvePackageJsonWorkspaceProtocols(
+        {
+          name: "x",
+          dependencies: {
+            "@missing/pkg": "workspace:^",
+          },
+        },
+        new Map()
+      ),
+    /Cannot resolve workspace protocol/
+  );
+});
+
+test("collectWorkspaceVersions reads npm workspaces and pnpm-workspace.yaml", () => {
+  const root = tmpDir("workspace-versions-");
+
+  writeJson(path.join(root, "package.json"), {
+    name: "root",
+    version: "0.0.0",
+    workspaces: ["packages/*", "open-sse"],
+  });
+
+  fs.mkdirSync(path.join(root, "packages", "a"), { recursive: true });
+  writeJson(path.join(root, "packages", "a", "package.json"), {
+    name: "@scope/a",
+    version: "1.0.0",
+  });
+
+  fs.mkdirSync(path.join(root, "open-sse"), { recursive: true });
+  writeJson(path.join(root, "open-sse", "package.json"), {
+    name: "@scope/open-sse",
+    version: "2.0.0",
+  });
+
+  // pnpm-workspace.yaml adds an extra directory not in npm workspaces.
+  fs.mkdirSync(path.join(root, "packages", "b"), { recursive: true });
+  writeJson(path.join(root, "packages", "b", "package.json"), {
+    name: "@scope/b",
+    version: "3.0.0",
+  });
+  fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+
+  const versions = collectWorkspaceVersions(root);
+  assert.equal(versions.get("@scope/a"), "1.0.0");
+  assert.equal(versions.get("@scope/open-sse"), "2.0.0");
+  assert.equal(versions.get("@scope/b"), "3.0.0");
+});
+
+test("findPackageJsonFiles skips node_modules and respects maxDepth", () => {
+  const root = tmpDir("pkg-json-files-");
+  fs.mkdirSync(path.join(root, "a"), { recursive: true });
+  writeJson(path.join(root, "a", "package.json"), {});
+  fs.mkdirSync(path.join(root, "node_modules", "x"), { recursive: true });
+  writeJson(path.join(root, "node_modules", "x", "package.json"), {});
+
+  const files = findPackageJsonFiles(root);
+  assert.equal(files.length, 1);
+  assert.ok(files[0].endsWith(path.join("a", "package.json")));
+
+  // Build a deep tree and confirm maxDepth bounds the walk.
+  const deep = tmpDir("pkg-json-deep-");
+  let current = deep;
+  for (let i = 0; i < 12; i += 1) {
+    current = path.join(current, `level${i}`);
+    fs.mkdirSync(current, { recursive: true });
+  }
+  writeJson(path.join(current, "package.json"), {});
+  assert.equal(findPackageJsonFiles(deep, 10).length, 0);
+  assert.equal(findPackageJsonFiles(deep, 12).length, 1);
+});
+
+test("collectWorkspaceVersions parses pnpm-workspace.yaml with js-yaml", () => {
+  const root = tmpDir("pnpm-yaml-");
+
+  writeJson(path.join(root, "package.json"), { name: "root", version: "0.0.0" });
+
+  // Flow-style array, nested quotes, comments inside the packages list, and an
+  // unrelated top-level key before packages are all valid YAML that the old line
+  // scanner could not handle.
+  fs.writeFileSync(
+    path.join(root, "pnpm-workspace.yaml"),
+    "preferWorkspacePackages: true\n" +
+      "packages:\n" +
+      '  - "packages/*"\n' +
+      "  - 'apps/*'\n" +
+      "  # comment inside the list\n" +
+      "  - open-sse\n"
+  );
+
+  fs.mkdirSync(path.join(root, "packages", "a"), { recursive: true });
+  writeJson(path.join(root, "packages", "a", "package.json"), {
+    name: "@scope/a",
+    version: "1.0.0",
+  });
+
+  fs.mkdirSync(path.join(root, "apps", "web"), { recursive: true });
+  writeJson(path.join(root, "apps", "web", "package.json"), {
+    name: "@scope/web",
+    version: "2.0.0",
+  });
+
+  fs.mkdirSync(path.join(root, "open-sse"), { recursive: true });
+  writeJson(path.join(root, "open-sse", "package.json"), {
+    name: "@scope/open-sse",
+    version: "3.0.0",
+  });
+
+  const versions = collectWorkspaceVersions(root);
+  assert.equal(versions.get("@scope/a"), "1.0.0");
+  assert.equal(versions.get("@scope/web"), "2.0.0");
+  assert.equal(versions.get("@scope/open-sse"), "3.0.0");
+});
+
+test("prepublish Step 11 fixture resolves workspace: protocols in dist package.json files", () => {
+  const root = tmpDir("prepublish-step11-");
+  const distDir = path.join(root, "dist");
+
+  // Workspace member source files contain a workspace: specifier (simulating the
+  // monorepo source). They must NOT be mutated by the publish step.
+  fs.mkdirSync(path.join(root, "packages", "shared"), { recursive: true });
+  const sourcePkgPath = path.join(root, "packages", "shared", "package.json");
+  writeJson(sourcePkgPath, {
+    name: "@scope/shared",
+    version: "1.2.3",
+    dependencies: {
+      "@scope/other": "workspace:*",
+    },
+  });
+
+  fs.mkdirSync(path.join(root, "packages", "other"), { recursive: true });
+  writeJson(path.join(root, "packages", "other", "package.json"), {
+    name: "@scope/other",
+    version: "4.5.6",
+  });
+
+  writeJson(path.join(root, "package.json"), {
+    name: "root",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+  });
+
+  // The staged dist/ package.json contains workspace: specifiers that leaked
+  // into the publish artifact and must be rewritten to concrete versions.
+  fs.mkdirSync(distDir, { recursive: true });
+  const distPkgPath = path.join(distDir, "package.json");
+  writeJson(distPkgPath, {
+    name: "omniroute",
+    version: "3.8.51",
+    dependencies: {
+      "@scope/shared": "workspace:^",
+      "@scope/other": "workspace:*",
+      lodash: "^4.17.0",
+    },
+  });
+
+  // This is the same logic prepublish.ts Step 11 runs, scoped to the fixture.
+  const workspaceVersions = collectWorkspaceVersions(root);
+  const publishablePackageJsonPaths = findPackageJsonFiles(distDir).filter((filePath) =>
+    fs.existsSync(filePath)
+  );
+
+  for (const pkgJsonPath of publishablePackageJsonPaths) {
+    const pkg = readJson(pkgJsonPath);
+    if (!hasWorkspaceProtocol(pkg)) continue;
+    const resolved = resolvePackageJsonWorkspaceProtocols(pkg, workspaceVersions);
+    fs.writeFileSync(pkgJsonPath, JSON.stringify(resolved, null, 2) + "\n");
+  }
+
+  // dist/package.json must have concrete versions.
+  const distPkg = readJson(distPkgPath);
+  assert.equal((distPkg.dependencies as Record<string, string>)["@scope/shared"], "^1.2.3");
+  assert.equal((distPkg.dependencies as Record<string, string>)["@scope/other"], "4.5.6");
+  assert.equal((distPkg.dependencies as Record<string, string>).lodash, "^4.17.0");
+  assert.equal(hasWorkspaceProtocol(distPkg), false);
+
+  // Source package.json must remain untouched.
+  const sourcePkg = readJson(sourcePkgPath);
+  assert.equal((sourcePkg.dependencies as Record<string, string>)["@scope/other"], "workspace:*");
+});


### PR DESCRIPTION
### Summary
Fixes #11540 (and #11544): When running `npm install -g omniroute`, installation fails with `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:": workspace:^`.

### Changes
- Added `scripts/build/resolveWorkspaceProtocols.ts` to parse workspace versions and resolve all `workspace:*`, `workspace:^`, `workspace:~`, and range specs to concrete semver version strings.
- Added Step 11 to `scripts/build/prepublish.ts` to sweep and resolve all `package.json` files under `dist/` before npm packaging.

### Test Plan
- Added `tests/unit/build/pack-no-workspace-protocol.test.ts` (7/7 tests pass).
- `npm run typecheck:core` clean.

Closes #11540