### PR TITLE
fix(authz): trust cf-connecting-ip for via-proxy detection when peer is Cloudflare edge (#11514)

### DIFF
--- a/scripts/dev/peer-stamp.mjs
+++ b/scripts/dev/peer-stamp.mjs
@@ -1,3 +1,4 @@
+import { isIPv4, isIPv6 } from "node:net";
 import { randomUUID } from "node:crypto";
 
 /**
@@ -22,23 +23,152 @@ export const PEER_IP_HEADER = "x-omniroute-peer-ip";
 
 /**
  * Companion header to PEER_IP_HEADER: `<token>|1` when the inbound TCP request
- * carried forwarding headers (`x-forwarded-for` / `x-real-ip`), `<token>|0`
- * otherwise. Required so the middleware can tell that a loopback socket is the
- * reverse-proxy hop (nginx / Caddy / Cloudflare Tunnel) and NOT trust it as
- * local — without this, a leaked JWT over a public tunnel would reach the
- * LOCAL_ONLY routes that spawn child processes (Hard Rules #15 + #17;
- * port of upstream decolua/9router commit da667836).
+ * carried forwarding headers (`x-forwarded-for` / `x-real-ip`) or arrived from
+ * a Cloudflare edge IP with `cf-connecting-ip`, `<token>|0` otherwise. Required
+ * so the middleware can tell that a loopback socket is the reverse-proxy hop
+ * (nginx / Caddy / Cloudflare Tunnel) and NOT trust it as local — without this,
+ * a leaked JWT over a public tunnel would reach the LOCAL_ONLY routes that
+ * spawn child processes (Hard Rules #15 + #17; port of upstream decolua/9router
+ * commit da667836).
  *
  * Keep VIA_PROXY_HEADER in sync with VIA_PROXY_HEADER in
  * src/server/authz/headers.ts (the TS side cannot import this .mjs).
  */
 export const VIA_PROXY_HEADER = "x-omniroute-via-proxy";
 
+/**
+ * Cloudflare IPv4 ranges used to authenticate the `cf-connecting-ip` header.
+ *
+ * `cf-connecting-ip` is Cloudflare-specific: a direct client can trivially forge
+ * it, but only traffic actually routed through Cloudflare originates from one of
+ * these IP addresses. We therefore trust `cf-connecting-ip` as a proxy marker
+ * ONLY when `req.socket.remoteAddress` falls inside these ranges.
+ *
+ * Source: https://api.cloudflare.com/client/v4/ips
+ * Snapshot date: 2026-08-25
+ * Refresh: re-query the URL above periodically (quarterly is a safe default,
+ * or whenever Cloudflare announces edge-range changes) and replace the arrays.
+ *
+ * This list is intentionally embedded as a static constant. peer-stamp.mjs is
+ * packaged into the standalone server artifact and MUST NOT depend on runtime
+ * file/network access to load the ranges.
+ */
+const CLOUDFLARE_IPV4_CIDRS = [
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+];
+
+/**
+ * Cloudflare IPv6 ranges (same semantics as CLOUDFLARE_IPV4_CIDRS).
+ *
+ * Source: https://api.cloudflare.com/client/v4/ips
+ * Snapshot date: 2026-08-25
+ * Refresh: re-query the URL above periodically (quarterly is a safe default,
+ * or whenever Cloudflare announces edge-range changes) and replace the arrays.
+ */
+const CLOUDFLARE_IPV6_CIDRS = [
+  "2400:cb00::/32",
+  "2606:4700::/32",
+  "2803:f800::/32",
+  "2405:b500::/32",
+  "2405:8100::/32",
+  "2a06:98c0::/29",
+  "2c0f:f248::/32",
+];
+
 /** Generate (once) and return the per-process stamp token, persisting it in env
  *  so the middleware running in the same process reads the identical value. */
 export function ensurePeerStampToken() {
   process.env.OMNIROUTE_PEER_STAMP_TOKEN ||= randomUUID();
   return process.env.OMNIROUTE_PEER_STAMP_TOKEN;
+}
+
+/** Convert an IPv4 address string to an unsigned 32-bit integer. */
+function ipv4ToInt(ip) {
+  const parts = ip.split(".");
+  return (
+    ((parseInt(parts[0], 10) << 24) |
+      (parseInt(parts[1], 10) << 16) |
+      (parseInt(parts[2], 10) << 8) |
+      parseInt(parts[3], 10)) >>>
+    0
+  );
+}
+
+/** Check whether `ip` belongs to the given IPv4 CIDR. */
+export function matchesIPv4Cidr(ip, cidr) {
+  const [range, bits] = cidr.split("/");
+  const maskBits = parseInt(bits, 10);
+  if (maskBits === 0) return true;
+  const ipInt = ipv4ToInt(ip);
+  const rangeInt = ipv4ToInt(range);
+  return ipInt >>> (32 - maskBits) === rangeInt >>> (32 - maskBits);
+}
+
+/** Convert an IPv6 address string to a 128-bit BigInt. */
+function ipv6ToBigInt(ip) {
+  // Expand the compressed form into 8 groups of 16-bit hex.
+  let expanded = ip;
+  if (expanded.includes("::")) {
+    const [left, right] = expanded.split("::");
+    const leftGroups = left ? left.split(":") : [];
+    const rightGroups = right ? right.split(":") : [];
+    const missing = 8 - leftGroups.length - rightGroups.length;
+    const fill = Array.from({ length: missing }, () => "0");
+    expanded = [...leftGroups, ...fill, ...rightGroups].join(":");
+  }
+  const groups = expanded.split(":");
+  let result = 0n;
+  for (const group of groups) {
+    result = (result << 16n) | BigInt(parseInt(group || "0", 16));
+  }
+  return result;
+}
+
+/** Check whether `ip` belongs to the given IPv6 CIDR. */
+export function matchesIPv6Cidr(ip, cidr) {
+  const [range, bits] = cidr.split("/");
+  const maskBits = parseInt(bits, 10);
+  if (maskBits === 0) return true;
+  const ipInt = ipv6ToBigInt(ip);
+  const rangeInt = ipv6ToBigInt(range);
+  const mask = -1n << (128n - BigInt(maskBits));
+  return (ipInt & mask) === (rangeInt & mask);
+}
+
+/**
+ * Return true when `ip` is a Cloudflare edge address. IPv4-mapped IPv6 addresses
+ * (`::ffff:x.x.x.x`) are normalized to dotted-decimal before checking.
+ */
+export function isCloudflareIP(ip) {
+  if (!ip) return false;
+  let normalized = ip.replace(/^::ffff:/i, "");
+  if (normalized === ip) {
+    // Full-form IPv4-mapped addresses (0:0:0:0:0:ffff:a.b.c.d) also need to be
+    // normalized to dotted-decimal before the CIDR check.
+    const fullFormMatch = /^(?:0+:){5}ffff:([0-9.]+)$/i.exec(ip);
+    if (fullFormMatch) normalized = fullFormMatch[1];
+  }
+  if (isIPv4(normalized)) {
+    return CLOUDFLARE_IPV4_CIDRS.some((cidr) => matchesIPv4Cidr(normalized, cidr));
+  }
+  if (isIPv6(normalized)) {
+    return CLOUDFLARE_IPV6_CIDRS.some((cidr) => matchesIPv6Cidr(normalized, cidr));
+  }
+  return false;
 }
 
 /** Strip any client-supplied PEER_IP_HEADER + VIA_PROXY_HEADER and stamp the
@@ -59,7 +189,14 @@ export function stampPeerIp(req) {
       // loopback socket is the proxy hop, not the end-user, so it must not be
       // trusted as local. Token-prefix the marker so a remote caller cannot
       // forge it (or its absence) on a non-proxied request.
-      const viaProxy = !!(req.headers["x-forwarded-for"] || req.headers["x-real-ip"]);
+      //
+      // `cf-connecting-ip` is Cloudflare-specific and trivially forged by a
+      // direct client. Only treat it as a proxy marker when the TCP peer itself
+      // is a Cloudflare edge IP; otherwise a direct forger could flip the
+      // via-proxy bit and force the middleware to ignore the real peer IP.
+      const hasGenericProxyHeaders = !!(req.headers["x-forwarded-for"] || req.headers["x-real-ip"]);
+      const hasCloudflareHeader = !!(req.headers["cf-connecting-ip"] && isCloudflareIP(ip));
+      const viaProxy = hasGenericProxyHeaders || hasCloudflareHeader;
       req.headers[VIA_PROXY_HEADER] = `${token}|${viaProxy ? "1" : "0"}`;
     }
   } catch {

--- a/tests/unit/authz/peer-stamp.test.ts
+++ b/tests/unit/authz/peer-stamp.test.ts
@@ -1,0 +1,180 @@
+// Direct unit tests for scripts/dev/peer-stamp.mjs::stampPeerIp.
+//
+// These tests assert the exact x-omniroute-peer-ip / x-omniroute-via-proxy
+// headers the custom server stamps before forwarding the request to Next.js.
+// They are intentionally standalone (mock IncomingMessage) so a bug in the
+// cf-connecting-ip path can be reproduced by reverting the corresponding line
+// in peer-stamp.mjs without relying on the rest of the authz pipeline.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const peerStamp = await import("../../../scripts/dev/peer-stamp.mjs");
+const {
+  stampPeerIp,
+  PEER_IP_HEADER,
+  VIA_PROXY_HEADER,
+  matchesIPv4Cidr,
+  matchesIPv6Cidr,
+  isCloudflareIP,
+} = peerStamp;
+
+const ORIGINAL_STAMP_TOKEN = process.env.OMNIROUTE_PEER_STAMP_TOKEN;
+
+function makeReq(remoteAddress: string, headers: Record<string, string> = {}) {
+  return {
+    headers: { ...headers },
+    socket: { remoteAddress },
+  };
+}
+
+function getPeerIp(req: ReturnType<typeof makeReq>) {
+  return req.headers[PEER_IP_HEADER] ?? null;
+}
+
+function getViaProxy(req: ReturnType<typeof makeReq>) {
+  return req.headers[VIA_PROXY_HEADER] ?? null;
+}
+
+test.after(() => {
+  if (ORIGINAL_STAMP_TOKEN === undefined) delete process.env.OMNIROUTE_PEER_STAMP_TOKEN;
+  else process.env.OMNIROUTE_PEER_STAMP_TOKEN = ORIGINAL_STAMP_TOKEN;
+});
+
+test.beforeEach(() => {
+  delete process.env.OMNIROUTE_PEER_STAMP_TOKEN;
+  process.env.OMNIROUTE_PEER_STAMP_TOKEN = "stamp-tok";
+});
+
+test("stamps peer IP and via-proxy=0 for direct connection (no forwarding headers)", () => {
+  const req = makeReq("203.0.113.99");
+  stampPeerIp(req);
+
+  assert.equal(
+    getPeerIp(req),
+    "stamp-tok|203.0.113.99",
+    "peer-ip header must contain token|real-ip"
+  );
+  assert.equal(getViaProxy(req), "stamp-tok|0", "via-proxy must be 0 on direct connection");
+});
+
+test("stamps via-proxy=1 when x-forwarded-for is present", () => {
+  const req = makeReq("127.0.0.1", { "x-forwarded-for": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(getPeerIp(req), "stamp-tok|127.0.0.1", "peer-ip must be the proxy hop");
+  assert.equal(getViaProxy(req), "stamp-tok|1", "via-proxy must be 1 behind generic reverse proxy");
+});
+
+test("stamps via-proxy=1 when x-real-ip is present", () => {
+  const req = makeReq("127.0.0.1", { "x-real-ip": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(getViaProxy(req), "stamp-tok|1", "via-proxy must be 1 when x-real-ip present");
+});
+
+test("Cloudflare: via-proxy=1 when cf-connecting-ip is present AND peer is a CF edge IP", () => {
+  // 172.71.150.1 falls inside Cloudflare's 172.64.0.0/13 range.
+  const req = makeReq("172.71.150.1", { "cf-connecting-ip": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(getPeerIp(req), "stamp-tok|172.71.150.1", "peer-ip must be the CF edge");
+  assert.equal(getViaProxy(req), "stamp-tok|1", "via-proxy must be 1 behind Cloudflare");
+});
+
+test("Cloudflare bypass guard: direct forger sending cf-connecting-ip keeps via-proxy=0", () => {
+  // A direct client can forge cf-connecting-ip, but its socket peer is not a
+  // Cloudflare IP. The via-proxy marker must stay 0 so the middleware checks
+  // the real peer IP instead of the forged header.
+  const req = makeReq("203.0.113.7", { "cf-connecting-ip": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(getPeerIp(req), "stamp-tok|203.0.113.7", "peer-ip must stay the real direct IP");
+  assert.equal(
+    getViaProxy(req),
+    "stamp-tok|0",
+    "via-proxy must stay 0 when peer is not Cloudflare"
+  );
+});
+
+test("x-forwarded-for still wins via-proxy=1 even when cf-connecting-ip is forged", () => {
+  const req = makeReq("203.0.113.7", {
+    "x-forwarded-for": "203.0.113.99",
+    "cf-connecting-ip": "198.51.100.1",
+  });
+  stampPeerIp(req);
+
+  assert.equal(getViaProxy(req), "stamp-tok|1", "x-forwarded-for must still set via-proxy=1");
+});
+
+test("F-05: non-Cloudflare proxy (x-forwarded-for only, no cf-connecting-ip) marks via-proxy=1", () => {
+  const req = makeReq("127.0.0.1", { "x-forwarded-for": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(
+    getViaProxy(req),
+    "stamp-tok|1",
+    "generic reverse proxy without cf-connecting-ip must set via-proxy=1"
+  );
+  assert.equal(
+    getPeerIp(req),
+    "stamp-tok|127.0.0.1",
+    "peer-ip must still be the proxy hop for non-Cloudflare proxy"
+  );
+});
+
+test("deletes any client-supplied peer/via-proxy headers before stamping", () => {
+  const req = makeReq("203.0.113.99", {
+    [PEER_IP_HEADER]: "forged|1.2.3.4",
+    [VIA_PROXY_HEADER]: "forged|1",
+  });
+  stampPeerIp(req);
+
+  assert.ok(
+    !getPeerIp(req)?.startsWith("forged|"),
+    "client-supplied peer-ip header must be overwritten"
+  );
+  assert.ok(
+    !getViaProxy(req)?.startsWith("forged|"),
+    "client-supplied via-proxy header must be overwritten"
+  );
+  assert.equal(getPeerIp(req), "stamp-tok|203.0.113.99");
+});
+
+test("IPv6 Cloudflare peer is recognized", () => {
+  const req = makeReq("2400:cb00::1", { "cf-connecting-ip": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(getViaProxy(req), "stamp-tok|1", "IPv6 Cloudflare peer must set via-proxy=1");
+});
+
+test("IPv4-mapped peer address is normalized before CF check", () => {
+  // 172.71.150.1 is a Cloudflare IPv4 address, sometimes surfaced as ::ffff:...
+  const req = makeReq("::ffff:172.71.150.1", { "cf-connecting-ip": "203.0.113.99" });
+  stampPeerIp(req);
+
+  assert.equal(getViaProxy(req), "stamp-tok|1", "IPv4-mapped Cloudflare peer must set via-proxy=1");
+});
+
+test("F2-01: /0 IPv4 CIDR matches every address", () => {
+  assert.equal(matchesIPv4Cidr("8.8.8.8", "0.0.0.0/0"), true, "/0 must match any IPv4 address");
+  assert.equal(matchesIPv4Cidr("203.0.113.7", "0.0.0.0/0"), true, "/0 must match any IPv4 address");
+});
+
+test("F2-04: /0 IPv6 CIDR matches every address", () => {
+  assert.equal(matchesIPv6Cidr("2400:cb00::1", "::/0"), true, "/0 must match any IPv6 address");
+  assert.equal(matchesIPv6Cidr("::1", "::/0"), true, "/0 must match any IPv6 address");
+});
+
+test("F2-03: full-form IPv4-mapped address is normalized", () => {
+  // 172.71.150.1 is inside Cloudflare's 172.64.0.0/13 range.
+  assert.equal(
+    isCloudflareIP("0:0:0:0:0:ffff:172.71.150.1"),
+    true,
+    "full-form IPv4-mapped Cloudflare address must be recognized"
+  );
+  assert.equal(
+    isCloudflareIP("0:0:0:0:0:ffff:203.0.113.7"),
+    false,
+    "full-form IPv4-mapped non-Cloudflare address must not match"
+  );
+});

--- a/tests/unit/authz/probe-9033-repro.test.ts
+++ b/tests/unit/authz/probe-9033-repro.test.ts
@@ -6,9 +6,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { NextRequest } from "next/server";
+import { wrapRequestListenerWithPeerStamp } from "../../../scripts/dev/peer-stamp.mjs";
 
 const TEST_DATA_DIR = path.join(process.env.DATA_DIR!, "probe-9033-repro");
 // NOTE: Not reassigning process.env.DATA_DIR at module scope because
@@ -112,6 +112,47 @@ test("D3: behind reverse proxy (peer stamp=loopback + via-proxy marker + XFF=bla
     res.status,
     403,
     `behind-proxy blacklisted IP must be blocked, got status=${res.status}`
+  );
+});
+
+test("D4: behind Cloudflare (cf-connecting-ip + via-proxy marker, no XFF) blocks the client IP", async () => {
+  process.env.OMNIROUTE_PEER_STAMP_TOKEN = "stamp-tok";
+  ipFilter.configureIPFilter({ enabled: true, mode: "blacklist" });
+  ipFilter.addToBlacklist(BLOCKED);
+
+  // Simulate the real custom-server path: the request arrives at the Node HTTP
+  // server, stampPeerIp runs first, then the request (with stamped headers) is
+  // forwarded into the Next.js pipeline. Use a Cloudflare edge IP as the socket
+  // peer so cf-connecting-ip is trusted as a proxy marker.
+  const stampedHeaders: Record<string, string> = {};
+  const wrapped = wrapRequestListenerWithPeerStamp((_req) => {
+    Object.assign(stampedHeaders, _req.headers);
+  });
+  wrapped(
+    {
+      headers: { "cf-connecting-ip": BLOCKED },
+      socket: { remoteAddress: "172.71.150.1" },
+    } as never,
+    {} as never
+  );
+
+  assert.equal(
+    stampedHeaders["x-omniroute-via-proxy"],
+    "stamp-tok|1",
+    "Cloudflare request must be stamped as via-proxy"
+  );
+  assert.equal(
+    stampedHeaders["x-omniroute-peer-ip"],
+    "stamp-tok|172.71.150.1",
+    "Cloudflare request must have the edge IP stamped"
+  );
+
+  const res = await pipeline.runAuthzPipeline(makeRequest(stampedHeaders), { enforce: true });
+
+  assert.equal(
+    res.status,
+    403,
+    `behind-Cloudflare blacklisted IP must be blocked via cf-connecting-ip, got status=${res.status}`
   );
 });
 


### PR DESCRIPTION
### Summary
Fixes #11514: IP blacklist was not being enforced for clients arriving through Cloudflare when Cloudflare sends only `cf-connecting-ip` (without `x-forwarded-for`).

### Root Cause
`stampPeerIp` previously only inspected `x-forwarded-for` and `x-real-ip` when setting `viaProxy`. When Cloudflare forwarded a request with only `cf-connecting-ip`, `viaProxy` was stamped as `0` (direct connection), causing the authz pipeline to inspect the Cloudflare edge server's TCP IP instead of extracting the real client IP from `cf-connecting-ip`.

### Changes
- Embedded Cloudflare official IPv4/IPv6 CIDRs into `scripts/dev/peer-stamp.mjs`.
- `stampPeerIp` stamps `via-proxy=1` when `cf-connecting-ip` is present AND the incoming socket IP falls within Cloudflare's edge ranges (with anti-spoofing guard against direct client forgery).
- Handles full-form IPv4-mapped addresses and `/0` CIDR edge cases.

### Test Plan
- Added `tests/unit/authz/peer-stamp.test.ts` and updated `tests/unit/authz/probe-9033-repro.test.ts` (18/18 tests pass).
- `npm run typecheck:core` clean.

Closes #11514