### PR TITLE
chore(lint): prune stale ESLint suppressions (base-red #11449)

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -2790,11 +2790,6 @@
       "count": 3
     }
   },
-  "src/mitm/dns/dnsConfig.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "src/mitm/dns/provision.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1
@@ -2922,11 +2917,6 @@
     }
   },
   "src/shared/hooks/useTheme.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
-  "src/shared/middleware/chatBodyAdmission.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1
     }


### PR DESCRIPTION
Fixes the "No new ESLint warnings" gate (exit 2, `There are suppressions left that do not occur anymore`) that is red on `release/v3.8.51` via #11449.

`config/quality/eslint-suppressions.json` carried two `@typescript-eslint/no-unused-vars` suppressions whose violations no longer occur on current tip, so the gate that recommends `--prune-suppressions` could not pass:

- `src/mitm/dns/dnsConfig.ts`
- `src/shared/middleware/chatBodyAdmission.ts`

Pruned with the exact ESLint `--prune-suppressions --suppressions-location config/quality/eslint-suppressions.json` pass the gate itself points at; it only strips entries resolved to a zero count, so **no active suppression was modified**. This is a pure allowlist cleanup (AGENTS.md: fix the cause / prune stale entries — no source change).

## Verification

```
npm run lint:json -- --max-warnings 0   # exit 0 (was: exit 2 + "suppressions left that do not occur anymore")
npx eslint . --suppressions-location config/quality/eslint-suppressions.json --prune-suppressions
git diff --stat  # only eslint-suppressions.json: 2 entries removed
```

Note: platform-independent — the counts the rule suppresses (`no-unused-vars` on .ts files) are source-determined, identical on Windows (here) and ubuntu-latest (CI).
