### PR TITLE
fix(security): namespace the dedup hash by the calling API key (GHSA-6c7w-56xp-wpc6 follow-up)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2984,7 +2984,10 @@ export async function handleChatCore({
 
   const dedupRequestBody = { ...translatedBody, model: `${provider}/${model}`, stream };
   const dedupEnabled = shouldDeduplicate(dedupRequestBody);
-  const dedupHash = dedupEnabled ? computeRequestHash(dedupRequestBody) : null;
+  // Namespaced by the calling API key: dedup hands the SAME response object to
+  // every joiner, so a shared hash across keys is a cross-principal response
+  // leak (GHSA-6c7w-56xp-wpc6).
+  const dedupHash = dedupEnabled ? computeRequestHash(dedupRequestBody, apiKeyInfo?.id) : null;
 
   const executeProviderRequest = async (modelToCall = effectiveModel, allowDedup = false) => {
     const execute = async () => {

--- a/open-sse/services/requestDedup.ts
+++ b/open-sse/services/requestDedup.ts
@@ -129,8 +129,26 @@ function extractSystemContent(body: Record<string, unknown>): unknown {
  * `translatedBody`), so the body shape here is whatever the target provider
  * format produced — see `extractPromptContent`/`extractSystemContent` for the
  * full list of shapes this must cover (#10249, #10438).
+ *
+ * `tenantId` (the calling API key's id) namespaces the hash. Dedup shares ONE
+ * upstream call, and therefore one response, between everyone landing on the
+ * same hash — so the hash has to answer "who is asking", not just "what is
+ * being asked". Without it, two distinct API keys issuing the same request
+ * joined the same in-flight promise: the response was produced with the
+ * initiator's provider connection, under the initiator's per-key policy
+ * (allowedConnections / allowedModels), billed to the initiator, and handed to
+ * a different authenticated principal (GHSA-6c7w-56xp-wpc6).
+ *
+ * It is a PLAINTEXT prefix rather than digest input, matching
+ * `semanticCache.generateSignature` (#3740): the id is an internal namespace
+ * key, not a credential, and keeping it out of the digest avoids the
+ * false-positive CodeQL js/insufficient-password-hash on a cache/dedup key.
+ *
+ * Omitting `tenantId` keeps the un-namespaced hash. Keyless local-first
+ * deployments have no tenant boundary to preserve, and every such install would
+ * otherwise silently lose dedup.
  */
-export function computeRequestHash(requestBody: unknown): string {
+export function computeRequestHash(requestBody: unknown, tenantId?: string | null): string {
   const body = requestBody as Record<string, unknown>;
   const canonical = {
     model: body.model ?? null,
@@ -145,7 +163,8 @@ export function computeRequestHash(requestBody: unknown): string {
     frequency_penalty: body.frequency_penalty ?? null,
     presence_penalty: body.presence_penalty ?? null,
   };
-  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 16);
+  const digest = createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 16);
+  return tenantId ? `${tenantId}.${digest}` : digest;
 }
 
 /** Determine whether a request should be deduplicated */

--- a/tests/unit/request-dedup-tenant-isolation.test.ts
+++ b/tests/unit/request-dedup-tenant-isolation.test.ts
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeRequestHash,
+  deduplicate,
+  clearInflight,
+} from "../../open-sse/services/requestDedup.ts";
+
+// GHSA-6c7w-56xp-wpc6 follow-up. The dedup layer shares ONE upstream call — and
+// therefore one response object — between every concurrent caller landing on the
+// same hash. The hash canonicalized model + prompt + sampling params and nothing
+// about WHO was asking, so two distinct OmniRoute API keys issuing the same
+// request joined the same in-flight promise: the response was produced with the
+// initiator's provider connection, under the initiator's per-key policy, and
+// handed to a different authenticated principal.
+//
+// #10438 fixed the *prompt* half of this class (translated bodies hashing the
+// prompt as `null`). This is the *identity* half.
+
+const body = {
+  messages: [{ role: "user", content: "Summarize the incident report." }],
+  temperature: 0,
+  model: "codex/gpt-5.6-terra",
+  stream: false,
+};
+
+test("the same request from two different API keys does NOT share a dedup hash", () => {
+  const hashKey1 = computeRequestHash(body, "apikey-1");
+  const hashKey2 = computeRequestHash(body, "apikey-2");
+  assert.notEqual(
+    hashKey1,
+    hashKey2,
+    "an identical request from a different API key must not join the first key's in-flight call"
+  );
+});
+
+test("the same request from the same API key still dedups", () => {
+  assert.equal(computeRequestHash(body, "apikey-1"), computeRequestHash(body, "apikey-1"));
+});
+
+test("concurrent identical requests on two keys each get their own response", async () => {
+  clearInflight();
+  const hash1 = computeRequestHash(body, "apikey-1");
+  const hash2 = computeRequestHash(body, "apikey-2");
+
+  let released!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    released = resolve;
+  });
+
+  const first = deduplicate(hash1, async () => {
+    await gate;
+    return "RESPONSE_FOR_KEY_1";
+  });
+  const second = deduplicate(hash2, async () => {
+    await gate;
+    return "RESPONSE_FOR_KEY_2";
+  });
+  released();
+
+  const [a, b] = await Promise.all([first, second]);
+  assert.equal(a.result, "RESPONSE_FOR_KEY_1");
+  assert.equal(b.result, "RESPONSE_FOR_KEY_2");
+  assert.equal(b.wasDeduplicated, false, "key 2 must not have joined key 1's in-flight call");
+});
+
+test("an unkeyed (anonymous) caller keeps the un-namespaced hash", () => {
+  // Keyless local-first deployments have no tenant boundary to preserve, so the
+  // behaviour there is unchanged — and must stay stable, or every such install
+  // silently loses dedup.
+  const anonymous = computeRequestHash(body);
+  assert.equal(computeRequestHash(body, undefined), anonymous);
+  assert.equal(computeRequestHash(body, null as unknown as undefined), anonymous);
+  assert.notEqual(computeRequestHash(body, "apikey-1"), anonymous);
+});
+
+test("the tenant namespace cannot be forged by a colliding request body", () => {
+  // The namespace is a plaintext prefix, so it must not be possible to move
+  // between namespaces by crafting a body — the separator has to survive.
+  const h1 = computeRequestHash(body, "a");
+  const h2 = computeRequestHash(body, "a.b");
+  assert.notEqual(h1, h2);
+  assert.ok(h1.startsWith("a."), "namespace must prefix the digest");
+});
+
+test("chatCore passes the caller's API key id into the dedup hash", async () => {
+  const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const source = readFileSync(
+    fileURLToPath(new URL("../../open-sse/handlers/chatCore.ts", import.meta.url)),
+    "utf8"
+  );
+  assert.ok(
+    /computeRequestHash\(\s*dedupRequestBody\s*,\s*apiKeyInfo\?\.id/.test(source),
+    "the dedup hash must be namespaced by the calling API key (GHSA-6c7w-56xp-wpc6)"
+  );
+});


### PR DESCRIPTION
Follow-up to **GHSA-6c7w-56xp-wpc6**. Targets `release/v3.8.51` — `release/v3.8.50` is frozen (#11439).

## Context: the reported bug is already fixed, this is the part that wasn't

The advisory reports 4 concurrent non-streaming `temperature: 0` requests on `cx/gpt-5.6-terra`, across 2 distinct API keys, all receiving **one identical response body** — the first KEY1 response fanned out to all four.

Root cause, confirmed against the reported version:

- `deduplicate()` (`open-sse/services/requestDedup.ts`) collapses concurrent requests with the same hash onto one upstream call and hands every joiner the same response. It engages for `stream !== true` and `temperature <= 0.1` — exactly the reported configuration.
- On **v3.8.49** (tagged 2026-07-29, the reported version) `computeRequestHash` read `messages: body.messages ?? null`.
- `cx` is `codex`, whose provider format is `openai-responses`, so the translated body carries the prompt under **`input`**, not `messages`. Every codex request therefore hashed its prompt as `null` → one hash for all prompts → the first in-flight response served to every concurrent caller, across API keys.
- **#10438** (`7f0404bf82`, 2026-08-18) replaced that with `extractPromptContent()` covering `messages`/`contents`/`input`/Antigravity/Kiro. It is **not** an ancestor of `v3.8.49` — it ships in v3.8.50.

Verified rather than assumed: running the real translator, two different prompts through the codex/`openai-responses` path now produce `e46c2fc4aee68fd8` vs `7c578283f944cc20` — no collision — while `shouldDeduplicate` still returns `true` for that configuration.

## What #10438 did not fix

The hash canonicalizes model, prompt, system and sampling params. It answers *what is being asked*, never *who is asking*.

Two distinct API keys issuing the **same** request still join the same in-flight promise. The response is produced with the initiator's provider connection, under the initiator's per-key policy (`allowedConnections`, `allowedModels`, `disableNonPublicModels`), billed to the initiator — and handed to a different authenticated principal.

That is narrower than the reported bug (it needs identical requests, not merely concurrent ones) but it is the same class and it is present on the tip. Dedup is an optimization; it must not be a hole in the auth boundary.

## Fix

`computeRequestHash(body, tenantId?)` namespaces the hash with the calling API key's id, and `chatCore` passes `apiKeyInfo?.id`.

The id is a **plaintext prefix**, not digest input — matching `semanticCache.generateSignature` (#3740). It is an internal namespace key rather than a credential, and keeping it out of the digest avoids a false-positive CodeQL `js/insufficient-password-hash` on a dedup key, which is a alert this repo has already dismissed 39 times.

Omitting the id keeps the un-namespaced hash: keyless local-first deployments have no tenant boundary to preserve and would otherwise silently lose dedup. That behaviour is pinned by a test rather than left to chance.

## Validation

`tests/unit/request-dedup-tenant-isolation.test.ts` — 6 tests, **5 red before the fix**:

- two different API keys do not share a hash for the same request
- the same API key still dedups (the optimization is not disabled)
- two concurrent identical requests on different keys each get their **own** response, and the second reports `wasDeduplicated: false`
- the anonymous/unkeyed hash is unchanged
- the namespace prefix cannot be forged from the request body
- `chatCore` actually threads the key id through (source guard)

Sibling sweep, hermetic (`env -u OMNIROUTE_API_KEY`): `request-dedup-10249` + this file — **15/15**; `chatcore-semantic-cache` + `semantic-cache` — **35/35**. `typecheck:core` exit 0. `eslint` and `prettier --check` clean.

`computeRequestHash` has exactly one production consumer (`chatCore.ts:2990`), which this PR updates; the new parameter is optional, so nothing else changes behaviour.

## Still open on the advisory

This does not close GHSA-6c7w-56xp-wpc6. The reporter should be asked to confirm the original repro against v3.8.50/v3.8.51, where #10438 is present — that is the datum that turns the root-cause analysis above into a confirmed fix.

⚠️ base-red inherited: #11449
