### PR TITLE
fix(dashboard): project Codex routing quota in account pools

### DIFF
--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -30,9 +30,14 @@ import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { normalizeQoderPatProviderData } from "@omniroute/open-sse/services/qoderCli";
 import { projectCodexAccountPool } from "@omniroute/open-sse/services/codexAccount/index.ts";
 import {
+  CODEX_SPARK_QUOTA_SESSION,
+  CODEX_SPARK_QUOTA_WEEKLY,
+} from "@omniroute/open-sse/config/codexQuotaScopes.ts";
+import {
   normalizeProviderSpecificData,
   sanitizeProviderSpecificDataForResponse,
 } from "@/lib/providers/requestDefaults";
+import { getQuotaWindowObservation } from "@/domain/quotaCache";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { isManagedProviderConnectionId } from "@/lib/providers/catalog";
 import { isApiKeyRevealEnabled, maskStoredApiKey } from "@/lib/apiKeyExposure";
@@ -44,6 +49,48 @@ import {
 } from "@/shared/services/modelSyncScheduler";
 import { finalizeValidatedChatGptWebCodexSecrets } from "@omniroute/open-sse/services/chatgptWebCodexAdmin.ts";
 import { testSingleConnection } from "./[id]/test/route";
+
+function projectCodexAccountPoolWithRoutingQuota(
+  connection: Parameters<typeof projectCodexAccountPool>[0],
+  now: number
+) {
+  const projection = projectCodexAccountPool(connection, now);
+  const children = projection.children.map((child) => {
+    const fiveHourWindow = child.key.scope === "spark" ? CODEX_SPARK_QUOTA_SESSION : "session";
+    const weeklyWindow = child.key.scope === "spark" ? CODEX_SPARK_QUOTA_WEEKLY : "weekly";
+    const fiveHour = getQuotaWindowObservation(connection.id, fiveHourWindow);
+    const weekly = getQuotaWindowObservation(connection.id, weeklyWindow);
+    if (!fiveHour && !weekly) return child;
+
+    return {
+      ...child,
+      quota: {
+        ...child.quota,
+        observedAt: fiveHour?.observedAt ?? weekly?.observedAt ?? null,
+        windows: {
+          "5h": fiveHour
+            ? {
+                usage: null,
+                limit: null,
+                resetAt: fiveHour.resetAt,
+                usedPercentage: fiveHour.usedPercentage,
+              }
+            : child.quota.windows["5h"],
+          "7d": weekly
+            ? {
+                usage: null,
+                limit: null,
+                resetAt: weekly.resetAt,
+                usedPercentage: weekly.usedPercentage,
+              }
+            : child.quota.windows["7d"],
+        },
+      },
+    };
+  }) as typeof projection.children;
+
+  return { ...projection, children };
+}
 
 // GET /api/providers - List all connections
 export async function GET(request: Request) {
@@ -81,7 +128,7 @@ export async function GET(request: Request) {
         providerSpecificData,
         ...(c.provider === "codex"
           ? {
-              codexAccountPool: projectCodexAccountPool(
+              codexAccountPool: projectCodexAccountPoolWithRoutingQuota(
                 {
                   id: c.id,
                   provider: c.provider,

--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -70,6 +70,12 @@ interface QuotaWindowStatus {
   reachedThreshold: boolean;
 }
 
+export interface QuotaWindowObservation {
+  usedPercentage: number;
+  resetAt: string | null;
+  observedAt: string | null;
+}
+
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const ACTIVE_TTL_MS = 5 * 60 * 1000; // 5 minutes for active accounts
@@ -662,6 +668,28 @@ export function getQuotaWindowStatus(
         : remainingPercentage <= 0
           ? true
           : usedPercentage >= thresholdPercent,
+  };
+}
+
+/** Return the display-safe observation behind the routing decision for one quota window. */
+export function getQuotaWindowObservation(
+  connectionId: string,
+  windowName: string
+): QuotaWindowObservation | null {
+  const entry = getState().cache.get(connectionId) || hydrateQuotaCacheFromSnapshots(connectionId);
+  if (!entry) return null;
+
+  const window = resolveQuotaWindow(entry.quotas, windowName);
+  if (!window || window.fractionReported === false) return null;
+
+  const status = getQuotaWindowStatus(connectionId, windowName);
+  if (!status) return null;
+  const observedDate = new Date(entry.fetchedAt);
+
+  return {
+    usedPercentage: status.usedPercentage,
+    resetAt: status.resetAt,
+    observedAt: Number.isFinite(observedDate.getTime()) ? observedDate.toISOString() : null,
   };
 }
 

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -306,6 +306,7 @@
       "tests/unit/provider-error-rules.test.ts",
       "tests/unit/provider-health-matrix.test.ts",
       "tests/unit/provider-request-failure-pipeline.test.ts",
+      "tests/unit/providers-route-codex-account-pool.test.ts",
       "tests/unit/proxy-logs-egress-lookup-10880.test.ts",
       "tests/unit/public-client-ids-3493.test.ts",
       "tests/unit/publicCreds.test.ts",

--- a/tests/unit/providers-route-codex-account-pool.test.ts
+++ b/tests/unit/providers-route-codex-account-pool.test.ts
@@ -12,9 +12,12 @@ process.env.ALLOW_API_KEY_REVEAL = "false";
 
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
+const quotaCache = await import("../../src/domain/quotaCache.ts");
+const auth = await import("../../src/sse/services/auth.ts");
 const providersRoute = await import("../../src/app/api/providers/route.ts");
 
 test.after(() => {
+  quotaCache.__clearForTests();
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
@@ -112,4 +115,103 @@ test("GET keeps one parent row and projects raw Codex state without exposing cre
   }
   const safeProviderData = codexRow.providerSpecificData as Record<string, unknown>;
   assert.equal("consoleApiKey" in safeProviderData, false);
+});
+
+test("GET projects the same scoped Codex quota observations used by routing", async () => {
+  const resetAt5h = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+  const resetAt7d = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  const codex = await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "Codex cache-only quota",
+    quotaVisible: true,
+    providerSpecificData: {
+      limitPolicy: {
+        enabled: true,
+        thresholdPercent: 99,
+        windows: ["session", "weekly"],
+      },
+    },
+  });
+
+  quotaCache.setQuotaCache(codex.id, "codex", {
+    session: { remainingPercentage: 50, resetAt: resetAt5h },
+    weekly: { remainingPercentage: 50, resetAt: resetAt7d },
+  });
+  quotaCache.setQuotaCache(codex.id, "codex", {
+    session: { remainingPercentage: 0, resetAt: resetAt5h },
+    weekly: { remainingPercentage: 75, resetAt: resetAt7d },
+    gpt_5_3_codex_spark_session: { remainingPercentage: 60, resetAt: resetAt5h },
+    gpt_5_3_codex_spark_weekly: { remainingPercentage: 40, resetAt: resetAt7d },
+  });
+
+  const routing = auth.evaluateQuotaLimitPolicy(
+    "codex",
+    {
+      id: codex.id,
+      providerSpecificData: codex.providerSpecificData ?? {},
+    } as never,
+    "gpt-5.5-codex"
+  );
+  assert.equal(routing.blocked, true);
+  assert.deepEqual(routing.reasons, ["session usage 100%"]);
+
+  const response = await providersRoute.GET(
+    await makeManagementSessionRequest("http://localhost/api/providers?provider=codex")
+  );
+  const body = (await response.json()) as {
+    connections: Array<{
+      id: string;
+      codexAccountPool: {
+        children: Array<{
+          key: { scope: "codex" | "spark" };
+          quota: {
+            observedAt: string | null;
+            windows: Record<
+              "5h" | "7d",
+              {
+                usage: number | null;
+                limit: number | null;
+                resetAt: string | null;
+                usedPercentage: number | null;
+              } | null
+            >;
+          };
+        }>;
+      };
+    }>;
+  };
+  const pool = body.connections.find((connection) => connection.id === codex.id)?.codexAccountPool;
+  assert.ok(pool);
+  const general = pool.children.find((child) => child.key.scope === "codex");
+  const spark = pool.children.find((child) => child.key.scope === "spark");
+  assert.ok(general);
+  assert.ok(spark);
+
+  assert.deepEqual(general.quota.windows["5h"], {
+    usage: null,
+    limit: null,
+    resetAt: resetAt5h,
+    usedPercentage: 100,
+  });
+  assert.deepEqual(general.quota.windows["7d"], {
+    usage: null,
+    limit: null,
+    resetAt: resetAt7d,
+    usedPercentage: 25,
+  });
+  assert.deepEqual(spark.quota.windows["5h"], {
+    usage: null,
+    limit: null,
+    resetAt: resetAt5h,
+    usedPercentage: 40,
+  });
+  assert.deepEqual(spark.quota.windows["7d"], {
+    usage: null,
+    limit: null,
+    resetAt: resetAt7d,
+    usedPercentage: 60,
+  });
+  assert.ok(general.quota.observedAt);
+  assert.equal(general.quota.observedAt, spark.quota.observedAt);
 });

--- a/tests/unit/ui/codex-account-details.test.tsx
+++ b/tests/unit/ui/codex-account-details.test.tsx
@@ -113,4 +113,46 @@ describe("CodexAccountDetails", () => {
     expect(container.textContent).not.toContain("Cooling down");
     expect(container.textContent).toContain("Until ");
   });
+
+  it("renders cache-derived percentages when absolute usage and limit are unavailable", () => {
+    const container = renderPool({
+      parentConnectionId: "parent-cache-quota",
+      aggregate: { status: "available", limitedChildCount: 0 },
+      children: [
+        {
+          key: { parentConnectionId: "parent-cache-quota", scope: "codex" },
+          unavailable: false,
+          cooldown: { active: false, rateLimitedUntil: null },
+          quota: {
+            exhaustedWindow: null,
+            observedAt: "2026-08-26T12:00:00.000Z",
+            windows: {
+              "5h": {
+                usage: null,
+                limit: null,
+                resetAt: "2026-08-26T17:00:00.000Z",
+                usedPercentage: 100,
+              },
+              "7d": {
+                usage: null,
+                limit: null,
+                resetAt: "2026-09-02T12:00:00.000Z",
+                usedPercentage: 25,
+              },
+            },
+          },
+        },
+        {
+          key: { parentConnectionId: "parent-cache-quota", scope: "spark" },
+          unavailable: false,
+          cooldown: { active: false, rateLimitedUntil: null },
+          quota: quota(),
+        },
+      ],
+    });
+
+    expect(container.textContent).toContain("5h: 100% used");
+    expect(container.textContent).toContain("7d: 25% used");
+    expect(container.textContent).not.toContain("100/100");
+  });
 });


### PR DESCRIPTION
## Summary

- expose the latest authoritative Codex and Spark quota-window observations from the routing quota cache
- overlay those observations onto the authenticated providers account-pool projection
- keep unknown quota data null and preserve persisted fallback, reset times, privacy, and child-scope isolation
- register the new providers-route regression test in the repository mutation-test coverage inventory

## Root cause

The routing path reads live Codex quota from the domain quota cache, but the providers API account-pool projection only read persisted provider-specific data. When upstream quota existed only in the cache, routing could filter at 100 percent while the dashboard received null 5h and 7d windows and rendered dashes.

This is API projection loss, not configuration, missing upstream data, stale cache, or dashboard parsing.

## TDD reproduction

A sanitized route test first reproduced the mismatch: quota policy evaluation reported session usage 100 percent while GET /api/providers returned a null 5h window for the same connection. The test passes after the projection overlay.

## CI classification

Run 32989807428 tested head 99568fabf5ce298a5576455d38d0450adc4ed646 against exact base 91aeca04402afa4d29ad7061928ce8193fc7ba9d.

PR-caused:

- mutation-test-coverage: tests/unit/providers-route-codex-account-pool.test.ts covers mutated src/sse/services/auth.ts but was absent from stryker.conf.json tap.testFiles. Fixed conventionally with the single missing registration; the strict drift gate now passes.

Inherited base-red, not repaired here:

- Docs Gates: provider reference and four SVG claims remain at 354 while the base live-module count is 356.
- ESLint: the base lint command exits because stale suppressions remain. Exact-base release-green issue #11449 records both the docs and ESLint failures at 91aeca044.
- Unit shard 1: six unrelated failures in chatcore translation, live WebSocket module loading, and provider-count expectations.
- Unit shard 2: four unrelated failures in context7 policy, probe gating, provider golden snapshot, and token-health behavior.
- Unit shard 3: three unrelated failures in the docs-count test and embed WebSocket tests.
- Unit shard 4: eight unrelated failures in chat fallback, combo cooldown/cascade, gamification, lease inventory, live WebSocket cookie loading, and reserved-prefix counts.

The exact-base diff for this PR contains only the quota projection implementation and its focused tests; none of the inherited failing tests or their owning source areas were changed. The quota-cache addition is a read-only observation accessor and does not alter admission, routing, or cooldown writes.

## Verification

- strict mutation test-coverage gate: passed, 4590 tests scanned against 31 mutated modules with no drift
- focused quota cache and providers API tests: 15/15 passed
- focused dashboard test: 3/3 passed
- touched-file Prettier: passed
- touched TypeScript ESLint with repository suppressions: passed
- core typecheck: previously passed at the runtime-source head and remains reusable because the follow-up changes JSON only
- production build: previously passed and intentionally reused; no runtime source changed in the follow-up
- git diff --check: passed

## Scope

No admission, routing strategy, credential health, entitlement, configuration, or unrelated quota behavior changed. No percentage is synthesized when upstream omits the quota fraction.

⚠️ base-red inherited: #11449