### PR TITLE
test(chatcore): move fixtures off models the lifecycle guard now rejects

### DIFF
--- a/changelog.d/fixes/11626-retired-model-test-updates.md
+++ b/changelog.d/fixes/11626-retired-model-test-updates.md
@@ -1,0 +1,1 @@
+- **test(chatcore):** move Codex/Claude combo fixtures off models the lifecycle guard now rejects — `gpt-5.1-codex`/`gpt-5-codex` are vendor-retired (snapshot, #11626) and `claude-3-5-sonnet-20241022` is shut down, so native-passthrough and combo-fallback tests switched to `gpt-5.6-sol` and `claude-sonnet-4.6` ([#11626](https://github.com/diegosouzapw/OmniRoute/pull/11626)).

--- a/tests/unit/chat-route-coverage.test.ts
+++ b/tests/unit/chat-route-coverage.test.ts
@@ -279,7 +279,7 @@ test("handleChat keeps protected combo fallback separate from Global Fallback Mo
     ],
   });
   await settingsDb.updateSettings({
-    globalFallbackModel: "claude/claude-3-5-sonnet-20241022",
+    globalFallbackModel: "claude/claude-sonnet-4.6",
   });
 
   const attemptedKeys: string[] = [];
@@ -407,7 +407,7 @@ test("handleChat keeps the combo error when the global fallback throws", async (
     models: ["openai/gpt-4.1"],
   });
   await settingsDb.updateSettings({
-    globalFallbackModel: "claude/claude-3-5-sonnet-20241022",
+    globalFallbackModel: "claude/claude-sonnet-4.6",
   });
 
   let attempts = 0;
@@ -617,7 +617,7 @@ test("handleChat returns the primary budget error when emergency fallback also f
 test("handleChat rejects models that are not allowed by the caller API key policy", async () => {
   await seedConnection("openai", { apiKey: "sk-openai-policy" });
   const apiKey = await seedApiKey({
-    allowedModels: ["claude/claude-3-5-sonnet-20241022"],
+    allowedModels: ["claude/claude-sonnet-4.6"],
   });
 
   const response = await handleChat(

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -541,11 +541,11 @@ test("chatCore can disable pipeline stream chunk capture through environment", a
 test("chatCore keeps Responses-native Codex payloads in native passthrough mode", async () => {
   const { call, result } = await invokeChatCore({
     provider: "codex",
-    model: "gpt-5.1-codex",
+    model: "gpt-5.6-sol",
     endpoint: "/v1/responses",
     credentials: { accessToken: "codex-token", providerSpecificData: {} },
     body: {
-      model: "gpt-5.1-codex",
+      model: "gpt-5.6-sol",
       input: "ship it",
       instructions: "custom system prompt",
       store: true,
@@ -1111,14 +1111,14 @@ test("chatCore captures streaming no-tool reasoning for Responses replay", async
 test("chatCore automatically preserves provider-generated opaque reasoning for Codex", async () => {
   const { call, result } = await invokeChatCore({
     provider: "codex",
-    model: "gpt-5.1-codex",
+    model: "gpt-5.6-sol",
     endpoint: "/v1/responses",
     credentials: {
       accessToken: "codex-token",
       providerSpecificData: {},
     },
     body: {
-      model: "gpt-5.1-codex",
+      model: "gpt-5.6-sol",
       stream: false,
       input: [
         { id: "rs_valid", type: "reasoning", encrypted_content: "encrypted-blob" },
@@ -2503,7 +2503,7 @@ test("chatCore preserves Codex dual-window scope cooldowns on 429 responses", as
   const resetAt7d = new Date(Date.now() + 3_600_000).toISOString();
   const { result } = await invokeChatCore({
     provider: "codex",
-    model: "gpt-5.1-codex",
+    model: "gpt-5.6-sol",
     endpoint: "/v1/responses",
     connectionId: connection.id,
     credentials: {
@@ -2511,7 +2511,7 @@ test("chatCore preserves Codex dual-window scope cooldowns on 429 responses", as
       providerSpecificData: {},
     },
     body: {
-      model: "gpt-5.1-codex",
+      model: "gpt-5.6-sol",
       input: "persist quota",
       stream: false,
     },

--- a/tests/unit/combo-provider-cooldown.test.ts
+++ b/tests/unit/combo-provider-cooldown.test.ts
@@ -49,7 +49,7 @@ test("combo failover skips the cooled provider target on the next request", asyn
     strategy: "priority",
     config: { maxRetries: 0, retryDelayMs: 0 },
     // openai/gpt-4o-mini is now ambiguous (multi-provider); use o3-mini which resolves unambiguously to openai
-    models: ["openai/o3-mini", "claude/claude-3-5-sonnet-20241022"],
+    models: ["openai/o3-mini", "claude/claude-sonnet-4.6"],
   });
 
   let openaiCalls = 0;
@@ -137,8 +137,8 @@ test("pre-screen marks target unavailable when circuit breaker is OPEN", async (
     {
       kind: "model" as const,
       stepId: "step-2",
-      executionKey: "claude/claude-3-5-sonnet-20241022",
-      modelStr: "claude/claude-3-5-sonnet-20241022",
+      executionKey: "claude/claude-sonnet-4.6",
+      modelStr: "claude/claude-sonnet-4.6",
       provider: "claude",
       providerId: "conn-2",
       connectionId: "conn-2",
@@ -153,7 +153,7 @@ test("pre-screen marks target unavailable when circuit breaker is OPEN", async (
   assert.ok(openaiResult, "openai target should have a pre-screen result");
   assert.equal(openaiResult.available, false, "open-circuit-breaker target should be unavailable");
 
-  const claudeResult = results.get("claude/claude-3-5-sonnet-20241022");
+  const claudeResult = results.get("claude/claude-sonnet-4.6");
   assert.ok(claudeResult, "claude target should have a pre-screen result");
   assert.equal(claudeResult.available, true, "closed-circuit-breaker target should be available");
 });

--- a/tests/unit/combo-same-provider-cascade.test.ts
+++ b/tests/unit/combo-same-provider-cascade.test.ts
@@ -57,7 +57,7 @@ test("combo hits a failing provider only once before falling back across same-pr
       "openai/o3-mini",
       "openai/o1-mini",
       "openai/gpt-4.1-mini",
-      "claude/claude-3-5-sonnet-20241022",
+      "claude/claude-sonnet-4.6",
     ],
   });
 

--- a/tests/unit/probe-gate-autodisable.test.ts
+++ b/tests/unit/probe-gate-autodisable.test.ts
@@ -249,7 +249,7 @@ test("codex 429 probe never runs the account-rotation failover (no persisted coo
   mockUpstream(429, "rate limited");
   const result = await runSingleModelTest({
     providerId: "codex",
-    modelId: "gpt-5-codex",
+    modelId: "gpt-5.6-sol",
     connectionId: connId,
     timeoutMs: 10_000,
   });


### PR DESCRIPTION
## What was broken

Five chatCore/Codex/combo test files used **models the model-lifecycle guard now rejects with HTTP 410**, so the mocked upstream was never reached and the behavior under test could not be exercised. On `release/v3.8.51` (and PR #11644's CI):

```
✖ chatCore keeps Responses-native Codex payloads in native passthrough mode       false !== true
✖ chatCore automatically preserves provider-generated opaque reasoning for Codex  false !== true
✖ chatCore preserves Codex dual-window scope cooldowns on 429 responses          410 !== 429
✖ handleChat keeps protected combo fallback separate from Global Fallback Model   503 !== 200
✖ handleChat keeps the combo error when the global fallback throws                1 !== 2
✖ combo failover skips the cooled provider target on the next request             502 !== 200
✖ combo hits a failing provider only once before falling back (#3200)             410 !== 200
✖ codex 429 probe never runs the account-rotation failover                        AssertionError
```

Root cause in the logs:

```
❌ claude [410]: Model "claude/claude-3-5-sonnet-20241022" was shut down on 2025-10-28 ...
❌ Model "codex/gpt-5.1-codex" has been retired by its vendor ...
❌ Model "codex/gpt-5-codex" has been retired by its vendor ...
```

## Root cause

- `claude-3-5-sonnet-20241022` has a **dated shutdown record** (2025-10-28, guard from #8627).
- `gpt-5.1-codex` / `gpt-5-codex` are in the **vendor-retired snapshot** `config/quality/model-lifecycle.json` (id-scoped guard added by #11626).

The guard correctly rejects these models for ALL providers; the tests were simply still using retired fixtures. Current model ids the `codex`/`claude` registries serve: `gpt-5.6-sol`, `claude-sonnet-4.6`.

## Fix (model swap only — no assertion changes)

| File | Lines | Change |
| --- | --- | --- |
| `tests/unit/chatcore-translation-paths.test.ts` | 544, 548, 1114, 1121, 2506, 2514 | `gpt-5.1-codex` → `gpt-5.6-sol` |
| `tests/unit/chat-route-coverage.test.ts` | 282, 410, 620 | `claude/claude-3-5-sonnet-20241022` → `claude/claude-sonnet-4.6` |
| `tests/unit/combo-provider-cooldown.test.ts` | 52, 140–141, 156 | `claude/claude-3-5-sonnet-20241022` → `claude/claude-sonnet-4.6` |
| `tests/unit/combo-same-provider-cascade.test.ts` | 60 | `claude/claude-3-5-sonnet-20241022` → `claude/claude-sonnet-4.6` |
| `tests/unit/probe-gate-autodisable.test.ts` | 252 | `gpt-5-codex` → `gpt-5.6-sol` |
| `changelog.d/fixes/11626-retired-model-test-updates.md` | — | new fragment |

Verified the replacement models are `untracked/allow` via `getModelLifecycleDecision`.

## Green evidence (after)

```
ℹ tests 102
ℹ pass 102
ℹ fail 0
```
(5 test files: `chatcore-translation-paths`, `chat-route-coverage`, `combo-provider-cooldown`, `combo-same-provider-cascade`, `probe-gate-autodisable`)