### PR TITLE
test(gamification): pin aggregate level to #11604 XP-derived semantics

### DIFF
--- a/changelog.d/fixes/11604-aggregate-profile-level-pin.md
+++ b/changelog.d/fixes/11604-aggregate-profile-level-pin.md
@@ -1,0 +1,1 @@
+- **test(gamification):** pin the aggregate profile level to the XP-derived semantics of #11604 — `getAggregateXp()` now derives `currentLevel` from the summed XP (`calculateLevel(sum)`), not `MAX(stored current_level)`, and the #3484 fixture levels are aligned with the XP curve ([#11604](https://github.com/diegosouzapw/OmniRoute/pull/11604)).

--- a/tests/unit/gamification/aggregate-profile-3484.test.ts
+++ b/tests/unit/gamification/aggregate-profile-3484.test.ts
@@ -47,18 +47,21 @@ test("#3484 seedBuiltinBadges populates the catalog (getBadgeDefinitions non-emp
   assert.equal(gami.getBadgeDefinitions().length, BUILTIN_BADGES.length);
 });
 
-test("#3484 getAggregateXp sums XP across keys and takes the highest level", () => {
+test("#3484 getAggregateXp sums XP across keys and derives the level from the summed XP", () => {
   const db = getDbInstance();
   const upsert = db.prepare(
     `INSERT OR REPLACE INTO user_levels (api_key_id, total_xp, current_level, updated_at)
      VALUES (?, ?, ?, datetime('now'))`
   );
-  upsert.run("key-a", 100, 2);
-  upsert.run("key-b", 250, 5);
+  // Both keys are individually level 1 on the XP curve (cumulative threshold for
+  // level 2 is 282 XP); summed they cross it — the aggregate level must be derived
+  // from the SAME summed XP the profile displays (#11604), not MAX(stored levels).
+  upsert.run("key-a", 100, 1);
+  upsert.run("key-b", 250, 1);
 
   const agg = gami.getAggregateXp();
   assert.equal(agg.totalXp, 350);
-  assert.equal(agg.currentLevel, 5);
+  assert.equal(agg.currentLevel, 2);
 });
 
 test("#3484 getAllEarnedBadges returns distinct badges earned by any key", () => {


### PR DESCRIPTION
## What was broken

`tests/unit/gamification/aggregate-profile-3484.test.ts` failed on `release/v3.8.51` (and PR #11644's CI):

```
✖ #3484 getAggregateXp sums XP across keys and takes the highest level
  AssertionError: 2 !== 5   (agg.currentLevel)
```

## Root cause

#11604 (`fix(dashboard): keep Profile XP and level consistent`) deliberately changed `getAggregateXp()` in `src/lib/db/gamification.ts`:

```diff
- SELECT COALESCE(SUM(total_xp), 0) AS total_xp,
-        COALESCE(MAX(current_level), 1) AS current_level,
+ SELECT COALESCE(SUM(total_xp), 0) AS total_xp,
   MAX(updated_at) AS updated_at
...
- currentLevel: row?.current_level ?? 1,
+ currentLevel: calculateLevel(totalXp),
```

The aggregate level must be derived from the **same summed XP the profile displays**. The #3484 test still asserted the old `MAX(stored level)` semantics — and its fixtures were off-curve anyway (`100 XP → level 2` and `250 XP → level 5` are impossible on the XP curve where level 2 requires 282 XP).

## Fix

`tests/unit/gamification/aggregate-profile-3484.test.ts` (lines 50–65):

- Test renamed: *"sums XP across keys and takes the highest level"* → *"…derives the level from the summed XP"*.
- Fixtures aligned to the XP curve: `key-a: 100 XP / level 1`, `key-b: 250 XP / level 1` (both individually level 1; sum 350 crosses the level-2 threshold of 282).
- Assertion: `currentLevel === 2` (`calculateLevel(350)`), pinning the #11604 semantics.

## Green evidence (after)

```
ℹ tests 4
ℹ pass 4
ℹ fail 0
```

Files: `tests/unit/gamification/aggregate-profile-3484.test.ts`, `changelog.d/fixes/11604-aggregate-profile-level-pin.md`.