### PR TITLE
test(sse): bump hard-lease inventory count for #11495 sweep query

### DIFF
--- a/changelog.d/maintenance/11495-hard-lease-inventory-count.md
+++ b/changelog.d/maintenance/11495-hard-lease-inventory-count.md
@@ -1,0 +1,1 @@
+- **test(sse):** bump the hard-lease connection-query inventory for `src/lib/tokenHealthCheck.ts` to 2 — the verify-only web-cookie sweep added by #11495 split the single `getProviderConnections` call into oauth + cookie variants, which the frozen inventory had not tracked ([#11495](https://github.com/diegosouzapw/OmniRoute/pull/11495)).

--- a/tests/unit/hard-session-lease-bypass-inventory.test.ts
+++ b/tests/unit/hard-session-lease-bypass-inventory.test.ts
@@ -137,7 +137,8 @@ const EXPECTED: Record<InventoryKind, Record<string, number>> = {
     "src/lib/proxyEgress.ts": 1,
     "src/lib/quota/connectionRecovery.ts": 2,
     "src/lib/sync/bundle.ts": 1,
-    "src/lib/tokenHealthCheck.ts": 1,
+    // #11495: verify-only sweep queries oauth + cookie connections
+    "src/lib/tokenHealthCheck.ts": 2,
     "src/lib/tokenHealthCheckCopilot.ts": 1,
     "src/lib/usage/callLogs.ts": 1,
     "src/lib/usage/codexResetCredits.ts": 1,


### PR DESCRIPTION
## What was broken

`tests/unit/hard-session-lease-bypass-inventory.test.ts` failed on `release/v3.8.51` (and PR #11644's CI):

```
✖ hard-lease credential, executor, and connection-query inventory has no unclassified site
  +   'src/lib/tokenHealthCheck.ts': 2,
  -   'src/lib/tokenHealthCheck.ts': 1,
```

## Root cause

#11495 (`feat(providers): verify-only health sweep for web-cookie connections`) changed the sweep's connection query in `src/lib/tokenHealthCheck.ts`:

```diff
-    const connections = await getProviderConnections({ authType: "oauth" });
+      ...(await getProviderConnections({ authType: "oauth" })),
+      ...(await getProviderConnections({ authType: "cookie" })),
```

One call became two (oauth + cookie), but the frozen hard-lease connection-query inventory (which guards against unclassified credential/connection-query sites) still recorded 1.

## Fix

`tests/unit/hard-session-lease-bypass-inventory.test.ts` line 141: `"src/lib/tokenHealthCheck.ts": 1` → `2`, with a comment pointing at #11495. The file is already classified (class `C`); only the count changed.

## Green evidence (after)

```
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

Files: `tests/unit/hard-session-lease-bypass-inventory.test.ts`, `changelog.d/maintenance/11495-hard-lease-inventory-count.md`.