### PR TITLE
fix(dashboard): show the system prompt in Conversation Context for Responses-API requests

### DIFF
--- a/src/mitm/inspector/conversationNormalizer.ts
+++ b/src/mitm/inspector/conversationNormalizer.ts
@@ -322,7 +322,18 @@ export function buildRequestTurns(body: unknown): NormalizedTurn[] | null {
     return [{ role: "user", blocks: [{ type: "text", text: obj.input }] }];
   }
   if (Array.isArray(obj.input)) {
-    return turnsFromOpenAiMessages(obj.input);
+    // OpenAI Responses API requests carry the system prompt via top-level
+    // `instructions`, sibling to `input`, not as an `input` message — unlike
+    // `messages/system` (Chat Completions/Anthropic) or
+    // `contents/systemInstruction` (Gemini) handled above. Without this,
+    // the conversation view silently drops the system turn for every
+    // Responses-API request.
+    const turns: NormalizedTurn[] = [];
+    if (typeof obj.instructions === "string" && obj.instructions.length > 0) {
+      turns.push({ role: "system", blocks: [{ type: "text", text: obj.instructions }] });
+    }
+    turns.push(...turnsFromOpenAiMessages(obj.input));
+    return turns;
   }
 
   return null;

--- a/tests/unit/inspector-conversation-normalizer.test.ts
+++ b/tests/unit/inspector-conversation-normalizer.test.ts
@@ -165,6 +165,42 @@ test("normalizes Responses API reasoning items (no `role` field) into an assista
   assert.equal((conv.request[0].blocks[0] as { text: string }).text, "Thinking about the request.");
 });
 
+test("normalizes Responses API top-level `instructions` into a system turn", () => {
+  // The Responses API carries the system prompt via a top-level
+  // `instructions` string sibling to `input`, not as an `input` message
+  // (unlike Chat Completions' `messages`/`system` or Gemini's
+  // `contents`/`systemInstruction`, both handled above) — previously
+  // silently dropped, matching the `function_call`/`reasoning` gap fixed
+  // above.
+  const req = makeReq({
+    path: "/v1/responses",
+    requestBody: JSON.stringify({
+      instructions: "You are helpful.",
+      input: [{ role: "user", content: [{ type: "input_text", text: "Hello!" }] }],
+    }),
+  });
+  const conv = normalizeConversation(req);
+  assert.ok(conv);
+  assert.equal(conv.request.length, 2);
+  assert.equal(conv.request[0].role, "system");
+  assert.equal(conv.request[0].blocks[0].type, "text");
+  assert.equal((conv.request[0].blocks[0] as { text: string }).text, "You are helpful.");
+  assert.equal(conv.request[1].role, "user");
+});
+
+test("omits the system turn when Responses API `instructions` is absent", () => {
+  const req = makeReq({
+    path: "/v1/responses",
+    requestBody: JSON.stringify({
+      input: [{ role: "user", content: [{ type: "input_text", text: "Hello!" }] }],
+    }),
+  });
+  const conv = normalizeConversation(req);
+  assert.ok(conv);
+  assert.equal(conv.request.length, 1);
+  assert.equal(conv.request[0].role, "user");
+});
+
 test("normalizes Anthropic request with top-level system + tool_use response", () => {
   const req = makeReq({
     host: "api.anthropic.com",


### PR DESCRIPTION
## What Problem This Solves

The dashboard's Conversation Context panel (`RequestLoggerDetail.sections.tsx`'s `ConversationContextSection`, backed by `conversationNormalizer.ts`'s `buildRequestTurns`) silently dropped the system prompt for any OpenAI Responses API request whose system prompt travels via the top-level `instructions` field instead of an embedded `input` message. Readers were left with the raw JSON payload dump as the only way to see what was actually sent for that turn.

## Why This Change Was Made

`buildRequestTurns` already has dedicated handling for each API's system-prompt convention: `messages`/`system` for Chat Completions and Anthropic, `contents`/`systemInstruction` for Gemini. The Responses API branch (`Array.isArray(obj.input)`) had no equivalent — it only ever worked because callers historically embedded the system prompt as a `role: "system"/"developer"` message inside `input[0]`, which the generic message-role handling in `turnsFromOpenAiMessages` picked up incidentally.

Callers that instead send the system prompt via the top-level `instructions` field (sibling to `input`, not an `input` message — this is itself a real, correct usage of the Responses API; e.g. the native Codex/ChatGPT route has always used it) hit a gap: `instructions` was never read anywhere in this file, so the system turn was silently omitted with no error or fallback.

Fix: read `obj.instructions` alongside `obj.input` and emit it as a `system`-role turn, exactly mirroring the existing `systemTurnFromAnthropic` pattern.

## User Impact

- The Conversation Context panel now shows the actual system prompt for every Responses-API request, regardless of whether the caller embeds it in `input` or sends it via `instructions`.
- No change for requests that still embed the system prompt in `input[0]` — the existing message-role handling continues to work unchanged.

## Evidence

- New unit coverage in `tests/unit/inspector-conversation-normalizer.test.ts`: one test asserting `instructions` becomes a leading system turn, one asserting no system turn is emitted when `instructions` is absent (guards against always-inserting a turn).
- Ran the full `inspector-conversation-normalizer.test.ts` file (13/13 passing) in both the main checkout and a running dev environment.
- Verified against a real captured production request artifact (OpenClaw's Responses-API traffic through this OmniRoute instance): before the fix, `buildRequestTurns` dropped the system prompt entirely for this shape; after the fix, it correctly returns the system prompt as the first of 45 turns.
- Deployed live to this instance's `omniroute-dev` container via Turbopack HMR (no restart) and re-verified against the same real request artifact post-deploy.
