### PR TITLE
chore(search): drop unreachable credential sweep after #11642

### DIFF
--- a/src/lib/search/executeWebSearch.ts
+++ b/src/lib/search/executeWebSearch.ts
@@ -201,27 +201,7 @@ export async function executeWebSearch(
     }
 
     if (!credentials) {
-      // 1. Try credentialed providers first, sorted by cost. Fallback-only
-      // providers are reached only if no configured provider is available.
-      const sortedIds = Object.values(SEARCH_PROVIDERS)
-        .filter((provider) => !provider.fallbackOnly && supportsSearchType(provider, searchType))
-        .sort((a, b) => a.costPerQuery - b.costPerQuery)
-        .map((provider) => provider.id);
-
-      for (const providerId of sortedIds) {
-        if (providerId === providerConfig.id) continue;
-        const altConfig = getSearchProvider(providerId);
-        const altCreds = await resolveSearchCredentials(providerId);
-        if (altConfig && altCreds) {
-          providerConfig = altConfig;
-          credentials = altCreds;
-          break;
-        }
-      }
-    }
-
-    if (!credentials) {
-      // 2. Last resort: fallback-only providers so out-of-the-box search
+      // Last resort: fallback-only providers so out-of-the-box search
       // still works when no credentialed provider is configured.
       const fallbackProviders = Object.values(SEARCH_PROVIDERS)
         .filter((provider) => provider.fallbackOnly && supportsSearchType(provider, searchType))


### PR DESCRIPTION
### Summary

Follow-up cleanup for #11642.

`/merge-batch` resolved the conflict between #11565 and #11642 (both fixing #11524) by keeping both fixes. The merged result walks non-fallback providers by cost in the auto-select loop, and then — if that found no credentials — walks the exact same provider set again with the same filters in a second sweep.

That second sweep can only run when the first one concluded that no non-fallback provider has credentials. Re-scanning the same set then returns nothing by construction, so the block is unreachable in effect: it either finds nothing, or re-does work the first loop already did.

### Changes
- Removes the step-1 credential sweep (and renumbers the last-resort comment) in `src/lib/search/executeWebSearch.ts`. `getSearchProvider` stays: the execution-time failover loop still uses it.

### Test Plan
- `tests/unit/execute-web-search-fallback-11524.test.ts`: 1/1 pass (the #11565 regression test — proves configured-paid-over-fallback still holds with the sweep gone).
- `tests/integration/skills-pipeline.test.ts`: 19/19 pass (includes both #11642 regression tests for serper-search auto-select in the /v1/responses path).
- `tests/unit/credential-health-search-providers.test.ts`: 4/4 pass.
- `npm run typecheck:core` clean.

No behavior change: the last-resort fallback-only step and the no-credentials error path are untouched.

Refs #11524