### PR TITLE
feat(models): reactive discovery sync after Antigravity model-not-found 404

### DIFF
--- a/open-sse/executors/antigravity/executeAttempt.ts
+++ b/open-sse/executors/antigravity/executeAttempt.ts
@@ -8,6 +8,7 @@
 import { mergeAbortSignals, type ExecutorLog } from "../base.ts";
 import { applyFingerprint, isCliCompatEnabled } from "../../config/cliFingerprints.ts";
 import { buildAntigravityUpstreamError } from "../antigravityUpstreamError.ts";
+import { maybeTriggerReactiveModelSync } from "@/lib/providerModels/reactiveModelSync.ts";
 import {
   HTTP_STATUS,
   STREAM_READINESS_TIMEOUT_MS,
@@ -383,6 +384,13 @@ export async function sendAntigravityRequest(
       "TELEMETRY",
       `[Antigravity] Error Response - URL: ${url}, Status: ${response.status}, Model: ${model}`
     );
+    if (response.status === HTTP_STATUS.NOT_FOUND) {
+      // The backend may have shipped/renamed models the synced catalog does not
+      // know yet (pinned-catalog staleness). Kick a discovery sync for this
+      // connection so the fresh list lands in the synced catalog and the next
+      // request can resolve. Cooldown + in-flight dedup live in the trigger.
+      maybeTriggerReactiveModelSync(provider, credentials.connectionId);
+    }
   }
 
   return { response, finalHeaders };

--- a/src/lib/providerModels/reactiveModelSync.ts
+++ b/src/lib/providerModels/reactiveModelSync.ts
@@ -1,0 +1,87 @@
+/**
+ * Reactive model sync — the self-healing half of pinned-catalog staleness.
+ *
+ * Curated model catalogs are frozen snapshots; when the upstream backend
+ * ships (or renames) a model, requests for it 404 upstream until somebody
+ * re-freezes the catalog by hand (Gemini 3.7 Flash on Antigravity, zai-web
+ * #7678, Claude Opus 4.8 #2979). The Antigravity executor calls
+ * maybeTriggerReactiveModelSync() on a model-not-found 404: this runs the
+ * existing discovery sync for that connection (loopback sync-models), so the
+ * fresh model list lands in the synced catalog and the next request resolves.
+ *
+ * Guardrails: provider allow-list, per-connection cooldown, in-flight dedup —
+ * a burst of 404s triggers at most one sync per connection per window. The
+ * sync is fire-and-forget; failures only log (the scheduled auto-sync cycle
+ * stays the backstop).
+ */
+
+import {
+  getModelSyncInternalBaseUrl,
+  syncConnectionModels,
+} from "@/shared/services/modelSyncScheduler";
+
+/** Providers whose connections support live model discovery. Extend as other
+ * discovery-capable providers get wired to the reactive trigger. */
+const REACTIVE_SYNC_PROVIDERS = new Set<string>(["antigravity", "agy"]);
+
+/** Minimum interval between two reactive syncs for the same connection. */
+const REACTIVE_SYNC_COOLDOWN_MS = 10 * 60 * 1000;
+let cooldownMs = REACTIVE_SYNC_COOLDOWN_MS;
+
+const lastTriggerAt = new Map<string, number>();
+const inFlight = new Set<string>();
+
+type SyncFn = (connectionId: string, provider: string, baseUrl: string) => Promise<boolean>;
+const defaultSyncFn: SyncFn = (connectionId, provider, baseUrl) =>
+  syncConnectionModels(connectionId, provider, baseUrl);
+let syncFn: SyncFn = defaultSyncFn;
+
+/**
+ * Kick a discovery sync for the connection if the provider supports discovery
+ * and the connection is not cooling down / already syncing. Returns true when
+ * a sync was scheduled (fire-and-forget), false when the call was a no-op.
+ */
+export function maybeTriggerReactiveModelSync(provider: string, connectionId: string): boolean {
+  const providerId = provider.trim().toLowerCase();
+  const connection = connectionId.trim();
+  if (!REACTIVE_SYNC_PROVIDERS.has(providerId) || !connection) return false;
+
+  const key = `${providerId}:${connection}`;
+  const now = Date.now();
+  const last = lastTriggerAt.get(key);
+  if (last !== undefined && now - last < cooldownMs) return false;
+  if (inFlight.has(key)) return false;
+
+  lastTriggerAt.set(key, now);
+  inFlight.add(key);
+  void (async () => {
+    try {
+      const ok = await syncFn(connection, providerId, getModelSyncInternalBaseUrl());
+      console.log(
+        `[ReactiveModelSync] ${providerId} (${connection.slice(0, 8)}): discovery sync ${
+          ok ? "succeeded" : "failed"
+        } after upstream model-not-found`
+      );
+    } catch (err) {
+      console.warn(
+        `[ReactiveModelSync] ${providerId} (${connection.slice(0, 8)}): sync error —`,
+        (err as Error).message
+      );
+    } finally {
+      inFlight.delete(key);
+    }
+  })();
+  return true;
+}
+
+/** Test helper: swap the sync implementation (null restores the loopback sync). */
+export function __setReactiveSyncFnForTests(fn: SyncFn | null): void {
+  syncFn = fn ?? defaultSyncFn;
+}
+
+/** Test helper: clear cooldown/in-flight state and optionally shrink the cooldown. */
+export function __resetReactiveModelSyncForTests(testCooldownMs?: number): void {
+  lastTriggerAt.clear();
+  inFlight.clear();
+  cooldownMs = typeof testCooldownMs === "number" ? testCooldownMs : REACTIVE_SYNC_COOLDOWN_MS;
+}

--- a/src/shared/services/modelSyncScheduler.ts
+++ b/src/shared/services/modelSyncScheduler.ts
@@ -182,8 +182,12 @@ async function getAutoSyncConnections(): Promise<
 
 /**
  * Sync models for a single connection via the internal sync-models endpoint.
+ *
+ * Shared by the scheduled auto-sync cycle and the reactive trigger
+ * (src/lib/providerModels/reactiveModelSync.ts) that runs a discovery sync
+ * after an upstream model-not-found 404.
  */
-async function syncConnectionModels(
+export async function syncConnectionModels(
   connectionId: string,
   provider: string,
   baseUrl: string

--- a/tests/unit/reactive-model-sync.test.ts
+++ b/tests/unit/reactive-model-sync.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Reactive model sync — a model-not-found 404 on a discovery-capable provider
+ * kicks a discovery sync for that connection so freshly shipped upstream
+ * models land in the synced catalog (pinned-catalog staleness self-heal).
+ * Guardrails under test: provider allow-list, per-connection cooldown,
+ * in-flight dedup.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  maybeTriggerReactiveModelSync,
+  __resetReactiveModelSyncForTests,
+  __setReactiveSyncFnForTests,
+} = await import("../../src/lib/providerModels/reactiveModelSync.ts");
+
+type SyncCall = { connectionId: string; provider: string; baseUrl: string };
+
+function installCountingSync() {
+  const calls: SyncCall[] = [];
+  __setReactiveSyncFnForTests(async (connectionId, provider, baseUrl) => {
+    calls.push({ connectionId, provider, baseUrl });
+    return true;
+  });
+  return calls;
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("allowed provider triggers a discovery sync with the right arguments", async () => {
+  __resetReactiveModelSyncForTests();
+  const calls = installCountingSync();
+
+  const triggered = maybeTriggerReactiveModelSync("antigravity", "conn-aaa-111");
+  assert.equal(triggered, true);
+  await flushMicrotasks();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].connectionId, "conn-aaa-111");
+  assert.equal(calls[0].provider, "antigravity");
+  assert.equal(typeof calls[0].baseUrl, "string");
+});
+
+test("agy provider id is also allowed and normalized", async () => {
+  __resetReactiveModelSyncForTests();
+  const calls = installCountingSync();
+
+  assert.equal(maybeTriggerReactiveModelSync("AGY ", "conn-bbb-222"), true);
+  await flushMicrotasks();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].provider, "agy");
+});
+
+test("providers without discovery support never trigger", async () => {
+  __resetReactiveModelSyncForTests();
+  const calls = installCountingSync();
+
+  assert.equal(maybeTriggerReactiveModelSync("openai", "conn-ccc-333"), false);
+  assert.equal(maybeTriggerReactiveModelSync("", "conn-ccc-333"), false);
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "  "), false);
+  await flushMicrotasks();
+  assert.equal(calls.length, 0);
+});
+
+test("second trigger inside the cooldown window is a no-op", async () => {
+  __resetReactiveModelSyncForTests();
+  const calls = installCountingSync();
+
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-ddd-444"), true);
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-ddd-444"), false);
+  await flushMicrotasks();
+  assert.equal(calls.length, 1);
+});
+
+test("cooldown is per connection — a different connection still triggers", async () => {
+  __resetReactiveModelSyncForTests();
+  const calls = installCountingSync();
+
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-eee-555"), true);
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-fff-666"), true);
+  await flushMicrotasks();
+  assert.equal(calls.length, 2);
+});
+
+test("trigger is allowed again once the cooldown expires", async () => {
+  __resetReactiveModelSyncForTests(1); // 1ms cooldown
+  const calls = installCountingSync();
+
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-ggg-777"), true);
+  await flushMicrotasks();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-ggg-777"), true);
+  await flushMicrotasks();
+  assert.equal(calls.length, 2);
+});
+
+test("in-flight dedup: concurrent triggers collapse into one sync", async () => {
+  __resetReactiveModelSyncForTests();
+  let releaseSync: ((value: boolean) => void) | null = null;
+  const calls: SyncCall[] = [];
+  __setReactiveSyncFnForTests(
+    (connectionId, provider, baseUrl) =>
+      new Promise<boolean>((resolve) => {
+        calls.push({ connectionId, provider, baseUrl });
+        releaseSync = resolve;
+      })
+  );
+
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-hhh-888"), true);
+  // First sync still pending — the second trigger must be dropped, not queued.
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-hhh-888"), false);
+  assert.equal(calls.length, 1);
+
+  assert.ok(releaseSync);
+  releaseSync(true);
+  await flushMicrotasks();
+  assert.equal(calls.length, 1);
+});
+
+test("a sync failure does not break subsequent triggers after cooldown", async () => {
+  __resetReactiveModelSyncForTests(1);
+  let attempts = 0;
+  __setReactiveSyncFnForTests(async () => {
+    attempts += 1;
+    return false; // sync endpoint reported failure
+  });
+
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-iii-999"), true);
+  await flushMicrotasks();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(maybeTriggerReactiveModelSync("antigravity", "conn-iii-999"), true);
+  await flushMicrotasks();
+  assert.equal(attempts, 2);
+});
+
+test("cleanup restores the default loopback sync implementation", () => {
+  __setReactiveSyncFnForTests(null);
+  __resetReactiveModelSyncForTests();
+  assert.ok(true);
+});


### PR DESCRIPTION
## Summary

Pinned model catalogs go stale the moment the upstream backend ships or renames a model — Gemini 3.7 Flash on Antigravity (this cycle), zai-web (#7678), Claude Opus 4.8 (#2979). Requests 404 upstream until somebody re-freezes the catalog by hand. The 404 itself is the most precise trigger available, so this PR makes it self-healing for the Antigravity family:

- new src/lib/providerModels/reactiveModelSync.ts — on a model-not-found 404 the Antigravity executor kicks a discovery sync for that connection via the existing per-connection loopback sync (discovery → synced AvailableModels store). The fresh list lands in the synced catalog, so the next request resolves and /v1/models self-heals on the same path
- guardrails: provider allow-list (antigravity/agy), 10-minute per-connection cooldown, in-flight dedup; fire-and-forget with log-only failures — the scheduled auto-sync cycle (#488) stays the backstop
- syncConnectionModels is exported from modelSyncScheduler so the scheduled cycle and the reactive trigger share one loopback implementation

This is the smallest reactive slice of the accepted direction in #2979 (background discovery/sync). Extending to other discovery-capable providers is a matter of growing the allow-list.

## Related Issues

- Related to #2979 (accepted background discovery/sync direction)
- Related to #488 (model auto-sync scheduler), #8123 (live AGY discovery), #7678 (same staleness failure mode)

## Validation

- [x] Change type: provider
- [x] Focused tests: node --import tsx/esm --test tests/unit/reactive-model-sync.test.ts → 9/9 pass
- [x] Regression: model-sync-scheduler, model-sync-route, model-sync-custom-preservation, antigravity-streaming-error-body-sanitized-2461, repro-antigravity-404-family-cooldown-hijack → 33/33 pass
- [x] npx eslint clean on new/changed files (note: modelSyncScheduler.ts carries one pre-existing no-restricted-imports error on its untouched localDb import — part of the frozen CI error set, not introduced here)
- [x] node scripts/check/check-file-size.mjs → OK
- [x] Reconciled with current main (v3.8.50)
- [x] Production-code changes include new automated tests in this PR

## Tests Added Or Updated

- tests/unit/reactive-model-sync.test.ts (new, 9 tests): trigger fires with correct args; agy id normalization; allow-list rejection; cooldown window no-op; per-connection isolation; cooldown expiry re-trigger; in-flight dedup under a held sync promise; failure tolerance after cooldown; test-helper restore.

## Coverage Notes

New module fully covered by the new test file (injected sync fn — no experimental mock flags needed). The executeAttempt wiring is the 404 branch only; behavior verified via the antigravity error-path regression tests above.

## Reviewer Notes

- Trigger point: sendAntigravityRequest's non-ok branch, status 404 only (model-not-found class). Other statuses untouched.
- Loopback sync reuses the scheduler's internal-auth fetch — no new auth surface.
- Worst case under a 404 storm: one sync per connection per 10 minutes.
- The synced-catalog merge for agy/antigravity already exists in the /v1/models builder (they are not curated-only providers), so no catalog-side change was needed.
