### PR TITLE
fix(ddgw): normaliza system no upstream da release v3.8.51

### DIFF
--- a/open-sse/executors/duckduckgo-web.ts
+++ b/open-sse/executors/duckduckgo-web.ts
@@ -463,17 +463,7 @@ export class DuckDuckGoWebExecutor extends BaseExecutor {
       bodyObj,
       rawMessages
     );
-    // #ddgw defense-in-depth: duckchat/v1/chat accepts only user/assistant roles.
-    // The request translator already folds system/developer for this provider
-    // (roleNormalizer), but anything that reintroduces them after translation —
-    // e.g. prepareToolMessages' injected tool prompt — must be folded here too,
-    // right before the upstream POST. Passing the provider id keeps the fold
-    // active even if the capability catalog ever drops this provider.
-    const messages = normalizeSystemRole(
-      effectiveMessages,
-      "duckduckgo-web",
-      upstreamModel
-    ) as typeof effectiveMessages;
+    const messages = effectiveMessages;
     const isStreaming = stream !== false;
     const upstreamHeaders = upstreamExtraHeaders || {};
 
@@ -570,8 +560,17 @@ export class DuckDuckGoWebExecutor extends BaseExecutor {
         }
       }
 
+      // #ddgw defense-in-depth: duckchat/v1/chat accepts only user/assistant roles.
+      // Normalize after catalog resolution so the effective upstream model is used.
+      // This also shields the system tool prompt injected by prepareToolMessages.
+      const normalizedMessages = normalizeSystemRole(
+        messages,
+        "duckduckgo-web",
+        upstreamModel
+      ) as typeof messages;
+
       const sendChat = async (vqdHeaders: DuckDuckGoAuthHeaders): Promise<Response> => {
-        const payload = buildDuckDuckGoPayload(upstreamModel, messages);
+        const payload = buildDuckDuckGoPayload(upstreamModel, normalizedMessages);
         const response = await fetch(CHAT_URL, {
           method: "POST",
           headers: mergeHeadersCaseInsensitive(
@@ -797,10 +796,7 @@ export class DuckDuckGoWebExecutor extends BaseExecutor {
           try {
             return {
               vqd4: retry.vqd4,
-              vqdHash1: await solveDuckDuckGoChallenge(
-                retry.vqdHash1,
-                FAKE_HEADERS["User-Agent"]
-              ),
+              vqdHash1: await solveDuckDuckGoChallenge(retry.vqdHash1, FAKE_HEADERS["User-Agent"]),
               status: retry.status,
               retryAfter: retry.retryAfter,
             };

--- a/open-sse/executors/duckduckgo-web.ts
+++ b/open-sse/executors/duckduckgo-web.ts
@@ -16,6 +16,7 @@ import { prepareToolMessages, buildToolAwareResult } from "../translator/webTool
 import type { Session } from "../services/sessionPool/session.ts";
 import { tryBackedChat } from "../services/browserBackedChat.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
+import { normalizeSystemRole } from "../services/roleNormalizer.ts";
 
 // Issue #6999: Lightweight circuit breaker for the DuckDuckGo executor.
 // After CB_THRESHOLD consecutive failures (429, 5xx, or network errors),
@@ -462,7 +463,17 @@ export class DuckDuckGoWebExecutor extends BaseExecutor {
       bodyObj,
       rawMessages
     );
-    const messages = effectiveMessages;
+    // #ddgw defense-in-depth: duckchat/v1/chat accepts only user/assistant roles.
+    // The request translator already folds system/developer for this provider
+    // (roleNormalizer), but anything that reintroduces them after translation —
+    // e.g. prepareToolMessages' injected tool prompt — must be folded here too,
+    // right before the upstream POST. Passing the provider id keeps the fold
+    // active even if the capability catalog ever drops this provider.
+    const messages = normalizeSystemRole(
+      effectiveMessages,
+      "duckduckgo-web",
+      upstreamModel
+    ) as typeof effectiveMessages;
     const isStreaming = stream !== false;
     const upstreamHeaders = upstreamExtraHeaders || {};
 

--- a/open-sse/services/roleNormalizer.ts
+++ b/open-sse/services/roleNormalizer.ts
@@ -23,6 +23,11 @@ const PROVIDERS_WITHOUT_SYSTEM_ROLE = new Set([
   // Known to reject system role (from troubleshooting report)
   // GLM uses Claude format, so this is handled through claude translator
   // But if accessed through OpenAI-format providers like nvidia, it needs this:
+  // DuckDuckGo duck.ai (duckchat/v1/chat) accepts only user/assistant roles — a
+  // system/developer message yields 400 ERR_BAD_REQUEST (#ddgw). Registry id +
+  // alias are both listed because either may arrive as the routing provider id.
+  "duckduckgo-web",
+  "ddgw",
 ]);
 
 /**

--- a/tests/unit/duckduckgo-web-executor.test.ts
+++ b/tests/unit/duckduckgo-web-executor.test.ts
@@ -1,9 +1,10 @@
-import { describe, it } from "node:test";
+import { describe, it, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import { FETCH_TIMEOUT_MS } from "../../open-sse/config/constants.ts";
 import {
   DuckDuckGoWebExecutor,
   DUCKDUCKGO_BASE,
+  CHAT_URL,
   normalizeDuckDuckGoMessages,
   STATUS_URL,
 } from "../../open-sse/executors/duckduckgo-web.ts";
@@ -228,6 +229,122 @@ describe("DuckDuckGoWebExecutor", () => {
       const body = await response.json();
       assert.ok(body.error, "error response should have error object");
       assert.ok(body.error.message, "error should have message");
+    });
+  });
+
+  describe("system-role shielding (#ddgw)", () => {
+    type ExecuteArgs = Parameters<DuckDuckGoWebExecutor["execute"]>[0];
+    // duck.ai's duckchat/v1/chat rejects role:"system" with 400 ERR_BAD_REQUEST.
+    // The translator-side normalizer folds system/developer into the first user
+    // message; this shield guarantees the executor never forwards such roles
+    // upstream even when a future bypass reintroduces them after translation
+    // (e.g. prepareToolMessages' injected tool prompt).
+    function mockDuckChat(t: TestContext, capturedBodies: unknown[]): void {
+      t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (method === "GET" && url === STATUS_URL) {
+          return new Response(null, {
+            status: 200,
+            headers: { "x-vqd-4": "test-vqd-4" },
+          });
+        }
+        if (method === "POST" && url === CHAT_URL) {
+          capturedBodies.push(JSON.parse(String(init?.body)));
+          return new Response('data: {"message":"OK"}\n\ndata: [DONE]\n\n', {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        }
+        // warmSession + country/token fetches tolerate empty 2xx responses.
+        return new Response(null, { status: 200 });
+      });
+    }
+
+    it("folds a leading system message into the first user message before the upstream POST", async (t) => {
+      const captured: unknown[] = [];
+      mockDuckChat(t, captured);
+
+      await new DuckDuckGoWebExecutor().execute({
+        model: "gpt-5.4-nano",
+        body: {
+          messages: [
+            { role: "system", content: "You are a helpful assistant." },
+            { role: "user", content: "Reply with OK" },
+          ],
+        },
+        stream: false,
+      } as unknown as ExecuteArgs);
+
+      assert.equal(captured.length, 1, "chat POST should be captured");
+      const upstreamMessages = (captured[0] as { messages: Array<{ role: string }> }).messages;
+      const roles = upstreamMessages.map((m) => m.role);
+      assert.equal(
+        roles.some((r) => r === "system" || r === "developer"),
+        false,
+        "no system/developer role may reach the upstream payload"
+      );
+      assert.deepEqual(roles, ["user"]);
+      assert.match(
+        String((upstreamMessages[0] as { content: string }).content),
+        /^\[System Instructions\]\n/
+      );
+    });
+
+    it("preserves plain user/assistant conversations untouched", async (t) => {
+      const captured: unknown[] = [];
+      mockDuckChat(t, captured);
+
+      await new DuckDuckGoWebExecutor().execute({
+        model: "gpt-5.4-nano",
+        body: {
+          messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "hello" },
+            { role: "user", content: "bye" },
+          ],
+        },
+        stream: false,
+      } as unknown as ExecuteArgs);
+
+      const upstream = (captured[0] as { messages: Array<{ role: string; content: string }> })
+        .messages;
+      assert.deepEqual(
+        upstream.map((m) => [m.role, m.content]),
+        [
+          ["user", "hi"],
+          ["assistant", "hello"],
+          ["user", "bye"],
+        ]
+      );
+    });
+
+    it("shields the executor-injected tool prompt system message too", async (t) => {
+      const captured: unknown[] = [];
+      mockDuckChat(t, captured);
+
+      await new DuckDuckGoWebExecutor().execute({
+        model: "grole",
+        body: {
+          messages: [{ role: "user", content: "list files" }],
+          tools: [
+            {
+              type: "function",
+              function: { name: "list_files", description: "lists files", parameters: {} },
+            },
+          ],
+        },
+        stream: false,
+      } as unknown as ExecuteArgs);
+
+      const upstream = (captured[0] as { messages: Array<{ role: string; content: string }> })
+        .messages;
+      assert.equal(
+        upstream.some((m) => m.role === "system" || m.role === "developer"),
+        false,
+        "the tool-prompt system message must be folded before dispatch"
+      );
+      assert.match(String(upstream.at(-1)?.content), /list_files/);
     });
   });
 

--- a/tests/unit/role-normalizer.test.ts
+++ b/tests/unit/role-normalizer.test.ts
@@ -110,9 +110,7 @@ test("normalizeSystemRole still strips the system role for pre-5.1 GLM and bare 
     { role: "system", content: "policy" },
     { role: "user", content: "ok" },
   ];
-  const merged = [
-    { role: "user", content: "[System Instructions]\npolicy\n\n[User Message]\nok" },
-  ];
+  const merged = [{ role: "user", content: "[System Instructions]\npolicy\n\n[User Message]\nok" }];
   for (const model of ["glm", "glm-4.7", "glm-5", "glm-5-turbo", "glm-5.0", "glm-5.0-turbo"]) {
     assert.deepEqual(
       normalizeSystemRole(messages, "openai", model),
@@ -184,6 +182,44 @@ test("normalizeRoles composes model, developer and system normalization in order
     },
     { role: "", content: "empty role should survive" },
   ]);
+});
+
+test("normalizeSystemRole folds system/developer into the first user message for DuckDuckGo duck.ai providers (#ddgw)", () => {
+  // duckchat/v1/chat accepts only user/assistant — a system/developer message
+  // yields 400 ERR_BAD_REQUEST. Both the registry id and its alias must fold.
+  const messages = [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "Reply with OK" },
+  ];
+  for (const provider of ["duckduckgo-web", "ddgw"]) {
+    const result = normalizeSystemRole(messages, provider, "gpt-5.4-nano");
+    assert.deepEqual(
+      result,
+      [
+        {
+          role: "user",
+          content:
+            "[System Instructions]\nYou are a helpful assistant.\n\n[User Message]\nReply with OK",
+        },
+      ],
+      `expected system folded for provider ${provider}`
+    );
+  }
+});
+
+test("normalizeRoles keeps folding for every current duck.ai wire model via the ddgw alias (#ddgw)", () => {
+  const messages = [
+    { role: "developer", content: "policy" },
+    { role: "user", content: "hello" },
+  ];
+  for (const model of ["gpt-5.4-mini", "gpt-5.4-nano", "claude-haiku-4-5", "mistral-small-2603"]) {
+    const result = normalizeRoles(messages, "ddgw", model, "openai");
+    assert.deepEqual(
+      result,
+      [{ role: "user", content: "[System Instructions]\npolicy\n\n[User Message]\nhello" }],
+      `expected developer folded for ${model}`
+    );
+  }
 });
 
 test("role normalization returns non-arrays unchanged", () => {


### PR DESCRIPTION
## Resumo

Corrige o HTTP 400 determinístico do executor DuckDuckGo Web quando o payload contém mensagens `system` ou `developer`.

## Causa-raiz

O endpoint DDGW `duckchat/v1/chat` aceita somente os papéis `user` e `assistant`. Mensagens `system`/`developer` eram repassadas ao upstream e retornavam `400 ERR_BAD_REQUEST`.

## Implementação

- registra `duckduckgo-web` e o alias `ddgw` no normalizador geral de providers sem suporte a `system`;
- aplica blindagem adicional depois de `prepareToolMessages`, cobrindo também o tool prompt injetado;
- adapta o port da release ativa para normalizar somente após a resolução do catálogo vivo, usando o `upstreamModel` efetivo no payload.

## Port para a release ativa

- base inicial do port: `91aeca04402afa4d29ad7061928ce8193fc7ba9d` (`release/v3.8.51`);
- cherry-pick rastreável: `836ceddaa9cc6e1de05485112f88b5624da5f22a`;
- adaptação de compatibilidade: `119ea910c6cfee129596ada55144a333e0a6950c`.

O diff contém exatamente quatro arquivos:

1. `open-sse/executors/duckduckgo-web.ts`
2. `open-sse/services/roleNormalizer.ts`
3. `tests/unit/duckduckgo-web-executor.test.ts`
4. `tests/unit/role-normalizer.test.ts`

## Evidências

- RED original: regressões de normalização falhavam antes da implementação;
- GREEN na release ativa: **35/35 testes focados**, 0 falhas;
- `npm run typecheck:core`: exit 0;
- `git diff --check`: limpo;
- lint oficial: **BASE_RED_INHERITED**, reproduzido na base exata e registrado em #11449 (`There are suppressions left that do not occur anymore`).

### Smoke

- o commit original na linha v3.8.50 teve smoke isolado verde: payload `role:"system"` retornou HTTP 200 e Hermes → gateway respondeu `ONLINE-OK`;
- **não há alegação de smoke local verde para v3.8.51**;
- o smoke local da release ativa não foi executado integralmente porque `better-sqlite3`, optionalDependency, foi omitido pelo npm 12;
- tentativas ambientais documentadas: npm 12 (`better-sqlite3` omitido), `npm approve-scripts better-sqlite3` (`ENOMATCH`) e npm 10 efêmero (`EUSAGE`, lockfile incompatível para `npm ci`).

Este Draft PR solicita que o CI valide build e testes em ambiente limpo.

## Governança

- release ativa: `release/v3.8.51`;
- freeze histórica de `release/v3.8.50`: #11439 (atualmente fechada);
- ⚠️ base-red inherited: #11449;
- nenhum merge solicitado neste momento.
