### PR TITLE
docs(dedup): correct the CodeQL claim on the tenant-namespace comment

### DIFF
--- a/open-sse/services/requestDedup.ts
+++ b/open-sse/services/requestDedup.ts
@@ -141,8 +141,16 @@ function extractSystemContent(body: Record<string, unknown>): unknown {
  *
  * It is a PLAINTEXT prefix rather than digest input, matching
  * `semanticCache.generateSignature` (#3740): the id is an internal namespace
- * key, not a credential, and keeping it out of the digest avoids the
- * false-positive CodeQL js/insufficient-password-hash on a cache/dedup key.
+ * key, not a credential, and a namespace you can read off the key is worth more
+ * than one you cannot when debugging a dedup collision.
+ *
+ * It does NOT dodge the CodeQL js/insufficient-password-hash false positive,
+ * which the #3740 comment claims for its own version and which this comment
+ * claimed too until alert #874 was raised on the `createHash` below anyway.
+ * Once an API-key-derived value reaches this file at all, the query flags the
+ * sibling digest regardless of what actually goes into it. Dismissed per HR#14;
+ * expect it to come back on any edit here, and do not "fix" it with a KDF —
+ * that would break the determinism dedup depends on.
  *
  * Omitting `tenantId` keeps the un-namespaced hash. Keyless local-first
  * deployments have no tenant boundary to preserve, and every such install would


### PR DESCRIPTION
Comment-only correction to something I got wrong in #11649.

That PR's comment said keeping the API key id out of the digest "avoids the false-positive CodeQL `js/insufficient-password-hash` on a cache/dedup key". It does not.

CodeQL raised **alert #874** on the `createHash` in that very function on the first scan after the merge. Once an API-key-derived value reaches the file at all, the query flags the sibling digest regardless of what actually goes into it — the plaintext prefix buys nothing here.

The design itself stands: a namespace you can read off the key beats one you cannot when debugging a dedup collision, and it matches `semanticCache.generateSignature` (#3740) — whose comment, for the record, makes the same incorrect claim about that query.

But a rationale that is measurably false is worse than no rationale. The next person edits this function, sees the alert the comment promised would not happen, and ends up doubting the design instead of the comment.

Replaced with what actually holds, plus the two things worth knowing next time:

- the alert is dismissed per HR#14 and **will** come back on any edit here;
- it must not be "fixed" with a KDF — that would break the determinism dedup depends on.

No behaviour change. `request-dedup-tenant-isolation` + `request-dedup-10249` — 15/15. `prettier --check` clean.

Targets `release/v3.8.51` (`release/v3.8.50` is frozen, #11439).
