### PR TITLE
docs(changelog): v3.8.50 stats, top-25 ranking and a .mailmap that repairs a misattributed identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,40 @@
+# .mailmap — canonical author identities for git log/shortlog/blame.
+#
+# Why this file exists: between 2026-08-13 and 2026-08-26 this checkout carried a
+# `git config --local` whose user.name was one contributor's ("Xiangzhe" / @xz-dev)
+# and whose user.email was ANOTHER contributor's (@backryun). Every commit produced
+# on this machine in that window was therefore signed with @backryun's address —
+# 237 commits, all in the -0300 timezone, while @backryun's own work commits from
+# +0900 and continued normally throughout. The local override was removed on
+# 2026-08-26; this file repairs the RECORD without rewriting published history
+# (those commits live on release/v3.8.50 and release/v3.8.51, which other sessions
+# and open PRs build on — a rewrite would force-push both and orphan the v3.8.50 tag).
+#
+# Format: Canonical Name <canonical@email> Commit Name <commit@email>
+
+# --- Maintainer: several addresses used over the project's life ---
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <diegosouza.pw@gmail.com>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <diegosouza.pw@outlook.com>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <diegosouzapw@users.noreply.github.com>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> Diego Rodrigues de Sa e Souza <8016841+diegosouzapw@users.noreply.github.com>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> Diego Souza <8016841+diegosouzapw@users.noreply.github.com>
+
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <diego.souza.pw@gmail.com>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <souzamiriamrodrigues790@gmail.com>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <diego.souza@cdwasolutions.com.br>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> <diegosouzapw@devbox.local>
+
+# --- The misattribution window: name Xiangzhe + @backryun's email, from -0300.
+# These are maintainer/session commits, NOT @backryun's contributions.
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> Xiangzhe <bakryun0718@proton.me>
+diegosouzapw <8016841+diegosouzapw@users.noreply.github.com> Xiangzhe <diegosouza.pw@gmail.com>
+
+# --- Xiangzhe (@xz-dev) — a distinct contributor; keep their own work intact ---
+Xiangzhe <32761048+xz-dev@users.noreply.github.com> <xz-dev@users.noreply.github.com>
+Xiangzhe <32761048+xz-dev@users.noreply.github.com> <xiangzhedev@gmail.com>
+
+# --- @backryun's own alternate addresses (their real work, kept intact) ---
+backryun <24198422+backryun@users.noreply.github.com> <bakryun0718@proton.me>
+backryun <24198422+backryun@users.noreply.github.com> <backryun@daonlab.local>
+backryun <24198422+backryun@users.noreply.github.com> <busan011@ormbiz.co.kr>
+backryun <24198422+backryun@users.noreply.github.com> <backryun@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,67 @@
 
 _Living section — regenerated 2026-08-12 from all cycle commits (cycle open `ed2db6cb19` → tip). Bullets carry the merged PR and its author; direct pushes listed separately._
 
+### 📊 Release by the numbers
+
+| | |
+| --- | ---: |
+| 👥 People who contributed | **248** |
+| 📝 Commits in the cycle | **1,714** |
+| 🔀 Pull requests referenced | **1,666** |
+| 📋 Changelog entries | **1,182** |
+| 🙌 Contributors credited in entries | **256** |
+| 🤖 Automated dependency commits | 22 |
+
+**Entries by type**
+
+| Type | Count |
+| --- | ---: |
+| 🐛 Fixes | 779 |
+| ✨ Features | 169 |
+| 📚 Docs | 29 |
+| 🧹 Chore | 27 |
+| 🧪 Tests | 15 |
+| ♻️ Refactor | 5 |
+| ⚡ Performance | 3 |
+| providers | 2 |
+| 🔒 Security | 2 |
+| ⚙️ CI | 2 |
+| deps | 2 |
+| maint | 2 |
+
+### 🏆 Top 25 contributors this cycle
+
+_By commits in `ed2db6cb19..v3.8.50`, author identities consolidated via `.mailmap`. Bots excluded._
+
+| # | Contributor | Commits |
+| ---: | --- | ---: |
+| 🥇 | diegosouzapw | 738 |
+| 🥈 | backryun | 88 |
+| 🥉 | Dizzle | 66 |
+| 4 | Ravi Tharuma | 52 |
+| 5 | Markus Hartung | 48 |
+| 6 | Bob.Hou | 42 |
+| 7 | Rouzbeh† | 38 |
+| 8 | Xiangzhe | 31 |
+| 9 | Paco Cartones | 28 |
+| 10 | Nguyen Thanh Dat | 23 |
+| 11 | Aman | 22 |
+| 12 | Will Gordon | 19 |
+| 13 | 小妍儿 ✨ | 17 |
+| 14 | adevwithpurpose | 16 |
+| 15 | Andrew B. | 10 |
+| 16 | NOXX - Commiter | 10 |
+| 17 | ignamiranda | 10 |
+| 18 | Jonathan Bailey | 9 |
+| 19 | Ke Jin | 9 |
+| 20 | Austin Liu | 8 |
+| 21 | Chewji | 8 |
+| 22 | Prudhvi Vuda | 7 |
+| 23 | benzntech | 7 |
+| 24 | rinseaid | 7 |
+| 25 | stanley | 7 |
+
+
 ### ✨ New Features
 - **feat(search):** first-class X Search provider (`x-search`) on `POST /v1/search` and MCP `omniroute_x_search` using SuperGrok / xAI server-side `x_search`. Explicit provider or `search_type: "x"` only — never auto-selected for web. Reuses `xai-oauth` / `xao` / `xai` credentials. Not the X Developer Platform MCP. ([#10985](https://github.com/diegosouzapw/OmniRoute/issues/10985))
 - **feat(core):** add Layer A capability filter at router (#5696)


### PR DESCRIPTION
## Two changes

### 1. `.mailmap` — repairs a real misattribution

Between **2026-08-13 and 2026-08-26** this checkout carried a `git config --local` that paired one contributor's **name** (`Xiangzhe` / @xz-dev) with **another contributor's email** (@backryun). Every commit produced on that machine in the window was signed with @backryun's address — **237 commits**.

The timezone split settles it:

| identity | commits | timezone |
| --- | ---: | --- |
| @backryun's own work | 533 | **+0900** |
| name `Xiangzhe` + @backryun's email | 237 | **−0300** |

@backryun kept contributing normally from +0900 throughout the window (last: 2026-08-23), so this is not a compromised account. No file in the repository sets that address — it was a local `git config` mix-up of two contributors' details. The local override has been removed; the global identity (`diegosouzapw`) was correct all along.

**History is deliberately NOT rewritten.** Those commits live on `release/v3.8.50` and `release/v3.8.51`, which open PRs and parallel sessions build on, and the `v3.8.50` tag was cut from that line — a rewrite would force-push both branches and orphan the tag. `.mailmap` is git's own answer for this: it fixes `log`/`shortlog`/`blame` without touching a single commit. `main` is unaffected either way, since releases squash-merge.

### 2. Consolidated stats + top-25 ranking in the CHANGELOG

All measured, none estimated:

| | |
| --- | ---: |
| People who contributed | **248** |
| Commits in the cycle | **1,714** |
| Pull requests referenced | **1,666** |
| Changelog entries | **1,182** |
| Contributors credited in entries | **256** |

Entries by type: **779 fixes**, **169 features**, 29 docs, 27 chore, 15 tests, 5 refactor, 3 perf.

The ranking uses the consolidated identities, so **@backryun keeps their 88 real cycle commits** and the 68 misattributed ones return to the maintainer.

`check:changelog-integrity`: OK — no base bullets lost.