### PR TITLE
fix(ci): stamp dist/BUILD_SHA before the npm publish provenance gate

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -226,6 +226,28 @@ jobs:
           JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
         run: npm run build:cli
 
+      # `build:cli` assembles dist/ but does NOT write dist/BUILD_SHA — only
+      # `build:release` does, by calling write-build-sha.mjs. The #10427 provenance
+      # guard inside check:pack-artifact rejects an artifact with no SHA (and rejects
+      # it even under OMNIROUTE_ALLOW_CANARY_BUILD=1: what cannot be identified cannot
+      # be vouched for). Without this step the build+validate pair in this job is
+      # structurally incompatible and fails 100% of the time — the same gap that was
+      # fixed in ci.yml's Package Artifact job.
+      - name: Stamp dist/BUILD_SHA for the provenance guard (#10427)
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          OMNIROUTE_BUILD_SHA: ${{ github.sha }}
+        run: |
+          export OMNIROUTE_BUILD_SHA="${OMNIROUTE_BUILD_SHA:0:7}"
+          node scripts/build/write-build-sha.mjs
+
+      # The guard checks ancestry against origin/main by default, which is correct
+      # here (a release tag is cut from main), but the ref has to exist locally for
+      # `git merge-base` to resolve it.
+      - name: Fetch main for the provenance probe
+        if: steps.resolve.outputs.skip != 'true'
+        run: git fetch --no-tags --depth=50 origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Validate npm package artifact
         if: steps.resolve.outputs.skip != 'true'
         run: npm run check:pack-artifact


### PR DESCRIPTION
## Why

The v3.8.50 npm publish fails at `Validate npm package artifact`:

```
[provenance] dist/BUILD_SHA is missing — the artifact cannot be traced to a commit.
❌ Build provenance check failed.
```

`build:cli` assembles `dist/` but does **not** write `dist/BUILD_SHA` — only `build:release` does, by calling `write-build-sha.mjs`. The #10427 provenance guard inside `check:pack-artifact` rejects an artifact with no SHA, so the build+validate pair in this job **could never pass**.

This is the **same structural gap already fixed in `ci.yml`'s Package Artifact job** during this cycle. `npm-publish.yml` carried it too, and it only surfaced now: the job had been dying earlier, at `Checkout`, because the self-hosted runner's disk was 100% full.

## What

- Stamp `dist/BUILD_SHA` from `github.sha` before the gate. On a `release` event that is the tag commit, which is on `main`.
- Fetch `origin/main` so `git merge-base` can resolve the ref the guard checks ancestry against by default.

## Not included

The Docker publish still fails on the **Bun base image only** (`cannot allocate memory` during `bun run build`); the supported `runner-base` and `runner-web` images build fine on both architectures. That one needs a decision rather than a patch — the manifest job consumes the Bun digests, so simply marking the step non-blocking would move the failure downstream. Left for a separate PR.