### PR TITLE
fix(ci): run OpenSSF Scorecard on the repository default branch, not hardcoded main

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,13 +4,20 @@ on:
   schedule:
     - cron: "27 7 * * 1"
   push:
-    branches: ["main"]
 
 permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
+    # ossf/scorecard-action refuses to run on non-default branches
+    # ("Only the default branch <X> is supported"), so the trigger must not
+    # hardcode a branch name that becomes stale when the release cycle renames
+    # the default branch (release/v3.8.51 as of v3.8.50). Previous hardcode on
+    # `main` reded every push to main with that error. Guard by the repository
+    # default instead; schedule/branch_protection_rule events carry the same
+    # repository context, so the weekly default-branch run still works.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:
       # security-events: write removed — Scorecard findings are advisory and no longer


### PR DESCRIPTION
fix(ci): run OpenSSF Scorecard on the repository default branch, not hardcoded main

## Why

OpenSSF Scorecard is red on every push to `main` (e.g. runs 33005392350, 32994073449) with:

```
##[error]Only the default branch release/v3.8.51 is supported.
```

`ossf/scorecard-action@v2.4.4` refuses to run on non-default branches. The workflow's `push:` trigger hardcodes `branches: ["main"]`, and the repository default branch is `release/v3.8.51` (the release-cycle development branch — main was last the default for v3.8.50). Scorecard only ever scores the default branch (that is what the OpenSSF badge / publish_results points at), so the hardcoded main trigger fails every time instead of running.

## Fix

- Remove the hardcoded `push: branches: ["main"]` filter.
- Gate the `analysis` job on the repository default branch instead:

```yaml
if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
```

The same repository context is available on `schedule` and `branch_protection_rule` events, so the weekly default-branch run is unaffected. Because the guard is derived from the repository default, it survives the next release-cycle branch rename without another workflow edit.

No behavior change for the badge or the SARIF artifact (scope, permissions, publish_results unchanged).