### PR TITLE
fix(docker): decouple the best-effort Bun image from the release manifest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -185,6 +185,13 @@ jobs:
 
       - name: Build and push BUN base platform image by digest
         id: build-bun-base
+        # Bun is a best-effort compatibility target, not a supported runtime
+        # (AGENTS.md -> Environment). Its `bun run build` has been OOM-killing on
+        # both arches; letting that sink the whole publish means the SUPPORTED
+        # runner-base / runner-web images never reach the registry either. The
+        # image is still built and pushed whenever it succeeds — only its power to
+        # block the release is removed.
+        continue-on-error: true
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -203,6 +210,13 @@ jobs:
 
       - name: Build and push BUN web platform image by digest
         id: build-bun-web
+        # Bun is a best-effort compatibility target, not a supported runtime
+        # (AGENTS.md -> Environment). Its `bun run build` has been OOM-killing on
+        # both arches; letting that sink the whole publish means the SUPPORTED
+        # runner-base / runner-web images never reach the registry either. The
+        # image is still built and pushed whenever it succeeds — only its power to
+        # block the release is removed.
+        continue-on-error: true
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -230,8 +244,15 @@ jobs:
           mkdir -p /tmp/digests/base /tmp/digests/web /tmp/digests/bun-base /tmp/digests/bun-web
           touch "/tmp/digests/base/${DIGEST_BASE#sha256:}"
           touch "/tmp/digests/web/${DIGEST_WEB#sha256:}"
-          touch "/tmp/digests/bun-base/${DIGEST_BUN_BASE#sha256:}"
-          touch "/tmp/digests/bun-web/${DIGEST_BUN_WEB#sha256:}"
+          # Empty when the (non-blocking) bun build produced no image. `if` blocks,
+          # not `[ -n ] && touch`: under `set -e` a failing AND-list aborts the step,
+          # which is precisely the case being handled here.
+          if [ -n "$DIGEST_BUN_BASE" ]; then
+            touch "/tmp/digests/bun-base/${DIGEST_BUN_BASE#sha256:}"
+          fi
+          if [ -n "$DIGEST_BUN_WEB" ]; then
+            touch "/tmp/digests/bun-web/${DIGEST_BUN_WEB#sha256:}"
+          fi
 
       - name: Upload base digests
         uses: actions/upload-artifact@v7
@@ -338,7 +359,7 @@ jobs:
           set -euo pipefail
 
           create_manifest() {
-            local image="$1" suffix="$2" dir="$3"
+            local image="$1" suffix="$2" dir="$3" optional="${4:-}"
             local tags=(-t "${image}:${VERSION}${suffix}")
             if [ "$PROMOTE_LATEST" = "true" ]; then
               tags+=(-t "${image}:latest${suffix}")
@@ -348,6 +369,10 @@ jobs:
               refs+=("${image}@sha256:$(basename "$digest_file")")
             done < <(find "$dir" -type f | sort)
             if [ "${#refs[@]}" -eq 0 ]; then
+              if [ -n "$optional" ]; then
+                echo "::warning::No image digests in $dir — skipping optional tag ${image}:${VERSION}${suffix}" >&2
+                return 0
+              fi
               echo "No image digests in $dir" >&2
               exit 1
             fi
@@ -356,15 +381,15 @@ jobs:
 
           create_manifest "${IMAGE_NAME}" "" /tmp/digests/base
           create_manifest "${IMAGE_NAME}" "-web" /tmp/digests/web
-          create_manifest "${IMAGE_NAME}" "-bun" /tmp/digests/bun-base
-          create_manifest "${IMAGE_NAME}" "-web-bun" /tmp/digests/bun-web
+          create_manifest "${IMAGE_NAME}" "-bun" /tmp/digests/bun-base optional
+          create_manifest "${IMAGE_NAME}" "-web-bun" /tmp/digests/bun-web optional
 
       - name: Create GHCR manifest
         run: |
           set -euo pipefail
 
           create_manifest() {
-            local image="$1" suffix="$2" dir="$3"
+            local image="$1" suffix="$2" dir="$3" optional="${4:-}"
             local tags=(-t "${image}:${VERSION}${suffix}")
             if [ "$PROMOTE_LATEST" = "true" ]; then
               tags+=(-t "${image}:latest${suffix}")
@@ -374,6 +399,10 @@ jobs:
               refs+=("${image}@sha256:$(basename "$digest_file")")
             done < <(find "$dir" -type f | sort)
             if [ "${#refs[@]}" -eq 0 ]; then
+              if [ -n "$optional" ]; then
+                echo "::warning::No image digests in $dir — skipping optional tag ${image}:${VERSION}${suffix}" >&2
+                return 0
+              fi
               echo "No image digests in $dir" >&2
               exit 1
             fi
@@ -382,8 +411,8 @@ jobs:
 
           create_manifest "${GHCR_IMAGE_NAME}" "" /tmp/digests/base
           create_manifest "${GHCR_IMAGE_NAME}" "-web" /tmp/digests/web
-          create_manifest "${GHCR_IMAGE_NAME}" "-bun" /tmp/digests/bun-base
-          create_manifest "${GHCR_IMAGE_NAME}" "-web-bun" /tmp/digests/bun-web
+          create_manifest "${GHCR_IMAGE_NAME}" "-bun" /tmp/digests/bun-base optional
+          create_manifest "${GHCR_IMAGE_NAME}" "-web-bun" /tmp/digests/bun-web optional
 
       - name: Inspect image
         if: needs.prepare.outputs.version != 'main'


### PR DESCRIPTION
## Why

The v3.8.50 Docker publish failed on **both** architectures with:

```
process "/bin/sh -c bun run --quiet build" ... cannot allocate memory
ERROR: failed to solve: ResourceExhausted
```

Only `Dockerfile.bun` failed. The **supported** images built fine:

| image | amd64 | arm64 |
| --- | ---: | ---: |
| `runner-base` | ✅ 16m03 | ✅ 14m13 |
| `runner-web` | ✅ 3m15 | ✅ 1m31 |
| `Dockerfile.bun (runner-base)` | ❌ OOM | ❌ OOM |

Yet **none of them reached the registry**, because one best-effort target sank the whole workflow.

`AGENTS.md` → Environment is explicit that Bun is a *compatibility path and NOT a supported runtime*. Letting it block the release inverts that: the runtime users actually run stayed unpublished so an experimental one could fail loudly.

## What

The Bun image is **still built and still pushed** on every run — it only stops being a release blocker:

- both Bun build steps get `continue-on-error: true`
- digest files are created only when a digest actually exists
- `create_manifest` gains an `optional` flag: an empty digest dir warns and skips that tag instead of `exit 1`

`base` / `web` stay **hard-fail**, so a real regression in a supported image still stops the publish. Applied to both the Docker Hub and GHCR manifest steps.

## One trap worth naming

The digest guard uses `if` blocks, not `[ -n "$X" ] && touch ...`. Under `set -euo pipefail` a failing AND-list aborts the step — which is *exactly* the empty-digest case this handles, so the terse form would have swapped one blocker for another. Verified by simulating both `create_manifest` paths in bash: supported manifest created, Bun tag skipped, step survives.

## Follow-up not in scope

The Bun OOM itself is untouched and still needs a fix (or a documented decision that the image is expected to fail on hosted runners). This PR only stops it from holding the supported images hostage.