### PR TITLE
docs(legal): add pinned MIT third-party notices

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -24,3 +24,59 @@ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPO
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## blackwell-systems/gcf-typescript
+
+The generic-profile codec in
+`open-sse/services/compression/engines/headroom/gcf/{decode_generic,generic,index,scalar}.ts`
+is adapted from
+[`blackwell-systems/gcf-typescript`](https://github.com/blackwell-systems/gcf-typescript/tree/00972f2dc781477eb6d369e62edfe03ad4112a07),
+commit `00972f2dc781477eb6d369e62edfe03ad4112a07`. The license below is reproduced
+from that commit's
+[`LICENSE`](https://github.com/blackwell-systems/gcf-typescript/blob/00972f2dc781477eb6d369e62edfe03ad4112a07/LICENSE).
+
+MIT License
+
+Copyright (c) 2026 Dayna Blackwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## lipis/flag-icons
+
+The country flag SVGs in `docs/assets/flags/` are copied from the `flags/4x3/` directory of
+[`lipis/flag-icons`](https://github.com/lipis/flag-icons/tree/086f7e97d657358203916dbe84f61c2bccaa81eb),
+commit `086f7e97d657358203916dbe84f61c2bccaa81eb`. The license below is reproduced
+from that commit's
+[`LICENSE`](https://github.com/lipis/flag-icons/blob/086f7e97d657358203916dbe84f61c2bccaa81eb/LICENSE).
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Panayiotis Lipiridis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/changelog.d/maintenance/00000-third-party-notices.md
+++ b/changelog.d/maintenance/00000-third-party-notices.md
@@ -1,0 +1,1 @@
+- **docs(legal):** centralize pinned MIT notices for the vendored GCF codec and local flag assets

--- a/changelog.d/maintenance/00000-third-party-notices.md
+++ b/changelog.d/maintenance/00000-third-party-notices.md
@@ -1,1 +1,0 @@
-- **docs(legal):** centralize pinned MIT notices for the vendored GCF codec and local flag assets

--- a/changelog.d/maintenance/11726-third-party-notices.md
+++ b/changelog.d/maintenance/11726-third-party-notices.md
@@ -1,0 +1,1 @@
+- **docs(legal):** centralize pinned MIT notices for the vendored GCF codec and local flag assets ([#11726](https://github.com/diegosouzapw/OmniRoute/pull/11726))


### PR DESCRIPTION
## Summary

- Adds the complete upstream MIT license notice for the vendored generic-profile GCF codec,
  pinned to `blackwell-systems/gcf-typescript@00972f2dc781477eb6d369e62edfe03ad4112a07`.
- Adds the complete upstream MIT license notice for the local country-flag SVGs, pinned to
  `lipis/flag-icons@086f7e97d657358203916dbe84f61c2bccaa81eb`.
- Maps each notice to the exact local files it covers; no runtime or provider behavior changes.

## Status and evidence

| Item | Status | Primary evidence | Disposition |
| --- | --- | --- | --- |
| `blackwell-systems/gcf-typescript` | **PASS** | The pinned tree contains `src/{decode_generic,generic,index,scalar}.ts` and [`LICENSE`](https://github.com/blackwell-systems/gcf-typescript/blob/00972f2dc781477eb6d369e62edfe03ad4112a07/LICENSE), with `Copyright (c) 2026 Dayna Blackwell` | Full notice reproduced in `THIRD_PARTY_NOTICES.md` |
| `lipis/flag-icons` | **PASS** | The pinned [`LICENSE`](https://github.com/lipis/flag-icons/blob/086f7e97d657358203916dbe84f61c2bccaa81eb/LICENSE) names `Copyright (c) 2013 Panayiotis Lipiridis`; all 38 local SVG Git blob SHAs match `flags/4x3/` at that commit | Full notice reproduced in `THIRD_PARTY_NOTICES.md` |
| `chouzz/llm-interceptor` | **HOLD — excluded from diff** | At contemporaneous commit `821373cc26aca39ced334a6431375ac9beb5a08e`, `pyproject.toml` declares MIT and author `chouzz`, but `LICENSE`, `LICENSE.md`, `COPYING`, and `COPYING.md` are absent (GitHub Contents API: 404) | No central notice added and no copyright inferred; requires a primary upstream notice or owner clarification |

## Validation

| Gate | Result | Evidence |
| --- | --- | --- |
| License text fidelity | **PASS** | Both included license texts match the pinned upstream files word-for-word; wrapping only differs |
| Asset provenance | **PASS** | `flag-icons`: 38/38 local SVG blob SHAs match, 0 mismatches, 0 missing |
| Pinned source availability | **PASS** | Both commit endpoints and both pinned `LICENSE` endpoints return HTTP 200 |
| Prettier | **PASS** | `THIRD_PARTY_NOTICES.md` and the changelog fragment match repository formatting |
| Diff integrity | **PASS** | `git diff --check` clean |
| Changelog integrity | **PASS** | `npm run check:changelog-integrity` |
| Tracked-artifact policy | **PASS** | `npm run check:tracked-artifacts` |
| Documentation gate | **PASS** | `npm run check:docs-all` exited 0: sync, strict counts, env contract, internal links, and fabricated-doc checks passed; only pre-existing soft drift warnings were reported |

## Tests and coverage

Documentation/legal-notice-only change; no production code is modified, so no runtime test or coverage
delta applies.

## Scope guard

- No `chatgpt-web`, provider registry, migration, runtime, or dependency changes.
- No claim that `llm-interceptor` has a reproducible complete license notice.
- This PR is intentionally left open and draft; no automerge, merge, tag, release, or deploy was
  requested or performed.

## Published readback

| Field | Value |
| --- | --- |
| PR | [#11726](https://github.com/diegosouzapw/OmniRoute/pull/11726) |
| State | **OPEN — DRAFT** |
| Base | `release/v3.8.50` @ `091589089cd134a94df9f6cdab9ba562b2cefd18` |
| Head | `docs/v3850-third-party-notices` @ `59c618f2f6d37641beee6b2f0d6abfd37fa6c782` |
| Local/remote | Exact match at readback |
| Commits | `fbb089cab2` (notices), `59c618f2f6` (fragment bound to #11726) |
| CI | Started; queued/in progress at readback, not reported as green |
