### PR TITLE
fix(ci): surface and clear release-green ESLint failure

### DIFF
--- a/scripts/quality/validate-release-green.mjs
+++ b/scripts/quality/validate-release-green.mjs
@@ -60,6 +60,7 @@ import { parse as parseYaml } from "yaml";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..");
 const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+export const ESLINT_TIMEOUT_MS = 60 * 60 * 1000;
 
 // Per-gate captured output. execFileSync buffers everything and the report only
 // shows a one-line summary, so without these files every red requires RE-RUNNING
@@ -177,6 +178,56 @@ export function parseEslintJson(out) {
     }
   }
   return null;
+}
+
+/**
+ * Turn one ESLint process result into release-green records.
+ *
+ * Keep process failures distinct from report parsing failures. In particular, a timed-out
+ * ESLint process has no JSON report by definition; collapsing its code-124 diagnostic into
+ * "could not parse eslint json" hides the actionable cause and sends maintainers debugging
+ * the parser instead of the gate ceiling.
+ */
+export function evaluateEslintRun({ code, out }, warningBaseline) {
+  const parsed = parseEslintJson(out);
+  if (!parsed) {
+    return [
+      {
+        id: "lint",
+        label: "ESLint",
+        kind: "hard",
+        ok: false,
+        detail:
+          code === 0
+            ? "ESLint exited successfully but produced no valid JSON report"
+            : firstFailureLine(out),
+      },
+    ];
+  }
+
+  const { errors, warnings } = eslintCounts(parsed);
+  const warningDrift = isDrift(warnings, warningBaseline);
+  return [
+    {
+      id: "lint-errors",
+      label: "ESLint errors",
+      kind: "hard",
+      ok: errors === 0,
+      detail: `${errors} error(s)`,
+    },
+    {
+      id: "eslint-warnings",
+      label: "ESLint warnings (ratchet)",
+      kind: "drift",
+      ok: !warningDrift,
+      detail:
+        warningBaseline == null
+          ? `${warnings} (no baseline)`
+          : `${warnings} vs baseline ${warningBaseline}${
+              warningDrift ? ` (+${warnings - warningBaseline} drift → rebaseline at release)` : ""
+            }`,
+    },
+  ];
 }
 
 /** Pull the cognitive-complexity violation count from the gate's output. */
@@ -451,16 +502,19 @@ async function main() {
 
   // ESLint: ONE pass → errors (hard) + warnings (drift)
   {
-    announce("ESLint (errors + warnings — ~5-15min)");
+    announce("ESLint (errors + warnings — ~15-45min)");
     // Suppressions-aware, matching `npm run lint` (Pacote 4 no-new-warnings): the frozen
     // pre-existing debt in config/quality/eslint-suppressions.json must not count as
-    // errors here — only NET-NEW violations are release reds. Timeout raised: a full
-    // repo pass takes ~14min alone and this pre-flight often runs alongside test suites.
-    const { out } = run(
+    // errors here — only NET-NEW violations are release reds. The cold release runner can
+    // exceed 30 minutes as the repository grows, and this pre-flight often runs under load.
+    const lintRun = run(
       "npx",
       [
         "eslint",
         ".",
+        "--cache",
+        "--cache-location",
+        ".eslintcache",
         "--format",
         "json",
         "--suppressions-location",
@@ -471,39 +525,16 @@ async function main() {
         // reason alone, which used to mask the real `--format json` report (#7837).
         "--pass-on-unpruned-suppressions",
       ],
-      { timeout: 30 * 60 * 1000 }
+      // The cold release runner crossed the old 30-minute ceiling as the repository grew,
+      // then the timeout text was misreported as invalid JSON. Keep a real upper bound, but
+      // leave enough headroom for the same full-tree walk that completes immediately after it
+      // under the complexity config on that runner.
+      { timeout: ESLINT_TIMEOUT_MS }
     );
+    const { out } = lintRun;
     saveGateLog("lint", out);
-    const parsed = parseEslintJson(out);
-    if (!parsed) {
-      record({
-        id: "lint",
-        label: "ESLint",
-        kind: "hard",
-        ok: false,
-        detail: "could not parse eslint json",
-      });
-    } else {
-      const { errors, warnings } = eslintCounts(parsed);
-      record({
-        id: "lint-errors",
-        label: "ESLint errors",
-        kind: "hard",
-        ok: errors === 0,
-        detail: `${errors} error(s)`,
-      });
-      const base = baselineValue("eslintWarnings");
-      const over = isDrift(warnings, base);
-      record({
-        id: "eslint-warnings",
-        label: "ESLint warnings (ratchet)",
-        kind: "drift",
-        ok: !over,
-        detail:
-          base == null
-            ? `${warnings} (no baseline)`
-            : `${warnings} vs baseline ${base}${over ? ` (+${warnings - base} drift → rebaseline at release)` : ""}`,
-      });
+    for (const result of evaluateEslintRun(lintRun, baselineValue("eslintWarnings"))) {
+      record(result);
     }
   }
 
@@ -638,7 +669,8 @@ async function main() {
         // forever) into a visible failure — survives at 100min.
         // Measured on idle .113: unavailable (checkout not found). Tightened to 80min from 100min as a conservative step. TODO: re-measure on idle .113 and tighten to ~1.8× measured.
         id: "unit",
-        label: "Unit tests (full suite, CI concurrency — ~30-50min idle, up to ~80min under load (awaiting idle .113 measurement, #9532))",
+        label:
+          "Unit tests (full suite, CI concurrency — ~30-50min idle, up to ~80min under load (awaiting idle .113 measurement, #9532))",
         args: ["run", "test:unit:ci"],
         timeout: 80 * 60 * 1000,
       },

--- a/src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx
@@ -23,7 +23,7 @@ function renderApiKeySaveHook(): {
   document.body.appendChild(container);
   let hookResult: ReturnType<typeof useApiKeySave> | null = null;
   function Wrapper() {
-    hookResult = useApiKeySave({
+    const result = useApiKeySave({
       providerId: "huge-catalog-openai-compatible",
       fetchConnections: vi.fn().mockResolvedValue(undefined),
       fetchProviderModelMeta: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +34,9 @@ function renderApiKeySaveHook(): {
       notify: { success: vi.fn(), error: vi.fn() },
       t,
     });
+    React.useEffect(() => {
+      hookResult = result;
+    }, [result]);
     return null;
   }
   const root = createRoot(container);
@@ -82,12 +85,16 @@ describe("useApiKeySave.handleSaveApiKey — full-sync opt-out (#11324)", () => 
       await hookResult().handleSaveApiKey({ apiKey: "sk-test", skipModelSync: true });
     });
 
-    const syncCalls = fetchMock.mock.calls.filter(([input]) => String(input).includes("/sync-models"));
+    const syncCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes("/sync-models")
+    );
     expect(syncCalls).toHaveLength(0);
 
     // The opt-out is a client-side intent signal only — it must never leak into the
     // persisted connection payload sent to the server.
-    const providersCall = fetchMock.mock.calls.find(([input]) => String(input) === "/api/providers");
+    const providersCall = fetchMock.mock.calls.find(
+      ([input]) => String(input) === "/api/providers"
+    );
     const postedBody = JSON.parse((providersCall?.[1] as RequestInit).body as string);
     expect(postedBody).not.toHaveProperty("skipModelSync");
   });
@@ -111,7 +118,9 @@ describe("useApiKeySave.handleSaveApiKey — full-sync opt-out (#11324)", () => 
       await hookResult().handleSaveApiKey({ apiKey: "sk-test" });
     });
 
-    const syncCalls = fetchMock.mock.calls.filter(([input]) => String(input).includes("/sync-models"));
+    const syncCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes("/sync-models")
+    );
     expect(syncCalls).toHaveLength(1);
   });
 });

--- a/tests/unit/validate-release-green.test.ts
+++ b/tests/unit/validate-release-green.test.ts
@@ -7,6 +7,7 @@ const mod = await import("../../scripts/quality/validate-release-green.mjs");
 const {
   firstFailureLine,
   eslintCounts,
+  evaluateEslintRun,
   parseEslintJson,
   parseCognitiveCount,
   isDrift,
@@ -17,6 +18,7 @@ const {
   fullCiTimeoutFor,
   curatedEquivalentId,
   fullCiKindFor,
+  ESLINT_TIMEOUT_MS,
 } = mod;
 
 const extract = extractCiGates as (
@@ -48,6 +50,22 @@ test("parseEslintJson tolerates ESLint's trailing unpruned-suppressions stderr s
   assert.deepEqual(parseEslintJson(eslintJsonReport + stderrTail), [
     { filePath: "open-sse/executors/example.ts", errorCount: 0, warningCount: 0, messages: [] },
   ]);
+});
+
+test("evaluateEslintRun preserves an ESLint timeout instead of misreporting invalid JSON", () => {
+  const timedOut = classifyRunError({ killed: true, code: "ETIMEDOUT" }, 30 * 60 * 1000);
+
+  assert.deepEqual(evaluateEslintRun(timedOut, 0), [
+    {
+      id: "lint",
+      label: "ESLint",
+      kind: "hard",
+      ok: false,
+      detail:
+        "gate exceeded its 1800s ceiling and was killed — treat as a hung/failed gate (e.g. an unreleased DB handle in the unit suite); does NOT pass",
+    },
+  ]);
+  assert.equal(ESLINT_TIMEOUT_MS, 60 * 60 * 1000, "cold release lint needs >30m headroom");
 });
 
 test("parseCognitiveCount reads the gate's count (en + pt)", () => {


### PR DESCRIPTION
## Summary

Clear the ESLint hard failure currently reported by release-green on pristine `release/v3.8.51` tip `2e8326d53` (base-red #11449).

- move the hook-test result assignment out of React render and into an effect, clearing the hidden `react-hooks/globals` error
- give the cold full-tree ESLint walk a 60-minute ceiling instead of the 30-minute ceiling it crossed on the release runner
- enable the existing `.eslintcache` path for repeat runs
- preserve process failures such as code-124 timeout diagnostics instead of feeding them into the JSON parser and reporting the misleading `could not parse eslint json`

## Root cause

Run `33024734511` spent the full old 30-minute ESLint ceiling, so `classifyRunError()` returned the correct timeout diagnostic. The lint block ignored the non-zero process result, tried to parse that diagnostic as JSON, and replaced the actionable cause with `could not parse eslint json`.

A completed full-tree lint on the same base then exposed the real violation hidden behind the timeout:

```
src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx:26:5
react-hooks/globals — hookResult was reassigned during render
```

The test now publishes the hook result from `useEffect`, matching the established hook-test pattern in this repository.

## Verification

- full ESLint inventory: **9,774 files, 0 errors, 0 warnings**
- release-green `--quick --hermetic`: ESLint hard gate **0 errors**, warning ratchet **0 vs baseline 0**
- `node --import tsx/esm --test tests/unit/validate-release-green.test.ts`: **31/31 pass**
- focused Vitest hook suite: **2/2 pass**
- scoped ESLint on changed test files: **0 errors, 0 warnings**
- `git diff --check`: pass

The separate provider-reference 356→357 docs red remains outside this focused PR and is already covered by #11710.
