### PR TITLE
fix(docker): let the bun digest artifact be absent, not fatal

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -275,7 +275,11 @@ jobs:
         with:
           name: digests-bun-base-${{ matrix.arch }}
           path: /tmp/digests/bun-base/*
-          if-no-files-found: error
+          # `ignore`, not `error`: the bun build is non-blocking, so an absent
+          # digest is the expected outcome of a failed/skipped bun image — the
+          # manifest step already treats these tags as optional. Leaving `error`
+          # here just relocates the blocker from the manifest to the upload.
+          if-no-files-found: ignore
           retention-days: 1
 
       - name: Upload bun-web digests
@@ -283,7 +287,11 @@ jobs:
         with:
           name: digests-bun-web-${{ matrix.arch }}
           path: /tmp/digests/bun-web/*
-          if-no-files-found: error
+          # `ignore`, not `error`: the bun build is non-blocking, so an absent
+          # digest is the expected outcome of a failed/skipped bun image — the
+          # manifest step already treats these tags as optional. Leaving `error`
+          # here just relocates the blocker from the manifest to the upload.
+          if-no-files-found: ignore
           retention-days: 1
 
   merge:
@@ -341,6 +349,9 @@ jobs:
           merge-multiple: true
 
       - name: Download bun-base digests
+        # Non-blocking: the bun image is best-effort, so its artifact may not
+        # exist at all. The manifest step treats these tags as optional.
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: digests-bun-base-*
@@ -348,6 +359,9 @@ jobs:
           merge-multiple: true
 
       - name: Download bun-web digests
+        # Non-blocking: the bun image is best-effort, so its artifact may not
+        # exist at all. The manifest step treats these tags as optional.
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: digests-bun-web-*


### PR DESCRIPTION
Follow-up to #11724 — that PR stopped one step short.

#11724 made the bun image non-blocking and taught the manifest step to skip its tags when no digest exists. But the **upload** still carried `if-no-files-found: error`, so an absent digest — now the *expected* outcome of a skipped bun build — failed the job anyway.

Run [33030348950](https://github.com/diegosouzapw/OmniRoute/actions/runs/33030348950) shows it exactly: both arches died at **`Upload bun-base digests`**, after the decoupling had already done its part. The blocker had simply **moved** from the manifest to the upload.

## Changes

- bun digest **uploads**: `if-no-files-found: ignore`
- bun digest **downloads**: `continue-on-error`, since the artifact may not exist at all

`base` / `web` keep `error` on both sides — a supported image producing no digest is still a real failure that must stop the publish.

## Note for review

This is the second time in this cycle that a fix relocated a failure instead of removing it (the first: the npm publish moved from `Checkout` → `Validate npm package artifact` once disk was freed). Worth checking the whole bun path end to end rather than the one step the log names.