### PR TITLE
fix(api): preserve caller correlation id

### DIFF
--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -203,14 +203,14 @@ export async function POST(request) {
     // on the response when internal early-returns (idempotency cache, some combo
     // paths) drop the meta the docs promise.
     const compressionRequestHeader = readCompressionRequestHeader(request);
+    const correlationId = request.headers.get("x-correlation-id") || generateRequestId();
 
     if (wantsStreaming) {
-      const reqId = generateRequestId();
       // Wrap the real handler response, not the synthetic early-keepalive response. If the
       // client cancels while handleChat is still pending, earlyStreamKeepalive will cancel the
       // eventual handler body; only that confirmed cleanup releases heavyweight capacity.
       const handlerResponse = releaseChatAdmissionAfterHandler(
-        handleChat(request, null, parsedBody, reqId),
+        handleChat(request, null, parsedBody, correlationId),
         admission.lease
       );
       const streamedResponse = await withEarlyStreamKeepalive(handlerResponse, {
@@ -219,14 +219,14 @@ export async function POST(request) {
         keepaliveFrame: OPENAI_KEEPALIVE_FRAME,
         startupFrame: OPENAI_STARTUP_FRAME,
         errorFrame: OPENAI_CHAT_ERROR_FRAME,
-        extraHeaders: { "X-Correlation-Id": reqId },
+        extraHeaders: { "X-Correlation-Id": correlationId },
       });
       return withCompressionHeaderEcho(streamedResponse, compressionRequestHeader);
     }
 
     return finishAdmission(
       withCompressionHeaderEcho(
-        await handleChat(request, null, parsedBody),
+        await handleChat(request, null, parsedBody, correlationId),
         compressionRequestHeader
       )
     );

--- a/tests/unit/chat-route-correlation-id-11739.test.ts
+++ b/tests/unit/chat-route-correlation-id-11739.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-correlation-11739-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const chatRoute = await import("../../src/app/api/v1/chat/completions/route.ts");
+const originalFetch = globalThis.fetch;
+
+async function seedHealthyConnection() {
+  await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "correlation-route-test",
+    apiKey: "sk-correlation-route-test",
+    isActive: true,
+    testStatus: "active",
+  });
+}
+
+function request(correlationId: string, stream = false) {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Correlation-Id": correlationId,
+      "X-OmniRoute-No-Cache": "true",
+    },
+    body: JSON.stringify({
+      model: "openai/gpt-4.1",
+      messages: [{ role: "user", content: "Correlation contract test" }],
+      stream,
+    }),
+  });
+}
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  globalThis.fetch = originalFetch;
+  await resetStorage();
+  await seedHealthyConnection();
+});
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#11739 preserves caller correlation IDs for JSON, streaming, and provider failures", async () => {
+  const correlationId = "caller-correlation-11739";
+
+  globalThis.fetch = async () =>
+    Response.json({
+      id: "chatcmpl-correlation-json",
+      choices: [{ message: { role: "assistant", content: "OK" } }],
+    });
+  const jsonResponse = await chatRoute.POST(request(correlationId));
+  assert.equal(jsonResponse.status, 200);
+  assert.equal(jsonResponse.headers.get("x-correlation-id"), correlationId);
+
+  globalThis.fetch = async () =>
+    new Response(
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "OK" } }] })}\n\ndata: [DONE]\n\n`,
+      { status: 200, headers: { "Content-Type": "text/event-stream" } }
+    );
+  const streamingResponse = await chatRoute.POST(request(correlationId, true));
+  assert.equal(streamingResponse.status, 200);
+  assert.equal(streamingResponse.headers.get("x-correlation-id"), correlationId);
+  await streamingResponse.text();
+
+  globalThis.fetch = async () => new Response("synthetic provider failure", { status: 400 });
+  const errorResponse = await chatRoute.POST(request(correlationId));
+  assert.notEqual(errorResponse.status, 200);
+  assert.equal(errorResponse.headers.get("x-correlation-id"), correlationId);
+});


### PR DESCRIPTION
## Summary

Preserves a caller-supplied `X-Correlation-Id` through the OpenAI-compatible chat completions route. A new ID is generated only when the header is absent.

The same correlation now flows through JSON responses, streaming responses, and provider-error responses.

Closes #11739.

## Validation

- `node --import tsx/esm --test tests/unit/chat-route-correlation-id-11739.test.ts`
- Commit hooks: formatting, lint-staged checks, documentation sync, explicit-any budget, tracked-artifact policy

## Scope

No provider credentials, routing strategy, persistence, or public response body changes.