### PR TITLE
fix(lint): pin react hooks plugin to 7.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "dpdm": "^4.3.0",
         "eslint": "^9.39.4",
         "eslint-config-next": "16.3.1",
+        "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-sonarjs": "^4.1.0",
         "fast-check": "^4.8.0",
         "fumadocs-mdx": "^15.2.3",

--- a/package.json
+++ b/package.json
@@ -378,6 +378,7 @@
     "dpdm": "^4.3.0",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.3.1",
+    "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-sonarjs": "^4.1.0",
     "fast-check": "^4.8.0",
     "fumadocs-mdx": "^15.2.3",

--- a/tests/unit/eslint-react-hooks-version-pinned.test.ts
+++ b/tests/unit/eslint-react-hooks-version-pinned.test.ts
@@ -1,0 +1,41 @@
+/**
+ * eslint-react-hooks-version-pinned.test.ts — keep lint policy deterministic.
+ *
+ * eslint-config-next accepts any eslint-plugin-react-hooks 7.x release. Minor
+ * releases can change React Compiler diagnostics, so resolving a newer plugin
+ * from unchanged source can produce hundreds of unrelated lint failures. Keep
+ * the direct declaration exact and aligned with the lockfile.
+ */
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = new URL("../../", import.meta.url);
+const PLUGIN = "eslint-plugin-react-hooks";
+const EXPECTED_VERSION = "7.0.1";
+
+async function readJson(relative: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(fileURLToPath(new URL(relative, ROOT)), "utf8"));
+}
+
+test("eslint-plugin-react-hooks is directly pinned to the locked version", async () => {
+  const pkg = await readJson("package.json");
+  const lock = await readJson("package-lock.json");
+  const declared = ((pkg.devDependencies ?? {}) as Record<string, string>)[PLUGIN];
+  const packages = (lock.packages ?? {}) as Record<string, { version?: string }>;
+  const locked = packages[`node_modules/${PLUGIN}`]?.version;
+
+  assert.ok(declared, `${PLUGIN} must be a direct devDependency`);
+  assert.equal(
+    declared,
+    EXPECTED_VERSION,
+    `${PLUGIN} must remain pinned to ${EXPECTED_VERSION} until the 7.1.1 lint migration`
+  );
+  assert.ok(locked, `${PLUGIN} missing from package-lock.json`);
+  assert.equal(
+    declared,
+    locked,
+    `package.json declares ${PLUGIN}@${declared} but package-lock.json resolves ${locked}`
+  );
+});


### PR DESCRIPTION
## Summary

- pin eslint-plugin-react-hooks 7.0.1 as a direct devDependency
- prevent eslint-config-next transitive range drift from changing lint policy
- add a regression test that locks the expected version and package-lock alignment

## Root cause

eslint-config-next allows eslint-plugin-react-hooks through ^7.0.0. A reused or refreshed node_modules could therefore load 7.1.1 while the repository lockfile and source remained unchanged. The 7.1 analyzer changes then surfaced hundreds of React Compiler diagnostics across unrelated dashboard files.

## Verification

- focused regression test: pass
- npm run check:lockfile: pass
- npm run lint: pass
- npm ls eslint-plugin-react-hooks: one deduped 7.0.1 installation
- pre-commit formatting, ESLint, docs sync, any-budget, and tracked-artifacts gates: pass
- npm run test:all: unit matrix reached 34,427 tests; 34,395 passed, 6 failed, 7 cancelled, 19 skipped. The command stopped before Vitest/E2E. These failures are outside this manifest-only change; the focused regression remains green.

## Follow-up

Upgrade to eslint-plugin-react-hooks 7.1.1 separately as an explicit lint-policy migration rather than accepting it through transitive dependency drift.