### PR TITLE
test(auto-combo): tolerate full-suite rotation load

### DIFF
--- a/tests/unit/autoCombo/tieredRotation.test.ts
+++ b/tests/unit/autoCombo/tieredRotation.test.ts
@@ -194,11 +194,11 @@ describe("Per-Connection Rotation", () => {
       }
       expect(seenConnections.size).toBeGreaterThanOrEqual(10);
     },
-    // 200 synchronous selectProvider() calls over a 43-connection pool are CPU-bound and
-    // vitest's 5000ms default is too tight under shared-devbox contention (load avg 40+
-    // observed alongside parallel test/tsc/lint runs) — the assertion itself is unchanged,
-    // only the execution-time budget is widened. Refs #9985.
-    20000
+    // 200 synchronous selectProvider() calls over a 43-connection pool are CPU-bound and can
+    // exceed 20s under the full Vitest worker load on the validation VPS, while the isolated
+    // file remains green. The assertion is unchanged; only the execution budget is widened.
+    // Refs #9985.
+    60000
   );
 
   it("different combos maintain independent round-robin state", () => {


### PR DESCRIPTION
## Context

Exact-SHA validation for Video Bridge PR-1 exposed a Vitest base-red in the CPU-bound Cerebras rotation test. The candidate and its exact base fail identically under the full 20-worker suite, while the file passes in isolation on both SHAs. This is exact-base attribution for the broad release monitor #11449; it is not a Video Bridge regression.

## Change

- widen only this existing per-test budget from 20 s to 60 s;
- keep the 200-call behavioral assertion unchanged;
- touch no production code.

## RED to GREEN on VPS 192.168.0.15

- RED candidate c467c3232bff: 456/457, status 1, log SHA-256 0f30908989b6e491df7999e18303be23e4166c7971d313dfef279e544ea41c0d.
- RED exact base c9f11d86b55d: 456/457, status 1, same timeout, log SHA-256 5b73926effbf5101599dba5d1be3ebad446d6557a9c5a2e3a94abe8508ad6ae7.
- Isolated control: candidate 11/11 and base 11/11, status 0 on both.
- GREEN ad3e293f9fef: 49/49 files, 457/457 tests, status 0, log SHA-256 7473ee53d114c2c375305f9abfc43c4848c76483834a1722377a3667583bc4b5.

Command: npm run test:vitest. Node 24.14.1, npm 11.11.0.

The release monitor remains open because its scope is broader than this one test.