### PR TITLE
fix(api): keep registry width and type on embedding models

### DIFF
--- a/changelog.d/fixes/11761-embedding-registry-width-and-type.md
+++ b/changelog.d/fixes/11761-embedding-registry-width-and-type.md
@@ -1,0 +1,5 @@
+- Keep the embedding registry's vector width and `embedding` type on models when a synced model exists
+  for the same id, so `/v1/models` no longer reports registry-described embedding models widthless or
+  untyped (#11761)
+- Correct `google/gemini-embedding-001` on the OpenRouter route to 3072 dimensions, the width it
+  returns when `dimensions` is not sent (#11761)

--- a/open-sse/config/embeddingRegistry.ts
+++ b/open-sse/config/embeddingRegistry.ts
@@ -239,7 +239,7 @@ export const EMBEDDING_PROVIDERS: Record<string, EmbeddingProvider> = {
       {
         id: "google/gemini-embedding-001",
         name: "Gemini Embedding 001 (OpenRouter)",
-        dimensions: 768,
+        dimensions: 3072,
       },
       {
         id: "google/gemini-embedding-2",

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -1357,13 +1357,13 @@ async function buildUnifiedModelsResponseCore(
       return activeAliases.has(alias) || activeAliases.has(provider);
     };
 
-    const hasEquivalentSpecialtyModel = (
+    const findEquivalentSpecialtyModel = (
       providerId: string,
       rawModelId: string,
       type: string,
       scopedModelId: string
     ) =>
-      models.some((model: any) => {
+      models.find((model: any) => {
         if (model?.id === scopedModelId) return true;
         if (model?.owned_by !== providerId || model?.type !== type) return false;
         const existingRoot =
@@ -1374,6 +1374,13 @@ async function buildUnifiedModelsResponseCore(
               : null;
         return existingRoot === rawModelId;
       });
+
+    const hasEquivalentSpecialtyModel = (
+      providerId: string,
+      rawModelId: string,
+      type: string,
+      scopedModelId: string
+    ) => findEquivalentSpecialtyModel(providerId, rawModelId, type, scopedModelId) !== undefined;
 
     // Helper: strip the provider prefix from a specialty model ID to get the
     // provider-relative path (e.g. "openrouter/google/chirp-3" -> "google/chirp-3").
@@ -1389,7 +1396,22 @@ async function buildUnifiedModelsResponseCore(
       const rawModelId = getSpecialtyModelRelativeId(embModel.id, embModel.provider);
       if (!providerSupportsModel(embModel.provider, rawModelId)) continue;
       if (isModelHiddenBulk(embModel.provider, rawModelId)) continue;
-      if (hasEquivalentSpecialtyModel(embModel.provider, rawModelId, "embedding", embModel.id)) {
+      const existingEmbedding = findEquivalentSpecialtyModel(
+        embModel.provider,
+        rawModelId,
+        "embedding",
+        embModel.id
+      );
+      if (existingEmbedding) {
+        // Discovery publishes no vector width, so the registry is the authority.
+        if (embModel.dimensions !== undefined) {
+          existingEmbedding.dimensions = embModel.dimensions;
+        }
+        // A provider that does not report its endpoints leaves the model unclassified. Being in
+        // the embedding registry is that statement, so make it rather than leave it untyped.
+        if (!existingEmbedding.type) {
+          existingEmbedding.type = "embedding";
+        }
         continue;
       }
       models.push({

--- a/tests/unit/11759-embedding-registry-width-and-type.test.ts
+++ b/tests/unit/11759-embedding-registry-width-and-type.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test for #11759 — `/v1/models` dropped the vector width and the
+ * `embedding` type from embedding models that `embeddingRegistry.ts` describes,
+ * whenever a synced model existed for the same id.
+ *
+ * `embeddingRegistry.ts` is the only machine-readable source of two facts: a model's
+ * vector width, and that it is an embedding model at all. No upstream provider
+ * publishes either — OpenRouter's catalogue carries no `dimensions`, and OpenAI's
+ * `/v1/models` returns ids with no capability information.
+ *
+ * Two paths lost them:
+ *
+ *  - Width. The registry loop skipped its entry outright when discovery had already
+ *    produced the model (`hasEquivalentSpecialtyModel(...) continue`), so the surviving
+ *    entry was the discovered one — typed, but with no `dimensions`.
+ *
+ *  - Type. Classification comes from `sm.supportedEndpoints`, which falls back to
+ *    `["chat"]`. A provider that does not report endpoints therefore yielded
+ *    `modelType === undefined` and the `type` key was omitted entirely, so an embedding
+ *    model read as a chat model.
+ *
+ * A consumer that stores vectors needs both: collections are keyed on width, and an
+ * untyped model cannot be identified as an embedding model. These tests assert the
+ * merged `/v1/models` output, not the registry in isolation — the registry was always
+ * correct; the loss happened in `catalog.ts`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-11759-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+const embeddingRegistry = await import("../../open-sse/config/embeddingRegistry.ts");
+
+/** Both are real registry entries, so the expected widths come from the registry itself. */
+const OPENROUTER_MODEL = "qwen/qwen3-embedding-8b";
+const OPENAI_MODEL = "text-embedding-3-small";
+
+function registryWidth(providerId: string, modelId: string): number {
+  const provider = embeddingRegistry.getEmbeddingProvider(providerId);
+  assert.ok(provider, `embeddingRegistry has no provider "${providerId}"`);
+  const model = provider!.models.find((m) => m.id === modelId);
+  assert.ok(model, `embeddingRegistry has no model "${modelId}" on "${providerId}"`);
+  const { dimensions } = model!;
+  assert.equal(
+    typeof dimensions,
+    "number",
+    `this test assumes a single advertised width for "${modelId}"`
+  );
+  return dimensions as number;
+}
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  v1ModelsCatalog.__resetCatalogBuilderRunsForTest();
+}
+
+/** An active connection, which is what makes the provider's registry models eligible. */
+async function connectProvider(provider: string) {
+  return (await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    name: `${provider}-conn`,
+    apiKey: "sk-test",
+    isActive: true,
+    testStatus: "active",
+  })) as { id: string };
+}
+
+async function modelEntry(id: string) {
+  const response = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const entry = body.data.find((model) => model.id === id);
+  assert.ok(
+    entry,
+    `expected "${id}" in /v1/models, got ${JSON.stringify(
+      body.data.filter((m) => String(m.id).includes("embedding")).map((m) => m.id)
+    )}`
+  );
+  return entry!;
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#11759: a synced embedding model keeps the width the registry states", async () => {
+  const connection = await connectProvider("openrouter");
+
+  // What discovery produces for OpenRouter: typed as an embedding model, and carrying no
+  // width, because the upstream catalogue does not publish one.
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openrouter", connection.id, [
+    {
+      id: OPENROUTER_MODEL,
+      name: "Qwen3 Embedding 8B",
+      source: "imported",
+      supportedEndpoints: ["embeddings"],
+    },
+  ]);
+
+  const entry = await modelEntry(`openrouter/${OPENROUTER_MODEL}`);
+  const expected = registryWidth("openrouter", OPENROUTER_MODEL);
+
+  assert.equal(
+    entry.dimensions,
+    expected,
+    `the registry states ${expected} for "${OPENROUTER_MODEL}"; the synced entry must not drop it — got ${JSON.stringify(entry.dimensions)}`
+  );
+  assert.equal(entry.type, "embedding", "a synced embedding model must stay typed as one");
+});
+
+test("#11759: a synced model the embedding registry names is typed as an embedding model", async () => {
+  const connection = await connectProvider("openai");
+
+  // What discovery produces for OpenAI: no `supportedEndpoints`, because `/v1/models`
+  // returns ids with no capability information, so classification falls back to `["chat"]`
+  // and the model is emitted with no `type` at all.
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openai", connection.id, [
+    {
+      id: OPENAI_MODEL,
+      name: "Text Embedding 3 Small",
+      source: "imported",
+    },
+  ]);
+
+  const entry = await modelEntry(`openai/${OPENAI_MODEL}`);
+
+  assert.equal(
+    entry.type,
+    "embedding",
+    `"${OPENAI_MODEL}" is in the embedding registry, so it must not be published untyped — got ${JSON.stringify(entry.type)}`
+  );
+  assert.equal(
+    entry.dimensions,
+    registryWidth("openai", OPENAI_MODEL),
+    "an embedding model published without its width cannot be indexed by a consumer"
+  );
+});


### PR DESCRIPTION
## What

Keeps the vector width and the `embedding` type on models the embedding registry already describes,
so `/v1/models` reports both instead of dropping them during the catalogue merge.

Closes #11759 (findings 1 and 2). The multi-width enhancement in that issue is not in this PR.

## Why

`embeddingRegistry.ts` is the only machine-readable source of two facts: a model's vector width, and
that it is an embedding model at all. No upstream provider publishes either. Today both are lost
whenever a synced model exists for the same id.

**Width.** The registry entry is skipped rather than merged:

```js
if (hasEquivalentSpecialtyModel(embModel.provider, rawModelId, "embedding", embModel.id)) {
  continue;
}
```

With an OpenRouter provider added through the dashboard, every embedding model comes back typed and
widthless, because discovery produced it first and discovery has no width to give:

```jsonc
{ "id": "openrouter/qwen/qwen3-embedding-8b", "type": "embedding", "api_format": "embeddings" }
```

**Type.** Classification comes from `sm.supportedEndpoints`, which OpenAI does not provide, since
OpenAI's `/v1/models` returns ids with no capability information. The `["chat"]` fallback applies and
`type` is omitted entirely:

```
openai/text-embedding-3-small              type=<none>      dimensions=<none>
openrouter/openai/text-embedding-3-small   type=embedding   dimensions=1536
```

An organization connecting OpenAI rather than OpenRouter therefore sees no embedding models. The
untyped copies are also worse than absent: with no `type` they read as chat models and surface in
chat model pickers, where they cannot work.

## Changes

**`src/app/api/v1/models/catalog.ts`**

- `hasEquivalentSpecialtyModel` is now a wrapper over a new `findEquivalentSpecialtyModel`, so the
  embedding loop can reach the entry rather than only ask whether one exists. The rerank, image and
  audio callers are untouched.
- A registry model whose equivalent already exists fills in what only the registry knows:

```js
if (existingEmbedding) {
  if (embModel.dimensions !== undefined) {
    existingEmbedding.dimensions = embModel.dimensions;
  }
  if (!existingEmbedding.type) {
    existingEmbedding.type = "embedding";
  }
  continue;
}
```

Deduplication is unchanged: same models in, same models out. The surviving entry gains its width, and
gains a type only if nothing has classified it.

The width assignment is unconditional on purpose. Filling only when `dimensions === undefined` would
mean a width captured once can never be corrected by editing the registry, which is what makes the
`gemini-embedding-001` entry below unfixable in place.

**`open-sse/config/embeddingRegistry.ts`**

- `google/gemini-embedding-001` on the `openrouter` route: `768` to `3072`. Measured against
  `https://openrouter.ai/api/v1/embeddings`, the model returns 3072 when `dimensions` is not sent.
  768 is a width it supports but not its default, so a consumer creates a 768 collection, asks for a
  vector and gets 3072 back. Every other entry on that route measures correctly.

## Not in this PR

- The same entry in the direct `gemini` block also records 768. It routes through
  `gemini-embed-content` rather than the OpenAI-compatible path, so it is left alone here rather than
  changed without checking that route behaves the same.
- `dimensions?: number | number[]`, so a model can advertise the choice it actually offers
  (`gemini-embedding-001` honours 3072, 1536 and 768). That is finding 3 of #11759 and a feature
  rather than a fix, so it belongs in its own PR.

## Testing

TODO before opening: tests covering the two catalogue paths, against the 60% gate.

- a registry model whose equivalent was produced by discovery keeps its width
- an untyped equivalent is typed `embedding`; one already typed is left alone
- deduplication is unchanged, so the model count does not move

## Changelog

`changelog.d/fixes/<PR>-embedding-registry-width-and-type.md`:

```
- Keep the registry's vector width and `embedding` type on embedding models when a synced model
  exists for the same id, so `/v1/models` no longer reports them widthless or untyped (#PR)
- Correct `google/gemini-embedding-001` on the OpenRouter route to 3072 dimensions (#PR)
```
