### PR TITLE
fix(resilience): lock permanently retired models instead of short backoff (Gemini ban prevention)

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -239,6 +239,28 @@ export const OAUTH_INVALID_TOKEN_SIGNALS = [
   "invalid credentials",
 ];
 
+// A model that upstream has permanently retired — Gemini's deprecated-model 404
+// ("This model models/gemini-2.5-flash is no longer available to new users...")
+// and Fireworks/OpenAI-compatible "end of life" 410s ("has reached its end of
+// life ... and is no longer available") — will 404/410 on EVERY future request;
+// no cooldown short enough to retry soon is ever correct. Without this check
+// these fall through to the generic "all other errors" branch at the bottom of
+// checkFallbackError, which only applies a short (seconds-to-minutes) transient
+// cooldown, so combo/auto-routing keeps re-selecting the dead model roughly
+// every cooldown window, forever — wasted upstream calls that, at volume, look
+// like abusive traffic to the provider (observed: a Gemini free-tier key
+// retried `gemini-2.5-flash`/`gemini-2.5-flash-lite` every ~15-45 minutes for a
+// full day). Matched independent of MODEL_ACCESS_DENIED_PATTERNS below because
+// those only fire for status 400; this needs to catch the far more common
+// 404/410 status a retired model actually returns.
+export const MODEL_PERMANENTLY_UNAVAILABLE_PATTERNS = [
+  /\bno longer available\b/i,
+  /\bno longer supported\b/i,
+  /\bhas reached (?:its |the )?end.?of.?life\b/i,
+  /\bmodel[\s\S]{0,40}?\b(?:deprecated|retired|discontinued|decommissioned)\b/i,
+  /\b(?:deprecated|retired|discontinued|decommissioned)[\s\S]{0,40}?\bmodel\b/i,
+];
+
 // Context overflow patterns — the prompt exceeds the model's maximum context length.
 // Different providers phrase this differently. Used to decide whether a 400 error
 // should trigger combo fallback (a different model may have a larger context window).
@@ -409,6 +431,15 @@ export function isAccountDeactivated(errorText: string): boolean {
 export function isCreditsExhausted(errorText: string): boolean {
   const lower = String(errorText || "").toLowerCase();
   return CREDITS_EXHAUSTED_SIGNALS.some((sig) => lower.includes(sig));
+}
+
+/**
+ * Returns true if the response body indicates the requested model has been
+ * permanently retired by the provider (see MODEL_PERMANENTLY_UNAVAILABLE_PATTERNS).
+ */
+export function isModelPermanentlyUnavailable(errorText: string): boolean {
+  const text = String(errorText || "");
+  return MODEL_PERMANENTLY_UNAVAILABLE_PATTERNS.some((p) => p.test(text));
 }
 
 /**
@@ -1670,6 +1701,28 @@ export function checkFallbackError(
         cooldownMs: 365 * 24 * 60 * 60 * 1000, // 1 year = effectively permanent
         reason: RateLimitReason.AUTH_ERROR,
         permanent: true,
+      };
+    }
+
+    // A retired model (Gemini deprecated-model 404, Fireworks/etc. end-of-life 410)
+    // will fail identically on every future request — lock it for a long, fixed
+    // window instead of falling through to the generic transient-error branch's
+    // short backoff, which would otherwise keep re-selecting a permanently dead
+    // model roughly every cooldown window, all day, hammering the provider with
+    // guaranteed-to-fail requests (see MODEL_PERMANENTLY_UNAVAILABLE_PATTERNS).
+    // `quotaResetHintMs` flows into combo.ts's per-request model-lockout as an
+    // upstream-verified reset, so it is honored in full and not clamped to the
+    // normal ~20min model-lockout ceiling.
+    if (
+      (status === HTTP_STATUS.NOT_FOUND || status === HTTP_STATUS.GONE) &&
+      isModelPermanentlyUnavailable(errorStr)
+    ) {
+      const cooldownMs = 24 * 60 * 60 * 1000; // 24h
+      return {
+        shouldFallback: true,
+        cooldownMs,
+        reason: "not_found",
+        quotaResetHintMs: cooldownMs,
       };
     }
 

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -245,6 +245,7 @@
       "tests/unit/format-provider-error-cause.test.ts",
       "tests/unit/forwarded-header-budget.test.ts",
       "tests/unit/fusion-vision-panel-3378.test.ts",
+      "tests/unit/gemini-deprecated-model-lockout.test.ts",
       "tests/unit/gemini-web-capabilities-9356.test.ts",
       "tests/unit/gemini-web-missing-browser-3516.test.ts",
       "tests/unit/grok-cli-oauth.test.ts",

--- a/tests/unit/gemini-deprecated-model-lockout.test.ts
+++ b/tests/unit/gemini-deprecated-model-lockout.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression guard: a permanently retired model (Gemini's deprecated-model 404,
+ * "This model models/gemini-2.5-flash is no longer available to new users...",
+ * or a Fireworks/etc. end-of-life 410) must get a long, fixed lockout instead of
+ * falling through to the generic transient-error branch's short backoff.
+ *
+ * Without this classification, combo/auto-routing kept re-selecting the dead
+ * model roughly every cooldown window (a few minutes, escalating to ~20min max)
+ * for as long as the model stayed in the registry — all day, every day — sending
+ * guaranteed-to-fail requests to the provider. At volume this looks like abusive
+ * traffic and was implicated in a Gemini free-tier API key getting banned.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { checkFallbackError, isModelPermanentlyUnavailable } =
+  await import("../../open-sse/services/accountFallback.ts");
+
+const GEMINI_DEPRECATED_404 =
+  "[404]: This model models/gemini-2.5-flash is no longer available to new users. " +
+  "Please update your code to use models/gemini-3.6-flash for the latest features and improvements.";
+
+const END_OF_LIFE_410 =
+  '[410]: {"type":"about:blank","title":"Gone","status":410,"detail":"The model ' +
+  "'minimaxai/minimax-m2.7' has reached its end of life on 2026-07-27T00:00:00Z and is no longer available.\"}\n";
+
+test("isModelPermanentlyUnavailable matches Gemini's deprecated-model phrasing", () => {
+  assert.equal(isModelPermanentlyUnavailable(GEMINI_DEPRECATED_404), true);
+});
+
+test("isModelPermanentlyUnavailable matches end-of-life phrasing", () => {
+  assert.equal(isModelPermanentlyUnavailable(END_OF_LIFE_410), true);
+});
+
+test("isModelPermanentlyUnavailable does not match an ordinary 404", () => {
+  assert.equal(
+    isModelPermanentlyUnavailable("[404]: Model not found, inaccessible, and/or not deployed"),
+    false
+  );
+});
+
+test("checkFallbackError locks a deprecated Gemini model for 24h, not a short backoff", () => {
+  const result = checkFallbackError(404, GEMINI_DEPRECATED_404, 0, "gemini-2.5-flash", "gemini");
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.reason, "not_found");
+  assert.equal(result.cooldownMs, 24 * 60 * 60 * 1000);
+  // Feeds combo.ts's per-request model-lockout as an upstream-verified reset,
+  // so it bypasses the normal ~20min model-lockout ceiling.
+  assert.equal(result.quotaResetHintMs, 24 * 60 * 60 * 1000);
+});
+
+test("checkFallbackError locks an end-of-life model (410) for 24h too", () => {
+  const result = checkFallbackError(410, END_OF_LIFE_410, 0, "minimaxai/minimax-m2.7", "nvidia");
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.reason, "not_found");
+  assert.equal(result.cooldownMs, 24 * 60 * 60 * 1000);
+});
+
+test("a generic 404 (not a deprecation message) still falls through to the short transient cooldown", () => {
+  const result = checkFallbackError(
+    404,
+    "[404]: Model not found, inaccessible, and/or not deployed",
+    0,
+    "some-model",
+    "openrouter"
+  );
+
+  assert.equal(result.reason, "unknown");
+  assert.notEqual(result.cooldownMs, 24 * 60 * 60 * 1000);
+});


### PR DESCRIPTION
## Why this happened

We had a Gemini API key get **banned** after a burst of "spam-looking" traffic. Filtering our 24h request logs for `provider: "gemini"` showed three repeating patterns:

**1. Genuine free-tier 429 quota errors** (expected/handled correctly, not the bug):
```
[429]: You exceeded your current quota, please check your plan and billing details. ...
* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests,
  limit: 20, model: gemini-3-flash
Please retry in 20.551466945s.
```

**2. The actual bug — deprecated-model 404s, recurring every ~15–45 minutes, all day:**
```
"model": "gemini-2.5-flash",
"status": 404,
"error": "[404]: This model models/gemini-2.5-flash is no longer available to new users.
          Please update your code to use models/gemini-3.6-flash for the latest features
          and improvements."
```
```
"model": "gemini-2.5-flash-lite",
"status": 404,
"error": "[404]: This model models/gemini-2.5-flash-lite is no longer available to new users.
          Please update your code to use models/gemini-3.5-flash-lite for the latest features
          and improvements."
```

**3. Symptom of the above — the local rate-limit queue repeatedly getting congested:**
```
"status": 502,
"error": "[502]: Request dropped: the local rate-limit queue for gemini/gemini-3.1-flash-lite
          was detected as wedged (stalled with nothing executing) and force-reset. This is
          OmniRoute's own queue recovering, not an upstream error."
```

### Root cause

I traced `checkFallbackError()` in `open-sse/services/accountFallback.ts` end-to-end. Contrary to my first hypothesis, Gemini's `"Please retry in Ns"` 429 hint is already parsed and honored correctly (`parseRetryFromErrorText` + `useUpstreamRetryHints`, which defaults to `true` for apikey-category providers) — that part was **not** the bug.

The real gap: a 404 for a **permanently retired model** (Google explicitly says "no longer available to new users") had no dedicated classification. It fell through to the generic "all other errors" branch at the bottom of `checkFallbackError`, which only applies a short transient cooldown (a few seconds, escalating to a ~20 minute cap via `BACKOFF_STEPS_MS`). Because Gemini is a per-model-quota provider (`hasPerModelQuota("gemini") === true`), combo/auto-routing kept re-selecting the same dead model roughly every cooldown window — forever, since the model will never succeed. That produced a steady drumbeat of guaranteed-to-fail requests against the account, on top of the genuine 429 bursts on other Gemini model aliases. At volume, this combination looks like abusive/spam traffic to Google and is what got the account flagged and banned.

## The fix

In `open-sse/services/accountFallback.ts`:

- Added `MODEL_PERMANENTLY_UNAVAILABLE_PATTERNS` — matches phrasing like "no longer available", "no longer supported", "has reached its end of life", "model ... deprecated/retired/discontinued" (also fixes the same class of bug for Fireworks/etc. end-of-life 410s, e.g. `minimaxai/minimax-m2.7` seen in the same logs).
- Added `isModelPermanentlyUnavailable()` to test error text against those patterns.
- `checkFallbackError()` now classifies a 404/410 matching those patterns with a **24-hour lockout** (`reason: "not_found"`), instead of the short generic transient cooldown. The lockout is surfaced via `quotaResetHintMs`, which flows into combo's per-request model-lockout (`open-sse/services/combo.ts`) as an *upstream-verified* reset — so it is honored in full and is **not** clamped down to the normal ~20 minute model-lockout ceiling.
- A generic/unrelated 404 (e.g. "Model not found, inaccessible, and/or not deployed") is untouched and still falls through to the existing short-backoff path — this change is narrowly scoped to the specific "permanently retired" phrasing.

### How this prevents future bans

- Once Google tells us a model is retired, OmniRoute now stops hammering it for 24h instead of retrying every few minutes forever — cutting the volume of guaranteed-to-fail requests against a Gemini account from "dozens per day, indefinitely" down to effectively zero after the first failure.
- Combined with the free-tier 429 handling (already correct), this removes the main source of sustained abusive-looking traffic against a single Gemini key, which is the behavior Google's anti-abuse systems flag for bans.

## Testing

Added `tests/unit/gemini-deprecated-model-lockout.test.ts` (6 tests, all passing):
- Matches Gemini's deprecated-model phrasing and generic end-of-life 410 phrasing.
- Does **not** match an unrelated/generic 404.
- `checkFallbackError` returns a 24h lockout (`reason: "not_found"`, `quotaResetHintMs`) for both the Gemini 404 and a Fireworks-style end-of-life 410.
- A generic 404 still gets the short transient cooldown (no regression).

Ran locally:
```
node --import tsx/esm --test tests/unit/gemini-deprecated-model-lockout.test.ts
# 6/6 pass

node --import tsx/esm --test tests/integration/gemini-rate-limit-classification.test.ts \
  tests/unit/account-fallback-service.test.ts tests/unit/error-classification.test.ts
# 133/133 pass, no regressions
```

## Files changed

- `open-sse/services/accountFallback.ts` — new pattern set + classification branch.
- `tests/unit/gemini-deprecated-model-lockout.test.ts` — new regression test.
