### PR TITLE
fix: mark Vercel AI Gateway as passthroughModels

### DIFF
--- a/open-sse/config/providers/registry/vercel-ai-gateway/index.ts
+++ b/open-sse/config/providers/registry/vercel-ai-gateway/index.ts
@@ -10,4 +10,5 @@ export const vercel_ai_gatewayProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "bearer",
   models: CHAT_OPENAI_COMPAT_MODELS["vercel-ai-gateway"],
+  passthroughModels: true,
 };

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -764,6 +764,7 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     icon: "route",
     color: "#111827",
     textIcon: "VAI",
+    passthroughModels: true,
     website: "https://vercel.com/docs/ai-gateway",
   },
   llm7: {


### PR DESCRIPTION
## Problem

Vercel AI Gateway (https://ai-gateway.vercel.sh) recently opened free access to all registered users. When adding custom models under this provider (e.g. `minimax/minimax-m3`, `minimax/minimax-m2.7`), they get stored via the model-alias mechanism and don't work.

## Root cause

`vercel-ai-gateway` is a multi-model routing gateway, same category as `openrouter` and `requesty`, but its provider entry was missing `passthroughModels: true` in:

- `src/shared/constants/providers/apikey/gateways.ts`
- `open-sse/config/providers/registry/vercel-ai-gateway/index.ts`

Without that flag, `isValidModel()` (`open-sse/config/providerModels.ts`) only accepts the handful of models hardcoded in the seed catalog (`open-sse/config/providers/shared.ts`), currently just 5 entries (`openai/gpt-4.1`, `anthropic/claude-4-sonnet`, `google/gemini-2.5-pro`, `moonshotai/kimi-k2`, `vercel/v0-1.5-md`). Any other valid upstream model — like MiniMax's newly free `minimax/minimax-m3` — isn't recognized, and 404s from unlisted models get treated as account-level failures instead of model-specific ones (per the passthroughModels set consumed in `open-sse/config/providerRegistry.ts`).

## Fix

Add `passthroughModels: true` to both vercel-ai-gateway entries, mirroring the existing `openrouter`/`requesty` gateway configs, so any model on the Vercel AI Gateway catalog can be added/used.

## Testing

Config-only change (single boolean literal on an already-typed optional field, matching an existing pattern used elsewhere in the same files). No behavior change for other providers.