### PR TITLE
fix(ci): stamp dist/BUILD_SHA in npm-publish so provenance gate stops blocking releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -226,6 +226,14 @@ jobs:
           JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
         run: npm run build:cli
 
+      # `build:cli` alone never stamps dist/BUILD_SHA (only `build:release` does, via
+      # write-build-sha.mjs) — without this step the provenance gate in
+      # check:pack-artifact (#10427) fails every release-triggered publish, whether the
+      # standalone tree came from a fresh `next build` or the restored CI artifact above.
+      - name: Stamp build provenance (dist/BUILD_SHA)
+        if: steps.resolve.outputs.skip != 'true'
+        run: OMNIROUTE_BUILD_SHA=$(git rev-parse --short HEAD) node scripts/build/write-build-sha.mjs
+
       - name: Validate npm package artifact
         if: steps.resolve.outputs.skip != 'true'
         run: npm run check:pack-artifact


### PR DESCRIPTION
## Why 3.8.50 never reached npm and `omniroute update` still says 3.8.49 is latest

`omniroute update` isn't buggy — it runs `npm view omniroute version --prefer-online` and
reports exactly what the npm registry says. The registry itself is stuck:

```
$ npm view omniroute dist-tags --json
{ "latest": "3.8.49" }
```

even though `v3.8.50` has a git tag and a GitHub Release.

### Root cause

`.github/workflows/npm-publish.yml` builds the CLI bundle with:

```yaml
- name: Build CLI bundle (standalone app)
  run: npm run build:cli
```

`build:cli` (`scripts/build/prepublish.ts`) assembles `dist/`, but it never writes
`dist/BUILD_SHA`. Only `npm run build:release` does that, via
`scripts/build/write-build-sha.mjs` (`build:release` = `build` + `build:cli` +
`write-build-sha.mjs`, see package.json).

The build-provenance gate added by #10427 (`scripts/build/buildProvenance.ts`, enforced inside
`npm run check:pack-artifact`) hard-fails when `dist/BUILD_SHA` is missing:

```
[provenance] dist/BUILD_SHA is missing — the artifact cannot be traced to a commit.
❌ Build provenance check failed.
##[error]Process completed with exit code 1.
```

Confirmed in the actual failed runs:

- `v3.8.50` release-triggered `npm-publish.yml` run (id `33005520967`): failed at
  `check:pack-artifact` with exactly this error.
- The same release-triggered run for `v3.8.49` also failed for the same reason; only a later
  `workflow_dispatch` run happened to succeed, which is why 3.8.49 made it to npm at all while
  the regular release-tag publish for 3.8.50 silently did not.

So since #10427 landed, the release-tag-triggered publish path has been broken: it builds the
tarball, then fails its own provenance check, and the job stops before `npm publish` ever runs —
with no version bump landing on the registry.

### Fix

Add a step right after "Build CLI bundle" and before "Validate npm package artifact" that stamps
the same sentinel `build:release` writes:

```yaml
- name: Stamp build provenance (dist/BUILD_SHA)
  if: steps.resolve.outputs.skip != 'true'
  run: OMNIROUTE_BUILD_SHA=$(git rev-parse --short HEAD) node scripts/build/write-build-sha.mjs
```

This works whether `dist/`'s `.build/next/standalone` came from a fresh `next build` or from the
restored CI `next-build` artifact (the "Reuse CI's next-build artifact" step above it) — both
paths produce `.build/next/standalone`, which is all `write-build-sha.mjs` requires.

The same `dist/` is reused by all three publish steps later in the job (npm staged publish, npm
direct/emergency publish, and GitHub Packages publish), so this one addition unblocks every
publish mode in this workflow.

### Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/npm-publish.yml'))"` — YAML
  parses cleanly after the edit.
- Traced the actual failing CI run logs (`gh run view <id> --log-failed`) to confirm the exact
  failure point and message quoted above.
- This is a CI-workflow-only change (no `src/`, `open-sse/`, `electron/`, or `bin/` production
  code touched), so the 60/60/60/60 coverage gate and per-PR test requirement do not apply — the
  actual validation is the next `npm-publish.yml` run itself succeeding through
  `check:pack-artifact` and `npm publish`.

### Follow-up needed after merge

Merging this alone does not retroactively publish 3.8.50 — a maintainer needs to re-run (or
re-trigger via a new patch/tag) the `npm-publish.yml` workflow so the registry catches up.
