### PR TITLE
fix(combo): lock GitHub models rejected as "not supported" for future requests

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -16,6 +16,7 @@ import {
   hasPerModelQuota,
   isAccountSemaphoreFull,
   isModelLocked,
+  lockModelIfPerModelQuota,
   MODEL_ACCESS_DENIED_PATTERNS,
   recordModelLockoutFailure,
   recordProviderFailure,
@@ -2231,6 +2232,26 @@ async function handleComboChatInner({
             return { ok: false, response: result };
           }
 
+          // A model-scoped 400 ("The requested model is not supported" / "not
+          // available for integrator") is permanent for THIS connection — the
+          // account/integration will not gain support for the model mid-session.
+          // Combo still advances to the next target immediately (unchanged,
+          // preserves #5249's cross-provider fallback), but without a lockout
+          // here the SAME dead model gets retried on every future, separate
+          // request forever (observed: every auto-combo request wasted several
+          // upstream 400s on the same GitHub models, all day). isModelLocked()
+          // is checked before dispatch (see the pre-check above this loop), so
+          // this lockout is honored on the next request.
+          if (result.status === 400 && isModelScoped400(errorText) && provider && rawModel) {
+            lockModelIfPerModelQuota(
+              provider,
+              targetWithConnection.connectionId || "",
+              rawModel,
+              "model_capacity",
+              60 * 60 * 1000 // 1h
+            );
+          }
+
           // Trigger shared provider circuit breaker for 5xx errors and connection failures. If the
           // next target is on the same provider, don't mark it failed (a different model may still
           // succeed) — #8376: EXCEPT a proxy-unreachable failure, which poisons every model alike.
@@ -3286,24 +3307,20 @@ async function handleRoundRobinCombo({
               "COMBO-RR",
               `Maximum combo attempts (${maxGlobalAttempts}) exceeded. Terminating loop to prevent runaway requests.`
             );
-            return errorResponseWithComboDiagnostics(
-              503,
-              "Maximum combo retry limit reached",
-              {
-                poolSize: modelCount,
-                attempted: globalAttempts,
-                excluded: [
-                  ...[...exhaustedProviders].map((p) => ({ provider: p, reason: "exhausted" })),
-                  ...[...exhaustedConnections].map((c) => formatExhaustedConnectionKey(String(c))),
-                ],
-                attemptOrder: rrOutcomes.map((o) => ({
-                  provider: o.model.split("/")[0] || "unknown",
-                  model: o.model,
-                })),
-                terminalReason: "max_attempts_exceeded",
-                recovery: buildRecoveryHint("max_attempts_exceeded"),
-              }
-            );
+            return errorResponseWithComboDiagnostics(503, "Maximum combo retry limit reached", {
+              poolSize: modelCount,
+              attempted: globalAttempts,
+              excluded: [
+                ...[...exhaustedProviders].map((p) => ({ provider: p, reason: "exhausted" })),
+                ...[...exhaustedConnections].map((c) => formatExhaustedConnectionKey(String(c))),
+              ],
+              attemptOrder: rrOutcomes.map((o) => ({
+                provider: o.model.split("/")[0] || "unknown",
+                model: o.model,
+              })),
+              terminalReason: "max_attempts_exceeded",
+              recovery: buildRecoveryHint("max_attempts_exceeded"),
+            });
           }
           if (retry > 0) {
             log.info(

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -180,6 +180,7 @@
       "tests/unit/combo-lockout-quota-reset-6863.test.ts",
       "tests/unit/combo-max-depth-config.test.ts",
       "tests/unit/combo-model-lockout-honors-reset-1308.test.ts",
+      "tests/unit/combo-model-scoped-400-advance.test.ts",
       "tests/unit/combo-omnimodel-tag-stripping.test.ts",
       "tests/unit/combo-param-validation-fallback-4519.test.ts",
       "tests/unit/combo-prescreen.test.ts",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -247,6 +247,7 @@
       "tests/unit/fusion-vision-panel-3378.test.ts",
       "tests/unit/gemini-web-capabilities-9356.test.ts",
       "tests/unit/gemini-web-missing-browser-3516.test.ts",
+      "tests/unit/github-model-not-supported-lockout.test.ts",
       "tests/unit/grok-cli-oauth.test.ts",
       "tests/unit/guardrails-api-3496.test.ts",
       "tests/unit/guardrails/visionBridge-responses-9597.test.ts",

--- a/tests/unit/combo-model-scoped-400-advance.test.ts
+++ b/tests/unit/combo-model-scoped-400-advance.test.ts
@@ -26,6 +26,16 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "combo-model-400-test-secret";
 
 const { handleComboChat, isModelScoped400 } = await import("../../open-sse/services/combo.ts");
+const { clearAllModelLockouts } = await import("../../open-sse/services/accountFallback.ts");
+
+// Reused "github/claude-fable-5" across sub-tests below now persists a
+// cross-request model lockout on a 400 "model not supported" (matches
+// production combo.ts behavior). Reset it between tests so each sub-test
+// still exercises a fresh dispatch instead of being skipped by a lockout
+// left over from a previous sub-test in this file.
+test.beforeEach(() => {
+  clearAllModelLockouts();
+});
 
 const noop = () => {};
 const log = { info: noop, warn: noop, debug: noop, error: noop };
@@ -53,7 +63,10 @@ test("isModelScoped400 recognizes model-not-supported shapes (incl. invalid/Bad 
   assert.equal(isModelScoped400("Bad Request: The model is not supported"), true);
   assert.equal(isModelScoped400("model claude-fable-5 does not support Responses API."), true);
   assert.equal(isModelScoped400("unsupported_api_for_model"), true);
-  assert.equal(isModelScoped400("The model `x` does not exist or you do not have access to it."), true);
+  assert.equal(
+    isModelScoped400("The model `x` does not exist or you do not have access to it."),
+    true
+  );
   // Genuinely body-specific — must NOT be treated as model-scoped
   assert.equal(isModelScoped400("Invalid message format: the request body is malformed."), false);
   assert.equal(isModelScoped400("malformed JSON in request body"), false);
@@ -68,7 +81,10 @@ async function assertAdvancesOn(errorMessage: string, label: string) {
     handleSingleModel: async (_body: unknown, modelStr: string) => {
       modelsCalled.push(modelStr);
       if (modelStr === "github/claude-fable-5") {
-        return Response.json({ error: { message: errorMessage, type: "invalid_request_error" } }, { status: 400 });
+        return Response.json(
+          { error: { message: errorMessage, type: "invalid_request_error" } },
+          { status: 400 }
+        );
       }
       return okResponse(modelStr);
     },
@@ -128,6 +144,10 @@ test("combo still STOPS on genuinely body-specific invalid message format", asyn
     allCombos: [],
   });
 
-  assert.equal(modelsCalled.length, 1, `body-specific 400 must stop at target 1; tried: ${modelsCalled.join(", ")}`);
+  assert.equal(
+    modelsCalled.length,
+    1,
+    `body-specific 400 must stop at target 1; tried: ${modelsCalled.join(", ")}`
+  );
   assert.equal(response.status, 400, "body-specific 400 must surface to the client");
 });

--- a/tests/unit/github-model-not-supported-lockout.test.ts
+++ b/tests/unit/github-model-not-supported-lockout.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression guard: a GitHub Copilot 400 "The requested model is not
+ * supported" / "not available for integrator ..." — permanent for THIS
+ * account/integration — must get locked out via lockModelIfPerModelQuota so
+ * future, separate requests skip the same dead model instead of retrying it
+ * on every single auto-combo request forever (observed: every request in
+ * production logs wasted several upstream 400 calls on the same GitHub
+ * models — gpt-5.4, gpt-5.5, gpt-5.6-luna, etc. — all day).
+ *
+ * Combo's existing #5249/#2101 guard already lets the current request keep
+ * rotating to the next target — that behavior is unchanged and untested
+ * here. This guards the NEW cross-request lockout side effect only.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { isModelScoped400 } = await import("../../open-sse/services/combo/comboPredicates.ts");
+const { lockModelIfPerModelQuota, isModelLocked, hasPerModelQuota } =
+  await import("../../open-sse/services/accountFallback.ts");
+
+const GITHUB_NOT_SUPPORTED_400 = "[400]: The requested model is not supported.";
+const GITHUB_INTEGRATOR_400 =
+  '[400]: The requested model is not available for integrator "vscode-chat". ' +
+  "Available models: [gpt-4.1 claude-fable-5]. Verify the correct Copilot-Integration-Id header is being sent.";
+
+test("isModelScoped400 matches GitHub's two 'model not supported' phrasings", () => {
+  assert.equal(isModelScoped400(GITHUB_NOT_SUPPORTED_400), true);
+  assert.equal(isModelScoped400(GITHUB_INTEGRATOR_400), true);
+});
+
+test("github has per-model quota (locks the model, not the whole connection)", () => {
+  assert.equal(hasPerModelQuota("github"), true);
+});
+
+test("lockModelIfPerModelQuota locks a model-not-supported GitHub model for future requests", () => {
+  const connectionId = `github-${Date.now()}`;
+
+  const locked = lockModelIfPerModelQuota(
+    "github",
+    connectionId,
+    "gpt-5.4",
+    "model_capacity",
+    60 * 60 * 1000
+  );
+
+  assert.equal(locked, true);
+  assert.equal(isModelLocked("github", connectionId, "gpt-5.4"), true);
+  // A sibling model on the same connection must stay eligible.
+  assert.equal(isModelLocked("github", connectionId, "gpt-5.5"), false);
+});


### PR DESCRIPTION
## Follow-up to #11762 / #11774 — same bug class, this time in combo's own model routing

Checking a fresh 1h log confirmed another instance of the "permanent failure never gets locked out, so it's retried forever" bug — this time not in `checkFallbackError`'s classification, but in `combo.ts`'s own model-lockout wiring.

### The symptom

`github` rejects several models with a 400 that is **permanent for this account's Copilot integration** — it will never start working mid-session:
```
"provider": "github",
"model": "gpt-5.4",
"status": 400,
"error": "[400]: The requested model is not supported."
```
```
"provider": "github",
"model": "gpt-5.3-codex",
"status": 400,
"error": "[400]: The requested model is not available for integrator \"vscode-chat\".
          Available models: [gpt-4.1 claude-fable-5 ... gemini-3.6-flash ...].
          Verify the correct Copilot-Integration-Id header is being sent."
```
This isn't a one-off — the same models (`gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`, `mai-code-1-flash`) get rejected with this exact 400 on **every single `virtual-auto-default-*-github` combo step, in every request, for the entire hour** (dozens of times across the log). Each occurrence is a wasted upstream call.

### Root cause

Combo's #5249 guard (`isModelScoped400`) correctly lets the combo **advance to the next target within the same request** — that's intentional and correct, since a different provider might serve the model. But nothing ever recorded a **cross-request** lockout for the rejected model, because the per-request "same-model retry" lockout path in `combo.ts` (`recordModelLockoutFailure`, gated by `isTransient`) only fires for `[408, 429, 500, 502, 503, 504]` — **400 is deliberately excluded there** (a 400 always advances immediately, never retries the same model in-request). So a model that GitHub will reject forever for this account gets tried again from scratch on every new incoming request, indefinitely.

### The fix

In `open-sse/services/combo.ts`, right after the existing #2101/#5249 stop-guard: when `isModelScoped400(errorText)` is true, call `lockModelIfPerModelQuota(provider, connectionId, rawModel, "model_capacity", 1h)`.

- `github` already has per-model-quota enabled (`hasPerModelQuota("github") === true`), so this locks **only the rejected model**, not the whole GitHub connection — sibling models keep working normally.
- `isModelLocked()` is already checked **before dispatch** on every future request (`combo.ts` pre-check), so the lockout is honored automatically — no other wiring needed.
- The in-request combo-advance behavior from #5249 is completely unchanged; this only adds a side effect for *future, separate* requests.

### Testing

Added `tests/unit/github-model-not-supported-lockout.test.ts` (3 tests, all passing):
- `isModelScoped400` matches both GitHub phrasings from the logs.
- `github` confirmed as a per-model-quota provider.
- `lockModelIfPerModelQuota` locks the rejected model while leaving a sibling model on the same connection eligible.

Also fixed `tests/unit/combo-model-scoped-400-advance.test.ts`: its sub-tests reuse the same model name (`github/claude-fable-5`) across several `test()` blocks without clearing lockout state — with the new persistent lockout, the first sub-test's 400 now (correctly) locks that model, causing later sub-tests in the same process to skip it. Added a `clearAllModelLockouts()` `beforeEach` to keep each sub-test isolated; no behavioral assertions changed.

Ran locally:
```
node --import tsx/esm --test tests/unit/github-model-not-supported-lockout.test.ts
# 3/3 pass

node --import tsx/esm --test tests/unit/combo-body-specific-400-stop-4279.test.ts \
  tests/unit/account-fallback-service.test.ts tests/unit/agentrouter-lock-scope-10334.test.ts
# 113/113 pass

node --import tsx/esm --test tests/unit/combo-model-scoped-400-advance.test.ts \
  tests/unit/combo-param-validation-fallback-4519.test.ts
# 12/12 pass (was 2 failing before the beforeEach fix — confirmed root cause, not a real regression)

node --import tsx/esm --test tests/unit/combo-quota-token-limit.test.ts \
  tests/unit/combo-lockout-quota-reset-6863.test.ts tests/unit/model-lockout-max-cooldown.test.ts \
  tests/unit/combo-terminal-status-policy-10501.test.ts tests/unit/combo-resource-404-health.test.ts \
  tests/unit/combo-input-bound-failure-8375.test.ts tests/unit/combo-input-bound-heterogeneous-8375.test.ts
# 12/12 pass, no regressions
```

Also registered the new test in `stryker.conf.json`'s `tap.testFiles` (required for the `mutation-test-coverage` gate, per CI feedback on #11762).

## Files changed

- `open-sse/services/combo.ts` — new `lockModelIfPerModelQuota` import + call at the model-scoped-400 site.
- `tests/unit/github-model-not-supported-lockout.test.ts` — new regression test.
- `tests/unit/combo-model-scoped-400-advance.test.ts` — added lockout-state isolation between sub-tests.
- `stryker.conf.json` — register the new test file.
