### PR TITLE
[Barrel #59 Phase 3] Migrate 32 src/lib/ files from localDb barrel to direct db/ imports

### DIFF
--- a/src/lib/api/proxyRegistryRouteHandlers.ts
+++ b/src/lib/api/proxyRegistryRouteHandlers.ts
@@ -1,16 +1,9 @@
-import {
-  createProxy,
-  createProxyAndAssign,
-  deleteProxyById,
-  getProxyById,
-  getProxyWhereUsed,
-  updateProxy,
-  updateProxyAndAssign,
-} from "@/lib/localDb";
+
 import { createErrorResponse, createErrorResponseFromUnknown } from "@/lib/api/errorResponse";
 import { createProxyRegistrySchema, updateProxyRegistrySchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { clearDispatcherCache } from "@omniroute/open-sse/utils/proxyDispatcher";
+import { createProxy, createProxyAndAssign, deleteProxyById, getProxyById, getProxyWhereUsed, updateProxy, updateProxyAndAssign } from "@/lib/db/proxies";
 
 async function readJsonBody(request: Request) {
   try {

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
-import { getProviderConnections, updateProviderConnection } from "@/lib/localDb";
+
 import { buildConfigSyncEnvelope, toLegacyCloudSyncPayload } from "@/lib/sync/bundle";
+import { getProviderConnections, updateProviderConnection } from "@/lib/db/providers";
 
 const CLOUD_URL = process.env.CLOUD_URL || process.env.NEXT_PUBLIC_CLOUD_URL;
 const CLOUD_SYNC_TIMEOUT_MS = Number(process.env.CLOUD_SYNC_TIMEOUT_MS || 12000);

--- a/src/lib/combos/builderOptions.ts
+++ b/src/lib/combos/builderOptions.ts
@@ -1,12 +1,4 @@
-import {
-  getAllCustomModels,
-  getAllSyncedAvailableModels,
-  getCombos,
-  getModelIsHidden,
-  getProviderConnections,
-  getProviderNodes,
-  getSettings,
-} from "@/lib/localDb";
+
 import { getAccountDisplayName, getProviderDisplayName } from "@/lib/display/names";
 import { getCompatibleFallbackModels } from "@/lib/providers/managedAvailableModels";
 import { getResolvedModelCapabilities } from "@/lib/modelCapabilities";
@@ -21,6 +13,10 @@ import {
 } from "@/shared/constants/providers";
 import type { RegistryModel } from "@omniroute/open-sse/config/providerRegistry.ts";
 import { appendSyncedEffortVariants } from "@omniroute/open-sse/utils/syncedEffortVariants";
+import { getAllCustomModels, getAllSyncedAvailableModels, getModelIsHidden } from "@/lib/db/models";
+import { getCombos } from "@/lib/db/combos";
+import { getProviderConnections, getProviderNodes } from "@/lib/db/providers";
+import { getSettings } from "@/lib/db/settings";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -18,7 +18,7 @@
  */
 
 import { testSingleConnection } from "@/app/api/providers/[id]/test/route";
-import { getProviderConnections } from "@/lib/localDb";
+
 import {
   setCredentialHealth,
   removeCredentialHealth,
@@ -31,6 +31,7 @@ import {
 import { emit } from "@/lib/events/eventBus";
 import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 import { SEARCH_VALIDATOR_CONFIGS } from "@/lib/providers/validation/searchProviders";
+import { getProviderConnections } from "@/lib/db/providers";
 
 // ── Config ────────────────────────────────────────────────────────────────
 

--- a/src/lib/evals/runtime.ts
+++ b/src/lib/evals/runtime.ts
@@ -1,8 +1,10 @@
 import { POST as postChatCompletion } from "@/app/api/v1/chat/completions/route";
 import type { PersistedEvalRun, EvalTargetType } from "@/lib/db/evals";
 import { saveEvalRun } from "@/lib/db/evals";
-import { getApiKeyById, getCombos } from "@/lib/localDb";
+
 import { getSuite, listSuites, runSuite } from "./evalRunner";
+import { getApiKeyById } from "@/lib/db/apiKeys";
+import { getCombos } from "@/lib/db/combos";
 
 export interface EvalTargetInput {
   type: EvalTargetType;

--- a/src/lib/freeProxyProviders/scheduler.ts
+++ b/src/lib/freeProxyProviders/scheduler.ts
@@ -22,8 +22,9 @@
  */
 
 import { getEnabledProviders } from "@/lib/freeProxyProviders";
-import { getFreeProxyStats } from "@/lib/localDb";
+
 import { runFreeProxySyncCycle, type FreeProxySyncCycleResult } from "./syncCycle";
+import { getFreeProxyStats } from "@/lib/db/freeProxies";
 
 const STARTUP_DELAY_MS = 5_000;
 const DEFAULT_INTERVAL_MS = 1_800_000;

--- a/src/lib/freeProxyProviders/syncCycle.ts
+++ b/src/lib/freeProxyProviders/syncCycle.ts
@@ -1,10 +1,7 @@
 import { getEnabledProviders } from "@/lib/freeProxyProviders";
-import {
-  recordFreeProxySync,
-  clearFreeProxySyncErrors,
-  recordFreeProxySyncErrors,
-} from "@/lib/localDb";
+
 import type { FreeProxyProvider } from "@/lib/freeProxyProviders/types";
+import { recordFreeProxySync, clearFreeProxySyncErrors, recordFreeProxySyncErrors } from "@/lib/db/freeProxies";
 
 export interface FreeProxySyncCycleResult {
   results: Record<string, unknown>;

--- a/src/lib/idempotencyLayer.ts
+++ b/src/lib/idempotencyLayer.ts
@@ -1,3 +1,4 @@
+import { getSettings } from "@/lib/db/settings";
 /**
  * Idempotency Layer — Phase 9.2
  *
@@ -10,7 +11,7 @@
  * @module lib/idempotencyLayer
  */
 
-import { getSettings } from "@/lib/localDb";
+
 
 const DEFAULT_WINDOW_MS = 5000;
 

--- a/src/lib/images/imageRouteModel.ts
+++ b/src/lib/images/imageRouteModel.ts
@@ -18,7 +18,8 @@ import { parseImageModel } from "@omniroute/open-sse/config/imageRegistry.ts";
 import { resolveComboTargets } from "@omniroute/open-sse/services/combo.ts";
 
 import { getComboByName, getCombos } from "@/lib/db/combos";
-import { getCachedProviderNodes } from "@/lib/localDb";
+import { getCachedProviderNodes } from "@/lib/db/readCache";
+
 
 /**
  * Rewrite a `prefix/model` custom image model to its internal `<nodeId>/<model>` form.

--- a/src/lib/localHealthCheck.ts
+++ b/src/lib/localHealthCheck.ts
@@ -11,8 +11,9 @@
  * Uses Promise.allSettled so one slow/down node doesn't block others.
  */
 
-import { getCachedProviderNodes } from "@/lib/localDb";
+
 import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
+import { getCachedProviderNodes } from "@/lib/db/readCache";
 
 // ── Types ────────────────────────────────────────────────────────────────
 

--- a/src/lib/memory/embedding/index.ts
+++ b/src/lib/memory/embedding/index.ts
@@ -5,7 +5,7 @@ import {
   type EmbeddingProviderNodeRow,
 } from "@omniroute/open-sse/config/embeddingRegistry.ts";
 import { getProviderCredentials } from "@/sse/services/auth";
-import { getCachedProviderNodes } from "@/lib/localDb";
+
 import type { MemorySettingsExtended } from "@/shared/schemas/memory";
 import type {
   EmbeddingResolution,
@@ -18,6 +18,7 @@ import { embedStatic } from "./staticPotion";
 import { embedTransformers } from "./transformersLocal";
 import { buildCacheKey, get as cacheGet, set as cacheSet } from "./cache";
 import { resolveMemoryCustomEmbeddingProvider } from "./customProvider";
+import { getCachedProviderNodes } from "@/lib/db/readCache";
 
 const STATIC_MODEL = process.env.MEMORY_STATIC_MODEL || "minishlab/potion-base-8M";
 const TRANSFORMERS_MODEL = process.env.MEMORY_TRANSFORMERS_MODEL || "Xenova/all-MiniLM-L6-v2";

--- a/src/lib/memory/reindex.ts
+++ b/src/lib/memory/reindex.ts
@@ -3,16 +3,13 @@
  * Used by POST /api/memory/reindex (F6).
  */
 
-import {
-  getMemoryReindexQueue,
-  countMemoryReindexPending,
-  markMemoryNeedsReindex,
-} from "@/lib/localDb";
+
 import { resolveEmbeddingSource, embed } from "./embedding";
 import { getVectorStore } from "./vectorStore";
 import { getMemorySettings } from "./settings";
 import { logger } from "../../../open-sse/utils/logger.ts";
 import { sanitizeErrorMessage } from "../../../open-sse/utils/error.ts";
+import { getMemoryReindexQueue, countMemoryReindexPending, markMemoryNeedsReindex } from "@/lib/db/memoryVec";
 
 const log = logger("MEMORY_REINDEX");
 

--- a/src/lib/memory/store.ts
+++ b/src/lib/memory/store.ts
@@ -10,7 +10,8 @@ import { sanitizeErrorMessage } from "../../../open-sse/utils/error.ts";
 import { resolveEmbeddingSource, embed } from "./embedding";
 import { getVectorStore } from "./vectorStore";
 import { getMemorySettings } from "./settings";
-import { markMemoryNeedsReindex } from "@/lib/localDb";
+import { markMemoryNeedsReindex } from "@/lib/db/memoryVec";
+
 
 const log = logger("MEMORY_STORE");
 

--- a/src/lib/monitoring/providerHealthAutopilot.ts
+++ b/src/lib/monitoring/providerHealthAutopilot.ts
@@ -1,9 +1,10 @@
 import { createHash } from "crypto";
 
 import { getProviderConnections, updateProviderConnection } from "@/lib/db/providers";
-import { getCachedProviderConnectionById } from "@/lib/localDb";
+
 import { clearProviderFailure, clearModelLock } from "@omniroute/open-sse/services/accountFallback";
 import { resolveProviderAlias } from "@omniroute/open-sse/services/model";
+import { getCachedProviderConnectionById } from "@/lib/db/readCache";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/oauth/utils/agyAuthImport.ts
+++ b/src/lib/oauth/utils/agyAuthImport.ts
@@ -1,14 +1,11 @@
-import {
-  getProviderConnections,
-  createProviderConnection,
-  updateProviderConnection,
-} from "@/lib/localDb";
+
 import { AGY_CONFIG } from "@/lib/oauth/constants/oauth";
 import {
   getAntigravityContentHeaders,
   getAntigravityLoadCodeAssistMetadata,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
 import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
+import { getProviderConnections, createProviderConnection, updateProviderConnection } from "@/lib/db/providers";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/oauth/utils/claudeAuthFile.ts
+++ b/src/lib/oauth/utils/claudeAuthFile.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import { getCachedProviderConnectionById } from "@/lib/localDb";
+
 import { createBackup } from "@/shared/services/backupService";
 import { getCliConfigPaths } from "@/shared/services/cliRuntime";
 import {
@@ -9,6 +9,7 @@ import {
   updateProviderCredentials,
 } from "@/sse/services/tokenRefresh";
 import { isUnrecoverableRefreshError } from "@omniroute/open-sse/services/tokenRefresh.ts";
+import { getCachedProviderConnectionById } from "@/lib/db/readCache";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/oauth/utils/claudeAuthImport.ts
+++ b/src/lib/oauth/utils/claudeAuthImport.ts
@@ -1,11 +1,8 @@
 import crypto from "node:crypto";
-import {
-  getProviderConnections,
-  createProviderConnection,
-  updateProviderConnection,
-} from "@/lib/localDb";
+
 import { getClaudeCodeUserAgent } from "@/shared/constants/claudeCodeClient";
 import { ClaudeAuthFileError } from "@/lib/oauth/utils/claudeAuthFile";
+import { getProviderConnections, createProviderConnection, updateProviderConnection } from "@/lib/db/providers";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/oauth/utils/codexAuthFile.ts
+++ b/src/lib/oauth/utils/codexAuthFile.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import { getCachedProviderConnectionById } from "@/lib/localDb";
+
 import { createBackup } from "@/shared/services/backupService";
 import { getCliConfigPaths } from "@/shared/services/cliRuntime";
 import {
@@ -9,6 +9,7 @@ import {
   updateProviderCredentials,
 } from "@/sse/services/tokenRefresh";
 import { isUnrecoverableRefreshError } from "@omniroute/open-sse/services/tokenRefresh.ts";
+import { getCachedProviderConnectionById } from "@/lib/db/readCache";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/oauth/utils/codexAuthImport.ts
+++ b/src/lib/oauth/utils/codexAuthImport.ts
@@ -1,10 +1,7 @@
-import {
-  getProviderConnections,
-  createProviderConnection,
-  updateProviderConnection,
-} from "@/lib/localDb";
+
 import { CodexAuthFileError } from "@/lib/oauth/utils/codexAuthFile";
 import { pickCodexConnectionForUser } from "@/lib/oauth/utils/codexConnectionSelection";
+import { getProviderConnections, createProviderConnection, updateProviderConnection } from "@/lib/db/providers";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/providerModels/managedAvailableModels.ts
+++ b/src/lib/providerModels/managedAvailableModels.ts
@@ -1,16 +1,12 @@
-import {
-  deleteModelAlias,
-  getModelAliases,
-  getModelIsHidden,
-  getProviderNodeById,
-  setModelAlias,
-} from "@/lib/localDb";
+
 import {
   getProviderAlias,
   isAnthropicCompatibleProvider,
   isOpenAICompatibleProvider,
 } from "@/shared/constants/providers";
 import { resolveManagedModelAlias } from "@/shared/utils/providerModelAliases";
+import { deleteModelAlias, getModelAliases, getModelIsHidden, setModelAlias } from "@/lib/db/models";
+import { getProviderNodeById } from "@/lib/db/providers";
 
 function isCompatibleProvider(providerId: string): boolean {
   return isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId);

--- a/src/lib/proxyHealth/scheduler.ts
+++ b/src/lib/proxyHealth/scheduler.ts
@@ -22,7 +22,7 @@
  *                               same threshold, not independently tunable.
  */
 
-import { deleteProxyById, listProxies, updateProxy } from "@/lib/localDb";
+
 import { isProxyLogIncludeIps } from "@/lib/proxyLogger";
 import {
   getRecentEgressSharingSummary,
@@ -47,6 +47,7 @@ import {
   waitForProbeSlot,
 } from "./probeTarget.ts";
 import { resolveProviderProbeTarget } from "./providerProbeTarget.ts";
+import { deleteProxyById, listProxies, updateProxy } from "@/lib/db/proxies";
 
 // #6246: a HEAD to the public probe target through a legit (often loaded) proxy
 // can exceed a few seconds; the old 5s ceiling produced false negatives that

--- a/src/lib/quota/planResolver.ts
+++ b/src/lib/quota/planResolver.ts
@@ -12,9 +12,10 @@
  * Part of: Group B — Quota Sharing Engine (plan 22, frente F6).
  */
 
-import { getProviderPlan } from "@/lib/localDb";
+
 import { getKnownPlan } from "./planRegistry";
 import type { ProviderPlan } from "./dimensions";
+import { getPlan as getProviderPlan } from "@/lib/db/providerPlans";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/lib/quota/quotaCombos.ts
+++ b/src/lib/quota/quotaCombos.ts
@@ -12,7 +12,7 @@
 
 import { getPool } from "@/lib/db/quotaPools";
 import { getGroupName } from "@/lib/db/quotaGroups";
-import { getCachedProviderConnectionById } from "@/lib/localDb";
+
 import {
   getCombos,
   createCombo,
@@ -29,6 +29,7 @@ import {
 } from "./quotaModelNaming";
 import { createLogger } from "@/shared/utils/logger";
 import type { AnyRoutingStrategyValue } from "@/shared/constants/routingStrategies";
+import { getCachedProviderConnectionById } from "@/lib/db/readCache";
 
 /**
  * Routing strategy for every auto-minted quota-share (qtSd/) combo. Internal

--- a/src/lib/quota/quotaKey.ts
+++ b/src/lib/quota/quotaKey.ts
@@ -8,10 +8,11 @@
  */
 
 import { getPool, getPoolsByGroup } from "@/lib/db/quotaPools";
-import { getCachedProviderConnectionById } from "@/lib/localDb";
+
 import { getApiKeyById, updateApiKeyPermissions } from "@/lib/db/apiKeys";
 import { quotaGroupSlug } from "./quotaModelNaming";
 import { getGroupName } from "@/lib/db/quotaGroups";
+import { getCachedProviderConnectionById } from "@/lib/db/readCache";
 
 // ---------------------------------------------------------------------------
 // Public interface

--- a/src/lib/quota/redisQuotaStore.ts
+++ b/src/lib/quota/redisQuotaStore.ts
@@ -16,14 +16,12 @@
  * Part of: Group B — Quota Sharing Engine (plan 22, frente F6).
  */
 
-import {
-  getPool,
-  listAllocationsForApiKey,
-} from "@/lib/localDb";
+
 import { WINDOW_MS, dimensionKeyToString } from "./dimensions";
 import type { DimensionKey } from "./dimensions";
 import type { QuotaStore, PoolUsageSnapshot } from "./types";
 import { computeBurnRateFromWindow } from "./burnRate";
+import { getPool, listAllocationsForApiKey } from "@/lib/db/quotaPools";
 
 // ---------------------------------------------------------------------------
 // Redis connection singleton

--- a/src/lib/quota/sqliteQuotaStore.ts
+++ b/src/lib/quota/sqliteQuotaStore.ts
@@ -15,11 +15,13 @@
  * Part of: Group B — Quota Sharing Engine (plan 22, frente F6).
  */
 
-import { getPool, getBucket, incrementBucket, getPair, sumPoolDimension } from "@/lib/localDb";
+
 import { WINDOW_MS, dimensionKeyToString } from "./dimensions";
 import type { DimensionKey } from "./dimensions";
 import type { QuotaStore, PoolUsageSnapshot } from "./types";
 import { computeBurnRateFromWindow } from "./burnRate";
+import { getPool } from "@/lib/db/quotaPools";
+import { getBucket, incrementBucket, getPair, sumPoolDimension } from "@/lib/db/quotaConsumption";
 
 // ---------------------------------------------------------------------------
 // In-memory mutex (anti-thundering-herd, same pattern as auth.ts)

--- a/src/lib/services/quotaAutoPing.ts
+++ b/src/lib/services/quotaAutoPing.ts
@@ -25,11 +25,13 @@ import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
 import { getExecutor } from "@omniroute/open-sse/executors/index.ts";
 import type { BaseExecutor } from "@omniroute/open-sse/executors/base";
 import { getCodexUsage } from "@omniroute/open-sse/services/usage/codex.ts";
-import { getSettings, getProviderConnections, updateProviderConnection } from "@/lib/localDb";
+
 import { isConnectionUnavailableToAuxiliaryActivity } from "@/lib/exclusiveLeaseIsolation";
 import { refreshAndUpdateCredentials } from "@/lib/usage/providerLimits";
 import { getCircuitBreaker } from "@/shared/utils/circuitBreaker";
 import {
+import { getSettings } from "@/lib/db/settings";
+import { getProviderConnections, updateProviderConnection } from "@/lib/db/providers";
   QUOTA_AUTOPING_FAILURE_COOLDOWN_MS,
   QUOTA_AUTOPING_PROVIDERS,
   QUOTA_AUTOPING_REFRESH_AHEAD_MS,

--- a/src/lib/sync/bundle.ts
+++ b/src/lib/sync/bundle.ts
@@ -1,13 +1,12 @@
+import { getApiKeys } from "@/lib/db/apiKeys";
+import { getCombos } from "@/lib/db/combos";
+import { getModelAliases } from "@/lib/db/models";
+import { getProviderConnections } from "@/lib/db/providers";
+import { getCachedProviderNodes } from "@/lib/db/readCache";
+import { getSettings } from "@/lib/db/settings";
+import { getReasoningRoutingRules } from "@/lib/db/reasoningRoutingRules";
 import { createHash } from "crypto";
-import {
-  getApiKeys,
-  getCombos,
-  getModelAliases,
-  getProviderConnections,
-  getCachedProviderNodes,
-  getSettings,
-  getReasoningRoutingRules,
-} from "@/lib/localDb";
+
 
 type JsonRecord = Record<string, unknown>;
 

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -11,13 +11,7 @@
  * updates the DB, and logs the result.
  */
 
-import {
-  getProviderConnections,
-  getCachedProviderConnectionById,
-  updateProviderConnection,
-  getSettings,
-  resolveProxyForConnection,
-} from "@/lib/localDb";
+
 import {
   getAccessToken,
   getDeprecationNotice,
@@ -31,6 +25,9 @@ import { refreshGithubCopilotSubTokenIfNeeded } from "@/lib/tokenHealthCheckCopi
 import { checkCursorConnectionIfNeeded } from "@/lib/tokenHealthCheckCursor";
 import { checkKimiWebConnectionIfNeeded } from "@/lib/tokenHealthCheckKimi";
 import {
+import { getProviderConnections, updateProviderConnection } from "@/lib/db/providers";
+import { getCachedProviderConnectionById } from "@/lib/db/readCache";
+import { getSettings, resolveProxyForConnection } from "@/lib/db/settings";
   checkWebCookieConnectionIfNeeded,
   isWebCookieHealthProbeCandidate,
 } from "@/lib/tokenHealthCheckWebCookie";

--- a/src/lib/tokenHealthCheckCopilot.ts
+++ b/src/lib/tokenHealthCheckCopilot.ts
@@ -10,8 +10,9 @@
  * frozen file-size budget (see config/quality/file-size-baseline.json).
  */
 
-import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
+
 import { refreshCopilotToken } from "@omniroute/open-sse/services/tokenRefresh.ts";
+import { getProviderConnectionById, updateProviderConnection } from "@/lib/db/providers";
 
 type HealthCheckLogger = {
   info: (tag: string, msg: string) => void;

--- a/src/lib/usage/codexResetCredits.ts
+++ b/src/lib/usage/codexResetCredits.ts
@@ -1,4 +1,4 @@
-import { getProviderConnectionById, resolveProxyForConnection } from "@/lib/localDb";
+
 import { isConnectionUnavailableToAuxiliaryActivity } from "@/lib/exclusiveLeaseIsolation";
 import {
   fetchAndPersistProviderLimits,
@@ -8,6 +8,8 @@ import { invalidateCodexQuotaCache } from "@omniroute/open-sse/services/codexQuo
 import { getCodexBackendIdentityHeaders } from "@omniroute/open-sse/config/codexClient.ts";
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
+import { getProviderConnectionById } from "@/lib/db/providers";
+import { resolveProxyForConnection } from "@/lib/db/settings";
 
 const CODEX_RESET_CREDIT_CONSUME_URL =
   "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";

--- a/src/lib/ws/handshake.ts
+++ b/src/lib/ws/handshake.ts
@@ -1,6 +1,7 @@
 import { jwtVerify } from "jose";
-import { getSettings } from "@/lib/localDb";
+
 import { validateApiKey } from "@/lib/db/apiKeys";
+import { getSettings } from "@/lib/db/settings";
 
 export const DEFAULT_WS_PATH = "/v1/ws";
 const WS_QUERY_TOKEN_KEYS = ["api_key", "token", "access_token"];


### PR DESCRIPTION
Part of #11782 (tracks #59 on the fork)

## Summary

Phase 3 of Issue #59: replace all barrel imports from `@/lib/localDb` with direct imports to the specific `db/` modules in `src/lib/`.

**32 files changed, 80 insertions, 91 deletions.** Zero barrel imports remain in `src/lib/` (excluding the barrel file itself).

## What this does

Same mechanical rewrite as Phase 2, applied to the service/handler layer:

```diff
- import { getProviderConnections, getCachedSettings } from "@/lib/localDb";
+ import { getProviderConnections } from "@/lib/db/providers";
+ import { getCachedSettings } from "@/lib/db/readCache";
```

## Why

- AGENTS.md says: "Never barrel-import from `localDb.ts` — import specific `db/` modules instead"
- Vercel best practice `bundle-barrel-imports`: "Import directly, avoid barrel files"
- This phase covers the 32 `src/lib/` consumers

## Testing

- Mechanical import path rewrites — no logic changes
- Verified: `rg -c "from.*@/lib/localDb" src/lib/ --type ts` returns 0 (excluding the barrel file)

## Dependencies

Should be merged after Phase 2 and before Phase 5 (barrel deletion).