### PR TITLE
fix(cli): probe both IPv4 and IPv6 loopback for server readiness

### DIFF
--- a/bin/cli/utils/pid.mjs
+++ b/bin/cli/utils/pid.mjs
@@ -100,31 +100,66 @@ export async function waitForServer(port, timeout = 60000) {
 // - "hanging": the request timed out waiting for any response — the
 //   process accepted the TCP connection but never answered (#6800).
 // - "not-listening": nothing is accepting connections on the port at all.
+// #11766: probe both IPv4 and IPv6 loopback to handle servers listening on
+// either family (or both).
 async function pollHealthOnce(port) {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/api/monitoring/health`, {
-      signal: AbortSignal.timeout(2000),
-    });
-    return res.ok ? "ready" : "fast-reject";
-  } catch (err) {
-    if (err?.name === "TimeoutError") return "hanging";
-    const listening = await isPortListening(port).catch(() => false);
-    return listening ? "fast-reject" : "not-listening";
-  }
+  const hosts = ["127.0.0.1", "::1"];
+  const outcomes = [];
+
+  // Probe both loopback families concurrently
+  const results = await Promise.all(
+    hosts.map(async (host) => {
+      try {
+        const res = await fetch(`http://${host}:${port}/api/monitoring/health`, {
+          signal: AbortSignal.timeout(2000),
+        });
+        return { host, outcome: res.ok ? "ready" : "fast-reject" };
+      } catch (err) {
+        const outcome = err?.name === "TimeoutError" ? "hanging" : "error";
+        return { host, outcome };
+      }
+    })
+  );
+
+  outcomes.push(...results.map((r) => r.outcome));
+
+  // If either family is ready, the server is ready
+  if (outcomes.includes("ready")) return "ready";
+
+  // If either family is fast-reject, treat as fast-reject
+  // (TCP is listening and rejecting, just route not ready yet)
+  if (outcomes.includes("fast-reject")) return "fast-reject";
+
+  // If either family is hanging, server accepted TCP but not answering
+  // (still booting, must not report as ready per #6800)
+  if (outcomes.includes("hanging")) return "hanging";
+
+  // Both families failed — check if either port is actually listening
+  // If listening, then errors above are route-level (fast-reject case)
+  const listening = await isPortListening(port).catch(() => false);
+  return listening ? "fast-reject" : "not-listening";
 }
 
 async function isPortListening(port) {
   const net = await import("node:net");
-  return new Promise((resolve) => {
-    const socket = net.connect({ host: "127.0.0.1", port, timeout: 1000 });
-    const finish = (ok) => {
-      try {
-        socket.destroy();
-      } catch {}
-      resolve(ok);
-    };
-    socket.once("connect", () => finish(true));
-    socket.once("error", () => finish(false));
-    socket.once("timeout", () => finish(false));
-  });
+  // #11766: check both IPv4 and IPv6 loopback. Return true if either is listening.
+  const hosts = ["127.0.0.1", "::1"];
+  const results = await Promise.all(
+    hosts.map(
+      (host) =>
+        new Promise((resolve) => {
+          const socket = net.connect({ host, port, timeout: 1000 });
+          const finish = (ok) => {
+            try {
+              socket.destroy();
+            } catch {}
+            resolve(ok);
+          };
+          socket.once("connect", () => finish(true));
+          socket.once("error", () => finish(false));
+          socket.once("timeout", () => finish(false));
+        })
+    )
+  );
+  return results.some((ok) => ok);
 }

--- a/tests/unit/cli-waitForServer.test.mjs
+++ b/tests/unit/cli-waitForServer.test.mjs
@@ -11,6 +11,7 @@ import { waitForServer } from "../../bin/cli/utils/pid.mjs";
 // listening, and (d) return false when the port merely accepts TCP and then
 // hangs without ever answering a request (#6800 — a still-booting/CPU-bound
 // process must NOT be reported as ready just because the socket is open).
+// #11766: also test that IPv6 loopback is checked when IPv4 is unavailable.
 
 async function freePort() {
   return new Promise((resolve) => {
@@ -72,6 +73,35 @@ test("waitForServer returns false when the port accepts TCP but never answers a 
       result,
       false,
       "expected waitForServer to NOT report ready for a TCP-open-but-never-responding socket"
+    );
+  } finally {
+    await new Promise((resolve) => server.close(() => resolve()));
+  }
+});
+
+test("waitForServer detects IPv6 loopback health endpoint when IPv4 is unavailable (#11766)", async () => {
+  const port = await freePort();
+  const server = net.createServer((socket) => {
+    socket.on("data", (data) => {
+      const request = data.toString();
+      if (request.includes("GET /api/monitoring/health")) {
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+      }
+    });
+  });
+
+  // Listen only on IPv6 loopback
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "::1", () => resolve());
+  });
+
+  try {
+    const result = await waitForServer(port, 8000);
+    assert.equal(
+      result,
+      true,
+      "expected waitForServer to detect health endpoint on IPv6 loopback even when IPv4 is unavailable"
     );
   } finally {
     await new Promise((resolve) => server.close(() => resolve()));


### PR DESCRIPTION
## Problem
The CLI wrapper was printing a false "Server did not respond within 60s" timeout warning despite the server being healthy and responding correctly. This occurred when the server listened exclusively on IPv6 loopback (`::1`), because the readiness probe only checked IPv4 loopback (`127.0.0.1`).

## Solution
Modified the readiness probe to check both IPv4 and IPv6 loopback addresses **concurrently**, accepting either family returning 200 OK as ready. This maintains all existing behavior for IPv4-only setups while enabling IPv6-only servers to be properly detected.

### Key Changes
- **`pollHealthOnce()`**: Now probes both `127.0.0.1` and `::1` concurrently using `Promise.all()`, aggregating outcomes intelligently:
  - If either family responds with 200, server is ready
  - If any family shows TCP is listening but rejecting (fast-reject), respect the 3-second grace window for "not-yet-mounted route" (#2460)
  - If any family shows TCP accepting but never responding, treat as still-booting
  - Only return "not-listening" if both families fail to connect
  
- **`isPortListening()`**: Checks both IPv4 and IPv6, returns true if either is listening

- **New regression test**: Validates IPv6-only server detection by creating an HTTP server on `::1`, confirming it's detected as ready

## Testing
All 6 tests pass:
- Timeout behavior on closed port (#2460) ✓
- TCP fallback when route is not mounted (#2460) ✓
- Safeguard: TCP-accept-but-never-respond stays NOT ready (#6800) ✓
- **NEW**: IPv6-only loopback server detection (#11766) ✓
- TCP-accept-never-respond comprehensive test ✓
- TCP fallback grace period recovery ✓

## Backward Compatibility
- IPv4-only setups: unchanged behavior
- IPv6-only setups: now work (was broken)
- Dual-stack setups: both families checked, whichever responds first determines outcome
- No timeout changes, no grace window changes, all existing diagnostics preserved

Fixes: #11766