### PR TITLE
fix(sse): preserve CLIProxyAPI wrappers per connection

### DIFF
--- a/open-sse/handlers/chatCore/executorProxy.ts
+++ b/open-sse/handlers/chatCore/executorProxy.ts
@@ -105,7 +105,11 @@ export async function resolveExecutorWithProxy(
       "UPSTREAM_PROXY",
       `${prov} routed through CLIProxyAPI (per-connection claude-native override)`
     );
-    return getExecutor("cliproxyapi");
+    const [cfg, { dedicatedApiKey }] = await Promise.all([
+      getUpstreamProxyConfigCached(prov),
+      loadCliproxyapiSettings(),
+    ]);
+    return resolveCliproxyapiExecutor(cfg.cliproxyapiModelMapping, dedicatedApiKey);
   }
 
   // Sibling per-connection override for Dario (#dario). Checked AFTER the

--- a/tests/unit/cliproxyapi-dedicated-credential-7645.test.ts
+++ b/tests/unit/cliproxyapi-dedicated-credential-7645.test.ts
@@ -70,13 +70,19 @@ type ExecutorLike = { execute: (input: ExecuteInput) => Promise<unknown> };
  */
 async function withCapturedCliproxyapiRequest(
   fn: () => Promise<unknown>
-): Promise<{ headers: Record<string, string>; called: boolean }> {
+): Promise<{
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+  called: boolean;
+}> {
   let capturedHeaders: Record<string, string> | null = null;
+  let capturedBody: Record<string, unknown> | null = null;
   const originalFetch = globalThis.fetch;
   // @ts-expect-error test stub
   globalThis.fetch = async (url: string, init: RequestInit) => {
     if (String(url).includes("8317")) {
       capturedHeaders = init.headers as Record<string, string>;
+      capturedBody = JSON.parse(String(init.body)) as Record<string, unknown>;
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -89,7 +95,11 @@ async function withCapturedCliproxyapiRequest(
   } finally {
     globalThis.fetch = originalFetch;
   }
-  return { headers: capturedHeaders ?? {}, called: capturedHeaders !== null };
+  return {
+    headers: capturedHeaders ?? {},
+    body: capturedBody ?? {},
+    called: capturedHeaders !== null,
+  };
 }
 
 describe("#7645 — settingsSchemas has a dedicated cliproxyapi_api_key field", () => {
@@ -161,6 +171,47 @@ describe("#7645 — CLIProxyAPI fallback leg authenticates with the dedicated ke
       `Bearer ${DEDICATED_KEY}`,
       "CLIProxyAPI passthrough mode must authenticate with the dedicated key"
     );
+  });
+
+  it("per-connection claude-native mode keeps the dedicated key and model mapping", async () => {
+    const sourceModel = "claude-3-opus";
+    const mappedModel = "claude-3-opus-mapped";
+
+    await settingsDb.updateSettings({ cliproxyapi_api_key: DEDICATED_KEY });
+    await upstreamProxyDb.upsertUpstreamProxyConfig({
+      providerId: "anthropic-7645-per-connection",
+      mode: "native",
+      enabled: true,
+      cliproxyapiModelMapping: { [sourceModel]: mappedModel },
+    });
+
+    const executor = await resolveExecutorWithProxy(
+      "anthropic-7645-per-connection",
+      undefined,
+      { cliproxyapiMode: "claude-native" }
+    );
+
+    const { headers, body, called } = await withCapturedCliproxyapiRequest(() =>
+      (executor as ExecutorLike).execute({
+        model: sourceModel,
+        body: { model: sourceModel, messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: { apiKey: NATIVE_KEY },
+      })
+    );
+
+    assert.equal(called, true, "the per-connection override must invoke CLIProxyAPI");
+    assert.equal(
+      headers.Authorization,
+      `Bearer ${DEDICATED_KEY}`,
+      "per-connection CLIProxyAPI mode must authenticate with the dedicated key"
+    );
+    assert.notEqual(
+      headers.Authorization,
+      `Bearer ${NATIVE_KEY}`,
+      "per-connection CLIProxyAPI mode must not reuse the native credential"
+    );
+    assert.equal(body.model, mappedModel, "per-connection CLIProxyAPI mode must map the model");
   });
 
   it("falls back to the connection's own credential when no dedicated key is configured (no regression)", async () => {


### PR DESCRIPTION
## Summary

- Route the per-connection `cliproxyapiMode: "claude-native"` override through the existing CLIProxyAPI credential and model-mapping wrappers.
- Prevent the native provider credential and unmapped model from leaking into that passthrough path.
- Add a wire-level regression covering both headers and request body.

## Related Issues

- Closes #11796
- Related to #7645
- Related to #6876

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / routing
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Focused validation:

- `node --import tsx/esm --test tests/unit/cliproxyapi-dedicated-credential-7645.test.ts`
- `node --import tsx/esm --test tests/unit/cliproxyapi-model-mapping-dispatch.test.ts tests/unit/cliproxyapi-fallback-wiring.test.ts`
- `npm exec eslint -- open-sse/handlers/chatCore/executorProxy.ts tests/unit/cliproxyapi-dedicated-credential-7645.test.ts --max-warnings=0`
- `npm run typecheck:core`
- `npm run check:cycles`
- `git diff --check`

## Tests Added Or Updated

- `tests/unit/cliproxyapi-dedicated-credential-7645.test.ts`
  - Proves the previous branch sends the native key.
  - Proves the fix sends the dedicated CLIProxyAPI key and mapped model.

## Coverage Notes

The updated wire-level test executes `resolveExecutorWithProxy()` and the real CLIProxyAPI executor boundary for the per-connection branch.

## Reviewer Notes

The change reuses the same wrappers already used by provider-level passthrough and fallback. It adds no schema, migration, dependency, or new routing precedence.
