### PR TITLE
fix(providers): honor model auto-fetch opt-in on create

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx
@@ -103,7 +103,7 @@ describe("useApiKeySave.handleSaveApiKey — full-sync opt-out (#11324)", () => 
   });
 
   it("keeps the full /sync-models catalog fetch off when autoFetchModels is omitted", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
       if (url === "/api/providers") return response(true, { connection: { id: "conn-1" } });
       if (url.includes("/sync-models")) {
@@ -128,7 +128,7 @@ describe("useApiKeySave.handleSaveApiKey — full-sync opt-out (#11324)", () => 
   });
 
   it("auto-triggers one client-owned sync when autoFetchModels is true", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
       if (url === "/api/providers") return response(true, { connection: { id: "conn-1" } });
       if (url.includes("/sync-models")) {

--- a/src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-// Regression for issue #11324: adding a custom/manual model connection for a
-// non-curated provider must not force a full upstream /models catalog sync
-// when the caller explicitly opts out via `skipModelSync`.
+// Regression for issue #11324 and the autoFetchModels opt-in contract: adding a
+// connection must not force a full upstream /models catalog sync unless the
+// connection explicitly enables it.
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -97,9 +97,12 @@ describe("useApiKeySave.handleSaveApiKey — full-sync opt-out (#11324)", () => 
     );
     const postedBody = JSON.parse((providersCall?.[1] as RequestInit).body as string);
     expect(postedBody).not.toHaveProperty("skipModelSync");
+    expect(new Headers((providersCall?.[1] as RequestInit).headers).get("x-skip-model-sync")).toBe(
+      "true"
+    );
   });
 
-  it("still auto-triggers the full /sync-models catalog fetch by default (legacy behavior preserved)", async () => {
+  it("keeps the full /sync-models catalog fetch off when autoFetchModels is omitted", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/providers") return response(true, { connection: { id: "conn-1" } });
@@ -121,6 +124,40 @@ describe("useApiKeySave.handleSaveApiKey — full-sync opt-out (#11324)", () => 
     const syncCalls = fetchMock.mock.calls.filter(([input]) =>
       String(input).includes("/sync-models")
     );
+    expect(syncCalls).toHaveLength(0);
+  });
+
+  it("auto-triggers one client-owned sync when autoFetchModels is true", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/providers") return response(true, { connection: { id: "conn-1" } });
+      if (url.includes("/sync-models")) {
+        return response(true, { syncedModels: 3, availableModelsCount: 3, models: [] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hookResult, root, container } = renderApiKeySaveHook();
+    roots.push(root);
+    containers.push(container);
+
+    await act(async () => {
+      await hookResult().handleSaveApiKey({
+        apiKey: "sk-test",
+        providerSpecificData: { autoFetchModels: true },
+      });
+    });
+
+    const syncCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes("/sync-models")
+    );
     expect(syncCalls).toHaveLength(1);
+    const providersCall = fetchMock.mock.calls.find(
+      ([input]) => String(input) === "/api/providers"
+    );
+    expect(new Headers((providersCall?.[1] as RequestInit).headers).get("x-skip-model-sync")).toBe(
+      "true"
+    );
   });
 });

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useApiKeySave.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useApiKeySave.ts
@@ -60,13 +60,23 @@ export function useApiKeySave({
       // Issue #11324: callers that only want to add one manual model (rather than
       // importing an upstream provider's entire catalog) can pass `skipModelSync: true`
       // to opt out of the automatic post-save full /sync-models call. This flag is a
-      // client-side intent signal only — strip it before it reaches the connection
-      // creation payload.
+      // client-side intent signal only — keep it out of the persisted connection
+      // payload and relay it only through the non-persisted request header below.
       const { skipModelSync, ...connectionFormData } = formData;
+      const autoFetchModels =
+        (
+          connectionFormData.providerSpecificData as
+            | Record<string, unknown>
+            | null
+            | undefined
+        )?.autoFetchModels === true;
       try {
         const res = await fetch("/api/providers", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(autoFetchModels || skipModelSync ? { "X-Skip-Model-Sync": "true" } : {}),
+          },
           body: JSON.stringify({
             provider: resolveApiKeySaveProviderId(providerId),
             ...connectionFormData,
@@ -82,7 +92,12 @@ export function useApiKeySave({
           // Most providers sync their live catalog after connection creation. Curated-only
           // providers intentionally use the registry list and must not show an import flow.
           // Issue #11324: callers may also opt out explicitly via `skipModelSync`.
-          if (newConnection?.id && !providerUsesCuratedModelsOnly(providerId) && !skipModelSync) {
+          if (
+            newConnection?.id &&
+            !providerUsesCuratedModelsOnly(providerId) &&
+            autoFetchModels &&
+            !skipModelSync
+          ) {
             setShowImportModal(true);
             setImportProgress({
               current: 0,

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -48,6 +48,7 @@ import {
   getModelSyncInternalBaseUrl,
 } from "@/shared/services/modelSyncScheduler";
 import { finalizeValidatedChatGptWebCodexSecrets } from "@omniroute/open-sse/services/chatgptWebCodexAdmin.ts";
+import { isAutoFetchModelsEnabled } from "@/lib/providerModels/modelDiscovery";
 import { testSingleConnection } from "./[id]/test/route";
 
 function projectCodexAccountPoolWithRoutingQuota(
@@ -282,50 +283,56 @@ export async function POST(request: Request) {
       testStatus: testStatus || "unknown",
     });
 
-    // Auto-trigger model discovery for the newly created connection.
+    // Auto-trigger model discovery only for an explicit autoFetchModels opt-in.
     // Fire-and-forget: model sync can take seconds and should NOT block the
     // POST response. If it fails, we log and move on — the connection itself
     // is already persisted and the user can manually trigger a sync later.
     // We use a self-fetch against our own /sync-models route, forwarding the
     // incoming cookies (preserves management auth) plus the internal sync
     // auth header (defense in depth) and an X-Internal-Auto-Sync marker for
-    // log correlation.
-    try {
-      // SECURITY: use the trusted loopback/env-pinned origin, NOT
-      // `new URL(request.url).origin` — the latter comes from the client-
-      // controlled Host header, which would let a caller redirect this
-      // credential-bearing internal self-fetch to an arbitrary host
-      // (SSRF + internal-auth-header exfiltration; CodeQL js/request-forgery).
-      const internalOrigin = getModelSyncInternalBaseUrl();
-      const cookieHeader = request.headers.get("cookie") || "";
-      const syncHeaders: Record<string, string> = {
-        "Content-Type": "application/json",
-        "X-Internal-Auto-Sync": "true",
-        ...(cookieHeader ? { cookie: cookieHeader } : {}),
-        ...buildModelSyncInternalHeaders(),
-      };
-      const syncUrl = `${internalOrigin}/api/providers/${encodeURIComponent(newConnection.id)}/sync-models?mode=import`;
-      // Intentionally not awaited: this is async/non-blocking work.
-      void fetchModelSyncInternal(syncUrl, {
-        method: "POST",
-        headers: syncHeaders,
-        redirect: "error",
-      })
-        .then((syncRes) => {
-          if (!syncRes.ok) {
-            console.log(`[providers] Auto-sync failed for ${newConnection.id}: ${syncRes.status}`);
-          }
+    // log correlation. The dashboard skips this server-owned copy when it
+    // performs the same sync itself so it can render progress.
+    if (
+      isAutoFetchModelsEnabled(providerSpecificData) &&
+      request.headers.get("x-skip-model-sync") !== "true"
+    ) {
+      try {
+        // SECURITY: use the trusted loopback/env-pinned origin, NOT
+        // `new URL(request.url).origin` — the latter comes from the client-
+        // controlled Host header, which would let a caller redirect this
+        // credential-bearing internal self-fetch to an arbitrary host
+        // (SSRF + internal-auth-header exfiltration; CodeQL js/request-forgery).
+        const internalOrigin = getModelSyncInternalBaseUrl();
+        const cookieHeader = request.headers.get("cookie") || "";
+        const syncHeaders: Record<string, string> = {
+          "Content-Type": "application/json",
+          "X-Internal-Auto-Sync": "true",
+          ...(cookieHeader ? { cookie: cookieHeader } : {}),
+          ...buildModelSyncInternalHeaders(),
+        };
+        const syncUrl = `${internalOrigin}/api/providers/${encodeURIComponent(newConnection.id)}/sync-models?mode=import`;
+        // Intentionally not awaited: this is async/non-blocking work.
+        void fetchModelSyncInternal(syncUrl, {
+          method: "POST",
+          headers: syncHeaders,
+          redirect: "error",
         })
-        .catch((err) => {
-          console.log(`[providers] Auto-sync error for ${newConnection.id}:`, err?.message || err);
-        });
-    } catch (syncSetupError) {
-      // Defensive: if URL parsing or header construction itself throws, do
-      // not let it break the (already successful) POST response.
-      console.log(
-        `[providers] Auto-sync setup failed for ${newConnection.id}:`,
-        syncSetupError?.message || syncSetupError
-      );
+          .then((syncRes) => {
+            if (!syncRes.ok) {
+              console.log(`[providers] Auto-sync failed for ${newConnection.id}: ${syncRes.status}`);
+            }
+          })
+          .catch((err) => {
+            console.log(`[providers] Auto-sync error for ${newConnection.id}:`, err?.message || err);
+          });
+      } catch (syncSetupError) {
+        // Defensive: if URL parsing or header construction itself throws, do
+        // not let it break the (already successful) POST response.
+        console.log(
+          `[providers] Auto-sync setup failed for ${newConnection.id}:`,
+          syncSetupError?.message || syncSetupError
+        );
+      }
     }
 
     // Auto-test the newly created connection so `testStatus` reflects reality

--- a/tests/unit/providers-route-model-autofetch-optin.test.ts
+++ b/tests/unit/providers-route-model-autofetch-optin.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { makeManagementSessionRequest } from "../helpers/managementSession.ts";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-provider-autofetch-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "provider-autofetch-test-secret";
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+
+const originalFetch = globalThis.fetch;
+const core = await import("../../src/lib/db/core.ts");
+const providersRoute = await import("../../src/app/api/providers/route.ts");
+
+const modelSyncUrls: string[] = [];
+globalThis.fetch = (async (input: string | URL | Request) => {
+  const url =
+    typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+  if (new URL(url).pathname.includes("/sync-models")) {
+    modelSyncUrls.push(url);
+  }
+  return new Response(JSON.stringify({ data: [] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}) as typeof fetch;
+
+type CreateOptions = {
+  autoFetchModels?: boolean;
+  clientOwnsModelSync?: boolean;
+};
+
+async function createConnection(options: CreateOptions = {}): Promise<Response> {
+  const providerSpecificData =
+    options.autoFetchModels === undefined
+      ? undefined
+      : { autoFetchModels: options.autoFetchModels };
+
+  const response = await providersRoute.POST(
+    await makeManagementSessionRequest("http://localhost/api/providers", {
+      method: "POST",
+      headers: options.clientOwnsModelSync ? { "X-Skip-Model-Sync": "true" } : undefined,
+      body: {
+        provider: "openai",
+        apiKey: "sk-provider-autofetch-test",
+        name: "Provider auto-fetch test",
+        ...(providerSpecificData ? { providerSpecificData } : {}),
+      },
+    })
+  );
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  return response;
+}
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  modelSyncUrls.length = 0;
+});
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("POST /api/providers does not sync models when autoFetchModels is omitted", async () => {
+  const response = await createConnection();
+
+  assert.equal(response.status, 201);
+  assert.equal(modelSyncUrls.length, 0);
+});
+
+test("POST /api/providers does not sync models when autoFetchModels is false", async () => {
+  const response = await createConnection({ autoFetchModels: false });
+
+  assert.equal(response.status, 201);
+  assert.equal(modelSyncUrls.length, 0);
+});
+
+test("POST /api/providers syncs models exactly once when autoFetchModels is true", async () => {
+  const response = await createConnection({ autoFetchModels: true });
+
+  assert.equal(response.status, 201);
+  assert.equal(modelSyncUrls.length, 1);
+  assert.match(modelSyncUrls[0], /\/api\/providers\/[^/]+\/sync-models\?mode=import$/);
+});
+
+test("POST /api/providers lets a dashboard-owned sync suppress the server duplicate", async () => {
+  const response = await createConnection({ autoFetchModels: true, clientOwnsModelSync: true });
+
+  assert.equal(response.status, 201);
+  assert.equal(modelSyncUrls.length, 0);
+});


### PR DESCRIPTION
## Summary

- Honor the existing `autoFetchModels` default-off contract on both provider-creation paths.
- Keep automatic model discovery at zero calls when the flag is omitted or false.
- Run exactly one sync when explicitly enabled: API clients use the server-owned background sync, while the dashboard owns the request when it needs progress UI.
- Reuse the existing `skipModelSync` intent as a non-persisted request header; no new setting, schema, or dependency is added.

## Related Issues

- Closes #11324
- Related to #10603
- Related to #5837

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / UI
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Focused validation:

- `node --import tsx/esm --test tests/unit/providers-route-model-autofetch-optin.test.ts`
- `npm exec vitest -- run --config vitest.config.ts 'src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx'`
- `npm exec vitest -- run --config vitest.config.ts 'src/app/(dashboard)/dashboard/providers/[id]/__tests__/useModelImportHandlers.test.tsx' 'tests/unit/ui/use-provider-models-auto-fetch.test.tsx'`
- Focused ESLint on all four changed files
- `npm run typecheck:core`
- `npm run check:cycles`
- `git diff --check`

## Tests Added Or Updated

- `tests/unit/providers-route-model-autofetch-optin.test.ts`
- `src/app/(dashboard)/dashboard/providers/[id]/__tests__/useApiKeySaveSkipsFullSync.test.tsx`

The tests cover omitted, false, true, explicit client opt-out, and duplicate client/server ownership.

## Coverage Notes

The route test executes the real authenticated `POST /api/providers` handler and captures internal model-sync requests. The hook test covers the dashboard branch and verifies the intent marker is not persisted in the connection payload.

## Reviewer Notes

This deliberately reuses the opt-in introduced by #10603 instead of adding the extra checkbox proposed during #11324 triage. Manual model creation and new connections now stay quiet by default; explicit opt-in preserves automatic discovery.
