### PR TITLE
fix(oauth): reactivate recovered expired connections

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -957,6 +957,7 @@ export async function checkConnection(conn) {
         const now = new Date().toISOString();
         const updateData: ConnectionUpdate = {
           accessToken: refreshResult.accessToken,
+          isActive: true,
           lastHealthCheckAt: now,
           testStatus: "active",
           lastError: null,

--- a/tests/unit/token-health-check-retry-deactivation.test.ts
+++ b/tests/unit/token-health-check-retry-deactivation.test.ts
@@ -88,6 +88,31 @@ function createMockFetchForInvalidGrant(tokenUrl: string) {
   return originalFetch;
 }
 
+function createMockFetchForSuccessfulRefresh(tokenUrl: string) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url === tokenUrl) {
+      return new Response(
+        JSON.stringify({
+          access_token: "at_retry_recovered",
+          refresh_token: "rt_retry_recovered",
+          expires_in: 3600,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    }
+    return originalFetch(
+      input as Parameters<typeof originalFetch>[0],
+      init as Parameters<typeof originalFetch>[1]
+    );
+  }) as typeof fetch;
+  return originalFetch;
+}
+
 const PROVIDER_ID = "custom-oauth-retry-deactivation";
 const TOKEN_URL = "https://token-retry.test.invalid/token";
 const PROVIDER_CONFIG = {
@@ -281,6 +306,47 @@ test("checkConnection strictly skips deactivated connection with exhausted retry
       );
       assert.equal(updated?.isActive, false, "isActive must remain false");
       assert.equal(updated?.testStatus, "expired", "testStatus must remain 'expired'");
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("successful expired retry reactivates a previously inactive connection", async () => {
+  await resetStorage();
+  const originalFetch = createMockFetchForSuccessfulRefresh(TOKEN_URL);
+
+  try {
+    await withPatchedProvider(PROVIDER_ID, PROVIDER_CONFIG, async () => {
+      const connection = await createRetryTestConnection({
+        isActive: false,
+        testStatus: "expired",
+        providerSpecificData: {
+          expiredRetry: { count: 1, at: new Date(Date.now() - 10 * 60 * 1000).toISOString() },
+        },
+        lastError: "invalid_grant",
+        lastErrorAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        lastErrorType: "unrecoverable_refresh_error",
+        lastErrorSource: "oauth",
+        errorCode: "invalid_grant",
+      });
+
+      await tokenHealthCheck.checkConnection({
+        ...connection,
+        lastHealthCheckAt: new Date(Date.now() - 61 * 60 * 1000).toISOString(),
+      });
+
+      const updated = await providersDb.getProviderConnectionById(connection.id);
+
+      assert.equal(updated?.accessToken, "at_retry_recovered");
+      assert.equal(updated?.refreshToken, "rt_retry_recovered");
+      assert.equal(updated?.isActive, true, "successful refresh must restore routing eligibility");
+      assert.equal(updated?.testStatus, "active");
+      assert.equal(updated?.lastError ?? null, null);
+      assert.equal(updated?.lastErrorType ?? null, null);
+      assert.equal(updated?.lastErrorSource ?? null, null);
+      assert.equal(updated?.errorCode ?? null, null);
+      assert.equal(updated?.providerSpecificData?.expiredRetry, undefined);
     });
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

- Restore `isActive: true` when a successful background OAuth refresh recovers an expired connection with retry budget remaining.
- Without this update, the retry path introduced by #11414 persists fresh credentials and `testStatus: "active"` but leaves the connection excluded from routing.
- The change does not broaden retry eligibility: inactive connections reach this callback only when they are already `expired` and still have retry budget.

## Related Issues

- Related to #11414

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: other (OAuth resilience)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Commands run:

```text
node --import tsx/esm --test tests/unit/token-health-check-retry-deactivation.test.ts tests/unit/token-health-no-refresh-token-expired-5326.test.ts
npm run typecheck:core
npm run lint -- --no-cache
npx prettier --check src/lib/tokenHealthCheck.ts tests/unit/token-health-check-retry-deactivation.test.ts
npm run check:tracked-artifacts
npm run check:any-budget:t11
npm run check:cycles
git diff --check origin/release/v3.8.51...HEAD
```

## Tests Added Or Updated

- Updated `tests/unit/token-health-check-retry-deactivation.test.ts` with a successful expired-retry recovery case.
- Red before the production fix: the new regression failed because `isActive` remained `false` after the refresh succeeded.
- Green after the production fix: 12/12 focused and adjacent token-health tests pass.

## Coverage Notes

- The regression exercises the successful refresh persistence callback and verifies fresh access/refresh tokens, routing eligibility, active status, cleared error metadata, and removal of expired-retry state.
- The production change is one assignment on that covered path; broad coverage and quality ratchets remain CI-owned per the golden path.

## Reviewer Notes

- No migrations, feature flags, generated files, or dependencies.
- Retry limits and terminal-state eligibility are unchanged.
- Base commit checked before push: `2acbfc6fa6ef13e55552ce5bc3de45cbf2e535be`.
- Base-red inherited: #11449. The active base issue currently records unrelated full-suite/Vitest/integration/package-artifact failures; this PR does not attempt to absorb those base repairs.
