### PR TITLE
fix(db): skip absent compression telemetry cleanup table

### DIFF
--- a/changelog.d/fixes/11802-compression-telemetry-cleanup-missing-table.md
+++ b/changelog.d/fixes/11802-compression-telemetry-cleanup-missing-table.md
@@ -1,0 +1,1 @@
+- **fix(db):** Fresh installs no longer log a non-fatal `no such table: compression_run_telemetry` warning when retention cleanup runs before the lazily-created telemetry table exists ([#11802](https://github.com/diegosouzapw/OmniRoute/pull/11802)) — thanks @RaviTharuma

--- a/src/lib/db/cleanup.ts
+++ b/src/lib/db/cleanup.ts
@@ -13,6 +13,7 @@ import {
   deleteAllFromTable,
   deleteCallLogArtifacts,
   deleteFromTableBefore,
+  tableExists,
   type DeleteByPeriodTarget,
 } from "./cleanup/usagePurge";
 
@@ -196,7 +197,9 @@ export async function cleanupMcpAudit(): Promise<CleanupResult> {
 /**
  * Clean up old config_audit_log based on retention settings.
  */
-export async function cleanupConfigAudit(retentionDays = getRetentionSettings().configAudit): Promise<CleanupResult> {
+export async function cleanupConfigAudit(
+  retentionDays = getRetentionSettings().configAudit
+): Promise<CleanupResult> {
   const db = getDbInstance();
   const result: CleanupResult = { deleted: 0, errors: 0 };
 
@@ -237,7 +240,9 @@ export async function cleanupA2aEvents(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(`[Cleanup] Deleted ${result.deleted} a2a_task_events older than ${retentionDays} days`);
+    console.log(
+      `[Cleanup] Deleted ${result.deleted} a2a_task_events older than ${retentionDays} days`
+    );
   } catch (err: unknown) {
     console.error("[Cleanup] Error cleaning a2a_task_events:", err);
     result.errors++;
@@ -381,6 +386,7 @@ export async function cleanupCompressionRunTelemetry(): Promise<CleanupResult> {
   const cutoffEpoch = Date.now() - retentionDays * 86_400_000;
 
   const result: CleanupResult = { deleted: 0, errors: 0 };
+  if (!tableExists("compression_run_telemetry")) return result;
 
   try {
     const stmt = db.prepare("DELETE FROM compression_run_telemetry WHERE timestamp < ?");
@@ -600,16 +606,56 @@ function isResetUsageHistoryPeriod(period: string): period is ResetUsageHistoryP
  */
 const RESET_TARGETS: Array<DeleteByPeriodTarget & { resultKey: keyof ResetUsageHistoryResult }> = [
   { table: "usage_history", column: "timestamp", cutoff: "iso", resultKey: "deletedUsageHistory" },
-  { table: "daily_usage_summary", column: "date", cutoff: "date", resultKey: "deletedDailySummary" },
-  { table: "hourly_usage_summary", column: "date_hour", cutoff: "dateHour", resultKey: "deletedHourlySummary" },
+  {
+    table: "daily_usage_summary",
+    column: "date",
+    cutoff: "date",
+    resultKey: "deletedDailySummary",
+  },
+  {
+    table: "hourly_usage_summary",
+    column: "date_hour",
+    cutoff: "dateHour",
+    resultKey: "deletedHourlySummary",
+  },
   { table: "call_logs", column: "timestamp", cutoff: "iso", resultKey: "deletedCallLogs" },
-  { table: "request_detail_logs", column: "timestamp", cutoff: "iso", resultKey: "deletedRequestDetailLogs" },
+  {
+    table: "request_detail_logs",
+    column: "timestamp",
+    cutoff: "iso",
+    resultKey: "deletedRequestDetailLogs",
+  },
   { table: "proxy_logs", column: "timestamp", cutoff: "iso", resultKey: "deletedProxyLogs" },
-  { table: "relay_logs", column: "created_at", cutoff: "epochSeconds", resultKey: "deletedRelayLogs" },
-  { table: "compression_analytics", column: "timestamp", cutoff: "iso", resultKey: "deletedCompressionAnalytics" },
-  { table: "compression_run_telemetry", column: "timestamp", cutoff: "epochMs", resultKey: "deletedCompressionRunTelemetry" },
-  { table: "routing_decisions", column: "created_at", cutoff: "iso", resultKey: "deletedRoutingDecisions" },
-  { table: "quota_consumption", column: "updated_at", cutoff: "epochMs", resultKey: "deletedQuotaConsumption" },
+  {
+    table: "relay_logs",
+    column: "created_at",
+    cutoff: "epochSeconds",
+    resultKey: "deletedRelayLogs",
+  },
+  {
+    table: "compression_analytics",
+    column: "timestamp",
+    cutoff: "iso",
+    resultKey: "deletedCompressionAnalytics",
+  },
+  {
+    table: "compression_run_telemetry",
+    column: "timestamp",
+    cutoff: "epochMs",
+    resultKey: "deletedCompressionRunTelemetry",
+  },
+  {
+    table: "routing_decisions",
+    column: "created_at",
+    cutoff: "iso",
+    resultKey: "deletedRoutingDecisions",
+  },
+  {
+    table: "quota_consumption",
+    column: "updated_at",
+    cutoff: "epochMs",
+    resultKey: "deletedQuotaConsumption",
+  },
   { table: "token_ledger", column: "created_at", cutoff: "iso", resultKey: "deletedTokenLedger" },
 ];
 

--- a/src/lib/db/cleanup.ts
+++ b/src/lib/db/cleanup.ts
@@ -386,9 +386,10 @@ export async function cleanupCompressionRunTelemetry(): Promise<CleanupResult> {
   const cutoffEpoch = Date.now() - retentionDays * 86_400_000;
 
   const result: CleanupResult = { deleted: 0, errors: 0 };
-  if (!tableExists("compression_run_telemetry")) return result;
 
   try {
+    if (!tableExists("compression_run_telemetry")) return result;
+
     const stmt = db.prepare("DELETE FROM compression_run_telemetry WHERE timestamp < ?");
     const runResult = stmt.run(cutoffEpoch);
     result.deleted = runResult.changes;

--- a/tests/unit/telemetry-auto-cleanup-6848.test.ts
+++ b/tests/unit/telemetry-auto-cleanup-6848.test.ts
@@ -189,6 +189,22 @@ test("#6848 cleanupCompressionRunTelemetry: missing lazy table is an empty no-op
   assert.deepStrictEqual(result, { deleted: 0, errors: 0 });
 });
 
+test("#6848 cleanupCompressionRunTelemetry: contains table lookup failures", async (t) => {
+  const db = getDbInstance()!;
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql: string) => {
+    if (sql.includes("sqlite_master")) {
+      throw new Error("injected table lookup failure");
+    }
+    return prepare(sql);
+  });
+  t.mock.method(console, "error", () => {});
+
+  const result = await cleanupCompressionRunTelemetry();
+
+  assert.deepStrictEqual(result, { deleted: 0, errors: 1 });
+});
+
 test("#6848 no rows deleted when all data is within retention window (calls all 4 real functions)", async () => {
   ensureTelemetryTable();
   const db = getDbInstance()!;

--- a/tests/unit/telemetry-auto-cleanup-6848.test.ts
+++ b/tests/unit/telemetry-auto-cleanup-6848.test.ts
@@ -181,6 +181,14 @@ test("#6848 cleanupCompressionRunTelemetry: deletes rows older than retention wi
   assert.strictEqual(remaining.cnt, 1);
 });
 
+test("#6848 cleanupCompressionRunTelemetry: missing lazy table is an empty no-op", async () => {
+  getDbInstance()!.exec("DROP TABLE compression_run_telemetry");
+
+  const result = await cleanupCompressionRunTelemetry();
+
+  assert.deepStrictEqual(result, { deleted: 0, errors: 0 });
+});
+
 test("#6848 no rows deleted when all data is within retention window (calls all 4 real functions)", async () => {
   ensureTelemetryTable();
   const db = getDbInstance()!;


### PR DESCRIPTION
## Summary

- Treat an absent lazily-created `compression_run_telemetry` table as empty during retention cleanup.
- Reuse the existing `tableExists()` DB helper, so a fresh install no longer emits a non-fatal SQLite warning 30 seconds after startup.
- Keep the existence probe inside the cleanup error boundary so a database lookup failure is reported without aborting later cleanup work.
- Preserve retention deletion unchanged once the first telemetry write or summary read creates the table.

Public-image reproduction:

```text
diegosouzapw/omniroute:3.8.50
digest sha256:085c57adf499a8aaa9f35ccde95c0df9c11bd9ecd18d6c9edbf3b68b8079ba9d
[Cleanup] Error cleaning compression_run_telemetry: SqliteError: no such table: compression_run_telemetry
[Cleanup] Auto-cleanup complete: 0 deleted, 1 errors
```

The current `release/v3.8.51` source has the same lazy-only table initialization and cleanup ordering. Its public Docker publish run did not produce a new image because the arm64 build exhausted memory: https://github.com/diegosouzapw/OmniRoute/actions/runs/33041245780

## Related Issues

- Related to #6848
- Duplicate search found no open report for this fresh-install warning; no extra issue was created for this two-line fix.

## Validation

- [x] Change type: DB
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Red-first proof:

```text
# Before the production edit
✖ #6848 cleanupCompressionRunTelemetry: missing lazy table is an empty no-op
actual: { deleted: 0, errors: 1 }
expected: { deleted: 0, errors: 0 }

# After the guard
✔ #6848 cleanupCompressionRunTelemetry: missing lazy table is an empty no-op

# Review follow-up before moving the guard inside try
✖ #6848 cleanupCompressionRunTelemetry: contains table lookup failures
Error: injected table lookup failure

# After restoring the existing cleanup error boundary
✔ #6848 cleanupCompressionRunTelemetry: contains table lookup failures
```

Passed:

```text
node --import tsx/esm --test \
  tests/unit/telemetry-auto-cleanup-6848.test.ts \
  tests/unit/repro-compression-run-telemetry-ms.test.ts \
  tests/unit/db/compressionRunTelemetry.test.ts
# 12 passed, 0 failed

npm run lint
npm run typecheck:core
npm run check:db-rules
npm run check:cycles
```

## Tests Added Or Updated

- `tests/unit/telemetry-auto-cleanup-6848.test.ts` drops the lazy table and asserts cleanup returns an empty, error-free result.
- The same test injects a table-lookup failure and asserts cleanup contains it as `{ deleted: 0, errors: 1 }`.
- Existing tests still prove old rows are deleted after the table exists.

## Coverage Notes

The regressions execute the changed branches in `cleanupCompressionRunTelemetry()` against isolated, real SQLite. The injected failure goes through the real `tableExists()` call, and the existing sibling test covers the table-present deletion path.

## Reviewer Notes

- No migration, schema, dependency, feature flag, or hot-path behavior change.
- The only writer and summary reader still lazily create the table in `src/lib/db/compressionRunTelemetry.ts`; the startup cleanup is the sole caller that can reach it first.
- The mandatory pre-commit formatter also normalized pre-existing unformatted regions in `src/lib/db/cleanup.ts`; those lines are mechanical only.
- ⚠️ base-red inherited: #11449
