### PR TITLE
fix(dashboard): make mixed model auto-fetch order-independent

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/hooks/useProviderModels.ts
+++ b/src/app/(dashboard)/dashboard/providers/hooks/useProviderModels.ts
@@ -77,11 +77,18 @@ export function useProviderModels(providerId: string): UseProviderModelsResult {
                 }>;
               };
               if (cancelled) return;
-              const providerConn = connData.connections?.find(
+              const providerConnections = connData.connections?.filter(
                 (c) => (c.provider === providerId || c.id === providerId) && c.isActive !== false
               );
+              const providerConn = providerConnections?.[0];
 
-              if (providerConn?.providerSpecificData?.autoFetchModels === true && !cancelled) {
+              if (
+                providerConn &&
+                providerConnections.every(
+                  (connection) => connection.providerSpecificData?.autoFetchModels === true
+                ) &&
+                !cancelled
+              ) {
                 const syncRes = await fetch(
                   `/api/providers/${encodeURIComponent(providerConn.id)}/sync-models?mode=sync`,
                   { method: "POST" }

--- a/tests/unit/ui/use-provider-models-auto-fetch.test.tsx
+++ b/tests/unit/ui/use-provider-models-auto-fetch.test.tsx
@@ -6,15 +6,23 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
 
-const { useProviderModels } = await import(
-  "@/app/(dashboard)/dashboard/providers/hooks/useProviderModels"
-);
+const { useProviderModels } =
+  await import("@/app/(dashboard)/dashboard/providers/hooks/useProviderModels");
 
 function createResponse(body: unknown, ok = true): Response {
   return {
     ok,
     json: async () => body,
   } as Response;
+}
+
+function connection(id: string, autoFetchModels: boolean, isActive = true) {
+  return {
+    id,
+    provider: "custom-provider",
+    isActive,
+    providerSpecificData: { autoFetchModels },
+  };
 }
 
 async function renderProviderModels(providerId = "custom-provider") {
@@ -101,8 +109,71 @@ describe("useProviderModels upstream auto-fetch", () => {
     const mounted = await renderProviderModels();
     await flushQueuedSync();
 
+    expect(fetchMock).toHaveBeenCalledWith("/api/providers/connection-1/sync-models?mode=sync", {
+      method: "POST",
+    });
+    mounted.unmount();
+  });
+
+  it.each([
+    [
+      "enabled connection first",
+      [connection("connection-on", true), connection("connection-off", false)],
+    ],
+    [
+      "disabled connection first",
+      [connection("connection-off", false), connection("connection-on", true)],
+    ],
+  ])("does not synchronize a mixed provider when the %s", async (_name, connections) => {
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.startsWith("/api/v1/providers/")) {
+        return createResponse({ data: [] });
+      }
+      if (input === "/api/providers") {
+        return createResponse({ connections });
+      }
+      throw new Error(`Unexpected request: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mounted = await renderProviderModels();
+    try {
+      await flushQueuedSync();
+
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("/sync-models?mode=sync"),
+        expect.anything()
+      );
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("ignores inactive opt-outs when every active connection is enabled", async () => {
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.startsWith("/api/v1/providers/")) {
+        return createResponse({ data: [] });
+      }
+      if (input === "/api/providers") {
+        return createResponse({
+          connections: [
+            connection("connection-inactive", false, false),
+            connection("connection-active", true),
+          ],
+        });
+      }
+      if (input === "/api/providers/connection-active/sync-models?mode=sync") {
+        return createResponse({});
+      }
+      throw new Error(`Unexpected request: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mounted = await renderProviderModels();
+    await flushQueuedSync();
+
     expect(fetchMock).toHaveBeenCalledWith(
-      "/api/providers/connection-1/sync-models?mode=sync",
+      "/api/providers/connection-active/sync-models?mode=sync",
       { method: "POST" }
     );
     mounted.unmount();


### PR DESCRIPTION
## Summary

- Evaluate every active connection before treating provider-level model auto-fetch as enabled.
- Keep mixed opt-in state disabled regardless of API/database connection order.
- Ignore inactive opt-outs and reuse the first active opted-in connection as the sync target.

## Related Issues

- Closes #11800
- Related to #10603
- Related to #11798

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / UI
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Focused TDD evidence:

- Old implementation + regression matrix: `1 failed | 4 passed`; the enabled-first mixed case incorrectly posted `/sync-models?mode=sync`.
- Fixed implementation: `5 passed (5)`.
- `npm run lint`
- `npm run typecheck:core`
- `npm run check:dashboard-typecheck`
- `npm run check:cycles`
- `git diff --check`

Full-suite observations:

- `npm run test:vitest`: `48 passed | 1 failed`; inherited `auto/glm` 20-second timeout already recorded by the active release-base incident.
- `npm run test:vitest:ui`: `281 passed | 15 failed`; unrelated base/environment failures include Node 26 localStorage unavailability and stale UI expectations.
- ⚠️ base-red inherited: #11449

## Tests Added Or Updated

- `tests/unit/ui/use-provider-models-auto-fetch.test.tsx`

The regression matrix covers both mixed connection orders. A separate case verifies that an inactive opt-out does not block synchronization when every active connection opted in.

## Coverage Notes

The hook test drives the real empty-catalog auto-fetch branch, returns multiple provider connections from `/api/providers`, and asserts whether the sync request is emitted.

## Reviewer Notes

No schema, dependency, API, or feature-flag changes. #11798 remains separate and covers create-time synchronization ownership; this PR only fixes the shared dashboard hook's multi-connection decision.
