### PR TITLE
fix(docker): keep cache export failures non-blocking

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -171,7 +171,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
             ${{ env.GHCR_IMAGE_NAME }}
           cache-from: type=gha,scope=docker-${{ matrix.arch }}
-          cache-to: type=gha,scope=docker-${{ matrix.arch }},mode=max
+          cache-to: type=gha,scope=docker-${{ matrix.arch }},mode=max,ignore-error=true
           no-cache: false
         env:
           DOCKER_BUILDKIT_INLINE_CACHE: 1
@@ -188,7 +188,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
             ${{ env.GHCR_IMAGE_NAME }}
           cache-from: type=gha,scope=docker-web-${{ matrix.arch }}
-          cache-to: type=gha,scope=docker-web-${{ matrix.arch }},mode=max
+          cache-to: type=gha,scope=docker-web-${{ matrix.arch }},mode=max,ignore-error=true
           no-cache: false
         env:
           DOCKER_BUILDKIT_INLINE_CACHE: 1
@@ -206,7 +206,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
             ${{ env.GHCR_IMAGE_NAME }}
           cache-from: type=gha,scope=docker-bun-base-${{ matrix.arch }}
-          cache-to: type=gha,scope=docker-bun-base-${{ matrix.arch }},mode=max
+          cache-to: type=gha,scope=docker-bun-base-${{ matrix.arch }},mode=max,ignore-error=true
           no-cache: false
         env:
           DOCKER_BUILDKIT_INLINE_CACHE: 1
@@ -224,7 +224,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
             ${{ env.GHCR_IMAGE_NAME }}
           cache-from: type=gha,scope=docker-bun-web-${{ matrix.arch }}
-          cache-to: type=gha,scope=docker-bun-web-${{ matrix.arch }},mode=max
+          cache-to: type=gha,scope=docker-bun-web-${{ matrix.arch }},mode=max,ignore-error=true
           no-cache: false
         env:
           DOCKER_BUILDKIT_INLINE_CACHE: 1

--- a/tests/unit/docker-cache-export-best-effort-7518.test.ts
+++ b/tests/unit/docker-cache-export-best-effort-7518.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { resolve } from "node:path";
+
+const workflowPath = resolve(".github/workflows/docker-publish.yml");
+
+function ghaCacheExports(): string[] {
+  return readFileSync(workflowPath, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("cache-to:"))
+    .map((line) => line.slice("cache-to:".length).trim())
+    .filter((config) => config.split(",").some((option) => option.trim() === "type=gha"));
+}
+
+test("Docker publish treats every GitHub Actions cache export as best effort", () => {
+  const exports = ghaCacheExports();
+  const scopes = exports
+    .map((config) => {
+      const scope = config
+        .split(",")
+        .map((option) => option.trim())
+        .find((option) => option.startsWith("scope="));
+      return scope?.slice("scope=".length);
+    })
+    .sort();
+
+  assert.deepEqual(scopes, [
+    "docker-${{ matrix.arch }}",
+    "docker-bun-base-${{ matrix.arch }}",
+    "docker-bun-web-${{ matrix.arch }}",
+    "docker-web-${{ matrix.arch }}",
+  ]);
+
+  for (const config of exports) {
+    assert.ok(
+      config.split(",").some((option) => option.trim() === "ignore-error=true"),
+      `GitHub Actions cache export must be best effort: ${config}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Keep successful Docker image publication successful when the optional GitHub Actions cache exporter fails.
- Add BuildKit's `ignore-error=true` option to all four GHA cache exporters: native base, native web, Bun base, and Bun web.
- Add a static regression that inventories the four known cache scopes and requires every GHA cache export to remain best effort.

The failing `linux/arm64` run had already pushed both Docker Hub and GHCR manifests before the Azure Actions cache backend returned `404 BlobNotFound` during cache export:
https://github.com/diegosouzapw/OmniRoute/actions/runs/33024696933

This does not weaken image build or registry-push failures, and it does not alter the separate Bun/OOM behavior. It only prevents optional cache persistence from invalidating an otherwise successful publish.

## Related Issues

- Related to #7518

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: build-deploy
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Focused validation:

- Red before the workflow edit, then green twice:
  `node --import tsx/esm --test tests/unit/docker-cache-export-best-effort-7518.test.ts`
- `npm run lint`
- `npm run typecheck:core`
- `npx eslint tests/unit/docker-cache-export-best-effort-7518.test.ts`
- `npm run check:workflows`
- `npm run check:cycles`
- `npm run check:file-size`
- `npm run check:test-discovery`
- `npm run check:changelog-integrity`
- `js-yaml` parse of `.github/workflows/docker-publish.yml`
- `git diff --check`

`npm run check:workflows -- --ratchet` reports the inherited release-base result: 194 zizmor findings with v1.28.0 against the frozen baseline of 192. The pristine `release/v3.8.51` tip reports the identical 194 findings; this patch adds none. This is part of the already-tracked base-red state in #11449. `actionlint` was not installed locally; CI runs the repository's workflow gates.

## Tests Added Or Updated

- `tests/unit/docker-cache-export-best-effort-7518.test.ts`

## Coverage Notes

- No `src/`, `open-sse/`, `electron/`, or `bin/` files changed.
- The static test reads the real publish workflow, pins all four expected cache scopes, and rejects any GHA cache exporter without `ignore-error=true`.

## Reviewer Notes

- Scope is deliberately limited to the four existing `cache-to: type=gha` entries.
- Registry pushes and supported-image failures remain hard failures; only the cache-export side effect becomes best effort.
- Inherited base-red: #11449.
