### PR TITLE
fix(services): separate CLIProxyAPI health and model auth

### DIFF
--- a/changelog.d/fixes/11811-cliproxy-health-model-auth.md
+++ b/changelog.d/fixes/11811-cliproxy-health-model-auth.md
@@ -1,0 +1,1 @@
+- **fix(services):** embedded CLIProxyAPI lifecycle checks now use public `/healthz`, while model discovery uses the configured dedicated data-plane API key instead of the management password ([#11811](https://github.com/diegosouzapw/OmniRoute/pull/11811))

--- a/src/app/api/services/cliproxy/_lib.ts
+++ b/src/app/api/services/cliproxy/_lib.ts
@@ -20,7 +20,7 @@ export async function getOrInitSupervisor(): Promise<ServiceSupervisor> {
     tool: TOOL,
     port: PORT,
     spawnArgs: () => resolveSpawnArgs(PORT, managementKey),
-    healthUrl: () => `http://127.0.0.1:${PORT}/v1/models`,
+    healthUrl: () => `http://127.0.0.1:${PORT}/healthz`,
     healthIntervalMs: 5_000,
     stopTimeoutMs: 15_000,
     logsBufferBytes: 5_242_880,

--- a/src/lib/services/bootstrap.ts
+++ b/src/lib/services/bootstrap.ts
@@ -1,5 +1,7 @@
 import { getVersionManagerTool } from "@/lib/db/versionManager";
+import { getSettings } from "@/lib/db/settings";
 import { markAllUnavailable } from "@/lib/db/serviceModels";
+import { resolveDedicatedCliproxyapiApiKey } from "@omniroute/open-sse/handlers/chatCore/cliproxyapiCredentials";
 import { registerSupervisor, getSupervisor } from "./registry";
 import { ServiceSupervisor } from "./ServiceSupervisor";
 import { resolveSpawnArgs as nineRouterSpawnArgs } from "./installers/ninerouter";
@@ -8,10 +10,7 @@ import {
   CLIPROXY_DEFAULT_PORT,
 } from "./installers/cliproxy";
 import { resolveSpawnArgs as muxSpawnArgs, MUX_DEFAULT_PORT } from "./installers/mux";
-import {
-  resolveSpawnArgs as bifrostSpawnArgs,
-  BIFROST_DEFAULT_PORT,
-} from "./installers/bifrost";
+import { resolveSpawnArgs as bifrostSpawnArgs, BIFROST_DEFAULT_PORT } from "./installers/bifrost";
 import { resolveSpawnArgs as darioSpawnArgs, DARIO_DEFAULT_PORT } from "./installers/dario";
 import { getOrCreateApiKey } from "./apiKey";
 import { scheduleServiceModelSync, stopServiceModelSync } from "./modelSync";
@@ -59,7 +58,7 @@ const SERVICES: ServiceEntry[] = [
   {
     tool: "cliproxy",
     port: CLIPROXY_PORT,
-    healthPath: "/v1/models",
+    healthPath: "/healthz",
     healthIntervalMs: 5_000,
     stopTimeoutMs: 15_000,
     logsBufferBytes: 5_242_880,
@@ -128,6 +127,11 @@ export async function bootstrapEmbeddedServices(): Promise<void> {
     const apiKey = cfg.needsApiKey
       ? await getOrCreateApiKey(cfg.tool).catch(() => "placeholder")
       : "";
+    // CLIProxyAPI's generated key is management-only; /v1/models uses its dedicated data-plane key.
+    const modelSyncApiKey =
+      cfg.tool === "cliproxy"
+        ? (resolveDedicatedCliproxyapiApiKey(await getSettings()) ?? "")
+        : apiKey;
 
     const supervisor = new ServiceSupervisor({
       tool: cfg.tool,
@@ -148,7 +152,7 @@ export async function bootstrapEmbeddedServices(): Promise<void> {
     const baseUrl = `http://127.0.0.1:${cfg.port}`;
     supervisor.on("stateChange", (status: ServiceStatus) => {
       if (status.state === "running") {
-        scheduleServiceModelSync(cfg.tool, baseUrl, apiKey);
+        scheduleServiceModelSync(cfg.tool, baseUrl, modelSyncApiKey);
       } else if (status.state === "stopped" || status.state === "error") {
         stopServiceModelSync(cfg.tool);
         markAllUnavailable(cfg.tool);

--- a/tests/unit/services/cliproxy-health-model-auth.test.ts
+++ b/tests/unit/services/cliproxy-health-model-auth.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression for #11803: embedded CLIProxyAPI health and model-discovery credentials.
+ *
+ * The fake service deliberately separates its public liveness endpoint from
+ * its authenticated data plane:
+ *   - GET /healthz is public.
+ *   - GET /v1/models accepts only the operator-configured dedicated API key.
+ *
+ * CLIProxyAPI's MANAGEMENT_PASSWORD is a control-plane credential and must
+ * never be reused for /v1/models.
+ */
+
+import { after, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-cliproxy-auth-"));
+const DEDICATED_API_KEY = "cpa-dedicated-data-plane-key";
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.NODE_ENV = "test";
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+process.env.STORAGE_ENCRYPTION_KEY = "cliproxy-health-model-auth-test-key";
+process.env.OMNIROUTE_ADOPT_EXISTING_SERVICE = "1";
+
+const seenPaths: string[] = [];
+const modelAuthorizationHeaders: Array<string | null> = [];
+
+const fakeCliproxy = http.createServer((req, res) => {
+  const requestPath = req.url ?? "/";
+  seenPaths.push(requestPath);
+
+  if (requestPath === "/healthz") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return;
+  }
+
+  if (requestPath === "/v1/models") {
+    const authorization = req.headers.authorization ?? null;
+    modelAuthorizationHeaders.push(authorization);
+    if (authorization !== `Bearer ${DEDICATED_API_KEY}`) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "invalid API key" }));
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ data: [{ id: "fake-cpa-model", object: "model" }] }));
+    return;
+  }
+
+  res.writeHead(404).end();
+});
+
+await new Promise<void>((resolve, reject) => {
+  fakeCliproxy.once("error", reject);
+  fakeCliproxy.listen(0, "127.0.0.1", () => resolve());
+});
+
+const address = fakeCliproxy.address();
+assert.ok(address && typeof address === "object");
+process.env.CLIPROXYAPI_PORT = String(address.port);
+
+const core = await import("../../../src/lib/db/core.ts");
+const settingsDb = await import("../../../src/lib/db/settings.ts");
+const versionManager = await import("../../../src/lib/db/versionManager.ts");
+const { decrypt } = await import("../../../src/lib/db/encryption.ts");
+const { bootstrapEmbeddedServices } = await import("../../../src/lib/services/bootstrap.ts");
+const { getSupervisor, unregisterSupervisor } =
+  await import("../../../src/lib/services/registry.ts");
+const { getOrInitSupervisor } = await import("../../../src/app/api/services/cliproxy/_lib.ts");
+const { getServiceModels } = await import("../../../src/lib/db/serviceModels.ts");
+const { stopServiceModelSync } = await import("../../../src/lib/services/modelSync.ts");
+
+await versionManager.upsertVersionManagerTool({
+  tool: "cliproxy",
+  installedVersion: "test",
+  status: "stopped",
+  port: address.port,
+});
+await settingsDb.updateSettings({ cliproxyapi_api_key: DEDICATED_API_KEY });
+
+after(async () => {
+  stopServiceModelSync("cliproxy");
+  const supervisor = getSupervisor("cliproxy");
+  if (supervisor) await supervisor.stop();
+  unregisterSupervisor("cliproxy");
+  await new Promise<void>((resolve) => fakeCliproxy.close(() => resolve()));
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("embedded CLIProxyAPI uses public health and dedicated model credentials", async () => {
+  await bootstrapEmbeddedServices();
+
+  const supervisor = getSupervisor("cliproxy");
+  assert.ok(supervisor, "bootstrap must register the installed CLIProxyAPI service");
+
+  const serviceRow = await versionManager.getServiceRow("cliproxy");
+  const managementKey = decrypt(serviceRow?.apiKey);
+  assert.ok(managementKey, "bootstrap must create the separate management credential");
+  assert.notEqual(
+    managementKey,
+    DEDICATED_API_KEY,
+    "the management and data-plane credentials must remain distinct"
+  );
+
+  const status = await supervisor.start();
+  assert.equal(status.state, "running", "the public /healthz probe must accept the fake service");
+
+  const deadline = Date.now() + 3_000;
+  while (modelAuthorizationHeaders.length === 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  assert.ok(seenPaths.includes("/healthz"), "embedded health checks must use public /healthz");
+  assert.deepEqual(
+    modelAuthorizationHeaders,
+    [`Bearer ${DEDICATED_API_KEY}`],
+    "/v1/models must receive only settings.cliproxyapi_api_key"
+  );
+  assert.ok(
+    getServiceModels("cliproxy").some((model) => model.id === "cliproxy/fake-cpa-model"),
+    "the authenticated discovery response must be persisted"
+  );
+
+  stopServiceModelSync("cliproxy");
+  await supervisor.stop();
+  unregisterSupervisor("cliproxy");
+  seenPaths.length = 0;
+  modelAuthorizationHeaders.length = 0;
+
+  const onDemandSupervisor = await getOrInitSupervisor();
+  const onDemandStatus = await onDemandSupervisor.start();
+  assert.equal(
+    onDemandStatus.state,
+    "running",
+    "the on-demand route supervisor must also use public /healthz"
+  );
+  assert.ok(seenPaths.includes("/healthz"));
+  assert.equal(
+    modelAuthorizationHeaders.length,
+    0,
+    "the on-demand health probe must not call authenticated /v1/models"
+  );
+});


### PR DESCRIPTION
## Summary

- probe embedded CLIProxyAPI through its public `/healthz` lifecycle endpoint in both supervisor construction paths
- authenticate periodic `/v1/models` discovery with the existing dedicated `settings.cliproxyapi_api_key`
- keep the generated `MANAGEMENT_PASSWORD` strictly on CLIProxyAPI's management plane

## Related Issues

- Closes #11803
- Related to #7645

⚠️ base-red inherited: #11449

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: other (embedded-service lifecycle/authentication)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Focused evidence:

- RED on the unmodified release tip:
  `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test --test-force-exit tests/unit/services/cliproxy-health-model-auth.test.ts`
  failed with `the public /healthz probe must accept the fake service` (`error !== running`).
- GREEN after the fix: the same command passes.
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test --test-force-exit --test-concurrency=1 tests/unit/services/modelSync.test.ts tests/unit/cliproxyapi-dedicated-credential-7645.test.ts tests/unit/services/cliproxy-health-model-auth.test.ts`
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test --test-force-exit --test-concurrency=1 tests/unit/services/ServiceSupervisor.test.ts tests/unit/services/portProbePid.test.ts`
- `npm run typecheck:core`
- `npm run typecheck:noimplicit:core`
- `npm run lint`
- `npm run check:file-size`
- `npm run check:complexity`
- `npm run check:cognitive-complexity`
- `npm run check:cycles`
- `npm run check:deps`
- `npm run check:public-creds`
- `npm run check:test-discovery`
- `npm run check:test-runner-api`
- `npm run check:test-masking`
- `npm run check:dead-code`
- `npm run check:complexity-ratchets`
- `npm run check:changelog-integrity`

Local environment-only gaps:

- `check:forgotten-sibling-tests` cannot run because the release tip does not contain `config/quality/test-impact-map.json`.
- `check:secrets` cannot invoke the unconfigured local `gitleaks` mise shim; CI retains the authoritative secret scan.

## Tests Added Or Updated

- `tests/unit/services/cliproxy-health-model-auth.test.ts`
  - runs a fake CLIProxyAPI where `/healthz` is public and `/v1/models` accepts only a dedicated data-plane key
  - proves the generated management key is distinct and never reaches `/v1/models`
  - exercises both bootstrap and on-demand supervisor construction paths

Release note:

- `changelog.d/fixes/11811-cliproxy-health-model-auth.md`

## Coverage Notes

The new integration-style unit regression executes the real bootstrap, supervisor, settings DB,
credential resolver, model-sync scheduler, and service-model persistence path. It fails if either
health caller returns to `/v1/models` or if discovery reuses the management credential.

## Reviewer Notes

- No schema, migration, dependency, external-connection, or wrapper changes.
- Missing/blank `cliproxyapi_api_key` remains a failed model sync; it does not fall back to the management credential.
- The active base is `release/v3.8.51` at `2acbfc6fa`; no release freeze is open.
- The active base-red marker #11449 remains open and reports unrelated broad-suite/CI failures.
