### PR TITLE
fix(backend): capture usage on trailing choices:[] streaming chunks

### DIFF
--- a/changelog.d/fixes/11817-streaming-usage-trailing-empty-choices.md
+++ b/changelog.d/fixes/11817-streaming-usage-trailing-empty-choices.md
@@ -1,0 +1,1 @@
+- fix(backend): capture usage on trailing `choices: []` streaming chunks in the OpenAI→Claude translator, so cache token accounting from upstreams using `stream_options.include_usage` (e.g. Fireworks) is no longer silently dropped (#11817)

--- a/docs/architecture/meta.json
+++ b/docs/architecture/meta.json
@@ -13,6 +13,7 @@
     "admission-lanes",
     "cluster-decisions",
     "persistence-backend-boundary",
-    "ADAPTIVE_ROUTING"
+    "ADAPTIVE_ROUTING",
+    "streaming-usage-trailing-chunk-decision"
   ]
 }

--- a/docs/architecture/streaming-usage-trailing-chunk-decision.md
+++ b/docs/architecture/streaming-usage-trailing-chunk-decision.md
@@ -1,0 +1,42 @@
+---
+title: "Streaming Usage: Trailing Empty-Choices Chunk"
+version: 3.8.51
+lastUpdated: 2026-08-29
+---
+
+# Decision Record — Capturing Usage on Trailing `choices: []` Streaming Chunks
+
+**Status:** proposed (PR #11833, awaiting @diegosouzapw review)
+**Date:** 2026-08-29
+**Refs:** [#11817](https://github.com/diegosouzapw/OmniRoute/issues/11817), companion to [#9536](https://github.com/diegosouzapw/OmniRoute/issues/9536) / PR #9657
+
+## TL;DR
+
+`openaiToClaudeResponse()` in [`open-sse/translator/response/openai-to-claude.ts`](../../open-sse/translator/response/openai-to-claude.ts) early-returned before capturing `usage` whenever a chunk had no `choices[0]`. Upstreams using OpenAI's `stream_options.include_usage` contract (confirmed: Fireworks) send the authoritative usage block — including prompt-cache accounting — on exactly that shape: a trailing chunk with `choices: []`. The fix reorders the function so usage capture runs before the choices guard, at the cost of doing that check on every chunk instead of only ones with a choice.
+
+## Context
+
+Two ways OpenAI-compatible upstreams deliver usage in a stream:
+
+1. **Usage attached to the finish_reason chunk itself.** Single chunk, `choices: [{finish_reason: "stop", ...}], usage: {...}`. This already worked.
+2. **Usage on a separate trailing chunk, per the `include_usage` spec.** The finish_reason chunk arrives with `usage: null`, then one more chunk follows with `choices: []` and the real `usage` object. This is what Fireworks does, and it's spec-compliant OpenAI behavior, not a Fireworks quirk — so any upstream following that spec exactly hits the same bug.
+
+The existing code only handled case 1. Case 2's trailing chunk was dropped by the `!chunk.choices?.[0]` guard before ever reaching the usage-extraction logic, so `state.usage` kept whatever the finish_reason chunk had set (no cache split, or an estimate downstream falls back to).
+
+## Decision
+
+Move the usage-capture block (lines ~194-215) to run unconditionally on any non-null chunk, before the `choices?.[0]` guard. The guard itself is unchanged for everything after it — content/tool/finish handling still requires a real choice and returns `null` when there isn't one.
+
+### Alternatives considered
+
+- **Special-case `choices: []` explicitly** (`if (chunk.choices?.length === 0 && chunk.usage) { ...capture...; return null; }`) instead of reordering. Rejected: duplicates the extraction logic in two places, or requires extracting it into a shared helper for a one-call-site function — more surface area than reordering three lines for the same effect.
+- **Delay `message_delta`/`message_stop` until stream end**, so the terminal SSE event always has final usage regardless of which chunk it arrives on. This is the more complete fix (see Known Limitation below) but changes the finish-emission path shared by every provider going through this translator — bigger blast radius than this PR's scope. Left as a follow-up, not bundled here.
+
+## Known limitation (not fixed by this PR)
+
+`message_delta`/`message_stop` fire as soon as `choice.finish_reason` is seen (guarded by `state.claudeFinishEmitted`), which — per the ordering in case 2 above — is typically _before_ the trailing usage chunk arrives. This PR guarantees `state.usage` is correct for anything reading it **after** the stream completes (billing/logging writes, admin dashboards). It does **not** guarantee the live SSE `message_delta.usage` sent to the client reflects the corrected numbers, since that event may already be on the wire by the time the real usage lands. Confirming and closing that gap (if it matters for OmniRoute's actual billing pipeline) is the follow-up described above.
+
+## Validation
+
+- `tests/unit/11817-streaming-usage-trailing-empty-choices.test.ts` — reproduces the issue's exact Fireworks payload shape and asserts `state.usage` (input/output/cache_read) matches provider-reported numbers; asserts a usage-less trailing chunk is still a safe no-op.
+- Full existing suite touching this function (tool calls, XML `<invoke>` parsing, tool-name casing, finish-dedup, the non-streaming #9536 companion test): 93/93 pass, no regressions.

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -46,10 +46,22 @@ function extractXmlInvokeBlocks(
     const toolCallTextMatch = remaining.match(/TOOL_CALL\s+([A-Za-z0-9_]+):\s*/);
 
     const matches = [
-      invokeMatch ? { type: "invoke" as const, index: invokeMatch.index!, data: invokeMatch } : null,
-      toolCallTagMatch ? { type: "tool_call_tag" as const, index: toolCallTagMatch.index!, data: toolCallTagMatch } : null,
-      toolCallTextMatch ? { type: "tool_call_text" as const, index: toolCallTextMatch.index!, data: toolCallTextMatch } : null,
-    ].filter(Boolean).sort((a, b) => a!.index - b!.index);
+      invokeMatch
+        ? { type: "invoke" as const, index: invokeMatch.index!, data: invokeMatch }
+        : null,
+      toolCallTagMatch
+        ? { type: "tool_call_tag" as const, index: toolCallTagMatch.index!, data: toolCallTagMatch }
+        : null,
+      toolCallTextMatch
+        ? {
+            type: "tool_call_text" as const,
+            index: toolCallTextMatch.index!,
+            data: toolCallTextMatch,
+          }
+        : null,
+    ]
+      .filter(Boolean)
+      .sort((a, b) => a!.index - b!.index);
 
     if (matches.length === 0) {
       cleaned += remaining;
@@ -94,9 +106,7 @@ function extractXmlInvokeBlocks(
         const name = (parsed.name || parsed.tool_name || "") as string;
         const rawArgs = parsed.arguments || parsed.args || parsed.parameters || {};
         const args: Record<string, string> =
-          typeof rawArgs === "string"
-            ? JSON.parse(rawArgs)
-            : (rawArgs as Record<string, string>);
+          typeof rawArgs === "string" ? JSON.parse(rawArgs) : (rawArgs as Record<string, string>);
         if (name) {
           toolCalls.push({ id: `toolu_txt_${Date.now()}_${toolCalls.length}`, name, args });
         }
@@ -114,12 +124,27 @@ function extractXmlInvokeBlocks(
       let jsonEndIndex = -1;
       for (let i = 0; i < afterPrefix.length; i++) {
         const c = afterPrefix[i];
-        if (escape) { escape = false; continue; }
-        if (c === "\\" && inString) { escape = true; continue; }
-        if (c === '"') { inString = !inString; continue; }
+        if (escape) {
+          escape = false;
+          continue;
+        }
+        if (c === "\\" && inString) {
+          escape = true;
+          continue;
+        }
+        if (c === '"') {
+          inString = !inString;
+          continue;
+        }
         if (!inString) {
           if (c === "{") depth++;
-          else if (c === "}") { depth--; if (depth === 0) { jsonEndIndex = i + 1; break; } }
+          else if (c === "}") {
+            depth--;
+            if (depth === 0) {
+              jsonEndIndex = i + 1;
+              break;
+            }
+          }
         }
       }
       if (jsonEndIndex === -1) {
@@ -164,13 +189,15 @@ function stopTextBlock(state, results) {
 
 // Convert OpenAI stream chunk to Claude format
 export function openaiToClaudeResponse(chunk, state) {
-  if (!chunk || !chunk.choices?.[0]) return null;
+  if (!chunk) return null;
 
-  const results = [];
-  const choice = chunk.choices[0];
-  const delta = choice.delta;
-
-  // Track usage from OpenAI chunk if available
+  // Track usage from OpenAI chunk if available. This must run before the
+  // `choices?.[0]` guard below: upstreams using `stream_options.include_usage`
+  // (confirmed: Fireworks) send the real usage block — including cache token
+  // accounting — on a trailing chunk shaped `{choices: [], usage: {...}}`,
+  // which has no choice to process. Bailing out early on that shape (as this
+  // used to) silently dropped the real usage and left `state.usage` on
+  // whatever estimate/undefined value it had from the finish_reason chunk (#11817).
   if (chunk.usage && typeof chunk.usage === "object") {
     const promptTokens =
       typeof chunk.usage.prompt_tokens === "number" ? chunk.usage.prompt_tokens : 0;
@@ -205,6 +232,12 @@ export function openaiToClaudeResponse(chunk, state) {
     // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
     // No need to add separately as Claude expects total output_tokens
   }
+
+  if (!chunk.choices?.[0]) return null;
+
+  const results = [];
+  const choice = chunk.choices[0];
+  const delta = choice.delta;
 
   // First chunk - ALWAYS send message_start first
   if (!state.messageStartSent) {

--- a/tests/unit/11817-streaming-usage-trailing-empty-choices.test.ts
+++ b/tests/unit/11817-streaming-usage-trailing-empty-choices.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiToClaudeResponse } =
+  await import("../../open-sse/translator/response/openai-to-claude.ts");
+
+function createState() {
+  return {
+    toolCalls: new Map(),
+    _pendingXmlToolCalls: [],
+    _xmlInvokeBuffer: "",
+  };
+}
+
+/**
+ * #11817: openaiToClaudeResponse() discarded the real usage block whenever it
+ * arrived on a trailing chunk shaped `{choices: [], usage: {...}}` — the shape
+ * upstreams using `stream_options.include_usage` (confirmed: Fireworks, e.g.
+ * accounts/fireworks/models/kimi-k3) send it in. The early `!chunk.choices?.[0]`
+ * guard returned null before the usage-capture block ever ran, so
+ * cache_read_input_tokens / cache_creation_input_tokens were silently lost and
+ * downstream Claude-format clients only ever saw OmniRoute's own estimate.
+ *
+ * Companion to #9536 / PR #9657, which fixed the same field mapping on the
+ * non-streaming /v1/messages path.
+ */
+
+test("#11817: trailing choices:[] chunk with real usage updates state.usage (cache read)", () => {
+  const state = createState();
+
+  // Normal content + finish_reason chunk, no usage yet (typical mid-stream shape).
+  openaiToClaudeResponse(
+    {
+      id: "chatcmpl-1",
+      model: "accounts/fireworks/models/kimi-k3",
+      choices: [{ index: 0, delta: { content: "Hi" }, finish_reason: null }],
+    },
+    state
+  );
+  openaiToClaudeResponse(
+    {
+      id: "chatcmpl-1",
+      model: "accounts/fireworks/models/kimi-k3",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    },
+    state
+  );
+
+  // Trailing usage-only chunk, exactly as Fireworks sends it.
+  const trailing = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-1",
+      model: "accounts/fireworks/models/kimi-k3",
+      choices: [],
+      usage: {
+        prompt_tokens: 6103,
+        total_tokens: 6119,
+        completion_tokens: 16,
+        prompt_tokens_details: { cached_tokens: 6102 },
+        completion_tokens_details: { reasoning_tokens: 16 },
+      },
+    },
+    state
+  );
+
+  // No choice to process on this chunk, so no Claude events are emitted for it.
+  assert.equal(trailing, null);
+
+  // But state.usage must reflect the real, provider-reported numbers.
+  assert.equal(state.usage.input_tokens, 1); // 6103 - 6102 cached
+  assert.equal(state.usage.cache_read_input_tokens, 6102);
+  assert.equal(state.usage.output_tokens, 16);
+  assert.equal(state.usage.cache_creation_input_tokens, undefined);
+});
+
+test("#11817: trailing choices:[] chunk with no usage is still a safe no-op", () => {
+  const state = createState();
+  const result = openaiToClaudeResponse({ id: "chatcmpl-2", choices: [] }, state);
+  assert.equal(result, null);
+  assert.equal(state.usage, undefined);
+});


### PR DESCRIPTION
## Summary

Closes #11817.

`openaiToClaudeResponse()` (`open-sse/translator/response/openai-to-claude.ts`) early-returned on `!chunk.choices?.[0]` **before** the usage-capture block ran. Upstreams using `stream_options.include_usage` (confirmed by the reporter: Fireworks, `accounts/fireworks/models/kimi-k3`) send the real usage object — including `prompt_tokens_details` cache accounting — on a trailing chunk shaped `{choices: [], usage: {...}}`. That shape was silently discarded, so `state.usage` was left on whatever value the finish_reason chunk had set (often no cache split, or an estimate).

Fix moves the usage-capture block above the `choices?.[0]` guard so it runs regardless of whether the chunk has a choice to process. The function still returns `null` for that trailing chunk (nothing to translate into a Claude event), matching the existing `null`-chunk test — only `state.usage` changes.

This mirrors the non-streaming fix for the companion bug (#9536, landed in 3.8.50 via #9657) — same field-mapping logic, same root shape of bug, streaming path instead of non-streaming.

## Known follow-up (flagging, not fixing here)

`message_delta`/`message_stop` are emitted as soon as `choice.finish_reason` is seen (a few lines below, guarded by `state.claudeFinishEmitted`). Per the OpenAI `include_usage` contract, the trailing usage-only chunk this PR fixes typically arrives *after* the finish_reason chunk — meaning by the time the real usage lands, `message_stop` may already have been sent to the client with the old estimate. This PR guarantees `state.usage` is correct for any consumer that reads it after the stream (e.g. logging/billing), which is what the issue's own validation plan asks for and mirrors #9536's scope — but if the SSE `message_delta.usage` sent *to the client* also needs to reflect this, that requires buffering the terminal event by one chunk, which is a bigger change I didn't want to bundle in here unreviewed. Happy to follow up if maintainers want that handled too.

## Test plan

- Added `tests/unit/11817-streaming-usage-trailing-empty-choices.test.ts`: trailing `choices: []` chunk with real usage now populates `state.usage` (cache_read_input_tokens, input_tokens net of cache) exactly as in the issue's repro; a trailing chunk with no usage remains a safe no-op.
- Ran the full existing test suite touching this function (translator-resp-openai-to-claude, tool-call/XML/casing/shim tests, #9536 non-streaming companion test): 93/93 pass, no regressions.
- Pre-commit hooks (prettier, eslint, t11 any-budget, docs-sync) all pass.