### PR TITLE
feat(config): support runtime system prompt hot-reloading

### DIFF
--- a/src/lib/config/runtimeSettings.ts
+++ b/src/lib/config/runtimeSettings.ts
@@ -21,6 +21,7 @@ export type RuntimeReloadSection =
   | "corsOrigins"
   | "ccBridgeTransforms"
   | "systemTransforms"
+  | "systemPrompt"
   | "authzBypass"
   | "bannedSignals";
 
@@ -48,6 +49,7 @@ interface RuntimeSettingsSnapshot {
   corsOrigins: string;
   ccBridgeTransforms: unknown;
   systemTransforms: unknown;
+  systemPrompt: unknown;
   authzBypass: AuthzBypassSnapshot;
   customBannedSignals: string[];
   providerErrorRules: Record<string, OperatorProviderErrorRule[]> | null;
@@ -75,6 +77,7 @@ const DEFAULT_RUNTIME_SETTINGS_SNAPSHOT: RuntimeSettingsSnapshot = {
   corsOrigins: "",
   ccBridgeTransforms: null,
   systemTransforms: null,
+  systemPrompt: null,
   authzBypass: DEFAULT_AUTHZ_BYPASS_SNAPSHOT,
   customBannedSignals: [],
   providerErrorRules: null,
@@ -92,7 +95,6 @@ function isTruthyEnvFlag(value: string | undefined): boolean {
   if (typeof value !== "string") return false;
   return new Set(["1", "true", "yes", "on"]).has(value.trim().toLowerCase());
 }
-
 
 function toRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
@@ -276,6 +278,9 @@ export function buildRuntimeSettingsSnapshot(
     corsOrigins: typeof settings.corsOrigins === "string" ? settings.corsOrigins : "",
     ccBridgeTransforms: parseStoredJson(settings.ccBridgeTransforms, "ccBridgeTransforms"),
     systemTransforms: parseStoredJson(settings.systemTransforms, "systemTransforms"),
+    systemPrompt: settings.systemPrompt
+      ? parseStoredJson(settings.systemPrompt, "systemPrompt")
+      : null,
     authzBypass: normalizeAuthzBypass(settings),
     customBannedSignals: normalizeStringArray(settings.customBannedSignals),
     providerErrorRules: normalizeOperatorProviderErrorRules(settings.providerErrorRules),
@@ -402,6 +407,21 @@ async function applySystemTransformsSection(systemTransforms: unknown) {
   }
 
   setSystemTransformsConfig(systemTransforms);
+}
+
+async function applySystemPromptSection(systemPrompt: unknown) {
+  const { setSystemPromptConfig } = await import("@omniroute/open-sse/services/systemPrompt.ts");
+
+  if (systemPrompt && typeof systemPrompt === "object") {
+    setSystemPromptConfig(systemPrompt as Record<string, unknown>);
+  } else {
+    setSystemPromptConfig({
+      enabled: false,
+      prefixPrompt: "",
+      suffixPrompt: "",
+      prompt: "",
+    });
+  }
 }
 
 async function applyModelsDevSyncSection(
@@ -560,6 +580,11 @@ export async function applyRuntimeSettings(
   if (force || hasChanged(currentSnapshot.systemTransforms, previousSnapshot.systemTransforms)) {
     await applySystemTransformsSection(currentSnapshot.systemTransforms);
     markChanged("systemTransforms");
+  }
+
+  if (force || hasChanged(currentSnapshot.systemPrompt, previousSnapshot.systemPrompt)) {
+    await applySystemPromptSection(currentSnapshot.systemPrompt);
+    markChanged("systemPrompt");
   }
 
   if (force || hasChanged(currentSnapshot.authzBypass, previousSnapshot.authzBypass)) {

--- a/tests/unit/system-prompt-runtime-hotreload.test.ts
+++ b/tests/unit/system-prompt-runtime-hotreload.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyRuntimeSettings,
+  resetRuntimeSettingsStateForTests,
+} from "../../src/lib/config/runtimeSettings";
+import { getSystemPromptConfig } from "../../open-sse/services/systemPrompt.ts";
+
+test.afterEach(() => {
+  resetRuntimeSettingsStateForTests();
+});
+
+test("systemPrompt settings hot-reload updates globalThis in-memory config", async () => {
+  const newSettings = {
+    systemPrompt: {
+      enabled: true,
+      prefixPrompt: "Prefix rules for agent",
+      suffixPrompt: "Suffix rules for agent",
+    },
+  };
+
+  const changes = await applyRuntimeSettings(newSettings, { force: true, source: "test" });
+  assert.ok(
+    changes.some((c) => c.section === "systemPrompt"),
+    "systemPrompt section must be reported as reloaded"
+  );
+
+  const cfg = getSystemPromptConfig();
+  assert.equal(cfg.enabled, true, "systemPrompt enabled flag must be updated");
+  assert.equal(
+    cfg.prefixPrompt,
+    "Prefix rules for agent",
+    "prefixPrompt must match updated settings"
+  );
+  assert.equal(
+    cfg.suffixPrompt,
+    "Suffix rules for agent",
+    "suffixPrompt must match updated settings"
+  );
+
+  // Hot-reload clearing systemPrompt
+  await applyRuntimeSettings({ systemPrompt: null }, { force: true, source: "test" });
+  const clearedCfg = getSystemPromptConfig();
+  assert.equal(clearedCfg.enabled, false, "systemPrompt must be disabled when set to null");
+  assert.equal(clearedCfg.prefixPrompt, "", "prefixPrompt must be cleared when set to null");
+});


### PR DESCRIPTION
## Summary

  - Adds runtime settings hot-reloading for system prompt configurations (`prefixPrompt` and
  `suffixPrompt`).
  - Updates `applyRuntimeSettings` so changes to `systemPrompt` update in-memory settings without needing a
  server restart, and setting it to `null` properly disables and clears the prompt.

  ## Related Issues

  - Related to #2468
  - Related to #2470

  ## Validation

  Choose the change type and focused loop from the
  [Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
  Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

  - [x] Change type: other (runtime configuration)
  - [x] Focused tests and category gates from the golden path (`node --import tsx/esm --test
  tests/unit/system-prompt-runtime-hotreload.test.ts`)
  - [x] `npm run lint`
  - [x] Reconciled with the current active release base; focused checks rerun afterward
  - [x] Production-code changes include a new or updated automated test in this PR
  - SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

  ## Tests Added Or Updated

  - `tests/unit/system-prompt-runtime-hotreload.test.ts`

  ## Coverage Notes

  - Covered by `tests/unit/system-prompt-runtime-hotreload.test.ts`, which tests both the hot-reload
  configuration update and resetting state back to default when cleared.

  ## Reviewer Notes

  - No database schema migrations or breaking API changes.
  - Uses dynamic import to load `setSystemPromptConfig` inside `runtimeSettings.ts` only when `systemPrompt`
   changes or force reload is requested.