### PR TITLE
fix(sse): preserve coherent markdown token boundaries across stream translation chunks (#11606)

### DIFF
--- a/open-sse/translator/helpers/markdownBoundary.ts
+++ b/open-sse/translator/helpers/markdownBoundary.ts
@@ -34,40 +34,153 @@ function isOpenerContext(text: string, suffixStart: number): boolean {
 function scanBacktickState(
   text: string,
   initialRun: number,
-  initialTrailingBackslash: boolean
-): { backtickRun: number; trailingBackslash: boolean } {
+  initialTrailingBackslash: boolean,
+  initialFenceRun: number,
+  initialFenceOpening: boolean,
+  initialFenceClosingRun: number,
+  initialLineIndent: number
+): {
+  backtickRun: number;
+  trailingBackslash: boolean;
+  fenceRun: number;
+  fenceOpening: boolean;
+  fenceClosingRun: number;
+  lineIndent: number;
+} {
   let openRun = initialRun;
-  let backslashes = openRun === 0 && initialTrailingBackslash ? 1 : 0;
+  let fenceRun = initialFenceRun;
+  let fenceOpening = initialFenceOpening;
+  let fenceClosingRun = initialFenceClosingRun;
+  let lineIndent = initialLineIndent;
+  let backslashes = openRun === 0 && fenceRun === 0 && initialTrailingBackslash ? 1 : 0;
+
   for (let index = 0; index < text.length;) {
-    if (text[index] !== "`") {
-      if (openRun === 0) backslashes = text[index] === "\\" ? backslashes + 1 : 0;
+    const char = text[index];
+
+    if (fenceOpening) {
+      if (char === "\n" || char === "\r") {
+        fenceOpening = false;
+        lineIndent = 0;
+      } else if (char === "`" && lineIndent === -1) {
+        let runEnd = index + 1;
+        while (runEnd < text.length && text[runEnd] === "`") runEnd++;
+        fenceRun += runEnd - index;
+        index = runEnd;
+        continue;
+      } else if (char === "`") {
+        openRun = fenceRun;
+        fenceRun = 0;
+        fenceOpening = false;
+        continue;
+      } else lineIndent = 4;
+      index++;
+      continue;
+    }
+
+    if (fenceClosingRun) {
+      if (char === "\n" || char === "\r") {
+        fenceRun = 0;
+        fenceClosingRun = 0;
+        lineIndent = 0;
+      } else if (char === "`" && lineIndent === -1) {
+        let runEnd = index + 1;
+        while (runEnd < text.length && text[runEnd] === "`") runEnd++;
+        fenceClosingRun += runEnd - index;
+        index = runEnd;
+        continue;
+      } else if (char === " " || char === "\t") {
+        lineIndent = 4;
+      } else if (char !== " " && char !== "\t") {
+        fenceClosingRun = 0;
+        lineIndent = 4;
+      }
+      index++;
+      continue;
+    }
+
+    if (fenceRun) {
+      if (char === "\n" || char === "\r") {
+        lineIndent = 0;
+        index++;
+        continue;
+      }
+      if (char === " " && lineIndent < 4) {
+        lineIndent++;
+        index++;
+        continue;
+      }
+      if (char === "`" && lineIndent <= 3) {
+        let runEnd = index + 1;
+        while (runEnd < text.length && text[runEnd] === "`") runEnd++;
+        const runLength = runEnd - index;
+        if (runLength >= fenceRun) {
+          fenceClosingRun = runLength;
+          lineIndent = -1;
+        } else lineIndent = 4;
+        index = runEnd;
+        continue;
+      }
+      lineIndent = 4;
+      index++;
+      continue;
+    }
+
+    if (char !== "`") {
+      if (char === "\n" || char === "\r") lineIndent = 0;
+      else if (char === " " && lineIndent < 4) lineIndent++;
+      else lineIndent = 4;
+      if (openRun === 0) backslashes = char === "\\" ? backslashes + 1 : 0;
       index++;
       continue;
     }
     if (openRun === 0 && backslashes % 2 === 1) {
       backslashes = 0;
+      lineIndent = 4;
       index++;
       continue;
     }
     let runEnd = index + 1;
     while (runEnd < text.length && text[runEnd] === "`") runEnd++;
     const runLength = runEnd - index;
-    if (openRun === 0) openRun = runLength;
+    if (openRun === 0 && runLength >= 3 && lineIndent <= 3) {
+      fenceRun = runLength;
+      fenceOpening = true;
+      lineIndent = -1;
+    } else if (openRun === 0) openRun = runLength;
     else if (openRun === runLength) openRun = 0;
+    if (!fenceOpening) lineIndent = 4;
     backslashes = 0;
     index = runEnd;
   }
+
   return {
     backtickRun: openRun,
-    trailingBackslash: openRun === 0 && backslashes % 2 === 1,
+    trailingBackslash: openRun === 0 && fenceRun === 0 && backslashes % 2 === 1,
+    fenceRun,
+    fenceOpening,
+    fenceClosingRun,
+    lineIndent,
   };
 }
 
 export function splitMarkdownBoundary(
   text: string,
   priorBacktickRun = 0,
-  priorTrailingBackslash = false
-): { emit: string; hold: string; backtickRun?: number; trailingBackslash?: boolean } {
+  priorTrailingBackslash = false,
+  priorFenceRun = 0,
+  priorFenceOpening = false,
+  priorFenceClosingRun = 0,
+  priorLineIndent = 0
+): {
+  emit: string;
+  hold: string;
+  backtickRun?: number;
+  trailingBackslash?: boolean;
+  fenceRun?: number;
+  fenceOpening?: boolean;
+  fenceClosingRun?: number;
+  lineIndent?: number;
+} {
   if (!text) return { emit: "", hold: "" };
 
   // 1) Incomplete fenced code block opener or inline code opener:
@@ -82,15 +195,20 @@ export function splitMarkdownBoundary(
     const suffix = fenceMatch[0];
     const suffixStart = text.length - suffix.length;
     const runLength = suffix.match(/^`+/)?.[0].length ?? 0;
-    const { backtickRun: openRun } = scanBacktickState(
+    const { backtickRun: openRun, fenceRun } = scanBacktickState(
       text.slice(0, suffixStart),
       priorBacktickRun,
-      priorTrailingBackslash
+      priorTrailingBackslash,
+      priorFenceRun,
+      priorFenceOpening,
+      priorFenceClosingRun,
+      priorLineIndent
     );
     const closesKnownRun = openRun === runLength;
     const mayCompleteKnownRun = openRun > runLength;
     if (
       suffix.length <= MAX_HOLD_CHARS &&
+      fenceRun === 0 &&
       !closesKnownRun &&
       (mayCompleteKnownRun || isOpenerContext(text, suffixStart))
     ) {
@@ -98,7 +216,15 @@ export function splitMarkdownBoundary(
       return {
         emit,
         hold: suffix,
-        ...scanBacktickState(emit, priorBacktickRun, priorTrailingBackslash),
+        ...scanBacktickState(
+          emit,
+          priorBacktickRun,
+          priorTrailingBackslash,
+          priorFenceRun,
+          priorFenceOpening,
+          priorFenceClosingRun,
+          priorLineIndent
+        ),
       };
     }
   }
@@ -112,7 +238,15 @@ export function splitMarkdownBoundary(
       return {
         emit,
         hold: suffix,
-        ...scanBacktickState(emit, priorBacktickRun, priorTrailingBackslash),
+        ...scanBacktickState(
+          emit,
+          priorBacktickRun,
+          priorTrailingBackslash,
+          priorFenceRun,
+          priorFenceOpening,
+          priorFenceClosingRun,
+          priorLineIndent
+        ),
       };
     }
   }
@@ -120,6 +254,14 @@ export function splitMarkdownBoundary(
   return {
     emit: text,
     hold: "",
-    ...scanBacktickState(text, priorBacktickRun, priorTrailingBackslash),
+    ...scanBacktickState(
+      text,
+      priorBacktickRun,
+      priorTrailingBackslash,
+      priorFenceRun,
+      priorFenceOpening,
+      priorFenceClosingRun,
+      priorLineIndent
+    ),
   };
 }

--- a/open-sse/translator/helpers/markdownBoundary.ts
+++ b/open-sse/translator/helpers/markdownBoundary.ts
@@ -10,15 +10,15 @@
  * boundary token and defers it to the next chunk so the token is emitted in
  * one piece.
  *
- * Rules (all bounded by MAX_HOLD_CHARS):
+ * Rules (held suffixes are bounded by MAX_HOLD_CHARS):
  *   - 1-2 trailing backticks in an "opener" context (start, whitespace, or
  *     punctuation before the run) are held.
  *   - Three trailing backticks followed by a non-empty fence info string are
  *     held; plain "```" is emitted so a closing fence is not accidentally
  *     merged with following text.
- *   - A single trailing asterisk in an opener context is held. We never hold
- *     part of a "**" run, and we never hold when preceded by an alphanumeric
- *     character (which indicates a closing delimiter).
+ *   - One to three trailing asterisks in an opener context are held. We never
+ *     hold when preceded by an alphanumeric character (which indicates a
+ *     closing delimiter).
  */
 
 const MAX_HOLD_CHARS = 32;
@@ -29,6 +29,21 @@ function isOpenerContext(text: string, suffixStart: number): boolean {
   // Alphanumeric preceding characters usually mean the delimiter is closing
   // (e.g. "`code`" or "**bold**"), so do not hold those suffixes.
   return !/[A-Za-z0-9_]/.test(prev);
+}
+
+function hasUnclosedBacktickRun(text: string, suffixStart: number, runLength: number): boolean {
+  let matchingRuns = 0;
+  for (let index = 0; index < suffixStart;) {
+    if (text[index] !== "`") {
+      index++;
+      continue;
+    }
+    let runEnd = index + 1;
+    while (runEnd < suffixStart && text[runEnd] === "`") runEnd++;
+    if (runEnd - index === runLength) matchingRuns++;
+    index = runEnd;
+  }
+  return matchingRuns % 2 === 1;
 }
 
 export function splitMarkdownBoundary(text: string): { emit: string; hold: string } {
@@ -43,7 +58,10 @@ export function splitMarkdownBoundary(text: string): { emit: string; hold: strin
   const fenceMatch = text.match(/(?<!`)(`{1,2}[A-Za-z0-9_+#-]*|`{3,}[A-Za-z0-9_+#-]+)$/);
   if (fenceMatch) {
     const suffix = fenceMatch[0];
-    if (suffix.length <= MAX_HOLD_CHARS && isOpenerContext(text, text.length - suffix.length)) {
+    const suffixStart = text.length - suffix.length;
+    const runLength = suffix.match(/^`+/)?.[0].length ?? 0;
+    const closesKnownRun = hasUnclosedBacktickRun(text, suffixStart, runLength);
+    if (suffix.length <= MAX_HOLD_CHARS && !closesKnownRun && isOpenerContext(text, suffixStart)) {
       return { emit: text.slice(0, -suffix.length), hold: suffix };
     }
   }

--- a/open-sse/translator/helpers/markdownBoundary.ts
+++ b/open-sse/translator/helpers/markdownBoundary.ts
@@ -31,22 +31,21 @@ function isOpenerContext(text: string, suffixStart: number): boolean {
   return !/[A-Za-z0-9_]/.test(prev);
 }
 
-function scanBacktickRun(text: string, initialRun: number): number {
+function scanBacktickState(
+  text: string,
+  initialRun: number,
+  initialTrailingBackslash: boolean
+): { backtickRun: number; trailingBackslash: boolean } {
   let openRun = initialRun;
+  let backslashes = openRun === 0 && initialTrailingBackslash ? 1 : 0;
   for (let index = 0; index < text.length;) {
     if (text[index] !== "`") {
+      if (openRun === 0) backslashes = text[index] === "\\" ? backslashes + 1 : 0;
       index++;
       continue;
     }
-    let escapes = 0;
-    for (
-      let escapeIndex = index - 1;
-      escapeIndex >= 0 && text[escapeIndex] === "\\";
-      escapeIndex--
-    ) {
-      escapes++;
-    }
-    if (escapes % 2 === 1) {
+    if (openRun === 0 && backslashes % 2 === 1) {
+      backslashes = 0;
       index++;
       continue;
     }
@@ -55,15 +54,20 @@ function scanBacktickRun(text: string, initialRun: number): number {
     const runLength = runEnd - index;
     if (openRun === 0) openRun = runLength;
     else if (openRun === runLength) openRun = 0;
+    backslashes = 0;
     index = runEnd;
   }
-  return openRun;
+  return {
+    backtickRun: openRun,
+    trailingBackslash: openRun === 0 && backslashes % 2 === 1,
+  };
 }
 
 export function splitMarkdownBoundary(
   text: string,
-  priorBacktickRun = 0
-): { emit: string; hold: string; backtickRun?: number } {
+  priorBacktickRun = 0,
+  priorTrailingBackslash = false
+): { emit: string; hold: string; backtickRun?: number; trailingBackslash?: boolean } {
   if (!text) return { emit: "", hold: "" };
 
   // 1) Incomplete fenced code block opener or inline code opener:
@@ -78,7 +82,11 @@ export function splitMarkdownBoundary(
     const suffix = fenceMatch[0];
     const suffixStart = text.length - suffix.length;
     const runLength = suffix.match(/^`+/)?.[0].length ?? 0;
-    const openRun = scanBacktickRun(text.slice(0, suffixStart), priorBacktickRun);
+    const { backtickRun: openRun } = scanBacktickState(
+      text.slice(0, suffixStart),
+      priorBacktickRun,
+      priorTrailingBackslash
+    );
     const closesKnownRun = openRun === runLength;
     const mayCompleteKnownRun = openRun > runLength;
     if (
@@ -87,8 +95,11 @@ export function splitMarkdownBoundary(
       (mayCompleteKnownRun || isOpenerContext(text, suffixStart))
     ) {
       const emit = text.slice(0, -suffix.length);
-      const backtickRun = scanBacktickRun(emit, priorBacktickRun);
-      return backtickRun ? { emit, hold: suffix, backtickRun } : { emit, hold: suffix };
+      return {
+        emit,
+        hold: suffix,
+        ...scanBacktickState(emit, priorBacktickRun, priorTrailingBackslash),
+      };
     }
   }
 
@@ -98,11 +109,17 @@ export function splitMarkdownBoundary(
     const suffix = emphMatch[0];
     if (isOpenerContext(text, text.length - suffix.length)) {
       const emit = text.slice(0, -suffix.length);
-      const backtickRun = scanBacktickRun(emit, priorBacktickRun);
-      return backtickRun ? { emit, hold: suffix, backtickRun } : { emit, hold: suffix };
+      return {
+        emit,
+        hold: suffix,
+        ...scanBacktickState(emit, priorBacktickRun, priorTrailingBackslash),
+      };
     }
   }
 
-  const backtickRun = scanBacktickRun(text, priorBacktickRun);
-  return backtickRun ? { emit: text, hold: "", backtickRun } : { emit: text, hold: "" };
+  return {
+    emit: text,
+    hold: "",
+    ...scanBacktickState(text, priorBacktickRun, priorTrailingBackslash),
+  };
 }

--- a/open-sse/translator/helpers/markdownBoundary.ts
+++ b/open-sse/translator/helpers/markdownBoundary.ts
@@ -1,0 +1,61 @@
+/**
+ * Markdown boundary buffering for streaming text deltas.
+ *
+ * Upstream SSE chunks can split in the middle of Markdown tokens such as
+ * fenced code blocks (```language) or bold markers (**). Emitting those
+ * partial tokens as separate text_delta events causes clients to render the
+ * stream with broken Markdown until the next delta arrives.
+ *
+ * This helper identifies a trailing suffix that is an *incomplete* Markdown
+ * boundary token and defers it to the next chunk so the token is emitted in
+ * one piece.
+ *
+ * Rules (all bounded by MAX_HOLD_CHARS):
+ *   - 1-2 trailing backticks in an "opener" context (start, whitespace, or
+ *     punctuation before the run) are held.
+ *   - Three trailing backticks followed by a non-empty fence info string are
+ *     held; plain "```" is emitted so a closing fence is not accidentally
+ *     merged with following text.
+ *   - A single trailing asterisk in an opener context is held. We never hold
+ *     part of a "**" run, and we never hold when preceded by an alphanumeric
+ *     character (which indicates a closing delimiter).
+ */
+
+const MAX_HOLD_CHARS = 32;
+
+function isOpenerContext(text: string, suffixStart: number): boolean {
+  if (suffixStart <= 0) return true;
+  const prev = text[suffixStart - 1];
+  // Alphanumeric preceding characters usually mean the delimiter is closing
+  // (e.g. "`code`" or "**bold**"), so do not hold those suffixes.
+  return !/[A-Za-z0-9_]/.test(prev);
+}
+
+export function splitMarkdownBoundary(text: string): { emit: string; hold: string } {
+  if (!text) return { emit: "", hold: "" };
+
+  // 1) Incomplete fenced code block opener or inline code opener:
+  //    - ` or `` (incomplete delimiter)
+  //    - `code or ``code (incomplete inline code run)
+  //    - ```python (fence delimiter + partial info string)
+  //    Do NOT hold plain "```" by itself to avoid gluing a closing fence to
+  //    the next line of normal text.
+  const fenceMatch = text.match(/(?<!`)(`{1,2}[A-Za-z0-9_+#-]*|`{3,}[A-Za-z0-9_+#-]+)$/);
+  if (fenceMatch) {
+    const suffix = fenceMatch[0];
+    if (suffix.length <= MAX_HOLD_CHARS && isOpenerContext(text, text.length - suffix.length)) {
+      return { emit: text.slice(0, -suffix.length), hold: suffix };
+    }
+  }
+
+  // 2) Incomplete emphasis/bold opener: 1 to 3 asterisks in an opener context.
+  const emphMatch = text.match(/(?<!\*)\*{1,3}$/);
+  if (emphMatch) {
+    const suffix = emphMatch[0];
+    if (isOpenerContext(text, text.length - suffix.length)) {
+      return { emit: text.slice(0, -suffix.length), hold: suffix };
+    }
+  }
+
+  return { emit: text, hold: "" };
+}

--- a/open-sse/translator/helpers/markdownBoundary.ts
+++ b/open-sse/translator/helpers/markdownBoundary.ts
@@ -31,38 +31,64 @@ function isOpenerContext(text: string, suffixStart: number): boolean {
   return !/[A-Za-z0-9_]/.test(prev);
 }
 
-function hasUnclosedBacktickRun(text: string, suffixStart: number, runLength: number): boolean {
-  let matchingRuns = 0;
-  for (let index = 0; index < suffixStart;) {
+function scanBacktickRun(text: string, initialRun: number): number {
+  let openRun = initialRun;
+  for (let index = 0; index < text.length;) {
     if (text[index] !== "`") {
       index++;
       continue;
     }
+    let escapes = 0;
+    for (
+      let escapeIndex = index - 1;
+      escapeIndex >= 0 && text[escapeIndex] === "\\";
+      escapeIndex--
+    ) {
+      escapes++;
+    }
+    if (escapes % 2 === 1) {
+      index++;
+      continue;
+    }
     let runEnd = index + 1;
-    while (runEnd < suffixStart && text[runEnd] === "`") runEnd++;
-    if (runEnd - index === runLength) matchingRuns++;
+    while (runEnd < text.length && text[runEnd] === "`") runEnd++;
+    const runLength = runEnd - index;
+    if (openRun === 0) openRun = runLength;
+    else if (openRun === runLength) openRun = 0;
     index = runEnd;
   }
-  return matchingRuns % 2 === 1;
+  return openRun;
 }
 
-export function splitMarkdownBoundary(text: string): { emit: string; hold: string } {
+export function splitMarkdownBoundary(
+  text: string,
+  priorBacktickRun = 0
+): { emit: string; hold: string; backtickRun?: number } {
   if (!text) return { emit: "", hold: "" };
 
   // 1) Incomplete fenced code block opener or inline code opener:
   //    - ` or `` (incomplete delimiter)
   //    - `code or ``code (incomplete inline code run)
-  //    - ```python (fence delimiter + partial info string)
+  //    - ```info (fence delimiter + partial info string; any non-backtick,
+  //      non-line-ending CommonMark info character)
   //    Do NOT hold plain "```" by itself to avoid gluing a closing fence to
   //    the next line of normal text.
-  const fenceMatch = text.match(/(?<!`)(`{1,2}[A-Za-z0-9_+#-]*|`{3,}[A-Za-z0-9_+#-]+)$/);
+  const fenceMatch = text.match(/(?<!`)(`{1,2}[A-Za-z0-9_+#-]*|`{3,}[^`\r\n]+)$/);
   if (fenceMatch) {
     const suffix = fenceMatch[0];
     const suffixStart = text.length - suffix.length;
     const runLength = suffix.match(/^`+/)?.[0].length ?? 0;
-    const closesKnownRun = hasUnclosedBacktickRun(text, suffixStart, runLength);
-    if (suffix.length <= MAX_HOLD_CHARS && !closesKnownRun && isOpenerContext(text, suffixStart)) {
-      return { emit: text.slice(0, -suffix.length), hold: suffix };
+    const openRun = scanBacktickRun(text.slice(0, suffixStart), priorBacktickRun);
+    const closesKnownRun = openRun === runLength;
+    const mayCompleteKnownRun = openRun > runLength;
+    if (
+      suffix.length <= MAX_HOLD_CHARS &&
+      !closesKnownRun &&
+      (mayCompleteKnownRun || isOpenerContext(text, suffixStart))
+    ) {
+      const emit = text.slice(0, -suffix.length);
+      const backtickRun = scanBacktickRun(emit, priorBacktickRun);
+      return backtickRun ? { emit, hold: suffix, backtickRun } : { emit, hold: suffix };
     }
   }
 
@@ -71,9 +97,12 @@ export function splitMarkdownBoundary(text: string): { emit: string; hold: strin
   if (emphMatch) {
     const suffix = emphMatch[0];
     if (isOpenerContext(text, text.length - suffix.length)) {
-      return { emit: text.slice(0, -suffix.length), hold: suffix };
+      const emit = text.slice(0, -suffix.length);
+      const backtickRun = scanBacktickRun(emit, priorBacktickRun);
+      return backtickRun ? { emit, hold: suffix, backtickRun } : { emit, hold: suffix };
     }
   }
 
-  return { emit: text, hold: "" };
+  const backtickRun = scanBacktickRun(text, priorBacktickRun);
+  return backtickRun ? { emit: text, hold: "", backtickRun } : { emit: text, hold: "" };
 }

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -323,7 +323,7 @@ export function geminiToClaudeResponse(chunk, state) {
           const { emit: textToEmit, hold: textToHold } = splitMarkdownBoundary(combinedText);
           state._markdownBuffer = textToHold;
 
-          // Fully-held chunk (e.g. "`" + "code" → whole text deferred to the
+          // Fully-held chunk (e.g. "`" + "code" -> whole text deferred to the
           // boundary buffer): emitting an empty delta here opens a text block
           // and fires a zero-length text_delta for nothing. The held content
           // flushes on the next chunk; skip the event pair entirely.

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -100,6 +100,7 @@ function extractXmlInvokeBlocks(
 function flushMarkdownBuffer(state, results) {
   const buffered = state._markdownBuffer;
   state._markdownCodeSpanRun = 0;
+  state._markdownTrailingBackslash = false;
   if (!buffered) return;
   state._markdownBuffer = "";
   if (state.openTextBlockIdx === null) {
@@ -147,6 +148,7 @@ export function geminiToClaudeResponse(chunk, state) {
     state.openTextBlockIdx = null;
     state._markdownBuffer = "";
     state._markdownCodeSpanRun = 0;
+    state._markdownTrailingBackslash = false;
 
     results.push({
       type: "message_start",
@@ -326,9 +328,15 @@ export function geminiToClaudeResponse(chunk, state) {
             emit: textToEmit,
             hold: textToHold,
             backtickRun,
-          } = splitMarkdownBoundary(combinedText, state._markdownCodeSpanRun || 0);
+            trailingBackslash,
+          } = splitMarkdownBoundary(
+            combinedText,
+            state._markdownCodeSpanRun || 0,
+            state._markdownTrailingBackslash === true,
+          );
           state._markdownBuffer = textToHold;
           state._markdownCodeSpanRun = backtickRun || 0;
+          state._markdownTrailingBackslash = trailingBackslash === true;
 
           // Fully-held chunk (e.g. "`" + "code" -> whole text deferred to the
           // boundary buffer): emitting an empty delta here opens a text block

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -99,6 +99,7 @@ function extractXmlInvokeBlocks(
 // Helper: flush any buffered Markdown boundary text before closing the open text block
 function flushMarkdownBuffer(state, results) {
   const buffered = state._markdownBuffer;
+  state._markdownCodeSpanRun = 0;
   if (!buffered) return;
   state._markdownBuffer = "";
   if (state.openTextBlockIdx === null) {
@@ -145,6 +146,7 @@ export function geminiToClaudeResponse(chunk, state) {
     // Track open text block so we can keep it open across chunks
     state.openTextBlockIdx = null;
     state._markdownBuffer = "";
+    state._markdownCodeSpanRun = 0;
 
     results.push({
       type: "message_start",
@@ -320,8 +322,13 @@ export function geminiToClaudeResponse(chunk, state) {
           const bufferedPrefix = state._markdownBuffer || "";
           state._markdownBuffer = "";
           const combinedText = bufferedPrefix + cleaned;
-          const { emit: textToEmit, hold: textToHold } = splitMarkdownBoundary(combinedText);
+          const {
+            emit: textToEmit,
+            hold: textToHold,
+            backtickRun,
+          } = splitMarkdownBoundary(combinedText, state._markdownCodeSpanRun || 0);
           state._markdownBuffer = textToHold;
+          state._markdownCodeSpanRun = backtickRun || 0;
 
           // Fully-held chunk (e.g. "`" + "code" -> whole text deferred to the
           // boundary buffer): emitting an empty delta here opens a text block

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -323,21 +323,27 @@ export function geminiToClaudeResponse(chunk, state) {
           const { emit: textToEmit, hold: textToHold } = splitMarkdownBoundary(combinedText);
           state._markdownBuffer = textToHold;
 
-          // Open a new text block only if none is open yet
-          if (state.openTextBlockIdx === null) {
-            const idx = state.contentBlockIndex++;
-            state.openTextBlockIdx = idx;
+          // Fully-held chunk (e.g. "`" + "code" → whole text deferred to the
+          // boundary buffer): emitting an empty delta here opens a text block
+          // and fires a zero-length text_delta for nothing. The held content
+          // flushes on the next chunk; skip the event pair entirely.
+          if (textToEmit) {
+            // Open a new text block only if none is open yet
+            if (state.openTextBlockIdx === null) {
+              const idx = state.contentBlockIndex++;
+              state.openTextBlockIdx = idx;
+              results.push({
+                type: "content_block_start",
+                index: idx,
+                content_block: { type: "text", text: "" },
+              });
+            }
             results.push({
-              type: "content_block_start",
-              index: idx,
-              content_block: { type: "text", text: "" },
+              type: "content_block_delta",
+              index: state.openTextBlockIdx,
+              delta: { type: "text_delta", text: textToEmit },
             });
           }
-          results.push({
-            type: "content_block_delta",
-            index: state.openTextBlockIdx,
-            delta: { type: "text_delta", text: textToEmit },
-          });
         }
       }
     }

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -101,6 +101,10 @@ function flushMarkdownBuffer(state, results) {
   const buffered = state._markdownBuffer;
   state._markdownCodeSpanRun = 0;
   state._markdownTrailingBackslash = false;
+  state._markdownFenceRun = 0;
+  state._markdownFenceOpening = false;
+  state._markdownFenceClosingRun = 0;
+  state._markdownLineIndent = 0;
   if (!buffered) return;
   state._markdownBuffer = "";
   if (state.openTextBlockIdx === null) {
@@ -149,6 +153,10 @@ export function geminiToClaudeResponse(chunk, state) {
     state._markdownBuffer = "";
     state._markdownCodeSpanRun = 0;
     state._markdownTrailingBackslash = false;
+    state._markdownFenceRun = 0;
+    state._markdownFenceOpening = false;
+    state._markdownFenceClosingRun = 0;
+    state._markdownLineIndent = 0;
 
     results.push({
       type: "message_start",
@@ -329,14 +337,26 @@ export function geminiToClaudeResponse(chunk, state) {
             hold: textToHold,
             backtickRun,
             trailingBackslash,
+            fenceRun,
+            fenceOpening,
+            fenceClosingRun,
+            lineIndent,
           } = splitMarkdownBoundary(
             combinedText,
             state._markdownCodeSpanRun || 0,
             state._markdownTrailingBackslash === true,
+            state._markdownFenceRun || 0,
+            state._markdownFenceOpening === true,
+            state._markdownFenceClosingRun || 0,
+            state._markdownLineIndent || 0,
           );
           state._markdownBuffer = textToHold;
           state._markdownCodeSpanRun = backtickRun || 0;
           state._markdownTrailingBackslash = trailingBackslash === true;
+          state._markdownFenceRun = fenceRun || 0;
+          state._markdownFenceOpening = fenceOpening === true;
+          state._markdownFenceClosingRun = fenceClosingRun || 0;
+          state._markdownLineIndent = lineIndent || 0;
 
           // Fully-held chunk (e.g. "`" + "code" -> whole text deferred to the
           // boundary buffer): emitting an empty delta here opens a text block

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -6,6 +6,7 @@ import {
   buildGeminiThoughtSignatureKey,
   storeGeminiThoughtSignature,
 } from "../../services/geminiThoughtSignatureStore.ts";
+import { splitMarkdownBoundary } from "../helpers/markdownBoundary.ts";
 
 function normalizeToolName(name: string, toolNameMap?: Map<string, string> | null): string {
   return restoreClaudeToolName(name, toolNameMap);
@@ -95,6 +96,27 @@ function extractXmlInvokeBlocks(
   return { cleaned, toolCalls };
 }
 
+// Helper: flush any buffered Markdown boundary text before closing the open text block
+function flushMarkdownBuffer(state, results) {
+  const buffered = state._markdownBuffer;
+  if (!buffered) return;
+  state._markdownBuffer = "";
+  if (state.openTextBlockIdx === null) {
+    const idx = state.contentBlockIndex++;
+    state.openTextBlockIdx = idx;
+    results.push({
+      type: "content_block_start",
+      index: idx,
+      content_block: { type: "text", text: "" },
+    });
+  }
+  results.push({
+    type: "content_block_delta",
+    index: state.openTextBlockIdx,
+    delta: { type: "text_delta", text: buffered },
+  });
+}
+
 /**
  * Direct Gemini → Claude response translator.
  * Converts Gemini streaming chunks directly to Claude Messages API
@@ -122,6 +144,7 @@ export function geminiToClaudeResponse(chunk, state) {
     state.contentBlockIndex = 0;
     // Track open text block so we can keep it open across chunks
     state.openTextBlockIdx = null;
+    state._markdownBuffer = "";
 
     results.push({
       type: "message_start",
@@ -153,6 +176,7 @@ export function geminiToClaudeResponse(chunk, state) {
       // Thinking content → thinking block (always open+close per chunk)
       if (isThought && part.text) {
         // Close any open text block first
+        flushMarkdownBuffer(state, results);
         if (state.openTextBlockIdx !== null) {
           results.push({ type: "content_block_stop", index: state.openTextBlockIdx });
           state.openTextBlockIdx = null;
@@ -186,6 +210,7 @@ export function geminiToClaudeResponse(chunk, state) {
       // Function call → tool_use block
       if (part.functionCall) {
         // Close any open text block first
+        flushMarkdownBuffer(state, results);
         if (state.openTextBlockIdx !== null) {
           results.push({ type: "content_block_stop", index: state.openTextBlockIdx });
           state.openTextBlockIdx = null;
@@ -250,6 +275,7 @@ export function geminiToClaudeResponse(chunk, state) {
 
         // Process any extracted text-format tool calls (<tool_call>, TOOL_CALL, <invoke>)
         if (textToolCalls.length > 0) {
+          flushMarkdownBuffer(state, results);
           if (state.openTextBlockIdx !== null) {
             results.push({ type: "content_block_stop", index: state.openTextBlockIdx });
             state.openTextBlockIdx = null;
@@ -290,6 +316,13 @@ export function geminiToClaudeResponse(chunk, state) {
         }
 
         if (cleaned) {
+          // Rehydrate buffered Markdown boundary prefix before emitting.
+          const bufferedPrefix = state._markdownBuffer || "";
+          state._markdownBuffer = "";
+          const combinedText = bufferedPrefix + cleaned;
+          const { emit: textToEmit, hold: textToHold } = splitMarkdownBoundary(combinedText);
+          state._markdownBuffer = textToHold;
+
           // Open a new text block only if none is open yet
           if (state.openTextBlockIdx === null) {
             const idx = state.contentBlockIndex++;
@@ -303,7 +336,7 @@ export function geminiToClaudeResponse(chunk, state) {
           results.push({
             type: "content_block_delta",
             index: state.openTextBlockIdx,
-            delta: { type: "text_delta", text: cleaned },
+            delta: { type: "text_delta", text: textToEmit },
           });
         }
       }
@@ -334,6 +367,7 @@ export function geminiToClaudeResponse(chunk, state) {
   // ── Finish reason → close open blocks + message_delta + message_stop ──
   if (candidate.finishReason) {
     // Close any still-open text block before finishing
+    flushMarkdownBuffer(state, results);
     if (state.openTextBlockIdx !== null) {
       results.push({ type: "content_block_stop", index: state.openTextBlockIdx });
       state.openTextBlockIdx = null;

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -155,6 +155,7 @@ function stopThinkingBlock(state, results) {
 // Helper: flush any buffered Markdown boundary text before closing a text block
 function flushMarkdownBuffer(state, results) {
   const buffered = state._markdownBuffer;
+  state._markdownCodeSpanRun = 0;
   if (!buffered) return;
   state._markdownBuffer = "";
   if (!state.textBlockStarted) {
@@ -245,6 +246,7 @@ export function openaiToClaudeResponse(chunk, state) {
     state._pendingXmlToolCalls = [];
     state._xmlInvokeBuffer = "";
     state._markdownBuffer = "";
+    state._markdownCodeSpanRun = 0;
     results.push({
       type: "message_start",
       message: {
@@ -325,8 +327,13 @@ export function openaiToClaudeResponse(chunk, state) {
       }
 
       // Defer any trailing incomplete Markdown boundary token to the next chunk.
-      const { emit: textToEmit, hold: textToHold } = splitMarkdownBoundary(cleaned);
+      const {
+        emit: textToEmit,
+        hold: textToHold,
+        backtickRun,
+      } = splitMarkdownBoundary(cleaned, state._markdownCodeSpanRun || 0);
       state._markdownBuffer = textToHold;
+      state._markdownCodeSpanRun = backtickRun || 0;
 
       // Emit remaining non-XML text content
       if (!textToEmit) {

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -156,6 +156,7 @@ function stopThinkingBlock(state, results) {
 function flushMarkdownBuffer(state, results) {
   const buffered = state._markdownBuffer;
   state._markdownCodeSpanRun = 0;
+  state._markdownTrailingBackslash = false;
   if (!buffered) return;
   state._markdownBuffer = "";
   if (!state.textBlockStarted) {
@@ -247,6 +248,7 @@ export function openaiToClaudeResponse(chunk, state) {
     state._xmlInvokeBuffer = "";
     state._markdownBuffer = "";
     state._markdownCodeSpanRun = 0;
+    state._markdownTrailingBackslash = false;
     results.push({
       type: "message_start",
       message: {
@@ -331,9 +333,15 @@ export function openaiToClaudeResponse(chunk, state) {
         emit: textToEmit,
         hold: textToHold,
         backtickRun,
-      } = splitMarkdownBoundary(cleaned, state._markdownCodeSpanRun || 0);
+        trailingBackslash,
+      } = splitMarkdownBoundary(
+        cleaned,
+        state._markdownCodeSpanRun || 0,
+        state._markdownTrailingBackslash === true,
+      );
       state._markdownBuffer = textToHold;
       state._markdownCodeSpanRun = backtickRun || 0;
+      state._markdownTrailingBackslash = trailingBackslash === true;
 
       // Emit remaining non-XML text content
       if (!textToEmit) {

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -157,6 +157,10 @@ function flushMarkdownBuffer(state, results) {
   const buffered = state._markdownBuffer;
   state._markdownCodeSpanRun = 0;
   state._markdownTrailingBackslash = false;
+  state._markdownFenceRun = 0;
+  state._markdownFenceOpening = false;
+  state._markdownFenceClosingRun = 0;
+  state._markdownLineIndent = 0;
   if (!buffered) return;
   state._markdownBuffer = "";
   if (!state.textBlockStarted) {
@@ -249,6 +253,10 @@ export function openaiToClaudeResponse(chunk, state) {
     state._markdownBuffer = "";
     state._markdownCodeSpanRun = 0;
     state._markdownTrailingBackslash = false;
+    state._markdownFenceRun = 0;
+    state._markdownFenceOpening = false;
+    state._markdownFenceClosingRun = 0;
+    state._markdownLineIndent = 0;
     results.push({
       type: "message_start",
       message: {
@@ -334,38 +342,29 @@ export function openaiToClaudeResponse(chunk, state) {
         hold: textToHold,
         backtickRun,
         trailingBackslash,
+        fenceRun,
+        fenceOpening,
+        fenceClosingRun,
+        lineIndent,
       } = splitMarkdownBoundary(
         cleaned,
         state._markdownCodeSpanRun || 0,
         state._markdownTrailingBackslash === true,
+        state._markdownFenceRun || 0,
+        state._markdownFenceOpening === true,
+        state._markdownFenceClosingRun || 0,
+        state._markdownLineIndent || 0,
       );
       state._markdownBuffer = textToHold;
       state._markdownCodeSpanRun = backtickRun || 0;
       state._markdownTrailingBackslash = trailingBackslash === true;
+      state._markdownFenceRun = fenceRun || 0;
+      state._markdownFenceOpening = fenceOpening === true;
+      state._markdownFenceClosingRun = fenceClosingRun || 0;
+      state._markdownLineIndent = lineIndent || 0;
 
       // Emit remaining non-XML text content
-      if (!textToEmit) {
-        // All content was XML invoke blocks or is being held: skip text block
-        // (tool calls will be emitted at finish)
-      } else if (xmlToolCalls.length > 0) {
-        // Text before/between/after XML blocks — (re)start a text block
-        if (!state.textBlockStarted) {
-          state.textBlockIndex = state.nextBlockIndex++;
-          state.textBlockStarted = true;
-          state.textBlockClosed = false;
-          results.push({
-            type: "content_block_start",
-            index: state.textBlockIndex,
-            content_block: { type: "text", text: "" },
-          });
-        }
-        results.push({
-          type: "content_block_delta",
-          index: state.textBlockIndex,
-          delta: { type: "text_delta", text: textToEmit },
-        });
-      } else {
-        // No XML — emit as regular text (original behaviour)
+      if (textToEmit) {
         if (!state.textBlockStarted) {
           state.textBlockIndex = state.nextBlockIndex++;
           state.textBlockStarted = true;

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -178,8 +178,8 @@ function flushMarkdownBuffer(state, results) {
 
 // Helper: stop text block if started
 function stopTextBlock(state, results) {
-  if (!state.textBlockStarted || state.textBlockClosed) return;
   flushMarkdownBuffer(state, results);
+  if (!state.textBlockStarted || state.textBlockClosed) return;
   state.textBlockClosed = true;
   results.push({
     type: "content_block_stop",

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -10,6 +10,7 @@ import {
 } from "../../utils/reasoningPlaceholder.ts";
 import { REVERSE_MAP, restoreClaudeToolName } from "../../services/claudeCodeToolRemapper.ts";
 import { sanitizeToolId } from "../helpers/schemaCoercion.ts";
+import { splitMarkdownBoundary } from "../helpers/markdownBoundary.ts";
 
 function normalizeToolName(name: string): string {
   return REVERSE_MAP[name] ?? name;
@@ -151,9 +152,34 @@ function stopThinkingBlock(state, results) {
   state.thinkingBlockStarted = false;
 }
 
+// Helper: flush any buffered Markdown boundary text before closing a text block
+function flushMarkdownBuffer(state, results) {
+  const buffered = state._markdownBuffer;
+  if (!buffered) return;
+  state._markdownBuffer = "";
+  if (!state.textBlockStarted) {
+    state.textBlockIndex = state.nextBlockIndex++;
+    state.textBlockStarted = true;
+    state.textBlockClosed = false;
+    results.push({
+      type: "content_block_start",
+      index: state.textBlockIndex,
+      content_block: { type: "text", text: "" },
+    });
+  }
+  if (!state.textBlockClosed) {
+    results.push({
+      type: "content_block_delta",
+      index: state.textBlockIndex,
+      delta: { type: "text_delta", text: buffered },
+    });
+  }
+}
+
 // Helper: stop text block if started
 function stopTextBlock(state, results) {
   if (!state.textBlockStarted || state.textBlockClosed) return;
+  flushMarkdownBuffer(state, results);
   state.textBlockClosed = true;
   results.push({
     type: "content_block_stop",
@@ -218,6 +244,7 @@ export function openaiToClaudeResponse(chunk, state) {
     state.nextBlockIndex = 0;
     state._pendingXmlToolCalls = [];
     state._xmlInvokeBuffer = "";
+    state._markdownBuffer = "";
     results.push({
       type: "message_start",
       message: {
@@ -279,8 +306,16 @@ export function openaiToClaudeResponse(chunk, state) {
     if (strippedContent) {
       stopThinkingBlock(state, results);
 
+      // Rehydrate any Markdown boundary suffix buffered from the previous chunk
+      // before searching for XML tool calls, so the prefix is not lost.
+      const bufferedPrefix = state._markdownBuffer || "";
+      state._markdownBuffer = "";
+
       // Check for XML <invoke> blocks that some models emit instead of JSON tool_calls
-      const { cleaned, toolCalls: xmlToolCalls } = extractXmlInvokeBlocks(strippedContent, state);
+      const { cleaned, toolCalls: xmlToolCalls } = extractXmlInvokeBlocks(
+        bufferedPrefix + strippedContent,
+        state
+      );
 
       // Accumulate extracted tool calls for emission at finish
       if (xmlToolCalls.length > 0) {
@@ -289,9 +324,13 @@ export function openaiToClaudeResponse(chunk, state) {
         state._pendingXmlToolCalls.push(...xmlToolCalls);
       }
 
+      // Defer any trailing incomplete Markdown boundary token to the next chunk.
+      const { emit: textToEmit, hold: textToHold } = splitMarkdownBoundary(cleaned);
+      state._markdownBuffer = textToHold;
+
       // Emit remaining non-XML text content
-      if (!cleaned) {
-        // All content was XML invoke blocks — skip text block entirely
+      if (!textToEmit) {
+        // All content was XML invoke blocks or is being held: skip text block
         // (tool calls will be emitted at finish)
       } else if (xmlToolCalls.length > 0) {
         // Text before/between/after XML blocks — (re)start a text block
@@ -308,7 +347,7 @@ export function openaiToClaudeResponse(chunk, state) {
         results.push({
           type: "content_block_delta",
           index: state.textBlockIndex,
-          delta: { type: "text_delta", text: cleaned },
+          delta: { type: "text_delta", text: textToEmit },
         });
       } else {
         // No XML — emit as regular text (original behaviour)
@@ -325,7 +364,7 @@ export function openaiToClaudeResponse(chunk, state) {
         results.push({
           type: "content_block_delta",
           index: state.textBlockIndex,
-          delta: { type: "text_delta", text: cleaned },
+          delta: { type: "text_delta", text: textToEmit },
         });
       }
     }

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -1,0 +1,263 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { splitMarkdownBoundary } =
+  await import("../../open-sse/translator/helpers/markdownBoundary.ts");
+const { openaiToClaudeResponse } =
+  await import("../../open-sse/translator/response/openai-to-claude.ts");
+const { geminiToClaudeResponse } =
+  await import("../../open-sse/translator/response/gemini-to-claude.ts");
+
+function flatten(items: (unknown[] | null)[]) {
+  return items.flatMap((item) => item || []);
+}
+
+function getTextDeltas(events: unknown[]) {
+  return events
+    .filter(
+      (e) =>
+        (e as Record<string, unknown>)?.type === "content_block_delta" &&
+        ((e as Record<string, unknown>).delta as Record<string, unknown>)?.type === "text_delta"
+    )
+    .map(
+      (e) =>
+        (((e as Record<string, unknown>).delta as Record<string, unknown>).text as string) ?? ""
+    );
+}
+
+// -- splitMarkdownBoundary unit cases ---------------------------------------
+
+test("splitMarkdownBoundary: no boundary emits everything", () => {
+  const { emit, hold } = splitMarkdownBoundary("Hello world");
+  assert.equal(emit, "Hello world");
+  assert.equal(hold, "");
+});
+
+test("splitMarkdownBoundary: defers single trailing backtick in opener context", () => {
+  const { emit, hold } = splitMarkdownBoundary("Use `git");
+  assert.equal(emit, "Use ");
+  assert.equal(hold, "`git");
+});
+
+test("splitMarkdownBoundary: defers two trailing backticks", () => {
+  const { emit, hold } = splitMarkdownBoundary("code ``");
+  assert.equal(emit, "code ");
+  assert.equal(hold, "``");
+});
+
+test("splitMarkdownBoundary: defers fence opener plus partial language", () => {
+  const { emit, hold } = splitMarkdownBoundary("\n```p");
+  assert.equal(emit, "\n");
+  assert.equal(hold, "```p");
+});
+
+test("splitMarkdownBoundary: emits plain triple backticks unchanged", () => {
+  const { emit, hold } = splitMarkdownBoundary("code\n```");
+  assert.equal(emit, "code\n```");
+  assert.equal(hold, "");
+});
+
+test("splitMarkdownBoundary: defers single trailing asterisk in opener context", () => {
+  const { emit, hold } = splitMarkdownBoundary("This is *");
+  assert.equal(emit, "This is ");
+  assert.equal(hold, "*");
+});
+
+test("splitMarkdownBoundary: does not defer closing delimiter after alphanumerics", () => {
+  const { emit, hold } = splitMarkdownBoundary("code`");
+  assert.equal(emit, "code`");
+  assert.equal(hold, "");
+});
+
+test("splitMarkdownBoundary: preserves whitespace boundaries", () => {
+  const { emit, hold } = splitMarkdownBoundary("Hello, ");
+  assert.equal(emit, "Hello, ");
+  assert.equal(hold, "");
+});
+
+// -- OpenAI to Claude streaming boundary cases -------------------------------
+
+function createOpenAIState() {
+  return {
+    toolCalls: new Map(),
+    _pendingXmlToolCalls: [],
+    _xmlInvokeBuffer: "",
+    _markdownBuffer: "",
+  };
+}
+
+test("OpenAI to Claude: code fence language is not split across chunks", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-md1",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "Here is code:\n\n```p" }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-md1",
+      model: "gpt-4.1",
+      choices: [
+        { index: 0, delta: { content: "ython\nprint(1)\n```" }, finish_reason: "stop" },
+      ],
+      usage: { prompt_tokens: 2, completion_tokens: 10, total_tokens: 12 },
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["Here is code:\n\n", "```python\nprint(1)\n```"]);
+});
+
+test("OpenAI to Claude: bold marker is not split across chunks", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-md2",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "This is **" }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-md2",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "bold** text" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 2, completion_tokens: 5, total_tokens: 7 },
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["This is ", "**bold** text"]);
+});
+
+test("OpenAI to Claude: flushes held boundary on finish", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-md3",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "inline `code" }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-md3",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["inline ", "`code"]);
+});
+
+test("OpenAI to Claude: whitespace between chunks is still preserved", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-space",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "Hello, " }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-space",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "world." }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["Hello, ", "world."]);
+  assert.equal(textDeltas.join(""), "Hello, world.");
+});
+
+// -- Gemini to Claude streaming boundary cases -------------------------------
+
+function createGeminiState() {
+  return {
+    _xmlInvokeBuffer: "",
+    _markdownBuffer: "",
+  };
+}
+
+function geminiChunk(text: string, finish = false) {
+  return {
+    responseId: "msg-md-gemini",
+    modelVersion: "gemini-2.0",
+    candidates: [
+      {
+        content: { parts: [{ text }] },
+        finishReason: finish ? "STOP" : undefined,
+      },
+    ],
+  };
+}
+
+test("Gemini to Claude: code fence language is not split across chunks", () => {
+  const state = createGeminiState();
+  const chunk1 = geminiToClaudeResponse(geminiChunk("Here is code:\n\n```p"), state);
+  const chunk2 = geminiToClaudeResponse(geminiChunk("ython\nprint(1)\n```", true), state);
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["Here is code:\n\n", "```python\nprint(1)\n```"]);
+});
+
+test("Gemini to Claude: bold marker is not split across chunks", () => {
+  const state = createGeminiState();
+  const chunk1 = geminiToClaudeResponse(geminiChunk("This is **"), state);
+  const chunk2 = geminiToClaudeResponse(geminiChunk("bold** text", true), state);
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["This is ", "**bold** text"]);
+});
+
+test("Gemini to Claude: flushes held boundary before tool call transition", () => {
+  const state = createGeminiState();
+  const chunk1 = geminiToClaudeResponse(geminiChunk("Run `ls"), state);
+  const chunk2 = geminiToClaudeResponse(
+    {
+      responseId: "msg-md-gemini",
+      modelVersion: "gemini-2.0",
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: "` then" },
+              {
+                functionCall: {
+                  name: "bash",
+                  args: { command: "ls -la" },
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  assert.deepEqual(textDeltas, ["Run ", "`ls` then"]);
+  const toolStart = result.find(
+    (e) =>
+      (e as Record<string, unknown>)?.type === "content_block_start" &&
+      ((e as Record<string, unknown>).content_block as Record<string, unknown>)?.type === "tool_use"
+  );
+  assert.ok(toolStart, "expected tool_use block after flushed text");
+});

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -51,6 +51,12 @@ test("splitMarkdownBoundary: defers fence opener plus partial language", () => {
   assert.equal(hold, "```p");
 });
 
+test("splitMarkdownBoundary: defers fence info containing CommonMark punctuation", () => {
+  const { emit, hold } = splitMarkdownBoundary("\n```text/x-c");
+  assert.equal(emit, "\n");
+  assert.equal(hold, "```text/x-c");
+});
+
 test("splitMarkdownBoundary: emits plain triple backticks unchanged", () => {
   const { emit, hold } = splitMarkdownBoundary("code\n```");
   assert.equal(emit, "code\n```");
@@ -324,6 +330,54 @@ test("OpenAI to Claude: extends a held code span across multiple chunks", () => 
   assert.equal(state._markdownBuffer, "");
 });
 
+test("OpenAI to Claude: emits punctuation-adjacent closer opened in a prior chunk", () => {
+  const state = createOpenAIState();
+  const chunks = ["Use `foo ", "(bar)`", " done"].map((content, index) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-cross-chunk-code",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: index === 2 ? "stop" : null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["Use `foo ", "(bar)`", " done"]);
+});
+
+test("OpenAI to Claude: ignores escaped backticks while tracking cross-chunk code spans", () => {
+  const state = createOpenAIState();
+  const chunks = ["\\` foo `bar", "`"].map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-escaped-code",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["\\` foo ", "`bar`"]);
+});
+
+test("OpenAI to Claude: ignores literal backtick runs inside longer code spans", () => {
+  const state = createOpenAIState();
+  const chunks = ["`` ` `` `foo", "`"].map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-nested-code",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["`` ` `` ", "`foo`"]);
+});
+
 test("OpenAI to Claude: whitespace between chunks is still preserved", () => {
   const state = createOpenAIState();
   const chunk1 = openaiToClaudeResponse(
@@ -387,6 +441,24 @@ test("Gemini to Claude: bold marker is not split across chunks", () => {
   const result = flatten([chunk1, chunk2]);
   const textDeltas = getTextDeltas(result);
   assert.deepEqual(textDeltas, ["This is ", "**bold** text"]);
+});
+
+test("Gemini to Claude: emits punctuation-adjacent closer opened in a prior chunk", () => {
+  const state = createGeminiState();
+  const chunks = ["Use `foo ", "(bar)`", " done"].map((text, index) =>
+    geminiToClaudeResponse(geminiChunk(text, index === 2), state)
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["Use `foo ", "(bar)`", " done"]);
+});
+
+test("Gemini to Claude: joins a closing backtick run split across chunks", () => {
+  const state = createGeminiState();
+  const chunks = ["``a`", "`", " done"].map((text, index) =>
+    geminiToClaudeResponse(geminiChunk(text, index === 2), state)
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["``a", "``", " done"]);
 });
 
 test("Gemini to Claude: flushes held boundary before tool call transition", () => {

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -261,3 +261,34 @@ test("Gemini to Claude: flushes held boundary before tool call transition", () =
   );
   assert.ok(toolStart, "expected tool_use block after flushed text");
 });
+
+test("Gemini to Claude: fully-held chunk emits no empty text_delta (#11606 R1)", () => {
+  const state = createGeminiState();
+  // Chunk 1 ends with a single backtick (opener context) -> fully held.
+  const chunk1 = geminiToClaudeResponse(geminiChunk("Run `", false), state);
+  // Chunk 2 continues with the inline code body + closing backtick.
+  const chunk2 = geminiToClaudeResponse(geminiChunk("ls` done", true), state);
+  const result = flatten([chunk1, chunk2]);
+  const textDeltas = getTextDeltas(result);
+  // No zero-length delta may appear; the boundary flushes joined on chunk 2.
+  assert.ok(
+    textDeltas.every((d) => d.length > 0),
+    `zero-length text_delta emitted: ${JSON.stringify(textDeltas)}`
+  );
+  assert.deepEqual(textDeltas, ["Run ", "`ls` done"]);
+  // The trailing backtick is held; only the real text "Run " is emitted on
+  // chunk 1. In particular NO zero-length text_delta may appear (the R1
+  // finding: a fully-held "cleaned" chunk used to open a text block and fire
+  // an empty delta for nothing).
+  const chunk1TextDeltas = (chunk1 as unknown as Record<string, unknown>[])
+    .filter(
+      (e) =>
+        (e as Record<string, unknown>)?.type === "content_block_delta" &&
+        ((e as Record<string, unknown>).delta as Record<string, unknown>)?.type === "text_delta"
+    )
+    .map(
+      (e) =>
+        ((e as Record<string, unknown>).delta as Record<string, unknown>).text ?? ""
+    );
+  assert.deepEqual(chunk1TextDeltas, ["Run "]);
+});

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -69,6 +69,25 @@ test("splitMarkdownBoundary: does not defer closing delimiter after alphanumeric
   assert.equal(hold, "");
 });
 
+test("splitMarkdownBoundary: does not defer a matched closing backtick after punctuation", () => {
+  const text = "`(foo)`";
+  const { emit, hold } = splitMarkdownBoundary(text);
+  assert.equal(emit, text);
+  assert.equal(hold, "");
+});
+
+test("splitMarkdownBoundary: conservatively defers an unmatched backtick after punctuation", () => {
+  const { emit, hold } = splitMarkdownBoundary("(foo)`");
+  assert.equal(emit, "(foo)");
+  assert.equal(hold, "`");
+});
+
+test("splitMarkdownBoundary: keeps different backtick run lengths distinct", () => {
+  const { emit, hold } = splitMarkdownBoundary("``(foo)`");
+  assert.equal(emit, "``(foo)");
+  assert.equal(hold, "`");
+});
+
 test("splitMarkdownBoundary: preserves whitespace boundaries", () => {
   const { emit, hold } = splitMarkdownBoundary("Hello, ");
   assert.equal(emit, "Hello, ");
@@ -100,9 +119,7 @@ test("OpenAI to Claude: code fence language is not split across chunks", () => {
     {
       id: "chatcmpl-md1",
       model: "gpt-4.1",
-      choices: [
-        { index: 0, delta: { content: "ython\nprint(1)\n```" }, finish_reason: "stop" },
-      ],
+      choices: [{ index: 0, delta: { content: "ython\nprint(1)\n```" }, finish_reason: "stop" }],
       usage: { prompt_tokens: 2, completion_tokens: 10, total_tokens: 12 },
     },
     state
@@ -251,6 +268,62 @@ test("OpenAI to Claude: tool call flushes a fully-held boundary before tool use"
   );
 });
 
+test("OpenAI to Claude: reasoning flushes a fully-held boundary before thinking", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-held-reasoning",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "`" }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-held-reasoning",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { reasoning_content: "Thinking" }, finish_reason: null }],
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+
+  assert.deepEqual(getTextDeltas(result), ["`"]);
+  assert.equal(state._markdownBuffer, "");
+  assert.deepEqual(
+    result.slice(1).map((event) => {
+      const record = event as Record<string, unknown>;
+      const contentBlock = record.content_block as Record<string, unknown> | undefined;
+      const delta = record.delta as Record<string, unknown> | undefined;
+      return [record.type, contentBlock?.type ?? delta?.type ?? null];
+    }),
+    [
+      ["content_block_start", "text"],
+      ["content_block_delta", "text_delta"],
+      ["content_block_stop", null],
+      ["content_block_start", "thinking"],
+      ["content_block_delta", "thinking_delta"],
+    ]
+  );
+});
+
+test("OpenAI to Claude: extends a held code span across multiple chunks", () => {
+  const state = createOpenAIState();
+  const chunks = ["`", "c", "ode` body"].map((content, index) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-multistep",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: index === 2 ? "stop" : null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["`code` body"]);
+  assert.equal(state._markdownBuffer, "");
+});
+
 test("OpenAI to Claude: whitespace between chunks is still preserved", () => {
   const state = createOpenAIState();
   const chunk1 = openaiToClaudeResponse(
@@ -377,9 +450,26 @@ test("Gemini to Claude: fully-held chunk emits no empty text_delta (#11606 R1)",
         (e as Record<string, unknown>)?.type === "content_block_delta" &&
         ((e as Record<string, unknown>).delta as Record<string, unknown>)?.type === "text_delta"
     )
-    .map(
-      (e) =>
-        ((e as Record<string, unknown>).delta as Record<string, unknown>).text ?? ""
-    );
+    .map((e) => ((e as Record<string, unknown>).delta as Record<string, unknown>).text ?? "");
   assert.deepEqual(chunk1TextDeltas, ["Run "]);
+});
+
+test("Gemini to Claude: finish flushes a fully-held boundary before message stop", () => {
+  const state = createGeminiState();
+  const chunk1 = geminiToClaudeResponse(geminiChunk("`"), state);
+  const chunk2 = geminiToClaudeResponse(geminiChunk("", true), state);
+  const result = flatten([chunk1, chunk2]);
+
+  assert.deepEqual(getTextDeltas(result), ["`"]);
+  assert.equal(state._markdownBuffer, "");
+  assert.deepEqual(
+    result.slice(1).map((event) => (event as Record<string, unknown>).type),
+    [
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]
+  );
 });

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -160,6 +160,97 @@ test("OpenAI to Claude: flushes held boundary on finish", () => {
   assert.deepEqual(textDeltas, ["inline ", "`code"]);
 });
 
+test("OpenAI to Claude: finish flushes a fully-held boundary before message stop", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-held-finish",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "`" }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-held-finish",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+
+  assert.deepEqual(getTextDeltas(result), ["`"]);
+  assert.equal(state._markdownBuffer, "");
+  assert.deepEqual(
+    result.slice(1).map((event) => (event as Record<string, unknown>).type),
+    [
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]
+  );
+});
+
+test("OpenAI to Claude: tool call flushes a fully-held boundary before tool use", () => {
+  const state = createOpenAIState();
+  const chunk1 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-held-tool",
+      model: "gpt-4.1",
+      choices: [{ index: 0, delta: { content: "`" }, finish_reason: null }],
+    },
+    state
+  );
+  const chunk2 = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-held-tool",
+      model: "gpt-4.1",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_held_tool",
+                function: { name: "bash", arguments: '{"command":"pwd"}' },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    },
+    state
+  );
+  const result = flatten([chunk1, chunk2]);
+  const contentEvents = result.filter((event) =>
+    String((event as Record<string, unknown>).type).startsWith("content_block_")
+  );
+
+  assert.deepEqual(getTextDeltas(result), ["`"]);
+  assert.equal(state._markdownBuffer, "");
+  assert.deepEqual(
+    contentEvents.map((event) => {
+      const record = event as Record<string, unknown>;
+      const contentBlock = record.content_block as Record<string, unknown> | undefined;
+      const delta = record.delta as Record<string, unknown> | undefined;
+      return [record.type, contentBlock?.type ?? delta?.type ?? null];
+    }),
+    [
+      ["content_block_start", "text"],
+      ["content_block_delta", "text_delta"],
+      ["content_block_stop", null],
+      ["content_block_start", "tool_use"],
+      ["content_block_delta", "input_json_delta"],
+      ["content_block_stop", null],
+    ]
+  );
+});
+
 test("OpenAI to Claude: whitespace between chunks is still preserved", () => {
   const state = createOpenAIState();
   const chunk1 = openaiToClaudeResponse(

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -108,6 +108,8 @@ function createOpenAIState() {
     _pendingXmlToolCalls: [],
     _xmlInvokeBuffer: "",
     _markdownBuffer: "",
+    _markdownCodeSpanRun: 0,
+    _markdownFenceRun: 0,
   };
 }
 
@@ -346,6 +348,42 @@ test("OpenAI to Claude: emits punctuation-adjacent closer opened in a prior chun
   assert.deepEqual(getTextDeltas(flatten(chunks)), ["Use `foo ", "(bar)`", " done"]);
 });
 
+test("OpenAI to Claude: longer fence closer restores inline code parsing", () => {
+  const state = createOpenAIState();
+  const contents = ["```\nfoo\n", "````\n", "`(bar)`", " done"];
+  const chunks = contents.map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-long-fence-close",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), contents);
+  assert.equal(state._markdownFenceRun, 0);
+});
+
+test("OpenAI to Claude: shorter fence run does not close a longer fence", () => {
+  const state = createOpenAIState();
+  const contents = ["````\nfoo\n", "```\n", "`(bar)`", " done"];
+  const chunks = contents.map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-short-fence-close",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), contents);
+  assert.equal(state._markdownFenceRun, 4);
+});
+
 test("OpenAI to Claude: ignores escaped backticks while tracking cross-chunk code spans", () => {
   const state = createOpenAIState();
   const chunks = ["\\` foo `bar", "`"].map((content) =>
@@ -458,6 +496,8 @@ function createGeminiState() {
   return {
     _xmlInvokeBuffer: "",
     _markdownBuffer: "",
+    _markdownCodeSpanRun: 0,
+    _markdownFenceRun: 0,
   };
 }
 
@@ -499,6 +539,24 @@ test("Gemini to Claude: emits punctuation-adjacent closer opened in a prior chun
   );
 
   assert.deepEqual(getTextDeltas(flatten(chunks)), ["Use `foo ", "(bar)`", " done"]);
+});
+
+test("Gemini to Claude: longer fence closer restores inline code parsing", () => {
+  const state = createGeminiState();
+  const contents = ["```\nfoo\n", "````\n", "`(bar)`", " done"];
+  const chunks = contents.map((text) => geminiToClaudeResponse(geminiChunk(text), state));
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), contents);
+  assert.equal(state._markdownFenceRun, 0);
+});
+
+test("Gemini to Claude: shorter fence run does not close a longer fence", () => {
+  const state = createGeminiState();
+  const contents = ["````\nfoo\n", "```\n", "`(bar)`", " done"];
+  const chunks = contents.map((text) => geminiToClaudeResponse(geminiChunk(text), state));
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), contents);
+  assert.equal(state._markdownFenceRun, 4);
 });
 
 test("Gemini to Claude: joins a closing backtick run split across chunks", () => {

--- a/tests/unit/stream-markdown-token-boundary.test.ts
+++ b/tests/unit/stream-markdown-token-boundary.test.ts
@@ -362,6 +362,55 @@ test("OpenAI to Claude: ignores escaped backticks while tracking cross-chunk cod
   assert.deepEqual(getTextDeltas(flatten(chunks)), ["\\` foo ", "`bar`"]);
 });
 
+test("OpenAI to Claude: backslash does not escape a code span closing backtick", () => {
+  const state = createOpenAIState();
+  const chunks = ["`foo\\`", "(bar)`", " done"].map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-code-backslash",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      state
+    )
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["`foo\\`", "(bar)", "` done"]);
+});
+
+test("OpenAI to Claude: escaped opener is equivalent when split after backslash", () => {
+  const splitState = createOpenAIState();
+  const splitChunks = ["\\", "` foo ", "(bar)`"].map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-split-escape",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      splitState
+    )
+  );
+  const joinedState = createOpenAIState();
+  const joinedChunks = ["\\` foo ", "(bar)`"].map((content) =>
+    openaiToClaudeResponse(
+      {
+        id: "chatcmpl-joined-escape",
+        model: "gpt-4.1",
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      },
+      joinedState
+    )
+  );
+
+  assert.equal(
+    getTextDeltas(flatten(splitChunks)).join(""),
+    getTextDeltas(flatten(joinedChunks)).join("")
+  );
+  assert.equal(splitState._markdownBuffer, "`");
+  assert.equal(splitState._markdownBuffer, joinedState._markdownBuffer);
+  assert.equal(splitState._markdownCodeSpanRun || 0, joinedState._markdownCodeSpanRun || 0);
+});
+
 test("OpenAI to Claude: ignores literal backtick runs inside longer code spans", () => {
   const state = createOpenAIState();
   const chunks = ["`` ` `` `foo", "`"].map((content) =>
@@ -459,6 +508,34 @@ test("Gemini to Claude: joins a closing backtick run split across chunks", () =>
   );
 
   assert.deepEqual(getTextDeltas(flatten(chunks)), ["``a", "``", " done"]);
+});
+
+test("Gemini to Claude: backslash does not escape a code span closing backtick", () => {
+  const state = createGeminiState();
+  const chunks = ["`foo\\`", "(bar)`", " done"].map((text) =>
+    geminiToClaudeResponse(geminiChunk(text), state)
+  );
+
+  assert.deepEqual(getTextDeltas(flatten(chunks)), ["`foo\\`", "(bar)", "` done"]);
+});
+
+test("Gemini to Claude: escaped opener is equivalent when split after backslash", () => {
+  const splitState = createGeminiState();
+  const splitChunks = ["\\", "` foo ", "(bar)`"].map((text) =>
+    geminiToClaudeResponse(geminiChunk(text), splitState)
+  );
+  const joinedState = createGeminiState();
+  const joinedChunks = ["\\` foo ", "(bar)`"].map((text) =>
+    geminiToClaudeResponse(geminiChunk(text), joinedState)
+  );
+
+  assert.equal(
+    getTextDeltas(flatten(splitChunks)).join(""),
+    getTextDeltas(flatten(joinedChunks)).join("")
+  );
+  assert.equal(splitState._markdownBuffer, "`");
+  assert.equal(splitState._markdownBuffer, joinedState._markdownBuffer);
+  assert.equal(splitState._markdownCodeSpanRun || 0, joinedState._markdownCodeSpanRun || 0);
 });
 
 test("Gemini to Claude: flushes held boundary before tool call transition", () => {


### PR DESCRIPTION
## Summary
Fixes #11606. Prevents split markdown formatting tokens and code fences from breaking stream rendering across translator chunks by preserving token boundary state and code span/fence context across stream deltas.

## Changes
- Implement `splitMarkdownBoundary` helper in `open-sse/translator/helpers/markdownBoundary.ts`
- Preserve and flush boundary buffers in OpenAI and Gemini stream response translators (`openai-to-claude.ts`, `gemini-to-claude.ts`)
- Track fenced-code block opener length, line boundary, and escape backslash parity across chunks
- Suppress zero-length `text_delta` emissions on fully held chunks
- Add comprehensive test suite in `tests/unit/stream-markdown-token-boundary.test.ts` (38 test cases)

## Verification
- Focused suite: `node --import tsx/esm --test tests/unit/stream-markdown-token-boundary.test.ts` (38/38 PASS)
- Direct translator suites: 74/74 PASS
- `npm run typecheck:core` clean
- Scoped ESLint & ASCII diff scan clean
- 3 clean review cycles (9 passes) PASS

⚠️ base-red inherited: #11449
