### PR TITLE
fix(cli): separate node endpoint from server base URL

### DIFF
--- a/bin/cli/commands/nodes.mjs
+++ b/bin/cli/commands/nodes.mjs
@@ -70,7 +70,7 @@ export function registerNodes(program) {
   nodes
     .command("add")
     .requiredOption("--provider <p>", t("nodes.add.provider"))
-    .requiredOption("--base-url <url>", t("nodes.add.baseUrl"))
+    .requiredOption("--endpoint <url>", t("nodes.add.baseUrl"))
     .option("--name <n>", t("nodes.add.name"))
     .option("--weight <w>", t("nodes.add.weight"), parseInt, 100)
     .option("--region <r>", t("nodes.add.region"))
@@ -83,14 +83,18 @@ export function registerNodes(program) {
     .action(async (opts, cmd) => {
       const body = {
         provider: opts.provider,
-        baseUrl: opts.baseUrl,
+        baseUrl: opts.endpoint,
         name: opts.name,
         weight: opts.weight,
         region: opts.region,
         enabled: true,
         headers: opts.authHeader?.length ? opts.authHeader : undefined,
       };
-      const res = await apiFetch("/api/provider-nodes", { method: "POST", body });
+      const res = await apiFetch("/api/provider-nodes", {
+        ...cmd.optsWithGlobals(),
+        method: "POST",
+        body,
+      });
       if (!res.ok) {
         process.stderr.write(`Error: ${res.status}\n`);
         process.exit(1);
@@ -100,17 +104,22 @@ export function registerNodes(program) {
 
   nodes
     .command("update <nodeId>")
-    .option("--base-url <url>", t("nodes.update.baseUrl"))
+    .option("--endpoint <url>", t("nodes.update.baseUrl"))
     .option("--name <n>", t("nodes.update.name"))
     .option("--weight <w>", t("nodes.update.weight"), parseInt)
     .option("--region <r>", t("nodes.update.region"))
     .option("--enabled <b>", t("nodes.update.enabled"), (v) => v === "true")
     .action(async (id, opts, cmd) => {
       const body = {};
-      for (const k of ["baseUrl", "name", "weight", "region", "enabled"]) {
+      if (opts.endpoint !== undefined) body.baseUrl = opts.endpoint;
+      for (const k of ["name", "weight", "region", "enabled"]) {
         if (opts[k] !== undefined) body[k] = opts[k];
       }
-      const res = await apiFetch(`/api/provider-nodes/${id}`, { method: "PUT", body });
+      const res = await apiFetch(`/api/provider-nodes/${id}`, {
+        ...cmd.optsWithGlobals(),
+        method: "PUT",
+        body,
+      });
       if (!res.ok) {
         process.stderr.write(`Error: ${res.status}\n`);
         process.exit(1);
@@ -136,12 +145,13 @@ export function registerNodes(program) {
 
   nodes
     .command("validate")
-    .requiredOption("--base-url <url>", t("nodes.validate.baseUrl"))
+    .requiredOption("--endpoint <url>", t("nodes.validate.baseUrl"))
     .requiredOption("--provider <p>", t("nodes.validate.provider"))
     .action(async (opts, cmd) => {
       const res = await apiFetch("/api/provider-nodes/validate", {
+        ...cmd.optsWithGlobals(),
         method: "POST",
-        body: { baseUrl: opts.baseUrl, provider: opts.provider },
+        body: { baseUrl: opts.endpoint, provider: opts.provider },
       });
       if (!res.ok) {
         process.stderr.write(`Error: ${res.status}\n`);

--- a/changelog.d/fixes/11860-cli-node-base-url-collision.md
+++ b/changelog.d/fixes/11860-cli-node-base-url-collision.md
@@ -1,0 +1,1 @@
+- **fix(cli):** keep the global OmniRoute server `--base-url` separate from provider-node `--endpoint` values in add, update, and validate commands ([#11860](https://github.com/diegosouzapw/OmniRoute/pull/11860)) — thanks @pacocartones

--- a/tests/unit/cli-program.test.ts
+++ b/tests/unit/cli-program.test.ts
@@ -124,6 +124,75 @@ test("program registers 'update' command", () => {
   assert.ok(cmd, "update command exists");
 });
 
+test("nodes endpoint commands reserve --base-url for the global server target", () => {
+  const program = createProgram();
+  const nodes = program.commands.find((c) => c.name() === "nodes");
+  assert.ok(nodes, "nodes command exists");
+
+  for (const commandName of ["add", "update", "validate"]) {
+    const command = nodes.commands.find((c) => c.name() === commandName);
+    assert.ok(command, `nodes ${commandName} command exists`);
+    assert.ok(
+      command.options.some((option) => option.long === "--endpoint"),
+      `nodes ${commandName} exposes --endpoint for the provider-node URL`
+    );
+    assert.equal(
+      command.options.some((option) => option.long === "--base-url"),
+      false,
+      `nodes ${commandName} does not shadow the global --base-url option`
+    );
+    command.parseOptions([
+      ...(commandName === "update" ? ["node-1"] : []),
+      ...(commandName === "add" || commandName === "validate" ? ["--provider", "openai"] : []),
+      "--endpoint",
+      "https://api.openai.com/v1",
+    ]);
+    assert.equal(command.opts().endpoint, "https://api.openai.com/v1");
+  }
+});
+
+test("nodes endpoint commands keep the global server target separate from payload baseUrl", async () => {
+  const cases = [
+    { command: "add", args: ["--provider", "openai"] },
+    { command: "update", args: ["node-1"] },
+    { command: "validate", args: ["--provider", "openai"] },
+  ];
+  const originalFetch = globalThis.fetch;
+
+  try {
+    for (const { command, args } of cases) {
+      let capturedUrl = "";
+      let capturedBody: Record<string, unknown> = {};
+      globalThis.fetch = (async (url, init) => {
+        capturedUrl = String(url);
+        capturedBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: "node-1" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "omniroute",
+        "--base-url",
+        "https://server.example",
+        "nodes",
+        command,
+        ...args,
+        "--endpoint",
+        "https://provider.example/v1",
+      ]);
+
+      assert.ok(capturedUrl.startsWith("https://server.example/api/provider-nodes"));
+      assert.equal(capturedBody.baseUrl, "https://provider.example/v1");
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 // ─── exitOverride / --help via Commander ─────────────────────────────────────
 
 test("--help throws CommanderError with exit code 0", async () => {

--- a/tests/unit/cli-program.test.ts
+++ b/tests/unit/cli-program.test.ts
@@ -153,18 +153,36 @@ test("nodes endpoint commands reserve --base-url for the global server target", 
 
 test("nodes endpoint commands keep the global server target separate from payload baseUrl", async () => {
   const cases = [
-    { command: "add", args: ["--provider", "openai"] },
-    { command: "update", args: ["node-1"] },
-    { command: "validate", args: ["--provider", "openai"] },
+    {
+      command: "add",
+      args: ["--provider", "openai"],
+      expectedUrl: "https://server.example/api/provider-nodes",
+      expectedMethod: "POST",
+    },
+    {
+      command: "update",
+      args: ["node-1"],
+      expectedUrl: "https://server.example/api/provider-nodes/node-1",
+      expectedMethod: "PUT",
+    },
+    {
+      command: "validate",
+      args: ["--provider", "openai"],
+      expectedUrl: "https://server.example/api/provider-nodes/validate",
+      expectedMethod: "POST",
+    },
   ];
   const originalFetch = globalThis.fetch;
+  const originalBaseUrl = process.env.OMNIROUTE_BASE_URL;
 
   try {
-    for (const { command, args } of cases) {
+    for (const { command, args, expectedUrl, expectedMethod } of cases) {
       let capturedUrl = "";
+      let capturedMethod = "";
       let capturedBody: Record<string, unknown> = {};
       globalThis.fetch = (async (url, init) => {
         capturedUrl = String(url);
+        capturedMethod = String(init?.method);
         capturedBody = JSON.parse(String(init?.body));
         return new Response(JSON.stringify({ id: "node-1" }), {
           status: 200,
@@ -185,11 +203,41 @@ test("nodes endpoint commands keep the global server target separate from payloa
         "https://provider.example/v1",
       ]);
 
-      assert.ok(capturedUrl.startsWith("https://server.example/api/provider-nodes"));
+      assert.equal(capturedUrl, expectedUrl);
+      assert.equal(capturedMethod, expectedMethod);
       assert.equal(capturedBody.baseUrl, "https://provider.example/v1");
     }
+
+    process.env.OMNIROUTE_BASE_URL = "https://env-server.example";
+    let envCapturedUrl = "";
+    let envCapturedBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (url, init) => {
+      envCapturedUrl = String(url);
+      envCapturedBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ id: "node-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const envProgram = createProgram();
+    await envProgram.parseAsync([
+      "node",
+      "omniroute",
+      "nodes",
+      "validate",
+      "--provider",
+      "openai",
+      "--endpoint",
+      "https://provider.example/v1",
+    ]);
+
+    assert.equal(envCapturedUrl, "https://env-server.example/api/provider-nodes/validate");
+    assert.equal(envCapturedBody.baseUrl, "https://provider.example/v1");
   } finally {
     globalThis.fetch = originalFetch;
+    if (originalBaseUrl === undefined) delete process.env.OMNIROUTE_BASE_URL;
+    else process.env.OMNIROUTE_BASE_URL = originalBaseUrl;
   }
 });
 


### PR DESCRIPTION
## Summary

- rename the provider-node URL flag to `--endpoint` for `nodes add`, `nodes update`, and `nodes validate`
- preserve global `--base-url` as the OmniRoute server target
- keep request payloads using the API field `baseUrl`
- add Commander-level regression coverage for destination and payload separation

Fixes #11818.

## Tests

- `node --import tsx/esm --test tests/unit/cli-program.test.ts tests/unit/cli-nodes-commands.test.ts`
- `npm run lint`
- `npm run typecheck:core`
- `npx prettier --check bin/cli/commands/nodes.mjs tests/unit/cli-program.test.ts`
- `git diff --check`

Draft only to reserve the required changelog fragment number; the numbered fragment and exact-head revalidation follow immediately.