### PR TITLE
fix(build): drop Next trace manifests from the npm tarball (413 on publish)

### DIFF
--- a/changelog.d/fixes/11856-npm-payload-nft-manifests.md
+++ b/changelog.d/fixes/11856-npm-payload-nft-manifests.md
@@ -1,0 +1,4 @@
+- Excluded Next.js Node File Trace manifests (`*.nft.json`) from the published npm
+  tarball. They are build-time metadata and are never read while serving, but had
+  grown to 668.7 MB — 61% of the package — which pushed the upload past the
+  registry limit and made `npm publish` fail with `413 Payload Too Large`.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "!**/*.test.js",
     "!**/*.test.mjs",
     "!**/*.spec.ts",
-    "!**/*.spec.tsx"
+    "!**/*.spec.tsx",
+    "!**/*.nft.json"
   ],
   "workspaces": [
     "open-sse",

--- a/tests/unit/npm-payload-nft-manifests-excluded.test.ts
+++ b/tests/unit/npm-payload-nft-manifests-excluded.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import type { Dirent } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * v3.8.50 was refused by the registry with `413 Payload Too Large` on
+ * `POST /-/stage/package/omniroute`: the tarball had reached 288.7 MB packed
+ * (1.1 GB unpacked), against 174.5 MB for the 3.8.49 that published fine.
+ *
+ * 668.7 MB of that — 61% of the whole package — was 842 `*.nft.json` files.
+ * Those are Next.js Node File Trace manifests: build-time metadata used to
+ * COMPUTE the standalone bundle, never read while serving. They had doubled
+ * since 3.8.49 (325.0 MB across 748 files), which is what tipped the payload
+ * over the limit.
+ *
+ * The guard is the `files[]` negation, so a future entry that re-widens the
+ * glob (or a rewrite of the array) cannot silently put them back.
+ */
+const pkg = JSON.parse(readFileSync(join(import.meta.dirname, "../../package.json"), "utf8")) as {
+  files?: string[];
+};
+
+test("package.json files[] excludes Next's .nft.json trace manifests", () => {
+  const files = pkg.files ?? [];
+  assert.ok(files.length > 0, "package.json must declare files[]");
+  assert.ok(
+    files.includes("!**/*.nft.json"),
+    "files[] must negate **/*.nft.json — they are build metadata and were 61% of the 3.8.50 payload"
+  );
+});
+
+test("the negation sits after the positive dist/ entry it has to override", () => {
+  // npm applies files[] in order: a negation listed BEFORE the directory that
+  // pulls the files in is a no-op. Positive anchor, so this test cannot pass
+  // just because both strings happen to be present somewhere.
+  const files = pkg.files ?? [];
+  const dist = files.indexOf("dist/");
+  const negation = files.indexOf("!**/*.nft.json");
+  assert.notEqual(dist, -1, "dist/ must still be published");
+  assert.ok(negation > dist, "the .nft.json negation must come after dist/");
+});
+
+test("no source module reads a .nft.json at runtime", () => {
+  // If this ever stops holding, the exclusion above becomes a runtime break
+  // rather than a size win — which is exactly the assumption worth pinning.
+  const roots = ["src", "open-sse", "bin"];
+  const hits: string[] = [];
+  for (const root of roots) {
+    const dir = join(import.meta.dirname, "../..", root);
+    const stack = [dir];
+    while (stack.length > 0) {
+      const current = stack.pop() as string;
+      let entries: Dirent[];
+      try {
+        entries = readdirSync(current, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const full = join(current, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "node_modules") stack.push(full);
+        } else if (/\.(ts|tsx|mjs|js)$/.test(entry.name)) {
+          if (readFileSync(full, "utf8").includes(".nft.json")) hits.push(full);
+        }
+      }
+    }
+  }
+  assert.deepEqual(hits, [], `nothing may depend on .nft.json at runtime: ${hits.join(", ")}`);
+});


### PR DESCRIPTION
## Problema

O staged publish da v3.8.50 foi recusado pelo registry:

```
npm error code E413
npm error 413 Payload Too Large - POST https://registry.npmjs.org/-/stage/package/omniroute
```

O CI fez tudo certo — o pacote foi construído, assinado e teve a proveniência registrada no Sigstore. O que falhou foi o upload, por tamanho.

## Causa

| | 3.8.49 (publicou) | 3.8.50 (recusado) |
| --- | --- | --- |
| tarball empacotado | 174,5 MB | **288,7 MB** |
| expandido | 792,3 MB | **1,1 GB** |
| arquivos `.nft.json` | 748 → 325,0 MB | 842 → **668,7 MB** |

Os `*.nft.json` sozinhos eram **61% do pacote**, e tinham dobrado de peso desde a .49 com apenas 94 arquivos a mais.

São manifestos do Node File Trace do Next: metadados de build usados para calcular o bundle standalone, nunca lidos ao servir.

## Conserto

Uma entrada de negação em `files[]`, seguindo o padrão que o array já usa para `node_modules` e fontes de teste.

## Validação

- **TDD**: os dois primeiros testes falham sem a mudança e passam com ela (3/3 verdes).
- **Semântica do glob provada em pacote isolado**: `page.js.nft.json` é excluído, `page.js` e `other.json` permanecem — não pega demais.
- **Terceiro teste** varre `src/`, `open-sse/` e `bin/` e falha se algum módulo passar a depender de `.nft.json`, transformando a exclusão em quebra de runtime.

## Achado separado, não tratado aqui

O JavaScript compilado sob `dist/.build/next` também cresceu **69%** entre a .49 e a .50 (231,9 MB → 391,9 MB, +3.695 arquivos). Não foi o que quebrou a publicação, e misturar as duas coisas atrapalharia a revisão. Vai como issue própria.

Refs #11439

⚠️ base-red inherited: #11866 (`Unit Tests (1/8)` — allowlist da Alibaba expirou em 27/08, vermelho em `main` antes desta branch existir)
