### PR TITLE
fix(tests): await async getExecutor() in gemini-web-image-retirement test

### DIFF
--- a/changelog.d/fixes/11708-gemini-web-retirement-test-async-getexecutor.md
+++ b/changelog.d/fixes/11708-gemini-web-retirement-test-async-getexecutor.md
@@ -1,0 +1,1 @@
+- **fix(tests):** the new Gemini Web Images retirement test (#11708) called the now-async `getExecutor()` synchronously, throwing `TypeError: getExecutor(...).getProvider is not a function` instead of asserting Gemini Web chat stays available. Awaited to match the R0.3 executor-registry refactor (#11220).

--- a/tests/unit/gemini-web-image-retirement.test.ts
+++ b/tests/unit/gemini-web-image-retirement.test.ts
@@ -111,9 +111,9 @@ test("Gemini Web image-only parser and handler artifacts are retired", () => {
   );
 });
 
-test("Gemini Web chat and legitimate Gemini image providers remain available", () => {
+test("Gemini Web chat and legitimate Gemini image providers remain available", async () => {
   assert.equal(hasSpecializedExecutor("gemini-web"), true);
-  assert.equal(getExecutor("gemini-web").getProvider(), "gemini-web");
+  assert.equal((await getExecutor("gemini-web")).getProvider(), "gemini-web");
   assert.equal(REGISTRY["gemini-web"]?.executor, "gemini-web");
   assert.deepEqual(
     REGISTRY["gemini-web"]?.models.map(({ id }) => id),


### PR DESCRIPTION
## Summary

- #11708 (Gemini Web Images retirement) added a test that calls `getExecutor("gemini-web").getProvider()` synchronously. `getExecutor()` became async with the R0.3 executor-registry refactor (#11220), so this threw `TypeError: getExecutor(...).getProvider is not a function` instead of asserting the intended contract.
- Found during the /merge-batch combined-worktree validation for the v3.8.51 provenance sweep, but landed on `release/v3.8.51` before the fix could be folded into #11708's own diff (the merge outran the fix). This is the immediate follow-up.

## Test plan

- `node --import tsx/esm --test tests/unit/gemini-web-image-retirement.test.ts` — 4/4 passing.