### PR TITLE
fix(sse): stop Vision Bridge reroute for hyperspace claude-4.8-opus

### DIFF
--- a/open-sse/config/providers/registry/openai/index.ts
+++ b/open-sse/config/providers/registry/openai/index.ts
@@ -15,7 +15,13 @@ export const openaiProvider: RegistryEntry = {
     // #11489: per OpenAI's model reference `gpt-5.6` is an ALIAS of `gpt-5.6-sol`,
     // not a distinct model — quality scores point forward, which no suffix
     // stripper can express. Siblings `-terra`/`-luna` are their own models.
-    { id: "gpt-5.6", name: "GPT-5.6", scoresAs: "gpt-5.6-sol", ...GPT_5_6_API_CAPABILITIES },
+    {
+      id: "gpt-5.6",
+      name: "GPT-5.6",
+      scoresAs: "gpt-5.6-sol",
+      liveCatalogIds: ["gpt-5.6-sol"],
+      ...GPT_5_6_API_CAPABILITIES,
+    },
     { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", ...GPT_5_6_API_CAPABILITIES },
     { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", ...GPT_5_6_API_CAPABILITIES },
     { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", ...GPT_5_6_API_CAPABILITIES },

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -408,7 +408,12 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     supportsTools: true,
     supportsVision: true,
     adaptiveThinkingOnly: true,
-    aliases: BEDROCK_CLAUDE_ALIASES("claude-opus-4-8", "claude-opus-4.8", "claude-opus-4.8-fast"),
+    aliases: BEDROCK_CLAUDE_ALIASES(
+      "claude-opus-4-8",
+      "claude-opus-4.8",
+      "claude-opus-4.8-fast",
+      "claude-4.8-opus"
+    ),
   },
 
   // ── Claude Sonnet 4.5 ───────────────────────────────────────────

--- a/tests/unit/live-model-catalog-reconciliation-8926.test.ts
+++ b/tests/unit/live-model-catalog-reconciliation-8926.test.ts
@@ -167,6 +167,15 @@ test("#8926: providers without an authoritative live catalog retain static fallb
   assert.equal(resolved.model, "gpt-4o-mini");
 });
 
+test("OpenAI gpt-5.6 alias accepts the canonical live catalog model", async () => {
+  await seedProviderCatalog("openai", "openai-live-gpt-5-6", ["gpt-5.6-sol"]);
+
+  const resolved = await getModelInfo("openai/gpt-5.6");
+
+  assert.equal(resolved.provider, "openai");
+  assert.equal(resolved.model, "gpt-5.6");
+});
+
 test("#8926: registered effort variant is rejected when its live base is absent", async () => {
   await seedProviderCatalog("cursor", "cursor-live-without-base-8926", ["cursor-live-only-8926"]);
 

--- a/tests/unit/model-capabilities-path-shaped-vision-8032.test.ts
+++ b/tests/unit/model-capabilities-path-shaped-vision-8032.test.ts
@@ -79,13 +79,51 @@ test("#8032 leaf fallback: cline-pass/kimi-k3 resolves MODEL_SPECS kimi-k3 visio
   assert.equal(caps.supportsVision, true);
 });
 
+test("Hyperspace Claude 4.8 Opus alias resolves native vision", () => {
+  const caps = modelCapabilities.getResolvedModelCapabilities("hyperspace/claude-4.8-opus[1m]");
+  assert.equal(caps.supportsVision, true);
+});
+
+test("Vision Bridge keeps Hyperspace Claude 4.8 Opus for image requests", async () => {
+  const model = "hyperspace/claude-4.8-opus[1m]";
+  const { VisionBridgeGuardrail } = await import("../../src/lib/guardrails/visionBridge.ts");
+  let visionCallCount = 0;
+  const guardrail = new VisionBridgeGuardrail({
+    deps: {
+      getSettings: async () => ({ visionBridgeEnabled: true }),
+      callVisionModel: async () => {
+        visionCallCount++;
+        return "should not run";
+      },
+    },
+  });
+
+  const result = await guardrail.preCall(
+    {
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            { type: "image_url", image_url: { url: "https://example.com/photo.png" } },
+          ],
+        },
+      ],
+    },
+    { model, log: console }
+  );
+
+  assert.equal(result.block, false);
+  assert.equal(visionCallCount, 0);
+  assert.equal(result.modifiedPayload, undefined);
+});
+
 test("#8032 leaf fallback is vision-only: aihorde/deepseek/deepseek-v4-flash keeps tools=false", () => {
   // Regression guard from PR review (#8495 / #8212): shared getStaticSpec leaf
   // lookup previously promoted this live-discovered AI Horde id to the real
   // DeepSeek V4 Flash supportsTools:true spec. Leaf lookup must stay vision-only.
-  const caps = modelCapabilities.getResolvedModelCapabilities(
-    "aihorde/deepseek/deepseek-v4-flash"
-  );
+  const caps = modelCapabilities.getResolvedModelCapabilities("aihorde/deepseek/deepseek-v4-flash");
   assert.equal(caps.toolCalling, false);
   assert.equal(caps.supportsTools, false);
   assert.equal(


### PR DESCRIPTION
## Summary

- Add `claude-4.8-opus` to the Claude Opus 4.8 `MODEL_SPECS` aliases so path-shaped ids like `hyperspace/claude-4.8-opus[1m]` resolve `supportsVision=true`.
- Map OpenAI registry alias `gpt-5.6` to live catalog slug `gpt-5.6-sol` via `liveCatalogIds`, preventing false live-catalog rejection when Vision Bridge or clients request the alias.

## Problem

Image requests configured as `hyperspace/claude-4.8-opus[1m]` were misclassified as text-only because the reversed Hyperspace model id did not match existing Opus 4.8 aliases. Vision Bridge then whole-request rerouted to a credentialed vision model (often `openai/gpt-5.6`), even though the user never selected GPT.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/model-capabilities-path-shaped-vision-8032.test.ts`
- [x] `node --import tsx/esm --test tests/unit/live-model-catalog-reconciliation-8926.test.ts`
- [x] `npm run typecheck:core`
- [x] ESLint on changed files