### PR TITLE
fix(providers): pass xAI reasoning_effort xhigh through to grok-4.6+

### DIFF
--- a/changelog.d/fixes/11879-xai-xhigh-reasoning-effort.md
+++ b/changelog.d/fixes/11879-xai-xhigh-reasoning-effort.md
@@ -1,0 +1,1 @@
+- **fix(providers):** xAI `reasoning_effort: "xhigh"` now reaches grok-4.6+ instead of being silently clamped to `"high"` ([#11879](https://github.com/diegosouzapw/OmniRoute/pull/11879)) — thanks @NoxzRCW

--- a/src/lib/providers/xai/thinking.ts
+++ b/src/lib/providers/xai/thinking.ts
@@ -12,14 +12,16 @@
  *   - honor explicit caller intent verbatim
  */
 
-const VALID_EFFORTS = new Set(["minimal", "low", "medium", "high"]);
+const VALID_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh"]);
 
-export type ReasoningEffort = "minimal" | "low" | "medium" | "high";
+export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
 
 export function normalizeXaiReasoningEffort(effort: unknown): ReasoningEffort | undefined {
   if (typeof effort !== "string") return undefined;
   const normalized = effort.toLowerCase();
-  if (normalized === "max" || normalized === "xhigh") return "high";
+  // "max" is not an xAI tier; "xhigh" is real on grok-4.6+ and xAI itself
+  // degrades it to "high" on older models, so passing it through is always safe.
+  if (normalized === "max") return "high";
   return VALID_EFFORTS.has(normalized) ? (normalized as ReasoningEffort) : undefined;
 }
 

--- a/tests/unit/xai-translators.test.ts
+++ b/tests/unit/xai-translators.test.ts
@@ -60,19 +60,27 @@ test("applyThinking: honors xAI-native reasoning.effort verbatim", () => {
   assert.equal((out as Record<string, unknown>).foo, 1);
 });
 
-test("normalizeXaiReasoningEffort: downgrades max/xhigh to xAI-supported high", () => {
+test("normalizeXaiReasoningEffort: downgrades max, passes xhigh through (#11816)", () => {
+  // "max" is not an xAI tier -> still folded onto "high".
   assert.equal(normalizeXaiReasoningEffort("max"), "high");
-  assert.equal(normalizeXaiReasoningEffort("xhigh"), "high");
+  // "xhigh" is a real xAI tier on grok-4.6+; xAI itself degrades it to "high"
+  // on older models, so forwarding it verbatim is always safe.
+  assert.equal(normalizeXaiReasoningEffort("xhigh"), "xhigh");
+  assert.equal(normalizeXaiReasoningEffort("XHIGH"), "xhigh");
   assert.equal(normalizeXaiReasoningEffort("HIGH"), "high");
   assert.equal(normalizeXaiReasoningEffort("ultra"), undefined);
 });
 
-test("applyThinking: normalizes xAI-native max/xhigh to high", () => {
+test("applyThinking: folds max to high, keeps xhigh intact (#11816)", () => {
   const maxOut = applyThinking({ reasoning: { effort: "max", summary: "auto" } });
   assert.deepStrictEqual(maxOut.reasoning, { effort: "high", summary: "auto" });
 
   const xhighOut = applyThinking({ reasoning: { effort: "xhigh" } });
-  assert.deepStrictEqual(xhighOut.reasoning, { effort: "high" });
+  assert.deepStrictEqual(xhighOut.reasoning, { effort: "xhigh" });
+
+  const chatOut = applyThinking({ reasoning_effort: "xhigh" });
+  assert.deepStrictEqual(chatOut.reasoning, { effort: "xhigh" });
+  assert.equal(chatOut.reasoning_effort, undefined);
 });
 
 test("applyThinking: rewrites OpenAI Chat reasoning_effort into reasoning.effort", () => {


### PR DESCRIPTION
## Summary

`reasoning_effort: "xhigh"` never reached xAI. `normalizeXaiReasoningEffort()` folded it onto `"high"` before the request left the router, so anyone who picked `xhigh` on grok-4.6 was quietly getting `high` instead, with no warning anywhere.

Per the [xAI reasoning docs](https://docs.x.ai/developers/model-capabilities/text/reasoning), `xhigh` is a real tier on grok-4.6 and later, and xAI degrades it to `high` itself on models that do not support it. Forwarding the value verbatim is therefore safe on every model, including older ones.

`"max"` is not an xAI tier and still maps to `high`.

I measured this against grok-4.6 with the patch applied, same prompt three times, reading `reasoning_tokens` off the response usage:

| effort | reasoning_tokens |
| --- | ---: |
| low | 590 |
| high | 830 |
| xhigh | 1052 |

Before the patch, `xhigh` and `high` were indistinguishable.

## Related Issues

- Closes #11816

## Validation

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

```
node --import tsx/esm --test tests/unit/xai-translators.test.ts tests/unit/executor-xai.test.ts tests/unit/usage-xai-split.test.ts
# tests 59 / pass 59 / fail 0

npm run typecheck:core        # 0 errors
npm run lint                  # clean
```

## Tests Added Or Updated

- `tests/unit/xai-translators.test.ts`

Two existing tests asserted the old behaviour and had to be updated, otherwise this fix reads as a regression in CI:

- `normalizeXaiReasoningEffort: downgrades max/xhigh to xAI-supported high` now expects `xhigh` to pass through, and also covers the uppercase `XHIGH` input.
- `applyThinking: normalizes xAI-native max/xhigh to high` now asserts `max` still folds to `high` while `xhigh` survives, and adds the OpenAI Chat `reasoning_effort` entry point.

## Coverage Notes

`src/lib/providers/xai/thinking.ts` is covered by `tests/unit/xai-translators.test.ts`, which exercises both the normalizer directly and `applyThinking()` across all four inbound shapes.

## Reviewer Notes

`ReasoningEffort` widens from four members to five. The only consumer is `src/lib/providers/xai/translators/openai-chat.ts`, which passes the value straight through, so nothing switches on the union. `typecheck:core` is clean.

The behaviour change is narrow: only requests that explicitly pass `xhigh` to an xAI upstream are affected.
