### PR TITLE
fix(dashboard): guard provider icon lookups against prototype collisions

### DIFF
--- a/changelog.d/fixes/11880-provider-icon-prototype-collision.md
+++ b/changelog.d/fixes/11880-provider-icon-prototype-collision.md
@@ -1,0 +1,1 @@
+- **fix(dashboard):** the providers page no longer crashes into the error boundary when a provider id collides with an `Object.prototype` member (`constructor`, `__proto__`); icon lookups are own-property guarded ([#11880](https://github.com/diegosouzapw/OmniRoute/pull/11880)) — thanks @NoxzRCW

--- a/src/shared/components/lobeProviderIcons.ts
+++ b/src/shared/components/lobeProviderIcons.ts
@@ -484,9 +484,17 @@ export function getLobeProviderIcon(
   providerId: string,
   type: "mono" | "color" = "color"
 ): LobeIconComponent | null {
-  const iconKey = LOBE_PROVIDER_ALIASES[providerId.toLowerCase()];
-  if (!iconKey) return null;
+  if (typeof providerId !== "string") return null;
+  const aliasKey = providerId.toLowerCase();
+  // Own-property guards: a providerId such as "constructor" or "__proto__"
+  // otherwise resolves through Object.prototype, yielding a truthy iconKey
+  // whose LOBE_ICON_COMPONENTS lookup is undefined -> `entry.color` throws and
+  // takes down the whole providers dashboard via the error boundary.
+  if (!Object.hasOwn(LOBE_PROVIDER_ALIASES, aliasKey)) return null;
+  const iconKey = LOBE_PROVIDER_ALIASES[aliasKey];
+  if (!iconKey || !Object.hasOwn(LOBE_ICON_COMPONENTS, iconKey)) return null;
 
   const entry = LOBE_ICON_COMPONENTS[iconKey];
+  if (!entry) return null;
   return type === "color" && entry.color ? entry.color : entry.mono;
 }

--- a/tests/unit/lobe-provider-icons-prototype-collision-11853.test.ts
+++ b/tests/unit/lobe-provider-icons-prototype-collision-11853.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression for #11853 — the providers dashboard crashed with
+ * "Cannot read properties of undefined (reading 'color')" and rendered a
+ * misleading "Failed to load providers — check your connection" card.
+ *
+ * `getLobeProviderIcon()` indexed two plain object literals without own-property
+ * guards. A provider id whose lowercased form is an Object.prototype member
+ * resolves through the prototype chain: `LOBE_PROVIDER_ALIASES["constructor"]`
+ * returns the Object constructor (truthy, so the `if (!iconKey) return null`
+ * guard passes), then `LOBE_ICON_COMPONENTS[<that function>]` is undefined and
+ * `entry.color` throws — taking the whole page down through the App Router
+ * error boundary, since ProviderIcon calls this for every provider card.
+ *
+ * Only `constructor` and `__proto__` are reachable: every other Object.prototype
+ * member is camelCase and no longer collides after `.toLowerCase()`.
+ *
+ * Runner: node --import tsx/esm --test tests/unit/lobe-provider-icons-prototype-collision-11853.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { getLobeProviderIcon } = await import("../../src/shared/components/lobeProviderIcons.ts");
+
+test("#11853 — prototype-colliding provider ids return null instead of throwing", () => {
+  for (const id of ["constructor", "__proto__", "CONSTRUCTOR", "__PROTO__"]) {
+    for (const type of ["color", "mono"] as const) {
+      assert.doesNotThrow(() => getLobeProviderIcon(id, type), `${id} (${type}) must not throw`);
+      assert.equal(getLobeProviderIcon(id, type), null, `${id} (${type}) must resolve to null`);
+    }
+  }
+});
+
+test("#11853 — camelCase prototype members were already safe and stay safe", () => {
+  for (const id of ["valueOf", "toString", "hasOwnProperty", "isPrototypeOf"]) {
+    assert.equal(getLobeProviderIcon(id), null);
+  }
+});
+
+test("#11853 — no regression: known providers still resolve, unknown ones still null", () => {
+  assert.notEqual(getLobeProviderIcon("openai"), null);
+  assert.notEqual(getLobeProviderIcon("anthropic"), null);
+  assert.equal(getLobeProviderIcon("definitely-not-a-provider"), null);
+});
+
+test("#11853 — a non-string provider id does not throw", () => {
+  assert.doesNotThrow(() => getLobeProviderIcon(undefined as unknown as string));
+  assert.equal(getLobeProviderIcon(undefined as unknown as string), null);
+});


### PR DESCRIPTION
## Summary

The providers dashboard intermittently rendered the red "Failed to load providers, check your connection and try again" card while the server was healthy and its logs were clean. The card comes from the App Router error boundary at `src/app/(dashboard)/dashboard/providers/error.tsx`, which catches any uncaught client-side throw under `/dashboard/providers/**`, so the copy blaming the network is misleading. No request has to fail to produce it.

The throw is in `getLobeProviderIcon()`:

```ts
const iconKey = LOBE_PROVIDER_ALIASES[providerId.toLowerCase()];
if (!iconKey) return null;
const entry = LOBE_ICON_COMPONENTS[iconKey];   // undefined
return type === "color" && entry.color ? entry.color : entry.mono;   // throws
```

Both maps are plain object literals indexed with no own-property check. A provider id whose lowercased form is an `Object.prototype` member resolves through the prototype chain, so `LOBE_PROVIDER_ALIASES["constructor"]` returns the `Object` constructor. That is truthy, the falsy guard lets it through, and the follow-up lookup is `undefined`. Reading `.color` off it throws `Cannot read properties of undefined (reading 'color')`, which matches the minified console trace exactly.

`ProviderIcon` calls this for every provider card, so a single such id takes the whole page down.

Worth noting for anyone reading the original report: only `constructor` and `__proto__` can actually reach this. Every other `Object.prototype` member is camelCase and stops colliding once `.toLowerCase()` has run, so `valueOf`, `hasOwnProperty` and friends already returned `null` safely. I checked this at runtime rather than by inspection.

The fix adds `Object.hasOwn()` guards on both lookups plus a defensive `entry` check, and returns `null` for a non-string id instead of throwing on `.toLowerCase()`.

## Related Issues

- Closes #11853

## Validation

- [x] Change type: UI
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

```
node --import tsx/esm --test tests/unit/lobe-provider-icons-prototype-collision-11853.test.ts \
  tests/unit/provider-icon-devin-desktop.test.ts tests/unit/qwen-web-retirement.test.ts
# tests 11 / pass 11 / fail 0

npx vitest run --config vitest.config.ts tests/unit/ui/lobe-provider-icons-anysearch.test.tsx \
  tests/unit/ui/lobe-provider-icons-stepfun.test.tsx
# 2 files / 3 tests passed

npm run check:dashboard-typecheck   # OK, 219 pre-existing errors, all within frozen baseline
npm run lint                        # clean
```

I also swept all 171 real ids in `LOBE_PROVIDER_ALIASES` in both `color` and `mono` modes, before and after the change, and got zero behavioural differences. That sweep is not in the committed test since it would just restate the alias table, but the committed test does cover the known-provider and unknown-provider paths.

## Tests Added Or Updated

- `tests/unit/lobe-provider-icons-prototype-collision-11853.test.ts` (new)

## Coverage Notes

The new file covers `getLobeProviderIcon()` end to end: the two colliding ids in both icon modes, the camelCase prototype members that were already safe, a known provider, an unknown provider, and a non-string id.

## Reviewer Notes

Same unguarded-lookup pattern exists in `PROVIDER_ICON_ALIASES`, `LOCAL_SVG_ALIASES` and `THEMED_SVGS`, which `ProviderIcon` also consults. I kept this PR to the one map that actually throws today so the change stays reviewable. Happy to follow up on the other three if you want them hardened in the same pass.

There is a second, unrelated crash on the same page that I did not touch here: opening `/dashboard/providers/<id>` for an id missing from the dashboard catalog makes `resolveDashboardProviderInfo` return `null`, which then gets spread into `providerInfo`, and a downstream `providerId.toLowerCase()` throws. Same error card, different signature (`reading 'toLowerCase'`). Say the word and I will open a separate issue for it.
