### PR TITLE
fix(skills): expand shorthand property types in injected tool schemas

### DIFF
--- a/changelog.d/fixes/11881-skills-shorthand-tool-schema.md
+++ b/changelog.d/fixes/11881-skills-shorthand-tool-schema.md
@@ -1,0 +1,1 @@
+- **fix(skills):** injected skill tools declared in shorthand (`{"content": "string"}`) now forward valid JSON Schema, unblocking providers that validate tool schemas strictly such as Zhipu GLM on the Console Go tier ([#11881](https://github.com/diegosouzapw/OmniRoute/pull/11881)) — thanks @NoxzRCW

--- a/src/lib/skills/injection.ts
+++ b/src/lib/skills/injection.ts
@@ -63,9 +63,17 @@ function normalizeInputSchema(input: Record<string, unknown>): Record<string, un
   if (typeof input.type === "string") {
     return input;
   }
+  // Expand shorthand values: skills may declare `{ "content": "string" }`
+  // instead of `{ "content": { "type": "string" } }`. Forwarding the shorthand
+  // verbatim produces invalid JSON Schema, which strict-validating upstreams
+  // (Zhipu GLM behind Console Go) reject with a 400 for the entire request.
+  const properties: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    properties[key] = typeof value === "string" ? { type: value } : value;
+  }
   return {
     type: "object",
-    properties: input,
+    properties,
   };
 }
 

--- a/tests/unit/skills-injection.test.ts
+++ b/tests/unit/skills-injection.test.ts
@@ -81,7 +81,7 @@ test("injectSkills renders enabled tools in provider-specific shapes", async () 
     function: {
       name: "omr_skill_c2VhcmNoQDEuMC4w", // encodedName("search@1.0.0")
       description: "search the web",
-      parameters: { type: "object", properties: { query: "string" } },
+      parameters: { type: "object", properties: { query: { type: "string" } } },
     },
   });
   assert.equal(decodeSkillToolName("omr_skill_c2VhcmNoQDEuMC4w"), "search@1.0.0");
@@ -90,14 +90,14 @@ test("injectSkills renders enabled tools in provider-specific shapes", async () 
     {
       name: "omr_skill_c2VhcmNoQDEuMC4w",
       description: "search the web",
-      input_schema: { type: "object", properties: { query: "string" } },
+      input_schema: { type: "object", properties: { query: { type: "string" } } },
     },
   ]);
   assert.deepEqual(geminiTools, [
     {
       name: "omr_skill_c2VhcmNoQDEuMC4w",
       description: "search the web",
-      parameters: { type: "object", properties: { query: "string" } },
+      parameters: { type: "object", properties: { query: { type: "string" } } },
     },
   ]);
   assert.deepEqual(fallbackTools, [openaiTools[0]]);
@@ -219,7 +219,7 @@ test("injectSkills auto mode matches message/context semantics and applies score
     function: {
       name: encodedName("issueSearch@1.0.0"),
       description: "search github issues and pull requests",
-      parameters: { type: "object", properties: { query: "string" } },
+      parameters: { type: "object", properties: { query: { type: "string" } } },
     },
   });
 });
@@ -337,4 +337,61 @@ test("injectSkills auto mode limits selected auto skills and keeps on-mode skill
   );
   assert.equal(names.includes("alwaysOnUtility@1.0.0"), true);
   assert.equal(names.filter((name) => name.startsWith("searchSkill")).length, 5);
+});
+
+/**
+ * Regression for #11856 — injected skill tools carried a malformed JSON Schema.
+ *
+ * Skills may declare their input in shorthand (`{ "content": "string" }`).
+ * normalizeInputSchema() wrapped that bare property map as
+ * `{ type: "object", properties: { content: "string" } }` without expanding the
+ * shorthand values — and `"string"` is not a JSON Schema object. Zhipu GLM
+ * behind the Console Go tier validates tool schemas strictly and rejected the
+ * whole request with `[1210] Invalid API parameter`, giving a 100% failure rate
+ * on that provider regardless of request content or credentials. Most other
+ * providers tolerate the malformed schema, which is why it surfaced late.
+ *
+ * SkillSchema is `z.record(z.string(), z.unknown())`, so shorthand values pass
+ * validation from every skill source — the skills API, the GitHub collector and
+ * the skillssh marketplace alike.
+ */
+test("#11856 injectSkills expands shorthand property types into valid JSON Schema", async () => {
+  await skillRegistry.register({
+    name: "generation",
+    version: "1.0.0",
+    description: "generate content",
+    schema: {
+      input: {
+        content: "string",
+        count: "number",
+        // already-expanded entries must survive untouched
+        options: { type: "object", properties: { tone: { type: "string" } } },
+      },
+      output: { result: "string" },
+    },
+    handler: "generation-handler",
+    enabled: true,
+    apiKeyId: "key-11856",
+  });
+
+  const expected = {
+    type: "object",
+    properties: {
+      content: { type: "string" },
+      count: { type: "number" },
+      options: { type: "object", properties: { tone: { type: "string" } } },
+    },
+  };
+
+  const openaiTools = injectSkills({ provider: "openai", apiKeyId: "key-11856" });
+  assert.deepEqual(
+    (openaiTools[0] as { function: { parameters: unknown } }).function.parameters,
+    expected
+  );
+
+  const claudeTools = injectSkills({ provider: "anthropic", apiKeyId: "key-11856" });
+  assert.deepEqual((claudeTools[0] as { input_schema: unknown }).input_schema, expected);
+
+  const geminiTools = injectSkills({ provider: "google", apiKeyId: "key-11856" });
+  assert.deepEqual((geminiTools[0] as { parameters: unknown }).parameters, expected);
 });


### PR DESCRIPTION
## Summary

Every chat completion to a provider that validates tool schemas strictly failed with a 400, regardless of the request body or the credentials. Reproduced on `opencode-go/glm-5.3-flash` with a minimal body:

```
[400]: Error from provider (Console Go): Upstream request failed: [1210] Invalid API parameter, please check the documentation.
```

The same body posted directly to the upstream returns 200, so it was not the caller's parameters.

The cause is on our side. Skills may declare their input in shorthand:

```json
{ "content": "string" }
```

`normalizeInputSchema()` wrapped that bare property map as `{ "type": "object", "properties": { "content": "string" } }` without expanding the values, and `"string"` is not a JSON Schema object. Every injected `omr_skill_*` tool therefore carried an invalid schema. Most upstreams tolerate it, which is why this went unnoticed. Zhipu GLM behind the Console Go tier does not, and rejects the whole request.

The fix expands string property values during normalization. Schemas that are already valid, and schemas that carry their own root `type`, are untouched.

## Related Issues

- Closes #11856
- Same `[1210]` signature as #11819 and #11274, different cause. Those two are about `reasoning_effort` rewriting. This one fires with no `reasoning_effort` at all.

## Validation

- [x] Change type: other (skills)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

```
node --import tsx/esm --test tests/unit/skills-injection.test.ts tests/unit/skills-registry.test.ts \
  tests/unit/chatcore-skills-format.test.ts
# tests 26 / pass 26 / fail 0

npm run typecheck:core   # 0 errors
npm run lint             # clean
```

## Tests Added Or Updated

- `tests/unit/skills-injection.test.ts`

New case: `#11856 injectSkills expands shorthand property types into valid JSON Schema`, covering all three provider shapes (OpenAI `parameters`, Claude `input_schema`, Gemini `parameters`) with a mixed schema so both the expanded and the already-valid entries are asserted in one pass.

The existing `injectSkills renders enabled tools in provider-specific shapes` test had four assertions pinned to the malformed output (`properties: { query: "string" }`). Those are updated to the expanded form. Without that, the fix reads as a regression in CI.

## Coverage Notes

`src/lib/skills/injection.ts` is covered by `tests/unit/skills-injection.test.ts`. `normalizeInputSchema()` is private, so the new case goes through `injectSkills()` and the real registry rather than reaching in.

## Reviewer Notes

The report that led me here blamed three builtin skills (`generation@1.0.0`, `frontend-design@1.0.0`, `brainstorming@1.0.0`) for declaring shorthand schemas. I could not find any of them in the tree, so I would not take that part at face value.

The reachable vector is wider anyway. `SkillSchema` is `z.record(z.string(), z.unknown())`, so a shorthand value passes validation from any skill source: the skills API, the GitHub collector, and the skillssh marketplace. That last one matters most, since it means third-party content can put a malformed schema in front of every request for a given key.

If you would rather reject shorthand at the schema boundary instead of normalizing it at injection time, that is a bigger change and I did not want to break existing skills in a bug fix. Happy to look at it separately.
