### PR TITLE
fix(translator): keep upstream usage from trailing empty-choices chunks

### DIFF
--- a/changelog.d/fixes/11883-openai-to-claude-trailing-usage.md
+++ b/changelog.d/fixes/11883-openai-to-claude-trailing-usage.md
@@ -1,0 +1,1 @@
+- **fix(translator):** the streaming OpenAI→Claude translator keeps upstream usage, including prompt-cache tokens, when it arrives on a trailing `choices: []` chunk (Fireworks and any upstream using `stream_options.include_usage`) ([#11883](https://github.com/diegosouzapw/OmniRoute/pull/11883)) — thanks @NoxzRCW

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -162,49 +162,61 @@ function stopTextBlock(state, results) {
   state.textBlockStarted = false;
 }
 
+// Harvest the upstream usage block from any chunk, including trailing
+// usage-only chunks that carry `choices: []` (#11817).
+function trackUsageFromChunk(chunk, state) {
+  if (!chunk.usage || typeof chunk.usage !== "object") return;
+  const promptTokens =
+    typeof chunk.usage.prompt_tokens === "number" ? chunk.usage.prompt_tokens : 0;
+  const outputTokens =
+    typeof chunk.usage.completion_tokens === "number" ? chunk.usage.completion_tokens : 0;
+
+  // Extract cache tokens from prompt_tokens_details
+  const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens;
+  const cacheCreationTokens = chunk.usage.prompt_tokens_details?.cache_creation_tokens;
+  const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
+  const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
+
+  // input_tokens = prompt_tokens - cached_tokens - cache_creation_tokens
+  // Because OpenAI's prompt_tokens includes all prompt-side tokens
+  const inputTokens = promptTokens - cacheReadTokens - cacheCreateTokens;
+
+  state.usage = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+  };
+
+  // Add cache_read_input_tokens if present
+  if (cacheReadTokens > 0) {
+    state.usage.cache_read_input_tokens = cacheReadTokens;
+  }
+
+  // Add cache_creation_input_tokens if present
+  if (cacheCreateTokens > 0) {
+    state.usage.cache_creation_input_tokens = cacheCreateTokens;
+  }
+
+  // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
+  // No need to add separately as Claude expects total output_tokens
+}
+
 // Convert OpenAI stream chunk to Claude format
 export function openaiToClaudeResponse(chunk, state) {
-  if (!chunk || !chunk.choices?.[0]) return null;
+  if (!chunk) return null;
+
+  // Usage must be harvested BEFORE the choices guard: many OpenAI-compatible
+  // upstreams (Fireworks, vLLM, Together, …) deliver the authoritative usage
+  // block — including prompt_tokens_details.cached_tokens — on a trailing
+  // usage-only chunk shaped `{"choices":[],"usage":{...}}`. Returning early on
+  // that chunk discarded the real numbers and left downstream accounting on
+  // OmniRoute's own tokenizer estimate (#11817).
+  trackUsageFromChunk(chunk, state);
+
+  if (!chunk.choices?.[0]) return null;
 
   const results = [];
   const choice = chunk.choices[0];
   const delta = choice.delta;
-
-  // Track usage from OpenAI chunk if available
-  if (chunk.usage && typeof chunk.usage === "object") {
-    const promptTokens =
-      typeof chunk.usage.prompt_tokens === "number" ? chunk.usage.prompt_tokens : 0;
-    const outputTokens =
-      typeof chunk.usage.completion_tokens === "number" ? chunk.usage.completion_tokens : 0;
-
-    // Extract cache tokens from prompt_tokens_details
-    const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens;
-    const cacheCreationTokens = chunk.usage.prompt_tokens_details?.cache_creation_tokens;
-    const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
-    const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
-
-    // input_tokens = prompt_tokens - cached_tokens - cache_creation_tokens
-    // Because OpenAI's prompt_tokens includes all prompt-side tokens
-    const inputTokens = promptTokens - cacheReadTokens - cacheCreateTokens;
-
-    state.usage = {
-      input_tokens: inputTokens,
-      output_tokens: outputTokens,
-    };
-
-    // Add cache_read_input_tokens if present
-    if (cacheReadTokens > 0) {
-      state.usage.cache_read_input_tokens = cacheReadTokens;
-    }
-
-    // Add cache_creation_input_tokens if present
-    if (cacheCreateTokens > 0) {
-      state.usage.cache_creation_input_tokens = cacheCreateTokens;
-    }
-
-    // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
-    // No need to add separately as Claude expects total output_tokens
-  }
 
   // First chunk - ALWAYS send message_start first
   if (!state.messageStartSent) {

--- a/tests/unit/openai-to-claude-trailing-usage-11817.test.ts
+++ b/tests/unit/openai-to-claude-trailing-usage-11817.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression for #11817 — the streaming OpenAI→Claude translator dropped the
+ * upstream usage block (including prompt-cache accounting) whenever it arrived
+ * on a trailing usage-only chunk shaped `{"choices":[],"usage":{...}}`.
+ *
+ * Many OpenAI-compatible upstreams (confirmed: Fireworks / kimi-k3, also vLLM
+ * and Together with `stream_options.include_usage`) emit usage exactly that
+ * way. `openaiToClaudeResponse()` returned early on `!chunk.choices?.[0]`
+ * BEFORE reading `chunk.usage`, so `state.usage` stayed undefined and every
+ * downstream consumer fell back to OmniRoute's own tokenizer estimate — no
+ * cache_read_input_tokens, no cache_creation_input_tokens, and an input_tokens
+ * figure that disagreed with the provider's own count.
+ *
+ * Impact was silent over-billing: a session served ~75% from prompt cache was
+ * metered at the full uncached rate.
+ *
+ * Runner: node --import tsx/esm --test tests/unit/openai-to-claude-trailing-usage-11817.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiToClaudeResponse } =
+  await import("../../open-sse/translator/response/openai-to-claude.ts");
+
+function newState() {
+  return { toolCalls: new Map(), messageId: "msg_11817", model: "kimi-k3" } as Record<
+    string,
+    unknown
+  >;
+}
+
+test("#11817 — usage on a trailing choices:[] chunk is harvested, with cache split", () => {
+  const state = newState();
+
+  openaiToClaudeResponse({ choices: [{ index: 0, delta: { content: "ok" } }] }, state);
+  openaiToClaudeResponse({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }, state);
+  openaiToClaudeResponse(
+    {
+      choices: [],
+      usage: {
+        prompt_tokens: 6103,
+        completion_tokens: 24,
+        prompt_tokens_details: { cached_tokens: 6102 },
+      },
+    },
+    state
+  );
+
+  assert.deepEqual(state.usage, {
+    input_tokens: 1, // 6103 - 6102 cached
+    output_tokens: 24,
+    cache_read_input_tokens: 6102,
+  });
+});
+
+test("#11817 — cache_creation_tokens on a trailing chunk is mapped too", () => {
+  const state = newState();
+  openaiToClaudeResponse(
+    {
+      choices: [],
+      usage: {
+        prompt_tokens: 1000,
+        completion_tokens: 5,
+        prompt_tokens_details: { cached_tokens: 400, cache_creation_tokens: 100 },
+      },
+    },
+    state
+  );
+
+  assert.deepEqual(state.usage, {
+    input_tokens: 500,
+    output_tokens: 5,
+    cache_read_input_tokens: 400,
+    cache_creation_input_tokens: 100,
+  });
+});
+
+test("#11817 — a usage-only chunk still emits no Claude events", () => {
+  const state = newState();
+  const out = openaiToClaudeResponse(
+    { choices: [], usage: { prompt_tokens: 10, completion_tokens: 1 } },
+    state
+  );
+  assert.equal(out, null);
+});
+
+test("#11817 — no regression: usage carried inline on the finish chunk", () => {
+  const state = newState();
+  openaiToClaudeResponse({ choices: [{ index: 0, delta: { content: "hi" } }] }, state);
+  openaiToClaudeResponse(
+    {
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 100, completion_tokens: 10 },
+    },
+    state
+  );
+  assert.deepEqual(state.usage, { input_tokens: 100, output_tokens: 10 });
+});
+
+test("#11817 — no regression: empty and nullish chunks are still ignored", () => {
+  assert.equal(openaiToClaudeResponse(null, newState()), null);
+  assert.equal(openaiToClaudeResponse({ choices: [] }, newState()), null);
+  assert.equal(openaiToClaudeResponse({}, newState()), null);
+});


### PR DESCRIPTION
## Summary

`openaiToClaudeResponse()` returned early on `!chunk.choices?.[0]` before it read `chunk.usage`:

```ts
export function openaiToClaudeResponse(chunk, state) {
  if (!chunk || !chunk.choices?.[0]) return null;   // usage block below never runs
  ...
```

A number of OpenAI-compatible upstreams deliver the authoritative usage block on a trailing usage-only chunk shaped like this:

```
data: {"choices":[],"usage":{"prompt_tokens":6103,"prompt_tokens_details":{"cached_tokens":6102},...}}
```

Confirmed on Fireworks with `accounts/fireworks/models/kimi-k3`, and it is the normal shape whenever `stream_options.include_usage` is set. That chunk was dropped whole, so `state.usage` stayed `undefined` and everything downstream fell back to the router's own tokenizer estimate.

The visible cost is billing. Prompt-cache accounting never reached the Claude side, so `message_delta` carried an estimate with no cache split at all:

```
data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"input_tokens":7908,"output_tokens":24,"estimated":true}}
```

`input_tokens: 7908` does not even agree with the real `prompt_tokens: 6103` from the same request on the OpenAI-shaped endpoint. For a backend priced at $3/M uncached against $0.30/M cached, a session running at a 75% cache hit rate gets metered at roughly three times what it should, with nothing in the logs to suggest anything is wrong.

Usage harvesting now happens before the choices guard, in a small `trackUsageFromChunk()` helper. A usage-only chunk still emits no Claude events, so nothing changes on the wire for well-behaved upstreams.

This is the streaming companion to #9536, which fixed the same field mapping on the non-streaming `/v1/messages` path in 3.8.50.

## Related Issues

- Closes #11817
- Streaming companion to #9536

## Validation

- [x] Change type: provider (translator)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

```
node --import tsx/esm --test tests/unit/openai-to-claude-trailing-usage-11817.test.ts \
  tests/unit/9536-usage-misreporting-openai-to-claude.test.ts \
  tests/unit/translator-resp-openai-to-claude.test.ts
# tests 23 / pass 23 / fail 0
```

I also ran the 51 test files touching the translator, the icons, the skills and the xAI paths together while working through a batch of fixes: 385 tests, all passing.

```
npm run check:open-sse-typecheck   # OK, 5 pre-existing errors, all within frozen baseline
npm run lint                       # clean
```

## Tests Added Or Updated

- `tests/unit/openai-to-claude-trailing-usage-11817.test.ts` (new)

Five cases: the full Fireworks sequence with the cache split, `cache_creation_tokens` on a trailing chunk, a usage-only chunk emitting no events, usage carried inline on the finish chunk (the well-behaved path, unchanged), and the nullish and empty chunks that must stay ignored.

Before the change the first case leaves `state.usage` as `undefined`. After it, `{ input_tokens: 1, output_tokens: 24, cache_read_input_tokens: 6102 }`.

## Coverage Notes

The extracted `trackUsageFromChunk()` carries the arithmetic that was previously inline, and the new file covers both cache fields plus the no-usage path. The surrounding event emission is unchanged and stays covered by the existing `openai-to-claude-*` and `translator-resp-openai-to-claude` suites.

## Reviewer Notes

One thing I deliberately did not fix here, so you know where the remaining gap is.

The terminal `message_delta` and `message_stop` are emitted together the moment `choice.finish_reason` arrives. When an upstream sends its usage chunk after the finish chunk, as Fireworks does, the client-facing `message_delta` has already gone out by the time the real numbers land. So this PR gets the correct usage into `state.usage`, which is what `chatCore` reads for cost accounting, logging and metering, but a Claude-protocol client watching the stream still sees the estimate in that event.

Closing that gap properly means holding the terminal events until the upstream stream ends. That is a real change to a path that has already regressed once (#5828, the `claudeFinishEmitted` guard), so I did not want to bundle it into a usage fix. Happy to take it on separately if you want it.

The diff is larger than the change because the usage block moved out into a helper. `git diff -w --ignore-blank-lines` reads cleaner.
