### PR TITLE
fix(lint): pin react hooks plugin to 7.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "dpdm": "^4.3.0",
         "eslint": "^9.39.4",
         "eslint-config-next": "16.3.2",
+        "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-sonarjs": "^4.1.0",
         "fast-check": "^4.8.0",
         "fumadocs-mdx": "^15.3.1",

--- a/package.json
+++ b/package.json
@@ -381,6 +381,7 @@
     "dpdm": "^4.3.0",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.3.2",
+    "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-sonarjs": "^4.1.0",
     "fast-check": "^4.8.0",
     "fumadocs-mdx": "^15.3.1",

--- a/tests/unit/eslint-react-hooks-version-pinned.test.ts
+++ b/tests/unit/eslint-react-hooks-version-pinned.test.ts
@@ -1,0 +1,41 @@
+/**
+ * eslint-react-hooks-version-pinned.test.ts — keep lint policy deterministic.
+ *
+ * eslint-config-next accepts any eslint-plugin-react-hooks 7.x release. Minor
+ * releases can change React Compiler diagnostics, so resolving a newer plugin
+ * from unchanged source can produce hundreds of unrelated lint failures. Keep
+ * the direct declaration exact and aligned with the lockfile.
+ */
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = new URL("../../", import.meta.url);
+const PLUGIN = "eslint-plugin-react-hooks";
+const EXPECTED_VERSION = "7.0.1";
+
+async function readJson(relative: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(fileURLToPath(new URL(relative, ROOT)), "utf8"));
+}
+
+test("eslint-plugin-react-hooks is directly pinned to the locked version", async () => {
+  const pkg = await readJson("package.json");
+  const lock = await readJson("package-lock.json");
+  const declared = ((pkg.devDependencies ?? {}) as Record<string, string>)[PLUGIN];
+  const packages = (lock.packages ?? {}) as Record<string, { version?: string }>;
+  const locked = packages[`node_modules/${PLUGIN}`]?.version;
+
+  assert.ok(declared, `${PLUGIN} must be a direct devDependency`);
+  assert.equal(
+    declared,
+    EXPECTED_VERSION,
+    `${PLUGIN} must remain pinned to ${EXPECTED_VERSION} until the 7.1.1 lint migration`
+  );
+  assert.ok(locked, `${PLUGIN} missing from package-lock.json`);
+  assert.equal(
+    declared,
+    locked,
+    `package.json declares ${PLUGIN}@${declared} but package-lock.json resolves ${locked}`
+  );
+});


### PR DESCRIPTION
## Summary

Recreation of #11749 (MumuTW) onto the active `release/v3.8.51` — the original PR was opened
against the stale `release/v3.8.50`, and MumuTW's fork rejects maintainer pushes, so a direct
rebase-and-push wasn't possible. Cherry-picked the PR's single commit (author preserved) onto
the current tip and re-validated here.

- pin eslint-plugin-react-hooks 7.0.1 as a direct devDependency
- prevent eslint-config-next transitive range drift from changing lint policy
- add a regression test that locks the expected version and package-lock alignment

## Root cause

eslint-config-next allows eslint-plugin-react-hooks through ^7.0.0. A reused or refreshed
node_modules could therefore load 7.1.1 while the repository lockfile and source remained
unchanged. The 7.1 analyzer changes then surfaced hundreds of React Compiler diagnostics
across unrelated dashboard files.

## Verification (on release/v3.8.51 tip)

- focused regression test: `node --import tsx/esm --test tests/unit/eslint-react-hooks-version-pinned.test.ts` — pass
- `npm run check:lockfile`: pass
- `node scripts/check/check-file-size.mjs`: pass
- package.json/package-lock.json JSON validity: pass

Closes #11749 (recreated — commit author MumuTW preserved via cherry-pick).

Co-authored-by: MumuTW <42820974+MumuTW@users.noreply.github.com>