### PR TITLE
feat(models): auto-aliases and token limits from synced Antigravity discovery

### DIFF
--- a/src/app/api/providers/[id]/models/discovery/normalizers.ts
+++ b/src/app/api/providers/[id]/models/discovery/normalizers.ts
@@ -29,7 +29,31 @@ type AntigravityDiscoveryModel = {
   id: string;
   name: string;
   isInternal?: boolean;
+  /** Token window advertised by the upstream discovery payload, when present. */
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
 };
+
+/**
+ * Forward discovery-advertised token windows when the upstream payload carries
+ * them. Field names are probed defensively (payload shape is not contractual);
+ * absent/non-numeric fields yield no entry, so nothing downstream changes.
+ */
+function extractDiscoveryTokenLimits(item: Record<string, unknown>): {
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
+} {
+  const limits: { inputTokenLimit?: number; outputTokenLimit?: number } = {};
+  const input = item.inputTokenLimit ?? item.contextWindow;
+  if (typeof input === "number" && Number.isFinite(input) && input > 0) {
+    limits.inputTokenLimit = input;
+  }
+  const output = item.outputTokenLimit ?? item.maxOutputTokens;
+  if (typeof output === "number" && Number.isFinite(output) && output > 0) {
+    limits.outputTokenLimit = output;
+  }
+  return limits;
+}
 
 export function normalizeAntigravityModelsResponse(data: unknown): AntigravityDiscoveryModel[] {
   const payload = asRecord(data).models;
@@ -52,7 +76,14 @@ export function normalizeAntigravityModelsResponse(data: unknown): AntigravityDi
             : typeof item.name === "string"
               ? item.name
               : id;
-        return id ? { id, name, ...(item.isInternal === true ? { isInternal: true } : {}) } : null;
+        return id
+          ? {
+              id,
+              name,
+              ...extractDiscoveryTokenLimits(item),
+              ...(item.isInternal === true ? { isInternal: true } : {}),
+            }
+          : null;
       })
       .filter((value): value is AntigravityDiscoveryModel => Boolean(value));
   }
@@ -67,7 +98,14 @@ export function normalizeAntigravityModelsResponse(data: unknown): AntigravityDi
           : typeof item.name === "string"
             ? item.name
             : id;
-      return id ? { id, name, ...(item.isInternal === true ? { isInternal: true } : {}) } : null;
+      return id
+        ? {
+            id,
+            name,
+            ...extractDiscoveryTokenLimits(item),
+            ...(item.isInternal === true ? { isInternal: true } : {}),
+          }
+        : null;
     })
     .filter((value): value is AntigravityDiscoveryModel => Boolean(value));
 }
@@ -86,11 +124,13 @@ export function filterUserCallableAntigravityModels(
 }
 
 export function mapAntigravityModelForClient(
-  model: { id: string; name: string },
+  model: { id: string; name: string; inputTokenLimit?: number; outputTokenLimit?: number },
   provider: "antigravity" | "agy" = "antigravity"
 ): {
   id: string;
   name: string;
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
 } {
   const clientId = toClientAntigravityModelId(model.id);
   return {
@@ -99,6 +139,12 @@ export function mapAntigravityModelForClient(
       provider === "agy"
         ? getClientVisibleAgyModelName(clientId, model.name)
         : getClientVisibleAntigravityModelName(clientId, model.name),
+    ...(typeof model.inputTokenLimit === "number"
+      ? { inputTokenLimit: model.inputTokenLimit }
+      : {}),
+    ...(typeof model.outputTokenLimit === "number"
+      ? { outputTokenLimit: model.outputTokenLimit }
+      : {}),
   };
 }
 
@@ -108,7 +154,9 @@ export async function fetchAntigravityDiscoveryModelsCached(
   proxy: unknown,
   providerSpecificData?: unknown,
   provider: "antigravity" | "agy" = "antigravity"
-): Promise<Array<{ id: string; name: string }>> {
+): Promise<
+  Array<{ id: string; name: string; inputTokenLimit?: number; outputTokenLimit?: number }>
+> {
   const profile = normalizeAntigravityClientProfile(asRecord(providerSpecificData).clientProfile);
   const cacheKey = `${provider}:${connectionId}:${accessToken.substring(0, 16)}:${profile}`;
   const inflight = antigravityDiscoveryInflight.get(cacheKey);

--- a/src/lib/providerModels/syncedAutoAliases.ts
+++ b/src/lib/providerModels/syncedAutoAliases.ts
@@ -1,0 +1,85 @@
+/**
+ * Auto-aliases derived from synced (discovered) Antigravity-family models.
+ *
+ * Bare model names only resolve when something maps them; every new upstream
+ * model used to need a hand-written alias (Gemini 3.7 Flash shipped with none,
+ * so bare names mis-routed until a catalog refresh). The Antigravity backend
+ * advertises tiered ids (…-high/-medium/-low) while users naturally ask for
+ * the bare base name, so derive: bare base → default tier (high > medium >
+ * low), mirroring the backend's own High default.
+ *
+ * Derived in memory from the synced store — no persistence, always consistent
+ * with the latest discovery, and merged at the LOWEST precedence so explicit
+ * human aliases (DB namespace, settings, wildcards) always win.
+ */
+
+import { getAllActiveSyncedModels } from "@/lib/db/models/activeSyncedCatalog";
+
+/** Providers whose synced catalogs participate in auto-alias derivation. */
+const AUTO_ALIAS_FAMILY_PROVIDERS = ["agy", "antigravity"] as const;
+
+/** Preferred default tier when a bare base name is aliased onto a group. */
+const TIER_PREFERENCE = ["-high", "-medium", "-low"] as const;
+
+/**
+ * Pure derivation (exported for tests): given per-provider synced model id
+ * lists, produce bare-base → "provider/defaultTierId" alias entries.
+ *
+ * Rules:
+ * - only tiered groups (ids carrying a -high/-medium/-low suffix) participate
+ * - a base that is itself a callable synced id gets no alias (nothing to map)
+ * - within one provider the first eligible group per base wins; across
+ *   providers the AUTO_ALIAS_FAMILY_PROVIDERS order wins (agy first)
+ */
+export function deriveSyncedTierAliases(
+  syncedIdsByProvider: Record<string, readonly string[]>
+): Record<string, string> {
+  const aliases: Record<string, string> = {};
+
+  for (const provider of AUTO_ALIAS_FAMILY_PROVIDERS) {
+    const ids = syncedIdsByProvider[provider];
+    if (!Array.isArray(ids) || ids.length === 0) continue;
+
+    const idSet = new Set(ids);
+    const groups = new Map<string, string[]>();
+    for (const id of ids) {
+      if (typeof id !== "string" || !id) continue;
+      const suffix = TIER_PREFERENCE.find((candidate) => id.endsWith(candidate));
+      if (!suffix) continue;
+      const base = id.slice(0, -suffix.length);
+      if (!base) continue;
+      const bucket = groups.get(base) ?? [];
+      bucket.push(id);
+      groups.set(base, bucket);
+    }
+
+    for (const [base, variants] of groups) {
+      if (aliases[base]) continue; // earlier provider already claimed it
+      if (idSet.has(base)) continue; // bare base itself is callable — no alias needed
+      const chosen = TIER_PREFERENCE.map((suffix) => base + suffix).find((id) =>
+        variants.includes(id)
+      );
+      if (chosen) aliases[base] = `${provider}/${chosen}`;
+    }
+  }
+
+  return aliases;
+}
+
+/** Auto-aliases from the live synced catalog (empty on any read failure). */
+export async function getSyncedAutoAliases(): Promise<Record<string, string>> {
+  try {
+    const syncedByProvider = await getAllActiveSyncedModels();
+    const picked: Record<string, readonly string[]> = {};
+    for (const provider of AUTO_ALIAS_FAMILY_PROVIDERS) {
+      const rows = syncedByProvider[provider];
+      if (!Array.isArray(rows)) continue;
+      picked[provider] = rows
+        .map((row) => (row && typeof row.id === "string" ? row.id : ""))
+        .filter(Boolean);
+    }
+    return deriveSyncedTierAliases(picked);
+  } catch {
+    return {};
+  }
+}

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -7,6 +7,8 @@ import {
   getCachedProviderNodes,
   getCustomModels,
 } from "@/lib/localDb";
+
+import { getSyncedAutoAliases } from "@/lib/providerModels/syncedAutoAliases.ts";
 import { getCachedSettings } from "@/lib/localDb";
 import { getActiveSyncedCatalog } from "@/lib/db/models/activeSyncedCatalog";
 import { getModelCompatOverrides } from "@/lib/db/models/compat";
@@ -63,6 +65,8 @@ function buildWildcardAliasMap(settings: Record<string, unknown>): Record<string
 
 /**
  * Build a combined model alias map that merges all alias stores:
+ * 0. Auto-aliases derived from synced Antigravity-family discovery (lowest
+ *    precedence — bare base name → default tier; see syncedAutoAliases.ts).
  * 1. DB-namespace aliases (key_value WHERE namespace='modelAliases') — set via
  *    /api/models/alias/ and seeded at startup.
  * 2. Settings-based exact aliases (settings.modelAliases) — set via the Settings UI and
@@ -78,9 +82,10 @@ function buildWildcardAliasMap(settings: Record<string, unknown>): Record<string
  * cannot collide with a real model id, so ordering never affects exact-alias lookups.
  */
 async function getCombinedModelAliases(): Promise<Record<string, unknown>> {
-  const [dbAliases, settings] = await Promise.all([
+  const [dbAliases, settings, autoAliases] = await Promise.all([
     getModelAliases().catch(() => ({})),
     getCachedSettings().catch(() => ({}) as Record<string, unknown>),
+    getSyncedAutoAliases().catch(() => ({}) as Record<string, string>),
   ]);
 
   const settingsAliases =
@@ -92,7 +97,9 @@ async function getCombinedModelAliases(): Promise<Record<string, unknown>> {
 
   const wildcardMap = buildWildcardAliasMap(settings);
 
-  return { ...dbAliases, ...settingsAliases, ...wildcardMap };
+  // Auto-aliases (derived from synced discovery) merge first — lowest
+  // precedence: any explicit DB/settings/wildcard alias always wins.
+  return { ...autoAliases, ...dbAliases, ...settingsAliases, ...wildcardMap };
 }
 
 /**

--- a/tests/unit/synced-auto-aliases.test.ts
+++ b/tests/unit/synced-auto-aliases.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Auto-aliases derived from synced Antigravity-family discovery: bare base
+ * names map onto the default tier (high > medium > low) at the lowest alias
+ * precedence, so freshly shipped tiered models resolve without hand-written
+ * aliases (Gemini 3.7 Flash shipped with none).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-auto-aliases-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { deriveSyncedTierAliases, getSyncedAutoAliases } =
+  await import("../../src/lib/providerModels/syncedAutoAliases.ts");
+const { normalizeAntigravityModelsResponse, mapAntigravityModelForClient } =
+  await import("../../src/app/api/providers/[id]/models/discovery/normalizers.ts");
+
+test("tiered group aliases the bare base onto the high tier", () => {
+  const aliases = deriveSyncedTierAliases({
+    agy: ["gemini-3.7-flash-high", "gemini-3.7-flash-medium", "gemini-3.7-flash-low"],
+  });
+  assert.deepEqual(aliases, { "gemini-3.7-flash": "agy/gemini-3.7-flash-high" });
+});
+
+test("missing high tier falls back to medium, then low", () => {
+  assert.deepEqual(deriveSyncedTierAliases({ agy: ["x-model-medium", "x-model-low"] }), {
+    "x-model": "agy/x-model-medium",
+  });
+  assert.deepEqual(deriveSyncedTierAliases({ agy: ["y-model-low"] }), {
+    "y-model": "agy/y-model-low",
+  });
+});
+
+test("a callable bare base gets no alias", () => {
+  const aliases = deriveSyncedTierAliases({
+    agy: ["gemini-3.7-flash", "gemini-3.7-flash-high", "gemini-3.7-flash-low"],
+  });
+  assert.equal(aliases["gemini-3.7-flash"], undefined);
+});
+
+test("non-tiered model ids are ignored", () => {
+  assert.deepEqual(deriveSyncedTierAliases({ agy: ["gemini-pro-agent", "claude-sonnet-4-6"] }), {});
+});
+
+test("agy provider wins over antigravity for the same base", () => {
+  const aliases = deriveSyncedTierAliases({
+    antigravity: ["gemini-3.7-flash-high"],
+    agy: ["gemini-3.7-flash-medium"],
+  });
+  assert.deepEqual(aliases, { "gemini-3.7-flash": "agy/gemini-3.7-flash-medium" });
+});
+
+test("empty or unknown providers produce nothing", () => {
+  assert.deepEqual(deriveSyncedTierAliases({}), {});
+  assert.deepEqual(deriveSyncedTierAliases({ openai: ["gpt-x-high"] }), {});
+  assert.deepEqual(deriveSyncedTierAliases({ agy: [] }), {});
+});
+
+test("discovery normalization carries numeric token limits when present", () => {
+  const models = normalizeAntigravityModelsResponse({
+    models: {
+      "gemini-3.7-flash-high": {
+        displayName: "Gemini 3.7 Flash (High)",
+        inputTokenLimit: 1048576,
+        outputTokenLimit: 65536,
+      },
+    },
+  });
+  assert.equal(models.length, 1);
+  assert.equal(models[0].inputTokenLimit, 1048576);
+  assert.equal(models[0].outputTokenLimit, 65536);
+});
+
+test("normalization accepts contextWindow/maxOutputTokens spellings and drops junk", () => {
+  const models = normalizeAntigravityModelsResponse({
+    models: {
+      "model-a": { displayName: "A", contextWindow: 262144, maxOutputTokens: 32768 },
+      "model-b": { displayName: "B", inputTokenLimit: "huge", outputTokenLimit: -1 },
+      "model-c": { displayName: "C" },
+    },
+  });
+  const byId = Object.fromEntries(models.map((m) => [m.id, m]));
+  assert.equal(byId["model-a"].inputTokenLimit, 262144);
+  assert.equal(byId["model-a"].outputTokenLimit, 32768);
+  assert.equal(byId["model-b"].inputTokenLimit, undefined);
+  assert.equal(byId["model-b"].outputTokenLimit, undefined);
+  assert.equal(byId["model-c"].inputTokenLimit, undefined);
+});
+
+test("client mapping preserves token limits", () => {
+  const mapped = mapAntigravityModelForClient(
+    { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)", inputTokenLimit: 1048576 },
+    "agy"
+  );
+  assert.equal(mapped.inputTokenLimit, 1048576);
+  assert.equal(typeof mapped.id, "string");
+});
+
+test("getSyncedAutoAliases reads the live synced catalog", async () => {
+  const { replaceSyncedAvailableModelsForConnection } = await import("../../src/lib/db/models");
+  const { createProviderConnection } = await import("../../src/lib/db/providers.ts");
+  const { resetDbInstance } = await import("../../src/lib/db/core.ts");
+  resetDbInstance();
+
+  // Only ACTIVE connections' synced rows count — seed a real agy connection.
+  const connection = await createProviderConnection({
+    provider: "agy",
+    authType: "oauth",
+    name: "auto-alias-fixture",
+    accessToken: "fixture-access-token",
+    refreshToken: "fixture-refresh-token",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connectionId = String((connection as Record<string, unknown>).id);
+
+  await replaceSyncedAvailableModelsForConnection("agy", connectionId, [
+    { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)" },
+    { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)" },
+  ]);
+
+  const aliases = await getSyncedAutoAliases();
+  assert.equal(aliases["gemini-3.7-flash"], "agy/gemini-3.7-flash-high");
+});


### PR DESCRIPTION
## Summary

Recreation of #11689 (MumuTW) onto the active `release/v3.8.51` — the original PR was opened
against `main`, too far diverged from the active release for a clean retarget, and MumuTW's
fork rejects maintainer pushes. Cherry-picked the PR's single commit (author preserved) onto
the current tip and re-validated here; auto-merged cleanly with the already-boarded #11888.

Third slice of the accepted direction in #2979 (pairs with #11887 autoSync default and #11888
reactive discovery trigger). Two gaps closed:

1. Bare-name resolution no longer needs hand-written aliases for new Antigravity-family models.
   New `src/lib/providerModels/syncedAutoAliases.ts` derives bare-base → default-tier
   (high > medium > low) aliases from the synced discovery catalog — in memory, no persistence,
   always consistent with the latest sync. Merged at the LOWEST precedence in
   `getCombinedModelAliases`: explicit DB/settings/wildcard aliases always win. A base that is
   itself callable gets no alias; `agy` wins over `antigravity` for the same base.
2. Discovery-advertised token windows now survive to the enforcement chain. The Antigravity
   discovery normalizer previously dropped every field except id/name — it now forwards
   `inputTokenLimit`/`outputTokenLimit` (also probing `contextWindow`/`maxOutputTokens`
   spellings). Extraction is defensive: absent/non-numeric fields yield nothing.

## Related Issues

Related to #2979, #488, #8123, #7678.

## Verification (on release/v3.8.51 tip)

- `node --import tsx/esm --test tests/unit/synced-auto-aliases.test.ts` — 10/10 passing
- `node scripts/check/check-file-size.mjs` — pass

Closes #11689 (recreated — commit author MumuTW preserved via cherry-pick).

Co-authored-by: MumuTW <42820974+MumuTW@users.noreply.github.com>