### PR TITLE
fix(ci): keep the next-build artefact on disk, not on the runner's tmpfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,10 +687,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: ${{ runner.temp }}
+          # Workspace-relative on purpose: the matrix below includes windows-latest, whose
+          # default shell is pwsh, where $RUNNER_TEMP is empty (it is $env:RUNNER_TEMP) —
+          # #11896's first cut broke the Electron smoke on exactly that. A relative path
+          # works in bash and pwsh alike; hosted workspaces are ephemeral.
+          path: next-build-artifact
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf "$RUNNER_TEMP/e2e-build.tar.gz"
+          tar -xzf next-build-artifact/e2e-build.tar.gz
       # build:cli consumes the downloaded .build/next standalone artifact and assembles dist/;
       # it only rebuilds if the downloaded standalone artifact is missing.
       - run: npm run build:cli
@@ -778,10 +782,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: ${{ runner.temp }}
+          # Workspace-relative on purpose: the matrix below includes windows-latest, whose
+          # default shell is pwsh, where $RUNNER_TEMP is empty (it is $env:RUNNER_TEMP) —
+          # #11896's first cut broke the Electron smoke on exactly that. A relative path
+          # works in bash and pwsh alike; hosted workspaces are ephemeral.
+          path: next-build-artifact
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf "$RUNNER_TEMP/e2e-build.tar.gz"
+          tar -xzf next-build-artifact/e2e-build.tar.gz
       - name: Install Electron dependencies
         working-directory: electron
         run: npm install --no-audit --no-fund
@@ -1241,10 +1249,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: ${{ runner.temp }}
+          # Workspace-relative on purpose: the matrix below includes windows-latest, whose
+          # default shell is pwsh, where $RUNNER_TEMP is empty (it is $env:RUNNER_TEMP) —
+          # #11896's first cut broke the Electron smoke on exactly that. A relative path
+          # works in bash and pwsh alike; hosted workspaces are ephemeral.
+          path: next-build-artifact
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf "$RUNNER_TEMP/e2e-build.tar.gz"
+          tar -xzf next-build-artifact/e2e-build.tar.gz
       # WS4.1: duration-balanced shards (LPT over config/quality/e2e-timings.json).
       # Measured skew of plain --shard was 14× (24m47s vs 1m47s) — E2E was the CI
       # critical path. The balancer self-verifies completeness and exits non-zero on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,14 +657,14 @@ jobs:
         # Keep standalone/node_modules intact: package/electron jobs consume the
         # Next-traced standalone tree and must not replace it with root node_modules.
         run: |
-          tar -czf /tmp/e2e-build.tar.gz \
+          tar -czf "$RUNNER_TEMP/e2e-build.tar.gz" \
             --exclude='.build/next/cache' \
             .build/next
       - name: Upload Next.js build for downstream jobs
         uses: actions/upload-artifact@v7
         with:
           name: next-build
-          path: /tmp/e2e-build.tar.gz
+          path: ${{ runner.temp }}/e2e-build.tar.gz
           retention-days: 1
 
   package-artifact:
@@ -687,10 +687,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: /tmp/
+          path: ${{ runner.temp }}
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf /tmp/e2e-build.tar.gz
+          tar -xzf "$RUNNER_TEMP/e2e-build.tar.gz"
       # build:cli consumes the downloaded .build/next standalone artifact and assembles dist/;
       # it only rebuilds if the downloaded standalone artifact is missing.
       - run: npm run build:cli
@@ -778,10 +778,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: /tmp/
+          path: ${{ runner.temp }}
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf /tmp/e2e-build.tar.gz
+          tar -xzf "$RUNNER_TEMP/e2e-build.tar.gz"
       - name: Install Electron dependencies
         working-directory: electron
         run: npm install --no-audit --no-fund
@@ -1241,10 +1241,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: /tmp/
+          path: ${{ runner.temp }}
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf /tmp/e2e-build.tar.gz
+          tar -xzf "$RUNNER_TEMP/e2e-build.tar.gz"
       # WS4.1: duration-balanced shards (LPT over config/quality/e2e-timings.json).
       # Measured skew of plain --shard was 14× (24m47s vs 1m47s) — E2E was the CI
       # critical path. The balancer self-verifies completeness and exits non-zero on

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -204,8 +204,11 @@ jobs:
             exit 0
           fi
           RUN=""
+          # $RUNNER_TEMP, never /tmp: on the .113 pool /tmp is a 12 GB tmpfs (RAM). Parking
+          # this 1.3 GB artefact there took 27–32 min of the 76-min publish job — the
+          # same bytes upload from disk in 2 min. RUNNER_TEMP is per-runner and on disk.
           for candidate in $CANDIDATES; do
-            if gh run download "$candidate" --repo "$REPO" --name next-build --dir /tmp/next-build 2>/dev/null; then
+            if gh run download "$candidate" --repo "$REPO" --name next-build --dir "$RUNNER_TEMP/next-build" 2>/dev/null; then
               RUN="$candidate"
               break
             fi
@@ -215,8 +218,8 @@ jobs:
             echo "::notice::none of the candidate runs still carries next-build (1-day retention) — falling back to a full build"
             exit 0
           fi
-          tar -xzf /tmp/next-build/e2e-build.tar.gz -C .
-          rm -rf /tmp/next-build
+          tar -xzf "$RUNNER_TEMP/next-build/e2e-build.tar.gz" -C .
+          rm -rf "$RUNNER_TEMP/next-build"
           if [ -f .build/next/standalone/server.js ]; then
             echo "✅ standalone tree restored from CI run $RUN — build:cli will skip next build"
           else

--- a/changelog.d/maintenance/11896-ci-artifact-download-to-disk.md
+++ b/changelog.d/maintenance/11896-ci-artifact-download-to-disk.md
@@ -1,0 +1,5 @@
+- The `next-build` artefact (1.3 GB) is now written and read under `$RUNNER_TEMP`
+  (per-runner, on disk) instead of `/tmp`, which on the self-hosted pool is a
+  12 GB tmpfs in RAM. Landing it there took 27–32 of the publish job's 76 minutes,
+  and the fixed `/tmp/e2e-build.tar.gz` name let E2E jobs on different runners
+  overwrite each other's download.


### PR DESCRIPTION
## Problema

Na pool `.113`, `/tmp` é um **tmpfs de 12 GB — é RAM**. O artefato `next-build` de 1,3 GB era estacionado lá **quatro vezes**: o `Build` o comprimia em `/tmp/e2e-build.tar.gz` (6 min), três jobs E2E baixavam para `/tmp/` e extraíam dali, e o `npm-publish.yml` puxava com `gh run download` para `/tmp/next-build`.

Medido nas tentativas de publicação da v3.8.50: esse download levou **27 min** (9ª) e **32 min** (10ª) — **42% de um job de 76 minutos**. Os mesmos bytes sobem do disco em 2 min, e a caixa baixa do GitHub a 7,3 MB/s (1,3 GB ≈ 3 min). A rede nunca foi o gargalo; um tmpfs a 75% sob pressão de memória era.

## O que muda

Todos os pontos passam a usar `$RUNNER_TEMP` / `${{ runner.temp }}`: por-runner, em disco (`_work/_temp` sob o diretório do runner na pool; `/home/runner/work/_temp` nas imagens hospedadas), e limpo pelo runner entre jobs.

| arquivo | ponto | antes | depois |
| --- | --- | --- | --- |
| `ci.yml` | produtor (`Build`) | `tar -czf /tmp/e2e-build.tar.gz` + `path: /tmp/e2e-build.tar.gz` | `$RUNNER_TEMP/…` + `${{ runner.temp }}/…` |
| `ci.yml` | 3 consumidores E2E | `path: /tmp/` + `tar -xzf /tmp/e2e-build.tar.gz` | `${{ runner.temp }}` + `"$RUNNER_TEMP/e2e-build.tar.gz"` |
| `npm-publish.yml` | reuse do artefato | `gh run download … --dir /tmp/next-build` | `--dir "$RUNNER_TEMP/next-build"` |

## Race latente que isto também remove

`e2e-build.tar.gz` é um **nome fixo** num `/tmp` compartilhado por todos os runners da caixa: dois shards E2E em runners diferentes podiam sobrescrever o download um do outro no meio da extração. `RUNNER_TEMP` é por runner.

## Validação

- `tests/unit/npm-publish-artifact-provenance.test.ts` (guard de supply-chain do fast path) pina a seleção de run candidato e o `--name`, não o diretório — **3/3 verdes**
- `check:workflows --ratchet`: zizmor inalterado na baseline (194), YAML válido nos dois arquivos
- Efeito esperado, a confirmar no próximo publish: passo de reuse de ~30 min → ~4 min

Refs #11877
⚠️ base-red inherited: #11866 (`Unit Tests (1/8)` — allowlist da Alibaba, consertada em #11867)
