### PR TITLE
fix(ci): give main's build its own lane on the self-hosted pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,17 @@ jobs:
     # var unset/false) also falls back to ubuntu-latest.
     runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-release"]') || 'ubuntu-latest' }}
     needs: changes
+    # The .113 pool runs ONE next-build with room to spare and two at the edge: the
+    # box has 31 GB and a single next-build peaks at 14–16 GB RSS. On 2026-08-28
+    # 13:50Z the kernel OOM-killed main's build while a PR build ran beside it
+    # (five Build jobs had been queued by a burst of PRs). Two lanes: main keeps
+    # its own so a release is never queued behind PR traffic; PR builds serialize
+    # among themselves. GitHub keeps one running + one pending per group and
+    # CANCELS older pendings — a cancelled PR build is re-runnable; a dead main
+    # build costs the publish its artefact and a 40-minute rebuild that OOMs.
+    concurrency:
+      group: heavy-build-${{ github.ref == 'refs/heads/main' && 'main' || 'pr' }}
+      cancel-in-progress: false
     if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v7

--- a/changelog.d/maintenance/11897-ci-heavy-build-lane.md
+++ b/changelog.d/maintenance/11897-ci-heavy-build-lane.md
@@ -1,0 +1,3 @@
+- The CI `build` job now runs in two concurrency lanes — `main` and pull requests —
+  so a release build is never queued behind (or OOM-killed beside) PR builds on the
+  self-hosted pool, which holds one `next-build` comfortably and two at the edge.


### PR DESCRIPTION
## Problema

A `.113` tem 31 GB e um `next-build` sozinho chega a **14–16 GB de RSS**: um build cabe com folga, dois ficam no limite, três derrubam a caixa. Em 2026-08-28 13:50Z o kernel matou por OOM o `next-build` de **`main`** (15,7 GB) enquanto um build de PR rodava ao lado — **cinco** jobs `Build` tinham sido enfileirados por uma rajada de PRs. Sem artefato, o publish cai no rebuild de 40 min que estoura memória sozinho (tentativa nº 5 desta release).

```
[13:50:41] Out of memory: Killed process 540001 (next-build) anon-rss:15766796kB
           task_memcg=/system.slice/actions.runner.diegosouzapw-OmniRoute.omniroute-113-6.service
[13:50:56] Worker: Step result: Canceled
[13:51:40] systemd: Started actions.runner...omniroute-113-6.service   ← a fome levou o Listener junto
```

## O que muda

`concurrency` **no job `build`**, em duas faixas:

| grupo | quem | efeito |
| --- | --- | --- |
| `heavy-build-main` | pushes em `main` | nunca disputa com PR; uma release nunca fica atrás de tráfego de PR |
| `heavy-build-pr` | pull requests | serializam entre si |

`cancel-in-progress: false` — um build em execução nunca é morto por um mais novo.

## O trade-off, dito claramente

A regra do GitHub por grupo é **1 em execução + 1 pendente; pendentes mais antigos são cancelados**. Numa rajada, o 3º build de PR aparece como "cancelled" e precisa de re-run. Um check de PR cancelado é re-executável; um build de `main` morto custa uma release.

O conserto definitivo continua sendo o **split por label** (`omni-build` em 2 runners, `omni-light` nos demais), que move a fila para o lado do runner sem cancelamentos — decisão de operador, registrada em `docs/ops/RUNNER_BOX.md` (#11893).

## Validação

- YAML válido; `check:workflows --ratchet`: zizmor inalterado (194)
- O próprio CI desta PR roda na faixa `heavy-build-pr`

⚠️ base-red inherited: #11866 (`Unit Tests (1/8)` — allowlist da Alibaba, consertada em #11867)
