### PR TITLE
fix(translator): preserve usage metrics from trailing choices-empty chunks (#11817)

### DIFF
--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -164,22 +164,22 @@ function stopTextBlock(state, results) {
 
 // Convert OpenAI stream chunk to Claude format
 export function openaiToClaudeResponse(chunk, state) {
-  if (!chunk || !chunk.choices?.[0]) return null;
+  if (!chunk && !state.pendingClaudeFinishChoice) return null;
 
   const results = [];
-  const choice = chunk.choices[0];
-  const delta = choice.delta;
+  const chunkUsage = chunk?.usage;
+  const hasChunkUsage = chunkUsage && typeof chunkUsage === "object";
 
   // Track usage from OpenAI chunk if available
-  if (chunk.usage && typeof chunk.usage === "object") {
+  if (hasChunkUsage) {
     const promptTokens =
-      typeof chunk.usage.prompt_tokens === "number" ? chunk.usage.prompt_tokens : 0;
+      typeof chunkUsage.prompt_tokens === "number" ? chunkUsage.prompt_tokens : 0;
     const outputTokens =
-      typeof chunk.usage.completion_tokens === "number" ? chunk.usage.completion_tokens : 0;
+      typeof chunkUsage.completion_tokens === "number" ? chunkUsage.completion_tokens : 0;
 
     // Extract cache tokens from prompt_tokens_details
-    const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens;
-    const cacheCreationTokens = chunk.usage.prompt_tokens_details?.cache_creation_tokens;
+    const cachedTokens = chunkUsage.prompt_tokens_details?.cached_tokens;
+    const cacheCreationTokens = chunkUsage.prompt_tokens_details?.cache_creation_tokens;
     const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
     const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
 
@@ -205,6 +205,13 @@ export function openaiToClaudeResponse(chunk, state) {
     // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
     // No need to add separately as Claude expects total output_tokens
   }
+
+  const chunkChoice = chunk?.choices?.[0];
+  const flushingPendingFinish = !chunkChoice && Boolean(state.pendingClaudeFinishChoice);
+  const choice = chunkChoice || state.pendingClaudeFinishChoice;
+  if (!choice) return null;
+  if (flushingPendingFinish) state.pendingClaudeFinishChoice = null;
+  const delta = choice.delta;
 
   // First chunk - ALWAYS send message_start first
   if (!state.messageStartSent) {
@@ -436,6 +443,11 @@ export function openaiToClaudeResponse(chunk, state) {
   // guard therefore misfired and silently dropped the terminal message_delta/message_stop
   // for Responses→Claude streams (#5828 regression).
   if (choice.finish_reason && !state.claudeFinishEmitted) {
+    if (!hasChunkUsage && !flushingPendingFinish) {
+      state.pendingClaudeFinishChoice = choice;
+      return results.length > 0 ? results : null;
+    }
+
     state.claudeFinishEmitted = true;
     stopThinkingBlock(state, results);
     stopTextBlock(state, results);

--- a/tests/unit/translator/openai-to-claude-trailing-usage.test.ts
+++ b/tests/unit/translator/openai-to-claude-trailing-usage.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { openaiToClaudeResponse } from "../../../open-sse/translator/response/openai-to-claude.ts";
+
+type ClaudeUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+
+type TranslatorState = Record<string, unknown> & {
+  toolCalls: Map<number, unknown>;
+  usage?: ClaudeUsage;
+};
+
+const TRAILING_USAGE = {
+  prompt_tokens: 6103,
+  completion_tokens: 16,
+  total_tokens: 6119,
+  prompt_tokens_details: {
+    cached_tokens: 6000,
+    cache_creation_tokens: 100,
+  },
+};
+
+function createState(): TranslatorState {
+  return { toolCalls: new Map() };
+}
+
+function collectEvents(
+  chunks: Array<Record<string, unknown> | null>,
+  state: TranslatorState
+): Array<Record<string, unknown>> {
+  return chunks.flatMap((chunk) => openaiToClaudeResponse(chunk, state) ?? []);
+}
+
+test("usage-only choices-empty chunk updates Claude usage without emitting a content delta", () => {
+  const state = createState();
+
+  const events = openaiToClaudeResponse(
+    {
+      id: "chatcmpl-11817",
+      model: "accounts/fireworks/models/kimi-k3",
+      choices: [],
+      usage: TRAILING_USAGE,
+    },
+    state
+  );
+
+  assert.equal(events, null);
+  assert.deepEqual(state.usage, {
+    input_tokens: 3,
+    output_tokens: 16,
+    cache_read_input_tokens: 6000,
+    cache_creation_input_tokens: 100,
+  });
+});
+
+test("trailing choices-empty usage completes the stream with real cache accounting", () => {
+  const state = createState();
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-11817",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: { content: "OK" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-11817",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+      {
+        id: "chatcmpl-11817",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [],
+        usage: TRAILING_USAGE,
+      },
+    ],
+    state
+  );
+
+  assert.equal(events[0].type, "message_start");
+  assert.equal(events[1].type, "content_block_start");
+  assert.equal(events[2].type, "content_block_delta");
+  assert.equal(events[2].delta?.text, "OK");
+  assert.equal(events[3].type, "content_block_stop");
+  assert.equal(events[4].type, "message_delta");
+  assert.equal(events[4].delta?.stop_reason, "end_turn");
+  assert.deepEqual(events[4].usage, {
+    input_tokens: 3,
+    output_tokens: 16,
+    cache_read_input_tokens: 6000,
+    cache_creation_input_tokens: 100,
+  });
+  assert.equal(events[5].type, "message_stop");
+  assert.equal(events.length, 6);
+});
+
+test("stream-end flush still emits terminal events when upstream omits usage", () => {
+  const state = createState();
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-11817-no-usage",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: { content: "OK" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-11817-no-usage",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+      null,
+    ],
+    state
+  );
+
+  assert.deepEqual(
+    events.filter((event) => event.type === "message_delta" || event.type === "message_stop"),
+    [
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+      { type: "message_stop" },
+    ]
+  );
+});
+
+test("trailing chunk without choices property updates usage and flushes finish", () => {
+  const state = createState();
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-11817-no-choices-key",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: { content: "Done" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-11817-no-choices-key",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+      {
+        id: "chatcmpl-11817-no-choices-key",
+        model: "accounts/fireworks/models/kimi-k3",
+        usage: TRAILING_USAGE,
+      },
+    ],
+    state
+  );
+
+  const terminalEvents = events.filter(
+    (event) => event.type === "message_delta" || event.type === "message_stop"
+  );
+  assert.deepEqual(terminalEvents, [
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: {
+        input_tokens: 3,
+        output_tokens: 16,
+        cache_read_input_tokens: 6000,
+        cache_creation_input_tokens: 100,
+      },
+    },
+    { type: "message_stop" },
+  ]);
+});
+
+test("trailing choices-empty chunk with tool_calls finish_reason preserves tool_use stop_reason and usage", () => {
+  const state = createState();
+  const events = collectEvents(
+    [
+      {
+        id: "chatcmpl-11817-tool",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_123",
+                  function: { name: "get_weather", arguments: "{\"city\":\"Beijing\"}" },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-11817-tool",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+      },
+      {
+        id: "chatcmpl-11817-tool",
+        model: "accounts/fireworks/models/kimi-k3",
+        choices: [],
+        usage: TRAILING_USAGE,
+      },
+    ],
+    state
+  );
+
+  const terminalEvents = events.filter(
+    (event) => event.type === "message_delta" || event.type === "message_stop"
+  );
+  assert.deepEqual(terminalEvents, [
+    {
+      type: "message_delta",
+      delta: { stop_reason: "tool_use" },
+      usage: {
+        input_tokens: 3,
+        output_tokens: 16,
+        cache_read_input_tokens: 6000,
+        cache_creation_input_tokens: 100,
+      },
+    },
+    { type: "message_stop" },
+  ]);
+});


### PR DESCRIPTION
Fixes #11817. Preserves usage (including cache tokens) from trailing OpenAI chunks with empty choices array in the OpenAI→Claude stream translator. Includes TDD test coverage. ⚠️ base-red inherited: #11449