### PR TITLE
fix(ollama): preserve multi-byte UTF-8 content split across stream chunks

### DIFF
--- a/changelog.d/fixes/11921-ollama-multibyte-utf8-boundary.md
+++ b/changelog.d/fixes/11921-ollama-multibyte-utf8-boundary.md
@@ -1,0 +1,1 @@
+- fix(ollama): preserve multi-byte UTF-8 content split across stream chunks in the Ollama NDJSON transform, which previously corrupted CJK/emoji into U+FFFD (#11921)

--- a/open-sse/utils/ollamaTransform.ts
+++ b/open-sse/utils/ollamaTransform.ts
@@ -19,11 +19,14 @@ export function transformToOllama(response, model) {
   let buffer = "";
   let pendingToolCalls: Record<number, PendingToolCall> = {};
   const completedToolCalls: PendingToolCall[] = [];
+  // Persistent decoder with { stream: true } carries pending bytes between chunks, so a
+  // multi-byte UTF-8 sequence split across network chunks is not corrupted into U+FFFD.
+  const decoder = new TextDecoder();
 
   const transform = new TransformStream(
     {
       transform(chunk, controller) {
-        const text = new TextDecoder().decode(chunk);
+        const text = decoder.decode(chunk, { stream: true });
         buffer += text;
         const lines = buffer.split("\n");
         buffer = lines.pop() || "";

--- a/tests/unit/ollama-transform.test.ts
+++ b/tests/unit/ollama-transform.test.ts
@@ -261,6 +261,52 @@ test("transformToOllama leaves successful non-SSE responses untouched", async ()
   assert.deepEqual(await result.json(), body);
 });
 
+test("transformToOllama preserves multi-byte UTF-8 content split across chunks", async () => {
+  // Content with multi-byte code points (CJK) that upstreams stream in raw byte chunks.
+  const content = "你好世界🌍";
+  const inputSSE =
+    `data: ${JSON.stringify({
+      choices: [{ index: 0, delta: { content }, finish_reason: null }],
+    })}\n` +
+    `data: ${JSON.stringify({
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    })}\n`;
+
+  const bytes = new TextEncoder().encode(inputSSE);
+  // Split at a byte offset that lands INSIDE a multi-byte sequence (a UTF-8 continuation
+  // byte, 0x80–0xBF), so each half ends/starts mid-character.
+  let splitAt = -1;
+  for (let i = 1; i < bytes.length; i++) {
+    if (bytes[i] >= 0x80 && bytes[i] < 0xc0) {
+      splitAt = i;
+      break;
+    }
+  }
+  assert.ok(splitAt > 0, "test fixture should contain a multi-byte sequence to split");
+
+  const inputStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes.slice(0, splitAt));
+      controller.enqueue(bytes.slice(splitAt));
+      controller.close();
+    },
+  });
+
+  const mockResponse = new Response(inputStream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+
+  const text = await transformToOllama(mockResponse, "test-model").text();
+  const lines = text
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+
+  const streamed = lines.map((line) => line.message?.content || "").join("");
+  assert.equal(streamed, content, "streamed content should match the original bytes exactly");
+  assert.ok(!streamed.includes("�"), "must not contain the U+FFFD replacement character");
+});
+
 test("transformToOllama merges multi-chunk numeric tool_call id", async () => {
   const inputSSE = [
     `data: ${JSON.stringify({


### PR DESCRIPTION
## Summary

- The Ollama-compatible streaming transform (`transformToOllama` in `open-sse/utils/ollamaTransform.ts`) decoded every upstream network chunk with a fresh `new TextDecoder().decode(chunk)` and no `{ stream: true }`. A multi-byte UTF-8 character (CJK, emoji) split across a chunk boundary was decoded as two incomplete halves and turned into `U+FFFD` replacement characters in the NDJSON delivered to Ollama-format clients. The line-level `buffer` reassembles split SSE *lines*, but the corruption happens one layer below at byte decode, so it cannot recover it.
- Fixed by hoisting a single persistent `TextDecoder` and decoding with `{ stream: true }`, so pending bytes carry across chunks. This matches the pattern already used by every other streaming transform/executor in `open-sse/` — e.g. `responsesTransformer.ts` (which comments *"persistent decoder with { stream: true } carries pending bytes between chunks"*), `stream.ts`, and the `*-web` executors. `ollamaTransform.ts` was the only streaming transform not doing this.

## Related Issues

- No linked issue — unreported bug found while reviewing the streaming transforms.

## Validation

- [x] Change type: routing (SSE stream transform)
- [x] Focused test: `tests/unit/ollama-transform.test.ts` — the new case fails on the pre-fix code (`'���好世界🌍'`, `AssertionError`) and passes after; full file 10/10 with the fix.
- [ ] `npm run lint` / full unit suite / coverage / build — not run locally (dependencies not installed); CI (#8329) runs them on this PR. The change is a 3-line decoder hoist with no new imports.
- [x] Reconciled with the current active release base (branched from `main` tip `d5dfcff`); focused test rerun afterward.
- [x] Production-code change includes a new automated test in this PR.

## Tests Added Or Updated

- `tests/unit/ollama-transform.test.ts` — new test *"transformToOllama preserves multi-byte UTF-8 content split across chunks"*: splits a CJK+emoji delta at a UTF-8 continuation byte (0x80–0xBF) across two enqueued chunks and asserts exact reassembly with no `U+FFFD`. Verified failing on the pre-fix code and passing after.

## Coverage Notes

- Touches `open-sse/utils/ollamaTransform.ts`; the new test exercises the changed decode path (chunk-boundary reassembly) directly.

## Reviewer Notes

- Behaviour change is limited to byte decoding; SSE line framing, tool-call aggregation, and error/non-SSE passthrough are unchanged.
