### PR TITLE
fix(providers): route OrcaRouter chat requests to /v1/chat/completions

### DIFF
--- a/changelog.d/fixes/11923-orcarouter-baseurl.md
+++ b/changelog.d/fixes/11923-orcarouter-baseurl.md
@@ -1,0 +1,1 @@
+- **fix(providers):** OrcaRouter chat requests now target `/v1/chat/completions` instead of the bare `/v1` API root, fixing the upstream `404 Invalid URL (POST /v1)` ([#11923](https://github.com/diegosouzapw/OmniRoute/pull/11923)).

--- a/open-sse/config/providers/registry/orcarouter/index.ts
+++ b/open-sse/config/providers/registry/orcarouter/index.ts
@@ -13,7 +13,7 @@ export const orcarouterProvider: RegistryEntry = {
   alias: "orcarouter",
   format: "openai",
   executor: "default",
-  baseUrl: "https://api.orcarouter.ai/v1",
+  baseUrl: "https://api.orcarouter.ai/v1/chat/completions",
   authType: "apikey",
   authHeader: "bearer",
   defaultContextLength: 128000,


### PR DESCRIPTION
## Problem

Chat requests routed to the `orcarouter` provider fail with:

    [orcarouter/<model>] [404]: Invalid URL (POST /v1)

## Root cause

The OrcaRouter registry entry set `baseUrl` to the bare API root `https://api.orcarouter.ai/v1`. For this provider (`executor: "default"`, `format: "openai"`), `DefaultExecutor.buildUrl` returns `baseUrl` verbatim (nothing is appended when there is no per-request override and no `urlSuffix`), so chat requests are POSTed to the API root and the upstream rejects them with `404 Invalid URL (POST /v1)`. Every other OpenAI-format registry entry carries the full `/chat/completions` path in `baseUrl`; OrcaRouter was the outlier.

## Fix

```diff
-  baseUrl: "https://api.orcarouter.ai/v1",
+  baseUrl: "https://api.orcarouter.ai/v1/chat/completions",
```

## Verification

- Endpoint probe: `POST https://api.orcarouter.ai/v1` returns `404 Invalid URL (POST /v1)`; `POST https://api.orcarouter.ai/v1/chat/completions` returns `401 Invalid API key` (route exists and accepts the request; only the key is rejected).
- Model discovery is unaffected: the discovery route in `src/app/api/providers/[id]/models/route.ts` strips `/chat/completions` and `/v1` before re-deriving `/v1/models`, so both the old and new `baseUrl` resolve to the same `https://api.orcarouter.ai/v1/models`.
- Full production build (`npm run build`) passes.
