### PR TITLE
fix(guardrails): prevent duplicate prompt-injection-guard log output

### DIFF
--- a/src/lib/guardrails/promptInjection.ts
+++ b/src/lib/guardrails/promptInjection.ts
@@ -111,7 +111,7 @@ function shouldBlock(detections: Detection[], threshold: "low" | "medium" | "hig
 }
 
 function getLogger(options: PromptInjectionGuardrailOptions, context: GuardrailContext) {
-  return options.logger || context.log || console;
+  return options.logger ?? context.log ?? null;
 }
 
 function emitGuardrailLog(

--- a/src/middleware/promptInjectionGuard.ts
+++ b/src/middleware/promptInjectionGuard.ts
@@ -33,7 +33,7 @@ export function createInjectionGuard(options: PromptInjectionGuardrailOptions = 
 
     const decision = evaluatePromptInjection(body, options, {
       disabledGuardrails: resolveDisabledGuardrails({ body }),
-      log: options.logger || console,
+      log: options.logger ?? null,
     });
     return {
       blocked: decision.blocked,


### PR DESCRIPTION
## Problem

`getLogger()` in `src/lib/guardrails/promptInjection.ts` fell back to `console` when no logger was provided:

```ts
// before
return options.logger || context.log || console;
```

`emitGuardrailLog()` checks `if (logger === console)` and fires `console.warn()` directly. Combined with the structured pino log already written by the guardrail registry, every injection guard event produced **two lines**: a plain-text `console.warn` and a pino JSON entry.

The middleware factory in `src/middleware/promptInjectionGuard.ts` had the same issue:

```ts
// before
log: options.logger || console,
```

This passed `console` as `context.log`, so the `||` chain in `getLogger` returned `console` even when `options.logger` was undefined.

## Fix

Return `null` instead of `console` from both sites:

```ts
// promptInjection.ts
return options.logger ?? context.log ?? null;

// promptInjectionGuard.ts
log: options.logger ?? null,
```

With `null`, `emitGuardrailLog()`'s `logger?.[level]` is `undefined`. `typeof undefined !== 'function'` → early return → no plain-text output. The pino JSON from the registry is unaffected.

## Validation

Verified on a live container: after applying the equivalent runtime patch to the compiled chunks, injection guard events produce exactly one pino JSON entry with no `console.warn` duplicate.