### PR TITLE
fix(auth): downgrade expected transient states from warn to debug

### DIFF
--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -1412,7 +1412,7 @@ export async function getProviderCredentials(
             retryAfterHuman: formatRetryAfter(earliest),
           };
         }
-        log.warn("AUTH", `${provider} | ${allConnections.length} accounts found but none active`);
+        log.debug("AUTH", `${provider} | ${allConnections.length} accounts found but none active`);
         allConnections.forEach((c) => {
           log.debug(
             "AUTH",
@@ -1463,7 +1463,7 @@ export async function getProviderCredentials(
         return geminiEnvCredentials;
       }
       invalidateManagedLease(options, "CONNECTION_INELIGIBLE");
-      log.warn("AUTH", `No credentials for ${provider}`);
+      log.debug("AUTH", `No credentials for ${provider}`);
       return null;
     }
 


### PR DESCRIPTION
## Problem

Two `log.warn()` calls in `src/sse/services/auth.ts` fire for normal, recoverable operational states:

| Message | Condition |
|---|---|
| `${provider} \| N accounts found but none active` | All connections are rate-limited; the caller receives `allRateLimited: true` with a `retryAfter` value and handles it. |
| `No credentials for ${provider}` | No active account was found; upstream combo routing or the circuit breaker handles this. |

Both conditions are **expected during normal operation** with many provider connections and produce log noise at the `warn` level (visible by default), especially when rate limits are cycling.

## Fix

Downgrade both calls to `log.debug()`:

```ts
// before
log.warn("AUTH", `${provider} | ${allConnections.length} accounts found but none active`);
log.warn("AUTH", `No credentials for ${provider}`);

// after
log.debug("AUTH", `${provider} | ${allConnections.length} accounts found but none active`);
log.debug("AUTH", `No credentials for ${provider}`);
```

`debug` is the correct level: the surrounding code already handles both cases gracefully and the caller has full context. No information is lost — operators who need to diagnose auth flow can set `APP_LOG_LEVEL=debug`.