### PR TITLE
test(check): escape the runs-on fixture with JSON.stringify (CodeQL #888)

### DIFF
--- a/tests/unit/check-workflows-provenance-runner.test.ts
+++ b/tests/unit/check-workflows-provenance-runner.test.ts
@@ -59,7 +59,7 @@ test("classifyRunsOn: hosted labels are hosted, opaque expressions are unknown (
 test("flags --provenance inside a job routed to the self-hosted pool", () => {
   const found = findProvenanceOnSelfHosted(
     workflow(
-      `"${VPS_EXPR.replace(/"/g, '\\"')}"`,
+      JSON.stringify(VPS_EXPR),
       'npm stage publish --provenance --access public --tag "$TAG"'
     ),
     "npm-publish.yml"


### PR DESCRIPTION
CodeQL flagged `js/incomplete-sanitization` (high) on the fixture helper added in #11895: `VPS_EXPR.replace(/"/g, '\\"')` escapes quotes but not backslashes. `JSON.stringify(VPS_EXPR)` produces the double-quoted YAML scalar with every escape. Test-only; 7/7 pass locally. The same fix reaches `release/v3.8.51` through #11929.