### PR TITLE
chore(quality): re-freeze the ESLint suppressions on release/v3.8.51 from a clean-room run

### DIFF
--- a/changelog.d/maintenance/11924-eslint-refreeze-v3851.md
+++ b/changelog.d/maintenance/11924-eslint-refreeze-v3851.md
@@ -1,0 +1,1 @@
+- Re-freeze the ESLint suppressions on `release/v3.8.51` from a clean-room measurement (2 stale file entries pruned, 55 pre-existing `no-explicit-any` in six new files frozen under #11924) and drop the dead `GPT_SIZE_MAP` constant orphaned by the Adobe Firefly client split, so `No new ESLint warnings` stops failing every PR with exit 2 (Refs #11924)

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -401,11 +401,6 @@
       "count": 3
     }
   },
-  "open-sse/services/adobeFireflyClient.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "open-sse/services/adobeFireflySession.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1
@@ -840,6 +835,11 @@
   "open-sse/utils/setupPolyfill.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5
+    }
+  },
+  "open-sse/utils/socksConnectorWithFamily.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 4
     }
   },
   "open-sse/utils/stream.ts": {
@@ -2564,11 +2564,6 @@
   "src/lib/providers/validation/searchProviders.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1
-    }
-  },
-  "src/lib/providers/validation/webProvidersA.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 2
     }
   },
   "src/lib/providers/validation/webProvidersB.ts": {
@@ -4957,6 +4952,11 @@
       "count": 20
     }
   },
+  "tests/unit/free-models-isfree.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    }
+  },
   "tests/unit/functional-gateway-mirrors-append.test.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1
@@ -5241,6 +5241,11 @@
     },
     "@typescript-eslint/no-unused-vars": {
       "count": 3
+    }
+  },
+  "tests/unit/models-db-isfree.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 18
     }
   },
   "tests/unit/modelsDevSync-extended.test.ts": {
@@ -5540,6 +5545,11 @@
   "tests/unit/provider-validation-specialty.test.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 4
+    }
+  },
+  "tests/unit/providerModelMutationSchema-isfree.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 2
     }
   },
   "tests/unit/providers-route-managed-catalog.test.ts": {
@@ -6009,6 +6019,16 @@
   "tests/unit/skills-skillssh.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 7
+    }
+  },
+  "tests/unit/socks-connect-timeout-e2e.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 11
+    }
+  },
+  "tests/unit/socks-connect-timeout.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 18
     }
   },
   "tests/unit/spend-batch-writer.test.ts": {

--- a/config/quality/quality-baseline.json
+++ b/config/quality/quality-baseline.json
@@ -82,9 +82,10 @@
       "tightenSlack": 10
     },
     "openapiCoverage.pct": {
-      "value": 38.4,
+      "value": 39,
       "direction": "up",
       "eps": 0.5,
+      "_tighten_2026_08_28_v3851_eslint_refreeze": "38.4 -> 39. Aperto EXIGIDO pelo step --require-tighten do job No new ESLint warnings na PR #11955 (release/v3.8.51): assim que o ESLint voltou a medir 0/0, o ratchet passou a cobrar o aperto. 39 = valor medido pelo collect-metrics do CI no run 33213844112 e reproduzido numa sala limpa da ponta 777d9d1629 (clone --depth 1 + npm ci do lockfile). A cobertura melhorou porque as rotas novas do ciclo entraram documentadas em docs/openapi.yaml; nenhuma rota tocada nesta PR. Aperto = gate mais ESTRITO, nunca mascaramento.",
       "_rebaseline_2026_08_21_v3850_cycle_drift": "39.2 -> 38.4. Measured locally and in CI collect-metrics on release/v3.8.50 (260/677 implemented routes documented). Cycle added internal/dashboard routes faster than docs/openapi.yaml; documenting LOCAL_ONLY catch-all and service-management paths in the public spec would be gaming (same class as v3.8.34/v3.8.39/v3.8.47). This PR (#10988) adds 0 API routes.",
       "_tighten_2026_08_06_v3850_sweepreds": "38.0 -> 39.2 (aperto EXIGIDO pelo step 'Require-tighten (blocking)', que estava vermelho em ~60 PRs abertas de release/v3.8.50 — base-red herdado, nao defeito das PRs). A cobertura melhorou no ciclo porque as rotas novas entraram documentadas. 39.2 = valor medido pelo CI Quality Ratchet no run 31088889488; o tip puro 2ddbbc61a6 mede 39.3 localmente (npm run check:openapi-coverage: 247/628 rotas), entao 39.2 e o valor conservador dos dois. Aperto = gate mais ESTRITO, nunca mascaramento.",
       "_tighten_2026_07_04_v3844_release": "36.9 -> 39.3 (aperto exigido pelo --require-tighten no PR de release #5925). A cobertura OpenAPI melhorou no ciclo (9 rotas documentadas em 8fb020676 + as rotas novas de #5939/#5817/#6034/#5998 documentadas junto das features). 39.3 = valor medido pelo CI Quality Ratchet no run 28708141003 (tip 00c55afcb).",

--- a/open-sse/services/adobeFireflyCatalog.ts
+++ b/open-sse/services/adobeFireflyCatalog.ts
@@ -226,45 +226,6 @@ export const NANO_SIZE_MAP: Record<string, Record<string, { width: number; heigh
   },
 };
 
-const GPT_SIZE_MAP: Record<string, Record<string, { width: number; height: number }>> = {
-  "1K": {
-    "1:1": { width: 1024, height: 1024 },
-    "5:4": { width: 1120, height: 896 },
-    "9:16": { width: 720, height: 1280 },
-    "21:9": { width: 1456, height: 624 },
-    "16:9": { width: 1280, height: 720 },
-    "4:3": { width: 1152, height: 864 },
-    "3:2": { width: 1248, height: 832 },
-    "4:5": { width: 896, height: 1120 },
-    "3:4": { width: 864, height: 1152 },
-    "2:3": { width: 832, height: 1248 },
-  },
-  "2K": {
-    "1:1": { width: 2048, height: 2048 },
-    "5:4": { width: 2240, height: 1792 },
-    "9:16": { width: 1440, height: 2560 },
-    "21:9": { width: 3024, height: 1296 },
-    "16:9": { width: 2560, height: 1440 },
-    "4:3": { width: 2304, height: 1728 },
-    "3:2": { width: 2496, height: 1664 },
-    "4:5": { width: 1792, height: 2240 },
-    "3:4": { width: 1728, height: 2304 },
-    "2:3": { width: 1664, height: 2496 },
-  },
-  "4K": {
-    "1:1": { width: 2880, height: 2880 },
-    "5:4": { width: 3200, height: 2560 },
-    "9:16": { width: 2160, height: 3840 },
-    "21:9": { width: 3696, height: 1584 },
-    "16:9": { width: 3840, height: 2160 },
-    "4:3": { width: 3264, height: 2448 },
-    "3:2": { width: 3504, height: 2336 },
-    "4:5": { width: 2560, height: 3200 },
-    "3:4": { width: 2448, height: 3264 },
-    "2:3": { width: 2336, height: 3504 },
-  },
-};
-
 export const PIXEL_SIZE_TO_RATIO: Record<string, string> = {
   "1024x1024": "1:1",
   "1536x1536": "1:1",


### PR DESCRIPTION
## Por que

`No new ESLint warnings` falhava em **toda** PR contra a `release/v3.8.51` com `exit 2` — "There are suppressions left that do not occur anymore". É o último red estrutural da branch depois de #11929, #11940 e #11944.

## Medição (sala limpa, não devbox)

Clone `--depth 1` + `npm ci --ignore-scripts` do lockfile da própria branch + comando exato do job (`npm run lint:json -- --max-warnings 0`): **56 erros** — 55 `@typescript-eslint/no-explicit-any` em 6 arquivos que entraram sob a base vermelha (#11843 isFree: 22; `b7102140d5` socks timeout: 33) + 1 `no-unused-vars` — e entradas obsoletas. O número anterior de #11924 (280, com 224 `react-hooks/*`) era artefato da devbox e foi retirado da issue.

## O que muda

| arquivo | mudança |
| --- | --- |
| `config/quality/eslint-suppressions.json` | `--prune-suppressions` (2 entradas obsoletas removidas) + os 55 `any` pré-existentes congelados nas contagens exatas — ratchet só decresce; dívida rastreada em #11924 |
| `open-sse/services/adobeFireflyCatalog.ts` | remove `GPT_SIZE_MAP`, constante que o split `f3d9279b44` deixou sem leitor (a violação real: corrigida, não congelada) |

## Segunda rodada

Com o ESLint em 0/0, o passo seguinte do mesmo job (`check-quality-ratchet --require-tighten`) passou a cobrar o aperto de `openapiCoverage.pct` 38.4→39 (medido pelo CI no run 33213844112 e reproduzido em sala limpa da ponta `777d9d1629`). Apertado só essa métrica, com a anotação no padrão do arquivo. Branch também mergeada com a ponta atual da `.51` (#11957).

## Validação

Sala limpa depois das duas mudanças, mesmo comando do CI: **exit 0, 0 erros, 0 warnings** (1238 arquivos / 5487 supressões). Esta PR nasce contra a `.51` já com #11929 + #11940 + #11944 mergeadas — serve de prova de que uma PR nova não nasce mais vermelha (exceto #11946).

⚠️ base-red inherited: #11946 (`Fast Production Build`/`dast-smoke` hospedados em OOM)

