### PR TITLE
fix(ci): prevent build OOM in Build App and Docker publish workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,15 @@ jobs:
         run: |
           npm run build:release
         env:
-          NODE_OPTIONS: "--max-old-space-size=12288"
-          OMNIROUTE_BUILD_MEMORY_MB: "12288"
+          # Heap lowered 12288 -> 8192 (v3.8.51, 2026-08-28): --max-old-space-size only
+          # bounds V8's JS heap, never Turbopack's native (Rust) allocation (#6409). A
+          # 12 GB V8 request plus Turbopack's native peak overcommitted the 16 GB
+          # ubuntu-latest runner and the build was canceled mid-step ("The operation was
+          # canceled."). 8192 is the heap the ci.yml build job runs with (the
+          # build-next-isolated.mjs default) and passes consistently; the 10 GB swap
+          # above stays as the safety net for Turbopack's native peak.
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          OMNIROUTE_BUILD_MEMORY_MB: "8192"
           OMNIROUTE_USE_TURBOPACK: "1"
 
       - name: Archive build outputs

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -84,7 +84,7 @@ jobs:
     # the .113's RAM". That premise no longer holds: `Fast Production Build` (build.yml) runs
     # `build:release` — a SUPERSET of this job's `npm run build`, plus the CLI bundle — on plain
     # ubuntu-latest and passed 24/25 of its last runs in ~15 min. What it has and this job did
-    # not is memory PROVISIONING: a 10 GB swapfile plus a 12 GB V8 heap. That matters because
+    # not is memory PROVISIONING: a 10 GB swapfile plus an 8 GB V8 heap. That matters because
     # --max-old-space-size only bounds V8's JS heap, never Turbopack's native (Rust) allocation
     # (#6409) — swap is what absorbs the native peak. Both are mirrored below.
     runs-on: ubuntu-latest
@@ -115,10 +115,12 @@ jobs:
       - run: npm run build
         env:
           OMNIROUTE_USE_TURBOPACK: "1"
-          # Same heap build.yml proves sufficient. build-next-isolated.mjs defaults to 8192 and
-          # honours OMNIROUTE_BUILD_MEMORY_MB; NODE_OPTIONS is set for parity with build.yml.
-          NODE_OPTIONS: "--max-old-space-size=12288"
-          OMNIROUTE_BUILD_MEMORY_MB: "12288"
+          # Heap mirrored from build.yml (12288 -> 8192, v3.8.51 2026-08-28): a 12 GB V8
+          # request plus Turbopack's unbounded native peak overcommitted the 16 GB hosted
+          # runner and canceled the build. 8192 matches the ci.yml build job (the
+          # build-next-isolated.mjs default), which passes consistently.
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          OMNIROUTE_BUILD_MEMORY_MB: "8192"
       # No artifact upload here: the PR-to-release quality workflow has no
       # downstream package/e2e jobs that consume the Next.js build output.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,22 +123,23 @@ RUN --mount=type=cache,id=s/92ca8a61-c1ba-421f-a389-d48ac7258c2d-npm-cache,targe
   && (test -n "$(find node_modules/tls-client-node/bin -mindepth 1 -print -quit 2>/dev/null)" \
       || (echo "tls-client-node native binary missing after postinstall — GitHub API fetch likely rate-limited or failed (#7802)" >&2 && exit 1))
 
-# Build with Turbopack (stable in Next 16, the repo default). The v3.8.27-era
-# TurbopackInternalError panic ("entered unreachable code: there must be a path to a
-# root" in ImportTracer::get_traces) no longer reproduces on Next 16.2.9 — validated
-# 2026-07-05 with clean amd64 (12min14s, image smoke-tested: /api/monitoring/health
-# 200) and arm64 (qemu, exit 0, zero panic strings) builds. Turbopack cut the bare
-# build from 17min to 9min on the same 32-core box. Webpack stays available as the
-# escape hatch: `--build-arg`/-e OMNIROUTE_USE_TURBOPACK=0.
-# See docs/ops/QUALITY_GATE_PLAYBOOK.md Parte 6.
+# Build with Webpack by default. Turbopack (the repo default for local/dev
+# builds) cuts build time ~2x, but its compile runs in native Rust memory that
+# lives OUTSIDE the V8 heap, so --max-old-space-size/OMNIROUTE_BUILD_MEMORY_MB
+# cannot bound it (#6409). On RAM-constrained hosts — including the 16 GB
+# GitHub-hosted runners docker-publish.yml builds on — the Turbopack peak for
+# this module graph OOMs the BuildKit build ("cannot allocate memory" on both
+# linux/amd64 and linux/arm64, v3.8.51, 2026-08-28). Webpack's production pass
+# peaks ~3.9 GB (bounded by the heap below, #4076/#10060) and is the documented
+# fallback for memory-constrained builds (docs/reference/ENVIRONMENT.md).
+# Re-enable Turbopack on hosts with RAM to spare:
+# `--build-arg OMNIROUTE_USE_TURBOPACK=1`.
 #
 # Declared as ARG+ENV, not a bare ENV: a bare ENV shadows any same-named ARG for
-# the rest of the stage, so `--build-arg OMNIROUTE_USE_TURBOPACK=0` was silently
-# ignored and the escape hatch above only ever worked via `-e` at runtime, never
-# at build time. Turbopack compiles in native Rust memory that lives outside the
-# V8 heap, so OMNIROUTE_BUILD_MEMORY_MB cannot bound it and a memory-constrained
-# build host gets SIGKILLed by the cgroup OOM killer with no error message.
-ARG OMNIROUTE_USE_TURBOPACK=1
+# the rest of the stage, so the `--build-arg` escape hatch would be silently
+# ignored (historically it only ever worked via `-e` at runtime, never at build
+# time — #9695).
+ARG OMNIROUTE_USE_TURBOPACK=0
 ENV OMNIROUTE_USE_TURBOPACK="${OMNIROUTE_USE_TURBOPACK}"
 
 # Next.js basePath is fixed at build time; pass OMNIROUTE_BASE_PATH here when the

--- a/tests/unit/build/check-workflows.test.ts
+++ b/tests/unit/build/check-workflows.test.ts
@@ -356,8 +356,8 @@ test("#7307 quality.yml adds an advisory production build for release PR code ch
   // half. Dropping either one puts the hosted build back at risk of an OOM.
   assert.match(buildJob[0], /fallocate -l 10G \/mnt\/swapfile/);
   assert.match(buildJob[0], /swapon \/mnt\/swapfile/);
-  assert.match(buildJob[0], /NODE_OPTIONS: "--max-old-space-size=12288"/);
-  assert.match(buildJob[0], /OMNIROUTE_BUILD_MEMORY_MB: "12288"/);
+  assert.match(buildJob[0], /NODE_OPTIONS: "--max-old-space-size=8192"/);
+  assert.match(buildJob[0], /OMNIROUTE_BUILD_MEMORY_MB: "8192"/);
   assert.match(buildJob[0], /continue-on-error: true/);
   assert.match(buildJob[0], /uses: actions\/checkout@[0-9a-f]{40} # v7/);
   assert.match(buildJob[0], /uses: actions\/setup-node@[0-9a-f]{40} # v7/);


### PR DESCRIPTION
## What

The `release/v3.8.51` CI was red because both heavy build workflows OOM'd on the 16 GB GitHub-hosted runners:

- **Build App** — canceled mid-step ("The operation was canceled.") at `Build Next.js app & CLI bundle` (runs 33211438056, 33211987878).
- **Publish to Docker Hub** — `cannot allocate memory` inside the BuildKit build, on both `linux/amd64` and `linux/arm64` (runs 33211438044, 33211987882).

**Root cause:** the production build uses Turbopack, whose compile runs in native Rust memory that `--max-old-space-size` cannot bound (#6409). A 12 GB V8 heap request (Build App) plus Turbopack's native peak overcommitted the runner; in Docker the unbounded Turbopack peak exhausted the BuildKit build.

## Changes

- `.github/workflows/build.yml` — heap `12288 → 8192`: the same value the `ci.yml` build job runs with (the `build-next-isolated.mjs` default) and passes consistently; the 10 GB swap stays as the native-peak safety net.
- `.github/workflows/quality.yml` — mirrors the heap change in the advisory build.
- `Dockerfile` — builder stage now defaults to **webpack** (`ARG OMNIROUTE_USE_TURBOPACK=0`), whose peak (~3.9 GB) is bounded by `OMNIROUTE_BUILD_MEMORY_MB` (#4076/#10060). Re-enable Turbopack where the host has RAM to spare: `--build-arg OMNIROUTE_USE_TURBOPACK=1`.
- `tests/unit/build/check-workflows.test.ts` — updated the #7307 regression guard to the new heap values.

## Verification

- `tests/unit/build/check-workflows.test.ts`: 32/32 pass (incl. the #7307 guard)
- dockerfile-embed-arg / vps-runner-scope / repro-8542 / quality-rail / bun-support: 16/16 pass
- Prettier + ESLint clean on all changed files

⚠️ base-red inherited: #11874