### PR TITLE
chore(release): sync main into release/v3.8.51 — the four post-release CI/publish commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,12 +606,12 @@ jobs:
     # Dynamic runner: when the release captain flips the USE_VPS_RUNNER repo var to
     # 'true' (scripts/vps/release-runner-up.sh does it after the self-hosted VM is
     # online), the heavy jobs run on the dedicated 32-core VPS runners (label
-    # omni-release) instead of queueing on the 20-concurrent-job hosted pool.
+    # omni-build) instead of queueing on the 20-concurrent-job hosted pool.
     # Safety: fork PRs NEVER reach the self-hosted runner — the expression falls
     # back to ubuntu-latest unless the PR head repo is this repository (push /
     # dispatch events are own-origin by definition). Any failure path (VM down,
     # var unset/false) also falls back to ubuntu-latest.
-    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-release"]') || 'ubuntu-latest' }}
+    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-build"]') || 'ubuntu-latest' }}
     needs: changes
     # The .113 pool runs ONE next-build with room to spare and two at the edge: the
     # box has 31 GB and a single next-build peaks at 14–16 GB RSS. On 2026-08-28

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,14 +657,14 @@ jobs:
         # Keep standalone/node_modules intact: package/electron jobs consume the
         # Next-traced standalone tree and must not replace it with root node_modules.
         run: |
-          tar -czf /tmp/e2e-build.tar.gz \
+          tar -czf "$RUNNER_TEMP/e2e-build.tar.gz" \
             --exclude='.build/next/cache' \
             .build/next
       - name: Upload Next.js build for downstream jobs
         uses: actions/upload-artifact@v7
         with:
           name: next-build
-          path: /tmp/e2e-build.tar.gz
+          path: ${{ runner.temp }}/e2e-build.tar.gz
           retention-days: 1
 
   package-artifact:
@@ -687,10 +687,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: /tmp/
+          # Workspace-relative on purpose: the matrix below includes windows-latest, whose
+          # default shell is pwsh, where $RUNNER_TEMP is empty (it is $env:RUNNER_TEMP) —
+          # #11896's first cut broke the Electron smoke on exactly that. A relative path
+          # works in bash and pwsh alike; hosted workspaces are ephemeral.
+          path: next-build-artifact
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf /tmp/e2e-build.tar.gz
+          tar -xzf next-build-artifact/e2e-build.tar.gz
       # build:cli consumes the downloaded .build/next standalone artifact and assembles dist/;
       # it only rebuilds if the downloaded standalone artifact is missing.
       - run: npm run build:cli
@@ -778,10 +782,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: /tmp/
+          # Workspace-relative on purpose: the matrix below includes windows-latest, whose
+          # default shell is pwsh, where $RUNNER_TEMP is empty (it is $env:RUNNER_TEMP) —
+          # #11896's first cut broke the Electron smoke on exactly that. A relative path
+          # works in bash and pwsh alike; hosted workspaces are ephemeral.
+          path: next-build-artifact
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf /tmp/e2e-build.tar.gz
+          tar -xzf next-build-artifact/e2e-build.tar.gz
       - name: Install Electron dependencies
         working-directory: electron
         run: npm install --no-audit --no-fund
@@ -1241,10 +1249,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: next-build
-          path: /tmp/
+          # Workspace-relative on purpose: the matrix below includes windows-latest, whose
+          # default shell is pwsh, where $RUNNER_TEMP is empty (it is $env:RUNNER_TEMP) —
+          # #11896's first cut broke the Electron smoke on exactly that. A relative path
+          # works in bash and pwsh alike; hosted workspaces are ephemeral.
+          path: next-build-artifact
       - name: Extract Next.js build artifact
         run: |
-          tar -xzf /tmp/e2e-build.tar.gz
+          tar -xzf next-build-artifact/e2e-build.tar.gz
       # WS4.1: duration-balanced shards (LPT over config/quality/e2e-timings.json).
       # Measured skew of plain --shard was 14× (24m47s vs 1m47s) — E2E was the CI
       # critical path. The balancer self-verifies completeness and exits non-zero on

--- a/.github/workflows/nightly-release-green.yml
+++ b/.github/workflows/nightly-release-green.yml
@@ -68,7 +68,7 @@ jobs:
     # this runs on the dedicated VPS runner — clean env (no operator OMNIROUTE_API_KEY,
     # no local noauth CLIs => zero machine-specific false positives) and no contention.
     # Nightly cron normally finds the var false (VM off) and falls back to hosted.
-    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && fromJSON('["self-hosted","omni-release"]')) || 'ubuntu-latest' }}
+    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && fromJSON('["self-hosted","omni-build"]')) || 'ubuntu-latest' }}
     env:
       JWT_SECRET: ci-nightly-secret-with-sufficient-length-for-validation
       API_KEY_SECRET: ci-nightly-api-key-secret-long
@@ -217,7 +217,7 @@ jobs:
     # On a push, only run for a push to main — a push to release/* is handled by
     # release-green above. Schedule/dispatch always run (they also sweep main).
     if: ${{ github.event_name != 'push' || github.ref_name == 'main' }}
-    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && fromJSON('["self-hosted","omni-release"]')) || 'ubuntu-latest' }}
+    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && fromJSON('["self-hosted","omni-build"]')) || 'ubuntu-latest' }}
     env:
       JWT_SECRET: ci-nightly-secret-with-sufficient-length-for-validation
       API_KEY_SECRET: ci-nightly-api-key-secret-long

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -204,8 +204,11 @@ jobs:
             exit 0
           fi
           RUN=""
+          # $RUNNER_TEMP, never /tmp: on the .113 pool /tmp is a 12 GB tmpfs (RAM). Parking
+          # this 1.3 GB artefact there took 27–32 min of the 76-min publish job — the
+          # same bytes upload from disk in 2 min. RUNNER_TEMP is per-runner and on disk.
           for candidate in $CANDIDATES; do
-            if gh run download "$candidate" --repo "$REPO" --name next-build --dir /tmp/next-build 2>/dev/null; then
+            if gh run download "$candidate" --repo "$REPO" --name next-build --dir "$RUNNER_TEMP/next-build" 2>/dev/null; then
               RUN="$candidate"
               break
             fi
@@ -215,8 +218,8 @@ jobs:
             echo "::notice::none of the candidate runs still carries next-build (1-day retention) — falling back to a full build"
             exit 0
           fi
-          tar -xzf /tmp/next-build/e2e-build.tar.gz -C .
-          rm -rf /tmp/next-build
+          tar -xzf "$RUNNER_TEMP/next-build/e2e-build.tar.gz" -C .
+          rm -rf "$RUNNER_TEMP/next-build"
           if [ -f .build/next/standalone/server.js ]; then
             echo "✅ standalone tree restored from CI run $RUN — build:cli will skip next build"
           else

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,11 +23,12 @@ on:
           - next
           - historic
       publish_mode:
-        description: "staged = npm stage publish (owner approves with 2FA after the staged boot-verify); direct = legacy immediate publish (emergency fallback only)"
+        description: "auto = publish through npm Trusted Publishing (OIDC, no token, no 2FA prompt — the default); staged = npm stage publish (owner approves with 2FA); direct = legacy token publish (emergency fallback only)"
         required: false
-        default: "staged"
+        default: "auto"
         type: choice
         options:
+          - auto
           - staged
           - direct
   workflow_call:
@@ -407,8 +408,34 @@ jobs:
           fi
           npm --version
 
+      # Trusted Publishing (OIDC): npm mints a short-lived credential for THIS run from
+      # GitHub's id-token — no NPM_TOKEN secret, no 2FA prompt, provenance included, and
+      # it is the bypass npm sanctions now that tokens which skip 2FA are being retired
+      # (gh.io/npm-gat-bypass2fa-deprecation). Requires the package's Trusted Publisher to
+      # be configured on npmjs.com (owner: diegosouzapw/OmniRoute, workflow
+      # npm-publish.yml) and a github-hosted runner — which is why this job exists.
+      # Without that configuration `npm publish` fails with ENEEDAUTH: re-dispatch with
+      # publish_mode=staged or direct. Automatic publishing was the flow up to v3.8.48;
+      # v3.8.49 moved to staged (WS1.3) to keep a leaked token from publishing alone —
+      # OIDC gives the same guarantee without the manual approve.
+      - name: Publish to npm (Trusted Publishing / OIDC — automatic)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish_mode == 'auto'
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
+          TAG: ${{ needs.publish.outputs.tag }}
+        run: |
+          set -euo pipefail
+          TARBALL="omniroute-${VERSION}.tgz"
+          test -f "$TARBALL" || { echo "tarball $TARBALL did not arrive from the publish job" >&2; ls -la; exit 1; }
+          # Deliberately NO NODE_AUTH_TOKEN in this step: npm >= 11.5 detects the GitHub
+          # OIDC token itself. Always pass --tag explicitly (defense in depth: an older
+          # VERSION can never claim `@latest`).
+          npm publish "$TARBALL" --provenance --access public --tag "$TAG" --ignore-scripts
+          echo "✅ Published omniroute@$VERSION (dist-tag=$TAG) via Trusted Publishing"
+
       - name: Publish to npm (staged — owner approves with 2FA)
-        if: github.event_name != 'workflow_dispatch' || inputs.publish_mode != 'direct'
+        # Only on an explicit request now: Trusted Publishing below is the default.
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_mode == 'staged'
         env:
           VERSION: ${{ needs.publish.outputs.version }}
           TAG: ${{ needs.publish.outputs.tag }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,7 +62,7 @@ jobs:
     # mid-"Creating an optimized production build" while v3.8.48 had still fit in 16min.
     # This job never runs on `pull_request`, so the fork-safety clause is always true here;
     # it is kept verbatim so the expression stays greppable against ci.yml.
-    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-release"]') || 'ubuntu-latest' }}
+    runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-build"]') || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.resolve.outputs.version }}
       tag: ${{ steps.resolve.outputs.tag }}

--- a/changelog.d/features/npm-trusted-publishing-oidc.md
+++ b/changelog.d/features/npm-trusted-publishing-oidc.md
@@ -1,0 +1,4 @@
+- The npm publish is automatic again, through npm Trusted Publishing (OIDC): the hosted
+  `stage-npm` job publishes with a short-lived credential minted from GitHub's id-token —
+  no `NPM_TOKEN`, no 2FA prompt, provenance attached. `publish_mode=staged` (owner
+  approves with 2FA) and `direct` (token) remain available on `workflow_dispatch`.

--- a/changelog.d/maintenance/11896-ci-artifact-download-to-disk.md
+++ b/changelog.d/maintenance/11896-ci-artifact-download-to-disk.md
@@ -1,0 +1,5 @@
+- The `next-build` artefact (1.3 GB) is now written and read under `$RUNNER_TEMP`
+  (per-runner, on disk) instead of `/tmp`, which on the self-hosted pool is a
+  12 GB tmpfs in RAM. Landing it there took 27–32 of the publish job's 76 minutes,
+  and the fixed `/tmp/e2e-build.tar.gz` name let E2E jobs on different runners
+  overwrite each other's download.

--- a/changelog.d/maintenance/ci-omni-build-runner-label.md
+++ b/changelog.d/maintenance/ci-omni-build-runner-label.md
@@ -1,0 +1,4 @@
+- Every CI job that runs a `next build` (`build`, the npm `publish`, both release-green
+  validations) now targets the `omni-build` runner label, which only two of the eight
+  self-hosted runners carry. The box holds one build comfortably and two at the edge; a
+  third now queues on GitHub instead of being OOM-killed by the kernel.

--- a/docs/ops/RELEASE_CHECKLIST.md
+++ b/docs/ops/RELEASE_CHECKLIST.md
@@ -1,12 +1,12 @@
 ---
 title: "Release Checklist"
-version: 3.8.40
-lastUpdated: 2026-06-28
+version: 3.8.51
+lastUpdated: 2026-08-28
 ---
 
 # Release Checklist
 
-> **Last updated:** 2026-06-28 — v3.8.40
+> **Last updated:** 2026-08-28 — v3.8.51
 > Streamlined release flow that leverages Claude Code skills for automation.
 >
 > **Keep the queue/branch green between releases:** see [RELEASE_GREEN.md](./RELEASE_GREEN.md)
@@ -37,7 +37,21 @@ npm run test:e2e           # optional but recommended
 /capture-release-evidences-cc
 ```
 
-## npm Staged Publishing (default since v3.8.49 — WS1.3/D2)
+## npm Trusted Publishing (default since v3.8.51) — staged on request, direct as fallback
+
+`npm-publish.yml` publishes through **npm Trusted Publishing (OIDC)** by default: the
+`stage-npm` job (github-hosted) exchanges GitHub's id-token for a short-lived npm
+credential for that run — no long-lived npm token in the repository secrets, no 2FA prompt, provenance attached.
+That is the bypass npm sanctions now that tokens which skip 2FA are being retired;
+it restores the fully automatic flow the project had up to v3.8.48 while keeping the
+WS1.3 guarantee (a leaked token cannot publish alone — there is no token).
+
+**One-time setup (owner):** npmjs.com → package `omniroute` → Settings → *Trusted
+Publisher* → GitHub: owner `diegosouzapw`, repo `OmniRoute`, workflow `npm-publish.yml`
+(environment: none). Until that exists, the automatic step fails with `ENEEDAUTH`:
+re-dispatch with `publish_mode=staged` (below) or `direct`.
+
+### Staged publishing (on request — `publish_mode=staged`)
 
 The npm-publish workflow no longer publishes directly: it boots the packed tarball
 (`check:pack-boot`) and then runs `npm stage publish` — the exact bytes are parked on

--- a/docs/ops/RUNNER_BOX.md
+++ b/docs/ops/RUNNER_BOX.md
@@ -4,7 +4,7 @@ title: Self-Hosted Runner Box Operations
 
 # Self-Hosted Runner Box Operations (.113 pool)
 
-The self-hosted pool (`self-hosted, omni-release` labels) runs on the **.113** box.
+The self-hosted pool (`self-hosted, omni-release` on all eight runners; `omni-build` on two) runs on the **.113** box.
 Measured 2026-08-28 (v3.8.50 postmortem, Parte III):
 
 | resource  | value                                                            | what it means for scheduling                                                                                                                  |
@@ -49,10 +49,14 @@ a time, only when idle**, with the idle check and the restart in the same comman
 
 ## Operating rules
 
-- **Heavy-build ceiling: 2 at a time.** The listener ceiling (`MAX_ACTIVE_RUNNERS=8`
-  in cron) is a proxy until jobs are split by label — `omni-build` on 2 runners for
-  Build/publish/heavy shards, `omni-light` on the rest — which is an operator
-  decision, not something cron should enforce by killing listeners.
+- **Heavy-build ceiling: 2 at a time — enforced by label.** Every job that runs a
+  `next build` (`ci.yml` `build`, `npm-publish.yml` `publish`, both `nightly-release-green`
+  validations) targets `[self-hosted, omni-build]`, and only **two** runners carry that
+  label (`omniroute-113-5`, `omniroute-113-6`, added through the runners API — no
+  re-registration). The other six keep `omni-release` and take nothing heavy; GitHub
+  queues a third build instead of the kernel killing one. Pair with the `heavy-build-*`
+  concurrency lanes in `ci.yml`. To add capacity, label another runner — never raise
+  the count past what 31 GB holds (one next-build ≈ 14–16 GB).
 - **Never clean `/tmp` or `_work` by hand while any runner is busy.** A
   check-then-delete with a gap between the two is how a live Build job lost its
   `_work` on 2026-08-27. The janitor does the check and the removal in one step;

--- a/tests/unit/check-workflows-provenance-runner.test.ts
+++ b/tests/unit/check-workflows-provenance-runner.test.ts
@@ -59,7 +59,7 @@ test("classifyRunsOn: hosted labels are hosted, opaque expressions are unknown (
 test("flags --provenance inside a job routed to the self-hosted pool", () => {
   const found = findProvenanceOnSelfHosted(
     workflow(
-      `"${VPS_EXPR.replace(/"/g, '\\"')}"`,
+      JSON.stringify(VPS_EXPR),
       'npm stage publish --provenance --access public --tag "$TAG"'
     ),
     "npm-publish.yml"

--- a/tests/unit/openai-to-claude-trailing-usage-deferred-finish.test.ts
+++ b/tests/unit/openai-to-claude-trailing-usage-deferred-finish.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { openaiToClaudeResponse } from "../../../open-sse/translator/response/openai-to-claude.ts";
+import { openaiToClaudeResponse } from "../../open-sse/translator/response/openai-to-claude.ts";
 
 type ClaudeUsage = {
   input_tokens: number;


### PR DESCRIPTION
## O que traz

Os 4 commits que entraram na `main` depois do sync-back da v3.8.50 (todos desta sessão, já verdes lá com `Build` completo):

| commit | PR | conteúdo |
| --- | --- | --- |
| `5b38ec717d` | #11896 | artefato do `next-build` no disco do runner, não no tmpfs |
| `f907b5ea8e` | #11932 | builds pesados limitados a 2 runners (`omni-build`) |
| `226538fa27` | #11931 | publicação no npm via Trusted Publishing (OIDC) por padrão |
| `24c0643a94` | #11942 | escape do fixture no teste de proveniência (CodeQL #888) — já estava na `.51` via #11929; merge sem delta |

Merge limpo (8 arquivos: 3 workflows, 2 docs de ops, 3 fragmentos de changelog). `check:workflows --ratchet` sem regressão (230 findings idênticos aos da ponta), `provenanceRunnerFindings=0`, teste do provenance-runner 7/7, `docs-sync` PASS.

## Também nesta PR

`777d9d1629` — conserto do import relativo do teste que #11940 relocou (`tests/unit/openai-to-claude-trailing-usage-deferred-finish.test.ts`): ficou um nível errado e o arquivo falhava ao carregar, pintando `Unit Tests fast-path (3/4)` em toda PR desde `a94fe23e89`. 5/5 local.

## Como entra

Por **fast-forward push** (como #11929), não por squash — squash quebraria `main ⊂ release/v3.8.51` e o próximo sync-back voltaria a conflitar em centenas de arquivos. O GitHub marca a PR como merged sozinho.

⚠️ base-red inherited: #11946 (`Fast Production Build`/`dast-smoke` hospedados em OOM)

