### PR TITLE
docs(agents): sync-back landings are fast-forward, never squash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,6 +594,18 @@ inside your feature branch (a base-red fix is its own freeze-gated `fix/release-
 PR); and if you must open a PR anyway, add `⚠️ base-red inherited: #<issue>` to the PR body so
 reviewers and CI babysitters do not chase ghosts.
 
+### Sync-back landings are fast-forward, never squash
+
+A `main → release/vX+1` sync-back (Phase 5 of `/generate-release`, or any later "bring main's
+post-release commits over" PR) must reach the release branch as the merge commit it already is:
+`git merge-base --is-ancestor origin/release/vX+1 <head>` then
+`git push origin <head>:refs/heads/release/vX+1` (GitHub marks the PR merged). Squash-merging it
+drops `main` from the release branch's ancestry and the next sync-back re-conflicts on every file
+main touched (551 conflicts on the v3.8.50 → v3.8.51 sync before the two-step merge). After
+landing, `git merge-base --is-ancestor origin/main origin/release/vX+1` must be true — and check
+that `config/quality/eslint-suppressions.json` / `quality-baseline.json` carried main's freezes
+(they merge as "ours" silently). Details: `.agents/skills/generate-release/phases/phase-5-next-cycle.md`.
+
 ---
 
 ## Upstream contributions


### PR DESCRIPTION
Regra nova em `AGENTS.md` → Git Workflow, logo após o *Base-green check*: um sync `main → release/vX+1` entra por **fast-forward push**, nunca squash — squash tira a `main` da ancestralidade da release e o próximo sync-back reconflita em todo arquivo que a `main` tocou (551 conflitos neste ciclo antes do merge em duas etapas). Inclui os 2 checks pós-pouso (assert de ancestralidade; arquivos de ratchet carregaram os congelamentos da `main` — eles mergeiam como `ours` em silêncio).

O procedimento completo e as quatro verificações baratas antes de rotular um vermelho (`runner_name`, checkout raso, shard travado, lint só em sala limpa) foram para as skills (`.agents`, repo próprio: `generate-release/phases/phase-5-next-cycle.md` e `_shared/merge-gates.md` §3, commit `8650fe1`).

Só documentação; `check:docs-sync` e `check:fabricated-docs` verdes localmente.

⚠️ base-red inherited: #11946 (até a #11962 entrar)