### PR TITLE
fix(ci): stop a stalled Codecov upload from cancelling the Coverage job and the main run (twin of #11972)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -976,7 +976,11 @@ jobs:
     # 10min was sized before #7114 added the lcov reporter (Codecov/Sonar need it);
     # merging 8 shard JSONs + text+json+lcov now takes ~10-12min — three consecutive
     # release-tip runs died at exactly 10m as job-timeout "cancelled" (2026-07-15/16).
-    timeout-minutes: 20
+    # 30, not 20 (2026-08-29): the informational Codecov upload below hung for the rest of
+    # the budget on two consecutive main runs (33207760653, 33215115341); the job ended
+    # `cancelled` and dragged the whole run's conclusion to `cancelled` although every
+    # blocking job was green. The upload step now has its own ceiling; this is headroom.
+    timeout-minutes: 30
     needs: test-unit
     if: ${{ !cancelled() && needs.test-unit.result == 'success' && !contains(github.event.pull_request.labels.*.name, 'hotfix') }}
     env:
@@ -1055,6 +1059,10 @@ jobs:
       # (if-no-files-found: warn) — Sonar consumes the same file.
       - name: Upload coverage to Codecov (informational)
         if: always()
+        # Informational means informational: its own ceiling and continue-on-error, so a
+        # stalled upload can neither eat the job's budget nor turn a green job cancelled.
+        timeout-minutes: 5
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage/lcov.info

--- a/changelog.d/maintenance/ci-coverage-codecov-step-timeout.md
+++ b/changelog.d/maintenance/ci-coverage-codecov-step-timeout.md
@@ -1,0 +1,1 @@
+- `Coverage` job on `ci.yml`: the informational Codecov upload gets its own 5-minute ceiling and `continue-on-error`, and the job budget grows from 20 to 30 minutes (the 8-shard c8 merge alone takes ~10) — a stalled upload no longer ends the job `cancelled` and drags a fully green `main` run's conclusion down with it


### PR DESCRIPTION
Gêmeo na `main` da #11972 (já mergeada na `release/v3.8.51`, 17/17): o job `Coverage` tinha teto de 20 min, o merge c8 de 8 shards leva ~10 e o upload informativo ao Codecov travava o resto do orçamento nos 2 últimos runs da `main` (33207760653, 33215115341) — job `cancelled` e a conclusão do run inteiro `cancelled` com tudo verde.

- passo do Codecov: `timeout-minutes: 5` + `continue-on-error: true`;
- job: `timeout-minutes: 30`.

Mesmo diff validado pelo CI da #11972; prettier e actionlint limpos aqui.