### PR TITLE
fix(codex): keep parallel_tool_calls:false on translated Responses Lite path (#11707)

### DIFF
--- a/changelog.d/fixes/11707-codex-responses-lite-parallel-tool-calls.md
+++ b/changelog.d/fixes/11707-codex-responses-lite-parallel-tool-calls.md
@@ -1,0 +1,1 @@
+- fix(codex): keep `parallel_tool_calls:false` on the translated Codex Responses Lite path (#11707)

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -1478,6 +1478,11 @@ export class CodexExecutor extends BaseExecutor {
       "client_metadata",
       // GPT-5 output verbosity ({ verbosity } — normalized above by normalizeCodexVerbosity).
       "text",
+      // Responses Lite (#7171/#7821/#11707): enforceCodexResponsesLiteParallelToolCalls()
+      // forces this field on the translated (non-_nativeCodexPassthrough) path too — it
+      // must survive this allowlist filter or upstream rejects with "X-OpenAI-Internal-
+      // Codex-Responses-Lite requires `parallel_tool_calls` to be false."
+      "parallel_tool_calls",
       // Internal markers used by OmniRoute pipeline
       "_omnirouteResponsesStore",
     ]);

--- a/tests/unit/executor-codex-responses-lite-translated-path.test.ts
+++ b/tests/unit/executor-codex-responses-lite-translated-path.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.ts";
+
+// Issue #11707: "X-OpenAI-Internal-Codex-Responses-Lite requires parallel_tool_calls
+// to be false" persists even though #7171/#7821 already force
+// parallel_tool_calls:false in enforceCodexResponsesLiteParallelToolCalls() at the
+// top of CodexExecutor.execute().
+//
+// Root cause: that enforcement result flows into transformRequest(), which early-
+// returns the body BEFORE field filtering only when `_nativeCodexPassthrough` is
+// true (client sent native Responses-API-shaped input straight through). For any
+// request that reaches the codex executor via the TRANSLATED path (client format
+// is not the native Responses API — e.g. Chat Completions shaped input translated
+// by chatCore for the codex provider), `_nativeCodexPassthrough` is never set, so
+// transformRequest() falls through to the RESPONSES_API_ALLOWLIST loop — and that
+// allowlist did not include "parallel_tool_calls", so the very value
+// enforceCodexResponsesLiteParallelToolCalls() just forced to `false` gets
+// silently deleted again right before the fetch body is serialized.
+//
+// This reproduces with any model — matching the reporter's "every model I select
+// fails" — because the deletion is unconditional on the translated path.
+
+async function runLiteRequest(body: Record<string, unknown>): Promise<Record<string, unknown>[]> {
+  const executor = new CodexExecutor();
+  const originalFetch = globalThis.fetch;
+  const capturedBodies: Record<string, unknown>[] = [];
+
+  globalThis.fetch = async (_url, init) => {
+    capturedBodies.push(JSON.parse(String(init?.body || "{}")));
+    return new Response(JSON.stringify({ id: "resp_lite", object: "response" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    await executor.execute({
+      model: String(body.model),
+      body,
+      stream: true,
+      credentials: { accessToken: "codex-token" },
+      clientHeaders: { "X-OpenAI-Internal-Codex-Responses-Lite": "true" },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  return capturedBodies;
+}
+
+test("#11707: Responses Lite parallel_tool_calls:false survives the TRANSLATED (non-native-passthrough) codex path", async () => {
+  // No `_nativeCodexPassthrough` marker — this is how a request arrives when the
+  // client's own format isn't detected as native OpenAI Responses (e.g. a
+  // manually configured Codex client sending Chat-Completions-shaped input, or
+  // any other translated path chatCore routes into the codex provider).
+  const body = {
+    model: "gpt-5",
+    messages: [{ role: "user", content: "hi" }],
+  };
+
+  const capturedBodies = await runLiteRequest(body);
+
+  assert.equal(
+    capturedBodies[0].parallel_tool_calls,
+    false,
+    "Responses Lite must force parallel_tool_calls:false on the outbound Codex " +
+      "request even when the request took the translated (non-passthrough) path " +
+      "through transformRequest()'s RESPONSES_API_ALLOWLIST filter — otherwise " +
+      "upstream rejects with 'X-OpenAI-Internal-Codex-Responses-Lite requires " +
+      "`parallel_tool_calls` to be false.' (#11707)"
+  );
+});

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -273,7 +273,6 @@ test("CodexExecutor.transformRequest non-passthrough allowlist strips all residu
     function_call: "auto",
     functions: [{ name: "test", parameters: {} }],
     max_completion_tokens: 1000,
-    parallel_tool_calls: true,
     user: "cursor-user",
     metadata: { key: "value" },
     stream_options: { include_usage: true },
@@ -310,7 +309,6 @@ test("CodexExecutor.transformRequest non-passthrough allowlist strips all residu
   assert.equal(result.function_call, undefined, "function_call should be stripped");
   assert.equal(result.functions, undefined, "functions should be stripped");
   assert.equal(result.max_completion_tokens, undefined, "max_completion_tokens should be stripped");
-  assert.equal(result.parallel_tool_calls, undefined, "parallel_tool_calls should be stripped");
   assert.equal(result.user, undefined, "user should be stripped");
   assert.equal(result.metadata, undefined, "metadata should be stripped");
   assert.equal(result.stream_options, undefined, "stream_options should be stripped");


### PR DESCRIPTION
Closes #11707

## Root cause

`enforceCodexResponsesLiteParallelToolCalls()` correctly forces `parallel_tool_calls: false` at the top of `CodexExecutor.execute()` when a client's request carries the `X-OpenAI-Internal-Codex-Responses-Lite` header. That forced value then flows into `transformRequest()`, which only skips its field filter (`RESPONSES_API_ALLOWLIST`) when `body._nativeCodexPassthrough === true` — i.e. only when the client's own request was detected as native OpenAI Responses-API-shaped input. Any request that reaches the codex executor via the **translated** path (e.g. a manually configured client sending Chat-Completions-shaped input) never gets that flag, so `transformRequest()` falls through to the allowlist filter, which did not include `"parallel_tool_calls"` — silently deleting the value that was just forced to `false`, right before the request is sent to `chatgpt.com/backend-api/codex/responses`. This reproduced the exact reported upstream rejection ("X-OpenAI-Internal-Codex-Responses-Lite requires `parallel_tool_calls` to be false") for every model, since the deletion was unconditional on the translated path.

## Fix

Add `"parallel_tool_calls"` to `RESPONSES_API_ALLOWLIST` in `open-sse/executors/codex.ts` so the field survives the translated path too (it was already forwarded unfiltered on the native-passthrough path).

## Regression test

New: `tests/unit/executor-codex-responses-lite-translated-path.test.ts` — reproduces the translated (non-`_nativeCodexPassthrough`) path and asserts the outbound Codex request body carries `parallel_tool_calls: false`. Confirmed RED against unfixed code, GREEN after the fix.

Also updated `tests/unit/executor-codex.test.ts` (`#2608` allowlist test): it previously asserted `parallel_tool_calls` gets stripped alongside genuine Chat-Completions-only fields (temperature, top_p, etc.) — that assertion encoded the bug. `parallel_tool_calls` is a legitimate Responses API field (already forwarded on the native-passthrough path) so it must now survive the filter; the test body/assertions were aligned to that corrected contract.

## Gates run (all green)

- `node --import tsx/esm --test tests/unit/executor-codex-responses-lite-translated-path.test.ts tests/unit/executor-codex.test.ts tests/unit/executor-codex-gpt56.test.ts tests/unit/executor-codex-gpt56-lite-ultra.test.ts` — 55/55 pass
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2672 violations, baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1192 violations, baseline 1223)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/executors/codex.ts tests/unit/executor-codex.test.ts tests/unit/executor-codex-responses-lite-translated-path.test.ts` — exit 0

Diff is scoped to the allowlist fix, the new regression test, the corrected sibling assertion, and the changelog fragment.