### PR TITLE
fix(sse): set X-OmniRoute-Selected-Connection-Id on successful combo dispatches (#11810)

### DIFF
--- a/changelog.d/fixes/11810-combo-success-connection-header.md
+++ b/changelog.d/fixes/11810-combo-success-connection-header.md
@@ -1,0 +1,1 @@
+- fix(sse): set X-OmniRoute-Selected-Connection-Id on successful combo dispatches so downstream consumers stop falling back to an empty connection id (#11810)

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1913,11 +1913,15 @@ async function handleSingleModelChat(
         }
         if (telemetry) telemetry.startPhase("finalize");
         if (telemetry) telemetry.endPhase();
+        const successResponse = withSelectedConnectionHeader(
+          result.response,
+          credentials?.connectionId
+        );
         if (requestBody.stream === true) {
-          return wrapResponseWithOAuthSessionRelease(result.response, releaseOAuthSession);
+          return wrapResponseWithOAuthSessionRelease(successResponse, releaseOAuthSession);
         }
         releaseOAuthSession();
-        return result.response;
+        return successResponse;
       }
 
       // A final hard-lease fence rejection is authoritative. It must never mutate

--- a/tests/unit/combo-success-selected-connection-header-11810.test.ts
+++ b/tests/unit/combo-success-selected-connection-header-11810.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression test for #11810.
+ *
+ * On a successful provider dispatch, `handleSingleModelChat()`'s
+ * `result.success` branch in `src/sse/handlers/chat.ts` used to return
+ * `result.response` (non-streaming) or
+ * `wrapResponseWithOAuthSessionRelease(result.response, releaseOAuthSession)`
+ * (streaming) directly, without first calling `withSelectedConnectionHeader()`
+ * — unlike every failure exit in the same function, which does call it.
+ *
+ * As a result `X-OmniRoute-Selected-Connection-Id` was absent on every
+ * successful response for a dynamically-selected (unpinned) connection, so
+ * combo.ts's consumers (success-decay, provider cooldown recovery, webhook
+ * attribution, session stickiness, LKGP) fell back to the target's static
+ * `connectionId`, which is empty for provider-level combo targets like
+ * `openai/o3-mini`.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createChatPipelineHarness } from "../integration/_chatPipelineHarness.ts";
+
+const harness = await createChatPipelineHarness("combo-success-sel-conn-11810");
+const { buildOpenAIResponse, buildRequest, combosDb, handleChat, resetStorage, seedConnection } =
+  harness;
+
+const textEncoder = new TextEncoder();
+
+function buildOpenAIStreamResponse(text = "hello streamed") {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          textEncoder.encode(
+            `data: ${JSON.stringify({
+              id: "chatcmpl_stream_11810",
+              object: "chat.completion.chunk",
+              created: 1,
+              model: "o3-mini",
+              choices: [{ index: 0, delta: { role: "assistant", content: text } }],
+            })}\n\n`
+          )
+        );
+        controller.enqueue(textEncoder.encode(`data: [DONE]\n\n`));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.afterEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  await harness.cleanup();
+});
+
+test("#11810 combo success response carries X-OmniRoute-Selected-Connection-Id for a dynamically selected connection", async () => {
+  const connection = await seedConnection("openai", {
+    apiKey: "sk-openai-11810",
+  });
+
+  await combosDb.createCombo({
+    name: "combo-11810-priority",
+    strategy: "priority",
+    config: { maxRetries: 0, retryDelayMs: 0 },
+    // Provider-level target, no pinned connectionId — the connection is selected
+    // dynamically at dispatch time.
+    models: ["openai/o3-mini"],
+  });
+
+  globalThis.fetch = async () => buildOpenAIResponse("hello from o3-mini", "o3-mini");
+
+  const response = await handleChat(
+    buildRequest({
+      body: {
+        model: "combo-11810-priority",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      },
+    })
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { choices: Array<{ message: { content: string } }> };
+  assert.equal(body.choices[0].message.content, "hello from o3-mini");
+
+  const selectedConnectionId = response.headers.get("X-OmniRoute-Selected-Connection-Id");
+  assert.equal(
+    selectedConnectionId,
+    connection.id,
+    `expected the response to carry the dynamically selected connection id (${connection.id}), got ${selectedConnectionId}`
+  );
+});
+
+test("#11810 combo streaming success response carries X-OmniRoute-Selected-Connection-Id for a dynamically selected connection", async () => {
+  const connection = await seedConnection("openai", {
+    apiKey: "sk-openai-11810-stream",
+  });
+
+  await combosDb.createCombo({
+    name: "combo-11810-priority-stream",
+    strategy: "priority",
+    config: { maxRetries: 0, retryDelayMs: 0 },
+    // Provider-level target, no pinned connectionId — the connection is selected
+    // dynamically at dispatch time.
+    models: ["openai/o3-mini"],
+  });
+
+  globalThis.fetch = async () => buildOpenAIStreamResponse("hello streamed from o3-mini");
+
+  const response = await handleChat(
+    buildRequest({
+      body: {
+        model: "combo-11810-priority-stream",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      },
+    })
+  );
+
+  assert.equal(response.status, 200);
+
+  const selectedConnectionId = response.headers.get("X-OmniRoute-Selected-Connection-Id");
+  assert.equal(
+    selectedConnectionId,
+    connection.id,
+    `expected the streaming response to carry the dynamically selected connection id (${connection.id}), got ${selectedConnectionId}`
+  );
+
+  // Drain the stream so the harness's fetch mock/db handles are released cleanly.
+  await response.text();
+});


### PR DESCRIPTION
Closes #11810

## Root cause
On a successful provider dispatch, `handleSingleModelChat()`'s `result.success` branch in `src/sse/handlers/chat.ts` returned `result.response` (non-streaming) or `wrapResponseWithOAuthSessionRelease(result.response, releaseOAuthSession)` (streaming) directly, without first calling `withSelectedConnectionHeader()` — unlike every failure exit in the same function, which does call it. As a result, `X-OmniRoute-Selected-Connection-Id` was absent on every successful response for a dynamically-selected (unpinned) connection, so `combo.ts`'s consumers (success-decay, provider cooldown recovery, webhook attribution, session stickiness, LKGP) fell back to the target's static `connectionId`, which is empty for provider-level combo targets like `openai/o3-mini`.

## Fix
Apply `withSelectedConnectionHeader(result.response, credentials?.connectionId)` to `result.response` before both the streaming-wrap and the direct non-streaming return in the `result.success` block of `handleSingleModelChat`, mirroring the pattern already used on every failure exit of the same function.

## Regression test
`tests/unit/combo-success-selected-connection-header-11810.test.ts` — two cases (non-streaming and streaming success) that dispatch through the real `handleChat` → `handleComboChat` → `handleSingleModelChat` pipeline with a mocked upstream `fetch`, and assert the response carries `X-OmniRoute-Selected-Connection-Id` for a dynamically-selected (unpinned provider-level) connection.

- RED (pre-fix, both cases): `expected the response to carry the dynamically selected connection id (...), got null`
- GREEN (post-fix): `tests 2, pass 2, fail 0`

## Gates run (all green)
- `node --import tsx/esm --test tests/unit/combo-success-selected-connection-header-11810.test.ts` — 2/2 pass
- Sibling regression coverage: `tests/unit/combo-selected-connection-success.test.ts`, `tests/unit/rate-limit-local-error-classification.test.ts`, `tests/unit/rate-limit-queue-timeout-lockout.test.ts`, `tests/unit/account-fallback-service.test.ts`, `tests/unit/stream-early-eof-affinity-8928.test.ts`, `tests/unit/chat-safetynet-reqid-6097.test.ts` — 101/101 pass
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2672 violations vs baseline 2774)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1192 violations vs baseline 1223)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/sse/handlers/chat.ts tests/unit/combo-success-selected-connection-header-11810.test.ts` — 0 errors

Note: `tests/unit/combo-provider-cooldown.test.ts` ("combo failover skips the cooled provider target on the next request") was observed flaking under this run due to extreme devbox CPU contention from many concurrent parallel sessions (test durations of 100-124s for a test whose logic depends on a 3s cooldown window expiring between two sequential requests). This test is structurally unrelated to this fix (it asserts connection-cooldown/retry-count behavior, not response headers), and the diff here only touches the `result.success` return path — no cooldown/backoff logic. Re-running the other 101 sibling tests touching the same header/function all passed.

⚠️ base-red inherited: #11874 — docs-sync (README provider count), unrelated to this fix.