### PR TITLE
fix(ci): move docker-publish amd64 leg to the omni-build pool

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -118,7 +118,18 @@ jobs:
     name: Build Docker (${{ matrix.platform }})
     needs: prepare
     if: needs.prepare.outputs.skip != 'true'
-    runs-on: ${{ matrix.runner }}
+    # Dynamic runner for the amd64 leg only (#11976): the hosted ubuntu-24.04 runner's
+    # 7 GB ceiling no longer fits the release/v3.8.51 tree — every push to that branch
+    # OOMs mid `npm run build` (ResourceExhausted), and the same workflow publishes the
+    # release image on the version tag, so a stuck build ships the release without
+    # Docker. Same dynamic-runner rule as ci.yml's `build` / npm-publish.yml's `publish`:
+    # with the repo var USE_VPS_RUNNER=true, route to the self-hosted omni-build pool
+    # (31 GB) — never for a fork PR (this workflow has no pull_request trigger today,
+    # but the guard is kept verbatim so the expression stays greppable and safe if one
+    # is ever added). The arm64 leg stays on the hosted ubuntu-24.04-arm runner (free
+    # for public repos on GitHub-hosted ARM images) and is therefore still at the
+    # memory ceiling — tracked separately in #11865.
+    runs-on: ${{ (matrix.arch == 'amd64' && vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-build"]') || matrix.runner }}
     permissions:
       contents: read
       packages: write

--- a/changelog.d/fixes/11976-docker-publish-amd64-omni-build.md
+++ b/changelog.d/fixes/11976-docker-publish-amd64-omni-build.md
@@ -1,0 +1,5 @@
+- Routed the `docker-publish` amd64 build leg to the self-hosted `omni-build` pool
+  (31 GB) behind the existing `USE_VPS_RUNNER` repo variable — the hosted
+  `ubuntu-24.04` runner's 7 GB no longer fits the release tree and was OOMing on
+  every `release/v3.8.51` push, including the version-tag build that publishes the
+  release image. The arm64 leg stays on the hosted `ubuntu-24.04-arm` runner.


### PR DESCRIPTION
## What changed

`docker-publish.yml`'s `build` job amd64 leg now routes to the self-hosted
`omni-build` pool (31 GB) when the repo variable `USE_VPS_RUNNER == 'true'`,
falling back to the current hosted `ubuntu-24.04` runner otherwise. The arm64
leg is untouched — it stays on the hosted `ubuntu-24.04-arm` runner.

```
runs-on: ${{ (matrix.arch == 'amd64' && vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-build"]') || matrix.runner }}
```

This is the character-for-character fork/PR guard already used by
`ci.yml`'s `build` job (line ~617) and `npm-publish.yml`'s `publish` job
(line ~66), extended with a `matrix.arch == 'amd64'` gate so only the amd64
matrix entry is affected. `docker-publish.yml` has no `pull_request` trigger
today, so the guard is currently a no-op safety net — kept verbatim so the
expression stays greppable/consistent with the other two workflows and stays
safe if a `pull_request` trigger is ever added.

## Why

Every push to `release/v3.8.51` OOMs both build legs on the hosted 7 GB
runner (`ResourceExhausted` mid `npm run build`) — confirmed 5/5 failures on
that branch while the same workflow succeeds on `main`. This matters beyond
noise: the same workflow publishes the release image on the version tag, so
without this fix the v3.8.51 release could ship without a Docker image (the
v3.8.50 tag build hit the same failure on both legs and only passed on a
manual re-run).

**This fixes the amd64 leg only.** The arm64 leg remains on the hosted
runner and is therefore still at the memory ceiling — the underlying tree-size
growth is tracked separately in #11865. Owner-approved as Option 1 of #11976
(vs. a paid larger hosted runner, or shrinking the in-container `next build`
memory footprint).

## Operational note (please verify before/after merge)

I could not confirm from the repository whether the self-hosted `omni-build`
runners (.113 box) already have Docker Engine + the `buildx` plugin
installed — every existing `omni-build` job (`ci.yml` build, `npm-publish.yml`
publish, both `nightly-release-green` validations) only runs `next build`
directly, never a `docker build`. `docker/setup-buildx-action` configures a
buildx builder on top of an existing Docker installation; it does not install
Docker itself. If Docker isn't present on those runners yet, the first
`USE_VPS_RUNNER=true` run of this workflow will fail at the "Set up Docker
Buildx" / "Login to Docker Hub" step and need Docker provisioned on the box
before this fix takes effect. Everything else in the amd64 leg (checkout,
buildx, Docker Hub / GHCR login, build-push-action, artifact upload) is
generic and runner-agnostic.

## Validation

No unit test applies to a runner-label change (Hard Rule #18's TDD path does
not apply here). Validated instead by:

- **YAML parses**: `node -e "const y=require('js-yaml');y.load(require('fs').readFileSync('.github/workflows/docker-publish.yml','utf8'));console.log('yaml ok')"` → `yaml ok`
- **Character-for-character parity** of the fork/PR guard clause against the
  two existing precedents (`ci.yml:617`, `npm-publish.yml:66`) — diffed and
  confirmed identical.
- No `actionlint`/workflow-lint script exists in this repo (checked
  `package.json` scripts).

Gates run (all green):
- `npm run typecheck:core` — exit 0
- `npm run typecheck:noimplicit:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0 (0 errors)
- `npm run check:complexity-ratchets` — exit 0 (complexity 2672/baseline 2774, cognitive 1192/baseline 1223)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-test-discovery.mjs` — OK

⚠️ base-red inherited: #11874 — Docs sync + fabricated-docs (strict)

Refs #11865 (arm64/tree-size follow-up)
Closes #11976