### PR TITLE
fix(ci): drop the stale ESLint cache restore-keys fallback from ci.yml (#11600)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,11 @@ jobs:
             .eslintcache
             .eslintcache-complexity
           key: eslint-${{ runner.os }}-${{ hashFiles('eslint.config.mjs', 'eslint.complexity-ratchets.config.mjs', 'config/quality/eslint-suppressions.json', 'package-lock.json') }}
-          restore-keys: |
-            eslint-${{ runner.os }}-
+          # No restore-keys fallback on purpose (#11600, P-II.1 of the v3.8.50 postmortem): a
+          # cache built under a different suppressions file / lint config / lockfile reports
+          # stale per-file verdicts, which is exactly how 215 pre-existing errors stayed
+          # invisible for a whole cycle. Exact key or a cold full lint (~13 min) — never a
+          # partial cache from another configuration.
       # Single ESLint inventory (JSON) — quality-gate reuses the artifact instead of
       # a second cold full-tree pass for eslintWarnings ratchet counts.
       - name: ESLint (JSON report)
@@ -209,8 +212,11 @@ jobs:
             .eslintcache
             .eslintcache-complexity
           key: eslint-${{ runner.os }}-${{ hashFiles('eslint.config.mjs', 'eslint.complexity-ratchets.config.mjs', 'config/quality/eslint-suppressions.json', 'package-lock.json') }}
-          restore-keys: |
-            eslint-${{ runner.os }}-
+          # No restore-keys fallback on purpose (#11600, P-II.1 of the v3.8.50 postmortem): a
+          # cache built under a different suppressions file / lint config / lockfile reports
+          # stale per-file verdicts, which is exactly how 215 pre-existing errors stayed
+          # invisible for a whole cycle. Exact key or a cold full lint (~13 min) — never a
+          # partial cache from another configuration.
       # Coverage mergeada (coverage-summary.json) p/ o ratchet de cobertura.
       # continue-on-error: o artifact pode não existir se a job test-coverage foi
       # SKIPPED (shard flaky). Nesse caso collect-metrics pula coverage.* (ausente sem

--- a/changelog.d/fixes/11600-eslint-gate-cache-suppressions.md
+++ b/changelog.d/fixes/11600-eslint-gate-cache-suppressions.md
@@ -1,0 +1,5 @@
+- Dropped the stale-`.eslintcache` `restore-keys` fallback from both "Restore ESLint file
+  cache" steps in `ci.yml`, so the blocking `Lint` job can no longer be served per-file
+  verdicts computed under a different lint config, suppressions file or lockfile. `quality.yml`
+  had already dropped it in #11963; `ci.yml` — the workflow that actually gates PRs — had not
+  (#11600).


### PR DESCRIPTION
Refs #11600

## Scope — deliberately half of the issue

Issue #11600 has two distinct, independently-provable sub-defects. **PR #11983 (opened by a parallel session) already covers the second one**; this PR covers only the first, so the two do not collide.

| Sub-defect | Where | Covered by |
| --- | --- | --- |
| A. stale `.eslintcache` `restore-keys` fallback still in `ci.yml` | `.github/workflows/ci.yml` | **this PR** |
| B. `run-eslint-json.mjs` missing `--pass-on-unpruned-suppressions` | `scripts/quality/run-eslint-json.mjs` | #11983 |

This branch originally carried both; the `run-eslint-json.mjs` change and its test were dropped once #11983 appeared, to avoid two PRs editing the same file and the same new test path.

## Root cause (sub-defect A)

PR #11963 removed the `restore-keys: | eslint-${{ runner.os }}-` fallback from `quality.yml`'s two "Restore ESLint file cache" steps, with a comment citing this issue: a cache restored on a *prefix* match is a cache built under a different lint config, suppressions file or lockfile, and it reports stale per-file verdicts.

`ci.yml` was left untouched — and `ci.yml` is the workflow that runs the **blocking `Lint` job** on every PR. Both of its "Restore ESLint file cache" steps (the `lint` job and the `quality-gate` job) still carried the prefix fallback, so the exact mechanism #11963 fixed for `quality.yml` was still live on the gate that actually blocks contributors.

## Fix

Removed the `restore-keys` fallback from both steps in `ci.yml` and replaced it with the same explanatory comment `quality.yml` already carries, so the two workflows now state and enforce the same policy: exact key or a cold full lint, never a partial cache from another configuration.

## Validation

No unit test can cover a workflow-runner cache policy. Validated by:
- byte-level parity with the already-merged `quality.yml` shape from #11963 (same removal, same comment);
- the cache `key:` expression is unchanged — only the prefix-match fallback is gone, so an exact-key hit still restores as before.

Stated plainly: this half is validated by review + parity, not by a test. Hard Rule #18's TDD path does not apply to a CI runner-cache directive.

## Note on the issue's headline

The "223 errors hidden by the cache" headline was investigated earlier this cycle and found to be a phantom local-devbox measurement (a 215-entry freeze was committed and then reverted; CI's own clean-checkout artifact showed zero unsuppressed errors). This PR does **not** freeze or add any suppression.