### PR TITLE
feat(settings): raise sticky round-robin limit caps to 1000

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
@@ -418,7 +418,7 @@ export default function ComboDefaultsTab() {
             <Input
               type="number"
               min="1"
-              max="10"
+              max="1000"
               value={comboDefaults.stickyRoundRobinLimit || 3}
               onChange={async (e) => {
                 const nextLimit = parseInt(e.target.value) || 3;

--- a/src/app/(dashboard)/dashboard/settings/components/ProviderAccountRoutingCard.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ProviderAccountRoutingCard.tsx
@@ -21,7 +21,7 @@ const STRATEGY_OPTIONS = ACCOUNT_FALLBACK_STRATEGY_VALUES.filter((v) =>
 
 function clampProviderStickyLimit(raw: string): number {
   const val = parseInt(raw, 10);
-  return Math.min(10, Math.max(1, Number.isNaN(val) ? 3 : val));
+  return Math.min(1000, Math.max(1, Number.isNaN(val) ? 3 : val));
 }
 
 /** Loads/saves the per-provider account-routing override. Extracted out of the
@@ -124,7 +124,7 @@ export default function ProviderAccountRoutingCard({ providerKey, connectionCoun
             label={t("stickyLimit")}
             type="number"
             min={1}
-            max={10}
+            max={1000}
             disabled={busy}
             value={stickyLimit || "3"}
             onChange={(e) => setStickyLimit(e.target.value)}

--- a/src/app/(dashboard)/dashboard/settings/components/RoutingStrategyCard.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/RoutingStrategyCard.tsx
@@ -124,7 +124,7 @@ function AccountRoundRobinSection({ t, busy, settings, setSettings, run }: Secti
           <Input
             type="number"
             min={1}
-            max={10}
+            max={1000}
             disabled={busy}
             className="w-16 sm:w-20 text-center shrink-0"
             value={settings.stickyRoundRobinLimit ?? 3}
@@ -132,7 +132,7 @@ function AccountRoundRobinSection({ t, busy, settings, setSettings, run }: Secti
             onBlur={() =>
               run(async () => {
                 const limit = Math.min(
-                  10,
+                  1000,
                   Math.max(1, parseInt(String(settings.stickyRoundRobinLimit), 10) || 3)
                 );
                 const updated = await patchSettings({ stickyRoundRobinLimit: limit });
@@ -182,7 +182,7 @@ function ComboRoundRobinSection({ t, busy, settings, setSettings, run }: Section
           <Input
             type="number"
             min={1}
-            max={100}
+            max={1000}
             disabled={busy}
             className="w-20 text-center"
             value={settings.comboStickyRoundRobinLimit ?? 1}
@@ -192,7 +192,7 @@ function ComboRoundRobinSection({ t, busy, settings, setSettings, run }: Section
             onBlur={() =>
               run(async () => {
                 const limit = Math.min(
-                  100,
+                  1000,
                   Math.max(1, parseInt(String(settings.comboStickyRoundRobinLimit), 10) || 1)
                 );
                 const updated = await patchSettings({ comboStickyRoundRobinLimit: limit });

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -280,7 +280,7 @@ export const updateSettingsSchema = z.object({
   stickyRoundRobinLimit: z.number().int().min(0).max(1000).optional(),
   /** 9router parity: global combo expansion strategy (fallback vs round-robin). */
   comboStrategy: z.enum(["fallback", "round-robin"]).optional(),
-  comboStickyRoundRobinLimit: z.number().int().min(1).max(100).nullable().optional(),
+  comboStickyRoundRobinLimit: z.number().int().min(1).max(1000).nullable().optional(),
   providerStrategies: z
     .record(
       z.string().trim().min(1),

--- a/tests/unit/sticky-limit-cap-1000.test.ts
+++ b/tests/unit/sticky-limit-cap-1000.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Sticky round-robin limit caps — Settings → Routing inputs and the settings
+ * schema must all accept up to 1000 (the previous caps of 10 / 100 silently
+ * clamped operator intent for long-lived sessions).
+ */
+
+const { updateSettingsSchema } = await import("../../src/shared/validation/settingsSchemas.ts");
+
+test("global stickyRoundRobinLimit accepts up to 1000", () => {
+  const ok = updateSettingsSchema.safeParse({ stickyRoundRobinLimit: 1000 });
+  assert.equal(ok.success, true);
+  const tooHigh = updateSettingsSchema.safeParse({ stickyRoundRobinLimit: 1001 });
+  assert.equal(tooHigh.success, false);
+});
+
+test("global comboStickyRoundRobinLimit accepts up to 1000 (was 100)", () => {
+  const ok = updateSettingsSchema.safeParse({ comboStickyRoundRobinLimit: 1000 });
+  assert.equal(ok.success, true);
+  const tooHigh = updateSettingsSchema.safeParse({ comboStickyRoundRobinLimit: 1001 });
+  assert.equal(tooHigh.success, false);
+});
+
+test("per-provider stickyRoundRobinLimit accepts up to 1000 (was 10)", () => {
+  const ok = updateSettingsSchema.safeParse({
+    providerStrategies: { "opencode-go": { fallbackStrategy: "round-robin", stickyRoundRobinLimit: 1000 } },
+  });
+  assert.equal(ok.success, true);
+  const tooHigh = updateSettingsSchema.safeParse({
+    providerStrategies: { "opencode-go": { stickyRoundRobinLimit: 1001 } },
+  });
+  assert.equal(tooHigh.success, false);
+});


### PR DESCRIPTION
## Summary

The **Sticky Limit** inputs all capped at absurdly low values:

| Setting | Location | Old max | New max |
|---|---|---|---|
| Global account Sticky Limit | Settings → Routing (RoutingStrategyCard) | 10 | 1000 |
| Global Combo Sticky Limit | Settings → Routing (RoutingStrategyCard) | 100 | 1000 |
| Combo default Sticky Limit | Settings → Routing → Combo Defaults (ComboDefaultsTab) | 10 | 1000 |
| Per-provider Sticky Limit | Provider page → Multi-account routing (ProviderAccountRoutingCard) | 10 | 1000 |

The backend schema for the global combo sticky limit (`comboStickyRoundRobinLimit` in `settingsSchemas.ts`) also capped at 100 — raised to 1000. Per-combo `stickyRoundRobinLimit` / `stickyWeightedLimit` already allowed 1000 (`schemas/combo.ts`), so this aligns the global + provider-level settings with the per-combo bound.

Long-lived agent sessions routinely exceed 10 calls per account, so the old caps silently clamped operator intent mid-session.

## Files changed

- `src/shared/validation/settingsSchemas.ts` — `comboStickyRoundRobinLimit` max 100 → 1000.
- `src/app/(dashboard)/dashboard/settings/components/RoutingStrategyCard.tsx` — account sticky input max + `Math.min` clamp 10 → 1000; combo sticky input max + `Math.min` clamp 100 → 1000.
- `src/app/(dashboard)/dashboard/settings/components/ProviderAccountRoutingCard.tsx` — `clampProviderStickyLimit` 10 → 1000; input max 10 → 1000.
- `src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx` — combo-default sticky input max 10 → 1000.

## Test plan

- `tests/unit/combo-config.test.ts`, `tests/unit/combo-strategy-fallbacks.test.ts`, `tests/unit/sse-auth.test.ts` — 134/134 pass (no bound regressions; existing per-combo 1001-rejection test still passes because per-combo max stays 1000).
- `npx tsc --noEmit -p tsconfig.typecheck-core.json` — clean.
- `npx eslint` on changed files — no new issues (two pre-existing errors in `ComboDefaultsTab.tsx` / `ProviderAccountRoutingCard.tsx` are untouched).
