### PR TITLE
fix(build): honor OMNIROUTE_USE_TURBOPACK from .env on the build path

### DIFF
--- a/scripts/build/build-next-isolated.mjs
+++ b/scripts/build/build-next-isolated.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs/promises";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -93,6 +93,8 @@ export function ensureWindowsBuildProfileDirs(env, mkdirImpl = mkdirSync) {
 
 function runNextBuild() {
   return new Promise((resolve) => {
+    // .env bundler flag fill-in before the arg is constructed (see helper doc).
+    honorBundlerFlagFromEnvFile();
     const nextBin = path.join(projectRoot, "node_modules", "next", "dist", "bin", "next");
     const buildEnv = resolveNextBuildEnv(process.env);
     ensureWindowsBuildProfileDirs(buildEnv);
@@ -140,6 +142,30 @@ export function resolveNextBuildBundlerFlag(baseEnv = process.env) {
     return "--webpack";
   }
   return "--turbopack";
+}
+
+// Honor OMNIROUTE_USE_TURBOPACK from the repo `.env` on the BUILD path too.
+// Unlike the dev server (scripts/dev/run-next.mjs → bootstrapEnv()), this script
+// never loads .env, so the documented escape hatch set there — the exact remedy
+// for the #6409/#9695 RAM-constrained / macOS arm64 local-stall cases — was
+// silently ignored by `npm run build`: .env said 0 but the build still ran
+// Turbopack and stalled (2026-08-29 local investigation). Shell env wins;
+// .env only fills the variable in when it is absent (ports the DATA_DIR
+// pre-read pattern from run-next.mjs).
+// @param {NodeJS.ProcessEnv} [env]
+// @param {string} [cwd]
+export function honorBundlerFlagFromEnvFile(env = process.env, cwd = process.cwd()) {
+  if (env.OMNIROUTE_USE_TURBOPACK !== undefined) return env.OMNIROUTE_USE_TURBOPACK ?? null;
+  try {
+    const raw = readFileSync(path.join(cwd, ".env"), "utf8");
+    const match = raw.match(/^OMNIROUTE_USE_TURBOPACK=(\S+)\s*$/m);
+    if (match?.[1]) {
+      env.OMNIROUTE_USE_TURBOPACK = match[1].trim();
+    }
+  } catch {
+    /* .env missing or unreadable — shell env stays authoritative */
+  }
+  return env.OMNIROUTE_USE_TURBOPACK ?? null;
 }
 
 /**

--- a/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
+++ b/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
@@ -1,7 +1,20 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { resolveNextBuildBundlerFlag } from "../../../scripts/build/build-next-isolated.mjs";
+import {
+  honorBundlerFlagFromEnvFile,
+  resolveNextBuildBundlerFlag,
+} from "../../../scripts/build/build-next-isolated.mjs";
+
+/** Throwaway project dir carrying a `.env` with the given bundler setting. */
+function makeProjectDir(envLine) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-bundler-env-"));
+  fs.writeFileSync(path.join(dir, ".env"), `OTHER_SETTING=1\n${envLine}\n`);
+  return dir;
+}
 
 test("resolveNextBuildBundlerFlag returns --turbopack by default", () => {
   const flag = resolveNextBuildBundlerFlag({});
@@ -16,4 +29,31 @@ test("resolveNextBuildBundlerFlag returns --webpack when OMNIROUTE_USE_TURBOPACK
 test("resolveNextBuildBundlerFlag returns --turbopack when OMNIROUTE_USE_TURBOPACK is '1'", () => {
   const flag = resolveNextBuildBundlerFlag({ OMNIROUTE_USE_TURBOPACK: "1" });
   assert.equal(flag, "--turbopack");
+});
+
+// `npm run build` is the only entry point that never loads `.env` (the dev server
+// goes through scripts/dev/run-next.mjs → bootstrapEnv()). So the documented
+// escape hatch for the macOS arm64 Turbopack stall (#6409/#9695) was silently
+// ignored on the build path: `.env` said 0 and the build still ran Turbopack.
+test("honorBundlerFlagFromEnvFile fills OMNIROUTE_USE_TURBOPACK from .env", () => {
+  const dir = makeProjectDir("OMNIROUTE_USE_TURBOPACK=0");
+  const env = {};
+  honorBundlerFlagFromEnvFile(env, dir);
+  assert.equal(env.OMNIROUTE_USE_TURBOPACK, "0");
+  assert.equal(resolveNextBuildBundlerFlag(env), "--webpack");
+});
+
+test("honorBundlerFlagFromEnvFile lets the shell env win over .env", () => {
+  const dir = makeProjectDir("OMNIROUTE_USE_TURBOPACK=0");
+  const env = { OMNIROUTE_USE_TURBOPACK: "1" };
+  honorBundlerFlagFromEnvFile(env, dir);
+  assert.equal(env.OMNIROUTE_USE_TURBOPACK, "1");
+  assert.equal(resolveNextBuildBundlerFlag(env), "--turbopack");
+});
+
+test("honorBundlerFlagFromEnvFile is a no-op when .env is missing", () => {
+  const env = {};
+  honorBundlerFlagFromEnvFile(env, fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-no-env-")));
+  assert.equal(env.OMNIROUTE_USE_TURBOPACK, undefined);
+  assert.equal(resolveNextBuildBundlerFlag(env), "--turbopack");
 });


### PR DESCRIPTION
## Problem

`npm run build` was the only entry point that never loads `.env`. The dev server goes
through `scripts/dev/run-next.mjs → bootstrapEnv()`, but
`scripts/build/build-next-isolated.mjs` hands `process.env` straight to
`resolveNextBuildBundlerFlag()`.

So the escape hatch documented for the RAM-constrained / macOS arm64 Turbopack stall
(#6409, #9695) was silently ignored on the build path: `.env` said
`OMNIROUTE_USE_TURBOPACK=0` and the build still ran `--turbopack`.

`resolveNextBuildBundlerFlag()` defaults to `--turbopack`, so the only way out was
exporting the variable in the shell for every single invocation — and forgetting once
meant a build that never converged (25+ min with no progress on this machine, while the
same commit is green in CI in ~7 min).

## Fix

Add `honorBundlerFlagFromEnvFile()` and call it at the top of `runNextBuild()`, before
the bundler argument is constructed.

- Shell env keeps precedence — an explicit export still wins.
- `.env` only fills the variable in when it is absent.
- A missing or unreadable `.env` is a no-op.

This ports the DATA_DIR pre-read pattern already used by the dev launcher.

## Tests

`tests/unit/build/resolve-next-build-bundler-flag.test.mjs` — 3 new cases:

- `.env` fills `OMNIROUTE_USE_TURBOPACK` (→ `--webpack`)
- shell env wins over `.env`
- a missing `.env` is a no-op (→ `--turbopack`, unchanged default)

Existing 3 cases unchanged. `tests/unit/build-next-isolated.test.ts` 10/10 — no
regression.

⚠️ base-red inherited: #11874
