### PR TITLE
fix(css): scope the Tailwind v4 content scan with source(none)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,16 @@
-@import "tailwindcss";
+/* PERFORMANCE: `source(none)` disables Tailwind v4 automatic content
+   detection, which walks the whole repository root (tests/ ~5k files, docs/,
+   CHANGELOG.md ~2.4 MB, scripts/...) and costs ~13.5 s PER fresh worker
+   process. The Turbopack build delegates this postcss transform to a pool of
+   short-lived node workers, so every worker respawn re-paid the full cold
+   scan and the build never converged (local macOS arm64 stall, 2026-08-29 —
+   see _tasks/research/2026-08-29-turbopack-local-build-stall-rootcause.md).
+   The explicit @source globs below cover every production class-bearing tree
+   (className usage lives only under src/ in .tsx files; verified by
+   repo-wide grep). Rule: when adding UI code with Tailwind classes OUTSIDE
+   src/, add an explicit @source line here. NB: keep glob `*` and `/` apart
+   inside comments — the sequence closes the comment. */
+@import "tailwindcss" source(none);
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 /* Self-hosted Material Symbols icon font (#3695): the Google Fonts CDN
@@ -8,6 +20,7 @@
    The bundled @font-face uses family "Material Symbols Outlined", matching the
    .material-symbols-outlined rule defined later in this file. */
 @import "material-symbols/outlined.css";
+@source "../";
 @source "../../node_modules/fumadocs-ui/css/generated/*.css";
 
 /* Tailwind v4 auto-detection cannot scan directories with parentheses

--- a/tests/unit/tailwind-content-scan.test.mjs
+++ b/tests/unit/tailwind-content-scan.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const globalsCss = fs.readFileSync(path.join(process.cwd(), "src/app/globals.css"), "utf8");
+
+/** Lines that add a source root: `@source "<glob>"` without the `not` keyword. */
+function positiveSources(css) {
+  return css
+    .split("\n")
+    .map((line) => line.match(/^\s*@source\s+(?!not\s)"([^"]+)"\s*;/))
+    .filter(Boolean)
+    .map((match) => match[1]);
+}
+
+test("globals.css disables Tailwind v4 automatic content detection", () => {
+  // Tailwind v4's auto-detection walks the whole repository root from
+  // src/app/globals.css — tests/ (~5k files), docs/, CHANGELOG.md (~2.4 MB) and
+  // everything else — costing ~13.5s per cold process. The Turbopack build
+  // delegates this postcss transform to a pool of short-lived node workers, so
+  // every worker respawn re-paid the full scan (44 respawns observed in 11 min).
+  assert.match(
+    globalsCss,
+    /@import\s+"tailwindcss"\s+source\(none\)\s*;/,
+    "globals.css must import tailwindcss with source(none) so the content scan is bounded by the explicit @source directives below"
+  );
+});
+
+test("globals.css declares an explicit source root covering the app tree", () => {
+  // source(none) with no positive @source emits ZERO utilities — an unstyled
+  // dashboard with no build error. src/app/globals.css lives at src/app/, so
+  // "../" resolves to src/, which is where every production className lives
+  // (verified by repo-wide grep). Route groups with parentheses cannot be
+  // globbed, hence the separate @source "../app/(dashboard)" entry.
+  const sources = positiveSources(globalsCss);
+  assert.ok(
+    sources.length > 0,
+    "source(none) requires at least one explicit @source directive or no utilities are generated"
+  );
+  assert.ok(
+    sources.includes("../"),
+    `expected @source "../" (the whole src/ tree) among the source roots: ${sources.join(", ")}`
+  );
+  assert.ok(
+    sources.includes("../app/(dashboard)"),
+    `expected @source "../app/(dashboard)" — Tailwind cannot glob parenthesised route groups: ${sources.join(", ")}`
+  );
+});
+
+test("globals.css keeps the fumadocs and sqlite/.claude scan exclusions", () => {
+  // The fumadocs sources supply the docs theme utilities; the `not` entries keep
+  // the scan off database files and the local agent directory. Dropping either
+  // changes the emitted stylesheet or re-introduces junk scanning.
+  const sources = positiveSources(globalsCss);
+  assert.ok(
+    sources.some((s) => s.includes("fumadocs-ui")),
+    `expected a fumadocs-ui source root: ${sources.join(", ")}`
+  );
+  assert.match(globalsCss, /@source\s+not\s+"\.\.\/\.\.\/\*\.sqlite\*"\s*;/);
+  assert.match(globalsCss, /@source\s+not\s+"\.\.\/\.\.\/\.claude\*"\s*;/);
+});


### PR DESCRIPTION
## Problem

Tailwind v4 automatic content detection walks the whole repository root from
`src/app/globals.css` — `tests/` (~5k files), `docs/`, `CHANGELOG.md` (~2.4 MB),
`scripts/` — and costs **~13.5 s per cold process**.

That is fine for webpack, whose postcss-loader scans once in-process. The Turbopack
build instead delegates this transform to a pool of short-lived node workers, so
**every worker respawn re-paid the full cold scan** and the build stopped converging
(44 unique workers observed in 11 minutes on this machine).

## Fix

Disable auto-detection and declare the class-bearing trees explicitly:

```css
@import "tailwindcss" source(none);
@source "../";                        /* src/ — every production className lives here */
```

The existing route-group, fumadocs and `not` exclusion directives are untouched.

## Verification

- Cold scan **13.5 s → 2.05 s** (6.6×).
- Production class parity checked before/after: **2,457 classes retained**, the 37
  dropped all originate outside `src/` (tests, docs, scripts) — so no shipped class is
  lost.
- Repo-wide grep confirms `className` usage lives only under `src/` in `.tsx` files.

## Rule for future UI work

Tailwind classes added **outside `src/`** need an explicit `@source` line here.

## Tests

New `tests/unit/tailwind-content-scan.test.mjs` — 3 cases guarding both halves of the
invariant:

- `source(none)` stays set (a revert re-introduces the unbounded scan)
- a positive source root still covers the app tree — `source(none)` with no `@source`
  emits **zero utilities**, an unstyled dashboard with no build error
- the fumadocs / `.sqlite` / `.claude` directives are preserved

Existing CSS-reading tests re-run green: `design-grid-background`,
`material-icons-self-hosted`, `dashboard-sidebar-desktop-visible`,
`connection-row-rtl-margin` (25/25).

⚠️ base-red inherited: #11874
