### PR TITLE
fix(release): attach the SBOM to the GitHub Release on dispatch publishes too

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -273,11 +273,20 @@ jobs:
           if-no-files-found: error
 
       - name: Attach SBOM to GitHub Release
-        if: steps.resolve.outputs.skip != 'true' && github.event_name == 'release'
+        # Not only on the `release` event: the v3.8.50 package shipped through a
+        # workflow_dispatch (staged publish, 11 attempts) and this step was skipped, so the
+        # GitHub Release carried no SBOM until it was attached by hand from the run's
+        # `sbom-npm` artifact. Attach whenever a release for the published tag exists.
+        if: steps.resolve.outputs.skip != 'true' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: gh release upload "$TAG" sbom-npm.cdx.json --clobber
+          TAG: ${{ github.event_name == 'release' && github.ref_name || format('v{0}', inputs.version) }}
+        run: |
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::notice::no GitHub Release for $TAG yet — SBOM stays on the sbom-npm workflow artifact"
+            exit 0
+          fi
+          gh release upload "$TAG" sbom-npm.cdx.json --repo "$GITHUB_REPOSITORY" --clobber
 
       # WS1.2/WS1.3 (#7065 class): the artifact that is about to be published must
       # BOOT. build:cli already assembled dist/ above; this packs+installs+boots the

--- a/changelog.d/fixes/v3850-sbom-attach-on-dispatch.md
+++ b/changelog.d/fixes/v3850-sbom-attach-on-dispatch.md
@@ -1,0 +1,1 @@
+- npm publish workflow: the CycloneDX SBOM is attached to the GitHub Release on `workflow_dispatch` publishes too (when a release for the tag exists), not only on the `release` event — v3.8.50 shipped through a staged dispatch and its release carried no SBOM until it was attached by hand from the run's `sbom-npm` artifact


### PR DESCRIPTION
## Por que

O passo `Attach SBOM to GitHub Release` do `npm-publish.yml` só rodava com `github.event_name == 'release'`. A v3.8.50 foi publicada por `workflow_dispatch` (staged, 11 tentativas) — o SBOM foi **gerado** e subiu como artefato do run (33180410848), mas o passo de anexar ficou `skipped` e a release ficou sem `sbom-npm.cdx.json` (a v3.8.49 tem). Anexei à mão a partir do artefato (5,0 MB, 1.886 componentes, `omniroute@3.8.50`).

## O que muda

Anexa em `release` **ou** `workflow_dispatch`, com a tag resolvida (`github.ref_name` no release; `v<inputs.version>` no dispatch) e um guard: se a release da tag ainda não existir, avisa e sai 0 (o artefato do run continua sendo a cópia durável).

actionlint e prettier limpos; `npm-publish-artifact-provenance` 3/3, `check-workflows-provenance-runner` 7/7.