### PR TITLE
fix(build): prune non-production trees in NFT trace excludes and tsconfig

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -262,20 +262,30 @@ const nextConfig = {
     ],
   },
   outputFileTracingExcludes: {
-    // Planning/task docs are not runtime assets and can break standalone copies
-    // when broad fs/path tracing pulls the whole repository into the NFT graph.
-    "/*": [
-      "./.git/**/*",
-      "./_tasks/**/*",
-      "./_references/**/*",
-      "./_ideia/**/*",
-      "./_mono_repo/**/*",
-      "./coverage/**/*",
-      "./test-results/**/*",
-      "./playwright-report/**/*",
-      "./app.__qa_backup/**/*",
-      "./tests/**/*",
-      "./logs/**/*",
+    // Planning/task docs, tests, and non-production worktrees are not runtime assets
+    // and break standalone copies when broad NFT tracing pulls the whole repository into memory.
+    // Using "**/*" ensures the exclusion applies across all app and API routes, not just "/".
+    "**/*": [
+      "**/.git/**",
+      "**/_tasks/**",
+      "**/_references/**",
+      "**/_ideia/**",
+      "**/_mono_repo/**",
+      "**/coverage/**",
+      "**/test-results/**",
+      "**/playwright-report/**",
+      "**/app.__qa_backup/**",
+      "**/tests/**",
+      "**/logs/**",
+      "**/.claude/**",
+      "**/.opencode/**",
+      "**/.scratch/**",
+      "**/.agents/**",
+      "**/.slim/**",
+      "**/packages/**",
+      "**/.tmp/**",
+      "**/electron/**",
+      "**/docs/**",
     ],
   },
   serverExternalPackages: [

--- a/tests/unit/next-config.test.ts
+++ b/tests/unit/next-config.test.ts
@@ -75,8 +75,14 @@ test("next config exposes standalone build settings and canonical rewrites", asy
 test("next config declares Turbopack aliases, runtime assets and server externals", async () => {
   const { default: nextConfig } = await loadNextConfig("runtime-assets");
   const serverExternalPackages = new Set(nextConfig.serverExternalPackages);
-  const tracingIncludes = nextConfig.outputFileTracingIncludes["/*"];
-  const tracingExcludes = nextConfig.outputFileTracingExcludes["/*"];
+  const tracingIncludes =
+    nextConfig.outputFileTracingIncludes?.["/*"] ||
+    nextConfig.outputFileTracingIncludes?.["**/*"] ||
+    [];
+  const tracingExcludes =
+    nextConfig.outputFileTracingExcludes?.["**/*"] ||
+    nextConfig.outputFileTracingExcludes?.["/*"] ||
+    [];
 
   assert.equal(nextConfig.turbopack.root, process.cwd());
   // #6344: the @/mitm/manager stub alias is OPT-IN (OMNIROUTE_MITM_STUB=1, Docker only).
@@ -100,8 +106,18 @@ test("next config declares Turbopack aliases, runtime assets and server external
     tracingIncludes.includes("./node_modules/sql.js/dist/sql-wasm.wasm"),
     "sql-wasm.wasm must be trace-included so the sql.js fallback works in standalone builds"
   );
-  assert.ok(tracingExcludes.includes("./_tasks/**/*"));
-  assert.ok(tracingExcludes.includes("./tests/**/*"));
+  assert.ok(
+    tracingExcludes.some((p) => p.includes("_tasks")),
+    "outputFileTracingExcludes should exclude _tasks"
+  );
+  assert.ok(
+    tracingExcludes.some((p) => p.includes("tests")),
+    "outputFileTracingExcludes should exclude tests"
+  );
+  assert.ok(
+    tracingExcludes.some((p) => p.includes(".claude")),
+    "outputFileTracingExcludes should exclude .claude worktrees"
+  );
 
   for (const packageName of [
     "thread-stream",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,6 +59,11 @@
     "_tasks",
     "_ideia",
     "_mono_repo",
-    "_references"
+    "_references",
+    ".opencode",
+    ".scratch",
+    ".agents",
+    ".slim",
+    "packages"
   ]
 }


### PR DESCRIPTION
### Summary

Resolves build-time memory exhaustion (OOM / `SIGKILL`) during standalone compilation (`next build` / `output: "standalone"`) by pruning non-production directory trees from Next.js Node File Trace (NFT) and TypeScript static analysis.

### Root Cause
1. **Route pattern mismatch in NFT excludes**: `next.config.mjs` previously configured `outputFileTracingExcludes` under the `"/*"` key, which Next.js NFT matches only against root-level routes (e.g. `/`). Nested app routes and API endpoints (`/api/*`, `/dashboard/*`) were un-excluded, allowing NFT to recursively traverse heavy directories (`.claude/worktrees`, `tests`, `coverage`, `docs`, `_tasks`) across hundreds of routes, inflating in-memory AST graphs to >4GB RAM.
2. **TypeScript build scope**: Non-production directories (`.opencode`, `.scratch`, `.agents`, `.slim`, `packages`) were omitted from `tsconfig.json`'s `exclude` list, increasing TypeScript AST file scanning by thousands of superfluous files.

### Changes
- **`next.config.mjs`**:
  - Replaced route-level `"/*"` selector with universal `"**/*"` in `outputFileTracingExcludes`.
  - Broadened recursive glob patterns to exclude `**/.claude/**`, `**/.opencode/**`, `**/.scratch/**`, `**/.agents/**`, `**/.slim/**`, `**/tests/**`, `**/docs/**`, `**/electron/**`, and `**/packages/**`.
- **`tsconfig.json`**:
  - Added `.opencode`, `.scratch`, `.agents`, `.slim`, and `packages` to `exclude`.
- **`tests/unit/next-config.test.ts`**:
  - Updated configuration assertions to accept wildcard keys and verify `.claude` worktree exclusions.

### Verification
- Ran `node --import tsx/esm --test tests/unit/next-config.test.ts`: 9/9 tests pass.
- Ran `node scripts/check/check-build-scope.mjs`: verified build scope is reduced and clean (8,303 files, well under the 12,000 threshold).
- Verified standalone assembly completes cleanly without memory exhaustion.