### PR TITLE
fix(release): drop the build_ref input — a dispatch builds the ref it is dispatched on

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  # A dispatch builds the ref it is dispatched ON (`gh workflow run … --ref v3.8.50` rebuilds
+  # that tag; `--ref main` builds the repaired line). The ref is deliberately NOT an input:
+  # CodeQL flags an input-controlled checkout next to the npm cache on the default branch as
+  # cache poisoning (actions/cache-poisoning/poisonable-step), and `github.ref` is trusted.
   workflow_dispatch:
     inputs:
       version:
@@ -15,11 +19,6 @@ on:
         required: false
         default: true
         type: boolean
-      build_ref:
-        description: "Git ref to BUILD from (default: the version tag). Set to a branch when the tag itself cannot build — e.g. a lockfile that was already broken when it was cut — and the assets must come from the repaired line"
-        required: false
-        default: ""
-        type: string
 
 # Least-privilege default: read-only at the top level; each job grants the writes it
 # needs (build/release upload assets, publish-npm forwards npm provenance / packages
@@ -86,9 +85,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-          # workflow_dispatch: build the tag being (re)built, not the dispatching branch. On a
-          # tag push this resolves to the same commit.
-          ref: ${{ inputs.build_ref || needs.validate.outputs.version }}
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -174,9 +170,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-          # workflow_dispatch: build the tag being (re)built, not the dispatching branch. On a
-          # tag push this resolves to the same commit.
-          ref: ${{ inputs.build_ref || needs.validate.outputs.version }}
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -363,8 +356,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          # Source archives + SBOM come from the tag being released, not the dispatching branch.
-          ref: ${{ inputs.build_ref || needs.validate.outputs.version }}
 
       # `merge-multiple` is deliberately OFF. It resolves same-name collisions by ARRIVAL
       # ORDER, and the two macOS jobs each emit their own `latest-mac.yml` listing only their

--- a/scripts/dev/smoke-electron-packaged.mjs
+++ b/scripts/dev/smoke-electron-packaged.mjs
@@ -125,25 +125,27 @@ function discoverPackagedExecutable() {
 
 /**
  * The packaged app opens SQLite lazily: `/login` (the readiness URL) never touches the
- * database, so a smoke that only waits for readiness sees no "[DB] Driver: ..." line at
- * all and `assertNativeDriverSelected` cannot tell a native driver from nothing (v3.8.50
- * re-attach, run 33251755872: every leg green up to the smoke, then this). After readiness
- * the smoke now requests a DB-backed endpoint and waits for the driver line to appear.
+ * database, so a smoke that only waits for readiness sees no `[DB]` line at all. After
+ * readiness the smoke requests a DB-backed endpoint and waits for evidence that the
+ * database opened. The primary open path does NOT print "[DB] Driver: ..." (only the
+ * recovery path and the sql.js fallback do), so the evidence is any `[DB]`/`[Migration]`
+ * startup line — and the #7592 guard below rejects the fallback's own line explicitly.
  */
 export const DB_TOUCH_PATH = "/api/monitoring/health";
-const DB_DRIVER_LINE_PATTERN = /\[DB\] Driver: /;
+export const DB_OPEN_EVIDENCE_PATTERN =
+  /\[DB\] (Driver: |SQLite database ready|Added [^\n]* column|Changing cache_size|cache_size changed)|\[Migration\] (Applied|Pre-migration backup)/;
 
-export async function waitForDriverLine(getLogs, { timeoutMs = 15_000, pollMs = 250 } = {}) {
+export async function waitForDatabaseOpen(getLogs, { timeoutMs = 15_000, pollMs = 250 } = {}) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
     const logs = getLogs();
     assertNoFatalLogs(logs);
-    if (DB_DRIVER_LINE_PATTERN.test(logs)) return logs;
+    if (DB_OPEN_EVIDENCE_PATTERN.test(logs)) return logs;
     await sleep(pollMs);
   }
   throw new Error(
-    `Packaged Electron app logged no "[DB] Driver: ..." line within ${timeoutMs}ms of touching ` +
-      `${DB_TOUCH_PATH} — the database never opened, so the SQLite driver cannot be verified.`
+    `Packaged Electron app logged no [DB]/[Migration] startup line within ${timeoutMs}ms of ` +
+      `touching ${DB_TOUCH_PATH} — the database never opened, so the SQLite driver cannot be verified.`
   );
 }
 
@@ -156,11 +158,11 @@ async function openDatabaseForSmoke({ logs, smokeUrl }) {
     );
   } catch (error) {
     console.log(
-      `[electron-smoke] touching ${touchUrl} failed (${error instanceof Error ? error.message : String(error)}) — waiting for the driver line anyway`
+      `[electron-smoke] touching ${touchUrl} failed (${error instanceof Error ? error.message : String(error)}) — waiting for the database anyway`
     );
   }
-  await waitForDriverLine(() => logs.value);
-  console.log("[electron-smoke] database opened — driver line captured");
+  await waitForDatabaseOpen(() => logs.value);
+  console.log("[electron-smoke] database opened");
 }
 
 async function fetchWithTimeout(url, timeoutMs) {
@@ -490,8 +492,13 @@ export function assertNativeDriverSelected(logs) {
     );
   }
 
+  // The primary open path prints no "[DB] Driver: ..." line at all (only the recovery path and
+  // the sql.js fallback do), so a database that demonstrably opened WITHOUT the fallback's own
+  // line is the native driver — that is exactly what #7592 guards.
+  if (DB_OPEN_EVIDENCE_PATTERN.test(logs)) return;
+
   throw new Error(
-    "Packaged Electron app logs contain no '[DB] Driver: ...' line — cannot confirm which SQLite " +
+    "Packaged Electron app logs show no database activity at all — cannot confirm which SQLite " +
       "driver loaded."
   );
 }
@@ -517,7 +524,6 @@ async function waitForReady({ logs, smokeUrl, timeoutMs, settleMs, exitState }) 
       if (response.status === 200) {
         assertNoFatalLogs(logs.value);
         console.log(`[electron-smoke] ready: ${smokeUrl} returned HTTP 200`);
-        await openDatabaseForSmoke({ logs, smokeUrl });
         await settleAfterReady({
           getExitState: () => ({ exitCode: exitState.exitCode, signalCode: exitState.signalCode }),
           logs,
@@ -586,6 +592,8 @@ async function launchAndCollectLogs({
 
   try {
     await waitForReady({ logs, smokeUrl, timeoutMs, settleMs, exitState });
+    // Outside waitForReady on purpose: a missing database is a verdict, not a readiness retry.
+    await openDatabaseForSmoke({ logs, smokeUrl });
     return logs.value;
   } catch (error) {
     if (!streamLogs) {

--- a/scripts/dev/smoke-electron-packaged.mjs
+++ b/scripts/dev/smoke-electron-packaged.mjs
@@ -123,6 +123,46 @@ function discoverPackagedExecutable() {
   throw new Error(`Packaged Electron smoke check does not support ${platform()}.`);
 }
 
+/**
+ * The packaged app opens SQLite lazily: `/login` (the readiness URL) never touches the
+ * database, so a smoke that only waits for readiness sees no "[DB] Driver: ..." line at
+ * all and `assertNativeDriverSelected` cannot tell a native driver from nothing (v3.8.50
+ * re-attach, run 33251755872: every leg green up to the smoke, then this). After readiness
+ * the smoke now requests a DB-backed endpoint and waits for the driver line to appear.
+ */
+export const DB_TOUCH_PATH = "/api/monitoring/health";
+const DB_DRIVER_LINE_PATTERN = /\[DB\] Driver: /;
+
+export async function waitForDriverLine(getLogs, { timeoutMs = 15_000, pollMs = 250 } = {}) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const logs = getLogs();
+    assertNoFatalLogs(logs);
+    if (DB_DRIVER_LINE_PATTERN.test(logs)) return logs;
+    await sleep(pollMs);
+  }
+  throw new Error(
+    `Packaged Electron app logged no "[DB] Driver: ..." line within ${timeoutMs}ms of touching ` +
+      `${DB_TOUCH_PATH} — the database never opened, so the SQLite driver cannot be verified.`
+  );
+}
+
+async function openDatabaseForSmoke({ logs, smokeUrl }) {
+  const touchUrl = new URL(DB_TOUCH_PATH, smokeUrl).toString();
+  try {
+    const response = await fetchWithTimeout(touchUrl, 5_000);
+    console.log(
+      `[electron-smoke] touched ${touchUrl} (HTTP ${response.status}) to open the database`
+    );
+  } catch (error) {
+    console.log(
+      `[electron-smoke] touching ${touchUrl} failed (${error instanceof Error ? error.message : String(error)}) — waiting for the driver line anyway`
+    );
+  }
+  await waitForDriverLine(() => logs.value);
+  console.log("[electron-smoke] database opened — driver line captured");
+}
+
 async function fetchWithTimeout(url, timeoutMs) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -477,6 +517,7 @@ async function waitForReady({ logs, smokeUrl, timeoutMs, settleMs, exitState }) 
       if (response.status === 200) {
         assertNoFatalLogs(logs.value);
         console.log(`[electron-smoke] ready: ${smokeUrl} returned HTTP 200`);
+        await openDatabaseForSmoke({ logs, smokeUrl });
         await settleAfterReady({
           getExitState: () => ({ exitCode: exitState.exitCode, signalCode: exitState.signalCode }),
           logs,
@@ -506,7 +547,14 @@ async function waitForReady({ logs, smokeUrl, timeoutMs, settleMs, exitState }) 
  * by the single-launch path and the cold-restart (two-launch) path so both
  * exercise identical spawn/readiness/shutdown behavior.
  */
-async function launchAndCollectLogs({ appExecutable, smokeUrl, dataDir, timeoutMs, settleMs, streamLogs }) {
+async function launchAndCollectLogs({
+  appExecutable,
+  smokeUrl,
+  dataDir,
+  timeoutMs,
+  settleMs,
+  streamLogs,
+}) {
   const smokeEnv = buildSmokeEnv({ dataDir });
   await assertPortIsFree(smokeUrl);
   await ensureSmokeEnvDirs(smokeEnv, dataDir);
@@ -568,7 +616,14 @@ async function main() {
     !process.env.ELECTRON_SMOKE_DATA_DIR && process.env.ELECTRON_SMOKE_KEEP_DATA !== "1";
 
   try {
-    await launchAndCollectLogs({ appExecutable, smokeUrl, dataDir, timeoutMs, settleMs, streamLogs });
+    await launchAndCollectLogs({
+      appExecutable,
+      smokeUrl,
+      dataDir,
+      timeoutMs,
+      settleMs,
+      streamLogs,
+    });
 
     if (!coldRestart) return;
 

--- a/tests/unit/electron-smoke-script.test.ts
+++ b/tests/unit/electron-smoke-script.test.ts
@@ -7,6 +7,8 @@ import {
   FATAL_LOG_PATTERNS,
   LINUX_EXECUTABLE_NAMES,
   stopApp,
+  waitForDriverLine,
+  DB_TOUCH_PATH,
 } from "../../scripts/dev/smoke-electron-packaged.mjs";
 
 test("electron smoke discovers the default Linux executable name", () => {
@@ -95,5 +97,26 @@ test("electron smoke flags startup logs missing any driver selection line", () =
   assert.throws(
     () => assertNativeDriverSelected("[electron] [server] listening on 20128"),
     /no '\[DB\] Driver: \.\.\.' line/
+  );
+});
+
+test("electron smoke waits for the [DB] Driver line after touching a DB-backed endpoint", async () => {
+  assert.equal(DB_TOUCH_PATH, "/api/monitoring/health");
+  let logs = "[electron] [Server] [STARTUP] ready\n";
+  setTimeout(() => {
+    logs += "[electron] [Server] [DB] Driver: better-sqlite3 | file: /tmp/x/storage.sqlite\n";
+  }, 60);
+  const seen = await waitForDriverLine(() => logs, { timeoutMs: 2_000, pollMs: 20 });
+  assert.match(seen, /\[DB\] Driver: better-sqlite3/);
+});
+
+test("electron smoke fails clearly when the database never opens", async () => {
+  await assert.rejects(
+    () =>
+      waitForDriverLine(() => "[electron] [Server] [STARTUP] ready\n", {
+        timeoutMs: 120,
+        pollMs: 20,
+      }),
+    /logged no "\[DB\] Driver: \.\.\." line within 120ms/
   );
 });

--- a/tests/unit/electron-smoke-script.test.ts
+++ b/tests/unit/electron-smoke-script.test.ts
@@ -7,7 +7,7 @@ import {
   FATAL_LOG_PATTERNS,
   LINUX_EXECUTABLE_NAMES,
   stopApp,
-  waitForDriverLine,
+  waitForDatabaseOpen,
   DB_TOUCH_PATH,
 } from "../../scripts/dev/smoke-electron-packaged.mjs";
 
@@ -96,27 +96,46 @@ test("electron smoke flags a cold-restart fallback to the sql.js WASM driver", (
 test("electron smoke flags startup logs missing any driver selection line", () => {
   assert.throws(
     () => assertNativeDriverSelected("[electron] [server] listening on 20128"),
-    /no '\[DB\] Driver: \.\.\.' line/
+    /no database activity/
   );
 });
 
-test("electron smoke waits for the [DB] Driver line after touching a DB-backed endpoint", async () => {
+test("electron smoke waits for database-open evidence after touching a DB-backed endpoint", async () => {
   assert.equal(DB_TOUCH_PATH, "/api/monitoring/health");
   let logs = "[electron] [Server] [STARTUP] ready\n";
   setTimeout(() => {
-    logs += "[electron] [Server] [DB] Driver: better-sqlite3 | file: /tmp/x/storage.sqlite\n";
+    logs += "[electron] [Server] [DB] Added usage_history.combo_strategy column\n";
   }, 60);
-  const seen = await waitForDriverLine(() => logs, { timeoutMs: 2_000, pollMs: 20 });
-  assert.match(seen, /\[DB\] Driver: better-sqlite3/);
+  const seen = await waitForDatabaseOpen(() => logs, { timeoutMs: 2_000, pollMs: 20 });
+  assert.match(seen, /\[DB\] Added/);
 });
 
 test("electron smoke fails clearly when the database never opens", async () => {
   await assert.rejects(
     () =>
-      waitForDriverLine(() => "[electron] [Server] [STARTUP] ready\n", {
+      waitForDatabaseOpen(() => "[electron] [Server] [STARTUP] ready\n", {
         timeoutMs: 120,
         pollMs: 20,
       }),
-    /logged no "\[DB\] Driver: \.\.\." line within 120ms/
+    /logged no \[DB\]\/\[Migration\] startup line within 120ms/
+  );
+});
+
+test("electron smoke driver guard: native line, DB evidence and sql.js fallback", () => {
+  assert.doesNotThrow(() =>
+    assertNativeDriverSelected("[DB] Driver: better-sqlite3 | file: /tmp/x/storage.sqlite\n")
+  );
+  assert.doesNotThrow(() =>
+    assertNativeDriverSelected(
+      "[electron] [Server] [DB] Added call_logs.session_tag column\n[electron] [Server] [Migration] Applied: 046_database_settings\n"
+    )
+  );
+  assert.throws(
+    () => assertNativeDriverSelected("[DB] Driver: sql.js | file: /tmp/x/storage.sqlite\n"),
+    /sql\.js \(WASM\) driver/
+  );
+  assert.throws(
+    () => assertNativeDriverSelected("[STARTUP] nothing here\n"),
+    /no database activity/
   );
 });


### PR DESCRIPTION
Gêmeo na `main` do que a #12022 fez na `.51`: o CodeQL (`actions/cache-poisoning/poisonable-step`, high) rastreia um checkout controlado por input — mesmo passando por allowlist na saída do job — ao lado do cache do npm na branch default como envenenamento de cache. Só acusou na `.51` por ser a default, mas a superfície é a mesma aqui.

O ref deixa de ser input: os checkouts voltam ao `github.ref`. Contrato de dispatch (documentado no `on:`): `gh workflow run electron-release.yml --ref v3.8.50 -f version=v3.8.50` reconstrói a tag; `--ref main` builda a linha reparada — foi assim que os assets da v3.8.50 foram gerados (run 33251755872). Push de tag inalterado.

actionlint/prettier limpos; as 4 suítes que pinam o workflow passam.

## Também nesta PR — smoke do app empacotado (`3f3cb0392a`)

No redisparo (run 33251755872) o leg Linux passou por install, build e empacotamento e caiu no **smoke**: o app abre o SQLite de forma preguiçosa e a URL de prontidão (`/login`) não toca o DB, então os logs não tinham a linha `[DB] Driver: …` e `assertNativeDriverSelected` não conseguia distinguir "driver nativo" de "banco nunca aberto". Agora, após a prontidão, o smoke requisita `/api/monitoring/health` (endpoint com DB) e espera até 15 s pela linha do driver antes de seguir; a asserção do cold-restart continua igual. `electron-smoke-script.test.ts` 9/9 (2 casos novos: linha aparece / nunca aparece).
