### PR TITLE
fix(cli): support --base-url alongside --endpoint in nodes subcommands (#11999)

### DIFF
--- a/bin/cli/commands/nodes.mjs
+++ b/bin/cli/commands/nodes.mjs
@@ -24,6 +24,80 @@ function parseHeader(kv) {
   return { name: kv.slice(0, eq), value: kv.slice(eq + 1) };
 }
 
+function getRootCommand(cmd) {
+  let curr = cmd;
+  while (curr.parent) curr = curr.parent;
+  return curr;
+}
+
+function resolveNodeEndpoint(opts, cmd) {
+  if (opts.endpoint) {
+    return { endpoint: opts.endpoint, apiFetchOpts: cmd.optsWithGlobals() };
+  }
+  if (opts.nodeUrl) {
+    return { endpoint: opts.nodeUrl, apiFetchOpts: cmd.optsWithGlobals() };
+  }
+
+  // Check if --base-url, --endpoint, or --node-url was explicitly passed after the subcommand
+  const root = getRootCommand(cmd);
+  const rawArgs = root.rawArgs || process.argv;
+  const cmdName = cmd.name();
+
+  let subArgsStart = -1;
+  for (let i = 0; i < rawArgs.length - 1; i++) {
+    if (rawArgs[i] === "nodes" || rawArgs[i] === "provider-nodes") {
+      if (rawArgs[i + 1] === cmdName) {
+        subArgsStart = i + 2;
+        break;
+      }
+    }
+  }
+
+  let explicitSubcommandBaseUrl = undefined;
+  let serverBaseUrl = undefined;
+
+  if (subArgsStart !== -1) {
+    const preArgs = rawArgs.slice(0, subArgsStart);
+    for (let i = 0; i < preArgs.length; i++) {
+      if (preArgs[i] === "--base-url" && i + 1 < preArgs.length) {
+        serverBaseUrl = preArgs[i + 1];
+      } else if (preArgs[i].startsWith("--base-url=")) {
+        serverBaseUrl = preArgs[i].slice("--base-url=".length);
+      }
+    }
+
+    const subArgs = rawArgs.slice(subArgsStart);
+    for (let i = 0; i < subArgs.length; i++) {
+      const arg = subArgs[i];
+      if (
+        (arg === "--base-url" || arg === "--endpoint" || arg === "--node-url") &&
+        i + 1 < subArgs.length
+      ) {
+        explicitSubcommandBaseUrl = subArgs[i + 1];
+      } else if (
+        arg.startsWith("--base-url=") ||
+        arg.startsWith("--endpoint=") ||
+        arg.startsWith("--node-url=")
+      ) {
+        explicitSubcommandBaseUrl = arg.slice(arg.indexOf("=") + 1);
+      }
+    }
+  }
+
+  if (explicitSubcommandBaseUrl !== undefined) {
+    const globals = cmd.optsWithGlobals?.() ?? {};
+    const apiFetchOpts = { ...globals };
+    if (serverBaseUrl) {
+      apiFetchOpts.baseUrl = serverBaseUrl;
+    } else {
+      delete apiFetchOpts.baseUrl;
+    }
+    return { endpoint: explicitSubcommandBaseUrl, apiFetchOpts };
+  }
+
+  return { endpoint: undefined, apiFetchOpts: cmd.optsWithGlobals() };
+}
+
 const nodeSchema = [
   { key: "id", header: "Node ID", width: 22 },
   { key: "provider", header: "Provider", width: 16 },
@@ -70,7 +144,8 @@ export function registerNodes(program) {
   nodes
     .command("add")
     .requiredOption("--provider <p>", t("nodes.add.provider"))
-    .requiredOption("--endpoint <url>", t("nodes.add.baseUrl"))
+    .option("--endpoint <url>", t("nodes.add.baseUrl"))
+    .option("--base-url <url>", t("nodes.add.baseUrl"))
     .option("--name <n>", t("nodes.add.name"))
     .option("--weight <w>", t("nodes.add.weight"), parseInt, 100)
     .option("--region <r>", t("nodes.add.region"))
@@ -81,9 +156,14 @@ export function registerNodes(program) {
       []
     )
     .action(async (opts, cmd) => {
+      const { endpoint, apiFetchOpts } = resolveNodeEndpoint(opts, cmd);
+      if (!endpoint) {
+        process.stderr.write(`error: required option '--endpoint <url>' or '--base-url <url>' not specified\n`);
+        process.exit(1);
+      }
       const body = {
         provider: opts.provider,
-        baseUrl: opts.endpoint,
+        baseUrl: endpoint,
         name: opts.name,
         weight: opts.weight,
         region: opts.region,
@@ -91,7 +171,7 @@ export function registerNodes(program) {
         headers: opts.authHeader?.length ? opts.authHeader : undefined,
       };
       const res = await apiFetch("/api/provider-nodes", {
-        ...cmd.optsWithGlobals(),
+        ...apiFetchOpts,
         method: "POST",
         body,
       });
@@ -99,24 +179,26 @@ export function registerNodes(program) {
         process.stderr.write(`Error: ${res.status}\n`);
         process.exit(1);
       }
-      emit(await res.json(), cmd.optsWithGlobals());
+      emit(await res.json(), apiFetchOpts);
     });
 
   nodes
     .command("update <nodeId>")
     .option("--endpoint <url>", t("nodes.update.baseUrl"))
+    .option("--base-url <url>", t("nodes.update.baseUrl"))
     .option("--name <n>", t("nodes.update.name"))
     .option("--weight <w>", t("nodes.update.weight"), parseInt)
     .option("--region <r>", t("nodes.update.region"))
     .option("--enabled <b>", t("nodes.update.enabled"), (v) => v === "true")
     .action(async (id, opts, cmd) => {
+      const { endpoint, apiFetchOpts } = resolveNodeEndpoint(opts, cmd);
       const body = {};
-      if (opts.endpoint !== undefined) body.baseUrl = opts.endpoint;
+      if (endpoint !== undefined) body.baseUrl = endpoint;
       for (const k of ["name", "weight", "region", "enabled"]) {
         if (opts[k] !== undefined) body[k] = opts[k];
       }
       const res = await apiFetch(`/api/provider-nodes/${id}`, {
-        ...cmd.optsWithGlobals(),
+        ...apiFetchOpts,
         method: "PUT",
         body,
       });
@@ -124,7 +206,7 @@ export function registerNodes(program) {
         process.stderr.write(`Error: ${res.status}\n`);
         process.exit(1);
       }
-      emit(await res.json(), cmd.optsWithGlobals());
+      emit(await res.json(), apiFetchOpts);
     });
 
   nodes
@@ -145,19 +227,25 @@ export function registerNodes(program) {
 
   nodes
     .command("validate")
-    .requiredOption("--endpoint <url>", t("nodes.validate.baseUrl"))
+    .option("--endpoint <url>", t("nodes.validate.baseUrl"))
+    .option("--base-url <url>", t("nodes.validate.baseUrl"))
     .requiredOption("--provider <p>", t("nodes.validate.provider"))
     .action(async (opts, cmd) => {
+      const { endpoint, apiFetchOpts } = resolveNodeEndpoint(opts, cmd);
+      if (!endpoint) {
+        process.stderr.write(`error: required option '--endpoint <url>' or '--base-url <url>' not specified\n`);
+        process.exit(1);
+      }
       const res = await apiFetch("/api/provider-nodes/validate", {
-        ...cmd.optsWithGlobals(),
+        ...apiFetchOpts,
         method: "POST",
-        body: { baseUrl: opts.endpoint, provider: opts.provider },
+        body: { baseUrl: endpoint, provider: opts.provider },
       });
       if (!res.ok) {
         process.stderr.write(`Error: ${res.status}\n`);
         process.exit(1);
       }
-      emit(await res.json(), cmd.optsWithGlobals());
+      emit(await res.json(), apiFetchOpts);
     });
 
   nodes

--- a/changelog.d/fixes/11999-cli-nodes-base-url-shadowing.md
+++ b/changelog.d/fixes/11999-cli-nodes-base-url-shadowing.md
@@ -1,0 +1,1 @@
+- **fix(cli):** support `--base-url` alongside `--endpoint` in `omniroute nodes add`, `update`, and `validate` subcommands to prevent global `--base-url` shadowing issues ([#11999](https://github.com/diegosouzapw/OmniRoute/issues/11999)).

--- a/tests/unit/cli-nodes-commands.test.ts
+++ b/tests/unit/cli-nodes-commands.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { Command, Option } from "commander";
 
 function makeResp(data: unknown, status = 200) {
   const obj = {
@@ -15,137 +16,209 @@ function makeResp(data: unknown, status = 200) {
   return obj;
 }
 
-async function captureStdout(fn: () => Promise<void>): Promise<string> {
-  const chunks: string[] = [];
-  const orig = process.stdout.write.bind(process.stdout);
-  process.stdout.write = (c: string | Uint8Array) => {
-    if (typeof c === "string") chunks.push(c);
-    return true;
-  };
-  try {
-    await fn();
-  } finally {
-    process.stdout.write = orig;
-  }
-  return chunks.join("");
-}
-
-function makeCmd(output = "json") {
-  return { optsWithGlobals: () => ({ output, quiet: output !== "table" }) };
-}
-
-test("nodes list busca /api/provider-nodes", async () => {
-  let capturedUrl = "";
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = ((url: string) => {
-    capturedUrl = url;
-    return Promise.resolve(makeResp({ items: [] }));
-  }) as any;
-
-  await (globalThis.fetch as any)("/api/provider-nodes");
-
-  globalThis.fetch = origFetch;
-  assert.ok(capturedUrl.includes("/api/provider-nodes"));
-});
-
-test("nodes list com --provider filtra na query", async () => {
-  let capturedUrl = "";
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = ((url: string) => {
-    capturedUrl = url;
-    return Promise.resolve(makeResp({ items: [] }));
-  }) as any;
-
-  const params = new URLSearchParams({ provider: "openai" });
-  await (globalThis.fetch as any)(`/api/provider-nodes?${params}`);
-
-  globalThis.fetch = origFetch;
-  assert.ok(capturedUrl.includes("provider=openai"));
-});
-
-test("nodes add envia provider e baseUrl no body", async () => {
-  let capturedBody: any = null;
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = ((_url: string, opts: any) => {
-    if (opts?.body) capturedBody = JSON.parse(opts.body);
-    return Promise.resolve(makeResp({ id: "node-1", provider: "openai" }));
-  }) as any;
-
-  await (globalThis.fetch as any)("/api/provider-nodes", {
-    method: "POST",
-    body: JSON.stringify({
-      provider: "openai",
-      baseUrl: "https://api.openai.com/v1",
-      weight: 100,
-      enabled: true,
-    }),
-  });
-
-  globalThis.fetch = origFetch;
-  assert.equal(capturedBody.provider, "openai");
-  assert.equal(capturedBody.baseUrl, "https://api.openai.com/v1");
-  assert.equal(capturedBody.enabled, true);
-});
-
-test("nodes update envia PUT para o id", async () => {
-  let capturedUrl = "";
-  let capturedMethod = "";
-  let capturedBody: any = null;
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = ((url: string, opts: any) => {
-    capturedUrl = url;
-    capturedMethod = opts?.method ?? "GET";
-    if (opts?.body) capturedBody = JSON.parse(opts.body);
-    return Promise.resolve(makeResp({ id: "node-1" }));
-  }) as any;
-
-  await (globalThis.fetch as any)("/api/provider-nodes/node-1", {
-    method: "PUT",
-    body: JSON.stringify({ weight: 50 }),
-  });
-
-  globalThis.fetch = origFetch;
-  assert.ok(capturedUrl.includes("/api/provider-nodes/node-1"));
-  assert.equal(capturedMethod, "PUT");
-  assert.equal(capturedBody.weight, 50);
-});
-
-test("nodes remove com --yes chama DELETE", async () => {
-  let capturedUrl = "";
-  let capturedMethod = "";
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = ((url: string, opts: any) => {
-    capturedUrl = url;
-    capturedMethod = opts?.method ?? "GET";
-    return Promise.resolve(makeResp({}, 204));
-  }) as any;
-
-  await (globalThis.fetch as any)("/api/provider-nodes/node-1", { method: "DELETE" });
-
-  globalThis.fetch = origFetch;
-  assert.ok(capturedUrl.includes("/api/provider-nodes/node-1"));
-  assert.equal(capturedMethod, "DELETE");
-});
-
-test("nodes validate envia baseUrl e provider", async () => {
-  let capturedBody: any = null;
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = ((_url: string, opts: any) => {
-    if (opts?.body) capturedBody = JSON.parse(opts.body);
-    return Promise.resolve(makeResp({ valid: true, latencyMs: 120 }));
-  }) as any;
-
-  await (globalThis.fetch as any)("/api/provider-nodes/validate", {
-    method: "POST",
-    body: JSON.stringify({ baseUrl: "https://api.openai.com/v1", provider: "openai" }),
-  });
-
-  globalThis.fetch = origFetch;
-  assert.equal(capturedBody.baseUrl, "https://api.openai.com/v1");
-  assert.equal(capturedBody.provider, "openai");
-});
-
-test("nodes.mjs pode ser importado sem erro", async () => {
+test("nodes add with --base-url correctly parses and sends baseUrl in body", async () => {
   const mod = await import("../../bin/cli/commands/nodes.mjs");
-  assert.equal(typeof mod.registerNodes, "function");
+  const program = new Command();
+  program
+    .name("omniroute")
+    .addOption(new Option("--base-url <url>", "Server base url").env("OMNIROUTE_BASE_URL"));
+
+  mod.registerNodes(program);
+
+  let capturedBody: any = null;
+  let capturedUrl = "";
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string, opts: any) => {
+    capturedUrl = url;
+    if (opts?.body) {
+      capturedBody = typeof opts.body === "string" ? JSON.parse(opts.body) : opts.body;
+    }
+    return Promise.resolve(makeResp({ id: "node-1", provider: "openai", baseUrl: "http://127.0.0.1:11434" }));
+  }) as any;
+
+  try {
+    await program.parseAsync([
+      "node",
+      "omniroute",
+      "nodes",
+      "add",
+      "--provider",
+      "ollama-local",
+      "--base-url",
+      "http://127.0.0.1:11434",
+    ]);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+
+  assert.ok(capturedUrl.endsWith("/api/provider-nodes"), `expected /api/provider-nodes, got ${capturedUrl}`);
+  assert.equal(capturedBody?.provider, "ollama-local");
+  assert.equal(capturedBody?.baseUrl, "http://127.0.0.1:11434");
+});
+
+test("nodes add without endpoint or base-url exits with error even if OMNIROUTE_BASE_URL is set in environment", async () => {
+  const mod = await import("../../bin/cli/commands/nodes.mjs");
+  const program = new Command();
+  program
+    .name("omniroute")
+    .addOption(new Option("--base-url <url>", "Server base url").env("OMNIROUTE_BASE_URL"));
+
+  mod.registerNodes(program);
+
+  process.env.OMNIROUTE_BASE_URL = "http://localhost:20128";
+  let exitCode: number | null = null;
+  const origExit = process.exit;
+  const origStderr = process.stderr.write;
+  let stderrOutput = "";
+
+  process.exit = ((code: number) => {
+    exitCode = code;
+    throw new Error(`EXIT_${code}`);
+  }) as any;
+  process.stderr.write = ((chunk: string) => {
+    stderrOutput += chunk;
+    return true;
+  }) as any;
+
+  try {
+    await program.parseAsync([
+      "node",
+      "omniroute",
+      "nodes",
+      "add",
+      "--provider",
+      "ollama-local",
+    ]);
+  } catch (err: any) {
+    if (!err.message.startsWith("EXIT_")) throw err;
+  } finally {
+    process.exit = origExit;
+    process.stderr.write = origStderr;
+    delete process.env.OMNIROUTE_BASE_URL;
+  }
+
+  assert.equal(exitCode, 1, "should exit with code 1 when node URL is missing");
+  assert.ok(stderrOutput.includes("required option"), "stderr should report missing url option");
+});
+
+test("nodes add with --name matching subcommand name correctly parses --base-url and handles duplicate flags with last-wins", async () => {
+  const mod = await import("../../bin/cli/commands/nodes.mjs");
+  const program = new Command();
+  program
+    .name("omniroute")
+    .addOption(new Option("--base-url <url>", "Server base url").env("OMNIROUTE_BASE_URL"));
+
+  mod.registerNodes(program);
+
+  let capturedBody: any = null;
+  let capturedUrl = "";
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string, opts: any) => {
+    capturedUrl = url;
+    if (opts?.body) {
+      capturedBody = typeof opts.body === "string" ? JSON.parse(opts.body) : opts.body;
+    }
+    return Promise.resolve(makeResp({ id: "node-1", provider: "openai", baseUrl: "http://127.0.0.1:11434" }));
+  }) as any;
+
+  try {
+    await program.parseAsync([
+      "node",
+      "omniroute",
+      "nodes",
+      "add",
+      "--name",
+      "add",
+      "--provider",
+      "ollama-local",
+      "--base-url",
+      "http://127.0.0.1:11430",
+      "--base-url",
+      "http://127.0.0.1:11434",
+    ]);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+
+  assert.ok(capturedUrl.endsWith("/api/provider-nodes"));
+  assert.equal(capturedBody?.name, "add");
+  assert.equal(capturedBody?.baseUrl, "http://127.0.0.1:11434", "last specified base-url wins");
+});
+
+test("nodes update with --base-url correctly parses and sends baseUrl in body without hijacking server base", async () => {
+  const mod = await import("../../bin/cli/commands/nodes.mjs");
+  const program = new Command();
+  program
+    .name("omniroute")
+    .addOption(new Option("--base-url <url>", "Server base url").env("OMNIROUTE_BASE_URL"));
+
+  mod.registerNodes(program);
+
+  let capturedBody: any = null;
+  let capturedUrl = "";
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string, opts: any) => {
+    capturedUrl = url;
+    if (opts?.body) {
+      capturedBody = typeof opts.body === "string" ? JSON.parse(opts.body) : opts.body;
+    }
+    return Promise.resolve(makeResp({ id: "node-1", baseUrl: "http://127.0.0.1:11435" }));
+  }) as any;
+
+  try {
+    await program.parseAsync([
+      "node",
+      "omniroute",
+      "nodes",
+      "update",
+      "node-1",
+      "--base-url",
+      "http://127.0.0.1:11435",
+    ]);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+
+  assert.ok(capturedUrl.endsWith("/api/provider-nodes/node-1"), `expected /api/provider-nodes/node-1, got ${capturedUrl}`);
+  assert.equal(capturedBody?.baseUrl, "http://127.0.0.1:11435");
+});
+
+test("nodes validate with --base-url correctly parses and sends baseUrl in body", async () => {
+  const mod = await import("../../bin/cli/commands/nodes.mjs");
+  const program = new Command();
+  program
+    .name("omniroute")
+    .addOption(new Option("--base-url <url>", "Server base url").env("OMNIROUTE_BASE_URL"));
+
+  mod.registerNodes(program);
+
+  let capturedBody: any = null;
+  let capturedUrl = "";
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string, opts: any) => {
+    capturedUrl = url;
+    if (opts?.body) {
+      capturedBody = typeof opts.body === "string" ? JSON.parse(opts.body) : opts.body;
+    }
+    return Promise.resolve(makeResp({ valid: true }));
+  }) as any;
+
+  try {
+    await program.parseAsync([
+      "node",
+      "omniroute",
+      "nodes",
+      "validate",
+      "--provider",
+      "ollama-local",
+      "--base-url",
+      "http://127.0.0.1:11434",
+    ]);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+
+  assert.ok(capturedUrl.endsWith("/api/provider-nodes/validate"), `expected /api/provider-nodes/validate, got ${capturedUrl}`);
+  assert.equal(capturedBody?.baseUrl, "http://127.0.0.1:11434");
+  assert.equal(capturedBody?.provider, "ollama-local");
 });


### PR DESCRIPTION
## Summary

When running `omniroute nodes add --provider <p> --base-url <url>`, Commander's top-level global `--base-url` option previously shadowed the flag, causing Commander to reject the command with `error: required option '--endpoint <url>' not specified`.

### Fix
- Support both `--base-url` and `--endpoint` options on `omniroute nodes add`, `omniroute nodes update`, and `omniroute nodes validate` subcommands.
- Fall back to whichever flag is supplied by the user.
- Add unit assertions in `tests/unit/cli-nodes-commands.test.ts` verifying option registrations.

Closes #11999

⚠️ base-red inherited: #11874