### PR TITLE
fix(sse): default crash-guard logger to console.warn, not console

### DIFF
--- a/src/shared/utils/httpClientAbortGuard.mjs
+++ b/src/shared/utils/httpClientAbortGuard.mjs
@@ -117,7 +117,10 @@ export function installProcessCrashGuard(log) {
   if (crashGuardInstalled) return;
   crashGuardInstalled = true;
 
-  const logger = log ?? console;
+  // `console` is an object, not a callable: `log ?? console` followed by
+  // `logger("warn", ...)` throws TypeError and kills the process on the very
+  // abort the guard exists to swallow. Default to console.warn as a function.
+  const logger = typeof log === "function" ? log : console.warn.bind(console);
 
   process.on("uncaughtException", (err, origin) => {
     if (shouldSwallowUncaught(err, origin)) {

--- a/tests/unit/httpClientAbortGuard-default-logger.test.mjs
+++ b/tests/unit/httpClientAbortGuard-default-logger.test.mjs
@@ -1,0 +1,33 @@
+"use strict";
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+// Production calls installProcessCrashGuard() with NO argument in
+// apiBridgeServer.ts / liveServer.ts / embedWsProxy.ts. The default logger
+// must be callable; this file runs in its own node:test process, so the
+// module-level installed flag starts unset and the no-arg path is exercised
+// for real. Emitting "uncaughtException" through process.emit would trip the
+// test runner's own listener, so the guard handler is invoked directly.
+import { installProcessCrashGuard } from "../../src/shared/utils/httpClientAbortGuard.mjs";
+
+test("installProcessCrashGuard() with no argument swallows a client abort without throwing", () => {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    installProcessCrashGuard();
+    const handlers = process
+      .listeners("uncaughtException")
+      .filter((fn) => fn.toString().includes("swallowed client-abort"));
+    assert.ok(handlers.length > 0, "guard handler must be registered");
+    const abortErr = Object.assign(new Error("aborted"), { code: "ECONNRESET" });
+    // A broken default logger (console is an object, not a function) throws
+    // TypeError here — that is what took the production process down.
+    assert.doesNotThrow(() => handlers[0](abortErr, "uncaughtException"));
+    assert.equal(warnings.length, 1, "the swallowed abort must be logged once");
+    assert.ok(String(warnings[0][1]).includes("swallowed client-abort"));
+  } finally {
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
fix(sse): default crash-guard logger to console.warn, not console

## Problem

`installProcessCrashGuard()` is called with no argument from
`apiBridgeServer.ts`, `liveServer.ts` and `embedWsProxy.ts`. The default
logger was `log ?? console`, and the swallow path calls
`logger("warn", ...)`. `console` is an object, not a function, so the first
client abort that reached the process-level guard threw `TypeError: b is not
a function` inside the `uncaughtException` handler and took the whole server
down.

Observed in production on 2026-08-29 under load: a burst of client aborts
(ECONNRESET from cancelled streaming requests) hit the guard, the TypeError
killed the process, and systemd restarted it — twice in three minutes
(exit status 7, "uncaughtException: Error: aborted" immediately followed by
"TypeError: b is not a function" in the crash log). The guard introduced by
#11556 to prevent exactly this class of crash had become the crash itself.

## Fix

Default the logger to `console.warn.bind(console)` — a function — when the
caller passes nothing or a non-function:

```js
const logger = typeof log === "function" ? log : console.warn.bind(console);
```

## Verification

- New regression test exercises the no-argument path end to end: installs the
  guard, locates the registered handler, feeds it a real ECONNRESET-shaped
  error, and asserts the abort is swallowed and logged once (the broken
  default throws TypeError right there).
- Bug-injection round trip: reverting to `log ?? console` makes the new test
  fail; restoring the function default passes.
- Existing guard suite (re-export identity, idempotent install, swallow
  classification) stays green: 9/9.
