### PR TITLE
fix(provider/nous): inject required user tag into inference requests (#11861)

### DIFF
--- a/changelog.d/fixes/11861-nous-tags-user-injection.md
+++ b/changelog.d/fixes/11861-nous-tags-user-injection.md
@@ -1,0 +1,1 @@
+- **fix(provider/nous):** inject required user= tag into Nous Research inference requests to resolve upstream 400 "missing tags" error ([#11861](https://github.com/diegosouzapw/OmniRoute/issues/11861)) — thanks @Karan825

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -639,8 +639,7 @@ export class DefaultExecutor extends BaseExecutor {
 
     const record = body as Record<string, unknown>;
     const rf = record.response_format as
-      | { type?: string; json_schema?: { schema?: unknown } }
-      | undefined;
+      { type?: string; json_schema?: { schema?: unknown } } | undefined;
     if (!rf) return body;
 
     // openai-compatible-* providers accept json_object natively — only the
@@ -747,6 +746,38 @@ export class DefaultExecutor extends BaseExecutor {
       const withoutClientMetadata = { ...(withDefaults as Record<string, unknown>) };
       delete withoutClientMetadata.client_metadata;
       withDefaults = withoutClientMetadata;
+    }
+    // Nous Research inference gateway (portal.nousresearch.com) requires a top-level
+    // `tags` array containing at least a `user=` item on raw API-key requests (#11861).
+    // Without `tags`, upstream returns 400 "missing tags".
+    // Without `user=...`, upstream returns 400 "missing user tag".
+    if (
+      this.provider === "nous-research" &&
+      withDefaults &&
+      typeof withDefaults === "object" &&
+      !Array.isArray(withDefaults)
+    ) {
+      const record = withDefaults as Record<string, unknown>;
+      const extraBody = record.extra_body as Record<string, unknown> | undefined;
+
+      const rawTags = Array.isArray(record.tags)
+        ? (record.tags as unknown[])
+        : Array.isArray(extraBody?.tags)
+          ? (extraBody.tags as unknown[])
+          : [];
+
+      const stringTags = rawTags.filter(
+        (t): t is string => typeof t === "string" && t.trim().length > 0
+      );
+
+      const hasUserTag = stringTags.some((t) => t.startsWith("user="));
+      if (!hasUserTag) {
+        const username =
+          typeof record.user === "string" && record.user.trim() ? record.user.trim() : "omniroute";
+        record.tags = [...stringTags, `user=${username}`];
+      } else {
+        record.tags = stringTags;
+      }
     }
 
     // 9router#1649: Mistral's API returns 422 (extra_forbidden) when an

--- a/src/lib/providers/validation/audioMiscProviders.ts
+++ b/src/lib/providers/validation/audioMiscProviders.ts
@@ -631,6 +631,7 @@ export async function validateNousResearchProvider({ apiKey, providerSpecificDat
         model: modelId,
         messages: [{ role: "user", content: "test" }],
         max_tokens: 1,
+        tags: ["user=omniroute"],
       }),
     });
 

--- a/tests/unit/executor-nous-research.test.ts
+++ b/tests/unit/executor-nous-research.test.ts
@@ -29,8 +29,62 @@ test("nous-research DefaultExecutor.buildUrl() targets the correct inference end
 
   const url = executor.buildUrl("Hermes-4-70B", false, 0, null);
 
-  assert.equal(
-    url,
-    "https://inference-api.nousresearch.com/v1/chat/completions"
-  );
+  assert.equal(url, "https://inference-api.nousresearch.com/v1/chat/completions");
+});
+
+test("nous-research DefaultExecutor.transformRequest injects user=omniroute tag when tags is absent (#11861)", () => {
+  const executor = new DefaultExecutor("nous-research");
+  const transformed = executor.transformRequest(
+    "Hermes-4-70B",
+    { model: "Hermes-4-70B", messages: [{ role: "user", content: "hello" }] },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  assert.ok(Array.isArray(transformed.tags), "Expected tags array on nous-research body");
+  assert.deepEqual(transformed.tags, ["user=omniroute"]);
+});
+
+test("nous-research DefaultExecutor.transformRequest respects client-sent user in tags (#11861)", () => {
+  const executor = new DefaultExecutor("nous-research");
+  const transformed = executor.transformRequest(
+    "Hermes-4-70B",
+    { model: "Hermes-4-70B", user: "dev-user", messages: [{ role: "user", content: "hello" }] },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  assert.deepEqual(transformed.tags, ["user=dev-user"]);
+});
+
+test("nous-research DefaultExecutor.transformRequest preserves existing tags and appends user tag (#11861)", () => {
+  const executor = new DefaultExecutor("nous-research");
+  const transformed = executor.transformRequest(
+    "Hermes-4-70B",
+    {
+      model: "Hermes-4-70B",
+      tags: ["client=agent"],
+      messages: [{ role: "user", content: "hello" }],
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  assert.deepEqual(transformed.tags, ["client=agent", "user=omniroute"]);
+});
+
+test("nous-research DefaultExecutor.transformRequest does not duplicate user tag if already present (#11861)", () => {
+  const executor = new DefaultExecutor("nous-research");
+  const transformed = executor.transformRequest(
+    "Hermes-4-70B",
+    {
+      model: "Hermes-4-70B",
+      tags: ["user=custom-tag"],
+      messages: [{ role: "user", content: "hello" }],
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  assert.deepEqual(transformed.tags, ["user=custom-tag"]);
 });


### PR DESCRIPTION
Hi @diegosouzapw,

I have successfully isolated and confirmed the exact root cause!

When using raw API-key authentication against the Nous Portal inference gateway (`https://inference-api.nousresearch.com/v1/chat/completions`), the upstream API strictly requires a top-level `tags` array containing at least one `user=` entry.

Here are the captured request/response test cases:

---

### Case 1: Standard OpenAI request (Omitted `tags`)
**Request:**
```bash
curl https://inference-api.nousresearch.com/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $NOUS_API_KEY" \
  -d '{
    "model": "Hermes-4-70B",
    "messages": [{"role": "user", "content": "Hello"}]
  }'
```
**Upstream Response (HTTP 400):**
```json
{
  "error": {
    "message": "This request is not valid. Check the model name and other parameters. Additional info: missing tags",
    "type": "invalid_request_error"
  }
}
```
*This is the exact error reported by the Discord user.*

---

### Case 2: `tags` array present, but missing `user=` entry
**Request:**
```json
{
  "model": "Hermes-4-70B",
  "messages": [{"role": "user", "content": "Hello"}],
  "tags": ["client=omniroute"]
}
```
**Upstream Response (HTTP 400):**
```json
{
  "error": {
    "message": "This request is not valid. Check the model name and other parameters. Additional info: missing user tag",
    "type": "invalid_request_error"
  }
}
```

---

### Case 3: `tags` array with `user=` entry
**Request:**
```json
{
  "model": "Hermes-4-70B",
  "messages": [{"role": "user", "content": "Hello"}],
  "tags": ["user=omniroute"]
}
```
**Upstream Response (HTTP 200):**
```json
{
  "id": "chatcmpl-...",
  "object": "chat.completion",
  "model": "Hermes-4-70B",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Hello! How can I help you today?"
      },
      "finish_reason": "stop"
    }
  ]
}
```
*Succeeds immediately.*

---

### Why OmniRoute was affected
OmniRoute's `DefaultExecutor` forwards incoming OpenAI-compatible requests verbatim without `tags`. In fact, OmniRoute's own validator probe in `src/lib/providers/validation/audioMiscProviders.ts` was hitting this exact 400, which led to the 4xx masking workaround in #3881.

### Solution
I have opened a PR with the fix:
1. Updated `DefaultExecutor.transformRequest()` to ensure a `user=` item is present in `tags` for `nous-research` (using `body.user` if provided, otherwise defaulting to `user=omniroute`), while preserving any client-sent tags or `extra_body.tags`.
2. Updated the validator probe in `audioMiscProviders.ts` with `tags: ["user=omniroute"]`.
3. Added 4 regression tests in `tests/unit/executor-nous-research.test.ts` covering tag injection, preservation of client tags, and non-duplication (all 6 tests passing).
4. Added changelog fragment for release aggregation.
