### PR TITLE
fix(release): the packaged-app smoke verifies the database opened, not a driver line the primary path never prints (twin of #12032)

### DIFF
--- a/scripts/dev/smoke-electron-packaged.mjs
+++ b/scripts/dev/smoke-electron-packaged.mjs
@@ -123,6 +123,48 @@ function discoverPackagedExecutable() {
   throw new Error(`Packaged Electron smoke check does not support ${platform()}.`);
 }
 
+/**
+ * The packaged app opens SQLite lazily: `/login` (the readiness URL) never touches the
+ * database, so a smoke that only waits for readiness sees no `[DB]` line at all. After
+ * readiness the smoke requests a DB-backed endpoint and waits for evidence that the
+ * database opened. The primary open path does NOT print "[DB] Driver: ..." (only the
+ * recovery path and the sql.js fallback do), so the evidence is any `[DB]`/`[Migration]`
+ * startup line — and the #7592 guard below rejects the fallback's own line explicitly.
+ */
+export const DB_TOUCH_PATH = "/api/monitoring/health";
+export const DB_OPEN_EVIDENCE_PATTERN =
+  /\[DB\] (Driver: |SQLite database ready|Added [^\n]* column|Changing cache_size|cache_size changed)|\[Migration\] (Applied|Pre-migration backup)/;
+
+export async function waitForDatabaseOpen(getLogs, { timeoutMs = 15_000, pollMs = 250 } = {}) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const logs = getLogs();
+    assertNoFatalLogs(logs);
+    if (DB_OPEN_EVIDENCE_PATTERN.test(logs)) return logs;
+    await sleep(pollMs);
+  }
+  throw new Error(
+    `Packaged Electron app logged no [DB]/[Migration] startup line within ${timeoutMs}ms of ` +
+      `touching ${DB_TOUCH_PATH} — the database never opened, so the SQLite driver cannot be verified.`
+  );
+}
+
+async function openDatabaseForSmoke({ logs, smokeUrl }) {
+  const touchUrl = new URL(DB_TOUCH_PATH, smokeUrl).toString();
+  try {
+    const response = await fetchWithTimeout(touchUrl, 5_000);
+    console.log(
+      `[electron-smoke] touched ${touchUrl} (HTTP ${response.status}) to open the database`
+    );
+  } catch (error) {
+    console.log(
+      `[electron-smoke] touching ${touchUrl} failed (${error instanceof Error ? error.message : String(error)}) — waiting for the database anyway`
+    );
+  }
+  await waitForDatabaseOpen(() => logs.value);
+  console.log("[electron-smoke] database opened");
+}
+
 async function fetchWithTimeout(url, timeoutMs) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -360,12 +402,7 @@ function isInsideDir(parentDir, candidateDir) {
   return candidate === parent || candidate.startsWith(parent + sep);
 }
 
-export async function ensureSmokeEnvDirs(smokeEnv, dataDir, { currentPlatform = platform() } = {}) {
-  // The win32 branches below must key off the SMOKE TARGET's platform, not the
-  // host's: tests (and any future cross-platform dry-run) inject a win32-shaped
-  // smokeEnv while running on a Linux CI host, and branching on the host
-  // platform() there silently skipped the USERPROFILE/APPDATA userData tree —
-  // exactly what this function exists to pre-create (#7592).
+async function ensureSmokeEnvDirs(smokeEnv, dataDir) {
   const dirNames = [
     "DATA_DIR",
     "HOME",
@@ -388,19 +425,9 @@ export async function ensureSmokeEnvDirs(smokeEnv, dataDir, { currentPlatform = 
   // On Windows, Electron derives its userData from APPDATA/<productName>.
   // requestSingleInstanceLock() runs synchronously at module load and
   // fails silently if the directory doesn't exist yet — causing exit(0).
-  if (currentPlatform === "win32" && smokeEnv.APPDATA) {
+  if (platform() === "win32" && smokeEnv.APPDATA) {
     for (const subdir of ["omniroute-desktop", "OmniRoute", "omniroute"]) {
       dirs.push(join(smokeEnv.APPDATA, subdir));
-    }
-  }
-  // Electron resolves the Roaming profile from %USERPROFILE%\AppData\Roaming
-  // (USERPROFILE takes precedence over the APPDATA env var) and the path
-  // service throws — rather than creates — when that directory is missing,
-  // which makes requestSingleInstanceLock() return false and the app exit(0)
-  // before app.whenReady(). Pre-create the derived tree as well.
-  if (currentPlatform === "win32" && smokeEnv.USERPROFILE) {
-    for (const subdir of ["omniroute-desktop", "OmniRoute", "omniroute"]) {
-      dirs.push(join(smokeEnv.USERPROFILE, "AppData", "Roaming", subdir));
     }
   }
 
@@ -465,8 +492,13 @@ export function assertNativeDriverSelected(logs) {
     );
   }
 
+  // The primary open path prints no "[DB] Driver: ..." line at all (only the recovery path and
+  // the sql.js fallback do), so a database that demonstrably opened WITHOUT the fallback's own
+  // line is the native driver — that is exactly what #7592 guards.
+  if (DB_OPEN_EVIDENCE_PATTERN.test(logs)) return;
+
   throw new Error(
-    "Packaged Electron app logs contain no '[DB] Driver: ...' line — cannot confirm which SQLite " +
+    "Packaged Electron app logs show no database activity at all — cannot confirm which SQLite " +
       "driver loaded."
   );
 }
@@ -560,6 +592,8 @@ async function launchAndCollectLogs({
 
   try {
     await waitForReady({ logs, smokeUrl, timeoutMs, settleMs, exitState });
+    // Outside waitForReady on purpose: a missing database is a verdict, not a readiness retry.
+    await openDatabaseForSmoke({ logs, smokeUrl });
     return logs.value;
   } catch (error) {
     if (!streamLogs) {

--- a/scripts/dev/smoke-electron-packaged.mjs
+++ b/scripts/dev/smoke-electron-packaged.mjs
@@ -402,7 +402,12 @@ function isInsideDir(parentDir, candidateDir) {
   return candidate === parent || candidate.startsWith(parent + sep);
 }
 
-async function ensureSmokeEnvDirs(smokeEnv, dataDir) {
+export async function ensureSmokeEnvDirs(smokeEnv, dataDir, { currentPlatform = platform() } = {}) {
+  // The win32 branches below must key off the SMOKE TARGET's platform, not the
+  // host's: tests (and any future cross-platform dry-run) inject a win32-shaped
+  // smokeEnv while running on a Linux CI host, and branching on the host
+  // platform() there silently skipped the USERPROFILE/APPDATA userData tree —
+  // exactly what this function exists to pre-create (#7592).
   const dirNames = [
     "DATA_DIR",
     "HOME",
@@ -425,9 +430,19 @@ async function ensureSmokeEnvDirs(smokeEnv, dataDir) {
   // On Windows, Electron derives its userData from APPDATA/<productName>.
   // requestSingleInstanceLock() runs synchronously at module load and
   // fails silently if the directory doesn't exist yet — causing exit(0).
-  if (platform() === "win32" && smokeEnv.APPDATA) {
+  if (currentPlatform === "win32" && smokeEnv.APPDATA) {
     for (const subdir of ["omniroute-desktop", "OmniRoute", "omniroute"]) {
       dirs.push(join(smokeEnv.APPDATA, subdir));
+    }
+  }
+  // Electron resolves the Roaming profile from %USERPROFILE%\AppData\Roaming
+  // (USERPROFILE takes precedence over the APPDATA env var) and the path
+  // service throws — rather than creates — when that directory is missing,
+  // which makes requestSingleInstanceLock() return false and the app exit(0)
+  // before app.whenReady(). Pre-create the derived tree as well.
+  if (currentPlatform === "win32" && smokeEnv.USERPROFILE) {
+    for (const subdir of ["omniroute-desktop", "OmniRoute", "omniroute"]) {
+      dirs.push(join(smokeEnv.USERPROFILE, "AppData", "Roaming", subdir));
     }
   }
 

--- a/tests/unit/electron-smoke-script.test.ts
+++ b/tests/unit/electron-smoke-script.test.ts
@@ -1,24 +1,30 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
   assertNativeDriverSelected,
   buildSmokeEnv,
+  ensureSmokeEnvDirs,
   FATAL_LOG_PATTERNS,
   LINUX_EXECUTABLE_NAMES,
   stopApp,
   waitForDatabaseOpen,
   DB_TOUCH_PATH,
 } from "../../scripts/dev/smoke-electron-packaged.mjs";
+import { tarPack } from "../../scripts/build/optionalPackStaging.mjs";
 
 test("electron smoke discovers the default Linux executable name", () => {
   assert.ok(LINUX_EXECUTABLE_NAMES.includes("omniroute-desktop"));
 });
 
 test("electron smoke env allowlists runtime variables and drops secrets", () => {
+  const dataDir = path.join("/tmp", "omniroute-electron-smoke-test");
   const env = buildSmokeEnv({
     currentPlatform: "linux",
-    dataDir: "/tmp/omniroute-electron-smoke-test",
+    dataDir,
     parentEnv: {
       DISPLAY: ":99",
       GITHUB_TOKEN: "should-not-leak",
@@ -27,15 +33,62 @@ test("electron smoke env allowlists runtime variables and drops secrets", () => 
     },
   });
 
-  assert.equal(env.DATA_DIR, "/tmp/omniroute-electron-smoke-test");
+  // Expected values are built with path.join so the assertions hold on every
+  // host platform: buildSmokeEnv() composes its redirected paths with join(),
+  // which yields backslashes on Windows even when currentPlatform is "linux".
+  assert.equal(env.DATA_DIR, dataDir);
   assert.equal(env.DISPLAY, ":99");
   assert.equal(env.PATH, "/usr/bin");
-  assert.equal(env.HOME, "/tmp/omniroute-electron-smoke-test/home");
-  assert.equal(env.XDG_CONFIG_HOME, "/tmp/omniroute-electron-smoke-test/config");
+  assert.equal(env.HOME, path.join(dataDir, "home"));
+  assert.equal(env.XDG_CONFIG_HOME, path.join(dataDir, "config"));
   assert.equal(env.ELECTRON_ENABLE_LOGGING, "1");
   assert.equal(env.ELECTRON_ENABLE_STACK_DUMPING, "1");
   assert.equal(env.GITHUB_TOKEN, undefined);
   assert.equal(env.SNYK_TOKEN, undefined);
+});
+
+test("electron smoke pre-creates the USERPROFILE-derived Roaming userData tree on Windows", async () => {
+  // #7592: Electron resolves userData from %USERPROFILE%\AppData\Roaming\<name>
+  // (USERPROFILE takes precedence over the APPDATA env var) and the path
+  // service throws — rather than creates — when the directory is missing, so
+  // requestSingleInstanceLock() returns false and the app exits(0) silently.
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-smoke-env-test-"));
+  try {
+    const smokeEnv = buildSmokeEnv({ currentPlatform: "win32", dataDir });
+    // Inject the smoke TARGET platform: ensureSmokeEnvDirs must key its win32
+    // userData-tree branches off the target, not the host OS — otherwise this
+    // guard can never pass on a Linux CI host (the 8/9 red the reviewer hit).
+    await ensureSmokeEnvDirs(smokeEnv, dataDir, { currentPlatform: "win32" });
+
+    for (const appName of ["omniroute-desktop", "OmniRoute", "omniroute"]) {
+      const derived = path.join(smokeEnv.USERPROFILE, "AppData", "Roaming", appName);
+      assert.ok(fs.existsSync(derived), `expected pre-created derived userData dir: ${derived}`);
+      const viaAppData = path.join(smokeEnv.APPDATA, appName);
+      assert.ok(fs.existsSync(viaAppData), `expected pre-created APPDATA dir: ${viaAppData}`);
+    }
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});
+
+test("electron smoke tarPack handles absolute Windows-style tarball paths", () => {
+  // GNU tar treats `C:\...` in `-f` as a remote rsh target ("Cannot connect to
+  // C:"), which broke optional-pack staging on Windows. tarPack() must pass a
+  // bare filename with cwd at the tarball directory instead.
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-tar-pack-test-"));
+  try {
+    const nodeModules = path.join(staging, "pack", "node_modules");
+    fs.mkdirSync(path.join(nodeModules, "fixture-pkg"), { recursive: true });
+    fs.writeFileSync(path.join(nodeModules, "fixture-pkg", "index.js"), "module.exports = 1;");
+
+    const tarballPath = path.join(staging, "optional-pack-fixture.tar.gz");
+    tarPack(path.join(staging, "pack"), tarballPath);
+
+    assert.ok(fs.existsSync(tarballPath), "tarball should exist after tarPack");
+    assert.ok(fs.statSync(tarballPath).size > 0, "tarball should not be empty");
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
 });
 
 test("electron smoke treats Electron process errors as fatal startup logs", () => {

--- a/tests/unit/electron-smoke-script.test.ts
+++ b/tests/unit/electron-smoke-script.test.ts
@@ -1,28 +1,24 @@
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import test from "node:test";
 
 import {
   assertNativeDriverSelected,
   buildSmokeEnv,
-  ensureSmokeEnvDirs,
   FATAL_LOG_PATTERNS,
   LINUX_EXECUTABLE_NAMES,
   stopApp,
+  waitForDatabaseOpen,
+  DB_TOUCH_PATH,
 } from "../../scripts/dev/smoke-electron-packaged.mjs";
-import { tarPack } from "../../scripts/build/optionalPackStaging.mjs";
 
 test("electron smoke discovers the default Linux executable name", () => {
   assert.ok(LINUX_EXECUTABLE_NAMES.includes("omniroute-desktop"));
 });
 
 test("electron smoke env allowlists runtime variables and drops secrets", () => {
-  const dataDir = path.join("/tmp", "omniroute-electron-smoke-test");
   const env = buildSmokeEnv({
     currentPlatform: "linux",
-    dataDir,
+    dataDir: "/tmp/omniroute-electron-smoke-test",
     parentEnv: {
       DISPLAY: ":99",
       GITHUB_TOKEN: "should-not-leak",
@@ -31,62 +27,15 @@ test("electron smoke env allowlists runtime variables and drops secrets", () => 
     },
   });
 
-  // Expected values are built with path.join so the assertions hold on every
-  // host platform: buildSmokeEnv() composes its redirected paths with join(),
-  // which yields backslashes on Windows even when currentPlatform is "linux".
-  assert.equal(env.DATA_DIR, dataDir);
+  assert.equal(env.DATA_DIR, "/tmp/omniroute-electron-smoke-test");
   assert.equal(env.DISPLAY, ":99");
   assert.equal(env.PATH, "/usr/bin");
-  assert.equal(env.HOME, path.join(dataDir, "home"));
-  assert.equal(env.XDG_CONFIG_HOME, path.join(dataDir, "config"));
+  assert.equal(env.HOME, "/tmp/omniroute-electron-smoke-test/home");
+  assert.equal(env.XDG_CONFIG_HOME, "/tmp/omniroute-electron-smoke-test/config");
   assert.equal(env.ELECTRON_ENABLE_LOGGING, "1");
   assert.equal(env.ELECTRON_ENABLE_STACK_DUMPING, "1");
   assert.equal(env.GITHUB_TOKEN, undefined);
   assert.equal(env.SNYK_TOKEN, undefined);
-});
-
-test("electron smoke pre-creates the USERPROFILE-derived Roaming userData tree on Windows", async () => {
-  // #7592: Electron resolves userData from %USERPROFILE%\AppData\Roaming\<name>
-  // (USERPROFILE takes precedence over the APPDATA env var) and the path
-  // service throws — rather than creates — when the directory is missing, so
-  // requestSingleInstanceLock() returns false and the app exits(0) silently.
-  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-smoke-env-test-"));
-  try {
-    const smokeEnv = buildSmokeEnv({ currentPlatform: "win32", dataDir });
-    // Inject the smoke TARGET platform: ensureSmokeEnvDirs must key its win32
-    // userData-tree branches off the target, not the host OS — otherwise this
-    // guard can never pass on a Linux CI host (the 8/9 red the reviewer hit).
-    await ensureSmokeEnvDirs(smokeEnv, dataDir, { currentPlatform: "win32" });
-
-    for (const appName of ["omniroute-desktop", "OmniRoute", "omniroute"]) {
-      const derived = path.join(smokeEnv.USERPROFILE, "AppData", "Roaming", appName);
-      assert.ok(fs.existsSync(derived), `expected pre-created derived userData dir: ${derived}`);
-      const viaAppData = path.join(smokeEnv.APPDATA, appName);
-      assert.ok(fs.existsSync(viaAppData), `expected pre-created APPDATA dir: ${viaAppData}`);
-    }
-  } finally {
-    fs.rmSync(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-  }
-});
-
-test("electron smoke tarPack handles absolute Windows-style tarball paths", () => {
-  // GNU tar treats `C:\...` in `-f` as a remote rsh target ("Cannot connect to
-  // C:"), which broke optional-pack staging on Windows. tarPack() must pass a
-  // bare filename with cwd at the tarball directory instead.
-  const staging = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-tar-pack-test-"));
-  try {
-    const nodeModules = path.join(staging, "pack", "node_modules");
-    fs.mkdirSync(path.join(nodeModules, "fixture-pkg"), { recursive: true });
-    fs.writeFileSync(path.join(nodeModules, "fixture-pkg", "index.js"), "module.exports = 1;");
-
-    const tarballPath = path.join(staging, "optional-pack-fixture.tar.gz");
-    tarPack(path.join(staging, "pack"), tarballPath);
-
-    assert.ok(fs.existsSync(tarballPath), "tarball should exist after tarPack");
-    assert.ok(fs.statSync(tarballPath).size > 0, "tarball should not be empty");
-  } finally {
-    fs.rmSync(staging, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-  }
 });
 
 test("electron smoke treats Electron process errors as fatal startup logs", () => {
@@ -147,6 +96,46 @@ test("electron smoke flags a cold-restart fallback to the sql.js WASM driver", (
 test("electron smoke flags startup logs missing any driver selection line", () => {
   assert.throws(
     () => assertNativeDriverSelected("[electron] [server] listening on 20128"),
-    /no '\[DB\] Driver: \.\.\.' line/
+    /no database activity/
+  );
+});
+
+test("electron smoke waits for database-open evidence after touching a DB-backed endpoint", async () => {
+  assert.equal(DB_TOUCH_PATH, "/api/monitoring/health");
+  let logs = "[electron] [Server] [STARTUP] ready\n";
+  setTimeout(() => {
+    logs += "[electron] [Server] [DB] Added usage_history.combo_strategy column\n";
+  }, 60);
+  const seen = await waitForDatabaseOpen(() => logs, { timeoutMs: 2_000, pollMs: 20 });
+  assert.match(seen, /\[DB\] Added/);
+});
+
+test("electron smoke fails clearly when the database never opens", async () => {
+  await assert.rejects(
+    () =>
+      waitForDatabaseOpen(() => "[electron] [Server] [STARTUP] ready\n", {
+        timeoutMs: 120,
+        pollMs: 20,
+      }),
+    /logged no \[DB\]\/\[Migration\] startup line within 120ms/
+  );
+});
+
+test("electron smoke driver guard: native line, DB evidence and sql.js fallback", () => {
+  assert.doesNotThrow(() =>
+    assertNativeDriverSelected("[DB] Driver: better-sqlite3 | file: /tmp/x/storage.sqlite\n")
+  );
+  assert.doesNotThrow(() =>
+    assertNativeDriverSelected(
+      "[electron] [Server] [DB] Added call_logs.session_tag column\n[electron] [Server] [Migration] Applied: 046_database_settings\n"
+    )
+  );
+  assert.throws(
+    () => assertNativeDriverSelected("[DB] Driver: sql.js | file: /tmp/x/storage.sqlite\n"),
+    /sql\.js \(WASM\) driver/
+  );
+  assert.throws(
+    () => assertNativeDriverSelected("[STARTUP] nothing here\n"),
+    /no database activity/
   );
 });


### PR DESCRIPTION
Gêmeo na `release/v3.8.51` da parte de smoke da #12032, para o leg Linux da tag v3.8.51 não morrer no mesmo ponto.

**Achado (run 33251755872):** o app empacotado abre o SQLite durante o smoke (migrações, `[DB] Added … column`, `cache_size`), mas o caminho primário de abertura **não imprime** `[DB] Driver: …` — só o caminho de recuperação e o fallback sql.js imprimem. A asserção #7592 exigia uma linha inexistente.

**Guarda nova:** rejeita a linha do fallback sql.js (que sempre aparece quando ele acontece), aceita a linha de driver nativo e, fora isso, aceita evidência de atividade do banco. Após a prontidão o smoke requisita `/api/monitoring/health` e espera essa evidência (15 s), fora do loop de prontidão.

`electron-smoke-script.test.ts` 10/10; prettier limpo.