### PR TITLE
fix(radar): restore D12 public-source boundary

### DIFF
--- a/open-sse/utils/imageNormalize.ts
+++ b/open-sse/utils/imageNormalize.ts
@@ -1,7 +1,7 @@
 /**
  * Optional-sharp image normalization.
  *
- * Rationale (migrated from freellmapi `server/src/lib/image-normalize.ts:40-58`):
+ * Rationale:
  * OpenAI resizes images to a long-edge cap of 2048px server-side, Anthropic applies
  * a similar cap. Downscaling client-side before upload reduces tokens/latency without
  * changing model behavior. `sharp` is loaded via dynamic import so that a platform


### PR DESCRIPTION
## Summary

- removes a forbidden competitor attribution reintroduced after the D12 boundary was established
- keeps the image-normalization rationale and all runtime behavior unchanged
- limits the patch to one documentation line in the existing source file

## Validation

- private D12 tracked-tree guard: PASS
- `image-normalize.test.ts` + `vision-bridge-image-normalize.test.ts`: 6/6 PASS
- `git diff --check`: PASS

## Risk

Comment-only change; no production behavior, dependency, schema, or API change.