### PR TITLE
fix(build): default to webpack on Apple silicon (Turbopack does not converge, #12059)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -225,19 +225,36 @@ PORT=20128
 # Used by: src/app/api/v1/relay/chat/completions/route.ts
 # RELAY_IP_PER_MINUTE=30
 
-# Bundler selection for `npm run dev`. Set to 0 to fall back to webpack.
-# Default is 1 (Turbopack). PR #4092 had forced webpack because earlier
-# Turbopack 16.2.x panicked on the OmniRoute module graph with "internal error:
-# entered unreachable code: there must be a path to a root"
+# Bundler selection for `npm run dev` and `npm run build`. Set to 0 to force
+# webpack, 1 to force Turbopack.
+#
+# LEFT UNSET ON PURPOSE. When this is unset the build picks a platform-aware
+# default: webpack on Apple silicon, Turbopack everywhere else. Hardcoding 1
+# here overrides that and re-breaks the machines it exists to protect — see
+# below. Note `npm install` regenerates `.env` from this file, so a local
+# edit to `.env` does not survive the next install; the platform default does.
+#
+# Why Apple silicon needs webpack (#12059): on macOS arm64 with Next 16.3.2,
+# Turbopack does not converge. `next build` stalls indefinitely (25 min+ with
+# no progress, chunks pinned at 20) and `next dev` never reaches listen state
+# (stuck at "Compiling instrumentation Node.js"), while the same commits build
+# green in ~7 min in CI on Linux x64. Root cause is upstream: the JS transform
+# pool workers continuously respawn (44 unique workers in 11 min) and every
+# respawn re-runs the build's postcss transform. See vercel/next.js#98043 and
+# #97802 (open). The webpack path completes in ~13 min and is the reliable
+# option there.
+#
+# History: PR #4092 forced webpack because Turbopack 16.2.x panicked with
+# "internal error: entered unreachable code: there must be a path to a root"
 # (turbopack-core/module_graph/mod.rs:662). That panic no longer reproduces on
 # the pinned Next 16.2.9 — verified across a broad cold-compile sweep (36
 # dashboard routes + open-sse-heavy API routes incl. /api/v1/chat/completions,
 # /api/v1/models, /api/mcp) and repeated HMR rebuilds: zero panics. Turbopack
 # also keeps dev memory far lower on the edit→rebuild loop (HMR rebuild RSS stays
 # ~flat vs webpack's monotonic growth), which mitigates the dev-server OOM on
-# this 60+ route app. The production build still uses webpack (build pipeline is
-# unaffected by this dev-only flag).
-OMNIROUTE_USE_TURBOPACK=1
+# this 60+ route app. That verification predates 16.3.2 and does not cover the
+# arm64 stall above.
+#OMNIROUTE_USE_TURBOPACK=1
 
 # Disable systemd sd_notify (Type=notify / WatchdogSec=) even when running
 # under a systemd unit with NOTIFY_SOCKET set.

--- a/scripts/build/build-next-isolated.mjs
+++ b/scripts/build/build-next-isolated.mjs
@@ -132,13 +132,39 @@ function runNextBuild() {
   });
 }
 
-export function resolveNextBuildBundlerFlag(baseEnv = process.env) {
+/**
+ * True where Turbopack is known not to converge: Apple silicon on Next 16.3.2 (#12059).
+ * `next build` never completes (25 min+ with no progress, chunks pinned at 20) and
+ * `next dev` never reaches listen state, while the same commits build green in CI on
+ * Linux x64. Narrow on purpose — Intel Macs are untouched, so this does not penalise
+ * platforms we have not measured.
+ */
+export function isTurbopackStallPlatform(platform = process.platform, arch = process.arch) {
+  return platform === "darwin" && arch === "arm64";
+}
+
+export function resolveNextBuildBundlerFlag(
+  baseEnv = process.env,
+  platform = process.platform,
+  arch = process.arch
+) {
   // Turbopack is the default; OMNIROUTE_USE_TURBOPACK=0 is the documented escape hatch
   // to webpack (Windows, native-binding trouble, RAM-constrained machines — #6409, and
-  // docs/reference/ENVIRONMENT.md). The choice is env-only ON PURPOSE: the variable is
-  // the operator's control and CI sets it explicitly, so sniffing the runtime here would
-  // silently override an operator who asked for Turbopack.
+  // docs/reference/ENVIRONMENT.md). The variable is the operator's control and CI sets
+  // it explicitly, so an explicit value always wins below and runtime sniffing never
+  // overrides an operator who asked for Turbopack.
+  //
+  // What changed (#12059): the platform now selects the DEFAULT when nobody asked. On
+  // Apple silicon, picking Turbopack by default means a build that silently never
+  // finishes, which is worse than the slower-but-reliable webpack path (13 min).
+  // Operators who want Turbopack back set OMNIROUTE_USE_TURBOPACK=1 explicitly.
   if (baseEnv.OMNIROUTE_USE_TURBOPACK === "0") {
+    return "--webpack";
+  }
+  if (baseEnv.OMNIROUTE_USE_TURBOPACK !== undefined) {
+    return "--turbopack";
+  }
+  if (isTurbopackStallPlatform(platform, arch)) {
     return "--webpack";
   }
   return "--turbopack";

--- a/scripts/build/build-next-isolated.mjs
+++ b/scripts/build/build-next-isolated.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs/promises";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -93,6 +93,8 @@ export function ensureWindowsBuildProfileDirs(env, mkdirImpl = mkdirSync) {
 
 function runNextBuild() {
   return new Promise((resolve) => {
+    // .env bundler flag fill-in before the arg is constructed (see helper doc).
+    honorBundlerFlagFromEnvFile();
     const nextBin = path.join(projectRoot, "node_modules", "next", "dist", "bin", "next");
     const buildEnv = resolveNextBuildEnv(process.env);
     ensureWindowsBuildProfileDirs(buildEnv);
@@ -140,6 +142,30 @@ export function resolveNextBuildBundlerFlag(baseEnv = process.env) {
     return "--webpack";
   }
   return "--turbopack";
+}
+
+// Honor OMNIROUTE_USE_TURBOPACK from the repo `.env` on the BUILD path too.
+// Unlike the dev server (scripts/dev/run-next.mjs → bootstrapEnv()), this script
+// never loads .env, so the documented escape hatch set there — the exact remedy
+// for the #6409/#9695 RAM-constrained / macOS arm64 local-stall cases — was
+// silently ignored by `npm run build`: .env said 0 but the build still ran
+// Turbopack and stalled (2026-08-29 local investigation). Shell env wins;
+// .env only fills the variable in when it is absent (ports the DATA_DIR
+// pre-read pattern from run-next.mjs).
+// @param {NodeJS.ProcessEnv} [env]
+// @param {string} [cwd]
+export function honorBundlerFlagFromEnvFile(env = process.env, cwd = process.cwd()) {
+  if (env.OMNIROUTE_USE_TURBOPACK !== undefined) return env.OMNIROUTE_USE_TURBOPACK ?? null;
+  try {
+    const raw = readFileSync(path.join(cwd, ".env"), "utf8");
+    const match = raw.match(/^OMNIROUTE_USE_TURBOPACK=(\S+)\s*$/m);
+    if (match?.[1]) {
+      env.OMNIROUTE_USE_TURBOPACK = match[1].trim();
+    }
+  } catch {
+    /* .env missing or unreadable — shell env stays authoritative */
+  }
+  return env.OMNIROUTE_USE_TURBOPACK ?? null;
 }
 
 /**

--- a/scripts/dev/run-next.mjs
+++ b/scripts/dev/run-next.mjs
@@ -5,6 +5,7 @@ import http from "node:http";
 import path from "node:path";
 import next from "next";
 import { bootstrapEnv } from "../build/bootstrap-env.mjs";
+import { isTurbopackStallPlatform } from "../build/build-next-isolated.mjs";
 import { resolveRuntimePorts, withRuntimePortEnv } from "../build/runtime-env.mjs";
 import { createOmnirouteWsBridge } from "./v1-ws-bridge.mjs";
 import { createResponsesWsProxy } from "./responses-ws-proxy.mjs";
@@ -16,10 +17,7 @@ import { isTurbopackCacheCorruption, purgeAllTurbopackCaches } from "./turbopack
 import { randomUUID } from "node:crypto";
 import { getMainServerTimeoutConfig } from "./main-server-timeouts.mjs";
 import { createSystemdNotifier } from "./systemd-notify.mjs";
-import {
-  attachRequestStreamGuards,
-  installProcessCrashGuard,
-} from "./httpClientAbortGuard.mjs";
+import { attachRequestStreamGuards, installProcessCrashGuard } from "./httpClientAbortGuard.mjs";
 
 const { maybeHandleDisallowedMethod } = methodGuard;
 const { wrapRequestListenerWithHeadResponseGuard } = headResponseGuard;
@@ -108,8 +106,18 @@ const hostname = process.env.HOST || "0.0.0.0";
 // build default in build-next-isolated.mjs); OMNIROUTE_USE_TURBOPACK=0 is the
 // webpack escape hatch. Under Bun, Turbopack native V8 bindings are unavailable,
 // so Bun automatically disables Turbopack and uses Webpack.
+//
+// #12059: on Apple silicon Turbopack does not converge and `next dev` never reaches
+// listen state — measured at 5 min with zero progress past "Compiling instrumentation
+// Node.js", where webpack dev listens normally. So when the operator has NOT chosen,
+// fall back to the same platform default the build path uses, keeping dev and build
+// consistent. An explicit OMNIROUTE_USE_TURBOPACK still wins either way.
 const isBun = Boolean(process.versions.bun);
-const useTurbopack = dev && mergedEnv.OMNIROUTE_USE_TURBOPACK !== "0" && !isBun;
+const devBundlerExplicit = mergedEnv.OMNIROUTE_USE_TURBOPACK;
+const useTurbopack =
+  dev &&
+  !isBun &&
+  (devBundlerExplicit !== undefined ? devBundlerExplicit !== "0" : !isTurbopackStallPlatform());
 process.env.OMNIROUTE_WS_BRIDGE_SECRET ||= randomUUID();
 // Per-process secret used to prove the trusted peer-IP stamp came from this
 // server (read by the authz middleware in the same process). See peer-stamp.mjs.

--- a/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
+++ b/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
@@ -17,7 +17,9 @@ function makeProjectDir(envLine) {
 }
 
 test("resolveNextBuildBundlerFlag returns --turbopack by default", () => {
-  const flag = resolveNextBuildBundlerFlag({});
+  // Platform pinned: the default is platform-dependent since #12059, so a bare call
+  // would assert this machine's architecture instead of the rule being tested.
+  const flag = resolveNextBuildBundlerFlag({}, "linux", "x64");
   assert.equal(flag, "--turbopack");
 });
 
@@ -55,5 +57,31 @@ test("honorBundlerFlagFromEnvFile is a no-op when .env is missing", () => {
   const env = {};
   honorBundlerFlagFromEnvFile(env, fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-no-env-")));
   assert.equal(env.OMNIROUTE_USE_TURBOPACK, undefined);
-  assert.equal(resolveNextBuildBundlerFlag(env), "--turbopack");
+  // Platform pinned for the same reason as the default case above.
+  assert.equal(resolveNextBuildBundlerFlag(env, "linux", "x64"), "--turbopack");
+});
+
+// Turbopack is unusable on macOS arm64 with Next 16.3.2: `next build` never converges
+// (25 min+, chunks pinned at 20) and `next dev` never reaches listen state, while the
+// same commits are green in CI on Linux x64. See issue #12059.
+test("resolveNextBuildBundlerFlag defaults to --webpack on darwin/arm64", () => {
+  assert.equal(resolveNextBuildBundlerFlag({}, "darwin", "arm64"), "--webpack");
+});
+
+test("resolveNextBuildBundlerFlag still defaults to --turbopack on linux", () => {
+  assert.equal(resolveNextBuildBundlerFlag({}, "linux", "x64"), "--turbopack");
+});
+
+test("resolveNextBuildBundlerFlag defaults to --turbopack on darwin/x64 (Intel Mac)", () => {
+  // The stall is specific to arm64; do not penalise Intel Macs on a guess.
+  assert.equal(resolveNextBuildBundlerFlag({}, "darwin", "x64"), "--turbopack");
+});
+
+test("an explicit OMNIROUTE_USE_TURBOPACK=1 still wins on darwin/arm64", () => {
+  // The platform default only applies when the operator has NOT chosen. Overriding an
+  // explicit request is exactly what the original env-only design guarded against.
+  assert.equal(
+    resolveNextBuildBundlerFlag({ OMNIROUTE_USE_TURBOPACK: "1" }, "darwin", "arm64"),
+    "--turbopack"
+  );
 });

--- a/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
+++ b/tests/unit/build/resolve-next-build-bundler-flag.test.mjs
@@ -1,7 +1,20 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { resolveNextBuildBundlerFlag } from "../../../scripts/build/build-next-isolated.mjs";
+import {
+  honorBundlerFlagFromEnvFile,
+  resolveNextBuildBundlerFlag,
+} from "../../../scripts/build/build-next-isolated.mjs";
+
+/** Throwaway project dir carrying a `.env` with the given bundler setting. */
+function makeProjectDir(envLine) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-bundler-env-"));
+  fs.writeFileSync(path.join(dir, ".env"), `OTHER_SETTING=1\n${envLine}\n`);
+  return dir;
+}
 
 test("resolveNextBuildBundlerFlag returns --turbopack by default", () => {
   const flag = resolveNextBuildBundlerFlag({});
@@ -16,4 +29,31 @@ test("resolveNextBuildBundlerFlag returns --webpack when OMNIROUTE_USE_TURBOPACK
 test("resolveNextBuildBundlerFlag returns --turbopack when OMNIROUTE_USE_TURBOPACK is '1'", () => {
   const flag = resolveNextBuildBundlerFlag({ OMNIROUTE_USE_TURBOPACK: "1" });
   assert.equal(flag, "--turbopack");
+});
+
+// `npm run build` is the only entry point that never loads `.env` (the dev server
+// goes through scripts/dev/run-next.mjs → bootstrapEnv()). So the documented
+// escape hatch for the macOS arm64 Turbopack stall (#6409/#9695) was silently
+// ignored on the build path: `.env` said 0 and the build still ran Turbopack.
+test("honorBundlerFlagFromEnvFile fills OMNIROUTE_USE_TURBOPACK from .env", () => {
+  const dir = makeProjectDir("OMNIROUTE_USE_TURBOPACK=0");
+  const env = {};
+  honorBundlerFlagFromEnvFile(env, dir);
+  assert.equal(env.OMNIROUTE_USE_TURBOPACK, "0");
+  assert.equal(resolveNextBuildBundlerFlag(env), "--webpack");
+});
+
+test("honorBundlerFlagFromEnvFile lets the shell env win over .env", () => {
+  const dir = makeProjectDir("OMNIROUTE_USE_TURBOPACK=0");
+  const env = { OMNIROUTE_USE_TURBOPACK: "1" };
+  honorBundlerFlagFromEnvFile(env, dir);
+  assert.equal(env.OMNIROUTE_USE_TURBOPACK, "1");
+  assert.equal(resolveNextBuildBundlerFlag(env), "--turbopack");
+});
+
+test("honorBundlerFlagFromEnvFile is a no-op when .env is missing", () => {
+  const env = {};
+  honorBundlerFlagFromEnvFile(env, fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-no-env-")));
+  assert.equal(env.OMNIROUTE_USE_TURBOPACK, undefined);
+  assert.equal(resolveNextBuildBundlerFlag(env), "--turbopack");
 });

--- a/tests/unit/run-next-node-env.test.ts
+++ b/tests/unit/run-next-node-env.test.ts
@@ -41,3 +41,26 @@ test("NODE_ENV normalization runs after the merged-env copy and before next()", 
   );
   assert.ok(normalizeIdx < nextCallIdx, "NODE_ENV must be normalized BEFORE next() reads it");
 });
+
+// run-next.mjs still cannot be imported in-process, so this stays a source guard like
+// the cases above. #12059: on macOS arm64 Turbopack never finishes the first dev
+// compile — measured at 5 min with zero progress past "Compiling instrumentation
+// Node.js", where webpack dev reaches listen state. The dev path must therefore fall
+// back to the same platform default the build path uses instead of hardcoding
+// Turbopack, while still letting an operator-set value win.
+test("run-next.mjs falls back to the platform bundler default when unset", () => {
+  assert.match(
+    source,
+    /isTurbopackStallPlatform\s*\(/,
+    "run-next.mjs must consult isTurbopackStallPlatform() so dev and build agree on the default"
+  );
+  assert.match(
+    source,
+    /devBundlerExplicit\s*!==\s*undefined/,
+    "the platform default must only apply when OMNIROUTE_USE_TURBOPACK is unset, so an explicit operator choice still wins"
+  );
+  assert.ok(
+    !/const useTurbopack = dev && [^;]*OMNIROUTE_USE_TURBOPACK !== "0" && !isBun;/.test(source),
+    "run-next.mjs must not unconditionally default dev to Turbopack (#12059)"
+  );
+});


### PR DESCRIPTION
Fixes #12059. Stacked on #12018 (base: `fix/build-honor-env-bundler-flag`) so both
touch `build-next-isolated.mjs` without conflicting — this PR shows its own two
commits once #12018 lands.

## Problem

On macOS arm64 with Next 16.3.2, Turbopack does not finish. Measured on this
machine (M4, 10 cores, 32 GB):

| | Result |
|---|---|
| `next build`, Turbopack, macOS arm64 | **Never completes** — 25 min+, no progress, chunks pinned at 20 |
| `next build`, Turbopack, CI Linux x64 | ~7 min, green |
| `next build`, webpack, macOS arm64 | **13 min**, exit 0 |
| `next dev`, Turbopack | **Never listens** — stuck at `○ Compiling instrumentation Node.js ...`, **zero further output across a 300 s budget** |
| `next dev`, webpack | `[Next] dev server listening on http://0.0.0.0:20128 (webpack)` |

Root cause is upstream: Turbopack delegates the postcss/loader transform to a pool
of short-lived node workers — **44 unique workers in 11 min**, continuous respawn —
and every respawn re-runs the transform. Trace: 2,802,951 spans
(`turbopack_core::resolve` 427,456). See `vercel/next.js#98043` and `#97802` (open).

CI hides this completely: it is green on Linux, so nothing signals to an Apple
silicon contributor that the default is broken.

## Fix

`resolveNextBuildBundlerFlag()` and `run-next.mjs` now share one
`isTurbopackStallPlatform()` helper and pick a **platform-aware default**: webpack
on `darwin`/`arm64`, Turbopack everywhere else. Dev and build agree.

Deliberately narrow — Intel Macs and Linux are untouched, so nothing is penalised
on a guess.

**An operator-set value still wins.** The original env-only design explicitly
guarded against runtime sniffing overriding an explicit request; that guard is
intact. This only fills in the default when nobody asked. Setting
`OMNIROUTE_USE_TURBOPACK=1` on Apple silicon still gets Turbopack.

Decided outcomes (verified by reproduction of the expression):

```
unset   -> webpack     (Apple silicon)
"0"     -> webpack
"1"     -> turbopack   (explicit operator choice respected)
```

## Why `.env.example` changes too

It hardcoded `OMNIROUTE_USE_TURBOPACK=1`, which would override the new platform
default and re-break exactly the machines it protects. It has to be unset for the
default to apply.

This matters more than it looks: **`npm install`'s postinstall regenerates `.env`
from `.env.example`**, so a local `.env` edit does not survive the next install —
but a platform default does. That is precisely how the previous `=0` workaround was
silently lost on this machine.

The stale "no panics on Next 16.2.9" note is kept for history and marked as
predating 16.3.2, since the repo now runs 16.3.2.

## Tests

4 new cases in `tests/unit/build/resolve-next-build-bundler-flag.test.mjs`:

- default is `--webpack` on darwin/arm64
- default is still `--turbopack` on linux
- default is still `--turbopack` on darwin/x64 (Intel Mac)
- an explicit `OMNIROUTE_USE_TURBOPACK=1` still wins on darwin/arm64

Two existing "by default" cases now pin the platform explicitly. They were failing
after this change for a legitimate reason — they asserted *this machine's*
architecture rather than the rule, which is the wrong thing to encode in a test for
a platform-conditional function.

1 new source guard in `tests/unit/run-next-node-env.test.ts`, following that file's
existing convention (it cannot import `run-next.mjs` in-process due to top-level
side effects). It fails if the dev path reverts to unconditional Turbopack.

The `build-next-isolated.mjs` import added to `run-next.mjs` is side-effect free
(12 ms; `main()` is guarded by the entry-script check), which matters on the dev hot
path.

## Not included

The 13-minute webpack build time is unchanged. During this investigation the
following were measured and ruled out as build-time levers:

- NFT trace duplication (1,680 → 2 manifests, but 219 s → 227 s — no gain)
- `experimental.turbotrace` — removed in Next 16.3.2
- onnxruntime (340 MB but only 733 files; copy 1.1 s)
- postbuild I/O (docs + onnxruntime ≈ 2.4 s)

⚠️ base-red inherited: #11874
