### PR TITLE
[URGENT] fix(dev): bound webpack and Tailwind scans (phase 1)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -329,11 +329,12 @@ const nextConfig = {
     // TODO: Re-enable after fixing all sub-component useTranslations scope issues
     ignoreBuildErrors: true,
   },
-  webpack(config, { webpack }) {
+  webpack(config, { dev, webpack }) {
     config.ignoreWarnings = [
       ...(config.ignoreWarnings || []),
       isNextIntlExtractorDynamicImportWarning,
     ];
+    const nextDefaultSplitChunks = config.optimization?.splitChunks;
     config.optimization = config.optimization || {};
     config.optimization.splitChunks = {
       ...config.optimization.splitChunks,
@@ -392,6 +393,9 @@ const nextConfig = {
         },
       },
     };
+    // Next's development defaults are tuned for incremental route compilation.
+    // Retain the custom vendor topology for production without imposing it on dev.
+    if (dev) config.optimization.splitChunks = nextDefaultSplitChunks;
 
     if (isMinimalBuild) {
       // Mirror the turbopack.resolveAlias entries for webpack-built artifacts.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 /* Self-hosted Material Symbols icon font (#3695): the Google Fonts CDN
@@ -10,14 +10,12 @@
 @import "material-symbols/outlined.css";
 @source "../../node_modules/fumadocs-ui/css/generated/*.css";
 
-/* Tailwind v4 auto-detection cannot scan directories with parentheses
-   (e.g. Next.js route groups like "(dashboard)"). Explicit @source
-   directives ensure all utility classes in route groups are included. */
-@source "../app/(dashboard)";
+/* Keep Tailwind v4 from scanning the entire repository. The UI lives in the
+   App Router and shared component trees; third-party Fumadocs sources remain
+   explicit because node_modules is ignored by automatic detection. */
+@source "../app";
+@source "../shared";
 @source "../../node_modules/fumadocs-ui/dist/**/*.js";
-@source not "../../*.sqlite*";
-@source not "../../.claude*";
-@source not "../../.claude-memory";
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/tests/unit/dev-bundler-boundaries-12074.test.ts
+++ b/tests/unit/dev-bundler-boundaries-12074.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.cwd();
+const nextConfigPath = path.join(repoRoot, "next.config.mjs");
+
+async function loadNextConfig(label: string) {
+  return import(`${pathToFileURL(nextConfigPath).href}?case=${label}-${Date.now()}`);
+}
+
+test("Tailwind scans only the UI source roots declared by OmniRoute (#12074 phase 1)", () => {
+  const css = readFileSync(path.join(repoRoot, "src/app/globals.css"), "utf8");
+
+  assert.match(
+    css,
+    /@import\s+"tailwindcss"\s+source\(none\);/,
+    "automatic repository-wide Tailwind source detection must stay disabled"
+  );
+  assert.match(css, /@source\s+"\.\.\/app";/, "App Router components must stay scanned");
+  assert.match(css, /@source\s+"\.\.\/shared";/, "shared UI components must stay scanned");
+  assert.match(
+    css,
+    /@source\s+"\.\.\/\.\.\/node_modules\/fumadocs-ui\/dist\/\*\*\/\*\.js";/,
+    "Fumadocs runtime classes must stay scanned"
+  );
+});
+
+test("webpack dev keeps Next defaults instead of production vendor cache groups (#12074 phase 1)", async () => {
+  const { default: nextConfig } = await loadNextConfig("dev-split-chunks");
+  const originalSplitChunks = {
+    chunks: "async",
+    cacheGroups: {
+      framework: { name: "framework" },
+    },
+  };
+  const config = {
+    context: repoRoot,
+    ignoreWarnings: [],
+    optimization: { splitChunks: originalSplitChunks },
+    plugins: [],
+  };
+
+  nextConfig.webpack(config, {
+    dev: true,
+    isServer: false,
+    defaultLoaders: { babel: {} },
+    webpack: {},
+  });
+
+  assert.equal(config.optimization.splitChunks, originalSplitChunks);
+  const cacheGroups = config.optimization.splitChunks.cacheGroups as Record<string, unknown>;
+  assert.equal(cacheGroups.recharts, undefined);
+  assert.equal(cacheGroups.fumadocs, undefined);
+});
+
+test("webpack production retains OmniRoute vendor cache groups (#12074 phase 1)", async () => {
+  const { default: nextConfig } = await loadNextConfig("production-split-chunks");
+  const config = {
+    context: repoRoot,
+    ignoreWarnings: [],
+    optimization: { splitChunks: { cacheGroups: {} as Record<string, unknown> } },
+    plugins: [],
+  };
+
+  nextConfig.webpack(config, {
+    dev: false,
+    isServer: false,
+    defaultLoaders: { babel: {} },
+    webpack: {},
+  });
+
+  assert.ok(config.optimization.splitChunks.cacheGroups.recharts);
+  assert.ok(config.optimization.splitChunks.cacheGroups.fumadocs);
+});


### PR DESCRIPTION
## Summary

Phase 1 of #12074 bounds two avoidable sources of development-bundler work:

- Tailwind now uses source(none) and scans only the app/shared trees plus the required Fumadocs output.
- Webpack development mode keeps Next.js' own splitChunks defaults instead of applying the production vendor topology.
- Production chunking behavior remains unchanged.

This is intentionally conservative. It does not attempt the larger import-graph refactors tracked as later phases in #12074.

## Why

The current development build can retain multiple gigabytes while compiling ordinary dashboard and API routes. The global stylesheet previously allowed automatic Tailwind source discovery, and the webpack callback imposed the production cache-group topology during development as well.

## Validation

Regression command:

    node --import tsx/esm --test tests/unit/dev-bundler-boundaries-12074.test.ts tests/unit/next-config.test.ts tests/unit/run-next-node-env.test.ts tests/unit/design-grid-background.test.ts tests/unit/dashboard/material-icons-self-hosted.test.ts

Result: 36 passed, 0 failed.

An isolated webpack development smoke test used a temporary data directory/database and a separate Next output directory:

- cold /dashboard/providers: 307 in 3.71 s
- cold /api/health/ping: 200 in 2.56 s
- warm requests: about 0.01 s
- settled process RSS after both routes: about 5.89 GB
- no MaxListeners warning observed during the bounded smoke run

These measurements establish a reproducible Phase 1 baseline; they are not claimed as an apples-to-apples comparison with earlier runs.

## Out of scope

The issue deliberately separates the remaining work:

1. split the root settings read path
2. reduce instrumentation/executor graph fan-out
3. make logging/startup resources process-singleton
4. re-enable and qualify Turbopack

Refs #12074

## Cross-phase Webpack qualification

A controlled local A/B run stacked Phases 1-4 on the exact shared base. The combined tree reduced the representative dashboard cold compile from 23.21 s to 7.76 s and settled post-HMR RSS from 15.94 GiB to 14.06 GiB, but one layout HMR still retained roughly 6.4 GiB. The overall Webpack acceptance criteria are therefore not met yet.

This cross-phase result does not attribute the aggregate improvement to this standalone PR or expand its scope. Full measurements and the remaining graph evidence are recorded in [#12074](https://github.com/diegosouzapw/OmniRoute/issues/12074#issuecomment-5466049538).