### PR TITLE
[URGENT] fix(dev): isolate root layout settings reads (phase 2)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getLocale, getTranslations } from "next-intl/server";
 import { RTL_LOCALES } from "@/i18n/config";
 import { normalizeComplianceEventTypes } from "@/i18n/request";
-import { getSettings } from "@/lib/db/settings";
+import { getRootLayoutSettings } from "@/lib/db/rootLayoutSettings";
 import type { Viewport } from "next";
 import { PwaRegister } from "@/shared/components/PwaRegister";
 import { LocaleAutoDetect } from "@/shared/components/LocaleAutoDetect";
@@ -22,9 +22,9 @@ export const viewport: Viewport = {
 };
 
 export async function generateMetadata() {
-  const settings = await getSettings();
-  const instanceName = settings?.instanceName || "OmniRoute";
-  const customFaviconUrl = settings?.customFaviconUrl || settings?.customFaviconBase64;
+  const settings = await getRootLayoutSettings();
+  const instanceName = settings.instanceName;
+  const customFaviconUrl = settings.customFaviconUrl || settings.customFaviconBase64;
 
   return {
     title: `${instanceName} — AI Gateway for Multi-Provider LLMs`,

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -40,6 +40,7 @@ import { invalidateDbCache } from "./readCache";
 import { rowToCamel } from "./caseMapping";
 import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 import { parseModelAccessMode } from "./apiKeys/modelAccessMode";
+import { getExistingDbInstance as getDb, setDbInstance as setDb } from "./singleton";
 // Re-exported so existing call sites that pull these helpers off the core module keep working.
 export { toSnakeCase, toCamelCase, objToSnake, rowToCamel, cleanNulls } from "./caseMapping";
 import {
@@ -514,7 +515,6 @@ const SCHEMA_SQL = `
 // Module-level `let` resets on every webpack recompile, causing connection leaks.
 
 declare global {
-  var __omnirouteDb: SqliteAdapter | undefined;
   // Cycle-breaker counter for the probe-failed/restore cascade. Survives
   // Next.js HMR re-evaluations so concurrent subsystems all see the same
   // count and we abort with a clear error instead of looping forever.
@@ -527,18 +527,6 @@ declare global {
   // (BATCH, HealthCheck, ProviderLimitsSync, ModelSync) re-throws the same
   // OOM error forever with no terminal diagnostic.
   var __omnirouteDbOomFailureCount: number | undefined;
-}
-
-function getDb(): SqliteDatabase | null {
-  return globalThis.__omnirouteDb ?? null;
-}
-
-function setDb(db: SqliteDatabase | null): void {
-  if (db) {
-    globalThis.__omnirouteDb = db;
-  } else {
-    delete globalThis.__omnirouteDb;
-  }
 }
 
 function checkpointDb(db: SqliteDatabase, mode: CheckpointMode = "TRUNCATE"): boolean {

--- a/src/lib/db/rootLayoutSettings.ts
+++ b/src/lib/db/rootLayoutSettings.ts
@@ -1,0 +1,62 @@
+import { getExistingDbInstance } from "./singleton";
+
+export interface RootLayoutSettings {
+  instanceName: string;
+  customFaviconUrl: string;
+  customFaviconBase64: string;
+}
+
+type RootLayoutSettingKey = keyof RootLayoutSettings;
+type SettingsRow = {
+  key?: unknown;
+  value?: unknown;
+};
+
+const ROOT_LAYOUT_SETTING_KEYS = [
+  "instanceName",
+  "customFaviconUrl",
+  "customFaviconBase64",
+] as const satisfies readonly RootLayoutSettingKey[];
+
+const ROOT_LAYOUT_SETTING_KEY_SET = new Set<string>(ROOT_LAYOUT_SETTING_KEYS);
+
+const DEFAULT_ROOT_LAYOUT_SETTINGS: RootLayoutSettings = {
+  instanceName: "OmniRoute",
+  customFaviconUrl: "",
+  customFaviconBase64: "",
+};
+
+function parseStoredString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read only the settings needed while compiling and rendering the root layout. */
+export async function getRootLayoutSettings(): Promise<RootLayoutSettings> {
+  const db = getExistingDbInstance();
+  if (!db) return { ...DEFAULT_ROOT_LAYOUT_SETTINGS };
+
+  const rows = db
+    .prepare(
+      `SELECT key, value FROM key_value
+       WHERE namespace = 'settings' AND key IN (?, ?, ?)`
+    )
+    .all(...ROOT_LAYOUT_SETTING_KEYS) as SettingsRow[];
+  const settings = { ...DEFAULT_ROOT_LAYOUT_SETTINGS };
+
+  for (const row of rows) {
+    if (typeof row.key !== "string" || !ROOT_LAYOUT_SETTING_KEY_SET.has(row.key)) continue;
+    const value = parseStoredString(row.value);
+    if (value === null) continue;
+    settings[row.key as RootLayoutSettingKey] = value;
+  }
+
+  if (!settings.instanceName) settings.instanceName = DEFAULT_ROOT_LAYOUT_SETTINGS.instanceName;
+  return settings;
+}

--- a/src/lib/db/singleton.ts
+++ b/src/lib/db/singleton.ts
@@ -1,0 +1,19 @@
+import type { SqliteAdapter } from "./adapters/types";
+
+declare global {
+  var __omnirouteDb: SqliteAdapter | undefined;
+}
+
+/** Read the process-wide DB handle without initializing storage. */
+export function getExistingDbInstance(): SqliteAdapter | null {
+  return globalThis.__omnirouteDb ?? null;
+}
+
+/** Replace the process-wide DB handle while preserving it across Next.js HMR. */
+export function setDbInstance(db: SqliteAdapter | null): void {
+  if (db) {
+    globalThis.__omnirouteDb = db;
+  } else {
+    delete globalThis.__omnirouteDb;
+  }
+}

--- a/tests/unit/root-layout-settings-boundary-12074.test.ts
+++ b/tests/unit/root-layout-settings-boundary-12074.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-layout-settings-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const ORIGINAL_INITIAL_PASSWORD = process.env.INITIAL_PASSWORD;
+const core = await import("../../src/lib/db/core.ts");
+const { getRootLayoutSettings } = await import("../../src/lib/db/rootLayoutSettings.ts");
+
+function resetStorage(): void {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(() => {
+  resetStorage();
+  delete process.env.INITIAL_PASSWORD;
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_INITIAL_PASSWORD === undefined) {
+    delete process.env.INITIAL_PASSWORD;
+  } else {
+    process.env.INITIAL_PASSWORD = ORIGINAL_INITIAL_PASSWORD;
+  }
+});
+
+test("root layout imports the read-only settings leaf", () => {
+  const layoutSource = fs.readFileSync(path.join(process.cwd(), "src/app/layout.tsx"), "utf8");
+  const leafSource = fs.readFileSync(
+    path.join(process.cwd(), "src/lib/db/rootLayoutSettings.ts"),
+    "utf8"
+  );
+  const coreSource = fs.readFileSync(path.join(process.cwd(), "src/lib/db/core.ts"), "utf8");
+  const singletonSource = fs.readFileSync(
+    path.join(process.cwd(), "src/lib/db/singleton.ts"),
+    "utf8"
+  );
+
+  assert.match(
+    layoutSource,
+    /import \{ getRootLayoutSettings \} from "@\/lib\/db\/rootLayoutSettings";/
+  );
+  assert.doesNotMatch(layoutSource, /@\/lib\/db\/settings/);
+  assert.match(leafSource, /from "\.\/singleton"/);
+  assert.doesNotMatch(
+    leafSource,
+    /db\/settings|\.\/core|runtimeSettings|tokenHealth|providerModels/
+  );
+  assert.doesNotMatch(leafSource, /\b(?:INSERT|UPDATE|DELETE|REPLACE)\b/i);
+  assert.match(coreSource, /from "\.\/singleton"/);
+  assert.doesNotMatch(singletonSource, /db\/settings|\.\/core|readCache|runtimeSettings/);
+});
+
+test("root layout settings reader does not initialize the database", async () => {
+  process.env.INITIAL_PASSWORD = "must-not-trigger-startup";
+
+  assert.deepEqual(await getRootLayoutSettings(), {
+    instanceName: "OmniRoute",
+    customFaviconUrl: "",
+    customFaviconBase64: "",
+  });
+  assert.equal(fs.existsSync(path.join(TEST_DATA_DIR, "storage.sqlite")), false);
+});
+
+test("root layout settings reader returns only the persisted metadata fields", async () => {
+  const db = core.getDbInstance();
+  const insert = db.prepare(
+    "INSERT INTO key_value (namespace, key, value) VALUES ('settings', ?, ?)"
+  );
+
+  insert.run("instanceName", JSON.stringify("Route Lab"));
+  insert.run("customFaviconUrl", JSON.stringify("https://example.com/favicon.png"));
+  insert.run("customFaviconBase64", JSON.stringify("data:image/png;base64,AA=="));
+  insert.run("proxyEnabled", JSON.stringify(false));
+
+  assert.deepEqual(await getRootLayoutSettings(), {
+    instanceName: "Route Lab",
+    customFaviconUrl: "https://example.com/favicon.png",
+    customFaviconBase64: "data:image/png;base64,AA==",
+  });
+});
+
+test("root layout settings reader is read-only and falls back safely", async () => {
+  process.env.INITIAL_PASSWORD = "must-not-trigger-onboarding";
+  const db = core.getDbInstance();
+  db.prepare(
+    "INSERT INTO key_value (namespace, key, value) VALUES ('settings', 'instanceName', ?)"
+  ).run("not-json");
+
+  assert.deepEqual(await getRootLayoutSettings(), {
+    instanceName: "OmniRoute",
+    customFaviconUrl: "",
+    customFaviconBase64: "",
+  });
+
+  const onboardingRows = db
+    .prepare(
+      "SELECT key FROM key_value WHERE namespace = 'settings' AND key IN ('setupComplete', 'requireLogin')"
+    )
+    .all();
+  assert.deepEqual(onboardingRows, []);
+});


### PR DESCRIPTION
## Summary

Phase 2 of #12074 isolates the root layout metadata read from the full settings/runtime graph.

- replace the root layout import of `db/settings` with a narrow read-only leaf
- expose the already-initialized process-wide DB handle through a dependency-free singleton
- keep DB initialization, migrations, onboarding writes, runtime reloads, token health, and provider validation out of the root layout graph
- add focused boundary and behavior regression coverage

## Scope boundary

This PR is intentionally independent of Phase 1 and is based directly on `release/v3.8.51`. Executor and runtime graph decomposition remains Phase 3.

## Validation

- `node --import tsx/esm --test tests/unit/root-layout-settings-boundary-12074.test.ts tests/unit/db-core-init.test.ts tests/unit/db-read-cache.test.ts tests/unit/db-settings-crud.test.ts` — 50 passed
- `npm run typecheck:core` — passed
- `npm run check:cycles` — no cycles across 431 files
- `npm run lint` — passed
- Prettier check and `git diff --check` — passed

## Isolated webpack smoke

With an isolated `DATA_DIR`/`SQLITE_FILE` and `OMNIROUTE_USE_TURBOPACK=0`:

- `/login` cold request: 200; warm request: 200
- compiled page bundles contain `rootLayoutSettings.ts` and `singleton.ts`
- zero compiled-page occurrences of `db/core.ts`, `db/readCache.ts`, `db/settings.ts`, `runtimeSettings.ts`, `tokenHealthCheck.ts`, and provider validation
- observed server output changed from 954 MB to 860 MB and process RSS from about 7.62 GiB to 6.62 GiB in the same diagnostic session

Cold compile timing varied between runs, so this PR does not claim a timing improvement from that sample.

Refs #12074


## Cross-phase Webpack qualification

A controlled local A/B run stacked Phases 1-4 on the exact shared base. The combined tree reduced the representative dashboard cold compile from 23.21 s to 7.76 s and settled post-HMR RSS from 15.94 GiB to 14.06 GiB, but one layout HMR still retained roughly 6.4 GiB. The overall Webpack acceptance criteria are therefore not met yet.

This cross-phase result does not attribute the aggregate improvement to this standalone PR or expand its scope. Full measurements and the remaining graph evidence are recorded in [#12074](https://github.com/diegosouzapw/OmniRoute/issues/12074#issuecomment-5466049538).