### PR TITLE
fix(sse): keep unavailable forced connections scoped

### DIFF
--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -130,6 +130,7 @@ import { isFreeModel } from "@/shared/utils/freeModels";
 import {
   applySessionAffinityPin,
   formatSessionKeyForLog,
+  isForcedConnectionMissingFromPool,
   resolveForcedConnectionForCredentialPool,
   resolveSessionAffinityTtlMs,
   selectSessionAffinityConnection,
@@ -1342,21 +1343,39 @@ export async function getProviderCredentials(
         }) ?? forcedConnectionId;
     }
 
-    forcedConnectionId = resolveForcedConnectionForCredentialPool({
-      forcedConnectionId,
-      excludedConnectionIds,
-      connections,
-      allowRateLimitedConnections,
-      bypassQuotaPolicy,
-      isQuotaExhausted: (connectionId) =>
-        isQuotaExhaustedForRequest(connectionId, provider, requestedModel),
-      isQuotaPolicyBlocked: (connection) =>
-        evaluateQuotaLimitPolicy(provider, connection as ProviderConnectionView, requestedModel)
-          .blocked,
-    });
+    // A forced connection (combo step `connectionId` / `x-omniroute-connection`) is an
+    // operator instruction, not a suggestion. resolveForcedConnectionForCredentialPool()
+    // legitimately returns null for several *intentional* pin-release cases (forced ID
+    // already in excludedConnectionIds after a failed attempt, cooldown, quota exhaustion,
+    // quota-policy block) — those must keep degrading to normal sibling fallback, unchanged.
+    // The bug is narrower: the forced connection was requested, was NOT intentionally
+    // excluded, and simply is not present in the current active/allowed pool at all (e.g.
+    // an operator deactivated it). Detect exactly that case *before* calling the resolver,
+    // so it never gets folded in with the intentional-release cases above.
+    if (isForcedConnectionMissingFromPool(forcedConnectionId, excludedConnectionIds, connections)) {
+      // Route through the existing "target has no eligible credentials" recoverable path
+      // (the connections.length === 0 branch just below) instead of falling through to the
+      // full active pool. That path already returns null/CONNECTION_INELIGIBLE, which the
+      // chat handler turns into a 404 for combo requests so the combo loop advances to its
+      // next target — the same mechanism a whole disabled provider already relies on.
+      connections = [];
+    } else {
+      forcedConnectionId = resolveForcedConnectionForCredentialPool({
+        forcedConnectionId,
+        excludedConnectionIds,
+        connections,
+        allowRateLimitedConnections,
+        bypassQuotaPolicy,
+        isQuotaExhausted: (connectionId) =>
+          isQuotaExhaustedForRequest(connectionId, provider, requestedModel),
+        isQuotaPolicyBlocked: (connection) =>
+          evaluateQuotaLimitPolicy(provider, connection as ProviderConnectionView, requestedModel)
+            .blocked,
+      });
 
-    if (forcedConnectionId) {
-      connections = connections.filter((conn) => conn.id === forcedConnectionId);
+      if (forcedConnectionId) {
+        connections = connections.filter((conn) => conn.id === forcedConnectionId);
+      }
     }
     const activeConnectionsCount = connections.length;
     const rawConnectionsCount = connectionsRaw.length;

--- a/src/sse/services/sessionAffinityPin.ts
+++ b/src/sse/services/sessionAffinityPin.ts
@@ -575,3 +575,28 @@ export function resolveForcedConnectionForCredentialPool(
 
   return forced;
 }
+
+/**
+ * A forced connection (combo step `connectionId` / `x-omniroute-connection`) is an
+ * operator instruction, not a suggestion. resolveForcedConnectionForCredentialPool()
+ * above returns null for two very different reasons: (a) intentional pin-release
+ * cases it already handles correctly (the forced id was excluded after a failed
+ * attempt, is cooling down, or is quota-blocked — those must keep degrading to
+ * normal sibling fallback), and (b) the forced id simply not being present in the
+ * pool at all (e.g. an operator deactivated that connection). Only (b) must be
+ * treated as a hard failure instead of falling through to dynamic sibling
+ * selection across the rest of the provider's connections — this predicate
+ * identifies exactly (b), checked *before* resolveForcedConnectionForCredentialPool
+ * runs, so the two cases are never conflated.
+ */
+export function isForcedConnectionMissingFromPool(
+  forcedConnectionId: string | null,
+  excludedConnectionIds: ReadonlySet<string>,
+  connections: AffinityPinConnection[]
+): boolean {
+  return (
+    forcedConnectionId !== null &&
+    !excludedConnectionIds.has(forcedConnectionId) &&
+    !connections.some((conn) => conn.id === forcedConnectionId)
+  );
+}

--- a/tests/unit/forced-connection-fallback.test.ts
+++ b/tests/unit/forced-connection-fallback.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveForcedConnectionForCredentialPool } from "../../src/sse/services/sessionAffinityPin.ts";
+import {
+  isForcedConnectionMissingFromPool,
+  resolveForcedConnectionForCredentialPool,
+} from "../../src/sse/services/sessionAffinityPin.ts";
 
 const conn = (id: string, rateLimitedUntil: string | null = null) => ({
   id,
@@ -82,5 +85,94 @@ test("resolveForcedConnectionForCredentialPool with empty connections only check
       isQuotaPolicyBlocked: () => true,
     }),
     "pinned-account"
+  );
+});
+
+// --- isForcedConnectionMissingFromPool: the sibling-account-substitution fix ---
+//
+// getProviderCredentials() in src/sse/services/auth.ts calls this predicate BEFORE
+// resolveForcedConnectionForCredentialPool() to decide whether an ineligible pin must
+// fail closed (connections = []) instead of falling through to resolveForced...'s
+// intentional pin-release cases, which correctly degrade to sibling fallback.
+
+test("BUG CASE: forced connection deactivated (missing from active pool) is detected as missing", () => {
+  // Reproduces the kw/claude-worker leak: primary is active, secondary is pinned but
+  // has been deactivated, so it never appears in the active-connections pool at all.
+  // It was never excluded (no failed attempt happened) — this must still be treated as
+  // a hard failure, not folded into resolveForcedConnectionForCredentialPool's
+  // intentional-release cases.
+  const activePoolWithOnlyPrimary = [conn("claude-primary")];
+  assert.equal(
+    isForcedConnectionMissingFromPool(
+      "claude-secondary",
+      new Set(), // never excluded — this is not a post-failure fallback
+      activePoolWithOnlyPrimary // secondary deactivated, so absent entirely
+    ),
+    true
+  );
+});
+
+test("EXISTING BEHAVIOR: forced connection already excluded after a failed attempt is NOT missing-from-pool", () => {
+  // The account is still present in the (active) pool — it 429'd and the retry loop
+  // added it to excludedConnectionIds. This must keep going through
+  // resolveForcedConnectionForCredentialPool's normal pin-release path, which lets a
+  // healthy sibling take over, not through the new fail-closed path.
+  assert.equal(
+    isForcedConnectionMissingFromPool(
+      "dead-account",
+      new Set(["dead-account"]),
+      [conn("dead-account"), conn("healthy-account")]
+    ),
+    false
+  );
+});
+
+test("EXISTING BEHAVIOR: forced connection present but cooling down is NOT missing-from-pool", () => {
+  // Present in the pool (just rate-limited) — must fall through to
+  // resolveForcedConnectionForCredentialPool, which already handles cooldown correctly.
+  assert.equal(
+    isForcedConnectionMissingFromPool("cooling-account", new Set(), [conn("cooling-account")]),
+    false
+  );
+});
+
+test("EXISTING BEHAVIOR: forced connection present but quota-exhausted is NOT missing-from-pool", () => {
+  // Present in the pool — quota exhaustion is resolveForcedConnectionForCredentialPool's
+  // job (via isQuotaExhausted), not this predicate's.
+  assert.equal(
+    isForcedConnectionMissingFromPool("exhausted-account", new Set(), [conn("exhausted-account")]),
+    false
+  );
+});
+
+test("no forcing requested is never missing-from-pool", () => {
+  assert.equal(isForcedConnectionMissingFromPool(null, new Set(), [conn("some-account")]), false);
+});
+
+test("REGRESSION: healthy sibling remains selectable when the forced pin is released after exclusion", () => {
+  // End-to-end proof of test requirement #2: forced account already attempted
+  // (excluded), a healthy sibling exists — the pin must release and the sibling must
+  // still be reachable through the unchanged resolveForcedConnectionForCredentialPool
+  // path, exactly as before this fix.
+  const excluded = new Set(["primary-attempted-and-failed"]);
+  const connections = [conn("primary-attempted-and-failed"), conn("healthy-sibling")];
+
+  assert.equal(
+    isForcedConnectionMissingFromPool("primary-attempted-and-failed", excluded, connections),
+    false,
+    "excluded-after-failure must not be treated as the new fail-closed case"
+  );
+  assert.equal(
+    resolveForcedConnectionForCredentialPool({
+      forcedConnectionId: "primary-attempted-and-failed",
+      excludedConnectionIds: excluded,
+      connections,
+      allowRateLimitedConnections: false,
+      bypassQuotaPolicy: false,
+      isQuotaExhausted: () => false,
+      isQuotaPolicyBlocked: () => false,
+    }),
+    null,
+    "pin releases, letting normal account selection reach the healthy sibling"
   );
 });


### PR DESCRIPTION
## Summary

An explicit forced connection that is absent from the current credential pool can lose its constraint during credential resolution, allowing selection to continue against another connection for the provider.

`resolveForcedConnectionForCredentialPool()` correctly releases a forced pin for several intentional cases — the forced id is already in `excludedConnectionIds` after a failed attempt, it's cooling down, or it's quota-blocked — so normal sibling fallback can proceed for those. It has no way to distinguish those from a forced connection that is simply **missing from the pool entirely** (e.g. deactivated): both return `null` the same way, and the caller treated any `null` as "no forcing was requested," widening selection back to the full active pool for the provider.

## Fix

Adds `isForcedConnectionMissingFromPool()` (`src/sse/services/sessionAffinityPin.ts`), checked in `getProviderCredentials()` *before* `resolveForcedConnectionForCredentialPool()` runs. When a forced connection is requested, is **not** already excluded, and is absent from the current pool, dispatch now fails closed through the existing no-eligible-credentials recoverable path — the same one already used when a whole provider has zero active connections — so combo routing advances to its next target instead of substituting a sibling account.

`resolveForcedConnectionForCredentialPool()` itself is unchanged. All of its existing pin-release cases (excluded-after-failure, cooldown, quota exhaustion, quota-policy block) keep their current behavior and are covered by regression tests below.

## Testing

- `node --import tsx/esm --test tests/unit/forced-connection-fallback.test.ts` — 11/11 pass (5 pre-existing + 6 new: missing-from-pool detection, excluded-after-failure stays on the normal path, cooling-down stays on the normal path, quota-exhausted stays on the normal path, no-forcing case, and an end-to-end sibling-fallback-after-exclusion proof)
- Adjacent forced-connection / session-affinity suites: `codex-session-affinity-reset-aware-5903`, `sse-auth-codex-account-pool`, `session-affinity-generic-7274`, `combo-fingerprint-pin-6696` — all green
- Broader pin/cooldown/affinity matrix: `combo-pin-health-gate`, `combo-provider-cooldown(-sibling)`, `sticky-affinity-failover-6219`, `native-codex-turn-pin-10379`, `stream-early-eof-affinity-8928`, `session-affinity-edge-cases`, `session-affinity-combo-timeout-eviction`, `lkgp-stale-pin-exhaustion-11911`, `combo-account-allowlist-3266`, `combo-sessionless-pin-3825`, `combo-rr-sticky-9router` — all green (95 tests, 0 failures)
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean

## Related investigations

These are related, not duplicates — each is a different mechanism around forced/pinned-connection selection:

- #3266 — thanks to @KernelBypass for the pinned-account reproduction, and @diegosouzapw for documenting the expected forced-connection semantics
- #6692 / #6696 — thanks to the community reporters referenced in those issues, and @diegosouzapw for the pin/fallback analysis; #6696 was addressed via #6732
- #8928 — thanks to @cryptiklemur for the separate Claude/session-affinity eviction case
- #10379 — thanks to @equalsthreerussian-collab for the separate 3.8.50 Codex turn-pin/failover case
- #6612 — thanks to @Jensenwgd for the related combo resilience investigation

Thanks to the reporters, community members, and maintainers involved in the earlier routing and pinning investigations. Those reports helped clarify the expected account-selection and fallback semantics exercised by this regression test.
