### PR TITLE
[URGENT] fix(dev): isolate batch dispatch from instrumentation (phase 4b)

### DIFF
--- a/src/lib/batches/dispatch.ts
+++ b/src/lib/batches/dispatch.ts
@@ -1,29 +1,6 @@
 import type { SupportedBatchEndpoint } from "@/shared/constants/batchEndpoints";
-
-type BatchRouteHandler = (request: Request) => Promise<Response> | Response;
-
-const handlerLoaders: Record<SupportedBatchEndpoint, () => Promise<BatchRouteHandler>> = {
-  "/v1/responses": async () => (await import("@/app/api/v1/responses/route")).POST,
-  "/v1/chat/completions": async () => (await import("@/app/api/v1/chat/completions/route")).POST,
-  "/v1/embeddings": async () => (await import("@/app/api/v1/embeddings/route")).POST,
-  "/v1/completions": async () => (await import("@/app/api/v1/completions/route")).POST,
-  "/v1/moderations": async () => (await import("@/app/api/v1/moderations/route")).POST,
-  "/v1/images/generations": async () =>
-    (await import("@/app/api/v1/images/generations/route")).POST,
-  "/v1/videos/generations": async () =>
-    (await import("@/app/api/v1/videos/generations/route")).POST,
-};
-
-const handlerCache = new Map<SupportedBatchEndpoint, BatchRouteHandler>();
-
-async function getHandler(endpoint: SupportedBatchEndpoint): Promise<BatchRouteHandler> {
-  const cached = handlerCache.get(endpoint);
-  if (cached) return cached;
-
-  const handler = await handlerLoaders[endpoint]();
-  handlerCache.set(endpoint, handler);
-  return handler;
-}
+import { getRuntimePorts } from "@/lib/runtime/ports";
+import { normalizeBasePath } from "@/shared/utils/basePath";
 
 async function dispatchBatchApiRequest({
   endpoint,
@@ -39,13 +16,17 @@ async function dispatchBatchApiRequest({
     headers.set("Authorization", `Bearer ${apiKey}`);
   }
 
-  const handler = await getHandler(endpoint);
-  const request = new Request(`http://localhost${endpoint}`, {
+  const { dashboardPort } = getRuntimePorts();
+  const basePath = normalizeBasePath(process.env.OMNIROUTE_BASE_PATH);
+  const url = `http://127.0.0.1:${dashboardPort}${basePath}${endpoint}`;
+
+  return await globalThis.fetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
+    // Never follow a redirect while carrying the stored batch API key.
+    redirect: "error",
   });
-  return await handler(request);
 }
 
 export const dispatch = {

--- a/tests/unit/batch-dispatch-instrumentation-boundary-12074.test.ts
+++ b/tests/unit/batch-dispatch-instrumentation-boundary-12074.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const dispatchSourcePath = join(import.meta.dirname, "../../src/lib/batches/dispatch.ts");
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  OMNIROUTE_PORT: process.env.OMNIROUTE_PORT,
+  PORT: process.env.PORT,
+  DASHBOARD_PORT: process.env.DASHBOARD_PORT,
+  OMNIROUTE_BASE_PATH: process.env.OMNIROUTE_BASE_PATH,
+};
+
+function restoreEnv(): void {
+  for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+test("batch dispatch does not pull API route modules into the instrumentation graph", () => {
+  const source = readFileSync(dispatchSourcePath, "utf8");
+
+  assert.doesNotMatch(source, /@\/app\/api\/v1\/.+\/route/);
+  assert.doesNotMatch(source, /handlerLoaders|BatchRouteHandler/);
+});
+
+test("batch dispatch posts to the active dashboard loopback listener", async () => {
+  process.env.OMNIROUTE_PORT = "24120";
+  process.env.PORT = "24121";
+  process.env.DASHBOARD_PORT = "24122";
+  process.env.OMNIROUTE_BASE_PATH = "/omniroute/";
+
+  const calls: Array<{ input: string; init?: RequestInit }> = [];
+  const upstreamResponse = new Response("accepted", { status: 202 });
+  globalThis.fetch = async (input, init) => {
+    calls.push({ input: String(input), init });
+    return upstreamResponse;
+  };
+
+  const { dispatch } = await import("../../src/lib/batches/dispatch.ts");
+  const response = await dispatch.dispatchBatchApiRequest({
+    endpoint: "/v1/chat/completions",
+    body: { model: "provider/model", messages: [] },
+    apiKey: "batch-secret",
+  });
+
+  assert.strictEqual(response, upstreamResponse);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].input, "http://127.0.0.1:24122/omniroute/v1/chat/completions");
+  assert.equal(calls[0].init?.method, "POST");
+  assert.equal(calls[0].init?.redirect, "error");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer batch-secret");
+  assert.deepEqual(JSON.parse(String(calls[0].init?.body)), {
+    model: "provider/model",
+    messages: [],
+  });
+});

--- a/tests/unit/batch_api.test.ts
+++ b/tests/unit/batch_api.test.ts
@@ -202,6 +202,13 @@ test("Batch API and Processing", async () => {
 });
 
 test("Batch handles and counts failures correctly", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: { message: "Model not found" } }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+
   initBatchProcessor();
   try {
     // 1. Create a file with a request that will fail (invalid provider/model)
@@ -264,6 +271,7 @@ test("Batch handles and counts failures correctly", async () => {
     }
   } finally {
     stopBatchProcessor();
+    globalThis.fetch = originalFetch;
   }
 });
 
@@ -390,6 +398,21 @@ test("Batch rejects input lines whose url does not match the batch endpoint", as
 });
 
 test("Batch forces stream: false for all requests", async () => {
+  const originalFetch = globalThis.fetch;
+  let dispatchedBody: Record<string, unknown> | null = null;
+  globalThis.fetch = async (_input, init) => {
+    dispatchedBody = JSON.parse(String(init?.body));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { role: "assistant", content: "batch response" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  };
+
   initBatchProcessor();
   try {
     const batchItems = [
@@ -449,8 +472,10 @@ test("Batch forces stream: false for all requests", async () => {
         "Should not have JSON parsing error from SSE stream"
       );
     }
+    assert.strictEqual(dispatchedBody?.stream, false, "Batch dispatch must disable streaming");
   } finally {
     stopBatchProcessor();
+    globalThis.fetch = originalFetch;
   }
 });
 


### PR DESCRIPTION
## Summary

Phase 4b of #12074 removes the deferred batch API-route fan-out that remained in the
instrumentation graph after Phase 3. Batch execution still traverses the real Next API route,
but it now does so at runtime through the active loopback dashboard listener instead of
compile-time dynamic imports of seven route modules.

## Changes

- replace the seven `@/app/api/v1/**/route` dynamic imports in batch dispatch with one
  loopback HTTP POST
- pin the target to `127.0.0.1` and the active `dashboardPort`; do not derive it from request
  headers or a public base URL
- honor `OMNIROUTE_BASE_PATH` for subpath deployments
- reject redirects while carrying the stored batch API key
- add an import-boundary regression and direct assertions for URL, method, auth, body, and
  redirect behavior
- update the affected batch tests to mock the new HTTP boundary explicitly

## Validation

- TDD regression: the new boundary test failed before the production change on the seven
  route imports, then passed after the change
- focused batch suite: 37 tests passed
- Webpack real-server batch E2E: upload -> create batch -> loopback dispatch -> fake provider
  relay -> result file; 2/2 items completed, 0 failed
- `npm run typecheck:core`: passed
- changed-file ESLint with repository suppressions and no cache: passed
- `npm run check:cycles`: passed
- Prettier and `git diff --check`: passed

## Controlled Webpack graph comparison

I stacked this commit on the existing Phases 1-4 integration branch and compared it with the
same branch without Phase 4b. Both runs used a fresh Next cache and DB, the same Node command,
Webpack mode, port, request order, and sequential execution.

| Measurement | Phases 1-4 | Phases 1-4b |
| --- | ---: | ---: |
| Cold `/dashboard/providers` | 19.04 s | 12.74 s |
| Cold provider-model probe | 3.24 s | 3.41 s |
| RSS after the cold routes | 7.32 GiB | 7.38 GiB |
| Next dev output | 1,922,500 KiB | 1,534,152 KiB |
| Instrumentation-prefixed chunks | 243 | 160 |
| Target batch-route references | 8 | 0 |
| Target batch-route chunk total | 154,296 KiB | 0 KiB |
| RSS after two invalidations and 15 s settle | 7.85 GiB | 7.59 GiB |

The reproducible result is the graph/output reduction: about 379 MiB less dev output and no
batch-route modules under the instrumentation-prefixed graph. The provider-model timing is
effectively noise, and this repeat did not reproduce the earlier 14 GiB layout-HMR spike, so
this PR does **not** claim to close the overall memory issue or replace the remaining Phase 5
Turbopack investigation.

Part of #12074.
