### PR TITLE
fix(ci): reconcile release test contract drift

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -39,9 +39,7 @@
   "incremental": true,
   "incrementalFile": "reports/mutation/stryker-incremental.json",
   "testRunner": "tap",
-  "plugins": [
-    "@stryker-mutator/tap-runner"
-  ],
+  "plugins": ["@stryker-mutator/tap-runner"],
   "tap": {
     "testFiles": [
       "tests/unit/10085-compatible-generic-vs-uuid-credential.test.ts",
@@ -266,6 +264,7 @@
       "tests/unit/issue-7071-ollama-session-quota.test.ts",
       "tests/unit/kimi-quota-reset-recovery.test.ts",
       "tests/unit/least-used-rotation-10945.test.ts",
+      "tests/unit/lkgp-stale-pin-exhaustion-11911.test.ts",
       "tests/unit/livews-forward-backoff-4604.test.ts",
       "tests/unit/management-auth-hardening.test.ts",
       "tests/unit/mark-account-unavailable-numeric-epoch-guard.test.ts",
@@ -512,11 +511,7 @@
     ".worktrees",
     ".stryker-tmp"
   ],
-  "reporters": [
-    "progress",
-    "html",
-    "json"
-  ],
+  "reporters": ["progress", "html", "json"],
   "htmlReporter": {
     "fileName": "reports/mutation/mutation.html"
   },

--- a/tests/unit/cli-program.test.ts
+++ b/tests/unit/cli-program.test.ts
@@ -124,7 +124,7 @@ test("program registers 'update' command", () => {
   assert.ok(cmd, "update command exists");
 });
 
-test("nodes endpoint commands reserve --base-url for the global server target", () => {
+test("nodes endpoint commands expose --endpoint and the legacy --base-url alias", () => {
   const program = createProgram();
   const nodes = program.commands.find((c) => c.name() === "nodes");
   assert.ok(nodes, "nodes command exists");
@@ -136,10 +136,9 @@ test("nodes endpoint commands reserve --base-url for the global server target", 
       command.options.some((option) => option.long === "--endpoint"),
       `nodes ${commandName} exposes --endpoint for the provider-node URL`
     );
-    assert.equal(
+    assert.ok(
       command.options.some((option) => option.long === "--base-url"),
-      false,
-      `nodes ${commandName} does not shadow the global --base-url option`
+      `nodes ${commandName} preserves the legacy --base-url alias`
     );
     command.parseOptions([
       ...(commandName === "update" ? ["node-1"] : []),

--- a/tests/unit/combo-model-lockout-honors-reset-1308.test.ts
+++ b/tests/unit/combo-model-lockout-honors-reset-1308.test.ts
@@ -27,7 +27,10 @@ const RESET_160H = 160 * HOUR + 27 * 60_000 + 24_000; // "160h27m24s"
 test("selectLockoutCooldownMs honors a parsed reset longer than the base cooldown", () => {
   // exponential backoff on, but a 160h upstream reset must win
   assert.equal(
-    selectLockoutCooldownMs(RESET_160H, { baseCooldownMs: 5 * 60_000, useExponentialBackoff: true }),
+    selectLockoutCooldownMs(RESET_160H, {
+      baseCooldownMs: 5 * 60_000,
+      useExponentialBackoff: true,
+    }),
     RESET_160H
   );
 });
@@ -53,9 +56,18 @@ test("model lockout honors the long upstream reset end-to-end (#1308)", () => {
     baseCooldownMs: 5 * 60_000,
     useExponentialBackoff: true,
   });
-  recordModelLockoutFailure("antigravity", "conn-1", "claude-sonnet-4-6", "rate_limit", 429, 5 * 60_000, null, {
-    exactCooldownMs: exact,
-  });
+  recordModelLockoutFailure(
+    "antigravity",
+    "conn-1",
+    "claude-sonnet-4-6",
+    "rate_limit",
+    429,
+    5 * 60_000,
+    null,
+    {
+      exactCooldownMs: exact,
+    }
+  );
   const info = getModelLockoutInfo("antigravity", "conn-1", "claude-sonnet-4-6");
   assert.ok(info, "expected an active lockout");
   // remaining should be ~160h, NOT the ~5min base cooldown
@@ -118,7 +130,13 @@ test("Retry-After remains authoritative for model locks when connection hints ar
   );
 
   assert.equal(result.retryHintSource, "header");
-  assert.equal(result.quotaResetHintMs, 131 * HOUR);
+  const expectedResetMs = 131 * HOUR;
+  const actualResetMs = result.quotaResetHintMs;
+  assert.ok(typeof actualResetMs === "number", "expected a numeric Retry-After reset hint");
+  assert.ok(
+    actualResetMs <= expectedResetMs && actualResetMs >= expectedResetMs - 1_000,
+    `expected Retry-After within one clock tick of ${expectedResetMs}ms, got ${actualResetMs}ms`
+  );
   assert.equal(retryHintBypassesMaxCooldownMs(result.retryHintSource), true);
 });
 


### PR DESCRIPTION
## Summary

Restore the current `release/v3.8.51` CI contracts without changing production behavior:

- align the stale CLI program assertion with the intentionally restored legacy `nodes ... --base-url` compatibility from #12033 while retaining `--endpoint` and the server-target separation coverage;
- add `tests/unit/lkgp-stale-pin-exhaustion-11911.test.ts` to Stryker `tap.testFiles`, matching the strict mutation-coverage gate;
- make the Retry-After assertion tolerate at most one second of elapsed clock time instead of requiring an impossible exact millisecond value.

## Why this is separate

These failures are inherited by the dev-bundler phase PRs and are unrelated to their import-graph changes. Keeping this repair separate avoids duplicating CI-only commits across #12075, #12076, #12078, #12079, and #12081.

No open PR was found that changes any of the affected contract files.

## Validation

- `node --import tsx/esm --test tests/unit/cli-program.test.ts tests/unit/cli-nodes-commands.test.ts tests/unit/combo-model-lockout-honors-reset-1308.test.ts tests/unit/lkgp-stale-pin-exhaustion-11911.test.ts` — 41 passed
- Retry-After focused suite repeated 20 times — all passed
- `npm run check:mutation-test-coverage -- --strict` — no drift
- ESLint with the repository suppressions — passed
- Prettier and `git diff --check` — passed
- docs sync, T11 any budget, and tracked-artifact gates — passed

Unblocks #12074.