### PR TITLE
fix(cli): register alias resolver hooks in-thread on modern runtimes (#12073)

### DIFF
--- a/bin/aliasResolver.mjs
+++ b/bin/aliasResolver.mjs
@@ -176,13 +176,14 @@ function isWithinRoot(ancestor, candidate) {
  * Register the ESM resolve hook for the current process. Safe to call multiple
  * times — subsequent calls are no-ops once the hook is installed.
  *
- * Uses Node's stable `module.register()` API (available since Node 20.6,
- * required Node 22+ here). The hook runs in a worker thread but only reads the
- * captured `root`, so no shared-state hazards.
+ * Modern runtimes import the hook module in-thread, initialize its root with a
+ * plain function call, and register its synchronous resolver through
+ * `module.registerHooks()`. Runtimes without that API (notably Bun) retain the
+ * `module.register()` worker-thread loader lifecycle path.
  *
  * @param {string} root  Absolute path to the package root.
  * @returns {Promise<boolean>}  Resolves `true` once registered (or if already
- *   registered), `false` on environments where `module.register` is unavailable.
+ *   registered), `false` when neither registration API is usable.
  */
 let _registered = false;
 export async function registerAliasResolver(root) {
@@ -201,7 +202,7 @@ export async function registerAliasResolver(root) {
   }
 
   try {
-    const { register } = await import("node:module");
+    const mod = await import("node:module");
     // #7808: load the hook from a real file on disk via pathToFileURL() instead
     // of building a `data:text/javascript,...` URL dynamically. CodeQL's
     // `js/incomplete-url-substring-sanitization` flagged the interpolated
@@ -211,14 +212,21 @@ export async function registerAliasResolver(root) {
     // package.json "files": ["bin/"].
     const hookPath = join(__dirname, "aliasResolverHook.mjs");
     const hookUrl = pathToFileURL(hookPath);
-    register(hookUrl, { data: { root } });
+    if (typeof mod.registerHooks === "function") {
+      const hook = await import(hookUrl.href);
+      hook.initialize({ root });
+      mod.registerHooks({ resolve: hook.resolve });
+      _registered = true;
+      return true;
+    }
+    mod.register(hookUrl, { data: { root } });
     _registered = true;
     return true;
   } catch {
-    // Older Node or sandboxed env without module.register — fall back to the
-    // default resolver. The bug will resurface only in the exact global-install
-    // scenario, which is what we explicitly patched; other entry points still
-    // work because they import via relative paths.
+    // Runtime or sandboxed env without a usable module hook API — fall back to
+    // the default resolver. The bug will resurface only in the exact
+    // global-install scenario, which is what we explicitly patched; other entry
+    // points still work because they import via relative paths.
     return false;
   }
 }

--- a/changelog.d/fixes/12073-node26-alias-hooks.md
+++ b/changelog.d/fixes/12073-node26-alias-hooks.md
@@ -1,0 +1,1 @@
+- **fix(cli):** use in-thread alias resolver hooks on modern runtimes to avoid deprecation noise and improve Node.js forward compatibility ([#12073](https://github.com/diegosouzapw/OmniRoute/issues/12073)).

--- a/tests/unit/cli/alias-resolver-12073.test.ts
+++ b/tests/unit/cli/alias-resolver-12073.test.ts
@@ -1,0 +1,167 @@
+/**
+ * RED regression coverage for issue #12073: Node 26 deprecates
+ * module.register() in favor of the synchronous module.registerHooks() API.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parseNodeVersion } from "../../../src/shared/utils/nodeRuntimeSupport.ts";
+
+import { registerAliasResolver, resolveAlias } from "../../../bin/aliasResolver.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const NODE_VERSION = parseNodeVersion(process.versions.node);
+const NODE_26_SKIP_REASON =
+  `running Node ${process.versions.node}; DEP0205 assertion is unverified on this runtime ` +
+  "(requires Node >= 26)";
+
+// Child import() specifiers must be real file URLs. A Windows drive letter in
+// a bare path would otherwise be parsed as a URL scheme.
+const repoFileUrl = (relPath: string) => pathToFileURL(join(REPO_ROOT, relPath)).href;
+
+function runChild(script: string, cwd = REPO_ROOT) {
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd,
+    env: {
+      ...process.env,
+      DATA_DIR: mkdtempSync(join(tmpdir(), "alias-resolver-12073-")),
+      OMNIROUTE_CLI_SKIP_REPO_ENV: "1",
+    },
+    encoding: "utf8",
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
+describe("aliasResolver Node 26 registration (#12073)", () => {
+  it(
+    "uses the real entry point without emitting DEP0205",
+    { skip: NODE_VERSION.major >= 26 ? false : NODE_26_SKIP_REASON },
+    () => {
+      const script = `
+        await import("tsx/esm");
+        const { registerAliasResolver } = await import(${JSON.stringify(repoFileUrl("bin/aliasResolver.mjs"))});
+        const ok = await registerAliasResolver(${JSON.stringify(REPO_ROOT)});
+        if (!ok) { console.error("FAIL: registerAliasResolver returned false"); process.exit(2); }
+        try {
+          const m = await import(${JSON.stringify(repoFileUrl("src/shared/network/outboundUrlGuard.ts"))});
+          console.log("OK:" + Object.keys(m).sort().join(","));
+        } catch (err) {
+          console.error("FAIL:" + (err && err.message || err));
+          process.exit(3);
+        }
+      `;
+      const { stdout, stderr, status } = runChild(script);
+
+      assert.equal(status, 0, `expected exit 0, got ${status}. stderr=${stderr.slice(0, 500)}`);
+      assert.match(stdout.trim(), /^OK:/);
+      assert.doesNotMatch(stderr, /DEP0205|DeprecationWarning/);
+    }
+  );
+
+  it("keeps global-install-style alias imports working", () => {
+    // A foreign cwd has no repository tsconfig or package.json to let tsx
+    // resolve the bare alias by itself. This makes the import a tripwire for a
+    // hook that registers without throwing but silently never runs.
+    const globalInstallCwd = mkdtempSync(join(tmpdir(), "alias-resolver-global-install-"));
+    try {
+      const script = `
+        await import(${JSON.stringify(repoFileUrl("node_modules/tsx/dist/esm/index.mjs"))});
+        const { registerAliasResolver } = await import(${JSON.stringify(repoFileUrl("bin/aliasResolver.mjs"))});
+        const ok = await registerAliasResolver(${JSON.stringify(REPO_ROOT)});
+        if (!ok) { console.error("FAIL: registerAliasResolver returned false"); process.exit(2); }
+        try {
+          const m = await import("@/shared/network/outboundUrlGuard");
+          console.log("OK:" + Object.keys(m).sort().join(","));
+        } catch (err) {
+          console.error("FAIL:" + (err && err.message || err));
+          process.exit(3);
+        }
+      `;
+      const { stdout, stderr, status } = runChild(script, globalInstallCwd);
+
+      assert.equal(status, 0, `expected exit 0, got ${status}. stderr=${stderr.slice(0, 500)}`);
+      const trimmed = stdout.trim();
+      assert.match(trimmed, /^OK:/, `expected OK:<exports>, got: ${trimmed}`);
+      assert.match(trimmed, /OutboundUrlGuardError|PROVIDER_URL_BLOCKED_MESSAGE/);
+    } finally {
+      rmSync(globalInstallCwd, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
+    }
+  });
+
+  it("retains module.register() for simulated legacy runtimes", () => {
+    const script = `
+      await import("tsx/esm");
+      const { createRequire, syncBuiltinESMExports } = await import("node:module");
+      const require = createRequire(import.meta.url);
+      const cjsModule = require("node:module");
+      const saved = cjsModule.registerHooks;
+      try {
+        cjsModule.registerHooks = undefined;
+        syncBuiltinESMExports();
+        const esmModule = await import("node:module");
+        if (esmModule.registerHooks !== undefined) {
+          console.error("FAIL: registerHooks was not blanked");
+          process.exitCode = 2;
+        } else {
+          const { registerAliasResolver } = await import(${JSON.stringify(repoFileUrl("bin/aliasResolver.mjs"))});
+          const ok = await registerAliasResolver(${JSON.stringify(REPO_ROOT)});
+          const m = await import(${JSON.stringify(repoFileUrl("src/shared/network/outboundUrlGuard.ts"))});
+          const hasExpectedExport = "OutboundUrlGuardError" in m || "PROVIDER_URL_BLOCKED_MESSAGE" in m;
+          if (!ok || !hasExpectedExport) {
+            console.error("FAIL: legacy registration did not resolve the alias");
+            process.exitCode = 3;
+          } else {
+            console.log("OK:true:" + Object.keys(m).sort().join(","));
+          }
+        }
+      } catch (err) {
+        console.error("FAIL:" + (err && err.message || err));
+        process.exitCode = 4;
+      } finally {
+        cjsModule.registerHooks = saved;
+        syncBuiltinESMExports();
+      }
+    `;
+    const { stdout, stderr, status } = runChild(script);
+
+    assert.equal(status, 0, `expected exit 0, got ${status}. stderr=${stderr.slice(0, 500)}`);
+    assert.match(stdout.trim(), /^OK:true:/);
+    if (NODE_VERSION.major >= 26) {
+      assert.match(stderr, /DEP0205|DeprecationWarning/);
+    }
+  });
+
+  it("keeps idempotency, input validation, and traversal guards characterized", async () => {
+    const noSrcRoot = mkdtempSync(join(tmpdir(), "alias-resolver-no-src-"));
+    const emptySrcRoot = mkdtempSync(join(tmpdir(), "alias-resolver-empty-src-"));
+
+    try {
+      assert.equal(await registerAliasResolver(noSrcRoot), false);
+
+      mkdirSync(join(emptySrcRoot, "src"), { recursive: true });
+      assert.equal(await registerAliasResolver(emptySrcRoot), true);
+      assert.equal(await registerAliasResolver(emptySrcRoot), true);
+
+      await assert.rejects(() => registerAliasResolver(""), TypeError);
+      await assert.rejects(() => registerAliasResolver(null), TypeError);
+      await assert.rejects(() => registerAliasResolver(123), TypeError);
+
+      assert.equal(resolveAlias("@/../../../etc/hostname", REPO_ROOT), null);
+      assert.equal(resolveAlias("@omniroute/open-sse/../../etc/passwd", REPO_ROOT), null);
+    } finally {
+      rmSync(noSrcRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      rmSync(emptySrcRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`bin/aliasResolver.mjs` registers the CLI's `@/…` alias loader through `module.register()`. On
current Node that API emits

```
(node:NNNNN) [DEP0205] DeprecationWarning: Use `module.registerHooks()` instead of `module.register()`
```

so every `omniroute` invocation on a modern runtime prints deprecation noise on stderr.

This is a **deprecation-noise / forward-compatibility** fix, not a correctness fix.
`bin/omniroute.mjs:59-64` already redirects console output to stderr and DEP0205 already went to
stderr, so no JSON-RPC stream was ever corrupted by it. Please do not read this PR as fixing a
data-corruption bug.

## The change

Two files, on top of a tests-only RED commit:

- `bin/aliasResolver.mjs` — the destructured `const { register }` becomes a namespace import, and a
  modern branch is added **ahead of** the untouched legacy call, both still inside the one existing
  `try/catch`:

  ```js
  const mod = await import("node:module");
  // … unchanged #7808 hookPath / hookUrl construction …
  if (typeof mod.registerHooks === "function") {
    const hook = await import(hookUrl.href);
    hook.initialize({ root });
    mod.registerHooks({ resolve: hook.resolve });
    _registered = true;
    return true;
  }
  mod.register(hookUrl, { data: { root } });
  _registered = true;
  return true;
  ```

  plus a JSDoc correction — the old block claimed a worker thread and `module.register()` only,
  which is no longer true of the primary path.

- `changelog.d/fixes/12073-node26-alias-hooks.md` — one bullet.

Nothing else moved. `bin/aliasResolverHook.mjs`, `bin/omniroute.mjs`, `package.json`,
`package-lock.json`, `scripts/build/validate-pack-artifact.ts`, `tests/unit/pack-artifact-policy.test.ts`,
`.size-limit.json`, `src/shared/utils/nodeRuntimeSupport.ts`, `config/quality/*`,
`.github/workflows/*` and `tests/unit/cli/alias-resolver-7791.test.ts` are byte-identical to the base.

The AR/HK duplication is deliberately preserved: `bin/aliasResolverHook.mjs:5-6` says HK must not
import AR because under `register()` it loads in a separate isolate, and that is still true on the
legacy path. No third copy of the alias table was authored, `initialize` is still a real export and
`resolve` is still synchronous.

## RED → GREEN structure

Two commits on `release/v3.8.51`, in order:

| commit | tree | what |
|---|---|---|
| `38e2baa87913dfb345d911f99fb54159df38ebdd` | `812b07e49c826f701c6264624f604238733ec27c` | base (current tip of `release/v3.8.51`) |
| `3561b06a3470e42bed95899195c4a1ed19674f11` | `6d27fcbad6be898894f600be06c0bbd404416168` | **RED**, tests only — `tests/unit/cli/alias-resolver-12073.test.ts` |
| `a730e71c17d476d9f0c03a05bfdb32cc0a20fda0` | `1f59e27921b4bce2a8afa0e12d03c16bfa78098c` | **GREEN**, the fix |

The RED test was **not** edited to make it pass: its blob is
`b2568ff2b16028755f3cff682f8d7d7c9acd69e6` at both the RED tip and HEAD. Verified independently by
copying that exact blob into a materialization of the base tree: it exits 1 with a single failure —
the DEP0205 assertion — and 4/4 on the head tree.

Please review the two commits separately if that is easier; the RED alone reproduces the issue.

## Test matrix

Focused suites re-run on four runtimes:

| runtime | `alias-resolver-12073` | `alias-resolver-7791` | `tests/unit/cli/**/*.test.ts` |
|---|---|---|---|
| Node 26.5.0 | 4 tests · **4 pass · 0 fail** | 23/23 | 198 tests · **196 pass · 0 fail** · 2 skip |
| Node 24.13.0 | 4 tests · 3 pass · 0 fail · 1 gated skip | 23/23 | — |
| Node 22.23.2 | 4 tests · 3 pass · 0 fail · 1 gated skip | 23/23 | — |
| Node 22.22.0 | 4 tests · 3 pass · 0 fail · 1 gated skip | 23/23 | 198 tests · **195 pass · 0 fail** · 3 skip |

The RED baseline on Node 26 was 195 pass / 1 fail / 2 skip for the same glob.

`prettier --check` on both changed files exits 0. `eslint bin/aliasResolver.mjs` exits 0 with
`File ignored because of a matching ignore pattern` — `eslint.config.mjs:187` lists `bin/**` in
`ignores`; that is existing repo policy and the config is byte-identical to base, so this is not a
regression introduced here.

`npm run check:pack-policy` **passes** (3411 entries, 6.2 MB packed). `npm pack --dry-run` confirms
the tarball ships **both** `bin/aliasResolver.mjs` and `bin/aliasResolverHook.mjs`.

`CHANGELOG_BASE_REF=38e2baa879… npm run check:changelog-integrity` → `OK — no base bullets lost`.
(Without the explicit ref it auto-skips, because
`scripts/check/check-changelog-integrity.mjs:285-292` looks for an `origin/…` base ref and this
clone's remotes are named `upstream`/`fork`. Environmental, not a code issue.)

### DEP0205 evidence — on a discriminating probe

`bin/omniroute.mjs --help` and `--version` are **fast-paths**: they exit before the async
deprecation warning flushes and emit 0 stderr bytes on the base tree as well, so they cannot show
this fix working. Please do not use them as evidence either way.

On commands that actually reach the loader — `omniroute nodes list`, `omniroute pricing list`:

| tree | stderr | DEP0205 lines |
|---|---|---|
| base `38e2baa879` | 201–202 bytes | 1 |
| head `a730e71c17` | 11 bytes (an unrelated `Error: 403`, no network here) | **0** |

stdout and exit code identical on both.

Registration-path counting on Node 26: base = `register` 1 / `registerHooks` 0; head = `register` 0
/ `registerHooks` 1. Exactly one registration on each path, no double registration.

### Bun — the legacy branch is exercised and unchanged

Repo-pinned Bun 1.3.14: `registerHooks` is `undefined`, `register` is a `function`, the legacy
branch is taken, `registerAliasResolver` returns `true` with **0 bytes of stderr** — identical to
the base tree. No CI job covers this path (`AGENTS.md:630-631`), so it was checked by hand; a
`registerHooks`-only swap would have broken it.

### Adversarial probes (base vs head, both identical unless noted)

- a bare `@/…` specifier from a foreign `mktemp -d` cwd still resolves (9 exports) — the hook is
  genuinely active, not a silent no-op;
- a genuinely missing `@/…` module still raises `ERR_MODULE_NOT_FOUND` — no over-short-circuiting;
- `hook.resolve` is a plain arity-3 `Function`, not an `AsyncFunction`;
- `initialize` takes effect as a plain in-thread call: before it, `resolve` delegates to
  `nextResolve`; after it, it returns the resolved URL with `shortCircuit: true`;
- `resolveAlias` edge cases all return `null` on both trees: bare `@/`, directory without an index,
  non-matching, empty, `..` traversal, absolute-ish escape;
- a `worker_threads` `Worker` importing `@/…` fails `ERR_MODULE_NOT_FOUND` on both trees — worker
  scope is unchanged;
- idempotent repeat → `true`; `""` / `null` / `123` → `TypeError`; missing `src/` → `false`.

## Three behavioural notes for the maintainer

These were judged **not defects** during review, but they are real and deliberate to disclose rather
than omit. Please disagree if you see it differently.

1. **`registerHooks` also intercepts CJS `require()`**, whereas `register()` was ESM-only. So
   `require("@/lib/dataPaths")` now loads on the head tree where it raised `MODULE_NOT_FOUND` on the
   base tree (Node 26, verified via `createRequire`). Blast radius traced rather than assumed: the
   only `require()` of an alias specifier in the packaged surface is
   `open-sse/config/credentialLoader.ts:47`, and it is unreachable as written under the shipped
   tsx-ESM loader (`require` is undefined there → the same `catch` fallback fires on **both** trees).
   A `node_modules` scan finds no third-party `require("@/…")`. `src/lib/dataPaths.ts` has no
   top-level side effects, so there is no dual-instance hazard even if a CJS consumer did reach it.

2. **The in-thread path activates across essentially the whole supported Node range**, not just
   Node 26. `registerHooks` is a `function` on 22.22.0, 22.23.2, 24.13.0 and 26.5.0, and behaviour
   was verified identical on all four. Wider than the issue title implies.

3. **Bun's `module.register()` is already inert for alias resolution.** Under Bun 1.3.14 a bare
   `@/…` import fails `ERR_MODULE_NOT_FOUND` on base *and* head alike. Parity is exactly preserved
   and keeping the legacy branch is still the right call — removing it would be a gratuitous change
   on an uncovered path — but this PR should not be read as claiming that
   `bun install -g omniroute` currently depends on that branch.

## Honest caveats

- `check:pack-artifact`, `check:pack-boot` and `check:install-upgrade` are **unverified on their
  merits** here. `check:pack-artifact` fails on this host inside the Next/Turbopack production
  build — a phase that never reads `bin/`. An A/B control run on the pure RED tip with a clean
  worktree gives **716** Turbopack panics at
  `turbopack/crates/turbopack-core/src/module_graph/mod.rs:746:25`, versus **715** at the identical
  site on this head, same exit code. `check:pack-boot` / `check:install-upgrade` then exit 2 with
  `dist/server.js missing — run npm run build:cli first`, i.e. they are gated on the staging that
  broken build cannot produce. Pre-existing and host-local; these three remain CI's responsibility.
- Not verified: a real `npm i -g omniroute` layout (simulated by foreign cwd only — tsx still loads
  from this repo's `node_modules`); Node 22.0–22.14, the genuine no-`registerHooks` range, which is
  not installed on this host; Windows path behaviour; full CI — only the focused suites and gates
  listed above were run; and whether the upstream `nightly-compat` Node 26 job is currently green.

## Status

Opening as **Draft** — this is a candidate awaiting your decision, not a merge request, and it is
fully reversible: happy to rescope, split, or close it if you would rather this be solved another
way (for example gating on `process.features` or deferring until the legacy branch can be dropped
entirely).

Deliberately **not** writing `Closes #12073`, so the issue stays yours to close.

Refs #12073
