### PR TITLE
fix(ci): accept CVE-2025-68121 in the prebuilt tls-client .so, auto-close base-red issues, guard Scorecard on the default branch (main twin)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -485,6 +485,9 @@ jobs:
           severity: CRITICAL
           ignore-unfixed: true
           exit-code: "1"
+          # Explicit: the advisory scan above already points at it, and the blocking
+          # gate must honour the same accepted-risk list (#12084).
+          trivyignores: .trivyignore
 
       - name: Upload Trivy SARIF to Security tab
         if: needs.prepare.outputs.version != 'main'

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -413,10 +413,14 @@ jobs:
           tag_name: ${{ needs.validate.outputs.version }}
           draft: false
           prerelease: false
-          # Only on the tag push. A re-attach dispatch runs against a release whose curated
-          # notes already exist, and `true` APPENDS GitHub's auto-generated "What's Changed"
-          # block to them (v3.8.50, run 33238093090: +1,416 chars on a 121 KB body).
-          generate_release_notes: ${{ github.event_name != 'workflow_dispatch' }}
+          # NEVER. Phase 3 of the release flow creates the GitHub Release with the curated
+          # notes seconds after pushing the tag, so by the time this step runs (1-2 h of
+          # builds later) the body already exists — and `true` APPENDS GitHub's
+          # auto-generated "What's Changed" block to it (v3.8.48 shipped that way; the
+          # v3.8.50 re-attach dispatch added +1,416 chars to a 121 KB body, run
+          # 33238093090). A curated body sits ~3 KB under the 125,000-char cap, so the
+          # append can also turn this step RED and leave the release with no assets.
+          generate_release_notes: false
           fail_on_unmatched_files: false
           files: |
             release-assets/*.dmg

--- a/.github/workflows/nightly-release-green.yml
+++ b/.github/workflows/nightly-release-green.yml
@@ -196,6 +196,26 @@ jobs:
             gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --label base-red --body-file issue-body.md
           fi
 
+      - name: Close tracking issue when the branch is green again
+        if: steps.validate.outputs.exit == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET: ${{ steps.branch.outputs.target }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # The open/update step above is the UPWARD half of the loop; without this
+          # step a stale "not green" issue outlives the fix and every base-green check
+          # (`AGENTS.md` → "Base-green check") keeps stamping new PRs as base-red inherited.
+          TITLE="🔴 Release branch not green: ${TARGET}"
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title $TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" --reason completed \
+              --comment "✅ \`${TARGET}\` is release-green again at \`${GITHUB_SHA:0:9}\` — ${RUN_URL}. Auto-closed by Release-Green (continuous)."
+            echo "Closed issue #$EXISTING"
+          fi
+
       - name: Upload report artifact
         if: always()
         uses: actions/upload-artifact@v7
@@ -292,6 +312,25 @@ jobs:
             echo "Updated existing issue #$EXISTING"
           else
             gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --label base-red --body-file issue-body.md
+          fi
+
+      - name: Close tracking issue when the branch is green again
+        if: steps.validate.outputs.exit == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # The open/update step above is the UPWARD half of the loop; without this
+          # step a stale "not green" issue outlives the fix and every base-green check
+          # (`AGENTS.md` → "Base-green check") keeps stamping new PRs as base-red inherited.
+          TITLE="🔴 main branch not green"
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title $TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" --reason completed \
+              --comment "✅ \`main\` is main-green again at \`${GITHUB_SHA:0:9}\` — ${RUN_URL}. Auto-closed by Release-Green (continuous)."
+            echo "Closed issue #$EXISTING"
           fi
 
       - name: Upload report artifact

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,12 +4,15 @@ on:
   schedule:
     - cron: "27 7 * * 1"
   push:
-    branches: ["main"]
+    # Scorecard only accepts the DEFAULT branch — here the active release/vX.Y.Z,
+    # not `main`. The job below guards on it so a push to any other branch skips.
+    branches: ["main", "release/**"]
 
 permissions: read-all
 
 jobs:
   analysis:
+    if: ${{ github.event_name != 'push' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:

--- a/.trivyignore
+++ b/.trivyignore
@@ -19,4 +19,12 @@
 # Keep this list SHORT and reviewed every release. Prefer fixing (rebuild on a
 # patched base / bump the dep) over suppressing. Stale entries are debt.
 #
-# (No accepted-risk suppressions at present — ignore-unfixed covers the noise.)
+# CVE-2025-68121 — Go stdlib crypto/tls (session-resumption certificate validation)
+#   inside the PREBUILT bogdanfinn/tls-client v1.15.1 .so that tls-client-node's
+#   postinstall downloads (built with go 1.24.1; fixed in 1.24.13). No upstream
+#   rebuild exists (v1.15.1 is still the latest release) and nothing in this repo
+#   can bump it. The binary is only loaded by the browser-TLS web-provider
+#   executors (claude-web / grok-web / lmarena / perplexity-web / notion-web),
+#   whose handshakes go through utls. Tracking issue: #12084. Revisit at the next
+#   tls-client release or base-image bump and BEFORE the v3.8.51 tag (2026-09-15).
+CVE-2025-68121


### PR DESCRIPTION
Twin of #12085 for `main` (cherry-pick, same 4 files so the next sync-back stays conflict-free). On `main` the effective change is the **Scorecard** default-branch guard — every push to `main` currently fails with `Only the default branch release/v3.8.51 is supported` (run 33269014480). The Trivy gate is skipped for `main` images and Release-Green's scheduled runs use the default branch's file, so those two hunks are inert here.

Refs #12084