### PR TITLE
fix(api): clear the six API-route TypeScript regressions the new gate (#11705) landed red on

### DIFF
--- a/config/quality/api-typecheck-baseline.json
+++ b/config/quality/api-typecheck-baseline.json
@@ -158,7 +158,7 @@
   "src/app/api/providers/route.ts": {
     "TS2352": 1,
     "TS2322": 2,
-    "TS2345": 4
+    "TS2345": 3
   },
   "src/app/api/providers/test-batch/route.ts": {
     "TS2345": 4
@@ -182,8 +182,7 @@
     "TS2739": 1
   },
   "src/app/api/providers/volcengine-plan/connect/route.ts": {
-    "TS2739": 1,
-    "TS2339": 1
+    "TS2739": 1
   },
   "src/app/api/radar/local-model-state/route.ts": {
     "TS2339": 4
@@ -256,15 +255,6 @@
     "TS2345": 1,
     "TS2322": 1
   },
-  "src/app/api/tunnels/cloudflared/route.ts": {
-    "TS2339": 1
-  },
-  "src/app/api/tunnels/ngrok/route.ts": {
-    "TS2339": 1
-  },
-  "src/app/api/tunnels/tailscale/routeUtils.ts": {
-    "TS2339": 1
-  },
   "src/app/api/usage/analytics/route.ts": {
     "TS2352": 15
   },
@@ -273,9 +263,6 @@
   },
   "src/app/api/v1/batches/route.ts": {
     "TS2339": 1
-  },
-  "src/app/api/v1/chatgpt-web/image/[id]/route.ts": {
-    "TS2345": 1
   },
   "src/app/api/v1/classify/route.ts": {
     "TS2322": 1
@@ -287,8 +274,8 @@
     "TS2339": 1
   },
   "src/app/api/v1/images/edits/route.ts": {
-    "TS2339": 21,
-    "TS2322": 5
+    "TS2339": 18,
+    "TS2322": 4
   },
   "src/app/api/v1/messages/count_tokens/route.ts": {
     "TS2339": 2,
@@ -355,12 +342,6 @@
   },
   "src/lib/db/tierConfig.ts": {
     "TS2345": 2
-  },
-  "src/lib/guardrails/videoBridgeHelpers.ts": {
-    "TS2488": 1,
-    "TS2365": 2,
-    "TS2322": 1,
-    "TS2345": 1
   },
   "src/lib/monitoring/comboHealthAutopilot.ts": {
     "TS2305": 1,

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -503,7 +503,10 @@ export async function DELETE(request: Request) {
   try {
     const requestedIds = new Set(body.ids);
     const deletedConnections = (
-      await getProviderConnections({}, undefined, undefined, ["id", "provider"])
+      (await getProviderConnections({}, undefined, undefined, ["id", "provider"])) as Array<{
+        id: string;
+        provider: string;
+      }>
     ).filter((connection) => requestedIds.has(connection.id));
     const deleted = await deleteProviderConnections(body.ids);
 

--- a/src/app/api/providers/volcengine-plan/connect/[sessionId]/code/route.ts
+++ b/src/app/api/providers/volcengine-plan/connect/[sessionId]/code/route.ts
@@ -24,7 +24,7 @@ export async function POST(
   // regardless of whether the session happens to exist, and answering 404 for
   // it (the previous behavior) hides the real cause.
   const validation = validateBody(volcenginePlanCodeSchema, raw);
-  if (!validation.success) {
+  if (validation.success === false) {
     return NextResponse.json(
       { success: false, error: formatValidationMessage(validation.error) },
       { status: 400 }

--- a/src/app/api/providers/volcengine-plan/connect/[sessionId]/identity/route.ts
+++ b/src/app/api/providers/volcengine-plan/connect/[sessionId]/identity/route.ts
@@ -21,7 +21,7 @@ export async function POST(
   const raw = await request.json().catch(() => ({}));
   // Validate BEFORE the session lookup — see the sibling code/route.ts note.
   const validation = validateBody(volcenginePlanIdentitySchema, raw);
-  if (!validation.success) {
+  if (validation.success === false) {
     return NextResponse.json(
       { success: false, error: formatValidationMessage(validation.error) },
       { status: 400 }

--- a/src/app/api/providers/volcengine-plan/connect/route.ts
+++ b/src/app/api/providers/volcengine-plan/connect/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const raw = await request.json().catch(() => ({}));
   const validation = validateBody(volcenginePlanConnectSchema, raw);
-  if (!validation.success) {
+  if (validation.success === false) {
     return NextResponse.json(
       { success: false, error: formatValidationMessage(validation.error) },
       { status: 400 }
@@ -26,7 +26,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         "@omniroute/open-sse/services/volcengineConsoleAutoLogin.ts"
       );
       const started = await volcengineConsoleAutoLoginService.startLogin(phone, { timeout });
-      if (!started.ok) {
+      if (started.ok === false) {
         return NextResponse.json({ success: false, error: started.error }, { status: 400 });
       }
       return NextResponse.json({ success: true, session: started.session });

--- a/src/app/api/tunnels/tailscale/install/route.ts
+++ b/src/app/api/tunnels/tailscale/install/route.ts
@@ -32,14 +32,13 @@ export async function POST(request: Request) {
             status: await getTailscaleTunnelStatus(),
           });
         } catch (error) {
-          pushEvent(
-            "error",
-            toPublicSafeTunnelError(
+          pushEvent("error", {
+            ...toPublicSafeTunnelError(
               error,
               "Failed to install Tailscale.",
               "tunnels/tailscale/install POST"
-            )
-          );
+            ),
+          });
         } finally {
           controller.close();
         }

--- a/src/app/api/webhooks/[id]/test/route.ts
+++ b/src/app/api/webhooks/[id]/test/route.ts
@@ -12,7 +12,6 @@ import { buildTelegramUrl, buildTelegramPayload } from "@/lib/webhooks/integrati
 import { buildDiscordPayload } from "@/lib/webhooks/integrations/discord";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { insertDelivery } from "@/lib/db/webhookDeliveries";
-import { getWebhook, recordWebhookDelivery } from "@/lib/db/webhooks";
 import { isPrivateHost, OutboundUrlGuardError } from "@/shared/network/outboundUrlGuard";
 import { parseAndValidateWebhookUrl } from "@/shared/network/outboundUrlGuardPolicy";
 import crypto from "crypto";


### PR DESCRIPTION
## Why

`API Route Typecheck` (new gate from #11705, merged 2026-08-30) is red on **every** open PR into `release/v3.8.51` (e.g. run [33299099596](https://github.com/diegosouzapw/OmniRoute/actions/runs/33299099596)): its baseline was frozen days before it merged and six diagnostics regressed on the branch in between. The gate's own rule is *fix regressions, do not widen the baseline* — so this fixes them.

## What (6 files, +12/−11)

| file | diagnostic | fix |
|---|---|---|
| `webhooks/[id]/test/route.ts` | TS2300 ×4 — duplicate `import { getWebhook, recordWebhookDelivery }` (barrel migration #12051) | drop the duplicate line — **real defect**, ESM refuses duplicate bindings at load |
| `providers/volcengine-plan/connect/route.ts`, `…/code/route.ts`, `…/identity/route.ts` | TS2339 `.error` on the union | `if (!x.ok)` does not narrow discriminated unions with `strict: false`; compare `=== false` |
| `providers/route.ts` | TS2345 `unknown` → `string` | type the `["id","provider"]` column projection |
| `tunnels/tailscale/install/route.ts` | TS2345 interface → `Record<string, unknown>` | spread the body |

Plus `config/quality/api-typecheck-baseline.json` ratcheted **down** with `--update` (12 baselined diagnostics no longer exist; no count increased).

## Validation

- `node scripts/check/check-api-typecheck.mjs` → OK (289 errors, all frozen)
- `tests/unit/build/check-api-typecheck.test.ts` → pass
- eslint on the 6 files clean under the CI suppressions; prettier warnings on 4 of them pre-exist on the base (not reformatted on purpose)

⚠️ base-red inherited: the 4 unit shards fail on the pure `release/v3.8.51` tip (vi locale parity, `request-log-detail-*` / `request-timeline-lane-allocation`, `media-page-client-browser-bundle`, `syncAllProviderLimits` spacing) after the 2026-08-30 ~04:00–09:30Z merge batch — reproduced locally on the tip without this diff; none of them touch the files changed here.