### PR TITLE
test(ui): correct inactive auto-fetch expectation

### DIFF
--- a/tests/unit/ui/use-provider-models-auto-fetch.test.tsx
+++ b/tests/unit/ui/use-provider-models-auto-fetch.test.tsx
@@ -188,8 +188,9 @@ describe("useProviderModels upstream auto-fetch", () => {
     );
     mounted.unmount();
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/providers/connection-1/sync-models?mode=sync", {
-      method: "POST",
-    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/providers/connection-inactive/sync-models?mode=sync",
+      expect.anything()
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Replace a sync-back-stale `connection-1` expectation in the inactive opt-out case.
- Keep the positive assertion that the active opted-in connection owns synchronization.
- Assert that the inactive opted-out connection is never selected as the sync target.

## Related Issues

- Related to #11800
- Follow-up to #11805

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: UI test-only
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` (focused ESLint passed; full lint runs in CI)
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] No production-code changes; existing production behavior remains covered
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Focused validation:

- Red before: the inactive-opt-out test failed at line 191 because it expected a non-existent `connection-1` sync after already proving `connection-active` was used.
- `npm exec vitest -- run --config vitest.config.ts tests/unit/ui/use-provider-models-auto-fetch.test.tsx -t 'ignores inactive opt-outs when every active connection is enabled'` -- 1 passed
- `npm exec vitest -- run --config vitest.config.ts tests/unit/ui/use-provider-models-auto-fetch.test.tsx` -- 5 passed
- Focused ESLint and Prettier check
- `GITHUB_BASE_REF=release/v3.8.51 npm run check:test-masking`
- `npm run check:tracked-artifacts`
- `git diff --check`

## Tests Added Or Updated

- `tests/unit/ui/use-provider-models-auto-fetch.test.tsx`
- No production code changed.

## Coverage Notes

- Test-only correction; coverage does not move.

## Reviewer Notes

- Root cause: the release sync-back combined the older single-connection timer cleanup with #11805's expanded connection matrix, leaving the old target assertion attached to the new inactive-connection case.
- Production `useProviderModels` is unchanged from #11805 and both mixed connection orders remain green.
- The existing timer-based harness is still contention-sensitive; an isolated target run and a sequential full-file run are green. This PR does not expand into a timer-harness refactor.
