### PR TITLE
fix(dashboard): make RequestLoggerDetail loadable outside Next — CSS via globals.css + CJS/ESM interop (#11703 base-reds)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,10 @@
    The bundled @font-face uses family "Material Symbols Outlined", matching the
    .material-symbols-outlined rule defined later in this file. */
 @import "material-symbols/outlined.css";
+/* react18-json-view (request/response JSON tree in RequestLoggerDetail) — imported here
+   instead of in the component so node:test / esbuild never see a .css import. */
+@import "react18-json-view/src/style.css";
+@import "react18-json-view/src/dark.css";
 @source "../../node_modules/fumadocs-ui/css/generated/*.css";
 
 /* Keep Tailwind v4 from scanning the entire repository. The UI lives in the

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -11253,6 +11253,11 @@
     "detail": {
       "collapse": "Thu gọn {title}",
       "expand": "Mở rộng {title}",
+      "collapseAllLevels": "Thu gọn tất cả",
+      "collapseOneLevel": "Thu gọn một cấp",
+      "currentExpandLevel": "Cấp mở rộng hiện tại",
+      "expandOneLevel": "Mở rộng một cấp",
+      "expandAllLevels": "Mở rộng tất cả",
       "copyTitle": "Sao chép {title}",
       "copied": "Đã sao chép!",
       "copy": "Sao chép",

--- a/src/shared/components/RequestLoggerDetail.sections.tsx
+++ b/src/shared/components/RequestLoggerDetail.sections.tsx
@@ -2,10 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import JsonViewModule from "react18-json-view";
-// Stylesheets for react18-json-view live in src/app/globals.css: a CSS import here
-// is fine for Next but crashes node:test (ERR_UNKNOWN_FILE_EXTENSION) and the
-// browser-bundle safety check for every module that imports this component.
+import { JsonView } from "@/shared/components/jsonView";
 import { ChatBubble } from "@/app/(dashboard)/dashboard/tools/traffic-inspector/components/chat/ChatBubble";
 import { buildRequestTurns, buildResponseTurns } from "@/mitm/inspector/conversationNormalizer";
 import type { InterceptedRequest, NormalizedTurn } from "@/mitm/inspector/types";
@@ -16,12 +13,6 @@ import {
 } from "@/shared/hooks/useTimestampTitles";
 import { JsonTreeExpandControls } from "@/shared/components/JsonTreeExpandControls";
 import { useJsonTreeExpandLevel } from "@/store/jsonTreeExpandStore";
-
-// react18-json-view ships no `exports` map: bundlers take the ESM `module` build and
-// hand over the component, but node ESM (node:test) resolves the CJS `main`, where the
-// default import is the whole module namespace. Same interop as redisQuotaStore/keytar.
-const JsonView = ((JsonViewModule as unknown as { default?: typeof JsonViewModule }).default ??
-  JsonViewModule) as typeof JsonViewModule;
 
 // ─── Payload Code Block ─────────────────────────────────────────────────────
 // Renders parsed payloads as a collapsible JSON tree (react18-json-view) so

--- a/src/shared/components/RequestLoggerDetail.sections.tsx
+++ b/src/shared/components/RequestLoggerDetail.sections.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import JsonView from "react18-json-view";
-import "react18-json-view/src/style.css";
-import "react18-json-view/src/dark.css";
+import JsonViewModule from "react18-json-view";
+// Stylesheets for react18-json-view live in src/app/globals.css: a CSS import here
+// is fine for Next but crashes node:test (ERR_UNKNOWN_FILE_EXTENSION) and the
+// browser-bundle safety check for every module that imports this component.
 import { ChatBubble } from "@/app/(dashboard)/dashboard/tools/traffic-inspector/components/chat/ChatBubble";
 import { buildRequestTurns, buildResponseTurns } from "@/mitm/inspector/conversationNormalizer";
 import type { InterceptedRequest, NormalizedTurn } from "@/mitm/inspector/types";
@@ -15,6 +16,12 @@ import {
 } from "@/shared/hooks/useTimestampTitles";
 import { JsonTreeExpandControls } from "@/shared/components/JsonTreeExpandControls";
 import { useJsonTreeExpandLevel } from "@/store/jsonTreeExpandStore";
+
+// react18-json-view ships no `exports` map: bundlers take the ESM `module` build and
+// hand over the component, but node ESM (node:test) resolves the CJS `main`, where the
+// default import is the whole module namespace. Same interop as redisQuotaStore/keytar.
+const JsonView = ((JsonViewModule as unknown as { default?: typeof JsonViewModule }).default ??
+  JsonViewModule) as typeof JsonViewModule;
 
 // ─── Payload Code Block ─────────────────────────────────────────────────────
 // Renders parsed payloads as a collapsible JSON tree (react18-json-view) so

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -2,10 +2,7 @@
 
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import JsonViewModule from "react18-json-view";
-// Stylesheets for react18-json-view live in src/app/globals.css: a CSS import here
-// is fine for Next but crashes node:test (ERR_UNKNOWN_FILE_EXTENSION) and the
-// browser-bundle safety check for every module that imports this component.
+import { JsonView } from "@/shared/components/jsonView";
 import {
   PROVIDER_COLORS,
   getHttpStatusStyle as getStatusStyle,
@@ -24,12 +21,6 @@ import {
   PayloadSection,
   ConversationContextSection,
 } from "@/shared/components/RequestLoggerDetail.sections";
-
-// react18-json-view ships no `exports` map: bundlers take the ESM `module` build and
-// hand over the component, but node ESM (node:test) resolves the CJS `main`, where the
-// default import is the whole module namespace. Same interop as redisQuotaStore/keytar.
-const JsonView = ((JsonViewModule as unknown as { default?: typeof JsonViewModule }).default ??
-  JsonViewModule) as typeof JsonViewModule;
 
 // ─── Copy-all composition ────────────────────────────────────────────────────
 // Compose every visible payload section + stream chunk into a single block so

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import JsonView from "react18-json-view";
-import "react18-json-view/src/style.css";
-import "react18-json-view/src/dark.css";
+import JsonViewModule from "react18-json-view";
+// Stylesheets for react18-json-view live in src/app/globals.css: a CSS import here
+// is fine for Next but crashes node:test (ERR_UNKNOWN_FILE_EXTENSION) and the
+// browser-bundle safety check for every module that imports this component.
 import {
   PROVIDER_COLORS,
   getHttpStatusStyle as getStatusStyle,
@@ -23,6 +24,12 @@ import {
   PayloadSection,
   ConversationContextSection,
 } from "@/shared/components/RequestLoggerDetail.sections";
+
+// react18-json-view ships no `exports` map: bundlers take the ESM `module` build and
+// hand over the component, but node ESM (node:test) resolves the CJS `main`, where the
+// default import is the whole module namespace. Same interop as redisQuotaStore/keytar.
+const JsonView = ((JsonViewModule as unknown as { default?: typeof JsonViewModule }).default ??
+  JsonViewModule) as typeof JsonViewModule;
 
 // ─── Copy-all composition ────────────────────────────────────────────────────
 // Compose every visible payload section + stream chunk into a single block so

--- a/src/shared/components/jsonView.ts
+++ b/src/shared/components/jsonView.ts
@@ -1,0 +1,9 @@
+import JsonViewModule from "react18-json-view";
+
+// react18-json-view ships no `exports` map: bundlers take the ESM `module` build and hand
+// over the component, but node ESM (node:test) resolves the CJS `main`, where the default
+// import is the whole module namespace. Same interop as redisQuotaStore / keytar-reader.
+// Its stylesheets are @imported from src/app/globals.css — never import CSS here or in the
+// components (node:test and the browser-bundle check cannot load .css).
+export const JsonView = ((JsonViewModule as unknown as { default?: typeof JsonViewModule })
+  .default ?? JsonViewModule) as typeof JsonViewModule;


### PR DESCRIPTION
## Origin

#11703 (`5684589ce7`, collapsible JSON tree viewer) imports `react18-json-view/src/{style,dark}.css` at module level in `RequestLoggerDetail(.sections).tsx` and uses a bare default import of `react18-json-view`. Next handles both; nothing else does — so on the `release/v3.8.51` tip every test that renders the component dies, which is why **all 4 unit shards are red on every open PR** (e.g. #12106, #12099, #12081):

| symptom | cause |
|---|---|
| `request-log-detail-{layout,stream}`, `request-logger-detail-copy-all`, `request-timeline-lane-allocation` — `ERR_UNKNOWN_FILE_EXTENSION ".css"` | CSS import in a module loaded by node:test/tsx |
| `media-page-client-browser-bundle` — esbuild cannot resolve the `.css` specifiers | same |
| `Element type is invalid … got: object` once the CSS is out of the way | node ESM resolves the package's CJS `main` (no `exports` map) → default import is the module namespace |
| `i18n-vi-completeness` ×3 | 5 new `requestLogger.detail.*` keys without `vi` (strict parity) |

## Fix (at the source, not in the tests)

- `src/app/globals.css`: `@import` the two stylesheets there (same pattern as `material-symbols`/`fumadocs`); the components no longer import CSS.
- Components: `const JsonView = (mod.default ?? mod)` — the interop already used by `redisQuotaStore`/`keytar-reader`.
- `vi.json`: the 5 strings.

## Validation

- node:test: the 6 affected files → **24/24 pass**; vitest `payload-section-collapsible-json` + `timestamp-titles` → 8/8.
- eslint + prettier clean on the touched files.
- Local `node_modules` needed `react18-json-view` installed (`npm install --no-save`) — CI's `npm ci` already has it (the lockfile is fine).

⚠️ base-red inherited: every red check here reproduces on the pure `release/v3.8.51` tip (see the merge-batch audit in the session report) and none touches this PR's files.