### PR TITLE
test(providers): regenerate the translate-path golden for OrcaRouter (#11923 base-red on unit shard 2/4)

### DIFF
--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -4611,8 +4611,8 @@
       }
     },
     "url": {
-      "nonStream": "https://api.orcarouter.ai/v1",
-      "stream": "https://api.orcarouter.ai/v1"
+      "nonStream": "https://api.orcarouter.ai/v1/chat/completions",
+      "stream": "https://api.orcarouter.ai/v1/chat/completions"
     }
   },
   "ovhcloud": {


### PR DESCRIPTION
#11923 (`22011437f8`, merged 08:27Z) deliberately routes OrcaRouter chat requests to `https://api.orcarouter.ai/v1/chat/completions`, but the golden `provider/translate-path` snapshot still pinned `/v1` → **GOLDEN provider.ts translate-path is stable across all providers** fails on the release tip and turns `Unit Tests fast-path (2/4)` red on every open PR (e.g. #12114 run).

Regenerated with `UPDATE_GOLDEN=1`; the only delta is the `orcarouter` block (nonStream + stream). Test passes afterwards.

Refs #11923

⚠️ base-red inherited: every red check here reproduces on the pure `release/v3.8.51` tip (see the merge-batch audit in the session report) and none touches this PR's files.