### PR TITLE
fix(plugins): refresh stored manifest from disk on activate so new ho…

### DIFF
--- a/src/lib/db/plugins.ts
+++ b/src/lib/db/plugins.ts
@@ -171,6 +171,32 @@ export function updatePluginStatus(
   return result.changes > 0;
 }
 
+/**
+ * Refresh the persisted manifest snapshot (and the derived hooks list) for a plugin.
+ *
+ * The `manifest` column is a snapshot validated by the Zod schema of the OmniRoute
+ * version that INSTALLED the plugin; when a later version adds a manifest field
+ * (e.g. hooks.onStreamComplete, #11934), activate() re-reads plugin.json from disk
+ * and calls this to bring the row up to date without requiring a version-bump upgrade.
+ */
+export function updatePluginManifest(
+  name: string,
+  manifest: Record<string, unknown>,
+  hooks: string[]
+): boolean {
+  const db = getDbInstance();
+  const now = new Date().toISOString();
+
+  const result = db
+    .prepare("UPDATE plugins SET manifest = ?, hooks = ?, updated_at = ? WHERE name = ?")
+    .run(JSON.stringify(manifest), JSON.stringify(hooks), now, name);
+
+  if (result.changes > 0) {
+    log.info("plugin.manifest_updated", { name });
+  }
+  return result.changes > 0;
+}
+
 export function updatePluginConfig(name: string, config: Record<string, unknown>): boolean {
   const db = getDbInstance();
   const now = new Date().toISOString();

--- a/src/lib/plugins/manager.ts
+++ b/src/lib/plugins/manager.ts
@@ -20,6 +20,7 @@ import {
   listPlugins as dbListPlugins,
   updatePluginStatus,
   updatePluginConfig,
+  updatePluginManifest,
   deletePlugin as dbDeletePlugin,
   pluginExists,
   type PluginRow,
@@ -371,6 +372,60 @@ class PluginManager {
   }
 
   /**
+   * Refresh the stored manifest from the on-disk plugin.json, falling back to the
+   * DB snapshot when the disk copy is unreadable, invalid, or mismatched.
+   *
+   * The `manifest` column is a snapshot validated by the Zod schema of the OmniRoute
+   * version that INSTALLED the plugin. When a later upgrade adds a manifest field
+   * (e.g. hooks.onStreamComplete, #11934), plugins installed earlier keep a snapshot
+   * with that field stripped — and nothing re-reads plugin.json: scan() only inserts
+   * unknown plugins, upgrade() requires a strictly newer version, and activate()
+   * never re-validated. The new hook then silently never registers while the
+   * dashboard still shows the plugin active.
+   *
+   * Fail-safe by design: any read/parse/validation failure, a name mismatch, or a
+   * `main` escaping the plugin dir returns the stored manifest unchanged, so a
+   * broken plugin.json can never brick an install that used to activate.
+   */
+  private async refreshManifestFromDisk(row: PluginRow): Promise<PluginManifestWithDefaults> {
+    const stored = JSON.parse(row.manifest) as PluginManifestWithDefaults;
+    try {
+      const { safeValidateManifest } = await import("./manifest");
+      const raw = await readFile(join(row.pluginDir, "plugin.json"), "utf-8");
+      const result = safeValidateManifest(JSON.parse(raw));
+      if (!result.success) return stored;
+      const fresh = result.data;
+      // A plugin.json naming a different plugin must never overwrite this row.
+      if (fresh.name !== row.name) return stored;
+      // CRITICAL-3: same containment gate as install/upgrade — never persist a
+      // manifest whose `main` resolves outside the plugin directory.
+      assertEntryPointWithinDest(row.pluginDir, join(row.pluginDir, fresh.main));
+
+      const freshJson = JSON.stringify(fresh);
+      if (freshJson !== row.manifest) {
+        updatePluginManifest(
+          row.name,
+          fresh as unknown as Record<string, unknown>,
+          [
+            fresh.hooks.onRequest && "onRequest",
+            fresh.hooks.onResponse && "onResponse",
+            fresh.hooks.onError && "onError",
+            fresh.hooks.onInstall && "onInstall",
+            fresh.hooks.onActivate && "onActivate",
+            fresh.hooks.onDeactivate && "onDeactivate",
+            fresh.hooks.onUninstall && "onUninstall",
+            fresh.hooks.onStreamComplete && "onStreamComplete",
+          ].filter(Boolean) as string[]
+        );
+        log.info("manager.manifest_refreshed", { name: row.name });
+      }
+      return fresh;
+    } catch {
+      return stored;
+    }
+  }
+
+  /**
    * Activate a plugin — load into VM, register hooks, update DB.
    */
   async activate(name: string): Promise<void> {
@@ -383,7 +438,9 @@ class PluginManager {
     // silently enforces nothing while the UI still reports it as active.
     if (row.status === "active" && this.loadedPlugins.has(name)) return;
 
-    const manifest = JSON.parse(row.manifest) as PluginManifestWithDefaults;
+    // Prefer a fresh read of plugin.json over the install-time DB snapshot so hook
+    // fields added by newer schema versions reach pre-existing installs (#11934).
+    const manifest = await this.refreshManifestFromDisk(row);
 
     // Path traversal guard: use realpath to resolve symlinks
     const entryPoint = join(row.pluginDir, manifest.main);

--- a/tests/unit/plugins-manifest-refresh-on-activate.test.ts
+++ b/tests/unit/plugins-manifest-refresh-on-activate.test.ts
@@ -1,0 +1,259 @@
+// Regression test — activate() must refresh the stored manifest from disk so new
+// hook fields reach plugins installed BEFORE the schema learned them.
+//
+// #11934 added `onStreamComplete` to HooksSchema plus the loader/manager delivery
+// wiring, but a plugin activates with the manifest JSON persisted to the DB at
+// INSTALL time (insertPlugin({manifest}), re-read in activate() as
+// JSON.parse(row.manifest) — src/lib/plugins/manager.ts). Plugins installed before
+// that upgrade carry a stored manifest the OLD Zod schema stripped (`hooks` object
+// has no `onStreamComplete` key at all), and nothing ever re-reads plugin.json:
+// scan() only inserts unknown plugins, upgrade() requires a strictly newer plugin
+// version, activate() never re-validates. So loader.ts's `manifestFlag` is falsy,
+// no IPC wrapper is built, the hook never registers — while the dashboard still
+// shows the plugin active. The #11825 regression test misses this because it
+// installs a FRESH plugin, which persists the NEW schema's manifest.
+//
+// The fix must also be fail-safe: a corrupt/missing/mismatched plugin.json on disk
+// falls back to the stored manifest exactly as before — never brick an install.
+import { test, describe, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+const mgr = await import("../../src/lib/plugins/manager.ts");
+const db = await import("../../src/lib/db/plugins.ts");
+const { getDbInstance, resetDbInstance } = await import("../../src/lib/db/core.ts");
+const { runPluginOnStreamCompleteHook } =
+  await import("../../open-sse/handlers/chatCore/pluginOnResponse.ts");
+
+// Release the SQLite handle when the file is done — a leaked handle hangs the
+// Node test runner (see AGENTS.md → "Database Handles in Tests").
+after(() => {
+  resetDbInstance();
+});
+
+async function waitFor(pred: () => boolean, timeoutMs = 6000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && !pred()) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+/**
+ * Exactly what the pre-#11934 code persisted at install time: applyDefaults()
+ * output from a schema whose HooksSchema had no `onStreamComplete` field — the
+ * flag was stripped by Zod and the old applyDefaults never re-added the key.
+ */
+function legacyStoredManifest(name: string, hooks: Record<string, boolean>) {
+  return {
+    name,
+    version: "1.0.0",
+    license: "MIT",
+    main: "index.js",
+    source: "local",
+    tags: [],
+    requires: { permissions: [] },
+    hooks: {
+      onRequest: false,
+      onResponse: false,
+      onError: false,
+      onInstall: false,
+      onActivate: false,
+      onDeactivate: false,
+      onUninstall: false,
+      // deliberately NO onStreamComplete key
+      ...hooks,
+    },
+    skills: [],
+    enabledByDefault: false,
+    configSchema: {},
+  };
+}
+
+/** Insert the DB row as a pre-upgrade install would have left it. */
+function insertLegacyRow(name: string, pluginDir: string, hooks: Record<string, boolean>) {
+  db.insertPlugin({
+    id: randomUUID(),
+    name,
+    version: "1.0.0",
+    main: "index.js",
+    manifest: legacyStoredManifest(name, hooks),
+    hooks: Object.keys(hooks).filter((k) => hooks[k]),
+    permissions: [],
+    pluginDir,
+    enabled: false,
+  });
+}
+
+function makePluginDir(name: string): { tmp: string; pluginDir: string } {
+  const tmp = mkdtempSync(join(tmpdir(), "manifest-refresh-"));
+  const pluginDir = join(tmp, name);
+  mkdirSync(pluginDir, { recursive: true });
+  return { tmp, pluginDir };
+}
+
+describe("activate() refreshes the stored manifest from disk (pre-#11934 installs)", () => {
+  beforeEach(() => {
+    getDbInstance(); // ensure the plugins table migration has run
+  });
+
+  test("a hook field the old schema stripped registers after activate()", async (t) => {
+    const NAME = "sc-manifest-refresh";
+    const outFile = join(tmpdir(), `omniroute-manifest-refresh-${process.pid}.json`);
+    rmSync(outFile, { force: true });
+    const { tmp, pluginDir } = makePluginDir(NAME);
+
+    // On DISK the plugin declares the new hook (its author always shipped it)…
+    writeFileSync(
+      join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: NAME,
+        version: "1.0.0",
+        main: "index.js",
+        hooks: { onStreamComplete: true },
+      })
+    );
+    writeFileSync(
+      join(pluginDir, "index.js"),
+      `const fs = require("fs");
+const OUT = ${JSON.stringify(outFile)};
+module.exports = {
+  onStreamComplete: async (payload) => { fs.writeFileSync(OUT, JSON.stringify(payload)); },
+};
+`
+    );
+
+    // …but the DB row was persisted by the OLD schema: the flag is gone.
+    try {
+      db.deletePlugin(NAME);
+    } catch {}
+    insertLegacyRow(NAME, pluginDir, {});
+
+    t.after(async () => {
+      await mgr.pluginManager.deactivate(NAME).catch(() => {});
+      try {
+        db.deletePlugin(NAME);
+      } catch {}
+      rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      rmSync(outFile, { force: true });
+    });
+
+    await mgr.pluginManager.activate(NAME);
+
+    // Drive the REAL producer entry point used by chatCore.ts.
+    await runPluginOnStreamCompleteHook({
+      status: 200,
+      usage: { prompt_tokens: 7, completion_tokens: 13 },
+      ttft: 80,
+      model: "claude-3-opus",
+      provider: "anthropic",
+      errorCode: undefined,
+      startTime: Date.now() - 250,
+      requestId: "trace-manifest-refresh",
+    });
+
+    await waitFor(() => existsSync(outFile));
+    assert.ok(
+      existsSync(outFile),
+      "onStreamComplete never reached the plugin — activate() used the stale DB manifest " +
+        "(hooks.onStreamComplete stripped at install time) instead of re-reading plugin.json"
+    );
+    const payload = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
+    assert.equal(payload.requestId, "trace-manifest-refresh");
+
+    // The refreshed manifest must also be persisted so the row stays coherent.
+    const row = db.getPluginByName(NAME);
+    assert.ok(row, "plugin row should exist");
+    const storedManifest = JSON.parse(row!.manifest) as {
+      hooks: Record<string, boolean | undefined>;
+    };
+    assert.equal(
+      storedManifest.hooks.onStreamComplete,
+      true,
+      "stored manifest should be refreshed from disk on activate()"
+    );
+    assert.ok(
+      (JSON.parse(row!.hooks) as string[]).includes("onStreamComplete"),
+      "stored hooks list should be refreshed alongside the manifest"
+    );
+  });
+
+  test("a corrupt plugin.json on disk falls back to the stored manifest (never bricks)", async (t) => {
+    const NAME = "sc-manifest-fallback";
+    const { tmp, pluginDir } = makePluginDir(NAME);
+
+    writeFileSync(join(pluginDir, "plugin.json"), "{ this is not JSON");
+    writeFileSync(join(pluginDir, "index.js"), `module.exports = { onRequest: async () => ({}) };`);
+
+    try {
+      db.deletePlugin(NAME);
+    } catch {}
+    insertLegacyRow(NAME, pluginDir, { onRequest: true });
+    const before = db.getPluginByName(NAME)!.manifest;
+
+    t.after(async () => {
+      await mgr.pluginManager.deactivate(NAME).catch(() => {});
+      try {
+        db.deletePlugin(NAME);
+      } catch {}
+      rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    });
+
+    await mgr.pluginManager.activate(NAME);
+
+    assert.ok(
+      mgr.pluginManager.getLoaded(NAME),
+      "activation must still succeed on the stored manifest when plugin.json is unreadable"
+    );
+    assert.equal(
+      db.getPluginByName(NAME)!.manifest,
+      before,
+      "a failed disk read must not overwrite the stored manifest"
+    );
+  });
+
+  test("a disk manifest whose name mismatches the row is ignored", async (t) => {
+    const NAME = "sc-manifest-name-guard";
+    const { tmp, pluginDir } = makePluginDir(NAME);
+
+    // plugin.json names a DIFFERENT plugin — refreshing from it would corrupt the row.
+    writeFileSync(
+      join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "some-other-plugin",
+        version: "9.9.9",
+        main: "index.js",
+        hooks: { onStreamComplete: true },
+      })
+    );
+    writeFileSync(join(pluginDir, "index.js"), `module.exports = { onRequest: async () => ({}) };`);
+
+    try {
+      db.deletePlugin(NAME);
+    } catch {}
+    insertLegacyRow(NAME, pluginDir, { onRequest: true });
+    const before = db.getPluginByName(NAME)!.manifest;
+
+    t.after(async () => {
+      await mgr.pluginManager.deactivate(NAME).catch(() => {});
+      try {
+        db.deletePlugin(NAME);
+      } catch {}
+      rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    });
+
+    await mgr.pluginManager.activate(NAME);
+
+    assert.ok(
+      mgr.pluginManager.getLoaded(NAME),
+      "activation should proceed on the stored manifest"
+    );
+    assert.equal(
+      db.getPluginByName(NAME)!.manifest,
+      before,
+      "a name-mismatched disk manifest must never replace the stored one"
+    );
+  });
+});


### PR DESCRIPTION
…ok fields reach existing installs

The plugins.manifest DB column is a snapshot validated by the Zod schema of the OmniRoute version that INSTALLED the plugin (insertPlugin({manifest})), and activate() consumed it verbatim via JSON.parse(row.manifest) (src/lib/plugins/manager.ts:386 pre-fix). When #11934 added hooks.onStreamComplete to HooksSchema plus the loader/manager delivery wiring, plugins installed BEFORE that upgrade kept a stored manifest the old schema had stripped, and nothing ever re-read plugin.json from disk: scan() only inserts unknown plugins, upgrade() requires a strictly newer version, and activate() never re-validated. loader.ts's manifestFlag (src/lib/plugins/loader.ts:346) therefore stayed falsy, no IPC wrapper was built and the hook never registered — the #11825 fix silently never took effect for pre-existing installs while the dashboard showed the plugin active.

Fix: activate() (which also covers the loadAll() boot path) now calls refreshManifestFromDisk(): it re-reads plugin.json, safeValidateManifest()s it with the CURRENT schema, and when it validates — and names the same plugin, and its main passes the same assertEntryPointWithinDest() containment gate as install/upgrade — persists the refreshed manifest and derived hooks list via the new db updatePluginManifest() and activates with it. Any disk read/parse/validation failure, name mismatch, or containment violation falls back to the stored manifest exactly as before, so a broken plugin.json can never brick an install that used to activate. All existing entry-point security checks (realpath containment in activate()) are preserved.

Validated (TDD, red on 25aa95f0d then green with the fix): node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/plugins-manifest-refresh-on-activate.test.ts Neighboring suites (plugins-onstreamcomplete-delivery-11825, manager lifecycle/restart, loader, loader-ipc, db, upgrade, hooks, fs-safety, chatcore-plugin-onresponse, manifest, 8395-plugin-hooks-fire): 132/132 pass. npm run typecheck:core: clean.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
