### PR TITLE
test(providers): regenerate translate-path golden for OrcaRouter chat…

### DIFF
--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -4611,8 +4611,8 @@
       }
     },
     "url": {
-      "nonStream": "https://api.orcarouter.ai/v1",
-      "stream": "https://api.orcarouter.ai/v1"
+      "nonStream": "https://api.orcarouter.ai/v1/chat/completions",
+      "stream": "https://api.orcarouter.ai/v1/chat/completions"
     }
   },
   "ovhcloud": {


### PR DESCRIPTION
…-completions base URL

Commit 22011437f (#11923) changed the OrcaRouter baseUrl in open-sse/config/providers/registry/orcarouter/index.ts from https://api.orcarouter.ai/v1 to https://api.orcarouter.ai/v1/chat/completions but did not regenerate the translate-path golden snapshot. goldenSnapshot() strict-compares the recorded URLs, so tests/unit/provider-translate-path-golden.test.ts failed with GoldenMismatchError on the release tip. This regenerates tests/snapshots/provider/translate-path.json via UPDATE_GOLDEN=1; the diff touches only the orcarouter stream/nonStream url entries. Validated with: node --import tsx/esm --test tests/unit/provider-translate-path-golden.test.ts (3/3 pass).

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
