### PR TITLE
fix(codex): preserve existing provider state when bulk-import upserts…

### DIFF
--- a/src/app/api/oauth/codex/import/route.ts
+++ b/src/app/api/oauth/codex/import/route.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { normalizeCodexImportRecord, flattenCodexImportPayload } from "@/lib/oauth/services/codexImport";
-import { createProviderConnection } from "@/models";
+import {
+  normalizeCodexImportRecord,
+  flattenCodexImportPayload,
+  preserveExistingCodexConnectionState,
+} from "@/lib/oauth/services/codexImport";
+import { createProviderConnection, getProviderConnections } from "@/models";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
-import { refreshCodexToken, isUnrecoverableRefreshError } from "@omniroute/open-sse/services/tokenRefresh.ts";
+import {
+  refreshCodexToken,
+  isUnrecoverableRefreshError,
+} from "@omniroute/open-sse/services/tokenRefresh.ts";
 
 /**
  * Message returned when the imported record's refresh_token is already dead
@@ -29,9 +36,10 @@ const EXPIRED_SESSION_MESSAGE =
  * error string when the refresh_token is confirmed dead and the import
  * should be rejected.
  */
-async function validateCodexRefreshToken(
-  payload: { accessToken: string; refreshToken: string },
-): Promise<string | null> {
+async function validateCodexRefreshToken(payload: {
+  accessToken: string;
+  refreshToken: string;
+}): Promise<string | null> {
   let refreshResult: unknown;
   try {
     refreshResult = await refreshCodexToken(payload.refreshToken, undefined, null);
@@ -96,17 +104,14 @@ export async function POST(request: Request) {
   try {
     rawBody = await request.json();
   } catch {
-    return NextResponse.json(
-      { error: "Invalid or empty JSON body" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Invalid or empty JSON body" }, { status: 400 });
   }
 
   const parsed = bodySchema.safeParse(rawBody);
   if (!parsed.success) {
     return NextResponse.json(
       { error: parsed.error.errors[0]?.message ?? "Invalid request body" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
@@ -115,10 +120,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: flat.error }, { status: 400 });
   }
   if (flat.records.length === 0) {
-    return NextResponse.json(
-      { error: "No accounts found in payload" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "No accounts found in payload" }, { status: 400 });
   }
 
   const results: Array<
@@ -144,7 +146,18 @@ export async function POST(request: Request) {
     }
 
     try {
-      const conn = await createProviderConnection(norm.payload as Record<string, unknown>);
+      // A record matching an existing connection (same email + workspaceId)
+      // flows into createProviderConnection's upsert, which replaces supplied
+      // columns wholesale — carry the matched row's providerSpecificData and
+      // priority through the payload so a re-import cannot clobber them
+      // (#11954 follow-up). Fetched per record: an earlier record in this
+      // batch may have just created the row a later duplicate must match.
+      const existing = await getProviderConnections({ provider: "codex", authType: "oauth" });
+      const payload = preserveExistingCodexConnectionState(
+        norm.payload,
+        existing as Array<Record<string, unknown>>
+      );
+      const conn = await createProviderConnection(payload as Record<string, unknown>);
       imported += 1;
       results.push({
         index: i,

--- a/src/lib/oauth/services/codexImport.ts
+++ b/src/lib/oauth/services/codexImport.ts
@@ -26,6 +26,10 @@ export type CodexImportPayload = {
   idToken?: string;
   email: string;
   expiresAt: string;
+  // Mirrors expiresAt — the dashboard token-health badge prefers tokenExpiresAt
+  // over expiresAt, so an upsert that leaves the old row's stale value behind
+  // shows "Token Expired" for freshly imported tokens (#5326 pattern).
+  tokenExpiresAt: string;
   testStatus: "active";
   isActive: true;
   errorCode: null;
@@ -41,6 +45,9 @@ export type CodexImportPayload = {
     // Canonical alias consumed by the existing Codex workspace upsert path.
     workspaceId?: string;
     chatgptPlanType?: string;
+    // On a matching re-import the existing row's providerSpecificData is
+    // carried through here (preserveExistingCodexConnectionState).
+    [key: string]: unknown;
   };
 };
 
@@ -250,6 +257,7 @@ export function normalizeCodexImportRecord(input: unknown): NormalizeResult {
     refreshToken,
     email,
     expiresAt,
+    tokenExpiresAt: expiresAt,
     testStatus: "active",
     // Fresh imported OAuth credentials supersede a previous refresh failure.
     isActive: true,
@@ -270,6 +278,56 @@ export function normalizeCodexImportRecord(input: unknown): NormalizeResult {
   }
 
   return { ok: true, payload };
+}
+
+function toPsdRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * When a bulk-imported record matches an existing connection (same email +
+ * providerSpecificData.workspaceId — the exact key createProviderConnection's
+ * Codex oauth upsert matches on), the upsert replaces every column the payload
+ * supplies wholesale. Adjust the payload so a re-import refreshes credentials
+ * WITHOUT clobbering state the import cannot know about (#11954 follow-up):
+ *
+ * - providerSpecificData: merge the import's keys OVER the existing row's, so
+ *   chatgptUserId / organizations / workspacePlanType (OAuth login flow),
+ *   runtime quota state (codexExhaustedWindowByScope, codexScopeRateLimitedUntil)
+ *   and the operator-set codexFingerprintMode survive — the same pattern the
+ *   single-file import uses (codexAuthImport.ts).
+ * - priority: drop the forwarded 9router priority — the upsert path never
+ *   reorders siblings, so overwriting the matched row's priority can duplicate
+ *   another connection's. The operator's existing ordering wins.
+ *
+ * Pure: the caller supplies the candidate connections (provider "codex",
+ * authType "oauth"); no match returns the payload unchanged.
+ */
+export function preserveExistingCodexConnectionState(
+  payload: CodexImportPayload,
+  existingConnections: Array<Record<string, unknown>>
+): CodexImportPayload {
+  const workspaceId = payload.providerSpecificData?.workspaceId;
+  if (!workspaceId) return payload;
+  const match = existingConnections.find(
+    (conn) =>
+      conn.provider === "codex" &&
+      conn.authType === "oauth" &&
+      conn.email === payload.email &&
+      toPsdRecord(conn.providerSpecificData).workspaceId === workspaceId
+  );
+  if (!match) return payload;
+  const adjusted: CodexImportPayload = {
+    ...payload,
+    providerSpecificData: {
+      ...toPsdRecord(match.providerSpecificData),
+      ...payload.providerSpecificData,
+    },
+  };
+  delete adjusted.priority;
+  return adjusted;
 }
 
 /**

--- a/tests/unit/codex-bulk-import-preserve-state-11954.test.ts
+++ b/tests/unit/codex-bulk-import-preserve-state-11954.test.ts
@@ -1,0 +1,224 @@
+// Regression tests for the #11954 follow-up: since bulk imports mirror
+// workspaceId (commit 8180b3213), a re-import of an already-connected account
+// flows into createProviderConnection()'s Codex oauth upsert (matched on
+// email + providerSpecificData.workspaceId). That upsert replaces the columns
+// supplied by the payload wholesale, so the import used to:
+//   (a) clobber providerSpecificData — losing chatgptUserId / organizations /
+//       workspacePlanType (written by the OAuth login flow), runtime quota
+//       state (codexExhaustedWindowByScope / codexScopeRateLimitedUntil) and
+//       the operator-set codexFingerprintMode;
+//   (b) leave the row's stale tokenExpiresAt behind (the payload only carried
+//       expiresAt), so the dashboard badge — which prefers tokenExpiresAt —
+//       kept showing "Token Expired" for freshly imported tokens;
+//   (c) overwrite the matched row's priority with the forwarded 9router
+//       priority WITHOUT reordering siblings, creating duplicate priorities.
+//
+// global.fetch is mocked to throw so the pre-persist refresh_token validation
+// (#7522) is inconclusive and the originally supplied tokens are imported.
+//
+// DB handles are released in test.after (CLAUDE.md learning: unreleased
+// SQLite handles hang node:test).
+
+import { after, beforeEach, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-codex-import-11954-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const route = await import("../../src/app/api/oauth/codex/import/route.ts");
+
+beforeEach(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  await settingsDb.updateSettings({ requireLogin: false });
+});
+
+after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+const PAST_ISO = "2026-01-01T00:00:00.000Z";
+const FUTURE_ISO = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+const WORKSPACE_ID = "ws-acct-11954";
+const EMAIL = "operator@example.com";
+
+/** Unsigned JWT with a base64url payload — enough for the import's decode. */
+function makeJwt(payload: Record<string, unknown>): string {
+  const seg = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${seg({ alg: "none", typ: "JWT" })}.${seg(payload)}.sig`;
+}
+
+const IMPORT_ID_TOKEN = makeJwt({
+  email: EMAIL,
+  "https://api.openai.com/auth": {
+    chatgpt_account_id: WORKSPACE_ID,
+    chatgpt_plan_type: "pro",
+  },
+});
+
+/** The operator/runtime state a re-import can never know about. */
+const EXISTING_PSD = {
+  workspaceId: WORKSPACE_ID,
+  chatgptAccountId: WORKSPACE_ID,
+  chatgptUserId: "user-11954",
+  organizations: [{ id: "org-1", title: "Team WS", role: "member" }],
+  workspacePlanType: "team",
+  codexFingerprintMode: "full",
+  codexExhaustedWindowByScope: { primary: "2026-08-30T00:00:00.000Z" },
+  codexScopeRateLimitedUntil: { primary: "2026-08-30T01:00:00.000Z" },
+};
+
+async function createExistingConnection() {
+  const connection = await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "Operator Codex",
+    email: EMAIL,
+    accessToken: "old-access",
+    refreshToken: "old-refresh",
+    expiresAt: PAST_ISO,
+    tokenExpiresAt: PAST_ISO,
+    providerSpecificData: { ...EXISTING_PSD },
+  });
+  assert.ok(connection && typeof connection.id === "string");
+  return connection as Record<string, unknown>;
+}
+
+async function postImport(body: unknown) {
+  const originalFetch = globalThis.fetch;
+  // Transient validation failure → import proceeds with the supplied tokens.
+  globalThis.fetch = (async () => {
+    throw new Error("ECONNRESET");
+  }) as unknown as typeof fetch;
+  try {
+    const request = new Request("http://localhost:20128/api/oauth/codex/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const response = await route.POST(request);
+    return { status: response.status, body: await response.json() };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function importRecord(extra: Record<string, unknown> = {}) {
+  return {
+    access_token: "imported-access",
+    refresh_token: "imported-refresh",
+    id_token: IMPORT_ID_TOKEN,
+    expired: FUTURE_ISO,
+    ...extra,
+  };
+}
+
+async function getCodexRows() {
+  return (await providersDb.getProviderConnections({
+    provider: "codex",
+    authType: "oauth",
+  })) as Array<Record<string, unknown>>;
+}
+
+test("(a) re-import keeps the existing row's providerSpecificData while updating the import's own keys", async () => {
+  const existing = await createExistingConnection();
+
+  const { status, body } = await postImport({ accounts: importRecord() });
+  assert.equal(status, 200);
+  assert.equal(body.success, true, JSON.stringify(body));
+
+  const rows = await getCodexRows();
+  assert.equal(rows.length, 1, "matching re-import must upsert, not add a row");
+  const row = rows[0];
+  assert.equal(row.id, existing.id);
+  assert.equal(row.accessToken, "imported-access", "fresh credentials must apply");
+
+  const psd = row.providerSpecificData as Record<string, unknown>;
+  // State only the OAuth login / runtime / operator writes — must survive.
+  assert.equal(psd.chatgptUserId, EXISTING_PSD.chatgptUserId);
+  assert.deepEqual(psd.organizations, EXISTING_PSD.organizations);
+  assert.equal(psd.workspacePlanType, EXISTING_PSD.workspacePlanType);
+  assert.equal(psd.codexFingerprintMode, EXISTING_PSD.codexFingerprintMode);
+  assert.deepEqual(psd.codexExhaustedWindowByScope, EXISTING_PSD.codexExhaustedWindowByScope);
+  assert.deepEqual(psd.codexScopeRateLimitedUntil, EXISTING_PSD.codexScopeRateLimitedUntil);
+  // The import's own keys must still update.
+  assert.equal(psd.chatgptPlanType, "pro");
+  assert.equal(psd.workspaceId, WORKSPACE_ID);
+  assert.equal(psd.chatgptAccountId, WORKSPACE_ID);
+});
+
+test("(b) re-import refreshes tokenExpiresAt alongside expiresAt", async () => {
+  await createExistingConnection();
+
+  const { body } = await postImport({ accounts: importRecord() });
+  assert.equal(body.success, true, JSON.stringify(body));
+
+  const rows = await getCodexRows();
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].expiresAt, FUTURE_ISO);
+  assert.equal(
+    rows[0].tokenExpiresAt,
+    FUTURE_ISO,
+    "the dashboard badge prefers tokenExpiresAt — a stale value shows 'Token Expired'"
+  );
+});
+
+test("(c) re-import keeps the operator's priority and never duplicates a sibling's", async () => {
+  const existing = await createExistingConnection(); // auto priority 1
+  const sibling = await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "Other Codex",
+    email: "other@example.com",
+    accessToken: "other-access",
+    refreshToken: "other-refresh",
+    providerSpecificData: { workspaceId: "ws-other" },
+  }); // auto priority 2
+  assert.ok(sibling);
+
+  // 9router exports forward a priority; here it collides with the sibling's.
+  const { body } = await postImport({ accounts: importRecord({ priority: 2 }) });
+  assert.equal(body.success, true, JSON.stringify(body));
+
+  const rows = await getCodexRows();
+  assert.equal(rows.length, 2);
+  const matched = rows.find((r) => r.id === existing.id);
+  assert.ok(matched);
+  assert.equal(matched?.priority, 1, "matched row must keep the operator's priority");
+  const priorities = rows.map((r) => Number(r.priority)).sort();
+  assert.deepEqual(priorities, [1, 2], "priorities must stay unique");
+});
+
+test("import with no existing match creates a row with tokenExpiresAt and a unique priority", async () => {
+  const sibling = await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "Other Codex",
+    email: "other@example.com",
+    accessToken: "other-access",
+    refreshToken: "other-refresh",
+    providerSpecificData: { workspaceId: "ws-other" },
+  }); // auto priority 1
+  assert.ok(sibling);
+
+  const { body } = await postImport({ accounts: importRecord({ priority: 5 }) });
+  assert.equal(body.success, true, JSON.stringify(body));
+
+  const rows = await getCodexRows();
+  assert.equal(rows.length, 2, "no existing email+workspaceId match — a new row is created");
+  const created = rows.find((r) => r.id !== sibling.id);
+  assert.equal(created?.tokenExpiresAt, FUTURE_ISO);
+  // The create path runs reorderConnections, which compacts priorities to 1..N.
+  const priorities = rows.map((r) => Number(r.priority)).sort();
+  assert.deepEqual(priorities, [1, 2], "priorities stay unique after a brand-new import");
+});


### PR DESCRIPTION
… a matching connection

Since 8180b3213 (#11954) mirrored workspaceId, a bulk re-import matches the existing OAuth row and flows into createProviderConnection's upsert, whose merged = { ...existing, ...data } replaced providerSpecificData wholesale with the import's 3-key object — losing chatgptUserId/organizations/workspacePlanType, runtime quota state (codexExhaustedWindowByScope, codexScopeRateLimitedUntil) and the operator-set codexFingerprintMode, degrading buildAccountIdentity to email-keyed and fragmenting usage history. The payload also never set tokenExpiresAt (so the dashboard badge kept showing 'Token Expired' from the stale row value) and the forwarded 9router priority overwrote the matched row's priority without reordering, creating duplicates. The route now passes each payload through preserveExistingCodexConnectionState (pure, in codexImport.ts), which merges the import's providerSpecificData over the matched row's and drops the forwarded priority — the same pattern as codexAuthImport.ts — and the normalizer mirrors expiresAt into tokenExpiresAt. Validated by: node --import tsx/esm --test tests/unit/codex-bulk-import-preserve-state-11954.test.ts (all four scenarios failed before the fix, pass after).

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
