### PR TITLE
fix(sse): stop advertising video providers the dispatcher cannot run

### DIFF
--- a/open-sse/config/videoRegistry.ts
+++ b/open-sse/config/videoRegistry.ts
@@ -190,6 +190,13 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     authType: "apikey",
     authHeader: "bearer",
     format: "pollinations-video",
+    // Живая проверка 2026-08-30: диспетчер videoGeneration.ts не разбирает
+    // "pollinations-video" и отвечает 400 Unsupported video format — модель
+    // висела в выдаче каталога, но не исполнялась ни при каких ключах.
+    unsupported: true,
+    unsupportedReason:
+      "Pollinations video has no submit/poll transport in the dispatcher yet. " +
+      "Use an image model or another video provider until one is added.",
     models: [{ id: "default", name: "Pollinations Video (Free)" }],
   },
 
@@ -200,6 +207,12 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     authType: "apikey",
     authHeader: "bearer",
     format: "minimax-video",
+    // Живая проверка 2026-08-30: 400 Unsupported video format на всех трёх
+    // моделях Hailuo. Свой submit → query API, не покрытый job-пресетами.
+    unsupported: true,
+    unsupportedReason:
+      "MiniMax video uses its own submit/query transport that the dispatcher " +
+      "does not implement yet. Generate video via another provider for now.",
     models: [
       { id: "MiniMax-Hailuo-2.3", name: "Hailuo 2.3" },
       { id: "MiniMax-Hailuo-02", name: "Hailuo 02" },
@@ -214,6 +227,12 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     authType: "apikey",
     authHeader: "bearer",
     format: "together-video",
+    // Не рекламируется по той же причине, что pollinations/minimax: формат
+    // объявлен, ветки в диспетчере нет (проверено разбором 2026-08-30).
+    unsupported: true,
+    unsupportedReason:
+      "Together video has no transport in the dispatcher yet. " +
+      "Use another video provider until one is added.",
     models: [
       { id: "wan-ai/wan2.1-t2v-480p", name: "Wan 2.1 T2V 480p" },
       { id: "wan-ai/wan2.7-t2v", name: "Wan 2.7 T2V" },
@@ -227,6 +246,12 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     authType: "apikey",
     authHeader: "bearer",
     format: "replicate-video",
+    // Не рекламируется: формат объявлен, ветки в диспетчере нет
+    // (проверено разбором 2026-08-30).
+    unsupported: true,
+    unsupportedReason:
+      "Replicate video has no prediction submit/poll transport in the " +
+      "dispatcher yet. Use another video provider until one is added.",
     models: [
       { id: "minimax/video-01", name: "MiniMax Video 01" },
       { id: "wan-ai/wan2.1-t2v-480p", name: "Wan 2.1 T2V" },
@@ -394,7 +419,11 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     baseUrl: "https://nano-gpt.com/api/v1/video/generations",
     authType: "apikey",
     authHeader: "bearer",
-    format: "openai",
+    // Диспетчер знает формат под именем "openai-video" — под "openai" ветки нет,
+    // и провайдер отдавал 400 Unsupported video format (живая проверка
+    // 2026-08-30). Тот же обработчик обслуживает кастомные OpenAI-совместимые
+    // ноды, а baseUrl выше — ровно их путь.
+    format: "openai-video",
     models: [{ id: "default", name: "NanoGPT Video" }],
   },
 };

--- a/open-sse/config/videoRegistry.ts
+++ b/open-sse/config/videoRegistry.ts
@@ -424,6 +424,15 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     // 2026-08-30). Тот же обработчик обслуживает кастомные OpenAI-совместимые
     // ноды, а baseUrl выше — ровно их путь.
     format: "openai-video",
+    // Живая проверка 2026-08-30: адрес выше отдаёт 404 (HTML-страница), как и
+    // вариант во множественном числе /api/v1/videos/generations. Контроль на том
+    // же ключе: /api/v1/images/generations отвечает 401 JSON — то есть 404 здесь
+    // значит «маршрута нет», а не «ключ не тот». Формат исправлен на рабочее имя
+    // заранее, чтобы провайдер ожил правкой одного адреса, когда он появится.
+    unsupported: true,
+    unsupportedReason:
+      "NanoGPT video endpoint returns 404 — no video route is published under " +
+      "/api/v1/video(s)/generations. Use another video provider.",
     models: [{ id: "default", name: "NanoGPT Video" }],
   },
 };

--- a/open-sse/handlers/videoGeneration/openai.ts
+++ b/open-sse/handlers/videoGeneration/openai.ts
@@ -35,6 +35,11 @@ function resolveVideoEndpoint(credentials: unknown, fallback: string): string {
       ? creds.baseUrl.trim()
       : null;
   const nodeBaseUrl = psdBaseUrl || topLevelBaseUrl;
+  // Узел своего адреса может не иметь — у встроенных провайдеров его и не
+  // бывает. Тогда работает `fallback`: это готовый endpoint из реестра, а не
+  // корень, поэтому путь к нему не дописывается (у nanogpt адрес оканчивается
+  // на /video/generations — в единственном числе).
+  if (!nodeBaseUrl) return fallback;
   let n = nodeBaseUrl;
   while (n.endsWith("/")) n = n.slice(0, -1);
   if (n.endsWith("/videos/generations")) return n;

--- a/tests/unit/video-openai-endpoint-fallback.test.ts
+++ b/tests/unit/video-openai-endpoint-fallback.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * `resolveVideoEndpoint` принимает запасной адрес и обязан им пользоваться.
+ *
+ * Функция объявлена как `(credentials, fallback)`, и вызывающий передаёт
+ * `providerConfig.baseUrl` — адрес из реестра. Но пока адрес брался только из
+ * учётных данных: у встроенного провайдера, где узел своего baseUrl не хранит,
+ * получался `null.endsWith(...)` и маршрут отвечал 500 с пустым телом.
+ *
+ * Дефект был не виден, потому что единственный встроенный провайдер формата
+ * `openai-video` (nanogpt) до этой ветки не доходил — его формат в реестре был
+ * записан как `openai`, и диспетчер отбрасывал его раньше (400 Unsupported
+ * video format). Живая проверка 2026-08-30: как только имя формата исправили,
+ * тот же запрос дал 500 и стек с `Cannot read properties of null`.
+ *
+ * Адрес из реестра — готовый endpoint, а не корень узла: у nanogpt это
+ * `/api/v1/video/generations` (единственное число), и дописывать к нему
+ * `/videos/generations` нельзя.
+ */
+
+const { handleOpenAIVideoGeneration } =
+  await import("../../open-sse/handlers/videoGeneration/openai.ts");
+
+const REGISTRY_ENDPOINT = "https://nano-gpt.com/api/v1/video/generations";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function captureRequestUrl() {
+  const seen: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    seen.push(typeof input === "string" ? input : input.toString());
+    return new Response(JSON.stringify({ data: [{ url: "https://example.test/out.mp4" }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return seen;
+}
+
+test("falls back to the registry endpoint when the node carries no baseUrl", async () => {
+  const seen = captureRequestUrl();
+
+  const result = await handleOpenAIVideoGeneration({
+    model: "default",
+    provider: "nanogpt",
+    providerConfig: { baseUrl: REGISTRY_ENDPOINT, authHeader: "bearer" },
+    body: { prompt: "hello world" },
+    credentials: { apiKey: "test-key" },
+  });
+
+  assert.notEqual(result, undefined, "обработчик обязан вернуть результат, а не упасть");
+  assert.deepEqual(seen, [REGISTRY_ENDPOINT]);
+});
+
+test("still prefers the node's own baseUrl and appends the OpenAI path", async () => {
+  const seen = captureRequestUrl();
+
+  await handleOpenAIVideoGeneration({
+    model: "default",
+    provider: "custom-node",
+    providerConfig: { baseUrl: REGISTRY_ENDPOINT, authHeader: "bearer" },
+    body: { prompt: "hello world" },
+    credentials: { apiKey: "test-key", baseUrl: "https://node.test/v1/" },
+  });
+
+  assert.deepEqual(seen, ["https://node.test/v1/videos/generations"]);
+});

--- a/tests/unit/video-registry-dispatch-parity.test.ts
+++ b/tests/unit/video-registry-dispatch-parity.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Страж соответствия реестра и диспетчера видео.
+ *
+ * `GET /v1/videos/generations` рекламирует всё, что лежит в VIDEO_PROVIDERS без
+ * пометки `unsupported`. Диспетчер `handleVideoGeneration` умеет меньше: он
+ * разбирает `providerConfig.format` цепочкой ветвлений плюс job-пресетами, а на
+ * незнакомом формате отвечает `Unsupported video format`. Пока списки
+ * расходятся, каталог обещает модели, которые исполнитель гарантированно
+ * отвергает с 400 — независимо от ключей и баланса. Живая проверка 2026-08-30:
+ * `minimax/MiniMax-Hailuo-02`, `pollinations/default` и `nanogpt/default`
+ * отдавали ровно этот 400, будучи в выдаче каталога.
+ *
+ * Разбор идёт по тексту диспетчера, а не вызовом: неизвестный формат виден до
+ * первого сетевого запроса, а живой вызов каждого провайдера в юнит-тесте либо
+ * уходит в сеть, либо виснет на ретраях. Цена — тест надо поправить, если
+ * цепочку `format === "..."` заменят на другую конструкцию; тогда счётчик
+ * распознанных форматов упадёт до нуля и страж ниже скажет об этом прямо.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "../..");
+
+const { VIDEO_PROVIDERS } = await import("../../open-sse/config/videoRegistry.ts");
+
+function readSource(relativePath: string) {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
+
+/** Форматы, для которых у диспетчера есть собственная ветка. */
+function branchFormats() {
+  const source = readSource("open-sse/handlers/videoGeneration.ts");
+  return new Set(
+    [...source.matchAll(/providerConfig\.format === "([a-z0-9-]+)"/g)].map((match) => match[1])
+  );
+}
+
+/** Форматы, которые обслуживает общий submit → poll конвейер job-пресетов. */
+function jobPresetFormats() {
+  const source = readSource("open-sse/handlers/videoGeneration/job.ts");
+  const block = source.slice(source.indexOf("VIDEO_JOB_PRESETS"));
+  return new Set([...block.matchAll(/^\s{2}"([a-z0-9-]+)":\s*\{/gm)].map((match) => match[1]));
+}
+
+test("dispatcher formats are still discoverable in the source", () => {
+  assert.ok(
+    branchFormats().size >= 10,
+    "в videoGeneration.ts не нашлось ветвлений по providerConfig.format — " +
+      "диспетчер переписан, и разбор в этом тесте пора обновить"
+  );
+  assert.ok(
+    jobPresetFormats().size >= 1,
+    "в videoGeneration/job.ts не нашлось job-пресетов — разбор пора обновить"
+  );
+});
+
+test("every advertised video provider declares a format the dispatcher handles", () => {
+  const dispatchable = new Set([...branchFormats(), ...jobPresetFormats()]);
+
+  const broken = Object.entries(VIDEO_PROVIDERS)
+    .filter(([, config]) => !config.unsupported)
+    .filter(([, config]) => !dispatchable.has(config.format))
+    .map(([providerId, config]) => `${providerId} (format: ${config.format})`);
+
+  assert.deepEqual(
+    broken,
+    [],
+    "каталог рекламирует провайдеров, чей формат диспетчер не разбирает — " +
+      "либо добавьте ветку, либо пометьте провайдера unsupported:\n  " +
+      broken.join("\n  ")
+  );
+});
+
+test("unsupported providers state a reason", () => {
+  const silent = Object.entries(VIDEO_PROVIDERS)
+    .filter(([, config]) => config.unsupported)
+    .filter(([, config]) => !config.unsupportedReason?.trim())
+    .map(([providerId]) => providerId);
+
+  assert.deepEqual(silent, [], "провайдер снят с витрины без причины: " + silent.join(", "));
+});


### PR DESCRIPTION
⚠️ base-red inherited: #12109

## Problem

`GET /v1/videos/generations` advertises every `VIDEO_PROVIDERS` entry that is not flagged
`unsupported`, while `handleVideoGeneration` dispatches on `providerConfig.format` and answers
`400 Unsupported video format` for anything it has no branch (or job preset) for. Five providers
sat on the wrong side of that gap, so the catalog listed models that could never run — regardless
of keys or balance.

Live check against a local gateway (2026-08-30), models taken straight from the catalog response:

| Model | Result |
| --- | --- |
| `minimax/MiniMax-Hailuo-02` | 400 `Unsupported video format: minimax-video` |
| `pollinations/default` | 400 `Unsupported video format: pollinations-video` |
| `nanogpt/default` | 400 `Unsupported video format: openai` |

## Changes

**1. Stop advertising providers the dispatcher cannot run.** `pollinations`, `minimax`,
`together` and `replicate` are marked `unsupported` with a reason, reusing the mechanism added in
#10285. Their transports can be implemented later; until then the catalog stays honest.

**2. Fix the nanogpt format name.** It declared `"openai"` while the dispatcher knows the format
as `"openai-video"` — a name mismatch, not a missing transport.

**3. Honor the registry endpoint fallback.** Fixing (2) exposed a live 500 with an empty body:

```
TypeError: Cannot read properties of null (reading 'endsWith')
    at resolveVideoEndpoint (open-sse/handlers/videoGeneration/openai.ts:39)
```

`resolveVideoEndpoint(credentials, fallback)` takes a fallback — the caller passes
`providerConfig.baseUrl` — and never used it. A built-in provider stores no baseUrl on the node,
so the value was `null`. The fallback is a complete endpoint, not a node root, so it is returned
as-is. This also affects any custom OpenAI-compatible node whose credentials carry no baseUrl.

**4. De-list nanogpt video.** Both `/api/v1/video/generations` and `/api/v1/videos/generations`
answer 404 (an HTML page) upstream, while `/api/v1/images/generations` on the same probe key
answers 401 JSON — so the 404 means the route does not exist, not that the key is wrong. The
format name stays corrected so a single baseUrl edit revives the provider later.

## Validation

TDD per Hard Rule #18 — each fix has a test that failed first.

- `tests/unit/video-registry-dispatch-parity.test.ts` — derives the dispatchable format set from
  the dispatcher itself (branches + job presets) and fails when the registry advertises a format
  outside it. Carries its own guard: if the branch scan finds fewer than 10 formats it reports
  that the parser needs updating instead of passing on an empty set.
- `tests/unit/video-openai-endpoint-fallback.test.ts` — reproduces the null-baseUrl TypeError and
  pins that the node's own baseUrl still wins when present.

Suites run: both new files, plus `veoaifree-video-route`, `nanogpt-endpoint-surface`,
`google-flow-video-4569`, `video-deepinfra-6653`, `adobe-firefly`, `agnes-provider`,
`segmind-image-video-provider-6656`, `qwen-cloud-video-media`, `new-content-providers`,
`media-provider-ordering`, `preserve-video-url-compat`, `video-bridge-broker` — all green.
tsc/eslint/prettier clean.

**Live verification** on a scratch instance built from this branch (separate port, copy of a
populated DB): `GET /v1/videos/generations` went from **9** advertised models to **4**, and the
four survivors are all dispatchable veo/seedance entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

