### PR TITLE
feat(resilience): default the credential health check sweep to 60 minutes

### DIFF
--- a/src/lib/credentialHealth/scheduler.ts
+++ b/src/lib/credentialHealth/scheduler.ts
@@ -129,7 +129,7 @@ export function resolveCredentialHealthSweepInterval(
     const parsed = parseInt(envVal, 10);
     if (!isNaN(parsed) && parsed >= 10_000) return parsed;
   }
-  return 300_000; // default 5 min
+  return 3_600_000; // default 60 min
 }
 
 /**
@@ -142,7 +142,7 @@ function getSweepInterval(): number {
     const parsed = parseInt(envVal, 10);
     if (!isNaN(parsed) && parsed >= 10_000) return parsed;
   }
-  return 300_000; // default 5 min
+  return 3_600_000; // default 60 min
 }
 
 /**

--- a/src/lib/resilience/settings.ts
+++ b/src/lib/resilience/settings.ts
@@ -184,10 +184,11 @@ export const DEFAULT_RESILIENCE_SETTINGS: ResilienceSettings = {
   // default until an operator adds an override here.
   providerQuotaOverrides: {},
   // Global default cadence for the background credential health check sweep.
-  // 5 minutes preserves the pre-setting scheduler default (300 000 ms);
-  // 0 disables the sweep entirely. Per-connection overrides always win.
+  // 60 minutes: the sweep makes a real upstream probe against EVERY active
+  // connection, so the previous 5-minute default cost 12 requests/hour per
+  // connection. 0 disables the sweep entirely. Per-connection overrides win.
   credentialHealthCheck: {
-    intervalMinutes: 5,
+    intervalMinutes: 60,
   },
 };
 

--- a/tests/unit/credential-health-sweep-interval.test.ts
+++ b/tests/unit/credential-health-sweep-interval.test.ts
@@ -20,13 +20,13 @@ function withEnv(value: string | undefined, fn: () => void) {
   }
 }
 
-test("default resilience settings include a 5-minute credential health check cadence", () => {
-  assert.equal(DEFAULT_RESILIENCE_SETTINGS.credentialHealthCheck.intervalMinutes, 5);
+test("default resilience settings include a 60-minute credential health check cadence", () => {
+  assert.equal(DEFAULT_RESILIENCE_SETTINGS.credentialHealthCheck.intervalMinutes, 60);
 });
 
 test("resolveResilienceSettings returns the default interval when nothing is stored", () => {
   const resolved = resolveResilienceSettings({});
-  assert.equal(resolved.credentialHealthCheck.intervalMinutes, 5);
+  assert.equal(resolved.credentialHealthCheck.intervalMinutes, 60);
 });
 
 test("mergeResilienceSettings stores an operator interval and preserves other sections", () => {
@@ -45,9 +45,9 @@ test("mergeResilienceSettings clamps the interval into the 0-1440 band", () => {
   assert.equal(high.credentialHealthCheck.intervalMinutes, 1440);
 });
 
-test("sweep interval: no operator setting and no env → built-in 5 min default", () => {
+test("sweep interval: no operator setting and no env → built-in 60 min default", () => {
   withEnv(undefined, () => {
-    assert.equal(resolveCredentialHealthSweepInterval({}), 300_000);
+    assert.equal(resolveCredentialHealthSweepInterval({}), 60 * 60_000);
   });
 });
 
@@ -87,6 +87,6 @@ test("sweep interval: non-numeric stored interval falls back to env/default", ()
     const settings = {
       resilienceSettings: { credentialHealthCheck: { intervalMinutes: "abc" } },
     };
-    assert.equal(resolveCredentialHealthSweepInterval(settings), 300_000);
+    assert.equal(resolveCredentialHealthSweepInterval(settings), 60 * 60_000);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to [#12043](https://github.com/diegosouzapw/OmniRoute/pull/12043): raises the **default** credential health check cadence from 5 minutes to **60 minutes**.

### Reasoning

The background credential health sweep makes a **real upstream probe against every active connection** on each cycle. At the previous 5-minute default that meant:

- **12 requests per hour per connection** (288/day, ~8,640/month on a 30-day month) against every provider you have connected.
- On quota- or request-capped plans this traffic is pure overhead: it buys credential freshness, not model output, and it scales linearly with the number of accounts.

A 60-minute default cuts that to **1 request per hour per connection** (~720/month) while still detecting stale/expired credentials well within a practical recovery window. Operators who want faster detection can still lower the value:

- per-connection via the **Health Check (min)** field on each connection's edit dialog (0 = never check that connection),
- globally via **Settings › Resilience › Credential Health Check**,
- or via the existing `CREDENTIAL_HEALTH_CHECK_INTERVAL` env var, which still wins over the built-in default when no operator setting is stored.

### What changed

- `DEFAULT_RESILIENCE_SETTINGS.credentialHealthCheck.intervalMinutes`: `5` → `60`.
- The scheduler's env/default fallback (`resolveCredentialHealthSweepInterval` / `getSweepInterval`) aligned to the same cadence: `300_000` → `3_600_000` ms, so a fresh install with no settings stored and no env var gets the 60-minute sweep.
- Updated `credential-health-sweep-interval.test.ts` expectations (default = 60 min, fallback = `3_600_000`).

### Compatibility

- Deployments that already set `CREDENTIAL_HEALTH_CHECK_INTERVAL` are **unaffected** (env still wins over the built-in default).
- Deployments that already stored `resilienceSettings.credentialHealthCheck` are **unaffected** (DB wins over everything).
- Only the built-in default for brand-new/unconfigured installs changes.

### Tests

- `credential-health-sweep-interval.test.ts` (10 cases) updated and passing.
- `resilience-settings-normalize-split.test.ts` and `resilience-tab-response-fields.test.ts` still green (22/22 combined).
- `npm run typecheck:core` clean.
