### PR TITLE
fix(cli): setup-claude prints an absolute CLAUDE_CONFIG_DIR hint (#11…

### DIFF
--- a/bin/cli/commands/setup-claude.mjs
+++ b/bin/cli/commands/setup-claude.mjs
@@ -19,7 +19,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import os from "node:os";
-import { printHeading, printInfo, printSuccess, printError } from "../io.mjs";
+import { printHeading, printInfo, printSuccess, printError, printWarning } from "../io.mjs";
 import { guardHostConfigTarget } from "../utils/config-home-guard.mjs";
 import {
   categoriseModel,
@@ -43,6 +43,59 @@ function effortLevelFor(cfg) {
 export function fallbackClaudeProfile(modelId, model) {
   if (!isCodexCompatibleTextModel(model)) return null;
   return { name: profileNameFromModelId(modelId) };
+}
+
+/**
+ * Manual-launch hint for one profile, in the syntax of the host shell.
+ *
+ * Claude Code resolves `CLAUDE_CONFIG_DIR` verbatim — its config root is
+ * `process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")`, with **no
+ * tilde expansion**. So the `CLAUDE_CONFIG_DIR=~/.claude/profiles/<name>`
+ * one-liner this command used to print only works on a shell that expands `~`
+ * itself (bash/zsh). On PowerShell or cmd.exe it either fails to parse or
+ * resolves to a literal `./~/.claude/...` that does not exist — Claude Code
+ * then starts with NO `ANTHROPIC_BASE_URL`, and its `firstParty` provider
+ * falls back to `api.anthropic.com`, which rejects an OmniRoute key with a real
+ * Anthropic `401 {"type":"error","error":{"type":"authentication_error",…}}`
+ * (#11525).
+ *
+ * Always emit the ABSOLUTE profile directory so the hint is copy-pasteable on
+ * every platform.
+ *
+ * @param {string} profileDir  absolute path to `<claudeHome>/profiles/<name>`
+ * @param {NodeJS.Platform|string} [platform]
+ * @returns {string}
+ */
+export function formatManualLaunchHint(profileDir, platform = process.platform) {
+  if (platform === "win32") {
+    return (
+      `$env:CLAUDE_CONFIG_DIR="${profileDir}"; ` +
+      `$env:ANTHROPIC_AUTH_TOKEN="<your OmniRoute key>"; claude`
+    );
+  }
+  return `CLAUDE_CONFIG_DIR="${profileDir}" ANTHROPIC_AUTH_TOKEN="<your OmniRoute key>" claude`;
+}
+
+/**
+ * `ANTHROPIC_API_KEY` inherited from the operator's shell is the other half of
+ * the #11525 dead end: Claude Code sends it as `x-api-key` and shows the
+ * "Detected a custom API key in your environment" consent screen, so a session
+ * that never picked up `ANTHROPIC_BASE_URL` looks configured right up until
+ * Anthropic itself answers 401. Warn once, at generation time.
+ *
+ * @param {Record<string,string|undefined>} env
+ * @returns {string|null} the warning line, or null when the shell is clean
+ */
+export function inheritedAnthropicKeyWarning(env = process.env) {
+  const key = env?.ANTHROPIC_API_KEY;
+  if (!key || !String(key).trim()) return null;
+  return (
+    "ANTHROPIC_API_KEY is set in this shell. Claude Code sends it as x-api-key and asks " +
+    "\"Detected a custom API key in your environment\" — if ANTHROPIC_BASE_URL is not " +
+    "picked up, that key goes to api.anthropic.com and you get a real Anthropic 401. " +
+    "Unset it, or use `omniroute launch --profile <name>` (it strips every inherited " +
+    "ANTHROPIC_* var before spawning claude)."
+  );
 }
 
 /** Build the settings.json content for one Claude Code profile. */
@@ -204,9 +257,17 @@ export async function runSetupClaudeCommand(opts = {}) {
     if (skipped > 0) printInfo(`${skipped} models skipped (no matching profile pattern)`);
     console.log("\nTo use a profile:");
     console.log("  omniroute launch --profile <name>     # e.g. omniroute launch --profile glm52");
-    console.log(
-      "  # or: CLAUDE_CONFIG_DIR=~/.claude/profiles/<name> claude  (export ANTHROPIC_AUTH_TOKEN first)"
-    );
+    // Absolute path, host-shell syntax: Claude Code does not expand `~` in
+    // CLAUDE_CONFIG_DIR, and a config dir that does not resolve silently drops
+    // ANTHROPIC_BASE_URL — the request then goes to api.anthropic.com (#11525).
+    const sample = join(profilesRoot, profiles[0]?.name ?? "<name>");
+    console.log("  # or, without the launcher:");
+    console.log(`  ${formatManualLaunchHint(sample)}`);
+    const keyWarning = inheritedAnthropicKeyWarning();
+    if (keyWarning) {
+      console.log("");
+      printWarning(keyWarning);
+    }
   } else {
     console.log(`\n[dry-run] ${written} profiles would be written (${skipped} skipped)`);
   }

--- a/tests/unit/cli/setup-claude.test.ts
+++ b/tests/unit/cli/setup-claude.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import {
   buildProfileSettings,
   fallbackClaudeProfile,
+  formatManualLaunchHint,
+  inheritedAnthropicKeyWarning,
   syncClaudeProfilesFromModels,
 } from "../../../bin/cli/commands/setup-claude.mjs";
 import { buildClaudeEnv, resolveLaunchTarget } from "../../../bin/cli/commands/launch.mjs";
@@ -204,4 +206,46 @@ test("resolveLaunchTarget: explicit --remote wins, strips /v1", () => {
 test("resolveLaunchTarget: explicit token wins over everything", () => {
   const { authToken } = resolveLaunchTarget({ remote: "http://x:20128", token: "tok-explicit" });
   assert.equal(authToken, "tok-explicit");
+});
+
+// ── #11525 — manual-launch hint must not depend on shell tilde expansion ─────
+//
+// Claude Code's config root is `process.env.CLAUDE_CONFIG_DIR ?? join(homedir(),
+// ".claude")` — verbatim, no tilde expansion. A `CLAUDE_CONFIG_DIR=~/.claude/...`
+// hint therefore silently resolves to a non-existent literal `~` directory on any
+// shell that does not expand it (PowerShell, cmd.exe). Claude Code then starts
+// with no ANTHROPIC_BASE_URL and its `firstParty` provider falls back to
+// api.anthropic.com, which answers a genuine Anthropic 401.
+
+test("formatManualLaunchHint emits an absolute path, never a tilde (#11525)", () => {
+  const hint = formatManualLaunchHint("/home/u/.claude/profiles/glm52", "linux");
+  assert.equal(hint.includes("~"), false);
+  assert.ok(hint.includes('CLAUDE_CONFIG_DIR="/home/u/.claude/profiles/glm52"'));
+  assert.ok(hint.includes("ANTHROPIC_AUTH_TOKEN"));
+  assert.ok(hint.trimEnd().endsWith("claude"));
+});
+
+test("formatManualLaunchHint uses PowerShell syntax on win32 (#11525)", () => {
+  const dir = "C:\\Users\\u\\.claude\\profiles\\glm52";
+  const hint = formatManualLaunchHint(dir, "win32");
+  assert.equal(hint.includes("~"), false);
+  assert.ok(hint.startsWith(`$env:CLAUDE_CONFIG_DIR="${dir}";`));
+  assert.ok(hint.includes('$env:ANTHROPIC_AUTH_TOKEN="<your OmniRoute key>";'));
+  // The bash `VAR=value cmd` prefix form is a parse error in PowerShell.
+  assert.equal(hint.includes("CLAUDE_CONFIG_DIR=C:"), false);
+});
+
+test("formatManualLaunchHint never bakes a real key into the hint", () => {
+  const hint = formatManualLaunchHint("/home/u/.claude/profiles/glm52", "linux");
+  assert.ok(hint.includes("<your OmniRoute key>"));
+});
+
+test("inheritedAnthropicKeyWarning fires only when ANTHROPIC_API_KEY is set (#11525)", () => {
+  assert.equal(inheritedAnthropicKeyWarning({}), null);
+  assert.equal(inheritedAnthropicKeyWarning({ ANTHROPIC_API_KEY: "   " }), null);
+  const warning = inheritedAnthropicKeyWarning({ ANTHROPIC_API_KEY: "oma_live_xxx" });
+  assert.ok(warning);
+  assert.ok(warning.includes("api.anthropic.com"));
+  // Never echo the key itself back to the terminal.
+  assert.equal(warning.includes("oma_live_xxx"), false);
 });


### PR DESCRIPTION
Claude Code resolves CLAUDE_CONFIG_DIR verbatim (`process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")`) and never expands `~`. The hint printed at the end of `omniroute setup-claude` used
`CLAUDE_CONFIG_DIR=~/.claude/profiles/<name> claude`, which only works on a shell that expands the tilde itself. On PowerShell or cmd.exe the config dir does not resolve, settings.json is never read, the session starts with no ANTHROPIC_BASE_URL, and Claude Code's `firstParty` provider falls back to api.anthropic.com — which rejects the OmniRoute key with a genuine Anthropic 401 `API key is invalid.`

`firstParty` is the provider kind, not a destination: it is what every non-Bedrock/Vertex/Foundry/Mantle/gateway session is labelled, and its URL is resolved separately as ANTHROPIC_BASE_URL with api.anthropic.com only as the fallback. So the reported `dispatching to firstParty` line is expected output; the defect is the base URL never arriving, which our own printed hint caused.

- `formatManualLaunchHint()` emits the absolute profile directory in the host shell's syntax (PowerShell `$env:` form on win32, `VAR=value cmd` elsewhere), with a `<your OmniRoute key>` placeholder — never a real key. The command now prints it filled in with the first generated profile.
- `inheritedAnthropicKeyWarning()` warns when ANTHROPIC_API_KEY is exported in the operator's shell: Claude Code sends it as x-api-key behind the "Detected a custom API key in your environment" prompt, which makes a base-URL-less session look configured until Anthropic answers 401. The warning never echoes the key back to the terminal.

Tests: 4 cases in tests/unit/cli/setup-claude.test.ts — the no-tilde invariant on both platforms, PowerShell syntax on win32, the key placeholder, and the warning's gate (unset / whitespace-only / set, and that it never echoes the key).

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
