### PR TITLE
fix(translator): strip neutral tool_choice when tools absent in Responses-to-Chat (#12141)

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -768,6 +768,15 @@ export function openaiResponsesToOpenAIRequest(
     }
   }
 
+  // #12141: When translated Chat tools is empty/absent, strip neutral tool_choice
+  // ("auto" / "none") so strict Chat endpoints (e.g. vLLM) do not reject with 400
+  // ("When using tool_choice, tools must be set"). Contradictory choices like "required"
+  // or forced functions are preserved so the upstream error remains visible.
+  const finalChatTools = Array.isArray(result.tools) ? result.tools : [];
+  if (finalChatTools.length === 0 && (result.tool_choice === "auto" || result.tool_choice === "none")) {
+    delete result.tool_choice;
+  }
+
   // Cleanup Responses API specific fields
   // Note: prompt_cache_key is intentionally preserved for OpenAI destinations — it is
   // used by Codex as a cache-affinity signal and stripping it unconditionally broke

--- a/tests/unit/responses-to-chat-no-tools-tool-choice-12141.test.ts
+++ b/tests/unit/responses-to-chat-no-tools-tool-choice-12141.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiResponsesToOpenAIRequest } = await import(
+  "../../open-sse/translator/request/openai-responses.ts"
+);
+
+test("#12141: Responses-to-Chat strips tool_choice='auto' when tools is empty array", () => {
+  const body = {
+    model: "vllm/qwen-2.5-72b",
+    input: "hello",
+    tools: [],
+    tool_choice: "auto",
+    stream: false,
+  };
+
+  const result = openaiResponsesToOpenAIRequest(null, body, null, null) as Record<string, unknown>;
+
+  assert.equal(
+    result.tool_choice,
+    undefined,
+    "Neutral tool_choice 'auto' must be omitted when no tools exist"
+  );
+});
+
+test("#12141: Responses-to-Chat strips tool_choice='none' when tools is absent or empty", () => {
+  const body = {
+    model: "vllm/qwen-2.5-72b",
+    input: "hello",
+    tool_choice: "none",
+    stream: false,
+  };
+
+  const result = openaiResponsesToOpenAIRequest(null, body, null, null) as Record<string, unknown>;
+
+  assert.equal(
+    result.tool_choice,
+    undefined,
+    "Neutral tool_choice 'none' must be omitted when no tools exist"
+  );
+});
+
+test("#12141: Responses-to-Chat preserves tools and tool_choice='auto' when valid tools are present", () => {
+  const body = {
+    model: "vllm/qwen-2.5-72b",
+    input: "what is the weather?",
+    tools: [
+      {
+        type: "function",
+        name: "get_weather",
+        description: "Get weather",
+        parameters: { type: "object", properties: { location: { type: "string" } } },
+      },
+    ],
+    tool_choice: "auto",
+    stream: false,
+  };
+
+  const result = openaiResponsesToOpenAIRequest(null, body, null, null) as Record<string, unknown>;
+
+  assert.ok(Array.isArray(result.tools), "tools must be preserved as an array");
+  assert.equal((result.tools as unknown[]).length, 1);
+  assert.equal(result.tool_choice, "auto", "tool_choice 'auto' must be preserved when tools exist");
+});
+
+test("#12141: Responses-to-Chat preserves tool_choice='required' when tools is empty (explicit contradiction)", () => {
+  const body = {
+    model: "vllm/qwen-2.5-72b",
+    input: "hello",
+    tools: [],
+    tool_choice: "required",
+    stream: false,
+  };
+
+  const result = openaiResponsesToOpenAIRequest(null, body, null, null) as Record<string, unknown>;
+
+  assert.equal(
+    result.tool_choice,
+    "required",
+    "Contradictory tool_choice 'required' must be preserved so upstream surfaces the error"
+  );
+});

--- a/tests/unit/responses-translation-fixes.test.ts
+++ b/tests/unit/responses-translation-fixes.test.ts
@@ -405,10 +405,19 @@ test("Chat→Responses: tool_choice {type:'function', function:{name}} unwrapped
   });
 });
 
-test("Responses→Chat: string tool_choice passes through unchanged", () => {
-  const body = { model: "gpt-4", input: "hello", tool_choice: "auto" };
-  const result = openaiResponsesToOpenAIRequest(null, body, null, null);
-  assert.equal((result as any).tool_choice, "auto");
+test("Responses->Chat: string tool_choice passes through when tools present, stripped when absent (#12141)", () => {
+  const withTools = {
+    model: "gpt-4",
+    input: "hello",
+    tools: [{ type: "function", name: "f", parameters: {} }],
+    tool_choice: "auto",
+  };
+  const resWith = openaiResponsesToOpenAIRequest(null, withTools, null, null) as Record<string, unknown>;
+  assert.equal(resWith.tool_choice, "auto");
+
+  const noTools = { model: "gpt-4", input: "hello", tool_choice: "auto" };
+  const resWithout = openaiResponsesToOpenAIRequest(null, noTools, null, null) as Record<string, unknown>;
+  assert.equal(resWithout.tool_choice, undefined);
 });
 
 test("Chat→Responses: string tool_choice passes through unchanged", () => {


### PR DESCRIPTION
## Summary
Closes #12141.

When clients invoke the `/v1/responses` endpoint with neutral `tool_choice` (`"auto"` or `"none"`) without providing tools (or passing `tools: []`), translating to Chat Completions (`openaiResponsesToOpenAIRequest`) previously preserved `tool_choice` verbatim. Strict Chat Completions backends (such as vLLM, Ollama, and strict OpenAI-compatible engines) reject requests containing `tool_choice` without `tools` with `HTTP 400: When using tool_choice, tools must be set`.

## Changes
- **`open-sse/translator/request/openai-responses.ts`**: In `openaiResponsesToOpenAIRequest`, after tool extraction and filtering, when `finalChatTools.length === 0` and `result.tool_choice` is `"auto"` or `"none"`, delete `result.tool_choice`. Contradictory choices (`"required"` or explicit function objects) remain preserved so upstream contracts remain transparent.
- **`tests/unit/responses-to-chat-no-tools-tool-choice-12141.test.ts`**: Dedicated test suite verifying empty tools with `auto`, `none`, valid tools preservation, and contradictory choice retention.
- **`tests/unit/responses-translation-fixes.test.ts`**: Updated existing test case to verify both with-tools preservation and without-tools stripping.

## Verification
- `npm run typecheck:core`: 0 errors.
- `npm run check:cycles`: PASS (no cycles).
- `node --test tests/unit/responses-to-chat-no-tools-tool-choice-12141.test.ts tests/unit/responses-translation-fixes.test.ts`: 48/48 PASS.
- Regression suite: all translator tests (76/76) PASS.