### PR TITLE
chore(quality): register search-432 cooldown test in stryker tap.testFiles

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -354,6 +354,7 @@
       "tests/unit/router-strategies.test.ts",
       "tests/unit/routing-adaptive-e2e.test.ts",
       "tests/unit/rule12-error-sanitization-sweep.test.ts",
+      "tests/unit/search-432-plan-limit-cooldown.test.ts",
       "tests/unit/serial/combo-health-autopilot.test.ts",
       "tests/unit/serial/combo-quota-share-cooldown-wait-timing.test.ts",
       "tests/unit/serial/combo-strategy-fallbacks-half-open-timing.test.ts",


### PR DESCRIPTION
check:mutation-test-coverage --strict fails on every PR targeting release/v3.8.51 since #12139 added tests/unit/search-432-plan-limit-cooldown.test.ts (covering open-sse/services/accountFallback.ts and src/sse/services/auth.ts) without registering it in stryker.conf.json tap.testFiles. This registers the file for both modules so its mutant kills count. Gate output before/after in the PR checks. Refs #12139.