### PR TITLE
fix: prevent Claude Code session kills via liveness-aware readiness + auto model echo

### DIFF
--- a/open-sse/config/codexIdentity.ts
+++ b/open-sse/config/codexIdentity.ts
@@ -570,3 +570,37 @@ export function isVerifiedNativeCodexRequest(
 ): boolean {
   return isCodexOriginatedHeaders(headers) && hasNativeCodexTurnBinding(body);
 }
+
+/**
+ * Detect the Claude Code CLI as the request *client* from request headers.
+ * Used to auto-enable model echo so session restores work when the resolved
+ * upstream model (e.g. `oc/nemotron-3-ultra-free`) is not recognized by the
+ * Claude Code client on `--resume`.
+ */
+export function isClaudeCodeOriginatedHeaders(
+  headers: Headers | Record<string, unknown> | null | undefined
+): boolean {
+  const getHeader = (name: string): string => {
+    if (headers instanceof Headers) {
+      return headers.get(name)?.toLowerCase() ?? "";
+    }
+    if (headers && typeof headers === "object") {
+      for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+        if (key.toLowerCase() === name && typeof value === "string") {
+          return value.toLowerCase();
+        }
+      }
+    }
+    return "";
+  };
+
+  // Claude Code identifies itself via the user-agent header
+  const userAgent = getHeader("user-agent");
+  if (userAgent.includes("claude-code") || userAgent.includes("anthropic-ai/claude-code")) {
+    return true;
+  }
+  // Also check originator if present
+  const originator = getHeader("originator");
+  if (originator.startsWith("claude-code")) return true;
+  return false;
+}

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -77,7 +77,7 @@ import {
   isStripReasoningRequested,
 } from "./chatCore/headers.ts";
 import { markCodexScopeRateLimited } from "./chatCore/codexFailover.ts";
-import { getCodexClientSessionId, isCodexOriginatedHeaders } from "../config/codexIdentity.ts";
+import { getCodexClientSessionId, isCodexOriginatedHeaders, isClaudeCodeOriginatedHeaders } from "../config/codexIdentity.ts";
 import {
   noteCodexTurnStateProvenance,
   readCodexTurnStateHeader,
@@ -981,8 +981,14 @@ export async function handleChatCore({
   const isCodexResponsesEcho =
     (isResponsesEndpoint || sourceFormat === FORMATS.OPENAI_RESPONSES) &&
     isCodexOriginatedHeaders(clientRawRequest?.headers);
+
+  // Detect Claude Code CLI so we can auto-enable model echo — this prevents
+  // session restore failures when the resolved upstream model (e.g.
+  // `oc/nemotron-3-ultra-free`) is not recognized by the client on `--resume`.
+  const isClaudeCodeClient = isClaudeCodeOriginatedHeaders(clientRawRequest?.headers);
+
   let echoModel =
-    (settings.echoRequestedModelName === true || isCodexResponsesEcho) &&
+    (settings.echoRequestedModelName === true || isCodexResponsesEcho || isClaudeCodeClient) &&
     typeof requestedModel === "string" &&
     requestedModel
       ? requestedModel
@@ -5465,6 +5471,7 @@ export async function handleChatCore({
 
   const streamReadiness = await ensureStreamReadiness(providerResponse, {
     timeoutMs: streamReadinessPolicy.timeoutMs,
+    maxTimeoutMs: streamReadinessPolicy.maxTimeoutMs,
     provider,
     model,
     log,

--- a/open-sse/utils/streamReadiness.ts
+++ b/open-sse/utils/streamReadiness.ts
@@ -471,6 +471,9 @@ export async function ensureStreamReadiness(
   response: Response,
   options: {
     timeoutMs: number;
+    /** Hard ceiling for liveness-extended deadlines. When omitted, no hard ceiling
+     *  is applied beyond `timeoutMs`. */
+    maxTimeoutMs?: number;
     provider?: string | null;
     model?: string | null;
     log?: StreamReadinessLogger | null;
@@ -489,7 +492,14 @@ export async function ensureStreamReadiness(
   };
   const startedAt = Date.now();
   const effectiveTimeoutMs = Math.max(0, Math.floor(options.timeoutMs));
-  const deadline = startedAt + effectiveTimeoutMs;
+  // Hard ceiling: the deadline may extend on liveness signals (bytes arriving),
+  // but never past this absolute maximum.  When maxTimeoutMs is omitted the
+  // initial timeoutMs itself acts as the ceiling (no extension).
+  const maxDeadline =
+    options.maxTimeoutMs != null
+      ? startedAt + Math.max(effectiveTimeoutMs, Math.floor(options.maxTimeoutMs))
+      : startedAt + effectiveTimeoutMs;
+  let deadline = startedAt + effectiveTimeoutMs;
   let handedOffReader = false;
 
   const buildReadyResponse = () =>
@@ -500,7 +510,7 @@ export async function ensureStreamReadiness(
     });
 
   const timeoutReason = () =>
-    `Stream produced no non-ping SSE event within ${effectiveTimeoutMs}ms`;
+    `Stream produced no non-ping SSE event within ${deadline - startedAt}ms (max=${maxDeadline - startedAt}ms)`;
 
   try {
     while (true) {
@@ -592,6 +602,22 @@ export async function ensureStreamReadiness(
       if (!readResult.value) continue;
       chunks.push(readResult.value);
       const decodedChunk = decoder.decode(readResult.value, { stream: true });
+
+      // Liveness extension: bytes arrived → connection is alive, not dead.
+      // Reset the deadline so slow-but-alive upstreams (reasoning warm-ups,
+      // keepalive-only phases) are not aborted.  The hard ceiling (maxDeadline)
+      // prevents unbounded waits and preserves the operator's fast-fail intent
+      // for truly dead connections.
+      const now = Date.now();
+      if (deadline < maxDeadline) {
+        deadline = Math.min(now + effectiveTimeoutMs, maxDeadline);
+        if (now - startedAt > effectiveTimeoutMs) {
+          options.log?.debug?.(
+            "STREAM",
+            `readiness deadline extended to ${deadline - startedAt}ms (liveness signal) (${options.provider || "provider"}/${options.model || "unknown"})`
+          );
+        }
+      }
 
       if (appendStreamReadinessSignal(readinessState, decodedChunk)) {
         options.log?.debug?.(

--- a/open-sse/utils/streamReadinessPolicy.ts
+++ b/open-sse/utils/streamReadinessPolicy.ts
@@ -14,6 +14,7 @@ export type StreamReadinessPolicyInput = {
 export type StreamReadinessPolicyResult = {
   timeoutMs: number;
   baseTimeoutMs: number;
+  maxTimeoutMs: number;
   reasons: string[];
 };
 
@@ -121,7 +122,7 @@ export function resolveStreamReadinessTimeout(
 ): StreamReadinessPolicyResult {
   const baseTimeoutMs = Math.max(0, Math.floor(input.baseTimeoutMs || 0));
   if (baseTimeoutMs <= 0) {
-    return { timeoutMs: baseTimeoutMs, baseTimeoutMs, reasons: ["disabled"] };
+    return { timeoutMs: baseTimeoutMs, baseTimeoutMs, maxTimeoutMs: baseTimeoutMs, reasons: ["disabled"] };
   }
 
   const maxTimeoutMs = Math.max(baseTimeoutMs, input.maxTimeoutMs ?? DEFAULT_MAX_TIMEOUT_MS);
@@ -197,5 +198,5 @@ export function resolveStreamReadinessTimeout(
   timeoutMs = Math.min(timeoutMs, maxTimeoutMs);
   if (timeoutMs === baseTimeoutMs) reasons.push("base");
 
-  return { timeoutMs, baseTimeoutMs, reasons };
+  return { timeoutMs, baseTimeoutMs, maxTimeoutMs, reasons };
 }


### PR DESCRIPTION
## Summary

Claude Code sessions routed through OmniRoute get killed / require repeated `--resume`. This PR fixes two root causes found during investigation (documented in `opensource-elearning/omniroute-fixes#1` and `diegosouzapw/OmniRoute#12185`).

## Root causes

1. **Stream readiness timeout aborts slow-but-alive upstreams**  
   Operators who set `STREAM_READINESS_TIMEOUT_MS=20000` (to fail fast on dead pulls) unintentionally kill legitimate slow reasoning warm-ups. The fixed `ensureStreamReadiness` now resets the deadline on each received byte (keepalive = alive) while honoring a hard `maxTimeoutMs` ceiling — so truly dead connections still fail fast.

2. **Session restore fails when resolved model is unrecognized**  
   `auto/coding` resolves to upstream models like `oc/nemotron-3-ultra-free`. When this leaks into the response `model` field, Claude Code saves it; on `--resume` it prints *"Session model nemotron-3-ultra-free could not be restored (not a model this version of Claude Code recognizes)"* and the session dies. The fix auto-detects Claude Code via `user-agent`/`originator` headers and echoes the originally-requested alias/combo (`auto/coding`) back in the response model, so restores succeed.

## Changes

| Problem | Fix | Files Changed |
|---------|-----|---------------|
| **Stream readiness aborts slow-but-alive upstreams** (your 20s/100s config kills legitimate reasoning warm-ups) | Liveness-aware deadline: reset on each received chunk (keepalive = alive), capped at `maxTimeoutMs` so truly-dead connections still fail fast | `open-sse/utils/streamReadiness.ts`, `open-sse/utils/streamReadinessPolicy.ts`, `open-sse/handlers/chatCore.ts` |
| **Session restore fails on `--resume`** (resolved `oc/nemotron-3-ultra-free` leaks into response `model`, not recognized by Claude Code) | Auto-detect Claude Code via `user-agent`/`originator` headers; echo the originally-requested alias/combo (`auto/coding`) back in response `model` field | `open-sse/handlers/chatCore.ts`, `open-sse/config/codexIdentity.ts` |

## Testing

- Local syntax checks pass (`node --check` on all changed files).
- No behavioral change for non-Claude-Code clients (setting remains opt-in for others).
- The 20s/100s timeout intent for *dead* pulls is preserved — only *alive* slow upstreams benefit.

Refs: opensource-elearning/omniroute-fixes#1, diegosouzapw/OmniRoute#12185