### PR TITLE
build: add contributor fast profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,9 @@ npm run dev
 npm run build    # next build → .build/next/ then assembleStandalone → dist/
 npm run start
 
+# Fast backend/API-only build for contributor changes
+npm run build:contributor
+
 # Release build (clean rebuild + HEAD sentinel — required for deploy)
 npm run build:release   # rm -rf .build dist && build + writes dist/BUILD_SHA
 
@@ -99,6 +102,11 @@ npm run build
 
 `npm run build:release` additionally cleans both directories first and writes
 `dist/BUILD_SHA` (= `git rev-parse --short HEAD`) as a deploy integrity sentinel.
+
+`npm run build:contributor` uses the backend-only build profile. It temporarily stubs
+dashboard UI files while building, keeps API route handlers, and restores the original files
+after the build. Use `npm run build` for changes that affect the dashboard UI or for full
+release validation; the contributor profile is not a replacement for the release build.
 
 > **VPS deploy note:** the remote image directory `/usr/lib/node_modules/omniroute/app/`
 > is unchanged. The deploy skills rsync the contents of `dist/` into it.

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "build": "node scripts/build/build-next-isolated.mjs",
     "build:secure": "OMNIROUTE_BUILD_PROFILE=minimal node scripts/build/build-next-isolated.mjs",
     "build:backend": "cross-env OMNIROUTE_BUILD_BACKEND_ONLY=1 node scripts/build/build-next-isolated.mjs",
+    "build:contributor": "cross-env OMNIROUTE_BUILD_PROFILE=contributor node scripts/build/build-next-isolated.mjs",
     "build:cli": "node --import tsx scripts/build/prepublish.ts",
     "omniroute:verify": "node scripts/check/omniroute-verify.mjs",
     "build:release": "rm -rf .build dist && OMNIROUTE_BUILD_SHA=$(git rev-parse --short HEAD) npm run build && npm run build:cli && node scripts/build/write-build-sha.mjs",

--- a/scripts/build/backendOnlyPages.mjs
+++ b/scripts/build/backendOnlyPages.mjs
@@ -2,7 +2,7 @@
 /**
  * Backend-only build helper.
  *
- * When `OMNIROUTE_BUILD_BACKEND_ONLY=1` (or `OMNIROUTE_BUILD_PROFILE=backend`) is set,
+ * When `OMNIROUTE_BUILD_BACKEND_ONLY=1` (or `OMNIROUTE_BUILD_PROFILE=backend|contributor`) is set,
  * `build-next-isolated.mjs` calls `stubDashboardPages()` BEFORE `next build` and
  * `restoreDashboardPages()` in a `finally` afterward.
  *
@@ -83,7 +83,11 @@ function stripLeadingUseServer(src) {
 
 /** True when the current build should skip the dashboard frontend. */
 export function isBackendOnlyBuild(env = process.env) {
-  return env.OMNIROUTE_BUILD_BACKEND_ONLY === "1" || env.OMNIROUTE_BUILD_PROFILE === "backend";
+  return (
+    env.OMNIROUTE_BUILD_BACKEND_ONLY === "1" ||
+    env.OMNIROUTE_BUILD_PROFILE === "backend" ||
+    env.OMNIROUTE_BUILD_PROFILE === "contributor"
+  );
 }
 
 function walkFiles(dir, out = []) {

--- a/tests/unit/build/backend-only-smoke-workflows.test.ts
+++ b/tests/unit/build/backend-only-smoke-workflows.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
+import { isBackendOnlyBuild } from "../../../scripts/build/backendOnlyPages.mjs";
 
 interface WorkflowStep {
   name?: string;
@@ -41,6 +42,14 @@ function isBackendOnly(step: WorkflowStep): boolean {
   const env = step.env || {};
   return env.OMNIROUTE_BUILD_BACKEND_ONLY === "1" || env.OMNIROUTE_BUILD_PROFILE === "backend";
 }
+
+test("contributor build profile enables backend-only mode", () => {
+  assert.equal(isBackendOnlyBuild({ OMNIROUTE_BUILD_PROFILE: "contributor" }), true);
+});
+
+test("full build remains the default when no backend-only profile is set", () => {
+  assert.equal(isBackendOnlyBuild({}), false);
+});
 
 // jobName: null selector means "any job" — used when a file has exactly one
 // "Build CLI bundle" step but we don't want to hardcode/duplicate the job key.


### PR DESCRIPTION
## Issue

Contributors working on API, routing, or provider changes currently have to use the generic production build command, even when the dashboard is outside the scope of their change. This makes the local feedback loop unnecessarily expensive on constrained machines.

## Cause and effect

The repository already has a safe backend-only build implementation that temporarily stubs dashboard UI files and restores them after the build, but it is exposed only through the less discoverable `build:backend` command or a low-level environment variable.

## Fix

- Add the explicit `npm run build:contributor` command.
- Accept `OMNIROUTE_BUILD_PROFILE=contributor` in the existing backend-only profile resolver.
- Document that API route handlers remain included, dashboard UI files are restored, and full `npm run build` remains required for UI and release validation.

## Validation

- Direct profile resolver check passed for `contributor` and the default full profile.
- `git diff --check` passed.
- The full Node test could not start in the clean checkout because dependencies (`tsx`/`js-yaml`) are not installed there; no source test failure was observed.
