### PR TITLE
fix(oauth): mark empty Antigravity projectId as degraded and clear stale errors (#11284)

### DIFF
--- a/src/app/api/oauth/[provider]/[action]/route.ts
+++ b/src/app/api/oauth/[provider]/[action]/route.ts
@@ -25,7 +25,10 @@ import {
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { isValidGheUrl } from "@/shared/validation/providerSpecificData";
 import { AWS_REGION_PATTERN } from "@/lib/oauth/constants/oauth";
-import { antigravityDegradedProjectState } from "@/lib/oauth/antigravityProjectGate";
+import {
+  antigravityDegradedProjectState,
+  antigravityPersistStatus,
+} from "@/lib/oauth/antigravityProjectGate";
 import { syncToCloud } from "@/lib/cloudSync";
 import { startLocalServer } from "@/lib/oauth/utils/server";
 import { runWithProxyContextOrDirect } from "@omniroute/open-sse/utils/proxyFetch.ts";
@@ -549,8 +552,7 @@ export async function POST(
           connection = await updateProviderConnection(matchId, {
             ...tokenData,
             expiresAt,
-            testStatus: degradedProject?.testStatus ?? "active",
-            ...(degradedProject ?? {}),
+            ...antigravityPersistStatus(degradedProject),
             isActive: true,
           });
         }
@@ -778,8 +780,7 @@ export async function POST(
             connection = await updateProviderConnection(matchId, {
               ...tokenData,
               expiresAt,
-              testStatus: degradedProject?.testStatus ?? "active",
-              ...(degradedProject ?? {}),
+              ...antigravityPersistStatus(degradedProject),
               isActive: true,
             });
           }

--- a/src/lib/oauth/antigravityProjectGate.ts
+++ b/src/lib/oauth/antigravityProjectGate.ts
@@ -33,29 +33,52 @@ const DISCOVERY_FAILED_WARNING =
   "(loadCodeAssist/onboardUser failed). The account is marked degraded; discovery retries " +
   "automatically on the first request.";
 
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** Cloud Code project id from either the mapped token top-level or providerSpecificData. */
+export function extractAntigravityProjectId(
+  tokenData: Record<string, unknown> | null | undefined
+): string {
+  if (!tokenData) return "";
+  const nested = toRecord(tokenData.providerSpecificData);
+  for (const candidate of [tokenData.projectId, nested.projectId]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  return "";
+}
+
 /**
  * #11284: when projectId discovery failed at connect time, return the degrade
  * fields to persist (testStatus:"degraded" + typed error markers) instead of
  * silently saving a false "active". Returns null for healthy payloads.
+ *
+ * The original gate only fired when `projectDiscoveryOutcome` was set. Paste
+ * credentials, persistOAuthConnection, and agy CLI import can persist an empty
+ * projectId without that flag -- treat the empty id itself as the signal.
  */
 export function antigravityDegradedProjectState(
   provider: string,
   tokenData: Record<string, unknown> | null | undefined
 ): AntigravityDegradedProjectState | null {
   if (!PROJECT_EXPECTED_PROVIDERS.has(provider)) return null;
+  if (extractAntigravityProjectId(tokenData)) return null;
   const outcome = tokenData?.projectDiscoveryOutcome;
-  if (!outcome) return null;
+  const resolvedOutcome =
+    outcome === "discovery_failed" ? "discovery_failed" : "requires_manual_project";
   console.warn(
-    `[oauth] ${provider}: marking connection degraded — no Cloud Code projectId (${String(outcome)}) (#11284)`
+    `[oauth] ${provider}: marking connection degraded - no Cloud Code projectId (${String(resolvedOutcome)}) (#11284)`
   );
   return {
     testStatus: "degraded",
     errorCode: "missing_project_id",
     lastErrorType: "oauth_missing_project_id",
     lastError:
-      outcome === "requires_manual_project"
-        ? BYOP_WARNING
-        : DISCOVERY_FAILED_WARNING,
-    warning: outcome === "requires_manual_project" ? BYOP_WARNING : DISCOVERY_FAILED_WARNING,
+      resolvedOutcome === "requires_manual_project" ? BYOP_WARNING : DISCOVERY_FAILED_WARNING,
+    warning:
+      resolvedOutcome === "requires_manual_project" ? BYOP_WARNING : DISCOVERY_FAILED_WARNING,
   };
 }

--- a/src/lib/oauth/antigravityProjectGate.ts
+++ b/src/lib/oauth/antigravityProjectGate.ts
@@ -40,7 +40,7 @@ function toRecord(value: unknown): Record<string, unknown> {
 }
 
 /** Cloud Code project id from either the mapped token top-level or providerSpecificData. */
-export function extractAntigravityProjectId(
+function extractAntigravityProjectId(
   tokenData: Record<string, unknown> | null | undefined
 ): string {
   if (!tokenData) return "";
@@ -80,5 +80,30 @@ export function antigravityDegradedProjectState(
       resolvedOutcome === "requires_manual_project" ? BYOP_WARNING : DISCOVERY_FAILED_WARNING,
     warning:
       resolvedOutcome === "requires_manual_project" ? BYOP_WARNING : DISCOVERY_FAILED_WARNING,
+  };
+}
+
+/** Persist fields that MUST win over a spread tokenData payload. */
+export function antigravityPersistStatus(
+  degradedProject: AntigravityDegradedProjectState | null | undefined
+): {
+  testStatus: "degraded" | "active";
+  errorCode: string | null;
+  lastErrorType: string | null;
+  lastError: string | null;
+} {
+  if (degradedProject) {
+    return {
+      testStatus: degradedProject.testStatus,
+      errorCode: degradedProject.errorCode,
+      lastErrorType: degradedProject.lastErrorType,
+      lastError: degradedProject.lastError,
+    };
+  }
+  return {
+    testStatus: "active",
+    errorCode: null,
+    lastErrorType: null,
+    lastError: null,
   };
 }

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -14,6 +14,7 @@ import {
 } from "@/models";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
+import { antigravityDegradedProjectState } from "@/lib/oauth/antigravityProjectGate";
 
 /**
  * Constant-time string comparison to prevent timing-oracle attacks (CWE-208).
@@ -148,6 +149,7 @@ export async function persistOAuthConnection(
   const expiresAt = tokenData.expiresIn
     ? new Date(Date.now() + tokenData.expiresIn * 1000).toISOString()
     : null;
+  const degradedProject = antigravityDegradedProjectState(provider, tokenData);
 
   let connection: any;
   // A connectionId is an explicit "update THIS connection" signal (token refresh
@@ -163,14 +165,21 @@ export async function persistOAuthConnection(
       connection = await updateProviderConnection(matchId, {
         ...tokenData,
         expiresAt,
-        testStatus: "active",
+        testStatus: degradedProject?.testStatus ?? "active",
+        ...(degradedProject
+          ? {
+              errorCode: degradedProject.errorCode,
+              lastErrorType: degradedProject.lastErrorType,
+              lastError: degradedProject.lastError,
+            }
+          : {}),
         isActive: true,
       });
     }
   }
   if (!connection) {
     connection = await createProviderConnection(
-      buildOAuthConnectionCreatePayload(provider, tokenData, expiresAt)
+      buildOAuthConnectionCreatePayload(provider, tokenData, expiresAt, degradedProject)
     );
   }
 

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -172,7 +172,7 @@ export async function persistOAuthConnection(
               lastErrorType: degradedProject.lastErrorType,
               lastError: degradedProject.lastError,
             }
-          : {}),
+          : { errorCode: null, lastErrorType: null, lastError: null }),
         isActive: true,
       });
     }

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -16,6 +16,7 @@ import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
 import {
   antigravityDegradedProjectState,
+  antigravityPersistStatus,
   type AntigravityDegradedProjectState,
 } from "@/lib/oauth/antigravityProjectGate";
 
@@ -112,15 +113,9 @@ export function buildOAuthConnectionCreatePayload(
     tokenExpiresAt: expiresAt,
     // #11284: degraded when Cloud Code projectId discovery failed at connect
     // time — the row is saved (refresh token stored, request-time bootstrap
-    // can self-heal) but visibly NOT active.
-    testStatus: degradedProject?.testStatus ?? ("active" as const),
-    ...(degradedProject
-      ? {
-          errorCode: degradedProject.errorCode,
-          lastErrorType: degradedProject.lastErrorType,
-          lastError: degradedProject.lastError,
-        }
-      : { errorCode: null, lastErrorType: null, lastError: null }),
+    // can self-heal) but visibly NOT active. Spread AFTER tokenData so stale
+    // error fields in the payload cannot leak through.
+    ...antigravityPersistStatus(degradedProject),
   };
 }
 
@@ -164,14 +159,7 @@ export async function persistOAuthConnection(
       connection = await updateProviderConnection(matchId, {
         ...tokenData,
         expiresAt,
-        testStatus: degradedProject?.testStatus ?? "active",
-        ...(degradedProject
-          ? {
-              errorCode: degradedProject.errorCode,
-              lastErrorType: degradedProject.lastErrorType,
-              lastError: degradedProject.lastError,
-            }
-          : { errorCode: null, lastErrorType: null, lastError: null }),
+        ...antigravityPersistStatus(degradedProject),
         isActive: true,
       });
     }

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -14,7 +14,10 @@ import {
 } from "@/models";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
-import { antigravityDegradedProjectState } from "@/lib/oauth/antigravityProjectGate";
+import {
+  antigravityDegradedProjectState,
+  type AntigravityDegradedProjectState,
+} from "@/lib/oauth/antigravityProjectGate";
 
 /**
  * Constant-time string comparison to prevent timing-oracle attacks (CWE-208).
@@ -98,12 +101,8 @@ export function buildOAuthConnectionCreatePayload(
   provider: string,
   tokenData: Record<string, any>,
   expiresAt: string | null,
-  degradedProject?: {
-    testStatus: "degraded";
-    errorCode: string;
-    lastErrorType: string;
-    lastError: string;
-  } | null
+  // warning is HTTP-response only (oauth route); persistence copies error fields.
+  degradedProject?: AntigravityDegradedProjectState | null
 ) {
   return {
     provider,

--- a/src/lib/oauth/connectionPersistence.ts
+++ b/src/lib/oauth/connectionPersistence.ts
@@ -121,7 +121,7 @@ export function buildOAuthConnectionCreatePayload(
           lastErrorType: degradedProject.lastErrorType,
           lastError: degradedProject.lastError,
         }
-      : {}),
+      : { errorCode: null, lastErrorType: null, lastError: null }),
   };
 }
 

--- a/src/lib/oauth/utils/agyAuthImport.ts
+++ b/src/lib/oauth/utils/agyAuthImport.ts
@@ -9,6 +9,7 @@ import {
   getAntigravityLoadCodeAssistMetadata,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
 import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
+import { antigravityDegradedProjectState } from "@/lib/oauth/antigravityProjectGate";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -203,6 +204,11 @@ export async function createConnectionFromAgyToken(
         );
       }
 
+      const degradedProject = antigravityDegradedProjectState("agy", {
+        projectId: enriched.projectId ?? "",
+        providerSpecificData: { projectId: enriched.projectId ?? "", clientProfile: "cli" },
+      });
+
       const updated = await updateProviderConnection(existing.id as string, {
         accessToken: enriched.accessToken,
         refreshToken: enriched.refreshToken,
@@ -213,7 +219,14 @@ export async function createConnectionFromAgyToken(
           (existing.name as string | undefined) ||
           resolvedEmail ||
           "Antigravity CLI (imported)",
-        testStatus: "active",
+        testStatus: degradedProject?.testStatus ?? "active",
+        ...(degradedProject
+          ? {
+              errorCode: degradedProject.errorCode,
+              lastErrorType: degradedProject.lastErrorType,
+              lastError: degradedProject.lastError,
+            }
+          : { errorCode: null, lastErrorType: null, lastError: null }),
         isActive: true,
         providerSpecificData: {
           // Auto-sync default for newly discovered backends — see
@@ -241,6 +254,10 @@ export async function createConnectionFromAgyToken(
   }
 
   const name = options.name || resolvedEmail || "Antigravity CLI (imported)";
+  const degradedProject = antigravityDegradedProjectState("agy", {
+    projectId: enriched.projectId ?? "",
+    providerSpecificData: { projectId: enriched.projectId ?? "", clientProfile: "cli" },
+  });
 
   const connection = await createProviderConnection({
     provider: "agy",
@@ -251,7 +268,14 @@ export async function createConnectionFromAgyToken(
     refreshToken: enriched.refreshToken,
     expiresAt: enriched.expiresAt,
     isActive: true,
-    testStatus: "active",
+    testStatus: degradedProject?.testStatus ?? "active",
+    ...(degradedProject
+      ? {
+          errorCode: degradedProject.errorCode,
+          lastErrorType: degradedProject.lastErrorType,
+          lastError: degradedProject.lastError,
+        }
+      : {}),
     providerSpecificData: {
       // Default new imports into model auto-sync — see mapAntigravityTokens.
       autoSync: true,

--- a/src/lib/oauth/utils/agyAuthImport.ts
+++ b/src/lib/oauth/utils/agyAuthImport.ts
@@ -237,6 +237,12 @@ export async function createConnectionFromAgyToken(
           clientProfile: "cli",
           tokenType: enriched.tokenType,
           authMethod: enriched.authMethod,
+          // CLI tokens are issued by the public Antigravity desktop client.
+          // A prior dashboard OAuth against ANTIGRAVITY_OAUTH_CLIENT_ID=web
+          // leaves oauthClient=custom:... on the row; spreading that marker
+          // would refresh the CLI token against the wrong Google client
+          // (401 unauthorized_client) after the imported access token expires.
+          oauthClient: "builtin",
           projectId: enriched.projectId ?? toRecord(existing.providerSpecificData).projectId,
           tier: enriched.tier ?? toRecord(existing.providerSpecificData).tier,
           importedAt: new Date().toISOString(),
@@ -282,6 +288,7 @@ export async function createConnectionFromAgyToken(
       clientProfile: "cli",
       tokenType: enriched.tokenType,
       authMethod: enriched.authMethod,
+      oauthClient: "builtin",
       projectId: enriched.projectId,
       tier: enriched.tier,
       importedAt: new Date().toISOString(),

--- a/src/lib/oauth/utils/agyAuthImport.ts
+++ b/src/lib/oauth/utils/agyAuthImport.ts
@@ -281,7 +281,7 @@ export async function createConnectionFromAgyToken(
           lastErrorType: degradedProject.lastErrorType,
           lastError: degradedProject.lastError,
         }
-      : {}),
+      : { errorCode: null, lastErrorType: null, lastError: null }),
     providerSpecificData: {
       // Default new imports into model auto-sync — see mapAntigravityTokens.
       autoSync: true,

--- a/src/lib/oauth/utils/agyAuthImport.ts
+++ b/src/lib/oauth/utils/agyAuthImport.ts
@@ -9,7 +9,10 @@ import {
   getAntigravityLoadCodeAssistMetadata,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
 import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
-import { antigravityDegradedProjectState } from "@/lib/oauth/antigravityProjectGate";
+import {
+  antigravityDegradedProjectState,
+  antigravityPersistStatus,
+} from "@/lib/oauth/antigravityProjectGate";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -219,14 +222,7 @@ export async function createConnectionFromAgyToken(
           (existing.name as string | undefined) ||
           resolvedEmail ||
           "Antigravity CLI (imported)",
-        testStatus: degradedProject?.testStatus ?? "active",
-        ...(degradedProject
-          ? {
-              errorCode: degradedProject.errorCode,
-              lastErrorType: degradedProject.lastErrorType,
-              lastError: degradedProject.lastError,
-            }
-          : { errorCode: null, lastErrorType: null, lastError: null }),
+        ...antigravityPersistStatus(degradedProject),
         isActive: true,
         providerSpecificData: {
           // Auto-sync default for newly discovered backends — see
@@ -274,14 +270,7 @@ export async function createConnectionFromAgyToken(
     refreshToken: enriched.refreshToken,
     expiresAt: enriched.expiresAt,
     isActive: true,
-    testStatus: degradedProject?.testStatus ?? "active",
-    ...(degradedProject
-      ? {
-          errorCode: degradedProject.errorCode,
-          lastErrorType: degradedProject.lastErrorType,
-          lastError: degradedProject.lastError,
-        }
-      : { errorCode: null, lastErrorType: null, lastError: null }),
+    ...antigravityPersistStatus(degradedProject),
     providerSpecificData: {
       // Default new imports into model auto-sync — see mapAntigravityTokens.
       autoSync: true,

--- a/tests/unit/antigravity-empty-project-degrade-11284.test.ts
+++ b/tests/unit/antigravity-empty-project-degrade-11284.test.ts
@@ -21,7 +21,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { antigravityDegradedProjectState } from "../../src/lib/oauth/antigravityProjectGate.ts";
+import {
+  antigravityDegradedProjectState,
+  antigravityPersistStatus,
+} from "../../src/lib/oauth/antigravityProjectGate.ts";
 
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-11284-empty-project-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
@@ -82,6 +85,21 @@ test("gate stays healthy when projectId is present even if discovery_failed", ()
 
 test("gate ignores non-antigravity providers even with empty projectId", () => {
   assert.equal(antigravityDegradedProjectState("codex", { projectId: "" }), null);
+});
+
+test("antigravityPersistStatus wins over stale error fields in a spread payload", () => {
+  const stale = { errorCode: "missing_project_id", lastErrorType: "oauth_missing_project_id" };
+  const merged = { ...stale, ...antigravityPersistStatus(null) };
+  assert.equal(merged.testStatus, "active");
+  assert.equal(merged.errorCode, null);
+  assert.equal(merged.lastErrorType, null);
+  assert.equal(merged.lastError, null);
+
+  const degraded = antigravityDegradedProjectState("agy", { projectId: "" });
+  assert.ok(degraded);
+  const down = { testStatus: "active", ...antigravityPersistStatus(degraded) };
+  assert.equal(down.testStatus, "degraded");
+  assert.equal(down.errorCode, "missing_project_id");
 });
 
 test("persistOAuthConnection does not save agy with empty projectId as active", async () => {

--- a/tests/unit/antigravity-empty-project-degrade-11284.test.ts
+++ b/tests/unit/antigravity-empty-project-degrade-11284.test.ts
@@ -69,6 +69,17 @@ test("gate stays null for a real Cloud Code projectId", () => {
   );
 });
 
+test("gate stays healthy when projectId is present even if discovery_failed", () => {
+  assert.equal(
+    antigravityDegradedProjectState("agy", {
+      projectId: "aicode-consumers-xyz",
+      projectDiscoveryOutcome: "discovery_failed",
+    }),
+    null,
+    "projectId is the source of truth; outcome only picks the empty-id warning"
+  );
+});
+
 test("gate ignores non-antigravity providers even with empty projectId", () => {
   assert.equal(antigravityDegradedProjectState("codex", { projectId: "" }), null);
 });

--- a/tests/unit/antigravity-empty-project-degrade-11284.test.ts
+++ b/tests/unit/antigravity-empty-project-degrade-11284.test.ts
@@ -28,7 +28,9 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
-const { persistOAuthConnection } = await import("../../src/lib/oauth/connectionPersistence.ts");
+const { persistOAuthConnection, buildOAuthConnectionCreatePayload } = await import(
+  "../../src/lib/oauth/connectionPersistence.ts"
+);
 const { createConnectionFromAgyToken } = await import("../../src/lib/oauth/utils/agyAuthImport.ts");
 
 test.after(() => {
@@ -173,4 +175,59 @@ test("agy CLI import with a projectId stays active (#9204 reactivation still wor
   );
   const stored = await providersDb.getProviderConnectionById(connection.id as string);
   assert.equal(stored?.testStatus, "active");
+  // getProviderConnectionById runs cleanNulls, so SQL NULL becomes undefined.
+  assert.ok(!stored?.errorCode);
+  assert.ok(!stored?.lastErrorType);
+  assert.ok(!stored?.lastError);
+});
+
+test("healthy create payload sets error fields to null, not omitted", () => {
+  const payload = buildOAuthConnectionCreatePayload(
+    "agy",
+    { email: "create-null@example.test", accessToken: "t", refreshToken: "r" },
+    null,
+    null
+  );
+  assert.equal(payload.testStatus, "active");
+  assert.equal(payload.errorCode, null);
+  assert.equal(payload.lastErrorType, null);
+  assert.equal(payload.lastError, null);
+  assert.ok("errorCode" in payload, "key must be present so SQLite writes NULL");
+});
+
+test("createProviderConnection upsert clears stale degrade fields from payload nulls", async () => {
+  const first = await providersDb.createProviderConnection({
+    provider: "agy",
+    authType: "oauth",
+    email: "create-upsert@example.test",
+    accessToken: "agy-access-token-fixture",
+    refreshToken: "agy-refresh-token-fixture",
+    isActive: true,
+    testStatus: "degraded",
+    errorCode: "missing_project_id",
+    lastErrorType: "oauth_missing_project_id",
+    lastError: "no Cloud Code projectId",
+  });
+  assert.equal(first?.errorCode, "missing_project_id");
+
+  await providersDb.createProviderConnection({
+    provider: "agy",
+    authType: "oauth",
+    email: "create-upsert@example.test",
+    accessToken: "agy-access-token-fixture-2",
+    refreshToken: "agy-refresh-token-fixture",
+    isActive: true,
+    testStatus: "active",
+    errorCode: null,
+    lastErrorType: null,
+    lastError: null,
+    projectId: "healed-cloud-code-proj",
+  });
+
+  const stored = await providersDb.getProviderConnectionById(first.id as string);
+  assert.equal(stored?.id, first.id, "same connection is updated, not duplicated");
+  assert.equal(stored?.testStatus, "active");
+  assert.ok(!stored?.errorCode);
+  assert.ok(!stored?.lastErrorType);
+  assert.ok(!stored?.lastError);
 });

--- a/tests/unit/antigravity-empty-project-degrade-11284.test.ts
+++ b/tests/unit/antigravity-empty-project-degrade-11284.test.ts
@@ -87,6 +87,38 @@ test("persistOAuthConnection does not save agy with empty projectId as active", 
   assert.equal(stored?.isActive, true, "refresh token stays stored; request-time bootstrap can heal");
 });
 
+test("persistOAuthConnection clears stale degrade fields once projectId appears", async () => {
+  const first = await persistOAuthConnection("agy", {
+    email: "heal-project@example.test",
+    accessToken: "agy-access-token-fixture",
+    refreshToken: "agy-refresh-token-fixture",
+    expiresIn: 3600,
+    projectId: "",
+    providerSpecificData: { clientProfile: "cli", projectId: "", tier: "legacy-tier" },
+  });
+  assert.equal(first.testStatus, "degraded");
+  assert.equal(first.errorCode, "missing_project_id");
+
+  const healed = await persistOAuthConnection("agy", {
+    email: "heal-project@example.test",
+    accessToken: "agy-access-token-fixture-2",
+    refreshToken: "agy-refresh-token-fixture",
+    expiresIn: 3600,
+    projectId: "healed-cloud-code-proj",
+    providerSpecificData: {
+      clientProfile: "cli",
+      projectId: "healed-cloud-code-proj",
+      tier: "g1-pro-tier",
+    },
+  });
+  const stored = await providersDb.getProviderConnectionById(healed.id);
+  assert.equal(stored?.id, first.id, "same connection is updated, not duplicated");
+  assert.equal(stored?.testStatus, "active");
+  assert.ok(!stored?.errorCode);
+  assert.ok(!stored?.lastErrorType);
+  assert.ok(!stored?.lastError);
+});
+
 test("persistOAuthConnection keeps a discovered projectId active", async () => {
   const connection = await persistOAuthConnection("agy", {
     email: "has-project@example.test",

--- a/tests/unit/antigravity-empty-project-degrade-11284.test.ts
+++ b/tests/unit/antigravity-empty-project-degrade-11284.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #11284 follow-up: empty Cloud Code projectId must mark the connection
+ * degraded even when projectDiscoveryOutcome is missing.
+ *
+ * Production evidence (X500, 2026-08-31): an agy OAuth connect for a working
+ * Google One account persisted testStatus="active" with projectId="" and
+ * tier="legacy-tier". Dashboard usage then showed "Antigravity access
+ * forbidden. Check subscription." because fetchAvailableModels returned 403.
+ * The official Windows `agy` CLI could still serve Gemini on the same
+ * account -- Omni never stored the CLI's Cloud Code project.
+ *
+ * The original #11284 gate only fired when tokenData.projectDiscoveryOutcome
+ * was set. Paste-credentials / persistOAuthConnection / agy CLI import all
+ * persist empty projectId without that flag, so the dashboard showed Connected.
+ *
+ * Run: node --import tsx/esm --test tests/unit/antigravity-empty-project-degrade-11284.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { antigravityDegradedProjectState } from "../../src/lib/oauth/antigravityProjectGate.ts";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-11284-empty-project-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { persistOAuthConnection } = await import("../../src/lib/oauth/connectionPersistence.ts");
+const { createConnectionFromAgyToken } = await import("../../src/lib/oauth/utils/agyAuthImport.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("gate degrades agy/antigravity when projectId is empty even without outcome flag", () => {
+  for (const provider of ["agy", "antigravity"]) {
+    const degraded = antigravityDegradedProjectState(provider, {
+      projectId: "",
+      providerSpecificData: { projectId: "", tier: "legacy-tier" },
+    });
+    assert.ok(degraded, `${provider}: empty projectId must degrade`);
+    assert.equal(degraded.testStatus, "degraded");
+    assert.equal(degraded.errorCode, "missing_project_id");
+    assert.equal(degraded.lastErrorType, "oauth_missing_project_id");
+  }
+});
+
+test("gate degrades when only providerSpecificData.projectId is empty", () => {
+  const degraded = antigravityDegradedProjectState("agy", {
+    providerSpecificData: { projectId: "   ", clientProfile: "cli" },
+  });
+  assert.ok(degraded, "whitespace projectId is empty");
+  assert.equal(degraded.testStatus, "degraded");
+});
+
+test("gate stays null for a real Cloud Code projectId", () => {
+  assert.equal(
+    antigravityDegradedProjectState("agy", {
+      projectId: "dotted-relic-q6pck",
+      providerSpecificData: { projectId: "dotted-relic-q6pck", tier: "g1-pro-tier" },
+    }),
+    null
+  );
+});
+
+test("gate ignores non-antigravity providers even with empty projectId", () => {
+  assert.equal(antigravityDegradedProjectState("codex", { projectId: "" }), null);
+});
+
+test("persistOAuthConnection does not save agy with empty projectId as active", async () => {
+  const connection = await persistOAuthConnection("agy", {
+    email: "empty-project@example.test",
+    accessToken: "agy-access-token-fixture",
+    refreshToken: "agy-refresh-token-fixture",
+    expiresIn: 3600,
+    projectId: "",
+    providerSpecificData: { clientProfile: "cli", projectId: "", tier: "legacy-tier" },
+  });
+  const stored = await providersDb.getProviderConnectionById(connection.id);
+  assert.equal(stored?.testStatus, "degraded");
+  assert.equal(stored?.errorCode, "missing_project_id");
+  assert.equal(stored?.lastErrorType, "oauth_missing_project_id");
+  assert.equal(stored?.isActive, true, "refresh token stays stored; request-time bootstrap can heal");
+});
+
+test("persistOAuthConnection keeps a discovered projectId active", async () => {
+  const connection = await persistOAuthConnection("agy", {
+    email: "has-project@example.test",
+    accessToken: "agy-access-token-fixture",
+    refreshToken: "agy-refresh-token-fixture",
+    expiresIn: 3600,
+    projectId: "generated-strength-t6b5h",
+    providerSpecificData: {
+      clientProfile: "cli",
+      projectId: "generated-strength-t6b5h",
+      tier: "g1-pro-tier",
+    },
+  });
+  const stored = await providersDb.getProviderConnectionById(connection.id);
+  assert.equal(stored?.testStatus, "active");
+  assert.ok(!stored?.errorCode);
+});
+
+test("agy CLI import with empty projectId is degraded, not Connected", async () => {
+  const { connection, created } = await createConnectionFromAgyToken(
+    {
+      accessToken: "agy-access-token-fixture",
+      refreshToken: "agy-refresh-token-fixture",
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      tokenType: "Bearer",
+      authMethod: "oauth",
+      email: "cli-empty@example.test",
+      projectId: "",
+      tier: "legacy-tier",
+    },
+    {}
+  );
+  assert.equal(created, true);
+  const stored = await providersDb.getProviderConnectionById(connection.id as string);
+  assert.equal(stored?.testStatus, "degraded");
+  assert.equal(stored?.errorCode, "missing_project_id");
+});
+
+test("agy CLI import with a projectId stays active (#9204 reactivation still works)", async () => {
+  const { connection } = await createConnectionFromAgyToken(
+    {
+      accessToken: "agy-access-token-fixture",
+      refreshToken: "agy-refresh-token-fixture",
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      tokenType: "Bearer",
+      authMethod: "oauth",
+      email: "cli-ok@example.test",
+      projectId: "project-9204",
+      tier: "free-tier",
+    },
+    {}
+  );
+  const stored = await providersDb.getProviderConnectionById(connection.id as string);
+  assert.equal(stored?.testStatus, "active");
+});

--- a/tests/unit/bug-9204-agy-reimport-reactivates.test.ts
+++ b/tests/unit/bug-9204-agy-reimport-reactivates.test.ts
@@ -26,6 +26,10 @@ test("#9204: reimporting an inactive Antigravity CLI account reactivates it", as
     expiresAt: new Date(Date.now() - 60_000).toISOString(),
     isActive: false,
     testStatus: "expired",
+    providerSpecificData: {
+      oauthClient: "custom:293923686274-example.apps.googleusercontent.com",
+      clientProfile: "cli",
+    },
   });
 
   await createConnectionFromAgyToken(
@@ -42,9 +46,15 @@ test("#9204: reimporting an inactive Antigravity CLI account reactivates it", as
     { overwriteExisting: true }
   );
 
-  const stored = await providersDb.getProviderConnectionById(existing.id);
+  const stored = await providersDb.getProviderConnectionById(existing.id as string);
   assert.equal(stored?.testStatus, "active");
   assert.equal(stored?.isActive, true, "a successful reimport must reactivate the account");
+  const specific = (stored?.providerSpecificData ?? {}) as Record<string, unknown>;
+  assert.equal(
+    specific.oauthClient,
+    "builtin",
+    "CLI import must not keep a leftover custom OAuth client marker"
+  );
 
   const active = await providersDb.getProviderConnections({ provider: "agy", isActive: true });
   assert.deepEqual(

--- a/tests/unit/bug-9204-agy-reimport-reactivates.test.ts
+++ b/tests/unit/bug-9204-agy-reimport-reactivates.test.ts
@@ -26,6 +26,9 @@ test("#9204: reimporting an inactive Antigravity CLI account reactivates it", as
     expiresAt: new Date(Date.now() - 60_000).toISOString(),
     isActive: false,
     testStatus: "expired",
+    errorCode: "missing_project_id",
+    lastErrorType: "oauth_missing_project_id",
+    lastError: "stale degrade leftover",
     providerSpecificData: {
       oauthClient: "custom:293923686274-example.apps.googleusercontent.com",
       clientProfile: "cli",
@@ -49,6 +52,9 @@ test("#9204: reimporting an inactive Antigravity CLI account reactivates it", as
   const stored = await providersDb.getProviderConnectionById(existing.id as string);
   assert.equal(stored?.testStatus, "active");
   assert.equal(stored?.isActive, true, "a successful reimport must reactivate the account");
+  assert.ok(!stored?.errorCode, "reimport must clear leftover degrade errorCode");
+  assert.ok(!stored?.lastErrorType);
+  assert.ok(!stored?.lastError);
   const specific = (stored?.providerSpecificData ?? {}) as Record<string, unknown>;
   assert.equal(
     specific.oauthClient,

--- a/tests/unit/oauth-route-antigravity-project-gate.test.ts
+++ b/tests/unit/oauth-route-antigravity-project-gate.test.ts
@@ -32,8 +32,8 @@ test("degrade gate is wired into both exchange and poll-callback branches", () =
 test("connects are SAVED with degraded status, not rejected", () => {
   // No 422 rejection in the antigravity project path: the upsert proceeds and
   // the degraded fields flow into both the update and create payloads.
-  assert.match(routeSource, /testStatus: degradedProject\?\.testStatus \?\? "active"/);
-  assert.match(persistenceSource, /degradedProject\?\.testStatus \?\? \("active" as const\)/);
+  assert.match(routeSource, /\.\.\.antigravityPersistStatus\(degradedProject\)/);
+  assert.match(persistenceSource, /\.\.\.antigravityPersistStatus\(degradedProject\)/);
   assert.match(routeSource, /warning: degradedProject\.warning/);
   // paste-credentials / device-complete used to hardcode testStatus:"active".
   assert.match(

--- a/tests/unit/oauth-route-antigravity-project-gate.test.ts
+++ b/tests/unit/oauth-route-antigravity-project-gate.test.ts
@@ -35,6 +35,15 @@ test("connects are SAVED with degraded status, not rejected", () => {
   assert.match(routeSource, /testStatus: degradedProject\?\.testStatus \?\? "active"/);
   assert.match(persistenceSource, /degradedProject\?\.testStatus \?\? \("active" as const\)/);
   assert.match(routeSource, /warning: degradedProject\.warning/);
+  // paste-credentials / device-complete used to hardcode testStatus:"active".
+  assert.match(
+    persistenceSource,
+    /const degradedProject = antigravityDegradedProjectState\(provider, tokenData\)/
+  );
+  assert.match(
+    persistenceSource,
+    /buildOAuthConnectionCreatePayload\(provider, tokenData, expiresAt, degradedProject\)/
+  );
 });
 
 test("gate only applies to antigravity and agy, marks typed error fields", () => {


### PR DESCRIPTION
fix(oauth): mark empty Antigravity projectId as degraded and clear stale errors

### Summary
Follow-up to #11284. Previously, the OAuth connect-time degradation gate only triggered when `tokenData.projectDiscoveryOutcome` was explicitly present. If an Antigravity/`agy` connection was saved with an empty `projectId` via paths like paste-credentials, CLI import, or reconnects, it still defaulted to `testStatus: "active"`. This caused subsequent requests to fail with 403 / "Antigravity access forbidden" because Google Cloud Code companion project discovery had not succeeded.

### Changes
1. **Empty Project ID Degradation Gate (`antigravityProjectGate.ts`)**:
   - `antigravityDegradedProjectState` treats any empty or whitespace-only `projectId` as degraded (`testStatus: "degraded"`, `errorCode: "missing_project_id"`, `lastErrorType: "oauth_missing_project_id"`), regardless of whether `projectDiscoveryOutcome` was set.
   - If a valid `projectId` is present, it returns `null` (healthy).

2. **Centralized Persist Status (`antigravityPersistStatus`)**:
   - Extracted `antigravityPersistStatus` helper to ensure `testStatus`, `errorCode`, `lastErrorType`, and `lastError` are consistently mapped.
   - When a connection is healthy or recovers with a valid `projectId`, `errorCode`, `lastErrorType`, and `lastError` are explicitly set to `null` on both create and update paths (`connectionPersistence.ts`, `agyAuthImport.ts`, and OAuth route exchange/poll-callback) so stale degrade markers in SQLite are cleared.

3. **CLI Import Client Binding (`agyAuthImport.ts`)**:
   - `createConnectionFromAgyToken` sets `oauthClient: "builtin"` on imported CLI tokens so future refreshes do not inherit stale custom web OAuth client markers.

### Verification
- Targeted unit tests in `tests/unit/`:
  - `antigravity-empty-project-degrade-11284.test.ts` (degrade on empty project, clear on heal, healthy create/upsert nulling)
  - `bug-9204-agy-reimport-reactivates.test.ts` (re-import reactivates and clears leftover error fields)
  - `oauth-route-antigravity-project-gate.test.ts` (route wiring and persist helper integration)
  - `oauth-connection-persistence-codex-dedup.test.ts`
  - `agy-auth-import.test.ts`
- All 25 unit tests pass. `npm run typecheck:core` passes with 0 errors.

Signed-off-by: Minxi Hou <houminxi@gmail.com>
