### PR TITLE
fix(providers): gate the Codex auto-ping usage read on the shared quota throttle

### DIFF
--- a/src/lib/services/quotaAutoPing.ts
+++ b/src/lib/services/quotaAutoPing.ts
@@ -24,6 +24,7 @@ import { logger } from "@omniroute/open-sse/utils/logger.ts";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
 import type { BaseExecutor } from "@omniroute/open-sse/executors/base";
 import { getCodexUsage } from "@omniroute/open-sse/services/usage/codex.ts";
+import { throttleQuotaFetch } from "@omniroute/open-sse/services/quotaFetchThrottle.ts";
 import { getSettings } from "@/lib/db/settings";
 import { getProviderConnections, updateProviderConnection } from "@/lib/db/providers";
 import { isConnectionUnavailableToAuxiliaryActivity } from "@/lib/exclusiveLeaseIsolation";
@@ -62,10 +63,13 @@ export interface QuotaAutoPingDeps {
   refreshAndUpdateCredentials: (
     connection: QuotaAutoPingConnection
   ) => Promise<{ connection: QuotaAutoPingConnection }>;
-  getCodexUsage: (
-    accessToken?: string,
-    providerSpecificData?: JsonRecord
-  ) => Promise<JsonRecord>;
+  getCodexUsage: (accessToken?: string, providerSpecificData?: JsonRecord) => Promise<JsonRecord>;
+  /**
+   * #11904: the #6009/#6058 gate that spaces genuine upstream quota fetches. Every
+   * other Codex quota read is behind it; this scheduler's read has to be too, since
+   * it runs unattended once a minute per connection.
+   */
+  throttleQuotaFetch: () => Promise<void>;
   getExecutor: (provider: "codex") => Promise<BaseExecutor>;
   canExecuteProvider: (provider: string) => boolean;
   isConnectionUnavailableToAuxiliaryActivity: (connectionId: string) => Promise<boolean>;
@@ -107,6 +111,7 @@ export function createDefaultQuotaAutoPingDeps(): QuotaAutoPingDeps {
     refreshAndUpdateCredentials: async (connection) =>
       refreshAndUpdateCredentialsWithResolver(connection, loadQuotaAutoPingExecutor),
     getCodexUsage,
+    throttleQuotaFetch,
     getExecutor: loadQuotaAutoPingExecutor,
     canExecuteProvider: (provider) => getCircuitBreaker(provider).canExecute(),
     isConnectionUnavailableToAuxiliaryActivity,
@@ -361,6 +366,10 @@ async function pingConnection(
   const current = await refreshConnectionForPing(connection, provider, deps, state, key, nowMs);
   if (!current) return;
 
+  // Pace this the same way every other quota fetcher does. Placed after the skip
+  // checks above so a connection that never reaches the network does not consume a
+  // slot and delay the ones that do.
+  await deps.throttleQuotaFetch();
   const usage = await deps.getCodexUsage(current.accessToken, current.providerSpecificData);
   const quotas = (usage.quotas as JsonRecord) || {};
   const quota = quotas[providerConfig.quotaKey] as JsonRecord | undefined;

--- a/tests/unit/quota-auto-ping.test.ts
+++ b/tests/unit/quota-auto-ping.test.ts
@@ -50,6 +50,9 @@ function baseDeps(overrides = {}) {
     },
     refreshAndUpdateCredentials: async (connection) => ({ connection }),
     getCodexUsage: async () => ({ quotas: {} }),
+    // #11904: real callers get this from createDefaultQuotaAutoPingDeps(); the fixture
+    // mirrors it so tests exercise the gated path without a real timer.
+    throttleQuotaFetch: async () => {},
     getExecutor: (provider) => {
       calls.getExecutor.push(provider);
       return {
@@ -399,4 +402,59 @@ test("#6977 does not ping when credential refresh throws", async () => {
 
   assert.equal(calls.getExecutor.length, 0);
   assert.equal(state.failureCache["codex:codex-1"], NOW_MS);
+});
+
+test("routes the auto-ping usage read through the shared quota-fetch throttle (#11904)", async () => {
+  // #11904: every other Codex quota read goes through `throttleQuotaFetch()` — the
+  // #6009/#6058 gate that spaces genuine upstream calls so many accounts on one IP do
+  // not fire in the same second, which is the pattern that got a Codex OAuth token
+  // revoked. The auto-ping scheduler called `getCodexUsage` directly, so the one Codex
+  // path that runs unattended every 60s per connection was the one skipping the
+  // mitigation written for Codex.
+  const order = [];
+  const { deps } = baseDeps({
+    getSettings: async () => ({
+      codexAutoPing: { connections: { "codex-1": true, "codex-2": true } },
+    }),
+    getProviderConnections: async ({ provider }) =>
+      provider === "codex"
+        ? [
+            { id: "codex-1", provider: "codex", authType: "oauth", accessToken: "t1" },
+            { id: "codex-2", provider: "codex", authType: "oauth", accessToken: "t2" },
+          ]
+        : [],
+    throttleQuotaFetch: async () => {
+      order.push("throttle");
+    },
+    getCodexUsage: async () => {
+      order.push("fetch");
+      return { quotas: {} };
+    },
+  });
+
+  await runQuotaAutoPingTick(deps, createQuotaAutoPingState(), () => NOW_MS);
+
+  // Two connections, so two gated fetches, and the gate must precede each one.
+  assert.deepEqual(order, ["throttle", "fetch", "throttle", "fetch"]);
+});
+
+test("does not consume a throttle slot when the connection is skipped before fetching (#11904)", async () => {
+  // The throttle paces genuine upstream calls only. A connection filtered out by the
+  // circuit breaker never reaches the network, so it must not take a slot and delay
+  // the connections that do.
+  const order = [];
+  const { deps } = baseDeps({
+    canExecuteProvider: () => false,
+    throttleQuotaFetch: async () => {
+      order.push("throttle");
+    },
+    getCodexUsage: async () => {
+      order.push("fetch");
+      return { quotas: {} };
+    },
+  });
+
+  await runQuotaAutoPingTick(deps, createQuotaAutoPingState(), () => NOW_MS);
+
+  assert.deepEqual(order, []);
 });


### PR DESCRIPTION
## Summary

Every Codex quota read in the codebase goes through `throttleQuotaFetch()` — the #6009/#6058 gate that spaces genuine upstream calls so many accounts behind one egress IP don't fire in the same second. That gate's own docstring names the consequence:

> per router-for-me/CLIProxyAPI#2385 — can get a Codex OAuth token revoked

Ten fetchers sit behind it (`codexQuotaFetcher`, `opencodeQuotaFetcher`, `agentrouterQuotaFetcher`, …). The auto-ping scheduler called `getCodexUsage()` directly, so **the one Codex path that runs unattended every 60 seconds per connection was the one skipping the mitigation written for Codex.**

`runProviderTick` walks connections sequentially but with no spacing between them, so N enabled connections still produce N upstream usage requests inside a few hundred milliseconds — the burst shape the throttle exists to break up.

This gates that read on the same throttle, injected through `deps` like every other effect in the module. Placed **after** the skip checks, so a connection filtered out by the circuit breaker, a rate-limit cooldown or the failure cache doesn't consume a slot and delay the connections that actually reach the network.

**Deliberately not changing the polling cadence**, which #11904 also suggests. Codex sets `pingWhenResetAtSlides` and the code explains why:

```ts
// Codex has no fixed reset schedule (pingWhenResetAtSlides): resetAt keeps
// sliding forward while the window is idle, so we must re-fetch usage every
// tick to detect the slide.
```

Deferring the poll until near a cached `resetAt` would defeat exactly that detection. The reported symptom is the unpaced burst, and that's what this fixes; if you do want the cadence revisited, it's a separate change and needs that comment answered first.

## Related Issues

- Closes #11904

## Validation

- [x] Change type: provider (quota fetching)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint` — clean on both changed files
- [x] Reconciled with the current active release base (`6706c382d`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Both tests were written first. `routes the auto-ping usage read through the shared quota-fetch throttle` failed on the unmodified scheduler; the second passed from the start, which is the point — it's the guard against the fix over-throttling.

Focused suites after the change:

```
tests/unit/quota-auto-ping.test.ts
tests/unit/quota-fetch-throttle-6009.test.ts
tests/unit/quota-fetch-throttle-scope-6911.test.ts
tests/unit/codex-quota-fetcher.test.ts
tests/unit/codex-quota-sync-no-proactive-refresh.test.ts
tests/unit/headroom-codex-quota-snapshot-6379.test.ts
tests/unit/quota-scheduler.test.ts
→ 47 tests, 47 pass, 0 fail
```

Both the presence *and the placement* of the gate are mutation-tested — each mutation killed exactly one test:

| mutation | result |
|---|---|
| remove `await deps.throttleQuotaFetch()` entirely | 1 fail (the pacing test) |
| move it above the skip checks | 1 fail (the no-wasted-slot test) |

## Tests Added Or Updated

- `tests/unit/quota-auto-ping.test.ts` — 2 added, plus `throttleQuotaFetch` in the shared `baseDeps` fixture so it mirrors `createDefaultQuotaAutoPingDeps()`:
  - two connections produce `throttle, fetch, throttle, fetch` — the gate precedes every upstream read
  - a connection blocked by the circuit breaker consumes neither a slot nor a fetch

## Coverage Notes

`src/lib/services/quotaAutoPing.ts` is the only production file changed, and both new branches (gate fires / connection skipped before the gate) are covered by the tests above. Coverage does not move down in any touched file.

## Reviewer Notes

- **This adds 2 `tsc` errors, and I'd rather flag it than have you find it.** `tsc --noEmit` reports 18 errors across these two files on `6706c382d` and 20 with this branch. They're all one pre-existing cause: `baseDeps()` returns an untyped object literal that doesn't satisfy `QuotaAutoPingDeps`, so *every* `runQuotaAutoPingTick(deps, …)` call already errors — 17 calls + 1 production error = 18. My two tests add two more instances of that same error, not a new kind. Happy to type the fixture properly in this PR or a follow-up if you want the count going the other way; I left it alone to keep the diff to the bug.
- The rebase onto `6706c382d` took your import split (`@/lib/db/settings` + `@/lib/db/providers`) and the `Promise<BaseExecutor>` signature over my versions. Incidentally that clears the `no-restricted-imports` error this file had on the older base — eslint is now clean on it.
- Behaviour change is bounded: one `await` on a gate that is fail-open by construction (`acquire()` only ever awaits a timer, it cannot throw), and disabled entirely at `minIntervalMs = 0`.
