### PR TITLE
fix(deepseek-web): stop Turbopack dev panic in the PoW worker path resolver

### DIFF
--- a/open-sse/lib/deepseek-pow.ts
+++ b/open-sse/lib/deepseek-pow.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 
 import { findDeepSeekPowNonce, MAX_DEEPSEEK_POW_DIFFICULTY } from "./deepseek-pow-hash.js";
@@ -74,10 +73,21 @@ function solveSynchronously({ challenge, prefix, difficulty }: ValidatedChalleng
   return findDeepSeekPowNonce(prefix, challenge, difficulty);
 }
 
+// Anchored on process.cwd(), never import.meta.url: the production standalone bundle
+// freezes import.meta.url to the build-machine path (same app-wide gotcha documented on
+// GATE_DEP_REL in open-sse/services/compression/engines/llmlingua/worker.ts), so an
+// import.meta.url-relative fallback here was silently dead in production. It also gave
+// this function two return branches, one of which contained a `new URL(literal,
+// import.meta.url)` construct -- Turbopack's dev-mode static worker-chunk detector
+// partially resolves that pattern independent of which branch actually runs, producing
+// an inconsistent module-graph node and crashing turbo-tasks on startup (bisected to
+// 657d3a484). A single non-branching path resolution avoids both problems.
 function resolveWorkerPath(): string {
-  const tracedPath = path.join(process.cwd(), "open-sse/lib/deepseek-pow-worker.mjs");
-  if (existsSync(tracedPath)) return tracedPath;
-  return fileURLToPath(new URL("./deepseek-pow-worker.mjs", import.meta.url));
+  const workerPath = path.join(process.cwd(), "open-sse/lib/deepseek-pow-worker.mjs");
+  if (!existsSync(workerPath)) {
+    throw new Error(`DeepSeek PoW worker script not found at ${workerPath}`);
+  }
+  return workerPath;
 }
 
 function solveInWorker(


### PR DESCRIPTION
## Summary

`npm run dev` (Turbopack) has been crash-looping since #11732 landed: `turbo-tasks` panics internally on startup, `Restart=on-failure` silently retries, and the dev server never comes up. Fixes the two-branch worker-path resolver in `deepseek-pow.ts` that Turbopack's dev-mode static analysis chokes on, and removes an `import.meta.url` fallback that was already dead in the production standalone bundle.

## Related Issues

- Not filed as an issue first; this was found and root-caused live while debugging a stuck `omniroute-dev` deployment. Happy to file one if preferred.

## Root cause

`resolveWorkerPath()` had two return branches:

```ts
function resolveWorkerPath(): string {
  const tracedPath = path.join(process.cwd(), "open-sse/lib/deepseek-pow-worker.mjs");
  if (existsSync(tracedPath)) return tracedPath;
  return fileURLToPath(new URL("./deepseek-pow-worker.mjs", import.meta.url));
}
```

Turbopack's dev-mode static worker-chunk detector partially resolves the `new URL(literal, import.meta.url)` construct in the fallback branch independent of which branch actually executes at runtime, producing an inconsistent module-graph node. `turbo-tasks` then panics on startup with either:

- `inner_of_upper_lost_followers...` (`turbo-tasks-backend/src/backend/operation/aggregation_update.rs:2396`), or
- `there must be a path to a root...` (`turbopack-core/src/module_graph/mod.rs:746`)

`git bisect` across `443c96d28` (known-good) → `b7a0c5413` (known-bad, 418 commits, 9 steps) isolated this to 657d3a484 (#11732). Confirmed by direct isolation, not just bisect inference: with the dev server running at that exact commit,

- removing the `new Worker(...)` call entirely → clean boot, no panic
- replacing the two-branch resolver with a single, non-branching `new Worker(new URL("./deepseek-pow-worker.mjs", import.meta.url), ...)` inlined at the call site → also clean boot, no panic
- only the original two-branch resolver panics

The `import.meta.url` fallback branch was also silently dead code in production: the standalone bundle (webpack) freezes `import.meta.url` to the build-machine path, not the runtime path — the same app-wide gotcha already documented on `GATE_DEP_REL` in `open-sse/services/compression/engines/llmlingua/worker.ts`'s fail-open probe. So this fix removes a real prod bug and a dev bug with the same one-line change: drop the branch, keep only `process.cwd()`-anchored resolution, and fail loudly (not silently mis-resolve) if the file is ever missing.

`process.cwd()` alone is correct in every real layout this app runs from: `run-next.mjs dev`/`start` both run with `process.cwd()` at the repo root, and the production standalone bundle's `outputFileTracingIncludes` already copies `deepseek-pow-worker.mjs` preserving its `process.cwd()`-relative path.

Checked the two sibling `new Worker(...)` call sites for the same fragility (`compressionWorkerPool.ts`, `llmlingua/worker.ts`): both are handled by a dedicated `colocate-standalone.mjs` bundling step for production, unlike `deepseek-pow-worker.mjs`, which relied purely on `outputFileTracingIncludes` + runtime path resolution. Neither showed up in the bisect range, and I didn't touch them — flagging only as a note in case they're worth a closer look separately; no evidence either is currently broken.

## Validation

- [x] Change type: build-deploy (dev-mode Turbopack bundling + production standalone-build asset resolution)
- [x] Focused tests: `node --test tests/unit/deepseek-pow-js-only.test.ts tests/unit/deepseek-web.test.ts` — 44/44 passing
- [x] `npm run lint` (scoped: `eslint open-sse/lib/deepseek-pow.ts`) — clean
- [x] Reconciled with `release/v3.8.51` tip (`upstream/release/v3.8.51` @ `63e4afa32` at branch time)
- [ ] Production-code changes include a new or updated automated test in this PR — see Coverage Notes below; this specific regression is a bundler static-analysis crash, not observable from a runtime unit test.

Real behavior verified live, not just unit tests:

- **Dev (Turbopack), the actual regression**: `OMNIROUTE_USE_TURBOPACK=1 npm run dev` (via `run-next.mjs`) now reaches `[Next] dev server listening on http://0.0.0.0:20128 (turbopack)` cleanly. Pre-fix, at the exact bisected commit, it panicked every time.
- **Production standalone build**: `npm run build` produced a clean webpack compile and a working standalone tree; `.build/next/standalone/open-sse/lib/deepseek-pow-worker.mjs` landed at exactly the traced path. Ran the real `solveDeepSeekPowAsync` from `cwd = .build/next/standalone` (matching how the standalone server is actually deployed) against a fabricated but valid `DeepSeekHashV1` challenge (known nonce, real hash) — the worker spawned and returned the correct nonce.
- `tsc --noEmit`: clean on the touched file (repo-wide errors present are pre-existing, in unrelated test files — `usage-service-deepseek.test.ts`, `deepseek-thinking-efforts.test.ts`, etc., none touching `deepseek-pow.ts`).

## Tests Added Or Updated

- No new test file. The existing `tests/unit/deepseek-pow-js-only.test.ts` ("DeepSeek PoW remains functional without redistributing extracted solver artifacts", "DeepSeek PoW caps concurrent worker searches at two") already exercises the real worker spawn + solve path this fix touches, and passes against the fix.

## Coverage Notes

- `open-sse/lib/deepseek-pow.ts` is covered by the existing worker-spawn tests above at the runtime-behavior level. The actual bug this PR fixes is a Turbopack dev-mode bundler static-analysis crash, which a Node `--test` unit test can't observe (process.cwd()-based resolution already worked correctly at runtime pre-fix; only the bundler's static graph-building over the two-branch function was broken). I don't see an existing CI check that boots `npm run dev` under Turbopack and asserts it stays up — that's the actual regression surface here, and I don't have a good bounded way to add one from this PR without more context on the golden-path CI setup. Flagging rather than silently leaving the gap.

## Reviewer Notes

- Root-caused via `git bisect` plus direct isolation testing at the bisected commit (three separate live dev-server runs: original code panics, Worker-removed variant is clean, inlined-literal variant is clean) — not just the bisect result on its own.
- The one-line production diff is intentionally the entire fix: no new abstractions, no defensive layering beyond turning a silent mis-resolution into a clear thrown error if the worker file is ever genuinely missing.
- Happy to open a companion issue documenting the bisect if that's useful for tracking, or to look at the two sibling worker call sites in a follow-up if a maintainer wants that checked more rigorously.
