### PR TITLE
fix(chat-admission): clarify local 503 source

### DIFF
--- a/src/shared/middleware/chatAdmissionResponses.ts
+++ b/src/shared/middleware/chatAdmissionResponses.ts
@@ -61,7 +61,7 @@ export function structuralRejectionResponse(status: 413 | 503, maxMessages: numb
     status,
     historyLimit
       ? `Chat history exceeds the ${maxMessages}-message limit; compact the conversation and retry.`
-      : "Structurally heavy chat request capacity is busy; retry shortly.",
+      : "Local chat admission capacity is busy for this structurally heavy request; upstream provider routing was not attempted. Retry shortly.",
     undefined,
     {
       type: historyLimit ? "payload_too_large" : "server_error",

--- a/tests/unit/probe-10268-structural-503.test.ts
+++ b/tests/unit/probe-10268-structural-503.test.ts
@@ -14,7 +14,10 @@ import {
 } from "../../src/shared/middleware/chatBodyAdmission.ts";
 
 function heavyBody() {
-  const messages = Array.from({ length: 201 }, (_, i) => ({ role: "user", content: `prompt ${i}` }));
+  const messages = Array.from({ length: 201 }, (_, i) => ({
+    role: "user",
+    content: `prompt ${i}`,
+  }));
   const tools = Array.from({ length: 32 }, (_, i) => ({
     type: "function",
     function: { name: `tool_${i}`, description: "a".repeat(64), parameters: { type: "object" } },
@@ -40,7 +43,10 @@ test("#10268: 2nd structurally-heavy agent request is rejected 503 (chat_admissi
     const res = (second as { admit: false; response: Response }).response;
     assert.equal(res.status, 503); // client is shown HTTP 503
     const body = await res.json();
-    assert.equal(body.error?.message, "Structurally heavy chat request capacity is busy; retry shortly.");
+    assert.equal(
+      body.error?.message,
+      "Local chat admission capacity is busy for this structurally heavy request; upstream provider routing was not attempted. Retry shortly."
+    );
     assert.equal(body.error?.code, "chat_admission_busy");
     assert.equal(body.error?.reason, "structure_limit");
   } finally {


### PR DESCRIPTION
## Problem

A locally generated `chat_admission_busy` 503 can be mistaken for an upstream provider capacity failure, even though OmniRoute rejected the request locally before provider routing was attempted.

## Change

- Clarify that the 503 comes from local chat admission.
- Explicitly state that upstream provider routing was not attempted.
- Update the existing #10268 regression assertion.

No admission behavior, HTTP status, error code, reason, or routing behavior changes.

## Verification

- #10268 focused regression: 2 passed, 0 failed.
- Targeted ESLint passed.
- `git diff --check` passed.
- Commit hooks passed.