### PR TITLE
test(free-tier): counting vs deciding regimes

### DIFF
--- a/changelog.d/maintenance/12226-free-verdict-two-regimes.md
+++ b/changelog.d/maintenance/12226-free-verdict-two-regimes.md
@@ -1,0 +1,1 @@
+- **docs(free-tier):** declare the counting vs deciding regimes for "is it free?" and guard the deciding path from DB-backed catalog resolution ([#12226](https://github.com/diegosouzapw/OmniRoute/pull/12226))

--- a/docs/reference/FREE_TIERS.md
+++ b/docs/reference/FREE_TIERS.md
@@ -1,7 +1,7 @@
 ---
 title: "Free Tiers & Free-Token Budget"
 version: 3.8.50
-lastUpdated: 2026-08-26
+lastUpdated: 2026-08-31
 ---
 
 # Free Tiers & Free-Token Budget
@@ -48,6 +48,23 @@ A 50-agent web-research pass (official docs + last-7-days news, adversarially ve
 > The detailed per-provider table further down is the **2026-06-05 snapshot**; the deltas above supersede it. The live, canonical source is the per-model catalog `open-sse/config/freeModelCatalog.ts`.
 
 ---
+
+## Two regimes — counting vs deciding
+
+OmniRoute answers "is it free?" through two regimes that intentionally read
+different sources:
+
+| Regime | Source of truth | Surfaces |
+|---|---|---|
+| **Counting / displaying** | Resolved catalog — the shipped baseline overlaid by the Radar feed (`getRadarCatalog`) | Free-tier totals, budget card, dashboards |
+| **Deciding** | Shipped catalog only (`FREE_MODEL_BUDGETS` in `open-sse/config/freeModelCatalog.data.ts`) plus the local heuristics (`:free` suffix, zero pricing, `grantsFreeAccess`) | Every consumer of `src/shared/utils/freeModels.ts`: model import, `auto/*` routing, `GET /v1/models`, and the browser previews |
+
+Counting can improve whenever a feed is available. Deciding stays on the
+release artifact, so the answer is identical in the browser and on the server,
+reproducible offline, and testable without a database. Letting the browser
+preview read one source while the server import reads another would produce a
+preview that disagrees with what happens on click — the split is kept on
+purpose.
 
 ## Methodology & caveats
 

--- a/src/shared/utils/freeModels.ts
+++ b/src/shared/utils/freeModels.ts
@@ -7,6 +7,27 @@ import { AI_MODELS } from "@/shared/constants/models";
  * Free-model detection shared between the "import only free models" connection
  * option (Add API Key modal) and the model-sync import filter.
  *
+ * Two regimes answer "is it free?", on purpose, from different sources:
+ *
+ *  - **Counting / displaying** (free-token totals, dashboards) MAY use the
+ *    resolved catalog: the shipped baseline overlaid by the Radar feed
+ *    (`getRadarCatalog` in `src/lib/radar/index.ts`). Totals are
+ *    informational and may improve when a feed is available.
+ *
+ *  - **Deciding** (is this provider/model free? should it be imported? should
+ *    `auto/*` route to it? should it appear in `GET /v1/models`?) reads ONLY
+ *    the shipped catalog `FREE_MODEL_BUDGETS`
+ *    (`open-sse/config/freeModelCatalog.data.ts`) plus the local heuristics
+ *    below. It must never reach `getRadarCatalog` / `getRadarCache`.
+ *
+ * Why deciding stays on the shipped catalog: the answer is then identical in
+ * the browser and on the server, reproducible offline from the release
+ * artifact, and unit-testable without seeding a database. This module runs in
+ * both — six `"use client"` components import it — so a DB-backed read here
+ * would also drag the SQLite driver into the client bundle. Splitting it
+ * instead (server reads the feed, browser keeps the baseline) would make the
+ * import modal's preview disagree with the import route that runs on click.
+ *
  * A provider is considered to "have free models" when it appears in the
  * documented free-tier catalog (`FREE_MODEL_BUDGETS`). A single model is
  * considered free when its id carries the OpenRouter-style `:free` suffix, when

--- a/tests/unit/free-verdict-no-radar-resolution.test.ts
+++ b/tests/unit/free-verdict-no-radar-resolution.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Two regimes answer "is this model free?", and they read different sources on
+ * purpose: counting/displaying MAY use the Radar-overlaid catalog, deciding
+ * (model import, `auto/*` routing, `GET /v1/models`, the browser previews)
+ * reads only the shipped baseline. `src/shared/utils/freeModels.ts` states the
+ * contract in its header; this test holds it on the server arc.
+ *
+ * `client-bundle-no-server-only-10692.test.ts` already holds the browser arc
+ * (every `"use client"` file must not reach server-only code). Nothing held the
+ * server arc: wiring the import route, the published catalog or the paid-model
+ * filter onto `getRadarCatalog` would make the modal's preview disagree with
+ * the import that runs on click, and no check would turn red. That is the
+ * regression class #10692 paid sixty red builds for, and whose docstring says
+ * a comment cannot fail a build.
+ *
+ * Shape mirrors #10692 deliberately, including how entries are discovered
+ * rather than hand-listed: static-import BFS, `import type` is not an edge,
+ * dynamic `import()` is not followed — both exclusions are load-bearing, a
+ * guard that cries wolf gets switched off.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** The module that answers the question: every consumer of it decides. */
+const VERDICT_MODULE = "src/shared/utils/freeModels.ts";
+
+/** DB-backed catalog resolution. Deciding must never reach these. */
+const DB_BACKED_RESOLUTION = new Set([
+  "src/lib/radar/index.ts", // getRadarCatalog
+  "src/lib/db/radar.ts", // getRadarCache & co, reads radar_*_cache
+]);
+
+/**
+ * Surfaces allowed to both decide and resolve. Empty on purpose: an entry here
+ * is a documented exception carrying its reason, not a reason to widen the rule.
+ */
+const COUNTING_SURFACES = new Set<string>([]);
+
+const SCAN_ROOTS = ["src", "open-sse"];
+const EXTENSIONS = [".ts", ".tsx", ".mts", ".js"];
+const SKIP_DIRS = new Set(["node_modules", ".git", ".build", "dist", ".next", ".claude"]);
+
+/** Resolve an import specifier to a repo-relative file, or null when it leaves the repo. */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  let base: string;
+  if (specifier.startsWith(".")) {
+    base = path.resolve(path.dirname(path.join(REPO_ROOT, fromFile)), specifier);
+  } else if (specifier.startsWith("@omniroute/open-sse")) {
+    const rest = specifier.slice("@omniroute/open-sse".length).replace(/^\//, "");
+    base = path.join(REPO_ROOT, "open-sse", rest);
+  } else if (specifier.startsWith("@omniroute/browser-pool")) {
+    const rest = specifier.slice("@omniroute/browser-pool".length).replace(/^\//, "");
+    base = path.join(REPO_ROOT, "packages/browser-pool/src", rest);
+  } else if (specifier.startsWith("@/")) {
+    base = path.join(REPO_ROOT, "src", specifier.slice(2));
+  } else {
+    return null;
+  }
+  const candidates = [
+    base,
+    ...EXTENSIONS.map((ext) => base + ext),
+    ...EXTENSIONS.map((ext) => path.join(base, `index${ext}`)),
+  ];
+  if (base.endsWith(".js")) candidates.push(base.replace(/\.js$/, ".ts"));
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return path.relative(REPO_ROOT, candidate);
+    }
+  }
+  return null;
+}
+
+function isTypeOnlyClause(clause: string): boolean {
+  if (/^\s*type\s/.test(clause)) return true;
+  const named = /\{([^}]*)\}/.exec(clause);
+  if (!named) return false;
+  const outsideBraces = clause.replace(/\{[^}]*\}/, "").trim();
+  if (/[A-Za-z_$*]/.test(outsideBraces)) return false;
+  const bindings = named[1].split(",").map((b) => b.trim()).filter(Boolean);
+  return bindings.length > 0 && bindings.every((b) => /^type\s/.test(b));
+}
+
+/** Value-carrying static specifiers only. */
+function staticSpecifiers(source: string): string[] {
+  const withoutDynamic = source.replace(/\bimport\s*\(/g, "__dynamic_import__(");
+  const out: string[] = [];
+  for (const pattern of [
+    /(?:^|\n)\s*import\s+([^;'"]*)from\s*["']([^"']+)["']/g,
+    /(?:^|\n)\s*export\s+([^;'"]*)from\s*["']([^"']+)["']/g,
+  ]) {
+    for (const match of withoutDynamic.matchAll(pattern)) {
+      if (isTypeOnlyClause(match[1])) continue;
+      out.push(match[2]);
+    }
+  }
+  for (const match of withoutDynamic.matchAll(/(?:^|\n)\s*import\s*["']([^"']+)["']/g)) {
+    out.push(match[1]);
+  }
+  return out;
+}
+
+const sourceCache = new Map<string, string>();
+function readSource(file: string): string {
+  const cached = sourceCache.get(file);
+  if (cached !== undefined) return cached;
+  const absolute = path.join(REPO_ROOT, file);
+  const source = fs.existsSync(absolute) ? fs.readFileSync(absolute, "utf8") : "";
+  sourceCache.set(file, source);
+  return source;
+}
+
+const specifierCache = new Map<string, string[]>();
+function edgesOf(file: string): string[] {
+  const cached = specifierCache.get(file);
+  if (cached) return cached;
+  const edges = staticSpecifiers(readSource(file))
+    .map((specifier) => resolveSpecifier(file, specifier))
+    .filter((resolved): resolved is string => resolved !== null);
+  specifierCache.set(file, edges);
+  return edges;
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  const absolute = path.join(REPO_ROOT, dir);
+  if (!fs.existsSync(absolute)) return acc;
+  for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+    const relative = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(relative, acc);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      acc.push(relative);
+    }
+  }
+  return acc;
+}
+
+function isClientComponent(file: string): boolean {
+  return /^\s*["']use client["']/m.test(readSource(file).slice(0, 200));
+}
+
+/**
+ * Every file that decides: the verdict module, plus every non-`"use client"`
+ * file importing it. Client components are skipped because the browser arc is
+ * already guarded by #10692 — not because they are outside the contract.
+ */
+function decidingEntries(): string[] {
+  const found = [VERDICT_MODULE];
+  for (const root of SCAN_ROOTS) {
+    for (const file of walk(root)) {
+      if (file === VERDICT_MODULE) continue;
+      if (COUNTING_SURFACES.has(file) || isClientComponent(file)) continue;
+      if (edgesOf(file).includes(VERDICT_MODULE)) found.push(file);
+    }
+  }
+  return found.sort();
+}
+
+/** BFS over static imports; returns the first path reaching DB-backed resolution. */
+function findResolutionPath(entry: string): string[] | null {
+  const seen = new Set<string>([entry]);
+  const queue: Array<string[]> = [[entry]];
+  while (queue.length > 0) {
+    const trail = queue.shift()!;
+    for (const resolved of edgesOf(trail[trail.length - 1])) {
+      if (seen.has(resolved)) continue;
+      if (DB_BACKED_RESOLUTION.has(resolved)) return [...trail, resolved];
+      seen.add(resolved);
+      queue.push([...trail, resolved]);
+    }
+  }
+  return null;
+}
+
+test("no deciding surface statically reaches DB-backed catalog resolution", () => {
+  const entries = decidingEntries();
+
+  // The scan found the repo's deciding surfaces, not an empty set.
+  assert.ok(
+    entries.includes("open-sse/services/autoCombo/paidModelFilter.ts"),
+    `discovery looks broken: found ${entries.length} entries, without the paid-model filter`
+  );
+
+  const offenders = entries
+    .map((entry) => ({ entry, trail: findResolutionPath(entry) }))
+    .filter((row): row is { entry: string; trail: string[] } => row.trail !== null);
+
+  assert.deepEqual(
+    offenders.map((o) => o.entry),
+    [],
+    "Deciding must read the shipped catalog only:\n" +
+      offenders.map((o) => `  ${o.trail.join("\n    → ")}`).join("\n\n") +
+      "\nBreak the chain — deciding reads FREE_MODEL_BUDGETS, never getRadarCatalog. " +
+      "If the wiring is intentional, update the contract header on freeModels.ts and " +
+      "FREE_TIERS.md first; if the file counts as well as decides, add it to " +
+      "COUNTING_SURFACES with the reason."
+  );
+});
+
+test("the guard detects a real crossing: the counting surface is caught", () => {
+  // Positive control on a real file. The free-tier summary route is a counting
+  // surface: it legitimately imports getRadarCatalog. Running the same walk over
+  // it proves the parser, the alias resolution and the BFS all still work — a
+  // check that only ever passes is a check that has stopped looking.
+  const countingSurface = "src/app/api/free-tier/summary/route.ts";
+  const trail = findResolutionPath(countingSurface);
+
+  assert.ok(
+    trail !== null,
+    `${countingSurface} resolves the Radar catalog, so the walk must reach it — ` +
+      "if this fails, the import scan or the alias resolution is broken, not the code"
+  );
+  assert.ok(
+    trail.some((step) => DB_BACKED_RESOLUTION.has(step)),
+    `expected a DB-backed resolution module in the trail, got ${trail.join(" → ")}`
+  );
+  assert.ok(
+    !decidingEntries().includes(countingSurface),
+    `${countingSurface} counts, it does not decide — it must not be a deciding entry`
+  );
+});


### PR DESCRIPTION
## Summary

OmniRoute answers "is it free?" two ways and it matters which source each one reads.

Counting (how many free tokens you have, the dashboard) can use the live Radar overlay — if there's fresher data, great, the total gets better. Deciding — should this model be imported, routed via `auto/*`, or listed in `GET /v1/models`? — can't. It has to read the same catalog in the browser and on the server, so the Add API Key modal doesn't show you one thing and then import another when you click.

That's already what the code does: `src/shared/utils/freeModels.ts:6` described *how* it decides, never *why* it stays off the live source. This just writes it down — header on that file plus a short reference in `docs/reference/FREE_TIERS.md`. Nothing about routing or pricing changes.

## Related Issues

- Related to #10692

## Validation

Choose the change type and focused loop from the [Contribution Golden Path] (../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite, Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: other — guard only (touched `src/` header is docs-only, 0 logic) — treated as `other`; no provider/routing/UI/DB behavior changes
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward — `release/v3.8.51`, highest `release/v*`, no base-red open
- [x] Production-code changes include a new or updated automated test in this PR — `tests/unit/free-verdict-no-radar-resolution.test.ts` (no logic changed in `src/shared/utils/freeModels.ts`, header comment only)

Focused run:

- `npm run typecheck:core` — PASS
- `npm run check:cycles` — PASS
- `npm run check:docs-all` — PASS (`check:doc-links` 147 docs / 860 links, `check:fabricated-docs` 0)
- `npm run check:docs-symbols` — PASS
- `npx eslint` on touched files — 0 new errors
- `node --import tsx/esm --test tests/unit/free-verdict-no-radar-resolution.test.ts tests/unit/client-bundle-no-server-only-10692.test.ts` — 3/3 PASS

## Tests Added Or Updated

- `tests/unit/free-verdict-no-radar-resolution.test.ts` — new. It finds every non-`"use client"` file that imports `freeModels.ts` (not a hand-kept list) and walks the static import graph to make sure none reaches `getRadarCatalog` / `getRadarCache`. Same shape as the browser-arc guard from #10692, so `import type` and dynamic `import()` don't count. The `free-tier/summary` route is used as a positive control — it *should* reach Radar, which proves the walk would actually notice a leak.

## Coverage Notes

Only docs changed in `src/` — 21 lines of comment on `src/shared/utils/freeModels.ts`, no logic. The guard was checked both ways: injecting a `getRadarCatalog` edge makes it fail with the exact trail (`freeModels.ts → src/lib/radar/index.ts`), removing it brings it back green.

## Reviewer Notes

I know this looks like a guard for something nobody's tried to wire up yet — fair concern. Reason I'd still keep it: we already paid for this exact kind of slip once (#10692, sixty builds red because a `"use client"` file reached server code through a long import chain), and the fix there was the same kind of test. This one costs no production code, just a file you can delete without breaking the docs. If it feels early, dropping `free-verdict-no-radar-resolution.test.ts` leaves the rest complete.

