### PR TITLE
[URGENT] fix(dev): stop runtime loader warning floods

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -74,6 +74,35 @@ function isNextIntlExtractorDynamicImportWarning(warning) {
   );
 }
 
+const IGNORED_INFRASTRUCTURE_BUILD_DEPENDENCY_MODULES = [
+  "/node_modules/fumadocs-mdx/dist/load-from-file-",
+  "/node_modules/next-intl/dist/esm/production/extractor/format/index.js",
+];
+
+function isKnownInfrastructureBuildDependencyWarning(args) {
+  const message = args
+    .filter((value) => typeof value === "string")
+    .join(" ")
+    .replaceAll("\\", "/");
+  return (
+    message.includes("webpack.FileSystemInfo") &&
+    message.includes("for build dependencies failed at 'import(") &&
+    message.includes("incorrect cache invalidation") &&
+    IGNORED_INFRASTRUCTURE_BUILD_DEPENDENCY_MODULES.some((modulePath) =>
+      message.includes(modulePath)
+    )
+  );
+}
+
+function filterKnownInfrastructureWarnings(baseConsole) {
+  const filteredConsole = Object.create(baseConsole);
+  filteredConsole.warn = (...args) => {
+    if (isKnownInfrastructureBuildDependencyWarning(args)) return;
+    Reflect.apply(baseConsole.warn, baseConsole, args);
+  };
+  return filteredConsole;
+}
+
 // OMNIROUTE_BUILD_PROFILE=minimal physically removes four optional privileged
 // modules (MITM cert install, Zed keychain import, Cloud Sync, 9router
 // installer) from the built bundle by aliasing them to feature-disabled stubs.
@@ -132,9 +161,7 @@ const nextConfig = {
     // instead of keeping the old generation in control. Falls back to a
     // value that is unique per build run when git is absent (CI tarball).
     NEXT_PUBLIC_SW_BUILD_ID:
-      process.env.OMNIROUTE_SW_BUILD_ID ||
-      process.env.SOURCE_VERSION ||
-      `${Date.now()}`,
+      process.env.OMNIROUTE_SW_BUILD_ID || process.env.SOURCE_VERSION || `${Date.now()}`,
   },
   distDir,
   // Turbopack config: redirect native modules to stubs at build time
@@ -344,6 +371,11 @@ const nextConfig = {
       ...(config.ignoreWarnings || []),
       isNextIntlExtractorDynamicImportWarning,
     ];
+    const infrastructureLogging = config.infrastructureLogging || {};
+    config.infrastructureLogging = {
+      ...infrastructureLogging,
+      console: filterKnownInfrastructureWarnings(infrastructureLogging.console || console),
+    };
     const nextDefaultSplitChunks = config.optimization?.splitChunks;
     config.optimization = config.optimization || {};
     config.optimization.splitChunks = {

--- a/open-sse/services/browserPool.ts
+++ b/open-sse/services/browserPool.ts
@@ -123,7 +123,10 @@ async function resolveCloakLaunch(): Promise<((opts: unknown) => Promise<Browser
   if (state.cloakLaunchResolved) return state.cloakLaunch;
   state.cloakLaunchResolved = true;
   try {
-    const mod = (await import(getCloakbrowserModuleId())) as unknown as {
+    const mod = (await import(
+      /* webpackIgnore: true */
+      getCloakbrowserModuleId()
+    )) as unknown as {
       launch?: (opts: unknown) => Promise<Browser>;
     };
     state.cloakLaunch = mod.launch ?? null;

--- a/open-sse/utils/tlsClient.ts
+++ b/open-sse/utils/tlsClient.ts
@@ -1,8 +1,8 @@
-import { createRequire } from "module";
 import { createHash } from "node:crypto";
+import * as nodeModule from "node:module";
 import { getTlsClientTimeoutConfig } from "@/shared/utils/runtimeTimeouts";
 
-const runtimeRequire = createRequire(import.meta.url);
+const runtimeRequire = nodeModule.createRequire(import.meta.url);
 
 function loadRuntimeModule(moduleName: string): unknown {
   // Keep the specifier dynamic. Turbopack rewrites a literal createRequire call
@@ -55,14 +55,7 @@ function getProxyFromEnv(): string | undefined {
 }
 
 export type WreqBodyInit =
-  | string
-  | ArrayBuffer
-  | ArrayBufferView
-  | URLSearchParams
-  | Buffer
-  | Blob
-  | FormData
-  | null;
+  string | ArrayBuffer | ArrayBufferView | URLSearchParams | Buffer | Blob | FormData | null;
 
 export interface TlsFetchOptions {
   method?: string;
@@ -251,14 +244,10 @@ export class TlsClient {
   private readonly _libraryAvailable: boolean;
   private readonly maxSessions: number;
 
-  constructor(
-    createSessionFn: CreateSessionFn | null = createSession,
-    maxSessions = 128
-  ) {
+  constructor(createSessionFn: CreateSessionFn | null = createSession, maxSessions = 128) {
     this.createSessionFn = createSessionFn;
     this._libraryAvailable = !!createSessionFn;
-    this.maxSessions =
-      Number.isInteger(maxSessions) && maxSessions > 0 ? maxSessions : 128;
+    this.maxSessions = Number.isInteger(maxSessions) && maxSessions > 0 ? maxSessions : 128;
   }
 
   /** Library availability only. Per-session circuit state is enforced inside fetch(). */
@@ -445,10 +434,7 @@ export class TlsClient {
     return true;
   }
 
-  private recordFailure(
-    key = this.getDefaultSessionKey(),
-    sessionHadCookies = false
-  ): void {
+  private recordFailure(key = this.getDefaultSessionKey(), sessionHadCookies = false): void {
     const state = this.circuits.get(key) ?? {
       failureCount: 0,
       cooldownMs: this.baseCooldownMs,
@@ -501,10 +487,7 @@ export class TlsClient {
     if (state) state.halfOpenInFlight = false;
   }
 
-  private async getSession(
-    resolvedProxy: string | null,
-    key: string
-  ): Promise<WreqSession | null> {
+  private async getSession(resolvedProxy: string | null, key: string): Promise<WreqSession | null> {
     const cached = this.sessions.get(key);
     if (cached) {
       this.pendingEvictions.delete(key);
@@ -526,10 +509,7 @@ export class TlsClient {
 
     const creating = Reflect.apply(this.createSessionFn, undefined, [sessionOpts])
       .then(async (session) => {
-        if (
-          globalEpoch !== this.globalSessionEpoch ||
-          sessionEpoch !== this.getSessionEpoch(key)
-        ) {
+        if (globalEpoch !== this.globalSessionEpoch || sessionEpoch !== this.getSessionEpoch(key)) {
           await this.closeSession(session);
           throw new Error("wreq-js session invalidated");
         }
@@ -615,8 +595,7 @@ export class TlsClient {
       return response;
     } catch (err) {
       const isCallerAbort = options.signal?.aborted === true;
-      const sessionHadCookies =
-        !isCallerAbort && this.hasSessionCookies(session, url);
+      const sessionHadCookies = !isCallerAbort && this.hasSessionCookies(session, url);
       releaseSession();
       if (isCallerAbort) {
         this.releaseHalfOpen(key);
@@ -664,14 +643,11 @@ export class TlsClient {
     const circuitOpenUntil = state?.circuitOpenUntil ?? 0;
     const circuitTripped = state?.circuitTripped ?? false;
     return {
-      available:
-        this._libraryAvailable &&
-        (!circuitTripped || Date.now() >= circuitOpenUntil),
+      available: this._libraryAvailable && (!circuitTripped || Date.now() >= circuitOpenUntil),
       circuitTripped,
       failureCount: state?.failureCount ?? 0,
       circuitOpenUntil,
-      coolDownRemainingMs:
-        circuitOpenUntil > 0 ? Math.max(0, circuitOpenUntil - Date.now()) : 0,
+      coolDownRemainingMs: circuitOpenUntil > 0 ? Math.max(0, circuitOpenUntil - Date.now()) : 0,
     };
   }
 }

--- a/packages/browser-pool/src/services/browserPool.ts
+++ b/packages/browser-pool/src/services/browserPool.ts
@@ -102,7 +102,10 @@ async function resolveCloakLaunch(): Promise<((opts: unknown) => Promise<Browser
   if (state.cloakLaunchResolved) return state.cloakLaunch;
   state.cloakLaunchResolved = true;
   try {
-    const mod = (await import(getCloakbrowserModuleId())) as unknown as {
+    const mod = (await import(
+      /* webpackIgnore: true */
+      getCloakbrowserModuleId()
+    )) as unknown as {
       launch?: (opts: unknown) => Promise<Browser>;
     };
     state.cloakLaunch = mod.launch ?? null;

--- a/src/lib/db/adapters/runtimeRequire.ts
+++ b/src/lib/db/adapters/runtimeRequire.ts
@@ -8,12 +8,12 @@
  * where `require` is unavailable; the `createRequire(import.meta.url)` fallback
  * handles those callers.
  */
-import { createRequire } from "node:module";
+import * as nodeModule from "node:module";
 
 declare const require: NodeRequire | undefined;
 
 function esmRuntimeRequire(specifier: string): unknown {
-  return createRequire(import.meta.url)(specifier);
+  return nodeModule.createRequire(import.meta.url)(specifier);
 }
 
 export function runtimeRequire(specifier: string): unknown {

--- a/src/lib/machineToken.ts
+++ b/src/lib/machineToken.ts
@@ -1,12 +1,12 @@
 import { createHash, createHmac } from "node:crypto";
-import { createRequire } from "node:module";
+import * as nodeModule from "node:module";
 
 let machineIdSync: (original?: boolean) => string;
 try {
   // Anchor runtime resolution to the process entrypoint. Turbopack rewrites
   // createRequire(import.meta.url) into an in-bundle resolver, which cannot load
   // external CommonJS packages from the installed standalone node_modules tree.
-  const runtimeRequire = createRequire(process.argv[1] || process.cwd());
+  const runtimeRequire = nodeModule.createRequire(process.argv[1] || process.cwd());
   const mod = runtimeRequire("node-machine-id");
   machineIdSync = mod.machineIdSync || mod.default?.machineIdSync;
 } catch {

--- a/tests/unit/browser-pool-optional-import.test.ts
+++ b/tests/unit/browser-pool-optional-import.test.ts
@@ -6,22 +6,32 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../..");
-const BROWSER_POOL_PATH = path.join(REPO_ROOT, "open-sse/services/browserPool.ts");
+const BROWSER_POOL_PATHS = [
+  path.join(REPO_ROOT, "open-sse/services/browserPool.ts"),
+  path.join(REPO_ROOT, "packages/browser-pool/src/services/browserPool.ts"),
+];
 
 describe("browserPool optional cloakbrowser import", () => {
   it("keeps cloakbrowser out of static dynamic import resolution", () => {
-    const source = readFileSync(BROWSER_POOL_PATH, "utf8");
+    for (const browserPoolPath of BROWSER_POOL_PATHS) {
+      const source = readFileSync(browserPoolPath, "utf8");
 
-    assert.equal(
-      /import\(\s*["']cloakbrowser["']\s*\)/.test(source),
-      false,
-      "cloakbrowser must remain runtime-optional; static dynamic import triggers Turbopack resolution"
-    );
-    assert.match(
-      source,
-      /Turbopack resolve it during route compilation/,
-      "the computed import rationale should stay documented near the helper"
-    );
-    assert.match(source, /return \["cloak", "browser"\]\.join\(""\);/);
+      assert.equal(
+        /import\(\s*["']cloakbrowser["']\s*\)/.test(source),
+        false,
+        "cloakbrowser must remain runtime-optional; static dynamic import triggers Turbopack resolution"
+      );
+      assert.match(
+        source,
+        /Turbopack resolve it during route compilation/,
+        "the computed import rationale should stay documented near the helper"
+      );
+      assert.match(source, /return \["cloak", "browser"\]\.join\(""\);/);
+      assert.match(
+        source,
+        /\/\* webpackIgnore: true \*\//,
+        "Webpack must leave the optional runtime import unresolved"
+      );
+    }
   });
 });

--- a/tests/unit/next-config.test.ts
+++ b/tests/unit/next-config.test.ts
@@ -257,8 +257,14 @@ test("manager.stub.ts exports every name statically imported from @/mitm/manager
 
 test("next-intl webpack hook preserves caller config and filters known extractor warnings", async () => {
   const { default: nextConfig } = await loadNextConfig("webpack-pass-through");
+  const infrastructureWarnings: unknown[][] = [];
+  const infrastructureConsole = Object.create(console) as Console;
+  infrastructureConsole.warn = (...args: unknown[]) => {
+    infrastructureWarnings.push(args);
+  };
   const config: any = {
     context: process.cwd(),
+    infrastructureLogging: { console: infrastructureConsole },
     plugins: [],
     externals: [],
     ignoreWarnings: [],
@@ -313,6 +319,22 @@ test("next-intl webpack hook preserves caller config and filters known extractor
     config.ignoreWarnings[0]({ message: "Critical dependency: request is expression" }),
     false
   );
+  config.infrastructureLogging.console.warn(
+    "[webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo] Parsing of " +
+      "/repo/node_modules/fumadocs-mdx/dist/load-from-file-test.js for build dependencies " +
+      "failed at 'import(url.href)'.\nBuild dependencies behind this expression are ignored " +
+      "and might cause incorrect cache invalidation."
+  );
+  config.infrastructureLogging.console.warn(
+    "[webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo] Parsing of " +
+      "/repo/node_modules/next-intl/dist/esm/production/extractor/format/index.js for build " +
+      "dependencies failed at 'import(t)'.\nBuild dependencies behind this expression are ignored " +
+      "and might cause incorrect cache invalidation."
+  );
+  assert.deepEqual(infrastructureWarnings, []);
+
+  config.infrastructureLogging.console.warn("unrelated infrastructure warning");
+  assert.deepEqual(infrastructureWarnings, [["unrelated infrastructure warning"]]);
 });
 
 test("turbopack.ignoreIssue suppresses the agentSkills over-bundling warning (#6582)", async () => {

--- a/tests/unit/webpack-create-require-warning.test.ts
+++ b/tests/unit/webpack-create-require-warning.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ModuleKind, ScriptTarget, transpileModule } from "typescript";
+
+interface WebpackStats {
+  hasErrors(): boolean;
+  toJson(options: Record<string, boolean>): {
+    errors?: unknown[];
+    warnings?: unknown[];
+  };
+}
+
+interface WebpackCompiler {
+  run(callback: (error?: Error | null, stats?: WebpackStats) => void): void;
+  close(callback: (error?: Error | null) => void): void;
+}
+
+type WebpackFactory = (config: Record<string, unknown>) => WebpackCompiler;
+
+const require = createRequire(import.meta.url);
+const { webpack } = require("next/dist/compiled/webpack/webpack") as {
+  webpack: WebpackFactory;
+};
+
+function renderIssue(issue: unknown): string {
+  if (typeof issue === "string") return issue;
+  if (issue && typeof issue === "object" && "message" in issue) {
+    return String((issue as { message: unknown }).message);
+  }
+  return JSON.stringify(issue);
+}
+
+async function compileRuntimeRequireModules(): Promise<string[]> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-webpack-create-require-"));
+  const sourcePaths = [
+    "src/lib/db/adapters/runtimeRequire.ts",
+    "src/lib/machineToken.ts",
+    "open-sse/services/browserPool.ts",
+    "open-sse/utils/tlsClient.ts",
+  ] as const;
+  const entries: Record<string, string> = {};
+
+  try {
+    for (const sourcePath of sourcePaths) {
+      const source = fs.readFileSync(path.resolve(sourcePath), "utf8");
+      const output = transpileModule(source, {
+        compilerOptions: {
+          module: ModuleKind.ESNext,
+          target: ScriptTarget.ES2022,
+        },
+        fileName: sourcePath,
+      }).outputText;
+      const entryName = path.basename(sourcePath, ".ts");
+      // Next's server compilation feeds SWC output through javascript/auto.
+      // A .mjs fixture would take Webpack's javascript/esm parser path and miss
+      // the createRequire warning emitted by the production build.
+      const entryPath = path.join(tempDir, `${entryName}.js`);
+      fs.writeFileSync(entryPath, output, "utf8");
+      entries[entryName] = entryPath;
+    }
+
+    const compiler = webpack({
+      devtool: false,
+      entry: entries,
+      externals: [
+        "../../src/lib/db/proxies",
+        "@/shared/utils/runtimeTimeouts",
+        "better-sqlite3",
+        "bun:sqlite",
+        "sql.js",
+        "sqlite-vec",
+        "playwright",
+        "wreq-js",
+      ],
+      externalsPresets: { node: true },
+      mode: "development",
+      module: {
+        parser: {
+          javascript: {
+            createRequire: true,
+          },
+        },
+        rules: [
+          {
+            test: /\.js$/,
+            type: "javascript/auto",
+          },
+        ],
+      },
+      output: {
+        filename: "[name].js",
+        path: path.join(tempDir, "dist"),
+      },
+      target: "node",
+    });
+
+    const stats = await new Promise<WebpackStats>((resolve, reject) => {
+      compiler.run((error, result) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (!result) {
+          reject(new Error("Webpack completed without stats"));
+          return;
+        }
+        resolve(result);
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      compiler.close((error) => (error ? reject(error) : resolve()));
+    });
+
+    const report = stats.toJson({ all: false, errors: true, warnings: true });
+    assert.equal(stats.hasErrors(), false, (report.errors ?? []).map(renderIssue).join("\n"));
+    return (report.warnings ?? []).map(renderIssue);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+}
+
+test("Webpack does not warn while parsing optional runtime modules", async () => {
+  const warnings = await compileRuntimeRequireModules();
+  const runtimeModuleWarnings = warnings.filter(
+    (warning) =>
+      warning.includes("module.createRequire failed parsing argument") ||
+      warning.includes("Critical dependency: the request of a dependency is an expression") ||
+      warning.includes(
+        "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted"
+      )
+  );
+
+  assert.deepEqual(runtimeModuleWarnings, []);
+});


### PR DESCRIPTION
## Summary

- stop Webpack from repeatedly parsing four runtime-only dependency loaders as statically traceable application dependencies
- keep optional `cloakbrowser`, native DB drivers, `node-machine-id`, and `wreq-js` resolved at runtime without changing their fallback behavior
- add a real Webpack parser regression test that compiles the affected modules and rejects the exact warning classes
- narrowly filter only the known Fumadocs/next-intl infrastructure-cache diagnostics while preserving unrelated warnings

Follow-up to #12074. This repairs one exact runtime dependency boundary required by Phase 5; it does not claim that the wider Turbopack qualification work is complete.

## The warning flood

The captured log excerpt contained **13 repeated warning blocks from only four root causes**. The same module warning was printed again for every server entry that reached it through the shared authorization, instrumentation, provider, health, or settings graph:

- `browserPool.ts`: 3 blocks
- `tlsClient.ts`: 3 blocks
- `runtimeRequire.ts`: 3 blocks
- `machineToken.ts`: 4 blocks

Representative excerpts:

```text
⚠ ./open-sse/services/browserPool.ts
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
./open-sse/services/browserPool.ts
./open-sse/services/browserBackedChat.ts
./open-sse/executors/zai-web.ts
./src/lib/providers/validation/webCookie.ts
./src/lib/providers/validation.ts
./src/lib/vncSession/service.ts
./src/lib/gracefulShutdown.ts
./src/server/authz/pipeline.ts
```

The same `browserPool.ts` warning then appeared again through both `src/instrumentation-node.ts` and `src/app/api/providers/route.ts`.

```text
./open-sse/utils/tlsClient.ts
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

Import trace for requested module:
./open-sse/utils/tlsClient.ts
./open-sse/utils/proxyFetch.ts
./src/domain/quotaCache.ts
./src/sse/services/auth.ts
./src/server/authz/policies/clientApi.ts
./src/server/authz/pipeline.ts
```

The same `tlsClient.ts` warning was repeated through `src/instrumentation-node.ts` and `src/app/api/providers/route.ts`.

```text
./src/lib/db/adapters/runtimeRequire.ts
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
./src/lib/db/adapters/runtimeRequire.ts
./src/lib/db/adapters/driverFactory.ts
./src/lib/db/core.ts
./src/lib/gracefulShutdown.ts
./src/server/authz/pipeline.ts
```

It was repeated again through `src/instrumentation-node.ts` and `/api/health/ping`.

```text
./src/lib/machineToken.ts
module.createRequire failed parsing argument.

Import trace for requested module:
./src/lib/machineToken.ts
./src/server/authz/peerContext.ts
./src/server/authz/policies/management.ts
./src/server/authz/pipeline.ts
```

Webpack emitted the `machineToken.ts` diagnostic twice through the auth pipeline and twice more through `/api/settings`.

This is not harmless cosmetic noise: every repeated trace records another server entry reaching a runtime-only loader that Webpack attempted to analyze. It obscures real diagnostics and adds avoidable parser/logging work to the already oversized development graph tracked by #12074.

## Root cause and fix

- `browserPool.ts` intentionally computes the optional `cloakbrowser` specifier. `/* webpackIgnore: true */` now tells Webpack to preserve that runtime import instead of attempting context-module discovery. The core and package copies remain aligned.
- `tlsClient.ts`, `runtimeRequire.ts`, and `machineToken.ts` now access `createRequire` through the `node:module` namespace. Runtime semantics stay unchanged, while Webpack no longer applies its fragile direct-`createRequire` argument parser to these expressions.
- The infrastructure logger filter matches only the exact Fumadocs/next-intl cache-analysis diagnostic and forwards every unrelated infrastructure warning.

No blanket `ignoreWarnings` rule was added for `Critical dependency` or `module.createRequire`.

## Validation

- `tests/unit/webpack-create-require-warning.test.ts` compiles all four affected modules with Next.js's bundled Webpack and observes **zero** matching runtime-loader warnings
- focused bundler/config tests: **14/14 passed**
- `npm run typecheck:core` — passed
- `git diff --check` — passed

The regression fixture rejects all three observed warning forms:

```text
module.createRequire failed parsing argument
Critical dependency: the request of a dependency is an expression
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
```
