### PR TITLE
Revert "docs: recommend gstack for AI-assisted workflows" (#11770)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,16 +68,3 @@ Before cutting a branch or opening a PR, run the base-green check (`AGENTS.md` �
 "Base-green check"; project skills reference it as `.agents/skills/_shared/base-green.md`). A PR
 opened while the base tip is red must carry `⚠️ base-red inherited: #<issue>` in its body. To
 drain an accumulated red state (base tip + red PRs), use the `/sweep-reds` skill.
-
-## gstack (recommended)
-
-This project uses [gstack](https://github.com/garrytan/gstack) for AI-assisted workflows.
-Install it for the best experience:
-
-```bash
-git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
-cd ~/.claude/skills/gstack && ./setup --team
-```
-
-Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
-Use /browse for all web browsing. Use ~/.claude/skills/gstack/... for gstack file paths.


### PR DESCRIPTION
Reverts #11770 — **process reason, not a judgement on the tool**.

#11770 carried the `manual-review` label, which the maintainer applies to changes he wants to decide on personally. It was merged in a batch sweep whose filter only excluded `deferred-v3.8.52` and `needs-info`, so the `manual-review` flag was not honoured. That is my mistake, and this revert puts the decision back where it belongs.

The change added a "gstack (recommended)" section to `CLAUDE.md` instructing contributors to clone `garrytan/gstack` and run `./setup --team` into `~/.claude/skills/`. For the record: the repository is legitimate and widely used (~130k stars), so there is no security concern being raised here. But recommending a third-party tool inside the project's own AI-assistant instruction file — including a command that installs it into the contributor's environment — is an editorial call for the maintainer to make, not something to land as a routine docs merge.

@santosraju99-hub sorry for the churn — your PR was not rejected on merit. Once @diegosouzapw decides, it can be relanded as-is with a single click; nothing about the content needs to change.

Refs #11770