### PR TITLE
docs(agents): protected-surface merge rule — operator approval for agent-instruction files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,6 +494,12 @@ Why this matters: fixing bug A while opening bug B is worse than not fixing at a
   pipeline, and A2A skills.
 - Do not close a contributor pull request after using its code; merge it through GitHub so
   the contributor receives credit.
+- **Never merge a PR that touches an agent-instruction surface without explicit operator
+  approval** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `llm.txt` (+ mirrors) and
+  `skills/**/SKILL.md` are executed as authority by every AI session; a merged instruction
+  compromises every future agent run. Check with `gh pr diff <N> --name-only` before any
+  merge. Incident record: PR #11770 (2026-09-01) told agents to execute a third-party
+  setup script and was swept in by a merge campaign; reverted in #12249.
 
 ---
 


### PR DESCRIPTION
Hardening do incidente gstack (PR #11770 → revert #12249, 2026-09-01), **aprovado pelo dono** ("sim ajuste esse erro do incidente").

Adiciona ao **Review focus** do AGENTS.md a regra: **PR que toca superfície de instrução de agente** (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `llm.txt` + espelhos, `skills/**/SKILL.md`) **fica em HOLD até aprovação explícita do operador por PR** — CI valida código, não intenção de superfície de instrução. Verificação: `gh pr diff <N> --name-only` antes de qualquer merge.

A regra operacional completa + registro do incidente já está nas 6 skills de campanha que mergeiam (`.agents/skills/_shared/protected-surfaces.md`, commit `3f9cec7` no repo .agents — privado, fora deste diff).

*(Meta: esta PR toca o próprio AGENTS.md — a aprovação do dono para ela está registrada na conversa desta sessão.)*