### PR TITLE
fix(quality): base-red pair — stryker tap registration + turn-pin suites aligned to the window gate

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -39,7 +39,9 @@
   "incremental": true,
   "incrementalFile": "reports/mutation/stryker-incremental.json",
   "testRunner": "tap",
-  "plugins": ["@stryker-mutator/tap-runner"],
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ],
   "tap": {
     "testFiles": [
       "tests/unit/10085-compatible-generic-vs-uuid-credential.test.ts",
@@ -406,7 +408,9 @@
       "tests/unit/felo-web-runtime-block.test.ts",
       "tests/unit/microsoft-designer-web-runtime-block.test.ts",
       "tests/unit/qwen-web-runtime-block.test.ts",
-      "tests/unit/tunnel-routes-error-sanitization.test.ts"
+      "tests/unit/tunnel-routes-error-sanitization.test.ts",
+      "tests/unit/native-codex-turn-pin-10379.test.ts",
+      "tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts"
     ],
     "nodeArgs": [
       "--import",
@@ -515,7 +519,11 @@
     ".worktrees",
     ".stryker-tmp"
   ],
-  "reporters": ["progress", "html", "json"],
+  "reporters": [
+    "progress",
+    "html",
+    "json"
+  ],
   "htmlReporter": {
     "fileName": "reports/mutation/mutation.html"
   },

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -39,9 +39,7 @@
   "incremental": true,
   "incrementalFile": "reports/mutation/stryker-incremental.json",
   "testRunner": "tap",
-  "plugins": [
-    "@stryker-mutator/tap-runner"
-  ],
+  "plugins": ["@stryker-mutator/tap-runner"],
   "tap": {
     "testFiles": [
       "tests/unit/10085-compatible-generic-vs-uuid-credential.test.ts",
@@ -519,11 +517,7 @@
     ".worktrees",
     ".stryker-tmp"
   ],
-  "reporters": [
-    "progress",
-    "html",
-    "json"
-  ],
+  "reporters": ["progress", "html", "json"],
   "htmlReporter": {
     "fileName": "reports/mutation/mutation.html"
   },

--- a/tests/unit/native-codex-turn-pin-10379.test.ts
+++ b/tests/unit/native-codex-turn-pin-10379.test.ts
@@ -20,6 +20,7 @@ const { getCircuitBreaker, resetAllCircuitBreakers } =
   await import("../../src/shared/utils/circuitBreaker.ts");
 const { recordProviderCooldown, clearCooldownState } =
   await import("../../open-sse/services/providerCooldownTracker.ts");
+const { PROVIDER_PROFILES } = await import("../../open-sse/config/constants.ts");
 const { resolveResilienceSettings } = await import("../../src/lib/resilience/settings.ts");
 
 const BODY = {
@@ -222,9 +223,13 @@ test("isPinnedTargetModelScopedUnusable distinguishes model lockout from provide
     false
   );
 
-  // Reset breaker, test provider cooldown
+  // Reset breaker, test provider cooldown. Since #12247 the global provider
+  // cooldown honors the PROVIDER_PROFILES window gate: the provider only counts
+  // as cooling after providerFailureThreshold failures inside the window.
   cb.reset();
-  recordProviderCooldown("antigravity", undefined, resilienceSettings);
+  for (let i = 0; i < PROVIDER_PROFILES.oauth.providerFailureThreshold; i++) {
+    recordProviderCooldown("antigravity", undefined, resilienceSettings);
+  }
   assert.equal(
     await isPinnedTargetModelScopedUnusable({
       target,

--- a/tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts
+++ b/tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts
@@ -19,6 +19,7 @@ const {
 } = await import("../../open-sse/services/combo/nativeCodexTurnPin.ts");
 const { recordProviderCooldown, isProviderInCooldown, clearCooldownState } =
   await import("../../open-sse/services/providerCooldownTracker.ts");
+const { PROVIDER_PROFILES } = await import("../../open-sse/config/constants.ts");
 const { getCircuitBreaker, resetAllCircuitBreakers } =
   await import("../../src/shared/utils/circuitBreaker.ts");
 const { resolveResilienceSettings } = await import("../../src/lib/resilience/settings.ts");
@@ -403,7 +404,11 @@ describe("Native Codex Turn Pin model-scoped fallback", () => {
       allCombos: null,
     });
 
-    recordProviderCooldown("antigravity", undefined, settings);
+    // #12247: the window gate needs providerFailureThreshold failures before
+    // the whole provider counts as cooling.
+    for (let i = 0; i < PROVIDER_PROFILES.oauth.providerFailureThreshold; i++) {
+      recordProviderCooldown("antigravity", undefined, settings);
+    }
     assert.equal(isProviderInCooldown("antigravity", undefined, settings), true);
 
     const attempted: string[] = [];


### PR DESCRIPTION
**Base-red fix** (PR própria, conforme a regra base-green — nunca na feature branch que herda o red). Dois reds da base, mesma origem: a onda de merges da campanha (#10379) entrou DEPOIS do fork da #12247, criando um conflito semântico invisível ao git.

1. **`check:mutation-test-coverage --strict` vermelho**: as suítes `native-codex-turn-pin-*` cobrem o turn-pin e `circuitBreaker.ts` mas não estavam em `tap.testFiles` do `stryker.conf.json`. Registradas → **✓ No drift (4728 test files)**.
2. **Unit shards 3/4 e 4/4 vermelhos no tip**: as mesmas suítes montavam "provider em cooldown global" com **1** `recordProviderCooldown` — o contrato pré-#12247. Com o window gate (decisão do dono), o provider só conta como cooling após `providerFailureThreshold` falhas na janela; o setup agora faz o loop até o threshold do perfil (mesmo alinhamento da suíte legada do tracker na #12247).

**Varredura de irmãos** (lição da auditoria — red vem em cluster): as 7 suítes que tocam `recordProviderCooldown` passam **60/60** na árvore tip+fix.