### PR TITLE
fix(ci): register native-codex-turn-pin tests in stryker tap.testFiles (base-red)

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -283,6 +283,8 @@
       "tests/unit/model-lockout-decay.test.ts",
       "tests/unit/model-lockout-exact-cooldown-cap.test.ts",
       "tests/unit/model-lockout-max-cooldown.test.ts",
+      "tests/unit/native-codex-turn-pin-10379.test.ts",
+      "tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts",
       "tests/unit/no-memory-header.test.ts",
       "tests/unit/noauth-autocombo-lockout-7623.test.ts",
       "tests/unit/ollama-404-model-lockout-11071.test.ts",


### PR DESCRIPTION
Base-red drain for `release/v3.8.51`: the tip fails `check:mutation-test-coverage --strict` (job **Fast Quality Gates**) for every PR.

## Root cause

#12240 and #10573 added `tests/unit/native-codex-turn-pin-10379.test.ts` and `tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts`, which cover the mutated modules `open-sse/services/accountFallback.ts` and `src/shared/utils/circuitBreaker.ts` — but neither was registered in `stryker.conf.json` → `tap.testFiles`, which that gate enforces in strict mode. First exposed by the docs-only PR #12250 (its only red is this gate; reproduced locally on the pristine tip).

## Fix

Register both files in `tap.testFiles` (alphabetical position). Local run now: `✓ No drift — every covering unit test is listed in tap.testFiles` across 4728 test files / 31 mutated modules. Their mutant kills now also count in the nightly mutation run.

Config-only change to a quality-gate manifest — no production code.