### PR TITLE
[URGENT] fix(dev): qualify Turbopack runtime boundaries (phase 5)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -286,6 +286,9 @@ const nextConfig = {
       // (better-sqlite3 → node:sqlite → sql.js). Next traces sql-wasm.js but can
       // omit the runtime sql-wasm.wasm asset from the standalone bundle.
       "./node_modules/sql.js/dist/sql-wasm.wasm",
+      // tiktoken is server-externalized below so Node selects its CommonJS entry.
+      // That entry reads the tokenizer WASM beside itself at runtime.
+      "./node_modules/tiktoken/tiktoken_bg.wasm",
     ],
   },
   outputFileTracingExcludes: {
@@ -339,6 +342,10 @@ const nextConfig = {
     "tough-cookie",
     "@ngrok/ngrok",
     "@huggingface/transformers",
+    // The ESM entry imports tiktoken_bg.wasm as a module. Turbopack can compile
+    // that graph but omits the runtime asset, making provider routes fail during
+    // module evaluation. Keep Node's CommonJS loader and colocated WASM intact.
+    "tiktoken",
     // copilot-m365-web.ts imports 'ws' as a client-side WebSocket. When bundled,
     // ws cannot resolve its 'bufferutil' native addon (frame masking) and throws
     // TypeError: b.mask is not a function on the first outgoing frame, causing

--- a/src/lib/db/adapters/runtimeRequire.ts
+++ b/src/lib/db/adapters/runtimeRequire.ts
@@ -5,13 +5,17 @@
  * The standalone server is emitted as CommonJS chunks and externalizes the
  * native database packages. Keep those requests as static `require()` calls so
  * webpack preserves the external boundary. Development and tests run as ESM,
- * where `require` is unavailable; the `createRequire(import.meta.url)` fallback
- * handles those callers.
+ * where `require` is unavailable; the fallback anchors resolution to the real
+ * process entrypoint so Turbopack cannot replace it with an in-bundle resolver.
  */
 import * as nodeModule from "node:module";
 
+const esmRequire = nodeModule.createRequire(process.argv[1] || process.cwd());
+
 function esmRuntimeRequire(specifier: string): unknown {
-  return nodeModule.createRequire(import.meta.url)(specifier);
+  // Reflect keeps the optional request dynamic. A direct call is rewritten by
+  // Turbopack and fails at runtime as "Cannot find module as expression is too dynamic".
+  return Reflect.apply(esmRequire, undefined, [specifier]);
 }
 
 export function runtimeRequire(specifier: string): unknown {

--- a/tests/unit/turbopack-runtime-boundaries-12074.test.ts
+++ b/tests/unit/turbopack-runtime-boundaries-12074.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.cwd();
+
+test("#12074: Turbopack keeps the WASM-backed tiktoken package external", async () => {
+  const configUrl = `${pathToFileURL(path.join(repoRoot, "next.config.mjs")).href}?phase5=${Date.now()}`;
+  const { default: nextConfig } = await import(configUrl);
+
+  assert.ok(
+    new Set(nextConfig.serverExternalPackages).has("tiktoken"),
+    "bundling tiktoken selects its ESM WASM entry and makes /api/providers fail with Missing tiktoken_bg.wasm"
+  );
+  assert.ok(
+    nextConfig.outputFileTracingIncludes?.["/*"]?.includes(
+      "./node_modules/tiktoken/tiktoken_bg.wasm"
+    ),
+    "the external tokenizer must retain its runtime WASM asset in standalone output"
+  );
+});
+
+test("#12074: the ESM SQLite loader stays outside Turbopack's module resolver", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "src/lib/db/adapters/runtimeRequire.ts"),
+    "utf8"
+  );
+
+  assert.doesNotMatch(source, /createRequire\(import\.meta\.url\)/);
+  assert.match(source, /createRequire\(process\.argv\[1\] \|\| process\.cwd\(\)\)/);
+  assert.match(source, /Reflect\.apply\(/);
+});


### PR DESCRIPTION
## Summary

Completes the implementation side of Phase 5 for #12074 by fixing the two exact runtime boundaries reproduced on the post-Phase-4b release head:

- keep `tiktoken` external so Node selects its CommonJS loader instead of Turbopack bundling the ESM `tiktoken_bg.wasm` import;
- retain `tiktoken_bg.wasm` in standalone output tracing;
- anchor the optional SQLite loader to the real process entrypoint and invoke it through `Reflect.apply`, preventing Turbopack from rewriting the dynamic request into its in-bundle resolver.

This does not add warning ignores or mix provider/dependency/catalog work into the phase.

## Reproduction and result

Qualification was repeated from an empty Next cache and isolated SQLite directory on release head `2e17161ea` with `OMNIROUTE_USE_TURBOPACK=1`.

Before this patch:

- both `better-sqlite3` and `node:sqlite` failed with `Cannot find module as expression is too dynamic`, forcing the `sql.js` fallback;
- `/api/providers` returned 500 because `tiktoken_bg.wasm` was missing during module evaluation;
- the same failures were repeated across provider/settings/instrumentation import paths.

After this patch:

- cold start reached the Turbopack listening state in **4.350 s**;
- the runtime selected **better-sqlite3** directly;
- the targeted log scan found no dynamic-module error, missing tiktoken WASM, Turbopack panic, `createRequire` parse failure, critical-dependency flood, or `MaxListenersExceededWarning`;
- graceful SIGINT drained requests, checkpointed SQLite, stopped the ChatGPT Web runtime and logger resources, and exited cleanly.

| Route | Status | First request |
| --- | ---: | ---: |
| `/dashboard/providers` | 200 | 3.174 s |
| `/api/health/ping` | 200 | 0.373 s |
| `/api/providers` | 200 | 0.600 s |
| `/api/settings` | 200 | 0.218 s |
| `/api/v1/models` | 200 | 1.534 s |

Three real provider-page source edits/restoration returned 200 in **59 ms / 61 ms / 77 ms**. RSS moved from **4,805,408 KiB** after the first HMR graph activation to **4,822,272 KiB** after the third cycle (+16,864 KiB), rather than showing the previous runaway pattern.

After the representative routes and three HMR cycles:

- RSS: **4,822,272 KiB**
- total dev output: **2,389,080 KiB**
- cache: **1,337,708 KiB**
- server output: **934,828 KiB**
- static output: **115,092 KiB**

All temporary source probes were restored. The isolated DBs and approximately 4.6 GiB of before/after generated caches were deleted after measurement.

## Automated validation

- focused Node regression set: **41/41 passed**
- Vitest: **50 files, 463/463 passed** (serial workers with an isolated DB)
- `npm run typecheck:core`
- Prettier, ESLint, `git diff --check`, pre-commit documentation sync and quality gates

I also started the full `npm run test:unit` command. It did not complete: the pre-existing `warmupScheduler/circuitBreakerFactory*` group remained pending for more than five minutes and blocked the remaining runner queue, so I interrupted it rather than claiming a full-suite pass. The changed DB/config tests and both non-overlapping focused/Vitest suites above are green.

## Scope

- `next.config.mjs`
- `src/lib/db/adapters/runtimeRequire.ts`
- `tests/unit/turbopack-runtime-boundaries-12074.test.ts`
