### PR TITLE
[URGENT] test(ci): align turn pins with provider cooldown window gate

### DIFF
--- a/tests/unit/native-codex-turn-pin-10379.test.ts
+++ b/tests/unit/native-codex-turn-pin-10379.test.ts
@@ -20,6 +20,7 @@ const { getCircuitBreaker, resetAllCircuitBreakers } =
   await import("../../src/shared/utils/circuitBreaker.ts");
 const { recordProviderCooldown, clearCooldownState } =
   await import("../../open-sse/services/providerCooldownTracker.ts");
+const { PROVIDER_PROFILES } = await import("../../open-sse/config/constants.ts");
 const { resolveResilienceSettings } = await import("../../src/lib/resilience/settings.ts");
 
 const BODY = {
@@ -224,7 +225,9 @@ test("isPinnedTargetModelScopedUnusable distinguishes model lockout from provide
 
   // Reset breaker, test provider cooldown
   cb.reset();
-  recordProviderCooldown("antigravity", undefined, resilienceSettings);
+  for (let i = 0; i < PROVIDER_PROFILES.oauth.providerFailureThreshold; i += 1) {
+    recordProviderCooldown("antigravity", undefined, resilienceSettings);
+  }
   assert.equal(
     await isPinnedTargetModelScopedUnusable({
       target,

--- a/tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts
+++ b/tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts
@@ -19,6 +19,7 @@ const {
 } = await import("../../open-sse/services/combo/nativeCodexTurnPin.ts");
 const { recordProviderCooldown, isProviderInCooldown, clearCooldownState } =
   await import("../../open-sse/services/providerCooldownTracker.ts");
+const { PROVIDER_PROFILES } = await import("../../open-sse/config/constants.ts");
 const { getCircuitBreaker, resetAllCircuitBreakers } =
   await import("../../src/shared/utils/circuitBreaker.ts");
 const { resolveResilienceSettings } = await import("../../src/lib/resilience/settings.ts");
@@ -403,7 +404,9 @@ describe("Native Codex Turn Pin model-scoped fallback", () => {
       allCombos: null,
     });
 
-    recordProviderCooldown("antigravity", undefined, settings);
+    for (let i = 0; i < PROVIDER_PROFILES.oauth.providerFailureThreshold; i += 1) {
+      recordProviderCooldown("antigravity", undefined, settings);
+    }
     assert.equal(isProviderInCooldown("antigravity", undefined, settings), true);
 
     const attempted: string[] = [];


### PR DESCRIPTION
## Summary

Aligns two stale native Codex turn-pin tests with the provider-level cooldown contract introduced by #12247.

#12247 changed whole-provider cooldowns from “one recorded failure starts cooldown” to the `PROVIDER_PROFILES` window gate: the provider only enters cooldown after `providerFailureThreshold` failures within `providerFailureWindowMs`. The production implementation and its new focused tests are correct, but two pre-existing turn-pin tests still recorded only one Antigravity failure before asserting that the whole provider was cooling.

That drift currently fails release fast-path shards 3/4 and 4/4, including on #12258:

- `native-codex-turn-pin-10379.test.ts` expected a provider outage to mask an existing model lockout, but had not actually tripped provider cooldown.
- `native-codex-turn-pin-model-scoped-fallback.test.ts` asserted `isProviderInCooldown(...) === true` after only one provider-level failure.

## Change

Both tests now record `PROVIDER_PROFILES.oauth.providerFailureThreshold` failures for Antigravity before exercising their global-cooldown assertions.

This is test-only. No production routing, cooldown, provider, dependency, or bundler behavior changes.

## Validation

Before the fix, the exact two files reproduced **2 failures / 15 tests** locally, matching CI.

After the fix, the turn-pin files plus #12247's provider cooldown suites pass:

- **38/38 tests passed**
- Prettier passed
- ESLint passed
- `git diff --check` passed

Unblocks the inherited release checks on #12258.
