### PR TITLE
chore(quality): register native-codex turn-pin tests in stryker tap.testFiles

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -283,6 +283,8 @@
       "tests/unit/model-lockout-decay.test.ts",
       "tests/unit/model-lockout-exact-cooldown-cap.test.ts",
       "tests/unit/model-lockout-max-cooldown.test.ts",
+      "tests/unit/native-codex-turn-pin-10379.test.ts",
+      "tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts",
       "tests/unit/no-memory-header.test.ts",
       "tests/unit/noauth-autocombo-lockout-7623.test.ts",
       "tests/unit/ollama-404-model-lockout-11071.test.ts",


### PR DESCRIPTION
check:mutation-test-coverage --strict fails on every PR targeting release/v3.8.51 since the native-codex turn-pin tests landed covering mutated modules without tap.testFiles registration (same drift class as #12170). Registers both files so their mutant kills count. Gate: red before, green after (evidence in commit).