### PR TITLE
chore(quality): dedupe tap.testFiles entries from racing base-red fixes

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -65,7 +65,6 @@
       "tests/unit/aihorde-optional-api-key.test.ts",
       "tests/unit/agentrouter-error-rules.test.ts",
       "tests/unit/agentrouter-lock-scope-10334.test.ts",
-      "tests/unit/aihorde-optional-api-key.test.ts",
       "tests/unit/alibaba-free-tier-exhaustion.test.ts",
       "tests/unit/anthropic-thinking-signature-recovery.test.ts",
       "tests/unit/antigravity-429-quota-cooldown.test.ts",
@@ -339,8 +338,6 @@
       "tests/unit/repro-9486.test.ts",
       "tests/unit/repro-9630-combo-false-503.test.ts",
       "tests/unit/repro-antigravity-404-family-cooldown-hijack.test.ts",
-      "tests/unit/repro-combo-persisted-cooldown-preskip.test.ts",
-      "tests/unit/repro-glm-iso-reset-24h-cap.test.ts",
       "tests/unit/resilience-connections.test.ts",
       "tests/unit/responses-handler.test.ts",
       "tests/unit/responses-passthrough-openai-compatible.test.ts",
@@ -359,7 +356,6 @@
       "tests/unit/router-strategies.test.ts",
       "tests/unit/routing-adaptive-e2e.test.ts",
       "tests/unit/rule12-error-sanitization-sweep.test.ts",
-      "tests/unit/search-432-plan-limit-cooldown.test.ts",
       "tests/unit/serial/combo-health-autopilot.test.ts",
       "tests/unit/serial/combo-quota-share-cooldown-wait-timing.test.ts",
       "tests/unit/serial/combo-strategy-fallbacks-half-open-timing.test.ts",
@@ -408,9 +404,7 @@
       "tests/unit/felo-web-runtime-block.test.ts",
       "tests/unit/microsoft-designer-web-runtime-block.test.ts",
       "tests/unit/qwen-web-runtime-block.test.ts",
-      "tests/unit/tunnel-routes-error-sanitization.test.ts",
-      "tests/unit/native-codex-turn-pin-10379.test.ts",
-      "tests/unit/native-codex-turn-pin-model-scoped-fallback.test.ts"
+      "tests/unit/tunnel-routes-error-sanitization.test.ts"
     ],
     "nodeArgs": [
       "--import",


### PR DESCRIPTION
Sessões paralelas corrigindo o mesmo drift de tap.testFiles (#12170/#12255/#12263) registraram 6 entradas em duplicata (aihorde, 2× turn-pin, 2× repro-*, search-432). Remove as duplicatas — 363 entradas únicas; `check:mutation-test-coverage --strict` verde local no conteúdo exato pós-merge. Higiene de 1 arquivo, sem mudança de comportamento.