### PR TITLE
feat(providers): add CLOVA Studio embedding v2

### DIFF
--- a/open-sse/config/embeddingRegistry.ts
+++ b/open-sse/config/embeddingRegistry.ts
@@ -10,6 +10,7 @@
 
 export type EmbeddingModality = "text" | "image" | "audio" | "video" | "document";
 export type StructuredEmbeddingProtocol = "jina-v1" | "gemini-embed-content";
+export type SingleTextEmbeddingProtocol = "clova-v2";
 
 export interface EmbeddingModel {
   id: string;
@@ -34,6 +35,13 @@ export interface EmbeddingProvider {
   models: EmbeddingModel[];
   /** Provider-native serializer required for canonical structured input. */
   structuredInputProtocol?: StructuredEmbeddingProtocol;
+  /**
+   * Set when the endpoint embeds exactly ONE text per request (`{"text": …}` →
+   * one vector) instead of accepting OpenAI's `input` array. A batched
+   * `/v1/embeddings` call is then fanned out into N sequential upstream calls and
+   * merged back into a single OpenAI list response.
+   */
+  singleTextProtocol?: SingleTextEmbeddingProtocol;
 }
 
 export interface EmbeddingProviderNodeRow {
@@ -295,6 +303,18 @@ export const EMBEDDING_PROVIDERS: Record<string, EmbeddingProvider> = {
       { id: "voyage-finance-2", name: "Voyage Finance 2", dimensions: 1024 },
       { id: "voyage-law-2", name: "Voyage Law 2", dimensions: 1024 },
     ],
+  },
+
+  // Naver CLOVA Studio — embedding v2. The endpoint takes a single `{"text": …}`
+  // body and returns `{status, result:{embedding:[…1024 floats], inputTokens}}`,
+  // with no batch array and no `usage` object, hence `singleTextProtocol`.
+  "clova-studio": {
+    id: "clova-studio",
+    baseUrl: "https://clovastudio.stream.ntruss.com/v1/api-tools/embedding/v2",
+    authType: "apikey",
+    authHeader: "bearer",
+    singleTextProtocol: "clova-v2",
+    models: [{ id: "clova-embedding-v2", name: "CLOVA Embedding v2", dimensions: 1024 }],
   },
 
   "jina-ai": {

--- a/open-sse/handlers/embeddingStructuredInput.ts
+++ b/open-sse/handlers/embeddingStructuredInput.ts
@@ -128,10 +128,7 @@ export async function prepareJinaMixedEmbeddingInput(
       continue;
     }
     if (isCanonicalEmbeddingItem(item)) {
-      const [translated] = await prepareJinaInput(
-        [item as EmbeddingMultimodalItem],
-        fetchMedia
-      );
+      const [translated] = await prepareJinaInput([item as EmbeddingMultimodalItem], fetchMedia);
       out.push(translated);
       continue;
     }
@@ -163,7 +160,9 @@ function embeddingValues(entry: unknown): unknown[] {
   return Array.isArray(values) ? values : [];
 }
 
-function normalizeGeminiEmbedContentResponse(data: Record<string, unknown>): Record<string, unknown> {
+function normalizeGeminiEmbedContentResponse(
+  data: Record<string, unknown>
+): Record<string, unknown> {
   return {
     object: "list",
     data: [{ object: "embedding", embedding: embeddingValues(data.embedding), index: 0 }],
@@ -263,10 +262,7 @@ async function itemToGeminiContent(
     return { parts: [await jinaDocToGeminiPart(item, fetchMedia)] };
   }
   if (isCanonicalEmbeddingItem(item)) {
-    const [part] = await prepareGeminiParts(
-      [item as EmbeddingMultimodalItem],
-      fetchMedia
-    );
+    const [part] = await prepareGeminiParts([item as EmbeddingMultimodalItem], fetchMedia);
     return { parts: [part] };
   }
   throw new Error("Unsupported Gemini embedding input item");
@@ -345,4 +341,42 @@ export async function prepareStructuredEmbeddingRequest(
     };
   }
   throw new Error(`Provider ${provider.id} has no structured embedding input translator`);
+}
+
+/**
+ * Normalize a single-text embedding endpoint's response into OpenAI's
+ * `/v1/embeddings` list shape.
+ *
+ * CLOVA Studio's embedding v2 answers:
+ *
+ * ```
+ * {"status":{"code":"20000","message":"OK"},
+ *  "result":{"embedding":[…1024 floats],"inputTokens":4}}
+ * ```
+ *
+ * There is no `data[]` and no `usage` object, so both are synthesized. `index` is
+ * left at 0 here — the batching loop in `embeddings.ts` rewrites it to the
+ * caller's position before the response is returned.
+ *
+ * A non-20000 status or malformed success envelope throws so an HTTP-200 error
+ * envelope can never be exposed as an empty successful embedding response.
+ */
+export function normalizeClovaEmbeddingV2Response(
+  rawData: Record<string, unknown>
+): Record<string, unknown> {
+  const statusCode = (rawData?.status as { code?: unknown } | undefined)?.code;
+  if (String(statusCode) !== "20000") {
+    throw new Error("CLOVA Studio embedding v2 returned an unsuccessful status");
+  }
+
+  const result = (rawData?.result ?? {}) as Record<string, unknown>;
+  if (!Array.isArray(result.embedding)) {
+    throw new Error("CLOVA Studio embedding v2 response is missing an embedding vector");
+  }
+
+  const inputTokens = Number(result.inputTokens) || 0;
+  return {
+    data: [{ object: "embedding", index: 0, embedding: result.embedding }],
+    usage: { prompt_tokens: inputTokens, total_tokens: inputTokens },
+  };
 }

--- a/open-sse/handlers/embeddings.ts
+++ b/open-sse/handlers/embeddings.ts
@@ -32,6 +32,7 @@ import { stripTrailingSlashes } from "../utils/urlSanitize.ts";
 import { fetchRemoteImage } from "@/shared/network/remoteImageFetch";
 import {
   hasStructuredEmbeddingInput,
+  normalizeClovaEmbeddingV2Response,
   prepareJinaMixedEmbeddingInput,
   prepareStructuredEmbeddingRequest,
 } from "./embeddingStructuredInput.ts";
@@ -405,14 +406,102 @@ export async function handleEmbedding({
       }
     }
 
-    // Log provider request
-    reqLogger.logTargetRequest(upstreamUrl, headers, upstreamBody);
+    // Providers whose endpoint embeds exactly one text per request need a batched
+    // `/v1/embeddings` call fanned out into sequential upstream calls. A parallel
+    // burst would race the connection's own rate limit before the batch can finish.
+    const singleTexts =
+      providerConfig.singleTextProtocol === "clova-v2"
+        ? Array.isArray(body.input)
+          ? body.input
+          : [body.input]
+        : null;
 
-    const response = await fetch(upstreamUrl, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(upstreamBody),
-    });
+    if (
+      singleTexts &&
+      (singleTexts.length === 0 ||
+        singleTexts.some((item) => typeof item !== "string" || item.trim().length === 0))
+    ) {
+      return {
+        success: false,
+        status: 400,
+        error: "CLOVA Studio embedding v2 accepts non-empty text strings only",
+      };
+    }
+
+    if (singleTexts && body.encoding_format === "base64") {
+      return {
+        success: false,
+        status: 400,
+        error: "CLOVA Studio embedding v2 supports float encoding only",
+      };
+    }
+
+    if (singleTexts && body.dimensions !== undefined && Number(body.dimensions) !== 1024) {
+      return {
+        success: false,
+        status: 400,
+        error: "CLOVA Studio embedding v2 has a fixed dimension of 1024",
+      };
+    }
+
+    let response: Response;
+    if (singleTexts) {
+      const collectedEmbeddings: Array<Record<string, unknown>> = [];
+      const collectedUsage = { prompt_tokens: 0, total_tokens: 0 };
+      let failedResponse: Response | null = null;
+      let lastHeaders = new Headers();
+
+      for (const text of singleTexts as string[]) {
+        const requestBody = { text };
+        reqLogger.logTargetRequest(upstreamUrl, headers, requestBody);
+
+        const itemResponse = await fetch(upstreamUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(requestBody),
+        });
+        lastHeaders = itemResponse.headers;
+        if (!itemResponse.ok) {
+          failedResponse = itemResponse;
+          break;
+        }
+
+        const rawData = (await itemResponse.json()) as Record<string, unknown>;
+        const parsed = normalizeClovaEmbeddingV2Response(rawData) as {
+          data?: unknown;
+          usage?: { prompt_tokens?: number; total_tokens?: number };
+        };
+        if (!Array.isArray(parsed.data)) {
+          throw new Error("CLOVA Studio embedding v2 returned an invalid data list");
+        }
+        for (const item of parsed.data) {
+          flattenSingleRowEmbedding(item);
+          if (!item || typeof item !== "object") {
+            throw new Error("CLOVA Studio embedding v2 returned an invalid embedding item");
+          }
+          (item as { index?: number }).index = collectedEmbeddings.length;
+          collectedEmbeddings.push(item as Record<string, unknown>);
+        }
+        collectedUsage.prompt_tokens +=
+          parsed.usage?.prompt_tokens || parsed.usage?.total_tokens || 0;
+        collectedUsage.total_tokens +=
+          parsed.usage?.total_tokens || parsed.usage?.prompt_tokens || 0;
+      }
+
+      response =
+        failedResponse ??
+        new Response(JSON.stringify({ data: collectedEmbeddings, usage: collectedUsage }), {
+          status: 200,
+          headers: lastHeaders,
+        });
+    } else {
+      reqLogger.logTargetRequest(upstreamUrl, headers, upstreamBody);
+      response = await fetch(upstreamUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(upstreamBody),
+      });
+    }
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -544,7 +633,8 @@ export async function handleEmbedding({
           model: model || undefined,
           cost: {
             tokens: data.usage?.prompt_tokens || data.usage?.total_tokens || 0,
-            requests: 1,
+            // A fanned-out batch is N upstream requests, not one.
+            requests: singleTexts?.length ?? 1,
           },
         });
       } catch {

--- a/tests/unit/embedding-clova-v2.test.ts
+++ b/tests/unit/embedding-clova-v2.test.ts
@@ -1,0 +1,258 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Naver CLOVA Studio embedding v2.
+//
+// The endpoint embeds exactly ONE text per request (`{"text": …}` → one vector)
+// and answers `{status, result:{embedding:[…1024 floats], inputTokens}}`, so a
+// batched `/v1/embeddings` call has to be fanned out into N upstream calls and
+// merged back into OpenAI's list shape.
+//
+// Live-verified against the API on 2026-09-01: 1024 dimensions, ~100ms per call,
+// and an empty string is rejected with `40004 Text empty`.
+
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-clova-embeddings-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.SQLITE_FILE = join(TEST_DATA_DIR, "storage.sqlite");
+
+const registry = await import("../../open-sse/config/embeddingRegistry.ts");
+const { normalizeClovaEmbeddingV2Response } =
+  await import("../../open-sse/handlers/embeddingStructuredInput.ts");
+const { handleEmbedding } = await import("../../open-sse/handlers/embeddings.ts");
+const { resetDbInstance } = await import("../../src/lib/db/core.ts");
+
+test.after(async () => {
+  // handleEmbedding records call logs asynchronously; let those writes settle
+  // before closing the singleton so a late write cannot reopen the test DB.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  resetDbInstance();
+});
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+test("clova embedding v2 is registered with the single-text protocol", () => {
+  const provider = registry.getEmbeddingProvider("clova-studio");
+  assert.ok(provider, "clova-studio must be an embedding provider");
+  assert.equal(provider.baseUrl, "https://clovastudio.stream.ntruss.com/v1/api-tools/embedding/v2");
+  assert.equal(provider.singleTextProtocol, "clova-v2");
+  assert.equal(provider.authType, "apikey");
+  assert.equal(provider.authHeader, "bearer");
+  assert.deepEqual(provider.models, [
+    { id: "clova-embedding-v2", name: "CLOVA Embedding v2", dimensions: 1024 },
+  ]);
+});
+
+test("clova embedding v2 resolves its model and dimension", () => {
+  assert.deepEqual(registry.parseEmbeddingModel("clova-studio/clova-embedding-v2"), {
+    provider: "clova-studio",
+    model: "clova-embedding-v2",
+  });
+  assert.equal(registry.getEmbeddingDimension("clova-studio/clova-embedding-v2"), 1024);
+});
+
+// ---------------------------------------------------------------------------
+// Response normalisation
+// ---------------------------------------------------------------------------
+
+test("a success envelope is normalised into OpenAI list shape", () => {
+  const normalized = normalizeClovaEmbeddingV2Response({
+    status: { code: "20000", message: "OK" },
+    result: { embedding: [0.1, -0.2, 0.3], inputTokens: 4 },
+  });
+  assert.deepEqual(normalized, {
+    data: [{ object: "embedding", index: 0, embedding: [0.1, -0.2, 0.3] }],
+    usage: { prompt_tokens: 4, total_tokens: 4 },
+  });
+});
+
+test("a failure envelope is rejected instead of becoming an empty success", () => {
+  assert.throws(
+    () =>
+      normalizeClovaEmbeddingV2Response({
+        status: { code: "40004", message: "Text empty" },
+      }),
+    /unsuccessful status/
+  );
+});
+
+test("a payload without an embedding vector is rejected", () => {
+  assert.throws(
+    () =>
+      normalizeClovaEmbeddingV2Response({
+        status: { code: "20000" },
+        result: { inputTokens: 0 },
+      }),
+    /missing an embedding vector/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Batch fan-out through the real handler
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+function mockClova(calls: Array<Record<string, unknown>>): void {
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    calls.push(JSON.parse(String(init.body)));
+    const text = String((calls[calls.length - 1] as { text?: string }).text ?? "");
+    return new Response(
+      JSON.stringify({
+        status: { code: "20000", message: "OK" },
+        result: { embedding: [text.length, 1, 2], inputTokens: text.length },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }) as typeof fetch;
+}
+
+function mockClovaEnvelope(
+  calls: Array<Record<string, unknown>>,
+  envelope: Record<string, unknown>
+): void {
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    calls.push(JSON.parse(String(init.body)));
+    return new Response(JSON.stringify(envelope), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+test("a batched input is fanned out into one upstream call per text", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  mockClova(calls);
+  try {
+    const result = await handleEmbedding({
+      body: { model: "clova-studio/clova-embedding-v2", input: ["alpha", "beta", "gamma"] },
+      credentials: { apiKey: "test-key" },
+    });
+
+    assert.equal(result.success, true, JSON.stringify(result));
+    // One request per text — the endpoint cannot batch.
+    assert.deepEqual(
+      calls.map((c) => c.text),
+      ["alpha", "beta", "gamma"]
+    );
+
+    const data = (result as { data: Record<string, unknown> }).data;
+    assert.equal(data.object, "list");
+    assert.equal(data.model, "clova-studio/clova-embedding-v2");
+    assert.equal((data.data as unknown[]).length, 3);
+    // Indexes must reflect the caller's positions, not each upstream call's 0.
+    assert.deepEqual(
+      (data.data as Array<{ index: number }>).map((d) => d.index),
+      [0, 1, 2]
+    );
+    // Token usage is summed across the fan-out.
+    assert.equal((data.usage as { prompt_tokens: number }).prompt_tokens, 5 + 4 + 5);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("an empty text rejects the batch without changing response indexes", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  mockClova(calls);
+  try {
+    const result = await handleEmbedding({
+      body: { model: "clova-studio/clova-embedding-v2", input: ["", "  ", "real"] },
+      credentials: { apiKey: "test-key" },
+    });
+    assert.equal(result.success, false);
+    assert.equal((result as { status: number }).status, 400);
+    assert.equal(calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("an all-empty input fails without calling upstream", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  mockClova(calls);
+  try {
+    const result = await handleEmbedding({
+      body: { model: "clova-studio/clova-embedding-v2", input: ["", ""] },
+      credentials: { apiKey: "test-key" },
+    });
+    assert.equal(result.success, false);
+    assert.equal((result as { status: number }).status, 400);
+    assert.equal(calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a single string input takes the fan-out path too", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  mockClova(calls);
+  try {
+    const result = await handleEmbedding({
+      body: { model: "clova-studio/clova-embedding-v2", input: "solo" },
+      credentials: { apiKey: "test-key" },
+    });
+    assert.equal(result.success, true, JSON.stringify(result));
+    assert.deepEqual(
+      calls.map((c) => c.text),
+      ["solo"]
+    );
+    assert.equal(((result as { data: Record<string, unknown> }).data.data as unknown[]).length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("an HTTP-200 CLOVA error envelope becomes a provider failure", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  mockClovaEnvelope(calls, { status: { code: "40004", message: "Text empty" } });
+  try {
+    const result = await handleEmbedding({
+      body: { model: "clova-studio/clova-embedding-v2", input: "text" },
+      credentials: { apiKey: "test-key" },
+    });
+    assert.equal(result.success, false);
+    assert.equal((result as { status: number }).status, 502);
+    assert.equal(calls.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("token-array input is rejected instead of being silently dropped", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  mockClova(calls);
+  try {
+    const result = await handleEmbedding({
+      body: { model: "clova-studio/clova-embedding-v2", input: [101, 202] },
+      credentials: { apiKey: "test-key" },
+    });
+    assert.equal(result.success, false);
+    assert.equal((result as { status: number }).status, 400);
+    assert.equal(calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("unsupported output options are rejected instead of ignored", async () => {
+  for (const extra of [{ encoding_format: "base64" }, { dimensions: 1536 }]) {
+    const calls: Array<Record<string, unknown>> = [];
+    mockClova(calls);
+    try {
+      const result = await handleEmbedding({
+        body: { model: "clova-studio/clova-embedding-v2", input: "text", ...extra },
+        credentials: { apiKey: "test-key" },
+      });
+      assert.equal(result.success, false);
+      assert.equal((result as { status: number }).status, 400);
+      assert.equal(calls.length, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- register Naver CLOVA Studio embedding v2 as a 1024-dimensional embedding model
- adapt the native one-text-per-request contract to OpenAI `/v1/embeddings` with sequential batch fan-out, stable indexes, and aggregated usage
- reject unsupported token-array, base64-encoding, and non-1024-dimension requests instead of silently changing their meaning
- treat malformed or HTTP-200 CLOVA error envelopes as provider failures

## Validation

- `node --import tsx/esm --test` — 66 focused embedding tests passed
- `npm run test:vitest` — 50 files / 463 tests passed
- `npm run typecheck:core`
- `node scripts/check/check-api-typecheck.mjs`
- scoped ESLint for all changed files
- provider consistency and known-symbol gates with isolated storage

`npm run lint` currently exits 2 on both this branch and the unchanged base because the repository has stale suppression entries; the changed files themselves pass ESLint.