### PR TITLE
fix(security): strip Qwen/Alibaba console-session cookies from provider API responses

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -379,13 +379,16 @@ export default function EditConnectionModal({
         quotaPerUnit: existingQuotaPerUnit,
         glmOrganizationId: existingGlmOrganizationId,
         glmProjectId: existingGlmProjectId,
+        // Console-session credentials are stripped from API responses
+        // (sanitizeProviderSpecificDataForResponse), so there is nothing to
+        // round-trip: start empty and let "blank keeps the stored value" hold —
+        // the quota-scraping assign skips empty fields and the PUT merge
+        // preserves keys the payload does not carry.
         ollamaCloudUsageCookie: "",
-        alibabaConsoleCookie: stringField(connection.providerSpecificData?.alibabaConsoleCookie),
-        qwenCloudCookie: stringField(connection.providerSpecificData?.qwenCloudCookie),
-        qwenCloudSecToken: stringField(connection.providerSpecificData?.qwenCloudSecToken),
-        alibabaConsoleSecToken: stringField(
-          connection.providerSpecificData?.alibabaConsoleSecToken
-        ),
+        alibabaConsoleCookie: "",
+        qwenCloudCookie: "",
+        qwenCloudSecToken: "",
+        alibabaConsoleSecToken: "",
         ccCompatibleContext1m: ccRequestDefaults.context1m,
         ccCompatibleRedactThinking: ccRequestDefaults.redactThinking,
         ccCompatibleSummarizeThinking: ccRequestDefaults.summarizeThinking,

--- a/src/lib/providers/requestDefaults.ts
+++ b/src/lib/providers/requestDefaults.ts
@@ -336,6 +336,14 @@ export function sanitizeProviderSpecificDataForResponse(value: unknown): JsonRec
   delete sanitized.ollamaCloudUsageCookie;
   delete sanitized.ollamaCloudCookie;
   delete sanitized.usageCookie;
+  // Qwen/Alibaba Token Plan console session — a browser credential for the operator's
+  // cloud-console account, same class as the ollama/opencode cookies above. The edit
+  // modal initializes these fields empty and the PUT merge preserves unsent keys, so
+  // stripping them here cannot clobber the stored values.
+  delete sanitized.qwenCloudCookie;
+  delete sanitized.qwenCloudSecToken;
+  delete sanitized.alibabaConsoleCookie;
+  delete sanitized.alibabaConsoleSecToken;
   delete sanitized.runtimeKey;
   delete sanitized.validationId;
   // System-managed Codex fingerprint seed: never exposed through the API

--- a/tests/unit/console-cookie-sanitization.test.ts
+++ b/tests/unit/console-cookie-sanitization.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Console-session cookies are credentials: the Qwen/Alibaba Token Plan cookie grants
+ * access to the operator's cloud-console account. Every sibling secret in
+ * providerSpecificData (apiKey, ollamaCloudUsageCookie, opencodeGoAuthCookie, …) is
+ * stripped from API responses by sanitizeProviderSpecificDataForResponse — but the
+ * qwen/alibaba console fields were forgotten, so GET /api/providers returned the
+ * operator's console session in the clear to any dashboard session (found in the
+ * 2026-09-01 audit of the Token Plan quota feature).
+ *
+ * The edit round-trip stays safe after stripping because it was designed for exactly
+ * this shape: the client-side assign only writes a cookie field when the form holds a
+ * non-empty value, and the PUT handler merges partially ({...existing, ...incoming}),
+ * preserving DB keys the client no longer echoes. The second test pins that contract.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitizeProviderSpecificDataForResponse } from "../../src/lib/providers/requestDefaults.ts";
+import {
+  assignQuotaScrapingProviderData,
+  EMPTY_QUOTA_SCRAPING_FIELDS,
+} from "../../src/app/(dashboard)/dashboard/providers/[id]/components/modals/quotaScrapingFieldValues.ts";
+
+const SECRET_FIELD_PATTERN = /(?:Cookie|SecToken)$/;
+
+test("every quota-scraping credential field is stripped from API responses", () => {
+  const secretFields = Object.keys(EMPTY_QUOTA_SCRAPING_FIELDS).filter((key) =>
+    SECRET_FIELD_PATTERN.test(key)
+  );
+  // The guard must actually cover the known credential fields (catches a rename).
+  for (const expected of [
+    "qwenCloudCookie",
+    "qwenCloudSecToken",
+    "alibabaConsoleCookie",
+    "alibabaConsoleSecToken",
+    "ollamaCloudUsageCookie",
+  ]) {
+    assert.ok(secretFields.includes(expected), `${expected} missing from the field inventory`);
+  }
+
+  const record: Record<string, string> = { region: "global-sg", tag: "primary" };
+  for (const key of secretFields) record[key] = `secret-value-${key}`;
+
+  const sanitized = sanitizeProviderSpecificDataForResponse(record) ?? {};
+
+  for (const key of secretFields) {
+    assert.ok(!(key in sanitized), `${key} leaked through sanitizeProviderSpecificDataForResponse`);
+  }
+  // Non-secret keys survive.
+  assert.equal(sanitized.region, "global-sg");
+  assert.equal(sanitized.tag, "primary");
+});
+
+test("edit round-trip with a blank form keeps the stored console cookie", () => {
+  // After sanitization the edit form initializes these fields empty. Saving the
+  // connection must not clobber the stored cookie: the client assign skips empty
+  // values, so the PUT payload carries no cookie key, and the server-side partial
+  // merge keeps the DB value.
+  const stored = {
+    qwenCloudCookie: "cna=abc; login_aliyunid_ticket=xyz",
+    qwenCloudSecToken: "sec-1",
+    region: "global-sg",
+  };
+
+  // Client: what the edit modal sends (existing psd is the SANITIZED view).
+  const sanitizedView = sanitizeProviderSpecificDataForResponse(stored) ?? {};
+  const incoming: Record<string, unknown> = { ...sanitizedView };
+  assignQuotaScrapingProviderData(
+    "bailian-coding-plan",
+    { ...EMPTY_QUOTA_SCRAPING_FIELDS },
+    incoming
+  );
+  assert.ok(!("qwenCloudCookie" in incoming), "blank form must not echo a cookie key");
+
+  // Server: the PUT handler's partial merge (route.ts — {...existingPsd, ...incomingPsd}).
+  const merged = { ...stored, ...incoming };
+  assert.equal(merged.qwenCloudCookie, stored.qwenCloudCookie);
+  assert.equal(merged.qwenCloudSecToken, stored.qwenCloudSecToken);
+  assert.equal(merged.region, "global-sg");
+});
+
+test("a re-pasted cookie still replaces the stored one", () => {
+  const incoming: Record<string, unknown> = {};
+  assignQuotaScrapingProviderData(
+    "qwen-cloud-token-plan",
+    { ...EMPTY_QUOTA_SCRAPING_FIELDS, qwenCloudCookie: "  fresh-cookie  " },
+    incoming
+  );
+  assert.equal(incoming.qwenCloudCookie, "fresh-cookie");
+});


### PR DESCRIPTION
## Problem

The personal Token Plan quota fetcher (#10290) authenticates with the operator's **browser
console session cookie** — a credential that grants access to the Qwen Cloud / Alibaba Cloud
console account. `sanitizeProviderSpecificDataForResponse` strips every sibling secret from
provider API responses (`apiKey`, `ollamaCloudUsageCookie`, `opencodeGoAuthCookie`,
`secretAccessKey`, …) but the four qwen/alibaba console fields were missing from the list:

- `qwenCloudCookie`, `qwenCloudSecToken`
- `alibabaConsoleCookie`, `alibabaConsoleSecToken`

So `GET /api/providers` (list and detail) returned the operator's console session **in the
clear** to any authenticated dashboard session. Found in the 2026-09-01 audit of the Token Plan
quota feature.

## Why the edit flow does not break

The edit modal silently depended on the leak: it initialized these form fields from the
round-tripped response. This PR pairs the strip with the form change — the fields now start
empty (the exact `ollamaCloudUsageCookie` pattern):

- the quota-scraping assign only writes a cookie key when the form holds a non-empty value;
- the PUT handler's `providerSpecificData` merge is partial (`{...existing, ...incoming}`),
  preserving keys the payload does not carry;
- so "Leave blank to keep the stored cookie" — which the field hints already promise — now
  holds for real, and re-pasting still replaces.

## Tests (TDD — RED first)

`tests/unit/console-cookie-sanitization.test.ts`:

1. **Generic guard**: every `*Cookie`/`*SecToken` field in the quota-scraping inventory must be
   stripped by the sanitizer (covers future fields, catches renames), non-secret keys survive —
   RED before the fix (4 fields leaked).
2. **Edit round-trip**: sanitized view + blank form → payload carries no cookie key → the PUT
   partial merge keeps the stored cookie/secToken — RED before the fix.
3. **Re-paste** still replaces the stored value.

Also green: `request-defaults-store-session`, `qwen-token-plan-cookie-field`,
`qwen-token-plan-quota-fetcher`, `qwen-token-plan-console-site` (29 sibling tests),
`typecheck:core`, focused ESLint + Prettier.