### PR TITLE
chore(quality): baseline-headroom skips generated and vendored files in the fileSize worst-file signal

### DIFF
--- a/scripts/quality/baseline-headroom.mjs
+++ b/scripts/quality/baseline-headroom.mjs
@@ -63,9 +63,19 @@ export function sumTypecheckBaseline(json) {
   return n;
 }
 
+// Files whose size is not an editable-code signal: generated modules are frozen at
+// their emitter's exact output size (≈0% headroom by construction — growth is policed
+// by re-freezing, e.g. openapi.generated.ts in #12212), and vendored code is upstream's.
+// The GATE (check:file-size) still enforces both; only the monitor skips them so the
+// nightly headroom-alert reflects files a human can actually slim.
+export function isMonitorExemptFile(file) {
+  return file.includes(".generated.") || /(^|\/)vendor\//.test(file);
+}
+
 /**
  * Frozen-file headroom: the worst (most consumed) frozen file and how many sit within
  * `warnFraction` of their cap. `locOf(file)` returns the live line count or null.
+ * Generated/vendored files are excluded (see isMonitorExemptFile).
  */
 export function fileSizeHeadroom(frozen, locOf, warnFraction = 0.1) {
   let worst = null;
@@ -73,7 +83,7 @@ export function fileSizeHeadroom(frozen, locOf, warnFraction = 0.1) {
   let over = 0;
   let measured = 0;
   for (const [file, capRaw] of Object.entries(frozen)) {
-    if (file.startsWith("_")) continue;
+    if (file.startsWith("_") || isMonitorExemptFile(file)) continue;
     const cap = Number(capRaw);
     const loc = locOf(file);
     if (!Number.isFinite(cap) || loc === null || loc === undefined) continue;

--- a/tests/unit/build/baseline-headroom.test.ts
+++ b/tests/unit/build/baseline-headroom.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   fileSizeHeadroom,
   headroomOf,
+  isMonitorExemptFile,
   renderMarkdown,
   statusOf,
   sumTypecheckBaseline,
@@ -52,6 +53,30 @@ test("fileSizeHeadroom reports the worst frozen file and the near-cap / over cou
   assert.equal(r.nearCap, 1); // a.ts within 10%
   assert.equal(r.worst?.file, "b.ts");
   assert.ok(r.worst!.headroom < 0);
+});
+
+test("fileSizeHeadroom skips generated and vendored files (monitor-only exemption)", () => {
+  assert.equal(isMonitorExemptFile("src/app/docs/lib/openapi.generated.ts"), true);
+  assert.equal(
+    isMonitorExemptFile("open-sse/vendor/codex-chatgpt-web/adapters/chatgpt-web/browser-worker.ts"),
+    true
+  );
+  assert.equal(isMonitorExemptFile("vendor/thing.ts"), true);
+  assert.equal(isMonitorExemptFile("src/lib/generatedReport.ts"), false);
+  assert.equal(isMonitorExemptFile("src/lib/vendorAdapter.ts"), false);
+
+  const frozen = {
+    "x.generated.ts": 100, // 0% headroom by construction — must not be the worst
+    "open-sse/vendor/lib/big.ts": 1000,
+    "real.ts": "1200",
+  };
+  const loc = (f: string) =>
+    ({ "x.generated.ts": 100, "open-sse/vendor/lib/big.ts": 999, "real.ts": 900 })[f] ?? null;
+  const r = fileSizeHeadroom(frozen, loc, 0.1);
+  assert.equal(r.measured, 1); // only real.ts counted
+  assert.equal(r.nearCap, 0);
+  assert.equal(r.over, 0);
+  assert.equal(r.worst?.file, "real.ts");
 });
 
 test("renderMarkdown lists every row with its status icon and flags the bad ones", () => {


### PR DESCRIPTION
## Summary

Fixes the chronic 🟡 on the `fileSize` row of the nightly **📈 Baseline headroom** report (#12149): the worst frozen file was `src/app/docs/lib/openapi.generated.ts`, which #12212 froze **at its emitter's exact output size** — ~0% headroom *by construction* (growth is policed by conscious re-freezes, never by hand-editing the module). Same class: `open-sse/vendor/**` (upstream code nobody slims by hand).

- New `isMonitorExemptFile()` in `scripts/quality/baseline-headroom.mjs`: excludes `.generated.` modules and `vendor/` paths from the **monitor's** worst/near-cap accounting.
- **The gate is untouched** — `check:file-size` still enforces caps on both classes; only the alerting stops crying wolf about files a human cannot slim.
- After the change the row points at the worst human-editable frozen file: `tests/integration/skills-pipeline.test.ts` at 4.5% — a **true** early warning (its baseline note from the 08-26 batch already requires a split rationale for any further growth; deliberately NOT relaxed here).

## Validation

- `tests/unit/build/baseline-headroom.test.ts`: +1 test (exemption matrix + integration through `fileSizeHeadroom`) — 7/7 pass.
- `node scripts/quality/baseline-headroom.mjs --only fileSize` before/after: worst `openapi.generated.ts 1346/1347 (0.1%)` → `skills-pipeline.test.ts 1156/1211 (4.5%)`, frozen-count 127 → 124 measured.

Refs #12149