### PR TITLE
fix(cache): fold the response output contract into the semantic cache signature

### DIFF
--- a/open-sse/handlers/chatCore/semanticCache.ts
+++ b/open-sse/handlers/chatCore/semanticCache.ts
@@ -2,6 +2,7 @@ import {
   generateSignature,
   getCachedResponse,
   isCacheableForRead,
+  outputContractOf,
 } from "@/lib/semanticCache";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { trackPendingRequest } from "@/lib/usageDb";
@@ -51,7 +52,8 @@ export async function checkSemanticCache({
       body.messages ?? body.input,
       body.temperature,
       body.top_p,
-      apiKeyId ?? undefined
+      apiKeyId ?? undefined,
+      outputContractOf(body)
     );
     const cached = getCachedResponse(signature);
     if (cached) {

--- a/open-sse/handlers/chatCore/semanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/semanticCacheStore.ts
@@ -10,6 +10,7 @@
  */
 import {
   generateSignature as defaultGenerateSignature,
+  outputContractOf,
   setCachedResponse as defaultSetCachedResponse,
   isCacheableForWrite as defaultIsCacheableForWrite,
 } from "@/lib/semanticCache";
@@ -65,7 +66,8 @@ export function storeSemanticCacheResponse(
     args.body.messages ?? args.body.input,
     args.body.temperature,
     args.body.top_p,
-    args.apiKeyId ?? undefined
+    args.apiKeyId ?? undefined,
+    outputContractOf(args.body)
   );
   const tokensSaved = args.usage?.prompt_tokens + args.usage?.completion_tokens || 0;
   deps.setCachedResponse(signature, args.model, args.translatedResponse, tokensSaved);

--- a/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
@@ -11,6 +11,7 @@
  */
 import {
   generateSignature as defaultGenerateSignature,
+  outputContractOf,
   setCachedResponse as defaultSetCachedResponse,
   isCacheableForWrite as defaultIsCacheableForWrite,
 } from "@/lib/semanticCache";
@@ -69,7 +70,8 @@ function writeStreamingCacheEntry(
       args.body.messages ?? args.body.input,
       args.body.temperature,
       args.body.top_p,
-      args.apiKeyId ?? undefined
+      args.apiKeyId ?? undefined,
+      outputContractOf(args.body)
     );
     const tokensSaved = streamTokensSaved(args.streamUsage);
     deps.setCachedResponse(sig, args.model, cleanBody, tokensSaved);

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -6,7 +6,8 @@
  * are cached after assembly; cache hits always return JSON.
  * Two-tier: in-memory LRU (fast) + SQLite (persistent across restarts).
  *
- * Cache key = SHA-256(model + normalized messages + temperature + top_p)
+ * Cache key = SHA-256(model + normalized messages + temperature + top_p
+ *             + output contract, when present — see outputContractOf, #12307)
  * Bypass: X-OmniRoute-No-Cache: true
  *
  * @module lib/semanticCache
@@ -146,18 +147,43 @@ export function clearMemoryCache(): void {
  * @param {string} [apiKeyId] - API key ID for per-key isolation (prevents cross-user cache hits)
  * @returns {string} hex signature
  */
+/**
+ * The parts of a request that decide what a *valid response* looks like.
+ * Two calls that agree on the conversation but disagree here are not
+ * interchangeable and must not share a cache entry (#12307): a request for
+ * {color, wheels} must not be served a stored {value: "..."} body, and a
+ * tool-calling request must not be served the body of one without tools.
+ *
+ * Returns null when the request carries none of these, so plain-chat
+ * signatures — and every cache entry already written for them — are unchanged.
+ */
+export function outputContractOf(body: unknown): unknown {
+  const record = asRecord(body);
+  const text = asRecord(record.text);
+  const contract: JsonRecord = {};
+  if (record.response_format != null) contract.response_format = record.response_format;
+  if (text.format != null) contract.text_format = text.format;
+  if (record.tools != null) contract.tools = record.tools;
+  if (record.tool_choice != null) contract.tool_choice = record.tool_choice;
+  return Object.keys(contract).length > 0 ? contract : null;
+}
+
 export function generateSignature(
   model,
   conversation,
   temperature = 0,
   topP = 1,
-  apiKeyId?: string
+  apiKeyId?: string,
+  outputContract?: unknown
 ) {
   const payload = JSON.stringify({
     model,
     messages: normalizeConversation(conversation),
     temperature,
     top_p: topP,
+    // #12307: anything that changes the shape of a valid answer belongs in the
+    // key. Spread only when present so plain-chat signatures stay stable.
+    ...(outputContract != null ? { output: outputContract } : {}),
   });
   const digest = crypto.createHash("sha256").update(payload).digest("hex");
   // Per-key cache isolation (#3740) namespaces the signature with the apiKeyId as a

--- a/tests/unit/12307-semantic-cache-output-contract.test.ts
+++ b/tests/unit/12307-semantic-cache-output-contract.test.ts
@@ -1,0 +1,113 @@
+// Regression for #12307: the semantic-cache signature ignored response_format /
+// tools, so two temp=0 requests with identical messages but different response
+// schemas shared a cache key — the second was served the first's stored body
+// under a 200, violating the schema it asked for. The signature now folds an
+// "output contract" (response_format, text.format, tools, tool_choice) into the
+// digest when present, and stays byte-identical to the legacy key when absent
+// so existing plain-chat cache entries survive the upgrade.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { generateSignature, outputContractOf } = await import("../../src/lib/semanticCache.ts");
+const { storeSemanticCacheResponse } = await import(
+  "../../open-sse/handlers/chatCore/semanticCacheStore.ts"
+);
+const { storeStreamingSemanticCacheResponse } = await import(
+  "../../open-sse/handlers/chatCore/streamingSemanticCacheStore.ts"
+);
+
+const MESSAGES = [{ role: "user", content: "Describe a red bicycle." }];
+
+const schemaOf = (properties: Record<string, unknown>) => ({
+  type: "json_schema",
+  json_schema: { name: "d", strict: true, schema: { type: "object", properties } },
+});
+
+test("different response schemas over identical messages produce different signatures", () => {
+  const a = generateSignature("m", MESSAGES, 0, 1, "key",
+    outputContractOf({ response_format: schemaOf({ value: { type: "string" } }) }));
+  const b = generateSignature("m", MESSAGES, 0, 1, "key",
+    outputContractOf({ response_format: schemaOf({ color: { type: "string" }, wheels: { type: "integer" } }) }));
+  assert.notEqual(a, b);
+});
+
+test("identical response schemas still share a signature", () => {
+  const contract = () => outputContractOf({ response_format: schemaOf({ value: { type: "string" } }) });
+  assert.equal(
+    generateSignature("m", MESSAGES, 0, 1, "key", contract()),
+    generateSignature("m", MESSAGES, 0, 1, "key", contract())
+  );
+});
+
+test("tools presence splits the signature from a tool-less request", () => {
+  const withTools = generateSignature("m", MESSAGES, 0, 1, "key",
+    outputContractOf({ tools: [{ type: "function", function: { name: "f", parameters: {} } }] }));
+  const without = generateSignature("m", MESSAGES, 0, 1, "key", outputContractOf({}));
+  assert.notEqual(withTools, without);
+});
+
+test("plain chat keeps the legacy signature — existing cache entries stay valid", () => {
+  const legacy = generateSignature("m", MESSAGES, 0, 1, "key");
+  const withNullContract = generateSignature("m", MESSAGES, 0, 1, "key", outputContractOf({ stream: true }));
+  assert.equal(legacy, withNullContract);
+});
+
+test("outputContractOf returns null when no shape-determining field is present", () => {
+  assert.equal(outputContractOf({ model: "m", messages: MESSAGES, temperature: 0 }), null);
+  assert.equal(outputContractOf(null), null);
+  assert.equal(outputContractOf("nonsense"), null);
+});
+
+test("outputContractOf collects the Responses-API text.format spelling too", () => {
+  const contract = outputContractOf({ text: { format: { type: "json_schema", schema: {} } } });
+  assert.ok(contract && typeof contract === "object");
+  assert.ok("text_format" in (contract as Record<string, unknown>));
+});
+
+function recordingDeps() {
+  const calls: unknown[][] = [];
+  return {
+    calls,
+    deps: {
+      isCacheableForWrite: () => true,
+      isSmallEnoughForSemanticCache: () => true,
+      generateSignature: (...args: unknown[]) => {
+        calls.push(args);
+        return "sig";
+      },
+      setCachedResponse: () => {},
+    },
+  };
+}
+
+test("non-streaming store path forwards the output contract to the signature", () => {
+  const { calls, deps } = recordingDeps();
+  const body = { messages: MESSAGES, temperature: 0, top_p: 1, response_format: schemaOf({ v: { type: "string" } }) };
+  storeSemanticCacheResponse(
+    { enabled: true, body, headers: {}, translatedResponse: { ok: true }, model: "m", apiKeyId: "key" },
+    deps as never
+  );
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0][5], outputContractOf(body));
+});
+
+test("streaming store path forwards the output contract to the signature", () => {
+  const { calls, deps } = recordingDeps();
+  const body = { messages: MESSAGES, temperature: 0, top_p: 1, response_format: schemaOf({ v: { type: "string" } }) };
+  storeStreamingSemanticCacheResponse(
+    {
+      enabled: true,
+      streamStatus: 200,
+      streamResponseBody: { ok: true },
+      body,
+      headers: {},
+      model: "m",
+      apiKeyId: "key",
+      streamUsage: null,
+      log: null,
+    } as never,
+    deps as never
+  );
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0][5], outputContractOf(body));
+});


### PR DESCRIPTION
## Summary

- The semantic-cache signature hashed only `{model, messages, temperature, top_p}`. Two temp=0 requests with identical messages but **different `response_format`** therefore shared a cache key, and the second was served the first's stored body under a 200 — a response that violates the schema it asked for. `tools`/`tool_choice` had the same exposure. (Live repro in #12307: a request for `{color, wheels}` was served a stored `{"value": "A vibrant red bicycle…"}`.)
- `generateSignature` now accepts an optional **output contract** — `response_format`, `text.format` (Responses API spelling), `tools`, `tool_choice`, collected by a new exported `outputContractOf(body)` — and folds it into the hashed payload **only when present**. Plain-chat signatures are byte-identical to before, so every existing plain-chat cache entry survives the upgrade; only structured-output/tool requests get new keys (their old entries age out within the 30-minute TTL).
- All three call sites pass it: the read path (`chatCore/semanticCache.ts`) and both write paths (`semanticCacheStore.ts`, `streamingSemanticCacheStore.ts`). Read/write key symmetry is preserved automatically because `bodyForCacheWrite` snapshots the same body object the read path hashed (the existing `#cache-signature-asymmetry` guard).

## Related Issues

- Closes #12307
- Related to #12308 (this cache defect corrupts the experiment used to investigate that one)

## Validation

- [x] Change type: other — semantic cache (`src/lib` + chatCore decomposition modules)
- [x] Focused tests from the golden path (commands below)
- [ ] `npm run lint` — targeted `npx eslint` run on the five touched files instead; full lint left to CI
      (every reported error reproduces identically on the untouched `release/v3.8.51` base — pre-existing, none introduced by this diff; the new/changed files themselves lint clean)
- [x] Reconciled with the current active release base (branched from `release/v3.8.51` HEAD `d920e64`)
- [x] Production-code changes include a new automated test in this PR

Commands run locally:

```bash
node --import tsx/esm --test tests/unit/12307-semantic-cache-output-contract.test.ts
node --import tsx/esm --test tests/unit/cache-signature-roundtrip.test.ts     # existing guard, still green
node --import tsx/esm --test tests/unit/11559-semantic-cache-ttl-expiry.test.ts  # existing guard, still green
npx eslint src/lib/semanticCache.ts open-sse/handlers/chatCore/semanticCache.ts \
  open-sse/handlers/chatCore/semanticCacheStore.ts \
  open-sse/handlers/chatCore/streamingSemanticCacheStore.ts \
  tests/unit/12307-semantic-cache-output-contract.test.ts
```

## Tests Added Or Updated

- `tests/unit/12307-semantic-cache-output-contract.test.ts` (new): different schemas ⇒ different signatures; identical schemas ⇒ shared signature; tools split the key; **plain chat keeps the legacy signature byte-for-byte** (backward compat); `outputContractOf` returns `null` for plain chat and collects the `text.format` spelling; both store paths forward the contract to `generateSignature` (via injected deps, mirroring the existing DI seams).

## Coverage Notes

- `src/lib/semanticCache.ts`: new exported helper + one parameter — covered by the six signature tests.
- The three chatCore modules: one-argument change each — covered by the two deps-injection forwarding tests.
- Existing guards `cache-signature-roundtrip` and `11559-semantic-cache-ttl-expiry` rerun green, so read/write symmetry and TTL behaviour are unchanged.

## Reviewer Notes

- **Key stability:** the `output` field is spread into the payload only when the contract is non-null, so plain-chat keys (the overwhelming majority — on the instance where this was found, the cache served 13 hits against 5390 upstream calls over three days) are unchanged and their entries stay valid. Structured-output entries written by the old code become unreachable and expire via TTL; that is the point of the fix.
- **Key-order caveat:** `response_format`/`tools` are folded in as sent, so two clients serialising the same schema with different key order will miss each other's entries. That is a miss, not a collision — and it mirrors how `messages` content objects are already treated.
- **Alternative considered:** refusing to cache schema-carrying requests entirely (measured cost ≈ 0.24 % hit-rate loss). Folding the contract into the key was chosen because it keeps those hits and covers `tools` uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
