### PR TITLE
fix(gemini): preserve response-schema nullability across union flattening

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -621,7 +621,49 @@ function flattenTypeArrays(obj: unknown): void {
 
 // Clean JSON Schema for Antigravity API compatibility - removes unsupported keywords recursively
 // Reference: CLIProxyAPI/internal/util/gemini_schema.go
-export function cleanJSONSchemaForAntigravity(schema: unknown): unknown {
+/**
+ * JSON Schema spells a nullable field as a union — `type: ["string","null"]`,
+ * or an anyOf/oneOf with a `{"type":"null"}` branch. Gemini's Schema proto has
+ * no unions and spells it as a sibling key, `nullable: true`. Record that
+ * before Phase 2 flattens the union and destroys the evidence (#12308).
+ *
+ * Response schemas only (opt-in below). For a tool parameter, flattening to a
+ * concrete type is correct — Gemini wants one, and the caller decides what an
+ * absent argument means. For a response schema the union is the only thing
+ * telling the model that "nothing" is a legal answer; without it a model with
+ * nothing to say returns the string "null" or fabricates a value, and either
+ * reaches the client as schema-conformant data.
+ *
+ * `nullable` survives the rest of the pipeline for free: it is absent from
+ * GEMINI_UNSUPPORTED_SCHEMA_KEYS, and flattenAnyOfOneOf merges the surviving
+ * branch with Object.assign, which cannot clobber a key the branch lacks.
+ */
+function preserveNullable(obj: unknown): void {
+  if (!obj || typeof obj !== "object") return;
+
+  const record = obj as JsonRecord;
+  const hasNullBranch = (list: unknown): boolean =>
+    Array.isArray(list) && list.some((s) => s && toRecord(s).type === "null");
+
+  if (
+    (Array.isArray(record.type) && record.type.includes("null")) ||
+    hasNullBranch(record.anyOf) ||
+    hasNullBranch(record.oneOf)
+  ) {
+    record.nullable = true;
+  }
+
+  for (const value of Object.values(record)) {
+    if (value && typeof value === "object") {
+      preserveNullable(value);
+    }
+  }
+}
+
+export function cleanJSONSchemaForAntigravity(
+  schema: unknown,
+  options: { preserveNullable?: boolean } = {}
+): unknown {
   if (!schema || typeof schema !== "object") return schema;
 
   const root = cloneSchemaValue(schema);
@@ -630,6 +672,10 @@ export function cleanJSONSchemaForAntigravity(schema: unknown): unknown {
   // Phase 1: Convert and prepare
   convertConstToEnum(cleaned);
   convertEnumValuesToStrings(cleaned);
+
+  // Phase 1b: response schemas only — record nullability while the union
+  // still exists; afterwards there is nothing left to detect (#12308).
+  if (options.preserveNullable) preserveNullable(cleaned);
 
   // Phase 2: Flatten complex structures
   mergeAllOf(cleaned);

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -600,7 +600,11 @@ function openaiToGeminiBase(
       // Extract the schema (may be nested under .schema key)
       const schema = responseFormat.json_schema.schema || responseFormat.json_schema;
       if (schema && typeof schema === "object") {
-        result.generationConfig.responseSchema = cleanJSONSchemaForAntigravity(schema);
+        // #12308: response schemas opt in to nullability preservation; tool
+        // parameters (geminiToolsSanitizer) keep the default flattening.
+        result.generationConfig.responseSchema = cleanJSONSchemaForAntigravity(schema, {
+          preserveNullable: true,
+        });
       }
     } else if (responseFormat.type === "json_object") {
       result.generationConfig.responseMimeType = "application/json";

--- a/tests/unit/12308-gemini-response-schema-nullable.test.ts
+++ b/tests/unit/12308-gemini-response-schema-nullable.test.ts
@@ -1,0 +1,81 @@
+// Regression for #12308: cleanJSONSchemaForAntigravity flattened every union
+// spelling of "nullable" (type arrays, anyOf, oneOf) before the schema reached
+// Gemini, which is correct for tool parameters and wrong for response schemas —
+// a model with nothing to say could no longer answer null, so it returned the
+// *string* "null" or fabricated a value. With { preserveNullable: true } the
+// union is recorded as Gemini's `nullable: true` sibling key before Phase 2
+// destroys it; the key is absent from GEMINI_UNSUPPORTED_SCHEMA_KEYS, so it
+// survives sanitizing. Tool parameters keep the default (no flag, no change).
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { cleanJSONSchemaForAntigravity, GEMINI_UNSUPPORTED_SCHEMA_KEYS } = await import(
+  "../../open-sse/translator/helpers/geminiHelper.ts"
+);
+
+const clean = (schema: unknown) => cleanJSONSchemaForAntigravity(schema, { preserveNullable: true });
+const valueProp = (out: unknown) =>
+  (out as { properties: { value: Record<string, unknown> } }).properties.value;
+
+const wrap = (value: unknown) => ({
+  type: "object",
+  properties: { value },
+  required: ["value"],
+  additionalProperties: false,
+});
+
+test("type-array union survives as nullable: true", () => {
+  const out = valueProp(clean(wrap({ type: ["string", "null"] })));
+  assert.equal(out.type, "string");
+  assert.equal(out.nullable, true);
+});
+
+test("anyOf union survives as nullable: true (the Pydantic Optional[str] shape)", () => {
+  const out = valueProp(clean(wrap({ anyOf: [{ type: "string" }, { type: "null" }] })));
+  assert.equal(out.type, "string");
+  assert.equal(out.nullable, true);
+});
+
+test("oneOf union survives as nullable: true", () => {
+  const out = valueProp(clean(wrap({ oneOf: [{ type: "number" }, { type: "null" }] })));
+  assert.equal(out.type, "number");
+  assert.equal(out.nullable, true);
+});
+
+test("nested nullable fields are marked too", () => {
+  const out = clean({
+    type: "object",
+    properties: {
+      items: {
+        type: "array",
+        items: { type: "object", properties: { note: { type: ["string", "null"] } } },
+      },
+    },
+  }) as Record<string, never>;
+  const note = out.properties["items"]["items"]["properties"]["note"];
+  assert.equal(note.type, "string");
+  assert.equal(note.nullable, true);
+});
+
+test("a union without a null branch is left alone", () => {
+  const out = valueProp(clean(wrap({ anyOf: [{ type: "string" }, { type: "number" }] })));
+  assert.ok(!("nullable" in out));
+});
+
+test("an explicit nullable: true sent by the caller still passes through", () => {
+  const out = valueProp(clean(wrap({ type: "string", nullable: true })));
+  assert.equal(out.type, "string");
+  assert.equal(out.nullable, true);
+});
+
+test("default call (tool parameters) is unchanged: unions flatten, nothing is marked", () => {
+  const out = cleanJSONSchemaForAntigravity(wrap({ type: ["string", "null"] })) as {
+    properties: { value: Record<string, unknown> };
+  };
+  assert.equal(out.properties.value.type, "string");
+  assert.ok(!("nullable" in out.properties.value));
+});
+
+test("guard: nullable must stay out of GEMINI_UNSUPPORTED_SCHEMA_KEYS or the fix silently dies", () => {
+  assert.ok(!GEMINI_UNSUPPORTED_SCHEMA_KEYS.has("nullable"));
+});


### PR DESCRIPTION
## Summary

- `cleanJSONSchemaForAntigravity` flattens every union spelling of "nullable" before a schema reaches Gemini: `flattenTypeArrays` turns `["string","null"]` into `"string"`, and `flattenAnyOfOneOf` drops the `{"type":"null"}` branch. That is correct for **tool parameters** and wrong for **response schemas**, where the union is the only thing telling the model that "nothing" is a legal answer. Stripped of it, a model with nothing to say returns the *string* `"null"` — or fabricates a value (live repro in #12308: an empty `{}` payload produced a fully-adjectived invented product). Pydantic emits the `anyOf` spelling for `Optional[str]`, so the fabricating path is the common one for Python consumers.
- A new `preserveNullable` walk runs as **Phase 1b**, before the Phase 2 flattening destroys the union: it records Gemini's sibling-key spelling, `nullable: true`, on any node whose `type` array contains `"null"` or whose `anyOf`/`oneOf` carries a `{"type":"null"}` branch.
- The key survives the rest of the pipeline for free: `nullable` is absent from `GEMINI_UNSUPPORTED_SCHEMA_KEYS`, and `flattenAnyOfOneOf` merges the surviving branch with `Object.assign`, which cannot clobber a key the branch lacks. No existing pass changes.
- **Opt-in**: `cleanJSONSchemaForAntigravity` gains `options: { preserveNullable?: boolean }` defaulting to off. Only the `responseSchema` call site in `openai-to-gemini.ts` passes it; the three tool-parameter call sites in `geminiToolsSanitizer.ts` keep today's behaviour exactly.

## Related Issues

- Closes #12308
- Related to #12307 (fix that one first — it corrupts the repro for this one)

## Validation

- [x] Change type: provider (Gemini/Antigravity translator path)
- [x] Focused tests from the golden path (commands below)
- [ ] `npm run lint` — targeted `npx eslint` run on the three touched files instead; full lint left to CI
      (every reported error reproduces identically on the untouched `release/v3.8.51` base — pre-existing, none introduced by this diff; the new/changed files themselves lint clean)
- [x] Reconciled with the current active release base (branched from `release/v3.8.51` HEAD `d920e64`)
- [x] Production-code changes include a new automated test in this PR

Commands run locally:

```bash
node --import tsx/esm --test tests/unit/12308-gemini-response-schema-nullable.test.ts
npx eslint open-sse/translator/helpers/geminiHelper.ts \
  open-sse/translator/request/openai-to-gemini.ts \
  tests/unit/12308-gemini-response-schema-nullable.test.ts
```

Verified end-to-end against a live gateway carrying this change (unique nonce per request so nothing was served from cache):

```
type: ["string","null"]        -> {"value": null}     upstream 1685ms
anyOf: [{string},{null}]       -> {"value": null}     upstream 1697ms
oneOf: [{string},{null}]       -> {"value": null}     upstream 1674ms
anyOf: [{string},{number}]     -> {"value": "null"}   upstream 2242ms   <- negative control: no null branch, nothing marked
```

A/B on the same gateway, same prompts: with the fix, 5/5 real JSON nulls; without it, the string `"null"` and two fabricated descriptions.

## Tests Added Or Updated

- `tests/unit/12308-gemini-response-schema-nullable.test.ts` (new): all three union spellings survive as `nullable: true`; nested fields are marked; a union **without** a null branch is left untouched; a caller-supplied `nullable: true` passes through; **the default (tool-parameter) call is byte-unchanged**; and a guard pins `nullable` out of `GEMINI_UNSUPPORTED_SCHEMA_KEYS` so a future keyword-list edit cannot silently kill the fix.

## Coverage Notes

- `geminiHelper.ts`: the new walk + options parameter are covered by all eight tests, including the negative control and the default-path test.
- `openai-to-gemini.ts`: a one-argument change at the `responseSchema` call site; visible in the diff, exercised by the live verification above. (Importing that module in a unit test drags in the executor/registry graph, so the call-site is deliberately not unit-tested — the helper-level flag semantics are.)

## Reviewer Notes

- **Tool-calling behaviour is deliberately untouched.** Flattening to a concrete type is correct for `functionDeclarations.parameters` (and `VALIDATED` mode depends on today's shapes); the flag exists so the fix cannot leak there. The default-path test locks this.
- Known limitation, pre-existing: `hasNullBranch` matches `type === "null"` exactly, mirroring the filter `flattenAnyOfOneOf` already uses — a branch written as `{"type": ["null"]}` is matched by neither. Rare; can be handled separately if it ever turns up.
- `claude-to-gemini.ts` imports this helper but never calls it (dead import, line 5); left alone here to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
