### PR TITLE
fix(grok-cli): treat omitted SuperGrokPro creditUsagePercent as 0%

### DIFF
--- a/changelog.d/fixes/12312-grok-cli-supergrok-quota.md
+++ b/changelog.d/fixes/12312-grok-cli-supergrok-quota.md
@@ -1,0 +1,1 @@
+- **fix(grok-cli):** treat omitted SuperGrokPro `creditUsagePercent` as 0% used so Provider Limits still renders a weekly bar (proto3 zero-elision) ([#12312](https://github.com/diegosouzapw/OmniRoute/pull/12312)) — thanks @HouMinXi

--- a/open-sse/services/usage/grokCli.ts
+++ b/open-sse/services/usage/grokCli.ts
@@ -239,9 +239,12 @@ export async function getGrokCliUsage(accessToken?: string) {
   const config = billing.config;
   const resetAt = config.currentPeriod?.end || null;
   const quotas: Record<string, ReturnType<typeof percentageQuota>> = {};
-  if (config.creditUsagePercent != null) {
-    quotas.weekly = percentageQuota(config.creditUsagePercent, resetAt);
-  }
+  // SuperGrokPro (and proto3 omit-zero) billing configs often omit
+  // creditUsagePercent / productUsage. A present config object is a
+  // successful billing read, so treat a missing percent as 0% used and
+  // still render a weekly bar. A missing config still returns
+  // "Grok Build billing status unavailable" above — that path is unchanged.
+  quotas.weekly = percentageQuota(config.creditUsagePercent ?? 0, resetAt);
   Object.assign(quotas, buildProductQuotas(config.productUsage, resetAt));
 
   const autoTopUpResponse = userId

--- a/tests/unit/grok-cli-provider-limits.test.ts
+++ b/tests/unit/grok-cli-provider-limits.test.ts
@@ -38,6 +38,10 @@ function successFixtures(
     userId?: unknown;
     prepaidBalance?: Record<string, unknown> | null | undefined;
     productUsage?: unknown;
+    creditUsagePercent?: number | null;
+    omitCreditUsagePercent?: boolean;
+    omitProductUsage?: boolean;
+    currentPeriod?: Record<string, unknown> | null;
   } = {}
 ) {
   const tier = "tier" in options ? options.tier : "SuperGrok Heavy";
@@ -51,6 +55,14 @@ function successFixtures(
           { product: "API", usagePercent: 12.5 },
           { product: "Grok Code", usagePercent: 44 },
         ];
+  const currentPeriod =
+    "currentPeriod" in options
+      ? options.currentPeriod
+      : {
+          type: "WEEKLY",
+          start: "2026-07-27T00:00:00.000Z",
+          end: "2026-08-03T00:00:00.000Z",
+        };
 
   return async (input: string | URL | Request) => {
     const url = String(input);
@@ -64,13 +76,14 @@ function successFixtures(
     if (url.endsWith("/billing?format=credits")) {
       return response({
         config: {
-          creditUsagePercent: 37.25,
-          currentPeriod: {
-            type: "WEEKLY",
-            start: "2026-07-27T00:00:00.000Z",
-            end: "2026-08-03T00:00:00.000Z",
-          },
-          productUsage,
+          ...(options.omitCreditUsagePercent
+            ? {}
+            : {
+                creditUsagePercent:
+                  "creditUsagePercent" in options ? options.creditUsagePercent : 37.25,
+              }),
+          ...(currentPeriod === undefined ? {} : { currentPeriod }),
+          ...(options.omitProductUsage ? {} : { productUsage }),
           ...(prepaidBalance === undefined ? {} : { prepaidBalance }),
         },
       });
@@ -491,4 +504,69 @@ test("Provider Limits cache persists only the public Grok billing contract", () 
 
 test("grok-cli is registered on the public Provider Limits usage seam", () => {
   assert.ok((USAGE_FETCHER_PROVIDERS as readonly string[]).includes("grok-cli"));
+});
+
+test("SuperGrokPro omitted creditUsagePercent still yields a weekly quota bar", async () => {
+  const usage = await getUsage(
+    successFixtures({
+      tier: "SuperGrokPro",
+      omitCreditUsagePercent: true,
+      omitProductUsage: true,
+      prepaidBalance: { val: 0 },
+    }) as typeof fetch
+  );
+
+  assert.equal(usage.plan, "SuperGrokPro");
+  assert.deepEqual(usage.quotas?.weekly, {
+    used: 0,
+    total: 100,
+    remaining: 100,
+    remainingPercentage: 100,
+    resetAt: "2026-08-03T00:00:00.000Z",
+    isPercentageOnly: true,
+  });
+  assert.equal(usage.message, undefined);
+});
+
+test("SuperGrokPro explicit null creditUsagePercent still yields a weekly quota bar", async () => {
+  const usage = await getUsage(
+    successFixtures({
+      tier: "SuperGrokPro",
+      creditUsagePercent: null,
+      omitProductUsage: true,
+      prepaidBalance: { val: 0 },
+    }) as typeof fetch
+  );
+
+  assert.equal(usage.plan, "SuperGrokPro");
+  assert.deepEqual(usage.quotas?.weekly, {
+    used: 0,
+    total: 100,
+    remaining: 100,
+    remainingPercentage: 100,
+    resetAt: "2026-08-03T00:00:00.000Z",
+    isPercentageOnly: true,
+  });
+});
+
+test("SuperGrokPro omitted currentPeriod still yields a weekly bar with null resetAt", async () => {
+  const usage = await getUsage(
+    successFixtures({
+      tier: "SuperGrokPro",
+      omitCreditUsagePercent: true,
+      omitProductUsage: true,
+      currentPeriod: null,
+      prepaidBalance: { val: 0 },
+    }) as typeof fetch
+  );
+
+  assert.equal(usage.plan, "SuperGrokPro");
+  assert.deepEqual(usage.quotas?.weekly, {
+    used: 0,
+    total: 100,
+    remaining: 100,
+    remainingPercentage: 100,
+    resetAt: null,
+    isPercentageOnly: true,
+  });
 });


### PR DESCRIPTION
fix(grok-cli): treat omitted SuperGrokPro creditUsagePercent as 0%

### Summary
SuperGrokPro billing configs from `cli-chat-proxy.grok.com/v1/billing?format=credits` often omit `creditUsagePercent` and `productUsage` (proto3 zero-elision). `getGrokCliUsage` only filled `quotas.weekly` when the percent field was present, so Provider Limits rendered "no quota data" for a healthy SuperGrokPro account.

A present `config` object is a successful billing read. Missing percent is now treated as 0% used and still emits a weekly bar. A missing `config` still returns "Grok Build billing status unavailable".

### Measured against live API (2026-09-01)
Same host, same `grok-cli` fetcher:

| Account | plan | quotas before |
|---|---|---|
| adioseden0230@gmail.com | SuperGrokPro | `{}` |
| 364432949@qq.com | GrokPro | weekly 17% + Grok Build 17% |

Account was imported and active. The blank UI was the mapper, not a missing connection.

### Tests
- omitted `creditUsagePercent` + omitted `productUsage` → weekly 0%
- explicit `creditUsagePercent: null` → weekly 0%
- omitted `currentPeriod` → weekly 0% with `resetAt: null`
- existing grok-cli Provider Limits suite: 13/13 pass
- sibling grok-web / xai-oauth suites: 21/21 pass
- `npm run typecheck:core` clean

### Not in this PR
- Mapping `onDemandUsed` / `onDemandCap` as extra bars
- Changing grok-web / xai-oauth fetchers (they already default omitted percent to 0)

### Review
Forge CI pass (mimo-direct) on the first commit: 1 CONFIRMED (missing null-percent test — added), 1 UNCERTAIN (0% vs unknown — rebutted: missing `config` still unavailable; present `config` is a successful read).
