### PR TITLE
test(sse): drop the dead collectSSE helper that reds the lint gate

### DIFF
--- a/tests/unit/stream-passthrough-usage-estimation.test.ts
+++ b/tests/unit/stream-passthrough-usage-estimation.test.ts
@@ -34,24 +34,6 @@ test("passthrough no fake: tool_only contentLength==0 -> no estimate (tool_calls
 
 import { createSSEStream } from "../../open-sse/utils/stream.ts";
 
-function collectSSE(stream: TransformStream<Uint8Array, Uint8Array>) {
-  return async (writable: WritableStream<Uint8Array>, readable: ReadableStream<Uint8Array>) => {
-    const chunks: string[] = [];
-    const decoder = new TextDecoder();
-    const reader = readable.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        chunks.push(decoder.decode(value, { stream: true }));
-      }
-    } finally {
-      reader.releaseLock();
-    }
-    return chunks.join("");
-  };
-}
-
 function parseSSEUsage(sseText: string): unknown[] {
   return sseText
     .split("\n\n")


### PR DESCRIPTION
## Base-red fix (window red, no issue open yet)

#12151 (`5e6c9a92dc`, merged today 11:50) landed `tests/unit/stream-passthrough-usage-estimation.test.ts` with a never-called `collectSSE` helper. Its three unused identifiers (`collectSSE`, `stream`, `writable`) fail `npm run lint:json -- --max-warnings 0`, so the **No new ESLint warnings** job reds every PR merge-ref cut from the current `release/v3.8.51` tip.

First seen red: PR #11564's post-sync Quality Gates run (job 99893586905 → run 33525495722 step "No new ESLint warnings"). The `Release-Green (continuous)` issue has not opened yet — this is a same-day window red.

## Fix

Remove only the dead closure (18 lines). `createSSEStream` and `parseSSEUsage` are genuinely used by the SSE estimation tests and stay untouched. No assertion changes.

## Validation

- `eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/stream-passthrough-usage-estimation.test.ts` → clean (was: 3 no-unused-vars errors)
- `node --test tests/unit/stream-passthrough-usage-estimation.test.ts` → 6/6 pass

Refs #12151