### PR TITLE
chore(deps): freeze the paired/pinned deps out of dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,22 @@ updates:
       # on the VPS — so keep auto-bumps frozen (no update-types = ignore every version).
       # Migrate it intentionally, not via dependabot (#4050).
       - dependency-name: "@huggingface/transformers"
+      # onnxruntime-node is the OTHER HALF of the @huggingface/transformers pair frozen
+      # above: the hoisted copy must equal the exact version transformers pins, or npm
+      # nests a second ABI-incompatible native copy (contract test
+      # tests/unit/onnxruntime-single-copy.test.ts, pair established in #9962). A solo
+      # bump can never be correct — it only ever moves together with transformers, in
+      # the same deliberate migration PR. Freezing it keeps the production group PRs
+      # (e.g. #12219) from being born red on the pair contract.
+      - dependency-name: "onnxruntime-node"
+      # eslint-plugin-react-hooks is pinned to 7.0.1 by a contract test
+      # (tests/unit/eslint-react-hooks-version-pinned.test.ts) until the 7.1.1 rule set
+      # is adopted deliberately — that adoption needs a full cold lint run and its own
+      # PR (the #12146 react-hooks migration finished on 2026-09-01, so the path is
+      # open; the bump still must not ride a dependabot group, where it reds the
+      # development group PRs, e.g. #12220). Remove this ignore in the adoption PR
+      # together with the pin test.
+      - dependency-name: "eslint-plugin-react-hooks"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Both open dependabot group PRs are born red on deliberate contract tests:

- **#12219 (production group)**: `onnxruntime-node 1.24.3→1.29.0` violates `tests/unit/onnxruntime-single-copy.test.ts` — the hoisted copy must equal the exact version `@huggingface/transformers` pins (pair from #9962; transformers itself is already frozen in this file). The pair only ever moves together, in a deliberate migration PR.
- **#12220 (development group)**: `eslint-plugin-react-hooks 7.0.1→7.1.1` violates the pin contract (`tests/unit/eslint-react-hooks-version-pinned.test.ts`). The #12146 migration finished today, so adopting 7.1.1 is now viable — but in its own PR with a full cold lint run, removing the pin test in the same move; never riding a group.

This adds the two ignores (with rationale comments) so the groups recreate clean. After merge, `@dependabot recreate` on both PRs drops the offending packages and the remaining 14+11 healthy bumps can land.