### PR TITLE
test(sse): remove dead collectSSE helper — clears lint errors (base-red #12335)

### DIFF
--- a/tests/unit/stream-passthrough-usage-estimation.test.ts
+++ b/tests/unit/stream-passthrough-usage-estimation.test.ts
@@ -34,24 +34,6 @@ test("passthrough no fake: tool_only contentLength==0 -> no estimate (tool_calls
 
 import { createSSEStream } from "../../open-sse/utils/stream.ts";
 
-function collectSSE(stream: TransformStream<Uint8Array, Uint8Array>) {
-  return async (writable: WritableStream<Uint8Array>, readable: ReadableStream<Uint8Array>) => {
-    const chunks: string[] = [];
-    const decoder = new TextDecoder();
-    const reader = readable.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        chunks.push(decoder.decode(value, { stream: true }));
-      }
-    } finally {
-      reader.releaseLock();
-    }
-    return chunks.join("");
-  };
-}
-
 function parseSSEUsage(sseText: string): unknown[] {
   return sseText
     .split("\n\n")
@@ -70,7 +52,12 @@ function parseSSEUsage(sseText: string): unknown[] {
 }
 
 test("passthrough SSE: finish stop without usage + include_usage:true -> emits usage.estimated:true", async () => {
-  const body = { model: "m", messages: [{ role: "user", content: "hi" }], stream: true, stream_options: { include_usage: true } };
+  const body = {
+    model: "m",
+    messages: [{ role: "user", content: "hi" }],
+    stream: true,
+    stream_options: { include_usage: true },
+  };
   const stream = createSSEStream({
     mode: "passthrough" as const,
     body,
@@ -91,15 +78,26 @@ test("passthrough SSE: finish stop without usage + include_usage:true -> emits u
   })();
   const enc = new TextEncoder();
   // delta content -> accumulates totalContentLength
-  await writer.write(enc.encode(`data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "hello world" }, finish_reason: null }] })}\n\n`));
+  await writer.write(
+    enc.encode(
+      `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "hello world" }, finish_reason: null }] })}\n\n`
+    )
+  );
   // finish without usage
-  await writer.write(enc.encode(`data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`));
+  await writer.write(
+    enc.encode(
+      `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`
+    )
+  );
   await writer.write(enc.encode("data: [DONE]\n\n"));
   await writer.close();
   const text = await readAll;
   const parsed = parseSSEUsage(text);
   const withUsage = parsed.filter((p: unknown) => (p as Record<string, unknown>).usage);
-  assert.ok(withUsage.length >= 1, `expected at least 1 chunk with usage, got ${withUsage.length} — text: ${text.slice(0, 600)}`);
+  assert.ok(
+    withUsage.length >= 1,
+    `expected at least 1 chunk with usage, got ${withUsage.length} — text: ${text.slice(0, 600)}`
+  );
   const last = withUsage[withUsage.length - 1] as Record<string, unknown>;
   const usage = last.usage as Record<string, unknown>;
   assert.equal(usage.estimated, true);
@@ -108,7 +106,12 @@ test("passthrough SSE: finish stop without usage + include_usage:true -> emits u
 });
 
 test("passthrough SSE: trailing choices:[] valid after estimated finish -> trailing is dropped (estimated wins)", async () => {
-  const body = { model: "m", messages: [{ role: "user", content: "hi" }], stream: true, stream_options: { include_usage: true } };
+  const body = {
+    model: "m",
+    messages: [{ role: "user", content: "hi" }],
+    stream: true,
+    stream_options: { include_usage: true },
+  };
   const stream = createSSEStream({
     mode: "passthrough" as const,
     body,
@@ -128,11 +131,23 @@ test("passthrough SSE: trailing choices:[] valid after estimated finish -> trail
     return Buffer.concat(chunks).toString("utf8");
   })();
   const enc = new TextEncoder();
-  await writer.write(enc.encode(`data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "hello world" }, finish_reason: null }] })}\n\n`));
+  await writer.write(
+    enc.encode(
+      `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "hello world" }, finish_reason: null }] })}\n\n`
+    )
+  );
   // finish without usage -> should estimate (injectedUsage=false at that point)
-  await writer.write(enc.encode(`data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`));
+  await writer.write(
+    enc.encode(
+      `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`
+    )
+  );
   // trailing choices:[] with valid usage 50ms after -> inside empty-choices block hasValid(emptyChoicesUsage)&&!injectedUsage is now false, so chunk is dropped (warn path)
-  await writer.write(enc.encode(`data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [], usage: { prompt_tokens: 8, completion_tokens: 6, total_tokens: 14 } })}\n\n`));
+  await writer.write(
+    enc.encode(
+      `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [], usage: { prompt_tokens: 8, completion_tokens: 6, total_tokens: 14 } })}\n\n`
+    )
+  );
   await writer.write(enc.encode("data: [DONE]\n\n"));
   await writer.close();
   const text = await readAll;
@@ -140,6 +155,13 @@ test("passthrough SSE: trailing choices:[] valid after estimated finish -> trail
   const withUsage = parsed.filter((p: unknown) => (p as Record<string, unknown>).usage);
   // With the guard, the trailing valid is dropped (estimated was already sent on finish). Without guard we would see 2 (double). We assert drop.
   // If upstream ever sends real include_usage trailing, this documents the v1 tradeoff: estimated wins, valid is dropped.
-  assert.equal(withUsage.length, 1, `expected 1 usage (estimated, trailing dropped), got ${withUsage.length} — usages: ${JSON.stringify(withUsage.map((p) => (p as Record<string, unknown>).usage))}`);
-  assert.equal((withUsage[0] as Record<string, unknown> & { usage: Record<string, unknown> }).usage.estimated, true);
+  assert.equal(
+    withUsage.length,
+    1,
+    `expected 1 usage (estimated, trailing dropped), got ${withUsage.length} — usages: ${JSON.stringify(withUsage.map((p) => (p as Record<string, unknown>).usage))}`
+  );
+  assert.equal(
+    (withUsage[0] as Record<string, unknown> & { usage: Record<string, unknown> }).usage.estimated,
+    true
+  );
 });


### PR DESCRIPTION
## Summary

Fixes the second reproducible hard failure behind **base-red #12335** on `release/v3.8.51`: three `@typescript-eslint/no-unused-vars` errors in `tests/unit/stream-passthrough-usage-estimation.test.ts` that failed `npm run lint:json` (the CI lint gate).

## Root cause — test-only dead code

`collectSSE` was **never called**. Both async SSE tests read the stream with their own inline `readAll` loop; `collectSSE` (and its unused `stream` / `writable` params) was an orphaned helper — all three errors lived inside it.

- Production code (`open-sse/utils/usageTracking.ts`, `open-sse/utils/stream.ts`) is **untouched**.
- **No assertion or coverage is lost** — the live SSE tests already exercise both paths (estimate-on-finish and trailing-dropped).

## Fix

Delete the orphaned `collectSSE` helper. `parseSSEUsage` and the `createSSEStream` import stay — both are used by the real tests.

## Test plan
- `npx eslint tests/unit/stream-passthrough-usage-estimation.test.ts` → **0 errors** (was 3).
- `npm run lint:json` (the exact command the CI `lint` job runs) → **exit 0** (green). The local `npm run lint` still reports pre-existing *unused-suppression* drift, but CI's `lint:json` passes `--pass-on-unpruned-suppressions`, so that is non-blocking and out of scope here.
- `node --test tests/unit/stream-passthrough-usage-estimation.test.ts` → **6/6 pass**.
- Test-only change; no production code touched.

> Part of clearing base-red **#12335**. Companion PR **#12350** fixes the other reproducible failure (openapi-security-tiers checker false positives).
