### PR TITLE
fix(api): preserve API key ACL on creation

### DIFF
--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -71,6 +71,9 @@ export async function POST(request) {
     }
     const {
       name,
+      modelAccessMode,
+      allowedModels,
+      allowedCombos,
       noLog,
       scopes,
       allowedConnections,
@@ -84,7 +87,12 @@ export async function POST(request) {
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
     const normalizedScopes = normalizeSelfServiceScopesForCreate(scopes);
-    const apiKey = await createApiKey(name, machineId, normalizedScopes, { allowedConnections });
+    const apiKey = await createApiKey(name, machineId, normalizedScopes, {
+      modelAccessMode,
+      allowedModels,
+      allowedCombos,
+      allowedConnections,
+    });
     if (
       noLog === true ||
       allowUsageCommand === true ||
@@ -119,6 +127,9 @@ export async function POST(request) {
         name: apiKey.name,
         id: apiKey.id,
         machineId: apiKey.machineId,
+        modelAccessMode: apiKey.modelAccessMode,
+        allowedModels: apiKey.allowedModels,
+        allowedCombos: apiKey.allowedCombos,
         allowedConnections: apiKey.allowedConnections,
         noLog: noLog === true,
         allowUsageCommand: allowUsageCommand === true,

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -78,6 +78,13 @@ interface CacheEntry<TValue> {
   value: TValue;
 }
 
+interface CreateApiKeyOptions {
+  modelAccessMode?: ModelAccessMode;
+  allowedModels?: string[];
+  allowedCombos?: string[];
+  allowedConnections?: string[];
+}
+
 export type { AccessSchedule, RateLimitRule } from "./apiKeys/types";
 
 interface ApiKeyMetadata {
@@ -233,9 +240,7 @@ function assertExclusiveLeaseKeyPolicy(
   allowedConnections: readonly string[]
 ): void {
   if (scopes.includes(EXCLUSIVE_LEASE_SCOPE) && allowedConnections.length === 0) {
-    throw new ApiKeyPolicyInvariantError(
-      "lease:exclusive requires explicit allowedConnections"
-    );
+    throw new ApiKeyPolicyInvariantError("lease:exclusive requires explicit allowedConnections");
   }
 }
 
@@ -346,7 +351,7 @@ async function getModelPermissionCandidates(modelId: string): Promise<string[]> 
         providerOrAlias,
         providerScopedModel,
         resolveProviderId,
-        getProviderAlias,
+        getProviderAlias
       );
     }
     return Array.from(candidates);
@@ -364,7 +369,7 @@ async function getModelPermissionCandidates(modelId: string): Promise<string[]> 
 }
 
 async function getPublishedModelLookupTarget(
-  modelId: string,
+  modelId: string
 ): Promise<{ providerId: string; modelId: string } | null> {
   const cleanModelId = stripExtendedContextSuffix(modelId.trim());
   if (!cleanModelId) return null;
@@ -393,7 +398,7 @@ async function getPublishedModelLookupTarget(
 function ensureApiKeyColumn(
   db: ApiKeysDbLike,
   columnNames: Set<string>,
-  column: (typeof API_KEY_COLUMN_FALLBACKS)[number],
+  column: (typeof API_KEY_COLUMN_FALLBACKS)[number]
 ): void {
   if (columnNames.has(column.name)) return;
   db.exec(`ALTER TABLE api_keys ADD COLUMN ${column.definition}`);
@@ -433,13 +438,13 @@ function getPreparedStatements(db: ApiKeysDbLike): ApiKeysStatements {
     _stmtGetAllKeys = db.prepare<ApiKeyRow>("SELECT * FROM api_keys ORDER BY created_at");
     _stmtGetKeyById = db.prepare<ApiKeyRow>("SELECT * FROM api_keys WHERE id = ?");
     _stmtValidateKey = db.prepare<JsonRecord>(
-      "SELECT id, expires_at, revoked_at, is_active, is_banned FROM api_keys WHERE key = ? OR key_hash = ?",
+      "SELECT id, expires_at, revoked_at, is_active, is_banned FROM api_keys WHERE key = ? OR key_hash = ?"
     );
     _stmtGetKeyMetadata = db.prepare<ApiKeyRow>(
-      "SELECT id, name, machine_id, model_access_mode, allowed_models, blocked_models, allowed_combos, allowed_connections, allowed_quotas, no_log, auto_resolve, is_active, access_schedule, max_requests_per_day, max_requests_per_minute, throttle_delay_ms, max_sessions, revoked_at, expires_at, ip_allowlist, scopes, rate_limits, is_banned, key_hash, allowed_endpoints, stream_default_mode, cache_default_mode, disable_non_public_models, allow_usage_command, usage_limit_enabled, daily_usage_limit_usd, weekly_usage_limit_usd, chaos_mode_enabled, compression_enabled, proxy_id FROM api_keys WHERE key = ? OR key_hash = ?",
+      "SELECT id, name, machine_id, model_access_mode, allowed_models, blocked_models, allowed_combos, allowed_connections, allowed_quotas, no_log, auto_resolve, is_active, access_schedule, max_requests_per_day, max_requests_per_minute, throttle_delay_ms, max_sessions, revoked_at, expires_at, ip_allowlist, scopes, rate_limits, is_banned, key_hash, allowed_endpoints, stream_default_mode, cache_default_mode, disable_non_public_models, allow_usage_command, usage_limit_enabled, daily_usage_limit_usd, weekly_usage_limit_usd, chaos_mode_enabled, compression_enabled, proxy_id FROM api_keys WHERE key = ? OR key_hash = ?"
     );
     _stmtInsertKey = db.prepare(
-      "INSERT INTO api_keys (id, name, key, machine_id, allowed_models, allowed_combos, allowed_connections, no_log, created_at, key_prefix, key_hash, scopes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO api_keys (id, name, key, machine_id, model_access_mode, allowed_models, allowed_combos, allowed_connections, no_log, created_at, key_prefix, key_hash, scopes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     _stmtDeleteKey = db.prepare("DELETE FROM api_keys WHERE id = ?");
   }
@@ -497,7 +502,7 @@ export async function getApiKeys(limit?: number, offset?: number) {
     camelRow.streamDefaultMode = parseStreamDefaultMode((camelRow as JsonRecord).streamDefaultMode);
     camelRow.cacheDefaultMode = parseCacheDefaultMode((camelRow as JsonRecord).cacheDefaultMode);
     camelRow.disableNonPublicModels = parseDisableNonPublicModels(
-      (camelRow as JsonRecord).disableNonPublicModels,
+      (camelRow as JsonRecord).disableNonPublicModels
     );
     camelRow.allowUsageCommand = parseAllowUsageCommand((camelRow as JsonRecord).allowUsageCommand);
     camelRow.chaosModeEnabled = parseChaosModeEnabled((camelRow as JsonRecord).chaosModeEnabled);
@@ -556,7 +561,7 @@ export async function getExclusiveLeaseConnectionIds(): Promise<Set<string>> {
  * inactive, banned, or hard-lease key, and it never widens a key's allowedModels.
  */
 export async function pickApiKeyForInternalUse(
-  purpose: "combo-health-check" | "cloud-sync-verify" | "internal-probe" = "internal-probe",
+  purpose: "combo-health-check" | "cloud-sync-verify" | "internal-probe" = "internal-probe"
 ): Promise<string | null> {
   try {
     const keys = (await getApiKeys()) as Array<{
@@ -579,7 +584,7 @@ export async function pickApiKeyForInternalUse(
 
     // 1. Management-scoped key (preferred for any internal probe).
     const manageKey = keys.find(
-      (k) => isUsable(k) && Array.isArray(k.scopes) && k.scopes.includes("manage"),
+      (k) => isUsable(k) && Array.isArray(k.scopes) && k.scopes.includes("manage")
     );
     if (manageKey?.key) return manageKey.key;
 
@@ -634,7 +639,7 @@ export async function getApiKeyById(id: string) {
   camelRow.streamDefaultMode = parseStreamDefaultMode((camelRow as JsonRecord).streamDefaultMode);
   camelRow.cacheDefaultMode = parseCacheDefaultMode((camelRow as JsonRecord).cacheDefaultMode);
   camelRow.disableNonPublicModels = parseDisableNonPublicModels(
-    (camelRow as JsonRecord).disableNonPublicModels,
+    (camelRow as JsonRecord).disableNonPublicModels
   );
   camelRow.allowUsageCommand = parseAllowUsageCommand((camelRow as JsonRecord).allowUsageCommand);
   camelRow.chaosModeEnabled = parseChaosModeEnabled((camelRow as JsonRecord).chaosModeEnabled);
@@ -662,12 +667,19 @@ export async function createApiKey(
   name: string,
   machineId: string,
   scopes: string[] = [],
-  options: { allowedConnections?: string[] } = {}
+  options: CreateApiKeyOptions = {}
 ) {
   if (!machineId) {
     throw new Error("machineId is required");
   }
   const allowedConnections = options.allowedConnections ?? [];
+  const modelAccess = normalizeApiKeyPermissionsUpdate({
+    modelAccessMode: options.modelAccessMode,
+    allowedModels: options.allowedModels,
+  });
+  const modelAccessMode = modelAccess.modelAccessMode ?? "all";
+  const allowedModels = modelAccess.allowedModels ?? [];
+  const allowedCombos = options.allowedCombos ?? [ALL_COMBOS_ACCESS_RULE];
   assertExclusiveLeaseKeyPolicy(scopes, allowedConnections);
 
   const db = getDbInstance() as ApiKeysDbLike;
@@ -681,9 +693,9 @@ export async function createApiKey(
     name: name,
     key: result.key,
     machineId: machineId,
-    modelAccessMode: "all" as const,
-    allowedModels: [], // Empty array means all models allowed
-    allowedCombos: [ALL_COMBOS_ACCESS_RULE], // Explicit wildcard means all combos allowed
+    modelAccessMode,
+    allowedModels,
+    allowedCombos,
     allowedConnections,
     noLog: false,
     allowUsageCommand: false,
@@ -697,14 +709,15 @@ export async function createApiKey(
     apiKey.name,
     apiKey.key,
     apiKey.machineId,
-    "[]",
+    apiKey.modelAccessMode,
+    JSON.stringify(apiKey.allowedModels),
     JSON.stringify(apiKey.allowedCombos),
     JSON.stringify(allowedConnections),
     0,
     apiKey.createdAt,
     apiKey.key.slice(0, 12),
     await hashKey(apiKey.key),
-    JSON.stringify(scopes),
+    JSON.stringify(scopes)
   );
   setNoLog(apiKey.id, false);
 
@@ -726,7 +739,7 @@ export async function regenerateApiKey(id: string) {
 
   // Update in DB
   const updateStmt = db.prepare(
-    "UPDATE api_keys SET key = ?, key_hash = ?, key_prefix = ? WHERE id = ?",
+    "UPDATE api_keys SET key = ?, key_hash = ?, key_prefix = ? WHERE id = ?"
   );
   updateStmt.run(newKey, newHash, newPrefix, id);
 
@@ -747,7 +760,7 @@ export async function regenerateApiKey(id: string) {
 
 export async function updateApiKeyPermissions(
   id: string,
-  update: string[] | ApiKeyPermissionsUpdate,
+  update: string[] | ApiKeyPermissionsUpdate
 ) {
   const db = getDbInstance() as ApiKeysDbLike;
   getPreparedStatements(db);
@@ -1050,7 +1063,9 @@ export async function updateApiKeyPermissions(
         return false;
       }
       assertExclusiveLeaseKeyPolicy(parseStringList(row.scopes), normalized.allowedConnections);
-      const upd = db.prepare(`UPDATE api_keys SET ${updates.join(", ")} WHERE id = @id`).run(params);
+      const upd = db
+        .prepare(`UPDATE api_keys SET ${updates.join(", ")} WHERE id = @id`)
+        .run(params);
       changedRows = upd.changes ?? 0;
       db.exec("COMMIT");
     } catch (err) {
@@ -1162,7 +1177,7 @@ export async function revokeApiKey(id: string): Promise<boolean> {
 
   const result = db
     .prepare(
-      "UPDATE api_keys SET revoked_at = COALESCE(revoked_at, @ts), is_active = 0 WHERE id = @id",
+      "UPDATE api_keys SET revoked_at = COALESCE(revoked_at, @ts), is_active = 0 WHERE id = @id"
     )
     .run({ id, ts: new Date().toISOString() });
 
@@ -1291,7 +1306,7 @@ export async function validateApiKey(key: string | null | undefined) {
             revokedAt: row.revoked_at,
           }),
           "EX",
-          3600, // 1 hour cache
+          3600 // 1 hour cache
         );
       }
     } catch {
@@ -1308,7 +1323,7 @@ export async function validateApiKey(key: string | null | undefined) {
  * Get API key metadata with caching for performance
  */
 export async function getApiKeyMetadata(
-  key: string | null | undefined,
+  key: string | null | undefined
 ): Promise<ApiKeyMetadata | null> {
   if (!key || typeof key !== "string") return null;
 
@@ -1415,10 +1430,10 @@ export async function getApiKeyMetadata(
     blockedModels: parseAllowedModels(record.blocked_models ?? record.blockedModels),
     allowedCombos: parseAllowedCombos(record.allowed_combos ?? record.allowedCombos),
     allowedConnections: parseAllowedConnections(
-      record.allowed_connections ?? record.allowedConnections,
+      record.allowed_connections ?? record.allowedConnections
     ),
     allowedQuotas: parseAllowedQuotas(
-      (record as JsonRecord).allowed_quotas ?? (record as JsonRecord).allowedQuotas,
+      (record as JsonRecord).allowed_quotas ?? (record as JsonRecord).allowedQuotas
     ),
     noLog: parseNoLog(record.no_log ?? record.noLog),
     autoResolve: parseAutoResolve(record.auto_resolve ?? record.autoResolve),
@@ -1440,26 +1455,26 @@ export async function getApiKeyMetadata(
     proxyId:
       typeof record.proxy_id === "string" && record.proxy_id.trim() !== "" ? record.proxy_id : null,
     allowedEndpoints: parseStringList(
-      (record as JsonRecord).allowed_endpoints ?? (record as JsonRecord).allowedEndpoints,
+      (record as JsonRecord).allowed_endpoints ?? (record as JsonRecord).allowedEndpoints
     ),
     streamDefaultMode: parseStreamDefaultMode(
-      (record as JsonRecord).stream_default_mode ?? (record as JsonRecord).streamDefaultMode,
+      (record as JsonRecord).stream_default_mode ?? (record as JsonRecord).streamDefaultMode
     ),
     cacheDefaultMode: parseCacheDefaultMode(
       (record as JsonRecord).cache_default_mode ?? (record as JsonRecord).cacheDefaultMode
     ),
     disableNonPublicModels: parseDisableNonPublicModels(
       (record as JsonRecord).disable_non_public_models ??
-        (record as JsonRecord).disableNonPublicModels,
+        (record as JsonRecord).disableNonPublicModels
     ),
     allowUsageCommand: parseAllowUsageCommand(
-      (record as JsonRecord).allow_usage_command ?? (record as JsonRecord).allowUsageCommand,
+      (record as JsonRecord).allow_usage_command ?? (record as JsonRecord).allowUsageCommand
     ),
     chaosModeEnabled: parseChaosModeEnabled(
-      (record as JsonRecord).chaos_mode_enabled ?? (record as JsonRecord).chaosModeEnabled,
+      (record as JsonRecord).chaos_mode_enabled ?? (record as JsonRecord).chaosModeEnabled
     ),
     compressionEnabled: parseCompressionEnabled(
-      (record as JsonRecord).compression_enabled ?? (record as JsonRecord).compressionEnabled,
+      (record as JsonRecord).compression_enabled ?? (record as JsonRecord).compressionEnabled
     ),
     ...parseApiKeyUsageLimitFields(record as JsonRecord),
   };
@@ -1485,7 +1500,7 @@ export async function getApiKeyMetadata(
  */
 export async function isModelAllowedForKey(
   key: string | null | undefined,
-  modelId: string | null | undefined,
+  modelId: string | null | undefined
 ) {
   // If no key provided, allow (request may be using different auth method like JWT)
   // If no modelId provided, deny (invalid request)

--- a/src/shared/validation/schemas/keys.ts
+++ b/src/shared/validation/schemas/keys.ts
@@ -33,9 +33,28 @@ const requireExclusiveLeaseConnections = (
     });
 };
 
+const requireConsistentModelAccess = (
+  value: {
+    modelAccessMode?: "all" | "restricted";
+    allowedModels?: string[];
+  },
+  ctx: z.RefinementCtx
+) => {
+  if (value.modelAccessMode === "all" && value.allowedModels && value.allowedModels.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "allowedModels must be empty when modelAccessMode is 'all'",
+      path: ["allowedModels"],
+    });
+  }
+};
+
 export const createKeySchema = z
   .object({
     name: z.string().min(1, "Name is required").max(200),
+    modelAccessMode: z.enum(["all", "restricted"]).optional(),
+    allowedModels: z.array(z.string().trim().min(1)).max(1000).optional(),
+    allowedCombos: z.array(z.string().trim().min(1).max(200)).max(500).optional(),
     noLog: z.boolean().optional(),
     allowUsageCommand: z.boolean().optional(),
     usageLimitEnabled: z.boolean().optional(),
@@ -45,7 +64,10 @@ export const createKeySchema = z
     scopes: z.array(z.string().trim().min(1).max(64)).max(32).optional(),
     allowedConnections: z.array(z.string().uuid()).min(1).max(100).optional(),
   })
-  .superRefine(requireExclusiveLeaseConnections);
+  .superRefine((value, ctx) => {
+    requireConsistentModelAccess(value, ctx);
+    requireExclusiveLeaseConnections(value, ctx);
+  });
 
 export const createSyncTokenSchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(200),

--- a/tests/integration/api-keys.test.ts
+++ b/tests/integration/api-keys.test.ts
@@ -12,6 +12,8 @@ process.env.CLOUD_URL = "http://cloud.example";
 
 const core = await import("../../src/lib/db/core.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const apiKeyPolicy = await import("../../src/shared/utils/apiKeyPolicy.ts");
 const { updateSettings } = await import("@/lib/db/settings");
 const localDb = { updateSettings };
 const compliance = await import("../../src/lib/compliance/index.ts");
@@ -132,6 +134,74 @@ test("POST /api/keys creates a key, preserves special characters, and persists n
   assert.equal(stored?.noLog, true);
   assert.equal(stored?.compressionEnabled, true);
   assert.equal(compliance.isNoLog(body.id), true);
+});
+
+test("POST /api/keys preserves creation-time ACL and enforces it (#12275)", async () => {
+  await enableManagementAuth();
+  await createManagementKey();
+
+  const response = await listRoute.POST(
+    await makeManagementSessionRequest("http://localhost/api/keys", {
+      method: "POST",
+      body: {
+        name: "Restricted Create",
+        modelAccessMode: "restricted",
+        allowedModels: ["openai/gpt-4.1-mini"],
+        allowedCombos: ["focused-chat"],
+      },
+    })
+  );
+  const body = (await response.json()) as {
+    id: string;
+    key: string;
+    modelAccessMode: string;
+    allowedModels: string[];
+    allowedCombos: string[];
+  };
+  const stored = await apiKeysDb.getApiKeyById(body.id);
+
+  await combosDb.createCombo({
+    name: "focused-chat",
+    strategy: "priority",
+    config: { maxRetries: 0, retryDelayMs: 0 },
+    models: ["openai/gpt-4.1-mini"],
+  });
+  await combosDb.createCombo({
+    name: "blocked-chat",
+    strategy: "priority",
+    config: { maxRetries: 0, retryDelayMs: 0 },
+    models: ["anthropic/claude-sonnet-4-5"],
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(body.modelAccessMode, "restricted");
+  assert.deepEqual(body.allowedModels, ["openai/gpt-4.1-mini"]);
+  assert.deepEqual(body.allowedCombos, ["focused-chat"]);
+  assert.equal(stored?.modelAccessMode, "restricted");
+  assert.deepEqual(stored?.allowedModels, ["openai/gpt-4.1-mini"]);
+  assert.deepEqual(stored?.allowedCombos, ["focused-chat"]);
+
+  const allowed = await apiKeyPolicy.enforceApiKeyPolicy(
+    makeRequest("http://localhost/api/v1/chat/completions", { token: body.key }),
+    "openai/gpt-4.1-mini"
+  );
+  const denied = await apiKeyPolicy.enforceApiKeyPolicy(
+    makeRequest("http://localhost/api/v1/chat/completions", { token: body.key }),
+    "anthropic/claude-sonnet-4-5"
+  );
+  const allowedCombo = await apiKeyPolicy.enforceApiKeyPolicy(
+    makeRequest("http://localhost/api/v1/chat/completions", { token: body.key }),
+    "focused-chat"
+  );
+  const deniedCombo = await apiKeyPolicy.enforceApiKeyPolicy(
+    makeRequest("http://localhost/api/v1/chat/completions", { token: body.key }),
+    "blocked-chat"
+  );
+
+  assert.equal(allowed.rejection, null);
+  assert.equal(denied.rejection?.status, 403);
+  assert.equal(allowedCombo.rejection, null);
+  assert.equal(deniedCombo.rejection?.status, 403);
 });
 
 test("POST /api/keys validates missing and oversized names", async () => {


### PR DESCRIPTION
## Summary

Fixes #12275 by preserving explicit API-key ACL fields during `POST /api/keys` creation instead of silently falling back to permissive defaults.

## Problem

A create request could include:

- `modelAccessMode: "restricted"`
- `allowedModels`
- `allowedCombos`

but the creation path did not preserve those fields. The key was created with broader defaults (`modelAccessMode='all'`, empty model list interpreted as allow-all, and `allowedCombos=['combo/*']`).

Security invariant:

> Requested restriction must not result in broader effective authorization.

## Root Cause

- `createKeySchema` did not include the ACL fields, so validation stripped them.
- `POST /api/keys` did not destructure or forward them.
- `createApiKey()` only accepted `allowedConnections` in creation options and inserted permissive ACL defaults.

## Solution

- Add create-path schema support for `modelAccessMode`, `allowedModels`, and `allowedCombos`.
- Forward validated ACL fields from `POST /api/keys` into `createApiKey()`.
- Extend `createApiKey()` options and persist ACL fields in the initial insert, avoiding a create-then-update fail-open window.
- Return created ACL fields in the 201 response for readback evidence.
- Add an integration regression test that checks response, persisted state, model enforcement, and combo enforcement.

## Validation

Passed:

```bash
node --import tsx/esm --test tests/integration/api-keys.test.ts
# 17 pass, 0 fail

npm run typecheck:core
# pass

git diff --check
# pass
```

Regression proof:

- With the new regression test present and the source fix reverted, the test failed on the create-path ACL readback: actual `undefined`, expected `restricted`.
- Restoring the fix made the same focused integration test pass.

Not fully green locally:

```bash
npm run lint
```

failed on the current repository baseline with 5161 errors across 1053 files, mostly pre-existing `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-unused-vars` reports. I did not change lint policy or suppress failures.

## Scope / Risk

In scope:

- API-key creation schema/handler/persistence
- focused regression coverage for #12275

Out of scope:

- broad authorization engine refactor
- WebSocket authorization
- other credential types
- provider-plugin or marketplace governance changes

Compatibility:

- Requests that omit ACL fields keep the existing defaults.
- Explicit restricted requests now preserve and enforce the requested narrower policy.

## Effective Authorization Proof

This regression verifies authorization behavior, not only persistence/readback.

REQUESTED:
- restricted
- allowedModels = ["openai/gpt-4.1-mini"]
- allowedCombos = ["focused-chat"]

PERSISTED:
- restricted
- ["openai/gpt-4.1-mini"]
- ["focused-chat"]

EFFECTIVE AUTHORIZATION:

| Target | Requested | Effective |
|---|---|---|
| openai/gpt-4.1-mini | allow | ALLOW |
| anthropic/claude-4-5 | deny | DENY |
| focused-chat | allow | ALLOW |
| blocked-chat | deny | DENY |

## Effective Behavior

- `getApiKeyById` returns exactly the requested ACL shape.
- `validateApiKey` allows the requested model/combo and denies unlisted targets.

No broader effective authorization is produced from the creation path.
