### PR TITLE
fix(providers): stop an unrelated-provider tiktoken bundling failure from crashing /api/providers

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -761,15 +761,21 @@ export default function CombosPage() {
   const [proxyConfig, setProxyConfig] = useState(null);
   const { comboProxyAssignedIds, fetchComboProxyAssignments } = useComboProxyAssignments();
   const [providerNodes, setProviderNodes] = useState([]);
-  const [showUsageGuide, setShowUsageGuide] = useState(() => {
-    // Lazy initializer instead of a mount effect (react-hooks/set-state-in-effect).
+  // SSR has no localStorage, so a lazy initializer reading it here returns a
+  // different value server-side (always "not dismissed") than the client's
+  // real stored value -- exactly the kind of source React's hydration
+  // mismatch check is built to catch, and in dev mode a mismatch forces a
+  // full client-only re-render of this tree, discarding whatever the fetch
+  // effects below had already populated. Start with the SSR-safe default on
+  // both passes and correct it client-only, after hydration, in an effect.
+  const [showUsageGuide, setShowUsageGuide] = useState(true);
+  useEffect(() => {
     try {
-      return globalThis.localStorage?.getItem(COMBO_USAGE_GUIDE_STORAGE_KEY) !== "1";
+      setShowUsageGuide(globalThis.localStorage?.getItem(COMBO_USAGE_GUIDE_STORAGE_KEY) !== "1");
     } catch {
       // Ignore storage access errors (privacy mode / restricted environments)
-      return true;
     }
-  });
+  }, []);
   const [recentlyCreatedCombo, setRecentlyCreatedCombo] = useState("");
   const [creatingKimiPreset, setCreatingKimiPreset] = useState(false);
   const [comboDragIndex, setComboDragIndex] = useState(null);

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -47,7 +47,15 @@ import {
   fetchModelSyncInternal,
   getModelSyncInternalBaseUrl,
 } from "@/shared/services/modelSyncScheduler";
-import { finalizeValidatedChatGptWebCodexSecrets } from "@omniroute/open-sse/services/chatgptWebCodexAdmin.ts";
+// Dynamically imported below, inside the one `provider === "chatgpt-web-codex"`
+// branch that needs it: this module's transitive chain pulls in tiktoken's
+// WASM tokenizer, which Turbopack dev mode fails to resolve for this graph
+// even with `tiktoken` listed in serverExternalPackages (the standalone
+// Node require works fine; only Turbopack's bundling of this import path
+// doesn't). A static top-level import evaluates that whole chain on EVERY
+// /api/providers request regardless of provider, turning an unrelated-
+// provider bug into a route-wide 500. Loading it lazily, only when actually
+// needed, avoids paying that cost (and that risk) on the common path.
 import { isAutoFetchModelsEnabled } from "@/lib/providerModels/modelDiscovery";
 import { testSingleConnection } from "./[id]/test/route";
 import { rejectRetiredCommonChatGptWebProvider } from "@/lib/providers/chatgptWebRetirementResponse";
@@ -204,6 +212,8 @@ export async function POST(request: Request) {
           ? providerSpecificData.validationId
           : "";
       try {
+        const { finalizeValidatedChatGptWebCodexSecrets } =
+          await import("@omniroute/open-sse/services/chatgptWebCodexAdmin.ts");
         const finalized = finalizeValidatedChatGptWebCodexSecrets(apiKey || "", validationId);
         persistedApiKey = finalized.encodedCredential;
         providerSpecificData = { ...(providerSpecificData || {}) };
@@ -324,11 +334,16 @@ export async function POST(request: Request) {
         })
           .then((syncRes) => {
             if (!syncRes.ok) {
-              console.log(`[providers] Auto-sync failed for ${newConnection.id}: ${syncRes.status}`);
+              console.log(
+                `[providers] Auto-sync failed for ${newConnection.id}: ${syncRes.status}`
+              );
             }
           })
           .catch((err) => {
-            console.log(`[providers] Auto-sync error for ${newConnection.id}:`, err?.message || err);
+            console.log(
+              `[providers] Auto-sync error for ${newConnection.id}:`,
+              err?.message || err
+            );
           });
       } catch (syncSetupError) {
         // Defensive: if URL parsing or header construction itself throws, do

--- a/src/lib/providers/validation/chatgptWebCodex.ts
+++ b/src/lib/providers/validation/chatgptWebCodex.ts
@@ -4,13 +4,22 @@ import { rmSync } from "node:fs";
 import { CHATGPT_WEB_CODEX_CONNECTOR_NAME } from "@/shared/constants/chatgptWebCodex";
 import { inspectBrowserLoginCapabilities } from "@omniroute/open-sse/vendor/codex-chatgpt-web/browser-login.ts";
 import { decodeChatGptWebCodexSecrets } from "@omniroute/open-sse/executors/chatgpt-web-codex/credentials.ts";
-import { detectChromeExecutable } from "@omniroute/open-sse/executors/chatgpt-web-codex.ts";
 import {
   connectionRuntimePaths,
   ensureConnectionStorageState,
   ensureConnectionStorageStateFromCredential,
 } from "@omniroute/open-sse/executors/chatgpt-web-codex/storageState.ts";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
+
+// detectChromeExecutable (executors/chatgpt-web-codex.ts) is imported
+// dynamically below, not statically here: this module is re-exported through
+// the shared `@/lib/providers/validation` barrel that every provider
+// validator's callers pull in, and executors/chatgpt-web-codex.ts's own
+// import chain (its vendor browser adapter -> token-estimate.ts -> tiktoken's
+// WASM tokenizer) fails to bundle under Turbopack dev mode even with
+// `tiktoken` server-externalized -- turning validation of an unrelated
+// provider into a route-wide crash for anyone who merely imports the barrel.
+// A static import here evaluates that whole chain unconditionally.
 
 export async function validateChatGptWebCodexProvider({
   apiKey,
@@ -54,6 +63,8 @@ export async function validateChatGptWebCodexProvider({
       };
     }
     const cdpEndpoint = process.env.CHATGPT_WEB_CODEX_CDP_URL?.trim();
+    const { detectChromeExecutable } =
+      await import("@omniroute/open-sse/executors/chatgpt-web-codex.ts");
     const chromeExecutablePath = detectChromeExecutable(
       typeof providerSpecificData.chromeExecutablePath === "string"
         ? providerSpecificData.chromeExecutablePath


### PR DESCRIPTION
## Summary

`/api/providers` (and every barrel importer of `@/lib/providers/validation`) 500'd on every single request, caused by an unrelated provider's WASM tokenizer failing to bundle under Turbopack dev mode. Traced live: this cascaded into the combos dashboard appearing to have zero combos despite `context_handoffs`... er, `/api/combos` genuinely returning the right data every time.

## What was actually happening

1. `src/app/api/providers/route.ts` statically imports `finalizeValidatedChatGptWebCodexSecrets` from `chatgptWebCodexAdmin.ts` at module scope, even though it's only used inside the one `provider === "chatgpt-web-codex"` branch.
2. That module's transitive chain (vendor ChatGPT-Web browser adapter → `token-estimate.ts` → `tiktoken`'s WASM tokenizer) fails to bundle under Turbopack dev mode -- even with `tiktoken` already listed in `serverExternalPackages` (confirmed: the standalone Node `require()` works fine; only Turbopack's bundling of this specific import graph doesn't).
3. A static import evaluates that whole chain on **every** request regardless of which provider is actually being managed, turning an unrelated provider's bundling bug into a route-wide 500 for everyone.
4. Found the same pattern one layer deeper: `validation/chatgptWebCodex.ts` (a per-provider validator re-exported through the shared `@/lib/providers/validation` barrel that every provider validator's callers pull in) also statically imports `detectChromeExecutable` from the same `executors/chatgpt-web-codex.ts` module -- crashing anyone who merely imports the barrel, including code with nothing to do with chatgpt-web-codex.

**Observed cascading effect:** the combos dashboard page's `fetchData()` awaits four parallel requests (`combos`, `providers`, `combos/metrics`, `provider-nodes`) sequentially and calls `.json()` on each *before* ever calling `setCombos()`. Next.js dev mode returns an HTML error page (not JSON) for an uncaught exception, so `/api/providers`'s 500 threw inside that sequence and aborted the whole function before the combos fetch's own successful response was ever applied to state -- even though `/api/combos` itself returned `200` with the correct single combo every single time it was called standalone.

**Also fixes a related, independently-discovered SSR/hydration bug** in the same page: `showUsageGuide`'s `useState` lazy initializer read `localStorage` directly. SSR has no `localStorage`, so the server always computed "not dismissed" while the client could compute a different real value -- a hydration mismatch that forces React to discard and remount the client tree in dev mode, which could interrupt the fetch effect's in-flight state update. Moved the read into a mount effect instead.

## Fix

Made both `chatgptWebCodexAdmin.ts` and `executors/chatgpt-web-codex.ts` imports dynamic (`await import(...)`), loaded only when the `chatgpt-web-codex` branch actually runs, at both call sites. No behavior change to the validation logic itself.

## User Impact

- `/api/providers` (and anything importing the shared validation barrel) no longer crashes because of an unrelated provider's bundling issue.
- The combos dashboard reliably shows existing combos again.
- The `showUsageGuide` SSR/hydration mismatch is gone.

## Validation

- [x] Live-verified on a real deployment: root-caused via `call_logs`/server logs, applied the fix, confirmed `/api/providers` returns `200` and the combos page shows the existing combo again after a full restart.
- [x] `tests/unit/chatgpt-web-codex.test.ts`, `tests/unit/providers-route-codex-account-pool.test.ts`, `tests/unit/providers-route-managed-catalog.test.ts`, `tests/unit/providers-route-model-autofetch-optin.test.ts`, `tests/unit/providers-route-patch-method.test.ts`, `tests/unit/provider-journey.contract.test.ts` -- 50/50 pass.
- [x] Complexity ratchet: no new violations.
- [x] Reconciled with `upstream/release/v3.8.51` tip at branch time.
