### PR TITLE
fix(api-keys): persist the creation ACL atomically with the key row

### DIFF
--- a/changelog.d/fixes/PENDING-api-key-create-acl.md
+++ b/changelog.d/fixes/PENDING-api-key-create-acl.md
@@ -1,0 +1,1 @@
+- **fix(api-keys):** persist model and Combo access controls supplied when creating an API key

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -87,17 +87,21 @@ export async function POST(request) {
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
     const normalizedScopes = normalizeSelfServiceScopesForCreate(scopes);
-    const apiKey = await createApiKey(name, machineId, normalizedScopes, { allowedConnections });
+    // The model/Combo ACL is persisted in the same INSERT as the key row: a key must never
+    // exist, even transiently, with a wider access policy than the one requested (#12275).
+    const apiKey = await createApiKey(name, machineId, normalizedScopes, {
+      allowedConnections,
+      ...(modelAccessMode !== undefined && { modelAccessMode }),
+      ...(allowedModels !== undefined && { allowedModels }),
+      ...(allowedCombos !== undefined && { allowedCombos }),
+    });
     if (
       noLog === true ||
       allowUsageCommand === true ||
       usageLimitEnabled === true ||
       dailyUsageLimitUsd !== undefined ||
       weeklyUsageLimitUsd !== undefined ||
-      chaosModeEnabled === true ||
-      modelAccessMode !== undefined ||
-      allowedModels !== undefined ||
-      allowedCombos !== undefined
+      chaosModeEnabled === true
     ) {
       await updateApiKeyPermissions(apiKey.id, {
         ...(noLog === true && { noLog: true }),
@@ -106,9 +110,6 @@ export async function POST(request) {
         ...(dailyUsageLimitUsd !== undefined && { dailyUsageLimitUsd }),
         ...(weeklyUsageLimitUsd !== undefined && { weeklyUsageLimitUsd }),
         ...(chaosModeEnabled === true && { chaosModeEnabled: true }),
-        ...(modelAccessMode !== undefined && { modelAccessMode }),
-        ...(allowedModels !== undefined && { allowedModels }),
-        ...(allowedCombos !== undefined && { allowedCombos }),
       });
     }
 

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -79,6 +79,9 @@ export async function POST(request) {
       dailyUsageLimitUsd,
       weeklyUsageLimitUsd,
       chaosModeEnabled,
+      modelAccessMode,
+      allowedModels,
+      allowedCombos,
     } = validation.data;
 
     // Always get machineId from server
@@ -91,7 +94,10 @@ export async function POST(request) {
       usageLimitEnabled === true ||
       dailyUsageLimitUsd !== undefined ||
       weeklyUsageLimitUsd !== undefined ||
-      chaosModeEnabled === true
+      chaosModeEnabled === true ||
+      modelAccessMode !== undefined ||
+      allowedModels !== undefined ||
+      allowedCombos !== undefined
     ) {
       await updateApiKeyPermissions(apiKey.id, {
         ...(noLog === true && { noLog: true }),
@@ -100,6 +106,9 @@ export async function POST(request) {
         ...(dailyUsageLimitUsd !== undefined && { dailyUsageLimitUsd }),
         ...(weeklyUsageLimitUsd !== undefined && { weeklyUsageLimitUsd }),
         ...(chaosModeEnabled === true && { chaosModeEnabled: true }),
+        ...(modelAccessMode !== undefined && { modelAccessMode }),
+        ...(allowedModels !== undefined && { allowedModels }),
+        ...(allowedCombos !== undefined && { allowedCombos }),
       });
     }
 

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -58,7 +58,7 @@ import {
   setCachedModelPermission,
   evictModelPermissionCache,
 } from "./apiKeys/modelPermissionCache";
-import type { ModelAccessMode } from "./apiKeys/modelAccessMode";
+import { normalizeModelAccessUpdate, type ModelAccessMode } from "./apiKeys/modelAccessMode";
 import {
   normalizeApiKeyPermissionsUpdate,
   type ApiKeyPermissionsUpdate,
@@ -233,9 +233,7 @@ function assertExclusiveLeaseKeyPolicy(
   allowedConnections: readonly string[]
 ): void {
   if (scopes.includes(EXCLUSIVE_LEASE_SCOPE) && allowedConnections.length === 0) {
-    throw new ApiKeyPolicyInvariantError(
-      "lease:exclusive requires explicit allowedConnections"
-    );
+    throw new ApiKeyPolicyInvariantError("lease:exclusive requires explicit allowedConnections");
   }
 }
 
@@ -346,7 +344,7 @@ async function getModelPermissionCandidates(modelId: string): Promise<string[]> 
         providerOrAlias,
         providerScopedModel,
         resolveProviderId,
-        getProviderAlias,
+        getProviderAlias
       );
     }
     return Array.from(candidates);
@@ -364,7 +362,7 @@ async function getModelPermissionCandidates(modelId: string): Promise<string[]> 
 }
 
 async function getPublishedModelLookupTarget(
-  modelId: string,
+  modelId: string
 ): Promise<{ providerId: string; modelId: string } | null> {
   const cleanModelId = stripExtendedContextSuffix(modelId.trim());
   if (!cleanModelId) return null;
@@ -393,7 +391,7 @@ async function getPublishedModelLookupTarget(
 function ensureApiKeyColumn(
   db: ApiKeysDbLike,
   columnNames: Set<string>,
-  column: (typeof API_KEY_COLUMN_FALLBACKS)[number],
+  column: (typeof API_KEY_COLUMN_FALLBACKS)[number]
 ): void {
   if (columnNames.has(column.name)) return;
   db.exec(`ALTER TABLE api_keys ADD COLUMN ${column.definition}`);
@@ -433,13 +431,13 @@ function getPreparedStatements(db: ApiKeysDbLike): ApiKeysStatements {
     _stmtGetAllKeys = db.prepare<ApiKeyRow>("SELECT * FROM api_keys ORDER BY created_at");
     _stmtGetKeyById = db.prepare<ApiKeyRow>("SELECT * FROM api_keys WHERE id = ?");
     _stmtValidateKey = db.prepare<JsonRecord>(
-      "SELECT id, expires_at, revoked_at, is_active, is_banned FROM api_keys WHERE key = ? OR key_hash = ?",
+      "SELECT id, expires_at, revoked_at, is_active, is_banned FROM api_keys WHERE key = ? OR key_hash = ?"
     );
     _stmtGetKeyMetadata = db.prepare<ApiKeyRow>(
-      "SELECT id, name, machine_id, model_access_mode, allowed_models, blocked_models, allowed_combos, allowed_connections, allowed_quotas, no_log, auto_resolve, is_active, access_schedule, max_requests_per_day, max_requests_per_minute, throttle_delay_ms, max_sessions, revoked_at, expires_at, ip_allowlist, scopes, rate_limits, is_banned, key_hash, allowed_endpoints, stream_default_mode, cache_default_mode, disable_non_public_models, allow_usage_command, usage_limit_enabled, daily_usage_limit_usd, weekly_usage_limit_usd, chaos_mode_enabled, compression_enabled, proxy_id FROM api_keys WHERE key = ? OR key_hash = ?",
+      "SELECT id, name, machine_id, model_access_mode, allowed_models, blocked_models, allowed_combos, allowed_connections, allowed_quotas, no_log, auto_resolve, is_active, access_schedule, max_requests_per_day, max_requests_per_minute, throttle_delay_ms, max_sessions, revoked_at, expires_at, ip_allowlist, scopes, rate_limits, is_banned, key_hash, allowed_endpoints, stream_default_mode, cache_default_mode, disable_non_public_models, allow_usage_command, usage_limit_enabled, daily_usage_limit_usd, weekly_usage_limit_usd, chaos_mode_enabled, compression_enabled, proxy_id FROM api_keys WHERE key = ? OR key_hash = ?"
     );
     _stmtInsertKey = db.prepare(
-      "INSERT INTO api_keys (id, name, key, machine_id, allowed_models, allowed_combos, allowed_connections, no_log, created_at, key_prefix, key_hash, scopes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO api_keys (id, name, key, machine_id, model_access_mode, allowed_models, allowed_combos, allowed_connections, no_log, created_at, key_prefix, key_hash, scopes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     _stmtDeleteKey = db.prepare("DELETE FROM api_keys WHERE id = ?");
   }
@@ -497,7 +495,7 @@ export async function getApiKeys(limit?: number, offset?: number) {
     camelRow.streamDefaultMode = parseStreamDefaultMode((camelRow as JsonRecord).streamDefaultMode);
     camelRow.cacheDefaultMode = parseCacheDefaultMode((camelRow as JsonRecord).cacheDefaultMode);
     camelRow.disableNonPublicModels = parseDisableNonPublicModels(
-      (camelRow as JsonRecord).disableNonPublicModels,
+      (camelRow as JsonRecord).disableNonPublicModels
     );
     camelRow.allowUsageCommand = parseAllowUsageCommand((camelRow as JsonRecord).allowUsageCommand);
     camelRow.chaosModeEnabled = parseChaosModeEnabled((camelRow as JsonRecord).chaosModeEnabled);
@@ -556,7 +554,7 @@ export async function getExclusiveLeaseConnectionIds(): Promise<Set<string>> {
  * inactive, banned, or hard-lease key, and it never widens a key's allowedModels.
  */
 export async function pickApiKeyForInternalUse(
-  purpose: "combo-health-check" | "cloud-sync-verify" | "internal-probe" = "internal-probe",
+  purpose: "combo-health-check" | "cloud-sync-verify" | "internal-probe" = "internal-probe"
 ): Promise<string | null> {
   try {
     const keys = (await getApiKeys()) as Array<{
@@ -579,7 +577,7 @@ export async function pickApiKeyForInternalUse(
 
     // 1. Management-scoped key (preferred for any internal probe).
     const manageKey = keys.find(
-      (k) => isUsable(k) && Array.isArray(k.scopes) && k.scopes.includes("manage"),
+      (k) => isUsable(k) && Array.isArray(k.scopes) && k.scopes.includes("manage")
     );
     if (manageKey?.key) return manageKey.key;
 
@@ -634,7 +632,7 @@ export async function getApiKeyById(id: string) {
   camelRow.streamDefaultMode = parseStreamDefaultMode((camelRow as JsonRecord).streamDefaultMode);
   camelRow.cacheDefaultMode = parseCacheDefaultMode((camelRow as JsonRecord).cacheDefaultMode);
   camelRow.disableNonPublicModels = parseDisableNonPublicModels(
-    (camelRow as JsonRecord).disableNonPublicModels,
+    (camelRow as JsonRecord).disableNonPublicModels
   );
   camelRow.allowUsageCommand = parseAllowUsageCommand((camelRow as JsonRecord).allowUsageCommand);
   camelRow.chaosModeEnabled = parseChaosModeEnabled((camelRow as JsonRecord).chaosModeEnabled);
@@ -658,17 +656,29 @@ async function hashKey(key: string): Promise<string> {
   return createHash("sha256").update(key).digest("hex"); // nosemgrep: insufficient-password-hash
 }
 
+export interface CreateApiKeyOptions {
+  allowedConnections?: string[];
+  /** Access control persisted atomically with the key row (never via a follow-up update). */
+  modelAccessMode?: ModelAccessMode;
+  allowedModels?: string[];
+  allowedCombos?: string[];
+}
+
 export async function createApiKey(
   name: string,
   machineId: string,
   scopes: string[] = [],
-  options: { allowedConnections?: string[] } = {}
+  options: CreateApiKeyOptions = {}
 ) {
   if (!machineId) {
     throw new Error("machineId is required");
   }
   const allowedConnections = options.allowedConnections ?? [];
   assertExclusiveLeaseKeyPolicy(scopes, allowedConnections);
+  const modelAccess = normalizeModelAccessUpdate(options.modelAccessMode, options.allowedModels);
+  const modelAccessMode: ModelAccessMode = modelAccess.modelAccessMode ?? "all";
+  const allowedModels = modelAccess.allowedModels ?? [];
+  const allowedCombos = options.allowedCombos ?? [ALL_COMBOS_ACCESS_RULE];
 
   const db = getDbInstance() as ApiKeysDbLike;
   const now = new Date().toISOString();
@@ -681,9 +691,9 @@ export async function createApiKey(
     name: name,
     key: result.key,
     machineId: machineId,
-    modelAccessMode: "all" as const,
-    allowedModels: [], // Empty array means all models allowed
-    allowedCombos: [ALL_COMBOS_ACCESS_RULE], // Explicit wildcard means all combos allowed
+    modelAccessMode,
+    allowedModels, // Empty array with mode "all" means all models allowed
+    allowedCombos, // ["combo/*"] means all combos allowed; [] denies every Combo
     allowedConnections,
     noLog: false,
     allowUsageCommand: false,
@@ -697,14 +707,15 @@ export async function createApiKey(
     apiKey.name,
     apiKey.key,
     apiKey.machineId,
-    "[]",
+    apiKey.modelAccessMode,
+    JSON.stringify(apiKey.allowedModels),
     JSON.stringify(apiKey.allowedCombos),
     JSON.stringify(allowedConnections),
     0,
     apiKey.createdAt,
     apiKey.key.slice(0, 12),
     await hashKey(apiKey.key),
-    JSON.stringify(scopes),
+    JSON.stringify(scopes)
   );
   setNoLog(apiKey.id, false);
 
@@ -726,7 +737,7 @@ export async function regenerateApiKey(id: string) {
 
   // Update in DB
   const updateStmt = db.prepare(
-    "UPDATE api_keys SET key = ?, key_hash = ?, key_prefix = ? WHERE id = ?",
+    "UPDATE api_keys SET key = ?, key_hash = ?, key_prefix = ? WHERE id = ?"
   );
   updateStmt.run(newKey, newHash, newPrefix, id);
 
@@ -747,7 +758,7 @@ export async function regenerateApiKey(id: string) {
 
 export async function updateApiKeyPermissions(
   id: string,
-  update: string[] | ApiKeyPermissionsUpdate,
+  update: string[] | ApiKeyPermissionsUpdate
 ) {
   const db = getDbInstance() as ApiKeysDbLike;
   getPreparedStatements(db);
@@ -1050,7 +1061,9 @@ export async function updateApiKeyPermissions(
         return false;
       }
       assertExclusiveLeaseKeyPolicy(parseStringList(row.scopes), normalized.allowedConnections);
-      const upd = db.prepare(`UPDATE api_keys SET ${updates.join(", ")} WHERE id = @id`).run(params);
+      const upd = db
+        .prepare(`UPDATE api_keys SET ${updates.join(", ")} WHERE id = @id`)
+        .run(params);
       changedRows = upd.changes ?? 0;
       db.exec("COMMIT");
     } catch (err) {
@@ -1162,7 +1175,7 @@ export async function revokeApiKey(id: string): Promise<boolean> {
 
   const result = db
     .prepare(
-      "UPDATE api_keys SET revoked_at = COALESCE(revoked_at, @ts), is_active = 0 WHERE id = @id",
+      "UPDATE api_keys SET revoked_at = COALESCE(revoked_at, @ts), is_active = 0 WHERE id = @id"
     )
     .run({ id, ts: new Date().toISOString() });
 
@@ -1291,7 +1304,7 @@ export async function validateApiKey(key: string | null | undefined) {
             revokedAt: row.revoked_at,
           }),
           "EX",
-          3600, // 1 hour cache
+          3600 // 1 hour cache
         );
       }
     } catch {
@@ -1308,7 +1321,7 @@ export async function validateApiKey(key: string | null | undefined) {
  * Get API key metadata with caching for performance
  */
 export async function getApiKeyMetadata(
-  key: string | null | undefined,
+  key: string | null | undefined
 ): Promise<ApiKeyMetadata | null> {
   if (!key || typeof key !== "string") return null;
 
@@ -1415,10 +1428,10 @@ export async function getApiKeyMetadata(
     blockedModels: parseAllowedModels(record.blocked_models ?? record.blockedModels),
     allowedCombos: parseAllowedCombos(record.allowed_combos ?? record.allowedCombos),
     allowedConnections: parseAllowedConnections(
-      record.allowed_connections ?? record.allowedConnections,
+      record.allowed_connections ?? record.allowedConnections
     ),
     allowedQuotas: parseAllowedQuotas(
-      (record as JsonRecord).allowed_quotas ?? (record as JsonRecord).allowedQuotas,
+      (record as JsonRecord).allowed_quotas ?? (record as JsonRecord).allowedQuotas
     ),
     noLog: parseNoLog(record.no_log ?? record.noLog),
     autoResolve: parseAutoResolve(record.auto_resolve ?? record.autoResolve),
@@ -1440,26 +1453,26 @@ export async function getApiKeyMetadata(
     proxyId:
       typeof record.proxy_id === "string" && record.proxy_id.trim() !== "" ? record.proxy_id : null,
     allowedEndpoints: parseStringList(
-      (record as JsonRecord).allowed_endpoints ?? (record as JsonRecord).allowedEndpoints,
+      (record as JsonRecord).allowed_endpoints ?? (record as JsonRecord).allowedEndpoints
     ),
     streamDefaultMode: parseStreamDefaultMode(
-      (record as JsonRecord).stream_default_mode ?? (record as JsonRecord).streamDefaultMode,
+      (record as JsonRecord).stream_default_mode ?? (record as JsonRecord).streamDefaultMode
     ),
     cacheDefaultMode: parseCacheDefaultMode(
       (record as JsonRecord).cache_default_mode ?? (record as JsonRecord).cacheDefaultMode
     ),
     disableNonPublicModels: parseDisableNonPublicModels(
       (record as JsonRecord).disable_non_public_models ??
-        (record as JsonRecord).disableNonPublicModels,
+        (record as JsonRecord).disableNonPublicModels
     ),
     allowUsageCommand: parseAllowUsageCommand(
-      (record as JsonRecord).allow_usage_command ?? (record as JsonRecord).allowUsageCommand,
+      (record as JsonRecord).allow_usage_command ?? (record as JsonRecord).allowUsageCommand
     ),
     chaosModeEnabled: parseChaosModeEnabled(
-      (record as JsonRecord).chaos_mode_enabled ?? (record as JsonRecord).chaosModeEnabled,
+      (record as JsonRecord).chaos_mode_enabled ?? (record as JsonRecord).chaosModeEnabled
     ),
     compressionEnabled: parseCompressionEnabled(
-      (record as JsonRecord).compression_enabled ?? (record as JsonRecord).compressionEnabled,
+      (record as JsonRecord).compression_enabled ?? (record as JsonRecord).compressionEnabled
     ),
     ...parseApiKeyUsageLimitFields(record as JsonRecord),
   };
@@ -1485,7 +1498,7 @@ export async function getApiKeyMetadata(
  */
 export async function isModelAllowedForKey(
   key: string | null | undefined,
-  modelId: string | null | undefined,
+  modelId: string | null | undefined
 ) {
   // If no key provided, allow (request may be using different auth method like JWT)
   // If no modelId provided, deny (invalid request)

--- a/src/shared/validation/schemas/keys.ts
+++ b/src/shared/validation/schemas/keys.ts
@@ -42,10 +42,22 @@ export const createKeySchema = z
     dailyUsageLimitUsd: z.coerce.number().min(0).optional().nullable(),
     weeklyUsageLimitUsd: z.coerce.number().min(0).optional().nullable(),
     chaosModeEnabled: z.boolean().optional(),
+    modelAccessMode: z.enum(["all", "restricted"]).optional(),
+    allowedModels: z.array(z.string().trim().min(1)).max(1000).optional(),
+    allowedCombos: z.array(z.string().trim().min(1).max(200)).max(500).optional(),
     scopes: z.array(z.string().trim().min(1).max(64)).max(32).optional(),
     allowedConnections: z.array(z.string().uuid()).min(1).max(100).optional(),
   })
-  .superRefine(requireExclusiveLeaseConnections);
+  .superRefine((value, ctx) => {
+    requireExclusiveLeaseConnections(value, ctx);
+    if (value.modelAccessMode === "all" && value.allowedModels?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "allowedModels must be empty when modelAccessMode is 'all'",
+        path: ["allowedModels"],
+      });
+    }
+  });
 
 export const createSyncTokenSchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(200),

--- a/tests/integration/api-keys.test.ts
+++ b/tests/integration/api-keys.test.ts
@@ -134,6 +134,57 @@ test("POST /api/keys creates a key, preserves special characters, and persists n
   assert.equal(compliance.isNoLog(body.id), true);
 });
 
+test("POST /api/keys persists a restricted model and Combo ACL", async () => {
+  await enableManagementAuth();
+  await createManagementKey();
+
+  const response = await listRoute.POST(
+    await makeManagementSessionRequest("http://localhost/api/keys", {
+      method: "POST",
+      body: {
+        name: "Restricted Create",
+        modelAccessMode: "restricted",
+        allowedModels: [],
+        allowedCombos: ["my-combo"],
+      },
+    })
+  );
+  const body = (await response.json()) as { id: string; key: string };
+  const stored = await apiKeysDb.getApiKeyById(body.id);
+
+  assert.equal(response.status, 201);
+  assert.equal(stored?.modelAccessMode, "restricted");
+  assert.deepEqual(stored?.allowedModels, []);
+  assert.deepEqual(stored?.allowedCombos, ["my-combo"]);
+  assert.equal(await apiKeysDb.isModelAllowedForKey(body.key, "openai/gpt-4.1"), false);
+});
+
+test("POST /api/keys preserves an explicit model allowlist", async () => {
+  await enableManagementAuth();
+  await createManagementKey();
+
+  const response = await listRoute.POST(
+    await makeManagementSessionRequest("http://localhost/api/keys", {
+      method: "POST",
+      body: {
+        name: "Allowlisted Create",
+        modelAccessMode: "restricted",
+        allowedModels: ["openai/gpt-4.1"],
+      },
+    })
+  );
+  const body = (await response.json()) as { id: string; key: string };
+  const stored = await apiKeysDb.getApiKeyById(body.id);
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(stored?.allowedModels, ["openai/gpt-4.1"]);
+  assert.equal(await apiKeysDb.isModelAllowedForKey(body.key, "openai/gpt-4.1"), true);
+  assert.equal(
+    await apiKeysDb.isModelAllowedForKey(body.key, "anthropic/claude-3-5-sonnet"),
+    false
+  );
+});
+
 test("POST /api/keys validates missing and oversized names", async () => {
   await enableManagementAuth();
   await createManagementKey();

--- a/tests/integration/api-keys.test.ts
+++ b/tests/integration/api-keys.test.ts
@@ -159,6 +159,29 @@ test("POST /api/keys persists a restricted model and Combo ACL", async () => {
   assert.equal(await apiKeysDb.isModelAllowedForKey(body.key, "openai/gpt-4.1"), false);
 });
 
+test("POST /api/keys with an empty Combo allowlist denies every Combo from creation", async () => {
+  await enableManagementAuth();
+  await createManagementKey();
+
+  const response = await listRoute.POST(
+    await makeManagementSessionRequest("http://localhost/api/keys", {
+      method: "POST",
+      body: {
+        name: "No Combos",
+        allowedCombos: [],
+      },
+    })
+  );
+  const body = (await response.json()) as { id: string; key: string };
+  const stored = await apiKeysDb.getApiKeyById(body.id);
+  const metadata = await apiKeysDb.getApiKeyMetadata(body.key);
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(stored?.allowedCombos, []);
+  assert.deepEqual(metadata?.allowedCombos, []);
+  assert.equal(stored?.modelAccessMode, "all");
+});
+
 test("POST /api/keys preserves an explicit model allowlist", async () => {
   await enableManagementAuth();
   await createManagementKey();

--- a/tests/unit/api-key-scope-validation.test.ts
+++ b/tests/unit/api-key-scope-validation.test.ts
@@ -47,6 +47,25 @@ test("api key validation accepts more than sixteen scopes", () => {
   assert.equal(updateKeyPermissionsSchema.safeParse({ scopes }).success, true);
 });
 
+test("createKeySchema rejects an allow-all mode with a non-empty model allowlist", () => {
+  assert.equal(
+    createKeySchema.safeParse({
+      name: "contradictory-model-policy",
+      modelAccessMode: "all",
+      allowedModels: ["openai/gpt-4.1"],
+    }).success,
+    false
+  );
+  assert.equal(
+    createKeySchema.safeParse({
+      name: "deny-all-model-policy",
+      modelAccessMode: "restricted",
+      allowedModels: [],
+    }).success,
+    true
+  );
+});
+
 test("lease scope requires an explicit non-empty connection allowlist", () => {
   const connection = "00000000-0000-4000-8000-000000000001";
   assert.equal(

--- a/tests/unit/db-apiKeys-crud.test.ts
+++ b/tests/unit/db-apiKeys-crud.test.ts
@@ -63,6 +63,46 @@ test("createApiKey with scopes stores them", async () => {
   assert.deepEqual(key.scopes, ["read", "write"]);
 });
 
+test("createApiKey persists the requested model and Combo ACL in the key row itself", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("acl-key", "machine-acl", [], {
+    modelAccessMode: "restricted",
+    allowedModels: [],
+    allowedCombos: [],
+  });
+  const stored = await apiKeys.getApiKeyById(created.id);
+
+  assert.equal(created.modelAccessMode, "restricted");
+  assert.deepEqual(created.allowedModels, []);
+  assert.deepEqual(created.allowedCombos, []);
+  assert.equal(stored?.modelAccessMode, "restricted");
+  assert.deepEqual(stored?.allowedModels, []);
+  assert.deepEqual(stored?.allowedCombos, []);
+  assert.equal(await apiKeys.isModelAllowedForKey(created.key, "openai/gpt-4.1"), false);
+});
+
+test("createApiKey without ACL options keeps the permissive defaults", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("default-key", "machine-default");
+  const stored = await apiKeys.getApiKeyById(created.id);
+
+  assert.equal(stored?.modelAccessMode, "all");
+  assert.deepEqual(stored?.allowedModels, []);
+  assert.deepEqual(stored?.allowedCombos, ["combo/*"]);
+});
+
+test("createApiKey normalizes an allow-all mode to an empty model allowlist", async () => {
+  await resetStorage();
+  const created = await apiKeys.createApiKey("normalized-key", "machine-norm", [], {
+    modelAccessMode: "all",
+    allowedModels: ["openai/gpt-4.1"],
+  });
+  const stored = await apiKeys.getApiKeyById(created.id);
+
+  assert.equal(stored?.modelAccessMode, "all");
+  assert.deepEqual(stored?.allowedModels, []);
+});
+
 test("createApiKey rejects empty machineId", async () => {
   await resetStorage();
   await assert.rejects(() => apiKeys.createApiKey("Bad Key", ""), {


### PR DESCRIPTION
## Summary

- `POST /api/keys` now persists the `modelAccessMode`, `allowedModels` and `allowedCombos` supplied at creation time instead of silently creating a permissive key.
- The ACL is written by the same `INSERT` that creates the key row: a key never exists, even transiently, with a wider policy than requested, and a failed follow-up update can no longer leave it permissive.
- The create schema accepts the same ACL shapes as the PATCH route and rejects the contradictory `modelAccessMode: "all"` + non-empty `allowedModels` form.

## Related Issues

- Closes #12275

## Validation

- [x] Change type: DB / API
- [x] Focused tests and category gates from the golden path: `tests/integration/api-keys.test.ts` 19/19, `tests/unit/api-key-scope-validation.test.ts` + `tests/unit/api-manager-provider-permissions.test.ts` + `tests/unit/api-key-policy.test.ts` + `tests/unit/db-apiKeys-crud.test.ts` 124/124, `npm run typecheck:core` exit 0, focused ESLint exit 0, `check:changelog-integrity` OK, `check:provider-consistency` OK
- [ ] `npm run lint` — exit 0 on the current tip (repository-wide)
- [x] Reconciled with the current active release base `release/v3.8.51@158647618`; focused checks rerun afterward
- [x] Production-code changes include new automated tests in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Mutation checks: removing the ACL pass-through in the route, or making `createApiKey` ignore its ACL options, turns the new tests RED (2/2 fail in each case); restoring the patch returns GREEN.

## Tests Added Or Updated

- `tests/integration/api-keys.test.ts` — restricted mode + empty model list + named Combo persisted from `POST /api/keys`; explicit model allowlist preserved; empty `allowedCombos` denies every Combo from creation
- `tests/unit/db-apiKeys-crud.test.ts` — `createApiKey` persists the ACL in the key row; defaults unchanged without options; allow-all mode normalizes to an empty allowlist
- `tests/unit/api-key-scope-validation.test.ts` — `createKeySchema` rejects allow-all with a non-empty allowlist and accepts restricted + empty

## Coverage Notes

- `src/lib/db/apiKeys.ts` (`createApiKey`, insert statement) is covered by the new CRUD tests; `src/app/api/keys/route.ts` and `src/shared/validation/schemas/keys.ts` by the integration and schema tests above.
- No file's coverage moved down; the touched functions gained tests.

## Reviewer Notes

- The `INSERT` now sets `model_access_mode` explicitly (column exists since migration 147, default `'all'`), so rows created without ACL options are byte-identical to before.
- `createApiKey` gained an optional `modelAccessMode` / `allowedModels` / `allowedCombos` on its existing `options` object; existing callers are unaffected.
- Semantics match the PATCH route: `restricted` + `allowedModels: []` denies every direct model; `allowedCombos: []` denies every Combo; `["combo/*"]` (the default) allows all Combos.
