### PR TITLE
test(executors): restore the #10986 reasoning-only fallback guards

### DIFF
--- a/tests/unit/command-code-executor.test.ts
+++ b/tests/unit/command-code-executor.test.ts
@@ -485,6 +485,117 @@ test("Command Code executor falls back to /alpha/generate on 403 (Go plan) for n
   assert.equal(usage.total_tokens, 5);
 });
 
+// Simulates a Go-plan key: /provider/v1/chat/completions answers 403 and the executor
+// falls back to /alpha/generate, whose CLI SSE stream is built from `cliLines`.
+function goPlanFallbackFetch(cliLines: unknown[]) {
+  const calls: string[] = [];
+  globalThis.fetch = async (url) => {
+    const urlStr = String(url);
+    calls.push(urlStr);
+
+    if (urlStr.includes("/provider/v1/chat/completions")) {
+      return new Response(
+        JSON.stringify({ error: { message: "upgrade_required", code: "upgrade_required" } }),
+        { status: 403, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    if (urlStr.includes("/alpha/generate")) {
+      const cliSse = cliLines.map((line) => `data: ${JSON.stringify(line)}\n\n`).join("");
+      return new Response(cliSse, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  };
+  return calls;
+}
+
+test("Command Code /alpha/generate fallback: reasoning-only output falls back to reasoning as content (non-stream) (#10986)", async () => {
+  const calls = goPlanFallbackFetch([
+    { type: "reasoning-delta", text: "The user wants 79874+93658. " },
+    { type: "reasoning-delta", text: "That equals 173532." },
+    {
+      type: "finish",
+      finishReason: "stop",
+      totalUsage: {
+        inputTokens: 20,
+        outputTokens: 64,
+        outputTokenDetails: { reasoningTokens: 61 },
+      },
+    },
+  ]);
+
+  const { response, url } = await (
+    await getExecutor("command-code")
+  ).execute({
+    model: "deepseek/deepseek-v4-flash",
+    stream: false,
+    credentials: { apiKey: "cc_go_plan_key" },
+    body: {
+      messages: [
+        { role: "user", content: "Calculate 79874+93658, and reply with the result only." },
+      ],
+    },
+  });
+
+  assert.equal(calls.length, 2, "probed /provider/v1 first, then fell back to /alpha/generate");
+  assert.ok(url.includes("/alpha/generate"));
+  const json = (await response.json()) as {
+    choices: Array<{
+      message: { content: string; reasoning_content?: string };
+      finish_reason: string;
+    }>;
+    usage: { completion_tokens_details: { reasoning_tokens: number } };
+  };
+  const message = json.choices[0].message;
+  // Regression #10986: when the model emits only reasoning-delta events (never a
+  // text-delta), content must fall back to the reasoning text instead of "" (which
+  // OpenAI-compatible clients treat as null/no answer).
+  assert.equal(message.content, "The user wants 79874+93658. That equals 173532.");
+  // reasoning_content must STAY populated for reasoning-aware clients.
+  assert.equal(message.reasoning_content, "The user wants 79874+93658. That equals 173532.");
+  assert.equal(json.choices[0].finish_reason, "stop");
+  assert.equal(json.usage.completion_tokens_details.reasoning_tokens, 61);
+});
+
+test("Command Code /alpha/generate fallback: reasoning-only output emits a content delta chunk when streaming (#10986)", async () => {
+  const calls = goPlanFallbackFetch([
+    { type: "reasoning-delta", text: "The result is 173532." },
+    { type: "finish", finishReason: "stop" },
+  ]);
+
+  const { response, url } = await (
+    await getExecutor("command-code")
+  ).execute({
+    model: "deepseek/deepseek-v4-flash",
+    stream: true,
+    credentials: { apiKey: "cc_go_plan_key" },
+    body: { messages: [{ role: "user", content: "Calcular 79874+93658" }] },
+  });
+
+  assert.equal(calls.length, 2, "probed /provider/v1 first, then fell back to /alpha/generate");
+  assert.ok(url.includes("/alpha/generate"));
+  const sse = await response.text();
+  assert.match(sse, /data: \[DONE\]/);
+  const chunks = parseSsePayloads(sse);
+  assert.equal(chunks[0].choices[0].delta.role, "assistant");
+  // Regression #10986: the reasoning-only stream must emit a content delta when it
+  // otherwise ends with no content. reasoning_content stays present too.
+  const contentChunks = chunks.filter((c) => c.choices[0]?.delta?.content !== undefined);
+  assert.equal(contentChunks.length, 1, "exactly one synthesized content delta");
+  assert.equal(contentChunks[0].choices[0].delta.content, "The result is 173532.");
+  const reasoningDelta = chunks.find((c) => c.choices[0]?.delta?.reasoning_content !== undefined);
+  assert.equal(reasoningDelta.choices[0].delta.reasoning_content, "The result is 173532.");
+  // The synthesized content lands after the reasoning delta and before the finish chunk.
+  const finishIndex = chunks.findIndex((c) => c.choices[0]?.finish_reason === "stop");
+  assert.ok(finishIndex > chunks.indexOf(contentChunks[0]));
+  assert.ok(chunks.indexOf(contentChunks[0]) > chunks.indexOf(reasoningDelta));
+  assert.equal(chunks[finishIndex].choices[0].finish_reason, "stop");
+});
+
 test("Command Code executor surfaces fallback error when both /provider/v1 and /alpha/generate fail", async () => {
   globalThis.fetch = async (url) => {
     const urlStr = String(url);


### PR DESCRIPTION
## Summary

- Restores the two regression tests that #10986 added for reasoning-only Command Code output. The #10265 rewrite of `tests/unit/command-code-executor.test.ts` (b6412c6fe) deleted them, even though the production fallback in `createJsonResponse` / `createStreamResponse` (`open-sse/executors/commandCode.ts`) survived that rewrite, leaving it unguarded.
- Since #10265 the CLI translator is only reachable through the `/alpha/generate` fallback taken when `/provider/v1/chat/completions` answers 403/404, so both tests are routed through that path via a shared `goPlanFallbackFetch()` helper.
- Non-stream: a reasoning-only `/alpha/generate` stream yields `message.content` equal to the reasoning text, `reasoning_content` stays populated, `reasoning_tokens` is carried through from `totalUsage`.
- Stream: exactly one synthesized content delta is emitted, after the reasoning delta and before the finish chunk.

## Related Issues

- Related to #10986
- Related to #12130

## Validation

- [x] Change type: other (test-only hardening)
- [x] Focused tests and category gates from the golden path: `tests/unit/command-code-executor.test.ts` via the repository runner, 18 pass / 0 fail. Disabling the three fallback guards in `commandCode.ts` makes exactly these two tests fail (non-stream `content` becomes `""`; stream emits 0 content deltas); the file was restored unchanged afterward.
- [x] `npm run lint` — repository-wide eslint exit 0 (run with `--pass-on-unpruned-suppressions`; the literal command reports only pre-existing unused global suppressions on this base); `npm run typecheck:core` 0; `git diff --check` clean; `npm run check:changelog-integrity` OK
- [x] Reconciled with the current active release base `release/v3.8.51@158647618`; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR: not applicable, no production code changed
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- `tests/unit/command-code-executor.test.ts`: added `goPlanFallbackFetch()` helper and two tests:
  - `Command Code /alpha/generate fallback: reasoning-only output falls back to reasoning as content (non-stream) (#10986)`
  - `Command Code /alpha/generate fallback: reasoning-only output emits a content delta chunk when streaming (#10986)`
- No production code changed.

## Coverage Notes

- No change to `src/`, `open-sse/`, `electron/`, or `bin/`. The restored tests exercise the existing reasoning-only branches of `createJsonResponse` and `createStreamResponse` in `open-sse/executors/commandCode.ts`, so coverage of that file can only move up.

## Reviewer Notes

- Test-only; no runtime behaviour changes and no migrations or flags.
- This does not claim to fix #12130; it only re-establishes the guard that #10986 originally shipped so a future regression in the fallback is caught by CI.
- No changelog fragment added since there is no user-facing change; a `changelog.d/maintenance/` entry can be added if preferred.
