### PR TITLE
fix(cli): remove duplicate positional argument in tunnel create command

### DIFF
--- a/bin/cli/commands/tunnel.mjs
+++ b/bin/cli/commands/tunnel.mjs
@@ -18,7 +18,7 @@ export function registerTunnel(program) {
     });
 
   tunnel
-    .command("create [type]")
+    .command("create")
     .description(t("tunnel.createDescription"))
     .addArgument(
       new Argument("[type]", "Tunnel type").choices(VALID_TUNNEL_TYPES).default("cloudflare")

--- a/changelog.d/fixes/0000-tunnel-create-crash.md
+++ b/changelog.d/fixes/0000-tunnel-create-crash.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `omniroute tunnel create` no longer crashes with `Cannot read properties of undefined (reading optsWithGlobals)` — removed the duplicate positional argument that caused Commander.js to misalign the action callback parameters ([#12295](https://github.com/diegosouzapw/OmniRoute/issues/12295))

--- a/changelog.d/fixes/12368-tunnel-create-crash.md
+++ b/changelog.d/fixes/12368-tunnel-create-crash.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `omniroute tunnel create` no longer crashes with `Cannot read properties of undefined (reading optsWithGlobals)` — removed the duplicate positional argument that caused Commander.js to misalign the action callback parameters ([#12295](https://github.com/diegosouzapw/OmniRoute/issues/12295), [#12368](https://github.com/diegosouzapw/OmniRoute/pull/12368))

--- a/tests/unit/cli-tunnel-create-command.test.ts
+++ b/tests/unit/cli-tunnel-create-command.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #12295: `omniroute tunnel create <type>` crashed with
+// "Cannot read properties of undefined (reading optsWithGlobals)" because
+// `.command("create [type]")` + `.addArgument(new Argument("[type]", ...))`
+// registered TWO positional arguments. Commander then passed
+// (type, type2, opts, command) to the action callback, but the handler
+// destructured only (type, opts, cmd) — so `cmd` was bound to the real opts
+// object and `cmd.parent` was undefined.
+
+test("tunnel create subcommand declares exactly one positional argument (#12295)", async () => {
+  const { Command } = await import("commander");
+  const { registerTunnel } = await import("../../bin/cli/commands/tunnel.mjs");
+
+  const program = new Command();
+  registerTunnel(program);
+
+  const tunnelCmd = program.commands.find((c) => c.name() === "tunnel");
+  assert.ok(tunnelCmd, "tunnel subcommand must exist");
+
+  const createCmd = tunnelCmd.commands.find((c) => c.name() === "create");
+  assert.ok(createCmd, "create subcommand must exist");
+
+  // Before the fix, Commander registered two arguments named "type" because
+  // both .command("create [type]") and .addArgument(...) contributed one.
+  // After the fix, only .addArgument(...) defines the positional.
+  // Commander stores positional arguments in _args; the public args getter
+  // returns only required args, so optional args (like [type]) only appear in _args.
+  assert.equal(
+    createCmd._args.length,
+    1,
+    `create subcommand must have exactly 1 positional argument, got ${createCmd._args.length}`
+  );
+});
+
+test("tunnel create subcommand action handler accesses parent via Command instance (#12295)", async () => {
+  const { Command } = await import("commander");
+  const { registerTunnel } = await import("../../bin/cli/commands/tunnel.mjs");
+
+  const program = new Command();
+  registerTunnel(program);
+
+  const tunnelCmd = program.commands.find((c) => c.name() === "tunnel");
+  const createCmd = tunnelCmd.commands.find((c) => c.name() === "create");
+
+  assert.ok(createCmd._actionHandler, "create subcommand must have an action handler");
+
+  // Before the fix, the action callback received (type, type2, opts, command)
+  // because of the double positional. Destructuring (type, opts, cmd) then
+  // bound cmd to the opts object, making cmd.parent undefined and
+  // cmd.parent.optsWithGlobals() throw.
+  // After the fix, there's only one positional, so (type, opts, cmd) correctly
+  // binds cmd to the Command instance where cmd.parent === tunnelCmd.
+  // We can verify this by checking the parent chain on the createCmd itself:
+  assert.equal(
+    createCmd.parent,
+    tunnelCmd,
+    "create subcommand's parent must be the tunnel command"
+  );
+  assert.equal(
+    createCmd.parent.parent,
+    program,
+    "tunnel command's parent must be the root program"
+  );
+});
+
+test("tunnel create subcommand accepts valid tunnel type choices", async () => {
+  const { Command } = await import("commander");
+  const { registerTunnel } = await import("../../bin/cli/commands/tunnel.mjs");
+
+  const program = new Command();
+  registerTunnel(program);
+
+  const tunnelCmd = program.commands.find((c) => c.name() === "tunnel");
+  const createCmd = tunnelCmd.commands.find((c) => c.name() === "create");
+
+  // The addArgument with choices should still be registered.
+  assert.equal(createCmd._args.length, 1, "must have exactly one positional after addArgument");
+
+  // Verify choices are present on the argument.
+  const arg = createCmd._args[0];
+  assert.ok(arg, "first argument must exist");
+  assert.deepEqual(
+    arg.argChoices,
+    ["cloudflare", "tailscale", "ngrok"],
+    "argument choices must match VALID_TUNNEL_TYPES"
+  );
+  assert.equal(arg.defaultValue, "cloudflare", "default type must be cloudflare");
+});


### PR DESCRIPTION
## Summary

`omniroute tunnel create <type>` crashed immediately with `Cannot read properties of undefined (reading optsWithGlobals)` because Commander.js registered two positional arguments for `type`.

The subcommand was declared as `.command("create [type]")` and then `.addArgument(new Argument("[type]", ...))` was called, which added a second `type` positional. Commander passed four arguments `(type, type2, opts, command)` to the action callback, but the handler destructured only three `(type, opts, cmd)` — so `cmd` was bound to the real opts object and `cmd.parent` was `undefined`.

Fix: change `.command("create [type]")` to `.command("create")` and rely solely on `.addArgument()` for the optional type argument with choices and default — matching how the other subcommands (`stop`, `status`, `logs`, `info`, `rotate`) each declare a single positional.

## Related Issues

- Closes #12295

## Validation

- [x] Change type: CLI
- [x] Focused tests: `node --import tsx/esm --test tests/unit/cli-tunnel-create-command.test.ts` — 3/3 pass
- [x] Existing tunnel tests pass: `tests/unit/tunnel-routes-error-sanitization.test.ts` (9/9) and `tests/unit/authz/route-guard-tunnel-processes-local-only.test.ts` (4/4)
- [x] Pre-commit hooks passed (Prettier, ESLint, docs-sync, any-budget, tracked-artifacts)
- [x] TypeScript typecheck passes

## Tests Added Or Updated

- **Added**: `tests/unit/cli-tunnel-create-command.test.ts` — 3 tests:
  1. Verifies `create` subcommand has exactly 1 positional argument (not 2)
  2. Verifies parent chain is correct (`createCmd.parent === tunnelCmd`)
  3. Verifies argument choices and default value are preserved

## Coverage Notes

- This PR changes `bin/cli/commands/tunnel.mjs`. The new test file covers the command structure and argument registration. The action handler itself (`runTunnelCreateCommand`) requires a running server to fully exercise, which is out of scope for a unit test.

## Reviewer Notes

- This is a minimal fix — 1 line changed in the production code. The bug is straightforward Commander.js API misuse.
- The `changelog.d/fixes/0000-tunnel-create-crash.md` entry uses `0000` as a placeholder PR number — the release captain will update it during aggregation.