### PR TITLE
fix(sse): stop mergeAbortSignals from leaking abort listeners

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -225,14 +225,36 @@ export type CountTokensInput = {
   signal?: AbortSignal | null;
 };
 
+/**
+ * Merge two abort signals into one that fires when either does.
+ *
+ * The `primary`/`secondary` abort listeners registered below MUST be removed once the
+ * merged controller settles — otherwise they outlive this call and stay attached to
+ * whichever input signal is longer-lived (typically the combo/client signal, which
+ * stays open for the whole request while this merge is re-done per executor fetch
+ * attempt/retry). A hedge cancellation or client disconnect arriving after this
+ * particular merge's caller has already moved on then still fires the listener,
+ * detached from anything that's still awaiting it. Mirrors the already-correct
+ * self-cleaning pattern in `open-sse/utils/directResponseStartTimeout.ts`'s local
+ * `mergeAbortSignals` (#hedge-cancelled-abort-listener-leak).
+ */
 export function mergeAbortSignals(primary: AbortSignal, secondary: AbortSignal): AbortSignal {
   const controller = new AbortController();
+
+  const cleanup = () => {
+    primary.removeEventListener("abort", onPrimaryAbort);
+    secondary.removeEventListener("abort", onSecondaryAbort);
+  };
 
   const abortFrom = (source: AbortSignal) => {
     if (!controller.signal.aborted) {
       controller.abort(source.reason);
     }
+    cleanup();
   };
+
+  const onPrimaryAbort = () => abortFrom(primary);
+  const onSecondaryAbort = () => abortFrom(secondary);
 
   if (primary.aborted) {
     abortFrom(primary);
@@ -243,8 +265,8 @@ export function mergeAbortSignals(primary: AbortSignal, secondary: AbortSignal):
     return controller.signal;
   }
 
-  primary.addEventListener("abort", () => abortFrom(primary), { once: true });
-  secondary.addEventListener("abort", () => abortFrom(secondary), { once: true });
+  primary.addEventListener("abort", onPrimaryAbort, { once: true });
+  secondary.addEventListener("abort", onSecondaryAbort, { once: true });
   return controller.signal;
 }
 

--- a/tests/unit/executor-base-utils.test.ts
+++ b/tests/unit/executor-base-utils.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
+import type { EventEmitter } from "node:events";
 
 const base = await import("../../open-sse/executors/base.ts");
 
@@ -114,6 +116,42 @@ test("mergeAbortSignals aborts when secondary fires", () => {
   assert.ok(!merged.aborted);
   c2.abort(new Error("secondary"));
   assert.ok(merged.aborted);
+});
+
+// Regression: mergeAbortSignals used to attach its "abort" listeners to `primary`/
+// `secondary` and never remove them. Every executor fetch attempt calls this (once
+// per URL/retry — open-sse/executors/base.ts's fetchWithStartTimeout), so a busy
+// combo request accumulated one live listener per call on the long-lived combo/
+// client signal. Each leaked listener still fires when that signal is aborted later
+// (e.g. a hedge cancellation — COMBO_HEDGE_CANCELLED_REASON, "hedge-cancelled" —
+// arriving after this particular merge's own caller already finished), for a
+// `merged` output nothing is watching anymore. Proven here by counting real
+// listener growth (via node:events' getEventListeners) across repeated merges of
+// the SAME long-lived primary signal — exactly the fetchWithStartTimeout pattern.
+test("mergeAbortSignals removes its listeners once the merged signal settles (no leak across repeated merges)", () => {
+  const countAbortListeners = (target: AbortSignal) =>
+    getEventListeners(target as unknown as EventEmitter, "abort").length;
+
+  const longLived = new AbortController();
+  const before = countAbortListeners(longLived.signal);
+
+  for (let i = 0; i < 25; i++) {
+    const perAttempt = new AbortController();
+    const merged = base.mergeAbortSignals(longLived.signal, perAttempt.signal);
+    assert.ok(!merged.aborted);
+    // Simulate this attempt finishing on its own (its own timeout/abort fires),
+    // the way each fetchWithStartTimeout call's timeoutController does.
+    perAttempt.abort(new Error(`attempt-${i}-timeout`));
+    assert.ok(merged.aborted);
+  }
+
+  const after = countAbortListeners(longLived.signal);
+  assert.ok(
+    after <= before + 1,
+    `expected mergeAbortSignals to clean up its "abort" listener on the long-lived ` +
+      `signal after each merge settles; listener count grew from ~${before} to ${after} ` +
+      `across 25 merges (leak)`
+  );
 });
 
 test("sanitizeReasoningEffortForProvider passes through body without reasoning_effort", () => {


### PR DESCRIPTION
## Summary

`mergeAbortSignals()` in `open-sse/executors/base.ts` attached `"abort"` listeners to its `primary`/`secondary` signals but never removed them once the merged signal settled. Every executor fetch attempt calls this (`fetchWithStartTimeout`, once per URL/retry), so a busy combo request accumulated one live listener per call on the long-lived combo/client signal. A leaked listener still fires when that signal is later aborted (e.g. a hedge cancellation arriving after this merge's own caller already finished), for a merged output nothing is watching anymore.

Fix mirrors the already-correct self-cleaning pattern in `open-sse/utils/directResponseStartTimeout.ts`'s local `mergeAbortSignals`.

Originally investigated from a production crash: `Error [AbortError]: hedge-cancelled` thrown unhandled from deep inside the built Next.js server bundle, killing the whole Node process. This fix addresses one confirmed, measured listener leak on the exact signal-merge path that carries the hedge-cancellation reason through every provider fetch — it removes a real defect regardless, though it was not possible to build a full end-to-end repro of that exact crash through the entire combo-hedging dispatch path.

## Test plan

- [x] TDD: added a regression test (`tests/unit/executor-base-utils.test.ts`) that merges the same long-lived signal 25 times and counts real listener growth via `node:events`' `getEventListeners`.
- [x] Confirmed red on pre-fix code: exactly 25 leaked listeners after 25 merges.
- [x] Confirmed green on fixed code: 0 leaked listeners, 23/23 tests passing in the full file.
- [x] Ran `tests/unit/executor-base-utils.test.ts` on Windows (the platform the original crash was observed on) — 23/23 pass.
- [x] Scoped ESLint on both changed files — 0 new violations (pre-existing violations elsewhere in `base.ts` are outside this diff's hunks).
