### PR TITLE
fix(memory): resolve rerank provider node cache import

### DIFF
--- a/src/app/api/memory/rerank-providers/route.ts
+++ b/src/app/api/memory/rerank-providers/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
     // Local rerank-capable provider_nodes appended after curated entries.
     const extra = [];
     try {
-      const { getCachedProviderNodes } = await import("@/lib/localDb");
+      const { getCachedProviderNodes } = await import("@/lib/db/readCache");
       const nodes = await getCachedProviderNodes();
       for (const n of Array.isArray(nodes) ? nodes : []) {
         const apiType = (n as { apiType?: string }).apiType || "";

--- a/tests/unit/rerank-providers-route.test.ts
+++ b/tests/unit/rerank-providers-route.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { NextRequest } from "next/server";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rerank-providers-route-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { createProviderNode } = await import("../../src/lib/db/providers/nodes.ts");
+const rerankProvidersRoute = await import("../../src/app/api/memory/rerank-providers/route.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("GET /api/memory/rerank-providers includes rerank-capable local provider nodes", async () => {
+  await createProviderNode({
+    id: "rerank-route-test-node",
+    type: "openai-compatible",
+    name: "Local reranker",
+    prefix: "local-reranker",
+    apiType: "rerank",
+    baseUrl: "http://127.0.0.1:8099/v1",
+  });
+
+  const response = await rerankProvidersRoute.GET(
+    new NextRequest("http://localhost/api/memory/rerank-providers")
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(
+    body.providers.find(
+      (provider: { provider?: string }) => provider.provider === "local-reranker"
+    ),
+    { provider: "local-reranker", hasKey: true, models: [] }
+  );
+});


### PR DESCRIPTION
## Summary

- Replaces the stale `@/lib/localDb` dynamic import in the rerank-provider listing route with the specific `@/lib/db/readCache` module.
- Restores local rerank-capable provider nodes in `GET /api/memory/rerank-providers`.
- Adds a route-level regression test through the public GET handler.

## Related Issues

- Follow-up to the rerank-provider listing introduced in #11390.

## Validation

| Check | Before | Final candidate |
| --- | --- | --- |
| Raw API-route TypeScript diagnostic | `route.ts(43,55): TS2307: Cannot find module '@/lib/localDb'` | Resolved through `@/lib/db/readCache` |
| `node scripts/check/check-api-typecheck.mjs` | RED: 290 live diagnostics; 163 baseline improvements; exactly 1 regression (`rerank-providers/route.ts TS2307`) | PASS: 289 pre-existing diagnostics, all within the frozen baseline |
| Public route regression test | RED: local rerank provider missing (`undefined`) | PASS: 1/1 |
| Focused rerank tests | — | PASS: 3/3 |
| `npm run typecheck:core` | — | PASS |
| ESLint on changed files | — | PASS |
| Prettier on changed files | — | PASS |
| `git diff --check` | — | PASS |
| API typecheck baseline | Unchanged | Unchanged; no ratchet or widening |
| GitHub API Route Typecheck | Base-red on the unrelated test-only PR | SUCCESS on this candidate |
| GitHub security checks | — | CodeQL and Semgrep SUCCESS |

- [x] Change type: API / DB read path
- [x] RED→GREEN route-level regression test
- [x] Focused rerank tests
- [x] Exact API typecheck gate
- [x] Core typecheck
- [x] Targeted ESLint and Prettier
- [x] Production-code change includes an automated test

## Tests Added Or Updated

- Added `tests/unit/rerank-providers-route.test.ts`.
- The test creates an isolated local `apiType: "rerank"` provider node, calls the public GET handler, and verifies the provider is returned.
- Test database paths are fresh directories under `/tmp`; the live OmniRoute database is not accessed.

## Coverage Notes

- The new test covers the local provider-node branch that previously swallowed the unresolved dynamic import and silently omitted local rerank providers.

## Reviewer Notes

- Development base: `713440be0a06432a88ac0d8a32e430876fc8c335`.
- Reconciled live target: `cabbbe410ac79a0b2e9fd86c300c337db67a9a32`.
- Candidate head: `a2de0de5e892b5fae49bedae7cb289eeec428680`.
- Scope: 2 files, 43 insertions, 1 deletion.
- `config/quality/api-typecheck-baseline.json` is intentionally untouched despite 163 informational improvements.
- No changed-path overlap exists between the development base and the reconciled live target.
- `git merge-tree` completed without conflicts; GitHub reports the PR as `MERGEABLE` / `CLEAN`.
- This PR remains intentionally draft and open. No merge or automerge is requested.
