### PR TITLE
fix(combos): clear LKGP pins on delete

### DIFF
--- a/changelog.d/fixes/12326-combo-delete-lkgp-cleanup.md
+++ b/changelog.d/fixes/12326-combo-delete-lkgp-cleanup.md
@@ -1,0 +1,1 @@
+- **fix(combos):** deleting a combo now clears its persisted LKGP pins instead of leaving unreachable `key_value` rows behind ([#12326](https://github.com/diegosouzapw/OmniRoute/issues/12326))

--- a/src/lib/db/repositories/sqliteComboRepository.ts
+++ b/src/lib/db/repositories/sqliteComboRepository.ts
@@ -11,6 +11,7 @@ import type {
 import { normalizeComboRecord } from "@/lib/combos/steps";
 import { validateComboInvariant } from "@/lib/combos/invariants";
 import { getDbInstance } from "../core";
+import { deleteLKGPRowsByComboName } from "../settings/lkgp";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -349,8 +350,27 @@ export async function reorderCombos(comboIds: string[]): Promise<ComboReorderRes
 
 export async function deleteCombo(id: string) {
   const db = getDbInstance();
-  const result = db.prepare("DELETE FROM combos WHERE id = ?").run(id);
-  if (result.changes === 0) return false;
+  const deleteTransaction = db.transaction(() => {
+    const combo = db.prepare("SELECT name FROM combos WHERE id = ?").get(id) as
+      { name?: string } | undefined;
+    const result = db.prepare("DELETE FROM combos WHERE id = ?").run(id);
+    if (result.changes === 0) return { deleted: false, lkgpKeys: [] as string[] };
+    return {
+      deleted: true,
+      lkgpKeys: combo?.name ? deleteLKGPRowsByComboName(combo.name) : ([] as string[]),
+    };
+  });
+
+  const { deleted, lkgpKeys } = deleteTransaction();
+  if (!deleted) return false;
+
+  if (lkgpKeys.length > 0) {
+    const { invalidateCachedLKGP } = await import("../readCache");
+    for (const key of lkgpKeys) {
+      invalidateCachedLKGP(key);
+    }
+  }
+
   return true;
 }
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -840,6 +840,8 @@ export {
   setLKGP,
   clearAllLKGP,
   clearLKGP,
+  deleteLKGPByComboName,
+  deleteLKGPRowsByComboName,
   deleteLKGPByConnectionIds,
 } from "./settings/lkgp";
 

--- a/src/lib/db/settings/lkgp.ts
+++ b/src/lib/db/settings/lkgp.ts
@@ -4,6 +4,34 @@
 
 import { getDbInstance } from "../core";
 
+/**
+ * Escape SQLite `LIKE` wildcards so a combo name containing `%` or `_` cannot
+ * widen the prefix match into unrelated combos' pins.
+ */
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
+export function deleteLKGPRowsByComboName(comboName: string): string[] {
+  if (!comboName) return [];
+
+  const db = getDbInstance();
+  const prefix = `${comboName}:`;
+  const rows = db
+    .prepare("SELECT key FROM key_value WHERE namespace = 'lkgp' AND key LIKE ? ESCAPE '\\'")
+    .all(`${escapeLikePattern(prefix)}%`) as Array<{ key?: string }>;
+
+  const staleKeys = rows.map((row) => row?.key).filter((key): key is string => Boolean(key));
+  if (staleKeys.length === 0) return [];
+
+  const deleteStatement = db.prepare("DELETE FROM key_value WHERE namespace = 'lkgp' AND key = ?");
+  for (const key of staleKeys) {
+    deleteStatement.run(key);
+  }
+
+  return staleKeys;
+}
+
 export interface LKGPRecord {
   provider: string;
   connectionId?: string;
@@ -65,6 +93,27 @@ export async function clearLKGP(comboName: string, modelId: string): Promise<voi
   db.prepare("DELETE FROM key_value WHERE namespace = 'lkgp' AND key = ?").run(key);
   const { invalidateCachedLKGP } = await import("../readCache");
   invalidateCachedLKGP(key);
+}
+
+/**
+ * Delete every persisted LKGP pin belonging to a combo. Pins are keyed by
+ * `${comboName}:${modelId}`, so deleting a combo leaves its pins addressable by
+ * a name that no longer resolves — `clearAllLKGP()` is too broad and
+ * `clearLKGP()` needs a modelId the caller no longer knows. Combo delete paths
+ * call this so the pins die with their combo instead of accumulating as
+ * unreachable rows.
+ */
+export async function deleteLKGPByComboName(comboName: string): Promise<number> {
+  const staleKeys = deleteLKGPRowsByComboName(comboName);
+
+  if (staleKeys.length === 0) return 0;
+
+  const { invalidateCachedLKGP } = await import("../readCache");
+  for (const key of staleKeys) {
+    invalidateCachedLKGP(key);
+  }
+
+  return staleKeys.length;
 }
 
 /**

--- a/tests/unit/combo-delete-lkgp-cleanup-12326.test.ts
+++ b/tests/unit/combo-delete-lkgp-cleanup-12326.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Issue #12326 — deleting a combo must remove the LKGP pins keyed by its name
+ * without disturbing surviving combos' pins.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-lkgp-12326-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const comboRepo = await import("../../src/lib/db/repositories/sqliteComboRepository.ts");
+const lkgpDb = await import("../../src/lib/db/settings/lkgp.ts");
+const readCache = await import("../../src/lib/db/readCache.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      break;
+    } catch (error: unknown) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code?: unknown }).code)
+          : "";
+
+      if ((code === "EBUSY" || code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function createCombo(name: string): Promise<string> {
+  const combo = await comboRepo.createCombo({
+    name,
+    models: [{ provider: "berry", model: "model-x" }],
+  } as Parameters<typeof comboRepo.createCombo>[0]);
+
+  assert.equal(typeof combo.id, "string", "combo fixture must return an id");
+  return combo.id as string;
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("#12326: deleting a combo removes its LKGP pins", async () => {
+  const doomedId = await createCombo("doomed-combo");
+  await createCombo("survivor-combo");
+
+  await lkgpDb.setLKGP("doomed-combo", "model-x", "berry", "conn-1");
+  await lkgpDb.setLKGP("doomed-combo", "model-y", "berry", "conn-2");
+  await lkgpDb.setLKGP("survivor-combo", "model-x", "berry", "conn-3");
+
+  assert.equal(await comboRepo.deleteCombo(doomedId), true);
+
+  assert.equal(await lkgpDb.getLKGP("doomed-combo", "model-x"), null);
+  assert.equal(await lkgpDb.getLKGP("doomed-combo", "model-y"), null);
+  assert.deepEqual(await lkgpDb.getLKGP("survivor-combo", "model-x"), {
+    provider: "berry",
+    connectionId: "conn-3",
+  });
+});
+
+test("#12326: deleting a combo invalidates warmed LKGP read-cache entries", async () => {
+  const doomedId = await createCombo("cached-combo");
+
+  await lkgpDb.setLKGP("cached-combo", "model-x", "berry", "conn-1");
+
+  assert.deepEqual(await readCache.getCachedLKGP("cached-combo", "model-x"), {
+    provider: "berry",
+    connectionId: "conn-1",
+  });
+
+  assert.equal(await comboRepo.deleteCombo(doomedId), true);
+
+  assert.equal(
+    await readCache.getCachedLKGP("cached-combo", "model-x"),
+    null,
+    "deleted combos' LKGP pins must not survive in the read cache"
+  );
+});
+
+test("#12326: a combo whose name prefixes another keeps the sibling's pins", async () => {
+  const doomedId = await createCombo("prod");
+  await createCombo("prod-canary");
+
+  await lkgpDb.setLKGP("prod", "model-x", "berry", "conn-1");
+  await lkgpDb.setLKGP("prod-canary", "model-x", "berry", "conn-2");
+
+  assert.equal(await comboRepo.deleteCombo(doomedId), true);
+
+  assert.equal(await lkgpDb.getLKGP("prod", "model-x"), null);
+  assert.deepEqual(
+    await lkgpDb.getLKGP("prod-canary", "model-x"),
+    { provider: "berry", connectionId: "conn-2" },
+    "the ':' delimiter must keep a prefix-sharing sibling's pins intact"
+  );
+});
+
+test("#12326: LIKE wildcards in a combo name do not widen the cleanup", async () => {
+  const doomedId = await createCombo("temp_a");
+  await createCombo("tempXa");
+
+  await lkgpDb.setLKGP("temp_a", "model-x", "berry", "conn-1");
+  await lkgpDb.setLKGP("tempXa", "model-x", "berry", "conn-2");
+
+  assert.equal(await comboRepo.deleteCombo(doomedId), true);
+
+  assert.equal(await lkgpDb.getLKGP("temp_a", "model-x"), null);
+  assert.deepEqual(
+    await lkgpDb.getLKGP("tempXa", "model-x"),
+    { provider: "berry", connectionId: "conn-2" },
+    "'_' must be escaped so it cannot match an arbitrary character"
+  );
+});
+
+test("#12326: deleting an unknown combo id leaves LKGP state untouched", async () => {
+  await createCombo("untouched-combo");
+  await lkgpDb.setLKGP("untouched-combo", "model-x", "berry", "conn-1");
+
+  assert.equal(await comboRepo.deleteCombo("00000000-0000-0000-0000-000000000000"), false);
+
+  assert.deepEqual(await lkgpDb.getLKGP("untouched-combo", "model-x"), {
+    provider: "berry",
+    connectionId: "conn-1",
+  });
+});
+
+test("#12326: deleting a combo without pins succeeds", async () => {
+  const doomedId = await createCombo("no-pins-combo");
+
+  assert.equal(await comboRepo.deleteCombo(doomedId), true);
+  assert.equal(await lkgpDb.getLKGP("no-pins-combo", "model-x"), null);
+});


### PR DESCRIPTION
## Summary

- Cleans up LKGP `key_value` rows when a persisted combo is deleted.
- Preserves unrelated LKGP state, including prefix-sharing combo names and names containing SQLite `LIKE` wildcards.
- Adds regression coverage for deleted, unrelated, nonexistent, cached, and no-pin delete paths.

## Problem

`deleteCombo()` deleted the combo row but did not delete LKGP pins keyed by that combo name. The result was unreachable `key_value` rows under `namespace = 'lkgp'` after the combo no longer existed.

## Root Cause

LKGP pins are stored as `key = "${comboName}:${modelId}"`. Existing cleanup helpers either delete one exact `comboName:modelId` pair (`clearLKGP()`), all LKGP (`clearAllLKGP()`), or pins by provider connection id (`deleteLKGPByConnectionIds()`). `deleteCombo()` only executed `DELETE FROM combos WHERE id = ?`, so it never removed rows that belonged exclusively to the deleted combo name.

## Solution

- Add a combo-name LKGP cleanup helper that deletes keys under the exact `${comboName}:` namespace prefix.
- Escape `%`, `_`, and `\\` in the SQLite `LIKE` pattern and rely on the `:` delimiter to avoid collateral deletion.
- Run combo-row deletion and LKGP-row deletion in one SQLite transaction, then invalidate LKGP read-cache entries for the deleted keys.

## Invariant

DELETE COMBO X → REMOVE LKGP STATE OWNED BY X

AND

UNRELATED LKGP STATE → PRESERVED

Forbidden state:

DELETED COMBO → ORPHANED LKGP REFERENCE

## Regression Evidence

- Before the fix, `tests/unit/combo-delete-lkgp-cleanup-12326.test.ts` failed: deleted combo LKGP rows still returned `{ provider: 'berry', connectionId: 'conn-1' }` instead of `null`.
- After the fix, the focused regression test passes.
- Sabotage check performed by temporarily reverting the `deleteCombo()` cleanup while keeping the test: focused test failed again; after restoring the fix it passed again.

## Behavior Proof

- deleted combo pins removed
- unrelated combo pins preserved
- prefix-sharing names preserved
- cache invalidated correctly for deleted keys
- nonexistent/no-pin behavior remains safe

## Validation

- `node --import tsx/esm --test tests/unit/combo-delete-lkgp-cleanup-12326.test.ts`
- `node --import tsx/esm --test tests/unit/combo-delete-lkgp-cleanup-12326.test.ts tests/unit/combo-cache-invalidation.test.ts`
- `npm run typecheck:core`
- `npx eslint src/lib/db/repositories/sqliteComboRepository.ts src/lib/db/settings/lkgp.ts src/lib/db/settings.ts tests/unit/combo-delete-lkgp-cleanup-12326.test.ts`
- `git diff --check`

## Scope / Risk

Low scope: persistence cleanup only. No routing-provider, circuit-breaker, API-key ACL, authz, or provider-plugin behavior changed.

## Compatibility

No schema migration and no public LKGP contract change. Existing LKGP key format is preserved.

Fixes #12326
