### PR TITLE
fix(cli): preserve Claude settings on config set

### DIFF
--- a/bin/cli/commands/config.mjs
+++ b/bin/cli/commands/config.mjs
@@ -16,6 +16,29 @@ function ensureBackup(configPath) {
   return backupPath;
 }
 
+function mergeClaudeSettings(existingContent, generatedContent) {
+  const generated = JSON.parse(generatedContent);
+  let current = {};
+  if (existingContent && existingContent.trim()) {
+    current = JSON.parse(existingContent);
+    if (!current || typeof current !== "object" || Array.isArray(current)) current = {};
+  }
+  return JSON.stringify(
+    {
+      ...current,
+      ...generated,
+      env: {
+        ...(current.env && typeof current.env === "object" && !Array.isArray(current.env)
+          ? current.env
+          : {}),
+        ...(generated.env || {}),
+      },
+    },
+    null,
+    2
+  );
+}
+
 async function runConfigListCommand(opts = {}) {
   const { detectAllTools } = await import("../../../src/lib/cli-helper/tool-detector.ts");
   const tools = await detectAllTools();
@@ -120,7 +143,12 @@ async function runConfigSetCommand(toolId, opts = {}) {
   const backupPath = ensureBackup(result.configPath);
   if (backupPath) printInfo(`Backup saved to: ${backupPath}`);
 
-  fs.writeFileSync(result.configPath, result.content, "utf-8");
+  let content = result.content;
+  if (toolId === "claude" && fs.existsSync(result.configPath)) {
+    content = mergeClaudeSettings(fs.readFileSync(result.configPath, "utf-8"), result.content);
+  }
+
+  fs.writeFileSync(result.configPath, content, "utf-8");
   printSuccess(`Config written to ${result.configPath}`);
   return 0;
 }

--- a/src/lib/cli-helper/config-generator/claude.ts
+++ b/src/lib/cli-helper/config-generator/claude.ts
@@ -16,9 +16,13 @@ export function generateClaudeConfig(options: {
   const model = options.model || "claude-3-5-sonnet-20241022";
 
   const config = {
-    baseUrl: `${base}/v1`,
-    authToken: options.apiKey,
-    models: [{ id: model }],
+    model,
+    env: {
+      ANTHROPIC_BASE_URL: base,
+      ANTHROPIC_AUTH_TOKEN: options.apiKey,
+      ANTHROPIC_MODEL: model,
+      CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1",
+    },
   };
 
   return JSON.stringify(config, null, 2);

--- a/tests/unit/cli/claude-config-set-12407.test.ts
+++ b/tests/unit/cli/claude-config-set-12407.test.ts
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const cliPath = path.join(repoRoot, "bin", "omniroute.mjs");
+
+test("#12407: config set claude preserves existing settings and writes Claude Code env keys", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "omniroute-claude-config-"));
+  try {
+    const settingsPath = path.join(home, ".claude", "settings.json");
+    await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify(
+        {
+          model: "existing-model",
+          effortLevel: "high",
+          hooks: { PreToolUse: [{ command: "echo keep" }] },
+          statusLine: { type: "command", command: "omniroute status" },
+          env: { KEEP_ME: "1", ANTHROPIC_BASE_URL: "http://old" },
+        },
+        null,
+        2
+      )
+    );
+
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [
+        cliPath,
+        "config",
+        "set",
+        "claude",
+        "--model",
+        "claude-fallback",
+        "--yes",
+        "--non-interactive",
+        "--allow-container-write",
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          OMNIROUTE_API_KEY: "sk_test_12407",
+          OMNIROUTE_BASE_URL: "http://localhost:20128/v1",
+        },
+        timeout: 30_000,
+      }
+    );
+
+    assert.match(stdout + stderr, /Config written/);
+    const written = JSON.parse(await fs.readFile(settingsPath, "utf8"));
+
+    assert.equal(written.model, "claude-fallback");
+    assert.equal(written.effortLevel, "high");
+    assert.deepEqual(written.hooks, { PreToolUse: [{ command: "echo keep" }] });
+    assert.deepEqual(written.statusLine, { type: "command", command: "omniroute status" });
+    assert.equal(written.env.KEEP_ME, "1");
+    assert.equal(written.env.ANTHROPIC_BASE_URL, "http://localhost:20128");
+    assert.equal(written.env.ANTHROPIC_AUTH_TOKEN, "sk_test_12407");
+    assert.equal(written.env.ANTHROPIC_MODEL, "claude-fallback");
+    assert.equal(written.env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY, "1");
+    assert.equal("baseUrl" in written, false);
+    assert.equal("authToken" in written, false);
+    assert.equal("models" in written, false);
+  } finally {
+    await fs.rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12407.

`omniroute config set claude` now updates Claude Code settings without replacing unrelated user settings.

## Reproduction

Before this change, running:

```sh
omniroute config set claude --model claude-fallback --yes --non-interactive
```

against an existing `~/.claude/settings.json` replaced the file with only legacy `baseUrl`, `authToken`, and `models` keys. Existing Claude Code settings such as `hooks`, `statusLine`, `effortLevel`, and custom `env` entries were lost.

## Root cause

The Claude generator emitted a complete replacement document in an obsolete shape, and the CLI wrote it with `writeFileSync(result.configPath, result.content)`.

## Fix

- Generate Claude Code-compatible settings using top-level `model` plus `env.ANTHROPIC_*` keys.
- For `config set claude`, merge generated settings into the existing settings object.
- Preserve unrelated top-level settings and unrelated `env` entries.
- Still overwrite OmniRoute-owned Claude env keys and the selected model.

## Invariant

CONFIG SET CLAUDE → UPDATE OMNIROUTE-OWNED CLAUDE FIELDS → PRESERVE UNRELATED USER STATE

NEVER → WHOLESALE REPLACEMENT OF settings.json

## Preservation Proof

PRESERVED:
- hooks
- statusLine
- effortLevel
- unrelated env entries

UPDATED:
- model
- ANTHROPIC_BASE_URL
- ANTHROPIC_AUTH_TOKEN
- ANTHROPIC_MODEL

## Tests

- `DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/cli/claude-config-set-12407.test.ts tests/unit/cli/setup-claude.test.ts` — PASS, 16/16
- `npm run typecheck:core` — PASS
- scoped ESLint on changed TS test/generator — PASS
- `git diff --check` — PASS

`npm run quality:scan:fast` still has current-base failures unrelated to this change (`check:error-helper`, `check:route-guard-membership`, `check:file-size`), matching the known base drift seen during prior checks.

## Scope

No broader Claude profile redesign, no setup-claude changes, no repository-wide lint cleanup.
