### PR TITLE
fix(release): repair the tip syntax break from the maxai/uc merge auto-resolve

### DIFF
--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -612,7 +612,10 @@ export async function GET(
 
       try {
         const discovery = await discoverMaxaiModels({
-          providerSpecificData: connection.providerSpecificData,
+          providerSpecificData: connection.providerSpecificData as
+            | Record<string, unknown>
+            | null
+            | undefined,
           accessToken: apiKey || accessToken,
           fetchImpl: (url, init) =>
             safeOutboundFetch(url, {

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -348,6 +348,8 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
       "maxaiDeviceId",
       "userId",
       "maxaiUserId",
+    ],
+  },
   uc: {
     // UC (uncensored.com) persona: auth is the durable Clerk `__client` cookie
     // (a JWT with no exp) plus the session id + user id, all stored in


### PR DESCRIPTION
Third base-red window of the cycle, opened ~06:00Z by the #11461 × #11513 merge auto-resolve eating two closing lines of the `maxai` entry in `webSessionCredentials.ts` — the tip currently fails API Route Typecheck with 11 syntax errors, and every PR merge-ref cut since inherits it (first casualty: #12428).

1. Restore `],` + `},` closing the `maxai` `storageKeys` block.
2. The un-broken parser then reveals one real TS2322 the MaxAI block added in `providers/[id]/models/route.ts` — cast `connection.providerSpecificData` to the exact `Record&lt;string, unknown&gt; | null | undefined` shape `resolveMaxaiCredential` takes (pure type-level, zero runtime change; the identical neighboring callsites are baselined).

Validated locally on the tip: `check-api-typecheck` → **OK, 289 pre-existing, all baselined**; `typecheck:core` → **0 errors**.