### PR TITLE
fix(release): drain the remaining FQG reds from the UC merge window

### DIFF
--- a/config/quality/model-lifecycle.json
+++ b/config/quality/model-lifecycle.json
@@ -14,6 +14,7 @@
     "claude-3-7-sonnet-20250219",
     "google/gemini-2.0-flash",
     "gpt-4-0125-preview",
+    "gpt-5.2-codex",
     "openai/gpt-5.2-codex"
   ],
   "allowedRetiredInCatalog_note": "TODO(#11503): ratchet to burn down. Each id is retired by its vendor but still routable from the provider catalog. Removing a catalog row or adding a BUILT_IN_ALIASES forward is a maintainer call (some aggregators still serve these ids), so they are allowlisted here rather than silently dropped. Delete an entry as soon as it is forwarded or removed; never add one without a tracking issue.",

--- a/open-sse/executors/uc/ws.ts
+++ b/open-sse/executors/uc/ws.ts
@@ -14,6 +14,7 @@
  * fake socket (same pattern as muse-spark-web).
  */
 import WebSocket from "ws";
+import { sanitizeErrorMessage } from "../../utils/error.ts";
 
 import { UC_ORIGIN, UC_WS_HOST, UC_WS_TIMEOUT_MS } from "./constants.ts";
 import { buildPersonaFrame, type UcHistoryEntry } from "./protocol.ts";
@@ -82,7 +83,7 @@ export function runUcTurn(input: UcTurnInput): Promise<UcTurnResult> {
       resolve({
         content: "",
         reasoning: "",
-        error: `ws connect failed: ${err instanceof Error ? err.message : String(err)}`,
+        error: `ws connect failed: ${sanitizeErrorMessage(err instanceof Error ? err.message : String(err))}`,
       });
       return;
     }
@@ -126,7 +127,7 @@ export function runUcTurn(input: UcTurnInput): Promise<UcTurnResult> {
         });
         ws.send(JSON.stringify(frame));
       } catch (err) {
-        fail(`ws send failed: ${err instanceof Error ? err.message : String(err)}`);
+        fail(`ws send failed: ${sanitizeErrorMessage(err instanceof Error ? err.message : String(err))}`);
       }
     };
 

--- a/open-sse/handlers/uc/ucTts.ts
+++ b/open-sse/handlers/uc/ucTts.ts
@@ -28,6 +28,7 @@
  * path is unit-testable with no live network.
  */
 import { randomUUID } from "node:crypto";
+import { sanitizeErrorMessage } from "../../utils/error.ts";
 import { Buffer } from "node:buffer";
 
 import WebSocket from "ws";
@@ -151,7 +152,7 @@ export function runUcTtsSocket(input: UcTtsSocketInput): Promise<UcTtsSocketResu
     } catch (err) {
       resolve({
         audio: Buffer.alloc(0) as Buffer<ArrayBuffer>,
-        error: `ws connect failed: ${err instanceof Error ? err.message : String(err)}`,
+        error: `ws connect failed: ${sanitizeErrorMessage(err instanceof Error ? err.message : String(err))}`,
       });
       return;
     }
@@ -194,7 +195,7 @@ export function runUcTtsSocket(input: UcTtsSocketInput): Promise<UcTtsSocketResu
         });
         ws.send(JSON.stringify(frame));
       } catch (err) {
-        fail(`ws send failed: ${err instanceof Error ? err.message : String(err)}`);
+        fail(`ws send failed: ${sanitizeErrorMessage(err instanceof Error ? err.message : String(err))}`);
       }
     };
 


### PR DESCRIPTION
Completes the 2026-09-02 window drain (syntax half was #12433; file-size was #12434 by another session). Both remaining Fast Quality Gates reds reproduced on the pure tip:

1. **error-helper**: `open-sse/handlers/uc/ucTts.ts` + `open-sse/executors/uc/ws.ts` (from #11513) built WS error payloads from raw `err.message` — Hard Rule #12. Wrapped in `sanitizeErrorMessage()`; UC suites 51/51 after.
2. **model-lifecycle**: the UC catalog registers the vendor-retired bare `gpt-5.2-codex` (gate: retired-but-routable, no forward). Allowlisted per the file's own policy with tracking issue #12436 — a global `BUILT_IN_ALIASES` forward is the owner's call since it would rewrite the just-approved provider's model.

Local: check-error-helper OK (1090 files), model-lifecycle PASS (68 retired / 1345 catalog), typecheck:core 0.