### PR TITLE
fix(perplexity-web): declare tool-calling params unsupported

### DIFF
--- a/open-sse/config/providers/registry/perplexity/web/index.ts
+++ b/open-sse/config/providers/registry/perplexity/web/index.ts
@@ -8,6 +8,7 @@ export const perplexity_webProvider: RegistryEntry = {
   baseUrl: "https://www.perplexity.ai/rest/sse/perplexity_ask",
   authType: "apikey",
   authHeader: "cookie",
+  unsupportedParams: ["tools", "tool_choice", "parallel_tool_calls"],
   models: [
     { id: "pplx-auto", name: "Perplexity Best", toolCalling: false },
     { id: "pplx-sonar", name: "Sonar 2 (via Perplexity)", toolCalling: false },

--- a/tests/unit/12104-perplexity-web-tools-unsupported.test.ts
+++ b/tests/unit/12104-perplexity-web-tools-unsupported.test.ts
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { perplexity_webProvider } from "../../open-sse/config/providers/registry/perplexity/web/index.ts";
+import { checkToolCallingRequiredButUnsupported } from "../../open-sse/handlers/chatCore/toolCallingRequiredCheck.ts";
+import { filterTargetsByRequestCompatibility } from "../../open-sse/services/combo/comboStructure.ts";
+import { getUnsupportedParams } from "../../open-sse/config/providerRegistry.ts";
+
+test("PR #2: perplexity-web provider metadata declares tool-calling unsupported", () => {
+  assert.ok(
+    perplexity_webProvider.unsupportedParams?.includes("tools"),
+    "Expected 'tools' to be unsupported"
+  );
+  assert.ok(
+    perplexity_webProvider.unsupportedParams?.includes("tool_choice"),
+    "Expected 'tool_choice' to be unsupported"
+  );
+  assert.ok(
+    perplexity_webProvider.unsupportedParams?.includes("parallel_tool_calls"),
+    "Expected 'parallel_tool_calls' to be unsupported"
+  );
+});
+
+test("PR #2: direct chatCore request with tools returns 400 error guard", () => {
+  const model = "pplx-sonar";
+  const provider = "perplexity-web";
+  const unsupported = getUnsupportedParams(provider, model);
+  
+  // 1. tools array
+  const checkTools = checkToolCallingRequiredButUnsupported(
+    { model, tools: [{ type: "function", function: { name: "test" } }] },
+    unsupported,
+    false,
+    model
+  );
+  assert.equal(checkTools.blocked, true);
+  assert.ok(checkTools.message?.includes("does not support tool calling"));
+});
+
+test("PR #2: combo/auto routing excludes perplexity-web when tools are present", () => {
+  // Mock combo targets
+  const candidateTargets: any[] = [
+    { provider: "openai", model: "gpt-4" },
+    { provider: "perplexity-web", model: "pplx-sonar" }
+  ];
+
+  // Request WITH tools
+  const bodyWithTools = {
+    model: "auto",
+    messages: [{ role: "user", content: "hello" }],
+    tools: [{ type: "function", function: { name: "test" } }]
+  };
+
+  const filteredWithTools = filterTargetsByRequestCompatibility(
+    candidateTargets,
+    bodyWithTools,
+    console, // Mock logger
+    undefined,
+    { bypassChecks: false }
+  );
+
+  // OpenAI should remain, Perplexity should be dropped because tools are unsupported
+  assert.equal(filteredWithTools.length, 1);
+  assert.equal(filteredWithTools[0].provider, "openai");
+
+  // Request WITHOUT tools
+  const bodyNoTools = {
+    model: "auto",
+    messages: [{ role: "user", content: "hello" }]
+  };
+
+  const filteredNoTools = filterTargetsByRequestCompatibility(
+    candidateTargets,
+    bodyNoTools,
+    console, // Mock logger
+    undefined,
+    { bypassChecks: false }
+  );
+
+  // Both should remain
+  assert.equal(filteredNoTools.length, 2);
+  assert.equal(filteredNoTools[1].provider, "perplexity-web");
+});


### PR DESCRIPTION
**Summary**
This PR fixes an issue where providing tool schemas to a combo/auto route that falls back to `perplexity-web` results in an immediate 400 error. 

**Root Cause**
The `perplexity-web` registry configuration lacked the explicit `unsupportedParams` metadata array. As a result, OmniRoute's `chatCore` failed to recognize that the provider cannot process tool parameters.

**Proposed Solution**
Added `unsupportedParams: ["tools", "tool_choice", "parallel_tool_calls"]` to the `perplexity-web` registry entry. 
- On direct requests, this triggers `stripUnsupportedParams`, correctly sanitizing the payload before execution.
- On auto/combo fallback, it triggers `filterTargetsByRequestCompatibility`, ensuring requests requiring tool calling don't route to this unsupported backend.

**Notes for Reviewers**
- This aligns `perplexity-web` with the standard API `pplx-*` models which already declare tool calling as unsupported.
- This change strictly affects capability routing and sanitization prior to execution. It does not modify the `perplexity-web` executor protocol itself.
- A regression test (`tests/unit/12104-perplexity-web-tools-unsupported.test.ts`) is included to verify the compatibility logic integration.
