### PR TITLE
fix(perplexity-web): preserve system contract on follow-up requests

### DIFF
--- a/open-sse/executors/perplexity-web/protocol.ts
+++ b/open-sse/executors/perplexity-web/protocol.ts
@@ -388,7 +388,9 @@ function searchHintEnabled(): boolean {
 export function buildQuery(parsed: ParsedMessages, followUpUuid: string | null): string {
   if (followUpUuid) {
     const sys = parsed.systemMsg.trim();
-    return sys ? `${sys}\n\n${parsed.currentMsg}` : parsed.currentMsg;
+    const hint = searchHintEnabled() ? `\n\n${SEARCH_HINT}` : "";
+    const contract = sys ? `${sys}${hint}` : "";
+    return contract ? `${contract}\n\n${parsed.currentMsg}` : parsed.currentMsg;
   }
 
   const obj: Record<string, unknown> = {};

--- a/open-sse/executors/perplexity-web/protocol.ts
+++ b/open-sse/executors/perplexity-web/protocol.ts
@@ -386,7 +386,10 @@ function searchHintEnabled(): boolean {
 }
 
 export function buildQuery(parsed: ParsedMessages, followUpUuid: string | null): string {
-  if (followUpUuid) return parsed.currentMsg;
+  if (followUpUuid) {
+    const sys = parsed.systemMsg.trim();
+    return sys ? `${sys}\n\n${parsed.currentMsg}` : parsed.currentMsg;
+  }
 
   const obj: Record<string, unknown> = {};
   if (parsed.systemMsg.trim()) {

--- a/tests/unit/12104-perplexity-web-followup-contract.test.ts
+++ b/tests/unit/12104-perplexity-web-followup-contract.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildQuery } from "../../open-sse/executors/perplexity-web/protocol.ts";
+
+test("PR #3: buildQuery preserves system contract on follow-up requests", () => {
+  const parsed = {
+    systemMsg: "You are an expert coder. <tool>contract</tool>",
+    history: [],
+    currentMsg: "How do I reverse a string in JS?"
+  };
+
+  // Turn 1: followUpUuid is null
+  const turn1Raw = buildQuery(parsed, null);
+  const turn1Obj = JSON.parse(turn1Raw);
+  assert.ok(turn1Obj.instructions !== undefined, "Turn 1 JSON should contain instructions");
+  assert.equal(turn1Obj.instructions[0], "You are an expert coder. <tool>contract</tool>");
+
+  // Turn 2: follow-up request
+  const parsedTurn2 = {
+    systemMsg: "You are an expert coder. <tool>contract</tool>",
+    history: [{ role: "user", content: "How do I reverse a string in JS?" }, { role: "assistant", content: "Use .reverse()" }],
+    currentMsg: "What about Python?"
+  };
+  const turn2Output = buildQuery(parsedTurn2, "abc-123");
+
+  // Since we append systemMsg to currentMsg for follow-ups (Approach B)
+  assert.ok(turn2Output.includes("<tool>contract</tool>"), "Follow-up query should preserve the tool contract");
+  assert.ok(turn2Output.includes("What about Python?"), "Follow-up query should include the current message");
+});


### PR DESCRIPTION
**Summary**
This PR addresses the OmniRoute-side bug described in #12104 where follow-up messages on the `perplexity-web` provider drop the system instructions containing the injected tool-use contract, causing subsequent conversational turns to fail at using tools.

**Root Cause**
When formatting a follow-up request, `buildQuery()` historically hit an early return if a `followUpUuid` was present, returning only `parsed.currentMsg` and explicitly discarding the `systemMsg` instruction block.

**Proposed Solution**
Updated `buildQuery` to correctly prepend `parsed.systemMsg` (and the `SEARCH_HINT`, if enabled) to `parsed.currentMsg` when formatting follow-up requests. This preserves the injected instructions for the lifetime of the session without interfering with the existing UI abstraction.

**Important Clarification**
This PR **only** fixes OmniRoute's explicit dropping of instructions for follow-up turns. It **does not** claim to fix upstream limitations in Perplexity's own backend where their model might refuse or mangle structured JSON during its first response. This ensures the contract is successfully sent; how the backend handles it remains upstream behavior.

**Notes for Reviewers**
- A regression test (`tests/unit/12104-perplexity-web-followup-contract.test.ts`) is included to verify that `buildQuery` correctly includes the system contract strings on Turn 2+ follow-ups.
