### PR TITLE
fix(sse): remap non-contiguous upstream tool_calls index to a gap-free output_index

### DIFF
--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -504,9 +504,34 @@ function toolCallOutputIndexBase(state) {
   return state.msgItemAdded[msgIdx] ? msgIdx + 1 : msgIdx;
 }
 
+// Live incident (2026-09-02, minimax-m3:free via OpenRouter/GMICloud): the
+// upstream's own tool_calls delta `index` doesn't reliably start at 0 or stay
+// contiguous per turn -- this turn's two calls arrived with raw index 1 and 2
+// (never 0). Adding that raw index straight onto toolCallOutputIndexBase()
+// left a GAP in the emitted output_index sequence (0 for the message, then 2
+// and 3 for the calls -- index 1 never used). A client that reads
+// response.completed's final `output[]` array by ARRAY POSITION and expects
+// position to equal output_index (the Responses API's own contract) reads
+// output[1] (this turn's first call, real output_index 2) while looking it
+// up under output_index 1, misses it, then reads output[2] (the second call,
+// real output_index 3) under output_index 2 -- landing on the FIRST call's
+// tracked slot with a different call_id, which a spec-following client
+// correctly treats as "stream changed output item identity" and aborts.
+// Fix: remap each turn's raw upstream indices to a local, contiguous,
+// 0-based sequence in first-seen order, so gaps in the raw index can never
+// propagate into the emitted output_index sequence.
+function resolveLocalToolCallIndex(state, tcIdx) {
+  if (!state.toolCallLocalIndex) state.toolCallLocalIndex = {};
+  if (state.toolCallLocalIndex[tcIdx] === undefined) {
+    state.toolCallLocalIndex[tcIdx] = state.toolCallLocalIndexNext ?? 0;
+    state.toolCallLocalIndexNext = state.toolCallLocalIndex[tcIdx] + 1;
+  }
+  return state.toolCallLocalIndex[tcIdx];
+}
+
 function emitToolCall(state, emit, tc) {
   const tcIdx = tc.index ?? 0;
-  const outputIndex = toolCallOutputIndexBase(state) + normalizeOutputIndex(tcIdx);
+  const outputIndex = toolCallOutputIndexBase(state) + resolveLocalToolCallIndex(state, tcIdx);
   const newCallId = tc.id;
   const funcName = tc.function?.name;
 
@@ -609,7 +634,7 @@ function emitToolCall(state, emit, tc) {
 function closeToolCall(state, emit, idx, recordAsCompleted = true) {
   const callId = state.funcCallIds[idx];
   if (callId && !state.funcItemDone[idx]) {
-    const normalizedIndex = toolCallOutputIndexBase(state) + normalizeOutputIndex(idx);
+    const normalizedIndex = toolCallOutputIndexBase(state) + resolveLocalToolCallIndex(state, idx);
     const args = state.funcArgsBuf[idx] || "{}";
     const toolName = state.funcNames[idx] || "";
     // See emitToolCall()'s isCustomTool comment — must stay in sync (both compute the

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -23,12 +23,12 @@ import {
 import { createEventEmitter } from "./openai-responses/eventEmitter.ts";
 import { buildResponsesToolCallItem } from "./responsesToolItem.ts";
 import { resolveRequestToolIdentity } from "./openai-responses/requestToolIdentity.ts";
+import { resolveLocalToolCallIndex } from "./openai-responses/toolCallLocalIndex.ts";
 import {
   synthesizeCompletedToolCalls,
   computeFinishReason,
   withAssistantRoleOnFirstDelta,
 } from "./openai-responses/synthesizeCompletedToolCalls.ts";
-
 // normalizeUpstreamFailure is re-exported for external importers (tests).
 export { normalizeUpstreamFailure } from "./openai-responses/pureHelpers.ts";
 
@@ -502,31 +502,6 @@ function closeMessage(state, emit, idx) {
 function toolCallOutputIndexBase(state) {
   const msgIdx = state.reasoningId ? normalizeOutputIndex(state.reasoningIndex) + 1 : 0;
   return state.msgItemAdded[msgIdx] ? msgIdx + 1 : msgIdx;
-}
-
-// Live incident (2026-09-02, minimax-m3:free via OpenRouter/GMICloud): the
-// upstream's own tool_calls delta `index` doesn't reliably start at 0 or stay
-// contiguous per turn -- this turn's two calls arrived with raw index 1 and 2
-// (never 0). Adding that raw index straight onto toolCallOutputIndexBase()
-// left a GAP in the emitted output_index sequence (0 for the message, then 2
-// and 3 for the calls -- index 1 never used). A client that reads
-// response.completed's final `output[]` array by ARRAY POSITION and expects
-// position to equal output_index (the Responses API's own contract) reads
-// output[1] (this turn's first call, real output_index 2) while looking it
-// up under output_index 1, misses it, then reads output[2] (the second call,
-// real output_index 3) under output_index 2 -- landing on the FIRST call's
-// tracked slot with a different call_id, which a spec-following client
-// correctly treats as "stream changed output item identity" and aborts.
-// Fix: remap each turn's raw upstream indices to a local, contiguous,
-// 0-based sequence in first-seen order, so gaps in the raw index can never
-// propagate into the emitted output_index sequence.
-function resolveLocalToolCallIndex(state, tcIdx) {
-  if (!state.toolCallLocalIndex) state.toolCallLocalIndex = {};
-  if (state.toolCallLocalIndex[tcIdx] === undefined) {
-    state.toolCallLocalIndex[tcIdx] = state.toolCallLocalIndexNext ?? 0;
-    state.toolCallLocalIndexNext = state.toolCallLocalIndex[tcIdx] + 1;
-  }
-  return state.toolCallLocalIndex[tcIdx];
 }
 
 function emitToolCall(state, emit, tc) {

--- a/open-sse/translator/response/openai-responses/toolCallLocalIndex.ts
+++ b/open-sse/translator/response/openai-responses/toolCallLocalIndex.ts
@@ -1,0 +1,35 @@
+/**
+ * Remap a turn's raw upstream tool_calls delta `index` onto a local,
+ * contiguous, 0-based sequence in first-seen order.
+ *
+ * Live incident (2026-09-02, minimax-m3:free via OpenRouter/GMICloud): the
+ * upstream's own `index` doesn't reliably start at 0 or stay contiguous per
+ * turn — this turn's two calls arrived with raw index 1 and 2 (never 0).
+ * Adding that raw index straight onto toolCallOutputIndexBase() left a GAP
+ * in the emitted output_index sequence (0 for the message, then 2 and 3 for
+ * the calls — index 1 never used). A client that reads response.completed's
+ * final `output[]` array by ARRAY POSITION and expects position to equal
+ * output_index (the Responses API's own contract) reads output[1] (this
+ * turn's first call, real output_index 2) while looking it up under
+ * output_index 1, misses it, then reads output[2] (the second call, real
+ * output_index 3) under output_index 2 — landing on the FIRST call's tracked
+ * slot with a different call_id, which a spec-following client correctly
+ * treats as "stream changed output item identity" and aborts.
+ */
+
+export type ToolCallLocalIndexState = {
+  toolCallLocalIndex?: Record<string, number>;
+  toolCallLocalIndexNext?: number;
+};
+
+export function resolveLocalToolCallIndex(
+  state: ToolCallLocalIndexState,
+  tcIdx: string | number
+): number {
+  if (!state.toolCallLocalIndex) state.toolCallLocalIndex = {};
+  if (state.toolCallLocalIndex[tcIdx] === undefined) {
+    state.toolCallLocalIndex[tcIdx] = state.toolCallLocalIndexNext ?? 0;
+    state.toolCallLocalIndexNext = state.toolCallLocalIndex[tcIdx] + 1;
+  }
+  return state.toolCallLocalIndex[tcIdx];
+}

--- a/tests/unit/translator-resp-openai-responses.test.ts
+++ b/tests/unit/translator-resp-openai-responses.test.ts
@@ -994,3 +994,143 @@ test("OpenAI -> Responses: a text message and a following tool call in the same 
     "completed output must include the tool call"
   );
 });
+
+// Live incident (2026-09-02): a free-tier streaming model, after a short text
+// preamble, opened two tool calls whose upstream `tool_calls[].index` was 1
+// and 2 -- never 0. toolCallOutputIndexBase()+index therefore emitted
+// output_index 0 (message), 2, 3 -- skipping 1 entirely. A spec-following
+// Responses-API client reads response.completed's final `output[]` array by
+// ARRAY POSITION and expects position === output_index (the API's own
+// contract): output[1] (this turn's first call, real output_index 2) gets
+// looked up under output_index 1 and missed, then output[2] (the second
+// call, real output_index 3) gets looked up under output_index 2 and
+// collides with the FIRST call's tracked slot -- two different call_ids on
+// what the client thinks is one identity, which it correctly refuses to
+// treat as anything but a broken stream. Reproduced verbatim (anonymized
+// content, same index/id shape) against OpenClaw's own
+// createResponsesOutputTracker before this fix; content and tool/model names
+// below are placeholders, not the real incident's.
+test("OpenAI -> Responses: tool-call output_index stays gap-free when the upstream's own index doesn't start at 0", () => {
+  const events = collectEvents([
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        { index: 0, delta: { content: "Status:", role: "assistant" }, finish_reason: null },
+      ],
+    },
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        { index: 0, delta: { content: " all clear.", role: "assistant" }, finish_reason: null },
+      ],
+    },
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: null,
+            role: "assistant",
+            tool_calls: [
+              {
+                index: 1,
+                id: "call_stub_1",
+                type: "function",
+                function: { name: "notify", arguments: "" },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: null,
+            role: "assistant",
+            tool_calls: [{ index: 1, function: { arguments: '{"a":1}' } }],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: null,
+            role: "assistant",
+            tool_calls: [
+              {
+                index: 2,
+                id: "call_stub_2",
+                type: "function",
+                function: { name: "notify", arguments: "" },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: null,
+            role: "assistant",
+            tool_calls: [{ index: 2, function: { arguments: '{"a":2}' } }],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-gap1",
+      model: "stub-model",
+      choices: [
+        { index: 0, delta: { content: "", role: "assistant" }, finish_reason: "tool_calls" },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    },
+    null,
+  ]);
+
+  const addedEvents = events.filter((e) => e.event === "response.output_item.added");
+  const indexes = addedEvents.map((e) => e.data.output_index).sort((a, b) => a - b);
+  const sequential = indexes.map((_, i) => i);
+  assert.deepEqual(
+    indexes,
+    sequential,
+    `output_index values must be a gap-free 0..n-1 sequence (position === output_index is the Responses API's own contract); got ${JSON.stringify(indexes)}`
+  );
+
+  // The exact client-observable symptom: response.completed's output[]
+  // array, read by array position, must match each item's own tracked
+  // output_index -- otherwise a client keying by array position resolves
+  // the wrong item.
+  const completedGap = events.find((e) => e.event === "response.completed");
+  completedGap.data.response.output.forEach((item, position) => {
+    const addedEvent = addedEvents.find((e) => e.data.item?.id === item.id);
+    assert.equal(
+      addedEvent?.data.output_index,
+      position,
+      `item ${item.id} (type ${item.type}) streamed at output_index ${addedEvent?.data.output_index} but sits at array position ${position} in the completed output`
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves
Ping (an OpenClaw agent) hit a recurring, ~hourly production failure: `⚠️ omniroute/default request failed`, `rawError=Responses stream changed output item identity`. Every occurrence traced to `minimax/minimax-m3:free` via OpenRouter/GMICloud.

## Why This Change Was Made
GMICloud's stream sent `tool_calls[].index` starting at 1 (never 0) for a turn with two calls. `emitToolCall`/`closeToolCall` added that raw index directly onto `toolCallOutputIndexBase()`, so the emitted Responses-API `output_index` sequence was `0` (message), `2`, `3` — skipping 1.

OpenClaw's own Responses-stream client reads `response.completed`'s final `output[]` array by **array position**, expecting position === `output_index` (the Responses API's own contract, not a bug on OpenClaw's side — confirmed by direct inspection of `packages/ai/src/transports/openai-responses-stream-slots-internal.ts`). With the gap, `output[1]` (the real call at `output_index=2`) got looked up under index 1 and missed; `output[2]` (the second call, real `output_index=3`) got looked up under index 2, landed on the first call's tracked slot, saw a different `call_id`, and correctly threw — aborting the whole turn with no retry.

Confirmed the exact mechanism two ways: replayed the real captured stream through OmniRoute's own translator to get the actual emitted event sequence, then fed that sequence directly into OpenClaw's real `processResponsesStream()` and reproduced the identical throw with a full stack trace pointing at the exact line.

Fix: `resolveLocalToolCallIndex()` remaps each turn's raw upstream tool-call indices to a local, contiguous, 0-based sequence in first-seen order, used at both `emitToolCall` and `closeToolCall` so they can no longer drift apart from the raw upstream numbering.

## User Impact
Stops a real, recurring production failure (confirmed ~hourly for the affected model) that silently dropped an entire agent turn with no client-side retry.

## Evidence
- Regression test (anonymized real-incident shape) added to `tests/unit/translator-resp-openai-responses.test.ts`, proven RED against unfixed code (`got [0,2,3]`) and GREEN after.
- Full translator suite: 783/783 passing, no regressions.
- Root cause cross-verified against OpenClaw's own client source, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
