### PR TITLE
fix(conversations): resolve turn content OmniRoute never sends back to the client

### DIFF
--- a/open-sse/services/conversationTurnContent.ts
+++ b/open-sse/services/conversationTurnContent.ts
@@ -23,6 +23,56 @@ export type TurnDisplayContent = {
   toolName: string | null;
 };
 
+type CanonicalTurnLike = {
+  role: string;
+  text: string;
+  blockKind: "text" | "tool_use" | "tool_result";
+  toolName: string | null;
+};
+
+/**
+ * extractCanonicalTurns's Chat Completions branch only reads a message's
+ * `content` -- a tool-calling assistant message carries its call in
+ * `tool_calls` instead with `content: null`, so it silently produces no turn
+ * at all and the matching conversation_turn_nodes row can never resolve.
+ * Deliberately scoped to this read-only display path instead of extending
+ * extractCanonicalTurns itself: that function also drives
+ * conversationTracker.ts's write-path identity/hashing, and this codebase's
+ * only caller of it there (chat.ts's resolveConversationId) always feeds the
+ * client-facing Responses-API body -- never Chat Completions
+ * `messages`/`tool_calls` -- so extending it there would be unreachable for
+ * real traffic here but still carries real write-path identity-hash risk for
+ * any other caller/format that function might ever serve. Mirrors
+ * extractCanonicalTurns's own Responses-shape function_call handling: one
+ * turn per call, role "tool" (matches how a Responses API function_call item,
+ * which also carries no `role`, canonicalizes -- not "assistant"), toolName
+ * from the call, text the raw arguments string untouched (already a JSON
+ * string in both APIs, so passing it through unmodified is what a
+ * byte-identical hash against the original Responses-shaped item needs).
+ */
+function extractChatCompletionsToolUseTurns(messages: unknown): CanonicalTurnLike[] {
+  if (!Array.isArray(messages)) return [];
+  const turns: CanonicalTurnLike[] = [];
+  for (const item of messages) {
+    const rec = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+    if (rec.role !== "assistant" || !Array.isArray(rec.tool_calls)) continue;
+    for (const call of rec.tool_calls) {
+      const fn =
+        call && typeof call === "object" ? (call as Record<string, unknown>).function : null;
+      const fnRec = fn && typeof fn === "object" ? (fn as Record<string, unknown>) : null;
+      const args = fnRec?.arguments;
+      if (typeof args !== "string" || !args) continue;
+      turns.push({
+        role: "tool",
+        text: args,
+        blockKind: "tool_use",
+        toolName: typeof fnRec?.name === "string" ? fnRec.name : null,
+      });
+    }
+  }
+  return turns;
+}
+
 /**
  * Resolve display content for a batch of turn nodes, keyed by content_hash.
  * Content_hash is sha256(role+text) only — real traffic has plenty of
@@ -64,11 +114,65 @@ export function resolveTurnDisplayContent(
   for (const relPath of artifactPathByCorrelationId.values()) {
     const { artifact, state } = readCallArtifact(relPath);
     if (state !== "ready") continue;
-    const clientRawRequest = artifact?.pipeline?.clientRawRequest as { body?: unknown } | undefined;
-    const body = clientRawRequest?.body;
-    if (!body || typeof body !== "object") continue;
 
-    for (const turn of extractCanonicalTurns(body as Record<string, unknown>)) {
+    const clientRawRequest = artifact?.pipeline?.clientRawRequest as { body?: unknown } | undefined;
+    const requestBody = clientRawRequest?.body;
+    const requestTurns =
+      requestBody && typeof requestBody === "object"
+        ? extractCanonicalTurns(requestBody as Record<string, unknown>)
+        : [];
+
+    // A genuine-continuation turn's own client request only ever carries the
+    // NEW delta (see responsesContinuationStore.ts's doc comment) -- unlike a
+    // full-history-resend conversation, it never resends the model's own
+    // prior output as history, so the assistant/tool_use turns THIS call
+    // generated exist only in this same artifact's own response, never in
+    // any request body (this one's or a later one's) -- request-only
+    // resolution silently rendered them as empty. Read the response the same
+    // dual-shape way resolvePreviousResponseState does: a streaming response
+    // nests output under clientResponse.summary.output, a non-streaming one
+    // carries it directly. Reusing extractCanonicalTurns under an `input` key
+    // works unchanged -- Responses API output items share input's shape.
+    const clientResponse = artifact?.pipeline?.clientResponse as
+      { output?: unknown; summary?: { output?: unknown } } | undefined;
+    const responseOutput = Array.isArray(clientResponse?.output)
+      ? clientResponse.output
+      : clientResponse?.summary?.output;
+    const responseTurns = Array.isArray(responseOutput)
+      ? extractCanonicalTurns({ input: responseOutput })
+      : [];
+
+    // For a node whose creating request/response pair is itself long gone
+    // from the current continuation window (an older turn a later,
+    // still-thin delta request never touches again -- INSERT OR IGNORE never
+    // updates an existing node's last_correlation_id), the only remaining
+    // record of its text is the provider-translated request OmniRoute
+    // actually forwarded upstream for THIS artifact -- which, for a
+    // non-Responses-native provider, carries the full reconstructed history
+    // as Chat Completions `messages`. Best-effort only: translated text can
+    // differ byte-for-byte from what was originally hashed (a
+    // pass-through-only tool-call/reasoning shape mismatch), so this closes
+    // most but not all of the gap -- an unresolved node still falls back to
+    // toTurn's "_(empty)_" placeholder rather than showing wrong content.
+    const providerRequestBody = (
+      artifact?.pipeline?.providerRequest as { body?: unknown } | undefined
+    )?.body;
+    const providerTurns =
+      providerRequestBody && typeof providerRequestBody === "object"
+        ? extractCanonicalTurns(providerRequestBody as Record<string, unknown>)
+        : [];
+    const providerToolUseTurns = extractChatCompletionsToolUseTurns(
+      providerRequestBody && typeof providerRequestBody === "object"
+        ? (providerRequestBody as Record<string, unknown>).messages
+        : undefined
+    );
+
+    for (const turn of [
+      ...requestTurns,
+      ...responseTurns,
+      ...providerTurns,
+      ...providerToolUseTurns,
+    ]) {
       const hash = hashTurnContent(turn);
       if (result.has(hash)) continue;
       result.set(hash, {

--- a/open-sse/services/conversationTurnContent.ts
+++ b/open-sse/services/conversationTurnContent.ts
@@ -24,11 +24,22 @@ export type TurnDisplayContent = {
 };
 
 type CanonicalTurnLike = {
-  role: string;
+  role: "system" | "user" | "assistant" | "tool";
   text: string;
   blockKind: "text" | "tool_use" | "tool_result";
   toolName: string | null;
 };
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" ? (value as JsonRecord) : null;
+}
+
+function turnsFromBody(body: unknown): CanonicalTurnLike[] {
+  const rec = asRecord(body);
+  return rec ? extractCanonicalTurns(rec) : [];
+}
 
 /**
  * extractCanonicalTurns's Chat Completions branch only reads a message's
@@ -54,23 +65,46 @@ function extractChatCompletionsToolUseTurns(messages: unknown): CanonicalTurnLik
   if (!Array.isArray(messages)) return [];
   const turns: CanonicalTurnLike[] = [];
   for (const item of messages) {
-    const rec = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+    const rec = asRecord(item) ?? {};
     if (rec.role !== "assistant" || !Array.isArray(rec.tool_calls)) continue;
     for (const call of rec.tool_calls) {
-      const fn =
-        call && typeof call === "object" ? (call as Record<string, unknown>).function : null;
-      const fnRec = fn && typeof fn === "object" ? (fn as Record<string, unknown>) : null;
-      const args = fnRec?.arguments;
+      const fn = asRecord(asRecord(call)?.function);
+      const args = fn?.arguments;
       if (typeof args !== "string" || !args) continue;
       turns.push({
         role: "tool",
         text: args,
         blockKind: "tool_use",
-        toolName: typeof fnRec?.name === "string" ? fnRec.name : null,
+        toolName: typeof fn?.name === "string" ? fn.name : null,
       });
     }
   }
   return turns;
+}
+
+function turnsFromClientResponse(clientResponse: unknown): CanonicalTurnLike[] {
+  const rec = asRecord(clientResponse);
+  if (!rec) return [];
+  const summary = asRecord(rec.summary);
+  const output = Array.isArray(rec.output) ? rec.output : summary?.output;
+  return Array.isArray(output) ? extractCanonicalTurns({ input: output }) : [];
+}
+
+function turnsFromProviderRequest(body: unknown): CanonicalTurnLike[] {
+  const rec = asRecord(body);
+  return [...turnsFromBody(rec), ...extractChatCompletionsToolUseTurns(rec?.messages)];
+}
+
+function indexTurns(result: Map<string, TurnDisplayContent>, turns: CanonicalTurnLike[]): void {
+  for (const turn of turns) {
+    const hash = hashTurnContent(turn);
+    if (result.has(hash)) continue;
+    result.set(hash, {
+      textPreview: turn.text,
+      blockKind: turn.blockKind,
+      toolName: turn.toolName,
+    });
+  }
 }
 
 /**
@@ -114,73 +148,10 @@ export function resolveTurnDisplayContent(
   for (const relPath of artifactPathByCorrelationId.values()) {
     const { artifact, state } = readCallArtifact(relPath);
     if (state !== "ready") continue;
-
-    const clientRawRequest = artifact?.pipeline?.clientRawRequest as { body?: unknown } | undefined;
-    const requestBody = clientRawRequest?.body;
-    const requestTurns =
-      requestBody && typeof requestBody === "object"
-        ? extractCanonicalTurns(requestBody as Record<string, unknown>)
-        : [];
-
-    // A genuine-continuation turn's own client request only ever carries the
-    // NEW delta (see responsesContinuationStore.ts's doc comment) -- unlike a
-    // full-history-resend conversation, it never resends the model's own
-    // prior output as history, so the assistant/tool_use turns THIS call
-    // generated exist only in this same artifact's own response, never in
-    // any request body (this one's or a later one's) -- request-only
-    // resolution silently rendered them as empty. Read the response the same
-    // dual-shape way resolvePreviousResponseState does: a streaming response
-    // nests output under clientResponse.summary.output, a non-streaming one
-    // carries it directly. Reusing extractCanonicalTurns under an `input` key
-    // works unchanged -- Responses API output items share input's shape.
-    const clientResponse = artifact?.pipeline?.clientResponse as
-      { output?: unknown; summary?: { output?: unknown } } | undefined;
-    const responseOutput = Array.isArray(clientResponse?.output)
-      ? clientResponse.output
-      : clientResponse?.summary?.output;
-    const responseTurns = Array.isArray(responseOutput)
-      ? extractCanonicalTurns({ input: responseOutput })
-      : [];
-
-    // For a node whose creating request/response pair is itself long gone
-    // from the current continuation window (an older turn a later,
-    // still-thin delta request never touches again -- INSERT OR IGNORE never
-    // updates an existing node's last_correlation_id), the only remaining
-    // record of its text is the provider-translated request OmniRoute
-    // actually forwarded upstream for THIS artifact -- which, for a
-    // non-Responses-native provider, carries the full reconstructed history
-    // as Chat Completions `messages`. Best-effort only: translated text can
-    // differ byte-for-byte from what was originally hashed (a
-    // pass-through-only tool-call/reasoning shape mismatch), so this closes
-    // most but not all of the gap -- an unresolved node still falls back to
-    // toTurn's "_(empty)_" placeholder rather than showing wrong content.
-    const providerRequestBody = (
-      artifact?.pipeline?.providerRequest as { body?: unknown } | undefined
-    )?.body;
-    const providerTurns =
-      providerRequestBody && typeof providerRequestBody === "object"
-        ? extractCanonicalTurns(providerRequestBody as Record<string, unknown>)
-        : [];
-    const providerToolUseTurns = extractChatCompletionsToolUseTurns(
-      providerRequestBody && typeof providerRequestBody === "object"
-        ? (providerRequestBody as Record<string, unknown>).messages
-        : undefined
-    );
-
-    for (const turn of [
-      ...requestTurns,
-      ...responseTurns,
-      ...providerTurns,
-      ...providerToolUseTurns,
-    ]) {
-      const hash = hashTurnContent(turn);
-      if (result.has(hash)) continue;
-      result.set(hash, {
-        textPreview: turn.text,
-        blockKind: turn.blockKind,
-        toolName: turn.toolName,
-      });
-    }
+    const pipeline = asRecord(artifact?.pipeline);
+    indexTurns(result, turnsFromBody(asRecord(pipeline?.clientRawRequest)?.body));
+    indexTurns(result, turnsFromClientResponse(pipeline?.clientResponse));
+    indexTurns(result, turnsFromProviderRequest(asRecord(pipeline?.providerRequest)?.body));
   }
   return result;
 }


### PR DESCRIPTION
## What Problem This Solves
`/dashboard/conversations`'s turn tree showed many turns as "Tool (empty)"/"Assistant (empty)" for genuine-continuation conversations, even though the actual content clearly existed and was served correctly.

## Why This Change Was Made
`resolveTurnDisplayContent` only ever read a turn node's originating `clientRawRequest.body` — fine for a full-history-resend conversation (every later request's body eventually contains everything), but a genuine-continuation turn's own request only ever carries the NEW delta. That silently left the model's own generated tool_use/text turns unresolved — their content never appears in any request body, only in a response.

Verified against a real 133-node continuation conversation: request-only resolution left 131/133 nodes unresolved.

Added two more sources, read from the SAME already-loaded artifact (no extra I/O):
- the call's own `clientResponse.output` (the model's own generated turn — 131 → 76 unresolved)
- the call's own `providerRequest.body` (the server-reconstructed full history actually forwarded upstream for non-Responses-native providers, Chat Completions `messages` shape) — best-effort, translated text can differ byte-for-byte from what was originally hashed, so this doesn't close 100%, but it does close the "Tool (empty)" case entirely (76 → 21, all 112 tool nodes resolved; the remaining 21 are plain user/assistant text turns old enough to predate both available artifacts — genuinely lost history, not a resolution gap).

## User Impact
The conversation tree now renders real content for tool calls and assistant turns in continuation-mode conversations instead of empty placeholders.

## Evidence
Verified against a real production conversation (133 turn nodes): before/after unresolved-node counts (131 → 76 → 21) computed by replaying the exact resolution logic against the real stored artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
