### PR TITLE
fix(combo): do not treat credits-exhausted 401 as auth skip

### DIFF
--- a/open-sse/services/combo/targetExhaustion.ts
+++ b/open-sse/services/combo/targetExhaustion.ts
@@ -61,12 +61,18 @@ export function isQuotaOrCreditsError(
   errorText: string,
   structuredError?: { code?: string; type?: string; message?: string }
 ): boolean {
-  const blob = [errorText, structuredError?.code, structuredError?.type, structuredError?.message]
-    .filter(Boolean)
-    .join(" ");
-  if (/credits exhausted/i.test(blob)) return true;
-  if (/quota exhausted/i.test(blob) && !/authentication expired/i.test(blob)) return true;
-  return classifyErrorText(structuredError?.code || errorText) === RateLimitReason.QUOTA_EXHAUSTED;
+  const blobs = [
+    errorText,
+    structuredError?.type,
+    structuredError?.message,
+    structuredError?.code,
+  ].filter((value): value is string => Boolean(value));
+  const joined = blobs.join(" ");
+  if (/credits exhausted/i.test(joined)) return true;
+  if (/quota exhausted/i.test(joined) && !/authentication expired/i.test(joined)) return true;
+  // Classify each candidate independently. A non-quota structuredError.code must
+  // not hide quota wording in errorText or structuredError.message.
+  return blobs.some((blob) => classifyErrorText(blob) === RateLimitReason.QUOTA_EXHAUSTED);
 }
 
 export type ComboExhaustionSets = {

--- a/open-sse/services/combo/targetExhaustion.ts
+++ b/open-sse/services/combo/targetExhaustion.ts
@@ -56,6 +56,19 @@ function isEmptyContentFailure(status: number, errorText: string): boolean {
   return status === 502 && (/empty content/i.test(errorText) || /empty response/i.test(errorText));
 }
 
+/** #12441 — quota/credits bodies must not take the 401/403 auth-skip path. */
+export function isQuotaOrCreditsError(
+  errorText: string,
+  structuredError?: { code?: string; type?: string; message?: string }
+): boolean {
+  const blob = [errorText, structuredError?.code, structuredError?.type, structuredError?.message]
+    .filter(Boolean)
+    .join(" ");
+  if (/credits exhausted/i.test(blob)) return true;
+  if (/quota exhausted/i.test(blob) && !/authentication expired/i.test(blob)) return true;
+  return classifyErrorText(structuredError?.code || errorText) === RateLimitReason.QUOTA_EXHAUSTED;
+}
+
 export type ComboExhaustionSets = {
   exhaustedProviders: Set<string>;
   exhaustedConnections: Set<string>;
@@ -173,12 +186,14 @@ export function applyComboTargetExhaustion(
       .filter(Boolean)
       .join(" ")
   );
+  const quotaMisclassifiedAsAuth = isQuotaOrCreditsError(errorText, structuredError);
   if (
     AUTH_LEVEL_ERROR_STATUSES.includes(result.status) &&
     // Cloudflare 1010 is a 403-ONLY fingerprint rejection. A 401 that merely happens to
     // mention "1010" or "fingerprint_rejection" in a port/count/model token must NOT skip
     // auth-level exhaustion — only a 403 carrying the Cloudflare fingerprint signal does.
     !(result.status === 403 && (fingerprintToken || fingerprintText)) &&
+    !quotaMisclassifiedAsAuth &&
     provider &&
     provider !== "unknown"
   ) {

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -320,9 +320,12 @@ export async function createEmbeddingResponse(
       );
     }
     if ("allExpired" in credentials && credentials.allExpired) {
+      const expiredStatus = (credentials as { expiredStatus?: string }).expiredStatus;
+      const quota = expiredStatus === "credits_exhausted";
+      const reason = quota ? "credits exhausted" : "authentication expired";
       return errorResponse(
-        HTTP_STATUS.UNAUTHORIZED,
-        `[${provider}] All ${credentials.expiredCount || 1} connection(s) authentication expired — please reconnect in the dashboard`
+        quota ? HTTP_STATUS.PAYMENT_REQUIRED : HTTP_STATUS.UNAUTHORIZED,
+        `[${provider}] All ${credentials.expiredCount || 1} connection(s) ${reason} — please reconnect in the dashboard`
       );
     }
   } else if (provider === "ollama-local" || provider === "lmstudio") {

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -777,9 +777,11 @@ export function handleNoCredentials(
   }
   if (credentials?.allExpired) {
     // Every connection for this provider is in a terminal state (expired,
-    // banned, or credits_exhausted). Surface as 401 with a re-auth hint
-    // instead of the generic 400 "No credentials", so dashboards/CLIs can
-    // distinguish "never configured" from "needs to reconnect".
+    // banned, or credits_exhausted). Surface expired/banned as 401 with a
+    // re-auth hint instead of the generic 400 "No credentials", so
+    // dashboards/CLIs can distinguish "never configured" from "needs to
+    // reconnect". credits_exhausted is quota (HTTP 402), not invalid
+    // credentials — see #12441.
     const status = credentials.expiredStatus || "expired";
     const count = credentials.expiredCount || 1;
     const reason =
@@ -790,7 +792,12 @@ export function handleNoCredentials(
           : "authentication expired";
     const message = `[${provider}] All ${count} connection(s) ${reason} — please reconnect in the dashboard`;
     log.warn("CHAT", message);
-    return errorResponse(HTTP_STATUS.UNAUTHORIZED, message);
+    // #12441: credits_exhausted is quota, not invalid credentials. Combo
+    // dispatch treats 401 as AUTH_LEVEL skip (#8133). Surface 402 so quota
+    // exhaustion follows the #1731 path instead of "authentication expired".
+    const httpStatus =
+      status === "credits_exhausted" ? HTTP_STATUS.PAYMENT_REQUIRED : HTTP_STATUS.UNAUTHORIZED;
+    return errorResponse(httpStatus, message);
   }
   if (!excludeConnectionId) {
     // Ported from upstream decolua/9router#336 (Ibrahim Ryan): surface as 404

--- a/tests/unit/12441-embeddings-credits-402.test.ts
+++ b/tests/unit/12441-embeddings-credits-402.test.ts
@@ -1,0 +1,41 @@
+/**
+ * #12441 — embeddings credential exhaustion with credits_exhausted must
+ * surface HTTP 402, matching handleNoCredentials.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-embed-credits-402-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "embed-credits-402-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("createEmbeddingResponse maps allExpired+credits_exhausted to HTTP 402", async () => {
+  await providersDb.createProviderConnection({
+    provider: "mistral",
+    authType: "apikey",
+    apiKey: "mistral-exhausted-key",
+    isActive: true,
+    testStatus: "credits_exhausted",
+  });
+
+  const res = await createEmbeddingResponse({
+    model: "mistral/mistral-embed",
+    input: "hello",
+  });
+  const body = (await res.json()) as { error?: { message?: string } };
+
+  assert.equal(res.status, 402);
+  assert.match(String(body.error?.message || ""), /credits exhausted/i);
+});

--- a/tests/unit/12441-quota-not-auth-skip.test.ts
+++ b/tests/unit/12441-quota-not-auth-skip.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #12441 — credits-exhausted / quota bodies restated as HTTP 401 must not
+ * take the combo AUTH_LEVEL skip path (#8133 authentication expired).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyComboTargetExhaustion,
+  isQuotaOrCreditsError,
+  type ComboExhaustionSets,
+} from "../../open-sse/services/combo/targetExhaustion.ts";
+
+function emptySets(): ComboExhaustionSets {
+  return {
+    exhaustedProviders: new Set<string>(),
+    exhaustedConnections: new Set<string>(),
+    transientRateLimitedProviders: new Set<string>(),
+  };
+}
+
+const log = { info() {}, warn() {}, error() {}, debug() {} };
+
+function chutesTarget() {
+  return {
+    kind: "model",
+    executionKey: "ek",
+    modelStr: "chutes/moonshotai/Kimi-K3-TEE",
+    provider: "chutes",
+    providerId: null,
+    connectionId: "conn-chutes-1",
+  } as Parameters<typeof applyComboTargetExhaustion>[0];
+}
+
+test("#12441 isQuotaOrCreditsError detects credits-exhausted 401 bodies", () => {
+  assert.equal(
+    isQuotaOrCreditsError(
+      "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard"
+    ),
+    true
+  );
+  assert.equal(
+    isQuotaOrCreditsError("[claude] All 1 connection(s) authentication expired — please reconnect in the dashboard"),
+    false
+  );
+});
+
+test("#12441 credits-exhausted HTTP 401 does not mark auth-level connection skip", () => {
+  const s = emptySets();
+  const exhausted = applyComboTargetExhaustion(chutesTarget(), {
+    result: { status: 401 },
+    fallbackResult: {},
+    errorText:
+      "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
+    rawModel: "moonshotai/Kimi-K3-TEE",
+    isTokenLimitBreach: false,
+    allAccountsRateLimited: false,
+    requestScopedFailure: false,
+    sets: s,
+    log,
+    tag: "COMBO",
+    exhaustedLogLevel: "info",
+  });
+  assert.equal(exhausted, false);
+  assert.equal(s.exhaustedConnections.has("chutes:conn-chutes-1"), false);
+  assert.equal(s.exhaustedProviders.has("chutes"), false);
+});
+
+test("#12441 real authentication expired 401 still marks the connection", () => {
+  const s = emptySets();
+  const exhausted = applyComboTargetExhaustion(chutesTarget(), {
+    result: { status: 401 },
+    fallbackResult: {},
+    errorText:
+      "[claude] All 1 connection(s) authentication expired — please reconnect in the dashboard",
+    rawModel: "claude-opus-4-8",
+    isTokenLimitBreach: false,
+    allAccountsRateLimited: false,
+    requestScopedFailure: false,
+    sets: s,
+    log,
+    tag: "COMBO",
+    exhaustedLogLevel: "info",
+  });
+  assert.equal(exhausted, true);
+  assert.equal(s.exhaustedConnections.has("chutes:conn-chutes-1"), true);
+});
+
+
+function quotaTarget() {
+  return {
+    kind: "model",
+    executionKey: "ek",
+    modelStr: "test-dedup-provider/m1",
+    provider: "test-dedup-provider",
+    providerId: null,
+    connectionId: "conn-1",
+  } as Parameters<typeof applyComboTargetExhaustion>[0];
+}
+
+test("#12441 credits-exhausted 401 on a non-passthrough provider takes quota skip (#1731) not auth skip (#8133)", () => {
+  const s = emptySets();
+  const exhausted = applyComboTargetExhaustion(quotaTarget(), {
+    result: { status: 401 },
+    fallbackResult: {},
+    errorText:
+      "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
+    rawModel: "m1",
+    isTokenLimitBreach: false,
+    allAccountsRateLimited: false,
+    requestScopedFailure: false,
+    sets: s,
+    log,
+    tag: "COMBO",
+    exhaustedLogLevel: "info",
+  });
+  assert.equal(exhausted, true);
+  assert.equal(
+    s.exhaustedConnections.has("test-dedup-provider:conn-1"),
+    false,
+    "must not take the #8133 auth-level connection skip"
+  );
+  assert.equal(
+    s.exhaustedProviders.has("test-dedup-provider"),
+    true,
+    "quota body restated as 401 must still follow #1731 provider skip"
+  );
+});

--- a/tests/unit/12441-quota-not-auth-skip.test.ts
+++ b/tests/unit/12441-quota-not-auth-skip.test.ts
@@ -39,7 +39,34 @@ test("#12441 isQuotaOrCreditsError detects credits-exhausted 401 bodies", () => 
     true
   );
   assert.equal(
-    isQuotaOrCreditsError("[claude] All 1 connection(s) authentication expired — please reconnect in the dashboard"),
+    isQuotaOrCreditsError(
+      "[claude] All 1 connection(s) authentication expired — please reconnect in the dashboard"
+    ),
+    false
+  );
+});
+
+test("#12441 isQuotaOrCreditsError still matches quota text when structuredError.code is non-quota", () => {
+  assert.equal(
+    isQuotaOrCreditsError("generic upstream failure", {
+      code: "invalid_request",
+      type: "api_error",
+      message: "You've reached your usage limit for this billing cycle",
+    }),
+    true
+  );
+  assert.equal(
+    isQuotaOrCreditsError(
+      "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
+      { code: "unauthorized", type: "auth_error" }
+    ),
+    true
+  );
+  assert.equal(
+    isQuotaOrCreditsError("generic upstream failure", {
+      code: "unauthorized",
+      message: "authentication expired",
+    }),
     false
   );
 });
@@ -49,8 +76,7 @@ test("#12441 credits-exhausted HTTP 401 does not mark auth-level connection skip
   const exhausted = applyComboTargetExhaustion(chutesTarget(), {
     result: { status: 401 },
     fallbackResult: {},
-    errorText:
-      "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
+    errorText: "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
     rawModel: "moonshotai/Kimi-K3-TEE",
     isTokenLimitBreach: false,
     allAccountsRateLimited: false,
@@ -63,6 +89,29 @@ test("#12441 credits-exhausted HTTP 401 does not mark auth-level connection skip
   assert.equal(exhausted, false);
   assert.equal(s.exhaustedConnections.has("chutes:conn-chutes-1"), false);
   assert.equal(s.exhaustedProviders.has("chutes"), false);
+});
+
+test("#12441 structuredError quota message with a non-quota code does not auth-skip", () => {
+  const s = emptySets();
+  const exhausted = applyComboTargetExhaustion(chutesTarget(), {
+    result: { status: 401 },
+    fallbackResult: {},
+    errorText: "generic upstream failure",
+    rawModel: "moonshotai/Kimi-K3-TEE",
+    isTokenLimitBreach: false,
+    allAccountsRateLimited: false,
+    requestScopedFailure: false,
+    sets: s,
+    log,
+    tag: "COMBO",
+    exhaustedLogLevel: "info",
+    structuredError: {
+      code: "invalid_request",
+      message: "You've reached your usage limit for this billing cycle",
+    },
+  });
+  assert.equal(exhausted, false);
+  assert.equal(s.exhaustedConnections.has("chutes:conn-chutes-1"), false);
 });
 
 test("#12441 real authentication expired 401 still marks the connection", () => {
@@ -85,7 +134,6 @@ test("#12441 real authentication expired 401 still marks the connection", () => 
   assert.equal(s.exhaustedConnections.has("chutes:conn-chutes-1"), true);
 });
 
-
 function quotaTarget() {
   return {
     kind: "model",
@@ -102,8 +150,7 @@ test("#12441 credits-exhausted 401 on a non-passthrough provider takes quota ski
   const exhausted = applyComboTargetExhaustion(quotaTarget(), {
     result: { status: 401 },
     fallbackResult: {},
-    errorText:
-      "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
+    errorText: "[chutes] All 3 connection(s) credits exhausted — please reconnect in the dashboard",
     rawModel: "m1",
     isTokenLimitBreach: false,
     allAccountsRateLimited: false,

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -25,6 +25,16 @@ const { getCircuitBreaker, resetAllCircuitBreakers, STATE } =
 // DATA_DIR must be fixed before these modules load; keep this test seam dynamic.
 const { setTlsClientForTest } = await import("../../open-sse/utils/proxyFetch.ts");
 
+type ApiErrorJson = {
+  error?: {
+    message?: string;
+    code?: string;
+    type?: string;
+    model?: string;
+    reset_seconds?: number;
+  };
+};
+
 async function resetStorage() {
   resetAllCircuitBreakers();
   core.resetDbInstance();
@@ -85,7 +95,7 @@ test("resolveModelOrError rejects unknown built-in auto catalog ids", async () =
 
   assert.ok(result.error);
   assert.equal(result.error.status, 400);
-  const json = (await result.error.json()) as any;
+  const json = (await result.error.json()) as ApiErrorJson;
   assert.match(json.error.message, /Unknown built-in auto combo/i);
 });
 
@@ -120,7 +130,7 @@ test("resolveModelOrError rejects ambiguous aliases without a provider prefix", 
 
   assert.ok(result.error);
   assert.equal(result.error.status, 400);
-  const json = (await result.error.json()) as any;
+  const json = (await result.error.json()) as ApiErrorJson;
   assert.match(json.error.message, /Ambiguous model/i);
 });
 
@@ -133,7 +143,7 @@ test("resolveModelOrError rejects ambiguous slashful canonical ids instead of mi
 
   assert.ok(result.error);
   assert.equal(result.error.status, 400);
-  const json = (await result.error.json()) as any;
+  const json = (await result.error.json()) as ApiErrorJson;
   assert.match(json.error.message, /Ambiguous model/i);
   assert.match(json.error.message, /openai\/gpt-oss-120b/i);
 });
@@ -147,7 +157,7 @@ test("resolveModelOrError rejects malformed model strings", async () => {
 
   assert.ok(result.error);
   assert.equal(result.error.status, 400);
-  const json = (await result.error.json()) as any;
+  const json = (await result.error.json()) as ApiErrorJson;
   assert.match(json.error.message, /Invalid model format/i);
 });
 
@@ -261,7 +271,7 @@ test("checkPipelineGates blocks providers with an open circuit breaker", async (
       resetTimeoutMs: 5_000,
     },
   });
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as ApiErrorJson;
   const retryAfter = Number(response.headers.get("Retry-After"));
 
   assert.equal(response.status, 503);
@@ -329,8 +339,8 @@ test("handleNoCredentials reports missing provider credentials and exhausted acc
     500
   );
 
-  const missingJson = (await missing.json()) as any;
-  const exhaustedJson = (await exhausted.json()) as any;
+  const missingJson = (await missing.json()) as ApiErrorJson;
+  const exhaustedJson = (await exhausted.json()) as ApiErrorJson;
 
   assert.equal(missing.status, 404);
   assert.match(missingJson.error.message, /No active credentials for provider: openai/);
@@ -413,7 +423,7 @@ test("handleNoCredentials returns Retry-After when every account is rate limited
     null,
     null
   );
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as ApiErrorJson;
 
   assert.equal(response.status, 429);
   assert.ok(Number(response.headers.get("Retry-After")) >= 1);
@@ -438,7 +448,7 @@ test("handleNoCredentials returns structured model_cooldown when every credentia
     null,
     null
   );
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as ApiErrorJson;
 
   assert.equal(response.status, 429);
   assert.equal(Number(response.headers.get("Retry-After")) >= 1, true);
@@ -461,7 +471,7 @@ test("handleNoCredentials returns 401 with re-auth hint when every connection is
     null,
     null
   );
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as ApiErrorJson;
 
   assert.equal(response.status, 401);
   assert.match(json.error.message, /\[kiro\]/);
@@ -478,7 +488,7 @@ test("handleNoCredentials maps allExpired status='expired' to the 'authenticatio
     null,
     null
   );
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as ApiErrorJson;
 
   assert.equal(response.status, 401);
   assert.match(json.error.message, /3 connection\(s\) authentication expired/);
@@ -493,7 +503,7 @@ test("handleNoCredentials maps credits_exhausted to HTTP 402 not 401 (#12441)", 
     null,
     null
   );
-  const json = (await response.json()) as any;
+  const json = (await response.json()) as ApiErrorJson;
 
   assert.equal(response.status, 402);
   assert.match(json.error.message, /3 connection\(s\) credits exhausted/);
@@ -516,7 +526,7 @@ test("handleNoCredentials preserves lastError over allExpired after a failed att
 test("safeResolveProxy returns the direct route when no proxy config is present", async () => {
   const connection = await seedConnection("openai", { apiKey: "sk-openai-direct" });
 
-  const resolved = await safeResolveProxy((connection as any).id);
+  const resolved = await safeResolveProxy((connection as { id: string }).id);
 
   assert.deepEqual(resolved, {
     proxy: null,
@@ -708,7 +718,7 @@ test("resolveModelOrError returns model_not_found error for unrecognised bare mo
 
   assert.ok(result.error);
   assert.equal(result.error.status, 400);
-  const json = (await result.error.json()) as any;
+  const json = (await result.error.json()) as ApiErrorJson;
   assert.match(json.error.message, /Unable to determine provider/i);
   assert.match(json.error.message, /completely-unknown-model-xyz/i);
 });

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -484,6 +484,21 @@ test("handleNoCredentials maps allExpired status='expired' to the 'authenticatio
   assert.match(json.error.message, /3 connection\(s\) authentication expired/);
 });
 
+test("handleNoCredentials maps credits_exhausted to HTTP 402 not 401 (#12441)", async () => {
+  const response = handleNoCredentials(
+    { allExpired: true, expiredCount: 3, expiredStatus: "credits_exhausted" },
+    null,
+    "chutes",
+    "moonshotai/Kimi-K3-TEE",
+    null,
+    null
+  );
+  const json = (await response.json()) as any;
+
+  assert.equal(response.status, 402);
+  assert.match(json.error.message, /3 connection\(s\) credits exhausted/);
+});
+
 test("handleNoCredentials preserves lastError over allExpired after a failed attempt", async () => {
   const response = handleNoCredentials(
     { allExpired: true, expiredCount: 1, expiredStatus: "credits_exhausted" },


### PR DESCRIPTION
## Summary

- Combo dispatch treated HTTP 401/403 as authentication-expired (#8133) even when the body was quota/credits exhaustion, so remaining combo targets were skipped.
- `credits_exhausted` is now surfaced as HTTP 402 (`PAYMENT_REQUIRED`) from chat and embeddings credential exhaustion, matching the quota class.
- `applyComboTargetExhaustion` ignores quota/credits bodies on the auth-skip path. Real expired 401 still marks the connection.

## Related Issues

- Closes #12441
- Related to #8133, #1731, #10314, #12294

## Validation

- [x] Change type: routing
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` (CI)
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Focused command:

```
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/12441-quota-not-auth-skip.test.ts tests/unit/chat-helpers.test.ts
```

Result: 32 pass, 0 fail.

## Tests Added Or Updated

- `tests/unit/12441-quota-not-auth-skip.test.ts`
- `tests/unit/chat-helpers.test.ts`

## Coverage Notes

- Combo skip classification is covered by the new #12441 unit tests.
- Chat credential exhaustion HTTP status is covered by `handleNoCredentials maps credits_exhausted to HTTP 402 not 401`.

## Reviewer Notes

- This does not change genuine 403 auth skip (invalid token / embeddings 403).
- Combo per-model timeout vs upstream fetch timeout is still a follow-up from #12441.
- TOKEN_REFRESH success still does not by itself clear skip state; that is a separate follow-up.
