### PR TITLE
fix(system): stop auto-update misreading a global npm install as a source checkout

### DIFF
--- a/src/lib/system/autoUpdate.ts
+++ b/src/lib/system/autoUpdate.ts
@@ -28,12 +28,35 @@ export function isValidPackageMarker(dir: string): boolean {
   }
 }
 
+/**
+ * Turbopack (Next.js 16 server bundles) does not preserve `__dirname`: it inlines a build-time
+ * placeholder rooted at `/ROOT/` (e.g. `"/ROOT/src/lib/system"`) instead of the real on-disk
+ * directory. Walking up from that path finds nothing, so `PROJECT_ROOT` used to fall back to
+ * `$HOME` — and when `$HOME/.git` exists (a `bd init`, a dotfiles repo) a global npm install was
+ * misclassified as a *source checkout* and the updater ran `git fetch --tags origin` in the home
+ * directory (`fatal: 'origin' does not appear to be a git repository`).
+ *
+ * When the start dir is missing or is that placeholder, the server's cwd (`dist/` for the npm
+ * package, the repo root for a checkout) is the trustworthy anchor instead.
+ *
+ * @internal — exported for testability.
+ */
+export function isBundledDirnamePlaceholder(dir: string | undefined): boolean {
+  if (!dir) return true;
+  return /^[/\\]ROOT([/\\]|$)/.test(dir);
+}
+
+function moduleDirname(): string | undefined {
+  return typeof __dirname !== "undefined" ? __dirname : undefined;
+}
+
 /** @internal — exported for testability. */
 export function resolveProjectRoot(
   fallback: string,
-  startDir: string = typeof __dirname !== "undefined" ? __dirname : process.cwd()
+  startDir: string | undefined = moduleDirname(),
+  cwd: string = process.cwd()
 ): string {
-  let dir = path.resolve(startDir);
+  let dir = path.resolve(isBundledDirnamePlaceholder(startDir) ? cwd : startDir);
   while (true) {
     if (existsSync(path.join(dir, ".git"))) return dir;
     if (existsSync(path.join(dir, "package.json")) && isValidPackageMarker(dir)) return dir;
@@ -42,6 +65,17 @@ export function resolveProjectRoot(
     dir = parent;
   }
   return fallback;
+}
+
+/**
+ * A directory is an OmniRoute *source checkout* only when it is a git worktree (`.git` dir or
+ * worktree file) AND carries the project `package.json`. A bare `.git` (e.g. `$HOME` under a
+ * dotfiles/`bd init` repo reached through the fallback) is not a checkout the updater may drive.
+ *
+ * @internal — exported for testability.
+ */
+export function isSourceCheckout(dir: string): boolean {
+  return existsSync(path.join(dir, ".git")) && isValidPackageMarker(dir);
 }
 
 const FALLBACK_CWD = process.env.HOME || homedir() || "/tmp";
@@ -140,15 +174,22 @@ function parsePatchCommits(raw: string | undefined): string[] {
     .filter(Boolean);
 }
 
-export function getAutoUpdateConfig(env: NodeJS.ProcessEnv = process.env): AutoUpdateConfig {
+export function getAutoUpdateConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  location: { projectRoot?: string; currentDir?: string } = {}
+): AutoUpdateConfig {
   const dataDir = env.DATA_DIR || "/tmp/omniroute";
   const repoDir = env.AUTO_UPDATE_REPO_DIR || "/workspace/omniroute";
 
   let mode = normalizeMode(env.AUTO_UPDATE_MODE);
   if (mode === "npm") {
-    const isGitRepo = existsSync(path.join(PROJECT_ROOT, ".git"));
-    const currentDir = typeof __dirname !== "undefined" ? __dirname : PROJECT_ROOT;
-    mode = resolveAutoUpdateMode(mode, { isGitRepo, currentDir });
+    const projectRoot = location.projectRoot ?? PROJECT_ROOT;
+    // In the bundled server `__dirname` is a Turbopack placeholder (see
+    // isBundledDirnamePlaceholder), so classify by the real project root instead — a global
+    // install under node_modules must resolve to "npm" even when $HOME happens to be a git repo.
+    const rawDir = location.currentDir ?? moduleDirname();
+    const currentDir = isBundledDirnamePlaceholder(rawDir) ? projectRoot : rawDir;
+    mode = resolveAutoUpdateMode(mode, { isGitRepo: isSourceCheckout(projectRoot), currentDir });
   }
 
   return {

--- a/tests/unit/auto-update-bundled-dirname-root.test.ts
+++ b/tests/unit/auto-update-bundled-dirname-root.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const autoUpdate = await import("../../src/lib/system/autoUpdate.ts");
+
+// Turbopack inlines `__dirname` in Next.js server bundles as a placeholder rooted at
+// `/ROOT/` (e.g. "/ROOT/src/lib/system"). Walking up from that path finds nothing, so
+// PROJECT_ROOT fell back to $HOME. On a machine where `$HOME/.git` exists (a `bd init`,
+// a dotfiles repo) the npm install was then misclassified as a *source checkout* and the
+// updater ran `git fetch --tags origin` in the home directory:
+//   fatal: 'origin' does not appear to be a git repository
+const TURBOPACK_PLACEHOLDER = "/ROOT/src/lib/system";
+
+function makeFakeGlobalInstall(): { base: string; dist: string; chunks: string } {
+  const base = mkdtempSync(path.join(os.tmpdir(), "omniroute-bundled-dirname-"));
+  const dist = path.join(base, "lib", "node_modules", "omniroute", "dist");
+  const chunks = path.join(dist, ".build", "next", "server", "chunks");
+  mkdirSync(chunks, { recursive: true });
+  // Real npm layout: dist/package.json carries the package name; the synthetic
+  // .build/next/package.json has no name and must be skipped (#8956).
+  writeFileSync(path.join(dist, "package.json"), JSON.stringify({ name: "omniroute" }));
+  writeFileSync(
+    path.join(dist, ".build", "next", "package.json"),
+    JSON.stringify({ type: "commonjs" })
+  );
+  return { base, dist, chunks };
+}
+
+test("isBundledDirnamePlaceholder flags the Turbopack /ROOT placeholder (and no __dirname)", () => {
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder(TURBOPACK_PLACEHOLDER), true);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder("/ROOT"), true);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder("\\ROOT\\src\\lib\\system"), true);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder(undefined), true);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder(""), true);
+  // Real (or merely unusual) paths are never placeholders — a missing dir still walks up and
+  // falls back exactly as before, so `/proc/1`-style probes keep their behaviour.
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder(os.tmpdir()), false);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder("/proc/1"), false);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder("/opt/ROOT/omniroute"), false);
+  assert.equal(autoUpdate.isBundledDirnamePlaceholder("/ROOTFS/app"), false);
+});
+
+test("resolveProjectRoot ignores the bundled placeholder and resolves from the server cwd", () => {
+  const { base, dist, chunks } = makeFakeGlobalInstall();
+  try {
+    const homeLike = path.join(base, "home");
+    mkdirSync(path.join(homeLike, ".git"), { recursive: true });
+
+    // Before the fix: the walk from /ROOT/... found nothing and returned the fallback ($HOME).
+    const root = autoUpdate.resolveProjectRoot(homeLike, TURBOPACK_PLACEHOLDER, chunks);
+    assert.equal(
+      root,
+      dist,
+      `expected the npm package dist dir, got ${root} (fallback leak → git ran in $HOME)`
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("resolveProjectRoot still honours a real start dir when one is given", () => {
+  const { base, dist, chunks } = makeFakeGlobalInstall();
+  try {
+    assert.equal(autoUpdate.resolveProjectRoot("/fallback", chunks, "/unused-cwd"), dist);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("isSourceCheckout: a .git dir without an OmniRoute package.json is NOT a source checkout", () => {
+  const base = mkdtempSync(path.join(os.tmpdir(), "omniroute-home-git-"));
+  try {
+    // $HOME after `bd init` / dotfiles repo: has .git, no package.json.
+    mkdirSync(path.join(base, ".git"));
+    assert.equal(autoUpdate.isSourceCheckout(base), false);
+
+    // A real checkout has both.
+    writeFileSync(path.join(base, "package.json"), JSON.stringify({ name: "omniroute" }));
+    assert.equal(autoUpdate.isSourceCheckout(base), true);
+
+    // A git worktree uses a `.git` *file* — still a checkout.
+    const wt = path.join(base, "wt");
+    mkdirSync(wt);
+    writeFileSync(path.join(wt, ".git"), "gitdir: ../.git/worktrees/wt\n");
+    writeFileSync(path.join(wt, "package.json"), JSON.stringify({ name: "omniroute" }));
+    assert.equal(autoUpdate.isSourceCheckout(wt), true);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("getAutoUpdateConfig: global npm install under a git-tracked $HOME resolves to npm mode", () => {
+  const { base, dist, chunks } = makeFakeGlobalInstall();
+  try {
+    const homeLike = path.join(base, "home");
+    mkdirSync(path.join(homeLike, ".git"), { recursive: true });
+    const config = autoUpdate.getAutoUpdateConfig(
+      {},
+      {
+        projectRoot: autoUpdate.resolveProjectRoot(homeLike, TURBOPACK_PLACEHOLDER, chunks),
+        currentDir: TURBOPACK_PLACEHOLDER,
+      }
+    );
+    assert.equal(config.mode, "npm");
+    assert.equal(autoUpdate.resolveProjectRoot(homeLike, TURBOPACK_PLACEHOLDER, chunks), dist);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

The dashboard **Update** button fails on a global npm install (`npm install -g omniroute`) with:

```
Install Package — Fetching latest tags from origin...
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.
```

Observed on 3.8.49 → 3.8.50 (macOS, `omniroute` installed under `~/.hermes/node/lib/node_modules`).

## Root cause

Turbopack does not preserve `__dirname` in the Next.js server bundle — it inlines the build-time placeholder `"/ROOT/src/lib/system"` (verified in the published `dist/.build/next/server/chunks/_1m239kc._.js`).

`resolveProjectRoot()` in `src/lib/system/autoUpdate.ts` walks up from that path, which does not exist, finds no `.git` / `package.json`, and returns the fallback `$HOME`. Two consequences:

1. When `$HOME/.git` exists (a `bd init`, a dotfiles repo), `existsSync(PROJECT_ROOT/.git)` is true → mode `source` → the route runs `git fetch --tags origin` with `cwd=$HOME` → the error above.
2. Otherwise `isUnderNodeModules("/ROOT/src/lib/system")` is false → mode `source` anyway → `validateAutoUpdateRuntime` rejects with "Not a git repository. Download source or use npm install -g."

So the in-app updater is effectively broken for every npm install of the bundled server, not only machines with a git repo in `$HOME`.

## Fix (`src/lib/system/autoUpdate.ts`)

- `isBundledDirnamePlaceholder()` recognises the Turbopack `/ROOT` placeholder (and a missing `__dirname`); `resolveProjectRoot()` then anchors the walk on the server cwd (`dist/` for the npm package, the repo root for a checkout) instead of the fake path.
- `isSourceCheckout()` requires `.git` **and** the project `package.json`, so a bare `$HOME/.git` reached through the fallback can never enable git mode.
- `getAutoUpdateConfig()` classifies by the real project root rather than the placeholder, so a global install under `node_modules` resolves to `npm`. It accepts an optional location override for tests.
- Explicit `AUTO_UPDATE_MODE=source|docker-compose` is untouched.

## Validation (Hard Rule #18 — TDD)

New regression test `tests/unit/auto-update-bundled-dirname-root.test.ts` builds a fake `lib/node_modules/omniroute/dist/.build/next/server/chunks` layout plus a `home/.git` fallback dir and asserts the resolved root / mode. On the previous code it fails with the fallback leak (`resolveProjectRoot` returns the home dir); it passes now.

```
node --import tsx/esm --test tests/unit/auto-update-bundled-dirname-root.test.ts \
  tests/unit/auto-update.test.ts tests/unit/auto-update-mode-detection.test.ts \
  tests/unit/auto-update-runtime.test.ts tests/unit/repro-8956.test.ts \
  tests/unit/autoupdate-npm-win32-5542.test.ts tests/unit/system-version-check-4100.test.ts \
  tests/unit/system-version-cache-8278.test.ts
# tests 50 / pass 50 / fail 0

npx eslint src/lib/system/autoUpdate.ts tests/unit/auto-update-bundled-dirname-root.test.ts   # clean
npm run typecheck:core                                                                          # exit 0
```

Base-green check for `release/v3.8.51`: no open `Release branch not green` issue at the time of opening.
