### PR TITLE
fix(resilience): surface Responses failed.error.message in 502s

### DIFF
--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -327,8 +327,9 @@ export function describeMalformedNonStream(
     const rawMessage =
       typeof err?.message === "string" && err.message.trim().length > 0 ? err.message.trim() : null;
     return {
+      // Trim only here; buildErrorBody (chatCore) does the single sanitization pass.
       message: rawMessage
-        ? sanitizeErrorMessage(`upstream reported a failed response: ${rawMessage}`)
+        ? `upstream reported a failed response: ${rawMessage}`
         : "upstream reported a failed response without usable output",
       code: "upstream_response_failed",
       type: "upstream_response_error",

--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -323,8 +323,13 @@ export function describeMalformedNonStream(
 ): { message: string; code: string; type: string } {
   const body = resp && typeof resp === "object" ? (resp as Record<string, unknown>) : null;
   if (body?.object === "response" && body.status === "failed") {
+    const err = body.error && typeof body.error === "object" ? (body.error as Record<string, unknown>) : null;
+    const rawMessage =
+      typeof err?.message === "string" && err.message.trim().length > 0 ? err.message.trim() : null;
     return {
-      message: "upstream reported a failed response without usable output",
+      message: rawMessage
+        ? sanitizeErrorMessage(`upstream reported a failed response: ${rawMessage}`)
+        : "upstream reported a failed response without usable output",
       code: "upstream_response_failed",
       type: "upstream_response_error",
     };

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -105,6 +105,22 @@ test("failed Responses API body gets a request-scoped machine-readable classific
   });
 });
 
+test("failed Responses API body surfaces the upstream error message when present", () => {
+  const failed = {
+    object: "response",
+    status: "failed",
+    output: [],
+    error: { code: "server_error", message: "  Gemini 503: overloaded  " },
+  };
+  const reason = detectMalformedNonStream(failed);
+  assert.equal(reason, "empty_choices");
+  assert.deepEqual(describeMalformedNonStream(failed, reason), {
+    message: "upstream reported a failed response: Gemini 503: overloaded",
+    code: "upstream_response_failed",
+    type: "upstream_response_error",
+  });
+});
+
 test("detectMalformedNonStream returns 'empty_choices' when choice message has no content", () => {
   const body = {
     choices: [{ message: { content: "", tool_calls: null }, finish_reason: "stop" }],


### PR DESCRIPTION
Fixes #12136.

describeMalformedNonStream treated every Responses status=failed body as the generic "upstream reported a failed response without usable output" string, even when openai-responses.ts already stored the real upstream error at response.error.

This keeps the request-scoped upstream_response_failed code (combo skip / exhaustion unchanged) and interpolates a sanitized error.message when present. Empty/missing error still uses the generic fallback.

The 3.8.49 vs 3.8.50 producer regression remains a separate follow-up; this only stops the classifier from discarding the error the translator already holds.