### PR TITLE
fix(sse): add missing Claude Opus 5 / Sonnet 5 max+effort variants to Devin catalog

### DIFF
--- a/open-sse/config/providers/registry/devin/catalog.ts
+++ b/open-sse/config/providers/registry/devin/catalog.ts
@@ -18,6 +18,11 @@ export const DEVIN_MODEL_CATALOG: RegistryModel[] = [
   { id: "claude-opus-5-high", name: "Claude Opus 5 High", contextLength: 1000000 },
   { id: "claude-opus-5-medium", name: "Claude Opus 5 Medium", contextLength: 1000000 },
   { id: "claude-opus-5-low", name: "Claude Opus 5 Low", contextLength: 1000000 },
+  // Claude Opus 5 Max + Effort
+  { id: "claude-opus-5-max-xhigh", name: "Claude Opus 5 Max XHigh", contextLength: 1000000 },
+  { id: "claude-opus-5-max-high", name: "Claude Opus 5 Max High", contextLength: 1000000 },
+  { id: "claude-opus-5-max-medium", name: "Claude Opus 5 Max Medium", contextLength: 1000000 },
+  { id: "claude-opus-5-max-low", name: "Claude Opus 5 Max Low", contextLength: 1000000 },
   // Claude Opus 4.8
   { id: "claude-opus-4-8-max", name: "Claude Opus 4.8 Max", contextLength: 1000000 },
   { id: "claude-opus-4-8-xhigh", name: "Claude Opus 4.8 XHigh", contextLength: 1000000 },
@@ -45,6 +50,11 @@ export const DEVIN_MODEL_CATALOG: RegistryModel[] = [
   { id: "claude-sonnet-5-high", name: "Claude Sonnet 5 High", contextLength: 1000000 },
   { id: "claude-sonnet-5-medium", name: "Claude Sonnet 5 Medium", contextLength: 1000000 },
   { id: "claude-sonnet-5-low", name: "Claude Sonnet 5 Low", contextLength: 1000000 },
+  // Claude Sonnet 5 Max + Effort
+  { id: "claude-sonnet-5-max-xhigh", name: "Claude Sonnet 5 Max XHigh", contextLength: 1000000 },
+  { id: "claude-sonnet-5-max-high", name: "Claude Sonnet 5 Max High", contextLength: 1000000 },
+  { id: "claude-sonnet-5-max-medium", name: "Claude Sonnet 5 Max Medium", contextLength: 1000000 },
+  { id: "claude-sonnet-5-max-low", name: "Claude Sonnet 5 Max Low", contextLength: 1000000 },
   // Claude Sonnet 4.6
   {
     id: "claude-sonnet-4-6-thinking-1m",

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -348,6 +348,8 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
       "maxaiDeviceId",
       "userId",
       "maxaiUserId",
+    ],
+  },
   uc: {
     // UC (uncensored.com) persona: auth is the durable Clerk `__client` cookie
     // (a JWT with no exp) plus the session id + user id, all stored in


### PR DESCRIPTION
## What

Adds 8 missing combined base+effort model variants to the Devin model catalog (`open-sse/config/providers/registry/devin/catalog.ts`):

- `claude-opus-5-max-xhigh`
- `claude-opus-5-max-high`
- `claude-opus-5-max-medium`
- `claude-opus-5-max-low`
- `claude-sonnet-5-max-xhigh`
- `claude-sonnet-5-max-high`
- `claude-sonnet-5-max-medium`
- `claude-sonnet-5-max-low`

Also fixes a pre-existing syntax error in `src/shared/providers/webSessionCredentials.ts` where the `maxai` entry's storage keys array and object were never closed before the `uc` entry, which broke `npm run dev` compilation for any environment.

## Why

Requests for any of these 8 `dva/*` variants returned `400 "Model is not present in the current Devin catalog"`. The base entries (`claude-opus-5-max`, `claude-sonnet-5-max`) and individual effort entries (`claude-opus-5-high`, etc.) all exist, but the combined forms were never added — even though the same combined forms exist for other generations (e.g. `claude-opus-4-8-*`).

## Verification

- Catalog entries now resolve: `dva/*` requests route correctly to the Devin CLI instead of failing catalog validation.
- Unauthenticated requests return the expected `502: Devin ACP error -32000: Authentication failed. Run /login`, confirming routing works end-to-end and the only remaining step is the user's own Devin auth.

## Related

- Fixes #12477 (catalog portion)