### PR TITLE
chore(quality): base fixes — stryker tap.testFiles + node_modules cache key

### DIFF
--- a/.github/actions/npm-ci-retry/action.yml
+++ b/.github/actions/npm-ci-retry/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: node_modules
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.node.outputs.version }}-${{ hashFiles('package-lock.json', '.npmrc', 'scripts/build/postinstall.mjs', 'scripts/build/postinstallSupport.mjs', 'scripts/build/colocateOptionals.mjs', 'scripts/build/fixTlsClientNodeBinary.mjs', 'scripts/build/fixPlaywrightAndroid.mjs', 'scripts/build/native-binary-compat.mjs') }}
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.node.outputs.version }}-${{ hashFiles('package-lock.json', '.npmrc', 'scripts/build/postinstall.mjs', 'scripts/build/postinstallSupport.mjs', 'scripts/build/colocateOptionals.mjs', 'scripts/build/wreqJsNative.mjs', 'scripts/build/fixPlaywrightAndroid.mjs', 'scripts/build/native-binary-compat.mjs') }}
 
     - name: npm ci (with retry)
       if: steps.node-modules.outputs.cache-hit != 'true'

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -402,6 +402,7 @@
       "tests/unit/vertex-passthrough-model-lockout.test.ts",
       "tests/unit/video-bridge-drilldown-consumer-route.test.ts",
       "tests/unit/video-bridge-drilldown-route.test.ts",
+      "tests/unit/video-bridge-memory-suppression.test.ts",
       "tests/unit/video-bridge-route-security.test.ts",
       "tests/unit/xai-agent-tools-passthrough.test.ts",
       "tests/unit/combo/connection-aware-expansion.test.ts",

--- a/tests/unit/build/npm-ci-retry-composite.test.ts
+++ b/tests/unit/build/npm-ci-retry-composite.test.ts
@@ -45,7 +45,7 @@ test("composite restores node_modules via actions/cache with an exact, fully-qua
     "scripts/build/postinstall.mjs",
     "scripts/build/postinstallSupport.mjs",
     "scripts/build/colocateOptionals.mjs",
-    "scripts/build/fixTlsClientNodeBinary.mjs",
+    "scripts/build/wreqJsNative.mjs",
     "scripts/build/fixPlaywrightAndroid.mjs",
     "scripts/build/native-binary-compat.mjs",
   ]) {


### PR DESCRIPTION
## Contexto

Duas correções de drift base (`base-red`), agrupadas nesta PR porque ambas caem na convenção
do projeto de que fixes de base-red viajam numa PR dedicada de manutenção, sem tocar
comportamento de produto.

### Fix 1 — `tap.testFiles` sem o teste do video-bridge memory suppression

O teste `tests/unit/video-bridge-memory-suppression.test.ts`, introduzido pela #12427, cobre o
módulo mutado `open-sse/handlers/chatCore/memoryExtraction.ts`, mas não foi registrado em
`tap.testFiles` no `stryker.conf.json`. Como resultado, o gate `mutation-test-coverage` (dentro
de "Fast Quality Gates") falhava em TODA PR aberta com:

```
✗ 1 covering unit test(s) across 1 module(s) are missing from stryker.conf.json tap.testFiles
```

Correção: uma única entrada nova, inserida na posição alfabética correta dentro do array
`tap.testFiles` (`stryker.conf.json`):

```diff
       "tests/unit/video-bridge-drilldown-route.test.ts",
+      "tests/unit/video-bridge-memory-suppression.test.ts",
       "tests/unit/video-bridge-route-security.test.ts",
```

### Fix 2 — cache key do `node_modules` ainda referenciava o script removido pela migração wreq-js

A #12429 ("fix(providers): migrate web cookie TLS transport to wreq-js") removeu
`scripts/build/fixTlsClientNodeBinary.mjs` e passou a usar `scripts/build/wreqJsNative.mjs`
(importado por `scripts/build/postinstall.mjs`), mas não atualizou duas referências que ainda
citavam o arquivo apagado:

- a cache key de `node_modules` em `.github/actions/npm-ci-retry/action.yml` (dentro do
  `hashFiles(...)`);
- a lista de scripts esperados em `tests/unit/build/npm-ci-retry-composite.test.ts`.

Resultado: dois testes falhavam em toda PR aberta (`composite restores node_modules via
actions/cache with an exact, fully-qualified key` e `every postinstall helper imported by
postinstall.mjs is in the cache key`), e a cache key silenciosamente perdeu um componente — uma
mudança em `wreqJsNative.mjs` não invalidaria o cache do `node_modules`.

Correção: troca pontual de `scripts/build/fixTlsClientNodeBinary.mjs` por
`scripts/build/wreqJsNative.mjs` nos dois lugares, mantendo estrutura/ordem do array e sem
enfraquecer nenhuma asserção.

```diff
-        key: node-modules-...-${{ hashFiles(..., 'scripts/build/fixTlsClientNodeBinary.mjs', ...) }}
+        key: node-modules-...-${{ hashFiles(..., 'scripts/build/wreqJsNative.mjs', ...) }}
```

Nenhuma das duas correções altera comportamento de produto — apenas realinham metadados de
gates de qualidade/CI com a realidade do código já mergeado.

## Validação

```
$ node --import tsx/esm --test tests/unit/build/npm-ci-retry-composite.test.ts
✔ composite restores node_modules via actions/cache with an exact, fully-qualified key
✔ npm ci is the cache-miss path and still retries
✔ cache can be disabled per caller and defaults on
✔ every postinstall helper imported by postinstall.mjs is in the cache key
ℹ tests 4, pass 4, fail 0

$ npm run check:mutation-test-coverage
Mutation test-coverage gate — tap.testFiles drift detection
===========================================================
Scanned 4794 unit test file(s) against 31 mutated module(s).
✓ No drift — every covering unit test is listed in tap.testFiles.
Exit code: 0

$ npm run check:workflows
[check-workflows] ADVISORY — 238 finding(s) detected (pré-existentes, nenhum referente a
npm-ci-retry/action.yml). Exit code: 0.
```

## Créditos

- O teste `tests/unit/video-bridge-memory-suppression.test.ts` foi escrito e trazido pela
  #12427 — o Fix 1 desta PR apenas registra a entrada faltante em `tap.testFiles`, sem alterar
  o teste.
- O Fix 2 corrige drift deixado pela #12429 ("fix(providers): migrate web cookie TLS transport
  to wreq-js"), que renomeou o script de suporte sem atualizar a cache key e o teste de
  contrato do composite `npm-ci-retry`.
