### PR TITLE
fix(command-code): floor tiny muse-spark output budgets so hidden reasoning cannot consume the whole budget

### DIFF
--- a/open-sse/executors/commandCode.ts
+++ b/open-sse/executors/commandCode.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { isVisionModelId } from "@/shared/constants/visionModels";
+import { MUSE_SPARK_PATTERN } from "./base/reasoningEffort.ts";
 import { REGISTRY } from "../config/providerRegistry.ts";
 import {
   BaseExecutor,
@@ -59,6 +60,29 @@ function clampMaxTokens(value: unknown): number | undefined {
   return Math.min(Math.floor(numeric), MAX_COMMAND_CODE_TOKENS);
 }
 
+/**
+ * muse-spark (Meta) models are served through command-code with a hidden
+ * server-side reasoning phase that consumes the entire output budget before any
+ * visible content is emitted. With small caller-set budgets the upstream
+ * answers HTTP 200 with an empty message and `completion_tokens == max_tokens`
+ * (the symptom this fix targets: `out=64, reasoning=61` with null content);
+ * chatCore then flags the fake success as "Provider returned empty content".
+ *
+ * Floor raised budgets only — explicit large budgets are untouched, and no
+ * budget is synthesized when the caller set none. Detection is prefix-aware so
+ * provider-prefixed ids (`meta/muse-spark-1.2-contributor`, `cmd/meta/muse-…`)
+ * are caught, not just bare `muse-spark-*`.
+ */
+const MUSE_SPARK_MIN_OUTPUT_TOKENS = 512;
+
+function applyMuseSparkMinOutputTokens(model: string, body: JsonRecord): void {
+  if (!MUSE_SPARK_PATTERN.test(model)) return;
+  const current = body.max_tokens;
+  if (typeof current !== "number" || !Number.isFinite(current)) return;
+  if (current >= MUSE_SPARK_MIN_OUTPUT_TOKENS) return;
+  body.max_tokens = MUSE_SPARK_MIN_OUTPUT_TOKENS;
+}
+
 const COMMAND_CODE_PASSTHROUGH_FIELDS = [
   "reasoning_effort",
   "reasoning",
@@ -111,6 +135,7 @@ function buildOpenAiBody(model: string, body: unknown, stream: boolean): { body:
   if (maxTokens !== undefined) {
     out.max_tokens = maxTokens;
   }
+  applyMuseSparkMinOutputTokens(resolvedModel, out);
 
   return { body: out };
 }
@@ -374,6 +399,7 @@ function buildCommandCodeCliBody(
   if (maxTokens !== undefined) {
     params.max_tokens = maxTokens;
   }
+  applyMuseSparkMinOutputTokens(resolvedModel, params);
 
   for (const field of COMMAND_CODE_PASSTHROUGH_FIELDS) {
     const value = input[field];

--- a/tests/unit/command-code-executor.test.ts
+++ b/tests/unit/command-code-executor.test.ts
@@ -334,6 +334,37 @@ test("Command Code executor honors a smaller client-provided max_tokens", async 
   assert.equal((calls[0].body as Record<string, unknown>).max_tokens, 2048);
 });
 
+test("Command Code executor floors tiny muse-spark output budgets so hidden reasoning cannot consume the whole budget", async () => {
+  const calls = captureFetch({});
+  (await getExecutor("command-code")).execute({
+    model: "meta/muse-spark-1.2-contributor",
+    stream: false,
+    credentials: { apiKey: "cc_test_key" },
+    body: {
+      messages: [{ role: "user", content: "Hi" }],
+      max_tokens: 64,
+    },
+  });
+  // The prefixed id must be caught by the prefix-aware detection, and the tiny
+  // caller budget raised to the floor so the upstream emits visible content
+  // instead of a 200 with null content (out=64, reasoning=61).
+  assert.equal((calls[0].body as Record<string, unknown>).max_tokens, 512);
+});
+
+test("Command Code executor leaves existing large muse-spark budgets untouched", async () => {
+  const calls = captureFetch({});
+  (await getExecutor("command-code")).execute({
+    model: "meta/muse-spark-1.2-contributor",
+    stream: false,
+    credentials: { apiKey: "cc_test_key" },
+    body: {
+      messages: [{ role: "user", content: "Hi" }],
+      max_tokens: 4096,
+    },
+  });
+  assert.equal((calls[0].body as Record<string, unknown>).max_tokens, 4096);
+});
+
 test("Command Code stream preserves the upstream OpenAI usage chunk (passthrough)", async () => {
   const sse =
     openAiSse({


### PR DESCRIPTION
## Summary

- muse-spark (Meta) models routed through **command-code** burn their entire output budget on invisible server-side reasoning before emitting any visible content. With a small
caller-set `max_tokens` (e.g. 64) the upstream answers HTTP 200 with **null content** (`out=64, reasoning=61`) — the client receives an empty assistant turn and OmniRoute flags the
fake success as "Provider returned empty content". This is the reproduction in **#12130**.
- Fix: reuse the already prefix-aware `MUSE_SPARK_PATTERN` (`/(?:^|\/|\b)muse-spark/i`) to detect muse-spark ids — **including provider-prefixed forms**
(`meta/muse-spark-1.2-contributor`, `cmd/meta/muse-…`) that a bare `startsWith("muse-spark")` would miss — and floor a tiny caller budget to `MUSE_SPARK_MIN_OUTPUT_TOKENS = 512` so
the hidden reasoning phase can never consume the whole budget.
- Applied in **both** command-code body builders: `buildOpenAiBody` (the `/provider/v1/chat/completions` path that the reproduction goes through) and `buildCommandCodeCliBody` (the
`/alpha/generate` 403/404 fallback), mirroring the existing `applyMuseSparkMinOutputTokens` behavior already shipped for the opencode-go executor.

## Related Issues

- Related to #12130 (OpenAI API returns null content when model output consists of reasoning tokens, e.g. `command-code/meta/muse-spark-1.2-contributor`) — the exact `out=64,
reasoning=61, content:null` reproduction this fix targets.
- Related to #11214 (muse-spark output budget is floored so it stops returning empty-content responses) — same empty-content-on-small-budget class; previously applied only to
opencode-go, now extended to command-code.
- Related to #10986 (original reasoning-only `content:null` report) — this fix paves the `/provider/v1` path so the budget-floor mitigation prevents the empty-content condition
rather than relying on a downstream fallback.

## Validation

- [x] Change type: provider / routing
- [x] Focused tests and category gates from the golden path

  `node --test tests/unit/command-code-executor.test.ts` → 20/20 pass
  `tsc --noEmit -p tsconfig.typecheck-core.json` → clean
- [x] `npm run lint`
- [x] Reconciled with the current active release base (`release/v3.8.51`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/command-code-executor.test.ts` — 2 new cases:
  - `meta/muse-spark-1.2-contributor` + `max_tokens: 64` → raised to `512` (the #12130 bug path)
  - large budget (`4096`) left untouched (no over-flooring)

> The existing `tests/unit/opencode-muse-spark-min-output.test.ts` (11/11 pass) confirms the opencode-go executor is **untouched** — only command-code was modified.

## Coverage Notes

- `open-sse/executors/commandCode.ts` is covered by the two new tests above, exercising `applyMuseSparkMinOutputTokens` on both the floor and no-op paths (bare + prefixed id
detection).
- Full `npm run test:coverage` (global 60% gate) was attempted; the c8 `--merge-async` run stalled into an 8GB `coverage/tmp` on this Windows workstation, so the per-change gates
above (scoped tests + typecheck) were used as the focused loop. The global 60% gate runs in CI on the PR (#8329).

## Reviewer Notes

- Detection now uses the prefix-aware `MUSE_SPARK_PATTERN`. For command-code this is a **superset** of any prior bare-prefix check — no model is exempted, only newly covered (e.g.
the `meta/…` id in this reproduction).
- This PR is the **budget-floor prevention** approach: it stops the empty-content condition for small caller budgets. It does **not** add a reasoning→content fallback inside the
`/provider/v1` raw passthrough for the case where a model emits reasoning-only with a *large* budget — that remains the domain of #10986's fallback (already present on the
`/alpha/generate` path). Maintainer's note in #12130 confirms `/provider/v1` currently returns the upstream `Response` unmodified; if we also want a downstream reasoning→content
fallback there, that is a deliberate follow-up.
- No new dependency, feature flag, DB migration, or manual validation required.