### PR TITLE
fix(api): thread X-OmniRoute-Fallback-Attempts through chat completions (#12339)

### DIFF
--- a/changelog.d/fixes/12339-fallback-attempts-chat-completions.md
+++ b/changelog.d/fixes/12339-fallback-attempts-chat-completions.md
@@ -1,0 +1,1 @@
+- **fix(api):** thread `X-OmniRoute-Fallback-Attempts` through streaming and non-streaming chat completions ([#12339](https://github.com/diegosouzapw/OmniRoute/issues/12339)) 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -548,6 +548,7 @@ export async function handleChatCore({
   // applied to a CLONE of `body` at the persistAttemptLogs sink (surface 1) —
   // the model-bound `body` itself is never touched.
   videoBridgeLog = undefined,
+  fallbackAttempts = 0,
 }) {
   let { provider, model, extendedContext } = modelInfo;
   // #12150 P1b: true iff the video-bridge guardrail rendered >=1 transcript
@@ -5411,6 +5412,7 @@ export async function handleChatCore({
       requestId: skillRequestId,
       compressionResponseMeta,
       comboStrategy,
+      fallbackAttempts,
     });
     // #6426: align response body `model` with the `X-OmniRoute-Model` header
     // (both must be the resolved backend model). Some upstreams (notably legacy
@@ -5561,6 +5563,7 @@ export async function handleChatCore({
     pendingRequestId,
     compressionResponseMeta,
     comboStrategy,
+    fallbackAttempts,
   });
 
   // The streaming headers (turn-state included, when present) are committed to

--- a/open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts
+++ b/open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts
@@ -21,6 +21,7 @@ export function buildNonStreamingResponseHeaders(
     requestId: string | null | undefined;
     compressionResponseMeta?: string | null | undefined;
     comboStrategy?: string | null | undefined;
+    fallbackAttempts?: number;
   },
   deps: { attachOmniRouteMetaHeaders: typeof defaultAttachMeta; now: () => number } = {
     attachOmniRouteMetaHeaders: defaultAttachMeta,
@@ -40,6 +41,7 @@ export function buildNonStreamingResponseHeaders(
     costUsd: args.estimatedCost,
     requestId: args.requestId,
     strategy: args.comboStrategy ?? "single",
+    fallbackAttempts: args.fallbackAttempts,
   });
   if (args.compressionResponseMeta) {
     responseHeaders[OMNIROUTE_RESPONSE_HEADERS.compression] = args.compressionResponseMeta;

--- a/open-sse/handlers/chatCore/streamingResponseHeaders.ts
+++ b/open-sse/handlers/chatCore/streamingResponseHeaders.ts
@@ -19,6 +19,7 @@ export function assembleStreamingResponseHeaders(
     pendingRequestId: string;
     compressionResponseMeta?: string | null | undefined;
     comboStrategy?: string | null | undefined;
+    fallbackAttempts?: number;
   },
   buildStreamingResponseHeaders: typeof defaultBuildStreaming = defaultBuildStreaming
 ): Record<string, string> {
@@ -31,6 +32,7 @@ export function assembleStreamingResponseHeaders(
       usage: null,
       costUsd: 0,
       strategy: args.comboStrategy ?? "single",
+      fallbackAttempts: args.fallbackAttempts,
     }),
     "x-omniroute-request-id": args.pendingRequestId,
   };

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -1726,6 +1726,7 @@ async function handleComboChatInner({
             ...targetForAttempt,
             effectiveComboStrategy: strategy,
             failoverBeforeRetry: config.failoverBeforeRetry,
+            fallbackAttempts: fallbackCount,
           });
 
           // Success — validate response quality before returning
@@ -3471,6 +3472,7 @@ async function handleRoundRobinCombo({
               ...targetForAttempt,
               effectiveComboStrategy: "round-robin",
               failoverBeforeRetry: config.failoverBeforeRetry,
+              fallbackAttempts: fallbackCount,
             }),
             rrSafetyPromise,
           ]);

--- a/open-sse/services/combo/types.ts
+++ b/open-sse/services/combo/types.ts
@@ -60,8 +60,9 @@ export type SingleModelTarget =
       modelAbortSignal?: AbortSignal | null;
       /** True when this target was selected via context-cache session pinning. */
       modelPinned?: boolean;
+      fallbackAttempts?: number;
     })
-  | { modelAbortSignal: AbortSignal };
+  | { modelAbortSignal: AbortSignal; fallbackAttempts?: number };
 
 export type HandleSingleModel = (
   body: Record<string, unknown>,

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1108,6 +1108,7 @@ async function handleChatImplementation(
           providerId?: string | null;
           effectiveComboStrategy?: string | null;
           modelAbortSignal?: AbortSignal | null;
+          fallbackAttempts?: number;
         }
       ) =>
         handleSingleModelChat(
@@ -1145,6 +1146,7 @@ async function handleChatImplementation(
             reasoningRequestTags: requestRoutingTags.tags,
             managedLease,
             videoBridgeLog,
+            fallbackAttempts: target?.fallbackAttempts ?? 0,
             // #7360 follow-up: without this, a target dispatch abandoned by
             // targetTimeoutRunner.ts's per-target timeout (comboTargetTimeoutMs)
             // never learns it was abandoned — it only watches the ORIGINAL
@@ -1367,6 +1369,7 @@ async function handleSingleModelChat(
      * the signal used for the actual dispatch, not left unused.
      */
     modelAbortSignal?: AbortSignal | null;
+    fallbackAttempts?: number;
   } = {},
   comboStrategy: string | null = null,
   isCombo: boolean = false
@@ -1924,6 +1927,7 @@ async function handleSingleModelChat(
             reasoningTransportFallback: runtimeOptions.reasoningTransportFallback ?? "drop",
             managedLease: runtimeOptions.managedLease ?? null,
             videoBridgeLog: runtimeOptions.videoBridgeLog,
+            fallbackAttempts: runtimeOptions?.fallbackAttempts ?? 0,
           },
           runtimeOptions
         );

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -443,6 +443,7 @@ export async function executeChatWithBreaker({
   // for every non-video request. Passed straight through to handleChatCore;
   // see its own destructure default for the shape and consumers.
   videoBridgeLog = undefined,
+  fallbackAttempts = 0,
 }: ExecuteChatWithBreakerOptions): Promise<ExecuteChatWithBreakerResult> {
   let tlsFingerprintUsed = false;
   const normalizedTrafficType: TrafficType =
@@ -503,6 +504,7 @@ export async function executeChatWithBreaker({
             reasoningTransportFallback,
             managedLease,
             videoBridgeLog,
+            fallbackAttempts,
             skipResourcePressureGuard: true,
             onCredentialsRefreshed: async (newCreds: any) => {
               await updateProviderCredentials(credentials.connectionId, {

--- a/tests/unit/chatcore-nonstreaming-response-headers.test.ts
+++ b/tests/unit/chatcore-nonstreaming-response-headers.test.ts
@@ -87,3 +87,10 @@ test("compression meta present → compression header set to that value", () => 
   );
   assert.ok(Object.values(h).includes("engine:x; source=header"));
 });
+
+test("meta receives fallbackAttempts when provided", () => {
+  const { deps, metaCalls } = makeDeps(1000);
+  buildNonStreamingResponseHeaders(baseArgs({ fallbackAttempts: 3 }), deps);
+  assert.equal(metaCalls.length, 1);
+  assert.equal(metaCalls[0].meta.fallbackAttempts, 3);
+});

--- a/tests/unit/chatcore-streaming-response-headers.test.ts
+++ b/tests/unit/chatcore-streaming-response-headers.test.ts
@@ -63,3 +63,10 @@ test("compression meta present → compression header set", () => {
   );
   assert.ok(Object.values(h).includes("engine:z; source=routing"));
 });
+
+test("forwards fallbackAttempts to buildStreamingResponseHeaders when provided", () => {
+  const { build, calls } = makeBuild();
+  assembleStreamingResponseHeaders(baseArgs({ fallbackAttempts: 2 }), build);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].meta.fallbackAttempts, 2);
+}); 

--- a/tests/unit/omniroute-meta-fallback-attempts.test.ts
+++ b/tests/unit/omniroute-meta-fallback-attempts.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { OMNIROUTE_RESPONSE_HEADERS } from "../../src/shared/constants/headers.ts";
 import { buildOmniRouteResponseMetaHeaders } from "../../src/domain/omnirouteResponseMeta.ts";
+import { assembleStreamingResponseHeaders } from "../../open-sse/handlers/chatCore/streamingResponseHeaders.ts";                                   
+import { buildNonStreamingResponseHeaders } from "../../open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts";
 
 test("headers constant exposes the fallback-attempts key", () => {
   assert.equal(
@@ -20,4 +22,58 @@ test("buildOmniRouteResponseMetaHeaders omits the header when 0 / absent", () =>
   assert.equal(none["X-OmniRoute-Fallback-Attempts"], undefined);
   const zero = buildOmniRouteResponseMetaHeaders({ model: "gpt", fallbackAttempts: 0 });
   assert.equal(zero["X-OmniRoute-Fallback-Attempts"], undefined);
+});
+
+test("assembleStreamingResponseHeaders includes X-OmniRoute-Fallback-Attempts on streaming responses when fallbackAttempts > 0", () => {                               
+  const providerHeaders = new Headers();                                            
+  const headers = assembleStreamingResponseHeaders({                                
+    providerHeaders,                                                                
+    provider: "openai",                                                             
+    model: "gpt-4o",                                                                
+    pendingRequestId: "req-stream-1",                                               
+    comboStrategy: "priority",                                                      
+    fallbackAttempts: 2,                                                            
+  });                                                                               
+  assert.equal(headers["X-OmniRoute-Fallback-Attempts"], "2");                      
+});                                                                                 
+                                                                                        
+test("assembleStreamingResponseHeaders omits X-OmniRoute-Fallback-Attempts on streaming responses when fallbackAttempts is 0 or absent", () => {                    
+  const providerHeaders = new Headers();                                            
+  const headers = assembleStreamingResponseHeaders({                                
+    providerHeaders,                                                                
+    provider: "openai",                                                             
+    model: "gpt-4o",                                                                
+    pendingRequestId: "req-stream-2",                                               
+    comboStrategy: "priority",                                                      
+    fallbackAttempts: 0,                                                            
+  });                                                                               
+  assert.equal("X-OmniRoute-Fallback-Attempts" in headers, false);                  
+});                                                                                 
+                                                                                        
+test("buildNonStreamingResponseHeaders includes X-OmniRoute-Fallback-Attempts on non-streaming responses when fallbackAttempts > 0", () => {                           
+  const headers = buildNonStreamingResponseHeaders({                                
+    provider: "openai",                                                             
+    model: "gpt-4o",                                                                
+    startTime: Date.now() - 50,                                                     
+    responseUsage: null,                                                            
+    estimatedCost: 0,                                                               
+    requestId: "req-nonstream-1",                                                   
+    comboStrategy: "priority",                                                      
+    fallbackAttempts: 1,                                                            
+  });                                                                               
+  assert.equal(headers["X-OmniRoute-Fallback-Attempts"], "1");                      
+});                                                                                 
+                                                                                        
+test("buildNonStreamingResponseHeaders omits X-OmniRoute-Fallback-Attempts on non-streaming responses when fallbackAttempts is 0 or absent", () => {                    
+  const headers = buildNonStreamingResponseHeaders({                                
+    provider: "openai",                                                             
+    model: "gpt-4o",                                                                
+    startTime: Date.now() - 50,                                                     
+    responseUsage: null,                                                            
+    estimatedCost: 0,                                                               
+    requestId: "req-nonstream-2",                                                   
+    comboStrategy: "priority",                                                      
+    fallbackAttempts: 0,                                                            
+  });                                                                               
+  assert.equal("X-OmniRoute-Fallback-Attempts" in headers, false);                  
 });


### PR DESCRIPTION
## Problem

As reported in #12339 by @diegosouzapw:

On `/v1/chat/completions` responses (both streaming `stream: true` and non-streaming `stream: false`), the `X-OmniRoute-Fallback-Attempts` HTTP header is absent (or defaults to `0`), even when a combo failover to a non-primary target occurred before the stream/response opened.

While `X-OmniRoute-Provider` and `X-OmniRoute-Model` update correctly to the winning provider, the fallback attempts counter was completely missing from chat responses.

## Root Cause

1. **Missing parameter in response-header builders:** Both `assembleStreamingResponseHeaders` and `buildNonStreamingResponseHeaders` built metadata headers without accepting or passing `fallbackAttempts` into `buildStreamingResponseHeaders` / `attachOmniRouteMetaHeaders`.

2. **Missing forwarding in `chatCore.ts`:** `handleChatCore` did not accept `fallbackAttempts` or pass it to either header builder.

3. **Dropped in the dispatch chain:** While `open-sse/services/combo.ts` properly calculates `fallbackCount`, it was not passed through `handleSingleModel` (`chat.ts`), `executeChatWithBreaker` (`chatHelpers.ts`), or `dispatchChatWithAffinityEviction`.

## Fix

### 1. Response Header Builders

- **`open-sse/handlers/chatCore/nonStreamingResponseHeaders.ts`**
  - Added `fallbackAttempts?: number` to the `args` type.
  - Forwarded `fallbackAttempts: args.fallbackAttempts` to `deps.attachOmniRouteMetaHeaders`.

- **`open-sse/handlers/chatCore/streamingResponseHeaders.ts`**
  - Added `fallbackAttempts?: number` to the `args` type.
  - Forwarded `fallbackAttempts: args.fallbackAttempts` to `buildStreamingResponseHeaders`.

### 2. Core Handler & Dispatch Chain

- **`open-sse/handlers/chatCore.ts`**
  - Added `fallbackAttempts = 0` to `handleChatCore` parameters.
  - Forwarded `fallbackAttempts` to `buildNonStreamingResponseHeaders` and `assembleStreamingResponseHeaders`.

- **`src/sse/handlers/chatHelpers.ts`**
  - Added `fallbackAttempts = 0` to `executeChatWithBreaker` options.
  - Forwarded `fallbackAttempts` into `handleChatCore`.

- **`src/sse/handlers/chat.ts`**
  - Added `fallbackAttempts?: number` to the `target` type in `handleSingleModel`.
  - Forwarded `fallbackAttempts: target?.fallbackAttempts ?? 0` into `handleSingleModelChat`.
  - Added `fallbackAttempts?: number` to the `runtimeOptions` type in `handleSingleModelChat`.
  - Forwarded `fallbackAttempts: runtimeOptions?.fallbackAttempts ?? 0` into `dispatchChatWithAffinityEviction`.

### 3. Combo Layer

- **`open-sse/services/combo.ts`**
  - Added `fallbackAttempts: fallbackCount` when dispatching targets in `handleComboChatInner` (`handleSingleModelWithTimeout`).
  - Added `fallbackAttempts: fallbackCount` when dispatching targets in `handleRoundRobinCombo` (`handleSingleModel`).

- **`open-sse/services/combo/types.ts`**
  - Added `fallbackAttempts?: number` to the `SingleModelTarget` type definition.

### 4. Changelog

- Added `changelog.d/fixes/12339-fallback-attempts-chat-completions.md`.

## Tests Added

1. **`tests/unit/chatcore-streaming-response-headers.test.ts`**
   - Added a unit test verifying `assembleStreamingResponseHeaders` passes `meta.fallbackAttempts` to `buildStreamingResponseHeaders`.

2. **`tests/unit/chatcore-nonstreaming-response-headers.test.ts`**
   - Added a unit test verifying `buildNonStreamingResponseHeaders` passes `meta.fallbackAttempts` to `attachOmniRouteMetaHeaders`.

3. **`tests/unit/omniroute-meta-fallback-attempts.test.ts`**
   - Added a streaming test verifying `X-OmniRoute-Fallback-Attempts: 2` when `fallbackAttempts = 2`.
   - Added a streaming test verifying the header is omitted when `fallbackAttempts = 0`.
   - Added a non-streaming test verifying `X-OmniRoute-Fallback-Attempts: 1` when `fallbackAttempts = 1`.
   - Added a non-streaming test verifying the header is omitted when `fallbackAttempts = 0`.

## Validation

- [x] Closes #12339
- [x] Focused tests executed:
  - `node --import tsx/esm --test tests/unit/chatcore-streaming-response-headers.test.ts` (PASS - 4/4)
  - `node --import tsx/esm --test tests/unit/chatcore-nonstreaming-response-headers.test.ts` (PASS - 6/6)
  - `node --import tsx/esm --test tests/unit/omniroute-meta-fallback-attempts.test.ts` (PASS - 7/7)
- [x] Type check: `npm run typecheck:core` (PASS - 0 errors)
- [x] Linter: `npm run lint` (PASS - 0 errors)
- [x] Rebased on the active `release/v3.8.51` base