### PR TITLE
fix(security): unbiased maxai X-Random nonce + stricter URL/regex test assertions (destrava o gate codeql-ratchet)

### DIFF
--- a/open-sse/executors/maxai/signing.ts
+++ b/open-sse/executors/maxai/signing.ts
@@ -23,7 +23,7 @@
  * The non-secret STRUCTURAL fields (appVersion, ctxKey, header names) carry safe
  * defaults so a transient parse miss can't break an otherwise-working signer.
  */
-import { createHmac, createHash, createCipheriv, randomBytes } from "node:crypto";
+import { createHmac, createHash, createCipheriv, randomBytes, randomInt } from "node:crypto";
 import type { MaxaiSigningConstants, MaxaiHeaderNames } from "./constants.ts";
 import { MAXAI_DEFAULT_HEADER_NAMES } from "./constants.ts";
 
@@ -39,8 +39,22 @@ const BLANK_USER_ROUTES = new Set([
 
 const MAGIC = Buffer.from("Salted__", "ascii");
 
+/**
+ * The wire `X-Random` slot: a 6-digit decimal string (100000-999999).
+ *
+ * Uses `crypto.randomInt`, which rejection-samples internally, instead of
+ * `randomBytes(4) % 900000` — a plain modulo over a 32-bit draw does not divide
+ * evenly by 900000, so the low ~4772 values of the range came out marginally
+ * more often. The emitted shape is unchanged (always exactly 6 digits).
+ */
+export function maxaiRandomSlot(): string {
+  return String(randomInt(100000, 1000000));
+}
+
 function hmacSha1Hex(message: string, key: string): string {
-  return createHmac("sha1", Buffer.from(key, "utf8")).update(Buffer.from(message, "utf8")).digest("hex");
+  return createHmac("sha1", Buffer.from(key, "utf8"))
+    .update(Buffer.from(message, "utf8"))
+    .digest("hex");
 }
 
 function sm3Hex(message: string): string {
@@ -58,7 +72,9 @@ function evpBytesToKey(
   let block = Buffer.alloc(0);
   const pass = Buffer.from(passphrase, "utf8");
   while (derived.length < keyLen + ivLen) {
-    block = createHash("md5").update(Buffer.concat([block, pass, salt])).digest();
+    block = createHash("md5")
+      .update(Buffer.concat([block, pass, salt]))
+      .digest();
     derived = Buffer.concat([derived, block]);
   }
   return { key: derived.subarray(0, keyLen), iv: derived.subarray(keyLen, keyLen + ivLen) };
@@ -124,8 +140,7 @@ export function buildMaxaiSignedHeaders(
   constants: MaxaiSigningConstants
 ): Record<string, string> {
   const reqTime = (input.now ?? (() => Date.now()))();
-  const random =
-    input.random?.() ?? String((randomBytes(4).readUInt32BE(0) % 900000) + 100000);
+  const random = input.random?.() ?? maxaiRandomSlot();
   const h: MaxaiHeaderNames = { ...MAXAI_DEFAULT_HEADER_NAMES, ...constants.headerNames };
   const ctxKey = constants.ctxKey;
   const appVersion = constants.appVersion;

--- a/tests/unit/custom-provider-prefix-shadowing-11943.test.ts
+++ b/tests/unit/custom-provider-prefix-shadowing-11943.test.ts
@@ -95,10 +95,14 @@ test("handleChat names the shadowed custom node when the built-in prefix has no 
     /prefix "of" is reserved by the built-in provider "openference"/,
     `runtime error must explain that the prefix resolved to the built-in, got: ${message}`
   );
-  assert.match(
-    message,
-    new RegExp(`"${SHADOWED_NODE_NAME.replace(/[()]/g, "\\$&")}" \\(${SHADOWED_NODE_ID}\\)`),
-    `runtime error must name the shadowed node and its id, got: ${message}`
+  // Exact substring, not a hand-escaped RegExp: the name carries regex
+  // metacharacters (parentheses) and the previous `.replace(/[()]/g, …)` escaped
+  // only those, so any other metachar in a future name would have been
+  // interpreted instead of matched literally (CodeQL js/incomplete-sanitization).
+  const expectedNodeMention = `"${SHADOWED_NODE_NAME}" (${SHADOWED_NODE_ID})`;
+  assert.ok(
+    message.includes(expectedNodeMention),
+    `runtime error must name the shadowed node and its id (${expectedNodeMention}), got: ${message}`
   );
   assert.match(message, /Rename that node's prefix/);
 });

--- a/tests/unit/helpers/ucClerkUrl.ts
+++ b/tests/unit/helpers/ucClerkUrl.ts
@@ -1,0 +1,31 @@
+/**
+ * Strict recognizer for the UC (uncensored.com) Clerk session-token mint call,
+ * shared by the uc-image / uc-video mock `fetch` routers.
+ *
+ * The mock routers used to dispatch on `url.includes("clerk.uncensored.com")`.
+ * That is a substring test over a whole URL, so ANY host answers as long as the
+ * name appears somewhere in it — `https://evil.example/?next=clerk.uncensored.com`
+ * would have been served the mint response. A test whose router accepts a
+ * malformed URL cannot fail when the executor builds one, which is exactly the
+ * regression such a test exists to catch (and CodeQL flags it as
+ * `js/incomplete-url-substring-sanitization`).
+ *
+ * This matches the real shape instead:
+ *   POST https://clerk.uncensored.com/v1/client/sessions/{sid}/tokens?_clerk_js_version=…
+ * comparing the parsed origin against the production constant and pinning the
+ * path shape.
+ */
+import { UC_CLERK_FAPI } from "../../../open-sse/executors/uc/constants.ts";
+
+const MINT_PATH = /^\/v1\/client\/sessions\/[^/]+\/tokens$/;
+
+/** True only for the Clerk mint endpoint on the real Clerk FAPI origin. */
+export function isUcClerkMintUrl(raw: unknown): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(String(raw));
+  } catch {
+    return false;
+  }
+  return parsed.origin === UC_CLERK_FAPI && MINT_PATH.test(parsed.pathname);
+}

--- a/tests/unit/maxai-image.test.ts
+++ b/tests/unit/maxai-image.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../open-sse/handlers/imageGeneration/providers/maxaiImage.ts";
 import { IMAGE_PROVIDERS } from "../../open-sse/config/imageRegistry.ts";
 import { __setMaxaiConstantsForTest } from "../../open-sse/executors/maxai/constantsStore.ts";
+import { MAXAI_BASE_URL } from "../../open-sse/executors/maxai/protocol.ts";
 import { MOCK_CONSTANTS } from "./helpers/maxaiMockConstants.ts";
 
 // Image generation signs like any request; seed the in-process constants memo
@@ -28,7 +29,9 @@ const CRED = {
 // --- Registry ------------------------------------------------------------
 
 test("maxai is registered in IMAGE_PROVIDERS with the maxai-image format + 6 models", () => {
-  const entry = (IMAGE_PROVIDERS as Record<string, { format?: string; baseUrl?: string; models?: unknown[] }>)["maxai"];
+  const entry = (
+    IMAGE_PROVIDERS as Record<string, { format?: string; baseUrl?: string; models?: unknown[] }>
+  )["maxai"];
   assert.ok(entry, "maxai must exist in IMAGE_PROVIDERS");
   assert.equal(entry.format, "maxai-image");
   assert.match(String(entry.baseUrl), /api\.maxai\.me\/gpt\/get_image_generate_response/);
@@ -93,7 +96,10 @@ test("handleMaxaiImageGeneration returns OpenAI image data on success", async ()
       ok: true,
       status: 200,
       async json() {
-        return { status: "OK", data: [{ png_url: "https://cdn/x.png", webp_url: "https://cdn/x.webp" }] };
+        return {
+          status: "OK",
+          data: [{ png_url: "https://cdn/x.png", webp_url: "https://cdn/x.webp" }],
+        };
       },
       async text() {
         return "";
@@ -111,8 +117,12 @@ test("handleMaxaiImageGeneration returns OpenAI image data on success", async ()
 
   assert.equal(result.success, true);
   assert.deepEqual(result.data?.data, [{ url: "https://cdn/x.png" }]);
-  // Hit the image endpoint with the signed body.
-  assert.match(capturedUrl, new RegExp(MAXAI_IMAGE_PATH.replace(/\//g, "\\/")));
+  // Hit the image endpoint with the signed body. Exact URL equality instead of a
+  // hand-escaped RegExp over the path — the old `.replace(/\//g, "\\/")` escaped
+  // only slashes (which need no escaping in a RegExp anyway) and would have let
+  // any other metacharacter through (CodeQL js/incomplete-sanitization), while
+  // also accepting the path appearing anywhere in a wrong URL.
+  assert.equal(capturedUrl, MAXAI_BASE_URL + MAXAI_IMAGE_PATH);
   assert.equal(capturedBody.model_name, "flux-1-schnell");
   assert.equal(capturedBody.size, "512x512"); // flux passes size through
   assert.equal(capturedBody.n, 2);

--- a/tests/unit/maxai.test.ts
+++ b/tests/unit/maxai.test.ts
@@ -12,6 +12,7 @@ import {
   computeMaxaiProof,
   maxaiAesEncrypt,
   buildMaxaiSignedHeaders,
+  maxaiRandomSlot,
 } from "../../open-sse/executors/maxai/signing.ts";
 import {
   assembleMaxaiContext,
@@ -103,7 +104,13 @@ test("computeMaxaiProof blanks the user id only on /oauth/* routes", () => {
   // A blank-user route yields a different proof than the same route with a uid,
   // proving the uid is dropped for /oauth/* (and only there).
   const t = 1784594159681;
-  const oauthWithUid = computeMaxaiProof("/oauth/signin_with_email", t, USER_ID, HMAC_KEY, APP_VERSION);
+  const oauthWithUid = computeMaxaiProof(
+    "/oauth/signin_with_email",
+    t,
+    USER_ID,
+    HMAC_KEY,
+    APP_VERSION
+  );
   const oauthNoUid = computeMaxaiProof("/oauth/signin_with_email", t, "", HMAC_KEY, APP_VERSION);
   assert.equal(oauthWithUid, oauthNoUid); // uid ignored for /oauth/*
   const chatWithUid = computeMaxaiProof("/gpt/cwc/chat", t, USER_ID, HMAC_KEY, APP_VERSION);
@@ -306,7 +313,28 @@ test("buildMaxaiSignedHeaders emits the X-App/X-Browser companions + X-Authoriza
   assert.equal(h["X-App-Version"], MOCK_APP_VERSION);
   assert.equal(h["X-App-Env"], "MaxAI-Browser-Extension");
   assert.ok(h["X-Authorization"].length > 0);
-  assert.equal(Buffer.from(h["X-Authorization"], "base64").subarray(0, 8).toString("ascii"), "Salted__");
+  assert.equal(
+    Buffer.from(h["X-Authorization"], "base64").subarray(0, 8).toString("ascii"),
+    "Salted__"
+  );
+});
+
+test("maxaiRandomSlot emits an unbiased 6-digit X-Random slot", () => {
+  // The wire slot is always exactly 6 decimal digits, i.e. 100000-999999.
+  const samples = Array.from({ length: 4000 }, () => maxaiRandomSlot());
+  for (const s of samples) {
+    assert.match(s, /^\d{6}$/, `X-Random must be 6 digits, got: ${s}`);
+    const n = Number(s);
+    assert.ok(n >= 100000 && n <= 999999, `X-Random out of range: ${s}`);
+  }
+  // Regression guard for the modulo bias the previous
+  // `randomBytes(4).readUInt32BE(0) % 900000` draw introduced: the value must
+  // still spread across the whole range, not collapse onto its low end.
+  assert.ok(new Set(samples).size > samples.length * 0.9, "X-Random must not repeat heavily");
+  assert.ok(
+    samples.some((s) => Number(s) < 550000) && samples.some((s) => Number(s) >= 550000),
+    "X-Random must cover both halves of the 100000-999999 range"
+  );
 });
 
 // ── Context assembly ─────────────────────────────────────────────────────────
@@ -364,7 +392,12 @@ test("contentToText flattens multipart content, dropping non-text parts", () => 
 });
 
 test("buildMaxaiChatBody pins field order + constants", () => {
-  const body = buildMaxaiChatBody({ conversationId: "conv-1", text: "hi", modelName: "gpt-5.6", appVersion: APP_VERSION });
+  const body = buildMaxaiChatBody({
+    conversationId: "conv-1",
+    text: "hi",
+    modelName: "gpt-5.6",
+    appVersion: APP_VERSION,
+  });
   const keys = Object.keys(body);
   assert.equal(keys[0], "chat_mode");
   assert.equal(keys[3], "message_content");
@@ -379,7 +412,12 @@ test("buildMaxaiChatBody pins field order + constants", () => {
 // ── Vision input (image_url parts) ───────────────────────────────────────────
 
 test("buildMaxaiChatBody text-only path is unchanged (no imageUrls)", () => {
-  const body = buildMaxaiChatBody({ conversationId: "c", text: "hi", modelName: "gpt-5.6", appVersion: APP_VERSION });
+  const body = buildMaxaiChatBody({
+    conversationId: "c",
+    text: "hi",
+    modelName: "gpt-5.6",
+    appVersion: APP_VERSION,
+  });
   // Byte-identical to the pre-vision shape: a single text part.
   assert.deepEqual(body.message_content, [{ type: "text", text: "hi" }]);
   assert.deepEqual(body.doc_list, []);
@@ -563,8 +601,7 @@ test("maxaiRefreshAccessToken sends the exact web-app request + parses data.acce
 
 test("maxaiRefreshAccessToken returns a structured error on non-200 (no throw)", async () => {
   const nowSec = Math.floor(Date.now() / 1000);
-  const fakeFetch = (async () =>
-    new Response("nope", { status: 418 })) as unknown as typeof fetch;
+  const fakeFetch = (async () => new Response("nope", { status: 418 })) as unknown as typeof fetch;
   const result = await maxaiRefreshAccessToken({
     refreshToken: fakeJwt(nowSec + 1000, USER_ID),
     deviceId: "dev",
@@ -687,7 +724,9 @@ test("verifyMaxaiEmailCode maps code 10119 to an expired-code message", async ()
 
 test("verifyMaxaiEmailCode defaults to an invalid-code message otherwise", async () => {
   const fakeFetch = (async () =>
-    new Response(JSON.stringify({ data: { status: "FAIL" } }), { status: 200 })) as unknown as typeof fetch;
+    new Response(JSON.stringify({ data: { status: "FAIL" } }), {
+      status: 200,
+    })) as unknown as typeof fetch;
   const r = await verifyMaxaiEmailCode({
     email: "x@y.z",
     code: "999999",
@@ -1009,10 +1048,9 @@ test("discoverMaxaiModels drops deprecated, non-chat, and non-curated models", a
 
 test("discoverMaxaiModels falls back to the catalog window when max_tokens is absent", async () => {
   const fakeFetch = (async () =>
-    new Response(
-      modelsConfigBody([{ model_name: "claude-5-sonnet", type: "chat" }]),
-      { status: 200 }
-    )) as unknown as typeof fetch;
+    new Response(modelsConfigBody([{ model_name: "claude-5-sonnet", type: "chat" }]), {
+      status: 200,
+    })) as unknown as typeof fetch;
   const { models } = await discoverMaxaiModels({
     providerSpecificData: DISCOVERY_CRED.providerSpecificData,
     accessToken: DISCOVERY_CRED.accessToken,

--- a/tests/unit/uc-image.test.ts
+++ b/tests/unit/uc-image.test.ts
@@ -9,6 +9,7 @@ import {
   UC_DIRECT_IMAGE_URL,
 } from "../../open-sse/handlers/imageGeneration/providers/ucImage.ts";
 import { IMAGE_PROVIDERS, parseImageModel } from "../../open-sse/config/imageRegistry.ts";
+import { isUcClerkMintUrl } from "./helpers/ucClerkUrl.ts";
 
 // A valid PERSONA credential (durable Clerk cookie + sid + uid in psd). No API
 // key, so the handler takes the persona web path (mint -> POST -> poll).
@@ -144,7 +145,7 @@ function personaFetch(opts: {
   let pollsSeen = 0;
   return (async (url: string, init: RequestInit = {}) => {
     // 1) Clerk mint
-    if (url.includes("clerk.uncensored.com")) {
+    if (isUcClerkMintUrl(url)) {
       return {
         ok: true,
         status: 200,
@@ -265,7 +266,7 @@ test("handleUcImageGeneration (persona) times out with 504 when the result never
 
 test("handleUcImageGeneration (persona) surfaces a Clerk mint failure", async () => {
   const fetchImpl = (async (url: string) => {
-    if (url.includes("clerk.uncensored.com")) {
+    if (isUcClerkMintUrl(url)) {
       return {
         ok: false,
         status: 401,

--- a/tests/unit/uc-video.test.ts
+++ b/tests/unit/uc-video.test.ts
@@ -13,6 +13,7 @@ import {
   UC_DIRECT_VIDEO_URL,
 } from "../../open-sse/handlers/videoGeneration/providers/ucVideo.ts";
 import { VIDEO_PROVIDERS } from "../../open-sse/config/videoRegistry.ts";
+import { isUcClerkMintUrl } from "./helpers/ucClerkUrl.ts";
 
 // A valid PERSONA credential (durable Clerk cookie + sid + uid in psd). No API
 // key, so the handler takes the persona web path (mint -> generate -> poll).
@@ -148,7 +149,7 @@ function personaFetch(opts: {
   let pollsSeen = 0;
   return (async (url: string, init: RequestInit = {}) => {
     // Clerk mint
-    if (url.includes("clerk.uncensored.com")) {
+    if (isUcClerkMintUrl(url)) {
       return {
         ok: true,
         status: 200,
@@ -339,7 +340,7 @@ test("handleUcVideoGeneration (persona) times out with 504 when never ready", as
 
 test("handleUcVideoGeneration (persona) surfaces a Clerk mint failure", async () => {
   const fetchImpl = (async (url: string) => {
-    if (url.includes("clerk.uncensored.com")) {
+    if (isUcClerkMintUrl(url)) {
       return {
         ok: false,
         status: 401,


### PR DESCRIPTION
## Contexto

O gate **`codeql-ratchet`** está em **REGRESSÃO** e reprova **toda PR aberta** do repositório:

```
[codeql-ratchet] Alertas CodeQL abertos (não-dismissed): 13
[codeql-ratchet] REGRESSÃO — 13 alertas CodeQL abertos > baseline 11
```

Os 13 alertas **não vieram do trabalho que eles estão bloqueando** — chegaram com merges recentes de provider/mídia de outros autores:

| Commit | PR | Alertas |
|---|---|---|
| `cabbbe41` `feat(providers): add MaxAI — signed OpenAI-compatible provider …` | #11461 | 5 |
| `530096a3` `feat(providers): add UC (uncensored.com) — persona + direct` | #11513 | 4 (2 preservados por `752aac65` / #12423) |
| `3a564183` `fix(sse): name the shadowed custom provider node …` | #12365 | 1 |
| `84504e3f` `chore(providers): retire Felo Web on provenance hold` | #11698 | 1 |

Esta PR corrige em código os **7 alertas que são defeito real** e documenta os **6 restantes** para dispensa do operador com justificativa (**Hard Rule #14** — nenhum alerta foi dispensado via API por esta sessão).

Projeção: **13 → 6 alertas abertos**, abaixo do baseline 11. O rebaseline (`--update`) fica a cargo do operador, depois que a contagem assentar.

## Triagem completa — 13 alertas

| # | Regra | Arquivo:linha | Veredito | Justificativa |
|---|---|---|---|---|
| 975 | `js/biased-cryptographic-random` | `open-sse/executors/maxai/signing.ts:128` | **corrigido** | `randomBytes(4).readUInt32BE(0) % 900000` enviesa o slot `X-Random` (2^32 não divide 900000). Trocado por `crypto.randomInt(100000, 1000000)`, que faz rejection sampling internamente. Forma na rede idêntica: sempre 6 dígitos. |
| 971 | `js/incomplete-sanitization` | `tests/unit/maxai-image.test.ts:115` | **corrigido** | `new RegExp(MAXAI_IMAGE_PATH.replace(/\//g, "\\/"))` escapava só `/` (que nem precisa de escape em RegExp) e aceitava o path em qualquer posição de uma URL errada. Trocado por igualdade exata `assert.equal(capturedUrl, MAXAI_BASE_URL + MAXAI_IMAGE_PATH)`. |
| 980 | `js/incomplete-sanitization` | `tests/unit/custom-provider-prefix-shadowing-11943.test.ts:100` | **corrigido** | RegExp montada com `NAME.replace(/[()]/g, "\\$&")` — só parênteses escapados; qualquer outro metacaractere num nome futuro seria interpretado em vez de casado literalmente. Trocado por `message.includes(...)` com a string exata. |
| 976 | `js/incomplete-url-substring-sanitization` | `tests/unit/uc-image.test.ts:147` | **corrigido** | O router do `fetch` mockado despachava por `url.includes("clerk.uncensored.com")` — qualquer host que apenas contivesse o nome (ex.: `https://evil.example/?next=clerk.uncensored.com`) recebia a resposta do mint, ou seja, o teste **não conseguia falhar** se o executor montasse a URL errada. Trocado pelo helper novo `isUcClerkMintUrl()`: `new URL(url).origin === UC_CLERK_FAPI` + shape do path `/v1/client/sessions/{sid}/tokens`. |
| 977 | `js/incomplete-url-substring-sanitization` | `tests/unit/uc-image.test.ts:268` | **corrigido** | idem #976 |
| 978 | `js/incomplete-url-substring-sanitization` | `tests/unit/uc-video.test.ts:151` | **corrigido** | idem #976 |
| 979 | `js/incomplete-url-substring-sanitization` | `tests/unit/uc-video.test.ts:342` | **corrigido** | idem #976 |
| 973 | `js/weak-cryptographic-algorithm` | `open-sse/executors/maxai/signing.ts:43` | **exigência do protocolo** | HMAC-SHA1 é o MAC que o servidor da MaxAI verifica (`sha1 = HMAC_SHA1(sign_str, key=reqTime:hmacKey)`). Trocar o algoritmo invalida toda assinatura e derruba o provider. HMAC-SHA1 também não é afetado pelos ataques de colisão contra SHA-1. |
| 972 | `js/weak-cryptographic-algorithm` | `open-sse/executors/maxai/constants.ts:279` | **exigência do protocolo** | `reproduceProof()` é a reimplementação pura do **mesmo** cálculo (HMAC-SHA1 + SM3), usada para validar constantes extraídas. Mesma justificativa de #973. |
| 974 | `js/weak-cryptographic-algorithm` | `tests/unit/helpers/maxaiMockConstants.ts:52` | **exigência do protocolo** | `referenceProof()` é a implementação de referência **independente** do proof (deliberadamente não importada da produção) para provar que a matemática bate com a spec externa. Arquivo de teste, chaves MOCK, nenhum segredo real. |
| 969 | `js/insufficient-password-hash` | `open-sse/executors/maxai/signing.ts:43` | **falso positivo** | O CodeQL classifica o `hmacKey` como "password" e o HMAC como hash de senha. Não é: é a chave de um MAC de assinatura de requisição. Nada é armazenado nem comparado como hash de senha, e o `hmacKey` é uma constante **pública** que o próprio bundle JS da MaxAI publica (ver cabeçalho de `signing.ts`). Um KDF com custo (bcrypt/scrypt/argon2) é semanticamente inaplicável aqui e quebraria o protocolo. |
| 970 | `js/insufficient-password-hash` | `open-sse/executors/maxai/signing.ts:61` | **exigência do protocolo** | `evpBytesToKey()` é o `EVP_BytesToKey(MD5)` do OpenSSL — exatamente a derivação que `CryptoJS.AES.encrypt(text, passphrase)` usa. É obrigatória para produzir um envelope `Salted__` que a MaxAI consiga decifrar. A "passphrase" é o `aesKey` público extraído do bundle, não uma senha de usuário. |
| 984 | `js/stack-trace-exposure` | `open-sse/utils/error.ts:749` | **falso positivo** | Precedente documentado (**Hard Rule #14** + `docs/security/ERROR_SANITIZATION.md`): o CodeQL não reconhece sanitizadores customizados. A linha é `JSON.stringify({ error: { message: sanitizeErrorMessage(message), … } })` e a única entrada tainted passa por `sanitizeErrorMessage()` (`open-sse/utils/error.ts:64`), que corta a string no primeiro `\n` (descartando os frames `at …`), substitui paths absolutos por `<path>`, trunca em `MAX_ERROR_LEN` e roda `redactSensitiveErrorText()`. |

**Resumo:** 7 corrigidos · 2 falsos positivos (#969, #984) · 4 exigências de protocolo (#970, #972, #973, #974).

## Precisa de ação do operador

Os 6 alertas abaixo **não** foram dispensados por esta sessão (Hard Rule #14 reserva o dismissal ao operador). Sugestão de motivo para cada um:

| # | Regra | Motivo sugerido |
|---|---|---|
| 969 | `js/insufficient-password-hash` | `false positive` — chave de MAC de assinatura de requisição (constante pública do bundle MaxAI), não hash de senha. |
| 970 | `js/insufficient-password-hash` | `won't fix` — `EVP_BytesToKey(MD5)` exigido pelo formato `Salted__` do CryptoJS que a MaxAI decifra. |
| 972 | `js/weak-cryptographic-algorithm` | `won't fix` — HMAC-SHA1 + SM3 é o esquema de assinatura da MaxAI; mudar quebra o provider. |
| 973 | `js/weak-cryptographic-algorithm` | `won't fix` — idem #972 (caminho de produção). |
| 974 | `js/weak-cryptographic-algorithm` | `used in tests` — implementação de referência do proof, com chaves MOCK. |
| 984 | `js/stack-trace-exposure` | `false positive` — já sanitizado por `sanitizeErrorMessage()`; ver `docs/security/ERROR_SANITIZATION.md`. |

Depois que a contagem assentar, o rebaseline é `node scripts/check/check-codeql-ratchet.mjs --update` (não rodei — é decisão do operador).

## Mudanças

| Arquivo | O quê |
|---|---|
| `open-sse/executors/maxai/signing.ts` | **única mudança de produção** — `maxaiRandomSlot()` sobre `crypto.randomInt` |
| `tests/unit/helpers/ucClerkUrl.ts` | **novo** — `isUcClerkMintUrl()`, recognizer estrito do mint do Clerk |
| `tests/unit/uc-image.test.ts`, `tests/unit/uc-video.test.ts` | router do mock com match estrito de origin + path |
| `tests/unit/maxai-image.test.ts` | igualdade exata de URL no lugar da RegExp semi-escapada |
| `tests/unit/custom-provider-prefix-shadowing-11943.test.ts` | substring exata no lugar da RegExp semi-escapada |
| `tests/unit/maxai.test.ts` | teste novo: `maxaiRandomSlot emits an unbiased 6-digit X-Random slot` |

**Nenhuma asserção existente foi enfraquecida** — todas as trocas em teste são estritamente mais restritivas do que o que estava lá. O `prettier` do `lint-staged` reformatou algumas linhas pré-existentes de `signing.ts` / `maxai.test.ts` / `maxai-image.test.ts` (esses arquivos entraram no repo não formatados); é ruído de formatação, não mudança de comportamento.

## Verificação (foreground)

| Comando | Exit | Resultado |
|---|---|---|
| `npm run typecheck:core` | 0 | limpo |
| `node --import tsx/esm --test tests/unit/maxai.test.ts tests/unit/maxai-image.test.ts tests/unit/uc-image.test.ts tests/unit/uc-video.test.ts tests/unit/custom-provider-prefix-shadowing-11943.test.ts` | 0 | `tests 99 · pass 99 · fail 0` |
| `node --import tsx/esm --test tests/unit/maxai-documents.test.ts` | 0 | `tests 14 · pass 14 · fail 0` |
| `npx eslint <7 arquivos alterados>` | 0 | 0 problemas |

Base `release/v3.8.51` verificada verde na abertura (sem issue `Release branch not green` aberta) e sem `release-freeze` ativo.
