### PR TITLE
docs: add Claude-Codex handoff protocol

### DIFF
--- a/.agent-handoffs/claude-review.md
+++ b/.agent-handoffs/claude-review.md
@@ -1,0 +1,25 @@
+# Revisão independente do Claude Code
+
+## Commit revisado
+
+`PREENCHER_COM_SHA`
+
+## Escopo verificado
+
+## Achados
+
+Registre cada achado com prioridade, arquivo/linha, evidência, impacto e correção sugerida.
+
+## Testes independentes
+
+| Comando | Resultado | Observações |
+| --- | --- | --- |
+|  |  |  |
+
+## Veredito
+
+- [ ] Aprovado
+- [ ] Aprovado com observações
+- [ ] Requer correções
+
+## Limitações da revisão

--- a/.agent-handoffs/codex-implementation.md
+++ b/.agent-handoffs/codex-implementation.md
@@ -1,0 +1,25 @@
+# Implementação do Codex
+
+## Objetivo recebido
+
+## Commit implementado
+
+`PREENCHER_COM_SHA`
+
+## Arquivos alterados
+
+## Decisões técnicas
+
+## Testes executados
+
+| Comando | Resultado | Observações |
+| --- | --- | --- |
+|  |  |  |
+
+## Riscos e limitações
+
+## Instruções para a revisão independente
+
+- Revisar exatamente o SHA informado.
+- Comparar com `origin/release/v3.8.51`.
+- Não modificar a branch do implementador durante a revisão.

--- a/.agent-handoffs/final-verification.md
+++ b/.agent-handoffs/final-verification.md
@@ -1,0 +1,24 @@
+# Verificação final
+
+## Commit final verificado
+
+`PREENCHER_COM_SHA`
+
+## Achados do Claude incorporados
+
+## Achados rejeitados e justificativas
+
+## Testes finais
+
+| Comando | Resultado | Observações |
+| --- | --- | --- |
+|  |  |  |
+
+## Pendências conhecidas
+
+## Aprovação
+
+- [ ] Implementação conferida pelo Codex
+- [ ] Revisão independente concluída pelo Claude Code
+- [ ] Verificação final concluída
+- [ ] Operador autorizou push/PR/merge

--- a/.agent-handoffs/task.md
+++ b/.agent-handoffs/task.md
@@ -12,11 +12,9 @@ Estabelecer um protocolo auditável para que o Codex implemente mudanças e o Cl
 - Branch desta tarefa: `chore/claude-codex-handoff`
 - Worktree: `.claude/worktrees/claude-codex-handoff`
 
-## Estado herdado da base
+## Estado da base
 
-⚠️ base-red inherited: #12335
-
-Não corrigir falhas herdadas da base nesta branch documental.
+A checagem autenticada anterior ao push não encontrou `release-freeze` nem issue `base-red` aberta para `release/v3.8.51`. A issue histórica `#12335` está encerrada desde 2 de setembro de 2026 às 00:59:31 UTC.
 
 ## Responsabilidades
 

--- a/.agent-handoffs/task.md
+++ b/.agent-handoffs/task.md
@@ -1,0 +1,35 @@
+# Tarefa compartilhada: Claude Code + Codex
+
+## Objetivo
+
+Estabelecer um protocolo auditável para que o Codex implemente mudanças e o Claude Code faça uma revisão independente em worktree próprio.
+
+## Base confirmada pelo operador
+
+- Repositório: `diegosouzapw/OmniRoute`
+- Branch-base: `release/v3.8.51`
+- Base usada no worktree: `e243b04de22da2d78900c27fde5f83f4fbc3d7f9`
+- Branch desta tarefa: `chore/claude-codex-handoff`
+- Worktree: `.claude/worktrees/claude-codex-handoff`
+
+## Estado herdado da base
+
+⚠️ base-red inherited: #12335
+
+Não corrigir falhas herdadas da base nesta branch documental.
+
+## Responsabilidades
+
+1. Codex implementa no worktree dedicado da tarefa e registra commit, testes, decisões e riscos em `codex-implementation.md`.
+2. Claude Code revisa o commit indicado sem reutilizar as conclusões do implementador e registra achados em `claude-review.md`.
+3. Codex avalia os achados aceitos, aplica correções e documenta os testes finais em `final-verification.md`.
+4. O operador decide sobre push, PR e merge.
+
+## Regras
+
+- Nunca usar `git stash` ou `git stash pop`.
+- Nunca alterar worktrees ou branches pertencentes a outras sessões.
+- Nunca registrar segredos, tokens, cookies, `.env`, bancos locais ou dados pessoais.
+- Trocar trabalho por commits/SHA; não depender de mudanças soltas.
+- Não atribuir autoria de commits ou PRs a agentes de IA.
+- Não fazer push, merge, rebase ou force-push sem a autorização e autenticação correspondentes.


### PR DESCRIPTION
## Summary

- add a versioned task handoff template
- add implementation, independent review, and final verification records
- document branch/worktree isolation and cross-session safety expectations

## Validation

- `git diff origin/release/v3.8.51..HEAD --check`
- documentation-only change; no runtime tests required

## Base status

Authenticated pre-push checks found no open `release-freeze` or `base-red` issue for `release/v3.8.51`. Historical issue #12335 is closed.