### PR TITLE
fix(cli): support dashboard API key ids

### DIFF
--- a/bin/cli/commands/keys.mjs
+++ b/bin/cli/commands/keys.mjs
@@ -352,10 +352,24 @@ export async function runKeysRegenerateCommand(id, opts = {}) {
     return 1;
   }
   try {
-    const res = await apiFetch(`/api/v1/registered-keys/${encodeURIComponent(id)}/regenerate`, {
+    const encodedId = encodeURIComponent(id);
+    let res = await apiFetch(`/api/v1/registered-keys/${encodedId}/regenerate`, {
       method: "POST",
       retry: false,
+      acceptNotOk: true,
     });
+    // `keys` predates the split between registered keys and the dashboard's
+    // ordinary API keys. IDs shown by `keys list`/the dashboard belong to
+    // `/api/keys`, while deployment/registered-key IDs belong to
+    // `/api/v1/registered-keys`. Try the ordinary-key route when the ID is not
+    // present in the registered-key store so the command works with either ID.
+    if (isRouteUnavailableStatus(res.status)) {
+      res = await apiFetch(`/api/keys/${encodedId}/regenerate`, {
+        method: "POST",
+        retry: false,
+        acceptNotOk: true,
+      });
+    }
     if (!res.ok) {
       console.error(t("common.error", { message: `HTTP ${res.status}` }));
       return 1;
@@ -410,9 +424,17 @@ export async function runKeysRevealCommand(id, opts = {}) {
     return 1;
   }
   try {
-    const res = await apiFetch(`/api/v1/registered-keys/${encodeURIComponent(id)}/reveal`, {
+    const encodedId = encodeURIComponent(id);
+    let res = await apiFetch(`/api/v1/registered-keys/${encodedId}/reveal`, {
       retry: false,
+      acceptNotOk: true,
     });
+    if (isRouteUnavailableStatus(res.status)) {
+      res = await apiFetch(`/api/keys/${encodedId}/reveal`, {
+        retry: false,
+        acceptNotOk: true,
+      });
+    }
     if (!res.ok) {
       console.error(t("common.error", { message: `HTTP ${res.status}` }));
       return 1;

--- a/tests/unit/cli-keys-api-key-fallback.test.ts
+++ b/tests/unit/cli-keys-api-key-fallback.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE_URL = process.env.OMNIROUTE_BASE_URL;
+
+async function withFetchMock(
+  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
+  run: () => Promise<void>,
+) {
+  process.env.OMNIROUTE_BASE_URL = "http://127.0.0.1:20128";
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) =>
+    handler(new URL(String(input)), init)) as typeof fetch;
+
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_BASE_URL === undefined) delete process.env.OMNIROUTE_BASE_URL;
+    else process.env.OMNIROUTE_BASE_URL = ORIGINAL_BASE_URL;
+  }
+}
+
+test("keys regenerate falls back from registered keys to ordinary API keys", async () => {
+  const calls: Array<{ method: string; pathname: string }> = [];
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  await withFetchMock(async (url, init) => {
+    calls.push({ method: init?.method ?? "GET", pathname: url.pathname });
+    if (url.pathname === "/api/health") return Response.json({ status: "ok" });
+    if (url.pathname.includes("/api/v1/registered-keys/")) {
+      return Response.json({ error: "Key not found" }, { status: 404 });
+    }
+    return Response.json({ key: "sk-test-regenerated-key" });
+  }, async () => {
+    console.log = (message?: unknown) => logs.push(String(message));
+    const { runKeysRegenerateCommand } = await import("../../bin/cli/commands/keys.mjs");
+    assert.equal(await runKeysRegenerateCommand("ordinary-key-id", { yes: true }), 0);
+  });
+
+  console.log = originalLog;
+  assert.deepEqual(calls.map((call) => call.pathname), [
+    "/api/health",
+    "/api/v1/registered-keys/ordinary-key-id/regenerate",
+    "/api/keys/ordinary-key-id/regenerate",
+  ]);
+  assert.match(logs.join("\n"), /sk-test-regenerated-key/);
+});
+
+test("keys reveal falls back from registered keys to ordinary API keys", async () => {
+  const paths: string[] = [];
+  const logs: string[] = [];
+  const originalLog = console.log;
+  const originalWrite = process.stderr.write;
+
+  await withFetchMock(async (url) => {
+    paths.push(url.pathname);
+    if (url.pathname === "/api/health") return Response.json({ status: "ok" });
+    if (url.pathname.includes("/api/v1/registered-keys/")) {
+      return Response.json({ error: "Key not found" }, { status: 404 });
+    }
+    return Response.json({ key: "sk-test-revealed-key" });
+  }, async () => {
+    console.log = (message?: unknown) => logs.push(String(message));
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    const { runKeysRevealCommand } = await import("../../bin/cli/commands/keys.mjs");
+    assert.equal(await runKeysRevealCommand("ordinary-key-id"), 0);
+  });
+
+  console.log = originalLog;
+  process.stderr.write = originalWrite;
+  assert.deepEqual(paths, [
+    "/api/health",
+    "/api/v1/registered-keys/ordinary-key-id/reveal",
+    "/api/keys/ordinary-key-id/reveal",
+  ]);
+  assert.deepEqual(logs, ["sk-test-revealed-key"]);
+});


### PR DESCRIPTION
## Summary
- fall back from registered-key endpoints to ordinary dashboard API-key endpoints for regenerate and reveal
- preserve registered-key behavior when those IDs exist
- add regression coverage for both fallback paths

## Validation
- node --import tsx/esm --test tests/unit/cli-keys-api-key-fallback.test.ts
- node --import tsx/esm --test tests/unit/cli-keys-command.test.ts tests/unit/cli-route-unavailable-fallback-10081.test.ts
- live local validation: regenerated a dashboard API key and authenticated /v1/models with HTTP 200