### PR TITLE
fix(rerank): clamp Voyage top_k and honor NVIDIA return_documents

### DIFF
--- a/changelog.d/fixes/12523-rerank-topk-and-return-documents.md
+++ b/changelog.d/fixes/12523-rerank-topk-and-return-documents.md
@@ -1,0 +1,1 @@
+- **fix(rerank):** clamp Voyage `top_k` to the documents actually sent after empty-string filtering, and honor `return_documents: false` in the NVIDIA response adapter (#12523 — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-rerank-topk-and-return-documents.md
+++ b/changelog.d/fixes/PENDING-rerank-topk-and-return-documents.md
@@ -1,0 +1,1 @@
+- **fix(rerank):** clamp Voyage `top_k` to the documents actually sent after empty-string filtering, and honor `return_documents: false` in the NVIDIA response adapter (#PENDING — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-rerank-topk-and-return-documents.md
+++ b/changelog.d/fixes/PENDING-rerank-topk-and-return-documents.md
@@ -1,1 +1,0 @@
-- **fix(rerank):** clamp Voyage `top_k` to the documents actually sent after empty-string filtering, and honor `return_documents: false` in the NVIDIA response adapter (#PENDING — thanks @pacocartones)

--- a/open-sse/handlers/rerank.ts
+++ b/open-sse/handlers/rerank.ts
@@ -73,6 +73,10 @@ function buildAuthHeader(providerConfig, token) {
   // strings (whitespace-only documents are accepted and ranked upstream). We
   // filter out exact empty strings and track original indices implicitly via the
   // response adapter, which reconstructs the map from options.documents (#7809).
+  // `top_k` is clamped to the number of documents actually sent: the handler
+  // defaults `top_n` to the caller's *unfiltered* document count, so dropping an
+  // empty string would otherwise ask Voyage to rank more documents than it got,
+  // and Voyage rejects `top_k > documents.length` with HTTP 400.
   // `return_documents` is always forced off upstream: Voyage echoes documents as
   // plain strings (not Cohere's {text}), so we never rely on the echo — document
   // text is always synthesized locally from the caller's originals (#7811).
@@ -84,7 +88,7 @@ function buildAuthHeader(providerConfig, token) {
       model: body.model,
       query: body.query,
       documents: docTexts,
-      top_k: body.top_n || docTexts.length,
+      top_k: Math.min(body.top_n || docTexts.length, docTexts.length),
       return_documents: false,
     };
   }
@@ -101,12 +105,13 @@ function buildAuthHeader(providerConfig, token) {
   options: RerankResponseOptions = {}
 ) {
   if (providerConfig.format === "nvidia") {
+    const returnDocuments = options.return_documents !== false;
     return {
       id: data.id != null ? String(data.id) : `rerank-${Date.now()}`,
       results: (data.rankings || []).map((r) => ({
         index: r.index,
         relevance_score: r.logit || r.score || 0,
-        document: { text: r.text || "" },
+        ...(returnDocuments ? { document: { text: r.text || "" } } : {}),
       })),
       meta: {
         api_version: { version: "2" },

--- a/tests/unit/rerank-providers-5332.test.ts
+++ b/tests/unit/rerank-providers-5332.test.ts
@@ -69,3 +69,37 @@ test("#5332 deepinfra response omits document text when return_documents=false",
   assert.equal(out.results[0].document, undefined);
   assert.equal(out.results[0].index, 1);
 });
+
+// ─── NVIDIA must honor return_documents like its deepinfra/voyage siblings ──
+
+test("#5332 nvidia response omits document text when return_documents=false", () => {
+  const cfg = getRerankProvider("nvidia");
+  const out = transformResponseFromProvider(
+    cfg,
+    { id: "r1", rankings: [{ index: 0, logit: 0.8, text: "a" }] },
+    { documents: ["a"], return_documents: false }
+  );
+  assert.equal(out.results[0].document, undefined);
+  assert.equal(out.results[0].index, 0);
+  assert.equal(out.results[0].relevance_score, 0.8);
+});
+
+test("#5332 nvidia response includes document text when return_documents is true", () => {
+  const cfg = getRerankProvider("nvidia");
+  const out = transformResponseFromProvider(
+    cfg,
+    { id: "r1", rankings: [{ index: 1, logit: 0.4, text: "b" }] },
+    { documents: ["a", "b"], return_documents: true }
+  );
+  assert.equal(out.results[0].document.text, "b");
+});
+
+test("#5332 nvidia response includes document text when return_documents is omitted", () => {
+  const cfg = getRerankProvider("nvidia");
+  const out = transformResponseFromProvider(
+    cfg,
+    { id: "r1", rankings: [{ index: 0, logit: 0.9, text: "a" }] },
+    { documents: ["a"] }
+  );
+  assert.equal(out.results[0].document.text, "a");
+});

--- a/tests/unit/rerank-voyage-7809.test.ts
+++ b/tests/unit/rerank-voyage-7809.test.ts
@@ -223,3 +223,47 @@ test("#7809 voyage response adapter handles empty data array", () => {
   const out = transformResponseFromProvider(cfg, { data: [] }, { documents: ["a", "b"] });
   assert.deepEqual(out.results, []);
 });
+
+// ─── top_k must never exceed the surviving document count ──────────────────
+// The handler normalizes `top_n: top_n || documents.length` BEFORE the adapter
+// runs, so a caller that omits top_n and sends an exact empty string yields
+// top_k > documents.length — which Voyage rejects with HTTP 400.
+
+test("#7809 voyage request adapter clamps top_k to the surviving document count", () => {
+  const cfg = getRerankProvider("voyage-ai");
+  const out = transformRequestForProvider(cfg, {
+    model: "rerank-2.5-lite",
+    query: "teste",
+    documents: ["a", "", "b"],
+    // Mirrors the handler's `top_n: top_n || documents.length` when the caller omits top_n.
+    top_n: 3,
+    return_documents: true,
+  });
+  assert.deepEqual(out.documents, ["a", "b"]);
+  assert.equal(out.top_k, 2, "top_k must not exceed the number of documents actually sent");
+});
+
+test("#7809 voyage request adapter clamps an explicit oversized top_n", () => {
+  const cfg = getRerankProvider("voyage-ai");
+  const out = transformRequestForProvider(cfg, {
+    model: "rerank-2.5-lite",
+    query: "teste",
+    documents: ["a", "", "", "b"],
+    top_n: 10,
+    return_documents: true,
+  });
+  assert.deepEqual(out.documents, ["a", "b"]);
+  assert.equal(out.top_k, 2);
+});
+
+test("#7809 voyage request adapter keeps a legitimate top_n below the document count", () => {
+  const cfg = getRerankProvider("voyage-ai");
+  const out = transformRequestForProvider(cfg, {
+    model: "rerank-2.5-lite",
+    query: "teste",
+    documents: ["a", "b", "c"],
+    top_n: 2,
+    return_documents: true,
+  });
+  assert.equal(out.top_k, 2);
+});


### PR DESCRIPTION
## Summary

- Two rerank adapter defects in `open-sse/handlers/rerank.ts`, both on the current `release/v3.8.51` base:
  - **Voyage `top_k` exceeds the documents sent.** `handleRerank` normalizes `top_n: top_n || documents.length` from the caller's *unfiltered* array (`rerank.ts:237`) before the request adapter runs; the Voyage adapter then drops exact empty strings (`rerank.ts:80-82`) but still emits `top_k: body.top_n || docTexts.length` (`rerank.ts:87`), i.e. the unfiltered count. `POST /v1/rerank` with `documents: ["a", "", "b"]` and no `top_n` sends 2 documents with `top_k: 3`; Voyage rejects `top_k > documents.length` with HTTP 400 and the caller sees a gateway failure for a request that is valid under the Cohere-style contract this endpoint exposes. The same happens for an explicit `top_n` larger than the surviving count.
  - **NVIDIA ignores `return_documents: false`.** The NVIDIA response adapter always emits `document: { text }` (`rerank.ts:109`), while its deepinfra (`rerank.ts:121,128`) and voyage (`rerank.ts:147,163`) siblings gate the field on `options.return_documents !== false`, and the handler already passes `return_documents` into the adapter for every provider. Callers that opt out of document echo still get the full text back on NVIDIA.
- After: the Voyage request adapter clamps `top_k` to `Math.min(body.top_n || docTexts.length, docTexts.length)`, so a legitimate `top_n` below the count is untouched and only the impossible case is corrected; the NVIDIA response adapter gates `document` exactly like deepinfra and voyage. Default behavior (`return_documents` omitted or `true`) is unchanged.
- Out of scope: the `top_n || documents.length` default in the handler (it is correct for every other provider, which does not drop documents), Voyage's handling of whitespace-only documents (accepted and ranked upstream, see #7809), and any change to `index` remapping or score ordering.

## Related Issues

- Closes: none. No open issue tracks either defect (open issues searched for `rerank`, `voyage top_k`, `return_documents`).
- Related to #7809, #7811 (Voyage adapter: empty-string filtering and `top_k` mapping), #5332 (NVIDIA/deepinfra adapters and the `return_documents` gate on deepinfra)

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider (rerank request/response adapters in `open-sse/handlers/rerank.ts`)
- [x] Focused tests and category gates from the golden path: `tests/unit/rerank-*.test.ts` 46/46 (12 files, 3 suites); `npm run check:provider-consistency` OK; `npm run check:provider-assets` OK; `node scripts/check/check-complexity-ratchets.mjs --base-ref origin/release/v3.8.51` OK (new-code violations 0/0); `npm run check:changelog-integrity` OK; `npm run typecheck:core` exit 0; `eslint` on the three touched files exit 0
- [ ] `npm run lint`
- [x] Reconciled with the current active release base `release/v3.8.51` (rebased onto `86e83d413`, no conflicts); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Red/green: with the base `rerank.ts` swapped in, the two touched test files report 25 pass / 3 fail — exactly the three new cases that encode the defects (`nvidia … return_documents=false`, `voyage … clamps top_k to the surviving document count`, `voyage … clamps an explicit oversized top_n`). With the change, 28/28.

## Tests Added Or Updated

- `tests/unit/rerank-voyage-7809.test.ts` (+3 cases): `top_k` clamped to the surviving count when `top_n` mirrors the handler's unfiltered default (`["a", "", "b"]`, `top_n: 3` → `documents: ["a", "b"]`, `top_k: 2`); an explicit oversized `top_n: 10` with two empty strings is clamped to 2; a legitimate `top_n: 2` over three non-empty documents stays 2.
- `tests/unit/rerank-providers-5332.test.ts` (+3 cases): NVIDIA omits `document` when `return_documents: false` while keeping `index` and `relevance_score`; includes `document.text` when `return_documents: true`; includes it when `return_documents` is omitted (default preserved).
- `changelog.d/fixes/PENDING-rerank-topk-and-return-documents.md`: changelog fragment; the `PENDING` prefix will be replaced with this PR's number.

## Coverage Notes

- `open-sse/handlers/rerank.ts`: the Voyage `top_k` expression is exercised by the three new `transformRequestForProvider` cases (clamped, clamped from explicit oversized, not clamped); the NVIDIA `returnDocuments` branch is exercised in both directions plus the omitted-option default by the three new `transformResponseFromProvider` cases. Existing cases in both files (empty-string filtering, index remapping, sorting, `top_n` honoring, deepinfra gate) are unchanged and green.
- No touched file lost coverage; the change adds one branch per adapter and both branches of each are covered.

## Reviewer Notes

- Both changes are confined to the two provider-specific adapters; no shared handler path, endpoint, registry, or other provider changes.
- The clamp uses `Math.min` on the already-computed value rather than moving the `top_n` default into the adapter, so the handler's normalization (and the `top_n` logged in `saveCallLog`) is untouched; only the value sent to Voyage changes.
- The NVIDIA gate follows the sibling adapters verbatim (`options.return_documents !== false`), so a missing option keeps today's behavior of returning the text.
- No live call against Voyage or NVIDIA was made for this PR; the 400 is documented Voyage behavior for `top_k > len(documents)` and the tests assert the request payload shape rather than the provider response.
