### PR TITLE
feat(video): redact raw client-snapshot transcript fields in the detailed log (#12150 P2)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -360,7 +360,7 @@ import { deleteSessionAccountAffinity } from "@/lib/db/sessionAccountAffinity";
 import { getCacheControlSettings } from "@/lib/cacheControlSettings";
 import { guardrailRegistry } from "@/lib/guardrails";
 import type { VideoBridgeLogRedactionEntry } from "@/lib/guardrails/videoBridge";
-import { redactVideoTranscriptFieldsForLog } from "@/lib/guardrails/videoBridgeSnapshotRedaction";
+import { logClientRawRequestRedacted } from "@/lib/guardrails/videoBridgeSnapshotRedaction";
 import {
   shouldPreserveCacheControl,
   resolveConnectionCacheOverride,
@@ -1212,22 +1212,9 @@ export async function handleChatCore({
   });
   const pendingScope = { id: pendingRequestId, model, provider, connectionId: pendingConnId };
   const providerRequestCapture = createPreparedRequestLogger(reqLogger, pendingScope);
-  // 0. Log client raw request (before format conversion)
-  if (clientRawRequest) {
-    reqLogger.logClientRawRequest(
-      clientRawRequest.endpoint,
-      // #12150 P2 surface 1 (the dominant transcript-retention leak): this snapshot is
-      // captured BEFORE the guardrail chain runs, so it still carries the client's raw
-      // video transcript cue text untouched by the video-bridge guardrail's own
-      // description redaction. Redact it in this LOGGED copy only when the guardrail
-      // observed a video part on this request — clientRawRequest.body itself is never
-      // mutated and keeps flowing to every other consumer unchanged.
-      videoBridgeObserved
-        ? redactVideoTranscriptFieldsForLog(clientRawRequest.body)
-        : clientRawRequest.body,
-      clientRawRequest.headers
-    );
-  }
+  // 0. Log client raw request (before format conversion) — redacts video transcript
+  // cues in the logged copy only; see videoBridgeSnapshotRedaction.ts.
+  logClientRawRequestRedacted(reqLogger, clientRawRequest, videoBridgeObserved);
   const reasoningRouteDecision =
     body && typeof body === "object"
       ? (body as Record<string, unknown>)._omnirouteReasoningRouteTrace

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -360,6 +360,7 @@ import { deleteSessionAccountAffinity } from "@/lib/db/sessionAccountAffinity";
 import { getCacheControlSettings } from "@/lib/cacheControlSettings";
 import { guardrailRegistry } from "@/lib/guardrails";
 import type { VideoBridgeLogRedactionEntry } from "@/lib/guardrails/videoBridge";
+import { redactVideoTranscriptFieldsForLog } from "@/lib/guardrails/videoBridgeSnapshotRedaction";
 import {
   shouldPreserveCacheControl,
   resolveConnectionCacheOverride,
@@ -1215,7 +1216,15 @@ export async function handleChatCore({
   if (clientRawRequest) {
     reqLogger.logClientRawRequest(
       clientRawRequest.endpoint,
-      clientRawRequest.body,
+      // #12150 P2 surface 1 (the dominant transcript-retention leak): this snapshot is
+      // captured BEFORE the guardrail chain runs, so it still carries the client's raw
+      // video transcript cue text untouched by the video-bridge guardrail's own
+      // description redaction. Redact it in this LOGGED copy only when the guardrail
+      // observed a video part on this request — clientRawRequest.body itself is never
+      // mutated and keeps flowing to every other consumer unchanged.
+      videoBridgeObserved
+        ? redactVideoTranscriptFieldsForLog(clientRawRequest.body)
+        : clientRawRequest.body,
       clientRawRequest.headers
     );
   }

--- a/src/lib/guardrails/videoBridgeSnapshotRedaction.ts
+++ b/src/lib/guardrails/videoBridgeSnapshotRedaction.ts
@@ -1,0 +1,102 @@
+/**
+ * #12150 P2 surface 1 (the dominant transcript-retention leak): structured redaction of
+ * video transcript fields on the CLIENT-REQUEST SNAPSHOT that lands in the detailed-log
+ * artifact.
+ *
+ * `clientRawRequest.body` (src/sse/handlers/chat/clientRawRequest.ts::buildClientRawRequest)
+ * is a bounded clone of the client's ORIGINAL request, captured BEFORE the guardrail chain
+ * runs, and persisted verbatim by `reqLogger.logClientRawRequest`
+ * (open-sse/handlers/chatCore.ts). Because it predates the video-bridge guardrail's own
+ * description redaction (#12150 P1 — see `describeVideoPart`'s `descriptionRedacted` in
+ * videoBridgeHelpers.ts), it still carries the client's raw `transcript` / `audioTranscript`
+ * cue text on any video part. This module redacts THAT COPY ONLY: the body sent to the
+ * provider and the response returned to the client are never touched here.
+ *
+ * Deliberately a standalone, dependency-light module — NOT part of videoBridgeHelpers.ts,
+ * which pulls in the frame-extraction broker client, audio/video fusion, contact-sheet
+ * composition and `sharp` for real video processing. The chat request hot path statically
+ * imports whatever module owns the `logClientRawRequest` call site on every request
+ * (video or not), so keeping this redaction free of that dependency chain matters for cold
+ * start and blast radius.
+ *
+ * The field walk mirrors `extractVideoParts` (videoBridgeHelpers.ts): for each content part,
+ * the candidate objects are the part itself, its `video_url` sub-object, and its `source`
+ * sub-object (the same three checked there) — but this walk is deliberately WIDER: any of
+ * those objects carrying a `transcript`/`audioTranscript` key gets redacted regardless of
+ * the part's `type`/shape. Those two field names are video-cue-only in this codebase's
+ * request contract, so matching on field presence rather than a shape allowlist is strictly
+ * safer (fails closed on an unusual or future video shape instead of silently skipping it).
+ * Redaction is a structured field substitution, not a scan over rendered text, so it cannot
+ * be bypassed by adversarial cue content (see the discarded regex approach recorded in the
+ * #12150 design doc, `_tasks/superpowers/specs/2026-09-01-video-transcript-retention-design.md`).
+ */
+
+// Kept as a local literal (not imported from videoBridgeHelpers.ts) for the reason in the
+// file header above. Equality with the canonical `VIDEO_TRANSCRIPT_REDACTION_PLACEHOLDER`
+// export is enforced by a drift test in
+// tests/unit/guardrails/videoBridgeSnapshotRedaction.test.ts.
+const REDACTION_PLACEHOLDER = "[redacted-video-transcript]";
+
+const TRANSCRIPT_FIELD_NAMES = ["transcript", "audioTranscript"] as const;
+const NESTED_SUBOBJECT_KEYS = ["video_url", "source"] as const;
+const CONTAINER_KEYS = ["messages", "input"] as const;
+
+type UnknownRecord = Record<string, unknown>;
+
+function isPlainRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Overwrites transcript field VALUES in place on `part` and its `video_url`/`source`
+ * sub-objects. Only ever called on a part that already lives inside the function's own
+ * `structuredClone`, never on caller-owned data. Keys are overwritten, never deleted, so
+ * downstream shape/observability (e.g. "this part had a transcript") is preserved.
+ */
+function redactTranscriptFieldsOnPart(part: unknown): void {
+  if (!isPlainRecord(part)) return;
+  const candidates: UnknownRecord[] = [part];
+  for (const key of NESTED_SUBOBJECT_KEYS) {
+    const nested = part[key];
+    if (isPlainRecord(nested)) candidates.push(nested);
+  }
+  for (const candidate of candidates) {
+    for (const field of TRANSCRIPT_FIELD_NAMES) {
+      if (candidate[field] !== undefined) {
+        candidate[field] = REDACTION_PLACEHOLDER;
+      }
+    }
+  }
+}
+
+function redactContentArray(content: unknown): void {
+  if (!Array.isArray(content)) return;
+  for (const part of content) {
+    redactTranscriptFieldsOnPart(part);
+  }
+}
+
+/** `messages` (Chat Completions) or `input` (Responses API) — either container shape. */
+function redactContainer(container: unknown): void {
+  if (!Array.isArray(container)) return;
+  for (const message of container) {
+    if (!isPlainRecord(message)) continue;
+    redactContentArray(message.content);
+  }
+}
+
+/**
+ * Returns a NEW structure with every video transcript cue field value replaced by the
+ * redaction placeholder. Never mutates `body` — the caller (chatCore.ts) must keep passing
+ * the untouched original to translation/dispatch/response. A non-object `body`, or one with
+ * neither `messages` nor `input`, or with video parts that carry no transcript field, is
+ * returned as an equivalent (cloned) structure with nothing to change.
+ */
+export function redactVideoTranscriptFieldsForLog(body: unknown): unknown {
+  if (!isPlainRecord(body)) return body;
+  const cloned = structuredClone(body) as UnknownRecord;
+  for (const key of CONTAINER_KEYS) {
+    redactContainer(cloned[key]);
+  }
+  return cloned;
+}

--- a/src/lib/guardrails/videoBridgeSnapshotRedaction.ts
+++ b/src/lib/guardrails/videoBridgeSnapshotRedaction.ts
@@ -100,3 +100,36 @@ export function redactVideoTranscriptFieldsForLog(body: unknown): unknown {
   }
   return cloned;
 }
+
+interface ClientRawRequestLike {
+  endpoint: unknown;
+  body: unknown;
+  headers?: unknown;
+}
+
+interface RequestLoggerLike {
+  logClientRawRequest: (endpoint: unknown, body: unknown, headers?: unknown) => void;
+}
+
+/**
+ * Call-site wrapper for `reqLogger.logClientRawRequest` (chatCore.ts's "0. Log client raw
+ * request" step): keeps the null-check and the observed/redacted guard out of chatCore.ts,
+ * which is a size-frozen file (`config/quality/file-size-baseline.json`) — this owns the
+ * redaction, so it owns the one guarded call site that applies it. Behavior is identical to
+ * the inline block it replaces: a non-observed request logs `clientRawRequest.body` by the
+ * exact same reference (no clone); an observed one logs the redacted clone.
+ */
+export function logClientRawRequestRedacted(
+  reqLogger: RequestLoggerLike,
+  clientRawRequest: ClientRawRequestLike | null | undefined,
+  videoBridgeObserved: boolean
+): void {
+  if (!clientRawRequest) return;
+  reqLogger.logClientRawRequest(
+    clientRawRequest.endpoint,
+    videoBridgeObserved
+      ? redactVideoTranscriptFieldsForLog(clientRawRequest.body)
+      : clientRawRequest.body,
+    clientRawRequest.headers
+  );
+}

--- a/tests/unit/guardrails/videoBridgeSnapshotRedaction.test.ts
+++ b/tests/unit/guardrails/videoBridgeSnapshotRedaction.test.ts
@@ -1,0 +1,207 @@
+// #12150 P2 surface 1 (the dominant transcript-retention leak): pure-helper coverage for
+// redactVideoTranscriptFieldsForLog — the structured redaction applied to the RAW
+// client-request snapshot (clientRawRequest.body) before it is persisted by
+// reqLogger.logClientRawRequest (open-sse/handlers/chatCore.ts). See
+// src/lib/guardrails/videoBridgeSnapshotRedaction.ts for the full design rationale
+// (deliberately dependency-light; field-presence match rather than a shape allowlist).
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { redactVideoTranscriptFieldsForLog } from "../../../src/lib/guardrails/videoBridgeSnapshotRedaction.ts";
+// Heavy import is fine here (test only, never in the production module under test) — used
+// solely to prove the local placeholder literal never drifts from the canonical P1 constant.
+import { VIDEO_TRANSCRIPT_REDACTION_PLACEHOLDER } from "../../../src/lib/guardrails/videoBridgeHelpers.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord {
+  return value as JsonRecord;
+}
+
+function contentAt(
+  body: unknown,
+  container: "messages" | "input",
+  messageIndex: number
+): JsonRecord[] {
+  const messages = asRecord(body)[container] as JsonRecord[];
+  return messages[messageIndex].content as JsonRecord[];
+}
+
+test("redacts transcript and audioTranscript directly on a video part (messages container)", () => {
+  const body = {
+    model: "gpt-x",
+    messages: [
+      { role: "system", content: "sys" },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at this video" },
+          {
+            type: "input_video",
+            video_url: "https://example.com/clip.mp4",
+            transcript: { cues: [{ text: "secret words", startSeconds: 0, endSeconds: 2 }] },
+            audioTranscript: { cues: [{ text: "audio secret", startSeconds: 0, endSeconds: 1 }] },
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  assert.notEqual(result, body, "must return a new structure, not the same reference");
+
+  const videoPart = contentAt(result, "messages", 1)[1];
+  assert.equal(videoPart.transcript, "[redacted-video-transcript]");
+  assert.equal(videoPart.audioTranscript, "[redacted-video-transcript]");
+  // The video ref itself and the sibling non-video part must survive untouched.
+  assert.equal(videoPart.video_url, "https://example.com/clip.mp4");
+  assert.equal(contentAt(result, "messages", 1)[0].text, "look at this video");
+  assert.equal(asRecord(result).messages, asRecord(result).messages); // sanity: still an array
+
+  const serialized = JSON.stringify(result);
+  assert.ok(!serialized.includes("secret words"), "raw video transcript must not survive");
+  assert.ok(!serialized.includes("audio secret"), "raw audio transcript must not survive");
+});
+
+test("redacts a transcript nested under the video_url sub-object", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "video_url",
+            video_url: {
+              url: "https://example.com/nested.mp4",
+              transcript: { cues: [{ text: "nested secret" }] },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  const part = contentAt(result, "messages", 0)[0];
+  const videoUrl = part.video_url as JsonRecord;
+  assert.equal(videoUrl.transcript, "[redacted-video-transcript]");
+  assert.equal(videoUrl.url, "https://example.com/nested.mp4");
+  assert.ok(!JSON.stringify(result).includes("nested secret"));
+});
+
+test("redacts a transcript nested under the source sub-object (video_source shape)", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "video_source",
+            source: {
+              type: "url",
+              url: "https://example.com/source.mp4",
+              audioTranscript: { cues: [{ text: "source secret" }] },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  const part = contentAt(result, "messages", 0)[0];
+  const source = part.source as JsonRecord;
+  assert.equal(source.audioTranscript, "[redacted-video-transcript]");
+  assert.equal(source.url, "https://example.com/source.mp4");
+  assert.ok(!JSON.stringify(result).includes("source secret"));
+});
+
+test("covers the input container (Responses API shape)", () => {
+  const body = {
+    model: "gpt-x",
+    input: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_video",
+            video_url: "https://example.com/input.mp4",
+            transcript: { cues: [{ text: "input secret" }] },
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  const part = contentAt(result, "input", 0)[0];
+  assert.equal(part.transcript, "[redacted-video-transcript]");
+  assert.ok(!JSON.stringify(result).includes("input secret"));
+});
+
+test("does not mutate the input", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_video",
+            video_url: "https://example.com/clip.mp4",
+            transcript: { cues: [{ text: "secret words" }] },
+            audioTranscript: { cues: [{ text: "audio secret" }] },
+          },
+        ],
+      },
+    ],
+  };
+  const before = JSON.parse(JSON.stringify(body));
+
+  redactVideoTranscriptFieldsForLog(body);
+
+  assert.deepEqual(body, before, "input object must be byte-identical after the call");
+});
+
+test("a non-video body is returned unchanged", () => {
+  const body = {
+    model: "gpt-x",
+    messages: [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hello, no video here" },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  assert.deepEqual(result, body);
+});
+
+test("a body with a video part but no transcript field is unchanged", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "input_video", video_url: "https://example.com/no-transcript.mp4" }],
+      },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  assert.deepEqual(result, body);
+});
+
+test("the redaction placeholder matches the canonical P1 constant (no drift)", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "input_video", video_url: "https://example.com/clip.mp4", transcript: "raw" },
+        ],
+      },
+    ],
+  };
+
+  const result = redactVideoTranscriptFieldsForLog(body);
+  const part = contentAt(result, "messages", 0)[0];
+  assert.equal(part.transcript, VIDEO_TRANSCRIPT_REDACTION_PLACEHOLDER);
+});

--- a/tests/unit/video-bridge-log-redaction.test.ts
+++ b/tests/unit/video-bridge-log-redaction.test.ts
@@ -26,6 +26,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { redactVideoTranscriptFieldsForLog } from "../../src/lib/guardrails/videoBridgeSnapshotRedaction.ts";
+
 const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-video-log-redaction-test-"));
 process.env.DATA_DIR = testDataDir;
 
@@ -263,5 +265,88 @@ test("Scenario A (adversarial review): a message prepended AFTER the guardrail b
     persisted.messages[0].content,
     "You are a helpful assistant.",
     "the prepended system message must be untouched"
+  );
+});
+
+// #12150 P2 surface 1 (the dominant transcript-retention leak): the RAW client-request
+// snapshot passed to reqLogger.logClientRawRequest (open-sse/handlers/chatCore.ts's
+// "0. Log client raw request" step) is a DIFFERENT sink from persistAttemptLogs above —
+// it is captured before the guardrail chain even runs, so it carries the client's raw
+// `transcript`/`audioTranscript` FIELDS on a structured video part, not a flattened
+// description string. Importing the real chatCore.ts here would pull the full
+// request-pipeline dependency graph (executors, providers, combo routing, DB-backed
+// settings, ...) into the test just to reach one guarded ternary a few hundred lines into
+// a 5900+ line handler, for no additional proof beyond what's below — so this exercises
+// the EXACT call-site pattern
+// (`videoBridgeObserved ? redactVideoTranscriptFieldsForLog(body) : body`) against a fake
+// logClientRawRequest. The pure helper itself has its own thorough suite in
+// tests/unit/guardrails/videoBridgeSnapshotRedaction.test.ts.
+function fakeReqLogger() {
+  const calls: unknown[] = [];
+  return {
+    calls,
+    logClientRawRequest(_endpoint: unknown, body: unknown, _headers?: unknown) {
+      calls.push(body);
+    },
+  };
+}
+
+/** Mirrors chatCore.ts's guarded logClientRawRequest call site verbatim. */
+function callLogClientRawRequestAsChatCoreDoes(
+  reqLogger: ReturnType<typeof fakeReqLogger>,
+  clientRawRequest: { endpoint: string; body: unknown; headers: unknown },
+  videoBridgeObserved: boolean
+) {
+  reqLogger.logClientRawRequest(
+    clientRawRequest.endpoint,
+    videoBridgeObserved
+      ? redactVideoTranscriptFieldsForLog(clientRawRequest.body)
+      : clientRawRequest.body,
+    clientRawRequest.headers
+  );
+}
+
+test("surface 2 (raw snapshot): the fake logClientRawRequest receives a redacted snapshot only when videoBridgeObserved is true", () => {
+  const rawBody = {
+    model: "openai/gpt-x",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at this video" },
+          {
+            type: "input_video",
+            video_url: "https://example.com/clip.mp4",
+            transcript: { cues: [{ text: SECRET, startSeconds: 0, endSeconds: 2 }] },
+          },
+        ],
+      },
+    ],
+  };
+  const clientRawRequest = { endpoint: "/v1/chat/completions", body: rawBody, headers: {} };
+
+  const observedLogger = fakeReqLogger();
+  callLogClientRawRequestAsChatCoreDoes(observedLogger, clientRawRequest, true);
+  const observedSnapshot = observedLogger.calls[0];
+  assert.ok(
+    !JSON.stringify(observedSnapshot).includes(SECRET),
+    "an observed request must not log the raw transcript"
+  );
+  assert.notEqual(
+    observedSnapshot,
+    rawBody,
+    "the observed path must log a redacted CLONE, not the original reference"
+  );
+  assert.ok(
+    JSON.stringify(rawBody).includes(SECRET),
+    "clientRawRequest.body itself must stay untouched for every other consumer (translation/dispatch)"
+  );
+
+  const nonObservedLogger = fakeReqLogger();
+  callLogClientRawRequestAsChatCoreDoes(nonObservedLogger, clientRawRequest, false);
+  assert.equal(
+    nonObservedLogger.calls[0],
+    rawBody,
+    "the non-observed path must log the exact same object reference — byte-identical, no clone"
   );
 });

--- a/tests/unit/video-bridge-log-redaction.test.ts
+++ b/tests/unit/video-bridge-log-redaction.test.ts
@@ -26,7 +26,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { redactVideoTranscriptFieldsForLog } from "../../src/lib/guardrails/videoBridgeSnapshotRedaction.ts";
+import { logClientRawRequestRedacted } from "../../src/lib/guardrails/videoBridgeSnapshotRedaction.ts";
 
 const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-video-log-redaction-test-"));
 process.env.DATA_DIR = testDataDir;
@@ -275,11 +275,11 @@ test("Scenario A (adversarial review): a message prepended AFTER the guardrail b
 // `transcript`/`audioTranscript` FIELDS on a structured video part, not a flattened
 // description string. Importing the real chatCore.ts here would pull the full
 // request-pipeline dependency graph (executors, providers, combo routing, DB-backed
-// settings, ...) into the test just to reach one guarded ternary a few hundred lines into
-// a 5900+ line handler, for no additional proof beyond what's below — so this exercises
-// the EXACT call-site pattern
-// (`videoBridgeObserved ? redactVideoTranscriptFieldsForLog(body) : body`) against a fake
-// logClientRawRequest. The pure helper itself has its own thorough suite in
+// settings, ...) into the test just to reach one guarded call a few hundred lines into
+// a 5900+ line handler, for no additional proof beyond what's below — so this calls the
+// REAL exported `logClientRawRequestRedacted` (the exact function chatCore.ts's call site
+// invokes, post file-size-refactor) against a fake logClientRawRequest. The pure redaction
+// helper itself has its own thorough suite in
 // tests/unit/guardrails/videoBridgeSnapshotRedaction.test.ts.
 function fakeReqLogger() {
   const calls: unknown[] = [];
@@ -289,21 +289,6 @@ function fakeReqLogger() {
       calls.push(body);
     },
   };
-}
-
-/** Mirrors chatCore.ts's guarded logClientRawRequest call site verbatim. */
-function callLogClientRawRequestAsChatCoreDoes(
-  reqLogger: ReturnType<typeof fakeReqLogger>,
-  clientRawRequest: { endpoint: string; body: unknown; headers: unknown },
-  videoBridgeObserved: boolean
-) {
-  reqLogger.logClientRawRequest(
-    clientRawRequest.endpoint,
-    videoBridgeObserved
-      ? redactVideoTranscriptFieldsForLog(clientRawRequest.body)
-      : clientRawRequest.body,
-    clientRawRequest.headers
-  );
 }
 
 test("surface 2 (raw snapshot): the fake logClientRawRequest receives a redacted snapshot only when videoBridgeObserved is true", () => {
@@ -326,7 +311,7 @@ test("surface 2 (raw snapshot): the fake logClientRawRequest receives a redacted
   const clientRawRequest = { endpoint: "/v1/chat/completions", body: rawBody, headers: {} };
 
   const observedLogger = fakeReqLogger();
-  callLogClientRawRequestAsChatCoreDoes(observedLogger, clientRawRequest, true);
+  logClientRawRequestRedacted(observedLogger, clientRawRequest, true);
   const observedSnapshot = observedLogger.calls[0];
   assert.ok(
     !JSON.stringify(observedSnapshot).includes(SECRET),
@@ -343,10 +328,18 @@ test("surface 2 (raw snapshot): the fake logClientRawRequest receives a redacted
   );
 
   const nonObservedLogger = fakeReqLogger();
-  callLogClientRawRequestAsChatCoreDoes(nonObservedLogger, clientRawRequest, false);
+  logClientRawRequestRedacted(nonObservedLogger, clientRawRequest, false);
   assert.equal(
     nonObservedLogger.calls[0],
     rawBody,
     "the non-observed path must log the exact same object reference — byte-identical, no clone"
+  );
+
+  const skippedLogger = fakeReqLogger();
+  logClientRawRequestRedacted(skippedLogger, null, true);
+  assert.equal(
+    skippedLogger.calls.length,
+    0,
+    "a missing clientRawRequest must not call logClientRawRequest at all (mirrors the old if-guard)"
   );
 });


### PR DESCRIPTION
Refs #12150, #12430 (P2 surface 1)

⚠️ base-red inherited: #12518

## What

`clientRawRequest.body` is a bounded clone of the client's ORIGINAL request,
captured **before** the guardrail chain runs, and persisted verbatim by
`reqLogger.logClientRawRequest` (`open-sse/handlers/chatCore.ts`). Because it
predates the video-bridge guardrail's own description redaction (#12150 P1),
it still carried the client's raw `transcript` / `audioTranscript` cue text on
any video part — the dominant transcript-retention leak identified in the
#12150 design doc (surface 2 there, P2's "surface 1").

This PR redacts that snapshot, and only that snapshot:

- New file `src/lib/guardrails/videoBridgeSnapshotRedaction.ts` exports
  `redactVideoTranscriptFieldsForLog(body: unknown): unknown` — a pure,
  dependency-light helper that walks `body.messages[].content[]` and
  `body.input[].content[]` and replaces `transcript` / `audioTranscript`
  field VALUES (on the part itself, or its `video_url`/`source` sub-object —
  mirrors how `extractVideoParts` in `videoBridgeHelpers.ts` reads them) with
  the sentinel `"[redacted-video-transcript]"`. Keys are never deleted.
  Returns a new `structuredClone`, never mutates the input.
  - Deliberately **not** part of `videoBridgeHelpers.ts` (frame-extraction
    broker, audio/video fusion, contact-sheet composition, `sharp`) so the
    hot chat-request path doesn't statically import that dependency chain
    just to reach this one redaction. The placeholder is kept as a local
    literal (not imported) for the same reason; a drift test asserts it
    matches the canonical `VIDEO_TRANSCRIPT_REDACTION_PLACEHOLDER` export.
- One guarded call-site change in `open-sse/handlers/chatCore.ts`
  (`logClientRawRequest`): when `videoBridgeObserved` (already threaded by
  P1), pass `redactVideoTranscriptFieldsForLog(clientRawRequest.body)`
  instead of the raw body. Non-observed path is byte-identical (same object
  reference, no clone) — verified directly in a test.

Out of scope (P2b/P2c): the continuation store and derived-prompt dispatches.

## Testing

TDD, `env -u OMNIROUTE_API_KEY` throughout:

- RED: 8 new tests in `tests/unit/guardrails/videoBridgeSnapshotRedaction.test.ts`
  run against a naive passthrough stub — 3 pass / 5 fail (captured).
- GREEN: same 8 tests against the real implementation — 8/8 pass. Covers both
  `messages` and `input` containers, transcript directly on the part vs.
  nested under `video_url`/`source`, ref/non-video-part preservation,
  no-mutation, a non-video body unchanged, a video part with no transcript
  field unchanged, and no drift from the P1 placeholder constant.
- Extended `tests/unit/video-bridge-log-redaction.test.ts` (the existing P1
  surface-1 file) with a new test exercising the exact
  `videoBridgeObserved ? redact(...) : body` call-site pattern against a fake
  `logClientRawRequest` — redacted+cloned when observed, byte-identical
  reference when not. Sanity-mutated the guard condition to confirm the test
  fails when the wiring is wrong (4 pass / 1 fail), then reverted — 5/5 green.
  A full `handleChatCore` integration test was not attempted: importing the
  real `chatCore.ts` is feasible (44 existing tests do) but driving it this
  deep requires the ~900-line DB/upstream-fetch mocking harness seen in
  `chatcore-sanitization.test.ts`, for no additional proof beyond what the
  above two suites already cover — per the task brief's own escape hatch.
- Full `tests/unit/guardrails/**` directory: 528/528 pass (no regressions).
- `tests/unit/chatcore-imports-cleanly.test.ts` +
  `tests/unit/video-bridge-memory-suppression.test.ts`: 12/12 pass (chatCore.ts
  still imports cleanly with the new static import; P1's Memory-suppression
  surface is unaffected).
- `tests/unit/chatcore-sanitization.test.ts` (full `handleChatCore`
  integration, detailed-logging path): 18/18 pass.
- `npm run test:vitest`: 51 files / 465 tests pass.
- `npm run typecheck:core`: clean.
- `npx prettier --check` on all touched files: clean.
- eslint was not run — broken repo-wide (`@eslint/compat`), per the task's
  stated gate substitution (prettier + typecheck:core).

Full `npm run test:unit` (whole-repo suite) was not run given its multi-hour
scope and the change's narrow, well-isolated surface confirmed green above;
flagging this explicitly for the reviewer.