### PR TITLE
chore(quality): tighten the CodeQL ratchet baseline from 11 to 6

### DIFF
--- a/config/quality/quality-baseline.json
+++ b/config/quality/quality-baseline.json
@@ -157,7 +157,7 @@
       "dedicatedGate": true
     },
     "codeqlAlerts": {
-      "value": 11,
+      "value": 6,
       "direction": "down",
       "dedicatedGate": true,
       "_rebaseline_2026_08_06_base_grew": "Base branch file-size drift: translator-openai-to-gemini.test.ts grew 1619->1622 (test assertions for Gemini translator compatibility). CodeQL alert (js/insufficient-password-hash in raycast.ts) is pre-existing base-red; incremented baseline to match.",


### PR DESCRIPTION
## Contexto

A PR #12502 corrigiu 7 alertas CodeQL reais (aleatoriedade tendenciosa no signer do MaxAI, 2 sanitizações incompletas e 4 defeitos de correspondência de URL em testes). Após o merge, a análise CodeQL manualmente disparada publicou o resultado e fechou esses alertas — a contagem real de alertas abertos caiu de 13 para **6**.

A catraca (`config/quality/quality-baseline.json` → `metrics.codeqlAlerts.value`) ficou parada em **11**, ou seja, permitia silenciosamente uma regressão de até 5 alertas antes de bloquear qualquer PR. Esta PR só atualiza esse valor para o número real.

## O que muda

- `config/quality/quality-baseline.json`: `metrics.codeqlAlerts.value` `11` → `6`. Nenhum outro campo do arquivo foi tocado.

## Verificação

Contagem live confirmada via API antes e depois da atualização:

```
gh api "repos/diegosouzapw/OmniRoute/code-scanning/alerts?state=open&per_page=50" --jq 'length'
# 6
```

Breakdown por regra dos 6 alertas restantes:

| Regra | Qtde | Local |
| --- | --- | --- |
| `js/weak-cryptographic-algorithm` | 3 | `open-sse/executors/maxai/signing.ts:56`, `open-sse/executors/maxai/constants.ts:279`, `tests/unit/helpers/maxaiMockConstants.ts:52` |
| `js/insufficient-password-hash` | 2 | `open-sse/executors/maxai/signing.ts:76`, `open-sse/executors/maxai/signing.ts:56` |
| `js/stack-trace-exposure` | 1 | `open-sse/utils/error.ts:749` |

Todos os 6 estão pendentes de dismissal manual pelo operador (Hard Rule #14 — dismissal via API é proibido para agentes), com a justificativa técnica já registrada na PR #12502:

- Os 5 alertas de `open-sse/executors/maxai/` são exigidos pelo **protocolo do provider MaxAI** (o algoritmo fraco/hash é o que o upstream MaxAI exige para assinar requisições — não é escolha do OmniRoute).
- O alerta de `js/stack-trace-exposure` em `open-sse/utils/error.ts:749` é falso positivo — o callsite já passa por `sanitizeErrorMessage()`/`buildErrorBody()` (ver `docs/security/ERROR_SANITIZATION.md`); é uma limitação conhecida do CodeQL em reconhecer sanitizers customizados (mesma classe documentada na Hard Rule #14).

Comandos executados:

```
node scripts/check/check-codeql-ratchet.mjs --update
# baseline ratcheado: 6 (era 11) — exit 0

node scripts/check/check-codeql-ratchet.mjs
# OK — sem regressão — 6 alertas (baseline 6) — exit 0
```

## Escopo

Apenas o valor da métrica `codeqlAlerts` foi alterado — nenhum outro campo/métrica do baseline foi tocado, nenhuma catraca foi afrouxada (é um aperto: 11 → 6).
