### PR TITLE
fix(gemini): strip prefixItems from Gemini tool schemas

### DIFF
--- a/changelog.d/fixes/12540-gemini-strip-prefixitems-nested.md
+++ b/changelog.d/fixes/12540-gemini-strip-prefixitems-nested.md
@@ -1,0 +1,1 @@
+- **fix(gemini):** strip the JSON-Schema-2020-12 `prefixItems` keyword from Gemini tool schemas at every nesting level, so Claude Code tool definitions no longer fail with `400 Unknown name "prefixItems"` on Gemini models (#12540 — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-gemini-strip-prefixitems-nested.md
+++ b/changelog.d/fixes/PENDING-gemini-strip-prefixitems-nested.md
@@ -1,1 +1,0 @@
-- **fix(gemini):** strip the JSON-Schema-2020-12 `prefixItems` keyword from Gemini tool schemas at every nesting level, so Claude Code tool definitions no longer fail with `400 Unknown name "prefixItems"` on Gemini models (#PENDING — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-gemini-strip-prefixitems-nested.md
+++ b/changelog.d/fixes/PENDING-gemini-strip-prefixitems-nested.md
@@ -1,0 +1,1 @@
+- **fix(gemini):** strip the JSON-Schema-2020-12 `prefixItems` keyword from Gemini tool schemas at every nesting level, so Claude Code tool definitions no longer fail with `400 Unknown name "prefixItems"` on Gemini models (#PENDING — thanks @pacocartones)

--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -63,6 +63,12 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   // it, rejecting the whole request with "Unknown name \"uniqueItems\"".
   // Upstream 9router already strips it alongside `contains` for the same error.
   "uniqueItems",
+  // #12509: JSON-Schema-2020-12 tuple keyword. Claude Code's built-in tools
+  // describe `[start_line, end_line]` ranges with it (nested under `items`),
+  // and Gemini's schema parser rejects the whole tool list with
+  // "Unknown name \"prefixItems\" ... Cannot find field". ensureArrayItems
+  // below still guarantees an `items` schema for the tuple-typed array.
+  "prefixItems",
   // Complex schema keywords (handled by flattenAnyOfOneOf/mergeAllOf)
   "anyOf",
   "oneOf",

--- a/tests/unit/12509-gemini-prefixitems.test.ts
+++ b/tests/unit/12509-gemini-prefixitems.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildGeminiTools } from "../../open-sse/translator/helpers/geminiToolsSanitizer.ts";
+import { GEMINI_UNSUPPORTED_SCHEMA_KEYS } from "../../open-sse/translator/helpers/geminiHelper.ts";
+
+// Issue #12509: Gemini rejects the JSON-Schema-2020-12 tuple keyword `prefixItems` in
+// function_declarations parameter schemas with HTTP 400
+// `Unknown name "prefixItems" at 'tools[0].function_declarations[1].parameters.properties[5]
+// .value.properties[0].value.items': Cannot find field.` — the same class of error already
+// fixed for `uniqueItems` (#9617), `multipleOf`, `strict` and `encrypted` in
+// GEMINI_UNSUPPORTED_SCHEMA_KEYS (open-sse/translator/helpers/geminiHelper.ts).
+
+type GeminiFunctionDeclaration = { name: string; parameters: Record<string, unknown> };
+
+function declarationsOf(tools: unknown[]): GeminiFunctionDeclaration[] {
+  const geminiTools = buildGeminiTools(tools) as Array<{
+    functionDeclarations?: GeminiFunctionDeclaration[];
+  }> | null;
+  assert.ok(geminiTools, "expected buildGeminiTools to return a tools array");
+  return geminiTools.flatMap((tool) => tool.functionDeclarations ?? []);
+}
+
+function assertNoPrefixItems(tools: unknown[]): GeminiFunctionDeclaration[] {
+  const declarations = declarationsOf(tools);
+  const serialized = JSON.stringify(declarations);
+  assert.equal(
+    serialized.includes("prefixItems"),
+    false,
+    `prefixItems leaked into the Gemini payload (would trigger upstream 400 "Unknown name \\"prefixItems\\""): ${serialized}`
+  );
+  return declarations;
+}
+
+// The reporter's shape: a tuple nested under `items` — an array of `[start_line, end_line]`
+// ranges, i.e. `properties.ranges.items.prefixItems`.
+const nestedTupleParameters = {
+  type: "object",
+  properties: {
+    file_path: { type: "string" },
+    ranges: {
+      type: "array",
+      description: "Line ranges to read",
+      items: {
+        type: "array",
+        prefixItems: [{ type: "integer" }, { type: "integer" }],
+        items: false,
+        minItems: 2,
+        maxItems: 2,
+      },
+    },
+  },
+  required: ["file_path", "ranges"],
+};
+
+test("buildGeminiTools strips prefixItems nested under items (OpenAI tool shape, issue #12509)", () => {
+  const [declaration] = assertNoPrefixItems([
+    {
+      type: "function",
+      function: {
+        name: "read_ranges",
+        description: "tuple-typed array parameter nested under items",
+        parameters: nestedTupleParameters,
+      },
+    },
+  ]);
+
+  const ranges = (declaration.parameters.properties as Record<string, Record<string, unknown>>)
+    .ranges;
+  assert.equal(ranges.type, "array");
+  const inner = ranges.items as Record<string, unknown>;
+  assert.equal(inner.type, "array");
+  assert.ok(inner.items && typeof inner.items === "object", "inner array keeps an items schema");
+});
+
+test("buildGeminiTools strips prefixItems from a Claude input_schema (issue #12509)", () => {
+  const [declaration] = assertNoPrefixItems([
+    {
+      name: "read_ranges",
+      description: "Claude Messages tool shape",
+      input_schema: nestedTupleParameters,
+    },
+  ]);
+  assert.equal(declaration.name, "read_ranges");
+});
+
+test("buildGeminiTools strips a top-level prefixItems tuple and keeps a usable items schema (issue #12509)", () => {
+  const [declaration] = assertNoPrefixItems([
+    {
+      type: "function",
+      function: {
+        name: "read_range",
+        description: "single [start_line, end_line] tuple",
+        parameters: {
+          type: "object",
+          properties: {
+            range: {
+              type: "array",
+              prefixItems: [{ type: "integer" }, { type: "integer" }],
+            },
+          },
+          required: ["range"],
+        },
+      },
+    },
+  ]);
+
+  const range = (declaration.parameters.properties as Record<string, Record<string, unknown>>)
+    .range;
+  assert.equal(range.type, "array");
+  assert.ok(range.items && typeof range.items === "object", "Gemini requires items on arrays");
+});
+
+test("buildGeminiTools strips prefixItems that sits next to a regular items schema (issue #12509)", () => {
+  const [declaration] = assertNoPrefixItems([
+    {
+      type: "function",
+      function: {
+        name: "pair",
+        description: "tuple keyword as a sibling of a regular items schema",
+        parameters: {
+          type: "object",
+          properties: {
+            pair: {
+              type: "array",
+              prefixItems: [{ type: "string" }],
+              items: { type: "string" },
+            },
+          },
+        },
+      },
+    },
+  ]);
+
+  const pair = (declaration.parameters.properties as Record<string, Record<string, unknown>>).pair;
+  assert.deepEqual(pair.items, { type: "string" });
+});
+
+test("prefixItems is registered in GEMINI_UNSUPPORTED_SCHEMA_KEYS (issue #12509)", () => {
+  assert.ok(GEMINI_UNSUPPORTED_SCHEMA_KEYS.has("prefixItems"));
+});


### PR DESCRIPTION
## Summary

- `GEMINI_UNSUPPORTED_SCHEMA_KEYS` (`open-sse/translator/helpers/geminiHelper.ts:9-105` on the base) is the only strip-list `cleanJSONSchemaForAntigravity` applies to tool parameter schemas (`removeUnsupportedKeywords`, `geminiHelper.ts:643`), and it did not contain the JSON-Schema-2020-12 tuple keyword `prefixItems`. Claude Code's built-in tools describe `[start_line, end_line]` ranges as a tuple nested under `items`, so every tool-bearing Claude Code request routed to a Gemini model was rejected before generation with `400 Invalid JSON payload received. Unknown name "prefixItems" at 'tools[0].function_declarations[1].parameters.properties[5].value.properties[0].value.items': Cannot find field` (#12509). All three tool shapes that `buildGeminiTools` accepts go through the same cleaner (`geminiToolsSanitizer.ts:207`, `:220` for Claude `input_schema`, `:238` for OpenAI `function.parameters`), so the Claude Messages compatibility path the reporter uses and the OpenAI path were both affected.
- Before: `prefixItems` survived at every nesting level (top-level array property, sibling of `items`, and the reporter's tuple under `items`) and reached Gemini verbatim. After: `prefixItems` is added to `GEMINI_UNSUPPORTED_SCHEMA_KEYS` next to `uniqueItems` (#9617), so it is removed recursively at every level, the same way `multipleOf`, `strict` and `encrypted` already are. When the tuple carried `items: false` (the 2020-12 idiom for "no extra elements"), Phase 8 `ensureArrayItems` (`geminiHelper.ts:733` on the base) already injects `{ type: "string" }`, so the parameter stays a valid Gemini array with an `items` schema; when a regular `items` schema sits next to `prefixItems`, that `items` schema is kept untouched.
- Deliberately out of scope: promoting `prefixItems[0]` into `items` (the tuple's element types can differ, and Gemini has no way to express positional typing, so the safe default `items` schema is the honest translation); touching `UNSUPPORTED_SCHEMA_CONSTRAINTS` beyond what it already derives from the Set; any change to the Antigravity envelope or to response schemas.

## Related Issues

- Closes #12509
- Related to #9617 (same class of fix, `uniqueItems`)
- Related to #12310 (touches the same file; see Reviewer Notes)

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider (Gemini tool-schema translation)
- [x] Focused tests and category gates from the golden path: `tests/unit/12509-gemini-prefixitems.test.ts` 5/5 plus the neighbouring Gemini schema suites (`9617-gemini-uniqueitems`, `gemini-codex-encrypted-tool-schema`, `gemini-schema-recursive-type`, `gemini-strict-tool-schema`, `gemini-tool-params-object-3357`, `translator-gemini-schema-pattern-property`, `9568-gemini-tool-casing-mismatch`, `gemini-tool-choice`, `v1beta-gemini-tool-calling-6222`) 45/45; `node scripts/check/check-complexity-ratchets.mjs --base-ref origin/release/v3.8.51` OK; `npm run check:changelog-integrity` OK; `npm run typecheck:core` exit 0; eslint on the two touched `.ts` files exit 0
- [ ] `npm run lint`
- [x] Reconciled with the current active release base `release/v3.8.51` (`1a0375fba`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Mutation: with the `"prefixItems"` entry removed from `GEMINI_UNSUPPORTED_SCHEMA_KEYS` (the base), all 5 new tests fail (0/5); with it, 5/5 pass.

## Tests Added Or Updated

- `tests/unit/12509-gemini-prefixitems.test.ts` (new, 5 cases): the reporter's shape — a `[start_line, end_line]` tuple nested under `items` with `items: false` — through the OpenAI `function.parameters` path and through the Claude `input_schema` path; a top-level `prefixItems` tuple with no `items` (asserts Gemini still gets an `items` schema); `prefixItems` next to a regular `items` schema (asserts that `items` survives unchanged); and a guard that `prefixItems` is registered in `GEMINI_UNSUPPORTED_SCHEMA_KEYS`. Every case asserts the serialized `functionDeclarations` no longer contain `prefixItems`. Red on the base (0/5), green with the change (5/5).
- No existing test file changed.

## Coverage Notes

- `open-sse/translator/helpers/geminiHelper.ts`: the one-entry change to `GEMINI_UNSUPPORTED_SCHEMA_KEYS` is exercised end-to-end through `buildGeminiTools` → `cleanJSONSchemaForAntigravity` → `removeUnsupportedKeywords` and `ensureArrayItems` by the new test file; the existing `9617-gemini-uniqueitems.test.ts` and the other Gemini schema suites above stay green.
- No touched file lost coverage; the diff to production code is a Set entry plus its comment.

## Reviewer Notes

- #12310 (`fix(gemini): preserve nullable in response schemas`) edits the same file, but only `cleanJSONSchemaForAntigravity`'s signature and body (`@@ -621` and `@@ -631`); this PR only touches the `GEMINI_UNSUPPORTED_SCHEMA_KEYS` literal at the top of the file, so the two apply in either order without a conflict. #12310's own guard test (`nullable` must stay out of the Set) is unaffected.
- The reporter's real payload has `prefixItems` under `items` inside an object property; the test reproduces that exact nesting (`properties.ranges.items.prefixItems`) rather than only the top-level case, so the recursive strip is what is being verified.
- Behavioural note for reviewers: a tuple-typed parameter is translated to a plain array whose `items` schema is either the sibling `items` the client sent or the `{ type: "string" }` default from #10578. That loses positional typing, but Gemini's schema subset cannot express it either way, and the previous behaviour was a hard 400 for the whole tool list.
- No stryker `tap.testFiles` change: `geminiHelper.ts` and `geminiToolsSanitizer.ts` are not in `stryker.conf.json`'s `mutate` list.
