### PR TITLE
fix(compression): terminate idle workers instead of dropping them

### DIFF
--- a/changelog.d/fixes/12542-compression-terminate-idle-workers.md
+++ b/changelog.d/fixes/12542-compression-terminate-idle-workers.md
@@ -1,0 +1,1 @@
+- **fix(compression):** Terminate idle compression workers instead of only dropping them from the pool, so each idle cycle no longer leaks a live thread and V8 isolate while `dispatch()` spawns a replacement (#12542 — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-compression-terminate-idle-workers.md
+++ b/changelog.d/fixes/PENDING-compression-terminate-idle-workers.md
@@ -1,0 +1,1 @@
+- **fix(compression):** Terminate idle compression workers instead of only dropping them from the pool, so each idle cycle no longer leaks a live thread and V8 isolate while `dispatch()` spawns a replacement (#PENDING — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-compression-terminate-idle-workers.md
+++ b/changelog.d/fixes/PENDING-compression-terminate-idle-workers.md
@@ -1,1 +1,0 @@
-- **fix(compression):** Terminate idle compression workers instead of only dropping them from the pool, so each idle cycle no longer leaks a live thread and V8 isolate while `dispatch()` spawns a replacement (#PENDING — thanks @pacocartones)

--- a/open-sse/services/compression/compressionWorkerPool.ts
+++ b/open-sse/services/compression/compressionWorkerPool.ts
@@ -131,7 +131,7 @@ export class CompressionWorkerPool {
   }
   async close(): Promise<void> {
     for (const job of this.queue.splice(0)) job.resolve(unchanged(job.originalBody));
-    await Promise.all([...this.workers].map((slot) => this.remove(slot, true)));
+    await Promise.all([...this.workers].map((slot) => this.remove(slot)));
   }
   private spawn(): PoolWorker {
     const slot: PoolWorker = {
@@ -185,7 +185,7 @@ export class CompressionWorkerPool {
     slot.timeout = null;
     slot.job = null;
     job.resolve(result);
-    slot.idle = setTimeout(() => void this.remove(slot, false), this.idleMs);
+    slot.idle = setTimeout(() => void this.remove(slot), this.idleMs);
     slot.idle.unref();
     this.dispatch();
   }
@@ -193,13 +193,18 @@ export class CompressionWorkerPool {
     const job = slot.job;
     if (job) job.resolve(unchanged(job.originalBody));
     slot.job = null;
-    void this.remove(slot, true).finally(() => this.dispatch());
+    void this.remove(slot).finally(() => this.dispatch());
   }
-  private async remove(slot: PoolWorker, terminate: boolean): Promise<void> {
+  /**
+   * Drop the slot from the pool AND terminate its thread. Dropping alone is not enough:
+   * the worker keeps a `parentPort` listener, so its event loop (and V8 isolate) stays
+   * alive forever while `dispatch()` respawns a replacement (#11804).
+   */
+  private async remove(slot: PoolWorker): Promise<void> {
     if (!this.workers.delete(slot)) return;
     if (slot.timeout) clearTimeout(slot.timeout);
     if (slot.idle) clearTimeout(slot.idle);
-    if (terminate) await slot.worker.terminate().catch(() => undefined);
+    await slot.worker.terminate().catch(() => undefined);
   }
 }
 

--- a/tests/unit/compression/compression-worker.test.ts
+++ b/tests/unit/compression/compression-worker.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, describe, it } from "node:test";
+import { Worker } from "node:worker_threads";
 import {
   isCompressionWorkerEligible,
   isStrictlySerializable,
@@ -133,6 +134,40 @@ describe("compression worker execution", () => {
       assert.deepEqual(result, { body, compressed: false, stats: null });
     } finally {
       await pool.close();
+    }
+  });
+
+  it("terminates an idle worker instead of only dropping it from the pool", async () => {
+    const spawned = new Set<Worker>();
+    const terminated: Promise<number>[] = [];
+    const originalPostMessage = Worker.prototype.postMessage;
+    const originalTerminate = Worker.prototype.terminate;
+    Worker.prototype.postMessage = function (this: Worker, ...args) {
+      spawned.add(this);
+      return originalPostMessage.apply(this, args);
+    };
+    Worker.prototype.terminate = function (this: Worker) {
+      const exit = originalTerminate.call(this);
+      terminated.push(exit);
+      return exit;
+    };
+    const messagePorts = () =>
+      process.getActiveResourcesInfo().filter((resource) => resource === "MessagePort").length;
+    const portsBefore = messagePorts();
+    const pool = new CompressionWorkerPool({ size: 1, idleMs: 50 });
+    try {
+      await pool.run(body, "stacked", { config });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      assert.equal(spawned.size, 1);
+      assert.equal(terminated.length, 1, "idle eviction must terminate the worker thread");
+      await Promise.all(terminated);
+      assert.ok(messagePorts() <= portsBefore, "idle eviction must not retain the worker's port");
+    } finally {
+      Worker.prototype.postMessage = originalPostMessage;
+      Worker.prototype.terminate = originalTerminate;
+      await pool.close();
+      // Reap anything the pool forgot so a regression fails instead of hanging the runner.
+      await Promise.all([...spawned].map((worker) => worker.terminate().catch(() => undefined)));
     }
   });
 


### PR DESCRIPTION
## Summary

- `CompressionWorkerPool.finish()` (`open-sse/services/compression/compressionWorkerPool.ts:188`) evicted an idle worker with `this.remove(slot, false)`, and `remove()` (`:198-203`) only called `worker.terminate()` `if (terminate)`. The idle path therefore deleted the slot from the pool set but never terminated the thread; `compressionWorker.ts:13` keeps a `parentPort.on("message")` listener, so the worker's event loop and V8 isolate stayed alive forever, and `dispatch()` (`:156`) spawned a replacement because `workers.size < size`. The `OMNI_COMPRESSION_WORKERS` cap held in bookkeeping only: every idle cycle leaked one live thread. This is the mechanism confirmed on #11804 (request-driven thread growth, ~90 threads parked in `ep_poll`, RSS far outside the main heap) and the one-line patch the reporter measured on a live instance: 57 leaked workers / 72 threads / 5.77 GB climbing before, 0 leaked / 15 threads / 846 MB flat after.
- `remove()` now always terminates the thread. The `terminate` parameter is removed rather than flipped at the idle call site: `close()` and `fail()` already passed `true`, so the parameter only existed to express the buggy case. A short comment on `remove()` records why dropping the slot alone is not enough. `close()`, `fail()`, timeouts and the queue/dispatch logic are otherwise unchanged; `terminate()` failures are still swallowed as before.
- Out of scope, on purpose: the `callLogArtifactWorker` hypothesis raised mid-thread (later marked unconfirmed by its author), the six bundled copies of the pool in the Next.js server chunks (they pick this change up at build time), and any change to the idle timeout or pool size defaults.

## Related Issues

- Closes #11804
- Related to #12245 (the combo loop-safety timer leak reported on the same issue, already merged)

## Validation

- [x] Change type: other (compression worker pool, `open-sse/`)
- [x] Focused tests and category gates from the golden path: `tests/unit/compression/compression-worker.test.ts` + `tests/unit/compression/compression-worker-file-resolution.test.ts` 17/17 (4 suites), `node scripts/check/check-complexity-ratchets.mjs --base-ref origin/release/v3.8.51` OK (0 violations, base 0), `npm run check:changelog-integrity` OK, `npm run typecheck:core` exit 0
- [ ] `npm run lint` — eslint run on the two touched source files only (`--suppressions-location config/quality/eslint-suppressions.json`), exit 0; the repository-wide command was not run
- [x] Reconciled with the current active release base `release/v3.8.51` (`1a0375fba`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Red/green: the new case fails on the base with `idle eviction must terminate the worker thread: 0 !== 1` and passes with the change (three consecutive runs, 8/8 in the file).

## Tests Added Or Updated

- `tests/unit/compression/compression-worker.test.ts` (1 new case, "terminates an idle worker instead of only dropping it from the pool"): spies on `Worker.prototype.terminate` and `Worker.prototype.postMessage` around a local `{ size: 1, idleMs: 50 }` pool, runs one job, waits past the idle window, and asserts that exactly one worker was spawned, that `terminate()` was called once, and that the process does not retain the worker's `MessagePort` (`process.getActiveResourcesInfo()`). The `finally` block restores both prototypes, closes the pool, and terminates any worker the pool forgot, so a future regression fails the assertion instead of keeping the test runner alive. The seven existing cases are untouched.
- No `stryker.conf.json` change: `open-sse/services/compression/` is not in the `mutate` list.

## Coverage Notes

- `open-sse/services/compression/compressionWorkerPool.ts`: the idle path of `finish()` and the unconditional `terminate()` in `remove()` are exercised by the new case; `close()` by the new case's `finally` and the existing timeout case; `fail()` by the existing "fails open" case. No touched file lost coverage.

## Reviewer Notes

- Behavioural change is limited to idle eviction: the thread is now terminated at the moment it is removed from the set, which is what `close()` and `fail()` already did. Nothing about job routing changes, so a request arriving after eviction still gets a freshly spawned worker exactly as before.
- Anyone patching an installed 3.8.50/3.8.51 bundle by hand should note that the minified idle call site appears in five files (four Next.js runtime chunks plus `open-sse/mcp-server/server.js`), as documented on the issue; a normal build from this branch covers all of them.
- No migrations, feature flags, or env changes.
