### PR TITLE
fix(video): clamp estimateJpegFrameBytes, reuse the shared JPEG prefix

### DIFF
--- a/changelog.d/fixes/12543-video-frame-estimate-clamp.md
+++ b/changelog.d/fixes/12543-video-frame-estimate-clamp.md
@@ -1,0 +1,1 @@
+- **fix(video):** Clamp `estimateJpegFrameBytes` at zero for padding-only payloads and build the three encode-side frame data URIs from `JPEG_FRAME_DATA_URI_PREFIX` instead of a repeated literal (#12543 — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-video-frame-estimate-clamp.md
+++ b/changelog.d/fixes/PENDING-video-frame-estimate-clamp.md
@@ -1,0 +1,1 @@
+- **fix(video):** Clamp `estimateJpegFrameBytes` at zero for padding-only payloads and build the three encode-side frame data URIs from `JPEG_FRAME_DATA_URI_PREFIX` instead of a repeated literal (#PENDING — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-video-frame-estimate-clamp.md
+++ b/changelog.d/fixes/PENDING-video-frame-estimate-clamp.md
@@ -1,1 +1,0 @@
-- **fix(video):** Clamp `estimateJpegFrameBytes` at zero for padding-only payloads and build the three encode-side frame data URIs from `JPEG_FRAME_DATA_URI_PREFIX` instead of a repeated literal (#PENDING — thanks @pacocartones)

--- a/src/lib/guardrails/videoBridgeContactSheet.ts
+++ b/src/lib/guardrails/videoBridgeContactSheet.ts
@@ -1,4 +1,8 @@
-import { decodeJpegFrameDataUri, estimateJpegFrameBytes } from "./videoBridgeFrameContract";
+import {
+  JPEG_FRAME_DATA_URI_PREFIX,
+  decodeJpegFrameDataUri,
+  estimateJpegFrameBytes,
+} from "./videoBridgeFrameContract";
 import { VIDEO_FRAME_MAX_BYTES } from "./videoBridgeRuntime";
 
 export interface ContactSheetFrame {
@@ -120,7 +124,7 @@ export async function buildVideoContactSheet(
     if (signal.aborted) throw new Error("Video contact sheet was aborted");
     if (output.byteLength > MAX_SHEET_BYTES) return fallback(frames);
     return {
-      dataUri: `data:image/jpeg;base64,${output.toString("base64")}`,
+      dataUri: `${JPEG_FRAME_DATA_URI_PREFIX}${output.toString("base64")}`,
       frames: frames.map((frame) => ({ ...frame })),
       height: rows * TILE_SIZE,
       timestamps: frames.map((frame) => frame.timestampSeconds),

--- a/src/lib/guardrails/videoBridgeDrilldownLifecycle.ts
+++ b/src/lib/guardrails/videoBridgeDrilldownLifecycle.ts
@@ -22,6 +22,7 @@ import {
   type VideoDrilldownPutValue,
   type VideoDrilldownResult,
 } from "./videoBridgeDrilldown";
+import { JPEG_FRAME_DATA_URI_PREFIX } from "./videoBridgeFrameContract";
 
 export type VideoDrilldownVariant = "preview" | "standard" | "detail";
 
@@ -170,7 +171,7 @@ async function shrinkFrameForVariant(
     .toBuffer();
   const metadata = await sharp(resized).metadata();
   return {
-    dataUri: `data:image/jpeg;base64,${resized.toString("base64")}`,
+    dataUri: `${JPEG_FRAME_DATA_URI_PREFIX}${resized.toString("base64")}`,
     height: metadata.height ?? frame.height,
     timestampSeconds: frame.timestampSeconds,
     width: metadata.width ?? frame.width,

--- a/src/lib/guardrails/videoBridgeFrameContract.ts
+++ b/src/lib/guardrails/videoBridgeFrameContract.ts
@@ -24,5 +24,6 @@ export function decodeJpegFrameDataUri(dataUri: string): Buffer {
 export function estimateJpegFrameBytes(dataUri: string): number {
   const encoded = matchJpegFrame(dataUri);
   const padding = encoded.endsWith("==") ? 2 : encoded.endsWith("=") ? 1 : 0;
-  return Math.floor((encoded.length * 3) / 4) - padding;
+  // Padding-only payloads (e.g. "=") pass the charset pattern; never report a negative size.
+  return Math.max(0, Math.floor((encoded.length * 3) / 4) - padding);
 }

--- a/src/lib/guardrails/videoBridgeRuntime.ts
+++ b/src/lib/guardrails/videoBridgeRuntime.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 
+import { JPEG_FRAME_DATA_URI_PREFIX } from "./videoBridgeFrameContract";
+
 const execFileAsync = promisify(execFile);
 
 export interface VideoCommandOptions {
@@ -997,7 +999,7 @@ export async function extractVideoFramesFromBytes(
     return {
       durationSeconds: metadata.durationSeconds,
       frames: frameFiles.map((frame, index) => ({
-        dataUri: `data:image/jpeg;base64,${frameBytes[index].toString("base64")}`,
+        dataUri: `${JPEG_FRAME_DATA_URI_PREFIX}${frameBytes[index].toString("base64")}`,
         timestampSeconds: frame.timestampSeconds,
       })),
       sampling: frameFiles.sampling,

--- a/tests/unit/guardrails/videoBridgeFrameContract.test.ts
+++ b/tests/unit/guardrails/videoBridgeFrameContract.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   JPEG_FRAME_DATA_URI_PREFIX,
@@ -31,5 +34,40 @@ test("estimates decoded bytes without decoding, accounting for padding", () => {
   for (const source of ["a", "ab", "abc", "abcd", "x".repeat(3000)]) {
     const uri = `data:image/jpeg;base64,${Buffer.from(source).toString("base64")}`;
     assert.equal(estimateJpegFrameBytes(uri), Buffer.byteLength(source));
+  }
+});
+
+test("never estimates below zero for degenerate padding-only payloads (#12323)", () => {
+  // The charset-only pattern admits these; the estimate must clamp instead of going to -1.
+  for (const encoded of ["=", "==", "A=", "A=="]) {
+    const uri = `${JPEG_FRAME_DATA_URI_PREFIX}${encoded}`;
+    const estimate = estimateJpegFrameBytes(uri);
+    assert.ok(estimate >= 0, `${JSON.stringify(encoded)} estimated ${estimate}`);
+    assert.ok(
+      estimate >= decodeJpegFrameDataUri(uri).byteLength,
+      `${JSON.stringify(encoded)} estimate is not an upper bound`
+    );
+  }
+  assert.equal(estimateJpegFrameBytes(`${JPEG_FRAME_DATA_URI_PREFIX}=`), 0);
+  assert.equal(estimateJpegFrameBytes(`${JPEG_FRAME_DATA_URI_PREFIX}==`), 0);
+});
+
+test("encode sites build frame data URIs from JPEG_FRAME_DATA_URI_PREFIX (#12323)", () => {
+  const guardrailsDir = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../src/lib/guardrails"
+  );
+  for (const file of [
+    "videoBridgeContactSheet.ts",
+    "videoBridgeRuntime.ts",
+    "videoBridgeDrilldownLifecycle.ts",
+  ]) {
+    const source = fs.readFileSync(path.join(guardrailsDir, file), "utf8");
+    assert.doesNotMatch(source, /data:image\/jpeg;base64,/, `${file} hardcodes the JPEG prefix`);
+    assert.match(
+      source,
+      /\bJPEG_FRAME_DATA_URI_PREFIX\b/,
+      `${file} does not use the shared prefix`
+    );
   }
 });


### PR DESCRIPTION
## Summary

- `estimateJpegFrameBytes` (`src/lib/guardrails/videoBridgeFrameContract.ts:24-27`) subtracted the padding count from the floored estimate with no floor of its own, so the padding-only payloads the charset-only pattern admits (`data:image/jpeg;base64,=` and `==`) came back as `-1`. Consequence-free in today's upper-bound usage, as #12323 notes, but a documented byte estimate never goes negative: the return is now `Math.max(0, ...)` (item 1).
- The three encode sites named in the issue (`videoBridgeContactSheet.ts:123`, `videoBridgeRuntime.ts:1000`, `videoBridgeDrilldownLifecycle.ts:173`) still built their frame data URIs from a hardcoded `data:image/jpeg;base64,` template literal; they now import `JPEG_FRAME_DATA_URI_PREFIX` from the shared contract (item 2). Byte-for-byte identical output, since the constant is the same literal.
- Deliberately out of scope: item 3 (`videoBridgeBrokerClient.ts:104`, the case-sensitive broker-output regex) and item 4 (structural base64 validation). Both are behaviour decisions per the issue text, so the issue stays open; this PR is `Refs`, not `Closes`. `videoBridgeRuntime.ts` gains a single import of the zero-dependency contract module, so no import cycle is introduced (`videoBridgeContactSheet.ts` already imported both).

## Related Issues

- Closes #
- Related to #12323 (items 1 and 2)
- Related to #12322 (the shared contract this builds on)

## Validation

- [x] Change type: other (backend guardrails / video frame contract)
- [x] Focused tests and category gates from the golden path: `tests/unit/guardrails/videoBridgeFrameContract.test.ts` + `videoBridgeContactSheet.test.ts` + `videoBridgeRuntime.test.ts` + `videoBridgeDrilldownLifecycle.test.ts` 38/38, `node scripts/check/check-complexity-ratchets.mjs --base-ref origin/release/v3.8.51` OK (7/7 and 1/1 unchanged), `npm run check:changelog-integrity` OK, `npm run typecheck:core` exit 0, eslint exit 0 over the five touched `.ts` files
- [ ] `npm run lint`
- [x] Reconciled with the current active release base `release/v3.8.51`; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- `tests/unit/guardrails/videoBridgeFrameContract.test.ts` (2 new cases): padding-only payloads (`=`, `==`, `A=`, `A==`) estimate `>= 0`, stay an upper bound of the real decode, and `=`/`==` estimate exactly `0`; and a source-level check that the three encode sites no longer contain the `data:image/jpeg;base64,` literal and do reference `JPEG_FRAME_DATA_URI_PREFIX`. Red on the base (2 fail / 3 pass: `"=" estimated -1`, `videoBridgeContactSheet.ts hardcodes the JPEG prefix`), green with the change (5/5). The three existing cases are unchanged.

## Coverage Notes

- `src/lib/guardrails/videoBridgeFrameContract.ts`: the clamp is exercised directly by the new padding-only case; the existing padding-accounting case still pins the non-degenerate values.
- `src/lib/guardrails/videoBridgeContactSheet.ts`, `videoBridgeRuntime.ts`, `videoBridgeDrilldownLifecycle.ts`: the prefix swap is behaviour-neutral and is covered by the existing `videoBridgeContactSheet.test.ts`, `videoBridgeRuntime.test.ts` and `videoBridgeDrilldownLifecycle.test.ts` suites (all green), plus the new source-level guard against the literal creeping back.
- No touched file lost coverage.

## Reviewer Notes

- Two hunks in `videoBridgeDrilldownLifecycle.ts` (lines 214 and 366) are not Prettier-clean on the base; the pre-commit hook wanted to rewrap them. They were left untouched on purpose so this diff stays on the two lines the issue names. Happy to include the rewrap if you prefer the file fully formatted.
- No migrations, feature flags or manual validation; the encoded output is identical before and after.
