### PR TITLE
fix(orchestration): keep the first staleSince while a source keeps failing

### DIFF
--- a/changelog.d/fixes/12544-orchestration-keep-first-stale-since.md
+++ b/changelog.d/fixes/12544-orchestration-keep-first-stale-since.md
@@ -1,0 +1,1 @@
+- **fix(orchestration):** Keep the first `staleSince` a failing agent source was stamped with while it keeps failing, so the source node reports when it actually went stale instead of the last poll and the canvas snapshot stops re-minting every tick (#12544 — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-orchestration-keep-first-stale-since.md
+++ b/changelog.d/fixes/PENDING-orchestration-keep-first-stale-since.md
@@ -1,1 +1,0 @@
-- **fix(orchestration):** Keep the first `staleSince` a failing agent source was stamped with while it keeps failing, so the source node reports when it actually went stale instead of the last poll and the canvas snapshot stops re-minting every tick (#PENDING — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-orchestration-keep-first-stale-since.md
+++ b/changelog.d/fixes/PENDING-orchestration-keep-first-stale-since.md
@@ -1,0 +1,1 @@
+- **fix(orchestration):** Keep the first `staleSince` a failing agent source was stamped with while it keeps failing, so the source node reports when it actually went stale instead of the last poll and the canvas snapshot stops re-minting every tick (#PENDING — thanks @pacocartones)

--- a/src/app/(dashboard)/dashboard/orchestration/hooks/useOrchestrationSnapshot.ts
+++ b/src/app/(dashboard)/dashboard/orchestration/hooks/useOrchestrationSnapshot.ts
@@ -89,6 +89,22 @@ function buildSourceStatuses(
   return next;
 }
 
+/**
+ * Keeps the FIRST `staleSince` a failing source was stamped with while it keeps failing.
+ * `buildSourceStatuses` stamps every failed slot with the current poll's `nowIso`, so
+ * without this the node would read "stale since <last poll>" instead of the first error
+ * and `snapshotContentKey` would churn every tick for as long as the source is down.
+ * A source that recovers (`ok: true`) has no `staleSince`, so the next failure restamps.
+ */
+export function carryStaleSince(prev: SourceStatus[], next: SourceStatus[]): SourceStatus[] {
+  return next.map((status) => {
+    if (status.ok) return status;
+    const before = prev.find((p) => p.source === status.source);
+    if (!before || before.ok || !before.staleSince) return status;
+    return { ...status, staleSince: before.staleSince };
+  });
+}
+
 export function useOrchestrationSnapshot() {
   // `raw` and `polledAt` are React state (not refs) so the merge below reads them
   // during render like any other state — a ref read during render trips the
@@ -133,7 +149,7 @@ export function useOrchestrationSnapshot() {
         a2a: a2a.status === "fulfilled" ? a2a.value.tasks : prev.a2a,
         conductor: cond.status === "fulfilled" ? cond.value : prev.conductor,
       }));
-      setStatuses(next);
+      setStatuses((prev) => carryStaleSince(prev, next));
       setPolledAt(nowMs);
       setIsLoading(false);
     };

--- a/tests/unit/ui/useOrchestrationSnapshot.test.tsx
+++ b/tests/unit/ui/useOrchestrationSnapshot.test.tsx
@@ -287,4 +287,62 @@ describe("useOrchestrationSnapshot", () => {
     });
     expect(latest!.snapshot).not.toBe(firstSnapshot);
   });
+
+  it("keeps the first staleSince while a source keeps failing and clears it once it recovers (#12392)", async () => {
+    let latest: ReturnType<typeof useOrchestrationSnapshot> | null = null;
+    const fetchMock = okFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const failCloudAgent = () =>
+      fetchMock.mockImplementation((url: string) => {
+        if (url.startsWith("/api/v1/agents/tasks")) return Promise.reject(new Error("boom"));
+        if (url.startsWith("/api/a2a/tasks"))
+          return okJson({ tasks: [], total: 0, limit: 200, offset: 0 });
+        return okJson({ offline: false, runners: [], tasks: [] });
+      });
+    const cloudAgent = () => latest!.snapshot.sources.find((s) => s.source === "cloud-agent");
+
+    // Poll 1: everything healthy — no staleSince.
+    await act(async () => {
+      root.render(
+        <HookProbe
+          onRender={(v) => {
+            latest = v;
+          }}
+        />
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(cloudAgent()?.ok).toBe(true);
+    expect(cloudAgent()?.staleSince).toBeUndefined();
+
+    // Poll 2: cloud-agent starts failing — staleSince stamped with this poll's time.
+    failCloudAgent();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    const firstStale = cloudAgent()?.staleSince;
+    expect(cloudAgent()?.ok).toBe(false);
+    expect(typeof firstStale).toBe("string");
+    const snapshotWhileStale = latest!.snapshot;
+
+    // Poll 3: still failing 5s later — the ORIGINAL staleSince must survive (not the latest
+    // poll's time), so the node keeps showing when the source first went stale and the
+    // snapshot content key does not churn every tick.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(cloudAgent()?.ok).toBe(false);
+    expect(cloudAgent()?.staleSince).toBe(firstStale);
+    expect(latest!.snapshot).toBe(snapshotWhileStale);
+
+    // Poll 4: source recovers — staleSince is dropped again.
+    fetchMock.mockImplementation(okFetchMock());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(cloudAgent()?.ok).toBe(true);
+    expect(cloudAgent()?.staleSince).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- `buildSourceStatuses` (`src/app/(dashboard)/dashboard/orchestration/hooks/useOrchestrationSnapshot.ts:63-90`) stamps every failed source with the current poll's `nowIso` (lines 76, 79, 87), and the poll loop replaced the whole list with `setStatuses(next)`. With the `sourceStale` message now live, `SourceNode` (`nodes/SourceNode.tsx:24-28`) therefore read "stale since <last poll>" instead of the first error, and because `snapshotContentKey` serialises `s.sources`, the key changed on every 5s/30s tick for as long as a source was down — re-minting the node/edge arrays the `React.memo` gate exists to protect.
- This is the second bullet of #12392 ("`staleSince` avança a cada poll"). Fix: a pure `carryStaleSince(prev, next)` helper (line 99) copies the previous `staleSince` onto a source that was already failing, applied through the functional update `setStatuses((prev) => carryStaleSince(prev, next))` (line 152). A source that recovers is pushed as `{ ok: true }` with no `staleSince`, so the next failure is stamped fresh; a first failure keeps this poll's `nowIso`. `buildSourceStatuses`, `mergeSnapshot` and the conductor `offline` branch are untouched.
- Deliberately out of scope: the other bullets of #12392 (toolbar debounce race, placeholder-only stale indicator in `mergeSnapshot`, a11y, `noMatches`, particle budget, drawer error banner, `toggleCsv`) — each is a separate surface and the issue stays open.

## Related Issues

- Refs #12392 (second checklist item; the issue has further bullets and stays open)

## Validation

- [x] Change type: UI (dashboard orchestration hook)
- [x] Focused tests and category gates from the golden path: `./node_modules/.bin/vitest run --config vitest.config.ts tests/unit/ui/useOrchestrationSnapshot.test.tsx` 8/8; `tests/unit/ui/orchestration*` + the hook test 89/89 (7 files); `node scripts/check/check-complexity-ratchets.mjs --base-ref origin/release/v3.8.51` OK (0 violations, cognitive 0); `npm run check:changelog-integrity` OK; `npm run typecheck:core` exit 0
- [ ] `npm run lint`
- [x] Reconciled with the current active release base `release/v3.8.51` (on top of #12508 / #12530); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

eslint on the two touched files exits 0 (also run by the lint-staged pre-commit hook).

## Tests Added Or Updated

- `tests/unit/ui/useOrchestrationSnapshot.test.tsx` — new case "keeps the first staleSince while a source keeps failing and clears it once it recovers (#12392)": ok → fail → fail → ok with fake timers. Asserts no `staleSince` on the healthy poll, a string on the first failure, the SAME value on the next failing poll 5s later (base fails here: `expected '…:18.927Z' to be '…:13.927Z'`), snapshot referential identity preserved across the two failing polls, and `staleSince` cleared on recovery. Red on the base (1 fail / 7 pass), green with the change (8/8). The seven existing cases are unchanged.

## Coverage Notes

- `src/app/(dashboard)/dashboard/orchestration/hooks/useOrchestrationSnapshot.ts`: `carryStaleSince` is exercised end-to-end through the hook in all three branches (first failure → keep own stamp; repeated failure → carry; recovery → drop) by the new case, plus the existing "failed source keeps the last good data" case.
- No touched file lost coverage.

## Reviewer Notes

- Behaviour change is limited to the `staleSince` value while a source stays down; `ok`, `error` and `offline` are still refreshed every poll. `error` text changing between polls will still bump the content key, which is intended (it is user-visible).
- The helper is exported only so it can be unit-tested directly later if wanted; nothing else imports it.
- Changelog fragment: `changelog.d/fixes/PENDING-orchestration-keep-first-stale-since.md` — rename `PENDING` to the PR number after opening.
