### PR TITLE
fix(orchestration): emit the real task status on non-status updates

### DIFF
--- a/changelog.d/fixes/12550-orchestration-emit-real-status.md
+++ b/changelog.d/fixes/12550-orchestration-emit-real-status.md
@@ -1,0 +1,1 @@
+- **fix(orchestration):** `updateCloudAgentTask` now publishes the task's real `status` on `agent.task.updated` when an update only touches `result`, `activities` or `error`, instead of the fabricated `"updated"` state, and stays silent when no row matched the id (#12550 — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-orchestration-emit-real-status.md
+++ b/changelog.d/fixes/PENDING-orchestration-emit-real-status.md
@@ -1,1 +1,0 @@
-- **fix(orchestration):** `updateCloudAgentTask` now publishes the task's real `status` on `agent.task.updated` when an update only touches `result`, `activities` or `error`, instead of the fabricated `"updated"` state, and stays silent when no row matched the id (#PENDING — thanks @pacocartones)

--- a/changelog.d/fixes/PENDING-orchestration-emit-real-status.md
+++ b/changelog.d/fixes/PENDING-orchestration-emit-real-status.md
@@ -1,0 +1,1 @@
+- **fix(orchestration):** `updateCloudAgentTask` now publishes the task's real `status` on `agent.task.updated` when an update only touches `result`, `activities` or `error`, instead of the fabricated `"updated"` state, and stays silent when no row matched the id (#PENDING — thanks @pacocartones)

--- a/src/lib/cloudAgent/db.ts
+++ b/src/lib/cloudAgent/db.ts
@@ -121,7 +121,10 @@ export function updateCloudAgentTask(
     WHERE id = @id
   `
   ).run({ id, ...validUpdates });
-  emitAgentTaskUpdated("cloud-agent", id, (validUpdates.status as string) ?? "updated");
+  // Publish the row's real status: an update that only touches result/activities/error must
+  // not fabricate a state the canvas has never heard of. No row means nothing was written.
+  const state = (validUpdates.status as string | undefined) ?? getCloudAgentTaskById(id)?.status;
+  if (state) emitAgentTaskUpdated("cloud-agent", id, state);
 }
 
 export function getCloudAgentTaskById(id: string): CloudAgentTaskRow | null {

--- a/tests/unit/agents-channel-publish.test.ts
+++ b/tests/unit/agents-channel-publish.test.ts
@@ -132,7 +132,9 @@ test("a throwing agent.task.updated listener does not break A2ATaskManager.creat
 
 // ── (b) cloud-agent DB writers ──────────────────────────────────────────────────────────
 
-function makeTaskRow(overrides: Partial<Parameters<typeof cloudAgentDb.insertCloudAgentTask>[0]> = {}) {
+function makeTaskRow(
+  overrides: Partial<Parameters<typeof cloudAgentDb.insertCloudAgentTask>[0]> = {}
+) {
   const now = new Date().toISOString();
   return {
     id: `task-${Math.random().toString(36).slice(2)}`,
@@ -192,9 +194,10 @@ test("updateCloudAgentTask emits agent.task.updated with the new status", () => 
   }
 });
 
-test("updateCloudAgentTask without a status field emits state 'updated'", () => {
+test("updateCloudAgentTask without a status field emits the row's current status", () => {
   const row = makeTaskRow({ status: "queued" });
   cloudAgentDb.insertCloudAgentTask(row);
+  cloudAgentDb.updateCloudAgentTask(row.id, { status: "running" });
 
   const events: AgentTaskUpdatedPayload[] = [];
   const unsubscribe = on("agent.task.updated", (payload) => events.push(payload));
@@ -204,7 +207,19 @@ test("updateCloudAgentTask without a status field emits state 'updated'", () => 
     assert.equal(events.length, 1);
     assert.equal(events[0].source, "cloud-agent");
     assert.equal(events[0].taskId, row.id);
-    assert.equal(events[0].state, "updated");
+    assert.equal(events[0].state, "running");
+  } finally {
+    unsubscribe();
+  }
+});
+
+test("updateCloudAgentTask on an unknown id does not emit (nothing was written)", () => {
+  const events: AgentTaskUpdatedPayload[] = [];
+  const unsubscribe = on("agent.task.updated", (payload) => events.push(payload));
+  try {
+    cloudAgentDb.updateCloudAgentTask("task-does-not-exist", { result: "partial output" });
+
+    assert.equal(events.length, 0);
   } finally {
     unsubscribe();
   }


### PR DESCRIPTION
## Summary

- `updateCloudAgentTask` (`src/lib/cloudAgent/db.ts:124`) published `state: "updated"` on `agent.task.updated` whenever the update carried no `status` field. The `activities` sync in `src/app/api/v1/agents/tasks/[id]/route.ts:175` and the `result`/`error` writes hit that path, so the `agents` WS channel carried a fabricated state that no `OrchState` maps to. This is the first bullet of the PR-B1 minors in #12392 ("read the row's real `status` or document `"updated"` as a sentinel").
- The writer now reads the row's current `status` after the `UPDATE` and publishes that; a status-carrying update still publishes the value it wrote, without the extra read. When no row matched the id nothing was written, so nothing is published either (the A2A `updateTask` already behaves this way for an unknown id).
- Deliberately out of scope: the duplicated `emitAgentTaskUpdated` helper (third bullet, it needs `a2a/taskManager.ts` and lands better after PR-B2), the no-op `status` write in the GET sync (fourth bullet), and the `hubProxy` module-level state (second bullet).

## Related Issues

- Refs #12392 (PR-B1 minors, first bullet)
- Related to #12409 (the `agents` WS channel that introduced the writer)

## Validation

- [x] Change type: DB (cloud-agent task writer, event payload)
- [x] Focused tests and category gates from the golden path: `tests/unit/agents-channel-publish.test.ts` 10/10 (`node --test`), `node scripts/check/check-complexity-ratchets.mjs --base-ref origin/release/v3.8.51` OK (0 violations in touched files), `npm run check:changelog-integrity` OK, `npm run typecheck:core` 0 errors
- [ ] `npm run lint`
- [x] Reconciled with the current active release base `release/v3.8.51`; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

eslint over the two touched files exits 0. Mutation: restoring the `?? "updated"` fallback fails the "emits the row's current status" case; dropping the `if (state)` guard fails the "unknown id does not emit" case.

## Tests Added Or Updated

- `tests/unit/agents-channel-publish.test.ts`: the "without a status field emits state 'updated'" case is replaced by "without a status field emits the row's current status" (queued → running, then a `result`-only update publishes `running`), and a new "on an unknown id does not emit" case. Red on the base (2 fail / 8 pass), green with the change (10/10). The other eight cases are unchanged.

## Coverage Notes

- `src/lib/cloudAgent/db.ts`: the new read-back branch and the no-row guard in `updateCloudAgentTask` are both exercised by the two cases above; the status-carrying branch stays covered by the existing "emits agent.task.updated with the new status" case.
- No touched file lost coverage.

## Reviewer Notes

- One extra `SELECT ... WHERE id = ?` per status-less update (the `activities` sync on drawer open, `result`/`error` writes). It runs on the primary key of a table that is already read on the same request path.
- Behaviour change for consumers of the `agents` channel: after a `result`-only write they now receive the task's real status (for example `running`) instead of `"updated"`; nothing in `src/` matched on the old sentinel.
