### PR TITLE
feat(api): add flatkey OpenAI-compatible aggregator provider

### DIFF
--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -218,6 +218,7 @@ import { kiroProvider } from "./registry/kiro/index.ts";
 import { openadapterProvider } from "./registry/openadapter/index.ts";
 import { ditProvider } from "./registry/dit/index.ts";
 import { tokenrouterProvider } from "./registry/tokenrouter/index.ts";
+import { flatkeyProvider } from "./registry/flatkey/index.ts";
 import { token_kioskProvider } from "./registry/token-kiosk/index.ts";
 import { grok_cliProvider } from "./registry/grok-cli/index.ts";
 import { codebuddy_cnProvider } from "./registry/codebuddy-cn/index.ts";
@@ -489,6 +490,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   openadapter: openadapterProvider,
   dit: ditProvider,
   tokenrouter: tokenrouterProvider,
+  flatkey: flatkeyProvider,
   "token-kiosk": token_kioskProvider,
   "grok-cli": grok_cliProvider,
   "codebuddy-cn": codebuddy_cnProvider,

--- a/open-sse/config/providers/registry/flatkey/index.ts
+++ b/open-sse/config/providers/registry/flatkey/index.ts
@@ -1,0 +1,73 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+// Flatkey (#4239 class) — OpenAI-compatible aggregator/router at router.flatkey.ai.
+// Bearer auth, OpenAI-compatible, working `/v1/models` (97 live models as of
+// 2026-09-03). Standard named OpenAI-style provider, zenmux shape.
+//
+// Seed list is a fallback ONLY — the provider is in NAMED_OPENAI_STYLE_PROVIDERS
+// so `/models` serves the live upstream catalog and falls back here on error.
+// All seed ids verified against the live catalog; contextLengths are canonical
+// upstream values (the /v1/models response does not carry them).
+export const flatkeyProvider: RegistryEntry = {
+  id: "flatkey",
+  alias: "fk",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://router.flatkey.ai/v1/chat/completions",
+  modelsUrl: "https://router.flatkey.ai/v1/models",
+  authType: "apikey",
+  authHeader: "bearer",
+  defaultContextLength: 128000,
+  models: [
+    {
+      id: "claude-sonnet-5",
+      name: "Claude Sonnet 5 (Flatkey)",
+      contextLength: 200000,
+      toolCalling: true,
+      supportsReasoning: true,
+    },
+    {
+      id: "claude-opus-5",
+      name: "Claude Opus 5 (Flatkey)",
+      contextLength: 200000,
+      toolCalling: true,
+      supportsReasoning: true,
+    },
+    {
+      id: "claude-haiku-4-5-20251001",
+      name: "Claude Haiku 4.5 (Flatkey)",
+      contextLength: 200000,
+      toolCalling: true,
+    },
+    { id: "gpt-5.5", name: "GPT-5.5 (Flatkey)", contextLength: 400000, toolCalling: true, supportsReasoning: true },
+    { id: "gpt-5.4-mini", name: "GPT-5.4 Mini (Flatkey)", contextLength: 400000, toolCalling: true, supportsReasoning: true },
+    {
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro (Flatkey)",
+      contextLength: 163840,
+      toolCalling: true,
+      supportsReasoning: true,
+    },
+    {
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash (Flatkey)",
+      contextLength: 163840,
+      toolCalling: true,
+      supportsReasoning: true,
+    },
+    {
+      id: "gemini-2.5-pro",
+      name: "Gemini 2.5 Pro (Flatkey)",
+      contextLength: 1048576,
+      toolCalling: true,
+      supportsReasoning: true,
+    },
+    {
+      id: "gemini-2.5-flash-lite",
+      name: "Gemini 2.5 Flash Lite (Flatkey)",
+      contextLength: 1048576,
+      toolCalling: true,
+    },
+    { id: "kimi-k2.6", name: "Kimi K2.6 (Flatkey)", contextLength: 262144, toolCalling: true, supportsReasoning: true },
+  ],
+};

--- a/src/app/api/providers/[id]/models/discovery/providerSets.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerSets.ts
@@ -24,6 +24,7 @@ export const NAMED_OPENAI_STYLE_PROVIDERS = new Set([
   "dit",
   "tokenrouter",
   "token-kiosk",
+  "flatkey",
   // provider-model-sweep (2026-06-19): same class as #3976/#4202/#4249 — keyed
   // openai-style providers with a real live `<baseUrl>/models` catalog, served
   // their small hardcoded seed because unclassified. Seed stays as offline fallback.

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -55,6 +55,7 @@ export const PROVIDER_ENDPOINTS = {
   dit: "https://api.dit.ai/v1/chat/completions",
   tokenrouter: "https://api.tokenrouter.com/v1/chat/completions",
   "token-kiosk": "https://agent-router.gaib.ai/v1/chat/completions",
+  flatkey: "https://router.flatkey.ai/v1/chat/completions",
   sumopod: "https://ai.sumopod.com/v1/chat/completions",
   x5lab: "https://api.x5lab.dev/v1/chat/completions",
   kenari: "https://kenari.id/v1/chat/completions",

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -946,6 +946,19 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
       "Get your Factory API key at https://app.factory.ai/settings/api-keys, then paste it as a Bearer token. OpenAI-compatible endpoint at https://api.factory.ai/v1.",
     passthroughModels: true,
   },
+  flatkey: {
+    id: "flatkey",
+    alias: "fk",
+    name: "Flatkey",
+    icon: "hub",
+    color: "#7C3AED",
+    textIcon: "FK",
+    website: "https://flatkey.ai",
+    authHint:
+      "Use your Flatkey API key in Authorization: Bearer <key>. Fully OpenAI-compatible. API base URL: https://router.flatkey.ai/v1.",
+    apiHint:
+      "Flatkey exposes an OpenAI-compatible chat completions endpoint at https://router.flatkey.ai/v1/chat/completions, plus a working /v1/models catalog (97 models as of 2026-09). OmniRoute uses the OpenAI protocol.",
+  },
   bluesminds: {
     id: "bluesminds",
     alias: "bm",

--- a/src/shared/constants/visionBridgeDefaults.ts
+++ b/src/shared/constants/visionBridgeDefaults.ts
@@ -22,6 +22,13 @@ const FORCED_VISION_BRIDGE_MODELS = new Set<string>([
   // vision model instead of being passed through to text-only backends.
   "tokenrouter/deepseek-v4-pro",
   "tokenrouter/deepseek-v4-flash",
+  // flatkey provider (router.flatkey.ai): same overstatement — deepseek-v4-pro
+  // and deepseek-v4-flash come back type:text from the live /v1/models catalog.
+  // Mirror tokenrouter so image requests reach the bridge VLM, not a text-only
+  // backend. Seed ids per fixindex: flatkey uses bare `deepseek-v4-flash`, not
+  // the `-0731` suffixed CheaperInference slug.
+  "flatkey/deepseek-v4-pro",
+  "flatkey/deepseek-v4-flash",
 ]);
 
 export function isVisionBridgeForcedModel(model: string | null | undefined): boolean {

--- a/tests/unit/provider-node-reserved-prefix.test.ts
+++ b/tests/unit/provider-node-reserved-prefix.test.ts
@@ -106,13 +106,13 @@ test("shared set excludes manual aliases that never intercept nodes at runtime",
   assert.equal(RESERVED_PROVIDER_PREFIXES.has("aq"), false);
 });
 
-test("shared set size matches full REGISTRY scan (395 unique prefixes)", () => {
+test("shared set size matches full REGISTRY scan (397 unique prefixes)", () => {
   // Count measured against release/v3.8.50 tip after this merge-batch boarded
   // #11333 (volcengine-coding-plan + volcengine-agent-plan, +4 ids/aliases) on
   // top of the 391 pinned post-upstream-65e81158a (was 329 at c68cda7df) —
   // the assertion pins that the set is a full REGISTRY walk, not a
   // hand-maintained list.
-  assert.equal(RESERVED_PREFIX_COUNT, 395);
+  assert.equal(RESERVED_PREFIX_COUNT, 397);
 });
 
 test("isReservedProviderPrefix rejects non-string input", () => {

--- a/tests/unit/visionBridgeDefaults.test.ts
+++ b/tests/unit/visionBridgeDefaults.test.ts
@@ -46,6 +46,10 @@ test("isVisionBridgeForcedModel forces tokenrouter deepseek models (text-only ba
   // data leaks to a backend that cannot process it.
   assert.strictEqual(isVisionBridgeForcedModel("tokenrouter/deepseek-v4-pro"), true);
   assert.strictEqual(isVisionBridgeForcedModel("tokenrouter/deepseek-v4-flash"), true);
+  // flatkey (router.flatkey.ai): deepseek models are text-only in the live
+  // /v1/models catalog, so they must be force-bridged too (mirrors tokenrouter).
+  assert.strictEqual(isVisionBridgeForcedModel("flatkey/deepseek-v4-pro"), true);
+  assert.strictEqual(isVisionBridgeForcedModel("flatkey/deepseek-v4-flash"), true);
 });
 
 test("getVisionBridgeConfig returns defaults when no settings provided", () => {


### PR DESCRIPTION
Register Flatkey (router.flatkey.ai) as a named OpenAI-style provider so it appears in the dashboard provider list with a live 97-model catalog and full routing.

- `REGISTRY` entry `open-sse/config/providers/registry/flatkey/` — OpenAI-compatible, bearer auth, live `/v1/models` discovery, seed catalog as offline fallback
- `NAMED_OPENAI_STYLE_PROVIDERS` — live catalog path
- `PROVIDER_ENDPOINTS` + dashboard gateway (id `flatkey`, alias `fk`)
- `FORCED_VISION_BRIDGE_MODELS` — deepseek-v4-pro/flash report `type:text` from the live catalog; mirror tokenrouter so image requests reach the bridge VLM
- `RESERVED_PREFIX_COUNT` snapshot 395→397 (flatkey id + `fk` alias, +2 to the REGISTRY walk)

Checks: provider-consistency OK (271 REGISTRY entries), typecheck clean, 41 unit tests pass (reserved-prefix, vision-bridge, openai-style-4239).