### PR TITLE
fix(sse): prefer cgroup PSI for chat admission

### DIFF
--- a/changelog.d/fixes/resource-pressure-cgroup-psi.md
+++ b/changelog.d/fixes/resource-pressure-cgroup-psi.md
@@ -1,0 +1,1 @@
+- **fix(sse):** chat admission PSI uses the container cgroup `memory.pressure` file instead of host-wide `/proc/pressure/memory`, so a swapping host no longer 503s an idle Docker/cgroup OmniRoute with `resource_pressure`; the host file remains the fallback when the cgroup sample is missing

--- a/docs/architecture/admission-lanes.md
+++ b/docs/architecture/admission-lanes.md
@@ -39,7 +39,10 @@ complementary; operators should know which one they are looking at.
   cgroup, PSI, OOM events — `open-sse/utils/resourcePressurePolicy.ts`) shortens
   the bounded wait under `high` pressure and sheds immediately with
   `503 resource_pressure` under `critical` pressure, before any bytes are even
-  ingested.
+  ingested. PSI is read from this unit's cgroup `memory.pressure` when present
+  (`open-sse/utils/resourcePressureSampler.ts`); `/proc/pressure/memory` is
+  host-wide and is only the fallback on bare metal / cgroup v1, so a swapping
+  host cannot 503 an idle container.
 - **Tuning:**
   - `OMNIROUTE_CHAT_MAX_INFLIGHT_BYTES` — override for the auto-derived byte budget
   - `OMNIROUTE_CHAT_MAX_HEAVY_IN_FLIGHT` — legacy request-count cap, opt-in only

--- a/open-sse/utils/resourcePressureSampler.ts
+++ b/open-sse/utils/resourcePressureSampler.ts
@@ -218,6 +218,13 @@ function parsePsi(text: string | null): ResourceSignals["psi"] {
   return matched ? result : null;
 }
 
+function firstParseablePsi(...samples: Array<string | null>): string | null {
+  for (const sample of samples) {
+    if (parsePsi(sample)) return sample;
+  }
+  return null;
+}
+
 export async function sampleResourceSignals(
   deps: SampleResourceSignalsDeps = {}
 ): Promise<ResourceSignals> {
@@ -249,6 +256,7 @@ export async function sampleResourceSignals(
         readText(path.join(cgroupDirectory, "memory.high")),
         readText(path.join(cgroupDirectory, "memory.events")),
         readText(path.join(cgroupDirectory, "memory.stat")),
+        readText(path.join(cgroupDirectory, "memory.pressure")),
       ])
     : null;
   // Named bindings instead of positional indices: the read order above is
@@ -260,8 +268,15 @@ export async function sampleResourceSignals(
     high: cgroupReads?.[2] ?? null,
     events: cgroupReads?.[3] ?? null,
     stat: cgroupReads?.[4] ?? null,
+    pressure: cgroupReads?.[5] ?? null,
   };
-  const psi = await readText("/proc/pressure/memory").catch(() => null);
+  // /proc/pressure/memory is host-wide. Inside Docker/cgroup that stalls the
+  // chat admission gate (503 resource_pressure) when the *machine* is swapping
+  // even if this container is idle. Prefer this unit's cgroup PSI; fall back
+  // to the host file only when the cgroup sample is missing or unparseable
+  // (bare metal, cgroup v1, or a stub filesystem).
+  const hostPsi = await readText("/proc/pressure/memory").catch(() => null);
+  const psi = firstParseablePsi(cgroupFiles.pressure, hostPsi);
 
   return {
     observedAtMs: (deps.nowMs ?? Date.now)(),

--- a/tests/unit/resource-pressure-sampler.test.ts
+++ b/tests/unit/resource-pressure-sampler.test.ts
@@ -162,6 +162,58 @@ describe("sampleResourceSignals", () => {
     assert.equal(signals.psi?.fullAvg10, 0.25);
   });
 
+  it("prefers cgroup memory.pressure over host-wide /proc/pressure/memory", async () => {
+    const fs = mapFs([
+      ["/proc/self/cgroup", "0::/slice/service\n"],
+      ["/proc/self/mountinfo", "43 34 0:35 / /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"],
+      ["/sys/fs/cgroup/slice/service/memory.current", `${800 * MiB}\n`],
+      ["/sys/fs/cgroup/slice/service/memory.max", `${GiB}\n`],
+      ["/sys/fs/cgroup/slice/service/memory.high", "max\n"],
+      ["/sys/fs/cgroup/slice/service/memory.events", "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n"],
+      ["/sys/fs/cgroup/slice/service/memory.stat", "anon 268435456\nfile 0\n"],
+      [
+        "/sys/fs/cgroup/slice/service/memory.pressure",
+        "some avg10=0.00 avg60=0.00 avg300=0.00 total=1\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=1\n",
+      ],
+      [
+        "/proc/pressure/memory",
+        "some avg10=41.00 avg60=20.00 avg300=10.00 total=9\nfull avg10=40.00 avg60=10.00 avg300=5.00 total=1\n",
+      ],
+    ]);
+    const signals = await sampleResourceSignals({
+      nowMs: () => 42,
+      memoryUsage: () => memoryUsage(250 * MiB),
+      heapStatistics: () => ({ heap_size_limit: GiB, used_heap_size: 250 * MiB }),
+      fs,
+    });
+    assert.equal(signals.psi?.someAvg10, 0);
+    assert.equal(signals.psi?.fullAvg10, 0);
+  });
+
+  it("falls back to /proc/pressure/memory when the cgroup pressure file is absent", async () => {
+    const fs = mapFs([
+      ["/proc/self/cgroup", "0::/slice/service\n"],
+      ["/proc/self/mountinfo", "43 34 0:35 / /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"],
+      ["/sys/fs/cgroup/slice/service/memory.current", `${800 * MiB}\n`],
+      ["/sys/fs/cgroup/slice/service/memory.max", `${GiB}\n`],
+      ["/sys/fs/cgroup/slice/service/memory.high", "max\n"],
+      ["/sys/fs/cgroup/slice/service/memory.events", "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n"],
+      ["/sys/fs/cgroup/slice/service/memory.stat", "anon 268435456\nfile 0\n"],
+      [
+        "/proc/pressure/memory",
+        "some avg10=1.50 avg60=2.00 avg300=3.25 total=9\nfull avg10=0.25 avg60=0.50 avg300=0.75 total=1\n",
+      ],
+    ]);
+    const signals = await sampleResourceSignals({
+      nowMs: () => 42,
+      memoryUsage: () => memoryUsage(250 * MiB),
+      heapStatistics: () => ({ heap_size_limit: GiB, used_heap_size: 250 * MiB }),
+      fs,
+    });
+    assert.equal(signals.psi?.someAvg10, 1.5);
+    assert.equal(signals.psi?.fullAvg10, 0.25);
+  });
+
   it("fails open when platform reads fail or return malformed values", async () => {
     const signals = await sampleResourceSignals({
       memoryUsage: () => memoryUsage(),


### PR DESCRIPTION
## Summary

Chat admission's resource-pressure sampler read host-wide `/proc/pressure/memory`. In Docker that file is the **machine**, not the container: a swapping host 503s idle OmniRoute with `resource_pressure` even when the cgroup is well under its limit (V8/cgroup ratios stay `normal`).

Prefer this unit's cgroup v2 `memory.pressure` when it parses. Keep `/proc/pressure/memory` only as fallback (bare metal, cgroup v1, missing file).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/resource-pressure-sampler.test.ts`
  - prefers cgroup PSI when both files exist and disagree
  - falls back to `/proc/pressure/memory` when the cgroup pressure file is absent
  - existing sampler cases still pass
- [ ] Docker host under memory PSI, container idle: `/v1/chat/completions` is not 503 `resource_pressure`