### PR TITLE
fix(quota): keep Antigravity Gemini usable when Claude weekly is empty

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -26,6 +26,8 @@ import {
 } from "../services/antigravityCredits.ts";
 import { persistCreditBalance, getAllPersistedCreditBalances } from "@/lib/db/creditBalance";
 import { setConnectionRateLimitUntil } from "@/lib/db/providers";
+import { lockModel } from "../services/accountFallback.ts";
+import { persistAntigravityFamilyCooldown } from "../services/antigravityFamilyCooldown.ts";
 import { getMitmAlias } from "@/lib/db/models";
 import {
   MAX_ANTIGRAVITY_OUTPUT_TOKENS,
@@ -250,8 +252,22 @@ export function createCreditsExtractionTransform(
  * cross-request and post-restart routing skips this connection until the
  * cooldown expires. Exported for unit testing. @internal
  */
-export function markConnectionQuotaExhausted(connectionId: string, retryAfterMs: number): void {
+export function markConnectionQuotaExhausted(
+  connectionId: string,
+  retryAfterMs: number,
+  model?: string | null
+): void {
   try {
+    if (model) {
+      lockModel("agy", connectionId, model, "quota_exhausted", retryAfterMs);
+      lockModel("antigravity", connectionId, model, "quota_exhausted", retryAfterMs);
+      void persistAntigravityFamilyCooldown({
+        connectionId,
+        model,
+        rateLimitedUntil: new Date(Date.now() + retryAfterMs).toISOString(),
+      }).catch(() => {});
+      return;
+    }
     setConnectionRateLimitUntil(connectionId, Date.now() + retryAfterMs);
   } catch {
     // DB write failure must never crash the request path
@@ -1620,7 +1636,7 @@ export class AntigravityExecutor extends BaseExecutor {
           updateAntigravityRemainingCredits
         );
         if (creditsResult) return { kind: "return", result: creditsResult };
-        if (retryMs) markConnectionQuotaExhausted(accountId, retryMs);
+        if (retryMs) markConnectionQuotaExhausted(accountId, retryMs, ctx.model);
       }
 
       return {

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -26,8 +26,7 @@ import {
 } from "../services/antigravityCredits.ts";
 import { persistCreditBalance, getAllPersistedCreditBalances } from "@/lib/db/creditBalance";
 import { setConnectionRateLimitUntil } from "@/lib/db/providers";
-import { lockModel } from "../services/accountFallback.ts";
-import { persistAntigravityFamilyCooldown } from "../services/antigravityFamilyCooldown.ts";
+import { markAntigravityModelQuotaExhausted } from "../services/antigravityFamilyCooldown.ts";
 import { getMitmAlias } from "@/lib/db/models";
 import {
   MAX_ANTIGRAVITY_OUTPUT_TOKENS,
@@ -247,31 +246,15 @@ export function createCreditsExtractionTransform(
   );
 }
 
-/**
- * Persist a quota-exhausted cooldown to the DB for `connectionId` so that
- * cross-request and post-restart routing skips this connection until the
- * cooldown expires. Exported for unit testing. @internal
- */
 export function markConnectionQuotaExhausted(
   connectionId: string,
   retryAfterMs: number,
   model?: string | null
 ): void {
   try {
-    if (model) {
-      lockModel("agy", connectionId, model, "quota_exhausted", retryAfterMs);
-      lockModel("antigravity", connectionId, model, "quota_exhausted", retryAfterMs);
-      void persistAntigravityFamilyCooldown({
-        connectionId,
-        model,
-        rateLimitedUntil: new Date(Date.now() + retryAfterMs).toISOString(),
-      }).catch(() => {});
-      return;
-    }
+    if (markAntigravityModelQuotaExhausted(connectionId, retryAfterMs, model)) return;
     setConnectionRateLimitUntil(connectionId, Date.now() + retryAfterMs);
-  } catch {
-    // DB write failure must never crash the request path
-  }
+  } catch {}
 }
 
 /**

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -650,6 +650,17 @@ export async function recordCoreOwnedAntigravityQuotaState({
       exactCooldownIsUpstreamReset: retryHintBypassesMaxCooldownMs(fallback.retryHintSource),
     }
   );
+  if (lockout.cooldownMs > 0) {
+    void import("./antigravityFamilyCooldown.ts")
+      .then(({ persistAntigravityFamilyCooldown }) =>
+        persistAntigravityFamilyCooldown({
+          connectionId,
+          model,
+          rateLimitedUntil: new Date(Date.now() + lockout.cooldownMs).toISOString(),
+        })
+      )
+      .catch(() => {});
+  }
   return { cooldownMs: lockout.cooldownMs, failureCount: lockout.failureCount };
 }
 
@@ -2393,7 +2404,9 @@ export function applyErrorState<T extends AccountState | null | undefined>(
     typeof connId === "string" &&
     connId.length > 0 &&
     effectiveCooldownMs > 0 &&
-    nextState.rateLimitedUntil
+    nextState.rateLimitedUntil &&
+    prov !== "antigravity" &&
+    prov !== "agy"
   ) {
     try {
       const untilMs = cooldownUntilMs(nextState.rateLimitedUntil);

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -650,7 +650,9 @@ export async function recordCoreOwnedAntigravityQuotaState({
       exactCooldownIsUpstreamReset: retryHintBypassesMaxCooldownMs(fallback.retryHintSource),
     }
   );
-  if (lockout.cooldownMs > 0) {
+  // RPM / burst 429s stay exact-model (#8630). Family PSD is only for
+  // weekly/plan quota so Gemini does not inherit a Claude window.
+  if (lockout.cooldownMs > 0 && isProviderExhaustedReason(fallback)) {
     void import("./antigravityFamilyCooldown.ts")
       .then(({ persistAntigravityFamilyCooldown }) =>
         persistAntigravityFamilyCooldown({

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -49,7 +49,8 @@ import {
 } from "../../src/shared/constants/providers";
 import { resolveUseUpstream429BreakerHints } from "../../src/shared/utils/providerHints";
 import { getCodexModelScope } from "../config/codexQuotaScopes.ts";
-import { getQuotaScopedModelForProvider } from "./antigravityQuotaFamily.ts";
+import { getQuotaScopedModelForProvider, isAntigravityQuotaProvider } from "./antigravityQuotaFamily.ts";
+import { persistAntigravityFamilyCooldownIfQuota } from "./antigravityFamilyCooldown.ts";
 import {
   classifyGeminiQuotaMetricFromText,
   isRpdExhausted,
@@ -650,18 +651,8 @@ export async function recordCoreOwnedAntigravityQuotaState({
       exactCooldownIsUpstreamReset: retryHintBypassesMaxCooldownMs(fallback.retryHintSource),
     }
   );
-  // RPM / burst 429s stay exact-model (#8630). Family PSD is only for
-  // weekly/plan quota so Gemini does not inherit a Claude window.
   if (lockout.cooldownMs > 0 && isProviderExhaustedReason(fallback)) {
-    void import("./antigravityFamilyCooldown.ts")
-      .then(({ persistAntigravityFamilyCooldown }) =>
-        persistAntigravityFamilyCooldown({
-          connectionId,
-          model,
-          rateLimitedUntil: new Date(Date.now() + lockout.cooldownMs).toISOString(),
-        })
-      )
-      .catch(() => {});
+    persistAntigravityFamilyCooldownIfQuota({ provider, connectionId, model, cooldownMs: lockout.cooldownMs, reason: "quota_exhausted" });
   }
   return { cooldownMs: lockout.cooldownMs, failureCount: lockout.failureCount };
 }
@@ -2402,14 +2393,7 @@ export function applyErrorState<T extends AccountState | null | undefined>(
   // (`markConnectionQuotaExhausted`) so a DB failure can never crash the
   // chat path. See issue #1 (per-account 429 cascade not persisting).
   const connId = (account as AccountState | null | undefined)?.id;
-  if (
-    typeof connId === "string" &&
-    connId.length > 0 &&
-    effectiveCooldownMs > 0 &&
-    nextState.rateLimitedUntil &&
-    prov !== "antigravity" &&
-    prov !== "agy"
-  ) {
+  if (typeof connId === "string" && connId.length > 0 && effectiveCooldownMs > 0 && nextState.rateLimitedUntil && !isAntigravityQuotaProvider(prov)) {
     try {
       const untilMs = cooldownUntilMs(nextState.rateLimitedUntil);
       if (Number.isFinite(untilMs) && untilMs > Date.now()) {

--- a/open-sse/services/antigravityFamilyCooldown.ts
+++ b/open-sse/services/antigravityFamilyCooldown.ts
@@ -3,7 +3,10 @@
  * on the connection row, without cooling the whole account.
  */
 import { lockModel, isModelLocked } from "./accountFallback.ts";
-import { getAntigravityQuotaFamily } from "./antigravityQuotaFamily.ts";
+import {
+  getAntigravityQuotaFamily,
+  isAntigravityQuotaProvider,
+} from "./antigravityQuotaFamily.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -13,10 +16,6 @@ function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as JsonRecord)
     : {};
-}
-
-function isAntigravityProvider(provider: string | null | undefined): boolean {
-  return provider === "antigravity" || provider === "agy";
 }
 
 function parseUntilMs(value: unknown): number {
@@ -47,7 +46,7 @@ export async function persistAntigravityFamilyCooldown(params: {
   const conn = (await getProviderConnectionById(params.connectionId)) as
     | { provider?: string; providerSpecificData?: JsonRecord | null }
     | null;
-  if (!conn || !isAntigravityProvider(conn.provider ?? null)) return null;
+  if (!conn || !isAntigravityQuotaProvider(conn.provider ?? null)) return null;
 
   const psd = asRecord(conn.providerSpecificData);
   const untils = asRecord(psd[FAMILY_PSD_KEY]);
@@ -66,12 +65,45 @@ export async function persistAntigravityFamilyCooldown(params: {
   return nextPsd;
 }
 
+/** Fire-and-forget family PSD write. RPM/burst 429s must pass reason !== quota_exhausted. */
+export function persistAntigravityFamilyCooldownIfQuota(params: {
+  provider?: string | null;
+  connectionId: string;
+  model?: string | null;
+  cooldownMs: number;
+  reason?: string | null;
+}): void {
+  if (!isAntigravityQuotaProvider(params.provider)) return;
+  if (!params.model?.trim() || params.cooldownMs <= 0) return;
+  if (params.reason != null && params.reason !== "quota_exhausted") return;
+  void persistAntigravityFamilyCooldown({
+    connectionId: params.connectionId,
+    model: params.model,
+    rateLimitedUntil: new Date(Date.now() + params.cooldownMs).toISOString(),
+  }).catch(() => {});
+}
+
+export async function persistAntigravityPreflightFamilyLock(params: {
+  provider: string;
+  connectionId: string;
+  model: string;
+  unavailableUntil: string;
+}): Promise<void> {
+  const cooldownMs = Math.max(0, Date.parse(params.unavailableUntil) - Date.now());
+  lockModel(params.provider, params.connectionId, params.model, "quota_exhausted", cooldownMs);
+  await persistAntigravityFamilyCooldown({
+    connectionId: params.connectionId,
+    model: params.model,
+    rateLimitedUntil: params.unavailableUntil,
+  });
+}
+
 export function rehydrateAntigravityFamilyLocks(
   provider: string,
   connectionId: string,
   providerSpecificData: JsonRecord | null | undefined
 ): void {
-  if (!isAntigravityProvider(provider)) return;
+  if (!isAntigravityQuotaProvider(provider)) return;
   const untils = asRecord(asRecord(providerSpecificData)[FAMILY_PSD_KEY]);
   const now = Date.now();
   for (const family of ["gemini", "claude"] as const) {
@@ -84,4 +116,37 @@ export function rehydrateAntigravityFamilyLocks(
       lockModel(lockProvider, connectionId, model, "quota_exhausted", remainingMs);
     }
   }
+}
+
+export function rehydrateAntigravityFamilyLocksForConnections(
+  provider: string,
+  connections: Array<{ id: string; providerSpecificData?: unknown }>
+): void {
+  if (!isAntigravityQuotaProvider(provider)) return;
+  for (const conn of connections) {
+    rehydrateAntigravityFamilyLocks(
+      provider,
+      conn.id,
+      conn.providerSpecificData as JsonRecord | null | undefined
+    );
+  }
+}
+
+/** Family lock for executor quota exhaustion. Returns false when model is absent. */
+export function markAntigravityModelQuotaExhausted(
+  connectionId: string,
+  retryAfterMs: number,
+  model?: string | null
+): boolean {
+  if (!model) return false;
+  lockModel("agy", connectionId, model, "quota_exhausted", retryAfterMs);
+  lockModel("antigravity", connectionId, model, "quota_exhausted", retryAfterMs);
+  persistAntigravityFamilyCooldownIfQuota({
+    provider: "agy",
+    connectionId,
+    model,
+    cooldownMs: retryAfterMs,
+    reason: "quota_exhausted",
+  });
+  return true;
 }

--- a/open-sse/services/antigravityFamilyCooldown.ts
+++ b/open-sse/services/antigravityFamilyCooldown.ts
@@ -1,0 +1,87 @@
+/**
+ * Persist Antigravity/agy quota cooldowns per model family (gemini vs claude)
+ * on the connection row, without cooling the whole account.
+ */
+import { lockModel, isModelLocked } from "./accountFallback.ts";
+import { getAntigravityQuotaFamily } from "./antigravityQuotaFamily.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+const FAMILY_PSD_KEY = "antigravityFamilyRateLimitedUntil";
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+function isAntigravityProvider(provider: string | null | undefined): boolean {
+  return provider === "antigravity" || provider === "agy";
+}
+
+function parseUntilMs(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const ms = /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : Date.parse(value);
+    return Number.isFinite(ms) ? ms : NaN;
+  }
+  return NaN;
+}
+
+function dummyModelForFamily(family: "gemini" | "claude"): string {
+  return family === "gemini" ? "gemini-family-lock" : "claude-family-lock";
+}
+
+export async function persistAntigravityFamilyCooldown(params: {
+  connectionId: string;
+  model: string;
+  rateLimitedUntil: string;
+}): Promise<JsonRecord | null> {
+  if (!params.model.trim()) return null;
+  const family = getAntigravityQuotaFamily(params.model);
+  if (family === "other") return null;
+
+  const { getProviderConnectionById, updateProviderConnection } = await import(
+    "@/lib/db/providers"
+  );
+  const conn = (await getProviderConnectionById(params.connectionId)) as
+    | { provider?: string; providerSpecificData?: JsonRecord | null }
+    | null;
+  if (!conn || !isAntigravityProvider(conn.provider ?? null)) return null;
+
+  const psd = asRecord(conn.providerSpecificData);
+  const untils = asRecord(psd[FAMILY_PSD_KEY]);
+  const existingMs = parseUntilMs(untils[family]);
+  const nextMs = parseUntilMs(params.rateLimitedUntil);
+  if (!Number.isFinite(nextMs)) return psd;
+  if (Number.isFinite(existingMs) && existingMs > Date.now() && existingMs >= nextMs) {
+    return psd;
+  }
+
+  const nextPsd: JsonRecord = {
+    ...psd,
+    [FAMILY_PSD_KEY]: { ...untils, [family]: params.rateLimitedUntil },
+  };
+  await updateProviderConnection(params.connectionId, { providerSpecificData: nextPsd });
+  return nextPsd;
+}
+
+export function rehydrateAntigravityFamilyLocks(
+  provider: string,
+  connectionId: string,
+  providerSpecificData: JsonRecord | null | undefined
+): void {
+  if (!isAntigravityProvider(provider)) return;
+  const untils = asRecord(asRecord(providerSpecificData)[FAMILY_PSD_KEY]);
+  const now = Date.now();
+  for (const family of ["gemini", "claude"] as const) {
+    const untilMs = parseUntilMs(untils[family]);
+    if (!Number.isFinite(untilMs) || untilMs <= now) continue;
+    const model = dummyModelForFamily(family);
+    const remainingMs = untilMs - now;
+    for (const lockProvider of [provider, provider === "agy" ? "antigravity" : "agy"]) {
+      if (isModelLocked(lockProvider, connectionId, model)) continue;
+      lockModel(lockProvider, connectionId, model, "quota_exhausted", remainingMs);
+    }
+  }
+}

--- a/open-sse/services/antigravityFamilyCooldown.ts
+++ b/open-sse/services/antigravityFamilyCooldown.ts
@@ -2,7 +2,7 @@
  * Persist Antigravity/agy quota cooldowns per model family (gemini vs claude)
  * on the connection row, without cooling the whole account.
  */
-import { lockModel, isModelLocked } from "./accountFallback.ts";
+import { lockModel } from "./accountFallback.ts";
 import {
   getAntigravityQuotaFamily,
   isAntigravityQuotaProvider,
@@ -29,6 +29,16 @@ function parseUntilMs(value: unknown): number {
 
 function dummyModelForFamily(family: "gemini" | "claude"): string {
   return family === "gemini" ? "gemini-family-lock" : "claude-family-lock";
+}
+
+function lockAntigravityFamilyModel(
+  connectionId: string,
+  model: string,
+  reason: string,
+  cooldownMs: number
+): void {
+  lockModel("agy", connectionId, model, reason, cooldownMs);
+  lockModel("antigravity", connectionId, model, reason, cooldownMs);
 }
 
 export async function persistAntigravityFamilyCooldown(params: {
@@ -90,7 +100,7 @@ export async function persistAntigravityPreflightFamilyLock(params: {
   unavailableUntil: string;
 }): Promise<void> {
   const cooldownMs = Math.max(0, Date.parse(params.unavailableUntil) - Date.now());
-  lockModel(params.provider, params.connectionId, params.model, "quota_exhausted", cooldownMs);
+  lockAntigravityFamilyModel(params.connectionId, params.model, "quota_exhausted", cooldownMs);
   await persistAntigravityFamilyCooldown({
     connectionId: params.connectionId,
     model: params.model,
@@ -111,10 +121,7 @@ export function rehydrateAntigravityFamilyLocks(
     if (!Number.isFinite(untilMs) || untilMs <= now) continue;
     const model = dummyModelForFamily(family);
     const remainingMs = untilMs - now;
-    for (const lockProvider of [provider, provider === "agy" ? "antigravity" : "agy"]) {
-      if (isModelLocked(lockProvider, connectionId, model)) continue;
-      lockModel(lockProvider, connectionId, model, "quota_exhausted", remainingMs);
-    }
+    lockAntigravityFamilyModel(connectionId, model, "quota_exhausted", remainingMs);
   }
 }
 
@@ -139,8 +146,7 @@ export function markAntigravityModelQuotaExhausted(
   model?: string | null
 ): boolean {
   if (!model) return false;
-  lockModel("agy", connectionId, model, "quota_exhausted", retryAfterMs);
-  lockModel("antigravity", connectionId, model, "quota_exhausted", retryAfterMs);
+  lockAntigravityFamilyModel(connectionId, model, "quota_exhausted", retryAfterMs);
   persistAntigravityFamilyCooldownIfQuota({
     provider: "agy",
     connectionId,

--- a/open-sse/services/antigravityQuotaFamily.ts
+++ b/open-sse/services/antigravityQuotaFamily.ts
@@ -59,6 +59,36 @@ export function isAntigravityQuotaProvider(provider: string | null | undefined):
   return provider === "antigravity" || provider === "agy";
 }
 
+export function quotaWindowNamesForScope(
+  names: string[],
+  scope?: { provider?: string | null; requestedModel?: string | null }
+): string[] {
+  if (!scope?.requestedModel || !isAntigravityQuotaProvider(scope.provider)) return names;
+  const scoped = selectAntigravityQuotaWindowNames(names, scope.requestedModel);
+  return scoped.length > 0 ? scoped : names;
+}
+
+/** Min remaining % across scoped windows, or 100 when an Antigravity family scope matched none. */
+export function remainingPercentFromQuotaWindows(
+  rawWindows: Record<string, unknown>,
+  scope?: { provider?: string | null; requestedModel?: string | null }
+): number | null {
+  const names = Object.keys(rawWindows);
+  const namesToScan = quotaWindowNamesForScope(names, scope);
+  let minRemaining: number | null = null;
+  for (const name of namesToScan) {
+    const windowInfo = rawWindows[name];
+    if (!windowInfo || typeof windowInfo !== "object") continue;
+    const percentUsed = Number((windowInfo as Record<string, unknown>).percentUsed);
+    if (!Number.isFinite(percentUsed)) continue;
+    const remaining = Math.max(0, Math.min(100, (1 - percentUsed) * 100));
+    minRemaining = minRemaining === null ? remaining : Math.min(minRemaining, remaining);
+  }
+  if (minRemaining !== null) return minRemaining;
+  if (scope?.requestedModel && namesToScan !== names) return 100;
+  return null;
+}
+
 /**
  * Windows that belong to the requested Antigravity family. Claude weekly must
  * not ride along on a Gemini request (and the reverse).

--- a/open-sse/services/antigravityQuotaFamily.ts
+++ b/open-sse/services/antigravityQuotaFamily.ts
@@ -54,3 +54,47 @@ export function getQuotaScopeLabelForProvider(
   if (provider !== "antigravity" && provider !== "agy") return "model";
   return getAntigravityQuotaFamily(model) === "other" ? "model" : "family";
 }
+
+export function isAntigravityQuotaProvider(provider: string | null | undefined): boolean {
+  return provider === "antigravity" || provider === "agy";
+}
+
+/**
+ * Windows that belong to the requested Antigravity family. Claude weekly must
+ * not ride along on a Gemini request (and the reverse).
+ */
+export function selectAntigravityQuotaWindowNames(
+  quotaNames: string[],
+  requestedModel: string | null | undefined
+): string[] {
+  if (!requestedModel) return quotaNames;
+  const requestedFamily = getAntigravityQuotaFamily(requestedModel);
+  const cleanRequestedModel = requestedModel.replace(/^(antigravity|agy)\//, "");
+  const bareModel = cleanRequestedModel.includes("/")
+    ? cleanRequestedModel.slice(cleanRequestedModel.lastIndexOf("/") + 1)
+    : cleanRequestedModel;
+
+  if (requestedFamily === "other") {
+    return quotaNames.filter((windowName) => {
+      const bare = windowName.replace(/^(antigravity|agy)\//, "");
+      return bare === bareModel || bare === cleanRequestedModel;
+    });
+  }
+
+  const familyAggregates =
+    requestedFamily === "gemini"
+      ? ["gemini_weekly"]
+      : requestedFamily === "claude"
+        ? ["claude_gpt_weekly"]
+        : [];
+
+  const exactWindows = quotaNames.filter((windowName) => {
+    const bare = windowName.replace(/^(antigravity|agy)\//, "");
+    return bare === bareModel;
+  });
+  const aggregateWindows = familyAggregates.filter((key) => quotaNames.includes(key));
+  const scoped = [...exactWindows, ...aggregateWindows];
+  if (scoped.length > 0) return scoped;
+
+  return quotaNames.filter((windowName) => getAntigravityQuotaFamily(windowName) === requestedFamily);
+}

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -613,10 +613,7 @@ export async function buildAutoCandidates(
         const quota = await quotaPromises.get(quotaKey)!;
         resetWindowAffinity = calculateResetWindowAffinity(quota, resetWindowConfig);
         if (!quotaCutoffBlocked) {
-          quotaRemaining = quotaRemainingPercentFromQuota(quota, {
-            provider,
-            requestedModel: modelStr,
-          });
+          quotaRemaining = quotaRemainingPercentFromQuota(quota, { provider, requestedModel: modelStr });
         }
         if (!quotaCutoffBlocked && quotaCutoffEnabled) {
           const cutoffDecision = evaluateQuotaCutoff(
@@ -1383,8 +1380,7 @@ async function handleComboChatInner({
             resilienceSettings,
             quotaCutoffResetWindowConfig,
             combo.name,
-            log,
-            modelStr
+            log, modelStr
           );
           if (quotaCutoff.blocked) {
             log.info(
@@ -4020,8 +4016,5 @@ async function handleRoundRobinCombo({
   }
 
   log.warn("COMBO-RR", `All models failed | ${msg}`);
-  return new Response(JSON.stringify({ error: { message: msg } }), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
+  return new Response(JSON.stringify({ error: { message: msg } }), { status, headers: { "Content-Type": "application/json" } });
 }

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -613,12 +613,16 @@ export async function buildAutoCandidates(
         const quota = await quotaPromises.get(quotaKey)!;
         resetWindowAffinity = calculateResetWindowAffinity(quota, resetWindowConfig);
         if (!quotaCutoffBlocked) {
-          quotaRemaining = quotaRemainingPercentFromQuota(quota);
+          quotaRemaining = quotaRemainingPercentFromQuota(quota, {
+            provider,
+            requestedModel: modelStr,
+          });
         }
         if (!quotaCutoffBlocked && quotaCutoffEnabled) {
           const cutoffDecision = evaluateQuotaCutoff(
             quota as QuotaInfo | null,
-            buildAutoQuotaThresholds(provider, connection, resilienceSettings)
+            buildAutoQuotaThresholds(provider, connection, resilienceSettings),
+            { provider, requestedModel: modelStr }
           );
           if (!cutoffDecision.proceed) {
             quotaCutoffBlocked = true;
@@ -1379,7 +1383,8 @@ async function handleComboChatInner({
             resilienceSettings,
             quotaCutoffResetWindowConfig,
             combo.name,
-            log
+            log,
+            modelStr
           );
           if (quotaCutoff.blocked) {
             log.info(

--- a/open-sse/services/combo/comboPredicates.ts
+++ b/open-sse/services/combo/comboPredicates.ts
@@ -7,6 +7,7 @@
  */
 
 import { EXECUTOR_CONTRACT_VIOLATION_CODE } from "../../config/constants.ts";
+import { selectAntigravityQuotaWindowNames } from "../antigravityQuotaFamily.ts";
 import { errorResponse } from "../../utils/error.ts";
 import { parseModel } from "../model.ts";
 import { isSelfInflictedUpstreamTimeout } from "../../handlers/chatCore/cooldownClassification.ts";
@@ -431,15 +432,25 @@ export function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, value));
 }
 
-export function quotaRemainingPercentFromQuota(quota: unknown): number {
+export function quotaRemainingPercentFromQuota(
+  quota: unknown,
+  scope?: { provider?: string | null; requestedModel?: string | null }
+): number {
   if (!quota || typeof quota !== "object") return 100;
   const record = quota as Record<string, unknown>;
-  if (record.limitReached === true) return 0;
 
   const windows = record.windows;
   if (windows && typeof windows === "object" && !Array.isArray(windows)) {
+    const rawWindows = windows as Record<string, unknown>;
+    const names = Object.keys(rawWindows);
+    const scopedNames =
+      scope?.requestedModel && (scope.provider === "agy" || scope.provider === "antigravity")
+        ? selectAntigravityQuotaWindowNames(names, scope.requestedModel)
+        : names;
+    const namesToScan = scopedNames.length > 0 ? scopedNames : names;
     let minRemaining: number | null = null;
-    for (const windowInfo of Object.values(windows as Record<string, unknown>)) {
+    for (const name of namesToScan) {
+      const windowInfo = rawWindows[name];
       if (!windowInfo || typeof windowInfo !== "object") continue;
       const percentUsed = Number((windowInfo as Record<string, unknown>).percentUsed);
       if (!Number.isFinite(percentUsed)) continue;
@@ -447,7 +458,12 @@ export function quotaRemainingPercentFromQuota(quota: unknown): number {
       minRemaining = minRemaining === null ? remaining : Math.min(minRemaining, remaining);
     }
     if (minRemaining !== null) return minRemaining;
+    if (scope?.requestedModel && (scope.provider === "agy" || scope.provider === "antigravity")) {
+      return 100;
+    }
   }
+
+  if (record.limitReached === true) return 0;
 
   const percentUsed = Number(record.percentUsed);
   if (Number.isFinite(percentUsed)) return clampPercent((1 - percentUsed) * 100);

--- a/open-sse/services/combo/comboPredicates.ts
+++ b/open-sse/services/combo/comboPredicates.ts
@@ -7,7 +7,7 @@
  */
 
 import { EXECUTOR_CONTRACT_VIOLATION_CODE } from "../../config/constants.ts";
-import { selectAntigravityQuotaWindowNames } from "../antigravityQuotaFamily.ts";
+import { remainingPercentFromQuotaWindows } from "../antigravityQuotaFamily.ts";
 import { errorResponse } from "../../utils/error.ts";
 import { parseModel } from "../model.ts";
 import { isSelfInflictedUpstreamTimeout } from "../../handlers/chatCore/cooldownClassification.ts";
@@ -441,26 +441,11 @@ export function quotaRemainingPercentFromQuota(
 
   const windows = record.windows;
   if (windows && typeof windows === "object" && !Array.isArray(windows)) {
-    const rawWindows = windows as Record<string, unknown>;
-    const names = Object.keys(rawWindows);
-    const scopedNames =
-      scope?.requestedModel && (scope.provider === "agy" || scope.provider === "antigravity")
-        ? selectAntigravityQuotaWindowNames(names, scope.requestedModel)
-        : names;
-    const namesToScan = scopedNames.length > 0 ? scopedNames : names;
-    let minRemaining: number | null = null;
-    for (const name of namesToScan) {
-      const windowInfo = rawWindows[name];
-      if (!windowInfo || typeof windowInfo !== "object") continue;
-      const percentUsed = Number((windowInfo as Record<string, unknown>).percentUsed);
-      if (!Number.isFinite(percentUsed)) continue;
-      const remaining = clampPercent((1 - percentUsed) * 100);
-      minRemaining = minRemaining === null ? remaining : Math.min(minRemaining, remaining);
-    }
-    if (minRemaining !== null) return minRemaining;
-    if (scope?.requestedModel && (scope.provider === "agy" || scope.provider === "antigravity")) {
-      return 100;
-    }
+    const fromWindows = remainingPercentFromQuotaWindows(
+      windows as Record<string, unknown>,
+      scope
+    );
+    if (fromWindows !== null) return fromWindows;
   }
 
   if (record.limitReached === true) return 0;

--- a/open-sse/services/combo/nativeCodexTurnPin.ts
+++ b/open-sse/services/combo/nativeCodexTurnPin.ts
@@ -245,7 +245,8 @@ export async function isPinnedTargetModelScopedUnusable(args: {
       resilienceSettings,
       quotaCutoffResetWindowConfig,
       comboName,
-      log ?? { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+      log ?? { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      target.modelStr
     );
     if (cutoff.blocked) return true;
   }

--- a/open-sse/services/combo/quotaExhaustionCutoff.ts
+++ b/open-sse/services/combo/quotaExhaustionCutoff.ts
@@ -97,7 +97,8 @@ export async function resolveQuotaExhaustionCutoffForTarget(
   resilienceSettings: ResilienceSettings | null | undefined,
   resetWindowConfig: ResetWindowConfig,
   comboName: string,
-  log: { debug?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void }
+  log: { debug?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void },
+  requestedModel?: string | null
 ): Promise<{ blocked: boolean; reason?: string }> {
   const quotaCutoffEnabled =
     (resilienceSettings ?? resolveResilienceSettings(null))?.quotaPreflight?.enabled === true;
@@ -126,7 +127,8 @@ export async function resolveQuotaExhaustionCutoffForTarget(
     });
     const cutoffDecision = evaluateQuotaCutoff(
       quota as QuotaInfo | null,
-      buildAutoQuotaThresholds(provider, connection, resilienceSettings)
+      buildAutoQuotaThresholds(provider, connection, resilienceSettings),
+      { provider, requestedModel: requestedModel ?? null }
     );
     if (!cutoffDecision.proceed) {
       return { blocked: true, reason: cutoffDecision.reason || "quota_exhausted" };

--- a/open-sse/services/quotaPreflight.ts
+++ b/open-sse/services/quotaPreflight.ts
@@ -21,12 +21,22 @@
 import { isCompatibleProviderConnectionId } from "@/shared/utils/compatibleProviderId";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
 import { fetchNewApiAggregatorQuota } from "./newApiAggregatorQuotaFetcher.ts";
+import {
+  isAntigravityQuotaProvider,
+  selectAntigravityQuotaWindowNames,
+} from "./antigravityQuotaFamily.ts";
 
 export interface PreflightQuotaResult {
   proceed: boolean;
   reason?: string;
   quotaPercent?: number;
   resetAt?: string | null;
+  windowName?: string | null;
+}
+
+export interface QuotaCutoffScope {
+  provider?: string | null;
+  requestedModel?: string | null;
 }
 
 export interface QuotaWindowInfo {
@@ -156,13 +166,34 @@ function isRemainingAtOrBelowThreshold(
   return remainingPercent <= thresholdPercent + REMAINING_PERCENT_EPSILON;
 }
 
-function exhaustedResult(quotaPercent: number, resetAt: string | null): PreflightQuotaResult {
+function exhaustedResult(
+  quotaPercent: number,
+  resetAt: string | null,
+  windowName?: string | null
+): PreflightQuotaResult {
   return {
     proceed: false,
     reason: "quota_exhausted",
     quotaPercent,
     resetAt,
+    windowName: windowName ?? null,
   };
+}
+
+function windowsForScope(
+  windows: NonNullable<QuotaInfo["windows"]>,
+  scope?: QuotaCutoffScope
+): NonNullable<QuotaInfo["windows"]> {
+  if (!scope?.requestedModel || !isAntigravityQuotaProvider(scope.provider ?? null)) {
+    return windows;
+  }
+  const selected = selectAntigravityQuotaWindowNames(Object.keys(windows), scope.requestedModel);
+  if (selected.length === 0) return windows;
+  const scoped: NonNullable<QuotaInfo["windows"]> = {};
+  for (const name of selected) {
+    if (windows[name]) scoped[name] = windows[name];
+  }
+  return Object.keys(scoped).length > 0 ? scoped : windows;
 }
 
 function limitReachedResult(quota: QuotaInfo): PreflightQuotaResult {
@@ -201,7 +232,9 @@ function quotaWindowCutoffResult(
     worstResetAt = windowInfo.resetAt ?? null;
   }
 
-  return worstWindow === null ? null : exhaustedResult(worstUsedPercent, worstResetAt);
+  return worstWindow === null
+    ? null
+    : exhaustedResult(worstUsedPercent, worstResetAt, worstWindow);
 }
 
 function quotaPercentCutoffResult(
@@ -227,21 +260,27 @@ function quotaPercentCutoffResult(
  */
 export function evaluateQuotaCutoff(
   quota: QuotaInfo | null | undefined,
-  thresholds?: PreflightQuotaThresholds
+  thresholds?: PreflightQuotaThresholds,
+  scope?: QuotaCutoffScope
 ): PreflightQuotaResult {
   if (!quota) return { proceed: true };
-  if (quota.limitReached === true) return limitReachedResult(quota);
 
   const windows = quota.windows;
   if (windows && Object.keys(windows).length > 0) {
-    return (
-      quotaWindowCutoffResult(windows, thresholds) ?? {
-        proceed: true,
-        quotaPercent: quota.percentUsed,
-      }
-    );
+    const scopedWindows = windowsForScope(windows, scope);
+    const cutoff = quotaWindowCutoffResult(scopedWindows, thresholds);
+    if (cutoff) return cutoff;
+    if (isAntigravityQuotaProvider(scope?.provider ?? null) && scope?.requestedModel) {
+      return { proceed: true, quotaPercent: quota.percentUsed };
+    }
+    if (quota.limitReached === true) return limitReachedResult(quota);
+    return {
+      proceed: true,
+      quotaPercent: quota.percentUsed,
+    };
   }
 
+  if (quota.limitReached === true) return limitReachedResult(quota);
   return quotaPercentCutoffResult(quota, thresholds);
 }
 
@@ -297,61 +336,40 @@ export async function preflightQuota(
     return { proceed: true };
   }
 
-  if (quota.limitReached === true) {
-    return limitReachedResult(quota);
-  }
-
-  // Per-window evaluation — only when the fetcher surfaces a windows map.
-  // We block as soon as ANY single window's remaining quota drops to its
-  // configured cutoff or below; warnings are logged independently per window.
-  if (quota.windows && Object.keys(quota.windows).length > 0) {
-    let worstUsedPercent = 0;
-    let worstWindow: string | null = null;
-    let worstResetAt: string | null = null;
-    for (const [windowName, windowInfo] of Object.entries(quota.windows)) {
-      const minRemainingPercent = resolveOrDefault(
-        thresholds?.resolveMinRemainingPercent,
-        windowName,
-        DEFAULT_MIN_REMAINING_PERCENT
-      );
+  const requestedModel =
+    typeof connection.requestedModel === "string" ? connection.requestedModel : null;
+  const scope: QuotaCutoffScope = { provider, requestedModel };
+  const windows = quota.windows;
+  if (windows && Object.keys(windows).length > 0) {
+    const scopedWindows = windowsForScope(windows, scope);
+    for (const [windowName, windowInfo] of Object.entries(scopedWindows)) {
       const warnRemainingPercent = resolveOrDefault(
         thresholds?.resolveWarnRemainingPercent,
         windowName,
         DEFAULT_WARN_REMAINING_PERCENT
       );
       const remainingPercent = remainingPercentFrom(windowInfo.percentUsed);
-
-      if (isRemainingAtOrBelowThreshold(remainingPercent, minRemainingPercent)) {
-        // Track the most-depleted blocking window so the response can name it.
-        if (windowInfo.percentUsed > worstUsedPercent) {
-          worstUsedPercent = windowInfo.percentUsed;
-          worstWindow = windowName;
-          worstResetAt = windowInfo.resetAt ?? null;
-        } else if (worstWindow === null) {
-          worstWindow = windowName;
-          worstResetAt = windowInfo.resetAt ?? null;
-        }
-      } else if (isRemainingAtOrBelowThreshold(remainingPercent, warnRemainingPercent)) {
+      if (isRemainingAtOrBelowThreshold(remainingPercent, warnRemainingPercent)) {
         console.warn(
           `[QuotaPreflight] ${provider}/${connectionId} ${windowName}: ${remainingPercent.toFixed(1)}% remaining — approaching cutoff`
         );
       }
     }
+  }
 
-    if (worstWindow !== null) {
-      const worstRemaining = remainingPercentFrom(worstUsedPercent);
-      console.info(
-        `[QuotaPreflight] ${provider}/${connectionId} ${worstWindow}: ${worstRemaining.toFixed(1)}% remaining — switching`
-      );
-      return {
-        proceed: false,
-        reason: "quota_exhausted",
-        quotaPercent: worstUsedPercent,
-        resetAt: worstResetAt,
-      };
-    }
-
-    return { proceed: true, quotaPercent: quota.percentUsed };
+  const decision = evaluateQuotaCutoff(quota, thresholds, scope);
+  if (!decision.proceed) {
+    const windowLabel = decision.windowName ? ` ${decision.windowName}` : "";
+    const remaining = Number.isFinite(decision.quotaPercent)
+      ? remainingPercentFrom(decision.quotaPercent as number).toFixed(1)
+      : "?";
+    console.info(
+      `[QuotaPreflight] ${provider}/${connectionId}${windowLabel}: ${remaining}% remaining - switching`
+    );
+    return decision;
+  }
+  if (windows && Object.keys(windows).length > 0) {
+    return decision;
   }
 
   // Legacy single-signal path for fetchers that don't expose per-window data.

--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -38,7 +38,7 @@ import {
   resolveCodexAccount,
   type CodexPersistedQuotaState,
 } from "@omniroute/open-sse/services/codexAccount/index.ts";
-import { getAntigravityQuotaFamily } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
+import { selectAntigravityQuotaWindowNames } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -273,37 +273,7 @@ function resolveAntigravityQuotaWindowsForModel(
   quotaNames: string[],
   requestedModel: string
 ): string[] {
-  const requestedFamily = getAntigravityQuotaFamily(requestedModel);
-  const cleanRequestedModel = requestedModel.replace(/^(antigravity|agy)\//, "");
-  const bareModel = cleanRequestedModel.includes("/")
-    ? cleanRequestedModel.slice(cleanRequestedModel.lastIndexOf("/") + 1)
-    : cleanRequestedModel;
-
-  if (requestedFamily === "other") {
-    return quotaNames.filter((windowName) => {
-      const bare = windowName.replace(/^(antigravity|agy)\//, "");
-      return bare === bareModel || bare === cleanRequestedModel;
-    });
-  }
-
-  const familyAggregates =
-    requestedFamily === "gemini"
-      ? ["gemini_weekly"]
-      : requestedFamily === "claude"
-        ? ["claude_gpt_weekly"]
-        : [];
-
-  const exactWindows = quotaNames.filter((windowName) => {
-    const bare = windowName.replace(/^(antigravity|agy)\//, "");
-    return bare === bareModel;
-  });
-  const aggregateWindows = familyAggregates.filter((key) => quotaNames.includes(key));
-  const scoped = [...exactWindows, ...aggregateWindows];
-  if (scoped.length > 0) return scoped;
-
-  return quotaNames.filter(
-    (windowName) => getAntigravityQuotaFamily(windowName) === requestedFamily
-  );
+  return selectAntigravityQuotaWindowNames(quotaNames, requestedModel);
 }
 
 function isAntigravityQuotaExhausted(

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -2995,7 +2995,13 @@ export async function markAccountUnavailable(
         "AUTH",
         `Model-only lockout for ${provider}:${model} — ${status} ${reason} ${Math.ceil(lockout.cooldownMs / 1000)}s (failureCount=${lockout.failureCount}, connection stays active)`
       );
-      if (isAntigravityQuotaProvider(provider) && lockout.cooldownMs > 0) {
+      // Weekly/plan quota only. RPM 429s stay exact-model (#8630); writing
+      // family PSD here would rehydrate as family:gemini and block siblings.
+      if (
+        isAntigravityQuotaProvider(provider) &&
+        lockout.cooldownMs > 0 &&
+        reason === "quota_exhausted"
+      ) {
         void persistAntigravityFamilyCooldown({
           connectionId,
           model,

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -47,7 +47,11 @@ import {
   hydrateCodexQuotaCacheForRequest,
   isQuotaExhaustedForRequest,
 } from "@/domain/quotaCache";
-import { getQuotaScopeLabelForProvider } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
+import {
+  getQuotaScopeLabelForProvider,
+  isAntigravityQuotaProvider,
+} from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
+import { persistAntigravityFamilyCooldown, rehydrateAntigravityFamilyLocks } from "@omniroute/open-sse/services/antigravityFamilyCooldown.ts";
 import { getCreditsMode } from "@omniroute/open-sse/services/antigravityCredits.ts";
 import { preferAntigravityConnectionsWithStoredProject } from "@omniroute/open-sse/services/antigravityProjectPersistence.ts";
 import {
@@ -911,6 +915,17 @@ async function markQuotaPreflightAccountUnavailable(
     return unavailableUntil;
   }
 
+  if (isAntigravityQuotaProvider(provider) && requestedModel?.trim()) {
+    const cooldownMs = Math.max(0, Date.parse(unavailableUntil) - Date.now());
+    lockModel(provider, connectionId, requestedModel, "quota_exhausted", cooldownMs);
+    await persistAntigravityFamilyCooldown({
+      connectionId,
+      model: requestedModel,
+      rateLimitedUntil: unavailableUntil,
+    });
+    return unavailableUntil;
+  }
+
   const percentLabel = Number.isFinite(preflight.quotaPercent)
     ? `${Math.round((preflight.quotaPercent as number) * 100)}%`
     : "exhausted";
@@ -1320,6 +1335,15 @@ export async function getProviderCredentials(
     if (isAlibabaModelStudioProvider(provider)) {
       for (const conn of connections) {
         rehydrateAlibabaFreeDrainedModelLocks(
+          provider,
+          conn.id,
+          conn.providerSpecificData as Record<string, unknown>
+        );
+      }
+    }
+    if (isAntigravityQuotaProvider(provider)) {
+      for (const conn of connections) {
+        rehydrateAntigravityFamilyLocks(
           provider,
           conn.id,
           conn.providerSpecificData as Record<string, unknown>
@@ -2405,7 +2429,11 @@ export async function getProviderCredentialsWithQuotaPreflight(
       return defaultThresholdPercent;
     };
     // #6842: openrouter also needs requestedModel, for the :free-window check.
-    const modelAwarePreflight = provider === "codex" || provider === "openrouter";
+    // agy/antigravity need it so Claude weekly cannot cool a Gemini request.
+    const modelAwarePreflight =
+      provider === "codex" ||
+      provider === "openrouter" ||
+      isAntigravityQuotaProvider(provider);
     const preflightCredentials =
       requestedModel && modelAwarePreflight ? { ...credentials, requestedModel } : credentials;
     let preflight;
@@ -2967,6 +2995,13 @@ export async function markAccountUnavailable(
         "AUTH",
         `Model-only lockout for ${provider}:${model} — ${status} ${reason} ${Math.ceil(lockout.cooldownMs / 1000)}s (failureCount=${lockout.failureCount}, connection stays active)`
       );
+      if (isAntigravityQuotaProvider(provider) && lockout.cooldownMs > 0) {
+        void persistAntigravityFamilyCooldown({
+          connectionId,
+          model,
+          rateLimitedUntil: new Date(Date.now() + lockout.cooldownMs).toISOString(),
+        }).catch(() => {});
+      }
       return { shouldFallback: true, cooldownMs: lockout.cooldownMs };
     }
     const result = fallbackResult;

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -51,7 +51,8 @@ import {
   getQuotaScopeLabelForProvider,
   isAntigravityQuotaProvider,
 } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
-import { persistAntigravityFamilyCooldown, rehydrateAntigravityFamilyLocks } from "@omniroute/open-sse/services/antigravityFamilyCooldown.ts";
+import { rehydrateAntigravityFamilyLocksForConnections, persistAntigravityFamilyCooldownIfQuota } from "@omniroute/open-sse/services/antigravityFamilyCooldown.ts";
+import { markQuotaPreflightAccountUnavailable } from "./quotaPreflightUnavailable.ts";
 import { getCreditsMode } from "@omniroute/open-sse/services/antigravityCredits.ts";
 import { preferAntigravityConnectionsWithStoredProject } from "@omniroute/open-sse/services/antigravityProjectPersistence.ts";
 import {
@@ -895,54 +896,6 @@ function buildQuotaPreflightRateLimitedResult(
     lastErrorCode: 429,
   };
 }
-function quotaPreflightUnavailableUntil(resetAt?: string | null): string {
-  const resetMs = parseFutureDateMs(resetAt ?? null);
-  return new Date(resetMs ?? Date.now() + 5 * 60 * 1000).toISOString();
-}
-async function markQuotaPreflightAccountUnavailable(
-  provider: string,
-  connectionId: string,
-  preflight: { quotaPercent?: number; resetAt?: string | null },
-  requestedModel: string | null
-): Promise<string> {
-  const unavailableUntil = quotaPreflightUnavailableUntil(preflight.resetAt ?? null);
-  if (provider === "codex" && requestedModel?.trim()) {
-    await persistCodexChildCooldown({
-      connectionId,
-      model: requestedModel,
-      rateLimitedUntil: unavailableUntil,
-    });
-    return unavailableUntil;
-  }
-
-  if (isAntigravityQuotaProvider(provider) && requestedModel?.trim()) {
-    const cooldownMs = Math.max(0, Date.parse(unavailableUntil) - Date.now());
-    lockModel(provider, connectionId, requestedModel, "quota_exhausted", cooldownMs);
-    await persistAntigravityFamilyCooldown({
-      connectionId,
-      model: requestedModel,
-      rateLimitedUntil: unavailableUntil,
-    });
-    return unavailableUntil;
-  }
-
-  const percentLabel = Number.isFinite(preflight.quotaPercent)
-    ? `${Math.round((preflight.quotaPercent as number) * 100)}%`
-    : "exhausted";
-  const modelLabel = requestedModel ? ` for ${requestedModel}` : "";
-
-  await updateProviderConnection(connectionId, {
-    rateLimitedUntil: unavailableUntil,
-    testStatus: "unavailable",
-    lastError: `Quota preflight blocked${modelLabel}: ${percentLabel}`,
-    lastErrorType: "quota_exhausted",
-    lastErrorSource: "quota_preflight",
-    errorCode: 429,
-    lastErrorAt: new Date().toISOString(),
-  });
-
-  return unavailableUntil;
-}
 
 // Provider-scoped mutexes prevent race conditions during account selection without
 // serializing unrelated providers behind a single global lock.
@@ -1341,15 +1294,7 @@ export async function getProviderCredentials(
         );
       }
     }
-    if (isAntigravityQuotaProvider(provider)) {
-      for (const conn of connections) {
-        rehydrateAntigravityFamilyLocks(
-          provider,
-          conn.id,
-          conn.providerSpecificData as Record<string, unknown>
-        );
-      }
-    }
+    rehydrateAntigravityFamilyLocksForConnections(provider, connections);
     // allowedConnections: restrict to specific connection IDs (from API key policy, #363)
     if (allowedConnections && allowedConnections.length > 0) {
       connections = connections.filter((conn) => allowedConnections.includes(conn.id));
@@ -2431,9 +2376,7 @@ export async function getProviderCredentialsWithQuotaPreflight(
     // #6842: openrouter also needs requestedModel, for the :free-window check.
     // agy/antigravity need it so Claude weekly cannot cool a Gemini request.
     const modelAwarePreflight =
-      provider === "codex" ||
-      provider === "openrouter" ||
-      isAntigravityQuotaProvider(provider);
+      provider === "codex" || provider === "openrouter" || isAntigravityQuotaProvider(provider);
     const preflightCredentials =
       requestedModel && modelAwarePreflight ? { ...credentials, requestedModel } : credentials;
     let preflight;
@@ -2995,19 +2938,7 @@ export async function markAccountUnavailable(
         "AUTH",
         `Model-only lockout for ${provider}:${model} — ${status} ${reason} ${Math.ceil(lockout.cooldownMs / 1000)}s (failureCount=${lockout.failureCount}, connection stays active)`
       );
-      // Weekly/plan quota only. RPM 429s stay exact-model (#8630); writing
-      // family PSD here would rehydrate as family:gemini and block siblings.
-      if (
-        isAntigravityQuotaProvider(provider) &&
-        lockout.cooldownMs > 0 &&
-        reason === "quota_exhausted"
-      ) {
-        void persistAntigravityFamilyCooldown({
-          connectionId,
-          model,
-          rateLimitedUntil: new Date(Date.now() + lockout.cooldownMs).toISOString(),
-        }).catch(() => {});
-      }
+      persistAntigravityFamilyCooldownIfQuota({ provider, connectionId, model, cooldownMs: lockout.cooldownMs, reason });
       return { shouldFallback: true, cooldownMs: lockout.cooldownMs };
     }
     const result = fallbackResult;

--- a/src/sse/services/quotaPreflightUnavailable.ts
+++ b/src/sse/services/quotaPreflightUnavailable.ts
@@ -1,0 +1,61 @@
+import { persistCodexChildCooldown } from "@omniroute/open-sse/services/codexAccount/index.ts";
+import { persistAntigravityPreflightFamilyLock } from "@omniroute/open-sse/services/antigravityFamilyCooldown.ts";
+import { isAntigravityQuotaProvider } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
+import { cooldownUntilMs } from "@omniroute/open-sse/services/accountFallback.ts";
+import { updateProviderConnection } from "@/lib/db/providers";
+
+function parseFutureDateMs(value: string | null): number | null {
+  if (!value) return null;
+  const ms = cooldownUntilMs(value);
+  if (!Number.isFinite(ms) || ms <= Date.now()) return null;
+  return ms;
+}
+
+function quotaPreflightUnavailableUntil(resetAt?: string | null): string {
+  const resetMs = parseFutureDateMs(resetAt ?? null);
+  return new Date(resetMs ?? Date.now() + 5 * 60 * 1000).toISOString();
+}
+
+export async function markQuotaPreflightAccountUnavailable(
+  provider: string,
+  connectionId: string,
+  preflight: { quotaPercent?: number; resetAt?: string | null },
+  requestedModel: string | null
+): Promise<string> {
+  const unavailableUntil = quotaPreflightUnavailableUntil(preflight.resetAt ?? null);
+  if (provider === "codex" && requestedModel?.trim()) {
+    await persistCodexChildCooldown({
+      connectionId,
+      model: requestedModel,
+      rateLimitedUntil: unavailableUntil,
+    });
+    return unavailableUntil;
+  }
+
+  if (isAntigravityQuotaProvider(provider) && requestedModel?.trim()) {
+    await persistAntigravityPreflightFamilyLock({
+      provider,
+      connectionId,
+      model: requestedModel,
+      unavailableUntil,
+    });
+    return unavailableUntil;
+  }
+
+  const percentLabel = Number.isFinite(preflight.quotaPercent)
+    ? `${Math.round((preflight.quotaPercent as number) * 100)}%`
+    : "exhausted";
+  const modelLabel = requestedModel ? ` for ${requestedModel}` : "";
+
+  await updateProviderConnection(connectionId, {
+    rateLimitedUntil: unavailableUntil,
+    testStatus: "unavailable",
+    lastError: `Quota preflight blocked${modelLabel}: ${percentLabel}`,
+    lastErrorType: "quota_exhausted",
+    lastErrorSource: "quota_preflight",
+    errorCode: 429,
+    lastErrorAt: new Date().toISOString(),
+  });
+
+  return unavailableUntil;
+}

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -67,6 +67,7 @@
       "tests/unit/agentrouter-lock-scope-10334.test.ts",
       "tests/unit/alibaba-free-tier-exhaustion.test.ts",
       "tests/unit/anthropic-thinking-signature-recovery.test.ts",
+      "tests/unit/agy-family-not-connection-cooldown.test.ts",
       "tests/unit/antigravity-429-quota-cooldown.test.ts",
       "tests/unit/antigravity-429-quota-tdd.test.ts",
       "tests/unit/antigravity-prefer-stored-project.test.ts",

--- a/tests/unit/agy-family-not-connection-cooldown.test.ts
+++ b/tests/unit/agy-family-not-connection-cooldown.test.ts
@@ -130,6 +130,39 @@ test("markConnectionQuotaExhausted with a Gemini model locks the family, not the
   assert.equal(fallback.isModelLocked("agy", connId, "claude-opus-4-6-thinking"), false);
 });
 
+test("Antigravity QPM 429 stays exact-model and does not persist a family cooldown", async () => {
+  fallback.clearAllModelLockouts();
+  const auth = await import("../../src/sse/services/auth.ts");
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "qpm@example.test",
+    accessToken: "tok-qpm",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = (conn as { id: string }).id;
+
+  await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted (queries per minute limit was reached)",
+    "antigravity",
+    "gemini-3-pro"
+  );
+
+  const sibling = await auth.getProviderCredentials("antigravity", null, null, "gemini-2.5-pro");
+  assert.ok(sibling && !("allRateLimited" in sibling && sibling.allRateLimited));
+  assert.equal(sibling.connectionId, connId);
+
+  const fresh = await providersDb.getProviderConnectionById(connId);
+  const psd = (fresh as { providerSpecificData?: Record<string, unknown> }).providerSpecificData;
+  assert.equal(
+    psd && typeof psd === "object" ? psd.antigravityFamilyRateLimitedUntil : undefined,
+    undefined
+  );
+});
+
 test("persisted family cooldown rehydrates after a process-local lockout wipe", async () => {
   fallback.clearAllModelLockouts();
   const conn = await providersDb.createProviderConnection({

--- a/tests/unit/agy-family-not-connection-cooldown.test.ts
+++ b/tests/unit/agy-family-not-connection-cooldown.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Claude weekly exhaustion must not cool the whole agy/antigravity connection.
+ * Gemini on the same account stays routable; only family:claude is locked.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-agy-family-cd-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "agy-family-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const quotaPreflight = await import("../../open-sse/services/quotaPreflight.ts");
+const family = await import("../../open-sse/services/antigravityQuotaFamily.ts");
+const fallback = await import("../../open-sse/services/accountFallback.ts");
+const { markConnectionQuotaExhausted } = await import("../../open-sse/executors/antigravity.ts");
+const { quotaRemainingPercentFromQuota } = await import(
+  "../../open-sse/services/combo/comboPredicates.ts"
+);
+
+const CLAUDE_RESET = "2026-09-06T17:38:10.000Z";
+const GEMINI_RESET = "2026-09-09T09:59:00.000Z";
+
+function mixedWindows() {
+  return {
+    claude_gpt_weekly: { percentUsed: 1, resetAt: CLAUDE_RESET },
+    gemini_weekly: { percentUsed: 0.022, resetAt: GEMINI_RESET },
+    "gemini-3.1-flash-lite": { percentUsed: 0.1, resetAt: null },
+  };
+}
+
+test.after(() => {
+  fallback.clearAllModelLockouts();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("selectAntigravityQuotaWindowNames keeps Claude weekly off a Gemini request", () => {
+  const names = family.selectAntigravityQuotaWindowNames(Object.keys(mixedWindows()), "gemini-3.1-flash-lite");
+  assert.deepEqual(names.sort(), ["gemini-3.1-flash-lite", "gemini_weekly"].sort());
+});
+
+test("preflightQuota proceeds on Gemini when only Claude weekly is exhausted", async () => {
+  quotaPreflight.registerQuotaFetcher("agy", async () => ({
+    used: 0,
+    total: 0,
+    percentUsed: 1,
+    limitReached: true,
+    windows: mixedWindows(),
+  }));
+
+  const result = await quotaPreflight.preflightQuota("agy", "conn-1", {
+    requestedModel: "agy/gemini-3.1-flash-lite",
+  });
+  assert.equal(result.proceed, true, "Gemini must not inherit Claude weekly exhaustion");
+});
+
+test("preflightQuota blocks Gemini when gemini_weekly is exhausted", async () => {
+  quotaPreflight.registerQuotaFetcher("agy-gemini-dead", async () => ({
+    used: 0,
+    total: 0,
+    percentUsed: 0.99,
+    windows: {
+      claude_gpt_weekly: { percentUsed: 0.1, resetAt: CLAUDE_RESET },
+      gemini_weekly: { percentUsed: 0.99, resetAt: GEMINI_RESET },
+    },
+  }));
+
+  const result = await quotaPreflight.preflightQuota("agy-gemini-dead", "conn-2", {
+    requestedModel: "gemini-3.1-flash-lite",
+  });
+  assert.equal(result.proceed, false);
+  assert.equal(result.windowName, "gemini_weekly");
+  assert.equal(result.resetAt, GEMINI_RESET);
+});
+
+test("evaluateQuotaCutoff with requestedModel ignores the other family window", () => {
+  const quota = {
+    used: 0,
+    total: 0,
+    percentUsed: 1,
+    limitReached: true,
+    windows: mixedWindows(),
+  };
+  const gemini = quotaPreflight.evaluateQuotaCutoff(quota, undefined, {
+    provider: "antigravity",
+    requestedModel: "gemini-3.1-flash-lite",
+  });
+  assert.equal(gemini.proceed, true);
+
+  const claude = quotaPreflight.evaluateQuotaCutoff(quota, undefined, {
+    provider: "agy",
+    requestedModel: "claude-opus-4-6-thinking",
+  });
+  assert.equal(claude.proceed, false);
+  assert.equal(claude.windowName, "claude_gpt_weekly");
+});
+
+test("quotaRemainingPercentFromQuota for Gemini uses Gemini windows, not Claude", () => {
+  const quota = { windows: mixedWindows(), percentUsed: 1, limitReached: true };
+  const remaining = quotaRemainingPercentFromQuota(quota, {
+    provider: "agy",
+    requestedModel: "gemini-3.1-flash-lite",
+  });
+  assert.ok(remaining > 50, `expected Gemini remaining, got ${remaining}`);
+});
+
+test("markConnectionQuotaExhausted with a Gemini model locks the family, not the row", async () => {
+  fallback.clearAllModelLockouts();
+  const conn = await providersDb.createProviderConnection({
+    provider: "agy",
+    authType: "oauth",
+    name: "agy-family-gemini",
+  });
+  const connId = (conn as { id: string }).id;
+
+  markConnectionQuotaExhausted(connId, 24 * 60 * 60 * 1000, "gemini-3.1-flash-lite");
+
+  assert.equal(
+    providersDb.isConnectionRateLimited(connId),
+    false,
+    "connection row must stay selectable for the other family"
+  );
+  assert.equal(fallback.isModelLocked("agy", connId, "gemini-3.1-flash-lite"), true);
+  assert.equal(fallback.isModelLocked("agy", connId, "gemini-3.7-flash-high"), true);
+  assert.equal(fallback.isModelLocked("agy", connId, "claude-opus-4-6-thinking"), false);
+});
+
+test("persisted family cooldown rehydrates after a process-local lockout wipe", async () => {
+  fallback.clearAllModelLockouts();
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name: "ag-family-persist",
+  });
+  const connId = (conn as { id: string }).id;
+  const until = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  const { persistAntigravityFamilyCooldown, rehydrateAntigravityFamilyLocks } = await import(
+    "../../open-sse/services/antigravityFamilyCooldown.ts"
+  );
+  await persistAntigravityFamilyCooldown({
+    connectionId: connId,
+    model: "claude-sonnet-4",
+    rateLimitedUntil: until,
+  });
+
+  fallback.clearAllModelLockouts();
+  assert.equal(fallback.isModelLocked("antigravity", connId, "claude-opus-4"), false);
+
+  const fresh = await providersDb.getProviderConnectionById(connId);
+  rehydrateAntigravityFamilyLocks(
+    "antigravity",
+    connId,
+    (fresh as { providerSpecificData?: Record<string, unknown> }).providerSpecificData
+  );
+  assert.equal(fallback.isModelLocked("antigravity", connId, "claude-opus-4"), true);
+  assert.equal(fallback.isModelLocked("antigravity", connId, "gemini-3.1-flash-lite"), false);
+  assert.equal(providersDb.isConnectionRateLimited(connId), false);
+});

--- a/tests/unit/agy-family-not-connection-cooldown.test.ts
+++ b/tests/unit/agy-family-not-connection-cooldown.test.ts
@@ -130,6 +130,40 @@ test("markConnectionQuotaExhausted with a Gemini model locks the family, not the
   assert.equal(fallback.isModelLocked("agy", connId, "claude-opus-4-6-thinking"), false);
 });
 
+test("Antigravity RPM 429 stays exact-model and does not persist a family cooldown", async () => {
+  fallback.clearAllModelLockouts();
+  const auth = await import("../../src/sse/services/auth.ts");
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "rpm@example.test",
+    accessToken: "tok-rpm",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = (conn as { id: string }).id;
+
+  await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted (requests per minute / RPM limit was reached)",
+    "antigravity",
+    "gemini-3-pro"
+  );
+
+  const sibling = await auth.getProviderCredentials("antigravity", null, null, "gemini-2.5-pro");
+  assert.ok(sibling && !("allRateLimited" in sibling && sibling.allRateLimited));
+  assert.equal(sibling.connectionId, connId);
+
+  const fresh = await providersDb.getProviderConnectionById(connId);
+  const psd = (fresh as { providerSpecificData?: Record<string, unknown> }).providerSpecificData;
+  assert.equal(
+    psd && typeof psd === "object" ? psd.antigravityFamilyRateLimitedUntil : undefined,
+    undefined
+  );
+  await providersDb.updateProviderConnection(connId, { isActive: false });
+});
+
 test("Antigravity QPM 429 stays exact-model and does not persist a family cooldown", async () => {
   fallback.clearAllModelLockouts();
   const auth = await import("../../src/sse/services/auth.ts");
@@ -161,6 +195,7 @@ test("Antigravity QPM 429 stays exact-model and does not persist a family cooldo
     psd && typeof psd === "object" ? psd.antigravityFamilyRateLimitedUntil : undefined,
     undefined
   );
+  await providersDb.updateProviderConnection(connId, { isActive: false });
 });
 
 test("persisted family cooldown rehydrates after a process-local lockout wipe", async () => {
@@ -194,4 +229,30 @@ test("persisted family cooldown rehydrates after a process-local lockout wipe", 
   assert.equal(fallback.isModelLocked("antigravity", connId, "claude-opus-4"), true);
   assert.equal(fallback.isModelLocked("antigravity", connId, "gemini-3.1-flash-lite"), false);
   assert.equal(providersDb.isConnectionRateLimited(connId), false);
+});
+
+test("preflight family lock covers both agy and antigravity spellings", async () => {
+  fallback.clearAllModelLockouts();
+  const { persistAntigravityPreflightFamilyLock } = await import(
+    "../../open-sse/services/antigravityFamilyCooldown.ts"
+  );
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name: "ag-preflight-alias",
+  });
+  const connId = (conn as { id: string }).id;
+  const until = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  await persistAntigravityPreflightFamilyLock({
+    provider: "antigravity",
+    connectionId: connId,
+    model: "claude-sonnet-4",
+    unavailableUntil: until,
+  });
+
+  assert.equal(fallback.isModelLocked("antigravity", connId, "claude-opus-4"), true);
+  assert.equal(fallback.isModelLocked("agy", connId, "claude-opus-4"), true);
+  assert.equal(fallback.isModelLocked("antigravity", connId, "gemini-3.1-flash-lite"), false);
+  assert.equal(fallback.isModelLocked("agy", connId, "gemini-3.1-flash-lite"), false);
 });

--- a/tests/unit/hard-session-lease-bypass-inventory.test.ts
+++ b/tests/unit/hard-session-lease-bypass-inventory.test.ts
@@ -84,6 +84,8 @@ const EXPECTED: Record<InventoryKind, Record<string, number>> = {
     "open-sse/handlers/cursorCliProxy.ts": 1,
     "open-sse/services/alibabaFreeTier.ts": 1,
     "open-sse/services/alibabaFreeTierQuotaFetcher.ts": 1,
+    // Family cooldown persist looks the row up to write PSD, not dispatch.
+    "open-sse/services/antigravityFamilyCooldown.ts": 1,
     // v3.8.50 back-merge additions (f95b03d7): combo routing infra and the
     // volcengine-plan binding/auto-sync services query connections the same
     // way as their classified siblings.


### PR DESCRIPTION
fix(quota): keep Antigravity Gemini usable when Claude weekly is empty

### Summary
When Claude weekly hit 0, we wrote `rate_limited_until` from `claude_gpt_weekly.resetAt` (28h-150h) onto the whole connection. Auth then dropped the account before `family:claude` locks were even considered, so Gemini quota that was still 40-100% sat unused.

Preflight and combo cutoff now look only at the requested model family. Family locks persist in `providerSpecificData` and rehydrate on load. agy / antigravity quota exhaustion no longer writes connection-level `rate_limited_until`.

### Tests
- Gemini preflight ignores Claude weekly
- 429 does not write a connection cooldown
- combo cutoff is family-scoped
- PSD persist / rehydrate
- sibling preflight, quota-skipping, 429 cooldown, and sse-auth credits suites still pass
- disable family window selection and Gemini inherits Claude weekly (new tests fail); restore the 429 `rateLimitedUntil` write and the picker test fails

### Not in this PR
- Dashboard UI for family cooldowns
- A schema change (locks live in existing PSD JSON)
