### PR TITLE
chore(deps): pin browserslist override to ^4.28.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -461,6 +461,7 @@
     "unrs-resolver": true
   },
   "overrides": {
+    "browserslist": "^4.28.8",
     "onnxruntime-node": "1.24.3",
     "eslint-plugin-react-hooks": "7.1.1",
     "fast-xml-parser": "^5.10.1",


### PR DESCRIPTION
## Summary

One-line `package.json` override pinning `browserslist` to `^4.28.8` to fix a cold-install `RangeError: Out of range argument` in node 22 when downstream tooling (autoprefixer >=10.5.0, caniuse-lite via vite 8) requires the newer query-parser.

## Why

Without this override, `npm install` resolves browserslist to ^4.27.x, which fails on the `'last-N-versions'` query syntax with:

```
RangeError: Out of range argument
    at Object.parse (node:internal/querystring:159:23)
    at parseDataQuery (.../browserslist/node.js:...)
```

The `browserslist` library is pulled in transitively through `@yarnpkg/parsers`, `monaco-editor`, and `vite`. Pinning the override removes the failure mode without changing the direct dependency tree.

## Change

```diff
   "overrides": {
+    "browserslist": "^4.28.8",
     "onnxruntime-node": "1.24.3",
```

## Test

```bash
rm -rf node_modules
npm ci
npm run build
```

Expected: clean install, no `RangeError`.

## Provenance

This is a re-built 1-line delta from `KooshaPari/OmniRoute@6da8329cb`. The original commit also modified `README.md`, `config/quality/eslint-suppressions.json`, and `config/quality/quality-baseline.json`; those changes have already landed on upstream `release/v3.8.51` (or were re-baselined). Only this single `package.json` line remains portable as of 2026-09-03.

W-class: P (portable)
Cherry-pick source: `KooshaPari/OmniRoute@6da8329cb`
Cherry-pick commit: `e2147aee7` (1 file, +1)