### PR TITLE
fix(ci): clear base-reds on release/v3.8.51

### DIFF
--- a/changelog.d/fixes/12581-basereds-licenses-a2a-lifecycle.md
+++ b/changelog.d/fixes/12581-basereds-licenses-a2a-lifecycle.md
@@ -1,0 +1,1 @@
+- **fix(ci):** document MIT exceptions for `@eloqnt/{config,format-json,format-po}` (next-intl transitive; locked tarballs omit `license`) and keep the A2A lifecycle vitest off the real SQLite persistence seam ([#12581](https://github.com/diegosouzapw/OmniRoute/issues/12581))

--- a/config/quality/.license-allowlist.json
+++ b/config/quality/.license-allowlist.json
@@ -74,6 +74,24 @@
       "justification": "CC-BY-4.0 applies to the caniuse browser-support data (a dataset, not code). The Creative Commons Attribution license requires attribution when distributing — OmniRoute does not distribute caniuse-lite data directly to end users; it is consumed by browserslist/PostCSS at build time to generate CSS compatibility info. This is a widely accepted pattern in the Node.js ecosystem (caniuse-lite is in millions of projects). Attribution is satisfied by keeping the package in node_modules with its original license file.",
       "risk": "low",
       "reviewAt": "v4.0.0"
+    },
+    "@eloqnt/config": {
+      "license": "MIT",
+      "justification": "Transitive of next-intl (MIT). npm registry SPDX for the @eloqnt scope is MIT; @eloqnt/config@0.1.0 republished with license: MIT. The locked 0.0.2 tarball (next-intl's ^0.0.2 range, which is 0.0.x only) omits both package.json#license and a LICENSE file, so license-checker reports UNKNOWN. Same author (Jan Amann / amannn). OmniRoute does not modify the package. Re-review when next-intl bumps the range to a release that ships the license field.",
+      "risk": "low",
+      "reviewAt": "v4.0.0"
+    },
+    "@eloqnt/format-json": {
+      "license": "MIT",
+      "justification": "Same as @eloqnt/config: next-intl transitive, registry SPDX MIT, locked 0.0.3 tarball omits license field and LICENSE file so the checker reports UNKNOWN. Re-review with the next-intl range bump.",
+      "risk": "low",
+      "reviewAt": "v4.0.0"
+    },
+    "@eloqnt/format-po": {
+      "license": "MIT",
+      "justification": "Same as @eloqnt/config: next-intl transitive, registry SPDX MIT, locked 0.0.3 tarball omits license field and LICENSE file so the checker reports UNKNOWN. Re-review with the next-intl range bump.",
+      "risk": "low",
+      "reviewAt": "v4.0.0"
     }
   }
 }

--- a/open-sse/mcp-server/__tests__/a2aLifecycle.test.ts
+++ b/open-sse/mcp-server/__tests__/a2aLifecycle.test.ts
@@ -1,11 +1,21 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { A2ATaskManager } from "../../../src/lib/a2a/taskManager.ts";
+import { A2ATaskManager, type A2APersistence } from "../../../src/lib/a2a/taskManager.ts";
 import { executeA2ATaskWithState } from "../../../src/lib/a2a/taskExecution.ts";
 
 const managers: A2ATaskManager[] = [];
 
+// Default persistence opens SQLite (167 migrations) inside the vitest thread pool.
+// Tests inject a no-op so they never touch the DB (same seam as a2a-task-persistence.test.ts).
+function noopPersistence(): A2APersistence {
+  return {
+    upsert: (() => {}) as A2APersistence["upsert"],
+    appendEvent: (() => {}) as A2APersistence["appendEvent"],
+    purge: ((): number => 0) as A2APersistence["purge"],
+  };
+}
+
 function createManager(ttlMinutes = 5) {
-  const manager = new A2ATaskManager(ttlMinutes);
+  const manager = new A2ATaskManager(ttlMinutes, noopPersistence());
   managers.push(manager);
   return manager;
 }
@@ -44,9 +54,14 @@ describe("A2A task lifecycle regressions", () => {
     tm.updateTask(task.id, "working");
 
     await expect(
-      executeA2ATaskWithState(tm, task, async () => {
-        throw new Error("upstream failure");
-      })
+      executeA2ATaskWithState(
+        tm,
+        task,
+        async () => {
+          throw new Error("upstream failure");
+        },
+        { search: async () => [], appendEvent: () => {} }
+      )
     ).rejects.toThrow("upstream failure");
 
     const loaded = tm.getTask(task.id);

--- a/tests/unit/build/check-licenses.test.ts
+++ b/tests/unit/build/check-licenses.test.ts
@@ -330,3 +330,19 @@ test("integration: classifyLicense denies AGPL-3.0 against real allowlist", () =
   const result = classifyLicense("hypothetical-agpl@1.0.0", "AGPL-3.0", allowlist);
   assert.equal(result.status, "denied");
 });
+
+test("integration: @eloqnt/* UNKNOWN licenses are documented exceptions (next-intl transitive)", () => {
+  const allowlist = loadAllowlist();
+  for (const pkg of [
+    "@eloqnt/config@0.0.2",
+    "@eloqnt/format-json@0.0.3",
+    "@eloqnt/format-po@0.0.3",
+  ]) {
+    const result = classifyLicense(pkg, "UNKNOWN", allowlist);
+    assert.equal(
+      result.status,
+      "exception",
+      `${pkg} ships no license field; must be a documented exception, not allowed/denied`
+    );
+  }
+});


### PR DESCRIPTION
Clears reproducible HARD failures from base-red [#12581](https://github.com/diegosouzapw/OmniRoute/issues/12581) (run [33720531420](https://github.com/diegosouzapw/OmniRoute/actions/runs/33720531420), tip `2a6d45abea`). Does not merge.

### HARDs fixed
- **`check:licenses` `@eloqnt/config@0.0.2: UNKNOWN`** (and the same unpublished-license hit on `@eloqnt/format-json@0.0.3` / `@eloqnt/format-po@0.0.3`). Transitive of `next-intl`. Registry SPDX is MIT (`@eloqnt/config@0.1.0` republished with `license: MIT`); the locked `^0.0.2` 0.0.x tarballs omit both `package.json#license` and a LICENSE file. Documented `exceptions` entries in `config/quality/.license-allowlist.json` (not `allowed: UNKNOWN`). Guard: `tests/unit/build/check-licenses.test.ts`.
- **Vitest `open-sse/mcp-server/__tests__/a2aLifecycle.test.ts` (A2A task lifecycle).** Default `A2ATaskManager` persistence now writes SQLite (`#12479` / `#12508`), so this vitest file ran 167 migrations inside the thread pool and called `collectMemoryHits` against the real memory backend. Injected the existing no-op `A2APersistence` seam + no-op memory deps. Same 4 assertions; isolated run dropped from ~756ms with a live DB to 28ms with no `[DB] SQLite database ready`.

### HARDs not in this PR
- **`check:openapi-security-tiers` POST `/api/vnc-session/{params}`** — already fixed in open PR **#12350** (`fix/release-v3.8.51-openapi-security-tiers-checker`, GREEN). HOLD; not duplicated.
- **Unit suite timeout 4800s / integration timeout 2400s** — not reproduced as a new unreleased DB handle. `t09-a2a-lifecycle.test.ts` does open SQLite via default persistence but exits cleanly in isolation (~2.7s). Needs-owner (infra/hang unless a later session proves a leak).
- **Package artifact: `Error: Turbopack build failed with 1 error:`** — GitHub job logs for run 33720531420 are truncated to the wrapper line; the next-line compile/panic detail is not in the uploaded `release-green-report`. Typecheck + dashboard-typecheck passed on that run. Not distinguished from the known Turbopack unreachable-code panic (`OMNIROUTE_USE_TURBOPACK=0` already on the docker-publish path). Did not edit `.github/workflows/`. Needs-owner.
- **Tarball boot-smoke** — skipped because pack-artifact did not produce `dist/`. Follows pack-artifact.
- **File-size ratchet `src/sse/handlers/chat.ts` 2434 > 2424** — drift, not rebaselined.

- **fix(ci):** document MIT exceptions for `@eloqnt/{config,format-json,format-po}` (next-intl transitive; locked tarballs omit `license`) and keep the A2A lifecycle vitest off the real SQLite persistence seam ([#12581](https://github.com/diegosouzapw/OmniRoute/issues/12581))