### PR TITLE
feat(providers): refresh Gemini Web model catalog

### DIFF
--- a/open-sse/config/providers/registry/gemini/index.ts
+++ b/open-sse/config/providers/registry/gemini/index.ts
@@ -19,8 +19,8 @@ export const geminiProvider: RegistryEntry = {
   },
   models: [
     {
-      id: "gemini-3.7-flash",
-      name: "Gemini 3.7 Flash",
+      id: "gemini-3.8-flash",
+      name: "Gemini 3.8 Flash",
       toolCalling: true,
       supportsVision: true,
     },

--- a/open-sse/config/providers/registry/gemini/web/index.ts
+++ b/open-sse/config/providers/registry/gemini/web/index.ts
@@ -24,14 +24,14 @@ export const gemini_webProvider: RegistryEntry = {
       supportsReasoning: false,
     },
     {
-      id: "gemini-3.7-flash",
-      name: "Gemini 3.7 Flash",
+      id: "gemini-3.8-flash",
+      name: "Gemini 3.8 Flash",
       toolCalling: false,
       supportsReasoning: false,
     },
     {
-      id: "gemini-3.1-flash-lite",
-      name: "Gemini 3.1 Flash-Lite",
+      id: "gemini-3.5-flash-lite",
+      name: "Gemini 3.5 Flash-Lite",
       toolCalling: false,
       supportsReasoning: false,
     },

--- a/tests/unit/gemini-web-image-retirement.test.ts
+++ b/tests/unit/gemini-web-image-retirement.test.ts
@@ -117,7 +117,7 @@ test("Gemini Web chat and legitimate Gemini image providers remain available", a
   assert.equal(REGISTRY["gemini-web"]?.executor, "gemini-web");
   assert.deepEqual(
     REGISTRY["gemini-web"]?.models.map(({ id }) => id),
-    ["gemini-3.1-pro", "gemini-3.7-flash", "gemini-3.1-flash-lite"]
+    ["gemini-3.1-pro", "gemini-3.8-flash", "gemini-3.5-flash-lite"]
   );
 
   assert.deepEqual(parseImageModel("nano-banana"), {

--- a/tests/unit/gemini-web.test.ts
+++ b/tests/unit/gemini-web.test.ts
@@ -171,8 +171,8 @@ test("Provider: gemini-web has correct models", async () => {
     models.map((m: any) => [m.id, m.name]),
     [
       ["gemini-3.1-pro", "Gemini 3.1 Pro"],
-      ["gemini-3.7-flash", "Gemini 3.7 Flash"],
-      ["gemini-3.1-flash-lite", "Gemini 3.1 Flash-Lite"],
+      ["gemini-3.8-flash", "Gemini 3.8 Flash"],
+      ["gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite"],
     ]
   );
 });


### PR DESCRIPTION
## Summary
- Refreshes Gemini Web (`gemini-web`) model catalog:
  - `gemini-3.7-flash` → `gemini-3.8-flash`
  - `gemini-3.1-flash-lite` → `gemini-3.5-flash-lite`
- Updates corresponding unit test assertions in `tests/unit/gemini-web.test.ts` and `tests/unit/gemini-web-image-retirement.test.ts`.

## Verification
- Executed unit test suites:
  - `node --import tsx/esm --test tests/unit/gemini-web.test.ts tests/unit/gemini-web-image-retirement.test.ts`
  - Result: 18 passed, 0 failed.