### PR TITLE
chore(deps): bump fast-uri to 3.1.7 in the electron lockfile (4 HIGH alerts)

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1575,9 +1575,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes Dependabot alerts **#196, #197, #198, #199** — four HIGH advisories on `fast-uri` (`GHSA-jqff-g426-hqxp`, `GHSA-fph4-wmhf-6fwf`, `GHSA-f65p-4m7j-42xc`, `GHSA-5jgf-p345-68v8`), all patched in `3.1.6`.

## Why this is one file and not fourteen

The Dependabot page showed 14 open alerts. Checking the tip before writing anything: **`origin/release/v3.8.51` already carries the patched versions** for `fast-uri`, `qs`, `browserslist`, `@xmldom/xmldom` and `@humanfs/node` in the root `package-lock.json`. My first attempt at a bump was a no-op against a stale local checkout — those alerts close on their own with the next scan, and by the time I re-read the API the count was already down to 5.

What is genuinely still open is a **second lockfile**: `electron/package-lock.json` was still pinning `fast-uri@3.1.5`. That is what alerts #196–#199 report.

## The change

Transitive, one copy, pulled by `ajv` (`^3.0.1`), so `npm update fast-uri --package-lock-only` lifts it without touching any manifest. The whole diff is three lines — `version`, `resolved`, `integrity` for that single entry:

```
-      "version": "3.1.5",
+      "version": "3.1.7",
```

`check:lockfile` (including the workspace lock/manifest consistency check) and `check:tracked-artifacts` pass.

## Not fixed here

**`extract-zip` (#191, HIGH, `<= 2.0.1`)** has no published patch. It arrives through `@openai/codex-security` and is dev-scope. Closing it needs either an upstream release or a decision to drop/replace that dependency — neither belongs in a lockfile bump. Flagging rather than silently leaving it out of the PR description.

Targets `release/v3.8.51`.
