### PR TITLE
fix(docs): add required frontmatter to REMOVED_PROVIDERS.md

### DIFF
--- a/docs/reference/REMOVED_PROVIDERS.md
+++ b/docs/reference/REMOVED_PROVIDERS.md
@@ -1,3 +1,9 @@
+---
+title: "Removed Providers"
+version: 3.8.50
+lastUpdated: 2026-09-03
+---
+
 # Providers removed at their operator's request
 
 Some services were integrated into OmniRoute and later removed because the people who run


### PR DESCRIPTION
## Summary

- Add the required frontmatter to docs/reference/REMOVED_PROVIDERS.md so it can be processed correctly by Fumadocs/MDX during the production build.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- No automated tests added or updated; this PR only changes documentation frontmatter.

## Coverage Notes

- no production code was changed.

## Reviewer Notes

- This change only adds the required title, version, and lastUpdated frontmatter to REMOVED_PROVIDERS.md
