### PR TITLE
docs(quality): document how the CodeQL ratchet refreshes and how to tighten it

### DIFF
--- a/docs/architecture/QUALITY_GATES.md
+++ b/docs/architecture/QUALITY_GATES.md
@@ -90,17 +90,17 @@ Runs on every PR to `main`. Blocks merge on failure.
 
 Runs after `test-coverage`. Blocks merge on failure.
 
-| Script                       | Validates                                                                                                                                         | Blocking                  |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `quality:collect`            | Emits `quality-metrics.json` (ESLint warning count, coverage from merged shard report)                                                            | Yes (upstream of ratchet) |
-| `quality:ratchet`            | Each metric in `quality-baseline.json` has not regressed (ESLint warnings ≤ baseline; coverage ≥ baseline)                                        | Yes                       |
-| `check:duplication`          | Code duplication (jscpd@4) does not exceed baseline in `quality-baseline.json`                                                                    | Yes                       |
-| `check:complexity`           | File-level cyclomatic complexity does not exceed the cap (core ESLint `complexity` + `max-lines-per-function`)                                    | Yes                       |
-| `check:cognitive-complexity` | Cognitive complexity ratchet (`eslint-plugin-sonarjs`) — separate ESLint pass; CI runs both merged as the single `check:complexity-ratchets` step | Yes                       |
-| `check:dead-code`            | Unused exports / files ratchet (knip) does not regress vs baseline                                                                                | Yes                       |
-| `check:compression-budget`   | Compression benchmark budget — per-engine token-savings floors must not regress                                                                   | Yes                       |
-| `check:type-coverage`        | Percent-typed ratchet (`type-coverage`) does not regress; largely subsumes `typecheck:noimplicit:core`                                            | Yes                       |
-| `check:codeql-ratchet`       | Open CodeQL alert count does not regress (reads via `gh api`; graceful-skip without token)                                                        | Yes                       |
+| Script                       | Validates                                                                                                                                                   | Blocking                  |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `quality:collect`            | Emits `quality-metrics.json` (ESLint warning count, coverage from merged shard report)                                                                      | Yes (upstream of ratchet) |
+| `quality:ratchet`            | Each metric in `quality-baseline.json` has not regressed (ESLint warnings ≤ baseline; coverage ≥ baseline)                                                  | Yes                       |
+| `check:duplication`          | Code duplication (jscpd@4) does not exceed baseline in `quality-baseline.json`                                                                              | Yes                       |
+| `check:complexity`           | File-level cyclomatic complexity does not exceed the cap (core ESLint `complexity` + `max-lines-per-function`)                                              | Yes                       |
+| `check:cognitive-complexity` | Cognitive complexity ratchet (`eslint-plugin-sonarjs`) — separate ESLint pass; CI runs both merged as the single `check:complexity-ratchets` step           | Yes                       |
+| `check:dead-code`            | Unused exports / files ratchet (knip) does not regress vs baseline                                                                                          | Yes                       |
+| `check:compression-budget`   | Compression benchmark budget — per-engine token-savings floors must not regress                                                                             | Yes                       |
+| `check:type-coverage`        | Percent-typed ratchet (`type-coverage`) does not regress; largely subsumes `typecheck:noimplicit:core`                                                      | Yes                       |
+| `check:codeql-ratchet`       | Open CodeQL alert count does not regress (reads via `gh api`; graceful-skip without token) — refresh cadence and manual trigger: see "CodeQL ratchet" below | Yes                       |
 
 ### Job: `quality-extended`
 
@@ -323,6 +323,36 @@ The `--update` flag writes the current measured values into `quality-baseline.js
 Commit this file alongside the change that improved the metric. A PR that improves a
 metric without updating the baseline will be caught by `--require-tighten` (Fase 6A.5,
 pending implementation).
+
+### CodeQL ratchet: refresh cadence and manual trigger
+
+`check:codeql-ratchet` reads **repo state, refreshed on a schedule — not per PR.**
+`gh api repos/diegosouzapw/OmniRoute/code-scanning/default-setup` reports
+`state: configured`, `schedule: weekly`: GitHub's default-setup scan, not a per-push
+analysis. Consequence: after a PR that FIXES alerts merges, the ratchet keeps reading
+the old, higher count until the next scheduled scan runs — so it reports a regression
+on every open PR, including the fixing PR's own follow-ups, until the scan catches up.
+
+**Manual refresh**: `gh workflow run codeql.yml --ref release/vX.Y.Z` re-runs the
+analysis and republishes alerts within minutes. Read `.github/workflows/codeql.yml`
+first — its header explains it is `workflow_dispatch`-only **because it conflicts with
+GitHub's "default setup"** (`CodeQL analyses from advanced configurations cannot be
+processed when the default setup is enabled`). Restoring `push`/`pull_request`/
+`schedule` triggers requires an **owner action first**: Settings → Code security →
+CodeQL: Default → Advanced. Do not add a `schedule:` trigger without that switch — it
+will only produce failing runs.
+
+**Tighten the baseline after the count drops** — `node scripts/check/check-codeql-ratchet.mjs
+--update` writes the new measured count into `quality-baseline.json` →
+`metrics.codeqlAlerts.value`, so the ratchet does not silently permit a regression back
+up to the old ceiling. Worked example (2026-09-02/03): PR #12502 fixed 7 real alerts
+(13 → 6 measured open); PR #12530 tightened the frozen baseline 11 → 6 to match; the
+remaining 6 were then dismissed with per-alert justification down to 0 open.
+
+**Dismissals are the operator's call (Hard Rule #14)** — never dismiss a CodeQL alert
+without recording the technical justification in the dismissal comment: `won't fix` for
+an upstream-protocol requirement, `used in tests` for a test fixture, `false positive`
+for a sanitizer CodeQL cannot see (precedent: `docs/security/ERROR_SANITIZATION.md`).
 
 ---
 


### PR DESCRIPTION
⚠️ base-red inherited: #12581

## Contexto

Documentação de uma armadilha operacional que custou uma sessão inteira hoje: o gate
`check:codeql-ratchet` lê a contagem de alertas CodeQL abertos como **estado do repositório**,
atualizado pelo "default setup" do GitHub num agendamento **semanal** (`gh api
repos/diegosouzapw/OmniRoute/code-scanning/default-setup` → `state: configured`, `schedule:
weekly`) — não a cada PR/push. Consequência: depois que uma PR **corrige** alertas e é
mergeada, o ratchet continua enxergando a contagem antiga (mais alta) até o próximo scan
agendado, então ele reporta regressão em toda PR aberta — inclusive nos follow-ups da própria
PR que corrigiu os alertas, que portanto nunca conseguem ficar verdes antes do merge.

## O que foi documentado

Nova subseção `### CodeQL ratchet: refresh cadence and manual trigger` em
`docs/architecture/QUALITY_GATES.md`, logo após a seção "Ratchet Baseline" (mesma vizinhança
de "Banking Ratchet Shrinks" e "Allowlist Policy"), cobrindo:

1. **Por que o gate demora a refletir uma correção** — cadência semanal do default setup, não
   por PR.
2. **Refresh manual**: `gh workflow run codeql.yml --ref release/vX.Y.Z` reroda a análise e
   republica os alertas em minutos. `.github/workflows/codeql.yml` é `workflow_dispatch`-only
   **de propósito** — o cabeçalho do arquivo explica que um trigger automático conflita com o
   "default setup" do GitHub (`CodeQL analyses from advanced configurations cannot be
   processed when the default setup is enabled`) e que restaurar os triggers
   `push`/`pull_request`/`schedule` exige uma ação prévia do dono em Settings → Code security
   → CodeQL: Default → Advanced.
3. **Apertar a baseline depois que a contagem cai**: `node scripts/check/check-codeql-ratchet.mjs
   --update` grava o novo valor medido em `config/quality/quality-baseline.json` →
   `metrics.codeqlAlerts.value`, para o ratchet não permitir silenciosamente uma regressão de
   volta ao teto antigo.
4. **Dismissals são decisão do operador (Hard Rule #14)** — nunca dispensar um alerta CodeQL
   sem registrar a justificativa técnica no comentário de dismissal.

Também adicionado um ponteiro na linha do `check:codeql-ratchet` na tabela de inventário de
gates (Job `quality-gate`, ~linha 103) apontando para a nova subseção.

## Exemplo real citado (2026-09-02/03)

- **#12502** — `fix(security): unbiased maxai X-Random nonce + stricter URL/regex test
  assertions (destrava o gate codeql-ratchet)`: corrigiu 7 alertas reais, contagem medida
  13 → 6.
- **#12530** — `chore(quality): tighten the CodeQL ratchet baseline from 11 to 6`: apertou a
  baseline congelada de 11 para 6, alinhando com a contagem real pós-fix.
- Os 6 alertas restantes foram então dispensados individualmente com justificativa por
  alerta (Hard Rule #14) → 0 alertas abertos hoje (confirmado via `gh api
  repos/diegosouzapw/OmniRoute/code-scanning/alerts` nesta sessão).

## Escopo

Apenas `docs/architecture/QUALITY_GATES.md` foi tocado. Nenhum workflow de CI, script de
gate, ou configuração de repositório foi alterado.

## Verificação (foreground)

| Comando | Exit | Resultado |
|---|---|---|
| `npm run check:docs-all` | 0 | `check:docs-sync` limpo; `check:doc-links` PASS (149 docs, 953 links); `check:fabricated-docs --strict` PASS (0 referências fabricadas) |

Base `release/v3.8.51` está com a issue `🔴 Release branch not green` (#12581) aberta no
momento da abertura desta PR — inherited, não introduzido por esta mudança (PR docs-only).