### PR TITLE
fix(quality): re-point the zcodeProtocol public-creds allowlist to line 313 (base-red)

### DIFF
--- a/scripts/check/check-public-creds.mjs
+++ b/scripts/check/check-public-creds.mjs
@@ -90,14 +90,18 @@ const ENV_KEY_RE = /(clientId|clientSecret|apiKey)Env\s*:/;
 //   The MiniMax family was extracted from services/usage.ts into services/usage/minimax.ts
 //   (god-file decomposition), so the FP moved with the getMiniMaxUsage signature.
 //
-//   open-sse/executors/zcodeProtocol.ts L302: `clientId: \`omniroute-${process.pid}\``
+//   open-sse/executors/zcodeProtocol.ts L313: `clientId: \`omniroute-${process.pid}\``
 //   is the per-process identifier in the local ZCode app-server handshake. It is
 //   generated from the process PID, is not an upstream OAuth/client credential, and
 //   must remain visible in the wire contract. Frozen by file:line:value key.
+//   NOTE: the key includes the LINE, so any edit that shifts this statement breaks
+//   the gate twice over — a stale-entry error plus a "new violation" for the same
+//   literal. That is what happened here (L302 -> L313). Re-point the line; do not
+//   remove the entry.
 export const KNOWN_LITERAL_CREDS = new Set([
   "open-sse/services/usage/minimax.ts:213:minimax", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (getMiniMaxUsage signature)
   "open-sse/services/usage/minimax.ts:213:minimax-cn", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (getMiniMaxUsage signature)
-  "open-sse/executors/zcodeProtocol.ts:302:omniroute-${process.pid}", // local per-process ZCode handshake ID, not an upstream credential
+  "open-sse/executors/zcodeProtocol.ts:313:omniroute-${process.pid}", // local per-process ZCode handshake ID, not an upstream credential
 ]);
 
 /**

--- a/tests/unit/check-public-creds.test.ts
+++ b/tests/unit/check-public-creds.test.ts
@@ -68,7 +68,10 @@ test("allowlist freezes a literal by file:line:value key", () => {
 });
 
 test("allowlist preserves the local ZCode handshake client ID without weakening credential detection", () => {
-  const src = `${"\n".repeat(301)}clientId: \`omniroute-\${process.pid}\`,`;
+  // 312 newlines puts the statement on line 313, which is where it lives in
+  // zcodeProtocol.ts today. The allowlist key carries the line number, so this
+  // literal has to be kept in step with the source (it moved 302 -> 313).
+  const src = `${"\n".repeat(312)}clientId: \`omniroute-\${process.pid}\`,`;
   assert.deepEqual(
     findLiteralCreds(src, KNOWN_LITERAL_CREDS, "open-sse/executors/zcodeProtocol.ts"),
     []


### PR DESCRIPTION
`check:public-creds` has been failing `Fast Quality Gates` on every open PR against `release/v3.8.51` — including the two security PRs merged today (#12600, #12601), where I had to discriminate it as inherited rather than fix it inside a feature branch.

## Nothing regressed — the allowlist key went stale

The gate reported the *same literal* twice:

```
✗ 1 entrada(s) obsoleta(s) na allowlist — zcodeProtocol.ts:302
✗ 1 credencial(is) pública(s) como string literal — zcodeProtocol.ts L313
```

`KNOWN_LITERAL_CREDS` is keyed by `file:line:value`. An edit shifted `clientId: \`omniroute-${process.pid}\`` from line 302 to 313, which invalidated the frozen key — so the gate flagged the entry as stale **and** the literal as a brand-new violation, for one unchanged line of code.

## The fix

Re-point the key and its comment to 313. The literal is unchanged and stays frozen: the entry is not removed and the detector is not weakened — the gate's own test still asserts that renaming the value to `upstream-client-` is flagged.

`tests/unit/check-public-creds.test.ts` synthesizes the source with a newline count so the statement lands on the allowlisted line, so that count moves too (301 → 312 newlines = line 313). The test keeps pinning the real contract instead of a stale one.

## The sharp edge, documented inline

Keying by line number means **any edit near this statement breaks the gate in two places at once**, and the remedy is to re-point the line, never to drop the entry — dropping it would un-freeze a literal that was audited and deliberately kept.

Tightening the key to `file:value` would remove the trap entirely, but it widens what a single entry freezes (the same literal anywhere in the file). That is a real trade-off and does not belong in a base-red drain, so it is a note in the source rather than a change here.

## Validation

- `check:public-creds` — OK (1563 files, 3 frozen literals)
- `tests/unit/check-public-creds.test.ts` — **20/20**
- `check:tracked-artifacts` — OK; `prettier --check` clean; `eslint` clean (1 pre-existing ignore-pattern warning on the `.mjs` script)
