### PR TITLE
chore(quality): rebaseline file-size caps the HouMinXi batch grew past when stacked

### DIFF
--- a/changelog.d/maintenance/houminxi-batch-filesize.md
+++ b/changelog.d/maintenance/houminxi-batch-filesize.md
@@ -1,0 +1,1 @@
+- **chore(quality):** rebaseline the file-size caps the HouMinXi batch grew past when its PRs stacked (`providers/page.tsx`, `chatCore.ts`, `accountFallback.ts`) — each PR measured correctly in isolation, none saw the stacking

--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -415,12 +415,12 @@
     "open-sse/executors/codex.ts": 1499,
     "open-sse/executors/cursor.ts": 1759,
     "open-sse/executors/muse-spark-web.ts": 1405,
-    "open-sse/handlers/chatCore.ts": 5981,
+    "open-sse/handlers/chatCore.ts": 5984,
     "open-sse/handlers/imageGeneration.ts": 3259,
     "open-sse/handlers/search.ts": 1789,
     "open-sse/mcp-server/schemas/tools.ts": 1621,
     "open-sse/mcp-server/server.ts": 1572,
-    "open-sse/services/accountFallback.ts": 2461,
+    "open-sse/services/accountFallback.ts": 2467,
     "open-sse/services/adobeFireflyBrowserLogin.ts": 1401,
     "open-sse/services/combo.ts": 4023,
     "open-sse/translator/response/openai-responses.ts": 1466,
@@ -435,7 +435,7 @@
     "src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx": 1319,
     "src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx": 2491,
     "src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx": 1631,
-    "src/app/(dashboard)/dashboard/providers/page.tsx": 2007,
+    "src/app/(dashboard)/dashboard/providers/page.tsx": 2025,
     "src/app/(dashboard)/dashboard/runtime/RuntimePageClient.tsx": 1201,
     "src/app/(dashboard)/dashboard/settings/components/ProxyRegistryManager.tsx": 1475,
     "src/app/(dashboard)/dashboard/settings/components/ResilienceTab.tsx": 1271,
@@ -633,5 +633,6 @@
   "open-sse/executors/chatgpt-web.ts": "3241",
   "_rebaseline_2026_08_30_11771_vercel_gateway_passthrough": "PR #11771 adds passthroughModels: true (1 line) to the Vercel AI Gateway registry entry — no split available, single-line provider-config addition.",
   "_relax_velocity_2026_08_30": "127 frozen line caps and cap/testCap raised by 20% (velocity phase; see quality-baseline.json _policy).",
-  "_rebaseline_2026_09_02_12325_merge_v3851": "Merge of release/v3.8.51 into #12325. Both sides grew chatCore.ts at the same chokepoint: #12239 took it 5946->5976 upstream, and this PR adds its +9 non-Codex 429 branch on top. check-file-size.mjs counts split(\"\\\\n\").length (trailing-newline empty element), so the merged file is 5981. The cap is the merged LOC, not either side alone; no other entry moves."
+  "_rebaseline_2026_09_02_12325_merge_v3851": "Merge of release/v3.8.51 into #12325. Both sides grew chatCore.ts at the same chokepoint: #12239 took it 5946->5976 upstream, and this PR adds its +9 non-Codex 429 branch on top. check-file-size.mjs counts split(\"\\\\n\").length (trailing-newline empty element), so the merged file is 5981. The cap is the merged LOC, not either side alone; no other entry moves.",
+  "_rebaseline_2026_09_03_houminxi_batch_stacked": "Crescimento medido DEPOIS que os 9 PRs da leva HouMinXi entraram, quando cada um empilhou sobre o rebaseline do anterior: providers/page.tsx 2007->2025 (+18 = feedback de erro por linha do import CSV do #12504 somado a busca por nome/baseUrl do #12495, ambos no mesmo painel de conexoes); chatCore.ts 5981->5984 (+3 = o #12325 invalida o cache generico de quota no 429 upstream, ao lado do ramo Codex ja existente); accountFallback.ts 2461->2467 (+6 = o #12566 empilha a carve-out de familia Antigravity sobre o rebaseline 2422->2461 que o #12590 registrou para o carve-out credits_exhausted da Moonshot; os dois tocam checkFallbackError). Cada PR mediu certo isoladamente, mas nenhum enxergava o empilhamento. Fiacao em chokepoints existentes. NAO cobre codex.ts nem stream.ts, que ja violavam no tip antes desta leva (drift da base)."
 }


### PR DESCRIPTION
The nine PRs of the HouMinXi batch (#12312 #12495 #12325 #12504 #12487 #12488 #12566 #12557 #12590) each measured their own file-size growth correctly against the tip they forked from. Three files were touched by more than one of them, so the caps only broke once they were **stacked** — which is why every PR was green on its own and the release tip went red after they all landed.

Measured on the release tip with all nine merged:

```
src/app/(dashboard)/dashboard/providers/page.tsx  2007 -> 2025  (+18)
open-sse/handlers/chatCore.ts                     5981 -> 5984  (+3)
open-sse/services/accountFallback.ts              2461 -> 2467  (+6)
```

- `providers/page.tsx` — #12504's per-row CSV import errors plus #12495's name/baseUrl search, both in the same connections panel.
- `chatCore.ts` — #12325 drops the generic quota cache on an upstream 429, next to the existing Codex 429 branch.
- `accountFallback.ts` — #12566 stacks the Antigravity family carve-out on top of the `2422 -> 2461` rebaseline #12590 had already registered for Moonshot's `credits_exhausted` carve-out. Both touch `checkFallbackError`.

All three are wiring at existing chokepoints, not extractable without splitting the functions mid-response-flow.

**Deliberately not included:** `open-sse/executors/codex.ts` (1503 > 1499) and `open-sse/utils/stream.ts` (3078 > 3072). Both were already over their caps on the pure tip before this batch — that is base drift and belongs to its own base-red sweep, not here.

After this PR the only remaining `check-file-size` violations are those two.
