### PR TITLE
fix(ci): retarget public-creds allowlist after zcodeProtocol line drift

### DIFF
--- a/scripts/check/check-public-creds.mjs
+++ b/scripts/check/check-public-creds.mjs
@@ -90,14 +90,14 @@ const ENV_KEY_RE = /(clientId|clientSecret|apiKey)Env\s*:/;
 //   The MiniMax family was extracted from services/usage.ts into services/usage/minimax.ts
 //   (god-file decomposition), so the FP moved with the getMiniMaxUsage signature.
 //
-//   open-sse/executors/zcodeProtocol.ts L302: `clientId: \`omniroute-${process.pid}\``
+//   open-sse/executors/zcodeProtocol.ts L313: `clientId: \`omniroute-${process.pid}\``
 //   is the per-process identifier in the local ZCode app-server handshake. It is
 //   generated from the process PID, is not an upstream OAuth/client credential, and
 //   must remain visible in the wire contract. Frozen by file:line:value key.
 export const KNOWN_LITERAL_CREDS = new Set([
   "open-sse/services/usage/minimax.ts:213:minimax", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (getMiniMaxUsage signature)
   "open-sse/services/usage/minimax.ts:213:minimax-cn", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (getMiniMaxUsage signature)
-  "open-sse/executors/zcodeProtocol.ts:302:omniroute-${process.pid}", // local per-process ZCode handshake ID, not an upstream credential
+  "open-sse/executors/zcodeProtocol.ts:313:omniroute-${process.pid}", // local per-process ZCode handshake ID, not an upstream credential
 ]);
 
 /**

--- a/tests/unit/check-public-creds.test.ts
+++ b/tests/unit/check-public-creds.test.ts
@@ -68,7 +68,7 @@ test("allowlist freezes a literal by file:line:value key", () => {
 });
 
 test("allowlist preserves the local ZCode handshake client ID without weakening credential detection", () => {
-  const src = `${"\n".repeat(301)}clientId: \`omniroute-\${process.pid}\`,`;
+  const src = `${"\n".repeat(312)}clientId: \`omniroute-\${process.pid}\`,`;
   assert.deepEqual(
     findLiteralCreds(src, KNOWN_LITERAL_CREDS, "open-sse/executors/zcodeProtocol.ts"),
     []


### PR DESCRIPTION
## Summary
`check:public-creds` keys the ZCode handshake `clientId` as `file:line:value`. On `release/v3.8.51` the literal moved from L302 to L313, so the allowlist entry is stale and the live assignment is a new violation.

Every open PR against this base fails Fast Quality Gates with:

```
1 gate(s) failed: public-creds
open-sse/executors/zcodeProtocol.ts:302:omniroute-${process.pid}  (stale)
open-sse/executors/zcodeProtocol.ts L313: clientId = "omniroute-${process.pid}"  (live)
```

None of those PRs touch `zcodeProtocol.ts`. This retargets the frozen key (and the unit fixture that pads to that line).

## Test plan
- [x] `node scripts/check/check-public-creds.mjs` → OK
- [x] `node --import tsx/esm --test tests/unit/check-public-creds.test.ts` → 20/20

## Not in this PR
- Moving the handshake ID behind `resolvePublicCred()` (still a local per-process id, not an upstream credential)

Signed-off-by: Minxi Hou <houminxi@gmail.com>