### PR TITLE
chore(quality): rebaseline file-size caps the hartmark batch grew past

### DIFF
--- a/changelog.d/maintenance/hartmark-batch-filesize.md
+++ b/changelog.d/maintenance/hartmark-batch-filesize.md
@@ -1,0 +1,1 @@
+- **chore(quality):** rebaseline the file-size caps the hartmark batch grew past (`combos/page.tsx` via [#12355](https://github.com/diegosouzapw/OmniRoute/pull/12355), `open-sse/services/combo.ts` via [#12338](https://github.com/diegosouzapw/OmniRoute/pull/12338))

--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -422,7 +422,7 @@
     "open-sse/mcp-server/server.ts": 1572,
     "open-sse/services/accountFallback.ts": 2467,
     "open-sse/services/adobeFireflyBrowserLogin.ts": 1401,
-    "open-sse/services/combo.ts": 4023,
+    "open-sse/services/combo.ts": 4036,
     "open-sse/translator/response/openai-responses.ts": 1466,
     "open-sse/utils/cursorAgentProtobuf.ts": 1547,
     "open-sse/utils/proxyFetch.ts": 1271,
@@ -431,7 +431,7 @@
     "open-sse/vendor/codex-chatgpt-web/bridge.ts": 1322,
     "src/app/(dashboard)/dashboard/HomePageClient.tsx": 1344,
     "src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx": 3186,
-    "src/app/(dashboard)/dashboard/combos/page.tsx": 5012,
+    "src/app/(dashboard)/dashboard/combos/page.tsx": 5018,
     "src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx": 1319,
     "src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx": 2491,
     "src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx": 1631,
@@ -634,5 +634,6 @@
   "_rebaseline_2026_08_30_11771_vercel_gateway_passthrough": "PR #11771 adds passthroughModels: true (1 line) to the Vercel AI Gateway registry entry — no split available, single-line provider-config addition.",
   "_relax_velocity_2026_08_30": "127 frozen line caps and cap/testCap raised by 20% (velocity phase; see quality-baseline.json _policy).",
   "_rebaseline_2026_09_02_12325_merge_v3851": "Merge of release/v3.8.51 into #12325. Both sides grew chatCore.ts at the same chokepoint: #12239 took it 5946->5976 upstream, and this PR adds its +9 non-Codex 429 branch on top. check-file-size.mjs counts split(\"\\\\n\").length (trailing-newline empty element), so the merged file is 5981. The cap is the merged LOC, not either side alone; no other entry moves.",
-  "_rebaseline_2026_09_03_houminxi_batch_stacked": "Crescimento medido DEPOIS que os 9 PRs da leva HouMinXi entraram, quando cada um empilhou sobre o rebaseline do anterior: providers/page.tsx 2007->2025 (+18 = feedback de erro por linha do import CSV do #12504 somado a busca por nome/baseUrl do #12495, ambos no mesmo painel de conexoes); chatCore.ts 5981->5984 (+3 = o #12325 invalida o cache generico de quota no 429 upstream, ao lado do ramo Codex ja existente); accountFallback.ts 2461->2467 (+6 = o #12566 empilha a carve-out de familia Antigravity sobre o rebaseline 2422->2461 que o #12590 registrou para o carve-out credits_exhausted da Moonshot; os dois tocam checkFallbackError). Cada PR mediu certo isoladamente, mas nenhum enxergava o empilhamento. Fiacao em chokepoints existentes. NAO cobre codex.ts nem stream.ts, que ja violavam no tip antes desta leva (drift da base)."
+  "_rebaseline_2026_09_03_houminxi_batch_stacked": "Crescimento medido DEPOIS que os 9 PRs da leva HouMinXi entraram, quando cada um empilhou sobre o rebaseline do anterior: providers/page.tsx 2007->2025 (+18 = feedback de erro por linha do import CSV do #12504 somado a busca por nome/baseUrl do #12495, ambos no mesmo painel de conexoes); chatCore.ts 5981->5984 (+3 = o #12325 invalida o cache generico de quota no 429 upstream, ao lado do ramo Codex ja existente); accountFallback.ts 2461->2467 (+6 = o #12566 empilha a carve-out de familia Antigravity sobre o rebaseline 2422->2461 que o #12590 registrou para o carve-out credits_exhausted da Moonshot; os dois tocam checkFallbackError). Cada PR mediu certo isoladamente, mas nenhum enxergava o empilhamento. Fiacao em chokepoints existentes. NAO cobre codex.ts nem stream.ts, que ja violavam no tip antes desta leva (drift da base).",
+  "_rebaseline_2026_09_03_hartmark_batch": "Leva hartmark (#12293 #12355 #12447 #12445 #12446 #12460 #12461 #12338 #12448) crescimento proprio, medido no tip com os nove mergeados: src/app/(dashboard)/dashboard/combos/page.tsx 5012->5018 (+6, #12355 impede que a falha de bundling do tiktoken de um provider sem relacao derrube /api/providers, e o painel passa a lidar com o estado degradado); open-sse/services/combo.ts 4023->4036 (+13, #12338 nos fixes do universal-handoff: nota de bare-fallback, escopo por mesma requisicao e log da falha silenciosa). Fiacao em chokepoints existentes do roteamento de combo. NAO cobre codex.ts nem stream.ts, ja violando no tip antes desta leva (drift da base)."
 }


### PR DESCRIPTION
Same pattern as #12619, for the hartmark batch (#12293 #12355 #12447 #12445 #12446 #12460 #12461 #12338 #12448): each PR measured its own growth correctly against the tip it forked from, but the caps only broke once they were all on the branch.

Measured on the release tip with all nine merged:

```
src/app/(dashboard)/dashboard/combos/page.tsx  5012 -> 5018  (+6)
open-sse/services/combo.ts                     4023 -> 4036  (+13)
```

- `combos/page.tsx` — #12355 stops an unrelated provider's tiktoken bundling failure from crashing `/api/providers`, and the panel now handles the degraded state.
- `open-sse/services/combo.ts` — #12338's universal-handoff fixes: the bare-fallback note, same-request scoping, and silent-failure logging.

Both are wiring at existing combo-routing chokepoints.

**Deliberately not included:** `open-sse/executors/codex.ts` (1503 > 1499) and `open-sse/utils/stream.ts` (3078 > 3072) — both were already over their caps on the pure tip before this batch. That is base drift and belongs to its own sweep.

After this PR the only remaining `check-file-size` violations are those two.
