### PR TITLE
feat(api): emit gateway-measured tokens-per-second excluding TTFT

### DIFF
--- a/changelog.d/features/12616-tokens-per-second.md
+++ b/changelog.d/features/12616-tokens-per-second.md
@@ -1,0 +1,1 @@
+- **feat(api):** Emit gateway-measured `tokens_per_second` (TTFT excluded) on streaming usage and `X-OmniRoute-Tokens-Per-Second` when first-token latency is known ([#12616](https://github.com/diegosouzapw/OmniRoute/issues/12616))

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -854,6 +854,9 @@
   "src/app/(dashboard)/dashboard/combos/page.tsx": {
     "@typescript-eslint/no-unused-vars": {
       "count": 6
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx": {

--- a/open-sse/utils/generationThroughput.ts
+++ b/open-sse/utils/generationThroughput.ts
@@ -5,7 +5,10 @@
  * first-token wait and is not generation speed. When TTFT is unknown (typical
  * non-streaming JSON), omit the field rather than guessing.
  */
-export function generationDurationMs(totalMs: number, ttftMs: number | null | undefined): number | null {
+export function generationDurationMs(
+  totalMs: number,
+  ttftMs: number | null | undefined
+): number | null {
   if (!Number.isFinite(totalMs) || totalMs <= 0) return null;
   if (ttftMs == null || !Number.isFinite(ttftMs) || ttftMs < 0) return null;
   const generationMs = totalMs - ttftMs;

--- a/open-sse/utils/generationThroughput.ts
+++ b/open-sse/utils/generationThroughput.ts
@@ -1,0 +1,41 @@
+/**
+ * Gateway-measured generation throughput (#12616).
+ *
+ * tok/s MUST exclude TTFT. `output_tokens / total_latency` includes queueing and
+ * first-token wait and is not generation speed. When TTFT is unknown (typical
+ * non-streaming JSON), omit the field rather than guessing.
+ */
+export function generationDurationMs(totalMs: number, ttftMs: number | null | undefined): number | null {
+  if (!Number.isFinite(totalMs) || totalMs <= 0) return null;
+  if (ttftMs == null || !Number.isFinite(ttftMs) || ttftMs < 0) return null;
+  const generationMs = totalMs - ttftMs;
+  return generationMs > 0 ? generationMs : null;
+}
+
+export function tokensPerSecond(
+  outputTokens: number,
+  generationMs: number | null | undefined
+): number | null {
+  if (generationMs == null || !Number.isFinite(generationMs) || generationMs <= 0) return null;
+  if (!Number.isFinite(outputTokens) || outputTokens <= 0) return null;
+  return outputTokens / (generationMs / 1000);
+}
+
+function outputTokenCount(usage: Record<string, unknown>): number {
+  const raw =
+    usage.completion_tokens ??
+    usage.output_tokens ??
+    usage.candidatesTokenCount ??
+    usage.outputTokens ??
+    usage.completionTokens;
+  const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Attach `tokens_per_second` when generation duration (excluding TTFT) is known. */
+export function attachTokensPerSecond<T>(usage: T, generationMs: number | null | undefined): T {
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return usage;
+  const tps = tokensPerSecond(outputTokenCount(usage as Record<string, unknown>), generationMs);
+  if (tps == null) return usage;
+  return { ...(usage as Record<string, unknown>), tokens_per_second: Number(tps.toFixed(3)) } as T;
+}

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1036,11 +1036,11 @@ export function createSSEStream(options: StreamOptions = {}) {
       totalContentLength > 0
     ) {
       const estimated = estimateUsage(body, totalContentLength, sourceFormat);
-      itemSanitized.usage = filterUsageForFormat(estimated, sourceFormat);
+      itemSanitized.usage = timing.withTps(filterUsageForFormat(estimated, sourceFormat));
       state.usage = estimated;
     } else if (state?.finishReason && isFinishChunk && state.usage) {
       const buffered = addBufferToUsage(state.usage);
-      itemSanitized.usage = filterUsageForFormat(buffered, sourceFormat);
+      itemSanitized.usage = timing.withTps(filterUsageForFormat(buffered, sourceFormat));
     }
 
     if (
@@ -1079,8 +1079,8 @@ export function createSSEStream(options: StreamOptions = {}) {
       model,
       cacheHit: false,
       latencyMs: Date.now() - streamStartedAt,
-      usage: finalUsage,
-      costUsd,
+      usage: timing.withTps(finalUsage),
+      costUsd, ttftMs: timing.ttftMs(),
     });
     if (!comment) return;
     reqLogger?.appendConvertedChunk?.(comment);
@@ -2006,7 +2006,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // estimate is now emitted in flush(), only when the upstream stayed silent.
                   if (isFinishChunk && hasValidUsage(usage) && !passthroughForwardedUsage) {
                     const buffered = addBufferToUsage(usage);
-                    parsed.usage = filterUsageForFormat(buffered, sourceFormat || FORMATS.OPENAI);
+                    parsed.usage = timing.withTps(filterUsageForFormat(buffered, sourceFormat || FORMATS.OPENAI));
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     passthroughForwardedUsage = true;
                     injectedUsage = true;
@@ -2532,7 +2532,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   created: Math.floor(Date.now() / 1000),
                   model,
                   choices: [],
-                  usage: filterUsageForFormat(usage, sourceFormat || FORMATS.OPENAI),
+                  usage: timing.withTps(filterUsageForFormat(usage, sourceFormat || FORMATS.OPENAI)),
                 };
                 const usageOutput = `data: ${JSON.stringify(usageOnlyChunk)}\n\n`;
                 reqLogger?.appendConvertedChunk?.(usageOutput);

--- a/open-sse/utils/streamTiming.ts
+++ b/open-sse/utils/streamTiming.ts
@@ -30,6 +30,8 @@
  * instances as absolute times — the same convention `earlyStreamKeepalive.ts`
  * already follows on this streaming path.
  */
+import { attachTokensPerSecond, generationDurationMs } from "./generationThroughput.js";
+
 export interface StreamTiming {
   startedAt: number;
   firstByteAt: number | null;
@@ -48,6 +50,10 @@ export interface StreamTiming {
   avgItlMs(): number | null;
   /** Time from stream start to completion (ms). */
   totalMs(): number;
+  /**
+   * Attach gateway-measured tok/s (TTFT excluded). No-op when TTFT is unknown.
+   */
+  withTps<T>(usage: T): T;
 }
 
 /** Max number of inter-chunk samples kept (bounds memory). */
@@ -87,6 +93,9 @@ export function createStreamTiming(): StreamTiming {
     },
     totalMs() {
       return performance.now() - this.startedAt;
+    },
+    withTps(usage) {
+      return attachTokensPerSecond(usage, generationDurationMs(this.totalMs(), this.ttftMs()));
     },
   };
   return timing;

--- a/open-sse/utils/streamTiming.ts
+++ b/open-sse/utils/streamTiming.ts
@@ -30,7 +30,7 @@
  * instances as absolute times — the same convention `earlyStreamKeepalive.ts`
  * already follows on this streaming path.
  */
-import { attachTokensPerSecond, generationDurationMs } from "./generationThroughput.js";
+import { attachTokensPerSecond, generationDurationMs } from "./generationThroughput.ts";
 
 export interface StreamTiming {
   startedAt: number;

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -293,6 +293,7 @@ export function filterUsageForFormat(usage: UsageLike | null | undefined, target
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "estimated",
+      "tokens_per_second",
     ],
     [FORMATS.GEMINI]: [
       "promptTokenCount",
@@ -301,6 +302,7 @@ export function filterUsageForFormat(usage: UsageLike | null | undefined, target
       "cachedContentTokenCount",
       "thoughtsTokenCount",
       "estimated",
+      "tokens_per_second",
     ],
     [FORMATS.OPENAI_RESPONSES]: [
       "input_tokens",
@@ -312,6 +314,7 @@ export function filterUsageForFormat(usage: UsageLike | null | undefined, target
       "cost_in_usd_ticks",
       "server_side_tool_usage_details",
       "server_side_tool_usage",
+      "tokens_per_second",
     ],
     // OpenAI format (default for OPENAI, CODEX, KIRO, etc.)
     default: [
@@ -327,6 +330,7 @@ export function filterUsageForFormat(usage: UsageLike | null | undefined, target
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "estimated",
+      "tokens_per_second",
     ],
   };
 

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -675,9 +675,20 @@ export function hasValidUsage(usage: UsageLike | null | undefined) {
 export function isEmptyUsage(usage: unknown): boolean {
   if (!usage || typeof usage !== "object" || Array.isArray(usage)) return true;
   const u = usage as Record<string, unknown>;
-  for (const k of ["prompt_tokens","completion_tokens","total_tokens","input_tokens","output_tokens","promptTokenCount","candidatesTokenCount","totalTokenCount"]) {
+  for (const k of [
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "input_tokens",
+    "output_tokens",
+    "promptTokenCount",
+    "candidatesTokenCount",
+    "totalTokenCount",
+  ]) {
     const v = u[k];
-    if (typeof v === "number" && Number.isFinite(v)) { if (v > 0) return false; }
+    if (typeof v === "number" && Number.isFinite(v)) {
+      if (v > 0) return false;
+    }
   }
   return true;
 }

--- a/src/domain/omnirouteResponseMeta.ts
+++ b/src/domain/omnirouteResponseMeta.ts
@@ -1,6 +1,10 @@
 import { getProviderAlias } from "@/shared/constants/providers";
 import { OMNIROUTE_RESPONSE_HEADERS } from "@/shared/constants/headers";
 import { APP_CONFIG } from "@/shared/constants/appConfig";
+import {
+  generationDurationMs,
+  tokensPerSecond,
+} from "@omniroute/open-sse/utils/generationThroughput";
 
 type UsageLike = Record<string, unknown> | null | undefined;
 
@@ -123,6 +127,7 @@ export function buildOmniRouteResponseMetaHeaders({
   requestId = null,
   strategy = null,
   usage = null,
+  ttftMs = null,
 }: {
   cacheHit?: boolean;
   costUsd?: unknown;
@@ -145,6 +150,12 @@ export function buildOmniRouteResponseMetaHeaders({
    */
   strategy?: string | null;
   usage?: UsageLike;
+  /**
+   * First-token latency in ms. Required to emit tok/s: generation speed is
+   * `output_tokens / (latencyMs - ttftMs)` and MUST omit the field when TTFT
+   * is unknown so plugins do not treat `tokens / total_latency` as speed.
+   */
+  ttftMs?: number | null;
 }): Record<string, string> {
   const tokens = getOmniRouteTokenCounts(usage);
   const headers: Record<string, string> = {
@@ -184,6 +195,18 @@ export function buildOmniRouteResponseMetaHeaders({
   const decisionValue = buildOmniRouteDecisionHeaderValue({ strategy, provider, latencyMs });
   if (decisionValue !== null) {
     headers[OMNIROUTE_RESPONSE_HEADERS.decision] = decisionValue;
+  }
+
+  let tps = tokensPerSecond(
+    tokens.output,
+    generationDurationMs(toFiniteNumber(latencyMs), ttftMs)
+  );
+  if (tps == null && usage && typeof usage === "object") {
+    const fromUsage = toFiniteNumber((usage as Record<string, unknown>).tokens_per_second);
+    if (fromUsage > 0) tps = fromUsage;
+  }
+  if (tps != null) {
+    headers[OMNIROUTE_RESPONSE_HEADERS.tokensPerSecond] = toHeaderValue(tps.toFixed(3));
   }
 
   return headers;

--- a/src/domain/omnirouteResponseMeta.ts
+++ b/src/domain/omnirouteResponseMeta.ts
@@ -197,10 +197,7 @@ export function buildOmniRouteResponseMetaHeaders({
     headers[OMNIROUTE_RESPONSE_HEADERS.decision] = decisionValue;
   }
 
-  let tps = tokensPerSecond(
-    tokens.output,
-    generationDurationMs(toFiniteNumber(latencyMs), ttftMs)
-  );
+  let tps = tokensPerSecond(tokens.output, generationDurationMs(toFiniteNumber(latencyMs), ttftMs));
   if (tps == null && usage && typeof usage === "object") {
     const fromUsage = toFiniteNumber((usage as Record<string, unknown>).tokens_per_second);
     if (fromUsage > 0) tps = fromUsage;

--- a/src/shared/constants/headers.ts
+++ b/src/shared/constants/headers.ts
@@ -14,5 +14,6 @@ export const OMNIROUTE_RESPONSE_HEADERS = {
   responseCost: "X-OmniRoute-Response-Cost",
   tokensIn: "X-OmniRoute-Tokens-In",
   tokensOut: "X-OmniRoute-Tokens-Out",
+  tokensPerSecond: "X-OmniRoute-Tokens-Per-Second",
   version: "X-OmniRoute-Version",
 } as const;

--- a/tests/unit/generation-throughput.test.ts
+++ b/tests/unit/generation-throughput.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  attachTokensPerSecond,
+  generationDurationMs,
+  tokensPerSecond,
+} from "../../open-sse/utils/generationThroughput.ts";
+import { filterUsageForFormat } from "../../open-sse/utils/usageTracking.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+import { createStreamTiming } from "../../open-sse/utils/streamTiming.ts";
+import {
+  buildOmniRouteResponseMetaHeaders,
+  buildOmniRouteSseMetadataComment,
+} from "../../src/domain/omnirouteResponseMeta.ts";
+import { OMNIROUTE_RESPONSE_HEADERS } from "../../src/shared/constants/headers.ts";
+
+test("#12616 tok/s excludes TTFT (200 tokens over 2s generation after 3s TTFT)", () => {
+  const generationMs = generationDurationMs(5000, 3000);
+  assert.equal(generationMs, 2000);
+  assert.equal(tokensPerSecond(200, generationMs), 100);
+});
+
+test("#12616 tok/s is omitted when TTFT is unknown (do not use tokens/total_latency)", () => {
+  assert.equal(generationDurationMs(5000, null), null);
+  assert.equal(tokensPerSecond(200, null), null);
+  const usage = attachTokensPerSecond({ prompt_tokens: 10, completion_tokens: 200 }, null);
+  assert.equal((usage as { tokens_per_second?: number }).tokens_per_second, undefined);
+});
+
+test("#12616 tok/s is omitted when generation duration is not positive", () => {
+  assert.equal(generationDurationMs(3000, 3000), null);
+  assert.equal(generationDurationMs(2000, 3000), null);
+  assert.equal(tokensPerSecond(0, 2000), null);
+});
+
+test("#12616 filterUsageForFormat keeps tokens_per_second for OpenAI and Claude", () => {
+  const usage = { prompt_tokens: 10, completion_tokens: 20, tokens_per_second: 42.5 };
+  const openai = filterUsageForFormat(usage, FORMATS.OPENAI) as Record<string, unknown>;
+  const claude = filterUsageForFormat(
+    { input_tokens: 10, output_tokens: 20, tokens_per_second: 42.5 },
+    FORMATS.CLAUDE
+  ) as Record<string, unknown>;
+  assert.equal(openai.tokens_per_second, 42.5);
+  assert.equal(claude.tokens_per_second, 42.5);
+});
+
+test("#12616 headers omit tok/s without ttftMs and emit it when TTFT is known", () => {
+  const without = buildOmniRouteResponseMetaHeaders({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    latencyMs: 5000,
+    usage: { prompt_tokens: 11, completion_tokens: 200 },
+  });
+  assert.equal(without[OMNIROUTE_RESPONSE_HEADERS.tokensPerSecond], undefined);
+
+  const withTtft = buildOmniRouteResponseMetaHeaders({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    latencyMs: 5000,
+    ttftMs: 3000,
+    usage: { prompt_tokens: 11, completion_tokens: 200 },
+  });
+  assert.equal(withTtft[OMNIROUTE_RESPONSE_HEADERS.tokensPerSecond], "100.000");
+});
+
+test("#12616 SSE comment carries tok/s from usage.tokens_per_second when TTFT is unknown", () => {
+  const comment = buildOmniRouteSseMetadataComment({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    latencyMs: 50,
+    usage: { prompt_tokens: 4, completion_tokens: 2, tokens_per_second: 12.5 },
+  });
+  assert.match(comment, /^: x-omniroute-tokens-per-second=12.500/m);
+});
+
+test("#12616 StreamTiming.withTps attaches tok/s after first forward", async () => {
+  const t = createStreamTiming();
+  t.markForward();
+  await new Promise((r) => setTimeout(r, 25));
+  const usage = t.withTps({ prompt_tokens: 1, completion_tokens: 100 });
+  const tps = (usage as { tokens_per_second?: number }).tokens_per_second;
+  assert.equal(typeof tps, "number");
+  assert.ok(tps! > 0);
+});


### PR DESCRIPTION
## Summary

Harness plugins cannot show generation speed until OmniRoute puts a **gateway-measured** tok/s on the inference response. `output_tokens / latency_ms` is not tok/s: it includes TTFT (and tool pauses). This PR emits tok/s only when first-token latency is known.

- Streaming usage objects gain `usage.tokens_per_second` (3 decimal places).
- Meta headers gain `X-OmniRoute-Tokens-Per-Second` when TTFT is known, including the final SSE metadata comment.
- When TTFT is unknown (typical non-streaming JSON), the field is **omitted**. Plugins must show `—`, not invent a number.

## Related Issues

- Closes #12616
- Related to #12617 (official OpenCode plugin mapping)
- Related to plugin follow-ups that must not invent tok/s from `tokens / latency`

## Contract

| Signal | Where | Rule |
| --- | --- | --- |
| `usage.tokens_per_second` | final stream usage (OpenAI / Claude / Gemini / Responses allowlists) | `output_tokens / (totalMs - ttftMs)` |
| `X-OmniRoute-Tokens-Per-Second` | response meta headers + SSE comment | same value; omitted without TTFT |
| Failover / combo | winning model already on `X-OmniRoute-Model` / usage | tok/s is for the **winning** attempt only |

Frozen `open-sse/utils/stream.ts` stays line-count neutral: tok/s is attached via `StreamTiming.withTps()` on existing usage assignments.

## Validation

- [x] Change type: other (public inference telemetry / API headers)
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` (not run in this environment; CI runs it)
- [x] Branched from current `release/v3.8.51` tip
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in; it is not a PR gate.

Focused loop:

```bash
node --import tsx/esm --test tests/unit/generation-throughput.test.ts tests/unit/omniroute-response-meta.test.ts tests/unit/stream-timing.test.ts
```

Result locally: 30 pass / 0 fail. `open-sse/utils/stream.ts` remains 3077 lines.

## Tests Added Or Updated

- `tests/unit/generation-throughput.test.ts` (new) — TTFT exclusion, omit-when-unknown, allowlist keep, header + SSE comment, `StreamTiming.withTps`
- `tests/unit/omniroute-response-meta.test.ts` (existing suite still green)
- `tests/unit/stream-timing.test.ts` (existing suite still green)

## Coverage Notes

New helper `open-sse/utils/generationThroughput.ts` plus header/allowlist wiring. Coverage should go **up** on the new leaf; `stream.ts` only wraps existing usage lines.

## Reviewer Notes

- Do **not** compute tok/s as `tokens / X-OmniRoute-Latency-Ms`.
- Non-streaming JSON still has no first-token clock; omitting the field is intentional.
- Official OpenCode plugin (`@omniroute/opencode-plugin`) still needs #12617 to map this into session cost/speed UI.
- Changelog fragment: `changelog.d/features/12616-tokens-per-second.md`
