### PR TITLE
fix(dashboard): keep a request's pending-tracking id stable across combo target retries

### DIFF
--- a/src/lib/usage/usageHistory.ts
+++ b/src/lib/usage/usageHistory.ts
@@ -154,6 +154,7 @@ declare global {
           details: Record<string, Record<string, PendingRequestDetail[]>>;
         };
         pendingById: Map<string, PendingRequestDetail>;
+        pendingIdByCorrelation: Map<string, { id: string; touchedAt: number }>;
       }
     | undefined;
 }
@@ -173,6 +174,7 @@ const pendingState = (globalThis.__omnirouteUsageHistoryPendingState ??= {
     details: Object.create(null) as Record<string, Record<string, PendingRequestDetail[]>>,
   },
   pendingById: new Map<string, PendingRequestDetail>(),
+  pendingIdByCorrelation: new Map<string, { id: string; touchedAt: number }>(),
 });
 
 const pendingRequests = pendingState.pendingRequests;
@@ -182,6 +184,21 @@ const pendingRequests = pendingState.pendingRequests;
  * Populated when a detail is created and cleaned up when it is removed/finalized.
  */
 const pendingById = pendingState.pendingById;
+
+// Live incident: a combo dispatch calls trackPendingRequest once PER TARGET
+// ATTEMPT (open-sse/handlers/chatCore.ts's single "started" call site, hit
+// again on every fallback), each generating its OWN fresh id. A dashboard tab
+// polling /api/logs/<id> for the FIRST attempt goes stale the moment that
+// attempt finalizes and the combo silently retries with a different target
+// under a different id -- the tab has no way to discover the new id, and the
+// request keeps streaming (successfully) with nobody watching it live. Since
+// correlationId is already stable across every attempt of one client request
+// (see the trackPendingRequest call site's `correlationId` metadata field),
+// reusing the SAME pending id for every attempt sharing a correlationId keeps
+// one dashboard tab's poll target valid across combo fallbacks. Bounded by
+// PENDING_SWEEP_INTERVAL_MS's existing reaper cycle (see sweepStalePendingRequests)
+// so this never grows unboundedly with one-shot correlation ids.
+const pendingIdByCorrelation = pendingState.pendingIdByCorrelation;
 
 const DEFAULT_MAX_PENDING_REQUEST_AGE_MS = 60 * 60 * 1000;
 const MAX_PENDING_DETAILS = 5000;
@@ -249,6 +266,20 @@ export function sweepStalePendingRequests(
     for (const detail of oldest) remove(detail);
   }
 
+  // pendingIdByCorrelation entries are correlation ids, never reused across
+  // separate client requests, so nothing else ever removes them — same
+  // age/cap sweep as pendingById above, or the map grows unboundedly.
+  for (const [correlationId, entry] of pendingIdByCorrelation) {
+    if (now - entry.touchedAt > maxAgeMs) pendingIdByCorrelation.delete(correlationId);
+  }
+  if (pendingIdByCorrelation.size > MAX_PENDING_DETAILS) {
+    const overflow = pendingIdByCorrelation.size - MAX_PENDING_DETAILS;
+    const oldest = [...pendingIdByCorrelation.entries()]
+      .sort((a, b) => a[1].touchedAt - b[1].touchedAt)
+      .slice(0, overflow);
+    for (const [correlationId] of oldest) pendingIdByCorrelation.delete(correlationId);
+  }
+
   return removed;
 }
 
@@ -308,11 +339,23 @@ export function trackPendingRequest(
         pendingRequests.details[connectionId][modelKey] = [];
       }
       const now = Date.now();
+      // Reuse the same pending id across every target attempt of one client
+      // request (see pendingIdByCorrelation's module-level comment) so a
+      // dashboard tab's live poll survives a combo fallback to a different
+      // target instead of silently going stale. Concurrent speculative
+      // attempts (combo.ts's zeroLatencyOptimizationsEnabled hedging) can
+      // race two "started" calls for the same correlationId — the second
+      // simply overwrites the id-keyed view of the first's still-live entry,
+      // no worse than today's per-attempt id (which loses tracking entirely
+      // once any attempt finalizes) and self-corrects on the next attempt.
+      const reusableId = normalizedMetadata.correlationId
+        ? pendingIdByCorrelation.get(normalizedMetadata.correlationId)?.id
+        : undefined;
       const newDetail = {
         // crypto RNG (not Math.random) to satisfy CodeQL js/insecure-randomness —
         // this pending-request id flows into attempt logging; it's a correlation
         // id, not a security secret.
-        id: `${now}-${globalThis.crypto.randomUUID().slice(0, 6)}`,
+        id: reusableId ?? `${now}-${globalThis.crypto.randomUUID().slice(0, 6)}`,
         model,
         provider,
         connectionId,
@@ -321,6 +364,9 @@ export function trackPendingRequest(
       };
       pendingRequests.details[connectionId][modelKey].push(newDetail);
       pendingById.set(newDetail.id, newDetail);
+      if (normalizedMetadata.correlationId) {
+        pendingIdByCorrelation.set(normalizedMetadata.correlationId, { id: newDetail.id, touchedAt: now });
+      }
       return newDetail.id;
     } else if (!started && nextCount >= 0) {
       if (pendingRequests.details[connectionId]?.[modelKey]?.length) {
@@ -519,6 +565,7 @@ export function clearPendingRequests() {
     Record<string, PendingRequestDetail[]>
   >;
   pendingById.clear();
+  pendingIdByCorrelation.clear();
   clearCompletedDetails();
 }
 

--- a/tests/unit/usage-pending-sweep.test.ts
+++ b/tests/unit/usage-pending-sweep.test.ts
@@ -112,3 +112,88 @@ test("invalid pending sweep max age falls back to one hour", () => {
     else process.env.MAX_PENDING_REQUEST_AGE_MS = previous;
   }
 });
+
+// Live incident: a combo dispatch calls trackPendingRequest once PER TARGET
+// ATTEMPT (open-sse/handlers/chatCore.ts's single "started" call site, hit
+// again on every fallback), each previously generating its OWN fresh id. A
+// dashboard tab polling /api/logs/<id> for the FIRST attempt went stale the
+// moment that attempt finalized and the combo silently retried under a
+// different id -- the tab had no way to discover the new id, even though the
+// request kept streaming successfully. Fix: reuse the same pending id for
+// every attempt sharing a correlationId (already passed as metadata on every
+// "started" call, already stable across a combo's retries).
+test("trackPendingRequest reuses the same id across a combo's target-attempt retries sharing a correlationId", () => {
+  clearPendingRequests();
+
+  const firstId = trackPendingRequest("model-a", "provider-a", "conn-a", true, {
+    correlationId: "corr-retry-1",
+  });
+  assert.ok(firstId, "first attempt should produce an id");
+
+  // First target attempt finalizes (fails) -- the combo retries with a
+  // different target, but the SAME client-facing request/correlation.
+  trackPendingRequest("model-a", "provider-a", "conn-a", false);
+  assert.equal(getPendingById().has(firstId), false, "finalized attempt is removed by id");
+
+  const secondId = trackPendingRequest("model-b", "provider-b", "conn-b", true, {
+    correlationId: "corr-retry-1",
+  });
+
+  assert.equal(secondId, firstId, "retry attempt must reuse the first attempt's id");
+  assert.equal(getPendingById().has(firstId), true, "reused id is live again under the new attempt");
+  assert.equal(getPendingById().get(firstId)?.model, "model-b", "entry reflects the NEW attempt's target");
+
+  clearPendingRequests();
+});
+
+test("trackPendingRequest never reuses an id across two different correlationIds", () => {
+  clearPendingRequests();
+
+  const idA = trackPendingRequest("model-a", "provider-a", "conn-a", true, {
+    correlationId: "corr-unrelated-1",
+  });
+  const idB = trackPendingRequest("model-a", "provider-a", "conn-b", true, {
+    correlationId: "corr-unrelated-2",
+  });
+
+  assert.ok(idA && idB);
+  assert.notEqual(idA, idB, "unrelated client requests must never share a pending id");
+
+  clearPendingRequests();
+});
+
+test("trackPendingRequest without a correlationId keeps generating a fresh id every attempt (unchanged behavior)", () => {
+  clearPendingRequests();
+
+  const idA = trackPendingRequest("model-a", "provider-a", "conn-a", true);
+  trackPendingRequest("model-a", "provider-a", "conn-a", false);
+  const idB = trackPendingRequest("model-a", "provider-a", "conn-a", true);
+
+  assert.ok(idA && idB);
+  assert.notEqual(idA, idB, "no correlationId means no cross-attempt identity to reuse");
+
+  clearPendingRequests();
+});
+
+test("sweepStalePendingRequests evicts stale correlation-id-to-pending-id mappings so an old id can never resurface", () => {
+  clearPendingRequests();
+
+  const firstId = trackPendingRequest("model-a", "provider-a", "conn-a", true, {
+    correlationId: "corr-stale-mapping",
+  });
+  assert.ok(firstId);
+  trackPendingRequest("model-a", "provider-a", "conn-a", false);
+
+  // Sweep with a max age of 0 so the just-recorded correlation mapping (whose
+  // touchedAt is "now") is immediately treated as stale, mirroring what a
+  // real 1-hour-later sweep does to a genuinely abandoned mapping.
+  sweepStalePendingRequests(Date.now() + HOUR_MS + MINUTE_MS, HOUR_MS);
+
+  const secondId = trackPendingRequest("model-b", "provider-b", "conn-b", true, {
+    correlationId: "corr-stale-mapping",
+  });
+
+  assert.notEqual(secondId, firstId, "an evicted mapping must not resurrect the old id");
+
+  clearPendingRequests();
+});


### PR DESCRIPTION
## What Problem This Solves

A request's dashboard detail view ("Conversation Context" panel) stops
updating live partway through an in-progress request that internally
retries via combo fallback — even though the request keeps streaming and
eventually succeeds. Closing and reopening the tab picks up the final state
correctly, just under a different id than the one the user had open.

## Why This Change Was Made

`trackPendingRequest()` — the in-memory tracker `RequestLoggerDetail`'s
Conversation Context live-poll reads via `/api/logs/[id]` — is called once
**per combo target attempt** (`open-sse/handlers/chatCore.ts`'s single
"started" call site, hit again on every fallback), generating a brand new id
every time. A dashboard tab watching the first target attempt's id goes
stale the moment that attempt finalizes (fails) and the combo silently
retries with a different target under a completely different id — the tab's
poll just finds nothing live under the old one from then on.

Reported live against real usage (no redeploy in the window, so not a
dev-HMR/restart artifact) with symptoms matching this mechanism exactly.
Root-caused via direct tracing of `trackPendingRequest`'s per-attempt id
generation against `combo.ts`'s target-fallback loop — not a captured
end-to-end trace of one specific live combo retry; the regression test below
exercises the identical mechanism at the unit level instead.

## Fix

Reuse the same pending id across every target attempt that shares a
`correlationId`. `correlationId` is already stable across a combo's whole
retry sequence and already passed as metadata on every "started" call
(`chatCore.ts:933`) — this needed no new call-site threading, just a small
`correlationId -> pending-id` map inside `trackPendingRequest`'s "started"
branch. Bounded by the existing `sweepStalePendingRequests` reaper cycle
(same age/cap policy as `pendingById`) so it can never grow unboundedly with
one-shot correlation ids.

## User Impact

A dashboard tab open on an in-progress request now stays live across combo
fallbacks instead of silently going stale. No behavior change for a
single-attempt (non-retried) request, and no change for any caller that
doesn't pass a `correlationId`.

## Evidence

`tests/unit/usage-pending-sweep.test.ts`:
- New case **"reuses the same id across a combo's target-attempt retries
  sharing a correlationId"** — fails on pre-fix code (generates a second,
  different id instead of reusing the first).
- New case **"never reuses an id across two different correlationIds"**.
- New case **"without a correlationId keeps generating a fresh id every
  attempt (unchanged behavior)"**.
- New case **"evicts stale correlation-id-to-pending-id mappings so an old
  id can never resurface"**.

Full file: 9/9 passing. Sibling `usageHistory` suites
(`usagehistory-helpers-split`, `usageHistoryDedup`, `request-logger-endpoints`,
`conversations-active-call-log-id`, `active-request-stream-chunks-lifecycle`):
82/82 passing, no regressions. `eslint` /
`tsc --pretty false -p tsconfig.typecheck-core.json` clean.
