### PR TITLE
fix(ci): openapi-security-tiers must read ALWAYS_PROTECTED_API_PATTERNS (base-red #12581)

### DIFF
--- a/scripts/check/check-openapi-security-tiers.mjs
+++ b/scripts/check/check-openapi-security-tiers.mjs
@@ -115,12 +115,14 @@ const ALWAYS_PROTECTED_PATTERNS = parsePatterns("ALWAYS_PROTECTED_API_PATTERNS")
 if (
   LOCAL_ONLY_PREFIXES.length === 0 ||
   LOCAL_ONLY_PATTERNS.length === 0 ||
-  ALWAYS_PROTECTED_PATHS.length === 0
+  ALWAYS_PROTECTED_PATHS.length === 0 ||
+  ALWAYS_PROTECTED_PATTERNS.length === 0
 ) {
   console.error(
     `[openapi-security-tiers] FAIL — could not parse routeGuard.ts constants ` +
       `(prefixes=${LOCAL_ONLY_PREFIXES.length}, patterns=${LOCAL_ONLY_PATTERNS.length}, ` +
-      `alwaysProtected=${ALWAYS_PROTECTED_PATHS.length})`
+      `alwaysProtected=${ALWAYS_PROTECTED_PATHS.length}, ` +
+      `alwaysProtectedPatterns=${ALWAYS_PROTECTED_PATTERNS.length})`
   );
   process.exit(1);
 }

--- a/tests/unit/openapi-security-tiers-gate.test.ts
+++ b/tests/unit/openapi-security-tiers-gate.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const GATE = join(ROOT, "scripts", "check", "check-openapi-security-tiers.mjs");
+
+function runGate(): { code: number; out: string } {
+  try {
+    const out = execFileSync(process.execPath, [GATE], {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+// routeGuard protects a path when EITHER list matches — `isAlwaysProtectedPath`
+// ORs ALWAYS_PROTECTED_API_PATHS with ALWAYS_PROTECTED_API_PATTERNS. The gate
+// used to read only the prefix array, so every regex-covered route was reported
+// as an annotation mismatch: the four `{claude,codex}-auth/{export,apply-local}`
+// routes turned release/v3.8.51 red while being correctly protected at runtime.
+// Same defect class the LOCAL_ONLY arm already had (#12350).
+test("openapi-security-tiers accepts routes covered only by ALWAYS_PROTECTED_API_PATTERNS", () => {
+  const { code, out } = runGate();
+
+  assert.ok(
+    !/has x-always-protected but is NOT/.test(out),
+    `gate reported an always-protected route as uncovered:\n${out}`
+  );
+  assert.equal(code, 0, `gate must pass on a clean tree, got exit ${code}:\n${out}`);
+});


### PR DESCRIPTION
⚠️ base-red inherited: #12581

## The failure

`release/v3.8.51` is red on `check:openapi-security-tiers` with four routes reported as unprotected:

```
POST /api/providers/{id}/claude-auth/apply-local: has x-always-protected but is NOT in ALWAYS_PROTECTED_API_PATHS [...]
POST /api/providers/{id}/claude-auth/export:      ...
POST /api/providers/{id}/codex-auth/apply-local:  ...
POST /api/providers/{id}/codex-auth/export:       ...
```

## They are not unprotected

`isAlwaysProtectedPath()` ORs **two** arrays:

```ts
// src/server/authz/routeGuard.ts
ALWAYS_PROTECTED_API_PATHS.some((p) => path === p || path.startsWith(p)) ||
ALWAYS_PROTECTED_API_PATTERNS.some((re) => re.test(path))
```

All four routes are covered by the pattern that shipped with the credential-export hard-gate:

```ts
/^\/api\/providers\/[^/]+\/(claude|codex)-auth\/(export|apply-local)\/?$/
```

A runtime probe over the real `isAlwaysProtectedPath()` returns **true** for all four. The gate parsed only `ALWAYS_PROTECTED_API_PATHS` and never `ALWAYS_PROTECTED_API_PATTERNS`, so it was blind to half of its own input — **a false positive, not a security hole.**

This is the residual half of the defect #12350 fixed for the LOCAL_ONLY tier this cycle; that arm already reads both `LOCAL_ONLY_API_PREFIXES` and `LOCAL_ONLY_API_PATTERNS`.

## Change

- Parse `ALWAYS_PROTECTED_API_PATTERNS`, and include it in the fatal parse guard so a future formatting change in `routeGuard.ts` fails loudly instead of silently degrading back into false positives.
- Add `coveredByAlwaysProtected()` mirroring `coveredByLocalOnly()` — both concretize `{param}` before matching.
- Name both arrays in the error text.

## Validation

Gate on a clean tree: `FAIL — 4 annotation mismatches` before, `PASS — all security tier annotations match routeGuard.ts` (exit 0) after.

New `tests/unit/openapi-security-tiers-gate.test.ts` runs the gate as a subprocess — deliberately **not** importing `routeGuard.ts`, so the unit suite gains no DB handle (that suite is already hanging on one). Mutation-checked: reverting the gate to its previous version makes the test fail and print all four routes; restoring the fix makes it pass.