### PR TITLE
feat(providers): register gemini-3.8-flash

### DIFF
--- a/changelog.d/features/12638-gemini-3.8-flash.md
+++ b/changelog.d/features/12638-gemini-3.8-flash.md
@@ -1,0 +1,1 @@
+- **feat(providers):** register `gemini-3.8-flash` ([#12638](https://github.com/diegosouzapw/OmniRoute/issues/12638)) — Gemini 3.8 Flash (DeepMind 2026-09-02) with tool calling and vision support

--- a/open-sse/config/providers/registry/gemini/index.ts
+++ b/open-sse/config/providers/registry/gemini/index.ts
@@ -19,6 +19,12 @@ export const geminiProvider: RegistryEntry = {
   },
   models: [
     {
+      id: "gemini-3.8-flash",
+      name: "Gemini 3.8 Flash",
+      toolCalling: true,
+      supportsVision: true,
+    },
+    {
       id: "gemini-3.7-flash",
       name: "Gemini 3.7 Flash",
       toolCalling: true,


### PR DESCRIPTION
Closes #12638

DeepMind published Gemini 3.8 Flash (2026-09-02, https://deepmind.google/models/model-cards/gemini-3-8-flash/) as next iteration after 3.7. Registry topped out at 3.7.

- Root cause: `open-sse/config/providers/registry/gemini/index.ts:12` missing 3.8 entry (verified via `git show origin/release/v3.8.51:...`)
- Change: add model `{id: "gemini-3.8-flash", name: "Gemini 3.8 Flash", toolCalling:true, supportsVision:true}` at top of `models[]` (newest-first, same style as 3.7, 6 lines, no refactor)
- Verification: `npx tsc --noEmit --skipLibCheck` exit 0; manual parse shows 9 models with 3.8 first; `grep -R socket .github/workflows` 0 hits unaffected; fragment `changelog.d/features/12638-gemini-3.8-flash.md` added per CONTRIBUTING
- No CHANGELOG.md edit, no Co-Authored-By, 2 commits (feat + chore fragment)