### PR TITLE
docs(dependencies): clarify socket.yml is registry-side scan, not CI gate

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -218,6 +218,8 @@ These rules are enforced by tooling and reviewers:
 
 ## Supply-chain scanner findings (Socket.dev / Snyk / similar)
 
+> **Scope note:** `socket.yml` at the repository root only shapes `projectIgnorePaths` for Socket.dev's registry-side post-publish scan of the published npm artifact — it is not an enforced CI/PR merge gate. No workflow in `.github/workflows`, no `package.json` script, and no `Makefile` target invokes Socket.dev.
+
 The published `omniroute` npm artifact bundles the Next.js `output: "standalone"`
 build, which means every route handler — including documented privileged
 features (MITM, Zed import, Cloud Sync, embedded service supervisor) — ends

--- a/docs/security/SOCKET_DEV_FINDINGS.md
+++ b/docs/security/SOCKET_DEV_FINDINGS.md
@@ -5,6 +5,8 @@ description: "Maintainer attestation for the AI-detected potential-malware findi
 
 # Socket.dev / supply-chain finding attestation
 
+> **Scope note:** `socket.yml` configures Socket.dev's registry-side post-publish scan of the npm artifact (ignore-paths for non-shipped content such as `tests/`, `docs/`, and build reports). It does not wire a CI/PR merge gate — no workflow in `.github/workflows`, no `package.json` script, and no `Makefile` target invokes Socket.dev.
+
 This document is the maintainer-authored attestation for the six
 `AI-detected potential malware` findings raised against `omniroute@3.8.5` and
 the mitigations applied in `omniroute@3.8.6`. It exists so:

--- a/socket.yml
+++ b/socket.yml
@@ -1,6 +1,12 @@
 # Socket.dev / Socket GitHub app configuration.
 # Documentation: https://docs.socket.dev/docs/socket-yml
 #
+# NOTE: This file does NOT enforce a CI/PR gate. No workflow in
+# .github/workflows, no package.json script, and no Makefile target invokes
+# Socket.dev. It only shapes `projectIgnorePaths` for Socket's registry-side
+# post-publish scan of the published npm artifact (see
+# docs/security/SOCKET_DEV_FINDINGS.md).
+#
 # OmniRoute bundles privileged opt-in features (MITM proxy, Zed credential
 # import, embedded service supervisor, Cloud Sync) inside the Next.js
 # standalone build output. The v3.8.6 release applies in-tree mitigations for


### PR DESCRIPTION
Closes #12575

socket.yml and surrounding docs read like enforced CI gate, but no workflow/package.json/Makefile invokes Socket.dev.

- Root cause: `socket.yml:1-13` sets `projectIgnorePaths` for registry-side scan; `grep -R socket .github/workflows` 0 hits, `package.json` scripts 0 hits (verified)
- Change: add scope note to `socket.yml:4-10`, `SECURITY.md:221`, `docs/security/SOCKET_DEV_FINDINGS.md:8` (3 files, 10 insertions) — states registry-side post-publish scan, not PR gate, with pointer. Minimal docs-only.
- Verification: `python yaml.safe_load(socket.yml)` ok, `grep -R socket .github/workflows` still 0, docs-only no TS impact
- No changelog fragment required (docs), no Co-Authored-By