### PR TITLE
fix(tests): retire dead model ids from the chat-pipeline integration suite (base-red #12581)

### DIFF
--- a/tests/integration/chat-pipeline.test.ts
+++ b/tests/integration/chat-pipeline.test.ts
@@ -170,7 +170,7 @@ function buildOpenAIToolCallResponse({
   );
 }
 
-function buildClaudeResponse(text = "ok", model = "claude-3-5-sonnet-20241022") {
+function buildClaudeResponse(text = "ok", model = "claude-sonnet-4-6") {
   return new Response(
     JSON.stringify({
       id: "msg_json",
@@ -286,7 +286,7 @@ function buildOpenAIStreamResponse(text = "streamed from openai") {
 
 function buildOpenAIResponsesSSE({
   text = "responses streamed from codex",
-  model = "gpt-5.1-codex",
+  model = "gpt-5.6-sol",
   usage = null,
 } = {}) {
   return new Response(
@@ -567,7 +567,7 @@ test("chat pipeline persists Codex responses cache and reasoning tokens to call 
     buildRequest({
       url: "http://localhost/v1/responses",
       body: {
-        model: "codex/gpt-5.1-codex",
+        model: "codex/gpt-5.6-sol",
         stream: false,
         input: "Persist cache + reasoning usage",
       },
@@ -983,7 +983,7 @@ test("chat pipeline translates OpenAI requests to Claude and returns OpenAI-shap
   const response = await handleChat(
     buildRequest({
       body: {
-        model: "claude/claude-3-5-sonnet-20241022",
+        model: "claude/claude-sonnet-4-6",
         stream: false,
         messages: [{ role: "user", content: "Hello Claude" }],
       },
@@ -1566,7 +1566,7 @@ test("chat pipeline falls back across combo models when the first provider fails
     name: "combo-fallback",
     strategy: "priority",
     config: { maxRetries: 0, retryDelayMs: 0 },
-    models: ["openai/gpt-4o-mini", "claude/claude-3-5-sonnet-20241022"],
+    models: ["openai/gpt-4o-mini", "claude/claude-sonnet-4-6"],
   });
   const attempts = [];
 


### PR DESCRIPTION
⚠️ base-red inherited: #12581

## One cause, three failures

`tests/integration/chat-pipeline.test.ts` still routes two model ids that the vendor lifecycle registry marks `retired`. The pipeline correctly refuses them, and the tests assert on that refusal:

| test | assertion | retired id |
|---|---|---|
| persists Codex responses cache and reasoning tokens to call logs | `410 !== 200` | `codex/gpt-5.1-codex` |
| translates OpenAI requests to Claude and returns OpenAI-shaped responses | `410 !== 200` | `claude/claude-3-5-sonnet-20241022` |
| falls back across combo models when the first provider fails | `502 !== 200` | same id, as the combo's fallback target |

```
❌ codex [410]: Model "codex/gpt-5.1-codex" has been retired by its vendor and cannot be routed automatically.
```

`open-sse/services/modelLifecycle.ts:87` records `gpt-5.1-codex` as retired on 2026-07-23 with successor `gpt-5.6-sol`; `claude-3-5-sonnet-20241022` is retired as well. I checked **every** model id in the file against `isVendorRetiredId()` — these two are the only ones.

## Why only one showed up in the report

The release-green report prints the first failing line of a gate, so only the Codex one was visible. And all three had been hidden longer than that: the integration gate has repeatedly died on its **2400s ceiling**, and a gate killed by its ceiling never reports an individual test failure. This is not a new regression — it is a pre-existing breakage that only became visible once the suite actually finished.

## The change

Both ids replaced with live ones: the successor the lifecycle record itself names for the Codex case, and the `claude-sonnet-4-6` this same file already uses elsewhere for the Claude case.

One extra line was needed: `buildOpenAIResponsesSSE()` also echoed the retired Codex id, and the call log derives its `provider` from the model in the **response**. Leaving it made the row log `provider: "openai"` for a request that had correctly used the codex connection (its `Authorization: Bearer sk-codex-primary` assertion passed) — a wrong-attribution failure that looks nothing like the original 410.

**No assertion is changed, removed or relaxed.**

## Validation

Run with the CI invocation (`setupPolyfill` + `isolateDataDir` + `--test-force-exit --test-concurrency=1`):

- before: `tests 28 | pass 25 | fail 3`
- after: `tests 28 | pass 28 | fail 0`, exit 0

Worth noting for anyone reproducing: running the file **without** `--import ./tests/_setup/isolateDataDir.ts` hits the developer's real `~/.omniroute` database and produces a spurious `expected a call log row to be created`. Use the full invocation.