### PR TITLE
fix(providers): route opencode-go/muse-spark-1.3-contributor to Responses API

### DIFF
--- a/changelog.d/fixes/12675-opencode-go-muse-spark-1-3-responses.md
+++ b/changelog.d/fixes/12675-opencode-go-muse-spark-1-3-responses.md
@@ -1,0 +1,1 @@
+- Fix `opencode-go/muse-spark-1.3-contributor` returning 500 by routing it (base + minimal/low/medium/high/xhigh effort aliases) to the Responses API like the 1.2 family. (#12675 — thanks @bacnh85)

--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -226,6 +226,78 @@ export const opencode_goProvider: RegistryEntry = {
       supportsVideo: true,
       targetFormat: "openai-responses",
     },
+    // #12674: Muse Spark 1.3 Contributor — base + effort-tier aliases from the
+    // OpenCode Go registry (`opencode models opencode-go --refresh --verbose`;
+    // exact suffix set: minimal/low/medium/high/xhigh, no max — same as 1.2).
+    // Upstream serves Muse Spark only on the Responses API; without
+    // targetFormat:"openai-responses" these fall through to /chat/completions
+    // and the upstream returns 500 (same class as #12196).
+    {
+      id: "muse-spark-1.3-contributor",
+      name: "Muse Spark 1.3 Contributor",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
+      supportsReasoning: true,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.3-contributor-minimal",
+      name: "Muse Spark 1.3 Contributor (minimal effort)",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
+      supportsReasoning: true,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.3-contributor-low",
+      name: "Muse Spark 1.3 Contributor (low effort)",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
+      supportsReasoning: true,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.3-contributor-medium",
+      name: "Muse Spark 1.3 Contributor (medium effort)",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
+      supportsReasoning: true,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.3-contributor-high",
+      name: "Muse Spark 1.3 Contributor (high effort)",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
+      supportsReasoning: true,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      targetFormat: "openai-responses",
+    },
+    {
+      id: "muse-spark-1.3-contributor-xhigh",
+      name: "Muse Spark 1.3 Contributor (xhigh effort)",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
+      supportsReasoning: true,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      targetFormat: "openai-responses",
+    },
     // #8353: Grok 4.5 + effort tiers from the OpenCode Go registry.
     {
       id: "grok-4.5",

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -85,6 +85,8 @@ const OPENCODE_FREE_MODELS = new Set([
  *   grok-4.5 low/medium/high; hy3 none/low/high; kimi-k3 max;
  *   qwen3.6-plus / qwen3.7-max / qwen3.7-plus high/max;
  *   muse-spark-1.2-contributor minimal/low/medium/high/xhigh (no max)
+ * - #12674 Muse Spark 1.3 Contributor: minimal/low/medium/high/xhigh (no max),
+ *   verified via `opencode models opencode-go --refresh --verbose`
  */
 const EFFORT_TIERS: Record<string, readonly string[]> = {
   "deepseek-v4-pro": EFFORT_LEVELS,
@@ -98,6 +100,7 @@ const EFFORT_TIERS: Record<string, readonly string[]> = {
   "qwen3.7-max": ["high", "max"],
   "qwen3.7-plus": ["high", "max"],
   "muse-spark-1.2-contributor": ["minimal", "low", "medium", "high", "xhigh"],
+  "muse-spark-1.3-contributor": ["minimal", "low", "medium", "high", "xhigh"],
 };
 
 /**

--- a/tests/unit/opencode-go-muse-spark-1-3-12674.test.ts
+++ b/tests/unit/opencode-go-muse-spark-1-3-12674.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseEffortLevel,
+  resolveOpencodeTargetFormat,
+} from "../../open-sse/executors/opencode.ts";
+
+const { REGISTRY } = (await import("../../open-sse/config/providerRegistry.ts")) as {
+  REGISTRY: Record<
+    string,
+    {
+      models?: Array<{
+        id: string;
+        targetFormat?: string;
+        supportsReasoning?: boolean;
+        contextLength?: number;
+        maxOutputTokens?: number;
+      }>;
+    }
+  >;
+};
+
+// #12674: opencode-go/muse-spark-1.3-contributor (upstream release 2026-09-02)
+// 500s via /v1/chat/completions because the upstream serves Muse Spark only on
+// the Responses API and the model had no registry targetFormat entry, so the
+// executor fell back to "openai". Base + effort-tier alias set verified via
+// `opencode models opencode-go --refresh --verbose` (minimal/low/medium/high/
+// xhigh, no max — same as 1.2).
+const BASE = "muse-spark-1.3-contributor";
+const ALIASES = ["minimal", "low", "medium", "high", "xhigh"].map((effort) => ({
+  alias: `${BASE}-${effort}`,
+  effort,
+}));
+
+function goModels() {
+  const entry = REGISTRY["opencode-go"];
+  assert.ok(entry, "opencode-go registry entry must exist");
+  return entry.models ?? [];
+}
+
+test("#12674 registry: 1.3 base + effort aliases target the Responses API", () => {
+  const models = goModels();
+  for (const id of [BASE, ...ALIASES.map((a) => a.alias)]) {
+    const model = models.find((m) => m.id === id);
+    assert.ok(model, `${id} must be registered on opencode-go`);
+    assert.equal(model?.targetFormat, "openai-responses", `${id} must target Responses`);
+    assert.equal(model?.supportsReasoning, true, `${id} must support reasoning`);
+    assert.equal(model?.contextLength, 1048576, `${id} context must be 1M`);
+    assert.equal(model?.maxOutputTokens, 131072, `${id} max output must be 128K`);
+  }
+});
+
+test("#12674 executor: 1.3 resolves to openai-responses (URL selection)", () => {
+  assert.equal(resolveOpencodeTargetFormat("opencode-go", BASE), "openai-responses");
+  assert.equal(resolveOpencodeTargetFormat("opencode-go", `${BASE}-high`), "openai-responses");
+});
+
+for (const { alias, effort } of ALIASES) {
+  test(`#12674 parseEffortLevel: ${alias} → ${effort}`, () => {
+    assert.deepEqual(parseEffortLevel(alias), { baseModel: BASE, effort });
+  });
+}
+
+test("#12674 parseEffortLevel: 1.3 has no max tier", () => {
+  assert.equal(parseEffortLevel(`${BASE}-max`), null);
+});
+
+test("#12674 catalog: 1.3 aliases stay Go-only (not on opencode-zen)", () => {
+  const zenIds = new Set((REGISTRY["opencode-zen"]?.models ?? []).map((m) => m.id));
+  assert.equal(zenIds.has(BASE), false, "opencode-zen must not expose 1.3 base");
+  for (const { alias } of ALIASES) {
+    assert.equal(zenIds.has(alias), false, `opencode-zen must not expose ${alias}`);
+  }
+});


### PR DESCRIPTION
Fixes #12674.

Upstream (`opencode.ai/zen/go`) serves Muse Spark only on the Responses API (`/v1/responses`); direct `/v1/chat/completions` returns 500 for both 1.2 and 1.3 (verified same key, same server). The 1.2 family has registry `targetFormat: "openai-responses"` entries, but 1.3 (upstream release 2026-09-02) was never added, so `resolveOpencodeTargetFormat()` falls back to `"openai"` and the request 500s (retried 3x, account cooldown, `(reset after 3s)`).

## Changes

- `open-sse/config/providers/registry/opencode/go/index.ts`: 1.3 base + minimal/low/medium/high/xhigh effort aliases (no max), each `contextLength 1048576 / maxOutputTokens 131072 / supportsReasoning+vision+audio+video / targetFormat openai-responses`, mirroring the 1.2 block. Specs verified via `opencode models opencode-go --refresh --verbose` (same effort set, limits, and $0.10/$0.20 pricing as 1.2).
- `open-sse/executors/opencode.ts`: `EFFORT_TIERS["muse-spark-1.3-contributor"] = ["minimal","low","medium","high","xhigh"]` so suffixed aliases parse and get reasoning_effort injection.
- `tests/unit/opencode-go-muse-spark-1-3-12674.test.ts`: registry entries, executor URL resolution, parseEffortLevel (incl. max→null), Go-only scoping.

## Verification

- New test file: 9/9 pass.
- Neighbors `opencode-go-effort-aliases-8353`, `opencode-muse-spark-responses-10867`, `opencode-target-format-alias-11045`, `opencode-muse-spark-min-output`, `opencode-session-fingerprint-headers-10571`: 64/64 pass.
- `check-provider-consistency`: OK.

Out of scope (noted in #12674): bare `muse-spark-1.3-contributor` combo path also tries `command-code/meta/...` → 502 empty response; may need the same treatment in that provider.