### PR TITLE
fix(cursor): guard non-array tool_calls in request translator

### DIFF
--- a/changelog.d/fixes/12689-cursor-toolcalls-guard.md
+++ b/changelog.d/fixes/12689-cursor-toolcalls-guard.md
@@ -1,0 +1,1 @@
+- **fix(cursor):** a non-array `tool_calls` on an assistant message no longer crashes the cursor request translator with a `TypeError`; both loops now require an array ([#12689](https://github.com/diegosouzapw/OmniRoute/issues/12689))

--- a/open-sse/translator/request/openai-to-cursor.ts
+++ b/open-sse/translator/request/openai-to-cursor.ts
@@ -80,7 +80,7 @@ function convertMessages(messages) {
   };
 
   for (const msg of messages) {
-    if (msg.role === "assistant" && msg.tool_calls) {
+    if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
       for (const tc of msg.tool_calls) {
         rememberToolMeta(tc.id || "", tc.function?.name || "tool");
       }
@@ -166,7 +166,7 @@ function convertMessages(messages) {
 
       const content = extractContent(msg.content);
 
-      if (msg.role === "assistant" && msg.tool_calls && msg.tool_calls.length > 0) {
+      if (msg.role === "assistant" && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
         const assistantMsg: {
           role: string;
           content?: string;

--- a/tests/unit/translator-openai-to-cursor.test.ts
+++ b/tests/unit/translator-openai-to-cursor.test.ts
@@ -199,3 +199,15 @@ test("OpenAI -> Cursor accepts shorthand image_url string form", () => {
     { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
   ]);
 });
+
+test("#12689: non-array tool_calls is skipped instead of throwing TypeError", () => {
+  for (const toolCalls of [5, { a: 1 }, "x"]) {
+    const result = buildCursorRequest(
+      "gpt-4o",
+      { messages: [{ role: "assistant", content: "Working", tool_calls: toolCalls }] },
+      false,
+      null
+    );
+    assert.ok(result);
+  }
+});


### PR DESCRIPTION
## Summary

A chat request whose assistant message carries a non-array truthy `tool_calls` crashed the cursor request translator with a raw `TypeError` (first `is not iterable`, then `.map is not a function` one loop down), surfacing as HTTP 500. Both loops now require an array, matching the sibling kiro translator. The changelog fragment is included per repo convention.

## How to test

1. Call `buildCursorRequest` with `messages: [{ role: "assistant", tool_calls: 5 }]` (also tried an object and a string).
2. Observe no throw now. Before the fix, all three shapes threw `TypeError`.
3. Run `node --import tsx/esm --test tests/unit/translator-openai-to-cursor.test.ts`. All 7 tests pass, including the new `#12689` regression test (red without the fix, green with it).

## Related issues

Fixes #12689