### PR TITLE
fix(xai): map legacy assistant function_call instead of dropping it

### DIFF
--- a/changelog.d/fixes/12692-xai-legacy-function-call.md
+++ b/changelog.d/fixes/12692-xai-legacy-function-call.md
@@ -1,0 +1,1 @@
+- **fix(xai):** assistant messages using the legacy `function_call` field are now mapped to `function_call` items instead of being silently dropped ([#12692](https://github.com/diegosouzapw/OmniRoute/issues/12692))

--- a/src/lib/providers/xai/translators/openai-chat.ts
+++ b/src/lib/providers/xai/translators/openai-chat.ts
@@ -38,6 +38,7 @@ interface OpenAiMessage {
   content?: MessageContent;
   tool_calls?: OpenAiToolCall[];
   tool_call_id?: string;
+  function_call?: { name?: string; arguments?: string };
 }
 
 interface OpenAiChatRequest {
@@ -211,6 +212,20 @@ export function chatRequestToXaiResponses(req: OpenAiChatRequest): XaiResponsesR
           arguments: tc.function.arguments ?? "",
         });
       }
+      continue;
+    }
+    if (m.role === "assistant" && m.function_call?.name) {
+      // Legacy function_call form (still accepted by OpenAI): map it the
+      // same way instead of dropping the name + arguments (#12692).
+      if (m.content) {
+        input.push({ role: "assistant", content: messageContentToXaiBlocks(m.content) });
+      }
+      input.push({
+        type: "function_call",
+        call_id: genId("call"),
+        name: m.function_call.name,
+        arguments: m.function_call.arguments ?? "",
+      });
       continue;
     }
     input.push({ role: m.role ?? "user", content: messageContentToXaiBlocks(m.content ?? "") });

--- a/tests/unit/xai-translators.test.ts
+++ b/tests/unit/xai-translators.test.ts
@@ -521,3 +521,21 @@ test("xaiCompletedToGeminiJson: maps usage to usageMetadata", () => {
   assert.equal(meta.candidatesTokenCount, 20);
   assert.equal(meta.totalTokenCount, 30);
 });
+
+test("#12692: legacy assistant function_call maps to a function_call item", () => {
+  const out = chatRequestToXaiResponses({
+    model: "grok-4",
+    messages: [
+      {
+        role: "assistant",
+        content: null,
+        function_call: { name: "get_weather", arguments: '{"city":"Paris"}' },
+      },
+    ],
+  } as never);
+  const calls = out.input.filter((i) => i.type === "function_call");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].name, "get_weather");
+  assert.equal(calls[0].arguments, '{"city":"Paris"}');
+  assert.ok(calls[0].call_id);
+});


### PR DESCRIPTION
## Summary

The xAI OpenAI-chat translator only mapped the modern `tool_calls` array. An assistant message using the legacy `function_call` field fell through to the generic branch and its name + arguments vanished. It now maps to a `function_call` item the same way, with a generated `call_id` (the legacy form has none). The changelog fragment is included per repo convention.

## How to test

1. Call `chatRequestToXaiResponses` with `messages: [{ role: "assistant", content: null, function_call: { name: "get_weather", arguments: "..." } }]`.
2. Observe a `function_call` item with the name and arguments now. Before the fix, the input held only an empty `input_text` block.
3. Run `node --import tsx/esm --test tests/unit/xai-translators.test.ts`. All 47 tests pass, including the new `#12692` regression test (red without the fix, green with it).

## Related issues

Fixes #12692