### PR TITLE
fix(xai): include legacy usage names in total token count

### DIFF
--- a/changelog.d/fixes/12700-xai-usage-total.md
+++ b/changelog.d/fixes/12700-xai-usage-total.md
@@ -1,0 +1,1 @@
+- **fix(xai):** usage totals now include legacy `prompt_tokens` / `completion_tokens` names instead of reporting 0 ([#12700](https://github.com/diegosouzapw/OmniRoute/issues/12700))

--- a/src/lib/providers/xai/translators/gemini.ts
+++ b/src/lib/providers/xai/translators/gemini.ts
@@ -263,7 +263,7 @@ function toolsGeminiToXai(tools: GeminiTool[]): XaiTool[] | undefined {
  */
 export function geminiRequestToXaiResponses(
   req: GeminiRequest,
-  model: string | null = null,
+  model: string | null = null
 ): XaiResponsesRequest {
   if (!req || typeof req !== "object") return req as unknown as XaiResponsesRequest;
   const input: XaiInputItem[] = [];
@@ -275,9 +275,7 @@ export function geminiRequestToXaiResponses(
     if (fnItems.length) {
       for (const it of fnItems) input.push(it);
       // Filter remaining text/image parts
-      const remaining = (c.parts ?? []).filter(
-        (p) => !p?.functionCall && !p?.functionResponse,
-      );
+      const remaining = (c.parts ?? []).filter((p) => !p?.functionCall && !p?.functionResponse);
       if (remaining.length) input.push({ role, content: partsToXaiBlocks(remaining) });
     } else {
       input.push({ role, content: partsToXaiBlocks(c.parts ?? []) });
@@ -324,7 +322,7 @@ export function geminiRequestToXaiResponses(
  */
 export function xaiCompletedToGeminiJson(
   completed: XaiCompleted,
-  origReq: GeminiRequest | null = null,
+  origReq: GeminiRequest | null = null
 ): object {
   const parts: unknown[] = [];
   const finishReason = "STOP";
@@ -364,7 +362,8 @@ export function xaiCompletedToGeminiJson(
       promptTokenCount: u.input_tokens ?? u.prompt_tokens ?? 0,
       candidatesTokenCount: u.output_tokens ?? u.completion_tokens ?? 0,
       totalTokenCount:
-        u.total_tokens ?? ((u.input_tokens ?? 0) + (u.output_tokens ?? 0)),
+        u.total_tokens ??
+        (u.input_tokens ?? u.prompt_tokens ?? 0) + (u.output_tokens ?? u.completion_tokens ?? 0),
     };
   }
   return out;

--- a/src/lib/providers/xai/translators/openai-chat.ts
+++ b/src/lib/providers/xai/translators/openai-chat.ts
@@ -303,7 +303,9 @@ export function xaiCompletedToChatJson(
     out.usage = {
       prompt_tokens: u.input_tokens ?? u.prompt_tokens ?? 0,
       completion_tokens: u.output_tokens ?? u.completion_tokens ?? 0,
-      total_tokens: u.total_tokens ?? (u.input_tokens ?? 0) + (u.output_tokens ?? 0),
+      total_tokens:
+        u.total_tokens ??
+        (u.input_tokens ?? u.prompt_tokens ?? 0) + (u.output_tokens ?? u.completion_tokens ?? 0),
     };
   }
   return out;

--- a/tests/unit/xai-translators.test.ts
+++ b/tests/unit/xai-translators.test.ts
@@ -521,3 +521,19 @@ test("xaiCompletedToGeminiJson: maps usage to usageMetadata", () => {
   assert.equal(meta.candidatesTokenCount, 20);
   assert.equal(meta.totalTokenCount, 30);
 });
+
+test("#12700: legacy usage names still sum the total (chat)", () => {
+  const res = xaiCompletedToChatJson({
+    output: [{ type: "message", content: [{ type: "output_text", text: "hi" }] }],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
+  } as never);
+  assert.equal(res.usage?.total_tokens, 15);
+});
+
+test("#12700: legacy usage names still sum the total (gemini)", () => {
+  const out = xaiCompletedToGeminiJson({
+    output: [{ type: "message", content: [{ type: "output_text", text: "hi" }] }],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
+  } as never);
+  assert.equal(out.usageMetadata?.totalTokenCount, 15);
+});


### PR DESCRIPTION
## Summary

The xAI response translators reported `total_tokens` / `totalTokenCount` as 0 when upstream usage used the legacy `prompt_tokens` / `completion_tokens` names — the parts already fell back to those aliases, only the total didn't. Both totals now sum the same resolved values. The changelog fragment is included per repo convention.

## How to test

1. Call `xaiCompletedToChatJson` / `xaiCompletedToGeminiJson` with `usage: { prompt_tokens: 10, completion_tokens: 5 }`.
2. Observe totals of 15 now. Before the fix, both reported 0.
3. Run `node --import tsx/esm --test tests/unit/xai-translators.test.ts`. All 48 tests pass, including the 2 new `#12700` regression tests (red without the fix, green with it).

## Related issues

Fixes #12700