### PR TITLE
fix(sse): stop rebuilding a truncated summary from the collector's cap-dropped event array

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -30,10 +30,7 @@ import { rejectEmptyChoicesStream, buildEmptyChoicesStreamError } from "./stream
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { buildOmniRouteSseMetadataComment } from "@/domain/omnirouteResponseMeta";
 import { sseCommentsEnabled } from "./sseHeartbeat.ts";
-import {
-  createStructuredSSECollector,
-  buildStreamSummaryFromEvents,
-} from "./streamPayloadCollector.ts";
+import { createStructuredSSECollector } from "./streamPayloadCollector.ts";
 import { STREAM_IDLE_TIMEOUT_MS, FETCH_BODY_TIMEOUT_MS, HTTP_STATUS } from "../config/constants.ts";
 import {
   OMIT_STREAMING_CHUNK_MARKER,
@@ -844,6 +841,27 @@ export function createSSEStream(options: StreamOptions = {}) {
   });
   const clientPayloadCollector = createStructuredSSECollector({
     stage: "client_response",
+    // Live incident (2026-09-04): the OPENAI_RESPONSES-only carve-outs below
+    // rebuilt the client summary from clientPayloadCollector.getEvents() --
+    // the collector's own RETAINED (possibly cap-truncated) event array --
+    // even after providerPayloadCollector got a live cap-independent reducer
+    // for the exact same class of bug (#9315, see that collector's own
+    // `format:` comment above). A reasoning-heavy stream that exhausts the
+    // cap during the reasoning phase alone (measured live: routine, not an
+    // edge case) silently dropped the terminal response.completed event from
+    // the retained array, so the rebuilt-from-events summary permanently
+    // showed status "in_progress" with empty output even though the client
+    // itself received the real, complete reply. Wiring `format` here gives
+    // this collector the SAME always-live reducer providerPayloadCollector
+    // already has, so switching the carve-outs below from
+    // buildStreamSummaryFromEvents(collector.getEvents(), ...) to
+    // collector.getSummary() makes them cap-independent too -- strictly
+    // equivalent for a stream that never hits the cap, correct instead of
+    // silently empty for one that does. Same mode ternary as
+    // clientExpectsResponsesStream/clientExpectsClaudeStream above: passthrough
+    // forwards clientResponseFormat as-is, translate re-shapes to sourceFormat.
+    format: mode === STREAM_MODE.PASSTHROUGH ? clientResponseFormat : sourceFormat,
+    fallbackModel: model,
   });
   // Per-stream instances to avoid shared state with concurrent streams
   const decoder = new TextDecoder();
@@ -2665,18 +2683,19 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // #9315 switched the summary to the accumulated responseBody to avoid
                   // stale/truncated event data — but responseBody here is synthesized in
                   // chat-completion shape, which loses the Responses API `response` object.
-                  // Keep the events-derived summary for OPENAI_RESPONSES only. responseBody
+                  // Keep a Responses-shaped summary for OPENAI_RESPONSES only. responseBody
                   // itself never carries an `object` marker (it's built purely for the
                   // client, which doesn't need one) — the dashboard's Provider Response
                   // panel does, so stamp `object: "chat.completion"` on a shallow copy
                   // used only for this summary, leaving responseBody itself untouched.
+                  // getSummary(), not buildStreamSummaryFromEvents(getEvents(), ...): the
+                  // latter only sees the collector's RETAINED (possibly cap-truncated)
+                  // events, silently losing a late response.completed event on a long
+                  // reasoning-heavy stream (live incident 2026-09-04) -- see
+                  // providerPayloadCollector's own `format:` construction comment above.
                   providerPayload: providerPayloadCollector.build(
                     sourceFormat === FORMATS.OPENAI_RESPONSES
-                      ? buildStreamSummaryFromEvents(
-                          providerPayloadCollector.getEvents(),
-                          sourceFormat,
-                          model
-                        )
+                      ? providerPayloadCollector.getSummary()
                       : { object: "chat.completion", ...responseBody },
                     { includeEvents: false }
                   ),
@@ -2687,14 +2706,13 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // src/lib/usage/callLogs.ts is always null for a Responses-API client
                   // (extractResponsesId reads `clientResponse.id`, which the chat-shaped
                   // responseBody never has), so previous_response_id continuation lookups
-                  // in src/lib/db/responsesContinuationStore.ts always miss.
+                  // in src/lib/db/responsesContinuationStore.ts always miss. getSummary(),
+                  // not buildStreamSummaryFromEvents(getEvents(), ...) -- same cap-truncation
+                  // reasoning as providerPayload above; clientPayloadCollector's own `format:`
+                  // construction above gives it the same live, cap-independent reducer.
                   clientPayload: clientPayloadCollector.build(
                     clientResponseFormat === FORMATS.OPENAI_RESPONSES
-                      ? buildStreamSummaryFromEvents(
-                          clientPayloadCollector.getEvents(),
-                          clientResponseFormat,
-                          model
-                        )
+                      ? clientPayloadCollector.getSummary()
                       : responseBody,
                     { includeEvents: false }
                   ),
@@ -2941,13 +2959,14 @@ export function createSSEStream(options: StreamOptions = {}) {
                 // all — stamp `object: "chat.completion"` on a shallow copy used only
                 // for this summary; responseBody itself (sent to the client / below)
                 // stays untouched.
+                // getSummary(), not buildStreamSummaryFromEvents(getEvents(), ...) -- the
+                // latter only sees the collector's RETAINED (possibly cap-truncated)
+                // events, silently losing a late response.completed event on a long
+                // reasoning-heavy stream (live incident 2026-09-04) -- see
+                // providerPayloadCollector's own `format:` construction comment above.
                 providerPayload: providerPayloadCollector.build(
                   targetFormat === FORMATS.OPENAI_RESPONSES
-                    ? buildStreamSummaryFromEvents(
-                        providerPayloadCollector.getEvents(),
-                        targetFormat,
-                        model
-                      )
+                    ? providerPayloadCollector.getSummary()
                     : { object: "chat.completion", ...responseBody },
                   { includeEvents: false }
                 ),
@@ -2958,14 +2977,13 @@ export function createSSEStream(options: StreamOptions = {}) {
                 // sourceFormat, ...) above confirms that direction. emitTranslatedClientItem
                 // already pushes every client-visible translated item into
                 // clientPayloadCollector unconditionally, so the events are already there;
-                // this only fixes what gets built from them.
+                // getSummary() (not buildStreamSummaryFromEvents(getEvents(), ...)) makes
+                // reading them back cap-independent -- same reasoning as providerPayload
+                // above; clientPayloadCollector's own `format:` construction gives it the
+                // same live reducer.
                 clientPayload: clientPayloadCollector.build(
                   sourceFormat === FORMATS.OPENAI_RESPONSES
-                    ? buildStreamSummaryFromEvents(
-                        clientPayloadCollector.getEvents(),
-                        sourceFormat,
-                        model
-                      )
+                    ? clientPayloadCollector.getSummary()
                     : responseBody,
                   { includeEvents: false }
                 ),

--- a/open-sse/utils/streamPayloadCollector.ts
+++ b/open-sse/utils/streamPayloadCollector.ts
@@ -885,24 +885,28 @@ export function compactStructuredStreamPayload(payload: unknown): unknown {
   };
 }
 
-// Live incident (2026-09-02): a reasoning-heavy response streams reasoning
-// token-by-token as hundreds to thousands of tiny SSE deltas BEFORE the real
-// output/tool_calls ever arrive. At the old defaults (200 events / 48KB) the
-// cap was routinely exhausted during the reasoning phase alone, dropping the
-// completion event entirely -- measured live: ~22% of a sample of recent
-// successful responses hit this. For a caller with no `format` (no live
-// reducer -- see the CollectorOptions.format doc comment), the logged
-// summary is reconstructed from getEvents() (open-sse/utils/stream.ts), so a
+// Live incident (2026-09-02, recurred 2026-09-04): a reasoning-heavy response
+// streams reasoning token-by-token as hundreds to thousands of tiny SSE
+// deltas BEFORE the real output/tool_calls ever arrive. At the old defaults
+// (200 events / 48KB) the cap was routinely exhausted during the reasoning
+// phase alone, dropping the completion event entirely -- measured live:
+// ~22% of a sample of recent successful responses hit this. For a caller
+// that reconstructs its logged summary from getEvents() after the fact
+// (open-sse/utils/stream.ts's buildStreamSummaryFromEvents(collector.getEvents(),
+// ...) pattern) instead of reading getSummary()'s always-live reducer, a
 // dropped completion event produced a served-successfully response logged
 // with status "in_progress" and empty output -- which
 // src/lib/db/responsesContinuationStore.ts then had nothing real to
 // reconstruct a later continuation turn from (see its own fail-closed fix,
-// 2026-09-02). Raising the cap doesn't eliminate the class of bug for an
-// arbitrarily long stream, but it removes it as a routine, everyday failure;
-// the format-driven live reducer (used by providerPayloadCollector, an
-// analogous prior fix) is the cap-independent fix and remains the deeper
-// follow-up for a caller that still wants build()'s summary correct beyond
-// any fixed cap.
+// 2026-09-02), and which /dashboard/conversations had no way to distinguish
+// from a genuinely healthy conversation (see its own "stalled" badge,
+// 2026-09-04). Raising the cap alone doesn't eliminate the class of bug for
+// an arbitrarily long stream, only makes it less routine; the actual
+// cap-independent fix is for every caller to read getSummary() (fed live on
+// every push(), see below) instead of re-deriving from getEvents() -- both
+// stream.ts collector instances (provider and client payload, passthrough
+// and translate mode, all four OPENAI_RESPONSES-shaped build() call sites)
+// now do this consistently.
 export function createStructuredSSECollector(options: CollectorOptions = {}) {
   const { maxEvents = 2000, maxBytes = 524288, stage, format, fallbackModel } = options;
   const events: StructuredSSEEvent[] = [];
@@ -952,9 +956,9 @@ export function createStructuredSSECollector(options: CollectorOptions = {}) {
     // payload (see CollectorOptions.format) — unlike
     // buildStreamSummaryFromEvents(getEvents(), ...), this is correct even
     // once the collector has truncated its retained event array. Returns
-    // undefined if no format was configured (e.g. the client-response
-    // collector, which builds its summary from independently-accumulated
-    // response state instead).
+    // undefined if no format was configured (e.g. a caller that never needs
+    // a reconstructed summary at all and only reads getEvents()/build()'s
+    // raw event log).
     getSummary(): unknown {
       return reducer?.finalize();
     },

--- a/tests/unit/responses-continuation-client-payload-survives-cap-truncation.test.ts
+++ b/tests/unit/responses-continuation-client-payload-survives-cap-truncation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Live incident (2026-09-04): a reasoning-heavy stream pushed 3013 SSE events
+ * (mostly tiny reasoning deltas) before its terminal response.completed --
+ * blowing past createStructuredSSECollector's 2000-event default cap. The
+ * client itself received the real, complete reply (forwarding is unbounded),
+ * but onComplete's clientPayload/providerPayload were still being rebuilt
+ * from `collector.getEvents()` -- the collector's own RETAINED (cap-dropped)
+ * array -- for a Responses-API client, via
+ * buildStreamSummaryFromEvents(collector.getEvents(), format, model). The
+ * dropped completion event meant that rebuild permanently produced
+ * status:"in_progress" / output:[] for a response the client actually
+ * received in full: src/lib/db/responsesContinuationStore.ts then had
+ * nothing real to reconstruct a later continuation turn from, and
+ * /dashboard/conversations had no way to tell this apart from a healthy
+ * conversation.
+ *
+ * Root-cause fix: both stream.ts collectors now read `.getSummary()`
+ * (fed live on EVERY push(), see createStructuredSSECollector's
+ * CollectorOptions.format doc comment) instead of re-deriving from
+ * `.getEvents()` -- strictly equivalent for a stream that never hits the
+ * cap, correct instead of silently empty for one that does. This test
+ * proves it by genuinely exceeding the real production cap (2000 events),
+ * through the real createSSEStream() pipeline, not a shrunk test-only cap.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+const { createSSEStream } = await import("../../open-sse/utils/stream.ts");
+
+const textEncoder = new TextEncoder();
+
+type OnCompletePayload = {
+  status: number;
+  clientPayload?: unknown;
+  providerPayload?: unknown;
+};
+
+async function runTranslate(
+  chunks: string[]
+): Promise<{ output: string; onCompletePayload: OnCompletePayload | undefined }> {
+  let onCompletePayload: OnCompletePayload | undefined;
+  const source = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(textEncoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  const output = await new Response(
+    source.pipeThrough(
+      createSSEStream({
+        mode: "translate",
+        // Matches the real incident: a chat-completions-native upstream
+        // (targetFormat) translated into Responses shape for a Responses-API
+        // client (sourceFormat) -- see responses-continuation-translate-client-payload.test.ts's
+        // own comment on why this is the real production shape, not passthrough.
+        targetFormat: FORMATS.OPENAI,
+        sourceFormat: FORMATS.OPENAI_RESPONSES,
+        provider: "openrouter",
+        model: "nemotron-3.5-lightning-free",
+        body: { input: [{ type: "message", role: "user", content: "think hard" }] },
+        onComplete: (payload: OnCompletePayload) => {
+          onCompletePayload = payload;
+        },
+      })
+    )
+  ).text();
+  return { output, onCompletePayload };
+}
+
+function reasoningDeltaChunk(i: number) {
+  return `data: ${JSON.stringify({
+    id: "chatcmpl-real-provider-id",
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta: { reasoning_content: `r${i} ` } }],
+  })}\n\n`;
+}
+
+test("translate mode's clientPayload/providerPayload survive a stream that exceeds the real production event cap", async () => {
+  // 2005 tiny reasoning-delta events: 5 over createStructuredSSECollector's
+  // real default (maxEvents=2000) -- the exact live-incident mechanism, not
+  // a shrunk test-only cap. The genuine content/finish sequence lands entirely
+  // in the dropped tail.
+  const reasoningDeltas = Array.from({ length: 2005 }, (_, i) => reasoningDeltaChunk(i));
+
+  const { onCompletePayload } = await runTranslate([
+    ...reasoningDeltas,
+    `data: ${JSON.stringify({
+      id: "chatcmpl-real-provider-id",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { role: "assistant", content: "the real answer" } }],
+    })}\n\n`,
+    `data: ${JSON.stringify({
+      id: "chatcmpl-real-provider-id",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    })}\n\n`,
+    `data: ${JSON.stringify({
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 5, completion_tokens: 2006, total_tokens: 2011 },
+    })}\n\n`,
+    "data: [DONE]\n\n",
+  ]);
+
+  assert.ok(onCompletePayload, "onComplete must fire");
+  const clientPayload = onCompletePayload!.clientPayload as
+    | { id?: unknown; summary?: { id?: unknown; status?: unknown; output?: unknown } }
+    | undefined;
+  assert.ok(clientPayload, "clientPayload must be present");
+
+  const status = clientPayload!.summary?.status;
+  const output = clientPayload!.summary?.output as Array<Record<string, unknown>> | undefined;
+  assert.equal(
+    status,
+    "completed",
+    "status must be the real terminal state, not stuck at in_progress from a dropped completion event"
+  );
+  assert.ok(
+    Array.isArray(output) && output.length > 0,
+    "output must reflect the real reply, not the empty array a cap-truncated getEvents() rebuild would produce"
+  );
+  const text = JSON.stringify(output);
+  assert.ok(
+    text.includes("the real answer"),
+    "the actual final content must be present, not lost to the collector's storage cap"
+  );
+
+  // providerPayload gets the identical treatment at the same call site.
+  const providerPayload = onCompletePayload!.providerPayload as
+    | { summary?: { status?: unknown } }
+    | undefined;
+  assert.ok(providerPayload, "providerPayload must be present");
+});


### PR DESCRIPTION
## What Problem This Solves

A reasoning-heavy stream that exceeds the SSE payload collector's event cap
loses its own logged/stored completion state permanently — even though the
connected client received the real, complete reply. This is the true root
cause behind two workarounds already shipped this week
(`resolvePreviousResponseState`'s fail-closed check, and
`/dashboard/conversations`' "stalled" badge): they detect and route around
the symptom, but the actual data loss at the source was never fixed.

## Why This Change Was Made

Live incident: a stream pushed 3013 SSE events (mostly tiny reasoning
deltas) before its terminal `response.completed` — past
`createStructuredSSECollector`'s 2000-event default cap. `onComplete`'s
`clientPayload`/`providerPayload` for a Responses-API client were rebuilt
via `buildStreamSummaryFromEvents(collector.getEvents(), format, model)` —
reading the collector's own **retained (cap-dropped)** event array. The
dropped completion event meant this permanently produced
`status: "in_progress"` / `output: []` for a response the client actually
received in full.

Root cause has three layers, all traced via direct code/history reading
(`git log -p -S`), not guessed:

1. `clientPayloadCollector` never had a `format` at construction, so it had
   no live reducer at all — unlike `providerPayloadCollector`, which got one
   in an earlier `#9315` fix.
2. Even where `providerPayloadCollector` *did* already have a live reducer
   wired, its own `OPENAI_RESPONSES` `build()` call sites never actually
   called it — a later commit (08-08 base-red cleanup) deliberately
   reintroduced the events-derived rebuild for `OPENAI_RESPONSES` specifically,
   to fix a real but *different* bug (the accumulated `responseBody` is
   chat-completions-shaped and loses the Responses `response` object) —
   without noticing this silently reintroduced the exact truncation
   vulnerability `#9315` had just fixed, for the one format most likely to
   carry large reasoning payloads.
3. `clientPayload`'s own later `OPENAI_RESPONSES` carve-out (`#11434`) copied
   the same now-vulnerable pattern.

## Fix

All four `OPENAI_RESPONSES`-shaped `build()` call sites (provider + client,
passthrough + translate mode) now call `.getSummary()` — the reducer that
already runs live on **every** `push()`, not just the ones that survive the
storage cap — instead of `buildStreamSummaryFromEvents(.getEvents(), ...)`.
`getSummary()` and `buildStreamSummaryFromEvents(getEvents())` are the exact
same reducer (`createResponsesReducer`); the only difference is whether
`ingest()` saw every pushed chunk or only the capped remainder — strictly
equivalent for a stream that never hits the cap, correct instead of silently
empty for one that does. No behavior change for a non-Responses client.

## User Impact

A long reasoning-heavy Responses-API stream no longer loses its own logged
completion state, no matter how many events it takes to finish. Both
existing workarounds (fail-closed continuation, "stalled" badge) become
genuinely unreachable for this cause going forward instead of routinely
firing.

## Evidence

New dedicated regression test pushes 2005 real SSE chunks (5 over the actual
production cap, not a shrunk test-only one) through the real
`createSSEStream()` pipeline and asserts the terminal status/output survive.
**Fails on pre-fix code with the incident's own exact signature**
(`status: "in_progress"` instead of `"completed"`) — verified by reverting
just this commit's `stream.ts` and rerunning.

Full touched-file suite: 112/112 passing, including both existing `#11434`
passthrough/translate regression tests and the `#9315` provider-truncation
test — no regressions.

`eslint` / `tsc --pretty false -p tsconfig.typecheck-core.json` clean (the
two pre-existing `eslint` findings in `stream.ts` are confirmed unrelated —
present identically on current `main` via `git stash` before/after).
