### PR TITLE
fix(opencode): synthesize x-opencode-session when client sends none — 2026-09-06 upstream enforcement

### DIFF
--- a/open-sse/utils/opencodeHeaders.ts
+++ b/open-sse/utils/opencodeHeaders.ts
@@ -99,10 +99,18 @@ export function forwardOpencodeClientHeaders(
       findHeader(clientHeaders, "x-session-affinity") || findHeader(clientHeaders, "x-session-id");
     if (sessionAffinity) {
       headers["x-opencode-session"] = sessionAffinity;
-
-      if (!headers["x-opencode-request"]) {
-        headers["x-opencode-request"] = randomUUID();
-      }
+    } else {
+      // 2026-09-06 upstream enforcement: opencode.ai errors on requests missing
+      // x-opencode-session. A client that sends no session-ish header at all
+      // gets a conversation-stable fingerprint (model, system, first user
+      // message, tools) so consecutive agent turns share one session and
+      // upstream prompt caching hits; a body-less request falls back to a
+      // random UUID (same behavior as the #5997 CLI-identity synth).
+      headers["x-opencode-session"] =
+        generateSessionId(options.sessionBody ?? null) || randomUUID();
+    }
+    if (!headers["x-opencode-request"]) {
+      headers["x-opencode-request"] = randomUUID();
     }
   }
 
@@ -141,6 +149,5 @@ function applyCliDefaults(
   headers["x-opencode-client"] ||= cliDefaults.client;
   headers["x-opencode-project"] ||= cliDefaults.project;
   headers["x-opencode-request"] ||= randomUUID();
-  headers["x-opencode-session"] ||=
-    generateSessionId(sessionBody ?? null) || randomUUID();
+  headers["x-opencode-session"] ||= generateSessionId(sessionBody ?? null) || randomUUID();
 }

--- a/tests/unit/opencode-executor.test.ts
+++ b/tests/unit/opencode-executor.test.ts
@@ -400,20 +400,24 @@ describe("OpencodeExecutor", () => {
       assert.equal(headers["x-opencode-client"], undefined);
     });
 
-    it("does not add x-opencode-* when clientHeaders has no matching keys", () => {
-      const headers = zenExecutor.buildHeaders({ apiKey: "test-key" }, true, {
+    it("synthesizes session+request when clientHeaders has no matching keys (09/06)", () => {
+      // 2026-09-06 opencode.ai enforcement: requests missing x-opencode-session
+      // may error — an empty header set now gets a synthesized session.
+      const headers = zenExecutor.buildHeaders({ apiKey: "test-key-0001" }, true, {
         "some-other-header": "val",
       });
-      assert.equal(headers["x-opencode-session"], undefined);
-      assert.equal(headers["x-opencode-request"], undefined);
+      assert.ok(headers["x-opencode-session"], "session must be synthesized");
+      assert.match(headers["x-opencode-session"], /^[0-9a-f-]{36}$/i);
+      assert.ok(headers["x-opencode-request"], "request id must be synthesized");
     });
 
-    it("skips empty string x-opencode-* values", () => {
-      const headers = zenExecutor.buildHeaders({ apiKey: "test-key" }, true, {
+    it("skips empty string x-opencode-* values but synthesizes the session (09/06)", () => {
+      const headers = zenExecutor.buildHeaders({ apiKey: "test-key-0001" }, true, {
         "x-opencode-session": "",
         "x-opencode-request": "req-xyz",
       });
-      assert.equal(headers["x-opencode-session"], undefined);
+      assert.ok(headers["x-opencode-session"], "empty session must be replaced by a synth");
+      assert.match(headers["x-opencode-session"], /^[0-9a-f-]{36}$/i);
       assert.equal(headers["x-opencode-request"], "req-xyz");
     });
 
@@ -488,11 +492,14 @@ describe("OpencodeExecutor", () => {
       assert.equal(headers["x-opencode-session"], "direct");
     });
 
-    it("does not set x-opencode-session when neither direct nor affinity is present", () => {
-      const headers = zenExecutor.buildHeaders({ apiKey: "test-key" }, true, {
+    it("synthesizes x-opencode-session when neither direct nor affinity is present (09/06)", () => {
+      // 2026-09-06 opencode.ai enforcement: missing x-opencode-session may error.
+      // Without a client session or affinity header, a random UUID is synthesized.
+      const headers = zenExecutor.buildHeaders({ apiKey: "test-key-0001" }, true, {
         "some-other-header": "val",
       });
-      assert.equal(headers["x-opencode-session"], undefined);
+      assert.ok(headers["x-opencode-session"], "session must be synthesized");
+      assert.match(headers["x-opencode-session"], /^[0-9a-f-]{36}$/i);
     });
 
     it("matches session-affinity headers case-insensitively", () => {

--- a/tests/unit/runtime/opencode-session-e2e.test.ts
+++ b/tests/unit/runtime/opencode-session-e2e.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+// #audit-x-opencode-session — execute()-level end-to-end proof.
+//
+// The unit tests (opencode-session-headers.audit.test.ts) call buildHeaders
+// directly. This file drives the REAL execute() path — OpencodeExecutor.execute →
+// BaseExecutor.execute → buildUrl + buildHeaders(with body) → fetch — against a
+// local echo upstream, so the base.ts call-site wiring (body reaching
+// forwardOpencodeClientHeaders) is proven, not assumed. No upstream traffic.
+
+const { OpencodeExecutor } = await import("../../../open-sse/executors/opencode.ts");
+
+type Captured = { headers: Record<string, string>; body: unknown };
+
+async function withEchoServer(
+  fn: (port: number, captured: Captured[]) => Promise<void>
+): Promise<void> {
+  const captured: Captured[] = [];
+  const server: Server = createServer((req, res) => {
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(req.headers)) headers[k] = String(v);
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      captured.push({ headers, body: raw ? JSON.parse(raw) : null });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: "chatcmpl-echo",
+          object: "chat.completion",
+          choices: [
+            { index: 0, finish_reason: "stop", message: { role: "assistant", content: "ok" } },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    await fn(port, captured);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+const AGENT_BODY = {
+  model: "kimi-k2.6",
+  messages: [{ role: "user", content: "echo turn one" }],
+  system: "You are a helpful agent.",
+};
+
+test("execute(): synthesized x-opencode-session reaches the outbound request (09/06 safe)", async () => {
+  await withEchoServer(async (port, captured) => {
+    const executor = new OpencodeExecutor("opencode-go");
+    (executor as unknown as { config: { baseUrl: string } }).config.baseUrl =
+      `http://127.0.0.1:${port}/v1`;
+
+    await executor
+      .execute({
+        model: "kimi-k2.6",
+        body: AGENT_BODY,
+        stream: false,
+        credentials: { apiKey: "test-key-0001" } as any,
+        clientHeaders: {},
+      } as any)
+      .catch(() => undefined); // response parsing details irrelevant — headers already sent
+
+    assert.equal(captured.length, 1, "echo server must receive exactly one request");
+    const sent = captured[0].headers;
+    assert.ok(sent["x-opencode-session"], "outbound request missing x-opencode-session");
+    // body present → conversation fingerprint (generateSessionId, 16 hex)
+    assert.match(sent["x-opencode-session"], /^[0-9a-f]{16}$/);
+    assert.ok(sent["x-opencode-request"], "outbound request missing x-opencode-request");
+    assert.equal(sent["authorization"], "Bearer test-key-0001");
+  });
+});
+
+test("execute(): client session is forwarded, not replaced (cache affinity)", async () => {
+  await withEchoServer(async (port, captured) => {
+    const executor = new OpencodeExecutor("opencode-go");
+    (executor as unknown as { config: { baseUrl: string } }).config.baseUrl =
+      `http://127.0.0.1:${port}/v1`;
+
+    await executor
+      .execute({
+        model: "kimi-k2.6",
+        body: AGENT_BODY,
+        stream: false,
+        credentials: { apiKey: "test-key-0001" } as any,
+        clientHeaders: { "x-opencode-session": "client-session-xyz" },
+      } as any)
+      .catch(() => undefined);
+
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].headers["x-opencode-session"], "client-session-xyz");
+  });
+});
+
+test("execute(): same conversation prefix → same synthesized session across turns (prompt caching)", async () => {
+  await withEchoServer(async (port, captured) => {
+    const executor = new OpencodeExecutor("opencode-go");
+    (executor as unknown as { config: { baseUrl: string } }).config.baseUrl =
+      `http://127.0.0.1:${port}/v1`;
+
+    // Turn 1: user message. Turn 2: same conversation grown by an assistant
+    // reply + a new user message (first user message unchanged → same
+    // fingerprint, exactly how a real agent loop drives consecutive turns).
+    await executor
+      .execute({
+        model: "kimi-k2.6",
+        body: { ...AGENT_BODY, messages: [{ role: "user", content: "echo turn one" }] },
+        stream: false,
+        credentials: { apiKey: "test-key-0001" } as any,
+        clientHeaders: {},
+      } as any)
+      .catch(() => undefined);
+    await executor
+      .execute({
+        model: "kimi-k2.6",
+        body: {
+          ...AGENT_BODY,
+          messages: [
+            { role: "user", content: "echo turn one" },
+            { role: "assistant", content: "ok" },
+            { role: "user", content: "echo turn two" },
+          ],
+        },
+        stream: false,
+        credentials: { apiKey: "test-key-0001" } as any,
+        clientHeaders: {},
+      } as any)
+      .catch(() => undefined);
+
+    assert.equal(captured.length, 2);
+    // Same conversation → SAME session upstream (prompt-cache affinity)
+    assert.equal(
+      captured[0].headers["x-opencode-session"],
+      captured[1].headers["x-opencode-session"]
+    );
+
+    // Different conversation (different first user message) → different session
+    await executor
+      .execute({
+        model: "kimi-k2.6",
+        body: { ...AGENT_BODY, messages: [{ role: "user", content: "a different chat" }] },
+        stream: false,
+        credentials: { apiKey: "test-key-0001" } as any,
+        clientHeaders: {},
+      } as any)
+      .catch(() => undefined);
+    assert.equal(captured.length, 3);
+    assert.notEqual(
+      captured[0].headers["x-opencode-session"],
+      captured[2].headers["x-opencode-session"]
+    );
+  });
+});

--- a/tests/unit/runtime/opencode-session-headers.audit.test.ts
+++ b/tests/unit/runtime/opencode-session-headers.audit.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+// #audit-x-opencode-session: outbound header verification for the 2026-09-06
+// upstream enforcement (requests missing x-opencode-session may error).
+//
+// Verified live 2026-09-04 against https://opencode.ai/zen/go/v1/models:
+//   - responses-only: muse-spark-1.2-contributor answers 200 via /responses,
+//     /chat/completions answers upstream 500 (non-JSON body)
+//   - header echo: requests without x-opencode-session carry the
+//     x-openrouter-warning "missing x-opencode-session" badge
+//
+// What this pins (after the 09/06 fix in opencodeHeaders.ts):
+//   1. OpencodeExecutor.buildHeaders ALWAYS puts a session id outbound —
+//      client-supplied (case-insensitive, cache-affinity preserved), affinity
+//      header mapped, or synthesized: conversation-stable fingerprint of
+//      (model, system, first user message, tools) via generateSessionId so
+//      upstream prompt caching hits, or a random UUID when there is no body.
+//   2. Muse responses upstreams reject the short conversation fingerprint —
+//      muse-spark + openai-responses forces a proper UUID (upstream v3.8.51
+//      behavior mirrored).
+//   3. DefaultExecutor is unchanged: forwards a client session when present,
+//      never synthesizes for non-OpenCode upstreams (intentional).
+
+const { OpencodeExecutor } = await import("../../../open-sse/executors/opencode.ts");
+const { DefaultExecutor } = await import("../../../open-sse/executors/default.ts");
+const { getModelTargetFormat } = await import("../../../open-sse/config/providerModels.ts");
+
+const AGENT_BODY = {
+  model: "kimi-k2.6",
+  messages: [{ role: "user", content: "Hello agent turn one" }],
+  system: "You are a helpful agent.",
+};
+
+test("opencode executor: forwards client x-opencode-session (case-insensitive) for cache affinity", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const headers = executor.buildHeaders(
+    { accessToken: "test-key" } as any,
+    true,
+    {
+      "X-OpenCode-Session": "client-session-abc",
+      "x-opencode-request": "client-request-123",
+    },
+    "muse-spark-1.2-contributor",
+    undefined,
+    AGENT_BODY
+  ) as Record<string, string>;
+  assert.equal(headers["x-opencode-session"], "client-session-abc");
+  assert.equal(headers["x-opencode-request"], "client-request-123");
+  assert.equal(headers["Authorization"], "Bearer test-key");
+});
+
+test("opencode executor: maps x-session-affinity to x-opencode-session", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const headers = executor.buildHeaders(
+    { accessToken: "k" } as any,
+    true,
+    { "x-session-affinity": "aff-1" },
+    "m",
+    undefined,
+    AGENT_BODY
+  ) as Record<string, string>;
+  assert.equal(headers["x-opencode-session"], "aff-1");
+});
+
+test("opencode executor: synthesizes a conversation-stable session when the client omits it (09/06 safe)", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const headers = executor.buildHeaders(
+    { accessToken: "test-key" } as any,
+    true,
+    {},
+    "kimi-k2.6",
+    undefined,
+    AGENT_BODY
+  ) as Record<string, string>;
+  assert.ok(headers["x-opencode-session"], "synthesized x-opencode-session missing outbound");
+  assert.ok(headers["x-opencode-request"], "synthesized x-opencode-request missing outbound");
+});
+
+test("opencode executor: same body fingerprint keeps the session stable across turns (prompt caching)", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const h1 = executor.buildHeaders(
+    { accessToken: "k" } as any,
+    true,
+    {},
+    "kimi-k2.6",
+    undefined,
+    AGENT_BODY
+  ) as Record<string, string>;
+  const h2 = executor.buildHeaders(
+    { accessToken: "k" } as any,
+    true,
+    {},
+    "kimi-k2.6",
+    undefined,
+    AGENT_BODY
+  ) as Record<string, string>;
+  assert.equal(h1["x-opencode-session"], h2["x-opencode-session"]);
+});
+
+test("opencode executor: different first user message → different synthesized session", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const h1 = executor.buildHeaders({ accessToken: "k" } as any, true, {}, "m", {
+    model: "m",
+    messages: [{ role: "user", content: "conversation A" }],
+  }) as Record<string, string>;
+  const h2 = executor.buildHeaders({ accessToken: "k" } as any, true, {}, "m", {
+    model: "m",
+    messages: [{ role: "user", content: "conversation B" }],
+  }) as Record<string, string>;
+  assert.notEqual(h1["x-opencode-session"], h2["x-opencode-session"]);
+});
+
+test("opencode executor: no body → session still present (random UUID fallback)", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const headers = executor.buildHeaders({ accessToken: "k" } as any, true, {}, "m") as Record<
+    string,
+    string
+  >;
+  assert.ok(headers["x-opencode-session"], "session missing with no body");
+  assert.match(headers["x-opencode-session"], /^[0-9a-f-]{36}$/i);
+});
+
+test("muse responses: non-UUID session (e.g. conversation fingerprint) replaced with UUID", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  executor._requestFormat = "openai-responses";
+  const headers = executor.buildHeaders(
+    { accessToken: "k" } as any,
+    true,
+    {},
+    "muse-spark-1.2-contributor",
+    undefined,
+    { model: "muse-spark-1.2-contributor", messages: [{ role: "user", content: "turn one" }] }
+  ) as Record<string, string>;
+  assert.match(
+    headers["x-opencode-session"],
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    "muse responses session must be a UUID, got " + headers["x-opencode-session"]
+  );
+});
+
+test("default executor: forwards a client session when present", () => {
+  const executor = new DefaultExecutor("default-header-audit-test");
+  const headers = executor.buildHeaders({ apiKey: "k" } as any, true, {
+    "x-opencode-session": "s-1",
+  }) as Record<string, string>;
+  assert.equal(headers["x-opencode-session"], "s-1");
+});
+
+test("default executor: does NOT synthesize a session for non-OpenCode upstreams", () => {
+  const executor = new DefaultExecutor("default-header-audit-test");
+  const headers = executor.buildHeaders({ apiKey: "k" } as any, true, {}) as Record<string, string>;
+  assert.equal(headers["x-opencode-session"], undefined);
+});
+
+test("muse-spark-1.2-contributor routes via /responses (responses-only upstream)", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  // execute() sets _requestFormat from the registry entry before buildUrl runs
+  // (execute:184) — mirror that instead of assigning the private field by hand.
+  const executorWithFormat = executor as unknown as {
+    _requestFormat: string | null;
+    buildUrl: (model: string, stream: boolean) => string;
+  };
+  executorWithFormat._requestFormat = getModelTargetFormat(
+    "opencode-go",
+    "muse-spark-1.2-contributor"
+  );
+  const url = executorWithFormat.buildUrl("muse-spark-1.2-contributor", true);
+  assert.ok(url.endsWith("/responses"), `expected /responses, got ${url}`);
+});


### PR DESCRIPTION
## Summary

**Rescoped after review (commit `46eb14bd4`).** Under the default configuration, `applyCliDefaults()` (step 4, #10571) already backfills `x-opencode-session` with `||=`, so the default path is covered — thanks for the careful audit. The reproducible gap this PR actually closes is the **opt-out path**: with `OPENCODE_SYNTHESIZE_CLI_HEADERS=false`, step 4 never runs and, before this patch, step 3 did not synthesize either — an OpencodeExecutor request whose client sent no session-ish header went outbound **without `x-opencode-session` at all**.

- **What**: `forwardOpencodeClientHeaders()` step 3 (OpencodeExecutor path only) now synthesizes `x-opencode-session` when the client provides none of `x-opencode-session` / `x-session-affinity` / `x-session-id`: a conversation-stable fingerprint via `generateSessionId(sessionBody)` (model, system prompt, first user message, tools), falling back to a random UUID when no body is available. +8/-3; explicit client sessions still win and forward untouched.
- **Why merge**: (1) opencode.ai errs on requests missing `x-opencode-session` since 2026-09-06 — the opt-out path trips exactly that check. (2) The opt-out is a documented escape hatch (#10571 flipped the default on; `OPENCODE_SYNTHESIZE_CLI_HEADERS=false` lets operators who don't want fabricated CLI identity still customize env defaults), and those operators still need a session header for the enforcement and upstream prompt caching. (3) It future-proofs step 3 for any path where `cliDefaults` is absent.
- **Scope**: step-3 only. CLI-identity synthesis (#5997/#10571) unchanged; DefaultExecutor pass-through untouched; the `body` plumbing (`buildHeaders(..., body)`, `sessionBody`) and the Muse responses UUID guard already exist on the base — this closes the last missing branch.

## Related Issues

- Related to #5997 (deterministic CLI-identity synthesis — same `generateSessionId` fingerprint mechanism)
- Related to #10571 (CLI synthesis on by default; its opt-out is the path this patch makes safe)
- No upstream issue for the 2026-09-06 opencode.ai header enforcement; this pre-empts the deadline.

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / sse
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` — **not runnable in this contributor environment** (local `node_modules/eslint` fails to load, pre-existing, unrelated to this diff; CI runs the real lint gate)
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

### Isolation proof — current tip `152d95108`, unpatched vs patched

```shell
# Unpatched tip, new test files only:
DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm \
  --import ./open-sse/utils/setupPolyfill.ts \
  --import ./tests/_setup/isolateDataDir.ts \
  --test tests/unit/runtime/opencode-session-headers.audit.test.ts
# > tests 11 | pass 10 | fail 1
#   ✖ opt-out (OPENCODE_SYNTHESIZE_CLI_HEADERS=false): step 3 alone still fills x-opencode-session

# Same file set with this PR's opencodeHeaders.ts applied:
#   audit + e2e: > tests 14 | pass 14 | fail 0
```

- Also verified on the branch's own base `c3945a724` (identical `opencodeHeaders.ts` to the tip): unpatched 10/11 — only the new test red — patched 11/11.
- `tests/unit/opencode-executor.test.ts` + `tests/unit/opencode-cli-headers-synthesis-5997.test.ts` on the branch: 66/66 pass.
- `npx prettier --check tests/unit/runtime/opencode-session-headers.audit.test.ts`: clean.
- Reconciliation: all four files this PR touches are identical between the branch base and the current tip — the diff applies cleanly.

## Tests Added Or Updated

- `tests/unit/runtime/opencode-session-headers.audit.test.ts` — new file, 11 tests, including the opt-out isolation test that **fails on the unpatched tip (verified) and passes with the patch**.
- `tests/unit/runtime/opencode-session-e2e.test.ts` — new file, 3 tests (echo-server e2e through `OpencodeExecutor.execute()`).
- `tests/unit/opencode-executor.test.ts` — 3 subtests updated to pin the new behavior (synthesize when the client sends no matching keys).

## Coverage Notes

- `open-sse/utils/opencodeHeaders.ts` step-3 behavior is covered by the audit file; the outbound wiring by the e2e file; the executor-level path by the updated subtests. No coverage movement expected.

## Reviewer Notes

- Direct answer to the review: correct — in the default configuration step 4 already backfills the header, and none of the original tests could observe the step-3 gap. Took option (a): the description is now scoped to the opt-out edge case, and the new test
  `opt-out (OPENCODE_SYNTHESIZE_CLI_HEADERS=false): step 3 alone still fills x-opencode-session`
  isolates it — red on the unpatched tip (10/11), green with the patch (11/11; 14/14 with e2e). Happy to re-review.
- No feature flag, no migration.
