### PR TITLE
refactor(providers): single source of truth for agy/antigravity public catalogs (#12724)

### DIFF
--- a/changelog.d/fixes/12724-agy-antigravity-catalog-dedup.md
+++ b/changelog.d/fixes/12724-agy-antigravity-catalog-dedup.md
@@ -1,0 +1,1 @@
+- **fix(providers):** `AGY_PUBLIC_MODELS` is now a re-export of the canonical `ANTIGRAVITY_PUBLIC_MODELS` catalog instead of a second hand-maintained copy — the two lists had been byte-equal for over a month and could silently drift whenever a new Antigravity-backed model shipped ([#12724](https://github.com/diegosouzapw/OmniRoute/issues/12724))

--- a/open-sse/config/agyModels.ts
+++ b/open-sse/config/agyModels.ts
@@ -1,110 +1,20 @@
 // Antigravity CLI (`agy`) model catalog.
 //
-// These models are pinned from the live `:fetchAvailableModels` endpoint
-// (https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels) using a
-// real `agy` consumer-OAuth token. The public catalog exposes the upstream Gemini 3.7
-// Flash ids verbatim; the shared Antigravity executor dispatches them unchanged.
+// The `agy` provider reuses the `antigravity` executor/translator (identical
+// backend). Its public catalog is a direct re-export of ANTIGRAVITY_PUBLIC_MODELS:
+// both surfaces expose the same callable Claude/Gemini/GPT set and the lists
+// were hand-maintained as two copies until they were byte-equal for months —
+// a new model shipped on one side silently missed the other (#12724). Keeping
+// one canonical array in antigravityModelAliases.ts makes drift impossible.
+// Tab-completion models (`tab_flash_lite_preview`, `tab_jump_flash_lite_preview`)
+// are intentionally excluded from the shared catalog — they are not chat-callable.
 //
-// The `agy` provider reuses the `antigravity` executor/translator (identical backend),
-// but keeps its own catalog so the CLI and IDE model surfaces can evolve independently.
-// Both currently expose the same callable Claude/Gemini/GPT set. Tab-completion models
-// (`tab_flash_lite_preview`, `tab_jump_flash_lite_preview`) are intentionally excluded —
-// they are not chat-callable.
+// The agy-specific helpers below (non-chat / retired id sets, client-visible
+// names) stay here because they encode CLI-surface policy, not catalog content.
 
-export const AGY_PUBLIC_MODELS = Object.freeze([
-  // Gemini 3.7 Flash tiers. The live endpoint selects High by default and advertises
-  // all three ids to both the IDE 2.5.5 and CLI 1.1.x clients.
-  {
-    id: "gemini-3.7-flash-high",
-    name: "Gemini 3.7 Flash (High)",
-    contextLength: 1048576,
-    maxOutputTokens: 65536,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  {
-    id: "gemini-3.7-flash-medium",
-    name: "Gemini 3.7 Flash (Medium)",
-    contextLength: 1048576,
-    maxOutputTokens: 65536,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  {
-    id: "gemini-3.7-flash-low",
-    name: "Gemini 3.7 Flash (Low)",
-    contextLength: 1048576,
-    maxOutputTokens: 65536,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  {
-    id: "gemini-3.7-flash-tiered",
-    name: "Gemini 3.7 Flash (Tiered)",
-    contextLength: 1048576,
-    maxOutputTokens: 65536,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  // Gemini 3.1 Pro
-  {
-    id: "gemini-pro-agent",
-    name: "Gemini 3.1 Pro (High)",
-    contextLength: 1048576,
-    maxOutputTokens: 65535,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  {
-    id: "gemini-3.1-pro-low",
-    name: "Gemini 3.1 Pro (Low)",
-    contextLength: 1048576,
-    maxOutputTokens: 65535,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  {
-    id: "gemini-3.1-flash-lite",
-    name: "Gemini 3.1 Flash Lite",
-    contextLength: 1048576,
-    maxOutputTokens: 65535,
-    toolCalling: true,
-  },
-  // Claude (Antigravity backend).
-  {
-    id: "claude-opus-4-6-thinking",
-    name: "Claude Opus 4.6 (Thinking)",
-    contextLength: 1048576,
-    maxOutputTokens: 65536,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  {
-    id: "claude-sonnet-4-6",
-    name: "Claude Sonnet 4.6 (Thinking)",
-    contextLength: 1048576,
-    maxOutputTokens: 65536,
-    supportsReasoning: true,
-    supportsVision: true,
-    toolCalling: true,
-  },
-  // GPT-OSS
-  {
-    id: "gpt-oss-120b-medium",
-    name: "GPT-OSS 120B (Medium)",
-    contextLength: 131072,
-    maxOutputTokens: 32768,
-    supportsReasoning: true,
-    toolCalling: true,
-  },
-]);
+import { ANTIGRAVITY_PUBLIC_MODELS } from "./antigravityModelAliases.ts";
+
+export const AGY_PUBLIC_MODELS = ANTIGRAVITY_PUBLIC_MODELS;
 
 const AGY_PUBLIC_MODEL_IDS = new Set(AGY_PUBLIC_MODELS.map((model) => model.id));
 const AGY_NON_CHAT_MODEL_IDS = new Set(["tab_flash_lite_preview", "tab_jump_flash_lite_preview"]);

--- a/tests/unit/agy-antigravity-catalog-dedup-12724.test.ts
+++ b/tests/unit/agy-antigravity-catalog-dedup-12724.test.ts
@@ -1,0 +1,43 @@
+// #12724 — AGY_PUBLIC_MODELS and ANTIGRAVITY_PUBLIC_MODELS were two
+// hand-maintained copies of the same list; they had been byte-equal for months
+// and could silently drift whenever a new Antigravity-backed model shipped.
+// agyModels.ts now re-exports the canonical antigravity catalog, so the two
+// can never diverge. These tests pin that invariant.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { AGY_PUBLIC_MODELS } from "../../open-sse/config/agyModels.ts";
+import { ANTIGRAVITY_PUBLIC_MODELS } from "../../open-sse/config/antigravityModelAliases.ts";
+
+test("AGY_PUBLIC_MODELS is the same array as ANTIGRAVITY_PUBLIC_MODELS (single source of truth)", () => {
+  assert.strictEqual(
+    AGY_PUBLIC_MODELS,
+    ANTIGRAVITY_PUBLIC_MODELS,
+    "agy must reuse the canonical antigravity catalog — two hand-synced copies silently drift (#12724)"
+  );
+});
+
+test("agy and antigravity expose the same model id set (defensive)", () => {
+  const agyIds = AGY_PUBLIC_MODELS.map((model) => model.id).sort();
+  const antigravityIds = ANTIGRAVITY_PUBLIC_MODELS.map((model) => model.id).sort();
+  assert.deepEqual(agyIds, antigravityIds);
+});
+
+test("agy catalog matches the documented 10-model callable set", () => {
+  assert.equal(AGY_PUBLIC_MODELS.length, 10);
+  const ids = new Set(AGY_PUBLIC_MODELS.map((model) => model.id));
+  for (const id of [
+    "claude-opus-4-6-thinking",
+    "claude-sonnet-4-6",
+    "gemini-pro-agent",
+    "gemini-3.1-flash-lite",
+    "gemini-3.1-pro-low",
+    "gemini-3.7-flash-low",
+    "gemini-3.7-flash-medium",
+    "gemini-3.7-flash-high",
+    "gemini-3.7-flash-tiered",
+    "gpt-oss-120b-medium",
+  ]) {
+    assert.ok(ids.has(id), `expected ${id} in the agy public catalog`);
+  }
+});


### PR DESCRIPTION
Fixes #12724.

`agyModels.ts` and `antigravityModelAliases.ts` carried two hand-maintained copies of the same model list — byte-identical since 2026-07-29, so every new Antigravity-backed model meant the same edit twice and the copies could silently drift. This makes `ANTIGRAVITY_PUBLIC_MODELS` the single source of truth and turns `AGY_PUBLIC_MODELS` into a re-export of it.

I verified on this branch that the two arrays are deep-equal (same ids, same order, same specs) before collapsing them, so this is behavior-preserving. The agy-specific helpers (`isUserCallableAgyModelId`, `isDiscoverableAgyModelId`, retired/non-chat id sets, client-visible names) stay in `agyModels.ts` — they encode CLI-surface policy, not catalog content.

Tests: `tests/unit/agy-antigravity-catalog-dedup-12724.test.ts` pins the invariant (same array reference, same id set, and the documented 10-model set). The existing agy/antigravity suites (20 tests) and the #12058 catalog tests stay green; `check:provider-consistency`, typecheck and lint pass.

Note for later merges: two open PRs (#12608, #12672) touch both catalogs — after this lands, a catalog refresh only needs to edit `antigravityModelAliases.ts`.

base-red inherited: #12732 (pre-existing — blames other PRs, none related to this change).

