### PR TITLE
fix(dashboard): read the CC onboarding key placeholder raw; disable docs theme override

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-code/components/ClaudeGatewayOnboardingBlock.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/ClaudeGatewayOnboardingBlock.tsx
@@ -20,7 +20,7 @@ export default function ClaudeGatewayOnboardingBlock({ baseUrl }: { baseUrl: str
 
   const snippet = buildClaudeDiscoverySettingsSnippet({
     baseUrl,
-    apiKeyPlaceholder: t("ccOnboardingKeyPlaceholder"),
+    apiKeyPlaceholder: t.raw("ccOnboardingKeyPlaceholder"),
   });
 
   const handleCopy = async () => {

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -51,8 +51,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
   return (
     <RootProvider
       theme={{
-        defaultTheme: "dark",
-        attribute: "class",
+        enabled: false,
       }}
       search={{
         options: {


### PR DESCRIPTION
⚠️ base-red inherited: #12732

Two small, unrelated dashboard fixes.

## 1. CC onboarding snippet drops the API-key placeholder

`ClaudeGatewayOnboardingBlock` builds the copyable Claude discovery settings snippet with

```ts
apiKeyPlaceholder: t("ccOnboardingKeyPlaceholder"),
```

The message is angle-bracketed in every locale — `"ccOnboardingKeyPlaceholder": "<your OmniRoute API key>"` (`src/i18n/messages/en.json`, and the same shape across all 40 locale files). next-intl parses `<...>` in a message as **rich-text tags**, so the placeholder does not survive interpolation into the snippet the user copies.

`t.raw()` returns the message verbatim, which is exactly what a literal placeholder needs. No message files change.

## 2. /docs forces its own dark theme

The fumadocs `RootProvider` in `src/app/docs/layout.tsx` set

```tsx
theme={{ defaultTheme: "dark", attribute: "class" }}
```

which makes the provider drive the `class` attribute on `/docs` and fight the surrounding app's own theme handling. `theme={{ enabled: false }}` leaves the app in charge; the docs pages then follow the dashboard theme instead of pinning dark.

## Validation

Both changes are single-expression edits with no new logic, so there is no behaviour to encode as a unit test; they are covered by the existing typecheck/lint gates:

```
npm run typecheck:core                                             # exit 0
npx eslint src/app/(dashboard)/.../ClaudeGatewayOnboardingBlock.tsx src/app/docs/layout.tsx   # clean
npx prettier --check <both files>                                  # clean
```

Branch is rebased onto `c3945a724` (current `release/v3.8.51` tip).
