### PR TITLE
fix: resolve free-mode providers from live economics

### DIFF
--- a/open-sse/config/freeModelCatalog.ts
+++ b/open-sse/config/freeModelCatalog.ts
@@ -11,6 +11,21 @@ export type FreeModelFreeType =
   | "keyless"
   | "discontinued";
 
+/** Whether each catalog regime currently grants access without incremental spend. */
+const FREE_ACCESS_BY_TYPE: Record<FreeModelFreeType, boolean> = {
+  "recurring-daily": true,
+  "recurring-monthly": true,
+  "recurring-credit": true,
+  "recurring-uncapped": true,
+  "one-time-initial": true,
+  keyless: true,
+  discontinued: false,
+};
+
+export function grantsFreeAccess(freeType: FreeModelFreeType): boolean {
+  return FREE_ACCESS_BY_TYPE[freeType];
+}
+
 export interface FreeModelBudget {
   provider: string;
   modelId: string;

--- a/open-sse/services/__tests__/tierResolver.test.ts
+++ b/open-sse/services/__tests__/tierResolver.test.ts
@@ -20,8 +20,8 @@ import {
 import { NOAUTH_PROVIDERS } from "@/shared/constants/providers.ts";
 
 describe("TierResolver", () => {
-  // Reset cache between tests
-  beforeEach(() => clearTierCache());
+  // Reset both config and cache so override tests cannot leak into later cases.
+  beforeEach(() => setTierConfig(DEFAULT_TIER_CONFIG));
 
   describe("classifyTier - free providers", () => {
     it("classifies Kiro as free", () => {
@@ -123,6 +123,13 @@ describe("TierResolver", () => {
       const result = classifyTier("openai", "gpt-4o");
       expect(result.tier).toBe(PROVIDER_TIER.CHEAP);
       expect(result.reason.includes("override")).toBe(true);
+    });
+
+    it("lets an explicit non-free override beat default free-provider classification", () => {
+      setTierConfig({ providerOverrides: [{ provider: "groq", tier: "premium" }] });
+      const result = classifyTier("groq", "openai/gpt-oss-120b");
+      expect(result.tier).toBe(PROVIDER_TIER.PREMIUM);
+      expect(result.hasFreeTier).toBe(false);
     });
 
     it("respects model-level glob pattern override", () => {

--- a/open-sse/services/autoCombo/candidateConnectionScope.ts
+++ b/open-sse/services/autoCombo/candidateConnectionScope.ts
@@ -1,0 +1,51 @@
+import { classifyTier } from "../tierResolver";
+
+type ConnectionScopedCandidate = {
+  provider: string;
+  model: string;
+  allowedConnectionIds?: string[];
+  freeConnectionIds?: string[];
+};
+
+export function clonePreparedCandidates<T extends ConnectionScopedCandidate>(
+  candidates: readonly T[]
+): T[] {
+  return candidates.map((candidate) => ({
+    ...candidate,
+    ...(candidate.allowedConnectionIds
+      ? { allowedConnectionIds: [...candidate.allowedConnectionIds] }
+      : {}),
+    ...(candidate.freeConnectionIds ? { freeConnectionIds: [...candidate.freeConnectionIds] } : {}),
+  }));
+}
+
+/**
+ * `auto/*:free` is itself a routing guarantee. When a model is admitted only
+ * because one or more synced connections reported it free, narrow dispatch to
+ * those exact connections even when the global `hidePaidModels` and strict
+ * zero-cost settings are off. Models that are globally classified free keep
+ * their existing provider-wide connection scope.
+ */
+export function narrowConnectionScopedFreeCandidates<T extends ConnectionScopedCandidate>(
+  candidates: T[]
+): T[] {
+  return candidates.flatMap((candidate) => {
+    const discoveredFree = candidate.freeConnectionIds ?? [];
+    if (discoveredFree.length === 0) return [candidate];
+
+    try {
+      if (classifyTier(candidate.provider, candidate.model).tier === "free") return [candidate];
+    } catch {
+      // If global tier classification is unavailable, fail closed to the
+      // connection-scoped free evidence that admitted this candidate.
+    }
+
+    const allowed = candidate.allowedConnectionIds ?? [];
+    const narrowed = discoveredFree.filter((id) => allowed.includes(id));
+    if (narrowed.length === 0) return [];
+
+    const same =
+      allowed.length === narrowed.length && narrowed.every((id) => allowed.includes(id));
+    return same ? [candidate] : [{ ...candidate, allowedConnectionIds: narrowed }];
+  });
+}

--- a/open-sse/services/autoCombo/paidModelFilter.ts
+++ b/open-sse/services/autoCombo/paidModelFilter.ts
@@ -12,22 +12,12 @@
  * isolation without seeding the DB-backed virtual factory.
  */
 import { isFreeModel } from "@/shared/utils/freeModels";
-import { isExplicitFreeTierOverride } from "../tierResolver";
 
 interface PaidFilterCandidate {
   provider: string;
   model: string;
   allowedConnectionIds?: string[];
   freeConnectionIds?: string[];
-}
-
-/** A candidate is globally free when the shared model predicate says so,
- * or when the operator explicitly overrode its tier to free. */
-function isGloballyFreeCandidate(candidate: PaidFilterCandidate): boolean {
-  return (
-    isFreeModel(candidate.provider, { id: candidate.model }) ||
-    isExplicitFreeTierOverride(candidate.provider, candidate.model)
-  );
 }
 
 /**
@@ -39,13 +29,22 @@ function isGloballyFreeCandidate(candidate: PaidFilterCandidate): boolean {
  */
 export function filterPaidOnlyCandidates<T extends PaidFilterCandidate>(
   pool: T[],
-  hidePaidModels: boolean
+  hidePaidModels: boolean,
+  resolveOperatorTier: (
+    provider: string,
+    model: string
+  ) => "free" | "cheap" | "premium" | undefined = () => undefined
 ): T[] {
   if (!hidePaidModels) return pool;
 
   const kept: T[] = [];
   for (const candidate of pool) {
-    if (isGloballyFreeCandidate(candidate)) {
+    const override = resolveOperatorTier(candidate.provider, candidate.model);
+    if (override !== undefined) {
+      if (override === "free") kept.push(candidate);
+      continue;
+    }
+    if (isFreeModel(candidate.provider, { id: candidate.model })) {
       kept.push(candidate);
       continue;
     }

--- a/open-sse/services/autoCombo/paidModelFilter.ts
+++ b/open-sse/services/autoCombo/paidModelFilter.ts
@@ -11,34 +11,53 @@
  * Kept as a pure, dependency-light function so the filter is unit-testable in
  * isolation without seeding the DB-backed virtual factory.
  */
-import { isFreeModel, providerHasFreeModels } from "@/shared/utils/freeModels";
+import { isFreeModel } from "@/shared/utils/freeModels";
+import { isExplicitFreeTierOverride } from "../tierResolver";
 
 interface PaidFilterCandidate {
   provider: string;
   model: string;
+  allowedConnectionIds?: string[];
+  freeConnectionIds?: string[];
 }
 
-/** A candidate is kept only when its provider has documented free models AND the
- * selected model itself qualifies as free — mirrors `shouldHidePaid` in
- * `src/app/api/v1/models/catalog.ts`. */
-function isFreeCandidate(candidate: PaidFilterCandidate): boolean {
+/** A candidate is globally free when the shared model predicate says so,
+ * or when the operator explicitly overrode its tier to free. */
+function isGloballyFreeCandidate(candidate: PaidFilterCandidate): boolean {
   return (
-    providerHasFreeModels(candidate.provider) &&
-    isFreeModel(candidate.provider, { id: candidate.model })
+    isFreeModel(candidate.provider, { id: candidate.model }) ||
+    isExplicitFreeTierOverride(candidate.provider, candidate.model)
   );
 }
 
 /**
  * Return the candidate pool filtered to free-only backends when
  * `hidePaidModels` is on; otherwise return the pool unchanged (identity — the
- * default, opt-in-off path). If every candidate is paid the result is empty, and
- * the caller's existing graceful empty-pool path handles it (consistent with the
- * opt-in intent — the operator asked not to route to paid models).
+ * default, opt-in-off path). Connection-scoped discovery is honored without
+ * widening it: when only some credentials reported this model free, the
+ * candidate's dispatch allowlist is narrowed to exactly those connections.
  */
 export function filterPaidOnlyCandidates<T extends PaidFilterCandidate>(
   pool: T[],
   hidePaidModels: boolean
 ): T[] {
   if (!hidePaidModels) return pool;
-  return pool.filter(isFreeCandidate);
+
+  const kept: T[] = [];
+  for (const candidate of pool) {
+    if (isGloballyFreeCandidate(candidate)) {
+      kept.push(candidate);
+      continue;
+    }
+
+    const freeConnections = candidate.freeConnectionIds ?? [];
+    if (freeConnections.length === 0) continue;
+    const allowed = candidate.allowedConnectionIds ?? [];
+    const narrowed = freeConnections.filter((id) => allowed.includes(id));
+    if (narrowed.length === 0) continue;
+    const same =
+      allowed.length === narrowed.length && narrowed.every((id) => allowed.includes(id));
+    kept.push(same ? candidate : ({ ...candidate, allowedConnectionIds: narrowed } as T));
+  }
+  return kept;
 }

--- a/open-sse/services/autoCombo/strictZeroCostFilter.ts
+++ b/open-sse/services/autoCombo/strictZeroCostFilter.ts
@@ -83,6 +83,7 @@ export interface StrictZeroCostCandidate {
   model: string;
   connectionId: string | null;
   allowedConnectionIds?: string[];
+  freeConnectionIds?: string[];
 }
 
 export interface StrictZeroCostOptions {
@@ -111,8 +112,13 @@ export interface StrictZeroCostOptions {
   maxStateAgeMs: number;
   /** `now` injection for deterministic tests; defaults to `Date.now`. */
   now?: () => number;
-  /** Explicit operator assertion that this provider/model is free. */
-  isOperatorDeclaredFree?: (provider: string, model: string) => boolean;
+  /** Explicit local policy wins over catalog/live inference in either direction. */
+  resolveOperatorTier?: (
+    provider: string,
+    model: string
+  ) => "free" | "cheap" | "premium" | undefined;
+  /** Whether this connection's model discovery was live-verified recently enough. */
+  isDiscoveryEvidenceFresh?: (provider: string, connectionId: string, maxAgeMs: number) => boolean;
   /**
    * The free-model catalog to look candidates up against. Defaults to the
    * real, live `FREE_MODEL_BUDGETS` — overridable so tests can prove the
@@ -179,12 +185,38 @@ export function evaluateCandidateConnections(
   candidate: StrictZeroCostCandidate,
   budgetEntry: FreeModelBudget | undefined,
   resolveFreeAccessState: StrictZeroCostOptions["resolveFreeAccessState"],
-  options: Pick<StrictZeroCostOptions, "minRemainingAllowance" | "maxStateAgeMs" | "now">
+  options: Pick<
+    StrictZeroCostOptions,
+    | "minRemainingAllowance"
+    | "maxStateAgeMs"
+    | "now"
+    | "resolveOperatorTier"
+    | "isDiscoveryEvidenceFresh"
+  >
 ): string[] {
-  if (isNousPortalFreeVariant(candidate)) {
-    return candidateConnectionIds(candidate).filter(
-      (connectionId) => connectionId !== SYNTHETIC_NOAUTH_CONNECTION_ID
+  const directConnectionIds = candidateConnectionIds(candidate).filter(
+    (connectionId) => connectionId !== SYNTHETIC_NOAUTH_CONNECTION_ID
+  );
+  const operatorTier = options.resolveOperatorTier?.(candidate.provider, candidate.model);
+  if (operatorTier !== undefined) {
+    return operatorTier === "free" ? directConnectionIds : [];
+  }
+
+  if ((candidate.freeConnectionIds?.length ?? 0) > 0) {
+    const liveFree = directConnectionIds.filter(
+      (connectionId) =>
+        candidate.freeConnectionIds!.includes(connectionId) &&
+        options.isDiscoveryEvidenceFresh?.(
+          candidate.provider,
+          connectionId,
+          options.maxStateAgeMs
+        ) === true
     );
+    if (liveFree.length > 0) return liveFree;
+  }
+
+  if (isNousPortalFreeVariant(candidate)) {
+    return directConnectionIds;
   }
 
   if (!budgetEntry) return []; // not in the catalog at all → paid, or genuinely unknown
@@ -239,15 +271,6 @@ export function filterStrictZeroCostCandidates<T extends StrictZeroCostCandidate
   const kept: T[] = [];
   let changed = false;
   for (const candidate of pool) {
-    if (options.isOperatorDeclaredFree?.(candidate.provider, candidate.model) === true) {
-      if (candidateConnectionIds(candidate).length > 0) {
-        kept.push(candidate);
-      } else {
-        changed = true;
-      }
-      continue;
-    }
-
     const budgetEntry = findBudgetEntry(candidate, options.catalog);
     const safeConnectionIds = evaluateCandidateConnections(
       candidate,

--- a/open-sse/services/autoCombo/strictZeroCostFilter.ts
+++ b/open-sse/services/autoCombo/strictZeroCostFilter.ts
@@ -111,6 +111,8 @@ export interface StrictZeroCostOptions {
   maxStateAgeMs: number;
   /** `now` injection for deterministic tests; defaults to `Date.now`. */
   now?: () => number;
+  /** Explicit operator assertion that this provider/model is free. */
+  isOperatorDeclaredFree?: (provider: string, model: string) => boolean;
   /**
    * The free-model catalog to look candidates up against. Defaults to the
    * real, live `FREE_MODEL_BUDGETS` — overridable so tests can prove the
@@ -129,6 +131,15 @@ export function findBudgetEntry(
   catalog: readonly FreeModelBudget[] = FREE_MODEL_BUDGETS
 ): FreeModelBudget | undefined {
   return catalog.find((m) => m.provider === candidate.provider && m.modelId === candidate.model);
+}
+
+function candidateConnectionIds(candidate: StrictZeroCostCandidate): string[] {
+  return candidate.connectionId ? [candidate.connectionId] : (candidate.allowedConnectionIds ?? []);
+}
+
+/** Nous Portal rotates price-locked free variants independently of releases. */
+function isNousPortalFreeVariant(candidate: StrictZeroCostCandidate): boolean {
+  return candidate.provider === "nous-research" && candidate.model.toLowerCase().endsWith(":free");
 }
 
 function isConnectionStateSafe(
@@ -170,6 +181,12 @@ export function evaluateCandidateConnections(
   resolveFreeAccessState: StrictZeroCostOptions["resolveFreeAccessState"],
   options: Pick<StrictZeroCostOptions, "minRemainingAllowance" | "maxStateAgeMs" | "now">
 ): string[] {
+  if (isNousPortalFreeVariant(candidate)) {
+    return candidateConnectionIds(candidate).filter(
+      (connectionId) => connectionId !== SYNTHETIC_NOAUTH_CONNECTION_ID
+    );
+  }
+
   if (!budgetEntry) return []; // not in the catalog at all → paid, or genuinely unknown
 
   const isGenuineNoAuthCandidate = candidate.connectionId === SYNTHETIC_NOAUTH_CONNECTION_ID;
@@ -194,12 +211,8 @@ export function evaluateCandidateConnections(
   // trust regardless of its answer.
   if (budgetEntry.hardStopGuaranteed !== true) return [];
 
-  const candidateConnectionIds = candidate.connectionId
-    ? [candidate.connectionId]
-    : (candidate.allowedConnectionIds ?? []);
-
   const safe: string[] = [];
-  for (const connectionId of candidateConnectionIds) {
+  for (const connectionId of candidateConnectionIds(candidate)) {
     if (connectionId === SYNTHETIC_NOAUTH_CONNECTION_ID) continue; // never reachable here, defensive
     if (isConnectionStateSafe(candidate.provider, connectionId, resolveFreeAccessState, options)) {
       safe.push(connectionId);
@@ -226,6 +239,15 @@ export function filterStrictZeroCostCandidates<T extends StrictZeroCostCandidate
   const kept: T[] = [];
   let changed = false;
   for (const candidate of pool) {
+    if (options.isOperatorDeclaredFree?.(candidate.provider, candidate.model) === true) {
+      if (candidateConnectionIds(candidate).length > 0) {
+        kept.push(candidate);
+      } else {
+        changed = true;
+      }
+      continue;
+    }
+
     const budgetEntry = findBudgetEntry(candidate, options.catalog);
     const safeConnectionIds = evaluateCandidateConnections(
       candidate,

--- a/open-sse/services/autoCombo/suffixComposition.ts
+++ b/open-sse/services/autoCombo/suffixComposition.ts
@@ -17,7 +17,7 @@
  * `virtualFactory.createVirtualAutoCombo`, and the weights reuse the existing mode packs.
  */
 import type { AutoVariant } from "./autoPrefix";
-import { classifyTier } from "../tierResolver";
+import { classifyTier, resolveExplicitTierOverride } from "../tierResolver";
 import { getResolvedModelCapabilities } from "@/lib/modelCapabilities";
 import { isVisionModelId } from "@/shared/constants/visionModels";
 import { isVisionBridgeForcedModel } from "@/shared/constants/visionBridgeDefaults";
@@ -147,7 +147,12 @@ export function buildAutoCandidateFilter(
     });
   }
   if (tier === "free") {
-    checks.push((c) => (c.freeConnectionIds?.length ?? 0) > 0 || safeClassifyTier(c) === "free");
+    checks.push((c) => {
+      const override = resolveExplicitTierOverride(c.provider, c.model);
+      return override !== undefined
+        ? override === "free"
+        : (c.freeConnectionIds?.length ?? 0) > 0 || safeClassifyTier(c) === "free";
+    });
   }
   if (tier === "pro") {
     checks.push((c) => safeClassifyTier(c) === "premium");

--- a/open-sse/services/autoCombo/suffixComposition.ts
+++ b/open-sse/services/autoCombo/suffixComposition.ts
@@ -95,6 +95,8 @@ export function tierToWeightVariant(tier?: AutoTier): AutoVariant | "reliability
 interface PoolCandidate {
   provider: string;
   model: string;
+  /** Connections whose synced discovery explicitly marks this model free. */
+  freeConnectionIds?: string[];
   resolvedSupportsVision?: boolean;
   resolvedReasoning?: boolean;
   resolvedSupportsThinking?: boolean;
@@ -145,7 +147,7 @@ export function buildAutoCandidateFilter(
     });
   }
   if (tier === "free") {
-    checks.push((c) => safeClassifyTier(c) === "free");
+    checks.push((c) => (c.freeConnectionIds?.length ?? 0) > 0 || safeClassifyTier(c) === "free");
   }
   if (tier === "pro") {
     checks.push((c) => safeClassifyTier(c) === "premium");

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -22,7 +22,11 @@ import {
   type AutoCategory,
   type AutoTier,
 } from "./suffixComposition";
-import { classifyTier, isExplicitFreeTierOverride } from "../tierResolver";
+import { isExplicitFreeTierOverride } from "../tierResolver";
+import {
+  clonePreparedCandidates,
+  narrowConnectionScopedFreeCandidates,
+} from "./candidateConnectionScope";
 import type { AutoVariant } from "./autoPrefix";
 import { buildFamilyCandidateFilter, type ModelFamily } from "./modelFamily";
 import { getHiddenModelsByProvider } from "@/models";
@@ -736,50 +740,6 @@ export function computeSnapshotWeights(
     scores.set(c.modelStr, Math.min(score, 1));
   }
   return scores;
-}
-
-function clonePreparedCandidates(
-  candidates: readonly VirtualAutoComboCandidate[]
-): VirtualAutoComboCandidate[] {
-  return candidates.map((candidate) => ({
-    ...candidate,
-    ...(candidate.allowedConnectionIds
-      ? { allowedConnectionIds: [...candidate.allowedConnectionIds] }
-      : {}),
-  }));
-}
-
-/**
- * `auto/*:free` is itself a routing guarantee. When a model is admitted only
- * because one or more synced connections reported it free, narrow dispatch to
- * those exact connections even when the global `hidePaidModels` and strict
- * zero-cost settings are off. Models that are globally classified free keep
- * their existing provider-wide connection scope.
- */
-function narrowConnectionScopedFreeCandidates(
-  candidates: VirtualAutoComboCandidate[]
-): VirtualAutoComboCandidate[] {
-  return candidates.flatMap((candidate) => {
-    const discoveredFree = candidate.freeConnectionIds ?? [];
-    if (discoveredFree.length === 0) return [candidate];
-
-    try {
-      if (classifyTier(candidate.provider, candidate.model).tier === "free") {
-        return [candidate];
-      }
-    } catch {
-      // If global tier classification is unavailable, fail closed to the
-      // connection-scoped free evidence that admitted this candidate.
-    }
-
-    const allowed = candidate.allowedConnectionIds ?? [];
-    const narrowed = discoveredFree.filter((id) => allowed.includes(id));
-    if (narrowed.length === 0) return [];
-
-    const same =
-      allowed.length === narrowed.length && narrowed.every((id) => allowed.includes(id));
-    return same ? [candidate] : [{ ...candidate, allowedConnectionIds: narrowed }];
-  });
 }
 
 export async function createVirtualAutoComboFromPrepared(

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -22,7 +22,7 @@ import {
   type AutoCategory,
   type AutoTier,
 } from "./suffixComposition";
-import { isExplicitFreeTierOverride } from "../tierResolver";
+import { resolveExplicitTierOverride } from "../tierResolver";
 import {
   clonePreparedCandidates,
   narrowConnectionScopedFreeCandidates,
@@ -31,6 +31,7 @@ import type { AutoVariant } from "./autoPrefix";
 import { buildFamilyCandidateFilter, type ModelFamily } from "./modelFamily";
 import { getHiddenModelsByProvider } from "@/models";
 import { getSyncedAvailableModelsByConnection, getCustomModels } from "@/lib/db/models";
+import { isProviderModelDiscoveryFresh } from "@/lib/providerModels/discoveryFreshness";
 import { filterPaidOnlyCandidates } from "./paidModelFilter";
 import { filterStrictZeroCostCandidates, filterTosAvoidCandidates } from "./strictZeroCostFilter";
 import { resolveFreeAccessState } from "./freeAccessQuota";
@@ -635,7 +636,11 @@ export async function prepareVirtualAutoComboInputs(
 
     // #6512 (follow-up to #6328/#6495): when the operator opts into `hidePaidModels`,
     // exclude paid-only backends from EVERY `auto/*` candidate pool.
-    const paidFilteredPool = filterPaidOnlyCandidates(pool, settings.hidePaidModels === true);
+    const paidFilteredPool = filterPaidOnlyCandidates(
+      pool,
+      settings.hidePaidModels === true,
+      resolveExplicitTierOverride
+    );
     if (paidFilteredPool !== pool) pool = paidFilteredPool;
 
     // STRICT_ZERO_COST: opt-in, off by default (`settings.freeAccessPolicy !== "strict"`
@@ -653,8 +658,10 @@ export async function prepareVirtualAutoComboInputs(
       // let a reading of e.g. 0.3% (rounding noise, not real headroom) pass.
       minRemainingAllowance: 1,
       maxStateAgeMs: toNumber(settings.autoRefreshProviderQuotaInterval, 180) * 1000,
-      // Explicit operator economics are authoritative for this deployment.
-      isOperatorDeclaredFree: isExplicitFreeTierOverride,
+      // Explicit operator economics are authoritative in either direction.
+      resolveOperatorTier: resolveExplicitTierOverride,
+      // Live discovery only authorizes a connection while that evidence remains fresh.
+      isDiscoveryEvidenceFresh: isProviderModelDiscoveryFresh,
     });
     if (strictFilteredPool !== pool) pool = strictFilteredPool;
 

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -45,9 +45,8 @@ import {
 } from "./resilienceCandidateFilter";
 import type { ChaosTuning } from "./chaosEngine";
 
-/** #4235 Phase B: optional category/tier overlay for `auto/<category>:<tier>` combos.
- * #6453: optional `family` overlay for `auto/<family>` combos (e.g. `auto/glm`) —
- * mutually exclusive with category/tier, applied instead of them when present. */
+/** #4235 category/tier overlay; #6453 optional `family` overlay for `auto/<family>`.
+ * Family is mutually exclusive with category/tier and applied instead when present. */
 export interface AutoComboSpec {
   category?: AutoCategory;
   tier?: AutoTier;

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -22,7 +22,7 @@ import {
   type AutoCategory,
   type AutoTier,
 } from "./suffixComposition";
-import { classifyTier } from "../tierResolver";
+import { classifyTier, isExplicitFreeTierOverride } from "../tierResolver";
 import type { AutoVariant } from "./autoPrefix";
 import { buildFamilyCandidateFilter, type ModelFamily } from "./modelFamily";
 import { getHiddenModelsByProvider } from "@/models";
@@ -88,6 +88,8 @@ export interface VirtualAutoComboCandidate {
   connectionId: string | null;
   /** Credentialed accounts that are eligible to serve this provider/model pair. */
   allowedConnectionIds?: string[];
+  /** Subset whose synced discovery explicitly reported this model free. */
+  freeConnectionIds?: string[];
   model: string;
   modelStr: string; // e.g., 'openai/gpt-4o'
   costPer1MTokens: number; // from providerRegistry
@@ -588,10 +590,15 @@ export async function prepareVirtualAutoComboInputs(
         .map((conn) => conn.id);
       if (allowedConnectionIds.length === 0) continue;
 
+      const freeConnectionIds = allowedConnectionIds.filter((connectionId) =>
+        (syncedByConnection[connectionId] ?? []).some((m) => m.id === modelId && m.isFree === true)
+      );
+
       candidatePool.push({
         provider: providerId,
         connectionId: null,
         allowedConnectionIds,
+        ...(freeConnectionIds.length > 0 ? { freeConnectionIds } : {}),
         model: modelId,
         modelStr: `${providerId}/${modelId}`,
         costPer1MTokens: 0, // Not used in virtual auto-combo (LKGP uses session stickiness)
@@ -643,6 +650,8 @@ export async function prepareVirtualAutoComboInputs(
       // let a reading of e.g. 0.3% (rounding noise, not real headroom) pass.
       minRemainingAllowance: 1,
       maxStateAgeMs: toNumber(settings.autoRefreshProviderQuotaInterval, 180) * 1000,
+      // Explicit operator economics are authoritative for this deployment.
+      isOperatorDeclaredFree: isExplicitFreeTierOverride,
     });
     if (strictFilteredPool !== pool) pool = strictFilteredPool;
 

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -749,6 +749,39 @@ function clonePreparedCandidates(
   }));
 }
 
+/**
+ * `auto/*:free` is itself a routing guarantee. When a model is admitted only
+ * because one or more synced connections reported it free, narrow dispatch to
+ * those exact connections even when the global `hidePaidModels` and strict
+ * zero-cost settings are off. Models that are globally classified free keep
+ * their existing provider-wide connection scope.
+ */
+function narrowConnectionScopedFreeCandidates(
+  candidates: VirtualAutoComboCandidate[]
+): VirtualAutoComboCandidate[] {
+  return candidates.flatMap((candidate) => {
+    const discoveredFree = candidate.freeConnectionIds ?? [];
+    if (discoveredFree.length === 0) return [candidate];
+
+    try {
+      if (classifyTier(candidate.provider, candidate.model).tier === "free") {
+        return [candidate];
+      }
+    } catch {
+      // If global tier classification is unavailable, fail closed to the
+      // connection-scoped free evidence that admitted this candidate.
+    }
+
+    const allowed = candidate.allowedConnectionIds ?? [];
+    const narrowed = discoveredFree.filter((id) => allowed.includes(id));
+    if (narrowed.length === 0) return [];
+
+    const same =
+      allowed.length === narrowed.length && narrowed.every((id) => allowed.includes(id));
+    return same ? [candidate] : [{ ...candidate, allowedConnectionIds: narrowed }];
+  });
+}
+
 export async function createVirtualAutoComboFromPrepared(
   prepared: PreparedVirtualAutoComboInputs,
   variant: AutoVariant | undefined,
@@ -823,7 +856,10 @@ export async function createVirtualAutoComboFromPrepared(
       ? buildAutoCandidateFilter(spec.category, spec.tier)
       : null;
   if (candidateFilter) {
-    const narrowed = candidatePool.filter((candidate) => candidateFilter(candidate));
+    let narrowed = candidatePool.filter((candidate) => candidateFilter(candidate));
+    if (!spec?.family && spec?.tier === "free") {
+      narrowed = narrowConnectionScopedFreeCandidates(narrowed);
+    }
     const label = spec?.family
       ? `auto/${spec.family}`
       : `auto/${spec?.category ?? ""}${spec?.tier ? `:${spec.tier}` : ""}`;

--- a/open-sse/services/tierResolver.ts
+++ b/open-sse/services/tierResolver.ts
@@ -3,7 +3,7 @@ import { PROVIDER_TIER } from "./tierTypes";
 import { getModelPricing } from "./providerCostData";
 import { isExplicitlyFree } from "./providerCostData";
 import { mergeTierConfig, DEFAULT_TIER_CONFIG } from "./tierConfig";
-import { isFreeModel } from "@/shared/utils/freeModels";
+import { FREE_MODEL_BUDGETS, grantsFreeAccess } from "../config/freeModelCatalog";
 
 let dbPersistenceChecked = false;
 
@@ -19,29 +19,74 @@ function matchGlob(pattern: string, text: string): boolean {
   return new RegExp(`^${regexStr}$`, "i").test(text);
 }
 
-/**
- * Whether the operator explicitly declared this provider/model free through
- * the persisted tier-override surface. This intentionally excludes automatic
- * free-provider and pricing inference so callers can treat it as an explicit
- * administrative assertion.
- */
-export function isExplicitFreeTierOverride(provider: string, model: string): boolean {
+function ensurePersistedTierConfigLoaded(): void {
+  if (dbPersistenceChecked) return;
+  if (process.env.NODE_ENV === "test" || typeof window !== "undefined") {
+    currentConfig = DEFAULT_TIER_CONFIG;
+    dbPersistenceChecked = true;
+    tierCache.clear();
+    return;
+  }
+  try {
+    const { loadTierConfig } = require("../../src/lib/db/tierConfig");
+    currentConfig = loadTierConfig();
+    dbPersistenceChecked = true;
+    tierCache.clear();
+  } catch {
+    // Routing can be imported before DB initialization in tests/tools. Keep the
+    // default and retry on a later call rather than permanently masking SQLite.
+    currentConfig = DEFAULT_TIER_CONFIG;
+  }
+}
+
+/** Highest-precedence local tier assertion, excluding automatic catalog/pricing inference. */
+export function resolveExplicitTierOverride(
+  provider: string,
+  model: string
+): ProviderTier | undefined {
+  ensurePersistedTierConfigLoaded();
   const providerOverride = currentConfig.providerOverrides.find(
     (o) => o.provider.toLowerCase() === provider.toLowerCase()
   );
-  if (providerOverride) return providerOverride.tier === PROVIDER_TIER.FREE;
-
-  const modelOverride = currentConfig.modelOverrides.find(
+  if (providerOverride) return providerOverride.tier;
+  return currentConfig.modelOverrides.find(
     (o) => o.provider.toLowerCase() === provider.toLowerCase() && matchGlob(o.modelPattern, model)
+  )?.tier;
+}
+
+function isModelFreeByStaticEvidence(provider: string, model: string): boolean {
+  if (model.toLowerCase().endsWith(":free")) return true;
+  return FREE_MODEL_BUDGETS.some(
+    (entry) =>
+      entry.provider.toLowerCase() === provider.toLowerCase() &&
+      entry.modelId === model &&
+      grantsFreeAccess(entry.freeType)
   );
-  return modelOverride?.tier === PROVIDER_TIER.FREE;
 }
 
 export function classifyTier(provider: string, model: string): TierAssignment {
+  ensurePersistedTierConfigLoaded();
   const key = cacheKey(provider, model);
 
   if (tierCache.has(key)) {
     return tierCache.get(key)!;
+  }
+
+  const explicitOverride = resolveExplicitTierOverride(provider, model);
+  if (explicitOverride) {
+    const pricing = getModelPricing(provider, model);
+    const assignment: TierAssignment = {
+      provider,
+      model,
+      tier: explicitOverride,
+      reason: `Explicit tier override: '${provider}/${model}' → ${explicitOverride}`,
+      costPer1MInput: explicitOverride === PROVIDER_TIER.FREE ? 0 : pricing.inputCostPer1M,
+      costPer1MOutput: explicitOverride === PROVIDER_TIER.FREE ? 0 : pricing.outputCostPer1M,
+      hasFreeTier: explicitOverride === PROVIDER_TIER.FREE,
+      freeQuotaLimit: pricing.freeQuotaLimit,
+    };
+    tierCache.set(key, assignment);
+    return assignment;
   }
 
   if (isExplicitlyFree(provider, currentConfig)) {
@@ -58,50 +103,12 @@ export function classifyTier(provider: string, model: string): TierAssignment {
     return assignment;
   }
 
-  const providerOverride = currentConfig.providerOverrides.find(
-    (o) => o.provider.toLowerCase() === provider.toLowerCase()
-  );
-  if (providerOverride) {
-    const pricing = getModelPricing(provider, model);
-    const assignment: TierAssignment = {
-      provider,
-      model,
-      tier: providerOverride.tier,
-      reason: `Provider-level override: '${provider}' → ${providerOverride.tier}`,
-      costPer1MInput: pricing.inputCostPer1M,
-      costPer1MOutput: pricing.outputCostPer1M,
-      hasFreeTier: pricing.isFree,
-      freeQuotaLimit: pricing.freeQuotaLimit,
-    };
-    tierCache.set(key, assignment);
-    return assignment;
-  }
-
-  const modelOverride = currentConfig.modelOverrides.find(
-    (o) => o.provider.toLowerCase() === provider.toLowerCase() && matchGlob(o.modelPattern, model)
-  );
-  if (modelOverride) {
-    const pricing = getModelPricing(provider, model);
-    const assignment: TierAssignment = {
-      provider,
-      model,
-      tier: modelOverride.tier,
-      reason: `Model-level override: '${provider}/${model}' matches '${modelOverride.modelPattern}' → ${modelOverride.tier}`,
-      costPer1MInput: pricing.inputCostPer1M,
-      costPer1MOutput: pricing.outputCostPer1M,
-      hasFreeTier: pricing.isFree,
-      freeQuotaLimit: pricing.freeQuotaLimit,
-    };
-    tierCache.set(key, assignment);
-    return assignment;
-  }
-
-  if (isFreeModel(provider, { id: model })) {
+  if (isModelFreeByStaticEvidence(provider, model)) {
     const assignment: TierAssignment = {
       provider,
       model,
       tier: PROVIDER_TIER.FREE,
-      reason: "Model is explicitly identified as free by the shared free-model classifier",
+      reason: "Model is explicitly identified as free by static model-level evidence",
       costPer1MInput: 0,
       costPer1MOutput: 0,
       hasFreeTier: true,
@@ -142,19 +149,17 @@ export function classifyTier(provider: string, model: string): TierAssignment {
 
 export function setTierConfig(config?: Partial<TierConfig> | null): void {
   if (config === null || config === undefined) {
-    try {
-      const { loadTierConfig } = require("../../src/lib/db/tierConfig");
-      currentConfig = loadTierConfig();
-    } catch {
-      currentConfig = DEFAULT_TIER_CONFIG;
-    }
+    dbPersistenceChecked = false;
+    ensurePersistedTierConfigLoaded();
   } else {
     currentConfig = mergeTierConfig(config);
+    dbPersistenceChecked = true;
   }
   tierCache.clear();
 }
 
 export function getTierConfig(): TierConfig {
+  ensurePersistedTierConfigLoaded();
   return { ...currentConfig };
 }
 

--- a/open-sse/services/tierResolver.ts
+++ b/open-sse/services/tierResolver.ts
@@ -3,6 +3,7 @@ import { PROVIDER_TIER } from "./tierTypes";
 import { getModelPricing } from "./providerCostData";
 import { isExplicitlyFree } from "./providerCostData";
 import { mergeTierConfig, DEFAULT_TIER_CONFIG } from "./tierConfig";
+import { isFreeModel } from "@/shared/utils/freeModels";
 
 let dbPersistenceChecked = false;
 
@@ -16,6 +17,24 @@ function cacheKey(provider: string, model: string): string {
 function matchGlob(pattern: string, text: string): boolean {
   const regexStr = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
   return new RegExp(`^${regexStr}$`, "i").test(text);
+}
+
+/**
+ * Whether the operator explicitly declared this provider/model free through
+ * the persisted tier-override surface. This intentionally excludes automatic
+ * free-provider and pricing inference so callers can treat it as an explicit
+ * administrative assertion.
+ */
+export function isExplicitFreeTierOverride(provider: string, model: string): boolean {
+  const providerOverride = currentConfig.providerOverrides.find(
+    (o) => o.provider.toLowerCase() === provider.toLowerCase()
+  );
+  if (providerOverride) return providerOverride.tier === PROVIDER_TIER.FREE;
+
+  const modelOverride = currentConfig.modelOverrides.find(
+    (o) => o.provider.toLowerCase() === provider.toLowerCase() && matchGlob(o.modelPattern, model)
+  );
+  return modelOverride?.tier === PROVIDER_TIER.FREE;
 }
 
 export function classifyTier(provider: string, model: string): TierAssignment {
@@ -72,6 +91,20 @@ export function classifyTier(provider: string, model: string): TierAssignment {
       costPer1MOutput: pricing.outputCostPer1M,
       hasFreeTier: pricing.isFree,
       freeQuotaLimit: pricing.freeQuotaLimit,
+    };
+    tierCache.set(key, assignment);
+    return assignment;
+  }
+
+  if (isFreeModel(provider, { id: model })) {
+    const assignment: TierAssignment = {
+      provider,
+      model,
+      tier: PROVIDER_TIER.FREE,
+      reason: "Model is explicitly identified as free by the shared free-model classifier",
+      costPer1MInput: 0,
+      costPer1MOutput: 0,
+      hasFreeTier: true,
     };
     tierCache.set(key, assignment);
     return assignment;

--- a/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
@@ -103,6 +103,60 @@ export function parsePerplexitySonarModels(data: any): any[] {
     (model: any) => typeof model?.id === "string" && /^sonar(-|$)/.test(model.id)
   );
 }
+
+/** Preserve Nous Portal's full recommendation list while tagging the live free subset. */
+export function parseNousRecommendedModels(data: any): any[] {
+  const free = Array.isArray(data?.freeRecommendedModels) ? data.freeRecommendedModels : [];
+  const paid = Array.isArray(data?.paidRecommendedModels)
+    ? data.paidRecommendedModels
+    : Array.isArray(data?.recommendedModels)
+      ? data.recommendedModels
+      : [];
+  const seen = new Set<string>();
+  const models: Array<Record<string, unknown>> = [];
+
+  const append = (entry: any, isFree: boolean) => {
+    const id =
+      typeof entry === "string"
+        ? entry.trim()
+        : typeof entry?.modelName === "string"
+          ? entry.modelName.trim()
+          : typeof entry?.id === "string"
+            ? entry.id.trim()
+            : "";
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    const name =
+      typeof entry?.displayName === "string" && entry.displayName.trim()
+        ? entry.displayName.trim()
+        : typeof entry?.name === "string" && entry.name.trim()
+          ? entry.name.trim()
+          : id;
+    models.push({ id, name, ...(isFree ? { isFree: true } : {}) });
+  };
+
+  for (const entry of free) append(entry, true);
+  for (const entry of paid) append(entry, false);
+  return models;
+}
+
+/** Portal recommendations augment the shipped Nous catalog; live rows win duplicate ids. */
+export function mergeNousRecommendedModelsWithCurated<T extends { id: string }>(
+  recommended: Array<Record<string, unknown>>,
+  curated: T[]
+): Array<Record<string, unknown> | T> {
+  const merged: Array<Record<string, unknown> | T> = [...recommended];
+  const seen = new Set(
+    recommended
+      .map((model) => (typeof model.id === "string" ? model.id : ""))
+      .filter(Boolean)
+  );
+  for (const model of curated) {
+    if (!seen.has(model.id)) merged.push(model);
+  }
+  return merged;
+}
+
 type ProviderModelsHeaderContext = {
   authType?: string;
   providerSpecificData?: unknown;
@@ -481,6 +535,12 @@ export const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> =
       });
     },
     parseResponse: parseGrokBuildModels,
+  },
+  "nous-research": {
+    url: "https://portal.nousresearch.com/api/nous/recommended-models",
+    method: "GET",
+    headers: { Accept: "application/json" },
+    parseResponse: parseNousRecommendedModels,
   },
   openrouter: {
     url: "https://openrouter.ai/api/v1/models",

--- a/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
@@ -104,6 +104,15 @@ export function parsePerplexitySonarModels(data: any): any[] {
   );
 }
 
+/** Distinguish an authoritative (possibly empty) Nous payload from malformed HTTP 200 data. */
+export function hasNousRecommendationPayloadShape(data: unknown): boolean {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+  const record = data as Record<string, unknown>;
+  const fields = ["freeRecommendedModels", "paidRecommendedModels", "recommendedModels"] as const;
+  const present = fields.filter((field) => record[field] !== undefined);
+  return present.length > 0 && present.every((field) => Array.isArray(record[field]));
+}
+
 /** Preserve Nous Portal's full recommendation list while tagging the live free subset. */
 export function parseNousRecommendedModels(data: any): any[] {
   const free = Array.isArray(data?.freeRecommendedModels) ? data.freeRecommendedModels : [];
@@ -152,7 +161,13 @@ export function mergeNousRecommendedModelsWithCurated<T extends { id: string }>(
       .filter(Boolean)
   );
   for (const model of curated) {
-    if (!seen.has(model.id)) merged.push(model);
+    if (seen.has(model.id)) continue;
+    const fallback = { ...model } as T & Record<string, unknown>;
+    Object.defineProperty(fallback, "_omnirouteDiscoveryFreeEvidence", {
+      value: false,
+      enumerable: false,
+    });
+    merged.push(fallback);
   }
   return merged;
 }
@@ -175,6 +190,7 @@ export type ProviderModelsConfigEntry = {
     token: string,
     connection?: ProviderModelsHeaderContext
   ) => Record<string, string>;
+  validateResponse?: (data: unknown) => boolean;
   parseResponse: (data: any) => any;
 };
 
@@ -540,6 +556,7 @@ export const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> =
     url: "https://portal.nousresearch.com/api/nous/recommended-models",
     method: "GET",
     headers: { Accept: "application/json" },
+    validateResponse: hasNousRecommendationPayloadShape,
     parseResponse: parseNousRecommendedModels,
   },
   openrouter: {

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -2124,7 +2124,7 @@ export async function GET(
         cachedDiscoveryModels.every((model, index) => model.id === cachedCatalogModels[index]?.id);
       const persistFilteredCacheIfNeeded = async () => {
         if (cachedIdsMatchFinalCatalog) return;
-        await persistDiscoveredModels(provider, connectionId, cachedCatalogModels);
+        await persistDiscoveredModels(provider, connectionId, cachedCatalogModels, false);
       };
 
       if (!refresh && cachedDiscoveryModels.length > 0) {
@@ -2364,6 +2364,11 @@ export async function GET(
       }
 
       const data = await response.json();
+      if (config.validateResponse && !config.validateResponse(data))
+        return (
+          buildDiscoveryFallbackResponse() ??
+          NextResponse.json({ error: "Invalid provider model payload" }, { status: 502 })
+        );
       let pageModels = config.parseResponse(data);
       if (provider === "alibaba" || provider === "alibaba-cn") {
         const { parseAlibabaModelStudioModelsForConnection } =

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -119,6 +119,7 @@ import { buildStaleEncryptionKeyResponse } from "./staleEncryptionGuard";
 import {
   type ProviderModelsConfigEntry,
   PROVIDER_MODELS_CONFIG,
+  mergeNousRecommendedModelsWithCurated,
 } from "./discovery/providerModelsConfig";
 import {
   buildCodexDiscoveryCatalog,
@@ -2430,6 +2431,13 @@ export async function GET(
           );
         }
       }
+    }
+
+    if (provider === "nous-research") {
+      allModels = mergeNousRecommendedModelsWithCurated(
+        allModels,
+        getModelsByProviderId(provider) || []
+      );
     }
 
     return buildApiDiscoveryResponse(allModels);

--- a/src/lib/db/models/synced.ts
+++ b/src/lib/db/models/synced.ts
@@ -19,6 +19,8 @@ export interface SyncedAvailableModel {
   alwaysThinking?: boolean;
   supportsTools?: boolean;
   supportsVideo?: boolean;
+  /** Provider/model was explicitly reported free at discovery time. */
+  isFree?: boolean;
   // #4264: image-input capability captured at sync time (e.g. OpenRouter
   // `architecture.input_modalities`/`modality`) so the catalog can surface vision.
   supportsVision?: boolean;
@@ -86,6 +88,7 @@ function normalizeSyncedAvailableModel(model: unknown): SyncedAvailableModel | n
     ...(record.alwaysThinking === true ? { alwaysThinking: true } : {}),
     ...(typeof record.supportsTools === "boolean" ? { supportsTools: record.supportsTools } : {}),
     ...(typeof record.supportsVideo === "boolean" ? { supportsVideo: record.supportsVideo } : {}),
+    ...(record.isFree === true ? { isFree: true } : {}),
     ...(record.supportsVision === true ? { supportsVision: true } : {}),
   };
 }

--- a/src/lib/providerModels/discoveryFreshness.ts
+++ b/src/lib/providerModels/discoveryFreshness.ts
@@ -1,0 +1,39 @@
+const lastSuccessfulDiscoveryMs = new Map<string, number>();
+
+function key(provider: string, connectionId: string): string {
+  return `${provider}::${connectionId}`;
+}
+
+/** Mark a provider/connection catalog as live-verified in this process. */
+export function markProviderModelDiscoveryFresh(
+  provider: string,
+  connectionId: string,
+  checkedAtMs = Date.now()
+): void {
+  lastSuccessfulDiscoveryMs.set(key(provider, connectionId), checkedAtMs);
+}
+
+export function invalidateProviderModelDiscoveryFreshness(
+  provider: string,
+  connectionId: string
+): void {
+  lastSuccessfulDiscoveryMs.delete(key(provider, connectionId));
+}
+
+/** Strict-free freshness proof. Process restart intentionally resets this to UNKNOWN. */
+export function isProviderModelDiscoveryFresh(
+  provider: string,
+  connectionId: string,
+  maxAgeMs: number,
+  nowMs = Date.now()
+): boolean {
+  if (!Number.isFinite(maxAgeMs) || maxAgeMs < 0) return false;
+  const checkedAtMs = lastSuccessfulDiscoveryMs.get(key(provider, connectionId));
+  return checkedAtMs !== undefined && nowMs >= checkedAtMs && nowMs - checkedAtMs <= maxAgeMs;
+}
+
+export const __testing = {
+  clear(): void {
+    lastSuccessfulDiscoveryMs.clear();
+  },
+};

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -5,6 +5,7 @@ import {
   type SyncedAvailableModel,
 } from "@/lib/db/models";
 import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization";
+import { isFreeModel } from "@/shared/utils/freeModels";
 import { isObsoleteKiroModelAlias } from "@omniroute/open-sse/services/kiroModels.ts";
 import { filterSelectableModels } from "@omniroute/open-sse/services/modelLifecycle.ts";
 
@@ -328,6 +329,20 @@ export function normalizeDiscoveredModels(
     // models reached the catalog with no vision flag and vision-capable models
     // (which work at request time) showed up as non-vision after import.
     const supportsVision = detectVisionInput(record);
+    const pricing = asRecord(record.pricing);
+    const promptPrice =
+      typeof pricing.prompt === "string" || typeof pricing.prompt === "number"
+        ? pricing.prompt
+        : undefined;
+    const completionPrice =
+      typeof pricing.completion === "string" || typeof pricing.completion === "number"
+        ? pricing.completion
+        : undefined;
+    const isFree = isFreeModel(providerId || "", {
+      id,
+      isFree: record.isFree === true,
+      pricing: { prompt: promptPrice, completion: completionPrice },
+    });
 
     deduped.set(id, {
       id,
@@ -356,6 +371,7 @@ export function normalizeDiscoveredModels(
       ...(record.alwaysThinking === true ? { alwaysThinking: true } : {}),
       ...(typeof record.supportsTools === "boolean" ? { supportsTools: record.supportsTools } : {}),
       ...(typeof record.supportsVideo === "boolean" ? { supportsVideo: record.supportsVideo } : {}),
+      ...(isFree ? { isFree: true } : {}),
       ...(supportsVision ? { supportsVision: true } : {}),
     });
   }

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/db/models";
 import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization";
 import { isFreeModel } from "@/shared/utils/freeModels";
+import { markProviderModelDiscoveryFresh } from "./discoveryFreshness";
 import { isObsoleteKiroModelAlias } from "@omniroute/open-sse/services/kiroModels.ts";
 import { filterSelectableModels } from "@omniroute/open-sse/services/modelLifecycle.ts";
 
@@ -338,11 +339,19 @@ export function normalizeDiscoveredModels(
       typeof pricing.completion === "string" || typeof pricing.completion === "number"
         ? pricing.completion
         : undefined;
-    const isFree = isFreeModel(providerId || "", {
-      id,
-      isFree: record.isFree === true,
-      pricing: { prompt: promptPrice, completion: completionPrice },
-    });
+    // Persist only evidence present in THIS discovery payload. Passing an empty
+    // provider intentionally disables provider/catalog membership inside
+    // isFreeModel while retaining its explicit isFree / :free / zero-price rules.
+    // Otherwise a stale shipped catalog row could masquerade as connection-scoped
+    // live economics and populate freeConnectionIds later in virtualFactory.
+    const isFree =
+      record._omnirouteDiscoveryFreeEvidence === false
+        ? false
+        : isFreeModel("", {
+            id,
+            isFree: record.isFree === true,
+            pricing: { prompt: promptPrice, completion: completionPrice },
+          });
 
     deduped.set(id, {
       id,
@@ -392,7 +401,8 @@ export async function getCachedDiscoveredModels(
 export async function persistDiscoveredModels(
   providerId: string,
   connectionId: string,
-  models: unknown
+  models: unknown,
+  markFresh = true
 ): Promise<SyncedAvailableModel[]> {
   // #11088 (option 1): the synced store is endpoint-agnostic — images/embeddings
   // models must persist so per-connection endpoint routing (#11088) and the
@@ -403,5 +413,6 @@ export async function persistDiscoveredModels(
     normalizeDiscoveredModels(models, providerId)
   );
   await replaceSyncedAvailableModelsForConnection(providerId, connectionId, normalized);
+  if (markFresh) markProviderModelDiscoveryFresh(providerId, connectionId);
   return normalized;
 }

--- a/src/shared/utils/freeModels.ts
+++ b/src/shared/utils/freeModels.ts
@@ -1,4 +1,4 @@
-import { FREE_MODEL_BUDGETS } from "@omniroute/open-sse/config/freeModelCatalog";
+import { FREE_MODEL_BUDGETS, grantsFreeAccess } from "@omniroute/open-sse/config/freeModelCatalog";
 import { resolveProviderId } from "@/shared/constants/providers";
 import { globToRegex } from "@/shared/utils/globPattern";
 import { AI_MODELS } from "@/shared/constants/models";
@@ -14,14 +14,15 @@ import { AI_MODELS } from "@/shared/constants/models";
  * free model for that provider in the catalog.
  */
 
+/** Catalogued entries whose regime still grants free access. */
+const FREE_BUDGETS = FREE_MODEL_BUDGETS.filter((m) => grantsFreeAccess(m.freeType));
+
 /** Provider ids that have at least one documented free model. */
-export const PROVIDERS_WITH_FREE_MODELS: Set<string> = new Set(
-  FREE_MODEL_BUDGETS.map((m) => m.provider)
-);
+export const PROVIDERS_WITH_FREE_MODELS: Set<string> = new Set(FREE_BUDGETS.map((m) => m.provider));
 
 const FREE_MODEL_IDS_BY_PROVIDER: Map<string, Set<string>> = (() => {
   const map = new Map<string, Set<string>>();
-  for (const m of FREE_MODEL_BUDGETS) {
+  for (const m of FREE_BUDGETS) {
     let set = map.get(m.provider);
     if (!set) {
       set = new Set<string>();

--- a/src/shared/utils/freeModels.ts
+++ b/src/shared/utils/freeModels.ts
@@ -50,11 +50,13 @@ function isZeroPrice(value: unknown): boolean {
 
 export interface FreeModelCandidate {
   id?: string;
+  isFree?: boolean;
   pricing?: { prompt?: string | number; completion?: string | number };
 }
 
 /** Whether a single fetched model qualifies as free for the given provider (id or alias). */
 export function isFreeModel(provider: string, model: FreeModelCandidate): boolean {
+  if (model.isFree === true) return true;
   if (typeof model.id === "string" && model.id.endsWith(":free")) return true;
   if (isZeroPrice(model.pricing?.prompt) && isZeroPrice(model.pricing?.completion)) return true;
   if (typeof model.id === "string") {

--- a/tests/unit/auto-free-connection-scope-12750.test.ts
+++ b/tests/unit/auto-free-connection-scope-12750.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createVirtualAutoComboFromPrepared } from "../../open-sse/services/autoCombo/virtualFactory.ts";
+
+test("auto/*:free narrows dispatch to the connections that reported a model free", async () => {
+  const candidate = {
+    provider: "openai",
+    connectionId: null,
+    allowedConnectionIds: ["free-account", "paid-account"],
+    freeConnectionIds: ["free-account"],
+    model: "gpt-4o",
+    modelStr: "openai/gpt-4o",
+    costPer1MTokens: 2.5,
+    resolvedContextLength: 128000,
+    resolvedMaxOutputTokens: 16384,
+    resolvedSupportsVision: true,
+    resolvedReasoning: false,
+    resolvedSupportsThinking: false,
+  };
+
+  const combo = await createVirtualAutoComboFromPrepared(
+    { regularCandidates: [candidate], familyCandidates: [candidate] },
+    undefined,
+    { tier: "free" }
+  );
+
+  assert.equal(combo.models.length, 1);
+  assert.deepEqual(combo.models[0]?.allowedConnectionIds, ["free-account"]);
+});

--- a/tests/unit/auto-free-connection-scope-12750.test.ts
+++ b/tests/unit/auto-free-connection-scope-12750.test.ts
@@ -28,3 +28,29 @@ test("auto/*:free narrows dispatch to the connections that reported a model free
   assert.equal(combo.models.length, 1);
   assert.deepEqual(combo.models[0]?.allowedConnectionIds, ["free-account"]);
 });
+
+test("auto/*:free keeps provider-wide scope for models that are globally classified free", async () => {
+  const candidate = {
+    provider: "openai",
+    connectionId: null,
+    allowedConnectionIds: ["account-a", "account-b"],
+    freeConnectionIds: ["account-a"],
+    model: "qwen3-coder-plus",
+    modelStr: "openai/qwen3-coder-plus",
+    costPer1MTokens: 0,
+    resolvedContextLength: 128000,
+    resolvedMaxOutputTokens: 16384,
+    resolvedSupportsVision: false,
+    resolvedReasoning: false,
+    resolvedSupportsThinking: false,
+  };
+
+  const combo = await createVirtualAutoComboFromPrepared(
+    { regularCandidates: [candidate], familyCandidates: [candidate] },
+    undefined,
+    { tier: "free" }
+  );
+
+  assert.equal(combo.models.length, 1);
+  assert.deepEqual(combo.models[0]?.allowedConnectionIds, ["account-a", "account-b"]);
+});

--- a/tests/unit/autoCombo/paid-model-filter-6512.test.ts
+++ b/tests/unit/autoCombo/paid-model-filter-6512.test.ts
@@ -9,7 +9,6 @@ import { test } from "vitest";
 import assert from "node:assert/strict";
 
 import { filterPaidOnlyCandidates } from "../../../open-sse/services/autoCombo/paidModelFilter.ts";
-import { setTierConfig } from "../../../open-sse/services/tierResolver.ts";
 
 // `agentrouter/claude-opus-4-8` is a documented free model (FREE_MODEL_BUDGETS);
 // `openai/gpt-4o` is paid (openai has no documented free models).
@@ -49,13 +48,17 @@ test("hidePaidModels ON preserves extra candidate fields on kept entries", () =>
 });
 
 test("hidePaidModels honors an explicit operator free-tier override", () => {
-  setTierConfig({ providerOverrides: [{ provider: "wandb", tier: "free" }] });
-  try {
-    const wandb = { provider: "wandb", model: "openai/gpt-oss-120b" };
-    assert.deepEqual(filterPaidOnlyCandidates([wandb, PAID], true), [wandb]);
-  } finally {
-    setTierConfig({ providerOverrides: [] });
-  }
+  const wandb = { provider: "wandb", model: "openai/gpt-oss-120b" };
+  assert.deepEqual(
+    filterPaidOnlyCandidates([wandb, PAID], true, (provider) =>
+      provider === "wandb" ? "free" : undefined
+    ),
+    [wandb]
+  );
+});
+
+test("hidePaidModels lets an explicit non-free override beat catalog free inference", () => {
+  assert.deepEqual(filterPaidOnlyCandidates([FREE], true, () => "premium"), []);
 });
 
 test("hidePaidModels narrows a discovered-free model to the connections that reported it free", () => {

--- a/tests/unit/autoCombo/paid-model-filter-6512.test.ts
+++ b/tests/unit/autoCombo/paid-model-filter-6512.test.ts
@@ -9,6 +9,7 @@ import { test } from "vitest";
 import assert from "node:assert/strict";
 
 import { filterPaidOnlyCandidates } from "../../../open-sse/services/autoCombo/paidModelFilter.ts";
+import { setTierConfig } from "../../../open-sse/services/tierResolver.ts";
 
 // `agentrouter/claude-opus-4-8` is a documented free model (FREE_MODEL_BUDGETS);
 // `openai/gpt-4o` is paid (openai has no documented free models).
@@ -45,4 +46,26 @@ test("hidePaidModels ON preserves extra candidate fields on kept entries", () =>
   };
   const result = filterPaidOnlyCandidates([enriched, PAID], true);
   assert.deepEqual(result, [enriched], "generic <T> filter must not strip candidate fields");
+});
+
+test("hidePaidModels honors an explicit operator free-tier override", () => {
+  setTierConfig({ providerOverrides: [{ provider: "wandb", tier: "free" }] });
+  try {
+    const wandb = { provider: "wandb", model: "openai/gpt-oss-120b" };
+    assert.deepEqual(filterPaidOnlyCandidates([wandb, PAID], true), [wandb]);
+  } finally {
+    setTierConfig({ providerOverrides: [] });
+  }
+});
+
+test("hidePaidModels narrows a discovered-free model to the connections that reported it free", () => {
+  const candidate = {
+    provider: "example-provider",
+    model: "model-a",
+    allowedConnectionIds: ["free-account", "paid-account"],
+    freeConnectionIds: ["free-account"],
+  };
+  assert.deepEqual(filterPaidOnlyCandidates([candidate], true), [
+    { ...candidate, allowedConnectionIds: ["free-account"] },
+  ]);
 });

--- a/tests/unit/autoCombo/strict-zero-cost-filter.test.ts
+++ b/tests/unit/autoCombo/strict-zero-cost-filter.test.ts
@@ -64,6 +64,11 @@ const UNKNOWN_MODEL = {
   model: "definitely-not-cataloged",
   connectionId: REAL_CONN,
 };
+const NOUS_DYNAMIC_FREE = {
+  provider: "nous-research",
+  model: "stepfun/step-3.7-flash:free",
+  connectionId: REAL_CONN,
+};
 // A provider with no free models documented anywhere (mirrors paid-model-filter-6512's own PAID fixture).
 const PAID = { provider: "openai", model: "gpt-4o", connectionId: REAL_CONN };
 
@@ -111,6 +116,13 @@ test("model absent from the free catalog is excluded even under a known provider
   assert.deepEqual(
     evaluateCandidateConnections(UNKNOWN_MODEL, undefined, () => undefined, BASE_OPTIONS),
     []
+  );
+});
+
+test("dynamic Nous Portal :free model passes strict mode without a stale catalog row", () => {
+  assert.deepEqual(
+    evaluateCandidateConnections(NOUS_DYNAMIC_FREE, undefined, () => undefined, BASE_OPTIONS),
+    [REAL_CONN]
   );
 });
 
@@ -227,6 +239,17 @@ test("freeAccessPolicy off (default) returns the pool UNCHANGED (identity, regre
     ...BASE_OPTIONS,
   });
   assert.equal(result, pool, "must return the exact same array reference when opt-in is off");
+});
+
+test("strict pool filter honors an explicit operator free declaration", () => {
+  const wandb = { provider: "wandb", model: "openai/gpt-oss-120b", connectionId: REAL_CONN };
+  const result = filterStrictZeroCostCandidates([wandb, PAID], {
+    enabled: true,
+    resolveFreeAccessState: () => undefined,
+    isOperatorDeclaredFree: (provider) => provider === "wandb",
+    ...BASE_OPTIONS,
+  });
+  assert.deepEqual(result, [wandb]);
 });
 
 test("strict pool filter keeps only keyless(no-auth) + guaranteed-quota-SAFE candidates", () => {

--- a/tests/unit/autoCombo/strict-zero-cost-filter.test.ts
+++ b/tests/unit/autoCombo/strict-zero-cost-filter.test.ts
@@ -126,6 +126,56 @@ test("dynamic Nous Portal :free model passes strict mode without a stale catalog
   );
 });
 
+test("live discovered-free evidence narrows strict mode to the proven connection", () => {
+  const candidate = {
+    provider: "example-provider",
+    model: "model-a",
+    connectionId: null,
+    allowedConnectionIds: ["free-account", "paid-account"],
+    freeConnectionIds: ["free-account"],
+  };
+  assert.deepEqual(
+    evaluateCandidateConnections(candidate, undefined, () => undefined, {
+      ...BASE_OPTIONS,
+      isDiscoveryEvidenceFresh: (_provider, connectionId) => connectionId === "free-account",
+    }),
+    ["free-account"]
+  );
+});
+
+test("stale discovered-free evidence does not bypass strict mode", () => {
+  const candidate = {
+    provider: "example-provider",
+    model: "model-a",
+    connectionId: REAL_CONN,
+    freeConnectionIds: [REAL_CONN],
+  };
+  assert.deepEqual(
+    evaluateCandidateConnections(candidate, undefined, () => undefined, {
+      ...BASE_OPTIONS,
+      isDiscoveryEvidenceFresh: () => false,
+    }),
+    []
+  );
+});
+
+test("explicit non-free policy vetoes otherwise-fresh discovered-free evidence", () => {
+  const candidate = {
+    provider: "example-provider",
+    model: "model-a",
+    connectionId: REAL_CONN,
+    freeConnectionIds: [REAL_CONN],
+  };
+  assert.deepEqual(
+    evaluateCandidateConnections(candidate, undefined, () => undefined, {
+      ...BASE_OPTIONS,
+      resolveOperatorTier: () => "premium",
+      isDiscoveryEvidenceFresh: () => true,
+    }),
+    []
+  );
+});
+
 // 5. quota SAFE + fresh + hardStop → PASS
 test("quota-based candidate with hardStopGuaranteed, fresh SAFE state above threshold passes", () => {
   const entry = FREE_MODEL_BUDGETS.find(
@@ -246,10 +296,20 @@ test("strict pool filter honors an explicit operator free declaration", () => {
   const result = filterStrictZeroCostCandidates([wandb, PAID], {
     enabled: true,
     resolveFreeAccessState: () => undefined,
-    isOperatorDeclaredFree: (provider) => provider === "wandb",
+    resolveOperatorTier: (provider) => (provider === "wandb" ? "free" : undefined),
     ...BASE_OPTIONS,
   });
   assert.deepEqual(result, [wandb]);
+});
+
+test("strict mode lets an explicit non-free override beat a Nous :free variant", () => {
+  const result = filterStrictZeroCostCandidates([NOUS_DYNAMIC_FREE], {
+    enabled: true,
+    resolveFreeAccessState: () => undefined,
+    resolveOperatorTier: () => "premium",
+    ...BASE_OPTIONS,
+  });
+  assert.deepEqual(result, []);
 });
 
 test("strict pool filter keeps only keyless(no-auth) + guaranteed-quota-SAFE candidates", () => {

--- a/tests/unit/autoCombo/suffixComposition-4517.test.ts
+++ b/tests/unit/autoCombo/suffixComposition-4517.test.ts
@@ -20,6 +20,7 @@ import {
   buildAutoCandidateFilter,
   parseAutoSuffix,
 } from "../../../open-sse/services/autoCombo/suffixComposition";
+import { setTierConfig } from "../../../open-sse/services/tierResolver";
 
 describe("suffixComposition :free tier (#4517)", () => {
   const ORIGINAL_ENV = { ...process.env };
@@ -29,9 +30,9 @@ describe("suffixComposition :free tier (#4517)", () => {
   });
 
   beforeEach(() => {
-    // Reset env to a known state so OMNIROUTE_AUTO_FREE_FALLBACK_TO_FULL_POOL
-    // doesn't leak between cases.
+    // Reset env/config so neighboring Vitest files cannot leak tier policy here.
     process.env = { ...ORIGINAL_ENV };
+    setTierConfig({ providerOverrides: [], modelOverrides: [] });
   });
 
   afterAll(() => {
@@ -85,6 +86,23 @@ describe("suffixComposition :free tier (#4517)", () => {
       }),
       true
     );
+  });
+
+  it("buildAutoCandidateFilter lets an explicit non-free override beat discovery", () => {
+    setTierConfig({ providerOverrides: [{ provider: "example-provider", tier: "premium" }] });
+    try {
+      const filter = buildAutoCandidateFilter("coding", "free");
+      assert.equal(
+        filter!({
+          provider: "example-provider",
+          model: "provider-priced-zero-model",
+          freeConnectionIds: ["free-account"],
+        }),
+        false
+      );
+    } finally {
+      setTierConfig({ providerOverrides: [] });
+    }
   });
 
   it("buildAutoCandidateFilter rejects paid models under :free", () => {

--- a/tests/unit/autoCombo/suffixComposition-4517.test.ts
+++ b/tests/unit/autoCombo/suffixComposition-4517.test.ts
@@ -66,6 +66,27 @@ describe("suffixComposition :free tier (#4517)", () => {
     assert.equal(filter!({ provider: "qoder", model: "qwen3-coder-plus" }), true);
   });
 
+  it("buildAutoCandidateFilter keeps rotating Nous Portal :free model ids", () => {
+    const filter = buildAutoCandidateFilter("coding", "free");
+    assert.equal(
+      filter!({ provider: "nous-research", model: "stepfun/step-3.7-flash:free" }),
+      true
+    );
+    assert.equal(filter!({ provider: "nous-research", model: "some-paid-model" }), false);
+  });
+
+  it("buildAutoCandidateFilter keeps connection-scoped discovered-free models", () => {
+    const filter = buildAutoCandidateFilter("coding", "free");
+    assert.equal(
+      filter!({
+        provider: "example-provider",
+        model: "provider-priced-zero-model",
+        freeConnectionIds: ["free-account"],
+      }),
+      true
+    );
+  });
+
   it("buildAutoCandidateFilter rejects paid models under :free", () => {
     // The bug: opencode-go/glm-5.1 was being picked because the filter
     // fell back to the full pool when no free candidate was found.

--- a/tests/unit/free-models.test.ts
+++ b/tests/unit/free-models.test.ts
@@ -27,6 +27,10 @@ test("isFreeModel: catalog membership works when called with the provider alias"
   assert.equal(isFreeModel("ollamacloud", { id: "deepseek-v4-pro" }), true);
 });
 
+test("isFreeModel: provider-declared isFree metadata is authoritative", () => {
+  assert.equal(isFreeModel("example-provider", { id: "rotating-model", isFree: true }), true);
+});
+
 test("isFreeModel: model id ending in :free is free", () => {
   assert.equal(isFreeModel("openrouter", { id: "deepseek/deepseek-r1:free" }), true);
 });

--- a/tests/unit/free-models.test.ts
+++ b/tests/unit/free-models.test.ts
@@ -56,9 +56,14 @@ test("isFreeModel: a model with no pricing and no :free suffix is NOT free", () 
   assert.equal(isFreeModel("openrouter", { id: "some/paid-model" }), false);
 });
 
-test("isFreeModel: a model id listed in the free catalog for that provider is free", () => {
-  const sample = FREE_MODEL_BUDGETS[0];
+test("isFreeModel: a model id listed in an active free catalog regime is free", () => {
+  const sample = FREE_MODEL_BUDGETS.find((entry) => entry.freeType !== "discontinued");
+  assert.ok(sample);
   assert.equal(isFreeModel(sample.provider, { id: sample.modelId }), true);
+});
+
+test("isFreeModel: discontinued catalog rows do not grant free access", () => {
+  assert.equal(isFreeModel("pollinations", { id: "gemini" }), false);
 });
 
 test("isFreeModel: NVIDIA GLM 5.2 is included in the reviewed trial catalog", () => {

--- a/tests/unit/model-discovery-free-metadata.test.ts
+++ b/tests/unit/model-discovery-free-metadata.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeDiscoveredModels } from "../../src/lib/providerModels/modelDiscovery.ts";
+
+test("normalizeDiscoveredModels preserves provider-declared free economics", () => {
+  const models = normalizeDiscoveredModels(
+    [
+      { id: "declared-free", isFree: true },
+      { id: "zero-priced", pricing: { prompt: "0", completion: 0 } },
+      { id: "rotating-model:free" },
+      { id: "paid", pricing: { prompt: "1", completion: "2" } },
+    ],
+    "example-provider"
+  );
+
+  assert.equal(models.find((model) => model.id === "declared-free")?.isFree, true);
+  assert.equal(models.find((model) => model.id === "zero-priced")?.isFree, true);
+  assert.equal(models.find((model) => model.id === "rotating-model:free")?.isFree, true);
+  assert.equal(models.find((model) => model.id === "paid")?.isFree, undefined);
+});

--- a/tests/unit/model-discovery-free-metadata.test.ts
+++ b/tests/unit/model-discovery-free-metadata.test.ts
@@ -2,6 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { normalizeDiscoveredModels } from "../../src/lib/providerModels/modelDiscovery.ts";
+import {
+  __testing as discoveryFreshnessTesting,
+  invalidateProviderModelDiscoveryFreshness,
+  isProviderModelDiscoveryFresh,
+  markProviderModelDiscoveryFresh,
+} from "../../src/lib/providerModels/discoveryFreshness.ts";
+import { normalizeSyncedAvailableModels } from "../../src/lib/db/models/synced.ts";
 
 test("normalizeDiscoveredModels preserves provider-declared free economics", () => {
   const models = normalizeDiscoveredModels(
@@ -9,6 +16,7 @@ test("normalizeDiscoveredModels preserves provider-declared free economics", () 
       { id: "declared-free", isFree: true },
       { id: "zero-priced", pricing: { prompt: "0", completion: 0 } },
       { id: "rotating-model:free" },
+      { id: "curated-only:free", _omnirouteDiscoveryFreeEvidence: false },
       { id: "paid", pricing: { prompt: "1", completion: "2" } },
     ],
     "example-provider"
@@ -17,5 +25,25 @@ test("normalizeDiscoveredModels preserves provider-declared free economics", () 
   assert.equal(models.find((model) => model.id === "declared-free")?.isFree, true);
   assert.equal(models.find((model) => model.id === "zero-priced")?.isFree, true);
   assert.equal(models.find((model) => model.id === "rotating-model:free")?.isFree, true);
+  assert.equal(models.find((model) => model.id === "curated-only:free")?.isFree, undefined);
   assert.equal(models.find((model) => model.id === "paid")?.isFree, undefined);
+});
+
+test("normalizeSyncedAvailableModels keeps free economics through DB serialization normalization", () => {
+  const [model] = normalizeSyncedAvailableModels([
+    { id: "live-free", name: "Live Free", source: "imported", isFree: true },
+  ]);
+  assert.equal(model?.isFree, true);
+});
+
+test("discovery freshness expires and process-local reset returns UNKNOWN", () => {
+  discoveryFreshnessTesting.clear();
+  markProviderModelDiscoveryFresh("provider-a", "connection-a", 1_000);
+  assert.equal(isProviderModelDiscoveryFresh("provider-a", "connection-a", 500, 1_500), true);
+  assert.equal(isProviderModelDiscoveryFresh("provider-a", "connection-a", 499, 1_500), false);
+  invalidateProviderModelDiscoveryFreshness("provider-a", "connection-a");
+  assert.equal(isProviderModelDiscoveryFresh("provider-a", "connection-a", 500, 1_500), false);
+  markProviderModelDiscoveryFresh("provider-a", "connection-a", 1_000);
+  discoveryFreshnessTesting.clear();
+  assert.equal(isProviderModelDiscoveryFresh("provider-a", "connection-a", 500, 1_500), false);
 });

--- a/tests/unit/provider-models-discovery-split.test.ts
+++ b/tests/unit/provider-models-discovery-split.test.ts
@@ -23,7 +23,10 @@ import {
   NAMED_OPENAI_STYLE_PROVIDERS,
   isNamedOpenAIStyleProvider,
 } from "../../src/app/api/providers/[id]/models/discovery/providerSets.ts";
-import { PROVIDER_MODELS_CONFIG } from "../../src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts";
+import {
+  PROVIDER_MODELS_CONFIG,
+  mergeNousRecommendedModelsWithCurated,
+} from "../../src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts";
 import { isCodexDiscoveryModelExcluded as isSharedCodexDiscoveryModelExcluded } from "../../src/shared/services/codexDiscoveryPolicy.ts";
 import {
   applyCodexDiscoveryFilters,
@@ -176,6 +179,47 @@ test("providerModelsConfig grok-cli.parseResponse preserves exact supported reas
   assert.deepEqual(parsed[1].supportedThinkingEfforts, ["low", "medium", "high"]);
   assert.equal(parsed[2].supportsThinking, true);
   assert.equal(parsed[2].supportedThinkingEfforts, undefined);
+});
+
+test("providerModelsConfig nous-research keeps paid recommendations and marks the live free subset", () => {
+  const config = PROVIDER_MODELS_CONFIG["nous-research"];
+  assert.equal(config.url, "https://portal.nousresearch.com/api/nous/recommended-models");
+  const parsed = config.parseResponse({
+    paidRecommendedModels: [{ modelName: "paid/model", displayName: "Paid Model" }],
+    freeRecommendedModels: [
+      { modelName: "stepfun/step-3.7-flash:free", displayName: "Step 3.7 Flash" },
+      { modelName: "stepfun/step-3.7-flash:free", displayName: "duplicate" },
+      "poolside/laguna-xs-2.1:free",
+      { id: "tencent/hy3:free" },
+      { nope: true },
+    ],
+  });
+  assert.deepEqual(parsed, [
+    { id: "stepfun/step-3.7-flash:free", name: "Step 3.7 Flash", isFree: true },
+    {
+      id: "poolside/laguna-xs-2.1:free",
+      name: "poolside/laguna-xs-2.1:free",
+      isFree: true,
+    },
+    { id: "tencent/hy3:free", name: "tencent/hy3:free", isFree: true },
+    { id: "paid/model", name: "Paid Model" },
+  ]);
+});
+
+test("providerModelsConfig Nous recommendations augment curated models without erasing live free metadata", () => {
+  const live = [
+    { id: "shared", name: "Live Shared", isFree: true },
+    { id: "portal-only:free", name: "Portal Only", isFree: true },
+  ];
+  const curated = [
+    { id: "shared", name: "Curated Shared" },
+    { id: "curated-paid", name: "Curated Paid" },
+  ];
+  assert.deepEqual(mergeNousRecommendedModelsWithCurated(live, curated), [
+    { id: "shared", name: "Live Shared", isFree: true },
+    { id: "portal-only:free", name: "Portal Only", isFree: true },
+    { id: "curated-paid", name: "Curated Paid" },
+  ]);
 });
 
 test("providerModelsConfig openrouter.parseResponse keeps the full catalog (LLMs not filtered out)", () => {

--- a/tests/unit/provider-models-discovery-split.test.ts
+++ b/tests/unit/provider-models-discovery-split.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../src/app/api/providers/[id]/models/discovery/providerSets.ts";
 import {
   PROVIDER_MODELS_CONFIG,
+  hasNousRecommendationPayloadShape,
   mergeNousRecommendedModelsWithCurated,
 } from "../../src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts";
 import { isCodexDiscoveryModelExcluded as isSharedCodexDiscoveryModelExcluded } from "../../src/shared/services/codexDiscoveryPolicy.ts";
@@ -181,6 +182,19 @@ test("providerModelsConfig grok-cli.parseResponse preserves exact supported reas
   assert.equal(parsed[2].supportedThinkingEfforts, undefined);
 });
 
+test("providerModelsConfig recognizes valid empty Nous payloads but rejects malformed 200 bodies", () => {
+  assert.equal(hasNousRecommendationPayloadShape({ freeRecommendedModels: [] }), true);
+  assert.equal(hasNousRecommendationPayloadShape({ paidRecommendedModels: [] }), true);
+  assert.equal(hasNousRecommendationPayloadShape({ recommendedModels: [] }), true);
+  assert.equal(hasNousRecommendationPayloadShape({ freeRecommendedModels: "bad" }), false);
+  assert.equal(
+    hasNousRecommendationPayloadShape({ freeRecommendedModels: [], paidRecommendedModels: "bad" }),
+    false
+  );
+  assert.equal(hasNousRecommendationPayloadShape({}), false);
+  assert.equal(hasNousRecommendationPayloadShape(null), false);
+});
+
 test("providerModelsConfig nous-research keeps paid recommendations and marks the live free subset", () => {
   const config = PROVIDER_MODELS_CONFIG["nous-research"];
   assert.equal(config.url, "https://portal.nousresearch.com/api/nous/recommended-models");
@@ -215,11 +229,14 @@ test("providerModelsConfig Nous recommendations augment curated models without e
     { id: "shared", name: "Curated Shared" },
     { id: "curated-paid", name: "Curated Paid" },
   ];
-  assert.deepEqual(mergeNousRecommendedModelsWithCurated(live, curated), [
+  const merged = mergeNousRecommendedModelsWithCurated(live, curated);
+  assert.deepEqual(merged, [
     { id: "shared", name: "Live Shared", isFree: true },
     { id: "portal-only:free", name: "Portal Only", isFree: true },
     { id: "curated-paid", name: "Curated Paid" },
   ]);
+  assert.equal((merged[2] as Record<string, unknown>)._omnirouteDiscoveryFreeEvidence, false);
+  assert.equal(JSON.stringify(merged).includes("_omnirouteDiscoveryFreeEvidence"), false);
 });
 
 test("providerModelsConfig openrouter.parseResponse keeps the full catalog (LLMs not filtered out)", () => {


### PR DESCRIPTION
## Summary

- preserve provider-declared/zero-price free status in synced model metadata and scope it per connection
- let `auto/*:free`, `hidePaidModels`, and strict-zero-cost routing honor live free economics and explicit operator free-tier overrides
- discover Nous Portal recommendations dynamically, keep the full curated Nous catalog, and treat live `:free` variants as strict-zero-cost routes
- add regression coverage for Nous rotation, W&B-style operator overrides, per-connection free status, and discovery persistence

## Validation

- exact PR head: `853865b369116b286ade67d82af80e8a389fca90`
- exact base: `c0b2253f21c2e70c5d73581ae1be6f60a4ac5647`
- code quality, both normal Vitest shards, backend build/tests, Rustfmt, Clippy, Rust tests, frontend E2E, security audit, AppImage, MSI, Coverage, Quality Ratchet, and CI Dashboard passed
- the shared `test:vitest:ui` lane ran 66 tests: both autoCombo suites passed; its only failures were two unrelated `ProviderSettings` password/remount tests timing out at 10s
- the exact base SHA passed the same `Vitest (MCP / autoCombo / UI components)` lane on main in CI run `33819289311`, job `100858366268`
- the separate Build failure ended in runner/system shutdown (SIGTERM), not a demonstrated source assertion/build failure
- contributor workflow rerun is unavailable (`403: Resource not accessible by integration`); maintainer rerun/authorization is the remaining CI action

No source change is warranted solely to perturb CI: the directly affected autoCombo coverage passed on this head and the failing assertions are outside this PR's change surface. No merge requested.