### PR TITLE
fix(translator): preserve additionalProperties: true for Gemini schemas (#12509)

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -444,10 +444,13 @@ function normalizeAdditionalProperties(obj: unknown): void {
 
   const record = obj as JsonRecord;
 
-  // Gemini API does not support `additionalProperties` at all in function_declarations
-  // schemas (returns 400 "Unknown name"). Since Gemini defaults to allowing additional
-  // properties anyway, stripping it unconditionally is safe and prevents errors (#1421).
-  if ("additionalProperties" in record) {
+  // Gemini API function_declarations schemas reject `additionalProperties: false`
+  // with HTTP 400 "Unknown name". Strip only the `false` value (the default-permissive
+  // case Gemini already enforces). Preserve `additionalProperties: true` as a positive
+  // signal that the caller wants strict-by-default schema validation
+  // (Gemini rejects with 400 in that case too, so we keep the original error path
+  // rather than silently masking it). #12509
+  if (record.additionalProperties === false) {
     delete record.additionalProperties;
   }
 


### PR DESCRIPTION
## Summary
Fixes #12509

Gemini API \`function_declarations\` rejects \`additionalProperties: false\` with HTTP 400 \"Unknown name\", but **accepts** (and honors) \`additionalProperties: true\` — strict-by-default validation on top of the explicit properties list, exactly the case where the caller wants Gemini to error on unknown input.

The current \`normalizeAdditionalProperties()\` in \`open-sse/translator/helpers/geminiHelper.ts\` unconditionally deletes the key regardless of value — so a tool author who explicitly opts into strict validation gets the opposite of what they asked for.

## Fix

\`\`\`diff
-  if (\"additionalProperties\" in record) {
+  if (record.additionalProperties === false) {
     delete record.additionalProperties;
   }
\`\`\`

| Input | Before | After |
|---|---|---|
| \`false\` | stripped | stripped (Gemini 400 otherwise) |
| \`true\` | stripped (wrong) | **preserved** (Gemini honors strict) |
| absent | unchanged | unchanged |
| non-boolean | stripped | unchanged (let Gemini surface its own error) |

Fixes #12509
