### PR TITLE
fix(glm): drop extra 16th arg to SSE transform helper

### DIFF
--- a/changelog.d/fixes/glm-sse-transform-arity.md
+++ b/changelog.d/fixes/glm-sse-transform-arity.md
@@ -1,0 +1,1 @@
+- **fix(glm):** drop the extra 16th argument to `createSSETransformStreamWithLogger` that TypeScript rejected (TS2554) and that never reached TransformStream

--- a/open-sse/executors/glm.ts
+++ b/open-sse/executors/glm.ts
@@ -223,8 +223,8 @@ export function translateSseResponse(
   suppressThinkClose: boolean = false
 ): Response {
   if (!response.body) return response;
-  // GLM is a high-throughput provider — use a larger stream buffer (64KB) to
-  // keep provider → client pacing ahead of the model's token emission rate.
+  // Helper has 15 parameters; a 16th positional (65536) was a TS2554 and
+  // never reached TransformStream. highWaterMark stays at the helper default.
   const transform = createSSETransformStreamWithLogger(
     FORMATS.CLAUDE,
     FORMATS.OPENAI,
@@ -238,10 +238,7 @@ export function translateSseResponse(
     null,
     null,
     false,
-    suppressThinkClose,
-    undefined,
-    undefined,
-    65536
+    suppressThinkClose
   );
   const headers = cloneHeaders(response.headers);
   headers.set("content-type", "text/event-stream");

--- a/tests/unit/glm-sse-transform-arity.test.ts
+++ b/tests/unit/glm-sse-transform-arity.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * GLM's translateSseResponse used to pass a 16th positional (65536) to
+ * createSSETransformStreamWithLogger. The helper only has 15 parameters
+ * (last is requestToolIdentityMap) — tsc reports TS2554 and the number
+ * never reached TransformStream.
+ *
+ * Guard the call site in source: no 65536, last arg is suppressThinkClose.
+ */
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function extractParens(src: string, openAt: number): string {
+  let i = openAt + 1;
+  let depth = 1;
+  while (i < src.length && depth > 0) {
+    const ch = src[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+    i += 1;
+  }
+  return src.slice(openAt, i);
+}
+
+test("createSSETransformStreamWithLogger has no highWaterMark slot", () => {
+  const src = readFileSync(join(root, "open-sse", "utils", "stream.ts"), "utf8");
+  const needle = "export function createSSETransformStreamWithLogger(";
+  const start = src.indexOf(needle);
+  assert.ok(start >= 0);
+  const header = extractParens(src, start + needle.length - 1);
+  assert.equal(/highWaterMark/.test(header), false, header);
+  assert.match(header, /requestToolIdentityMap/);
+  assert.match(header, /suppressThinkClose/);
+});
+
+test("GLM translateSseResponse does not pass a 16th positional to the stream helper", () => {
+  const src = readFileSync(join(root, "open-sse", "executors", "glm.ts"), "utf8");
+  const fnStart = src.indexOf("export function translateSseResponse(");
+  assert.ok(fnStart >= 0);
+  const fnEnd = src.indexOf("\nexport class GlmExecutor", fnStart);
+  const body = src.slice(fnStart, fnEnd);
+  const callAt = body.indexOf("createSSETransformStreamWithLogger(");
+  assert.ok(callAt >= 0);
+  const call = extractParens(body, callAt + "createSSETransformStreamWithLogger".length);
+  assert.equal(/65536/.test(call), false, `dead 16th arg still present:\n${call}`);
+  assert.match(call, /suppressThinkClose\s*\)\s*$/);
+});


### PR DESCRIPTION
`translateSseResponse` in `open-sse/executors/glm.ts` passed a 16th positional (`65536`) to `createSSETransformStreamWithLogger`. That helper has 15 parameters (`open-sse/utils/stream.ts:2998-3013`); last is `requestToolIdentityMap`. tsc reports TS2554. The number never reached `TransformStream`. The old comment about a 64KB buffer was wrong.

This is the same one-line drop that landed inside #12711. Isolated here so pin / combo-split / moonshot do not have to carry `glm.ts`.

## Fix

Drop `undefined, undefined, 65536`. Last argument stays `suppressThinkClose`. Comment now matches the helper.

## Tests

- `tests/unit/glm-sse-transform-arity.test.ts` — source guard: helper has no `highWaterMark` slot; GLM call site has no `65536` and ends on `suppressThinkClose`.
- `tests/unit/glm-think-close-marker-leak.test.ts` still green (3/3).
- Injection: put `65536` back → arity test red. Restore → 2/2 green.

`KeyHealth` / `translateJsonResponse` unused on tip are not in this diff.

## Not in this PR

- changelog fragment `reset-aware-model-family.md` missing `- ` (#12732)
- `cli-tunnel` skill dry-run generate
- batch-delete ConfirmModal (#12711)

Contributor only — not merging.
