### PR TITLE
chore(packaging): merge homebrew-omniroute tap into the OmniRoute monorepo

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,15 @@
+# Packaging
+
+Distribution formats for OmniRoute. Each subdirectory holds the artifacts
+for one channel; conventions live in the sub-README.
+
+- `homebrew/` — Homebrew formula (`Formula/omniroute.rb`)
+
+## Adding a new channel
+
+1. Create `packaging/<channel>/` with a `README.md` describing the install
+   path and bump procedure.
+2. Keep generated artifacts (tarballs, sha256 sums) out of the repo —
+   reference them by URL only.
+3. If the channel needs a release-time CI job, add a workflow under
+   `.github/workflows/` and reference it from the sub-README.

--- a/packaging/homebrew/Formula/omniroute.rb
+++ b/packaging/homebrew/Formula/omniroute.rb
@@ -1,0 +1,19 @@
+class Omniroute < Formula
+  desc "Unified AI router with 160+ providers, auto fallback, MCP/A2A, and OpenAI-compatible APIs"
+  homepage "https://github.com/KooshaPari/OmniRoute"
+  version "3.8.49-koosha.0"
+  url "https://registry.npmjs.org/@kooshapari/omniroute/-/omniroute-3.8.49-koosha.0.tgz"
+  sha256 "5cf098e0245aa5a5cf0eee7480e7f17aed0198557346afec7ac921a46731e1cf"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system "#{bin}/omniroute", "--version"
+  end
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -30,5 +30,5 @@ brew install omniroute
 Migrated from the standalone `KooshaPari/homebrew-omniroute` tap on
 2026-09-03 as part of monorepo consolidation. See
 `koosha-phenotype/docs/omniroute-integration/INTEGRATION_MANIFEST.md` for
-the decision and `repos/.archive/2026-09-03-monorepo-consolidation/` for
+the decision and `repos/zz-archive/2026-09-03-monorepo-consolidation/` for
 the archive.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,34 @@
+# Homebrew
+
+This directory hosts the Homebrew formula for OmniRoute, kept in-tree so the
+formula travels with the release it describes.
+
+## Install
+
+Once the formula is published to a tap (e.g. `KooshaPari/homebrew-omniroute`),
+users install with:
+
+```bash
+brew tap KooshaPari/omniroute https://github.com/KooshaPari/homebrew-omniroute.git
+brew install omniroute
+```
+
+## Layout
+
+- `Formula/omniroute.rb` — the formula. Version + sha256 must be bumped in
+  lockstep with the corresponding npm release of `@kooshapari/omniroute`.
+
+## Maintenance
+
+- Bump `version` and `sha256` when cutting a new npm release.
+- Bump `url` if the package name or registry path changes.
+- Do **not** edit `homepage` away from `KooshaPari/OmniRoute` — that is the
+  canonical source.
+
+## Provenance
+
+Migrated from the standalone `KooshaPari/homebrew-omniroute` tap on
+2026-09-03 as part of monorepo consolidation. See
+`koosha-phenotype/docs/omniroute-integration/INTEGRATION_MANIFEST.md` for
+the decision and `repos/.archive/2026-09-03-monorepo-consolidation/` for
+the archive.


### PR DESCRIPTION
## Summary
Move the standalone \`KooshaPari/homebrew-omniroute\` Homebrew tap into the OmniRoute monorepo at \`packaging/homebrew/\`, and bump the formula's \`homepage\` to point at the canonical repo URL. The formula's version (\`3.8.49-koosha.0\`) and the standalone tap repo remain as the published artifact until a new release cut.

## Why
- Single source of truth — the formula version tracks the release it describes (no more drift between tap and code).
- Eliminates a separate tap repo's maintenance overhead.
- Future \`npm version\` bumps regenerate the formula via \`scripts/bump-homebrew-formula.mjs\` (follow-up PR).

## Contents
- \`packaging/README.md\` — top-level packaging convention doc
- \`packaging/homebrew/Formula/omniroute.rb\` — the formula, with \`homepage\` repointed to \`KooshaPari/OmniRoute\`
- \`packaging/homebrew/README.md\` — install + bump instructions

## Provenance
- Pre-change: standalone repo \`KooshaPari/homebrew-omniroute\` (now archived at the same URL).
- Backup: local archive at \`repos/zz-archive/2026-09-03-monorepo-consolidation/homebrew-omniroute-backup/\` on the local working copy of the koosha-phenotype monorepo.
- Tap-mirror successor (live): \`KooshaPari/homebrew-tap\` already points at this in-tree formula.