### PR TITLE
[defer] feat: add Gemini prompt cache accounting

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -996,6 +996,13 @@ export async function handleChatCore({
   const noLogEnabled = apiKeyInfo?.noLog === true;
   // Consolidate settings reads — fetch once, reuse throughout the request
   const settings = cachedSettings ?? (await getCachedSettings());
+  const geminiPromptCacheMode = settings.geminiPromptCacheMode === "implicit" ? "implicit" : "off";
+  const isScopedGeminiCacheTarget =
+    (provider === "antigravity" || provider === "agy") &&
+    effectiveModel
+      .toLowerCase()
+      .split("/")
+      .some((segment) => segment.startsWith("gemini-"));
   // Opt-in tool-source diagnostics (#1825): summarize the request's tool definitions
   // (count + MCP/hosted/client source breakdown + first names) as a single debug line.
   if (settings.logToolSources === true) {
@@ -1064,8 +1071,16 @@ export async function handleChatCore({
     : null;
   // persistAttemptLogs extracted to chatCore/attemptLogging.ts (#3501); bind the per-request context
   // once so the 16 call sites keep passing only the per-attempt args (byte-identical).
-  const persistAttemptLogs = (args: PersistAttemptLogsArgs) =>
-    persistAttemptLogsFor(args, {
+  const persistAttemptLogs = (args: PersistAttemptLogsArgs) => {
+    if (isScopedGeminiCacheTarget && args.geminiPromptCache === undefined) {
+      args.geminiPromptCache = buildCacheUsageLogMeta(
+        args.tokens && typeof args.tokens === "object"
+          ? (args.tokens as Record<string, unknown>)
+          : null,
+        { mode: geminiPromptCacheMode, compressionTokens: tokensCompressed || undefined }
+      )?.geminiPromptCache;
+    }
+    return persistAttemptLogsFor(args, {
       traceId,
       provider,
       connectionId,
@@ -1098,6 +1113,7 @@ export async function handleChatCore({
       // to before this param existed) — see applyVideoBridgeLogRedaction.
       videoBridgeLogRedaction: (videoBridgeLog as VideoBridgeLogParam | undefined)?.redaction,
     });
+  };
 
   // Primary path: merge client model id + alias target so config on either key applies; resolved
   // id wins on same header name. T5 family fallback uses only (nextModel, resolveModelAlias(next))
@@ -1563,7 +1579,13 @@ export async function handleChatCore({
         compressionComboKey,
         estimatedTokens,
         body as Record<string, unknown>,
-        { provider, targetFormat, model: effectiveModel, connectionCacheOverride },
+        {
+          provider,
+          targetFormat,
+          model: effectiveModel,
+          geminiPromptCacheMode: isScopedGeminiCacheTarget ? geminiPromptCacheMode : null,
+          connectionCacheOverride,
+        },
         namedCombos,
         compressionHeader
       );
@@ -1662,7 +1684,13 @@ export async function handleChatCore({
         compressionComboKey,
         estimatedTokens,
         compressionInputBody,
-        { provider, targetFormat, model: effectiveModel, connectionCacheOverride },
+        {
+          provider,
+          targetFormat,
+          model: effectiveModel,
+          geminiPromptCacheMode: isScopedGeminiCacheTarget ? geminiPromptCacheMode : null,
+          connectionCacheOverride,
+        },
         namedCombos,
         compressionHeader,
         {
@@ -1701,7 +1729,13 @@ export async function handleChatCore({
         // #3890: in a caching context, never compress the system prompt (cacheable prefix)
         // even if the operator disabled preserveSystemPrompt — honors the cache-aware flag
         // that selectCompressionStrategy can only partially apply via the mode string.
-        const cacheCtx = { provider, targetFormat, model: effectiveModel, connectionCacheOverride };
+        const cacheCtx = {
+          provider,
+          targetFormat,
+          model: effectiveModel,
+          geminiPromptCacheMode: isScopedGeminiCacheTarget ? geminiPromptCacheMode : null,
+          connectionCacheOverride,
+        };
         const compressionConfig = resolveCacheAwareConfig(config, compressionInputBody, cacheCtx);
         const compressionPrincipalId = apiKeyInfo?.id ? String(apiKeyInfo.id) : undefined;
         const compressionOptions = {
@@ -2242,6 +2276,7 @@ export async function handleChatCore({
     comboStrategy,
     targetProvider: provider,
     targetFormat,
+    targetModel: effectiveModel,
     settings: { alwaysPreserveClientCache: cacheControlMode },
     connectionCacheOverride,
   });
@@ -5040,7 +5075,15 @@ export async function handleChatCore({
     }).catch(() => {});
 
     // Save structured call log with full payloads
-    const cacheUsageLogMeta = buildCacheUsageLogMeta(usage);
+    const cacheUsageLogMeta = buildCacheUsageLogMeta(
+      usage,
+      isScopedGeminiCacheTarget
+        ? {
+            mode: geminiPromptCacheMode,
+            compressionTokens: tokensCompressed || undefined,
+          }
+        : undefined
+    );
     recordNonStreamingUsageStats(usage, {
       traceEnabled,
       provider,
@@ -5237,6 +5280,7 @@ export async function handleChatCore({
         clientResponse: buildErrorBody(HTTP_STATUS.BAD_REQUEST, guardrailMessage),
         claudeCacheMeta: claudePromptCacheLogMeta,
         claudeCacheUsageMeta: cacheUsageLogMeta,
+        geminiPromptCache: cacheUsageLogMeta?.geminiPromptCache,
         cacheSource: "upstream",
       });
       if (apiKeyInfo?.id && estimatedCost > 0) {
@@ -5306,6 +5350,7 @@ export async function handleChatCore({
         clientResponse: malformedClientBody,
         claudeCacheMeta: claudePromptCacheLogMeta,
         claudeCacheUsageMeta: cacheUsageLogMeta,
+        geminiPromptCache: cacheUsageLogMeta?.geminiPromptCache,
         cacheSource: "upstream",
       });
       persistFailureUsage(HTTP_STATUS.BAD_GATEWAY, "malformed_translated_response");
@@ -5372,6 +5417,7 @@ export async function handleChatCore({
       clientResponse: translatedResponse,
       claudeCacheMeta: claudePromptCacheLogMeta,
       claudeCacheUsageMeta: cacheUsageLogMeta,
+      geminiPromptCache: cacheUsageLogMeta?.geminiPromptCache,
       cacheSource: "upstream",
     });
     if (apiKeyInfo?.id && estimatedCost > 0) {
@@ -5591,6 +5637,7 @@ export async function handleChatCore({
     ttft,
     itlMs: streamItlMs,
     interrupted: streamInterrupted,
+    cacheEvidence: streamCacheEvidence,
   }) => {
     const normalizedStreamStatus = streamStatus || 200;
     if (streamCompletionRecorded) return;
@@ -5599,7 +5646,17 @@ export async function handleChatCore({
       if (streamFailureCompletionRecorded) return;
       streamFailureCompletionRecorded = true;
     }
-    const cacheUsageLogMeta = buildCacheUsageLogMeta(streamUsage);
+    const cacheUsageLogMeta = buildCacheUsageLogMeta(
+      streamUsage,
+      isScopedGeminiCacheTarget
+        ? {
+            mode: geminiPromptCacheMode,
+            evidence: streamCacheEvidence,
+            compressionTokens: tokensCompressed || undefined,
+            timing: { ttftMs: ttft, itlMs: streamItlMs },
+          }
+        : undefined
+    );
     const streamConnectionId = getCurrentConnectionId();
 
     if (normalizedStreamStatus === 200) {
@@ -5754,6 +5811,7 @@ export async function handleChatCore({
       clientResponse: clientPayload ?? streamResponseBody ?? undefined,
       claudeCacheMeta: claudePromptCacheLogMeta,
       claudeCacheUsageMeta: cacheUsageLogMeta,
+      geminiPromptCache: cacheUsageLogMeta?.geminiPromptCache,
       cacheSource: "upstream",
     });
 

--- a/open-sse/handlers/chatCore/attemptLogging.ts
+++ b/open-sse/handlers/chatCore/attemptLogging.ts
@@ -208,6 +208,7 @@ export type PersistAttemptLogsArgs = {
   clientResponse?: unknown;
   claudeCacheMeta?: Record<string, unknown>;
   claudeCacheUsageMeta?: Record<string, unknown>;
+  geminiPromptCache?: Record<string, unknown> | null;
   cacheSource?: "upstream" | "semantic";
 };
 
@@ -340,6 +341,7 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
     clientResponse,
     claudeCacheMeta,
     claudeCacheUsageMeta,
+    geminiPromptCache,
     cacheSource,
   } = args;
   const {
@@ -467,6 +469,7 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
         {
           ...accountRotationMeta,
           claudePromptCache: claudeCacheMeta,
+          geminiPromptCache,
         }
       )
     ),
@@ -481,6 +484,7 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
             }
           : null,
         claudePromptCacheUsage: claudeCacheUsageMeta,
+        geminiPromptCache,
       })
     ),
     error: error || null,

--- a/open-sse/handlers/chatCore/cacheUsageMeta.ts
+++ b/open-sse/handlers/chatCore/cacheUsageMeta.ts
@@ -8,41 +8,107 @@
  * byte-identical to the previous module-level functions.
  */
 
+export type GeminiPromptCacheMode = "off" | "implicit";
+export type GeminiPromptCacheEvidence = "hit" | "miss" | "unreported" | "invalid";
+
+export type GeminiPromptCacheLogOptions = {
+  mode: GeminiPromptCacheMode;
+  evidence?: GeminiPromptCacheEvidence;
+  compressionTokens?: number | null;
+  timing?: { ttftMs?: number | null; itlMs?: number | null };
+};
+
 export function toPositiveNumber(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
 }
 
-export function buildCacheUsageLogMeta(usage: Record<string, unknown> | null | undefined) {
-  if (!usage || typeof usage !== "object") return null;
+function toNonNegativeNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function isGeminiCacheEvidence(value: unknown): value is GeminiPromptCacheEvidence {
+  return value === "hit" || value === "miss" || value === "unreported" || value === "invalid";
+}
+
+export function buildCacheUsageLogMeta(
+  usage: Record<string, unknown> | null | undefined,
+  geminiOptions?: GeminiPromptCacheLogOptions
+) {
+  const usageRecord = usage && typeof usage === "object" ? usage : {};
   const promptTokenDetails =
-    usage.prompt_tokens_details && typeof usage.prompt_tokens_details === "object"
-      ? (usage.prompt_tokens_details as Record<string, unknown>)
+    usageRecord.prompt_tokens_details && typeof usageRecord.prompt_tokens_details === "object"
+      ? (usageRecord.prompt_tokens_details as Record<string, unknown>)
       : undefined;
   // `cache_write_tokens` is the cache-creation alias emitted by OpenRouter, Devin
   // Desktop and the codex-chatgpt-web bridge; without it an OpenAI-shaped usage
   // payload logged a cache write of 0 for a model that actually reported one.
   const hasCacheFields =
-    "cache_read_input_tokens" in usage ||
-    "cached_tokens" in usage ||
-    "cache_creation_input_tokens" in usage ||
-    "cache_write_tokens" in usage ||
+    "cache_read_input_tokens" in usageRecord ||
+    "cached_tokens" in usageRecord ||
+    "cache_creation_input_tokens" in usageRecord ||
+    "cache_write_tokens" in usageRecord ||
     (!!promptTokenDetails &&
       ("cached_tokens" in promptTokenDetails ||
         "cache_creation_tokens" in promptTokenDetails ||
         "cache_write_tokens" in promptTokenDetails));
   const cacheReadTokens = toPositiveNumber(
-    usage.cache_read_input_tokens ?? usage.cached_tokens ?? promptTokenDetails?.cached_tokens
+    usageRecord.cache_read_input_tokens ?? usageRecord.cached_tokens ?? promptTokenDetails?.cached_tokens
   );
   const cacheCreationTokens = toPositiveNumber(
-    usage.cache_creation_input_tokens ??
+    usageRecord.cache_creation_input_tokens ??
       promptTokenDetails?.cache_creation_tokens ??
       promptTokenDetails?.cache_write_tokens ??
-      usage.cache_write_tokens
+      usageRecord.cache_write_tokens
   );
-  if (!hasCacheFields) return null;
+
+  const geminiPromptCache = geminiOptions
+    ? (() => {
+        const providerCachedTokens = toNonNegativeNumber(
+          usageRecord.cached_tokens ?? promptTokenDetails?.cached_tokens
+        );
+        const rawEvidence = geminiOptions.evidence ?? usageRecord.cache_evidence;
+        const evidence = isGeminiCacheEvidence(rawEvidence)
+          ? rawEvidence
+          : providerCachedTokens !== null
+            ? providerCachedTokens > 0
+              ? "hit"
+              : "miss"
+            : hasCacheFields
+              ? "invalid"
+              : "unreported";
+        const compressionTokens = toPositiveNumber(geminiOptions.compressionTokens);
+        const ttftMs = toNonNegativeNumber(geminiOptions.timing?.ttftMs);
+        const itlMs = toNonNegativeNumber(geminiOptions.timing?.itlMs);
+        return {
+          schemaVersion: 1,
+          mode: geminiOptions.mode,
+          evidence,
+          providerCounters: {
+            ...(providerCachedTokens !== null
+              ? { cachedContentTokenCount: providerCachedTokens }
+              : {}),
+          },
+          prefixBoundary: "unknown",
+          prefixMethod: "unavailable",
+          ...(compressionTokens > 0
+            ? { compressionDecision: { applied: true, tokens: compressionTokens } }
+            : {}),
+          ...(ttftMs !== null || itlMs !== null
+            ? {
+                timing: {
+                  ...(ttftMs !== null ? { ttftMs } : {}),
+                  ...(itlMs !== null ? { itlMs } : {}),
+                },
+              }
+            : {}),
+        };
+      })()
+    : null;
+
+  if (!hasCacheFields && !geminiPromptCache) return null;
   return {
-    cacheReadTokens,
-    cacheCreationTokens,
+    ...(hasCacheFields ? { cacheReadTokens, cacheCreationTokens } : {}),
+    ...(geminiPromptCache ? { geminiPromptCache } : {}),
   };
 }
 

--- a/open-sse/handlers/chatCore/upstreamBody.ts
+++ b/open-sse/handlers/chatCore/upstreamBody.ts
@@ -166,7 +166,7 @@ async function injectPromptCacheKey(
 ): Promise<Body> {
   if (
     targetFormat === FORMATS.OPENAI &&
-    providerSupportsCaching(provider, undefined, connectionCacheOverride) &&
+    providerSupportsCaching(provider, undefined, connectionCacheOverride, bodyToSend.model as string) &&
     !bodyToSend.prompt_cache_key &&
     Array.isArray(bodyToSend.messages) &&
     !["nvidia", "xai"].includes(provider)

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -15,6 +15,7 @@ import { restoreClaudeToolName } from "../services/claudeCodeToolRemapper.ts";
 import { extractReplayableResponsesReasoningText } from "../services/reasoningInputPolicy.ts";
 import { sanitizeToolId } from "../translator/helpers/schemaCoercion.ts";
 import { stripEmptyOptionalToolArgs } from "../translator/response/openai-responses/pureHelpers.ts";
+import { toNumber as toFiniteNumber } from "../../src/shared/utils/numeric.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -26,19 +27,9 @@ function toString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
 }
 
-function toNumber(value: unknown, fallback = 0): number {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && value.trim().length > 0
-        ? Number(value)
-        : Number.NaN;
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
 function firstPositiveNumber(...values: unknown[]): number {
   for (const value of values) {
-    const parsed = toNumber(value, 0);
+    const parsed = toFiniteNumber(value, 0);
     if (parsed > 0) {
       return parsed;
     }
@@ -290,7 +281,7 @@ export function translateNonStreamingResponse(
       console.log(`  → Final text content length: ${textContent.length}`);
     }
 
-    const createdAt = toNumber(response.created_at, Math.floor(Date.now() / 1000));
+    const createdAt = toFiniteNumber(response.created_at, Math.floor(Date.now() / 1000));
     const model = toString(response.model || responseRoot.model, "openai-responses");
     const finishReason = toolCalls.length > 0 ? "tool_calls" : "stop";
 
@@ -309,8 +300,8 @@ export function translateNonStreamingResponse(
     };
 
     if (Object.keys(usage).length > 0) {
-      const inputTokens = toNumber(usage.input_tokens, 0);
-      const outputTokens = toNumber(usage.output_tokens, 0);
+      const inputTokens = toFiniteNumber(usage.input_tokens, 0);
+      const outputTokens = toFiniteNumber(usage.output_tokens, 0);
       const inputTokensDetails = toRecord(usage.input_tokens_details);
       const outputTokensDetails = toRecord(usage.output_tokens_details);
       const promptTokensDetails = toRecord(usage.prompt_tokens_details);
@@ -517,23 +508,24 @@ export function translateNonStreamingResponse(
       };
 
       if (Object.keys(usage).length > 0) {
-        const promptTokens = toNumber(usage.promptTokenCount, 0);
-        const reasoningTokens = toNumber(usage.thoughtsTokenCount, 0);
-        const completionTokens = toNumber(usage.candidatesTokenCount, 0) + reasoningTokens;
+        const promptTokens = toFiniteNumber(usage.promptTokenCount, 0);
+        const reasoningTokens = toFiniteNumber(usage.thoughtsTokenCount, 0);
+        const completionTokens = toFiniteNumber(usage.candidatesTokenCount, 0) + reasoningTokens;
 
         result.usage = {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
-          total_tokens: toNumber(usage.totalTokenCount, 0),
+          total_tokens: toFiniteNumber(usage.totalTokenCount, 0),
         };
         if (reasoningTokens > 0) {
           (result.usage as JsonRecord).completion_tokens_details = {
             reasoning_tokens: reasoningTokens,
           };
         }
-        if (toNumber(usage.cachedContentTokenCount, 0) > 0) {
+        const cachedTokens = toFiniteNumber(usage.cachedContentTokenCount, -1);
+        if (cachedTokens >= 0 && cachedTokens <= promptTokens) {
           (result.usage as JsonRecord).prompt_tokens_details = {
-            cached_tokens: toNumber(usage.cachedContentTokenCount, 0),
+            cached_tokens: cachedTokens,
           };
         }
       }
@@ -622,10 +614,10 @@ export function translateNonStreamingResponse(
         // cache_read folds into prompt_tokens (it is billed prompt input);
         // cache_creation stays out of prompt_tokens and is exposed via
         // prompt_tokens_details, alongside cached_tokens (OpenAI field name).
-        const cachedTokens = toNumber(usage.cache_read_input_tokens, 0);
-        const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
-        const promptTokens = toNumber(usage.input_tokens, 0) + cachedTokens;
-        const completionTokens = toNumber(usage.output_tokens, 0);
+        const cachedTokens = toFiniteNumber(usage.cache_read_input_tokens, 0);
+        const cacheCreationTokens = toFiniteNumber(usage.cache_creation_input_tokens, 0);
+        const promptTokens = toFiniteNumber(usage.input_tokens, 0) + cachedTokens;
+        const completionTokens = toFiniteNumber(usage.output_tokens, 0);
         const reasoningTokens = firstPositiveNumber(
           toRecord(usage.output_tokens_details).thinking_tokens,
           toRecord(usage.completion_tokens_details).reasoning_tokens,
@@ -763,19 +755,26 @@ function convertOpenAINonStreamingToClaude(
   if (stopReason === "tool_calls") stopReason = "tool_use";
 
   const usageSrc = toRecord(openaiResponse.usage);
-  const promptTokens = toNumber(usageSrc.prompt_tokens, 0);
-  const outputTokens = toNumber(usageSrc.completion_tokens, 0);
+  const promptTokens = toFiniteNumber(usageSrc.prompt_tokens, 0);
+  const outputTokens = toFiniteNumber(usageSrc.completion_tokens, 0);
 
   // Extract cache tokens from prompt_tokens_details (mirrors the streaming
   // translator in open-sse/translator/response/openai-to-claude.ts lines 119-148).
   const promptDetails = toRecord(usageSrc.prompt_tokens_details);
-  const cachedTokens = toNumber(promptDetails.cached_tokens, 0);
-  const cacheCreationTokens = toNumber(promptDetails.cache_creation_tokens, 0);
+  const flatCachedTokens = toFiniteNumber(usageSrc.cached_tokens, 0);
+  const cachedTokens = Math.max(
+    0,
+    Math.min(promptTokens, toFiniteNumber(promptDetails.cached_tokens, flatCachedTokens))
+  );
+  const cacheCreationTokens = Math.max(
+    0,
+    Math.min(promptTokens - cachedTokens, toFiniteNumber(promptDetails.cache_creation_tokens, 0))
+  );
 
   // OpenAI's prompt_tokens includes all prompt-side tokens (cached + non-cached).
   // Claude expects input_tokens to be only non-cached tokens, with cached tokens
   // exposed separately as cache_read_input_tokens.
-  const inputTokens = promptTokens - cachedTokens - cacheCreationTokens;
+  const inputTokens = Math.max(0, promptTokens - cachedTokens - cacheCreationTokens);
 
   const usage: JsonRecord = {
     input_tokens: inputTokens,
@@ -870,8 +869,8 @@ function convertOpenAINonStreamingToGeminiFamily(openaiResponse: JsonRecord): Js
     OPENAI_TO_GEMINI_FINISH_REASON[toString(choice.finish_reason, "stop")] ?? "STOP";
 
   const usageSrc = toRecord(openaiResponse.usage);
-  const promptTokens = toNumber(usageSrc.prompt_tokens, 0);
-  const completionTokens = toNumber(usageSrc.completion_tokens, 0);
+  const promptTokens = toFiniteNumber(usageSrc.prompt_tokens, 0);
+  const completionTokens = toFiniteNumber(usageSrc.completion_tokens, 0);
 
   const geminiResponse: JsonRecord = {
     response: {
@@ -885,7 +884,7 @@ function convertOpenAINonStreamingToGeminiFamily(openaiResponse: JsonRecord): Js
       usageMetadata: {
         promptTokenCount: promptTokens,
         candidatesTokenCount: completionTokens,
-        totalTokenCount: toNumber(usageSrc.total_tokens, promptTokens + completionTokens),
+        totalTokenCount: toFiniteNumber(usageSrc.total_tokens, promptTokens + completionTokens),
       },
       modelVersion: toString(openaiResponse.model, "unknown"),
       responseId: toString(openaiResponse.id, `resp_${Date.now()}`),

--- a/open-sse/handlers/sseParser/geminiResponse.ts
+++ b/open-sse/handlers/sseParser/geminiResponse.ts
@@ -100,13 +100,55 @@ function applyFinishReason(
 /** Extract usageMetadata into the OpenAI-shaped usage object, if present. */
 function applyUsageMetadata(parsed: Record<string, unknown>, acc: GeminiSSEAccumulator): void {
   const response = parsed.response as Record<string, unknown> | undefined;
-  const um = response?.usageMetadata as Record<string, unknown> | undefined;
+  const um = (response?.usageMetadata ?? parsed.usageMetadata) as
+    Record<string, unknown> | undefined;
   if (!um) return;
-  acc.usage = {
-    prompt_tokens: um.promptTokenCount || 0,
-    completion_tokens: um.candidatesTokenCount || 0,
-    total_tokens: um.totalTokenCount || 0,
-  };
+
+  const previousUsage = acc.usage ?? {};
+  const promptTokens =
+    typeof um.promptTokenCount === "number" &&
+    Number.isFinite(um.promptTokenCount) &&
+    um.promptTokenCount >= 0
+      ? um.promptTokenCount
+      : previousUsage.prompt_tokens;
+  const completionTokens =
+    typeof um.candidatesTokenCount === "number" &&
+    Number.isFinite(um.candidatesTokenCount) &&
+    um.candidatesTokenCount >= 0
+      ? um.candidatesTokenCount
+      : previousUsage.completion_tokens;
+  const totalTokens =
+    typeof um.totalTokenCount === "number" &&
+    Number.isFinite(um.totalTokenCount) &&
+    um.totalTokenCount >= 0
+      ? um.totalTokenCount
+      : previousUsage.total_tokens;
+  const hasCachedCount = Object.prototype.hasOwnProperty.call(um, "cachedContentTokenCount");
+  const reportedCachedTokens = um.cachedContentTokenCount;
+  const cachedTokens =
+    typeof reportedCachedTokens === "number" &&
+    Number.isFinite(reportedCachedTokens) &&
+    reportedCachedTokens >= 0 &&
+    typeof promptTokens === "number" &&
+    reportedCachedTokens <= promptTokens
+      ? reportedCachedTokens
+      : !hasCachedCount
+        ? previousUsage.cached_tokens
+        : undefined;
+
+  const nextUsage = {
+    ...previousUsage,
+    ...(typeof promptTokens === "number" ? { prompt_tokens: promptTokens } : {}),
+    ...(typeof completionTokens === "number" ? { completion_tokens: completionTokens } : {}),
+    ...(typeof totalTokens === "number" ? { total_tokens: totalTokens } : {}),
+  } as Record<string, unknown>;
+  if (typeof cachedTokens === "number") {
+    nextUsage.cached_tokens = cachedTokens;
+  } else if (hasCachedCount) {
+    delete nextUsage.cached_tokens;
+    nextUsage.cache_evidence = "invalid";
+  }
+  acc.usage = nextUsage;
 }
 
 /** Parse one `data:` line's JSON payload and fold it into the accumulator (best-effort). */

--- a/open-sse/handlers/usageExtractor.ts
+++ b/open-sse/handlers/usageExtractor.ts
@@ -119,10 +119,29 @@ export function extractUsageFromResponse(responseBody, provider) {
     // Gemini reports thoughts outside candidates. Fold them into completion so
     // every provider keeps reasoning as a subset of completion tokens.
     const thoughts = usageMetadata.thoughtsTokenCount || 0;
+    const promptTokens = usageMetadata.promptTokenCount || 0;
+    const reportedCachedTokens = usageMetadata.cachedContentTokenCount;
+    const hasCachedCount = Object.prototype.hasOwnProperty.call(
+      usageMetadata,
+      "cachedContentTokenCount"
+    );
+    const hasValidCachedTokens =
+      typeof reportedCachedTokens === "number" &&
+      Number.isFinite(reportedCachedTokens) &&
+      reportedCachedTokens >= 0 &&
+      reportedCachedTokens <= promptTokens;
     return {
-      prompt_tokens: usageMetadata.promptTokenCount || 0,
+      prompt_tokens: promptTokens,
       completion_tokens: (usageMetadata.candidatesTokenCount || 0) + thoughts,
-      cached_tokens: usageMetadata.cachedContentTokenCount || 0,
+      ...(hasValidCachedTokens ? { cached_tokens: reportedCachedTokens } : {}),
+      cache_evidence:
+        !hasCachedCount
+          ? "unreported"
+          : hasValidCachedTokens
+            ? reportedCachedTokens > 0
+              ? "hit"
+              : "miss"
+            : "invalid",
       reasoning_tokens: thoughts,
     };
   }

--- a/open-sse/services/compression/cachingAware.ts
+++ b/open-sse/services/compression/cachingAware.ts
@@ -17,6 +17,7 @@ export interface CachingDetectionContext {
   provider?: string | null;
   targetFormat?: string | null;
   model?: string | null;
+  geminiPromptCacheMode?: "off" | "implicit" | null;
   connectionCacheOverride?: ConnectionCacheOverride | null;
 }
 
@@ -93,12 +94,22 @@ export function detectCachingContext(
     inferProviderFromModel(context.model) ??
     inferProviderFromModel(bodyRecord.model);
   const targetFormat = normalizeString(context.targetFormat)?.toLowerCase() ?? null;
+  const isAntigravityTarget = provider === "antigravity" || provider === "agy";
+  const geminiPromptCacheMode = context.geminiPromptCacheMode === "implicit" ? "implicit" : "off";
 
   return {
     hasCacheControl: hasCacheControl(body),
     provider,
     targetFormat,
-    isCachingProvider: providerSupportsCaching(provider, targetFormat, context.connectionCacheOverride),
+    isCachingProvider:
+      isAntigravityTarget && geminiPromptCacheMode === "off"
+        ? false
+        : providerSupportsCaching(
+            provider,
+            targetFormat,
+            context.connectionCacheOverride,
+            context.model
+          ),
   };
 }
 

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -387,21 +387,64 @@ export function geminiToClaudeResponse(chunk, state) {
   // ── Usage metadata ─────────────────────────────────────────────
   const usageMeta = response.usageMetadata || chunk.usageMetadata;
   if (usageMeta && typeof usageMeta === "object") {
+    const previousUsage = state.usage;
+    const previousRawInput =
+      (previousUsage?.input_tokens ?? 0) + (previousUsage?.cache_read_input_tokens ?? 0);
     const inputTokens =
-      typeof usageMeta.promptTokenCount === "number" ? usageMeta.promptTokenCount : 0;
+      typeof usageMeta.promptTokenCount === "number" &&
+      Number.isFinite(usageMeta.promptTokenCount) &&
+      usageMeta.promptTokenCount >= 0
+        ? usageMeta.promptTokenCount
+        : previousRawInput;
     const candidatesTokens =
-      typeof usageMeta.candidatesTokenCount === "number" ? usageMeta.candidatesTokenCount : 0;
+      typeof usageMeta.candidatesTokenCount === "number" &&
+      Number.isFinite(usageMeta.candidatesTokenCount) &&
+      usageMeta.candidatesTokenCount >= 0
+        ? usageMeta.candidatesTokenCount
+        : (previousUsage?.output_tokens ?? 0);
     const thoughtsTokens =
-      typeof usageMeta.thoughtsTokenCount === "number" ? usageMeta.thoughtsTokenCount : 0;
+      typeof usageMeta.thoughtsTokenCount === "number" &&
+      Number.isFinite(usageMeta.thoughtsTokenCount) &&
+      usageMeta.thoughtsTokenCount >= 0
+        ? usageMeta.thoughtsTokenCount
+        : 0;
+    const hasCachedCount = Object.prototype.hasOwnProperty.call(
+      usageMeta,
+      "cachedContentTokenCount"
+    );
+    const reportedCachedTokens = usageMeta.cachedContentTokenCount;
     const cachedTokens =
-      typeof usageMeta.cachedContentTokenCount === "number" ? usageMeta.cachedContentTokenCount : 0;
+      typeof reportedCachedTokens === "number" &&
+      Number.isFinite(reportedCachedTokens) &&
+      reportedCachedTokens >= 0 &&
+      reportedCachedTokens <= inputTokens
+        ? reportedCachedTokens
+        : undefined;
+    const previousCachedTokens = previousUsage?.cache_read_input_tokens;
+    const effectiveCachedTokens =
+      cachedTokens ??
+      (!hasCachedCount &&
+      typeof previousCachedTokens === "number" &&
+      previousCachedTokens <= inputTokens
+        ? previousCachedTokens
+        : undefined);
 
-    state.usage = {
-      input_tokens: inputTokens,
+    state.cacheEvidence = hasCachedCount
+    ? cachedTokens === undefined
+      ? "invalid"
+      : cachedTokens > 0
+        ? "hit"
+        : "miss"
+    : "unreported";
+      state.usage = {
+      input_tokens: Math.max(
+        0,
+        inputTokens - (typeof effectiveCachedTokens === "number" ? effectiveCachedTokens : 0)
+      ),
       output_tokens: candidatesTokens + thoughtsTokens,
     };
-    if (cachedTokens > 0) {
-      state.usage.cache_read_input_tokens = cachedTokens;
+    if (typeof effectiveCachedTokens === "number") {
+      state.usage.cache_read_input_tokens = effectiveCachedTokens;
     }
   }
 

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -31,6 +31,7 @@ type GeminiToOpenAIState = {
   textualReasoningTagBuffer?: string;
   activeTextualReasoningTag?: string;
   textualReasoningContentBuffer?: string;
+  cacheEvidence?: "hit" | "miss" | "unreported" | "invalid";
   usage?: {
     prompt_tokens: number;
     completion_tokens: number;
@@ -648,16 +649,43 @@ export function geminiToOpenAIResponse(chunk, state) {
   // Usage metadata - extract before finish reason so we can include it
   const usageMeta = response.usageMetadata || chunk.usageMetadata;
   if (usageMeta && typeof usageMeta === "object") {
-    const cachedTokens =
-      typeof usageMeta.cachedContentTokenCount === "number" ? usageMeta.cachedContentTokenCount : 0;
+    const previousUsage = state.usage;
     const promptTokenCountRaw =
-      typeof usageMeta.promptTokenCount === "number" ? usageMeta.promptTokenCount : 0;
+      typeof usageMeta.promptTokenCount === "number" &&
+      Number.isFinite(usageMeta.promptTokenCount) &&
+      usageMeta.promptTokenCount >= 0
+        ? usageMeta.promptTokenCount
+        : (previousUsage?.prompt_tokens ?? 0);
+    const hasCachedCount = Object.prototype.hasOwnProperty.call(
+      usageMeta,
+      "cachedContentTokenCount"
+    );
+    const reportedCachedTokens = usageMeta.cachedContentTokenCount;
+    const cachedTokens =
+      typeof reportedCachedTokens === "number" &&
+      Number.isFinite(reportedCachedTokens) &&
+      reportedCachedTokens >= 0 &&
+      reportedCachedTokens <= promptTokenCountRaw
+        ? reportedCachedTokens
+        : undefined;
     const thoughtsTokens =
-      typeof usageMeta.thoughtsTokenCount === "number" ? usageMeta.thoughtsTokenCount : 0;
+      typeof usageMeta.thoughtsTokenCount === "number" &&
+      Number.isFinite(usageMeta.thoughtsTokenCount) &&
+      usageMeta.thoughtsTokenCount >= 0
+        ? usageMeta.thoughtsTokenCount
+        : 0;
     let candidatesTokens =
-      typeof usageMeta.candidatesTokenCount === "number" ? usageMeta.candidatesTokenCount : 0;
+      typeof usageMeta.candidatesTokenCount === "number" &&
+      Number.isFinite(usageMeta.candidatesTokenCount) &&
+      usageMeta.candidatesTokenCount >= 0
+        ? usageMeta.candidatesTokenCount
+        : (previousUsage?.completion_tokens ?? 0);
     const totalTokens =
-      typeof usageMeta.totalTokenCount === "number" ? usageMeta.totalTokenCount : 0;
+      typeof usageMeta.totalTokenCount === "number" &&
+      Number.isFinite(usageMeta.totalTokenCount) &&
+      usageMeta.totalTokenCount >= 0
+        ? usageMeta.totalTokenCount
+        : (previousUsage?.total_tokens ?? 0);
 
     // prompt_tokens = promptTokenCount (includes cached tokens, matching claude-to-openai.js behavior)
     const promptTokens = promptTokenCountRaw;
@@ -671,16 +699,33 @@ export function geminiToOpenAIResponse(chunk, state) {
     // completion_tokens = candidatesTokenCount + thoughtsTokenCount (match Go code)
     const completionTokens = candidatesTokens + thoughtsTokens;
 
+    const previousCachedTokens = previousUsage?.prompt_tokens_details?.cached_tokens;
+
+    // Usage snapshots are cumulative. Keep the latest valid cache count, and do
+    // not erase it when a later snapshot omits cache metadata.
+    const effectiveCachedTokens =
+      cachedTokens ??
+      (!hasCachedCount &&
+      typeof previousCachedTokens === "number" &&
+      previousCachedTokens <= promptTokens
+        ? previousCachedTokens
+        : undefined);
+    const cacheEvidence = !hasCachedCount
+      ? "unreported"
+      : cachedTokens === undefined
+        ? "invalid"
+        : cachedTokens > 0
+          ? "hit"
+          : "miss";
+    state.cacheEvidence = cacheEvidence;
     state.usage = {
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
       total_tokens: totalTokens,
     };
-
-    // Add prompt_tokens_details if cached tokens exist
-    if (cachedTokens > 0) {
+    if (typeof effectiveCachedTokens === "number") {
       state.usage.prompt_tokens_details = {
-        cached_tokens: cachedTokens,
+        cached_tokens: effectiveCachedTokens,
       };
     }
 

--- a/open-sse/utils/cacheControlPolicy.ts
+++ b/open-sse/utils/cacheControlPolicy.ts
@@ -20,6 +20,7 @@ import type { RoutingStrategyValue } from "../../src/shared/constants/routingStr
  * Cache control preservation modes
  */
 export type CacheControlMode = "auto" | "always" | "never";
+export type GeminiPromptCacheMode = "off" | "implicit";
 
 /**
  * Cache control settings from the database
@@ -210,13 +211,28 @@ export function isClaudeCodeClient(userAgent: string | null | undefined): boolea
 export function providerSupportsCaching(
   provider: string | null | undefined,
   targetFormat?: string | null,
-  connectionCacheOverride?: ConnectionCacheOverride | null
+  connectionCacheOverride?: ConnectionCacheOverride | null,
+  model?: string | null
 ): boolean {
+  if (!provider) return false;
+  const providerId = provider.toLowerCase();
+  if (providerId === "antigravity" || providerId === "agy") {
+    // Antigravity carries Gemini, Claude, and GPT models. Only Gemini models
+    // are in this release's implicit-cache scope.
+    const modelSegments = String(model ?? "")
+      .toLowerCase()
+      .split("/")
+      .filter(Boolean);
+    if (!modelSegments.some((segment) => segment.startsWith("gemini-"))) return false;
+    if (typeof connectionCacheOverride?.supportsPromptCaching === "boolean") {
+      return connectionCacheOverride.supportsPromptCaching;
+    }
+    return true;
+  }
   if (typeof connectionCacheOverride?.supportsPromptCaching === "boolean") {
     return connectionCacheOverride.supportsPromptCaching;
   }
-  if (!provider) return false;
-  if (CACHING_PROVIDERS.has(provider.toLowerCase())) return true;
+  if (CACHING_PROVIDERS.has(providerId)) return true;
   // All Claude-protocol providers support prompt caching
   if (targetFormat === "claude") return true;
   return false;
@@ -259,6 +275,7 @@ export function shouldPreserveCacheControl({
   userAgent,
   targetProvider,
   targetFormat,
+  targetModel,
   settings,
   connectionCacheOverride,
 }: {
@@ -267,6 +284,7 @@ export function shouldPreserveCacheControl({
   comboStrategy?: RoutingStrategyValue | null;
   targetProvider: string | null | undefined;
   targetFormat?: string | null;
+  targetModel?: string | null;
   settings?: CacheControlSettings;
   connectionCacheOverride?: ConnectionCacheOverride | null;
 }): boolean {
@@ -284,7 +302,12 @@ export function shouldPreserveCacheControl({
   }
 
   // …talking to a provider that supports prompt caching.
-  return providerSupportsCaching(targetProvider, targetFormat, connectionCacheOverride);
+  return providerSupportsCaching(
+    targetProvider,
+    targetFormat,
+    connectionCacheOverride,
+    targetModel
+  );
 }
 
 /**

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -145,6 +145,7 @@ type StreamCompletePayload = {
   itlMs?: number | null;
   /** True when the stream was interrupted (timeout/abort/error) before a clean finish. */
   interrupted?: boolean;
+  cacheEvidence?: "hit" | "miss" | "unreported" | "invalid";
 };
 
 type StreamOptions = {
@@ -187,6 +188,7 @@ type TranslateState = ReturnType<typeof initState> & {
   toolNameMap?: unknown;
   signatureNamespace?: string | null;
   usage?: unknown;
+  cacheEvidence?: "hit" | "miss" | "unreported" | "invalid";
   finishReason?: unknown;
   copilotCompatibleReasoning?: boolean;
   /** Suppress the `</think>` close marker for clients that render it verbatim (#5245). */
@@ -728,6 +730,30 @@ export function createSSEStream(options: StreamOptions = {}) {
 
   let buffer = "";
   let usage: UsageLike | null = null;
+  let lastPropagatedCacheEvidence: TranslateState["cacheEvidence"];
+
+  function mergeUsageSnapshot(current: UsageLike | null, incoming: UsageLike): UsageLike {
+    if (!current) return { ...incoming };
+    return {
+      ...current,
+      ...incoming,
+      // A provider may split usage across snapshots. Undefined fields do not
+      // erase earlier evidence; explicit zero is meaningful (a cache miss).
+      ...(incoming.cache_evidence === "invalid"
+        ? { cached_tokens: undefined, cache_evidence: "invalid" }
+        : incoming.cached_tokens !== undefined
+          ? { cached_tokens: incoming.cached_tokens }
+          : {}),
+      ...(incoming.cache_read_input_tokens !== undefined
+        ? { cache_read_input_tokens: incoming.cache_read_input_tokens }
+        : {}),
+      ...(incoming.cache_creation_input_tokens !== undefined
+        ? { cache_creation_input_tokens: incoming.cache_creation_input_tokens }
+        : {}),
+      ...(incoming.cache_evidence !== undefined ? { cache_evidence: incoming.cache_evidence } : {}),
+    };
+  }
+
   /** Passthrough (OpenAI CC shape): saw tool_calls in stream before finish_reason */
   let passthroughHasToolCalls = false;
   /** Passthrough: whether a chunk with non-null finish_reason was seen (#7800) */
@@ -1080,7 +1106,8 @@ export function createSSEStream(options: StreamOptions = {}) {
       cacheHit: false,
       latencyMs: Date.now() - streamStartedAt,
       usage: timing.withTps(finalUsage),
-      costUsd, ttftMs: timing.ttftMs(),
+      costUsd,
+      ttftMs: timing.ttftMs(),
     });
     if (!comment) return;
     reqLogger?.appendConvertedChunk?.(comment);
@@ -1455,7 +1482,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // Responses SSE: only extract usage, forward payload as-is
                   const extracted = extractUsage(parsed);
                   if (extracted) {
-                    usage = extracted;
+                    usage = mergeUsageSnapshot(usage, extracted);
                   }
                   // Keep generic Responses deltas for fallback usage estimates,
                   // but only visible text deltas may become assistant content in
@@ -1721,9 +1748,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                     if (eu.prompt_tokens > 0) u.prompt_tokens = eu.prompt_tokens;
                     if (eu.completion_tokens > 0) u.completion_tokens = eu.completion_tokens;
                     if (eu.total_tokens > 0) u.total_tokens = eu.total_tokens;
-                    if (eu.cache_read_input_tokens)
+                    if (eu.cache_read_input_tokens !== undefined)
                       u.cache_read_input_tokens = eu.cache_read_input_tokens;
-                    if (eu.cache_creation_input_tokens)
+                    if (eu.cache_creation_input_tokens !== undefined)
                       u.cache_creation_input_tokens = eu.cache_creation_input_tokens;
                   }
                   if (
@@ -1997,7 +2024,7 @@ export function createSSEStream(options: StreamOptions = {}) {
 
                   const extracted = extractUsage(parsed);
                   if (extracted) {
-                    usage = extracted;
+                    usage = mergeUsageSnapshot(usage, extracted);
                   }
 
                   const isFinishChunk = parsed.choices?.[0]?.finish_reason;
@@ -2046,7 +2073,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // estimate is now emitted in flush(), only when the upstream stayed silent.
                   if (isFinishChunk && hasValidUsage(usage) && !passthroughForwardedUsage) {
                     const buffered = addBufferToUsage(usage);
-                    parsed.usage = timing.withTps(filterUsageForFormat(buffered, sourceFormat || FORMATS.OPENAI));
+                    parsed.usage = timing.withTps(
+                      filterUsageForFormat(buffered, sourceFormat || FORMATS.OPENAI)
+                    );
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     passthroughForwardedUsage = true;
                     injectedUsage = true;
@@ -2257,24 +2286,33 @@ export function createSSEStream(options: StreamOptions = {}) {
             if (!state.usage) {
               state.usage = extracted;
             } else {
-              const su = state.usage as Record<string, number>;
-              const eu = extracted as Record<string, number>;
+              const su = state.usage as UsageLike;
+              const eu = extracted as UsageLike;
               if (eu.prompt_tokens > 0) su.prompt_tokens = eu.prompt_tokens;
               if (eu.completion_tokens > 0) su.completion_tokens = eu.completion_tokens;
               if (eu.total_tokens > 0) su.total_tokens = eu.total_tokens;
               if (eu.input_tokens > 0) su.input_tokens = eu.input_tokens;
               if (eu.output_tokens > 0) su.output_tokens = eu.output_tokens;
-              if (eu.cache_read_input_tokens > 0)
+              if (eu.cache_read_input_tokens !== undefined)
                 su.cache_read_input_tokens = eu.cache_read_input_tokens;
-              if (eu.cache_creation_input_tokens > 0)
+              if (eu.cache_creation_input_tokens !== undefined)
                 su.cache_creation_input_tokens = eu.cache_creation_input_tokens;
-              if (eu.cached_tokens > 0) su.cached_tokens = eu.cached_tokens;
+              if (eu.cache_evidence === "invalid") {
+                delete su.cached_tokens;
+              } else if (eu.cached_tokens !== undefined) {
+                su.cached_tokens = eu.cached_tokens;
+              }
+              if (eu.cache_evidence !== undefined) su.cache_evidence = eu.cache_evidence;
               if (eu.reasoning_tokens > 0) su.reasoning_tokens = eu.reasoning_tokens;
             }
           }
 
           // Translate: targetFormat -> openai -> sourceFormat
           const translated = translateResponse(targetFormat, sourceFormat, parsed, state);
+          if (state?.cacheEvidence !== lastPropagatedCacheEvidence) {
+            usage = { ...usage, cache_evidence: state?.cacheEvidence };
+            lastPropagatedCacheEvidence = state?.cacheEvidence;
+          }
 
           // Log OpenAI intermediate chunks (if available)
           for (const item of getOpenAIIntermediateChunks(translated)) {
@@ -2571,7 +2609,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   created: Math.floor(Date.now() / 1000),
                   model,
                   choices: [],
-                  usage: timing.withTps(filterUsageForFormat(usage, sourceFormat || FORMATS.OPENAI)),
+                  usage: timing.withTps(
+                    filterUsageForFormat(usage, sourceFormat || FORMATS.OPENAI)
+                  ),
                 };
                 const usageOutput = `data: ${JSON.stringify(usageOnlyChunk)}\n\n`;
                 reqLogger?.appendConvertedChunk?.(usageOutput);
@@ -2658,6 +2698,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                 onComplete({
                   status: 200,
                   usage,
+                  cacheEvidence: usage?.cache_evidence as StreamCompletePayload["cacheEvidence"],
                   responseBody,
                   ttft: timing.ttftMs(),
                   itlMs: timing.avgItlMs(),
@@ -2725,23 +2766,32 @@ export function createSSEStream(options: StreamOptions = {}) {
                 if (!state.usage) {
                   state.usage = extracted;
                 } else {
-                  const su = state.usage as Record<string, number>;
-                  const eu = extracted as Record<string, number>;
+                  const su = state.usage as UsageLike;
+                  const eu = extracted as UsageLike;
                   if (eu.prompt_tokens > 0) su.prompt_tokens = eu.prompt_tokens;
                   if (eu.completion_tokens > 0) su.completion_tokens = eu.completion_tokens;
                   if (eu.total_tokens > 0) su.total_tokens = eu.total_tokens;
                   if (eu.input_tokens > 0) su.input_tokens = eu.input_tokens;
                   if (eu.output_tokens > 0) su.output_tokens = eu.output_tokens;
-                  if (eu.cache_read_input_tokens > 0)
+                  if (eu.cache_read_input_tokens !== undefined)
                     su.cache_read_input_tokens = eu.cache_read_input_tokens;
-                  if (eu.cache_creation_input_tokens > 0)
+                  if (eu.cache_creation_input_tokens !== undefined)
                     su.cache_creation_input_tokens = eu.cache_creation_input_tokens;
-                  if (eu.cached_tokens > 0) su.cached_tokens = eu.cached_tokens;
+                  if (eu.cache_evidence === "invalid") {
+                    delete su.cached_tokens;
+                  } else if (eu.cached_tokens !== undefined) {
+                    su.cached_tokens = eu.cached_tokens;
+                  }
+                  if (eu.cache_evidence !== undefined) su.cache_evidence = eu.cache_evidence;
                   if (eu.reasoning_tokens > 0) su.reasoning_tokens = eu.reasoning_tokens;
                 }
               }
 
               const translated = translateResponse(targetFormat, sourceFormat, parsed, state);
+              if (state?.cacheEvidence !== lastPropagatedCacheEvidence) {
+                usage = { ...usage, cache_evidence: state?.cacheEvidence };
+                lastPropagatedCacheEvidence = state?.cacheEvidence;
+              }
 
               // Log OpenAI intermediate chunks
               for (const item of getOpenAIIntermediateChunks(translated)) {
@@ -2934,6 +2984,7 @@ export function createSSEStream(options: StreamOptions = {}) {
               onComplete({
                 status: 200,
                 usage: state?.usage,
+                cacheEvidence: state?.cacheEvidence,
                 responseBody,
                 // Same OPENAI_RESPONSES carve-out as the passthrough branch above —
                 // the synthesized chat-shaped responseBody drops the `response` object,

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -51,6 +51,8 @@ export interface UsageLike {
   candidatesTokenCount?: number;
   totalTokenCount?: number;
   cachedContentTokenCount?: number;
+  /** Internal Gemini cache evidence; removed by filterUsageForFormat. */
+  cache_evidence?: "hit" | "miss" | "unreported" | "invalid";
   thoughtsTokenCount?: number;
   context_budget_input_tokens?: number;
   context_budget_prompt_tokens?: number;
@@ -624,7 +626,15 @@ export function normalizeUsage(usage: UsageLike | null | undefined) {
   assignNumber("output_tokens", usage?.output_tokens);
   assignNumber("cache_read_input_tokens", usage?.cache_read_input_tokens);
   assignNumber("cache_creation_input_tokens", pickCacheCreationTokens(usage));
-  assignNumber("cached_tokens", usage?.cached_tokens);
+  if (usage?.cached_tokens !== undefined) assignNumber("cached_tokens", usage.cached_tokens);
+  if (
+    usage?.cache_evidence === "hit" ||
+    usage?.cache_evidence === "miss" ||
+    usage?.cache_evidence === "unreported" ||
+    usage?.cache_evidence === "invalid"
+  ) {
+    (normalized as UsageLike).cache_evidence = usage.cache_evidence;
+  }
   assignNumber("no_cache_tokens", usage?.no_cache_tokens);
   assignNumber("reasoning_tokens", usage?.reasoning_tokens);
   // xAI's exact provider-reported cost (port of decolua/9router#2453, capability A —
@@ -815,11 +825,28 @@ export function extractUsage(chunk: UsagePayloadLike | null | undefined) {
     // Gemini reports thoughts outside candidates. Fold them into completion so
     // every provider keeps reasoning as a subset of completion tokens.
     const thoughts = usageMeta.thoughtsTokenCount || 0;
+    const promptTokens = usageMeta.promptTokenCount || 0;
+    const reportedCachedTokens = usageMeta.cachedContentTokenCount;
+    const cachedTokens =
+      typeof reportedCachedTokens === "number" &&
+      Number.isFinite(reportedCachedTokens) &&
+      reportedCachedTokens >= 0 &&
+      reportedCachedTokens <= promptTokens
+        ? reportedCachedTokens
+        : undefined;
     return normalizeUsage({
-      prompt_tokens: usageMeta.promptTokenCount || 0,
+      prompt_tokens: promptTokens,
       completion_tokens: (usageMeta.candidatesTokenCount || 0) + thoughts,
       total_tokens: usageMeta.totalTokenCount,
-      cached_tokens: usageMeta.cachedContentTokenCount,
+      ...(cachedTokens !== undefined ? { cached_tokens: cachedTokens } : {}),
+      cache_evidence:
+        !Object.prototype.hasOwnProperty.call(usageMeta, "cachedContentTokenCount")
+          ? "unreported"
+          : cachedTokens === undefined
+            ? "invalid"
+            : cachedTokens > 0
+              ? "hit"
+              : "miss",
       reasoning_tokens: thoughts,
     });
   }

--- a/src/lib/cacheControlSettings.ts
+++ b/src/lib/cacheControlSettings.ts
@@ -16,7 +16,11 @@ export async function getCacheControlSettings(): Promise<CacheControlMode> {
   }
 
   const settings = await getSettings();
-  cachedSettings = (settings.alwaysPreserveClientCache as CacheControlMode) || "auto";
+  const configured = settings.alwaysPreserveClientCache;
+  cachedSettings =
+    configured === "auto" || configured === "always" || configured === "never"
+      ? configured
+      : "auto";
   return cachedSettings;
 }
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -150,6 +150,7 @@ export async function getSettings() {
     // Global connection-aware expansion fallback for group-B combo strategies is opt-in.
     connectionAwareExpansion: false,
     promptCacheAffinityEnabled: true,
+    geminiPromptCacheMode: "off",
     comboStrategy: "fallback",
     comboStickyRoundRobinLimit: null, // null = inherit stickyRoundRobinLimit (a literal default here shadows the documented batched-rotation default of 3 — #6678 regression caught by the v3.8.47 release CI)
     providerStrategies: {},

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -404,6 +404,8 @@ export const updateSettingsSchema = z.object({
   stripModelPrefix: z.boolean().optional(),
   // Cache control preservation mode
   alwaysPreserveClientCache: z.enum(["auto", "always", "never"]).optional(),
+  // Gemini through Antigravity only; default off and no explicit cache resources.
+  geminiPromptCacheMode: z.enum(["off", "implicit"]).optional(),
   antigravitySignatureCacheMode: z.enum(signatureCacheModeValues).optional(),
   // Adaptive Volume Routing
   adaptiveVolumeRouting: z.boolean().optional(),

--- a/tests/unit/cache-config-preserve-client-cache.test.ts
+++ b/tests/unit/cache-config-preserve-client-cache.test.ts
@@ -61,6 +61,35 @@ test("alwaysPreserveClientCache set via cache-config reaches the runtime read pa
     assert.equal(await getCacheControlSettings(), "always");
   });
 
+  await t.test("invalid persisted cache mode falls back to auto", async () => {
+    const { updateSettings } = await import("../../src/lib/db/settings.ts");
+    const { getCacheControlSettings, invalidateCacheControlSettingsCache } =
+      await import("../../src/lib/cacheControlSettings.ts");
+    await updateSettings({ alwaysPreserveClientCache: "unexpected" } as never);
+    invalidateCacheControlSettingsCache();
+    assert.equal(await getCacheControlSettings(), "auto");
+  });
+
+  await t.test(
+    "the generic settings PATCH accepts Gemini mode and rejects invalid mode",
+    async () => {
+      const settingsRoute = await import("../../src/app/api/settings/route.ts");
+      const { getSettings } = await import("../../src/lib/db/settings.ts");
+      const patch = (value: unknown) =>
+        settingsRoute.PATCH(
+          new Request("http://localhost/api/settings", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ geminiPromptCacheMode: value }),
+          })
+        );
+      const valid = await patch("implicit");
+      assert.notEqual(valid.status, 400);
+      assert.equal((await getSettings()).geminiPromptCacheMode, "implicit");
+      assert.equal((await patch("invalid")).status, 400);
+    }
+  );
+
   await t.test("GET reports the flat value, not the ignored cache-section copy", async () => {
     // Seed a stale value in the databaseSettings "cache" section — the store
     // the runtime never reads. GET must not surface it.

--- a/tests/unit/cache-control-policy.test.ts
+++ b/tests/unit/cache-control-policy.test.ts
@@ -45,6 +45,46 @@ describe("Cache Control Policy", () => {
       assert.equal(providerSupportsCaching("openai"), true);
       assert.equal(providerSupportsCaching("codex"), true);
       assert.equal(providerSupportsCaching("azure"), true);
+      assert.equal(
+        providerSupportsCaching("antigravity", "gemini", null, "gemini-3.7-flash"),
+        true
+      );
+      assert.equal(providerSupportsCaching("agy", "gemini", null, "gemini-3.7-flash"), true);
+      assert.equal(
+        providerSupportsCaching(
+          "antigravity",
+          "gemini",
+          { supportsPromptCaching: true },
+          "claude-opus-4-6"
+        ),
+        false
+      );
+      assert.equal(
+        providerSupportsCaching(
+          "antigravity",
+          "gemini",
+          null,
+          "antigravity/gemini-3.7-flash-tiered"
+        ),
+        true
+      );
+      assert.equal(
+        providerSupportsCaching(
+          "antigravity",
+          "gemini",
+          null,
+          "antigravity/antigravity/gemini-3.8-flash-tiered"
+        ),
+        true
+      );
+      assert.equal(
+        providerSupportsCaching("antigravity", "claude", null, "claude-opus-4-6"),
+        false
+      );
+      assert.equal(
+        providerSupportsCaching("antigravity", "openai", null, "gpt-oss-120b-medium"),
+        false
+      );
     });
 
     test("rejects non-caching providers", () => {

--- a/tests/unit/call-log-detailed-tokens.test.ts
+++ b/tests/unit/call-log-detailed-tokens.test.ts
@@ -107,12 +107,14 @@ describe("detailed token extraction â€” per provider format", () => {
     assert.equal(getReasoningTokensOrNull(tokens), null, "No reasoning field");
   });
 
-  it("Antigravity / openai-compatible-sp: same as Codex (no breakdowns)", () => {
+  it("Antigravity / Gemini: cached input remains a subset of prompt input", () => {
     const tokens = {
-      prompt_tokens: 300,
-      completion_tokens: 150,
+      prompt_tokens: 46212,
+      completion_tokens: 4,
+      cached_tokens: 40929,
     };
-    assert.equal(getPromptCacheReadTokensOrNull(tokens), null);
+    assert.equal(getLoggedInputTokens(tokens), 46212);
+    assert.equal(getPromptCacheReadTokensOrNull(tokens), 40929);
     assert.equal(getPromptCacheCreationTokensOrNull(tokens), null);
     assert.equal(getReasoningTokensOrNull(tokens), null);
   });

--- a/tests/unit/chatcore-attempt-logging.test.ts
+++ b/tests/unit/chatcore-attempt-logging.test.ts
@@ -18,12 +18,13 @@ const { getCallLogById } = await import("../../src/lib/usage/callLogs.ts");
 const { persistAttemptLogs } = await import("../../open-sse/handlers/chatCore/attemptLogging.ts");
 const { getAuditLog } = await import("../../src/lib/compliance/index.ts");
 
-type CodexRotationEnvelope = {
+type CallLogEnvelope = {
   _omniroute?: {
     codexAccountRotation?: {
       initialConnectionId: unknown;
       finalConnectionId: unknown;
     };
+    geminiPromptCache?: Record<string, unknown>;
   };
 };
 
@@ -62,9 +63,13 @@ async function pollForCallLog(id: string, tries = 120) {
   return null;
 }
 
-function getCodexAccountRotation(value: unknown) {
+function getOmniRouteMeta(value: unknown) {
   if (!value || typeof value !== "object") return undefined;
-  return (value as CodexRotationEnvelope)._omniroute?.codexAccountRotation;
+  return (value as CallLogEnvelope)._omniroute;
+}
+
+function getCodexAccountRotation(value: unknown) {
+  return getOmniRouteMeta(value)?.codexAccountRotation;
 }
 
 before(async () => {
@@ -123,6 +128,37 @@ test("cacheSource 'semantic' is preserved", async () => {
   const row = await pollForCallLog(id);
   assert.ok(row);
   assert.equal(row.cacheSource, "semantic");
+});
+
+test("persists bounded Gemini cache evidence under request and response _omniroute metadata", async () => {
+  const id = "attempt-gemini-cache-1";
+  const geminiPromptCache = {
+    schemaVersion: 1,
+    mode: "implicit",
+    evidence: "hit",
+    providerCounters: { cachedContentTokenCount: 40_929 },
+    prefixBoundary: "unknown",
+    prefixMethod: "unavailable",
+  };
+
+  persistAttemptLogs(
+    {
+      status: 200,
+      tokens: { prompt_tokens: 46_212, cached_tokens: 40_929 },
+      responseBody: { candidates: [] },
+      geminiPromptCache,
+    },
+    baseCtx({
+      pendingRequestId: id,
+      provider: "antigravity",
+      model: "gemini-3.7-flash-tiered",
+    })
+  );
+
+  const row = await pollForCallLog(id);
+  assert.ok(row, "call log row should be persisted");
+  assert.deepEqual(getOmniRouteMeta(row.requestBody)?.geminiPromptCache, geminiPromptCache);
+  assert.deepEqual(getOmniRouteMeta(row.responseBody)?.geminiPromptCache, geminiPromptCache);
 });
 
 test("connectionId falls back to credentials.connectionId when null, and error is persisted", async () => {

--- a/tests/unit/chatcore-cache-usage-meta.test.ts
+++ b/tests/unit/chatcore-cache-usage-meta.test.ts
@@ -40,6 +40,63 @@ test("buildCacheUsageLogMeta reads prompt_tokens_details shapes", () => {
   assert.deepEqual(meta, { cacheReadTokens: 7, cacheCreationTokens: 2 });
 });
 
+test("buildCacheUsageLogMeta emits bounded Gemini cache evidence", () => {
+  const meta = buildCacheUsageLogMeta(
+    {
+      prompt_tokens: 46_212,
+      prompt_tokens_details: { cached_tokens: 40_929 },
+      cache_evidence: "hit",
+    },
+    { mode: "implicit" }
+  );
+
+  assert.deepEqual(meta, {
+    cacheReadTokens: 40_929,
+    cacheCreationTokens: 0,
+    geminiPromptCache: {
+      schemaVersion: 1,
+      mode: "implicit",
+      evidence: "hit",
+      providerCounters: { cachedContentTokenCount: 40_929 },
+      prefixBoundary: "unknown",
+      prefixMethod: "unavailable",
+    },
+  });
+  assert.equal(JSON.stringify(meta).includes("46_212"), false);
+});
+
+test("buildCacheUsageLogMeta records compression and timing only when measured", () => {
+  assert.deepEqual(buildCacheUsageLogMeta(null, { mode: "off", compressionTokens: 0 }), {
+    geminiPromptCache: {
+      schemaVersion: 1,
+      mode: "off",
+      evidence: "unreported",
+      providerCounters: {},
+      prefixBoundary: "unknown",
+      prefixMethod: "unavailable",
+    },
+  });
+  assert.deepEqual(
+    buildCacheUsageLogMeta(null, {
+      mode: "implicit",
+      compressionTokens: 8,
+      timing: { ttftMs: 12, itlMs: 4 },
+    }),
+    {
+      geminiPromptCache: {
+        schemaVersion: 1,
+        mode: "implicit",
+        evidence: "unreported",
+        providerCounters: {},
+        prefixBoundary: "unknown",
+        prefixMethod: "unavailable",
+        compressionDecision: { applied: true, tokens: 8 },
+        timing: { ttftMs: 12, itlMs: 4 },
+      },
+    }
+  );
+});
+
 test("attachLogMeta returns the payload untouched when meta is empty", () => {
   const payload = { a: 1 };
   assert.equal(attachLogMeta(payload, null), payload);

--- a/tests/unit/combo-routing-engine.test.ts
+++ b/tests/unit/combo-routing-engine.test.ts
@@ -591,6 +591,58 @@ test("handleComboChat preserves the weighted primary before prompt-cache affinit
   }
 });
 
+test("prompt-cache affinity falls through when its preferred account becomes runtime-ineligible", async () => {
+  const combo = {
+    name: "affinity-runtime-ineligible",
+    strategy: "round-robin",
+    models: [
+      {
+        kind: "model",
+        providerId: "openai",
+        model: "openai/gpt-4o-mini",
+        connectionId: "affinity-account-a",
+      },
+      {
+        kind: "model",
+        providerId: "openai",
+        model: "openai/gpt-4o-mini",
+        connectionId: "eligible-account-b",
+      },
+    ],
+    config: { maxRetries: 0 },
+  };
+  const resolvedTargets = resolveComboTargets(combo, null);
+  const cacheKey = Array.from({ length: 100 }, (_, index) => `affinity-cache-${index}`).find(
+    (key) =>
+      applyPromptCacheAffinity(resolvedTargets, { prompt_cache_key: key }).targets[0]
+        ?.connectionId === "affinity-account-a"
+  );
+  assert.ok(cacheKey, "fixture must prefer affinity account A");
+
+  const availabilityChecks: string[] = [];
+  const dispatches: string[] = [];
+  const result = await handleComboChat({
+    body: { prompt_cache_key: cacheKey },
+    combo,
+    handleSingleModel: async (_body: unknown, _modelStr: string, target: { connectionId?: string }) => {
+      dispatches.push(target.connectionId || "none");
+      return okResponse();
+    },
+    isModelAvailable: async (_modelStr: string, target: { connectionId?: string }) => {
+      availabilityChecks.push(target.connectionId || "none");
+      return target.connectionId !== "affinity-account-a";
+    },
+    log: createLog(),
+    settings: { promptCacheAffinityEnabled: true },
+    relayOptions: null,
+    allCombos: null,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(availabilityChecks[0], "affinity-account-a");
+  assert.deepEqual(dispatches, ["eligible-account-b"]);
+});
+
 test("handleComboChat weighted strategy falls back to uniform random when all weights are zero", async () => {
   const calls: any[] = [];
   _setSecureRandomFloatSource(() => 0.75);

--- a/tests/unit/compression-cache-guard-3955.test.ts
+++ b/tests/unit/compression-cache-guard-3955.test.ts
@@ -92,8 +92,64 @@ describe("#3955 automatic-cache prefix protection (no explicit cache_control)", 
     assert.equal(out.preserveSystemPrompt, true, "cacheable prefix must stay uncompressed");
   });
 
+  it("protects an Antigravity Gemini prefix without explicit cache_control", () => {
+    const body = autoCacheBody("gemini-3.7-flash");
+    const ctx = detectCachingContext(body, {
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      geminiPromptCacheMode: "implicit",
+    });
+    assert.equal(ctx.isCachingProvider, true);
+
+    const out = resolveCacheAwareConfig(cfg({ preserveSystemPrompt: false }), body, {
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      geminiPromptCacheMode: "implicit",
+    });
+    assert.equal(out.preserveSystemPrompt, true);
+  });
+
+  it("keeps unrelated provider protection unchanged when Gemini mode is off", () => {
+    const ctx = detectCachingContext(autoCacheBody("openai/gpt-4o"), {
+      provider: "openai",
+      geminiPromptCacheMode: "off",
+    });
+    assert.equal(ctx.isCachingProvider, true);
+    assert.equal(
+      detectCachingContext(autoCacheBody("codex/gpt-5-codex"), { provider: "codex" })
+        .isCachingProvider,
+      true
+    );
+  });
+
+  it("defaults Gemini mode to off and never protects an Antigravity Gemini prefix", () => {
+    const body = autoCacheBody("gemini-3.7-flash");
+    const ctx = detectCachingContext(body, {
+      provider: "antigravity",
+      model: "antigravity/gemini-3.7-flash-tiered",
+    });
+    assert.equal(ctx.isCachingProvider, false);
+    assert.equal(
+      resolveCacheAwareConfig(cfg({ preserveSystemPrompt: false }), body, {
+        provider: "antigravity",
+        model: "antigravity/gemini-3.7-flash-tiered",
+      }).preserveSystemPrompt,
+      false
+    );
+    assert.equal(
+      detectCachingContext(body, {
+        provider: "antigravity",
+        model: "claude-sonnet-4-6",
+        geminiPromptCacheMode: "implicit",
+      }).isCachingProvider,
+      false
+    );
+  });
+
   it("leaves a NON-caching provider unaffected (no prefix protection without cache_control)", () => {
-    const ctx = detectCachingContext(autoCacheBody("google/gemini-2.5-pro"), { provider: "google" });
+    const ctx = detectCachingContext(autoCacheBody("google/gemini-2.5-pro"), {
+      provider: "google",
+    });
     assert.equal(ctx.isCachingProvider, false);
     const result = getCacheAwareStrategy("aggressive", ctx);
     assert.equal(result.skipSystemPrompt, false);

--- a/tests/unit/sse-parser.test.ts
+++ b/tests/unit/sse-parser.test.ts
@@ -360,6 +360,68 @@ test("parseSSEToGeminiResponse extracts text content from candidate parts", () =
   });
 });
 
+test("parseSSEToGeminiResponse preserves wrapped cached usage across late snapshots", () => {
+  const rawSSE = [
+    'data: {"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}],"usageMetadata":{"promptTokenCount":46212,"candidatesTokenCount":2,"totalTokenCount":46214,"cachedContentTokenCount":40929}}}',
+    'data: {"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":46212,"candidatesTokenCount":4,"totalTokenCount":46216}}}',
+  ].join("\n");
+
+  const parsed = parseSSEToGeminiResponse(rawSSE, "gemini-3.7-flash");
+
+  assert.ok(parsed);
+  assert.deepEqual(parsed.usage, {
+    prompt_tokens: 46212,
+    completion_tokens: 4,
+    total_tokens: 46216,
+    cached_tokens: 40929,
+  });
+});
+
+test("parseSSEToGeminiResponse preserves an explicit cache miss", () => {
+  const rawSSE =
+    'data: {"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8,"cachedContentTokenCount":0}}}';
+
+  const parsed = parseSSEToGeminiResponse(rawSSE, "gemini-2.5-flash");
+
+  assert.ok(parsed);
+  assert.equal(parsed.usage.cached_tokens, 0);
+});
+
+test("parseSSEToGeminiResponse preserves usage fields from a partial late snapshot", () => {
+  const rawSSE = [
+    'data: {"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"totalTokenCount":12,"cachedContentTokenCount":4}}}',
+    'data: {"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"candidatesTokenCount":3}}}',
+  ].join("\n");
+
+  const parsed = parseSSEToGeminiResponse(rawSSE, "gemini-3.7-flash");
+
+  assert.deepEqual(parsed?.usage, {
+    prompt_tokens: 10,
+    completion_tokens: 3,
+    total_tokens: 12,
+    cached_tokens: 4,
+  });
+});
+
+test("parseSSEToGeminiResponse clears an earlier hit for an invalid count", () => {
+  const rawSSE = [
+    'data: {"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"totalTokenCount":12,"cachedContentTokenCount":4}}}',
+    'data: {"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":3,"totalTokenCount":13,"cachedContentTokenCount":20}}}',
+  ].join("\n");
+  const parsed = parseSSEToGeminiResponse(rawSSE, "gemini-3.7-flash");
+  assert.equal(parsed?.usage.cached_tokens, undefined);
+});
+
+test("parseSSEToGeminiResponse rejects an invalid cached count", () => {
+  const rawSSE =
+    'data: {"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8,"cachedContentTokenCount":6}}}';
+
+  const parsed = parseSSEToGeminiResponse(rawSSE, "gemini-2.5-flash");
+
+  assert.ok(parsed);
+  assert.equal(parsed.usage.cached_tokens, undefined);
+});
+
 test("parseSSEToGeminiResponse handles markdown shortcut format", () => {
   const rawSSE = [
     'data: {"markdown":"Hello "}',

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -2371,6 +2371,74 @@ test("createSSEStream passthrough forwards OpenAI usage-only empty choices chunk
   assert.deepEqual(onCompletePayload.responseBody.usage, usage);
 });
 
+test("createSSEStream translated Gemini path clears an invalid cache count after a hit", async () => {
+  let onCompletePayload = null;
+  await readTransformed(
+    [
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: "hello" }] } }], usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1, totalTokenCount: 11, cachedContentTokenCount: 4 } })}\n\n`,
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: " world" }] }, finishReason: "STOP" }], usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2, totalTokenCount: 12, cachedContentTokenCount: 20 } })}\n\n`,
+    ],
+    {
+      mode: "translate",
+      targetFormat: FORMATS.ANTIGRAVITY,
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.7-flash",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+  assert.equal(onCompletePayload.cacheEvidence, "invalid");
+  assert.equal(onCompletePayload.usage.cached_tokens, undefined);
+  assert.equal(onCompletePayload.responseBody.usage.cache_evidence, undefined);
+});
+
+test("createSSEStream passthrough preserves cache evidence across late snapshots", async () => {
+  let onCompletePayload = null;
+  await readTransformed(
+    [
+      `data: ${JSON.stringify({ id: "cache", choices: [{ delta: { content: "hello" } }], usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11, cached_tokens: 4 } })}\n\n`,
+      `data: ${JSON.stringify({ id: "cache", choices: [{ delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 } })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "openai-compatible",
+      model: "gpt-4.1-mini",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+  assert.equal(onCompletePayload.usage.cached_tokens, 4);
+  assert.equal(onCompletePayload.responseBody.usage.cached_tokens, undefined);
+});
+
+test("createSSEStream translated path clears a prior cache hit on explicit zero", async () => {
+  let onCompletePayload = null;
+  await readTransformed(
+    [
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: "hello" }] } }], usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1, totalTokenCount: 11, cachedContentTokenCount: 4 } })}\n\n`,
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: " world" }] }, finishReason: "STOP" }], usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2, totalTokenCount: 12, cachedContentTokenCount: 0 } })}\n\n`,
+    ],
+    {
+      mode: "translate",
+      targetFormat: FORMATS.ANTIGRAVITY,
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.7-flash",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+  assert.equal(onCompletePayload.usage.prompt_tokens_details.cached_tokens, 0);
+});
+
 test("createSSEStream passthrough logs empty response after tool_calls completion", async () => {
   let onCompletePayload = null;
   const text = await readTransformed(

--- a/tests/unit/translator-resp-gemini-to-claude.test.ts
+++ b/tests/unit/translator-resp-gemini-to-claude.test.ts
@@ -107,10 +107,77 @@ test("Gemini -> Claude stream: functionCall becomes tool_use and MAX_TOKENS maps
   assert.equal(result[2].delta.partial_json, JSON.stringify({ path: "/tmp/a" }));
   assert.equal(result[3].type, "content_block_stop");
   assert.equal(result[4].delta.stop_reason, "tool_use");
-  assert.equal(result[4].usage.input_tokens, 5);
+  assert.equal(result[4].usage.input_tokens, 4);
   assert.equal(result[4].usage.output_tokens, 5);
   assert.equal(result[4].usage.cache_read_input_tokens, 1);
   assert.equal(result[5].type, "message_stop");
+});
+
+test("Gemini -> Claude stream: cached input is separated from uncached input", () => {
+  const state = {};
+  const result = geminiToClaudeResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+      usageMetadata: {
+        promptTokenCount: 46212,
+        candidatesTokenCount: 4,
+        cachedContentTokenCount: 40929,
+      },
+    },
+    state
+  );
+
+  const usage = result.find((event) => event.type === "message_delta").usage;
+  assert.deepEqual(usage, {
+    input_tokens: 5283,
+    cache_read_input_tokens: 40929,
+    output_tokens: 4,
+  });
+});
+
+test("Gemini -> Claude stream: absent prompt field preserves earlier cache usage", () => {
+  const state = {};
+  geminiToClaudeResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 2,
+        cachedContentTokenCount: 80,
+      },
+    },
+    state
+  );
+  const result = geminiToClaudeResponse(
+    {
+      candidates: [{ content: { parts: [{ text: " done" }] }, finishReason: "STOP" }],
+      usageMetadata: { candidatesTokenCount: 5 },
+    },
+    state
+  );
+  const usage = result.find((event) => event.type === "message_delta").usage;
+  assert.deepEqual(usage, {
+    input_tokens: 20,
+    cache_read_input_tokens: 80,
+    output_tokens: 5,
+  });
+});
+
+test("Gemini -> Claude stream: explicit zero cache usage remains reported", () => {
+  const result = geminiToClaudeResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+      usageMetadata: {
+        promptTokenCount: 5,
+        candidatesTokenCount: 1,
+        cachedContentTokenCount: 0,
+      },
+    },
+    {}
+  );
+
+  const usage = result.find((event) => event.type === "message_delta").usage;
+  assert.equal(usage.cache_read_input_tokens, 0);
 });
 
 test("Gemini -> Claude stream: STOP after prior tool use still maps to tool_use", () => {
@@ -143,9 +210,8 @@ test("Gemini -> Claude stream: STOP after prior tool use still maps to tool_use"
 });
 
 test("Gemini -> Claude stream: stores thoughtSignature from a standalone part preceding functionCall", async () => {
-  const { getGeminiThoughtSignature, clearGeminiThoughtSignatureMemoryForTests } = await import(
-    "../../open-sse/services/geminiThoughtSignatureStore.ts"
-  );
+  const { getGeminiThoughtSignature, clearGeminiThoughtSignatureMemoryForTests } =
+    await import("../../open-sse/services/geminiThoughtSignatureStore.ts");
   clearGeminiThoughtSignatureMemoryForTests();
 
   const state: { signatureNamespace: string; pendingThoughtSignature?: string | null } = {

--- a/tests/unit/translator-resp-gemini-to-openai.test.ts
+++ b/tests/unit/translator-resp-gemini-to-openai.test.ts
@@ -7,6 +7,16 @@ const { translateNonStreamingResponse } =
   await import("../../open-sse/handlers/responseTranslator.ts");
 const { FORMATS } = await import("../../open-sse/translator/formats.ts");
 
+type OpenAIUsage = {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+};
+
+type OpenAIResponse = { usage?: OpenAIUsage };
+type OpenAIStreamEvent = { usage?: OpenAIUsage };
+
 function createStreamingState() {
   return {
     toolCalls: new Map(),
@@ -49,6 +59,69 @@ test("Gemini non-stream: single candidate text maps to one OpenAI choice", () =>
     completion_tokens: 5,
     total_tokens: 8,
   });
+});
+
+test("Gemini non-stream: cached input remains a subset of prompt input", () => {
+  const result = translateNonStreamingResponse(
+    {
+      response: {
+        responseId: "resp-cache",
+        modelVersion: "gemini-3.7-flash",
+        candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 46212,
+          candidatesTokenCount: 4,
+          totalTokenCount: 46216,
+          cachedContentTokenCount: 40929,
+        },
+      },
+    },
+    FORMATS.GEMINI,
+    FORMATS.OPENAI
+  );
+
+  assert.deepEqual((result as OpenAIResponse).usage, {
+    prompt_tokens: 46212,
+    completion_tokens: 4,
+    total_tokens: 46216,
+    prompt_tokens_details: { cached_tokens: 40929 },
+  });
+});
+
+test("Gemini non-stream: explicit zero cached input remains reported", () => {
+  const result = translateNonStreamingResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+      usageMetadata: {
+        promptTokenCount: 5,
+        candidatesTokenCount: 1,
+        totalTokenCount: 6,
+        cachedContentTokenCount: 0,
+      },
+    },
+    FORMATS.GEMINI,
+    FORMATS.OPENAI
+  );
+
+  assert.deepEqual((result as OpenAIResponse).usage?.prompt_tokens_details, { cached_tokens: 0 });
+});
+
+test("Gemini non-stream: invalid cached input is not exposed as a hit", () => {
+  const result = translateNonStreamingResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+      usageMetadata: {
+        promptTokenCount: 5,
+        candidatesTokenCount: 1,
+        totalTokenCount: 6,
+        cachedContentTokenCount: 6,
+      },
+    },
+    FORMATS.GEMINI,
+    FORMATS.OPENAI
+  );
+
+  assert.equal((result as OpenAIResponse).usage?.prompt_tokens_details, undefined);
 });
 
 test("Gemini non-stream: multiple candidates keep multimodal content, reasoning and tool calls", () => {
@@ -1126,6 +1199,133 @@ test("Gemini stream: checks lastParen before lastBracket when identifying partia
 // #3821-review LEDGER-4 — a signed native functionCall arriving while a textual
 // `<thinking>` wrapper opened in an earlier chunk is still buffered must flush that
 // buffered reasoning as reasoning_content, not silently discard it.
+test("Gemini stream: late usage without cache metadata preserves an earlier cache count", () => {
+  const state = createStreamingState();
+
+  geminiToOpenAIResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: {
+        promptTokenCount: 46212,
+        candidatesTokenCount: 2,
+        totalTokenCount: 46214,
+        cachedContentTokenCount: 40929,
+      },
+    },
+    state
+  );
+  const result =
+    geminiToOpenAIResponse(
+      {
+        candidates: [{ content: { parts: [] }, finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 46212,
+          candidatesTokenCount: 4,
+          totalTokenCount: 46216,
+        },
+      },
+      state
+    ) || [];
+
+  const finalUsage = result.find((event: OpenAIStreamEvent) => event.usage)?.usage;
+  assert.deepEqual(finalUsage, {
+    prompt_tokens: 46212,
+    completion_tokens: 4,
+    total_tokens: 46216,
+    prompt_tokens_details: { cached_tokens: 40929 },
+  });
+});
+
+test("Gemini stream: explicit zero cache usage remains reported", () => {
+  const state = createStreamingState();
+  const result =
+    geminiToOpenAIResponse(
+      {
+        candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 1,
+          totalTokenCount: 6,
+          cachedContentTokenCount: 0,
+        },
+      },
+      state
+    ) || [];
+
+  assert.deepEqual(result.find((event: OpenAIStreamEvent) => event.usage)?.usage.prompt_tokens_details, {
+    cached_tokens: 0,
+  });
+});
+
+test("Gemini stream: absent prompt and total fields preserve earlier usage", () => {
+  const state = createStreamingState();
+  geminiToOpenAIResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 2,
+        totalTokenCount: 102,
+        cachedContentTokenCount: 80,
+      },
+    },
+    state
+  );
+  const result = geminiToOpenAIResponse(
+    { candidates: [{ content: { parts: [] }, finishReason: "STOP" }], usageMetadata: { candidatesTokenCount: 5 } },
+    state
+  ) || [];
+  assert.deepEqual(result.find((event: OpenAIStreamEvent) => event.usage)?.usage, {
+    prompt_tokens: 100,
+    completion_tokens: 5,
+    total_tokens: 102,
+    prompt_tokens_details: { cached_tokens: 80 },
+  });
+});
+
+test("Gemini stream: invalid cache count clears an earlier hit", () => {
+  const state = createStreamingState();
+  geminiToOpenAIResponse(
+    {
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 2,
+        totalTokenCount: 102,
+        cachedContentTokenCount: 80,
+      },
+    },
+    state
+  );
+  const result = geminiToOpenAIResponse(
+    {
+      candidates: [{ content: { parts: [] }, finishReason: "STOP" }],
+      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 5, cachedContentTokenCount: 200 },
+    },
+    state
+  ) || [];
+  assert.equal(result.find((event: OpenAIStreamEvent) => event.usage)?.usage.prompt_tokens_details, undefined);
+});
+
+test("Gemini stream: invalid cached usage is not exposed as a hit", () => {
+  const state = createStreamingState();
+  const result =
+    geminiToOpenAIResponse(
+      {
+        candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 1,
+          totalTokenCount: 6,
+          cachedContentTokenCount: 6,
+        },
+      },
+      state
+    ) || [];
+
+  assert.equal(result.find((event: OpenAIStreamEvent) => event.usage)?.usage.prompt_tokens_details, undefined);
+});
+
 test("Gemini stream: open textual reasoning is flushed before a signed native tool call", () => {
   const state = createStreamingState();
 
@@ -1174,7 +1374,10 @@ test("Gemini stream: open textual reasoning is flushed before a signed native to
     "buffered textual reasoning must be flushed, not dropped, when a tool call arrives"
   );
   assert.equal(r2[toolIdx]?.choices[0].delta.tool_calls[0].id, "call-flush-1");
-  assert.ok(reasoningIdx >= 0 && toolIdx > reasoningIdx, "reasoning is emitted before the tool call");
+  assert.ok(
+    reasoningIdx >= 0 && toolIdx > reasoningIdx,
+    "reasoning is emitted before the tool call"
+  );
 });
 
 // #3821-review LEDGER-15 — a reasoning-only chunk interrupting a partially-buffered

--- a/tests/unit/usage-extractor.test.ts
+++ b/tests/unit/usage-extractor.test.ts
@@ -228,7 +228,7 @@ test("extractUsageFromResponse reads Gemini usageMetadata and thinking tokens", 
   assert.deepEqual(usage, {
     prompt_tokens: 11,
     completion_tokens: 7,
-    cached_tokens: 0,
+    cache_evidence: "unreported",
     reasoning_tokens: 2,
   });
 });
@@ -254,6 +254,7 @@ test("extractUsageFromResponse reads Gemini usageMetadata from the antigravity r
     prompt_tokens: 42,
     completion_tokens: 17,
     cached_tokens: 7,
+    cache_evidence: "hit",
     reasoning_tokens: 4,
   });
 });
@@ -270,9 +271,24 @@ test("extractUsageFromResponse prefers top-level usageMetadata over the envelope
   assert.deepEqual(usage, {
     prompt_tokens: 1,
     completion_tokens: 2,
-    cached_tokens: 0,
+    cache_evidence: "unreported",
     reasoning_tokens: 0,
   });
+});
+
+test("extractUsageFromResponse marks invalid Gemini cache counts", () => {
+  const usage = extractUsageFromResponse(
+    {
+      usageMetadata: {
+        promptTokenCount: 30,
+        candidatesTokenCount: 10,
+        cachedContentTokenCount: 31,
+      },
+    },
+    "gemini"
+  );
+  assert.equal(usage.cached_tokens, undefined);
+  assert.equal(usage.cache_evidence, "invalid");
 });
 
 test("extractUsageFromResponse surfaces Gemini cachedContentTokenCount as cached_tokens", () => {
@@ -294,6 +310,7 @@ test("extractUsageFromResponse surfaces Gemini cachedContentTokenCount as cached
     prompt_tokens: 30,
     completion_tokens: 13,
     cached_tokens: 12,
+    cache_evidence: "hit",
     reasoning_tokens: 3,
   });
 });


### PR DESCRIPTION
## Summary
- add a default-off local implicit-cache mode scoped to concrete Antigravity/AGY Gemini targets
- preserve cache evidence across wrapped, unwrapped, streaming, OpenAI, and Claude usage paths
- keep existing prompt-cache affinity while proving runtime-ineligible preferred accounts fall through
- persist bounded stream/non-stream cache evidence in call-log metadata without leaking internal fields to clients

## Verification
- focused source and observability suite: 323/323 passing
- full Vitest suite: 51 files, 465 tests passing
- core and no-implicit-any type checks passing
- package policy: 3,513 entries checked; 1,305 MCP source files checked
- diff check passing

## Known base and environment limits
⚠️ base-red inherited: #12732

Local full Node testing stalls in the inherited Adobe Firefly browser test. Local release builds were attempted with Turbopack and constrained webpack; worker processes were killed under WSL memory pressure, so no `dist/` was produced. This PR exists so clean CI runners can execute the build and package gates. No live Gemini pilot or production deployment has run.

## Release boundary
Release 1 covers implicit caching only. Explicit cache resources remain out of scope. Package install/upgrade/restart/rollback and the bounded live pilot remain required before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
