### PR TITLE
fix(translator): map Claude stop_sequences and stop to Gemini stopSequences

### DIFF
--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -1,9 +1,6 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
-import {
-  DEFAULT_SAFETY_SETTINGS,
-  cleanJSONSchemaForAntigravity,
-} from "../helpers/geminiHelper.ts";
+import { DEFAULT_SAFETY_SETTINGS, cleanJSONSchemaForAntigravity } from "../helpers/geminiHelper.ts";
 import { buildGeminiTools, sanitizeGeminiToolName } from "../helpers/geminiToolsSanitizer.ts";
 import {
   buildGeminiThoughtSignatureKey,
@@ -81,6 +78,10 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
     if (maxOutputTokens !== null) {
       result.generationConfig.maxOutputTokens = maxOutputTokens;
     }
+  }
+  if (body.stop_sequences !== undefined || body.stop !== undefined) {
+    const rawStop = body.stop_sequences ?? body.stop;
+    result.generationConfig.stopSequences = Array.isArray(rawStop) ? rawStop : [rawStop];
   }
 
   // ── System instruction ─────────────────────────────────────────

--- a/tests/unit/translator-claude-to-gemini.test.ts
+++ b/tests/unit/translator-claude-to-gemini.test.ts
@@ -478,3 +478,34 @@ test("Claude -> Gemini non-numeric budget_tokens falls through to effort path", 
     includeThoughts: true,
   });
 });
+
+test("Claude -> Gemini maps stop_sequences and stop to generationConfig.stopSequences", () => {
+  const result1 = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      stop_sequences: ["STOP", "\nHuman:"],
+    },
+    false
+  );
+  assert.deepEqual(result1.generationConfig.stopSequences, ["STOP", "\nHuman:"]);
+
+  const result2 = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      stop: "SINGLE_STOP",
+    },
+    false
+  );
+  assert.deepEqual(result2.generationConfig.stopSequences, ["SINGLE_STOP"]);
+
+  const result3 = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    },
+    false
+  );
+  assert.strictEqual(result3.generationConfig.stopSequences, undefined);
+});


### PR DESCRIPTION
## Summary

- Fixes an issue in direct Claude-to-Gemini request translation (`claudeToGeminiRequest`) where `stop_sequences` and `stop` were omitted from `result.generationConfig.stopSequences`.
- Ensures that Claude-formatted requests (`/v1/messages` or combo targets routed to Gemini) have their stop tokens properly forwarded, preventing models from continuing generation past intended delimiter boundaries.
- Aligns `claude-to-gemini.ts` with `openai-to-gemini.ts` and `claude-to-openai.ts`.

## Related Issues

- None (direct self-contained translator fix).

## Validation

- [x] Change type: provider (format translator)
- [x] Focused tests: `node --import tsx/esm --test tests/unit/translator-claude-to-gemini.test.ts` (19/19 pass)
- [x] `npm run lint` / ESLint passed with 0 errors on modified files
- [x] Reconciled with the current active release base (`release/v3.8.51`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/translator-claude-to-gemini.test.ts`
  - Added unit test asserting array `stop_sequences`, single `stop` strings, and omitted stop tokens.

## Coverage Notes

- Changes in `open-sse/translator/request/claude-to-gemini.ts` are 100% covered by the added test in `tests/unit/translator-claude-to-gemini.test.ts`.
- Coverage for `claudeToGeminiRequest` is preserved and improved.

## Reviewer Notes

- No migrations, database schema changes, or breaking changes.
- Safe, isolated logic within synchronous request translation.
