### PR TITLE
feat(providers): advertise free-tier capability in provider plugin manifest

### DIFF
--- a/changelog.d/features/12786-manifest-free-tier-capability.md
+++ b/changelog.d/features/12786-manifest-free-tier-capability.md
@@ -1,0 +1,1 @@
+- **feat(providers):** advertise a `free-tier` capability in the provider plugin manifest for every provider with documented free models, so sidecars and dashboards can filter free-capable providers without reading the quota catalog ([#12786](https://github.com/diegosouzapw/OmniRoute/pull/12786)) — thanks @maxmad64bis

--- a/open-sse/config/freeTierProviders.ts
+++ b/open-sse/config/freeTierProviders.ts
@@ -1,0 +1,24 @@
+/**
+ * freeTierProviders.ts — registration list of providers with documented free models.
+ *
+ * Derived from `FREE_MODEL_BUDGETS` (`./freeModelCatalog.data.ts`) filtered by
+ * `grantsFreeAccess` (`./freeModelCatalog.ts`), so a `discontinued` entry never
+ * grants access. Pure data — no imports outside `open-sse/config`, no module
+ * state — so it cannot introduce a cycle and `open-sse/config/providerPluginManifest.ts`
+ * stays a light leaf. The open-sse typecheck gate forbids open-sse → src imports;
+ * `src/shared/utils/freeModels.ts` reads the same source for dashboard use.
+ */
+
+import { FREE_MODEL_BUDGETS } from "./freeModelCatalog.data.ts";
+import { grantsFreeAccess } from "./freeModelCatalog.ts";
+
+const FREE_BUDGETS = FREE_MODEL_BUDGETS.filter((m) => grantsFreeAccess(m.freeType));
+
+export const FREE_TIER_PROVIDER_SET: ReadonlySet<string> = new Set(
+  FREE_BUDGETS.map((m) => m.provider)
+);
+
+export function hasFreeTierProvider(idOrAlias: string | undefined | null): boolean {
+  if (typeof idOrAlias !== "string") return false;
+  return FREE_TIER_PROVIDER_SET.has(idOrAlias);
+}

--- a/open-sse/config/providerPluginManifest.ts
+++ b/open-sse/config/providerPluginManifest.ts
@@ -1,10 +1,12 @@
 import type { RegistryEntry, RegistryModel } from "./providers/shared.ts";
 import { USAGE_FETCHER_PROVIDERS } from "../services/usage/fetcherProviders.ts";
 import { USAGE_SUPPORTED_PROVIDERS } from "../services/usage/supportedProviders.ts";
+import { hasFreeTierProvider } from "./freeTierProviders.ts";
 
 export type ProviderPluginCapability =
   | "apikey"
   | "custom-executor"
+  | "free-tier"
   | "oauth"
   | "passthrough-models"
   | "responses"
@@ -155,6 +157,9 @@ function capabilitiesFor(entry: RegistryEntry, eligible: boolean): ProviderPlugi
   }
   if (USAGE_SUPPORTED_PROVIDER_SET.has(entry.id)) {
     capabilities.add("usage-supported");
+  }
+  if ([entry.id, entry.alias].some(hasFreeTierProvider)) {
+    capabilities.add("free-tier");
   }
 
   return [...capabilities].sort();

--- a/scripts/check/check-docs-counts-sync.mjs
+++ b/scripts/check/check-docs-counts-sync.mjs
@@ -185,6 +185,9 @@ export function tallyDrift(checks, getContent) {
 function readCodeFacts() {
   const script = [
     'import {computeFreeModelTotals,FREE_MODEL_BUDGETS} from "./open-sse/config/freeModelCatalog.ts";',
+    'import {FREE_TIER_PROVIDER_SET} from "./open-sse/config/freeTierProviders.ts";',
+    'import {generateProviderPluginManifest} from "./open-sse/config/providerPluginManifestRegistry.ts";',
+    'import {REGISTRY} from "./open-sse/config/providers/index.ts";',
     'import {MODE_PACKS} from "./open-sse/services/autoCombo/modePacks.ts";',
     'import {ENGINE_IDS} from "./open-sse/services/compression/engineCatalog.ts";',
     'import {CLI_TOOLS} from "./src/shared/constants/cliTools.ts";',
@@ -232,7 +235,10 @@ function readCodeFacts() {
     "mcpTools:countUniqueMcpTools(cols),mcpScopes:sc.size,providers:pids.size,freeForever:ff.size,",
     "modePacks:Object.keys(MODE_PACKS),",
     "hardStop:FREE_MODEL_BUDGETS.filter(e=>e.hardStopGuaranteed===true).length,",
-    "trainsOnPrompts:FREE_MODEL_BUDGETS.filter(e=>e.trainsOnPrompts===true).length}));",
+    "trainsOnPrompts:FREE_MODEL_BUDGETS.filter(e=>e.trainsOnPrompts===true).length,",
+    "freeTierCount:FREE_TIER_PROVIDER_SET.size,",
+    "freeTierReg:FREE_TIER_PROVIDER_SET.size-[...FREE_TIER_PROVIDER_SET].filter(x=>!(x in REGISTRY)).length,",
+    'manifestFreeTier:generateProviderPluginManifest().providers.filter(p=>p.capabilities.includes("free-tier")).length}));',
   ].join("");
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docs-counts-"));
   try {
@@ -615,6 +621,23 @@ export function buildChecks() {
           strict: true,
           files: ["docs/reference/PROVIDER_REFERENCE.md"],
           validate: makeProviderReferenceValidator(f.providers),
+        },
+        // Gate: manifest emission vs catalogue intersection. Both numbers are
+        // live code facts from the same spawnSync computeur. The catalogue can
+        // name providers the registry does not serve yet (arcee-ai at
+        // 9d1a896c6), so the leaf raw size is informational — the gate
+        // compares the intersected count, never the raw size, and the script
+        // itself always exists so tallyDrift runs validate (skips null only).
+        {
+          label: "Manifest free-tier capability count (live code)",
+          actual: f.manifestFreeTier,
+          docKey: "free-tier capability",
+          strict: true,
+          files: ["scripts/check/check-docs-counts-sync.mjs"],
+          validate: () => ({
+            ok: f.manifestFreeTier === f.freeTierReg,
+            detail: `manifest ${f.manifestFreeTier} vs leaf∩registry ${f.freeTierReg} (leaf ${f.freeTierCount})`,
+          }),
         },
         {
           label: "SVG canonical numbers (live code)",

--- a/tests/unit/check-docs-counts-sync.test.ts
+++ b/tests/unit/check-docs-counts-sync.test.ts
@@ -20,6 +20,7 @@ const tally = tallyDrift as (
     docKey: string;
     strict: boolean;
     files: string[];
+    validate?: (content: string) => { ok: boolean; detail: string };
   }[],
   getContent: (file: string) => string | null
 ) => { strict: number; soft: number; lines: string[] };
@@ -567,4 +568,61 @@ test("neither claim fires on the other numbers the page is full of", () => {
     "$10 deposit unlock, 24M/mo boost, 800 output tokens, 2026-06-17.";
   assert.equal(makeValidator(7, HARD_STOP_CLAIM)(page).ok, true);
   assert.equal(makeValidator(13, TRAINING_CLAIM)(page).ok, true);
+});
+
+function freeTierCheck(freeTierCount: number, manifestFreeTier: number, freeTierReg?: number) {
+  const reg = freeTierReg ?? freeTierCount;
+  return {
+    label: "Manifest free-tier capability count (live code)",
+    actual: manifestFreeTier,
+    docKey: "free-tier capability",
+    strict: true,
+    files: ["scripts/check/check-docs-counts-sync.mjs"],
+    validate: () => ({
+      ok: manifestFreeTier === reg,
+      detail: `manifest ${manifestFreeTier} vs leaf∩registry ${reg} (leaf ${freeTierCount})`,
+    }),
+  };
+}
+
+test("gate flags STRICT when manifest free-tier count differs from leaf∩registry", () => {
+  const r = tally([freeTierCheck(5, 4, 5)], () => "live");
+  assert.equal(r.strict, 1);
+});
+
+test("gate passes when counts agree", () => {
+  const r = tally([freeTierCheck(5, 5, 5)], () => "live");
+  assert.equal(r.strict, 0);
+});
+
+test("gate passes on the arcee-ai shape: leaf=5, reg=4, manifest=4 (catalogue-only leaf)", () => {
+  // arcee-ai is in FREE_TIER_PROVIDER_SET (leaf) but absent from REGISTRY, so the
+  // prod gate compares the manifest against the intersection (reg), not the raw leaf.
+  const r = tally([freeTierCheck(5, 4, 4)], () => "live");
+  assert.equal(r.strict, 0);
+  // ...while the same manifest against the raw leaf (reg=leaf=5) must stay red.
+  const stale = tally([freeTierCheck(5, 4, 5)], () => "live");
+  assert.equal(stale.strict, 1);
+});
+
+test("gate skips when readCodeFacts fails (actual 0 fallback)", () => {
+  const r = tally(
+    [
+      {
+        label: "Code-derived counts",
+        actual: 0,
+        docKey: "code facts",
+        strict: false,
+        files: [] as string[],
+      },
+    ],
+    () => "live"
+  );
+  assert.equal(r.strict, 0);
+});
+
+test("buildChecks contains a free-tier gate", async () => {
+  const { buildChecks } = await import("../../scripts/check/check-docs-counts-sync.mjs");
+  const checks = (buildChecks as () => { label: string }[])();
+  assert.ok(checks.some((c) => c.label.includes("free-tier")));
 });

--- a/tests/unit/free-tier-providers.test.ts
+++ b/tests/unit/free-tier-providers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FREE_TIER_PROVIDER_SET,
+  hasFreeTierProvider,
+} from "../../open-sse/config/freeTierProviders.ts";
+
+describe("freeTierProviders leaf", () => {
+  it("contains a known free provider", () => {
+    assert.equal(hasFreeTierProvider("api-airforce"), true);
+  });
+  it("contains the documented alias target lookup (af is resolved by caller via entry.alias)", () => {
+    // The leaf stores canonical ids; alias resolution happens in capabilitiesFor
+    // via entry.alias. Document the contract: leaf answers ids, caller passes both.
+    assert.equal(FREE_TIER_PROVIDER_SET.size > 0, true);
+  });
+  it("rejects non-string input", () => {
+    assert.equal(hasFreeTierProvider(undefined), false);
+    assert.equal(hasFreeTierProvider(null), false);
+  });
+  it("keeps pollinations free despite discontinued entries", () => {
+    assert.equal(hasFreeTierProvider("pollinations"), true);
+  });
+  it("excludes a provider with no free models", () => {
+    assert.equal(hasFreeTierProvider("definitely-not-a-provider-xyz"), false);
+  });
+});

--- a/tests/unit/provider-plugin-manifest.test.ts
+++ b/tests/unit/provider-plugin-manifest.test.ts
@@ -8,6 +8,7 @@ import {
 import type { RegistryEntry } from "../../open-sse/config/providers/shared.ts";
 import { USAGE_FETCHER_PROVIDERS } from "../../open-sse/services/usage/fetcherProviders.ts";
 import { USAGE_SUPPORTED_PROVIDERS } from "../../open-sse/services/usage/supportedProviders.ts";
+import { hasFreeTierProvider } from "../../open-sse/config/freeTierProviders.ts";
 
 const registryFixture: Record<string, RegistryEntry> = {
   openai: {
@@ -260,4 +261,139 @@ test("usage-supported matches only on id, not alias (#10078)", () => {
     "fixture guard: claude must also be in USAGE_FETCHER_PROVIDERS for the divergence check"
   );
   assert.ok(entry.capabilities.includes("usage-fetch"));
+});
+
+test("manifest emits free-tier for a provider with documented free models", () => {
+  const entry = getProviderPluginManifestEntryFromRegistry(
+    {
+      ...registryFixture,
+      "api-airforce": {
+        id: "api-airforce",
+        alias: "af",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://api.airforce/v1/chat/completions",
+        authType: "apikey",
+        authHeader: "bearer",
+        defaultContextLength: 128000,
+        models: [{ id: "x-ai/grok-3", name: "Grok-3 (Free)" }],
+      },
+      "legacy-free": {
+        id: "legacy-free",
+        alias: "api-airforce",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://legacy.example/v1",
+        authType: "apikey",
+        authHeader: "bearer",
+        models: [{ id: "legacy-model", name: "Legacy" }],
+      },
+      "definitely-not-a-provider-xyz": {
+        id: "definitely-not-a-provider-xyz",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://xyz.example/v1",
+        authType: "apikey",
+        authHeader: "bearer",
+        models: [{ id: "xyz-model", name: "Xyz" }],
+      },
+      pollinations: {
+        id: "pollinations",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://text.pollinations.ai/v1",
+        authType: "optional",
+        authHeader: "bearer",
+        models: [{ id: "openai", name: "OpenAI (free)" }],
+      },
+    },
+    "api-airforce"
+  );
+  assert.ok(entry);
+  assert.ok(entry.capabilities.includes("free-tier"));
+});
+
+test("manifest emits free-tier via alias-only branch (id outside set, alias inside)", () => {
+  assert.equal(hasFreeTierProvider("legacy-free"), false);
+  assert.equal(hasFreeTierProvider("api-airforce"), true);
+  const entry = getProviderPluginManifestEntryFromRegistry(
+    {
+      ...registryFixture,
+      "legacy-free": {
+        id: "legacy-free",
+        alias: "api-airforce",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://legacy.example/v1",
+        authType: "apikey",
+        authHeader: "bearer",
+        models: [{ id: "legacy-model", name: "Legacy" }],
+      },
+    },
+    "legacy-free"
+  );
+  assert.ok(entry);
+  assert.ok(entry.capabilities.includes("free-tier"));
+});
+
+test("manifest omits free-tier for a provider with no free models", () => {
+  const entry = getProviderPluginManifestEntryFromRegistry(
+    {
+      ...registryFixture,
+      "definitely-not-a-provider-xyz": {
+        id: "definitely-not-a-provider-xyz",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://xyz.example/v1",
+        authType: "apikey",
+        authHeader: "bearer",
+        models: [{ id: "xyz-model", name: "Xyz" }],
+      },
+    },
+    "definitely-not-a-provider-xyz"
+  );
+  assert.ok(entry);
+  assert.equal(entry.capabilities.includes("free-tier"), false);
+});
+
+test("manifest emits free-tier for pollinations despite discontinued rows", () => {
+  const entry = getProviderPluginManifestEntryFromRegistry(
+    {
+      ...registryFixture,
+      pollinations: {
+        id: "pollinations",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://text.pollinations.ai/v1",
+        authType: "optional",
+        authHeader: "bearer",
+        models: [{ id: "openai", name: "OpenAI (free)" }],
+      },
+    },
+    "pollinations"
+  );
+  assert.ok(entry);
+  assert.ok(entry.capabilities.includes("free-tier"));
+});
+
+test("free-tier capability keeps capabilities sorted", () => {
+  const entry = getProviderPluginManifestEntryFromRegistry(
+    {
+      ...registryFixture,
+      "api-airforce": {
+        id: "api-airforce",
+        alias: "af",
+        format: "openai",
+        executor: "default",
+        baseUrl: "https://api.airforce/v1/chat/completions",
+        authType: "apikey",
+        authHeader: "bearer",
+        defaultContextLength: 128000,
+        models: [{ id: "x-ai/grok-3", name: "Grok-3 (Free)" }],
+      },
+    },
+    "api-airforce"
+  );
+  assert.ok(entry);
+  assert.deepEqual(entry.capabilities, [...entry.capabilities].sort());
 });


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

Sidecars and dashboards can now filter free-capable providers straight from the plugin manifest. A provider with documented free models carries a `free-tier` tag next to its existing capabilities (`usage-fetch`, `usage-supported`, ...), so consumers don't need to read the quota catalog. It's display metadata only — routing and quota logic are untouched.

The tag is derived live from the free-model catalog (77 providers at this writing) and only lights up for providers the registry actually serves (76 — one catalog entry, `arcee-ai`, has no registry entry yet). A STRICT docs gate fails CI if the manifest count ever drifts from the catalog.

## Related Issues

- Related to #12669 (catalog eligibility gating — this reads the same source)
- Related to #12744 (same "documented free tier" source on the decision side — this PR is the display side)

## Validation

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/free-tier-providers.test.ts` (new) — leaf set derivation: known free provider, alias contract, non-string rejection, `pollinations` despite `discontinued` rows, unknown id excluded (5/5 pass)
- `tests/unit/provider-plugin-manifest.test.ts` (extended) — 5 new emission cases, all pass (5/5): id branch, alias-only branch (`legacy-free`/`api-airforce`), unknown id omitted, `pollinations`, capabilities stay sorted (whole file 15/15 with the 10 pre-existing cases)
- `tests/unit/check-docs-counts-sync.test.ts` (extended) — gate form pins + `buildChecks()` contains a `free-tier` check; `node scripts/check/check-docs-counts-sync.mjs` shows `manifest 76 vs leaf∩registry 76 (leaf 77)` green

## Coverage Notes

- Changes `open-sse/config/` (new leaf `freeTierProviders.ts`, union +1 and `capabilitiesFor` branch in `providerPluginManifest.ts`) plus the docs-sync gate script. Covered by the three test files above; leaf is a pure derivation with no branches beyond the null-guard.
- Neighbor suites pass (`service-provider-plugin-manifest` 4/4, manifest route 10/10). One pre-existing failure is inherited from the red base, not this branch: the "gate exits 0 on synced repo" test trips on the 169-vs-170 migrations doc drift (#12732).

## Reviewer Notes

- One judgment call worth flagging: the gate compares the manifest count against the catalog∩registry intersection (76), not the raw catalog size (77), because `arcee-ai` is cataloged but has no registry entry yet. The raw size is logged in the gate detail line so the gap stays visible. If `arcee-ai` gets registered, both numbers move together and the gate stays green.
- No migrations, no flags, no routing changes. Single commit.
- Known asymmetry: `hasFreeTierProvider` matches exact ids only (no `resolveProviderId` — `open-sse` can't import from `src/`), unlike `providerHasFreeModels` which resolves aliases. An alias not declared in the entry's `alias` field is missed on the manifest side; callers must pass both id and alias (as `capabilitiesFor` does).

