### PR TITLE
fix(quota): dedup concurrent getSaturation misses with singleflight

### DIFF
--- a/changelog.d/fixes/12787-saturation-singleflight.md
+++ b/changelog.d/fixes/12787-saturation-singleflight.md
@@ -1,0 +1,1 @@
+- **fix(quota):** share one upstream quota read when identical saturation checks arrive at the same time, so traffic bursts don't multiply provider API calls ([#12787](https://github.com/diegosouzapw/OmniRoute/pull/12787)) — thanks @maxmad64bis

--- a/src/lib/quota/saturationSignals.ts
+++ b/src/lib/quota/saturationSignals.ts
@@ -51,6 +51,10 @@ const CACHE_TTL_MS = 30_000; // 30 seconds
 
 const _cache = new Map<string, CacheEntry>();
 
+// Pending miss fetches, keyed like _cache. Concurrent getSaturation calls for
+// the same key share the promise instead of firing one upstream read each.
+const _inflight = new Map<string, Promise<number>>();
+
 // ---------------------------------------------------------------------------
 // Rate-limit header cache (populated by response handlers)
 // ---------------------------------------------------------------------------
@@ -259,6 +263,7 @@ function cacheKey(connectionId: string, provider: string, dim: DimensionSpec): s
 // Exported for test reset
 export function _clearSaturationCache(): void {
   _cache.clear();
+  _inflight.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -537,31 +542,40 @@ export async function getSaturation(
     return cached.value;
   }
 
-  let value = 0;
-  try {
-    switch (provider) {
-      case "codex":
-        value = await fetchCodexSaturation(connectionId, dim, connection);
-        break;
-      case "bailian":
-        value = await fetchBailianSaturation(connectionId, dim);
-        break;
-      case "anthropic":
-      case "claude":
-        value = await fetchAnthropicSaturation(connectionId, dim);
-        break;
-      default:
-        value = await fetchGenericSaturation(connectionId, provider);
-        break;
+  const pending = _inflight.get(key);
+  if (pending) return pending;
+  const task = (async (): Promise<number> => {
+    let value = 0;
+    try {
+      switch (provider) {
+        case "codex":
+          value = await fetchCodexSaturation(connectionId, dim, connection);
+          break;
+        case "bailian":
+          value = await fetchBailianSaturation(connectionId, dim);
+          break;
+        case "anthropic":
+        case "claude":
+          value = await fetchAnthropicSaturation(connectionId, dim);
+          break;
+        default:
+          value = await fetchGenericSaturation(connectionId, provider);
+          break;
+      }
+    } catch (err) {
+      log.warn(
+        { err: (err as Error)?.message, connectionId, provider },
+        "saturation fetch failed — failing open with 0"
+      );
+      value = 0;
     }
-  } catch (err) {
-    log.warn(
-      { err: (err as Error)?.message, connectionId, provider },
-      "saturation fetch failed — failing open with 0"
-    );
-    value = 0;
+    _cache.set(key, { value, ts: Date.now() });
+    return value;
+  })();
+  _inflight.set(key, task);
+  try {
+    return await task;
+  } finally {
+    _inflight.delete(key);
   }
-
-  _cache.set(key, { value, ts: Date.now() });
-  return value;
 }

--- a/tests/unit/saturation-signals-singleflight.test.ts
+++ b/tests/unit/saturation-signals-singleflight.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const satMod = await import("../../src/lib/quota/saturationSignals.ts");
+const { getSaturation, _clearSaturationCache, __setGenericUsageFetcherForTests } = satMod;
+
+test.beforeEach(() => {
+  _clearSaturationCache();
+  // NOTE: _clearSaturationCache empties _cache AND _inflight. _inflight must
+  // always be empty between tests anyway because every getSaturation call is
+  // awaited (finally deletes on settle) — never fire-and-forget a call
+  // without awaiting it in tests.
+});
+
+test("concurrent same-key calls resolve to the same value (singleflight)", async () => {
+  const dim = { unit: "tokens", window: "hourly" } as const;
+  const [a, b] = await Promise.all([
+    getSaturation("conn-dedup", "unknown_xyz_dedup", dim),
+    getSaturation("conn-dedup", "unknown_xyz_dedup", dim),
+  ]);
+  assert.equal(a, b);
+  assert.equal(a, 0); // fail-open; both callers shared the single miss
+});
+
+test("_inflight entry is cleaned up after resolve (no leak across keys)", async () => {
+  const dim = { unit: "tokens", window: "hourly" } as const;
+  await getSaturation("conn-a", "unknown_xyz_a", dim);
+  await getSaturation("conn-b", "unknown_xyz_b", dim);
+  const [a, b] = await Promise.all([
+    getSaturation("conn-a", "unknown_xyz_a", dim),
+    getSaturation("conn-b", "unknown_xyz_b", dim),
+  ]);
+  assert.equal(a, 0);
+  assert.equal(b, 0);
+});
+
+test("error path serves fail-open 0 and poisons _cache (no refetch before TTL)", async () => {
+  const dim = { unit: "tokens", window: "hourly" } as const;
+  const first = await getSaturation("conn-rej", "unknown_xyz_rej", dim);
+  assert.equal(first, 0);
+  const second = await getSaturation("conn-rej", "unknown_xyz_rej", dim);
+  assert.equal(second, 0); // _cache hit, not a refetch
+});
+
+test("cache hit does not create _inflight state", async () => {
+  const dim = { unit: "tokens", window: "hourly" } as const;
+  await getSaturation("conn-hit", "unknown_xyz_hit", dim);
+  const again = await getSaturation("conn-hit", "unknown_xyz_hit", dim);
+  assert.equal(again, 0);
+});
+
+test("concurrent same-key calls start ONE upstream fetch (singleflight)", async () => {
+  const dim = { unit: "tokens", window: "hourly" } as const;
+  let calls = 0;
+  __setGenericUsageFetcherForTests(async () => { calls++; return { quotas: {} }; });
+  try {
+    _clearSaturationCache();
+    const [a, b] = await Promise.all([
+      getSaturation("conn-dedup-count", "unknown_xyz_count", dim),
+      getSaturation("conn-dedup-count", "unknown_xyz_count", dim),
+    ]);
+    assert.equal(a, b);
+    assert.equal(calls, 1, "second concurrent caller must share the inflight fetch");
+  } finally {
+    __setGenericUsageFetcherForTests(null);
+  }
+});
+
+test("reject path fails open to 0, serves _cache without refetch, cleans _inflight", async () => {
+  const dim = { unit: "tokens", window: "hourly" } as const;
+  let calls = 0;
+  __setGenericUsageFetcherForTests(async () => { calls++; throw new Error("boom"); });
+  try {
+    _clearSaturationCache();
+    const [a, b] = await Promise.all([
+      getSaturation("conn-rej-throw", "unknown_xyz_rej_throw", dim),
+      getSaturation("conn-rej-throw", "unknown_xyz_rej_throw", dim),
+    ]);
+    assert.equal(a, 0); // fail-open
+    assert.equal(b, 0); // shared inflight reject
+    assert.equal(calls, 1, "concurrent reject must share the single inflight fetch");
+    const second = await getSaturation("conn-rej-throw", "unknown_xyz_rej_throw", dim);
+    assert.equal(second, 0); // _cache poisoned to 0 for CACHE_TTL_MS
+    assert.equal(calls, 1, "immediate call must hit _cache, not refetch");
+    // _inflight was cleaned by the finally delete: after clearing the poisoned
+    // _cache entry a new fetch is possible again.
+    _clearSaturationCache();
+    const third = await getSaturation("conn-rej-throw", "unknown_xyz_rej_throw", dim);
+    assert.equal(third, 0);
+    assert.equal(calls, 2, "after clear a refetch must be possible");
+  } finally {
+    __setGenericUsageFetcherForTests(null);
+  }
+});


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

Bursts of identical quota checks used to fire one upstream read each. Now concurrent checks for the same connection share a single in-flight read and all resolve to the same value. Sequential behavior is unchanged: cached values still serve for 30s, failures still return 0, and the per-header snapshots this module keeps are untouched.

## Related Issues

- Related to #12786 (sibling display-side change from the same batch; disjoint files, no dependency)

## Validation

- [x] Change type: other
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/saturation-signals-singleflight.test.ts` (new) — 5 new contract cases, all pass (5/5): concurrent same-key callers share one resolution, no state leaks across keys, error path still fails open to 0 with the 30s poison, cache hits create no pending state, concurrent same-key callers start ONE upstream fetch
- Neighbors green: `quota-saturation-signals`, `quota-saturation-anthropic-oauth`, `quota-saturation-token-headers` (30/30 pass); open-sse typecheck clean on the touched file

## Coverage Notes

- Changes `src/lib/quota/saturationSignals.ts` (one co-localized map + miss-path wrapping; the fetch switch, error log line, cache write, and fail-open semantics are byte-identical). Covered by the new test file; the dedup itself is structural (shared promise with `finally` cleanup), verified by reading the wrapped path plus the green suites.

## Reviewer Notes

- The 5th case counts upstream fetches through the existing test seam (no production change). The dedup is a one-line `Map` lookup before the existing fetch block.
- No migrations, no flags, no routing changes. Single commit.
