### PR TITLE
fix(db): ignore non-finite rate_limited_until writes, preserve null clear

### DIFF
--- a/changelog.d/fixes/12788-ratelimit-write-guard.md
+++ b/changelog.d/fixes/12788-ratelimit-write-guard.md
@@ -1,0 +1,1 @@
+- **fix(db):** ignore expired or invalid rate-limit cooldown writes so a stale timestamp can't lock a connection that should be usable — clearing still works as before ([#12788](https://github.com/diegosouzapw/OmniRoute/pull/12788)) — thanks @maxmad64bis

--- a/src/lib/db/providers/rateLimit.ts
+++ b/src/lib/db/providers/rateLimit.ts
@@ -28,6 +28,11 @@ interface DbLike {
  * @param until - Epoch ms when the rate limit expires (null to clear)
  */
 export function setConnectionRateLimitUntil(connectionId: string, until: number | null): void {
+  // Guard: never persist a non-finite or already-expired timestamp. The TEXT
+  // column would store "NaN"/"Infinity" and pollute every future read. null
+  // is the only clear path (via clearConnectionRateLimit); past/zero
+  // timestamps are noops so an expired write cannot overwrite a live row.
+  if (until !== null && (!Number.isFinite(until) || until <= Date.now())) return;
   const db = getDbInstance() as unknown as DbLike;
   db.prepare(
     "UPDATE provider_connections SET rate_limited_until = ?, updated_at = ? WHERE id = ?"

--- a/tests/unit/db-rate-limit-guard.test.ts
+++ b/tests/unit/db-rate-limit-guard.test.ts
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-ratelimit-guard-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts") as typeof import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts") as typeof import("../../src/lib/db/providers.ts");
+const {
+  setConnectionRateLimitUntil,
+  clearConnectionRateLimit,
+  isConnectionRateLimited,
+} = providersDb;
+
+function readRateLimitedUntil(connectionId: string): unknown {
+  const db = (
+    core as unknown as {
+      getDbInstance: () => {
+        prepare: (sql: string) => {
+          get: (id: string) => { rate_limited_until: unknown } | undefined;
+        };
+      };
+    }
+  ).getDbInstance();
+  return db
+    .prepare("SELECT rate_limited_until FROM provider_connections WHERE id = ?")
+    .get(connectionId)?.rate_limited_until ?? null;
+}
+
+async function resetStorage() {
+  core.resetDbInstance();
+  // Retry loop copied from db-providers-crud.test.ts:17-30 (Windows EBUSY/EPERM).
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      }
+      break;
+    } catch (error: unknown) {
+      const code = (error as { code?: string } | null)?.code;
+      if ((code === "EBUSY" || code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  // No retry here (unlike resetStorage): teardown-only, Linux CI; Windows
+  // EBUSY surfaces in beforeEach retries, not here.
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+async function seedConnection(): Promise<string> {
+  const connection = await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "Guard probe",
+    apiKey: "guard-key",
+  });
+  return (connection as { id: string }).id;
+}
+
+test("ignores NaN (row unchanged)", async () => {
+  const id = await seedConnection();
+  setConnectionRateLimitUntil(id, NaN);
+  assert.equal(readRateLimitedUntil(id), null);
+});
+
+test("ignores Infinity and -Infinity", async () => {
+  const id = await seedConnection();
+  setConnectionRateLimitUntil(id, Infinity);
+  setConnectionRateLimitUntil(id, -Infinity);
+  assert.equal(readRateLimitedUntil(id), null);
+});
+
+test("ignores past timestamps and 0 (documented noop; clear path is null)", async () => {
+  const id = await seedConnection();
+  setConnectionRateLimitUntil(id, Date.now() - 1000);
+  setConnectionRateLimitUntil(id, 0);
+  assert.equal(readRateLimitedUntil(id), null);
+});
+
+test("writes future timestamps", async () => {
+  const id = await seedConnection();
+  const until = Date.now() + 60_000;
+  setConnectionRateLimitUntil(id, until);
+  assert.equal(Number(readRateLimitedUntil(id)), until);
+  assert.equal(isConnectionRateLimited(id), true);
+});
+
+test("preserves null clear (non-regression for clearConnectionRateLimit)", async () => {
+  const id = await seedConnection();
+  setConnectionRateLimitUntil(id, Date.now() + 60_000);
+  clearConnectionRateLimit(id);
+  assert.equal(readRateLimitedUntil(id), null);
+  assert.equal(isConnectionRateLimited(id), false);
+});
+
+test("expired write does not overwrite a live row (future preserved)", async () => {
+  const id = await seedConnection();
+  const future = Date.now() + 60_000;
+  setConnectionRateLimitUntil(id, future);
+  setConnectionRateLimitUntil(id, Date.now() - 1000);
+  assert.equal(Number(readRateLimitedUntil(id)), future);
+  assert.equal(isConnectionRateLimited(id), true);
+});
+
+// Without the guard the TEXT column stores the string "NaN" — rejected by
+// current readers, but hygiene demands never writing it.


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

Rate-limit cooldowns are timestamps in the database, and until now any value got written — including ones that make no sense, like `NaN`, or ones already in the past. A stale write could leave a connection looking locked (or unlocked) at the wrong time. Now only future timestamps are stored; anything expired or invalid is quietly skipped, and clearing a cooldown works exactly as before.

## Related Issues

- Related to #12786 and #12787 (sibling changes from the same batch; disjoint files, no dependency)

## Validation

- [x] Change type: DB
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/db-rate-limit-guard.test.ts` (new) — 6 cases: `NaN` ignored, ±`Infinity` ignored, past/`0` ignored, future writes through, `null` clear preserved, expired write doesn't overwrite a live row (6/6 pass; 3 fail before the guard as designed)
- Neighbors green: every suite under `tests/unit` that calls `setConnectionRateLimitUntil` — `db-providers-crud`, `db-providers-split`, `antigravity-429-quota-cooldown`, `persist-429-cooldown-account-fallback`, `cooldown-epoch-string-3954`, `mark-account-unavailable-numeric-epoch-guard` (82/82 pass)

## Coverage Notes

- Changes `src/lib/db/providers/rateLimit.ts` (one fused guard + comment at the head of `setConnectionRateLimitUntil`; readers, `markConnectionRateLimitedUntil`, and `clearConnectionRateLimit` untouched). Covered by the new test file; no new branches beyond the guard itself.

## Reviewer Notes

- One deliberate call: past timestamps are noops rather than implicit clears, so an expired write can never overwrite a live future row — the only clear path stays `null` via `clearConnectionRateLimit`. If any caller relied on writing the past to "unlock" a row, that pattern now needs an explicit clear (no such caller found in the test suites above).
- No migrations, no flags, no routing changes. Single commit.






