### PR TITLE
fix(auto-combo): stop neutral snapshot scoring on observed tier/quality/breaker

### DIFF
--- a/changelog.d/fixes/12794-snapshot-scoring.md
+++ b/changelog.d/fixes/12794-snapshot-scoring.md
@@ -1,0 +1,1 @@
+- **fix(auto-combo):** snapshot scoring uses the observed per-connection account tier and per-model quality instead of neutral constants, and circuit-open providers rank lower at build time ([#12794](https://github.com/diegosouzapw/OmniRoute/pull/12794)) — thanks @maxmad64bis

--- a/open-sse/services/autoCombo/scoring.ts
+++ b/open-sse/services/autoCombo/scoring.ts
@@ -207,6 +207,19 @@ export function calculateTierScore(
   return Math.min(1, baseScore * 0.8 + resetBonus * 0.2);
 }
 
+/**
+ * Project the account tier from a provider connection row.
+ * Tier whitelist in ONE place: test and combo.ts import this, never mirror it.
+ */
+export function projectAccountTier(
+  row: Record<string, unknown> | undefined
+): "ultra" | "pro" | "standard" | "free" | undefined {
+  const psd = row?.providerSpecificData as Record<string, unknown> | undefined;
+  const raw = row?.accountTier ?? psd?.accountTier;
+  const v = typeof raw === "string" ? raw.toLowerCase() : undefined;
+  return v === "ultra" || v === "pro" || v === "standard" || v === "free" ? v : undefined;
+}
+
 function calculateTierAffinity(
   candidate: ProviderCandidate,
   hint: RoutingHint | undefined | null

--- a/open-sse/services/autoCombo/snapshotBreaker.ts
+++ b/open-sse/services/autoCombo/snapshotBreaker.ts
@@ -1,0 +1,31 @@
+import { getCircuitBreaker } from "../../../src/shared/utils/circuitBreaker.ts";
+
+export type BreakerState = "CLOSED" | "HALF_OPEN" | "OPEN";
+
+/**
+ * Build-time breaker state per provider. Any other state (e.g. DEGRADED) and a
+ * failed lookup leave the provider absent, so it scores neutral.
+ */
+export function readBreakerStates(providers: Iterable<string>): Map<string, BreakerState> {
+  const states = new Map<string, BreakerState>();
+  for (const provider of providers) {
+    try {
+      const state = getCircuitBreaker(provider).getStatus().state as string;
+      if (state === "OPEN" || state === "HALF_OPEN" || state === "CLOSED") {
+        states.set(provider, state);
+      }
+    } catch {
+      // An unreadable breaker leaves the provider neutral.
+    }
+  }
+  return states;
+}
+
+/** Snapshot health factor: OPEN 0, CLOSED 1, HALF_OPEN or unknown 0.5 (neutral). */
+export function snapshotHealthFactor(
+  states: ReadonlyMap<string, BreakerState> | undefined,
+  provider: string
+): number {
+  const state = states?.get(provider);
+  return state === "OPEN" ? 0 : state === "CLOSED" ? 1 : 0.5;
+}

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -26,6 +26,8 @@ import {
   type AutoTier,
 } from "./suffixComposition";
 import { classifyTier } from "../tierResolver";
+import { getQualityScore } from "../routing/quality.ts";
+import { readBreakerStates, snapshotHealthFactor, type BreakerState } from "./snapshotBreaker.ts";
 import type { AutoVariant } from "./autoPrefix";
 import { buildFamilyCandidateFilter, type ModelFamily } from "./modelFamily";
 import { getHiddenModelsByProvider } from "@/models";
@@ -111,6 +113,8 @@ export interface VirtualAutoComboCandidate {
   resolvedSupportsVision?: boolean;
   resolvedReasoning?: boolean;
   resolvedSupportsThinking?: boolean;
+  /** Observed feedback quality 0..1 (the same signal as ProviderCandidate.quality). */
+  quality?: number | null;
   /**
    * Why STRICT_ZERO_COST would exclude this candidate, or null when it would
    * not. Only populated for the read-only inspector build (`skip`), where the
@@ -544,7 +548,7 @@ function yieldVirtualAutoPreparationTurn(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-async function attachPreparedCapabilityValues(
+export async function attachPreparedCapabilityValues(
   candidates: readonly VirtualAutoComboCandidate[],
   state: PreparedCapabilityState
 ): Promise<VirtualAutoComboCandidate[]> {
@@ -591,7 +595,11 @@ async function attachPreparedCapabilityValues(
         await yieldVirtualAutoPreparationTurn();
       }
     }
-    prepared.push({ ...candidate, ...values });
+    prepared.push({
+      ...candidate,
+      ...values,
+      quality: getQualityScore(candidate.provider, candidate.model),
+    });
   }
   return prepared;
 }
@@ -846,7 +854,8 @@ export async function prepareVirtualAutoComboInputs(
  */
 export function computeSnapshotWeights(
   candidates: readonly VirtualAutoComboCandidate[],
-  weights: ScoringWeights
+  weights: ScoringWeights,
+  breakerByProvider?: ReadonlyMap<string, BreakerState>
 ): Map<string, number> {
   const scores = new Map<string, number>();
   for (const c of candidates) {
@@ -884,8 +893,10 @@ export function computeSnapshotWeights(
     // (no runtime data at snapshot time, so equal baseline)
     if (weights.latencyInv > 0) score += weights.latencyInv * 0.5;
 
-    // health + quota: no runtime telemetry at snapshot time → neutral baseline
-    score += (weights.health + weights.quota) * 0.5;
+    // health: build-time breaker state (OPEN 0, CLOSED 1, else neutral 0.5); quota stays neutral
+    score += weights.health * snapshotHealthFactor(breakerByProvider, c.provider);
+    score += weights.quota * 0.5;
+    score += (weights.quality ?? 0) * (Number.isFinite(c.quality) ? Number(c.quality) : 0.5);
 
     scores.set(c.modelStr, Math.min(score, 1));
   }
@@ -1086,7 +1097,8 @@ export async function createVirtualAutoComboFromPrepared(
   }
 
   const providerPool = [...new Set(effectivePool.map((c) => c.provider))];
-  const snapshotScores = computeSnapshotWeights(effectivePool, weights);
+  const breakerStates = readBreakerStates(providerPool);
+  const snapshotScores = computeSnapshotWeights(effectivePool, weights, breakerStates);
   const models = effectivePool.map((candidate, index) => ({
     id: `virtual-auto-${variant || "default"}-${index + 1}-${candidate.provider}`,
     kind: "model" as const,

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -33,7 +33,7 @@ import { rejectRetiredAutoComboCandidates } from "./modelLifecycle.ts";
 import { createComboContext } from "./combo/context.ts";
 import { phaseComboSetup } from "./combo/comboSetup.ts";
 
-import { type ProviderCandidate } from "./autoCombo/scoring.ts";
+import { projectAccountTier, type ProviderCandidate } from "./autoCombo/scoring.ts";
 
 import { getSessionConnection } from "./sessionManager.ts";
 import { getOAuthSessionAvailability } from "./oauthSessionOccupancy.ts";
@@ -488,8 +488,15 @@ export async function buildAutoCandidates(
         latencyStdDev,
         errorRate,
         ...speedTelemetry,
-        accountTier: "standard" as const,
-        quotaResetIntervalSecs: 86400,
+        accountTier: projectAccountTier(connection as Record<string, unknown> | undefined),
+        quotaResetIntervalSecs: (() => {
+          const tierConn = connection as Record<string, unknown> | undefined;
+          const tierPsd = tierConn?.providerSpecificData as Record<string, unknown> | undefined;
+          const rawInterval = tierConn?.quotaResetIntervalSecs ?? tierPsd?.quotaResetIntervalSecs;
+          return typeof rawInterval === "number" && Number.isFinite(rawInterval) && rawInterval > 0
+            ? rawInterval
+            : 86400;
+        })(),
         contextAffinity,
         sessionAvailability,
         resetWindowAffinity,

--- a/tests/unit/combo-auto-tier.test.ts
+++ b/tests/unit/combo-auto-tier.test.ts
@@ -1,0 +1,38 @@
+// tests/unit/combo-auto-tier.test.ts — runner node:test
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { calculateTierScore } from "../../open-sse/services/autoCombo/scoring.ts";
+
+describe("combo auto tier projection", () => {
+  it("ultra > pro > standard > free discriminant (order only, no absolutes)", () => {
+    const ultra = calculateTierScore("ultra", 86400);
+    const pro = calculateTierScore("pro", 86400);
+    const std = calculateTierScore("standard", 86400);
+    const free = calculateTierScore("free", 86400);
+    // Formula is base*0.8 + resetBonus*0.2 — assert order, never absolute values
+    assert.ok(ultra > pro && pro > std && std > free);
+  });
+  it("unknown tier falls back to standard base (order preserved)", () => {
+    const undef = calculateTierScore(undefined, 86400);
+    const std = calculateTierScore("standard", 86400);
+    assert.equal(undef, std);
+  });
+  it("resetBonus short interval higher than long (same tier)", () => {
+    const sShort = calculateTierScore("standard", 3600);
+    const sLong = calculateTierScore("standard", 86400);
+    assert.ok(sShort > sLong);
+  });
+  it("projected tier discriminates vs neutral (shared helper, no file read)", async () => {
+    // Imports the SAME pure helper combo.ts uses — no local
+    // mirror, so prod/test divergence fails here instead of shipping green.
+    const { projectAccountTier } = await import("../../open-sse/services/autoCombo/scoring.ts");
+    const sUltra = calculateTierScore(projectAccountTier({ accountTier: "ultra" }), 86400);
+    const sNeutral = calculateTierScore(projectAccountTier({}), 86400);
+    const sPsd = calculateTierScore(
+      projectAccountTier({ providerSpecificData: { accountTier: "pro" } }),
+      86400
+    );
+    assert.ok(sUltra > sNeutral, `ultra ${sUltra} should exceed neutral ${sNeutral}`);
+    assert.ok(sPsd > sNeutral, `psd-pro ${sPsd} should exceed neutral ${sNeutral}`);
+  });
+});

--- a/tests/unit/virtualFactory-snapshot-breaker.test.ts
+++ b/tests/unit/virtualFactory-snapshot-breaker.test.ts
@@ -1,0 +1,90 @@
+// tests/unit/virtualFactory-snapshot-breaker.test.ts
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeSnapshotWeights,
+  type VirtualAutoComboCandidate,
+} from "../../open-sse/services/autoCombo/virtualFactory.ts";
+import type { ScoringWeights } from "../../open-sse/services/autoCombo/scoring.ts";
+
+describe("computeSnapshotWeights breaker and quality", () => {
+  const weights: ScoringWeights = {
+    quota: 0.1,
+    health: 0.3,
+    costInv: 0.05,
+    latencyInv: 0.05,
+    taskFit: 0.05,
+    stability: 0.05,
+    tierPriority: 0.05,
+    tierAffinity: 0,
+    specificityMatch: 0,
+    contextAffinity: 0,
+    sessionAvailability: 0.05,
+    resetWindowAffinity: 0,
+    connectionDensity: 0.05,
+    quality: 0.1,
+    reliability: 0,
+  } as ScoringWeights;
+  type BreakerMap = ReadonlyMap<string, "CLOSED" | "HALF_OPEN" | "OPEN">;
+  it("OPEN scores lower than CLOSED (same quality)", () => {
+    const c: VirtualAutoComboCandidate = {
+      provider: "openai",
+      model: "gpt-4o",
+      modelStr: "openai/gpt-4o",
+      connectionId: null,
+      costPer1MTokens: 5,
+      quality: 0.8,
+    };
+    const open: BreakerMap = new Map([["openai", "OPEN"]]);
+    const closed: BreakerMap = new Map([["openai", "CLOSED"]]);
+    const sOpen = computeSnapshotWeights([c], weights, open).get("openai/gpt-4o")!;
+    const sClosed = computeSnapshotWeights([c], weights, closed).get("openai/gpt-4o")!;
+    assert.ok(sClosed > sOpen, `closed ${sClosed} should > open ${sOpen}`);
+  });
+  it("HALF_OPEN is midpoint, absent breaker → neutral 0.5", () => {
+    const c: VirtualAutoComboCandidate = {
+      provider: "openai",
+      model: "gpt-4o",
+      modelStr: "openai/gpt-4o",
+      connectionId: null,
+      costPer1MTokens: 5,
+    };
+    const half: BreakerMap = new Map([["openai", "HALF_OPEN"]]);
+    const sHalf = computeSnapshotWeights([c], weights, half).get("openai/gpt-4o")!;
+    const sNone = computeSnapshotWeights([c], weights).get("openai/gpt-4o")!;
+    const sOpen = computeSnapshotWeights(
+      [c],
+      weights,
+      new Map([["openai", "OPEN"]]) as BreakerMap
+    ).get("openai/gpt-4o")!;
+    const sClosed = computeSnapshotWeights(
+      [c],
+      weights,
+      new Map([["openai", "CLOSED"]]) as BreakerMap
+    ).get("openai/gpt-4o")!;
+    assert.ok(sHalf > sOpen && sHalf < sClosed);
+    // absent → existing 0.5* health — between open and closed
+    assert.ok(sNone > sOpen && sNone < sClosed);
+  });
+  it("quality cold 0.5 vs hot 0.9 discriminant when weights.quality>0", () => {
+    const cold: VirtualAutoComboCandidate = {
+      provider: "openai",
+      model: "gpt-4o",
+      modelStr: "openai/gpt-4o",
+      connectionId: null,
+      costPer1MTokens: 5,
+      quality: undefined,
+    };
+    const hot: VirtualAutoComboCandidate = {
+      provider: "openai",
+      model: "gpt-4o",
+      modelStr: "openai/gpt-4o",
+      connectionId: null,
+      costPer1MTokens: 5,
+      quality: 0.9,
+    };
+    const sCold = computeSnapshotWeights([cold], weights).get("openai/gpt-4o")!;
+    const sHot = computeSnapshotWeights([hot], weights).get("openai/gpt-4o")!;
+    assert.ok(sHot > sCold);
+  });
+});

--- a/tests/unit/virtualFactory-snapshot-quality.test.ts
+++ b/tests/unit/virtualFactory-snapshot-quality.test.ts
@@ -1,0 +1,75 @@
+// tests/unit/virtualFactory-snapshot-quality.test.ts
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeSnapshotWeights,
+  type VirtualAutoComboCandidate,
+} from "../../open-sse/services/autoCombo/virtualFactory.ts";
+import type { ScoringWeights } from "../../open-sse/services/autoCombo/scoring.ts";
+import { createModelCapabilityResolutionSnapshot } from "../../src/lib/modelCapabilities.ts";
+
+describe("virtualFactory snapshot quality", () => {
+  it("factory-built candidate carries finite quality (attach path, both pools)", async () => {
+    // Exercises the REAL hydration path: push a raw candidate through
+    // attachPreparedCapabilityValues:547-598 (covers regular + family pools —
+    // both go through attach, so one call proves both).
+    const { attachPreparedCapabilityValues } =
+      await import("../../open-sse/services/autoCombo/virtualFactory.ts");
+    const raw: VirtualAutoComboCandidate[] = [
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        modelStr: "openai/gpt-4o",
+        connectionId: null,
+        costPer1MTokens: 5,
+      },
+    ];
+    const state = {
+      byTarget: new Map(),
+      resolvedSinceYield: 0,
+      resolutionSnapshot: createModelCapabilityResolutionSnapshot(),
+    };
+    const out = await attachPreparedCapabilityValues(raw, state);
+    const q = out[0]?.quality;
+    assert.ok(
+      typeof q === "number" && Number.isFinite(q) && q >= 0 && q <= 1,
+      `quality ${q} must be finite 0..1`
+    );
+  });
+  it("hot quality outranks cold through computeSnapshotWeights", () => {
+    const weights = {
+      quota: 0.1,
+      health: 0.1,
+      quality: 0.3,
+      taskFit: 0,
+      stability: 0,
+      tierPriority: 0,
+      costInv: 0,
+      latencyInv: 0,
+    } as ScoringWeights;
+    const cold: VirtualAutoComboCandidate = {
+      provider: "openai",
+      model: "gpt-4o",
+      modelStr: "openai/gpt-4o",
+      connectionId: null,
+      costPer1MTokens: 5,
+      quality: 0.5,
+    };
+    const hot: VirtualAutoComboCandidate = {
+      provider: "openai",
+      model: "gpt-4o",
+      modelStr: "openai/gpt-4o",
+      connectionId: null,
+      costPer1MTokens: 5,
+      quality: 0.9,
+    };
+    const sCold = computeSnapshotWeights([cold], weights).get("openai/gpt-4o")!;
+    const sHot = computeSnapshotWeights([hot], weights).get("openai/gpt-4o")!;
+    assert.ok(sHot > sCold, `hot ${sHot} should exceed cold ${sCold}`);
+  });
+  it("hydration stores a finite 0..1 quality (not NaN)", async () => {
+    const { getQualityScore } = await import("../../open-sse/services/routing/quality.ts");
+    const q = getQualityScore("openai", "gpt-4o");
+    assert.ok(typeof q === "number" && Number.isFinite(q) && q >= 0 && q <= 1);
+  });
+});


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

Auto-combo's snapshot scoring treated every candidate the same on three factors: all accounts looked "standard", all models looked average quality, and a tripped circuit breaker (the flag that says "this provider is failing, stop sending traffic") counted the same as a healthy one. This PR feeds the observed values in instead, so an Ultra account outranks a free one, a proven model outranks an untested one, and a failing provider sinks to the bottom at build time. It doesn't touch prices or budgets — that's a separate PR.

## Related Issues

- Related to #12480 (multi-account quota exhaustion reporting)

## Validation

- [x] Change type: routing
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/combo-auto-tier.test.ts` (new, 4 cases: tier order ultra > pro > standard > free, unknown-tier fallback, reset-interval bonus, shared-helper discrimination)
- `tests/unit/virtualFactory-snapshot-quality.test.ts` (new, 3 cases: attach path carries finite quality, hot > cold weighting, tracker value finite)
- `tests/unit/virtualFactory-snapshot-breaker.test.ts` (new, 3 cases: OPEN < CLOSED, HALF_OPEN midpoint + absent neutral, cold vs hot quality)

Focused suite: 10 passed. Neighbors (`snapshot-weights`, `auto-combo-scoring-clamp`, `combo-scoring-weights-schema`) 27 passed. `typecheck:core` clean, `check:cycles` clean, `check:known-symbols` clean.

## Coverage Notes

Touches `open-sse/services/combo.ts`, `open-sse/services/autoCombo/virtualFactory.ts`, `open-sse/services/autoCombo/scoring.ts`, and the new `open-sse/services/autoCombo/snapshotBreaker.ts` (breaker read + health factor, which keeps `virtualFactory.ts` under its 1200-line cap). Covered by the 10 new tests above; no coverage gate run locally (CI owns it).

## Reviewer Notes

The account-tier projection may change nothing on installs where no connection row carries a tier — that's expected, not a bug: unknown rows stay neutral exactly as before. The breaker wiring fails open (any read error keeps the old neutral score). Rebased onto the current `release/v3.8.51` tip and re-verified.


