### PR TITLE
fix(catalog): advertise input_modalities on vision-capable combos

### DIFF
--- a/changelog.d/fixes/12799-combo-vision-derived-modalities.md
+++ b/changelog.d/fixes/12799-combo-vision-derived-modalities.md
@@ -1,0 +1,1 @@
+- `/v1/models` combos whose merged `capabilities.vision` is `true` now also advertise `input_modalities: ["text","image"]` / `output_modalities: ["text"]` (synced modality intersections keep precedence), so models.dev-shaped clients no longer see a vision combo as text-only. (#12799 — thanks @aref-alapour)

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -97,6 +97,7 @@ import {
   maybeOmitCatalogModelName,
   getThinkingCapabilityFields,
   mergeComboCapabilities,
+  visionDerivedModalities,
   getConnectionScopedEffortTiers,
   type ConnectionScopedReasoningCatalog,
 } from "./catalogHelpers";
@@ -792,8 +793,7 @@ async function buildUnifiedModelsResponseCore(
         ...(contextLength ? { context_length: contextLength } : {}),
         ...(maxInputTokens ? { max_input_tokens: maxInputTokens } : {}),
         ...(maxOutputTokens ? { max_output_tokens: maxOutputTokens } : {}),
-        ...(inputModalities.length > 0 ? { input_modalities: inputModalities } : {}),
-        ...(outputModalities.length > 0 ? { output_modalities: outputModalities } : {}),
+        ...visionDerivedModalities(capabilities, inputModalities, outputModalities), // #12798
         ...(Object.keys(capabilities).length > 0 ? { capabilities } : {}),
       };
     };

--- a/src/app/api/v1/models/catalogHelpers.ts
+++ b/src/app/api/v1/models/catalogHelpers.ts
@@ -217,3 +217,37 @@ export function mergeComboCapabilities(
   }
   return capabilities;
 }
+
+/**
+ * #12798: a combo can advertise `capabilities.vision: true` while emitting no
+ * `input_modalities` / `output_modalities`. The merged vision verdict flows
+ * from the targets canonical capabilities - which honour the #9195 operator
+ * "Vision capable" override - while the combo-level modality intersection in
+ * buildComboCatalogMetadata only fills when EVERY known target carries synced
+ * modality data. An operator-flagged vision head with no synced modalities
+ * therefore listed `vision: true` next to an empty modality set, so
+ * models.dev-shaped clients that key off `input_modalities` (not the boolean)
+ * still saw a text-only entry. Derives the modalities from the already
+ * advertised vision verdict: mergeComboCapabilities only emits `vision: true`
+ * when every known target is vision-capable, so this makes no new claim.
+ * Synced intersections keep precedence; nothing is derived for unknown or
+ * text-only verdicts.
+ */
+export function visionDerivedModalities(
+  capabilities: Record<string, boolean | string[]>,
+  syncedInput: string[],
+  syncedOutput: string[]
+): { input_modalities?: string[]; output_modalities?: string[] } {
+  return {
+    ...(syncedInput.length > 0
+      ? { input_modalities: syncedInput }
+      : capabilities.vision === true
+        ? { input_modalities: ["text", "image"] }
+        : {}),
+    ...(syncedOutput.length > 0
+      ? { output_modalities: syncedOutput }
+      : capabilities.vision === true
+        ? { output_modalities: ["text"] }
+        : {}),
+  };
+}

--- a/tests/unit/models-catalog-combo-metadata.test.ts
+++ b/tests/unit/models-catalog-combo-metadata.test.ts
@@ -628,3 +628,73 @@ test("Ollama Cloud projects native efforts for base, tagged, and combo models", 
     assert.deepEqual(capabilitiesFor(modelId).effort_tiers, narrowEfforts, modelId);
   }
 });
+
+// #12798: an operator-flagged vision head (the dashboard "Vision capable"
+// toggle, #9195) with a synced capability row that carries limits but NO
+// modality data merged to `capabilities.vision: true` with an empty modality
+// set, so models.dev-shaped clients keying off `input_modalities` still saw a
+// text-only combo. The combo must derive its modalities from the vision
+// verdict it already advertises.
+test("vision-flagged combo derives input modalities from the merged vision verdict", async () => {
+  await providersDb.createProviderConnection({
+    provider: "openai-compatible",
+    authType: "api_key",
+    name: "vision-head-provider-12798",
+    apiKey: "vision-head-test-key",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: { baseUrl: "http://127.0.0.1:9/v1" },
+  });
+  await modelsDb.addCustomModel(
+    "vision-head-provider-12798",
+    "custom-vision-head",
+    "Custom Vision Head",
+    "manual",
+    "chat-completions",
+    ["chat"],
+    undefined,
+    {},
+    true
+  );
+  const { saveModelsDevCapabilities } = await import("../../src/lib/modelsDevSync.ts");
+  saveModelsDevCapabilities({
+    "vision-head-provider-12798": {
+      "custom-vision-head": {
+        tool_call: true,
+        reasoning: false,
+        attachment: null,
+        structured_output: true,
+        temperature: true,
+        modalities_input: null,
+        modalities_output: null,
+        knowledge_cutoff: null,
+        release_date: null,
+        last_updated: null,
+        status: null,
+        family: null,
+        open_weights: false,
+        limit_context: 200000,
+        limit_input: 200000,
+        limit_output: 8192,
+        interleaved_field: null,
+      },
+    },
+  });
+  await combosDb.createCombo({
+    name: "custom-vision-head-combo",
+    strategy: "auto",
+    models: ["vision-head-provider-12798/custom-vision-head"],
+  });
+
+  const response = await catalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const combo = body.data.find((item) => item.id === "custom-vision-head-combo");
+
+  assert.ok(combo, "combo entry missing from /v1/models");
+  const comboCapabilities = combo.capabilities as Record<string, unknown>;
+  assert.equal(comboCapabilities.vision, true, "merged vision verdict must be advertised");
+  assert.deepEqual(combo.input_modalities, ["text", "image"]);
+  assert.deepEqual(combo.output_modalities, ["text"]);
+});


### PR DESCRIPTION
## Summary

Combos whose merged `capabilities.vision === true` now also advertise `input_modalities: ["text", "image"]` / `output_modalities: ["text"]` in `/v1/models`, instead of the vision boolean next to an empty modality set.

Refs #12798.

## Problem

`buildComboCatalogMetadata` merges the vision verdict from the targets' **canonical** capabilities — which honour the #9195 operator "Vision capable" override — while the combo-level modality intersection only fills when **every** known target carries **synced** modality data. An operator-flagged vision head (or any target whose canonical vision verdict comes from a source the modality path doesn't read) therefore listed:

```json
{"id":"my-vision-combo","capabilities":{"tool_calling":true,"vision":true}}
```

with no `input_modalities`. models.dev-shaped clients that key off `input_modalities` (not the boolean) — e.g. agent CLIs building their model picker from `/v1/models` — still saw a text-only model and silently degraded image requests to placeholders. Observed live on a v3.8.x gateway: vision combos advertised `vision: true` with no modalities.

## Change

- `catalogHelpers.ts` — new `visionDerivedModalities(capabilities, syncedInput, syncedOutput)`: emits the synced intersection when present, else derives `["text","image"]` / `["text"]` from a `vision === true` verdict. Makes no new claim: `mergeComboCapabilities` only emits `vision: true` when **every** known target is vision-capable, so the derived modalities are exactly as strong as the boolean already advertised. Unknown / text-only verdicts derive nothing (fail-closed, same discipline as #4071 / #4072).
- `catalog.ts` — the two modality spreads in `buildComboCatalogMetadata` collapse into the helper call (with the synced values passed through), so the frozen file stays at its current LOC for the file-size ratchet.

## Testing

- New regression test in `tests/unit/models-catalog-combo-metadata.test.ts`: an operator-flagged custom vision head (`supportsVision: true`, synced capability row with limits but no modality data) in a single-target combo → the combo entry now carries `capabilities.vision: true` **and** `input_modalities: ["text","image"]`.
- Full file: 13/13 pass (the pre-existing "single-target combo preserves its direct model metadata" guards the synced-passthrough behaviour).
- `catalog-helpers-extraction` + `models-catalog-route`: 58/58 pass.
- `check:file-size` OK (catalog.ts unchanged in LOC), `prettier --check` clean.

I'm interested in contributing here beyond this patch (see the team-collab note in #12798) — happy to take on the `/v1/models`-side follow-ups from that issue, or adjust this approach if maintainers prefer deriving modalities at the target level instead of the combo level.
