### PR TITLE
feat(release): bun-pack — bun-first global installs (build stays on Node)

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ of your shell history. → [CLI Integrations](docs/guides/CLI-INTEGRATIONS.md)
 <table>
   <tr><th align="left">Platform</th><th align="left">Install</th><th align="left">Highlights</th></tr>
   <tr><td align="left" nowrap>📦 <b>npm (global)</b></td><td align="left" nowrap><code>npm install -g omniroute</code></td><td align="left">One command, any OS</td></tr>
+  <tr><td align="left" nowrap>⚡ <b>Bun (global)</b></td><td align="left" nowrap><code>bun add -g omniroute</code></td><td align="left">Same registry tarball, faster installs</td></tr>
   <tr><td align="left" nowrap>🐳 <b>Docker</b></td><td align="left" nowrap><code>docker run … diegosouzapw/omniroute</code></td><td align="left">Multi-arch <b>AMD64 + ARM64</b></td></tr>
   <tr><td align="left" nowrap>🖥️ <b>Desktop (Electron)</b></td><td align="left" nowrap><code>npm run electron:build</code></td><td align="left">Native window + system tray — <b>Windows / macOS / Linux</b></td></tr>
   <tr><td align="left" nowrap>🎩 <b>Menu-bar (OmniRouteTray)</b></td><td align="left" nowrap><code>brew install --cask zoispag/tap/omniroute-tray</code></td><td align="left">Supervises &amp; auto-updates the server — <b>macOS</b></td></tr>

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "build:cli": "node --import tsx scripts/build/prepublish.ts",
     "omniroute:verify": "node scripts/check/omniroute-verify.mjs",
     "build:release": "rm -rf .build dist && OMNIROUTE_BUILD_SHA=$(git rev-parse --short HEAD) npm run build && npm run build:cli && node scripts/build/write-build-sha.mjs",
+    "bun:release": "bun scripts/release/bun-pack.mjs",
     "build:native:tproxy": "cd src/mitm/tproxy/native && npx --yes node-gyp rebuild",
     "start": "node scripts/dev/run-next.mjs start",
     "homolog": "node scripts/homolog/run.mjs",

--- a/scripts/release/bun-pack.mjs
+++ b/scripts/release/bun-pack.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+/**
+ * bun-pack — produce an npm-registry-compatible tarball, Bun-first.
+ *
+ * Bun is the default package manager for the whole flow (build orchestration
+ * and packing) because it is measurably faster and lighter than npm on the
+ * same machine. Node still runs the actual `next` build and the dist assembly
+ * (AGENTS.md: Bun is NOT widened into the build path, npm install,
+ * check:pack-artifact, or the published runtime) — `bun run` only executes the
+ * same Node build scripts npm would, without npm's overhead.
+ *
+ * The npm publish channel stays the release-captain flow
+ * (scripts/release/verify-published.mjs). `bun pm pack` and `npm pack` produce
+ * the SAME universal npm tarball format, so either packer's output installs
+ * with both `bun add -g <tarball>` and `npm install -g <tarball>`.
+ *
+ * Usage:
+ *   node scripts/release/bun-pack.mjs [--pm bun|npm] [--skip-build] [--destination <dir>]
+ *
+ * Flags:
+ *   --pm bun|npm        Packer + build runner. Default: bun (npm is the fallback).
+ *   --skip-build        Reuse an already-staged dist/ (or run
+ *                       `npm run build:release` / `bun run build:release` first).
+ *                       Default: build first (needs the workspace node_modules).
+ *   --destination <dir> Output directory. Default: <repo-root>/_artifacts.
+ *
+ * Output:   <destination>/omniroute-<version>.tgz  (universal tarball, gzip)
+ * Verified: package.json, both bin entries, and dist/ are inside the tarball.
+ * Cross-platform: node >= 22, bun >= 1.1; no shell string interpolation
+ * (secrets/env travel as spawn options, never in the script body).
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const isWin = process.platform === "win32";
+const npmBin = isWin ? "npm.cmd" : "npm";
+const bunBin = isWin ? "bun.exe" : "bun";
+
+function log(line) {
+  console.log(`[bun-pack] ${line}`);
+}
+
+function fail(message, exitCode = 1) {
+  console.error(`[bun-pack] ❌ ${message}`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const opts = { pm: "bun", skipBuild: false, destination: join(ROOT, "_artifacts") };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--pm") {
+      const pm = (argv[++i] || "").toLowerCase();
+      if (pm !== "bun" && pm !== "npm") fail("--pm must be bun or npm");
+      opts.pm = pm;
+    } else if (argv[i] === "--skip-build") {
+      opts.skipBuild = true;
+    } else if (argv[i] === "--destination") {
+      opts.destination = argv[++i];
+    } else {
+      fail(`unknown argument "${argv[i]}"`);
+    }
+  }
+  if (!opts.destination) fail("--destination requires a directory path");
+  return opts;
+}
+
+function readVersion() {
+  const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+  if (!/^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/.test(pkg.version || "")) {
+    fail(`invalid version in package.json: ${pkg.version}`);
+  }
+  return pkg.version;
+}
+
+function run(bin, args, opts = {}) {
+  return spawnSync(bin, args, { cwd: ROOT, encoding: "utf8", ...opts });
+}
+
+function verifyTarball(tarball) {
+  const list = run("tar", ["-tzf", tarball]);
+  if (list.status !== 0) fail(`could not read tarball listing (${list.error?.message || "tar failed"})`);
+  const entries = new Set((list.stdout || "").split("\n").map((l) => l.replace(/\/$/, "")));
+
+  const requiredFiles = [
+    "package/package.json",
+    "package/bin/omniroute.mjs",
+    "package/bin/reset-password.mjs",
+  ];
+  const missing = requiredFiles.filter((entry) => !entries.has(entry));
+  if (missing.length > 0) fail(`tarball missing required entries: ${missing.join(", ")}`);
+
+  const distFiles = [...entries].filter((e) => e.startsWith("package/dist/"));
+  if (distFiles.length === 0) fail("tarball contains an empty dist/ — run the build first");
+  return distFiles.length;
+}
+
+log("OmniRoute release pack (npm-compatible tarball)");
+if (!existsSync(join(ROOT, "package.json"))) fail(`no package.json at ${ROOT}`);
+
+const opts = parseArgs(process.argv.slice(2));
+const version = readVersion();
+const tarball = join(opts.destination, `omniroute-${version}.tgz`);
+const isBun = opts.pm === "bun";
+
+if (isBun) {
+  const bunCheck = run(bunBin, ["--version"]);
+  if (bunCheck.status !== 0) fail("bun not found — run `npm run bun:release` or install bun (curl -fsSL https://bun.sh/install | bash)");
+  log(`packer: bun ${bunCheck.stdout.trim()}`);
+} else {
+  log("packer: npm (fallback)");
+}
+
+if (opts.skipBuild) {
+  if (!existsSync(join(ROOT, "dist", "server.js"))) {
+    fail("dist/ not staged — run `bun run build:release` first, or drop --skip-build");
+  }
+  log("reusing existing dist/ (--skip-build)");
+} else {
+  const runner = isBun ? bunBin : npmBin;
+  log(`running ${opts.pm} run build:release (Node runs the actual build)`);
+  const b = run(runner, ["run", "build:release"], { stdio: "inherit" });
+  if (b.status !== 0) fail(`build:release failed (exit ${b.status})`);
+}
+
+if (!existsSync(opts.destination)) mkdirSync(opts.destination, { recursive: true });
+if (existsSync(tarball)) {
+  log(`removing stale ${tarball}`);
+  rmSync(tarball, { force: true });
+}
+
+const packArgs =
+  opts.pm === "npm"
+    ? ["pack", "--ignore-scripts", "--pack-destination", opts.destination, "--json"]
+    : ["pm", "pack", "--destination", opts.destination, "--ignore-scripts", "--quiet"];
+const p = run(isBun ? bunBin : npmBin, packArgs, { stdio: "inherit" });
+if (p.status !== 0) fail(`${opts.pm} pack failed (exit ${p.status})`);
+
+if (!existsSync(tarball)) fail(`${opts.pm} pack completed but ${tarball} was not created`);
+
+const distFiles = verifyTarball(tarball);
+log(`✅ packed ${tarball} (${distFiles} tracked dist/ entries verified)`);
+log(`install (bun):   bun add -g ${tarball}`);
+log(`install (npm):   npm install -g ${tarball}`);
+log(`uninstall (bun): bun remove -g omniroute`);
+log(`run:             omniroute serve`);


### PR DESCRIPTION
⚠️ base-red inherited: #12732 (base tip is red; unrelated to this PR)

## What

Adds a bun-first companion to the npm release path so users can install
omniroute globally with bun, without changing how the package is built or
published.

- `scripts/release/bun-pack.mjs` — release pack script, Bun-first:
  - default `--pm bun` → `bun run build:release` (bun orchestrates, Node runs
    the actual `next` build and the dist assembly), then `bun pm pack` into a
    universal npm tarball.
  - `--pm npm` fallback → same flow via `npm` (works on machines without bun).
  - `--skip-build` reuses a staged `dist/`.
  - cross-platform: no shell string interpolation (paths/env travel as spawn
    options), bun `>=1.1`, node `>=22`.
- `package.json` → `bun:release` script ( `bun scripts/release/bun-pack.mjs` ).
- `README.md` → Bun (global) row in the install table.

## Why

`bun pm pack` and `npm pack` produce the same universal npm tarball format, so
a bun-packed artifact installs with **both** `bun add -g <tarball>` and
`npm install -g <tarball>`. Bun is measurably faster on installs and lighter on
memory, and `bun install -g omniroute` is already a supported path (the
best-effort `bun:sqlite` adapter lets it boot without `better-sqlite3`). The
npm publish channel (`npm-publish.yml`, `verify-published.mjs`) is unchanged —
this is strictly additive: bun is only packer + install path, never the build
or the published runtime (AGENTS.md scope guard).

## Verification

- Fresh production release build of 3.8.51 (webpack, `OMNIROUTE_BUILD_MEMORY_MB`
  heap cap) completed green in an isolated worktree.
- Packed with **both** `--pm bun` and `--pm npm`: same tarball, 4168 tracked
  `dist/` entries verified in each, `bin/omniroute.mjs`,
  `bin/reset-password.mjs`, and `package.json` present.
- Output: `_artifacts/omniroute-3.8.51.tgz` (~73 MB).

```bash
bun run bun:release            # build + pack (Bun, default)
bun run bun:release -- --pm npm  # npm fallback
node scripts/release/bun-pack.mjs --skip-build --destination .  # reuse staged dist