### PR TITLE
fix(mcp): preserve model catalog token limits

### DIFF
--- a/docs/frameworks/MCP-SERVER.md
+++ b/docs/frameworks/MCP-SERVER.md
@@ -83,6 +83,11 @@ Cursor, Cline, and compatible MCP client setup.
 | `omniroute_x_search`            | `execute:search`      | Search X through xAI/SuperGrok, or choose `xquik-search` for Xquik API results. Requires credentials for the selected backend. |
 | `omniroute_web_fetch`           | `execute:search`      | Fetch web content through the configured fetch providers                                                                       |
 
+The model catalog preserves `context_length` and `max_output_tokens` when the
+provider catalog supplies positive finite numbers. Unknown, zero, or invalid
+limits are omitted rather than reported as a zero-token budget. This applies to
+active connection catalogs (including local fallbacks) and no-auth provider catalogs.
+
 ## Advanced Tools (11) — Phase 2
 
 | Tool                               | Scopes                               | Description                                                                               |

--- a/open-sse/mcp-server/catalog.ts
+++ b/open-sse/mcp-server/catalog.ts
@@ -12,6 +12,8 @@ type McpCatalogResponse = {
     capabilities: string[];
     status: McpCatalogStatus;
     thinkingEffort?: string;
+    context_length?: number;
+    max_output_tokens?: number;
     pricing?: unknown;
   }>;
   source: string;
@@ -127,6 +129,17 @@ function getConnectionThinkingEffort(connection: ProviderConnectionLike): string
   return rawThinkingEffort || undefined;
 }
 
+function getCatalogTokenLimits(model: JsonRecord) {
+  const limits: Partial<Record<"context_length" | "max_output_tokens", number>> = {};
+  for (const field of ["context_length", "max_output_tokens"] as const) {
+    const value = model[field];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      limits[field] = value;
+    }
+  }
+  return limits;
+}
+
 function normalizeProviderModelRecord(
   rawModel: unknown,
   fallbackProvider: string,
@@ -143,6 +156,7 @@ function normalizeProviderModelRecord(
     capabilities: getCatalogModelCapabilities(model),
     status: normalizeCatalogStatus(model, source, warning),
     ...(thinkingEffort ? { thinkingEffort } : {}),
+    ...getCatalogTokenLimits(model),
     pricing: model.pricing,
   };
 }
@@ -155,8 +169,12 @@ function activeProviderConnections(
   return connections.filter((connection) => {
     const provider =
       typeof connection?.provider === "string" ? normalizeProviderId(connection.provider) : null;
-    return !!provider && !!connection?.id && connection.isActive !== false &&
-      (!requestedProvider || provider === requestedProvider);
+    return (
+      !!provider &&
+      !!connection?.id &&
+      connection.isActive !== false &&
+      (!requestedProvider || provider === requestedProvider)
+    );
   });
 }
 
@@ -201,7 +219,8 @@ function maybeCatalogModel(
   requestedCapability: string | null
 ): McpCatalogResponse["models"][number] | null {
   const normalized = normalizeProviderModelRecord(rawModel, spec.provider, source, warning);
-  if (spec.thinkingEffort && !normalized.thinkingEffort) normalized.thinkingEffort = spec.thinkingEffort;
+  if (spec.thinkingEffort && !normalized.thinkingEffort)
+    normalized.thinkingEffort = spec.thinkingEffort;
   if (!normalized.id) return null;
   if (requestedCapability && !normalized.capabilities.includes(requestedCapability)) return null;
   return normalized;
@@ -232,7 +251,10 @@ async function collectCatalogModels(
 
   for (const spec of requestSpecs) {
     const raw = toRecord(await fetchJson(spec.path));
-    const source = toString(raw.source, spec.path.startsWith("/api/providers/") ? "api" : "v1_catalog");
+    const source = toString(
+      raw.source,
+      spec.path.startsWith("/api/providers/") ? "api" : "v1_catalog"
+    );
     const warning = raw.warning ? String(raw.warning) : undefined;
     if (warning) warnings.add(warning);
     sources.add(source);
@@ -249,7 +271,8 @@ export async function getMcpModelsCatalog(
     listProviderConnections?: () => Promise<ProviderConnectionLike[]>;
   } = {}
 ): Promise<McpCatalogResponse> {
-  const fetchJson = deps.fetchJson ?? ((path: string) => import("./server.ts").then((m) => m.omniRouteFetch(path)));
+  const fetchJson =
+    deps.fetchJson ?? ((path: string) => import("./server.ts").then((m) => m.omniRouteFetch(path)));
   const listProviderConnections = deps.listProviderConnections ?? getProviderConnections;
   const aliasMap = buildProviderAliasMap();
   const normalizeProviderId = (value: string) => aliasMap[value] || value;

--- a/tests/unit/mcp-model-catalog.test.ts
+++ b/tests/unit/mcp-model-catalog.test.ts
@@ -147,3 +147,66 @@ test("getMcpModelsCatalog returns empty result when requested provider has no ac
     warning: "No active connections found for provider 'github'.",
   });
 });
+
+for (const source of ["api", "local_catalog"]) {
+  for (const envelope of ["models", "data"]) {
+    test(`getMcpModelsCatalog preserves token limits from ${source} ${envelope}`, async () => {
+      const result = await getMcpModelsCatalog(
+        { provider: "gh", capability: "chat" },
+        {
+          listProviderConnections: async () => [{ id: "conn-github", provider: "github" }],
+          fetchJson: async () => ({
+            source,
+            [envelope]: [
+              { id: "budgeted-model", context_length: 128000, max_output_tokens: 16384 },
+            ],
+          }),
+        }
+      );
+      assert.equal(result.models[0]?.context_length, 128000);
+      assert.equal(result.models[0]?.max_output_tokens, 16384);
+      assert.equal(result.models[0]?.status, source === "local_catalog" ? "degraded" : "available");
+    });
+  }
+}
+
+test("getMcpModelsCatalog preserves token limits for no-auth provider catalogs", async () => {
+  const result = await getMcpModelsCatalog(
+    { provider: "oc" },
+    {
+      listProviderConnections: async () => [],
+      fetchJson: async (path) => {
+        assert.equal(path, "/api/v1/providers/opencode/models");
+        return { data: [{ id: "budgeted-model", context_length: 64000, max_output_tokens: 8192 }] };
+      },
+    }
+  );
+  assert.equal(result.models[0]?.context_length, 64000);
+  assert.equal(result.models[0]?.max_output_tokens, 8192);
+});
+
+test("getMcpModelsCatalog omits unknown or invalid token limits independently", async () => {
+  const invalid = [undefined, null, 0, -1, NaN, Infinity, -Infinity, "128000", true, {}, []];
+  const result = await getMcpModelsCatalog(
+    {},
+    {
+      listProviderConnections: async () => [{ id: "conn-github", provider: "github" }],
+      fetchJson: async () => ({
+        models: invalid.flatMap((value, index) => [
+          { id: `context-${index}`, context_length: value, max_output_tokens: 8192 },
+          { id: `output-${index}`, context_length: 64000, max_output_tokens: value },
+        ]),
+      }),
+    }
+  );
+  assert.equal(result.models.length, invalid.length * 2);
+  for (const model of result.models) {
+    if (model.id.startsWith("context-")) {
+      assert.equal(Object.hasOwn(model, "context_length"), false);
+      assert.equal(model.max_output_tokens, 8192);
+    } else {
+      assert.equal(model.context_length, 64000);
+      assert.equal(Object.hasOwn(model, "max_output_tokens"), false);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Preserve `context_length` and `max_output_tokens` in the MCP model catalog so clients can budget prompts and output using metadata already supplied by provider catalogs. Both fields are optional: unknown, zero, negative, non-finite, or non-number values stay absent.

The shared projection covers active connections, local catalog fallbacks, both `models`/`data` envelopes, and no-auth provider catalogs. Existing filtering, status, pricing, and thinking-effort behavior remains intact.

## Related Issues

Fixes #12776.

⚠️ base-red inherited: #12732

## Validation

- [x] Change type: other — MCP response projection
- [x] Focused tests: `DATA_DIR=<temporary-directory> node --import tsx/esm --test tests/unit/mcp-model-catalog.test.ts` — 11 passed. The six new cases failed before the fix; five existing cases passed.
- [x] `npm run typecheck:core` passed.
- [x] Changed-file ESLint passed, as did all pre-commit hooks (format/lint, docs sync, any budget, tracked artifacts).
- [x] Reconciled with fetched `release/v3.8.51` at `9d1a896c6058b2ade94c9078c2e54377b9aa76d3`; no base movement. No open release-freeze issue found during preflight.
- [x] Production-code changes include automated tests.
- [ ] Repository-wide `npm run lint` reports unused suppressions. Neither changed TypeScript file has suppression entries; changed-file checks pass.
- [ ] `npm run check:docs-all` stops at three existing migration-count drifts in README.md, AGENTS.md, and llm.txt (169 documented versus 170 in source). Those files and migrations are unchanged. Docs sync/frontmatter passed before that failure; `npm run check:fabricated-docs` passed separately.

## Tests Added Or Updated

`tests/unit/mcp-model-catalog.test.ts`: metadata preservation for live and cached catalogs, both response envelopes, the no-auth path, and independent omission of invalid limits.

## Coverage Notes

Six added regression cases exercise the shared normalization path, including valid and invalid numeric branches. Full unit shards, Vitest, coverage ratchet, and production build remain CI validation, following the Contribution Golden Path.

## Reviewer Notes

No migrations, feature flags, new provider requests, or scope changes. Limits are preserved when supplied, not invented for providers that omit them. The public MCP documentation now states this contract.
