### PR TITLE
fix(compression): terminate idle workers on pool eviction

### DIFF
--- a/open-sse/services/compression/compressionWorkerPool.ts
+++ b/open-sse/services/compression/compressionWorkerPool.ts
@@ -185,7 +185,7 @@ export class CompressionWorkerPool {
     slot.timeout = null;
     slot.job = null;
     job.resolve(result);
-    slot.idle = setTimeout(() => void this.remove(slot, false), this.idleMs);
+    slot.idle = setTimeout(() => void this.remove(slot, true), this.idleMs);
     slot.idle.unref();
     this.dispatch();
   }


### PR DESCRIPTION
Fixes #12812.

## Problem

`CompressionWorkerPool.finish()` schedules idle eviction with `remove(slot, false)`. `remove()` deletes the slot from `this.workers` but only terminates the thread when the flag is `true`:

```ts
private async remove(slot: PoolWorker, terminate: boolean): Promise<void> {
  if (!this.workers.delete(slot)) return;      // pool drops its only reference
  if (slot.timeout) clearTimeout(slot.timeout);
  if (slot.idle) clearTimeout(slot.idle);
  if (terminate) await slot.worker.terminate().catch(() => undefined);
}
```

So an idle worker is forgotten by the pool while its thread, `MessagePort` and private heap stay alive — and since the reference is gone, nothing can terminate it afterwards. Every burst of compression traffic separated by more than `idleMs` (default 60s) strands up to `OMNI_COMPRESSION_WORKERS` (default 2) more threads.

`fail()` and `close()` already pass `true`. Only the success path leaked.

## Measured impact

On a 16.2h instance of v3.8.50 (Node v24.19.0, Windows 11):

| Metric | Leaking process | Plain Node baseline |
|---|---|---|
| Private / commit | **5,723 MB** | 33 MB |
| OS threads | **69** | 12 |
| `MessagePort` handles | **55, all refed** | — |

`process._getActiveHandles()` showed 55 `MessagePort` entries against only 3 `Server` and 2 `TLSSocket`. An address-space walk attributed 5,432 MB to 12,534 small `Private/READWRITE` regions with no allocation larger than 21 MB — many independent worker heaps rather than one large cache.

Worth noting for anyone triaging similar reports: `process.memoryUsage()` reported `rss=660MB / heapUsed=414MB` throughout, because V8 only accounts for the main thread's isolate. The leak is invisible to every JS-level metric and only shows up in OS commit charge.

## Change

```diff
-    slot.idle = setTimeout(() => void this.remove(slot, false), this.idleMs);
+    slot.idle = setTimeout(() => void this.remove(slot, true), this.idleMs);
```

Idle eviction now terminates the worker, which is the purpose of evicting it. `remove()` already handles the async terminate safely with a `.catch()`.

## Verification

I applied the equivalent one-character patch to the built bundle actually loaded by my running instance (`dist/.build/next/server/chunks/open-sse_services_compression_compressionWorkerPool_ts_13s5ju7._.js`, confirmed via CDP `Debugger.scriptParsed`) and verified it parses with `node --check`. Behavioural confirmation requires a restart with the rebuilt bundle, so I have not yet measured post-fix handle counts over a long uptime — happy to report back once I have a multi-hour sample.

A follow-up worth considering separately: `remove()`'s boolean parameter now has no caller passing `false`, so it could be dropped entirely to make the leak unrepresentable.
