### PR TITLE
refactor(compression): drop the terminate flag from pool removal

### DIFF
--- a/open-sse/services/compression/compressionWorkerPool.ts
+++ b/open-sse/services/compression/compressionWorkerPool.ts
@@ -185,7 +185,7 @@ export class CompressionWorkerPool {
     slot.timeout = null;
     slot.job = null;
     job.resolve(result);
-    slot.idle = setTimeout(() => void this.remove(slot, false), this.idleMs);
+    slot.idle = setTimeout(() => void this.remove(slot, true), this.idleMs);
     slot.idle.unref();
     this.dispatch();
   }

--- a/open-sse/services/compression/compressionWorkerPool.ts
+++ b/open-sse/services/compression/compressionWorkerPool.ts
@@ -131,7 +131,7 @@ export class CompressionWorkerPool {
   }
   async close(): Promise<void> {
     for (const job of this.queue.splice(0)) job.resolve(unchanged(job.originalBody));
-    await Promise.all([...this.workers].map((slot) => this.remove(slot, true)));
+    await Promise.all([...this.workers].map((slot) => this.remove(slot)));
   }
   private spawn(): PoolWorker {
     const slot: PoolWorker = {
@@ -185,7 +185,7 @@ export class CompressionWorkerPool {
     slot.timeout = null;
     slot.job = null;
     job.resolve(result);
-    slot.idle = setTimeout(() => void this.remove(slot, true), this.idleMs);
+    slot.idle = setTimeout(() => void this.remove(slot), this.idleMs);
     slot.idle.unref();
     this.dispatch();
   }
@@ -193,13 +193,13 @@ export class CompressionWorkerPool {
     const job = slot.job;
     if (job) job.resolve(unchanged(job.originalBody));
     slot.job = null;
-    void this.remove(slot, true).finally(() => this.dispatch());
+    void this.remove(slot).finally(() => this.dispatch());
   }
-  private async remove(slot: PoolWorker, terminate: boolean): Promise<void> {
+  private async remove(slot: PoolWorker): Promise<void> {
     if (!this.workers.delete(slot)) return;
     if (slot.timeout) clearTimeout(slot.timeout);
     if (slot.idle) clearTimeout(slot.idle);
-    if (terminate) await slot.worker.terminate().catch(() => undefined);
+    await slot.worker.terminate().catch(() => undefined);
   }
 }
 


### PR DESCRIPTION
Follow-up to #12813 — please merge that one first, as this branch is stacked on it.

## Rationale

After the idle-eviction fix, all three call sites pass `terminate: true`:

| Call site | Argument |
|---|---|
| `close()` | `true` |
| `finish()` idle timer | `true` *(was `false` — the bug in #12813)* |
| `fail()` | `true` |

The parameter now only exists to express a state the pool cannot safely be in: a slot deleted from `this.workers` while its `Worker` keeps running. Once `remove()` has done `this.workers.delete(slot)`, the pool has dropped its only reference — nothing can terminate that thread afterwards. Passing `false` is not a valid option, it is a leak.

Removing the flag makes that state unrepresentable, so the same bug cannot be reintroduced by a future caller.

## Change

```diff
-  private async remove(slot: PoolWorker, terminate: boolean): Promise<void> {
+  private async remove(slot: PoolWorker): Promise<void> {
     if (!this.workers.delete(slot)) return;
     if (slot.timeout) clearTimeout(slot.timeout);
     if (slot.idle) clearTimeout(slot.idle);
-    if (terminate) await slot.worker.terminate().catch(() => undefined);
+    await slot.worker.terminate().catch(() => undefined);
   }
```

Plus the three call sites dropping their now-redundant argument. `remove()` is `private`, so this is not a public API change.

No behavioural change on top of #12813.

## Note on the sibling pools

I checked the other two worker owners in the codebase while investigating:

- `open-sse/services/compression/engines/llmlingua/worker.ts` — `resetWorker()` always calls `w.terminate()`
- `src/lib/usage/callLogArtifactWriter.ts` — `terminateWorker()` always calls `.terminate()`

Both are singletons that route every exit path (idle, `error`, `exit`, close) through a single teardown function, and both null out the reference *before* terminating. Neither has an equivalent flag, which is why neither leaked. `compressionWorkerPool.ts` was the only place where "remove from pool" and "stop the thread" were decoupled — this PR closes that gap.
