### PR TITLE
fix(plugins): stop leaking an exit listener per kill escalation

### DIFF
--- a/src/lib/plugins/loader.ts
+++ b/src/lib/plugins/loader.ts
@@ -271,6 +271,30 @@ export async function loadPlugin(
     removeHostScript(hostScriptPath);
   });
 
+  // Escalate SIGTERM -> SIGKILL using a SINGLE shared timer and a SINGLE exit
+  // listener. Attaching `child.once("exit", ...)` per escalation leaks one
+  // listener per hook timeout on a child that survives SIGTERM, tripping
+  // MaxListenersExceededWarning and retaining closures for the process lifetime.
+  let killTimer: NodeJS.Timeout | null = null;
+  const clearKillTimer = (): void => {
+    if (killTimer) {
+      clearTimeout(killTimer);
+      killTimer = null;
+    }
+  };
+  child.once("exit", clearKillTimer);
+  const killEscalate = (): void => {
+    child.kill("SIGTERM");
+    if (killTimer) return; // escalation already pending
+    killTimer = setTimeout(() => {
+      killTimer = null;
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+    }, SIGKILL_GRACE_MS);
+    killTimer.unref?.();
+  };
+
   // Call a hook in the child process with a timeout. Blocking/lifecycle hooks escalate
   // SIGTERM → SIGKILL on timeout; NOTIFICATION_HOOKS only drop the pending call.
   const callHook = (hook: string, payload: unknown, timeout = hookTimeoutMs): Promise<unknown> => {
@@ -291,14 +315,7 @@ export async function loadPlugin(
           resolve(undefined);
           return;
         }
-        child.kill("SIGTERM");
-        // Escalate to SIGKILL if plugin ignores SIGTERM
-        const killTimer = setTimeout(() => {
-          try {
-            child.kill("SIGKILL");
-          } catch {}
-        }, SIGKILL_GRACE_MS);
-        child.once("exit", () => clearTimeout(killTimer));
+        killEscalate();
         reject(new Error(`Plugin hook '${hook}' timed out after ${timeout}ms`));
       }, timeout);
 
@@ -397,14 +414,7 @@ export async function loadPlugin(
   });
 
   const cleanup = () => {
-    child.kill("SIGTERM");
-    // Escalate to SIGKILL after grace period
-    const killTimer = setTimeout(() => {
-      try {
-        child.kill("SIGKILL");
-      } catch {}
-    }, SIGKILL_GRACE_MS);
-    child.once("exit", () => clearTimeout(killTimer));
+    killEscalate();
     removeHostScript(hostScriptPath);
     log.info("loader.cleanup", { name: manifest.name });
   };


### PR DESCRIPTION
Fixes #12819.

## Problem

Every SIGKILL escalation attached a **new** `child.once("exit", ...)` listener closing over its own `killTimer`. On a plugin child that survives `SIGTERM`, each hook timeout leaked one listener plus one retained closure — nothing removed them while the child stayed alive.

Two sites had the identical pattern: the hook-timeout handler and `cleanup()`.

Node made it visible on its own:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 exit listeners added to [ChildProcess]. MaxListeners is 10.
```

## Fix

One shared `killTimer` and one exit listener attached at spawn time:

- `killEscalate()` sends `SIGTERM`, then arms the SIGKILL timer **only if one is not already pending** — repeated escalations reuse it instead of stacking.
- A single `child.once("exit", clearKillTimer)` clears whatever is pending.
- `killTimer.unref?.()` so a pending escalation never keeps the event loop alive.

Both call sites now just call `killEscalate()`.

## Verification

Loaded a plugin whose hook never resolves, so every call hits the timeout, and counted `listenerCount("exit")` on the same child:

| after hook | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| before | 2 | 1 | 2 | 3 | **4** | **5** |
| after | 2 | 1 | 1 | 1 | 1 | 1 |

Growth is gone; the count stays flat. `MaxListenersExceededWarning` no longer appears.

Behaviour that is unchanged, checked explicitly:

- SIGTERM -> SIGKILL escalation still fires (verified with a plugin that ignores SIGTERM)
- zero orphaned child processes after runs with hanging plugins
- zero leaked `omniroute-plugin-host-*.mjs` temp scripts

## Notes

- Independent of #12813 / #12815 — different file, no overlap, can merge in any order.
- Ran against `release/v3.8.51`; the same code is in the published `3.8.50` package.
- I verified the patched loader in an isolated harness, not inside a long-running production instance, so I cannot report multi-hour soak numbers here.
