### PR TITLE
fix(llmlingua): pass a URL object to new Worker() instead of a file:// string

### DIFF
--- a/open-sse/services/compression/engines/llmlingua/worker.ts
+++ b/open-sse/services/compression/engines/llmlingua/worker.ts
@@ -234,7 +234,7 @@ function ensureWorker(): Worker {
 
   const { workerFile, execArgv } = resolveWorkerFile();
   const absoluteWorkerFile = path.resolve(workerFile);
-  const w = new Worker(pathToFileURL(absoluteWorkerFile).href, { execArgv });
+  const w = new Worker(pathToFileURL(absoluteWorkerFile), { execArgv });
 
   w.on("message", (reply: WorkerReply) => {
     const entry = pending.get(reply.id);


### PR DESCRIPTION
Fixes #12822.

## Problem

`new Worker()` does not accept a serialized `file://` **string** — it wants an absolute path, a `./`-relative path, or a WHATWG `URL` object. `worker.ts:237` passed `pathToFileURL(...).href`, so every spawn threw `ERR_WORKER_PATH`:

```
TypeError [ERR_WORKER_PATH]: The worker script or module filename must be an
absolute path or a relative path starting with './' or '../'.
Wrap file:// URLs with `new URL`. Received "file:///.../onnxWorker.js"
```

`pump()` catches spawn failures and fail-opens, so the LLMLingua engine silently returned **uncompressed** text instead of surfacing an error. The engine has effectively been a no-op wherever the dependency gate passes.

## Fix

```diff
-const w = new Worker(pathToFileURL(absoluteWorkerFile).href, { execArgv });
+const w = new Worker(pathToFileURL(absoluteWorkerFile), { execArgv });
```

This matches `compressionWorkerPool.ts`, which already passes the `URL` object returned by `pathToFileURL()` and spawns correctly. The two call sites now agree.

## Verification

Against the real `onnxWorker.js` from an installed 3.8.50, Node v24.19.0:

| call | result |
|---|---|
| `new Worker(pathToFileURL(f).href, …)` (current) | `ERR_WORKER_PATH` |
| `new Worker(pathToFileURL(f), …)` (this PR) | spawns, terminates cleanly |

Also exercised end-to-end through `workerBackend()` with the optional deps shimmed: before the change an 80-char input came back 80 chars unchanged (fail-open); after it, the worker starts and the round-trip reaches the worker.

## Note on error visibility

This PR is the minimal correctness fix. Separately, the bare `catch {}` around `ensureWorker()` is what let a 100% spawn failure go unnoticed — worth at least a debug-level log so a broken worker path cannot masquerade as "compression ran, saved nothing". Happy to add that here or in a follow-up, whichever you prefer.

## Relation to my other PRs

Independent of #12813 / #12815 / #12820 — different file, no overlap, any merge order works.
