### PR TITLE
feat(compression): add Hungarian Caveman language pack

### DIFF
--- a/open-sse/services/compression/caveman.ts
+++ b/open-sse/services/compression/caveman.ts
@@ -163,14 +163,26 @@ const RULE_KEYWORDS: Record<string, string[]> = {
 
 const ARTICLE_HINT_RE = /\b(?:a|an|the)\b/;
 
-function shouldAttemptRule(ruleName: string, lowerText: string): boolean {
-  if (ruleName === "articles") {
+function shouldAttemptRule(rule: CavemanRule, lowerText: string): boolean {
+  if (rule.name === "articles") {
     ARTICLE_HINT_RE.lastIndex = 0;
     return ARTICLE_HINT_RE.test(lowerText);
   }
 
-  const keywords = RULE_KEYWORDS[ruleName];
-  return !keywords || keywords.some((keyword) => lowerText.includes(keyword));
+  const keywords = RULE_KEYWORDS[rule.name];
+
+  if (!keywords) return true;
+
+  // File-based language packs have their own localized regexes.
+  // Do not block them using the English-only keyword prefilter.
+  if (!CAVEMAN_RULES.includes(rule)) {
+    rule.pattern.lastIndex = 0;
+    const matches = rule.pattern.test(lowerText);
+    rule.pattern.lastIndex = 0;
+    return matches;
+  }
+
+  return keywords.some((keyword) => lowerText.includes(keyword));
 }
 
 export function applyRulesToText(
@@ -182,7 +194,7 @@ export function applyRulesToText(
   const appliedRules: string[] = [];
 
   for (const rule of rules) {
-    if (!shouldAttemptRule(rule.name, lowerResult)) continue;
+    if (!shouldAttemptRule(rule, lowerResult)) continue;
 
     const before = result;
     const { pattern, replacement } = rule;

--- a/open-sse/services/compression/languageDetector.ts
+++ b/open-sse/services/compression/languageDetector.ts
@@ -9,6 +9,7 @@ const LANGUAGE_HINTS: Record<string, RegExp[]> = {
   fr: [/\b(?:fichier|erreur|merci|peux|besoin)\b/i],
   ru: [/\b(?:\u044d\u0442\u043e|\u0447\u0442\u043e|\u043a\u0430\u043a|\u0435\u0441\u043b\u0438|\u0447\u0442\u043e\u0431\u044b|\u043a\u043e\u0442\u043e\u0440\u044b\u0439|\u043c\u043e\u0436\u0435\u0442|\u043d\u0443\u0436\u043d\u043e|\u0435\u0441\u0442\u044c|\u0431\u044b\u043b\u043e|\u0431\u0443\u0434\u0435\u0442|\u043c\u043e\u0436\u043d\u043e|\u0434\u043e\u043b\u0436\u0435\u043d|\u0444\u0430\u0439\u043b|\u043e\u0448\u0438\u0431\u043a\u0430|\u043f\u0440\u043e\u0431\u043b\u0435\u043c\u0430|\u0434\u0430\u043d\u043d\u044b\u0435)\b/i, /[\u0430-\u044f\u0451]/i],
   ja: [/[\u3040-\u30ff]/],
+  hu: [/\b(?:kérlek|tudnád|szeretném|magyarázd|mutasd|miért|hogyan|függvény|beállítás|adatbázis|következő|problémám|megoldani|hiba|fájl)\b/i],
   id: [/\b(?:saya|kamu|anda|dengan|untuk|yang|tidak|bisa|terima\s+kasih|dari)\b/i],
 };
 

--- a/open-sse/services/compression/outputMode.ts
+++ b/open-sse/services/compression/outputMode.ts
@@ -39,6 +39,11 @@ export const CAVEMAN_INSTRUCTION_BY_LANGUAGE = {
     full: `Responda seco e compacto. Frases curtas OK. Preserve todo conteudo tecnico, codigo, erros, URLs e identificadores exatamente. ${SHARED_BOUNDARIES}`,
     ultra: `Responda ultra compacto. Use prosa tecnica curta e abreviacoes comuns como DB/auth/config/req/res/fn. Nunca abrevie simbolos de codigo, APIs, erros, URLs ou identificadores. ${SHARED_BOUNDARIES}`,
   },
+  hu: {
+    lite: `Válaszolj tömören. Hagyd el a tölteléket, udvariaskodást és bizonytalanságot. Tartsd meg a teljes mondatokat, technikai kifejezéseket, kódot, hibákat, URL-eket és azonosítókat pontosan. ${SHARED_BOUNDARIES}`,
+    full: `Válaszolj tömören, mint egy okos barlanglakó. Hagyd el a tölteléket, udvariaskodást és körülírást. Rövid mondatok és töredékek rendben. Tartsd meg minden technikai tartalmat, kódot, hibát, URL-t és azonosítót pontosan. ${SHARED_BOUNDARIES}`,
+    ultra: `Válaszolj ultra tömören. Maximális tömörítés, távirati stílus. Használj gyakori rövidítéseket (DB/auth/config/req/res/fn/impl), és hagyd el a felesleges kötőszavakat. Soha ne rövidíts kódszimbólumokat, API-neveket, hibaüzeneteket, URL-eket vagy azonosítókat. ${SHARED_BOUNDARIES}`,
+  },
   es: {
     lite: `Responde conciso. Quita relleno, cortesias y dudas. Conserva terminos tecnicos, codigo, errores, URLs e identificadores exactos. ${SHARED_BOUNDARIES}`,
     full: `Responde seco y compacto. Fragmentos OK. Conserva todo el contenido tecnico, codigo, errores, URLs e identificadores exactos. ${SHARED_BOUNDARIES}`,

--- a/open-sse/services/compression/rules/hu/context.json
+++ b/open-sse/services/compression/rules/hu/context.json
@@ -1,0 +1,108 @@
+{
+  "language": "hu",
+  "category": "context",
+  "rules": [
+    {
+      "name": "explanatory_prefix",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a függvény úgy tűnik, hogy|a kód úgy tűnik, hogy|az osztály az, amely|ez a modul az, amely)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "Function:",
+      "replacementMap": {
+        "a függvény úgy tűnik, hogy": "Function:",
+        "a kód úgy tűnik, hogy": "Code:",
+        "az osztály az, amely": "Class:",
+        "ez a modul az, amely": "Module:"
+      },
+      "context": "all",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Collapse explanatory Hungarian prefixes into compact labels."
+    },
+    {
+      "name": "question_to_directive",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:el tudnád magyarázni,? miért|meg tudnád mutatni,? hogyan|meg tudnád mondani,? miért|meg tudnád mondani,? hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "replacementMap": {
+        "el tudnád magyarázni, miért": "Magyarázd el, miért ",
+        "meg tudnád mutatni, hogyan": "Mutasd meg, hogyan ",
+        "meg tudnád mondani, miért": "Mondd meg, miért ",
+        "meg tudnád mondani, hogy": ""
+      },
+      "context": "user",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Turn indirect Hungarian questions into direct requests."
+    },
+    {
+      "name": "context_setup",
+      "pattern": "^(?:itt van a kódom|itt a kódom|az alábbi kód|a következő kód|itt található a kód)\\s*[:.]?\\s*",
+      "flags": "giu",
+      "replacement": "Code: ",
+      "context": "user",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Replace code-introduction prose with a compact context label."
+    },
+    {
+      "name": "intent_clarification",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:amit el szeretnék érni,? az|az a célom,? hogy|amire szükségem van,? az|azt próbálom megoldani,? hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "Goal:",
+      "context": "user",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Collapse explicit goal framing into a compact label."
+    },
+    {
+      "name": "background_removal",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:ahogy tudod,?\\s*|ahogy korábban megbeszéltük,?\\s*|mint korábban említettem,?\\s*)",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Remove repeated background framing."
+    },
+    {
+      "name": "meta_commentary",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:ne feledd, hogy|tartsd szem előtt, hogy|fontos megjegyezni, hogy|megjegyzés:)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Remove meta-commentary that does not add task-specific context."
+    },
+    {
+      "name": "example_setup",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:itt egy példa|az alábbi egy példa|példaként itt van)(?![\\p{L}\\p{N}_])\\s*[:.]?\\s*",
+      "flags": "giu",
+      "replacement": "Példa: ",
+      "context": "all",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Collapse example-introduction wording."
+    },
+    {
+      "name": "problem_statement",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:az a problémám, hogy|a problémám az, hogy|a probléma az, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "Probléma: ",
+      "context": "user",
+      "category": "context",
+      "minIntensity": "lite",
+      "description": "Turn verbose problem framing into a compact label."
+    },
+    {
+      "name": "expected_result",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:azt szeretném, hogy|azt szeretném elérni, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "Elvárt: ",
+      "context": "user",
+      "category": "context",
+      "minIntensity": "full",
+      "description": "Collapse desired-result framing into a compact label."
+    }
+  ]
+}

--- a/open-sse/services/compression/rules/hu/dedup.json
+++ b/open-sse/services/compression/rules/hu/dedup.json
@@ -1,0 +1,56 @@
+{
+  "language": "hu",
+  "category": "dedup",
+  "rules": [
+    {
+      "name": "repeated_context",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:ahogy korábban megbeszéltük|ahogy fentebb megbeszéltük|mint korábban említettem|ahogy már említettem)(?![\\p{L}\\p{N}_])[,.]?\\s*",
+      "flags": "giu",
+      "replacement": "Lásd fent. ",
+      "context": "all",
+      "category": "dedup",
+      "minIntensity": "lite",
+      "description": "Replace repeated conversational context with a compact reference."
+    },
+    {
+      "name": "repeated_question",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:ugyanaz a kérdés, mint korábban|ezt már korábban is megkérdeztem|ez ugyanaz a kérdés)(?![\\p{L}\\p{N}_])[,.]?\\s*",
+      "flags": "giu",
+      "replacement": "[ugyanaz a kérdés] ",
+      "context": "user",
+      "category": "dedup",
+      "minIntensity": "lite",
+      "description": "Collapse repeated-question framing."
+    },
+    {
+      "name": "reestablished_context",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:visszatérve a fenti kódhoz|visszatérve a korábbi kódhoz|a fentiekhez visszatérve|visszatérve erre)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "Re: ",
+      "context": "all",
+      "category": "dedup",
+      "minIntensity": "lite",
+      "description": "Compactly reference previously established context."
+    },
+    {
+      "name": "summary_replacement",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:összefoglalva, amit megbeszéltünk|a beszélgetésünk összefoglalásaként|röviden összefoglalva|összefoglalva)(?![\\p{L}\\p{N}_])[,.:]?\\s*",
+      "flags": "giu",
+      "replacement": "Összegzés: ",
+      "context": "assistant",
+      "category": "dedup",
+      "minIntensity": "lite",
+      "description": "Replace verbose recap lead-ins with a compact summary label."
+    },
+    {
+      "name": "repetition_acknowledgement",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:ahogy az előbb is mondtam|ahogy már korábban is írtam|ezt már fentebb leírtam)(?![\\p{L}\\p{N}_])[,.]?\\s*",
+      "flags": "giu",
+      "replacement": "Lásd fent. ",
+      "context": "all",
+      "category": "dedup",
+      "minIntensity": "lite",
+      "description": "Remove explicit repetition acknowledgements."
+    }
+  ]
+}

--- a/open-sse/services/compression/rules/hu/filler.json
+++ b/open-sse/services/compression/rules/hu/filler.json
@@ -1,0 +1,173 @@
+{
+  "language": "hu",
+  "category": "filler",
+  "rules": [
+    {
+      "name": "pleasantries",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:köszönöm(?: szépen)?|köszi|szívesen|nincs mit|örömmel|természetesen|persze|abszolút)(?![\\p{L}\\p{N}_])[,.!?\\s]*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove standalone Hungarian pleasantries and courtesy fillers."
+    },
+    {
+      "name": "polite_framing",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:kérlek\\s*,?|légy szíves\\s*,?|volnál szíves\\s*,?|megtennéd\\s*,? hogy|szeretném\\s*,? ha|arra kérlek\\s*,? hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "user",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove polite request framing while preserving the requested action."
+    },
+    {
+      "name": "hedging",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:úgy gondolom,? hogy|azt hiszem,? hogy|véleményem szerint|valószínűleg|talán|lehet,? hogy|úgy tűnik,? hogy|úgy látszik,? hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove common Hungarian hedging when it does not carry technical intent."
+    },
+    {
+      "name": "verbose_instructions",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:részletesen magyarázd el|magyarázd el részletesen|adj részletes magyarázatot|készíts átfogó magyarázatot|írj részletes magyarázatot)(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "magyarázd el",
+      "replacementMap": {
+        "részletesen magyarázd el": "magyarázd el",
+        "magyarázd el részletesen": "magyarázd el",
+        "adj részletes magyarázatot": "magyarázd el",
+        "készíts átfogó magyarázatot": "magyarázd el",
+        "írj részletes magyarázatot": "magyarázd el"
+      },
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Collapse verbose requests for detailed explanations into a direct instruction."
+    },
+    {
+      "name": "filler_adverbs",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:alapvetően|lényegében|tulajdonképpen|igazából|valójában|szó szerint|egyszerűen)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove common discourse-filler adverbs."
+    },
+    {
+      "name": "filler_phrases",
+      "pattern": "^(?:azt szeretném,? hogy|azt szeretném megtudni,? hogy|azt szeretném kérni,? hogy|szeretnék kérni|az lenne a kérdésem,? hogy)\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "user",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove first-person framing at the start of user requests."
+    },
+    {
+      "name": "redundant_openers",
+      "pattern": "^(?:szia|sziasztok|szervusz|jó reggelt|jó napot|helló|üdv)\\s*[,.!?]?\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "user",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove greeting openers from user prompts."
+    },
+    {
+      "name": "verbose_requests",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:azt szeretném megkérdezni,? hogy|az iránt érdeklődnék,? hogy|arra lennék kíváncsi,? hogy|meg tudnád mondani,? hogy|meg tudnád mutatni,? hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "user",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Shorten indirect Hungarian request formulations."
+    },
+    {
+      "name": "self_reference",
+      "pattern": "^(?:azon dolgozom,? hogy|éppen dolgozom azon,? hogy|próbálom megoldani,? hogy|megpróbálom|azzal próbálkozom,? hogy)\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "user",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove redundant first-person process framing from user prompts."
+    },
+    {
+      "name": "excessive_gratitude",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:nagyon köszönöm|előre is köszönöm|köszönöm szépen|hálás lennék)(?![\\p{L}\\p{N}_])[,.!?\\s]*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove repetitive gratitude that does not affect task intent."
+    },
+    {
+      "name": "qualifier_removal",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:egy kicsit|egy picit|némileg|valamennyire|egyfajta|olyanfajta)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove low-information qualifiers."
+    },
+    {
+      "name": "softeners",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:ha lehet|ha lehetséges|ha van rá lehetőség|amikor ráérsz|ha időd engedi|amennyiben lehetséges)(?![\\p{L}\\p{N}_])[,.!?\\s]*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove optionality-softening phrases that do not change the requested task."
+    },
+    {
+      "name": "uncertainty_fillers",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:nagyjából|többé-kevésbé|valamilyen szinten|bizonyos értelemben|mondhatni|nagy vonalakban)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove vague scope fillers when they add little signal."
+    },
+    {
+      "name": "assistant_fillers",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:itt van|alább találod|az alábbiakban|nézzük meg|lássuk)(?![\\p{L}\\p{N}_])[:,.!?\\s]*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "assistant",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove low-information assistant lead-ins."
+    },
+    {
+      "name": "current_state_filler",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:jelen pillanatban|ebben a pillanatban|most éppen)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "lite",
+      "description": "Remove temporal filler when the current state is obvious from context."
+    },
+    {
+      "name": "meta_politeness",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:köszönettel|köszönetképpen|szíves segítségeddel)(?![\\p{L}\\p{N}_])[,.!?\\s]*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "filler",
+      "minIntensity": "full",
+      "description": "Remove uncommon but redundant courtesy closings."
+    }
+  ]
+}

--- a/open-sse/services/compression/rules/hu/structural.json
+++ b/open-sse/services/compression/rules/hu/structural.json
@@ -1,0 +1,126 @@
+{
+  "language": "hu",
+  "category": "structural",
+  "rules": [
+    {
+      "name": "redundant_phrasing",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:győződj meg róla, hogy|biztosítsd azt, hogy|ügyelj arra, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Remove redundant certainty framing around direct instructions."
+    },
+    {
+      "name": "redundant_because",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:azért van, mert|ennek az oka az, hogy|annak az oka, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "mert ",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Shorten verbose Hungarian causal phrases."
+    },
+    {
+      "name": "redundant_directive",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:fontos, hogy|ne felejtsd el, hogy|érdemes megjegyezni, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Remove directive framing when the following instruction carries the meaning."
+    },
+    {
+      "name": "list_conjunction",
+      "pattern": "(?<![\\p{L}\\p{N}_]),?\\s*(?:és továbbá|valamint még|és ezenkívül)\\s+",
+      "flags": "giu",
+      "replacement": ", ",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Collapse redundant list conjunctions."
+    },
+    {
+      "name": "redundant_quantifiers",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:mindegyik és minden|minden egyes)(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "minden",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Collapse redundant Hungarian quantifier phrases."
+    },
+    {
+      "name": "all_quantifier",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:mind az összes|az összes és minden)(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "összes",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Collapse duplicated totality markers."
+    },
+    {
+      "name": "verbose_connectors",
+      "pattern": "^(?:továbbá,?\\s*|ezenkívül,?\\s*|ráadásul,?\\s*)",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "lite",
+      "description": "Remove low-information transition words at the start of a paragraph."
+    },
+    {
+      "name": "emphasis_removal",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:nagyon|rendkívül|igazán|különösen|teljesen)\\s+(?=[\\p{L}])",
+      "flags": "giu",
+      "replacement": "",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "lite",
+      "description": "Remove common intensifiers when the modified word remains meaningful."
+    },
+    {
+      "name": "task_framing",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a feladata az, hogy|az a feladata, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "Feladat: ",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Convert verbose task-framing prose into a compact label."
+    },
+    {
+      "name": "existence_framing",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:arra van lehetőség, hogy|lehetőség van arra, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "lehet ",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Shorten common possibility framing."
+    },
+    {
+      "name": "conditional_framing",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:abban az esetben, ha)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "ha ",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "lite",
+      "description": "Shorten verbose conditional framing."
+    },
+    {
+      "name": "manner_framing",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:olyan módon, hogy)(?![\\p{L}\\p{N}_])\\s*",
+      "flags": "giu",
+      "replacement": "úgy, hogy ",
+      "context": "all",
+      "category": "structural",
+      "minIntensity": "full",
+      "description": "Shorten verbose manner framing while preserving the conjunction."
+    }
+  ]
+}

--- a/open-sse/services/compression/rules/hu/ultra.json
+++ b/open-sse/services/compression/rules/hu/ultra.json
@@ -1,0 +1,130 @@
+{
+  "language": "hu",
+  "category": "ultra",
+  "rules": [
+    {
+      "name": "ultra_database_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*adatbázis(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "DB",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate adatbázis to the common technical DB form."
+    },
+    {
+      "name": "ultra_config_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*konfiguráció(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "config",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate konfiguráció to config."
+    },
+    {
+      "name": "ultra_function_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*függvény(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "fn",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate függvény to fn."
+    },
+    {
+      "name": "ultra_request_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*kérés(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "req",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate technical request references to req."
+    },
+    {
+      "name": "ultra_response_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*válasz(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "res",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate technical response references to res."
+    },
+    {
+      "name": "ultra_implementation_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*megvalósítás(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "impl",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate megvalósítás to impl."
+    },
+    {
+      "name": "ultra_authentication_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*hitelesítés(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "auth",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate hitelesítés to auth."
+    },
+    {
+      "name": "ultra_authorization_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])jogosultság-ellenőrzés(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "authz",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate explicit authorization-check terminology to authz."
+    },
+    {
+      "name": "ultra_application_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*alkalmazás(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "app",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate technical application references to app."
+    },
+    {
+      "name": "ultra_dependency_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*(?:függőség|függőségek)(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "dep",
+      "replacementMap": {
+        "függőség": "dep",
+        "függőségek": "deps"
+      },
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate dependency/dependencies to dep/deps."
+    },
+    {
+      "name": "ultra_development_environment_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])fejlesztői környezet(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "dev env",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Shorten the common technical phrase fejlesztői környezet."
+    },
+    {
+      "name": "ultra_parameter_abbreviation",
+      "pattern": "(?<![\\p{L}\\p{N}_])(?:a|az)?\\s*paraméter(?![\\p{L}\\p{N}_])",
+      "flags": "giu",
+      "replacement": "param",
+      "context": "all",
+      "category": "ultra",
+      "minIntensity": "ultra",
+      "description": "Abbreviate paraméter to param."
+    }
+  ]
+}

--- a/tests/unit/compression/language-packs.test.ts
+++ b/tests/unit/compression/language-packs.test.ts
@@ -9,10 +9,10 @@ import {
 import { applyRulesToText } from "../../../open-sse/services/compression/caveman.ts";
 import { getRulesForContext } from "../../../open-sse/services/compression/cavemanRules.ts";
 
-const LANGUAGES = ["pt-BR", "es", "de", "fr", "ja", "id"];
+const LANGUAGES = ["pt-BR", "es", "de", "fr", "ja", "id", "hu"];
 
 describe("Caveman language packs", () => {
-  it("ships 6 language packs with at least 15 rules each", () => {
+  it("ships 7 language packs with at least 15 rules each", () => {
     for (const language of LANGUAGES) {
       const rules = loadAllRulesForLanguage(language, { refresh: true });
       assert.ok(rules.length >= 15, `${language} expected 15+ rules, got ${rules.length}`);
@@ -38,6 +38,7 @@ describe("Caveman language packs", () => {
     assert.equal(detectCompressionLanguage("j'ai besoin de corriger cette erreur fichier"), "fr");
     assert.equal(detectCompressionLanguage("このコードを修正してください"), "ja");
     assert.equal(detectCompressionLanguage("bisa tolong jelaskan tentang database ini"), "id");
+    assert.equal(detectCompressionLanguage("kérlek javítsd ezt a hibát a kódban"), "hu");
   });
 
   it("applies non-English rule packs to golden samples", () => {
@@ -94,6 +95,20 @@ describe("Caveman language packs", () => {
     assert.ok(text.includes("src/auth.ts"));
   });
 
+  it("applies Hungarian rules without touching technical terms", () => {
+    const huRules = getRulesForContext("user", "ultra", "hu");
+    const { text } = applyRulesToText(
+      "Kérlek, adj részletes magyarázatot az adatbázis és a hitelesítés hibájáról a src/auth.ts fájlban.",
+      huRules
+    );
+
+    assert.ok(!text.toLowerCase().includes("kérlek"));
+    assert.ok(!text.toLowerCase().includes("részletes magyarázatot"));
+    assert.ok(text.includes("DB"));
+    assert.ok(text.includes("auth"));
+    assert.ok(text.includes("src/auth.ts"));
+  });
+
   it("builds localized output mode instructions", () => {
     const config = { enabled: true, intensity: "full" as const, autoClarity: true };
 
@@ -103,5 +118,6 @@ describe("Caveman language packs", () => {
     assert.match(buildCavemanOutputInstruction(config, "fr"), /Reponds/);
     assert.match(buildCavemanOutputInstruction(config, "ja"), /回答/);
     assert.match(buildCavemanOutputInstruction(config, "id"), /Jawab/);
+    assert.match(buildCavemanOutputInstruction(config, "hu"), /Válaszolj/);
   });
 });


### PR DESCRIPTION
## Summary

- add Hungarian (`hu`) Caveman language rules
- add filler, context, dedup, structural and ultra compression rules
- add Hungarian language detection
- add localized Hungarian Caveman output instructions
- add Hungarian language-pack tests
- update the compression rule application logic to support localized rule keywords

## Validation

- `node --import tsx/esm --test tests/unit/compression/language-packs.test.ts`
- `npm test`
- `npm run lint -- --pass-on-unpruned-suppressions`

## Notes

The Hungarian pack is designed to preserve technical terms, code, URLs,
file paths and identifiers while applying conservative Hungarian-specific
compression rules.