### PR TITLE
fix: bump Codex CLI version fingerprint to 0.153.4 to unblock gpt-6-astra

### DIFF
--- a/docs/security/STEALTH_GUIDE.md
+++ b/docs/security/STEALTH_GUIDE.md
@@ -242,7 +242,7 @@ All MITM endpoints require management auth (`requireCliToolsAuth`). The sudo pas
 | Variable                 | Default                                                         |
 | ------------------------ | --------------------------------------------------------------- |
 | `CLAUDE_USER_AGENT`      | `claude-cli/2.1.258 (external, cli)`                            |
-| `CODEX_USER_AGENT`       | `codex-cli/0.149.0 (Windows 10.0.26200; x64)`                   |
+| `CODEX_USER_AGENT`       | `codex-cli/0.153.4 (Windows 10.0.26200; x64)`                   |
 | `GITHUB_USER_AGENT`      | `GitHubCopilotChat/0.54.0`                                      |
 | `ANTIGRAVITY_USER_AGENT` | `antigravity/2.0.1 linux/arm64 google-api-nodejs-client/10.3.0` |
 | `KIRO_USER_AGENT`        | `AWS-SDK-JS/3.0.0 kiro-ide/1.0.0`                               |

--- a/src/shared/constants/codexClient.ts
+++ b/src/shared/constants/codexClient.ts
@@ -1,9 +1,9 @@
 // Kept in lockstep with the codex CLI actually installed in the OmniRoute image
 // (bin/omniroute-fix.Containerfile installs `codex` latest; app-server runtime is
-// 0.149.0 as of 2026-08-22). When the image's codex is bumped, refresh this so the
+// 0.153.4 as of 2026-09-05). When the image's codex is bumped, refresh this so the
 // fingerprint OpenAI sees from the OAuth/Responses face matches the real client
 // version. Overridable per-deployment via the CODEX_CLIENT_VERSION env.
-export const DEFAULT_CODEX_CLIENT_VERSION = "0.149.0";
+export const DEFAULT_CODEX_CLIENT_VERSION = "0.153.4";
 export const CODEX_CLI_RS_ORIGINATOR = "codex_cli_rs";
 
 export function getCodexCliRsHeaders(

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -1311,16 +1311,16 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.149.0 (<OS>; <ARCH>)",
-        "Version": "0.149.0",
+        "User-Agent": "codex-cli/0.153.4 (<OS>; <ARCH>)",
+        "Version": "0.153.4",
         "X-Codex-Beta-Features": "responses_websockets"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.149.0 (<OS>; <ARCH>)",
-        "Version": "0.149.0",
+        "User-Agent": "codex-cli/0.153.4 (<OS>; <ARCH>)",
+        "Version": "0.153.4",
         "X-Codex-Beta-Features": "responses_websockets"
       },
       "oauth": {
@@ -1328,8 +1328,8 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.149.0 (<OS>; <ARCH>)",
-        "Version": "0.149.0",
+        "User-Agent": "codex-cli/0.153.4 (<OS>; <ARCH>)",
+        "Version": "0.153.4",
         "X-Codex-Beta-Features": "responses_websockets"
       }
     },

--- a/tests/unit/agentrouter-chatcore-protocols.test.ts
+++ b/tests/unit/agentrouter-chatcore-protocols.test.ts
@@ -112,7 +112,7 @@ test("AgentRouter Responses requests automatically use the native Responses prot
       body: structuredClone(body),
       headers: new Headers({ accept: "application/json", originator: "codex_cli_rs" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.ok(captured);
@@ -176,7 +176,7 @@ test("AgentRouter OpenAI Chat requests automatically use the native Chat protoco
       body: structuredClone(body),
       headers: new Headers({ accept: "application/json" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.equal(result.success, true);
@@ -304,7 +304,7 @@ test("AgentRouter Responses streaming stays native without a connection protocol
       body: structuredClone(body),
       headers: new Headers({ accept: "text/event-stream", originator: "codex_cli_rs" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.equal(result.success, true);
@@ -383,7 +383,7 @@ test("AgentRouter OpenAI Chat streaming stays native without a connection protoc
       body: structuredClone(body),
       headers: new Headers({ accept: "text/event-stream" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.equal(result.success, true);

--- a/tests/unit/agentrouter-executor-protocols.test.ts
+++ b/tests/unit/agentrouter-executor-protocols.test.ts
@@ -84,7 +84,7 @@ test("AgentRouter OpenAI Chat dispatch uses Codex identity without Claude-only b
   assert.equal(captured.url, "https://agentrouter.org/v1/chat/completions");
   assert.equal(captured.headers.get("authorization"), "Bearer test-agentrouter-key");
   assert.equal(captured.headers.get("x-api-key"), null);
-  assert.equal(captured.headers.get("user-agent"), "codex_cli_rs/0.149.0");
+  assert.equal(captured.headers.get("user-agent"), "codex_cli_rs/0.153.4");
   assert.equal(captured.headers.get("originator"), "codex_cli_rs");
   assert.equal(captured.headers.get("x-app"), null);
   assert.equal(captured.headers.get("anthropic-version"), null);
@@ -130,7 +130,7 @@ test("AgentRouter OpenAI Responses dispatch uses the Responses endpoint and Code
   assert.ok(captured);
   assert.equal(captured.url, "https://agentrouter.org/v1/responses");
   assert.equal(captured.headers.get("authorization"), "Bearer test-agentrouter-key");
-  assert.equal(captured.headers.get("user-agent"), "codex_cli_rs/0.149.0");
+  assert.equal(captured.headers.get("user-agent"), "codex_cli_rs/0.153.4");
   assert.equal(captured.headers.get("originator"), "codex_cli_rs");
   assert.equal(captured.headers.get("x-app"), null);
   assert.equal(captured.headers.get("anthropic-beta"), null);

--- a/tests/unit/claude-codex-identity-version-sync.test.ts
+++ b/tests/unit/claude-codex-identity-version-sync.test.ts
@@ -57,9 +57,9 @@ test("Claude CLI wire versions match the captured 2.1.258 binary", () => {
   assert.equal(hdr.CLAUDE_CLI_BILLING_VERSION, canonical.CLAUDE_CODE_CLIENT_BILLING_VERSION);
 });
 
-test("Codex client is pinned to the captured 0.149.0 release", () => {
-  assert.equal(codexCfg.getCodexClientVersion(), "0.149.0");
-  assert.equal(codexCfg.getCodexUserAgent(), "codex-cli/0.149.0 (Windows 10.0.26200; x64)");
-  assert.equal(codexCfg.getCodexDefaultHeaders().Version, "0.149.0");
-  assert.equal(codexCfg.getCodexCliRsHeaders()["User-Agent"], "codex_cli_rs/0.149.0");
+test("Codex client is pinned to the captured 0.153.4 release", () => {
+  assert.equal(codexCfg.getCodexClientVersion(), "0.153.4");
+  assert.equal(codexCfg.getCodexUserAgent(), "codex-cli/0.153.4 (Windows 10.0.26200; x64)");
+  assert.equal(codexCfg.getCodexDefaultHeaders().Version, "0.153.4");
+  assert.equal(codexCfg.getCodexCliRsHeaders()["User-Agent"], "codex_cli_rs/0.153.4");
 });

--- a/tests/unit/client-identity-profiles.test.ts
+++ b/tests/unit/client-identity-profiles.test.ts
@@ -43,7 +43,7 @@ test("getClientIdentityProfileHeaders: known CLI profiles expose their preset he
   assert.equal(claudeCli["X-App"], "cli");
 
   const codexCli = getClientIdentityProfileHeaders("codex-cli");
-  assert.equal(codexCli["User-Agent"], "codex_cli_rs/0.149.0");
+  assert.equal(codexCli["User-Agent"], "codex_cli_rs/0.153.4");
   assert.equal(codexCli.originator, "codex_cli_rs");
 
   const geminiCli = getClientIdentityProfileHeaders("gemini-cli");
@@ -80,7 +80,7 @@ test("a selected profile's headers land in providerSpecificData.customHeaders", 
     customHeaders: { ...profileHeaders, "X-Operator-Set": "keep-me" },
   };
 
-  assert.equal(providerSpecificData.customHeaders["User-Agent"], "codex_cli_rs/0.149.0");
+  assert.equal(providerSpecificData.customHeaders["User-Agent"], "codex_cli_rs/0.153.4");
   assert.equal(providerSpecificData.customHeaders.originator, "codex_cli_rs");
   assert.equal(providerSpecificData.customHeaders["X-Operator-Set"], "keep-me");
 });

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -184,10 +184,10 @@ test("CodexExecutor.buildHeaders binds workspace ids and disables SSE accept for
   assert.equal(standardHeaders.Authorization, "Bearer codex-token");
   assert.equal(standardHeaders.Accept, "text/event-stream");
   assert.equal(standardHeaders["chatgpt-account-id"], "workspace-1");
-  assert.equal(standardHeaders.Version, "0.149.0");
+  assert.equal(standardHeaders.Version, "0.153.4");
   assert.equal(standardHeaders["Openai-Beta"], "responses=experimental");
   assert.equal(standardHeaders["X-Codex-Beta-Features"], "responses_websockets");
-  assert.equal(standardHeaders["User-Agent"], "codex-cli/0.149.0 (Windows 10.0.26200; x64)");
+  assert.equal(standardHeaders["User-Agent"], "codex-cli/0.153.4 (Windows 10.0.26200; x64)");
   assert.equal(compactHeaders.Accept, "application/json");
 });
 
@@ -213,7 +213,7 @@ test("CodexExecutor.buildHeaders honors safe env overrides for Version and User-
     },
     () => {
       const headers = executor.buildHeaders({ accessToken: "codex-token" }, true);
-      assert.equal(headers.Version, "0.149.0");
+      assert.equal(headers.Version, "0.153.4");
       assert.equal(headers["User-Agent"], "custom-codex/9.9.9");
     }
   );

--- a/tests/unit/provider-models-route-codex.test.ts
+++ b/tests/unit/provider-models-route-codex.test.ts
@@ -159,11 +159,11 @@ test("provider models route merges live Codex models with the local catalog then
   assert.equal(body.discoveredCandidateCount, undefined);
   assert.deepEqual(seenRequests, [
     {
-      url: "https://chatgpt.com/backend-api/codex/models?client_version=0.149.0",
+      url: "https://chatgpt.com/backend-api/codex/models?client_version=0.153.4",
       authorization: "Bearer codex-access-token",
       workspaceId: "account-123",
       originator: "codex_cli_rs",
-      userAgent: "codex-cli/0.149.0 (Windows 10.0.26200; x64)",
+      userAgent: "codex-cli/0.153.4 (Windows 10.0.26200; x64)",
     },
     {
       url: "https://raw.githubusercontent.com/openai/codex/refs/heads/main/codex-rs/models-manager/models.json",


### PR DESCRIPTION
## What

OmniRoute's `codex` provider doesn't run a real Codex CLI — it replays the user's OAuth token directly to OpenAI's Responses API, but fakes being a real Codex CLI client by sending a hardcoded `User-Agent: codex-cli/<version>` + `originator: codex_cli_rs` header pair. That version was hardcoded as `DEFAULT_CODEX_CLIENT_VERSION = "0.149.0"` in `src/shared/constants/codexClient.ts`.

OpenAI gates newer models server-side by the reported Codex CLI version, and was rejecting requests for the `gpt-6-astra` model with:

```
[400]: {"detail":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}
```

The real, current Codex CLI release on npm (`@openai/codex`) is `0.153.4` as of 2026-09-05 — three minors ahead of the hardcoded value.

## Why

OpenAI checks the reported Codex CLI version server-side per model; `0.149.0` was stale relative to the current `0.153.4` release, causing eligible models to be rejected even though the user's real OAuth session has access.

## Changes

- Bumped `DEFAULT_CODEX_CLIENT_VERSION` from `0.149.0` to `0.153.4` in `src/shared/constants/codexClient.ts` and refreshed the leading comment's version/date reference.
- Updated the duplicated example value in `docs/security/STEALTH_GUIDE.md`'s `CODEX_USER_AGENT` env var table.
- Updated the pinned `0.149.0` literals in the drift-guard/unit tests that assert on this default (`claude-codex-identity-version-sync`, `agentrouter-executor-protocols`, `executor-codex`, `client-identity-profiles`, `provider-models-route-codex`, `agentrouter-chatcore-protocols`) and regenerated the `tests/snapshots/provider/translate-path.json` golden snapshot.
- Left the unrelated `codex-app-server.ts` / `appServerAuthProbe.ts` / `codex-app-server.test.ts` comments about the real app-server binary's verified wire behavior untouched — those describe a different execution path (the app-server executor that spawns the real `codex` binary), not this header fingerprint.

Note: `CODEX_CLIENT_VERSION` env var already exists as an escape hatch/override, so this PR just fixes the shipped default.

## Follow-up (not blocking this PR)

This same drift will keep recurring every time OpenAI bumps the minimum required version. A more durable fix would be to detect the installed CLI's real version at build/runtime (e.g. from the image's `codex --version`) instead of hardcoding a literal that has to be manually kept in sync.

## Testing

- `node --import tsx/esm --test tests/unit/claude-codex-identity-version-sync.test.ts tests/unit/agentrouter-executor-protocols.test.ts tests/unit/executor-codex.test.ts tests/unit/client-identity-profiles.test.ts tests/unit/provider-models-route-codex.test.ts tests/unit/agentrouter-chatcore-protocols.test.ts` — 71 passed
- `node --import tsx/esm --test tests/unit/provider-translate-path-golden.test.ts tests/unit/gemini-cli-legacy-refresh.test.ts` — 8 passed
- `node --import tsx/esm --test tests/integration/chat-pipeline.test.ts` — 27/28 passed; the one failure (`chat pipeline rejects invalid API keys and malformed JSON bodies`, expected 401 got 502) is unrelated to this change (no auth/openai-key code touched) and reproduces identically against the unmodified base tip.