### PR TITLE
fix(tests): Adobe Firefly edits-route test launched a real headless Chrome at firefly.adobe.com

### DIFF
--- a/tests/unit/8510-adobe-firefly-edits-route.test.ts
+++ b/tests/unit/8510-adobe-firefly-edits-route.test.ts
@@ -13,6 +13,12 @@ import path from "node:path";
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-adobe-firefly-edits-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
 process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "adobe-firefly-edits-test-secret";
+// The route path cannot thread ensureAdobeFireflySession's allowBrowserRefresh:false seam,
+// and browser Forter-warm is the DEFAULT engine — without this kill switch the route's
+// session-resolve step launches a real headless Chrome at firefly.adobe.com (two live CDP
+// launches + ~3 min of network waits per suite run; both observed in CI logs).
+const PREV_BROWSER_REFRESH = process.env.ADOBE_FIREFLY_BROWSER_REFRESH;
+process.env.ADOBE_FIREFLY_BROWSER_REFRESH = "0";
 
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
@@ -85,6 +91,8 @@ test.after(() => {
   apiKeysDb.resetApiKeyState();
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  if (PREV_BROWSER_REFRESH === undefined) delete process.env.ADOBE_FIREFLY_BROWSER_REFRESH;
+  else process.env.ADOBE_FIREFLY_BROWSER_REFRESH = PREV_BROWSER_REFRESH;
 });
 
 test("#8510 v1 image edit POST uploads Adobe Firefly reference images and dispatches referenceBlobs", async () => {


### PR DESCRIPTION
## Summary

- `tests/unit/8510-adobe-firefly-edits-route.test.ts` exercises the real `POST /v1/images/edits` route handler. The route's session-resolve step cannot thread `ensureAdobeFireflySession`'s `allowBrowserRefresh: false` seam, and browser Forter-warm is the **default** engine (`adobeFireflySession.ts` — "Browser Forter-warm is the DEFAULT engine"), so every run launched a **real headless Chrome at https://firefly.adobe.com** over CDP.
- Observed in CI run logs: two live CDP launches per suite run plus ~3 min of network retries ("Chrome CDP launch attempt 1 failed: forterToken stale" — expected, since a real token requires a signed-in session).
- Fix: set the documented kill switch `ADOBE_FIREFLY_BROWSER_REFRESH=0` for the test process (mirroring the existing `DATA_DIR` env pattern) and restore it in `test.after`. No production code touched.

## Validation

- `node --import tsx/esm --test tests/unit/8510-adobe-firefly-edits-route.test.ts` — **4/4 pass in 12 s, zero CDP launches** (previously ~3 min with live network waits). Verified `grep -c "CDP warm attached"` = 0 on the fixed run.
- Prettier + ESLint (full lint-staged pre-commit incl. docs-sync, any-budget, tracked-artifacts) — pass.
- No production files changed; single test file, +8 lines.

## Related Issues

- Related to #12732 (inherited base-red — not addressed here)

⚠️ base-red inherited: #12732