### PR TITLE
fix(sse): re-enable prompt compression for native Codex passthrough

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1356,9 +1356,18 @@ export async function handleChatCore({
     const compressionSettings: CompressionConfig | null = compressionSettingsResult.settings;
     // #8034 — operator-named model/endpoint exclusions bypass the whole pipeline, exactly
     // like compression being globally disabled, so the body is provably byte-identical.
-    const compressionExcluded =
-      nativeCodexPassthrough ||
-      isCompressionExcluded({ provider, model: effectiveModel }, compressionSettings?.exclusions);
+    // Native Codex passthrough is deliberately NOT part of this exclusion: prompt
+    // compression runs through adaptBodyForCompression() (Responses input[] → messages
+    // → restore) with codex tool-output eligibility guards, so native contexts still
+    // compress (regression: #8933 introduced the passthrough bypass, landed on release
+    // via #11088, silencing codex analytics to skip_reason='excluded'). Reactive
+    // compaction + combo overflow fail-fast below still bypass native passthrough —
+    // intentionally left for follow-up. Operators who want byte-identical passthrough
+    // can add `codex/*` to the exclusions list.
+    const compressionExcluded = isCompressionExcluded(
+      { provider, model: effectiveModel },
+      compressionSettings?.exclusions
+    );
     // A per-key opt-out is a request-scoped hard kill for prompt compression. It
     // deliberately does not disable the independent reactive context-fit safety
     // passes, matching the existing x-omniroute-compression: off contract.

--- a/tests/unit/codex-prompt-compression-passthrough.test.ts
+++ b/tests/unit/codex-prompt-compression-passthrough.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  isCompressionExcluded,
+  normalizeCompressionExclusions,
+} from "../../open-sse/services/compression/exclusions.ts";
+
+const chatCoreSource = readFileSync(
+  new URL("../../open-sse/handlers/chatCore.ts", import.meta.url),
+  "utf8"
+);
+
+// Regression guard for https://github.com/diegosouzapw/OmniRoute/issues/12793:
+// native Codex passthrough (`POST /v1/responses`, provider `codex`) silently stopped
+// producing compression analytics (100% `skip_reason='excluded'`) after #8933 added
+// `nativeCodexPassthrough ||` to the prompt-compression exclusion (landed on release
+// via #11088). Prompt compression must depend ONLY on the operator exclusions list.
+
+test("codex prompt compression is not gated on native passthrough", () => {
+  const match = chatCoreSource.match(/const compressionExcluded =([\s\S]*?);/);
+  assert.ok(match, "compressionExcluded assignment must exist in chatCore.ts");
+  assert.doesNotMatch(
+    match[1],
+    /nativeCodexPassthrough/,
+    "prompt-compression exclusion must not reference nativeCodexPassthrough"
+  );
+  assert.match(match[1], /isCompressionExcluded/);
+});
+
+test("codex target is compressible by default; operators can still opt out via exclusions", () => {
+  assert.equal(
+    isCompressionExcluded(
+      { provider: "codex", model: "gpt-5.6-terra" },
+      normalizeCompressionExclusions([])
+    ),
+    false
+  );
+  assert.equal(
+    isCompressionExcluded(
+      { provider: "codex", model: "gpt-5.6-terra" },
+      normalizeCompressionExclusions(["codex/*"])
+    ),
+    true
+  );
+});
+
+test("prompt-only scope: reactive compaction still bypasses native passthrough", () => {
+  // Deliberately left for follow-up (overflow fail-fast + history-rewriting safety).
+  // If these gates are ever lifted, update the PR body notes, not just this test.
+  assert.match(
+    chatCoreSource,
+    /reactiveContextCompactionEnabled\s*&&\s*!nativeCodexPassthrough\s*&&\s*estimatedTokens\s*>\s*threshold/
+  );
+  assert.match(
+    chatCoreSource,
+    /reactiveContextCompactionEnabled\s*&&\s*!nativeCodexPassthrough\s*&&\s*finalEstimatedInputTokens\s*>=\s*finalContextLimit/
+  );
+});

--- a/tests/unit/combo-context-overflow-compression-probe.test.ts
+++ b/tests/unit/combo-context-overflow-compression-probe.test.ts
@@ -148,12 +148,15 @@ test("#10225 combo keeps the fast 400 when compression is disabled", async () =>
 
 // #10501-sweep #10503 — the deferral above is NOT target-aware by default: it only
 // checks operator-named compression exclusions, never whether chatCore will actually
-// attempt compression for the resolved target. handleChatCore.ts unconditionally sets
-// `compressionExcluded = nativeCodexPassthrough || ...` for a verified native Codex
-// Responses passthrough target (open-sse/handlers/chatCore.ts) — deferring the
+// attempt compression for the resolved target. chatCore's *reactive* compaction and
+// last-resort gates still bypass native Codex passthrough targets
+// (open-sse/handlers/chatCore.ts `!nativeCodexPassthrough` checks) — deferring the
 // preflight there means an oversized request sails past BOTH gates uncompressed. These
 // tests pin the fix: a native-codex-passthrough target must never count toward "can
 // compress", so the hard preflight stays active and no upstream dispatch happens.
+// NOTE: prompt (proactive) compression DOES run for native passthrough since the
+// codex analytics fix (see chatCore.ts `compressionExcluded`); only the reactive /
+// combo-deferral bypasses remain. That split is intentional prompt-only scope.
 // NOTE on `clientManagedResponsesContext: false` below: these tests deliberately do
 // NOT set it, to isolate the fix from the PRE-EXISTING, unrelated early-return a few
 // lines above in knownContextOverflow.ts ("Native Codex Responses clients compact
@@ -163,7 +166,7 @@ test("#10225 combo keeps the fast 400 when compression is disabled", async () =>
 // circuits to true for `provider === "codex"` regardless of verification (see
 // passthroughHelpers.ts), so an UNVERIFIED request that nonetheless targets a `codex`
 // combo member over `/v1/responses` in openai-responses format still hits chatCore's
-// compression bypass — exactly the gap `sourceFormat`/`endpointPath` (not the looser
+// reactive compression bypass — exactly the gap `sourceFormat`/`endpointPath` (not the looser
 // `clientManagedResponsesContext` flag) now closes.
 test("#10503 handleComboChat: native-codex-passthrough pool fails FAST locally, zero upstream dispatches", async () => {
   saveModelsDevCapabilities({ codex: { "gpt-5.6-terra": capabilityEntry(272_000) } });


### PR DESCRIPTION
## Summary

Native Codex passthrough (`POST /v1/responses`, `provider=codex`, e.g. opencode → omniroute) silently stopped producing compression savings: 100% of codex rows in `compression_analytics` became `skip_reason='excluded', mode='off', tokens_saved=0` while `call_logs` volume continued.

**Root cause:** Commit `32f83407` (2026-08-11, #8933) added `nativeCodexPassthrough ||` to the prompt-compression exclusion gate. Carried onto release line via `65e81158a` (v3.8.50, #11088 sync).

## Fix (prompt-only scope)

`open-sse/handlers/chatCore.ts`: `compressionExcluded` no longer includes `nativeCodexPassthrough`; prompt compression now depends only on the operator exclusions list (`#8034`). Native contexts compress via the existing `adaptBodyForCompression()` Responses→messages adapter with codex tool-output eligibility guards. Operators who want byte-identical passthrough can add `codex/*` to exclusions.

## Deliberately NOT changed (reactive + combo deferral)

- Reactive proactive/last-resort compaction (`!nativeCodexPassthrough` gates in `chatCore.ts`) still bypass native passthrough. These passes rewrite history (`trim_tools`/`purify_history`) and are the overflow safety net — re-enabling them for stateful Responses contexts needs its own validation.
- Combo overflow fail-fast (`dispatchPrelude`/`knownContextOverflow`, `#10225` / `#10503`) still treats native-codex pools as incompressible, so oversized requests keep failing fast locally instead of sailing upstream uncompressed.
- Net effect: normal-sized codex requests compress again (analytics return); oversized codex requests still fail fast without attempting compression. That asymmetry is intentional and pinned by the updated `#10503` comments.

## Regression Analysis & Verification

See issue comment: https://github.com/diegosouzapw/OmniRoute/issues/12793#issuecomment-5556101123

**Timeline:**
- **Aug 6** (#9200): Added `reactiveContextCompactionEnabled` to honor global compression "off" for reactive compaction
- **Aug 11** (#8933): **REGRESSION INTRODUCED** - added `nativeCodexPassthrough ||` to `compressionExcluded`, unconditionally disabling ALL compression for Codex `/v1/responses`
- **Aug 23** (65e81158a): Sync commit carried both to release line → **v3.8.50+ broken**

**Why #9200 didn't prevent this:** #8933 came AFTER #9200 and added a NEW unconditional bypass that overrode the global switch #9200 introduced.

**What #8933 actually fixed (verified still intact with my PR):**
1. **Executor repair** (`codex.ts`): `repairMissingCodexToolCallOutputs` - ensures function_call_output items exist for every function_call ✅ (43/43 tests pass)
2. **Compression bodyAdapter** (`bodyAdapter.ts`): Enhanced to properly track/restore `custom_tool_call` ↔ `custom_tool_call_output` pairing during compression ✅ (11/11 tests pass)
3. **Combo overflow** (`clientManagedResponsesContext` flag): Allows native Codex clients to self-manage context overflow ✅ (17/17 tests pass, including "native Responses context reaches an all-Codex target beyond its catalog hint")

**#9200 fix verified intact:** Global compression "off" still gates reactive/last-resort compaction ✅ (1/1 test passes)

## Validation

- New regression guard `tests/unit/codex-prompt-compression-passthrough.test.ts` (3/3 pass; first assertion fails on pre-fix source).
- Existing suites green: `compression-exclusions` (8/8), `chatcore-request-format` (9/9), `combo-context-overflow-compression-probe` (5/5 substantive incl. end-to-end chatCore compression dispatch; file has pre-existing teardown DB handle hang unrelated to this change), `executor-codex` (43/43), `body-adapter` (11/11), `combo-context-window-filter` (17/17), `reactive-context-compaction-policy` (1/1).

## Related

Closes #12793