### PR TITLE
fix(cursor): preserve native Claude effort model IDs before executor dispatch

### DIFF
--- a/docs/providers/CURSOR-API-KEY-AND-CLI.md
+++ b/docs/providers/CURSOR-API-KEY-AND-CLI.md
@@ -1,7 +1,7 @@
 ---
 title: "Cursor API provider and the Cursor CLI passthrough"
-version: 3.8.50
-lastUpdated: 2026-08-19
+version: 3.8.51
+lastUpdated: 2026-09-05
 ---
 
 # Cursor API provider and the Cursor CLI passthrough
@@ -65,6 +65,18 @@ Notes:
   needed on the OmniRoute host.
 - `POST /api/providers/{id}/refresh-cursor` is for the `cursor` IDE provider
   only; `cursor-api` connections have no IDE session to renew.
+
+## Native model IDs and effort
+
+For `cursor` / `cu` and `cursor-api` / `cua`, the shared Claude-effort normalizer
+leaves the requested model ID intact. Cursor can advertise a suffix such as
+`-low` as part of a real model ID, rather than as an OmniRoute effort alias.
+The Cursor executor preserves an exact live-catalog match; when there is no
+match, its existing model resolver owns suffix-to-parameter fallback.
+
+This does not change effort normalization for direct Claude, Claude-compatible,
+or Vertex routes. Availability still depends on the selected Cursor account's
+catalog and entitlement.
 
 ## Cursor CLI passthrough
 

--- a/open-sse/handlers/chatCore/claudeEffortVariant.ts
+++ b/open-sse/handlers/chatCore/claudeEffortVariant.ts
@@ -38,6 +38,17 @@ export function applyClaudeEffortVariant(opts: {
   sourceFormat: string;
 }): { effectiveModel: string; log: string | null } {
   const { provider, body, sourceFormat } = opts;
+  // Cursor advertises native effort-suffixed ids. Its executor resolves exact
+  // live-catalog ids before applying its own suffix fallback; stripping here
+  // destroys that information before the executor can see it.
+  if (
+    provider === "cursor" ||
+    provider === "cu" ||
+    provider === "cursor-api" ||
+    provider === "cua"
+  ) {
+    return { effectiveModel: opts.effectiveModel, log: null };
+  }
   let effectiveModel = opts.effectiveModel;
   let log: string | null = null;
 

--- a/tests/unit/chatcore-claude-effort-variant.test.ts
+++ b/tests/unit/chatcore-claude-effort-variant.test.ts
@@ -10,6 +10,48 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { applyClaudeEffortVariant } from "../../open-sse/handlers/chatCore/claudeEffortVariant.ts";
 import { FORMATS } from "../../open-sse/translator/formats.ts";
+import { resolveRequestedModel } from "../../open-sse/utils/cursorAgentProtobuf.ts";
+
+for (const provider of ["cursor", "cu", "cursor-api", "cua"]) {
+  for (const sourceFormat of [FORMATS.OPENAI, FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES]) {
+    test(`${provider}/${sourceFormat}: preserves native Cursor Claude model ids before executor resolution`, () => {
+      for (const model of [
+        "claude-fable-5-1-low",
+        "claude-fable-5-1-thinking-low",
+        "claude-opus-5-low",
+      ]) {
+        const body = { model, messages: [] };
+        const result = applyClaudeEffortVariant({
+          provider,
+          effectiveModel: model,
+          body,
+          sourceFormat,
+        });
+        assert.deepEqual(result, { effectiveModel: model, log: null });
+        assert.deepEqual(body, { model, messages: [] });
+        assert.deepEqual(
+          resolveRequestedModel(result.effectiveModel, { liveCatalogIds: new Set([model]) }),
+          { modelId: model, parameters: [] }
+        );
+      }
+    });
+  }
+}
+
+test("Cursor preserves explicit client effort while its encoder owns non-catalog suffix fallback", () => {
+  const body = { model: "claude-opus-5-low", reasoning_effort: "none", messages: [] };
+  const result = applyClaudeEffortVariant({
+    provider: "cursor",
+    effectiveModel: body.model,
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.deepEqual(body, { model: "claude-opus-5-low", reasoning_effort: "none", messages: [] });
+  assert.deepEqual(resolveRequestedModel(result.effectiveModel, { liveCatalogIds: new Set() }), {
+    modelId: "claude-opus-5",
+    parameters: [{ id: "effort", value: "low" }],
+  });
+});
 
 test("claude provider + effort suffix → strips to base, mutates body model + reasoning_effort, returns log", () => {
   const body: Record<string, unknown> = { model: "claude-sonnet-4-high", messages: [] };


### PR DESCRIPTION
## Summary

- Skip shared Anthropic effort-suffix stripping on Cursor provider IDs and aliases (`cursor`, `cu`, `cursor-api`, `cua`).
- Preserve exact live-catalog IDs such as `claude-fable-5-1-low` until the existing Cursor model resolver receives them.
- Retain Cursor's existing non-catalog suffix fallback and existing behavior for direct Claude, Claude-compatible, and Vertex providers.
- Document provider-owned model-ID resolution.

## Related Issues

- Duplicate check: not completed before submission. Recheck open Cursor/effort issues for pre-dispatch stripping of a valid native live-catalog effort ID.
- Base-red observed during preparation: #12732. Unrelated base failures are not fixed by this change.

## Validation

- [x] Change type: provider / routing
- [x] Focused normalizer and Cursor encoder tests: 32 passed. All 13 added cases failed on the unmodified normalizer first; the original 11 normalizer cases remained green.
- [ ] Provider translate-path golden test: 2 passes, 1 snapshot mismatch, reproduced on the untouched same-commit ZCode worktree. No golden regeneration performed.
- [ ] `npm run lint`: fails only on unused suppressions; identical failure reproduces on the unchanged same-commit baseline. Scoped ESLint on both changed TypeScript files passed.
- [x] `check:provider-consistency` and `check:provider-assets`
- [ ] `check:docs-all`: version sync and frontmatter passed, then stopped on three migration-count claims (169 documented vs 170 measured); same failure reproduces on the unchanged baseline.
- [x] Isolated full HTTP gateway: Fable Low text, SSE, forced tool call and tool-result continuation all passed (four requests).
- [x] Reconciled with the active release base at preparation time
- [x] Production-code changes include automated tests
- [x] `git diff --check`
- [x] `npm run typecheck:core`: clean

## Tests Added Or Updated

- `tests/unit/chatcore-claude-effort-variant.test.ts`: 4 provider identifiers x 3 client formats, with native Fable Low, thinking-low, and Opus Low IDs; checks normalizer output, unmutated body, and downstream exact-catalog resolution. One additional test checks explicit client effort remains unchanged and the encoder still owns non-catalog fallback.
- Existing `tests/unit/cursor-live-catalog-passthrough.test.ts` also passed, including Composer and GPT model-ID cases.

## Coverage Notes

- The new early-return branch and its provider aliases are exercised. Node's focused coverage run measured 100% lines, 95.24% branches and 100% functions for `claudeEffortVariant.ts`. The full suite/coverage matrix and production packaging remain pending; the isolated HTTP canary has passed.

## Reviewer Notes

- The reported live failure was a pre-dispatch rewrite of a valid Cursor model ID. The unchanged executor succeeds with the exact ID, but the gateway used to strip `-low` first.
- This change does not fix the separate misclassification of Cursor `not_found` as a retryable 429.
- No token, authentication, account, CLI-version, live gateway, or deployment configuration change is included.