### PR TITLE
fix(responses): preserve provider aliases alongside namespace identities

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,5 +1,5 @@
 import {
-  extractRequestToolIdentityMap,
+  extractRequestToolMetadata,
   resolveResponseToolNameMap,
 } from "./chatCore/requestToolIdentity.ts";
 import { injectMemoryAndSkills } from "./chatCore/memorySkillsInjection.ts";
@@ -2600,8 +2600,9 @@ export async function handleChatCore({
   // Keep the request translator's namespace identities separate from toolNameMap:
   // the latter is a Kiro/Claude passthrough alias channel with string values,
   // while namespace identities carry `{namespace, name}` for the #7936 response
-  // seam. Extract first because Kiro merge may reuse `_toolNameMap` below.
-  const requestToolIdentityMap = extractRequestToolIdentityMap(translatedBody);
+  // seam. Capture both before stripping their side channels: a Responses ->
+  // Gemini/Antigravity pivot carries both maps, not one recoverable ledger.
+  const { requestToolIdentityMap, toolNameAliasMap } = extractRequestToolMetadata(translatedBody);
 
   // Kiro: sanitize tool schemas before dispatch. Kiro returns 400 "Improperly
   // formed request" for unsupported JSON-Schema keywords (anyOf/$ref/if-then,
@@ -2642,13 +2643,13 @@ export async function handleChatCore({
   }
 
   // Extract toolNameMap for response translation (Claude OAuth)
-  const translatedToolNameMap = translatedBody._toolNameMap;
+  const translatedToolNameMap = translatedBody._toolNameMap ?? toolNameAliasMap;
   const nativeClaudeToolNameMap = isClaudePassthrough
     ? buildClaudePassthroughToolNameMap(body)
     : null;
-  // Resolution order matters: `_toolNameMap` was already deleted by
-  // `extractRequestToolIdentityMap`, so Gemini/Antigravity depend on the
-  // `requestToolIdentityMap` fallback inside this helper (#9568 / #7936).
+  // A later provider-specific ledger (Kiro above) wins; otherwise use the
+  // alias map captured before extraction. Namespace identities are distinct
+  // from aliases and cannot restore sanitized Gemini names on their own.
   const toolNameMap = resolveResponseToolNameMap(
     translatedToolNameMap,
     nativeClaudeToolNameMap,

--- a/open-sse/handlers/chatCore/requestToolIdentity.ts
+++ b/open-sse/handlers/chatCore/requestToolIdentity.ts
@@ -1,6 +1,25 @@
 export type NamespaceIdentity = { namespace: string; name: string };
 
 /**
+ * Capture both ledgers before the legacy extractor deletes their side channels.
+ * Responses pivots carry object-valued namespace identities AND string-valued
+ * provider aliases; recovering aliases from identities alone loses the latter.
+ */
+export function extractRequestToolMetadata(translatedBody: Record<string, unknown>): {
+  requestToolIdentityMap: Map<string, NamespaceIdentity> | null;
+  toolNameAliasMap: Map<string, string> | null;
+} {
+  const toolNameAliasMap = toToolNameAliasMap(
+    translatedBody._toolNameMap instanceof Map ? translatedBody._toolNameMap : null
+  );
+  const requestToolIdentityMap = extractRequestToolIdentityMap(translatedBody);
+  return {
+    requestToolIdentityMap,
+    toolNameAliasMap: toolNameAliasMap ?? toToolNameAliasMap(requestToolIdentityMap),
+  };
+}
+
+/**
  * Return a string-valued copy only when the complete map is an alias ledger.
  *
  * The legacy `_toolNameMap` side channel can carry either response aliases or

--- a/tests/unit/antigravity-responses-tool-metadata-roundtrip.test.ts
+++ b/tests/unit/antigravity-responses-tool-metadata-roundtrip.test.ts
@@ -1,0 +1,320 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractRequestToolMetadata,
+  resolveResponseToolNameMap,
+} from "../../open-sse/handlers/chatCore/requestToolIdentity.ts";
+
+await import("../../open-sse/translator/bootstrap.ts");
+const { translateRequest, translateResponse, initState } =
+  await import("../../open-sse/translator/index.ts");
+
+const names = ["mcp__graft__freshness", "mcp_graft_freshness"];
+const request = {
+  model: "gemini-3.7-flash-low",
+  input: "Use the requested tool",
+  tools: [
+    {
+      type: "namespace",
+      name: "functions",
+      tools: names.map((name) => ({
+        type: "function",
+        name,
+        description: "Return a test value",
+        parameters: {
+          type: "object",
+          properties: { token: { type: "string" } },
+          required: ["token"],
+        },
+      })),
+    },
+    {
+      type: "function",
+      name: "mcp__memory__health",
+      parameters: { type: "object", properties: {} },
+    },
+    { type: "function", name: "mcp_memory_health", parameters: { type: "object", properties: {} } },
+  ],
+};
+type WireRequest = { tools: Array<{ functionDeclarations: Array<{ name: string }> }> };
+type Event = {
+  event: string;
+  data: {
+    item?: { type?: string; name?: string; namespace?: string; arguments?: string };
+    response?: { output?: Array<{ name?: string; namespace?: string }> };
+  };
+};
+
+for (const target of ["gemini", "antigravity"]) {
+  test(`${target}: both namespace identities and sanitizer aliases survive chatCore extraction`, () => {
+    const body = translateRequest(
+      "openai-responses",
+      target,
+      request.model,
+      structuredClone(request),
+      true,
+      { projectId: "test-project" },
+      null,
+      "antigravity"
+    ) as Record<string, unknown>;
+    const aliasesBefore = body._toolNameMap as Map<string, string>;
+    const identitiesBefore = body._namespaceToolIdentityMap;
+    assert(aliasesBefore instanceof Map);
+    assert(identitiesBefore instanceof Map);
+    const metadata = extractRequestToolMetadata(body);
+    assert.deepEqual(metadata.toolNameAliasMap, aliasesBefore);
+    assert.equal(metadata.requestToolIdentityMap, identitiesBefore);
+    assert.equal(body._toolNameMap, undefined);
+    assert.equal(body._namespaceToolIdentityMap, undefined);
+    const serialized = JSON.stringify(body);
+    assert(!serialized.includes("_toolNameMap"));
+    assert(!serialized.includes("_namespaceToolIdentityMap"));
+  });
+
+  test(`${target}: sanitized colliding MCP names return exact Responses namespace/name pairs`, () => {
+    const body = translateRequest(
+      "openai-responses",
+      target,
+      request.model,
+      structuredClone(request),
+      true,
+      { projectId: "test-project" },
+      null,
+      "antigravity"
+    ) as Record<string, unknown>;
+    const wire = (target === "antigravity" ? body.request : body) as WireRequest;
+    const wireNames = wire.tools
+      .flatMap((tool) => tool.functionDeclarations ?? [])
+      .map((tool) => tool.name);
+    assert.equal(new Set(wireNames).size, 4);
+    assert(
+      wireNames.some((name) => /_[a-f0-9]{8,}$/.test(name)),
+      "precondition: real sanitizer collision"
+    );
+    const { requestToolIdentityMap, toolNameAliasMap } = extractRequestToolMetadata(body);
+    const expected = [
+      ...names.map((name) => ({ namespace: "functions", name })),
+      { namespace: undefined, name: "mcp__memory__health" },
+      { namespace: undefined, name: "mcp_memory_health" },
+    ];
+    wireNames.forEach((name, index) => {
+      const state = initState("openai-responses") as Record<string, unknown>;
+      state.requestToolIdentityMap = requestToolIdentityMap;
+      state.toolNameMap = resolveResponseToolNameMap(
+        body._toolNameMap ?? toolNameAliasMap,
+        null,
+        requestToolIdentityMap
+      );
+      const payload = {
+        responseId: `resp-${index}`,
+        modelVersion: request.model,
+        candidates: [
+          {
+            content: { parts: [{ functionCall: { name, args: { token: "ok" } } }] },
+            finishReason: "STOP",
+          },
+        ],
+      };
+      const events: Event[] = [
+        ...translateResponse(
+          target,
+          "openai-responses",
+          target === "antigravity" ? { response: payload } : payload,
+          state
+        ),
+        ...translateResponse(target, "openai-responses", null, state),
+      ];
+      for (const eventName of ["response.output_item.added", "response.output_item.done"]) {
+        const item = events.find(
+          (event) => event.event === eventName && event.data.item?.type === "function_call"
+        )?.data.item;
+        assert(item, `${eventName}: missing function call`);
+        assert.deepEqual(
+          { namespace: item.namespace ?? undefined, name: item.name },
+          expected[index]
+        );
+      }
+      const output = events.find((event) => event.event === "response.completed")?.data.response
+        ?.output;
+      assert(output, "missing terminal response.completed");
+      const item = output.find((item) => item.name);
+      assert.deepEqual(
+        { namespace: item?.namespace ?? undefined, name: item?.name },
+        expected[index]
+      );
+    });
+  });
+}
+
+test("namespace-only metadata never becomes a string alias map", () => {
+  const identity = new Map([["functions__read", { namespace: "functions", name: "read" }]]);
+  const metadata = extractRequestToolMetadata({
+    _namespaceToolIdentityMap: identity,
+    _toolNameMap: identity,
+  });
+  assert.equal(metadata.toolNameAliasMap, null);
+  assert.equal(metadata.requestToolIdentityMap, identity);
+});
+
+test("parallel native MCP calls after reasoning keep distinct output identities", () => {
+  const expected = [
+    { namespace: "mcp__graft", name: "graft_check_freshness" },
+    { namespace: "mcp__openviking_memory", name: "health" },
+  ];
+  const body = translateRequest(
+    "openai-responses",
+    "antigravity",
+    request.model,
+    {
+      input: "Call both health tools",
+      tools: expected.map((tool) => ({
+        type: "namespace",
+        name: tool.namespace,
+        tools: [
+          {
+            type: "function",
+            name: tool.name,
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      })),
+    },
+    true,
+    { projectId: "test-project" },
+    null,
+    "antigravity"
+  ) as Record<string, unknown>;
+  const wireNames = (body.request as WireRequest).tools
+    .flatMap((tool) => tool.functionDeclarations)
+    .map((tool) => tool.name);
+  const metadata = extractRequestToolMetadata(body);
+  const state = initState("openai-responses") as Record<string, unknown>;
+  state.requestToolIdentityMap = metadata.requestToolIdentityMap;
+  state.toolNameMap = metadata.toolNameAliasMap;
+  const events = [
+    ...translateResponse(
+      "antigravity",
+      "openai-responses",
+      {
+        response: {
+          responseId: "parallel",
+          candidates: [{ content: { parts: [{ text: "Checking both tools", thought: true }] } }],
+        },
+      },
+      state
+    ),
+    ...translateResponse(
+      "antigravity",
+      "openai-responses",
+      {
+        response: {
+          responseId: "parallel",
+          candidates: [
+            {
+              content: {
+                parts: wireNames.map((name, index) => ({
+                  functionCall: { id: `parallel-${index}`, name, args: {} },
+                })),
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      },
+      state
+    ),
+    ...translateResponse("antigravity", "openai-responses", null, state),
+  ];
+  const terminal = events.filter((event) => event.event === "response.completed");
+  assert.equal(terminal.length, 1);
+  const calls = terminal[0].data.response.output.filter((item) => item.type === "function_call");
+  assert.equal(calls.length, 2);
+  assert.equal(new Set(calls.map((item) => item.call_id)).size, 2);
+  assert.deepEqual(
+    calls.map((item) => ({ namespace: item.namespace, name: item.name })),
+    expected
+  );
+  for (const eventName of ["response.output_item.added", "response.output_item.done"]) {
+    const items = events.filter(
+      (event) => event.event === eventName && event.data.item?.type === "function_call"
+    );
+    assert.equal(items.length, 2);
+    assert.equal(new Set(items.map((event) => event.data.output_index)).size, 2);
+    assert.deepEqual(
+      items.map((event) => ({ namespace: event.data.item.namespace, name: event.data.item.name })),
+      expected
+    );
+  }
+});
+
+test("alias-only extraction remains compatible and empty requests have no metadata", () => {
+  const aliases = new Map([["mcp_graft_health", "mcp__graft__health"]]);
+  const body = { _toolNameMap: aliases };
+  const metadata = extractRequestToolMetadata(body);
+  assert.deepEqual(metadata.toolNameAliasMap, aliases);
+  assert.equal(body._toolNameMap, undefined);
+  assert.deepEqual(extractRequestToolMetadata({}), {
+    requestToolIdentityMap: null,
+    toolNameAliasMap: null,
+  });
+});
+
+for (const target of ["gemini", "antigravity"]) {
+  test(`${target}: tool-result replay does not grow collision hashes over repeated turns`, () => {
+    const input: Array<Record<string, unknown>> = [{ role: "user", content: "Use the first tool" }];
+    let previousWireNames: string[] | undefined;
+    for (let turn = 0; turn < 4; turn++) {
+      const body = translateRequest(
+        "openai-responses",
+        target,
+        request.model,
+        { ...structuredClone(request), input: structuredClone(input) },
+        true,
+        { projectId: "test-project" },
+        null,
+        "antigravity"
+      ) as Record<string, unknown>;
+      const wire = (target === "antigravity" ? body.request : body) as WireRequest;
+      const wireNames = wire.tools
+        .flatMap((tool) => tool.functionDeclarations ?? [])
+        .map((tool) => tool.name);
+      if (previousWireNames) assert.deepEqual(wireNames, previousWireNames);
+      previousWireNames = wireNames;
+      const { requestToolIdentityMap, toolNameAliasMap } = extractRequestToolMetadata(body);
+      const state = initState("openai-responses") as Record<string, unknown>;
+      state.requestToolIdentityMap = requestToolIdentityMap;
+      state.toolNameMap = resolveResponseToolNameMap(
+        body._toolNameMap ?? toolNameAliasMap,
+        null,
+        requestToolIdentityMap
+      );
+      const payload = {
+        responseId: `replay-${turn}`,
+        modelVersion: request.model,
+        candidates: [
+          {
+            content: { parts: [{ functionCall: { name: wireNames[0], args: { token: "ok" } } }] },
+            finishReason: "STOP",
+          },
+        ],
+      };
+      const events = [
+        ...translateResponse(
+          target,
+          "openai-responses",
+          target === "antigravity" ? { response: payload } : payload,
+          state
+        ),
+        ...translateResponse(target, "openai-responses", null, state),
+      ];
+      const item = events.find(
+        (event) =>
+          event.event === "response.output_item.done" && event.data.item?.type === "function_call"
+      )?.data.item;
+      assert(item);
+      assert.equal(item.name, names[0]);
+      assert.equal(item.namespace, "functions");
+      input.push(item, { type: "function_call_output", call_id: item.call_id, output: "ok" });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Preserve both request-scoped tool metadata maps before stripping their transport side channels.
- Responses pivots carry object-valued namespace identities plus string-valued provider aliases. The previous extraction preferred the namespace map and deleted the alias map; its recovery fallback could not recover strings from namespace objects.
- Add `extractRequestToolMetadata` and use its captured alias ledger in chatCore, while retaining later provider-specific map precedence and legacy extraction behavior for other callers.
- No sanitizer changes, guessed name mappings, auth changes, new provider or runtime feature flag.

## Related Issues

- Related-issue state UNVERIFIED at submission: recheck live #12007 and #9780/#9783 and link the correct issues. Earlier notes conflict on whether #12007 is closed or open.
- Base-red inherited: #12732.

## Validation

- [x] Change type: routing / provider translation
- [x] Red-before-green: four new namespace/alias cases reproduced the loss before the fix; the namespace-only guard already passed.
- [x] Focused five-file suite: 30 passed; one additional parallel-MCP regression subsequently passed (31 distinct checks across those runs).
- [x] Scoped ESLint on both production files and the new test file.
- [x] Changed metadata helper coverage: 100% lines, branches and functions in the focused coverage run.
- [x] Live Responses SSE namespace/collision identity and tool-result continuation.
- [x] Native Codex CLI 0.153.3: real Graft freshness and OpenViking health calls completed, final exact marker returned, exit 0.
- [ ] Full lint/CI/coverage matrix and production packaging.
- [x] Production changes include a regression test.
- [x] `npm run typecheck:core`: clean.
- [x] `check:provider-consistency` and `check:provider-assets`: pass.
- [x] `git diff --check`: clean.

## Tests Added Or Updated

- `tests/unit/antigravity-responses-tool-metadata-roundtrip.test.ts` exercises real request and response translators, the chatCore metadata-extraction helper, exact namespace/name restoration on added/done/completed events, genuine sanitizer collisions, four-turn replay without hash growth, alias-only and namespace-only requests, and parallel native MCP calls following reasoning.

## Coverage Notes

- The changed `open-sse/handlers/chatCore/requestToolIdentity.ts` reached 100% line/branch/function coverage. Live HTTP and native-client tests cover the new chatCore wiring; they do not replace the full cross-platform build/CI matrix.

## Reviewer Notes

- The live tests ran the isolated worktree's actual Next HTTP server in full profile on loopback, not a modified production deployment.
- Model: `antigravity/gemini-3.1-pro-low`, explicitly present in the account's synced catalog. This is evidence for that route, not every Antigravity model or multi-account behavior.
- Cleanup: temporary credentials inactive/cleared, child processes exited, test listeners closed. The running full build remains at `2265ce761f76b6c81e34515cc8483ca127d4b414`.
- This does not establish Claude Code continuation, multi-account/long-session parity or release readiness. Nothing was promoted.