### PR TITLE
fix(sse): fix double-escaped tabs in Codex JSON tool call arguments

### DIFF
--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -517,7 +517,7 @@ function emitToolCall(state, emit, tc) {
   if (tc.function?.arguments) {
     const refCallId = state.funcCallIds[tcIdx] || newCallId;
     const existingArgs = state.funcArgsBuf[tcIdx] || "";
-    const sanitized = escapeJsonStringValues(tc.function.arguments);
+    const sanitized = escapeJsonStringValues(fixDoubleEscapedTabs(tc.function.arguments));
     const nextArgs = appendToolCallArgumentDelta(existingArgs, sanitized);
     const emittedDelta = nextArgs.slice(existingArgs.length);
     state.funcArgsBuf[tcIdx] = nextArgs;

--- a/tests/unit/bug-12831.test.ts
+++ b/tests/unit/bug-12831.test.ts
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { openaiToOpenAIResponsesResponse } from "../../open-sse/translator/response/openai-responses.ts";
+
+test("Issue #12831: fixes double-escaped tabs in Codex JSON tool call arguments", () => {
+  const events = [];
+  const emit = (name, payload) => events.push(payload);
+  const state = {
+    responseId: "res_123",
+    funcCallIds: {},
+    funcNames: {},
+    funcArgsBuf: {},
+    funcArgsDone: {},
+    funcItemAdded: {},
+    funcItemDone: {},
+    msgItemAdded: {},
+    msgContentAdded: {},
+    msgTextBuf: {},
+    msgItemDone: {},
+  };
+
+  const chunk1 = {
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_123",
+              function: {
+                name: "_edit",
+                // gpt-5.6-luna-xhigh emits literally \ followed by t in the JSON string
+                // to represent a tab, instead of a JSON escape for tab or a raw tab.
+                // Wait, in JSON, a tab in a string is encoded as "\t" (two characters: \ and t).
+                // If it's double-escaped, it emits "\t" (four characters: \, \, t in JSON string? No, two backslashes and a t: "\t")
+                // Let's assume the string is: {"input": "some code\twith tabs"}
+                arguments: '{\n  "input": "some code\\twith tabs"',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const chunk2 = {
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                arguments: "\n}",
+              },
+            },
+          ],
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+  };
+
+  const chunk3 = {
+    usage: { prompt_tokens: 10, completion_tokens: 10 },
+  };
+
+  function processChunk(chunk) {
+    const chunkEvents = openaiToOpenAIResponsesResponse(chunk, state);
+    for (const ev of chunkEvents) {
+      emit(ev.event, ev.data);
+    }
+  }
+
+  processChunk(chunk1);
+  processChunk(chunk2);
+  processChunk(chunk3);
+
+  const doneEvent = events.find((e) => e.type === "response.function_call_arguments.done");
+
+  // Try parsing the arguments
+  const parsed = JSON.parse(doneEvent.arguments);
+  assert.strictEqual(
+    parsed.input,
+    "some code\twith tabs",
+    "The double-escaped tab should be unescaped to a single tab character"
+  );
+});


### PR DESCRIPTION
Fixes #12831. When the Codex upstream model produces string values in tool arguments that contain double-escaped tabs (\t inside the JSON string instead of \t), the parser outputs literal backslash-t characters. This breaks editor patches that rely on proper indentation. This commit adds a fixDoubleEscapedTabs sanitization step before parsing to restore them to single tabs.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [ ] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [ ] Focused tests and category gates from the golden path
- [ ] `npm run lint`
- [ ] Reconciled with the current active release base; focused checks rerun afterward
- [ ] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
