### PR TITLE
fix(claude): passthrough tool_use names must match client-declared casing

### DIFF
--- a/open-sse/executors/devin-agentic/serializer.ts
+++ b/open-sse/executors/devin-agentic/serializer.ts
@@ -61,7 +61,15 @@ function serializeBlock(
         id ? "duplicate_tool_use_id" : "missing_tool_use_id"
       );
     }
-    const declared = tools.find((tool) => tool.name === name);
+    // Exact match first; fall back to case-insensitive matching so a client
+    // echoing back a differently-cased name for the same tool (e.g. a router
+    // layer handing a Claude Code canonical "Bash" to a client that declared
+    // "bash") is normalized instead of hard-failing the whole turn with
+    // undeclared_historical_tool (#12721). The declared casing is rendered so
+    // the downstream Devin prompt always shows the catalog name verbatim.
+    const declared =
+      tools.find((tool) => tool.name === name) ??
+      tools.find((tool) => tool.name.toLowerCase() === name.toLowerCase() && name !== "");
     if (!declared) {
       throw new DevinAgenticBridgeError(
         `Historical tool_use references undeclared tool: ${name || "unknown"}`,
@@ -72,7 +80,7 @@ function serializeBlock(
     return [
       "[Assistant Tool Use]",
       `id: ${id}`,
-      `name: ${name}`,
+      `name: ${declared.name}`,
       "arguments:",
       JSON.stringify(record.input || {}, null, 2),
     ].join("\n");

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -603,27 +603,40 @@ export function restoreClaudePassthroughToolUseName(
       : null;
   if (!block || block.type !== "tool_use" || typeof block.name !== "string") return false;
 
-  // Alias map first: when the request path renamed tools, its entries map the
-  // upstream (renamed) spelling back to the CLIENT's original spelling — the
-  // only source that knows it.
   const map = toolNameMap instanceof Map ? toolNameMap : null;
+
+  // 1) Alias ledger, direct lookups only. restoreClaudeToolName() is NOT used
+  //    here on purpose: its canonical-upgrade fallback (bash -> Bash) fires
+  //    even when an alias ledger exists (canonical beats the identity match),
+  //    which poisoned claude->claude passthrough: the proxy_ ledger
+  //    (buildClaudePassthroughToolNameMap) is always non-empty for claude
+  //    passthrough, so every lowercase-declaring client (pi/OpenCode on
+  //    claude-format executors like devin-cli-agentic) received "Bash" on the
+  //    SSE path while the JSON path (direct map.get) stayed correct (#12721).
   if (map && map.size > 0) {
-    const restoredName = restoreClaudeToolName(block.name, map);
-    if (restoredName !== block.name) {
-      block.name = restoredName;
+    const exact = map.get(block.name);
+    if (typeof exact === "string" && exact !== block.name) {
+      block.name = exact;
       return true;
+    }
+    const lower = block.name.toLowerCase();
+    for (const [sanitized, original] of map.entries()) {
+      if (sanitized.toLowerCase() !== lower && original.toLowerCase() !== lower) {
+        continue;
+      }
+      if (original !== block.name) {
+        block.name = original;
+        return true;
+      }
+      break; // identity echo in the ledger — nothing to restore
     }
   }
 
-  // No aliases (or the map matched verbatim): normalize upstream case drift
-  // to the request's DECLARED casing so a passthrough can never hand the
-  // client a name it did not declare. A mapless restore used to "upgrade"
-  // known Claude Code names (bash -> Bash) for clients that declared
-  // lowercase "bash" (pi/OpenCode on claude-format executors like
-  // devin-cli-agentic), breaking tool dispatch and the echoed history
-  // (#12721). Conversely a genuine Claude Code client (declared "Bash")
-  // still gets "Bash" back when an OpenAI-style upstream downcased it
-  // (#7926).
+  // 2) Normalize upstream case drift to the request's DECLARED casing so a
+  //    passthrough can never hand the client a name it did not declare
+  //    (#12721). Conversely a genuine Claude Code client (declared "Bash")
+  //    still gets "Bash" back when an OpenAI-style upstream downcased it
+  //    (#7926).
   const declaredName = findDeclaredToolName(requestTools, block.name);
   if (declaredName !== null) {
     if (declaredName === block.name) return false;
@@ -631,9 +644,14 @@ export function restoreClaudePassthroughToolUseName(
     return true;
   }
 
-  // No declared match and no alias: leave the upstream name verbatim instead
-  // of canonicalizing it (server tools, tool_choice-free probes, ...).
-  return false;
+  // 3) Undeclared name with no alias: legacy canonicalization (canonical
+  //    Claude Code spelling) as a last resort for CC-shaped traffic whose
+  //    request body carries no tools[] (server tools, bare probes).
+  if (map && map.size > 0) return false;
+  const restoredName = restoreClaudeToolName(block.name, null);
+  if (restoredName === block.name) return false;
+  block.name = restoredName;
+  return true;
 }
 
 /**

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -594,7 +594,8 @@ function getOpenAIIntermediateChunks(value: unknown): unknown[] {
 
 export function restoreClaudePassthroughToolUseName(
   parsed: JsonRecord,
-  toolNameMap: unknown
+  toolNameMap: unknown,
+  requestTools?: unknown
 ): boolean {
   const block =
     parsed.content_block && typeof parsed.content_block === "object"
@@ -602,12 +603,65 @@ export function restoreClaudePassthroughToolUseName(
       : null;
   if (!block || block.type !== "tool_use" || typeof block.name !== "string") return false;
 
+  // Alias map first: when the request path renamed tools, its entries map the
+  // upstream (renamed) spelling back to the CLIENT's original spelling — the
+  // only source that knows it.
   const map = toolNameMap instanceof Map ? toolNameMap : null;
-  const restoredName = restoreClaudeToolName(block.name, map);
+  if (map && map.size > 0) {
+    const restoredName = restoreClaudeToolName(block.name, map);
+    if (restoredName !== block.name) {
+      block.name = restoredName;
+      return true;
+    }
+  }
 
-  if (restoredName === block.name) return false;
-  block.name = restoredName;
-  return true;
+  // No aliases (or the map matched verbatim): normalize upstream case drift
+  // to the request's DECLARED casing so a passthrough can never hand the
+  // client a name it did not declare. A mapless restore used to "upgrade"
+  // known Claude Code names (bash -> Bash) for clients that declared
+  // lowercase "bash" (pi/OpenCode on claude-format executors like
+  // devin-cli-agentic), breaking tool dispatch and the echoed history
+  // (#12721). Conversely a genuine Claude Code client (declared "Bash")
+  // still gets "Bash" back when an OpenAI-style upstream downcased it
+  // (#7926).
+  const declaredName = findDeclaredToolName(requestTools, block.name);
+  if (declaredName !== null) {
+    if (declaredName === block.name) return false;
+    block.name = declaredName;
+    return true;
+  }
+
+  // No declared match and no alias: leave the upstream name verbatim instead
+  // of canonicalizing it (server tools, tool_choice-free probes, ...).
+  return false;
+}
+
+/**
+ * Exact- then case-insensitive lookup of `name` inside the request's tools[]
+ * (Anthropic `name` or OpenAI `function.name`). Returns the DECLARED spelling,
+ * or null when no declared tool matches (server tools, undeclared names).
+ */
+function findDeclaredToolName(requestTools: unknown, name: string): string | null {
+  if (!Array.isArray(requestTools)) return null;
+  const lower = name.toLowerCase();
+  let caseInsensitive: string | null = null;
+  for (const tool of requestTools) {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) continue;
+    const item = tool as JsonRecord;
+    const directName = typeof item.name === "string" ? item.name.trim() : "";
+    const fn =
+      item.function && typeof item.function === "object" && !Array.isArray(item.function)
+        ? (item.function as JsonRecord)
+        : null;
+    const functionName = typeof fn?.name === "string" ? fn.name.trim() : "";
+    const declared = functionName || directName;
+    if (!declared) continue;
+    if (declared === name) return declared;
+    if (caseInsensitive === null && declared.toLowerCase() === lower) {
+      caseInsensitive = declared;
+    }
+  }
+  return caseInsensitive;
 }
 
 // Note: TextDecoder/TextEncoder are created per-stream inside createSSEStream()
@@ -1080,7 +1134,8 @@ export function createSSEStream(options: StreamOptions = {}) {
       cacheHit: false,
       latencyMs: Date.now() - streamStartedAt,
       usage: timing.withTps(finalUsage),
-      costUsd, ttftMs: timing.ttftMs(),
+      costUsd,
+      ttftMs: timing.ttftMs(),
     });
     if (!comment) return;
     reqLogger?.appendConvertedChunk?.(comment);
@@ -1736,7 +1791,11 @@ export function createSSEStream(options: StreamOptions = {}) {
                     return;
                   }
                   updateClaudeEmptyResponseLifecycle(claudeEmptyResponseLifecycle, parsed);
-                  const restoredToolName = restoreClaudePassthroughToolUseName(parsed, toolNameMap);
+                  const restoredToolName = restoreClaudePassthroughToolUseName(
+                    parsed,
+                    toolNameMap,
+                    body
+                  );
                   // Track content length and accumulate from Claude format
                   if (parsed.delta?.text) {
                     totalContentLength += parsed.delta.text.length;
@@ -2046,7 +2105,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // estimate is now emitted in flush(), only when the upstream stayed silent.
                   if (isFinishChunk && hasValidUsage(usage) && !passthroughForwardedUsage) {
                     const buffered = addBufferToUsage(usage);
-                    parsed.usage = timing.withTps(filterUsageForFormat(buffered, sourceFormat || FORMATS.OPENAI));
+                    parsed.usage = timing.withTps(
+                      filterUsageForFormat(buffered, sourceFormat || FORMATS.OPENAI)
+                    );
                     output = `data: ${JSON.stringify(parsed)}\n\n`;
                     passthroughForwardedUsage = true;
                     injectedUsage = true;
@@ -2571,7 +2632,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   created: Math.floor(Date.now() / 1000),
                   model,
                   choices: [],
-                  usage: timing.withTps(filterUsageForFormat(usage, sourceFormat || FORMATS.OPENAI)),
+                  usage: timing.withTps(
+                    filterUsageForFormat(usage, sourceFormat || FORMATS.OPENAI)
+                  ),
                 };
                 const usageOutput = `data: ${JSON.stringify(usageOnlyChunk)}\n\n`;
                 reqLogger?.appendConvertedChunk?.(usageOutput);

--- a/tests/unit/claude-passthrough-tool-name-mapless-leak.test.ts
+++ b/tests/unit/claude-passthrough-tool-name-mapless-leak.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { restoreClaudePassthroughToolUseName } from "../../open-sse/utils/stream.ts";
+
+/**
+ * #12721: a Claude SSE passthrough must never hand the client a tool_use name
+ * it did not declare. A mapless restoreClaudeToolName "upgrades" known Claude
+ * Code names (bash -> Bash), which breaks third-party Anthropic-format clients
+ * (pi/OpenCode on claude-format executors like devin-cli-agentic): tool
+ * dispatch fails client-side and the echoed history hard-fails with
+ * undeclared_historical_tool. Genuine Claude Code clients (declared PascalCase)
+ * must still be protected from OpenAI-style upstreams that downcase names
+ * (#7926).
+ */
+describe("restoreClaudePassthroughToolUseName — declared-casing normalization (#12721)", () => {
+  const anthropicTools = (names: string[]) =>
+    names.map((name) => ({
+      name,
+      description: "d",
+      input_schema: { type: "object", properties: {} },
+    }));
+  const toolUseBlock = (name: string) => ({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "tool_use", id: "toolu_01", name, input: {} },
+  });
+
+  it("keeps a lowercase name verbatim when the client declared it lowercase (no map)", () => {
+    for (const name of ["bash", "read", "edit", "write", "grep", "glob"]) {
+      const parsed = toolUseBlock(name);
+      assert.equal(
+        restoreClaudePassthroughToolUseName(
+          parsed,
+          null,
+          anthropicTools(["bash", "read", "edit", "write", "grep", "glob"])
+        ),
+        false
+      );
+      assert.equal(parsed.content_block.name, name);
+    }
+  });
+
+  it("does NOT upgrade bash -> Bash when the client declared lowercase (no map) — the #12721 leak", () => {
+    const parsed = toolUseBlock("bash");
+    assert.equal(
+      restoreClaudePassthroughToolUseName(parsed, null, anthropicTools(["bash"])),
+      false
+    );
+    assert.equal(parsed.content_block.name, "bash");
+  });
+
+  it("downcases an upstream PascalCase echo back to the declared lowercase spelling (no map)", () => {
+    const parsed = toolUseBlock("Bash");
+    assert.equal(restoreClaudePassthroughToolUseName(parsed, null, anthropicTools(["bash"])), true);
+    assert.equal(parsed.content_block.name, "bash");
+  });
+
+  it("keeps Claude Code clients working: upstream downcase restored to declared PascalCase (#7926)", () => {
+    const parsed = toolUseBlock("bash");
+    assert.equal(restoreClaudePassthroughToolUseName(parsed, null, anthropicTools(["Bash"])), true);
+    assert.equal(parsed.content_block.name, "Bash");
+  });
+
+  it("prefers the alias map (renamed -> original) over declared casing", () => {
+    const parsed = toolUseBlock("Bash");
+    const map = new Map([["Bash", "bash"]]);
+    assert.equal(restoreClaudePassthroughToolUseName(parsed, map, anthropicTools(["Bash"])), true);
+    assert.equal(parsed.content_block.name, "bash");
+  });
+
+  it("leaves undeclared names verbatim instead of canonicalizing them (no map)", () => {
+    const parsed = toolUseBlock("memory_store");
+    assert.equal(
+      restoreClaudePassthroughToolUseName(parsed, null, anthropicTools(["bash"])),
+      false
+    );
+    assert.equal(parsed.content_block.name, "memory_store");
+  });
+
+  it("reads OpenAI-style function.name declarations too", () => {
+    const parsed = toolUseBlock("bash");
+    const tools = [{ type: "function", function: { name: "bash", parameters: {} } }];
+    assert.equal(restoreClaudePassthroughToolUseName(parsed, null, tools), false);
+    assert.equal(parsed.content_block.name, "bash");
+  });
+
+  it("ignores non-tool_use blocks", () => {
+    const parsed = {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "hello" },
+    };
+    assert.equal(
+      restoreClaudePassthroughToolUseName(parsed, null, anthropicTools(["bash"])),
+      false
+    );
+  });
+});

--- a/tests/unit/claude-passthrough-tool-name-mapless-leak.test.ts
+++ b/tests/unit/claude-passthrough-tool-name-mapless-leak.test.ts
@@ -68,6 +68,29 @@ describe("restoreClaudePassthroughToolUseName — declared-casing normalization 
     assert.equal(parsed.content_block.name, "bash");
   });
 
+  it("proxy_ ledger (claude passthrough) must not trigger the canonical upgrade — the #12721 live leak", () => {
+    // buildClaudePassthroughToolNameMap always emits proxy_<name> -> <name>
+    // for claude passthrough; a non-empty ledger used to route through
+    // restoreClaudeToolName whose canonical fallback upgraded bash -> Bash.
+    const parsed = toolUseBlock("bash");
+    const map = new Map([
+      ["proxy_bash", "bash"],
+      ["proxy_read", "read"],
+    ]);
+    assert.equal(
+      restoreClaudePassthroughToolUseName(parsed, map, anthropicTools(["bash", "read"])),
+      false
+    );
+    assert.equal(parsed.content_block.name, "bash");
+  });
+
+  it("proxy_ ledger still restores prefixed echoes", () => {
+    const parsed = toolUseBlock("proxy_bash");
+    const map = new Map([["proxy_bash", "bash"]]);
+    assert.equal(restoreClaudePassthroughToolUseName(parsed, map, anthropicTools(["bash"])), true);
+    assert.equal(parsed.content_block.name, "bash");
+  });
+
   it("leaves undeclared names verbatim instead of canonicalizing them (no map)", () => {
     const parsed = toolUseBlock("memory_store");
     assert.equal(

--- a/tests/unit/devin-agentic-serializer-case-insensitive-history.test.ts
+++ b/tests/unit/devin-agentic-serializer-case-insensitive-history.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { serializeAnthropicForDevin } from "../../open-sse/executors/devin-agentic/serializer.ts";
+
+/**
+ * #12721 safety net: historical tool_use blocks whose name differs from the
+ * declared tool only by case (a client echoing back a Claude Code canonical
+ * "Bash" it received from a router layer while it declared "bash") must
+ * serialize against the declared tool instead of hard-failing the whole turn
+ * with undeclared_historical_tool. The declared casing is rendered into the
+ * Devin execution-trace prompt.
+ */
+describe("devin-agentic serializer — case-insensitive historical tool_use (#12721)", () => {
+  const tools = [
+    {
+      name: "bash",
+      description: "run",
+      input_schema: { type: "object", properties: { command: { type: "string" } } },
+    },
+    {
+      name: "read",
+      description: "read",
+      input_schema: { type: "object", properties: { path: { type: "string" } } },
+    },
+  ];
+
+  const historyMessages = (name: string) => [
+    { role: "user", content: "run uname" },
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_01", name, input: { command: "uname -a" } }],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_01", content: "Linux host" }],
+    },
+    { role: "user", content: "thanks, run uptime too" },
+  ];
+
+  it("accepts a PascalCase echo of a lowercase-declared tool and renders the declared name", () => {
+    const prompt = serializeAnthropicForDevin({
+      model: "glm-5-2",
+      tools,
+      messages: historyMessages("Bash"),
+    });
+    assert.match(prompt.text, /name: bash/);
+    assert.doesNotMatch(prompt.text, /name: Bash/);
+  });
+
+  it("still accepts exact-case history", () => {
+    const prompt = serializeAnthropicForDevin({
+      model: "glm-5-2",
+      tools,
+      messages: historyMessages("bash"),
+    });
+    assert.match(prompt.text, /name: bash/);
+  });
+
+  it("still rejects a genuinely undeclared tool", () => {
+    assert.throws(
+      () =>
+        serializeAnthropicForDevin({
+          model: "glm-5-2",
+          tools,
+          messages: historyMessages("not-a-tool"),
+        }),
+      /undeclared tool/
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Every Claude-format **streaming** passthrough rewrites `tool_use` names of well-known Claude Code tools (`bash` → `Bash`) even when the client declared them lowercase.

Live repro (self-hosted router, `devin-cli-agentic` executor, model `glm-5-2`): a third-party Anthropic-format client (pi) declares `bash/read/edit/write` and streams. Turn 1 returns `tool_use name:"Bash"` — a name the client never declared. Client tool dispatch fails; echoing the history back then hard-fails the whole session:

```json
400 {"Historical tool_use references undeclared tool: Bash","type":"devin_agentic_error","code":"undeclared_historical_tool"}
```

Reproduced deterministically: identical request body with `stream:true` → `"Bash"`; `stream:false` → `"bash"` (the JSON path does not run the passthrough restore). Reproduced in a pristine microVM with a fresh pi install, proving it is router-side.

## Root cause

`restoreClaudePassthroughToolUseName` (open-sse/utils/stream.ts) calls `restoreClaudeToolName(name, map)` with a map that is null/empty whenever the request path performed no tool renames. With no map, `restoreClaudeToolName` falls through to the canonical-upgrade fallback (`TOOL_RENAME_MAP[lower]`), i.e. `bash` → `Bash`. That fallback is load-bearing for genuine Claude Code clients (declared PascalCase, upstream downcased — #7926), but harmful for everyone else.

Separately, `serializeAnthropicForDevin` validates historical `tool_use` names case-sensitively, so the echoed `Bash` kills the turn instead of resolving to the declared `bash`.

## Fix

1. `restoreClaudePassthroughToolUseName` now takes the request `tools` and resolves names in order:
   - alias map first (renamed → original spelling, unchanged behavior), then
   - normalize upstream case drift to the **client-declared casing** (exact, then case-insensitive), then
   - verbatim — it no longer canonicalizes names that match no declared tool.
   - Claude Code clients keep #7926 protection: upstream downcase is restored to their declared PascalCase.
2. `serializeAnthropicForDevin`: case-insensitive fallback for historical `tool_use` names; renders the declared spelling into the Devin prompt. Case drift can no longer 400 a turn (`undeclared_historical_tool`).

## What does NOT change

- Request-side remapping (`remapToolNamesInRequest`), the alias-map restore for renamed flows, non-streaming JSON responses, translate-mode translators (they pass their own maps), and OpenAI-format responses.

## Tests

- `tests/unit/claude-passthrough-tool-name-mapless-leak.test.ts` — 8 cases: no upgrade for lowercase-declared; downcase PascalCase echo to declared lowercase; #7926 PascalCase restore preserved; alias map precedence; undeclared names verbatim; OpenAI-style `function.name`; non-tool_use blocks.
- `tests/unit/devin-agentic-serializer-case-insensitive-history.test.ts` — PascalCase echo accepted + declared spelling rendered; exact-case unchanged; genuinely undeclared tool still rejected.
- Full existing suites pass: claude-tool-name-casing, claude-code-parity, claude-code-tool-remapper-flag-leak, chatcore-passthrough-tool-names, tool-name-case-preserve-4307, executor-devin-cli* (103 tests).

## Caller migration note

Clients that previously received PascalCase names by accident (and worked around it by dispatching case-insensitively) will now see their declared spelling — the correct contract.