### PR TITLE
fix(translator): stop double-counting cached tokens in Gemini to Claude usage

### DIFF
--- a/changelog.d/fixes/12863-gemini-to-claude-cached-input-tokens.md
+++ b/changelog.d/fixes/12863-gemini-to-claude-cached-input-tokens.md
@@ -1,0 +1,1 @@
+- **fix(translator):** Gemini to Claude usage no longer double-counts the cached prompt prefix — `input_tokens` now excludes `cache_read_input_tokens`, matching the Anthropic Messages semantics ([#12863](https://github.com/diegosouzapw/OmniRoute/pull/12863))

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -397,7 +397,7 @@ export function geminiToClaudeResponse(chunk, state) {
       typeof usageMeta.cachedContentTokenCount === "number" ? usageMeta.cachedContentTokenCount : 0;
 
     state.usage = {
-      input_tokens: inputTokens,
+      input_tokens: Math.max(0, inputTokens - cachedTokens),
       output_tokens: candidatesTokens + thoughtsTokens,
     };
     if (cachedTokens > 0) {

--- a/tests/unit/translator-resp-gemini-to-claude.test.ts
+++ b/tests/unit/translator-resp-gemini-to-claude.test.ts
@@ -107,7 +107,7 @@ test("Gemini -> Claude stream: functionCall becomes tool_use and MAX_TOKENS maps
   assert.equal(result[2].delta.partial_json, JSON.stringify({ path: "/tmp/a" }));
   assert.equal(result[3].type, "content_block_stop");
   assert.equal(result[4].delta.stop_reason, "tool_use");
-  assert.equal(result[4].usage.input_tokens, 5);
+  assert.equal(result[4].usage.input_tokens, 4);
   assert.equal(result[4].usage.output_tokens, 5);
   assert.equal(result[4].usage.cache_read_input_tokens, 1);
   assert.equal(result[5].type, "message_stop");
@@ -189,4 +189,53 @@ test("Gemini -> Claude stream: response wrapper is supported and promptFeedback-
   assert.equal(wrapped[0].type, "message_start");
   assert.equal(wrapped[2].delta.text, "wrapped");
   assert.equal(geminiToClaudeResponse({ promptFeedback: { blockReason: "SAFETY" } }, {}), null);
+});
+
+test("Gemini -> Claude stream: input_tokens excludes cached tokens", () => {
+  const result = geminiToClaudeResponse(
+    {
+      responseId: "resp-6",
+      modelVersion: "gemini-2.5-pro",
+      candidates: [
+        {
+          content: { parts: [{ text: "done" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 7,
+        cachedContentTokenCount: 90,
+      },
+    },
+    {}
+  );
+
+  const delta = result.find((event) => event.type === "message_delta");
+  assert.equal(delta.usage.input_tokens, 10);
+  assert.equal(delta.usage.cache_read_input_tokens, 90);
+});
+
+test("Gemini -> Claude stream: input_tokens equals promptTokenCount when nothing is cached", () => {
+  const result = geminiToClaudeResponse(
+    {
+      responseId: "resp-7",
+      modelVersion: "gemini-2.5-pro",
+      candidates: [
+        {
+          content: { parts: [{ text: "done" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 7,
+      },
+    },
+    {}
+  );
+
+  const delta = result.find((event) => event.type === "message_delta");
+  assert.equal(delta.usage.input_tokens, 100);
+  assert.equal(delta.usage.cache_read_input_tokens, undefined);
 });


### PR DESCRIPTION
## Summary

- `gemini-to-claude.ts` reported the full `promptTokenCount` in `input_tokens` while also
  reporting the cached prefix in `cache_read_input_tokens`. In the Anthropic Messages API
  those two fields are disjoint, so any consumer that sums them saw roughly twice the real
  prompt once the cache warmed up. `input_tokens` now excludes the cached tokens.
- User-visible effect: clients driven by the reported usage (Claude Code auto-compaction,
  cost accounting in `src/lib/usage/tokenAccounting.ts`, which adds `cache_read` back on
  top of `input_tokens`) stop seeing an inflated prompt on cached turns.
- `gemini-to-openai.ts` is deliberately untouched: OpenAI's `prompt_tokens` includes the
  cached part, so passing `promptTokenCount` through is correct there.

## Related Issues

- Closes #12862

## Validation

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Focused loop on `release/v3.8.51` at `f9a1cc8a`:

```
node --import tsx/esm --test tests/unit/translator-resp-gemini-to-claude.test.ts
# tests 8
# pass 8
# fail 0
```

Without the production change, the same file reports `# fail 2` (the updated
`MAX_TOKENS` assert and the new cached-tokens case), so the tests do exercise the fix.

## Tests Added Or Updated

- `tests/unit/translator-resp-gemini-to-claude.test.ts`
  - updated: the `MAX_TOKENS` case asserted `input_tokens === 5` for
    `promptTokenCount: 5, cachedContentTokenCount: 1`; it now asserts `4`.
  - added: `input_tokens excludes cached tokens` — `promptTokenCount: 100`,
    `cachedContentTokenCount: 90` yields `input_tokens: 10` and
    `cache_read_input_tokens: 90`.
  - added: `input_tokens equals promptTokenCount when nothing is cached` — regression
    guard for the uncached path, where the value must stay untouched.

## Coverage Notes

- The change is one line in `open-sse/translator/response/gemini-to-claude.ts`, inside the
  usage-metadata branch. That branch is covered by the three tests listed above: the
  cached path, the uncached path, and the pre-existing `MAX_TOKENS` path.
- Coverage of the touched file does not move down; the usage branch gains two cases.

## Reviewer Notes

- `Math.max(0, ...)` guards against a provider reporting `cachedContentTokenCount` greater
  than `promptTokenCount`, which would otherwise yield a negative `input_tokens`.
- No migration, no feature flag, no config surface. The only behavioral change is the
  value reported in `usage.input_tokens` for the Gemini to Claude path.
