### PR TITLE
fix(gemini): strip prefixItems/additionalItems from tool schemas (#12871)

### DIFF
--- a/changelog.d/fixes/12872-gemini-prefixitems.md
+++ b/changelog.d/fixes/12872-gemini-prefixitems.md
@@ -1,0 +1,1 @@
+- **fix(gemini):** strip `prefixItems`/`additionalItems` from tool parameter schemas — tuple-typed arrays triggered a hard upstream 400 (`Unknown name "prefixItems"`), breaking every tool-enabled Claude Code request to a Gemini model ([#12872](https://github.com/diegosouzapw/OmniRoute/pull/12872)) — thanks @sonirahul

--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -63,6 +63,16 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   // it, rejecting the whole request with "Unknown name \"uniqueItems\"".
   // Upstream 9router already strips it alongside `contains` for the same error.
   "uniqueItems",
+  // #12871: tuple-typed array keywords. `prefixItems` (JSON Schema 2020-12) and its
+  // draft-07 spelling `additionalItems` describe positional array entries, which the
+  // Gemini schema parser has no field for — it rejects the request with
+  // "Unknown name \"prefixItems\" ... Cannot find field". Claude Code ships built-in
+  // tools whose schemas use tuples, so leaving these in breaks every tool-enabled
+  // request to a Gemini model. Stripping `prefixItems` leaves a bare `type: "array"`,
+  // which the `ensureArrayItems()` phase below (#10578) then fills with a safe `items`
+  // schema — the parameter degrades to an untyped array instead of failing the call.
+  "prefixItems",
+  "additionalItems",
   // Complex schema keywords (handled by flattenAnyOfOneOf/mergeAllOf)
   "anyOf",
   "oneOf",

--- a/tests/unit/12871-gemini-prefixitems.test.ts
+++ b/tests/unit/12871-gemini-prefixitems.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildGeminiTools } from "../../open-sse/translator/helpers/geminiToolsSanitizer.ts";
+
+// Issue #12871: Gemini rejects `prefixItems` in function_declarations parameter schemas
+// with HTTP 400 "Unknown name \"prefixItems\" ... Cannot find field" (Gemini's protobuf-JSON
+// schema parser only accepts a subset of JSON Schema/OpenAPI 3.0 — the same class of error
+// already fixed for `uniqueItems` (#9617), `multipleOf`, `strict` and `encrypted` in
+// GEMINI_UNSUPPORTED_SCHEMA_KEYS, open-sse/translator/helpers/geminiHelper.ts).
+//
+// Claude Code ships built-in tools whose schemas describe filter clauses as tuples, so
+// leaving `prefixItems` in place breaks every tool-enabled request to a Gemini model.
+test("buildGeminiTools strips prefixItems from tuple array schemas (issue #12871)", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "artifact_db",
+        description: "test tool with a tuple-typed filter parameter",
+        parameters: {
+          type: "object",
+          properties: {
+            collection: { type: "string" },
+            query: {
+              type: "object",
+              properties: {
+                where: {
+                  type: "array",
+                  items: {
+                    type: "array",
+                    prefixItems: [
+                      { type: "string" },
+                      { type: "string", enum: ["eq", "ne", "lt", "gt"] },
+                      {},
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          required: ["collection"],
+        },
+      },
+    },
+  ];
+
+  const geminiTools = buildGeminiTools(tools);
+  const serialized = JSON.stringify(geminiTools);
+
+  assert.ok(geminiTools, "expected buildGeminiTools to return a tools array");
+  assert.equal(
+    serialized.includes("prefixItems"),
+    false,
+    `prefixItems leaked into the Gemini payload (would trigger upstream 400 "Unknown name \\"prefixItems\\""): ${serialized}`
+  );
+});
+
+// The draft-07 spelling of the same tuple concept fails identically upstream.
+test("buildGeminiTools strips additionalItems from tuple array schemas (issue #12871)", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "list_pairs",
+        description: "test tool using the draft-07 tuple spelling",
+        parameters: {
+          type: "object",
+          properties: {
+            pairs: {
+              type: "array",
+              items: [{ type: "string" }, { type: "number" }],
+              additionalItems: false,
+            },
+          },
+          required: ["pairs"],
+        },
+      },
+    },
+  ];
+
+  const serialized = JSON.stringify(buildGeminiTools(tools));
+  assert.equal(serialized.includes("additionalItems"), false);
+});
+
+// Stripping the tuple must not leave a bare `type: "array"` behind: Gemini also requires
+// every array schema to declare `items` (#10578). The existing ensureArrayItems() phase
+// backfills it, so the parameter degrades to an untyped array rather than 400-ing.
+test("stripped prefixItems arrays still declare an items schema (issue #12871)", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "tuple_only",
+        description: "array described solely by prefixItems",
+        parameters: {
+          type: "object",
+          properties: {
+            pair: {
+              type: "array",
+              prefixItems: [{ type: "string" }, { type: "number" }],
+            },
+          },
+          required: ["pair"],
+        },
+      },
+    },
+  ];
+
+  const geminiTools = buildGeminiTools(tools) as
+    | Array<{ functionDeclarations?: Array<{ parameters?: unknown }> }>
+    | undefined;
+
+  const parameters = geminiTools?.[0]?.functionDeclarations?.[0]?.parameters as
+    | { properties?: Record<string, { type?: string; items?: unknown }> }
+    | undefined;
+  const pair = parameters?.properties?.pair;
+
+  assert.equal(pair?.type, "array");
+  assert.ok(pair?.items, "expected ensureArrayItems() to backfill an items schema");
+});


### PR DESCRIPTION
Fixes #12871.

## Problem

`GEMINI_UNSUPPORTED_SCHEMA_KEYS` did not include `prefixItems`, so tuple-typed array schemas survived `cleanJSONSchemaForAntigravity()` and were sent to Google verbatim. Gemini's function_declarations parser has no field for them and rejects the entire request:

```
400 Invalid JSON payload received. Unknown name "prefixItems" at
'tools[0].function_declarations[1].parameters.properties[5].value.properties[0].value.items':
Cannot find field.
```

Claude Code ships built-in tools whose schemas describe filter clauses as tuples, so **every tool-enabled request to a Gemini model failed**, with no config-level workaround.

`additionalItems` — the draft-07 spelling of the same concept — was missing for the same reason and produces an identical 400.

## Fix

Add both keywords to `GEMINI_UNSUPPORTED_SCHEMA_KEYS`. This is the same class of fix already applied for `uniqueItems` (#9617), `multipleOf`, `strict` and `encrypted`.

Stripping `prefixItems` leaves a bare `type: "array"`, which the existing `ensureArrayItems()` phase (#10578) backfills with a safe `items` schema — so the parameter degrades to an untyped array rather than failing the call. The third test pins that interaction so a future reorder of the cleanup phases can't silently reintroduce a bare array.

## Verification

Built a patched image and ran the reproduction from #12871 against `gemini-2.5-pro`. Before: upstream 400. After:

```json
{"type":"tool_use","name":"artifact_db",
 "input":{"query":{"where":[["status","==","open"]]},"collection":"notes"}}
```

Gemini fills the tuple correctly despite the erased positional types.

Unit tests, scoped to the 21 files importing `geminiHelper.ts` / `geminiToolsSanitizer.ts`:

| | tests | pass | fail |
|---|---|---|---|
| before | 83 | 76 | 7 |
| after | 86 | 79 | 7 |

+3 tests, +3 passing, no change in failures. The 7 pre-existing failures are `ERR_MODULE_NOT_FOUND` on extensionless imports in my local environment (Node 24), identical on a clean checkout of `main` and unrelated to this change.
