### PR TITLE
fix(semantic-cache): never cache a truncated completion

### DIFF
--- a/open-sse/handlers/chatCore/semanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/semanticCacheStore.ts
@@ -12,6 +12,7 @@ import {
   generateSignature as defaultGenerateSignature,
   setCachedResponse as defaultSetCachedResponse,
   isCacheableForWrite as defaultIsCacheableForWrite,
+  isTruncatedCompletion as defaultIsTruncatedCompletion,
 } from "@/lib/semanticCache";
 import { isSmallEnoughForSemanticCache as defaultIsSmallEnough } from "../../utils/estimateSize.ts";
 
@@ -28,6 +29,8 @@ type UsageLike = { prompt_tokens?: number; completion_tokens?: number } | null |
 
 export interface SemanticCacheStoreDeps {
   isCacheableForWrite: typeof defaultIsCacheableForWrite;
+  /** Optional so pre-existing callers/tests with partial deps keep working. */
+  isTruncatedCompletion?: typeof defaultIsTruncatedCompletion;
   isSmallEnoughForSemanticCache: typeof defaultIsSmallEnough;
   generateSignature: typeof defaultGenerateSignature;
   setCachedResponse: typeof defaultSetCachedResponse;
@@ -35,6 +38,7 @@ export interface SemanticCacheStoreDeps {
 
 const DEFAULT_DEPS: SemanticCacheStoreDeps = {
   isCacheableForWrite: defaultIsCacheableForWrite,
+  isTruncatedCompletion: defaultIsTruncatedCompletion,
   isSmallEnoughForSemanticCache: defaultIsSmallEnough,
   generateSignature: defaultGenerateSignature,
   setCachedResponse: defaultSetCachedResponse,
@@ -56,6 +60,7 @@ export function storeSemanticCacheResponse(
   if (
     !args.enabled ||
     !deps.isCacheableForWrite(args.body, args.headers) ||
+    (deps.isTruncatedCompletion ?? defaultIsTruncatedCompletion)(args.translatedResponse) ||
     !deps.isSmallEnoughForSemanticCache(args.translatedResponse)
   ) {
     return;

--- a/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
@@ -13,6 +13,7 @@ import {
   generateSignature as defaultGenerateSignature,
   setCachedResponse as defaultSetCachedResponse,
   isCacheableForWrite as defaultIsCacheableForWrite,
+  isTruncatedStreamBody as defaultIsTruncatedStreamBody,
 } from "@/lib/semanticCache";
 import { isSmallEnoughForSemanticCache as defaultIsSmallEnough } from "../../utils/estimateSize.ts";
 
@@ -27,6 +28,8 @@ type CacheBody = {
 
 export interface StreamingSemanticCacheStoreDeps {
   isCacheableForWrite: typeof defaultIsCacheableForWrite;
+  /** Optional so pre-existing callers/tests with partial deps keep working. */
+  isTruncatedStreamBody?: typeof defaultIsTruncatedStreamBody;
   isSmallEnoughForSemanticCache: typeof defaultIsSmallEnough;
   generateSignature: typeof defaultGenerateSignature;
   setCachedResponse: typeof defaultSetCachedResponse;
@@ -34,6 +37,7 @@ export interface StreamingSemanticCacheStoreDeps {
 
 const DEFAULT_DEPS: StreamingSemanticCacheStoreDeps = {
   isCacheableForWrite: defaultIsCacheableForWrite,
+  isTruncatedStreamBody: defaultIsTruncatedStreamBody,
   isSmallEnoughForSemanticCache: defaultIsSmallEnough,
   generateSignature: defaultGenerateSignature,
   setCachedResponse: defaultSetCachedResponse,
@@ -90,7 +94,8 @@ export function storeStreamingSemanticCacheResponse(
     !args.enabled ||
     args.streamStatus !== 200 ||
     !args.streamResponseBody ||
-    !deps.isCacheableForWrite(args.body, args.headers)
+    !deps.isCacheableForWrite(args.body, args.headers) ||
+    (deps.isTruncatedStreamBody ?? defaultIsTruncatedStreamBody)(args.streamResponseBody)
   ) {
     return;
   }

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -391,3 +391,56 @@ export function isCacheableForWrite(body, headers) {
   if (body.temperature !== 0) return false;
   return true;
 }
+
+/**
+ * A response cut short by the output-token ceiling is a partial answer, not a
+ * reusable one. Caching it under a temperature:0 signature pins the truncation
+ * for every later identical request — the caller sees a mid-sentence reply that
+ * no retry clears, because each retry is served the same poisoned entry.
+ *
+ * Only `length` (and its Claude-side spelling `max_tokens`) is treated as
+ * truncation. `stop`, `tool_calls`, and a missing/unknown reason are complete
+ * responses and stay cacheable, so this never narrows the cache beyond the bug.
+ */
+const TRUNCATED_FINISH_REASONS = new Set(["length", "max_tokens"]);
+
+export function isTruncatedCompletion(response: unknown): boolean {
+  if (!response || typeof response !== "object") return false;
+  const r = response as {
+    choices?: Array<{ finish_reason?: unknown }>;
+    stop_reason?: unknown;
+  };
+  if (Array.isArray(r.choices)) {
+    for (const choice of r.choices) {
+      const reason = choice?.finish_reason;
+      if (typeof reason === "string" && TRUNCATED_FINISH_REASONS.has(reason)) return true;
+    }
+  }
+  // Claude-format responses carry the reason at the top level instead.
+  if (typeof r.stop_reason === "string" && TRUNCATED_FINISH_REASONS.has(r.stop_reason)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Streaming variant: the assembled SSE body is scanned for a truncating
+ * finish_reason. Parsing is intentionally tolerant — an unparseable chunk is
+ * treated as "not known to be truncated" so a malformed frame never silently
+ * disables caching.
+ */
+export function isTruncatedStreamBody(streamBody: unknown): boolean {
+  if (typeof streamBody !== "string" || streamBody.length === 0) return false;
+  for (const line of streamBody.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) continue;
+    const payload = trimmed.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      if (isTruncatedCompletion(JSON.parse(payload))) return true;
+    } catch {
+      // Non-JSON frame — ignore.
+    }
+  }
+  return false;
+}

--- a/tests/unit/semantic-cache-no-truncated-writes.test.ts
+++ b/tests/unit/semantic-cache-no-truncated-writes.test.ts
@@ -1,0 +1,82 @@
+// Regression: a truncated upstream response (finish_reason "length") must never be
+// written to the semantic cache. A partial completion cached under a temperature:0
+// signature is served to every subsequent identical request, permanently returning
+// a mid-sentence answer that no retry can clear (only a cache flush).
+// Observed live on OmniRoute against github/gemini-3.5-flash: temperature:0 returned
+// finish_reason "length" at 93 completion tokens on every call, while the same request
+// with x-omniroute-no-cache:true returned a complete 239-token response.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { storeSemanticCacheResponse } =
+  await import("../../open-sse/handlers/chatCore/semanticCacheStore.ts");
+const { storeStreamingSemanticCacheResponse } =
+  await import("../../open-sse/handlers/chatCore/streamingSemanticCacheStore.ts");
+// Real truncation predicates — only the cache backend and the temperature/size
+// gates are stubbed, so these tests exercise the actual detection logic.
+const { isTruncatedCompletion, isTruncatedStreamBody } = await import("@/lib/semanticCache");
+
+function deps(stored: unknown[]) {
+  return {
+    isCacheableForWrite: () => true,
+    isTruncatedCompletion,
+    isTruncatedStreamBody,
+    isSmallEnoughForSemanticCache: () => true,
+    generateSignature: () => "sig",
+    setCachedResponse: (_s: unknown, _m: string, r: unknown, t: number) => stored.push({ r, t }),
+  } as never;
+}
+
+test("does not cache a non-streaming response truncated by max_tokens", () => {
+  const stored: unknown[] = [];
+  storeSemanticCacheResponse(
+    {
+      enabled: true,
+      body: { messages: [{ role: "user", content: "hi" }], temperature: 0 },
+      headers: undefined,
+      translatedResponse: {
+        choices: [{ finish_reason: "length", message: { content: "partial answ" } }],
+      },
+      model: "gemini-3.5-flash",
+      usage: { prompt_tokens: 10, completion_tokens: 93 },
+    },
+    deps(stored)
+  );
+  assert.equal(stored.length, 0, "truncated response must not be cached");
+});
+
+test("still caches a complete non-streaming response", () => {
+  const stored: unknown[] = [];
+  storeSemanticCacheResponse(
+    {
+      enabled: true,
+      body: { messages: [{ role: "user", content: "hi" }], temperature: 0 },
+      headers: undefined,
+      translatedResponse: {
+        choices: [{ finish_reason: "stop", message: { content: "complete answer" } }],
+      },
+      model: "gemini-3.5-flash",
+      usage: { prompt_tokens: 10, completion_tokens: 239 },
+    },
+    deps(stored)
+  );
+  assert.equal(stored.length, 1, "complete response must still be cached");
+});
+
+test("does not cache a streaming response truncated by max_tokens", () => {
+  const stored: unknown[] = [];
+  storeStreamingSemanticCacheResponse(
+    {
+      enabled: true,
+      streamStatus: 200,
+      streamResponseBody:
+        'data: {"choices":[{"finish_reason":"length","delta":{"content":"partial"}}]}\n\ndata: [DONE]\n\n',
+      body: { messages: [{ role: "user", content: "hi" }], temperature: 0 },
+      headers: undefined,
+      model: "gemini-3.5-flash",
+      streamUsage: { prompt_tokens: 10, completion_tokens: 93 },
+    } as never,
+    deps(stored)
+  );
+  assert.equal(stored.length, 0, "truncated streaming response must not be cached");
+});


### PR DESCRIPTION
## Summary

- A completion cut short by the token limit (`finish_reason: "length"`) is written to the
  semantic cache and served to every later caller that hits the same entry. Because the
  cache only writes on `temperature === 0`, the poisoned entry is stable and effectively
  permanent: deterministic callers keep getting a truncated answer for an unbounded time,
  long after the upstream provider would have returned a complete one.

`isCacheableForWrite` checks the request (`temperature`, size, streaming) but never
inspects the *response* it is about to store, so nothing distinguishes "the model finished"
from "the model ran out of budget mid-sentence".

### How it was found

Chasing what looked like a model quality problem — one model returning a 209-char answer to
a prompt that clearly needed more. It reproduced only at exactly `temperature: 0.0`, which
is the tell: that is the cache-write condition, not a sampling effect.

Real captured behavior against a live gateway, same prompt, same model:

```
normal request                  -> 209 chars   (poisoned cache entry)
X-OmniRoute-No-Cache: 1         -> 567 chars   (real provider answer)
normal request again            -> 209 chars   (poisoned entry again)
```

On the instance where this was diagnosed, **13 of 1483 stored entries (0.9%)** were
truncated completions.

## Related Issues

- Closes #
- Related to #

## Validation

- [x] Change type: routing (semantic cache write path)
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Verified on a clean checkout of `origin/main` (`c0b2253f2`) with a real `npm ci` — not a
reused `node_modules`:

| check | result |
|---|---|
| cherry-pick onto `origin/main` | 0 conflicts |
| `npm run lint` | exit 0 |
| `npm run typecheck:core` | exit 0 |
| focused suites | **11 pass / 0 fail** |

**Mutation-tested on upstream**: reverting the three source files while keeping the new
test file takes the suite to **2 fail / 3** (test count unchanged at 3, so this is a real
bite, not a vanished suite); restoring returns 3/3.

Also verified against a live gateway carrying the fix: the same `temperature: 0` prompt
returns `finish_reason=stop`, 1091 chars, on both the fresh call and the subsequent
cache-path call.

## Tests Added Or Updated

- `tests/unit/semantic-cache-no-truncated-writes.test.ts` (new) — covers the non-streaming
  write path, the streaming write path, and a negative control asserting complete responses
  are still cached.
- `tests/unit/chatcore-semantic-cache-store.test.ts` — ran as a regression guard, unchanged.

## Coverage Notes

Touches `src/lib/semanticCache.ts` and both `open-sse/handlers/chatCore/*SemanticCacheStore.ts`
write paths. Every added branch is covered by the new test file: truncated non-streaming
(rejected), truncated streaming (rejected), complete (still cached).

## Reviewer Notes

- **Deliberately conservative about what counts as truncated.** Only `"length"` and the
  Claude-side `"max_tokens"` spelling are treated as truncation. `"stop"`, `"tool_calls"`,
  and unknown/missing reasons stay cacheable, so an unfamiliar provider string can never
  silently disable caching.
- **The new helper params are optional with defensive defaults**, so existing callers and
  tests that construct store options without them keep compiling and behaving identically.
- No migration, no feature flag, no config surface. Behavior change is strictly "one class
  of response is no longer written to the cache" — existing poisoned entries are not
  retroactively evicted, they simply age out; operators who want them gone can clear the
  cache.
