### PR TITLE
fix(api): match the call-log API-key filter on the key id, not the name alone

### DIFF
--- a/changelog.d/fixes/12894-call-logs-api-key-id-filter.md
+++ b/changelog.d/fixes/12894-call-logs-api-key-id-filter.md
@@ -1,0 +1,1 @@
+- **fix(api):** Dashboard → Logs now returns rows when an API key is picked from the dropdown: the in-memory filter pass matched the key name only, while the dropdown sends the key id ([#12894](https://github.com/diegosouzapw/OmniRoute/pull/12894), closes [#12873](https://github.com/diegosouzapw/OmniRoute/issues/12873))

--- a/src/app/api/usage/call-logs/route.ts
+++ b/src/app/api/usage/call-logs/route.ts
@@ -44,7 +44,10 @@ export function rowMatchesFilter(row: any, filter: Record<string, any>): boolean
     if (!(Number(row?.status) >= 400 || Boolean(row?.error))) return false;
   } else if (filter.status === "ok") {
     if (!(Number(row?.status) >= 200 && Number(row?.status) < 300)) return false;
-  } else if (typeof filter.status === "number" || (typeof filter.status === "string" && !isNaN(Number(filter.status)))) {
+  } else if (
+    typeof filter.status === "number" ||
+    (typeof filter.status === "string" && !isNaN(Number(filter.status)))
+  ) {
     if (Number(row?.status) !== Number(filter.status)) return false;
   }
 
@@ -57,13 +60,25 @@ export function rowMatchesFilter(row: any, filter: Record<string, any>): boolean
   if (filter.account && !matchesSearch(row?.account || "", String(filter.account))) {
     return false;
   }
-  if (filter.apiKey && !matchesSearch(row?.apiKeyName || "", String(filter.apiKey))) {
+  // The SQL layer resolves this filter against either column
+  // (`cl.api_key_name LIKE @apiKeyQ OR cl.api_key_id LIKE @apiKeyQ`), and the
+  // dashboard's API-key dropdown sends the id. Matching the name alone here
+  // dropped every persisted row the SQL layer had just returned, so selecting a
+  // key from the dropdown emptied the grid while typing its name worked. #12873
+  if (
+    filter.apiKey &&
+    !matchesSearch(row?.apiKeyName || "", String(filter.apiKey)) &&
+    !matchesSearch(row?.apiKeyId || "", String(filter.apiKey))
+  ) {
     return false;
   }
   if (filter.combo && !matchesSearch(row?.comboName || "", String(filter.combo))) {
     return false;
   }
-  if (filter.correlationId && !matchesSearch(row?.correlationId || "", String(filter.correlationId))) {
+  if (
+    filter.correlationId &&
+    !matchesSearch(row?.correlationId || "", String(filter.correlationId))
+  ) {
     return false;
   }
   if (filter.search) {
@@ -74,6 +89,9 @@ export function rowMatchesFilter(row: any, filter: Record<string, any>): boolean
       row?.providerDisplay,
       row?.account,
       row?.apiKeyName,
+      // The free-text SQL predicate covers `cl.api_key_id` too, so the id
+      // belongs in the in-memory haystack for the same reason. #12873
+      row?.apiKeyId,
       row?.comboName,
       row?.correlationId,
       row?.error,

--- a/tests/unit/call-logs-row-filter.test.ts
+++ b/tests/unit/call-logs-row-filter.test.ts
@@ -44,4 +44,48 @@ test.describe("call-logs rowMatchesFilter unit tests", () => {
     assert.equal(rowMatchesFilter(baseRow, { search: "corr-12345" }), true);
     assert.equal(rowMatchesFilter(baseRow, { search: "non-existent" }), false);
   });
+
+  // #12873. The dashboard's API-key dropdown carries `apiKeyId || apiKeyName`
+  // as its option value, so selecting a key sends the id. `getCallLogs()`
+  // matches either column, then this predicate re-filtered the same rows on the
+  // name alone and discarded all of them: a key with thousands of calls showed
+  // zero rows from the dropdown while typing its name worked.
+  const keyedRow = {
+    ...baseRow,
+    apiKeyId: "01ab6f86-3789-403a-9cf4-2f3f68551db9",
+  };
+
+  test("#12873 apiKey filter matches the key id sent by the dropdown", () => {
+    assert.equal(
+      rowMatchesFilter(keyedRow, { apiKey: "01ab6f86-3789-403a-9cf4-2f3f68551db9" }),
+      true
+    );
+  });
+
+  test("#12873 apiKey filter still matches the key name", () => {
+    assert.equal(rowMatchesFilter(keyedRow, { apiKey: "DevKey" }), true);
+  });
+
+  test("#12873 apiKey filter rejects a different key id", () => {
+    assert.equal(
+      rowMatchesFilter(keyedRow, { apiKey: "ffffffff-0000-0000-0000-000000000000" }),
+      false
+    );
+  });
+
+  test("#12873 in-memory rows carry neither field and stay excluded", () => {
+    // buildCallLogListRows() emits active/completed entries with both fields
+    // null; an API-key filter must not start letting those through.
+    const inMemoryRow = { ...baseRow, apiKeyId: null, apiKeyName: null };
+    assert.equal(
+      rowMatchesFilter(inMemoryRow, { apiKey: "01ab6f86-3789-403a-9cf4-2f3f68551db9" }),
+      false
+    );
+    assert.equal(rowMatchesFilter(inMemoryRow, { apiKey: "DevKey" }), false);
+  });
+
+  test("#12873 free-text search reaches the key id, as the SQL predicate does", () => {
+    // getCallLogs()'s search branch matches `cl.api_key_id` too.
+    assert.equal(rowMatchesFilter(keyedRow, { search: "01ab6f86" }), true);
+  });
 });


### PR DESCRIPTION
Fixes #12873. Your trace is exact — the filter is applied twice and the second pass does not know what the first one matched on.

## Two passes, one of them narrower

`GET /api/usage/call-logs` filters the same `apiKey` value in two places:

| pass | predicate | matches |
|---|---|---|
| SQL, `getCallLogs()` (`src/lib/usage/callLogs.ts:722`) | `cl.api_key_name LIKE @apiKeyQ OR cl.api_key_id LIKE @apiKeyQ` | name **or** id |
| in-memory, `rowMatchesFilter()` (`route.ts:60`) | `matchesSearch(row.apiKeyName, filter.apiKey)` | name only |

The second pass exists for a good reason: `buildCallLogListRows()` merges active and recently-completed in-memory entries into the persisted rows, and those would otherwise bypass every filter. It is documented as "idempotent for DB rows (they already satisfy the predicate)" — and that is the part that stopped being true for this one filter. The dropdown sends `apiKeyId || apiKeyName`, so for any key that has an id the SQL layer returns the right rows and the in-memory pass then compares a UUID against a display name and throws all of them away. Typing the name works because both passes agree on that value.

## The fix

`rowMatchesFilter` now accepts a row when the filter matches **either** field, which is the SQL predicate expressed over the merged row:

```ts
if (
  filter.apiKey &&
  !matchesSearch(row?.apiKeyName || "", String(filter.apiKey)) &&
  !matchesSearch(row?.apiKeyId || "", String(filter.apiKey))
) {
  return false;
}
```

In-memory rows are unaffected: `buildCallLogListRows()` writes `apiKeyId: null, apiKeyName: null` on both the active and the completed entries, so an API-key filter still excludes them — they carry no attribution to match. There is a test for that so a later change cannot start letting unattributed rows through.

The free-text `search` branch had drifted the same way — `callLogs.ts:751` searches `cl.api_key_id`, the in-memory haystack did not — so `row.apiKeyId` joins that list too. Same root cause, one line, and it keeps the two layers describing the same thing.

## Tests

`tests/unit/call-logs-row-filter.test.ts`, 5 added cases: the dropdown's id matches; the name still matches; a different id does not; an in-memory row with both fields null stays excluded under an id filter and under a name filter; free-text search reaches the id.

Reverting only `route.ts` to the base commit and re-running the file:

```
not ok 5 - #12873 apiKey filter matches the key id sent by the dropdown
not ok 9 - #12873 free-text search reaches the key id, as the SQL predicate does
# tests 9  # pass 7  # fail 2
```

With the fix: 9 pass, 0 fail.

## Commands run

```
node --import tsx/esm --test tests/unit/call-logs-row-filter.test.ts      9 pass, 0 fail
eslint src/app/api/usage/call-logs/route.ts tests/...                     No issues found
prettier --check <both changed files>                                     clean
```

One disclosure about the diff: two hunks in `route.ts` (the `filter.status` branch and the `correlationId` branch) are prettier's, not mine — those lines are already over the line budget on `release/v3.8.51` and the repo's own pre-commit hook rewrapped them when it formatted the file. They are untouched by the fix; say the word and I will drop them.

I have not run the dashboard against a populated database — the reproduction in the issue is precise enough that the unit layer is where the defect lives, but the end-to-end confirmation (dropdown → rows appear) is yours to make if you want it before merge.
