### PR TITLE
fix(providers): read the vLLM context window from max_model_len

### DIFF
--- a/changelog.d/fixes/12897-vllm-max-model-len.md
+++ b/changelog.d/fixes/12897-vllm-max-model-len.md
@@ -1,0 +1,1 @@
+- **fix(providers):** vLLM connections now advertise the real context window: model discovery reads `max_model_len` instead of falling back to the 128K default ([#12897](https://github.com/diegosouzapw/OmniRoute/pull/12897), closes [#12858](https://github.com/diegosouzapw/OmniRoute/issues/12858))

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -310,10 +310,16 @@ export function normalizeDiscoveredModels(
     // `context_length` / `top_provider.context_length`, not `inputTokenLimit`.
     // Fall back across those names so synced models carry a real window instead
     // of the provider default (128K). Explicit `inputTokenLimit` still wins. #3202
+    // vLLM — and every server that copies its /v1/models shape — reports the
+    // window as `max_model_len`, the value the engine was actually started with.
+    // Without it a vLLM model syncs with no window at all and the resolver hands
+    // out the 128K default, understating a 250K deployment by half. #12858
     const inputTokenLimit = firstPositiveNumber(
       record.inputTokenLimit,
       record.context_length,
       record.contextLength,
+      record.max_model_len,
+      record.maxModelLen,
       topProvider.context_length
     );
     const outputTokenLimit = firstPositiveNumber(

--- a/tests/unit/vllm-max-model-len-12858.test.ts
+++ b/tests/unit/vllm-max-model-len-12858.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeDiscoveredModels } from "@/lib/providerModels/modelDiscovery";
+
+// Regression guard for #12858.
+//
+// vLLM's /v1/models reports the context window as `max_model_len` — the value
+// the engine was started with — and nothing else. The native `vllm` provider is
+// `passthroughModels: true`, and the OpenAI- and Anthropic-compatible custom
+// providers pass the same raw records through, so all three connection shapes
+// land here. Before the fix no window field matched, the model was persisted
+// with no `inputTokenLimit`, and `/v1/models` advertised the 128K provider
+// default for a deployment serving 250K.
+//
+// Same class of bug as #3202 (OpenRouter's `context_length`): the provider
+// declares the window under a name the normalizer does not read.
+
+test("#12858 maps vLLM max_model_len into inputTokenLimit", () => {
+  const [model] = normalizeDiscoveredModels([
+    { id: "qwen3.8", owned_by: "vllm", root: "/models/Qwen3.8-27B-FP8", max_model_len: 250000 },
+  ]);
+
+  assert.equal(model.id, "qwen3.8");
+  assert.equal(model.inputTokenLimit, 250000);
+});
+
+test("#12858 accepts the camelCase spelling too", () => {
+  // `contextLength` is already accepted next to `context_length`; keep the two
+  // spellings of this field symmetric with that pair.
+  const [model] = normalizeDiscoveredModels([{ id: "vendor/camel", maxModelLen: 131072 }]);
+
+  assert.equal(model.inputTokenLimit, 131072);
+});
+
+test("#12858 preserves an explicit inputTokenLimit over max_model_len", () => {
+  const [model] = normalizeDiscoveredModels([
+    { id: "vendor/explicit-wins", inputTokenLimit: 200000, max_model_len: 999999 },
+  ]);
+
+  assert.equal(model.inputTokenLimit, 200000);
+});
+
+test("#12858 keeps context_length ahead of max_model_len when a record has both", () => {
+  // OpenRouter-style catalogs are the older contract (#3202); a record carrying
+  // both fields must not change meaning because this one was added.
+  const [model] = normalizeDiscoveredModels([
+    { id: "vendor/both", context_length: 262144, max_model_len: 131072 },
+  ]);
+
+  assert.equal(model.inputTokenLimit, 262144);
+});
+
+test("#12858 ignores a non-positive or non-numeric max_model_len", () => {
+  const [zero] = normalizeDiscoveredModels([{ id: "vendor/zero", max_model_len: 0 }]);
+  const [negative] = normalizeDiscoveredModels([{ id: "vendor/negative", max_model_len: -1 }]);
+  const [text] = normalizeDiscoveredModels([{ id: "vendor/text", max_model_len: "250000" }]);
+
+  assert.equal(zero.inputTokenLimit, undefined);
+  assert.equal(negative.inputTokenLimit, undefined);
+  assert.equal(text.inputTokenLimit, undefined);
+});
+
+test("#12858 leaves inputTokenLimit unset when no window field is present", () => {
+  const [model] = normalizeDiscoveredModels([{ id: "vendor/no-window" }]);
+
+  assert.equal(model.inputTokenLimit, undefined);
+});


### PR DESCRIPTION
Fixes #12858. Your root cause holds all the way down — `max_model_len` appears nowhere in the tree, so there was never a path by which a vLLM window could be captured.

## Why all three connection shapes broke together

`normalizeDiscoveredModels` is the single funnel: the native `vllm` provider is `passthroughModels: true` (`src/shared/constants/providers/local.ts:62`), and the OpenAI- and Anthropic-compatible custom providers hand the same raw `/v1/models` records to it. So this is not three bugs that look alike, it is one chain that never listed the field vLLM uses:

```ts
firstPositiveNumber(
  record.inputTokenLimit,
  record.context_length,
  record.contextLength,
  topProvider.context_length
)
```

Everything downstream follows from the miss you named: nothing is persisted, so the Feature 5004 reconciler has nothing to pin, and the resolver answers with the 128K default. A 250K deployment is advertised at half its size, `min()` across combo targets inherits the wrong number, and `enforceOutputTokenBudget` can refuse a request the upstream would have served.

## The fix

`record.max_model_len` joins the chain, after the OpenRouter names and before `top_provider.context_length`. `record.maxModelLen` goes in beside it for the same reason `contextLength` sits beside `context_length` — the two spellings of one field stay symmetric, and a JSON-camelizing proxy in front of vLLM is a real shape.

Ordering is deliberate rather than incidental: an explicit `inputTokenLimit` still wins, and a record carrying both `context_length` and `max_model_len` still resolves to `context_length`, so no catalog that works today changes meaning. `firstPositiveNumber` already rejects `0`, negatives and strings, so a server that reports `"250000"` is ignored rather than half-trusted — the test pins that, since it is behaviour a reader would otherwise assume either way.

## Tests

`tests/unit/vllm-max-model-len-12858.test.ts`, 6 cases modeled on `openrouter-context-length-3202.test.ts`: the vLLM record from your report maps to 250000; the camelCase spelling maps; an explicit `inputTokenLimit` wins; `context_length` stays ahead when both are present; `0` / `-1` / `"250000"` are ignored; a record with no window field still yields `undefined`.

Reverting only `modelDiscovery.ts` to the base commit:

```
not ok 1 - #12858 maps vLLM max_model_len into inputTokenLimit
not ok 2 - #12858 accepts the camelCase spelling too
# tests 6  # pass 4  # fail 2
```

With the fix: 6 pass, 0 fail. `tests/unit/openrouter-context-length-3202.test.ts` also runs green alongside it (5 pass), which is the check that matters for the ordering claim above.

## Commands run

```
node --import tsx/esm --test tests/unit/vllm-max-model-len-12858.test.ts \
                             tests/unit/openrouter-context-length-3202.test.ts    11 pass, 0 fail
eslint src/lib/providerModels/modelDiscovery.ts tests/unit/vllm-max-model-len-12858.test.ts
                                                                                  No issues found
prettier --check <both files>                                                     clean
```

Changed test files: `tests/unit/vllm-max-model-len-12858.test.ts` (new).

What I have not done: run a real vLLM server behind a connection and watch `/v1/models` report 250000. The normalizer is where the field is read and the tests exercise it directly, but if you have that server handy, the end-to-end check is one `curl` and worth having on the record.
