### PR TITLE
fix(combos): accept isHidden in updateComboSchema

### DIFF
--- a/changelog.d/fixes/12898-combo-hidden-update-schema.md
+++ b/changelog.d/fixes/12898-combo-hidden-update-schema.md
@@ -1,0 +1,1 @@
+- **fix(combos):** A combo's visibility can be changed through the API again: `updateComboSchema` accepts `isHidden`, so a visibility-only update is no longer rejected as empty and a mixed update no longer drops it ([#12898](https://github.com/diegosouzapw/OmniRoute/pull/12898), closes [#12836](https://github.com/diegosouzapw/OmniRoute/issues/12836))

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -417,6 +417,11 @@ export const updateComboSchema = z
     strategy: comboStrategySchema.optional(),
     config: comboRuntimeConfigSchema.optional(),
     isActive: z.boolean().optional(),
+    // Stored on the combo record and honoured by the readers — the builder's
+    // option list and the dashboard grid both filter on it — but omitted here,
+    // so the one endpoint a client can flip it through stripped the field and
+    // a visibility-only update was rejected as empty. #12836
+    isHidden: z.boolean().optional(),
     allowedProviders: z.array(z.string().trim().min(1).max(200)).max(100).optional(),
     allowedModelFamilies: z.array(z.string().trim().min(1).max(100)).max(100).optional(),
     // Nullable like `description` and `context_length` above: an absent field means
@@ -441,6 +446,7 @@ export const updateComboSchema = z
       value.strategy === undefined &&
       value.config === undefined &&
       value.isActive === undefined &&
+      value.isHidden === undefined &&
       value.allowedProviders === undefined &&
       value.allowedModelFamilies === undefined &&
       value.system_message === undefined &&

--- a/tests/unit/combo-hidden-update-12836.test.ts
+++ b/tests/unit/combo-hidden-update-12836.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #12836 — a combo's visibility must be updatable through the API.
+ *
+ * `isHidden` is stored on the combo record and honoured by its readers: the
+ * builder's option list drops hidden combos (`src/lib/combos/builderOptions.ts`)
+ * and so does the dashboard grid. `createCombo` writes the field explicitly.
+ * The only endpoint a client can flip it through is `PUT /api/combos/[id]`,
+ * which spreads the *validated* body into the update — and `updateComboSchema`
+ * never listed `isHidden`, so zod stripped it. A visibility-only update was
+ * rejected as "No valid fields to update", and pairing it with a recognized
+ * field made the request succeed while silently dropping the visibility change.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-hidden-12836-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { updateComboSchema } = await import("../../src/shared/validation/schemas.ts");
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#12836 a visibility-only update is a valid update", () => {
+  assert.equal(updateComboSchema.parse({ isHidden: true }).isHidden, true);
+  assert.equal(updateComboSchema.parse({ isHidden: false }).isHidden, false);
+  // The empty-update refinement still fires for a genuinely empty body.
+  assert.throws(() => updateComboSchema.parse({}), /No valid fields to update/);
+});
+
+test("#12836 visibility survives a mixed update instead of being stripped", () => {
+  const parsed = updateComboSchema.parse({ description: "fixture", isHidden: true });
+  assert.equal(parsed.description, "fixture");
+  assert.equal(parsed.isHidden, true);
+});
+
+test("#12836 only a boolean is accepted", () => {
+  for (const bad of ["true", 1, null, {}]) {
+    assert.throws(() => updateComboSchema.parse({ isHidden: bad }));
+  }
+});
+
+test("#12836 hiding a combo persists and reads back", async () => {
+  const created = await combosDb.createCombo({
+    name: "Visibility Combo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+  });
+  assert.equal(created.isHidden, false);
+
+  const body = updateComboSchema.parse({ isHidden: true });
+  const updated = await combosDb.updateCombo(created.id as string, body);
+  assert.ok(updated);
+  assert.equal(updated!.isHidden, true);
+
+  // Re-read: this is the state the builder and the dashboard grid filter on.
+  const reread = await combosDb.getComboById(created.id as string);
+  assert.ok(reread);
+  assert.equal(reread!.isHidden, true);
+});
+
+test("#12836 unhiding it again works, and an unrelated update leaves it alone", async () => {
+  const created = await combosDb.createCombo({
+    name: "Round Trip Combo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+  });
+
+  await combosDb.updateCombo(created.id as string, updateComboSchema.parse({ isHidden: true }));
+  const shown = await combosDb.updateCombo(
+    created.id as string,
+    updateComboSchema.parse({ isHidden: false })
+  );
+  assert.ok(shown);
+  assert.equal(shown!.isHidden, false);
+
+  await combosDb.updateCombo(created.id as string, updateComboSchema.parse({ isHidden: true }));
+  const untouched = await combosDb.updateCombo(
+    created.id as string,
+    updateComboSchema.parse({ description: "note" })
+  );
+  assert.ok(untouched);
+  assert.equal(untouched!.description, "note");
+  assert.equal(untouched!.isHidden, true);
+});


### PR DESCRIPTION
Fixes #12836. Confirmed against `release/v3.8.51`, and the field is more load-bearing than "stored but unvalidated" suggests.

## The field has readers, just no writer

`isHidden` is not vestigial:

| site | what it does with it |
|---|---|
| `sqliteComboRepository.createCombo` | writes it explicitly — `isHidden: Boolean(data.isHidden)` |
| `src/lib/combos/builderOptions.ts:798` | `.filter((combo) => combo.isHidden !== true && combo.isActive !== false)` — hidden combos leave the builder's option list |
| `dashboard/combos/page.tsx:876` | drops them from the grid, filtering the fetched list on `!c.isHidden` |
| `PUT /api/combos/[id]` | spreads the **validated** body into `updateCombo` |

That last row is the only path a client has to the field, and `updateComboSchema` did not list it. Zod strips unknown keys, so `{ isHidden: true }` reached the empty-update refinement with nothing left and came back `No valid fields to update`; `{ description: "x", isHidden: true }` was accepted and wrote the description alone. A combo could therefore be born hidden but never be hidden or unhidden afterwards.

Storage is not the obstacle — `updateCombo` merges `{ ...current, ...data }` and serialises the whole record into the `data` column, so the moment validation stops discarding the key it persists. That is asserted rather than assumed: the tests below go through the real repository and re-read the row.

## The fix

Two lines, exactly as you scoped it: `isHidden: z.boolean().optional()` on the object, and `value.isHidden === undefined` in the empty-update refinement so a visibility-only body counts as a real update. No passthrough, no loosening of the model, config or authorization validation around it.

`createComboSchema` has the same omission and I have deliberately left it alone: creation already defaults the field through `Boolean(data.isHidden)`, "new combos are visible" is a defensible rule, and widening creation is a product decision rather than a bug fix. Happy to add it in this PR if you want the two schemas symmetric.

## Tests

`tests/unit/combo-hidden-update-12836.test.ts`, 5 cases modeled on `combo-clear-agent-features-12158.test.ts` (same seam, same repository round-trip):

- a visibility-only update parses for `true` and for `false`, while `{}` still fails the refinement;
- a mixed `{ description, isHidden }` update keeps both fields;
- `"true"`, `1`, `null` and `{}` are all still rejected;
- hiding a combo through `createCombo` → `updateCombo` → `getComboById` reads back `isHidden: true` — the state the two filters above act on;
- unhiding works, and a later unrelated update leaves the visibility where it was.

Reverting only `combo.ts` to the base commit:

```
not ok 1 - #12836 a visibility-only update is a valid update
not ok 2 - #12836 visibility survives a mixed update instead of being stripped
not ok 4 - #12836 hiding a combo persists and reads back
not ok 5 - #12836 unhiding it again works, and an unrelated update leaves it alone
# tests 5  # pass 1  # fail 4
```

(The type-rejection case passes on both sides — an unknown key is stripped, so a bad value was never accepted either. It is there to keep the new field from being widened later.)

## Commands run

```
node --import tsx/esm --test tests/unit/combo-hidden-update-12836.test.ts          5 pass, 0 fail
node --import tsx/esm --test combo-clear-agent-features-12158 shared/comboSchema \
                             combo-empty-models combo-context-length             41 pass, 0 fail
prettier --check <both changed files>                                            clean
```

Changed test files: `tests/unit/combo-hidden-update-12836.test.ts` (new).

Not covered: no dashboard control sends this field yet, so nothing in the UI exercises the path today — this fixes the API so a client (or a future toggle) can use it, which is what the issue reports.
