### PR TITLE
fix(sse): map reasoning_effort for self-hosted GLM-5.3-Flash to its native {low,high,max} tiers

### DIFF
--- a/open-sse/executors/base/reasoningEffort.ts
+++ b/open-sse/executors/base/reasoningEffort.ts
@@ -49,6 +49,14 @@ export const MISTRAL_NO_REASONING_EFFORT_PATTERN = /devstral/i;
 export const GITHUB_REASONING_EFFORT_OPT_IN_PATTERN = /claude[-_.]?(?:opus|sonnet)[-_.]?4[-_.]6/i;
 export const GITHUB_NO_REASONING_EFFORT_PATTERN = /(claude|haiku|oswe)/i;
 const NVIDIA_GLM_52_PATTERN = /z-ai\/glm-5\.2\b/i;
+const OPENAI_COMPATIBLE_PREFIX = "openai-compatible-";
+// Self-hosted GLM-5.3-Flash served through an OpenAI-Compatible surrogate
+// (e.g. an internal vLLM). GLM-5.3-Flash accepts reasoning_effort as
+// {low, high, max} literally — the same vocabulary Z.AI documents for the
+// GLM-5.3 Coding Plan surface — so pass those through unchanged and only map
+// the internal tiers GLM does not expose. Scoped to the 5.3 family so it does
+// not swallow GLM-5.2, which has its own (broader) vocabulary handling.
+const GLM_53_FLASH_MODEL_PATTERN = /glm[-_ ]?5\.3(?:[-_ ]?flash)?/i;
 
 /**
  * Model families whose top reasoning tier in their native API or upstream gateways
@@ -523,6 +531,32 @@ export function sanitizeReasoningEffortForProvider(
     return body;
   }
 
+  // OpenAI-Compatible endpoints serving a self-hosted GLM-5.3-Flash model
+  // (e.g. internal vLLM, provider id "openai-compatible-..."). GLM-5.3-Flash
+  // accepts reasoning_effort as {low, high, max} literally, so pass those
+  // through unchanged. Only map the internal tiers GLM does not expose: Claude
+  // Code may still send none/minimal/medium/xhigh (it cannot be constrained via
+  // model-catalogs), so none/minimal → low, medium → high, and xhigh → max
+  // before the request reaches the endpoint.
+  if (provider.startsWith(OPENAI_COMPATIBLE_PREFIX) && GLM_53_FLASH_MODEL_PATTERN.test(modelStr)) {
+    const mapped =
+      effortStr === "xhigh"
+        ? "max"
+        : effortStr === "medium"
+          ? "high"
+          : effortStr === "none" || effortStr === "minimal"
+            ? "low"
+            : null;
+    if (mapped && mapped !== effortStr) {
+      log?.info?.(
+        "REASONING_SANITIZE",
+        `${provider}/${modelStr}: normalized reasoning_effort ${effortStr} → ${mapped}`
+      );
+      return writeEffortValue(b, mapped, c);
+    }
+    return body;
+  }
+
   // Generic learned clamp (downgrade-only: greatest accepted <= demand).
   // Sits AFTER the per-provider early returns by design: deepseek/command-code/
   // ollama-cloud have deliberate static translations that take precedence; the
@@ -549,11 +583,10 @@ export function sanitizeReasoningEffortForProvider(
     ? modelStr.slice(provider.length + 1)
     : modelStr;
   const declaredEfforts = getProviderModels(provider).find(
-    (entry) => entry.id === providerModelIdForClamp || entry.aliases?.includes(providerModelIdForClamp)
+    (entry) =>
+      entry.id === providerModelIdForClamp || entry.aliases?.includes(providerModelIdForClamp)
   )?.supportedThinkingEfforts;
-  const declaredRanked = (
-    Array.isArray(declaredEfforts) ? declaredEfforts : []
-  )
+  const declaredRanked = (Array.isArray(declaredEfforts) ? declaredEfforts : [])
     .map((tier) => ({ tier, rank: REASONING_EFFORT_ORDER.indexOf(tier) }))
     .filter((x) => x.rank >= 0)
     .sort((a, b) => a.rank - b.rank);

--- a/tests/unit/base-executor-sanitize-effort.test.ts
+++ b/tests/unit/base-executor-sanitize-effort.test.ts
@@ -932,3 +932,148 @@ test("sanitizeReasoningEffortForProvider: #7044 output_config.effort high passes
   assert.equal(result, body, "high is supported — body returned unchanged");
   assert.equal((result as Record<string, unknown>).output_config.effort, "high");
 });
+
+// ── OpenAI-Compatible GLM-5.3-Flash (self-hosted vLLM) ──────────────────────
+// GLM-5.3-Flash accepts reasoning_effort as {low, high, max} literally — the same
+// vocabulary Z.AI documents for the Coding Plan surface. Claude Code sends its
+// own vocabulary (none/minimal/low/medium/high/xhigh/max), so the internal tiers
+// GLM-5.3-Flash does not expose are mapped: none/minimal → low, medium → high,
+// xhigh → max. native {low, high, max} pass through unchanged.
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash preserves low and high", () => {
+  for (const level of ["low", "high"]) {
+    const body = {
+      model: "GLM-5.3-Flash",
+      reasoning_effort: level,
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const result = sanitizeReasoningEffortForProvider(
+      body,
+      "openai-compatible-chat-sk",
+      "GLM-5.3-Flash",
+      null
+    );
+    assert.equal(result, body, `${level} passes through unchanged`);
+    assert.equal((result as Record<string, unknown>).reasoning_effort, level);
+  }
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash preserves max", () => {
+  const body = {
+    model: "GLM-5.3-Flash",
+    reasoning_effort: "max",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.3-Flash",
+    null
+  );
+  assert.equal(result, body, "max passes through unchanged");
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "max");
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash maps medium → high", () => {
+  const body = {
+    model: "GLM-5.3-Flash",
+    reasoning_effort: "medium",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.3-Flash",
+    null
+  );
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "high");
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash maps xhigh → max", () => {
+  const log = makeLog();
+  const body = {
+    model: "GLM-5.3-Flash",
+    reasoning_effort: "xhigh",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.3-Flash",
+    log
+  );
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "max");
+  assert.ok(
+    log.messages.some(([tag, m]) => tag === "REASONING_SANITIZE" && /xhigh → max/.test(m)),
+    "logs the normalization"
+  );
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash maps none → low", () => {
+  const body = {
+    model: "GLM-5.3-Flash",
+    reasoning_effort: "none",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.3-Flash",
+    null
+  );
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "low");
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash maps minimal → low", () => {
+  const body = {
+    model: "GLM-5.3-Flash",
+    reasoning_effort: "minimal",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.3-Flash",
+    null
+  );
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "low");
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash maps nested reasoning.effort xhigh → max", () => {
+  const body = {
+    model: "GLM-5.3-Flash",
+    reasoning: { effort: "xhigh", summary: "auto" },
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.3-Flash",
+    null
+  );
+  assert.equal((result as Record<string, unknown>).reasoning.effort, "max");
+  assert.equal(
+    (result as Record<string, unknown>).reasoning.summary,
+    "auto",
+    "other reasoning fields preserved"
+  );
+});
+
+test("sanitizeReasoningEffortForProvider: OpenAI-compatible GLM-5.3-Flash mapping is scoped to 5.3 (not GLM-5.2)", () => {
+  // GLM-5.2 served through the same OpenAI-compatible surrogate must not be
+  // caught by the 5.3 pattern — it has its own (broader) vocabulary handling.
+  const body = {
+    model: "GLM-5.2",
+    reasoning_effort: "medium",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openai-compatible-chat-sk",
+    "GLM-5.2",
+    null
+  );
+  // GLM-5.2 has no self-hosted mapping on v3.8.51, so medium passes through
+  // unchanged (the generic #8057 pass-through default) — NOT mapped to high.
+  assert.equal((result as Record<string, unknown>).reasoning_effort, "medium");
+});


### PR DESCRIPTION
### fix(sse): map reasoning_effort for self-hosted GLM-5.3-Flash to its native {low,high,max} tiers

## Summary

- The self-hosted GLM-5.3-Flash at the internal LLM gateway (skhynix) accepts only three reasoning_effort tiers: `low`/`high`/`max`. The canonical `reasoningEffort.ts` contains only the NVIDIA-hosted GLM-5.2 pattern, and lacks effort mapping for `openai-compatible` surrogate models (including GLM-5.3-Flash), so values such as `none`/`minimal`/`medium`/`xhigh` are sent unchanged and cause 400 errors.
- Add GLM-5.3-Flash mapping to `sanitizeReasoningEffortForProvider`: `none`/`minimal` → `low`, `medium` → `high`, `xhigh` → `max`.

## Related Issues

- Closes #12900

## Validation

- [x] Change type: provider / routing
- [x] Focused tests: `node --import tsx/esm --test tests/unit/base-executor-sanitize-effort.test.ts`
- [ ] `npm run lint`
- [ ] Reconciled with `release/v3.8.51` base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/base-executor-sanitize-effort.test.ts` — added GLM-5.3-Flash effort mapping cases (reference source: local `95ce30612`)

## Coverage Notes

- (Measured after implementation)

## Reviewer Notes

- Canonical evidence: 0 occurrences of `openai-compatible`/`5.3`/`GLM_53` in `reasoningEffort.ts` (only the NVIDIA GLM-5.2 pattern exists, `:51` `NVIDIA_GLM_52_PATTERN`).
- Reference local commit `95ce30612`. Mapping table: none/minimal→low, medium→high, xhigh→max.
- The canonical xhigh→max normalization targets specific providers such as DeepSeek, so the GLM-5.3-Flash surrogate requires a separate branch.

### changelog.d/fixes/12900-glm53-flash-effort-mapping.md
```
- **fix(sse):** map reasoning_effort for self-hosted GLM-5.3-Flash to its native {low,high,max} tiers — none/minimal→low, medium→high, xhigh→max — to stop 400 from the skhynix gateway ([#12900](https://github.com/diegosouzapw/OmniRoute/pull/12900))
```

---
