### PR TITLE
fix(compat): preserve GPT and Claude Code tool-call history

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -79,6 +79,29 @@ function appendReasoningContent(current: unknown, next: string): string {
   return existing ? `${existing}\n\n${next}` : next;
 }
 
+function normalizeRoleBasedToolCalls(toolCalls: unknown): JsonRecord[] {
+  if (!Array.isArray(toolCalls)) return [];
+
+  return toolCalls
+    .map((toolCallValue) => {
+      const toolCall = toRecord(toolCallValue);
+      const fn = toRecord(toolCall.function);
+      const name = toString(fn.name).trim();
+      const id = toString(toolCall.id).trim();
+      if (!name || !id) return null;
+      return {
+        id,
+        type: "function",
+        function: {
+          name,
+          arguments:
+            typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments ?? {}),
+        },
+      };
+    })
+    .filter((toolCall): toolCall is JsonRecord => toolCall !== null);
+}
+
 /**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
  */
@@ -252,6 +275,15 @@ export function openaiResponsesToOpenAIRequest(
         pendingToolResults = [];
       }
 
+      if (toString(item.role) === "tool") {
+        messages.push({
+          role: "tool",
+          tool_call_id: toString(item.tool_call_id),
+          content: toolOutputContentToString(item.content),
+        });
+        continue;
+      }
+
       // Convert content: input_text -> text, output_text -> text
       const content = Array.isArray(item.content)
         ? item.content.map((contentValue) => {
@@ -288,7 +320,17 @@ export function openaiResponsesToOpenAIRequest(
         : item.content;
 
       if (role === "assistant") {
-        if (!currentAssistantMsg) {
+        const roleBasedToolCalls = normalizeRoleBasedToolCalls(item.tool_calls);
+        if (roleBasedToolCalls.length > 0) {
+          if (currentAssistantMsg) {
+            messages.push(currentAssistantMsg);
+          }
+          currentAssistantMsg = {
+            role,
+            content,
+            tool_calls: roleBasedToolCalls,
+          };
+        } else if (!currentAssistantMsg) {
           currentAssistantMsg = { role, content };
         } else if (currentAssistantMsg.content == null && content != null) {
           currentAssistantMsg.content = content;

--- a/tests/unit/translator-openai-responses-tool-calls.test.ts
+++ b/tests/unit/translator-openai-responses-tool-calls.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiResponsesToOpenAIRequest } =
+  await import("../../open-sse/translator/request/openai-responses.ts");
+
+test("Responses -> Chat preserves role-based assistant tool_calls and tool results", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "deepseek-v4-flash",
+    {
+      model: "deepseek-v4-flash",
+      input: [
+        { role: "user", content: "Run pwd" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "exec_command", arguments: '{"cmd":"pwd"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "/tmp" },
+      ],
+    },
+    false,
+    { provider: "deepseek" }
+  ) as { messages: Array<Record<string, unknown>> };
+
+  assert.deepEqual(result.messages[1].tool_calls, [
+    {
+      id: "call_1",
+      type: "function",
+      function: { name: "exec_command", arguments: '{"cmd":"pwd"}' },
+    },
+  ]);
+  assert.deepEqual(result.messages[2], {
+    role: "tool",
+    tool_call_id: "call_1",
+    content: "/tmp",
+  });
+});
+
+test("Responses -> Chat drops role-based tool_calls with empty name or id", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "deepseek-v4-flash",
+    {
+      model: "deepseek-v4-flash",
+      input: [
+        { role: "user", content: "Run" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "call_nameless", type: "function", function: { name: "", arguments: "{}" } },
+            { id: "", type: "function", function: { name: "exec_command", arguments: "{}" } },
+          ],
+        },
+      ],
+    },
+    false,
+    { provider: "deepseek" }
+  ) as { messages: Array<Record<string, unknown>> };
+
+  assert.equal(result.messages[1].tool_calls, undefined);
+});


### PR DESCRIPTION
# fix(compat): preserve GPT and Claude Code tool-call history

## Summary

Agent tool-call history is lost when translating an OpenAI Responses API request to Chat Completions (`open-sse/translator/request/openai-responses.ts`):

1. `role:"tool"` items in the input list are not recognized, so tool results are dropped from the translated output → previous tool results are absent from subsequent requests.
2. The role-based `tool_calls` array on assistant items is not preserved, breaking `tool_call_id` matching between assistant messages and tool results.

In multi-turn sessions where GPT (Codex) and Claude Code send tool-call history in Responses format, the translated Chat Completions upstream receives incomplete history, causing re-invocation/malfunction.

**Changes**:
- New `normalizeRoleBasedToolCalls()` — normalizes `tool_calls` items (validates id/function.name, stringifies arguments, drops invalid items)
- `role:"tool"` items → direct conversion to `role:"tool"` messages (preserves `tool_call_id`)
- When an assistant item has valid `tool_calls`, push it as a separate assistant message (does not conflict with consecutive-assistant merge logic)

## Related Issues

- Closes #12909

## Validation

- [x] Change type: provider / routing
- [x] Focused tests: `node --import tsx/esm --test tests/unit/translator-openai-responses-tool-calls.test.ts` (2/2)
- [x] Full merge validation: 9 new/updated test files, 82/82 pass, `npx tsc --pretty false -p tsconfig.typecheck-core.json` — 0 errors
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

| Test file | Status | Coverage |
|------|------|------|
| `tests/unit/translator-openai-responses-tool-calls.test.ts` | New | preserves role-based assistant tool_calls + tool results, drops invalid (missing name/id) tool_calls |

## Coverage Notes

The new logic (`normalizeRoleBasedToolCalls` + direct `role:"tool"` branch) is fully tested. Regression impact is limited to the openai-responses request translation path — the existing content conversion path is unchanged.

## Reviewer Notes

- Commit `dbdac9c48` / patch `0021`. Patch re-export of a commit authored in fork (`initguru`) `release/v3.8.51`.
- Only `open-sse/translator/request/openai-responses.ts` is modified — no overlap with the response translator or Group A (`targetRequestSanitizer`, etc.) → independent PR.
- changelog fragment: `changelog.d/fixes/12909-tool-call-history-preserve.md`
