### PR TITLE
fix(usage): finalize semantic cache hits by exact request id

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1253,7 +1253,7 @@ export async function handleChatCore({
     stream: !!stream,
     reqLogger,
     effectiveServiceTier,
-    connectionId,
+    pendingScope,
     startTime,
     log,
     persistAttemptLogs,

--- a/open-sse/handlers/chatCore/semanticCache.ts
+++ b/open-sse/handlers/chatCore/semanticCache.ts
@@ -1,10 +1,6 @@
-import {
-  generateSignature,
-  getCachedResponse,
-  isCacheableForRead,
-} from "@/lib/semanticCache";
+import { generateSignature, getCachedResponse, isCacheableForRead } from "@/lib/semanticCache";
 import { calculateCost } from "@/lib/usage/costCalculator";
-import { trackPendingRequest } from "@/lib/usageDb";
+import { finalizePendingScope, type PendingRequestScope } from "@/lib/usage/pendingRequestScope";
 import { synthesizeOpenAiSseFromJson } from "../../utils/jsonToSse.ts";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { extractUsageFromResponse } from "../usageExtractor.ts";
@@ -19,7 +15,7 @@ export async function checkSemanticCache({
   stream,
   reqLogger,
   effectiveServiceTier,
-  connectionId,
+  pendingScope,
   startTime,
   log,
   persistAttemptLogs,
@@ -36,7 +32,7 @@ export async function checkSemanticCache({
   stream: boolean;
   reqLogger: { logConvertedResponse: (response: Record<string, unknown>) => void };
   effectiveServiceTier: string | null | undefined;
-  connectionId: string | null;
+  pendingScope: PendingRequestScope;
   startTime: number;
   log: { debug?: (...args: unknown[]) => void } | null;
   persistAttemptLogs: (args: unknown) => void;
@@ -74,7 +70,11 @@ export async function checkSemanticCache({
         clientResponse: cached,
         cacheSource: "semantic",
       });
-      trackPendingRequest(model, provider, connectionId, false);
+      finalizePendingScope(pendingScope, {
+        status: 200,
+        providerResponse: cached,
+        clientResponse: cached,
+      });
       const cachedSse = stream ? synthesizeOpenAiSseFromJson(JSON.stringify(cached)) : "";
       const headers: Record<string, string> = {
         "Content-Type": cachedSse ? "text/event-stream" : "application/json",

--- a/tests/unit/chatcore-semantic-cache.test.ts
+++ b/tests/unit/chatcore-semantic-cache.test.ts
@@ -42,7 +42,12 @@ function makeBaseArgs(overrides: Record<string, unknown> = {}) {
       },
     },
     effectiveServiceTier: undefined,
-    connectionId: null as string | null,
+    pendingScope: {
+      id: null,
+      model: "gpt-4o",
+      provider: "openai",
+      connectionId: null,
+    },
     startTime: Date.now(),
     log: {
       debug: () => {
@@ -162,7 +167,12 @@ function makeHitArgs(overrides: Record<string, unknown> = {}) {
       },
     },
     effectiveServiceTier: undefined,
-    connectionId: null as string | null,
+    pendingScope: {
+      id: null,
+      model: "gpt-4o",
+      provider: "openai",
+      connectionId: null,
+    },
     startTime: Date.now() - 5,
     log: {
       debug: (...a: unknown[]) => {
@@ -491,4 +501,51 @@ test("checkSemanticCache HIT includes X-OmniRoute-Cache-Latency: synthetic heade
     "synthetic",
     "HIT response carries X-OmniRoute-Cache-Latency: synthetic marker"
   );
+});
+
+test("checkSemanticCache HIT finalizes the exact pending request by id", async () => {
+  clearCache();
+  const { clearPendingRequests, getPendingById, trackPendingRequest } =
+    await import("../../src/lib/usage/usageHistory.ts");
+  const { getCompletedDetails } = await import("../../src/lib/usage/completedRequestDetails.ts");
+  clearPendingRequests();
+  try {
+    const cached = {
+      id: "chatcmpl-cached-finalize",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "finalize answer" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+    };
+    const pendingId = trackPendingRequest("gpt-4o", "openai", "account-a", true);
+    assert.ok(pendingId);
+    const { args } = makeHitArgs({
+      body: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "hit query finalize" }],
+        temperature: 0,
+      },
+      pendingScope: {
+        id: pendingId,
+        model: "gpt-4o",
+        provider: "openai",
+        connectionId: "account-a",
+      },
+    });
+    seedHit(args, cached);
+
+    const result = await checkSemanticCache(args as Parameters<typeof checkSemanticCache>[0]);
+    assert.ok(result);
+    assert.equal(getPendingById().has(pendingId as string), false);
+    const completed = getCompletedDetails().get(pendingId as string);
+    assert.ok(completed);
+    assert.equal(completed.status, 200);
+    assert.deepEqual(completed.clientResponse, cached);
+  } finally {
+    clearPendingRequests();
+  }
 });


### PR DESCRIPTION
# fix(usage): finalize semantic cache hits by exact request id

## Summary

The semantic-cache-hit usage finalization records an arbitrary pending request:

- Existing: `trackPendingRequest(model, provider, connectionId, false)` — finds pending by connectionId and marks it complete. If connectionId is null or multiple requests are in progress on the same connection, **the wrong request's pending entry is finalized**, or the actual cache-hit request's pending entry remains.
- Fix: `finalizePendingScope(pendingScope, { status: 200, providerResponse: cached, clientResponse: cached })` — finalize cache hits precisely by exact request id (`PendingRequestScope`).

Change the `checkSemanticCache` signature from `connectionId: string | null` to `pendingScope: PendingRequestScope`, and update the `chatCore.ts` call site to pass `pendingScope` (1 line). Semantic cache hits are now recorded in usage statistics under the exact request id.

## Related Issues

- Closes #12910

## Validation

- [x] Change type: provider / routing
- [x] Focused tests: `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --test tests/unit/chatcore-semantic-cache.test.ts` (passes, including updates)
- [x] Full merge validation: 9 new/updated test files, 82/82 pass, `npx tsc --pretty false -p tsconfig.typecheck-core.json` — 0 errors
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

| Test file | Status | Coverage |
|------|------|------|
| `tests/unit/chatcore-semantic-cache.test.ts` | Updated (+61) | cache hit → exact-id `finalizePendingScope` finalization, pendingScope passing |

## Coverage Notes

`finalizePendingScope`/`PendingRequestScope` are from the existing origin module (`src/lib/usage/pendingRequestScope.ts`, present since v3.8.27) — no new dependency. The change is limited to the cache-hit finalization path.

## Reviewer Notes

- Commit `692d5fa54` / patch `0022`. Authored in fork (`initguru`) `release/v3.8.51`.
- `chatCore.ts` 1 line (connectionId→pendingScope) + semanticCache.ts — `chatCore.ts` is shared with PR13 (turn-execution-guard, patch 0024), but the hunks are separate (different areas), so this can be an independent PR; apply patches in order as recommended.
- changelog fragment: `changelog.d/fixes/12910-semantic-cache-exact-id-finalize.md`
