### PR TITLE
fix(translator): drop unsigned reasoning on Claude output

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -5256,7 +5256,7 @@
   },
   "tests/unit/translator-resp-openai-to-claude.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 14
+      "count": 12
     }
   },
   "tests/unit/translator-thinking-provider-compat-2043.test.ts": {

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -719,11 +719,10 @@ function convertOpenAINonStreamingToClaude(
 
   const reasoningText = resolveReasoningText(messageObj);
   if (reasoningText) {
-    hasTextOrReasoning = true;
-    content.push({
-      type: "thinking",
-      thinking: reasoningText,
-    });
+    // Non-Anthropic reasoning has no Anthropic signature, so it cannot be
+    // replayed as a Claude `thinking` block. Do not launder it into text either:
+    // it may contain private chain-of-thought and would pollute future history.
+    void reasoningText;
   }
 
   // Always include text if it exists (even empty string), or if there are no tool calls and no reasoning

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -47,10 +47,22 @@ function extractXmlInvokeBlocks(
     const toolCallTextMatch = remaining.match(/TOOL_CALL\s+([A-Za-z0-9_]+):\s*/);
 
     const matches = [
-      invokeMatch ? { type: "invoke" as const, index: invokeMatch.index!, data: invokeMatch } : null,
-      toolCallTagMatch ? { type: "tool_call_tag" as const, index: toolCallTagMatch.index!, data: toolCallTagMatch } : null,
-      toolCallTextMatch ? { type: "tool_call_text" as const, index: toolCallTextMatch.index!, data: toolCallTextMatch } : null,
-    ].filter(Boolean).sort((a, b) => a!.index - b!.index);
+      invokeMatch
+        ? { type: "invoke" as const, index: invokeMatch.index!, data: invokeMatch }
+        : null,
+      toolCallTagMatch
+        ? { type: "tool_call_tag" as const, index: toolCallTagMatch.index!, data: toolCallTagMatch }
+        : null,
+      toolCallTextMatch
+        ? {
+            type: "tool_call_text" as const,
+            index: toolCallTextMatch.index!,
+            data: toolCallTextMatch,
+          }
+        : null,
+    ]
+      .filter(Boolean)
+      .sort((a, b) => a!.index - b!.index);
 
     if (matches.length === 0) {
       cleaned += remaining;
@@ -95,9 +107,7 @@ function extractXmlInvokeBlocks(
         const name = (parsed.name || parsed.tool_name || "") as string;
         const rawArgs = parsed.arguments || parsed.args || parsed.parameters || {};
         const args: Record<string, string> =
-          typeof rawArgs === "string"
-            ? JSON.parse(rawArgs)
-            : (rawArgs as Record<string, string>);
+          typeof rawArgs === "string" ? JSON.parse(rawArgs) : (rawArgs as Record<string, string>);
         if (name) {
           toolCalls.push({ id: `toolu_txt_${Date.now()}_${toolCalls.length}`, name, args });
         }
@@ -115,12 +125,27 @@ function extractXmlInvokeBlocks(
       let jsonEndIndex = -1;
       for (let i = 0; i < afterPrefix.length; i++) {
         const c = afterPrefix[i];
-        if (escape) { escape = false; continue; }
-        if (c === "\\" && inString) { escape = true; continue; }
-        if (c === '"') { inString = !inString; continue; }
+        if (escape) {
+          escape = false;
+          continue;
+        }
+        if (c === "\\" && inString) {
+          escape = true;
+          continue;
+        }
+        if (c === '"') {
+          inString = !inString;
+          continue;
+        }
         if (!inString) {
           if (c === "{") depth++;
-          else if (c === "}") { depth--; if (depth === 0) { jsonEndIndex = i + 1; break; } }
+          else if (c === "}") {
+            depth--;
+            if (depth === 0) {
+              jsonEndIndex = i + 1;
+              break;
+            }
+          }
         }
       }
       if (jsonEndIndex === -1) {
@@ -315,23 +340,10 @@ export function openaiToClaudeResponse(chunk, state) {
     reasoningContent !== "" &&
     !isInternalReasoningPlaceholder(reasoningContent)
   ) {
-    stopTextBlock(state, results);
-
-    if (!state.thinkingBlockStarted) {
-      state.thinkingBlockIndex = state.nextBlockIndex++;
-      state.thinkingBlockStarted = true;
-      results.push({
-        type: "content_block_start",
-        index: state.thinkingBlockIndex,
-        content_block: { type: "thinking", thinking: "" },
-      });
-    }
-
-    results.push({
-      type: "content_block_delta",
-      index: state.thinkingBlockIndex,
-      delta: { type: "thinking_delta", thinking: reasoningContent },
-    });
+    // Non-Anthropic reasoning has no Anthropic signature, so it cannot be
+    // replayed as a Claude `thinking` block. Do not launder it into text either:
+    // it may contain private chain-of-thought and would pollute future history.
+    void reasoningContent;
   }
 
   // Handle regular content — strip the internal reasoning placeholder if
@@ -378,7 +390,7 @@ export function openaiToClaudeResponse(chunk, state) {
         state._markdownFenceRun || 0,
         state._markdownFenceOpening === true,
         state._markdownFenceClosingRun || 0,
-        state._markdownLineIndent || 0,
+        state._markdownLineIndent || 0
       );
       state._markdownBuffer = textToHold;
       state._markdownCodeSpanRun = backtickRun || 0;

--- a/tests/unit/translator-resp-openai-to-claude.test.ts
+++ b/tests/unit/translator-resp-openai-to-claude.test.ts
@@ -51,7 +51,7 @@ test("OpenAI stream: text delta starts Claude message and closes cleanly on stop
   assert.equal(result[5].type, "message_stop");
 });
 
-test("OpenAI stream: reasoning_content closes before text content starts", () => {
+test("OpenAI stream: non-Anthropic reasoning_content is not emitted as Claude thinking", () => {
   const state = createState();
   const reasoning = openaiToClaudeResponse(
     {
@@ -71,11 +71,18 @@ test("OpenAI stream: reasoning_content closes before text content starts", () =>
   );
   const result = flatten([reasoning, text]);
 
-  assert.equal(result[1].content_block.type, "thinking");
-  assert.equal(result[2].delta.thinking, "Plan");
-  assert.equal(result[3].type, "content_block_stop");
-  assert.equal(result[4].content_block.type, "text");
-  assert.equal(result[5].delta.text, "Answer");
+  assert.equal(
+    result.some(
+      (event: { content_block?: { type?: string } }) => event.content_block?.type === "thinking"
+    ),
+    false
+  );
+  assert.equal(
+    result.some((event: { delta?: { type?: string } }) => event.delta?.type === "thinking_delta"),
+    false
+  );
+  assert.equal(result[1].content_block.type, "text");
+  assert.equal(result[2].delta.text, "Answer");
 });
 
 test("OpenAI stream: internal reasoning replay placeholder stays hidden from Claude thinking block", () => {
@@ -341,7 +348,7 @@ test("OpenAI stream: two finish_reason chunks emit finish events exactly once", 
   assert.equal(result.filter((e) => e.type === "message_stop").length, 1);
 });
 
-test("OpenAI non-stream: chat completion becomes Claude message with thinking and tool_use", () => {
+test("OpenAI non-stream: non-Anthropic reasoning_content is not emitted as Claude thinking", () => {
   const result = translateNonStreamingResponse(
     {
       id: "chatcmpl-ns",
@@ -379,13 +386,15 @@ test("OpenAI non-stream: chat completion becomes Claude message with thinking an
 
   assert.equal((result as any).type, "message");
   (assert as any).equal((result as any).model, "gpt-4.1");
-  (assert as any).equal((result as any).content[0].type, "thinking");
-  assert.equal((result as any).content[0].thinking, "Think first");
-  assert.equal((result as any).content[1].type, "text");
-  assert.equal((result as any).content[1].text, "Final answer");
-  assert.equal((result as any).content[2].type, "tool_use");
-  assert.equal((result as any).content[2].name, "read_file");
-  (assert as any).deepEqual((result as any).content[2].input, { path: "/tmp/a" });
+  assert.equal(
+    (result as any).content.some((block: { type?: string }) => block.type === "thinking"),
+    false
+  );
+  assert.equal((result as any).content[0].type, "text");
+  assert.equal((result as any).content[0].text, "Final answer");
+  assert.equal((result as any).content[1].type, "tool_use");
+  assert.equal((result as any).content[1].name, "read_file");
+  (assert as any).deepEqual((result as any).content[1].input, { path: "/tmp/a" });
   assert.equal((result as any).stop_reason, "tool_use");
   assert.deepEqual((result as any).usage, {
     input_tokens: 5,


### PR DESCRIPTION
## Summary
- stop converting non-Anthropic OpenAI-compatible `reasoning_content` into Claude `thinking` blocks
- apply the same suppression to the non-streaming OpenAI chat-completion to Claude conversion path
- update response translator regression tests to assert unsigned reasoning is not emitted as Claude thinking
- prune now-stale ESLint suppression count for the changed test file

## Why
`thinking` blocks sent back to Anthropic must carry Anthropic-valid signatures. Reasoning fields from OpenAI-compatible providers do not have those signatures, so translating them into Claude `thinking` creates replay history that Anthropic rejects with `Invalid signature in thinking block`.

## Validation
- `node --import tsx/esm --test tests/unit/translator-resp-openai-to-claude.test.ts`
- `node --import tsx/esm --test tests/unit/translator-openai-to-claude.test.ts`
- `npx eslint open-sse/handlers/responseTranslator.ts open-sse/translator/response/openai-to-claude.ts tests/unit/translator-resp-openai-to-claude.test.ts --cache --cache-location .eslintcache --suppressions-location config/quality/eslint-suppressions.json`
- `npm run typecheck:core -- --pretty false`

⚠️ base-red inherited: #12732
