### PR TITLE
fix(a2a): build the status agent card from the request that asked for it

### DIFF
--- a/changelog.d/fixes/12918-a2a-status-agent-card-base-url.md
+++ b/changelog.d/fixes/12918-a2a-status-agent-card-base-url.md
@@ -1,0 +1,1 @@
+- **fix(a2a):** `/api/a2a/status` now builds the agent card from the request that asked for it, so a gateway reached at a non-localhost host no longer advertises `http://localhost:20128` as its A2A URL ([#12918](https://github.com/diegosouzapw/OmniRoute/pull/12918)).

--- a/src/app/api/a2a/status/route.ts
+++ b/src/app/api/a2a/status/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import { getTaskManager } from "@/lib/a2a/taskManager";
 import { getCachedSettings } from "@/lib/db/settings";
 
-export async function GET() {
+export async function GET(request?: NextRequest) {
   try {
     const [settings, stats] = await Promise.all([
       getCachedSettings(),
@@ -14,7 +15,7 @@ export async function GET() {
     if (enabled) {
       try {
         const agentModule = await import("@/app/.well-known/agent.json/route");
-        const cardResponse = await agentModule.GET();
+        const cardResponse = await agentModule.GET(request);
         agentCard = await cardResponse.json();
       } catch {
         agentCard = null;

--- a/tests/unit/a2a-status-agent-card-12887.test.ts
+++ b/tests/unit/a2a-status-agent-card-12887.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-a2a-status-card-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+const ORIGINAL_BASE_URL = process.env.OMNIROUTE_BASE_URL;
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+// The bug only shows with no admin override: getBaseUrl() then reads
+// request.nextUrl.origin, which throws when the status route forgets to
+// forward its own request to the agent-card handler.
+delete process.env.OMNIROUTE_BASE_URL;
+
+const core = await import("../../src/lib/db/core.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const statusRoute = await import("../../src/app/api/a2a/status/route.ts");
+
+function statusRequest(url: string): NextRequest {
+  // A real NextRequest: `nextUrl` is what getBaseUrl() reads, and a plain
+  // Request does not have it.
+  return new NextRequest(new Request(url, { method: "GET" }));
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.OMNIROUTE_BASE_URL;
+  else process.env.OMNIROUTE_BASE_URL = ORIGINAL_BASE_URL;
+});
+
+test("A2A status serves the agent card built from the incoming request origin", async () => {
+  await settingsDb.updateSettings({ a2aEnabled: true });
+
+  const response = await statusRoute.GET(statusRequest("http://gateway.test:9999/api/a2a/status"));
+  const body = (await response.json()) as {
+    agent: { name?: string; url?: string } | null;
+    capabilities: { streaming?: boolean } | null;
+    skills: unknown[];
+  };
+
+  assert.equal(response.status, 200);
+  assert.notEqual(body.agent, null);
+  // A non-localhost origin: a hardcoded fallback base URL cannot pass by accident.
+  assert.equal(body.agent?.url, "http://gateway.test:9999/a2a");
+  assert.equal(body.capabilities?.streaming, true);
+  assert.ok(body.skills.length >= 6, `expected the card's skills, got ${body.skills.length}`);
+});


### PR DESCRIPTION
## What

`/api/a2a/status` builds its agent-card section by importing the
`/.well-known/agent.json` route handler and calling it in-process. It calls
`GET()` with no argument, so the card handler gets `request === undefined` and
`getBaseUrl()` cannot read `request.nextUrl.origin`. The card is then built
against the hardcoded `http://localhost:20128` — the exact hostname the S2 fix
removed from that helper.

Effect: a gateway reached at any other host (LAN IP, reverse proxy, container
hostname) serves a status payload whose `agent.url` points at localhost, and the
A2A dashboard shows that URL. The dedicated `/.well-known/agent.json` endpoint is
correct, because Next passes it a real request — only the in-process call is wrong.

Fix: forward the status route's own request to the card handler.

## Verifying the report first (#12887)

The report says the missing argument makes `getBaseUrl()` throw a `TypeError`,
the surrounding `try/catch` swallows it, and the panel renders
`agent: null, skills: []`. **That half no longer reproduces on the tip.**
`0023a9ec0` changed the helper to

```ts
return request?.nextUrl?.origin ?? "http://localhost:20128";
```

so there is no throw any more and the card is returned. What that guard did was
mask the missing wiring: instead of a visible `null`, the endpoint now reports a
confidently wrong URL. That is what this PR fixes; `getBaseUrl()` is left alone.

## Why no test caught it

`tests/unit/a2a-enabled-route.test.ts` calls `statusRoute.GET()` with no argument
too — the same shape as the bug — and asserts only `status`/`enabled`/`online`,
never the card. The route file is also outside `tsconfig.typecheck-core.json`'s
`files` list, so the missing argument was never a type error.

## Test

`tests/unit/a2a-status-agent-card-12887.test.ts` calls the status route with a real
`NextRequest` for `http://gateway.test:9999/api/a2a/status` (with
`OMNIROUTE_BASE_URL` unset) and asserts `agent.url === "http://gateway.test:9999/a2a"`.
The origin is deliberately not localhost, so the hardcoded fallback cannot pass by
accident; the two branches produce different strings.

```
npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm \
  --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts \
  --test --test-force-exit tests/unit/a2a-status-agent-card-12887.test.ts \
  tests/unit/a2a-enabled-route.test.ts
```

before the fix: 4 pass, 1 fail — the new test, `actual: 'http://localhost:20128/a2a'`
after the fix: 5 pass, 0 fail

## Mutation

Reverting the one wired line — `agentModule.GET(request)` back to
`agentModule.GET()` — turns the new test red again with the same
`actual: 'http://localhost:20128/a2a'`. The assertion is on the status route's
output, not on `getBaseUrl()` in isolation, so it pins the call site rather than
the helper.

Closes #12887
