### PR TITLE
fix(compression): keep tool_result blocks first when aging annotates a turn

### DIFF
--- a/changelog.d/fixes/12920-aging-tool-result-block-order.md
+++ b/changelog.d/fixes/12920-aging-tool-result-block-order.md
@@ -1,0 +1,1 @@
+- **fix(compression):** progressive aging now appends its `[COMPRESSED:aging:…]` annotation after a turn's `tool_result` blocks instead of in front of them, so Anthropic no longer rejects aged conversations with "`tool_use` ids were found without `tool_result` blocks immediately after" ([#12920](https://github.com/diegosouzapw/OmniRoute/pull/12920)).

--- a/open-sse/services/compression/messageContent.ts
+++ b/open-sse/services/compression/messageContent.ts
@@ -22,6 +22,12 @@ export function isTextBlock(value: unknown): value is TextBlock {
   );
 }
 
+export function isToolResultBlock(value: unknown): boolean {
+  return (
+    !!value && typeof value === "object" && (value as { type?: unknown }).type === "tool_result"
+  );
+}
+
 export function extractTextContent(content: ChatMessageLike["content"]): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
@@ -82,7 +88,14 @@ export function replaceTextContent(msg: ChatMessageLike, newText: string): ChatM
   });
 
   if (!replaced) {
-    return { ...msg, content: [{ type: "text", text: newText }, ...msg.content] };
+    // Anthropic requires every `tool_result` block to sit at the start of the
+    // user turn that answers a `tool_use`; a text block in front of them makes
+    // upstream reject the whole request with "tool_use ids were found without
+    // tool_result blocks immediately after" (#12890). Append the annotation in
+    // that case, and keep prepending everywhere else.
+    return msg.content.some(isToolResultBlock)
+      ? { ...msg, content: [...msg.content, { type: "text", text: newText }] }
+      : { ...msg, content: [{ type: "text", text: newText }, ...msg.content] };
   }
 
   return { ...msg, content };

--- a/tests/unit/compression/aging-tool-result-order-12890.test.ts
+++ b/tests/unit/compression/aging-tool-result-order-12890.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  replaceTextContent,
+  type ChatMessageLike,
+} from "../../../open-sse/services/compression/messageContent.ts";
+import { applyAging } from "../../../open-sse/services/compression/progressiveAging.ts";
+
+// ─── #12890 — aged tool_result turns must keep tool_result first ─────────────
+// The Anthropic Messages API requires the `tool_result` blocks answering a
+// `tool_use` to lead the following user message. Aging a tool-result-only user
+// turn used to prepend the `[COMPRESSED:aging:…]` annotation, producing
+// ["text", "tool_result"] and a 400 from upstream.
+
+function toolResultTurn(id: string): ChatMessageLike {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: id, content: "ls: 3 files" }],
+  };
+}
+
+function blockTypes(msg: unknown): string[] {
+  const content = (msg as ChatMessageLike).content;
+  return Array.isArray(content) ? content.map((b) => (b as { type?: string }).type ?? "") : [];
+}
+
+describe("aging a tool_result turn (#12890)", () => {
+  it("keeps tool_result first through applyAging", () => {
+    // distanceFromEnd of index 2 is 5 (> moderate: 3) → the fullSummary tier,
+    // which is where setContent/replaceTextContent injects the tag.
+    const messages: ChatMessageLike[] = [
+      { role: "user", content: "start the task" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_01", name: "bash", input: {} }],
+      },
+      toolResultTurn("toolu_01"),
+      { role: "assistant", content: "three files" },
+      { role: "user", content: "and now the second one" },
+      { role: "assistant", content: "done" },
+      { role: "user", content: "thanks" },
+      { role: "assistant", content: "you are welcome" },
+    ];
+
+    const { messages: aged } = applyAging(messages);
+    const types = blockTypes(aged[2]);
+
+    assert.deepEqual(types, ["tool_result", "text"], `got ${JSON.stringify(types)}`);
+    const annotation = (aged[2] as ChatMessageLike).content as Array<{ text?: string }>;
+    assert.match(annotation[1].text ?? "", /^\[COMPRESSED:aging:/);
+  });
+
+  it("still puts the annotation first when the turn carries no tool_result", () => {
+    const msg: ChatMessageLike = {
+      role: "user",
+      content: [{ type: "image", source: { foo: 1 } }],
+    };
+
+    const out = replaceTextContent(msg, "NEWTEXT");
+
+    assert.deepEqual(blockTypes(out), ["text", "image"]);
+  });
+});


### PR DESCRIPTION
## What

`replaceTextContent()` prepends the aging annotation when the message has no
text block to replace:

```ts
if (!replaced) {
  return { ...msg, content: [{ type: "text", text: newText }, ...msg.content] };
}
```

A user turn that answers a `tool_use` with a single `tool_result` block hits
exactly that branch, so aging rewrites it to `["text", "tool_result"]`. The
Anthropic Messages API requires the `tool_result` blocks to lead that turn, so
upstream rejects the entire request:

```
messages.N: `tool_use` ids were found without `tool_result` blocks immediately after
```

This PR appends the annotation when the turn carries a `tool_result`, and keeps
prepending for every other shape, so no existing ordering changes.

## Verifying the report first (#12890)

Confirmed on the tip, at the call site rather than from the description:

- `progressiveAging.ts::applyAging` → `setContent` → `replaceTextContent`. A
  tool-result-only turn has `extractTextContent(content) === ""`, so `replaced`
  stays false and the prepend branch runs.
- Reproduced through `applyAging` (not by calling the helper directly): a turn at
  `distanceFromEnd = 5` lands in the `fullSummary` tier and comes back as
  `["text", "tool_result"]`.

The report's suggested one-line fix (append unconditionally) would also move the
annotation for messages that carry no `tool_result` — images, for one — so the
condition is scoped to the shape that upstream actually constrains.

## Test

`tests/unit/compression/aging-tool-result-order-12890.test.ts`

1. **Wiring**: runs a real 8-message conversation through `applyAging()` and asserts
   the aged turn's block order is `["tool_result", "text"]` and that the trailing
   block is the `[COMPRESSED:aging:…]` annotation. It goes through the aging entry
   point, not `replaceTextContent` in isolation.
2. **Guard**: a turn holding only an `image` block still gets `["text", "image"]`.

## Mutation

| mutation | result |
|---|---|
| `!replaced` branch back to the unconditional prepend (the shipped bug) | ✖ `keeps tool_result first through applyAging` — `got ["text","tool_result"]` |
| `!replaced` branch to an unconditional append (the report's suggestion) | ✖ `still puts the annotation first when the turn carries no tool_result` |

Each mutation kills a different test, so neither branch of the new condition is
unpinned.

## Regression

The 7 test files that exercise `messageContent.ts` / `progressiveAging.ts` /
`aggressive.ts` — `aggressive-fidelity`, `aggressive`, `compression-aggressive`,
`golden-eval`, `progressiveAging`, `compression-aggressive-spare-last-user`, plus
the new file: **54 pass, 0 fail**.

Closes #12890
