### PR TITLE
fix(bedrock): resolve context limits for every vendor prefix, not just anthropic

### DIFF
--- a/changelog.d/fixes/12921-bedrock-vendor-context-limits.md
+++ b/changelog.d/fixes/12921-bedrock-vendor-context-limits.md
@@ -1,0 +1,1 @@
+- **fix(bedrock):** model import now resolves context limits for every vendor prefix instead of only `anthropic.*`, so `global.openai.gpt-5.6-*` no longer imports with a null `inputTokenLimit` and gets rejected pre-flight at the 200k default ([#12921](https://github.com/diegosouzapw/OmniRoute/pull/12921)).

--- a/open-sse/config/bedrock.ts
+++ b/open-sse/config/bedrock.ts
@@ -90,13 +90,19 @@ export function getBedrockKnownModelLimits(modelId: string): {
   if (!trimmed) return null;
 
   const unqualified = trimmed.includes("/") ? trimmed.slice(trimmed.indexOf("/") + 1) : trimmed;
-  const withoutProfilePrefix = unqualified.replace(/^(?:eu|us|global)\./i, "");
-  const withoutProviderPrefix = withoutProfilePrefix.replace(/^anthropic\./i, "");
-  const spec =
-    getModelSpec(trimmed) ||
-    getModelSpec(unqualified) ||
-    getModelSpec(withoutProfilePrefix) ||
-    getModelSpec(withoutProviderPrefix);
+  // A Bedrock id is "<vendor>.<model>" optionally behind a cross-region profile
+  // prefix: "global.openai.gpt-5.6-sol", "us.anthropic.claude-...". The model
+  // name itself contains dots ("gpt-5.6-sol"), so peel at most those two leading
+  // qualifiers and keep the first candidate a spec knows. Peeling only
+  // "anthropic." left every other vendor (openai, meta, amazon, ...) without a
+  // context window, and the caller then fell back to a 200k default (#12915).
+  const segments = unqualified.split(".");
+  const spec = [trimmed, unqualified, segments.slice(1).join("."), segments.slice(2).join(".")]
+    .filter((candidate) => candidate.length > 0)
+    .reduce<ReturnType<typeof getModelSpec>>(
+      (found, candidate) => found || getModelSpec(candidate),
+      undefined
+    );
 
   if (!spec?.contextWindow && !spec?.maxOutputTokens) return null;
   return {

--- a/tests/unit/bedrock-vendor-context-limits-12915.test.ts
+++ b/tests/unit/bedrock-vendor-context-limits-12915.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { discoverBedrockNativeModels } from "../../open-sse/services/bedrock.ts";
+
+// ─── #12915 — every Bedrock vendor prefix must resolve a context window ──────
+// Bedrock ids are "<vendor>.<model>", optionally behind a cross-region profile
+// prefix ("global.openai.gpt-5.6-sol"). The known-limits lookup used to peel
+// only "anthropic.", so imported openai.* models carried no inputTokenLimit and
+// the pre-flight context check fell back to a 200k default — rejecting 1M-context
+// models locally, before the request ever reached AWS.
+
+function bedrockFetcher(): (url: string, init: RequestInit) => Promise<Response> {
+  return async (url: string) => {
+    const body = url.includes("/inference-profiles")
+      ? { inferenceProfileSummaries: [] }
+      : {
+          modelSummaries: [
+            {
+              modelId: "global.openai.gpt-5.6-sol",
+              modelName: "GPT-5.6 Sol",
+              providerName: "OpenAI",
+              responseStreamingSupported: true,
+            },
+            {
+              modelId: "global.anthropic.claude-opus-4-6-v1",
+              modelName: "Claude Opus 4.6",
+              providerName: "Anthropic",
+              responseStreamingSupported: true,
+            },
+          ],
+        };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+describe("Bedrock model discovery (#12915)", () => {
+  it("carries a context window for openai.* models, not just anthropic.*", async () => {
+    const { models } = await discoverBedrockNativeModels({
+      apiKey: "test-key",
+      providerSpecificData: { region: "eu-west-1" },
+      fetcher: bedrockFetcher(),
+    });
+
+    const openai = models.find((m) => m.id === "global.openai.gpt-5.6-sol");
+    const anthropic = models.find((m) => m.id === "global.anthropic.claude-opus-4-6-v1");
+
+    // 1_050_000 and 1_000_000 differ, so a lookup that silently answered with the
+    // anthropic model's limit would not pass either assertion.
+    assert.equal(openai?.inputTokenLimit, 1_050_000);
+    assert.equal(openai?.outputTokenLimit, 128_000);
+    // The anthropic path must keep working unchanged.
+    assert.equal(anthropic?.inputTokenLimit, 1_000_000);
+  });
+});


### PR DESCRIPTION
## What

`getBedrockKnownModelLimits()` normalizes a Bedrock model id before looking up
`MODEL_SPECS`:

```ts
const withoutProfilePrefix = unqualified.replace(/^(?:eu|us|global)\./i, "");
const withoutProviderPrefix = withoutProfilePrefix.replace(/^anthropic\./i, "");
```

The vendor peel is hardcoded to `anthropic.`, so `global.openai.gpt-5.6-sol` is
only ever tried as `openai.gpt-5.6-sol` — which no spec matches. Every imported
`openai.*` model is stored with no `inputTokenLimit`, the pre-flight context
check falls back to the 200k default, and a 1M-context model is rejected locally
before the request reaches AWS:

```
[CONTEXT] Input exceeds context window for bedrock/global.openai.gpt-5.6-sol:
estimated 220940 input tokens, limit 200000.
```

This PR peels the two leading qualifiers a Bedrock id can carry (cross-region
profile, then vendor) and keeps the first candidate a spec knows.

## Verifying the report first (#12915)

Measured on the tip through `getBedrockKnownModelLimits()`:

| model id | before | after |
|---|---|---|
| `global.openai.gpt-5.6-sol` | `null` | `{inputTokenLimit: 1050000, outputTokenLimit: 128000}` |
| `global.openai.gpt-5.6-terra` | `null` | `{inputTokenLimit: 1050000, outputTokenLimit: 128000}` |
| `global.anthropic.claude-opus-4-6-v1` | `{1000000, 128000}` | unchanged |
| `us.anthropic.claude-sonnet-4-5-v1:0` | `{200000, 64000}` | unchanged |

So the report's root cause is confirmed, and its scope is wider than stated —
`meta.*`, `amazon.*`, `mistral.*`, `deepseek.*` hit the same gate.

**One correction to the expected values.** The report expects 1M; `MODEL_SPECS`
puts `gpt-5.6-sol` at **1_050_000**, so that is what the import now stores. The
`inputTokenLimit: null` symptom is fixed either way.

**What this does not fix.** After the vendor gate is gone, coverage is whatever
`MODEL_SPECS` knows. I checked 14 non-anthropic ids (`meta.llama4-maverick-…`,
`amazon.nova-pro-v1:0`, `cohere.command-r-plus-v1:0`, `mistral.mistral-large-…`,
`deepseek.r1-v1:0`, `qwen.*`, `ai21.*`, `writer.*`, `stability.*`, `twelvelabs.*`,
`luma.*`): all still resolve to `null`, because no spec carries those names. They
are also unchanged from today's behaviour — none of them regress, and none of them
matched a *wrong* spec through the wider peel, which was the risk worth checking.
Populating those families is a catalog-data change, not this lookup.

## Why the peel stops at two segments

A Bedrock model name contains dots of its own (`gpt-5.6-sol`), so splitting the
whole id and peeling greedily would eventually try `6-sol`. An id carries at most
two leading qualifiers — `<profile>.<vendor>.<model>` — so the candidate list is
`[id, unqualified, drop-1, drop-2]` and the first spec hit wins.

## Test

`tests/unit/bedrock-vendor-context-limits-12915.test.ts` drives
`discoverBedrockNativeModels()` with a stub fetcher returning a `modelSummaries`
payload — the real import entry point, not the lookup helper — and asserts the
`openai.*` model comes back with `inputTokenLimit: 1_050_000` while the
`anthropic.*` model keeps `1_000_000`. The two numbers differ, so a lookup that
answered with the neighbouring model's limit would fail both assertions.

## Mutation

| mutation | result |
|---|---|
| candidate list back to the `anthropic.`-only peel (shipped code) | ✖ `actual: undefined, expected: 1050000` |
| drop `...(getBedrockKnownModelLimits(model.id) \|\| {})` from `withKnownBedrockLimits` (the call site) | ✖ `actual: undefined` |

The second mutation is the point: the test fails when the *wiring* is removed,
not only when the helper's logic changes.

## Regression

`tests/unit/executor-bedrock.test.ts`,
`tests/unit/bedrock-image-log-redaction-7297.test.ts` and the new file:
**15 pass, 0 fail**.

Closes #12915
