### PR TITLE
fix(ci): make Merge integrity green — a bulletless changelog fragment and a stale generated skill

### DIFF
--- a/changelog.d/fixes/12637-reset-aware-model-family.md
+++ b/changelog.d/fixes/12637-reset-aware-model-family.md
@@ -1,0 +1,1 @@
+- **fix(combo):** Keep Antigravity Gemini usable when the same connection's Claude weekly quota is empty; the generic quota cache stays per-connection for every other provider ([#12637](https://github.com/diegosouzapw/OmniRoute/pull/12637)) — thanks @HouMinXi

--- a/changelog.d/fixes/reset-aware-model-family.md
+++ b/changelog.d/fixes/reset-aware-model-family.md
@@ -1,1 +1,0 @@
-Keep Antigravity Gemini usable when the same connection's Claude weekly quota is empty; generic quota cache stays per-connection for every other provider.

--- a/skills/cli-tunnel/SKILL.md
+++ b/skills/cli-tunnel/SKILL.md
@@ -37,12 +37,12 @@ omniroute tunnel
 omniroute tunnel list
 ```
 
-### `tunnel create [type]`
+### `tunnel create`
 
 **Example:**
 
 ```bash
-omniroute tunnel create [type]
+omniroute tunnel create
 ```
 
 ### `tunnel stop <type>`


### PR DESCRIPTION
`release/v3.8.51` fails its own **Merge integrity (changelog + generated skills)** gate, so every open pull request inherits a red check that has nothing to do with its diff. The gate has two halves and **both** are failing on the base branch. One PR fixes both, because fixing either alone leaves the check red.

## Half 1 — a changelog fragment with no bullet

```
$ node scripts/check/check-changelog-integrity.mjs     # on origin/release/v3.8.51, clean tree
[changelog-integrity] 1 invalid changelog fragment(s):
  ✗ changelog.d/fixes/reset-aware-model-family.md: fragment must start with a markdown bullet ("- ")
```

The file is a bare sentence. It arrived with `2a6eff0aec` (#12637, @HouMinXi, 3 Sep), and because the gate scans the whole `changelog.d/` tree rather than only the fragments a PR touches, one malformed file turns the check red for everybody.

Restored as the bullet the other fragments use, wording unchanged apart from an article, credit kept:

```markdown
- **fix(combo):** Keep Antigravity Gemini usable when the same connection's Claude weekly quota is empty; the generic quota cache stays per-connection for every other provider ([#12637](https://github.com/diegosouzapw/OmniRoute/pull/12637)) — thanks @HouMinXi
```

Also renamed to `12637-reset-aware-model-family.md`, since `changelog.d/README.md` specifies `<PR-number>-<short-slug>.md` and says the prefix is what keeps aggregation order deterministic. Happy to drop the rename if you would rather keep a fix like this to one line.

## Half 2 — a generated skill that drifted from the CLI

```
$ npm run -s check:agent-skills-sync                   # on origin/release/v3.8.51, clean tree
  GENERATED:
    + cli-tunnel
  UNCHANGED: 45 skills (all up-to-date)
```

`skills/cli-tunnel/SKILL.md` documents `tunnel create [type]`; the generator reads `tunnel create` from the current CLI definition. Two lines, and the file was never regenerated after the argument changed. Regenerated with `--apply`, no hand edits.

## Verification

Both halves, before and after, on a clean tree:

```
# before (origin/release/v3.8.51)
node scripts/check/check-changelog-integrity.mjs   → 1 invalid changelog fragment(s)   exit 1
npm run -s check:agent-skills-sync                 → GENERATED: + cli-tunnel

# after
node scripts/check/check-changelog-integrity.mjs   → OK — no base bullets lost           exit 0
npm run -s check:agent-skills-sync                 → UNCHANGED: 46 skills (all up-to-date)
node scripts/release/aggregate-changelog.mjs --dry-run
                                                   → aggregates cleanly, renamed file included
```

There is no unit test to add: the gate that was failing is the test, and it goes red → green on this diff. Nothing outside those two files is touched.

I have not checked whether either drift is present on other release branches; if they were cherry-picked, the same two fixes apply there.
