### PR TITLE
fix(guardrails): mask PII inside a tool_result's nested content

### DIFF
--- a/changelog.d/fixes/12930-pii-nested-tool-result.md
+++ b/changelog.d/fixes/12930-pii-nested-tool-result.md
@@ -1,0 +1,1 @@
+- **fix(guardrails):** mask PII inside a `tool_result`'s nested content array, which the masker walked past while redacting its sibling block ([#12930](https://github.com/diegosouzapw/OmniRoute/pull/12930))

--- a/src/lib/guardrails/piiMasker.ts
+++ b/src/lib/guardrails/piiMasker.ts
@@ -57,11 +57,18 @@ function applyToContentValue(
           modified ||= result.modified;
           record.text = result.text;
         }
-        if (typeof record.content === "string") {
-          const result = sanitizeStringValue(record.content);
-          detections.push(...result.detections);
+        // Recurse rather than only masking a string `content`. A tool_result
+        // block carries its payload as an array of parts, which is what every
+        // agentic client sends back, and the string-only test walked straight
+        // past it: the outer text block was redacted while the tool output next
+        // to it reached the provider intact. This is the same call
+        // sanitizeMessageLikeList already makes one level up, so the two agree
+        // on how deep masking goes. The payload is a JSON round-trip, so it is
+        // acyclic and the recursion is bounded by its nesting.
+        if ("content" in record) {
+          const result = applyToContentValue(record.content, detections);
           modified ||= result.modified;
-          record.content = result.text;
+          record.content = result.value;
         }
         return record;
       }

--- a/tests/unit/pii-nested-tool-result.test.ts
+++ b/tests/unit/pii-nested-tool-result.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.PII_REDACTION_ENABLED = "true";
+
+import { PIIMaskerGuardrail } from "../../src/lib/guardrails/piiMasker";
+import type { GuardrailContext } from "../../src/lib/guardrails/base";
+
+const SSN = "123-45-6789";
+const CONTEXT = {} as GuardrailContext;
+
+const guardrail = new PIIMaskerGuardrail();
+
+async function mask(payload: unknown) {
+  const result = await guardrail.preCall(payload, CONTEXT);
+  const out = (result as { modifiedPayload?: unknown }).modifiedPayload ?? payload;
+  return {
+    out,
+    serialised: JSON.stringify(out),
+    meta: result.meta as Record<string, unknown> | null,
+  };
+}
+
+const userTurn = (content: unknown) => ({ messages: [{ role: "user", content }] });
+
+test.describe("PII masking reaches nested content blocks", () => {
+  // The defect. A tool_result carries its payload as an array of parts, which
+  // is what every agentic client sends back after running a tool. The masker
+  // only descended into a `content` that was a string, so it walked past this.
+  test("a tool_result's array content is masked", async () => {
+    const { serialised } = await mask(
+      userTurn([
+        { type: "text", text: `visible ${SSN}` },
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_1",
+          content: [{ type: "text", text: `tool output ${SSN}` }],
+        },
+      ])
+    );
+
+    assert.ok(!serialised.includes(SSN), `SSN survived: ${serialised}`);
+    assert.equal(serialised.match(/\[SSN_REDACTED\]/g)?.length, 2);
+  });
+
+  test("the sibling block being masked is not enough on its own", async () => {
+    // Pins what the bug looked like from outside: the payload came back
+    // `modified: true` with a redaction in it, so nothing downstream could tell
+    // that a second copy of the same SSN had gone out untouched.
+    const { out } = await mask(
+      userTurn([
+        { type: "text", text: `visible ${SSN}` },
+        { type: "tool_result", content: [{ type: "text", text: `tool output ${SSN}` }] },
+      ])
+    );
+
+    const blocks = (
+      out as { messages: { content: { text?: string; content?: { text: string }[] }[] }[] }
+    ).messages[0].content;
+    assert.equal(blocks[0].text, "visible [SSN_REDACTED]");
+    assert.equal(blocks[1].content?.[0].text, "tool output [SSN_REDACTED]");
+  });
+
+  test("nesting deeper than one tool_result is still reached", async () => {
+    const { serialised } = await mask(
+      userTurn([
+        {
+          type: "tool_result",
+          content: [{ type: "tool_result", content: [{ type: "text", text: `deep ${SSN}` }] }],
+        },
+      ])
+    );
+
+    assert.ok(!serialised.includes(SSN), `SSN survived: ${serialised}`);
+  });
+
+  // The branch this change replaces, so it cannot be lost silently.
+  test("a string content on a block is still masked", async () => {
+    const { serialised } = await mask(
+      userTurn([{ type: "tool_result", tool_use_id: "toolu_1", content: `tool output ${SSN}` }])
+    );
+
+    assert.ok(!serialised.includes(SSN), `SSN survived: ${serialised}`);
+  });
+
+  test("a payload with nothing to mask is passed through unchanged", async () => {
+    const payload = userTurn([
+      { type: "tool_result", content: [{ type: "text", text: "no personal data here" }] },
+    ]);
+
+    const result = await guardrail.preCall(payload, CONTEXT);
+
+    assert.equal((result as { modifiedPayload?: unknown }).modifiedPayload, undefined);
+  });
+
+  test("the nested detection is counted, not just redacted", async () => {
+    const { meta } = await mask(
+      userTurn([{ type: "tool_result", content: [{ type: "text", text: `tool output ${SSN}` }] }])
+    );
+
+    assert.equal(meta?.redacted, true);
+    assert.equal(meta?.detections, 1);
+  });
+});


### PR DESCRIPTION
`applyToContentValue()` descends into a content block's `content` only when it is a string:

```ts
if (typeof record.content === "string") { … }
```

A `tool_result` carries its payload as an **array** of parts — the shape every agentic client sends back after running a tool — so the string test walks past it, and the tool output reaches the provider unmasked.

Driving `PIIMaskerGuardrail.preCall()` with `PII_REDACTION_ENABLED=true`:

```json
{"type":"text","text":"visible [SSN_REDACTED]"}
{"type":"tool_result","tool_use_id":"toolu_1",
 "content":[{"type":"text","text":"tool output 123-45-6789"}]}
```

## Why this is worse than it looks

The sibling block **is** redacted. So the guardrail returns `modified: true`, reports `{detections: 1, redacted: true}`, and the payload visibly contains a `[SSN_REDACTED]`. Every signal downstream says the masker did its job, while a second copy of the same value went out untouched. A guardrail that fails loudly is a bug; one that fails while reporting success is the reason I wrote a test for the counted-detection case too.

`CredentialMaskerGuardrail`, in the same directory, walks the entire payload via `walkValue`. Only the PII masker stopped at depth one.

## The change

`sanitizeMessageLikeList()` already calls `applyToContentValue` for a message's `content`. Making `applyToContentValue` do the same for a nested block is the same call, one level down, so the two agree on how deep masking goes:

```ts
if ("content" in record) {
  const result = applyToContentValue(record.content, detections);
  modified ||= result.modified;
  record.content = result.value;
}
```

This subsumes the string branch it replaces — `applyToContentValue` sanitizes a string and recurses into an array — so no case is lost. The payload is a `JSON.parse(JSON.stringify(...))` round-trip before this runs, so it is acyclic and the recursion is bounded by its nesting; no `seen` set is needed.

`maskResponsesOutput()` on the response path has the same depth-one shape. I have left it alone rather than widen this PR, and I am happy to send it separately.

## Verification

`tests/unit/pii-nested-tool-result.test.ts`, 6 tests. Checked by breaking it:

| reverted | killed |
|---|---|
| back to masking only a string `content` | the 3 nesting tests + the detection-count test |
| stop descending into `content` at all | those 4, plus the string-content regression guard |
| recurse but drop the `modified` flag | the deep-nesting and detection-count tests |

Under the first mutation the two guards — *a string content on a block is still masked* and *a payload with nothing to mask is passed through unchanged* — stay green, which is what should happen: that mutation restores the old behaviour for exactly the cases the old code handled.

`eslint` clean on both files; `tsc -p tsconfig.typecheck-core.json` reports 0 errors.
