### PR TITLE
fix(changelog): make the #12637 fragment a bullet so the gate can pass

### DIFF
--- a/changelog.d/fixes/12637-reset-aware-model-family.md
+++ b/changelog.d/fixes/12637-reset-aware-model-family.md
@@ -1,0 +1,1 @@
+- **fix(combo):** Keep Antigravity Gemini usable when the same connection's Claude weekly quota is empty; generic quota cache stays per-connection for every other provider ([#12637](https://github.com/diegosouzapw/OmniRoute/pull/12637)) — thanks @HouMinXi

--- a/changelog.d/fixes/reset-aware-model-family.md
+++ b/changelog.d/fixes/reset-aware-model-family.md
@@ -1,1 +1,0 @@
-Keep Antigravity Gemini usable when the same connection's Claude weekly quota is empty; generic quota cache stays per-connection for every other provider.

--- a/changelog.d/maintenance/12932-changelog-fragment-bullet.md
+++ b/changelog.d/maintenance/12932-changelog-fragment-bullet.md
@@ -1,0 +1,1 @@
+- **fix(changelog):** make the `#12637` fragment start with a markdown bullet so `check-changelog-integrity` stops failing on every open PR ([#12932](https://github.com/diegosouzapw/OmniRoute/pull/12932))


### PR DESCRIPTION
`check-changelog-integrity` requires every fragment's first non-empty line to start with `- `. `changelog.d/fixes/reset-aware-model-family.md` starts with `Keep Antigravity Gemini usable…`, so the gate fails:

```
[changelog-integrity] 1 invalid changelog fragment(s):
  ✗ changelog.d/fixes/reset-aware-model-family.md: fragment must start with a markdown bullet ("- ")
```

It walks the whole `changelog.d` tree rather than only the files a PR touches, so this fails on every open PR in the repo, whatever it changes. I found it while sorting my own red checks from the base's.

## The change

The wording is the author's, unchanged. It gains the bullet, the scope prefix its own commit already carries (`fix(combo)`, from #12637), the PR link, and the credit line — the format `changelog.d/README.md` documents.

Renamed to the documented `<PR-number>-<slug>` shape as well. That prefix is not decoration: `aggregate-changelog.mjs` sorts with

```js
.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
```

so an unprefixed name sorts after every numbered one, and the entry would land at the end of *Bug Fixes* rather than in PR order:

```
without prefix: 9999-zzz.md | 12930-pii.md | reset-aware-model-family.md
with prefix   : 9999-zzz.md | 12637-reset-aware-model-family.md | 12930-pii.md
```

## Verification

`node scripts/check/check-changelog-integrity.mjs`

- on `release/v3.8.51`: the failure quoted above
- with this change: `OK — no base bullets lost vs origin/release/v3.8.51`

## This does not turn the whole check green, and should not

**Merge integrity (changelog + generated skills)** runs two steps. With the changelog one fixed, CI now gets past it and the *second* step fails instead:

```
> node --import tsx/esm scripts/skills/generate-agent-skills.mjs
Generated: 1 · Unchanged: 45
  GENERATED:
    + cli-tunnel
```

**Please do not fix that by regenerating** — the committed file is the correct one and the generator's output is wrong. `cliRegistryParser.ts` is a deliberate regex parser over `.command("…")` strings that never imports the modules, so it cannot see positionals declared with `.addArgument()`. #12295 fixed a real crash by moving `tunnel create`'s argument from `.command("create [type]")` to `.addArgument(new Argument("[type]"))`, and the argument became invisible to the parser. Regenerating would delete a real argument from the docs.

The same blind spot is already producing a wrong file elsewhere, without any drift to signal it: `resilience set` takes a **required** `<name>` with choices `aggressive|balanced|conservative|custom`, and `skills/cli-resilience/SKILL.md` documents it as `omniroute resilience set` with no argument at all. An agent following that page runs a command that cannot succeed.

Those are the only two `.addArgument()` call sites in `bin/cli/commands/`. I have kept them out of this PR because the fix belongs in the parser, not in a changelog PR — happy to send it separately if you would like.

No source file is touched here, so the repo's other red checks are unaffected; those trace to `open-sse/executors/glm.ts` passing a 16th argument to a 15-parameter function, which #12925 fixes.
