### PR TITLE
fix(sse): treat "length" stop_reason as legitimate in detectMalformedNonStream for Claude messages

### DIFF
--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -271,6 +271,24 @@ export function detectMalformedNonStream(resp: unknown): MalformedReason | null 
       if (stopReason === "max_tokens" || stopReason === "tool_use") return null;
       return "empty_choices";
     }
+    // Content array is non-empty but has no visible text (only empty text
+    // blocks or the "(empty response)" sentinel) — treat the same as
+    // content:[] when stop_reason is a legitimate terminal empty-stop.
+    const allEmptyOrSentinel = content.every((block) => {
+      if (block === null || typeof block !== "object") return true;
+      const b = block as Record<string, unknown>;
+      return (
+        b.type === "text" &&
+        typeof b.text === "string" &&
+        (b.text === "" || b.text === "(empty response)")
+      );
+    });
+    if (allEmptyOrSentinel) {
+      const stopReason = typeof body.stop_reason === "string" ? body.stop_reason : "";
+      // ollama qwen3:1.7b reasoning budget exhausted → content=sentinel + length
+      if (stopReason === "length") return null;
+      return "empty_choices";
+    }
     return "empty_choices";
   }
 
@@ -323,7 +341,8 @@ export function describeMalformedNonStream(
 ): { message: string; code: string; type: string } {
   const body = resp && typeof resp === "object" ? (resp as Record<string, unknown>) : null;
   if (body?.object === "response" && body.status === "failed") {
-    const err = body.error && typeof body.error === "object" ? (body.error as Record<string, unknown>) : null;
+    const err =
+      body.error && typeof body.error === "object" ? (body.error as Record<string, unknown>) : null;
     const rawMessage =
       typeof err?.message === "string" && err.message.trim().length > 0 ? err.message.trim() : null;
     return {

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -56,6 +56,19 @@ test("synthOpenAIErrorChunk references provider in message", () => {
   );
 });
 
+test("detectMalformedNonStream allows Claude message with (empty response) + stop_reason=length (ollama qwen3)", () => {
+  const resp = {
+    type: "message",
+    content: [{ type: "text", text: "(empty response)" }],
+    stop_reason: "length",
+  };
+  assert.strictEqual(
+    detectMalformedNonStream(resp),
+    null,
+    "ollama reasoning truncation should not be empty_choices"
+  );
+});
+
 // ── (b) synthResponsesFailure matches a response.failed event ────────────────
 
 test("synthResponsesFailure produces a response.failed SSE event", () => {


### PR DESCRIPTION
## Summary

`/model ollama/qwen3:1.7b` returned a 502 because `qwen3:1.7b` exhausts reasoning before producing visible content. With a tiny `max_tokens` probe, Ollama returns `content: ""` and `finish_reason: "length"`. The Claude-formatted translation injected a `(empty response)` placeholder, and `detectMalformedNonStream` flagged it as `empty_choices` → 502. The Claude Messages branch now treats `(empty response) + stop_reason: "length"` as a legitimate truncated completion.

### How to test

1. Restart the dev server.
2. Run `/model ollama/qwen3:1.7b` in Claude Code. It should set the model and not 502.
3. Run `node --import tsx/esm --test tests/unit/diagnostics.test.ts`. All 37 tests pass, including the new `detectMalformedNonStream allows Claude message with (empty response) + stop_reason=length (ollama qwen3) regression test`