### PR TITLE
feat(volcengine): canonical quota window mapping and safe multi-connection plan binding

### DIFF
--- a/changelog.d/fixes/volcengine-quota-binding.md
+++ b/changelog.d/fixes/volcengine-quota-binding.md
@@ -1,0 +1,1 @@
+- fix(volcengine): resolve quota window mapping gaps, safe multi-connection console binding, and response cookie sanitization

--- a/open-sse/services/genericQuotaFetcher.ts
+++ b/open-sse/services/genericQuotaFetcher.ts
@@ -330,6 +330,19 @@ function antigravityWeeklyWindowMatchesFamily(
   return family === "gemini" ? key === "gemini_weekly" : key === "claude_gpt_weekly";
 }
 
+const TIME_WINDOW_KEYS = new Set([
+  "session",
+  "weekly",
+  "daily",
+  "monthly",
+  "session (5h)",
+  "weekly (7d)",
+  "AFPFiveHour",
+  "AFPWeekly",
+  "AFPDaily",
+  "AFPMonthly",
+]);
+
 function normalizeQuotaWindows(
   windows: Record<string, { percentUsed: number; resetAt: string | null }>,
   context: UsageToQuotaContext
@@ -340,12 +353,14 @@ function normalizeQuotaWindows(
       ? getAntigravityQuotaFamily(context.requestedModel)
       : null;
 
-  // Claude-style explicit time windows.
-  if (windows["session (5h)"] && !normalized.window5h) {
-    normalized.window5h = windows["session (5h)"];
+  // Explicit time windows (canonical and legacy aliases).
+  const fiveHourWindow = windows["session (5h)"] || windows["session"];
+  if (fiveHourWindow && !normalized.window5h) {
+    normalized.window5h = fiveHourWindow;
   }
-  if (windows["weekly (7d)"] && !normalized.window7d) {
-    normalized.window7d = windows["weekly (7d)"];
+  const sevenDayWindow = windows["weekly (7d)"] || windows["weekly"];
+  if (sevenDayWindow && !normalized.window7d) {
+    normalized.window7d = sevenDayWindow;
   }
 
   // Antigravity-style per-model windows: pick worst only inside requested family.
@@ -356,6 +371,7 @@ function normalizeQuotaWindows(
       !key.startsWith("window") &&
       !key.includes("(5h)") &&
       !key.includes("(7d)") &&
+      !TIME_WINDOW_KEYS.has(key) &&
       (requestedFamily === null ||
         requestedFamily === "other" ||
         getAntigravityQuotaFamily(key) === requestedFamily)

--- a/open-sse/services/usage/volcenginePlan.ts
+++ b/open-sse/services/usage/volcenginePlan.ts
@@ -101,9 +101,16 @@ function tsToIso(seconds: number): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
+const CODING_LEVEL_TO_CANONICAL: Record<string, string> = {
+  session: "session (5h)",
+  weekly: "weekly (7d)",
+  daily: "daily",
+  monthly: "monthly",
+};
+
 const CODING_WINDOW_LABEL: Record<string, string> = {
-  session: "Session (5h)",
-  weekly: "Weekly",
+  "session (5h)": "Session (5h)",
+  "weekly (7d)": "Weekly",
   monthly: "Monthly",
   daily: "Daily",
 };
@@ -119,27 +126,29 @@ function mapCodingPlanUsage(result: JsonRecord): Record<string, UsageQuota> {
     const w = toRecord(raw);
     const level = String(w.Level || "").toLowerCase();
     if (!level) continue;
-    const cap = toNumber(w.Cap, 100) || 100;
+    const canonicalKey = CODING_LEVEL_TO_CANONICAL[level] || level;
+    const rawCap = toNumber(w.Cap, 100);
+    const cap = rawCap > 0 ? rawCap : 100;
     const usedPercent = toNumber(w.Percent, 0);
     const remainingPercentage = Math.max(0, Math.min(100, cap - usedPercent));
-    quotas[level] = {
+    quotas[canonicalKey] = {
       used: usedPercent,
       total: cap,
       remaining: Math.max(0, cap - usedPercent),
       remainingPercentage,
       resetAt: tsToIso(toNumber(w.ResetTimestamp, 0)),
       unlimited: false,
-      displayName: CODING_WINDOW_LABEL[level] || level,
+      displayName: CODING_WINDOW_LABEL[canonicalKey] || level,
     };
   }
   return quotas;
 }
 
-const AGENT_WINDOW_LABEL: Array<[string, string]> = [
-  ["AFPFiveHour", "Session (5h)"],
-  ["AFPDaily", "Daily"],
-  ["AFPWeekly", "Weekly"],
-  ["AFPMonthly", "Monthly"],
+const AGENT_WINDOW_MAPPING: Array<[string, string, string]> = [
+  ["AFPFiveHour", "session (5h)", "Session (5h)"],
+  ["AFPDaily", "daily", "Daily"],
+  ["AFPWeekly", "weekly (7d)", "Weekly"],
+  ["AFPMonthly", "monthly", "Monthly"],
 ];
 
 /**
@@ -148,16 +157,16 @@ const AGENT_WINDOW_LABEL: Array<[string, string]> = [
  */
 function mapAgentPlanUsage(result: JsonRecord): Record<string, UsageQuota> {
   const quotas: Record<string, UsageQuota> = {};
-  for (const [key, label] of AGENT_WINDOW_LABEL) {
-    const w = toRecord(result[key]);
+  for (const [sourceKey, canonicalKey, label] of AGENT_WINDOW_MAPPING) {
+    const w = toRecord(result[sourceKey]);
     if (Object.keys(w).length === 0) continue;
     const total = toNumber(w.Quota, 0);
     const used = toNumber(w.Used, 0);
     const remaining = Math.max(0, total - used);
     const remainingPercentage =
-      total > 0 ? Math.max(0, Math.min(100, (remaining / total) * 100)) : 100;
+      total > 0 ? Math.max(0, Math.min(100, (remaining / total) * 100)) : 0;
     const resetMs = toNumber(w.ResetTime, 0);
-    quotas[key] = {
+    quotas[canonicalKey] = {
       used,
       total,
       remaining,
@@ -315,3 +324,8 @@ export async function getVolcenginePlanUsage(
     };
   }
 }
+
+export const __testing = {
+  mapCodingPlanUsage,
+  mapAgentPlanUsage,
+};

--- a/src/lib/providers/requestDefaults.ts
+++ b/src/lib/providers/requestDefaults.ts
@@ -346,6 +346,8 @@ export function sanitizeProviderSpecificDataForResponse(value: unknown): JsonRec
   delete sanitized.alibabaConsoleSecToken;
   delete sanitized.runtimeKey;
   delete sanitized.validationId;
+  delete sanitized.volcConsoleCookie;
+  delete sanitized.volcCsrfToken;
   // System-managed Codex fingerprint seed: never exposed through the API
   // (mirrors sub2api stripping `codex_fingerprint_seed`); the server-side
   // partial-update merge keeps it alive without the client round-tripping it.

--- a/src/lib/providers/volcenginePlanBinding.ts
+++ b/src/lib/providers/volcenginePlanBinding.ts
@@ -118,7 +118,20 @@ export async function detectPlan(
   if (!result.ok) {
     return { available: false, usage: {}, error: result.error };
   }
-  return { available: true, usage: record(result.json.Result), error: null };
+  const usage = record(result.json.Result);
+  if (kind === "coding") {
+    const quotaUsage = usage.QuotaUsage;
+    if (!Array.isArray(quotaUsage) || quotaUsage.length === 0) {
+      return { available: false, usage: {}, error: "No active Coding Plan quota windows" };
+    }
+  } else if (kind === "agent") {
+    const hasFiveHour = Boolean(usage.AFPFiveHour && Object.keys(record(usage.AFPFiveHour)).length > 0);
+    const hasWeekly = Boolean(usage.AFPWeekly && Object.keys(record(usage.AFPWeekly)).length > 0);
+    if (!hasFiveHour && !hasWeekly) {
+      return { available: false, usage: {}, error: "No active Agent Plan quota windows" };
+    }
+  }
+  return { available: true, usage, error: null };
 }
 
 function firstApiKeyItem(result: JsonRecord): JsonRecord | null {

--- a/src/lib/providers/volcenginePlanBinding.ts
+++ b/src/lib/providers/volcenginePlanBinding.ts
@@ -186,16 +186,53 @@ async function fetchRawApiKey(
   return { apiKey, id, maskedKey: stringField(item?.Key) || null, error: null };
 }
 
-async function upsertConnection(
+export async function upsertConnection(
   kind: PlanKind,
   apiKey: string,
   cookieHeader: string,
   csrfToken: string,
   apiKeyId: number | null,
-  usage: JsonRecord
+  usage: JsonRecord,
+  targetConnectionId?: string
 ) {
   const cfg = PLAN_CONFIG[kind];
+  const allConnections = (await getProviderConnections({ provider: cfg.provider })) as JsonRecord[];
+
+  let matched: JsonRecord | undefined;
+
+  // 1. targetConnectionId priority match (with provider affinity check)
+  if (targetConnectionId) {
+    matched = allConnections.find(
+      (conn) => stringField(conn.id) === targetConnectionId && stringField(conn.provider) === cfg.provider
+    );
+  }
+
+  // 2. Match by valid apiKey or valid volcApiKeyId
+  if (!matched && apiKey) {
+    matched = allConnections.find((conn) => stringField(conn.apiKey) === apiKey);
+  }
+  if (!matched && typeof apiKeyId === "number" && apiKeyId > 0) {
+    matched = allConnections.find((conn) => {
+      const psd = record(conn.providerSpecificData);
+      return Number(psd.volcApiKeyId) === apiKeyId;
+    });
+  }
+
+  // 3. Match by canonical default name
+  if (!matched) {
+    matched = allConnections.find((conn) => stringField(conn.name) === cfg.name);
+  }
+
+  // 4. Safe adoption for single connection scenario (e.g. user-named 'main')
+  if (!matched && allConnections.length === 1) {
+    matched = allConnections[0];
+  }
+
+  // 5. If multiple connections exist and none matched, do NOT clobber; fall through to create new connection.
+
+  const existingPsd = matched ? record(matched.providerSpecificData) : {};
   const providerSpecificData = {
+    ...existingPsd,
     volcConsoleCookie: cookieHeader,
     volcCsrfToken: csrfToken,
     volcApiKeyId: apiKeyId,
@@ -205,14 +242,10 @@ async function upsertConnection(
     autoSync: true,
   };
 
-  const existing = (await getProviderConnections({ provider: cfg.provider })).find(
-    (conn: JsonRecord) => stringField(conn.name) === cfg.name
-  );
-
-  if (existing?.id) {
-    return await updateProviderConnection(stringField(existing.id), {
+  if (matched?.id) {
+    return await updateProviderConnection(stringField(matched.id), {
       apiKey,
-      name: cfg.name,
+      name: stringField(matched.name) || cfg.name,
       providerSpecificData,
       isActive: true,
       testStatus: "active",
@@ -230,7 +263,10 @@ async function upsertConnection(
   });
 }
 
-export async function bindVolcenginePlansFromConsoleCredentials(credentials: JsonRecord) {
+export async function bindVolcenginePlansFromConsoleCredentials(
+  credentials: JsonRecord,
+  options?: { targetConnectionId?: string }
+) {
   const cookieHeader = buildCookieHeader(credentials);
   const csrfToken = extractCsrf(credentials, cookieHeader);
   if (!cookieHeader || !csrfToken) {
@@ -273,7 +309,8 @@ export async function bindVolcenginePlansFromConsoleCredentials(credentials: Jso
       cookieHeader,
       csrfToken,
       key.id,
-      detected.usage
+      detected.usage,
+      options?.targetConnectionId
     );
     results.push({
       plan: kind,
@@ -290,3 +327,7 @@ export async function bindVolcenginePlansFromConsoleCredentials(credentials: Jso
     results,
   };
 }
+
+export const __testing = {
+  upsertConnection,
+};

--- a/src/lib/providers/volcenginePlanBinding.ts
+++ b/src/lib/providers/volcenginePlanBinding.ts
@@ -186,6 +186,79 @@ async function fetchRawApiKey(
   return { apiKey, id, maskedKey: stringField(item?.Key) || null, error: null };
 }
 
+export interface FindTargetConnectionCriteria {
+  targetConnectionId?: string;
+  provider: string;
+  apiKey?: string;
+  apiKeyId?: number | null;
+  defaultName: string;
+}
+
+/**
+ * Pure matcher to find an existing connection to adopt or update during console binding.
+ *
+ * Matching precedence:
+ * 1. targetConnectionId priority match (strictly verified against criteria.provider).
+ * 2. Exact apiKey match, or volcApiKeyId match (numeric and > 0).
+ * 3. Canonical default name match (e.g. 'Volcano Ark Coding Plan').
+ * 4. Intentional fallback: safe adoption for single existing connection under this provider.
+ *    - Design rationale: Operators commonly created custom connections (e.g. named 'main')
+ *      prior to console login. This fallback connects console cookies to that sole instance.
+ *    - Safety boundary: strictly scoped to allConnections.length === 1 so that multiple
+ *      distinct accounts are never silently clobbered.
+ * 5. When multiple connections exist and none match: returns undefined (triggers new connection creation).
+ */
+export function findTargetConnection(
+  allConnections: JsonRecord[],
+  criteria: FindTargetConnectionCriteria
+): JsonRecord | undefined {
+  // 1. targetConnectionId priority match (with provider affinity check)
+  if (criteria.targetConnectionId) {
+    const matched = allConnections.find(
+      (conn) =>
+        stringField(conn.id) === criteria.targetConnectionId &&
+        stringField(conn.provider) === criteria.provider
+    );
+    if (matched) return matched;
+  }
+
+  // 2. Match by valid apiKey or valid volcApiKeyId
+  if (criteria.apiKey) {
+    const matched = allConnections.find(
+      (conn) =>
+        stringField(conn.apiKey) === criteria.apiKey &&
+        stringField(conn.provider) === criteria.provider
+    );
+    if (matched) return matched;
+  }
+  if (typeof criteria.apiKeyId === "number" && criteria.apiKeyId > 0) {
+    const matched = allConnections.find((conn) => {
+      const psd = record(conn.providerSpecificData);
+      return (
+        Number(psd.volcApiKeyId) === criteria.apiKeyId &&
+        stringField(conn.provider) === criteria.provider
+      );
+    });
+    if (matched) return matched;
+  }
+
+  // 3. Match by canonical default name
+  const nameMatched = allConnections.find(
+    (conn) =>
+      stringField(conn.name) === criteria.defaultName &&
+      stringField(conn.provider) === criteria.provider
+  );
+  if (nameMatched) return nameMatched;
+
+  // 4. Safe adoption for single connection scenario under matching provider (e.g. user-named 'main')
+  if (allConnections.length === 1 && stringField(allConnections[0].provider) === criteria.provider) {
+    return allConnections[0];
+  }
+
+  // 5. Multiple connections exist and none matched -> do not clobber; return undefined
+  return undefined;
+}
+
 export async function upsertConnection(
   kind: PlanKind,
   apiKey: string,
@@ -198,37 +271,13 @@ export async function upsertConnection(
   const cfg = PLAN_CONFIG[kind];
   const allConnections = (await getProviderConnections({ provider: cfg.provider })) as JsonRecord[];
 
-  let matched: JsonRecord | undefined;
-
-  // 1. targetConnectionId priority match (with provider affinity check)
-  if (targetConnectionId) {
-    matched = allConnections.find(
-      (conn) => stringField(conn.id) === targetConnectionId && stringField(conn.provider) === cfg.provider
-    );
-  }
-
-  // 2. Match by valid apiKey or valid volcApiKeyId
-  if (!matched && apiKey) {
-    matched = allConnections.find((conn) => stringField(conn.apiKey) === apiKey);
-  }
-  if (!matched && typeof apiKeyId === "number" && apiKeyId > 0) {
-    matched = allConnections.find((conn) => {
-      const psd = record(conn.providerSpecificData);
-      return Number(psd.volcApiKeyId) === apiKeyId;
-    });
-  }
-
-  // 3. Match by canonical default name
-  if (!matched) {
-    matched = allConnections.find((conn) => stringField(conn.name) === cfg.name);
-  }
-
-  // 4. Safe adoption for single connection scenario (e.g. user-named 'main')
-  if (!matched && allConnections.length === 1) {
-    matched = allConnections[0];
-  }
-
-  // 5. If multiple connections exist and none matched, do NOT clobber; fall through to create new connection.
+  const matched = findTargetConnection(allConnections, {
+    targetConnectionId,
+    provider: cfg.provider,
+    apiKey,
+    apiKeyId,
+    defaultName: cfg.name,
+  });
 
   const existingPsd = matched ? record(matched.providerSpecificData) : {};
   const providerSpecificData = {
@@ -329,5 +378,6 @@ export async function bindVolcenginePlansFromConsoleCredentials(
 }
 
 export const __testing = {
+  findTargetConnection,
   upsertConnection,
 };

--- a/tests/unit/generic-quota-fetcher-volcengine.test.ts
+++ b/tests/unit/generic-quota-fetcher-volcengine.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { convertUsageToQuotaInfo } from "../../open-sse/services/genericQuotaFetcher.ts";
+
+test("convertUsageToQuotaInfo extracts window5h and window7d for volcengine canonical keys", () => {
+  const usage = {
+    plan: "Volcano Ark Coding Plan",
+    quotas: {
+      "session (5h)": {
+        used: 40,
+        total: 100,
+        remainingPercentage: 60,
+        resetAt: "2026-09-07T12:00:00.000Z",
+      },
+      "weekly (7d)": {
+        used: 15,
+        total: 100,
+        remainingPercentage: 85,
+        resetAt: "2026-09-14T00:00:00.000Z",
+      },
+    },
+  };
+
+  const info = convertUsageToQuotaInfo(usage, { provider: "volcengine-coding-plan" });
+  assert.ok(info);
+  assert.equal(info.window5h?.percentUsed, 0.4);
+  assert.equal(info.window5h?.resetAt, "2026-09-07T12:00:00.000Z");
+  assert.equal(info.window7d?.percentUsed, 0.15);
+  assert.equal(info.window7d?.resetAt, "2026-09-14T00:00:00.000Z");
+});
+
+test("convertUsageToQuotaInfo extracts window5h and window7d from legacy fallback keys without poisoning modelWindows", () => {
+  const usage = {
+    plan: "Volcano Ark Agent Plan",
+    quotas: {
+      weekly: {
+        used: 200,
+        total: 1000,
+        remainingPercentage: 80,
+        resetAt: "2026-09-14T00:00:00.000Z",
+      },
+      monthly: {
+        used: 500,
+        total: 5000,
+        remainingPercentage: 90,
+        resetAt: "2026-10-01T00:00:00.000Z",
+      },
+    },
+  };
+
+  const info = convertUsageToQuotaInfo(usage, { provider: "volcengine-agent-plan" });
+  assert.ok(info);
+  // Missing 5h window must remain undefined, NOT poisoned by weekly or monthly
+  assert.equal(info.window5h, undefined);
+  assert.equal(info.window7d?.percentUsed, 0.2);
+  assert.equal(info.window7d?.resetAt, "2026-09-14T00:00:00.000Z");
+});

--- a/tests/unit/volcengine-plan-binding-upsert.test.ts
+++ b/tests/unit/volcengine-plan-binding-upsert.test.ts
@@ -129,3 +129,75 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
   assert.notEqual(agentUpsertResult.id, conn1.id);
   assert.equal(agentUpsertResult.id, agentConn.id, "Matched the single agent connection instead");
 });
+
+test("findTargetConnection pure matching logic and single-connection adoption intent", () => {
+  const criteria = {
+    provider: "volcengine-coding-plan",
+    defaultName: "Volcano Ark Coding Plan",
+    apiKey: "ark-key-match",
+  };
+
+  // 1. targetConnectionId priority match (strictly same provider)
+  const list1 = [
+    { id: "c1", provider: "volcengine-coding-plan", name: "any" },
+    { id: "c2", provider: "volcengine-coding-plan", name: "other" },
+  ];
+  assert.equal(
+    bindingTesting.findTargetConnection(list1, { ...criteria, targetConnectionId: "c2" })?.id,
+    "c2"
+  );
+  // targetConnectionId with mismatched provider does not match
+  assert.equal(
+    bindingTesting.findTargetConnection(
+      [{ id: "c-other", provider: "different-provider", name: "any" }],
+      { ...criteria, targetConnectionId: "c-other" }
+    ),
+    undefined
+  );
+
+  // 2. ApiKey match
+  const list2 = [
+    { id: "c1", provider: "volcengine-coding-plan", apiKey: "ark-key-match" },
+    { id: "c2", provider: "volcengine-coding-plan", apiKey: "ark-diff-key" },
+  ];
+  assert.equal(bindingTesting.findTargetConnection(list2, criteria)?.id, "c1");
+
+  // 3. VolcApiKeyId match
+  const list3 = [
+    { id: "c1", provider: "volcengine-coding-plan", providerSpecificData: { volcApiKeyId: 777 } },
+    { id: "c2", provider: "volcengine-coding-plan", providerSpecificData: { volcApiKeyId: 888 } },
+  ];
+  assert.equal(
+    bindingTesting.findTargetConnection(list3, { ...criteria, apiKey: undefined, apiKeyId: 888 })?.id,
+    "c2"
+  );
+
+  // 4. Default name match
+  const list4 = [
+    { id: "c1", provider: "volcengine-coding-plan", name: "custom-name" },
+    { id: "c2", provider: "volcengine-coding-plan", name: "Volcano Ark Coding Plan" },
+  ];
+  assert.equal(
+    bindingTesting.findTargetConnection(list4, { ...criteria, apiKey: undefined })?.id,
+    "c2"
+  );
+
+  // 5. Intentional fallback: single existing connection adoption
+  const list5 = [{ id: "c-single", provider: "volcengine-coding-plan", name: "main" }];
+  assert.equal(
+    bindingTesting.findTargetConnection(list5, { ...criteria, apiKey: undefined })?.id,
+    "c-single",
+    "Adopts sole existing connection for provider"
+  );
+
+  // 6. Multiple connections without match -> undefined (new connection will be created)
+  const list6 = [
+    { id: "c1", provider: "volcengine-coding-plan", name: "account-a" },
+    { id: "c2", provider: "volcengine-coding-plan", name: "account-b" },
+  ];
+  assert.equal(
+    bindingTesting.findTargetConnection(list6, { ...criteria, apiKey: undefined }),
+    undefined,
+    "Does not clobber when multiple connections exist"
+  );
+});

--- a/tests/unit/volcengine-plan-binding-upsert.test.ts
+++ b/tests/unit/volcengine-plan-binding-upsert.test.ts
@@ -1,6 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { detectPlan } from "../../src/lib/providers/volcenginePlanBinding.ts";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { resetDbInstance } from "../../src/lib/db/core.ts";
+import {
+  createProviderConnection,
+  getProviderConnectionById,
+} from "../../src/models/index.ts";
+import { detectPlan, __testing as bindingTesting } from "../../src/lib/providers/volcenginePlanBinding.ts";
 
 test("detectPlan returns available: false when account has no active quota windows (unsubscribed)", async (t) => {
   const originalFetch = globalThis.fetch;
@@ -35,4 +43,89 @@ test("detectPlan returns available: false when account has no active quota windo
 
   const agent = await detectPlan("agent", "cookie=1", "csrf=1");
   assert.equal(agent.available, false);
+});
+
+test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "or-volc-test-"));
+  const prevDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = tempDir;
+
+  t.after(() => {
+    resetDbInstance();
+    if (prevDataDir) process.env.DATA_DIR = prevDataDir;
+    else delete process.env.DATA_DIR;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  resetDbInstance();
+
+  // T-1: Single connection named 'main' is adopted and updated, preserving name and autoFetchModels
+  const conn1 = await createProviderConnection({
+    provider: "volcengine-coding-plan",
+    name: "main",
+    apiKey: "ark-original-key-1",
+    providerSpecificData: { autoFetchModels: true, customTag: "keep-me" },
+  });
+
+  const updated1 = await (bindingTesting as any).upsertConnection(
+    "coding",
+    "ark-new-key-1",
+    "new-cookie-1",
+    "new-csrf-1",
+    123,
+    { dummy: 1 },
+    undefined
+  );
+
+  assert.equal(updated1.id, conn1.id);
+  assert.equal(updated1.name, "main", "Preserves original custom name 'main'");
+  assert.equal(updated1.apiKey, "ark-new-key-1");
+  assert.equal(updated1.providerSpecificData.autoFetchModels, true, "Preserves existing PSD autoFetchModels");
+  assert.equal(updated1.providerSpecificData.customTag, "keep-me", "Preserves existing PSD customTag");
+  assert.equal(updated1.providerSpecificData.volcConsoleCookie, "new-cookie-1");
+  assert.equal(updated1.providerSpecificData.volcApiKeyId, 123);
+
+  // T-4: Multiple connections exist without match -> safely creates new connection without clobbering
+  await createProviderConnection({
+    provider: "volcengine-coding-plan",
+    name: "secondary",
+    apiKey: "ark-other-key-2",
+    providerSpecificData: {},
+  });
+
+  const createdNew = await (bindingTesting as any).upsertConnection(
+    "coding",
+    "ark-brand-new-key-3",
+    "new-cookie-3",
+    "new-csrf-3",
+    999,
+    {},
+    undefined
+  );
+
+  assert.notEqual(createdNew.id, conn1.id);
+  assert.equal(createdNew.name, "Volcano Ark Coding Plan");
+  const preserved = await getProviderConnectionById(conn1.id as string);
+  assert.equal(preserved.apiKey, "ark-new-key-1", "Original connection was NOT clobbered");
+
+  // T-5: targetConnectionId with cross-provider guard
+  const agentConn = await createProviderConnection({
+    provider: "volcengine-agent-plan",
+    name: "agent-main",
+    apiKey: "ark-agent-key",
+    providerSpecificData: {},
+  });
+
+  // Passing conn1.id (which is coding-plan) into agent upsert must NOT match conn1
+  const agentUpsertResult = await (bindingTesting as any).upsertConnection(
+    "agent",
+    "ark-agent-new-key",
+    "agent-cookie",
+    "agent-csrf",
+    888,
+    {},
+    conn1.id as string // Mismatched provider
+  );
+  assert.notEqual(agentUpsertResult.id, conn1.id);
+  assert.equal(agentUpsertResult.id, agentConn.id, "Matched the single agent connection instead");
 });

--- a/tests/unit/volcengine-plan-binding-upsert.test.ts
+++ b/tests/unit/volcengine-plan-binding-upsert.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { detectPlan } from "../../src/lib/providers/volcenginePlanBinding.ts";
+
+test("detectPlan returns available: false when account has no active quota windows (unsubscribed)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // Mock console response with empty QuotaUsage
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        ResponseMetadata: {},
+        Result: {
+          QuotaUsage: [],
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+
+  const coding = await detectPlan("coding", "cookie=1", "csrf=1");
+  assert.equal(coding.available, false);
+
+  // Mock console response for Agent with empty quota object
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        ResponseMetadata: {},
+        Result: {},
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+
+  const agent = await detectPlan("agent", "cookie=1", "csrf=1");
+  assert.equal(agent.available, false);
+});

--- a/tests/unit/volcengine-plan-quota-windows.test.ts
+++ b/tests/unit/volcengine-plan-quota-windows.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { __testing } from "../../open-sse/services/usage/volcenginePlan.ts";
+
+test("mapCodingPlanUsage maps windows to canonical names and handles cap edge cases", () => {
+  const sampleResult = {
+    QuotaUsage: [
+      {
+        Level: "session",
+        Cap: 100,
+        Percent: 35,
+        ResetTimestamp: 1725686400,
+      },
+      {
+        Level: "weekly",
+        Cap: 100,
+        Percent: 10,
+        ResetTimestamp: 1726204800,
+      },
+      {
+        Level: "daily",
+        Cap: 0,
+        Percent: 0,
+        ResetTimestamp: 0,
+      },
+    ],
+  };
+
+  const quotas = __testing.mapCodingPlanUsage(sampleResult);
+  assert.ok(quotas["session (5h)"]);
+  assert.equal(quotas["session (5h)"].used, 35);
+  assert.equal(quotas["session (5h)"].total, 100);
+  assert.equal(quotas["session (5h)"].remainingPercentage, 65);
+  assert.ok(quotas["session (5h)"].resetAt);
+
+  assert.ok(quotas["weekly (7d)"]);
+  assert.equal(quotas["weekly (7d)"].used, 10);
+  assert.equal(quotas["weekly (7d)"].remainingPercentage, 90);
+
+  assert.ok(quotas["daily"]);
+  assert.equal(quotas["daily"].resetAt, null);
+  assert.equal("session" in quotas, false);
+  assert.equal("weekly" in quotas, false);
+});
+
+test("mapAgentPlanUsage maps windows to canonical names and guards zero total", () => {
+  const sampleResult = {
+    AFPFiveHour: {
+      Quota: 1000,
+      Used: 250,
+      ResetTime: 1725686400000,
+    },
+    AFPWeekly: {
+      Quota: 5000,
+      Used: 500,
+      ResetTime: 1726204800000,
+    },
+    AFPDaily: {
+      Quota: 0,
+      Used: 0,
+      ResetTime: 0,
+    },
+  };
+
+  const quotas = __testing.mapAgentPlanUsage(sampleResult);
+  assert.ok(quotas["session (5h)"]);
+  assert.equal(quotas["session (5h)"].used, 250);
+  assert.equal(quotas["session (5h)"].total, 1000);
+  assert.equal(quotas["session (5h)"].remainingPercentage, 75);
+
+  assert.ok(quotas["weekly (7d)"]);
+  assert.equal(quotas["weekly (7d)"].used, 500);
+  assert.equal(quotas["weekly (7d)"].total, 5000);
+  assert.equal(quotas["weekly (7d)"].remainingPercentage, 90);
+
+  assert.ok(quotas["daily"]);
+  assert.equal(quotas["daily"].total, 0);
+  // Total 0 must result in remainingPercentage: 0, NOT 100 (which poisons routing priority)
+  assert.equal(quotas["daily"].remainingPercentage, 0);
+
+  assert.equal("AFPFiveHour" in quotas, false);
+  assert.equal("AFPWeekly" in quotas, false);
+});

--- a/tests/unit/volcengine-plan-request-sanitization.test.ts
+++ b/tests/unit/volcengine-plan-request-sanitization.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeProviderSpecificDataForResponse } from "../../src/lib/providers/requestDefaults.ts";
+
+test("sanitizeProviderSpecificDataForResponse strips volcConsoleCookie and volcCsrfToken", () => {
+  const input = {
+    autoSync: true,
+    autoFetchModels: true,
+    volcConsoleCookie: "session=secret123; AccountID=acc456",
+    volcCsrfToken: "csrf-token-xyz",
+    volcApiKeyId: 1001,
+    volcPlanKind: "coding",
+  };
+
+  const sanitized = sanitizeProviderSpecificDataForResponse(input);
+  assert.ok(sanitized);
+  assert.equal(sanitized.autoSync, true);
+  assert.equal(sanitized.autoFetchModels, true);
+  assert.equal(sanitized.volcApiKeyId, 1001);
+  assert.equal(sanitized.volcPlanKind, "coding");
+  assert.equal(sanitized.volcConsoleCookie, undefined);
+  assert.equal(sanitized.volcCsrfToken, undefined);
+  assert.equal("volcConsoleCookie" in sanitized, false);
+  assert.equal("volcCsrfToken" in sanitized, false);
+});


### PR DESCRIPTION
## Summary

Volcengine Ark console auto-login and quota fetchers had several integration issues:
1. Console cookies and CSRF tokens were returned unsanitized in REST provider responses.
2. Plan usage quota window keys (`session`, `AFPFiveHour`) differed from the canonical names (`session (5h)`, `weekly (7d)`), causing genericQuotaFetcher to miss them or fall back to single-minute polls.
3. Time window keys could leak into `modelWindows`, treating rate-limit windows as model names.
4. Auto-binding could clobber existing connections or fail to adopt single connections when names differed from official defaults.
5. `detectPlan` reported `available: true` on accounts without purchased quota windows.

This PR fixes response sanitization, window normalization, quota fetcher mapping, unpurchased plan gating, and connection reuse in plan binding.

## Changes

- **Response sanitization** (`src/lib/providers/requestDefaults.ts`): Strips `volcConsoleCookie` and `volcCsrfToken` from provider connection serialization.
- **Quota window canonicalization** (`open-sse/services/usage/volcenginePlan.ts`): Normalizes Coding Plan and Agent Plan window keys to `session (5h)` and `weekly (7d)`. Guards against division by zero (`remainingPercentage: 0` when `total === 0`).
- **Quota fetcher isolation** (`open-sse/services/genericQuotaFetcher.ts`): Maps Volcengine window aliases to `window5h` and `window7d`. Introduces `TIME_WINDOW_KEYS` set to isolate rate-limit windows from `modelWindows`.
- **Plan detection guard** (`src/lib/providers/volcenginePlanBinding.ts`): Checks for non-empty active quota windows before marking a plan available.
- **Connection reuse and adoption** (`src/lib/providers/volcenginePlanBinding.ts`):
  - Prioritizes `targetConnectionId` (with provider affinity check).
  - Matches by valid `apiKey` or `volcApiKeyId`.
  - Matches by default provider plan name.
  - Safely adopts the single existing connection when exactly one connection exists for the provider.
  - When multiple connections exist without a match, creates a new connection rather than overwriting.
  - Shallow merges `existingPsd` with new console session data to preserve user-configured flags like `autoFetchModels`.

## Test plan

- [x] `tests/unit/volcengine-plan-request-sanitization.test.ts` (1 pass)
- [x] `tests/unit/volcengine-plan-quota-windows.test.ts` (2 pass)
- [x] `tests/unit/generic-quota-fetcher-volcengine.test.ts` (2 pass)
- [x] `tests/unit/volcengine-plan-binding-upsert.test.ts` (3 pass)
- [x] `tests/unit/services/volcengine-console-auto-login.test.ts` (32 pass)
- [x] `npm run typecheck:core` (0 errors)
- [x] `npm run check:cycles` (0 cycles)
- [x] `npm run check:docs-sync` (PASS)

## Notes

Base: `release/v3.8.51` @ `b345c7f6c`.

⚠️ base-red inherited: #12732

- `changelog.d/fixes/reset-aware-model-family.md` missing leading `- `
- `open-sse/executors/glm.ts` extra 16th positional (TS2554, #12770)
- `check:agent-skills-sync` dry-run `GENERATED: + cli-tunnel`
- mutation-coverage names `tests/unit/reset-aware-request-scope-12600.test.ts` missing from `stryker.conf.json`

Unique diff does not touch those files. This PR's own fragment starts with `- `.
