### PR TITLE
fix(security): redact AIza credentials of any length in error bodies

### DIFF
--- a/changelog.d/fixes/google-key-redaction-length.md
+++ b/changelog.d/fixes/google-key-redaction-length.md
@@ -1,0 +1,1 @@
+- Redact Google API keys of any length in error bodies: the pattern required exactly 39 characters, so shorter or longer `AIza…` credentials passed through unredacted.

--- a/open-sse/utils/credentialPatterns.ts
+++ b/open-sse/utils/credentialPatterns.ts
@@ -18,7 +18,13 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
     regex: /sk-ant-[A-Za-z0-9_-]{20,}/g,
     replacement: "[REDACTED:anthropic]",
   },
-  { name: "google", regex: /AIza[0-9A-Za-z_-]{35}/g, replacement: "[REDACTED:google]" },
+  // {20,} rather than the exact {35} of a standard 39-char Google API key. #12506 added
+  // this pattern with the exact length; #12620 landed the anti-drift test that asserts
+  // /\bAIza[A-Za-z0-9_-]{20,}/ must not survive. Anything shorter or longer than 39 was
+  // therefore passing straight through into error bodies. In an error message
+  // over-redacting a string that merely starts with AIza costs nothing; under-redacting
+  // one leaks a credential, so the loose bound is the correct side to err on.
+  { name: "google", regex: /AIza[0-9A-Za-z_-]{20,}/g, replacement: "[REDACTED:google]" },
   { name: "huggingface", regex: /hf_[A-Za-z0-9]{34}/g, replacement: "[REDACTED:hf]" },
   { name: "replicate", regex: /r8_[A-Za-z0-9]{37}/g, replacement: "[REDACTED:replicate]" },
   { name: "github", regex: /gh[pousr]_[A-Za-z0-9]{36,}/g, replacement: "[REDACTED:github]" },


### PR DESCRIPTION
## Vazamento

`tests/unit/error-sanitizer-sk-key-qv45.test.ts` falha no tip de `release/v3.8.51`, em 8ms:

```
AssertionError: Google key survived: Bad credentials for AIzaSyA1B2C3D4E5F6G7H8I9J0KaLbMcNdOeP
```

Uma chave Google chega inteira ao corpo do erro.

## Causa

```ts
{ name: "google", regex: /AIza[0-9A-Za-z_-]{35}/g, replacement: "[REDACTED:google]" }
```

`{35}` é exato. Uma chave Google padrão tem 39 caracteres (`AIza` + 35) e casa; qualquer credencial `AIza…` mais curta ou mais longa **passa direto**.

O teste anti-drift cobra o contrato mais largo — `/\bAIza[A-Za-z0-9_-]{20,}/` não pode sobreviver.

## Como os dois lados divergiram

- O padrão, com `{35}`, veio do #12506 (`fix(security): harden public error boundaries`).
- O teste, com `{20,}`, veio do #12620 (`fix(security): close 3 advisories`).

Mesmo GHSA, arquiteturas diferentes, mergeados em sequência. A reconciliação manteve a divisão em módulos do #12506 e somou o `AIza` — mas com o comprimento estrito, não com o que o teste do #12620 cobra. Está vermelho desde então.

## Correção

`{20,}` no lugar de `{35}`. Numa mensagem de erro, redigir demais uma string que apenas começa com `AIza` não custa nada; redigir de menos vaza credencial. O lado errado para errar é claro.

## Evidência

- `error-sanitizer-sk-key-qv45.test.ts`: **9/9** (era 7/9, com 2 suítes vermelhas).
- Bateria de sanitização/redação — 538 testes: 533 passam. As 5 restantes são pré-existentes no tip, **não** desta mudança: 4 levam de 21s a 25s (spawn de processo isolado sob carga) e `tunnel-routes-error-sanitization` falha igual no tip puro, verificado.

Nenhum teste foi enfraquecido — o padrão foi ampliado para satisfazer a asserção que já existia.
