### PR TITLE
fix(tests): drain call-log saves before chat-pipeline DB resets (#12780)

### DIFF
--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -446,6 +446,12 @@ function getLegacyInlineDetail(id: string) {
 
 async function saveCallLogOperation(entry: any): Promise<void> {
   try {
+    // Bind the DB instance up front, before any await (resolveAccountName,
+    // writeCallArtifactAsync). If the singleton is reset/closed while this
+    // operation awaits, the insert must target the instance this request
+    // started against — a closed handle fails into the catch below instead of
+    // silently writing into whatever database opened afterwards (#12780).
+    const db = getDbInstance();
     const apiKeyContext = getCallLogApiKeyContext();
     // `||` (not `??`): an empty-string apiKeyId/apiKeyName is "unattributed",
     // same as before this fallback existed — it must not be persisted verbatim
@@ -563,7 +569,6 @@ async function saveCallLogOperation(entry: any): Promise<void> {
       }
     }
 
-    const db = getDbInstance();
     db.prepare(
       `
       INSERT INTO call_logs (

--- a/tests/integration/_chatPipelineHarness.ts
+++ b/tests/integration/_chatPipelineHarness.ts
@@ -285,6 +285,16 @@ export async function createChatPipelineHarness(prefix) {
     invalidateMemorySettingsCache();
     clearSkillState();
     await new Promise((resolve) => setTimeout(resolve, 20));
+    // Call-log persistence is fire-and-forget and the first cold artifact-worker
+    // spawn can take ~2.4s, so the previous test's saves may still be in flight.
+    // Drain before the DB reset so they land in the DB being torn down, not in the
+    // next test's fresh database (#12780).
+    const drained = await callLogsDb.waitForCallLogSaves(10_000);
+    if (!drained) {
+      console.warn(
+        `[chat-pipeline-harness:${prefix}] call-log saves did not drain within 10s; resetting anyway`
+      );
+    }
     core.resetDbInstance();
     fs.rmSync(testDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     fs.mkdirSync(testDataDir, { recursive: true });
@@ -299,6 +309,7 @@ export async function createChatPipelineHarness(prefix) {
     semanticCacheModule.clearCache();
     clearSkillState();
     resetAllCircuitBreakers();
+    await callLogsDb.waitForCallLogSaves(10_000);
     core.resetDbInstance();
     fs.rmSync(testDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }

--- a/tests/integration/chat-pipeline.test.ts
+++ b/tests/integration/chat-pipeline.test.ts
@@ -16,6 +16,7 @@ const settingsDb = await import("../../src/lib/db/settings.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
 const readCacheDb = await import("../../src/lib/db/readCache.ts");
 const { getLatestCallLog, getResponsesCallLogs } = await import("./_chatPipelineCallLogs.ts");
+const { waitForCallLogSaves } = await import("../../src/lib/usage/callLogs.ts");
 const { invalidateMemorySettingsCache } = await import("../../src/lib/memory/settings.ts");
 const { skillRegistry } = await import("../../src/lib/skills/registry.ts");
 const { skillExecutor } = await import("../../src/lib/skills/executor.ts");
@@ -372,6 +373,15 @@ async function resetStorage() {
   readCacheDb.invalidateDbCache();
   invalidateMemorySettingsCache();
   await new Promise((resolve) => setTimeout(resolve, 20));
+  // Call-log persistence is fire-and-forget (persistAttemptLogs → saveCallLog with
+  // a .catch(() => {})), and the first cold artifact-worker spawn can take ~2.4s, so
+  // the previous test's saves may still be in flight here. Draining before the DB
+  // reset keeps those rows in the DB being torn down instead of letting them land
+  // in the next test's fresh database (#12780).
+  const drained = await waitForCallLogSaves(10_000);
+  if (!drained) {
+    console.warn("[chat-pipeline] call-log saves did not drain within 10s; resetting anyway");
+  }
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
@@ -575,7 +585,13 @@ test("chat pipeline persists Codex responses cache and reasoning tokens to call 
   );
 
   const json = (await response.json()) as any;
-  const callLog = await waitFor(() => getLatestCallLog());
+  // Wait specifically for THIS request's Codex /v1/responses row instead of taking
+  // whatever the latest row happens to be: an unfiltered read can surface a row from
+  // a previous test that landed late in this database (#12780).
+  const callLog = await waitFor(async () => {
+    const rows = await getResponsesCallLogs();
+    return rows.find((row) => row.provider === "codex") ?? null;
+  });
 
   assert.equal(response.status, 200);
   assert.equal(fetchCalls.length, 1);

--- a/tests/unit/provider-request-failure-pipeline.test.ts
+++ b/tests/unit/provider-request-failure-pipeline.test.ts
@@ -21,7 +21,8 @@ const { clearInflight } = await import("../../open-sse/services/requestDedup.ts"
 const { resetAll: resetAccountSemaphores } =
   await import("../../open-sse/services/accountSemaphore.ts");
 const { clearModelLock } = await import("../../open-sse/services/accountFallback.ts");
-const { getCallLogs, getCallLogById } = await import("../../src/lib/usage/callLogs.ts");
+const { getCallLogs, getCallLogById, waitForCallLogSaves } =
+  await import("../../src/lib/usage/callLogs.ts");
 const { handleChatCore } = await import("../../open-sse/handlers/chatCore.ts");
 const { resetPayloadRulesConfigForTests } = await import("../../open-sse/services/payloadRules.ts");
 const { CLAUDE_CODE_COMPATIBLE_REDACT_THINKING_BETA, CONTEXT_1M_BETA_HEADER } =
@@ -56,6 +57,11 @@ async function resetStorage() {
   clearIdempotency();
   clearInflight();
   clearModelLock();
+  // Call-log persistence is fire-and-forget and the first cold artifact-worker
+  // spawn can take ~2.4s, so this test's saves may still be in flight when the
+  // next test resets the DB. Drain so a late row cannot land in the next test's
+  // fresh database and get picked up by its waitFor(getLatestCallLog()) (#12780).
+  await waitForCallLogSaves(10_000);
   core.resetDbInstance();
   // A full reset must also drop the settings read-cache. Otherwise the cached
   // value (e.g. call_log_pipeline_enabled=true seeded earlier) survives the DB


### PR DESCRIPTION
## Summary

Fixes cross-test database contamination during test teardowns where in-flight call-log persistence from one test wrote into the next test's database.

Because `persistAttemptLogs` calls `saveCallLog` asynchronously and the first worker-threads spawn takes ~2.4s, a call-log save from an earlier test could still be running when `resetStorage()` closed the SQLite singleton and wiped the data directory. When that save resumed, `getDbInstance()` resolved to the next test's newly opened database and inserted the stale row (for example, the preceding OpenAI test's row into the Codex test's database).

Changes:
1. Drains pending call-log saves (`waitForCallLogSaves(10_000)`) before resetting database singletons in `chat-pipeline.test.ts`, `_chatPipelineHarness.ts`, and `provider-request-failure-pipeline.test.ts`.
2. Binds the database instance at the start of `saveCallLogOperation` in `src/lib/usage/callLogs.ts` before any `await`. If a reset closes the database mid-write, the insert fails safely into the existing error logger instead of writing to a database opened afterwards.
3. Updates the assertion in `chat-pipeline.test.ts` to wait specifically for the Codex `/v1/responses` row via `getResponsesCallLogs()` instead of reading an unfiltered latest row.

⚠️ base-red inherited: #12732

## Related Issues

- Closes #12780
- Related to #12670

## Validation

- [x] Change type: other (test harness & usage logging resilience)
- [x] Focused tests and category gates from the golden path:
  - `env -u CODEX_USER_AGENT node --import tsx/esm --test tests/integration/chat-pipeline.test.ts` (28/28 passed)
  - `env -u CODEX_USER_AGENT DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/integration/chat-pipeline.test.ts` (28/28 passed)
  - `node --import tsx/esm --test tests/unit/provider-request-failure-pipeline.test.ts tests/unit/call-log-save-drain.test.ts` (8/8 passed)
  - `node --import tsx/esm --test tests/integration/memory-pipeline.test.ts` (14/14 passed)
- [x] `npm run typecheck:core` (clean)
- [x] `npm run lint` (0 errors or warnings introduced on touched files)
- [x] Reconciled with the current active release base (`release/v3.8.51`)
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/integration/chat-pipeline.test.ts`
- `tests/integration/_chatPipelineHarness.ts`
- `tests/unit/provider-request-failure-pipeline.test.ts`

## Coverage Notes

- Changes in `src/lib/usage/callLogs.ts` bind `db` before `resolveAccountName` and `writeCallArtifactAsync`. Covered by `tests/unit/call-log-save-drain.test.ts` and existing pipeline integration tests.
- Coverage gates remain satisfied (60/60/60/60).

## Reviewer Notes

- No migrations, configuration changes, or feature flags.
- Base branch `release/v3.8.51` is currently tracked under #12732 (unrelated README migration count drift on upstream tip).
- If testing locally in environments with `CODEX_USER_AGENT` set in the shell, run with `env -u CODEX_USER_AGENT` so the external environment variable does not override the test user agent assertion at line 696.