### PR TITLE
fix(sse): aggregate findInsensitive collision warning into one line per build

### DIFF
--- a/src/lib/modelMetadataRegistry.ts
+++ b/src/lib/modelMetadataRegistry.ts
@@ -303,26 +303,39 @@ export function getCanonicalModelMetadata(input: {
 // a rebuild instead of rebuilt per lookup.
 const lowercaseIndexCache = new WeakMap<object, Map<string, unknown>>();
 
+/** Colliding keys named in the aggregated collision warning before it truncates. */
+const COLLISION_SAMPLE_SIZE = 5;
+
 function findInsensitive<T>(obj: Record<string, T> | null | undefined, key: string): T | undefined {
   if (!obj || !key) return undefined;
   if (key in obj) return obj[key];
   let index = lowercaseIndexCache.get(obj);
   if (!index) {
     index = new Map();
+    const collisions: string[] = [];
     for (const [k, v] of Object.entries(obj)) {
       const lowerKey = k.toLowerCase();
-      // Warn once at index-build time (not per-lookup) if two keys collide
-      // case-insensitively — a real data-quality signal from an upstream sync (e.g.
-      // models.dev returning both "OpenAI" and "openai" as distinct provider keys).
-      // Matches the pre-fix scan's silent first-match-wins behavior, just surfaced
-      // instead of swallowed.
+      // Collisions are a real data-quality signal from an upstream sync (e.g.
+      // models.dev returning both "OpenAI" and "openai" as distinct provider
+      // keys), so they are surfaced rather than swallowed — first-match-wins,
+      // matching the pre-#8697 scan's behavior.
       if (index.has(lowerKey)) {
-        console.warn(
-          `[modelMetadataRegistry] findInsensitive: case-insensitive key collision on "${lowerKey}" — keeping first-seen value, later one discarded`
-        );
+        collisions.push(lowerKey);
         continue;
       }
       index.set(lowerKey, v);
+    }
+    // Aggregate into ONE line per index build. Warning per colliding key made
+    // the signal unreadable and expensive: a real catalog collides on hundreds
+    // of keys, and a production log carried 27,296 of these lines (40% of the
+    // file, ~500/sec bursts) driving 52 MB rotations. The count plus a bounded
+    // sample keeps the diagnostic without the flood.
+    if (collisions.length > 0) {
+      const sample = collisions.slice(0, COLLISION_SAMPLE_SIZE).join(", ");
+      const more = collisions.length > COLLISION_SAMPLE_SIZE ? ", …" : "";
+      console.warn(
+        `[modelMetadataRegistry] findInsensitive: ${collisions.length} case-insensitive key collision(s) — keeping first-seen value, later ones discarded. Keys: ${sample}${more}`
+      );
     }
     lowercaseIndexCache.set(obj, index);
   }

--- a/tests/unit/model-metadata-registry-collision-log.test.ts
+++ b/tests/unit/model-metadata-registry-collision-log.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `findInsensitive()` in modelMetadataRegistry builds a lowercase-key index and
+ * warns when two keys collide case-insensitively (e.g. models.dev returning both
+ * "OpenAI" and "openai"). The warning is a genuine upstream data-quality signal
+ * and must be kept.
+ *
+ * The problem is volume, not the signal: it logged once PER COLLIDING KEY per
+ * index build. On a real catalog that is hundreds of lines per rebuild — a
+ * production log captured 27,296 of these in a single file, 40% of all lines,
+ * in bursts of ~500/sec, driving 52 MB log rotations.
+ *
+ * This test pins the aggregate shape: one warning per index build, carrying the
+ * collision count, no matter how many keys collide. It fails against the
+ * per-key implementation (3 warnings for 3 collisions).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { enrichCatalogModelEntry } from "@/lib/modelMetadataRegistry";
+
+type Warn = (...args: unknown[]) => void;
+
+/** Runs `fn` with console.warn captured; returns the warning lines. */
+function captureWarnings(fn: () => void): string[] {
+  const lines: string[] = [];
+  const original: Warn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return lines.filter((l) => l.includes("findInsensitive"));
+}
+
+/**
+ * Fresh object per call: the lowercase index is cached in a WeakMap keyed by
+ * object identity, so reusing one would skip the rebuild (and the warning).
+ *
+ * The provider key is deliberately spelled "OpenAI", not "openai". findInsensitive
+ * short-circuits on `if (key in obj) return obj[key]` — an exact hit returns before
+ * the index is ever built, so a fixture containing the literal lookup key produces
+ * zero warnings and proves nothing.
+ */
+function pricingWithCollisions(count: number): Record<string, unknown> {
+  const pricing: Record<string, unknown> = {
+    OpenAI: { "gpt-4o": { input: 1, output: 2 } },
+  };
+  for (let i = 0; i < count; i++) {
+    // Same key differing only in case -> collides with a previously inserted one.
+    pricing[`Dup${i}Provider`] = { m: { input: 1, output: 2 } };
+    pricing[`dup${i}provider`] = { m: { input: 9, output: 9 } };
+  }
+  return pricing;
+}
+
+test("findInsensitive emits ONE aggregated warning per index build, not one per collision", () => {
+  const warnings = captureWarnings(() => {
+    enrichCatalogModelEntry(
+      { id: "gpt-4o", owned_by: "openai" },
+      { provider: "openai", model: "gpt-4o" },
+      { modelsDevPricing: pricingWithCollisions(3) } as never
+    );
+  });
+
+  assert.equal(
+    warnings.length,
+    1,
+    `expected a single aggregated warning, got ${warnings.length}:\n${warnings.join("\n")}`
+  );
+  assert.match(warnings[0], /3 case-insensitive key collision/);
+});
+
+test("the aggregated warning still names colliding keys so the signal survives", () => {
+  const warnings = captureWarnings(() => {
+    enrichCatalogModelEntry(
+      { id: "gpt-4o", owned_by: "openai" },
+      { provider: "openai", model: "gpt-4o" },
+      { modelsDevPricing: pricingWithCollisions(2) } as never
+    );
+  });
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /dup0provider/);
+});
+
+test("warning count stays at one as collisions scale", () => {
+  const warnings = captureWarnings(() => {
+    enrichCatalogModelEntry(
+      { id: "gpt-4o", owned_by: "openai" },
+      { provider: "openai", model: "gpt-4o" },
+      { modelsDevPricing: pricingWithCollisions(50) } as never
+    );
+  });
+
+  assert.equal(warnings.length, 1, "50 collisions must still produce exactly one line");
+  assert.match(warnings[0], /50 case-insensitive key collision/);
+});
+
+test("no collisions means no warning at all", () => {
+  const warnings = captureWarnings(() => {
+    enrichCatalogModelEntry(
+      { id: "gpt-4o", owned_by: "openai" },
+      { provider: "openai", model: "gpt-4o" },
+      { modelsDevPricing: { OpenAI: { "gpt-4o": { input: 1, output: 2 } } } } as never
+    );
+  });
+
+  assert.deepEqual(warnings, []);
+});


### PR DESCRIPTION
## Problem

`findInsensitive()` in `src/lib/modelMetadataRegistry.ts` warns once **per colliding key** while building its lowercase-key index. On a real catalog that is hundreds of lines per rebuild.

Measured on a production log from a local deployment:

| metric | value |
| --- | --- |
| lines in the active `app.log` | 67,353 |
| lines that are this one warning | **27,296 (40%)** |
| burst rate | ~500/sec |
| `logs/` on disk | 466 MB across 9 rotated 50 MB files |

The rotations are driven almost entirely by this single message.

## What this does not change

The warning itself is worth keeping, and this PR keeps it. A case-insensitive collision is a genuine upstream data-quality signal — models.dev returning both `OpenAI` and `openai` as distinct provider keys — and first-match-wins silently discards the later value. Removing the warning would have been the smaller diff and the wrong fix.

Also unchanged: the index itself, first-match-wins resolution, and the `WeakMap` identity cache from #8697. This is purely a logging-volume change.

## What changed

Collisions are collected during the index build and reported as **one line per build**, carrying the total count plus the first 5 keys:

```
[modelMetadataRegistry] findInsensitive: 312 case-insensitive key collision(s) — keeping first-seen value, later ones discarded. Keys: openai, anthropic, qwen/qwen3-235b-a22b-thinking-2507, moonshotai/kimi-k2.5, google, …
```

Same diagnostic, 1/N the volume.

## Validation (Hard Rule #18 — TDD)

New `tests/unit/model-metadata-registry-collision-log.test.ts`, 4 tests. Verified failing-then-passing:

- **Before:** 3 collisions → 3 warnings; 50 collisions → 50 warnings
- **After:** always exactly 1

Coverage: the aggregated count, that the line still names colliding keys, that the count stays at 1 as collisions scale, and that zero collisions emit nothing.

> **Note for reviewers / future editors:** the fixture deliberately spells the provider key `OpenAI`, not `openai`. `findInsensitive` short-circuits on `if (key in obj) return obj[key]` before the index is ever built, so a fixture containing the literal lookup key produces **zero** warnings and passes vacuously after the fix. The first draft of this test hit exactly that and proved nothing.

## Gates

- `node --import tsx/esm --test tests/unit/model-metadata-registry-collision-log.test.ts` — 4/4 pass
- `eslint` on both changed files — clean
- Base-green: no open `base-red` issue for `release/v3.8.50` at time of writing; no active `release-freeze`
- `typecheck:core` — 9 errors, **all** in `open-sse/services/compression/omniglyph*`, none in the changed files. Not from this branch: those sources are byte-identical to `origin/release/v3.8.50`, and the cause is a local `node_modules` carrying `omniglyph` 1.3.1 against the required `^1.4.0`. CI typechecks against a correct install.
