### PR TITLE
Docs: add JARVIS architectural overview to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -203,6 +203,31 @@ Release, deployment, proxies, tunnels, coverage, database, monitoring.
 
 Mermaid sources and exported SVG/PNG diagrams referenced from the docs above. See [diagrams/README.md](diagrams/README.md).
 
+## 🤖 Architectural Overview: JARVIS meets OmniRoute
+
+Unlike traditional cloud chatbots, **JARVIS** is an open-source desktop assistant designed to bridge high-level LLM reasoning with direct local system execution. 
+
+To achieve zero-cost, high-resilience AI execution without fragmenting provider SDKs, JARVIS uses **OmniRoute** as a centralized, local AI gateway.
+
+```text
+       [ YOUR VOICE / UI ]
+              │
+              ▼
+   [ Electron / Node.js ] (IPC Layer)
+              │
+              ▼
+    [ OmniRoute Gateway ] (localhost:20128)
+              │ (OpenAI-Compatible /v1 API)
+              ▼
+    [ Free / Local Model Layer ]
+              │
+              ▼
+   [ JSON-Schema Tool Calling ]
+              │
+              ├─► OS App Launcher (Chrome, Notepad, etc.)
+              ├─► PowerShell / Terminal Automation
+              └─► Local Filesystem Operations
+
 ## i18n/
 
 Translated mirrors of the documentation in 41 locales (plus the English originals — 42 languages in total). See [i18n/README.md](i18n/README.md) for the supported language list.


### PR DESCRIPTION
## Overview
This PR updates the repository documentation (`README.md`) to include an architectural breakdown and integration guide for **JARVIS**—an open-source desktop assistant controller built on top of OmniRoute.

## What's Changed
- Added a detailed architectural flowchart showing how the Electron/Node.js frontend communicates with the local OmniRoute gateway (`localhost:20128`) via OpenAI-compatible endpoints.
- Highlighted the implementation of JSON-schema tool calling for safe, local OS app launching, PowerShell automation, and filesystem operations.
- Outlined the zero-cost local model routing workflow enabled by OmniRoute's provider fallback layer.

## Motivation
To demonstrate real-world utility and agentic integration patterns utilizing OmniRoute as a centralized, local AI gateway for desktop automation.