### PR TITLE
test(plugin): wait for the v2 lazy-refresh tier instead of sleeping past it

### DIFF
--- a/@omniroute/opencode-plugin-v2/tests/index.test.ts
+++ b/@omniroute/opencode-plugin-v2/tests/index.test.ts
@@ -6,6 +6,33 @@ interface CapturedCall {
   kind: "catalog" | "integration";
 }
 
+/**
+ * Wait until `read()` stops changing, then return the settled value.
+ *
+ * The plugin's optional tier lands asynchronously after a publish. Waiting for
+ * it with a fixed `sleep(5)` raced the work: under load the tier arrived after
+ * the sleep, so the *next* assertion counted its reload and read 2 where it
+ * expected 1. Polling until the value holds steady for a few consecutive turns
+ * ties the wait to the work instead of to the clock.
+ */
+async function settle<T>(read: () => T, quietTurns = 3, timeoutMs = 5000): Promise<T> {
+  const { setTimeout: sleep } = await import("node:timers/promises");
+  const deadline = Date.now() + timeoutMs;
+  let last = read();
+  let stable = 0;
+  while (stable < quietTurns && Date.now() < deadline) {
+    await sleep(5);
+    const current = read();
+    if (current === last) {
+      stable += 1;
+    } else {
+      last = current;
+      stable = 0;
+    }
+  }
+  return last;
+}
+
 interface FakeCtx {
   options: Record<string, unknown>;
   catalog: {
@@ -163,7 +190,6 @@ describe("plugin-v2 entrypoint", () => {
     const { mkdtempSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
-    const { setTimeout: sleep } = await import("node:timers/promises");
     const dir = mkdtempSync(join(tmpdir(), "omniroute-lazy-"));
     const prevDataDir = process.env.OPENCODE_DATA_DIR;
     process.env.OPENCODE_DATA_DIR = dir;
@@ -222,16 +248,15 @@ describe("plugin-v2 entrypoint", () => {
       await cb(draft);
       assert.equal(reloads, 0, "the first publish sets the baseline, it does not reload");
       assert.equal(modelsCall, 1);
-      await sleep(5);
       // The optional tier lands after that first publish and brings combos and
       // the overlay with it — one reload, so the picker shows them without
       // waiting for the next refresh.
-      const afterFirstUpgrade = reloads;
+      const afterFirstUpgrade = await settle(() => reloads);
       assert.ok(afterFirstUpgrade <= 1, `at most one reload for the first upgrade, got ${reloads}`);
       await cb(draft);
       assert.equal(reloads, afterFirstUpgrade + 1, "a new model id reloads once");
       assert.equal(modelsCall, 2);
-      await sleep(5);
+      await settle(() => reloads);
       await cb(draft);
       assert.equal(reloads, afterFirstUpgrade + 1, "an identical run never reloads");
       assert.equal(modelsCall, 3);


### PR DESCRIPTION
Fixes a pre-existing race in the opencode plugin v2 suite. Surfaced by #12965 —
that PR is a dependency bump and does not cause this; it is simply the first PR
in a while to touch `@omniroute/opencode-plugin-v2/`, which is what makes the job
run at all.

### The race

`lazy refresh: [m1] then [m1,m2] reloads once; identical runs never reload` waits
for the plugin's asynchronous optional tier with a fixed `await sleep(5)`. When
the tier lands after that sleep, its reload is still pending and the next
assertion counts it:

```
✖ lazy refresh: [m1] then [m1,m2] reloads once; identical runs never reload
  AssertionError: an identical run never reloads
  2 !== 1
```

The file fails on **every** isolated run against the current `release/v3.8.51`
tip, with no changes applied. It only passed when the whole suite ran together
and unrelated work happened to give the tier enough slack — which is why the
green local `npm test` and the red CI job disagreed.

### The fix

Both sleeps become `await settle(() => reloads)`: poll until the observed value
holds steady for three consecutive turns, with a 5s ceiling. The wait now tracks
the work instead of the clock. **The assertions themselves are untouched** —
this changes how the test waits, not what it verifies.

### Why nobody saw it

`.github/workflows/opencode-plugin-ci.yml` filters on

```yaml
paths:
  - "@omniroute/opencode-plugin/**"
  - "@omniroute/opencode-plugin-v2/**"
```

so `Test v2` only runs when those directories change. The nightly release-green
sweep never triggers it, and the failure stayed off the base-red radar.

### Validation

| Check | Before | After |
|---|---|---|
| `tests/index.test.ts` isolated, 6 runs | 0/6 green | **6/6 green** |
| full v2 suite (`npm test`) | 218/218 | 218/218 |
| `npm run build` (tsup) | pass | pass |
| `prettier --check` | — | clean |

Diff is one file: `@omniroute/opencode-plugin-v2/tests/index.test.ts`.

⚠️ **base-red inherited: #12732** — `release/v3.8.51` is not green; any failing
check outside `Test v2` on this PR comes from the tip, not from this branch.