### PR TITLE
fix(claude): forward client-negotiated thinking-binding-controls and thinking-display-updates betas

### DIFF
--- a/changelog.d/fixes/12989-thinking-binding-controls-beta-forward.md
+++ b/changelog.d/fixes/12989-thinking-binding-controls-beta-forward.md
@@ -1,0 +1,1 @@
+- **fix(claude):** forward client-negotiated `thinking-binding-controls-2026-08-01` and `thinking-display-updates-2026-08-18` betas so Fable 5.1 `thinking.block_binding` / `thinking.display` requests are no longer rejected upstream with `Extra inputs are not permitted` ([#12989](https://github.com/diegosouzapw/OmniRoute/pull/12989))

--- a/open-sse/config/anthropicHeaders.ts
+++ b/open-sse/config/anthropicHeaders.ts
@@ -65,17 +65,9 @@ export const FORWARDABLE_CLIENT_BETAS = Object.freeze([
   // gate (#9505), so a client that sent it must keep it through the merge —
   // otherwise its effort negotiation is silently dropped.
   "effort-2025-11-24",
-  // thinking-binding-controls-2026-08-01 is required whenever the request body
-  // carries `thinking.block_binding` (Fable 5.1 recovers from thinking-block
-  // prefix mismatches via `prefixMismatchBehavior: "drop_block"`; @ai-sdk/anthropic
-  // sends both the field and this beta automatically). The allowlist used to drop
-  // it, so upstream Anthropic rejected the request with
-  // `thinking.adaptive.block_binding: Extra inputs are not permitted` even though
-  // the client negotiated the beta correctly.
+  // Fable 5.1 betas (@ai-sdk/anthropic sends both automatically): without them
+  // upstream rejects `thinking.block_binding` / `thinking.display` with 400.
   "thinking-binding-controls-2026-08-01",
-  // thinking-display-updates-2026-08-18 is required for `thinking.display:
-  // "updates"` on Fable 5.1 (streaming thinking summaries between tool calls;
-  // @ai-sdk/anthropic adds this beta automatically). Same drop class as above.
   "thinking-display-updates-2026-08-18",
 ]);
 

--- a/open-sse/config/anthropicHeaders.ts
+++ b/open-sse/config/anthropicHeaders.ts
@@ -65,6 +65,18 @@ export const FORWARDABLE_CLIENT_BETAS = Object.freeze([
   // gate (#9505), so a client that sent it must keep it through the merge —
   // otherwise its effort negotiation is silently dropped.
   "effort-2025-11-24",
+  // thinking-binding-controls-2026-08-01 is required whenever the request body
+  // carries `thinking.block_binding` (Fable 5.1 recovers from thinking-block
+  // prefix mismatches via `prefixMismatchBehavior: "drop_block"`; @ai-sdk/anthropic
+  // sends both the field and this beta automatically). The allowlist used to drop
+  // it, so upstream Anthropic rejected the request with
+  // `thinking.adaptive.block_binding: Extra inputs are not permitted` even though
+  // the client negotiated the beta correctly.
+  "thinking-binding-controls-2026-08-01",
+  // thinking-display-updates-2026-08-18 is required for `thinking.display:
+  // "updates"` on Fable 5.1 (streaming thinking summaries between tool calls;
+  // @ai-sdk/anthropic adds this beta automatically). Same drop class as above.
+  "thinking-display-updates-2026-08-18",
 ]);
 
 /**

--- a/tests/unit/thinking-binding-controls-beta-forward.test.ts
+++ b/tests/unit/thinking-binding-controls-beta-forward.test.ts
@@ -1,20 +1,8 @@
 /**
- * TDD regression: `anthropic` / `claude` providers drop the client-negotiated
- * `thinking-binding-controls-2026-08-01` beta, so any request carrying
- * `thinking.block_binding` (Fable 5.1 `prefixMismatchBehavior: "drop_block"`,
- * sent automatically by @ai-sdk/anthropic) is rejected upstream with
- * `thinking.adaptive.block_binding: Extra inputs are not permitted` — even when
- * the client negotiated the beta correctly. Same class covers
- * `thinking-display-updates-2026-08-18` (required for `thinking.display:
- * "updates"` on Fable 5.1).
- *
- * Root cause: FORWARDABLE_CLIENT_BETAS allowlist in
- * open-sse/config/anthropicHeaders.ts did not include either beta, so
- * mergeClientAnthropicBeta() stripped them on both the API-key path
- * (DefaultExecutor.buildHeaders) and the OAuth path (BaseExecutor).
- *
- * Fix: add both flags to FORWARDABLE_CLIENT_BETAS (forwarding only when the
- * client explicitly requests them).
+ * Fable 5.1 sends `thinking.block_binding` + `thinking-binding-controls-2026-08-01`
+ * (and `thinking.display` + `thinking-display-updates-2026-08-18`) automatically.
+ * The gateway stripped both betas, so upstream 400'd with `Extra inputs are not
+ * permitted`. Both must be forwarded when the client negotiates them.
  */
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/tests/unit/thinking-binding-controls-beta-forward.test.ts
+++ b/tests/unit/thinking-binding-controls-beta-forward.test.ts
@@ -1,0 +1,81 @@
+/**
+ * TDD regression: `anthropic` / `claude` providers drop the client-negotiated
+ * `thinking-binding-controls-2026-08-01` beta, so any request carrying
+ * `thinking.block_binding` (Fable 5.1 `prefixMismatchBehavior: "drop_block"`,
+ * sent automatically by @ai-sdk/anthropic) is rejected upstream with
+ * `thinking.adaptive.block_binding: Extra inputs are not permitted` — even when
+ * the client negotiated the beta correctly. Same class covers
+ * `thinking-display-updates-2026-08-18` (required for `thinking.display:
+ * "updates"` on Fable 5.1).
+ *
+ * Root cause: FORWARDABLE_CLIENT_BETAS allowlist in
+ * open-sse/config/anthropicHeaders.ts did not include either beta, so
+ * mergeClientAnthropicBeta() stripped them on both the API-key path
+ * (DefaultExecutor.buildHeaders) and the OAuth path (BaseExecutor).
+ *
+ * Fix: add both flags to FORWARDABLE_CLIENT_BETAS (forwarding only when the
+ * client explicitly requests them).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { ANTHROPIC_BETA_API_KEY, mergeClientAnthropicBeta, FORWARDABLE_CLIENT_BETAS } =
+  await import("../../open-sse/config/anthropicHeaders.ts");
+
+const BINDING_CONTROLS = "thinking-binding-controls-2026-08-01";
+const DISPLAY_UPDATES = "thinking-display-updates-2026-08-18";
+
+// ── allowlist membership ────────────────────────────────────────────────────
+
+test("FORWARDABLE_CLIENT_BETAS must include thinking-binding-controls beta", () => {
+  assert.ok(FORWARDABLE_CLIENT_BETAS.includes(BINDING_CONTROLS));
+});
+
+test("FORWARDABLE_CLIENT_BETAS must include thinking-display-updates beta", () => {
+  assert.ok(FORWARDABLE_CLIENT_BETAS.includes(DISPLAY_UPDATES));
+});
+
+// ── client-negotiated beta forwarding ───────────────────────────────────────
+
+test("mergeClientAnthropicBeta must forward client-negotiated thinking-binding-controls beta", () => {
+  const out = mergeClientAnthropicBeta(
+    ANTHROPIC_BETA_API_KEY,
+    `claude-code-20250219,${BINDING_CONTROLS}`
+  );
+  const tokens = out.split(",").map((s) => s.trim());
+  assert.ok(tokens.includes(BINDING_CONTROLS), `client beta dropped: ${out}`);
+});
+
+test("mergeClientAnthropicBeta must forward client-negotiated thinking-display-updates beta", () => {
+  const out = mergeClientAnthropicBeta(
+    ANTHROPIC_BETA_API_KEY,
+    `claude-code-20250219,${DISPLAY_UPDATES}`
+  );
+  const tokens = out.split(",").map((s) => s.trim());
+  assert.ok(tokens.includes(DISPLAY_UPDATES), `client beta dropped: ${out}`);
+});
+
+test("mergeClientAnthropicBeta forwards both betas together without duplication", () => {
+  const out = mergeClientAnthropicBeta(
+    `${ANTHROPIC_BETA_API_KEY},${BINDING_CONTROLS}`,
+    `claude-code-20250219,${BINDING_CONTROLS},${DISPLAY_UPDATES}`
+  );
+  const tokens = out.split(",").map((s) => s.trim());
+  assert.ok(tokens.includes(BINDING_CONTROLS), `binding-controls missing: ${out}`);
+  assert.ok(tokens.includes(DISPLAY_UPDATES), `display-updates missing: ${out}`);
+  assert.equal(
+    tokens.filter((t) => t.toLowerCase() === BINDING_CONTROLS).length,
+    1,
+    `binding-controls duplicated: ${out}`
+  );
+});
+
+// ── guard: allowlist still closed ───────────────────────────────────────────
+
+test("mergeClientAnthropicBeta still ignores non-allowlisted client betas", () => {
+  const out = mergeClientAnthropicBeta(
+    ANTHROPIC_BETA_API_KEY,
+    "some-random-future-beta-2099-01-01"
+  );
+  assert.ok(!out.includes("some-random-future-beta"), `unknown beta leaked: ${out}`);
+});


### PR DESCRIPTION
## Summary

- Forward client-negotiated `thinking-binding-controls-2026-08-01` and `thinking-display-updates-2026-08-18` betas upstream instead of dropping them. Without this, every Fable 5.1 agentic request from `@ai-sdk/anthropic` clients (OpenCode et al.) fails with `thinking.adaptive.block_binding: Extra inputs are not permitted`, even when the client negotiates the beta correctly.

## Related Issues

- Closes #12991
- Related to #12417 (Fable rejected on the OAuth path — different gate, client version), #12905 (response-side adaptive recognition)

## Validation

- [x] Change type: provider / routing
- [x] Focused tests: `node --import tsx/esm --test tests/unit/thinking-binding-controls-beta-forward.test.ts` (6/6) plus beta neighbors (`claude-tool-search-beta-3974`, `probe-9064`, `repro-10119`, `claude-context-1m-client-beta-forward`, `anthropic-header-dedupe-1475`, `claude-atu-effort-leak-9505`, 28/28)
- [x] `npm run lint` (clean on changed files)
- [x] Reconciled with `release/v3.8.51`; focused checks rerun afterward
- [x] Production-code changes include a new automated test in this PR
- [x] Live against upstream Anthropic: `POST /v1/messages` Fable 5.1 + `thinking:{type:"adaptive",block_binding:{prefix_mismatch_behavior:"drop_block"}}` with the beta header now returns `200`; without the header it still correctly returns `400`

## Tests Added Or Updated

- `tests/unit/thinking-binding-controls-beta-forward.test.ts` (new)

## Coverage Notes

- Touched file is `open-sse/config/anthropicHeaders.ts` (pure allowlist + comment); covered by the new test. No coverage movement expected elsewhere.

## Reviewer Notes

- Forward-only-when-client-requested: no fingerprint or default-header change for clients that do not send these betas.
- Unrelated heads-up while testing this branch: the `release/v3.8.51` image runs as `node`, so upgrading over a `root`-owned `DATA_DIR` fails the migration snapshot with `EACCES` on `db_backups` — operators may need a one-time `chown -R 1000:1000` on the volume.
