### PR TITLE
fix(sse): restore abort mapping, cache telemetry and fence safety on the non-streaming leg

### DIFF
--- a/changelog.d/fixes/chatcore-nonstreaming-regressions.md
+++ b/changelog.d/fixes/chatcore-nonstreaming-regressions.md
@@ -1,0 +1,1 @@
+- Restore four non-streaming behaviours the server-owned tool loop refactor dropped: client aborts map to 499 with the fixed `Request aborted` message, an aborted request no longer logs a synthetic `clientResponse`, Claude prompt-cache telemetry is recorded again, and a body that cannot be canonicalized no longer throws when the tool loop is off.

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -4927,7 +4927,14 @@ export async function handleChatCore({
           error: err.error || "Provider request failed",
           providerRequest: finalBody || translatedBody,
           providerResponse: isNetworkThrow ? undefined : err.response,
-          clientResponse: buildErrorBody(err.status, err.error || "Provider request failed"),
+          // On a client abort the client already disconnected before we got here, so this
+          // body is what we WOULD have sent, not what was delivered. The dashboard reads
+          // `clientResponse` as "what the client received", so logging it misleads —
+          // `error` above already records the reason. The pre-#12867 path omitted it here;
+          // the leg-based path must keep doing so.
+          clientResponse: isLocalStreamLifecycleError(err.originalError)
+            ? undefined
+            : buildErrorBody(err.status, err.error || "Provider request failed"),
           cacheSource: "upstream",
         });
         persistFailureUsage(err.status, err.errorCode || `upstream_${err.status}`);
@@ -4939,8 +4946,34 @@ export async function handleChatCore({
       const expectedConn = managedLease
         ? String(getCurrentConnectionId() || connectionId || "") || undefined
         : undefined;
+      // The identity is the tool loop's execution fence key, and deriveToolRequestIdentity
+      // canonicalizes the body — which by design rejects Dates, Maps and class instances.
+      // It was computed eagerly, so a body carrying any of those threw on EVERY
+      // non-streaming request even with SERVER_OWNED_TOOL_LOOP_ENABLED off (the default).
+      // Derive it only when the loop can run, and fail closed rather than crash: no
+      // identity means no fence, and without a fence the loop must not run.
+      let toolLoopEnabled = isServerOwnedToolLoopEnabled();
+      let postInjectionRequestIdentity = "";
+      if (toolLoopEnabled) {
+        try {
+          postInjectionRequestIdentity = derivePostInjectionRequestIdentity({
+            apiKeyId: memoryOwnerId || "local",
+            headers: clientRawRequest?.headers ?? null,
+            skillRequestId,
+            postInjectionBody: (body || {}) as Record<string, unknown>,
+          });
+        } catch (identityError) {
+          log?.warn?.(
+            "SERVER_OWNED_TOOL_LOOP",
+            `request body is not canonicalizable, skipping the loop: ${
+              identityError instanceof Error ? identityError.message : "unknown"
+            }`
+          );
+          toolLoopEnabled = false;
+        }
+      }
       const loopApply = await applyServerOwnedToolLoopIfNeeded({
-        enabled: isServerOwnedToolLoopEnabled(),
+        enabled: toolLoopEnabled,
         stream,
         isResponsesEndpoint,
         sourceFormat,
@@ -4951,12 +4984,7 @@ export async function handleChatCore({
           apiKeyId: memoryOwnerId || "local",
           sessionId: pipelineSessionId,
           requestId: skillRequestId,
-          requestIdentity: derivePostInjectionRequestIdentity({
-            apiKeyId: memoryOwnerId || "local",
-            headers: clientRawRequest?.headers ?? null,
-            skillRequestId,
-            postInjectionBody: (body || {}) as Record<string, unknown>,
-          }),
+          requestIdentity: postInjectionRequestIdentity,
           builtinToolNames: injectionResult.builtinToolNames,
           injectedCustomSkillNames: injectionResult.injectedCustomSkillNames,
           customSkillExecutionEnabled:
@@ -5066,6 +5094,16 @@ export async function handleChatCore({
         providerHeaders = normalizeHeaders(okLeg.headers);
       }
       finalBody = providerRequestCapture.body(okLeg.providerRequest || translatedBody);
+      // Built inside executeProviderRequest on the pre-#12867 path. The leg now owns the
+      // first non-streaming send, so that assignment never runs here and the meta stayed
+      // null — `_omniroute.claudePromptCache` silently vanished from every call log on
+      // this path. Same inputs, same helper, at the point where they are available.
+      claudePromptCacheLogMeta = buildClaudePromptCacheLogMeta(
+        targetFormat,
+        finalBody,
+        providerHeaders,
+        clientRawRequest?.headers
+      );
       const capturedOk = providerRequestCapture.latest?.();
       reqLogger.logTargetRequest(
         okLeg.requestUrl || capturedOk?.url || "",

--- a/open-sse/handlers/chatCore/nonStreamingProviderLeg.ts
+++ b/open-sse/handlers/chatCore/nonStreamingProviderLeg.ts
@@ -23,6 +23,7 @@ import { restoreNonStreamingToolNames } from "./passthroughToolNames.ts";
 import { extractUsageFromResponse } from "../usageExtractor.ts";
 import { sanitizeUsagePayloadForRequest } from "../../utils/usageTracking.ts";
 import { createErrorResult, formatProviderError } from "../../utils/error.ts";
+import { isLocalStreamLifecycleError } from "@/shared/utils/circuitBreaker";
 import { unwrapClinepassEnvelope } from "../../utils/clinepassEnvelope.ts";
 import { unwrapClineNonStreamingEnvelope } from "./clineResponseEnvelope.ts";
 import {
@@ -231,7 +232,6 @@ function parseRetryAfterMs(response: Response): number | null {
   }
   return null;
 }
-
 
 function finishOk(
   input: ProviderLegInput,
@@ -462,14 +462,22 @@ export async function runNonStreamingProviderLeg(
     ) {
       throw error;
     }
-    const failureStatus =
-      error instanceof Error && error.name === "AbortError"
-        ? 499
-        : error instanceof Error && error.name === "TimeoutError"
-          ? 504
-          : 502;
-    const failureMessage =
-      error instanceof Error
+    // `abort(reason)` can reject with a raw string that has no `name`/`status`, so
+    // `error.name === "AbortError"` is too narrow — that shape fell through to the 502
+    // provider-failure default (#7907). chatCore classified this through
+    // isLocalStreamLifecycleError before this leg took over the first send; mirror it.
+    const isRequestAborted = isLocalStreamLifecycleError(error);
+    const failureStatus = isRequestAborted
+      ? 499
+      : error instanceof Error && error.name === "TimeoutError"
+        ? 504
+        : 502;
+    // A client abort is not a provider failure: formatProviderError would stamp the raw
+    // upstream text as `[499]: <reason>`, leaking it to the client. chatCore has always
+    // normalized this to the fixed "Request aborted".
+    const failureMessage = isRequestAborted
+      ? "Request aborted"
+      : error instanceof Error
         ? formatProviderError(error, provider, currentModel, failureStatus)
         : "Provider request failed";
     const receipt = buildReceipt(input, {


### PR DESCRIPTION
> Empilhado sobre o #12963. Base é a branch dele, não a release — mergeie o #12963 primeiro e este vira um diff de 3 arquivos.

## Regressão

O #12867 quebrou **7 testes em `tests/unit/chatcore-translation-paths.test.ts`** — arquivo que ele não toca, e por isso fora da minha validação focada quando o mergeei. Medido:

| commit | resultado |
|---|---|
| `ce49d96` (antes do #12867) | **74/74** |
| `d6f3150` (com o #12867) | **67/74** |

Esta PR fecha **5 das 7**, cada uma pela causa. As 2 restantes estão descritas no fim — compartilham uma causa que é decisão de desenho do refactor, não conserto de linha.

## 1. Abort de cliente perdeu o mapeamento — 3 testes

`nonStreamingProviderLeg` classificava abort por `error.name === "AbortError"`. `abort(reason)` pode rejeitar com uma **string crua**, sem `name` nem `status` — essa forma caía no default 502 em vez de 499, exatamente o que o #7907 fixou.

E a mensagem passava por `formatProviderError`, produzindo `[499]: request aborted by client`: o texto cru do upstream vazando para o cliente.

O `chatCore` sempre classificou por `isLocalStreamLifecycleError` e normalizou para o literal `"Request aborted"`. O leg assumiu o primeiro send e não levou nenhum dos dois. Espelhados.

## 2. `clientResponse` sintético em abort — 1 teste

O caminho antigo omitia `clientResponse` no abort, com um comentário explicando: o cliente já desconectou, então esse corpo é o que **teríamos** enviado, não o que foi entregue, e o dashboard lê esse campo como "o que o cliente recebeu".

O caminho novo gravava incondicionalmente. Agora usa o mesmo predicado do item 1 — mais correto que o original, que testava só `error.name === "AbortError"` e portanto vazava na forma de string crua.

## 3. Telemetria de prompt cache sumiu do call log — 1 teste

`claudePromptCacheLogMeta` só era construído dentro de `executeProviderRequest`. O leg passou a ser dono do primeiro send não-streaming, aquela atribuição parou de rodar, a variável ficou `null` — e `_omniroute.claudePromptCache` **desapareceu em silêncio de todo call log desse caminho**.

Não é só o teste: é observabilidade de cache de prompt Claude perdida em produção, sem erro nenhum. Reconstruído com o mesmo helper e os mesmos insumos, no ponto onde eles existem.

## 4. Corpo não canonicalizável derrubava a request — 1 teste

`derivePostInjectionRequestIdentity` era chamado **eagerly**, antes de qualquer checagem da flag. Ele canonicaliza o corpo, e `canonicalStringify` rejeita por desenho `Date`, `Map`, `Set` e instâncias de classe.

Resultado: um corpo com qualquer uma dessas formas lançava `TypeError: Value cannot be represented as canonical JSON` em **toda** request não-streaming — inclusive com `SERVER_OWNED_TOOL_LOOP_ENABLED` desligada, que é o default. Uma feature atrás de flag derrubando o caminho quente com a flag off.

Agora a identidade é derivada só quando o loop pode rodar, e falha fechada: se o corpo não canonicaliza, o loop não roda (sem identidade não há fence, e sem fence o loop não deve executar) e a request segue normal, com um `warn`.

## Evidência

- `chatcore-translation-paths`: 67/74 → **72/74**
- 138 testes nas 5 suítes vizinhas (`chatcore-stream-error-result`, `non-streaming-provider-leg`, `provider-execution-pipeline`, `server-owned-tool-loop-wire`): 136 passam, e as 2 que faltam são as duas abaixo
- `typecheck:core` limpo · `check-api-typecheck` **OK, 289** (herdado do #12963) · ESLint 0 erros nos arquivos tocados

## ⚠️ As 2 que sobram — mesma causa, e é maior que um fix

`chatCore refreshes GitHub credentials after 401…` e `chatCore locks per-model quota failures…`.

**O leg encerra num não-2xx sem passar pela camada de classificação de falha do `chatCore`.** Confirmado por leitura: `nonStreamingProviderLeg.ts` não tem nenhuma ocorrência de `lockModel`, `lockModelIfPerModelQuota`, `refreshCredentials` ou `markAccountUnavailable`. O `chatCore` tem ~170 linhas disso (`chatCore.ts:4350-4520`) mais o bloco de refresh 401/403 (`chatCore.ts:3921-3990`), e o caminho do leg não chega em nenhum.

Em produção isso significa, no primeiro send não-streaming com resposta não-2xx:

- token Copilot/GitHub **não** é renovado no 401 — a request falha em vez de recuperar;
- 402/429 por quota de modelo **não** trava aquele modelo naquela conexão — o combo continua tentando um alvo que já se sabe esgotado.

Não consertei porque o leg já reimplementou ~500 linhas de tratamento próprio de não-2xx (fallback de família de modelo, contexto maior, retry) e devolver a `Response` ao `chatCore` não é possível: ela já foi consumida por `.text()` na linha 549. Escolher entre reimplementar a classificação no leg ou bufferizar e devolver é decisão de desenho do refactor — @HouMinXi tem o contexto que eu não tenho.

Abro issue separada se preferir rastrear assim.
