### PR TITLE
fix(cli): skip POSIX path lookup on Windows autostart

### DIFF
--- a/bin/cli/tray/autostart.mjs
+++ b/bin/cli/tray/autostart.mjs
@@ -13,11 +13,13 @@ const LINUX_DESKTOP_NAME = "omniroute.desktop";
 function resolveCliPath() {
   const candidates = [];
   if (process.argv[1]) candidates.push(process.argv[1]);
-  try {
-    const which = execSync("command -v omniroute 2>/dev/null", { encoding: "utf8" }).trim();
-    if (which) candidates.push(which);
-  } catch {
-    // command -v unavailable
+  if (process.platform !== "win32") {
+    try {
+      const which = execSync("command -v omniroute 2>/dev/null", { encoding: "utf8" }).trim();
+      if (which) candidates.push(which);
+    } catch {
+      // command -v unavailable
+    }
   }
   candidates.push(join(dirname(fileURLToPath(import.meta.url)), "..", "..", "omniroute.mjs"));
 

--- a/changelog.d/fixes/12993-windows-autostart-posix-lookup.md
+++ b/changelog.d/fixes/12993-windows-autostart-posix-lookup.md
@@ -1,0 +1,1 @@
+- **fix(cli):** skip the POSIX CLI path lookup during Windows autostart setup, preventing a bogus path error before successful enablement ([#12993](https://github.com/diegosouzapw/OmniRoute/pull/12993))

--- a/tests/unit/cli/autostart-windows.test.ts
+++ b/tests/unit/cli/autostart-windows.test.ts
@@ -69,6 +69,23 @@ test("Windows enable/disable writes and removes VBS in Startup folder", async ()
 // autostart-macos-launchctl.test.ts.
 // ---------------------------------------------------------------------------
 
+test("Windows path resolution skips the POSIX command lookup", () => {
+  const source = readFileSync(join(process.cwd(), "bin/cli/tray/autostart.mjs"), "utf8");
+  const resolveCliPath = source.match(/function resolveCliPath\(\) \{([\s\S]*?)\n\}/);
+
+  assert.ok(resolveCliPath, "resolveCliPath should exist");
+  const nonWindowsGuard = resolveCliPath[1].match(
+    /if \(process\.platform !== "win32"\) \{([\s\S]*?)\n  \}/
+  );
+  assert.ok(nonWindowsGuard, "resolveCliPath should have a non-Windows guard");
+  assert.match(nonWindowsGuard[1], /command -v omniroute/);
+  assert.doesNotMatch(
+    resolveCliPath[1].replace(nonWindowsGuard[0], ""),
+    /command -v omniroute/,
+    "the POSIX PATH probe must only appear inside the non-Windows guard"
+  );
+});
+
 test("Windows enableWin writes VBS to Startup folder, not reg add", () => {
   const source = readFileSync(join(process.cwd(), "bin/cli/tray/autostart.mjs"), "utf8");
 


### PR DESCRIPTION
## Summary

Prevent Windows autostart path resolution from invoking the following POSIX-only probe:

```bash
command -v omniroute 2>/dev/null
```

On Windows, this probe can emit:

```text
The system cannot find the path specified.
```

even though autostart creation subsequently succeeds.

The POSIX lookup is now skipped on `win32` while preserving the existing argv/module-relative path resolution and keeping POSIX behavior unchanged.

## Root cause

`resolveCliPath()` executed a POSIX shell command on every platform.

On Windows, Node's shell is not a POSIX shell and `/dev/null` is not the appropriate null device/path. The failing lookup was caught, allowing `enableWin()` to continue, which caused a misleading error followed by a successful `enabled: true` result.

## Real-world reproduction

Environment:

- Windows 10 Home 22H2, build 19045 x64
- Node.js v24.19.0
- npm global install
- reproduced on OmniRoute 3.8.50

Before:

```text
> omniroute autostart enable
The system cannot find the path specified.
---------
| enabled |
---------
| true    |
---------
```

The Startup-folder `OmniRoute.vbs` was nevertheless created.

After applying the platform guard:

```text
> omniroute autostart enable
---------
| enabled |
---------
| true    |
---------
```

No bogus Windows path error was emitted, and `OmniRoute.vbs` was still created successfully.

The red regression run in this checkout independently reproduced the bogus error before the production change; the green run passed without it.

Related to #8609, which documented the same misleading Windows error. #9374 addressed the tray implementation, while this patch fixes the remaining autostart path probe after the VBS migration in #7925.

## Scope

This patch intentionally does not change:

- Windows VBS autostart mechanism
- tray behavior
- legacy registry cleanup
- macOS LaunchAgent behavior
- Linux systemd/XDG behavior
- CLI output schemas

## Tests

Changed test file:

- `tests/unit/cli/autostart-windows.test.ts`

Passed:

- `node --import tsx/esm --test tests/unit/cli/autostart-windows.test.ts` — 5/5
- `node --import tsx/esm --test tests/unit/cli/autostart-linux.test.ts` — 4/4
- `node --import tsx/esm --test tests/unit/cli/autostart-macos-launchctl.test.ts` — 10/10
- `node --import tsx/esm --test tests/unit/cli/autostart.test.ts` — 1/1
- `node --import tsx/esm --test tests/unit/autostart-cli-shorthand-3331.test.ts` — 4/4
- `npm run check:cli-i18n`
- `node --check bin/cli/tray/autostart.mjs`
- changed-file ESLint and Prettier checks
- `git diff --check`
- `$env:CHANGELOG_BASE_REF="upstream/release/v3.8.51"; npm run check:changelog-integrity`

Local base/environment limitations:

- `npm run build:cli` could not complete safely on this 8 GB Windows host. Both the default Turbopack build and the documented `OMNIROUTE_USE_TURBOPACK=0` webpack fallback exceeded available memory and entered heavy paging, so they were stopped. The repository's build workflow likewise documents that the v3.8.51 tree does not fit hosted 7 GB runners; CI/self-hosted build remains the authoritative signal.
- `npm run check:pack-policy` reports 27 unexpected `@omniroute/opencode-plugin-v2/**` files already present outside this patch.
- `npm run lint` reports repository-wide stale suppressions (`There are suppressions left that do not occur anymore`). ESLint on both changed files passes; pre-commit ESLint also passed.

## Risk

Low.

- Windows no longer attempts the POSIX PATH probe.
- Existing `process.argv[1]` and module-relative fallback candidates remain.
- Existing realpath/existence validation remains.
- POSIX behavior is unchanged.
- No shell use or interpolation was added.