### PR TITLE
fix(combos): keep dashboard combo tests off reasoning and rate limits

### DIFF
--- a/changelog.d/fixes/combo-test-probe-timeout.md
+++ b/changelog.d/fixes/combo-test-probe-timeout.md
@@ -1,0 +1,1 @@
+- **fix(combos):** dashboard combo test uses a short prompt, serial probes, and a 60s timeout so reasoning models and rate-limited free pools do not fail the health check

--- a/src/app/api/combos/test/route.ts
+++ b/src/app/api/combos/test/route.ts
@@ -5,10 +5,14 @@ import { getComboByName, getCombos } from "@/lib/db/combos";
 import { pickApiKeyForInternalUse } from "@/lib/db/apiKeys";
 import { getRuntimePorts } from "@/lib/runtime/ports";
 import { resolveNestedComboTargets } from "@omniroute/open-sse/services/combo.ts";
+import type { ResolvedComboTarget } from "@omniroute/open-sse/services/combo/types.ts";
 import { testComboSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+export const COMBO_TEST_TIMEOUT_MS = 60_000;
+export const COMBO_TEST_TOTAL_TIMEOUT_MS = 180_000;
 
 async function getInternalApiKey(): Promise<string | null> {
   // Combo health-check probes hit /v1/chat/completions, which enforces
@@ -17,7 +21,24 @@ async function getInternalApiKey(): Promise<string | null> {
   return pickApiKeyForInternalUse("combo-health-check");
 }
 
-function buildComboTestResult(target, partial = {}) {
+type ComboTestResult = {
+  model: string;
+  provider: string;
+  stepId: string;
+  executionKey: string;
+  connectionId: string | null;
+  label: string | null;
+  status?: string;
+  error?: string;
+  statusCode?: number;
+  latencyMs?: number;
+  responseText?: string;
+};
+
+function buildComboTestResult(
+  target: ResolvedComboTarget,
+  partial: Partial<ComboTestResult> = {}
+): ComboTestResult {
   return {
     model: target.modelStr,
     provider: target.provider,
@@ -29,7 +50,11 @@ function buildComboTestResult(target, partial = {}) {
   };
 }
 
-async function testComboTarget(target, baseInternalUrl, internalApiKey: string | null) {
+async function testComboTarget(
+  target: ResolvedComboTarget,
+  baseInternalUrl: string,
+  internalApiKey: string | null
+) {
   const startTime = Date.now();
   try {
     // Issue #2359: combo entries with a malformed/missing modelStr surfaced
@@ -53,7 +78,7 @@ async function testComboTarget(target, baseInternalUrl, internalApiKey: string |
     const testBody = buildComboTestRequestBody(modelStr, isEmbedding);
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 20000);
+    const timeout = setTimeout(() => controller.abort(), COMBO_TEST_TIMEOUT_MS);
 
     let res;
     try {
@@ -117,7 +142,10 @@ async function testComboTarget(target, baseInternalUrl, internalApiKey: string |
     const latencyMs = Date.now() - startTime;
     return buildComboTestResult(target, {
       status: "error",
-      error: error.name === "AbortError" ? "Timeout (20s)" : sanitizeErrorMessage(error.message),
+      error:
+        error.name === "AbortError"
+          ? `Timeout (${COMBO_TEST_TIMEOUT_MS / 1000}s)`
+          : sanitizeErrorMessage(error.message),
       latencyMs,
     });
   }
@@ -168,9 +196,21 @@ export async function POST(request) {
 
     const baseInternalUrl = getInternalBaseUrl();
     const internalApiKey = await getInternalApiKey();
-    const results = await Promise.all(
-      targets.map((target) => testComboTarget(target, baseInternalUrl, internalApiKey))
-    );
+    const results: ComboTestResult[] = [];
+    const loopStarted = Date.now();
+    for (const target of targets) {
+      if (Date.now() - loopStarted >= COMBO_TEST_TOTAL_TIMEOUT_MS) {
+        results.push(
+          buildComboTestResult(target, {
+            status: "error",
+            error: `Timeout (${COMBO_TEST_TOTAL_TIMEOUT_MS / 1000}s total)`,
+            latencyMs: 0,
+          })
+        );
+        continue;
+      }
+      results.push(await testComboTarget(target, baseInternalUrl, internalApiKey));
+    }
     const resolvedResult = results.find((result) => result.status === "ok") || null;
     const resolvedBy = resolvedResult?.model || null;
 

--- a/src/lib/combos/testHealth.ts
+++ b/src/lib/combos/testHealth.ts
@@ -1,9 +1,8 @@
 type JsonRecord = Record<string, unknown>;
 
-const COMBO_TEST_MAX_TOKENS = 2048;
+const COMBO_TEST_MAX_TOKENS = 64;
 const STREAMING_MODEL_TEST_MAX_TOKENS = 64;
-const COMBO_TEST_OPERAND_MIN = 10000;
-const COMBO_TEST_OPERAND_RANGE = 90000;
+const COMBO_TEST_PROMPT = "Reply with exactly: pong";
 
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
@@ -108,15 +107,8 @@ function hasReasoningOnlyCompletion(body: JsonRecord): boolean {
   });
 }
 
-function getRandomFiveDigitNumber() {
-  return COMBO_TEST_OPERAND_MIN + Math.floor(Math.random() * COMBO_TEST_OPERAND_RANGE);
-}
-
 export function buildComboTestPrompt() {
-  const left = getRandomFiveDigitNumber();
-  const right = getRandomFiveDigitNumber();
-
-  return `Calculate ${left}+${right}, and reply with the result only.`;
+  return COMBO_TEST_PROMPT;
 }
 
 export function buildComboTestRequestBody(
@@ -133,11 +125,9 @@ export function buildComboTestRequestBody(
 
   return {
     model: modelStr,
-    // Randomize the arithmetic prompt so upstream providers are less likely to
-    // satisfy the smoke test with cached completions.
     messages: [{ role: "user", content: buildComboTestPrompt() }],
-    // Give reasoning-heavy models enough headroom to finish the request and
-    // still emit a visible answer without immediate truncation.
+    // Keep the smoke probe short so reasoning-heavy models do not burn the
+    // health-check budget on arithmetic.
     max_tokens:
       options.maxTokens ??
       (options.stream ? STREAMING_MODEL_TEST_MAX_TOKENS : COMBO_TEST_MAX_TOKENS),

--- a/tests/unit/combo-test-health.test.ts
+++ b/tests/unit/combo-test-health.test.ts
@@ -8,24 +8,12 @@ const {
   extractComboTestStreamText,
 } = await import("../../src/lib/combos/testHealth.ts");
 
-test("combo test helper builds a realistic smoke payload", () => {
-  const originalRandom = Math.random;
-  let callCount = 0;
-  let body;
-  try {
-    Math.random = () => {
-      callCount += 1;
-      return callCount === 1 ? 0.4680222223 : 0.2677;
-    };
-
-    body = buildComboTestRequestBody("openrouter/openai/gpt-5.4");
-  } finally {
-    Math.random = originalRandom;
-  }
+test("combo test helper builds a short smoke payload", () => {
+  const body = buildComboTestRequestBody("openrouter/openai/gpt-5.4");
 
   assert.equal(body.model, "openrouter/openai/gpt-5.4");
-  assert.equal(body.messages[0].content, "Calculate 52122+34093, and reply with the result only.");
-  assert.equal(body.max_tokens, 2048);
+  assert.equal(body.messages[0].content, "Reply with exactly: pong");
+  assert.equal(body.max_tokens, 64);
   assert.equal("temperature" in body, false);
   assert.equal(body.stream, false);
 });

--- a/tests/unit/combo-test-route.test.ts
+++ b/tests/unit/combo-test-route.test.ts
@@ -96,8 +96,6 @@ test("combo test route marks a model healthy only when it returns assistant text
   await createTestCombo();
 
   const fetchCalls = [];
-  const originalRandom = Math.random;
-  let callCount = 0;
   globalThis.fetch = async (url, init = {}) => {
     fetchCalls.push({ url: String(url), init });
     return new Response(
@@ -118,16 +116,7 @@ test("combo test route marks a model healthy only when it returns assistant text
     );
   };
 
-  let response;
-  try {
-    Math.random = () => {
-      callCount += 1;
-      return callCount === 1 ? 0.4680222223 : 0.2677;
-    };
-    response = await route.POST(makeRequest());
-  } finally {
-    Math.random = originalRandom;
-  }
+  const response = await route.POST(makeRequest());
   const body = (await response.json()) as any;
   const forwardedBody = JSON.parse(fetchCalls[0].init.body);
 
@@ -138,11 +127,8 @@ test("combo test route marks a model healthy only when it returns assistant text
   assert.equal(fetchCalls[0].init.headers["X-OmniRoute-No-Cache"], "true");
   assert.match(fetchCalls[0].init.headers["X-Request-Id"], /^combo-test-/);
   assert.equal(forwardedBody.model, "openrouter/openai/gpt-5.4");
-  assert.equal(
-    forwardedBody.messages[0].content,
-    "Calculate 52122+34093, and reply with the result only."
-  );
-  assert.equal(forwardedBody.max_tokens, 2048);
+  assert.equal(forwardedBody.messages[0].content, "Reply with exactly: pong");
+  assert.equal(forwardedBody.max_tokens, 64);
   assert.equal("temperature" in forwardedBody, false);
   assert.equal(body.resolvedBy, "openrouter/openai/gpt-5.4");
   assert.equal(body.results[0].status, "ok");
@@ -246,55 +232,38 @@ test("combo test route surfaces provider errors instead of downgrading them to r
   assert.equal("probeMethod" in body.results[0], false);
 });
 
-test("combo test route launches model probes concurrently while preserving combo order", async () => {
+test("combo test route probes combo steps sequentially while preserving combo order", async () => {
   await createTestCombo(["provider/first", "provider/second", "provider/third"]);
 
   const fetchCalls = [];
-  const resolvers = [];
-  globalThis.fetch = (url, init = {}) =>
-    new Promise((resolve) => {
-      fetchCalls.push({ url: String(url), init });
-      resolvers.push(resolve);
-    });
-
-  const responsePromise = route.POST(makeRequest());
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  assert.equal(fetchCalls.length, 3);
-  assert.deepEqual(
-    fetchCalls.map(({ init }) => JSON.parse(init.body).model),
-    ["provider/first", "provider/second", "provider/third"]
-  );
-
-  resolvers[2](
-    new Response(
+  let inFlight = 0;
+  let maxInFlight = 0;
+  globalThis.fetch = async (url, init: RequestInit = {}) => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    fetchCalls.push({ url: String(url), init });
+    const model = JSON.parse(String(init.body)).model as string;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    const text = model.split("/")[1].toUpperCase();
+    return new Response(
       JSON.stringify({
-        choices: [{ message: { role: "assistant", content: "THIRD" } }],
+        choices: [{ message: { role: "assistant", content: text } }],
       }),
       { status: 200, headers: { "content-type": "application/json" } }
-    )
-  );
-  resolvers[1](
-    new Response(
-      JSON.stringify({
-        choices: [{ message: { role: "assistant", content: "SECOND" } }],
-      }),
-      { status: 200, headers: { "content-type": "application/json" } }
-    )
-  );
-  resolvers[0](
-    new Response(
-      JSON.stringify({
-        choices: [{ message: { role: "assistant", content: "FIRST" } }],
-      }),
-      { status: 200, headers: { "content-type": "application/json" } }
-    )
-  );
+    );
+  };
 
-  const response = await responsePromise;
+  const response = await route.POST(makeRequest());
   const body = (await response.json()) as any;
 
   assert.equal(response.status, 200);
+  assert.equal(maxInFlight, 1);
+  assert.equal(fetchCalls.length, 3);
+  assert.deepEqual(
+    fetchCalls.map(({ init }) => JSON.parse(String(init.body)).model),
+    ["provider/first", "provider/second", "provider/third"]
+  );
   assert.equal(body.resolvedBy, "provider/first");
   assert.deepEqual(
     body.results.map((result) => ({
@@ -449,7 +418,7 @@ test("combo test route handles upstream timeouts and non-JSON error bodies", asy
       {
         model: "provider/timeout",
         status: "error",
-        error: "Timeout (20s)",
+        error: "Timeout (60s)",
         statusCode: null,
       },
       {
@@ -460,4 +429,35 @@ test("combo test route handles upstream timeouts and non-JSON error bodies", asy
       },
     ]
   );
+});
+
+test("combo test route stops probing once the total budget is spent", async () => {
+  await createTestCombo(["provider/first", "provider/second", "provider/third"]);
+
+  const probed: string[] = [];
+  const realNow = Date.now;
+  let clock = realNow();
+  Date.now = () => clock;
+
+  globalThis.fetch = async (_url, init: RequestInit = {}) => {
+    probed.push(JSON.parse(String(init.body)).model);
+    clock += route.COMBO_TEST_TOTAL_TIMEOUT_MS;
+    return new Response(JSON.stringify({ error: { message: "boom" } }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const response = await route.POST(makeRequest());
+    const body = (await response.json()) as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(probed, ["provider/first"]);
+    assert.equal(body.results.length, 3);
+    assert.equal(body.results[1].error, "Timeout (180s total)");
+    assert.equal(body.results[2].error, "Timeout (180s total)");
+  } finally {
+    Date.now = realNow;
+  }
 });


### PR DESCRIPTION
## Problem

The dashboard combo test reports `error` on every step for combos backed by
rate-limited or reasoning-heavy providers, even when the same combo answers
real chat traffic fine.

Two causes:

1. **The probe prompt is expensive.** It asks a model to add two random
   five-digit numbers with `max_tokens: 2048`. Reasoning models spend the whole
   budget thinking and return no text, so the probe records "HTTP 200 but no
   text content".
2. **All steps are probed at once with a 20s deadline.** `Promise.all` fires
   one request per step simultaneously. On a free-tier pool that is an instant
   burst of N concurrent requests against the same account, and 20s is below
   the first-byte latency of thinking models. A ten-step combo returned
   `20001ms error` on all ten steps.

## Change

- Probe prompt is now `Reply with exactly: pong` with `max_tokens: 64`.
- Steps are probed sequentially instead of concurrently.
- Per-step deadline 20s -> 60s (`COMBO_TEST_TIMEOUT_MS`).
- New total budget `COMBO_TEST_TOTAL_TIMEOUT_MS` = 180s. Once spent, the
  remaining steps report `Timeout (180s total)` instead of being probed, so a
  large combo cannot make the endpoint hang.

The randomized arithmetic prompt was there to defeat upstream caching. A cached
`pong` still proves the step is reachable and authenticated, which is what the
health check is for.

## Tests

23/23 in `tests/unit/combo-test-health.test.ts`,
`tests/unit/combo-test-route.test.ts`,
`tests/unit/combo-target-defensive-modelstr.test.ts`; `typecheck:core` clean.

New coverage: probes run sequentially and in combo order; the total budget
stops further probing. Both were verified by injection - restoring
`Promise.all` and disabling the budget check each turn the new tests red.

The `#2359` malformed-`modelStr` guard is untouched.
