### PR TITLE
fix(azure): match the generation, not one release, for max_completion_tokens

### DIFF
--- a/changelog.d/fixes/12981-azure-generation-range.md
+++ b/changelog.d/fixes/12981-azure-generation-range.md
@@ -1,0 +1,1 @@
+- **fix(azure):** Deployments from GPT-6 onward now send `max_completion_tokens` instead of `max_tokens`, which Azure rejects with HTTP 400. The rule matched a literal `gpt-5`, so each new generation arrived broken; it now matches the generation range, while `gpt-35-turbo` still keeps `max_tokens`.

--- a/open-sse/executors/azureParamRules.ts
+++ b/open-sse/executors/azureParamRules.ts
@@ -20,15 +20,24 @@
 /**
  * Deployments that require `max_completion_tokens` instead of `max_tokens`.
  *
- * Matches the GPT-5 family and the o1/o3/o4 reasoning series at a token
+ * Matches GPT-5 and later, and the o1/o3/o4 reasoning series, at a token
  * boundary, so a deployment named `my-gpt-5-prod` matches while an unrelated
  * `piston-o4-legacy`-style name does not match by accident. `gpt-chat-latest`
  * is listed explicitly: it is a moving alias that currently resolves to a
  * GPT-5-era model and rejects `max_tokens`, but carries no version number for
  * the boundary pattern to key on.
+ *
+ * The generation is a range rather than a literal `gpt-5`, because the rule is
+ * a property of the generation and not of one release: `gpt-6-astra` rejects
+ * `max_tokens` for exactly the reason `gpt-5` does, and pinning the literal
+ * meant every new family arrived broken (#12981).
+ *
+ * It is a range and not `\d+` on purpose. Azure's own name for GPT-3.5 is
+ * `gpt-35-turbo`, which takes `max_tokens` and would be caught by a digit-run.
+ * `1\d` keeps a future `gpt-10` working without letting `gpt-35` in.
  */
 export const AZURE_COMPLETION_TOKEN_DEPLOYMENT =
-  /(?:^|[/_-])(?:gpt-5|o(?:1|3|4))(?:[._-]|$)|^gpt-chat-latest$/i;
+  /(?:^|[/_-])(?:gpt-(?:[5-9]|1\d)|o(?:1|3|4))(?:[._-]|$)|^gpt-chat-latest$/i;
 
 /**
  * Apply the Azure param rules to an already-translated Chat Completions body.

--- a/tests/unit/azure-param-rules.test.ts
+++ b/tests/unit/azure-param-rules.test.ts
@@ -46,6 +46,37 @@ test("gpt-5 family converts max_tokens too", () => {
   }
 });
 
+test("generations after GPT-5 convert max_tokens too (#12981)", () => {
+  // The rule belongs to the generation, not to one release. gpt-6-astra is the
+  // deployment from the report; the rest are the next names Azure will use.
+  for (const model of ["gpt-6-astra", "gpt-6", "azure/gpt-7-mini", "gpt-9.1", "gpt-10-turbo"]) {
+    const out = applyAzureParamRules(model, { max_tokens: 100 }, { max_tokens: 100 }) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(out.max_tokens, undefined, `${model} should drop max_tokens`);
+    assert.equal(out.max_completion_tokens, 100, `${model} should set max_completion_tokens`);
+  }
+});
+
+test("gpt-35-turbo is not a GPT-3.5 deployment caught by the generation range", () => {
+  // Azure's own name for GPT-3.5 has no dot, so a digit-run like `gpt-\d+`
+  // would match it and strip the max_tokens it actually requires. This is why
+  // the pattern is a range and stops at 19.
+  for (const model of ["gpt-35-turbo", "gpt-35-turbo-16k", "azure/gpt-35"]) {
+    assert.equal(
+      AZURE_COMPLETION_TOKEN_DEPLOYMENT.test(model),
+      false,
+      `${model} must keep max_tokens`
+    );
+    const out = applyAzureParamRules(model, { max_tokens: 100 }, { max_tokens: 100 }) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(out.max_tokens, 100, `${model} should pass through untouched`);
+  }
+});
+
 test("reasoning_effort is dropped when tools are present", () => {
   const out = applyAzureParamRules(
     "gpt-5.1",


### PR DESCRIPTION
Closes #12981.

`azure/gpt-6-astra` fails validation and every request:

```
'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

## Why

`AZURE_COMPLETION_TOKEN_DEPLOYMENT` matched a **literal** `gpt-5`:

```js
/(?:^|[/_-])(?:gpt-5|o(?:1|3|4))(?:[._-]|$)|^gpt-chat-latest$/i
```

So the `max_tokens` → `max_completion_tokens` swap covered GPT-5 and the o-series and nothing after them. The requirement is a property of the **generation**, not of one release — `gpt-6-astra` rejects `max_tokens` for exactly the reason `gpt-5` does — so each new family arrives broken and needs another patch. Matching the range fixes GPT-6 and whatever follows in the same edit.

## Why a range and not `gpt-\d+`

Azure's own deployment name for GPT-3.5 is **`gpt-35-turbo`** — no dot. A digit-run matches it, and the swap would then strip the `max_tokens` that deployment actually requires. Breaking a working deployment is worse than the bug being fixed, so the range stops at 19: `gpt-(?:[5-9]|1\d)`. That still leaves room for a future `gpt-10`.

There is a test for exactly that, and it is the test that fails if someone later widens the pattern.

## Verification

`tests/unit/azure-param-rules.test.ts` — **10 passed**. Each claim checked by reverting it:

| reverted | fails |
|---|---|
| back to the `gpt-5` literal | only `generations after GPT-5 convert max_tokens too (#12981)` |
| widened to `gpt-\d+` | only `gpt-35-turbo is not a GPT-3.5 deployment caught by the generation range` |

The pattern lives in one place and has one consumer (`applyAzureParamRules`, shared by `azure-openai` and `azure-ai`), so both wire paths pick this up.
