### PR TITLE
fix(skills): read positionals declared with .addArgument()

### DIFF
--- a/changelog.d/fixes/cli-skill-parser-addargument.md
+++ b/changelog.d/fixes/cli-skill-parser-addargument.md
@@ -1,0 +1,1 @@
+- **fix(skills):** The CLI registry parser now reads positionals declared with `.addArgument()`, not only those written inline in `.command()`. `tunnel create [type]` was being published as `tunnel create`, so the agent-skills sync gate reported drift on every branch and regenerating would have deleted the argument.

--- a/skills/cli-resilience/SKILL.md
+++ b/skills/cli-resilience/SKILL.md
@@ -153,12 +153,12 @@ omniroute resilience profile
 omniroute resilience show
 ```
 
-### `resilience set`
+### `resilience set <name>`
 
 **Example:**
 
 ```bash
-omniroute resilience set
+omniroute resilience set <name>
 ```
 
 ### `resilience config`

--- a/src/lib/agentSkills/cliRegistryParser.ts
+++ b/src/lib/agentSkills/cliRegistryParser.ts
@@ -104,6 +104,11 @@ const DESCRIPTION_RE = /\.description\(\s*["']([^"']+)["']/g;
 // Matches: .option("--flag ...", "desc") — capture group 1 = flag string
 const OPTION_RE = /\.option\(\s*["']([^"']+)["']/g;
 
+// Matches: .addArgument(new Argument("<name>")) or ("[name]") — group 1 = the
+// token including its brackets, so it reads the same as an inline positional
+// written straight into .command("stop <type>").
+const ARGUMENT_RE = /new\s+Argument\(\s*["'](<[^"']+>|\[[^"']+\])["']/g;
+
 // ── Parser helpers ───────────────────────────────────────────────────────────
 
 interface RawCommand {
@@ -157,6 +162,16 @@ function extractCommandsFromContent(content: string, topLevelName: string): RawC
       flags.push(optMatch[1]);
     }
 
+    // Positionals declared with .addArgument() rather than inline in the
+    // .command() string. Commander accepts both, and the generated page has
+    // no way to tell them apart, so they are appended to the name here.
+    const args: string[] = [];
+    ARGUMENT_RE.lastIndex = 0;
+    let argMatch: RegExpExecArray | null;
+    while ((argMatch = ARGUMENT_RE.exec(effectiveSlice)) !== null) {
+      args.push(argMatch[1]);
+    }
+
     // Compose full command name:
     // - If rawName equals the top-level name (or is the isDefault pattern), use as-is
     // - Otherwise, qualify as "topLevel subname"
@@ -166,7 +181,8 @@ function extractCommandsFromContent(content: string, topLevelName: string): RawC
       // Some files declare standalone root commands (e.g. serve, health)
       !rawName.includes(" ");
 
-    const fullName = isTopLevel && i === 0 ? rawName : `${topLevelName} ${rawName}`;
+    const base = isTopLevel && i === 0 ? rawName : `${topLevelName} ${rawName}`;
+    const fullName = args.length > 0 ? `${base} ${args.join(" ")}` : base;
 
     commands.push({ name: fullName.trim(), description, flags });
   }

--- a/tests/unit/agentSkills-cliRegistryParser.test.ts
+++ b/tests/unit/agentSkills-cliRegistryParser.test.ts
@@ -286,6 +286,56 @@ export function registerBackup(program) {
   }
 });
 
+test("parseCliRegistry() reads positionals declared with .addArgument()", () => {
+  // Commander takes a positional either inline in .command("stop <type>") or
+  // through .addArgument(new Argument(...)). The parser only saw the first, so
+  // `tunnel create [type]` was published as `tunnel create` -- the generator
+  // then wanted to delete the argument from the committed page on every run.
+  const fixture = `
+import { Argument } from "commander";
+
+export function registerTunnel(program) {
+  const tunnel = program.command("tunnel").description("Manage tunnels");
+
+  tunnel
+    .command("create")
+    .description("Create a tunnel")
+    .addArgument(new Argument("[type]", "Tunnel type").choices(["cloudflare"]).default("cloudflare"));
+
+  tunnel
+    .command("set")
+    .description("Set a profile")
+    .addArgument(new Argument("<name>", "Profile name").choices(["a", "b"]));
+
+  tunnel.command("stop <type>").description("Stop a tunnel");
+}
+`;
+  const { cleanup } = withFixtureCli({ "tunnel.mjs": fixture });
+  try {
+    const { commands } = parseCliRegistry();
+    assert.ok(commands.get("tunnel create [type]"), "optional positional should be kept");
+    assert.ok(commands.get("tunnel set <name>"), "required positional should be kept");
+    // The inline form still works, and is not doubled up by the new pattern.
+    assert.ok(commands.get("tunnel stop <type>"), "inline positional should be unchanged");
+    assert.equal(
+      commands.get("tunnel create"),
+      undefined,
+      "the bare name must not also be registered"
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("parseCliRegistry() with the real tunnel.mjs keeps `tunnel create [type]`", () => {
+  // Guards the drift directly: this is the line the generator was rewriting.
+  const { commands } = parseCliRegistry();
+  assert.ok(
+    commands.get("tunnel create [type]"),
+    "tunnel create must carry its optional type argument"
+  );
+});
+
 test("parseCliRegistry() skips unrecognised .mjs files", () => {
   const { cleanup } = withFixtureCli({
     "unknown-custom.mjs": `export function register(p) {}`,


### PR DESCRIPTION
`check:agent-skills-sync` fails on every branch, and regenerating with `--apply` does not fix it — it makes it worse:

```diff
-### `tunnel create [type]`
+### `tunnel create`
```

## Why

Commander takes a positional two ways: inline in `.command("stop <type>")`, or through `.addArgument(new Argument("[type]"))`. `cliRegistryParser` matched only the first:

```js
const COMMAND_RE = /\.command\(\s*["']([^"']+)["']/g;
const OPTION_RE  = /\.option\(\s*["']([^"']+)["']/g;
// nothing for .addArgument
```

So `tunnel create` came out bare, disagreed with the committed page, and the gate reported drift that it could only "resolve" by deleting a real argument.

Two commands use that form, and the second is worse than cosmetic:

| declared | published before | actual |
|---|---|---|
| `tunnel create` + `Argument("[type]")` | `tunnel create` | optional, choices, default `cloudflare` |
| resilience profile `set` + `Argument("<name>")` | `resilience set` | **required**, four choices |

An agent reading the second page was told to run `omniroute resilience set` with no argument.

## Result

```
Agent Skills Generator [dry-run]
Generated: 0 · Unchanged: 46 · Pruned: 0 · Orphans: 0 · Errors: 0
```

Exit 0, with `tunnel create [type]` **reproduced** rather than removed. The only regenerated content is the two resilience lines that gain `<name>`.

## What this deliberately does not do

The parser flattens subcommands onto the family name, so `resilience profile set` still publishes as `resilience set`. Resolving the receiver chain looks like a small addition. It is not — and I tried it before deciding:

`cloud.mjs` builds its task commands under `cloud.command(agent)` inside `for (const agent of AGENTS)`, so the real path is `cloud codex task create` and no regex can reach a name held in a loop variable. A parent-chain pass rewrote 12 files and turned `cloud create` into `task create` — differently wrong rather than less wrong — so it is not in this change. The file's own header already records that limitation ("uses regex, not a full AST").

## Verification

`tests/unit/agentSkills-cliRegistryParser.test.ts` — **13 passed**, including one fixture test and one that asserts against the real `bin/cli/commands/tunnel.mjs`.

Reverting the change (`fullName = base`) fails exactly those two new tests **and** puts the gate back to exit 2 — the same check both ways.
